### PR TITLE
feat(cli): add progress spinner with ETA to atlas init

### DIFF
--- a/packages/cli/bin/atlas.ts
+++ b/packages/cli/bin/atlas.ts
@@ -578,7 +578,7 @@ export async function profilePostgres(
 
   await pool.end();
 
-  if (errors.length > 0) {
+  if (errors.length > 0 && !progress) {
     console.log(`\nWarning: ${errors.length} table(s)/view(s) failed to profile:`);
     for (const e of errors) {
       console.log(`  - ${e.table}: ${e.error}`);
@@ -808,7 +808,7 @@ export async function profileMySQL(
     });
   }
 
-  if (errors.length > 0) {
+  if (errors.length > 0 && !progress) {
     console.log(`\nWarning: ${errors.length} table(s)/view(s) failed to profile:`);
     for (const e of errors) {
       console.log(`  - ${e.table}: ${e.error}`);
@@ -1060,7 +1060,7 @@ export async function profileClickHouse(
     });
   }
 
-  if (errors.length > 0) {
+  if (errors.length > 0 && !progress) {
     console.log(`\nWarning: ${errors.length} table(s)/view(s) failed to profile:`);
     for (const e of errors) {
       console.log(`  - ${e.table}: ${e.error}`);
@@ -1407,7 +1407,7 @@ export async function profileSnowflake(
     }
   }
 
-  if (errors.length > 0) {
+  if (errors.length > 0 && !progress) {
     console.log(`\nWarning: ${errors.length} table(s)/view(s) failed to profile:`);
     for (const e of errors) {
       console.log(`  - ${e.table}: ${e.error}`);
@@ -1599,7 +1599,7 @@ export async function profileSalesforce(
     await source.close();
   }
 
-  if (errors.length > 0) {
+  if (errors.length > 0 && !progress) {
     console.log(`\nWarning: ${errors.length} object(s) failed to profile:`);
     for (const e of errors) {
       console.log(`  - ${e.table}: ${e.error}`);
@@ -4415,7 +4415,7 @@ async function profileDatasource(opts: ProfileDatasourceOpts): Promise<void> {
   }
 
   const profilingElapsed = Date.now() - profilingStart;
-  progress.onComplete(profiles.length, 0, profilingElapsed);
+  progress.onComplete(profiles.length, profilingElapsed);
 
   if (profiles.length === 0) {
     throw new Error("No tables or views were successfully profiled. Check the warnings above and verify your database permissions.");
@@ -4895,7 +4895,10 @@ async function main() {
     console.log("Profiling DuckDB tables...\n");
     const duckFilterTables = filterTables ?? tableNames;
     const duckProgress = createProgressTracker();
+    const duckStart = Date.now();
     const profiles = await profileDuckDB(dbPath, duckFilterTables, undefined, duckProgress);
+    duckProgress.onComplete(profiles.length, Date.now() - duckStart);
+
 
     if (profiles.length === 0) {
       console.error("\nError: No tables were successfully profiled.");

--- a/packages/cli/src/__tests__/progress.test.ts
+++ b/packages/cli/src/__tests__/progress.test.ts
@@ -27,6 +27,10 @@ describe("formatDuration", () => {
 });
 
 describe("estimateRemaining", () => {
+  test("returns 0 when total is 0", () => {
+    expect(estimateRemaining(5000, 0, 0)).toBe(0);
+  });
+
   test("returns 0 when no items completed", () => {
     expect(estimateRemaining(5000, 0, 10)).toBe(0);
   });

--- a/packages/cli/src/progress.ts
+++ b/packages/cli/src/progress.ts
@@ -16,7 +16,7 @@ export interface ProfileProgressCallbacks {
   onTableStart(name: string, index: number, total: number): void;
   onTableDone(name: string, index: number, total: number): void;
   onTableError(name: string, error: string, index: number, total: number): void;
-  onComplete(succeeded: number, failed: number, elapsedMs: number): void;
+  onComplete(succeeded: number, elapsedMs: number): void;
 }
 
 // ---------------------------------------------------------------------------
@@ -32,7 +32,7 @@ export function formatDuration(ms: number): string {
   return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
 }
 
-/** Estimate remaining time based on elapsed and completed count. Returns ms. */
+/** Estimate remaining time given elapsed time, items completed, and total items. Returns ms. */
 export function estimateRemaining(elapsedMs: number, completed: number, total: number): number {
   if (completed <= 0 || completed >= total) return 0;
   const perItem = elapsedMs / completed;
@@ -48,11 +48,13 @@ const ETA_INTERVAL = 5; // Show ETA every N tables
 export function createProgressTracker(): ProfileProgressCallbacks {
   const isTTY = process.stderr.isTTY ?? false;
   let startTime = 0;
+  let errorCount = 0;
   let spinner: ReturnType<typeof p.spinner> | undefined;
 
   return {
     onStart(total: number) {
       startTime = Date.now();
+      errorCount = 0;
 
       if (isTTY) {
         process.stderr.write(`\n${pc.cyan(`Found ${total} table${total !== 1 ? "s" : ""} to profile`)}\n\n`);
@@ -89,18 +91,26 @@ export function createProgressTracker(): ProfileProgressCallbacks {
     },
 
     onTableError(name: string, error: string, _index: number, _total: number) {
+      errorCount++;
       if (isTTY && spinner) {
-        // Temporarily stop spinner to print warning, then restart
-        spinner.stop(pc.yellow(`  Warning: Failed to profile ${name}: ${error}`));
-        spinner = p.spinner();
-        spinner.start("Continuing...");
+        try {
+          // Temporarily stop spinner to print warning, then restart
+          spinner.stop(pc.yellow(`  Warning: Failed to profile ${name}: ${error}`));
+          spinner = p.spinner();
+          spinner.start("Continuing...");
+        } catch {
+          // Terminal IO failed — fall back to plain write
+          spinner = undefined;
+          process.stderr.write(`  Warning: Failed to profile ${name}: ${error}\n`);
+        }
       } else {
         process.stderr.write(`  ${pc.yellow(`Warning: Failed to profile ${name}: ${error}`)}\n`);
       }
     },
 
-    onComplete(succeeded: number, _failed: number, elapsedMs: number) {
-      const summary = `Profiled ${succeeded} table${succeeded !== 1 ? "s" : ""} in ${formatDuration(elapsedMs)}`;
+    onComplete(succeeded: number, elapsedMs: number) {
+      const failPart = errorCount > 0 ? `, ${errorCount} failed` : "";
+      const summary = `Profiled ${succeeded} table${succeeded !== 1 ? "s" : ""} in ${formatDuration(elapsedMs)}${failPart}`;
       if (isTTY && spinner) {
         spinner.stop(pc.green(summary));
       } else {


### PR DESCRIPTION
## Summary
- Add a progress spinner to `atlas init` showing table count, current table, elapsed time, and ETA (updated every 5 tables)
- New `packages/cli/src/progress.ts` module with `createProgressTracker()` factory — uses `@clack/prompts` spinner in TTY mode, falls back to simple stderr line output in non-TTY
- All 6 profiler functions (Postgres, MySQL, ClickHouse, Snowflake, DuckDB, Salesforce) wired up via optional `ProfileProgressCallbacks` parameter — existing behavior preserved when no progress tracker is passed
- Completion summary: "Profiled N tables in Xs" with timing in final output

## Test plan
- [x] Unit tests for `formatDuration` and `estimateRemaining` (10 tests, edge cases: 0 tables, sub-minute, multi-minute, near-completion)
- [x] CI gates: lint, type, test, syncpack, template drift — all pass
- [ ] Manual: `atlas init --demo` with TTY — verify spinner renders with progress and ETA
- [ ] Manual: `atlas init --demo | cat` — verify non-TTY fallback (plain lines to stderr)

Closes #343