### PR TITLE
docs: config & environment variables reference

### DIFF
--- a/apps/docs/content/docs/reference/config.mdx
+++ b/apps/docs/content/docs/reference/config.mdx
@@ -6,7 +6,7 @@ description: Declarative configuration with atlas.config.ts for multi-datasource
 import { Callout } from "fumadocs-ui/components/callout";
 import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 
-Atlas can be configured via environment variables (see [Environment Variables](/reference/environment-variables)) or a declarative `atlas.config.ts` file. When both are present, the config file takes precedence for datasource, auth, and tool configuration. Environment variables still work as fallbacks.
+Atlas can be configured via environment variables (see [Environment Variables](/reference/environment-variables)) or a declarative `atlas.config.ts` file. For multi-datasource setups, plugins, RLS, or actions, use the config file. For simple single-datasource deployments, env vars alone are sufficient.
 
 ## File Location
 
@@ -29,11 +29,15 @@ Run [`atlas validate`](/reference/cli#validate) to check your config file and se
 
 ## Precedence
 
-When both a config file and environment variables are present:
+Config loading is **binary**: when a config file exists, it is used exclusively. Env vars like `ATLAS_DATASOURCE_URL` are **not** merged in. When no config file exists, all configuration comes from environment variables.
 
-1. **Config file wins** for `datasources`, `tools`, `auth`, `semanticLayer`, `plugins`, `actions`, `rls`, and `scheduler`
-2. **Environment variables** are used as fallbacks when the config file doesn't define a field
-3. **Secrets should stay in env vars** — reference them via `process.env` in the config file
+1. **Config file found** → parsed and validated via Zod. Fields omitted from the config file get Zod schema defaults (e.g. `auth: "auto"`, `semanticLayer: "./semantic"`), not env var values
+2. **No config file** → all configuration comes from environment variables
+3. **Secrets should stay in env vars** — reference them via `process.env` in the config file (this is user code executing at import time, not a config-loader merge)
+
+<Callout type="info">
+Auth mode is always determined by environment variables (`ATLAS_AUTH_MODE` or auto-detection). The `auth` field in the config file is stored but not yet wired to the auth detection pipeline. See [Authentication](/deployment/authentication) for how auth mode is resolved.
+</Callout>
 
 ```typescript
 // atlas.config.ts — secrets from env, structure in config
@@ -95,7 +99,7 @@ export default defineConfig({
     default: {
       // Connection string from env var
       url: process.env.ATLAS_DATASOURCE_URL!,
-      // PostgreSQL schema (default: public)
+      // PostgreSQL schema (omit for default search_path)
       schema: "public",
       // Shown in the agent system prompt
       description: "Primary PostgreSQL database",
@@ -158,7 +162,7 @@ export default defineConfig({
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `url` | `string` | Yes | — | Connection string (`postgresql://`, `mysql://`, or plugin schemes) |
-| `schema` | `string` | No | `"public"` | PostgreSQL schema name (sets `search_path`). Ignored for MySQL and plugins |
+| `schema` | `string` | No | — | PostgreSQL schema name (sets `search_path`). When omitted, PostgreSQL's default `search_path` applies (typically `public`). Ignored for MySQL and plugins |
 | `description` | `string` | No | — | Human-readable label shown in the agent system prompt |
 | `maxConnections` | `number` | No | — | Connection pool size for this datasource |
 | `idleTimeoutMs` | `number` | No | — | Idle connection timeout in milliseconds |
@@ -511,4 +515,4 @@ export default defineConfig({
 | `plugins` | `unknown[]` | — | Plugin instances to register at boot |
 | `actions` | `ActionsConfig` | — | Action framework configuration |
 | `rls` | `RLSConfig` | — | Row-Level Security policies |
-| `scheduler` | `SchedulerConfig` | — | Scheduled task configuration |
+| `scheduler` | `object` | — | Scheduled task configuration ([details](#scheduler)) |

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -6,15 +6,15 @@ description: Complete reference for all Atlas environment variables with default
 import { Callout } from "fumadocs-ui/components/callout";
 import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 
-All Atlas configuration is via environment variables. Most have safe defaults — a minimal deployment needs only an LLM provider key and a datasource URL.
+Atlas can be configured entirely via environment variables. Most have safe defaults — a minimal deployment needs only an LLM provider key and a datasource URL. For multi-datasource setups or advanced configuration, see the [Configuration reference](/reference/config).
 
 ## Precedence
 
-When both `atlas.config.ts` and environment variables are present:
+Config loading is **binary** — when `atlas.config.ts` exists, it is used exclusively for structure. Env vars like `ATLAS_DATASOURCE_URL` are not merged in as fallbacks. Fields omitted from the config file get Zod schema defaults, not env var values.
 
-1. **Config file wins** for `datasources`, `tools`, `auth`, `semanticLayer`, `plugins`, `actions`, `rls`, and `scheduler`
-2. **Env vars are fallbacks** — used when the config file doesn't define a field
-3. **Some vars are env-only** — secrets (`ANTHROPIC_API_KEY`, `BETTER_AUTH_SECRET`), runtime hints (`ATLAS_RUNTIME`), and networking (`PORT`, `ATLAS_CORS_ORIGIN`) are always read from environment variables
+1. **Config file found** → all structural config (`datasources`, `tools`, `semanticLayer`, `plugins`, `actions`, `rls`, `scheduler`) comes from the file
+2. **No config file** → all configuration comes from environment variables
+3. **Some vars are always env-only** — secrets (`ANTHROPIC_API_KEY`, `BETTER_AUTH_SECRET`), auth mode (`ATLAS_AUTH_MODE`), runtime hints (`ATLAS_RUNTIME`), and networking (`PORT`, `ATLAS_CORS_ORIGIN`) are always read from environment variables regardless of config file presence
 
 See the [Configuration reference](/reference/config) for the full `atlas.config.ts` guide.
 
@@ -336,8 +336,8 @@ Action framework settings. These can also be configured via [`atlas.config.ts`](
 |----------|---------|-------------|
 | `ATLAS_ACTIONS_ENABLED` | — | Set `true` to enable the action framework (approval-gated write operations) |
 | `ATLAS_ACTION_APPROVAL` | `manual` | Default approval mode for actions: `auto`, `manual`, or `admin-only` |
-| `ATLAS_ACTION_TIMEOUT` | `30000` | Per-action execution timeout in milliseconds |
-| `ATLAS_ACTION_MAX_PER_CONVERSATION` | `10` | Maximum number of actions allowed per conversation |
+| `ATLAS_ACTION_TIMEOUT` | — | Per-action execution timeout in milliseconds |
+| `ATLAS_ACTION_MAX_PER_CONVERSATION` | — | Maximum number of actions allowed per conversation |
 | `ATLAS_EMAIL_ALLOWED_DOMAINS` | — | Comma-separated list of allowed email recipient domains for the email action plugin. When unset, all domains are allowed |
 
 ```bash


### PR DESCRIPTION
## Summary
- **Config reference**: added file location context, `atlas validate` cross-link, per-datasource semantic layer path example, Fumadocs Tabs for multi-config examples, precedence rules, connection pool + scheduler sections, complete options summary table
- **Environment variables**: reorganized with inline examples per category using Tabs (Provider, Database, Security, Auth, RLS, Sandbox, Networking, Actions, Scheduler), documented config-vs-env precedence, added security Callouts, cross-linked to relevant guide pages

Closes #288

## Test plan
- [ ] `bun run lint` — passes
- [ ] `bun run type` — passes
- [ ] `bun run test` — passes
- [ ] `bun x syncpack lint` — no issues
- [ ] Template drift check — passes
- [ ] Verify config.mdx renders correctly in Fumadocs (Tabs, Callouts, tables)
- [ ] Verify environment-variables.mdx renders correctly (Tabs, Callouts, tables)
- [ ] Cross-links resolve to correct pages (CLI validate, authentication, RLS, actions, sandbox, observability, scheduled tasks, Slack, Python)