### PR TITLE
feat(plugins): webhook interaction plugin for Zapier/Make/n8n

### DIFF
--- a/.syncpackrc.json
+++ b/.syncpackrc.json
@@ -34,6 +34,7 @@
         "@useatlas/vercel-sandbox",
         "@useatlas/slack",
         "@useatlas/teams",
+        "@useatlas/webhook",
         "@useatlas/mcp",
         "@useatlas/email",
         "@useatlas/jira",

--- a/apps/docs/content/docs/plugins/interactions/meta.json
+++ b/apps/docs/content/docs/plugins/interactions/meta.json
@@ -5,6 +5,7 @@
     "mcp",
     "obsidian",
     "slack",
-    "teams"
+    "teams",
+    "webhook"
   ]
 }

--- a/apps/docs/content/docs/plugins/interactions/webhook.mdx
+++ b/apps/docs/content/docs/plugins/interactions/webhook.mdx
@@ -1,0 +1,238 @@
+---
+title: Webhook
+description: Accept inbound HTTP requests from Zapier, Make, n8n, and other automation tools to query Atlas.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+The Webhook interaction plugin accepts inbound HTTP requests with a query, runs the Atlas agent, and returns structured results. It is designed for integration with automation platforms like Zapier, Make, and n8n.
+
+Each webhook channel has its own authentication (API key header or HMAC signature) and can optionally deliver results asynchronously via a callback URL.
+
+## Installation
+
+```bash
+bun add @useatlas/webhook
+```
+
+### Prerequisites
+
+- At least one webhook channel configured with a secret
+- An `executeQuery` callback wired to the Atlas agent
+
+## Configuration
+
+```typescript
+import { defineConfig } from "@atlas/api/lib/config";
+import { executeAgentQuery } from "@atlas/api/lib/agent-query";
+import { webhookPlugin } from "@useatlas/webhook";
+
+export default defineConfig({
+  plugins: [
+    webhookPlugin({
+      channels: [
+        {
+          channelId: "zapier-prod",
+          authType: "api-key",
+          secret: process.env.WEBHOOK_SECRET!,
+          responseFormat: "json",
+        },
+      ],
+      executeQuery: executeAgentQuery,
+    }),
+  ],
+});
+```
+
+For multiple channels with different auth methods:
+
+```typescript
+export default defineConfig({
+  plugins: [
+    webhookPlugin({
+      channels: [
+        {
+          channelId: "zapier",
+          authType: "api-key",
+          secret: process.env.ZAPIER_WEBHOOK_SECRET!,
+          responseFormat: "json",
+        },
+        {
+          channelId: "n8n",
+          authType: "hmac",
+          secret: process.env.N8N_HMAC_SECRET!,
+          responseFormat: "json",
+          callbackUrl: "https://n8n.example.com/webhook-response",
+        },
+      ],
+      executeQuery: executeAgentQuery,
+    }),
+  ],
+});
+```
+
+### Options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `channels` | `WebhookChannel[]` | Yes | Array of webhook channel configurations. At least one channel is required. |
+| `executeQuery` | `function` | Yes | Callback that runs the Atlas agent on a question and returns structured results. |
+
+### Channel Options
+
+| Option | Type | Required | Default | Description |
+|--------|------|----------|---------|-------------|
+| `channelId` | `string` | Yes | — | Unique identifier for this webhook channel. Used in the endpoint URL. |
+| `authType` | `"api-key" \| "hmac"` | Yes | — | Authentication method for this channel. |
+| `secret` | `string` | Yes | — | API key or HMAC secret for request verification. |
+| `responseFormat` | `"json" \| "text"` | No | `"json"` | Response format. `"json"` returns structured data; `"text"` returns the answer string only. |
+| `callbackUrl` | `string` | No | — | When set, the plugin accepts requests immediately and POSTs results to this URL when done. |
+
+## Endpoint Reference
+
+### `POST /webhook/:channelId`
+
+The main inbound endpoint. Replace `:channelId` with the channel's `channelId` value from your configuration. The full URL path depends on how the host mounts the plugin (typically `/api/plugins/webhook-interaction/webhook/:channelId`).
+
+#### Authentication
+
+**API key mode** (`authType: "api-key"`): Send the secret in the `X-Webhook-Secret` header.
+
+```bash
+curl -X POST https://api.example.com/api/plugins/webhook-interaction/webhook/zapier \
+  -H "Content-Type: application/json" \
+  -H "X-Webhook-Secret: your-secret-here" \
+  -d '{"query": "How many active users last month?"}'
+```
+
+**HMAC mode** (`authType: "hmac"`): Compute an HMAC-SHA256 of the request body using the shared secret, and send the hex digest in the `X-Webhook-Signature` header.
+
+```bash
+BODY='{"query": "How many active users last month?"}'
+SIGNATURE=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "your-secret" | cut -d' ' -f2)
+
+curl -X POST https://api.example.com/api/plugins/webhook-interaction/webhook/n8n \
+  -H "Content-Type: application/json" \
+  -H "X-Webhook-Signature: $SIGNATURE" \
+  -d "$BODY"
+```
+
+#### Request Body
+
+```json
+{
+  "query": "How many active users last month?",
+  "context": { "source": "zapier", "workflow_id": "abc123" },
+  "callbackUrl": "https://example.com/callback"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `query` | `string` | Yes | The question to ask Atlas. |
+| `context` | `Record<string, string>` | No | Optional metadata. Accepted but not forwarded — reserved for future use. |
+| `callbackUrl` | `string` | No | Overrides the channel-level callback URL for this request. Must be a valid HTTP/HTTPS URL (internal/private IPs are rejected). |
+
+#### Synchronous Response (200)
+
+When no `callbackUrl` is configured (channel or request level):
+
+```json
+{
+  "success": true,
+  "result": {
+    "answer": "There were 1,247 active users last month.",
+    "sql": ["SELECT COUNT(*) FROM users WHERE active = true AND last_seen > NOW() - INTERVAL '30 days'"],
+    "columns": ["count"],
+    "rows": [{ "count": 1247 }]
+  }
+}
+```
+
+With `responseFormat: "text"`:
+
+```json
+{
+  "success": true,
+  "result": "There were 1,247 active users last month."
+}
+```
+
+#### Asynchronous Response (202)
+
+When a `callbackUrl` is present:
+
+```json
+{
+  "accepted": true,
+  "requestId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+The plugin POSTs the full result to the callback URL when ready. Delivery is at-most-once — if the callback endpoint is unreachable, results are logged but not retried. If the query fails, an error payload is delivered instead:
+
+```json
+{
+  "requestId": "550e8400-e29b-41d4-a716-446655440000",
+  "success": true,
+  "result": {
+    "answer": "There were 1,247 active users last month.",
+    "sql": ["SELECT COUNT(*) FROM users WHERE active = true AND last_seen > NOW() - INTERVAL '30 days'"],
+    "columns": ["count"],
+    "rows": [{ "count": 1247 }]
+  }
+}
+```
+
+#### Error Responses
+
+| Status | Meaning |
+|--------|---------|
+| `400` | Missing or empty `query`, or invalid JSON body |
+| `401` | Invalid API key or HMAC signature |
+| `404` | Unknown `channelId` |
+| `500` | Agent query execution failed |
+
+## Platform Setup Guides
+
+### Zapier
+
+1. Create a new Zap and add a **Webhooks by Zapier** action (or use a trigger from any app).
+2. Add a **Webhooks by Zapier > POST** action step.
+3. Set the URL to `https://your-atlas-api.com/api/plugins/webhook-interaction/webhook/zapier`.
+4. Add a header: `X-Webhook-Secret` with your secret value.
+5. Set the body to `{"query": "your question here"}`. Use Zapier template fields to make the query dynamic.
+
+### Make (Integromat)
+
+1. Add an **HTTP > Make a request** module.
+2. Set method to `POST` and URL to `https://your-atlas-api.com/api/plugins/webhook-interaction/webhook/make`.
+3. Add header `X-Webhook-Secret` with your secret.
+4. Set the body type to JSON: `{"query": "your question"}`.
+5. For async mode, add `"callbackUrl"` pointing to a **Webhooks > Custom webhook** trigger in another scenario.
+
+### n8n
+
+1. Add an **HTTP Request** node.
+2. Set method to `POST` and URL to `https://your-atlas-api.com/api/plugins/webhook-interaction/webhook/n8n`.
+3. Under **Authentication**, add a header auth with `X-Webhook-Secret`.
+4. Set the JSON body: `{"query": "{{$json.question}}"}`.
+5. For HMAC auth, use a **Code** node to compute the signature and set `X-Webhook-Signature`.
+
+<Callout type="info">
+The `executeQuery` callback is the bridge between the webhook plugin and the Atlas agent. It receives the user's question, runs the agent, and returns structured results with the SQL query, column names, and row data.
+</Callout>
+
+## Troubleshooting
+
+### 401 errors on all requests
+
+Verify that the secret in your automation tool matches the `secret` in your channel configuration. For HMAC mode, ensure you are computing SHA-256 over the raw request body (not URL-encoded).
+
+### Timeouts on synchronous requests
+
+Complex queries may take longer than your automation platform's timeout. Use async mode by setting a `callbackUrl` — the plugin will accept the request immediately and deliver results when ready.
+
+### 404 for a configured channel
+
+Ensure the `:channelId` in the URL matches the `channelId` in your channel configuration exactly (case-sensitive).

--- a/bun.lock
+++ b/bun.lock
@@ -574,6 +574,20 @@
         "@vercel/sandbox",
       ],
     },
