### PR TITLE
feat: agent prompt tuning for executePython

### DIFF
--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -151,8 +151,23 @@ function appendDialectHints(prompt: string): string {
   return prompt + "\n\n## Additional SQL Dialect Notes\n\n" + hints.map((h) => h.dialect).join("\n\n");
 }
 
+const PYTHON_GUIDANCE = `
+## SQL vs Python
+
+**Use SQL for:** filtering, aggregation, joins, window functions, GROUP BY, HAVING — anything the database handles natively.
+**Use Python for:** statistical analysis (correlations, regressions, hypothesis tests), complex reshaping (pivots, multi-index), time series decomposition, clustering, and advanced visualizations (heatmaps, scatter matrices, violin plots).
+
+**Anti-patterns to avoid:** SELECT * then aggregate in pandas, re-implementing GROUP BY or window functions in Python, using Python for simple counts/sums.
+
+**Chart guidance:** prefer \`_atlas_chart\` (interactive Recharts) for bar/line/pie charts. Use \`chart_path()\` only for advanced matplotlib visualizations that Recharts cannot render.`;
+
 function buildSystemPrompt(registry: ToolRegistry): string {
   let base = SYSTEM_PROMPT_PREFIX + "\n\n" + registry.describe() + "\n\n" + SYSTEM_PROMPT_SUFFIX;
+
+  // Add Python guidance only when the tool is available
+  if (registry.get("executePython")) {
+    base += "\n" + PYTHON_GUIDANCE;
+  }
 
   // Append the pre-indexed semantic layer summary
   const semanticIndex = getSemanticIndex();

--- a/packages/api/src/lib/tools/registry.ts
+++ b/packages/api/src/lib/tools/registry.ts
@@ -138,12 +138,19 @@ Use the executeSQL tool to query the database:
 
 const EXECUTE_PYTHON_DESCRIPTION = `### 4. Analyze Data with Python
 Use the executePython tool for analysis that SQL alone cannot handle:
-- Statistical analysis (correlations, regressions, distributions)
-- Data transformations (pivoting, reshaping, time series resampling)
-- Visualizations (charts saved to /tmp/chart_0.png, /tmp/chart_1.png, etc.)
-- Pass SQL results as the data parameter to avoid re-querying
-- Available libraries: pandas, numpy, matplotlib (if installed)
-- Do NOT use executePython for simple queries — use executeSQL instead`;
+- Statistical analysis (correlations, regressions, hypothesis tests)
+- Data transformations (pivoting, reshaping, time series decomposition)
+- Visualizations and advanced charts
+
+**Always run executeSQL first**, then pass results to executePython via the \`data\` parameter.
+
+**Output modes:**
+- \`_atlas_table\` — structured table results (columns + rows)
+- \`_atlas_chart\` — interactive Recharts chart (preferred for bar/line/pie)
+- \`chart_path(n)\` — matplotlib PNG (use for heatmaps, scatter matrices, violin plots)
+- \`print()\` — narrative text output
+
+Do NOT use executePython for simple aggregations, GROUP BY, or filtering — executeSQL handles those.`;
 
 // --- Default registry ---
 


### PR DESCRIPTION
## Summary

Closes #44

- Adds conditional `PYTHON_GUIDANCE` section to the agent system prompt (only included when `executePython` is in the tool registry)
- Teaches the agent SQL vs Python boundaries: SQL for filtering/aggregation/joins, Python for statistics/reshaping/advanced viz
- Documents anti-patterns to avoid (e.g., SELECT * then aggregate in pandas)
- Updates `EXECUTE_PYTHON_DESCRIPTION` with specific output mode docs (`_atlas_table`, `_atlas_chart`, `chart_path()`, `print()`)
- Adds chart guidance: prefer `_atlas_chart` (interactive Recharts) over `chart_path()` (static PNG) for standard chart types

## Test plan

- [x] `bun run test` — all tests pass (including agent cache, dialect, health, integration tests)
- [x] `bun run type` — clean
- [ ] Manual: enable `ATLAS_PYTHON_ENABLED=true` + sidecar, verify Python guidance appears in system prompt
- [ ] Manual: ask a question requiring statistical analysis, verify agent uses Python appropriately