### PR TITLE
docs: quick start overhaul with verification checkpoints

### DIFF
--- a/apps/docs/content/docs/getting-started/quick-start.mdx
+++ b/apps/docs/content/docs/getting-started/quick-start.mdx
@@ -14,7 +14,7 @@ Before you start, make sure you have:
 
 - **[Bun](https://bun.sh/) v1.3.10+** — check with `bun --version`
 - **[Docker](https://docs.docker.com/get-docker/)** — check with `docker --version` (Docker Desktop must be running)
-- **An LLM API key** — [Anthropic](https://console.anthropic.com/), [OpenAI](https://platform.openai.com/), or another [supported provider](/reference/config#llm-providers)
+- **An LLM API key** — [Anthropic](https://console.anthropic.com/), [OpenAI](https://platform.openai.com/), or another [supported provider](/reference/environment-variables#llm-provider)
 
 <Accordions>
 <Accordion title="Don't have Bun installed?">
@@ -37,6 +37,12 @@ git clone https://github.com/AtlasDevHQ/atlas.git
 cd atlas
 bun install
 ```
+
+<Accordions>
+<Accordion title="Starting a new project instead of cloning?">
+Use `bun create @useatlas my-app` for interactive setup with template selection, DB config, and provider setup — no need to clone the monorepo.
+</Accordion>
+</Accordions>
 </Step>
 
 <Step>
@@ -47,8 +53,10 @@ bun run db:up
 ```
 
 This launches two Docker containers:
-- **Postgres** with the demo dataset pre-seeded
+- **Postgres** with the simple demo dataset pre-seeded (3 tables, ~330 rows)
 - **Sandbox sidecar** for isolated code execution
+
+For a larger, production-like dataset, see [Demo Datasets](/getting-started/demo-datasets) (`--demo cybersec` or `--demo ecommerce`).
 
 <Callout type="info" title="You should see">
 ```
@@ -57,7 +65,7 @@ This launches two Docker containers:
  ✔ Container atlas-sandbox-1   Started
 ```
 
-Verify with `docker compose ps` — both containers should show "running".
+Verify with `docker compose ps` — both containers should show status `Up` or `running`.
 </Callout>
 
 <Accordions>
@@ -65,7 +73,7 @@ Verify with `docker compose ps` — both containers should show "running".
 Make sure Docker Desktop is running. On Linux, check the daemon with `systemctl status docker`. The `db:up` command requires Docker Compose.
 </Accordion>
 <Accordion title="Port 5432 already in use?">
-Another Postgres instance is using port 5432. Stop it with `docker stop <container>` or change the port in `docker-compose.yml`.
+Another Postgres instance is using port 5432. Stop it with `docker stop <container>`, or if it's a local install, stop the service (`brew services stop postgresql` on macOS, `sudo systemctl stop postgresql` on Linux).
 </Accordion>
 </Accordions>
 </Step>
@@ -79,7 +87,7 @@ cp .env.example .env
 
 Edit `.env` and set your LLM provider. The database URLs are pre-configured for the local Docker setup — you only need to add your API key:
 
-<Tabs items={["Anthropic", "OpenAI", "Other"]}>
+<Tabs items={["Anthropic", "OpenAI", "Bedrock / Ollama / Gateway"]}>
 <Tab value="Anthropic">
 ```bash
 ATLAS_PROVIDER=anthropic
@@ -92,15 +100,22 @@ ATLAS_PROVIDER=openai
 OPENAI_API_KEY=sk-...
 ```
 </Tab>
-<Tab value="Other">
+<Tab value="Bedrock / Ollama / Gateway">
 ```bash
-# See the full provider list in .env.example
-# Examples: google, bedrock, azure, groq, mistral
-ATLAS_PROVIDER=google
-GOOGLE_GENERATIVE_AI_API_KEY=...
+# AWS Bedrock
+ATLAS_PROVIDER=bedrock
+AWS_REGION=us-east-1
+
+# Local Ollama
+ATLAS_PROVIDER=ollama
+OLLAMA_BASE_URL=http://localhost:11434
+
+# AI Gateway (LiteLLM, Portkey, etc.)
+ATLAS_PROVIDER=gateway
+AI_GATEWAY_API_KEY=...
 ```
 
-See [Configuration Reference — LLM Providers](/reference/config#llm-providers) for all supported providers and their required environment variables.
+See [Environment Variables — LLM Provider](/reference/environment-variables#llm-provider) for all supported providers and their required variables.
 </Tab>
 </Tabs>
 </Step>
@@ -108,7 +123,7 @@ See [Configuration Reference — LLM Providers](/reference/config#llm-providers)
 <Step>
 ### Generate the semantic layer
 
-The semantic layer tells the agent what tables exist and what they mean. Generate it from the demo database:
+The semantic layer (a set of YAML entity files in `semantic/`) tells the agent what tables exist and what they mean. Generate it from the demo database:
 
 ```bash
 bun run atlas -- init
@@ -116,14 +131,16 @@ bun run atlas -- init
 
 <Callout type="info" title="You should see">
 ```
-Profiling atlas_demo...
-  ✔ companies (6 columns, 50 rows)
-  ✔ departments (5 columns, 12 rows)
-  ✔ employees (8 columns, 200 rows)
-Generated 3 entity files in semantic/entities/
+Profiling postgres database...
+
+  [1/3] Profiling companies...
+  [2/3] Profiling people...
+  [3/3] Profiling accounts...
+
+Done! Semantic layer for "default" is at ./semantic/
 ```
 
-Check the files: `ls semantic/entities/` should list `.yml` files for each table.
+Check the files: `ls semantic/entities/` should list `companies.yml`, `people.yml`, and `accounts.yml`.
 </Callout>
 
 <Accordions>
@@ -131,7 +148,7 @@ Check the files: `ls semantic/entities/` should list `.yml` files for each table
 Verify the containers are running (`docker compose ps`). If you see `ECONNREFUSED`, the Postgres container may still be starting — wait a few seconds and retry. Run `bun run atlas -- doctor` for a full diagnostic.
 </Accordion>
 <Accordion title="init fails with missing API key?">
-The `init` command profiles your database — it does not require an API key. If you see an API key error, check that `.env` exists and `ATLAS_DATASOURCE_URL` is set. For the local Docker setup, `.env.example` has the correct value pre-filled.
+Database profiling does not require an API key. If you see an API key error, it may be from optional LLM enrichment — run `bun run atlas -- init --no-enrich` to skip it. Also check that `.env` exists and `ATLAS_DATASOURCE_URL` is set (`.env.example` has the correct value pre-filled for local Docker).
 </Accordion>
 </Accordions>
 </Step>
@@ -168,8 +185,8 @@ Another dev server is using the port. Find it with `lsof -i :3000` (or `:3001`),
 The chat UI shows suggested questions based on the demo dataset. Try one:
 
 - "How many companies are there by industry?"
-- "What is the average revenue across all companies?"
-- "Which departments have the most people?"
+- "What are the top 5 companies by revenue?"
+- "Which department has the most people?"
 
 <Callout type="info" title="You should see">
 The agent will:
@@ -193,7 +210,7 @@ You're up and running. The agent can answer questions about the demo dataset usi
 | `bun run db:down` | Stop containers |
 | `bun run db:reset` | Nuke volume and re-seed from scratch |
 | `bun run atlas -- doctor` | Validate environment and connectivity |
-| `bun run atlas -- validate` | Check semantic layer YAMLs for errors |
+| `bun run atlas -- validate` | Check semantic layer YAMLs for errors (offline, no DB needed) |
 | `bun run atlas -- diff` | Compare DB schema against semantic layer |
 
 See [CLI Reference](/reference/cli) for all commands and flags.
@@ -204,5 +221,6 @@ See [CLI Reference](/reference/cli) for all commands and flags.
 - **[Deploy to production](/deployment/deploy)** — Railway, Vercel, or Docker
 - **[Set up authentication](/deployment/authentication)** — API key, managed auth, or bring-your-own-token
 - **[Embed in your app](/guides/embedding-widget)** — add Atlas as a chat widget in any web app
+- **[Integrate with Slack](/guides/slack)** — query data from Slack channels
 - **[Use as MCP server](/guides/mcp)** — connect Atlas to Claude Desktop or Cursor
 - **[Troubleshooting](/guides/troubleshooting)** — full error reference and debug logging


### PR DESCRIPTION
## Summary

- Restructures the quick start page using Fumadocs `<Steps>`, `<Tabs>`, `<Accordion>` components
- Adds **"You should see"** verification checkpoints after every major step (db:up, init, dev, first query)
- Adds **per-step troubleshooting** in collapsible accordions (Docker not running, port conflicts, connection errors, missing API key)
- Adds **tabbed provider selection** (Anthropic / OpenAI / Other) instead of a single hardcoded example
- Adds **expandable prerequisite help** (Bun install instructions)
- Moves corner cases to dedicated pages: "Using your own database" → Connect Your Data, advanced CLI flags → CLI Reference
- Trims the commands table to essentials, adds widget embedding to Next Steps

Closes #277

## Test plan

- [ ] `bun run build` in `apps/docs/` succeeds (verified locally — all 346 pages generated)
- [ ] Quick start page renders correctly with Steps, Tabs, Accordion components
- [ ] All internal links resolve (`/reference/config#llm-providers`, `/getting-started/connect-your-data`, etc.)
- [ ] Verification checkpoints are clear and match actual CLI output
- [ ] Troubleshooting accordions expand/collapse correctly
- [ ] Provider tabs switch between Anthropic/OpenAI/Other