### PR TITLE
docs: add per-action timeout to config reference + fix learn --suggestions CLI help (#1105)

### DIFF
--- a/apps/docs/content/docs/reference/config.mdx
+++ b/apps/docs/content/docs/reference/config.mdx
@@ -555,6 +555,7 @@ export default defineConfig({
 | `[actionType].enabled` | `boolean` | Enable/disable this action |
 | `[actionType].approval` | `string` | Override approval mode for this action |
 | `[actionType].requiredRole` | `string` | Minimum role to approve: `viewer`, `analyst`, `admin` |
+| `[actionType].timeout` | `number` | Execution timeout in ms. Overrides `defaults.timeout` for this action type |
 | `[actionType].credentials` | `object` | Required env vars (`{ VAR_NAME: { env: "VAR_NAME" } }`) |
 | `[actionType].rateLimit` | `number` | Max executions per minute for this action type |
 

--- a/packages/cli/bin/atlas.ts
+++ b/packages/cli/bin/atlas.ts
@@ -3520,6 +3520,7 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp> = {
     usage: "learn [options]",
     flags: [
       { flag: "--apply", description: "Write proposed changes to YAML files (default: dry-run)" },
+      { flag: "--suggestions", description: "Generate query suggestions from the audit log" },
       { flag: "--limit <n>", description: "Max audit log entries to analyze (default: 1000)" },
       { flag: "--since <date>", description: "Only analyze queries after this date (ISO 8601)" },
       { flag: "--source <name>", description: "Read from/write to semantic/{name}/ subdirectory" },


### PR DESCRIPTION
## Summary
- Add `[actionType].timeout` field to config reference Action fields table
- Add missing `--suggestions` flag to `SUBCOMMAND_HELP.learn.flags` in CLI source

Closes #1105

## Test plan
- [ ] Verify config.mdx Action fields table renders with new timeout row
- [ ] Verify `atlas learn --help` shows `--suggestions` flag