### PR TITLE
refactor: replace remaining setInterval calls with Effect Schedule fibers

### DIFF
--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -528,7 +528,8 @@ export function createApiTestMocks(
     recordQueryEvent: mock(() => {}),
     restoreAbuseState: mock(async () => {}),
     _resetAbuseState: mock(() => {}),
-    _stopCleanup: mock(() => {}),
+    abuseCleanupTick: mock(() => {}),
+    ABUSE_CLEANUP_INTERVAL_MS: 300_000,
   }));
 
   // ── Role helper functions ─────────────────────────────────────

--- a/packages/api/src/__tests__/demo.test.ts
+++ b/packages/api/src/__tests__/demo.test.ts
@@ -8,13 +8,7 @@ import {
   getDemoMaxSteps,
   getDemoRpmLimit,
   isDemoEnabled,
-  _stopDemoCleanup,
 } from "@atlas/api/lib/demo";
-
-// Stop cleanup timer to prevent test runner from hanging
-afterAll(() => {
-  _stopDemoCleanup();
-});
 
 describe("isDemoEnabled", () => {
   const original = process.env.ATLAS_DEMO_ENABLED;

--- a/packages/api/src/api/__tests__/admin-abuse.test.ts
+++ b/packages/api/src/api/__tests__/admin-abuse.test.ts
@@ -41,7 +41,8 @@ mock.module("@atlas/api/lib/security/abuse", () => ({
   recordQueryEvent: mock(() => {}),
   restoreAbuseState: mock(async () => {}),
   _resetAbuseState: mock(() => {}),
-  _stopCleanup: mock(() => {}),
+  abuseCleanupTick: mock(() => {}),
+  ABUSE_CLEANUP_INTERVAL_MS: 300_000,
 }));
 
 // --- Import app after mocks ---

--- a/packages/api/src/api/routes/conversations.ts
+++ b/packages/api/src/api/routes/conversations.ts
@@ -940,23 +940,31 @@ const PUBLIC_RATE_MAX = 60;
 
 const publicRateMap = new Map<string, { count: number; resetAt: number }>();
 
-/** Evict expired entries to prevent unbounded growth. Runs periodically. */
-function sweepPublicRateMap() {
+/**
+ * Evict expired entries to prevent unbounded growth. Called periodically
+ * by the SchedulerLayer fiber in lib/effect/layers.ts.
+ */
+export function conversationRateSweepTick(): void {
   const now = Date.now();
   for (const [key, entry] of publicRateMap) {
     if (now > entry.resetAt) publicRateMap.delete(key);
   }
 }
 
-// Sweep every 60 seconds
-const _sweepInterval = setInterval(sweepPublicRateMap, PUBLIC_RATE_WINDOW_MS);
-// Don't prevent process exit
-if (typeof _sweepInterval === "object" && "unref" in _sweepInterval) _sweepInterval.unref();
+/** Interval for conversation rate sweep. Exported for SchedulerLayer. */
+export const CONVERSATION_RATE_SWEEP_INTERVAL_MS = PUBLIC_RATE_WINDOW_MS;
 
-// Clean up expired share tokens every 60 minutes
-const SHARE_CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
+/** Interval for share token cleanup. Exported for SchedulerLayer. */
+export const SHARE_CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
+
 let shareCleanupConsecutiveFailures = 0;
-const _shareCleanupInterval = setInterval(async () => {
+
+/**
+ * Clean up expired share tokens. Called periodically by the SchedulerLayer
+ * fiber in lib/effect/layers.ts. Tracks consecutive failures and logs when
+ * they reach 5.
+ */
+export async function shareCleanupTick(): Promise<void> {
   try {
     const count = await cleanupExpiredShares();
     if (count >= 0) {
@@ -970,11 +978,11 @@ const _shareCleanupInterval = setInterval(async () => {
     }
   } catch (err) {
     shareCleanupConsecutiveFailures++;
-    log.error({ err: err instanceof Error ? err.message : String(err) },
-      "Unexpected error in share cleanup interval");
+    log.error({ err: err instanceof Error ? err.message : String(err), consecutiveFailures: shareCleanupConsecutiveFailures },
+      "Unexpected error in share cleanup tick");
+    throw err; // re-throw so Effect.catchAll in layers.ts also logs it
   }
-}, SHARE_CLEANUP_INTERVAL_MS);
-if (typeof _shareCleanupInterval === "object" && "unref" in _shareCleanupInterval) _shareCleanupInterval.unref();
+}
 
 function checkPublicRateLimit(ip: string): boolean {
   const now = Date.now();

--- a/packages/api/src/api/routes/dashboards.ts
+++ b/packages/api/src/api/routes/dashboards.ts
@@ -128,13 +128,19 @@ const PUBLIC_RATE_WINDOW_MS = 60_000;
 const PUBLIC_RATE_MAX = 30;
 const publicRateMap = new Map<string, { count: number; resetAt: number }>();
 
-const _cleanupInterval = setInterval(() => {
+/** Interval for dashboard rate-limit cleanup. Exported for SchedulerLayer. */
+export const DASHBOARD_RATE_CLEANUP_INTERVAL_MS = 60_000;
+
+/**
+ * Evict expired dashboard rate-limit entries. Called periodically by the
+ * SchedulerLayer fiber in lib/effect/layers.ts.
+ */
+export function dashboardRateLimitCleanupTick(): void {
   const now = Date.now();
   for (const [key, entry] of publicRateMap) {
     if (now > entry.resetAt) publicRateMap.delete(key);
   }
-}, 60_000);
-if (typeof _cleanupInterval === "object" && "unref" in _cleanupInterval) _cleanupInterval.unref();
+}
 
 function checkPublicRateLimit(ip: string): boolean {
   const now = Date.now();

--- a/packages/api/src/lib/demo.ts
+++ b/packages/api/src/lib/demo.ts
@@ -212,27 +212,20 @@ export function resetDemoRateLimits(): void {
   demoWindows.clear();
 }
 
-// Periodic cleanup — evict keys with no recent timestamps
-const demoCleanupInterval = setInterval(() => {
-  try {
-    const cutoff = Date.now() - WINDOW_MS;
-    for (const [key, timestamps] of demoWindows) {
-      if (timestamps.length === 0 || timestamps[timestamps.length - 1] <= cutoff) {
-        demoWindows.delete(key);
-      }
-    }
-  } catch (err) {
-    log.error(
-      { err: err instanceof Error ? err : new Error(String(err)) },
-      "Demo rate limit cleanup failed",
-    );
-  }
-}, WINDOW_MS);
-demoCleanupInterval.unref();
+/** Interval for demo rate-limit cleanup. Exported for SchedulerLayer. */
+export const DEMO_CLEANUP_INTERVAL_MS = WINDOW_MS;
 
-/** Stop the demo cleanup timer. For tests. */
-export function _stopDemoCleanup(): void {
-  clearInterval(demoCleanupInterval);
+/**
+ * Evict stale demo rate-limit entries. Called periodically by the
+ * SchedulerLayer fiber in lib/effect/layers.ts.
+ */
+export function demoCleanupTick(): void {
+  const cutoff = Date.now() - WINDOW_MS;
+  for (const [key, timestamps] of demoWindows) {
+    if (timestamps.length === 0 || timestamps[timestamps.length - 1] <= cutoff) {
+      demoWindows.delete(key);
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -27,8 +27,9 @@
  * MigrationLayer which depends on InternalDB).
  *
  * SettingsLive and SchedulerLayer fork long-lived periodic fibers
- * (settings refresh, OAuth cleanup, rate-limit cleanup, email scheduler)
- * that are interrupted when their Layer scope closes.
+ * (settings refresh, OAuth cleanup, rate-limit cleanup, email scheduler,
+ * demo cleanup, abuse cleanup, dashboard/conversation rate sweeps,
+ * share token cleanup) that are interrupted when their Layer scope closes.
  */
 
 import { Context, Duration, Effect, Fiber, Layer, Schedule } from "effect";
@@ -350,8 +351,10 @@ export class Scheduler extends Context.Tag("Scheduler")<
 
 /**
  * Create a Scheduler layer that reads the config to decide which backend
- * to start. Periodic cleanup fibers (OAuth state, rate-limit, email) are
- * forked and automatically interrupted when the Layer scope closes.
+ * to start. Periodic cleanup fibers (OAuth state, rate-limit, email, demo
+ * cleanup, abuse detection, dashboard rate-limit, conversation rate sweep,
+ * share token cleanup) are forked and automatically interrupted when the
+ * Layer scope closes.
  */
 export function makeSchedulerLive(
   config: ResolvedConfig,
@@ -504,6 +507,148 @@ export function makeSchedulerLive(
         rateLimitTick.pipe(Effect.repeat(Schedule.spaced(Duration.seconds(60)))),
       );
       yield* Effect.addFinalizer(() => Fiber.interrupt(rateLimitFiber));
+
+      // ── Periodic fiber: demo rate-limit cleanup — interval from DEMO_CLEANUP_INTERVAL_MS ──
+      const demoTick = Effect.try({
+        try: () => {
+          // eslint-disable-next-line @typescript-eslint/no-require-imports
+          const { demoCleanupTick } = require("@atlas/api/lib/demo") as {
+            demoCleanupTick: () => void;
+          };
+          demoCleanupTick();
+        },
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(
+        Effect.catchAll((err) =>
+          Effect.sync(() => {
+            log.error(
+              { err: err instanceof Error ? err.message : String(err) },
+              "Demo rate-limit cleanup tick failed",
+            );
+          }),
+        ),
+      );
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { DEMO_CLEANUP_INTERVAL_MS } = require("@atlas/api/lib/demo") as {
+        DEMO_CLEANUP_INTERVAL_MS: number;
+      };
+      const demoFiber = yield* Effect.fork(
+        demoTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(DEMO_CLEANUP_INTERVAL_MS)))),
+      );
+      yield* Effect.addFinalizer(() => Fiber.interrupt(demoFiber));
+
+      // ── Periodic fiber: abuse detection cleanup — every 5 min ──────
+      const abuseTick = Effect.try({
+        try: () => {
+          // eslint-disable-next-line @typescript-eslint/no-require-imports
+          const { abuseCleanupTick } = require("@atlas/api/lib/security/abuse") as {
+            abuseCleanupTick: () => void;
+          };
+          abuseCleanupTick();
+        },
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(
+        Effect.catchAll((err) =>
+          Effect.sync(() => {
+            log.warn(
+              { err: err instanceof Error ? err.message : String(err) },
+              "Abuse cleanup tick failed",
+            );
+          }),
+        ),
+      );
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { ABUSE_CLEANUP_INTERVAL_MS } = require("@atlas/api/lib/security/abuse") as {
+        ABUSE_CLEANUP_INTERVAL_MS: number;
+      };
+      const abuseFiber = yield* Effect.fork(
+        abuseTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(ABUSE_CLEANUP_INTERVAL_MS)))),
+      );
+      yield* Effect.addFinalizer(() => Fiber.interrupt(abuseFiber));
+
+      // ── Periodic fiber: dashboard public rate-limit cleanup — every 60s ─
+      const dashboardTick = Effect.try({
+        try: () => {
+          // eslint-disable-next-line @typescript-eslint/no-require-imports
+          const { dashboardRateLimitCleanupTick } = require("@atlas/api/api/routes/dashboards") as {
+            dashboardRateLimitCleanupTick: () => void;
+          };
+          dashboardRateLimitCleanupTick();
+        },
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(
+        Effect.catchAll((err) =>
+          Effect.sync(() => {
+            log.warn(
+              { err: err instanceof Error ? err.message : String(err) },
+              "Dashboard rate-limit cleanup tick failed",
+            );
+          }),
+        ),
+      );
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { DASHBOARD_RATE_CLEANUP_INTERVAL_MS } = require("@atlas/api/api/routes/dashboards") as {
+        DASHBOARD_RATE_CLEANUP_INTERVAL_MS: number;
+      };
+      const dashboardFiber = yield* Effect.fork(
+        dashboardTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(DASHBOARD_RATE_CLEANUP_INTERVAL_MS)))),
+      );
+      yield* Effect.addFinalizer(() => Fiber.interrupt(dashboardFiber));
+
+      // ── Periodic fiber: conversation public rate sweep — every 60s ──
+      const convSweepTick = Effect.try({
+        try: () => {
+          // eslint-disable-next-line @typescript-eslint/no-require-imports
+          const { conversationRateSweepTick } = require("@atlas/api/api/routes/conversations") as {
+            conversationRateSweepTick: () => void;
+          };
+          conversationRateSweepTick();
+        },
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(
+        Effect.catchAll((err) =>
+          Effect.sync(() => {
+            log.warn(
+              { err: err instanceof Error ? err.message : String(err) },
+              "Conversation rate sweep tick failed",
+            );
+          }),
+        ),
+      );
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { CONVERSATION_RATE_SWEEP_INTERVAL_MS, SHARE_CLEANUP_INTERVAL_MS } = require("@atlas/api/api/routes/conversations") as {
+        CONVERSATION_RATE_SWEEP_INTERVAL_MS: number;
+        SHARE_CLEANUP_INTERVAL_MS: number;
+      };
+      const convSweepFiber = yield* Effect.fork(
+        convSweepTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(CONVERSATION_RATE_SWEEP_INTERVAL_MS)))),
+      );
+      yield* Effect.addFinalizer(() => Fiber.interrupt(convSweepFiber));
+
+      // ── Periodic fiber: share token cleanup — every 60 min ─────────
+      const shareCleanupEffect = Effect.tryPromise({
+        try: () => {
+          // eslint-disable-next-line @typescript-eslint/no-require-imports
+          const { shareCleanupTick: tick } = require("@atlas/api/api/routes/conversations") as {
+            shareCleanupTick: () => Promise<void>;
+          };
+          return tick();
+        },
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(
+        Effect.catchAll((err) =>
+          Effect.sync(() => {
+            log.error(
+              { err: err instanceof Error ? err.message : String(err) },
+              "Unexpected error in share cleanup tick",
+            );
+          }),
+        ),
+      );
+      const shareCleanupFiber = yield* Effect.fork(
+        shareCleanupEffect.pipe(Effect.repeat(Schedule.spaced(Duration.millis(SHARE_CLEANUP_INTERVAL_MS)))),
+      );
+      yield* Effect.addFinalizer(() => Fiber.interrupt(shareCleanupFiber));
 
       // --- Finalizer: stop main scheduler ---
       yield* Effect.addFinalizer(() =>

--- a/packages/api/src/lib/security/__tests__/abuse.test.ts
+++ b/packages/api/src/lib/security/__tests__/abuse.test.ts
@@ -40,11 +40,7 @@ const {
   reinstateWorkspace,
   getAbuseConfig,
   _resetAbuseState,
-  _stopCleanup,
 } = await import("../abuse");
-
-// Stop cleanup timer to prevent test hangs
-_stopCleanup();
 
 describe("Abuse Prevention Engine", () => {
   beforeEach(() => {

--- a/packages/api/src/lib/security/abuse.ts
+++ b/packages/api/src/lib/security/abuse.ts
@@ -431,33 +431,26 @@ export async function restoreAbuseState(): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// Periodic cleanup — evict stale window data every 5 minutes
+// Periodic cleanup — evict stale window data (called by SchedulerLayer fiber)
 // ---------------------------------------------------------------------------
 
-const cleanupInterval = setInterval(() => {
-  try {
-    const config = getAbuseConfig();
-    const windowMs = config.queryRateWindowSeconds * 1000;
+/** Interval for abuse cleanup. Exported for SchedulerLayer. */
+export const ABUSE_CLEANUP_INTERVAL_MS = 300_000;
 
-    for (const [id, state] of workspaceState) {
-      pruneWindow(state.window, windowMs);
+/**
+ * Evict stale abuse detection window data. Called periodically by the
+ * SchedulerLayer fiber in lib/effect/layers.ts.
+ */
+export function abuseCleanupTick(): void {
+  const config = getAbuseConfig();
+  const windowMs = config.queryRateWindowSeconds * 1000;
 
-      // Remove entries with no activity and level "none"
-      if (state.level === "none" && state.window.timestamps.length === 0) {
-        workspaceState.delete(id);
-      }
+  for (const [id, state] of workspaceState) {
+    pruneWindow(state.window, windowMs);
+
+    // Remove entries with no activity and level "none"
+    if (state.level === "none" && state.window.timestamps.length === 0) {
+      workspaceState.delete(id);
     }
-  } catch (err) {
-    log.warn(
-      { err: err instanceof Error ? err.message : String(err) },
-      "Abuse cleanup tick failed",
-    );
   }
-}, 300_000);
-
-cleanupInterval.unref();
-
-/** Stop the periodic cleanup timer. For tests. */
-export function _stopCleanup(): void {
-  clearInterval(cleanupInterval);
 }


### PR DESCRIPTION
## Summary
Fixes #1283 — Replace the last 5 `setInterval` calls in `packages/api/` with Effect fibers forked in SchedulerLayer.

- **`lib/demo.ts`** — demo rate-limit cleanup → `demoCleanupTick()` fiber (every 60s)
- **`lib/security/abuse.ts`** — abuse detection window cleanup → `abuseCleanupTick()` fiber (every 5 min)
- **`api/routes/dashboards.ts`** — dashboard public rate-limit cleanup → `dashboardRateLimitCleanupTick()` fiber (every 60s)
- **`api/routes/conversations.ts`** — conversation rate sweep → `conversationRateSweepTick()` fiber (every 60s)
- **`api/routes/conversations.ts`** — share token cleanup → `shareCleanupTick()` fiber (every 60 min), preserves consecutive failure tracking

All fibers forked in `makeSchedulerLive()` with `Effect.addFinalizer(() => Fiber.interrupt(...))` — automatic cleanup on shutdown. Removed `_stopDemoCleanup()` and `_stopCleanup()` test helpers (no longer needed since there are no timers to stop). Updated mock files accordingly.

**Result:** Zero `setInterval(` calls remain in `packages/api/src/`.

## Test plan
- [x] `bun run type` — 0 errors
- [x] `bun run lint` — 0 errors (1 pre-existing warning)
- [x] `bun run test` — all tests pass (0 failures)
- [x] `bun x syncpack lint` — no issues
- [x] Template drift check — 354 files verified
- [x] `grep -r 'setInterval(' packages/api/src/` — zero results