### PR TITLE
feat(agent): make dialect system plugin-driven

### DIFF
--- a/packages/api/src/lib/__tests__/agent-dialect.test.ts
+++ b/packages/api/src/lib/__tests__/agent-dialect.test.ts
@@ -111,4 +111,19 @@ describe("appendDialectHints", () => {
     expect(content).toContain("Only this text.");
     expect(content).not.toContain("should-not-appear");
   });
+
+  test.each([
+    ["clickhouse", "SQL Dialect: ClickHouse"],
+    ["snowflake", "SQL Dialect: Snowflake"],
+    ["duckdb", "SQL Dialect: DuckDB"],
+    ["salesforce", "Query Language: Salesforce SOQL"],
+  ])("non-core dbType %s without plugin hints omits hardcoded guide", (dbType, oldHeader) => {
+    mockEntries.length = 0;
+    mockEntries.push({ id: "default", dbType: dbType as "clickhouse" | "snowflake" | "duckdb" | "salesforce" });
+    mockDialectHints = [];
+
+    const result = buildSystemParam("openai");
+    const content = typeof result === "string" ? result : result.content;
+    expect(content).not.toContain(oldHeader);
+  });
 });

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -84,12 +84,19 @@ This database uses MySQL. Key differences from PostgreSQL:
 - \`LIMIT offset, count\` or \`LIMIT count OFFSET offset\` — both forms work
 - \`COALESCE\`, \`CASE\`, \`NULLIF\`, \`COUNT\`, \`SUM\`, \`AVG\`, \`MIN\`, \`MAX\` work identically`;
 
+// Display names for known DB types. No exhaustive check — new types added
+// by plugins fall through to the capitalize fallback intentionally.
+const DIALECT_DISPLAY_NAMES: Record<string, string> = {
+  postgres: "PostgreSQL",
+  mysql: "MySQL",
+  clickhouse: "ClickHouse",
+  snowflake: "Snowflake",
+  duckdb: "DuckDB",
+  salesforce: "Salesforce (SOQL)",
+};
+
 function dialectName(dbType: DBType): string {
-  switch (dbType) {
-    case "postgres": return "PostgreSQL";
-    case "mysql": return "MySQL";
-    default: return dbType.charAt(0).toUpperCase() + dbType.slice(1);
-  }
+  return DIALECT_DISPLAY_NAMES[dbType] ?? dbType.charAt(0).toUpperCase() + dbType.slice(1);
 }
 
 function buildMultiSourceSection(


### PR DESCRIPTION
## Summary

Closes #16

- Removed 4 hardcoded dialect guide constants (`CLICKHOUSE_DIALECT_GUIDE`, `SNOWFLAKE_DIALECT_GUIDE`, `DUCKDB_DIALECT_GUIDE`, `SOQL_DIALECT_GUIDE`) from `agent.ts`
- Removed `getSfSourceMeta()` helper — Salesforce sources will register via ConnectionRegistry like all other plugins
- Simplified `dialectName()` to handle unknown `dbType` values gracefully (capitalize instead of exhaustive switch)
- Shrunk `buildSystemPrompt()` switch to postgres/mysql only — all other dialects are handled by `appendDialectHints()` which reads plugin `dialect` properties

The removed dialect guide strings will be added to each plugin's `dialect` property in #17-#20. The existing `appendDialectHints()` mechanism picks them up automatically.

## Test plan

- [x] `agent-dialect.test.ts` — 5/5 pass
- [x] `agent-cache.test.ts` — 28/28 pass
- [x] `agent-health-annotations.test.ts` — 5/5 pass
- [x] `agent-integration.test.ts` — 9/9 pass
- [x] TypeScript type check passes (no new errors)