### PR TITLE
fix: EE compliance test env isolation + enterprise smoke validation (#950)

### DIFF
--- a/ee/src/compliance/masking.test.ts
+++ b/ee/src/compliance/masking.test.ts
@@ -1,4 +1,11 @@
-import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, mock } from "bun:test";
+
+// ── Isolate from .env — enterprise flag must be controlled by mock ──
+const savedEnterpriseEnabled = process.env.ATLAS_ENTERPRISE_ENABLED;
+beforeAll(() => { delete process.env.ATLAS_ENTERPRISE_ENABLED; });
+afterAll(() => {
+  if (savedEnterpriseEnabled !== undefined) process.env.ATLAS_ENTERPRISE_ENABLED = savedEnterpriseEnabled;
+});
 
 // ── Mock external dependencies ──────────────────────────────────
 

--- a/ee/src/compliance/reports.test.ts
+++ b/ee/src/compliance/reports.test.ts
@@ -1,4 +1,11 @@
-import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, mock } from "bun:test";
+
+// ── Isolate from .env — enterprise flag must be controlled by mock ──
+const savedEnterpriseEnabled = process.env.ATLAS_ENTERPRISE_ENABLED;
+beforeAll(() => { delete process.env.ATLAS_ENTERPRISE_ENABLED; });
+afterAll(() => {
+  if (savedEnterpriseEnabled !== undefined) process.env.ATLAS_ENTERPRISE_ENABLED = savedEnterpriseEnabled;
+});
 
 // ── Mock external dependencies ──────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Fix `masking.test.ts` and `reports.test.ts` — clear `ATLAS_ENTERPRISE_ENABLED` env var so the config mock fully controls the enterprise gate (same pattern as #993)
- Validate all 434 enterprise tests pass individually, not just in the isolated test runner

## Bug
`isEnterpriseEnabled()` checks `config?.enterprise?.enabled` first, then falls back to `ATLAS_ENTERPRISE_ENABLED` env var. The compliance tests mock `getConfig()` but not the env var — when `.env` sets `ATLAS_ENTERPRISE_ENABLED=true`, the "throws when enterprise is disabled" tests fail.

Other EE tests (SSO, SCIM, branding, etc.) use the shared `createEEMock()` factory which mocks `../index` directly, bypassing the env var entirely.

## Enterprise Feature Smoke — Validation Report

All 434 EE tests pass across 14 test files:

| Feature | Tests | Status |
|---------|-------|--------|
| SSO (SAML + OIDC) | 50 | ✅ |
| IP Allowlist | 57 | ✅ |
| Approval Workflows | 50 | ✅ |
| Custom Roles | 43 | ✅ |
| PII Masking | 40 | ✅ |
| SCIM Provisioning | 29 | ✅ |
| Custom Domains | 29 | ✅ |
| PII Detection | 25 | ✅ |
| White-Label Branding | 24 | ✅ |
| Model Routing | 22 | ✅ |
| Data Residency | 20 | ✅ |
| Audit Retention | 20 | ✅ |
| Compliance Reports | 19 | ✅ |
| Audit Purge Scheduler | 6 | ✅ |

## Test plan
- [x] `bun test ee/src/compliance/masking.test.ts` — 40/40 pass (was 39/40)
- [x] `bun test ee/src/compliance/reports.test.ts` — 19/19 pass (was 17/19)
- [x] All 14 EE test files pass individually
- [x] `bun run test` — 250/250 files pass
- [x] `bun run type` — clean
- [x] `bun run lint` — clean

Closes #950