### PR TITLE
fix: rate limit Stripe portal session endpoint

### DIFF
--- a/packages/api/src/api/__tests__/billing.test.ts
+++ b/packages/api/src/api/__tests__/billing.test.ts
@@ -146,7 +146,7 @@ mock.module("@atlas/api/lib/semantic", () => ({
 
 // --- Import billing routes ---
 
-import { billing } from "../routes/billing";
+import { billing, _resetPortalRateLimits } from "../routes/billing";
 import { OpenAPIHono } from "@hono/zod-openapi";
 
 const app = new OpenAPIHono();
@@ -161,6 +161,7 @@ function request(path: string, options?: RequestInit) {
 describe("billing routes", () => {
   beforeEach(() => {
     mockHasInternalDB = true;
+    _resetPortalRateLimits();
     mockAuthenticateRequest.mockImplementation(() =>
       Promise.resolve({
         authenticated: true,
@@ -253,6 +254,72 @@ describe("billing routes", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test assertions on response shape
       const body = await res.json() as any;
       expect(body.error).toBe("no_customer");
+      delete process.env.STRIPE_SECRET_KEY;
+    });
+
+    it("returns 429 after 5 portal requests in the same window", async () => {
+      process.env.STRIPE_SECRET_KEY = "sk_test_fake";
+
+      // First 5 requests should succeed
+      for (let i = 0; i < 5; i++) {
+        const res = await request("/api/v1/billing/portal", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        });
+        expect(res.status).toBe(200);
+      }
+
+      // 6th request should be rate limited
+      const res = await request("/api/v1/billing/portal", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(429);
+      expect(res.headers.get("Retry-After")).toBeTruthy();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test assertions on response shape
+      const body = await res.json() as any;
+      expect(body.error).toBe("rate_limited");
+      expect(body.retryAfter).toBeGreaterThan(0);
+      expect(body.message).toContain("Too many portal requests");
+
+      delete process.env.STRIPE_SECRET_KEY;
+    });
+
+    it("rate limits are per-workspace", async () => {
+      process.env.STRIPE_SECRET_KEY = "sk_test_fake";
+
+      // Exhaust rate limit for org-1
+      for (let i = 0; i < 5; i++) {
+        const res = await request("/api/v1/billing/portal", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        });
+        expect(res.status).toBe(200);
+      }
+
+      // Switch to org-2 — should still be allowed
+      mockAuthenticateRequest.mockImplementation(() =>
+        Promise.resolve({
+          authenticated: true,
+          mode: "simple-key",
+          user: { id: "user-2", mode: "simple-key", label: "User 2", role: "admin", activeOrganizationId: "org-2" },
+        }),
+      );
+      mockGetWorkspaceDetails.mockImplementation(() =>
+        Promise.resolve({ ...mockWorkspace, id: "org-2", stripe_customer_id: "cus_test_456" }),
+      );
+
+      const res = await request("/api/v1/billing/portal", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(200);
+
       delete process.env.STRIPE_SECRET_KEY;
     });
   });

--- a/packages/api/src/api/routes/billing.ts
+++ b/packages/api/src/api/routes/billing.ts
@@ -35,6 +35,48 @@ import { adminAuth, requestContext, type AuthEnv } from "./middleware";
 const log = createLogger("billing");
 
 // ---------------------------------------------------------------------------
+// Portal rate limiter — 5 requests per workspace per hour (in-memory)
+// ---------------------------------------------------------------------------
+
+const PORTAL_RATE_LIMIT = 5;
+const PORTAL_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+
+interface PortalRateEntry {
+  count: number;
+  resetAt: number;
+}
+
+const portalRateMap = new Map<string, PortalRateEntry>();
+
+/**
+ * Check whether a workspace has exceeded the portal session rate limit.
+ * Returns `{ allowed: true }` or `{ allowed: false, retryAfterSec }`.
+ */
+function checkPortalRateLimit(orgId: string): { allowed: true } | { allowed: false; retryAfterSec: number } {
+  const now = Date.now();
+  const entry = portalRateMap.get(orgId);
+
+  if (!entry || now >= entry.resetAt) {
+    // Window expired or first request — start fresh
+    portalRateMap.set(orgId, { count: 1, resetAt: now + PORTAL_WINDOW_MS });
+    return { allowed: true };
+  }
+
+  if (entry.count < PORTAL_RATE_LIMIT) {
+    entry.count++;
+    return { allowed: true };
+  }
+
+  const retryAfterSec = Math.ceil((entry.resetAt - now) / 1000);
+  return { allowed: false, retryAfterSec };
+}
+
+/** Reset portal rate limit state. For tests. */
+export function _resetPortalRateLimits(): void {
+  portalRateMap.clear();
+}
+
+// ---------------------------------------------------------------------------
 // Schemas
 // ---------------------------------------------------------------------------
 
@@ -321,6 +363,20 @@ billing.openapi(createPortalSessionRoute, async (c) => {
 
     if (!orgId) {
       return c.json({ error: "org_required", message: "No active organization." }, 400);
+    }
+
+    // Rate limit: max 5 portal sessions per workspace per hour
+    const rl = checkPortalRateLimit(orgId);
+    if (!rl.allowed) {
+      const minutes = Math.ceil(rl.retryAfterSec / 60);
+      return c.json(
+        {
+          error: "rate_limited",
+          message: `Too many portal requests. Try again in ${minutes} minute${minutes === 1 ? "" : "s"}.`,
+          retryAfter: rl.retryAfterSec,
+        },
+        { status: 429, headers: { "Retry-After": String(rl.retryAfterSec) } },
+      );
     }
 
     const workspace = yield* Effect.promise(() => getWorkspaceDetails(orgId));


### PR DESCRIPTION
## Summary
- Adds in-memory rate limiting to `POST /api/v1/billing/portal` — max 5 requests per workspace per hour
- Returns 429 with `Retry-After` header and structured JSON error (`{ error: "rate_limited", message, retryAfter }`) when exceeded
- Window resets automatically after 1 hour; counter is per-org, so workspaces don't interfere with each other

## Details
Each call to the portal endpoint creates a Stripe Customer Portal session via the Stripe API. Without rate limiting, this is a DoS vector — an attacker with a valid session could hammer the endpoint and exhaust Stripe API quotas.

The rate limiter uses a simple `Map<orgId, { count, resetAt }>` pattern, consistent with other in-memory rate limiters in the codebase (`lib/auth/middleware.ts`, `lib/db/source-rate-limit.ts`). Exports `_resetPortalRateLimits()` for test cleanup.

## Test plan
- [x] Verify first 5 requests in a window return 200
- [x] Verify 6th request returns 429 with `Retry-After` header and structured error body
- [x] Verify rate limits are per-workspace (org-2 not affected by org-1 exhaustion)
- [x] All 13 tests pass (11 existing + 2 new)
- [x] `bun run lint` — no new errors
- [x] `bun run type` — no type errors

Closes #1317