### PR TITLE
docs: add demo dataset comparison to CLI prompt and docs

### DIFF
--- a/apps/docs/content/docs/getting-started/demo-datasets.mdx
+++ b/apps/docs/content/docs/getting-started/demo-datasets.mdx
@@ -3,21 +3,30 @@ title: Demo Datasets
 description: Pre-built demo datasets for evaluation and development.
 ---
 
-Atlas ships with three demo datasets for evaluation and development.
+Atlas ships with three demo datasets for evaluation and development. Each targets a different use case — pick the one that matches your goal.
 
 ## Quick Comparison
 
 | | Simple | Cybersec | E-commerce |
 |---|---|---|---|
+| Company | — | Sentinel Security | NovaMart |
+| Domain | CRM (companies, people, accounts) | B2B cybersecurity SaaS | DTC home goods brand + marketplace |
 | Tables | 3 | 62 | 52 |
 | Rows | ~330 | ~500K | ~480K |
 | Database | Postgres only | Postgres only | Postgres only |
 | Tech debt patterns | None | 4 patterns | 4 patterns |
+| Schema evolution | No | No | 5 instances (old + new columns coexist) |
 | Best for | Quick start, tutorials | Realistic evaluation, profiler testing | Universally understood domain, production-scale evaluation |
+| Load time | ~5 seconds | ~30 seconds | ~30 seconds |
+| CLI flag | `--demo` or `--demo simple` | `--demo cybersec` | `--demo ecommerce` |
 
-**Use Simple** when you want a fast setup.
-**Use Cybersec** when you want to see how Atlas handles a real-world B2B SaaS database with messy data.
-**Use E-commerce** when you want a universally understood domain (orders, products, customers) at production scale.
+### Which dataset should I choose?
+
+**Use Simple** when you want a fast setup — three clean tables, no ambiguity, perfect for tutorials and first-run evaluation.
+
+**Use Cybersec** when you want to see how Atlas handles a real-world B2B SaaS database with messy data. Includes missing FK constraints, abandoned tables, inconsistent enums, and denormalized reporting tables. Good for testing the profiler and evaluating agent reasoning on complex schemas.
+
+**Use E-commerce** when you want a universally understood domain (orders, products, customers) at production scale. Includes the same four tech debt patterns as cybersec, plus five schema evolution artifacts where old and new columns coexist. Good for demos to non-technical stakeholders who already understand retail data.
 
 ---
 

--- a/create-atlas/index.ts
+++ b/create-atlas/index.ts
@@ -653,6 +653,14 @@ async function main() {
     });
 
     if (loadDemo) {
+      p.note(
+        [
+          `${pc.bold("Simple")}       3 tables, ~330 rows     Quick evaluation, tutorials`,
+          `${pc.bold("Cybersec")}     62 tables, ~500K rows   B2B SaaS with tech debt patterns`,
+          `${pc.bold("E-commerce")}   52 tables, ~480K rows   DTC brand + marketplace`,
+        ].join("\n"),
+        "Available demo datasets"
+      );
       demoDataset = await selectOrDefault({
         label: "Demo dataset",
         message: "Which demo dataset?",


### PR DESCRIPTION
## Summary
- **CLI prompt**: Show a comparison note (table counts, row counts, use case) before the dataset selection in `create-atlas` so users can make an informed choice without reading external docs
- **Docs**: Enhance `demo-datasets.mdx` comparison table with domain descriptions, schema evolution info, load times, CLI flags, and expanded "which should I choose?" guidance

## Test plan
- [ ] Run `bun create atlas-agent --demo` and verify the comparison note renders before the select prompt
- [ ] Run `bun create atlas-agent --demo cybersec -y` and verify non-interactive mode still skips the note
- [ ] Verify docs page renders correctly with the expanded table
- [ ] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` passes

Closes #278