### PR TITLE
fix: load monorepo root .env for Next.js NEXT_PUBLIC vars (#957)

### DIFF
--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -1,5 +1,13 @@
 import type { NextConfig } from "next";
+import { loadEnvConfig } from "@next/env";
 import path from "path";
+
+// Next.js only loads .env files from its own package root (packages/web/),
+// but in the monorepo the .env file lives at the repo root. This makes
+// NEXT_PUBLIC_* vars (e.g. NEXT_PUBLIC_ATLAS_AUTH_MODE used by the proxy)
+// available in server-side code like proxy.ts. See #957.
+const monorepoRoot = path.resolve(import.meta.dirname, "../..");
+loadEnvConfig(monorepoRoot, process.env.NODE_ENV !== "production");
 
 const nextConfig: NextConfig = {
   reactCompiler: true,


### PR DESCRIPTION
## Summary
- Use `@next/env` `loadEnvConfig()` in `packages/web/next.config.ts` to load `.env` from the monorepo root
- Fixes `NEXT_PUBLIC_ATLAS_AUTH_MODE` being `undefined` in the proxy, which prevented auth redirects to `/signup`

## Context
Next.js only loads `.env` from its own package root (`packages/web/`), but in the monorepo the `.env` lives at the repo root. Bun loads from CWD (repo root) for the API server, so only `NEXT_PUBLIC_*` vars were affected.

## Test plan
- [x] Lint clean
- [x] Type check clean
- [x] No impact on standalone/create-atlas templates (their `.env` is co-located)

Closes #957