### PR TITLE
docs: fill reference gaps from 0.6.0-0.8.0 features

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,19 @@ ATLAS_ADMIN_EMAIL=admin@atlas.dev
 # ATLAS_CACHE_TTL=300000       # Default: 300000 (5 minutes) — cache TTL in milliseconds
 # ATLAS_CACHE_MAX_SIZE=1000    # Default: 1000 — max cached query results (LRU eviction)
 
+# === Dynamic Learning ===
+# ATLAS_LEARN_CONFIDENCE_THRESHOLD=0.7   # Default: 0.7 — min confidence (0-1) for auto-promoting learned patterns
+
+# === Demo Data ===
+# ATLAS_DEMO_DATA=true         # Use internal DB as both analytics datasource and internal DB
+
+# === Encryption ===
+# ATLAS_ENCRYPTION_KEY=        # Dedicated encryption key for connection URLs at rest (takes precedence over BETTER_AUTH_SECRET)
+
+# === Email ===
+# ATLAS_EMAIL_ALLOWED_DOMAINS=                    # Comma-separated allowed recipient domains for email actions (unset = all allowed)
+# ATLAS_EMAIL_FROM=Atlas <noreply@useatlas.dev>   # From address for scheduled task and action emails
+
 # === Production Deployment ===
 # Required for production (Railway, etc.):
 #   ATLAS_PROVIDER + its API key (e.g. ANTHROPIC_API_KEY)

--- a/apps/docs/content/docs/reference/cli.mdx
+++ b/apps/docs/content/docs/reference/cli.mdx
@@ -33,6 +33,8 @@ bun run atlas -- init [options]
 | `--no-enrich` | Explicitly skip LLM enrichment |
 | `--force` | Continue even if more than 20% of tables fail to profile |
 | `--demo [simple\|cybersec\|ecommerce]` | Load a demo dataset then profile (default: `simple`) |
+| `--org <orgId>` | Write to `semantic/.orgs/{orgId}/` and auto-import to DB (org-scoped mode). Requires managed auth (`DATABASE_URL` + `BETTER_AUTH_SECRET`) |
+| `--no-import` | Skip auto-import to DB in org-scoped mode (write disk only). Only meaningful with `--org` |
 
 **Examples:**
 
@@ -60,6 +62,12 @@ bun run atlas -- init --csv sales.csv,products.csv
 
 # Per-source layout (writes to semantic/warehouse/)
 bun run atlas -- init --source warehouse
+
+# Org-scoped: writes to semantic/.orgs/org-123/ and imports to DB
+bun run atlas -- init --org org-123
+
+# Org-scoped, disk only (skip DB import)
+bun run atlas -- init --org org-123 --no-import
 ```
 
 `--demo` without an argument loads the simple dataset (3 tables, ~330 rows). `--demo cybersec` loads the cybersec dataset (62 tables, ~500K rows). `--demo ecommerce` loads the e-commerce dataset (52 tables, ~480K rows).
@@ -379,7 +387,7 @@ bun run atlas -- learn [options]
 | `--limit <n>` | Max audit log entries to analyze (default: 1000) |
 | `--since <date>` | Only analyze queries after this date (ISO 8601, e.g. `2026-03-01`) |
 | `--source <name>` | Read from/write to `semantic/{name}/` subdirectory |
-| `--suggestions` | Generate query suggestions from the audit log (stored in `query_suggestions` table) |
+| `--suggestions` | Generate query suggestions from the audit log (stored in the `query_suggestions` table). Can be combined with `--apply` and other flags |
 
 **Requires** `DATABASE_URL` to be set (the audit log lives in the internal database).
 

--- a/apps/docs/content/docs/reference/config.mdx
+++ b/apps/docs/content/docs/reference/config.mdx
@@ -166,7 +166,7 @@ export default defineConfig({
 | `description` | `string` | No | — | Human-readable label shown in the agent system prompt |
 | `maxConnections` | `number` | No | — | Connection pool size for this datasource |
 | `idleTimeoutMs` | `number` | No | — | Idle connection timeout in milliseconds |
-| `rateLimit` | `object` | No | — | `{ queriesPerMinute: number, concurrency: number }` (defaults: 60 qpm, 5 concurrent) |
+| `rateLimit` | `object` | No | `{ queriesPerMinute: 60, concurrency: 5 }` | Per-datasource rate limiting. `queriesPerMinute` caps queries per minute (default: 60). `concurrency` caps concurrent queries (default: 5) |
 
 The `"default"` datasource is used when the agent's `executeSQL` tool is called without a `connectionId`. See [Multi-Datasource Routing](/guides/multi-datasource) for a full guide on how the agent selects and queries multiple datasources.
 
@@ -342,13 +342,36 @@ The cache is automatically flushed on config reload. Manual flush is available v
 
 ---
 
+## Dynamic Learning
+
+Configure how the offline learning loop (`atlas learn`) promotes discovered query patterns into the semantic layer.
+
+```typescript
+export default defineConfig({
+  learn: {
+    confidenceThreshold: 0.7,  // default: 0.7
+  },
+});
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `confidenceThreshold` | `number` | `0.7` | Minimum confidence score (0–1) for a learned pattern to be eligible for auto-promotion. Lower values promote more aggressively; higher values require stronger evidence from the audit log |
+
+**Env var equivalent:**
+```bash
+ATLAS_LEARN_CONFIDENCE_THRESHOLD=0.7
+```
+
+---
+
 ## RLS (Row-Level Security)
 
 Define RLS policies that inject WHERE clauses on every query based on user JWT claims. Each policy specifies which tables it applies to, which column to filter on, and which JWT claim provides the value.
 
 See [Row-Level Security](/security/row-level-security) for the full guide.
 
