### PR TITLE
feat(plugin-sdk): add parserDialect and forbiddenPatterns to datasource plugins

### DIFF
--- a/packages/plugin-sdk/src/__tests__/types.test.ts
+++ b/packages/plugin-sdk/src/__tests__/types.test.ts
@@ -857,7 +857,36 @@ describe("datasource plugin entities and dialect", () => {
         forbiddenPatterns: [/\bCOPY\b/i, "not-a-regex"],
       },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as any)).toThrow('Each entry in "forbiddenPatterns" must be a RegExp');
+    } as any)).toThrow('"forbiddenPatterns" entries must each be a RegExp');
+  });
+
+  test("throws when forbiddenPatterns contains duck-typed RegExp-like object", () => {
+    expect(() => definePlugin({
+      id: "bad-patterns",
+      type: "datasource",
+      version: "1.0.0",
+      connection: {
+        create: () => ({ query: async () => ({ columns: [], rows: [] }), close: async () => {} }),
+        dbType: "postgres",
+        forbiddenPatterns: [{ test: () => true, exec: () => null }],
+      },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)).toThrow('"forbiddenPatterns" entries must each be a RegExp');
+  });
+
+  test("accepts empty forbiddenPatterns array", () => {
+    const plugin = definePlugin({
+      id: "empty-patterns",
+      type: "datasource",
+      version: "1.0.0",
+      connection: {
+        create: () => ({ query: async () => ({ columns: [], rows: [] }), close: async () => {} }),
+        dbType: "postgres",
+        forbiddenPatterns: [],
+      },
+    } satisfies AtlasDatasourcePlugin);
+
+    expect(plugin.connection.forbiddenPatterns).toHaveLength(0);
   });
 
   test("createPlugin works with parserDialect and forbiddenPatterns", () => {

--- a/packages/plugin-sdk/src/helpers.ts
+++ b/packages/plugin-sdk/src/helpers.ts
@@ -62,7 +62,7 @@ function validatePluginShape(plugin: AtlasPlugin): void {
       }
       for (const p of ds.connection.forbiddenPatterns) {
         if (!(p instanceof RegExp)) {
-          throw new Error('Each entry in "forbiddenPatterns" must be a RegExp');
+          throw new Error('Datasource plugin connection "forbiddenPatterns" entries must each be a RegExp');
         }
       }
     }

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -7,6 +7,7 @@ export type {
   PluginDBConnection,
   QueryValidationResult,
   PluginDBType,
+  ParserDialect,
   PluginType,
   PluginStatus,
   PluginHealthResult,

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -50,6 +50,27 @@ export type PluginDBType =
   | "duckdb"
   | (string & {});
 
+/**
+ * Known node-sql-parser dialect strings, plus an escape hatch for future dialects.
+ * Values are case-sensitive — use exactly as listed (e.g. "PostgresQL", not "postgresql").
+ */
+export type ParserDialect =
+  | "Athena"
+  | "BigQuery"
+  | "Db2"
+  | "FlinkSQL"
+  | "Hive"
+  | "MariaDb"
+  | "MySQL"
+  | "NoQL"
+  | "PostgresQL"
+  | "Redshift"
+  | "Snowflake"
+  | "SQLite"
+  | "TransactSQL"
+  | "Trino"
+  | (string & {});
+
 // ---------------------------------------------------------------------------
 // Plugin lifecycle
 // ---------------------------------------------------------------------------
@@ -301,14 +322,32 @@ export interface AtlasDatasourcePlugin<TConfig = undefined> extends AtlasPluginB
      */
     validate?(query: string): QueryValidationResult;
     /**
-     * node-sql-parser dialect string (e.g. "PostgresQL", "MySQL", "Snowflake").
-     * Defaults to "PostgresQL" when not provided. Used by the core SQL validation
-     * pipeline to parse queries in the correct dialect.
+     * node-sql-parser dialect string for SQL validation. When not provided,
+     * the core pipeline auto-detects from `dbType`. Override this when `dbType`
+     * uses the `string & {}` escape hatch or when the auto-detected dialect is
+     * wrong for your database.
+     *
+     * Values are case-sensitive (e.g. `"PostgresQL"`, not `"postgresql"`).
+     * Use patterns with the `/i` flag for case-insensitive matching.
+     *
+     * Ignored when a custom `validate` function is provided (which replaces
+     * the entire SQL validation pipeline).
+     *
+     * **Note:** Wired into the core pipeline in #15. Until then, this field
+     * is validated at registration time but not yet consumed at query time.
      */
-    parserDialect?: string;
+    parserDialect?: ParserDialect;
     /**
      * Additional regex patterns to block beyond the base DML/DDL guard.
-     * Merged with core forbidden patterns during SQL validation.
+     * Each pattern is tested against the trimmed SQL string. Use `\b` word
+     * boundaries and the `/i` flag for case-insensitive matching, consistent
+     * with core forbidden patterns (see `FORBIDDEN_PATTERNS` in sql.ts).
+     *
+     * Ignored when a custom `validate` function is provided (which replaces
+     * the entire SQL validation pipeline).
+     *
+     * **Note:** Wired into the core pipeline in #15. Until then, this field
+     * is validated at registration time but not yet consumed at query time.
      */
     forbiddenPatterns?: RegExp[];
   };


### PR DESCRIPTION
## Summary

- Adds `parserDialect` (optional `string`) and `forbiddenPatterns` (optional `RegExp[]`) to `AtlasDatasourcePlugin.connection` in `packages/plugin-sdk/src/types.ts`
- Validates both fields in `validatePluginShape()` — `parserDialect` must be non-empty string if set; `forbiddenPatterns` must be array of `RegExp` if set
- 11 new tests covering happy paths, backward compat, and validation errors

No breaking changes — all new fields are optional.

Unblocks #15 (make `validateSQL` + `ConnectionRegistry` plugin-aware).

Closes #14

## Test plan

- [x] `bun test packages/plugin-sdk/src/__tests__/types.test.ts` — 73 pass
- [x] `bun test packages/plugin-sdk/src/__tests__/infer.test.ts` — 34 pass