### PR TITLE
refactor: migrate residency/domains error handling to domainErrors (#927)

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -535,7 +535,7 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
 
 ### Service Architecture (P5–P8)
 - [x] P5: Plugin lifecycle → Effect Layer composition (#908, PR #926)
-- [x] P6: Server startup → Effect Layer DAG (#909, PR #TBD)
+- [x] P6: Server startup → Effect Layer DAG (#909, PR #928)
 - [x] P7: Route handlers → Effect boundaries with typed error mapping (#910, PR #925)
 - [ ] P8: Auth and request context → Effect Context replacing AsyncLocalStorage (#911)
 
@@ -544,7 +544,7 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
 - [ ] P11: Database client → @effect/sql-pg and @effect/sql-mysql2 (#914)
 
 ### Follow-ups
-- [ ] Migrate platform-residency and platform-domains inner error handling to domainErrors (#927)
+- [x] Migrate platform-residency and platform-domains inner error handling to domainErrors (#927)
 
 ### Test Infrastructure
 - [ ] P9: Test infrastructure → Effect Layer-based test setup (#912)

--- a/packages/api/src/api/routes/platform-domains.ts
+++ b/packages/api/src/api/routes/platform-domains.ts
@@ -12,9 +12,9 @@
 
 import { createRoute, z } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
-import { runHandler } from "@atlas/api/lib/effect/hono";
-import { EnterpriseError } from "@atlas/ee/index";
+import { runHandler, type DomainErrorMapping } from "@atlas/api/lib/effect/hono";
 import { DomainError, type DomainErrorCode } from "@atlas/ee/platform/domains";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createPlatformRouter } from "./admin-router";
 
@@ -145,7 +145,10 @@ const deleteDomainRoute = createRoute({
 
 type DomainsModule = typeof import("@atlas/ee/platform/domains");
 
-const DOMAIN_ERROR_STATUS: Record<DomainErrorCode, number> = {
+/** Infrastructure error codes whose messages may contain internal details. */
+const SANITIZED_CODES = new Set<DomainErrorCode>(["railway_error", "railway_not_configured", "data_integrity"]);
+
+const DOMAIN_ERROR_STATUS: Record<DomainErrorCode, ContentfulStatusCode> = {
   no_internal_db: 503,
   invalid_domain: 400,
   duplicate_domain: 409,
@@ -154,6 +157,10 @@ const DOMAIN_ERROR_STATUS: Record<DomainErrorCode, number> = {
   railway_not_configured: 503,
   data_integrity: 500,
 };
+
+const domainDomainErrors: DomainErrorMapping[] = [
+  [DomainError, DOMAIN_ERROR_STATUS],
+];
 
 async function loadDomains(): Promise<DomainsModule | null> {
   try {
@@ -170,26 +177,20 @@ async function loadDomains(): Promise<DomainsModule | null> {
   }
 }
 
-function handleDomainError(err: unknown, requestId: string): { error: string; message: string; status: number; requestId: string } {
-  const message = err instanceof Error ? err.message : String(err);
-
-  // Typed domain errors — handle known domain-specific codes
-  if (err instanceof DomainError) {
-    const code = err.code;
-    const status = DOMAIN_ERROR_STATUS[code];
-    // Sanitize infrastructure/internal errors to avoid leaking details
-    const safeMessage = (code === "railway_error" || code === "railway_not_configured" || code === "data_integrity")
-      ? `Domain service error (ref: ${requestId.slice(0, 8)})`
-      : message;
-    return { error: code, message: safeMessage, status, requestId };
+/**
+ * Sanitize DomainError messages for infrastructure errors before they
+ * reach the client. Railway errors and data integrity errors may contain
+ * internal infrastructure details that should not be exposed.
+ *
+ * User-facing errors (invalid_domain, duplicate_domain, domain_not_found)
+ * pass through unmodified.
+ */
+function sanitizeDomainError(err: unknown, requestId: string): void {
+  if (err instanceof DomainError && SANITIZED_CODES.has(err.code)) {
+    // Log the real error for debugging, then replace the message
+    log.error({ err, code: err.code, requestId }, "Infrastructure domain error");
+    err.message = `Domain service error (ref: ${requestId.slice(0, 8)})`;
   }
-
-  // Enterprise feature gate → 403 (sanitize to avoid leaking config details)
-  if (err instanceof EnterpriseError) {
-    return { error: "enterprise_required", message: "This feature requires an enterprise license. Visit https://useatlas.dev/enterprise for licensing options.", status: 403, requestId };
-  }
-
-  return { error: "internal_error", message: `Unexpected error (ref: ${requestId.slice(0, 8)})`, status: 500, requestId };
 }
 
 // ---------------------------------------------------------------------------
@@ -208,17 +209,9 @@ platformDomains.openapi(listDomainsRoute, async (c) => runHandler(c, "list domai
     return c.json({ error: "not_available", message: "Custom domains require enterprise features to be enabled.", requestId }, 404);
   }
 
-  try {
-    const domains = await mod.listAllDomains();
-    return c.json({ domains }, 200);
-  } catch (err) {
-    const result = handleDomainError(err, requestId);
-    if (result.error === "internal_error") throw err;
-    const logFn = result.status >= 500 ? log.error : log.warn;
-    logFn({ err: err instanceof Error ? err : new Error(String(err)), requestId }, "Failed to list domains");
-    return c.json({ error: result.error, message: result.message, requestId: result.requestId }, result.status as 403);
-  }
-}));
+  const domains = await mod.listAllDomains();
+  return c.json({ domains }, 200);
+}, { domainErrors: domainDomainErrors }));
 
 // ── Register domain ──────────────────────────────────────────────────
 
@@ -236,13 +229,10 @@ platformDomains.openapi(registerDomainRoute, async (c) => runHandler(c, "registe
     log.info({ workspaceId: body.workspaceId, domain: body.domain, requestId }, "Custom domain registered");
     return c.json(domain, 201);
   } catch (err) {
-    const result = handleDomainError(err, requestId);
-    if (result.error === "internal_error") throw err;
-    const logFn = result.status >= 500 ? log.error : log.warn;
-    logFn({ err: err instanceof Error ? err : new Error(String(err)), domain: body.domain, requestId }, "Failed to register domain");
-    return c.json({ error: result.error, message: result.message, requestId: result.requestId }, result.status as 400);
+    sanitizeDomainError(err, requestId);
+    throw err;
   }
-}));
+}, { domainErrors: domainDomainErrors }));
 
 // ── Verify domain ────────────────────────────────────────────────────
 
@@ -259,13 +249,10 @@ platformDomains.openapi(verifyDomainRoute, async (c) => runHandler(c, "verify do
     const domain = await mod.verifyDomain(domainId);
     return c.json(domain, 200);
   } catch (err) {
-    const result = handleDomainError(err, requestId);
-    if (result.error === "internal_error") throw err;
-    const logFn = result.status >= 500 ? log.error : log.warn;
-    logFn({ err: err instanceof Error ? err : new Error(String(err)), domainId, requestId }, "Failed to verify domain");
-    return c.json({ error: result.error, message: result.message, requestId: result.requestId }, result.status as 404);
+    sanitizeDomainError(err, requestId);
+    throw err;
   }
-}));
+}, { domainErrors: domainDomainErrors }));
 
 // ── Delete domain ────────────────────────────────────────────────────
 
@@ -283,12 +270,9 @@ platformDomains.openapi(deleteDomainRoute, async (c) => runHandler(c, "delete do
     log.info({ domainId, requestId }, "Custom domain deleted");
     return c.json({ deleted: true }, 200);
   } catch (err) {
-    const result = handleDomainError(err, requestId);
-    if (result.error === "internal_error") throw err;
-    const logFn = result.status >= 500 ? log.error : log.warn;
-    logFn({ err: err instanceof Error ? err : new Error(String(err)), domainId, requestId }, "Failed to delete domain");
-    return c.json({ error: result.error, message: result.message, requestId: result.requestId }, result.status as 404);
+    sanitizeDomainError(err, requestId);
+    throw err;
   }
-}));
+}, { domainErrors: domainDomainErrors }));
 
 export { platformDomains };

