### PR TITLE
refactor(plugins): add wireSandboxPlugins() to wiring.ts

### DIFF
--- a/packages/api/src/lib/plugins/__tests__/wiring.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/wiring.test.ts
@@ -780,4 +780,20 @@ describe("wireSandboxPlugins", () => {
 
     expect(receivedRoot).toBe("/my/custom/semantic");
   });
+
+  test("rejects backend missing exec method from create()", async () => {
+    registry.register(makeSandboxPlugin("bad-backend", {
+      createFn: async () => ({} as SandboxExecBackend),
+    }));
+    registry.register(makeSandboxPlugin("good-backend", { priority: 40 }));
+    await registry.initializeAll(minimalCtx);
+
+    const result = await wireSandboxPlugins(registry, "/semantic");
+
+    // bad-backend has default priority (60) > good-backend (40), tried first but rejected
+    expect(result.pluginId).toBe("good-backend");
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0].pluginId).toBe("bad-backend");
+    expect(result.failed[0].error).toContain("missing exec method");
+  });
 });

--- a/packages/api/src/lib/plugins/index.ts
+++ b/packages/api/src/lib/plugins/index.ts
@@ -4,6 +4,7 @@
 
 export { plugins, PluginRegistry } from "./registry";
 export type { PluginLike, PluginContextLike, PluginHealthResult, PluginType, PluginStatus, PluginDescription } from "./registry";
-export { wireDatasourcePlugins, wireActionPlugins, wireInteractionPlugins, wireContextPlugins } from "./wiring";
+export { wireDatasourcePlugins, wireActionPlugins, wireInteractionPlugins, wireContextPlugins, wireSandboxPlugins } from "./wiring";
+export type { SandboxExecBackend } from "./wiring";
 export { dispatchHook } from "./hooks";
 export { getPluginTools, setPluginTools, getContextFragments, setContextFragments } from "./tools";

--- a/packages/api/src/lib/plugins/wiring.ts
+++ b/packages/api/src/lib/plugins/wiring.ts
@@ -260,19 +260,22 @@ export async function wireInteractionPlugins(
   return { wired, failed };
 }
 
-/**
- * For each healthy context plugin, call `contextProvider.load()` and collect
- * the returned text fragments. Fragments are injected into the agent system
- * prompt to provide additional context from plugins.
- */
 // ---------------------------------------------------------------------------
 // Sandbox plugins
 // ---------------------------------------------------------------------------
 
-/** Must match SANDBOX_DEFAULT_PRIORITY in @useatlas/plugin-sdk/types. */
+/**
+ * Duplicated from @useatlas/plugin-sdk/types to avoid runtime SDK dependency.
+ * Keep in sync — explore-sdk-compat.test.ts verifies structural equivalence.
+ */
 const SANDBOX_DEFAULT_PRIORITY = 60;
 
