### PR TITLE
fix: seed-demo sentinel checks table+column to avoid Atlas table collisions (#962)

### DIFF
--- a/examples/docker/scripts/seed-demo.ts
+++ b/examples/docker/scripts/seed-demo.ts
@@ -7,7 +7,12 @@
  *   3. ecommerce.sql — NovaMart DTC e-commerce ~480K rows
  *
  * Each dataset uses unique table names so they coexist without conflicts.
- * Idempotent: checks a sentinel table per dataset before seeding.
+ * Idempotent: checks a sentinel table + column per dataset before seeding.
+ *
+ * When DATABASE_URL and ATLAS_DATASOURCE_URL point to the same database,
+ * Atlas internal tables (auth, audit, settings) share the schema with
+ * analytics data. The sentinel check uses a dataset-specific column to
+ * distinguish analytics tables from Atlas internals. (#962)
  *
  * Exits 0 on success or "already seeded", exits 1 on failure.
  */
@@ -24,13 +29,21 @@ if (!url) {
 interface Dataset {
   name: string;
   file: string;
+  /** Table to check for idempotency. */
   sentinelTable: string;
+  /**
+   * A column unique to this dataset's sentinel table. Prevents false
+   * positives when an Atlas internal table (e.g. Better Auth's
+   * "organization") shares the same database. The seed is only skipped
+   * when BOTH the table and this column exist and the table has rows.
+   */
+  sentinelColumn: string;
 }
 
 const datasets: Dataset[] = [
-  { name: "SaaS CRM (demo)",          file: "/app/data/demo.sql",      sentinelTable: "companies" },
-  { name: "Sentinel Security (cybersec)", file: "/app/data/cybersec.sql",  sentinelTable: "organizations" },
-  { name: "NovaMart (ecommerce)",      file: "/app/data/ecommerce.sql", sentinelTable: "customers" },
+  { name: "SaaS CRM (demo)",               file: "/app/data/demo.sql",      sentinelTable: "companies",     sentinelColumn: "industry" },
+  { name: "Sentinel Security (cybersec)",   file: "/app/data/cybersec.sql",  sentinelTable: "organizations", sentinelColumn: "industry" },
+  { name: "NovaMart (ecommerce)",           file: "/app/data/ecommerce.sql", sentinelTable: "customers",     sentinelColumn: "acquisition_source" },
 ];
 
 const client = new pg.Client({
@@ -50,15 +63,20 @@ try {
       continue;
     }
 
-    // Check if dataset already seeded (sentinel table has rows)
+    // Check if dataset already seeded.
+    // We verify the sentinel table AND a dataset-specific column to avoid
+    // false positives from Atlas internal tables that happen to share the
+    // same database (e.g. Better Auth's "organization" table). (#962)
     const tableCheck = await client.query(`
       SELECT EXISTS (
-        SELECT 1 FROM information_schema.tables
-        WHERE table_schema = 'public' AND table_name = $1
-      ) AS table_exists
-    `, [ds.sentinelTable]);
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = $1
+          AND column_name = $2
+      ) AS dataset_exists
+    `, [ds.sentinelTable, ds.sentinelColumn]);
 
-    if (tableCheck.rows[0]?.table_exists) {
+    if (tableCheck.rows[0]?.dataset_exists) {
       const count = await client.query(
         `SELECT count(*) AS n FROM ${ds.sentinelTable}`
       );

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -408,8 +408,50 @@ export function _resetCircuitBreaker(): void {
   }
 }
 
+/**
+ * Log a warning when DATABASE_URL and ATLAS_DATASOURCE_URL resolve to the
+ * same Postgres database. Internal tables (auth, audit, settings) will
+ * share the public schema with analytics data.
+ *
+ * This is intentional in single-DB deployments (e.g. Railway with one
+ * Postgres addon) but can confuse the seed script or the agent — call
+ * this once at migration time to surface the situation.
+ */
+function warnIfSharedDatabase(): void {
+  const databaseUrl = process.env.DATABASE_URL;
+  const datasourceUrl = process.env.ATLAS_DATASOURCE_URL;
+  if (!databaseUrl || !datasourceUrl) return;
+
+  try {
+    const internalParsed = new URL(databaseUrl);
+    const datasourceParsed = new URL(datasourceUrl);
+
+    // Compare host + port + pathname (database name) to detect shared DB
+    const sameHost = internalParsed.hostname === datasourceParsed.hostname;
+    const samePort = (internalParsed.port || "5432") === (datasourceParsed.port || "5432");
+    const sameDB = internalParsed.pathname === datasourceParsed.pathname;
+
+    if (sameHost && samePort && sameDB) {
+      log.warn(
+        "DATABASE_URL and ATLAS_DATASOURCE_URL point to the same database — " +
+        "Atlas internal tables will share the schema with analytics data. " +
+        "Consider using a separate database for ATLAS_DATASOURCE_URL to isolate analytics data.",
+      );
+    }
+  } catch {
+    // URL parsing failed — not critical, skip the warning
+    log.debug("Could not parse DATABASE_URL or ATLAS_DATASOURCE_URL for shared-DB detection");
+  }
+}
+
 /** Idempotent migration: creates all Atlas internal tables and indexes. */
 export async function migrateInternalDB(): Promise<void> {
+  // Warn when DATABASE_URL and ATLAS_DATASOURCE_URL resolve to the same
+  // database — internal tables will share the schema with analytics data.
+  // This is intentional in single-DB deployments but can surprise operators
+  // who expect isolation. (#962)
+  warnIfSharedDatabase();
+
   const pool = getInternalDB();
   await pool.query(`
     CREATE TABLE IF NOT EXISTS audit_log (


### PR DESCRIPTION
## Summary
- Seed script now checks `information_schema.columns` (table + dataset-specific column) instead of `information_schema.tables` (table name only) to prevent false "already seeded" when Atlas internal tables share the database
- Added `warnIfSharedDatabase()` in `migrateInternalDB()` that logs when `DATABASE_URL` and `ATLAS_DATASOURCE_URL` resolve to the same database

## Root cause
In single-DB deployments (common on Railway), Better Auth's `organization` table collided with the cybersec dataset's `organizations` sentinel. The seed script saw the table existed and skipped seeding.

## Test plan
- [x] All 52 internal DB tests pass
- [x] All 9 auth migration tests pass
- [x] Lint clean, type check clean

Closes #962