### PR TITLE
refactor: consolidate AtlasUIProvider → AtlasProvider, shared auth types

### DIFF
--- a/examples/nextjs-standalone/src/app/page.tsx
+++ b/examples/nextjs-standalone/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { AtlasUIProvider } from "@atlas/web/ui/context";
+import { AtlasProvider } from "@atlas/web/ui/context";
 import { authClient } from "@/lib/auth/client";
 import { API_URL, IS_CROSS_ORIGIN } from "@/lib/api-url";
 
@@ -12,8 +12,8 @@ const AtlasChat = dynamic(
 
 export default function Home() {
   return (
-    <AtlasUIProvider config={{ apiUrl: API_URL, isCrossOrigin: IS_CROSS_ORIGIN, authClient }}>
+    <AtlasProvider config={{ apiUrl: API_URL, isCrossOrigin: IS_CROSS_ORIGIN, authClient }}>
       <AtlasChat />
-    </AtlasUIProvider>
+    </AtlasProvider>
   );
 }

--- a/packages/react/src/components/admin/change-password-dialog.tsx
+++ b/packages/react/src/components/admin/change-password-dialog.tsx
@@ -21,7 +21,7 @@ export function ChangePasswordDialog({
   onComplete: () => void;
 }) {
   const { apiUrl, isCrossOrigin } = useAtlasContext();
-  const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
+  const credentials: "include" | "omit" | "same-origin" = isCrossOrigin ? "include" : "same-origin";
 
   const [currentPassword, setCurrentPassword] = useState("atlas-dev");
   const [newPassword, setNewPassword] = useState("");

--- a/packages/react/src/components/atlas-chat.tsx
+++ b/packages/react/src/components/atlas-chat.tsx
@@ -6,7 +6,7 @@ import { useState, useRef, useEffect, useMemo, useCallback } from "react";
 import { useQuery, QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { AuthMode } from "../lib/types";
 import type { ToolRenderers } from "../lib/tool-renderer-types";
-import { AtlasContext, useAtlasContext, ActionAuthProvider, type AtlasAuthClient } from "../context";
+import { AtlasContext, useAtlasContext, ActionAuthProvider, noopAuthClient, type AtlasAuthClient } from "../context";
 import { DarkModeContext, useDarkMode, useThemeMode, setTheme, applyBrandColor, OKLCH_RE, type ThemeMode } from "../hooks/use-dark-mode";
 import { useConversations } from "../hooks/use-conversations";
 import { ErrorBanner } from "./chat/error-banner";
@@ -60,13 +60,6 @@ export interface AtlasChatProps {
 }
 
 /** No-op auth client for non-managed auth modes. */
-const noopAuthClient: AtlasAuthClient = {
-  signIn: { email: async () => ({ error: { message: "Not supported" } }) },
-  signUp: { email: async () => ({ error: { message: "Not supported" } }) },
-  signOut: async () => {},
-  useSession: () => ({ data: null, isPending: false }),
-};
-
 /* Static SVG icons — hoisted to avoid recreation on every render */
 const MenuIcon = (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-5 w-5">
@@ -313,7 +306,7 @@ function AtlasChatInner({
     return headers;
   }, [apiKey]);
 
-  const getCredentials = useCallback((): RequestCredentials => {
+  const getCredentials = useCallback((): "include" | "omit" | "same-origin" => {
     return isCrossOrigin ? "include" : "same-origin";
   }, [isCrossOrigin]);
 
@@ -343,7 +336,7 @@ function AtlasChatInner({
     }
   }, [propApiKey]);
 
-  const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
+  const credentials: "include" | "omit" | "same-origin" = isCrossOrigin ? "include" : "same-origin";
 
   // Sync health error + brand color as side effects.
   // Clears warning on recovery (e.g. window-focus refetch succeeds after initial failure).

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -2,26 +2,12 @@
 
 import { createContext, useContext, useMemo, useState, type ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { AtlasAuthClient, ActionAuthValue } from "@useatlas/types";
 
-// ── Auth client interface ──────────────────────────────────────────
-
-/**
- * Duck-typed interface that matches better-auth's client shape.
- * Components like ManagedAuthCard call signIn/signUp/signOut and useSession().
- */
-export interface AtlasAuthClient {
-  signIn: {
-    email: (opts: { email: string; password: string }) => Promise<{ error?: { message?: string } | null }>;
-  };
-  signUp: {
-    email: (opts: { email: string; password: string; name: string }) => Promise<{ error?: { message?: string } | null }>;
-  };
-  signOut: () => Promise<unknown>;
-  useSession: () => { data?: { user?: { email?: string } } | null; isPending?: boolean };
-}
+export type { AtlasAuthClient, ActionAuthValue } from "@useatlas/types";
 
 /** No-op auth client for non-managed auth modes. Warns when auth operations are attempted. */
-const noopAuthClient: AtlasAuthClient = {
+export const noopAuthClient: AtlasAuthClient = {
   signIn: {
     email: async () => {
       console.warn("[Atlas] signIn called but no authClient was provided to AtlasProvider");
@@ -118,11 +104,6 @@ export function AtlasProvider({
 export { AtlasContext };
 
 // ── ActionAuth — internal context for passing auth to action cards ──
-
-export interface ActionAuthValue {
-  getHeaders: () => Record<string, string>;
-  getCredentials: () => RequestCredentials;
-}
 
 const ActionAuthContext = createContext<ActionAuthValue | null>(null);
 

--- a/packages/react/src/hooks/use-health-query.ts
+++ b/packages/react/src/hooks/use-health-query.ts
@@ -16,7 +16,7 @@ export interface HealthData {
  */
 export function useHealthQuery() {
   const { apiUrl, isCrossOrigin } = useAtlasContext();
-  const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
+  const credentials: "include" | "omit" | "same-origin" = isCrossOrigin ? "include" : "same-origin";
 
   return useQuery<HealthData>({
     queryKey: ["atlas", "health"],

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -12,6 +12,31 @@ export type AuthMode = (typeof AUTH_MODES)[number];
 export const ATLAS_ROLES = ["member", "admin", "owner", "platform_admin"] as const;
 export type AtlasRole = (typeof ATLAS_ROLES)[number];
 
+// ── Client-side auth interfaces ────────────────────────────────────
+// Shared between @atlas/web and @useatlas/react so each package has
+// a single source of truth for auth client shapes.
+
+/**
+ * Duck-typed interface that matches better-auth's client shape.
+ * Components like ManagedAuthCard call signIn/signUp/signOut and useSession().
+ */
+export interface AtlasAuthClient {
+  signIn: {
+    email: (opts: { email: string; password: string }) => Promise<{ error?: { message?: string } | null }>;
+  };
+  signUp: {
+    email: (opts: { email: string; password: string; name: string }) => Promise<{ error?: { message?: string } | null }>;
+  };
+  signOut: () => Promise<unknown>;
+  useSession: () => { data?: { user?: { email?: string; role?: string } } | null; isPending: boolean };
+}
+
+/** Auth helpers passed to action approval cards via context. */
+export interface ActionAuthValue {
+  getHeaders: () => Record<string, string>;
+  getCredentials: () => "include" | "omit" | "same-origin";
+}
+
 export interface AtlasUser {
   id: string;
   mode: Exclude<AuthMode, "none">;

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,7 +11,7 @@
     "test": "bun scripts/test-isolated.ts"
   },
   "exports": {
-    "./ui/context": "./src/ui/context-reexport.ts",
+    "./ui/context": "./src/ui/context.tsx",
     "./ui/components/atlas-chat": "./src/ui/atlas-chat-reexport.ts"
   },
   "dependencies": {

--- a/packages/web/src/app/admin/layout.tsx
+++ b/packages/web/src/app/admin/layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Suspense } from "react";
-import { AtlasUIProvider } from "@/ui/context";
+import { AtlasProvider } from "@/ui/context";
 import { authClient } from "@/lib/auth/client";
 import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
 import { AdminLayout } from "@/ui/components/admin/admin-layout";
@@ -9,11 +9,11 @@ import { BrandingHead } from "@/ui/components/branding-head";
 
 export default function AdminRootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <AtlasUIProvider config={{ apiUrl: getApiUrl(), isCrossOrigin: isCrossOrigin(), authClient }}>
+    <AtlasProvider config={{ apiUrl: getApiUrl(), isCrossOrigin: isCrossOrigin(), authClient }}>
       <BrandingHead />
       <AdminLayout>
         <Suspense>{children}</Suspense>
       </AdminLayout>
-    </AtlasUIProvider>
+    </AtlasProvider>
   );
 }

--- a/packages/web/src/app/dashboards/[id]/page.tsx
+++ b/packages/web/src/app/dashboards/[id]/page.tsx
@@ -211,7 +211,7 @@ export default function DashboardViewPage() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const session = authClient.useSession();
-  const user = session.data?.user as { role?: string } | undefined;
+  const user = session.data?.user;
   const isAdmin = user?.role === "admin" || user?.role === "owner" || user?.role === "platform_admin";
 
   const { data: dashboard, loading, error, refetch } = useAdminFetch<DashboardWithCards>(

--- a/packages/web/src/app/dashboards/layout.tsx
+++ b/packages/web/src/app/dashboards/layout.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { Suspense } from "react";
-import { AtlasUIProvider } from "@/ui/context";
+import { AtlasProvider } from "@/ui/context";
 import { authClient } from "@/lib/auth/client";
 import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
 
 export default function DashboardsLayout({ children }: { children: React.ReactNode }) {
   return (
-    <AtlasUIProvider config={{ apiUrl: getApiUrl(), isCrossOrigin: isCrossOrigin(), authClient }}>
+    <AtlasProvider config={{ apiUrl: getApiUrl(), isCrossOrigin: isCrossOrigin(), authClient }}>
       <Suspense>{children}</Suspense>
-    </AtlasUIProvider>
+    </AtlasProvider>
   );
 }

--- a/packages/web/src/app/dashboards/page.tsx
+++ b/packages/web/src/app/dashboards/page.tsx
@@ -59,7 +59,7 @@ function timeAgo(iso: string): string {
 
 export default function DashboardsPage() {
   const session = authClient.useSession();
-  const user = session.data?.user as { role?: string } | undefined;
+  const user = session.data?.user;
   const isAdmin = user?.role === "admin" || user?.role === "owner" || user?.role === "platform_admin";
 
   const { data, loading, error, refetch } = useAdminFetch<{

--- a/packages/web/src/app/wizard/layout.tsx
+++ b/packages/web/src/app/wizard/layout.tsx
@@ -1,16 +1,16 @@
 "use client";
 
 import { Suspense } from "react";
-import { AtlasUIProvider } from "@/ui/context";
+import { AtlasProvider } from "@/ui/context";
 import { authClient } from "@/lib/auth/client";
 import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
 
 export default function WizardLayout({ children }: { children: React.ReactNode }) {
   return (
-    <AtlasUIProvider config={{ apiUrl: getApiUrl(), isCrossOrigin: isCrossOrigin(), authClient }}>
+    <AtlasProvider config={{ apiUrl: getApiUrl(), isCrossOrigin: isCrossOrigin(), authClient }}>
       <div className="min-h-dvh bg-background">
         <Suspense>{children}</Suspense>
       </div>
-    </AtlasUIProvider>
+    </AtlasProvider>
   );
 }

--- a/packages/web/src/ui/__tests__/admin-layout.test.tsx
+++ b/packages/web/src/ui/__tests__/admin-layout.test.tsx
@@ -28,7 +28,7 @@ import { render, fireEvent, waitFor, cleanup } from "@testing-library/react";
 import type React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AdminLayout } from "../components/admin/admin-layout";
-import { AtlasUIProvider, type AtlasAuthClient } from "../context";
+import { AtlasProvider, type AtlasAuthClient } from "../context";
 
 function makeAuthClient(overrides: Partial<AtlasAuthClient> = {}): AtlasAuthClient {
   return {
@@ -46,11 +46,11 @@ function renderLayout(authClient?: AtlasAuthClient) {
   const client = authClient ?? makeAuthClient();
   return render(
     <QueryClientProvider client={testQueryClient}>
-      <AtlasUIProvider config={{ apiUrl: "http://localhost:3001", isCrossOrigin: false, authClient: client }}>
+      <AtlasProvider config={{ apiUrl: "http://localhost:3001", isCrossOrigin: false, authClient: client }}>
         <AdminLayout>
           <div data-testid="child-content">Admin page content</div>
         </AdminLayout>
-      </AtlasUIProvider>
+      </AtlasProvider>
     </QueryClientProvider>,
   );
 }

--- a/packages/web/src/ui/__tests__/admin-sidebar.test.tsx
+++ b/packages/web/src/ui/__tests__/admin-sidebar.test.tsx
@@ -26,7 +26,7 @@ mock.module("@/ui/hooks/use-branding", () => ({
 
 import { render } from "@testing-library/react";
 import { SidebarProvider } from "@/components/ui/sidebar";
-import { AtlasUIProvider, type AtlasAuthClient } from "../context";
+import { AtlasProvider, type AtlasAuthClient } from "../context";
 import { AdminSidebar } from "../components/admin/admin-sidebar";
 
 const stubAuthClient: AtlasAuthClient = {
@@ -38,9 +38,9 @@ const stubAuthClient: AtlasAuthClient = {
 
 function Wrapper({ children }: { children: ReactNode }) {
   return (
-    <AtlasUIProvider config={{ apiUrl: "http://localhost:3001", isCrossOrigin: false, authClient: stubAuthClient }}>
+    <AtlasProvider config={{ apiUrl: "http://localhost:3001", isCrossOrigin: false, authClient: stubAuthClient }}>
       <SidebarProvider>{children}</SidebarProvider>
-    </AtlasUIProvider>
+    </AtlasProvider>
   );
 }
 

--- a/packages/web/src/ui/__tests__/change-password-dialog.test.tsx
+++ b/packages/web/src/ui/__tests__/change-password-dialog.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
 import { render, fireEvent, waitFor, cleanup } from "@testing-library/react";
 import { ChangePasswordDialog } from "../components/admin/change-password-dialog";
-import { AtlasUIProvider, type AtlasAuthClient } from "../context";
+import { AtlasProvider, type AtlasAuthClient } from "../context";
 
 const stubAuthClient: AtlasAuthClient = {
   signIn: { email: async () => ({}) },
@@ -12,9 +12,9 @@ const stubAuthClient: AtlasAuthClient = {
 
 function renderDialog(open: boolean, onComplete?: () => void) {
   return render(
-    <AtlasUIProvider config={{ apiUrl: "http://localhost:3001", isCrossOrigin: false, authClient: stubAuthClient }}>
+    <AtlasProvider config={{ apiUrl: "http://localhost:3001", isCrossOrigin: false, authClient: stubAuthClient }}>
       <ChangePasswordDialog open={open} onComplete={onComplete ?? (() => {})} />
-    </AtlasUIProvider>,
+    </AtlasProvider>,
   );
 }
 

--- a/packages/web/src/ui/__tests__/tool-part.test.tsx
+++ b/packages/web/src/ui/__tests__/tool-part.test.tsx
@@ -24,7 +24,7 @@ mock.module("next/dynamic", () => ({
 }));
 
 import { ToolPart } from "../components/chat/tool-part";
-import { AtlasUIProvider } from "../context";
+import { AtlasProvider } from "../context";
 
 const stubAuthClient = {
   signIn: { email: async () => ({}) },
@@ -35,9 +35,9 @@ const stubAuthClient = {
 
 function Wrapper({ children }: { children: ReactNode }) {
   return (
-    <AtlasUIProvider config={{ apiUrl: "http://localhost:3001", isCrossOrigin: false, authClient: stubAuthClient }}>
+    <AtlasProvider config={{ apiUrl: "http://localhost:3001", isCrossOrigin: false, authClient: stubAuthClient }}>
       {children}
-    </AtlasUIProvider>
+    </AtlasProvider>
   );
 }
 

--- a/packages/web/src/ui/__tests__/use-admin-fetch.test.ts
+++ b/packages/web/src/ui/__tests__/use-admin-fetch.test.ts
@@ -4,7 +4,7 @@ import { createElement, type ReactNode } from "react";
 import { z } from "zod";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { friendlyError, useAdminFetch, type FetchError } from "../hooks/use-admin-fetch";
-import { AtlasUIProvider } from "../context";
+import { AtlasProvider } from "../context";
 
 /* ------------------------------------------------------------------ */
 /*  friendlyError (pure function)                                      */
@@ -67,7 +67,7 @@ function wrapper({ children }: { children: ReactNode }) {
     QueryClientProvider,
     { client: testQueryClient },
     createElement(
-      AtlasUIProvider,
+      AtlasProvider,
       { config: { apiUrl: "http://localhost:3001", isCrossOrigin: false as const, authClient: stubAuthClient } },
       children,
     ),

--- a/packages/web/src/ui/__tests__/use-admin-mutation.test.ts
+++ b/packages/web/src/ui/__tests__/use-admin-mutation.test.ts
@@ -4,7 +4,7 @@ import { createElement, type ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useAdminMutation, type MutateResult } from "../hooks/use-admin-mutation";
 import { useAdminFetch } from "../hooks/use-admin-fetch";
-import { AtlasUIProvider } from "../context";
+import { AtlasProvider } from "../context";
 
 /* ------------------------------------------------------------------ */
 /*  Setup                                                              */
@@ -24,7 +24,7 @@ function wrapper({ children }: { children: ReactNode }) {
     QueryClientProvider,
     { client: testQueryClient },
     createElement(
-      AtlasUIProvider,
+      AtlasProvider,
       { config: { apiUrl: "http://localhost:3001", isCrossOrigin: false as const, authClient: stubAuthClient } },
       children,
     ),

--- a/packages/web/src/ui/context-reexport.ts
+++ b/packages/web/src/ui/context-reexport.ts
@@ -1,2 +1,0 @@
-/** Re-export AtlasUIProvider for standalone example and external consumers. */
-export { AtlasUIProvider, type AtlasUIConfig, useAtlasUIContext } from "./context";

--- a/packages/web/src/ui/context.tsx
+++ b/packages/web/src/ui/context.tsx
@@ -1,58 +1,41 @@
 "use client";
 
 import { createContext, useContext, useMemo, type ReactNode } from "react";
+import type { AtlasAuthClient, ActionAuthValue } from "@useatlas/types";
 
-/**
- * Duck-typed interface that matches better-auth's client shape.
- * Components like ManagedAuthCard call signIn/signUp/signOut and useSession().
- */
-export interface AtlasAuthClient {
-  signIn: {
-    email: (opts: { email: string; password: string }) => Promise<{ error?: { message?: string } | null }>;
-  };
-  signUp: {
-    email: (opts: { email: string; password: string; name: string }) => Promise<{ error?: { message?: string } | null }>;
-  };
-  signOut: () => Promise<unknown>;
-  useSession: () => { data?: { user?: { email?: string } } | null; isPending?: boolean };
-}
+export type { AtlasAuthClient, ActionAuthValue } from "@useatlas/types";
 
-export interface AtlasUIConfig {
+export interface AtlasConfig {
   apiUrl: string;
   isCrossOrigin: boolean;
   authClient: AtlasAuthClient;
 }
 
-const AtlasUIContext = createContext<AtlasUIConfig | null>(null);
+const AtlasContext = createContext<AtlasConfig | null>(null);
 
-export function useAtlasConfig(): AtlasUIConfig {
-  const ctx = useContext(AtlasUIContext);
-  if (!ctx) throw new Error("useAtlasConfig must be used within <AtlasUIProvider>");
+export function useAtlasConfig(): AtlasConfig {
+  const ctx = useContext(AtlasContext);
+  if (!ctx) throw new Error("useAtlasConfig must be used within <AtlasProvider>");
   return ctx;
 }
 
-export function AtlasUIProvider({
+export function AtlasProvider({
   config,
   children,
 }: {
-  config: AtlasUIConfig;
+  config: AtlasConfig;
   children: ReactNode;
 }) {
   return (
-    <AtlasUIContext.Provider value={config}>
+    <AtlasContext.Provider value={config}>
       {children}
-    </AtlasUIContext.Provider>
+    </AtlasContext.Provider>
   );
 }
 
 /* ------------------------------------------------------------------ */
 /*  ActionAuth — internal context for passing auth to action cards     */
 /* ------------------------------------------------------------------ */
-
-export interface ActionAuthValue {
-  getHeaders: () => Record<string, string>;
-  getCredentials: () => RequestCredentials;
-}
 
 const ActionAuthContext = createContext<ActionAuthValue | null>(null);
 

--- a/packages/web/src/ui/hooks/use-platform-admin-guard.ts
+++ b/packages/web/src/ui/hooks/use-platform-admin-guard.ts
@@ -17,9 +17,7 @@ import { useAtlasConfig } from "@/ui/context";
 export function useUserRole(): string | undefined {
   const { authClient } = useAtlasConfig();
   const session = authClient.useSession();
-  return (session.data?.user as Record<string, unknown> | undefined)?.role as
-    | string
-    | undefined;
+  return session.data?.user?.role;
 }
 
 /**

--- a/packages/web/src/ui/lib/query-utils.ts
+++ b/packages/web/src/ui/lib/query-utils.ts
@@ -67,7 +67,7 @@ export function adminQueryFn<T>(
 }
 
 /**
- * Extracts the `{ apiUrl, isCrossOrigin }` subset of `AtlasUIConfig` for use
+ * Extracts the `{ apiUrl, isCrossOrigin }` subset of `AtlasConfig` for use
  * with `adminQueryFn`. Isolates query utilities from the full config shape.
  */
 export function useQueryConfig() {


### PR DESCRIPTION
## Summary
- Rename `AtlasUIProvider` → `AtlasProvider` in `packages/web/` — one provider name per package
- Move `AtlasAuthClient` and `ActionAuthValue` interfaces to `@useatlas/types` — single source of truth, both `packages/web/` and `packages/react/` import from there
- Delete `context-reexport.ts` — web package export points directly to `context.tsx`
- Update 3 layouts, 6 test files, standalone example

**Before:** Two differently-named providers (`AtlasUIProvider` in web, `AtlasProvider` in react) with duplicated auth interfaces in each package.

**After:** Both packages export `AtlasProvider`. Shared types live in `@useatlas/types`.

## Test plan
- [x] `bun run type` — 0 errors
- [x] `bun run lint` — 0 errors (1 pre-existing warning)
- [x] `bun run test` — all tests pass
- [x] `bun x syncpack lint` — no issues
- [x] Template drift — 365 files verified