### PR TITLE
fix: demo dataset onboarding — missing connectionId + swallowed errors (#1032)

### DIFF
--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -649,7 +649,7 @@ onboarding.openapi(
       }
 
       const importResult = yield* Effect.tryPromise({
-        try: () => importFromDisk(orgId, { sourceDir: semanticDir }),
+        try: () => importFromDisk(orgId, { sourceDir: semanticDir, connectionId: "default" }),
         catch: (err) => err instanceof Error ? err : new Error(String(err)),
       }).pipe(Effect.catchAll((err) => {
         log.error({ err: err.message, requestId, demoType, semanticDir }, "Semantic layer import failed");

--- a/packages/web/src/app/signup/connect/page.tsx
+++ b/packages/web/src/app/signup/connect/page.tsx
@@ -233,7 +233,7 @@ export default function ConnectPage() {
           </div>
         )}
 
-        {connectionStatus === "error" && (
+        {(connectionStatus === "error" || error) && (
           <div className="flex items-start gap-2 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-200">
             <XCircle className="mt-0.5 size-4 shrink-0" />
             <span>{error ?? "Connection failed"}</span>


### PR DESCRIPTION
## Summary

- Fix `importFromDisk()` call in demo onboarding to pass `connectionId: "default"` — without this, semantic entities are stored with `NULL` connection_id and invisible to the agent's table whitelist
- Fix frontend error banner to display demo setup errors — previously only showed errors when `connectionStatus === "error"`, swallowing demo-specific failures

## Test plan

- [ ] New signup → pick demo dataset → semantic entities visible in admin
- [ ] Agent can query demo tables after onboarding
- [ ] If demo setup fails, error message displayed to user
- [ ] `bun run type` passes
- [ ] `bun run lint` passes

Closes #1032