### PR TITLE
feat: cross-region request misrouting detection

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -768,7 +768,7 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
   - [x] Region-aware ConnectionRegistry (#1151)
   - [x] Dynamic frontend API URL — runtime resolution from regionApiUrl (#1150)
   - [x] Multi-region Railway deployment — 3 regions live: api (us-west), api-eu (europe-west4), api-apac (asia-southeast1) (#1152)
-  - [ ] Cross-region request misrouting detection (#1153)
+  - [x] Cross-region request misrouting detection (#1153)
   - [ ] Region migration — actual cross-region data movement (#1154)
 - [x] Docs — semantic editor, plugin marketplace, platform plugin catalog guides (#1141, PR #1142)
 - [x] Fix flaky DuckDB ingest test — timeout bump (#1145, 71246b7c)

--- a/.env.example
+++ b/.env.example
@@ -237,6 +237,10 @@ ATLAS_SANDBOX_URL=http://localhost:8080
 # STRIPE_TEAM_ANNUAL_PRICE_ID=price_...            # Stripe Price ID for Team plan (annual)
 # STRIPE_ENTERPRISE_PRICE_ID=price_...             # Stripe Price ID for Enterprise plan
 
+# === Data Residency ===
+# ATLAS_API_REGION=                   # Region identity of this API instance (e.g. "us-west", "eu-west", "ap-southeast"). Used for misrouting detection. Falls back to residency.defaultRegion from atlas.config.ts if unset.
+# ATLAS_STRICT_ROUTING=false          # When true, misrouted requests receive 421 Misdirected Request instead of being served with a warning.
+
 # === Enterprise Features ===
 # ATLAS_ENTERPRISE_ENABLED=false      # Enable enterprise features (SSO, SCIM, PII detection, custom roles)
 # ATLAS_ENTERPRISE_LICENSE_KEY=       # License key for enterprise features (https://www.useatlas.dev/enterprise)

--- a/apps/docs/content/docs/platform-ops/data-residency.mdx
+++ b/apps/docs/content/docs/platform-ops/data-residency.mdx
@@ -146,6 +146,25 @@ When a workspace has a region assigned:
 
 The routing is transparent to the agent and end users — the same API endpoints work regardless of region.
 
+## Misrouting Detection
+
+When running multiple regional API instances, each instance identifies itself via the `ATLAS_API_REGION` env var (or falls back to `residency.defaultRegion` from config). If a request arrives from a workspace assigned to a different region, Atlas logs a warning with the request ID, org ID, expected region, and actual region.
+
+The `/api/health` endpoint includes a `region` field showing the instance's identity, plus a `misroutedRequests` counter when any misrouted requests have been detected.
+
+### Strict mode
+
+Set `ATLAS_STRICT_ROUTING=true` (or `residency.strictRouting: true` in config) to reject misrouted requests with `421 Misdirected Request`. The response includes a `correctApiUrl` hint (from the region's `apiUrl` config) so the client can redirect:
+
+```json
+{
+  "error": "misdirected_request",
+  "correctApiUrl": "https://api-eu.useatlas.dev",
+  "expectedRegion": "eu-west",
+  "actualRegion": "us-west"
+}
+```
+
 ## Limitations
 
 - Region assignment is immutable (no cross-region migration yet)

--- a/apps/docs/content/docs/reference/config.mdx
+++ b/apps/docs/content/docs/reference/config.mdx
@@ -823,6 +823,7 @@ export default defineConfig({
 |-------|------|----------|---------|-------------|
 | `regions` | `Record<string, RegionConfig>` | Yes | — | Map of region identifiers to database configuration. At least one region required |
 | `defaultRegion` | `string` | Yes | — | Default region for new workspaces. Must be a key in the `regions` map |
+| `strictRouting` | `boolean` | No | `false` | When `true`, misrouted requests receive `421 Misdirected Request` instead of a warning log. Also configurable via `ATLAS_STRICT_ROUTING` env var |
 
 **RegionConfig fields:**
 
@@ -831,6 +832,7 @@ export default defineConfig({
 | `label` | `string` | Yes | — | Human-readable region name for the admin console |
 | `databaseUrl` | `string` | Yes | — | Connection string for the region's internal database |
 | `datasourceUrl` | `string` | No | — | Analytics datasource override for the region. When unset, uses the default datasource |
+| `apiUrl` | `string` | No | — | Public API endpoint for this region (e.g. `https://api-eu.useatlas.dev`). Used in `421 Misdirected Request` responses to redirect clients to the correct region |
 
 ---
 

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -451,6 +451,17 @@ ATLAS_PUBLIC_URL=https://api.example.com
 
 ---
 
+## Data Residency
+
+Settings for multi-region deployments with per-workspace region routing. See also [`residency` in atlas.config.ts](/reference/config#residency) and the [Data Residency guide](/platform-ops/data-residency).
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ATLAS_API_REGION` | — | Region identity of this API instance (e.g. `us-west`, `eu-west`, `ap-southeast`). Used for misrouting detection. Falls back to `residency.defaultRegion` from config if unset |
+| `ATLAS_STRICT_ROUTING` | `false` | When `true`, misrouted requests receive `421 Misdirected Request` with a `correctApiUrl` hint instead of being served with a warning log |
+
+---
+
 ## Appearance
 
 | Variable | Default | Description |

--- a/packages/api/src/api/routes/health.ts
+++ b/packages/api/src/api/routes/health.ts
@@ -21,6 +21,7 @@ import { getExploreBackendType, getActiveSandboxPluginId } from "@atlas/api/lib/
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
 import { SENSITIVE_PATTERNS } from "@atlas/api/lib/security";
 import { getSetting } from "@atlas/api/lib/settings";
+import { getApiRegion, getMisroutedCount } from "@atlas/api/lib/residency/misrouting";
 
 const log = createLogger("health");
 
@@ -43,6 +44,8 @@ const ComponentHealthSchema = z.object({
 
 export const HealthResponseSchema = z.object({
   status: z.enum(["ok", "degraded", "error"]),
+  region: z.string().optional(),
+  misroutedRequests: z.number().int().nonnegative().optional(),
   warnings: z.array(z.string()).optional(),
   brandColor: z.string().optional(),
   components: z.object({
@@ -333,8 +336,14 @@ health.openapi(healthRoute, async (c) => {
     // Brand color for frontend theming (public, no auth required)
     const brandColor = getSetting("ATLAS_BRAND_COLOR");
 
+    // Region identity for monitoring / misrouting detection
+    const region = getApiRegion();
+    const misroutedRequests = getMisroutedCount();
+
     const response = {
       status,
+      ...(region && { region }),
+      ...(misroutedRequests > 0 && { misroutedRequests }),
       ...(warnings.length > 0 && { warnings }),
       ...(brandColor && { brandColor }),
       components,

--- a/packages/api/src/api/routes/middleware.ts
+++ b/packages/api/src/api/routes/middleware.ts
@@ -14,6 +14,7 @@
  */
 
 import type { Env } from "hono";
+import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
 import { createLogger, withRequestContext } from "@atlas/api/lib/logger";
 import type { AuthResult } from "@atlas/api/lib/auth/types";
@@ -22,6 +23,10 @@ import {
   checkRateLimit,
   getClientIP,
 } from "@atlas/api/lib/auth/middleware";
+import {
+  detectMisrouting,
+  isStrictRoutingEnabled,
+} from "@atlas/api/lib/residency/misrouting";
 
 const log = createLogger("middleware");
 
@@ -131,6 +136,37 @@ async function rateLimitAndIPCheck(
 }
 
 // ---------------------------------------------------------------------------
+// Misrouting detection — checks if the request reached the correct regional API
+// ---------------------------------------------------------------------------
+
+async function checkMisrouting(
+  c: Context,
+  authResult: AuthResult & { authenticated: true },
+  requestId: string,
+): Promise<{ body: Record<string, unknown>; status: number } | null> {
+  const orgId = authResult.user?.activeOrganizationId;
+  const result = await detectMisrouting(orgId, requestId);
+  if (!result) return null;
+
+  if (isStrictRoutingEnabled()) {
+    return {
+      body: {
+        error: "misdirected_request",
+        message: `This request should be directed to the ${result.expectedRegion} region API.`,
+        correctApiUrl: result.correctApiUrl,
+        expectedRegion: result.expectedRegion,
+        actualRegion: result.actualRegion,
+        requestId,
+      },
+      status: 421,
+    };
+  }
+
+  // Graceful mode — log already happened in detectMisrouting, serve normally
+  return null;
+}
+
+// ---------------------------------------------------------------------------
 // adminAuth — authenticate + enforce admin role + rate limit + IP allowlist
 // ---------------------------------------------------------------------------
 
@@ -159,6 +195,11 @@ export const adminAuth = createMiddleware<AuthEnv>(async (c, next) => {
   const blocked = await rateLimitAndIPCheck(c.req.raw, authResult, requestId);
   if (blocked) {
     return c.json(blocked.body, blocked.status as 429, blocked.headers);
+  }
+
+  const misrouted = await checkMisrouting(c, authResult, requestId);
+  if (misrouted) {
+    return c.json(misrouted.body, misrouted.status as 421);
   }
 
   c.set("authResult", authResult);
@@ -190,6 +231,11 @@ export const platformAdminAuth = createMiddleware<AuthEnv>(async (c, next) => {
     return c.json(blocked.body, blocked.status as 429, blocked.headers);
   }
 
+  const misrouted = await checkMisrouting(c, authResult, requestId);
+  if (misrouted) {
+    return c.json(misrouted.body, misrouted.status as 421);
+  }
+
   c.set("authResult", authResult);
   await next();
 });
@@ -211,6 +257,11 @@ export const standardAuth = createMiddleware<AuthEnv>(async (c, next) => {
   const blocked = await rateLimitAndIPCheck(c.req.raw, authResult, requestId);
   if (blocked) {
     return c.json(blocked.body, blocked.status as 429, blocked.headers);
+  }
+
+  const misrouted = await checkMisrouting(c, authResult, requestId);
+  if (misrouted) {
+    return c.json(misrouted.body, misrouted.status as 421);
   }
 
   c.set("authResult", authResult);

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -241,6 +241,8 @@ const ResidencyConfigSchema = z.object({
   ),
   /** Default region for new workspaces. Must be a key in the regions map. */
   defaultRegion: z.string().min(1),
+  /** When true, misrouted requests receive 421 Misdirected Request instead of a warning log. */
+  strictRouting: z.boolean().default(false),
 }).refine(
   (cfg) => cfg.defaultRegion in cfg.regions,
   { message: "defaultRegion must be one of the configured regions", path: ["defaultRegion"] },

--- a/packages/api/src/lib/residency/__tests__/misrouting.test.ts
+++ b/packages/api/src/lib/residency/__tests__/misrouting.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Tests for cross-region request misrouting detection.
+ *
+ * Covers: correct region (no warning), wrong region (warning logged),
+ * strict mode (421 response), no region configured (skip), unauthenticated (skip),
+ * health endpoint region field, counter increment, cache behavior.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+// ── Mocks ────────────────────────────────────────────────────────────
+
+let mockWorkspaceRegion: string | null = null;
+let mockGetWorkspaceRegionError: Error | null = null;
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => true,
+  getWorkspaceRegion: async (orgId: string) => {
+    if (mockGetWorkspaceRegionError) throw mockGetWorkspaceRegionError;
+    // Different orgs can have different regions
+    if (orgId === "org-eu") return "eu-west";
+    if (orgId === "org-us") return "us-west";
+    if (orgId === "org-no-region") return null;
+    return mockWorkspaceRegion;
+  },
+  internalQuery: () => Promise.resolve([]),
+  internalExecute: () => {},
+  getInternalDB: () => ({
+    query: () => Promise.resolve({ rows: [] }),
+    end: async () => {},
+    on: () => {},
+  }),
+  encryptUrl: (url: string) => url,
+  decryptUrl: (url: string) => url,
+  isPlaintextUrl: () => true,
+  getEncryptionKey: () => null,
+  _resetEncryptionKeyCache: () => {},
+  setWorkspaceRegion: () => Promise.resolve({ assigned: true }),
+  closeInternalDB: () => Promise.resolve(),
+  InternalDB: {},
+  makeInternalDBLive: () => {},
+  createInternalDBTestLayer: () => {},
+}));
+
+let mockConfig: Record<string, unknown> | null = null;
+
+mock.module("@atlas/api/lib/config", () => ({
+  getConfig: () => mockConfig,
+  configFromEnv: () => ({}),
+  loadConfig: async () => ({}),
+  defineConfig: (c: unknown) => c,
+  validateAndResolve: (r: unknown) => r,
+  _setConfigForTest: () => {},
+}));
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+// ── Import after mocks ──────────────────────────────────────────────
+
+const {
+  detectMisrouting,
+  getApiRegion,
+  isStrictRoutingEnabled,
+  getMisroutedCount,
+  _resetMisroutedCount,
+  _resetRegionCache,
+} = await import("../misrouting");
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe("misrouting detection", () => {
+  beforeEach(() => {
+    _resetMisroutedCount();
+    _resetRegionCache();
+    mockWorkspaceRegion = null;
+    mockGetWorkspaceRegionError = null;
+    mockConfig = null;
+    delete process.env.ATLAS_API_REGION;
+    delete process.env.ATLAS_STRICT_ROUTING;
+  });
+
+  // ── getApiRegion ──────────────────────────────────────────────────
+
+  describe("getApiRegion", () => {
+    it("returns ATLAS_API_REGION env var when set", () => {
+      process.env.ATLAS_API_REGION = "us-west";
+      expect(getApiRegion()).toBe("us-west");
+    });
+
+    it("falls back to config residency.defaultRegion", () => {
+      mockConfig = {
+        residency: {
+          defaultRegion: "eu-west",
+          regions: { "eu-west": { label: "Europe", databaseUrl: "postgres://..." } },
+        },
+      };
+      expect(getApiRegion()).toBe("eu-west");
+    });
+
+    it("returns null when no region is configured", () => {
+      expect(getApiRegion()).toBeNull();
+    });
+
+    it("env var takes precedence over config", () => {
+      process.env.ATLAS_API_REGION = "ap-southeast";
+      mockConfig = {
+        residency: {
+          defaultRegion: "eu-west",
+          regions: { "eu-west": { label: "Europe", databaseUrl: "postgres://..." } },
+        },
+      };
+      expect(getApiRegion()).toBe("ap-southeast");
+    });
+  });
+
+  // ── isStrictRoutingEnabled ────────────────────────────────────────
+
+  describe("isStrictRoutingEnabled", () => {
+    it("defaults to false", () => {
+      expect(isStrictRoutingEnabled()).toBe(false);
+    });
+
+    it("returns true when env var is set", () => {
+      process.env.ATLAS_STRICT_ROUTING = "true";
+      expect(isStrictRoutingEnabled()).toBe(true);
+    });
+
+    it("returns true when config has strictRouting", () => {
+      mockConfig = {
+        residency: {
+          defaultRegion: "us-west",
+          strictRouting: true,
+          regions: { "us-west": { label: "US", databaseUrl: "postgres://..." } },
+        },
+      };
+      expect(isStrictRoutingEnabled()).toBe(true);
+    });
+
+    it("env var takes precedence over config", () => {
+      process.env.ATLAS_STRICT_ROUTING = "true";
+      mockConfig = {
+        residency: {
+          defaultRegion: "us-west",
+          strictRouting: false,
+          regions: { "us-west": { label: "US", databaseUrl: "postgres://..." } },
+        },
+      };
+      expect(isStrictRoutingEnabled()).toBe(true);
+    });
+  });
+
+  // ── detectMisrouting ──────────────────────────────────────────────
+
+  describe("detectMisrouting", () => {
+    it("skips when no orgId is provided", async () => {
+      process.env.ATLAS_API_REGION = "us-west";
+      const result = await detectMisrouting(undefined, "req-1");
+      expect(result).toBeNull();
+      expect(getMisroutedCount()).toBe(0);
+    });
+
+    it("skips when no region is configured on this instance", async () => {
+      // No ATLAS_API_REGION, no config → self-hosted
+      const result = await detectMisrouting("org-eu", "req-1");
+      expect(result).toBeNull();
+      expect(getMisroutedCount()).toBe(0);
+    });
+
+    it("skips when workspace has no region assigned", async () => {
+      process.env.ATLAS_API_REGION = "us-west";
+      const result = await detectMisrouting("org-no-region", "req-1");
+      expect(result).toBeNull();
+      expect(getMisroutedCount()).toBe(0);
+    });
+
+    it("returns null when regions match (correct routing)", async () => {
+      process.env.ATLAS_API_REGION = "us-west";
+      const result = await detectMisrouting("org-us", "req-1");
+      expect(result).toBeNull();
+      expect(getMisroutedCount()).toBe(0);
+    });
+
+    it("detects misrouting when regions differ", async () => {
+      process.env.ATLAS_API_REGION = "us-west";
+      const result = await detectMisrouting("org-eu", "req-1");
+      expect(result).not.toBeNull();
+      expect(result!.expectedRegion).toBe("eu-west");
+      expect(result!.actualRegion).toBe("us-west");
+      expect(getMisroutedCount()).toBe(1);
+    });
+
+    it("includes correctApiUrl from config when available", async () => {
+      process.env.ATLAS_API_REGION = "us-west";
+      mockConfig = {
+        residency: {
+          defaultRegion: "us-west",
+          regions: {
+            "us-west": { label: "US", databaseUrl: "postgres://...", apiUrl: "https://api-us.useatlas.dev" },
+            "eu-west": { label: "Europe", databaseUrl: "postgres://...", apiUrl: "https://api-eu.useatlas.dev" },
+          },
+        },
+      };
+      const result = await detectMisrouting("org-eu", "req-1");
+      expect(result).not.toBeNull();
+      expect(result!.correctApiUrl).toBe("https://api-eu.useatlas.dev");
+    });
+
+    it("omits correctApiUrl when not in config", async () => {
+      process.env.ATLAS_API_REGION = "us-west";
+      mockConfig = null;
+      const result = await detectMisrouting("org-eu", "req-1");
+      expect(result).not.toBeNull();
+      expect(result!.correctApiUrl).toBeUndefined();
+    });
+
+    it("increments counter for each misrouted request", async () => {
+      process.env.ATLAS_API_REGION = "us-west";
+      await detectMisrouting("org-eu", "req-1");
+      await detectMisrouting("org-eu", "req-2");
+      await detectMisrouting("org-eu", "req-3");
+      expect(getMisroutedCount()).toBe(3);
+    });
+
+    it("skips gracefully when region lookup fails", async () => {
+      process.env.ATLAS_API_REGION = "us-west";
+      mockGetWorkspaceRegionError = new Error("DB connection failed");
+      const result = await detectMisrouting("org-unknown", "req-1");
+      expect(result).toBeNull();
+      expect(getMisroutedCount()).toBe(0);
+    });
+
+    it("uses cached region on subsequent calls", async () => {
+      process.env.ATLAS_API_REGION = "us-west";
+
+      // First call — hits DB
+      const result1 = await detectMisrouting("org-eu", "req-1");
+      expect(result1).not.toBeNull();
+
+      // Second call — should use cache (even if DB would error now)
+      mockGetWorkspaceRegionError = new Error("DB gone");
+      const result2 = await detectMisrouting("org-eu", "req-2");
+      expect(result2).not.toBeNull();
+      expect(result2!.expectedRegion).toBe("eu-west");
+    });
+  });
+
+  // ── Counter reset ─────────────────────────────────────────────────
+
+  describe("counter", () => {
+    it("resets to zero", () => {
+      expect(getMisroutedCount()).toBe(0);
+    });
+  });
+});

--- a/packages/api/src/lib/residency/misrouting.ts
+++ b/packages/api/src/lib/residency/misrouting.ts
@@ -1,0 +1,168 @@
+/**
+ * Cross-region request misrouting detection.
+ *
+ * Each Atlas API instance knows its own region via ATLAS_API_REGION (or
+ * residency.defaultRegion from config). When a request arrives from a
+ * workspace assigned to a different region, the middleware logs a warning
+ * and increments a counter. With strict routing enabled, misrouted
+ * requests receive 421 Misdirected Request.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { getConfig } from "@atlas/api/lib/config";
+
+const log = createLogger("misrouting");
+
+// ── In-memory counter ──────────────────────────────────────────────
+
+let misroutedCount = 0;
+
+/** Number of misrouted requests detected since process start. */
+export function getMisroutedCount(): number {
+  return misroutedCount;
+}
+
+/** @internal Reset counter — for testing only. */
+export function _resetMisroutedCount(): void {
+  misroutedCount = 0;
+}
+
+// ── Region cache (orgId → region) ──────────────────────────────────
+
+interface CacheEntry {
+  region: string | null;
+  expiresAt: number;
+}
+
+const regionCache = new Map<string, CacheEntry>();
+const CACHE_TTL_MS = 60_000;
+
+function getCachedRegion(orgId: string): string | null | undefined {
+  const cached = regionCache.get(orgId);
+  if (!cached) return undefined;
+  if (Date.now() > cached.expiresAt) {
+    regionCache.delete(orgId);
+    return undefined;
+  }
+  return cached.region;
+}
+
+function setCachedRegion(orgId: string, region: string | null): void {
+  regionCache.set(orgId, { region, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
+/** @internal Reset region cache — for testing only. */
+export function _resetRegionCache(): void {
+  regionCache.clear();
+}
+
+// ── API region identity ────────────────────────────────────────────
+
+/**
+ * Get the region identity of this API instance.
+ *
+ * Resolution order:
+ * 1. `ATLAS_API_REGION` env var (explicit per-instance override)
+ * 2. `residency.defaultRegion` from atlas.config.ts (shared config fallback)
+ * 3. `null` — no region configured (self-hosted compatibility, check is skipped)
+ */
+export function getApiRegion(): string | null {
+  const envRegion = process.env.ATLAS_API_REGION;
+  if (envRegion) return envRegion;
+  const config = getConfig();
+  return config?.residency?.defaultRegion ?? null;
+}
+
+// ── Strict routing flag ────────────────────────────────────────────
+
+/**
+ * Whether strict routing mode is enabled.
+ *
+ * In strict mode, misrouted requests receive 421 Misdirected Request
+ * with a `correctApiUrl` hint. In graceful mode (default), requests
+ * are served normally but the mismatch is logged.
+ *
+ * Controlled by `residency.strictRouting` in config or
+ * `ATLAS_STRICT_ROUTING=true` env var.
+ */
+export function isStrictRoutingEnabled(): boolean {
+  if (process.env.ATLAS_STRICT_ROUTING === "true") return true;
+  const config = getConfig();
+  return config?.residency?.strictRouting ?? false;
+}
+
+// ── Misrouting result ──────────────────────────────────────────────
+
+export interface MisroutingResult {
+  readonly expectedRegion: string;
+  readonly actualRegion: string;
+  readonly correctApiUrl?: string;
+}
+
+// ── Detection ──────────────────────────────────────────────────────
+
+/**
+ * Detect whether a request is misrouted to the wrong regional API instance.
+ *
+ * Returns a `MisroutingResult` when the workspace's assigned region
+ * doesn't match this instance's region. Returns `null` when:
+ * - No orgId (unauthenticated or no org context)
+ * - No region configured on this instance (self-hosted)
+ * - Workspace has no region assigned yet
+ * - Regions match (correct routing)
+ * - Region lookup fails (logged as warning, request continues)
+ */
+export async function detectMisrouting(
+  orgId: string | undefined,
+  requestId: string,
+): Promise<MisroutingResult | null> {
+  if (!orgId) return null;
+
+  const apiRegion = getApiRegion();
+  if (!apiRegion) return null;
+
+  // Check cache first, then DB
+  let workspaceRegion = getCachedRegion(orgId);
+  if (workspaceRegion === undefined) {
+    try {
+      const { getWorkspaceRegion } = await import("@atlas/api/lib/db/internal");
+      workspaceRegion = await getWorkspaceRegion(orgId);
+      setCachedRegion(orgId, workspaceRegion);
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err), requestId, orgId },
+        "Failed to look up workspace region — skipping misrouting check",
+      );
+      return null;
+    }
+  }
+
+  // No region assigned → skip (new workspace, not yet assigned)
+  if (!workspaceRegion) return null;
+
+  // Region matches → all good
+  if (workspaceRegion === apiRegion) return null;
+
+  // Mismatch detected
+  misroutedCount++;
+
+  const config = getConfig();
+  const correctApiUrl = config?.residency?.regions[workspaceRegion]?.apiUrl;
+
+  log.warn(
+    {
+      requestId,
+      orgId,
+      expectedRegion: workspaceRegion,
+      actualRegion: apiRegion,
+      correctApiUrl,
+    },
+    "Misrouted request — workspace assigned to different region",
+  );
+
+  return {
+    expectedRegion: workspaceRegion,
+    actualRegion: apiRegion,
+    ...(correctApiUrl ? { correctApiUrl } : {}),
+  };
+}


### PR DESCRIPTION
## Summary

Closes #1153. Implements misrouting detection middleware for multi-region Atlas deployments.

- **API region identity** — `ATLAS_API_REGION` env var (or `residency.defaultRegion` fallback) identifies each instance's region
- **Middleware** — after auth, compares workspace's assigned region with the serving instance. Integrated into `standardAuth`, `adminAuth`, and `platformAdminAuth`
- **Graceful mode** (default) — logs warning with full context (requestId, orgId, expectedRegion, actualRegion), serves the request
- **Strict mode** — `ATLAS_STRICT_ROUTING=true` or `residency.strictRouting: true` returns `421 Misdirected Request` with `correctApiUrl` hint
- **Health endpoint** — adds `region` and `misroutedRequests` fields
- **In-memory region cache** (60s TTL) avoids per-request DB lookups
- **Self-hosted compatible** — check is skipped entirely when no region is configured

## Test plan

- [x] 19 unit tests: correct region → no warning, wrong region → warning + counter, strict mode → 421, no region → skip, unauthenticated → skip, cache behavior, DB failure graceful handling
- [x] Existing residency tests pass (migrate.test.ts)
- [x] All CI gates: lint, type, test, syncpack, template drift