+    "plugins/webhook": {
+      "name": "@useatlas/webhook",
+      "version": "0.0.5",
+      "devDependencies": {
+        "@useatlas/plugin-sdk": "workspace:*",
+        "hono": "^4.12.3",
+        "zod": "^4.3.6",
+      },
+      "peerDependencies": {
+        "@useatlas/plugin-sdk": ">=0.0.1",
+        "hono": "^4.0.0",
+        "zod": "^4.0.0",
+      },
+    },
     "plugins/yaml-context": {
       "name": "@useatlas/yaml-context",
       "version": "0.0.5",
@@ -1833,6 +1847,8 @@
     "@useatlas/types": ["@useatlas/types@workspace:packages/types"],
 
     "@useatlas/vercel-sandbox": ["@useatlas/vercel-sandbox@workspace:plugins/vercel-sandbox"],
+
+    "@useatlas/webhook": ["@useatlas/webhook@workspace:plugins/webhook"],
 
     "@useatlas/yaml-context": ["@useatlas/yaml-context@workspace:plugins/yaml-context"],
 

--- a/plugins/webhook/README.md
+++ b/plugins/webhook/README.md
@@ -1,0 +1,90 @@
+# @useatlas/webhook
+
+Webhook interaction plugin for Atlas — accept inbound HTTP requests with a query, run the Atlas agent, and return structured results. Designed for Zapier, Make, and n8n integrations.
+
+## Install
+
+```bash
+bun add @useatlas/webhook
+```
+
+## Usage
+
+```typescript
+import { defineConfig } from "@atlas/api/lib/config";
+import { webhookPlugin } from "@useatlas/webhook";
+
+export default defineConfig({
+  plugins: [
+    webhookPlugin({
+      channels: [
+        {
+          channelId: "zapier-prod",
+          authType: "api-key",
+          secret: process.env.WEBHOOK_SECRET!,
+          responseFormat: "json",
+        },
+      ],
+      executeQuery: myQueryFunction,
+    }),
+  ],
+});
+```
+
+## Config
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `channels` | `WebhookChannel[]` | — | Array of webhook channel configurations |
+| `executeQuery` | `function` | — | Callback to run the Atlas agent on a question |
+
+### Channel Config
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `channelId` | `string` | — | Unique identifier for this webhook channel |
+| `authType` | `"api-key" \| "hmac"` | — | Authentication method |
+| `secret` | `string` | — | API key or HMAC secret |
+| `responseFormat` | `"json" \| "text"` | `"json"` | Response format |
+| `callbackUrl` | `string?` | — | Optional async callback URL |
+
+## Endpoint
+
+```
+POST /webhook/:channelId
+```
+
+### Request
+
+```json
+{
+  "query": "How many active users last month?",
+  "context": { "source": "zapier" },
+  "callbackUrl": "https://example.com/callback"
+}
+```
+
+### Response (sync)
+
+```json
+{
+  "success": true,
+  "result": {
+    "answer": "42 active users",
+    "sql": ["SELECT COUNT(*) FROM users WHERE active = true"],
+    "columns": ["count"],
+    "rows": [{ "count": 42 }]
+  }
+}
+```
+
+### Response (async — when callbackUrl is set)
+
+```json
+{ "accepted": true, "requestId": "uuid" }
+```
+
+## Reference
+
+- [Plugin SDK docs](https://docs.useatlas.dev/plugins/sdk)
+- [Authoring guide](https://docs.useatlas.dev/plugins/authoring-guide)

--- a/plugins/webhook/__tests__/webhook.test.ts
+++ b/plugins/webhook/__tests__/webhook.test.ts
@@ -1,0 +1,880 @@
+/**
+ * Tests for the Webhook Interaction Plugin.
+ *
+ * Tests plugin shape, config validation, lifecycle, route behavior
+ * (auth, sync/async modes, error cases), and integration payloads.
+ */
+
+import {
+  describe,
+  test,
+  expect,
+  mock,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from "bun:test";
+import crypto from "crypto";
+import { Hono } from "hono";
+import { definePlugin, isInteractionPlugin } from "@useatlas/plugin-sdk";
+import { webhookPlugin, buildWebhookPlugin } from "../src/index";
+import type { WebhookPluginConfig, WebhookQueryResult } from "../src/index";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TEST_SECRET = "wh-test-secret-123";
+
+const defaultQueryResult: WebhookQueryResult = {
+  answer: "42 active users",
+  sql: ["SELECT COUNT(*) FROM users WHERE active = true"],
+  data: [{ columns: ["count"], rows: [{ count: 42 }] }],
+};
+
+function createMockConfig(
+  overrides?: Partial<WebhookPluginConfig>,
+): WebhookPluginConfig {
+  return {
+    channels: [
+      {
+        channelId: "test-channel",
+        authType: "api-key",
+        secret: TEST_SECRET,
+        responseFormat: "json",
+      },
+    ],
+    executeQuery: mock(() =>
+      Promise.resolve(defaultQueryResult),
+    ) as WebhookPluginConfig["executeQuery"],
+    ...overrides,
+  };
+}
+
+function createMockCtx() {
+  const logged: string[] = [];
+  return {
+    ctx: {
+      db: null,
+      connections: { get: () => ({}), list: () => [] },
+      tools: { register: () => {} },
+      logger: {
+        info: (...args: unknown[]) =>
+          logged.push(
+            typeof args[0] === "string" ? args[0] : String(args[1] ?? ""),
+          ),
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
+      config: {},
+    },
+    logged,
+  };
+}
+
+function createTestApp(config: WebhookPluginConfig): Hono {
+  const plugin = buildWebhookPlugin(config);
+  const app = new Hono();
+  plugin.routes!(app);
+  return app;
+}
+
+function hmacSign(secret: string, body: string): string {
+  return crypto.createHmac("sha256", secret).update(body).digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Plugin shape validation
+// ---------------------------------------------------------------------------
+
+describe("webhookPlugin — shape validation", () => {
+  test("createPlugin() produces a valid AtlasInteractionPlugin", () => {
+    const plugin = webhookPlugin(createMockConfig());
+    expect(plugin.id).toBe("webhook-interaction");
+    expect(plugin.types).toEqual(["interaction"]);
+    expect(plugin.version).toBe("0.1.0");
+    expect(plugin.name).toBe("Webhook");
+  });
+
+  test("definePlugin() accepts the created plugin", () => {
+    const plugin = webhookPlugin(createMockConfig());
+    const validated = definePlugin(plugin);
+    expect(validated).toBe(plugin);
+  });
+
+  test("isInteractionPlugin type guard returns true", () => {
+    const plugin = webhookPlugin(createMockConfig());
+    expect(isInteractionPlugin(plugin)).toBe(true);
+  });
+
+  test("config is stored on the plugin object", () => {
+    const config = createMockConfig();
+    const plugin = webhookPlugin(config);
+    expect(plugin.config?.channels).toHaveLength(1);
+    expect(plugin.config?.channels[0].channelId).toBe("test-channel");
+  });
+
+  test("routes is defined", () => {
+    const plugin = webhookPlugin(createMockConfig());
+    expect(typeof plugin.routes).toBe("function");
+  });
+
+  test("buildWebhookPlugin is available for direct use", () => {
+    const plugin = buildWebhookPlugin(createMockConfig());
+    expect(plugin.id).toBe("webhook-interaction");
+    expect(plugin.types).toEqual(["interaction"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Config validation
+// ---------------------------------------------------------------------------
+
+describe("webhookPlugin — config validation", () => {
+  test("accepts valid config with api-key auth", () => {
+    expect(() =>
+      webhookPlugin({
+        channels: [
+          { channelId: "ch1", authType: "api-key", secret: "s", responseFormat: "json" },
+        ],
+        executeQuery: mock(() => Promise.resolve(defaultQueryResult)),
+      }),
+    ).not.toThrow();
+  });
+
+  test("accepts valid config with hmac auth", () => {
+    expect(() =>
+      webhookPlugin({
+        channels: [
+          { channelId: "ch1", authType: "hmac", secret: "s", responseFormat: "text" },
+        ],
+        executeQuery: mock(() => Promise.resolve(defaultQueryResult)),
+      }),
+    ).not.toThrow();
+  });
+
+  test("rejects empty channels array", () => {
+    expect(() =>
+      webhookPlugin({
+        channels: [],
+        executeQuery: mock(() => Promise.resolve(defaultQueryResult)),
+      }),
+    ).toThrow("Plugin config validation failed");
+  });
+
+  test("rejects empty channelId", () => {
+    expect(() =>
+      webhookPlugin({
+        channels: [
+          { channelId: "", authType: "api-key", secret: "s", responseFormat: "json" },
+        ],
+        executeQuery: mock(() => Promise.resolve(defaultQueryResult)),
+      }),
+    ).toThrow("Plugin config validation failed");
+  });
+
+  test("rejects empty secret", () => {
+    expect(() =>
+      webhookPlugin({
+        channels: [
+          { channelId: "ch1", authType: "api-key", secret: "", responseFormat: "json" },
+        ],
+        executeQuery: mock(() => Promise.resolve(defaultQueryResult)),
+      }),
+    ).toThrow("Plugin config validation failed");
+  });
+
+  test("rejects non-function executeQuery", () => {
+    expect(() =>
+      webhookPlugin({
+        channels: [
+          { channelId: "ch1", authType: "api-key", secret: "s", responseFormat: "json" },
+        ],
+        executeQuery: "not-a-function" as unknown as WebhookPluginConfig["executeQuery"],
+      }),
+    ).toThrow("Plugin config validation failed");
+  });
+
+  test("rejects duplicate channelIds", () => {
+    expect(() =>
+      webhookPlugin({
+        channels: [
+          { channelId: "same", authType: "api-key", secret: "s1", responseFormat: "json" },
+          { channelId: "same", authType: "hmac", secret: "s2", responseFormat: "text" },
+        ],
+        executeQuery: mock(() => Promise.resolve(defaultQueryResult)),
+      }),
+    ).toThrow("Plugin config validation failed");
+  });
+
+  test("buildWebhookPlugin rejects duplicate channelIds", () => {
+    expect(() =>
+      buildWebhookPlugin({
+        channels: [
+          { channelId: "dup", authType: "api-key", secret: "s1", responseFormat: "json" },
+          { channelId: "dup", authType: "api-key", secret: "s2", responseFormat: "json" },
+        ],
+        executeQuery: mock(() => Promise.resolve(defaultQueryResult)),
+      }),
+    ).toThrow('Duplicate channelId "dup"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+describe("webhookPlugin — lifecycle", () => {
+  test("initializes successfully", async () => {
+    const plugin = webhookPlugin(createMockConfig());
+    const { ctx, logged } = createMockCtx();
+
+    await plugin.initialize!(ctx as never);
+    expect(logged.some((m) => m.includes("initialized"))).toBe(true);
+  });
+
+  test("double initialize throws", async () => {
+    const plugin = webhookPlugin(createMockConfig());
+    const { ctx } = createMockCtx();
+
+    await plugin.initialize!(ctx as never);
+    await expect(plugin.initialize!(ctx as never)).rejects.toThrow(
+      "already initialized",
+    );
+  });
+
+  test("healthCheck returns unhealthy before init", async () => {
+    const plugin = webhookPlugin(createMockConfig());
+    const result = await plugin.healthCheck!();
+    expect(result.healthy).toBe(false);
+  });
+
+  test("healthCheck returns healthy after init", async () => {
+    const plugin = webhookPlugin(createMockConfig());
+    const { ctx } = createMockCtx();
+
+    await plugin.initialize!(ctx as never);
+    const result = await plugin.healthCheck!();
+    expect(result.healthy).toBe(true);
+  });
+
+  test("healthCheck returns unhealthy after teardown", async () => {
+    const plugin = webhookPlugin(createMockConfig());
+    const { ctx } = createMockCtx();
+
+    await plugin.initialize!(ctx as never);
+    await plugin.teardown!();
+    const result = await plugin.healthCheck!();
+    expect(result.healthy).toBe(false);
+  });
+
+  test("teardown is safe to call without initialization", async () => {
+    const plugin = webhookPlugin(createMockConfig());
+    await expect(plugin.teardown!()).resolves.toBeUndefined();
+  });
+
+  test("initialize logs channel count", async () => {
+    const plugin = webhookPlugin(
+      createMockConfig({
+        channels: [
+          { channelId: "a", authType: "api-key", secret: "s", responseFormat: "json" },
+          { channelId: "b", authType: "hmac", secret: "s", responseFormat: "text" },
+        ],
+      }),
+    );
+    const { ctx, logged } = createMockCtx();
+
+    await plugin.initialize!(ctx as never);
+    expect(logged.some((m) => m.includes("2 channels"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Route tests: API key auth
+// ---------------------------------------------------------------------------
+
+describe("routes — API key auth", () => {
+  test("valid API key returns 200 with result", async () => {
+    const app = createTestApp(createMockConfig());
+
+    const resp = await app.request("/webhook/test-channel", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Secret": TEST_SECRET,
+      },
+      body: JSON.stringify({ query: "how many users?" }),
+    });
+
+    expect(resp.status).toBe(200);
+    const json = (await resp.json()) as Record<string, unknown>;
+    expect(json.success).toBe(true);
+    const result = json.result as Record<string, unknown>;
+    expect(result.answer).toBe("42 active users");
+    expect(result.sql).toEqual(["SELECT COUNT(*) FROM users WHERE active = true"]);
+    expect(result.columns).toEqual(["count"]);
+    expect(result.rows).toEqual([{ count: 42 }]);
+  });
+
+  test("invalid API key returns 401", async () => {
+    const app = createTestApp(createMockConfig());
+
+    const resp = await app.request("/webhook/test-channel", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Secret": "wrong-key",
+      },
+      body: JSON.stringify({ query: "how many users?" }),
+    });
+
+    expect(resp.status).toBe(401);
+  });
+
+  test("missing API key header returns 401", async () => {
+    const app = createTestApp(createMockConfig());
+
+    const resp = await app.request("/webhook/test-channel", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "how many users?" }),
+    });
+
+    expect(resp.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Route tests: HMAC auth
+// ---------------------------------------------------------------------------
+
+describe("routes — HMAC auth", () => {
+  const HMAC_SECRET = "hmac-test-secret";
+
+  function createHmacApp(): Hono {
+    return createTestApp(
+      createMockConfig({
+        channels: [
+          {
+            channelId: "hmac-channel",
+            authType: "hmac",
+            secret: HMAC_SECRET,
+            responseFormat: "json",
+          },
+        ],
+      }),
+    );
+  }
+
+  test("valid HMAC signature returns 200", async () => {
+    const app = createHmacApp();
+    const body = JSON.stringify({ query: "revenue last month?" });
+    const signature = hmacSign(HMAC_SECRET, body);
+
+    const resp = await app.request("/webhook/hmac-channel", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Signature": signature,
+      },
+      body,
+    });
+
+    expect(resp.status).toBe(200);
+    const json = (await resp.json()) as Record<string, unknown>;
+    expect(json.success).toBe(true);
+  });
+
+  test("invalid HMAC signature returns 401", async () => {
+    const app = createHmacApp();
+    const body = JSON.stringify({ query: "revenue last month?" });
+
+    const resp = await app.request("/webhook/hmac-channel", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Signature": "invalid-signature",
+      },
+      body,
+    });
+
+    expect(resp.status).toBe(401);
+  });
+
+  test("missing HMAC signature returns 401", async () => {
+    const app = createHmacApp();
+
+    const resp = await app.request("/webhook/hmac-channel", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "revenue last month?" }),
+    });
+
+    expect(resp.status).toBe(401);
+  });
+
+  test("HMAC signature for different body is rejected", async () => {
+    const app = createHmacApp();
+    const bodyA = JSON.stringify({ query: "original query" });
+    const bodyB = JSON.stringify({ query: "tampered query" });
+    const signatureForA = hmacSign(HMAC_SECRET, bodyA);
+
+    const resp = await app.request("/webhook/hmac-channel", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Signature": signatureForA,
+      },
+      body: bodyB,
+    });
+
+    expect(resp.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Route tests: Request validation
+// ---------------------------------------------------------------------------
+
+describe("routes — request validation", () => {
+  test("unknown channelId returns 404", async () => {
+    const app = createTestApp(createMockConfig());
+
+    const resp = await app.request("/webhook/nonexistent", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Secret": TEST_SECRET,
+      },
+      body: JSON.stringify({ query: "hello" }),
+    });
+
+    expect(resp.status).toBe(404);
+    const json = (await resp.json()) as Record<string, unknown>;
+    expect(json.error).toBe("Unknown channel");
+  });
+
+  test("missing query body returns 400", async () => {
+    const app = createTestApp(createMockConfig());
+
+    const resp = await app.request("/webhook/test-channel", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Secret": TEST_SECRET,
+      },
+      body: JSON.stringify({}),
+    });
+
+    expect(resp.status).toBe(400);
+    const json = (await resp.json()) as Record<string, unknown>;
+    expect(json.error).toContain("Missing");
+  });
+
+  test("empty query string returns 400", async () => {
+    const app = createTestApp(createMockConfig());
+
+    const resp = await app.request("/webhook/test-channel", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Secret": TEST_SECRET,
+      },
+      body: JSON.stringify({ query: "  " }),
+    });
+
+    expect(resp.status).toBe(400);
+  });
+
+  test("invalid JSON body returns 400", async () => {
+    const app = createTestApp(createMockConfig());
+
+    const resp = await app.request("/webhook/test-channel", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Secret": TEST_SECRET,
+      },
+      body: "not json",
+    });
+
+    expect(resp.status).toBe(400);
+    const json = (await resp.json()) as Record<string, unknown>;
+    expect(json.error).toContain("Invalid JSON");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Route tests: Query execution
+// ---------------------------------------------------------------------------
+
+describe("routes — query execution", () => {
+  test("calls executeQuery with the provided query", async () => {
+    const mockExecuteQuery = mock(() =>
+      Promise.resolve(defaultQueryResult),
+    ) as Mock<WebhookPluginConfig["executeQuery"]>;
+    const app = createTestApp(createMockConfig({ executeQuery: mockExecuteQuery }));
+
+    await app.request("/webhook/test-channel", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Secret": TEST_SECRET,
+      },
+      body: JSON.stringify({ query: "how many users?" }),
+    });
+
+    expect(mockExecuteQuery).toHaveBeenCalledWith("how many users?");
+  });
+
+  test("returns 500 when executeQuery throws", async () => {
+    const failingQuery = mock(() =>
+      Promise.reject(new Error("Agent error")),
+    ) as Mock<WebhookPluginConfig["executeQuery"]>;
+    const app = createTestApp(createMockConfig({ executeQuery: failingQuery }));
+
+    const resp = await app.request("/webhook/test-channel", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Secret": TEST_SECRET,
+      },
+      body: JSON.stringify({ query: "bad query" }),
+    });
+
+    expect(resp.status).toBe(500);
+    const json = (await resp.json()) as Record<string, unknown>;
+    expect(json.error).toContain("execution failed");
+  });
+
+  test("text responseFormat returns plain answer", async () => {
+    const app = createTestApp(
+      createMockConfig({
+        channels: [
+          {
+            channelId: "text-ch",
+            authType: "api-key",
+            secret: TEST_SECRET,
+            responseFormat: "text",
+          },
+        ],
+      }),
+    );
+
+    const resp = await app.request("/webhook/text-ch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Secret": TEST_SECRET,
+      },
+      body: JSON.stringify({ query: "how many users?" }),
+    });
+
+    expect(resp.status).toBe(200);
+    const json = (await resp.json()) as Record<string, unknown>;
+    expect(json.success).toBe(true);
+    expect(json.result).toBe("42 active users");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Route tests: Async mode
+// ---------------------------------------------------------------------------
+
+describe("routes — async mode", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("returns 202 with requestId when callbackUrl is in channel config", async () => {
+    const app = createTestApp(
+      createMockConfig({
+        channels: [
+          {
+            channelId: "async-ch",
+            authType: "api-key",
+            secret: TEST_SECRET,
+            responseFormat: "json",
+            callbackUrl: "https://example.com/callback",
+          },
+        ],
+      }),
+    );
+
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 })),
+    ) as unknown as typeof globalThis.fetch;
+
+    const resp = await app.request("/webhook/async-ch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Secret": TEST_SECRET,
+      },
+      body: JSON.stringify({ query: "how many users?" }),
+    });
+
+    expect(resp.status).toBe(202);
+    const json = (await resp.json()) as Record<string, unknown>;
+    expect(json.accepted).toBe(true);
+    expect(typeof json.requestId).toBe("string");
+  });
+
+  test("returns 202 when callbackUrl is in request body", async () => {
+    const app = createTestApp(createMockConfig());
+
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 })),
+    ) as unknown as typeof globalThis.fetch;
+
+    const resp = await app.request("/webhook/test-channel", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Secret": TEST_SECRET,
+      },
+      body: JSON.stringify({
+        query: "how many users?",
+        callbackUrl: "https://example.com/callback",
+      }),
+    });
+
+    expect(resp.status).toBe(202);
+    const json = (await resp.json()) as Record<string, unknown>;
+    expect(json.accepted).toBe(true);
+  });
+
+  test("async mode delivers correct payload to callback URL", async () => {
+    const mockFetch = mock(() =>
+      Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 })),
+    );
+    globalThis.fetch = mockFetch as unknown as typeof globalThis.fetch;
+
+    const app = createTestApp(
+      createMockConfig({
+        channels: [
+          {
+            channelId: "async-ch",
+            authType: "api-key",
+            secret: TEST_SECRET,
+            responseFormat: "json",
+            callbackUrl: "https://example.com/callback",
+          },
+        ],
+      }),
+    );
+
+    await app.request("/webhook/async-ch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Secret": TEST_SECRET,
+      },
+      body: JSON.stringify({ query: "how many users?" }),
+    });
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(mockFetch).toHaveBeenCalled();
+    const [callUrl, callOpts] = mockFetch.mock.calls[0] as unknown as [string, RequestInit];
+    expect(callUrl).toBe("https://example.com/callback");
+    expect(callOpts.method).toBe("POST");
+    expect(callOpts.headers).toEqual({ "Content-Type": "application/json" });
+
+    const delivered = JSON.parse(callOpts.body as string) as Record<string, unknown>;
+    expect(typeof delivered.requestId).toBe("string");
+    expect(delivered.success).toBe(true);
+    const result = delivered.result as Record<string, unknown>;
+    expect(result.answer).toBe("42 active users");
+    expect(result.sql).toEqual(["SELECT COUNT(*) FROM users WHERE active = true"]);
+    expect(result.columns).toEqual(["count"]);
+  });
+
+  test("async mode delivers error payload when executeQuery fails", async () => {
+    const mockFetch = mock(() =>
+      Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 })),
+    );
+    globalThis.fetch = mockFetch as unknown as typeof globalThis.fetch;
+
+    const failingQuery = mock(() =>
+      Promise.reject(new Error("Agent crashed")),
+    ) as Mock<WebhookPluginConfig["executeQuery"]>;
+
+    const app = createTestApp(
+      createMockConfig({
+        channels: [
+          {
+            channelId: "async-ch",
+            authType: "api-key",
+            secret: TEST_SECRET,
+            responseFormat: "json",
+            callbackUrl: "https://example.com/callback",
+          },
+        ],
+        executeQuery: failingQuery,
+      }),
+    );
+
+    const resp = await app.request("/webhook/async-ch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Secret": TEST_SECRET,
+      },
+      body: JSON.stringify({ query: "bad query" }),
+    });
+
+    expect(resp.status).toBe(202);
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(mockFetch).toHaveBeenCalled();
+    const [, callOpts] = mockFetch.mock.calls[0] as unknown as [string, RequestInit];
+    const delivered = JSON.parse(callOpts.body as string) as Record<string, unknown>;
+    expect(delivered.success).toBe(false);
+    expect(delivered.error).toContain("execution failed");
+    expect(typeof delivered.requestId).toBe("string");
+  });
+
+  test("request-level callbackUrl overrides channel-level callbackUrl", async () => {
+    const mockFetch = mock(() =>
+      Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 })),
+    );
+    globalThis.fetch = mockFetch as unknown as typeof globalThis.fetch;
+
+    const app = createTestApp(
+      createMockConfig({
+        channels: [
+          {
+            channelId: "async-ch",
+            authType: "api-key",
+            secret: TEST_SECRET,
+            responseFormat: "json",
+            callbackUrl: "https://channel-level.com/callback",
+          },
+        ],
+      }),
+    );
+
+    await app.request("/webhook/async-ch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Secret": TEST_SECRET,
+      },
+      body: JSON.stringify({
+        query: "how many users?",
+        callbackUrl: "https://request-level.com/callback",
+      }),
+    });
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(mockFetch).toHaveBeenCalled();
+    const [callUrl] = mockFetch.mock.calls[0] as unknown as [string, RequestInit];
+    expect(callUrl).toBe("https://request-level.com/callback");
+  });
+
+  test("rejects internal/private callbackUrl (SSRF prevention)", async () => {
+    const app = createTestApp(createMockConfig());
+
+    const internalUrls = [
+      "http://localhost:3001/admin",
+      "http://127.0.0.1/secret",
+      "http://10.0.0.1/internal",
+      "http://192.168.1.1/router",
+      "http://169.254.169.254/latest/meta-data/",
+      "http://172.16.0.1/internal",
+    ];
+
+    for (const callbackUrl of internalUrls) {
+      const resp = await app.request("/webhook/test-channel", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Webhook-Secret": TEST_SECRET,
+        },
+        body: JSON.stringify({ query: "test", callbackUrl }),
+      });
+
+      expect(resp.status).toBe(400);
+      const json = (await resp.json()) as Record<string, unknown>;
+      expect(json.error).toContain("Invalid callback URL");
+    }
+  });
+
+  test("rejects non-string callbackUrl in request body", async () => {
+    const app = createTestApp(createMockConfig());
+
+    const resp = await app.request("/webhook/test-channel", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Secret": TEST_SECRET,
+      },
+      body: JSON.stringify({ query: "test", callbackUrl: 12345 }),
+    });
+
+    // Non-string callbackUrl is ignored, falls through to sync mode
+    expect(resp.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration examples: Zapier / n8n payloads
+// ---------------------------------------------------------------------------
+
+describe("routes — integration payloads", () => {
+  test("Zapier-style payload", async () => {
+    const app = createTestApp(createMockConfig());
+
+    const resp = await app.request("/webhook/test-channel", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Secret": TEST_SECRET,
+      },
+      body: JSON.stringify({
+        query: "What is our MRR this month?",
+        context: { source: "zapier", zap_id: "12345" },
+      }),
+    });
+
+    expect(resp.status).toBe(200);
+    const json = (await resp.json()) as Record<string, unknown>;
+    expect(json.success).toBe(true);
+  });
+
+  test("n8n-style payload with callback", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 })),
+    ) as unknown as typeof globalThis.fetch;
+
+    try {
+      const app = createTestApp(createMockConfig());
+
+      const resp = await app.request("/webhook/test-channel", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Webhook-Secret": TEST_SECRET,
+        },
+        body: JSON.stringify({
+          query: "Show me top 10 customers by revenue",
+          callbackUrl: "https://n8n.example.com/webhook-response/abc123",
+          context: { workflow: "revenue-report" },
+        }),
+      });
+
+      expect(resp.status).toBe(202);
+      const json = (await resp.json()) as Record<string, unknown>;
+      expect(json.accepted).toBe(true);
+      expect(typeof json.requestId).toBe("string");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/plugins/webhook/package.json
+++ b/plugins/webhook/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@useatlas/webhook",
+  "version": "0.0.5",
+  "description": "Atlas webhook interaction plugin for Zapier, Make, and n8n integrations",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "files": [
+    "src/",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "test": "bun test __tests__/webhook.test.ts"
+  },
+  "keywords": [
+    "atlas",
+    "text-to-sql",
+    "plugin",
+    "interaction",
+    "webhook",
+    "zapier",
+    "make",
+    "n8n"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AtlasDevHQ/atlas",
+    "directory": "plugins/webhook"
+  },
+  "homepage": "https://docs.useatlas.dev",
+  "bugs": {
+    "url": "https://github.com/AtlasDevHQ/atlas/issues"
+  },
+  "license": "MIT",
+  "peerDependencies": {
+    "hono": "^4.0.0",
+    "zod": "^4.0.0",
+    "@useatlas/plugin-sdk": ">=0.0.1"
+  },
+  "devDependencies": {
+    "hono": "^4.12.3",
+    "zod": "^4.3.6",
+    "@useatlas/plugin-sdk": "workspace:*"
+  }
+}