--- a/packages/api/src/api/routes/platform-residency.ts
+++ b/packages/api/src/api/routes/platform-residency.ts
@@ -12,9 +12,9 @@
 
 import { createRoute, z } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
-import { runHandler } from "@atlas/api/lib/effect/hono";
-import { EnterpriseError } from "@atlas/ee/index";
+import { runHandler, type DomainErrorMapping } from "@atlas/api/lib/effect/hono";
 import { ResidencyError, type ResidencyErrorCode } from "@atlas/ee/platform/residency";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createPlatformRouter } from "./admin-router";
 
@@ -145,13 +145,17 @@ const listAssignmentsRoute = createRoute({
 
 type ResidencyModule = typeof import("@atlas/ee/platform/residency");
 
-const RESIDENCY_ERROR_STATUS: Record<ResidencyErrorCode, number> = {
+const RESIDENCY_ERROR_STATUS: Record<ResidencyErrorCode, ContentfulStatusCode> = {
   not_configured: 404,
   invalid_region: 400,
   already_assigned: 409,
   workspace_not_found: 404,
   no_internal_db: 503,
 };
+
+const residencyDomainErrors: DomainErrorMapping[] = [
+  [ResidencyError, RESIDENCY_ERROR_STATUS],
+];
 
 async function loadResidency(): Promise<ResidencyModule | null> {
   try {
@@ -166,24 +170,6 @@ async function loadResidency(): Promise<ResidencyModule | null> {
     );
     throw err;
   }
-}
-
-function handleResidencyError(err: unknown, requestId: string): { error: string; message: string; status: number; requestId: string } {
-  const message = err instanceof Error ? err.message : String(err);
-
-  // Typed residency errors — handle known residency-specific codes
-  if (err instanceof ResidencyError) {
-    const code = err.code;
-    const status = RESIDENCY_ERROR_STATUS[code];
-    return { error: code, message, status, requestId };
-  }
-
-  // Enterprise feature gate → 403 (sanitize to avoid leaking config details)
-  if (err instanceof EnterpriseError) {
-    return { error: "enterprise_required", message: "This feature requires an enterprise license. Visit https://useatlas.dev/enterprise for licensing options.", status: 403, requestId };
-  }
-
-  return { error: "internal_error", message: `Unexpected error (ref: ${requestId.slice(0, 8)})`, status: 500, requestId };
 }
 
 // ---------------------------------------------------------------------------
@@ -202,18 +188,10 @@ platformResidency.openapi(listRegionsRoute, async (c) => runHandler(c, "list reg
     return c.json({ error: "not_available", message: "Data residency requires enterprise features to be enabled.", requestId }, 404);
   }
 
-  try {
-    const regions = await mod.listRegions();
-    const defaultRegion = mod.getDefaultRegion();
-    return c.json({ regions, defaultRegion }, 200);
-  } catch (err) {
-    const result = handleResidencyError(err, requestId);
-    if (result.error === "internal_error") throw err;
-    const logFn = result.status >= 500 ? log.error : log.warn;
-    logFn({ err: err instanceof Error ? err : new Error(String(err)), requestId }, "Failed to list regions");
-    return c.json({ error: result.error, message: result.message, requestId: result.requestId }, result.status as 403);
-  }
-}));
+  const regions = await mod.listRegions();
+  const defaultRegion = mod.getDefaultRegion();
+  return c.json({ regions, defaultRegion }, 200);
+}, { domainErrors: residencyDomainErrors }));
 
 // ── Get workspace region ─────────────────────────────────────────────
 
