### PR TITLE
fix: strip internal saasVisible field from settings API response

### DIFF
--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -4416,9 +4416,12 @@ admin.openapi(getSettingsRoute, async (c) => runHandler(c, "list settings", asyn
 
   // In SaaS mode, workspace admins only see settings they can control.
   // Platform admins and self-hosted mode see everything.
-  const settings = (deployMode === "saas" && !isPlatformAdmin)
+  const filtered = (deployMode === "saas" && !isPlatformAdmin)
     ? allSettings.filter((s) => s.saasVisible !== false)
     : allSettings;
+
+  // Strip internal-only saasVisible field from response
+  const settings = filtered.map(({ saasVisible: _, ...rest }) => rest);
 
   return c.json({ settings, manageable, deployMode }, 200);
 }));


### PR DESCRIPTION
## Summary

- Strip `saasVisible` internal metadata from settings API response before serialization
- The field is used server-side for SaaS filtering (#1022) but was leaking to clients unnecessarily
- Filter runs first (using `saasVisible`), then the field is stripped from the final JSON

## Test plan

- [x] `bun run type` passes
- [ ] Settings API response no longer includes `saasVisible` field
- [ ] SaaS filtering still works correctly (field used before stripping)