### PR TITLE
refactor: install @effect/sql and define SqlClient Layer bridge (P11a)

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -545,7 +545,7 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
 - [ ] P10c: Rewrite agent loop with AiLanguageModel.streamText (#935)
 
 ### Database (P11) — Native Effect SQL
-- [ ] P11a: Install @effect/sql, define SqlClient Layer bridge (#936)
+- [x] P11a: Install @effect/sql, define SqlClient Layer bridge (#936)
 - [ ] P11b: Replace raw pg/mysql2 with @effect/sql native clients (#937)
 
 ### Follow-ups

--- a/bun.lock
+++ b/bun.lock
@@ -141,6 +141,9 @@
         "@effect/ai": "^0.35.0",
         "@effect/ai-anthropic": "^0.25.0",
         "@effect/ai-openai": "^0.39.0",
+        "@effect/sql": "^0.51.0",
+        "@effect/sql-mysql2": "^0.52.0",
+        "@effect/sql-pg": "^0.52.1",
         "@types/js-yaml": "^4.0.9",
         "@types/pg": "^8.16.0",
       },
@@ -1008,6 +1011,12 @@
     "@effect/platform": ["@effect/platform@0.96.0", "", { "dependencies": { "find-my-way-ts": "^0.1.6", "msgpackr": "^1.11.4", "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^3.21.0" } }, "sha512-U7PLhkVzg7zzrgFvyWATOzD6reL87KG/fcdOxgLWBQ/J5CCU6qdPAVG+0o6o+IxcsLoqGwxs+rFxaFzrdtDV1A=="],
 
     "@effect/rpc": ["@effect/rpc@0.75.0", "", { "dependencies": { "msgpackr": "^1.11.4" }, "peerDependencies": { "@effect/platform": "^0.96.0", "effect": "^3.21.0" } }, "sha512-VFeJ16cZUXqiIzG9UHOVKGuiBPJ7fV+0lEbJU6xi12JnnxXe/19BQPpOwiRawCUbPOR3/xIURDUgGxU+Ft0pvQ=="],
+
+    "@effect/sql": ["@effect/sql@0.51.0", "", { "dependencies": { "uuid": "^11.0.3" }, "peerDependencies": { "@effect/experimental": "^0.60.0", "@effect/platform": "^0.96.0", "effect": "^3.21.0" } }, "sha512-e7hWe46QD15eMCr4kNBMVdItIVK/WLHJG+d8DLL1FjVf5Ra82k2mwUYIXplJewVbHjt3my6GSKPPd1ZrQjVd5A=="],
+
+    "@effect/sql-mysql2": ["@effect/sql-mysql2@0.52.0", "", { "dependencies": { "mysql2": "^3.11.0" }, "peerDependencies": { "@effect/experimental": "^0.60.0", "@effect/platform": "^0.96.0", "@effect/sql": "^0.51.0", "effect": "^3.21.0" } }, "sha512-oihi2T/wpguXag7TGGJN0lzGIxjwkpxAVsTwAzYOgS8dwVHhbBtOMEHrm5T/wuXKEnIMtiowKDh8BTb3rR+bww=="],
+
+    "@effect/sql-pg": ["@effect/sql-pg@0.52.1", "", { "dependencies": { "pg": "^8.16.3", "pg-connection-string": "2.9.1", "pg-cursor": "^2.15.3", "pg-pool": "^3.10.1", "pg-types": "^4.1.0" }, "peerDependencies": { "@effect/experimental": "^0.60.0", "@effect/platform": "^0.96.0", "@effect/sql": "^0.51.0", "effect": "^3.21.0" } }, "sha512-Lp0Zjas77WQ/AfWZ/FzzCOkyGCpx+wB2FXNHStzM4GrHEvwUYQoYQxMxdz5r7K+EUiZOPlxy/SBLVVReVIovjw=="],
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.3.15", "", {}, "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ=="],
 
@@ -3255,6 +3264,8 @@
 
     "obsidian-atlas": ["obsidian-atlas@workspace:plugins/obsidian"],
 
+    "obuf": ["obuf@1.1.2", "", {}, "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="],
+
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
@@ -3341,15 +3352,19 @@
 
     "pg-cloudflare": ["pg-cloudflare@1.3.0", "", {}, "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ=="],
 
-    "pg-connection-string": ["pg-connection-string@2.11.0", "", {}, "sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ=="],
+    "pg-connection-string": ["pg-connection-string@2.9.1", "", {}, "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w=="],
+
+    "pg-cursor": ["pg-cursor@2.19.0", "", { "peerDependencies": { "pg": "^8" } }, "sha512-J5cF1MUz7LRJ9emOqF/06QjabMHMZy587rSPF0UuA8rCwKeeYl2co8Pp+6k5UU9YrAYHMzWkLxilfZB0hqsWWw=="],
 
     "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
+
+    "pg-numeric": ["pg-numeric@1.0.2", "", {}, "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw=="],
 
     "pg-pool": ["pg-pool@3.12.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-eIJ0DES8BLaziFHW7VgJEBPi5hg3Nyng5iKpYtj3wbcAUV9A1wLgWiY7ajf/f/oO1wfxt83phXPY8Emztg7ITg=="],
 
     "pg-protocol": ["pg-protocol@1.12.0", "", {}, "sha512-uOANXNRACNdElMXJ0tPz6RBM0XQ61nONGAwlt8da5zs/iUOOCLBQOHSXnrC6fMsvtjxbOJrZZl5IScGv+7mpbg=="],
 
-    "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+    "pg-types": ["pg-types@4.1.0", "", { "dependencies": { "pg-int8": "1.0.1", "pg-numeric": "1.0.2", "postgres-array": "~3.0.1", "postgres-bytea": "~3.0.0", "postgres-date": "~2.1.0", "postgres-interval": "^3.0.0", "postgres-range": "^1.1.1" } }, "sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg=="],
 
     "pgpass": ["pgpass@1.0.5", "", { "dependencies": { "split2": "^4.1.0" } }, "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug=="],
 
@@ -3383,13 +3398,15 @@
 
     "postgres": ["postgres@3.4.7", "", {}, "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw=="],
 
-    "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
+    "postgres-array": ["postgres-array@3.0.4", "", {}, "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ=="],
 
-    "postgres-bytea": ["postgres-bytea@1.0.1", "", {}, "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="],
+    "postgres-bytea": ["postgres-bytea@3.0.0", "", { "dependencies": { "obuf": "~1.1.2" } }, "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw=="],
 
-    "postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
+    "postgres-date": ["postgres-date@2.1.0", "", {}, "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA=="],
 
-    "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
+    "postgres-interval": ["postgres-interval@3.0.0", "", {}, "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw=="],
+
+    "postgres-range": ["postgres-range@1.1.4", "", {}, "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w=="],
 
     "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
 
@@ -3875,7 +3892,7 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
+    "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "valibot": ["valibot@1.2.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg=="],
 
@@ -3993,6 +4010,8 @@
 
     "@azure/identity/open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
+    "@azure/msal-node/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
+
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -4033,11 +4052,11 @@
 
     "@ecies/ciphers/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
-    "@effect/experimental/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
-
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@google-cloud/storage/google-auth-library": ["google-auth-library@9.15.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^6.1.1", "gcp-metadata": "^6.1.0", "gtoken": "^7.0.0", "jws": "^4.0.0" } }, "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng=="],
+
+    "@google-cloud/storage/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
     "@inquirer/core/cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
 
@@ -4106,6 +4125,8 @@
     "@tanstack/start-plugin-core/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 
     "@ts-morph/common/fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "@types/pg/pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
 
     "@types/request/form-data": ["form-data@2.5.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.35", "safe-buffer": "^5.2.1" } }, "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A=="],
 
@@ -4261,6 +4282,10 @@
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
+    "pg/pg-connection-string": ["pg-connection-string@2.11.0", "", {}, "sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ=="],
+
+    "pg/pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+
     "pkg-types/confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 
     "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
@@ -4302,6 +4327,8 @@
     "shadcn/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 
     "snowflake-sdk/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "snowflake-sdk/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
     "tar-fs/tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
@@ -4369,6 +4396,14 @@
 
     "@ts-morph/common/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "@types/pg/pg-types/postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
+
+    "@types/pg/pg-types/postgres-bytea": ["postgres-bytea@1.0.1", "", {}, "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="],
+
+    "@types/pg/pg-types/postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
+
+    "@types/pg/pg-types/postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
+
     "@typespec/ts-http-runtime/http-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "@typespec/ts-http-runtime/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
@@ -4380,6 +4415,8 @@
     "botbuilder/@azure/msal-node/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
     "botframework-connector/@azure/msal-node/@azure/msal-common": ["@azure/msal-common@14.16.1", "", {}, "sha512-nyxsA6NA4SVKh5YyRpbSXiMr7oQbwark7JU9LMeg6tJYTSPyAGkdx61wPT4gyxZfxlSxMMEyAsWaubBlNyIa1w=="],
+
+    "botframework-connector/@azure/msal-node/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
     "botframework-connector/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
@@ -4478,6 +4515,14 @@
     "ora/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "ora/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "pg/pg-types/postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
+
+    "pg/pg-types/postgres-bytea": ["postgres-bytea@1.0.1", "", {}, "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="],
+
+    "pg/pg-types/postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
+
+    "pg/pg-types/postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
     "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -64,6 +64,9 @@
     "@effect/ai": "^0.35.0",
     "@effect/ai-anthropic": "^0.25.0",
     "@effect/ai-openai": "^0.39.0",
+    "@effect/sql": "^0.51.0",
+    "@effect/sql-mysql2": "^0.52.0",
+    "@effect/sql-pg": "^0.52.1",
     "@types/js-yaml": "^4.0.9",
     "@types/pg": "^8.16.0"
   }