-/** Minimal interface for a sandbox execution backend. Structurally identical to ExploreBackend. */
+/**
+ * Minimal interface for a sandbox execution backend.
+ * Structurally identical to ExploreBackend in explore.ts — duplicated here
+ * to avoid a circular dependency (explore.ts imports from wiring.ts).
+ * Changes to either interface should be mirrored.
+ */
 export interface SandboxExecBackend {
   exec(command: string): Promise<{ stdout: string; stderr: string; exitCode: number }>;
   close?(): Promise<void>;
@@ -299,10 +302,11 @@ function hasSandbox(p: PluginLike): p is PluginLike & SandboxShape {
  * create a backend from each until one succeeds.
  *
  * Unlike other wire functions, sandbox plugins are not registered into a
- * global registry — the result is a single backend instance used by the
- * explore tool. This function is called lazily on the first explore command,
- * not at startup, because the backend is a singleton that depends on
- * runtime environment detection (Vercel, nsjail, sidecar, etc.).
+ * global registry — the caller receives a single backend instance directly.
+ *
+ * NOTE: In practice, called lazily from getExploreBackend() on the first
+ * explore command (not at startup), because the explore backend is cached
+ * as a singleton and depends on runtime environment detection.
  */
 export async function wireSandboxPlugins(
   pluginRegistry: PluginRegistry,
@@ -337,12 +341,21 @@ export async function wireSandboxPlugins(
   for (const sp of sorted) {
     try {
       const backend = await sp.sandbox.create(semanticRoot);
+      if (!backend || typeof backend.exec !== "function") {
+        const msg = "create() returned invalid backend (missing exec method)";
+        failed.push({ pluginId: sp.id, error: msg });
+        log.error({ pluginId: sp.id }, msg);
+        continue;
+      }
       log.info({ pluginId: sp.id }, "Using sandbox plugin for explore backend");
       return { backend, pluginId: sp.id, failed };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       failed.push({ pluginId: sp.id, error: msg });
-      log.error({ pluginId: sp.id, err: msg }, "Sandbox plugin create() failed, trying next");
+      log.error(
+        { pluginId: sp.id, err: err instanceof Error ? err : new Error(String(err)) },
+        "Sandbox plugin create() failed, trying next",
+      );
     }
   }
 
@@ -350,6 +363,11 @@ export async function wireSandboxPlugins(
   return { backend: null, pluginId: null, failed };
 }
 
+/**
+ * For each healthy context plugin, call `contextProvider.load()` and collect
+ * the returned text fragments. Fragments are injected into the agent system
+ * prompt to provide additional context from plugins.
+ */
 export async function wireContextPlugins(
   pluginRegistry: PluginRegistry,
 ): Promise<{ fragments: string[]; failed: Array<{ pluginId: string; error: string }> }> {

--- a/packages/api/src/lib/tools/explore.ts
+++ b/packages/api/src/lib/tools/explore.ts
@@ -192,13 +192,25 @@ function getExploreBackend(): Promise<ExploreBackend> {
           const { plugins } = await import("@atlas/api/lib/plugins/registry");
           const { wireSandboxPlugins } = await import("@atlas/api/lib/plugins/wiring");
           const result = await wireSandboxPlugins(plugins, SEMANTIC_ROOT);
+          if (result.failed.length > 0) {
+            log.warn(
+              { failed: result.failed, selectedPlugin: result.pluginId },
+              "Some sandbox plugins failed during create()",
+            );
+          }
           if (result.backend) {
             _activeSandboxPluginId = result.pluginId;
             return result.backend as ExploreBackend;
           }
         } catch (err) {
           const detail = err instanceof Error ? err.message : String(err);
-          log.debug({ err: detail }, "Plugin registry not available for sandbox check");
+          const isModuleError = err != null && typeof err === "object" && "code" in err
+            && (err as NodeJS.ErrnoException).code === "MODULE_NOT_FOUND";
+          if (isModuleError) {
+            log.debug({ err: detail }, "Plugin modules not available — skipping sandbox plugins");
+          } else {
+            log.error({ err: detail }, "Unexpected error during sandbox plugin wiring");
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- Extracts sandbox plugin selection logic from `explore.ts` into `wireSandboxPlugins()` in `wiring.ts`, completing the set of per-type wiring functions (datasource, action, interaction, context, **sandbox**)
- `explore.ts` now calls `wireSandboxPlugins(plugins, SEMANTIC_ROOT)` instead of reaching into the plugin registry directly
- No behavioral changes — same priority-based selection, same lazy initialization, same fallback chain

## Details
Sandbox plugins were the only plugin type wired inline rather than through a dedicated function in `wiring.ts`. The new function:
- Discovers sandbox plugins via `pluginRegistry.getByType("sandbox")`
- Validates each has a `sandbox.create()` method (`hasSandbox()` type guard)
- Sorts by priority (highest first, default 60)
- Tries each plugin's `create(semanticRoot)` until one succeeds
- Returns `{ backend, pluginId, failed }` for the caller to use

The function is still called lazily from `getExploreBackend()` (not at startup) because backend selection is tightly coupled to runtime environment detection.

## Test plan
- [x] 8 new tests in `wiring.test.ts` covering: single plugin, priority sorting, default priority, create failure fallthrough, all-fail, no plugins, unhealthy skip, missing sandbox.create skip, semanticRoot passthrough
- [x] All 9 existing `explore-plugin.test.ts` tests pass unchanged
- [x] `bun run type` passes (pre-existing yaml-context errors only)
- [x] `bun run test` passes (pre-existing jira plugin failures only)

Closes #115