### PR TITLE
fix: correct misleading section header and docs for card flow

### DIFF
--- a/apps/docs/content/docs/plugins/interactions/chat.mdx
+++ b/apps/docs/content/docs/plugins/interactions/chat.mdx
@@ -143,9 +143,9 @@ For production deployments, use the `pg` backend. The `memory` backend is suitab
 
 The plugin bridges Chat SDK events to the Atlas agent:
 
-1. **Slash commands** (`/atlas <question>`) — Posts a "Thinking about: \<question\>..." indicator, subscribes the thread, runs `executeQuery`, edits the response with results
+1. **Slash commands** (`/atlas <question>`) — Posts a "Thinking about: \<question\>..." indicator, subscribes the thread, runs `executeQuery`, edits the response with a JSX card (or markdown fallback)
 2. **@mentions** — Subscribes to the thread, runs `executeQuery`, posts the result as a native JSX card (Block Kit on Slack, Adaptive Cards on Teams, Discord Embeds) with markdown fallback
-3. **Thread follow-ups** — Messages in subscribed threads are routed through `executeQuery` with conversation history
+3. **Thread follow-ups** — Messages in subscribed threads are routed through `executeQuery` with conversation history, posted as a JSX card with markdown fallback
 4. **Actions** — Approval button clicks call `actions.approve()` or `actions.deny()`, then update the original message
 
 ### Rich Cards

--- a/plugins/chat/src/bridge.ts
+++ b/plugins/chat/src/bridge.ts
@@ -58,7 +58,7 @@ const SENSITIVE_PATTERNS = [
 ];
 
 // ---------------------------------------------------------------------------
-// Response formatting (deprecated — use card builders from ./cards/)
+// Response formatting (legacy helpers — see also ./cards/ for JSX cards)
 // ---------------------------------------------------------------------------
 
 /**


### PR DESCRIPTION
## Summary
- Fix bridge.ts section header that falsely implied `formatActionResult` was deprecated — changed to "legacy helpers" since only `formatQueryResponse` and `buildApprovalCard` are deprecated
- Update chat.mdx to describe JSX cards for all 3 event paths (slash commands, mentions, follow-ups), not just mentions

Follow-up to #803 — comment-analyzer review findings.

## Test plan
- [x] Documentation-only changes, no code behavior affected