### PR TITLE
fix: harden usage metering error handling and test coverage

### DIFF
--- a/packages/api/src/api/__tests__/admin-usage.test.ts
+++ b/packages/api/src/api/__tests__/admin-usage.test.ts
@@ -235,10 +235,10 @@ describe("Admin Usage API", () => {
         user: { id: "admin-1", mode: "simple-key", label: "Admin", role: "admin", activeOrganizationId: "org-1" },
       }),
     );
-    mockGetCurrentPeriodUsage.mockClear();
-    mockGetUsageHistory.mockClear();
-    mockGetUsageBreakdown.mockClear();
-    mockAggregateUsageSummary.mockClear();
+    mockGetCurrentPeriodUsage.mockImplementation(() => Promise.resolve({ ...mockCurrentUsage }));
+    mockGetUsageHistory.mockImplementation(() => Promise.resolve([...mockHistorySummaries]));
+    mockGetUsageBreakdown.mockImplementation(() => Promise.resolve([...mockBreakdownUsers]));
+    mockAggregateUsageSummary.mockImplementation(() => Promise.resolve());
   });
 
   // --- GET /api/v1/admin/usage ---
@@ -326,6 +326,35 @@ describe("Admin Usage API", () => {
       expect(body.error).toBe("internal_error");
       expect(body.requestId).toBeTruthy();
     });
+
+    it("returns daily period when requested", async () => {
+      const res = await app.fetch(adminRequest("GET", "/api/v1/admin/usage/history?period=daily"));
+      expect(res.status).toBe(200);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body.period).toBe("daily");
+    });
+
+    it("returns 400 for invalid startDate", async () => {
+      const res = await app.fetch(adminRequest("GET", "/api/v1/admin/usage/history?startDate=not-a-date"));
+      expect(res.status).toBe(400);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body.error).toBe("invalid_param");
+    });
+
+    it("returns 400 for invalid endDate", async () => {
+      const res = await app.fetch(adminRequest("GET", "/api/v1/admin/usage/history?endDate=garbage"));
+      expect(res.status).toBe(400);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body.error).toBe("invalid_param");
+    });
+
+    it("clamps limit to valid range", async () => {
+      await app.fetch(adminRequest("GET", "/api/v1/admin/usage/history?limit=999"));
+      expect(mockGetUsageHistory).toHaveBeenCalled();
+      // limit=999 should be clamped to 365 — getUsageHistory(orgId, period, startDate, endDate, limit)
+      const lastCall = mockGetUsageHistory.mock.lastCall as unknown[];
+      expect(lastCall[4]).toBe(365);
+    });
   });
 
   // --- GET /api/v1/admin/usage/breakdown ---
@@ -354,6 +383,21 @@ describe("Admin Usage API", () => {
       const body = await res.json() as Record<string, unknown>;
       expect(body.error).toBe("internal_error");
       expect(body.requestId).toBeTruthy();
+    });
+
+    it("returns 400 for invalid startDate", async () => {
+      const res = await app.fetch(adminRequest("GET", "/api/v1/admin/usage/breakdown?startDate=not-a-date"));
+      expect(res.status).toBe(400);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body.error).toBe("invalid_param");
+    });
+
+    it("clamps limit to valid range", async () => {
+      await app.fetch(adminRequest("GET", "/api/v1/admin/usage/breakdown?limit=999"));
+      expect(mockGetUsageBreakdown).toHaveBeenCalled();
+      // limit=999 should be clamped to 500 — getUsageBreakdown(orgId, startDate, endDate, limit)
+      const lastCall = mockGetUsageBreakdown.mock.lastCall as unknown[];
+      expect(lastCall[3]).toBe(500);
     });
   });
 });

--- a/packages/api/src/api/routes/admin-usage.ts
+++ b/packages/api/src/api/routes/admin-usage.ts
@@ -20,6 +20,11 @@ const log = createLogger("admin-usage");
 
 const adminUsage = new Hono();
 
+/** Returns true if the string is a valid date (parseable by Date). */
+function isValidDateParam(value: string): boolean {
+  return !isNaN(Date.parse(value));
+}
+
 // ---------------------------------------------------------------------------
 // GET / — current period usage summary for the active workspace
 // ---------------------------------------------------------------------------
