### PR TITLE
fix(cli): fix 3 CLI bugs — validate, diff, init

### DIFF
--- a/packages/cli/bin/__tests__/schema-drift.test.ts
+++ b/packages/cli/bin/__tests__/schema-drift.test.ts
@@ -382,6 +382,45 @@ describe("computeDiff", () => {
     expect(diff.removedTables).toEqual(["customers", "orders"]);
     expect(diff.tableDiffs).toEqual([]);
   });
+
+  test("ignores dimension_table vs fact_table type difference (semantic classification)", () => {
+    const dbSnap: EntitySnapshot = {
+      table: "companies",
+      columns: new Map([["id", "number"]]),
+      foreignKeys: new Set(),
+      objectType: "fact_table",
+    };
+    const ymlSnap: EntitySnapshot = {
+      table: "companies",
+      columns: new Map([["id", "number"]]),
+      foreignKeys: new Set(),
+      objectType: "dimension_table",
+    };
+    const db = new Map([["companies", dbSnap]]);
+    const yml = new Map([["companies", ymlSnap]]);
+    const diff = computeDiff(db, yml);
+    expect(diff.tableDiffs).toEqual([]);
+  });
+
+  test("still flags real type changes (table vs view)", () => {
+    const dbSnap: EntitySnapshot = {
+      table: "orders",
+      columns: new Map([["id", "number"]]),
+      foreignKeys: new Set(),
+      objectType: "view",
+    };
+    const ymlSnap: EntitySnapshot = {
+      table: "orders",
+      columns: new Map([["id", "number"]]),
+      foreignKeys: new Set(),
+      objectType: "fact_table",
+    };
+    const db = new Map([["orders", dbSnap]]);
+    const yml = new Map([["orders", ymlSnap]]);
+    const diff = computeDiff(db, yml);
+    expect(diff.tableDiffs).toHaveLength(1);
+    expect(diff.tableDiffs[0].metadataChanges).toContain("type changed: fact_table → view");
+  });
 });
 
 // --- formatDiff ---

