### PR TITLE
refactor: extract ResultCardBase for SQL and Python result cards

### DIFF
--- a/packages/web/src/ui/__tests__/result-card-base.test.tsx
+++ b/packages/web/src/ui/__tests__/result-card-base.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import type React from "react";
 import { render, fireEvent } from "@testing-library/react";
-import { ResultCardBase } from "../components/chat/result-card-base";
+import { ResultCardBase, ResultCardErrorBoundary } from "../components/chat/result-card-base";
 
 describe("ResultCardBase", () => {
   test("renders badge text", () => {
@@ -33,6 +34,25 @@ describe("ResultCardBase", () => {
       </ResultCardBase>,
     );
     expect(container.textContent).toContain("5 rows");
+  });
+
+  test("headerExtra remains visible after collapse", () => {
+    const { container } = render(
+      <ResultCardBase
+        badge="SQL"
+        badgeClassName="bg-blue-100"
+        title="Query"
+        headerExtra={<span data-testid="row-count">5 rows</span>}
+      >
+        <div>content</div>
+      </ResultCardBase>,
+    );
+
+    const toggleBtn = container.querySelector("button")!;
+    fireEvent.click(toggleBtn);
+    // headerExtra is in the header, not the body — should persist
+    expect(container.textContent).toContain("5 rows");
+    expect(container.querySelector("[data-testid='row-count']")).not.toBeNull();
   });
 
   test("renders children when expanded (default)", () => {
@@ -137,5 +157,92 @@ describe("ResultCardBase", () => {
       </ResultCardBase>,
     );
     expect(container.textContent).toContain("\u25B8");
+  });
+
+  test("toggle button has aria-expanded=true when open", () => {
+    const { container } = render(
+      <ResultCardBase badge="SQL" badgeClassName="bg-blue-100" title="Query">
+        <div>content</div>
+      </ResultCardBase>,
+    );
+    const toggleBtn = container.querySelector("button")!;
+    expect(toggleBtn.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  test("toggle button has aria-expanded=false when collapsed", () => {
+    const { container } = render(
+      <ResultCardBase badge="SQL" badgeClassName="bg-blue-100" title="Query">
+        <div>content</div>
+      </ResultCardBase>,
+    );
+    const toggleBtn = container.querySelector("button")!;
+    fireEvent.click(toggleBtn);
+    expect(toggleBtn.getAttribute("aria-expanded")).toBe("false");
+  });
+});
+
+describe("ResultCardErrorBoundary", () => {
+  // Suppress console.error from the error boundary during tests
+  const originalError = console.error;
+  const suppress = () => { console.error = () => {}; };
+  const restore = () => { console.error = originalError; };
+
+  test("renders children when no error", () => {
+    const { container } = render(
+      <ResultCardErrorBoundary label="SQL">
+        <div data-testid="child">hello</div>
+      </ResultCardErrorBoundary>,
+    );
+    expect(container.querySelector("[data-testid='child']")).not.toBeNull();
+  });
+
+  test("renders error message when child throws", () => {
+    suppress();
+    function ThrowingChild(): React.ReactElement {
+      throw new Error("render boom");
+    }
+
+    const { container } = render(
+      <ResultCardErrorBoundary label="SQL">
+        <ThrowingChild />
+      </ResultCardErrorBoundary>,
+    );
+    restore();
+
+    expect(container.textContent).toContain("SQL result could not be rendered");
+    expect(container.textContent).toContain("render boom");
+  });
+
+  test("uses label prop in error message", () => {
+    suppress();
+    function ThrowingChild(): React.ReactElement {
+      throw new Error("oops");
+    }
+
+    const { container } = render(
+      <ResultCardErrorBoundary label="Python">
+        <ThrowingChild />
+      </ResultCardErrorBoundary>,
+    );
+    restore();
+
+    expect(container.textContent).toContain("Python result could not be rendered");
+  });
+
+  test("shows fallback when error has no message", () => {
+    suppress();
+    function ThrowingChild(): React.ReactElement {
+      throw new Error();
+    }
+
+    const { container } = render(
+      <ResultCardErrorBoundary label="Test">
+        <ThrowingChild />
+      </ResultCardErrorBoundary>,
+    );
+    restore();
+
+    expect(container.textContent).toContain("Test result could not be rendered");
+    expect(container.textContent).toContain("unknown error");
   });
 });

--- a/packages/web/src/ui/components/chat/python-result-card.tsx
+++ b/packages/web/src/ui/components/chat/python-result-card.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { Component, type ReactNode, type ErrorInfo, useContext, useState, useRef, useEffect } from "react";
+import { useContext, useState, useRef, useEffect } from "react";
 import { getToolArgs, getToolResult, isToolComplete } from "../../lib/helpers";
 import { DarkModeContext } from "../../hooks/use-dark-mode";
 import dynamic from "next/dynamic";
 import { LoadingCard } from "./loading-card";
 import { DataTable } from "./data-table";
-import { ResultCardBase } from "./result-card-base";
+import { ResultCardBase, ResultCardErrorBoundary } from "./result-card-base";
 import type { ChartDetectionResult, ChartType } from "../chart/chart-detection";
 
 const ResultChart = dynamic(
@@ -35,47 +35,14 @@ export type PythonProgressData =
 const ALLOWED_IMAGE_MIME = new Set(["image/png", "image/jpeg"]);
 
 /* ------------------------------------------------------------------ */
-/*  Error boundary                                                     */
-/* ------------------------------------------------------------------ */
-
-class PythonErrorBoundary extends Component<
-  { children: ReactNode },
-  { hasError: boolean; error?: Error }
-> {
-  constructor(props: { children: ReactNode }) {
-    super(props);
-    this.state = { hasError: false };
-  }
-
-  static getDerivedStateFromError(error: Error) {
-    return { hasError: true, error };
-  }
-
-  componentDidCatch(error: Error, info: ErrorInfo) {
-    console.error("PythonResultCard rendering failed:", error, info.componentStack);
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return (
-        <div className="my-2 rounded-lg border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-900/50 dark:bg-red-950/20 dark:text-red-400">
-          Python result could not be rendered: {this.state.error?.message ?? "unknown error"}
-        </div>
-      );
-    }
-    return this.props.children;
-  }
-}
-
-/* ------------------------------------------------------------------ */
 /*  Main component                                                     */
 /* ------------------------------------------------------------------ */
 
 export function PythonResultCard({ part, progressEvents }: { part: unknown; progressEvents?: PythonProgressData[] }) {
   return (
-    <PythonErrorBoundary>
+    <ResultCardErrorBoundary label="Python">
       <PythonResultCardInner part={part} progressEvents={progressEvents} />
-    </PythonErrorBoundary>
+    </ResultCardErrorBoundary>
   );
 }
 

--- a/packages/web/src/ui/components/chat/result-card-base.tsx
+++ b/packages/web/src/ui/components/chat/result-card-base.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
+import { Component, useState, type ReactNode, type ErrorInfo } from "react";
 import { cn } from "@/lib/utils";
 
-interface ResultCardBaseProps {
+export interface ResultCardBaseProps {
   /** Badge text shown in the header (e.g. "SQL", "Python") */
   badge: string;
-  /** Color classes for the badge */
+  /** Color classes for the badge — expects bg + text + dark variants, e.g. "bg-blue-100 text-blue-700 dark:bg-blue-600/20 dark:text-blue-400" */
   badgeClassName: string;
   /** Title/explanation text shown next to the badge */
   title: string;
@@ -34,6 +34,7 @@ export function ResultCardBase({
   return (
     <div className="my-2 overflow-hidden rounded-lg border border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900">
       <button
+        aria-expanded={open}
         onClick={() => setOpen(!open)}
         className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition-colors hover:bg-zinc-100/60 dark:hover:bg-zinc-800/60"
       >
@@ -53,4 +54,48 @@ export function ResultCardBase({
       )}
     </div>
   );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Shared error boundary for result cards                             */
+/* ------------------------------------------------------------------ */
+
+interface ResultCardErrorBoundaryProps {
+  /** Label for the error message, e.g. "SQL" or "Python" */
+  label: string;
+  children: ReactNode;
+}
+
+interface ResultCardErrorBoundaryState {
+  hasError: boolean;
+  error?: Error;
+}
+
+export class ResultCardErrorBoundary extends Component<
+  ResultCardErrorBoundaryProps,
+  ResultCardErrorBoundaryState
+> {
+  constructor(props: ResultCardErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error): ResultCardErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error(`${this.props.label} result card rendering failed:`, error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="my-2 rounded-lg border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-900/50 dark:bg-red-950/20 dark:text-red-400">
+          {this.props.label} result could not be rendered: {this.state.error?.message || "unknown error"}
+        </div>
+      );
+    }
+    return this.props.children;
+  }
 }

--- a/packages/web/src/ui/components/chat/sql-result-card.tsx
+++ b/packages/web/src/ui/components/chat/sql-result-card.tsx
@@ -14,7 +14,7 @@ const ResultChart = dynamic(
 import { LoadingCard } from "./loading-card";
 import { DataTable } from "./data-table";
 import { SQLBlock } from "./sql-block";
-import { ResultCardBase } from "./result-card-base";
+import { ResultCardBase, ResultCardErrorBoundary } from "./result-card-base";
 
 /** Convert structured rows (Record<string, unknown>[]) to string[][] for chart detection. */
 function toStringRows(columns: string[], rows: Record<string, unknown>[]): string[][] {
@@ -23,12 +23,21 @@ function toStringRows(columns: string[], rows: Record<string, unknown>[]): strin
 
 
 export function SQLResultCard({ part }: { part: unknown }) {
+  return (
+    <ResultCardErrorBoundary label="SQL">
+      <SQLResultCardInner part={part} />
+    </ResultCardErrorBoundary>
+  );
+}
+
+function SQLResultCardInner({ part }: { part: unknown }) {
   const dark = useContext(DarkModeContext);
   const args = getToolArgs(part);
   const result = getToolResult(part) as Record<string, unknown> | null;
   const done = isToolComplete(part);
   const [sqlOpen, setSqlOpen] = useState(false);
   const [viewMode, setViewMode] = useState<"both" | "chart" | "table">("both");
+  const [excelError, setExcelError] = useState(false);
 
   const columns = useMemo(
     () => (done && result?.success ? ((result.columns as string[]) ?? []) : []),
@@ -133,13 +142,22 @@ export function SQLResultCard({ part }: { part: unknown }) {
         )}
         {hasData && (
           <button
-            onClick={() => { downloadExcel(columns, rows).catch((err) => { console.warn("Excel download failed:", err); }); }}
+            onClick={() => {
+              setExcelError(false);
+              downloadExcel(columns, rows).catch((err: unknown) => {
+                console.warn("Excel download failed:", err);
+                setExcelError(true);
+              });
+            }}
             className="inline-flex items-center gap-1.5 rounded border border-zinc-200 px-2 py-1.5 text-xs text-zinc-500 transition-colors hover:border-zinc-400 hover:text-zinc-800 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-200"
             title="Download Excel"
           >
             <FileSpreadsheet className="size-3.5" />
             <span className="hidden sm:inline">Excel</span>
           </button>
+        )}
+        {excelError && (
+          <span className="text-xs text-red-500 dark:text-red-400">Excel download failed</span>
         )}
       </div>
       {sqlOpen && sql && (


### PR DESCRIPTION
## Summary

Fixes #897

- Extract shared collapsible card shell from `sql-result-card.tsx` and `python-result-card.tsx` into a new `ResultCardBase` component
- Both card components now use `ResultCardBase` as their outer shell, owning only their tool-specific content (chart rendering, download buttons, Python streaming, etc.)
- `ResultCardBase` handles: outer card div, collapsible header button (badge + title + optional extras + arrow), `open` state, and content wrapper with border

## What changed

| File | Change |
|------|--------|
| `result-card-base.tsx` | **New** — ~50-line shared component with props: `badge`, `badgeClassName`, `title`, `headerExtra`, `children`, `contentClassName`, `defaultOpen` |
| `sql-result-card.tsx` | Removed hand-rolled card shell, uses `ResultCardBase` |
| `python-result-card.tsx` | Same — success branch uses `ResultCardBase`, loading/streaming/error branches unchanged |
| `result-card-base.test.tsx` | **New** — 11 tests covering collapse/expand, badge, title, headerExtra, contentClassName, defaultOpen, arrow indicators |

**No visual changes** — cards look and behave identically. All 38 existing tests pass unchanged.

## Test plan

- [x] All 38 test files pass (`bun run test`)
- [x] SQL result card tests pass (collapse, badges, download buttons, row count, Show SQL)
- [x] Python result card tests pass (collapse, badges, stdout, charts, error states)
- [x] 11 new ResultCardBase tests pass
- [x] TypeScript type-check clean (`tsgo --noEmit`)
- [x] syncpack clean