### PR TITLE
chore: flat overage rate + Stripe plan fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -258,6 +258,7 @@ ATLAS_SANDBOX_URL=http://localhost:8080
 # STRIPE_PRO_PRICE_ID=price_...                     # Stripe Price ID for Pro plan (monthly, $59/seat)
 # STRIPE_PRO_ANNUAL_PRICE_ID=price_...              # Stripe Price ID for Pro plan (annual)
 # STRIPE_BUSINESS_PRICE_ID=price_...                # Stripe Price ID for Business plan (monthly, $99/seat)
+# STRIPE_BUSINESS_ANNUAL_PRICE_ID=price_...         # Stripe Price ID for Business plan (annual)
 
 # === Data Residency ===
 # ATLAS_API_REGION=                   # Region identity of this API instance (e.g. "us-west", "eu-west", "ap-southeast"). Used for misrouting detection. Falls back to residency.defaultRegion from atlas.config.ts if unset.

--- a/apps/www/src/app/pricing/pricing-content.tsx
+++ b/apps/www/src/app/pricing/pricing-content.tsx
@@ -136,7 +136,7 @@ const COMPARISON: ComparisonRow[] = [
   { feature: "Database connections", selfHosted: "Unlimited", starter: "1", pro: "3", business: "Unlimited" },
   { feature: "Extra connections", selfHosted: false, starter: "+$10/mo each", pro: "+$10/mo each", business: "Included" },
   { feature: "Chat integrations", selfHosted: "Config-based", starter: "1 platform", pro: "3 platforms", business: "All 8" },
-  { feature: "Overage rate", selfHosted: false, starter: "$0.10/query", pro: "$0.08/query", business: "$0.06/query" },
+  { feature: "Overage rate", selfHosted: false, starter: "$0.10/query", pro: "$0.10/query", business: "$0.10/query" },
   // Enterprise features
   { feature: "Custom domain", selfHosted: false, starter: false, pro: true, business: true },
   { feature: "SSO & SCIM", selfHosted: false, starter: false, pro: false, business: true },
@@ -164,7 +164,7 @@ const FAQS: FAQ[] = [
   {
     question: "What happens when I hit my query limit?",
     answer:
-      "You'll get warnings as you approach your limit. You have a 10% grace buffer beyond your included budget, and additional queries in that range are billed at your plan's overage rate ($0.10, $0.08, or $0.06 per query). To avoid overages entirely, switch to BYOK at any time — your own API key means unlimited queries.",
+      "You'll get warnings as you approach your limit. You have a 10% grace buffer beyond your included budget, and additional queries in that range are billed at $0.10 per query. To avoid overages entirely, switch to BYOK at any time — your own API key means unlimited queries.",
   },
   {
     question: "Is there a free option?",

--- a/packages/api/src/lib/billing/__tests__/plans.test.ts
+++ b/packages/api/src/lib/billing/__tests__/plans.test.ts
@@ -93,10 +93,10 @@ describe("billing/plans", () => {
       expect(business.features.sla).toBe("99.9%");
     });
 
-    it("overage rates decrease with higher tiers", () => {
+    it("overage rate is flat across all paid tiers", () => {
       expect(getPlanDefinition("starter").overagePerMillionTokens).toBe(1.0);
-      expect(getPlanDefinition("pro").overagePerMillionTokens).toBe(0.8);
-      expect(getPlanDefinition("business").overagePerMillionTokens).toBe(0.6);
+      expect(getPlanDefinition("pro").overagePerMillionTokens).toBe(1.0);
+      expect(getPlanDefinition("business").overagePerMillionTokens).toBe(1.0);
     });
   });
 
@@ -180,7 +180,7 @@ describe("billing/plans", () => {
       expect(plans.length).toBe(1);
       expect(plans[0].name).toBe("pro");
       expect(plans[0].priceId).toBe("price_pro_789");
-      expect(plans[0].freeTrial).toBeUndefined();
+      expect(plans[0].freeTrial).toEqual({ days: 14 });
     });
 
     it("includes business plan when STRIPE_BUSINESS_PRICE_ID is set", () => {
@@ -189,7 +189,7 @@ describe("billing/plans", () => {
       expect(plans.length).toBe(1);
       expect(plans[0].name).toBe("business");
       expect(plans[0].priceId).toBe("price_biz_789");
-      expect(plans[0].freeTrial).toBeUndefined();
+      expect(plans[0].freeTrial).toEqual({ days: 14 });
     });
 
     it("includes all plans when all price IDs are set", () => {

--- a/packages/api/src/lib/billing/plans.ts
+++ b/packages/api/src/lib/billing/plans.ts
@@ -113,7 +113,7 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
     displayName: "Pro",
     pricePerSeat: 59,
     defaultModel: "claude-sonnet-4-6",
-    overagePerMillionTokens: 0.8,
+    overagePerMillionTokens: 1.0,
     limits: {
       tokenBudgetPerSeat: 5_000_000,
       maxSeats: 25,
@@ -131,7 +131,7 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
     displayName: "Business",
     pricePerSeat: 99,
     defaultModel: "claude-sonnet-4-6",
-    overagePerMillionTokens: 0.6,
+    overagePerMillionTokens: 1.0,
     limits: {
       tokenBudgetPerSeat: 15_000_000,
       maxSeats: UNLIMITED,
@@ -217,6 +217,7 @@ export function getStripePlans(): Array<{
         seats: PLANS.pro.limits.maxSeats,
         connections: PLANS.pro.limits.maxConnections,
       },
+      freeTrial: { days: TRIAL_DAYS },
     });
   }
 
@@ -225,11 +226,13 @@ export function getStripePlans(): Array<{
     plans.push({
       name: "business",
       priceId: businessPriceId,
+      annualDiscountPriceId: process.env.STRIPE_BUSINESS_ANNUAL_PRICE_ID,
       limits: {
         tokenBudgetPerSeat: PLANS.business.limits.tokenBudgetPerSeat,
         seats: UNLIMITED,
         connections: UNLIMITED,
       },
+      freeTrial: { days: TRIAL_DAYS },
     });
   }
 
@@ -248,6 +251,7 @@ export function resolvePlanTierFromPriceId(priceId: string): PlanTier | null {
   const proPriceId = process.env.STRIPE_PRO_PRICE_ID;
   const proAnnualPriceId = process.env.STRIPE_PRO_ANNUAL_PRICE_ID;
   const businessPriceId = process.env.STRIPE_BUSINESS_PRICE_ID;
+  const businessAnnualPriceId = process.env.STRIPE_BUSINESS_ANNUAL_PRICE_ID;
 
   if (starterPriceId && (priceId === starterPriceId || (starterAnnualPriceId && priceId === starterAnnualPriceId))) {
     return "starter";
@@ -255,7 +259,7 @@ export function resolvePlanTierFromPriceId(priceId: string): PlanTier | null {
   if (proPriceId && (priceId === proPriceId || (proAnnualPriceId && priceId === proAnnualPriceId))) {
     return "pro";
   }
-  if (businessPriceId && priceId === businessPriceId) {
+  if (businessPriceId && (priceId === businessPriceId || (businessAnnualPriceId && priceId === businessAnnualPriceId))) {
     return "business";
   }
   return null;


### PR DESCRIPTION
## Summary
- Flatten overage rate to $1.0/M tokens across all paid tiers (was tiered $1.0/$0.8/$0.6) — simpler to communicate and model cost differences are absorbed into base pricing
- Add 14-day free trial to Pro and Business Stripe plans (was only on Starter — pricing page says all paid plans have trials)
- Add `STRIPE_BUSINESS_ANNUAL_PRICE_ID` env var and wire it through `getStripePlans()` and `resolvePlanTierFromPriceId()` — Business annual subscriptions would silently fail to resolve without this
- Update pricing page comparison table and FAQ to show flat $0.10/query rate

## Test plan
- [x] Billing tests pass (77 pass, 0 fail)
- [x] Type check passes
- [ ] Verify pricing page shows flat overage rate
- [ ] Verify Stripe checkout creates trials for all plans