### PR TITLE
fix: testing spike issues — demo data, enrichment, markdown tables, UX

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -216,6 +216,7 @@
         "react-markdown": "^10.1.0",
         "react-syntax-highlighter": "^16.1.0",
         "recharts": "^3.7.0",
+        "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.5.0",
         "xlsx": "^0.18.5",
       },

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -233,6 +233,11 @@ chat.post("/", async (c) => {
         const result = await runAgent({ messages, ...(toolRegistry && { tools: toolRegistry }), conversationId });
         const streamResponse = result.toUIMessageStreamResponse();
 
+        // Prevent proxy buffering (Next.js rewrites, nginx, etc.) so chunks
+        // reach the client immediately for real-time streaming.
+        streamResponse.headers.set("X-Accel-Buffering", "no");
+        streamResponse.headers.set("Cache-Control", "no-cache, no-transform");
+
         // Set conversation ID header so the client can track continuity
         if (conversationId) {
           streamResponse.headers.set("x-conversation-id", conversationId);

--- a/packages/api/src/lib/semantic-index.ts
+++ b/packages/api/src/lib/semantic-index.ts
@@ -32,6 +32,7 @@ interface EntityDimension {
   description?: string;
   sample_values?: unknown[];
   primary_key?: boolean;
+  virtual?: boolean;
 }
 
 interface EntityMeasure {
@@ -235,13 +236,29 @@ function formatEntity(
   if (full) {
     // Full mode: list all columns with types
     if (entity.dimensions && entity.dimensions.length > 0) {
-      lines.push("Columns:");
-      for (const dim of entity.dimensions) {
-        const name = dim.name ?? dim.sql ?? "?";
-        const type = dim.type ?? "unknown";
-        const pk = dim.primary_key ? " PK" : "";
-        const desc = dim.description ? ` — ${dim.description}` : "";
-        lines.push(`  - ${name} (${type}${pk})${desc}`);
+      const realCols = entity.dimensions.filter((d) => !d.virtual);
+      const virtualCols = entity.dimensions.filter((d) => d.virtual);
+
+      if (realCols.length > 0) {
+        lines.push("Columns:");
+        for (const dim of realCols) {
+          const name = dim.name ?? dim.sql ?? "?";
+          const type = dim.type ?? "unknown";
+          const pk = dim.primary_key ? " PK" : "";
+          const desc = dim.description ? ` — ${dim.description}` : "";
+          lines.push(`  - ${name} (${type}${pk})${desc}`);
+        }
+      }
+
+      if (virtualCols.length > 0) {
+        lines.push("Virtual columns (NOT real columns — use the SQL expression inline):");
+        for (const dim of virtualCols) {
+          const name = dim.name ?? "?";
+          const type = dim.type ?? "unknown";
+          const desc = dim.description ? ` — ${dim.description}` : "";
+          const sql = dim.sql ? ` sql: ${dim.sql.replace(/\n/g, " ")}` : "";
+          lines.push(`  - ${name} (${type})${desc}${sql}`);
+        }
       }
     }
 

--- a/packages/cli/bin/enrich.ts
+++ b/packages/cli/bin/enrich.ts
@@ -44,10 +44,15 @@ function addUsage(accumulator: TokenUsage, usage: Partial<TokenUsage>): void {
  * ```yaml ... ``` code blocks.
  */
 function extractYamlBlock(text: string): string {
-  const match = text.match(/```yaml\s*\n([\s\S]*?)```/);
+  // Match ```yaml or ```yml fenced blocks
+  const match = text.match(/```ya?ml[ \t]*\r?\n([\s\S]*?)```/);
   if (match) return match[1].trim();
 
-  // Fallback: try to parse the whole response as YAML
+  // Fallback: try a generic fenced block (``` without language tag)
+  const generic = text.match(/```\s*\r?\n([\s\S]*?)```/);
+  if (generic) return generic[1].trim();
+
+  // Last resort: try to parse the whole response as YAML
   console.warn("    Note: LLM response did not contain a ```yaml block, attempting to parse raw response");
   return text.trim();
 }

--- a/packages/cli/data/demo.sql
+++ b/packages/cli/data/demo.sql
@@ -35,6 +35,9 @@ CREATE TABLE IF NOT EXISTS accounts (
   contract_end DATE
 );
 
+-- Ensure idempotent seeding (safe to re-run without doubling rows)
+TRUNCATE TABLE accounts, people, companies RESTART IDENTITY CASCADE;
+
 -- Seed data: 50 companies
 INSERT INTO companies (name, industry, employee_count, founded_year, country, revenue, valuation) VALUES
   ('Acme Corp', 'Technology', 450, 2010, 'US', 85000000, 340000000),

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -35,6 +35,7 @@
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^16.1.0",
     "recharts": "^3.7.0",
+    "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.5.0",
     "xlsx": "^0.18.5"
   },

--- a/packages/web/src/components/ui/scroll-area.tsx
+++ b/packages/web/src/components/ui/scroll-area.tsx
@@ -8,15 +8,19 @@ import { cn } from "@/lib/utils"
 function ScrollArea({
   className,
   children,
+  viewportRef,
   ...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root> & {
+  viewportRef?: React.Ref<HTMLDivElement>
+}) {
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
-      className={cn("relative", className)}
+      className={cn("relative overflow-hidden", className)}
       {...props}
     >
       <ScrollAreaPrimitive.Viewport
+        ref={viewportRef}
         data-slot="scroll-area-viewport"
         className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
       >

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -26,6 +26,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { parseSuggestions } from "../lib/helpers";
 
 const API_KEY_STORAGE_KEY = "atlas-api-key";
@@ -421,7 +422,8 @@ export function AtlasChat() {
                   </div>
                 )}
 
-                <div ref={scrollRef} className="flex-1 space-y-4 overflow-y-auto pb-4">
+                <ScrollArea viewportRef={scrollRef} className="min-h-0 flex-1">
+                <div className="space-y-4 pb-4 pr-3">
                   {messages.length === 0 && !error && (
                     <div className="flex h-full flex-col items-center justify-center gap-6">
                       <div className="text-center">
@@ -519,6 +521,7 @@ export function AtlasChat() {
 
                   {isLoading && messages.length > 0 && <TypingIndicator />}
                 </div>
+                </ScrollArea>
 
                 {error && <ErrorBanner error={error} authMode={authMode} />}
 

--- a/packages/web/src/ui/components/chat/markdown.tsx
+++ b/packages/web/src/ui/components/chat/markdown.tsx
@@ -2,6 +2,7 @@
 
 import { memo, useContext, useState, useEffect, type ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { DarkModeContext } from "../../hooks/use-dark-mode";
 
 /* ------------------------------------------------------------------ */
@@ -83,6 +84,28 @@ const mdComponents = {
       {children}
     </blockquote>
   ),
+  table: ({ children }: { children?: ReactNode }) => (
+    <div className="my-3 overflow-x-auto rounded-lg border border-zinc-200 dark:border-zinc-700">
+      <table className="min-w-full text-sm">{children}</table>
+    </div>
+  ),
+  thead: ({ children }: { children?: ReactNode }) => (
+    <thead className="border-b border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800/50">
+      {children}
+    </thead>
+  ),
+  tbody: ({ children }: { children?: ReactNode }) => (
+    <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800">{children}</tbody>
+  ),
+  tr: ({ children }: { children?: ReactNode }) => <tr>{children}</tr>,
+  th: ({ children }: { children?: ReactNode }) => (
+    <th className="px-3 py-2 text-left text-xs font-medium text-zinc-600 dark:text-zinc-300">
+      {children}
+    </th>
+  ),
+  td: ({ children }: { children?: ReactNode }) => (
+    <td className="px-3 py-2 text-zinc-700 dark:text-zinc-300">{children}</td>
+  ),
   pre: ({ children }: { children?: ReactNode }) => <>{children}</>,
 };
 
@@ -90,6 +113,7 @@ export const Markdown = memo(function Markdown({ content }: { content: string })
   const dark = useContext(DarkModeContext);
   return (
     <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
       components={{
         ...mdComponents,
         code({ className, children, ...props }) {


### PR DESCRIPTION
## Summary

Fixes issues discovered during the testing spike:

- **#204 (P0)** — Demo data loaded twice: added `TRUNCATE ... RESTART IDENTITY CASCADE` before INSERTs in `demo.sql` so `atlas init --demo` is idempotent when Docker entrypoint already seeded
- **#205 (P1)** — Glossary enrichment YAML parse failure: `extractYamlBlock` now matches `` ```yml `` and generic `` ``` `` fences, not just `` ```yaml ``
- **#207 (P1)** — Markdown tables render as raw text: added `remark-gfm` plugin + styled `table/thead/tbody/tr/th/td` components to the markdown renderer
- **Agent first-query failures** — Virtual dimensions listed as regular columns in the semantic index; agent tried `SELECT company_size` instead of inlining the CASE expression. Now separated with explicit "use the SQL expression inline" guidance
- **Native scrollbar** — Replaced `overflow-y-auto` with shadcn `ScrollArea` in chat; added `viewportRef` prop to the component for auto-scroll support
- **Stream buffering** — Added `X-Accel-Buffering: no` and `Cache-Control: no-cache, no-transform` headers to prevent Next.js rewrite proxy from buffering chat stream chunks

Closes #204, closes #205, closes #207

## Test plan

- [x] `bun run db:reset && bun run atlas -- init --demo` → 50 companies, 198 people, 80 accounts
- [x] Glossary enrichment completes without "did not contain a yaml block" warning
- [x] GFM tables render as styled HTML in chat responses
- [x] Agent writes correct SQL on first attempt (no virtual column errors)
- [x] Chat uses shadcn scrollbar, text not overlapped
- [x] Chat text streams incrementally (not all-at-once)
- [x] `bun run type` passes