### PR TITLE
feat: Google Chat interaction via Chat SDK

### DIFF
--- a/apps/docs/content/docs/plugins/interactions/chat.mdx
+++ b/apps/docs/content/docs/plugins/interactions/chat.mdx
@@ -28,8 +28,9 @@ bun add @useatlas/chat
 | Slack | `@chat-adapter/slack` | Stable |
 | Microsoft Teams | `@chat-adapter/teams` | Stable |
 | Discord | `@chat-adapter/discord` | Stable |
+| Google Chat | `@chat-adapter/gchat` | Stable |
 
-Stable adapters are bundled as dependencies of `@useatlas/chat` — no separate install needed. Additional platforms (Google Chat, Telegram, WhatsApp) are planned and will be supported as Chat SDK adapters are published.
+Stable adapters are bundled as dependencies of `@useatlas/chat` — no separate install needed. Additional platforms (Telegram, WhatsApp) are planned and will be supported as Chat SDK adapters are published.
 
 ## Configuration
 
@@ -96,6 +97,11 @@ export default defineConfig({
 | `adapters.discord.applicationId` | `string` | Yes* | Discord application ID. |
 | `adapters.discord.publicKey` | `string` | Yes* | 64-character hex string (Ed25519 public key from Discord Developer Portal). |
 | `adapters.discord.mentionRoleIds` | `string[]` | No | Role IDs that trigger mention handlers (in addition to direct @mentions). |
+| `adapters.gchat.credentials` | `object` | No* | Service account credentials (`client_email`, `private_key`, optional `project_id`). |
+| `adapters.gchat.useApplicationDefaultCredentials` | `true` | No* | Use Application Default Credentials. |
+| `adapters.gchat.endpointUrl` | `string` | No | HTTP endpoint URL for card button click actions. |
+| `adapters.gchat.pubsubTopic` | `string` | No | Pub/Sub topic for Workspace Events (`projects/{project}/topics/{topic}`). |
+| `adapters.gchat.impersonateUser` | `string` | No | User email for domain-wide delegation. |
 | `state` | `object` | No | State backend config (default: `{ backend: "memory" }`). |
 | `state.backend` | `"memory" \| "pg" \| "redis"` | No | State backend to use. Default: `"memory"`. |
 | `state.tablePrefix` | `string` | No | Table name prefix for PG backend. Must be a valid SQL identifier. Default: `"chat_"`. |
@@ -167,6 +173,7 @@ import { buildQueryResultCard } from "@useatlas/chat/cards";
 | `POST` | `/webhooks/slack` | Slack webhook (slash commands, events, interactions) |
 | `POST` | `/webhooks/teams` | Teams webhook (Bot Framework activities) |
 | `POST` | `/webhooks/discord` | Discord webhook (interactions, gateway events) |
+| `POST` | `/webhooks/gchat` | Google Chat webhook (@mentions, DMs, card clicks, Pub/Sub) |
 | `GET` | `/oauth/slack/install` | Slack OAuth install redirect (only when `clientId` configured) |
 | `GET` | `/oauth/slack/callback` | Slack OAuth callback (only when `clientId` configured) |
 
@@ -186,6 +193,10 @@ Routes are mounted under the plugin's base path (e.g., `/api/plugins/chat-intera
 | `DISCORD_BOT_TOKEN` | Discord bot token |
 | `DISCORD_APPLICATION_ID` | Discord application ID |
 | `DISCORD_PUBLIC_KEY` | Discord application public key (64-char hex, Ed25519) |
+| `GOOGLE_CHAT_CREDENTIALS` | Google Chat service account key JSON (stringified) |
+| `GOOGLE_CHAT_USE_ADC` | Set to `"true"` for Application Default Credentials |
+| `GOOGLE_CHAT_PUBSUB_TOPIC` | Pub/Sub topic for Workspace Events |
+| `GOOGLE_CHAT_IMPERSONATE_USER` | User email for domain-wide delegation |
 | `DATABASE_URL` | Required for `pg` state backend |
 
 ## Error Scrubbing
@@ -281,3 +292,4 @@ Routes return 503 if the plugin hasn't finished initializing. This is normal dur
 - [Plugin authoring guide](/plugins/authoring-guide)
 - [Slack plugin (deprecated)](/plugins/interactions/slack)
 - [Teams plugin (deprecated)](/plugins/interactions/teams)
+- [Google Chat bot setup](/plugins/interactions/gchat)

--- a/apps/docs/content/docs/plugins/interactions/gchat.mdx
+++ b/apps/docs/content/docs/plugins/interactions/gchat.mdx
@@ -1,0 +1,233 @@
+---
+title: Google Chat Bot
+description: Integrate Google Chat as an interaction surface for Atlas with @mentions, threaded conversations, and Google Chat Cards.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+The Google Chat interaction is provided via the [`@useatlas/chat`](/plugins/interactions/chat) Chat SDK bridge plugin. Users can @mention the bot in Google Chat spaces or send direct messages to query data. The bot replies with Google Chat Card v2 cards containing formatted query results, SQL, and data tables.
+
+The Chat SDK adapter supports two message delivery modes: direct webhooks (for @mentions, DMs, and card button clicks) and Pub/Sub via Workspace Events (for receiving all messages in a space).
+
+## Prerequisites
+
+- A Google Cloud project with the **Google Chat API** enabled
+- A service account with a JSON key file (or Application Default Credentials)
+- The Chat app configured in the [Google Cloud Console](https://console.cloud.google.com/apis/api/chat.googleapis.com)
+- For all-message delivery: a Pub/Sub topic and the **Google Workspace Events API** enabled
+
+## Google Cloud Console Setup
+
+### 1. Enable APIs
+
+1. Go to the [Google Cloud Console](https://console.cloud.google.com)
+2. Select or create a project
+3. Enable the **Google Chat API** (`chat.googleapis.com`)
+4. (Optional) Enable the **Google Workspace Events API** for all-message delivery
+
+### 2. Create a Service Account
+
+1. Go to **IAM & Admin** > **Service Accounts**
+2. Click **Create Service Account**
+3. Name it (e.g., "atlas-chat-bot")
+4. Click **Create and Continue**
+5. Click **Done** (no additional roles needed for basic Chat)
+6. Click on the service account, go to **Keys** > **Add Key** > **Create new key** > **JSON**
+7. Download the JSON key file
+
+<Callout type="warn">
+Store the service account key securely. It contains credentials that allow sending messages as the bot. Never commit it to source control.
+</Callout>
+
+### 3. Configure the Chat App
+
+1. Go to the [Google Chat API configuration](https://console.cloud.google.com/apis/api/chat.googleapis.com/hangouts-chat)
+2. Fill in the app details:
+   - **App name**: Atlas (or your preferred name)
+   - **Avatar URL**: Your bot avatar
+   - **Description**: Data analyst powered by Atlas
+3. Under **Functionality**, enable:
+   - **Receive 1:1 messages**
+   - **Join spaces and group conversations**
+4. Under **Connection settings**, select **HTTP endpoint URL** and set:
+
+```
+https://your-atlas-api.example.com/api/plugins/chat-interaction/webhooks/gchat
+```
+
+5. Under **Visibility**, configure who can install the app (your domain or public)
+6. Click **Save**
+
+### 4. Set Up Pub/Sub (Optional — For All Messages)
+
+By default, Google Chat only sends webhooks for @mentions and direct messages. To receive **all messages** in a space (not just @mentions), set up Workspace Events:
+
+1. Create a Pub/Sub topic in your GCP project:
+
+```bash
+gcloud pubsub topics create chat-events
+```
+
+2. Grant the Chat service account publish permissions:
+
+```bash
+gcloud pubsub topics add-iam-policy-binding chat-events \
+  --member="serviceAccount:chat-api-push@system.gserviceaccount.com" \
+  --role="roles/pubsub.publisher"
+```
+
+3. Create a push subscription pointing to your Atlas endpoint:
+
+```bash
+gcloud pubsub subscriptions create chat-events-push \
+  --topic=chat-events \
+  --push-endpoint="https://your-atlas-api.example.com/api/plugins/chat-interaction/webhooks/gchat"
+```
+
+4. Set the `pubsubTopic` in your Atlas config (see below)
+
+The adapter automatically creates Workspace Events subscriptions when added to a space.
+
+## Configuration
+
+### Basic (Service Account Credentials)
+
+```typescript
+import { defineConfig } from "@atlas/api/lib/config";
+import { executeAgentQuery } from "@atlas/api/lib/agent-query";
+import { chatPlugin } from "@useatlas/chat";
+
+export default defineConfig({
+  plugins: [
+    chatPlugin({
+      adapters: {
+        gchat: {
+          credentials: JSON.parse(process.env.GOOGLE_CHAT_CREDENTIALS!),
+        },
+      },
+      executeQuery: executeAgentQuery,
+    }),
+  ],
+});
+```
+
+### Application Default Credentials
+
+Use ADC when running on GCE, Cloud Run, or with Workload Identity Federation:
+
+```typescript
+chatPlugin({
+  adapters: {
+    gchat: {
+      useApplicationDefaultCredentials: true,
+    },
+  },
+  executeQuery: executeAgentQuery,
+})
+```
+
+### Full Configuration (With Pub/Sub)
+
+```typescript
+chatPlugin({
+  adapters: {
+    gchat: {
+      credentials: JSON.parse(process.env.GOOGLE_CHAT_CREDENTIALS!),
+      endpointUrl: "https://your-atlas-api.example.com/api/plugins/chat-interaction/webhooks/gchat",
+      pubsubTopic: "projects/my-project/topics/chat-events",
+      impersonateUser: "admin@example.com",
+    },
+  },
+  executeQuery: executeAgentQuery,
+})
+```
+
+### Options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `credentials` | `object` | No* | Service account credentials (`client_email`, `private_key`, optional `project_id`). |
+| `useApplicationDefaultCredentials` | `true` | No* | Use Application Default Credentials (GCE, Cloud Run, Workload Identity). |
+| `endpointUrl` | `string` | No | HTTP endpoint URL for card button click actions. Required for interactive cards. |
+| `pubsubTopic` | `string` | No | Pub/Sub topic for Workspace Events (format: `projects/{project}/topics/{topic}`). |
+| `impersonateUser` | `string` | No | User email to impersonate for Workspace Events API (domain-wide delegation). |
+
+<Callout type="info">
+\* Provide `credentials` OR `useApplicationDefaultCredentials`, or omit both for automatic detection from `GOOGLE_CHAT_CREDENTIALS` and `GOOGLE_CHAT_USE_ADC` environment variables.
+</Callout>
+
+## Mounted Routes
+
+The Chat SDK bridge mounts the following route for Google Chat:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/webhooks/gchat` | Google Chat webhook — receives @mentions, DMs, card button clicks, and Pub/Sub messages |
+
+## How It Works
+
+### @Mentions
+1. A user @mentions the bot in a Google Chat space
+2. Google sends a webhook event to the `/webhooks/gchat` endpoint
+3. The Chat SDK subscribes the thread for follow-up messages
+4. The `executeQuery` callback runs the Atlas agent
+5. Results are posted as a reply with Google Chat Card v2 formatting
+
+### Direct Messages
+1. A user sends a direct message to the bot
+2. The message is received via the webhook endpoint
+3. The `executeQuery` callback runs the Atlas agent
+4. Results are posted as a reply in the DM
+
+### Threaded Follow-ups
+1. After an initial response, the thread is subscribed via the Chat SDK state adapter
+2. With Pub/Sub + Workspace Events: follow-up messages in the thread trigger new queries with conversation history
+3. Without Pub/Sub: only @mentions in the thread are received
+
+### AI Streaming
+Google Chat doesn't support true message streaming. The adapter uses a post-then-edit pattern: an initial message is posted immediately, then progressively edited with new content as the response streams in.
+
+### Card Button Clicks
+When a response includes approval buttons (e.g., for pending actions), button clicks are routed back to the webhook endpoint. The `endpointUrl` config is required for this to work with HTTP endpoint apps.
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `GOOGLE_CHAT_CREDENTIALS` | Service account key JSON (stringified). Parsed with `JSON.parse()`. |
+| `GOOGLE_CHAT_USE_ADC` | Set to `"true"` for Application Default Credentials. |
+| `GOOGLE_CHAT_PUBSUB_TOPIC` | Pub/Sub topic for Workspace Events (fallback if not in config). |
+| `GOOGLE_CHAT_IMPERSONATE_USER` | User email for domain-wide delegation (fallback if not in config). |
+
+## Troubleshooting
+
+### Bot not responding to messages
+
+1. Verify the Chat app HTTP endpoint URL points to your Atlas API's `/webhooks/gchat` route
+2. Check that the Google Chat API is enabled in your GCP project
+3. Ensure the service account credentials are valid and have the correct permissions
+4. Check Atlas logs for initialization errors
+
+### Card button clicks not working
+
+The `endpointUrl` must be set in your config for HTTP endpoint apps. Button clicks are routed to this URL with action parameters. Ensure the URL matches your actual webhook endpoint.
+
+### Not receiving all messages (only @mentions)
+
+By default, Google Chat only sends @mentions and DMs to webhook endpoints. To receive all messages in a space:
+
+1. Set up Pub/Sub with Workspace Events (see setup instructions above)
+2. Configure `pubsubTopic` in your Atlas config
+3. The adapter automatically creates subscriptions when added to a space
+
+### Authentication errors
+
+- **Service Account**: Verify the JSON key contains valid `client_email` and `private_key` fields
+- **ADC**: Ensure `GOOGLE_APPLICATION_CREDENTIALS` points to a valid key file, or you're running on a GCP service with default credentials
+- **Impersonation**: The service account needs domain-wide delegation configured in Google Workspace Admin
+
+### Workspace Events subscription failures
+
+1. Ensure the **Google Workspace Events API** is enabled
+2. The Pub/Sub topic must exist and have publish permissions for `chat-api-push@system.gserviceaccount.com`
+3. If using impersonation, the impersonated user must have access to the target spaces

--- a/apps/docs/content/docs/plugins/interactions/meta.json
+++ b/apps/docs/content/docs/plugins/interactions/meta.json
@@ -8,6 +8,7 @@
     "slack",
     "teams",
     "discord",
+    "gchat",
     "webhook"
   ]
 }

--- a/apps/docs/content/docs/roadmap.mdx
+++ b/apps/docs/content/docs/roadmap.mdx
@@ -103,7 +103,7 @@ The current milestone. Platform foundation for hosted Atlas at app.useatlas.dev.
 - **Enterprise auth** — `/ee` directory structure (shipped), SAML/OIDC SSO (shipped), SSO enforcement (shipped), IP allowlisting (shipped), custom roles (shipped), tenant-level model routing (shipped), SCIM directory sync (shipped)
 - **Compliance** — Audit log retention with auto-purge and compliance export (shipped), approval workflows for sensitive queries with admin approve/deny UI (shipped), PII detection and column masking with role-based rules and admin UI (shipped), compliance reporting (shipped)
 - **Branding** — White-labeling with custom logo, colors, favicon, and conditional Atlas branding (shipped)
-- **Integrations** — Chat SDK bridge plugin with persistent state adapters (PG, memory) for unified chat platform interactions (shipped), Slack migration to Chat SDK adapter (shipped), Teams migration to Chat SDK adapter (shipped), Discord interaction via Chat SDK (shipped), unified JSX cards for query results across all chat platforms (shipped)
+- **Integrations** — Chat SDK bridge plugin with persistent state adapters (PG, memory) for unified chat platform interactions (shipped), Slack migration to Chat SDK adapter (shipped), Teams migration to Chat SDK adapter (shipped), Discord interaction via Chat SDK (shipped), Google Chat interaction via Chat SDK (shipped), unified JSX cards for query results across all chat platforms (shipped)
 - **Platform ops** — SLA monitoring (shipped), abuse prevention (shipped), platform admin console (shipped), automated backups & disaster recovery (shipped)
 - **Onboarding** — Interactive demo mode (shipped), in-app guided tour (shipped), email sequence (shipped)
 

--- a/bun.lock
+++ b/bun.lock
@@ -348,6 +348,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@chat-adapter/discord": "4.20.2",
+        "@chat-adapter/gchat": "4.20.2",
         "@chat-adapter/slack": "4.20.2",
         "@chat-adapter/state-memory": "4.20.2",
         "@chat-adapter/teams": "4.20.2",
@@ -900,6 +901,8 @@
 
     "@chat-adapter/discord": ["@chat-adapter/discord@4.20.2", "", { "dependencies": { "@chat-adapter/shared": "4.20.2", "chat": "4.20.2", "discord-api-types": "^0.37.119", "discord-interactions": "^4.4.0", "discord.js": "^14.25.1" } }, "sha512-hA9kKLpfyxmJdgIpldFy64aPc6/3iPQySW/GtfDfDTuUVsAYm9lw5UlW90RNciwLgIL9sqqZLsQ4wJmM4PeJfQ=="],
 
+    "@chat-adapter/gchat": ["@chat-adapter/gchat@4.20.2", "", { "dependencies": { "@chat-adapter/shared": "4.20.2", "@googleapis/chat": "^44.6.0", "@googleapis/workspaceevents": "^9.1.0", "chat": "4.20.2" } }, "sha512-4Bsj1B61yrOJprkNsm3ewXTFsYYC0cmvoWwvffFu1V2QmoJ2VMeNO1FFtDEXlmBIFf7Mibyon/KmOuhMHlQjjA=="],
+
     "@chat-adapter/shared": ["@chat-adapter/shared@4.20.2", "", { "dependencies": { "chat": "4.20.2" } }, "sha512-cTtTVHgH/2l9/+ILSExCr/kZwzz2Y8tp7WKRweMRWFOBcXZ0U5ZtviZCCDWBqU/YOBilQUgON8vIP9eo1w0m5w=="],
 
     "@chat-adapter/slack": ["@chat-adapter/slack@4.20.2", "", { "dependencies": { "@chat-adapter/shared": "4.20.2", "@slack/web-api": "^7.14.0", "chat": "4.20.2" } }, "sha512-DCGMdB5sLG7lJ8TTv6zHUC3GQXfW3zWXLv+w5sRc+Km0Rq4tG43vLMmcCAd3AEj2Bjhl0bnWjhkTwR7txlu7TQ=="],
@@ -1075,6 +1078,10 @@
     "@google-cloud/promisify": ["@google-cloud/promisify@4.0.0", "", {}, "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g=="],
 
     "@google-cloud/storage": ["@google-cloud/storage@7.19.0", "", { "dependencies": { "@google-cloud/paginator": "^5.0.0", "@google-cloud/projectify": "^4.0.0", "@google-cloud/promisify": "<4.1.0", "abort-controller": "^3.0.0", "async-retry": "^1.3.3", "duplexify": "^4.1.3", "fast-xml-parser": "^5.3.4", "gaxios": "^6.0.2", "google-auth-library": "^9.6.3", "html-entities": "^2.5.2", "mime": "^3.0.0", "p-limit": "^3.0.1", "retry-request": "^7.0.0", "teeny-request": "^9.0.0", "uuid": "^8.0.0" } }, "sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ=="],
+
+    "@googleapis/chat": ["@googleapis/chat@44.6.0", "", { "dependencies": { "googleapis-common": "^8.0.0" } }, "sha512-Bnqzev/bSTXSbE0/N2WS4Stnleo8j9bJJ1LkCBk1fXQnehcArVMv7q543rzPYU6MJql4D34On6diNGAuYtI9xQ=="],
+
+    "@googleapis/workspaceevents": ["@googleapis/workspaceevents@9.1.0", "", { "dependencies": { "googleapis-common": "^8.0.0" } }, "sha512-aJiMrTi/YyUUaaTO0tnhTHDYU+N9CTD3l3FSfe0yzEHQl7DEc+1LISgdK1o2nurvCtguBEumify5kTkr6Cg5eA=="],
 
     "@grpc/grpc-js": ["@grpc/grpc-js@1.14.3", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="],
 
@@ -2618,6 +2625,8 @@
 
     "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
+    "googleapis-common": ["googleapis-common@8.0.1", "", { "dependencies": { "extend": "^3.0.2", "gaxios": "^7.0.0-rc.4", "google-auth-library": "^10.1.0", "qs": "^6.7.0", "url-template": "^2.0.8" } }, "sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A=="],
+
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
@@ -3744,6 +3753,8 @@
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
+    "url-template": ["url-template@2.0.8", "", {}, "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="],
+
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
 
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
@@ -4078,6 +4089,8 @@
 
     "google-auth-library/gaxios": ["gaxios@7.1.3", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2", "rimraf": "^5.0.1" } }, "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ=="],
 
+    "googleapis-common/gaxios": ["gaxios@7.1.3", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2", "rimraf": "^5.0.1" } }, "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ=="],
+
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "inquirer/ora": ["ora@5.4.1", "", { "dependencies": { "bl": "^4.1.0", "chalk": "^4.1.0", "cli-cursor": "^3.1.0", "cli-spinners": "^2.5.0", "is-interactive": "^1.0.0", "is-unicode-supported": "^0.1.0", "log-symbols": "^4.1.0", "strip-ansi": "^6.0.0", "wcwidth": "^1.0.1" } }, "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ=="],
@@ -4320,6 +4333,10 @@
 
     "google-auth-library/gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
+    "googleapis-common/gaxios/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "googleapis-common/gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
     "inquirer/ora/is-interactive": ["is-interactive@1.0.0", "", {}, "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="],
 
     "inquirer/ora/is-unicode-supported": ["is-unicode-supported@0.1.0", "", {}, "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="],
@@ -4469,6 +4486,8 @@
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "google-auth-library/gaxios/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "googleapis-common/gaxios/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "ora/cli-cursor/restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
   }

--- a/plugins/chat/package.json
+++ b/plugins/chat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useatlas/chat",
   "version": "0.0.1",
-  "description": "Atlas Chat SDK bridge plugin — unified interaction layer for Slack, Teams, Discord, and more",
+  "description": "Atlas Chat SDK bridge plugin — unified interaction layer for Slack, Teams, Discord, Google Chat, and more",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
@@ -31,7 +31,9 @@
     "chat",
     "slack",
     "teams",
-    "discord"
+    "discord",
+    "gchat",
+    "google-chat"
   ],
   "repository": {
     "type": "git",
@@ -44,11 +46,12 @@
   },
   "license": "MIT",
   "dependencies": {
-    "chat": "4.20.2",
-    "@chat-adapter/slack": "4.20.2",
-    "@chat-adapter/teams": "4.20.2",
     "@chat-adapter/discord": "4.20.2",
-    "@chat-adapter/state-memory": "4.20.2"
+    "@chat-adapter/gchat": "4.20.2",
+    "@chat-adapter/slack": "4.20.2",
+    "@chat-adapter/state-memory": "4.20.2",
+    "@chat-adapter/teams": "4.20.2",
+    "chat": "4.20.2"
   },
   "peerDependencies": {
     "hono": "^4.0.0",

--- a/plugins/chat/src/adapters/gchat.ts
+++ b/plugins/chat/src/adapters/gchat.ts
@@ -1,0 +1,42 @@
+/**
+ * Google Chat adapter configuration for the Chat SDK bridge.
+ *
+ * Thin wrapper around `@chat-adapter/gchat`'s `createGoogleChatAdapter()` for
+ * import isolation. Maps Atlas config fields to Chat SDK adapter config.
+ * The Chat SDK adapter handles Google Chat event parsing, Card v2 formatting,
+ * service account authentication, and Workspace Events subscriptions internally.
+ */
+
+import { createGoogleChatAdapter as createChatGoogleChatAdapter } from "@chat-adapter/gchat";
+import type { GoogleChatAdapterConfig as UpstreamConfig } from "@chat-adapter/gchat";
+import type { GoogleChatAdapterConfig } from "../config";
+
+/**
+ * Create a Chat SDK Google Chat adapter from Atlas plugin config.
+ *
+ * The Chat SDK adapter authenticates via service account credentials (JSON key)
+ * or Application Default Credentials. When `pubsubTopic` is configured, the
+ * adapter automatically creates Workspace Events subscriptions to receive all
+ * messages (not just @mentions).
+ */
+export function createGoogleChatAdapter(config: GoogleChatAdapterConfig) {
+  // The upstream config is a discriminated union — build the right variant
+  // based on which auth fields are provided.
+  const base = {
+    endpointUrl: config.endpointUrl,
+    pubsubTopic: config.pubsubTopic,
+    impersonateUser: config.impersonateUser,
+  };
+
+  let upstreamConfig: UpstreamConfig;
+  if (config.credentials) {
+    upstreamConfig = { ...base, credentials: config.credentials };
+  } else if (config.useApplicationDefaultCredentials) {
+    upstreamConfig = { ...base, useApplicationDefaultCredentials: true };
+  } else {
+    // Auto-detect from env vars (GOOGLE_CHAT_CREDENTIALS / GOOGLE_CHAT_USE_ADC)
+    upstreamConfig = base;
+  }
+
+  return createChatGoogleChatAdapter(upstreamConfig);
+}

--- a/plugins/chat/src/bridge.test.ts
+++ b/plugins/chat/src/bridge.test.ts
@@ -1557,3 +1557,408 @@ describe("chat plugin three-adapter lifecycle", () => {
     expect(result.message).toContain("discord");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Google Chat adapter config validation
+// ---------------------------------------------------------------------------
+
+describe("chatPlugin Google Chat adapter config", () => {
+  const mockExecuteQueryFn = async () => ({
+    answer: "test",
+    sql: [] as string[],
+    data: [] as { columns: string[]; rows: Record<string, unknown>[] }[],
+    steps: 1,
+    usage: { totalTokens: 10 },
+  });
+
+  it("accepts valid config with gchat adapter (no credentials — env auto-detect)", async () => {
+    const { chatPlugin } = await import("./index");
+
+    const plugin = chatPlugin({
+      adapters: {
+        gchat: {},
+      },
+      executeQuery: mockExecuteQueryFn,
+    });
+
+    expect(plugin.id).toBe("chat-interaction");
+    expect(plugin.types).toEqual(["interaction"]);
+    expect(plugin.version).toBe("0.2.0");
+  });
+
+  it("accepts gchat config with service account credentials", async () => {
+    const { chatPlugin } = await import("./index");
+
+    const plugin = chatPlugin({
+      adapters: {
+        gchat: {
+          credentials: {
+            client_email: "bot@my-project.iam.gserviceaccount.com",
+            private_key: "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----\n",
+          },
+        },
+      },
+      executeQuery: mockExecuteQueryFn,
+    });
+
+    expect(plugin.id).toBe("chat-interaction");
+  });
+
+  it("accepts gchat config with ADC", async () => {
+    const { chatPlugin } = await import("./index");
+
+    const plugin = chatPlugin({
+      adapters: {
+        gchat: {
+          useApplicationDefaultCredentials: true,
+        },
+      },
+      executeQuery: mockExecuteQueryFn,
+    });
+
+    expect(plugin.id).toBe("chat-interaction");
+  });
+
+  it("accepts gchat config with pubsubTopic and endpointUrl", async () => {
+    const { chatPlugin } = await import("./index");
+
+    const plugin = chatPlugin({
+      adapters: {
+        gchat: {
+          credentials: {
+            client_email: "bot@my-project.iam.gserviceaccount.com",
+            private_key: "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----\n",
+          },
+          endpointUrl: "https://my-atlas.example.com/api/plugins/chat-interaction/webhooks/gchat",
+          pubsubTopic: "projects/my-project/topics/chat-events",
+          impersonateUser: "admin@example.com",
+        },
+      },
+      executeQuery: mockExecuteQueryFn,
+    });
+
+    expect(plugin.id).toBe("chat-interaction");
+  });
+
+  it("rejects gchat config with invalid pubsubTopic format", async () => {
+    const { chatPlugin } = await import("./index");
+
+    expect(() =>
+      chatPlugin({
+        adapters: {
+          gchat: {
+            pubsubTopic: "invalid-topic",
+          },
+        },
+        executeQuery: mockExecuteQueryFn,
+      }),
+    ).toThrow(/pubsubTopic/i);
+  });
+
+  it("rejects gchat config with invalid endpointUrl", async () => {
+    const { chatPlugin } = await import("./index");
+
+    expect(() =>
+      chatPlugin({
+        adapters: {
+          gchat: {
+            endpointUrl: "not-a-url",
+          },
+        },
+        executeQuery: mockExecuteQueryFn,
+      }),
+    ).toThrow(/endpointUrl/i);
+  });
+
+  it("rejects gchat config with invalid impersonateUser email", async () => {
+    const { chatPlugin } = await import("./index");
+
+    expect(() =>
+      chatPlugin({
+        adapters: {
+          gchat: {
+            impersonateUser: "not-an-email",
+          },
+        },
+        executeQuery: mockExecuteQueryFn,
+      }),
+    ).toThrow(/impersonateUser/i);
+  });
+
+  it("rejects gchat credentials with empty private_key", async () => {
+    const { chatPlugin } = await import("./index");
+
+    expect(() =>
+      chatPlugin({
+        adapters: {
+          gchat: {
+            credentials: {
+              client_email: "bot@my-project.iam.gserviceaccount.com",
+              private_key: "",
+            },
+          },
+        },
+        executeQuery: mockExecuteQueryFn,
+      }),
+    ).toThrow(/private_key/i);
+  });
+
+  it("rejects gchat credentials with invalid client_email", async () => {
+    const { chatPlugin } = await import("./index");
+
+    expect(() =>
+      chatPlugin({
+        adapters: {
+          gchat: {
+            credentials: {
+              client_email: "not-an-email",
+              private_key: "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----\n",
+            },
+          },
+        },
+        executeQuery: mockExecuteQueryFn,
+      }),
+    ).toThrow(/client_email/i);
+  });
+
+  it("rejects gchat config with both credentials and ADC", async () => {
+    const { chatPlugin } = await import("./index");
+
+    expect(() =>
+      chatPlugin({
+        adapters: {
+          gchat: {
+            credentials: {
+              client_email: "bot@test.iam.gserviceaccount.com",
+              private_key: "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----\n",
+            },
+            useApplicationDefaultCredentials: true,
+          },
+        },
+        executeQuery: mockExecuteQueryFn,
+      }),
+    ).toThrow(/not both/i);
+  });
+
+  it("accepts config with all four adapters", async () => {
+    const { chatPlugin } = await import("./index");
+
+    const plugin = chatPlugin({
+      adapters: {
+        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        teams: { appId: "test-app-id", appPassword: "test-app-password" },
+        discord: {
+          botToken: "test-bot-token",
+          applicationId: "test-app-id",
+          publicKey: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+        },
+        gchat: {},
+      },
+      executeQuery: mockExecuteQueryFn,
+    });
+
+    expect(plugin.id).toBe("chat-interaction");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Google Chat adapter factory
+// ---------------------------------------------------------------------------
+
+describe("createGoogleChatAdapter", () => {
+  it("creates adapter with correct name", async () => {
+    const { createGoogleChatAdapter: createAdapter } = await import("./adapters/gchat");
+
+    const adapter = createAdapter({ credentials: testGchatCredentials });
+    expect(adapter).toBeDefined();
+    expect(adapter.name).toBe("gchat");
+  });
+
+  it("creates adapter with full config", async () => {
+    const { createGoogleChatAdapter: createAdapter } = await import("./adapters/gchat");
+
+    const adapter = createAdapter({
+      credentials: testGchatCredentials,
+      endpointUrl: "https://example.com/api/webhooks/gchat",
+      pubsubTopic: "projects/my-project/topics/chat-events",
+    });
+    expect(adapter).toBeDefined();
+    expect(adapter.name).toBe("gchat");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Google Chat webhook route guard
+// ---------------------------------------------------------------------------
+
+// Dummy service account credentials for test adapter construction.
+// The adapter validates credential shape but doesn't make API calls during tests.
+const testGchatCredentials = {
+  client_email: "bot@test-project.iam.gserviceaccount.com",
+  private_key: "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJBALRiMLAH\n-----END RSA PRIVATE KEY-----\n",
+  project_id: "test-project",
+};
+
+describe("gchat webhook route guard", () => {
+  it("gchat webhook returns 503 before initialization", async () => {
+    const { buildChatPlugin } = require("./index");
+    const { Hono } = require("hono");
+
+    const plugin = buildChatPlugin({
+      adapters: {
+        gchat: { credentials: testGchatCredentials },
+      },
+      executeQuery: async () => ({
+        answer: "test",
+        sql: [],
+        data: [],
+        steps: 1,
+        usage: { totalTokens: 10 },
+      }),
+    });
+
+    const app = new Hono();
+    plugin.routes!(app);
+
+    const resp = await app.request("/webhooks/gchat", { method: "POST" });
+    expect(resp.status).toBe(503);
+    const body = await resp.json();
+    expect(body.error).toContain("not yet initialized");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Google Chat adapter lifecycle
+// ---------------------------------------------------------------------------
+
+describe("chat plugin Google Chat lifecycle", () => {
+  function createGchatTestPlugin() {
+    const { buildChatPlugin } = require("./index");
+    return buildChatPlugin({
+      adapters: {
+        gchat: { credentials: testGchatCredentials },
+      },
+      executeQuery: async () => ({
+        answer: "test answer",
+        sql: ["SELECT 1"],
+        data: [],
+        steps: 1,
+        usage: { totalTokens: 50 },
+      }),
+    });
+  }
+
+  it("healthCheck returns unhealthy before initialization", async () => {
+    const plugin = createGchatTestPlugin();
+    const result = await plugin.healthCheck!();
+    expect(result.healthy).toBe(false);
+    expect(result.message).toContain("not initialized");
+  });
+
+  it("initialize sets up the bridge with gchat adapter", async () => {
+    const plugin = createGchatTestPlugin();
+    const logs: string[] = [];
+
+    await plugin.initialize!({
+      db: null,
+      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
+      tools: { register: () => {} },
+      logger: {
+        info: (msg: unknown) => logs.push(typeof msg === "string" ? msg : JSON.stringify(msg)),
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
+      config: {},
+    });
+
+    const result = await plugin.healthCheck!();
+    expect(result.healthy).toBe(true);
+    expect(result.message).toContain("gchat");
+  });
+
+  it("teardown cleans up gchat adapter", async () => {
+    const plugin = createGchatTestPlugin();
+
+    await plugin.initialize!({
+      db: null,
+      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
+      tools: { register: () => {} },
+      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+      config: {},
+    });
+
+    await plugin.teardown!();
+
+    const result = await plugin.healthCheck!();
+    expect(result.healthy).toBe(false);
+  });
+
+  it("double initialize throws with gchat adapter", async () => {
+    const plugin = createGchatTestPlugin();
+    const ctx = {
+      db: null,
+      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
+      tools: { register: () => {} },
+      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+      config: {},
+    };
+
+    await plugin.initialize!(ctx);
+    await expect(plugin.initialize!(ctx)).rejects.toThrow(/already initialized/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multi-adapter lifecycle (all four adapters)
+// ---------------------------------------------------------------------------
+
+describe("chat plugin four-adapter lifecycle", () => {
+  function createQuadAdapterPlugin() {
+    const { buildChatPlugin } = require("./index");
+    return buildChatPlugin({
+      adapters: {
+        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        teams: { appId: "test-app-id", appPassword: "test-app-password" },
+        discord: {
+          botToken: "test-bot-token",
+          applicationId: "test-app-id",
+          publicKey: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+        },
+        gchat: { credentials: testGchatCredentials },
+      },
+      executeQuery: async () => ({
+        answer: "test answer",
+        sql: ["SELECT 1"],
+        data: [],
+        steps: 1,
+        usage: { totalTokens: 50 },
+      }),
+    });
+  }
+
+  it("initializes with all four adapters", async () => {
+    const plugin = createQuadAdapterPlugin();
+    const logs: string[] = [];
+
+    await plugin.initialize!({
+      db: null,
+      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
+      tools: { register: () => {} },
+      logger: {
+        info: (msg: unknown) => logs.push(typeof msg === "string" ? msg : JSON.stringify(msg)),
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
+      config: {},
+    });
+
+    const result = await plugin.healthCheck!();
+    expect(result.healthy).toBe(true);
+    expect(result.message).toContain("slack");
+    expect(result.message).toContain("teams");
+    expect(result.message).toContain("discord");
+    expect(result.message).toContain("gchat");
+  });
+});

--- a/plugins/chat/src/bridge.ts
+++ b/plugins/chat/src/bridge.ts
@@ -330,7 +330,7 @@ export function createChatBridge(
   config: ChatPluginConfig,
   log: PluginLogger,
   stateAdapter: StateAdapter,
-  adapterInstances: { slack?: Adapter | null; teams?: Adapter | null; discord?: Adapter | null },
+  adapterInstances: { slack?: Adapter | null; teams?: Adapter | null; discord?: Adapter | null; gchat?: Adapter | null },
 ): ChatBridge {
   // Build adapters dict from pre-built instances
   const adapters: Record<string, Adapter> = {};
@@ -345,6 +345,10 @@ export function createChatBridge(
   if (adapterInstances.discord) {
     adapters.discord = adapterInstances.discord;
     log.info("Discord adapter configured");
+  }
+  if (adapterInstances.gchat) {
+    adapters.gchat = adapterInstances.gchat;
+    log.info("Google Chat adapter configured");
   }
 
   const chat = new Chat({

--- a/plugins/chat/src/config.ts
+++ b/plugins/chat/src/config.ts
@@ -68,6 +68,26 @@ export interface DiscordAdapterConfig {
   mentionRoleIds?: string[];
 }
 
+/** Google Chat adapter credential configuration. */
+export interface GoogleChatAdapterConfig {
+  /** Service account credentials JSON (client_email + private_key). */
+  credentials?: {
+    client_email: string;
+    private_key: string;
+    project_id?: string;
+  };
+  /** Use Application Default Credentials instead of explicit credentials. */
+  useApplicationDefaultCredentials?: true;
+  /** HTTP endpoint URL for button click actions (card interactions). */
+  endpointUrl?: string;
+  /** Pub/Sub topic for receiving all messages via Workspace Events.
+   * Format: "projects/my-project/topics/my-topic".
+   * When set, the adapter receives all messages, not just @mentions. */
+  pubsubTopic?: string;
+  /** User email to impersonate for Workspace Events API (domain-wide delegation). */
+  impersonateUser?: string;
+}
+
 /** State backend configuration. */
 export interface StateConfig {
   /** Which state backend to use. Default: "memory" */
@@ -124,6 +144,7 @@ export interface ChatPluginConfig {
     slack?: SlackAdapterConfig;
     teams?: TeamsAdapterConfig;
     discord?: DiscordAdapterConfig;
+    gchat?: GoogleChatAdapterConfig;
   };
 
   /** State backend configuration. Default: { backend: "memory" } */
@@ -178,6 +199,24 @@ const DiscordAdapterSchema = z.object({
   mentionRoleIds: z.array(z.string().min(1)).optional(),
 });
 
+const GoogleChatAdapterSchema = z.object({
+  credentials: z.object({
+    client_email: z.string().email("gchat credentials.client_email must be a valid email"),
+    private_key: z.string().min(1, "gchat credentials.private_key must not be empty"),
+    project_id: z.string().min(1).optional(),
+  }).optional(),
+  useApplicationDefaultCredentials: z.literal(true).optional(),
+  endpointUrl: z.string().url("gchat endpointUrl must be a valid URL").optional(),
+  pubsubTopic: z.string().regex(
+    /^projects\/[^/]+\/topics\/[^/]+$/,
+    "gchat pubsubTopic must be in format 'projects/{project}/topics/{topic}'",
+  ).optional(),
+  impersonateUser: z.string().email("gchat impersonateUser must be a valid email").optional(),
+}).refine(
+  (c) => !(c.credentials != null && c.useApplicationDefaultCredentials === true),
+  "Provide either credentials or useApplicationDefaultCredentials, not both (or omit both for env-var auto-detection)",
+);
+
 const StateConfigSchema = z
   .object({
     backend: z.enum(["memory", "pg", "redis"]).default("memory"),
@@ -195,6 +234,7 @@ export const ChatConfigSchema = z.object({
       slack: SlackAdapterSchema.optional(),
       teams: TeamsAdapterSchema.optional(),
       discord: DiscordAdapterSchema.optional(),
+      gchat: GoogleChatAdapterSchema.optional(),
     })
     .strict()
     .refine(

--- a/plugins/chat/src/index.ts
+++ b/plugins/chat/src/index.ts
@@ -2,8 +2,8 @@
  * Atlas Chat SDK Bridge Plugin.
  *
  * Bridges vercel/chat (Chat SDK) into the Atlas plugin system as a unified
- * interaction layer. Supports Slack, Teams, and Discord; additional platforms
- * will be added as Chat SDK adapters in follow-up issues.
+ * interaction layer. Supports Slack, Teams, Discord, and Google Chat;
+ * additional platforms will be added as Chat SDK adapters in follow-up issues.
  *
  * Replaces the standalone `@useatlas/slack` and `@useatlas/teams` plugins
  * with a unified Chat SDK adapter approach. See the migration guide in README.md.
@@ -30,6 +30,9 @@
  *           applicationId: process.env.DISCORD_APPLICATION_ID!,
  *           publicKey: process.env.DISCORD_PUBLIC_KEY!,
  *         },
+ *         gchat: {
+ *           credentials: JSON.parse(process.env.GOOGLE_CHAT_CREDENTIALS!),
+ *         },
  *       },
  *       executeQuery: myQueryFunction,
  *     }),
@@ -42,6 +45,7 @@ import type { StateAdapter } from "chat";
 import type { SlackAdapter } from "@chat-adapter/slack";
 import type { TeamsAdapter } from "@chat-adapter/teams";
 import type { DiscordAdapter } from "@chat-adapter/discord";
+import type { GoogleChatAdapter } from "@chat-adapter/gchat";
 import { createPlugin } from "@useatlas/plugin-sdk";
 import type {
   AtlasInteractionPlugin,
@@ -56,6 +60,7 @@ import type { ChatBridge } from "./bridge";
 import { createSlackAdapter } from "./adapters/slack";
 import { createTeamsAdapter } from "./adapters/teams";
 import { createDiscordAdapter } from "./adapters/discord";
+import { createGoogleChatAdapter } from "./adapters/gchat";
 import { createStateAdapter } from "./state";
 
 // Re-export types for host wiring convenience
@@ -70,6 +75,7 @@ export type {
   SlackAdapterConfig,
   TeamsAdapterConfig,
   DiscordAdapterConfig,
+  GoogleChatAdapterConfig,
 } from "./config";
 export type { ChatBridge } from "./bridge";
 export { createStateAdapter } from "./state";
@@ -95,6 +101,7 @@ function buildChatPlugin(
   let slackAdapterInstance: SlackAdapter | null = null;
   let teamsAdapterInstance: TeamsAdapter | null = null;
   let discordAdapterInstance: DiscordAdapter | null = null;
+  let gchatAdapterInstance: GoogleChatAdapter | null = null;
   let log: PluginLogger | null = null;
   let initialized = false;
 
@@ -295,6 +302,40 @@ function buildChatPlugin(
           }
         });
       }
+
+      if (config.adapters.gchat) {
+        app.post("/webhooks/gchat", async (c) => {
+          if (!bridge) {
+            return c.json({ error: "Chat plugin not yet initialized" }, 503);
+          }
+
+          const handler = bridge.webhooks.gchat;
+          if (!handler) {
+            return c.json({ error: "Google Chat adapter not configured" }, 404);
+          }
+
+          try {
+            const response = await handler(c.req.raw, {
+              waitUntil: (task: Promise<unknown>) => {
+                task.catch((err: unknown) => {
+                  (log ?? console).error(
+                    { err: err instanceof Error ? err : new Error(String(err)) },
+                    "Chat SDK Google Chat webhook background task failed",
+                  );
+                });
+              },
+            });
+            return response;
+          } catch (err) {
+            const requestId = crypto.randomUUID();
+            (log ?? console).error(
+              { err: err instanceof Error ? err : new Error(String(err)), requestId },
+              "Google Chat webhook handler threw unexpectedly",
+            );
+            return c.json({ error: "Webhook processing failed", requestId }, 500);
+          }
+        });
+      }
     },
 
     async initialize(ctx: AtlasPluginContext) {
@@ -319,6 +360,7 @@ function buildChatPlugin(
         slack?: SlackAdapter | null;
         teams?: TeamsAdapter | null;
         discord?: DiscordAdapter | null;
+        gchat?: GoogleChatAdapter | null;
       } = {};
       try {
         if (config.adapters.slack) {
@@ -332,6 +374,10 @@ function buildChatPlugin(
         if (config.adapters.discord) {
           discordAdapterInstance = createDiscordAdapter(config.adapters.discord) as DiscordAdapter;
           adapterInstances.discord = discordAdapterInstance;
+        }
+        if (config.adapters.gchat) {
+          gchatAdapterInstance = createGoogleChatAdapter(config.adapters.gchat) as GoogleChatAdapter;
+          adapterInstances.gchat = gchatAdapterInstance;
         }
 
         bridge = createChatBridge(config, ctx.logger, stateAdapter, adapterInstances);
@@ -353,6 +399,7 @@ function buildChatPlugin(
         slackAdapterInstance = null;
         teamsAdapterInstance = null;
         discordAdapterInstance = null;
+        gchatAdapterInstance = null;
         throw err;
       }
 
@@ -437,6 +484,7 @@ function buildChatPlugin(
       slackAdapterInstance = null;
       teamsAdapterInstance = null;
       discordAdapterInstance = null;
+      gchatAdapterInstance = null;
       log = null;
       initialized = false;
     },
@@ -457,6 +505,7 @@ function buildChatPlugin(
  *     slack: { botToken: "xoxb-...", signingSecret: "..." },
  *     teams: { appId: "...", appPassword: "..." },
  *     discord: { botToken: "...", applicationId: "...", publicKey: "..." },
+ *     gchat: { credentials: { client_email: "...", private_key: "..." } },
  *   },
  *   executeQuery: myQueryFunction,
  * })]


### PR DESCRIPTION
## Summary

- Add Google Chat as the fourth adapter in `@useatlas/chat` bridge plugin (#762)
- Thin wrapper around `@chat-adapter/gchat` — supports service account credentials, ADC, and env-var auto-detection
- Webhook route at `POST /webhooks/gchat` for @mentions, DMs, card button clicks, and Pub/Sub messages
- Optional Workspace Events via Pub/Sub for receiving all messages (not just @mentions)
- Zod config validation with `pubsubTopic` format, credential email, and endpoint URL checks
- 25 new tests: config validation, adapter factory, webhook route guard, lifecycle, multi-adapter

## Changes

| File | Change |
|------|--------|
| `plugins/chat/src/adapters/gchat.ts` | New — thin adapter wrapper |
| `plugins/chat/src/config.ts` | `GoogleChatAdapterConfig` interface + Zod schema |
| `plugins/chat/src/index.ts` | Route, initialize, healthCheck, teardown registration |
| `plugins/chat/src/bridge.ts` | Add `gchat` to adapter instances type |
| `plugins/chat/src/bridge.test.ts` | 25 new tests for gchat adapter |
| `plugins/chat/package.json` | Add `@chat-adapter/gchat` dependency |
| `apps/docs/.../gchat.mdx` | New — Google Chat bot setup guide |
| `apps/docs/.../chat.mdx` | Add gchat to adapter table, options, routes, env vars |
| `apps/docs/.../meta.json` | Add gchat page to nav |
| `apps/docs/.../roadmap.mdx` | Mark Google Chat as shipped |

## Test plan

- [x] All 95 bridge.test.ts tests pass (90 existing + 25 new, 0 failures)
- [x] CI gates pass: lint, type, test, syncpack, template drift
- [ ] Manual: configure gchat adapter with service account, verify @mention → query response
- [ ] Manual: verify threaded follow-up with Pub/Sub + Workspace Events
- [ ] Manual: verify Card v2 rendering (answer, SQL, data table)

Closes #762