### PR TITLE
docs: update competitor comparisons with March 2026 reality check

### DIFF
--- a/apps/docs/content/docs/comparisons/cube.mdx
+++ b/apps/docs/content/docs/comparisons/cube.mdx
@@ -44,7 +44,7 @@ Both tools use YAML-based semantic definitions, but the scope differs.
 
 ## AI Capabilities
 
-Cube D3 adds agentic analytics to the Cube platform — AI agents that understand the data model and generate queries. This is a natural extension of Cube's semantic layer.
+Cube D3 (launched June 2025) adds agentic analytics to the Cube platform with two specialized agents: the **AI Data Analyst** for self-serve natural language querying with visualizations and interactive data apps, and the **AI Data Engineer** for automating semantic model development from cloud data sources. Queries go through the semantic layer runtime rather than hitting the data warehouse directly — a trusted proxy architecture. Cube was recognized in the 2026 Gartner Market Guide for Agentic Analytics.
 
 Atlas is agent-native from day one. The entire product is an agent loop: multi-step reasoning, tool use (SQL execution, Python analysis, semantic layer exploration), 7-layer SQL validation, and structured output. The agent doesn't just generate a query — it reads context, writes SQL, validates it, runs it, and explains the results.
 

--- a/apps/docs/content/docs/comparisons/index.mdx
+++ b/apps/docs/content/docs/comparisons/index.mdx
@@ -15,9 +15,9 @@ Atlas is an embeddable text-to-SQL agent. The tools below solve overlapping prob
 
 | Feature | Atlas | WrenAI | Vanna | Metabase |
 |---|---|---|---|---|
-| **Deployment** | Self-hosted, cloud, embedded | Self-hosted, cloud | Self-hosted, cloud (SaaS) | Self-hosted, cloud |
+| **Deployment** | Self-hosted, cloud, embedded | Self-hosted, cloud SaaS, air-gapped enterprise | Self-hosted, cloud (SaaS) | Self-hosted, cloud |
 | **Embeddable widget** | Script tag, React component, API | API only (no widget) | Web component (`<vanna-chat>`) | Embedding SDK (paid), public links (free) |
-| **Semantic layer** | YAML files (code-first) | UI-based modeling (MDL) | Training via DDL/docs/SQL pairs | Data model UI |
+| **Semantic layer** | YAML files (code-first) | UI-based modeling (MDL) | Training via DDL/docs/SQL pairs | Data model UI + Data Studio |
 | **Plugin ecosystem** | 20+ official plugins, Plugin SDK | Limited | Python extensibility | Drivers + community plugins |
 | **Databases** | | | | |
 | PostgreSQL | Built-in | Yes | Yes | Yes |
@@ -27,11 +27,15 @@ Atlas is an embeddable text-to-SQL agent. The tools below solve overlapping prob
 | DuckDB | Plugin | Yes | Yes | Community driver |
 | Snowflake | Plugin | Yes | Yes | Yes |
 | Salesforce | Plugin | No | No | No |
+| Oracle | No | Yes | Yes | Yes |
+| SQL Server | No | Yes | Yes | Yes |
+| Redshift | No | Yes | Yes | Yes |
+| Databricks | No | Yes | No | No |
 | **Auth model** | Managed (Better Auth), BYOT, API key, SSO/SCIM | API key | BYOT (`UserResolver`) | Managed, SSO (paid) |
 | **License** | AGPL-3.0 core, MIT client libs | AGPL-3.0 | MIT | AGPL-3.0 (Pro is proprietary) |
 | **Python tool** | Sandboxed execution with charts | No | Python-native | No |
 | **Admin console** | Built-in | Basic UI | No | Full admin UI |
-| **MCP server** | Official plugin | No | No | No |
+| **MCP server** | Official plugin | Yes (Wren Engine) | No | No |
 | **Chat integrations** | Slack, Teams, Discord, Telegram, + 4 more (Chat SDK) | No | No | No |
 | **SDK** | TypeScript SDK (`@useatlas/sdk`) | No | Python package | Embedding SDK (React, paid) |
 | **Enterprise features** | SSO, SCIM, custom roles, IP allowlists, approval workflows | No | No | SSO, permissions (Pro) |

--- a/apps/docs/content/docs/comparisons/metabase.mdx
+++ b/apps/docs/content/docs/comparisons/metabase.mdx
@@ -14,10 +14,10 @@ import { Callout } from "fumadocs-ui/components/callout";
 | **License** | AGPL-3.0 core, MIT client libs | AGPL-3.0 (Pro/Enterprise is proprietary) |
 | **Category** | Embeddable text-to-SQL agent | Full BI platform |
 | **Embeddable** | Script tag, React component, API | Embedding SDK + public links (SDK requires Pro/Enterprise) |