@@ -226,20 +204,12 @@ platformResidency.openapi(getWorkspaceRegionRoute, async (c) => runHandler(c, "g
     return c.json({ error: "not_available", message: "Data residency requires enterprise features to be enabled.", requestId }, 404);
   }
 
-  try {
-    const assignment = await mod.getWorkspaceRegionAssignment(workspaceId);
-    if (!assignment) {
-      return c.json({ error: "not_found", message: `Workspace "${workspaceId}" has no region assigned.`, requestId }, 404);
-    }
-    return c.json(assignment, 200);
-  } catch (err) {
-    const result = handleResidencyError(err, requestId);
-    if (result.error === "internal_error") throw err;
-    const logFn = result.status >= 500 ? log.error : log.warn;
-    logFn({ err: err instanceof Error ? err : new Error(String(err)), workspaceId, requestId }, "Failed to get workspace region");
-    return c.json({ error: result.error, message: result.message, requestId: result.requestId }, result.status as 403);
+  const assignment = await mod.getWorkspaceRegionAssignment(workspaceId);
+  if (!assignment) {
+    return c.json({ error: "not_found", message: `Workspace "${workspaceId}" has no region assigned.`, requestId }, 404);
   }
-}));
+  return c.json(assignment, 200);
+}, { domainErrors: residencyDomainErrors }));
 
 // ── Assign region to workspace ───────────────────────────────────────
 
