### PR TITLE
fix: mock IP allowlist in test files to prevent query interference (#977, #960)

### DIFF
--- a/packages/api/src/api/__tests__/admin-learned-patterns.test.ts
+++ b/packages/api/src/api/__tests__/admin-learned-patterns.test.ts
@@ -209,7 +209,12 @@ mock.module("@atlas/ee/auth/ip-allowlist", () => ({
   listIPAllowlistEntries: mock(async () => []),
   addIPAllowlistEntry: mock(async () => ({})),
   removeIPAllowlistEntry: mock(async () => false),
-  IPAllowlistError: class IPAllowlistError extends Error {},
+  IPAllowlistError: class extends Error { constructor(message: string, public readonly code: string) { super(message); this.name = "IPAllowlistError"; } },
+  invalidateCache: mock(() => {}),
+  _clearCache: mock(() => {}),
+  parseCIDR: mock(() => null),
+  isIPInRange: mock(() => false),
+  isIPAllowed: mock(() => true),
 }));
 
 mock.module("@atlas/api/lib/conversations", () => ({

--- a/packages/api/src/api/__tests__/onboarding.test.ts
+++ b/packages/api/src/api/__tests__/onboarding.test.ts
@@ -128,7 +128,12 @@ mock.module("@atlas/ee/auth/ip-allowlist", () => ({
   listIPAllowlistEntries: mock(async () => []),
   addIPAllowlistEntry: mock(async () => ({})),
   removeIPAllowlistEntry: mock(async () => false),
-  IPAllowlistError: class IPAllowlistError extends Error {},
+  IPAllowlistError: class extends Error { constructor(message: string, public readonly code: string) { super(message); this.name = "IPAllowlistError"; } },
+  invalidateCache: mock(() => {}),
+  _clearCache: mock(() => {}),
+  parseCIDR: mock(() => null),
+  isIPInRange: mock(() => false),
+  isIPAllowed: mock(() => true),
 }));
 
 // --- Import the route after mocks are set up ---


### PR DESCRIPTION
## Summary
- Mock `@atlas/ee/auth/ip-allowlist` in `admin-learned-patterns.test.ts` and `onboarding.test.ts` to prevent IP allowlist `internalQuery` calls from shifting expected mock call indices
- Reset shared mocks (`mockInternalQuery`, `mockHasInternalDB`, `mockEncryptUrl`) in `beforeEach` blocks to prevent test bleed

## Root cause
`adminAuth` middleware dynamically imports `checkIPAllowlist()` which calls `internalQuery` before the handler runs. Tests checking `mockInternalQuery.mock.calls[0]` saw the IP allowlist query instead of the expected handler query.

## Test plan
- [x] All 27 tests pass in `admin-learned-patterns.test.ts`
- [x] All 28 tests pass in `onboarding.test.ts`

Closes #977, closes #960