### PR TITLE
fix: restore globalThis.fetch in SDK client tests

### DIFF
--- a/packages/sdk/src/__tests__/client.test.ts
+++ b/packages/sdk/src/__tests__/client.test.ts
@@ -1,9 +1,14 @@
-import { describe, test, expect, beforeEach, mock } from "bun:test";
+import { describe, test, expect, beforeEach, afterAll, mock } from "bun:test";
 import { createAtlasClient, AtlasError } from "../client";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+const originalFetch = globalThis.fetch;
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
 
 function jsonResponse(body: unknown, status = 200, headers?: Record<string, string>) {
   return new Response(JSON.stringify(body), {


### PR DESCRIPTION
## Summary
- `client.test.ts` replaced `globalThis.fetch` with mocks but never restored the original after tests completed
- The last mock (403 "Admin role required") leaked into `integration.test.ts` running in the same process, failing CI while passing locally
- Adds `afterAll` cleanup to save/restore `globalThis.fetch`, matching the pattern already used by `stream.test.ts`

## Test plan
- [x] `bun run test` — all 235 tests pass, 0 failures
- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun x syncpack lint` — no issues
- [x] Template drift check passed