### PR TITLE
feat(web): saved queries filter and inline save button

### DIFF
--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -86,29 +86,34 @@ function SaveButton({
   conversations: { id: string; starred: boolean }[];
   onStar: (id: string, starred: boolean) => Promise<boolean>;
 }) {
-  const convo = conversations.find((c) => c.id === conversationId);
-  const isStarred = convo?.starred ?? false;
+  const isStarred = conversations.find((c) => c.id === conversationId)?.starred ?? false;
   const [pending, setPending] = useState(false);
 
+  async function handleToggle() {
+    setPending(true);
+    try {
+      await onStar(conversationId, !isStarred);
+    } finally {
+      setPending(false);
+    }
+  }
+
   return (
-    <button
-      onClick={async () => {
-        if (pending) return;
-        setPending(true);
-        await onStar(conversationId, !isStarred);
-        setPending(false);
-      }}
+    <Button
+      variant="ghost"
+      size="xs"
+      onClick={handleToggle}
       disabled={pending}
-      className={`flex items-center gap-1.5 rounded-md px-2 py-1 text-xs transition-colors ${
+      className={
         isStarred
           ? "text-amber-500 hover:text-amber-600 dark:text-amber-400 dark:hover:text-amber-300"
           : "text-zinc-400 hover:text-amber-500 dark:text-zinc-500 dark:hover:text-amber-400"
-      } ${pending ? "opacity-50" : ""}`}
+      }
       aria-label={isStarred ? "Unsave conversation" : "Save conversation"}
     >
       <Star className="h-3.5 w-3.5" fill={isStarred ? "currentColor" : "none"} />
       <span>{isStarred ? "Saved" : "Save"}</span>
-    </button>
+    </Button>
   );
 }
 
