### PR TITLE
chore: password endpoint and cache edge case tests (#571, #572)

### DIFF
--- a/packages/api/src/api/__tests__/admin-password.test.ts
+++ b/packages/api/src/api/__tests__/admin-password.test.ts
@@ -214,7 +214,7 @@ describe("GET /api/v1/admin/me/password-status", () => {
     expect(body.passwordChangeRequired).toBe(false);
   });
 
-  it("returns false for non-managed auth (header mode)", async () => {
+  it("returns false for non-managed auth (simple-key mode)", async () => {
     mockAuthenticateRequest.mockResolvedValue({
       authenticated: true,
       mode: "simple-key",
@@ -264,6 +264,9 @@ describe("GET /api/v1/admin/me/password-status", () => {
 
     const res = await app.fetch(req("/api/v1/admin/me/password-status"));
     expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body.error).toBe("auth_error");
+    expect(body.message).toBe("No session found");
   });
 
   it("returns 500 when authenticateRequest throws", async () => {
@@ -326,7 +329,7 @@ describe("POST /api/v1/admin/me/password", () => {
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string; message: string };
     expect(body.error).toBe("invalid_request");
-    expect(body.message).toContain("incorrect");
+    expect(body.message).toBe("Current password is incorrect.");
   });
 
   it("returns 400 when fields are missing", async () => {
@@ -391,6 +394,9 @@ describe("POST /api/v1/admin/me/password", () => {
       }),
     );
     expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body.error).toBe("auth_error");
+    expect(body.message).toBe("No session found");
   });
 
   it("returns 500 on non-password-related changePassword error", async () => {
@@ -437,5 +443,49 @@ describe("POST /api/v1/admin/me/password", () => {
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("invalid_request");
+  });
+
+  it("returns 500 when authenticateRequest throws", async () => {
+    mockAuthenticateRequest.mockRejectedValue(new Error("auth system down"));
+
+    const res = await app.fetch(
+      req("/api/v1/admin/me/password", "POST", {
+        currentPassword: "OldPass123",
+        newPassword: "NewPass456",
+      }),
+    );
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("auth_error");
+  });
+
+  it("returns 500 if flag-clear fails after successful password change", async () => {
+    mockInternalQuery.mockRejectedValue(new Error("disk full"));
+
+    const res = await app.fetch(
+      req("/api/v1/admin/me/password", "POST", {
+        currentPassword: "OldPass123",
+        newPassword: "NewPass456",
+      }),
+    );
+    // Password was changed in auth system but flag clear failed
+    expect(mockChangePassword).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("internal_error");
+  });
+
+  it("returns 400 when error contains 'invalid' keyword", async () => {
+    mockChangePassword.mockRejectedValue(new Error("invalid credentials"));
+
+    const res = await app.fetch(
+      req("/api/v1/admin/me/password", "POST", {
+        currentPassword: "WrongPass",
+        newPassword: "NewPass456",
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body.message).toBe("Current password is incorrect.");
   });
 });

--- a/packages/api/src/lib/cache/__tests__/cache.test.ts
+++ b/packages/api/src/lib/cache/__tests__/cache.test.ts
@@ -128,36 +128,37 @@ describe("LRUCacheBackend — TTL edge cases", () => {
     expect(cache.get("long-lived")).not.toBeNull();
   });
 
-  it("entry at exact TTL boundary is expired (> check, not >=)", () => {
-    const now = Date.now();
-    const cache = new LRUCacheBackend(5, 300_000);
-    // cachedAt is exactly ttl ms in the past — Date.now() - cachedAt === ttl
-    // The check is `>` so entry at exact boundary is NOT expired
-    const entry = makeEntry({ cachedAt: now - 300_000, ttl: 300_000 });
-    cache.set("boundary", entry);
-    // Since Date.now() advances, this will be > ttl by the time get() runs
-    // We just verify the behavior is deterministic: at boundary it's expired
-    const result = cache.get("boundary");
-    // Either still valid (if get() is fast enough) or expired — both are correct
-    // The important thing is no crash or inconsistent state
-    expect(result === null || result.columns.length === 2).toBe(true);
+  it("entry at exact TTL boundary is NOT expired (> check, not >=)", () => {
+    const now = 1_000_000;
+    const originalNow = Date.now;
+    Date.now = () => now;
+    try {
+      const cache = new LRUCacheBackend(5, 300_000);
+      // cachedAt is exactly ttl ms in the past — Date.now() - cachedAt === ttl
+      // The implementation uses `>` so at exact boundary the entry is still valid
+      const entry = makeEntry({ cachedAt: now - 300_000, ttl: 300_000 });
+      cache.set("boundary", entry);
+      expect(cache.get("boundary")).not.toBeNull();
+    } finally {
+      Date.now = originalNow;
+    }
   });
 
   it("constructor rejects maxSize < 1", () => {
-    expect(() => new LRUCacheBackend(0, 300_000)).toThrow("maxSize must be >= 1");
+    expect(() => new LRUCacheBackend(0, 300_000)).toThrow("Cache maxSize must be >= 1, got 0");
   });
 
   it("constructor rejects defaultTtl < 1", () => {
-    expect(() => new LRUCacheBackend(5, 0)).toThrow("defaultTtl must be >= 1");
+    expect(() => new LRUCacheBackend(5, 0)).toThrow("Cache defaultTtl must be >= 1ms, got 0");
   });
 });
 
 // ---------------------------------------------------------------------------
-// Concurrent access
+// Interleaved operations
 // ---------------------------------------------------------------------------
 
-describe("LRUCacheBackend — concurrent access", () => {
-  it("simultaneous set() for the same key — last write wins", () => {
+describe("LRUCacheBackend — interleaved operations", () => {
+  it("consecutive set() for the same key — last write wins", () => {
     const cache = new LRUCacheBackend(5, 300_000);
     const entry1 = makeEntry({ rows: [{ id: 1, name: "first" }] });
     const entry2 = makeEntry({ rows: [{ id: 2, name: "second" }] });
@@ -378,6 +379,19 @@ describe("LRUCacheBackend — stats accuracy", () => {
     expect(stats.hits).toBe(0);
     expect(stats.misses).toBe(1);
     expect(stats.entryCount).toBe(0);
+  });
+
+  it("flush() clears entries but preserves hit/miss stats", () => {
+    const cache = new LRUCacheBackend(5, 300_000);
+    cache.set("a", makeEntry());
+    cache.get("a"); // hit
+    cache.get("miss"); // miss
+    cache.flush();
+
+    const stats = cache.stats();
+    expect(stats.entryCount).toBe(0);
+    expect(stats.hits).toBe(1);
+    expect(stats.misses).toBe(1);
   });
 
   it("overwriting a key does not inflate entry count", () => {


### PR DESCRIPTION
## Summary
- **#571**: New `admin-password.test.ts` with 18 tests covering `GET /me/password-status` (flag set/unset, non-managed auth, no internal DB, missing user row, DB error → 500, unauthenticated, auth system error) and `POST /me/password` (success + flag clear, wrong password, missing fields, empty body, short password, non-managed mode, unauthenticated, non-password error → 500, no internal DB, malformed JSON)
- **#572**: 20 new cache tests in `cache.test.ts` — TTL edge cases (1ms expiry, large TTL, boundary timing, constructor validation), concurrent access (last-write-wins, interleaved read/write, flush during reads, delete+set), large entries (10K-row integrity, eviction), LRU eviction ordering (insertion order, set refresh, multi-eviction sequence), stats accuracy (mixed ops, instance isolation, expired-as-miss, overwrite count)

## Test plan
- [x] `bun run test` — all 38 new tests pass, full suite green
- [x] `bun run lint` — 0 errors, 0 warnings
- [x] `bun run type` — 0 errors
- [x] `bun x syncpack lint` — no issues
- [x] Template drift check passed