### PR TITLE
fix: docs lastUpdate always undefined due to double .mdx extension

### DIFF
--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -18,6 +18,8 @@ export default defineConfig({
         light: "github-light",
         dark: "github-dark",
       },
+      // Preserve Fumadocs' built-in code transformers (copy button, etc.)
+      // before adding custom ones
       transformers: [
         ...(rehypeCodeDefaultOptions.transformers ?? []),
         transformerMetaHighlight(),

--- a/apps/docs/src/app/docs-og/[...slug]/route.tsx
+++ b/apps/docs/src/app/docs-og/[...slug]/route.tsx
@@ -7,7 +7,8 @@ export async function GET(
   { params }: { params: Promise<{ slug: string[] }> },
 ) {
   const { slug } = await params;
-  // Remove trailing "image.png" segment
+  // OG image URLs end with /image.png (e.g., /docs-og/guides/slack/image.png).
+  // Strip that trailing segment to recover the page slug for content lookup.
   const pageSlug = slug.slice(0, -1);
   const page = source.getPage(pageSlug);
   if (!page) notFound();

--- a/apps/docs/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/[[...slug]]/page.tsx
@@ -13,6 +13,12 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 import { LLMCopyButton } from "@/components/llm-copy-button";
 import { getGithubLastEdit } from "fumadocs-core/content/github";
 
+/**
+ * Fetch the last commit date for a docs page via the GitHub API.
+ * Returns undefined in development (to avoid rate limits) and on any
+ * API failure (graceful degradation — the UI simply hides the date).
+ * Results are cached for 24 hours (86400s) via Next.js fetch cache.
+ */
 async function getLastUpdate(path: string): Promise<Date | undefined> {
   if (process.env.NODE_ENV === "development") return undefined;
 
@@ -21,14 +27,20 @@ async function getLastUpdate(path: string): Promise<Date | undefined> {
       owner: "AtlasDevHQ",
       repo: "atlas",
       sha: "main",
-      path: `apps/docs/content/docs/${path}.mdx`,
+      // page.path already includes the .mdx extension (e.g., "guides/slack.mdx")
+      path: `apps/docs/content/docs/${path}`,
+      // getGithubLastEdit sets this as the raw Authorization header value
       token: process.env.GITHUB_TOKEN
         ? `Bearer ${process.env.GITHUB_TOKEN}`
         : undefined,
       options: { next: { revalidate: 86400 } },
     });
     return time ?? undefined;
-  } catch {
+  } catch (error) {
+    console.warn(
+      `[docs] Failed to fetch last edit time for "${path}":`,
+      error instanceof Error ? error.message : error,
+    );
     return undefined;
   }
 }

--- a/apps/docs/src/app/sitemap.ts
+++ b/apps/docs/src/app/sitemap.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from "next";
 import { source } from "@/lib/source";
 
+// Keep in sync with metadataBase in layout.tsx
 const baseUrl = "https://docs.useatlas.dev";
 
 export default function sitemap(): MetadataRoute.Sitemap {


### PR DESCRIPTION
## Summary

- **Fix double `.mdx` extension bug** — `page.path` already includes `.mdx` (e.g., `"guides/slack.mdx"`), but `getLastUpdate` appended it again (`${path}.mdx`), producing `"guides/slack.mdx.mdx"`. The GitHub API call always failed silently, so "last updated" timestamps never displayed on any page.
- **Add error logging to catch block** — The silent `catch { return undefined }` now logs `console.warn` with the file path and error message, making API failures (rate limiting, bad tokens, network errors) diagnosable.
- **Improve comments** — OG image slug convention, `Bearer` token format, transformer spread pattern, sitemap base URL sync note.

## Test plan

- [ ] Verify "last updated" timestamps appear on docs pages in production (they were silently broken before)
- [ ] Verify OG images still generate correctly
- [ ] Verify edit-on-GitHub links still work (already used `page.path` correctly)
- [ ] Check build logs for any `console.warn` from `getLastUpdate` (should be clean with valid token)