### PR TITLE
fix: Slack OAuth state, org hijack protection, useDeployMode error (#1072, #1074, #1076)

### DIFF
--- a/packages/api/src/api/routes/slack.ts
+++ b/packages/api/src/api/routes/slack.ts
@@ -672,26 +672,34 @@ slack.openapi(interactionsRoute, async (c) => {
   return c.json({ ok: true }, 200);
 });
 
-// --- OAuth CSRF state ---
+// --- OAuth CSRF state (shared DB-backed store) ---
 
-const pendingOAuthStates = new Map<string, number>();
-setInterval(() => {
-  const now = Date.now();
-  for (const [state, expiry] of pendingOAuthStates) {
-    if (now > expiry) pendingOAuthStates.delete(state);
-  }
-}, 600_000).unref();
+import { saveOAuthState, consumeOAuthState } from "@atlas/api/lib/auth/oauth-state";
 
 // --- GET /api/v1/slack/install ---
 
-slack.openapi(installRoute, (c) => {
+slack.openapi(installRoute, async (c) => {
   const clientId = process.env.SLACK_CLIENT_ID;
   if (!clientId) {
     return c.json({ error: "oauth_not_configured", message: "OAuth not configured" }, 501);
   }
 
+  // Extract orgId from session if available
+  let orgId: string | undefined;
+  try {
+    const authResult = c.get("authResult" as never) as
+      | { user?: { activeOrganizationId?: string } }
+      | undefined;
+    orgId = authResult?.user?.activeOrganizationId ?? undefined;
+  } catch (err) {
+    log.debug(
+      { err: err instanceof Error ? err.message : String(err) },
+      "authResult not available on Slack install route",
+    );
+  }
+
   const state = crypto.randomUUID();
-  pendingOAuthStates.set(state, Date.now() + 600_000);
+  await saveOAuthState(state, { orgId, provider: "slack" });
 
   const scopes = "commands,chat:write,app_mentions:read";
   const url = `https://slack.com/oauth/v2/authorize?client_id=${clientId}&scope=${scopes}&state=${state}`;
@@ -709,10 +717,10 @@ slack.openapi(callbackRoute, async (c) => {
   }
 
   const state = c.req.query("state");
-  if (!state || !pendingOAuthStates.has(state)) {
+  const oauthState = state ? await consumeOAuthState(state) : null;
+  if (!oauthState) {
     return c.json({ error: "invalid_state", message: "Invalid or expired state parameter" }, 400);
   }
-  pendingOAuthStates.delete(state);
 
   const code = c.req.query("code");
   if (!code) {
@@ -738,15 +746,8 @@ slack.openapi(callbackRoute, async (c) => {
 
   if (teamId && accessToken) {
     try {
-      // Extract org context if available (install may have been initiated by an authenticated admin)
-      let orgId: string | undefined;
-      try {
-        const authResult = c.get("authResult" as never) as { user?: { activeOrganizationId?: string } } | undefined;
-        orgId = authResult?.user?.activeOrganizationId ?? undefined;
-      } catch (err) {
-        // Expected: authResult not available on unauthenticated Slack routes
-        log.debug({ err: err instanceof Error ? err.message : String(err) }, "authResult not available on Slack callback route");
-      }
+      // Use orgId from the OAuth state (set during /install)
+      const orgId = oauthState.orgId;
 
       await saveInstallation(teamId, accessToken, { orgId, workspaceName: teamName ?? undefined });
       log.info({ teamId, orgId, teamName }, "Slack installation saved");

--- a/packages/api/src/lib/auth/oauth-state.ts
+++ b/packages/api/src/lib/auth/oauth-state.ts
@@ -15,7 +15,7 @@ const log = createLogger("oauth-state");
 // Types
 // ---------------------------------------------------------------------------
 
-export type OAuthProvider = "teams" | "discord";
+export type OAuthProvider = "slack" | "teams" | "discord";
 
 interface MemoryState {
   orgId: string | undefined;

--- a/packages/api/src/lib/slack/store.ts
+++ b/packages/api/src/lib/slack/store.ts
@@ -142,12 +142,34 @@ export async function saveInstallation(
     throw new Error("Cannot save Slack installation — no internal database configured");
   }
 
+  const orgId = opts?.orgId ?? null;
+  const workspaceName = opts?.workspaceName ?? null;
   const pool = getInternalDB();
+
+  // Reject if the team is already bound to a different org (prevents hijacking).
+  const existing = await pool.query(
+    "SELECT org_id FROM slack_installations WHERE team_id = $1",
+    [teamId],
+  );
+  if (existing.rows.length > 0) {
+    const existingOrgId = existing.rows[0].org_id;
+    if (existingOrgId && orgId && existingOrgId !== orgId) {
+      throw new Error(
+        `Slack workspace ${teamId} is already bound to a different organization. ` +
+        `Disconnect the existing installation first.`,
+      );
+    }
+  }
+
   await pool.query(
     `INSERT INTO slack_installations (team_id, bot_token, org_id, workspace_name)
      VALUES ($1, $2, $3, $4)
-     ON CONFLICT (team_id) DO UPDATE SET bot_token = $2, org_id = $3, workspace_name = $4, installed_at = now()`,
-    [teamId, botToken, opts?.orgId ?? null, opts?.workspaceName ?? null],
+     ON CONFLICT (team_id) DO UPDATE SET
+       bot_token = $2,
+       org_id = COALESCE($3, slack_installations.org_id),
+       workspace_name = COALESCE($4, slack_installations.workspace_name),
+       installed_at = now()`,
+    [teamId, botToken, orgId, workspaceName],
   );
 }
 

--- a/packages/web/src/ui/hooks/use-deploy-mode.ts
+++ b/packages/web/src/ui/hooks/use-deploy-mode.ts
@@ -13,13 +13,24 @@ interface SettingsResponse {
  * Returns the resolved deploy mode from the admin settings API.
  *
  * Fetches from `/api/v1/admin/settings` and extracts the `deployMode` field.
- * Defaults to `"self-hosted"` while loading or on error.
+ * Defaults to `"self-hosted"` while loading or on error. Exposes the error
+ * so consumers can detect when the fallback is due to a fetch failure
+ * (e.g., expired session) rather than an actual self-hosted deployment.
  */
-export function useDeployMode(): { deployMode: DeployMode; loading: boolean } {
-  const { data, loading } = useAdminFetch<SettingsResponse>("/api/v1/admin/settings");
+export function useDeployMode(): {
+  deployMode: DeployMode;
+  loading: boolean;
+  error: string | null;
+} {
+  const { data, loading, error } = useAdminFetch<SettingsResponse>("/api/v1/admin/settings");
+
+  if (error) {
+    console.warn("useDeployMode: failed to fetch deploy mode, defaulting to self-hosted:", error);
+  }
 
   return {
     deployMode: data?.deployMode ?? "self-hosted",
     loading,
+    error,
   };
 }


### PR DESCRIPTION
## Summary
Three bug fixes:

- **#1076** — Slack route migrated from in-memory OAuth state map to shared DB-backed `saveOAuthState`/`consumeOAuthState`, fixing multi-instance failures (same fix as Teams/Discord in PR #1071)
- **#1074** — Slack `saveInstallation()` now rejects if the team is already bound to a different org, preventing one workspace from silently stealing another's installation (matching Teams/Discord hijack protection)
- **#1072** — `useDeployMode()` now exposes the `error` field so consumers can detect when the `self-hosted` fallback is due to a fetch failure vs actual config

## Test plan
- [ ] Slack OAuth install/callback flow still works end-to-end
- [ ] Slack BYOT flow still works
- [ ] Attempting to bind a Slack workspace to a second org throws an error
- [ ] `useDeployMode()` returns `error` when settings API fails
- [ ] All existing consumers (`{ deployMode }` destructuring) unaffected