### PR TITLE
refactor: adopt react-hook-form for admin inline forms (batch 3)

### DIFF
--- a/packages/web/src/app/admin/approval/page.tsx
+++ b/packages/web/src/app/admin/approval/page.tsx
@@ -74,7 +74,13 @@ const createRuleSchema = z.object({
   ruleType: z.enum(["table", "column", "cost"]),
   pattern: z.string(),
   threshold: z.string(),
-});
+}).refine(
+  (data) => data.ruleType === "cost" || data.pattern.trim().length > 0,
+  { message: "Pattern is required for table/column rules", path: ["pattern"] },
+).refine(
+  (data) => data.ruleType !== "cost" || (data.threshold.trim().length > 0 && !isNaN(Number(data.threshold))),
+  { message: "A valid numeric threshold is required", path: ["threshold"] },
+);
 
 function statusBadge(status: ApprovalStatus) {
   switch (status) {

--- a/packages/web/src/app/admin/branding/page.tsx
+++ b/packages/web/src/app/admin/branding/page.tsx
@@ -67,6 +67,8 @@ export default function BrandingPage() {
         faviconUrl: data.faviconUrl ?? "",
         hideAtlasBranding: data.hideAtlasBranding,
       });
+    } else {
+      form.reset({ logoUrl: "", logoText: "", primaryColor: "", faviconUrl: "", hideAtlasBranding: false });
     }
   }, [data, loading]); // intentionally reset when data changes (after save/refetch)
 
@@ -82,7 +84,7 @@ export default function BrandingPage() {
   const colorValid = !primaryColor || HEX_RE.test(primaryColor);
 
   async function handleSave(values: z.infer<typeof brandingSchema>) {
-    await mutate({
+    const result = await mutate({
       method: "PUT",
       body: {
         logoUrl: values.logoUrl || null,
@@ -92,11 +94,16 @@ export default function BrandingPage() {
         hideAtlasBranding: values.hideAtlasBranding,
       },
     });
+    if (result === undefined) {
+      throw new Error("Save failed");
+    }
   }
 
   async function handleReset() {
-    await mutate({ method: "DELETE" });
-    form.reset({ logoUrl: "", logoText: "", primaryColor: "", faviconUrl: "", hideAtlasBranding: false });
+    const result = await mutate({ method: "DELETE" });
+    if (result !== undefined) {
+      form.reset({ logoUrl: "", logoText: "", primaryColor: "", faviconUrl: "", hideAtlasBranding: false });
+    }
   }
 
   return (

--- a/packages/web/src/app/admin/model-config/page.tsx
+++ b/packages/web/src/app/admin/model-config/page.tsx
@@ -101,7 +101,7 @@ export default function ModelConfigPage() {
 
   // Sync form when server data loads or changes (after save/refetch)
   useEffect(() => {
-    if (data === null) return; // still loading
+    if (loading) return; // wait for fetch to complete
     if (existingConfig) {
       form.reset({
         provider: existingConfig.provider,
@@ -113,11 +113,10 @@ export default function ModelConfigPage() {
       form.reset({ provider: "anthropic", model: "", apiKey: "", baseUrl: "" });
     }
     setTestResult(null);
-
     clearSaveError();
     clearDeleteError();
     clearTestError();
-  }, [data]); // intentionally depends only on `data` — reset when server data changes
+  }, [data, loading]); // reset when server data changes or loading completes
 
   // Gate: 401/403/404
   if (!loading && error?.status && [401, 403, 404].includes(error.status)) {


### PR DESCRIPTION
## Summary

Continues the react-hook-form migration from #856 / PR #862. This batch converts **inline settings forms** on admin pages from manual `useState` per field to `useForm` + Zod + shadcn `<Form>`.

### Migrated (3 pages)
- **approval/page.tsx** — Create-rule inline form (`name`, `ruleType`, `pattern`, `threshold`) → `useForm` + `createRuleSchema`. Review comments kept as `useState` (dynamic per-request).
- **model-config/page.tsx** — Provider config form (`provider`, `model`, `apiKey`, `baseUrl`) → `useForm` + `modelConfigSchema`. Replaced render-time state sync (`prevConfig` pattern) with `useEffect`-based `form.reset()`.
- **branding/page.tsx** — Branding settings form (`logoUrl`, `logoText`, `primaryColor`, `faviconUrl`, `hideAtlasBranding`) → `useForm` + `brandingSchema` with Zod hex color validation. Replaced `synced` flag with `useEffect`-based `form.reset()`.

### Skipped (2 pages — no forms to migrate)
- **platform/page.tsx** — Only has confirmation dialogs (suspend/unsuspend/delete) and a single Select for plan changes. No text-input forms.
- **semantic/page.tsx** — Pure read-only viewer with no forms at all.

### Pattern used
For inline forms (no Dialog):
```tsx
import { useForm } from "react-hook-form";
import { zodResolver } from "@hookform/resolvers/zod";
import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
```

### What's unchanged
- AlertDialog confirmations left as-is
- Table rendering, data fetching, filter/pagination logic untouched
- `useAdminFetch` / `useAdminMutation` hooks unchanged
- Non-form `useState` (dialog open state, tab state, filter state) unchanged

## Test plan
- [x] `bun run lint` — passes
- [x] `bun run type` — passes
- [x] `bun run test` — passes
- [x] `bun x syncpack lint` — passes
- [x] Template drift check — passes
- [ ] Manual: verify approval rule creation form validates and submits
- [ ] Manual: verify model config form syncs from server data and saves
- [ ] Manual: verify branding form syncs, validates hex color, saves, and resets