### PR TITLE
docs: fix all findings from docs audit + health check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -147,6 +147,9 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # === Multi-Tenancy ===
 # ATLAS_ORG_ID=                               # CLI-only: org-scoped semantic layer selection (reads/writes semantic/.orgs/{orgId}/)
 
+# === Settings ===
+# ATLAS_SETTINGS_REFRESH_INTERVAL=30000       # Hot-reload interval for settings in ms (default: 30s). Set 0 to disable
+
 # === Scheduler ===
 # ATLAS_SCHEDULER_ENABLED=false               # Enable scheduled task execution
 # ATLAS_SCHEDULER_SECRET=                     # Shared secret for the /tick endpoint (non-Vercel)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,8 +145,9 @@ POST /api/v1/chat → authenticateRequest → checkRateLimit → withRequestCont
     → streamText (AI SDK, ToolRegistry, stopWhen: stepCountIs(getAgentMaxSteps()))
         ├── explore → read semantic/*.yml (path-traversal protected)
         └── executeSQL → validate (4 layers) → query via ConnectionRegistry → { columns, rows }
-    → runHandler(c, ...) → RequestContext + AuthContext provided via Effect bridge
     → Data Stream Response → Chat UI
+
+Other routes use: runHandler(c, ...) → RequestContext + AuthContext provided via Effect bridge
 ```
 
 `runAgentEffect` yields `AtlasAiModel` from Effect Context — testable with mock LLM via `createAiModelTestLayer()`.

--- a/apps/docs/content/docs/guides/onboarding-emails.mdx
+++ b/apps/docs/content/docs/guides/onboarding-emails.mdx
@@ -62,7 +62,7 @@ Admins can view onboarding email status for their organization via the admin API
 - **List statuses** — `GET /api/v1/admin/onboarding-emails` returns per-user progress (sent steps, pending steps, unsubscribe status)
 - **View sequence** — `GET /api/v1/admin/onboarding-emails/sequence` returns the configured sequence steps with triggers and timing
 
-See the [API Reference](/api-reference/admin-onboarding-emails) for full endpoint documentation.
+See the [API Reference](/docs/api-reference/admin-onboarding-emails/getAdminOnboardingEmails) for full endpoint documentation.
 
 ---
 

--- a/apps/docs/content/docs/reference/cli.mdx
+++ b/apps/docs/content/docs/reference/cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: CLI Reference
-description: Complete reference for the Atlas CLI — init, diff, import, index, learn, query, doctor, validate, mcp, completions, and more.
+description: Complete reference for the Atlas CLI — init, diff, import, export, migrate-import, index, learn, query, doctor, validate, mcp, completions, and more.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
@@ -470,6 +470,62 @@ bun run atlas -- benchmark [options]
 | `--db <name>` | Filter to a single database |
 | `--csv` | CSV output |
 | `--resume <file>` | Resume from existing JSONL results file |
+
+## export
+
+Export workspace data to a portable migration bundle (JSON). Reads from the internal database. Used as the first step in a self-hosted → SaaS migration workflow. See [Migration guide](/guides/migration) for the full workflow.
+
+```bash
+bun run atlas -- export [options]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--output <path>` | Output file path (default: `./atlas-export-{date}.json`) |
+| `-o <path>` | Alias for `--output` |
+| `--org <orgId>` | Export data for a specific org (default: global/unscoped) |
+
+**Requires** `DATABASE_URL` to be set (reads from the internal database).
+
+**Examples:**
+
+```bash
+# Export all workspace data to a timestamped file
+bun run atlas -- export
+
+# Export to a specific file
+bun run atlas -- export --output backup.json
+
+# Export a specific organization's data
+bun run atlas -- export --org org_abc123
+```
+
+## migrate-import
+
+Import an export bundle into a hosted Atlas instance. Used for self-hosted → SaaS migration. Calls the target instance's internal migration API endpoint.
+
+```bash
+bun run atlas -- migrate-import --bundle <path> [options]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--bundle <path>` | Path to the export bundle JSON file (required) |
+| `--target <url>` | Target Atlas API URL (default: `https://app.useatlas.dev`) |
+| `--api-key <key>` | API key for the target workspace (or set `ATLAS_API_KEY`) |
+
+**Examples:**
+
+```bash
+# Import into the hosted SaaS (default target)
+bun run atlas -- migrate-import --bundle atlas-export-2026-04-02.json
+
+# Import into a self-hosted instance
+bun run atlas -- migrate-import --bundle backup.json --target https://atlas.internal.company.com
+
+# Use env var for the API key
+ATLAS_API_KEY=sk-... bun run atlas -- migrate-import --bundle backup.json
+```
 
 ## completions
 

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -459,6 +459,7 @@ Settings for multi-region deployments with per-workspace region routing. See als
 |----------|---------|-------------|
 | `ATLAS_API_REGION` | — | Region identity of this API instance (e.g. `us-west`, `eu-west`, `ap-southeast`). Used for misrouting detection. Falls back to `residency.defaultRegion` from config if unset |
 | `ATLAS_STRICT_ROUTING` | `false` | When `true`, misrouted requests receive `421 Misdirected Request` with a `correctApiUrl` hint instead of being served with a warning log |
+| `ATLAS_INTERNAL_SECRET` | — | Shared secret for cross-region service-to-service auth. Required for region migration operations. Both the source and target API instances must share the same secret |
 
 ---
 
@@ -689,6 +690,23 @@ Requires `BETTER_AUTH_SECRET` for demo token signing.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PORT` | `3001` | HTTP port for the standalone Hono API server. Most platforms (Railway, Vercel) set this automatically |
+
+---
+
+## Settings
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ATLAS_SETTINGS_REFRESH_INTERVAL` | `30000` | Hot-reload interval for settings in milliseconds (default: 30s). Controls how often the API re-reads workspace-level settings from the database. Set to `0` to disable periodic refresh |
+
+---
+
+## Status Page
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NEXT_PUBLIC_STATUS_URL` | — | External status page URL. When set, the built-in status page redirects here and the app shows incident banners from the feed |
+| `NEXT_PUBLIC_OPENSTATUS_SLUG` | — | OpenStatus status page slug for JSON feed. Used to fetch and display incident banners in the web frontend |
 
 ---
 

--- a/apps/docs/content/docs/reference/react.mdx
+++ b/apps/docs/content/docs/reference/react.mdx
@@ -405,6 +405,51 @@ function CustomWidget() {
 
 ## Utilities
 
+### setTheme
+
+Sets the theme mode globally without needing a hook. Useful for server-side rendering or setting the theme before React hydrates.
+
+```typescript
+import { setTheme } from "@useatlas/react";
+
+// Set theme before React renders (e.g. in a layout component)
+setTheme("dark");
+```
+
+#### Signature
+
+```typescript
+function setTheme(mode: ThemeMode): void
+```
+
+### buildThemeInitScript / THEME_STORAGE_KEY
+
+Server-side utilities for flicker-free theme initialization. `buildThemeInitScript` returns a `<script>` string that reads the user's stored preference from `localStorage` and applies it before the first paint. `THEME_STORAGE_KEY` is the localStorage key used for persistence.
+
+```typescript
+import { buildThemeInitScript, THEME_STORAGE_KEY } from "@useatlas/react";
+
+// In a server-rendered HTML template or Next.js layout:
+const script = buildThemeInitScript();
+// Inject `script` into <head> to prevent theme flash on page load
+
+// Read the stored theme preference directly:
+const stored = localStorage.getItem(THEME_STORAGE_KEY); // "light" | "dark" | "system" | null
+```
+
+### AtlasUIConfig
+
+The configuration object type accepted by `AtlasUIProvider`. Exported for type-safe wrapper components.
+
+```typescript
+import type { AtlasUIConfig } from "@useatlas/react";
+
+const config: AtlasUIConfig = {
+  apiUrl: "https://api.example.com",
+  authClient: myAuthClient,
+};
+```
+
 ### parseChatError
 
 Parses an AI SDK chat error into a user-friendly `ChatErrorInfo` object. Expects `error.message` to contain a JSON string with `{ error, message, retryAfterSeconds? }`. Falls back to a generic title when the body is not valid JSON (network failures, HTML error pages, etc.), preserving the original message as `detail` (truncated to 200 characters). Also classifies client-side errors (network failures, offline, HTTP status) via the `clientCode` field.

--- a/apps/docs/content/docs/reference/sdk.mdx
+++ b/apps/docs/content/docs/reference/sdk.mdx
@@ -580,7 +580,7 @@ if (result.warning) {
 ```typescript
 interface RollbackActionResponse {
   id: string;
-  status: string;
+  status: ActionStatus;
   action_type: string;
   target: string;
   summary: string;
@@ -830,6 +830,7 @@ import type {
   EntitySummary,
   SemanticStats,
   ConnectionHealth,
+  ConnectionHealthCheck, // @deprecated — alias for ConnectionHealth
   ConnectionInfo,
   ConnectionDetail,
   AuditLogEntry,
@@ -844,6 +845,7 @@ import type {
   ValidationLayer,
 
   // Actions
+  ActionStatus,
   RollbackActionResponse,
 } from "@useatlas/sdk";
 ```

--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -418,7 +418,7 @@ app.get("/api/v1/openapi.json", (c) => {
       openapi: "3.1.0",
       info: {
         title: "Atlas API",
-        version: "0.9.7",
+        version: "1.0.0",
         description:
           "Text-to-SQL data analyst agent. Ask natural-language questions about your data and receive structured answers.",
       },

--- a/packages/cli/src/completions.ts
+++ b/packages/cli/src/completions.ts
@@ -133,6 +133,22 @@ export const COMMANDS: Record<string, CommandSpec> = {
       "--resume": "Resume from existing JSONL results file",
     },
   },
+  export: {
+    description: "Export workspace data to a migration bundle",
+    flags: {
+      "--output": "Output file path (default: ./atlas-export-{date}.json)",
+      "-o": "Alias for --output",
+      "--org": "Export data for a specific org",
+    },
+  },
+  "migrate-import": {
+    description: "Import an export bundle into a hosted Atlas instance",
+    flags: {
+      "--bundle": "Path to the export bundle JSON file (required)",
+      "--target": "Target Atlas API URL (default: https://app.useatlas.dev)",
+      "--api-key": "API key for the target workspace",
+    },
+  },
   completions: {
     description: "Output shell completion script",
     flags: {},


### PR DESCRIPTION
## Summary

Fixes all findings from the `/docs-audit` (12 findings) and `/health-check` (2 findings) run on 2026-04-02.

### Docs audit fixes
- **Env vars reference** — Add 4 missing vars: `ATLAS_INTERNAL_SECRET`, `NEXT_PUBLIC_STATUS_URL`, `NEXT_PUBLIC_OPENSTATUS_SLUG`, `ATLAS_SETTINGS_REFRESH_INTERVAL`
- **CLI reference** — Document `atlas export` and `atlas migrate-import` commands (fully implemented but undocumented)
- **Shell completions** — Add `export` and `migrate-import` to `completions.ts` COMMANDS map
- **SDK reference** — Add `ConnectionHealthCheck` type alias, `ActionStatus` type, fix `RollbackActionResponse.status` type precision
- **React reference** — Document `setTheme`, `buildThemeInitScript`, `THEME_STORAGE_KEY`, `AtlasUIConfig` exports
- **Dead link** — Fix broken link in `onboarding-emails.mdx` → correct child page path
- **.env.example** — Add `ATLAS_SETTINGS_REFRESH_INTERVAL`

### Health check fixes
- **OpenAPI version** — Bump `0.9.7` → `1.0.0` in programmatic spec
- **CLAUDE.md** — Fix agent loop diagram (clarify `runHandler` is used by other routes, not the chat route)

## Test plan
- [x] `bun run lint` — passes
- [x] `bun run type` — passes

Closes #1171, closes #1172, closes #1173