### PR TITLE
docs: BYOT price removal, JIRA env vars, guided tour page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -184,6 +184,13 @@ ATLAS_SANDBOX_URL=http://localhost:8080
 # SLACK_CLIENT_ID=                    # Multi-workspace OAuth
 # SLACK_CLIENT_SECRET=                # Multi-workspace OAuth
 
+# === JIRA Integration (optional) ===
+# Requires ATLAS_ACTIONS_ENABLED=true
+# JIRA_BASE_URL=https://yourorg.atlassian.net   # Jira instance URL
+# JIRA_EMAIL=                                    # Jira account email for API auth
+# JIRA_API_TOKEN=                                # Jira API token (generate at id.atlassian.com)
+# JIRA_DEFAULT_PROJECT=                          # Default project key for issue creation (e.g. PROJ)
+
 # === Stripe Billing (SaaS only) ===
 # Enables Stripe billing when STRIPE_SECRET_KEY is set. Self-hosted deployments
 # skip this entirely — the self-hosted experience is the free tier.
@@ -191,7 +198,6 @@ ATLAS_SANDBOX_URL=http://localhost:8080
 # STRIPE_WEBHOOK_SECRET=whsec_...                  # Stripe webhook signing secret
 # STRIPE_TEAM_PRICE_ID=price_...                   # Stripe Price ID for Team plan (monthly)
 # STRIPE_TEAM_ANNUAL_PRICE_ID=price_...            # Stripe Price ID for Team plan (annual)
-# STRIPE_TEAM_BYOT_PRICE_ID=price_...              # Stripe Price ID for Team BYOT (monthly, bring-your-own LLM token)
 # STRIPE_ENTERPRISE_PRICE_ID=price_...             # Stripe Price ID for Enterprise plan
 
 # === Enterprise Features ===

--- a/apps/docs/content/docs/guides/billing-and-plans.mdx
+++ b/apps/docs/content/docs/guides/billing-and-plans.mdx
@@ -38,7 +38,7 @@ Atlas uses a tiered billing model. Self-hosted deployments are free with no enfo
 
 BYOT lets workspaces supply their own LLM API keys instead of using Atlas-provided tokens. When enabled:
 
-- The workspace is billed at a lower Stripe price (configured via `STRIPE_TEAM_BYOT_PRICE_ID`)
+- The workspace is billed at a lower rate on the Team plan (BYOT is a configuration flag, not a separate Stripe product)
 - Token usage is still metered for analytics, but token limits are not enforced
 - Admin or owner role is required to toggle BYOT
 
@@ -63,7 +63,6 @@ Set these environment variables to enable billing:
 | `STRIPE_WEBHOOK_SECRET` | Stripe webhook signing secret for verifying events |
 | `STRIPE_TEAM_PRICE_ID` | Price ID for the Team plan (monthly) |
 | `STRIPE_TEAM_ANNUAL_PRICE_ID` | Price ID for the Team plan (annual discount) |
-| `STRIPE_TEAM_BYOT_PRICE_ID` | Price ID for Team BYOT (lower price, customer supplies LLM keys) |
 | `STRIPE_ENTERPRISE_PRICE_ID` | Price ID for the Enterprise plan |
 
 When `STRIPE_SECRET_KEY` is set:

--- a/apps/docs/content/docs/guides/guided-tour.mdx
+++ b/apps/docs/content/docs/guides/guided-tour.mdx
@@ -1,0 +1,102 @@
+---
+title: Guided Tour
+description: In-app walkthrough that introduces new users to chat, notebook, admin, and semantic layer features.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+The guided tour is an interactive overlay that walks new users through Atlas's key features. It highlights four areas of the interface — chat, notebook, admin console, and semantic layer — with tooltips explaining each one.
+
+---
+
+## How It Works
+
+The tour auto-starts the first time a user visits Atlas. Returning users who have already completed (or skipped) the tour are not shown it again.
+
+Completion state is tracked in two layers:
+
+1. **Local storage** (`atlas-tour-completed`) — checked first for instant decisions without a network round-trip
+2. **Server-side** (`user_onboarding` table) — persists across browsers and devices when managed auth is enabled
+
+If the server is unreachable, the tour falls back to local storage only.
+
+---
+
+## Tour Steps
+
+| Step | Title | Description |
+|------|-------|-------------|
+| 1 | Chat with your data | Ask questions in natural language. Atlas translates them to SQL and returns results |
+| 2 | Notebook | Build multi-step analyses with cells you can re-run, reorder, and export |
+| 3 | Admin console | Manage connections, users, roles, and monitor usage (**admin-only** — skipped for non-admin users) |
+| 4 | Semantic layer | Entity definitions, metrics, and glossary terms that help Atlas understand your data |
+
+Non-admin users see 3 steps (the admin console step is filtered out automatically).
+
+---
+
+## Keyboard Navigation
+
+| Key | Action |
+|-----|--------|
+| `→` (Arrow Right) | Next step |
+| `←` (Arrow Left) | Previous step |
+| `Escape` | Skip and dismiss the tour |
+
+Each step also has clickable **Back**, **Next** (or **Done** on the last step), and **Skip** buttons.
+
+---
+
+## Replaying the Tour
+
+To re-trigger the tour after completing it, open the **help menu** (the `?` icon in the top navigation bar) and click **Replay guided tour**. This clears the completion state and restarts from step 1.
+
+---
+
+## API Endpoints
+
+Three endpoints under `/api/v1/onboarding` provide programmatic control over tour state. All require managed auth (`ATLAS_AUTH_MODE=managed`) and an authenticated session.
+
+### GET `/api/v1/onboarding/tour-status`
+
+Check whether the current user has completed the tour.
+
+```json
+{
+  "tourCompleted": false,
+  "tourCompletedAt": null
+}
+```
+
+### POST `/api/v1/onboarding/tour-complete`
+
+Mark the tour as completed. Idempotent — safe to call multiple times.
+
+```json
+{
+  "tourCompleted": true,
+  "tourCompletedAt": "2026-03-22T12:00:00.000Z"
+}
+```
+
+### POST `/api/v1/onboarding/tour-reset`
+
+Clear the completion flag so the tour can be replayed.
+
+```json
+{
+  "tourCompleted": false,
+  "tourCompletedAt": null
+}
+```
+
+<Callout type="info">
+These endpoints return `404` when managed auth is not configured or when no internal database is available. The frontend gracefully falls back to local storage in this case.
+</Callout>
+
+---
+
+## See Also
+
+- [Admin Console](/guides/admin-console) — The admin step highlighted during the tour
+- [Notebook View](/guides/notebook) — Cell-based analysis interface

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -14,6 +14,7 @@
     "signup",
     "semantic-layer-wizard",
     "demo-mode",
