### PR TITLE
fix: hide Organizations page from non-platform-admin

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -600,7 +600,7 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
 - [x] Add requireOrgContext to learned-patterns, suggestions, and prompts routes (#963)
 - [x] Add adminAuth middleware to scheduled-tasks routes (#964)
 - [x] Scope Users admin page to active org members in SaaS mode (#965)
-- [ ] Hide Organizations page from non-platform-admin (#966)
+- [x] Hide Organizations page from non-platform-admin (#966)
 
 ### Settings Architecture (P0)
 

--- a/packages/web/src/app/admin/organizations/page.tsx
+++ b/packages/web/src/app/admin/organizations/page.tsx
@@ -6,6 +6,7 @@ import { orgsSearchParams } from "./search-params";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useAtlasConfig } from "@/ui/context";
 import { LoadingState } from "@/ui/components/admin/loading-state";
+import { usePlatformAdminGuard } from "@/ui/hooks/use-platform-admin-guard";
 import { Badge } from "@/components/ui/badge";
 import { DataTable } from "@/components/data-table/data-table";
 import { DataTableToolbar } from "@/components/data-table/data-table-toolbar";
@@ -84,6 +85,7 @@ const ROLE_ICONS: Record<string, typeof Crown> = {
 };
 
 export default function OrganizationsPage() {
+  const { blocked } = usePlatformAdminGuard();
   const { apiUrl, isCrossOrigin } = useAtlasConfig();
   const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
 
@@ -220,6 +222,8 @@ export default function OrganizationsPage() {
     },
     getRowId: (row) => row.id,
   });
+
+  if (blocked) return <LoadingState message="Checking access..." />;
 
   return (
     <div className="p-6">

--- a/packages/web/src/ui/components/admin/admin-sidebar.tsx
+++ b/packages/web/src/ui/components/admin/admin-sidebar.tsx
@@ -85,7 +85,7 @@ const navGroups: NavGroup[] = [
     icon: Users,
     items: [
       { href: "/admin/users", label: "Users" },
-      { href: "/admin/organizations", label: "Organizations" },
+      { href: "/admin/organizations", label: "Organizations", requiredRole: "platform_admin" },
       { href: "/admin/roles", label: "Roles" },
       { href: "/admin/sessions", label: "Sessions" },
     ],


### PR DESCRIPTION
## Summary
- Add `requiredRole: "platform_admin"` to Organizations sidebar nav item
- Add `usePlatformAdminGuard()` to organizations page — redirects non-platform-admins to /admin

## Test plan
- [x] `bun run type` passes
- [ ] Manual: workspace admin doesn't see Organizations in sidebar
- [ ] Manual: direct navigation to `/admin/organizations` redirects to `/admin`
- [ ] Manual: platform admin sees Organizations page normally

Closes #966