### PR TITLE
feat(api): agent proposes learned patterns after successful queries

### DIFF
--- a/packages/api/src/api/__tests__/admin-invitations.test.ts
+++ b/packages/api/src/api/__tests__/admin-invitations.test.ts
@@ -112,7 +112,7 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getEncryptionKey: () => null,
   isPlaintextUrl: (value: string) => /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(value),
   _resetEncryptionKeyCache: mock(() => {}),
-  findSimilarPattern: async () => null,
+  findPatternBySQL: async () => null,
   insertLearnedPattern: () => {},
   incrementPatternCount: () => {},
 }));

--- a/packages/api/src/api/__tests__/admin-learned-patterns.test.ts
+++ b/packages/api/src/api/__tests__/admin-learned-patterns.test.ts
@@ -119,7 +119,7 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getEncryptionKey: () => null,
   isPlaintextUrl: (value: string) => /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(value),
   _resetEncryptionKeyCache: mock(() => {}),
-  findSimilarPattern: async () => null,
+  findPatternBySQL: async () => null,
   insertLearnedPattern: () => {},
   incrementPatternCount: () => {},
 }));

--- a/packages/api/src/api/__tests__/admin-password.test.ts
+++ b/packages/api/src/api/__tests__/admin-password.test.ts
@@ -83,7 +83,7 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getEncryptionKey: () => null,
   isPlaintextUrl: (value: string) => /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(value),
   _resetEncryptionKeyCache: mock(() => {}),
-  findSimilarPattern: async () => null,
+  findPatternBySQL: async () => null,
   insertLearnedPattern: () => {},
   incrementPatternCount: () => {},
 }));

--- a/packages/api/src/api/__tests__/admin-tokens.test.ts
+++ b/packages/api/src/api/__tests__/admin-tokens.test.ts
@@ -108,7 +108,7 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getEncryptionKey: () => null,
   isPlaintextUrl: (value: string) => /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(value),
   _resetEncryptionKeyCache: mock(() => {}),
-  findSimilarPattern: async () => null,
+  findPatternBySQL: async () => null,
   insertLearnedPattern: () => {},
   incrementPatternCount: () => {},
 }));

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -216,7 +216,7 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getEncryptionKey: () => null,
   isPlaintextUrl: (value: string) => /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(value),
   _resetEncryptionKeyCache: mock(() => {}),
-  findSimilarPattern: async () => null,
+  findPatternBySQL: async () => null,
   insertLearnedPattern: () => {},
   incrementPatternCount: () => {},
 }));

--- a/packages/api/src/api/__tests__/semantic.test.ts
+++ b/packages/api/src/api/__tests__/semantic.test.ts
@@ -159,7 +159,7 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getEncryptionKey: () => null,
   isPlaintextUrl: (value: string) => /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(value),
   _resetEncryptionKeyCache: mock(() => {}),
-  findSimilarPattern: async () => null,
+  findPatternBySQL: async () => null,
   insertLearnedPattern: () => {},
   incrementPatternCount: () => {},
 }));

--- a/packages/api/src/lib/__tests__/pattern-analyzer.test.ts
+++ b/packages/api/src/lib/__tests__/pattern-analyzer.test.ts
@@ -2,7 +2,8 @@
  * Unit tests for pattern-analyzer.ts — SQL normalization, fingerprinting,
  * and structural pattern extraction.
  *
