### PR TITLE
fix: wizard generate errors schema type mismatch

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -22630,7 +22630,15 @@
                     "errors": {
                       "type": "array",
                       "items": {
-                        "type": "string"
+                        "type": "object",
+                        "properties": {
+                          "table": {
+                            "type": "string"
+                          },
+                          "error": {
+                            "type": "string"
+                          }
+                        }
                       },
                       "description": "Errors encountered during profiling (non-fatal)."
                     }

--- a/packages/api/src/api/routes/openapi.ts
+++ b/packages/api/src/api/routes/openapi.ts
@@ -4550,7 +4550,13 @@ function buildSpec(): Record<string, unknown> {
                       },
                       errors: {
                         type: "array",
-                        items: { type: "string" },
+                        items: {
+                          type: "object",
+                          properties: {
+                            table: { type: "string" },
+                            error: { type: "string" },
+                          },
+                        },
                         description: "Errors encountered during profiling (non-fatal).",
                       },
                     },


### PR DESCRIPTION
## Summary
- Fix `errors` field in `wizardGenerate` OpenAPI response schema: was `string[]`, should be `{ table: string, error: string }[]` to match the actual `ProfileError` type returned by the handler

Caught by code-reviewer during #704 review.

## Test plan
- [x] Codegen pipeline runs cleanly
- [x] Schema matches `ProfilingResult.errors` type in `packages/api/src/lib/profiler.ts`