### PR TITLE
docs: persona audit — classify all 354 docs pages

### DIFF
--- a/docs/research/persona-audit.md
+++ b/docs/research/persona-audit.md
@@ -17,8 +17,8 @@ Note: **Developer/integrator** (self-hosting or embedding Atlas) appears frequen
 ## Summary
 
 - **Total pages audited:** 354 (99 content + 247 API reference + 8 index/meta)
-- **Pages with framing issues:** 28 content pages
-- **Pages correctly framed:** 71 content pages
+- **Pages with framing issues:** 24 content pages
+- **Pages correctly framed:** 83 content pages (including index pages)
 - **Key pattern:** SaaS enterprise features (SSO, SCIM, IP allowlist, custom roles, audit, approval) are well-framed. Self-hosted/deployment concerns bleed into user-facing guides.
 
 ---
@@ -265,6 +265,8 @@ API reference pages are auto-generated from OpenAPI spec. Classification is by e
 ---
 
 ## Issue Summary by Category
+
+Note: Some pages appear in multiple categories below (e.g., `slack.mdx` in Cat 2 and Cat 5). The 24 unique pages with framing issues are deduplicated in the tables above. Category 6 pages are marked "Yes" (minor UX improvements, not framing issues).
 
 ### Category 1: Deployment/Config — Self-hosted vs SaaS framing (7 pages)
 - `getting-started/connect-your-data.mdx` — SaaS customers don't set ATLAS_DATASOURCE_URL


### PR DESCRIPTION
## Summary

- Audited all 354 docs pages (99 content + 247 API reference + 8 index) and classified each by primary persona (end user, workspace admin, platform operator)
- Created classification table at `docs/research/persona-audit.md` with framing assessment and specific issues for each page
- Filed 6 sub-issues for Phase 2 (structural reorganization) and Phase 3 (content rewriting)

**28 pages with framing issues** found across 6 categories:
1. **Deployment/config** — SaaS vs self-hosted framing (7 pages) → #878
2. **Enterprise features** — customer vs operator voice (8 pages) → #880
3. **Security reference** — persona sections needed (2 pages) → #881
4. **Misplaced guides** — relocate to correct sections (5 pages) → #882
5. **Mixed-audience pages** — add persona sections (4 pages) → #883
6. **Plugin interactions** — minor improvements (2 pages) → #884

**Key finding:** SaaS enterprise features (SSO, SCIM, roles, audit, approval) are well-framed. Self-hosted/deployment concerns bleed into user-facing guides.

Closes #847

## Test plan

- [x] Every docs page classified with persona and framing assessment
- [x] Classification table committed to `docs/research/persona-audit.md`
- [x] Sub-issues filed for all pages needing rewriting
- [x] #847 updated with audit summary comment
- [x] CI gates: lint, type, test, syncpack, drift — all pass