### PR TITLE
chore: add deploy validation CI workflow

### DIFF
--- a/.github/workflows/deploy-validation.yml
+++ b/.github/workflows/deploy-validation.yml
@@ -11,7 +11,6 @@ on:
       - "packages/types/src/**"
       - "packages/cli/bin/**"
       - "packages/cli/data/**"
-      - "scripts/prepare-templates.sh"
       - "scripts/check-template-drift.sh"
       - ".github/workflows/deploy-validation.yml"
   push:
@@ -24,7 +23,6 @@ on:
       - "packages/types/src/**"
       - "packages/cli/bin/**"
       - "packages/cli/data/**"
-      - "scripts/prepare-templates.sh"
       - "scripts/check-template-drift.sh"
       - ".github/workflows/deploy-validation.yml"
 


### PR DESCRIPTION
## Summary

Closes #1029

- Adds `.github/workflows/deploy-validation.yml` — a path-filtered CI workflow that validates self-hosted deployment templates
- Runs on PRs/pushes that touch `create-atlas/`, `examples/`, `packages/api/src/`, `packages/web/src/`, `packages/types/`, `packages/cli/`, or template scripts

### Jobs (all run in parallel)

| Job | What it validates |
|-----|-------------------|
| **Scaffold (docker)** | `create-atlas/smoke-test.sh docker` — scaffolds project, installs, builds |
| **Scaffold (vercel)** | `create-atlas/smoke-test.sh vercel` — same for Vercel platform |
| **Standalone Example Build** | `bun run --filter '@atlas/nextjs-standalone' build` — Next.js build |
| **Config & Deploy Mode** | Docker compose config validation (all 3 files) + deploy mode default check |

### Deploy mode check

Verifies no template env/config file sets `ATLAS_DEPLOY_MODE=saas`, and the scaffolder doesn't write it to generated `.env`. Self-hosted is always the default.

## Test plan

- [x] All 3 docker-compose configs validate locally (`docker compose config`)
- [x] Deploy mode grep passes (no template defaults to SaaS)
- [x] CI gates pass: lint, type, test, syncpack, template drift
- [ ] Workflow triggers on this PR (touches `.github/workflows/deploy-validation.yml`)