--- a/packages/api/src/lib/effect/__tests__/sql.test.ts
+++ b/packages/api/src/lib/effect/__tests__/sql.test.ts
@@ -1,0 +1,127 @@
+import { describe, test, expect } from "bun:test";
+import { Effect, Layer, Exit } from "effect";
+import {
+  AtlasSqlClient,
+  createSqlClientTestLayer,
+  makeAtlasSqlClientLive,
+} from "../sql";
+import { createTestLayer } from "../services";
+
+describe("AtlasSqlClient", () => {
+  test("createSqlClientTestLayer provides default empty result", async () => {
+    const layer = createSqlClientTestLayer();
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* AtlasSqlClient;
+        const qr = yield* sql.query("SELECT 1");
+        return { columns: qr.columns, rows: qr.rows, dbType: sql.dbType };
+      }).pipe(Effect.provide(layer)),
+    );
+
+    expect(result.columns).toEqual([]);
+    expect(result.rows).toEqual([]);
+    expect(result.dbType).toBe("postgres");
+  });
+
+  test("createSqlClientTestLayer accepts custom query result", async () => {
+    const layer = createSqlClientTestLayer({
+      queryResult: { columns: ["name"], rows: [{ name: "Alice" }] },
+      dbType: "mysql",
+    });
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* AtlasSqlClient;
+        const qr = yield* sql.query("SELECT name FROM users");
+        return { rows: qr.rows, dbType: sql.dbType };
+      }).pipe(Effect.provide(layer)),
+    );
+
+    expect(result.rows).toEqual([{ name: "Alice" }]);
+    expect(result.dbType).toBe("mysql");
+  });
+
+  test("createSqlClientTestLayer with query error", async () => {
+    const layer = createSqlClientTestLayer({
+      queryError: new Error("connection refused"),
+    });
+
+    const exit = await Effect.runPromiseExit(
+      Effect.gen(function* () {
+        const sql = yield* AtlasSqlClient;
+        return yield* sql.query("SELECT 1");
+      }).pipe(Effect.provide(layer)),
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+  });
+
+  test("makeAtlasSqlClientLive reads from ConnectionRegistry", async () => {
+    const mockConn = {
+      query: async () => ({
+        columns: ["count"],
+        rows: [{ count: 42 }],
+      }),
+      close: async () => {},
+    };
+
+    const connLayer = createTestLayer({
+      get: () => mockConn,
+      has: () => true,
+      getDBType: () => "postgres" as const,
+    });
+
+    const sqlLayer = makeAtlasSqlClientLive("default");
+    const combined = Layer.provide(sqlLayer, connLayer);
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* AtlasSqlClient;
+        const qr = yield* sql.query("SELECT count(*) FROM users");
+        return { count: qr.rows[0]?.count, dbType: sql.dbType };
+      }).pipe(Effect.provide(combined)),
+    );
+
+    expect(result.count).toBe(42);
+    expect(result.dbType).toBe("postgres");
+  });
+
+  test("makeAtlasSqlClientLive fails when connection not found", async () => {
+    const connLayer = createTestLayer({
+      has: () => false,
+      get: () => {
+        throw new Error("not found");
+      },
+    });
+
+    const sqlLayer = makeAtlasSqlClientLive("nonexistent");
+    const combined = Layer.provide(sqlLayer, connLayer);
+
+    const exit = await Effect.runPromiseExit(
+      Effect.gen(function* () {
+        const sql = yield* AtlasSqlClient;
+        return yield* sql.query("SELECT 1");
+      }).pipe(Effect.provide(combined)),
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+  });
+
+  test("connectionId and dbType are accessible", async () => {
+    const layer = createSqlClientTestLayer({
+      connectionId: "analytics",
+      dbType: "postgres",
+    });
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* AtlasSqlClient;
+        return { id: sql.connectionId, type: sql.dbType };
+      }).pipe(Effect.provide(layer)),
+    );
+
+    expect(result.id).toBe("analytics");
+    expect(result.type).toBe("postgres");
+  });
+});

