### PR TITLE
fix: emit login events for active user tracking

### DIFF
--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -386,13 +386,29 @@ export function getAuthInstance(): AuthInstance {
             // Emit a login usage event for active-user tracking.
             // Fire-and-forget — never blocks or fails sign-in.
             try {
-              const orgId = session.activeOrganizationId;
+              let orgId = session.activeOrganizationId;
+
+              // The `before` hook may have set activeOrganizationId but
+              // Better Auth may not propagate the mutation to `after`.
+              // Fall back to querying the member table for single-org users.
+              if (!orgId) {
+                try {
+                  const { internalQuery, hasInternalDB } = await import("@atlas/api/lib/db/internal");
+                  if (hasInternalDB()) {
+                    const rows = await internalQuery<{ organizationId: string }>(
+                      `SELECT "organizationId" FROM member WHERE "userId" = $1 LIMIT 2`,
+                      [session.userId],
+                    );
+                    if (rows.length === 1) orgId = rows[0].organizationId;
+                  }
+                } catch {
+                  // intentionally best-effort — skip if lookup fails
+                }
+              }
+
               if (!orgId) return; // No workspace context — skip
 
               const { emitLoginEvent } = await import("@atlas/api/lib/metering");
-              // Intentionally not awaited within the try — emitLoginEvent
-              // handles its own errors internally. We do await here only to
-              // catch dynamic import failures.
               void emitLoginEvent(orgId, session.userId);
             } catch (err) {
               // intentionally best-effort — never block sign-in on metering

--- a/packages/api/src/lib/metering.ts
+++ b/packages/api/src/lib/metering.ts
@@ -91,8 +91,8 @@ export async function emitLoginEvent(
     let alreadyLogged = false;
     try {
       const rows = await internalQuery<{ n: number }>(
-        `SELECT 1 AS n FROM usage_events WHERE user_id = $1 AND event_type = 'login' AND created_at >= $2 LIMIT 1`,
-        [userId, todayStart.toISOString()],
+        `SELECT 1 AS n FROM usage_events WHERE user_id = $1 AND workspace_id = $2 AND event_type = 'login' AND created_at >= $3 LIMIT 1`,
+        [userId, workspaceId, todayStart.toISOString()],
       );
       alreadyLogged = rows.length > 0;
     } catch (err) {


### PR DESCRIPTION
## Summary
- Adds `emitLoginEvent()` to `packages/api/src/lib/metering.ts` with once-per-user-per-UTC-day deduplication
- Hooks into Better Auth `databaseHooks.session.create.after` in `packages/api/src/lib/auth/server.ts` to fire login events on sign-in
- Updates stale comment in metering.ts noting login events are now emitted

## Details

The metering system already defined `login` as a `UsageEventType` and the aggregation queries counted distinct login user_ids for `active_users`, but no code ever emitted login events — so active users was always 0 in the admin usage dashboard.

**Deduplication:** Before emitting, queries `usage_events` to check if a login event already exists for this user today (UTC midnight boundary). If the dedup check itself fails (DB error), emits anyway rather than silently dropping the event.

**Edge cases handled:**
- No active organization on session → skip (login events need workspace context)
- No internal DB → skip silently (self-hosted without internal DB)
- Dedup query failure → emit anyway, log warning
- Any other error → catch and log, never block sign-in

**Best-effort guarantee:** The `after` hook uses `void emitLoginEvent(...)` (fire-and-forget) wrapped in try/catch. The `emitLoginEvent` function itself has nested try/catch. Metering can never fail the sign-in flow.

Closes #1316

## Test plan
- [ ] Sign in to Atlas → verify a `login` event row appears in `usage_events` table
- [ ] Sign in again same day → verify no duplicate login event is created
- [ ] Sign in the next UTC day → verify a new login event is created
- [ ] Sign in without an active organization → verify no login event (no error)
- [ ] Check admin usage dashboard → verify `active_users` count is now > 0
- [ ] `bun run lint` passes with no new warnings
- [ ] `bun run type` passes (no errors in changed files)