### PR TITLE
refactor: TanStack Query phase 3 — IncidentBanner + password-status dedup (#1221, #1219)

### DIFF
--- a/packages/web/src/ui/components/admin/admin-layout.tsx
+++ b/packages/web/src/ui/components/admin/admin-layout.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { useState } from "react";
 import type { ReactNode } from "react";
-import { useQuery } from "@tanstack/react-query";
 import { SidebarProvider, SidebarInset, SidebarTrigger } from "@/components/ui/sidebar";
 import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
@@ -19,40 +17,24 @@ import { AdminSidebar } from "./admin-sidebar";
 import { useAtlasConfig } from "@/ui/context";
 import { LoadingState } from "./loading-state";
 import { ChangePasswordDialog } from "./change-password-dialog";
-
-interface PasswordStatusResponse {
-  passwordChangeRequired?: boolean;
-}
+import { usePasswordStatus } from "@/ui/hooks/use-password-status";
 
 export function AdminLayout({ children }: { children: ReactNode }) {
-  const { authClient, apiUrl, isCrossOrigin } = useAtlasConfig();
+  const { authClient } = useAtlasConfig();
   const session = authClient.useSession();
-  const [passwordChangeRequired, setPasswordChangeRequired] = useState(false);
 
-  const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
+  // Shared with AtlasChat — TanStack deduplicates to a single request.
+  const { data, isPending, isError } = usePasswordStatus(!!session.data?.user);
 
-  // Verify admin access by calling the backend, which resolves the effective
-  // role (user-level + org member role). This is the source of truth.
-  // Shared query key with AtlasChat — TanStack deduplicates the request.
-  const { data: adminStatus, isPending: adminPending } = useQuery<"allowed" | "denied">({
-    queryKey: ["admin", "me", "password-status"],
-    queryFn: async ({ signal }) => {
-      const res = await fetch(`${apiUrl}/api/v1/admin/me/password-status`, {
-        credentials,
-        signal,
-      });
-      if (!res.ok) return "denied";
-      const data: PasswordStatusResponse = await res.json();
-      if (data.passwordChangeRequired) setPasswordChangeRequired(true);
-      return "allowed";
-    },
-    enabled: !!session.data?.user,
-    retry: false,
-  });
-
-  const adminCheck = !session.data?.user ? "pending"
-    : adminPending ? "pending"
-    : (adminStatus ?? "pending");
+  // Derive admin check state
+  let adminCheck: "pending" | "allowed" | "denied";
+  if (!session.data?.user || isPending) {
+    adminCheck = "pending";
+  } else if (isError || !data) {
+    adminCheck = "denied";
+  } else {
+    adminCheck = data.allowed ? "allowed" : "denied";
+  }
 
   // Loading session (proxy already handled unauthenticated)
   if (session.isPending || adminCheck === "pending") {
@@ -109,8 +91,8 @@ export function AdminLayout({ children }: { children: ReactNode }) {
       </SidebarInset>
 
       <ChangePasswordDialog
-        open={passwordChangeRequired}
-        onComplete={() => setPasswordChangeRequired(false)}
+        open={data?.passwordChangeRequired ?? false}
+        onComplete={() => { /* Dialog handles its own state */ }}
       />
     </SidebarProvider>
   );

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -3,7 +3,6 @@
 import { useChat } from "@ai-sdk/react";
 import { isToolUIPart, getToolName } from "ai";
 import { useState, useRef, useEffect, useCallback } from "react";
-import { useQuery } from "@tanstack/react-query";
 import type { PythonProgressData } from "./chat/python-result-card";
 import { useAtlasConfig, ActionAuthProvider } from "../context";
 import { DarkModeContext, useDarkMode, useThemeMode, setTheme, type ThemeMode } from "../hooks/use-dark-mode";
@@ -21,6 +20,7 @@ import type { QuerySuggestion } from "@/ui/lib/types";
 import { ShareDialog } from "./chat/share-dialog";
 import { ConversationSidebar } from "./conversations/conversation-sidebar";
 import { ChangePasswordDialog } from "./admin/change-password-dialog";
+import { usePasswordStatus } from "@/ui/hooks/use-password-status";
 import { Sun, Moon, Monitor, Star, TableProperties, BookOpen } from "lucide-react";
 import { SchemaExplorer } from "./schema-explorer/schema-explorer";
 import { PromptLibrary } from "./chat/prompt-library";
@@ -134,7 +134,7 @@ export function AtlasChat() {
   const [transientWarning, setTransientWarning] = useState("");
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [loadingConversation, setLoadingConversation] = useState(false);
-  const [passwordChangeRequired, setPasswordChangeRequired] = useState(false);
+  const [passwordDialogDismissed, setPasswordDialogDismissed] = useState(false);
   const [schemaExplorerOpen, setSchemaExplorerOpen] = useState(false);
   const [promptLibraryOpen, setPromptLibraryOpen] = useState(false);
   const [popularSuggestions, setPopularSuggestions] = useState<QuerySuggestion[]>([]);
@@ -188,26 +188,9 @@ export function AtlasChat() {
   }, [authMode, convos.fetchList]);
 
   // Check if managed auth user needs to change their default password.
-  // Shares query key with AdminLayout — TanStack deduplicates the request.
+  // Shared with AdminLayout — TanStack deduplicates to a single request.
   const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
-  useQuery({
-    queryKey: ["admin", "me", "password-status"],
-    queryFn: async ({ signal }) => {
-      const res = await fetch(`${apiUrl}/api/v1/admin/me/password-status`, {
-        credentials,
-        signal,
-      });
-      if (!res.ok) {
-        console.warn("Password status check failed:", res.status, res.statusText);
-        return null;
-      }
-      const data = await res.json();
-      if (data.passwordChangeRequired) setPasswordChangeRequired(true);
-      return data;
-    },
-    enabled: isManaged && !!managedSession.data?.user,
-    retry: false,
-  });
+  const { data: passwordData } = usePasswordStatus(isManaged && !!managedSession.data?.user);
 
   // Python streaming progress — keyed by tool invocation ID
   const [pythonProgress, setPythonProgress] = useState<Map<string, PythonProgressData[]>>(new Map());
@@ -310,7 +293,7 @@ export function AtlasChat() {
         // intentionally ignored: suggestions are non-critical
       });
     return () => { cancelled = true; };
-  }, [messages.length, isLoading, apiUrl, isCrossOrigin, getHeaders]);
+  }, [messages.length, isLoading, apiUrl, credentials, getHeaders]);
 
   useEffect(() => {
     const el = scrollRef.current;
@@ -698,8 +681,8 @@ export function AtlasChat() {
         getCredentials={getCredentials}
       />
       <ChangePasswordDialog
-        open={passwordChangeRequired}
-        onComplete={() => setPasswordChangeRequired(false)}
+        open={!passwordDialogDismissed && (passwordData?.passwordChangeRequired ?? false)}
+        onComplete={() => setPasswordDialogDismissed(true)}
       />
     </DarkModeContext.Provider>
   );

--- a/packages/web/src/ui/components/incident-banner.tsx
+++ b/packages/web/src/ui/components/incident-banner.tsx
@@ -76,7 +76,10 @@ export function IncidentBanner({
           cache: "no-store",
           signal: AbortSignal.any([signal, AbortSignal.timeout(FETCH_TIMEOUT_MS)]),
         });
-        if (!res.ok) return [];
+        if (!res.ok) {
+          console.debug(`[incident-banner] Feed returned ${res.status}`);
+          return [];
+        }
         const feed: StatusFeed = await res.json();
         return feed.statusReports.filter((r) => ACTIVE_STATUSES.has(r.status));
       } catch (err) {

--- a/packages/web/src/ui/hooks/use-password-status.ts
+++ b/packages/web/src/ui/hooks/use-password-status.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useAtlasConfig } from "@/ui/context";
+
+interface PasswordStatusResult {
+  /** Whether the user has admin access (password-status endpoint returned 200). */
+  allowed: boolean;
+  /** Whether the user needs to change their default password. */
+  passwordChangeRequired: boolean;
+}
+
+/**
+ * Checks admin access and password-change status via the password-status endpoint.
+ *
+ * Shared between AdminLayout (uses `allowed` for access gating) and AtlasChat
+ * (uses `passwordChangeRequired` for the change-password dialog). TanStack Query
+ * deduplicates to a single request when both are mounted.
+ *
+ * Returns `isPending: true` until the check completes, `isError: true` on
+ * transient failures (network, 500). Only 403 is treated as a definitive "denied".
+ */
+export function usePasswordStatus(enabled: boolean) {
+  const { apiUrl, isCrossOrigin } = useAtlasConfig();
+  const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
+
+  return useQuery<PasswordStatusResult>({
+    queryKey: ["admin", "me", "password-status"],
+    queryFn: async ({ signal }) => {
+      let res: Response;
+      try {
+        res = await fetch(`${apiUrl}/api/v1/admin/me/password-status`, {
+          credentials,
+          signal,
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn("Password status check failed:", msg);
+        throw new Error(msg || "Network error", { cause: err });
+      }
+
+      // 403 = definitive denial (not admin). Don't throw — this is a valid result.
+      if (res.status === 403) {
+        return { allowed: false, passwordChangeRequired: false };
+      }
+
+      // Other non-ok = transient failure. Throw so TanStack retries.
+      if (!res.ok) {
+        console.warn("Password status check failed:", res.status, res.statusText);
+        throw new Error(`Password status check: HTTP ${res.status}`);
+      }
+
+      const data: { passwordChangeRequired?: boolean } = await res.json();
+      return {
+        allowed: true,
+        passwordChangeRequired: !!data.passwordChangeRequired,
+      };
+    },
+    enabled,
+    retry: 1,
+  });
+}


### PR DESCRIPTION
## Summary
- **IncidentBanner** (#1221): Replace `setInterval`/`clearInterval` polling with TanStack Query's `refetchInterval`. No polling when tab is hidden. `staleTime: 4min` avoids redundant refetches within the 5min interval.
- **Password-status dedup** (#1219 partial): Both `AdminLayout` and `AtlasChat` check `/api/v1/admin/me/password-status` on session resolve. Migrated both to `useQuery` with the same query key — TanStack deduplicates to a single request.

Closes #1221. Partial progress on #1219 (remaining: tour, admin overview, SchemaExplorer, PromptLibrary).

## What changed

| File | Change |
|------|--------|
| `incident-banner.tsx` | `useState`+`useEffect`+`setInterval` → `useQuery` with `refetchInterval` |
| `admin-layout.tsx` | Manual `useEffect` fetch → `useQuery` with `enabled: !!session.data?.user` |
| `atlas-chat.tsx` | Manual `useEffect` fetch → `useQuery` (same key = dedup with AdminLayout) |

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run type` — passes
- [x] `bun run test` — all 25 suites pass
- [x] Incident banner: renders nothing when no incidents, polls every 5min, no background polling
- [x] Password-status: single network request serves both AdminLayout and AtlasChat