--- a/plugins/webhook/src/config.ts
+++ b/plugins/webhook/src/config.ts
@@ -1,0 +1,49 @@
+/**
+ * Webhook plugin configuration schema.
+ *
+ * Each webhook channel has its own authentication method, response format,
+ * and optional callback URL for async delivery.
+ */
+
+import { z } from "zod";
+
+export const WebhookChannelSchema = z.object({
+  /** Unique identifier for this webhook channel. */
+  channelId: z.string().min(1, "channelId must not be empty"),
+  /** Authentication method: API key header or HMAC signature. */
+  authType: z.enum(["api-key", "hmac"]),
+  /** API key or HMAC secret for request verification. */
+  secret: z.string().min(1, "secret must not be empty"),
+  /** Response format: structured JSON or plain text. */
+  responseFormat: z.enum(["json", "text"]).default("json"),
+  /** Optional callback URL for async result delivery. */
+  callbackUrl: z.string().url().optional(),
+});
+
+export type WebhookChannel = z.infer<typeof WebhookChannelSchema>;
+
+export const WebhookConfigSchema = z.object({
+  /** One or more webhook channels, each with its own auth and config. */
+  channels: z
+    .array(WebhookChannelSchema)
+    .min(1, "At least one channel is required")
+    .refine(
+      (chs) => new Set(chs.map((c) => c.channelId)).size === chs.length,
+      "channelId values must be unique across channels",
+    ),
+  /** Run the Atlas agent on a question and return structured results. Required. */
+  executeQuery: z
+    .any()
+    .refine((v) => typeof v === "function", "executeQuery must be a function"),
+});
+
+export interface WebhookQueryResult {
+  answer: string;
+  sql: string[];
+  data: Array<{ columns: string[]; rows: Record<string, unknown>[] }>;
+}
+
+export interface WebhookPluginConfig {
+  channels: WebhookChannel[];
+  executeQuery: (question: string) => Promise<WebhookQueryResult>;
+}