--- a/packages/cli/bin/atlas.ts
+++ b/packages/cli/bin/atlas.ts
@@ -2916,7 +2916,13 @@ export function computeDiff(
 
     // Metadata differences
     const metadataChanges: string[] = [];
-    if (db.objectType && yml.objectType && db.objectType !== yml.objectType) {
+    // Only flag type changes that indicate real schema drift (e.g. table↔view).
+    // Semantic classifications like dimension_table vs fact_table are enrichment
+    // metadata — the profiler always assigns "fact_table" to non-views, so comparing
+    // it against enriched YAML produces false positives.
+    const semanticTypes = new Set(["fact_table", "dimension_table"]);
+    if (db.objectType && yml.objectType && db.objectType !== yml.objectType
+      && !(semanticTypes.has(db.objectType) && semanticTypes.has(yml.objectType))) {
       metadataChanges.push(`type changed: ${yml.objectType} → ${db.objectType}`);
     }
     if (db.partitionStrategy !== yml.partitionStrategy) {
@@ -4379,6 +4385,15 @@ async function profileDatasource(opts: ProfileDatasourceOpts): Promise<void> {
   fs.mkdirSync(entitiesOutDir, { recursive: true });
   fs.mkdirSync(metricsOutDir, { recursive: true });
 
+  // Clean stale entity/metric files from previous runs
+  for (const dir of [entitiesOutDir, metricsOutDir]) {
+    for (const file of fs.readdirSync(dir)) {
+      if (file.endsWith(".yml") || file.endsWith(".yaml")) {
+        fs.unlinkSync(path.join(dir, file));
+      }
+    }
+  }
+
   // Generate entity YAMLs
   console.log(`\nGenerating semantic layer...\n`);
 
@@ -4810,6 +4825,15 @@ async function main() {
     // Write semantic layer
     fs.mkdirSync(entitiesOutDir, { recursive: true });
     fs.mkdirSync(metricsOutDir, { recursive: true });
+
+    // Clean stale entity/metric files from previous runs
+    for (const dir of [entitiesOutDir, metricsOutDir]) {
+      for (const file of fs.readdirSync(dir)) {
+        if (file.endsWith(".yml") || file.endsWith(".yaml")) {
+          fs.unlinkSync(path.join(dir, file));
+        }
+      }
+    }
 
     console.log(`\nGenerating semantic layer...\n`);
 

--- a/packages/cli/src/__tests__/validate.test.ts
+++ b/packages/cli/src/__tests__/validate.test.ts
@@ -616,6 +616,44 @@ describe("checkCrossReferences", () => {
     expect(errors[0].detail).toContain("missing_table");
   });
 
+  test("resolves array-style joins with target_entity (profiler-generated)", () => {
+    const entities = [
+      {
+        file: "entities/people.yml",
+        table: "people",
+        dimensions: { id: { type: "integer" } },
+        joins: [
+          { target_entity: "Companies", relationship: "many_to_one", join_columns: { from: "company_id", to: "id" } },
+        ],
+      },
+      {
+        file: "entities/companies.yml",
+        table: "companies",
+        dimensions: { id: { type: "integer" } },
+      },
+    ];
+    const results = checkCrossReferences(entities, []);
+    const errors = results.filter((r) => r.status === "fail");
+    expect(errors.length).toBe(0);
+  });
+
+  test("array-style join with missing target_entity reports error", () => {
+    const entities = [
+      {
+        file: "entities/people.yml",
+        table: "people",
+        dimensions: { id: { type: "integer" } },
+        joins: [
+          { target_entity: "MissingTable", relationship: "many_to_one", join_columns: { from: "company_id", to: "id" } },
+        ],
+      },
+    ];
+    const results = checkCrossReferences(entities, []);
+    const errors = results.filter((r) => r.status === "fail");
+    expect(errors.length).toBe(1);
+    expect(errors[0].detail).toContain("missing_table");
+  });
+
   test("handles schema-qualified table names in joins", () => {
     const entities = [
       {

--- a/packages/cli/src/validate.ts
+++ b/packages/cli/src/validate.ts
@@ -585,19 +585,27 @@ export function checkCrossReferences(
   for (const entity of entities) {
     if (!entity.joins) continue;
 
-    for (const [joinKey, joinVal] of Object.entries(entity.joins)) {
-      // Join keys in entity YAMLs can be the target table name directly
-      // or an object with target_table/to
+    // Joins can be an array (profiler-generated) or an object (hand-written)
+    const joinEntries: Array<[string, unknown]> = Array.isArray(entity.joins)
+      ? entity.joins.map((v: unknown, i: number) => [String(i), v] as [string, unknown])
+      : Object.entries(entity.joins);
+
+    for (const [joinKey, joinVal] of joinEntries) {
       let targetTable: string | undefined;
 
       if (joinVal && typeof joinVal === "object") {
         const j = joinVal as Record<string, unknown>;
         if (typeof j.target_table === "string") targetTable = j.target_table;
-        else if (typeof j.to === "string") targetTable = j.to;
+        else if (typeof j.target_entity === "string") {
+          // target_entity is PascalCase — convert to snake_case table name
+          targetTable = j.target_entity.replace(/([a-z])([A-Z])/g, "$1_$2").toLowerCase();
+        } else if (typeof j.to === "string") targetTable = j.to;
       }
 
-      // The join key itself is often the target table name (convention: joins.other_table)
-      const target = targetTable ?? joinKey;
+      // For object-style joins, the key itself is often the target table name
+      const target = targetTable ?? (Array.isArray(entity.joins) ? undefined : joinKey);
+      if (!target) continue; // Array join with no resolvable target — skip
+
       const targetLower = target.toLowerCase();
       referencedTables.add(targetLower);
 


### PR DESCRIPTION
## Summary
- **#211**: `atlas validate` misparses array-style joins — handle both array and object formats, resolve `target_entity` (PascalCase → snake_case)
- **#212**: `atlas diff` reports false type drift (dimension_table → fact_table) — skip semantic classification comparisons, still flag real structural changes (table ↔ view)
- **#213**: `atlas init` doesn't clean stale files — clear existing `.yml` files in entities/metrics dirs before writing (both main profiler and DuckDB paths)

## Test plan
- [x] 40 validate tests pass (2 new: array-style joins with target_entity)
- [x] 38 schema-drift tests pass (2 new: semantic type ignore + real type change detection)
- [x] Full lint + type-check clean

Closes #211
Closes #212
Closes #213