### PR TITLE
refactor: create shared EE test mock factory

### DIFF
--- a/ee/src/__mocks__/internal.ts
+++ b/ee/src/__mocks__/internal.ts
@@ -1,7 +1,8 @@
 /**
  * Shared mock factory for EE test files.
  *
- * 9 test files independently mock the same three modules:
+ * 8 EE test files mock all three of these modules; 1 additional file
+ * (approval.test.ts) uses only the DB and logger mocks:
  *   - `../index` (enterprise gate)
  *   - `@atlas/api/lib/db/internal` (internal DB)
  *   - `@atlas/api/lib/logger` (logger)
@@ -43,8 +44,8 @@ export interface EEMock {
   capturedQueries: { sql: string; params: unknown[] }[];
 
   // ── Helpers ──────────────────────────────────────────────────
-  /** Queue rows that subsequent internalQuery / getInternalDB().query calls will return. */
-  setMockRows: (...batches: Record<string, unknown>[][]) => void;
+  /** Append row batches to the queue — subsequent internalQuery / getInternalDB().query calls consume them in order. */
+  queueMockRows: (...batches: Record<string, unknown>[][]) => void;
   /** Toggle the enterprise-enabled flag. */
   setEnterpriseEnabled: (enabled: boolean) => void;
   /** Set or clear the enterprise license key. */
