### PR TITLE
refactor: break up complex functions over 50 lines (#553)

### DIFF
--- a/packages/api/src/lib/startup.ts
+++ b/packages/api/src/lib/startup.ts
@@ -789,6 +789,7 @@ async function checkExplicitNsjail(): Promise<void> {
 }
 
 async function checkSidecarHealth(): Promise<void> {
+  // Caller guarantees ATLAS_SANDBOX_URL is set
   const sidecarUrl = process.env.ATLAS_SANDBOX_URL!;
   const { markSidecarFailed } = await import(
     "@atlas/api/lib/tools/explore"

--- a/packages/api/src/lib/tools/actions/handler.ts
+++ b/packages/api/src/lib/tools/actions/handler.ts
@@ -659,18 +659,7 @@ export function extractRollbackInfo(result: unknown): RollbackInfo | null {
 // Rollback
 // ---------------------------------------------------------------------------
 
-/**
- * Roll back an executed action using its stored rollback_info.
- *
- * Rollback is best-effort: the status transitions to "rolled_back" via CAS,
- * then the rollback method handler is dispatched. If dispatch fails, the error
- * is logged and stored but the status remains "rolled_back".
- *
- * Returns the updated entry, or null if CAS failed (action not in rollbackable state).
- */
-/**
- * Best-effort dispatch of a rollback handler. Updates the entry with any error.
- */
+/** Best-effort dispatch of a rollback handler. Updates the entry with any error. */
 async function dispatchRollback(
   actionId: string,
   entry: ActionLogEntry,
@@ -701,6 +690,15 @@ async function dispatchRollback(
   }
 }
 
+/**
+ * Roll back an executed action using its stored rollback_info.
+ *
+ * Rollback is best-effort: the status transitions to "rolled_back" via CAS,
+ * then the rollback method handler is dispatched. If dispatch fails, the error
+ * is logged and stored but the status remains "rolled_back".
+ *
+ * Returns the updated entry, or null if CAS failed (action not in rollbackable state).
+ */
 export async function rollbackAction(
   actionId: string,
   userId: string,

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -404,35 +404,46 @@ function resolveConnection(
 
 /**
  * Run query validation using either a custom validator or standard SQL validation.
- * Returns a clean result without side effects — caller handles audit logging.
+ * Does not write audit log entries — the caller is responsible for audit logging on failure.
+ * `auditError` preserves the specific error detail for audit logs (e.g., original exception message).
  */
 async function runQueryValidation(
   sql: string,
   connId: string,
   dbType: DBType | string,
   customValidator: CustomValidator | undefined,
-): Promise<{ ok: true; classification?: SQLClassification } | { ok: false; error: string }> {
+): Promise<{ ok: true; classification?: SQLClassification } | { ok: false; error: string; auditError: string }> {
   if (customValidator) {
     let result: { valid: boolean; reason?: string };
     try {
       result = await customValidator(sql);
     } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
       log.error({ err, connectionId: connId, sql: sql.slice(0, 200) }, "Custom validator threw an exception");
-      return { ok: false, error: `Query validation failed for connection "${connId}": internal validator error` };
+      return {
+        ok: false,
+        error: `Query validation failed for connection "${connId}": internal validator error`,
+        auditError: `Custom validator error: ${message}`,
+      };
     }
     if (typeof result?.valid !== "boolean") {
       log.error({ connectionId: connId, returnValue: result }, "Custom validator returned invalid shape");
-      return { ok: false, error: `Query validation misconfigured for connection "${connId}"` };
+      return {
+        ok: false,
+        error: `Query validation misconfigured for connection "${connId}"`,
+        auditError: "Custom validator returned invalid result",
+      };
     }
     if (!result.valid) {
-      return { ok: false, error: result.reason ?? "Query rejected by custom validator" };
+      const reason = result.reason ?? "Query rejected by custom validator";
+      return { ok: false, error: reason, auditError: `Validation rejected: ${reason}` };
     }
     return { ok: true };
   }
 
   const validation = validateSQL(sql, connId);
   if (!validation.valid) {
-    return { ok: false, error: validation.error };
+    return { ok: false, error: validation.error, auditError: `Validation rejected: ${validation.error}` };
   }
   return { ok: true, classification: validation.classification };
 }
@@ -440,6 +451,7 @@ async function runQueryValidation(
 /**
  * Apply RLS conditions to a query. Returns the modified SQL or an error.
  * Handles table extraction, filter resolution, and condition injection.
+ * Unlike runQueryValidation, this function logs audit entries on failure paths.
  */
 function applyRLSToQuery(
   sql: string,
@@ -528,7 +540,12 @@ function applyRLSToQuery(
   return { ok: true, sql };
 }
 
-/** Execute a validated query, handle caching, audit logging, and error responses. */
+/**
+ * Execute a validated query with tracing, cache write, audit logging, plugin hooks,
+ * and error filtering. Releases the concurrency slot (decrementSourceConcurrency)
+ * in its finally block — callers must not release it separately.
+ * SQL content is NOT included in span attributes for security.
+ */
 async function executeAndAudit(opts: {
   db: DBConnection;
   dbType: DBType;
@@ -713,7 +730,7 @@ Rules:
         durationMs: 0,
         rowCount: null,
         success: false,
-        error: `Validation rejected: ${initial.error}`,
+        error: initial.auditError,
         sourceId: connId,
         sourceType: dbType,
       });
@@ -818,7 +835,7 @@ Rules:
           durationMs: 0,
           rowCount: null,
           success: false,
-          error: `Plugin-rewritten SQL failed validation: ${revalidation.error}`,
+          error: `Plugin-rewritten SQL failed validation: ${revalidation.auditError}`,
           sourceId: connId,
           sourceType: dbType,
           targetHost,

--- a/packages/sandbox-sidecar/src/server.ts
+++ b/packages/sandbox-sidecar/src/server.ts
@@ -366,7 +366,11 @@ async function parsePythonRequest(req: Request): Promise<PythonExecSetup | Respo
   };
 }
 
-/** Write stdin data and handle EPIPE gracefully. */
+/**
+ * Write stdin data and handle EPIPE gracefully. EPIPE occurs when the Python
+ * process exits before consuming stdin (e.g., syntax error in the import guard)
+ * — the real error will be surfaced via the process exit code.
+ */
 function writePythonStdin(
   proc: { stdin: { write(data: string): void; end(): void } },
   data: unknown,


### PR DESCRIPTION
## Summary

- **startup.ts**: `validateEnvironment` (702 → ~50 lines) — extracted 15 helpers: `checkDatasourceUrlPresence`, `checkProviderApiKey`, `checkSemanticLayerPresence`, `checkDatasourceConnectivity`, `checkMysqlConnectivity`, `checkPostgresConnectivity`, `checkInternalDbConnectivity`, `checkConfigFile`, `checkAuthModeDiagnostics`, `checkManagedAuthMode`, `checkByotAuthMode`, `warnOrphanedAuthVars`, `checkActionFramework`, `logSandboxPlugins`, `checkSandboxPreFlight`, `checkExplicitNsjail`, `checkSidecarHealth`, `autoDetectNsjail`
- **sql.ts**: `executeSQL.execute` (494 → ~120 lines) — extracted `resolveConnection`, `runQueryValidation` (eliminates custom validator duplication between initial and re-validation), `applyRLSToQuery`, `executeAndAudit`
- **actions/handler.ts**: `approveAction` (209 → ~50 lines) — extracted `executeApprovedAction` to eliminate duplicated DB/memory execution paths; `rollbackAction` (131 → ~50 lines) — extracted `dispatchRollback` to eliminate duplicated DB/memory rollback dispatch
- **sandbox-sidecar/server.ts**: extracted `parsePythonRequest` (shared auth, concurrency, body validation) and `writePythonStdin` (shared stdin write with EPIPE handling) — used by both `handleExecPython` and `handleExecPythonStream`

### Functions identified over 50 lines (top offenders)

| Lines | Function | File |
|------:|----------|------|
| 702 | `validateEnvironment` | `packages/api/src/lib/startup.ts` |
| 519 | `executeSQL.execute` | `packages/api/src/lib/tools/sql.ts` |
| 264 | `createPythonSandboxBackend` | `packages/api/src/lib/tools/python-sandbox.ts` |
| 251 | `migrateInternalDB` | `packages/api/src/lib/db/internal.ts` |
| 209 | `approveAction` | `packages/api/src/lib/tools/actions/handler.ts` |
| 174 | `handleExecPythonStream` | `packages/sandbox-sidecar/src/server.ts` |
| 158 | `runAgent` | `packages/api/src/lib/agent.ts` |
| 143 | `getExploreBackend` | `packages/api/src/lib/tools/explore.ts` |
| 136 | `handleExecPython` | `packages/sandbox-sidecar/src/server.ts` |
| 133 | `configFromEnv` | `packages/api/src/lib/config.ts` |
| 131 | `rollbackAction` | `packages/api/src/lib/tools/actions/handler.ts` |

**Not refactored** (intentionally):
- `migrateInternalDB` (251 lines) — sequential DDL statements, not complex logic
- `createPythonSandboxBackend` (264 lines) — recently refactored in #557, inner `exec` method is a clear pipeline
- `runAgent` (158 lines) — streamText config is inherently dense, extraction would scatter related config
- `getExploreBackend` (143 lines) — already uses `tryCreateBackend` helper, remaining code is a priority chain
- `configFromEnv` (133 lines) — sequential env var reads, not complex logic

Closes #553

## Test plan
- [x] `bun run lint` — 0 warnings
- [x] `bun run type` — passes
- [x] `bun run test` — all tests pass (0 failures)
- [x] `bun x syncpack lint` — no issues
- [x] Template drift check — passes