### PR TITLE
fix: redact verification token from custom domain responses

### DIFF
--- a/ee/src/platform/domains.test.ts
+++ b/ee/src/platform/domains.test.ts
@@ -67,6 +67,7 @@ const {
   deleteDomain,
   resolveWorkspaceByHost,
   _resetHostCache,
+  redactDomain,
   DomainError,
 } = await import("./domains");
 
@@ -649,6 +650,41 @@ describe("domains", () => {
       const result = await run(hasVerifiedCustomDomain("org-1", "data.acme.com"));
       expect(result).toBe(false);
       expect(ee.capturedQueries).toHaveLength(0); // No DB query
+    });
+  });
+
+  describe("redactDomain", () => {
+    const fakeDomain = {
+      id: "dom-1",
+      workspaceId: "org-1",
+      domain: "data.acme.com",
+      status: "pending" as const,
+      railwayDomainId: null,
+      cnameTarget: null,
+      certificateStatus: null,
+      verificationToken: "atlas-verify=abcdef-1234-5678-9012",
+      domainVerified: false,
+      domainVerifiedAt: null,
+      domainVerificationStatus: "pending" as const,
+      createdAt: "2026-04-06T00:00:00Z",
+      verifiedAt: null,
+    };
+
+    it("masks verification token by default", () => {
+      const result = redactDomain(fakeDomain);
+      expect(result.verificationToken).toBe("atlas-verify=...");
+      expect(result.verificationToken).not.toContain("abcdef");
+    });
+
+    it("includes full token when includeToken is true", () => {
+      const result = redactDomain(fakeDomain, true);
+      expect(result.verificationToken).toBe("atlas-verify=abcdef-1234-5678-9012");
+    });
+
+    it("returns domain as-is when token is null", () => {
+      const noToken = { ...fakeDomain, verificationToken: null };
+      const result = redactDomain(noToken);
+      expect(result.verificationToken).toBeNull();
     });
   });
 

--- a/ee/src/platform/domains.ts
+++ b/ee/src/platform/domains.ts
@@ -118,6 +118,15 @@ function rowToDomain(row: Record<string, unknown>): CustomDomain {
   };
 }
 
+/**
+ * Redact the verification token from a CustomDomain before returning in API responses.
+ * Returns the full token only when `includeToken` is true (used at registration time).
+ */
+export function redactDomain(domain: CustomDomain, includeToken = false): CustomDomain {
+  if (includeToken || !domain.verificationToken) return domain;
+  return { ...domain, verificationToken: domain.verificationToken.slice(0, 13) + "..." };
+}
+
 // ── Railway GraphQL client ──────────────────────────────────────────
 
 interface RailwayConfig {

--- a/packages/api/src/api/routes/admin-domains.ts
+++ b/packages/api/src/api/routes/admin-domains.ts
@@ -261,7 +261,7 @@ adminDomains.openapi(getDomainRoute, async (c) => {
     }
 
     const domains = yield* mod.listDomains(orgId);
-    return c.json({ domain: domains[0] ?? null }, 200);
+    return c.json({ domain: domains[0] ? mod.redactDomain(domains[0]) : null }, 200);
   }), { label: "get workspace domain", domainErrors: [customDomainError] });
 });
 
@@ -303,7 +303,8 @@ adminDomains.openapi(addDomainRoute, async (c) => {
 
     const domain = yield* mod.registerDomain(orgId, body.domain);
     log.info({ orgId, domain: body.domain, requestId }, "Workspace custom domain registered");
-    return c.json(domain, 201);
+    // Return full token on registration so admin can set up the DNS TXT record
+    return c.json(mod.redactDomain(domain, true), 201);
   }), { label: "add workspace domain", domainErrors: [customDomainError] });
 });
 
@@ -329,7 +330,7 @@ adminDomains.openapi(verifyDomainRoute, async (c) => {
     }
 
     const domain = yield* mod.verifyDomain(domains[0].id);
-    return c.json(domain, 200);
+    return c.json(mod.redactDomain(domain), 200);
   }), { label: "verify workspace domain", domainErrors: [customDomainError] });
 });
 
@@ -354,7 +355,7 @@ adminDomains.openapi(verifyDnsTxtRoute, async (c) => {
     }
 
     const domain = yield* mod.verifyDomainDnsTxt(domains[0].id);
-    return c.json(domain, 200);
+    return c.json(mod.redactDomain(domain), 200);
   }), { label: "verify domain DNS TXT", domainErrors: [customDomainError] });
 });
 

--- a/packages/api/src/api/routes/platform-domains.ts
+++ b/packages/api/src/api/routes/platform-domains.ts
@@ -150,7 +150,7 @@ platformDomains.openapi(listDomainsRoute, async (c) => {
     }
 
     const domains = yield* mod.listAllDomains();
-    return c.json({ domains }, 200);
+    return c.json({ domains: domains.map((d) => mod.redactDomain(d)) }, 200);
   }), { label: "list domains", domainErrors: [customDomainError] });
 });
 
@@ -168,7 +168,7 @@ platformDomains.openapi(registerDomainRoute, async (c) => {
 
     const domain = yield* mod.registerDomain(body.workspaceId, body.domain);
     log.info({ workspaceId: body.workspaceId, domain: body.domain, requestId }, "Custom domain registered");
-    return c.json(domain, 201);
+    return c.json(mod.redactDomain(domain, true), 201);
   }), { label: "register domain", domainErrors: [customDomainError] });
 });
 
@@ -185,7 +185,7 @@ platformDomains.openapi(verifyDomainRoute, async (c) => {
     }
 
     const domain = yield* mod.verifyDomain(domainId);
-    return c.json(domain, 200);
+    return c.json(mod.redactDomain(domain), 200);
   }), { label: "verify domain", domainErrors: [customDomainError] });
 });
 


### PR DESCRIPTION
## Summary
- Add `redactDomain()` helper (mirrors SSO's `redactProvider`) that masks the verification token to `atlas-verify=...`
- Only `POST /` (registration) returns the full token so the admin can set up the DNS TXT record
- All other endpoints (GET, POST /verify, POST /verify-dns) return the masked version
- Applied to both admin-domains and platform-domains routes

## Test plan
- [x] 3 new unit tests: masks token by default, includes full token with flag, passthrough on null
- [x] All 47 domain tests pass
- [x] Lint + type check clean

Closes #1356