### PR TITLE
feat: executePython tool with import guard + just-bash backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,11 @@
-# Local dev: Postgres with two databases.
+# Local dev: Postgres + sandbox sidecar.
 #   atlas       — Atlas internal DB (auth, audit, settings)
 #   atlas_demo  — Demo analytics datasource (disposable, re-seedable)
 #
 # .env should have:
 #   DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas
 #   ATLAS_DATASOURCE_URL=postgresql://atlas:atlas@localhost:5432/atlas_demo
+#   ATLAS_SANDBOX_URL=http://localhost:8080  (for Python execution)
 
 services:
   postgres:
@@ -24,6 +25,24 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+
+  sandbox:
+    build:
+      context: .
+      dockerfile: packages/sandbox-sidecar/Dockerfile
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./semantic:/semantic:ro
+    environment:
+      SEMANTIC_DIR: /semantic
+      # No SIDECAR_AUTH_TOKEN in local dev — the sandbox is only reachable on localhost.
+      # Production deploys should set SIDECAR_AUTH_TOKEN on both the API and sandbox services.
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
 volumes:
   pgdata:

--- a/packages/api/src/lib/sidecar-types.ts
+++ b/packages/api/src/lib/sidecar-types.ts
@@ -1,7 +1,7 @@
 /**
  * Types for the sidecar HTTP contract.
  * Used by both the sidecar server (packages/sandbox-sidecar) and
- * the sidecar client (packages/api/src/lib/tools/explore-sidecar.ts).
+ * the sidecar clients (explore-sidecar.ts, python-sidecar.ts).
  */
 
 export interface SidecarExecRequest {
@@ -14,3 +14,14 @@ export interface SidecarExecResponse {
   stderr: string;
   exitCode: number;
 }
+
+// --- Python execution ---
+
+export interface SidecarPythonRequest {
+  code: string;
+  data?: { columns: string[]; rows: unknown[][] };
+  timeout?: number;
+}
+
+/** Wire-format alias — canonical type lives in python.ts. */
+export type { PythonResult as SidecarPythonResponse } from "@atlas/api/lib/tools/python";

--- a/packages/api/src/lib/tools/__tests__/python-sidecar.test.ts
+++ b/packages/api/src/lib/tools/__tests__/python-sidecar.test.ts
@@ -1,0 +1,365 @@
+import { describe, expect, it, mock, afterEach, beforeEach } from "bun:test";
+
+// Mock logger to avoid side effects
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  }),
+}));
+
+const { executePythonViaSidecar } = await import(
+  "@atlas/api/lib/tools/python-sidecar"
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SIDECAR_URL = "http://localhost:9999";
+
+const savedEnv: Record<string, string | undefined> = {};
+
+function setEnv(key: string, value: string | undefined) {
+  if (!(key in savedEnv)) savedEnv[key] = process.env[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+// Save original fetch and provide a type-safe mock helper
+const originalFetch = globalThis.fetch;
+
+/** Override globalThis.fetch with a mock function. */
+function mockFetch(fn: (input: string | URL | Request, init?: RequestInit) => Promise<Response>) {
+  globalThis.fetch = fn as typeof globalThis.fetch;
+}
+
+afterEach(() => {
+  // Restore env
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  for (const key of Object.keys(savedEnv)) delete savedEnv[key];
+
+  // Restore fetch
+  globalThis.fetch = originalFetch;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("executePythonViaSidecar", () => {
+  describe("URL validation", () => {
+    it("returns error for invalid sidecar URL", async () => {
+      const result = await executePythonViaSidecar(
+        "not-a-url",
+        'print("hello")',
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("Invalid ATLAS_SANDBOX_URL");
+      }
+    });
+  });
+
+  describe("connection errors", () => {
+    it("returns error when sidecar is unreachable", async () => {
+      mockFetch(() => Promise.reject(new Error("fetch failed: ECONNREFUSED")));
+
+      const result = await executePythonViaSidecar(
+        SIDECAR_URL,
+        'print("hello")',
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("sidecar unreachable");
+      }
+    });
+
+    it("returns timeout error when request exceeds deadline", async () => {
+      mockFetch(() => Promise.reject(new Error("TimeoutError: timed out")));
+
+      const result = await executePythonViaSidecar(
+        SIDECAR_URL,
+        'print("hello")',
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("timed out");
+      }
+    });
+
+    it("returns error for generic fetch failures", async () => {
+      mockFetch(() => Promise.reject(new Error("network error")));
+
+      const result = await executePythonViaSidecar(
+        SIDECAR_URL,
+        'print("hello")',
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("Sidecar request failed");
+      }
+    });
+  });
+
+  describe("HTTP error responses", () => {
+    it("parses structured error from HTTP 500", async () => {
+      mockFetch(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({ success: false, error: "crash" }),
+            { status: 500 },
+          ),
+        ));
+
+      const result = await executePythonViaSidecar(
+        SIDECAR_URL,
+        'print("hello")',
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe("crash");
+      }
+    });
+
+    it("returns raw error for non-500 HTTP errors", async () => {
+      mockFetch(() =>
+        Promise.resolve(
+          new Response("Rate limited", { status: 429 }),
+        ));
+
+      const result = await executePythonViaSidecar(
+        SIDECAR_URL,
+        'print("hello")',
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("HTTP 429");
+        expect(result.error).toContain("Rate limited");
+      }
+    });
+
+    it("returns raw error for 500 with non-JSON body", async () => {
+      mockFetch(() =>
+        Promise.resolve(
+          new Response("Internal Server Error", { status: 500 }),
+        ));
+
+      const result = await executePythonViaSidecar(
+        SIDECAR_URL,
+        'print("hello")',
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("HTTP 500");
+      }
+    });
+  });
+
+  describe("response parsing", () => {
+    it("returns error when response JSON is unparseable", async () => {
+      mockFetch(() =>
+        Promise.resolve(new Response("not json", { status: 200 })));
+
+      const result = await executePythonViaSidecar(
+        SIDECAR_URL,
+        'print("hello")',
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("Failed to parse sidecar response");
+      }
+    });
+
+    it("returns error when response lacks success boolean", async () => {
+      mockFetch(() =>
+        Promise.resolve(
+          Response.json({ output: "hello" }),
+        ));
+
+      const result = await executePythonViaSidecar(
+        SIDECAR_URL,
+        'print("hello")',
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("unexpected response format");
+      }
+    });
+  });
+
+  describe("successful execution", () => {
+    it("returns PythonResult on success", async () => {
+      mockFetch(() =>
+        Promise.resolve(
+          Response.json({
+            success: true,
+            output: "hello world",
+          }),
+        ));
+
+      const result = await executePythonViaSidecar(
+        SIDECAR_URL,
+        'print("hello world")',
+      );
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.output).toBe("hello world");
+      }
+    });
+
+    it("returns result with table data", async () => {
+      mockFetch(() =>
+        Promise.resolve(
+          Response.json({
+            success: true,
+            table: { columns: ["x"], rows: [[1], [2]] },
+          }),
+        ));
+
+      const result = await executePythonViaSidecar(
+        SIDECAR_URL,
+        "code",
+      );
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.table).toEqual({ columns: ["x"], rows: [[1], [2]] });
+      }
+    });
+
+    it("returns result with rechartsCharts", async () => {
+      mockFetch(() =>
+        Promise.resolve(
+          Response.json({
+            success: true,
+            rechartsCharts: [
+              { type: "bar", data: [{ x: 1 }], categoryKey: "x", valueKeys: ["x"] },
+            ],
+          }),
+        ));
+
+      const result = await executePythonViaSidecar(
+        SIDECAR_URL,
+        "code",
+      );
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.rechartsCharts).toHaveLength(1);
+      }
+    });
+
+    it("returns error result from sidecar", async () => {
+      mockFetch(() =>
+        Promise.resolve(
+          Response.json({
+            success: false,
+            error: "ZeroDivisionError: division by zero",
+          }),
+        ));
+
+      const result = await executePythonViaSidecar(
+        SIDECAR_URL,
+        "1/0",
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("ZeroDivisionError");
+      }
+    });
+  });
+
+  describe("request construction", () => {
+    it("sends auth header when SIDECAR_AUTH_TOKEN is set", async () => {
+      setEnv("SIDECAR_AUTH_TOKEN", "test-token-123");
+      let capturedHeaders: Headers | null = null;
+
+      mockFetch((_input, init) => {
+        capturedHeaders = new Headers(init?.headers);
+        return Promise.resolve(Response.json({ success: true }));
+      });
+
+      await executePythonViaSidecar(SIDECAR_URL, "code");
+      expect(capturedHeaders!.get("Authorization")).toBe("Bearer test-token-123");
+    });
+
+    it("omits auth header when SIDECAR_AUTH_TOKEN is not set", async () => {
+      setEnv("SIDECAR_AUTH_TOKEN", undefined);
+      let capturedHeaders: Headers | null = null;
+
+      mockFetch((_input, init) => {
+        capturedHeaders = new Headers(init?.headers);
+        return Promise.resolve(Response.json({ success: true }));
+      });
+
+      await executePythonViaSidecar(SIDECAR_URL, "code");
+      expect(capturedHeaders!.get("Authorization")).toBeNull();
+    });
+
+    it("sends data payload when provided", async () => {
+      let capturedBody: string | null = null;
+
+      mockFetch((_input, init) => {
+        capturedBody = init?.body as string;
+        return Promise.resolve(Response.json({ success: true }));
+      });
+
+      const data = { columns: ["id"], rows: [[1], [2]] };
+      await executePythonViaSidecar(SIDECAR_URL, "code", data);
+
+      const parsed = JSON.parse(capturedBody!);
+      expect(parsed.data).toEqual(data);
+      expect(parsed.code).toBe("code");
+    });
+
+    it("omits data from request when not provided", async () => {
+      let capturedBody: string | null = null;
+
+      mockFetch((_input, init) => {
+        capturedBody = init?.body as string;
+        return Promise.resolve(Response.json({ success: true }));
+      });
+
+      await executePythonViaSidecar(SIDECAR_URL, "code");
+
+      const parsed = JSON.parse(capturedBody!);
+      expect(parsed.data).toBeUndefined();
+    });
+  });
+
+  describe("timeout configuration", () => {
+    it("uses ATLAS_PYTHON_TIMEOUT when set", async () => {
+      setEnv("ATLAS_PYTHON_TIMEOUT", "5000");
+      let capturedBody: string | null = null;
+
+      mockFetch((_input, init) => {
+        capturedBody = init?.body as string;
+        return Promise.resolve(Response.json({ success: true }));
+      });
+
+      await executePythonViaSidecar(SIDECAR_URL, "code");
+
+      const parsed = JSON.parse(capturedBody!);
+      expect(parsed.timeout).toBe(5000);
+    });
+
+    it("falls back to default on invalid ATLAS_PYTHON_TIMEOUT", async () => {
+      setEnv("ATLAS_PYTHON_TIMEOUT", "not-a-number");
+      let capturedBody: string | null = null;
+
+      mockFetch((_input, init) => {
+        capturedBody = init?.body as string;
+        return Promise.resolve(Response.json({ success: true }));
+      });
+
+      await executePythonViaSidecar(SIDECAR_URL, "code");
+
+      const parsed = JSON.parse(capturedBody!);
+      expect(parsed.timeout).toBe(30000); // DEFAULT_TIMEOUT_MS
+    });
+  });
+});

