### PR TITLE
fix: replace remaining Enterprise features string matching with instanceof EnterpriseError

### DIFF
--- a/ee/src/governance/approval.ts
+++ b/ee/src/governance/approval.ts
@@ -13,7 +13,7 @@
  * All mutating operations call `requireEnterprise("approval-workflows")`.
  */
 
-import { requireEnterprise } from "../index";
+import { requireEnterprise, EnterpriseError } from "../index";
 import {
   hasInternalDB,
   internalQuery,
@@ -355,8 +355,8 @@ export async function checkApprovalRequired(
   try {
     requireEnterprise("approval-workflows");
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (!msg.includes("Enterprise features")) {
+    if (!(err instanceof EnterpriseError)) {
+      const msg = err instanceof Error ? err.message : String(err);
       log.warn({ err: msg }, "Unexpected error checking enterprise status in approval check");
     }
     return { required: false, matchedRules: [] };
@@ -580,8 +580,8 @@ export async function expireStaleRequests(): Promise<number> {
   try {
     requireEnterprise("approval-workflows");
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (!msg.includes("Enterprise features")) {
+    if (!(err instanceof EnterpriseError)) {
+      const msg = err instanceof Error ? err.message : String(err);
       log.warn({ err: msg }, "Unexpected error checking enterprise status in expireStaleRequests");
     }
     return 0;
@@ -607,8 +607,8 @@ export async function getPendingCount(orgId: string): Promise<number> {
   try {
     requireEnterprise("approval-workflows");
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (!msg.includes("Enterprise features")) {
+    if (!(err instanceof EnterpriseError)) {
+      const msg = err instanceof Error ? err.message : String(err);
       log.warn({ err: msg }, "Unexpected error checking enterprise status in getPendingCount");
     }
     return 0;

--- a/packages/api/src/api/__tests__/admin-branding.test.ts
+++ b/packages/api/src/api/__tests__/admin-branding.test.ts
@@ -51,6 +51,7 @@ let mockDeleteResult = false;
 let mockEeThrow: Error | null = null;
 
 const { BrandingError: RealBrandingError } = await import("@atlas/ee/branding/white-label");
+const { EnterpriseError } = await import("@atlas/ee/index");
 
 mock.module("@atlas/ee/branding/white-label", () => ({
   getWorkspaceBranding: async () => {
@@ -131,7 +132,7 @@ describe("GET /api/v1/admin/branding", () => {
   });
 
   it("returns 403 when enterprise disabled", async () => {
-    mockEeThrow = new Error("Enterprise features (branding) are not enabled.");
+    mockEeThrow = new EnterpriseError("Enterprise features (branding) are not enabled.");
     const res = await request("GET");
     expect(res.status).toBe(403);
     const json = await res.json() as { error: string };
@@ -192,7 +193,7 @@ describe("PUT /api/v1/admin/branding", () => {
   });
 
   it("returns 403 when enterprise disabled", async () => {
-    mockEeThrow = new Error("Enterprise features (branding) are not enabled.");
+    mockEeThrow = new EnterpriseError("Enterprise features (branding) are not enabled.");
     const res = await request("PUT", { logoText: "Test" });
     expect(res.status).toBe(403);
   });
@@ -230,7 +231,7 @@ describe("DELETE /api/v1/admin/branding", () => {
   });
 
   it("returns 403 when enterprise disabled", async () => {
-    mockEeThrow = new Error("Enterprise features (branding) are not enabled.");
+    mockEeThrow = new EnterpriseError("Enterprise features (branding) are not enabled.");
     const res = await request("DELETE");
     expect(res.status).toBe(403);
   });

--- a/packages/api/src/api/routes/admin-approval.ts
+++ b/packages/api/src/api/routes/admin-approval.ts
@@ -20,6 +20,7 @@ import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { validationHook } from "./validation-hook";
 import { HTTPException } from "hono/http-exception";
 import { createLogger } from "@atlas/api/lib/logger";
+import { EnterpriseError } from "@atlas/ee/index";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import {
   listApprovalRules,
@@ -45,10 +46,9 @@ const APPROVAL_ERROR_STATUS = { validation: 400, not_found: 404, conflict: 409, 
  * errors → 403; ApprovalError → 400/404/409/410. Unknown errors fall through.
  */
 function throwIfApprovalError(err: unknown): void {
-  const message = err instanceof Error ? err.message : String(err);
-  if (message.includes("Enterprise features")) {
+  if (err instanceof EnterpriseError) {
     throw new HTTPException(403, {
-      res: Response.json({ error: "enterprise_required", message }, { status: 403 }),
+      res: Response.json({ error: "enterprise_required", message: err.message }, { status: 403 }),
     });
   }
   if (err instanceof ApprovalError) {

--- a/packages/api/src/api/routes/admin-audit-retention.ts
+++ b/packages/api/src/api/routes/admin-audit-retention.ts
@@ -16,6 +16,7 @@ import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { validationHook } from "./validation-hook";
 import { HTTPException } from "hono/http-exception";
 import { createLogger } from "@atlas/api/lib/logger";
+import { EnterpriseError } from "@atlas/ee/index";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { adminAuth, requestContext, type AuthEnv } from "./middleware";
@@ -27,10 +28,9 @@ const log = createLogger("admin-audit-retention");
  * errors → 403; RetentionError → 400/404. Unknown errors fall through.
  */
 function throwIfRetentionError(err: unknown): void {
-  const message = err instanceof Error ? err.message : String(err);
-  if (message.includes("Enterprise features")) {
+  if (err instanceof EnterpriseError) {
     throw new HTTPException(403, {
-      res: Response.json({ error: "enterprise_required", message }, { status: 403 }),
+      res: Response.json({ error: "enterprise_required", message: err.message }, { status: 403 }),
     });
   }
   // Dynamically import to check error type

--- a/packages/api/src/api/routes/admin-branding.ts
+++ b/packages/api/src/api/routes/admin-branding.ts
@@ -9,6 +9,7 @@ import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { validationHook } from "./validation-hook";
 import { HTTPException } from "hono/http-exception";
 import { createLogger } from "@atlas/api/lib/logger";
+import { EnterpriseError } from "@atlas/ee/index";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import {
   getWorkspaceBranding,
@@ -28,10 +29,9 @@ const BRANDING_ERROR_STATUS = { validation: 400, not_found: 404 } as const;
  * errors → 403; BrandingError → 400/404. Unknown errors fall through.
  */
 function throwIfBrandingError(err: unknown): void {
-  const message = err instanceof Error ? err.message : String(err);
-  if (message.includes("Enterprise features")) {
+  if (err instanceof EnterpriseError) {
     throw new HTTPException(403, {
-      res: Response.json({ error: "enterprise_required", message }, { status: 403 }),
+      res: Response.json({ error: "enterprise_required", message: err.message }, { status: 403 }),
     });
   }
   if (err instanceof BrandingError) {

--- a/packages/api/src/api/routes/admin-compliance.ts
+++ b/packages/api/src/api/routes/admin-compliance.ts
@@ -16,6 +16,7 @@ import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { validationHook } from "./validation-hook";
 import { createLogger } from "@atlas/api/lib/logger";
+import { EnterpriseError } from "@atlas/ee/index";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import {
   listPIIClassifications,
@@ -47,10 +48,9 @@ const REPORT_ERROR_STATUS = { validation: 400, not_available: 404 } as const sat
  * Unknown errors fall through.
  */
 function throwIfComplianceError(err: unknown): void {
-  const message = err instanceof Error ? err.message : String(err);
-  if (message.includes("Enterprise features")) {
+  if (err instanceof EnterpriseError) {
     throw new HTTPException(403, {
-      res: Response.json({ error: "enterprise_required", message }, { status: 403 }),
+      res: Response.json({ error: "enterprise_required", message: err.message }, { status: 403 }),
     });
   }
   if (err instanceof ComplianceError) {

--- a/packages/api/src/api/routes/admin-ip-allowlist.ts
+++ b/packages/api/src/api/routes/admin-ip-allowlist.ts
@@ -9,6 +9,7 @@ import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { validationHook } from "./validation-hook";
 import { HTTPException } from "hono/http-exception";
 import { createLogger } from "@atlas/api/lib/logger";
+import { EnterpriseError } from "@atlas/ee/index";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import { getClientIP } from "@atlas/api/lib/auth/middleware";
 import {
@@ -35,10 +36,9 @@ const IP_ALLOWLIST_ERROR_STATUS = { validation: 400, conflict: 409, not_found: 4
  * errors → 403; IPAllowlistError → 400/404/409. Unknown errors fall through.
  */
 function throwIfIPAllowlistError(err: unknown): void {
-  const message = err instanceof Error ? err.message : String(err);
-  if (message.includes("Enterprise features")) {
+  if (err instanceof EnterpriseError) {
     throw new HTTPException(403, {
-      res: Response.json({ error: "enterprise_required", message }, { status: 403 }),
+      res: Response.json({ error: "enterprise_required", message: err.message }, { status: 403 }),
     });
   }
   if (err instanceof IPAllowlistError) {

--- a/packages/api/src/api/routes/admin-model-config.ts
+++ b/packages/api/src/api/routes/admin-model-config.ts
@@ -9,6 +9,7 @@ import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { validationHook } from "./validation-hook";
 import { HTTPException } from "hono/http-exception";
 import { createLogger } from "@atlas/api/lib/logger";
+import { EnterpriseError } from "@atlas/ee/index";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import {
   getWorkspaceModelConfig,
@@ -29,10 +30,9 @@ const MODEL_CONFIG_ERROR_STATUS = { validation: 400, not_found: 404, test_failed
  * errors → 403; ModelConfigError → 400/404/422. Unknown errors fall through.
  */
 function throwIfModelConfigError(err: unknown): void {
-  const message = err instanceof Error ? err.message : String(err);
-  if (message.includes("Enterprise features")) {
+  if (err instanceof EnterpriseError) {
     throw new HTTPException(403, {
-      res: Response.json({ error: "enterprise_required", message }, { status: 403 }),
+      res: Response.json({ error: "enterprise_required", message: err.message }, { status: 403 }),
     });
   }
   if (err instanceof ModelConfigError) {

--- a/packages/api/src/api/routes/admin-roles.ts
+++ b/packages/api/src/api/routes/admin-roles.ts
@@ -8,6 +8,7 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { createLogger } from "@atlas/api/lib/logger";
+import { EnterpriseError } from "@atlas/ee/index";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import {
   listRoles,
@@ -38,10 +39,9 @@ const ROLE_ERROR_STATUS = { not_found: 404, conflict: 409, validation: 400, buil
  * Unknown errors fall through.
  */
 function throwIfRoleError(err: unknown): void {
-  const message = err instanceof Error ? err.message : String(err);
-  if (message.includes("Enterprise features")) {
+  if (err instanceof EnterpriseError) {
     throw new HTTPException(403, {
-      res: Response.json({ error: "enterprise_required", message }, { status: 403 }),
+      res: Response.json({ error: "enterprise_required", message: err.message }, { status: 403 }),
     });
   }
   if (err instanceof RoleError) {

--- a/packages/api/src/api/routes/admin-scim.ts
+++ b/packages/api/src/api/routes/admin-scim.ts
@@ -13,6 +13,7 @@ import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { validationHook } from "./validation-hook";
 import { HTTPException } from "hono/http-exception";
 import { createLogger } from "@atlas/api/lib/logger";
+import { EnterpriseError } from "@atlas/ee/index";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import {
   listConnections,
@@ -47,10 +48,9 @@ function throwIfScimError(err: unknown): void {
       res: Response.json({ error: err.code, message: err.message }, { status }),
     });
   }
-  const message = err instanceof Error ? err.message : String(err);
-  if (message.includes("Enterprise features")) {
+  if (err instanceof EnterpriseError) {
     throw new HTTPException(403, {
-      res: Response.json({ error: "enterprise_required", message }, { status: 403 }),
+      res: Response.json({ error: "enterprise_required", message: err.message }, { status: 403 }),
     });
   }
 }

--- a/packages/api/src/api/routes/admin-sso.ts
+++ b/packages/api/src/api/routes/admin-sso.ts
@@ -9,6 +9,7 @@ import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { validationHook } from "./validation-hook";
 import { HTTPException } from "hono/http-exception";
 import { createLogger } from "@atlas/api/lib/logger";
+import { EnterpriseError } from "@atlas/ee/index";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import {
   listSSOProviders,
@@ -44,10 +45,9 @@ const SSO_ERROR_STATUS = { not_found: 404, conflict: 409, validation: 400 } as c
  * Throw HTTPException for known SSO/enterprise errors. Unknown errors fall through.
  */
 function throwIfSSOError(err: unknown): void {
-  const message = err instanceof Error ? err.message : String(err);
-  if (message.includes("Enterprise features")) {
+  if (err instanceof EnterpriseError) {
     throw new HTTPException(403, {
-      res: Response.json({ error: "enterprise_required", message }, { status: 403 }),
+      res: Response.json({ error: "enterprise_required", message: err.message }, { status: 403 }),
     });
   }
   if (err instanceof SSOEnforcementError) {


### PR DESCRIPTION
## Summary
- Completes the migration started in #827 — all enterprise error detection now uses `instanceof EnterpriseError` instead of `message.includes("Enterprise features")`
- Updated 9 admin route files: approval, scim, compliance, sso, roles, branding, audit-retention, ip-allowlist, model-config
- Updated 3 catch blocks in `ee/src/governance/approval.ts`
- Fixed test in `admin-branding.test.ts` to throw `EnterpriseError` instead of plain `Error`

Closes #817 (completes the fix across all files)

## Test plan
- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun run test` — 0 failures (including admin-branding and approval tests)
- [x] Verified zero remaining `includes("Enterprise features")` matches in codebase