### PR TITLE
refactor: TanStack Query — migrate SchemaExplorer, PromptLibrary, EntityEditor (#1220)

### DIFF
--- a/packages/web/src/ui/components/admin/entity-editor-dialog.tsx
+++ b/packages/web/src/ui/components/admin/entity-editor-dialog.tsx
@@ -735,8 +735,14 @@ function useColumnMetadata(tableName: string, isSaas: boolean, dialogOpen: boole
   const { apiUrl, isCrossOrigin } = useAtlasConfig();
   const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
 
-  // Debounce table name to avoid fetching on every keystroke
+  // Debounce table name to avoid fetching on every keystroke.
+  // Sync immediately on dialog open to avoid stale query from previous entity.
   const [debouncedTable, setDebouncedTable] = useState(tableName);
+  useEffect(() => {
+    if (dialogOpen) {
+      setDebouncedTable(tableName);
+    }
+  }, [dialogOpen, tableName]);
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedTable(tableName), 300);
     return () => clearTimeout(timer);

--- a/packages/web/src/ui/components/chat/prompt-library.tsx
+++ b/packages/web/src/ui/components/chat/prompt-library.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useAtlasConfig } from "../../context";
 import {
@@ -70,7 +70,7 @@ export function PromptLibrary({
               signal,
             });
             if (!itemRes.ok) {
-              console.debug(`Failed to fetch items for collection ${col.id}: HTTP ${itemRes.status}`);
+              console.warn(`Failed to fetch items for collection ${col.id}: HTTP ${itemRes.status}`);
               return { ...col, items: [] as PromptItem[] };
             }
             const itemData = await itemRes.json();
@@ -83,7 +83,13 @@ export function PromptLibrary({
       );
     },
     enabled: open,
+    retry: false,
   });
+
+  // Log query errors for developer observability.
+  useEffect(() => {
+    if (queryError) console.warn("Prompt library: failed to load:", queryError);
+  }, [queryError]);
 
   const error = queryError ? (queryError instanceof Error ? queryError.message : "Failed to load prompt library") : null;
 

--- a/packages/web/src/ui/components/schema-explorer/schema-explorer.tsx
+++ b/packages/web/src/ui/components/schema-explorer/schema-explorer.tsx
@@ -390,9 +390,11 @@ export function SchemaExplorer({
       return Array.isArray(data?.entities) ? data.entities : [];
     },
     enabled: open,
+    retry: false,
   });
 
   // Fetch entity detail when one is selected. Auto-cancels on selection change.
+  // staleTime: 0 ensures fresh data on every selection (matches old behavior).
   const entityDetail = useQuery<SemanticEntityDetail>({
     queryKey: ["semantic", "entities", selectedName],
     queryFn: async ({ signal }) => {
@@ -406,12 +408,22 @@ export function SchemaExplorer({
       return data?.entity ?? data;
     },
     enabled: !!selectedName,
+    staleTime: 0,
+    retry: false,
   });
 
   // Reset to list view on every open — prevents stale detail view on reopen
   useEffect(() => {
     if (open) setSelectedName(null);
   }, [open]);
+
+  // Log query errors for developer observability (TanStack catches internally).
+  useEffect(() => {
+    if (entityList.error) console.warn("Schema explorer: failed to fetch entities:", entityList.error);
+  }, [entityList.error]);
+  useEffect(() => {
+    if (entityDetail.error) console.warn("Schema explorer: failed to load entity:", entityDetail.error);
+  }, [entityDetail.error]);
 
   // Derive state from queries for the existing UI
   const entities = entityList.data ?? [];


### PR DESCRIPTION
## Summary
Migrate three component-level fetch patterns to TanStack Query, eliminating manual AbortController management, `cancelled` flags, and redundant state:

- **SchemaExplorer**: Entity list + detail fetches → `useQuery` with `enabled` flags. Removes 5 `useState`, 1 `useRef` (abortRef). TanStack auto-cancels on key change and sheet close.
- **PromptLibrary**: Collections + items fetch → `useQuery` with `enabled: open`. TanStack cache replaces manual `fetched` boolean. Retry button uses `query.refetch()`.
- **EntityEditorDialog**: Column metadata → `useQuery` with debounced table name. 404 modeled as `TableNotFoundError` for clean state derivation. 300ms debounce preserved via `useState`+`useEffect`.

**-65 net lines** (123 added, 188 removed).

Closes #1220.

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run type` — passes
- [x] `bun run test` — all 25 suites pass
- [x] SchemaExplorer: opens, lists entities, shows detail on click, back button works
- [x] PromptLibrary: opens, loads collections+items, search filters, retry works
- [x] EntityEditorDialog: column autocomplete fires after 300ms, 404 shows "table not found"