### PR TITLE
fix: audit log review fixes — error messages, types, export truncation

### DIFF
--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -795,6 +795,30 @@ describe("GET /api/v1/admin/audit", () => {
     expect(capturedParams).toContain("%100\\%%");
   });
 
+  it("correctly parameterizes combined new filters (search + connection + table)", async () => {
+    let capturedSql = "";
+    let capturedParams: unknown[] = [];
+    let callCount = 0;
+    mockInternalQuery.mockImplementation((sql: string, params?: unknown[]) => {
+      callCount++;
+      if (callCount === 1) {
+        capturedSql = sql;
+        capturedParams = params ?? [];
+        return Promise.resolve([{ count: "0" }]);
+      }
+      return Promise.resolve([]);
+    });
+
+    await app.fetch(adminRequest(
+      "/api/v1/admin/audit?connection=warehouse&table=orders&search=revenue",
+    ));
+
+    expect(capturedSql).toContain("source_id = $1");
+    expect(capturedSql).toContain("a.sql ILIKE $2");
+    expect(capturedSql).toContain("a.sql ILIKE $3 OR u.email ILIKE $3 OR a.error ILIKE $3");
+    expect(capturedParams).toEqual(["warehouse", "%orders%", "%revenue%"]);
+  });
+
   it("returns 400 for invalid date format", async () => {
     const res = await app.fetch(adminRequest("/api/v1/admin/audit?from=not-a-date"));
     expect(res.status).toBe(400);
@@ -821,20 +845,25 @@ describe("GET /api/v1/admin/audit/export", () => {
   });
 
   it("returns CSV with correct headers", async () => {
-    mockInternalQuery.mockResolvedValue([
-      {
-        id: "abc-123",
-        timestamp: "2026-03-01T10:00:00Z",
-        user_id: "u1",
-        sql: "SELECT * FROM orders",
-        duration_ms: 42,
-        row_count: 10,
-        success: true,
-        error: null,
-        source_id: "default",
-        user_email: "admin@test.com",
-      },
-    ]);
+    let callCount = 0;
+    mockInternalQuery.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return Promise.resolve([{ count: "1" }]);
+      return Promise.resolve([
+        {
+          id: "abc-123",
+          timestamp: "2026-03-01T10:00:00Z",
+          user_id: "u1",
+          sql: "SELECT * FROM orders",
+          duration_ms: 42,
+          row_count: 10,
+          success: true,
+          error: null,
+          source_id: "default",
+          user_email: "admin@test.com",
+        },
+      ]);
+    });
 
     const res = await app.fetch(adminRequest("/api/v1/admin/audit/export"));
     expect(res.status).toBe(200);
@@ -849,20 +878,25 @@ describe("GET /api/v1/admin/audit/export", () => {
   });
 
   it("escapes CSV fields with quotes", async () => {
-    mockInternalQuery.mockResolvedValue([
-      {
-        id: "abc-456",
-        timestamp: "2026-03-01T10:00:00Z",
-        user_id: "u1",
-        sql: 'SELECT "name" FROM users',
-        duration_ms: 10,
-        row_count: 5,
-        success: true,
-        error: null,
-        source_id: null,
-        user_email: null,
-      },
-    ]);
+    let callCount = 0;
+    mockInternalQuery.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return Promise.resolve([{ count: "1" }]);
+      return Promise.resolve([
+        {
+          id: "abc-456",
+          timestamp: "2026-03-01T10:00:00Z",
+          user_id: "u1",
+          sql: 'SELECT "name" FROM users',
+          duration_ms: 10,
+          row_count: 5,
+          success: true,
+          error: null,
+          source_id: null,
+          user_email: null,
+        },
+      ]);
+    });
 
     const res = await app.fetch(adminRequest("/api/v1/admin/audit/export"));
     const body = await res.text();
@@ -873,7 +907,10 @@ describe("GET /api/v1/admin/audit/export", () => {
   it("respects filters on export", async () => {
     let capturedSql = "";
     let capturedParams: unknown[] = [];
+    let callCount = 0;
     mockInternalQuery.mockImplementation((sql: string, params?: unknown[]) => {
+      callCount++;
+      if (callCount === 1) return Promise.resolve([{ count: "0" }]);
       capturedSql = sql;
       capturedParams = params ?? [];
       return Promise.resolve([]);
@@ -885,6 +922,34 @@ describe("GET /api/v1/admin/audit/export", () => {
     expect(capturedSql).toContain("success");
     expect(capturedParams).toContain("warehouse");
     expect(capturedParams).toContain(false);
+  });
+
+  it("returns 403 for non-admin user", async () => {
+    mockAuthenticateRequest.mockResolvedValue({
+      authenticated: true,
+      mode: "simple-key",
+      user: { id: "user-1", mode: "simple-key", label: "User", role: "member" },
+    });
+    const res = await app.fetch(adminRequest("/api/v1/admin/audit/export"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns CSV with only headers when no rows match", async () => {
+    let callCount = 0;
+    mockInternalQuery.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return Promise.resolve([{ count: "0" }]);
+      return Promise.resolve([]);
+    });
+    const res = await app.fetch(adminRequest("/api/v1/admin/audit/export"));
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toBe("id,timestamp,user,sql,duration_ms,row_count,success,error,connection\n");
+  });
+
+  it("returns 400 for invalid date on export", async () => {
+    const res = await app.fetch(adminRequest("/api/v1/admin/audit/export?from=garbage"));
+    expect(res.status).toBe(400);
   });
 
   it("returns 404 when no internal DB", async () => {
@@ -932,7 +997,7 @@ describe("GET /api/v1/admin/audit/stats", () => {
     const body = (await res.json()) as Record<string, unknown>;
     expect(body.totalQueries).toBe(100);
     expect(body.totalErrors).toBe(5);
-    expect(body.errorRate).toBe(0.05);
+    expect(body.errorRate).toBe(5);
     expect(Array.isArray(body.queriesPerDay)).toBe(true);
   });
 

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -957,19 +957,18 @@ function escapeIlike(s: string): string {
 /** Quote a value for safe CSV output (RFC 4180). */
 function csvField(val: string | null | undefined): string {
   const s = val ?? "";
-  if (s.includes(",") || s.includes('"') || s.includes("\n")) {
+  if (s.includes(",") || s.includes('"') || s.includes("\n") || s.includes("\r")) {
     return `"${s.replace(/"/g, '""')}"`;
   }
   return s;
 }
 
+type AuditFilterResult =
+  | { ok: true; conditions: string[]; params: unknown[]; paramIdx: number }
+  | { ok: false; error: string; message: string; status: 400 };
+
 /** Shared filter builder for audit list + export endpoints. */
-function buildAuditFilters(query: (key: string) => string | undefined): {
-  conditions: string[];
-  params: unknown[];
-  paramIdx: number;
-  error?: { error: string; message: string; status: number };
-} {
+function buildAuditFilters(query: (key: string) => string | undefined): AuditFilterResult {
   const conditions: string[] = [];
   const params: unknown[] = [];
   let paramIdx = 1;
@@ -989,7 +988,7 @@ function buildAuditFilters(query: (key: string) => string | undefined): {
   const from = query("from");
   if (from) {
     if (isNaN(Date.parse(from))) {
-      return { conditions, params, paramIdx, error: { error: "invalid_request", message: `Invalid 'from' date format: "${from}". Use ISO 8601 (e.g. 2026-01-01).`, status: 400 } };
+      return { ok: false, error: "invalid_request", message: `Invalid 'from' date format: "${from}". Use ISO 8601 (e.g. 2026-01-01).`, status: 400 };
     }
     conditions.push(`a.timestamp >= $${paramIdx++}`);
     params.push(from);
@@ -998,7 +997,7 @@ function buildAuditFilters(query: (key: string) => string | undefined): {
   const to = query("to");
   if (to) {
     if (isNaN(Date.parse(to))) {
-      return { conditions, params, paramIdx, error: { error: "invalid_request", message: `Invalid 'to' date format: "${to}". Use ISO 8601 (e.g. 2026-03-03).`, status: 400 } };
+      return { ok: false, error: "invalid_request", message: `Invalid 'to' date format: "${to}". Use ISO 8601 (e.g. 2026-03-03).`, status: 400 };
     }
     conditions.push(`a.timestamp <= $${paramIdx++}`);
     params.push(to);
@@ -1024,7 +1023,7 @@ function buildAuditFilters(query: (key: string) => string | undefined): {
     paramIdx++;
   }
 
-  return { conditions, params, paramIdx };
+  return { ok: true, conditions, params, paramIdx };
 }
 
 // GET /audit — query audit_log (paginated)
@@ -1052,8 +1051,8 @@ admin.get("/audit", async (c) => {
     // Queries the internal DB directly (not the analytics datasource),
     // so no validateSQL pipeline needed. Parameterized queries prevent injection.
     const filters = buildAuditFilters((k) => c.req.query(k));
-    if (filters.error) {
-      return c.json({ error: filters.error.error, message: filters.error.message }, filters.error.status as 400);
+    if (!filters.ok) {
+      return c.json({ error: filters.error, message: filters.message }, filters.status);
     }
     const { conditions, params } = filters;
     let { paramIdx } = filters;
@@ -1068,7 +1067,22 @@ admin.get("/audit", async (c) => {
       );
       const total = parseInt(String(countResult[0]?.count ?? "0"), 10);
 
-      const rows = await internalQuery(
+      const rows = await internalQuery<{
+        id: string;
+        timestamp: string;
+        user_id: string | null;
+        sql: string;
+        duration_ms: number;
+        row_count: number | null;
+        success: boolean;
+        error: string | null;
+        source_id: string | null;
+        source_type: string | null;
+        target_host: string | null;
+        user_label: string | null;
+        auth_mode: string;
+        user_email: string | null;
+      }>(
         `SELECT a.*, u.email AS user_email
          FROM audit_log a
          LEFT JOIN "user" u ON a.user_id = u.id
@@ -1101,8 +1115,8 @@ admin.get("/audit/export", async (c) => {
 
   return withRequestContext({ requestId, user: authResult.user }, async () => {
     const filters = buildAuditFilters((k) => c.req.query(k));
-    if (filters.error) {
-      return c.json({ error: filters.error.error, message: filters.error.message }, filters.error.status as 400);
+    if (!filters.ok) {
+      return c.json({ error: filters.error, message: filters.message }, filters.status);
     }
     const { conditions, params } = filters;
     let { paramIdx } = filters;
@@ -1111,13 +1125,20 @@ admin.get("/audit/export", async (c) => {
     const exportLimit = 10000;
 
     try {
+      // Count total matching rows to detect truncation
+      const countResult = await internalQuery<{ count: string }>(
+        `SELECT COUNT(*) as count FROM audit_log a LEFT JOIN "user" u ON a.user_id = u.id ${whereClause}`,
+        params,
+      );
+      const totalAvailable = parseInt(String(countResult[0]?.count ?? "0"), 10);
+
       const rows = await internalQuery<{
         id: string;
         timestamp: string;
-        user_id: string;
+        user_id: string | null;
         sql: string;
         duration_ms: number;
-        row_count: number;
+        row_count: number | null;
         success: boolean;
         error: string | null;
         source_id: string | null;
@@ -1148,11 +1169,17 @@ admin.get("/audit/export", async (c) => {
 
       const csv = csvHeader + csvRows.join("\n");
       const filename = `audit-log-${new Date().toISOString().slice(0, 10)}.csv`;
+      const truncated = totalAvailable > exportLimit;
 
       return new Response(csv, {
         headers: {
           "Content-Type": "text/csv; charset=utf-8",
           "Content-Disposition": `attachment; filename="${filename}"`,
+          ...(truncated && {
+            "X-Export-Truncated": "true",
+            "X-Export-Total": String(totalAvailable),
+            "X-Export-Limit": String(exportLimit),
+          }),
         },
       });
     } catch (err) {
@@ -1186,7 +1213,7 @@ admin.get("/audit/stats", async (c) => {
 
       const total = parseInt(String(totalResult[0]?.total ?? "0"), 10);
       const errors = parseInt(String(totalResult[0]?.errors ?? "0"), 10);
-      const errorRate = total > 0 ? errors / total : 0;
+      const errorRate = total > 0 ? (errors / total) * 100 : 0;
 
       const dailyResult = await internalQuery<{ day: string; count: string }>(
         `SELECT DATE(timestamp) as day, COUNT(*) as count FROM audit_log WHERE timestamp >= NOW() - INTERVAL '7 days' GROUP BY DATE(timestamp) ORDER BY day DESC`,

--- a/packages/web/src/app/admin/audit/columns.tsx
+++ b/packages/web/src/app/admin/audit/columns.tsx
@@ -9,14 +9,14 @@ import { Clock, User, Code, Timer, Rows3, CheckCircle } from "lucide-react";
 
 export interface AuditRow {
   id: string;
-  user_id: string;
+  user_id: string | null;
   sql: string;
   success: boolean;
   duration_ms: number;
-  row_count: number;
+  row_count: number | null;
   timestamp: string;
   user_email?: string | null;
-  error?: string;
+  error?: string | null;
   source_id?: string | null;
 }
 
@@ -120,7 +120,7 @@ export function getAuditColumns(): ColumnDef<AuditRow>[] {
       ),
       cell: ({ row }) => (
         <span className="text-right text-xs tabular-nums block">
-          {row.getValue<number>("row_count")}
+          {row.getValue<number | null>("row_count") ?? "—"}
         </span>
       ),
       meta: {

--- a/packages/web/src/app/admin/audit/page.tsx
+++ b/packages/web/src/app/admin/audit/page.tsx
@@ -40,7 +40,6 @@ interface AuditStats {
 
 interface ConnectionMeta {
   id: string;
-  dbType: string;
   description?: string;
 }
 
@@ -79,6 +78,17 @@ function buildQueryString(p: AuditQueryParams, opts?: { noPagination?: boolean }
   return qs;
 }
 
+/** Extract server error message from a non-ok response, falling back to status code. */
+async function extractErrorMessage(res: Response, fallback: string): Promise<string> {
+  try {
+    const body = await res.json();
+    if (body?.message) return body.message;
+  } catch {
+    // Response body not JSON
+  }
+  return `${fallback}: HTTP ${res.status}`;
+}
+
 export default function AuditPage() {
   const { apiUrl, isCrossOrigin } = useAtlasConfig();
   const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
@@ -87,6 +97,7 @@ export default function AuditPage() {
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<FetchError | null>(null);
+  const [exportError, setExportError] = useState<string | null>(null);
   const [exporting, setExporting] = useState(false);
 
   const [params, setParams] = useQueryStates(auditSearchParams);
@@ -97,7 +108,7 @@ export default function AuditPage() {
   const [analyticsTo, setAnalyticsTo] = useState("");
 
   // Connection list for filter dropdown
-  const { data: connectionsData } = useAdminFetch<{ connections: ConnectionMeta[] }>(
+  const { data: connectionsData, error: connectionsError } = useAdminFetch<{ connections: ConnectionMeta[] }>(
     "/api/v1/admin/connections",
   );
   const connectionList = connectionsData?.connections ?? [];
@@ -123,9 +134,10 @@ export default function AuditPage() {
     "/api/v1/admin/audit/stats",
   );
 
-  // Clear stale error when switching tabs
+  // Clear stale errors when switching tabs
   useEffect(() => {
     setError(null);
+    setExportError(null);
   }, [tab]);
 
   // Read pagination from table state for fetching
@@ -152,7 +164,10 @@ export default function AuditPage() {
         const qs = buildQueryString(queryParams);
         const res = await fetch(`${apiUrl}/api/v1/admin/audit?${qs}`, { credentials });
         if (!res.ok) {
-          if (!cancelled) setError({ message: `HTTP ${res.status}`, status: res.status });
+          if (!cancelled) {
+            const msg = await extractErrorMessage(res, "Failed to load audit log");
+            setError({ message: msg, status: res.status });
+          }
           return;
         }
         const data = await res.json();
@@ -176,13 +191,21 @@ export default function AuditPage() {
 
   async function handleExport() {
     setExporting(true);
+    setExportError(null);
     try {
       const qs = buildQueryString(queryParams, { noPagination: true });
       const res = await fetch(`${apiUrl}/api/v1/admin/audit/export?${qs}`, { credentials });
       if (!res.ok) {
-        setError({ message: `Export failed: HTTP ${res.status}`, status: res.status });
+        const msg = await extractErrorMessage(res, "Export failed");
+        setExportError(msg);
         return;
       }
+
+      // Check for truncation
+      const truncated = res.headers.get("X-Export-Truncated") === "true";
+      const exportTotal = res.headers.get("X-Export-Total");
+      const exportLimit = res.headers.get("X-Export-Limit");
+
       const blob = await res.blob();
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
@@ -190,10 +213,14 @@ export default function AuditPage() {
       a.download = `audit-log-${new Date().toISOString().slice(0, 10)}.csv`;
       a.click();
       URL.revokeObjectURL(url);
+
+      if (truncated) {
+        setExportError(
+          `Export limited to ${Number(exportLimit).toLocaleString()} rows out of ${Number(exportTotal).toLocaleString()} total. Apply filters to narrow results.`,
+        );
+      }
     } catch (err) {
-      setError({
-        message: err instanceof Error ? err.message : "Export failed",
-      });
+      setExportError(err instanceof Error ? err.message : "Export failed");
     } finally {
       setExporting(false);
     }
@@ -318,6 +345,14 @@ export default function AuditPage() {
             </div>
           ) : null}
 
+          {/* Export error (separate from list error) */}
+          {exportError && (
+            <ErrorBanner
+              message={exportError}
+              onRetry={() => { setExportError(null); handleExport(); }}
+            />
+          )}
+
           {/* Search + Filters */}
           <div className="flex flex-wrap items-end gap-3">
             <div className="relative flex-1 min-w-[200px] max-w-sm">
@@ -330,7 +365,7 @@ export default function AuditPage() {
               />
             </div>
 
-            {connectionList.length > 1 && (
+            {connectionList.length > 1 ? (
               <Select
                 value={connection || "__all__"}
                 onValueChange={(v) => setParams({ connection: v === "__all__" ? "" : v })}
@@ -347,7 +382,14 @@ export default function AuditPage() {
                   ))}
                 </SelectContent>
               </Select>
-            )}
+            ) : connectionsError && !connectionsError.status ? (
+              <Select disabled>
+                <SelectTrigger className="h-9 w-44 opacity-50">
+                  <SelectValue placeholder="Connections unavailable" />
+                </SelectTrigger>
+                <SelectContent />
+              </Select>
+            ) : null}
 
             <Input
               placeholder="Filter by table..."


### PR DESCRIPTION
## Summary
Closes #489, closes #490

Addresses all findings from the PR #487 review:

- **Server error extraction** — fetch/export handlers now parse `{ message }` from error responses instead of showing generic "HTTP 400"
- **Separate export error state** — export errors no longer clobber the list error; retry targets the correct action
- **errorRate display** — API returns percentage (5.0) not ratio (0.05), fixing "0.1%" → "5.0%" display
- **AuditRow nullability** — `user_id` and `row_count` typed as nullable per DB schema; null `row_count` renders "—"
- **Discriminated union** — `buildAuditFilters` returns `{ ok: true, ... } | { ok: false, ... }`, eliminating `as 400` casts
- **List endpoint type parameter** — `internalQuery<...>` on the list endpoint (export already had one)
- **Export truncation** — COUNT query detects truncation, sets `X-Export-Truncated`/`X-Export-Total`/`X-Export-Limit` headers; frontend shows warning banner
- **Connections error** — disabled dropdown with "Connections unavailable" instead of silently hidden
- **CSV \r handling** — `csvField` also handles carriage returns
- **4 new tests** — combined filters paramIdx, export auth (403), empty export, export invalid date (400)

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run type` — passes
- [x] `bun run test` — 64 admin tests pass (4 new)
- [x] `bun x syncpack lint` — no issues