### PR TITLE
fix: add missing Stripe webhook handlers for payment failures and plan changes

### DIFF
--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -19,12 +19,12 @@ import { apiKey } from "@better-auth/api-key";
 import { scim } from "@better-auth/scim";
 import { stripe as stripePlugin } from "@better-auth/stripe";
 import Stripe from "stripe";
-import { getInternalDB, hasInternalDB, internalQuery, updateWorkspacePlanTier, type PlanTier } from "@atlas/api/lib/db/internal";
+import { getInternalDB, hasInternalDB, internalQuery, updateWorkspacePlanTier, updateWorkspaceStatus, type PlanTier } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
 import { isEnterpriseEnabled } from "@atlas/ee/index";
 import { ac, owner as ownerRole, admin as adminRole, member as memberRole } from "@atlas/api/lib/auth/org-permissions";
 import { adminAccessControl, adminRole as adminUserRole, platformAdminRole } from "@atlas/api/lib/auth/admin-permissions";
-import { getStripePlans } from "@atlas/api/lib/billing/plans";
+import { getStripePlans, resolvePlanTierFromPriceId } from "@atlas/api/lib/billing/plans";
 import { invalidatePlanCache } from "@atlas/api/lib/billing/enforcement";
 
 /**
@@ -61,6 +61,7 @@ function buildSocialProviders(): Record<string, { clientId: string; clientSecret
 }
 
 const log = createLogger("auth:server");
+const billingLog = createLogger("billing");
 
 /**
  * Build the Better Auth plugins array.
@@ -185,6 +186,45 @@ function buildPlugins() {
                   }
                 }
               },
+              async onSubscriptionUpdate({ event, subscription }) {
+                const orgId = subscription.referenceId;
+                if (!orgId) return;
+
+                // Resolve the new plan tier from the Stripe subscription's price ID
+                const stripeSubscription = event.data.object as Stripe.Subscription;
+                const priceId = stripeSubscription.items?.data?.[0]?.price?.id;
+                if (!priceId) {
+                  billingLog.warn(
+                    { orgId, subscriptionId: subscription.id },
+                    "Subscription updated but no price ID found on Stripe subscription items — skipping plan sync",
+                  );
+                  return;
+                }
+
+                const newTier = resolvePlanTierFromPriceId(priceId);
+                if (!newTier) {
+                  billingLog.warn(
+                    { orgId, priceId },
+                    "Subscription updated with unrecognized price ID — cannot map to Atlas plan tier",
+                  );
+                  return;
+                }
+
+                try {
+                  await updateWorkspacePlanTier(orgId, newTier);
+                  invalidatePlanCache(orgId);
+                  billingLog.info(
+                    { orgId, newTier, priceId },
+                    "Subscription updated — plan tier synced",
+                  );
+                } catch (err) {
+                  billingLog.error(
+                    { err: err instanceof Error ? err.message : String(err), orgId, newTier, priceId },
+                    "Failed to sync plan tier on subscription update — Stripe will retry webhook",
+                  );
+                  throw err;
+                }
+              },
               async onSubscriptionDeleted({ subscription }) {
                 const orgId = subscription.referenceId;
                 if (orgId) {
@@ -201,6 +241,60 @@ function buildPlugins() {
                   }
                 }
               },
+            },
+            async onEvent(event: Stripe.Event) {
+              if (event.type === "invoice.payment_failed") {
+                const invoice = event.data.object as Stripe.Invoice;
+                const customerId = typeof invoice.customer === "string"
+                  ? invoice.customer
+                  : invoice.customer?.id;
+                // In Stripe API 2025+, subscription lives under parent.subscription_details
+                const parentSub = invoice.parent?.subscription_details?.subscription;
+                const subscriptionId = typeof parentSub === "string"
+                  ? parentSub
+                  : parentSub?.id;
+                const attemptCount = invoice.attempt_count ?? 0;
+
+                billingLog.warn(
+                  { customerId, subscriptionId, attemptCount, invoiceId: invoice.id },
+                  "Invoice payment failed (attempt %d)",
+                  attemptCount,
+                );
+
+                // After 3+ failed attempts, suspend the workspace.
+                // Stripe typically retries 3 times over ~3 weeks with Smart Retries.
+                if (attemptCount >= 3 && subscriptionId) {
+                  try {
+                    // Look up the org by subscription's referenceId in Better Auth's subscription table
+                    const rows = await internalQuery<{ referenceId: string }>(
+                      `SELECT "referenceId" FROM subscription WHERE "stripeSubscriptionId" = $1 LIMIT 1`,
+                      [subscriptionId],
+                    );
+                    const orgId = rows[0]?.referenceId;
+                    if (orgId) {
+                      await updateWorkspaceStatus(orgId, "suspended");
+                      invalidatePlanCache(orgId);
+                      billingLog.warn(
+                        { orgId, subscriptionId, attemptCount },
+                        "Workspace suspended after %d failed payment attempts",
+                        attemptCount,
+                      );
+                    } else {
+                      billingLog.warn(
+                        { subscriptionId },
+                        "Cannot suspend workspace — no subscription found for Stripe subscription ID",
+                      );
+                    }
+                  } catch (err) {
+                    billingLog.error(
+                      { err: err instanceof Error ? err.message : String(err), subscriptionId, attemptCount },
+                      "Failed to suspend workspace after repeated payment failures",
+                    );
+                    // Do not re-throw — the onEvent handler should not cause Stripe to retry
+                    // the entire webhook. The payment failure is already recorded by Stripe.
+                  }
+                }
+              }
             },
           }),
         );

--- a/packages/api/src/lib/billing/__tests__/plans.test.ts
+++ b/packages/api/src/lib/billing/__tests__/plans.test.ts
@@ -9,6 +9,7 @@ import {
   getPlanLimits,
   isUnlimited,
   getStripePlans,
+  resolvePlanTierFromPriceId,
 } from "@atlas/api/lib/billing/plans";
 
 describe("billing/plans", () => {
@@ -116,6 +117,48 @@ describe("billing/plans", () => {
       const plans = getStripePlans();
       expect(plans.length).toBe(2);
       expect(plans.map((p) => p.name)).toEqual(["team", "enterprise"]);
+    });
+  });
+
+  describe("resolvePlanTierFromPriceId", () => {
+    function cleanStripeEnv() {
+      delete process.env.STRIPE_TEAM_PRICE_ID;
+      delete process.env.STRIPE_TEAM_ANNUAL_PRICE_ID;
+      delete process.env.STRIPE_ENTERPRISE_PRICE_ID;
+    }
+    beforeEach(cleanStripeEnv);
+    afterEach(cleanStripeEnv);
+
+    it("returns null when no price IDs are configured", () => {
+      expect(resolvePlanTierFromPriceId("price_unknown")).toBeNull();
+    });
+
+    it("resolves team monthly price ID", () => {
+      process.env.STRIPE_TEAM_PRICE_ID = "price_team_monthly";
+      expect(resolvePlanTierFromPriceId("price_team_monthly")).toBe("team");
+    });
+
+    it("resolves team annual price ID", () => {
+      process.env.STRIPE_TEAM_PRICE_ID = "price_team_monthly";
+      process.env.STRIPE_TEAM_ANNUAL_PRICE_ID = "price_team_annual";
+      expect(resolvePlanTierFromPriceId("price_team_annual")).toBe("team");
+    });
+
+    it("resolves enterprise price ID", () => {
+      process.env.STRIPE_ENTERPRISE_PRICE_ID = "price_ent_001";
+      expect(resolvePlanTierFromPriceId("price_ent_001")).toBe("enterprise");
+    });
+
+    it("returns null for unrecognized price ID", () => {
+      process.env.STRIPE_TEAM_PRICE_ID = "price_team_monthly";
+      process.env.STRIPE_ENTERPRISE_PRICE_ID = "price_ent_001";
+      expect(resolvePlanTierFromPriceId("price_unknown_999")).toBeNull();
+    });
+
+    it("does not match team annual price when only monthly is set", () => {
+      process.env.STRIPE_TEAM_PRICE_ID = "price_team_monthly";
+      // STRIPE_TEAM_ANNUAL_PRICE_ID is not set
+      expect(resolvePlanTierFromPriceId("price_team_annual")).toBeNull();
     });
   });
 });

--- a/packages/api/src/lib/billing/plans.ts
+++ b/packages/api/src/lib/billing/plans.ts
@@ -153,3 +153,23 @@ export function getStripePlans(): Array<{
 
   return plans;
 }
+
+/**
+ * Resolve a Stripe price ID back to an Atlas PlanTier.
+ *
+ * Checks both monthly and annual price IDs from environment variables.
+ * Returns null if the price ID doesn't match any configured plan.
+ */
+export function resolvePlanTierFromPriceId(priceId: string): PlanTier | null {
+  const teamPriceId = process.env.STRIPE_TEAM_PRICE_ID;
+  const teamAnnualPriceId = process.env.STRIPE_TEAM_ANNUAL_PRICE_ID;
+  const enterprisePriceId = process.env.STRIPE_ENTERPRISE_PRICE_ID;
+
+  if (teamPriceId && (priceId === teamPriceId || (teamAnnualPriceId && priceId === teamAnnualPriceId))) {
+    return "team";
+  }
+  if (enterprisePriceId && priceId === enterprisePriceId) {
+    return "enterprise";
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- **#1312 — Failed payment handling:** Added `onEvent` handler for `invoice.payment_failed`. Logs every failure with workspace context (customer ID, subscription ID, attempt count). After 3+ consecutive failures, looks up the org via Better Auth's `subscription` table and calls `updateWorkspaceStatus(orgId, 'suspended')` + `invalidatePlanCache(orgId)`. Errors in the suspension path are logged but not re-thrown (avoids forcing Stripe to retry the entire webhook for a side-effect failure).
- **#1313 — Plan downgrade/upgrade webhook:** Added `onSubscriptionUpdate` handler. Extracts the price ID from the Stripe subscription event, resolves it to an Atlas plan tier via the new `resolvePlanTierFromPriceId()` utility (checks `STRIPE_TEAM_PRICE_ID`, `STRIPE_TEAM_ANNUAL_PRICE_ID`, `STRIPE_ENTERPRISE_PRICE_ID`), then calls `updateWorkspacePlanTier()` + `invalidatePlanCache()`. Unrecognized price IDs are logged as warnings and skipped.
- **New utility:** `resolvePlanTierFromPriceId(priceId)` in `packages/api/src/lib/billing/plans.ts` — reverse-maps Stripe price IDs to Atlas plan tiers.
- **6 new tests** for `resolvePlanTierFromPriceId` covering monthly, annual, enterprise, unrecognized, and unconfigured scenarios.

## Key design decisions
- Used `onEvent` (catch-all) for `invoice.payment_failed` because the Better Auth Stripe plugin does not have a dedicated payment failure hook — only subscription lifecycle hooks.
- Used `onSubscriptionUpdate` (plugin-native hook) for plan changes, which fires after the plugin has already updated its own subscription record.
- Suspension threshold is 3 attempts, matching Stripe's default Smart Retries cadence (~3 retries over 3 weeks).
- The `onEvent` handler does NOT re-throw on suspension errors to avoid Stripe retrying the entire webhook for a side-effect failure that can be investigated via logs.
- Used Stripe v21 `invoice.parent.subscription_details.subscription` path (not the deprecated top-level `invoice.subscription`).

Closes #1312, closes #1313

## Test plan
- [x] `bun test packages/api/src/lib/billing/__tests__/plans.test.ts` — 19 tests pass (6 new)
- [x] `bun run lint` — 0 errors (3 pre-existing warnings)
- [x] `bun run type` — no type errors