### PR TITLE
docs: enhanced code blocks + MDX components

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -17,6 +17,7 @@
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
+    "@shikijs/transformers": "^4.0.1",
     "@tailwindcss/postcss": "^4.2.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -1,4 +1,6 @@
 import { defineDocs, defineConfig } from "fumadocs-mdx/config";
+import { transformerMetaHighlight } from "@shikijs/transformers";
+import { rehypeCodeDefaultOptions } from "fumadocs-core/mdx-plugins";
 
 export const docs = defineDocs({
   dir: "content/docs",
@@ -9,4 +11,17 @@ export const docs = defineDocs({
   },
 });
 
-export default defineConfig();
+export default defineConfig({
+  mdxOptions: {
+    rehypeCodeOptions: {
+      themes: {
+        light: "github-light",
+        dark: "github-dark",
+      },
+      transformers: [
+        ...(rehypeCodeDefaultOptions.transformers ?? []),
+        transformerMetaHighlight(),
+      ],
+    },
+  },
+});

--- a/apps/docs/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/[[...slug]]/page.tsx
@@ -7,6 +7,9 @@ import {
 } from "fumadocs-ui/page";
 import { notFound } from "next/navigation";
 import defaultMdxComponents from "fumadocs-ui/mdx";
+import { Tab, Tabs } from "fumadocs-ui/components/tabs";
+import { Step, Steps } from "fumadocs-ui/components/steps";
+import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 import { LLMCopyButton } from "@/components/llm-copy-button";
 
 export default async function Page(props: {
@@ -26,7 +29,17 @@ export default async function Page(props: {
         <LLMCopyButton url={`${page.url}.mdx`} />
       </div>
       <DocsBody>
-        <MDX components={{ ...defaultMdxComponents }} />
+        <MDX
+          components={{
+            ...defaultMdxComponents,
+            Tab,
+            Tabs,
+            Step,
+            Steps,
+            Accordion,
+            Accordions,
+          }}
+        />
       </DocsBody>
     </DocsPage>
   );

--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,7 @@
         "react-dom": "^19.2.4",
       },
       "devDependencies": {
+        "@shikijs/transformers": "^4.0.1",
         "@tailwindcss/postcss": "^4.2.1",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",


### PR DESCRIPTION
Closes #85

## Summary

- Install `@shikijs/transformers` and configure `transformerMetaHighlight()` in `source.config.ts` for line highlighting (`{1,3-5}`) and file name meta (`title="filename.ts"`)
- Set explicit Shiki themes (`github-light` / `github-dark`) with default transformers preserved
- Register `Tab`, `Tabs`, `Step`, `Steps`, `Accordion`, `Accordions` from `fumadocs-ui` as MDX components

## Test plan

- [x] `bun run type` passes
- [x] `bun run build` passes — all 76 static pages generated
- [ ] Verify code blocks with `{1,3-5}` meta highlight the correct lines
- [ ] Verify code blocks with `title="file.ts"` show file name header
- [ ] Verify `<Tabs>`, `<Steps>`, `<Accordions>` render in MDX pages