### PR TITLE
chore: health check audit fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,10 +219,13 @@ atlas/
 │           └── helpers.ts       # definePlugin() factory + type guards
 │
 ├── apps/
-│   └── www/                     # @atlas/www — Static landing page (useatlas.dev)
-│       ├── serve.ts             # Bun static file server (production runtime)
-│       ├── railway.json         # Railway NIXPACKS deploy config
-│       └── src/app/             # Next.js static export (output: "export")
+│   ├── www/                     # @atlas/www — Static landing page (useatlas.dev)
+│   │   ├── serve.ts             # Bun static file server (production runtime)
+│   │   ├── railway.json         # Railway NIXPACKS deploy config
+│   │   └── src/app/             # Next.js static export (output: "export")
+│   └── docs/                    # @atlas/docs — Documentation site (Fumadocs, docs.useatlas.dev)
+│       ├── source.config.ts     # Fumadocs source config with Orama search
+│       └── src/app/             # MDX pages, OG images, layout
 │
 ├── examples/
 │   ├── docker/                  # Self-hosted Docker deploy + optional nsjail
@@ -234,7 +237,7 @@ atlas/
 │       ├── vercel.json          # Vercel framework + build config
 │       └── src/app/api/         # Catch-all route → @atlas/api (Hono)
 │
-├── deploy/                      # Production deploy configs (Railway: api, web, www, sidecar)
+├── deploy/                      # Production deploy configs (Railway: api, web, www, docs, sidecar)
 ├── docs/                        # Guides (docs/guides/) and design ADRs (docs/design/)
 ├── e2e/                         # End-to-end test suite
 ├── plugins/                     # Atlas plugins directory
@@ -475,6 +478,7 @@ bun run db:reset  # Nukes volume, re-seeds from scratch
 
 Internal DB: `postgresql://atlas:atlas@localhost:5432/atlas`
 Analytics datasource: `postgresql://atlas:atlas@localhost:5432/atlas_demo`
