### PR TITLE
fix: cast user.role in dashboard pages — CI regression

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -900,10 +900,11 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
 - [x] Powered by Atlas badge on embedded widgets (PR #1265)
 - [x] Semantic expert agent design doc (#1180, PR #1270)
 - [x] Docs: chatEndpoint default `/api/chat` → `/api/v1/chat` (#1271)
-- [x] Consolidate AtlasUIProvider + AtlasProvider into single AtlasProvider (61b986dc)
+- [x] Consolidate AtlasUIProvider + AtlasProvider into single AtlasProvider, shared auth types to @useatlas/types (PR #1298)
 - [x] Fix AtlasContext in AtlasChat — useHealthQuery crash on app.useatlas.dev (f158a4cc)
 - [x] Publish @useatlas/types 0.0.7 — SEMANTIC_TYPES + profiler exports
 - [x] Fix Effect/Turbopack serverExternalPackages conflict in templates
+- [x] Docs: fix stale AtlasUIProvider references in react.mdx (#1292, #1293)
 
 ---
 

--- a/packages/web/src/app/dashboards/[id]/page.tsx
+++ b/packages/web/src/app/dashboards/[id]/page.tsx
@@ -211,7 +211,9 @@ export default function DashboardViewPage() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const session = authClient.useSession();
-  const user = session.data?.user;
+  const user = session.data?.user as
+    | { email?: string; role?: string }
+    | undefined;
   const isAdmin = user?.role === "admin" || user?.role === "owner" || user?.role === "platform_admin";
 
   const { data: dashboard, loading, error, refetch } = useAdminFetch<DashboardWithCards>(

--- a/packages/web/src/app/dashboards/page.tsx
+++ b/packages/web/src/app/dashboards/page.tsx
@@ -59,7 +59,9 @@ function timeAgo(iso: string): string {
 
 export default function DashboardsPage() {
   const session = authClient.useSession();
-  const user = session.data?.user;
+  const user = session.data?.user as
+    | { email?: string; role?: string }
+    | undefined;
   const isAdmin = user?.role === "admin" || user?.role === "owner" || user?.role === "platform_admin";
 
   const { data, loading, error, refetch } = useAdminFetch<{


### PR DESCRIPTION
## Summary
- Cast `session.data?.user` to `{ email?: string; role?: string }` in dashboard pages, matching the pattern in `page.tsx` and `notebook/page.tsx`
- Better Auth's public session type doesn't include `role` (added by admin plugin at runtime) — the consolidation in #1298 exposed this
- Also updates ROADMAP: PR #1298 ref, docs fix entries for #1292/#1293

## Test plan
- [ ] `bun run --filter '@atlas/web' type` passes — no TS2339 on `.role`