### PR TITLE
feat: DNS TXT domain ownership verification for custom domains

### DIFF
--- a/ee/src/auth/sso.test.ts
+++ b/ee/src/auth/sso.test.ts
@@ -274,6 +274,40 @@ describe("createSSOProvider", () => {
     expect(provider.domain).toBe("acme.com");
   });
 
+  it("auto-verifies domain when workspace has verified custom domain", async () => {
+    // Domain uniqueness check
+    ee.queueMockRows([]);
+    // Cross-domain: hasVerifiedCustomDomain check — returns a match
+    ee.queueMockRows([{ id: "dom-1" }]);
+    // INSERT RETURNING (with auto-verified fields)
+    ee.queueMockRows([{
+      ...sampleSamlRow,
+      domain_verified: true,
+      domain_verified_at: "2026-04-06T12:00:00Z",
+      domain_verification_status: "verified",
+    }]);
+
+    const provider = await run(createSSOProvider("org-1", {
+      type: "saml",
+      issuer: "https://idp.acme.com",
+      domain: "acme.com",
+      config: {
+        idpEntityId: "https://idp.acme.com",
+        idpSsoUrl: "https://idp.acme.com/sso",
+        idpCertificate: "-----BEGIN CERTIFICATE-----\nMIIC...\n-----END CERTIFICATE-----",
+      },
+    }));
+
+    expect(provider.domainVerified).toBe(true);
+    expect(provider.domainVerificationStatus).toBe("verified");
+
+    // Verify INSERT params include autoVerified=true and status="verified"
+    const insertQuery = ee.capturedQueries.find((q) => q.sql.includes("INSERT INTO sso_providers"));
+    expect(insertQuery).toBeDefined();
+    expect(insertQuery!.params[6]).toBe(true); // autoVerified
+    expect(insertQuery!.params[7]).toBe("verified"); // status
+  });
+
   it("rejects invalid domain", async () => {
     await expect(run(createSSOProvider("org-1", {
       type: "saml",

--- a/ee/src/auth/sso.ts
+++ b/ee/src/auth/sso.ts
@@ -411,14 +411,20 @@ export const createSSOProvider = (
       return verified;
     }).pipe(
       Effect.catchAll((err) => {
-        log.debug({ err: err instanceof Error ? err.message : String(err) }, "Cross-domain verification unavailable — skipping");
+        // Distinguish import failures (expected in AGPL builds) from runtime errors
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("Cannot find module") || msg.includes("MODULE_NOT_FOUND")) {
+          log.debug({ err: msg }, "Cross-domain verification unavailable — domains module not present");
+        } else {
+          log.warn({ orgId, domain, err: msg }, "Cross-domain auto-verification failed — SSO domain will require manual verification");
+        }
         return Effect.succeed(false);
       }),
     );
 
     const rows = yield* Effect.promise(() => internalQuery<SSOProviderRow>(
       `INSERT INTO sso_providers (org_id, type, issuer, domain, enabled, config, verification_token, domain_verified, domain_verified_at, domain_verification_status)
-       VALUES ($1, $2, $3, $4, false, $5, $6, $7, ${autoVerified ? "now()" : "NULL"}, $8)
+       VALUES ($1, $2, $3, $4, false, $5, $6, $7, CASE WHEN $7 = true THEN now() ELSE NULL END, $8)
        RETURNING id, org_id, type, issuer, domain, enabled, sso_enforced, config, created_at, updated_at, verification_token, domain_verified, domain_verified_at, domain_verification_status`,
       [orgId, input.type, input.issuer, domain, JSON.stringify(storedConfig), verificationToken, autoVerified, autoVerified ? "verified" : "pending"],
     ));

--- a/ee/src/lib/domain-verification.ts
+++ b/ee/src/lib/domain-verification.ts
@@ -1,12 +1,15 @@
 /**
  * Shared DNS TXT domain verification utility.
  *
- * Used by SSO domain verification (ee/src/auth/sso.ts) to prove domain
- * ownership via DNS TXT records. Custom domains (ee/src/platform/domains.ts)
- * use a separate Railway-based verification flow.
+ * Used by both SSO domain verification (ee/src/auth/sso.ts) and custom
+ * domain ownership verification (ee/src/platform/domains.ts) to prove
+ * domain ownership via DNS TXT records. Custom domains also use Railway's
+ * CNAME-based verification for DNS routing — DNS TXT is additive,
+ * proving ownership independently.
  *
  * Token format: `atlas-verify=<uuid>`
- * Verification: DNS TXT lookup with timeout, returns structured result.
+ * Verification: DNS TXT lookup on the domain itself (not a subdomain),
+ * with configurable timeout. Returns structured result.
  */
 
 import { Effect } from "effect";

--- a/ee/src/platform/domains.test.ts
+++ b/ee/src/platform/domains.test.ts
@@ -535,12 +535,10 @@ describe("domains", () => {
 
     it("sets failed status when DNS TXT record not found", async () => {
       mockDnsResult = { ok: false, reason: "no_match", message: "No matching TXT record found.", records: [] };
-      // SELECT domain
+      // 1. SELECT domain
       ee.queueMockRows([makeDomainRow()]);
-      // UPDATE failed status
+      // 2. UPDATE failed status (best-effort persist)
       ee.queueMockRows([]);
-      // SELECT updated domain
-      ee.queueMockRows([makeDomainRow({ domain_verification_status: "failed" })]);
 
       const result = await run(verifyDomainDnsTxt("dom-1"));
       expect(result.domainVerificationStatus).toBe("failed");
@@ -555,6 +553,53 @@ describe("domains", () => {
     it("throws when domain has no verification token", async () => {
       ee.queueMockRows([makeDomainRow({ verification_token: null })]);
       await expect(run(verifyDomainDnsTxt("dom-1"))).rejects.toThrow("no verification token");
+    });
+
+    it("issues cross-domain SSO UPDATE on successful verification", async () => {
+      // 1. SELECT domain
+      ee.queueMockRows([makeDomainRow()]);
+      // 2. UPDATE domain_verified = true
+      ee.queueMockRows([]);
+      // 3. Cross-domain: UPDATE sso_providers
+      ee.queueMockRows([]);
+      // 4. SELECT updated domain
+      ee.queueMockRows([makeDomainRow({ domain_verified: true, domain_verified_at: MOCK_NOW, domain_verification_status: "verified" })]);
+
+      await run(verifyDomainDnsTxt("dom-1"));
+
+      // Verify the SSO UPDATE was issued with correct params
+      const ssoUpdate = ee.capturedQueries.find((q) => q.sql.includes("UPDATE sso_providers"));
+      expect(ssoUpdate).toBeDefined();
+      expect(ssoUpdate!.params?.[0]).toBe("org-1"); // workspace_id
+      expect(ssoUpdate!.params?.[1]).toBe("data.acme.com"); // domain (lowercased)
+    });
+
+    it("succeeds even when cross-domain SSO update fails", async () => {
+      // 1. SELECT domain
+      ee.queueMockRows([makeDomainRow()]);
+      // 2. UPDATE domain_verified = true
+      ee.queueMockRows([]);
+      // 3. Cross-domain SSO update — will fail (no rows queued, mock returns [])
+      ee.queueMockRows([]);
+      // 4. SELECT updated domain
+      ee.queueMockRows([makeDomainRow({ domain_verified: true, domain_verified_at: MOCK_NOW, domain_verification_status: "verified" })]);
+
+      // Should succeed even though SSO auto-verify is a no-op
+      const result = await run(verifyDomainDnsTxt("dom-1"));
+      expect(result.domainVerified).toBe(true);
+    });
+
+    it("throws when domain is deleted during verification", async () => {
+      // 1. SELECT domain
+      ee.queueMockRows([makeDomainRow()]);
+      // 2. UPDATE domain_verified = true
+      ee.queueMockRows([]);
+      // 3. Cross-domain SSO update
+      ee.queueMockRows([]);
+      // 4. SELECT updated domain — empty (deleted)
+      ee.queueMockRows([]);
+
+      await expect(run(verifyDomainDnsTxt("dom-1"))).rejects.toThrow("deleted during verification");
     });
   });
 
@@ -597,6 +642,13 @@ describe("domains", () => {
       ee.queueMockRows([]);
       const result = await run(hasVerifiedCustomDomain("org-1", "data.acme.com"));
       expect(result).toBe(false);
+    });
+
+    it("returns false when internal DB is not configured", async () => {
+      ee.setHasInternalDB(false);
+      const result = await run(hasVerifiedCustomDomain("org-1", "data.acme.com"));
+      expect(result).toBe(false);
+      expect(ee.capturedQueries).toHaveLength(0); // No DB query
     });
   });
 

--- a/ee/src/platform/domains.ts
+++ b/ee/src/platform/domains.ts
@@ -91,10 +91,15 @@ function rowToDomain(row: Record<string, unknown>): CustomDomain {
     );
   }
 
+  // Default to "pending" for pre-migration rows that lack the column
   const verificationStatusRaw = row.domain_verification_status != null ? String(row.domain_verification_status) : "pending";
-  const domainVerificationStatus: DomainVerificationStatus = DOMAIN_VERIFICATION_STATUSES.includes(verificationStatusRaw as DomainVerificationStatus)
-    ? (verificationStatusRaw as DomainVerificationStatus)
-    : "pending";
+  if (!DOMAIN_VERIFICATION_STATUSES.includes(verificationStatusRaw as DomainVerificationStatus)) {
+    throw new DomainError(
+      `rowToDomain: unexpected domain_verification_status "${verificationStatusRaw}" — expected one of ${DOMAIN_VERIFICATION_STATUSES.join(", ")}`,
+      "data_integrity",
+    );
+  }
+  const domainVerificationStatus = verificationStatusRaw as DomainVerificationStatus;
 
   return {
     id: String(id),
@@ -540,10 +545,13 @@ export const verifyDomainDnsTxt = (domainId: string): Effect.Effect<CustomDomain
   Effect.gen(function* () {
     yield* requireDB();
 
-    const rows = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(
-      `SELECT * FROM custom_domains WHERE id = $1`,
-      [domainId],
-    ));
+    const rows = yield* Effect.tryPromise({
+      try: () => internalQuery<Record<string, unknown>>(
+        `SELECT * FROM custom_domains WHERE id = $1`,
+        [domainId],
+      ),
+      catch: (err) => err instanceof Error ? err : new Error(String(err)),
+    });
 
     if (rows.length === 0) {
       return yield* Effect.fail(new DomainError(
@@ -580,12 +588,8 @@ export const verifyDomainDnsTxt = (domainId: string): Effect.Effect<CustomDomain
         return Effect.void;
       }));
 
-      // Return updated record with failed status
-      const failedRows = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(
-        `SELECT * FROM custom_domains WHERE id = $1`,
-        [domainId],
-      ));
-      return rowToDomain(failedRows[0]);
+      // Return record reflecting actual DNS result, even if the persist failed
+      return { ...record, domainVerificationStatus: "failed" as const };
     }
 
     // DNS TXT verified — update status
@@ -607,10 +611,21 @@ export const verifyDomainDnsTxt = (domainId: string): Effect.Effect<CustomDomain
     // Cross-domain: auto-verify SSO provider for the same domain + workspace
     yield* autoVerifySSODomain(record.workspaceId, record.domain);
 
-    const updatedRows = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(
-      `SELECT * FROM custom_domains WHERE id = $1`,
-      [domainId],
-    ));
+    const updatedRows = yield* Effect.tryPromise({
+      try: () => internalQuery<Record<string, unknown>>(
+        `SELECT * FROM custom_domains WHERE id = $1`,
+        [domainId],
+      ),
+      catch: (err) => err instanceof Error ? err : new Error(String(err)),
+    });
+
+    if (updatedRows.length === 0) {
+      return yield* Effect.fail(new DomainError(
+        `Domain "${domainId}" was deleted during verification.`,
+        "domain_not_found",
+      ));
+    }
+
     return rowToDomain(updatedRows[0]);
   });
 
@@ -630,10 +645,13 @@ export const checkDomainAvailability = (
       return { available: false, reason: "Invalid domain format." };
     }
 
-    const existing = yield* Effect.promise(() => internalQuery<{ id: string; workspace_id: string }>(
-      `SELECT id, workspace_id FROM custom_domains WHERE domain = $1`,
-      [normalized],
-    ));
+    const existing = yield* Effect.tryPromise({
+      try: () => internalQuery<{ id: string; workspace_id: string }>(
+        `SELECT id, workspace_id FROM custom_domains WHERE domain = $1`,
+        [normalized],
+      ),
+      catch: (err) => err instanceof Error ? err : new Error(String(err)),
+    });
 
     if (existing.length === 0) {
       return { available: true };
@@ -648,58 +666,59 @@ export const checkDomainAvailability = (
 
 /**
  * Cross-domain auto-verification: when a custom domain is verified,
- * auto-mark any SSO provider for the same domain in the same workspace as verified.
+ * auto-mark any unverified SSO provider for the same domain in the same workspace as verified.
+ * Logs a warning on failure — domain verification still succeeds.
  */
 const autoVerifySSODomain = (workspaceId: string, domain: string): Effect.Effect<void> =>
   Effect.gen(function* () {
     if (!hasInternalDB()) return;
 
-    yield* Effect.promise(async () => {
-      try {
-        const updated = await internalQuery(
-          `UPDATE sso_providers
-           SET domain_verified = true, domain_verified_at = now(), domain_verification_status = 'verified', updated_at = now()
-           WHERE org_id = $1 AND LOWER(domain) = $2 AND domain_verified = false`,
-          [workspaceId, domain.toLowerCase()],
-        );
+    yield* Effect.tryPromise({
+      try: () => internalQuery(
+        `UPDATE sso_providers
+         SET domain_verified = true, domain_verified_at = now(), domain_verification_status = 'verified', updated_at = now()
+         WHERE org_id = $1 AND LOWER(domain) = $2 AND domain_verified = false`,
+        [workspaceId, domain.toLowerCase()],
+      ),
+      catch: (err) => err instanceof Error ? err : new Error(String(err)),
+    }).pipe(
+      Effect.tap((updated) => {
         if (Array.isArray(updated) && updated.length > 0) {
           log.info({ workspaceId, domain }, "Cross-domain: auto-verified SSO provider via custom domain verification");
         }
-      } catch (err) {
+        return Effect.void;
+      }),
+      Effect.catchAll((err) => {
         log.warn(
-          { workspaceId, domain, err: err instanceof Error ? err.message : String(err) },
+          { workspaceId, domain, err: err.message },
           "Cross-domain SSO auto-verification failed — SSO domain must be verified separately",
         );
-      }
-    });
+        return Effect.void;
+      }),
+    );
   });
 
 /**
  * Check if the workspace has a verified custom domain for the given domain.
  * Used by SSO provider creation to auto-verify domains.
+ * Returns false if the internal DB is not configured.
+ * Propagates DB errors through the Effect error channel.
  */
 export const hasVerifiedCustomDomain = (
   workspaceId: string,
   domain: string,
-): Effect.Effect<boolean> =>
+): Effect.Effect<boolean, Error> =>
   Effect.gen(function* () {
     if (!hasInternalDB()) return false;
 
-    return yield* Effect.promise(async () => {
-      try {
-        const rows = await internalQuery<{ id: string }>(
-          `SELECT id FROM custom_domains WHERE workspace_id = $1 AND LOWER(domain) = $2 AND domain_verified = true LIMIT 1`,
-          [workspaceId, domain.toLowerCase()],
-        );
-        return rows.length > 0;
-      } catch (err) {
-        log.warn(
-          { workspaceId, domain, err: err instanceof Error ? err.message : String(err) },
-          "Failed to check verified custom domain — returning false",
-        );
-        return false;
-      }
+    const rows = yield* Effect.tryPromise({
+      try: () => internalQuery<{ id: string }>(
+        `SELECT id FROM custom_domains WHERE workspace_id = $1 AND LOWER(domain) = $2 AND domain_verified = true LIMIT 1`,
+        [workspaceId, domain.toLowerCase()],
+      ),
+      catch: (err) => err instanceof Error ? err : new Error(String(err)),
     });
+    return rows.length > 0;
   });
 
 /**

--- a/packages/api/src/api/routes/admin-domains.ts
+++ b/packages/api/src/api/routes/admin-domains.ts
@@ -139,7 +139,7 @@ const verifyDnsTxtRoute = createRoute({
   path: "/verify-dns",
   tags: ["Admin — Custom Domain"],
   summary: "Verify domain ownership via DNS TXT",
-  description: "Checks DNS TXT records for the workspace's custom domain verification token. Proves domain ownership independently from Railway CNAME verification.",
+  description: "Checks DNS TXT records for the workspace's custom domain verification token. Proves domain ownership independently from Railway CNAME verification. On successful verification, also auto-verifies any pending SSO provider for the same domain in the same workspace.",
   responses: {
     200: {
       description: "DNS TXT verification result",

--- a/packages/api/src/api/routes/shared-domains.ts
+++ b/packages/api/src/api/routes/shared-domains.ts
@@ -40,8 +40,6 @@ export const DomainCheckResponseSchema = z.object({
   reason: z.string().optional(),
 });
 
-export const DomainDnsTxtVerifyResponseSchema = CustomDomainSchema;
-
 export const customDomainError = domainError(DomainError, {
   no_internal_db: 503,
   invalid_domain: 400,

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -22,10 +22,6 @@ export const CERTIFICATE_STATUSES = ["PENDING", "ISSUED", "FAILED"] as const;
 export type CertificateStatus = (typeof CERTIFICATE_STATUSES)[number];
 
 // ---------------------------------------------------------------------------
-// Custom domain record
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
 // Domain verification status (DNS TXT ownership proof)
 // ---------------------------------------------------------------------------
 
@@ -40,6 +36,7 @@ export interface CustomDomain {
   id: string;
   workspaceId: string;
   domain: string;
+  /** Railway CNAME + TLS certificate verification status. */
   status: DomainStatus;
   /** Railway domain ID — used for Railway API calls. */
   railwayDomainId: string | null;
@@ -49,11 +46,11 @@ export interface CustomDomain {
   certificateStatus: CertificateStatus | null;
   /** DNS TXT verification token (atlas-verify=<uuid>). Null for pre-migration domains. */
   verificationToken: string | null;
-  /** Whether domain ownership has been verified via DNS TXT. */
+  /** Whether domain ownership has been verified via DNS TXT. Derived from `domainVerificationStatus === "verified"` — exists for query convenience. */
   domainVerified: boolean;
   /** Timestamp of successful DNS TXT verification. */
   domainVerifiedAt: string | null;
-  /** Current DNS TXT verification status. */
+  /** Current DNS TXT ownership verification status. Tracks independently from `status`, which reflects Railway CNAME/certificate verification. */
   domainVerificationStatus: DomainVerificationStatus;
   createdAt: string;
   verifiedAt: string | null;

--- a/packages/types/src/sso.ts
+++ b/packages/types/src/sso.ts
@@ -6,6 +6,8 @@
  * auto-provisioning maps email domains to organizations.
  */
 
+import type { DomainVerificationStatus } from "./domain";
+
 // ── Provider types ──────────────────────────────────────────────────
 
 export const SSO_PROVIDER_TYPES = ["saml", "oidc"] as const;
@@ -56,7 +58,7 @@ interface SSOProviderBase {
   /** Timestamp when domain was verified, or null if not yet verified. */
   domainVerifiedAt: string | null;
   /** Domain verification status — constrained by database CHECK constraint. */
-  domainVerificationStatus: "pending" | "verified" | "failed";
+  domainVerificationStatus: DomainVerificationStatus;
 }
 
 export interface SSOSamlProvider extends SSOProviderBase {


### PR DESCRIPTION
## Summary
- Custom domains now generate a DNS TXT verification token (`atlas-verify=<uuid>`) on creation, using the shared `domain-verification` utility already used by SSO
- New endpoints: `POST /api/v1/admin/domain/verify-dns` (triggers DNS TXT check) and `GET /api/v1/admin/domain/domain-check?domain=...` (availability check)
- Cross-domain auto-verification: verifying a custom domain auto-verifies SSO providers for the same domain/workspace, and creating an SSO provider auto-verifies if a verified custom domain already exists

## Test plan
- [x] Verification token generated on domain create (existing test updated)
- [x] DNS TXT verification success/failure/already-verified/no-token (4 new tests)
- [x] Domain availability check — unclaimed, same workspace, other workspace, invalid format (4 new tests)
- [x] `hasVerifiedCustomDomain` helper (2 new tests)
- [x] SSO cross-domain auto-verification mock rows updated (2 existing tests)
- [x] All 5 CI gates pass: lint, type, test (40 domain + 85 SSO), syncpack, template drift

Closes #1345