-| **AI querying** | Core feature (agent-based) | Add-on feature |
+| **AI querying** | Core feature (agent-based) | Metabot AI (cloud-only add-on, $100/mo for 500 requests; open-source gets single-shot SQL only) |
 | **Visual query builder** | No (natural language only) | Yes |
 | **Dashboards** | No | Yes (core feature) |
-| **Semantic layer** | YAML files | Data model UI (models, metrics) |
+| **Semantic layer** | YAML files | Data model UI + Data Studio (analyst workbench for glossary, measures, segments) |
 | **Databases** | Postgres, MySQL + plugins for BigQuery, ClickHouse, DuckDB, Salesforce, Snowflake | 20+ databases |
 | **Plugin system** | Plugin SDK + 20 official plugins | Database drivers + community |
 | **Auth model** | Managed, BYOT, API key | Managed, SSO, LDAP (Pro) |
@@ -28,7 +28,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 ## Different Tools for Different Problems
 
-**Metabase** is a BI platform. It replaces Excel, Tableau, and Looker for teams that need dashboards, scheduled reports, and visual exploration. AI querying is one feature among many.
+**Metabase** is a BI platform. It replaces Excel, Tableau, and Looker for teams that need dashboards, scheduled reports, and visual exploration. AI querying via Metabot is a growing feature — it handles natural language queries, SQL generation, SQL debugging, and smart content reuse — but it's currently a cloud-only add-on ($100/mo for 500 requests). Self-hosted Metabot is on the roadmap.
 
 **Atlas** is an AI agent you embed in other applications. It does one thing -- lets users query data in natural language -- and does it as a composable component, not a standalone product.
 
@@ -48,7 +48,7 @@ Both tools use a semantic layer to add business context to raw database schemas,
 
 **Atlas** uses YAML files checked into your repository. Entities, metrics, and glossary terms are defined in code, version-controlled, and deployed with your application.
 
-**Metabase** uses a UI-based data model. Admins define models, add descriptions, hide columns, and configure metrics through Metabase's admin interface. This is stored in Metabase's internal database.
+**Metabase** uses a UI-based data model. Admins define models, add descriptions, hide columns, and configure metrics through Metabase's admin interface. In 2026, Metabase launched **Data Studio** — an analyst workbench for curating the semantic layer with glossary terms, measures, and segments. Metabot queries against this semantic layer rather than raw SQL. Definitions are stored in Metabase's internal database.
 
 ## Licensing
 

--- a/apps/docs/content/docs/comparisons/thoughtspot.mdx
+++ b/apps/docs/content/docs/comparisons/thoughtspot.mdx
@@ -15,37 +15,53 @@ import { Callout } from "fumadocs-ui/components/callout";
 | **License** | AGPL-3.0 core, MIT client libs | Proprietary (SaaS + on-prem) |
 | **Pricing** | Self-hosted free, cloud starts at Team tier | Enterprise pricing (typically six-figure contracts) |
 | **Semantic layer** | YAML files (code-first, auto-generated) | TML (ThoughtSpot Modeling Language) + UI |
-| **AI agent** | Multi-step agent with tool use (SQL, Python, explore) | Spotter agent with conversational analytics |
+| **AI agent** | Multi-step agent with tool use (SQL, Python, explore) | Spotter 3 (data scientist w/ Python + forecasting), SpotterModel (semantic modeling), SpotterViz (automated dashboards), SpotterCode (IDE code generation) |
+| **Semantic layer** | YAML files (code-first, auto-generated) | TML + Spotter Semantics (governed Metrics Catalog, NL search tokens, dbt/Snowflake/Databricks integration) |
 | **Embeddable** | Script tag, React component, API, SDK | ThoughtSpot Embedded (SDK) |
 | **Deployment** | Docker, Railway, Vercel, embedded in Next.js | SaaS or on-premises appliance |
 | **Databases** | 7 via plugins (Postgres, MySQL, BigQuery, ClickHouse, DuckDB, Snowflake, Salesforce) | Cloud data warehouses (Snowflake, Databricks, BigQuery, Redshift, etc.) |
-| **SQL validation** | 7-layer pipeline | Query engine optimizes and governs |
-| **Plugin system** | Plugin SDK + 20 plugins | SpotApps marketplace |
+| **SQL validation** | 7-layer pipeline | Semantic layer governs query generation |
+| **MCP server** | Yes | Yes (ThoughtSpot MCP Server) |
+| **Plugin system** | Plugin SDK + 20 plugins | SpotApps marketplace + Spotter Connectors (Zendesk, Google Workspace, Slack) |
+| **Industry agents** | No | Spotter for Industries (healthcare, retail, financial services) |
 | **Open source** | Yes (full product) | No |
 
 ## Different Markets
 
