### PR TITLE
chore: upgrade Bun 1.3.10 → 1.3.11, fix DuckDB segfault

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -50,7 +50,7 @@ body:
     id: bun-version
     attributes:
       label: bun version
-      placeholder: "e.g. 1.3.10"
+      placeholder: "e.g. 1.3.11"
     validations:
       required: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 env:
-  BUN_VERSION: "1.3.10"
+  BUN_VERSION: "1.3.11"
 
 jobs:
   ci:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@e3914758a49697077f7bcd190d36582a61667aad # v2 + node24 (pending release)
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.11"
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/sync-starter.yml.disabled
+++ b/.github/workflows/sync-starter.yml.disabled
@@ -30,7 +30,7 @@ permissions:
   contents: read
 
 env:
-  BUN_VERSION: "1.3.10"
+  BUN_VERSION: "1.3.11"
 
 jobs:
   sync:

--- a/.github/workflows/sync-starters.yml
+++ b/.github/workflows/sync-starters.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read
 
 env:
-  BUN_VERSION: "1.3.10"
+  BUN_VERSION: "1.3.11"
 
 jobs:
   sync:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ you need to get started.
 
 ## Prerequisites
 
-- **[bun](https://bun.sh/)** >= 1.3.10 — package manager and runtime
+- **[bun](https://bun.sh/)** >= 1.3.11 — package manager and runtime
 - **[Docker](https://www.docker.com/)** — for the local Postgres database and sandbox sidecar
 
 ## Dev Setup

--- a/apps/docs/content/docs/getting-started/quick-start.mdx
+++ b/apps/docs/content/docs/getting-started/quick-start.mdx
@@ -12,7 +12,7 @@ import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
 
 Before you start, make sure you have:
 
-- **[Bun](https://bun.sh/) v1.3.10+** — check with `bun --version`
+- **[Bun](https://bun.sh/) v1.3.11+** — check with `bun --version`
 - **[Docker](https://docs.docker.com/get-docker/)** — check with `docker --version` (Docker Desktop must be running)
 - **An LLM API key** — [Anthropic](https://console.anthropic.com/), [OpenAI](https://platform.openai.com/), or another [supported provider](/reference/environment-variables#llm-provider)
 
@@ -22,7 +22,7 @@ Before you start, make sure you have:
 curl -fsSL https://bun.sh/install | bash
 ```
 
-Restart your terminal after installing. Verify with `bun --version` — you need v1.3.10 or later.
+Restart your terminal after installing. Verify with `bun --version` — you need v1.3.11 or later.
 </Accordion>
 </Accordions>
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@next/eslint-plugin-next": "^16.1.6",
         "@playwright/test": "^1.58.2",
-        "@types/bun": "^1.3.10",
+        "@types/bun": "^1.3.11",
         "@types/node": "^25.3.2",
         "@typescript/native-preview": "^7.0.0-dev.20260226.1",
         "eslint": "^10.0.2",
@@ -1849,7 +1849,7 @@
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
-    "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@types/caseless": ["@types/caseless@0.12.5", "", {}, "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="],
 
@@ -2171,7 +2171,7 @@
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
-    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 

--- a/create-atlas-plugin/package.json
+++ b/create-atlas-plugin/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/AtlasDevHQ/atlas/issues"
   },
   "engines": {
-    "bun": ">=1.3.10"
+    "bun": ">=1.3.11"
   },
   "dependencies": {
     "@clack/prompts": "^0.10.0",

--- a/create-atlas/package.json
+++ b/create-atlas/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/AtlasDevHQ/atlas/issues"
   },
   "engines": {
-    "bun": ">=1.3.10"
+    "bun": ">=1.3.11"
   },
   "dependencies": {
     "@clack/prompts": "^0.10.0",

--- a/create-atlas/templates/docker/Dockerfile
+++ b/create-atlas/templates/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.10 AS base
+FROM oven/bun:1.3.11 AS base
 
 FROM base AS deps
 WORKDIR /app

--- a/create-atlas/templates/docker/Dockerfile.sidecar
+++ b/create-atlas/templates/docker/Dockerfile.sidecar
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.10-debian AS base
+FROM oven/bun:1.3.11-debian AS base
 
 # Install only the tools needed for explore mode
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -63,7 +63,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/react-syntax-highlighter": "^15.5.13",
-    "@types/bun": "^1.3.10",
+    "@types/bun": "^1.3.11",
     "@typescript/native-preview": "^7.0.0-dev.20260226.1",
     "eslint": "^10.0.2",
     "tailwindcss": "^4.2.1",

--- a/create-atlas/templates/docker/sidecar/Dockerfile
+++ b/create-atlas/templates/docker/sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.10-debian AS base
+FROM oven/bun:1.3.11-debian AS base
 
 # Install only the tools needed for explore mode
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -60,7 +60,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/react-syntax-highlighter": "^15.5.13",
-    "@types/bun": "^1.3.10",
+    "@types/bun": "^1.3.11",
     "@typescript/native-preview": "^7.0.0-dev.20260226.1",
     "eslint": "^10.0.2",
     "tailwindcss": "^4.2.1",

--- a/deploy/api/Dockerfile
+++ b/deploy/api/Dockerfile
@@ -4,7 +4,7 @@
 # Build context: repo root (../../)
 #   docker build -f deploy/api/Dockerfile .
 
-FROM oven/bun:1.3.10 AS base
+FROM oven/bun:1.3.11 AS base
 
 # --- deps ---
 FROM base AS deps

--- a/deploy/docs/Dockerfile
+++ b/deploy/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.10 AS base
+FROM oven/bun:1.3.11 AS base
 
 # --- Build ---
 FROM base AS builder

--- a/deploy/web/Dockerfile
+++ b/deploy/web/Dockerfile
@@ -4,7 +4,7 @@
 # Build context: repo root (../../)
 #   docker build -f deploy/web/Dockerfile .
 
-FROM oven/bun:1.3.10 AS base
+FROM oven/bun:1.3.11 AS base
 
 # --- deps ---
 FROM base AS deps

--- a/docs/design/sandbox-architecture.md
+++ b/docs/design/sandbox-architecture.md
@@ -263,7 +263,7 @@ Response: {
 Minimal image — no secrets, no database drivers:
 
 ```dockerfile
-FROM oven/bun:1.3.10-debian AS base
+FROM oven/bun:1.3.11-debian AS base
 
 # Shell tools for explore + Python for executePython
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.10 AS base
+FROM oven/bun:1.3.11 AS base
 
 FROM base AS deps
 WORKDIR /app

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "engines": {
     "node": ">=20.9.0",
-    "bun": ">=1.3.10"
+    "bun": ">=1.3.11"
   },
   "homepage": "https://useatlas.dev",
   "devDependencies": {
@@ -60,7 +60,7 @@
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@next/eslint-plugin-next": "^16.1.6",
     "@playwright/test": "^1.58.2",
-    "@types/bun": "^1.3.10",
+    "@types/bun": "^1.3.11",
     "@types/node": "^25.3.2",
     "@typescript/native-preview": "^7.0.0-dev.20260226.1",
     "eslint": "^10.0.2",

--- a/packages/cli/bin/__tests__/duckdb-ingest.test.ts
+++ b/packages/cli/bin/__tests__/duckdb-ingest.test.ts
@@ -4,9 +4,8 @@
  * Tests the ingestIntoDuckDB, listDuckDBObjects, and profileDuckDB functions
  * using real DuckDB instances with temporary files.
  *
- * SKIPPED: @duckdb/node-api triggers a segfault in Bun 1.3.10.
- * https://bun.report/1.3.10/lt130e609eg3EugggC4xu5zEA2AwH
- * Re-enable once Bun ships a fix.
+ * Previously skipped due to @duckdb/node-api segfault in Bun 1.3.10.
+ * Fixed in Bun 1.3.11 — re-enabled.
  */
 import { describe, it, expect, afterEach } from "bun:test";
 import * as fs from "fs";
@@ -32,7 +31,7 @@ function cleanTmpDir(): void {
 
 afterEach(cleanTmpDir);
 
-describe.skip("ingestIntoDuckDB", () => {
+describe("ingestIntoDuckDB", () => {
   it("ingests a CSV file and creates a table", async () => {
     const dir = createTmpDir();
     const csvPath = path.join(dir, "sales.csv");
@@ -102,7 +101,7 @@ describe.skip("ingestIntoDuckDB", () => {
   });
 });
 
-describe.skip("listDuckDBObjects", () => {
+describe("listDuckDBObjects", () => {
   it("lists tables in a DuckDB database", async () => {
     const dir = createTmpDir();
     const csvPath = path.join(dir, "data.csv");
@@ -118,7 +117,7 @@ describe.skip("listDuckDBObjects", () => {
   });
 });
 
-describe.skip("profileDuckDB", () => {
+describe("profileDuckDB", () => {
   it("profiles a table with correct row count and columns", async () => {
     const dir = createTmpDir();
     const csvPath = path.join(dir, "employees.csv");

--- a/packages/sandbox-sidecar/Dockerfile
+++ b/packages/sandbox-sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.10-debian AS base
+FROM oven/bun:1.3.11-debian AS base
 
 # Install tools needed for explore mode + Python for executePython
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
- Upgrades Bun from 1.3.10 to 1.3.11 across all 23 version references (package.json engines, `@types/bun`, CI workflows, Dockerfiles, templates, docs)
- Re-enables 8 DuckDB integration tests that were skipped due to `@duckdb/node-api` segfault in Bun 1.3.10 — **confirmed fixed in 1.3.11**

## Test plan
- [x] All 8 DuckDB ingest tests pass (previously segfaulted)
- [x] `bun run lint` — zero errors
- [x] `bun run type` — zero errors
- [x] `bun run test` — all packages pass, 0 failures
- [x] `bun x syncpack lint` — no issues
- [x] Template drift check — 445 files verified

Fixes #811
Closes milestone 0.9.0