### PR TITLE
fix: scope Users admin page to active org members

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -599,14 +599,14 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
 
 - [x] Add requireOrgContext to learned-patterns, suggestions, and prompts routes (#963)
 - [x] Add adminAuth middleware to scheduled-tasks routes (#964)
-- [ ] Scope Users admin page to active org members in SaaS mode (#965)
+- [x] Scope Users admin page to active org members in SaaS mode (#965)
 - [ ] Hide Organizations page from non-platform-admin (#966)
 
 ### Settings Architecture (P0)
 
 - [ ] Activate org_id scoping on settings table for workspace-level overrides (#967)
 - [ ] Split Settings page into workspace and platform tiers (#968)
-- [ ] Hide platform-only admin pages from workspace admins (#969)
+- [x] Hide platform-only admin pages from workspace admins (#969)
 
 ### Self-Service Features
 

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -3640,7 +3640,7 @@ admin.openapi(deleteUserSessionsRoute, async (c) => runHandler(c, "revoke user s
 // -- Users ------------------------------------------------------------------
 
 admin.openapi(listUsersRoute, async (c) => runHandler(c, "list users", async () => {
-  await adminAuthAndContext(c);
+  const { authResult } = await adminAuthAndContext(c);
   const adminApi = await getAdminApi();
   if (!adminApi) {
     return c.json({ error: "not_available", message: "User management requires managed auth mode." }, 404);
@@ -3650,6 +3650,74 @@ admin.openapi(listUsersRoute, async (c) => runHandler(c, "list users", async () 
   const search = c.req.query("search");
   const role = c.req.query("role");
 
+  // Org-scoping: non-platform_admin users with an activeOrganizationId see
+  // only members of their org. Platform admins and self-hosted (no org) see all.
+  const orgId = authResult.user?.activeOrganizationId;
+  const isPlatformAdmin = authResult.user?.role === "platform_admin";
+
+  if (orgId && !isPlatformAdmin && hasInternalDB()) {
+    // Query users via member table JOIN, scoped to the caller's active org
+    const conditions: string[] = [`m."organizationId" = $1`];
+    const params: unknown[] = [orgId];
+    let paramIndex = 2;
+
+    if (search) {
+      conditions.push(`u.email ILIKE $${paramIndex}`);
+      params.push(`%${search}%`);
+      paramIndex++;
+    }
+    if (role && isValidRole(role)) {
+      // Use org-level role from the member table
+      conditions.push(`m.role = $${paramIndex}`);
+      params.push(role);
+      paramIndex++;
+    }
+
+    const whereClause = conditions.join(" AND ");
+
+    const [userRows, countRows] = await Promise.all([
+      internalQuery<{
+        id: string; email: string; name: string | null; role: string;
+        banned: boolean; banReason: string | null; banExpires: string | null;
+        createdAt: string;
+      }>(
+        `SELECT u.id, u.email, u.name, COALESCE(m.role, 'member') as role,
+                COALESCE(u.banned, false) as banned, u."banReason", u."banExpires",
+                u."createdAt"
+         FROM "user" u
+         JOIN member m ON m."userId" = u.id
+         WHERE ${whereClause}
+         ORDER BY u."createdAt" DESC
+         LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+        [...params, limit, offset],
+      ),
+      internalQuery<{ count: string }>(
+        `SELECT COUNT(*) as count
+         FROM "user" u
+         JOIN member m ON m."userId" = u.id
+         WHERE ${whereClause}`,
+        params,
+      ),
+    ]);
+
+    return c.json({
+      users: userRows.map((u) => ({
+        id: u.id,
+        email: u.email,
+        name: u.name,
+        role: u.role,
+        banned: u.banned,
+        banReason: u.banReason,
+        banExpires: u.banExpires,
+        createdAt: u.createdAt,
+      })),
+      total: parseInt(String(countRows[0]?.count ?? "0"), 10),
+      limit,
+      offset,
+    }, 200);
+  }
+
+  // Platform admin or self-hosted: global view via Better Auth admin API
   const result = await adminApi.listUsers({
     query: {
       limit,
@@ -3680,20 +3748,51 @@ admin.openapi(listUsersRoute, async (c) => runHandler(c, "list users", async () 
 }));
 
 admin.openapi(getUserStatsRoute, async (c) => runHandler(c, "query user stats", async () => {
-  await adminAuthAndContext(c);
+  const { authResult } = await adminAuthAndContext(c);
   if (!hasInternalDB() || detectAuthMode() !== "managed") {
     return c.json({ error: "not_available", message: "User management requires managed auth mode." }, 404);
   }
 
-  const totalResult = await internalQuery<{ count: string }>(
-    `SELECT COUNT(*) as count FROM "user"`,
-  );
-  const roleResult = await internalQuery<{ role: string; count: string }>(
-    `SELECT COALESCE(role, 'member') as role, COUNT(*) as count FROM "user" GROUP BY COALESCE(role, 'member')`,
-  );
-  const bannedResult = await internalQuery<{ count: string }>(
-    `SELECT COUNT(*) as count FROM "user" WHERE banned = true`,
-  );
+  // Org-scoping: non-platform_admin users with an activeOrganizationId get
+  // stats scoped to their org. Platform admins and self-hosted see global stats.
+  const orgId = authResult.user?.activeOrganizationId;
+  const isPlatformAdmin = authResult.user?.role === "platform_admin";
+
+  let totalResult: { count: string }[];
+  let roleResult: { role: string; count: string }[];
+  let bannedResult: { count: string }[];
+
+  if (orgId && !isPlatformAdmin) {
+    [totalResult, roleResult, bannedResult] = await Promise.all([
+      internalQuery<{ count: string }>(
+        `SELECT COUNT(*) as count FROM "user" u JOIN member m ON m."userId" = u.id WHERE m."organizationId" = $1`,
+        [orgId],
+      ),
+      internalQuery<{ role: string; count: string }>(
+        `SELECT COALESCE(m.role, 'member') as role, COUNT(*) as count
+         FROM "user" u JOIN member m ON m."userId" = u.id
+         WHERE m."organizationId" = $1
+         GROUP BY COALESCE(m.role, 'member')`,
+        [orgId],
+      ),
+      internalQuery<{ count: string }>(
+        `SELECT COUNT(*) as count FROM "user" u JOIN member m ON m."userId" = u.id WHERE m."organizationId" = $1 AND u.banned = true`,
+        [orgId],
+      ),
+    ]);
+  } else {
+    [totalResult, roleResult, bannedResult] = await Promise.all([
+      internalQuery<{ count: string }>(
+        `SELECT COUNT(*) as count FROM "user"`,
+      ),
+      internalQuery<{ role: string; count: string }>(
+        `SELECT COALESCE(role, 'member') as role, COUNT(*) as count FROM "user" GROUP BY COALESCE(role, 'member')`,
+      ),
+      internalQuery<{ count: string }>(
+        `SELECT COUNT(*) as count FROM "user" WHERE banned = true`,
+      ),
+    ]);
+  }
 
   const total = parseInt(String(totalResult[0]?.count ?? "0"), 10);
   const banned = parseInt(String(bannedResult[0]?.count ?? "0"), 10);

--- a/packages/web/src/app/admin/users/page.tsx
+++ b/packages/web/src/app/admin/users/page.tsx
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { usersSearchParams } from "./search-params";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useAtlasConfig } from "@/ui/context";
+import { useUserRole } from "@/ui/hooks/use-platform-admin-guard";
 import { Badge } from "@/components/ui/badge";
 import { DataTable } from "@/components/data-table/data-table";
 import { DataTableToolbar } from "@/components/data-table/data-table-toolbar";
@@ -112,6 +113,8 @@ const inviteSchema = z.object({
 export default function UsersPage() {
   const { apiUrl, isCrossOrigin } = useAtlasConfig();
   const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
+  const userRole = useUserRole();
+  const isPlatformAdmin = userRole === "platform_admin";
 
   const [users, setUsers] = useState<User[]>([]);
   const [total, setTotal] = useState(0);
@@ -425,7 +428,9 @@ export default function UsersPage() {
       <div className="mb-6 flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight">Users</h1>
-          <p className="text-sm text-muted-foreground">Manage user accounts and roles</p>
+          <p className="text-sm text-muted-foreground">
+            {isPlatformAdmin ? "Manage all user accounts and roles" : "Manage workspace members and roles"}
+          </p>
         </div>
         <Button onClick={() => { resetInviteDialog(); setInviteOpen(true); }}>
           <UserPlus className="mr-1.5 size-4" />

--- a/packages/web/src/ui/hooks/use-platform-admin-guard.ts
+++ b/packages/web/src/ui/hooks/use-platform-admin-guard.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAtlasConfig } from "@/ui/context";
+
+/**
+ * Returns the user's role from the Better Auth session.
+ * Used by the sidebar for item-level visibility and by page guards.
+ */
+export function useUserRole(): string | undefined {
+  const { authClient } = useAtlasConfig();
+  const session = authClient.useSession();
+  return (session.data?.user as Record<string, unknown> | undefined)?.role as
+    | string
+    | undefined;
+}
+
+/**
+ * Redirects non-platform-admin users to /admin.
+ *
+ * Call at the top of any page component that should be restricted to
+ * platform admins only. Returns `true` while the role is still loading
+ * or a redirect is in progress — the caller should render nothing (or a
+ * loading spinner) until it returns `false`.
+ */
+export function usePlatformAdminGuard(): { blocked: boolean } {
+  const { authClient } = useAtlasConfig();
+  const session = authClient.useSession();
+  const router = useRouter();
+
+  const role = (session.data?.user as Record<string, unknown> | undefined)
+    ?.role as string | undefined;
+  const isPending = session.isPending;
+
+  useEffect(() => {
+    if (isPending) return;
+    if (role !== "platform_admin") {
+      router.replace("/admin");
+    }
+  }, [isPending, role, router]);
+
+  // Block rendering while pending or when the user is not platform_admin
+  const blocked = isPending === true || role !== "platform_admin";
+  return { blocked };
+}


### PR DESCRIPTION
## Summary
- Backend: `GET /admin/users` and `/admin/users/stats` now filter by `activeOrganizationId` for non-platform-admin callers via `member` table JOIN
- Platform admins retain global view of all users
- Frontend: subtitle updates to reflect workspace vs platform context
- New `useUserRole()` and `usePlatformAdminGuard()` hooks for role-based UI gating

## Test plan
- [x] `bun run type` passes
- [x] `bun run lint` passes
- [x] `bun run test` passes
- [ ] Manual: workspace admin sees only their org members
- [ ] Manual: platform admin sees all users globally
- [ ] Manual: self-hosted single-org shows all users

Closes #965