### PR TITLE
fix: SSO docs — correct error message format and error code

### DIFF
--- a/apps/docs/content/docs/guides/enterprise-sso.mdx
+++ b/apps/docs/content/docs/guides/enterprise-sso.mdx
@@ -202,7 +202,7 @@ When validation fails, the response includes `errors` and optionally `warnings`:
     "certDaysRemaining": null,
     "idpReachable": null
   },
-  "errors": ["Certificate is malformed or cannot be parsed."],
+  "errors": ["Malformed PEM certificate: no start line"],
   "warnings": []
 }
 ```
@@ -316,9 +316,8 @@ All SSO endpoints require the `admin` role and an active enterprise license. The
 
 | Status | Code | When |
 |--------|------|------|
-| 400 | `validation` | Invalid config fields, malformed domain |
+| 400 | `validation` | Invalid config fields, malformed domain, or enabling a provider whose domain is not verified |
 | 400 | `no_provider` | Trying to enable enforcement with no active SSO provider |
-| 400 | `domain_not_verified` | Trying to enable a provider whose domain is not verified |
 | 403 | `enterprise_required` | Enterprise license not active |
 | 404 | `not_found` | Provider ID doesn't exist |
 | 409 | `conflict` | Domain already claimed by another SSO provider |


### PR DESCRIPTION
## Summary
Follow-up to #1347. Fixes two inaccuracies caught by the comment-analyzer review agent:

- **SAML test failure example**: actual error format is `"Malformed PEM certificate: <reason>"` (from `sso.ts:758`), not `"Certificate is malformed or cannot be parsed."`
- **Error code `domain_not_verified`**: doesn't exist in `SSOErrorCode` union — the actual code is `validation` with a descriptive message. Merged into the existing validation row

## Test plan
- [ ] Verify error string matches `ee/src/auth/sso.ts:758` format
- [ ] Verify no `domain_not_verified` code exists in `SSOErrorCode` type