### PR TITLE
fix(web,react): Lighthouse/axe accessibility audit

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "atlas",
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.1",
         "@eslint/js": "^10.0.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@next/eslint-plugin-next": "^16.1.6",
@@ -676,6 +677,8 @@
     "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.8", "", { "dependencies": { "@smithy/types": "^4.13.0", "fast-xml-parser": "5.3.6", "tslib": "^2.6.2" } }, "sha512-Ql8elcUdYCha83Ol7NznBsgN5GVZnv3vUd86fEc6waU6oUdY0T1O9NODkEEOS/Uaogr87avDrUC6DSeM4oXjZg=="],
 
     "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.3", "", {}, "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw=="],
+
+    "@axe-core/playwright": ["@axe-core/playwright@4.11.1", "", { "dependencies": { "axe-core": "~4.11.1" }, "peerDependencies": { "playwright-core": ">= 1.0.0" } }, "sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw=="],
 
     "@azure/abort-controller": ["@azure/abort-controller@2.1.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA=="],
 
@@ -1852,6 +1855,8 @@
     "aws-ssl-profiles": ["aws-ssl-profiles@1.1.2", "", {}, "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g=="],
 
     "aws4fetch": ["aws4fetch@1.0.20", "", {}, "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g=="],
+
+    "axe-core": ["axe-core@4.11.1", "", {}, "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A=="],
 
     "axios": ["axios@1.13.6", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^1.1.0" } }, "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ=="],
 

--- a/e2e/browser/accessibility.spec.ts
+++ b/e2e/browser/accessibility.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect, type Page } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+/**
+ * Accessibility audit — axe-core scans of key Atlas pages.
+ * Fails on any critical or serious violations.
+ */
+
+const AXE_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "best-practice"];
+
+/** Run axe-core and assert zero critical/serious violations. */
+async function assertNoAxeViolations(page: Page) {
+  const results = await new AxeBuilder({ page }).withTags(AXE_TAGS).analyze();
+
+  // Sanity check — axe actually scanned meaningful content
+  expect(results.passes.length, "axe-core should have evaluated at least one rule").toBeGreaterThan(0);
+
+  const critical = results.violations.filter((v) => v.impact === "critical" || v.impact === "serious");
+  const summary = critical.map((v) => `[${v.impact}] ${v.id}: ${v.description} (${v.nodes.length} instance(s))`).join("\n");
+  expect(critical, `Axe violations:\n${summary}`).toHaveLength(0);
+}
+
+test.describe("Accessibility", () => {
+  test("chat page has zero critical/serious axe violations", async ({ page }) => {
+    await page.goto("/");
+    await page.locator('input[placeholder="Ask a question about your data..."]').waitFor({ timeout: 15_000 });
+    await assertNoAxeViolations(page);
+  });
+
+  test("admin overview has zero critical/serious axe violations", async ({ page }) => {
+    await page.goto("/admin");
+    await expect(page.locator("h1", { hasText: "Overview" })).toBeVisible({ timeout: 15_000 });
+    await assertNoAxeViolations(page);
+  });
+
+  test("admin connections has zero critical/serious axe violations", async ({ page }) => {
+    await page.goto("/admin/connections");
+    await expect(page.locator("h1", { hasText: "Connections" })).toBeVisible({ timeout: 15_000 });
+    // Wait for page content to settle — table, empty state, or error banner
+    await expect(
+      page.locator("table").or(page.locator("text=No datasource connections")).or(page.locator("[role='alert']:not(#__next-route-announcer__)")),
+    ).toBeVisible({ timeout: 10_000 });
+    await assertNoAxeViolations(page);
+  });
+
+  test("admin audit log has zero critical/serious axe violations", async ({ page }) => {
+    await page.goto("/admin/audit");
+    await expect(page.locator("h1", { hasText: "Audit Log" })).toBeVisible({ timeout: 15_000 });
+    await assertNoAxeViolations(page);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "homepage": "https://useatlas.dev",
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.1",
     "@eslint/js": "^10.0.1",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@next/eslint-plugin-next": "^16.1.6",

--- a/packages/react/src/components/atlas-chat.tsx
+++ b/packages/react/src/components/atlas-chat.tsx
@@ -437,7 +437,7 @@ function AtlasChatInner({
           />
         )}
 
-        <main className="flex flex-1 flex-col overflow-hidden">
+        <main id="main" tabIndex={-1} className="flex flex-1 flex-col overflow-hidden">
           <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col overflow-hidden p-4">
             <header className="mb-4 flex-none border-b border-zinc-100 pb-3 dark:border-zinc-800">
               <div className="flex items-center justify-between">
@@ -529,7 +529,7 @@ function AtlasChatInner({
                         <p className="text-lg font-medium text-zinc-500 dark:text-zinc-400">
                           What would you like to know?
                         </p>
-                        <p className="mt-1 text-sm text-zinc-400 dark:text-zinc-600">
+                        <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-500">
                           Ask a question about your data to get started
                         </p>
                       </div>

--- a/packages/react/src/components/conversations/conversation-list.tsx
+++ b/packages/react/src/components/conversations/conversation-list.tsx
@@ -22,7 +22,7 @@ export function ConversationList({
 }) {
   if (conversations.length === 0) {
     return (
-      <div className="px-3 py-6 text-center text-xs text-zinc-400 dark:text-zinc-500">
+      <div className="px-3 py-6 text-center text-xs text-zinc-500 dark:text-zinc-400">
         {emptyMessage ?? "No conversations yet"}
       </div>
     );

--- a/packages/web/src/app/admin/audit/page.tsx
+++ b/packages/web/src/app/admin/audit/page.tsx
@@ -177,8 +177,9 @@ export default function AuditPage() {
           {/* Date range for analytics */}
           <div className="flex flex-wrap items-end gap-3">
             <div className="space-y-1">
-              <label className="text-xs font-medium text-muted-foreground">From</label>
+              <label htmlFor="analytics-from" className="text-xs font-medium text-muted-foreground">From</label>
               <Input
+                id="analytics-from"
                 type="date"
                 value={filters.from}
                 onChange={(e) => setFilters((f) => ({ ...f, from: e.target.value }))}
@@ -186,8 +187,9 @@ export default function AuditPage() {
               />
             </div>
             <div className="space-y-1">
-              <label className="text-xs font-medium text-muted-foreground">To</label>
+              <label htmlFor="analytics-to" className="text-xs font-medium text-muted-foreground">To</label>
               <Input
+                id="analytics-to"
                 type="date"
                 value={filters.to}
                 onChange={(e) => setFilters((f) => ({ ...f, to: e.target.value }))}
@@ -233,8 +235,9 @@ export default function AuditPage() {
           {/* Filter row */}
           <div className="flex flex-wrap items-end gap-3">
             <div className="space-y-1">
-              <label className="text-xs font-medium text-muted-foreground">From</label>
+              <label htmlFor="log-from" className="text-xs font-medium text-muted-foreground">From</label>
               <Input
+                id="log-from"
                 type="date"
                 value={filters.from}
                 onChange={(e) => setFilters((f) => ({ ...f, from: e.target.value }))}
@@ -242,8 +245,9 @@ export default function AuditPage() {
               />
             </div>
             <div className="space-y-1">
-              <label className="text-xs font-medium text-muted-foreground">To</label>
+              <label htmlFor="log-to" className="text-xs font-medium text-muted-foreground">To</label>
               <Input
+                id="log-to"
                 type="date"
                 value={filters.to}
                 onChange={(e) => setFilters((f) => ({ ...f, to: e.target.value }))}
@@ -251,8 +255,9 @@ export default function AuditPage() {
               />
             </div>
             <div className="space-y-1">
-              <label className="text-xs font-medium text-muted-foreground">User</label>
+              <label htmlFor="log-user" className="text-xs font-medium text-muted-foreground">User</label>
               <Input
+                id="log-user"
                 type="text"
                 placeholder="Filter by user..."
                 value={filters.user}

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -270,6 +270,7 @@ function ConnectionFormDialog({
                 size="sm"
                 className="absolute right-0 top-0 h-full px-3"
                 onClick={() => setShowUrl(!showUrl)}
+                aria-label={showUrl ? "Hide connection URL" : "Show connection URL"}
               >
                 {showUrl ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
               </Button>
@@ -555,7 +556,7 @@ export default function ConnectionsPage() {
                 <TableHead>Description</TableHead>
                 <TableHead>Health</TableHead>
                 <TableHead>Latency</TableHead>
-                <TableHead className="w-[180px]" />
+                <TableHead className="w-[180px]"><span className="sr-only">Actions</span></TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -581,6 +582,7 @@ export default function ConnectionsPage() {
                         size="sm"
                         disabled={testing.has(conn.id)}
                         onClick={() => testConnection(conn.id)}
+                        aria-label={testing.has(conn.id) ? `Testing connection ${conn.id}…` : undefined}
                       >
                         {testing.has(conn.id) ? (
                           <Loader2 className="size-3.5 animate-spin" />
@@ -595,6 +597,7 @@ export default function ConnectionsPage() {
                             size="sm"
                             onClick={() => handleEdit(conn.id)}
                             disabled={loadingDetail}
+                            aria-label={`Edit connection ${conn.id}`}
                           >
                             <Pencil className="size-3.5" />
                           </Button>
@@ -602,6 +605,7 @@ export default function ConnectionsPage() {
                             variant="ghost"
                             size="sm"
                             onClick={() => handleDelete(conn.id)}
+                            aria-label={`Delete connection ${conn.id}`}
                           >
                             <Trash2 className="size-3.5 text-destructive" />
                           </Button>

--- a/packages/web/src/app/admin/page.tsx
+++ b/packages/web/src/app/admin/page.tsx
@@ -271,8 +271,8 @@ export default function AdminOverview() {
       </div>
 
       {error && (
-        <div className="mb-4 rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3">
-          <p className="text-sm text-destructive">{error}</p>
+        <div role="alert" className="mb-4 rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3">
+          <p className="text-sm text-red-800 dark:text-red-300">{error}</p>
         </div>
       )}
 

--- a/packages/web/src/ui/components/admin/admin-layout.tsx
+++ b/packages/web/src/ui/components/admin/admin-layout.tsx
@@ -37,22 +37,26 @@ export function AdminLayout({ children }: { children: ReactNode }) {
   // Loading session
   if (session.isPending) {
     return (
-      <div className="flex h-dvh items-center justify-center">
+      <main id="main" tabIndex={-1} className="flex h-dvh items-center justify-center">
         <LoadingState message="Checking authentication..." />
-      </div>
+      </main>
     );
   }
 
   // Not signed in
   if (!session.data?.user) {
-    return <ManagedAuthCard />;
+    return (
+      <main id="main" tabIndex={-1}>
+        <ManagedAuthCard />
+      </main>
+    );
   }
 
   // Signed in but not admin
   const role = (session.data.user as Record<string, unknown>).role;
   if (role !== "admin") {
     return (
-      <div className="flex h-dvh items-center justify-center">
+      <main id="main" tabIndex={-1} className="flex h-dvh items-center justify-center">
         <div className="w-full max-w-sm space-y-3 rounded-lg border border-zinc-200 bg-zinc-50 p-6 text-center dark:border-zinc-700 dark:bg-zinc-900">
           <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
             Access Denied
@@ -68,14 +72,14 @@ export function AdminLayout({ children }: { children: ReactNode }) {
             Sign out
           </button>
         </div>
-      </div>
+      </main>
     );
   }
 
   return (
     <SidebarProvider>
       <AdminSidebar />
-      <SidebarInset>
+      <SidebarInset id="main" tabIndex={-1}>
         <header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
           <div className="flex items-center gap-2 px-4">
             <SidebarTrigger className="-ml-1" />

--- a/packages/web/src/ui/components/admin/empty-state.tsx
+++ b/packages/web/src/ui/components/admin/empty-state.tsx
@@ -26,7 +26,7 @@ export function EmptyState({
         <Icon className="mx-auto size-10 opacity-50" />
         {heading && <p className="mt-3 text-sm font-medium">{heading}</p>}
         {description && (
-          <p className="mt-1 text-xs text-muted-foreground/70">{description}</p>
+          <p className="mt-1 text-xs text-muted-foreground">{description}</p>
         )}
         {action && (
           <Button

--- a/packages/web/src/ui/components/admin/error-banner.tsx
+++ b/packages/web/src/ui/components/admin/error-banner.tsx
@@ -10,8 +10,8 @@ export function ErrorBanner({
   onRetry?: () => void;
 }) {
   return (
-    <div className="m-6 rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 flex items-center justify-between gap-4">
-      <p className="text-sm text-destructive">{message}</p>
+    <div role="alert" className="m-6 rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 flex items-center justify-between gap-4">
+      <p className="text-sm text-red-800 dark:text-red-300">{message}</p>
       {onRetry && (
         <Button variant="outline" size="sm" onClick={onRetry} className="shrink-0">
           Retry

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -355,7 +355,7 @@ export function AtlasChat() {
           />
         )}
 
-        <main id="main" className="flex flex-1 flex-col overflow-hidden">
+        <main id="main" tabIndex={-1} className="flex flex-1 flex-col overflow-hidden">
           <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col overflow-hidden p-4">
             <header className="mb-4 flex-none border-b border-zinc-100 pb-3 dark:border-zinc-800">
               <div className="flex items-center justify-between">
@@ -445,7 +445,7 @@ export function AtlasChat() {
                         <p className="text-lg font-medium text-zinc-500 dark:text-zinc-400">
                           What would you like to know?
                         </p>
-                        <p className="mt-1 text-sm text-zinc-400 dark:text-zinc-600">
+                        <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-500">
                           Ask a question about your data to get started
                         </p>
                       </div>


### PR DESCRIPTION
Closes #378

## Summary
- Add `@axe-core/playwright` and automated axe-core tests against 4 key pages (chat, admin overview, connections, audit)
- Fix all **critical** and **serious** axe-core violations
- Achieve Lighthouse accessibility score of **100** on both chat and admin pages

## Violations fixed

| Severity | Rule | Pages | Fix |
|----------|------|-------|-----|
| Serious | `color-contrast` | Chat, Audit | Bump `text-zinc-400` → `text-zinc-500` on light backgrounds; use `text-red-800` for error banners |
| Critical | `label` | Audit | Add `htmlFor`/`id` pairing to date and user filter inputs |
| Moderate | `skip-link` | All | Add `id="main"` + `tabIndex={-1}` to all `<main>` elements |
| — | `button-name` | Connections | Add `aria-label` to icon-only edit/delete/toggle buttons |
| — | `landmark` | Admin | Wrap auth states (login, access denied, loading) in `<main>` |

## Audit results

| Page | Lighthouse | axe critical/serious |
|------|-----------|---------------------|
| `/` (chat) | **100** | 0 |
| `/admin` (overview) | **100** | 0 |
| `/admin/connections` | **100** | 0 |
| `/admin/audit` | **100** | 0 |

### Remaining moderate violations
- `region` — content outside ARIA landmarks (shadcn/ui sidebar wrapper). Noted on #379 for keyboard navigation work.

## Files changed
- **`e2e/browser/accessibility.spec.ts`** (NEW) — axe-core tests for 4 pages
- **`packages/react/src/components/atlas-chat.tsx`** — contrast fix, `id="main"` + `tabIndex`
- **`packages/react/src/components/conversations/conversation-list.tsx`** — contrast fix
- **`packages/web/src/app/admin/audit/page.tsx`** — form label pairing
- **`packages/web/src/app/admin/connections/page.tsx`** — aria-labels, sr-only table header
- **`packages/web/src/app/admin/page.tsx`** — error banner contrast
- **`packages/web/src/ui/components/admin/admin-layout.tsx`** — landmarks for auth states
- **`packages/web/src/ui/components/admin/empty-state.tsx`** — contrast fix
- **`packages/web/src/ui/components/admin/error-banner.tsx`** — contrast + `role="alert"`
- **`packages/web/src/ui/components/atlas-chat.tsx`** — contrast fix, `tabIndex`

## Test plan
- [x] `bun x playwright test accessibility.spec.ts` — all 4 axe tests pass
- [x] Lighthouse accessibility ≥ 90 on chat and admin
- [x] CI gates: lint, type, test, syncpack, drift — all pass
- [ ] Visual spot check: error banners, empty states, conversation sidebar still look correct