### PR TITLE
fix: wrap Telegram botToken in body for useAdminMutation (#1057)

### DIFF
--- a/packages/web/src/app/admin/integrations/page.tsx
+++ b/packages/web/src/app/admin/integrations/page.tsx
@@ -146,7 +146,7 @@ export default function IntegrationsPage() {
   }
 
   async function handleTelegramConnect(botToken: string) {
-    await telegramConnectMutation.mutate({ botToken });
+    await telegramConnectMutation.mutate({ body: { botToken } });
   }
 
   async function handleTelegramDisconnect() {


### PR DESCRIPTION
## Summary
- Fixes CI type error on main — `botToken` was passed as a top-level property to `mutate()` instead of wrapped in `body`

## Test plan
- [ ] CI type check passes
- [ ] Telegram connect flow sends botToken in POST body