### PR TITLE
feat: pattern-matched errors + request ID wrapping

### DIFF
--- a/apps/docs/content/docs/reference/sdk.mdx
+++ b/apps/docs/content/docs/reference/sdk.mdx
@@ -439,8 +439,8 @@ try {
 | `invalid_response` | — | Response could not be parsed |
 | `unknown_error` | — | Unrecognized error |
 
-All error responses include a `requestId` field (8-character prefix of a UUID) for correlating
-client errors with server logs. Quote this value when reporting issues.
+All error responses include a `requestId` field (UUID) for correlating client errors with
+server logs. Quote this value when reporting issues.
 
 ### Handling Specific Error Codes
 

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -383,19 +383,28 @@ chat.post("/", async (c) => {
         }
 
         // --- Pattern-matched errors (non-APICallError exceptions) ---
+        // In the chat route, errors from runAgent are typically provider-related,
+        // so we override matchError's generic messages with provider-appropriate ones.
 
         const matched = matchError(err);
         if (matched) {
-          // In the chat route context, connection/DNS errors are provider-related
-          const code = (matched.code === "internal_error" && /ECONNREFUSED|ENOTFOUND|fetch failed/i.test(message))
+          const isConnectionError = /ECONNREFUSED|ENOTFOUND|fetch failed/i.test(message);
+          const code = (matched.code === "internal_error" && isConnectionError)
             ? "provider_unreachable" as const
+            : matched.code === "provider_unreachable" ? "provider_unreachable" as const
             : matched.code;
           const httpStatus = code === "provider_unreachable" ? 503
             : code === "provider_timeout" ? 504
             : 500;
+          // Use provider-appropriate messages instead of database-oriented matchError defaults
+          const userMessage = code === "provider_unreachable"
+            ? "Could not reach the LLM provider. Check your network connection and provider status."
+            : code === "provider_timeout"
+              ? "The request timed out. The LLM provider took too long to respond. Try again, or if using a local model, ensure it has sufficient resources."
+              : matched.message;
           log.error({ err: errObj, category: code }, "Matched error: %s", code);
           return c.json(
-            { error: code, message: matched.message, requestId },
+            { error: code, message: userMessage, requestId },
             httpStatus as 500,
           );
         }

--- a/packages/api/src/lib/__tests__/startup-first-run.test.ts
+++ b/packages/api/src/lib/__tests__/startup-first-run.test.ts
@@ -271,6 +271,7 @@ describe("first-run: database unreachable", () => {
     const errors = await validateEnvironment();
     const err = errors.find((e) => e.code === "DB_UNREACHABLE");
     expect(err).toBeDefined();
+    expect(err!.message).toContain("***@mysql.example.com:3306");
     expect(err!.message).toContain("Database unreachable");
     expect(err!.message).not.toContain("p4ssw0rd");
     expect(err!.message).not.toContain("admin:p4ssw0rd");

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -508,6 +508,8 @@ export class ConnectionRegistry {
       return result;
     } catch (err) {
       const latencyMs = Math.round(performance.now() - start);
+      const rawMessage = err instanceof Error ? err.message : String(err);
+      log.warn({ err: err instanceof Error ? err : new Error(rawMessage), connectionId: id, latencyMs }, "Health check failed");
       entry.consecutiveFailures++;
       if (entry.firstFailureAt === null) {
         entry.firstFailureAt = Date.now();
@@ -525,7 +527,7 @@ export class ConnectionRegistry {
       const result: HealthCheckResult = {
         status,
         latencyMs,
-        message: matched?.message ?? (err instanceof Error ? err.message : String(err)),
+        message: matched?.message ?? rawMessage,
         checkedAt: new Date(),
       };
       entry.lastHealth = result;

--- a/packages/api/src/lib/startup.ts
+++ b/packages/api/src/lib/startup.ts
@@ -186,16 +186,17 @@ export async function validateEnvironment(): Promise<DiagnosticError[]> {
           const detail = err instanceof Error ? err.message : "";
           log.error({ err: detail }, "MySQL connection check failed");
 
+          const maskedUrl = maskConnectionUrl(resolvedDatasourceUrl);
           const matched = matchError(err);
           let message: string;
           if (matched) {
-            message = matched.message;
+            message = `Cannot connect to ${maskedUrl}. ${matched.message}`;
           } else if (/Access denied/i.test(detail) || /ER_ACCESS_DENIED/i.test(detail)) {
-            message = `Cannot connect to ${maskConnectionUrl(resolvedDatasourceUrl)}. Authentication failed — check your username and password.`;
+            message = `Cannot connect to ${maskedUrl}. Authentication failed — check your username and password.`;
           } else if (/ER_BAD_DB_ERROR/i.test(detail)) {
-            message = `Cannot connect to ${maskConnectionUrl(resolvedDatasourceUrl)}. The specified database does not exist.`;
+            message = `Cannot connect to ${maskedUrl}. The specified database does not exist.`;
           } else {
-            message = `Cannot connect to ${maskConnectionUrl(resolvedDatasourceUrl)}. Check the connection string and ensure the database is running.`;
+            message = `Cannot connect to ${maskedUrl}. Check the connection string and ensure the database is running.`;
           }
 
           errors.push({ code: "DB_UNREACHABLE", message });
@@ -263,14 +264,15 @@ export async function validateEnvironment(): Promise<DiagnosticError[]> {
           const detail = err instanceof Error ? err.message : "";
           log.error({ err: detail }, "DB connection check failed");
 
+          const maskedUrl = maskConnectionUrl(resolvedDatasourceUrl);
           const matched = matchError(err);
           let message: string;
           if (matched) {
-            message = matched.message;
+            message = `Cannot connect to ${maskedUrl}. ${matched.message}`;
           } else if (/authentication/i.test(detail) || /password/i.test(detail)) {
-            message = `Cannot connect to ${maskConnectionUrl(resolvedDatasourceUrl)}. Authentication failed — check your username and password.`;
+            message = `Cannot connect to ${maskedUrl}. Authentication failed — check your username and password.`;
           } else {
-            message = `Cannot connect to ${maskConnectionUrl(resolvedDatasourceUrl)}. Check the connection string and ensure the database is running.`;
+            message = `Cannot connect to ${maskedUrl}. Check the connection string and ensure the database is running.`;
           }
 
           errors.push({ code: "DB_UNREACHABLE", message });
@@ -313,14 +315,15 @@ export async function validateEnvironment(): Promise<DiagnosticError[]> {
         const detail = err instanceof Error ? err.message : "";
         log.error({ err: detail }, "Internal DB connection check failed");
 
+        const maskedUrl = maskConnectionUrl(process.env.DATABASE_URL!);
         const matched = matchError(err);
         let message: string;
         if (matched) {
-          message = `Internal database: ${matched.message}`;
+          message = `Cannot connect to internal database at ${maskedUrl}. ${matched.message}`;
         } else if (/authentication/i.test(detail) || /password/i.test(detail)) {
-          message = `Cannot connect to the internal database at ${maskConnectionUrl(process.env.DATABASE_URL!)}. Authentication failed — check your username and password.`;
+          message = `Cannot connect to internal database at ${maskedUrl}. Authentication failed — check your username and password.`;
         } else {
-          message = `Cannot connect to the internal database at ${maskConnectionUrl(process.env.DATABASE_URL!)}. Check the connection string and ensure the database is running.`;
+          message = `Cannot connect to internal database at ${maskedUrl}. Check the connection string and ensure the database is running.`;
         }
 
         errors.push({ code: "INTERNAL_DB_UNREACHABLE", message });

--- a/packages/types/src/__tests__/errors.test.ts
+++ b/packages/types/src/__tests__/errors.test.ts
@@ -93,12 +93,18 @@ describe("matchError", () => {
 
   // --- SSL / TLS ---
 
-  test("matches SSL error", () => {
+  test("matches SSL connection error", () => {
     const result = matchError(new Error("SSL connection has been closed unexpectedly")) as MatchedError;
     expect(result).not.toBeNull();
     expect(result.code).toBe("internal_error");
     expect(result.message).toContain("SSL connection failed");
     expect(result.message).toContain("sslmode");
+  });
+
+  test("matches TLS handshake error", () => {
+    const result = matchError(new Error("TLS handshake failed: connection reset")) as MatchedError;
+    expect(result).not.toBeNull();
+    expect(result.message).toContain("SSL connection failed");
   });
 
   test("matches self-signed certificate error", () => {
@@ -113,10 +119,16 @@ describe("matchError", () => {
     expect(result.message).toContain("SSL connection failed");
   });
 
-  test("matches certificate error", () => {
+  test("matches certificate has expired", () => {
     const result = matchError(new Error("certificate has expired")) as MatchedError;
     expect(result).not.toBeNull();
     expect(result.message).toContain("SSL connection failed");
+  });
+
+  test("does NOT match bare 'SSL' or 'certificate' in column names", () => {
+    expect(matchError(new Error('column "ssl_enabled" does not exist'))).toBeNull();
+    expect(matchError(new Error('relation "tls_config" does not exist'))).toBeNull();
+    expect(matchError(new Error('column "certificate_id" is ambiguous'))).toBeNull();
   });
 
   // --- 502 / 503 ---
@@ -135,15 +147,38 @@ describe("matchError", () => {
     expect(result.code).toBe("provider_unreachable");
   });
 
+  test("does NOT match bare 502/503 in unrelated contexts", () => {
+    expect(matchError(new Error("Port 5032 is already in use"))).toBeNull();
+    expect(matchError(new Error("Error at line 503 of query"))).toBeNull();
+    expect(matchError(new Error('column "col503" does not exist'))).toBeNull();
+    expect(matchError(new Error("Row count: 50299"))).toBeNull();
+  });
+
+  // --- fetch failed ---
+
+  test("matches fetch failed", () => {
+    const result = matchError(new Error("TypeError: fetch failed")) as MatchedError;
+    expect(result).not.toBeNull();
+    expect(result.code).toBe("provider_unreachable");
+    expect(result.message).toContain("unreachable");
+  });
+
   // --- No stack traces in messages ---
+
+  test("ECONNREFUSED without trailing host returns unknown host", () => {
+    const result = matchError(new Error("ECONNREFUSED")) as MatchedError;
+    expect(result).not.toBeNull();
+    expect(result.message).toContain("(unknown host)");
+  });
 
   test("no stack traces in any matched message", () => {
     const errors = [
       new Error("connect ECONNREFUSED 127.0.0.1:5432"),
       new Error("getaddrinfo ENOTFOUND bad.host"),
-      new Error("SSL connection refused"),
+      new Error("SSL connection has been closed"),
       new Error("Query read timeout"),
       new Error("502 Bad Gateway"),
+      new Error("TypeError: fetch failed"),
     ];
     for (const err of errors) {
       err.stack = "Error: something\n    at Object.<anonymous> (/app/src/index.ts:42:5)";

--- a/packages/types/src/errors.ts
+++ b/packages/types/src/errors.ts
@@ -42,7 +42,7 @@ export function isChatErrorCode(value: string): value is ChatErrorCode {
  * - `retryAfterSeconds` — Seconds to wait before retrying (rate_limited only).
  *   Clamped to [0, 300].
  * - `code` — The server error code, if the response was valid JSON with a known code.
- * - `requestId` — Server-assigned request ID for log correlation (8-char prefix of a UUID).
+ * - `requestId` — Server-assigned request ID (UUID) for log correlation.
  */
 export interface ChatErrorInfo {
   title: string;
@@ -118,8 +118,8 @@ export function matchError(
     };
   }
 
-  // SSL / TLS errors
-  if (/SSL|TLS|SELF_SIGNED_CERT|UNABLE_TO_VERIFY_LEAF_SIGNATURE|certificate/i.test(msg)) {
+  // SSL / TLS errors — match specific error contexts, not bare keywords
+  if (/SELF_SIGNED_CERT|UNABLE_TO_VERIFY_LEAF_SIGNATURE|ssl\s+connection|tls\s+handshake|certificate\s+(has expired|verify|error|rejected)/i.test(msg)) {
     return {
       code: "internal_error",
       message: "SSL connection failed — check sslmode in your connection string",
@@ -128,18 +128,26 @@ export function matchError(
 
   // Timeout — query or request exceeded the configured limit
   if (/timeout|timed out|AbortError/i.test(msg)) {
-    const seconds = opts?.timeoutSeconds ?? 30;
+    const seconds = Math.max(1, opts?.timeoutSeconds ?? 30);
     return {
       code: "provider_timeout",
       message: `Query exceeded the ${seconds}-second timeout — try a simpler query or increase ATLAS_QUERY_TIMEOUT`,
     };
   }
 
-  // 502 / 503 — upstream provider unavailable
-  if (/502|Bad Gateway|503|Service Unavailable/i.test(msg)) {
+  // 502 / 503 — upstream provider unavailable (word boundaries prevent matching port numbers etc.)
+  if (/\b502\s+Bad Gateway\b|\b503\s+Service Unavailable\b/i.test(msg)) {
     return {
       code: "provider_unreachable",
       message: "AI provider API unavailable — this is usually temporary, retry in a few seconds",
+    };
+  }
+
+  // fetch failed — Node.js/undici connection failure (no ECONNREFUSED detail)
+  if (/fetch failed/i.test(msg)) {
+    return {
+      code: "provider_unreachable",
+      message: "Network request failed — the remote service may be down or unreachable",
     };
   }
 


### PR DESCRIPTION
## Summary

Closes #341, Closes #342

- **`matchError()`** in `@useatlas/types` — pattern-matches ECONNREFUSED, ENOTFOUND, SSL/TLS, timeout, and 502/503 errors into user-safe messages that never expose stack traces or connection strings
- **Request ID** (UUID) attached to every chat error response — full error details logged server-side, only generic message + ref ID reaches the client
- Wired into `chat.ts` (agent stream errors), `startup.ts` (connection tests), and `connection.ts` (health checks)
- `ChatErrorInfo` now includes `requestId` for client-side extraction via `parseChatError()`
- SDK docs updated with `requestId` documentation

## Test plan

- [x] 24 new tests for `matchError()` covering all 5 patterns + no-leak checks + edge cases
- [x] Existing `startup-first-run` tests updated for new message format (27/27 pass)
- [x] All CI gates pass: lint, type, test (140 files), syncpack, template drift