### PR TITLE
refactor: OpenAPI Phase 3 — single merged spec endpoint

### DIFF
--- a/packages/api/scripts/extract-openapi.ts
+++ b/packages/api/scripts/extract-openapi.ts
@@ -1,24 +1,19 @@
 /**
- * Extract the OpenAPI spec from the API route module and write it to apps/docs/openapi.json.
+ * Extract the OpenAPI spec from the API and write it to apps/docs/openapi.json.
  *
- * Uses a minimal Hono fetch to invoke the route handler without starting a server
- * or loading any database drivers. Only the openapi route module is imported.
+ * Uses a minimal Hono fetch to invoke the merged spec endpoint without starting
+ * a server. Database/auth modules use lazy initialization, so no connections
+ * are opened at import time. Safe to run in CI.
  *
  * Run: bun packages/api/scripts/extract-openapi.ts
  */
 
 import * as fs from "fs";
 import * as path from "path";
-import { Hono } from "hono";
 
-// Import the openapi route — this transitively loads route modules and their
-// dependencies, but all database/auth modules use lazy initialization, so no
-// connections are opened at import time. Safe to run in CI.
+// Import the full app — the merged OpenAPI endpoint lives on the app instance.
 // @ts-expect-error — Bun resolves .ts imports at runtime
-const { openapi } = await import("../src/api/routes/openapi.ts");
-
-const app = new Hono();
-app.route("/api/v1/openapi.json", openapi);
+const { app } = await import("../src/api/index.ts");
 
 const req = new Request("http://localhost/api/v1/openapi.json");
 const res = await app.fetch(req);

--- a/packages/api/src/api/__tests__/query.test.ts
+++ b/packages/api/src/api/__tests__/query.test.ts
@@ -883,16 +883,17 @@ describe("GET /api/v1/openapi.json", () => {
     expect(spec.paths).toBeDefined();
   });
 
