### PR TITLE
docs: add llms.txt nav links

### DIFF
--- a/apps/docs/src/app/docs/layout.tsx
+++ b/apps/docs/src/app/docs/layout.tsx
@@ -22,6 +22,14 @@ export default function Layout({ children }: { children: ReactNode }) {
           external: true,
         },
         {
+          text: "llms.txt",
+          url: "/llms.txt",
+        },
+        {
+          text: "llms-full.txt",
+          url: "/llms-full.txt",
+        },
+        {
           type: "icon" as const,
           text: "GitHub",
           url: "https://github.com/AtlasDevHQ/atlas",


### PR DESCRIPTION
## Summary
- Add llms.txt and llms-full.txt as navbar links in the docs site

## Test plan
- [ ] Verify links appear in navbar and navigate correctly