### PR TITLE
refactor: filter settings to workspace-relevant items in SaaS mode (#1022)

### DIFF
--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -4410,9 +4410,16 @@ admin.openapi(getSettingsRoute, async (c) => runHandler(c, "list settings", asyn
   const { authResult } = await adminAuthAndContext(c);
   const orgId = authResult.user?.activeOrganizationId;
   const isPlatformAdmin = authResult.user?.role === "platform_admin";
-  const settings = getSettingsForAdmin(orgId, isPlatformAdmin || !orgId);
+  const allSettings = getSettingsForAdmin(orgId, isPlatformAdmin || !orgId);
   const manageable = hasInternalDB();
   const deployMode = getConfig()?.deployMode ?? "self-hosted";
+
+  // In SaaS mode, workspace admins only see settings they can control.
+  // Platform admins and self-hosted mode see everything.
+  const settings = (deployMode === "saas" && !isPlatformAdmin)
+    ? allSettings.filter((s) => s.saasVisible !== false)
+    : allSettings;
+
   return c.json({ settings, manageable, deployMode }, 200);
 }));
 

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -37,6 +37,8 @@ export interface SettingDefinition {
   requiresRestart?: boolean;
   /** Whether this setting can be overridden per-workspace ("workspace") or is global only ("platform"). Defaults to "platform". */
   scope: SettingScope;
+  /** Whether this setting is visible to workspace admins in SaaS mode. Defaults to true. Platform admins always see all settings. */
+  saasVisible?: boolean;
 }
 
 export interface SettingWithValue extends SettingDefinition {
@@ -96,6 +98,7 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     envVar: "ATLAS_RLS_ENABLED",
     requiresRestart: true,
     scope: "platform",
+    saasVisible: false,
   },
   {
     key: "ATLAS_RLS_COLUMN",
@@ -106,6 +109,7 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     envVar: "ATLAS_RLS_COLUMN",
     requiresRestart: true,
     scope: "platform",
+    saasVisible: false,
   },
   {
     key: "ATLAS_RLS_CLAIM",
@@ -116,6 +120,7 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     envVar: "ATLAS_RLS_CLAIM",
     requiresRestart: true,
     scope: "platform",
+    saasVisible: false,
   },
   {
     key: "ATLAS_TABLE_WHITELIST",
@@ -127,6 +132,7 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     envVar: "ATLAS_TABLE_WHITELIST",
     requiresRestart: true,
     scope: "platform",
+    saasVisible: false,
   },
   {
     key: "ATLAS_CORS_ORIGIN",
@@ -138,6 +144,7 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     envVar: "ATLAS_CORS_ORIGIN",
     requiresRestart: true,
     scope: "platform",
+    saasVisible: false,
   },
 
   // Sessions
@@ -197,6 +204,7 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     envVar: "ATLAS_DEPLOY_MODE",
     requiresRestart: true,
     scope: "platform",
+    saasVisible: false,
   },
 
   // Agent
@@ -221,6 +229,7 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     envVar: "ATLAS_PROVIDER",
     requiresRestart: true,
     scope: "platform",
+    saasVisible: false,
   },
   {
     key: "ATLAS_MODEL",
@@ -231,6 +240,7 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     envVar: "ATLAS_MODEL",
     requiresRestart: true,
     scope: "platform",
+    saasVisible: false,
   },
   {
     key: "ATLAS_LOG_LEVEL",
@@ -243,6 +253,7 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     envVar: "ATLAS_LOG_LEVEL",
     requiresRestart: true,
     scope: "platform",
+    saasVisible: false,
   },
 
   // Appearance
@@ -267,6 +278,7 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     secret: true,
     envVar: "ANTHROPIC_API_KEY",
     scope: "platform",
+    saasVisible: false,
   },
   {
     key: "OPENAI_API_KEY",
@@ -277,6 +289,7 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     secret: true,
     envVar: "OPENAI_API_KEY",
     scope: "platform",
+    saasVisible: false,
   },
   {
     key: "DATABASE_URL",
@@ -287,6 +300,7 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     secret: true,
     envVar: "DATABASE_URL",
     scope: "platform",
+    saasVisible: false,
   },
   {
     key: "ATLAS_DATASOURCE_URL",
@@ -297,6 +311,7 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     secret: true,
     envVar: "ATLAS_DATASOURCE_URL",
     scope: "platform",
+    saasVisible: false,
   },
 ];
 


### PR DESCRIPTION
## Summary

- Add `saasVisible` flag to `SettingDefinition` type in settings registry
- Mark 13 platform-managed settings as `saasVisible: false` (RLS, table whitelist, CORS, provider, model, log level, API keys, database URLs, deploy mode)
- Filter settings server-side in admin GET endpoint: SaaS workspace admins only see ~8 controllable settings
- Platform admins in SaaS mode see all settings (no change)
- Self-hosted sees all settings (no change)

## Settings hidden from SaaS workspace admins

| Setting | Section | Why hidden |
|---------|---------|------------|
| ATLAS_RLS_ENABLED/COLUMN/CLAIM | Security | Platform-managed |
| ATLAS_TABLE_WHITELIST | Security | Platform-managed |
| ATLAS_CORS_ORIGIN | Security | Platform-managed |
| ATLAS_PROVIDER | Agent | Platform-managed |
| ATLAS_MODEL | Agent | Platform-managed |
| ATLAS_LOG_LEVEL | Agent | Platform-managed |
| ATLAS_DEPLOY_MODE | Platform | Platform-managed |
| ANTHROPIC_API_KEY | Secrets | Platform-managed |
| OPENAI_API_KEY | Secrets | Platform-managed |
| DATABASE_URL | Secrets | Platform-managed |
| ATLAS_DATASOURCE_URL | Secrets | Platform-managed |

## Test plan

- [ ] SaaS workspace admin sees only ~8 settings (row limit, timeout, RPM, session timeouts, max steps, brand color, sandbox)
- [ ] SaaS platform admin sees all settings
- [ ] Self-hosted admin sees all settings
- [ ] Hidden settings still apply server-side (no functional regression)
- [ ] `bun run type` passes
- [ ] `bun run lint` passes

Closes #1022