### PR TITLE
fix: org-scope admin write operations (#983)

### DIFF
--- a/packages/api/src/api/__tests__/admin-users-org-scope.test.ts
+++ b/packages/api/src/api/__tests__/admin-users-org-scope.test.ts
@@ -371,6 +371,16 @@ describe("Org-scoped user write operations (#983)", () => {
       expect(res.status).toBe(200);
       expect(mockUnbanUser).toHaveBeenCalled();
     });
+
+    it("platform admin can unban any user", async () => {
+      setPlatformAdmin();
+
+      const res = await app.fetch(
+        adminRequest("POST", "/api/v1/admin/users/user-in-any-org/unban", {}),
+      );
+      expect(res.status).toBe(200);
+      expect(mockUnbanUser).toHaveBeenCalled();
+    });
   });
 
   describe("DELETE /api/v1/admin/users/:id", () => {
@@ -429,6 +439,16 @@ describe("Org-scoped user write operations (#983)", () => {
 
       const res = await app.fetch(
         adminRequest("POST", "/api/v1/admin/users/user-in-org-1/revoke"),
+      );
+      expect(res.status).toBe(200);
+      expect(mockRevokeSessions).toHaveBeenCalled();
+    });
+
+    it("platform admin can revoke sessions for any user", async () => {
+      setPlatformAdmin();
+
+      const res = await app.fetch(
+        adminRequest("POST", "/api/v1/admin/users/user-in-any-org/revoke"),
       );
       expect(res.status).toBe(200);
       expect(mockRevokeSessions).toHaveBeenCalled();

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -114,8 +114,14 @@ async function verifyOrgMembership(
 ): Promise<boolean> {
   const orgId = authResult.user?.activeOrganizationId;
   const isPlatformAdmin = authResult.user?.role === "platform_admin";
-  // Self-hosted (no orgs) or platform admins — always allowed
-  if (!orgId || isPlatformAdmin || !hasInternalDB()) return true;
+  // Platform admins — always allowed
+  if (!orgId || isPlatformAdmin) return true;
+  // No internal DB — can't verify membership. Log if org context is present
+  // since this may indicate a misconfigured SaaS deployment.
+  if (!hasInternalDB()) {
+    log.warn({ orgId, targetUserId }, "Org membership check skipped — no internal DB available despite org context");
+    return true;
+  }
   try {
     const rows = await internalQuery<{ userId: string }>(
       `SELECT "userId" FROM member WHERE "userId" = $1 AND "organizationId" = $2 LIMIT 1`,


### PR DESCRIPTION
## Summary
- Adds `verifyOrgMembership()` helper that checks the `member` table before allowing user write operations
- Applies the check to all 5 user write endpoints: role change, ban, unban, delete, revoke sessions
- Returns **404** (not 403) when the target user is not in the caller's org — avoids revealing cross-tenant user existence
- Platform admins and self-hosted (no org context) bypass the check

## Context
PR #981 scoped the Users admin page **read** operations to the active org, but **write** operations remained unscoped. A workspace admin who knew a user ID from another org could change their role, ban, or delete them.

## Test plan
- [x] 14 new tests in `admin-users-org-scope.test.ts` covering all 5 endpoints
- [x] Cross-org requests return 404
- [x] Same-org requests succeed
- [x] Platform admin bypasses org check
- [x] Self-hosted (no org) works unchanged
- [x] Existing 93 admin tests still pass
- [x] Type check clean
- [x] Lint clean

Closes #983