### PR TITLE
refactor: CLI atlas init uses shared profiler library

### DIFF
--- a/packages/api/src/lib/profiler.ts
+++ b/packages/api/src/lib/profiler.ts
@@ -1074,7 +1074,7 @@ export async function listPostgresObjects(connectionString: string, schema: stri
   }
 }
 
-export async function listMySQLObjects(connectionString: string, _log: ProfileLogger = defaultLog): Promise<DatabaseObject[]> {
+export async function listMySQLObjects(connectionString: string, log: ProfileLogger = defaultLog): Promise<DatabaseObject[]> {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const mysql = require("mysql2/promise");
   const pool = mysql.createPool({
@@ -1094,7 +1094,7 @@ export async function listMySQLObjects(connectionString: string, _log: ProfileLo
     }));
   } finally {
     await pool.end().catch((err: unknown) => {
-      _log.warn({ err: err instanceof Error ? err.message : String(err) }, "MySQL pool cleanup warning");
+      log.warn({ err: err instanceof Error ? err.message : String(err) }, "MySQL pool cleanup warning");
     });
   }
 }
@@ -1139,10 +1139,12 @@ async function queryForeignKeys(
     SELECT
       a.attname AS from_column,
       cl.relname AS to_table,
-      af.attname AS to_column
+      af.attname AS to_column,
+      ns.nspname AS to_schema
     FROM pg_constraint c
     JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY(c.conkey)
     JOIN pg_class cl ON cl.oid = c.confrelid
+    JOIN pg_namespace ns ON ns.oid = cl.relnamespace
     JOIN pg_attribute af ON af.attrelid = c.confrelid AND af.attnum = ANY(c.confkey)
     WHERE c.contype = 'f'
       AND c.conrelid = $1::regclass
@@ -1150,9 +1152,9 @@ async function queryForeignKeys(
     `,
     [pgTableRef(tableName, schema)]
   );
-  return result.rows.map((r: { from_column: string; to_table: string; to_column: string }) => ({
+  return result.rows.map((r: { from_column: string; to_table: string; to_column: string; to_schema: string }) => ({
     from_column: r.from_column,
-    to_table: r.to_table,
+    to_table: r.to_schema !== schema ? `${r.to_schema}.${r.to_table}` : r.to_table,
     to_column: r.to_column,
     source: "constraint" as const,
   }));
@@ -1404,7 +1406,10 @@ export async function profilePostgres(
     );
 
     for (const r of partResult.rows as { relname: string; strategy: string; partition_key: string }[]) {
-      if (r.strategy !== "range" && r.strategy !== "list" && r.strategy !== "hash") continue;
+      if (r.strategy !== "range" && r.strategy !== "list" && r.strategy !== "hash") {
+        log.warn({ table: r.relname, strategy: r.strategy }, "Unrecognized partition strategy — skipping");
+        continue;
+      }
       partitionMap.set(r.relname, { strategy: r.strategy, key: r.partition_key });
     }
   } catch (partErr) {

--- a/packages/cli/bin/atlas.ts
+++ b/packages/cli/bin/atlas.ts
@@ -36,7 +36,7 @@
  * tables and views are profiled automatically.
  *
  * Requires ATLAS_DATASOURCE_URL in environment.
- * Supports PostgreSQL (postgresql://...) and MySQL (mysql://...).
+ * Supports PostgreSQL, MySQL, ClickHouse, Snowflake, DuckDB, and Salesforce.
  */
 
 import { Pool } from "pg";
@@ -79,8 +79,14 @@ import {
 /** Adapts the profiler's structured logger to CLI console output. */
 const cliProfileLogger: ProfileLogger = {
   info(_obj, msg) { console.log(`  ${msg}`); },
-  warn(obj, msg) { console.warn(`  Warning: ${msg}${obj.err ? `: ${obj.err}` : ""}`); },
-  error(obj, msg) { console.error(`  ${msg}${obj.err ? `: ${obj.err}` : ""}`); },
+  warn(obj, msg) {
+    const ctx = [obj.table, obj.column].filter(Boolean).join(".");
+    console.warn(`  Warning: ${msg}${ctx ? ` (${ctx})` : ""}${obj.err ? `: ${obj.err}` : ""}`);
+  },
+  error(obj, msg) {
+    const ctx = [obj.table, obj.column].filter(Boolean).join(".");
+    console.error(`  ${msg}${ctx ? ` (${ctx})` : ""}${obj.err ? `: ${obj.err}` : ""}`);
+  },
 };
 
 // Re-export from shared profiler for test backward compatibility
@@ -134,7 +140,7 @@ async function loadDuckDB() {
 const SEMANTIC_DIR = path.resolve("semantic");
 const ENTITIES_DIR = path.join(SEMANTIC_DIR, "entities");
 
-/** Log a warning summary for profiling errors (first 5 + overflow). */
+/** Log a warning summary for profiling errors (first 5 + overflow). CLI-specific: uses console.warn formatting rather than the profiler's structured logger. */
 export function logProfilingErrors(errors: ProfileError[], total: number): void {
   const pct = Math.round((errors.length / total) * 100);
   console.warn(


### PR DESCRIPTION
## Summary
- Fixes #686 — CLI `atlas init` now imports from `@atlas/api/lib/profiler` instead of duplicating ~1,636 lines of profiling logic
- Adds `cliProfileLogger` adapter to translate structured profiler logs to CLI console output
- Re-exports profiler symbols for backward compatibility with existing CLI test files
- Keeps all CLI-specific code: progress bars (ora/clack), colored output (picocolors), interactive prompts, ClickHouse/Snowflake/DuckDB/Salesforce profilers, all handlers

## Test plan
- [x] `bun run atlas -- init --help` works
- [x] `bun run atlas -- diff --help` works
- [x] All CLI test files pass (profiler-heuristics, view-yaml-generation, failure-threshold, fatal-error-propagation)
- [x] `bun run test` — all tests pass
- [x] `bun run lint` — 0 errors (1 pre-existing warning in ee/)
- [x] `bun run type` — passes
- [x] `bun x syncpack lint` — no issues
- [x] Template drift check passes
- [x] No duplicate function definitions between CLI and profiler