-**ThoughtSpot** is built for large enterprises. It replaces or complements existing BI tools (Tableau, Looker) with search-based analytics. Spotter, their AI agent, adds conversational data exploration. Typical deployments involve data engineering teams, weeks of onboarding, and enterprise contracts.
+**ThoughtSpot** is built for large enterprises. It replaces or complements existing BI tools (Tableau, Looker) with search-based analytics. The Spotter agent family adds conversational data exploration, automated dashboarding, semantic modeling, and IDE code generation. Typical deployments involve data engineering teams, weeks of onboarding, and enterprise contracts.
 
 **Atlas** is built for developers and small-to-mid teams who want to add natural language data querying to their own applications. It's open-source, deploys in minutes, and is designed to be embedded — not to be a standalone analytics platform.
 
 **Trade-off:** ThoughtSpot gives you a complete enterprise analytics suite with governance, certified data models, and organizational-scale features. Atlas gives you a focused, embeddable agent you control end-to-end.
 
+## Spotter Agent Family
+
+ThoughtSpot has expanded Spotter from a single conversational agent into a suite of four specialized agents (as of March 2026):
+
+- **Spotter 3** — AI data scientist with Python coding, forecasting, and multi-step analysis
+- **SpotterModel** — Automated semantic modeling agent that maps relationships, dimensions, and measures from your data
+- **SpotterViz** — Dashboarding agent that plans a data story, generates answers, and builds complete Liveboards automatically
+- **SpotterCode** — IDE-integrated agent for generating embed logic, code patterns, and ThoughtSpot components
+
+Additionally, **Spotter for Industries** (March 2026) provides domain-specific agents for healthcare, retail, and financial services with industry terminology, workflows, and regulatory compliance (HIPAA, GDPR).
+
+Atlas is a single general-purpose agent focused on text-to-SQL with tool use. It doesn't attempt to automate dashboarding, semantic modeling, or IDE code generation — it does one thing (natural language data querying) and makes it embeddable.
+
 ## Semantic Layer
 
-**ThoughtSpot** uses TML (ThoughtSpot Modeling Language) to define data models, relationships, and business logic. Models are managed through the ThoughtSpot UI or exported as YAML-like files. The platform includes a governance layer for certifying trusted data sources and managing access.
+**ThoughtSpot** uses TML (ThoughtSpot Modeling Language) to define data models, relationships, and business logic. In March 2026, they launched **Spotter Semantics** — an AI-native semantic layer with a governed Metrics Catalog, natural language search tokens for deterministic SQL generation, and integration with Snowflake, Databricks, and dbt models.
 
 **Atlas** uses plain YAML files on disk. Run `atlas init` to auto-profile your database, then enrich the generated entities with descriptions, metrics, and glossary terms. The semantic layer lives in your git repository and deploys as static files.
 
-**Trade-off:** ThoughtSpot's modeling is richer and includes governance features (certified models, usage analytics, lineage). Atlas's approach is simpler, code-first, and designed for teams that manage their data model in git.
+**Trade-off:** ThoughtSpot's modeling is richer and includes governance features (certified models, usage analytics, lineage, Metrics Catalog). Atlas's approach is simpler, code-first, and designed for teams that manage their data model in git.
 
-## Embedding
+## Embedding & MCP
 
 Both products offer embedding, but the model is different.
 
-**ThoughtSpot Embedded** provides a React SDK for embedding search, visualizations, liveboards, and the Spotter AI agent. Embedding requires a ThoughtSpot license and access to the ThoughtSpot backend.
+**ThoughtSpot Embedded** provides a React SDK for embedding search, visualizations, liveboards, and the Spotter AI agent. Embedding requires a ThoughtSpot license and access to the ThoughtSpot backend. ThoughtSpot also offers an **MCP Server** that lets external AI agents and LLMs integrate Spotter's capabilities into custom agentic applications.
 
-**Atlas** embedding is fully decoupled. The frontend (`@useatlas/react`, `@useatlas/sdk`) communicates over HTTP with no dependency on the backend package. You can embed a script tag widget, use the React component, or hit the API directly from any framework. Client libraries are MIT-licensed.
+**Atlas** embedding is fully decoupled. The frontend (`@useatlas/react`, `@useatlas/sdk`) communicates over HTTP with no dependency on the backend package. You can embed a script tag widget, use the React component, or hit the API directly from any framework. Client libraries are MIT-licensed. Atlas also provides an MCP server for Claude Desktop, Cursor, and other MCP clients.
 
 ## When to Choose ThoughtSpot
 