@@ -253,18 +223,10 @@ platformResidency.openapi(assignRegionRoute, async (c) => runHandler(c, "assign 
     return c.json({ error: "not_available", message: "Data residency requires enterprise features to be enabled.", requestId }, 404);
   }
 
-  try {
-    const assignment = await mod.assignWorkspaceRegion(workspaceId, body.region);
-    log.info({ workspaceId, region: body.region, requestId }, "Region assigned to workspace");
-    return c.json(assignment, 200);
-  } catch (err) {
-    const result = handleResidencyError(err, requestId);
-    if (result.error === "internal_error") throw err;
-    const logFn = result.status >= 500 ? log.error : log.warn;
-    logFn({ err: err instanceof Error ? err : new Error(String(err)), workspaceId, region: body.region, requestId }, "Failed to assign region");
-    return c.json({ error: result.error, message: result.message, requestId: result.requestId }, result.status as 400);
-  }
-}));
+  const assignment = await mod.assignWorkspaceRegion(workspaceId, body.region);
+  log.info({ workspaceId, region: body.region, requestId }, "Region assigned to workspace");
+  return c.json(assignment, 200);
+}, { domainErrors: residencyDomainErrors }));
 
 // ── List all assignments ─────────────────────────────────────────────
 
@@ -276,16 +238,8 @@ platformResidency.openapi(listAssignmentsRoute, async (c) => runHandler(c, "list
     return c.json({ error: "not_available", message: "Data residency requires enterprise features to be enabled.", requestId }, 404);
   }
 
-  try {
-    const assignments = await mod.listWorkspaceRegions();
-    return c.json({ assignments }, 200);
-  } catch (err) {
-    const result = handleResidencyError(err, requestId);
-    if (result.error === "internal_error") throw err;
-    const logFn = result.status >= 500 ? log.error : log.warn;
-    logFn({ err: err instanceof Error ? err : new Error(String(err)), requestId }, "Failed to list region assignments");
-    return c.json({ error: result.error, message: result.message, requestId: result.requestId }, result.status as 403);
-  }
-}));
+  const assignments = await mod.listWorkspaceRegions();
+  return c.json({ assignments }, 200);
+}, { domainErrors: residencyDomainErrors }));
 
 export { platformResidency };


### PR DESCRIPTION
## Summary

- **platform-residency.ts** — Remove `handleResidencyError` + 4 inner try-catch blocks. Domain errors now handled via `runHandler`'s `domainErrors` option (classifyError in Effect bridge). Net -32 lines.
- **platform-domains.ts** — Remove `handleDomainError` + 4 inner try-catch blocks. Keep message sanitization for infrastructure errors (`railway_error`, `railway_not_configured`, `data_integrity`) via `sanitizeDomainError` helper that sanitizes before re-throw. Net -30 lines.
- EnterpriseError → 403 now handled automatically by `classifyError` (was duplicated in both `handleX` functions)

Closes #927

## Test plan

- [x] `bun run type` — clean
- [x] `bun run lint` — clean  
- [x] `bun run test` — all pass
- [x] Status code mappings unchanged (same `RESIDENCY_ERROR_STATUS` / `DOMAIN_ERROR_STATUS` maps passed to `domainErrors`)
- [x] Infrastructure error messages still sanitized in domains routes