--- a/plugins/webhook/src/index.ts
+++ b/plugins/webhook/src/index.ts
@@ -1,0 +1,156 @@
+/**
+ * Webhook Interaction Plugin for Atlas.
+ *
+ * Accepts inbound HTTP requests with a query, runs the Atlas agent,
+ * and returns structured results. Designed for Zapier, Make, and n8n
+ * integrations.
+ *
+ * Each webhook channel has its own authentication (API key or HMAC)
+ * and can optionally deliver results asynchronously via a callback URL.
+ *
+ * @example
+ * ```typescript
+ * import { defineConfig } from "@atlas/api/lib/config";
+ * import { webhookPlugin } from "@useatlas/webhook";
+ *
+ * export default defineConfig({
+ *   plugins: [
+ *     webhookPlugin({
+ *       channels: [
+ *         {
+ *           channelId: "zapier-prod",
+ *           authType: "api-key",
+ *           secret: process.env.WEBHOOK_SECRET!,
+ *           responseFormat: "json",
+ *         },
+ *       ],
+ *       executeQuery: myQueryFunction,
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+
+import { createPlugin } from "@useatlas/plugin-sdk";
+import type {
+  AtlasInteractionPlugin,
+  AtlasPluginContext,
+  PluginHealthResult,
+  PluginLogger,
+} from "@useatlas/plugin-sdk";
+import { WebhookConfigSchema } from "./config";
+import type { WebhookPluginConfig, WebhookChannel, WebhookQueryResult } from "./config";
+import { createWebhookRoutes } from "./routes";
+import type { WebhookRuntimeDeps } from "./routes";
+
+// Re-export config types so consumers don't need to import from ./config directly
+export type { WebhookPluginConfig, WebhookChannel, WebhookQueryResult } from "./config";
+
+// ---------------------------------------------------------------------------
+// Plugin builder
+// ---------------------------------------------------------------------------
+
+function buildWebhookPlugin(
+  config: WebhookPluginConfig,
+): AtlasInteractionPlugin<WebhookPluginConfig> {
+  let log: PluginLogger | null = null;
+  let initialized = false;
+
+  const channelMap = new Map<string, WebhookChannel>();
+  for (const ch of config.channels) {
+    if (channelMap.has(ch.channelId)) {
+      throw new Error(`Duplicate channelId "${ch.channelId}" — each channel must have a unique ID`);
+    }
+    channelMap.set(ch.channelId, ch);
+  }
+
+  if (typeof config.executeQuery !== "function") {
+    throw new Error("executeQuery callback is required and must be a function");
+  }
+
+  return {
+    id: "webhook-interaction",
+    types: ["interaction"] as const,
+    version: "0.1.0",
+    name: "Webhook",
+    config,
+
+    routes(app) {
+      const deps: WebhookRuntimeDeps = {
+        channels: channelMap,
+        log: log ?? {
+          info: () => {},
+          warn: (...args: unknown[]) => console.warn("[webhook-interaction]", ...args),
+          error: (...args: unknown[]) => console.error("[webhook-interaction]", ...args),
+          debug: () => {},
+        },
+        executeQuery: config.executeQuery,
+      };
+
+      const webhookRoutes = createWebhookRoutes(deps);
+      app.route("", webhookRoutes);
+    },
+
+    async initialize(ctx: AtlasPluginContext) {
+      if (initialized) {
+        throw new Error("Webhook plugin already initialized — call teardown() first");
+      }
+
+      log = ctx.logger;
+      ctx.logger.info(
+        `Webhook interaction plugin initialized (${config.channels.length} channel${config.channels.length === 1 ? "" : "s"})`,
+      );
+      initialized = true;
+    },
+
+    async healthCheck(): Promise<PluginHealthResult> {
+      const start = performance.now();
+
+      if (!initialized) {
+        return {
+          healthy: false,
+          message: "Webhook plugin not initialized",
+          latencyMs: Math.round(performance.now() - start),
+        };
+      }
+
+      if (channelMap.size === 0) {
+        return {
+          healthy: false,
+          message: "No webhook channels configured",
+          latencyMs: Math.round(performance.now() - start),
+        };
+      }
+
+      return { healthy: true, latencyMs: Math.round(performance.now() - start) };
+    },
+
+    async teardown() {
+      log = null;
+      initialized = false;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Factory function for use in atlas.config.ts plugins array.
+ *
+ * @example
+ * ```typescript
+ * plugins: [webhookPlugin({ channels: [...], executeQuery })]
+ * ```
+ */
+export const webhookPlugin = createPlugin<
+  WebhookPluginConfig,
+  AtlasInteractionPlugin<WebhookPluginConfig>
+>({
+  configSchema: WebhookConfigSchema,
+  create: buildWebhookPlugin,
+});
+
+/** Direct builder for tests or manual construction. */
+export { buildWebhookPlugin };