@@ -53,7 +69,8 @@ Both products offer embedding, but the model is different.
 - Your organization has hundreds or thousands of analytics users
 - Certified data models, lineage tracking, and governance are requirements
 - You have the budget for enterprise software and a data team to manage it
-- You need search-based analytics (keyword search, not just conversational AI)
+- You need specialized agents for different analytics tasks (modeling, dashboarding, IDE integration)
+- You need industry-specific agents with regulatory compliance (healthcare, retail, financial services)
 - Integration with existing enterprise data infrastructure (Snowflake, Databricks) is critical
 
 <Callout type="info">

--- a/apps/docs/content/docs/comparisons/vanna.mdx
+++ b/apps/docs/content/docs/comparisons/vanna.mdx
@@ -17,7 +17,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 | **Embeddable** | Script tag, React component, API | Web component (`<vanna-chat>`), Flask UI, Streamlit |
 | **Deployment** | API server (Hono) + frontend (Next.js) | Python script or notebook |
 | **Plugin system** | Plugin SDK + 20 official plugins | Swappable LLM/vector store backends |
-| **Databases** | Postgres, MySQL + plugins for BigQuery, ClickHouse, DuckDB, Salesforce, Snowflake | Postgres, MySQL, BigQuery, Snowflake, DuckDB, SQLite, and more |
+| **Databases** | Postgres, MySQL + plugins for BigQuery, ClickHouse, DuckDB, Salesforce, Snowflake | Postgres, MySQL, BigQuery, Snowflake, DuckDB, SQLite, Oracle, SQL Server, ClickHouse, Redshift |
 | **Auth model** | Managed (Better Auth), BYOT, API key, SSO/SCIM | BYOT (`UserResolver` class) |
 | **Admin console** | Built-in (connections, users, plugins, analytics) | No |
 | **MCP server** | Yes | No |

--- a/apps/docs/content/docs/comparisons/wrenai.mdx
+++ b/apps/docs/content/docs/comparisons/wrenai.mdx
@@ -14,12 +14,12 @@ import { Callout } from "fumadocs-ui/components/callout";
 | **License** | AGPL-3.0 core, MIT client libs | AGPL-3.0 |
 | **Semantic layer** | YAML files (code-first, git-versioned) | UI-based MDL (Modeling Definition Language) |
 | **Embeddable** | Script tag, React component, API | API only (no pre-built widget) |
-| **Deployment** | Self-hosted, embedded, Vercel, Railway, Docker | Self-hosted, Docker |
+| **Deployment** | Self-hosted, embedded, Vercel, Railway, Docker | Self-hosted, Docker, cloud SaaS, air-gapped enterprise |
 | **Plugin system** | Plugin SDK + 20 official plugins | Limited extensibility |
-| **Databases** | Postgres, MySQL + plugins for BigQuery, ClickHouse, DuckDB, Salesforce, Snowflake | Postgres, MySQL, BigQuery, ClickHouse, DuckDB, Snowflake, and more |
+| **Databases** | Postgres, MySQL + plugins for BigQuery, ClickHouse, DuckDB, Salesforce, Snowflake | Postgres, MySQL, BigQuery, ClickHouse, DuckDB, Snowflake, MS SQL Server, Redshift, Databricks, Oracle, Trino, Athena |
 | **Python sandbox** | Yes (sandboxed execution with chart rendering) | No |
-| **MCP server** | Yes | No |
-| **Primary stack** | TypeScript (Hono + Next.js + Bun) | TypeScript + Rust (Wren Engine) |
+| **MCP server** | Yes | Yes (Wren Engine MCP server, Apache 2.0) |
+| **Primary stack** | TypeScript (Hono + Next.js + Bun) | TypeScript + Rust (Wren Engine, Apache DataFusion) |
 
 ## Semantic Layer
 


### PR DESCRIPTION
## Summary
- Fix factual inaccuracies across all 6 competitor comparison pages
- WrenAI: add MCP server, cloud SaaS deployment, expanded database list
- ThoughtSpot: add 4-agent Spotter family, MCP server, Spotter Semantics, Spotter for Industries
- Metabase: clarify Metabot is cloud-only add-on, add Data Studio
- Cube: expand D3 agents, Gartner recognition
- Vanna/Index: update database coverage, fix WrenAI MCP from "No" to "Yes"

## Test plan
- [ ] Docs build passes
- [ ] No broken links in comparison pages

https://claude.ai/code/session_01PsUpCtBhGiNMEAmr1UmzYk