### PR TITLE
feat: SSO test connection endpoint — OIDC discovery + SAML cert validation

### DIFF
--- a/ee/src/auth/sso.test.ts
+++ b/ee/src/auth/sso.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import { Effect } from "effect";
 import { createEEMock, EnterpriseError } from "../__mocks__/internal";
 
@@ -41,6 +41,9 @@ const {
   setSSOEnforcement,
   isSSOEnforced,
   isSSOEnforcedForDomain,
+  testSSOProvider,
+  testOidcProvider,
+  testSamlProvider,
   SSOEnforcementError,
 } = await import("./sso");
 
@@ -605,5 +608,284 @@ describe("isSSOEnforcedForDomain", () => {
     const result = await run(isSSOEnforcedForDomain("acme.com"));
     expect(result).not.toBeNull();
     expect(result!.enforced).toBe(false);
+  });
+});
+
+// ── Test Connection Unit Tests ─────────────────────────────────────
+
+import type { SSOOidcProvider, SSOSamlProvider, SSOOidcTestDetails, SSOSamlTestDetails } from "@useatlas/types";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- test mock needs to bypass fetch.preconnect type
+const mockFetch = (fn: (...args: any[]) => Promise<Response>) => {
+  globalThis.fetch = mock(fn) as unknown as typeof fetch;
+};
+
+const oidcProvider: SSOOidcProvider = {
+  id: "prov-oidc",
+  orgId: "org-1",
+  type: "oidc",
+  issuer: "https://idp.example.com",
+  domain: "example.com",
+  enabled: true,
+  ssoEnforced: false,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+  config: {
+    clientId: "client-1",
+    clientSecret: "secret-1",
+    discoveryUrl: "https://idp.example.com/.well-known/openid-configuration",
+  },
+};
+
+const validDiscoveryDoc = {
+  issuer: "https://idp.example.com",
+  authorization_endpoint: "https://idp.example.com/auth",
+  token_endpoint: "https://idp.example.com/token",
+  jwks_uri: "https://idp.example.com/jwks",
+};
+
+describe("testOidcProvider", () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("succeeds with valid discovery document", async () => {
+    mockFetch(async () =>
+      new Response(JSON.stringify(validDiscoveryDoc), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const result = await testOidcProvider(oidcProvider);
+    expect(result.type).toBe("oidc");
+    expect(result.success).toBe(true);
+    expect(result.testedAt).toBeDefined();
+    const details = result.details as SSOOidcTestDetails;
+    expect(details.discoveryReachable).toBe(true);
+    expect(details.issuerMatch).toBe(true);
+    expect(details.requiredFieldsPresent).toBe(true);
+    expect(details.endpoints.issuer).toBe("https://idp.example.com");
+    expect(result.errors).toBeUndefined();
+  });
+
+  it("fails for non-200 HTTP response", async () => {
+    mockFetch(async () => new Response("", { status: 500 }));
+
+    const result = await testOidcProvider(oidcProvider);
+    expect(result.success).toBe(false);
+    expect(result.errors![0]).toContain("HTTP 500");
+  });
+
+  it("fails for non-JSON body and includes parse reason", async () => {
+    mockFetch(async () =>
+      new Response("<html>Not Found</html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+    );
+
+    const result = await testOidcProvider(oidcProvider);
+    expect(result.success).toBe(false);
+    const details = result.details as SSOOidcTestDetails;
+    expect(details.discoveryReachable).toBe(false);
+    expect(result.errors![0]).toContain("non-JSON body");
+    expect(result.errors![0]).toContain("content-type: text/html");
+  });
+
+  it("fails when required fields are missing", async () => {
+    mockFetch(async () =>
+      new Response(JSON.stringify({ issuer: "https://idp.example.com" }), { status: 200 }),
+    );
+
+    const result = await testOidcProvider(oidcProvider);
+    expect(result.success).toBe(false);
+    const details = result.details as SSOOidcTestDetails;
+    expect(details.discoveryReachable).toBe(true);
+    expect(details.requiredFieldsPresent).toBe(false);
+    expect(result.errors![0]).toContain("authorization_endpoint");
+    expect(result.errors![0]).toContain("token_endpoint");
+    expect(result.errors![0]).toContain("jwks_uri");
+  });
+
+  it("fails when issuer does not match", async () => {
+    mockFetch(async () =>
+      new Response(JSON.stringify({ ...validDiscoveryDoc, issuer: "https://other.com" }), { status: 200 }),
+    );
+
+    const result = await testOidcProvider(oidcProvider);
+    expect(result.success).toBe(false);
+    const details = result.details as SSOOidcTestDetails;
+    expect(details.issuerMatch).toBe(false);
+    expect(result.errors![0]).toContain("Issuer mismatch");
+  });
+
+  it("fails on fetch timeout (AbortError)", async () => {
+    mockFetch(async () => {
+      throw new DOMException("The operation was aborted", "AbortError");
+    });
+
+    const result = await testOidcProvider(oidcProvider);
+    expect(result.success).toBe(false);
+    expect(result.errors![0]).toContain("timed out");
+  });
+
+  it("fails on network error", async () => {
+    mockFetch(async () => {
+      throw new Error("getaddrinfo ENOTFOUND");
+    });
+
+    const result = await testOidcProvider(oidcProvider);
+    expect(result.success).toBe(false);
+    expect(result.errors![0]).toContain("Failed to reach");
+    expect(result.errors![0]).toContain("ENOTFOUND");
+  });
+
+  it("rejects non-HTTPS URL", async () => {
+    const badProvider: SSOOidcProvider = {
+      ...oidcProvider,
+      config: { ...oidcProvider.config, discoveryUrl: "file:///etc/passwd" },
+    };
+
+    const result = await testOidcProvider(badProvider);
+    expect(result.success).toBe(false);
+    expect(result.errors![0]).toContain("unsupported protocol");
+  });
+});
+
+// ── SAML cert fixture ──────────────────────────────────────────────
+
+// Self-signed cert generated for testing (valid 2026-04-06 to 2030-04-05)
+const VALID_SELF_SIGNED_CERT = `-----BEGIN CERTIFICATE-----
+MIIDFzCCAf+gAwIBAgIUQCSGvDJthfMZ0SHEJaVbZ6eF2n4wDQYJKoZIhvcNAQEL
+BQAwGzEZMBcGA1UEAwwQdGVzdC5leGFtcGxlLmNvbTAeFw0yNjA0MDYyMjQ4MzJa
+Fw0zMDA0MDUyMjQ4MzJaMBsxGTAXBgNVBAMMEHRlc3QuZXhhbXBsZS5jb20wggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDeePGI8U+2eqhqRJ0NUUqoWQJ3
+EXC+JVPfP14xUZBIkfbzqXGF1p4h60MGN9rHrWMI7fW+Dwgu3wEGC3vVpLpHKxNw
+EpftRQk6tTJRqPmHuPB0+modGUObN4EPoYQC7Pj7Wv1+DO4bQNDcjTPbjifcNK1p
+a96gv9jx4LY9eTwEW826sQujayPeCqTteDJsR4J7H1CWxODzoqOXUpPo/xB08re+
+RS71Rav6XScupLKWL3iKyCCnwunCp5RI5f0pba+0V8Z0kEy8rZ3oKVHteabYCNYw
+c7vq0IexhFyPL2/YqxRpuywwzNXTzNxI74jVpD50bwDrW/BXg/5FyNTC5Ua9AgMB
+AAGjUzBRMB0GA1UdDgQWBBQACdVF4IUgb1bLZlEigwx6UPAkgDAfBgNVHSMEGDAW
+gBQACdVF4IUgb1bLZlEigwx6UPAkgDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3
+DQEBCwUAA4IBAQACKkWx5gimQXs7flQzALHnE8ej7UerSRN+DUAfmCxlLVZC/LPP
+9OC2T7oUfWRyHz0C8XVHzJvuDpHWN8WtbIpk4JDkEQBysvskP3Yl2xrD7SbvprDG
+XHIOvK/MEYMivJn41pNyVKGcvTB/A4879fCnJ8gKZMi2kUVCUK9CidcL0l68zdGd
+1qe5xpSJ6d6y+6t8pf3cK6uJLkSQ5YzQq2OvTGNJ/m2BmmbxbB6FGLSPGg/6zZU2
+gibJD2n7auzsYMABf9T8LASCtwi4Y0Gf1TB4pCUcG7Jutk148FG4emKtJwYxZKkB
+ByTeG8DfNTXzmBOR0LDHC+Z4uBHXPiVCbSAs
+-----END CERTIFICATE-----`;
+
+const samlProvider: SSOSamlProvider = {
+  id: "prov-saml",
+  orgId: "org-1",
+  type: "saml",
+  issuer: "https://idp.example.com",
+  domain: "example.com",
+  enabled: true,
+  ssoEnforced: false,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+  config: {
+    idpEntityId: "https://idp.example.com",
+    idpSsoUrl: "https://idp.example.com/sso",
+    idpCertificate: VALID_SELF_SIGNED_CERT,
+  },
+};
+
+describe("testSamlProvider", () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("succeeds with valid cert and reachable IdP", async () => {
+    mockFetch(async () => new Response("", { status: 200 }));
+
+    const result = await testSamlProvider(samlProvider);
+    const d = result.details as SSOSamlTestDetails;
+    expect(result.type).toBe("saml");
+    expect(result.success).toBe(true);
+    expect(result.testedAt).toBeDefined();
+    expect(d.certValid).toBe(true);
+    expect(d.certSubject).toContain("test.example.com");
+    expect(d.certExpiry).toBeDefined();
+    expect(typeof d.certDaysRemaining).toBe("number");
+    expect(d.idpReachable).toBe(true);
+  });
+
+  it("fails with malformed PEM", async () => {
+    mockFetch(async () => new Response("", { status: 200 }));
+    const badProvider: SSOSamlProvider = {
+      ...samlProvider,
+      config: { ...samlProvider.config, idpCertificate: "NOT A CERT" },
+    };
+
+    const result = await testSamlProvider(badProvider);
+    const d = result.details as SSOSamlTestDetails;
+    expect(result.success).toBe(false);
+    expect(d.certValid).toBe(false);
+    expect(result.errors![0]).toContain("Malformed PEM");
+  });
+
+  it("reports unreachable IdP with timeout", async () => {
+    mockFetch(async () => {
+      throw new DOMException("The operation was aborted", "AbortError");
+    });
+
+    const result = await testSamlProvider(samlProvider);
+    const d = result.details as SSOSamlTestDetails;
+    // Cert is still valid — only IdP is unreachable
+    expect(result.success).toBe(true);
+    expect(d.idpReachable).toBe(false);
+    expect(result.errors![0]).toContain("timed out");
+  });
+
+  it("reports IdP server error (5xx)", async () => {
+    mockFetch(async () => new Response("", { status: 503 }));
+
+    const result = await testSamlProvider(samlProvider);
+    const d = result.details as SSOSamlTestDetails;
+    expect(result.success).toBe(true);
+    expect(d.idpReachable).toBe(true);
+    expect(result.errors![0]).toContain("server error");
+    expect(result.errors![0]).toContain("503");
+  });
+
+  it("treats 405 (HEAD not supported) as reachable without error", async () => {
+    mockFetch(async () => new Response("", { status: 405 }));
+
+    const result = await testSamlProvider(samlProvider);
+    const d = result.details as SSOSamlTestDetails;
+    expect(result.success).toBe(true);
+    expect(d.idpReachable).toBe(true);
+    expect(result.errors).toBeUndefined();
+  });
+
+  it("rejects non-HTTPS IdP URL", async () => {
+    const badProvider: SSOSamlProvider = {
+      ...samlProvider,
+      config: { ...samlProvider.config, idpSsoUrl: "ftp://internal.server/sso" },
+    };
+
+    const result = await testSamlProvider(badProvider);
+    const d = result.details as SSOSamlTestDetails;
+    expect(d.idpReachable).toBe(false);
+    expect(result.errors!.find(e => e.includes("unsupported protocol"))).toBeDefined();
+  });
+});
+
+describe("testSSOProvider (Effect wrapper)", () => {
+  beforeEach(() => ee.reset());
+
+  it("throws when enterprise is disabled", async () => {
+    ee.setEnterpriseEnabled(false);
+    await expect(run(testSSOProvider("org-1", "prov-1"))).rejects.toThrow("Enterprise features");
+  });
+
+  it("throws SSOError when provider not found", async () => {
+    ee.queueMockRows([]);
+    await expect(run(testSSOProvider("org-1", "nonexistent"))).rejects.toThrow("not found");
   });
 });

--- a/ee/src/auth/sso.ts
+++ b/ee/src/auth/sso.ts
@@ -24,6 +24,9 @@ import type {
   SSOProviderType,
   SSOSamlConfig,
   SSOOidcConfig,
+  SSOTestResult,
+  SSOOidcTestDetails,
+  SSOSamlTestDetails,
   CreateSSOProviderRequest,
   UpdateSSOProviderRequest,
 } from "@useatlas/types";
@@ -401,20 +404,26 @@ export const findProviderByDomain = (emailDomain: string): Effect.Effect<SSOProv
     return rows[0] ? rowToProvider(rows[0]) : null;
   });
 