-  it("includes an auto-generated route path", async () => {
-    // /api/v1/chat moved to OpenAPIHono auto-generation; check a path from the auto-generated spec
+  it("includes both auto-generated and static paths", async () => {
     const response = await app.fetch(
       new Request("http://localhost/api/v1/openapi.json"),
     );
     const spec = (await response.json()) as {
       paths: Record<string, unknown>;
     };
-    // At least one path should exist in the combined spec
-    expect(Object.keys(spec.paths).length).toBeGreaterThan(0);
+    // Auto-generated path (from OpenAPIHono createRoute)
+    expect(spec.paths["/api/v1/query"]).toBeDefined();
+    // Static path (from openapi.ts staticPaths — auth proxy)
+    expect(spec.paths["/api/auth/sign-up/email"]).toBeDefined();
   });
 
   it("includes security schemes", async () => {

--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -23,7 +23,7 @@ import { chat } from "./routes/chat";
 import { health } from "./routes/health";
 import { auth } from "./routes/auth";
 import { query } from "./routes/query";
-import { openapi } from "./routes/openapi";
+import { staticPaths, staticTags, securitySchemes } from "./routes/openapi";
 import { conversations, publicConversations } from "./routes/conversations";
 import { semantic } from "./routes/semantic";
 import { tables } from "./routes/tables";
@@ -105,7 +105,7 @@ app.route("/api/v1/chat", chat);
 app.route("/api/health", health);
 app.route("/api/auth", auth);
 app.route("/api/v1/query", query);
-app.route("/api/v1/openapi.json", openapi);
+// OpenAPI spec served below via merged auto + static endpoint
 app.route("/api/v1/conversations", conversations);
 app.route("/api/public/conversations", publicConversations);
 app.route("/api/v1/semantic", semantic);
@@ -254,12 +254,49 @@ app.onError((err, c) => {
   );
 });
 
-// Auto-generated OpenAPI spec from route definitions.
-// Converted: health, validate-sql, tables, semantic (#715), admin (all sub-routers, #718).
-// The manual spec at /api/v1/openapi.json continues to serve unconverted routes.
-app.doc("/api/v1/openapi-auto.json", {
-  openapi: "3.1.0",
-  info: { title: "Atlas API", version: "0.9.0" },
+// ---------------------------------------------------------------------------
+// OpenAPI spec — merged auto-generated + static entries
+// ---------------------------------------------------------------------------
+// Auto-generated routes come from OpenAPIHono createRoute() definitions.
+// Static entries (auth proxy, widget assets) are defined in openapi.ts.
+
+let cachedSpec: Record<string, unknown> | null = null;
+
+app.get("/api/v1/openapi.json", (c) => {
+  if (!cachedSpec) {
+    const auto = app.getOpenAPI31Document({
+      openapi: "3.1.0",
+      info: {
+        title: "Atlas API",
+        version: "0.9.0",
+        description:
+          "Text-to-SQL data analyst agent. Ask natural-language questions about your data and receive structured answers.",
+      },
+      servers: [
+        { url: "http://localhost:3001", description: "Standalone API (development)" },
+        { url: "http://localhost:3000", description: "Same-origin via Next.js rewrites" },
+      ],
+    });
+
+    // Merge static paths (auth, widget) into the auto-generated spec
+    const autoPaths = (auto.paths ?? {}) as Record<string, unknown>;
+    const mergedPaths = { ...autoPaths, ...staticPaths };
+
+    // Merge static tags
+    const autoTags = (auto.tags ?? []) as Array<{ name: string; description?: string }>;
+    const autoTagNames = new Set(autoTags.map((t) => t.name));
+    const mergedTags = [...autoTags, ...staticTags.filter((t) => !autoTagNames.has(t.name))];
+
+    // Add security schemes
+    const autoComponents = (auto.components ?? {}) as Record<string, unknown>;
+    const mergedComponents = {
+      ...autoComponents,
+      securitySchemes: { ...((autoComponents.securitySchemes as Record<string, unknown>) ?? {}), ...securitySchemes },
+    };
+
+    cachedSpec = { ...auto, paths: mergedPaths, tags: mergedTags, components: mergedComponents };
+  }
+  return c.json(cachedSpec);
 });
 
 export { app };

--- a/packages/api/src/api/routes/openapi.ts
+++ b/packages/api/src/api/routes/openapi.ts
@@ -1,284 +1,232 @@
 /**
- * OpenAPI 3.1 specification endpoint.
+ * Static OpenAPI path entries for routes that are NOT on OpenAPIHono.
  *
- * GET /api/v1/openapi.json returns the spec for the v1 API, with request/response schemas derived from Zod types.
- * The spec is built once on first request and cached thereafter.
+ * Auth routes are proxied to Better Auth (dynamic, not schema-driven).
+ * Widget routes serve static assets (HTML/JS/CSS/TS declarations).
+ *
+ * These entries are merged into the auto-generated spec in index.ts.
  */
 
-import { Hono } from "hono";
 import { z } from "zod";
-
-const openapi = new Hono();
 
 function toJsonSchema(schema: z.ZodType): Record<string, unknown> {
   return z.toJSONSchema(schema) as Record<string, unknown>;
 }
 
-function buildSpec(): Record<string, unknown> {
-  const ErrorSchema = z.object({
-    error: z.string(),
-    message: z.string(),
-  });
-
-  const errorResponse = (
-    description: string,
-    schema: z.ZodType = ErrorSchema,
-  ) => ({
-    description,
-    content: { "application/json": { schema: toJsonSchema(schema) } },
-  });
-
-  return {
-    openapi: "3.1.0",
-    info: {
-      title: "Atlas API",
-      version: "0.1.0",
-      description:
-        "Text-to-SQL data analyst agent. Ask natural-language questions about your data and receive structured answers.",
-    },
-    servers: [
-      {
-        url: "http://localhost:3001",
-        description: "Standalone API (development)",
-      },
-      {
-        url: "http://localhost:3000",
-        description: "Same-origin via Next.js rewrites",
-      },
-    ],
-    paths: {
-      // -----------------------------------------------------------------
-      // Auth — Better Auth routes (key endpoints)
-      // -----------------------------------------------------------------
-      "/api/auth/sign-up/email": {
-        post: {
-          operationId: "signUpEmail",
-          summary: "Sign up with email",
-          description:
-            "Creates a new user account with email and password. Only available when auth mode is 'managed' (Better Auth).",
-          tags: ["Auth"],
-          requestBody: {
-            required: true,
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  required: ["email", "password", "name"],
-                  properties: {
-                    email: { type: "string", format: "email" },
-                    password: { type: "string", minLength: 8 },
-                    name: { type: "string" },
-                  },
-                },
-              },
-            },
-          },
-          responses: {
-            "200": {
-              description: "User created successfully",
-              content: { "application/json": { schema: { type: "object" } } },
-            },
-            "400": errorResponse("Invalid request"),
-            "404": errorResponse("Auth routes not enabled (not in managed mode)"),
-          },
-        },
-      },
-
-      "/api/auth/sign-in/email": {
-        post: {
-          operationId: "signInEmail",
-          summary: "Sign in with email",
-          description:
-            "Authenticates a user with email and password. Returns a session token. Only available when auth mode is 'managed'.",
-          tags: ["Auth"],
-          requestBody: {
-            required: true,
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  required: ["email", "password"],
-                  properties: {
-                    email: { type: "string", format: "email" },
-                    password: { type: "string" },
-                  },
-                },
-              },
-            },
-          },
-          responses: {
-            "200": {
-              description: "Session created",
-              content: { "application/json": { schema: { type: "object" } } },
-            },
-            "401": errorResponse("Invalid credentials"),
-            "404": errorResponse("Auth routes not enabled"),
-          },
-        },
-      },
-
-      "/api/auth/get-session": {
-        get: {
-          operationId: "getSession",
-          summary: "Get current session",
-          description:
-            "Returns the current session and user info. Requires a valid session cookie or Authorization header.",
-          tags: ["Auth"],
-          security: [{ bearerAuth: [] }],
-          responses: {
-            "200": {
-              description: "Current session",
-              content: { "application/json": { schema: { type: "object" } } },
-            },
-            "401": errorResponse("Not authenticated"),
-            "404": errorResponse("Auth routes not enabled"),
-          },
-        },
-      },
-
-      "/api/auth/sign-out": {
-        post: {
-          operationId: "signOut",
-          summary: "Sign out",
-          description: "Destroys the current session.",
-          tags: ["Auth"],
-          security: [{ bearerAuth: [] }],
-          responses: {
-            "200": { description: "Session destroyed" },
-            "404": errorResponse("Auth routes not enabled"),
-          },
-        },
-      },
-
-      // -----------------------------------------------------------------
-      // Widget — embeddable chat widget
-      // -----------------------------------------------------------------
-      "/widget": {
-        get: {
-          operationId: "widgetHost",
-          summary: "Widget HTML host page",
-          description:
-            "Serves a self-contained HTML page for iframe embedding. Renders the AtlasChat component with configurable theme, API URL, position, branding, and initial query.",
-          tags: ["Widget"],
-          security: [],
-          parameters: [
-            { name: "theme", in: "query", required: false, schema: { type: "string", enum: ["light", "dark", "system"], default: "system" }, description: "Color theme." },
-            { name: "apiUrl", in: "query", required: false, schema: { type: "string" }, description: "Atlas API base URL (http/https only)." },
-            { name: "position", in: "query", required: false, schema: { type: "string", enum: ["bottomRight", "bottomLeft", "inline"], default: "inline" }, description: "Widget position." },
-            { name: "logo", in: "query", required: false, schema: { type: "string" }, description: "HTTPS URL to a custom logo image." },
-            { name: "accent", in: "query", required: false, schema: { type: "string" }, description: "Hex color without # (e.g. '4f46e5')." },
-            { name: "welcome", in: "query", required: false, schema: { type: "string" }, description: "Welcome message (max 500 chars)." },
-            { name: "initialQuery", in: "query", required: false, schema: { type: "string" }, description: "Auto-send query on first open (max 500 chars)." },
-          ],
-          responses: {
-            "200": {
-              description: "Widget HTML page",
-              content: { "text/html": { schema: { type: "string" } } },
-            },
-            "503": {
-              description: "Widget bundle not built",
-              content: { "text/html": { schema: { type: "string" } } },
-            },
-          },
-        },
-      },
-
-      "/widget/atlas-widget.js": {
-        get: {
-          operationId: "widgetJS",
-          summary: "Widget JavaScript bundle",
-          description: "Self-contained ESM bundle (React + AtlasChat). Cached for 24 hours.",
-          tags: ["Widget"],
-          security: [],
-          responses: {
-            "200": {
-              description: "Widget JS bundle",
-              content: { "application/javascript": { schema: { type: "string" } } },
-            },
-            "404": { description: "Widget JS not built", content: { "text/plain": { schema: { type: "string" } } } },
-          },
-        },
-      },
-
-      "/widget/atlas-widget.css": {
-        get: {
-          operationId: "widgetCSS",
-          summary: "Widget CSS stylesheet",
-          description: "Pre-compiled Tailwind CSS for widget components. Cached for 24 hours.",
-          tags: ["Widget"],
-          security: [],
-          responses: {
-            "200": {
-              description: "Widget CSS",
-              content: { "text/css": { schema: { type: "string" } } },
-            },
-            "404": { description: "Widget CSS not built", content: { "text/plain": { schema: { type: "string" } } } },
-          },
-        },
-      },
-
-      // -----------------------------------------------------------------
-      // Widget loader — script tag for embedding
-      // -----------------------------------------------------------------
-      "/widget.js": {
-        get: {
-          operationId: "widgetLoader",
-          summary: "Widget script tag loader",
-          description:
-            "Returns a self-contained IIFE script that injects a floating chat bubble and iframe overlay into any host page. " +
-            "Reads data-* attributes from its own `<script>` tag for configuration. Exposes window.Atlas programmatic API.",
-          tags: ["Widget"],
-          security: [],
-          responses: {
-            "200": {
-              description: "Widget loader script (IIFE)",
-              content: { "application/javascript": { schema: { type: "string" } } },
-            },
-          },
-        },
-      },
-
-      "/widget.d.ts": {
-        get: {
-          operationId: "widgetTypeDeclarations",
-          summary: "Widget TypeScript declarations",
-          description:
-            "Returns ambient TypeScript declarations for window.Atlas. Fallback for embedders who load only the script tag without installing @useatlas/react.",
-          tags: ["Widget"],
-          security: [],
-          responses: {
-            "200": {
-              description: "TypeScript ambient declarations",
-              content: { "text/plain": { schema: { type: "string" } } },
-            },
-          },
-        },
-      },
-    },
-    components: {
-      securitySchemes: {
-        bearerAuth: {
-          type: "http",
-          scheme: "bearer",
-          description:
-            "API key or JWT token. Pass via Authorization: Bearer <token>.",
-        },
-      },
-    },
-    tags: [
-      { name: "Auth", description: "Authentication routes (managed auth via Better Auth)" },
-      { name: "Widget", description: "Embeddable chat widget (host page, loader script, assets)" },
-    ],
-  };
-}
-
-let cachedSpec: Record<string, unknown> | null = null;
-
-openapi.get("/", (c) => {
-  if (!cachedSpec) {
-    cachedSpec = buildSpec();
-  }
-  return c.json(cachedSpec);
+const ErrorSchema = z.object({
+  error: z.string(),
+  message: z.string(),
 });
 
-export { openapi };
+const errorResponse = (
+  description: string,
+  schema: z.ZodType = ErrorSchema,
+) => ({
+  description,
+  content: { "application/json": { schema: toJsonSchema(schema) } },
+});
+
+/** Static path entries for auth and widget routes. */
+export const staticPaths: Record<string, unknown> = {
+  // -------------------------------------------------------------------
+  // Auth — Better Auth routes (key endpoints)
+  // -------------------------------------------------------------------
+  "/api/auth/sign-up/email": {
+    post: {
+      operationId: "signUpEmail",
+      summary: "Sign up with email",
+      description:
+        "Creates a new user account with email and password. Only available when auth mode is 'managed' (Better Auth).",
+      tags: ["Auth"],
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              required: ["email", "password", "name"],
+              properties: {
+                email: { type: "string", format: "email" },
+                password: { type: "string", minLength: 8 },
+                name: { type: "string" },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "200": {
+          description: "User created successfully",
+          content: { "application/json": { schema: { type: "object" } } },
+        },
+        "400": errorResponse("Invalid request"),
+        "404": errorResponse("Auth routes not enabled (not in managed mode)"),
+      },
+    },
+  },
+
+  "/api/auth/sign-in/email": {
+    post: {
+      operationId: "signInEmail",
+      summary: "Sign in with email",
+      description:
+        "Authenticates a user with email and password. Returns a session token. Only available when auth mode is 'managed'.",
+      tags: ["Auth"],
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              required: ["email", "password"],
+              properties: {
+                email: { type: "string", format: "email" },
+                password: { type: "string" },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "200": {
+          description: "Session created",
+          content: { "application/json": { schema: { type: "object" } } },
+        },
+        "401": errorResponse("Invalid credentials"),
+        "404": errorResponse("Auth routes not enabled"),
+      },
+    },
+  },
+
+  "/api/auth/get-session": {
+    get: {
+      operationId: "getSession",
+      summary: "Get current session",
+      description:
+        "Returns the current session and user info. Requires a valid session cookie or Authorization header.",
+      tags: ["Auth"],
+      security: [{ bearerAuth: [] }],
+      responses: {
+        "200": {
+          description: "Current session",
+          content: { "application/json": { schema: { type: "object" } } },
+        },
+        "401": errorResponse("Not authenticated"),
+        "404": errorResponse("Auth routes not enabled"),
+      },
+    },
+  },
+
+  "/api/auth/sign-out": {
+    post: {
+      operationId: "signOut",
+      summary: "Sign out",
+      description: "Destroys the current session.",
+      tags: ["Auth"],
+      security: [{ bearerAuth: [] }],
+      responses: {
+        "200": { description: "Session destroyed" },
+        "404": errorResponse("Auth routes not enabled"),
+      },
+    },
+  },
+
+  // -------------------------------------------------------------------
+  // Widget — embeddable chat widget (static assets)
+  // -------------------------------------------------------------------
+  "/widget": {
+    get: {
+      operationId: "widgetHost",
+      summary: "Widget HTML host page",
+      description:
+        "Serves a self-contained HTML page for iframe embedding. Renders the AtlasChat component with configurable theme, API URL, position, branding, and initial query.",
+      tags: ["Widget"],
+      security: [],
+      parameters: [
+        { name: "theme", in: "query", required: false, schema: { type: "string", enum: ["light", "dark", "system"], default: "system" }, description: "Color theme." },
+        { name: "apiUrl", in: "query", required: false, schema: { type: "string" }, description: "Atlas API base URL (http/https only)." },
+        { name: "position", in: "query", required: false, schema: { type: "string", enum: ["bottomRight", "bottomLeft", "inline"], default: "inline" }, description: "Widget position." },
+        { name: "logo", in: "query", required: false, schema: { type: "string" }, description: "HTTPS URL to a custom logo image." },
+        { name: "accent", in: "query", required: false, schema: { type: "string" }, description: "Hex color without # (e.g. '4f46e5')." },
+        { name: "welcome", in: "query", required: false, schema: { type: "string" }, description: "Welcome message (max 500 chars)." },
+        { name: "initialQuery", in: "query", required: false, schema: { type: "string" }, description: "Auto-send query on first open (max 500 chars)." },
+      ],
+      responses: {
+        "200": { description: "Widget HTML page", content: { "text/html": { schema: { type: "string" } } } },
+        "503": { description: "Widget bundle not built", content: { "text/html": { schema: { type: "string" } } } },
+      },
+    },
+  },
+
+  "/widget/atlas-widget.js": {
+    get: {
+      operationId: "widgetJS",
+      summary: "Widget JavaScript bundle",
+      description: "Self-contained ESM bundle (React + AtlasChat). Cached for 24 hours.",
+      tags: ["Widget"],
+      security: [],
+      responses: {
+        "200": { description: "Widget JS bundle", content: { "application/javascript": { schema: { type: "string" } } } },
+        "404": { description: "Widget JS not built", content: { "text/plain": { schema: { type: "string" } } } },
+      },
+    },
+  },
+
+  "/widget/atlas-widget.css": {
+    get: {
+      operationId: "widgetCSS",
+      summary: "Widget CSS stylesheet",
+      description: "Pre-compiled Tailwind CSS for widget components. Cached for 24 hours.",
+      tags: ["Widget"],
+      security: [],
+      responses: {
+        "200": { description: "Widget CSS", content: { "text/css": { schema: { type: "string" } } } },
+        "404": { description: "Widget CSS not built", content: { "text/plain": { schema: { type: "string" } } } },
+      },
+    },
+  },
+
+  "/widget.js": {
+    get: {
+      operationId: "widgetLoader",
+      summary: "Widget script tag loader",
+      description:
+        "Returns a self-contained IIFE script that injects a floating chat bubble and iframe overlay into any host page. " +
+        "Reads data-* attributes from its own `<script>` tag for configuration. Exposes window.Atlas programmatic API.",
+      tags: ["Widget"],
+      security: [],
+      responses: {
+        "200": { description: "Widget loader script (IIFE)", content: { "application/javascript": { schema: { type: "string" } } } },
+      },
+    },
+  },
+
+  "/widget.d.ts": {
+    get: {
+      operationId: "widgetTypeDeclarations",
+      summary: "Widget TypeScript declarations",
+      description:
+        "Returns ambient TypeScript declarations for window.Atlas. Fallback for embedders who load only the script tag without installing @useatlas/react.",
+      tags: ["Widget"],
+      security: [],
+      responses: {
+        "200": { description: "TypeScript ambient declarations", content: { "text/plain": { schema: { type: "string" } } } },
+      },
+    },
+  },
+};
+
+/** Static tag definitions for auth and widget. */
+export const staticTags = [
+  { name: "Auth", description: "Authentication routes (managed auth via Better Auth)" },
+  { name: "Widget", description: "Embeddable chat widget (host page, loader script, assets)" },
+];
+
+/** Security scheme used across the API. */
+export const securitySchemes = {
+  bearerAuth: {
+    type: "http" as const,
+    scheme: "bearer",
+    description: "API key or JWT token. Pass via Authorization: Bearer <token>.",
+  },
+};


### PR DESCRIPTION
## Summary

Completes the OpenAPI auto-generation migration (#703). Replaces two separate endpoints with one merged spec.

**Before:** Two endpoints
- `/api/v1/openapi.json` — manual spec (auth + widget only, 284 lines)
- `/api/v1/openapi-auto.json` — auto-generated from OpenAPIHono routes

**After:** One endpoint
- `/api/v1/openapi.json` — merged spec (auto-generated + static auth/widget entries)

### Changes
- `openapi.ts`: converted from Hono route to pure data export (`staticPaths`, `staticTags`, `securitySchemes`)
- `index.ts`: merged endpoint via `app.getOpenAPI31Document()` + static path merge, cached on first request
- `extract-openapi.ts`: imports full app instead of just openapi route
- Test: verifies merged spec contains both auto-generated (`/api/v1/query`) and static (`/api/auth/sign-up/email`) paths

### Migration complete

**openapi.ts: 4,334 lines → 230 lines** (pure data, no route handler)

| Phase | PR |
|-------|-----|
| Phase 1 — foundation | #715 |
| Phase 2a — admin routes | #718 |
| Phase 2b — public routes | #721 |
| Cleanup — shared schemas | #722 |
| Phase 2c-i — conversations, billing, wizard | #725 |
| Phase 2c-ii — chat, demo, slack | #726 |
| **Phase 3 — switchover** | **This PR** |

## Test plan

- [ ] `bun run lint` — 0 errors
- [ ] `bun run type` — 0 errors
- [ ] `bun run test` — all pass (merged spec test verifies both auto + static paths)
- [ ] `GET /api/v1/openapi.json` returns merged spec with all routes
- [ ] `/api/v1/openapi-auto.json` no longer exists (404)