@@ -83,6 +88,13 @@ adminUsage.get("/history", async (c) => {
     const endDate = c.req.query("endDate");
     const limit = Math.min(Math.max(parseInt(c.req.query("limit") ?? "90", 10) || 90, 1), 365);
 
+    if (startDate && !isValidDateParam(startDate)) {
+      return c.json({ error: "invalid_param", message: "startDate must be a valid ISO date string." }, 400);
+    }
+    if (endDate && !isValidDateParam(endDate)) {
+      return c.json({ error: "invalid_param", message: "endDate must be a valid ISO date string." }, 400);
+    }
+
     try {
       // Trigger aggregation for the current period before returning history
       const now = new Date();
@@ -127,6 +139,13 @@ adminUsage.get("/breakdown", async (c) => {
     const startDate = c.req.query("startDate");
     const endDate = c.req.query("endDate");
     const limit = Math.min(Math.max(parseInt(c.req.query("limit") ?? "100", 10) || 100, 1), 500);
+
+    if (startDate && !isValidDateParam(startDate)) {
+      return c.json({ error: "invalid_param", message: "startDate must be a valid ISO date string." }, 400);
+    }
+    if (endDate && !isValidDateParam(endDate)) {
+      return c.json({ error: "invalid_param", message: "endDate must be a valid ISO date string." }, 400);
+    }
 
     try {
       const users = await getUsageBreakdown(orgId, startDate ?? undefined, endDate ?? undefined, limit);

--- a/packages/api/src/lib/__tests__/metering.test.ts
+++ b/packages/api/src/lib/__tests__/metering.test.ts
@@ -152,6 +152,18 @@ describe("metering", () => {
       expect(result.queryCount).toBe(0);
       expect(queryCalls).toHaveLength(0);
     });
+
+    it("returns zeros when query returns empty result set", async () => {
+      queryResults = [[]]; // empty array — rows[0] is undefined
+
+      const result = await getCurrentPeriodUsage("org-1");
+
+      expect(result.queryCount).toBe(0);
+      expect(result.tokenCount).toBe(0);
+      expect(result.activeUsers).toBe(0);
+      expect(result.periodStart).toBeTruthy();
+      expect(result.periodEnd).toBeTruthy();
+    });
   });
 
   describe("getUsageHistory", () => {
@@ -184,6 +196,16 @@ describe("metering", () => {
       mockHasInternalDB = false;
       const result = await getUsageHistory("org-1", "monthly");
       expect(result).toEqual([]);
+    });
+
+    it("passes custom limit as last SQL parameter", async () => {
+      queryResults = [[]];
+
+      await getUsageHistory("org-1", "daily", undefined, undefined, 10);
+
+      const call = queryCalls[0];
+      const params = call.params as unknown[];
+      expect(params[params.length - 1]).toBe(10);
     });
   });
 

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -632,23 +632,29 @@ export async function runAgent({
             log.warn({ err: err instanceof Error ? err.message : String(err) }, "Failed to persist token usage");
           }
 
-          // Log usage metering events for billing/overage tracking
-          const totalTokens = (totalUsage.inputTokens ?? 0) + (totalUsage.outputTokens ?? 0);
-          logUsageEvent({
-            workspaceId: orgId ?? null,
-            userId,
-            eventType: "query",
-            quantity: 1,
-            metadata: { conversationId, model: resolvedModelId, steps: steps.length },
-          });
-          if (totalTokens > 0) {
+          // Log usage metering events for billing/overage tracking.
+          // Wrapped in its own try/catch to ensure a metering failure
+          // never disrupts the onFinish callback or stream finalization.
+          try {
+            const totalTokens = (totalUsage.inputTokens ?? 0) + (totalUsage.outputTokens ?? 0);
             logUsageEvent({
               workspaceId: orgId ?? null,
-              userId,
-              eventType: "token",
-              quantity: totalTokens,
-              metadata: { input: totalUsage.inputTokens ?? 0, output: totalUsage.outputTokens ?? 0 },
+              userId: userId ?? null,
+              eventType: "query",
+              quantity: 1,
+              metadata: { conversationId, model: resolvedModelId, steps: steps.length },
             });
+            if (totalTokens > 0) {
+              logUsageEvent({
+                workspaceId: orgId ?? null,
+                userId: userId ?? null,
+                eventType: "token",
+                quantity: totalTokens,
+                metadata: { input: totalUsage.inputTokens ?? 0, output: totalUsage.outputTokens ?? 0 },
+              });
+            }
+          } catch (err) {
+            log.warn({ err: err instanceof Error ? err.message : String(err) }, "Failed to log usage metering events");
           }
         }
       },


### PR DESCRIPTION
## Summary
- Wrap metering `logUsageEvent` calls in agent.ts `onFinish` with defensive try/catch to prevent stream disruption
- Add date param validation on `/history` and `/breakdown` — returns 400 for malformed dates instead of letting PostgreSQL throw a 500
- Explicitly coerce `userId` to `null` for type safety (`string | null`, not `undefined`)
- Add missing test coverage: empty result fallback, limit clamping (365/500), daily period path, date validation, custom limit threading

## Test plan
- [x] 17 metering unit tests (was 15, +2 new: empty result set, custom limit)
- [x] 18 admin API tests (was 12, +6 new: daily period, date validation x3, limit clamping x2)
- [x] CI: lint ✓, type ✓, test (132/132 API) ✓, syncpack ✓, drift ✓

Followup to #675 / #650