+    "guided-tour",
     "enterprise-sso",
     "ip-allowlisting",
     "custom-roles",

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -511,6 +511,27 @@ See [Slack guide](/guides/slack) for the full setup.
 
 ---
 
+## JIRA Integration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `JIRA_BASE_URL` | — | Jira instance URL (e.g. `https://yourorg.atlassian.net`) |
+| `JIRA_EMAIL` | — | Jira account email for API authentication |
+| `JIRA_API_TOKEN` | — | Jira API token. Generate at [id.atlassian.com](https://id.atlassian.com/manage-profile/security/api-tokens) |
+| `JIRA_DEFAULT_PROJECT` | — | Default project key for issue creation (e.g. `PROJ`). Can be overridden per-action |
+
+Requires the [action framework](/guides/actions) to be enabled (`ATLAS_ACTIONS_ENABLED=true`).
+
+```bash
+# JIRA integration for the createJiraTicket action
+JIRA_BASE_URL=https://yourorg.atlassian.net
+JIRA_EMAIL=you@example.com
+JIRA_API_TOKEN=your-api-token
+JIRA_DEFAULT_PROJECT=PROJ
+```
+
+---
+
 ## Stripe Billing
 
 Stripe billing integration for SaaS deployments. Self-hosted deployments do not need these — the self-hosted experience has no billing or usage limits.
@@ -521,7 +542,6 @@ Stripe billing integration for SaaS deployments. Self-hosted deployments do not 
 | `STRIPE_WEBHOOK_SECRET` | — | Stripe webhook signing secret for verifying webhook events |
 | `STRIPE_TEAM_PRICE_ID` | — | Stripe Price ID for the Team plan (monthly) |
 | `STRIPE_TEAM_ANNUAL_PRICE_ID` | — | Stripe Price ID for the Team plan (annual discount) |
-| `STRIPE_TEAM_BYOT_PRICE_ID` | — | Stripe Price ID for Team BYOT (Bring Your Own Token — lower price, customer supplies LLM keys) |
 | `STRIPE_ENTERPRISE_PRICE_ID` | — | Stripe Price ID for the Enterprise plan |
 
 When `STRIPE_SECRET_KEY` is set, billing routes are mounted at `/api/v1/billing` and the Better Auth Stripe plugin handles checkout, webhooks, and subscription lifecycle at `/api/auth/stripe/*`.


### PR DESCRIPTION
## Summary

- **#748**: Remove `STRIPE_TEAM_BYOT_PRICE_ID` from environment-variables.mdx, billing-and-plans.mdx, and .env.example — BYOT is a configuration flag on the Team plan, not a separate Stripe product
- **#749**: Add `JIRA_BASE_URL`, `JIRA_EMAIL`, `JIRA_API_TOKEN`, `JIRA_DEFAULT_PROJECT` to environment-variables.mdx and .env.example with setup instructions
- **#750**: Create `guided-tour.mdx` covering tour steps, keyboard navigation, API endpoints, auto-start behavior, and help menu replay. Added to guides nav

## Test plan
- [ ] `bun run lint` — passes
- [ ] `bun run type` — passes
- [ ] Docs site builds without errors
- [ ] Guided tour page renders correctly in Fumadocs
- [ ] JIRA section appears in environment variables reference
- [ ] BYOT references no longer mention `STRIPE_TEAM_BYOT_PRICE_ID`

Closes #748
Closes #749
Closes #750