### PR TITLE
docs: fix env var table, config callout, CLI help alignment

### DIFF
--- a/apps/docs/content/docs/reference/config.mdx
+++ b/apps/docs/content/docs/reference/config.mdx
@@ -688,8 +688,15 @@ Module matching operates on **top-level package names** only (the first componen
 | `blockedModules` | `string[]` | No | `[]` | Additional modules to add to the default blocked list |
 | `allowModules` | `string[]` | No | `[]` | Modules to remove from the default blocked list |
 
-<Callout type="warn">
-Critical modules (`os`, `subprocess`, `sys`, `shutil`) **cannot be unblocked** — Atlas rejects the config at startup if they appear in `allowModules`. These provide direct OS/process access that no configuration should override.
+<Callout type="error" title="Critical modules are always blocked">
+The following modules are **always blocked** regardless of `blockedModules` or `allowModules` configuration — Atlas rejects the config at startup if any appear in `allowModules`:
+
+- `os` — filesystem and environment access
+- `subprocess` — arbitrary process execution
+- `sys` — interpreter internals and `sys.modules` manipulation
+- `shutil` — high-level file operations (copy, move, delete trees)
+
+These are enforced by the `PYTHON_CRITICAL_MODULES` list in `packages/api/src/lib/config.ts` and the runtime `CRITICAL_MODULES` set in `packages/api/src/lib/tools/python.ts`. No configuration — including `allowModules` — can override this.
 </Callout>
 
 ### Default blocked modules

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -40,6 +40,12 @@ LLM provider and model configuration.
 | `OLLAMA_BASE_URL` | `http://localhost:11434/v1` | Ollama server URL. Only used when `ATLAS_PROVIDER=ollama` |
 | `OPENAI_COMPATIBLE_BASE_URL` | — | Base URL for OpenAI-compatible servers (vLLM, TGI, LiteLLM). **Required** when `ATLAS_PROVIDER=openai-compatible` |
 | `OPENAI_COMPATIBLE_API_KEY` | `not-needed` | API key for OpenAI-compatible servers. Most local servers don't require one |
+| `ANTHROPIC_API_KEY` | — | API key for `anthropic` provider |
+| `OPENAI_API_KEY` | — | API key for `openai` provider |
+| `AWS_ACCESS_KEY_ID` | — | AWS access key ID for `bedrock` provider |
+| `AWS_SECRET_ACCESS_KEY` | — | AWS secret access key for `bedrock` provider |
+| `AWS_REGION` | — | AWS region for `bedrock` provider (e.g. `us-east-1`) |
+| `AI_GATEWAY_API_KEY` | — | API key for `gateway` provider (Vercel AI Gateway) |
 
 When `ATLAS_PROVIDER` is not set, the default depends on the runtime environment. On Vercel (detected via the platform-set `VERCEL` env var), the default is `gateway`. Everywhere else, the default is `anthropic`.
 

--- a/packages/cli/lib/help.ts
+++ b/packages/cli/lib/help.ts
@@ -271,7 +271,7 @@ export const SUBCOMMAND_HELP: Record<string, SubcommandHelp> = {
       {
         flag: "--suggestions",
         description:
-          "Generate query suggestions from the audit log",
+          "Generate query suggestions from the audit log (stored in the query_suggestions table). Can be combined with --apply, --since, --limit, and --source",
       },
       {
         flag: "--limit <n>",


### PR DESCRIPTION
## Summary

- **Add provider API key vars to env var reference table** — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, and `AI_GATEWAY_API_KEY` were documented in the per-provider tabs but missing from the main LLM Provider reference table in `environment-variables.mdx`
- **Upgrade Python critical modules callout** — Replace the brief `warn` callout in `config.mdx` with a detailed `error` callout listing all four critical modules (`os`, `subprocess`, `sys`, `shutil`) with descriptions and source file references
- **Align CLI help with docs** — Update the `--suggestions` flag description in `help.ts` to mention `query_suggestions` table storage and flag combinability, matching the fuller description in `cli.mdx`

## Test plan

- [ ] Verify env var reference table renders correctly with the six new rows
- [ ] Verify the error callout renders with the bulleted module list in the Python Import Guard section
- [ ] Run `bun run atlas -- learn --help` and confirm the updated `--suggestions` description appears