### PR TITLE
refactor: product-focused sandbox + residency UX for SaaS (#1026, #1027)

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -661,8 +661,8 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
   - [ ] Linear (#1045)
   - [ ] WhatsApp (#1046)
 - [ ] Plugin marketplace — browse, install, configure per workspace (#1025)
-- [ ] Product-focused sandbox selection UX for SaaS users (#1026)
-- [ ] Product-focused data residency UX for SaaS users (#1027)
+- [x] Product-focused sandbox selection UX for SaaS users (#1026, PR #1051)
+- [x] Product-focused data residency UX for SaaS users (#1027, PR #1051)
 
 ### SaaS Management
 

--- a/packages/web/src/app/admin/residency/page.tsx
+++ b/packages/web/src/app/admin/residency/page.tsx
@@ -32,8 +32,10 @@ import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
+import { useDeployMode } from "@/ui/hooks/use-deploy-mode";
+import { cn } from "@/lib/utils";
 import { formatDate } from "@/lib/format";
-import { Globe, MapPin, AlertTriangle } from "lucide-react";
+import { Globe, MapPin, AlertTriangle, Info } from "lucide-react";
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -55,6 +57,9 @@ interface ResidencyStatus {
 // ── Page ──────────────────────────────────────────────────────────
 
 export default function ResidencyPage() {
+  const { deployMode } = useDeployMode();
+  const isSaas = deployMode === "saas";
+
   const { data, loading, error, refetch } = useAdminFetch<ResidencyStatus>(
     "/api/v1/admin/residency",
     { transform: (json) => json as ResidencyStatus },
@@ -72,8 +77,9 @@ export default function ResidencyPage() {
         <div>
           <h1 className="text-2xl font-bold tracking-tight">Data Residency</h1>
           <p className="text-muted-foreground">
-            Control where your workspace data is stored for compliance
-            requirements.
+            {isSaas
+              ? "Choose where your data is stored to meet regulatory requirements."
+              : "Control where your workspace data is stored for compliance requirements."}
           </p>
         </div>
 
@@ -98,15 +104,25 @@ export default function ResidencyPage() {
           {data && (
             data.configured ? (
               data.region ? (
-                <AssignedRegionCard status={data} />
+                <AssignedRegionCard status={data} isSaas={isSaas} />
               ) : (
-                <RegionPickerCard
-                  status={data}
-                  onAssign={async (region) => {
-                    await assignMutation.mutate({ body: { region } });
-                  }}
-                  saving={assignMutation.saving}
-                />
+                isSaas ? (
+                  <SaasRegionSelector
+                    status={data}
+                    onAssign={async (region) => {
+                      await assignMutation.mutate({ body: { region } });
+                    }}
+                    saving={assignMutation.saving}
+                  />
+                ) : (
+                  <RegionPickerCard
+                    status={data}
+                    onAssign={async (region) => {
+                      await assignMutation.mutate({ body: { region } });
+                    }}
+                    saving={assignMutation.saving}
+                  />
+                )
               )
             ) : (
               <NotConfiguredCard />
@@ -120,7 +136,14 @@ export default function ResidencyPage() {
 
 // ── Assigned Region Card ─────────────────────────────────────────
 
-function AssignedRegionCard({ status }: { status: ResidencyStatus }) {
+function AssignedRegionCard({
+  status,
+  isSaas,
+}: {
+  status: ResidencyStatus;
+  isSaas: boolean;
+}) {
+  const regionDisplay = getRegionDisplay(status.region ?? "");
   return (
     <Card>
       <CardHeader>
@@ -142,12 +165,26 @@ function AssignedRegionCard({ status }: { status: ResidencyStatus }) {
           <div className="grid gap-3 text-sm">
             <div className="flex justify-between">
               <span className="text-muted-foreground">Region</span>
-              <span className="font-medium">{status.regionLabel}</span>
+              <span className="font-medium">
+                {isSaas && regionDisplay.flag
+                  ? `${regionDisplay.flag} ${status.regionLabel}`
+                  : status.regionLabel}
+              </span>
             </div>
-            <div className="flex justify-between">
-              <span className="text-muted-foreground">Region ID</span>
-              <code className="text-xs">{status.region}</code>
-            </div>
+            {!isSaas && (
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Region ID</span>
+                <code className="text-xs">{status.region}</code>
+              </div>
+            )}
+            {isSaas && regionDisplay.compliance && (
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Compliance</span>
+                <span className="text-xs font-medium">
+                  {regionDisplay.compliance}
+                </span>
+              </div>
+            )}
             {status.assignedAt && (
               <div className="flex justify-between">
                 <span className="text-muted-foreground">Assigned</span>
@@ -167,7 +204,180 @@ function AssignedRegionCard({ status }: { status: ResidencyStatus }) {
   );
 }
 
-// ── Region Picker Card ───────────────────────────────────────────
+// ── Region display info ──────────────────────────────────────────
+
+const REGION_DISPLAY: Record<
+  string,
+  { flag: string; description: string; compliance: string | null }
+> = {
+  "us-east-1": {
+    flag: "\u{1F1FA}\u{1F1F8}",
+    description: "Virginia, United States",
+    compliance: "SOC 2, HIPAA eligible",
+  },
+  "us-west-2": {
+    flag: "\u{1F1FA}\u{1F1F8}",
+    description: "Oregon, United States",
+    compliance: "SOC 2, HIPAA eligible",
+  },
+  "eu-west-1": {
+    flag: "\u{1F1EA}\u{1F1FA}",
+    description: "Ireland, European Union",
+    compliance: "GDPR-compliant",
+  },
+  "eu-central-1": {
+    flag: "\u{1F1EA}\u{1F1FA}",
+    description: "Frankfurt, European Union",
+    compliance: "GDPR-compliant",
+  },
+  "ap-southeast-1": {
+    flag: "\u{1F30F}",
+    description: "Singapore, Asia Pacific",
+    compliance: "PDPA-compliant",
+  },
+  "ap-northeast-1": {
+    flag: "\u{1F1EF}\u{1F1F5}",
+    description: "Tokyo, Japan",
+    compliance: "APPI-compliant",
+  },
+};
+
+function getRegionDisplay(regionId: string) {
+  return (
+    REGION_DISPLAY[regionId] ?? {
+      flag: "\u{1F310}",
+      description: regionId,
+      compliance: null,
+    }
+  );
+}
+
+// ── SaaS Region Selector ─────────────────────────────────────────
+
+function SaasRegionSelector({
+  status,
+  onAssign,
+  saving,
+}: {
+  status: ResidencyStatus;
+  onAssign: (region: string) => Promise<void>;
+  saving: boolean;
+}) {
+  const [selected, setSelected] = useState("");
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const selectedRegion = status.availableRegions.find(
+    (r) => r.id === selected,
+  );
+  const selectedLabel = selectedRegion?.label ?? selected;
+  const selectedDisplay = getRegionDisplay(selected);
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>Select Data Region</CardTitle>
+          <CardDescription>
+            Choose where your workspace data will be stored and processed to
+            meet your regulatory requirements.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {/* Context */}
+          <div className="flex items-start gap-3 rounded-md border border-blue-200 bg-blue-50 p-4 dark:border-blue-900 dark:bg-blue-950/50">
+            <Info className="mt-0.5 h-5 w-5 shrink-0 text-blue-600 dark:text-blue-400" />
+            <p className="text-sm text-blue-700 dark:text-blue-300">
+              Your data is stored and processed entirely within the selected
+              region. This choice is permanent and ensures compliance with local
+              regulations.
+            </p>
+          </div>
+
+          {/* Region cards */}
+          <div className="grid gap-3 sm:grid-cols-2">
+            {status.availableRegions.map((region) => {
+              const display = getRegionDisplay(region.id);
+              const isSelected = selected === region.id;
+              return (
+                <button
+                  key={region.id}
+                  type="button"
+                  className={cn(
+                    "flex flex-col items-start gap-2 rounded-lg border p-4 text-left transition-colors hover:bg-accent/50",
+                    isSelected && "ring-2 ring-primary border-primary",
+                  )}
+                  onClick={() => setSelected(region.id)}
+                >
+                  <div className="flex w-full items-center gap-2">
+                    <span className="text-lg" role="img" aria-label={region.label}>
+                      {display.flag}
+                    </span>
+                    <span className="text-sm font-medium">{region.label}</span>
+                    {region.isDefault && (
+                      <Badge
+                        variant="secondary"
+                        className="ml-auto text-[10px]"
+                      >
+                        Default
+                      </Badge>
+                    )}
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {display.description}
+                  </p>
+                  {display.compliance && (
+                    <Badge variant="outline" className="text-[10px]">
+                      {display.compliance}
+                    </Badge>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Assign button */}
+          <Button
+            onClick={() => setShowConfirm(true)}
+            disabled={!selected || saving}
+            size="sm"
+          >
+            {saving ? "Assigning..." : "Select Region"}
+          </Button>
+        </CardContent>
+      </Card>
+
+      {/* Confirmation dialog */}
+      <AlertDialog open={showConfirm} onOpenChange={setShowConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirm data region</AlertDialogTitle>
+            <AlertDialogDescription>
+              Your workspace data will be stored in{" "}
+              <strong>
+                {selectedDisplay.flag} {selectedLabel}
+              </strong>
+              . This decision is permanent. Changing your data region later
+              requires contacting support.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={async () => {
+                setShowConfirm(false);
+                await onAssign(selected);
+              }}
+            >
+              Confirm {selectedLabel}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+// ── Region Picker Card (self-hosted) ─────────────────────────────
 
 function RegionPickerCard({
   status,

--- a/packages/web/src/app/admin/sandbox/page.tsx
+++ b/packages/web/src/app/admin/sandbox/page.tsx
@@ -24,7 +24,9 @@ import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
-import { Box, RotateCcw, Save } from "lucide-react";
+import { useDeployMode } from "@/ui/hooks/use-deploy-mode";
+import { cn } from "@/lib/utils";
+import { Box, Cloud, Puzzle, RotateCcw, Save, Shield } from "lucide-react";
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -47,6 +49,9 @@ interface SandboxStatus {
 // ── Page ──────────────────────────────────────────────────────────
 
 export default function SandboxPage() {
+  const { deployMode } = useDeployMode();
+  const isSaas = deployMode === "saas";
+
   const { data, loading, error, refetch } = useAdminFetch<SandboxStatus>(
     "/api/v1/admin/sandbox/status",
     { transform: (json) => json as SandboxStatus },
@@ -72,13 +77,40 @@ export default function SandboxPage() {
   const mutationError =
     saveMutation.error ?? saveUrlMutation.error ?? resetMutation.error;
 
+  const handlers = {
+    onSelectBackend: async (backendId: string) => {
+      await saveMutation.mutate({ body: { value: backendId } });
+    },
+    onSetSidecarUrl: async (url: string) => {
+      await saveUrlMutation.mutate({ body: { value: url } });
+    },
+    onReset: async () => {
+      await Promise.all([
+        resetMutation.mutate({
+          path: "/api/v1/admin/settings/ATLAS_SANDBOX_BACKEND",
+        }),
+        resetMutation.mutate({
+          path: "/api/v1/admin/settings/ATLAS_SANDBOX_URL",
+        }),
+      ]);
+    },
+    saving:
+      saveMutation.saving ||
+      saveUrlMutation.saving ||
+      resetMutation.saving,
+  };
+
   return (
     <ErrorBoundary>
       <div className="space-y-6">
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">Sandbox</h1>
+          <h1 className="text-2xl font-bold tracking-tight">
+            {isSaas ? "Execution Environment" : "Sandbox"}
+          </h1>
           <p className="text-muted-foreground">
-            Configure the sandbox backend used for the explore and Python tools.
+            {isSaas
+              ? "Choose how your queries and explorations are executed."
+              : "Configure the sandbox backend used for the explore and Python tools."}
           </p>
         </div>
 
@@ -95,30 +127,11 @@ export default function SandboxPage() {
           emptyDescription="No sandbox status available."
         >
           {data && (
-            <SandboxConfigCard
-              status={data}
-              onSelectBackend={async (backendId) => {
-                await saveMutation.mutate({ body: { value: backendId } });
-              }}
-              onSetSidecarUrl={async (url) => {
-                await saveUrlMutation.mutate({ body: { value: url } });
-              }}
-              onReset={async () => {
-                await Promise.all([
-                  resetMutation.mutate({
-                    path: "/api/v1/admin/settings/ATLAS_SANDBOX_BACKEND",
-                  }),
-                  resetMutation.mutate({
-                    path: "/api/v1/admin/settings/ATLAS_SANDBOX_URL",
-                  }),
-                ]);
-              }}
-              saving={
-                saveMutation.saving ||
-                saveUrlMutation.saving ||
-                resetMutation.saving
-              }
-            />
+            isSaas ? (
+              <SaasBackendSelector status={data} {...handlers} />
+            ) : (
+              <SandboxConfigCard status={data} {...handlers} />
+            )
           )}
         </AdminContentWrapper>
       </div>
@@ -126,7 +139,168 @@ export default function SandboxPage() {
   );
 }
 
-// ── Sandbox Config Card ───────────────────────────────────────────
+// ── Backend display info ─────────────────────────────────────────
+
+const BACKEND_DISPLAY: Record<
+  string,
+  { label: string; description: string; icon: typeof Cloud }
+> = {
+  __default__: {
+    label: "Cloud Sandbox",
+    description:
+      "Standard cloud-hosted execution. Fast startup, shared infrastructure.",
+    icon: Cloud,
+  },
+  "vercel-sandbox": {
+    label: "Cloud Sandbox",
+    description:
+      "Standard cloud-hosted execution. Fast startup, shared infrastructure.",
+    icon: Cloud,
+  },
+  nsjail: {
+    label: "Isolated Container",
+    description:
+      "Dedicated container per query. Maximum isolation for sensitive data.",
+    icon: Shield,
+  },
+  sidecar: {
+    label: "Sidecar Service",
+    description:
+      "Dedicated sidecar service for execution. Managed by the platform.",
+    icon: Box,
+  },
+  "just-bash": {
+    label: "Direct Execution",
+    description:
+      "Runs commands directly on the host. Development use only.",
+    icon: Box,
+  },
+};
+
+function getBackendDisplay(backend: SandboxBackend) {
+  const info = BACKEND_DISPLAY[backend.id];
+  if (info) return info;
+  if (backend.type === "plugin") {
+    return {
+      label: backend.name,
+      description: backend.description ?? "Plugin-provided sandbox backend.",
+      icon: Puzzle,
+    };
+  }
+  return {
+    label: backend.name,
+    description: backend.description ?? "Sandbox backend.",
+    icon: Box,
+  };
+}
+
+// ── SaaS Backend Selector ────────────────────────────────────────
+
+function SaasBackendSelector({
+  status,
+  onSelectBackend,
+  onReset,
+  saving,
+}: {
+  status: SandboxStatus;
+  onSelectBackend: (backendId: string) => Promise<void>;
+  onSetSidecarUrl: (url: string) => Promise<void>;
+  onReset: () => Promise<void>;
+  saving: boolean;
+}) {
+  const availableBackends = status.availableBackends.filter((b) => b.available);
+  const [selected, setSelected] = useState(
+    status.workspaceOverride ?? status.activeBackend,
+  );
+  const hasOverride = !!status.workspaceOverride;
+  const hasChanges = selected !== (status.workspaceOverride ?? status.activeBackend);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Execution Environment</CardTitle>
+        <CardDescription>
+          Select how your workspace runs queries and explorations. The
+          recommended option balances speed and security for most teams.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* Backend cards */}
+        <div className="grid gap-3 sm:grid-cols-2">
+          {availableBackends.map((backend) => {
+            const display = getBackendDisplay(backend);
+            const Icon = display.icon;
+            const isSelected = selected === backend.id;
+            const isDefault = backend.id === status.platformDefault;
+            return (
+              <button
+                key={backend.id}
+                type="button"
+                className={cn(
+                  "flex flex-col items-start gap-2 rounded-lg border p-4 text-left transition-colors hover:bg-accent/50",
+                  isSelected && "ring-2 ring-primary border-primary",
+                )}
+                onClick={() => setSelected(backend.id)}
+              >
+                <div className="flex w-full items-center gap-2">
+                  <Icon className="size-4 shrink-0 text-muted-foreground" />
+                  <span className="text-sm font-medium">{display.label}</span>
+                  {backend.type === "plugin" && (
+                    <Badge variant="outline" className="text-[10px]">
+                      Plugin
+                    </Badge>
+                  )}
+                  {isDefault && (
+                    <Badge variant="secondary" className="ml-auto text-[10px]">
+                      Recommended
+                    </Badge>
+                  )}
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {display.description}
+                </p>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-2">
+          <Button
+            onClick={async () => {
+              if (selected === status.platformDefault && hasOverride) {
+                await onReset();
+              } else {
+                await onSelectBackend(selected);
+              }
+            }}
+            disabled={saving || !hasChanges}
+            size="sm"
+          >
+            <Save className="mr-2 h-4 w-4" />
+            {saving ? "Saving..." : "Save"}
+          </Button>
+          {hasOverride && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={async () => {
+                await onReset();
+                setSelected(status.platformDefault);
+              }}
+              disabled={saving}
+            >
+              <RotateCcw className="mr-2 h-4 w-4" />
+              Use recommended
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── Sandbox Config Card (self-hosted) ────────────────────────────
 
 function SandboxConfigCard({
   status,


### PR DESCRIPTION
## Summary
- **Sandbox page** (#1026): SaaS users see card-based backend selector with friendly names (Cloud Sandbox, Isolated Container, Plugin), descriptions, and "Recommended" badge. Sidecar URL input is hidden. Self-hosted keeps existing dropdown.
- **Residency page** (#1027): SaaS users see card-based region selector with flag emojis, geographic descriptions, and compliance badges (GDPR, SOC 2, etc.). Raw region IDs hidden. Self-hosted keeps existing dropdown.
- Both pages use `useDeployMode()` hook for branching — same save/reset API calls, only the UI layer changes.

Closes #1026, closes #1027.

## Test plan
- [ ] Verify sandbox page in self-hosted mode — dropdown UI unchanged
- [ ] Verify sandbox page in SaaS mode — card-based selector, no sidecar URL input, "Use recommended" button
- [ ] Verify residency page in self-hosted mode — dropdown UI unchanged
- [ ] Verify residency page in SaaS mode — card-based region selector with flags and compliance badges
- [ ] Verify save/reset functionality works in both modes
- [ ] Verify assigned region card shows compliance info in SaaS mode, raw ID in self-hosted mode