### PR TITLE
feat(web): add area, stacked bar, and scatter chart types

### DIFF
--- a/packages/web/src/ui/__tests__/chart-detection.test.ts
+++ b/packages/web/src/ui/__tests__/chart-detection.test.ts
@@ -240,6 +240,36 @@ describe("detectCharts", () => {
     expect(scatterRec.reason).toContain("size: bmi");
   });
 
+  test("line is primary recommendation over area for time-series data", () => {
+    const headers = ["date", "revenue"];
+    const rows = Array.from({ length: 12 }, (_, i) => [
+      `2024-${String(i + 1).padStart(2, "0")}-01`,
+      String(1000 + i * 100),
+    ]);
+    const result = detectCharts(headers, rows);
+    expect(result.chartable).toBe(true);
+    if (!result.chartable) return;
+    expect(result.recommendations[0].type).toBe("line");
+    const areaIdx = result.recommendations.findIndex((r) => r.type === "area");
+    expect(areaIdx).toBeGreaterThan(0);
+  });
+
+  test("fallback bar not added when categorical bar already exists", () => {
+    const headers = ["region", "revenue", "cost"];
+    const rows = [
+      ["East", "500", "200"],
+      ["West", "600", "250"],
+      ["North", "400", "180"],
+    ];
+    const result = detectCharts(headers, rows);
+    expect(result.chartable).toBe(true);
+    if (!result.chartable) return;
+    const barRecs = result.recommendations.filter((r) => r.type === "bar");
+    // Only one bar — categorical bar, no fallback duplicate
+    expect(barRecs).toHaveLength(1);
+    expect(barRecs[0].reason).toContain("Comparison");
+  });
+
   test("scatter: 2 numeric columns, no size encoding", () => {
     const headers = ["x", "y"];
     const rows = [
@@ -464,6 +494,29 @@ describe("transformData", () => {
     expect(data[0].weight).toBe(70);
     expect(data[0].height).toBe(175);
     expect(typeof data[0].weight).toBe("number");
+  });
+
+  test("scatter chart filters out non-numeric rows", () => {
+    const xCol: ClassifiedColumn = { index: 0, header: "weight", type: "numeric", uniqueCount: 4 };
+    const yCol: ClassifiedColumn = { index: 1, header: "height", type: "numeric", uniqueCount: 4 };
+    const recommendation: ChartRecommendation = {
+      type: "scatter",
+      categoryColumn: xCol,
+      valueColumns: [yCol],
+      reason: "test",
+    };
+
+    const rows = [
+      ["70", "175"],
+      ["N/A", "180"],
+      ["60", "unknown"],
+      ["90", "185"],
+    ];
+
+    const data = transformData(rows, recommendation);
+    expect(data).toHaveLength(2);
+    expect(data[0].weight).toBe(70);
+    expect(data[1].weight).toBe(90);
   });
 
   test("stacked-bar chart caps rows like bar", () => {

--- a/packages/web/src/ui/components/chart/chart-detection.ts
+++ b/packages/web/src/ui/components/chart/chart-detection.ts
@@ -262,6 +262,12 @@ function parseNumericValue(raw: string): number {
   return isFinite(num) ? num : 0;
 }
 
+function isFiniteNumeric(raw: string): boolean {
+  const cleaned = raw.replace(/[$%,\s]/g, "");
+  if (cleaned === "" || cleaned === "-") return false;
+  return isFinite(Number(cleaned));
+}
+
 export function transformData(
   rows: string[][],
   recommendation: ChartRecommendation,
@@ -271,14 +277,19 @@ export function transformData(
   const valIdxs = recommendation.valueColumns.map((c) => c.index);
 
   // Scatter: both axes are numeric — categoryColumn is x, first valueColumn is y, optional z for size
+  // Filter out rows where x or y are non-numeric to avoid misleading zero-origin clusters
   if (recommendation.type === "scatter") {
-    return rows.map((row) => {
+    const yIdx = recommendation.valueColumns[0].index;
+    return rows.flatMap((row) => {
+      const rawX = row[catIdx] ?? "";
+      const rawY = row[yIdx] ?? "";
+      if (!isFiniteNumeric(rawX) || !isFiniteNumeric(rawY)) return [];
       const record: RechartsRow = {};
-      record[catHeader] = parseNumericValue(row[catIdx] ?? "0");
+      record[catHeader] = parseNumericValue(rawX);
       for (const vc of recommendation.valueColumns) {
         record[vc.header] = parseNumericValue(row[vc.index] ?? "0");
       }
-      return record;
+      return [record];
     });
   }
 

--- a/packages/web/src/ui/components/chart/result-chart.tsx
+++ b/packages/web/src/ui/components/chart/result-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Component, type ReactNode, type ErrorInfo, useMemo, useState } from "react";
+import { Component, type ReactNode, type ErrorInfo, useMemo, useId, useState } from "react";
 import {
   ResponsiveContainer,
   BarChart,
@@ -134,7 +134,7 @@ function ChartTooltip({ active, payload, label, dark }: {
   if (!active || !payload?.length) return null;
   return (
     <div style={getTooltipStyle(dark)}>
-      <p style={TOOLTIP_LABEL_STYLE}>{label}</p>
+      {label && <p style={TOOLTIP_LABEL_STYLE}>{label}</p>}
       {payload.map((entry, i) => (
         <p key={i} style={{ color: entry.color }}>
           {entry.name}: {typeof entry.value === "number" ? formatNumber(entry.value) : entry.value}
@@ -304,6 +304,7 @@ function AreaChartView({
   rec: ChartRecommendation;
   dark: boolean;
 }) {
+  const chartId = useId();
   const colors = getColors(dark);
   const t = themeTokens(dark);
   const catKey = rec.categoryColumn.header;
@@ -314,7 +315,7 @@ function AreaChartView({
       <AreaChart data={data} margin={{ top: 8, right: 8, bottom: 40, left: 8 }}>
         <defs>
           {valKeys.map((key, i) => (
-            <linearGradient key={key} id={`area-gradient-${i}`} x1="0" y1="0" x2="0" y2="1">
+            <linearGradient key={key} id={`area-grad-${chartId}-${i}`} x1="0" y1="0" x2="0" y2="1">
               <stop offset="5%" stopColor={colors[i % colors.length]} stopOpacity={0.3} />
               <stop offset="95%" stopColor={colors[i % colors.length]} stopOpacity={0.05} />
             </linearGradient>
@@ -341,7 +342,7 @@ function AreaChartView({
             dataKey={key}
             stroke={colors[i % colors.length]}
             strokeWidth={2}
-            fill={`url(#area-gradient-${i})`}
+            fill={`url(#area-grad-${chartId}-${i})`}
           />
         ))}
       </AreaChart>
@@ -500,6 +501,39 @@ function ChartTypeSelector({
 }
 
 /* ------------------------------------------------------------------ */
+/*  Chart renderer (inside error boundary)                               */
+/* ------------------------------------------------------------------ */
+
+function ChartRenderer({
+  rows,
+  rec,
+  defaultData,
+  defaultRec,
+  dark,
+}: {
+  rows: string[][];
+  rec: ChartRecommendation;
+  defaultData: RechartsRow[];
+  defaultRec: ChartRecommendation;
+  dark: boolean;
+}) {
+  // Re-transform data when switching chart type (category axis may differ)
+  const chartData = rec === defaultRec ? defaultData : transformData(rows, rec);
+  const type = rec.type;
+
+  return (
+    <div className="p-2">
+      {type === "bar" ? <BarChartView data={chartData} rec={rec} dark={dark} />
+        : type === "line" ? <LineChartView data={chartData} rec={rec} dark={dark} />
+        : type === "area" ? <AreaChartView data={chartData} rec={rec} dark={dark} />
+        : type === "stacked-bar" ? <StackedBarChartView data={chartData} rec={rec} dark={dark} />
+        : type === "scatter" ? <ScatterChartView data={chartData} rec={rec} dark={dark} />
+        : <PieChartView data={chartData} rec={rec} dark={dark} />}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
 /*  Main ResultChart component                                          */
 /* ------------------------------------------------------------------ */
 
@@ -526,11 +560,6 @@ export function ResultChart({
   const currentType = activeType ?? result.recommendations[0].type;
   const currentRec = result.recommendations.find((r) => r.type === currentType) ?? result.recommendations[0];
 
-  // Re-transform data when switching chart type (category axis may differ)
-  const chartData = currentRec === result.recommendations[0]
-    ? result.data
-    : transformData(rows, currentRec);
-
   return (
     <div className="overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-700">
       <div className="flex items-center justify-between border-b border-zinc-100 bg-zinc-50/50 px-3 py-2 dark:border-zinc-800 dark:bg-zinc-900/50">
@@ -542,14 +571,13 @@ export function ResultChart({
         />
       </div>
       <ChartErrorBoundary key={currentType}>
-        <div className="p-2">
-          {currentType === "bar" ? <BarChartView data={chartData} rec={currentRec} dark={dark} />
-            : currentType === "line" ? <LineChartView data={chartData} rec={currentRec} dark={dark} />
-            : currentType === "area" ? <AreaChartView data={chartData} rec={currentRec} dark={dark} />
-            : currentType === "stacked-bar" ? <StackedBarChartView data={chartData} rec={currentRec} dark={dark} />
-            : currentType === "scatter" ? <ScatterChartView data={chartData} rec={currentRec} dark={dark} />
-            : <PieChartView data={chartData} rec={currentRec} dark={dark} />}
-        </div>
+        <ChartRenderer
+          rows={rows}
+          rec={currentRec}
+          defaultData={result.data}
+          defaultRec={result.recommendations[0]}
+          dark={dark}
+        />
       </ChartErrorBoundary>
     </div>
   );

--- a/packages/web/src/ui/components/chat/python-result-card.tsx
+++ b/packages/web/src/ui/components/chat/python-result-card.tsx
@@ -6,7 +6,7 @@ import { DarkModeContext } from "../../hooks/use-dark-mode";
 import dynamic from "next/dynamic";
 import { LoadingCard } from "./loading-card";
 import { DataTable } from "./data-table";
-import type { ChartDetectionResult } from "../chart/chart-detection";
+import type { ChartDetectionResult, ChartType } from "../chart/chart-detection";
 
 const ResultChart = dynamic(
   () => import("../chart/result-chart").then((m) => ({ default: m.ResultChart })),
@@ -14,7 +14,7 @@ const ResultChart = dynamic(
 );
 
 interface RechartsChartConfig {
-  type: "line" | "bar" | "pie";
+  type: ChartType;
   data: Record<string, unknown>[];
   categoryKey: string;
   valueKeys: string[];


### PR DESCRIPTION
## Summary
Closes #187

- **Area chart**: Gradient-filled alternative to line charts for time-series data (date + numeric columns). Recommended alongside line so users can toggle between them.
- **Stacked bar chart**: Part-to-whole comparisons when there's a categorical column + 2+ numeric columns. Uses `stackId` for stacking with auto-generated colors and legend.
- **Scatter plot**: Correlation analysis for 2+ numeric columns. First two numerics become x/y axes, optional 3rd numeric for bubble size via `ZAxis`.

Detection logic adds new types without breaking existing bar/line/pie recommendations. Chart type selector shows all recommended types with labels.

### Files changed
- `chart-detection.ts` — Extended `ChartType` union, added detection rules, scatter-specific `transformData`
- `result-chart.tsx` — Added `AreaChartView`, `StackedBarChartView`, `ScatterChartView` components + wiring
- `chart-detection.test.ts` — 8 new test cases covering detection and data transformation

## Test plan
- [x] All 39 chart-detection tests pass (`bun test packages/web/src/ui/__tests__/chart-detection.test.ts`)
- [x] No type errors in chart files (`bun run type`)
- [x] Existing bar/line/pie detection unchanged (verified by existing tests passing)
- [ ] Visual QA: area chart with time-series data shows gradient fill
- [ ] Visual QA: stacked bar with multi-measure categorical data shows stacked bars + legend
- [ ] Visual QA: scatter plot with 2+ numeric columns shows dots, optional size encoding
- [ ] Dark mode: all new chart types use correct color palette