### PR TITLE
feat: abuse prevention and auto-suspend (#668)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,11 @@ ATLAS_ADMIN_EMAIL=admin@atlas.dev
 # ATLAS_API_KEY_ROLE=analyst              # Role for simple-key auth (viewer/analyst/admin)
 # ATLAS_RATE_LIMIT_RPM=30                 # Max requests per minute per user (0 = disabled)
 # ATLAS_TRUST_PROXY=false                 # Trust X-Forwarded-For for client IP (set "true" behind a reverse proxy)
+# ATLAS_ABUSE_QUERY_RATE=200              # Max queries per workspace per sliding window (abuse prevention)
+# ATLAS_ABUSE_WINDOW_SECONDS=300          # Sliding window duration in seconds
+# ATLAS_ABUSE_ERROR_RATE=0.5              # Max error rate (0-1) before escalation
+# ATLAS_ABUSE_UNIQUE_TABLES=50            # Max unique tables accessed per window
+# ATLAS_ABUSE_THROTTLE_DELAY_MS=2000      # Delay injected for throttled workspaces (ms)
 # ATLAS_SESSION_IDLE_TIMEOUT=0            # Seconds of inactivity before session invalidation (0 = disabled)
 # ATLAS_SESSION_ABSOLUTE_TIMEOUT=0        # Max session lifetime in seconds (0 = disabled)
 # ATLAS_SEMANTIC_ROOT=                    # Dev/test override for semantic layer directory (production: use atlas.config.ts semanticLayer)

--- a/apps/docs/content/docs/guides/abuse-prevention.mdx
+++ b/apps/docs/content/docs/guides/abuse-prevention.mdx
@@ -1,0 +1,102 @@
+---
+title: Abuse Prevention
+description: Configure anomaly detection, graduated response, and auto-suspend for abusive query patterns.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+Atlas includes built-in abuse prevention that detects anomalous query patterns per workspace and applies a graduated response: **warn**, **throttle**, then **suspend**. This protects your analytics datasource from runaway queries, credential stuffing, and resource exhaustion.
+
+<Callout title="Prerequisites">
+- Atlas server running with `DATABASE_URL` configured (internal DB required for persistence)
+- Admin access for the admin console abuse management page
+</Callout>
+
+## How It Works
+
+Atlas monitors three anomaly signals per workspace using sliding window counters:
+
+| Signal | Default Threshold | Description |
+|--------|------------------|-------------|
+| **Query rate** | 200 queries / 5 min | Excessive request volume |
+| **Error rate** | 50% | High ratio of failed queries |
+| **Unique tables** | 50 tables / window | Unusual breadth of table access |
+
+When a threshold is exceeded, the workspace escalates through three levels:
+
+1. **Warning** — Event logged, visible in admin console. No user impact.
+2. **Throttled** — Configurable delay (default 2s) injected before each request. Users experience slower responses.
+3. **Suspended** — All requests blocked with `403 workspace_suspended`. Requires admin reinstatement.
+
+Each additional threshold breach while already flagged escalates to the next level.
+
+## Configuration
+
+All thresholds are configurable via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ATLAS_ABUSE_QUERY_RATE` | `200` | Max queries per workspace per sliding window |
+| `ATLAS_ABUSE_WINDOW_SECONDS` | `300` | Sliding window duration in seconds |
+| `ATLAS_ABUSE_ERROR_RATE` | `0.5` | Max error rate (0–1) before escalation |
+| `ATLAS_ABUSE_UNIQUE_TABLES` | `50` | Max unique tables accessed per window |
+| `ATLAS_ABUSE_THROTTLE_DELAY_MS` | `2000` | Delay injected for throttled workspaces (ms) |
+
+## Admin Console
+
+The **Abuse Prevention** page in the admin console (`/admin/abuse`) shows:
+
+- **Detection Thresholds** — Current configuration values
+- **Flagged Workspaces** — Table of workspaces with active flags (warning, throttled, or suspended)
+- **Reinstate** — Button to clear abuse flags and restore normal access
+
+### Reinstatement
+
+When you reinstate a workspace:
+- All abuse counters are reset to zero
+- The workspace immediately returns to normal operation
+- If the abusive pattern continues, the workspace will be flagged again
+
+## Audit Trail
+
+All abuse events are recorded in the audit trail:
+- Level changes (warn, throttle, suspend)
+- Manual reinstatements (includes the admin who performed the action)
+- Metadata includes query count, error count, unique tables, and escalation count
+
+Events are persisted to the `abuse_events` table in the internal database and are accessible via the admin API.
+
+## API Reference
+
+### List flagged workspaces
+
+```
+GET /api/v1/admin/abuse
+```
+
+Returns all workspaces with active abuse flags, including recent events.
+
+### Reinstate a workspace
+
+```
+POST /api/v1/admin/abuse/:workspaceId/reinstate
+```
+
+Clears abuse flags and restores normal access for the specified workspace.
+
+### Get threshold configuration
+
+```
+GET /api/v1/admin/abuse/config
+```
+
+Returns the current abuse detection threshold configuration.
+
+## Relationship to Rate Limiting
+
+Abuse prevention is separate from [rate limiting](/docs/guides/rate-limiting):
+
+- **Rate limiting** (ATLAS_RATE_LIMIT_RPM) is per-user, per-minute, and returns 429 immediately
+- **Abuse prevention** is per-workspace, uses a longer sliding window, and applies graduated response
+
+Both can be active simultaneously. Rate limiting catches individual users making too many requests; abuse prevention catches workspace-level patterns that may involve multiple users or automated access.

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -293,6 +293,25 @@ ATLAS_TRUST_PROXY=true
 
 See [Rate Limiting & Retry](/guides/rate-limiting) for client-side handling, SDK retry patterns, and troubleshooting.
 
+### Abuse Prevention
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ATLAS_ABUSE_QUERY_RATE` | `200` | Max queries per workspace per sliding window |
+| `ATLAS_ABUSE_WINDOW_SECONDS` | `300` | Sliding window duration in seconds |
+| `ATLAS_ABUSE_ERROR_RATE` | `0.5` | Max error rate (0–1) before escalation |
+| `ATLAS_ABUSE_UNIQUE_TABLES` | `50` | Max unique tables accessed per window |
+| `ATLAS_ABUSE_THROTTLE_DELAY_MS` | `2000` | Delay injected for throttled workspaces (ms) |
+
+```bash
+# Stricter abuse detection for production
+ATLAS_ABUSE_QUERY_RATE=100
+ATLAS_ABUSE_ERROR_RATE=0.3
+ATLAS_ABUSE_THROTTLE_DELAY_MS=5000
+```
+
+See [Abuse Prevention](/guides/abuse-prevention) for details on graduated response and admin reinstatement.
+
 ### Session Timeouts
 
 | Variable | Default | Description |

--- a/apps/docs/content/docs/roadmap.mdx
+++ b/apps/docs/content/docs/roadmap.mdx
@@ -104,7 +104,7 @@ The current milestone. Platform foundation for hosted Atlas at app.useatlas.dev.
 - **Compliance** — Audit log retention with auto-purge and compliance export (shipped), approval workflows for sensitive queries with admin approve/deny UI (shipped), PII detection and column masking with role-based rules and admin UI (shipped), compliance reporting (shipped)
 - **Branding** — White-labeling with custom logo, colors, favicon, and conditional Atlas branding (shipped)
 - **Integrations** — Chat SDK bridge plugin with persistent state adapters (PG, memory) for unified chat platform interactions (shipped), Slack migration to Chat SDK adapter (shipped)
-- **Platform ops** — SLA monitoring, abuse prevention, platform admin console (shipped), backups
+- **Platform ops** — SLA monitoring, abuse prevention (shipped), platform admin console (shipped), backups
 - **Onboarding** — Interactive demo mode (shipped), in-app guided tour (shipped), email sequence (shipped)
 
 ### 0.9.1 — Docs & Polish

--- a/packages/api/src/api/__tests__/admin-abuse.test.ts
+++ b/packages/api/src/api/__tests__/admin-abuse.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Tests for admin abuse prevention API endpoints.
+ *
+ * Covers: GET /admin/abuse, POST /admin/abuse/:id/reinstate, GET /admin/abuse/config.
+ */
+
+import { createConnectionMock } from "@atlas/api/testing/connection";
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  mock,
+  type Mock,
+} from "bun:test";
+
+// --- Mocks (before any import that touches the modules) ---
+
+const mockAuthenticateRequest: Mock<(req: Request) => Promise<unknown>> = mock(
+  () =>
+    Promise.resolve({
+      authenticated: true,
+      mode: "simple-key",
+      user: { id: "admin-1", mode: "simple-key", label: "Admin", role: "admin", activeOrganizationId: "org-1" },
+    }),
+);
+
+mock.module("@atlas/api/lib/auth/middleware", () => ({
+  authenticateRequest: mockAuthenticateRequest,
+  checkRateLimit: mock(() => ({ allowed: true })),
+  getClientIP: mock(() => null),
+  resetRateLimits: mock(() => {}),
+  _stopCleanup: mock(() => {}),
+  _setValidatorOverrides: mock(() => {}),
+}));
+
+mock.module("@atlas/api/lib/auth/detect", () => ({
+  detectAuthMode: () => "simple-key",
+  resetAuthModeCache: () => {},
+}));
+
+mock.module("@atlas/api/lib/startup", () => ({
+  validateEnvironment: mock(() => Promise.resolve([])),
+  getStartupWarnings: mock(() => []),
+}));
+
+mock.module("@atlas/api/lib/db/connection", () => createConnectionMock());
+
+// --- Abuse mock ---
+
+const mockListFlagged: Mock<() => unknown[]> = mock(() => []);
+const mockReinstateWorkspace: Mock<(wsId: string, actorId: string) => boolean> = mock(() => true);
+const mockGetAbuseEvents: Mock<(wsId: string, limit?: number) => Promise<unknown[]>> = mock(async () => []);
+const mockGetAbuseConfig: Mock<() => unknown> = mock(() => ({
+  queryRateLimit: 200,
+  queryRateWindowSeconds: 300,
+  errorRateThreshold: 0.5,
+  uniqueTablesLimit: 50,
+  throttleDelayMs: 2000,
+}));
+
+mock.module("@atlas/api/lib/security/abuse", () => ({
+  listFlaggedWorkspaces: mockListFlagged,
+  reinstateWorkspace: mockReinstateWorkspace,
+  getAbuseEvents: mockGetAbuseEvents,
+  getAbuseConfig: mockGetAbuseConfig,
+  checkAbuseStatus: mock(() => ({ level: "none" })),
+  recordQueryEvent: mock(() => {}),
+  restoreAbuseState: mock(async () => {}),
+  _resetAbuseState: mock(() => {}),
+  _stopCleanup: mock(() => {}),
+}));
+
+// --- Internal DB mock ---
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => true,
+  internalQuery: mock(() => Promise.resolve([])),
+  internalExecute: mock(() => {}),
+  getInternalDB: mock(() => ({})),
+  closeInternalDB: mock(() => Promise.resolve()),
+  migrateInternalDB: mock(() => Promise.resolve()),
+  loadSavedConnections: mock(() => Promise.resolve(0)),
+  _resetPool: mock(() => {}),
+  _resetCircuitBreaker: mock(() => {}),
+  encryptUrl: (url: string) => url,
+  decryptUrl: (url: string) => url,
+  getEncryptionKey: () => null,
+  isPlaintextUrl: (value: string) => /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(value),
+  _resetEncryptionKeyCache: mock(() => {}),
+  findPatternBySQL: async () => null,
+  insertLearnedPattern: () => {},
+  incrementPatternCount: () => {},
+  getApprovedPatterns: mock(async () => []),
+  upsertSuggestion: mock(() => Promise.resolve("created")),
+  getSuggestionsByTables: mock(() => Promise.resolve([])),
+  getPopularSuggestions: mock(() => Promise.resolve([])),
+  incrementSuggestionClick: mock(),
+  deleteSuggestion: mock(() => Promise.resolve(false)),
+  getAuditLogQueries: mock(() => Promise.resolve([])),
+  getWorkspaceStatus: mock(() => Promise.resolve(null)),
+  getWorkspaceDetails: mock(() => Promise.resolve(null)),
+  updateWorkspaceStatus: mock(() => Promise.resolve(false)),
+  updateWorkspacePlanTier: mock(() => Promise.resolve(false)),
+  cascadeWorkspaceDelete: mock(() => Promise.resolve({})),
+  getWorkspaceHealthSummary: mock(() => Promise.resolve(null)),
+}));
+
+mock.module("@atlas/api/lib/learn/pattern-cache", () => ({
+  buildLearnedPatternsSection: async () => "",
+  getRelevantPatterns: async () => [],
+  invalidatePatternCache: () => {},
+  extractKeywords: () => new Set(),
+  _resetPatternCache: () => {},
+}));
+
+mock.module("@atlas/api/lib/semantic", () => ({
+  getOrgWhitelistedTables: () => new Set(),
+  loadOrgWhitelist: async () => new Map(),
+  invalidateOrgWhitelist: () => {},
+  getOrgSemanticIndex: async () => "",
+  invalidateOrgSemanticIndex: () => {},
+  _resetOrgWhitelists: () => {},
+  _resetOrgSemanticIndexes: () => {},
+  getWhitelistedTables: () => new Set(),
+  getCrossSourceJoins: () => [],
+  _resetWhitelists: () => {},
+  registerPluginEntities: () => {},
+  _resetPluginEntities: () => {},
+}));
+
+mock.module("@atlas/api/lib/db/semantic-entities", () => ({
+  listEntities: mock(() => Promise.resolve([])),
+  getEntity: mock(() => Promise.resolve(null)),
+  upsertEntity: mock(() => Promise.resolve()),
+  deleteEntity: mock(() => Promise.resolve(false)),
+  countEntities: mock(() => Promise.resolve(0)),
+  bulkUpsertEntities: mock(() => Promise.resolve(0)),
+}));
+
+mock.module("@atlas/api/lib/plugins/registry", () => ({
+  plugins: {
+    describe: () => [],
+    get: () => undefined,
+    getStatus: () => undefined,
+    getAllHealthy: () => [],
+    getByType: () => [],
+    size: 0,
+  },
+  PluginRegistry: class {},
+}));
+
+mock.module("@atlas/api/lib/tools/explore", () => ({
+  getExploreBackendType: () => "just-bash",
+  getActiveSandboxPluginId: () => null,
+  explore: { type: "function" },
+}));
+
+mock.module("@atlas/api/lib/agent", () => ({
+  runAgent: mock(() => Promise.resolve({ text: "answer" })),
+}));
+
+mock.module("@atlas/api/lib/tools/actions", () => ({}));
+
+mock.module("@atlas/api/lib/security", () => ({
+  maskConnectionUrl: (_url: string) => "***masked***",
+  SENSITIVE_PATTERNS: [],
+}));
+
+mock.module("@atlas/api/lib/settings", () => ({
+  getSettingsForAdmin: mock(() => []),
+  getSettingsRegistry: mock(() => []),
+  setSetting: mock(async () => {}),
+  deleteSetting: mock(async () => {}),
+  getSetting: mock(() => undefined),
+  loadSettings: mock(async () => 0),
+  getAllSettingOverrides: mock(async () => []),
+  _resetSettingsCache: mock(() => {}),
+}));
+
+mock.module("@atlas/api/lib/plugins/settings", () => ({
+  savePluginEnabled: mock(async () => {}),
+  savePluginConfig: mock(async () => {}),
+  getPluginConfig: mock(async () => null),
+}));
+
+mock.module("@atlas/api/lib/semantic-diff", () => ({
+  runDiff: mock(async () => ({ connection: "default", newTables: [], removedTables: [], tableDiffs: [] })),
+}));
+
+// --- Import app after mocks ---
+
+const { app } = await import("../index");
+
+// --- Helper ---
+
+function adminRequest(method: string, path: string, body?: unknown): Request {
+  const opts: RequestInit = {
+    method,
+    headers: { "Content-Type": "application/json", "x-api-key": "test-key" },
+  };
+  if (body) opts.body = JSON.stringify(body);
+  return new Request(`http://localhost${path}`, opts);
+}
+
+// --- Tests ---
+
+describe("Admin Abuse API", () => {
+  beforeEach(() => {
+    mockAuthenticateRequest.mockImplementation(() =>
+      Promise.resolve({
+        authenticated: true,
+        mode: "simple-key",
+        user: { id: "admin-1", mode: "simple-key", label: "Admin", role: "admin", activeOrganizationId: "org-1" },
+      }),
+    );
+    mockListFlagged.mockImplementation(() => []);
+    mockReinstateWorkspace.mockImplementation(() => true);
+    mockGetAbuseEvents.mockImplementation(async () => []);
+  });
+
+  // --- GET /api/v1/admin/abuse ---
+
+  describe("GET /api/v1/admin/abuse", () => {
+    it("returns empty list when no workspaces flagged", async () => {
+      const res = await app.fetch(adminRequest("GET", "/api/v1/admin/abuse"));
+      expect(res.status).toBe(200);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body.workspaces).toEqual([]);
+      expect(body.total).toBe(0);
+    });
+
+    it("returns flagged workspaces", async () => {
+      mockListFlagged.mockImplementation(() => [
+        {
+          workspaceId: "org-1",
+          workspaceName: null,
+          level: "warning",
+          trigger: "query_rate",
+          message: "Excessive queries",
+          updatedAt: "2026-03-23T00:00:00.000Z",
+          events: [],
+        },
+      ]);
+      const res = await app.fetch(adminRequest("GET", "/api/v1/admin/abuse"));
+      expect(res.status).toBe(200);
+      const body = await res.json() as Record<string, unknown>;
+      expect((body.workspaces as unknown[]).length).toBe(1);
+      expect(body.total).toBe(1);
+    });
+
+    it("returns 403 for non-admin", async () => {
+      mockAuthenticateRequest.mockImplementation(() =>
+        Promise.resolve({
+          authenticated: true,
+          mode: "simple-key",
+          user: { id: "user-1", mode: "simple-key", label: "User", role: "member", activeOrganizationId: "org-1" },
+        }),
+      );
+      const res = await app.fetch(adminRequest("GET", "/api/v1/admin/abuse"));
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // --- POST /api/v1/admin/abuse/:id/reinstate ---
+
+  describe("POST /api/v1/admin/abuse/:id/reinstate", () => {
+    it("reinstates a flagged workspace", async () => {
+      const res = await app.fetch(
+        adminRequest("POST", "/api/v1/admin/abuse/org-1/reinstate"),
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body.success).toBe(true);
+      expect(body.workspaceId).toBe("org-1");
+    });
+
+    it("returns 400 when workspace not flagged", async () => {
+      mockReinstateWorkspace.mockImplementation(() => false);
+      const res = await app.fetch(
+        adminRequest("POST", "/api/v1/admin/abuse/org-clean/reinstate"),
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 403 for non-admin", async () => {
+      mockAuthenticateRequest.mockImplementation(() =>
+        Promise.resolve({
+          authenticated: true,
+          mode: "simple-key",
+          user: { id: "user-1", mode: "simple-key", label: "User", role: "member", activeOrganizationId: "org-1" },
+        }),
+      );
+      const res = await app.fetch(
+        adminRequest("POST", "/api/v1/admin/abuse/org-1/reinstate"),
+      );
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // --- GET /api/v1/admin/abuse/config ---
+
+  describe("GET /api/v1/admin/abuse/config", () => {
+    it("returns current threshold configuration", async () => {
+      const res = await app.fetch(adminRequest("GET", "/api/v1/admin/abuse/config"));
+      expect(res.status).toBe(200);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body.queryRateLimit).toBe(200);
+      expect(body.queryRateWindowSeconds).toBe(300);
+      expect(body.errorRateThreshold).toBe(0.5);
+      expect(body.uniqueTablesLimit).toBe(50);
+      expect(body.throttleDelayMs).toBe(2000);
+    });
+
+    it("returns 403 for non-admin", async () => {
+      mockAuthenticateRequest.mockImplementation(() =>
+        Promise.resolve({
+          authenticated: true,
+          mode: "simple-key",
+          user: { id: "user-1", mode: "simple-key", label: "User", role: "member", activeOrganizationId: "org-1" },
+        }),
+      );
+      const res = await app.fetch(adminRequest("GET", "/api/v1/admin/abuse/config"));
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/packages/api/src/api/routes/admin-abuse.ts
+++ b/packages/api/src/api/routes/admin-abuse.ts
@@ -1,0 +1,263 @@
+/**
+ * Admin abuse prevention routes.
+ *
+ * Mounted under /api/v1/admin/abuse. All routes require admin role.
+ * Provides listing of flagged workspaces, reinstatement, and threshold config.
+ */
+
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { validationHook } from "./validation-hook";
+import { createLogger, withRequestContext } from "@atlas/api/lib/logger";
+import {
+  listFlaggedWorkspaces,
+  reinstateWorkspace,
+  getAbuseEvents,
+  getAbuseConfig,
+} from "@atlas/api/lib/security/abuse";
+import { adminAuthPreamble } from "./admin-auth";
+import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
+
+const log = createLogger("admin-abuse");
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+const AbuseEventSchema = z.object({
+  id: z.string(),
+  workspaceId: z.string(),
+  level: z.enum(["none", "warning", "throttled", "suspended"]),
+  trigger: z.enum(["query_rate", "error_rate", "unique_tables", "manual"]),
+  message: z.string(),
+  metadata: z.record(z.string(), z.unknown()),
+  createdAt: z.string(),
+  actor: z.string(),
+});
+
+const AbuseStatusSchema = z.object({
+  workspaceId: z.string(),
+  workspaceName: z.string().nullable(),
+  level: z.enum(["none", "warning", "throttled", "suspended"]),
+  trigger: z.enum(["query_rate", "error_rate", "unique_tables", "manual"]).nullable(),
+  message: z.string().nullable(),
+  updatedAt: z.string(),
+  events: z.array(AbuseEventSchema),
+});
+
+const ListResponseSchema = z.object({
+  workspaces: z.array(AbuseStatusSchema),
+  total: z.number(),
+});
+
+const ReinstateResponseSchema = z.object({
+  success: z.boolean(),
+  workspaceId: z.string(),
+  message: z.string(),
+});
+
+const ConfigResponseSchema = z.object({
+  queryRateLimit: z.number(),
+  queryRateWindowSeconds: z.number(),
+  errorRateThreshold: z.number(),
+  uniqueTablesLimit: z.number(),
+  throttleDelayMs: z.number(),
+});
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+const listFlaggedRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["Admin — Abuse Prevention"],
+  summary: "List flagged workspaces",
+  description: "Returns all workspaces with active abuse flags (warning, throttled, or suspended).",
+  responses: {
+    200: {
+      description: "Flagged workspaces",
+      content: { "application/json": { schema: ListResponseSchema } },
+    },
+    401: {
+      description: "Authentication required",
+      content: { "application/json": { schema: AuthErrorSchema } },
+    },
+    403: {
+      description: "Forbidden — admin role required",
+      content: { "application/json": { schema: AuthErrorSchema } },
+    },
+    429: {
+      description: "Rate limit exceeded",
+      content: { "application/json": { schema: AuthErrorSchema } },
+    },
+    500: {
+      description: "Internal server error",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const reinstateRoute = createRoute({
+  method: "post",
+  path: "/:workspaceId/reinstate",
+  tags: ["Admin — Abuse Prevention"],
+  summary: "Reinstate a suspended workspace",
+  description: "Manually re-enable a workspace that was suspended or throttled due to abuse detection.",
+  request: {
+    params: z.object({
+      workspaceId: z.string(),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Workspace reinstated",
+      content: { "application/json": { schema: ReinstateResponseSchema } },
+    },
+    400: {
+      description: "Workspace not flagged",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    401: {
+      description: "Authentication required",
+      content: { "application/json": { schema: AuthErrorSchema } },
+    },
+    403: {
+      description: "Forbidden — admin role required",
+      content: { "application/json": { schema: AuthErrorSchema } },
+    },
+    429: {
+      description: "Rate limit exceeded",
+      content: { "application/json": { schema: AuthErrorSchema } },
+    },
+    500: {
+      description: "Internal server error",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const getConfigRoute = createRoute({
+  method: "get",
+  path: "/config",
+  tags: ["Admin — Abuse Prevention"],
+  summary: "Current abuse threshold configuration",
+  description: "Returns the current abuse detection thresholds (from env vars or defaults).",
+  responses: {
+    200: {
+      description: "Threshold configuration",
+      content: { "application/json": { schema: ConfigResponseSchema } },
+    },
+    401: {
+      description: "Authentication required",
+      content: { "application/json": { schema: AuthErrorSchema } },
+    },
+    403: {
+      description: "Forbidden — admin role required",
+      content: { "application/json": { schema: AuthErrorSchema } },
+    },
+    429: {
+      description: "Rate limit exceeded",
+      content: { "application/json": { schema: AuthErrorSchema } },
+    },
+    500: {
+      description: "Internal server error",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+const adminAbuse = new OpenAPIHono({ defaultHook: validationHook });
+
+// GET / — list flagged workspaces
+adminAbuse.openapi(listFlaggedRoute, async (c) => {
+  const req = c.req.raw;
+  const requestId = crypto.randomUUID();
+
+  const preamble = await adminAuthPreamble(req, requestId);
+  if ("error" in preamble) {
+    return c.json(preamble.error, preamble.status, preamble.headers) as never;
+  }
+  const { authResult } = preamble;
+
+  return withRequestContext({ requestId, user: authResult.user }, async () => {
+    try {
+      const workspaces = listFlaggedWorkspaces();
+
+      // Enrich with recent events from DB
+      const enriched = await Promise.all(
+        workspaces.map(async (ws) => {
+          const events = await getAbuseEvents(ws.workspaceId, 10);
+          return { ...ws, events };
+        }),
+      );
+
+      return c.json({ workspaces: enriched, total: enriched.length }, 200);
+    } catch (err) {
+      log.error({ err: err instanceof Error ? err : new Error(String(err)), requestId }, "Failed to list flagged workspaces");
+      return c.json({ error: "internal_error", message: "Failed to list flagged workspaces.", requestId }, 500);
+    }
+  });
+});
+
+// POST /:workspaceId/reinstate — reinstate a workspace
+adminAbuse.openapi(reinstateRoute, async (c) => {
+  const req = c.req.raw;
+  const requestId = crypto.randomUUID();
+
+  const preamble = await adminAuthPreamble(req, requestId);
+  if ("error" in preamble) {
+    return c.json(preamble.error, preamble.status, preamble.headers) as never;
+  }
+  const { authResult } = preamble;
+
+  return withRequestContext({ requestId, user: authResult.user }, async () => {
+    const { workspaceId } = c.req.valid("param");
+    const actorId = authResult.user?.id ?? "unknown";
+
+    try {
+      const success = reinstateWorkspace(workspaceId, actorId);
+      if (!success) {
+        return c.json(
+          { error: "not_flagged", message: "Workspace is not currently flagged for abuse.", requestId },
+          400,
+        );
+      }
+
+      return c.json({
+        success: true,
+        workspaceId,
+        message: "Workspace reinstated successfully.",
+      }, 200);
+    } catch (err) {
+      log.error({ err: err instanceof Error ? err : new Error(String(err)), requestId, workspaceId }, "Failed to reinstate workspace");
+      return c.json({ error: "internal_error", message: "Failed to reinstate workspace.", requestId }, 500);
+    }
+  });
+});
+
+// GET /config — current threshold configuration
+adminAbuse.openapi(getConfigRoute, async (c) => {
+  const req = c.req.raw;
+  const requestId = crypto.randomUUID();
+
+  const preamble = await adminAuthPreamble(req, requestId);
+  if ("error" in preamble) {
+    return c.json(preamble.error, preamble.status, preamble.headers) as never;
+  }
+  const { authResult } = preamble;
+
+  return withRequestContext({ requestId, user: authResult.user }, async () => {
+    try {
+      return c.json(getAbuseConfig(), 200);
+    } catch (err) {
+      log.error({ err: err instanceof Error ? err : new Error(String(err)), requestId }, "Failed to read abuse config");
+      return c.json({ error: "internal_error", message: "Failed to read abuse configuration.", requestId }, 500);
+    }
+  });
+});
+
+export { adminAbuse };

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -58,6 +58,7 @@ import { adminApproval } from "./admin-approval";
 import { adminCompliance } from "./admin-compliance";
 import { adminBranding } from "./admin-branding";
 import { adminOnboardingEmails } from "./admin-onboarding-emails";
+import { adminAbuse } from "./admin-abuse";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 
 const log = createLogger("admin-routes");
@@ -110,6 +111,8 @@ admin.route("/branding", adminBranding);
 admin.route("/branding/", adminBranding);
 admin.route("/onboarding-emails", adminOnboardingEmails);
 admin.route("/onboarding-emails/", adminOnboardingEmails);
+admin.route("/abuse", adminAbuse);
+admin.route("/abuse/", adminAbuse);
 
 // Path traversal guard, YAML helpers, entity discovery, and file finding
 // are all imported from @atlas/api/lib/semantic-files above.

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -23,6 +23,7 @@ import {
 } from "@atlas/api/lib/auth/middleware";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import { checkWorkspaceStatus } from "@atlas/api/lib/workspace";
+import { checkAbuseStatus } from "@atlas/api/lib/security/abuse";
 import { checkPlanLimits } from "@atlas/api/lib/billing/enforcement";
 import {
   createConversation,
@@ -210,6 +211,23 @@ chat.openapi(chatRoute, async (c) => {
       { error: wsCheck.errorCode, message: wsCheck.errorMessage, retryable: wsCheck.errorCode && isChatErrorCode(wsCheck.errorCode) ? isRetryableError(wsCheck.errorCode) : false, requestId },
       wsCheck.httpStatus ?? 403,
     );
+  }
+
+  // Abuse check — block suspended workspaces, delay throttled ones
+  const abuseOrgId = authResult.user?.activeOrganizationId;
+  if (abuseOrgId) {
+    const abuse = checkAbuseStatus(abuseOrgId);
+    if (abuse.level === "suspended") {
+      log.warn({ requestId, orgId: abuseOrgId }, "Workspace suspended due to abuse");
+      return c.json(
+        { error: "workspace_suspended", message: "Workspace suspended due to unusual activity. Contact your administrator.", retryable: false, requestId },
+        403,
+      );
+    }
+    if (abuse.level === "throttled" && abuse.throttleDelayMs) {
+      log.debug({ requestId, orgId: abuseOrgId, delayMs: abuse.throttleDelayMs }, "Throttling workspace request");
+      await new Promise((resolve) => setTimeout(resolve, abuse.throttleDelayMs));
+    }
   }
 
   // Plan limit check — block or warn when usage approaches/exceeds plan limits

--- a/packages/api/src/api/routes/query.ts
+++ b/packages/api/src/api/routes/query.ts
@@ -23,6 +23,7 @@ import { createLogger, withRequestContext } from "@atlas/api/lib/logger";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import { checkWorkspaceStatus } from "@atlas/api/lib/workspace";
 import { checkPlanLimits } from "@atlas/api/lib/billing/enforcement";
+import { checkAbuseStatus } from "@atlas/api/lib/security/abuse";
 import {
   createConversation,
   addMessage,
@@ -196,6 +197,23 @@ query.openapi(
         { error: wsError, message: wsMessage, retryable: isChatErrorCode(wsError) ? isRetryableError(wsError) : false, requestId },
         wsCheck.httpStatus ?? 403,
       ) as never;
+    }
+
+    // Abuse check — block suspended workspaces, delay throttled ones
+    const abuseOrgId = authResult.user?.activeOrganizationId;
+    if (abuseOrgId) {
+      const abuse = checkAbuseStatus(abuseOrgId);
+      if (abuse.level === "suspended") {
+        log.warn({ requestId, orgId: abuseOrgId }, "Workspace suspended due to abuse");
+        return c.json(
+          { error: "workspace_suspended", message: "Workspace suspended due to unusual activity. Contact your administrator.", retryable: false, requestId },
+          403,
+        ) as never;
+      }
+      if (abuse.level === "throttled" && abuse.throttleDelayMs) {
+        log.debug({ requestId, orgId: abuseOrgId, delayMs: abuse.throttleDelayMs }, "Throttling workspace request");
+        await new Promise((resolve) => setTimeout(resolve, abuse.throttleDelayMs));
+      }
     }
 
     // Plan limit check — block or warn when usage approaches/exceeds plan limits

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -102,9 +102,9 @@ describe("migrateAuthTables", () => {
     await migrateAuthTables();
 
     // migrateInternalDB: org table check skips workspace ALTERs in mock
-    // + loadSavedConnections SELECT + loadPluginSettings SELECT
-    // (includes SSO enforcement, ip_allowlist, custom_roles, user_onboarding, audit_retention_config, workspace_model_config, approval_rules, approval_queue, workspace_branding, onboarding_emails, email_preferences)
-    expect(queries.length).toBe(132);
+    // + loadSavedConnections SELECT + loadPluginSettings SELECT + restoreAbuseState SELECT
+    // (includes SSO enforcement, ip_allowlist, custom_roles, user_onboarding, audit_retention_config, workspace_model_config, approval_rules, approval_queue, workspace_branding, onboarding_emails, email_preferences, abuse_events)
+    expect(queries.length).toBe(136);
     expect(queries[0]).toContain("CREATE TABLE IF NOT EXISTS audit_log");
   });
 
@@ -146,9 +146,9 @@ describe("migrateAuthTables", () => {
     await migrateAuthTables();
 
     // Internal DB migration runs once (org table check skips workspace ALTERs)
-    // + loadSavedConnections + loadPluginSettings + ALTER TABLE password_change_required
-    // (includes SSO enforcement, ip_allowlist, custom_roles, user_onboarding, audit_retention_config, workspace_model_config, approval_rules, approval_queue, workspace_branding, onboarding_emails, email_preferences)
-    expect(queries.length).toBe(133);
+    // + loadSavedConnections + loadPluginSettings + restoreAbuseState + ALTER TABLE password_change_required
+    // (includes SSO enforcement, ip_allowlist, custom_roles, user_onboarding, audit_retention_config, workspace_model_config, approval_rules, approval_queue, workspace_branding, onboarding_emails, email_preferences, abuse_events)
+    expect(queries.length).toBe(137);
     // Better Auth migration runs once
     expect(getMigrationCount()).toBe(1);
   });

--- a/packages/api/src/lib/auth/audit.ts
+++ b/packages/api/src/lib/auth/audit.ts
@@ -19,6 +19,7 @@
 import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
 import { hasInternalDB, internalExecute } from "@atlas/api/lib/db/internal";
 import { SENSITIVE_PATTERNS } from "@atlas/api/lib/security";
+import { recordQueryEvent } from "@atlas/api/lib/security/abuse";
 import type { DBType } from "@atlas/api/lib/db/connection";
 
 const log = createLogger("audit");
@@ -63,6 +64,15 @@ export function logQueryAudit(entry: AuditEntry): void {
     },
     entry.success ? "query_success" : "query_failure",
   );
+
+  // Record query event for abuse detection (per-workspace anomaly tracking)
+  const orgId = ctx?.user?.activeOrganizationId;
+  if (orgId) {
+    recordQueryEvent(orgId, {
+      success: entry.success,
+      tablesAccessed: entry.tablesAccessed,
+    });
+  }
 
   // Insert into audit_log when internal DB is available (SQL truncated to 2000 chars)
   if (hasInternalDB()) {

--- a/packages/api/src/lib/auth/migrate.ts
+++ b/packages/api/src/lib/auth/migrate.ts
@@ -57,6 +57,14 @@ export async function migrateAuthTables(): Promise<void> {
     } catch (err) {
       log.error({ err }, "Failed to load plugin settings at startup — all plugins default to enabled");
     }
+
+    // Restore abuse prevention state from DB
+    try {
+      const { restoreAbuseState } = await import("@atlas/api/lib/security/abuse");
+      await restoreAbuseState();
+    } catch (err) {
+      log.error({ err }, "Failed to restore abuse state at startup — starting with empty state");
+    }
   }
 
   // Better Auth migration — only in managed mode

--- a/packages/api/src/lib/db/__tests__/internal.test.ts
+++ b/packages/api/src/lib/db/__tests__/internal.test.ts
@@ -200,10 +200,10 @@ describe("internal DB module", () => {
       _resetPool(pool);
 
       await migrateInternalDB();
-      // 130 base queries + 1 org table existence check (workspace ALTER TABLEs
+      // 133 base queries + 1 org table existence check (workspace ALTER TABLEs
       // are skipped because mock pool returns empty rows for the check)
-      // Includes: SSO enforcement, ip_allowlist, custom_roles, user_onboarding, audit_retention_config, workspace_model_config, approval_rules, approval_queue, workspace_branding, onboarding_emails, email_preferences tables + indexes
-      expect(calls.queries.length).toBe(130);
+      // Includes: SSO enforcement, ip_allowlist, custom_roles, user_onboarding, audit_retention_config, workspace_model_config, approval_rules, approval_queue, workspace_branding, onboarding_emails, email_preferences, abuse_events tables + indexes
+      expect(calls.queries.length).toBe(133);
       expect(calls.queries[0].sql).toContain("CREATE TABLE IF NOT EXISTS audit_log");
       expect(calls.queries[1].sql).toContain("idx_audit_log_timestamp");
       expect(calls.queries[2].sql).toContain("idx_audit_log_user_id");

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -798,6 +798,22 @@ export async function migrateInternalDB(): Promise<void> {
     );
   `);
 
+  // Abuse prevention events (0.9.0 — abuse prevention #668)
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS abuse_events (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      workspace_id TEXT NOT NULL,
+      level TEXT NOT NULL,
+      trigger_type TEXT NOT NULL,
+      message TEXT NOT NULL,
+      metadata JSONB NOT NULL DEFAULT '{}',
+      actor TEXT NOT NULL DEFAULT 'system',
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+  `);
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_abuse_events_workspace ON abuse_events(workspace_id, created_at);`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_abuse_events_level ON abuse_events(level);`);
+
   log.info("Internal DB migration complete");
 }
 

--- a/packages/api/src/lib/security/__tests__/abuse.test.ts
+++ b/packages/api/src/lib/security/__tests__/abuse.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Unit tests for abuse prevention engine.
+ *
+ * Tests anomaly detection, graduated escalation, reinstatement, and config.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  mock,
+} from "bun:test";
+
+// --- Mocks ---
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getRequestContext: () => null,
+  withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}));
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => false,
+  internalExecute: mock(() => {}),
+  internalQuery: mock(async () => []),
+}));
+
+// --- Import after mocks ---
+
+const {
+  recordQueryEvent,
+  checkAbuseStatus,
+  listFlaggedWorkspaces,
+  reinstateWorkspace,
+  getAbuseConfig,
+  _resetAbuseState,
+  _stopCleanup,
+} = await import("../abuse");
+
+// Stop cleanup timer to prevent test hangs
+_stopCleanup();
+
+describe("Abuse Prevention Engine", () => {
+  beforeEach(() => {
+    _resetAbuseState();
+  });
+
+  describe("getAbuseConfig()", () => {
+    it("returns default thresholds", () => {
+      const config = getAbuseConfig();
+      expect(config.queryRateLimit).toBe(200);
+      expect(config.queryRateWindowSeconds).toBe(300);
+      expect(config.errorRateThreshold).toBe(0.5);
+      expect(config.uniqueTablesLimit).toBe(50);
+      expect(config.throttleDelayMs).toBe(2000);
+    });
+  });
+
+  describe("checkAbuseStatus()", () => {
+    it("returns 'none' for unknown workspaces", () => {
+      const status = checkAbuseStatus("unknown-ws");
+      expect(status.level).toBe("none");
+    });
+
+    it("returns 'none' for workspaces with normal activity", () => {
+      // Record a few queries — well below threshold
+      for (let i = 0; i < 5; i++) {
+        recordQueryEvent("ws-normal", { success: true });
+      }
+      const status = checkAbuseStatus("ws-normal");
+      expect(status.level).toBe("none");
+    });
+  });
+
+  describe("graduated escalation", () => {
+    it("escalates to warning on first threshold breach", () => {
+      const config = getAbuseConfig();
+      // Exceed query rate limit
+      for (let i = 0; i <= config.queryRateLimit; i++) {
+        recordQueryEvent("ws-warn", { success: true });
+      }
+      const status = checkAbuseStatus("ws-warn");
+      expect(status.level).toBe("warning");
+    });
+
+    it("escalates through warning to throttled with continued abuse", () => {
+      const config = getAbuseConfig();
+      // Push exactly to the limit + 1 to trigger first warning
+      for (let i = 0; i <= config.queryRateLimit; i++) {
+        recordQueryEvent("ws-throttle", { success: true });
+      }
+      // The escalation count increments on each call over the limit.
+      // After exactly limit+1 calls, we should be at least at warning.
+      const level = checkAbuseStatus("ws-throttle").level;
+      expect(level).not.toBe("none");
+
+      // Adding more queries escalates further. Check throttle delay works for throttled level.
+      // Push to throttled by adding a couple more
+      for (let i = 0; i < 5; i++) {
+        recordQueryEvent("ws-throttle", { success: true });
+      }
+      const status = checkAbuseStatus("ws-throttle");
+      // Should be either throttled or suspended at this point
+      expect(["throttled", "suspended"]).toContain(status.level);
+      if (status.level === "throttled") {
+        expect(status.throttleDelayMs).toBe(config.throttleDelayMs);
+      }
+    });
+
+    it("escalates to suspended after sustained abuse", () => {
+      const config = getAbuseConfig();
+      // Exceed rate limit — each subsequent call while over threshold escalates
+      // warning (1st breach) → throttled (2nd) → suspended (3rd)
+      for (let i = 0; i <= config.queryRateLimit + 5; i++) {
+        recordQueryEvent("ws-suspend", { success: true });
+      }
+      const status = checkAbuseStatus("ws-suspend");
+      expect(status.level).toBe("suspended");
+    });
+
+    it("stops recording events for suspended workspaces", () => {
+      const config = getAbuseConfig();
+      // Get to suspended
+      for (let i = 0; i <= config.queryRateLimit + 5; i++) {
+        recordQueryEvent("ws-stopped", { success: true });
+      }
+      expect(checkAbuseStatus("ws-stopped").level).toBe("suspended");
+      // More events don't change anything (no crash, stays suspended)
+      recordQueryEvent("ws-stopped", { success: true });
+      expect(checkAbuseStatus("ws-stopped").level).toBe("suspended");
+    });
+
+    it("triggers on high error rate", () => {
+      // First 5 are success, next 5 are errors — 50% when checked at query 10
+      for (let i = 0; i < 5; i++) {
+        recordQueryEvent("ws-errors", { success: true });
+      }
+      // Now push errors to trigger error rate threshold
+      for (let i = 0; i < 6; i++) {
+        recordQueryEvent("ws-errors", { success: false });
+      }
+      const status = checkAbuseStatus("ws-errors");
+      // Should have been flagged (at least warning level)
+      expect(status.level).not.toBe("none");
+    });
+
+    it("triggers on unique tables limit", () => {
+      const config = getAbuseConfig();
+      const tables: string[] = [];
+      for (let i = 0; i <= config.uniqueTablesLimit; i++) {
+        tables.push(`table_${i}`);
+      }
+      recordQueryEvent("ws-tables", { success: true, tablesAccessed: tables });
+      const status = checkAbuseStatus("ws-tables");
+      expect(status.level).toBe("warning");
+    });
+  });
+
+  describe("listFlaggedWorkspaces()", () => {
+    it("returns empty when no workspaces are flagged", () => {
+      expect(listFlaggedWorkspaces()).toEqual([]);
+    });
+
+    it("returns flagged workspaces sorted by updatedAt desc", () => {
+      const config = getAbuseConfig();
+      // Flag two workspaces
+      for (let i = 0; i <= config.queryRateLimit; i++) {
+        recordQueryEvent("ws-a", { success: true });
+      }
+      for (let i = 0; i <= config.queryRateLimit; i++) {
+        recordQueryEvent("ws-b", { success: true });
+      }
+      const flagged = listFlaggedWorkspaces();
+      expect(flagged.length).toBe(2);
+      expect(flagged[0].level).toBe("warning");
+    });
+
+    it("excludes workspaces with level none", () => {
+      recordQueryEvent("ws-ok", { success: true });
+      expect(listFlaggedWorkspaces()).toEqual([]);
+    });
+  });
+
+  describe("reinstateWorkspace()", () => {
+    it("reinstates a flagged workspace", () => {
+      const config = getAbuseConfig();
+      for (let i = 0; i <= config.queryRateLimit; i++) {
+        recordQueryEvent("ws-reinstate", { success: true });
+      }
+      expect(checkAbuseStatus("ws-reinstate").level).toBe("warning");
+
+      const result = reinstateWorkspace("ws-reinstate", "admin-1");
+      expect(result).toBe(true);
+      expect(checkAbuseStatus("ws-reinstate").level).toBe("none");
+    });
+
+    it("returns false for non-flagged workspaces", () => {
+      const result = reinstateWorkspace("ws-nonexistent", "admin-1");
+      expect(result).toBe(false);
+    });
+
+    it("resets abuse counters on reinstate", () => {
+      const config = getAbuseConfig();
+      // Get to throttled
+      for (let i = 0; i <= config.queryRateLimit + 10; i++) {
+        recordQueryEvent("ws-counters", { success: true });
+      }
+      expect(checkAbuseStatus("ws-counters").level).not.toBe("none");
+
+      reinstateWorkspace("ws-counters", "admin-1");
+
+      // Normal queries after reinstate should not re-trigger
+      for (let i = 0; i < 5; i++) {
+        recordQueryEvent("ws-counters", { success: true });
+      }
+      expect(checkAbuseStatus("ws-counters").level).toBe("none");
+    });
+  });
+
+  describe("normal patterns do not trigger", () => {
+    it("does not flag low query rate", () => {
+      for (let i = 0; i < 10; i++) {
+        recordQueryEvent("ws-normal-rate", { success: true });
+      }
+      expect(checkAbuseStatus("ws-normal-rate").level).toBe("none");
+    });
+
+    it("does not flag low error rate", () => {
+      // 10 queries with 2 errors = 20% (below 50%)
+      for (let i = 0; i < 10; i++) {
+        recordQueryEvent("ws-normal-errors", { success: i < 8 });
+      }
+      expect(checkAbuseStatus("ws-normal-errors").level).toBe("none");
+    });
+
+    it("does not flag small table set", () => {
+      recordQueryEvent("ws-normal-tables", {
+        success: true,
+        tablesAccessed: ["orders", "users", "products"],
+      });
+      expect(checkAbuseStatus("ws-normal-tables").level).toBe("none");
+    });
+  });
+});

--- a/packages/api/src/lib/security/abuse.ts
+++ b/packages/api/src/lib/security/abuse.ts
@@ -1,0 +1,463 @@
+/**
+ * Abuse prevention — anomaly detection with graduated response.
+ *
+ * Detects abusive query patterns per workspace using sliding window counters:
+ * - Query rate (rapid-fire requests)
+ * - Error rate (high failure ratio)
+ * - Unique tables accessed (scanning unusual breadth)
+ *
+ * Graduated response: warn (log + webhook) → throttle (inject delays) → suspend.
+ *
+ * All state is in-memory with periodic flush to the internal DB for persistence
+ * across restarts. Thresholds are configurable via env vars or atlas.config.ts.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { hasInternalDB, internalExecute, internalQuery } from "@atlas/api/lib/db/internal";
+import type { AbuseLevel, AbuseTrigger, AbuseEvent, AbuseStatus, AbuseThresholdConfig } from "@useatlas/types";
+
+const log = createLogger("abuse");
+
+// ---------------------------------------------------------------------------
+// Configuration — env var thresholds
+// ---------------------------------------------------------------------------
+
+function envInt(key: string, fallback: number): number {
+  const raw = process.env[key];
+  if (!raw) return fallback;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+function envFloat(key: string, fallback: number): number {
+  const raw = process.env[key];
+  if (!raw) return fallback;
+  const n = parseFloat(raw);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+export function getAbuseConfig(): AbuseThresholdConfig {
+  return {
+    queryRateLimit: envInt("ATLAS_ABUSE_QUERY_RATE", 200),
+    queryRateWindowSeconds: envInt("ATLAS_ABUSE_WINDOW_SECONDS", 300),
+    errorRateThreshold: envFloat("ATLAS_ABUSE_ERROR_RATE", 0.5),
+    uniqueTablesLimit: envInt("ATLAS_ABUSE_UNIQUE_TABLES", 50),
+    throttleDelayMs: envInt("ATLAS_ABUSE_THROTTLE_DELAY_MS", 2000),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// In-memory workspace state
+// ---------------------------------------------------------------------------
+
+interface WindowCounter {
+  timestamps: number[];
+  errorCount: number;
+  tables: Set<string>;
+}
+
+interface WorkspaceAbuseState {
+  level: AbuseLevel;
+  trigger: AbuseTrigger | null;
+  message: string | null;
+  updatedAt: number;
+  window: WindowCounter;
+  /** Escalation count — how many consecutive windows triggered. */
+  escalations: number;
+}
+
+const workspaceState = new Map<string, WorkspaceAbuseState>();
+
+/** Reset all in-memory state. For tests. */
+export function _resetAbuseState(): void {
+  workspaceState.clear();
+}
+
+/** Get or create workspace state. */
+function getState(workspaceId: string): WorkspaceAbuseState {
+  let state = workspaceState.get(workspaceId);
+  if (!state) {
+    state = {
+      level: "none",
+      trigger: null,
+      message: null,
+      updatedAt: Date.now(),
+      window: { timestamps: [], errorCount: 0, tables: new Set() },
+      escalations: 0,
+    };
+    workspaceState.set(workspaceId, state);
+  }
+  return state;
+}
+
+// ---------------------------------------------------------------------------
+// Sliding window maintenance
+// ---------------------------------------------------------------------------
+
+function pruneWindow(w: WindowCounter, windowMs: number): void {
+  const cutoff = Date.now() - windowMs;
+  const firstValid = w.timestamps.findIndex((t) => t > cutoff);
+  if (firstValid > 0) {
+    w.timestamps.splice(0, firstValid);
+  } else if (firstValid === -1) {
+    w.timestamps.length = 0;
+    w.errorCount = 0;
+    w.tables.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Record a query event
+// ---------------------------------------------------------------------------
+
+/**
+ * Record a query event for abuse detection.
+ * Call this after each query execution (success or failure).
+ */
+export function recordQueryEvent(
+  workspaceId: string,
+  opts: { success: boolean; tablesAccessed?: string[] },
+): void {
+  const config = getAbuseConfig();
+  const windowMs = config.queryRateWindowSeconds * 1000;
+  const state = getState(workspaceId);
+  const w = state.window;
+
+  // If workspace is already suspended, skip tracking
+  if (state.level === "suspended") return;
+
+  pruneWindow(w, windowMs);
+
+  const now = Date.now();
+  w.timestamps.push(now);
+  if (!opts.success) w.errorCount++;
+  if (opts.tablesAccessed) {
+    for (const t of opts.tablesAccessed) w.tables.add(t);
+  }
+
+  // Check thresholds
+  checkThresholds(workspaceId, state, config);
+}
+
+// ---------------------------------------------------------------------------
+// Threshold evaluation & escalation
+// ---------------------------------------------------------------------------
+
+function checkThresholds(
+  workspaceId: string,
+  state: WorkspaceAbuseState,
+  config: AbuseThresholdConfig,
+): void {
+  const w = state.window;
+  const queryCount = w.timestamps.length;
+
+  // Query rate check
+  if (queryCount > config.queryRateLimit) {
+    escalate(workspaceId, state, "query_rate", `Query rate ${queryCount} exceeds limit ${config.queryRateLimit} in ${config.queryRateWindowSeconds}s window`);
+    return;
+  }
+
+  // Error rate check (need at least 10 queries to evaluate)
+  if (queryCount >= 10) {
+    const errorRate = w.errorCount / queryCount;
+    if (errorRate > config.errorRateThreshold) {
+      escalate(workspaceId, state, "error_rate", `Error rate ${(errorRate * 100).toFixed(0)}% exceeds threshold ${(config.errorRateThreshold * 100).toFixed(0)}%`);
+      return;
+    }
+  }
+
+  // Unique tables check
+  if (w.tables.size > config.uniqueTablesLimit) {
+    escalate(workspaceId, state, "unique_tables", `${w.tables.size} unique tables accessed exceeds limit ${config.uniqueTablesLimit}`);
+    return;
+  }
+
+  // No threshold exceeded — if we had escalations, decay them
+  if (state.escalations > 0 && queryCount < config.queryRateLimit * 0.5) {
+    state.escalations = Math.max(0, state.escalations - 1);
+  }
+}
+
+function escalate(
+  workspaceId: string,
+  state: WorkspaceAbuseState,
+  trigger: AbuseTrigger,
+  message: string,
+): void {
+  const prevLevel = state.level;
+  state.escalations++;
+  state.trigger = trigger;
+  state.message = message;
+  state.updatedAt = Date.now();
+
+  // First trigger → warning
+  // Second consecutive trigger → throttle
+  // Third consecutive trigger → suspend
+  if (state.escalations === 1 && prevLevel === "none") {
+    state.level = "warning";
+  } else if (state.escalations >= 2 && prevLevel === "warning") {
+    state.level = "throttled";
+  } else if (state.escalations >= 3 && prevLevel === "throttled") {
+    state.level = "suspended";
+  }
+
+  // Only emit event if level changed
+  if (state.level !== prevLevel) {
+    const event: AbuseEvent = {
+      id: crypto.randomUUID(),
+      workspaceId,
+      level: state.level,
+      trigger,
+      message,
+      metadata: {
+        queryCount: state.window.timestamps.length,
+        errorCount: state.window.errorCount,
+        uniqueTables: state.window.tables.size,
+        escalations: state.escalations,
+      },
+      createdAt: new Date().toISOString(),
+      actor: "system",
+    };
+
+    log.warn(
+      { workspaceId, level: state.level, trigger, message, escalations: state.escalations },
+      "Abuse level changed: %s → %s",
+      prevLevel,
+      state.level,
+    );
+
+    persistAbuseEvent(event);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Workspace abuse status check (called from middleware)
+// ---------------------------------------------------------------------------
+
+/**
+ * Check the current abuse level for a workspace.
+ * Returns the current level and throttle delay if applicable.
+ */
+export function checkAbuseStatus(workspaceId: string): {
+  level: AbuseLevel;
+  throttleDelayMs?: number;
+} {
+  const state = workspaceState.get(workspaceId);
+  if (!state || state.level === "none" || state.level === "warning") {
+    return { level: state?.level ?? "none" };
+  }
+
+  if (state.level === "throttled") {
+    const config = getAbuseConfig();
+    return { level: "throttled", throttleDelayMs: config.throttleDelayMs };
+  }
+
+  return { level: "suspended" };
+}
+
+// ---------------------------------------------------------------------------
+// Admin operations
+// ---------------------------------------------------------------------------
+
+/** List all workspaces with non-"none" abuse levels. */
+export function listFlaggedWorkspaces(): AbuseStatus[] {
+  const results: AbuseStatus[] = [];
+  for (const [workspaceId, state] of workspaceState) {
+    if (state.level === "none") continue;
+    results.push({
+      workspaceId,
+      workspaceName: null, // Resolved by the admin route
+      level: state.level,
+      trigger: state.trigger,
+      message: state.message,
+      updatedAt: new Date(state.updatedAt).toISOString(),
+      events: [],
+    });
+  }
+  return results.toSorted((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
+/** Manually reinstate a suspended or throttled workspace. */
+export function reinstateWorkspace(workspaceId: string, actorId: string): boolean {
+  const state = workspaceState.get(workspaceId);
+  if (!state || state.level === "none") return false;
+
+  const prevLevel = state.level;
+  state.level = "none";
+  state.trigger = null;
+  state.message = null;
+  state.escalations = 0;
+  state.updatedAt = Date.now();
+  // Reset the window so the workspace gets a clean slate
+  state.window = { timestamps: [], errorCount: 0, tables: new Set() };
+
+  const event: AbuseEvent = {
+    id: crypto.randomUUID(),
+    workspaceId,
+    level: "none",
+    trigger: "manual",
+    message: `Reinstated from ${prevLevel} by admin`,
+    metadata: { previousLevel: prevLevel },
+    createdAt: new Date().toISOString(),
+    actor: actorId,
+  };
+
+  log.info(
+    { workspaceId, previousLevel: prevLevel, actorId },
+    "Workspace reinstated from %s",
+    prevLevel,
+  );
+
+  persistAbuseEvent(event);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Persistence — abuse events to internal DB
+// ---------------------------------------------------------------------------
+
+function persistAbuseEvent(event: AbuseEvent): void {
+  if (!hasInternalDB()) return;
+
+  try {
+    internalExecute(
+      `INSERT INTO abuse_events (id, workspace_id, level, trigger_type, message, metadata, actor, created_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+      [
+        event.id,
+        event.workspaceId,
+        event.level,
+        event.trigger,
+        event.message,
+        JSON.stringify(event.metadata),
+        event.actor,
+        event.createdAt,
+      ],
+    );
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Failed to persist abuse event",
+    );
+  }
+}
+
+/** Load recent abuse events from DB for a workspace. */
+export async function getAbuseEvents(
+  workspaceId: string,
+  limit = 50,
+): Promise<AbuseEvent[]> {
+  if (!hasInternalDB()) return [];
+
+  try {
+    const rows = await internalQuery<{
+      id: string;
+      workspace_id: string;
+      level: string;
+      trigger_type: string;
+      message: string;
+      metadata: string;
+      actor: string;
+      created_at: string;
+    }>(
+      `SELECT id, workspace_id, level, trigger_type, message, metadata, actor, created_at
+       FROM abuse_events
+       WHERE workspace_id = $1
+       ORDER BY created_at DESC
+       LIMIT $2`,
+      [workspaceId, limit],
+    );
+
+    return rows.map((r) => ({
+      id: r.id,
+      workspaceId: r.workspace_id,
+      level: r.level as AbuseLevel,
+      trigger: r.trigger_type as AbuseTrigger,
+      message: r.message,
+      metadata: typeof r.metadata === "string" ? JSON.parse(r.metadata) as Record<string, unknown> : (r.metadata as Record<string, unknown>),
+      createdAt: r.created_at,
+      actor: r.actor,
+    }));
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), workspaceId },
+      "Failed to load abuse events",
+    );
+    return [];
+  }
+}
+
+/** Restore in-memory state from DB on startup. */
+export async function restoreAbuseState(): Promise<void> {
+  if (!hasInternalDB()) return;
+
+  try {
+    // Get the latest event per workspace to restore current level
+    const rows = await internalQuery<{
+      workspace_id: string;
+      level: string;
+      trigger_type: string;
+      message: string;
+      created_at: string;
+    }>(
+      `SELECT DISTINCT ON (workspace_id) workspace_id, level, trigger_type, message, created_at
+       FROM abuse_events
+       ORDER BY workspace_id, created_at DESC`,
+    );
+
+    for (const row of rows) {
+      const level = row.level as AbuseLevel;
+      if (level === "none") continue; // Already reinstated
+
+      const state = getState(row.workspace_id);
+      state.level = level;
+      state.trigger = row.trigger_type as AbuseTrigger;
+      state.message = row.message;
+      state.updatedAt = new Date(row.created_at).getTime();
+      // Set escalations based on current level to maintain correct position in the ladder
+      state.escalations = level === "warning" ? 1 : level === "throttled" ? 2 : 3;
+    }
+
+    const restored = [...workspaceState.values()].filter((s) => s.level !== "none").length;
+    if (restored > 0) {
+      log.info({ count: restored }, "Restored abuse state for %d workspaces", restored);
+    }
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Failed to restore abuse state from DB — starting with empty state",
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Periodic cleanup — evict stale window data every 5 minutes
+// ---------------------------------------------------------------------------
+
+const cleanupInterval = setInterval(() => {
+  try {
+    const config = getAbuseConfig();
+    const windowMs = config.queryRateWindowSeconds * 1000;
+
+    for (const [id, state] of workspaceState) {
+      pruneWindow(state.window, windowMs);
+
+      // Remove entries with no activity and level "none"
+      if (state.level === "none" && state.window.timestamps.length === 0) {
+        workspaceState.delete(id);
+      }
+    }
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Abuse cleanup tick failed",
+    );
+  }
+}, 300_000);
+
+cleanupInterval.unref();
+
+/** Stop the periodic cleanup timer. For tests. */
+export function _stopCleanup(): void {
+  clearInterval(cleanupInterval);
+}

--- a/packages/types/src/__tests__/errors.test.ts
+++ b/packages/types/src/__tests__/errors.test.ts
@@ -335,6 +335,7 @@ describe("isRetryableError", () => {
     "internal_error",
     "billing_check_failed",
     "workspace_check_failed",
+    "workspace_throttled",
   ];
 
   const nonRetryableCodes: ChatErrorCode[] = [

--- a/packages/types/src/abuse.ts
+++ b/packages/types/src/abuse.ts
@@ -1,0 +1,55 @@
+// ---------------------------------------------------------------------------
+// Abuse prevention types — wire format for API + admin UI
+// ---------------------------------------------------------------------------
+
+/** Graduated abuse response levels (escalation order). */
+export const ABUSE_LEVELS = ["none", "warning", "throttled", "suspended"] as const;
+export type AbuseLevel = (typeof ABUSE_LEVELS)[number];
+
+/** Which anomaly detector triggered the abuse event. */
+export const ABUSE_TRIGGERS = [
+  "query_rate",
+  "error_rate",
+  "unique_tables",
+  "manual",
+] as const;
+export type AbuseTrigger = (typeof ABUSE_TRIGGERS)[number];
+
+/** A single abuse event recorded in the audit trail. */
+export interface AbuseEvent {
+  id: string;
+  workspaceId: string;
+  level: AbuseLevel;
+  trigger: AbuseTrigger;
+  message: string;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  /** Who initiated the event — "system" for auto-detection, user ID for manual reinstate. */
+  actor: string;
+}
+
+/** Current abuse status for a workspace. */
+export interface AbuseStatus {
+  workspaceId: string;
+  workspaceName: string | null;
+  level: AbuseLevel;
+  trigger: AbuseTrigger | null;
+  message: string | null;
+  updatedAt: string;
+  /** Recent abuse events for this workspace. */
+  events: AbuseEvent[];
+}
+
+/** Abuse threshold configuration (read-only from admin API). */
+export interface AbuseThresholdConfig {
+  /** Max queries per workspace per sliding window. */
+  queryRateLimit: number;
+  /** Sliding window duration in seconds. */
+  queryRateWindowSeconds: number;
+  /** Max error rate (0–1) before escalation. */
+  errorRateThreshold: number;
+  /** Max unique tables accessed per window before escalation. */
+  uniqueTablesLimit: number;
+  /** Delay injected for throttled workspaces, in milliseconds. */
+  throttleDelayMs: number;
+}

--- a/packages/types/src/errors.ts
+++ b/packages/types/src/errors.ts
@@ -35,6 +35,7 @@ export const CHAT_ERROR_CODES = [
   "billing_check_failed",
   "workspace_check_failed",
   "workspace_suspended",
+  "workspace_throttled",
   "workspace_deleted",
 ] as const;
 
@@ -82,6 +83,7 @@ const RETRYABLE_MAP: Record<ChatErrorCode, boolean> = {
   billing_check_failed: true,
   workspace_check_failed: true,
   workspace_suspended: false,
+  workspace_throttled: true,
   workspace_deleted: false,
 };
 
@@ -507,6 +509,9 @@ export function parseChatError(error: Error, authMode: AuthMode): ChatErrorInfo 
 
     case "workspace_suspended":
       return { title: "Workspace suspended.", detail: serverMessage ?? "Contact your workspace administrator to reactivate it.", code: rawCode, retryable, requestId };
+
+    case "workspace_throttled":
+      return { title: "Workspace throttled.", detail: serverMessage ?? "Your workspace has been temporarily throttled due to unusual activity. Requests will be delayed.", code: rawCode, retryable, requestId };
 
     case "workspace_deleted":
       return { title: "Workspace deleted.", detail: serverMessage ?? "This workspace has been permanently deleted. Create a new workspace to continue.", code: rawCode, retryable, requestId };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -19,3 +19,4 @@ export * from "./approval";
 export * from "./platform";
 export * from "./branding";
 export * from "./onboarding-email";
+export * from "./abuse";

--- a/packages/web/src/app/admin/abuse/page.tsx
+++ b/packages/web/src/app/admin/abuse/page.tsx
@@ -1,0 +1,339 @@
+"use client";
+
+import { useState } from "react";
+import { useAtlasConfig } from "@/ui/context";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { LoadingState } from "@/ui/components/admin/loading-state";
+import { FeatureGate } from "@/ui/components/admin/feature-disabled";
+import { useAdminFetch, friendlyError } from "@/ui/hooks/use-admin-fetch";
+import { ErrorBoundary } from "@/ui/components/error-boundary";
+import {
+  ShieldAlert,
+  RotateCcw,
+  Loader2,
+  AlertTriangle,
+  Activity,
+  Settings2,
+} from "lucide-react";
+import type { AbuseStatus, AbuseThresholdConfig } from "@/ui/lib/types";
+
+// ── Types ─────────────────────────────────────────────────────────
+
+interface AbuseListResponse {
+  workspaces: AbuseStatus[];
+  total: number;
+}
+
+// ── Level badge colors ────────────────────────────────────────────
+
+function levelBadge(level: string) {
+  switch (level) {
+    case "warning":
+      return <Badge variant="outline" className="border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300">Warning</Badge>;
+    case "throttled":
+      return <Badge variant="outline" className="border-orange-500/30 bg-orange-500/10 text-orange-700 dark:text-orange-300">Throttled</Badge>;
+    case "suspended":
+      return <Badge variant="destructive">Suspended</Badge>;
+    default:
+      return <Badge variant="outline">None</Badge>;
+  }
+}
+
+function triggerLabel(trigger: string | null) {
+  switch (trigger) {
+    case "query_rate": return "Excessive queries";
+    case "error_rate": return "High error rate";
+    case "unique_tables": return "Unusual table access";
+    case "manual": return "Manual action";
+    default: return "-";
+  }
+}
+
+// ── Reinstate Dialog ──────────────────────────────────────────────
+
+function ReinstateDialog({
+  workspace,
+  open,
+  onOpenChange,
+  onReinstated,
+  apiUrl,
+  credentials,
+}: {
+  workspace: AbuseStatus | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onReinstated: () => void;
+  apiUrl: string;
+  credentials: RequestCredentials;
+}) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function handleOpen(next: boolean) {
+    if (!next) setError(null);
+    onOpenChange(next);
+  }
+
+  async function handleReinstate() {
+    if (!workspace) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `${apiUrl}/api/v1/admin/abuse/${encodeURIComponent(workspace.workspaceId)}/reinstate`,
+        { method: "POST", credentials },
+      );
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(
+          (data as Record<string, unknown> | null)?.message
+            ? String((data as Record<string, unknown>).message)
+            : `HTTP ${res.status}`,
+        );
+      }
+      onReinstated();
+      handleOpen(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to reinstate workspace");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpen}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Reinstate Workspace</DialogTitle>
+          <DialogDescription>
+            This will clear the abuse flag and allow the workspace to resume normal operations.
+          </DialogDescription>
+        </DialogHeader>
+
+        {workspace && (
+          <div className="space-y-3 py-2">
+            <div className="rounded-md bg-muted p-3">
+              <p className="text-sm font-medium">{workspace.workspaceName ?? workspace.workspaceId}</p>
+              <div className="mt-1 flex items-center gap-2">
+                {levelBadge(workspace.level)}
+                <span className="text-xs text-muted-foreground">{triggerLabel(workspace.trigger)}</span>
+              </div>
+              {workspace.message && (
+                <p className="mt-1 text-xs text-muted-foreground">{workspace.message}</p>
+              )}
+            </div>
+
+            <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2">
+              <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" />
+              <p className="text-xs text-amber-700 dark:text-amber-300">
+                Reinstating resets all abuse counters for this workspace. If the abusive pattern continues, the workspace will be flagged again.
+              </p>
+            </div>
+
+            {error && (
+              <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                {error}
+              </div>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleOpen(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleReinstate} disabled={loading}>
+            {loading && <Loader2 className="mr-1 size-3 animate-spin" />}
+            Reinstate
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Main Page ─────────────────────────────────────────────────────
+
+export default function AbusePage() {
+  const { apiUrl, isCrossOrigin } = useAtlasConfig();
+  const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
+  const [reinstateTarget, setReinstateTarget] = useState<AbuseStatus | null>(null);
+
+  const { data, loading, error, refetch } = useAdminFetch<AbuseListResponse>(
+    "/api/v1/admin/abuse",
+    { transform: (json) => json as AbuseListResponse },
+  );
+
+  const { data: config } = useAdminFetch<AbuseThresholdConfig>(
+    "/api/v1/admin/abuse/config",
+    { transform: (json) => json as AbuseThresholdConfig },
+  );
+
+  const workspaces = data?.workspaces ?? [];
+
+  // Gate: 401/403/404
+  if (!loading && error?.status && [401, 403, 404].includes(error.status)) {
+    return (
+      <div className="flex h-[calc(100dvh-3rem)] flex-col">
+        <div className="border-b px-6 py-4">
+          <h1 className="text-2xl font-bold tracking-tight">Abuse Prevention</h1>
+          <p className="text-sm text-muted-foreground">
+            Monitor and manage workspace abuse flags
+          </p>
+        </div>
+        <FeatureGate status={error.status as 401 | 403 | 404} feature="Abuse Prevention" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-[calc(100dvh-3rem)] flex-col">
+      <div className="flex items-center justify-between border-b px-6 py-4">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Abuse Prevention</h1>
+          <p className="text-sm text-muted-foreground">
+            Monitor anomalous query patterns and manage workspace suspensions
+          </p>
+        </div>
+      </div>
+
+      <ErrorBoundary>
+        <div className="flex-1 overflow-auto p-6 space-y-6">
+          {error && <ErrorBanner message={friendlyError(error)} onRetry={refetch} />}
+
+          {/* Threshold config summary */}
+          {config && (
+            <Card className="shadow-none">
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Settings2 className="size-4" />
+                  Detection Thresholds
+                </CardTitle>
+                <CardDescription>
+                  Configure via environment variables. See the abuse prevention guide for details.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+                  <div>
+                    <p className="text-xs text-muted-foreground">Query Rate Limit</p>
+                    <p className="text-sm font-medium">{config.queryRateLimit} / {config.queryRateWindowSeconds}s</p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-muted-foreground">Error Rate Threshold</p>
+                    <p className="text-sm font-medium">{(config.errorRateThreshold * 100).toFixed(0)}%</p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-muted-foreground">Unique Tables Limit</p>
+                    <p className="text-sm font-medium">{config.uniqueTablesLimit}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-muted-foreground">Throttle Delay</p>
+                    <p className="text-sm font-medium">{config.throttleDelayMs}ms</p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Flagged workspaces */}
+          {loading ? (
+            <LoadingState message="Loading abuse flags..." />
+          ) : workspaces.length > 0 ? (
+            <Card className="shadow-none">
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Activity className="size-4" />
+                  Flagged Workspaces
+                </CardTitle>
+                <CardDescription>
+                  Workspaces with active abuse warnings, throttling, or suspensions.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Workspace</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Trigger</TableHead>
+                      <TableHead>Details</TableHead>
+                      <TableHead>Updated</TableHead>
+                      <TableHead className="w-[80px]" />
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {workspaces.map((ws) => (
+                      <TableRow key={ws.workspaceId}>
+                        <TableCell className="font-mono text-sm">
+                          {ws.workspaceName ?? ws.workspaceId}
+                        </TableCell>
+                        <TableCell>{levelBadge(ws.level)}</TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {triggerLabel(ws.trigger)}
+                        </TableCell>
+                        <TableCell className="max-w-[200px] truncate text-xs text-muted-foreground">
+                          {ws.message ?? "-"}
+                        </TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {new Date(ws.updatedAt).toLocaleString()}
+                        </TableCell>
+                        <TableCell>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 px-2 text-xs"
+                            onClick={() => setReinstateTarget(ws)}
+                          >
+                            <RotateCcw className="mr-1 size-3" />
+                            Reinstate
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+          ) : !error ? (
+            <div className="flex flex-col items-center justify-center py-16 text-center">
+              <ShieldAlert className="mb-3 size-10 text-muted-foreground/50" />
+              <p className="text-sm font-medium">No workspaces flagged</p>
+              <p className="mt-1 max-w-sm text-xs text-muted-foreground">
+                All workspaces are operating within normal parameters. Anomalous query patterns will be automatically detected and shown here.
+              </p>
+            </div>
+          ) : null}
+        </div>
+      </ErrorBoundary>
+
+      <ReinstateDialog
+        workspace={reinstateTarget}
+        open={!!reinstateTarget}
+        onOpenChange={(open) => !open && setReinstateTarget(null)}
+        onReinstated={refetch}
+        apiUrl={apiUrl}
+        credentials={credentials}
+      />
+    </div>
+  );
+}

--- a/packages/web/src/ui/components/admin/admin-sidebar.tsx
+++ b/packages/web/src/ui/components/admin/admin-sidebar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { useAtlasConfig } from "@/ui/context";
 import { useBranding } from "@/ui/hooks/use-branding";
 import {
+  Ban,
   LayoutDashboard,
   Database,
   GitCompareArrows,
@@ -65,6 +66,7 @@ const navItems = [
   { href: "/admin/prompts", label: "Prompt Library", icon: BookOpen },
   { href: "/admin/roles", label: "Roles", icon: KeyRound },
   { href: "/admin/ip-allowlist", label: "IP Allowlist", icon: Shield },
+  { href: "/admin/abuse", label: "Abuse Prevention", icon: Ban },
   { href: "/admin/actions", label: "Actions", icon: Zap },
   { href: "/admin/approval", label: "Approval Workflows", icon: ShieldAlert },
   { href: "/admin/compliance", label: "PII Compliance", icon: Fingerprint },

--- a/packages/web/src/ui/lib/types.ts
+++ b/packages/web/src/ui/lib/types.ts
@@ -99,6 +99,14 @@ export type {
   OnboardingEmailStatus,
   OnboardingEmailPreferences,
 } from "@useatlas/types";
+export type {
+  AbuseLevel,
+  AbuseTrigger,
+  AbuseEvent,
+  AbuseStatus,
+  AbuseThresholdConfig,
+} from "@useatlas/types";
+export { ABUSE_LEVELS, ABUSE_TRIGGERS } from "@useatlas/types";
 export { ONBOARDING_EMAIL_STEPS, ONBOARDING_MILESTONES } from "@useatlas/types";
 export { PII_CATEGORIES, MASKING_STRATEGIES, PII_CONFIDENCE_LEVELS, COMPLIANCE_REPORT_TYPES } from "@useatlas/types";
 export { SHARE_EXPIRY_OPTIONS, PROMPT_INDUSTRIES, MODEL_CONFIG_PROVIDERS, APPROVAL_RULE_TYPES, APPROVAL_STATUSES, WORKSPACE_STATUSES, PLAN_TIERS, NOISY_NEIGHBOR_METRICS } from "@useatlas/types";


### PR DESCRIPTION
## Summary
- Implement anomaly detection with graduated response (warn → throttle → suspend) for abusive workspace query patterns
- Sliding window counters track query rate, error rate, and unique tables accessed per workspace
- Admin API endpoints for listing flagged workspaces, manual reinstatement, and viewing threshold config
- Admin UI page with threshold display, flagged workspace table, and reinstate confirmation dialog
- All abuse events persisted to `abuse_events` table for audit trail
- Configurable via `ATLAS_ABUSE_*` env vars

## Changes
- **New**: `packages/api/src/lib/security/abuse.ts` — core anomaly detection engine
- **New**: `packages/api/src/api/routes/admin-abuse.ts` — admin API (list, reinstate, config)
- **New**: `packages/web/src/app/admin/abuse/page.tsx` — admin UI page
- **New**: `packages/types/src/abuse.ts` — wire types (AbuseLevel, AbuseEvent, AbuseStatus, etc.)
- **Modified**: `chat.ts`, `query.ts` — abuse status check after workspace status check
- **Modified**: `audit.ts` — hooks `recordQueryEvent` into query audit for per-workspace tracking
- **Modified**: `errors.ts` — adds `workspace_throttled` error code
- **Modified**: `internal.ts` — adds `abuse_events` table migration
- **Modified**: `migrate.ts` — restores abuse state from DB on startup
- **New**: Guide page, env var docs, ROADMAP updated

## Test plan
- [x] Unit tests for anomaly detector: normal patterns don't trigger, sustained abuse escalates through levels (18 tests)
- [x] Admin API tests: list, reinstate, config endpoints with auth checks (8 tests)
- [x] Existing error type exhaustive test updated for `workspace_throttled`
- [x] Migration query count tests updated for new `abuse_events` table
- [x] All CI gates pass: lint, type, test (224 files / 0 failures), syncpack, template drift

Closes #668