@@ -61,7 +62,7 @@ export interface EEMock {
  */
 export function createEEMock(overrides?: EEMockOverrides): EEMock {
   // ── Mutable state ──────────────────────────────────────────────
-  let enterpriseEnabled = false;
+  let enterpriseEnabled = true;
   let enterpriseLicenseKey: string | undefined = "test-key";
   let hasInternalDB = true;
   const mockRows: Record<string, unknown>[][] = [];
@@ -101,7 +102,7 @@ export function createEEMock(overrides?: EEMockOverrides): EEMock {
     getInternalDB: () => ({
       query: async (sql: string, params?: unknown[]) => {
         const rows = handleQuery(sql, params);
-        return { rows };
+        return { rows, rowCount: rows.length };
       },
       end: async () => {},
       on: () => {},
@@ -132,7 +133,7 @@ export function createEEMock(overrides?: EEMockOverrides): EEMock {
   };
 
   // ── Helpers ────────────────────────────────────────────────────
-  function setMockRows(...batches: Record<string, unknown>[][]) {
+  function queueMockRows(...batches: Record<string, unknown>[][]) {
     mockRows.push(...batches);
   }
 
@@ -162,7 +163,7 @@ export function createEEMock(overrides?: EEMockOverrides): EEMock {
     internalDBMock,
     loggerMock,
     capturedQueries,
-    setMockRows,
+    queueMockRows,
     setEnterpriseEnabled,
     setEnterpriseLicenseKey,
     setHasInternalDB,

--- a/ee/src/auth/ip-allowlist.test.ts
+++ b/ee/src/auth/ip-allowlist.test.ts
@@ -222,7 +222,7 @@ describe("listIPAllowlistEntries", () => {
   beforeEach(resetMocks);
 
   it("returns entries from DB", async () => {
-    ee.setMockRows([
+    ee.queueMockRows([
       {
         id: "entry-1",
         org_id: "org-1",
@@ -251,9 +251,9 @@ describe("addIPAllowlistEntry", () => {
 
   it("adds a valid CIDR entry", async () => {
     // First query: duplicate check (no results)
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
     // Second query: INSERT RETURNING
-    ee.setMockRows([
+    ee.queueMockRows([
       {
         id: "new-id",
         org_id: "org-1",
@@ -281,7 +281,7 @@ describe("addIPAllowlistEntry", () => {
 
   it("rejects duplicate CIDR", async () => {
     // Duplicate check returns existing row
-    ee.setMockRows([{ id: "existing-id" }]);
+    ee.queueMockRows([{ id: "existing-id" }]);
 
     try {
       await addIPAllowlistEntry("org-1", "10.0.0.0/8", null, null);
@@ -302,13 +302,13 @@ describe("removeIPAllowlistEntry", () => {
   beforeEach(resetMocks);
 
   it("removes existing entry", async () => {
-    ee.setMockRows([{ id: "entry-1" }]);
+    ee.queueMockRows([{ id: "entry-1" }]);
     const deleted = await removeIPAllowlistEntry("org-1", "entry-1");
     expect(deleted).toBe(true);
   });
 
   it("returns false for non-existent entry", async () => {
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
     const deleted = await removeIPAllowlistEntry("org-1", "no-such-entry");
     expect(deleted).toBe(false);
   });
@@ -331,31 +331,31 @@ describe("checkIPAllowlist", () => {
   });
 
   it("allows when no allowlist entries exist (opt-in)", async () => {
-    ee.setMockRows([]); // empty allowlist
+    ee.queueMockRows([]); // empty allowlist
     const result = await checkIPAllowlist("org-1", "1.2.3.4");
     expect(result.allowed).toBe(true);
   });
 
   it("allows matching IP", async () => {
-    ee.setMockRows([{ cidr: "10.0.0.0/8" }]);
+    ee.queueMockRows([{ cidr: "10.0.0.0/8" }]);
     const result = await checkIPAllowlist("org-1", "10.0.0.1");
     expect(result.allowed).toBe(true);
   });
 
   it("blocks non-matching IP", async () => {
-    ee.setMockRows([{ cidr: "10.0.0.0/8" }]);
+    ee.queueMockRows([{ cidr: "10.0.0.0/8" }]);
     const result = await checkIPAllowlist("org-1", "192.168.1.1");
     expect(result.allowed).toBe(false);
   });
 
   it("blocks when IP is null and allowlist has entries", async () => {
-    ee.setMockRows([{ cidr: "10.0.0.0/8" }]);
+    ee.queueMockRows([{ cidr: "10.0.0.0/8" }]);
     const result = await checkIPAllowlist("org-1", null);
     expect(result.allowed).toBe(false);
   });
 
   it("uses cache on second call", async () => {
-    ee.setMockRows([{ cidr: "10.0.0.0/8" }]);
+    ee.queueMockRows([{ cidr: "10.0.0.0/8" }]);
     await checkIPAllowlist("org-1", "10.0.0.1");
     // Second call should not query DB (no additional rows needed)
     const result = await checkIPAllowlist("org-1", "10.0.0.1");
@@ -365,12 +365,12 @@ describe("checkIPAllowlist", () => {
   });
 
   it("cache invalidation forces DB reload", async () => {
-    ee.setMockRows([{ cidr: "10.0.0.0/8" }]);
+    ee.queueMockRows([{ cidr: "10.0.0.0/8" }]);
     await checkIPAllowlist("org-1", "10.0.0.1");
 
     // Invalidate cache
     _clearCache();
-    ee.setMockRows([{ cidr: "192.168.0.0/16" }]);
+    ee.queueMockRows([{ cidr: "192.168.0.0/16" }]);
 
     const result = await checkIPAllowlist("org-1", "10.0.0.1");
     // Should now be blocked because cache was cleared and new DB data loaded
@@ -385,7 +385,7 @@ describe("edge cases", () => {
   beforeEach(resetMocks);
 
   it("handles multiple CIDR ranges for one org", async () => {
-    ee.setMockRows([
+    ee.queueMockRows([
       { cidr: "10.0.0.0/8" },
       { cidr: "172.16.0.0/12" },
       { cidr: "192.168.0.0/16" },
@@ -396,7 +396,7 @@ describe("edge cases", () => {
   });
 
   it("handles mixed IPv4/IPv6 in allowlist", async () => {
-    ee.setMockRows([
+    ee.queueMockRows([
       { cidr: "10.0.0.0/8" },
       { cidr: "2001:db8::/32" },
     ]);
@@ -405,7 +405,7 @@ describe("edge cases", () => {
 
     // Clear cache for fresh query
     _clearCache();
-    ee.setMockRows([
+    ee.queueMockRows([
       { cidr: "10.0.0.0/8" },
       { cidr: "2001:db8::/32" },
     ]);
@@ -451,8 +451,8 @@ describe("fixed issues", () => {
 
   it("addIPAllowlistEntry normalizes CIDR for duplicate check", async () => {
     // First call: add 10.0.0.0/8
-    ee.setMockRows([]); // no duplicates
-    ee.setMockRows([
+    ee.queueMockRows([]); // no duplicates
+    ee.queueMockRows([
       {
         id: "new-id",
         org_id: "org-1",
@@ -505,8 +505,8 @@ describe("fixed issues", () => {
   });
 
   it("plain IP can be added to allowlist", async () => {
-    ee.setMockRows([]); // no duplicates
-    ee.setMockRows([
+    ee.queueMockRows([]); // no duplicates
+    ee.queueMockRows([
       {
         id: "new-id",
         org_id: "org-1",

--- a/ee/src/auth/roles.test.ts
+++ b/ee/src/auth/roles.test.ts
@@ -160,7 +160,7 @@ describe("resolvePermissions", () => {
   });
 
   it("returns custom role permissions when found in DB", async () => {
-    ee.setMockRows([makeRoleRow({
+    ee.queueMockRows([makeRoleRow({
       permissions: JSON.stringify(["query", "admin:audit"]),
     })]);
 
@@ -173,7 +173,7 @@ describe("resolvePermissions", () => {
   });
 
   it("falls back to legacy for admin role when no custom role in DB", async () => {
-    ee.setMockRows([]); // No custom role found
+    ee.queueMockRows([]); // No custom role found
 
     const user = makeUser({ role: "admin" });
     const perms = await resolvePermissions(user);
@@ -181,7 +181,7 @@ describe("resolvePermissions", () => {
   });
 
   it("falls back to legacy for member role when no custom role in DB", async () => {
-    ee.setMockRows([]); // No custom role found
+    ee.queueMockRows([]); // No custom role found
 
     const user = makeUser({ role: "member" });
     const perms = await resolvePermissions(user);
@@ -191,7 +191,7 @@ describe("resolvePermissions", () => {
   });
 
   it("falls back to member permissions for unknown roles", async () => {
-    ee.setMockRows([]); // No custom role found
+    ee.queueMockRows([]); // No custom role found
 
     const user = makeUser({ role: undefined });
     const perms = await resolvePermissions(user);
@@ -202,7 +202,7 @@ describe("resolvePermissions", () => {
 
   it("fails closed with empty permissions on corrupt role data", async () => {
     // Simulate corrupt JSON in permissions column
-    ee.setMockRows([{ id: "r1", org_id: "org-1", name: "test", description: "", permissions: "INVALID_JSON{", is_builtin: false, created_at: "", updated_at: "" }]);
+    ee.queueMockRows([{ id: "r1", org_id: "org-1", name: "test", description: "", permissions: "INVALID_JSON{", is_builtin: false, created_at: "", updated_at: "" }]);
 
     const user = makeUser({ role: "test" });
     const perms = await resolvePermissions(user);
@@ -216,12 +216,12 @@ describe("hasPermission", () => {
   beforeEach(resetMocks);
 
   it("returns true when user has the permission", async () => {
-    ee.setMockRows([]); // Falls back to legacy admin
+    ee.queueMockRows([]); // Falls back to legacy admin
     expect(await hasPermission(makeUser({ role: "admin" }), "admin:users")).toBe(true);
   });
 
   it("returns false when user lacks the permission", async () => {
-    ee.setMockRows([]); // Falls back to legacy member
+    ee.queueMockRows([]); // Falls back to legacy member
     expect(await hasPermission(makeUser({ role: "member" }), "admin:users")).toBe(false);
   });
 });
@@ -230,13 +230,13 @@ describe("checkPermission", () => {
   beforeEach(resetMocks);
 
   it("returns null when permission is satisfied", async () => {
-    ee.setMockRows([]); // Legacy admin
+    ee.queueMockRows([]); // Legacy admin
     const result = await checkPermission(makeUser({ role: "admin" }), "admin:users", "req-1");
     expect(result).toBeNull();
   });
 
   it("returns error response when permission is denied", async () => {
-    ee.setMockRows([]); // Legacy member
+    ee.queueMockRows([]); // Legacy member
     const result = await checkPermission(makeUser({ role: "member" }), "admin:users", "req-1");
     expect(result).not.toBeNull();
     expect(result!.status).toBe(403);
@@ -257,11 +257,11 @@ describe("CRUD operations", () => {
     it("returns roles from DB", async () => {
       // seedBuiltinRoles: 3 built-in roles × (SELECT existence check + INSERT if needed)
       // Each SELECT returns a row (already exists), so no INSERT needed
-      ee.setMockRows([{ id: "r1" }]); // admin exists
-      ee.setMockRows([{ id: "r2" }]); // analyst exists
-      ee.setMockRows([{ id: "r3" }]); // viewer exists
+      ee.queueMockRows([{ id: "r1" }]); // admin exists
+      ee.queueMockRows([{ id: "r2" }]); // analyst exists
+      ee.queueMockRows([{ id: "r3" }]); // viewer exists
       // listRoles query result
-      ee.setMockRows([
+      ee.queueMockRows([
         makeRoleRow(),
         makeRoleRow({ id: "role-2", name: "custom", is_builtin: false }),
       ]);
@@ -275,14 +275,14 @@ describe("CRUD operations", () => {
 
   describe("getRole", () => {
     it("returns role when found", async () => {
-      ee.setMockRows([makeRoleRow()]);
+      ee.queueMockRows([makeRoleRow()]);
       const role = await getRole("org-1", "role-1");
       expect(role).not.toBeNull();
       expect(role!.name).toBe("analyst");
     });
 
     it("returns null when not found", async () => {
-      ee.setMockRows([]);
+      ee.queueMockRows([]);
       const role = await getRole("org-1", "nonexistent");
       expect(role).toBeNull();
     });
@@ -290,8 +290,8 @@ describe("CRUD operations", () => {
 
   describe("createRole", () => {
     it("creates a custom role", async () => {
-      ee.setMockRows([]); // uniqueness check
-      ee.setMockRows([makeRoleRow({
+      ee.queueMockRows([]); // uniqueness check
+      ee.queueMockRows([makeRoleRow({
         id: "new-role",
         name: "data-engineer",
         is_builtin: false,
@@ -333,7 +333,7 @@ describe("CRUD operations", () => {
     });
 
     it("rejects duplicate names", async () => {
-      ee.setMockRows([{ id: "existing" }]); // uniqueness check finds existing
+      ee.queueMockRows([{ id: "existing" }]); // uniqueness check finds existing
 
       await expect(
         createRole("org-1", { name: "analyst", permissions: ["query"] }),
@@ -344,9 +344,9 @@ describe("CRUD operations", () => {
   describe("updateRole", () => {
     it("updates description and permissions", async () => {
       // getRole lookup
-      ee.setMockRows([makeRoleRow({ is_builtin: false })]);
+      ee.queueMockRows([makeRoleRow({ is_builtin: false })]);
       // UPDATE query
-      ee.setMockRows([makeRoleRow({
+      ee.queueMockRows([makeRoleRow({
         is_builtin: false,
         description: "Updated description",
         permissions: JSON.stringify(["query"]),
@@ -361,7 +361,7 @@ describe("CRUD operations", () => {
     });
 
     it("rejects modification of built-in roles", async () => {
-      ee.setMockRows([makeRoleRow({ is_builtin: true })]);
+      ee.queueMockRows([makeRoleRow({ is_builtin: true })]);
 
       await expect(
         updateRole("org-1", "role-1", { permissions: ["query"] }),
@@ -369,7 +369,7 @@ describe("CRUD operations", () => {
     });
 
     it("rejects when role not found", async () => {
-      ee.setMockRows([]); // getRole returns nothing
+      ee.queueMockRows([]); // getRole returns nothing
 
       await expect(
         updateRole("org-1", "nonexistent", { permissions: ["query"] }),
@@ -380,24 +380,24 @@ describe("CRUD operations", () => {
   describe("deleteRole", () => {
     it("deletes a custom role with no active members", async () => {
       // getRole (via internalQuery) returns custom role
-      ee.setMockRows([makeRoleRow({ is_builtin: false })]);
+      ee.queueMockRows([makeRoleRow({ is_builtin: false })]);
       // listRoleMembers: getRole returns the role again
-      ee.setMockRows([makeRoleRow({ is_builtin: false })]);
+      ee.queueMockRows([makeRoleRow({ is_builtin: false })]);
       // listRoleMembers: member table query returns empty (no members)
-      ee.setMockRows([]);
+      ee.queueMockRows([]);
       // DELETE (via getInternalDB().query) returns the deleted row
-      ee.setMockRows([{ id: "role-1" }]);
+      ee.queueMockRows([{ id: "role-1" }]);
 
       const result = await deleteRole("org-1", "role-1");
       expect(result).toBe(true);
     });
 
     it("rejects deletion when role has active members", async () => {
-      ee.setMockRows([makeRoleRow({ is_builtin: false })]);
+      ee.queueMockRows([makeRoleRow({ is_builtin: false })]);
       // listRoleMembers: getRole
-      ee.setMockRows([makeRoleRow({ is_builtin: false })]);
+      ee.queueMockRows([makeRoleRow({ is_builtin: false })]);
       // listRoleMembers: member table returns 2 members
-      ee.setMockRows([
+      ee.queueMockRows([
         { userId: "u1", role: "analyst", createdAt: "2026-01-01" },
         { userId: "u2", role: "analyst", createdAt: "2026-01-01" },
       ]);
@@ -408,7 +408,7 @@ describe("CRUD operations", () => {
     });
 
     it("rejects deletion of built-in roles", async () => {
-      ee.setMockRows([makeRoleRow({ is_builtin: true })]);
+      ee.queueMockRows([makeRoleRow({ is_builtin: true })]);
 
       await expect(
         deleteRole("org-1", "role-1"),
@@ -416,7 +416,7 @@ describe("CRUD operations", () => {
     });
 
     it("returns false when role not found", async () => {
-      ee.setMockRows([]); // getRole returns nothing
+      ee.queueMockRows([]); // getRole returns nothing
 
       const result = await deleteRole("org-1", "nonexistent");
       expect(result).toBe(false);
@@ -430,9 +430,9 @@ describe("Role assignment", () => {
   describe("listRoleMembers", () => {
     it("returns members for a role", async () => {
       // getRole lookup
-      ee.setMockRows([makeRoleRow()]);
+      ee.queueMockRows([makeRoleRow()]);
       // member query
-      ee.setMockRows([
+      ee.queueMockRows([
         { userId: "user-1", role: "analyst", createdAt: "2026-01-01" },
         { userId: "user-2", role: "analyst", createdAt: "2026-01-02" },
       ]);
@@ -443,7 +443,7 @@ describe("Role assignment", () => {
     });
 
     it("throws when role not found", async () => {
-      ee.setMockRows([]); // getRole returns nothing
+      ee.queueMockRows([]); // getRole returns nothing
 
       await expect(
         listRoleMembers("org-1", "nonexistent"),
@@ -454,9 +454,9 @@ describe("Role assignment", () => {
   describe("assignRole", () => {
     it("assigns a role to a user", async () => {
       // Role existence check
-      ee.setMockRows([{ id: "role-1" }]);
+      ee.queueMockRows([{ id: "role-1" }]);
       // UPDATE member
-      ee.setMockRows([{ userId: "user-1", role: "analyst" }]);
+      ee.queueMockRows([{ userId: "user-1", role: "analyst" }]);
 
       const result = await assignRole("org-1", "user-1", "analyst");
       expect(result.userId).toBe("user-1");
@@ -464,7 +464,7 @@ describe("Role assignment", () => {
     });
 
     it("rejects when role does not exist", async () => {
-      ee.setMockRows([]); // role not found
+      ee.queueMockRows([]); // role not found
 
       await expect(
         assignRole("org-1", "user-1", "nonexistent"),
@@ -472,8 +472,8 @@ describe("Role assignment", () => {
     });
 
     it("rejects when user is not a member", async () => {
-      ee.setMockRows([{ id: "role-1" }]); // role exists
-      ee.setMockRows([]); // member update returns nothing
+      ee.queueMockRows([{ id: "role-1" }]); // role exists
+      ee.queueMockRows([]); // member update returns nothing
 
       await expect(
         assignRole("org-1", "user-1", "analyst"),
@@ -487,7 +487,7 @@ describe("seedBuiltinRoles", () => {
 
   it("seeds all three built-in roles when none exist", async () => {
     // Three existence checks, all empty
-    ee.setMockRows([], [], []);
+    ee.queueMockRows([], [], []);
 
     await seedBuiltinRoles("org-1");
 
@@ -500,7 +500,7 @@ describe("seedBuiltinRoles", () => {
 
   it("skips roles that already exist", async () => {
     // First two exist, third doesn't
-    ee.setMockRows([{ id: "existing" }], [{ id: "existing" }], []);
+    ee.queueMockRows([{ id: "existing" }], [{ id: "existing" }], []);
 
     await seedBuiltinRoles("org-1");
 

--- a/ee/src/auth/scim.test.ts
+++ b/ee/src/auth/scim.test.ts
@@ -98,13 +98,13 @@ describe("listConnections", () => {
   beforeEach(resetMocks);
 
   it("returns empty array when no connections", async () => {
-    ee.setMockRows([]); // empty result
+    ee.queueMockRows([]); // empty result
     const result = await listConnections(ORG_ID);
     expect(result).toEqual([]);
   });
 
   it("returns connections for org", async () => {
-    ee.setMockRows([
+    ee.queueMockRows([
       {
         id: "conn-1",
         providerId: "okta-prod",
@@ -123,13 +123,13 @@ describe("deleteConnection", () => {
   beforeEach(resetMocks);
 
   it("returns true when connection deleted", async () => {
-    ee.setMockRows([{ id: "conn-1" }]); // pool.query RETURNING
+    ee.queueMockRows([{ id: "conn-1" }]); // pool.query RETURNING
     const result = await deleteConnection(ORG_ID, "conn-1");
     expect(result).toBe(true);
   });
 
   it("returns false when connection not found", async () => {
-    ee.setMockRows([]); // no match
+    ee.queueMockRows([]); // no match
     const result = await deleteConnection(ORG_ID, "nonexistent");
     expect(result).toBe(false);
   });
@@ -139,9 +139,9 @@ describe("getSyncStatus", () => {
   beforeEach(resetMocks);
 
   it("returns zero counts when no data", async () => {
-    ee.setMockRows([{ count: "0" }]); // connections count
-    ee.setMockRows([{ count: "0" }]); // user count
-    ee.setMockRows([{ last_sync: null }]); // last sync
+    ee.queueMockRows([{ count: "0" }]); // connections count
+    ee.queueMockRows([{ count: "0" }]); // user count
+    ee.queueMockRows([{ last_sync: null }]); // last sync
     const status = await getSyncStatus(ORG_ID);
     expect(status.connections).toBe(0);
     expect(status.provisionedUsers).toBe(0);
@@ -149,9 +149,9 @@ describe("getSyncStatus", () => {
   });
 
   it("returns correct counts", async () => {
-    ee.setMockRows([{ count: "2" }]);
-    ee.setMockRows([{ count: "15" }]);
-    ee.setMockRows([{ last_sync: "2026-03-22T10:00:00Z" }]);
+    ee.queueMockRows([{ count: "2" }]);
+    ee.queueMockRows([{ count: "15" }]);
+    ee.queueMockRows([{ last_sync: "2026-03-22T10:00:00Z" }]);
     const status = await getSyncStatus(ORG_ID);
     expect(status.connections).toBe(2);
     expect(status.provisionedUsers).toBe(15);
@@ -164,15 +164,15 @@ describe("group mappings", () => {
 
   describe("listGroupMappings", () => {
     it("returns empty when no mappings", async () => {
-      ee.setMockRows([]); // ensureGroupMappingsTable CREATE TABLE
-      ee.setMockRows([]); // query result
+      ee.queueMockRows([]); // ensureGroupMappingsTable CREATE TABLE
+      ee.queueMockRows([]); // query result
       const result = await listGroupMappings(ORG_ID);
       expect(result).toEqual([]);
     });
 
     it("returns mappings for org", async () => {
-      ee.setMockRows([]); // ensureGroupMappingsTable
-      ee.setMockRows([
+      ee.queueMockRows([]); // ensureGroupMappingsTable
+      ee.queueMockRows([
         {
           id: "map-1",
           org_id: ORG_ID,
@@ -190,10 +190,10 @@ describe("group mappings", () => {
 
   describe("createGroupMapping", () => {
     it("creates a mapping successfully", async () => {
-      ee.setMockRows([]); // ensureGroupMappingsTable
-      ee.setMockRows([{ id: "role-1" }]); // role exists check
-      ee.setMockRows([]); // duplicate check
-      ee.setMockRows([
+      ee.queueMockRows([]); // ensureGroupMappingsTable
+      ee.queueMockRows([{ id: "role-1" }]); // role exists check
+      ee.queueMockRows([]); // duplicate check
+      ee.queueMockRows([
         {
           id: "map-new",
           org_id: ORG_ID,
@@ -209,37 +209,37 @@ describe("group mappings", () => {
     });
 
     it("throws on invalid group name", async () => {
-      ee.setMockRows([]); // ensureGroupMappingsTable
+      ee.queueMockRows([]); // ensureGroupMappingsTable
       await expect(createGroupMapping(ORG_ID, "", "analyst")).rejects.toThrow(SCIMError);
     });
 
     it("throws when role does not exist", async () => {
-      ee.setMockRows([]); // ensureGroupMappingsTable
-      ee.setMockRows([]); // role not found
+      ee.queueMockRows([]); // ensureGroupMappingsTable
+      ee.queueMockRows([]); // role not found
       await expect(createGroupMapping(ORG_ID, "Engineers", "nonexistent")).rejects.toThrow(
         'Role "nonexistent" does not exist',
       );
     });
 
     it("throws on duplicate mapping", async () => {
-      ee.setMockRows([]); // ensureGroupMappingsTable
-      ee.setMockRows([{ id: "role-1" }]); // role exists
-      ee.setMockRows([{ id: "existing-map" }]); // duplicate found
+      ee.queueMockRows([]); // ensureGroupMappingsTable
+      ee.queueMockRows([{ id: "role-1" }]); // role exists
+      ee.queueMockRows([{ id: "existing-map" }]); // duplicate found
       await expect(createGroupMapping(ORG_ID, "Engineers", "analyst")).rejects.toThrow("already exists");
     });
   });
 
   describe("deleteGroupMapping", () => {
     it("returns true on success", async () => {
-      ee.setMockRows([]); // ensureGroupMappingsTable
-      ee.setMockRows([{ id: "map-1" }]); // pool.query RETURNING
+      ee.queueMockRows([]); // ensureGroupMappingsTable
+      ee.queueMockRows([{ id: "map-1" }]); // pool.query RETURNING
       const result = await deleteGroupMapping(ORG_ID, "map-1");
       expect(result).toBe(true);
     });
 
     it("returns false when not found", async () => {
-      ee.setMockRows([]); // ensureGroupMappingsTable
-      ee.setMockRows([]); // no match
+      ee.queueMockRows([]); // ensureGroupMappingsTable
+      ee.queueMockRows([]); // no match
       const result = await deleteGroupMapping(ORG_ID, "nonexistent");
       expect(result).toBe(false);
     });
@@ -250,23 +250,23 @@ describe("resolveGroupToRole", () => {
   beforeEach(resetMocks);
 
   it("returns role name when mapping exists", async () => {
-    ee.setMockRows([]); // ensureGroupMappingsTable
-    ee.setMockRows([{ role_name: "analyst" }]);
+    ee.queueMockRows([]); // ensureGroupMappingsTable
+    ee.queueMockRows([{ role_name: "analyst" }]);
     const result = await resolveGroupToRole(ORG_ID, "Engineers");
     expect(result).toBe("analyst");
   });
 
   it("returns null when no mapping", async () => {
-    ee.setMockRows([]); // ensureGroupMappingsTable
-    ee.setMockRows([]); // no match
+    ee.queueMockRows([]); // ensureGroupMappingsTable
+    ee.queueMockRows([]); // no match
     const result = await resolveGroupToRole(ORG_ID, "Unknown Group");
     expect(result).toBeNull();
   });
 
   it("does not require enterprise gate (skips requireEnterprise)", async () => {
     ee.setEnterpriseEnabled(false); // would throw if requireEnterprise were called
-    ee.setMockRows([]); // ensureGroupMappingsTable
-    ee.setMockRows([{ role_name: "analyst" }]);
+    ee.queueMockRows([]); // ensureGroupMappingsTable
+    ee.queueMockRows([{ role_name: "analyst" }]);
     const result = await resolveGroupToRole(ORG_ID, "Engineers");
     expect(result).toBe("analyst");
   });
@@ -276,7 +276,7 @@ describe("SCIMError codes", () => {
   beforeEach(resetMocks);
 
   it("throws validation code for invalid group name", async () => {
-    ee.setMockRows([]); // ensureGroupMappingsTable
+    ee.queueMockRows([]); // ensureGroupMappingsTable
     try {
       await createGroupMapping(ORG_ID, "", "analyst");
       expect(true).toBe(false); // should not reach
@@ -287,8 +287,8 @@ describe("SCIMError codes", () => {
   });
 
   it("throws not_found code for missing role", async () => {
-    ee.setMockRows([]); // ensureGroupMappingsTable
-    ee.setMockRows([]); // role not found
+    ee.queueMockRows([]); // ensureGroupMappingsTable
+    ee.queueMockRows([]); // role not found
     try {
       await createGroupMapping(ORG_ID, "Engineers", "nonexistent");
       expect(true).toBe(false);
@@ -299,9 +299,9 @@ describe("SCIMError codes", () => {
   });
 
   it("throws conflict code for duplicate mapping", async () => {
-    ee.setMockRows([]); // ensureGroupMappingsTable
-    ee.setMockRows([{ id: "role-1" }]); // role exists
-    ee.setMockRows([{ id: "existing-map" }]); // duplicate found
+    ee.queueMockRows([]); // ensureGroupMappingsTable
+    ee.queueMockRows([{ id: "role-1" }]); // role exists
+    ee.queueMockRows([{ id: "existing-map" }]); // duplicate found
     try {
       await createGroupMapping(ORG_ID, "Engineers", "analyst");
       expect(true).toBe(false);

--- a/ee/src/auth/sso.test.ts
+++ b/ee/src/auth/sso.test.ts
@@ -173,7 +173,7 @@ describe("listSSOProviders", () => {
   beforeEach(() => ee.reset());
 
   it("returns providers for the org", async () => {
-    ee.setMockRows([sampleSamlRow, sampleOidcRow]);
+    ee.queueMockRows([sampleSamlRow, sampleOidcRow]);
     const providers = await listSSOProviders("org-1");
     expect(providers).toHaveLength(2);
     expect(providers[0].type).toBe("saml");
@@ -182,7 +182,7 @@ describe("listSSOProviders", () => {
   });
 
   it("returns empty array when no providers", async () => {
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
     const providers = await listSSOProviders("org-1");
     expect(providers).toHaveLength(0);
   });
@@ -192,7 +192,7 @@ describe("getSSOProvider", () => {
   beforeEach(() => ee.reset());
 
   it("returns a single provider", async () => {
-    ee.setMockRows([sampleSamlRow]);
+    ee.queueMockRows([sampleSamlRow]);
     const provider = await getSSOProvider("org-1", "prov-1");
     expect(provider).not.toBeNull();
     expect(provider!.id).toBe("prov-1");
@@ -200,7 +200,7 @@ describe("getSSOProvider", () => {
   });
 
   it("returns null when not found", async () => {
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
     const provider = await getSSOProvider("org-1", "nonexistent");
     expect(provider).toBeNull();
   });
@@ -211,9 +211,9 @@ describe("createSSOProvider", () => {
 
   it("creates a SAML provider", async () => {
     // Domain uniqueness check
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
     // INSERT RETURNING
-    ee.setMockRows([sampleSamlRow]);
+    ee.queueMockRows([sampleSamlRow]);
 
     const provider = await createSSOProvider("org-1", {
       type: "saml",
@@ -244,7 +244,7 @@ describe("createSSOProvider", () => {
   });
 
   it("rejects duplicate domain", async () => {
-    ee.setMockRows([{ id: "existing-prov", org_id: "other-org" }]);
+    ee.queueMockRows([{ id: "existing-prov", org_id: "other-org" }]);
 
     await expect(createSSOProvider("org-1", {
       type: "saml",
@@ -281,13 +281,13 @@ describe("deleteSSOProvider", () => {
   beforeEach(() => ee.reset());
 
   it("returns true when provider exists", async () => {
-    ee.setMockRows([{ id: "prov-1" }]);
+    ee.queueMockRows([{ id: "prov-1" }]);
     const result = await deleteSSOProvider("org-1", "prov-1");
     expect(result).toBe(true);
   });
 
   it("returns false when provider not found", async () => {
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
     const result = await deleteSSOProvider("org-1", "nonexistent");
     expect(result).toBe(false);
   });
@@ -297,20 +297,20 @@ describe("findProviderByDomain", () => {
   beforeEach(() => ee.reset());
 
   it("finds enabled provider for domain", async () => {
-    ee.setMockRows([sampleSamlRow]);
+    ee.queueMockRows([sampleSamlRow]);
     const provider = await findProviderByDomain("acme.com");
     expect(provider).not.toBeNull();
     expect(provider!.domain).toBe("acme.com");
   });
 
   it("returns null when no matching domain", async () => {
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
     const provider = await findProviderByDomain("unknown.com");
     expect(provider).toBeNull();
   });
 
   it("normalizes domain case", async () => {
-    ee.setMockRows([sampleSamlRow]);
+    ee.queueMockRows([sampleSamlRow]);
     await findProviderByDomain("ACME.COM");
     expect(ee.capturedQueries[0].params[0]).toBe("acme.com");
   });
@@ -318,7 +318,7 @@ describe("findProviderByDomain", () => {
   it("does NOT call requireEnterprise — usable in login flow without license", async () => {
     ee.setEnterpriseEnabled(false);
     ee.setEnterpriseLicenseKey(undefined);
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
     // Should not throw even though enterprise is disabled
     const provider = await findProviderByDomain("acme.com");
     expect(provider).toBeNull();
@@ -330,9 +330,9 @@ describe("updateSSOProvider", () => {
 
   it("updates issuer only", async () => {
     // getSSOProvider: requireEnterprise + query
-    ee.setMockRows([sampleSamlRow]);
+    ee.queueMockRows([sampleSamlRow]);
     // UPDATE RETURNING
-    ee.setMockRows([{ ...sampleSamlRow, issuer: "https://new-idp.acme.com" }]);
+    ee.queueMockRows([{ ...sampleSamlRow, issuer: "https://new-idp.acme.com" }]);
 
     const provider = await updateSSOProvider("org-1", "prov-1", {
       issuer: "https://new-idp.acme.com",
@@ -342,11 +342,11 @@ describe("updateSSOProvider", () => {
 
   it("updates domain with uniqueness check", async () => {
     // getSSOProvider query
-    ee.setMockRows([sampleSamlRow]);
+    ee.queueMockRows([sampleSamlRow]);
     // Domain clash check
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
     // UPDATE RETURNING
-    ee.setMockRows([{ ...sampleSamlRow, domain: "newdomain.com" }]);
+    ee.queueMockRows([{ ...sampleSamlRow, domain: "newdomain.com" }]);
 
     const provider = await updateSSOProvider("org-1", "prov-1", {
       domain: "newdomain.com",
@@ -356,9 +356,9 @@ describe("updateSSOProvider", () => {
 
   it("rejects domain collision on update", async () => {
     // getSSOProvider query
-    ee.setMockRows([sampleSamlRow]);
+    ee.queueMockRows([sampleSamlRow]);
     // Domain clash check — found a collision
-    ee.setMockRows([{ id: "other-prov" }]);
+    ee.queueMockRows([{ id: "other-prov" }]);
 
     await expect(updateSSOProvider("org-1", "prov-1", {
       domain: "taken.com",
@@ -367,9 +367,9 @@ describe("updateSSOProvider", () => {
 
   it("updates enabled flag", async () => {
     // getSSOProvider query
-    ee.setMockRows([sampleSamlRow]);
+    ee.queueMockRows([sampleSamlRow]);
     // UPDATE RETURNING
-    ee.setMockRows([{ ...sampleSamlRow, enabled: false }]);
+    ee.queueMockRows([{ ...sampleSamlRow, enabled: false }]);
 
     const provider = await updateSSOProvider("org-1", "prov-1", {
       enabled: false,
@@ -379,7 +379,7 @@ describe("updateSSOProvider", () => {
 
   it("returns existing provider when no fields to update", async () => {
     // getSSOProvider query
-    ee.setMockRows([sampleSamlRow]);
+    ee.queueMockRows([sampleSamlRow]);
 
     const provider = await updateSSOProvider("org-1", "prov-1", {});
     expect(provider.id).toBe("prov-1");
@@ -387,7 +387,7 @@ describe("updateSSOProvider", () => {
 
   it("throws when provider not found", async () => {
     // getSSOProvider returns nothing
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
 
     await expect(updateSSOProvider("org-1", "nonexistent", {
       issuer: "https://new.com",
@@ -407,9 +407,9 @@ describe("OIDC encryption round-trip", () => {
 
   it("encrypts clientSecret on create", async () => {
     // Domain uniqueness check
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
     // INSERT RETURNING
-    ee.setMockRows([sampleOidcRow]);
+    ee.queueMockRows([sampleOidcRow]);
 
     await createSSOProvider("org-1", {
       type: "oidc",
@@ -430,7 +430,7 @@ describe("OIDC encryption round-trip", () => {
   });
 
   it("decrypts clientSecret on read", async () => {
-    ee.setMockRows([sampleOidcRow]);
+    ee.queueMockRows([sampleOidcRow]);
     const providers = await listSSOProviders("org-1");
     expect(providers).toHaveLength(1);
     // The mock decryptUrl strips "encrypted:" prefix
@@ -445,9 +445,9 @@ describe("setSSOEnforcement", () => {
 
   it("enables enforcement when active provider exists", async () => {
     // Check for active providers
-    ee.setMockRows([{ id: "prov-1" }]);
+    ee.queueMockRows([{ id: "prov-1" }]);
     // UPDATE RETURNING query — must return at least one row
-    ee.setMockRows([{ id: "prov-1" }]);
+    ee.queueMockRows([{ id: "prov-1" }]);
 
     const result = await setSSOEnforcement("org-1", true);
     expect(result.enforced).toBe(true);
@@ -463,9 +463,9 @@ describe("setSSOEnforcement", () => {
 
   it("throws when enable UPDATE affects zero rows (providers deleted mid-request)", async () => {
     // Check for active providers — one found
-    ee.setMockRows([{ id: "prov-1" }]);
+    ee.queueMockRows([{ id: "prov-1" }]);
     // UPDATE RETURNING — zero rows (provider deleted between check and update)
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
 
     await expect(setSSOEnforcement("org-1", true)).rejects.toThrow(
       "No SSO providers were updated",
@@ -474,7 +474,7 @@ describe("setSSOEnforcement", () => {
 
   it("disables enforcement without checking providers", async () => {
     // UPDATE query (no provider check needed for disabling)
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
 
     const result = await setSSOEnforcement("org-1", false);
     expect(result.enforced).toBe(false);
@@ -483,7 +483,7 @@ describe("setSSOEnforcement", () => {
 
   it("rejects enforcement without active provider", async () => {
     // Check for active providers — none found
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
 
     await expect(setSSOEnforcement("org-1", true)).rejects.toThrow(
       "Cannot enforce SSO without at least one active SSO provider",
@@ -491,7 +491,7 @@ describe("setSSOEnforcement", () => {
   });
 
   it("throws SSOEnforcementError when no providers", async () => {
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
     try {
       await setSSOEnforcement("org-1", true);
       throw new Error("Should have thrown");
@@ -517,7 +517,7 @@ describe("isSSOEnforced", () => {
 
   it("returns enforced: true when enforcement is active", async () => {
     const enforcedRow = { ...sampleSamlRow, sso_enforced: true };
-    ee.setMockRows([enforcedRow]);
+    ee.queueMockRows([enforcedRow]);
 
     const result = await isSSOEnforced("org-1");
     expect(result).not.toBeNull();
@@ -527,7 +527,7 @@ describe("isSSOEnforced", () => {
   });
 
   it("returns enforced: false when no enforced providers", async () => {
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
 
     const result = await isSSOEnforced("org-1");
     expect(result).not.toBeNull();
@@ -537,7 +537,7 @@ describe("isSSOEnforced", () => {
   it("does NOT call requireEnterprise — usable in login flow", async () => {
     ee.setEnterpriseEnabled(false);
     ee.setEnterpriseLicenseKey(undefined);
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
 
     const result = await isSSOEnforced("org-1");
     expect(result).not.toBeNull();
@@ -550,7 +550,7 @@ describe("isSSOEnforcedForDomain", () => {
 
   it("returns enforced: true when domain has enforcement", async () => {
     const enforcedRow = { ...sampleSamlRow, sso_enforced: true };
-    ee.setMockRows([enforcedRow]);
+    ee.queueMockRows([enforcedRow]);
 
     const result = await isSSOEnforcedForDomain("acme.com");
     expect(result).not.toBeNull();
@@ -560,7 +560,7 @@ describe("isSSOEnforcedForDomain", () => {
 
   it("returns OIDC discovery URL for OIDC providers", async () => {
     const enforcedOidcRow = { ...sampleOidcRow, enabled: true, sso_enforced: true };
-    ee.setMockRows([enforcedOidcRow]);
+    ee.queueMockRows([enforcedOidcRow]);
 
     const result = await isSSOEnforcedForDomain("example.com");
     expect(result).not.toBeNull();
@@ -569,7 +569,7 @@ describe("isSSOEnforcedForDomain", () => {
   });
 
   it("returns enforced: false when domain has no enforcement", async () => {
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
 
     const result = await isSSOEnforcedForDomain("noenforcement.com");
     expect(result).not.toBeNull();
@@ -577,7 +577,7 @@ describe("isSSOEnforcedForDomain", () => {
   });
 
   it("normalizes domain case", async () => {
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
     await isSSOEnforcedForDomain("ACME.COM");
     expect(ee.capturedQueries[0].params[0]).toBe("acme.com");
   });
@@ -585,7 +585,7 @@ describe("isSSOEnforcedForDomain", () => {
   it("does NOT call requireEnterprise — usable in login flow", async () => {
     ee.setEnterpriseEnabled(false);
     ee.setEnterpriseLicenseKey(undefined);
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
 
     const result = await isSSOEnforcedForDomain("acme.com");
     expect(result).not.toBeNull();

--- a/ee/src/branding/white-label.test.ts
+++ b/ee/src/branding/white-label.test.ts
@@ -41,7 +41,7 @@ describe("getWorkspaceBranding", () => {
   beforeEach(() => ee.reset());
 
   it("returns branding when found", async () => {
-    ee.setMockRows([makeRow()]);
+    ee.queueMockRows([makeRow()]);
     const result = await getWorkspaceBranding("org-1");
     expect(result).not.toBeNull();
     expect(result!.orgId).toBe("org-1");
@@ -52,7 +52,7 @@ describe("getWorkspaceBranding", () => {
   });
 
   it("returns null when no branding found", async () => {
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
     const result = await getWorkspaceBranding("org-1");
     expect(result).toBeNull();
   });
@@ -75,14 +75,14 @@ describe("getWorkspaceBrandingPublic", () => {
 
   it("returns branding without enterprise check", async () => {
     ee.setEnterpriseEnabled(false);
-    ee.setMockRows([makeRow()]);
+    ee.queueMockRows([makeRow()]);
     const result = await getWorkspaceBrandingPublic("org-1");
     expect(result).not.toBeNull();
     expect(result!.logoText).toBe("Acme Corp");
   });
 
   it("returns null when no branding found", async () => {
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
     const result = await getWorkspaceBrandingPublic("org-1");
     expect(result).toBeNull();
   });
@@ -99,7 +99,7 @@ describe("setWorkspaceBranding", () => {
   beforeEach(() => ee.reset());
 
   it("upserts branding and returns result", async () => {
-    ee.setMockRows([makeRow()]);
+    ee.queueMockRows([makeRow()]);
     const result = await setWorkspaceBranding("org-1", {
       logoUrl: "https://example.com/logo.png",
       logoText: "Acme Corp",
@@ -149,7 +149,7 @@ describe("setWorkspaceBranding", () => {
   });
 
   it("allows empty string values (treated as null)", async () => {
-    ee.setMockRows([makeRow({ logo_url: null, primary_color: null, favicon_url: null })]);
+    ee.queueMockRows([makeRow({ logo_url: null, primary_color: null, favicon_url: null })]);
     const result = await setWorkspaceBranding("org-1", {
       logoUrl: "",
       primaryColor: "",
@@ -159,7 +159,7 @@ describe("setWorkspaceBranding", () => {
   });
 
   it("allows null/empty values", async () => {
-    ee.setMockRows([makeRow({ logo_url: null, logo_text: null, primary_color: null, favicon_url: null, hide_atlas_branding: false })]);
+    ee.queueMockRows([makeRow({ logo_url: null, logo_text: null, primary_color: null, favicon_url: null, hide_atlas_branding: false })]);
     const result = await setWorkspaceBranding("org-1", {
       logoUrl: null,
       logoText: null,
@@ -186,7 +186,7 @@ describe("setWorkspaceBranding", () => {
   });
 
   it("throws when INSERT returns no rows", async () => {
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
     await expect(
       setWorkspaceBranding("org-1", { logoText: "Test" }),
     ).rejects.toThrow("Failed to save workspace branding");
@@ -197,13 +197,13 @@ describe("deleteWorkspaceBranding", () => {
   beforeEach(() => ee.reset());
 
   it("returns true when branding was deleted", async () => {
-    ee.setMockRows([{ id: "brand-123" }]);
+    ee.queueMockRows([{ id: "brand-123" }]);
     const result = await deleteWorkspaceBranding("org-1");
     expect(result).toBe(true);
   });
 
   it("returns false when no branding existed", async () => {
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
     const result = await deleteWorkspaceBranding("org-1");
     expect(result).toBe(false);
   });

--- a/ee/src/governance/approval.test.ts
+++ b/ee/src/governance/approval.test.ts
@@ -95,13 +95,13 @@ describe("listApprovalRules", () => {
   beforeEach(resetMocks);
 
   it("returns empty array when no rules exist", async () => {
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
     const result = await listApprovalRules("org-1");
     expect(result).toEqual([]);
   });
 
   it("returns rules for the organization", async () => {
-    ee.setMockRows([makeRuleRow(), makeRuleRow({ id: "rule-2", name: "SSN column" })]);
+    ee.queueMockRows([makeRuleRow(), makeRuleRow({ id: "rule-2", name: "SSN column" })]);
     const result = await listApprovalRules("org-1");
     expect(result).toHaveLength(2);
     expect(result[0].name).toBe("PII table approval");
@@ -118,13 +118,13 @@ describe("getApprovalRule", () => {
   beforeEach(resetMocks);
 
   it("returns null when rule does not exist", async () => {
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
     const result = await getApprovalRule("org-1", "rule-1");
     expect(result).toBeNull();
   });
 
   it("returns rule when found", async () => {
-    ee.setMockRows([makeRuleRow()]);
+    ee.queueMockRows([makeRuleRow()]);
     const result = await getApprovalRule("org-1", "rule-1");
     expect(result).not.toBeNull();
     expect(result!.name).toBe("PII table approval");
@@ -137,7 +137,7 @@ describe("createApprovalRule", () => {
   beforeEach(resetMocks);
 
   it("creates a table rule", async () => {
-    ee.setMockRows([makeRuleRow()]);
+    ee.queueMockRows([makeRuleRow()]);
     const result = await createApprovalRule("org-1", {
       name: "PII table approval",
       ruleType: "table",
@@ -182,20 +182,20 @@ describe("updateApprovalRule", () => {
 
   it("updates rule name", async () => {
     // getApprovalRule call
-    ee.setMockRows([makeRuleRow()]);
+    ee.queueMockRows([makeRuleRow()]);
     // UPDATE RETURNING
-    ee.setMockRows([makeRuleRow({ name: "Updated name" })]);
+    ee.queueMockRows([makeRuleRow({ name: "Updated name" })]);
     const result = await updateApprovalRule("org-1", "rule-1", { name: "Updated name" });
     expect(result.name).toBe("Updated name");
   });
 
   it("throws not_found for missing rule", async () => {
-    ee.setMockRows([]); // getApprovalRule returns nothing
+    ee.queueMockRows([]); // getApprovalRule returns nothing
     await expect(updateApprovalRule("org-1", "missing", { name: "x" })).rejects.toThrow("not found");
   });
 
   it("returns existing rule when no changes", async () => {
-    ee.setMockRows([makeRuleRow()]);
+    ee.queueMockRows([makeRuleRow()]);
     const result = await updateApprovalRule("org-1", "rule-1", {});
     expect(result.name).toBe("PII table approval");
   });
@@ -206,7 +206,7 @@ describe("deleteApprovalRule", () => {
 
   it("returns true when rule is deleted", async () => {
     // getInternalDB().query returns rowCount based on rows array length
-    ee.setMockRows([{ deleted: true }]); // simulate 1 affected row
+    ee.queueMockRows([{ deleted: true }]); // simulate 1 affected row
     const result = await deleteApprovalRule("org-1", "rule-1");
     expect(result).toBe(true);
   });
@@ -240,13 +240,13 @@ describe("checkApprovalRequired", () => {
   });
 
   it("returns false when no rules exist", async () => {
-    ee.setMockRows([]); // empty rules
+    ee.queueMockRows([]); // empty rules
     const result = await checkApprovalRequired("org-1", ["users"], ["id"]);
     expect(result.required).toBe(false);
   });
 
   it("matches table rule", async () => {
-    ee.setMockRows([makeRuleRow({ rule_type: "table", pattern: "users" })]);
+    ee.queueMockRows([makeRuleRow({ rule_type: "table", pattern: "users" })]);
     const result = await checkApprovalRequired("org-1", ["users"], ["id"]);
     expect(result.required).toBe(true);
     expect(result.matchedRules).toHaveLength(1);
@@ -254,25 +254,25 @@ describe("checkApprovalRequired", () => {
   });
 
   it("matches table rule case-insensitively", async () => {
-    ee.setMockRows([makeRuleRow({ rule_type: "table", pattern: "Users" })]);
+    ee.queueMockRows([makeRuleRow({ rule_type: "table", pattern: "Users" })]);
     const result = await checkApprovalRequired("org-1", ["users"], ["id"]);
     expect(result.required).toBe(true);
   });
 
   it("matches column rule", async () => {
-    ee.setMockRows([makeRuleRow({ rule_type: "column", pattern: "ssn" })]);
+    ee.queueMockRows([makeRuleRow({ rule_type: "column", pattern: "ssn" })]);
     const result = await checkApprovalRequired("org-1", ["users"], ["ssn"]);
     expect(result.required).toBe(true);
   });
 
   it("does not match when table is not accessed", async () => {
-    ee.setMockRows([makeRuleRow({ rule_type: "table", pattern: "secret_data" })]);
+    ee.queueMockRows([makeRuleRow({ rule_type: "table", pattern: "secret_data" })]);
     const result = await checkApprovalRequired("org-1", ["orders"], ["id"]);
     expect(result.required).toBe(false);
   });
 
   it("matches schema-qualified table name", async () => {
-    ee.setMockRows([makeRuleRow({ rule_type: "table", pattern: "users" })]);
+    ee.queueMockRows([makeRuleRow({ rule_type: "table", pattern: "users" })]);
     const result = await checkApprovalRequired("org-1", ["public.users"], ["id"]);
     expect(result.required).toBe(true);
   });
@@ -284,7 +284,7 @@ describe("createApprovalRequest", () => {
   beforeEach(resetMocks);
 
   it("creates an approval request", async () => {
-    ee.setMockRows([makeQueueRow()]);
+    ee.queueMockRows([makeQueueRow()]);
     const result = await createApprovalRequest({
       orgId: "org-1",
       ruleId: "rule-1",
@@ -308,13 +308,13 @@ describe("listApprovalRequests", () => {
   beforeEach(resetMocks);
 
   it("returns all requests", async () => {
-    ee.setMockRows([makeQueueRow(), makeQueueRow({ id: "req-2" })]);
+    ee.queueMockRows([makeQueueRow(), makeQueueRow({ id: "req-2" })]);
     const result = await listApprovalRequests("org-1");
     expect(result).toHaveLength(2);
   });
 
   it("filters by status", async () => {
-    ee.setMockRows([makeQueueRow({ status: "approved" })]);
+    ee.queueMockRows([makeQueueRow({ status: "approved" })]);
     const result = await listApprovalRequests("org-1", "approved");
     expect(result).toHaveLength(1);
     expect(ee.capturedQueries[0].sql).toContain("AND status = $2");
@@ -326,29 +326,29 @@ describe("reviewApprovalRequest", () => {
 
   it("approves a pending request", async () => {
     // getApprovalRequest call
-    ee.setMockRows([makeQueueRow()]);
+    ee.queueMockRows([makeQueueRow()]);
     // UPDATE RETURNING
-    ee.setMockRows([makeQueueRow({ status: "approved", reviewer_id: "admin-1", reviewed_at: "2026-01-01T12:00:00Z" })]);
+    ee.queueMockRows([makeQueueRow({ status: "approved", reviewer_id: "admin-1", reviewed_at: "2026-01-01T12:00:00Z" })]);
     const result = await reviewApprovalRequest("org-1", "req-1", "admin-1", "admin@example.com", "approve", "Looks good");
     expect(result.status).toBe("approved");
   });
 
   it("denies a pending request", async () => {
-    ee.setMockRows([makeQueueRow()]);
-    ee.setMockRows([makeQueueRow({ status: "denied", reviewer_id: "admin-1", reviewed_at: "2026-01-01T12:00:00Z" })]);
+    ee.queueMockRows([makeQueueRow()]);
+    ee.queueMockRows([makeQueueRow({ status: "denied", reviewer_id: "admin-1", reviewed_at: "2026-01-01T12:00:00Z" })]);
     const result = await reviewApprovalRequest("org-1", "req-1", "admin-1", "admin@example.com", "deny");
     expect(result.status).toBe("denied");
   });
 
   it("throws not_found for missing request", async () => {
-    ee.setMockRows([]); // getApprovalRequest returns nothing
+    ee.queueMockRows([]); // getApprovalRequest returns nothing
     await expect(
       reviewApprovalRequest("org-1", "missing", "admin-1", null, "approve"),
     ).rejects.toThrow("not found");
   });
 
   it("throws conflict for already-reviewed request", async () => {
-    ee.setMockRows([makeQueueRow({ status: "approved" })]);
+    ee.queueMockRows([makeQueueRow({ status: "approved" })]);
     await expect(
       reviewApprovalRequest("org-1", "req-1", "admin-1", null, "approve"),
     ).rejects.toThrow("Cannot approve request");
@@ -356,9 +356,9 @@ describe("reviewApprovalRequest", () => {
 
   it("auto-expires and throws for expired request", async () => {
     // Return a pending request that's already past its expiry
-    ee.setMockRows([makeQueueRow({ expires_at: "2020-01-01T00:00:00Z" })]);
+    ee.queueMockRows([makeQueueRow({ expires_at: "2020-01-01T00:00:00Z" })]);
     // For the UPDATE to expired status
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
     await expect(
       reviewApprovalRequest("org-1", "req-1", "admin-1", null, "approve"),
     ).rejects.toThrow("expired");
@@ -407,7 +407,7 @@ describe("getPendingCount", () => {
   });
 
   it("returns count from database", async () => {
-    ee.setMockRows([{ count: "5" }]);
+    ee.queueMockRows([{ count: "5" }]);
     const result = await getPendingCount("org-1");
     expect(result).toBe(5);
   });
@@ -417,7 +417,7 @@ describe("reviewApprovalRequest — self-approval", () => {
   beforeEach(resetMocks);
 
   it("throws conflict when reviewer is the requester", async () => {
-    ee.setMockRows([makeQueueRow({ requester_id: "user-1" })]);
+    ee.queueMockRows([makeQueueRow({ requester_id: "user-1" })]);
     await expect(
       reviewApprovalRequest("org-1", "req-1", "user-1", "user@example.com", "approve"),
     ).rejects.toThrow("Cannot review your own approval request");
@@ -428,14 +428,14 @@ describe("hasApprovedRequest", () => {
   beforeEach(resetMocks);
 
   it("returns true when an approved request exists", async () => {
-    ee.setMockRows([{ id: "req-1" }]);
+    ee.queueMockRows([{ id: "req-1" }]);
     const result = await hasApprovedRequest("org-1", "user-1", "SELECT * FROM users");
     expect(result).toBe(true);
     expect(ee.capturedQueries[0].sql).toContain("status = 'approved'");
   });
 
   it("returns false when no approved request exists", async () => {
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
     const result = await hasApprovedRequest("org-1", "user-1", "SELECT * FROM users");
     expect(result).toBe(false);
   });

--- a/ee/src/platform/domains.test.ts
+++ b/ee/src/platform/domains.test.ts
@@ -120,7 +120,7 @@ describe("domains", () => {
   describe("registerDomain", () => {
     it("registers a valid domain via Railway", async () => {
       // Check for existing → no results
-      ee.setMockRows([]);
+      ee.queueMockRows([]);
       // Railway availability check
       mockFetchResponses.push({
         ok: true,
@@ -145,7 +145,7 @@ describe("domains", () => {
         },
       });
       // INSERT → returning
-      ee.setMockRows([makeDomainRow()]);
+      ee.queueMockRows([makeDomainRow()]);
 
       const result = await registerDomain("org-1", "data.acme.com");
       expect(result.domain).toBe("data.acme.com");
@@ -165,12 +165,12 @@ describe("domains", () => {
     });
 
     it("rejects duplicate domain in local DB", async () => {
-      ee.setMockRows([{ id: "existing" }]); // existing domain found
+      ee.queueMockRows([{ id: "existing" }]); // existing domain found
       await expect(registerDomain("org-1", "data.acme.com")).rejects.toThrow("already registered");
     });
 
     it("rejects domain unavailable on Railway", async () => {
-      ee.setMockRows([]); // no existing
+      ee.queueMockRows([]); // no existing
       mockFetchResponses.push({
         ok: true,
         status: 200,
@@ -180,7 +180,7 @@ describe("domains", () => {
     });
 
     it("normalizes domain to lowercase", async () => {
-      ee.setMockRows([]);
+      ee.queueMockRows([]);
       mockFetchResponses.push({
         ok: true,
         status: 200,
@@ -202,7 +202,7 @@ describe("domains", () => {
           },
         },
       });
-      ee.setMockRows([makeDomainRow()]);
+      ee.queueMockRows([makeDomainRow()]);
 
       await registerDomain("org-1", "DATA.ACME.COM");
       // The INSERT query should use lowercase domain
@@ -212,12 +212,12 @@ describe("domains", () => {
 
     it("throws when Railway is not configured", async () => {
       cleanupEnv();
-      ee.setMockRows([]); // no existing
+      ee.queueMockRows([]); // no existing
       await expect(registerDomain("org-1", "data.acme.com")).rejects.toThrow("Railway API is not configured");
     });
 
     it("throws on Railway GraphQL errors (200 with errors array)", async () => {
-      ee.setMockRows([]); // no existing
+      ee.queueMockRows([]); // no existing
       mockFetchResponses.push({
         ok: true,
         status: 200,
@@ -233,7 +233,7 @@ describe("domains", () => {
     });
 
     it("throws on Railway missing data field", async () => {
-      ee.setMockRows([]); // no existing
+      ee.queueMockRows([]); // no existing
       mockFetchResponses.push({
         ok: true,
         status: 200,
@@ -249,7 +249,7 @@ describe("domains", () => {
     });
 
     it("throws on Railway network error", async () => {
-      ee.setMockRows([]); // no existing
+      ee.queueMockRows([]); // no existing
       // Override fetch to throw network error for railway calls
       const prevFetch = globalThis.fetch;
       // @ts-expect-error — mock fetch for network failure test
@@ -265,7 +265,7 @@ describe("domains", () => {
   describe("verifyDomain", () => {
     it("marks domain as verified when Railway says cert is ISSUED and DNS is valid", async () => {
       // SELECT domain
-      ee.setMockRows([makeDomainRow()]);
+      ee.queueMockRows([makeDomainRow()]);
       // Railway status check
       mockFetchResponses.push({
         ok: true,
@@ -284,7 +284,7 @@ describe("domains", () => {
         },
       });
       // UPDATE → returning
-      ee.setMockRows([makeDomainRow({ status: "verified", certificate_status: "ISSUED", verified_at: MOCK_NOW })]);
+      ee.queueMockRows([makeDomainRow({ status: "verified", certificate_status: "ISSUED", verified_at: MOCK_NOW })]);
 
       const result = await verifyDomain("dom-1");
       expect(result.status).toBe("verified");
@@ -292,7 +292,7 @@ describe("domains", () => {
     });
 
     it("keeps domain pending when cert is still PENDING", async () => {
-      ee.setMockRows([makeDomainRow()]);
+      ee.queueMockRows([makeDomainRow()]);
       mockFetchResponses.push({
         ok: true,
         status: 200,
@@ -309,14 +309,14 @@ describe("domains", () => {
           },
         },
       });
-      ee.setMockRows([makeDomainRow({ status: "pending", certificate_status: "PENDING" })]);
+      ee.queueMockRows([makeDomainRow({ status: "pending", certificate_status: "PENDING" })]);
 
       const result = await verifyDomain("dom-1");
       expect(result.status).toBe("pending");
     });
 
     it("marks domain as failed when cert is FAILED", async () => {
-      ee.setMockRows([makeDomainRow()]);
+      ee.queueMockRows([makeDomainRow()]);
       mockFetchResponses.push({
         ok: true,
         status: 200,
@@ -333,14 +333,14 @@ describe("domains", () => {
           },
         },
       });
-      ee.setMockRows([makeDomainRow({ status: "failed", certificate_status: "FAILED" })]);
+      ee.queueMockRows([makeDomainRow({ status: "failed", certificate_status: "FAILED" })]);
 
       const result = await verifyDomain("dom-1");
       expect(result.status).toBe("failed");
     });
 
     it("stays pending when cert is ISSUED but DNS is not valid", async () => {
-      ee.setMockRows([makeDomainRow()]);
+      ee.queueMockRows([makeDomainRow()]);
       mockFetchResponses.push({
         ok: true,
         status: 200,
@@ -357,26 +357,26 @@ describe("domains", () => {
           },
         },
       });
-      ee.setMockRows([makeDomainRow({ status: "pending", certificate_status: "ISSUED" })]);
+      ee.queueMockRows([makeDomainRow({ status: "pending", certificate_status: "ISSUED" })]);
 
       const result = await verifyDomain("dom-1");
       expect(result.status).toBe("pending");
     });
 
     it("throws for nonexistent domain", async () => {
-      ee.setMockRows([]); // no results
+      ee.queueMockRows([]); // no results
       await expect(verifyDomain("dom-999")).rejects.toThrow("not found");
     });
 
     it("throws when domain has no Railway ID", async () => {
-      ee.setMockRows([makeDomainRow({ railway_domain_id: null })]);
+      ee.queueMockRows([makeDomainRow({ railway_domain_id: null })]);
       await expect(verifyDomain("dom-1")).rejects.toThrow("no Railway domain ID");
     });
   });
 
   describe("listDomains", () => {
     it("returns domains for workspace", async () => {
-      ee.setMockRows([
+      ee.queueMockRows([
         makeDomainRow(),
         makeDomainRow({ id: "dom-2", domain: "api.acme.com", status: "verified" }),
       ]);
@@ -388,7 +388,7 @@ describe("domains", () => {
     });
 
     it("returns empty array when workspace has no domains", async () => {
-      ee.setMockRows([]);
+      ee.queueMockRows([]);
       const result = await listDomains("org-1");
       expect(result).toHaveLength(0);
     });
@@ -396,7 +396,7 @@ describe("domains", () => {
 
   describe("listAllDomains", () => {
     it("returns all domains across workspaces", async () => {
-      ee.setMockRows([
+      ee.queueMockRows([
         makeDomainRow(),
         makeDomainRow({ id: "dom-2", workspace_id: "org-2", domain: "api.other.com" }),
       ]);
@@ -409,7 +409,7 @@ describe("domains", () => {
   describe("deleteDomain", () => {
     it("deletes domain from both Railway and local DB", async () => {
       // SELECT domain
-      ee.setMockRows([makeDomainRow()]);
+      ee.queueMockRows([makeDomainRow()]);
       // Railway delete
       mockFetchResponses.push({
         ok: true,
@@ -417,7 +417,7 @@ describe("domains", () => {
         json: { data: { customDomainDelete: true } },
       });
       // DELETE
-      ee.setMockRows([]);
+      ee.queueMockRows([]);
 
       await deleteDomain("dom-1");
       expect(capturedFetches).toHaveLength(1); // Railway delete called
@@ -425,12 +425,12 @@ describe("domains", () => {
     });
 
     it("throws for nonexistent domain", async () => {
-      ee.setMockRows([]); // no results
+      ee.queueMockRows([]); // no results
       await expect(deleteDomain("dom-999")).rejects.toThrow("not found");
     });
 
     it("proceeds with local delete even if Railway delete fails", async () => {
-      ee.setMockRows([makeDomainRow()]);
+      ee.queueMockRows([makeDomainRow()]);
       // Railway delete fails
       mockFetchResponses.push({
         ok: false,
@@ -438,7 +438,7 @@ describe("domains", () => {
         json: { errors: [{ message: "Internal error" }] },
       });
       // Local DELETE still runs
-      ee.setMockRows([]);
+      ee.queueMockRows([]);
 
       // Should not throw
       await deleteDomain("dom-1");
@@ -446,8 +446,8 @@ describe("domains", () => {
     });
 
     it("skips Railway delete when no railway_domain_id", async () => {
-      ee.setMockRows([makeDomainRow({ railway_domain_id: null })]);
-      ee.setMockRows([]); // DELETE
+      ee.queueMockRows([makeDomainRow({ railway_domain_id: null })]);
+      ee.queueMockRows([]); // DELETE
 
       await deleteDomain("dom-1");
       expect(capturedFetches).toHaveLength(0); // No Railway call
@@ -456,19 +456,19 @@ describe("domains", () => {
 
   describe("resolveWorkspaceByHost", () => {
     it("resolves verified domain to workspace ID", async () => {
-      ee.setMockRows([{ workspace_id: "org-1" }]);
+      ee.queueMockRows([{ workspace_id: "org-1" }]);
       const result = await resolveWorkspaceByHost("data.acme.com");
       expect(result).toBe("org-1");
     });
 
     it("returns null for unknown domain", async () => {
-      ee.setMockRows([]);
+      ee.queueMockRows([]);
       const result = await resolveWorkspaceByHost("unknown.example.com");
       expect(result).toBeNull();
     });
 
     it("uses cache on second lookup", async () => {
-      ee.setMockRows([{ workspace_id: "org-1" }]);
+      ee.queueMockRows([{ workspace_id: "org-1" }]);
       await resolveWorkspaceByHost("data.acme.com");
       // Second call should not hit DB
       const result = await resolveWorkspaceByHost("data.acme.com");
@@ -477,14 +477,14 @@ describe("domains", () => {
     });
 
     it("normalizes hostname to lowercase", async () => {
-      ee.setMockRows([{ workspace_id: "org-1" }]);
+      ee.queueMockRows([{ workspace_id: "org-1" }]);
       await resolveWorkspaceByHost("DATA.ACME.COM");
       const query = ee.capturedQueries[0];
       expect(query.params?.[0]).toBe("data.acme.com");
     });
 
     it("returns null gracefully on DB error", async () => {
-      ee.setMockRows([]);
+      ee.queueMockRows([]);
       const result = await resolveWorkspaceByHost("unknown.example.com");
       expect(result).toBeNull();
       // Verify negative cache prevents second DB hit

--- a/ee/src/platform/model-routing.test.ts
+++ b/ee/src/platform/model-routing.test.ts
@@ -56,13 +56,13 @@ describe("getWorkspaceModelConfig", () => {
   beforeEach(() => ee.reset());
 
   it("returns null when no config exists", async () => {
-    ee.setMockRows([]); // empty result
+    ee.queueMockRows([]); // empty result
     const result = await getWorkspaceModelConfig("org-1");
     expect(result).toBeNull();
   });
 
   it("returns config with masked API key", async () => {
-    ee.setMockRows([makeRow()]);
+    ee.queueMockRows([makeRow()]);
     const result = await getWorkspaceModelConfig("org-1");
     expect(result).not.toBeNull();
     expect(result!.provider).toBe("anthropic");
@@ -81,13 +81,13 @@ describe("getWorkspaceModelConfigRaw", () => {
   beforeEach(() => ee.reset());
 
   it("returns null when no config exists", async () => {
-    ee.setMockRows([]); // empty result
+    ee.queueMockRows([]); // empty result
     const result = await getWorkspaceModelConfigRaw("org-1");
     expect(result).toBeNull();
   });
 
   it("returns raw config with decrypted API key", async () => {
-    ee.setMockRows([makeRow()]);
+    ee.queueMockRows([makeRow()]);
     const result = await getWorkspaceModelConfigRaw("org-1");
     expect(result).not.toBeNull();
     expect(result!.provider).toBe("anthropic");
@@ -97,7 +97,7 @@ describe("getWorkspaceModelConfigRaw", () => {
 
   it("does NOT enforce enterprise gate (called in hot path)", async () => {
     ee.setEnterpriseEnabled(false);
-    ee.setMockRows([]);
+    ee.queueMockRows([]);
     // Should not throw even when enterprise is disabled
     const result = await getWorkspaceModelConfigRaw("org-1");
     expect(result).toBeNull();
@@ -108,7 +108,7 @@ describe("setWorkspaceModelConfig", () => {
   beforeEach(() => ee.reset());
 
   it("saves config with encrypted API key", async () => {
-    ee.setMockRows([makeRow()]);
+    ee.queueMockRows([makeRow()]);
     const result = await setWorkspaceModelConfig("org-1", {
       provider: "anthropic",
       model: "claude-opus-4-6",
@@ -183,7 +183,7 @@ describe("setWorkspaceModelConfig", () => {
   });
 
   it("accepts valid base URL for custom provider", async () => {
-    ee.setMockRows([makeRow({
+    ee.queueMockRows([makeRow({
       provider: "custom",
       model: "llama-3",
       base_url: "https://api.example.com/v1",
@@ -214,14 +214,14 @@ describe("deleteWorkspaceModelConfig", () => {
   beforeEach(() => ee.reset());
 
   it("returns true when config is deleted", async () => {
-    ee.setMockRows([{ id: "cfg-123" }]); // DELETE RETURNING result
+    ee.queueMockRows([{ id: "cfg-123" }]); // DELETE RETURNING result
     const result = await deleteWorkspaceModelConfig("org-1");
     expect(result).toBe(true);
     expect(ee.capturedQueries[0].sql).toContain("DELETE FROM workspace_model_config");
   });
 
   it("returns false when no config exists", async () => {
-    ee.setMockRows([]); // empty DELETE RETURNING result
+    ee.queueMockRows([]); // empty DELETE RETURNING result
     const result = await deleteWorkspaceModelConfig("org-1");
     expect(result).toBe(false);
   });

--- a/ee/src/platform/residency.test.ts
+++ b/ee/src/platform/residency.test.ts
@@ -113,7 +113,7 @@ describe("residency", () => {
 
   describe("listRegions", () => {
     it("returns regions with workspace counts", async () => {
-      ee.setMockRows([
+      ee.queueMockRows([
         { region: "us-east", cnt: "3" },
         { region: "eu-west", cnt: "1" },
       ]);
@@ -127,7 +127,7 @@ describe("residency", () => {
     });
 
     it("returns zero counts for regions with no workspaces", async () => {
-      ee.setMockRows([]); // no workspace counts
+      ee.queueMockRows([]); // no workspace counts
       const regions = await listRegions();
       expect(regions[0].workspaceCount).toBe(0);
     });
@@ -160,7 +160,7 @@ describe("residency", () => {
 
   describe("getWorkspaceRegionAssignment", () => {
     it("returns assignment for workspace with region", async () => {
-      ee.setMockRows([{ region: "eu-west", region_assigned_at: "2026-03-23T00:00:00Z" }]);
+      ee.queueMockRows([{ region: "eu-west", region_assigned_at: "2026-03-23T00:00:00Z" }]);
       const result = await getWorkspaceRegionAssignment("org-1");
       expect(result).not.toBeNull();
       expect(result!.region).toBe("eu-west");
@@ -168,13 +168,13 @@ describe("residency", () => {
     });
 
     it("returns null for workspace without region", async () => {
-      ee.setMockRows([{ region: null, region_assigned_at: null }]);
+      ee.queueMockRows([{ region: null, region_assigned_at: null }]);
       const result = await getWorkspaceRegionAssignment("org-1");
       expect(result).toBeNull();
     });
 
     it("returns null for nonexistent workspace", async () => {
-      ee.setMockRows([]);
+      ee.queueMockRows([]);
       const result = await getWorkspaceRegionAssignment("org-999");
       expect(result).toBeNull();
     });
@@ -205,7 +205,7 @@ describe("residency", () => {
 
   describe("listWorkspaceRegions", () => {
     it("returns all assignments", async () => {
-      ee.setMockRows([
+      ee.queueMockRows([
         { id: "org-1", region: "us-east", region_assigned_at: "2026-03-23T00:00:00Z" },
         { id: "org-2", region: "eu-west", region_assigned_at: "2026-03-23T01:00:00Z" },
       ]);


### PR DESCRIPTION
## Summary
- Creates `ee/src/__mocks__/internal.ts` with a `createEEMock()` factory that centralises the enterprise gate, internal DB, and logger mocks duplicated across 9 EE test files
- Follows the `createConnectionMock()` precedent in `packages/api/src/__mocks__/connection.ts`
- Net reduction of **299 lines** (-470 in test files, +171 factory)

Fixes #836

## What changed

**New file:** `ee/src/__mocks__/internal.ts`
- `createEEMock()` returns `enterpriseMock`, `internalDBMock`, `loggerMock` + helpers
- Imports and re-exports the real `EnterpriseError` class (instanceof checks work)
- `requireEnterprise` throws `EnterpriseError`, not plain `Error`
- All named exports from each mocked module are included (prevents partial mock SyntaxError in Bun)
- Supports overrides for custom internal DB exports (used by residency.test.ts)

**Migrated files (9):**
- `ee/src/auth/sso.test.ts`
- `ee/src/auth/roles.test.ts`
- `ee/src/auth/ip-allowlist.test.ts`
- `ee/src/auth/scim.test.ts`
- `ee/src/branding/white-label.test.ts`
- `ee/src/platform/domains.test.ts`
- `ee/src/platform/model-routing.test.ts`
- `ee/src/platform/residency.test.ts`
- `ee/src/governance/approval.test.ts`

**Not migrated:** `masking.test.ts` — uses a fundamentally different mock pattern (mocks `getConfig` directly instead of `../index`).

## Test plan
- [x] All 9 migrated test files pass (323 tests total)
- [x] `bun run lint` passes
- [x] `bun run type` passes
- [x] `bun run test` passes (full suite)