### PR TITLE
docs: update admin console guide for SaaS hot-reload settings (#1103)

### DIFF
--- a/apps/docs/content/docs/guides/admin-console.mdx
+++ b/apps/docs/content/docs/guides/admin-console.mdx
@@ -255,13 +255,13 @@ Manage application configuration from the UI. Settings follow a three-tier resol
   - **default** (gray) — built-in default
 - **Edit** — Override any non-secret setting. Changes are saved to the internal database
 - **Live vs Restart** — Each setting shows whether changes take effect immediately (**Live**) or require a server restart (**Requires restart**). Query Limits, Rate Limiting, Sessions, Sandbox, and Appearance are live; Security, Platform, and Agent settings require a restart
-
-<Callout type="info">
-On **app.useatlas.dev** (SaaS mode), all settings are hot-reloadable — changes take effect within seconds without a server restart. The restart requirement only applies to self-hosted deployments.
-</Callout>
 - **Reset** — Remove a DB override to revert to the environment variable or default value
 - **Secrets** — Sensitive settings (API keys, database URLs) are masked and read-only. Manage these via environment variables
 - **SaaS mode** — Workspace admins only see settings marked as workspace-visible. Platform admins see all settings. The response includes a `deployMode` field and a `manageable` flag indicating whether settings can be persisted
+
+<Callout type="info">
+On **app.useatlas.dev** (SaaS mode), most settings are hot-reloadable — changes are picked up on the next request without a server restart. A few infrastructure settings (LLM provider, model) may still require redeployment to fully take effect. The restart requirement mainly applies to self-hosted deployments.
+</Callout>
 
 <Callout type="info">
 Settings overrides require an internal database (`DATABASE_URL`). Without it, the settings page is read-only — all values come from environment variables.
@@ -676,7 +676,7 @@ All admin endpoints are at `/api/v1/admin/` and require the `admin` role. See th
 
 **Cause:** Some settings (Security, Agent) require a server restart, while others (Query Limits, Rate Limiting) apply immediately. The settings page shows a **Live** or **Requires restart** badge on each setting.
 
-**Fix:** Check the badge next to the setting you changed. If it says **Requires restart**, restart the Atlas server for the change to apply. On **app.useatlas.dev** (SaaS mode), all settings are hot-reloadable and take effect within seconds — no restart is needed.
+**Fix:** Check the badge next to the setting you changed. If it says **Requires restart**, restart the Atlas server for the change to apply. On **app.useatlas.dev** (SaaS mode), most settings are picked up on the next request without a restart — though infrastructure settings like LLM provider and model may require redeployment.
 
 For more, see [Troubleshooting](/guides/troubleshooting).
 


### PR DESCRIPTION
## Summary
- Add Callout in settings section noting all settings are hot-reloadable on app.useatlas.dev (SaaS mode)
- Update troubleshooting section to mention SaaS hot-reload exception

Closes #1103

## Test plan
- [ ] Verify admin-console.mdx renders correctly with new Callout
- [ ] Verify troubleshooting section reads naturally with SaaS distinction