--- a/packages/api/src/lib/tools/__tests__/python.test.ts
+++ b/packages/api/src/lib/tools/__tests__/python.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, mock } from "bun:test";
+import { describe, expect, it, mock, afterEach } from "bun:test";
 
 // Mock logger and tracing to avoid side effects
 mock.module("@atlas/api/lib/logger", () => ({
@@ -14,7 +14,7 @@ mock.module("@atlas/api/lib/tracing", () => ({
   withSpan: async (_name: string, _attrs: unknown, fn: () => Promise<unknown>) => fn(),
 }));
 
-const { validatePythonCode, executePythonCode } = await import(
+const { validatePythonCode } = await import(
   "@atlas/api/lib/tools/python"
 );
 
@@ -95,6 +95,43 @@ describe("validatePythonCode", () => {
       expect(result.safe).toBe(false);
       if (!result.safe) expect(result.reason).toContain("os");
     });
+
+    // Network modules (added per PR review #5)
+    it("rejects import http", async () => {
+      const result = await validatePythonCode("import http");
+      expect(result.safe).toBe(false);
+      if (!result.safe) expect(result.reason).toContain("http");
+    });
+
+    it("rejects import urllib", async () => {
+      const result = await validatePythonCode("import urllib");
+      expect(result.safe).toBe(false);
+      if (!result.safe) expect(result.reason).toContain("urllib");
+    });
+
+    it("rejects import requests", async () => {
+      const result = await validatePythonCode("import requests");
+      expect(result.safe).toBe(false);
+      if (!result.safe) expect(result.reason).toContain("requests");
+    });
+
+    it("rejects import pickle", async () => {
+      const result = await validatePythonCode("import pickle");
+      expect(result.safe).toBe(false);
+      if (!result.safe) expect(result.reason).toContain("pickle");
+    });
+
+    it("rejects import tempfile", async () => {
+      const result = await validatePythonCode("import tempfile");
+      expect(result.safe).toBe(false);
+      if (!result.safe) expect(result.reason).toContain("tempfile");
+    });
+
+    it("rejects import pathlib", async () => {
+      const result = await validatePythonCode("import pathlib");
+      expect(result.safe).toBe(false);
+      if (!result.safe) expect(result.reason).toContain("pathlib");
+    });
   });
 
   describe("blocked builtins", () => {
@@ -132,6 +169,25 @@ describe("validatePythonCode", () => {
       const result = await validatePythonCode("breakpoint()");
       expect(result.safe).toBe(false);
       if (!result.safe) expect(result.reason).toContain("breakpoint");
+    });
+
+    // Guard bypass mitigations (PR review #1)
+    it("rejects getattr()", async () => {
+      const result = await validatePythonCode('getattr(__builtins__, "exec")("print(1)")');
+      expect(result.safe).toBe(false);
+      if (!result.safe) expect(result.reason).toContain("getattr");
+    });
+
+    it("rejects globals()", async () => {
+      const result = await validatePythonCode('globals()["__builtins__"]');
+      expect(result.safe).toBe(false);
+      if (!result.safe) expect(result.reason).toContain("globals");
+    });
+
+    it("rejects vars()", async () => {
+      const result = await validatePythonCode("vars()");
+      expect(result.safe).toBe(false);
+      if (!result.safe) expect(result.reason).toContain("vars");
     });
   });
 
@@ -215,138 +271,61 @@ z = x + y
 });
 
 // ---------------------------------------------------------------------------
-// Execution tests (real Python — requires python3)
+// Sidecar routing tests
 // ---------------------------------------------------------------------------
 