--- a/packages/api/src/lib/effect/index.ts
+++ b/packages/api/src/lib/effect/index.ts
@@ -116,3 +116,13 @@ export {
   createToolkitTestLayer,
   type AtlasToolkitShape,
 } from "./toolkit";
+
+// ── SQL Client Service (P11a) ───────────────────────────────────────
+
+export {
+  AtlasSqlClient,
+  makeAtlasSqlClientLive,
+  makeOrgSqlClientLive,
+  createSqlClientTestLayer,
+  type AtlasSqlClientShape,
+} from "./sql";

--- a/packages/api/src/lib/effect/sql.ts
+++ b/packages/api/src/lib/effect/sql.ts
@@ -1,0 +1,176 @@
+/**
+ * Atlas SQL Client as Effect Service (P11a).
+ *
+ * Wraps the existing DBConnection interface from ConnectionRegistry
+ * in an Effect Context.Tag so it can be yielded from Effect programs.
+ *
+ * This is a bridge layer — the actual DB connections are still managed
+ * by ConnectionRegistry (raw pg/mysql2 pools). P11b will migrate to
+ * native @effect/sql-pg and @effect/sql-mysql2 clients.
+ *
+ * @example
+ * ```ts
+ * import { AtlasSqlClient } from "@atlas/api/lib/effect";
+ *
+ * const program = Effect.gen(function* () {
+ *   const sql = yield* AtlasSqlClient;
+ *   const result = yield* sql.query("SELECT count(*) FROM users");
+ *   return result.rows;
+ * });
+ * ```
+ */
+
+import { Context, Effect, Layer } from "effect";
+import { ConnectionRegistry } from "./services";
+
+// ── Service interface ────────────────────────────────────────────────
+
+/**
+ * Atlas SQL client service — provides query execution.
+ *
+ * Bridges the existing DBConnection.query() to Effect Context.
+ * The query method returns an Effect that succeeds with { columns, rows }
+ * or fails with an Error.
+ */
+export interface AtlasSqlClientShape {
+  /** Execute a SQL query and return { columns, rows }. */
+  query(
+    sql: string,
+    timeoutMs?: number,
+  ): Effect.Effect<
+    { columns: string[]; rows: Record<string, unknown>[] },
+    Error
+  >;
+  /** The database type of the current connection. */
+  readonly dbType: string;
+  /** The connection ID being used. */
+  readonly connectionId: string;
+}
+
+// ── Context.Tag ──────────────────────────────────────────────────────
+
+export class AtlasSqlClient extends Context.Tag("AtlasSqlClient")<
+  AtlasSqlClient,
+  AtlasSqlClientShape
+>() {}
+
+// ── Live Layer ───────────────────────────────────────────────────────
+
+/**
+ * Create a Live layer for AtlasSqlClient from the ConnectionRegistry.
+ *
+ * Reads the specified connection (or default) from the registry and
+ * wraps its query() method as an Effect.
+ *
+ * @param connectionId - Connection ID to use. Defaults to "default".
+ */
+export function makeAtlasSqlClientLive(
+  connectionId?: string,
+): Layer.Layer<AtlasSqlClient, Error, ConnectionRegistry> {
+  return Layer.effect(
+    AtlasSqlClient,
+    Effect.gen(function* () {
+      const registry = yield* ConnectionRegistry;
+      const id = connectionId ?? "default";
+
+      if (!registry.has(id)) {
+        return yield* Effect.fail(
+          new Error(`Connection "${id}" not found in registry`),
+        );
+      }
+
+      const conn = registry.get(id);
+      const dbType = registry.getDBType(id);
+
+      const service: AtlasSqlClientShape = {
+        query: (sql, timeoutMs) =>
+          Effect.tryPromise({
+            try: () => conn.query(sql, timeoutMs),
+            catch: (err) =>
+              new Error(
+                `SQL query failed: ${err instanceof Error ? err.message : String(err)}`,
+              ),
+          }),
+        dbType,
+        connectionId: id,
+      };
+
+      return service;
+    }),
+  );
+}
+
+/**
+ * Create a Live layer for AtlasSqlClient for an org-scoped connection.
+ *
+ * Uses ConnectionRegistry.getForOrg() to get the org-specific pool.
+ */
+export function makeOrgSqlClientLive(
+  orgId: string,
+  connectionId?: string,
+): Layer.Layer<AtlasSqlClient, Error, ConnectionRegistry> {
+  return Layer.effect(
+    AtlasSqlClient,
+    Effect.gen(function* () {
+      const registry = yield* ConnectionRegistry;
+      const id = connectionId ?? "default";
+      const conn = registry.getForOrg(orgId, connectionId);
+      const dbType = registry.getDBType(id);
+
+      const service: AtlasSqlClientShape = {
+        query: (sql, timeoutMs) =>
+          Effect.tryPromise({
+            try: () => conn.query(sql, timeoutMs),
+            catch: (err) =>
+              new Error(
+                `SQL query failed: ${err instanceof Error ? err.message : String(err)}`,
+              ),
+          }),
+        dbType,
+        connectionId: id,
+      };
+
+      return service;
+    }),
+  );
+}
+
+// ── Test helper ──────────────────────────────────────────────────────
+
+/**
+ * Create a test Layer for AtlasSqlClient.
+ *
+ * Provides a mock SQL client with configurable query results.
+ * Does NOT require ConnectionRegistry — fully self-contained.
+ *
+ * @example
+ * ```ts
+ * const TestLayer = createSqlClientTestLayer({
+ *   queryResult: { columns: ["count"], rows: [{ count: 42 }] },
+ * });
+ *
+ * const result = await runTest(
+ *   Effect.gen(function* () {
+ *     const sql = yield* AtlasSqlClient;
+ *     return yield* sql.query("SELECT count(*) FROM users");
+ *   }),
+ * );
+ * ```
+ */
+export function createSqlClientTestLayer(options?: {
+  queryResult?: { columns: string[]; rows: Record<string, unknown>[] };
+  queryError?: Error;
+  dbType?: string;
+  connectionId?: string;
+}): Layer.Layer<AtlasSqlClient> {
+  return Layer.succeed(AtlasSqlClient, {
+    query: (_sql, _timeoutMs) =>
+      options?.queryError
+        ? Effect.fail(options.queryError)
+        : Effect.succeed(
+            options?.queryResult ?? { columns: [], rows: [] },
+          ),
+    dbType: options?.dbType ?? "postgres",
+    connectionId: options?.connectionId ?? "default",
+  });
+}


### PR DESCRIPTION
## Summary

- **Install** `@effect/sql`, `@effect/sql-pg`, `@effect/sql-mysql2`
- **AtlasSqlClient** Context.Tag bridging existing DBConnection.query() to Effect Context
- **makeAtlasSqlClientLive** — reads connection from ConnectionRegistry, wraps query as Effect
- **makeOrgSqlClientLive** — org-scoped connection via getForOrg()
- **createSqlClientTestLayer** — mock SQL client with configurable results/errors
- Bridge pattern: existing connection.ts unchanged. P11b migrates to native @effect/sql pools.

Closes #936

## Test plan
- [x] 6 tests (defaults, custom results, query errors, registry bridge, not-found, metadata)
- [x] All CI gates pass