-/**
- * Extract the domain part from an email address.
- * Returns null for invalid addresses.
- */
 // ── Test connection ─────────────────────────────────────────────────
 
-/** Structured result from testing an SSO provider's connectivity/config. */
-export interface SSOTestResult {
-  success: boolean;
-  details: Record<string, unknown>;
-  errors?: string[];
-}
+// Re-export wire types so route modules can import from ee/auth/sso
+export type { SSOTestResult, SSOOidcTestDetails, SSOSamlTestDetails } from "@useatlas/types";
 
 const TEST_TIMEOUT_MS = 5_000;
+
+/**
+ * Validate that a URL is HTTPS (or HTTP in dev) before making outbound requests.
+ * Blocks non-HTTP(S) schemes to prevent SSRF via file://, data://, etc.
+ */
+function validateTestUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === "https:" || parsed.protocol === "http:") return null;
+    return `URL has unsupported protocol: ${parsed.protocol}`;
+  } catch {
+    return `Not a valid URL: "${url}"`;
+  }
+}
 
 /**
  * Test an OIDC provider by fetching its discovery document and validating
@@ -422,40 +431,59 @@ const TEST_TIMEOUT_MS = 5_000;
  */
 export async function testOidcProvider(provider: SSOProvider & { type: "oidc" }): Promise<SSOTestResult> {
   const errors: string[] = [];
-  const details: Record<string, unknown> = {
+  const warnings: string[] = [];
+  const details: SSOOidcTestDetails = {
     discoveryReachable: false,
     issuerMatch: false,
     requiredFieldsPresent: false,
     endpoints: {},
   };
 
+  // Validate URL scheme before outbound request
+  const urlError = validateTestUrl(provider.config.discoveryUrl);
+  if (urlError) {
+    errors.push(`Discovery URL: ${urlError}`);
+    return { type: "oidc", success: false, testedAt: new Date().toISOString(), details, errors };
+  }
+
   let discoveryJson: Record<string, unknown>;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TEST_TIMEOUT_MS);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), TEST_TIMEOUT_MS);
     const res = await fetch(provider.config.discoveryUrl, { signal: controller.signal });
     clearTimeout(timer);
 
     if (!res.ok) {
       errors.push(`Discovery URL returned HTTP ${res.status}`);
-      return { success: false, details, errors };
+      return { type: "oidc", success: false, testedAt: new Date().toISOString(), details, errors };
     }
 
     const contentType = res.headers.get("content-type") ?? "";