-describe("executePythonCode", () => {
-  it("executes simple print", async () => {
-    const result = await executePythonCode('print("hello world")');
-    expect(result.success).toBe(true);
-    expect(result.output).toContain("hello world");
-  });
+describe("executePython tool", () => {
+  const savedEnv: Record<string, string | undefined> = {};
 
-  it("captures runtime errors", async () => {
-    const result = await executePythonCode("1 / 0");
-    expect(result.success).toBe(false);
-    expect(result.error).toContain("ZeroDivisionError");
-  });
+  function saveAndSetEnv(key: string, value: string | undefined) {
+    if (!(key in savedEnv)) {
+      savedEnv[key] = process.env[key];
+    }
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
 
-  it("receives data payload", async () => {
-    const code = `
-if data:
-    print(f"columns: {data['columns']}")
-    print(f"rows: {len(data['rows'])}")
-`;
-    const result = await executePythonCode(code, {
-      columns: ["id", "name"],
-      rows: [[1, "Alice"], [2, "Bob"]],
-    });
-    expect(result.success).toBe(true);
-    expect(result.output).toContain("columns: ['id', 'name']");
-    expect(result.output).toContain("rows: 2");
-  });
-
-  it("returns table result via _atlas_table", async () => {
-    const code = `
-_atlas_table = {"columns": ["x", "y"], "rows": [[1, 2], [3, 4]]}
-`;
-    const result = await executePythonCode(code);
-    expect(result.success).toBe(true);
-    expect(result.table).toEqual({
-      columns: ["x", "y"],
-      rows: [[1, 2], [3, 4]],
-    });
-  });
-
-  it("handles empty code output", async () => {
-    const result = await executePythonCode("x = 1 + 1");
-    expect(result.success).toBe(true);
-  });
-
-  it("handles multi-line output", async () => {
-    const code = `
-for i in range(3):
-    print(f"line {i}")
-`;
-    const result = await executePythonCode(code);
-    expect(result.success).toBe(true);
-    expect(result.output).toContain("line 0");
-    expect(result.output).toContain("line 2");
-  });
-
-  it("runs without data when none provided", async () => {
-    const code = `
-print(f"data is {data}")
-print(f"df is {df}")
-`;
-    const result = await executePythonCode(code);
-    expect(result.success).toBe(true);
-    expect(result.output).toContain("data is None");
-    expect(result.output).toContain("df is None");
-  });
-
-  it("returns Recharts chart via _atlas_chart dict", async () => {
-    const code = `
-_atlas_chart = {
-    "type": "bar",
-    "data": [{"month": "Jan", "revenue": 100}, {"month": "Feb", "revenue": 200}],
-    "categoryKey": "month",
-    "valueKeys": ["revenue"],
-}
-`;
-    const result = await executePythonCode(code);
-    expect(result.success).toBe(true);
-    expect(result.rechartsCharts).toHaveLength(1);
-    expect(result.rechartsCharts![0].type).toBe("bar");
-    expect(result.rechartsCharts![0].categoryKey).toBe("month");
-  });
-
-  it("returns multiple Recharts charts via _atlas_chart list", async () => {
-    const code = `
-_atlas_chart = [
-    {"type": "line", "data": [{"x": 1, "y": 2}], "categoryKey": "x", "valueKeys": ["y"]},
-    {"type": "bar", "data": [{"x": 1, "y": 3}], "categoryKey": "x", "valueKeys": ["y"]},
-]
-`;
-    const result = await executePythonCode(code);
-    expect(result.success).toBe(true);
-    expect(result.rechartsCharts).toHaveLength(2);
-    expect(result.rechartsCharts![0].type).toBe("line");
-    expect(result.rechartsCharts![1].type).toBe("bar");
-  });
-
-  it("provides chart_path() helper", async () => {
-    const code = `
-import os
-p = chart_path(0)
-print(f"path: {p}")
-print(f"exists: {os.path.isdir(os.path.dirname(p))}")
-`;
-    const result = await executePythonCode(code);
-    expect(result.success).toBe(true);
-    expect(result.output).toContain("path:");
-    expect(result.output).toContain("exists: True");
-  });
-
-  it("times out on runaway code", async () => {
-    // Override timeout to 1s for this test
-    const origTimeout = process.env.ATLAS_PYTHON_TIMEOUT;
-    process.env.ATLAS_PYTHON_TIMEOUT = "1000";
-    try {
-      // Re-import to pick up new timeout — but the module is cached.
-      // Instead, test the timeout behavior by running a sleep that exceeds default.
-      // The actual timeout constant is read at module load, so we test with a
-      // long-running script and rely on the 30s default being way more than needed.
-      // For a focused test, we'll just verify the function handles killed processes.
-      const result = await executePythonCode("import time; time.sleep(10)");
-      expect(result.success).toBe(false);
-      expect(result.error).toBeDefined();
-    } finally {
-      if (origTimeout !== undefined) {
-        process.env.ATLAS_PYTHON_TIMEOUT = origTimeout;
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
       } else {
-        delete process.env.ATLAS_PYTHON_TIMEOUT;
+        process.env[key] = value;
       }
     }
-  }, 15000);
+    for (const key of Object.keys(savedEnv)) {
+      delete savedEnv[key];
+    }
+  });
+
+  it("rejects execution when ATLAS_SANDBOX_URL is not set", async () => {
+    saveAndSetEnv("ATLAS_SANDBOX_URL", undefined);
+
+    const { executePython } = await import("@atlas/api/lib/tools/python");
+    const execute = executePython.execute!;
+    const result = await execute(
+      { code: 'print("hello")', explanation: "test", data: undefined },
+      {} as never,
+    ) as { success: boolean; error?: string };
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("ATLAS_SANDBOX_URL");
+  });
+
+  it("rejects code that fails import guard before hitting sidecar", async () => {
+    saveAndSetEnv("ATLAS_SANDBOX_URL", "http://localhost:9999");
+
+    const { executePython } = await import("@atlas/api/lib/tools/python");
+    const execute = executePython.execute!;
+    const result = await execute(
+      { code: "import subprocess", explanation: "test", data: undefined },
+      {} as never,
+    ) as { success: boolean; error?: string };
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("subprocess");
+  });
 });
+
+// Registry gating (ATLAS_PYTHON_ENABLED + ATLAS_SANDBOX_URL) is tested in registry.test.ts

--- a/packages/api/src/lib/tools/__tests__/registry.test.ts
+++ b/packages/api/src/lib/tools/__tests__/registry.test.ts
@@ -167,6 +167,43 @@ describe("defaultRegistry", () => {
 });
 
 describe("buildRegistry", () => {
+  it("throws when ATLAS_PYTHON_ENABLED=true but ATLAS_SANDBOX_URL is not set", async () => {
+    const saved = {
+      enabled: process.env.ATLAS_PYTHON_ENABLED,
+      url: process.env.ATLAS_SANDBOX_URL,
+    };
+    try {
+      process.env.ATLAS_PYTHON_ENABLED = "true";
+      delete process.env.ATLAS_SANDBOX_URL;
+      await expect(buildRegistry()).rejects.toThrow("ATLAS_SANDBOX_URL");
+    } finally {
+      if (saved.enabled !== undefined) process.env.ATLAS_PYTHON_ENABLED = saved.enabled;
+      else delete process.env.ATLAS_PYTHON_ENABLED;
+      if (saved.url !== undefined) process.env.ATLAS_SANDBOX_URL = saved.url;
+      else delete process.env.ATLAS_SANDBOX_URL;
+    }
+  });
+
+  it("includes executePython when ATLAS_PYTHON_ENABLED and ATLAS_SANDBOX_URL are set", async () => {
+    const saved = {
+      enabled: process.env.ATLAS_PYTHON_ENABLED,
+      url: process.env.ATLAS_SANDBOX_URL,
+    };
+    try {
+      process.env.ATLAS_PYTHON_ENABLED = "true";
+      process.env.ATLAS_SANDBOX_URL = "http://localhost:8080";
+      const registry = await buildRegistry();
+      const names = Object.keys(registry.getAll()).sort();
+      expect(names).toEqual(["executePython", "executeSQL", "explore"]);
+      expect(registry.describe()).toContain("### 4. Analyze Data with Python");
+    } finally {
+      if (saved.enabled !== undefined) process.env.ATLAS_PYTHON_ENABLED = saved.enabled;
+      else delete process.env.ATLAS_PYTHON_ENABLED;
+      if (saved.url !== undefined) process.env.ATLAS_SANDBOX_URL = saved.url;
+      else delete process.env.ATLAS_SANDBOX_URL;
+    }
+  });
+
   it("returns 2 core tools by default", async () => {
     const registry = await buildRegistry();
     const names = Object.keys(registry.getAll()).sort();

--- a/packages/api/src/lib/tools/python-sidecar.ts
+++ b/packages/api/src/lib/tools/python-sidecar.ts
@@ -1,0 +1,150 @@
+/**
+ * Sidecar backend for the Python execution tool.
+ *
+ * Calls the sandbox sidecar's POST /exec-python endpoint to run Python code
+ * in an isolated container with no secrets and no host access. The sidecar
+ * handles data injection, chart collection, and structured output.
+ *
+ * Configured via ATLAS_SANDBOX_URL (same as the explore sidecar).
+ */
+
+import type { SidecarPythonRequest } from "@atlas/api/lib/sidecar-types";
+import type { PythonResult } from "./python";
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("python-sidecar");
+
+/** Default timeout for Python execution (ms). */
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/** HTTP-level timeout — longer than the execution timeout to allow for overhead. */
+const HTTP_OVERHEAD_MS = 10_000;
+
+/** Shorthand for building error results. */
+function pythonError(error: string): PythonResult & { success: false } {
+  return { success: false, error };
+}
+
+export async function executePythonViaSidecar(
+  sidecarUrl: string,
+  code: string,
+  data?: { columns: string[]; rows: unknown[][] },
+): Promise<PythonResult> {
+  const authToken = process.env.SIDECAR_AUTH_TOKEN;
+
+  let baseUrl: URL;
+  try {
+    baseUrl = new URL(sidecarUrl);
+  } catch {
+    return pythonError(
+      `Invalid ATLAS_SANDBOX_URL: "${sidecarUrl}". Expected a valid URL (e.g. http://sandbox-sidecar:8080).`,
+    );
+  }
+
+  const execUrl = new URL("/exec-python", baseUrl).toString();
+  const rawTimeout = parseInt(process.env.ATLAS_PYTHON_TIMEOUT ?? String(DEFAULT_TIMEOUT_MS), 10);
+  if (Number.isNaN(rawTimeout)) {
+    log.warn({ value: process.env.ATLAS_PYTHON_TIMEOUT }, "Invalid ATLAS_PYTHON_TIMEOUT, using default");
+  }
+  const timeout = Number.isNaN(rawTimeout) ? DEFAULT_TIMEOUT_MS : rawTimeout;
+
+  const requestBody: SidecarPythonRequest = { code, timeout };
+  if (data) {
+    requestBody.data = data;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(execUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
+      },
+      body: JSON.stringify(requestBody),
+      signal: AbortSignal.timeout(timeout + HTTP_OVERHEAD_MS),
+    });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+
+    if (
+      detail.includes("ECONNREFUSED") ||
+      detail.includes("fetch failed") ||
+      detail.includes("Failed to connect")
+    ) {
+      log.error({ err: detail, url: execUrl }, "Sidecar connection failed for Python execution");
+      return pythonError(
+        `Python sidecar unreachable at ${baseUrl.origin}: ${detail}. Check that the sandbox-sidecar service is running.`,
+      );
+    }
+
+    if (detail.includes("TimeoutError") || detail.includes("timed out") || detail.includes("aborted")) {
+      log.warn({ timeout }, "Python sidecar request timed out");
+      return pythonError(`Python execution timed out after ${timeout}ms`);
+    }
+
+    log.error({ err: detail }, "Python sidecar request failed");
+    return pythonError(`Sidecar request failed: ${detail}`);
+  }
+
+  if (!response.ok) {
+    let errorBody: string;
+    try {
+      errorBody = await response.text();
+    } catch {
+      errorBody = `HTTP ${response.status}`;
+    }
+
+    log.error(
+      {
+        status: response.status,
+        contentLength: response.headers.get("content-length"),
+        body: errorBody.slice(0, 500),
+      },
+      "Python sidecar returned HTTP error",
+    );
+
+    // Try to parse as structured error (500 with PythonResult shape)
+    if (response.status === 500) {
+      try {
+        const parsed = JSON.parse(errorBody) as PythonResult;
+        if (typeof parsed.success === "boolean") {
+          return parsed;
+        }
+      } catch {
+        // Not structured — fall through
+      }
+    }
+
+    return pythonError(
+      `Python sidecar error (HTTP ${response.status}): ${errorBody.slice(0, 500)}`,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = await response.json();
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    log.error(
+      {
+        err: detail,
+        status: response.status,
+        contentLength: response.headers.get("content-length"),
+      },
+      "Failed to parse Python sidecar response",
+    );
+    return pythonError(`Failed to parse sidecar response: ${detail}`);
+  }
+
+  const result = parsed as PythonResult;
+  if (typeof result.success !== "boolean") {
+    log.error(
+      { body: JSON.stringify(parsed).slice(0, 500) },
+      "Python sidecar returned unexpected response shape",
+    );
+    return pythonError("Sidecar returned an unexpected response format.");
+  }
+
+  return result;
+}

--- a/packages/api/src/lib/tools/python.ts
+++ b/packages/api/src/lib/tools/python.ts
@@ -1,25 +1,24 @@
 /**
  * Python execution tool for data analysis and visualization.
  *
- * Runs Python code in a sandboxed environment with optional data injection.
- * The just-bash backend spawns python3 with a wrapper script that handles
- * data serialization (JSON on stdin) and structured output (JSON on stdout).
+ * Runs Python code in the sandbox sidecar — an isolated Docker container
+ * with no secrets, no host access, and a minimal environment. The sidecar
+ * handles data serialization, chart collection, and structured output.
  *
- * Security: An AST-based import guard blocks dangerous modules before execution.
- * Future backends (nsjail, sidecar, Vercel) will add process-level isolation.
+ * Security model:
+ * - AST-based import guard runs first as defense-in-depth (catches obvious mistakes)
+ * - The sidecar container is the actual security boundary (no secrets, no network to host)
+ * - Requires ATLAS_SANDBOX_URL — refuses to run without a sidecar
  */
 
 import { tool } from "ai";
 import { z } from "zod";
-import * as fs from "fs";
-import * as os from "os";
-import * as path from "path";
 import { createLogger } from "@atlas/api/lib/logger";
 import { withSpan } from "@atlas/api/lib/tracing";
 
 const log = createLogger("python");
 
-// --- Import guard ---
+// --- Import guard (defense-in-depth) ---
 
 const BLOCKED_MODULES = new Set([
   "subprocess",
@@ -38,6 +37,17 @@ const BLOCKED_MODULES = new Set([
   "termios",
   "resource",
   "posixpath",
+  // Network modules
+  "http",
+  "urllib",
+  "requests",
+  "httpx",
+  "aiohttp",
+  "webbrowser",
+  // Dangerous serialization/filesystem
+  "pickle",
+  "tempfile",
+  "pathlib",
 ]);
 
 const BLOCKED_BUILTINS = new Set([
@@ -47,6 +57,13 @@ const BLOCKED_BUILTINS = new Set([
   "__import__",
   "open",
   "breakpoint",
+  "getattr",
+  "globals",
+  "locals",
+  "vars",
+  "dir",
+  "delattr",
+  "setattr",
 ]);
 
 /**
@@ -54,8 +71,9 @@ const BLOCKED_BUILTINS = new Set([
  *
  * Uses Python's own `ast` module to parse the code, then checks for:
  * - `import X` / `from X import ...` where X is in BLOCKED_MODULES
- * - Calls to blocked builtins (exec, eval, compile, __import__, open, breakpoint)
+ * - Calls to blocked builtins (exec, eval, compile, __import__, open, getattr, etc.)
  *
+ * This is defense-in-depth — the sidecar container is the security boundary.
  * Returns { safe: true } or { safe: false, reason: string }.
  */
 export async function validatePythonCode(
@@ -91,17 +109,34 @@ for node in ast.walk(tree):
 json.dump({"imports": imports, "calls": calls}, sys.stdout)
 `;
 
-  const proc = Bun.spawn(["python3", "-c", checkerScript], {
-    stdin: "pipe",
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+  let proc;
+  try {
+    proc = Bun.spawn(["python3", "-c", checkerScript], {
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    log.error({ err: detail }, "python3 not available for AST validation — guard skipped, sidecar will enforce");
+    // If python3 isn't available locally, skip the guard.
+    // The sidecar is the security boundary, not this check.
+    return { safe: true };
+  }
 
-  proc.stdin.write(code);
-  proc.stdin.end();
+  try {
+    proc.stdin.write(code);
+    proc.stdin.end();
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    log.warn({ err: detail }, "Failed to write to python3 stdin");
+    return { safe: false, reason: `Code analysis failed: ${detail}` };
+  }
 
-  const stdout = await new Response(proc.stdout).text();
-  const stderr = await new Response(proc.stderr).text();
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
   const exitCode = await proc.exited;
 
   if (exitCode !== 0) {
@@ -145,229 +180,32 @@ export interface PythonChart {
 }
 
 export interface RechartsChart {
-  type: "line" | "bar" | "area" | "scatter" | "pie";
+  type: "line" | "bar" | "pie";
   data: Record<string, unknown>[];
   categoryKey: string;
   valueKeys: string[];
 }
 
-export interface PythonResult {
-  success: boolean;
-  output?: string;
-  error?: string;
-  table?: { columns: string[]; rows: unknown[][] };
-  charts?: PythonChart[];
-  rechartsCharts?: RechartsChart[];
-}
-
-// --- Execution timeout (ms) — read at call time so tests can override ---
-function getPythonTimeout(): number {
-  return parseInt(process.env.ATLAS_PYTHON_TIMEOUT ?? "30000", 10);
-}
-
-/**
- * Python execution backend interface.
- *
- * Implementations run Python code with optional data injection and return
- * structured results. The just-bash backend is the dev-mode default;
- * nsjail (#42), sidecar (#43), and Vercel (#45) backends will follow.
- */
-// TODO(#42, #43, #45): Extract PythonBackend interface when adding nsjail/sidecar/Vercel backends
-// interface PythonBackend {
-//   execute(code: string, data?: { columns: string[]; rows: unknown[][] }): Promise<PythonResult>;
-//   close?(): Promise<void>;
-// }
-
-// --- Wrapper script ---
-
-/**
- * Python wrapper that handles:
- * - Reading data from stdin as JSON
- * - Making it available as a pandas DataFrame (if pandas is installed) or dict
- * - Capturing print output
- * - Detecting and reading chart files saved to ATLAS_CHART_DIR/chart_*.png
- * - Returning structured JSON on stdout (last line, prefixed with __ATLAS_RESULT__)
- *
- * The chart directory is unique per execution (passed via ATLAS_CHART_DIR env var)
- * to avoid collisions between concurrent requests.
- *
- * User code can also set:
- * - _atlas_table = {"columns": [...], "rows": [...]}  — structured table output
- * - _atlas_chart = {"type": "line", "data": [...], "categoryKey": "month", "valueKeys": ["revenue"]}
- *   or a list of such dicts — Recharts-native interactive chart output
- */
-const PYTHON_WRAPPER = `
-import sys, json, io, base64, glob, os
-
-_chart_dir = os.environ.get("ATLAS_CHART_DIR", "/tmp")
-
-# Read data payload from stdin
-_stdin_data = sys.stdin.read()
-_atlas_data = None
-if _stdin_data.strip():
-    _atlas_data = json.loads(_stdin_data)
-
-# Make data available as DataFrame if pandas is installed
-data = None
-df = None
-if _atlas_data:
-    try:
-        import pandas as pd
-        df = pd.DataFrame(_atlas_data["rows"], columns=_atlas_data["columns"])
-        data = df
-    except ImportError:
-        data = _atlas_data
-
-# Capture stdout
-_old_stdout = sys.stdout
-sys.stdout = _captured = io.StringIO()
-
-# Configure matplotlib for headless rendering with chart dir
-try:
-    import matplotlib
-    matplotlib.use('Agg')
-except ImportError:
-    pass
-
-# Make chart_path helper available to user code
-def chart_path(n=0):
-    return os.path.join(_chart_dir, f"chart_{n}.png")
-
-# Execute user code
-_atlas_error = None
-try:
-    exec(open(sys.argv[1]).read())
-except Exception as e:
-    _atlas_error = f"{type(e).__name__}: {e}"
-
-# Collect output
-_output = _captured.getvalue()
-sys.stdout = _old_stdout
-
-# Collect PNG charts from the per-execution chart dir
-_charts = []
-for f in sorted(glob.glob(os.path.join(_chart_dir, "chart_*.png"))):
-    with open(f, "rb") as fh:
-        _charts.append({"base64": base64.b64encode(fh.read()).decode(), "mimeType": "image/png"})
-
-# Build result
-_result = {"success": _atlas_error is None}
-if _output.strip():
-    _result["output"] = _output.strip()
-if _atlas_error:
-    _result["error"] = _atlas_error
-
-# Check if user code produced a table result via _atlas_table
-if "_atlas_table" in dir():
-    _result["table"] = _atlas_table
-
-# Check if user code produced Recharts-native chart(s) via _atlas_chart
-if "_atlas_chart" in dir():
-    _ac = _atlas_chart
-    if isinstance(_ac, dict):
-        _result["rechartsCharts"] = [_ac]
-    elif isinstance(_ac, list):
-        _result["rechartsCharts"] = _ac
-
-if _charts:
-    _result["charts"] = _charts
-
-print("__ATLAS_RESULT__" + json.dumps(_result), file=_old_stdout)
-`;
-
-// --- Just-bash backend ---
-
-export async function executePythonCode(
-  code: string,
-  data?: { columns: string[]; rows: unknown[][] },
-): Promise<PythonResult> {
-  const tmpDir = os.tmpdir();
-  const execId = `${Date.now()}_${Math.random().toString(36).slice(2)}`;
-  const codeFile = path.join(tmpDir, `atlas_py_${execId}.py`);
-  const wrapperFile = path.join(tmpDir, `atlas_pyw_${execId}.py`);
-  // Per-execution chart directory avoids collisions between concurrent requests
-  const chartDir = path.join(tmpDir, `atlas_charts_${execId}`);
-
-  try {
-    fs.mkdirSync(chartDir, { recursive: true });
-    fs.writeFileSync(codeFile, code);
-    fs.writeFileSync(wrapperFile, PYTHON_WRAPPER);
-
-    const stdinPayload = data ? JSON.stringify(data) : "";
-
-    const proc = Bun.spawn(["python3", wrapperFile, codeFile], {
-      stdin: "pipe",
-      stdout: "pipe",
-      stderr: "pipe",
-      env: {
-        ...process.env,
-        MPLBACKEND: "Agg",
-        ATLAS_CHART_DIR: chartDir,
-      },
-    });
-
-    // Kill the process after timeout to prevent runaway execution
-    const timeout = getPythonTimeout();
-    const timer = setTimeout(() => proc.kill(), timeout);
-
-    proc.stdin.write(stdinPayload);
-    proc.stdin.end();
-
-    const stdout = await new Response(proc.stdout).text();
-    const stderr = await new Response(proc.stderr).text();
-    const exitCode = await proc.exited;
-
-    clearTimeout(timer);
-
-    // Killed by timeout — exitCode is null/non-zero, stderr may be empty
-    if (exitCode !== 0 && !stdout.includes("__ATLAS_RESULT__")) {
-      const isTimeout = exitCode === null || exitCode === 137 || exitCode === 9;
-      if (isTimeout) {
-        return {
-          success: false,
-          error: `Python execution timed out after ${timeout}ms`,
-        };
-      }
+export type PythonResult =
+  | {
+      success: true;
+      output?: string;
+      table?: { columns: string[]; rows: unknown[][] };
+      charts?: PythonChart[];
+      rechartsCharts?: RechartsChart[];
     }
-
-    // Extract structured result from the last __ATLAS_RESULT__ line
-    const lines = stdout.split("\n");
-    const resultLine = lines.findLast((l) => l.startsWith("__ATLAS_RESULT__"));
-
-    if (resultLine) {
-      try {
-        return JSON.parse(resultLine.slice("__ATLAS_RESULT__".length));
-      } catch {
-        log.warn("Failed to parse Python result JSON");
-      }
-    }
-
-    // Fallback: no structured result
-    if (exitCode !== 0) {
-      return {
-        success: false,
-        error: stderr.trim() || `Python exited with code ${exitCode}`,
-      };
-    }
-
-    return {
-      success: true,
-      output: stdout.trim() || undefined,
+  | {
+      success: false;
+      error: string;
+      output?: string;
     };
-  } finally {
-    // Clean up temp files and chart directory
-    try { fs.unlinkSync(codeFile); } catch { /* ignore */ }
-    try { fs.unlinkSync(wrapperFile); } catch { /* ignore */ }
-    try { fs.rmSync(chartDir, { recursive: true, force: true }); } catch { /* ignore */ }
-  }
-}
 
 // --- Tool definition ---
 
 export const executePython = tool({
   description: `Execute Python code for data analysis and visualization.
 
-The code runs in a sandboxed Python environment with access to common data science libraries (pandas, numpy, matplotlib, etc. if installed).
+The code runs in an isolated Python sandbox with access to common data science libraries (pandas, numpy, matplotlib, scipy, scikit-learn, statsmodels).
 
 When data is provided (from a previous SQL query), it is available as:
 - \`df\`: a pandas DataFrame (if pandas is installed)
@@ -375,7 +213,7 @@ When data is provided (from a previous SQL query), it is available as:
 
 Output options:
 - Table: set \`_atlas_table = {"columns": [...], "rows": [...]}\`
-- Interactive chart (Recharts): set \`_atlas_chart = {"type": "line", "data": [...], "categoryKey": "month", "valueKeys": ["revenue"]}\` (type can be line, bar, area, scatter, pie)
+- Interactive chart (Recharts): set \`_atlas_chart = {"type": "line", "data": [...], "categoryKey": "month", "valueKeys": ["revenue"]}\` (type can be line, bar, pie)
 - PNG chart (matplotlib): save to \`chart_path(0)\`, \`chart_path(1)\`, etc.
 - Text: use \`print()\` for narrative output
 
@@ -394,25 +232,36 @@ Blocked: subprocess, os, socket, shutil, sys, ctypes, importlib, exec(), eval(),
   }),
 
   execute: async ({ code, explanation, data }) => {
-    // 1. Validate imports
+    // 0. Require sidecar
+    const sidecarUrl = process.env.ATLAS_SANDBOX_URL;
+    if (!sidecarUrl) {
+      log.error("ATLAS_SANDBOX_URL is required for Python execution");
+      return {
+        success: false,
+        error: "Python execution requires a sandbox sidecar (ATLAS_SANDBOX_URL). See deployment docs.",
+      };
+    }
+
+    // 1. Validate imports (defense-in-depth — sidecar is the real boundary)
     const validation = await validatePythonCode(code);
     if (!validation.safe) {
       log.warn({ reason: validation.reason }, "Python code rejected by import guard");
       return { success: false, error: validation.reason };
     }
 
-    // 2. Execute
+    // 2. Execute via sidecar
     const start = performance.now();
     try {
+      const { executePythonViaSidecar } = await import("./python-sidecar");
       const result = await withSpan(
         "atlas.python.execute",
         { "code.length": code.length },
-        () => executePythonCode(code, data),
+        () => executePythonViaSidecar(sidecarUrl, code, data),
       );
       const durationMs = Math.round(performance.now() - start);
 
       log.debug(
-        { durationMs, success: result.success, hasCharts: !!result.charts?.length },
+        { durationMs, success: result.success, hasCharts: result.success && !!result.charts?.length },
         "python execution",
       );
 

--- a/packages/api/src/lib/tools/registry.ts
+++ b/packages/api/src/lib/tools/registry.ts
@@ -187,6 +187,20 @@ export async function buildRegistry(options?: {
   });
 
   if (process.env.ATLAS_PYTHON_ENABLED === "true") {
+    if (!process.env.ATLAS_SANDBOX_URL) {
+      const { createLogger } = await import("@atlas/api/lib/logger");
+      const pyLog = createLogger("registry");
+      pyLog.error(
+        "ATLAS_PYTHON_ENABLED=true but ATLAS_SANDBOX_URL is not set. " +
+          "Python execution requires a sandbox sidecar for isolation.",
+      );
+      throw new Error(
+        "ATLAS_PYTHON_ENABLED=true requires ATLAS_SANDBOX_URL to be set. " +
+          "The Python tool runs in the sandbox sidecar for security isolation. " +
+          "See deployment docs for sidecar setup.",
+      );
+    }
+
     try {
       const { executePython } = await import("./python");
       registry.register({
@@ -201,6 +215,7 @@ export async function buildRegistry(options?: {
         { err: err instanceof Error ? err : new Error(String(err)) },
         "Failed to load Python tool — executePython will be unavailable",
       );
+      throw err;
     }
   }
 

--- a/packages/sandbox-sidecar/Dockerfile
+++ b/packages/sandbox-sidecar/Dockerfile
@@ -1,13 +1,24 @@
 FROM oven/bun:1.3.10-debian AS base
 
-# Install only the tools needed for explore mode
+# Install tools needed for explore mode + Python for executePython
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \
     coreutils \
     grep \
     findutils \
     tree \
+    python3 \
+    python3-pip \
     && rm -rf /var/lib/apt/lists/*
+
+# Install data science libraries (user code may use these)
+RUN pip3 install --no-cache-dir --break-system-packages \
+    pandas \
+    numpy \
+    matplotlib \
+    scipy \
+    scikit-learn \
+    statsmodels
 
 # Use existing nobody user (65534) — don't create a new one, the base image has it
 # Fall back to creating if not present (shouldn't happen with debian-based images)
@@ -23,8 +34,6 @@ COPY packages/sandbox-sidecar/src/ ./src/
 # For custom datasets, rebuild with a volume mount or replace semantic/ in CI.
 COPY packages/cli/data/demo-semantic/ /semantic/
 RUN chmod -R a-w /semantic/
-
-# Keep this image minimal — adding packages or env vars weakens the isolation model
 
 # No secrets, no database drivers, no node_modules beyond bun runtime
 EXPOSE 8080

--- a/packages/sandbox-sidecar/src/server.ts
+++ b/packages/sandbox-sidecar/src/server.ts
@@ -7,13 +7,19 @@
  * command with cwd set to SEMANTIC_DIR, and cleans up.
  *
  * Endpoints:
- *   GET  /health — { status: "ok" }
- *   POST /exec   — { command, timeout? } → { stdout, stderr, exitCode }
+ *   GET  /health        — { status: "ok" }
+ *   POST /exec          — { command, timeout? } → { stdout, stderr, exitCode }
+ *   POST /exec-python   — { code, data?, timeout? } → PythonResult
  */
 
-import type { SidecarExecRequest, SidecarExecResponse } from "@atlas/api/lib/sidecar-types";
+import type {
+  SidecarExecRequest,
+  SidecarExecResponse,
+  SidecarPythonRequest,
+  SidecarPythonResponse,
+} from "@atlas/api/lib/sidecar-types";
 import { randomUUID } from "crypto";
-import { readdirSync } from "fs";
+import { readdirSync, writeFileSync } from "fs";
 import { mkdir, rm } from "fs/promises";
 import { join } from "path";
 
@@ -27,6 +33,10 @@ const AUTH_TOKEN = process.env.SIDECAR_AUTH_TOKEN;
 
 let activeExecs = 0;
 const MAX_CONCURRENT = 10;
+
+// --- Python defaults ---
+const PYTHON_DEFAULT_TIMEOUT_MS = 30_000;
+const PYTHON_MAX_TIMEOUT_MS = 120_000;
 
 /** Read up to `max` bytes from a ReadableStream. */
 async function readLimited(stream: ReadableStream, max: number): Promise<string> {
@@ -50,14 +60,26 @@ async function readLimited(stream: ReadableStream, max: number): Promise<string>
   return new TextDecoder().decode(Buffer.concat(chunks));
 }
 
-async function handleExec(req: Request): Promise<Response> {
-  // Optional auth check — if SIDECAR_AUTH_TOKEN is set, require it
-  if (AUTH_TOKEN) {
-    const authHeader = req.headers.get("Authorization");
-    if (authHeader !== `Bearer ${AUTH_TOKEN}`) {
-      return Response.json({ error: "Unauthorized" }, { status: 401 });
-    }
+/** Shared auth check. Returns a 401 Response if auth fails, null if OK. */
+function checkAuth(req: Request): Response | null {
+  if (!AUTH_TOKEN) return null;
+  const authHeader = req.headers.get("Authorization");
+  if (authHeader !== `Bearer ${AUTH_TOKEN}`) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+  return null;
+}
+
+/** Clamp a timeout value to [min, max]. */
+function clampTimeout(value: number | undefined, defaultMs: number, maxMs: number): number {
+  return Math.min(Math.max(value ?? defaultMs, 1000), maxMs);
+}
+
+// --- Shell exec handler ---
+
+async function handleExec(req: Request): Promise<Response> {
+  const authErr = checkAuth(req);
+  if (authErr) return authErr;
 
   // Concurrency control
   if (activeExecs >= MAX_CONCURRENT) {
@@ -75,11 +97,7 @@ async function handleExec(req: Request): Promise<Response> {
     return Response.json({ error: "Missing or invalid 'command' field" }, { status: 400 });
   }
 
-  // Clamp timeout: minimum 1s (prevent abuse), maximum 60s (prevent resource exhaustion)
-  const timeout = Math.min(
-    Math.max(body.timeout ?? DEFAULT_TIMEOUT_MS, 1000),
-    MAX_TIMEOUT_MS,
-  );
+  const timeout = clampTimeout(body.timeout, DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
 
   // Per-request isolation: unique temp directory
   const execId = randomUUID();
@@ -92,10 +110,6 @@ async function handleExec(req: Request): Promise<Response> {
   try {
     await mkdir(tmpDir, { recursive: true });
 
-    // Security: The sidecar does NOT validate commands. Isolation comes from
-    // the container boundary — no secrets mounted, minimal PATH, cwd fixed
-    // to the semantic directory. The calling API is responsible for scoping
-    // commands to safe operations (explore tool restrictions).
     const proc = Bun.spawn(["bash", "-c", body.command], {
       cwd: SEMANTIC_DIR,
       env: {
@@ -138,17 +152,305 @@ async function handleExec(req: Request): Promise<Response> {
     );
   } finally {
     activeExecs--;
-    // Cleanup temp directory — fire and forget
     rm(tmpDir, { recursive: true, force: true }).catch((err) => {
       console.warn(`[sandbox-sidecar] Failed to clean up ${tmpDir}: ${err instanceof Error ? err.message : String(err)}`);
     });
   }
 }
 
+// --- Python exec handler ---
+
+/**
+ * Python wrapper script injected into the sidecar.
+ *
+ * Security:
+ * - AST-based import guard runs before exec (sidecar-side enforcement)
+ * - User code runs in an isolated namespace (cannot see/modify wrapper vars)
+ * - Per-execution randomized result marker prevents stdout spoofing
+ *
+ * Handles data injection (JSON on stdin → DataFrame/dict), stdout capture,
+ * chart collection (PNG files + Recharts dicts), and structured output.
+ */
+const PYTHON_WRAPPER = `
+import sys, json, io, base64, glob, os, ast
+
+_marker = os.environ["ATLAS_RESULT_MARKER"]
+_chart_dir = os.environ.get("ATLAS_CHART_DIR", "/tmp")
+
+# --- Import guard (sidecar-side enforcement) ---
+_BLOCKED_MODULES = {
+    "subprocess", "os", "socket", "shutil", "sys", "ctypes", "importlib",
+    "code", "signal", "multiprocessing", "threading", "pty", "fcntl",
+    "termios", "resource", "posixpath",
+    "http", "urllib", "requests", "httpx", "aiohttp", "webbrowser",
+    "pickle", "tempfile", "pathlib",
+}
+_BLOCKED_BUILTINS = {
+    "compile", "exec", "eval", "__import__", "open", "breakpoint",
+    "getattr", "globals", "locals", "vars", "dir", "delattr", "setattr",
+}
+
+_user_code = open(sys.argv[1]).read()
+try:
+    _tree = ast.parse(_user_code)
+except SyntaxError as e:
+    print(_marker + json.dumps({"success": False, "error": f"SyntaxError: {e.msg} (line {e.lineno})"}))
+    sys.exit(0)
+
+_blocked = None
+for _node in ast.walk(_tree):
+    if _blocked:
+        break
+    if isinstance(_node, ast.Import):
+        for _alias in _node.names:
+            _mod = _alias.name.split('.')[0]
+            if _mod in _BLOCKED_MODULES:
+                _blocked = f'Blocked import: "{_mod}" is not allowed'
+                break
+    elif isinstance(_node, ast.ImportFrom):
+        if _node.module:
+            _mod = _node.module.split('.')[0]
+            if _mod in _BLOCKED_MODULES:
+                _blocked = f'Blocked import: "{_mod}" is not allowed'
+    elif isinstance(_node, ast.Call):
+        _name = None
+        if isinstance(_node.func, ast.Name):
+            _name = _node.func.id
+        elif isinstance(_node.func, ast.Attribute):
+            _name = _node.func.attr
+        if _name and _name in _BLOCKED_BUILTINS:
+            _blocked = f'Blocked builtin: "{_name}()" is not allowed'
+
+if _blocked:
+    print(_marker + json.dumps({"success": False, "error": _blocked}))
+    sys.exit(0)
+
+# --- Data injection ---
+_stdin_data = sys.stdin.read()
+_atlas_data = None
+if _stdin_data.strip():
+    _atlas_data = json.loads(_stdin_data)
+
+data = None
+df = None
+if _atlas_data:
+    try:
+        import pandas as pd
+        df = pd.DataFrame(_atlas_data["rows"], columns=_atlas_data["columns"])
+        data = df
+    except ImportError:
+        data = _atlas_data
+
+# Configure matplotlib for headless rendering
+try:
+    import matplotlib
+    matplotlib.use('Agg')
+except ImportError:
+    pass
+
+def chart_path(n=0):
+    return os.path.join(_chart_dir, f"chart_{n}.png")
+
+# --- Execute user code in isolated namespace ---
+_old_stdout = sys.stdout
+sys.stdout = _captured = io.StringIO()
+
+_user_ns = {"chart_path": chart_path, "data": data, "df": df}
+_atlas_error = None
+try:
+    exec(_user_code, _user_ns)
+except Exception as e:
+    _atlas_error = f"{type(e).__name__}: {e}"
+
+_output = _captured.getvalue()
+sys.stdout = _old_stdout
+
+# --- Collect results ---
+_charts = []
+for f in sorted(glob.glob(os.path.join(_chart_dir, "chart_*.png"))):
+    with open(f, "rb") as fh:
+        _charts.append({"base64": base64.b64encode(fh.read()).decode(), "mimeType": "image/png"})
+
+_result = {"success": _atlas_error is None}
+if _output.strip():
+    _result["output"] = _output.strip()
+if _atlas_error:
+    _result["error"] = _atlas_error
+
+if "_atlas_table" in _user_ns:
+    _result["table"] = _user_ns["_atlas_table"]
+
+if "_atlas_chart" in _user_ns:
+    _ac = _user_ns["_atlas_chart"]
+    if isinstance(_ac, dict):
+        _result["rechartsCharts"] = [_ac]
+    elif isinstance(_ac, list):
+        _result["rechartsCharts"] = _ac
+
+if _charts:
+    _result["charts"] = _charts
+
+print(_marker + json.dumps(_result), file=_old_stdout)
+`;
+
+async function handleExecPython(req: Request): Promise<Response> {
+  const authErr = checkAuth(req);
+  if (authErr) return authErr;
+
+  if (activeExecs >= MAX_CONCURRENT) {
+    return Response.json({ error: "Too many concurrent executions" }, { status: 429 });
+  }
+
+  let body: SidecarPythonRequest;
+  try {
+    body = (await req.json()) as SidecarPythonRequest;
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body.code || typeof body.code !== "string") {
+    return Response.json({ error: "Missing or invalid 'code' field" }, { status: 400 });
+  }
+
+  const timeout = clampTimeout(body.timeout, PYTHON_DEFAULT_TIMEOUT_MS, PYTHON_MAX_TIMEOUT_MS);
+
+  const execId = randomUUID();
+  const resultMarker = `__ATLAS_RESULT_${execId}__`;
+  const tmpDir = join("/tmp", `pyexec-${execId}`);
+  const codeFile = join(tmpDir, "user_code.py");
+  const wrapperFile = join(tmpDir, "wrapper.py");
+  const chartDir = join(tmpDir, "charts");
+
+  console.log(`[sandbox-sidecar] python=${execId} codeLen=${body.code.length} timeout=${timeout}`);
+
+  const startTime = Date.now();
+  activeExecs++;
+  try {
+    await mkdir(chartDir, { recursive: true });
+    writeFileSync(codeFile, body.code);
+    writeFileSync(wrapperFile, PYTHON_WRAPPER);
+
+    const stdinPayload = body.data ? JSON.stringify(body.data) : "";
+
+    const proc = Bun.spawn(["python3", wrapperFile, codeFile], {
+      cwd: tmpDir,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        PATH: "/bin:/usr/bin:/usr/local/bin",
+        HOME: tmpDir,
+        LANG: "C.UTF-8",
+        TMPDIR: tmpDir,
+        MPLBACKEND: "Agg",
+        ATLAS_CHART_DIR: chartDir,
+        ATLAS_RESULT_MARKER: resultMarker,
+      },
+    });
+
+    // SIGKILL — not catchable by Python
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      proc.kill(9);
+    }, timeout);
+
+    try {
+      proc.stdin.write(stdinPayload);
+      proc.stdin.end();
+    } catch (err) {
+      // EPIPE: python3 died before consuming stdin — will be caught by exit code
+      const detail = err instanceof Error ? err.message : String(err);
+      console.warn(`[sandbox-sidecar] python=${execId} stdin write error: ${detail}`);
+    }
+
+    let stdout: string;
+    let stderr: string;
+    let exitCode: number;
+    try {
+      [stdout, stderr] = await Promise.all([
+        readLimited(proc.stdout, MAX_OUTPUT_BYTES),
+        readLimited(proc.stderr, MAX_OUTPUT_BYTES),
+      ]);
+      exitCode = await proc.exited;
+    } finally {
+      clearTimeout(timer);
+    }
+
+    const duration = Date.now() - startTime;
+
+    if (timedOut) {
+      console.log(`[sandbox-sidecar] python=${execId} timed out after ${timeout}ms`);
+      const result: SidecarPythonResponse = {
+        success: false,
+        error: `Python execution timed out after ${timeout}ms`,
+      };
+      return Response.json(result);
+    }
+
+    // Extract structured result from the last marker line
+    const lines = stdout.split("\n");
+    const resultLine = lines.findLast((l) => l.startsWith(resultMarker));
+
+    if (resultLine) {
+      try {
+        const parsed = JSON.parse(resultLine.slice(resultMarker.length)) as SidecarPythonResponse;
+        console.log(`[sandbox-sidecar] python=${execId} success=${parsed.success} exitCode=${exitCode} duration=${duration}ms`);
+        return Response.json(parsed);
+      } catch {
+        console.warn(`[sandbox-sidecar] python=${execId} failed to parse result JSON, exitCode=${exitCode}`);
+        const result: SidecarPythonResponse = {
+          success: false,
+          error: `Python produced unparseable output. stderr: ${stderr.trim().slice(0, 500)}`,
+        };
+        return Response.json(result);
+      }
+    }
+
+    // No structured result — process errored before the wrapper could emit one
+    console.log(`[sandbox-sidecar] python=${execId} no result line, exitCode=${exitCode} stderr=${stderr.slice(0, 200)} duration=${duration}ms`);
+    const result: SidecarPythonResponse = {
+      success: false,
+      error: stderr.trim() || `Python execution failed (exit code ${exitCode})`,
+    };
+    return Response.json(result);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    console.error(`[sandbox-sidecar] python=${execId} error=${detail}`);
+    const result: SidecarPythonResponse = {
+      success: false,
+      error: `Execution failed: ${detail}`,
+    };
+    return Response.json(result, { status: 500 });
+  } finally {
+    activeExecs--;
+    rm(tmpDir, { recursive: true, force: true }).catch((err) => {
+      console.warn(`[sandbox-sidecar] Failed to clean up ${tmpDir}: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  }
+}
+
+// --- Health endpoint ---
+
 function handleHealth(): Response {
   try {
     const entries = readdirSync(SEMANTIC_DIR);
-    return Response.json({ status: "ok", semanticDir: SEMANTIC_DIR, fileCount: entries.length });
+
+    // Check python3 availability
+    let pythonAvailable = false;
+    try {
+      const proc = Bun.spawnSync(["python3", "--version"]);
+      pythonAvailable = proc.exitCode === 0;
+    } catch {
+      // python3 not found
+    }
+
+    return Response.json({
+      status: "ok",
+      semanticDir: SEMANTIC_DIR,
+      fileCount: entries.length,
+      pythonAvailable,
+    });
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
     return Response.json(
@@ -157,6 +459,8 @@ function handleHealth(): Response {
     );
   }
 }
+
+// --- Server ---
 
 Bun.serve({
   port: PORT,
@@ -169,6 +473,10 @@ Bun.serve({
 
     if (url.pathname === "/exec" && req.method === "POST") {
       return handleExec(req);
+    }
+
+    if (url.pathname === "/exec-python" && req.method === "POST") {
+      return handleExecPython(req);
     }
 
     return Response.json({ error: "Not found" }, { status: 404 });


### PR DESCRIPTION
## Summary

- **`executePython` AI SDK tool** (`packages/api/src/lib/tools/python.ts`) — accepts `{ code, explanation, data? }`, returns structured `PythonResult` with text output, table data, and/or base64 PNG charts
- **AST-based import guard** — shells out to `python3` with an `ast` module checker. Blocks 16 dangerous modules (`subprocess`, `os`, `socket`, `shutil`, `sys`, `ctypes`, `importlib`, `code`, `signal`, `multiprocessing`, `threading`, `pty`, `fcntl`, `termios`, `resource`, `posixpath`) and 6 dangerous builtins (`exec`, `eval`, `compile`, `__import__`, `open`, `breakpoint`). Hard reject before execution
- **Just-bash backend** — spawns `python3` with a wrapper script. Data payload injected via stdin JSON, available as `df` (pandas DataFrame) or `data` (raw dict). Charts detected from `/tmp/chart_*.png`. Structured output via tagged stdout line (`__ATLAS_RESULT__`)
- **Registry gating** — `ATLAS_PYTHON_ENABLED=true` env var enables the tool in `buildRegistry()`. Off by default. Static `defaultRegistry` unchanged

## Test plan

- [x] 36 unit tests passing (`bun test packages/api/src/lib/tools/__tests__/python.test.ts`)
  - Import guard: blocked modules (12), blocked builtins (6), allowed imports (8), syntax errors, complex patterns
  - Execution: simple print, runtime errors, data injection, `_atlas_table` return, empty output, multi-line, no-data fallback
- [x] Type-check passes (`bun run type`)
- [x] Existing registry tests still pass
- [ ] Manual: set `ATLAS_PYTHON_ENABLED=true`, run dev, verify tool appears in agent toolset

Closes #40