### PR TITLE
feat(api): add widget host route for iframe embedding

### DIFF
--- a/packages/api/src/api/__tests__/widget.test.ts
+++ b/packages/api/src/api/__tests__/widget.test.ts
@@ -1,7 +1,8 @@
 /**
  * Tests for the widget host route.
  *
- * Tests HTML response, headers, query param handling, and XSS prevention.
+ * Tests HTML response, headers, query param handling, XSS prevention,
+ * apiUrl sanitization, error handling infrastructure, and HTML structure.
  * The widget route has no internal dependencies, so no mocks are needed —
  * we mount it on a standalone Hono app for isolation.
  */
@@ -25,11 +26,22 @@ function widgetRequest(params?: Record<string, string>): Request {
 }
 
 describe("GET /widget", () => {
+  // --- Response basics ---
+
   it("returns 200 with text/html content type", async () => {
     const res = await app.fetch(widgetRequest());
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/html");
   });
+
+  it("returns 404 for POST requests", async () => {
+    const res = await app.fetch(
+      new Request("http://localhost/widget", { method: "POST" }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  // --- Security headers ---
 
   it("sets CSP frame-ancestors header for iframe embedding", async () => {
     const res = await app.fetch(widgetRequest());
@@ -41,6 +53,8 @@ describe("GET /widget", () => {
     const res = await app.fetch(widgetRequest());
     expect(res.headers.get("access-control-allow-origin")).toBe("*");
   });
+
+  // --- Query param handling ---
 
   it("includes config JSON with query params in response body", async () => {
     const res = await app.fetch(
@@ -56,6 +70,12 @@ describe("GET /widget", () => {
     const res = await app.fetch(widgetRequest());
     const html = await res.text();
     expect(html).toContain('"theme":"system"');
+  });
+
+  it("defaults apiUrl to empty string when not specified", async () => {
+    const res = await app.fetch(widgetRequest());
+    const html = await res.text();
+    expect(html).toContain('"apiUrl":""');
   });
 
   it("defaults position to inline when not specified", async () => {
@@ -92,27 +112,155 @@ describe("GET /widget", () => {
     }
   });
 
-  it("escapes < in apiUrl to prevent XSS", async () => {
+  // --- XSS prevention ---
+
+  it("escapes < in apiUrl to prevent script injection", async () => {
     const res = await app.fetch(
-      widgetRequest({ apiUrl: '</script><script>alert(1)</script>' }),
+      widgetRequest({ apiUrl: 'https://example.com/?q=</script><script>alert(1)</script>' }),
     );
     const html = await res.text();
-    // Raw </script> must not appear — < is escaped as \u003c in JSON
     expect(html).not.toContain("</script><script>alert(1)</script>");
     expect(html).toContain("\\u003c");
   });
 
-  it("includes postMessage listener", async () => {
+  it("does not include malicious theme values in the HTML", async () => {
+    const res = await app.fetch(
+      widgetRequest({ theme: '"><img src=x onerror=alert(1)>' }),
+    );
+    const html = await res.text();
+    // Invalid theme falls back to "system", malicious value should not appear
+    expect(html).toContain('"theme":"system"');
+    expect(html).not.toContain("onerror=alert");
+  });
+
+  it("does not include malicious position values in the HTML", async () => {
+    const res = await app.fetch(
+      widgetRequest({ position: '"><script>alert(1)</script>' }),
+    );
+    const html = await res.text();
+    expect(html).toContain('"position":"inline"');
+    expect(html).not.toContain("<script>alert(1)");
+  });
+
+  // --- apiUrl sanitization ---
+
+  it("rejects javascript: protocol in apiUrl", async () => {
+    const res = await app.fetch(
+      widgetRequest({ apiUrl: "javascript:alert(document.cookie)" }),
+    );
+    const html = await res.text();
+    expect(html).not.toContain("javascript:");
+    expect(html).toContain('"apiUrl":""');
+  });
+
+  it("rejects data: protocol in apiUrl", async () => {
+    const res = await app.fetch(
+      widgetRequest({ apiUrl: "data:text/html,<script>alert(1)</script>" }),
+    );
+    const html = await res.text();
+    expect(html).not.toContain("data:text/html");
+    expect(html).toContain('"apiUrl":""');
+  });
+
+  it("rejects non-URL strings in apiUrl", async () => {
+    const res = await app.fetch(widgetRequest({ apiUrl: "not a url" }));
+    const html = await res.text();
+    expect(html).toContain('"apiUrl":""');
+  });
+
+  it("allows valid https apiUrl", async () => {
+    const res = await app.fetch(
+      widgetRequest({ apiUrl: "https://api.example.com" }),
+    );
+    const html = await res.text();
+    expect(html).toContain("https://api.example.com");
+  });
+
+  it("allows valid http apiUrl", async () => {
+    const res = await app.fetch(
+      widgetRequest({ apiUrl: "http://localhost:3001" }),
+    );
+    const html = await res.text();
+    expect(html).toContain("http://localhost:3001");
+  });
+
+  // --- HTML structure ---
+
+  it("returns valid HTML document structure", async () => {
     const res = await app.fetch(widgetRequest());
     const html = await res.text();
-    expect(html).toContain('addEventListener("message"');
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html).toContain('<div id="atlas-widget">');
+    expect(html).toContain('<script id="atlas-config"');
   });
+
+  it("sets data-position attribute on body", async () => {
+    const res = await app.fetch(widgetRequest({ position: "bottomRight" }));
+    const html = await res.text();
+    expect(html).toContain('data-position="bottomRight"');
+  });
+
+  // --- Error handling infrastructure ---
+
+  it("includes global error handlers for uncaught errors", async () => {
+    const res = await app.fetch(widgetRequest());
+    const html = await res.text();
+    expect(html).toContain("window.onerror");
+    expect(html).toContain("unhandledrejection");
+  });
+
+  it("includes try/catch around CDN imports", async () => {
+    const res = await app.fetch(widgetRequest());
+    const html = await res.text();
+    expect(html).toContain("try{");
+    expect(html).toContain("}catch(err)");
+  });
+
+  it("includes React error boundary", async () => {
+    const res = await app.fetch(widgetRequest());
+    const html = await res.text();
+    expect(html).toContain("getDerivedStateFromError");
+    expect(html).toContain("componentDidCatch");
+  });
+
+  it("sends atlas:ready message to parent on successful load", async () => {
+    const res = await app.fetch(widgetRequest());
+    const html = await res.text();
+    expect(html).toContain("atlas:ready");
+  });
+
+  it("sends atlas:error message to parent on load failure", async () => {
+    const res = await app.fetch(widgetRequest());
+    const html = await res.text();
+    expect(html).toContain("atlas:error");
+    expect(html).toContain("LOAD_FAILED");
+  });
+
+  it("validates postMessage source is parent window", async () => {
+    const res = await app.fetch(widgetRequest());
+    const html = await res.text();
+    expect(html).toContain("e.source!==window.parent");
+  });
+
+  // --- Component and CDN references ---
 
   it("includes AtlasChat component import", async () => {
     const res = await app.fetch(widgetRequest());
     const html = await res.text();
     expect(html).toContain("AtlasChat");
     expect(html).toContain("@useatlas/react");
+  });
+
+  it("uses Promise.all for parallel CDN imports", async () => {
+    const res = await app.fetch(widgetRequest());
+    const html = await res.text();
+    expect(html).toContain("Promise.all");
+  });
+
+  it("includes postMessage listener", async () => {
+    const res = await app.fetch(widgetRequest());
+    const html = await res.text();
+    expect(html).toContain('addEventListener("message"');
   });
 
   it("includes theme init script to prevent FOUC", async () => {

--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -1,7 +1,7 @@
 /**
  * Atlas API — Hono application.
  *
- * Mounts chat, health, auth, v1 query, conversations, OpenAPI, admin, and widget routes
+ * Mounts chat, health, auth, v1 query, conversations, semantic, OpenAPI, admin, and widget routes
  * with CORS middleware. Actions, scheduled tasks, and Slack routes are
  * conditionally loaded based on env vars.
  * Can be served standalone (./server.ts). The Next.js frontend

--- a/packages/api/src/api/routes/widget.ts
+++ b/packages/api/src/api/routes/widget.ts
@@ -1,18 +1,26 @@
 /**
  * Widget host route — serves a self-contained HTML page for iframe embedding.
  *
- * Loaded by the script tag loader (#236) as an iframe target.
+ * Loaded by the script tag loader (issue #236) as an iframe target.
  * Renders the @useatlas/react AtlasChat component via CDN.
  *
  * Query params:
  *   theme    — "light" | "dark" | "system" (default: "system")
- *   apiUrl   — Atlas API base URL (default: current origin)
+ *   apiUrl   — Atlas API base URL, must be http(s) (default: "" → falls back
+ *              to the iframe's window.location.origin at runtime)
  *   position — "bottomRight" | "bottomLeft" | "inline" (default: "inline")
+ *              Applied as data-position on <body>; consumed by parent script loader.
  *
- * postMessage API (from parent window):
- *   { type: "theme", value: "dark" | "light" }
- *   { type: "auth", token: string }
- *   { type: "toggle" }
+ * postMessage API (from parent window only — e.source === window.parent):
+ *   { type: "theme", value: "dark" | "light" }  — "system" not supported via postMessage
+ *   { type: "auth", token: string }              — passed as apiKey prop to AtlasChat
+ *   { type: "toggle" }                           — show/hide the widget
+ *
+ * Widget → parent messages:
+ *   { type: "atlas:ready" }                                — widget loaded successfully
+ *   { type: "atlas:error", code: string, message: string } — load/render/runtime error
+ *
+ * Messages with unknown types or invalid shapes are silently ignored.
  */
 
 import { Hono } from "hono";
@@ -21,6 +29,18 @@ const widget = new Hono();
 
 const VALID_THEMES = new Set(["light", "dark", "system"]);
 const VALID_POSITIONS = new Set(["bottomRight", "bottomLeft", "inline"]);
+
+/** Reject non-HTTP(S) URLs to prevent open redirect / API traffic exfiltration. */
+function sanitizeApiUrl(raw: string): string {
+  if (!raw) return "";
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "https:" && url.protocol !== "http:") return "";
+    return raw;
+  } catch {
+    return "";
+  }
+}
 
 function buildWidgetHTML(config: {
   theme: string;
@@ -46,38 +66,68 @@ body{background:#fff;color:#09090b}
 .atlas-root{--radius:0.625rem;--background:oklch(1 0 0);--foreground:oklch(0.145 0 0);--card:oklch(1 0 0);--card-foreground:oklch(0.145 0 0);--popover:oklch(1 0 0);--popover-foreground:oklch(0.145 0 0);--primary:oklch(0.205 0 0);--primary-foreground:oklch(0.985 0 0);--secondary:oklch(0.97 0 0);--secondary-foreground:oklch(0.205 0 0);--muted:oklch(0.97 0 0);--muted-foreground:oklch(0.556 0 0);--accent:oklch(0.97 0 0);--accent-foreground:oklch(0.205 0 0);--destructive:oklch(0.577 0.245 27.325);--destructive-foreground:oklch(0.577 0.245 27.325);--border:oklch(0.922 0 0);--input:oklch(0.922 0 0);--ring:oklch(0.708 0 0);--atlas-brand:oklch(0.759 0.148 167.71)}
 .dark .atlas-root{--background:oklch(0.145 0 0);--foreground:oklch(0.985 0 0);--card:oklch(0.145 0 0);--card-foreground:oklch(0.985 0 0);--popover:oklch(0.145 0 0);--popover-foreground:oklch(0.985 0 0);--primary:oklch(0.985 0 0);--primary-foreground:oklch(0.205 0 0);--secondary:oklch(0.269 0 0);--secondary-foreground:oklch(0.985 0 0);--muted:oklch(0.269 0 0);--muted-foreground:oklch(0.708 0 0);--accent:oklch(0.269 0 0);--accent-foreground:oklch(0.985 0 0);--destructive:oklch(0.396 0.141 25.723);--destructive-foreground:oklch(0.637 0.237 25.331);--border:oklch(0.269 0 0);--input:oklch(0.269 0 0);--ring:oklch(0.439 0 0)}
 </style>
-<script>try{var t=localStorage.getItem("atlas-theme");var d=t==="dark"||(t!=="light"&&window.matchMedia("(prefers-color-scheme:dark)").matches);if(d)document.documentElement.classList.add("dark")}catch(e){}</script>
-<script src="https://cdn.tailwindcss.com"></script>
+<script>
+window.onerror=function(m){console.error("[Atlas Widget]",m);try{window.parent.postMessage({type:"atlas:error",code:"UNCAUGHT",message:String(m)},"*")}catch(x){}};
+window.addEventListener("unhandledrejection",function(e){console.error("[Atlas Widget]",e.reason);try{window.parent.postMessage({type:"atlas:error",code:"UNHANDLED_REJECTION",message:String(e.reason)},"*")}catch(x){}});
+</script>
+<script>try{var t=localStorage.getItem("atlas-theme");var d=t==="dark"||(t!=="light"&&window.matchMedia("(prefers-color-scheme:dark)").matches);if(d)document.documentElement.classList.add("dark")}catch(e){console.warn("[Atlas Widget] Could not read theme:",e.message)}</script>
+<!-- Tailwind CSS Play CDN — generates utility classes at runtime for CDN-loaded
+     @useatlas/react components. Temporary measure; v3 Play CDN is not intended
+     for production. TODO: replace with pre-compiled widget CSS bundle. -->
+<script src="https://cdn.tailwindcss.com" onerror="console.warn('[Atlas Widget] Tailwind CDN unavailable — styling may be degraded')"></script>
 </head>
-<body>
+<body data-position="${config.position}">
 <div id="atlas-widget"></div>
 <script id="atlas-config" type="application/json">${configJSON}</script>
 <script type="module">
-import{createElement}from"https://esm.sh/react@19";
-import{createRoot}from"https://esm.sh/react-dom@19/client";
-const{AtlasChat,setTheme}=await import("https://esm.sh/@useatlas/react?deps=react@19,react-dom@19");
+try{
+const[{createElement,Component},{createRoot},{AtlasChat,setTheme}]=await Promise.all([
+  import("https://esm.sh/react@19"),
+  import("https://esm.sh/react-dom@19/client"),
+  import("https://esm.sh/@useatlas/react?deps=react@19,react-dom@19"),
+]);
 
-const cfg=JSON.parse(document.getElementById("atlas-config").textContent);
+const configEl=document.getElementById("atlas-config");
+if(!configEl)throw new Error("Config element not found");
+const cfg=JSON.parse(configEl.textContent??"{}");
 const apiUrl=cfg.apiUrl||window.location.origin;
 const el=document.getElementById("atlas-widget");
 const root=createRoot(el);
 let state={theme:cfg.theme,apiKey:"",visible:true};
 
+class EB extends Component{
+  constructor(p){super(p);this.state={error:null}}
+  static getDerivedStateFromError(e){return{error:e}}
+  componentDidCatch(e){
+    console.error("[Atlas Widget] Render error:",e);
+    try{window.parent.postMessage({type:"atlas:error",code:"RENDER_FAILED",message:e.message},"*")}catch(x){}
+  }
+  render(){
+    if(this.state.error)return createElement("div",{style:{padding:"2rem",textAlign:"center",color:"#888",fontFamily:"system-ui"}},
+      createElement("p",null,"Unable to load Atlas Chat."),
+      createElement("p",{style:{fontSize:"0.875rem",marginTop:"0.5rem"}},"Try refreshing the page."));
+    return this.props.children;
+  }
+}
+
 function render(){
   if(!state.visible){el.dataset.hidden="";return}
   delete el.dataset.hidden;
-  root.render(createElement(AtlasChat,{apiUrl,apiKey:state.apiKey||void 0,theme:state.theme}));
+  root.render(createElement(EB,null,createElement(AtlasChat,{apiUrl,apiKey:state.apiKey||void 0,theme:state.theme})));
 }
 
 window.addEventListener("message",e=>{
+  if(e.source!==window.parent)return;
   const d=e.data;
   if(!d||typeof d!=="object"||typeof d.type!=="string")return;
   switch(d.type){
     case"theme":
-      if(d.value==="light"||d.value==="dark"){state={...state,theme:d.value};setTheme(d.value);render()}
+      if(d.value!=="light"&&d.value!=="dark"){console.warn("[Atlas Widget] Invalid theme:",d.value);break}
+      state={...state,theme:d.value};setTheme(d.value);render();
       break;
     case"auth":
-      if(typeof d.token==="string"){state={...state,apiKey:d.token};render()}
+      if(typeof d.token!=="string"){console.warn("[Atlas Widget] Invalid auth: token must be string");break}
+      state={...state,apiKey:d.token};render();
       break;
     case"toggle":
       state={...state,visible:!state.visible};render();
@@ -86,6 +136,13 @@ window.addEventListener("message",e=>{
 });
 
 render();
+window.parent.postMessage({type:"atlas:ready"},"*");
+}catch(err){
+console.error("[Atlas Widget] Failed to load:",err);
+const el=document.getElementById("atlas-widget");
+if(el)el.innerHTML='<div style="padding:2rem;text-align:center;color:#888;font-family:system-ui"><p>Unable to load Atlas Chat.</p><p style="font-size:0.875rem;margin-top:0.5rem">Check your network connection or try refreshing.</p></div>';
+try{window.parent.postMessage({type:"atlas:error",code:"LOAD_FAILED",message:String(err.message||err)},"*")}catch(x){}
+}
 </script>
 </body>
 </html>`;
@@ -97,13 +154,14 @@ widget.get("/", (c) => {
   const rawPosition = c.req.query("position") ?? "inline";
 
   const theme = VALID_THEMES.has(rawTheme) ? rawTheme : "system";
+  const apiUrl = sanitizeApiUrl(rawApiUrl);
   const position = VALID_POSITIONS.has(rawPosition) ? rawPosition : "inline";
 
   // Allow embedding as iframe from any origin
   c.header("Content-Security-Policy", "frame-ancestors *");
   c.header("Access-Control-Allow-Origin", "*");
 
-  return c.html(buildWidgetHTML({ theme, apiUrl: rawApiUrl, position }));
+  return c.html(buildWidgetHTML({ theme, apiUrl, position }));
 });
 
 export { widget };


### PR DESCRIPTION
## Summary

Closes #227

- Add `GET /widget` route on the Hono API that serves a self-contained HTML page for iframe embedding
- Page renders `@useatlas/react` `AtlasChat` via CDN (esm.sh for React/component, Tailwind CSS CDN for utility classes)
- CSP `frame-ancestors *` + CORS headers for cross-origin iframe usage
- Query params: `theme` (light/dark/system), `apiUrl` (API base URL), `position` (bottomRight/bottomLeft/inline) with validation and safe defaults
- `postMessage` listener for parent-to-iframe communication:
  - `{ type: "theme", value: "dark" | "light" }` — theme changes
  - `{ type: "auth", token: string }` — auth token injection
  - `{ type: "toggle" }` — open/close control
- XSS prevention: config JSON escapes `<` as `\u003c`, query params are validated against allowlists
- Inline CSS with design tokens from `@useatlas/react/styles.css` (no external stylesheet requests)
- Theme init script prevents dark-mode flash on load

## Test plan

- [x] 15 tests covering response status, content-type, CSP headers, CORS headers, query param handling, invalid param fallbacks, XSS prevention, HTML content validation
- [ ] Manual: load `/widget` in browser, verify HTML renders
- [ ] Manual: embed in iframe from a different origin, verify CSP allows it
- [ ] Manual: send postMessage events from parent, verify theme/auth/toggle work
- [ ] Integration with script tag loader (#236) once implemented