### PR TITLE
feat: encrypt connection URLs at rest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -428,7 +428,8 @@ export default defineConfig({
 | `ATLAS_ADMIN_EMAIL` | — | First managed-auth admin email. If set, this user gets `admin` role on signup and on migration. If unset, the first user to sign up gets admin automatically |
 | `ATLAS_API_KEY` | — | Simple API key auth — requires `Authorization: Bearer <key>` |
 | `ATLAS_API_KEY_ROLE` | `analyst` | Role for simple-key auth mode (viewer/analyst/admin) |
-| `BETTER_AUTH_SECRET` | — | Managed auth (Better Auth) — min 32 chars |
+| `ATLAS_ENCRYPTION_KEY` | — | AES-256-GCM key for encrypting connection URLs at rest. Falls back to `BETTER_AUTH_SECRET` if unset. Any length (SHA-256 derived) |
+| `BETTER_AUTH_SECRET` | — | Managed auth (Better Auth) — min 32 chars. Also used as fallback encryption key for connection URLs |
 | `BETTER_AUTH_URL` | auto-detect | Base URL for Better Auth |
 | `BETTER_AUTH_TRUSTED_ORIGINS` | — | Comma-separated CSRF-allowed origins |
 | `ATLAS_AUTH_JWKS_URL` | — | BYOT mode — JWKS endpoint URL for JWT verification |

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -186,8 +186,14 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getInternalDB: mock(() => ({})),
   closeInternalDB: mock(async () => {}),
   migrateInternalDB: mock(async () => {}),
+  loadSavedConnections: mock(async () => 0),
   _resetPool: mock(() => {}),
   _resetCircuitBreaker: mock(() => {}),
+  encryptUrl: (url: string) => url,
+  decryptUrl: (url: string) => url,
+  getEncryptionKey: () => null,
+  isPlaintextUrl: (value: string) => /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(value),
+  _resetEncryptionKeyCache: mock(() => {}),
 }));
 
 const mockPluginHealthCheck: Mock<() => Promise<unknown>> = mock(() =>

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -3,7 +3,7 @@
  *
  * Mounted at /api/v1/admin. All routes require admin role.
  * Browsing endpoints are read-only; health-check routes (POST) trigger
- * live probes and update cached health status.
+ * live probes. Connection CRUD routes persist encrypted URLs via encryptUrl/decryptUrl.
  */
 
 import * as fs from "fs";
@@ -748,11 +748,20 @@ admin.post("/connections", async (c) => {
       }, 400);
     }
 