-    const text = await res.text();
+
+    let text: string;
+    try {
+      text = await res.text();
+    } catch (bodyErr) {
+      details.discoveryReachable = true;
+      errors.push(`Discovery URL reachable but body could not be read: ${bodyErr instanceof Error ? bodyErr.message : String(bodyErr)}`);
+      return { type: "oidc", success: false, testedAt: new Date().toISOString(), details, errors };
+    }
+
     try {
       discoveryJson = JSON.parse(text) as Record<string, unknown>;
-    } catch {
-      errors.push("Discovery URL returned non-JSON body" + (contentType ? ` (content-type: ${contentType})` : ""));
-      return { success: false, details, errors };
+    } catch (parseErr) {
+      const reason = parseErr instanceof Error ? parseErr.message : String(parseErr);
+      errors.push(`Discovery URL returned non-JSON body (${reason})` + (contentType ? ` (content-type: ${contentType})` : ""));
+      return { type: "oidc", success: false, testedAt: new Date().toISOString(), details, errors };
     }
   } catch (err) {
+    clearTimeout(timer);
     if (err instanceof DOMException && err.name === "AbortError") {
       errors.push(`Discovery URL timed out after ${TEST_TIMEOUT_MS}ms`);
     } else {
       errors.push(`Failed to reach discovery URL: ${err instanceof Error ? err.message : String(err)}`);
     }
-    return { success: false, details, errors };
+    return { type: "oidc", success: false, testedAt: new Date().toISOString(), details, errors };
   }
 
   details.discoveryReachable = true;
