### PR TITLE
docs(sdk): streaming resilience & retryAfterSeconds null-safety

### DIFF
--- a/apps/docs/content/docs/reference/sdk.mdx
+++ b/apps/docs/content/docs/reference/sdk.mdx
@@ -448,7 +448,7 @@ try {
 | `status` | `number` | HTTP status code (0 for client-side errors like `network_error`) |
 | `message` | `string` | Human-readable description |
 | `retryable` | `boolean` | Whether retrying the same request may succeed |
-| `retryAfterSeconds` | `number \| undefined` | Server-suggested delay — only populated for `rate_limited` errors with a `Retry-After` header. **Always guard against `undefined`** |
+| `retryAfterSeconds` | `number \| undefined` | Server-suggested delay — only populated when the server includes `retryAfterSeconds` in the error response body (currently only for `rate_limited`). **Always guard against `undefined`** |
 
 ### Retry with Backoff
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -224,7 +224,7 @@ try {
 | `status` | `number` | HTTP status code (0 for client-side errors like `network_error`) |
 | `message` | `string` | Human-readable description |
 | `retryable` | `boolean` | Whether retrying the same request may succeed |
-| `retryAfterSeconds` | `number \| undefined` | Server-suggested delay — only populated for `rate_limited` errors with a `Retry-After` header. **Always guard against `undefined`** |
+| `retryAfterSeconds` | `number \| undefined` | Server-suggested delay — only populated when the server includes `retryAfterSeconds` in the error response body (currently only for `rate_limited`). **Always guard against `undefined`** |
 
 ### Retry with Backoff
 


### PR DESCRIPTION
## Summary
- **#419** — Document `streamQuery()` connection drop behavior, partial result validity, and error recovery pattern. Enhance cancellation docs.
- **#420** — Fix `retryAfterSeconds!` non-null assertion in README example. Add `AtlasError` properties table documenting `retryAfterSeconds` as `number | undefined` (only populated for `rate_limited`). Add null-safe retry-with-backoff example.

Both README and docs site (`sdk.mdx`) updated with matching content. Links to the error-codes reference for the full retry loop example (no duplication).

Closes #419, closes #420

## Test plan
- [ ] `bun run lint` — pass
- [ ] `bun run type` — pass
- [ ] `bun run test` — pass
- [ ] `bun x syncpack lint` — pass
- [ ] Template drift check — pass
- [ ] Review rendered README on GitHub
- [ ] Review rendered sdk.mdx on docs site preview