### PR TITLE
fix: build @useatlas/react in web Dockerfile — unbreak Railway web deploy

### DIFF
--- a/deploy/web/Dockerfile
+++ b/deploy/web/Dockerfile
@@ -52,8 +52,9 @@ FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app ./
 COPY . .
-# Build @useatlas/types first (exports point to dist/) then the Next.js app
+# Build workspace deps whose exports point to dist/ before the Next.js app
 RUN cd packages/types && bun run build
+RUN cd packages/react && bun run build
 # Bake build-time env vars into the client JS bundle
 ENV NEXT_PUBLIC_ATLAS_API_URL=https://api.useatlas.dev
 ENV NEXT_PUBLIC_ATLAS_AUTH_MODE=managed

--- a/deploy/web/railway.json
+++ b/deploy/web/railway.json
@@ -7,6 +7,8 @@
     "watchPatterns": [
       "packages/web/**",
       "packages/api/**",
+      "packages/react/**",
+      "packages/types/**",
       "deploy/web/**"
     ]
   },


### PR DESCRIPTION
## Summary
- Add `RUN cd packages/react && bun run build` to `deploy/web/Dockerfile` before the Next.js build — the react package exports point to `dist/` which didn't exist, causing `Module not found: Can't resolve '@useatlas/react'`
- Add `packages/react/**` and `packages/types/**` to Railway watch patterns so web rebuilds when workspace deps change

## Test plan
- [ ] Railway web service builds successfully after merge
- [ ] Verify `app.useatlas.dev` loads correctly