### PR TITLE
refactor: consolidate useBranding into useAdminFetch

### DIFF
--- a/packages/web/src/ui/hooks/use-branding.ts
+++ b/packages/web/src/ui/hooks/use-branding.ts
@@ -1,68 +1,26 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useAtlasConfig } from "@/ui/context";
+import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import type { WorkspaceBrandingPublic } from "@/ui/lib/types";
 
 export type { WorkspaceBrandingPublic } from "@/ui/lib/types";
 
 /**
  * Fetch workspace branding from the public endpoint.
- * Each component instance fetches independently on mount.
  * Returns null while loading or if no custom branding is set.
  */
 export function useBranding() {
-  const { apiUrl, isCrossOrigin } = useAtlasConfig();
-  const [branding, setBranding] = useState<WorkspaceBrandingPublic | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
-
-  useEffect(() => {
-    const controller = new AbortController();
-
-    async function fetchBranding() {
-      try {
-        const res = await fetch(`${apiUrl}/api/v1/branding`, {
-          credentials,
-          signal: controller.signal,
-        });
-        if (!res.ok) {
-          console.warn(`useBranding: branding endpoint returned ${res.status} — falling back to defaults`);
-          if (!controller.signal.aborted) {
-            setError(`HTTP ${res.status}`);
-          }
-          return;
+  const { data, loading, error } = useAdminFetch<WorkspaceBrandingPublic | null>(
+    "/api/v1/branding",
+    {
+      transform: (json) => {
+        if (typeof json === "object" && json !== null && "branding" in json) {
+          return (json as { branding: WorkspaceBrandingPublic | null }).branding;
         }
-        const json: unknown = await res.json();
-        if (
-          typeof json === "object" &&
-          json !== null &&
-          "branding" in json
-        ) {
-          const data = (json as { branding: WorkspaceBrandingPublic | null }).branding;
-          if (!controller.signal.aborted) {
-            setBranding(data);
-          }
-        }
-      } catch (err) {
-        if (err instanceof DOMException && err.name === "AbortError") return;
-        // intentionally ignored: branding fetch failure is non-critical — use defaults
-        const msg = err instanceof Error ? err.message : String(err);
-        console.debug("useBranding: fetch failed", msg);
-        if (!controller.signal.aborted) {
-          setError(msg);
-        }
-      } finally {
-        if (!controller.signal.aborted) {
-          setLoading(false);
-        }
-      }
-    }
+        return null;
+      },
+    },
+  );
 
-    fetchBranding();
-    return () => controller.abort();
-  }, [apiUrl, credentials]);
-
-  return { branding, loading, error };
+  return { branding: data ?? null, loading, error: error?.message ?? null };
 }


### PR DESCRIPTION
## Summary
- Replaces 68-line manual fetch implementation in `useBranding` with a thin wrapper over `useAdminFetch` (-54 lines, +12 lines)
- Eliminates duplicated loading/error/abort/credentials logic
- Preserves identical return type contract (`{ branding, loading, error }`) — no consumer changes needed

## Test plan
- [x] `bun run lint` — pass
- [x] `bun run type` — pass
- [x] `bun run test` — all packages pass
- [x] `bun x syncpack lint` — no issues
- [x] Template drift check — 343 files verified

Closes #1209