### PR TITLE
fix: TanStack react polish — health recovery + stable fetchList

### DIFF
--- a/packages/react/src/components/atlas-chat.tsx
+++ b/packages/react/src/components/atlas-chat.tsx
@@ -285,7 +285,11 @@ function AtlasChatInner({
   const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
 
   // Sync health error + brand color as side effects.
+  // Clears warning on recovery (e.g. window-focus refetch succeeds after initial failure).
   useEffect(() => {
+    if (healthQuery.data) {
+      setHealthWarning("");
+    }
     if (healthQuery.isError) {
       setHealthWarning("Unable to reach the API server. Try refreshing the page.");
     }

--- a/packages/react/src/hooks/use-conversations.ts
+++ b/packages/react/src/hooks/use-conversations.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { Conversation, ConversationWithMessages, Message } from "../lib/types";
 import type { UIMessage } from "@ai-sdk/react";
@@ -106,11 +106,15 @@ export function useConversations(opts: UseConversationsOptions): UseConversation
     ? (listQuery.error instanceof Error ? listQuery.error.message : "Failed to load conversations")
     : null;
 
+  // Stable ref for refetch — listQuery.refetch changes identity each render.
+  const refetchRef = useRef(listQuery.refetch);
+  refetchRef.current = listQuery.refetch;
+
   const fetchList = useCallback(async () => {
     if (!opts.enabled || !available) return;
-    const result = await listQuery.refetch();
+    const result = await refetchRef.current();
     if (result.error) throw result.error;
-  }, [opts.enabled, available, listQuery.refetch]);
+  }, [opts.enabled, available]);
 
   const loadConversation = useCallback(async (id: string): Promise<UIMessage[]> => {
     const res = await fetch(`${opts.apiUrl}${baseEndpoint}/${id}`, {


### PR DESCRIPTION
Follow-up to #1244. Fixes two issues from the code review:

1. **Health warning not cleared on recovery**: When the health check fails initially but succeeds on a window-focus refetch, the warning banner persisted. Now `setHealthWarning("")` runs when `healthQuery.data` arrives.

2. **Unstable fetchList reference**: `listQuery.refetch` changes identity each render, causing `fetchList` to change too, which re-fired the `useEffect` in `AtlasChatInner` continuously. Fixed via `refetchRef` pattern.

## Test plan
- [x] All 25 test suites pass
- [x] Lint + type clean