@@ -478,12 +483,10 @@ export function AtlasChat() {
                         })}
                         {isLastAssistant && !isLoading && (
                           <>
-                            <div className="flex items-center gap-2">
-                              <FollowUpChips
-                                suggestions={suggestions}
-                                onSelect={handleSend}
-                              />
-                            </div>
+                            <FollowUpChips
+                              suggestions={suggestions}
+                              onSelect={handleSend}
+                            />
                             {conversationId && convos.available && (
                               <SaveButton
                                 conversationId={conversationId}

--- a/packages/web/src/ui/components/conversations/conversation-list.tsx
+++ b/packages/web/src/ui/components/conversations/conversation-list.tsx
@@ -28,22 +28,21 @@ export function ConversationList({
     );
   }
 
-  // When sections are disabled (e.g. "Saved" filter), show a flat list
+  function renderItems(items: Conversation[]) {
+    return items.map((c) => (
+      <ConversationItem
+        key={c.id}
+        conversation={c}
+        isActive={c.id === selectedId}
+        onSelect={() => onSelect(c.id)}
+        onDelete={() => onDelete(c.id)}
+        onStar={(s) => onStar(c.id, s)}
+      />
+    ));
+  }
+
   if (!showSections) {
-    return (
-      <div className="space-y-1">
-        {conversations.map((c) => (
-          <ConversationItem
-            key={c.id}
-            conversation={c}
-            isActive={c.id === selectedId}
-            onSelect={() => onSelect(c.id)}
-            onDelete={() => onDelete(c.id)}
-            onStar={(s) => onStar(c.id, s)}
-          />
-        ))}
-      </div>
-    );
+    return <div className="space-y-1">{renderItems(conversations)}</div>;
   }
 
   const starred = conversations.filter((c) => c.starred);
@@ -56,16 +55,7 @@ export function ConversationList({
           <div className="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
             Starred
           </div>
-          {starred.map((c) => (
-            <ConversationItem
-              key={c.id}
-              conversation={c}
-              isActive={c.id === selectedId}
-              onSelect={() => onSelect(c.id)}
-              onDelete={() => onDelete(c.id)}
-              onStar={(s) => onStar(c.id, s)}
-            />
-          ))}
+          {renderItems(starred)}
           {unstarred.length > 0 && (
             <div className="px-3 pb-1 pt-3 text-[10px] font-semibold uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
               Recent
@@ -73,16 +63,7 @@ export function ConversationList({
           )}
         </>
       )}
-      {unstarred.map((c) => (
-        <ConversationItem
-          key={c.id}
-          conversation={c}
-          isActive={c.id === selectedId}
-          onSelect={() => onSelect(c.id)}
-          onDelete={() => onDelete(c.id)}
-          onStar={(s) => onStar(c.id, s)}
-        />
-      ))}
+      {renderItems(unstarred)}
     </div>
   );
 }

--- a/packages/web/src/ui/components/conversations/conversation-sidebar.tsx
+++ b/packages/web/src/ui/components/conversations/conversation-sidebar.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 import { Star } from "lucide-react";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { Badge } from "@/components/ui/badge";
 import type { Conversation } from "../../lib/types";
 import { ConversationList } from "./conversation-list";
 
@@ -29,10 +31,8 @@ export function ConversationSidebar({
   onMobileClose: () => void;
 }) {
   const [filter, setFilter] = useState<SidebarFilter>("all");
-  const starredCount = conversations.filter((c) => c.starred).length;
-  const filteredConversations = filter === "saved"
-    ? conversations.filter((c) => c.starred)
-    : conversations;
+  const starredConversations = conversations.filter((c) => c.starred);
+  const filteredConversations = filter === "saved" ? starredConversations : conversations;
 
   const sidebar = (
     <div className="flex h-full flex-col border-r border-zinc-200 bg-zinc-50/50 dark:border-zinc-800 dark:bg-zinc-950/50">
@@ -46,37 +46,27 @@ export function ConversationSidebar({
         </button>
       </div>
 
-      <div className="flex gap-1 border-b border-zinc-200 px-3 py-2 dark:border-zinc-800">
-        <button
-          onClick={() => setFilter("all")}
-          className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
-            filter === "all"
-              ? "bg-zinc-200 text-zinc-800 dark:bg-zinc-700 dark:text-zinc-200"
-              : "text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300"
-          }`}
+      <div className="border-b border-zinc-200 px-3 py-2 dark:border-zinc-800">
+        <ToggleGroup
+          type="single"
+          size="sm"
+          value={filter}
+          onValueChange={(val) => { if (val) setFilter(val as SidebarFilter); }}
+          className="gap-1"
         >
-          All
-        </button>
-        <button
-          onClick={() => setFilter("saved")}
-          className={`flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
-            filter === "saved"
-              ? "bg-zinc-200 text-zinc-800 dark:bg-zinc-700 dark:text-zinc-200"
-              : "text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300"
-          }`}
-        >
-          <Star className="h-3 w-3" fill={filter === "saved" ? "currentColor" : "none"} />
-          Saved
-          {starredCount > 0 && (
-            <span className={`rounded-full px-1.5 text-[10px] font-semibold leading-4 ${
-              filter === "saved"
-                ? "bg-zinc-300 text-zinc-700 dark:bg-zinc-600 dark:text-zinc-200"
-                : "bg-zinc-200 text-zinc-500 dark:bg-zinc-700 dark:text-zinc-400"
-            }`}>
-              {starredCount}
-            </span>
-          )}
-        </button>
+          <ToggleGroupItem value="all" className="px-2.5 text-xs">
+            All
+          </ToggleGroupItem>
+          <ToggleGroupItem value="saved" className="gap-1.5 px-2.5 text-xs">
+            <Star className="h-3 w-3" fill={filter === "saved" ? "currentColor" : "none"} />
+            Saved
+            {starredConversations.length > 0 && (
+              <Badge variant="secondary" className="h-4 px-1.5 text-[10px] font-semibold">
+                {starredConversations.length}
+              </Badge>
+            )}
+          </ToggleGroupItem>
+        </ToggleGroup>
       </div>
 
       <div className="flex-1 overflow-y-auto p-2">


### PR DESCRIPTION
## Summary
- Adds **"All" / "Saved" filter tabs** to the conversation sidebar with a star count badge on the Saved tab
- Adds an **inline save button** below the last assistant message, letting users star/save the current conversation without scrolling to the sidebar
- When "Saved" filter is active, shows only starred conversations in a flat list with a custom empty state ("Star conversations to save them here")
- When "All" filter is active, preserves existing behavior (Starred section at top, Recent section below)

Closes #185

## Test plan
- [x] Type-check passes (`bun run type` — no new errors in `packages/web` or `packages/api`)
- [x] Lint passes (`bun run lint`)
- [x] All 79 existing conversation tests pass (47 unit + 32 route)
- [ ] Manual: verify "All" / "Saved" tabs toggle correctly in the sidebar
- [ ] Manual: verify star count badge updates when starring/unstarring
- [ ] Manual: verify inline "Save" / "Saved" button appears after last assistant message
- [ ] Manual: verify clicking inline save button stars the conversation (optimistic update)
- [ ] Manual: verify empty state shows when "Saved" filter is active with no starred conversations
- [ ] Manual: verify mobile overlay sidebar also has the filter tabs