-<Tabs items={["Single policy", "Per-table policies", "All tables"]}>
+<Tabs items={["Single policy", "Per-table policies", "All tables", "OR-combined"]}>
 <Tab value="Single policy">
 ```typescript
 // atlas.config.ts — single RLS policy
@@ -402,7 +425,31 @@ export default defineConfig({
 });
 ```
 </Tab>
+<Tab value="OR-combined">
+```typescript
+// atlas.config.ts — OR-combined policies (match any one policy)
+export default defineConfig({
+  rls: {
+    enabled: true,
+    // "or" = user passes if ANY policy matches (default: "and" = ALL must match)
+    combineWith: "or",
+    policies: [
+      { tables: ["orders"], column: "tenant_id", claim: "org_id" },
+      { tables: ["orders"], column: "region", claim: "region" },
+    ],
+  },
+});
+```
+</Tab>
 </Tabs>
+
+### RLS config fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `enabled` | `boolean` | No | `false` | Whether RLS is active. When true, policies are enforced on every query |
+| `policies` | `RLSPolicy[]` | Yes (when enabled) | `[]` | Array of RLS policies (see below) |
+| `combineWith` | `"and" \| "or"` | No | `"and"` | How to combine conditions from different policies. `"and"` requires all policies to match. `"or"` requires at least one policy to match |
 
 ### RLS policy fields
 
@@ -470,7 +517,7 @@ export default defineConfig({
 | `[actionType].approval` | `string` | Override approval mode for this action |
 | `[actionType].requiredRole` | `string` | Minimum role to approve: `viewer`, `analyst`, `admin` |
 | `[actionType].credentials` | `object` | Required env vars (`{ VAR_NAME: { env: "VAR_NAME" } }`) |
-| `[actionType].rateLimit` | `number` | Per-action rate limit |
+| `[actionType].rateLimit` | `number` | Max executions per minute for this action type |
 
 ---
 
@@ -754,6 +801,11 @@ export default defineConfig({
   semanticIndex: {
     enabled: true,
   },
+
+  // Dynamic learning (offline audit log analysis)
+  learn: {
+    confidenceThreshold: 0.7,
+  },
 });
 ```
 
@@ -778,6 +830,7 @@ export default defineConfig({
 | `cache` | `object` | — | Query result caching ([details](#query-cache)) |
 | `pool` | `object` | — | Per-org connection pool isolation ([details](#per-org-pool-isolation)) |
 | `semanticIndex` | `object` | — | Semantic index configuration ([details](#semantic-index)) |
+| `learn` | `object` | — | Dynamic learning configuration ([details](#dynamic-learning)) |
 
 ---
 

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -437,6 +437,14 @@ Scheduled task execution. Can also be configured via [`atlas.config.ts`](/refere
 
 ---
 
+## Dynamic Learning
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ATLAS_LEARN_CONFIDENCE_THRESHOLD` | `0.7` | Minimum confidence score (0–1) for a learned pattern to be eligible for auto-promotion. Used by the `atlas learn` CLI command and the dynamic learning loop. Can also be set via [`atlas.config.ts`](/reference/config#dynamic-learning) |
+
+---
+
 ## Python Tool
 
 | Variable | Default | Description |


### PR DESCRIPTION
## Summary

Fills documentation reference gaps accumulated across milestones 0.6.0 through 0.8.0:

- **#630 — learn config, env var, RLS combineWith**: Added `learn` config section with `confidenceThreshold` to config reference, `ATLAS_LEARN_CONFIDENCE_THRESHOLD` to env var reference and `.env.example`, and documented `rls.combineWith` (`"and"` | `"or"`) with a new OR-combined tab example and an RLS config fields table
- **#631 — missing CLI flags**: Added `--org <orgId>` and `--no-import` to `init` command, and `--suggestions` to `learn` command in CLI reference
- **#633 — .env.example gaps + config reference**: Added `ATLAS_DEMO_DATA`, `ATLAS_ENCRYPTION_KEY`, `ATLAS_EMAIL_ALLOWED_DOMAINS`, `ATLAS_EMAIL_FROM` to `.env.example`; clarified `rateLimit` defaults (queriesPerMinute: 60, concurrency: 5) in datasource config; clarified per-action `rateLimit` description. Daytona plugin docs page already exists at `plugins/sandboxes/daytona.mdx`

Closes #630, closes #631, closes #633

## Test plan

- [ ] `bun run lint` passes (clean)
- [ ] `bun run type` passes (pre-existing plugin-sdk peer dep errors only)
- [ ] `bun x syncpack lint` passes (clean)
- [ ] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` passes (clean)
- [ ] Verify config.mdx renders correctly with new Dynamic Learning, RLS combineWith, and OR-combined tab sections
- [ ] Verify cli.mdx init flags table includes `--org` and `--no-import`
- [ ] Verify cli.mdx learn flags table includes `--suggestions`
- [ ] Verify environment-variables.mdx has new Dynamic Learning section
- [ ] Verify .env.example has all 5 new commented vars in appropriate sections