### PR TITLE
fix: add missing error codes to CHAT_ERROR_CODES

### DIFF
--- a/packages/types/src/__tests__/errors.test.ts
+++ b/packages/types/src/__tests__/errors.test.ts
@@ -310,6 +310,9 @@ describe("isChatErrorCode", () => {
     expect(isChatErrorCode("internal_error")).toBe(true);
     expect(isChatErrorCode("provider_timeout")).toBe(true);
     expect(isChatErrorCode("auth_error")).toBe(true);
+    expect(isChatErrorCode("session_expired")).toBe(true);
+    expect(isChatErrorCode("forbidden_role")).toBe(true);
+    expect(isChatErrorCode("org_not_found")).toBe(true);
   });
 
   test("rejects invalid codes", () => {
@@ -334,6 +337,7 @@ describe("isRetryableError", () => {
 
   const nonRetryableCodes: ChatErrorCode[] = [
     "auth_error",
+    "session_expired",
     "configuration_error",
     "no_datasource",
     "invalid_request",
@@ -342,6 +346,8 @@ describe("isRetryableError", () => {
     "validation_error",
     "not_found",
     "forbidden",
+    "forbidden_role",
+    "org_not_found",
   ];
 
   test("marks transient codes as retryable", () => {
@@ -380,7 +386,7 @@ describe("parseChatError retryable", () => {
   });
 
   test("retryable is false for all permanent error codes", () => {
-    for (const code of ["auth_error", "configuration_error", "no_datasource", "invalid_request", "provider_model_not_found", "provider_auth_error", "validation_error", "not_found", "forbidden"] as const) {
+    for (const code of ["auth_error", "session_expired", "configuration_error", "no_datasource", "invalid_request", "provider_model_not_found", "provider_auth_error", "validation_error", "not_found", "forbidden", "forbidden_role", "org_not_found"] as const) {
       const err = new Error(JSON.stringify({ error: code, message: "fail" }));
       const info = parseChatError(err, authMode);
       expect(info.retryable).toBe(false);

--- a/packages/types/src/errors.ts
+++ b/packages/types/src/errors.ts
@@ -13,6 +13,7 @@ declare const navigator: { onLine?: boolean } | undefined;
 // not a chat error code. The SDK defines it separately in AtlasErrorCode.
 export const CHAT_ERROR_CODES = [
   "auth_error",
+  "session_expired",
   "rate_limited",
   "configuration_error",
   "no_datasource",
@@ -27,6 +28,8 @@ export const CHAT_ERROR_CODES = [
   "validation_error",
   "not_found",
   "forbidden",
+  "forbidden_role",
+  "org_not_found",
 ] as const;
 
 /** Union of all error codes the server can return in the `error` field. */
@@ -57,6 +60,7 @@ const RETRYABLE_MAP: Record<ChatErrorCode, boolean> = {
   internal_error: true,
   // Permanent — retrying will not help
   auth_error: false,
+  session_expired: false,
   configuration_error: false,
   no_datasource: false,
   invalid_request: false,
@@ -65,6 +69,8 @@ const RETRYABLE_MAP: Record<ChatErrorCode, boolean> = {
   validation_error: false,
   not_found: false,
   forbidden: false,
+  forbidden_role: false,
+  org_not_found: false,
 };
 
 /** Returns `true` if the given error code represents a transient, retryable failure. */
@@ -465,6 +471,15 @@ export function parseChatError(error: Error, authMode: AuthMode): ChatErrorInfo 
 
     case "forbidden":
       return { title: "Access denied.", detail: serverMessage, code: rawCode, retryable, requestId };
+
+    case "session_expired":
+      return { title: "Your session has expired.", detail: serverMessage ?? "Please sign in again.", code: rawCode, retryable, requestId };
+
+    case "forbidden_role":
+      return { title: "Admin role required.", detail: serverMessage, code: rawCode, retryable, requestId };
+
+    case "org_not_found":
+      return { title: "No active organization.", detail: serverMessage ?? "Select an organization and try again.", code: rawCode, retryable, requestId };
 
     default: {
       const _exhaustive: never = rawCode;


### PR DESCRIPTION
## Summary
- Adds `session_expired`, `forbidden_role`, and `org_not_found` to `CHAT_ERROR_CODES` in `@useatlas/types`
- All three are classified as permanent (non-retryable) in `RETRYABLE_MAP`
- Adds `parseChatError` switch cases with user-friendly messages matching the existing patterns
- Updates tests to cover the new codes in `isChatErrorCode`, `isRetryableError`, and `parseChatError` assertions
- Docs (`error-codes.mdx`) already list these codes correctly — no docs changes needed

Closes #629

## Test plan
- [x] `bun test packages/types/src/__tests__/errors.test.ts` — 67 tests pass (0 fail)
- [x] `bun run test` — full test suite passes
- [x] `bun run lint` — clean
- [x] `bun run type` — no new errors (pre-existing plugin-sdk peer dep warnings only)
- [x] `bun x syncpack lint` — clean
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — 351 files verified