### PR TITLE
fix: address 3 pre-launch smoke test bugs (#1163, #1164, #1165)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -60,6 +60,7 @@ Each service points to its `railway.json` via the Railway dashboard. Key env var
 - `BETTER_AUTH_SECRET` — min 32 chars
 - `BETTER_AUTH_TRUSTED_ORIGINS=https://app.useatlas.dev`
 - `ATLAS_SANDBOX_URL` — Internal sidecar URL
+- `ATLAS_API_REGION` — Region identity for this instance (e.g. `us-east`). Required for multi-region deployments. Each regional API service (api, api-eu, api-apac) must set this so the health endpoint reports its region and misrouting detection works correctly
 
 ### Web service (`app.useatlas.dev`)
 

--- a/packages/web/src/app/admin/branding/page.tsx
+++ b/packages/web/src/app/admin/branding/page.tsx
@@ -8,6 +8,7 @@ import { Paintbrush, Loader2, RotateCcw, Eye } from "lucide-react";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
+import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
@@ -114,6 +115,7 @@ export default function BrandingPage() {
         </p>
       </div>
 
+      <ErrorBoundary>
       <AdminContentWrapper
         loading={loading}
         error={error}
@@ -295,6 +297,7 @@ export default function BrandingPage() {
           </Card>
         </>
       </AdminContentWrapper>
+      </ErrorBoundary>
     </div>
   );
 }

--- a/packages/web/src/app/signup/connect/page.tsx
+++ b/packages/web/src/app/signup/connect/page.tsx
@@ -64,13 +64,18 @@ export default function ConnectPage() {
   // Check if a default datasource is available (for "Try demo data" option)
   useEffect(() => {
     fetch(`${getApiBase()}/api/health`, { credentials: getCredentials() })
-      .then((res) => res.json())
+      .then((res) => {
+        if (!res.ok) throw new Error(`Health check returned ${res.status}`);
+        return res.json();
+      })
       .then((data) => {
         if (data?.checks?.datasource?.status === "ok") {
           setDemoAvailable(true);
         }
       })
-      .catch(() => { /* health check failed — demo option won't show */ });
+      .catch((err) => {
+        console.debug("[signup/connect] health check failed:", err instanceof Error ? err.message : String(err));
+      });
   }, []);
 
   async function handleTest() {


### PR DESCRIPTION
## Summary
Fixes the 3 bugs discovered during the pre-launch smoke test (#1161):

- **#1163 — US region missing `region` field**: Documented `ATLAS_API_REGION` as required in `deploy/README.md`. The US Railway instance needs this env var set (e.g. `us-east`) so the health endpoint reports its region and misrouting detection works for all 3 regions
- **#1164 — Admin branding page missing ErrorBoundary**: Added `<ErrorBoundary>` wrapper around the branding page content, matching the pattern used by all other 37 admin pages
- **#1165 — Signup health check silently swallows errors**: Added `res.ok` check before calling `.json()` (prevents parse errors on non-200 responses) and replaced the empty `.catch(() => {})` with `console.debug` logging

## Test plan
- [x] CI gates: lint, type, test, syncpack, template drift — all pass
- [x] Branding page still renders correctly (ErrorBoundary is transparent when no error)
- [x] Signup connect page health check behavior unchanged for happy path

Closes #1163, closes #1164, closes #1165