### PR TITLE
fix: Effect.ts audit fixes — type safety, consistency, docs

### DIFF
--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -130,7 +130,11 @@ export interface InternalPool {
 export interface InternalDBShape {
   /** Execute a parameterized query returning typed rows. */
   query<T extends Record<string, unknown>>(sql: string, params?: unknown[]): Promise<T[]>;
-  /** Fire-and-forget write (uses circuit breaker internally). */
+  /**
+   * Fire-and-forget write (uses circuit breaker internally).
+   * Intentionally void (not Effect/Promise) — called from onFinish callbacks
+   * in the agent loop where back-pressure would block stream finalization.
+   */
   execute(sql: string, params?: unknown[]): void;
   /** Whether the internal DB is available. */
   readonly available: boolean;

--- a/packages/api/src/lib/effect/ai.ts
+++ b/packages/api/src/lib/effect/ai.ts
@@ -71,7 +71,8 @@ export const AtlasAiModelLive: Layer.Layer<AtlasAiModel, Error> = Layer.effect(
         );
         const model = getModel();
         const providerType = getProviderType();
-        const modelId = process.env.ATLAS_MODEL ?? (model as unknown as { modelId?: string }).modelId ?? "unknown";
+        // LanguageModel type doesn't expose modelId directly — access via runtime property
+        const modelId = process.env.ATLAS_MODEL ?? (model as { modelId?: string }).modelId ?? "unknown";
         return { model, providerType, modelId };
       },
       catch: (err) =>

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -435,7 +435,7 @@ export function runHandler<T>(
 ): Promise<T> {
   const program = Effect.tryPromise({
     try: handler,
-    catch: (err) => err,
+    catch: (err) => (err instanceof Error ? err : new Error(String(err))),
   });
 
   // Provide Hono context as Effect Context layers

--- a/packages/api/src/lib/effect/index.ts
+++ b/packages/api/src/lib/effect/index.ts
@@ -86,7 +86,6 @@ export {
   SemanticSyncLive,
   Settings,
   SettingsLive,
-  Scheduler as SchedulerService,
   Scheduler,
   makeSchedulerLive,
   buildAppLayer,
@@ -112,6 +111,7 @@ export {
 
 export {
   AtlasToolkit,
+  AtlasToolkitLive,
   makeAtlasToolkitLive,
   createToolkitTestLayer,
   type AtlasToolkitShape,

--- a/packages/api/src/lib/effect/sql.ts
+++ b/packages/api/src/lib/effect/sql.ts
@@ -115,6 +115,8 @@ export function makeOrgSqlClientLive(
       const registry = yield* ConnectionRegistry;
       const id = connectionId ?? "default";
       const conn = registry.getForOrg(orgId, connectionId);
+      // Use the base connection ID for dbType lookup — org pools inherit
+      // the database type from their parent connection, not from the org ID.
       const dbType = registry.getDBType(id);
 
       const service: AtlasSqlClientShape = {

--- a/packages/api/src/lib/effect/toolkit.ts
+++ b/packages/api/src/lib/effect/toolkit.ts
@@ -98,6 +98,10 @@ export function makeAtlasToolkitLive(options?: {
   );
 }
 
+/** Default Live layer using default buildRegistry options. */
+export const AtlasToolkitLive: ReturnType<typeof makeAtlasToolkitLive> =
+  makeAtlasToolkitLive();
+
 // ── Test helper ──────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

Comprehensive audit of all Effect.ts code shipped in 0.9.4 (P0–P11b). Reviewed against Effect best practices via Context7 documentation.

**Fixes:**
- `runHandler` catch handler normalized to return `Error` (was `unknown`, broke typed error channel)
- `AtlasToolkitLive` default export added (was missing, inconsistent with all other services)
- Duplicate `Scheduler`/`SchedulerService` export removed from index.ts
- `InternalDB.execute` documented as intentionally void (not Effect composable)
- `makeOrgSqlClientLive` connection ID semantics documented
- `ai.ts` modelId cast simplified (removed `as unknown as`)

**Audit findings NOT addressed (tracked for future):**
- Boot-receipt services (Migration, SemanticSync, Settings) could be `Layer.effectDiscard` — deferred, low impact
- Health check fibers fire immediately on boot — deferred, cosmetic
- `connRegistry as unknown as ConnectionRegistryClass` in wiring.ts — requires interface change, deferred

**Positive findings:** Tagged errors use `Data.TaggedError` correctly, Hono bridge has defense-in-depth error classification, Layer.scoped vs Layer.effect used correctly, compile-time dependency enforcement works, test layers are composable.

## Test plan
- [x] All CI gates pass (type, lint, test, syncpack, template drift)