### PR TITLE
refactor: install @effect/ai and define provider Layers (P10a)

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -539,12 +539,18 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
 - [x] P7: Route handlers → Effect boundaries with typed error mapping (#910, PR #925)
 - [x] P8: Auth and request context → Effect Context replacing AsyncLocalStorage (#911)
 
-### AI & Database (P10–P11)
-- [ ] P10: Agent loop → @effect/ai with AiToolkit and provider Layers (#913)
-- [ ] P11: Database client → @effect/sql-pg and @effect/sql-mysql2 (#914)
+### AI (P10) — Agent Loop → @effect/ai
+- [ ] P10a: Install @effect/ai, define provider Layers — bridge to existing providers.ts (#933)
+- [ ] P10b: Define Atlas tools (explore, executeSQL) as AiToolkit (#934)
+- [ ] P10c: Rewrite agent loop with AiLanguageModel.streamText (#935)
+
+### Database (P11) — Native Effect SQL
+- [ ] P11a: Install @effect/sql, define SqlClient Layer bridge (#936)
+- [ ] P11b: Replace raw pg/mysql2 with @effect/sql native clients (#937)
 
 ### Follow-ups
 - [x] Migrate platform-residency and platform-domains inner error handling to domainErrors (#927)
+- [ ] Migrate route handlers from c.get() to Effect Context — incremental (#931)
 
 ### Test Infrastructure
 - [x] P9: Test infrastructure → Effect Layer-based test setup (#912)

--- a/bun.lock
+++ b/bun.lock
@@ -138,6 +138,9 @@
       },
       "devDependencies": {
         "@ai-sdk/provider": "^3.0.8",
+        "@effect/ai": "^0.35.0",
+        "@effect/ai-anthropic": "^0.25.0",
+        "@effect/ai-openai": "^0.39.0",
         "@types/js-yaml": "^4.0.9",
         "@types/pg": "^8.16.0",
       },
@@ -682,6 +685,8 @@
 
     "@antfu/ni": ["@antfu/ni@25.0.0", "", { "dependencies": { "ansis": "^4.0.0", "fzf": "^0.5.2", "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" }, "bin": { "na": "bin/na.mjs", "ni": "bin/ni.mjs", "nr": "bin/nr.mjs", "nci": "bin/nci.mjs", "nlx": "bin/nlx.mjs", "nun": "bin/nun.mjs", "nup": "bin/nup.mjs" } }, "sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA=="],
 
+    "@anthropic-ai/tokenizer": ["@anthropic-ai/tokenizer@0.0.4", "", { "dependencies": { "@types/node": "^18.11.18", "tiktoken": "^1.0.10" } }, "sha512-EHRKbxlxlc8W4KCBEseByJ7YwyYCmgu9OyN59H9+IYIGPoKv8tXyQXinkeGDI+cI8Tiuz9wk2jZb/kK7AyvL7g=="],
+
     "@asteasolutions/zod-to-openapi": ["@asteasolutions/zod-to-openapi@8.5.0", "", { "dependencies": { "openapi3-ts": "^4.1.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q=="],
 
     "@atlas/api": ["@atlas/api@workspace:packages/api"],
@@ -992,6 +997,18 @@
 
     "@ecies/ciphers": ["@ecies/ciphers@0.2.5", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A=="],
 
+    "@effect/ai": ["@effect/ai@0.35.0", "", { "dependencies": { "find-my-way-ts": "^0.1.6" }, "peerDependencies": { "@effect/experimental": "^0.60.0", "@effect/platform": "^0.96.0", "@effect/rpc": "^0.75.0", "effect": "^3.21.0" } }, "sha512-VOYFBN/TpHC0sB5AhUGOEJzOTEnuo2bbDtQcDDsU7ffHaE8ZbqZj1CuSHgifbmqMaY9+xofsKMazQZ3jlZfPSw=="],
+
+    "@effect/ai-anthropic": ["@effect/ai-anthropic@0.25.0", "", { "dependencies": { "@anthropic-ai/tokenizer": "^0.0.4" }, "peerDependencies": { "@effect/ai": "^0.35.0", "@effect/experimental": "^0.60.0", "@effect/platform": "^0.96.0", "effect": "^3.21.0" } }, "sha512-Qac2WUmi7qBHppu6uUdyA8Xa441IYXxfBirxe6YSibqVeMVam9uKqvTl0GnSaymHpPc/b0aXdbKUiFfMm3d2Ug=="],
+
+    "@effect/ai-openai": ["@effect/ai-openai@0.39.0", "", { "dependencies": { "gpt-tokenizer": "^2.9.0" }, "peerDependencies": { "@effect/ai": "^0.35.0", "@effect/experimental": "^0.60.0", "@effect/platform": "^0.96.0", "effect": "^3.21.0" } }, "sha512-PCzZ0Kpkrt0Tspk9y6G00FsN7UvRu+eUuRfADbQ403KkSLqE9T6pcvmuFeSdeFmVbg0uVEQ0rIQgmeBTgcgxbw=="],
+
+    "@effect/experimental": ["@effect/experimental@0.60.0", "", { "dependencies": { "uuid": "^11.0.3" }, "peerDependencies": { "@effect/platform": "^0.96.0", "effect": "^3.21.0", "ioredis": "^5", "lmdb": "^3" }, "optionalPeers": ["ioredis", "lmdb"] }, "sha512-i5zIg7Xup2KgHyqHlYtkgqSE1bNzCL0GbbTQxrpIzKF0q/ebknOk/ox8B/gIq2vImjoEE81h/oxU+6i1NH210g=="],
+
+    "@effect/platform": ["@effect/platform@0.96.0", "", { "dependencies": { "find-my-way-ts": "^0.1.6", "msgpackr": "^1.11.4", "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^3.21.0" } }, "sha512-U7PLhkVzg7zzrgFvyWATOzD6reL87KG/fcdOxgLWBQ/J5CCU6qdPAVG+0o6o+IxcsLoqGwxs+rFxaFzrdtDV1A=="],
+
+    "@effect/rpc": ["@effect/rpc@0.75.0", "", { "dependencies": { "msgpackr": "^1.11.4" }, "peerDependencies": { "@effect/platform": "^0.96.0", "effect": "^3.21.0" } }, "sha512-VFeJ16cZUXqiIzG9UHOVKGuiBPJ7fV+0lEbJU6xi12JnnxXe/19BQPpOwiRawCUbPOR3/xIURDUgGxU+Ft0pvQ=="],
+
     "@electric-sql/pglite": ["@electric-sql/pglite@0.3.15", "", {}, "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ=="],
 
     "@electric-sql/pglite-socket": ["@electric-sql/pglite-socket@0.0.20", "", { "peerDependencies": { "@electric-sql/pglite": "0.3.15" }, "bin": { "pglite-server": "dist/scripts/server.js" } }, "sha512-J5nLGsicnD9wJHnno9r+DGxfcZWh+YJMCe0q/aCgtG6XOm9Z7fKeite8IZSNXgZeGltSigM9U/vAWZQWdgcSFg=="],
@@ -1211,6 +1228,18 @@
     "@mongodb-js/zstd": ["@mongodb-js/zstd@7.0.0", "", { "dependencies": { "node-addon-api": "^8.5.0", "prebuild-install": "^7.1.3" } }, "sha512-mQ2s0pYYiav+tzCDR05Zptem8Ey2v8s11lri5RKGhTtL4COVCvVCk5vtyRYNT+9L8qSfyOqqefF9UtnW8mC5jA=="],
 
     "@mrleebo/prisma-ast": ["@mrleebo/prisma-ast@0.13.1", "", { "dependencies": { "chevrotain": "^10.5.0", "lilconfig": "^2.1.0" } }, "sha512-XyroGQXcHrZdvmrGJvsA9KNeOOgGMg1Vg9OlheUsBOSKznLMDl+YChxbkboRHvtFYJEMRYmlV3uoo/njCw05iw=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3", "", { "os": "linux", "cpu": "arm" }, "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg=="],
+
+    "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ=="],
 
     "@mswjs/interceptors": ["@mswjs/interceptors@0.41.3", "", { "dependencies": { "@open-draft/deferred-promise": "^2.2.0", "@open-draft/logger": "^0.3.0", "@open-draft/until": "^2.0.0", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "strict-event-emitter": "^0.5.1" } }, "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA=="],
 
@@ -2594,6 +2623,8 @@
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
+    "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
+
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
     "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
@@ -2689,6 +2720,8 @@
     "googleapis-common": ["googleapis-common@8.0.1", "", { "dependencies": { "extend": "^3.0.2", "gaxios": "^7.0.0-rc.4", "google-auth-library": "^10.1.0", "qs": "^6.7.0", "url-template": "^2.0.8" } }, "sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "gpt-tokenizer": ["gpt-tokenizer@2.9.0", "", {}, "sha512-YSpexBL/k4bfliAzMrRqn3M6+it02LutVyhVpDeMKrC/O9+pCe/5s8U2hYKa2vFLD5/vHhsKc8sOn/qGqII8Kg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
@@ -3146,7 +3179,13 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "msgpackr": ["msgpackr@1.11.9", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-FkoAAyyA6HM8wL882EcEyFZ9s7hVADSwG9xrVx3dxxNQAtgADTrJoEWivID82Iv1zWDsv/OtbrrcZAzGzOMdNw=="],
+
+    "msgpackr-extract": ["msgpackr-extract@3.0.3", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA=="],
+
     "msw": ["msw@2.12.10", "", { "dependencies": { "@inquirer/confirm": "^5.0.0", "@mswjs/interceptors": "^0.41.2", "@open-draft/deferred-promise": "^2.2.0", "@types/statuses": "^2.0.6", "cookie": "^1.0.2", "graphql": "^16.12.0", "headers-polyfill": "^4.0.2", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "path-to-regexp": "^6.3.0", "picocolors": "^1.1.1", "rettime": "^0.10.1", "statuses": "^2.0.2", "strict-event-emitter": "^0.5.1", "tough-cookie": "^6.0.0", "type-fest": "^5.2.0", "until-async": "^3.0.2", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": ">= 4.8.x" }, "optionalPeers": ["typescript"], "bin": { "msw": "cli/index.js" } }, "sha512-G3VUymSE0/iegFnuipujpwyTM2GuZAKXNeerUSrG2+Eg391wW63xFs5ixWsK9MWzr1AGoSkYGmyAzNgbR3+urw=="],
+
+    "multipasta": ["multipasta@0.2.7", "", {}, "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA=="],
 
     "multistream": ["multistream@3.1.0", "", { "dependencies": { "inherits": "^2.0.1", "readable-stream": "^3.4.0" } }, "sha512-zBgD3kn8izQAN/TaL1PCMv15vYpf+Vcrsfub06njuYVYlzUldzpopTlrEZ53pZVEbfn3Shtv7vRFoOv6LOV87Q=="],
 
@@ -3183,6 +3222,8 @@
     "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
 
     "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
+
+    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
     "node-liblzma": ["node-liblzma@2.2.0", "", { "dependencies": { "node-addon-api": "^8.5.0", "node-gyp-build": "^4.8.4" }, "bin": { "nxz": "lib/cli/nxz.js" } }, "sha512-s0KzNOWwOJJgPG6wxg6cKohnAl9Wk/oW1KrQaVzJBjQwVcUGPQCzpR46Ximygjqj/3KhOrtJXnYMp/xYAXp75g=="],
 
@@ -3714,6 +3755,8 @@
 
     "through": ["through@2.3.8", "", {}, "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="],
 
+    "tiktoken": ["tiktoken@1.0.22", "", {}, "sha512-PKvy1rVF1RibfF3JlXBSP0Jrcw2uq3yXdgcEXtKTYn3QJ/cBRBHDnrJ5jHky+MENZ6DIPwNUGWpkVx+7joCpNA=="],
+
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
     "tiny-warning": ["tiny-warning@1.0.3", "", {}, "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="],
@@ -3938,6 +3981,8 @@
 
     "@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
 
+    "@anthropic-ai/tokenizer/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
+
     "@aws-crypto/sha1-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
@@ -3987,6 +4032,8 @@
     "@dotenvx/dotenvx/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
     "@ecies/ciphers/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+
+    "@effect/experimental/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
@@ -4283,6 +4330,8 @@
     "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "wsl-utils/is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
+
+    "@anthropic-ai/tokenizer/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -61,6 +61,9 @@
   },
   "devDependencies": {
     "@ai-sdk/provider": "^3.0.8",
+    "@effect/ai": "^0.35.0",
+    "@effect/ai-anthropic": "^0.25.0",
+    "@effect/ai-openai": "^0.39.0",
     "@types/js-yaml": "^4.0.9",
     "@types/pg": "^8.16.0"
   }

--- a/packages/api/src/lib/effect/__tests__/ai.test.ts
+++ b/packages/api/src/lib/effect/__tests__/ai.test.ts
@@ -1,0 +1,112 @@
+import { describe, test, expect } from "bun:test";
+import { Effect, Layer } from "effect";
+import {
+  AtlasAiModel,
+  createAiModelTestLayer,
+  type AtlasAiModelShape,
+} from "../ai";
+
+describe("AtlasAiModel", () => {
+  test("createAiModelTestLayer provides default mock model", async () => {
+    const layer = createAiModelTestLayer();
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const ai = yield* AtlasAiModel;
+        return {
+          providerType: ai.providerType,
+          modelId: ai.modelId,
+          hasModel: ai.model != null,
+        };
+      }).pipe(Effect.provide(layer)),
+    );
+
+    expect(result.providerType).toBe("anthropic");
+    expect(result.modelId).toBe("test-model");
+    expect(result.hasModel).toBe(true);
+  });
+
+  test("createAiModelTestLayer accepts overrides", async () => {
+    const layer = createAiModelTestLayer({
+      providerType: "openai",
+      modelId: "gpt-4o",
+    });
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const ai = yield* AtlasAiModel;
+        return { providerType: ai.providerType, modelId: ai.modelId };
+      }).pipe(Effect.provide(layer)),
+    );
+
+    expect(result.providerType).toBe("openai");
+    expect(result.modelId).toBe("gpt-4o");
+  });
+
+  test("mock model throws on doGenerate/doStream", async () => {
+    const layer = createAiModelTestLayer();
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const ai = yield* AtlasAiModel;
+        return yield* Effect.tryPromise({
+          try: () =>
+            (ai.model as unknown as { doGenerate: () => Promise<void> }).doGenerate(),
+          catch: (err) => (err instanceof Error ? err.message : String(err)),
+        }).pipe(
+          Effect.matchEffect({
+            onSuccess: () => Effect.succeed("did-not-throw"),
+            onFailure: (msg) => Effect.succeed(msg),
+          }),
+        );
+      }).pipe(Effect.provide(layer)),
+    );
+
+    expect(result).toContain("Mock model");
+  });
+
+  test("provider type variants", async () => {
+    const providers: AtlasAiModelShape["providerType"][] = [
+      "anthropic",
+      "openai",
+      "bedrock",
+      "ollama",
+      "openai-compatible",
+      "gateway",
+    ];
+
+    for (const providerType of providers) {
+      const layer = createAiModelTestLayer({ providerType });
+
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const ai = yield* AtlasAiModel;
+          return ai.providerType;
+        }).pipe(Effect.provide(layer)),
+      );
+
+      expect(result).toBe(providerType);
+    }
+  });
+
+  test("composes with other test layers", async () => {
+    const { createRequestContextTestLayer, RequestContext } = await import(
+      "../services"
+    );
+
+    const combined = Layer.merge(
+      createAiModelTestLayer({ modelId: "claude-opus" }),
+      createRequestContextTestLayer({ requestId: "req-ai-test" }),
+    );
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const ai = yield* AtlasAiModel;
+        const req = yield* RequestContext;
+        return `${req.requestId}:${ai.modelId}`;
+      }).pipe(Effect.provide(combined)),
+    );
+
+    expect(result).toBe("req-ai-test:claude-opus");
+  });
+});

--- a/packages/api/src/lib/effect/ai.ts
+++ b/packages/api/src/lib/effect/ai.ts
@@ -1,0 +1,174 @@
+/**
+ * AI Model as Effect Service (P10a).
+ *
+ * Wraps the existing Vercel AI SDK LanguageModel from providers.ts
+ * in an Effect Context.Tag so it can be yielded from Effect programs.
+ *
+ * This is a bridge layer — the model is still created by providers.ts
+ * and uses Vercel AI SDK under the hood. P10c will migrate to native
+ * @effect/ai AiLanguageModel.
+ *
+ * @example
+ * ```ts
+ * import { AtlasAiModel } from "@atlas/api/lib/effect";
+ *
+ * const program = Effect.gen(function* () {
+ *   const { model, providerType } = yield* AtlasAiModel;
+ *   // Use model with Vercel AI SDK's streamText/generateText
+ *   return providerType;
+ * });
+ * ```
+ */
+
+import { Context, Effect, Layer } from "effect";
+import type { LanguageModel } from "ai";
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("effect:ai");
+
+// Re-export the ProviderType from providers.ts for convenience
+type ProviderType = import("@atlas/api/lib/providers").ProviderType;
+
+// ── Service interface ────────────────────────────────────────────────
+
+/**
+ * Atlas AI model service — provides the configured LLM.
+ *
+ * The model is a Vercel AI SDK LanguageModel (bridge pattern).
+ * `providerType` is used for cache control and prompt formatting decisions.
+ */
+export interface AtlasAiModelShape {
+  /** The configured LLM instance (Vercel AI SDK LanguageModel). */
+  readonly model: LanguageModel;
+  /** Provider type for cache control and system prompt formatting. */
+  readonly providerType: ProviderType;
+  /** Model ID string (e.g. "claude-opus-4-6", "gpt-4o"). */
+  readonly modelId: string;
+}
+
+// ── Context.Tag ──────────────────────────────────────────────────────
+
+export class AtlasAiModel extends Context.Tag("AtlasAiModel")<
+  AtlasAiModel,
+  AtlasAiModelShape
+>() {}
+
+// ── Live Layer ───────────────────────────────────────────────────────
+
+/**
+ * Create the Live layer for AtlasAiModel.
+ *
+ * Reads ATLAS_PROVIDER and ATLAS_MODEL from env vars via providers.ts.
+ * Fails the Layer if the provider is misconfigured.
+ */
+export const AtlasAiModelLive: Layer.Layer<AtlasAiModel, Error> = Layer.effect(
+  AtlasAiModel,
+  Effect.gen(function* () {
+    const { model, providerType, modelId } = yield* Effect.tryPromise({
+      try: async () => {
+        const { getModel, getProviderType } = await import(
+          "@atlas/api/lib/providers"
+        );
+        const model = getModel();
+        const providerType = getProviderType();
+        const modelId = process.env.ATLAS_MODEL ?? (model as unknown as { modelId?: string }).modelId ?? "unknown";
+        return { model, providerType, modelId };
+      },
+      catch: (err) =>
+        new Error(
+          `AI model initialization failed: ${err instanceof Error ? err.message : String(err)}`,
+        ),
+    });
+
+    log.info({ provider: providerType, model: modelId }, "AI model configured");
+
+    return { model, providerType, modelId } satisfies AtlasAiModelShape;
+  }),
+);
+
+/**
+ * Create a Live layer for a workspace-level model configuration.
+ *
+ * Enterprise workspaces can override the platform default with their
+ * own provider/model/API key. This Layer reads from workspace config
+ * instead of env vars.
+ */
+export function makeWorkspaceAiModelLayer(config: {
+  provider: import("@useatlas/types").ModelConfigProvider;
+  model: string;
+  apiKey: string;
+  baseUrl: string | null;
+}): Layer.Layer<AtlasAiModel, Error> {
+  return Layer.effect(
+    AtlasAiModel,
+    Effect.gen(function* () {
+      const { model, providerType } = yield* Effect.tryPromise({
+        try: async () => {
+          const { getModelFromWorkspaceConfig, getWorkspaceProviderType } =
+            await import("@atlas/api/lib/providers");
+          const model = getModelFromWorkspaceConfig(config);
+          const providerType = getWorkspaceProviderType(config.provider);
+          return { model, providerType };
+        },
+        catch: (err) =>
+          new Error(
+            `Workspace AI model initialization failed: ${err instanceof Error ? err.message : String(err)}`,
+          ),
+      });
+
+      return {
+        model,
+        providerType,
+        modelId: config.model,
+      } satisfies AtlasAiModelShape;
+    }),
+  );
+}
+
+// ── Test helper ──────────────────────────────────────────────────────
+
+/**
+ * Create a test Layer for AtlasAiModel.
+ *
+ * Provides a mock model that can be used in tests without requiring
+ * real API keys or network access.
+ *
+ * @example
+ * ```ts
+ * const TestLayer = createAiModelTestLayer({
+ *   providerType: "anthropic",
+ *   modelId: "test-model",
+ * });
+ *
+ * const result = await Effect.runPromise(
+ *   Effect.gen(function* () {
+ *     const { providerType } = yield* AtlasAiModel;
+ *     return providerType;
+ *   }).pipe(Effect.provide(TestLayer)),
+ * );
+ * ```
+ */
+export function createAiModelTestLayer(
+  partial: Partial<AtlasAiModelShape> = {},
+): Layer.Layer<AtlasAiModel> {
+  const mockModel = {
+    modelId: partial.modelId ?? "test-model",
+    provider: "test-provider",
+    specificationVersion: "v1",
+    defaultObjectGenerationMode: undefined,
+    supportsImageUrls: false,
+    supportsStructuredOutputs: false,
+    doGenerate: async () => {
+      throw new Error("Mock model: doGenerate not implemented");
+    },
+    doStream: async () => {
+      throw new Error("Mock model: doStream not implemented");
+    },
+  } as unknown as LanguageModel;
+
+  return Layer.succeed(AtlasAiModel, {
+    model: partial.model ?? mockModel,
+    providerType: partial.providerType ?? "anthropic",
+    modelId: partial.modelId ?? "test-model",
+  });
+}

--- a/packages/api/src/lib/effect/index.ts
+++ b/packages/api/src/lib/effect/index.ts
@@ -97,3 +97,13 @@ export {
   type SettingsShape,
   type SchedulerShape,
 } from "./layers";
+
+// ── AI Model Service (P10a) ─────────────────────────────────────────
+
+export {
+  AtlasAiModel,
+  AtlasAiModelLive,
+  makeWorkspaceAiModelLayer,
+  createAiModelTestLayer,
+  type AtlasAiModelShape,
+} from "./ai";


### PR DESCRIPTION
## Summary

- **Install** `@effect/ai`, `@effect/ai-anthropic`, `@effect/ai-openai`
- **AtlasAiModel** Context.Tag bridging Vercel AI SDK `LanguageModel` to Effect Context
- **AtlasAiModelLive** — reads ATLAS_PROVIDER/ATLAS_MODEL via existing providers.ts
- **makeWorkspaceAiModelLayer** — enterprise workspace-level model overrides
- **createAiModelTestLayer** — mock model for tests (no API keys needed)

Bridge pattern: existing `agent.ts` unchanged. Effect programs can now `yield* AtlasAiModel` to get the configured LLM. P10b (AiToolkit) and P10c (agent loop rewrite) build on this.

Closes #933

## Test plan

- [x] 5 new tests (defaults, overrides, mock throws, provider variants, Layer composition)
- [x] All existing tests pass unchanged
- [x] Full CI: lint, type, test, syncpack, template drift — all pass