### PR TITLE
fix: add missing p-6 padding to sandbox and residency admin pages

### DIFF
--- a/apps/docs/content/docs/guides/sandbox.mdx
+++ b/apps/docs/content/docs/guides/sandbox.mdx
@@ -48,7 +48,7 @@ Credentials are validated against the Vercel API before saving. The team name is
 
 ### E2B
 
-Ephemeral cloud sandboxes with sub-second startup.
+Bring your own E2B account for ephemeral cloud sandboxes with sub-second startup.
 
 **Credentials:**
 - **API Key** — E2B API key
@@ -57,7 +57,7 @@ Validated against the E2B sandboxes API before saving.
 
 ### Daytona
 
-Cloud-hosted development sandboxes.
+Bring your own Daytona account for cloud-hosted development sandboxes.
 
 **Credentials:**
 - **API Key** — Daytona API key

--- a/packages/web/src/app/admin/residency/page.tsx
+++ b/packages/web/src/app/admin/residency/page.tsx
@@ -67,6 +67,7 @@ export default function ResidencyPage() {
   });
 
   return (
+    <div className="p-6">
     <ErrorBoundary>
       <div className="space-y-6">
         <div>
@@ -115,6 +116,7 @@ export default function ResidencyPage() {
         </AdminContentWrapper>
       </div>
     </ErrorBoundary>
+    </div>
   );
 }
 

--- a/packages/web/src/app/admin/sandbox/page.tsx
+++ b/packages/web/src/app/admin/sandbox/page.tsx
@@ -157,6 +157,7 @@ export default function SandboxPage() {
     saveMutation.error ?? saveUrlMutation.error ?? resetMutation.error;
 
   return (
+    <div className="p-6">
     <ErrorBoundary>
       <div className="space-y-6">
         <div>
@@ -219,6 +220,7 @@ export default function SandboxPage() {
         </AdminContentWrapper>
       </div>
     </ErrorBoundary>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- Sandbox and residency admin pages were missing the `<div className="p-6">` wrapper that all other admin pages use
- Content rendered flush against the sidebar with no padding
- Also fixes sandbox.mdx docs: E2B and Daytona descriptions now consistently say "Bring your own" (matching Vercel)

## Test plan
- [ ] Visit /admin/sandbox — content has padding matching other pages
- [ ] Visit /admin/residency — content has padding matching other pages
- [ ] Docs site sandbox guide shows "Bring your own" for all 3 BYOC providers