### PR TITLE
fix(cli): close fatal error detection gaps in profilers

### DIFF
--- a/packages/cli/bin/__tests__/fatal-error-propagation.test.ts
+++ b/packages/cli/bin/__tests__/fatal-error-propagation.test.ts
@@ -10,7 +10,7 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
-import { FATAL_ERROR_PATTERN, ingestIntoDuckDB, profileDuckDB } from "../atlas";
+import { FATAL_ERROR_PATTERN, isFatalConnectionError, ingestIntoDuckDB, profileDuckDB } from "../atlas";
 
 describe("FATAL_ERROR_PATTERN", () => {
   const fatalCodes = [
@@ -42,6 +42,66 @@ describe("FATAL_ERROR_PATTERN", () => {
     expect(FATAL_ERROR_PATTERN.test("read ECONNRESET at TLSSocket._recv")).toBe(true);
     expect(FATAL_ERROR_PATTERN.test("connect ECONNREFUSED 127.0.0.1:5432")).toBe(true);
     expect(FATAL_ERROR_PATTERN.test("getaddrinfo ENOTFOUND db.example.com")).toBe(true);
+  });
+
+  it("does not false-positive on table names containing error substrings", () => {
+    // Word boundaries prevent matching partial words like "EPIPE_logs"
+    expect(FATAL_ERROR_PATTERN.test("permission denied for relation EPIPE_logs")).toBe(false);
+    expect(FATAL_ERROR_PATTERN.test("column ETIMEDOUT_counter not found")).toBe(false);
+  });
+});
+
+describe("isFatalConnectionError", () => {
+  it("detects fatal errors via message", () => {
+    expect(isFatalConnectionError(new Error("read ECONNRESET"))).toBe(true);
+    expect(isFatalConnectionError(new Error("connect ECONNREFUSED 127.0.0.1:5432"))).toBe(true);
+  });
+
+  it("detects fatal errors via error.code", () => {
+    const err = new Error("connection lost");
+    (err as NodeJS.ErrnoException).code = "ECONNRESET";
+    expect(isFatalConnectionError(err)).toBe(true);
+  });
+
+  it("detects fatal errors via cause chain", () => {
+    const cause = new Error("read ECONNRESET");
+    const wrapper = new Error("query failed", { cause });
+    expect(isFatalConnectionError(wrapper)).toBe(true);
+  });
+
+  it("detects fatal errors via cause.code", () => {
+    const cause = new Error("socket closed");
+    (cause as NodeJS.ErrnoException).code = "EPIPE";
+    const wrapper = new Error("query failed", { cause });
+    expect(isFatalConnectionError(wrapper)).toBe(true);
+  });
+
+  it("returns false for non-fatal errors", () => {
+    expect(isFatalConnectionError(new Error("permission denied"))).toBe(false);
+    expect(isFatalConnectionError(new Error("syntax error"))).toBe(false);
+  });
+
+  it("handles non-Error values", () => {
+    expect(isFatalConnectionError("ECONNRESET")).toBe(true);
+    expect(isFatalConnectionError("permission denied")).toBe(false);
+    expect(isFatalConnectionError(42)).toBe(false);
+  });
+
+  it("MySQL-specific fatal codes are detected alongside generic ones", () => {
+    // MySQL profiler uses: PROTOCOL_CONNECTION_LOST | ER_SERVER_SHUTDOWN | ...
+    // These are checked separately in the MySQL table-level catch, not via isFatalConnectionError.
+    // But the generic codes still work:
+    const err = new Error("Connection lost: The server closed the connection. ECONNRESET");
+    expect(isFatalConnectionError(err)).toBe(true);
+  });
+
+  it("Snowflake-specific fatal codes are numeric and checked separately", () => {
+    // Snowflake uses 390100 (auth expired), 390114 (auth invalid), 250001 (connection failure)
+    // These are NOT part of FATAL_ERROR_PATTERN — they are checked via /390100|390114|250001/
+    // in the Snowflake table-level catch. Verify they don't accidentally match:
+    expect(isFatalConnectionError(new Error("SQL error 390100: auth token expired"))).toBe(false);
+    // But generic codes still work for Snowflake:
+    expect(isFatalConnectionError(new Error("ECONNREFUSED"))).toBe(true);
   });
 });
 
@@ -91,38 +151,48 @@ describe("DuckDB profiler — error propagation behavior", () => {
 });
 
 describe("column-level catch re-throw contract", () => {
-  it("fatal errors in column profiling propagate to table-level catch", () => {
-    // This test verifies the re-throw contract that column-level catches implement:
-    // when a query throws a fatal error, the catch block re-throws it instead of
-    // logging a warning. The table-level catch then wraps it with context.
-    //
-    // We simulate the exact pattern used in all 6 profilers' column-level catches:
+  it("isFatalConnectionError triggers re-throw, non-fatal continues", () => {
+    // Simulates the exact pattern used in all 6 profilers' column-level catches:
     //
     //   } catch (colErr) {
-    //     const colMsg = colErr instanceof Error ? colErr.message : String(colErr);
-    //     if (FATAL_ERROR_PATTERN.test(colMsg)) {
-    //       throw colErr;  // <-- this is what we're testing
-    //     }
+    //     if (isFatalConnectionError(colErr)) throw colErr;
     //     console.warn(`Warning: ...`);
     //   }
 
     const fatalError = new Error("read ECONNRESET");
     const nonFatalError = new Error("permission denied for relation users");
 
-    // Simulate column-level catch behavior
     function columnCatch(err: Error): "warning" | "rethrow" {
-      const msg = err.message;
-      if (FATAL_ERROR_PATTERN.test(msg)) {
-        throw err;
-      }
+      if (isFatalConnectionError(err)) throw err;
       return "warning";
     }
 
-    // Fatal errors should re-throw
     expect(() => columnCatch(fatalError)).toThrow("ECONNRESET");
-
-    // Non-fatal errors should return "warning" (i.e., log and continue)
     expect(columnCatch(nonFatalError)).toBe("warning");
+  });
+
+  it("fatal errors via .code also trigger re-throw", () => {
+    const err = new Error("connection lost");
+    (err as NodeJS.ErrnoException).code = "ECONNREFUSED";
+
+    function columnCatch(e: Error): "warning" | "rethrow" {
+      if (isFatalConnectionError(e)) throw e;
+      return "warning";
+    }
+
+    expect(() => columnCatch(err)).toThrow("connection lost");
+  });
+
+  it("wrapped fatal errors propagate via cause chain", () => {
+    const original = new Error("read EPIPE");
+    const wrapped = new Error("query failed", { cause: original });
+
+    function columnCatch(e: Error): "warning" | "rethrow" {
+      if (isFatalConnectionError(e)) throw e;
+      return "warning";
+    }
+
+    expect(() => columnCatch(wrapped)).toThrow("query failed");
   });
 
   it("all six fatal error codes trigger the re-throw path", () => {
@@ -131,22 +201,12 @@ describe("column-level catch re-throw contract", () => {
     for (const code of codes) {
       const err = new Error(`connect ${code}: connection lost`);
       expect(() => {
-        const msg = err.message;
-        if (FATAL_ERROR_PATTERN.test(msg)) throw err;
+        if (isFatalConnectionError(err)) throw err;
       }).toThrow(code);
     }
   });
 
   it("table-level catch wraps fatal errors with profiling context", () => {
-    // Simulate the table-level catch that receives re-thrown column errors:
-    //
-    //   } catch (err) {
-    //     const msg = err instanceof Error ? err.message : String(err);
-    //     if (FATAL_ERROR_PATTERN.test(msg)) {
-    //       throw new Error(`Fatal database error while profiling ${table}: ${msg}`, { cause: err });
-    //     }
-    //   }
-
     const originalError = new Error("read ECONNRESET");
     const tableName = "users";
 
@@ -155,7 +215,7 @@ describe("column-level catch re-throw contract", () => {
       throw originalError;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      if (FATAL_ERROR_PATTERN.test(msg)) {
+      if (isFatalConnectionError(err)) {
         const wrapped = new Error(`Fatal database error while profiling ${tableName}: ${msg}`, { cause: err });
         expect(wrapped.message).toContain("Fatal database error");
         expect(wrapped.message).toContain("users");

--- a/packages/cli/bin/atlas.ts
+++ b/packages/cli/bin/atlas.ts
@@ -70,7 +70,17 @@ async function loadDuckDB() {
 }
 
 /** Network/socket error codes indicating the database connection is down or broken — re-throw immediately to abort profiling. */
-export const FATAL_ERROR_PATTERN = /ECONNRESET|ECONNREFUSED|EHOSTUNREACH|ENOTFOUND|EPIPE|ETIMEDOUT/i;
+export const FATAL_ERROR_PATTERN = /\bECONNRESET\b|\bECONNREFUSED\b|\bEHOSTUNREACH\b|\bENOTFOUND\b|\bEPIPE\b|\bETIMEDOUT\b/i;
+
+/** Check whether an error is a fatal connection error by inspecting message, code, and cause chain. */
+export function isFatalConnectionError(err: unknown): boolean {
+  if (!(err instanceof Error)) return FATAL_ERROR_PATTERN.test(String(err));
+  if (FATAL_ERROR_PATTERN.test(err.message)) return true;
+  const code = (err as NodeJS.ErrnoException).code;
+  if (code && FATAL_ERROR_PATTERN.test(code)) return true;
+  if (err.cause) return isFatalConnectionError(err.cause);
+  return false;
+}
 
 const SEMANTIC_DIR = path.resolve("semantic");
 const ENTITIES_DIR = path.join(SEMANTIC_DIR, "entities");
@@ -378,11 +388,8 @@ export async function profilePostgres(
         allObjects.push({ name: r.table_name, type: "materialized_view" });
       }
     } catch (mvErr) {
-      const mvMsg = mvErr instanceof Error ? mvErr.message : String(mvErr);
-      if (FATAL_ERROR_PATTERN.test(mvMsg)) {
-        throw mvErr;
-      }
-      console.warn(`  Warning: Could not discover materialized views: ${mvMsg}`);
+      if (isFatalConnectionError(mvErr)) throw mvErr;
+      console.warn(`  Warning: Could not discover materialized views: ${mvErr instanceof Error ? mvErr.message : String(mvErr)}`);
     }
     allObjects.sort((a, b) => a.name.localeCompare(b.name));
   }
@@ -416,11 +423,8 @@ export async function profilePostgres(
             matview_populated = mvResult.rows[0].ispopulated;
           }
         } catch (mvErr) {
-          const mvMsg = mvErr instanceof Error ? mvErr.message : String(mvErr);
-          if (FATAL_ERROR_PATTERN.test(mvMsg)) {
-            throw mvErr;
-          }
-          console.warn(`    Warning: Could not read matview status for ${table_name}: ${mvMsg}`);
+          if (isFatalConnectionError(mvErr)) throw mvErr;
+          console.warn(`    Warning: Could not read matview status for ${table_name}: ${mvErr instanceof Error ? mvErr.message : String(mvErr)}`);
         }
       }
 
@@ -443,20 +447,14 @@ export async function profilePostgres(
         try {
           primaryKeyColumns = await queryPrimaryKeys(pool, table_name, schema);
         } catch (pkErr) {
-          const pkMsg = pkErr instanceof Error ? pkErr.message : String(pkErr);
-          if (FATAL_ERROR_PATTERN.test(pkMsg)) {
-            throw pkErr;
-          }
-          console.warn(`    Warning: Could not read PK constraints for ${table_name}: ${pkMsg}`);
+          if (isFatalConnectionError(pkErr)) throw pkErr;
+          console.warn(`    Warning: Could not read PK constraints for ${table_name}: ${pkErr instanceof Error ? pkErr.message : String(pkErr)}`);
         }
         try {
           foreignKeys = await queryForeignKeys(pool, table_name, schema);
         } catch (fkErr) {
-          const fkMsg = fkErr instanceof Error ? fkErr.message : String(fkErr);
-          if (FATAL_ERROR_PATTERN.test(fkMsg)) {
-            throw fkErr;
-          }
-          console.warn(`    Warning: Could not read FK constraints for ${table_name}: ${fkMsg}`);
+          if (isFatalConnectionError(fkErr)) throw fkErr;
+          console.warn(`    Warning: Could not read FK constraints for ${table_name}: ${fkErr instanceof Error ? fkErr.message : String(fkErr)}`);
         }
       }
 
@@ -537,11 +535,8 @@ export async function profilePostgres(
             );
             sample_values = sv.rows.map((r: { v: unknown }) => String(r.v));
           } catch (colErr) {
-            const colMsg = colErr instanceof Error ? colErr.message : String(colErr);
-            if (FATAL_ERROR_PATTERN.test(colMsg)) {
-              throw colErr;
-            }
-            console.warn(`    Warning: Could not profile column ${table_name}.${col.column_name}: ${colMsg}`);
+            if (isFatalConnectionError(colErr)) throw colErr;
+            console.warn(`    Warning: Could not profile column ${table_name}.${col.column_name}: ${colErr instanceof Error ? colErr.message : String(colErr)}`);
           }
         }
 
@@ -576,7 +571,8 @@ export async function profilePostgres(
       progress?.onTableDone(table_name, i, objectsToProfile.length);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      if (FATAL_ERROR_PATTERN.test(msg)) {
+      // Fail fast on connection-level errors that will affect all remaining tables
+      if (isFatalConnectionError(err)) {
         throw new Error(`Fatal database error while profiling ${table_name}: ${msg}`, { cause: err });
       }
       if (progress) {
@@ -611,11 +607,8 @@ export async function profilePostgres(
       partitionMap.set(r.relname, { strategy: r.strategy, key: r.partition_key });
     }
   } catch (partErr) {
-    const partMsg = partErr instanceof Error ? partErr.message : String(partErr);
-    if (FATAL_ERROR_PATTERN.test(partMsg)) {
-      throw partErr;
-    }
-    console.warn(`  Warning: Could not read partition metadata: ${partMsg}`);
+    if (isFatalConnectionError(partErr)) throw partErr;
+    console.warn(`  Warning: Could not read partition metadata: ${partErr instanceof Error ? partErr.message : String(partErr)}`);
   }
 
   const childrenMap = new Map<string, string[]>();
@@ -636,11 +629,8 @@ export async function profilePostgres(
       childrenMap.set(r.parent, children);
     }
   } catch (childErr) {
-    const childMsg = childErr instanceof Error ? childErr.message : String(childErr);
-    if (FATAL_ERROR_PATTERN.test(childMsg)) {
-      throw childErr;
-    }
-    console.warn(`  Warning: Could not read partition children: ${childMsg}`);
+    if (isFatalConnectionError(childErr)) throw childErr;
+    console.warn(`  Warning: Could not read partition children: ${childErr instanceof Error ? childErr.message : String(childErr)}`);
   }
 
   for (const profile of profiles) {
@@ -758,20 +748,14 @@ export async function profileMySQL(
         try {
           primaryKeyColumns = await queryMySQLPrimaryKeys(pool, table_name);
         } catch (pkErr) {
-          const pkMsg = pkErr instanceof Error ? pkErr.message : String(pkErr);
-          if (FATAL_ERROR_PATTERN.test(pkMsg)) {
-            throw pkErr;
-          }
-          console.warn(`    Warning: Could not read PK constraints for ${table_name}: ${pkMsg}`);
+          if (isFatalConnectionError(pkErr)) throw pkErr;
+          console.warn(`    Warning: Could not read PK constraints for ${table_name}: ${pkErr instanceof Error ? pkErr.message : String(pkErr)}`);
         }
         try {
           foreignKeys = await queryMySQLForeignKeys(pool, table_name);
         } catch (fkErr) {
-          const fkMsg = fkErr instanceof Error ? fkErr.message : String(fkErr);
-          if (FATAL_ERROR_PATTERN.test(fkMsg)) {
-            throw fkErr;
-          }
-          console.warn(`    Warning: Could not read FK constraints for ${table_name}: ${fkMsg}`);
+          if (isFatalConnectionError(fkErr)) throw fkErr;
+          console.warn(`    Warning: Could not read FK constraints for ${table_name}: ${fkErr instanceof Error ? fkErr.message : String(fkErr)}`);
         }
       }
 
@@ -834,11 +818,8 @@ export async function profileMySQL(
           );
           sample_values = (svRows as { v: unknown }[]).map((r) => String(r.v));
         } catch (colErr) {
-          const colMsg = colErr instanceof Error ? colErr.message : String(colErr);
-          if (FATAL_ERROR_PATTERN.test(colMsg)) {
-            throw colErr;
-          }
-          console.warn(`    Warning: Could not profile column ${table_name}.${col.COLUMN_NAME}: ${colMsg}`);
+          if (isFatalConnectionError(colErr)) throw colErr;
+          console.warn(`    Warning: Could not profile column ${table_name}.${col.COLUMN_NAME}: ${colErr instanceof Error ? colErr.message : String(colErr)}`);
         }
 
         columns.push({
@@ -872,7 +853,7 @@ export async function profileMySQL(
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       // Fail fast on connection-level errors that will affect all remaining tables
-      if (/PROTOCOL_CONNECTION_LOST|ER_SERVER_SHUTDOWN|ER_NET_READ_ERROR|ER_NET_WRITE_ERROR/i.test(msg) || FATAL_ERROR_PATTERN.test(msg)) {
+      if (isFatalConnectionError(err) || /PROTOCOL_CONNECTION_LOST|ER_SERVER_SHUTDOWN|ER_NET_READ_ERROR|ER_NET_WRITE_ERROR/i.test(msg)) {
         throw new Error(`Fatal database error while profiling ${table_name}: ${msg}`, { cause: err });
       }
       if (progress) {
@@ -1027,11 +1008,8 @@ export async function profileClickHouse(
           try {
             primaryKeyColumns = await queryClickHousePrimaryKeys(client, table_name);
           } catch (pkErr) {
-            const pkMsg = pkErr instanceof Error ? pkErr.message : String(pkErr);
-            if (FATAL_ERROR_PATTERN.test(pkMsg)) {
-              throw pkErr;
-            }
-            console.warn(`    Warning: Could not read PK columns for ${table_name}: ${pkMsg}`);
+            if (isFatalConnectionError(pkErr)) throw pkErr;
+            console.warn(`    Warning: Could not read PK columns for ${table_name}: ${pkErr instanceof Error ? pkErr.message : String(pkErr)}`);
           }
         }
 
@@ -1089,11 +1067,8 @@ export async function profileClickHouse(
             );
             sample_values = svRows.map((r) => String(r.v));
           } catch (colErr) {
-            const colMsg = colErr instanceof Error ? colErr.message : String(colErr);
-            if (FATAL_ERROR_PATTERN.test(colMsg)) {
-              throw colErr;
-            }
-            console.warn(`    Warning: Could not profile column ${table_name}.${col.name}: ${colMsg}`);
+            if (isFatalConnectionError(colErr)) throw colErr;
+            console.warn(`    Warning: Could not profile column ${table_name}.${col.name}: ${colErr instanceof Error ? colErr.message : String(colErr)}`);
           }
 
           columns.push({
@@ -1126,7 +1101,8 @@ export async function profileClickHouse(
         progress?.onTableDone(table_name, i, objectsToProfile.length);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        if (FATAL_ERROR_PATTERN.test(msg)) {
+        // Fail fast on connection-level errors that will affect all remaining tables
+        if (isFatalConnectionError(err)) {
           throw new Error(`Fatal database error while profiling ${table_name}: ${msg}`, { cause: err });
         }
         if (progress) {
@@ -1337,20 +1313,14 @@ export async function profileSnowflake(
           try {
             primaryKeyColumns = await querySnowflakePrimaryKeys(pool, table_name, opts.database, opts.schema);
           } catch (pkErr) {
-            const pkMsg = pkErr instanceof Error ? pkErr.message : String(pkErr);
-            if (FATAL_ERROR_PATTERN.test(pkMsg)) {
-              throw pkErr;
-            }
-            console.warn(`    Warning: Could not read PK constraints for ${table_name}: ${pkMsg}`);
+            if (isFatalConnectionError(pkErr)) throw pkErr;
+            console.warn(`    Warning: Could not read PK constraints for ${table_name}: ${pkErr instanceof Error ? pkErr.message : String(pkErr)}`);
           }
           try {
             foreignKeys = await querySnowflakeForeignKeys(pool, table_name, opts.database, opts.schema);
           } catch (fkErr) {
-            const fkMsg = fkErr instanceof Error ? fkErr.message : String(fkErr);
-            if (FATAL_ERROR_PATTERN.test(fkMsg)) {
-              throw fkErr;
-            }
-            console.warn(`    Warning: Could not read FK constraints for ${table_name}: ${fkMsg}`);
+            if (isFatalConnectionError(fkErr)) throw fkErr;
+            console.warn(`    Warning: Could not read FK constraints for ${table_name}: ${fkErr instanceof Error ? fkErr.message : String(fkErr)}`);
           }
         }
 
@@ -1386,20 +1356,14 @@ export async function profileSnowflake(
               });
             }
           } catch (bulkErr) {
-            const bulkMsg = bulkErr instanceof Error ? bulkErr.message : String(bulkErr);
-            if (FATAL_ERROR_PATTERN.test(bulkMsg)) {
-              throw bulkErr;
-            }
-            console.warn(`    Warning: Bulk stats query failed for ${table_name}, falling back to row count only: ${bulkMsg}`);
+            if (isFatalConnectionError(bulkErr)) throw bulkErr;
+            console.warn(`    Warning: Bulk stats query failed for ${table_name}, falling back to row count only: ${bulkErr instanceof Error ? bulkErr.message : String(bulkErr)}`);
             try {
               const countResult = await snowflakeQuery(pool, `SELECT COUNT(*) as "RC" FROM "${escId(table_name)}"`);
               rowCount = parseInt(String(countResult.rows[0]?.RC ?? "0"), 10);
             } catch (countErr) {
-              const countMsg = countErr instanceof Error ? countErr.message : String(countErr);
-              if (FATAL_ERROR_PATTERN.test(countMsg)) {
-                throw countErr;
-              }
-              console.warn(`    Warning: Row count query also failed for ${table_name}: ${countMsg}`);
+              if (isFatalConnectionError(countErr)) throw countErr;
+              console.warn(`    Warning: Row count query also failed for ${table_name}: ${countErr instanceof Error ? countErr.message : String(countErr)}`);
             }
           }
         } else {
@@ -1407,11 +1371,8 @@ export async function profileSnowflake(
             const countResult = await snowflakeQuery(pool, `SELECT COUNT(*) as "RC" FROM "${escId(table_name)}"`);
             rowCount = parseInt(String(countResult.rows[0]?.RC ?? "0"), 10);
           } catch (countErr) {
-            const countMsg = countErr instanceof Error ? countErr.message : String(countErr);
-            if (FATAL_ERROR_PATTERN.test(countMsg)) {
-              throw countErr;
-            }
-            console.warn(`    Warning: Row count query failed for ${table_name}: ${countMsg}`);
+            if (isFatalConnectionError(countErr)) throw countErr;
+            console.warn(`    Warning: Row count query failed for ${table_name}: ${countErr instanceof Error ? countErr.message : String(countErr)}`);
           }
         }
 
@@ -1443,11 +1404,8 @@ export async function profileSnowflake(
               samplesMap.get(cn)!.push(String(row.V));
             }
           } catch (sampleErr) {
-            const sampleMsg = sampleErr instanceof Error ? sampleErr.message : String(sampleErr);
-            if (FATAL_ERROR_PATTERN.test(sampleMsg)) {
-              throw sampleErr;
-            }
-            console.warn(`    Warning: Batched sample values query failed for ${table_name} (${colMeta.length} columns affected): ${sampleMsg}`);
+            if (isFatalConnectionError(sampleErr)) throw sampleErr;
+            console.warn(`    Warning: Batched sample values query failed for ${table_name} (${colMeta.length} columns affected): ${sampleErr instanceof Error ? sampleErr.message : String(sampleErr)}`);
           }
         }
 
@@ -1487,7 +1445,9 @@ export async function profileSnowflake(
         progress?.onTableDone(table_name, i, objectsToProfile.length);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        if (FATAL_ERROR_PATTERN.test(msg) || /390100|390114|250001/.test(msg)) {
+        // Fail fast on connection-level errors that will affect all remaining tables
+        // Snowflake-specific: 390100 = auth token expired, 390114 = auth token invalid, 250001 = connection failure
+        if (isFatalConnectionError(err) || /390100|390114|250001/.test(msg)) {
           throw new Error(`Fatal database error while profiling ${table_name}: ${msg}`, { cause: err });
         }
         if (progress) {
@@ -1618,11 +1578,8 @@ export async function profileSalesforce(
             rowCount = parseInt(String(countVal ?? "0"), 10);
           }
         } catch (countErr) {
-          const countMsg = countErr instanceof Error ? countErr.message : String(countErr);
-          if (FATAL_ERROR_PATTERN.test(countMsg)) {
-            throw countErr;
-          }
-          console.warn(`    Warning: Could not get row count for ${objectName}: ${countMsg}`);
+          if (isFatalConnectionError(countErr)) throw countErr;
+          console.warn(`    Warning: Could not get row count for ${objectName}: ${countErr instanceof Error ? countErr.message : String(countErr)}`);
         }
 
         const foreignKeys: ForeignKey[] = [];
@@ -1681,7 +1638,8 @@ export async function profileSalesforce(
         progress?.onTableDone(objectName, i, objectsToProfile.length);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        if (FATAL_ERROR_PATTERN.test(msg)) {
+        // Fail fast on connection-level errors that will affect all remaining objects
+        if (isFatalConnectionError(err)) {
           throw new Error(`Fatal Salesforce error while profiling ${objectName}: ${msg}`, { cause: err });
         }
         if (progress) {
@@ -2787,12 +2745,9 @@ export async function profileDuckDB(
               sampleValues = sampleRows.map((r) => String(r.v));
             }
           } catch (colErr) {
-            const colMsg = colErr instanceof Error ? colErr.message : String(colErr);
-            if (FATAL_ERROR_PATTERN.test(colMsg)) {
-              throw colErr;
-            }
+            if (isFatalConnectionError(colErr)) throw colErr;
             console.warn(
-              `    Warning: Could not profile column ${tableName}.${col.column_name}: ${colMsg}`
+              `    Warning: Could not profile column ${tableName}.${col.column_name}: ${colErr instanceof Error ? colErr.message : String(colErr)}`
             );
           }
 
@@ -2830,7 +2785,7 @@ export async function profileDuckDB(
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         // Fail fast on connection-level errors that will affect all remaining tables
-        if (FATAL_ERROR_PATTERN.test(msg)) {
+        if (isFatalConnectionError(err)) {
           throw new Error(`Fatal database error while profiling ${tableName}: ${msg}`, { cause: err });
         }
         if (progress) {


### PR DESCRIPTION
## Summary

- **#358**: Postgres profiler was the only one missing fatal error detection (`ECONNRESET`, `ECONNREFUSED`, etc.) in its table-level catch block — it would silently continue profiling every table after a connection drop, producing N identical failure warnings
- **#359**: All six profilers' column-level catch blocks swallowed fatal connection errors as warnings — a connection drop during column profiling would log identical warnings for every remaining column before the table-level catch could detect it. Column-level catches now re-throw fatal errors immediately
- Extracts `FATAL_ERROR_PATTERN` as a shared exported constant, eliminating 12+ copies of the same regex

Closes #358, closes #359

## Test plan

- [x] New `fatal-error-propagation.test.ts` — 16 tests covering FATAL_ERROR_PATTERN matching (all 6 codes, case-insensitive), non-fatal exclusion, DuckDB corrupted DB propagation, and partial result preservation for non-fatal errors
- [x] All existing tests pass (`bun run test`)
- [x] Lint, type-check, syncpack, template drift all pass