### PR TITLE
fix(docs): add missing ChatErrorInfo fields in react.mdx

### DIFF
--- a/apps/docs/content/docs/reference/react.mdx
+++ b/apps/docs/content/docs/reference/react.mdx
@@ -688,7 +688,18 @@ interface ChatErrorInfo {
   detail?: string;             // Optional secondary context
   retryAfterSeconds?: number;  // Seconds until retry (rate_limited only, clamped 0–300)
   code?: ChatErrorCode;        // Server error code, if parseable
+  clientCode?: ClientErrorCode; // Client-side classification (network/offline/HTTP status)
+  retryable?: boolean;         // true = transient, false = permanent, undefined = unknown
+  requestId?: string;          // Server-assigned request ID (UUID) for log correlation
 }
+
+// ClientErrorCode — client-side error classification
+type ClientErrorCode =
+  | "api_unreachable"     // fetch failed, ECONNREFUSED, ENOTFOUND
+  | "auth_failure"        // HTTP 401
+  | "rate_limited_http"   // HTTP 429
+  | "server_error"        // HTTP 5xx
+  | "offline";            // navigator.onLine === false
 ```
 
 ### Hook Option & Return Types


### PR DESCRIPTION
## Summary
Update the `ChatErrorInfo` type in `apps/docs/content/docs/reference/react.mdx` to include the 3 missing fields: `clientCode`, `retryable`, and `requestId`.

## Test plan
- [x] Type definition matches actual `@useatlas/types` source
- [x] `bun run lint` — clean
- [x] `bun run type` — clean

Closes #406