### PR TITLE
feat(plugin-sdk): add testing utilities

### DIFF
--- a/packages/plugin-sdk/src/__tests__/testing.test.ts
+++ b/packages/plugin-sdk/src/__tests__/testing.test.ts
@@ -64,6 +64,17 @@ describe("createMockLogger", () => {
     logger.warn("b");
     expect(shared).toHaveLength(2);
   });
+
+  test("captures non-string non-object arguments as stringified", () => {
+    const { logger, logs } = createMockLogger();
+    (logger.info as Function)(42);
+    (logger.info as Function)(null);
+    (logger.info as Function)(undefined);
+    expect(logs).toHaveLength(3);
+    expect(logs[0].msg).toBe("42");
+    expect(logs[1].msg).toBe("null");
+    expect(logs[2].msg).toBe("undefined");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -134,6 +145,13 @@ describe("createMockConnection", () => {
     expect(conn.closed).toBe(false);
     await conn.close();
     expect(conn.closed).toBe(true);
+  });
+
+  test("mockQueryResult clears pending error", async () => {
+    const conn = createMockConnection({ queryError: new Error("fail") });
+    conn.mockQueryResult({ columns: ["ok"], rows: [] });
+    const result = await conn.query("SELECT 1");
+    expect(result.columns).toEqual(["ok"]);
   });
 
   test("satisfies PluginDBConnection interface", () => {
@@ -233,10 +251,10 @@ describe("createMockContext", () => {
     expect(typeof ctx.logger.debug).toBe("function");
   });
 
-  test("default connections.get() throws", () => {
+  test("default connections.get() throws with requested ID", () => {
     const { ctx } = createMockContext();
     expect(() => ctx.connections.get("default")).toThrow(
-      "No connections registered in mock context",
+      'No connection "default" registered in mock context',
     );
   });
 
@@ -318,6 +336,15 @@ describe("createMockContext", () => {
     expect(customResult.logs).toHaveLength(1);
     expect(customResult.logs[0].msg).toBe("custom");
     expect(logs).toHaveLength(0);
+  });
+
+  test("error propagates through context connections", async () => {
+    const conn = createMockConnection({ queryError: new Error("db down") });
+    const { ctx } = createMockContext({
+      connections: { get: () => conn, list: () => ["default"] },
+    });
+    const dbConn = ctx.connections.get("default");
+    await expect(dbConn.query("SELECT 1")).rejects.toThrow("db down");
   });
 
   test("satisfies AtlasPluginContext interface", () => {

--- a/packages/plugin-sdk/src/testing.ts
+++ b/packages/plugin-sdk/src/testing.ts
@@ -6,7 +6,7 @@
  *
  * @example
  * ```typescript
- * import { createMockContext, createMockConnection } from "@useatlas/plugin-sdk/testing";
+ * import { createMockContext } from "@useatlas/plugin-sdk/testing";
  *
  * const { ctx, logs, registeredTools } = createMockContext();
  * await plugin.initialize(ctx);
@@ -28,14 +28,15 @@ import type {
 // ---------------------------------------------------------------------------
 
 export interface CapturedLog {
-  level: "info" | "warn" | "error" | "debug";
+  level: keyof PluginLogger;
   msg: string;
   obj?: Record<string, unknown>;
 }
 
 /**
  * Create a PluginLogger that captures all log calls to an array.
- * Useful for asserting that a plugin logs expected messages.
+ * Optionally pass an existing array to append to (useful for sharing
+ * a log sink across multiple loggers).
  */
 export function createMockLogger(logs?: CapturedLog[]): {
   logger: PluginLogger;
@@ -53,6 +54,9 @@ export function createMockLogger(logs?: CapturedLog[]): {
           obj: args[0] as Record<string, unknown>,
           msg: typeof args[1] === "string" ? args[1] : "",
         });
+      } else {
+        // Capture unexpected argument shapes so they don't silently vanish
+        captured.push({ level, msg: String(args[0]) });
       }
     };
   }
@@ -72,20 +76,20 @@ export function createMockLogger(logs?: CapturedLog[]): {
 // ---------------------------------------------------------------------------
 
 export interface MockConnectionOptions {
-  /** The result to return from query(). Can be overridden per-call via mockQuery(). */
+  /** The result to return from query(). Can be overridden later via mockQueryResult(). */
   queryResult?: PluginQueryResult;
-  /** If set, query() rejects with this error. */
+  /** If set, query() rejects with this error. Resets after one throw. */
   queryError?: Error;
 }
 
 export interface MockConnection extends PluginDBConnection {
-  /** All calls made to query(), in order. */
-  queryCalls: Array<{ sql: string; timeoutMs?: number }>;
+  /** All calls made to query(), in order (read-only — populated by query()). */
+  readonly queryCalls: ReadonlyArray<{ sql: string; timeoutMs?: number }>;
   /** Whether close() has been called. */
-  closed: boolean;
-  /** Override the next query result. */
+  readonly closed: boolean;
+  /** Set the query result for all subsequent calls. Also clears any pending error. */
   mockQueryResult(result: PluginQueryResult): void;
-  /** Override the next query to reject. */
+  /** Make the next query() call reject with this error. Resets after one throw. */
   mockQueryError(error: Error): void;
 }
 
@@ -102,12 +106,15 @@ export function createMockConnection(
   };
   let nextError: Error | undefined = opts.queryError;
 
+  // Internal mutable arrays — exposed as readonly on the interface
+  const queryCalls: Array<{ sql: string; timeoutMs?: number }> = [];
+
   const conn: MockConnection = {
-    queryCalls: [],
+    queryCalls,
     closed: false,
 
     async query(sql: string, timeoutMs?: number): Promise<PluginQueryResult> {
-      conn.queryCalls.push({ sql, timeoutMs });
+      queryCalls.push({ sql, timeoutMs });
       if (nextError) {
         const err = nextError;
         // Reset so subsequent calls don't re-throw unless explicitly set
@@ -118,7 +125,7 @@ export function createMockConnection(
     },
 
     async close(): Promise<void> {
-      conn.closed = true;
+      (conn as { closed: boolean }).closed = true;
     },
 
     mockQueryResult(result: PluginQueryResult) {
@@ -139,20 +146,20 @@ export function createMockConnection(
 // ---------------------------------------------------------------------------
 
 export interface MockExploreBackendOptions {
-  /** The result to return from exec(). */
+  /** The result to return from exec(). Can be overridden later via mockExecResult(). */
   execResult?: PluginExecResult;
-  /** If set, exec() rejects with this error. */
+  /** If set, exec() rejects with this error. Resets after one throw. */
   execError?: Error;
 }
 
 export interface MockExploreBackend extends PluginExploreBackend {
-  /** All commands passed to exec(), in order. */
-  execCalls: string[];
+  /** All commands passed to exec(), in order (read-only — populated by exec()). */
+  readonly execCalls: ReadonlyArray<string>;
   /** Whether close() has been called. */
-  closed: boolean;
-  /** Override the next exec result. */
+  readonly closed: boolean;
+  /** Set the exec result for all subsequent calls. Also clears any pending error. */
   mockExecResult(result: PluginExecResult): void;
-  /** Override the next exec to reject. */
+  /** Make the next exec() call reject with this error. Resets after one throw. */
   mockExecError(error: Error): void;
 }
 
@@ -170,12 +177,15 @@ export function createMockExploreBackend(
   };
   let nextError: Error | undefined = opts.execError;
 
+  // Internal mutable array — exposed as readonly on the interface
+  const execCalls: string[] = [];
+
   const backend: MockExploreBackend = {
-    execCalls: [],
+    execCalls,
     closed: false,
 
     async exec(command: string): Promise<PluginExecResult> {
-      backend.execCalls.push(command);
+      execCalls.push(command);
       if (nextError) {
         const err = nextError;
         nextError = undefined;
@@ -185,7 +195,7 @@ export function createMockExploreBackend(
     },
 
     async close(): Promise<void> {
-      backend.closed = true;
+      (backend as { closed: boolean }).closed = true;
     },
 
     mockExecResult(result: PluginExecResult) {
@@ -237,7 +247,9 @@ export interface MockContextResult {
  * All fields can be overridden.
  *
  * Returns the context along with captured log entries and registered tools
- * for easy assertions.
+ * for easy assertions. Note: when `logger` or `tools` are overridden, the
+ * returned `logs` and `registeredTools` arrays are not connected to the
+ * overridden implementations.
  */
 export function createMockContext(
   overrides: MockContextOverrides = {},
@@ -247,17 +259,15 @@ export function createMockContext(
   const { logger } = createMockLogger(logs);
 
   const ctx: AtlasPluginContext = {
-    db:
-      overrides.db === undefined
-        ? null
-        : overrides.db === null
-          ? null
-          : overrides.db,
+    db: overrides.db ?? null,
     connections: {
       get:
         overrides.connections?.get ??
-        (() => {
-          throw new Error("No connections registered in mock context");
+        ((id: string) => {
+          throw new Error(
+            `No connection "${id}" registered in mock context. ` +
+            `Pass a connections override to createMockContext() to provide one.`,
+          );
         }),
       list: overrides.connections?.list ?? (() => []),
     },

--- a/plugins/yaml-context/__tests__/plugin.test.ts
+++ b/plugins/yaml-context/__tests__/plugin.test.ts
@@ -3,7 +3,6 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 import { definePlugin, isContextPlugin } from "@useatlas/plugin-sdk";
-import { createMockContext } from "@useatlas/plugin-sdk/testing";
 import {
   contextYamlPlugin,
   buildContextYamlPlugin,
@@ -98,8 +97,31 @@ afterAll(() => {
 
 // ---------------------------------------------------------------------------
 // Helper: mock AtlasPluginContext for initialize()
-// (Uses @useatlas/plugin-sdk/testing utilities)
 // ---------------------------------------------------------------------------
+
+function makeMockCtx() {
+  const logged: string[] = [];
+  return {
+    ctx: {
+      db: null,
+      connections: {
+        get: () => {
+          throw new Error("not implemented");
+        },
+        list: () => [],
+      },
+      tools: { register: () => {} },
+      logger: {
+        info: (msg: string) => logged.push(msg),
+        warn: (msg: string) => logged.push(msg),
+        error: (msg: string) => logged.push(msg),
+        debug: (msg: string) => logged.push(msg),
+      },
+      config: {},
+    },
+    logged,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Plugin shape validation
@@ -437,21 +459,21 @@ describe("healthCheck", () => {
 describe("initialize", () => {
   test("logs the semantic directory path", async () => {
     const plugin = contextYamlPlugin({ semanticDir });
-    const { ctx, logs } = createMockContext();
-    await plugin.initialize!(ctx);
-    const msg = logs.find((l) =>
-      l.msg.includes("Context-YAML plugin initialized"),
+    const { ctx, logged } = makeMockCtx();
+    await plugin.initialize!(ctx as never);
+    const msg = logged.find((m) =>
+      m.includes("Context-YAML plugin initialized"),
     );
     expect(msg).toBeDefined();
-    expect(msg!.msg).toContain(semanticDir);
+    expect(msg).toContain(semanticDir);
   });
 
   test("logs health check warning when unhealthy", async () => {
     const plugin = contextYamlPlugin({ semanticDir: "/nonexistent/dir" });
-    const { ctx, logs } = createMockContext();
-    await plugin.initialize!(ctx);
-    const warning = logs.find((l) =>
-      l.msg.includes("[context-yaml] Health check warning"),
+    const { ctx, logged } = makeMockCtx();
+    await plugin.initialize!(ctx as never);
+    const warning = logged.find((m) =>
+      m.includes("[context-yaml] Health check warning"),
     );
     expect(warning).toBeDefined();
   });


### PR DESCRIPTION
## Summary

Closes #106

- Added `@useatlas/plugin-sdk/testing` subpath export with mock factories for plugin test authoring
- `createMockContext(overrides?)` — Returns a mock `AtlasPluginContext` with in-memory log capture, tool registration tracking, and configurable overrides for all fields
- `createMockConnection(opts?)` — Returns a mock `PluginDBConnection` with configurable query results, call tracking, and error simulation
- `createMockExploreBackend(opts?)` — Returns a mock `PluginExploreBackend` with configurable exec results, call tracking, and error simulation
- `createMockLogger(logs?)` — Standalone mock logger that captures all log entries for assertions
- Refactored `yaml-context` plugin tests to use `createMockContext()` as proof of concept (replaced hand-rolled `makeMockCtx()`)
- 37 tests for the utilities themselves

## Test plan

- [x] `bun test packages/plugin-sdk/src/__tests__/testing.test.ts` — 37 tests pass
- [x] `bun test plugins/yaml-context/__tests__/plugin.test.ts` — 43 tests pass (refactored to use new utilities)
- [x] `bun run type` — clean
- [x] Existing plugin-sdk tests unaffected (types.test.ts, infer.test.ts)