### PR TITLE
feat(api): pool misconfiguration warning in admin overview

### DIFF
--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -158,6 +158,7 @@ const mockListOrgs: Mock<() => string[]> = mock(() => []);
 const mockDrainOrg: Mock<(orgId: string) => Promise<unknown>> = mock(() =>
   Promise.resolve({ drained: 2 }),
 );
+const mockGetPoolWarnings: Mock<() => string[]> = mock(() => []);
 
 mock.module("@atlas/api/lib/db/connection", () => ({
   getDB: () => mockDBConnection,
@@ -178,6 +179,7 @@ mock.module("@atlas/api/lib/db/connection", () => ({
     getOrgPoolConfig: mockGetOrgPoolConfig,
     listOrgs: mockListOrgs,
     drainOrg: mockDrainOrg,
+    getPoolWarnings: mockGetPoolWarnings,
     recordQuery: () => {},
     recordError: () => {},
     recordSuccess: () => {},
@@ -515,6 +517,26 @@ describe("GET /api/v1/admin/overview", () => {
     expect(body.glossaryTerms).toBe(2);
     expect(body.plugins).toBe(1);
     expect(Array.isArray(body.pluginHealth)).toBe(true);
+  });
+
+  it("omits poolWarnings when none", async () => {
+    mockGetPoolWarnings.mockReturnValue([]);
+    const res = await app.fetch(adminRequest("/api/v1/admin/overview"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.poolWarnings).toBeUndefined();
+  });
+
+  it("includes poolWarnings when capacity is over-provisioned", async () => {
+    mockGetPoolWarnings.mockReturnValue([
+      "Org pool capacity (50 orgs × 5 conns × 1 datasources = 250 slots) exceeds maxTotalConnections (100) by 2.5×.",
+    ]);
+    const res = await app.fetch(adminRequest("/api/v1/admin/overview"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(Array.isArray(body.poolWarnings)).toBe(true);
+    expect((body.poolWarnings as string[]).length).toBe(1);
+    expect((body.poolWarnings as string[])[0]).toContain("exceeds maxTotalConnections");
   });
 });
 

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -224,6 +224,8 @@ admin.get("/overview", async (c) => {
       }
     }
 
+    const poolWarnings = connections.getPoolWarnings();
+
     return c.json({
       connections: connList.length,
       entities: entities.length,
@@ -237,6 +239,7 @@ admin.get("/overview", async (c) => {
         status: p.status,
       })),
       ...(warnings.length > 0 && { warnings }),
+      ...(poolWarnings.length > 0 && { poolWarnings }),
     });
   });
 });

--- a/packages/api/src/lib/db/__tests__/tenant-pool.test.ts
+++ b/packages/api/src/lib/db/__tests__/tenant-pool.test.ts
@@ -425,4 +425,30 @@ describe("ConnectionRegistry org-scoped pools", () => {
       expect(() => registry.getForOrg("org-c")).toThrow("exceeding maxTotalConnections");
     });
   });
+
+  describe("getPoolWarnings", () => {
+    it("returns empty when org pooling is disabled", () => {
+      registry.register("default", { url: "postgresql://localhost/test" });
+      expect(registry.getPoolWarnings()).toEqual([]);
+    });
+
+    it("returns empty when capacity is within limits", () => {
+      registry.setMaxTotalConnections(100);
+      registry.register("default", { url: "postgresql://localhost/test" });
+      registry.setOrgPoolConfig({ maxConnections: 2, maxOrgs: 10 });
+      // 10 × 2 × 1 = 20 <= 100
+      expect(registry.getPoolWarnings()).toEqual([]);
+    });
+
+    it("returns warning when theoretical capacity exceeds maxTotalConnections", () => {
+      registry.setMaxTotalConnections(100);
+      registry.register("default", { url: "postgresql://localhost/test" });
+      registry.setOrgPoolConfig({ maxConnections: 5, maxOrgs: 50 });
+      // 50 × 5 × 1 = 250 > 100
+      const warnings = registry.getPoolWarnings();
+      expect(warnings.length).toBe(1);
+      expect(warnings[0]).toContain("exceeds maxTotalConnections");
+      expect(warnings[0]).toContain("2.5×");
+    });
+  });
 });

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -457,7 +457,9 @@ export class ConnectionRegistry {
     const numDatasources = Math.max(this.entries.size, 1);
     const theoreticalSlots = merged.maxOrgs * merged.maxConnections * numDatasources;
     if (theoreticalSlots > this.maxTotalConnections) {
-      log.warn(
+      const severity = theoreticalSlots > this.maxTotalConnections * 2 ? "error" : "warn";
+      const logFn = severity === "error" ? log.error.bind(log) : log.warn.bind(log);
+      logFn(
         {
           maxOrgs: merged.maxOrgs,
           maxConnections: merged.maxConnections,
@@ -484,6 +486,24 @@ export class ConnectionRegistry {
   /** Return the current org pool settings (for admin API / diagnostics). */
   getOrgPoolConfig(): Readonly<OrgPoolSettings> {
     return this.orgPoolSettings;
+  }
+
+  /** Return pool capacity warnings for the admin health check. Empty array when healthy. */
+  getPoolWarnings(): string[] {
+    const warnings: string[] = [];
+    if (!this.orgPoolSettings.enabled) return warnings;
+
+    const numDatasources = Math.max(this.entries.size, 1);
+    const theoreticalSlots = this.orgPoolSettings.maxOrgs * this.orgPoolSettings.maxConnections * numDatasources;
+    if (theoreticalSlots > this.maxTotalConnections) {
+      const ratio = Math.round(theoreticalSlots / this.maxTotalConnections * 10) / 10;
+      warnings.push(
+        `Org pool capacity (${this.orgPoolSettings.maxOrgs} orgs × ${this.orgPoolSettings.maxConnections} conns × ${numDatasources} datasources = ${theoreticalSlots} slots) ` +
+        `exceeds maxTotalConnections (${this.maxTotalConnections}) by ${ratio}×. ` +
+        `LRU eviction prevents exceeding the limit, but tenants may hit PoolCapacityExceededError under load.`
+      );
+    }
+    return warnings;
   }
 
   private _orgKey(orgId: string, connectionId: string): string {


### PR DESCRIPTION
## Summary
- `getPoolWarnings()` on `ConnectionRegistry` returns warnings when theoretical org pool capacity exceeds `maxTotalConnections`
- `GET /admin/overview` now includes `poolWarnings` array when capacity is over-provisioned (omitted when empty)
- Startup log escalated to `error` level when theoretical capacity exceeds 2× `maxTotalConnections`

## Test plan
- [x] `getPoolWarnings()` unit tests — disabled, within limits, over-provisioned
- [x] Admin overview tests — omits field when empty, includes when warnings exist
- [x] All existing tests pass

Closes #536