--- a/plugins/webhook/src/routes.ts
+++ b/plugins/webhook/src/routes.ts
@@ -1,0 +1,239 @@
+/**
+ * Webhook integration routes.
+ *
+ * - POST /webhook/:channelId — inbound webhook endpoint
+ *
+ * Authentication is per-channel: API key via `X-Webhook-Secret` header,
+ * or HMAC-SHA256 via `X-Webhook-Signature` header.
+ *
+ * Async mode provides at-most-once delivery — no retry on callback failure.
+ */
+
+import crypto from "crypto";
+import { Hono } from "hono";
+import type { PluginLogger } from "@useatlas/plugin-sdk";
+import type { WebhookChannel, WebhookPluginConfig, WebhookQueryResult } from "./config";
+
+// ---------------------------------------------------------------------------
+// Runtime dependency interface
+// ---------------------------------------------------------------------------
+
+export interface WebhookRuntimeDeps {
+  channels: Map<string, WebhookChannel>;
+  log: PluginLogger;
+  executeQuery: WebhookPluginConfig["executeQuery"];
+}
+
+// ---------------------------------------------------------------------------
+// Auth helpers
+// ---------------------------------------------------------------------------
+
+function verifyApiKey(
+  channel: WebhookChannel,
+  request: Request,
+): boolean {
+  const provided = request.headers.get("x-webhook-secret");
+  if (!provided) return false;
+  const expected = Buffer.from(channel.secret);
+  const actual = Buffer.from(provided);
+  if (expected.length !== actual.length) return false;
+  return crypto.timingSafeEqual(expected, actual);
+}
+
+function verifyHmac(
+  channel: WebhookChannel,
+  body: string,
+  request: Request,
+): boolean {
+  const signature = request.headers.get("x-webhook-signature");
+  if (!signature) return false;
+
+  const expected = crypto
+    .createHmac("sha256", channel.secret)
+    .update(body)
+    .digest("hex");
+
+  const expectedBuf = Buffer.from(expected);
+  const actualBuf = Buffer.from(signature);
+  if (expectedBuf.length !== actualBuf.length) return false;
+  return crypto.timingSafeEqual(expectedBuf, actualBuf);
+}
+
+// ---------------------------------------------------------------------------
+// Callback URL validation — prevents SSRF via request-body overrides
+// ---------------------------------------------------------------------------
+
+function isAllowedCallbackUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return false;
+    const hostname = parsed.hostname;
+    if (
+      hostname === "localhost" ||
+      hostname === "[::1]" ||
+      hostname.startsWith("127.") ||
+      hostname.startsWith("10.") ||
+      hostname.startsWith("192.168.") ||
+      hostname === "169.254.169.254" ||
+      // 172.16.0.0/12
+      (hostname.startsWith("172.") && (() => {
+        const second = parseInt(hostname.split(".")[1], 10);
+        return second >= 16 && second <= 31;
+      })())
+    ) {
+      return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Response formatting
+// ---------------------------------------------------------------------------
+
+function formatResult(result: WebhookQueryResult, format: "json" | "text") {
+  if (format === "text") {
+    return { success: true as const, result: result.answer };
+  }
+  return {
+    success: true as const,
+    result: {
+      answer: result.answer,
+      sql: result.sql,
+      columns: result.data[0]?.columns ?? [],
+      rows: result.data[0]?.rows ?? [],
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Route factory
+// ---------------------------------------------------------------------------
+
+export function createWebhookRoutes(deps: WebhookRuntimeDeps): Hono {
+  const webhook = new Hono();
+  const { channels, log } = deps;
+
+  webhook.post("/webhook/:channelId", async (c) => {
+    const channelId = c.req.param("channelId");
+
+    const channel = channels.get(channelId);
+    if (!channel) {
+      log.warn({ channelId }, "Webhook request for unknown channel");
+      return c.json({ error: "Unknown channel" }, 404);
+    }
+
+    const body = await c.req.raw.clone().text();
+
+    if (channel.authType === "api-key") {
+      if (!verifyApiKey(channel, c.req.raw)) {
+        log.warn({ channelId }, "Webhook API key verification failed");
+        return c.json({ error: "Invalid authentication" }, 401);
+      }
+    } else {
+      if (!verifyHmac(channel, body, c.req.raw)) {
+        log.warn({ channelId }, "Webhook HMAC verification failed");
+        return c.json({ error: "Invalid signature" }, 401);
+      }
+    }
+
+    let payload: Record<string, unknown>;
+    try {
+      payload = JSON.parse(body);
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err), channelId },
+        "Webhook received invalid JSON body",
+      );
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+
+    const query = payload.query;
+    if (!query || typeof query !== "string" || !query.trim()) {
+      return c.json({ error: "Missing or empty query" }, 400);
+    }
+
+    // Determine callback URL: request-level overrides channel-level
+    const rawCallbackUrl =
+      (typeof payload.callbackUrl === "string" ? payload.callbackUrl : undefined) ??
+      channel.callbackUrl;
+
+    // Validate callback URL to prevent SSRF
+    let callbackUrl: string | undefined;
+    if (rawCallbackUrl) {
+      if (!isAllowedCallbackUrl(rawCallbackUrl)) {
+        return c.json({ error: "Invalid callback URL" }, 400);
+      }
+      callbackUrl = rawCallbackUrl;
+    }
+
+    const responseFormat = channel.responseFormat ?? "json";
+
+    // Async mode: accept immediately, deliver result to callbackUrl when done.
+    // At-most-once delivery — failed deliveries are logged but not retried.
+    if (callbackUrl) {
+      const requestId = crypto.randomUUID();
+      log.info({ channelId, requestId, query: query.slice(0, 100) }, "Webhook async request accepted");
+
+      const deliverCallback = async (payload: Record<string, unknown>) => {
+        try {
+          const resp = await fetch(callbackUrl, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+            signal: AbortSignal.timeout(30_000),
+          });
+          if (!resp.ok) {
+            log.error({ channelId, requestId, status: resp.status }, "Callback delivery failed");
+          }
+        } catch (fetchErr) {
+          log.error(
+            { err: fetchErr instanceof Error ? fetchErr.message : String(fetchErr), channelId, requestId },
+            "Callback delivery request failed",
+          );
+        }
+      };
+
+      const processAsync = async () => {
+        try {
+          const result = await deps.executeQuery(query);
+          await deliverCallback({ requestId, ...formatResult(result, responseFormat) });
+        } catch (err) {
+          log.error(
+            { err: err instanceof Error ? err.message : String(err), channelId, requestId },
+            "Webhook async query execution failed",
+          );
+          // Deliver error to callback so the caller knows the request failed
+          await deliverCallback({ requestId, success: false, error: "Query execution failed" });
+        }
+      };
+
+      processAsync().catch((err) => {
+        log.error(
+          { err: err instanceof Error ? err.message : String(err), channelId, requestId },
+          "Unhandled error in webhook async processing",
+        );
+      });
+
+      return c.json({ accepted: true, requestId }, 202);
+    }
+
+    // Synchronous mode
+    log.info({ channelId, query: query.slice(0, 100) }, "Webhook sync request");
+
+    try {
+      const result = await deps.executeQuery(query);
+      return c.json(formatResult(result, responseFormat));
+    } catch (err) {
+      log.error(
+        { err: err instanceof Error ? err.message : String(err), channelId },
+        "Webhook query execution failed",
+      );
+      return c.json({ error: "Query execution failed" }, 500);
+    }
+  });
+
+  return webhook;
+}

--- a/plugins/webhook/tsconfig.json
+++ b/plugins/webhook/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*.ts", "__tests__/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- New `@useatlas/webhook` interaction plugin at `plugins/webhook/` — accepts inbound HTTP requests with a query, runs the Atlas agent, returns structured results
- Per-channel authentication: API key (`X-Webhook-Secret` header) or HMAC-SHA256 (`X-Webhook-Signature` header) with constant-time comparison
- Sync mode returns `{ success, result: { answer, sql, columns, rows } }`; async mode (callback URL) returns `{ accepted, requestId }` immediately and POSTs results when ready
- Docs page at `/plugins/interactions/webhook` with platform setup guides for Zapier, Make, and n8n
- 37 tests covering shape validation, config validation, lifecycle, auth (API key + HMAC), request validation, sync/async modes, and integration payloads
- Added `@useatlas/webhook` to syncpack peer dep ignore list

Closes #459

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run type` — passes
- [x] `bun run test` — all pass (37 new webhook tests)
- [x] `bun x syncpack lint` — no issues
- [x] Template drift check — passes