### PR TITLE
docs: use fumadocs getText, add copy-as-markdown button

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -11,6 +11,7 @@
     "fumadocs-core": "^16.6.10",
     "fumadocs-mdx": "^14.2.9",
     "fumadocs-ui": "^16.6.10",
+    "lucide-react": "^0.577.0",
     "next": "^16.1.6",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -2,6 +2,11 @@ import { defineDocs, defineConfig } from "fumadocs-mdx/config";
 
 export const docs = defineDocs({
   dir: "content/docs",
+  docs: {
+    postprocess: {
+      includeProcessedMarkdown: true,
+    },
+  },
 });
 
 export default defineConfig();

--- a/apps/docs/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/[[...slug]]/page.tsx
@@ -7,6 +7,7 @@ import {
 } from "fumadocs-ui/page";
 import { notFound } from "next/navigation";
 import defaultMdxComponents from "fumadocs-ui/mdx";
+import { LLMCopyButton } from "@/components/llm-copy-button";
 
 export default async function Page(props: {
   params: Promise<{ slug?: string[] }>;
@@ -21,6 +22,9 @@ export default async function Page(props: {
     <DocsPage toc={page.data.toc}>
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
+      <div className="flex items-center gap-2 border-b pb-4">
+        <LLMCopyButton url={`${page.url}.mdx`} />
+      </div>
       <DocsBody>
         <MDX components={{ ...defaultMdxComponents }} />
       </DocsBody>

--- a/apps/docs/src/components/llm-copy-button.tsx
+++ b/apps/docs/src/components/llm-copy-button.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState } from "react";
+import { Copy, Check } from "lucide-react";
+
+export function LLMCopyButton({ url }: { url: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    const res = await fetch(url);
+    const text = await res.text();
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
+    >
+      {copied ? (
+        <>
+          <Check className="size-3.5" />
+          Copied
+        </>
+      ) : (
+        <>
+          <Copy className="size-3.5" />
+          Copy as Markdown
+        </>
+      )}
+    </button>
+  );
+}

--- a/apps/docs/src/lib/get-llm-text.ts
+++ b/apps/docs/src/lib/get-llm-text.ts
@@ -1,19 +1,10 @@
-import * as fs from "fs/promises";
 import { source } from "./source";
 import type { InferPageType } from "fumadocs-core/source";
 
 export async function getLLMText(
   page: InferPageType<typeof source>,
 ): Promise<string> {
-  const filePath = page.absolutePath;
-  if (!filePath) {
-    throw new Error(
-      `No absolutePath for "${page.data.title}" (${page.url})`,
-    );
-  }
+  const processed = await page.data.getText("processed");
 
-  const raw = await fs.readFile(filePath, "utf-8");
-  const content = raw.replace(/^---[\s\S]*?---\n*/, "");
-
-  return `# ${page.data.title} (${page.url})\n\n${content}`;
+  return `# ${page.data.title} (${page.url})\n\n${processed}`;
 }

--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
         "fumadocs-core": "^16.6.10",
         "fumadocs-mdx": "^14.2.9",
         "fumadocs-ui": "^16.6.10",
+        "lucide-react": "^0.577.0",
         "next": "^16.1.6",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -2481,7 +2482,7 @@
 
     "lru.min": ["lru.min@1.1.4", "", {}, "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA=="],
 
-    "lucide-react": ["lucide-react@0.576.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-koNxU14BXrxUfZQ9cUaP0ES1uyPZKYDjk31FQZB6dQ/x+tXk979sVAn9ppZ/pVeJJyOxVM8j1E+8QEuSc02Vug=="],
+    "lucide-react": ["lucide-react@0.577.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
@@ -3367,6 +3368,8 @@
 
     "@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
 
+    "@atlas/web/lucide-react": ["lucide-react@0.576.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-koNxU14BXrxUfZQ9cUaP0ES1uyPZKYDjk31FQZB6dQ/x+tXk979sVAn9ppZ/pVeJJyOxVM8j1E+8QEuSc02Vug=="],
+
     "@aws-crypto/sha1-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
@@ -3518,8 +3521,6 @@
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "figures/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
-
-    "fumadocs-ui/lucide-react": ["lucide-react@0.577.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A=="],
 
     "gaxios/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 


### PR DESCRIPTION
## Summary
- **Processed markdown**: Enable `includeProcessedMarkdown` in source config, replace manual `fs.readFile` + frontmatter regex with `page.data.getText('processed')` — the proper fumadocs API
- **Copy-as-markdown button**: Add `LLMCopyButton` component on each docs page so users/LLMs can copy page content as markdown
- **lucide-react**: Added for Copy/Check icons

## Test plan
- [x] `bun run type` clean
- [x] `bun run build` passes (76 static pages)
- [ ] Verify `/llms.txt` returns page index
- [ ] Verify `/llms-full.txt` returns full content
- [ ] Verify `/docs/getting-started/quick-start.mdx` returns processed markdown
- [ ] Verify "Copy as Markdown" button appears on each docs page and works