### PR TITLE
chore: bump @useatlas/types 0.0.8, @useatlas/react 0.0.6

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/react",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Embeddable Atlas chat UI for React applications",
   "license": "MIT",
   "repository": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/types",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- **@useatlas/types 0.0.7 → 0.0.8**: shared auth types (PR #1298), semantic expert agent types (PR #1297)
- **@useatlas/react 0.0.5 → 0.0.6**: AtlasProvider consolidation (removed AtlasUIProvider), TanStack Query migration, Powered by Atlas badge, health warning recovery fix, AtlasChat crash fix

## After merge
Tag sequentially (types first since react depends on it):
```bash
git tag types-v0.0.8 && git push origin types-v0.0.8
# wait for publish workflow
git tag react-v0.0.6 && git push origin react-v0.0.6
# wait for publish workflow
```

Then bump refs in a follow-up commit:
- `packages/sdk/package.json`: `@useatlas/types` ^0.0.7 → ^0.0.8
- `packages/react/package.json`: `@useatlas/types` ^0.0.7 → ^0.0.8
- `create-atlas/templates/*/package.json`: types ^0.0.7 → ^0.0.8, react ^0.0.5 → ^0.0.6

## Test plan
- [ ] CI passes (version bump only — no code changes)