-    // Persist to internal DB
+    // Encrypt and persist to internal DB
+    let encryptedUrl: string;
+    try {
+      encryptedUrl = encryptUrl(url as string);
+    } catch (err) {
+      connections.unregister(id as string);
+      log.error({ err: err instanceof Error ? err.message : String(err), connectionId: id }, "Failed to encrypt connection URL");
+      return c.json({ error: "encryption_failed", message: "Failed to encrypt connection URL. Check ATLAS_ENCRYPTION_KEY or BETTER_AUTH_SECRET." }, 500);
+    }
+
     try {
       await internalQuery(
         `INSERT INTO connections (id, url, type, description, schema_name) VALUES ($1, $2, $3, $4, $5)`,
-        [id, encryptUrl(url as string), dbType, typeof description === "string" ? description : null, typeof schema === "string" ? schema : null],
+        [id, encryptedUrl, dbType, typeof description === "string" ? description : null, typeof schema === "string" ? schema : null],
       );
     } catch (err) {
       connections.unregister(id as string);
@@ -879,11 +888,29 @@ admin.put("/connections/:id", async (c) => {
       }
     }
 
-    // Update in DB — rollback registry on failure
+    // Encrypt and update in DB — rollback registry on failure
+    let encryptedNewUrl: string;
+    try {
+      encryptedNewUrl = encryptUrl(newUrl);
+    } catch (err) {
+      // Restore previous connection in registry
+      try {
+        connections.register(id, {
+          url: currentUrl,
+          description: current.description ?? undefined,
+          schema: current.schema_name ?? undefined,
+        });
+      } catch {
+        connections.unregister(id);
+      }
+      log.error({ err: err instanceof Error ? err.message : String(err), connectionId: id }, "Failed to encrypt connection URL");
+      return c.json({ error: "encryption_failed", message: "Failed to encrypt connection URL. Check ATLAS_ENCRYPTION_KEY or BETTER_AUTH_SECRET." }, 500);
+    }
+
     try {
       await internalQuery(
         `UPDATE connections SET url = $1, type = $2, description = $3, schema_name = $4, updated_at = NOW() WHERE id = $5`,
-        [encryptUrl(newUrl), dbType, newDescription, newSchema, id],
+        [encryptedNewUrl, dbType, newDescription, newSchema, id],
       );
     } catch (err) {
       // Restore old connection in registry to stay in sync with DB
@@ -893,7 +920,8 @@ admin.put("/connections/:id", async (c) => {
           description: current.description ?? undefined,
           schema: current.schema_name ?? undefined,
         });
-      } catch {
+      } catch (restoreErr) {
+        log.error({ connectionId: id, err: restoreErr instanceof Error ? restoreErr.message : String(restoreErr) }, "Failed to restore previous connection after DB update failure — connection unregistered");
         connections.unregister(id);
       }
       log.error({ err: err instanceof Error ? err : new Error(String(err)), connectionId: id }, "Failed to update connection in DB");
@@ -1007,9 +1035,14 @@ admin.get("/connections/:id", async (c) => {
           [id],
         );
         if (rows.length > 0) {
-          maskedUrl = maskConnectionUrl(decryptUrl(rows[0].url));
-          schema = rows[0].schema_name;
           managed = true;
+          schema = rows[0].schema_name;
+          try {
+            maskedUrl = maskConnectionUrl(decryptUrl(rows[0].url));
+          } catch (decryptErr) {
+            log.error({ connectionId: id, err: decryptErr instanceof Error ? decryptErr.message : String(decryptErr) }, "Failed to decrypt stored connection URL");
+            maskedUrl = "[encrypted — decryption failed]";
+          }
         }
       } catch (err) {
         log.warn({ err: err instanceof Error ? err.message : String(err), connectionId: id }, "Failed to fetch connection details from internal DB");

--- a/packages/api/src/lib/db/__tests__/internal.test.ts
+++ b/packages/api/src/lib/db/__tests__/internal.test.ts
@@ -548,6 +548,13 @@ describe("connection URL encryption", () => {
       expect(decryptUrl(encrypted)).toBe(url);
     });
 
+    it("handles URLs with special characters in password", () => {
+      process.env.ATLAS_ENCRYPTION_KEY = "test-key-for-round-trip-testing!";
+      const url = "postgresql://user:p%40ss+word/with=equals@host:5432/db?sslmode=require&options=-c%20search_path%3Dpublic";
+      const encrypted = encryptUrl(url);
+      expect(decryptUrl(encrypted)).toBe(url);
+    });
+
     it("produces different ciphertexts for the same input (random IV)", () => {
       process.env.ATLAS_ENCRYPTION_KEY = "test-key-for-round-trip-testing!";
       const url = "postgresql://user:pass@host/db";
@@ -588,18 +595,17 @@ describe("connection URL encryption", () => {
       expect(decryptUrl(url)).toBe(url);
     });
 
-    it("decryptUrl returns encrypted data as-is with warning when no key", () => {
+    it("decryptUrl throws when encountering encrypted data without a key", () => {
       // Encrypt with a key first
       process.env.ATLAS_ENCRYPTION_KEY = "temp-key-for-this-test!!!!!!!!!!!";
       const url = "postgresql://user:pass@host/db";
       const encrypted = encryptUrl(url);
 
-      // Now remove the key — decryptUrl should return the encrypted string as-is
+      // Now remove the key — decryptUrl should throw, not return garbage
       delete process.env.ATLAS_ENCRYPTION_KEY;
       delete process.env.BETTER_AUTH_SECRET;
-      // The encrypted value doesn't look like a URL, so it will try to decrypt
-      // but has no key — should log a warning and return as-is
-      expect(decryptUrl(encrypted)).toBe(encrypted);
+      _resetEncryptionKeyCache();
+      expect(() => decryptUrl(encrypted)).toThrow("Cannot decrypt connection URL: no encryption key available");
     });
   });
 
@@ -628,6 +634,23 @@ describe("connection URL encryption", () => {
       process.env.ATLAS_ENCRYPTION_KEY = "test-key-for-corruption-testing!";
       // 3 colon-separated parts but not valid encrypted data
       expect(() => decryptUrl("foo:bar:baz")).toThrow("Failed to decrypt connection URL");
+    });
+
+    it("throws on tampered auth tag", () => {
+      process.env.ATLAS_ENCRYPTION_KEY = "test-key-for-corruption-testing!";
+      const url = "postgresql://user:pass@host/db";
+      const encrypted = encryptUrl(url);
+      const parts = encrypted.split(":");
+      // Tamper with the auth tag (part[1])
+      parts[1] = "AAAA" + parts[1].slice(4);
+      const tampered = parts.join(":");
+      expect(() => decryptUrl(tampered)).toThrow("Failed to decrypt connection URL");
+    });
+
+    it("throws on non-3-part format when value is not a URL", () => {
+      process.env.ATLAS_ENCRYPTION_KEY = "test-key-for-corruption-testing!";
+      // 2 parts — not a URL, not 3-part encrypted format
+      expect(() => decryptUrl("some:garbage")).toThrow("unrecognized format");
     });
   });
 
@@ -664,6 +687,37 @@ describe("connection URL encryption", () => {
       const count = await loadSavedConnections();
       expect(count).toBe(1);
       expect(connections.has("warehouse")).toBe(true);
+    });
+
+    it("skips connections with undecryptable URLs without blocking others", async () => {
+      process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/atlas";
+      process.env.ATLAS_ENCRYPTION_KEY = "test-key-for-load-connections!!!";
+
+      const goodUrl = "postgresql://admin:secret@warehouse.example.com:5432/wh";
+      const goodEncrypted = encryptUrl(goodUrl);
+
+      // Encrypted with a different key — will fail to decrypt
+      process.env.ATLAS_ENCRYPTION_KEY = "different-key-that-wont-work!!!!";
+      _resetEncryptionKeyCache();
+      const badEncrypted = encryptUrl("postgresql://host/bad");
+
+      // Restore the original key
+      process.env.ATLAS_ENCRYPTION_KEY = "test-key-for-load-connections!!!";
+      _resetEncryptionKeyCache();
+
+      const { pool } = createMockPool();
+      pool._setResult({
+        rows: [
+          { id: "good-conn", url: goodEncrypted, type: "postgres", description: null, schema_name: null },
+          { id: "bad-conn", url: badEncrypted, type: "postgres", description: null, schema_name: null },
+        ],
+      });
+      _resetPool(pool);
+
+      const count = await loadSavedConnections();
+      expect(count).toBe(1);
+      expect(connections.has("good-conn")).toBe(true);
+      expect(connections.has("bad-conn")).toBe(false);
     });
 
     it("handles plaintext URLs (migration path) during load", async () => {

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -22,9 +22,9 @@ const AUTH_TAG_LENGTH = 16;
 let _cachedKey: { raw: string; key: Buffer } | null = null;
 
 /**
- * Returns the 32-byte encryption key derived from ATLAS_ENCRYPTION_KEY
- * (takes precedence) or BETTER_AUTH_SECRET. Returns null if neither is set.
- * Result is cached to avoid re-deriving on every call.
+ * Returns the 32-byte encryption key derived via SHA-256 from
+ * ATLAS_ENCRYPTION_KEY (takes precedence) or BETTER_AUTH_SECRET.
+ * Returns null if neither is set. Result is cached.
  */
 export function getEncryptionKey(): Buffer | null {
   const raw = process.env.ATLAS_ENCRYPTION_KEY ?? process.env.BETTER_AUTH_SECRET;
@@ -71,12 +71,15 @@ export function decryptUrl(stored: string): string {
 
   const key = getEncryptionKey();
   if (!key) {
-    log.warn("Encrypted connection URL found but no encryption key is available — returning as-is");
-    return stored;
+    log.error("Encrypted connection URL found but no encryption key is available — set ATLAS_ENCRYPTION_KEY or BETTER_AUTH_SECRET");
+    throw new Error("Cannot decrypt connection URL: no encryption key available");
   }
 
   const parts = stored.split(":");
-  if (parts.length !== 3) return stored; // Not in our format — treat as plaintext
+  if (parts.length !== 3) {
+    log.error({ partCount: parts.length }, "Stored connection URL is not plaintext and does not match encrypted format (expected 3 colon-separated parts)");
+    throw new Error("Failed to decrypt connection URL: unrecognized format");
+  }
 
   try {
     const iv = Buffer.from(parts[0], "base64");
@@ -96,7 +99,7 @@ export function decryptUrl(stored: string): string {
   }
 }
 
-/** Returns true if the stored value looks like a plaintext URL (not encrypted). */
+/** Returns true if the stored value looks like a plaintext URL (any URI scheme, not just database schemes). */
 export function isPlaintextUrl(value: string): boolean {
   return /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(value);
 }
@@ -230,7 +233,7 @@ export function _resetCircuitBreaker(): void {
   _droppedCount = 0;
 }
 
-/** Idempotent migration: creates audit_log, conversations, and messages tables. */
+/** Idempotent migration: creates all Atlas internal tables and indexes. */
 export async function migrateInternalDB(): Promise<void> {
   const pool = getInternalDB();
   await pool.query(`
@@ -365,7 +368,7 @@ export async function migrateInternalDB(): Promise<void> {
   await pool.query(`CREATE INDEX IF NOT EXISTS idx_scheduled_task_runs_task ON scheduled_task_runs(task_id);`);
   await pool.query(`CREATE INDEX IF NOT EXISTS idx_scheduled_task_runs_status ON scheduled_task_runs(status);`);
 
-  // Admin-managed connections
+  // Admin-managed connections (url column stores AES-256-GCM encrypted ciphertext; see encryptUrl/decryptUrl)
   await pool.query(`
     CREATE TABLE IF NOT EXISTS connections (
       id TEXT PRIMARY KEY,

--- a/packages/api/src/lib/startup.ts
+++ b/packages/api/src/lib/startup.ts
@@ -483,7 +483,7 @@ export async function validateEnvironment(): Promise<DiagnosticError[]> {
     log.warn(msg);
   }
 
-  // 6.5. Connection encryption key check
+  // 6.5. Connection encryption key check — only relevant when internal DB stores connection URLs
   if (process.env.DATABASE_URL && !process.env.ATLAS_ENCRYPTION_KEY && !process.env.BETTER_AUTH_SECRET) {
     const msg =
       "No encryption key available for connection URLs. Set ATLAS_ENCRYPTION_KEY or BETTER_AUTH_SECRET " +


### PR DESCRIPTION
## Summary

- Connection URLs in the `connections` table are now encrypted at rest using **AES-256-GCM**
- Encryption key derived from `ATLAS_ENCRYPTION_KEY` (takes precedence) or `BETTER_AUTH_SECRET` via SHA-256
- Stored as `iv:authTag:ciphertext` (all base64) in the existing `url` TEXT column — no schema migration needed
- Existing plaintext URLs detected automatically on read (URL scheme prefix) and passed through; re-encrypted on next write
- If no encryption key is available, a startup warning is logged but functionality continues with plaintext storage

### Changes

| File | What |
|------|------|
| `packages/api/src/lib/db/internal.ts` | `encryptUrl()`, `decryptUrl()`, `getEncryptionKey()`, `isPlaintextUrl()` helpers; decrypt in `loadSavedConnections()` |
| `packages/api/src/api/routes/admin.ts` | Encrypt on POST/PUT writes; decrypt on GET reads before masking |
| `packages/api/src/lib/startup.ts` | Startup warning when no encryption key is available |
| `packages/api/src/lib/db/__tests__/internal.test.ts` | 22 new tests covering round-trip, plaintext migration, missing key fallback, corrupted data, wrong key |

Closes #157

## Test plan

- [x] Round-trip encrypt/decrypt for PostgreSQL and MySQL URLs
- [x] Random IV produces different ciphertexts for same input
- [x] Plaintext URLs (postgresql://, mysql://) pass through decryptUrl unchanged
- [x] No encryption key → encryptUrl returns plaintext, decryptUrl returns plaintext URLs as-is
- [x] Tampered ciphertext throws descriptive error
- [x] Wrong encryption key throws descriptive error
- [x] loadSavedConnections decrypts encrypted URLs
- [x] loadSavedConnections handles legacy plaintext URLs (migration path)
- [x] ATLAS_ENCRYPTION_KEY takes precedence over BETTER_AUTH_SECRET
- [x] TypeScript type check passes
- [x] All 47 tests pass (25 existing + 22 new)