### PR TITLE
fix: install create-atlas deps in sync workflow

### DIFF
--- a/.github/workflows/sync-starters.yml
+++ b/.github/workflows/sync-starters.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Install create-atlas dependencies
+        run: cd create-atlas && bun install --frozen-lockfile
+
       - name: Prepare templates
         run: SKIP_SYNCPACK=1 bash create-atlas/scripts/prepare-templates.sh
 

--- a/create-atlas/scripts/generate-starters.sh
+++ b/create-atlas/scripts/generate-starters.sh
@@ -16,12 +16,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MONOREPO_ROOT="$SCRIPT_DIR/../.."
 CREATE_ATLAS="$SCRIPT_DIR/../index.ts"
 OUTPUT_DIR="${1:-$SCRIPT_DIR/../starters}"
-
-# Ensure Bun can resolve monorepo deps when CWD is a temp directory
-export NODE_PATH="${MONOREPO_ROOT}/node_modules"
 
 PLATFORMS=("vercel" "railway" "render" "docker")
 


### PR DESCRIPTION
## Summary

- `create-atlas` is not in the monorepo `workspaces` array, so root `bun install` doesn't install its deps (`@clack/prompts` etc)
- Adds a separate `cd create-atlas && bun install` step in the sync-starters workflow
- Reverts the `NODE_PATH` hack from #37 — Bun doesn't use `NODE_PATH`

## Test plan

- [ ] CI passes
- [ ] Merge and verify sync-starters workflow succeeds end-to-end