### PR TITLE
fix: browser e2e tour dismissal + nav selector (#951)

### DIFF
--- a/e2e/browser/auth.spec.ts
+++ b/e2e/browser/auth.spec.ts
@@ -25,6 +25,13 @@ async function waitForChatUI(page: import("@playwright/test").Page) {
     await page.locator('button:has-text("Change password")').click();
     await expect(changeDialog).toBeHidden({ timeout: 10_000 });
   }
+
+  // Dismiss the guided tour if visible (fresh DB / first login)
+  const skipTour = page.locator('button:has-text("Skip tour")');
+  if (await skipTour.isVisible({ timeout: 2_000 }).catch(() => false)) {
+    await skipTour.click();
+    await skipTour.waitFor({ state: "hidden", timeout: 5_000 }).catch(() => {});
+  }
 }
 
 test.describe("Auth Flows", () => {

--- a/e2e/browser/global-setup.ts
+++ b/e2e/browser/global-setup.ts
@@ -66,5 +66,12 @@ setup("authenticate as admin", async ({ page }) => {
     await expect(changePasswordTitle).toBeHidden({ timeout: 10_000 });
   }
 
+  // Dismiss the guided tour if it appears (fresh DB / first login)
+  const skipTour = page.locator('button:has-text("Skip tour")');
+  if (await skipTour.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await skipTour.click();
+    await skipTour.waitFor({ state: "hidden", timeout: 5_000 }).catch(() => {});
+  }
+
   await page.context().storageState({ path: STORAGE_STATE });
 });

--- a/e2e/browser/helpers.ts
+++ b/e2e/browser/helpers.ts
@@ -31,8 +31,18 @@ export async function startNewChat(page: Page) {
   await expect(input).toHaveValue("");
 }
 
+/** Dismiss the guided tour if it appears. */
+export async function dismissTourIfVisible(page: Page) {
+  const skipButton = page.locator('button:has-text("Skip tour")');
+  if (await skipButton.isVisible({ timeout: 2_000 }).catch(() => false)) {
+    await skipButton.click();
+    await skipButton.waitFor({ state: "hidden", timeout: 5_000 }).catch(() => {});
+  }
+}
+
 /** Navigate to home and ensure chat UI is ready. */
 export async function ensureChatReady(page: Page) {
   await page.goto("/");
   await page.locator('input[placeholder="Ask a question about your data..."]').waitFor({ timeout: 15_000 });
+  await dismissTourIfVisible(page);
 }

--- a/e2e/browser/production.spec.ts
+++ b/e2e/browser/production.spec.ts
@@ -14,7 +14,7 @@ test.describe("Production Smoke Tests", () => {
     expect(response).not.toBeNull();
     expect(response!.status()).toBeLessThan(400);
 
-    await expect(page.getByRole("navigation").getByText("atlas")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole("navigation").getByText("atlas").first()).toBeVisible({ timeout: 10_000 });
   });
 
   test("docs site loads", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Dismiss guided tour overlay in `global-setup.ts`, `helpers.ts` (`ensureChatReady`), and `auth.spec.ts` (`waitForChatUI`). Fresh DB shows a tour dialog that blocks all UI interaction.
- Fix `production.spec.ts` landing page — nav now has 2 "atlas" text elements after landing page update. Use `.first()` to resolve strict mode violation.

## Results
| Before | After |
|--------|-------|
| 33 passed, 14 failed | 44 passed, 3 failed |

### Remaining failures (pre-existing, not regressions)
- **Axe violations (2)** — `button-name` critical violation on admin connections and audit pages. Filed as #995.
- **Widget `Atlas.ask()` (1)** — widget iframe needs widget host running to send `atlas:ready` event. Works in full integration setup.

## Test plan
- [x] `bun run test:browser:fast` — 44/47 pass (was 33/47)
- [x] All auth tests pass (login, wrong password, logout, re-login, signup)
- [x] All schema explorer tests pass (5/5)
- [x] All mobile tests pass (3/3)
- [x] All admin console tests pass (9/9)
- [x] Production smoke: 3/4 pass (landing page fixed, widget host timeout is environmental)

Closes #951