### PR TITLE
fix: agent integration test env isolation (#949)

### DIFF
--- a/packages/api/src/lib/__tests__/agent-integration.test.ts
+++ b/packages/api/src/lib/__tests__/agent-integration.test.ts
@@ -11,7 +11,7 @@
  * - Shell backend (just-bash) → canned command outputs
  */
 
-import { describe, expect, it, beforeEach, mock } from "bun:test";
+import { describe, expect, it, beforeEach, afterEach, mock } from "bun:test";
 import {
   MockLanguageModelV3,
   convertArrayToReadableStream,
@@ -200,12 +200,22 @@ function findToolResults(steps: any[], toolName: string): any[] {
 // ---------------------------------------------------------------------------
 
 describe("agent integration", () => {
+  const savedSandboxUrl = process.env.ATLAS_SANDBOX_URL;
+
   beforeEach(() => {
     callId = 0;
     invalidateExploreBackend();
     process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
     delete process.env.ATLAS_TABLE_WHITELIST;
+    // Force just-bash fallback so the mocked Bash class is used (not sidecar)
+    delete process.env.ATLAS_SANDBOX_URL;
     mockDBQuery = async () => ({ columns: ["id", "name"], rows: [{ id: 1, name: "Acme" }] });
+  });
+
+  afterEach(() => {
+    if (savedSandboxUrl !== undefined) {
+      process.env.ATLAS_SANDBOX_URL = savedSandboxUrl;
+    }
   });
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Clear `ATLAS_SANDBOX_URL` in agent integration test `beforeEach` so explore tool uses the mocked just-bash backend instead of sidecar
- Restore the env var in `afterEach` to avoid leaking test state
- Fixes the "explore rejects path traversal" test failure when `.env` has `ATLAS_SANDBOX_URL` set (e.g. after `bun run db:up`)

## Test plan
- [x] `bun test packages/api/src/lib/__tests__/agent-integration.test.ts` — 9/9 pass (was 8/9)
- [x] `bun run test` — 250/250 files pass
- [x] `bun run type` — clean
- [x] `bun run lint` — clean

Closes #949