### PR TITLE
ci: automate starter repo sync

### DIFF
--- a/.github/workflows/sync-starters.yml
+++ b/.github/workflows/sync-starters.yml
@@ -44,12 +44,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.STARTER_SYNC_PAT }}
         run: |
+          set -euo pipefail
+
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           PLATFORMS=("vercel" "railway" "render" "docker")
           SHA="${{ github.sha }}"
           SHORT_SHA="${SHA:0:7}"
+          FAILED=0
+
+          mkdir -p /tmp/repos
 
           for platform in "${PLATFORMS[@]}"; do
             repo="AtlasDevHQ/atlas-starter-${platform}"
@@ -58,12 +63,11 @@ jobs:
 
             echo "--- Syncing ${repo} ---"
 
-            # Clone the starter repo
-            clone_output="$(git clone "https://x-access-token:${GH_TOKEN}@github.com/${repo}.git" "$clone_dir" 2>&1)" || {
-              echo "  WARN: Could not clone ${repo} — skipping"
-              echo "  $clone_output"
+            # Clone the starter repo (mask the URL to avoid leaking the token)
+            if ! git clone "https://x-access-token:${GH_TOKEN}@github.com/${repo}.git" "$clone_dir" 2>/dev/null; then
+              echo "  WARN: Could not clone ${repo} — skipping (repo may not exist yet)"
               continue
-            }
+            fi
 
             # Remove all tracked files (keep .git)
             cd "$clone_dir"
@@ -80,9 +84,18 @@ jobs:
             else
               git commit -m "sync: update from atlas monorepo (${SHORT_SHA})" \
                 -m "Source: https://github.com/AtlasDevHQ/atlas/commit/${SHA}"
-              git push origin main
-              echo "  Pushed updates"
+              if git push origin main; then
+                echo "  Pushed updates"
+              else
+                echo "  ERROR: Failed to push to ${repo}"
+                FAILED=1
+              fi
             fi
 
             cd /tmp
           done
+
+          if [ "$FAILED" -ne 0 ]; then
+            echo "One or more starter repos failed to sync"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/sync-starters.yml` that automatically syncs the 4 starter repos (`atlas-starter-{vercel,railway,render,docker}`) when template source files change on `main`
- Triggers on pushes to `packages/api/src/`, `packages/web/src/ui/`, `create-atlas/`, or `examples/`
- Also supports `workflow_dispatch` for manual trigger
- Runs `prepare-templates.sh` + `generate-starters.sh`, then pushes changes to each starter repo (skips if no diff)

Closes #34

## Setup required

The `STARTER_SYNC_PAT` repository secret must be configured in the repo settings before this workflow will work. The PAT needs push access to:
- `AtlasDevHQ/atlas-starter-vercel`
- `AtlasDevHQ/atlas-starter-railway`
- `AtlasDevHQ/atlas-starter-render`
- `AtlasDevHQ/atlas-starter-docker`

## Test plan

- [ ] Verify YAML syntax (validated locally with yaml-lint)
- [ ] Configure `STARTER_SYNC_PAT` secret
- [ ] Run workflow manually via `workflow_dispatch` and confirm starter repos are updated
- [ ] Push a change to `packages/api/src/` and confirm auto-trigger