+Sandbox sidecar: `http://localhost:8080` (Python execution isolation)
 
 Demo datasets:
 - **Simple** (`--demo`): 50 companies, ~200 people, 80 accounts — loaded from `data/demo.sql`

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -873,7 +873,10 @@ admin.post("/me/password", async (c) => {
   }
 
   return withRequestContext({ requestId, user: authResult.user }, async () => {
-    const body = await c.req.json().catch(() => null);
+    const body = await c.req.json().catch((err) => {
+      log.warn({ err: err instanceof Error ? err.message : String(err), requestId }, "Failed to parse JSON body in password change request");
+      return null;
+    });
     const currentPassword = body?.currentPassword;
     const newPassword = body?.newPassword;
 
@@ -1072,7 +1075,10 @@ admin.patch("/users/:id/role", async (c) => {
 
   return withRequestContext({ requestId, user: authResult.user }, async () => {
     const userId = c.req.param("id");
-    const body = await c.req.json().catch(() => null);
+    const body = await c.req.json().catch((err) => {
+      log.warn({ err: err instanceof Error ? err.message : String(err), requestId }, "Failed to parse JSON body in role change request");
+      return null;
+    });
     const newRole = body?.role;
 
     if (!isValidRole(newRole)) {
@@ -1142,7 +1148,10 @@ admin.post("/users/:id/ban", async (c) => {
       return c.json({ error: "forbidden", message: "Cannot ban yourself." }, 403);
     }
 
-    const body = await c.req.json().catch(() => ({}));
+    const body = await c.req.json().catch((err) => {
+      log.warn({ err: err instanceof Error ? err.message : String(err), requestId }, "Failed to parse JSON body in ban user request");
+      return {};
+    });
 
     try {
       await adminApi.banUser({

--- a/packages/api/src/lib/auth/middleware.ts
+++ b/packages/api/src/lib/auth/middleware.ts
@@ -156,6 +156,28 @@ export function _setValidatorOverrides(overrides: {
   _byotOverride = overrides.byot ?? null;
 }
 
+/**
+ * Categorize an auth error for diagnostic logging.
+ * Helps operators quickly identify whether a failure is a database issue,
+ * network problem, configuration error, or a programming bug.
+ */
+function categorizeAuthError(err: unknown): string {
+  if (err instanceof TypeError || err instanceof ReferenceError || err instanceof SyntaxError) {
+    return "programming-error";
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  if (/ECONNREFUSED|ENOTFOUND|ETIMEDOUT|ECONNRESET|fetch failed/i.test(msg)) {
+    return "network-error";
+  }
+  if (/relation.*does not exist|database|SQLITE|pg_|connect|pool/i.test(msg)) {
+    return "database-error";
+  }
+  if (/secret|config|env|missing|undefined|not set/i.test(msg)) {
+    return "config-error";
+  }
+  return "unknown";
+}
+
 /** Authenticate an incoming request based on the detected auth mode. */
 export async function authenticateRequest(req: Request): Promise<AuthResult> {
   const mode = detectAuthMode();
@@ -171,9 +193,11 @@ export async function authenticateRequest(req: Request): Promise<AuthResult> {
       try {
         return await (_managedOverride ?? validateManaged)(req);
       } catch (err) {
+        const category = categorizeAuthError(err);
         log.error(
-          { err: err instanceof Error ? err : new Error(String(err)), mode },
-          "Managed auth error",
+          { err: err instanceof Error ? err : new Error(String(err)), mode, category },
+          "Managed auth error (%s)",
+          category,
         );
         if (err instanceof TypeError || err instanceof ReferenceError || err instanceof SyntaxError) {
           log.error({ err, mode }, "BUG: Unexpected programming error in auth validator");
@@ -190,9 +214,11 @@ export async function authenticateRequest(req: Request): Promise<AuthResult> {
       try {
         return await (_byotOverride ?? validateBYOT)(req);
       } catch (err) {
+        const category = categorizeAuthError(err);
         log.error(
-          { err: err instanceof Error ? err : new Error(String(err)), mode },
-          "BYOT auth error",
+          { err: err instanceof Error ? err : new Error(String(err)), mode, category },
+          "BYOT auth error (%s)",
+          category,
         );
         if (err instanceof TypeError || err instanceof ReferenceError || err instanceof SyntaxError) {
           log.error({ err, mode }, "BUG: Unexpected programming error in auth validator");

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -379,6 +379,7 @@ async function tryLoadConfigFile(
         );
       }
       const raw = mod.default;
+      log.debug({ file: filePath }, "Config file loaded successfully");
       return raw;
     } catch (err) {
       // If the file exists but fails to parse/import, that is a hard error

--- a/packages/api/src/lib/semantic.ts
+++ b/packages/api/src/lib/semantic.ts
@@ -86,6 +86,8 @@ function loadEntitiesFromDir(
   for (const file of files) {
     try {
       const content = fs.readFileSync(path.join(dir, file), "utf-8");
+      // js-yaml v4+ yaml.load() uses DEFAULT_SCHEMA (JSON + core YAML types) which is
+      // safe — it does not instantiate arbitrary JS objects (unlike v3's yaml.load).
       const raw = yaml.load(content);
       const parsed = EntityShape.safeParse(raw);
       if (!parsed.success) {

--- a/packages/api/src/lib/startup.ts
+++ b/packages/api/src/lib/startup.ts
@@ -452,6 +452,14 @@ export async function validateEnvironment(): Promise<DiagnosticError[]> {
           "ATLAS_AUTH_ISSUER is required for BYOT auth mode. Set it to your identity provider's issuer URL (e.g. https://your-idp.com/).",
       });
     }
+
+    if (process.env.ATLAS_AUTH_AUDIENCE === "") {
+      const msg =
+        "ATLAS_AUTH_AUDIENCE is set to an empty string — audience validation will be skipped. " +
+        "Remove the variable entirely if audience checking is not needed, or set it to a valid audience value.";
+      if (!_startupWarnings.includes(msg)) _startupWarnings.push(msg);
+      log.warn(msg);
+    }
   }
 
   // Warn about orphaned auth env vars that suggest misconfiguration

--- a/packages/api/src/lib/tools/__tests__/explore-sidecar.test.ts
+++ b/packages/api/src/lib/tools/__tests__/explore-sidecar.test.ts
@@ -70,10 +70,12 @@ describe("sidecar exec", () => {
     expect(result.stderr).toBe("");
     expect(result.exitCode).toBe(0);
 
-    expect(fetchCalls).toHaveLength(1);
-    expect(fetchCalls[0].url).toBe("http://localhost:8080/exec");
+    // Filter out the health check call made during createSidecarBackend init
+    const execCalls = fetchCalls.filter((c) => c.url.endsWith("/exec"));
+    expect(execCalls).toHaveLength(1);
+    expect(execCalls[0].url).toBe("http://localhost:8080/exec");
 
-    const body = JSON.parse(fetchCalls[0].options.body as string);
+    const body = JSON.parse(execCalls[0].options.body as string);
     expect(body.command).toBe("ls");
     expect(body.timeout).toBe(10_000);
   });

--- a/packages/api/src/lib/tools/explore-sidecar.ts
+++ b/packages/api/src/lib/tools/explore-sidecar.ts
@@ -37,6 +37,31 @@ export async function createSidecarBackend(
   }
 
   const execUrl = new URL("/exec", baseUrl).toString();
+  const healthUrl = new URL("/health", baseUrl).toString();
+
+  // Lightweight health check on first creation — validates the sidecar is
+  // reachable before we return the backend. This catches misconfigured URLs
+  // and down services early (at backend init) rather than on the first user
+  // command, which produces a better error experience.
+  try {
+    const healthRes = await fetch(healthUrl, {
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!healthRes.ok) {
+      log.warn(
+        { status: healthRes.status, url: healthUrl },
+        "Sidecar health check returned non-OK status — commands may fail",
+      );
+    } else {
+      log.info({ url: baseUrl.origin }, "Sidecar health check passed");
+    }
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    log.warn(
+      { err: detail, url: healthUrl },
+      "Sidecar health check failed on init — sidecar may be starting up or unreachable",
+    );
+  }
 
   return {
     exec: async (command: string): Promise<ExecResult> => {

--- a/packages/api/src/lib/tools/explore.ts
+++ b/packages/api/src/lib/tools/explore.ts
@@ -275,10 +275,14 @@ function getExploreBackend(): Promise<ExploreBackend> {
       // Priority 5: just-bash (no process isolation)
       if (process.env.NODE_ENV === "production") {
         log.warn(
-          "Explore tool running without process isolation. " +
+          "SECURITY DEGRADATION: Explore tool running without process isolation (just-bash fallback). " +
+            "In production, this means shell commands execute directly on the host with only OverlayFs " +
+            "read-only protection — no namespace, network, or resource isolation. " +
             "Install nsjail, configure a sidecar (ATLAS_SANDBOX_URL), or deploy on Vercel for sandboxed execution. " +
             "See: https://github.com/google/nsjail",
         );
+      } else {
+        log.debug("Explore tool using just-bash backend (acceptable for development)");
       }
       return createBashBackend(SEMANTIC_ROOT);
     })().catch((err) => {

--- a/packages/api/src/lib/tools/python-sandbox.ts
+++ b/packages/api/src/lib/tools/python-sandbox.ts
@@ -276,7 +276,7 @@ export function createPythonSandboxBackend(): PythonBackend {
     } catch (err) {
       const detail = sandboxErrorDetail(err);
       log.error({ err: detail }, "Failed to set deny-all network policy");
-      try { await sandbox.stop(); } catch { /* best-effort cleanup */ }
+      try { await sandbox.stop(); } catch (stopErr) { log.warn({ err: stopErr instanceof Error ? stopErr.message : String(stopErr) }, "Failed to stop sandbox after network policy error"); }
       throw new Error(
         `Failed to lock down sandbox network: ${safeError(detail)}.`,
         { cause: err },
@@ -290,7 +290,9 @@ export function createPythonSandboxBackend(): PythonBackend {
     const old = sandboxPromise;
     sandboxPromise = null;
     if (old) {
-      old.then(instance => instance.sandbox.stop()).catch(() => {});
+      old.then(instance => instance.sandbox.stop()).catch((err) => {
+        log.warn({ err: err instanceof Error ? err.message : String(err) }, "Failed to stop old Python sandbox during cleanup");
+      });
     }
   }
 

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -53,7 +53,7 @@ function stripSqlComments(sql: string): string {
 
 const FORBIDDEN_PATTERNS = [
   /\b(INSERT|UPDATE|DELETE|DROP|CREATE|ALTER|TRUNCATE)\b/i,
-  /\b(GRANT|REVOKE|EXEC|EXECUTE|CALL)\b/i,
+  /\b(GRANT|REVOKE|EXEC|EXECUTE|CALL|KILL)\b/i,
   /\b(COPY|LOAD|VACUUM|REINDEX|OPTIMIZE)\b/i,
   /\bINTO\s+OUTFILE\b/i,
 ];
@@ -196,7 +196,8 @@ export function validateSQL(sql: string, connectionId?: string): { valid: boolea
           error: `Only SELECT statements are allowed, got: ${stmt.type}`,
         };
       }
-      // Collect CTE names so the table whitelist can ignore them
+      // CTE extraction: node-sql-parser doesn't expose .with in its type definitions,
+      // but the property exists at runtime for SELECT statements with CTEs.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       if (Array.isArray((stmt as any).with)) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -3,9 +3,9 @@
 # Used in Docker production builds where both processes run in one container.
 #
 # Platforms like Railway set PORT for external traffic routing.
-# Next.js inherits PORT (external-facing), while the API server gets a
-# fixed internal port (ATLAS_API_PORT, default 3001) that the Next.js
-# rewrite targets (ATLAS_API_URL defaults to http://localhost:3001).
+# Next.js inherits PORT (external-facing). The API server reads PORT
+# (set here from ATLAS_API_PORT, default 3001) as its listen port —
+# the Next.js rewrite targets this (ATLAS_API_URL defaults to http://localhost:3001).
 set -e
 
 cleanup() {


### PR DESCRIPTION
## Summary
- Security hardening: KILL in SQL regex, BYOT empty audience diagnostic, sidecar init health check, explore fallback warning
- Logging improvements: python-sandbox cleanup, admin JSON parse errors, auth error categorization, config load debug log
- Documentation: CLAUDE.md architecture updates (apps/docs/, sandbox sidecar, deploy/docs), start.sh comment clarification
- Code comments: CTE cast safety note, js-yaml v4 safety documentation

## Test plan
- [x] `bun run lint` — 0 warnings
- [x] `bun run type` — 0 errors
- [x] `bun run test` — 1,246 tests, 0 failures
- [x] Sidecar test updated to account for new init health check