### PR TITLE
fix(create-atlas): resolve monorepo deps when generating starters

### DIFF
--- a/create-atlas/scripts/generate-starters.sh
+++ b/create-atlas/scripts/generate-starters.sh
@@ -16,8 +16,12 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MONOREPO_ROOT="$SCRIPT_DIR/../.."
 CREATE_ATLAS="$SCRIPT_DIR/../index.ts"
 OUTPUT_DIR="${1:-$SCRIPT_DIR/../starters}"
+
+# Ensure Bun can resolve monorepo deps when CWD is a temp directory
+export NODE_PATH="${MONOREPO_ROOT}/node_modules"
 
 PLATFORMS=("vercel" "railway" "render" "docker")
 


### PR DESCRIPTION
## Summary

- `generate-starters.sh` `cd`s into a temp directory before running `create-atlas`, but Bun resolves imports relative to CWD — so `@clack/prompts` and other deps fail to resolve
- Fix: export `NODE_PATH` pointing to the monorepo root's `node_modules`
- Unblocks the sync-starters workflow (#34) which failed on first run

## Test plan

- [ ] CI passes
- [ ] Re-run sync-starters workflow after merge