### PR TITLE
fix: add @types/node to docs for standalone Docker build

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -20,6 +20,7 @@
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
+    "@types/node": "^25.5.0",
     "@shikijs/transformers": "^4.0.2",
     "@tailwindcss/postcss": "^4.2.2",
     "@types/react": "^19.2.14",


### PR DESCRIPTION
## Summary
- Railway docs deploy (`satisfied-creation - docs`) is still failing after #1049 — Next.js auto-detects TypeScript and tries to install `@types/node` via `npm`, but the `oven/bun` Docker image has no `npm`
- In the monorepo `@types/node` is hoisted from the root, but the standalone Dockerfile only installs deps from `apps/docs/package.json`
- Fix: add `@types/node` to docs devDependencies

## Test plan
- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun x syncpack lint` — no issues (version matches root)
- [x] Template drift — passed

https://claude.ai/code/session_017QsHtAvqTDbe8M86rBdRqw