### PR TITLE
chore: code review cleanup for 0.7.0 modules

### DIFF
--- a/packages/api/src/lib/tools/python-sidecar.ts
+++ b/packages/api/src/lib/tools/python-sidecar.ts
@@ -270,8 +270,8 @@ export async function executePythonViaSidecarStream(
             onProgress({ type: "chart", chart: event.data });
             break;
           case "recharts":
-            rechartsCharts.push(event.data as RechartsChart);
-            onProgress({ type: "recharts", chart: event.data as RechartsChart });
+            rechartsCharts.push(event.data);
+            onProgress({ type: "recharts", chart: event.data });
             break;
           case "table":
             table = event.data;

--- a/packages/cli/lib/learn/propose.ts
+++ b/packages/cli/lib/learn/propose.ts
@@ -269,18 +269,18 @@ function proposeJoins(
     if (join.count < 2) continue; // Need at least 2 observations
 
     // Check both directions — propose the join on the "from" table
-    for (const [sourceTable, targetTable] of [[join.fromTable, join.toTable], [join.toTable, join.fromTable]]) {
-      const entry = entities.get(sourceTable!);
+    for (const [sourceTable, targetTable] of [[join.fromTable, join.toTable], [join.toTable, join.fromTable]] as [string, string][]) {
+      const entry = entities.get(sourceTable);
       if (!entry) continue;
 
-      const targetEntry = entities.get(targetTable!);
-      const targetName = targetEntry?.entity.name ?? inferEntityName(targetTable!);
+      const targetEntry = entities.get(targetTable);
+      const targetName = targetEntry?.entity.name ?? inferEntityName(targetTable);
 
       if (joinExists(entry.entity, targetName)) continue;
 
       let joinColumns: { from: string; to: string } | null = null;
       if (join.onClause) {
-        joinColumns = parseOnClause(join.onClause, sourceTable!, targetTable!);
+        joinColumns = parseOnClause(join.onClause, sourceTable, targetTable);
       }
 
       const joinEntry = {
@@ -295,7 +295,7 @@ function proposeJoins(
       proposals.push({
         type: "join",
         filePath: entry.filePath,
-        table: sourceTable!,
+        table: sourceTable,
         description: `Add join: ${sourceTable} → ${targetName} (observed ${join.count}x)`,
         observedCount: join.count,
         yamlAddition: yaml.dump([joinEntry], { lineWidth: -1 }).trim(),

--- a/packages/sandbox-sidecar/src/server.ts
+++ b/packages/sandbox-sidecar/src/server.ts
@@ -457,7 +457,6 @@ async function handleExecPython(req: Request): Promise<Response> {
 const PYTHON_WRAPPER_STREAMING = `
 import sys, json, io, base64, glob, os, ast
 
-_marker = os.environ["ATLAS_RESULT_MARKER"]
 _stream_marker = os.environ["ATLAS_STREAM_MARKER"]
 _chart_dir = os.environ.get("ATLAS_CHART_DIR", "/tmp")
 
@@ -630,7 +629,6 @@ async function handleExecPythonStream(req: Request): Promise<Response> {
 
   const execId = randomUUID();
   const streamMarker = `__ATLAS_STREAM_${execId}__`;
-  const resultMarker = `__ATLAS_RESULT_${execId}__`;
   const tmpDir = join("/tmp", `pyexec-${execId}`);
   const codeFile = join(tmpDir, "user_code.py");
   const wrapperFile = join(tmpDir, "wrapper_stream.py");
@@ -675,7 +673,6 @@ async function handleExecPythonStream(req: Request): Promise<Response> {
             TMPDIR: tmpDir,
             MPLBACKEND: "Agg",
             ATLAS_CHART_DIR: chartDir,
-            ATLAS_RESULT_MARKER: resultMarker,
             ATLAS_STREAM_MARKER: streamMarker,
           },
         });


### PR DESCRIPTION
## Summary

Code review of ~2400 new lines shipped in 0.7.0. Closes #544.

### Modules reviewed
1. **`packages/cli/lib/learn/`** — analyze.ts, propose.ts, diff.ts + tests
2. **`packages/api/src/lib/tools/python-stream.ts`** — stream writer store
3. **`packages/api/src/lib/tools/python-sidecar.ts`** — sidecar streaming
4. **`packages/sandbox-sidecar/src/server.ts`** — SSE streaming endpoint
5. **Org-scoped code** — connection.ts (tenant pooling), semantic.ts (org whitelist/index), cache/keys.ts (org-scoped keys)

### Inline fixes
- Remove dead `_marker` / `ATLAS_RESULT_MARKER` from streaming Python wrapper — defined but never referenced in `PYTHON_WRAPPER_STREAMING`
- Replace 5 non-null assertions with `[string, string][]` tuple type in `proposeJoins` destructuring
- Remove redundant `as RechartsChart` casts — structural typing handles discriminated union narrowing

### Issues filed for larger findings
- #547 — Extract shared Python wrapper code between streaming and non-streaming handlers (~100 lines duplicated)
- #548 — Eliminate input parameter mutation in `generateProposals()`

## Test plan
- [x] `bun run type` — no errors
- [x] `bun run lint` — 0 errors (5 pre-existing warnings)
- [x] `bun run test` — 23 packages, 0 failures
- [x] `bun x syncpack lint` — no issues
- [x] Template drift check — passed