### PR TITLE
fix: add export + migrate-import to completions test registry

### DIFF
--- a/packages/cli/src/__tests__/completions.test.ts
+++ b/packages/cli/src/__tests__/completions.test.ts
@@ -16,7 +16,7 @@ describe("completions", () => {
       const expected = [
         "init", "diff", "query", "doctor", "validate",
         "mcp", "learn", "migrate", "plugin", "eval", "smoke",
-        "benchmark", "completions",
+        "benchmark", "export", "migrate-import", "completions",
       ];
       for (const cmd of expected) {
         expect(allCommands).toContain(cmd);


### PR DESCRIPTION
## Summary
- CLI added `export` and `migrate-import` commands (via #875 migration tooling) but the bidirectional completions test wasn't updated
- Test expected 13 commands but found 15, breaking CI on main

## Test plan
- [x] `bun test packages/cli/src/__tests__/completions.test.ts` — 22 pass, 0 fail