- * All functions under test are pure (no I/O) — no mocks needed.
+ * normalizeSQL, fingerprintSQL, and extractPatternInfo are pure (no I/O).
+ * loadYamlQueryPatterns reads the filesystem but is tested against a known fixture directory.
  */
 import { describe, test, expect } from "bun:test";
 import {

--- a/packages/api/src/lib/__tests__/pattern-proposer.test.ts
+++ b/packages/api/src/lib/__tests__/pattern-proposer.test.ts
@@ -77,12 +77,12 @@ describe("pattern-proposer", () => {
   // ── Novel pattern detection ────────────────────────────────────────
 
   test("inserts novel pattern when no match in YAML or DB", async () => {
-    // findSimilarPattern returns no match → INSERT fires
+    // findPatternBySQL returns no match → INSERT fires
     setResults({ rows: [] });
 
     await _analyzeAndPropose(defaultInput);
 
-    // First query: findSimilarPattern SELECT
+    // First query: findPatternBySQL SELECT
     expect(queryCalls.length).toBeGreaterThanOrEqual(1);
     const selectCall = queryCalls[0];
     expect(selectCall.sql).toContain("SELECT id, confidence, repetition_count FROM learned_patterns");
@@ -101,7 +101,7 @@ describe("pattern-proposer", () => {
   // ── Duplicate detection ────────────────────────────────────────────
 
   test("increments count when pattern already exists in DB", async () => {
-    // findSimilarPattern returns a match
+    // findPatternBySQL returns a match
     setResults({
       rows: [
         { id: "existing-123", confidence: 0.3, repetition_count: 5 },
@@ -110,7 +110,7 @@ describe("pattern-proposer", () => {
 
     await _analyzeAndPropose(defaultInput);
 
-    // First query: findSimilarPattern SELECT → found match
+    // First query: findPatternBySQL SELECT → found match
     expect(queryCalls[0].sql).toContain("SELECT id, confidence, repetition_count");
 
     // Second query: incrementPatternCount UPDATE (fire-and-forget)
@@ -134,7 +134,7 @@ describe("pattern-proposer", () => {
       await _analyzeAndPropose(defaultInput);
     });
 
-    // findSimilarPattern should use org_id = $2
+    // findPatternBySQL should use org_id = $2
     const selectCall = queryCalls[0];
     expect(selectCall.sql).toContain("org_id = $2");
     expect(selectCall.params).toContain("org-456");

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -564,10 +564,10 @@ export async function loadSavedConnections(): Promise<number> {
 // ── Learned pattern helpers ─────────────────────────────────────────
 
 /**
- * Find a learned pattern by normalized SQL for the given org.
+ * Find a learned pattern by exact normalized SQL match for the given org.
  * Returns the pattern's id, confidence, and repetition count, or null if not found.
  */
-export async function findSimilarPattern(
+export async function findPatternBySQL(
   orgId: string | null | undefined,
   patternSql: string,
 ): Promise<{ id: string; confidence: number; repetitionCount: number } | null> {
@@ -621,8 +621,8 @@ export function insertLearnedPattern(pattern: {
 }
 
 /**
- * Increment the repetition count and bump confidence for an existing learned pattern.
- * Appends the source fingerprint to source_queries (capped at 100 entries).
+ * Increment repetition_count by 1 and increase confidence by 0.1 (capped at 1.0).
+ * When sourceFingerprint is provided, appends it to source_queries (capped at 100 entries).
  * Fire-and-forget — errors are logged, never thrown.
  */
 export function incrementPatternCount(id: string, sourceFingerprint?: string): void {

--- a/packages/api/src/lib/learn/pattern-analyzer.ts
+++ b/packages/api/src/lib/learn/pattern-analyzer.ts
@@ -1,7 +1,8 @@
 /**
  * Pattern analysis for the learned patterns system.
  *
- * Extracted from packages/cli/lib/learn/analyze.ts for runtime use.
+ * Inspired by packages/cli/lib/learn/analyze.ts, adapted for runtime use
+ * with literal-placeholder normalization for stronger deduplication.
  * Provides SQL normalization, fingerprinting, and novelty detection
  * against YAML query_patterns in the semantic layer.
  */
@@ -39,7 +40,7 @@ export function normalizeSQL(sql: string): string {
 }
 
 /**
- * Generate a short fingerprint (SHA-256 hex prefix) for deduplication.
+ * Generate a 16-character SHA-256 hex prefix fingerprint for deduplication.
  */
 export function fingerprintSQL(normalizedSql: string): string {
   return crypto.createHash("sha256").update(normalizedSql).digest("hex").slice(0, 16);
@@ -195,8 +196,10 @@ function loadPatternsFromDir(dir: string, out: Set<string>): void {
 
 let _yamlPatternCache: Set<string> | null = null;
 
-/** Get cached YAML patterns. Lazily loaded on first access.
- * Empty results are not cached so subsequent calls retry the load. */
+/** Get YAML patterns. When semanticRoot is provided, reads directly from disk
+ * (bypasses cache). Otherwise, lazily loads from the default semantic directory
+ * and caches for subsequent calls. Empty results are not cached so subsequent
+ * calls retry the load. */
 export function getYamlPatterns(semanticRoot?: string): Set<string> {
   if (semanticRoot) return loadYamlQueryPatterns(semanticRoot);
   if (!_yamlPatternCache) {

--- a/packages/api/src/lib/learn/pattern-proposer.ts
+++ b/packages/api/src/lib/learn/pattern-proposer.ts
@@ -7,7 +7,7 @@
  */
 
 import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
-import { hasInternalDB, findSimilarPattern, insertLearnedPattern, incrementPatternCount } from "@atlas/api/lib/db/internal";
+import { hasInternalDB, findPatternBySQL, insertLearnedPattern, incrementPatternCount } from "@atlas/api/lib/db/internal";
 import { normalizeSQL, fingerprintSQL, extractPatternInfo, getYamlPatterns } from "@atlas/api/lib/learn/pattern-analyzer";
 
 const log = createLogger("pattern-proposer");
@@ -15,6 +15,7 @@ const log = createLogger("pattern-proposer");
 export interface PatternProposalInput {
   sql: string;
   dialect: string;
+  /** Used for debug logging only; not stored in the learned pattern record. */
   connectionId: string;
 }
 
@@ -56,7 +57,7 @@ export async function _analyzeAndPropose(input: PatternProposalInput): Promise<v
   const orgId = reqCtx?.user?.activeOrganizationId;
   const fingerprint = fingerprintSQL(normalized);
 
-  const existing = await findSimilarPattern(orgId, normalized);
+  const existing = await findPatternBySQL(orgId, normalized);
   if (existing) {
     // Duplicate — bump count and confidence, append source fingerprint
     incrementPatternCount(existing.id, fingerprint);

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -618,7 +618,10 @@ async function executeAndAudit(opts: {
       durationMs,
     });
 
-    // Fire-and-forget: propose as learned pattern if novel
+    // Fire-and-forget: propose as learned pattern if novel.
+    // Note: querySql may include auto-appended LIMIT (stripped by normalizeSQL)
+    // and RLS-injected WHERE clauses (not stripped — same base query may produce
+    // different patterns for different RLS contexts).
     proposePatternIfNovel({
       sql: querySql,
       dialect: parserDatabase(dbType, connId),


### PR DESCRIPTION
## Summary

- After a successful `executeSQL` call, fire-and-forget analyze the query and propose it as a learned pattern if novel
- SQL normalization (strip literals, comments, whitespace, LIMIT/OFFSET) enables pattern deduplication across different parameter values
- Novelty check: compare normalized SQL against existing YAML `query_patterns` and `learned_patterns` table
- Novel patterns inserted with `status: pending`, `confidence: 0.1`, `proposed_by: agent`
- Duplicate patterns increment `repetition_count` and bump confidence (`min(1.0, confidence + 0.1)`)
- Source fingerprints (SHA-256 prefix) accumulated in `source_queries` JSONB for traceability
- Org-scoped: patterns created under the active organization from request context

### New files
- `packages/api/src/lib/learn/pattern-analyzer.ts` — SQL normalization, fingerprinting, AST-based pattern info extraction, YAML query_patterns loading
- `packages/api/src/lib/learn/pattern-proposer.ts` — Fire-and-forget orchestration (normalize → check YAML → check DB → insert or increment)

### Modified files
- `packages/api/src/lib/db/internal.ts` — Added `findSimilarPattern`, `insertLearnedPattern`, `incrementPatternCount` helpers
- `packages/api/src/lib/tools/sql.ts` — Hook call in `executeAndAudit` success path

## Test plan
- [x] 25 pattern-analyzer tests: normalization, fingerprinting, AST extraction, YAML loading
- [x] 8 pattern-proposer tests: novel insert, duplicate increment, org-scoping, fire-and-forget safety, metadata correctness
- [x] All 122 existing API tests pass (updated 6 mock files with new internal.ts exports)
- [x] CI gates: lint, type, test, syncpack, template drift — all pass

Closes #587