### PR TITLE
fix: harden wizard error handling and MySQL identifier escaping

### DIFF
--- a/packages/api/src/api/routes/wizard.ts
+++ b/packages/api/src/api/routes/wizard.ts
@@ -76,7 +76,7 @@ wizard.post("/profile", async (c) => {
       log.error({ err: err instanceof Error ? err : new Error(String(err)), requestId, connectionId }, "Failed to resolve connection URL");
       return c.json({
         error: "connection_resolution_failed",
-        message: `Failed to resolve connection "${connectionId}": ${err instanceof Error ? err.message : String(err)}`,
+        message: "Failed to resolve connection. Check server logs for details.",
         requestId,
       }, 500);
     }
@@ -90,7 +90,7 @@ wizard.post("/profile", async (c) => {
       let objects;
       switch (dbType) {
         case "postgres":
-          objects = await listPostgresObjects(url, schema);
+          objects = await listPostgresObjects(url, schema, log);
           break;
         case "mysql":
           objects = await listMySQLObjects(url);
@@ -168,7 +168,7 @@ wizard.post("/generate", async (c) => {
       log.error({ err: err instanceof Error ? err : new Error(String(err)), requestId, connectionId }, "Failed to resolve connection URL");
       return c.json({
         error: "connection_resolution_failed",
-        message: `Failed to resolve connection "${connectionId}": ${err instanceof Error ? err.message : String(err)}`,
+        message: "Failed to resolve connection. Check server logs for details.",
         requestId,
       }, 500);
     }
@@ -182,10 +182,10 @@ wizard.post("/generate", async (c) => {
       let result: ProfilingResult;
       switch (dbType) {
         case "postgres":
-          result = await profilePostgres(url, tableNames, undefined, schema);
+          result = await profilePostgres(url, tableNames, undefined, schema, undefined, log);
           break;
         case "mysql":
-          result = await profileMySQL(url, tableNames);
+          result = await profileMySQL(url, tableNames, undefined, undefined, log);
           break;
         default:
           return c.json({
@@ -485,8 +485,9 @@ interface ResolvedConnection {
  * or the internal database (encrypted connections table).
  *
  * Returns the resolved connection, or null if the connection does not exist.
- * Throws on infrastructure errors (ECONNREFUSED, pool exhaustion, decryption failure)
- * so callers can distinguish "not found" from "lookup failed".
+ * Throws on infrastructure errors (e.g. database unreachable, pool exhaustion,
+ * decryption failure, missing encryption key) so callers can distinguish
+ * "not found" from "lookup failed".
  */
 async function resolveConnectionUrl(
   connectionId: string,
@@ -500,7 +501,6 @@ async function resolveConnectionUrl(
       // The describe() method masks the URL, so we need the raw URL for profiling.
       // Check internal DB first (it has the encrypted URL).
       if (hasInternalDB()) {
-        // Let errors propagate — callers must distinguish "not found" from "lookup failed"
         const rows = await internalQuery<{ url: string; schema_name: string | null }>(
           "SELECT url, schema_name FROM connections WHERE id = $1",
           [connectionId],
@@ -527,7 +527,6 @@ async function resolveConnectionUrl(
     const params: unknown[] = [connectionId];
     if (orgId) params.push(orgId);
 
-    // Let errors propagate — callers must distinguish "not found" from "lookup failed"
     const rows = await internalQuery<{ url: string; schema_name: string | null }>(
       `SELECT url, schema_name FROM connections WHERE id = $1${orgFilter}`,
       params,

--- a/packages/api/src/lib/profiler.ts
+++ b/packages/api/src/lib/profiler.ts
@@ -1,16 +1,16 @@
 /**
  * Shared profiler library — extracted from CLI for reuse by the wizard API.
  *
- * Contains pure functions: type mapping, YAML generation, heuristics, and
- * DB-specific profiling. The CLI imports from here; the wizard API calls
- * these functions directly via HTTP endpoints.
+ * Contains type mapping, YAML generation, heuristics, and DB-specific
+ * profiling. The CLI imports from here; the wizard API calls these
+ * functions directly via HTTP endpoints.
  */
 
 import * as yaml from "js-yaml";
 import type { DBType } from "@atlas/api/lib/db/connection";
 import { createLogger } from "@atlas/api/lib/logger";
 
-/** Minimal logger interface for profiler functions — compatible with pino and console. */
+/** Minimal structured logger interface — compatible with pino's (obj, msg) calling convention. */
 export interface ProfileLogger {
   info(obj: Record<string, unknown>, msg: string): void;
   warn(obj: Record<string, unknown>, msg: string): void;
@@ -120,6 +120,7 @@ export function checkFailureThreshold(
 }
 
 export function logProfilingErrors(errors: ProfileError[], total: number, log: ProfileLogger = defaultLog): void {
+  if (total === 0) return;
   const pct = Math.round((errors.length / total) * 100);
   log.warn(
     { errorCount: errors.length, total, pct, tables: errors.slice(0, 5).map((e) => e.table) },
@@ -1067,11 +1068,13 @@ export async function listPostgresObjects(connectionString: string, schema: stri
 
     return objects.sort((a, b) => a.name.localeCompare(b.name));
   } finally {
-    await pool.end();
+    await pool.end().catch((err: unknown) => {
+      log.warn({ err: err instanceof Error ? err.message : String(err) }, "Postgres pool cleanup warning");
+    });
   }
 }
 
-export async function listMySQLObjects(connectionString: string): Promise<DatabaseObject[]> {
+export async function listMySQLObjects(connectionString: string, _log: ProfileLogger = defaultLog): Promise<DatabaseObject[]> {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const mysql = require("mysql2/promise");
   const pool = mysql.createPool({
@@ -1090,7 +1093,9 @@ export async function listMySQLObjects(connectionString: string): Promise<Databa
       type: r.TABLE_TYPE === "VIEW" ? "view" as const : "table" as const,
     }));
   } finally {
-    await pool.end();
+    await pool.end().catch((err: unknown) => {
+      _log.warn({ err: err instanceof Error ? err.message : String(err) }, "MySQL pool cleanup warning");
+    });
   }
 }
 
@@ -1442,7 +1447,9 @@ export async function profilePostgres(
 
   return { profiles, errors };
   } finally {
-    await pool.end();
+    await pool.end().catch((err: unknown) => {
+      log.warn({ err: err instanceof Error ? err.message : String(err) }, "Postgres pool cleanup warning");
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes #684

- **resolveConnectionUrl returns 500 for infrastructure errors instead of 404**: DB lookup failures (ECONNREFUSED, pool exhaustion, decryption failure) now propagate as thrown errors. Callers catch them and return 500 with `requestId` for log correlation, rather than masking them as 404 "Connection not found"
- **MySQL backtick injection fix**: Added `mysqlQuoteIdent()` that escapes embedded backticks (`` ` `` → ` `` ``), matching `pgTableRef()` on the PostgreSQL side. All MySQL profiler identifier interpolation uses this helper. Table names can originate from HTTP request bodies (`filterTables`), making this security-relevant
- **Structured logging in profiler.ts**: Replaced 20+ `console.warn`/`console.log`/`console.error` calls with structured `ProfileLogger` interface backed by `createLogger("profiler")`. Profiling functions accept an optional logger parameter for injection (CLI vs API)

## Test plan
- [x] `bun run lint` passes
- [x] `bun run type` passes
- [x] `bun run test` passes (all packages exit 0)
- [x] `bun x syncpack lint` passes
- [x] Template drift check passes
- [x] Existing profiler tests (42 tests) pass
- [x] Existing wizard tests (13 tests) pass