@@ -470,7 +498,7 @@ export async function testOidcProvider(provider: SSOProvider & { type: "oidc" })
 
   // Populate endpoints from discovery
   details.endpoints = Object.fromEntries(
-    requiredFields.filter((f) => typeof discoveryJson[f] === "string").map((f) => [f, discoveryJson[f]]),
+    requiredFields.filter((f) => typeof discoveryJson[f] === "string").map((f) => [f, discoveryJson[f] as string]),
   );
 
   // Check issuer match
@@ -481,16 +509,24 @@ export async function testOidcProvider(provider: SSOProvider & { type: "oidc" })
     }
   }
 
-  return { success: errors.length === 0, details, errors: errors.length > 0 ? errors : undefined };
+  return {
+    type: "oidc",
+    success: errors.length === 0,
+    testedAt: new Date().toISOString(),
+    details,
+    errors: errors.length > 0 ? errors : undefined,
+    warnings: warnings.length > 0 ? warnings : undefined,
+  };
 }
 
 /**
- * Test a SAML provider by parsing its X.509 certificate and optionally
- * checking the IdP SSO URL reachability.
+ * Test a SAML provider by parsing its X.509 certificate and checking
+ * the IdP SSO URL reachability.
  */
 export async function testSamlProvider(provider: SSOProvider & { type: "saml" }): Promise<SSOTestResult> {
   const errors: string[] = [];
-  const details: Record<string, unknown> = {
+  const warnings: string[] = [];
+  const details: SSOSamlTestDetails = {
     certValid: false,
     certSubject: null,
     certExpiry: null,
@@ -507,50 +543,70 @@ export async function testSamlProvider(provider: SSOProvider & { type: "saml" })
     details.certExpiry = cert.validTo;
 
     const expiryDate = new Date(cert.validTo);
-    const now = new Date();
-    const daysRemaining = Math.floor((expiryDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
-    details.certDaysRemaining = daysRemaining;
+    if (isNaN(expiryDate.getTime())) {
+      errors.push(`Could not parse certificate expiry date: "${cert.validTo}"`);
+    } else {
+      const now = new Date();
+      const daysRemaining = Math.floor((expiryDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+      details.certDaysRemaining = daysRemaining;
 
-    if (daysRemaining < 0) {
-      errors.push(`Certificate expired ${Math.abs(daysRemaining)} day(s) ago`);
-      details.certValid = false;
-    } else if (daysRemaining < 30) {
-      errors.push(`Certificate expires in ${daysRemaining} day(s) — consider renewing soon`);
+      if (daysRemaining < 0) {
+        errors.push(`Certificate expired ${Math.abs(daysRemaining)} day(s) ago`);
+        details.certValid = false;
+      } else if (daysRemaining < 30) {
+        // Expiry warning — cert is still valid, so this is a warning not an error
+        warnings.push(`Certificate expires in ${daysRemaining} day(s) — consider renewing soon`);
+      }
     }
   } catch (err) {
     details.certValid = false;
     errors.push(`Malformed PEM certificate: ${err instanceof Error ? err.message : String(err)}`);
   }
 
-  // Check IdP SSO URL reachability
-  try {
+  // Check IdP SSO URL reachability (validate URL scheme first)
+  const idpUrlError = validateTestUrl(provider.config.idpSsoUrl);
+  if (idpUrlError) {
+    details.idpReachable = false;
+    errors.push(`IdP SSO URL: ${idpUrlError}`);
+  } else {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), TEST_TIMEOUT_MS);
-    const res = await fetch(provider.config.idpSsoUrl, { method: "HEAD", signal: controller.signal });
-    clearTimeout(timer);
-    // Any response (even 4xx) means the server is reachable
-    details.idpReachable = true;
-    // Some IdPs return 405 for HEAD — that's still "reachable"
-    if (res.status >= 500) {
-      errors.push(`IdP SSO URL returned server error (HTTP ${res.status})`);
-    }
-  } catch (err) {
-    details.idpReachable = false;
-    if (err instanceof DOMException && err.name === "AbortError") {
-      errors.push(`IdP SSO URL timed out after ${TEST_TIMEOUT_MS}ms`);
-    } else {
-      errors.push(`IdP SSO URL unreachable: ${err instanceof Error ? err.message : String(err)}`);
+    try {
+      const res = await fetch(provider.config.idpSsoUrl, { method: "HEAD", signal: controller.signal });
+      clearTimeout(timer);
+      // Any response (even 4xx) means the server is reachable.
+      // Some IdPs return 405 for HEAD — that's still "reachable".
+      details.idpReachable = true;
+      if (res.status >= 500) {
+        errors.push(`IdP SSO URL returned server error (HTTP ${res.status})`);
+      }
+    } catch (err) {
+      clearTimeout(timer);
+      details.idpReachable = false;
+      if (err instanceof DOMException && err.name === "AbortError") {
+        errors.push(`IdP SSO URL timed out after ${TEST_TIMEOUT_MS}ms`);
+      } else {
+        errors.push(`IdP SSO URL unreachable: ${err instanceof Error ? err.message : String(err)}`);
+      }
     }
   }
 
-  // Success if cert is valid (warnings about expiry < 30 days don't fail the test)
-  const certIsValid = details.certValid === true;
-  return { success: certIsValid, details, errors: errors.length > 0 ? errors : undefined };
+  // Success is determined solely by certificate validity — expiry warnings (< 30 days)
+  // and IdP reachability failures do not fail the test.
+  return {
+    type: "saml",
+    success: details.certValid,
+    testedAt: new Date().toISOString(),
+    details,
+    errors: errors.length > 0 ? errors : undefined,
+    warnings: warnings.length > 0 ? warnings : undefined,
+  };
 }
 
 /**
- * Test an SSO provider's configuration. Dispatches to OIDC or SAML test
- * based on provider type.
+ * Test an SSO provider's configuration. Requires enterprise license.
+ * Looks up the provider by org + ID (fails with SSOError if not found),
+ * then dispatches to the OIDC or SAML test based on provider type.
  */
 export const testSSOProvider = (
   orgId: string,
@@ -565,13 +621,29 @@ export const testSSOProvider = (
     }
 
     if (provider.type === "oidc") {
-      return yield* Effect.promise(() => testOidcProvider(provider));
+      return yield* Effect.tryPromise({
+        try: () => testOidcProvider(provider),
+        catch: (err) => new SSOError(
+          `OIDC test failed unexpectedly: ${err instanceof Error ? err.message : String(err)}`,
+          "validation",
+        ),
+      });
     }
-    return yield* Effect.promise(() => testSamlProvider(provider));
+    return yield* Effect.tryPromise({
+      try: () => testSamlProvider(provider),
+      catch: (err) => new SSOError(
+        `SAML test failed unexpectedly: ${err instanceof Error ? err.message : String(err)}`,
+        "validation",
+      ),
+    });
   });
 
 // ── Domain matching ─────────────────────────────────────────────────
 
+/**
+ * Extract the domain part from an email address.
+ * Returns null for invalid addresses.
+ */
 export function extractEmailDomain(email: string): string | null {
   const at = email.lastIndexOf("@");
   if (at < 1 || at === email.length - 1) return null;

--- a/packages/api/src/api/__tests__/admin-sso.test.ts
+++ b/packages/api/src/api/__tests__/admin-sso.test.ts
@@ -2,9 +2,9 @@
  * Tests for SSO test connection endpoint.
  *
  * Covers: POST /api/v1/admin/sso/providers/:id/test
- * - OIDC: valid discovery, invalid JSON, missing fields, issuer mismatch, timeout
- * - SAML: valid cert, expired cert, malformed PEM, IdP reachability
- * - 404 for non-existent provider, 404 for wrong org
+ * - OIDC: valid discovery, unreachable/timeout, non-JSON response, missing fields, issuer mismatch
+ * - SAML: valid cert, expired cert, malformed PEM
+ * - 404 for non-existent provider, 404 for wrong org, 403 for non-admin
  */
 
 import {
@@ -48,7 +48,7 @@ class MockSSOEnforcementError extends Error {
 const mockGetSSOProvider: Mock<(orgId: string, providerId: string) => Effect.Effect<unknown, unknown>> =
   mock(() => Effect.succeed(null));
 const mockTestSSOProvider: Mock<(orgId: string, providerId: string) => Effect.Effect<unknown, unknown>> =
-  mock(() => Effect.succeed({ success: true, details: {} }));
+  mock(() => Effect.succeed({ type: "oidc", success: true, testedAt: "2026-04-06T00:00:00.000Z", details: {} }));
 
 mock.module("@atlas/ee/auth/sso", () => ({
   // CRUD (unused but must be mocked)
@@ -59,8 +59,8 @@ mock.module("@atlas/ee/auth/sso", () => ({
   deleteSSOProvider: mock(() => Effect.succeed(false)),
   // Test
   testSSOProvider: mockTestSSOProvider,
-  testOidcProvider: mock(async () => ({ success: true, details: {} })),
-  testSamlProvider: mock(async () => ({ success: true, details: {} })),
+  testOidcProvider: mock(async () => ({ type: "oidc", success: true, testedAt: "2026-04-06T00:00:00.000Z", details: {} })),
+  testSamlProvider: mock(async () => ({ type: "saml", success: true, testedAt: "2026-04-06T00:00:00.000Z", details: {} })),
   // Enforcement
   setSSOEnforcement: mock(() => Effect.succeed({ enforced: false, orgId: "org-1" })),
   isSSOEnforced: mock(() => Effect.succeed({ enforced: false })),
@@ -126,7 +126,9 @@ describe("Admin SSO Test Connection API", () => {
     it("returns OIDC test result with valid discovery", async () => {
       mockTestSSOProvider.mockImplementation(() =>
         Effect.succeed({
+          type: "oidc",
           success: true,
+          testedAt: "2026-04-06T00:00:00.000Z",
           details: {
             discoveryReachable: true,
             issuerMatch: true,
@@ -146,7 +148,9 @@ describe("Admin SSO Test Connection API", () => {
       );
       expect(res.status).toBe(200);
       const body = (await res.json()) as Record<string, unknown>;
+      expect(body.type).toBe("oidc");
       expect(body.success).toBe(true);
+      expect(body.testedAt).toBe("2026-04-06T00:00:00.000Z");
       const details = body.details as Record<string, unknown>;
       expect(details.discoveryReachable).toBe(true);
       expect(details.issuerMatch).toBe(true);
@@ -156,7 +160,9 @@ describe("Admin SSO Test Connection API", () => {
     it("returns OIDC failure for unreachable discovery URL", async () => {
       mockTestSSOProvider.mockImplementation(() =>
         Effect.succeed({
+          type: "oidc",
           success: false,
+          testedAt: "2026-04-06T00:00:00.000Z",
           details: {
             discoveryReachable: false,
             issuerMatch: false,
@@ -179,14 +185,16 @@ describe("Admin SSO Test Connection API", () => {
     it("returns OIDC failure for non-JSON response", async () => {
       mockTestSSOProvider.mockImplementation(() =>
         Effect.succeed({
+          type: "oidc",
           success: false,
+          testedAt: "2026-04-06T00:00:00.000Z",
           details: {
             discoveryReachable: false,
             issuerMatch: false,
             requiredFieldsPresent: false,
             endpoints: {},
           },
-          errors: ["Discovery URL returned non-JSON body"],
+          errors: ["Discovery URL returned non-JSON body (Unexpected token <)"],
         }),
       );
 
@@ -202,7 +210,9 @@ describe("Admin SSO Test Connection API", () => {
     it("returns OIDC failure for missing discovery fields", async () => {
       mockTestSSOProvider.mockImplementation(() =>
         Effect.succeed({
+          type: "oidc",
           success: false,
+          testedAt: "2026-04-06T00:00:00.000Z",
           details: {
             discoveryReachable: true,
             issuerMatch: false,
@@ -225,7 +235,9 @@ describe("Admin SSO Test Connection API", () => {
     it("returns OIDC failure for issuer mismatch", async () => {
       mockTestSSOProvider.mockImplementation(() =>
         Effect.succeed({
+          type: "oidc",
           success: false,
+          testedAt: "2026-04-06T00:00:00.000Z",
           details: {
             discoveryReachable: true,
             issuerMatch: false,
@@ -248,7 +260,9 @@ describe("Admin SSO Test Connection API", () => {
     it("returns SAML test result with valid certificate", async () => {
       mockTestSSOProvider.mockImplementation(() =>
         Effect.succeed({
+          type: "saml",
           success: true,
+          testedAt: "2026-04-06T00:00:00.000Z",
           details: {
             certValid: true,
             certSubject: "CN=idp.example.com",
@@ -264,7 +278,9 @@ describe("Admin SSO Test Connection API", () => {
       );
       expect(res.status).toBe(200);
       const body = (await res.json()) as Record<string, unknown>;
+      expect(body.type).toBe("saml");
       expect(body.success).toBe(true);
+      expect(body.testedAt).toBe("2026-04-06T00:00:00.000Z");
       const details = body.details as Record<string, unknown>;
       expect(details.certValid).toBe(true);
       expect(details.idpReachable).toBe(true);
@@ -273,7 +289,9 @@ describe("Admin SSO Test Connection API", () => {
     it("returns SAML failure for expired certificate", async () => {
       mockTestSSOProvider.mockImplementation(() =>
         Effect.succeed({
+          type: "saml",
           success: false,
+          testedAt: "2026-04-06T00:00:00.000Z",
           details: {
             certValid: false,
             certSubject: "CN=idp.example.com",
@@ -297,7 +315,9 @@ describe("Admin SSO Test Connection API", () => {
     it("returns SAML failure for malformed PEM", async () => {
       mockTestSSOProvider.mockImplementation(() =>
         Effect.succeed({
+          type: "saml",
           success: false,
+          testedAt: "2026-04-06T00:00:00.000Z",
           details: {
             certValid: false,
             certSubject: null,
@@ -316,6 +336,34 @@ describe("Admin SSO Test Connection API", () => {
       const body = (await res.json()) as Record<string, unknown>;
       expect(body.success).toBe(false);
       expect((body.errors as string[])[0]).toContain("Malformed PEM");
+    });
+
+    it("returns SAML warning for cert expiring within 30 days", async () => {
+      mockTestSSOProvider.mockImplementation(() =>
+        Effect.succeed({
+          type: "saml",
+          success: true,
+          testedAt: "2026-04-06T00:00:00.000Z",
+          details: {
+            certValid: true,
+            certSubject: "CN=idp.example.com",
+            certExpiry: "2026-04-20T00:00:00Z",
+            certDaysRemaining: 14,
+            idpReachable: true,
+          },
+          warnings: ["Certificate expires in 14 day(s) — consider renewing soon"],
+        }),
+      );
+
+      const res = await app.fetch(
+        adminRequest("POST", "/api/v1/admin/sso/providers/prov-2/test"),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      // success is true — expiry warning does not fail the test
+      expect(body.success).toBe(true);
+      expect((body.warnings as string[])[0]).toContain("expires in 14 day(s)");
+      expect(body.errors).toBeUndefined();
     });
 
     it("returns 404 for non-existent provider", async () => {

--- a/packages/api/src/api/routes/admin-sso.ts
+++ b/packages/api/src/api/routes/admin-sso.ts
@@ -82,11 +82,39 @@ const UpdateSSOProviderBodySchema = z.object({
   config: z.record(z.string(), z.unknown()).optional(),
 });
 
-const SSOTestResultSchema = z.object({
-  success: z.boolean(),
-  details: z.record(z.string(), z.unknown()),
-  errors: z.array(z.string()).optional(),
+const SSOOidcTestDetailsSchema = z.object({
+  discoveryReachable: z.boolean(),
+  issuerMatch: z.boolean(),
+  requiredFieldsPresent: z.boolean(),
+  endpoints: z.record(z.string(), z.string()),
 });
+
+const SSOSamlTestDetailsSchema = z.object({
+  certValid: z.boolean(),
+  certSubject: z.string().nullable(),
+  certExpiry: z.string().nullable(),
+  certDaysRemaining: z.number().nullable(),
+  idpReachable: z.boolean().nullable(),
+});
+
+const SSOTestResultSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("oidc"),
+    success: z.boolean(),
+    testedAt: z.string(),
+    details: SSOOidcTestDetailsSchema,
+    errors: z.array(z.string()).optional(),
+    warnings: z.array(z.string()).optional(),
+  }),
+  z.object({
+    type: z.literal("saml"),
+    success: z.boolean(),
+    testedAt: z.string(),
+    details: SSOSamlTestDetailsSchema,
+    errors: z.array(z.string()).optional(),
+    warnings: z.array(z.string()).optional(),
+  }),
+]);
 
 const SSOEnforcementBodySchema = z.object({
   enforced: z.boolean(),

--- a/packages/types/src/sso.ts
+++ b/packages/types/src/sso.ts
@@ -82,3 +82,27 @@ export interface SSOProviderListResponse {
   providers: SSOProvider[];
   total: number;
 }
+
+// ── Test connection result ─────────────────────────────────────────
+
+/** OIDC-specific test details from discovery document validation. */
+export interface SSOOidcTestDetails {
+  discoveryReachable: boolean;
+  issuerMatch: boolean;
+  requiredFieldsPresent: boolean;
+  endpoints: Record<string, string>;
+}
+
+/** SAML-specific test details from certificate and IdP validation. */
+export interface SSOSamlTestDetails {
+  certValid: boolean;
+  certSubject: string | null;
+  certExpiry: string | null;
+  certDaysRemaining: number | null;
+  idpReachable: boolean | null;
+}
+
+/** Discriminated union for SSO provider test results. */
+export type SSOTestResult =
+  | { type: "oidc"; success: boolean; testedAt: string; details: SSOOidcTestDetails; errors?: string[]; warnings?: string[] }
+  | { type: "saml"; success: boolean; testedAt: string; details: SSOSamlTestDetails; errors?: string[]; warnings?: string[] };


### PR DESCRIPTION
## Summary

Closes #1333 (parent PRD: #1331)

- **New endpoint**: `POST /api/v1/admin/sso/providers/{id}/test` — validates SSO provider config before it goes live
- **OIDC test**: fetches `.well-known/openid-configuration`, validates required fields (`issuer`, `authorization_endpoint`, `token_endpoint`, `jwks_uri`), checks issuer match against provider config. Handles timeout (5s), non-200, non-JSON, missing fields
- **SAML test**: parses X.509 PEM certificate via `crypto.X509Certificate`, reports subject/expiry/days remaining, errors on expired cert, warns if <30 days. HEADs `idpSsoUrl` to check reachability. Handles malformed PEM, unreachable IdP
- **Returns**: `{ success, details, errors? }` — structured result for UI consumption

### Files changed

| File | Change |
|------|--------|
| `ee/src/auth/sso.ts` | Added `testOidcProvider`, `testSamlProvider`, `testSSOProvider`, `SSOTestResult` |
| `packages/api/src/api/routes/admin-sso.ts` | Added `POST /providers/{id}/test` route + handler |
| `packages/api/src/api/__tests__/admin-sso.test.ts` | 11 tests: OIDC (valid, timeout, non-JSON, missing fields, issuer mismatch), SAML (valid cert, expired, malformed PEM), 404 cases, 403 for non-admin |

## Test plan

- [x] `bun test packages/api/src/api/__tests__/admin-sso.test.ts` — 11 pass
- [x] `bun run test` — full suite passes
- [x] `bun run type` — no new type errors
- [x] `bun run lint` — no new lint errors
- [x] `bun x syncpack lint` — clean