### PR TITLE
refactor: extract shared DNS domain verification utility

### DIFF
--- a/ee/src/auth/sso.ts
+++ b/ee/src/auth/sso.ts
@@ -243,6 +243,7 @@ export const verifyDomain = (
     const dnsResult = yield* verifyDnsTxt(provider.domain, provider.verification_token);
 
     if (!dnsResult.ok) {
+      log.warn({ providerId, domain: provider.domain, reason: dnsResult.reason }, "SSO domain DNS verification failed");
       yield* Effect.tryPromise({
         try: () => internalQuery(
           `UPDATE sso_providers SET domain_verification_status = 'failed', updated_at = now() WHERE id = $1 AND org_id = $2`,

--- a/ee/src/lib/domain-verification.test.ts
+++ b/ee/src/lib/domain-verification.test.ts
@@ -20,8 +20,8 @@ mock.module("@atlas/api/lib/logger", () => ({
 
 const { generateVerificationToken, verifyDnsTxt } = await import("./domain-verification");
 
-const run = <A, E>(effect: Effect.Effect<A, E>): Promise<A> =>
-  Effect.runPromise(effect as Effect.Effect<A, never>);
+const run = <A>(effect: Effect.Effect<A, never>): Promise<A> =>
+  Effect.runPromise(effect);
 
 describe("generateVerificationToken", () => {
   it("returns token in atlas-verify=<uuid> format", () => {
@@ -53,7 +53,9 @@ describe("verifyDnsTxt", () => {
 
     const result = await run(verifyDnsTxt("example.com", token));
     expect(result.ok).toBe(true);
-    expect(result.verified).toBe(true);
+    if (result.ok) {
+      expect(result.records).toEqual([token]);
+    }
   });
 
   it("handles multi-part TXT records (DNS 255-byte chunks)", async () => {
@@ -62,7 +64,9 @@ describe("verifyDnsTxt", () => {
 
     const result = await run(verifyDnsTxt("example.com", token));
     expect(result.ok).toBe(true);
-    expect(result.verified).toBe(true);
+    if (result.ok) {
+      expect(result.records).toEqual([token]);
+    }
   });
 
   it("returns no_match when token not found in records", async () => {
@@ -70,12 +74,11 @@ describe("verifyDnsTxt", () => {
 
     const result = await run(verifyDnsTxt("example.com", "atlas-verify=expected"));
     expect(result.ok).toBe(false);
-    expect(result.verified).toBe(false);
     if (!result.ok) {
       expect(result.reason).toBe("no_match");
       expect(result.message).toContain("No matching TXT record");
       expect(result.message).toContain("atlas-verify=expected");
-      expect(result.records).toBeDefined();
+      expect(result.records).toEqual(["some-other-record", "unrelated-txt"]);
     }
   });
 
@@ -84,10 +87,24 @@ describe("verifyDnsTxt", () => {
 
     const result = await run(verifyDnsTxt("example.com", "atlas-verify=test"));
     expect(result.ok).toBe(false);
-    expect(result.verified).toBe(false);
     if (!result.ok) {
       expect(result.reason).toBe("dns_error");
       expect(result.message).toContain("DNS lookup failed");
+      expect(result.records).toEqual([]);
+    }
+  });
+
+  it("returns timeout when DNS lookup exceeds deadline", async () => {
+    mockResolveTxt.mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve([]), 5_000)),
+    );
+
+    const result = await run(verifyDnsTxt("example.com", "atlas-verify=test", 50));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("timeout");
+      expect(result.message).toContain("timed out");
+      expect(result.records).toEqual([]);
     }
   });
 
@@ -96,9 +113,9 @@ describe("verifyDnsTxt", () => {
 
     const result = await run(verifyDnsTxt("example.com", "atlas-verify=test"));
     expect(result.ok).toBe(false);
-    expect(result.verified).toBe(false);
     if (!result.ok) {
       expect(result.reason).toBe("no_match");
+      expect(result.records).toEqual([]);
     }
   });
 
@@ -112,7 +129,9 @@ describe("verifyDnsTxt", () => {
 
     const result = await run(verifyDnsTxt("example.com", token));
     expect(result.ok).toBe(true);
-    expect(result.verified).toBe(true);
+    if (result.ok) {
+      expect(result.records).toContain(token);
+    }
   });
 
   it("includes domain in failure message", async () => {

--- a/ee/src/lib/domain-verification.ts
+++ b/ee/src/lib/domain-verification.ts
@@ -3,8 +3,7 @@
  *
  * Used by SSO domain verification (ee/src/auth/sso.ts) to prove domain
  * ownership via DNS TXT records. Custom domains (ee/src/platform/domains.ts)
- * use Railway's CNAME/cert verification instead, but could adopt this
- * utility for additional ownership proof in the future.
+ * use a separate Railway-based verification flow.
  *
  * Token format: `atlas-verify=<uuid>`
  * Verification: DNS TXT lookup with timeout, returns structured result.
@@ -19,23 +18,26 @@ const log = createLogger("ee:domain-verification");
 
 // ── Types ──────────────────────────────────────────────────────────
 
-export type DomainVerificationStatus = "pending" | "verified" | "failed";
-
 export interface DnsTxtResult {
   readonly ok: true;
-  readonly verified: true;
   readonly records: string[];
 }
 
 export interface DnsTxtFailure {
   readonly ok: false;
-  readonly verified: false;
   readonly reason: "dns_error" | "no_match" | "timeout";
   readonly message: string;
-  readonly records?: string[];
+  readonly records: string[];
 }
 
 export type DnsTxtVerificationResult = DnsTxtResult | DnsTxtFailure;
+
+// ── Typed timeout sentinel ─────────────────────────────────────────
+
+class DnsTimeoutError extends Error {
+  readonly _tag = "DnsTimeoutError";
+  constructor() { super("DNS lookup timed out"); }
+}
 
 // ── Token generation ───────────────────────────────────────────────
 
@@ -55,9 +57,10 @@ export function generateVerificationToken(): string {
 /**
  * Verify domain ownership by checking DNS TXT records for the expected token.
  *
- * Performs a DNS TXT lookup with a configurable timeout (default 10s).
- * TXT records are flattened (multi-part records joined) before comparison.
- * Returns a structured result — never throws.
+ * Performs a DNS TXT lookup with a configurable timeout via `timeoutMs`
+ * (default 10,000ms / 10s). TXT records are flattened (multi-part records
+ * joined) before comparison. Returns a structured result with the error
+ * encoded in the success channel (Effect error channel is `never`).
  */
 export const verifyDnsTxt = (
   domain: string,
@@ -71,25 +74,22 @@ export const verifyDnsTxt = (
     }).pipe(
       Effect.timeoutFail({
         duration: `${timeoutMs} millis`,
-        onTimeout: () => new Error("DNS lookup timed out"),
+        onTimeout: () => new DnsTimeoutError(),
       }),
       Effect.map((records) => ({ ok: true as const, records })),
       Effect.catchAll((err) => {
-        log.warn({ domain, err: err.message }, "DNS TXT lookup failed");
-        return Effect.succeed({
-          ok: false as const,
-          reason: err.message.includes("timed out") ? "timeout" as const : "dns_error" as const,
-          message: err.message,
-        });
+        const reason = err instanceof DnsTimeoutError ? "timeout" as const : "dns_error" as const;
+        log.warn({ domain, err: err.message, reason }, "DNS TXT lookup failed");
+        return Effect.succeed({ ok: false as const, reason, message: err.message });
       }),
     );
 
     if (!dnsResult.ok) {
       return {
         ok: false as const,
-        verified: false as const,
         reason: dnsResult.reason,
         message: `DNS lookup failed for ${domain}: ${dnsResult.message}`,
+        records: [] as string[],
       };
     }
 
@@ -100,14 +100,12 @@ export const verifyDnsTxt = (
     if (found) {
       return {
         ok: true as const,
-        verified: true as const,
         records: flatRecords,
       };
     }
 
     return {
       ok: false as const,
-      verified: false as const,
       reason: "no_match" as const,
       message: `No matching TXT record found. Add a TXT record with value "${expectedToken}" to ${domain}.`,
       records: flatRecords,


### PR DESCRIPTION
## Summary
- Extracts `generateVerificationToken()` and `verifyDnsTxt()` from `ee/src/auth/sso.ts` into a new shared module `ee/src/lib/domain-verification.ts`
- SSO `verifyDomain` now delegates DNS TXT lookup to the shared utility — same behavior, less inline code (~35 lines removed)
- Custom domains (`ee/src/platform/domains.ts`) uses Railway CNAME/cert verification, not DNS TXT — filed #1345 for optional adoption

## What changed
| File | Change |
|------|--------|
| `ee/src/lib/domain-verification.ts` | **New** — `generateVerificationToken()`, `verifyDnsTxt()`, typed result discriminated union |
| `ee/src/lib/domain-verification.test.ts` | **New** — 10 tests: token format/uniqueness, DNS success/failure/timeout/multi-part/no-match |
| `ee/src/auth/sso.ts` | Replaced inline `dns.promises.resolveTxt` + `crypto` with imports from shared utility. Re-exports `generateVerificationToken` for existing consumers |

## Test plan
- [x] All 10 new domain-verification tests pass
- [x] All 85 existing SSO tests pass (no regressions)
- [x] Full test suite passes (all packages)
- [x] Lint clean
- [x] Type-check clean
- [x] Syncpack clean
- [x] Template drift check passes

Closes #1341