### PR TITLE
fix(types): add bun export conditions for monorepo source resolution

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -8,46 +8,55 @@
   },
   "exports": {
     ".": {
+      "bun": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./auth": {
+      "bun": "./src/auth.ts",
       "types": "./dist/auth.d.ts",
       "import": "./dist/auth.js",
       "default": "./dist/auth.js"
     },
     "./conversation": {
+      "bun": "./src/conversation.ts",
       "types": "./dist/conversation.d.ts",
       "import": "./dist/conversation.js",
       "default": "./dist/conversation.js"
     },
     "./connection": {
+      "bun": "./src/connection.ts",
       "types": "./dist/connection.d.ts",
       "import": "./dist/connection.js",
       "default": "./dist/connection.js"
     },
     "./action": {
+      "bun": "./src/action.ts",
       "types": "./dist/action.d.ts",
       "import": "./dist/action.js",
       "default": "./dist/action.js"
     },
     "./scheduled-task": {
+      "bun": "./src/scheduled-task.ts",
       "types": "./dist/scheduled-task.d.ts",
       "import": "./dist/scheduled-task.js",
       "default": "./dist/scheduled-task.js"
     },
     "./errors": {
+      "bun": "./src/errors.ts",
       "types": "./dist/errors.d.ts",
       "import": "./dist/errors.js",
       "default": "./dist/errors.js"
     },
     "./semantic": {
+      "bun": "./src/semantic.ts",
       "types": "./dist/semantic.d.ts",
       "import": "./dist/semantic.js",
       "default": "./dist/semantic.js"
     },
     "./share": {
+      "bun": "./src/share.ts",
       "types": "./dist/share.d.ts",
       "import": "./dist/share.js",
       "default": "./dist/share.js"


### PR DESCRIPTION
## Summary
- Add `"bun"` condition to every subpath export in `@useatlas/types` `package.json`, pointing to TypeScript source files under `src/`
- This lets bun resolve `@useatlas/types/errors` (and all other subpaths) directly from source without a prior build step
- Published consumers still use `dist/` artifacts via the `import`/`default` conditions

## Root cause
The exports map only had `types`/`import`/`default` conditions pointing to `dist/`. When `dist/` is missing (fresh clone, worktree, or CI without a build step), `@useatlas/types/errors` fails to resolve and `classifyClientError` appears as "not found".

## Test plan
- [x] Deleted `dist/` and confirmed `use-atlas-auth.test.tsx` passes (11/11)
- [x] Full test suite passes (`bun run test` — exit code 0)
- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun x syncpack lint` — clean
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — clean

Closes #402