### PR TITLE
fix: mobile nav horizontal scroll — add dropdown menu

### DIFF
--- a/apps/www/src/app/globals.css
+++ b/apps/www/src/app/globals.css
@@ -18,6 +18,7 @@
 
   html {
     scroll-behavior: smooth;
+    overflow-x: hidden;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }

--- a/apps/www/src/components/nav.tsx
+++ b/apps/www/src/components/nav.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useState } from "react";
 import { AtlasLogo } from "./shared";
 
 const NAV_LINKS = [
@@ -8,42 +11,97 @@ const NAV_LINKS = [
 ];
 
 export function Nav({ currentPage, logoHref = "/" }: { currentPage?: string; logoHref?: string }) {
+  const [open, setOpen] = useState(false);
+
   return (
-    <nav className="animate-fade-in mx-auto flex max-w-5xl items-center justify-between px-6 py-6">
-      <a href={logoHref} className="flex items-center gap-2.5">
-        <AtlasLogo className="h-6 w-6 text-brand" />
-        <span className="font-mono text-lg font-semibold tracking-tight text-zinc-100">
-          atlas
-        </span>
-        <span className="rounded-full border border-brand/20 bg-brand/10 px-2 py-0.5 font-mono text-[10px] font-medium tracking-wider text-brand uppercase">
-          beta
-        </span>
-      </a>
-      <div className="flex items-center gap-4 sm:gap-6">
-        {NAV_LINKS.map((link) => {
-          const isActive = currentPage === link.href;
-          return (
-            <a
-              key={link.href}
-              href={link.href}
-              {...(isActive ? { "aria-current": "page" as const } : {})}
-              className={`text-sm transition-colors ${
-                isActive
-                  ? "text-zinc-300 hover:text-zinc-100"
-                  : "text-zinc-500 hover:text-zinc-300"
-              }`}
-            >
-              {link.label}
-            </a>
-          );
-        })}
-        <a
-          href="https://app.useatlas.dev"
-          className="rounded-md bg-zinc-100 px-3.5 py-1.5 text-sm font-medium text-zinc-950 transition-colors hover:bg-white"
-        >
-          Sign up
+    <nav className="animate-fade-in relative mx-auto max-w-5xl px-6 py-6">
+      <div className="flex items-center justify-between">
+        <a href={logoHref} className="flex items-center gap-2.5">
+          <AtlasLogo className="h-6 w-6 text-brand" />
+          <span className="font-mono text-lg font-semibold tracking-tight text-zinc-100">
+            atlas
+          </span>
+          <span className="rounded-full border border-brand/20 bg-brand/10 px-2 py-0.5 font-mono text-[10px] font-medium tracking-wider text-brand uppercase">
+            beta
+          </span>
         </a>
+
+        {/* Desktop links */}
+        <div className="hidden items-center gap-6 sm:flex">
+          {NAV_LINKS.map((link) => {
+            const isActive = currentPage === link.href;
+            return (
+              <a
+                key={link.href}
+                href={link.href}
+                {...(isActive ? { "aria-current": "page" as const } : {})}
+                className={`text-sm transition-colors ${
+                  isActive
+                    ? "text-zinc-300 hover:text-zinc-100"
+                    : "text-zinc-500 hover:text-zinc-300"
+                }`}
+              >
+                {link.label}
+              </a>
+            );
+          })}
+          <a
+            href="https://app.useatlas.dev"
+            className="rounded-md bg-zinc-100 px-3.5 py-1.5 text-sm font-medium text-zinc-950 transition-colors hover:bg-white"
+          >
+            Sign up
+          </a>
+        </div>
+
+        {/* Mobile hamburger */}
+        <button
+          type="button"
+          onClick={() => setOpen(!open)}
+          className="flex h-8 w-8 items-center justify-center rounded-md text-zinc-400 transition-colors hover:text-zinc-100 sm:hidden"
+          aria-label={open ? "Close menu" : "Open menu"}
+          aria-expanded={open}
+        >
+          {open ? (
+            <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+              <path d="M4 4l10 10M14 4L4 14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+          ) : (
+            <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+              <path d="M3 5h12M3 9h12M3 13h12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+          )}
+        </button>
       </div>
+
+      {/* Mobile dropdown */}
+      {open && (
+        <div className="absolute right-6 left-6 top-full z-50 mt-1 flex flex-col gap-1 rounded-lg border border-zinc-800/60 bg-zinc-950/95 p-2 backdrop-blur-md sm:hidden">
+          {NAV_LINKS.map((link) => {
+            const isActive = currentPage === link.href;
+            return (
+              <a
+                key={link.href}
+                href={link.href}
+                {...(isActive ? { "aria-current": "page" as const } : {})}
+                className={`rounded-md px-3 py-2 text-sm transition-colors ${
+                  isActive
+                    ? "text-zinc-200"
+                    : "text-zinc-400 hover:bg-zinc-800/50 hover:text-zinc-200"
+                }`}
+              >
+                {link.label}
+              </a>
+            );
+          })}
+          <div className="my-1 border-t border-zinc-800/60" />
+          <a
+            href="https://app.useatlas.dev"
+            className="rounded-md bg-zinc-100 px-3 py-2 text-center text-sm font-medium text-zinc-950 transition-colors hover:bg-white"
+          >
+            Sign up
+          </a>
+        </div>
+      )}
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
- Nav links caused horizontal overflow on mobile since all items were displayed inline at every screen size
- Replaced with a hamburger dropdown menu below the `sm` breakpoint; desktop nav unchanged
- Added `overflow-x: hidden` on `html` as a safety net

## Test plan
- [ ] Open useatlas.dev on a mobile viewport (~375px) — no horizontal scroll
- [ ] Tap hamburger icon — dropdown appears with all nav links + sign up
- [ ] Tap X icon — dropdown closes
- [ ] Resize to desktop — hamburger hidden, inline links shown as before

https://claude.ai/code/session_01Cg1GeutTfdwPhbKCXVzufD