### PR TITLE
docs: settings split + GDPR workspace purge

### DIFF
--- a/apps/docs/content/docs/guides/admin-console.mdx
+++ b/apps/docs/content/docs/guides/admin-console.mdx
@@ -257,7 +257,7 @@ Settings are split into two pages by scope:
 
 Per-workspace configuration — query limits, agent behavior, sandbox backend, and session policies. Workspace admins can edit these settings for their own workspace. Changes apply only to the current workspace.
 
-- **Sections** — Query Limits, Rate Limiting, Sessions, Sandbox, Agent
+- **Sections** — Query Limits, Rate Limiting, Sessions, Sandbox, Agent, Intelligence
 - **Source badges** — Each setting shows where its current value comes from:
   - **workspace override** (purple) — value saved per-workspace in the internal database
   - **override** (blue) — value saved as a platform-level override
@@ -277,6 +277,10 @@ Per-workspace configuration — query limits, agent behavior, sandbox backend, a
 | Sandbox | `ATLAS_SANDBOX_BACKEND` | Sandbox backend for explore/Python tool isolation |
 | Sandbox | `ATLAS_SANDBOX_URL` | Custom sidecar service URL (sidecar backend only) |
 | Agent | `ATLAS_AGENT_MAX_STEPS` | Maximum tool-call steps per agent run (1–100, default: 25) |
+| Intelligence | `ATLAS_EXPERT_SCHEDULER_ENABLED` | Enable periodic semantic layer analysis (default: false) |
+| Intelligence | `ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS` | Hours between scheduled expert analysis runs (default: 24) |
+| Intelligence | `ATLAS_EXPERT_AUTO_APPROVE_THRESHOLD` | Auto-approve proposals above this confidence (empty = disabled) |
+| Intelligence | `ATLAS_EXPERT_AUTO_APPROVE_TYPES` | Comma-separated amendment types eligible for auto-approval |
 
 See [Workspace Settings](/guides/workspace-settings) for the full guide.
 
@@ -285,12 +289,12 @@ See [Workspace Settings](/guides/workspace-settings) for the full guide.
 **Route:** `/admin/platform/settings`
 
 <Callout type="info">
-Requires the `platform_admin` role. In self-hosted mode, all admins see this page.
+Requires the `platform_admin` role. In self-hosted deployments, the first user to sign up is automatically assigned `platform_admin`.
 </Callout>
 
 Global settings that affect all workspaces — security policies, LLM provider, deploy mode, branding, and secrets. Only platform admins can access this page. Changes here apply across every workspace.
 
-- **Sections** — Security, Platform, Agent, Appearance, Secrets
+- **Sections** — Security, Platform, Agent, Email, Appearance, Secrets
 - **Brand color** — A dedicated card lets you preview and set the primary brand color in oklch format, with a live color swatch. Changes apply immediately
 - **Live vs Restart** — Settings marked **Live** take effect immediately. Settings marked **Requires restart** need a server restart (self-hosted only — on **app.useatlas.dev**, most settings are hot-reloadable)
 - **Secrets** — Sensitive settings (API keys, database URLs) are masked and read-only. Manage these via environment variables
@@ -306,6 +310,11 @@ Global settings that affect all workspaces — security policies, LLM provider, 
 | Agent | `ATLAS_PROVIDER` | LLM provider selection |
 | Agent | `ATLAS_MODEL` | Model ID override |
 | Agent | `ATLAS_LOG_LEVEL` | Application log level |
+| Email | `ATLAS_EMAIL_PROVIDER` | Platform default email provider |
+| Email | `RESEND_API_KEY` | Resend API key (masked, read-only) |
+| Email | `SENDGRID_API_KEY` | SendGrid API key (masked, read-only) |
+| Email | `POSTMARK_SERVER_TOKEN` | Postmark server token (masked, read-only) |
+| Email | `ATLAS_EMAIL_FROM` | Default sender address for platform emails |
 | Appearance | `ATLAS_BRAND_COLOR` | Primary brand color in oklch format |
 | Secrets | `ANTHROPIC_API_KEY` | Anthropic provider API key (masked, read-only) |
 | Secrets | `OPENAI_API_KEY` | OpenAI provider API key (masked, read-only) |

--- a/apps/docs/content/docs/guides/admin-console.mdx
+++ b/apps/docs/content/docs/guides/admin-console.mdx
@@ -249,56 +249,72 @@ Plugin enable/disable state and config overrides are stored in the internal data
 
 ## Settings
 
+Settings are split into two pages by scope:
+
+### Workspace Settings
+
 **Route:** `/admin/settings`
 
-Manage application configuration from the UI. Settings follow a three-tier resolution: **DB override > env var > default**.
+Per-workspace configuration — query limits, agent behavior, sandbox backend, and session policies. Workspace admins can edit these settings for their own workspace. Changes apply only to the current workspace.
 
-- **Grouped sections** — Query Limits, Rate Limiting, Security, Sessions, Sandbox, Platform, Agent, Appearance, Secrets
+- **Sections** — Query Limits, Rate Limiting, Sessions, Sandbox, Agent
 - **Source badges** — Each setting shows where its current value comes from:
-  - **override** (blue) — value saved in the internal database
-  - **workspace-override** (purple) — value saved per-workspace
+  - **workspace override** (purple) — value saved per-workspace in the internal database
+  - **override** (blue) — value saved as a platform-level override
   - **env** (green) — value from an environment variable
   - **default** (gray) — built-in default
 - **Edit** — Override any non-secret setting. Changes are saved to the internal database
-- **Live vs Restart** — Each setting shows whether changes take effect immediately (**Live**) or require a server restart (**Requires restart**). Query Limits, Rate Limiting, Sessions, Sandbox, and Appearance are live; Security, Platform, and Agent settings require a restart
-- **Reset** — Remove a DB override to revert to the environment variable or default value
+- **Live** — All workspace settings take effect immediately without a server restart
+- **Reset** — Remove an override to revert to the platform default, environment variable, or built-in default
+
+| Section | Setting | Description |
+|---------|---------|-------------|
+| Query Limits | `ATLAS_ROW_LIMIT` | Maximum rows returned per query (default: 1000) |
+| Query Limits | `ATLAS_QUERY_TIMEOUT` | Query timeout in ms (default: 30000) |
+| Rate Limiting | `ATLAS_RATE_LIMIT_RPM` | Max requests per minute per user (0 = disabled) |
+| Sessions | `ATLAS_SESSION_IDLE_TIMEOUT` | Seconds of inactivity before session invalidation (0 = disabled) |
+| Sessions | `ATLAS_SESSION_ABSOLUTE_TIMEOUT` | Maximum session lifetime in seconds (0 = disabled) |
+| Sandbox | `ATLAS_SANDBOX_BACKEND` | Sandbox backend for explore/Python tool isolation |
+| Sandbox | `ATLAS_SANDBOX_URL` | Custom sidecar service URL (sidecar backend only) |
+| Agent | `ATLAS_AGENT_MAX_STEPS` | Maximum tool-call steps per agent run (1–100, default: 25) |
+
+See [Workspace Settings](/guides/workspace-settings) for the full guide.
+
+### Platform Settings
+
+**Route:** `/admin/platform/settings`
+
+<Callout type="info">
+Requires the `platform_admin` role. In self-hosted mode, all admins see this page.
+</Callout>
+
+Global settings that affect all workspaces — security policies, LLM provider, deploy mode, branding, and secrets. Only platform admins can access this page. Changes here apply across every workspace.
+
+- **Sections** — Security, Platform, Agent, Appearance, Secrets
+- **Brand color** — A dedicated card lets you preview and set the primary brand color in oklch format, with a live color swatch. Changes apply immediately
+- **Live vs Restart** — Settings marked **Live** take effect immediately. Settings marked **Requires restart** need a server restart (self-hosted only — on **app.useatlas.dev**, most settings are hot-reloadable)
 - **Secrets** — Sensitive settings (API keys, database URLs) are masked and read-only. Manage these via environment variables
-- **SaaS mode** — Workspace admins only see settings marked as workspace-visible. Platform admins see all settings. The response includes a `deployMode` field and a `manageable` flag indicating whether settings can be persisted
+
+| Section | Setting | Description |
+|---------|---------|-------------|
+| Security | `ATLAS_RLS_ENABLED` | Enable row-level security |
+| Security | `ATLAS_RLS_COLUMN` | Column name for RLS filtering |
+| Security | `ATLAS_RLS_CLAIM` | JWT claim path for RLS value |
+| Security | `ATLAS_TABLE_WHITELIST` | Only allow semantic layer tables (default: true) |
+| Security | `ATLAS_CORS_ORIGIN` | Allowed CORS origin (default: *) |
+| Platform | `ATLAS_DEPLOY_MODE` | Deployment mode: auto, saas, or self-hosted |
+| Agent | `ATLAS_PROVIDER` | LLM provider selection |
+| Agent | `ATLAS_MODEL` | Model ID override |
+| Agent | `ATLAS_LOG_LEVEL` | Application log level |
+| Appearance | `ATLAS_BRAND_COLOR` | Primary brand color in oklch format |
+| Secrets | `ANTHROPIC_API_KEY` | Anthropic provider API key (masked, read-only) |
+| Secrets | `OPENAI_API_KEY` | OpenAI provider API key (masked, read-only) |
+| Secrets | `DATABASE_URL` | Internal database connection string (masked, read-only) |
+| Secrets | `ATLAS_DATASOURCE_URL` | Analytics datasource connection string (masked, read-only) |
 
 <Callout type="info">
-On **app.useatlas.dev** (SaaS mode), most settings are hot-reloadable — changes are picked up on the next request without a server restart. A few infrastructure settings (LLM provider, model) may still require redeployment to fully take effect. The restart requirement mainly applies to self-hosted deployments.
+Settings overrides require an internal database (`DATABASE_URL`). Without it, both settings pages are read-only — all values come from environment variables.
 </Callout>
-
-<Callout type="info">
-Settings overrides require an internal database (`DATABASE_URL`). Without it, the settings page is read-only — all values come from environment variables.
-</Callout>
-
-**Available settings:**
-
-| Section | Setting | Description | Scope |
-|---------|---------|-------------|-------|
-| Query Limits | `ATLAS_ROW_LIMIT` | Maximum rows returned per query (default: 1000) | workspace |
-| Query Limits | `ATLAS_QUERY_TIMEOUT` | Query timeout in ms (default: 30000) | workspace |
-| Rate Limiting | `ATLAS_RATE_LIMIT_RPM` | Max requests per minute per user (0 = disabled) | workspace |
-| Security | `ATLAS_RLS_ENABLED` | Enable row-level security | platform |
-| Security | `ATLAS_RLS_COLUMN` | Column name for RLS filtering | platform |
-| Security | `ATLAS_RLS_CLAIM` | JWT claim path for RLS value | platform |
-| Security | `ATLAS_TABLE_WHITELIST` | Only allow semantic layer tables (default: true) | platform |
-| Security | `ATLAS_CORS_ORIGIN` | Allowed CORS origin (default: *) | platform |
-| Sessions | `ATLAS_SESSION_IDLE_TIMEOUT` | Seconds of inactivity before session invalidation (0 = disabled) | workspace |
-| Sessions | `ATLAS_SESSION_ABSOLUTE_TIMEOUT` | Maximum session lifetime in seconds (0 = disabled) | workspace |
-| Sandbox | `ATLAS_SANDBOX_BACKEND` | Sandbox backend for explore/Python tool isolation | workspace |
-| Sandbox | `ATLAS_SANDBOX_URL` | Custom sidecar service URL (sidecar backend only) | workspace |
-| Platform | `ATLAS_DEPLOY_MODE` | Deployment mode: auto, saas, or self-hosted | platform |
-| Agent | `ATLAS_AGENT_MAX_STEPS` | Maximum tool-call steps per agent run (1–100, default: 25) | workspace |
-| Agent | `ATLAS_PROVIDER` | LLM provider selection | platform |
-| Agent | `ATLAS_MODEL` | Model ID override | platform |
-| Agent | `ATLAS_LOG_LEVEL` | Application log level | platform |
-| Appearance | `ATLAS_BRAND_COLOR` | Primary brand color in oklch format | platform |
-| Secrets | `ANTHROPIC_API_KEY` | Anthropic provider API key (masked, read-only) | platform |
-| Secrets | `OPENAI_API_KEY` | OpenAI provider API key (masked, read-only) | platform |
-| Secrets | `DATABASE_URL` | Internal database connection string (masked, read-only) | platform |
-| Secrets | `ATLAS_DATASOURCE_URL` | Analytics datasource connection string (masked, read-only) | platform |
 
 ---
 

--- a/apps/docs/content/docs/guides/workspace-settings.mdx
+++ b/apps/docs/content/docs/guides/workspace-settings.mdx
@@ -5,7 +5,11 @@ description: Configure workspace-level preferences for query behavior, agent lim
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-Workspace settings let admins configure how Atlas behaves for everyone in the workspace — query limits, agent behavior, display preferences, and safety controls. Changes take effect immediately for all workspace members.
+Workspace settings let admins configure how Atlas behaves for everyone in the workspace — query limits, agent behavior, sandbox backend, and session policies. Changes take effect immediately for all workspace members.
+
+<Callout type="info" title="Platform settings">
+  Global settings that affect all workspaces (security, LLM provider, deploy mode, branding) are managed separately on the [Platform Settings](/guides/admin-console#platform-settings) page at `/admin/platform/settings`. Only platform admins can access platform settings.
+</Callout>
 
 <Callout type="info" title="Hosted platform">
   On [app.useatlas.dev](https://app.useatlas.dev), workspace settings are managed entirely from the admin console. Self-hosted operators configure these via environment variables or `atlas.config.ts` — see [Configuration](/reference/config) and [Environment Variables](/reference/environment-variables).
@@ -19,7 +23,7 @@ Workspace settings let admins configure how Atlas behaves for everyone in the wo
 
 ## Accessing Settings
 
-Navigate to **Admin > Settings** (`/admin/settings`). The settings page is split into sections, each controlling a different aspect of workspace behavior.
+Navigate to **Admin > Settings** (`/admin/settings`). The page shows only workspace-scoped settings, grouped into sections that control different aspects of workspace behavior.
 
 ---
 

--- a/apps/docs/content/docs/platform-ops/platform-admin.mdx
+++ b/apps/docs/content/docs/platform-ops/platform-admin.mdx
@@ -113,6 +113,7 @@ POST /api/v1/platform/workspaces/:id/purge
 | `403` | Platform admin role required |
 | `404` | Workspace not found or internal database not configured |
 | `409` | Workspace must be soft-deleted first |
+| `500` | Internal server error (includes `requestId` for log correlation) |
 
 **Success response:**
 
@@ -132,7 +133,7 @@ POST /api/v1/platform/workspaces/:id/purge
 }
 ```
 
-The `purged` object contains row counts for each table, useful for audit purposes. The `totalRows` field is the sum of all deleted rows.
+The `purged` object contains row counts for each table, useful for audit purposes. The example above is abbreviated — the actual response includes a key for every table deleted (approximately 50 entries). The `totalRows` field is the sum of all deleted rows.
 
 ## Noisy Neighbor Detection
 

--- a/apps/docs/content/docs/platform-ops/platform-admin.mdx
+++ b/apps/docs/content/docs/platform-ops/platform-admin.mdx
@@ -57,9 +57,82 @@ The workspaces tab lists all organizations with sortable columns and filters for
 | Suspend | `POST /api/v1/platform/workspaces/:id/suspend` | Block all access |
 | Unsuspend | `POST /api/v1/platform/workspaces/:id/unsuspend` | Restore access |
 | Delete | `DELETE /api/v1/platform/workspaces/:id` | Soft-delete + cascade cleanup |
+| Purge | `POST /api/v1/platform/workspaces/:id/purge` | GDPR hard delete (permanent) |
 | Change plan | `PATCH /api/v1/platform/workspaces/:id/plan` | Update plan tier |
 
 All actions require confirmation dialogs in the UI. Delete cascades to conversations, semantic entities, learned patterns, suggestions, and scheduled tasks.
+
+### GDPR Workspace Purge
+
+<Callout type="warn">
+Purging a workspace is **irreversible**. All data is permanently removed in a single transaction — there is no undo, no backup recovery, and no way to restore the workspace after purging.
+</Callout>
+
+The purge action permanently removes **all** data for a workspace to satisfy GDPR right-to-erasure (Article 17) requests. It deletes every row across all tables scoped to the workspace, including:
+
+- Conversations, messages, and audit logs
+- Connections, settings, and plugin configurations
+- Semantic entities, learned patterns, and query suggestions
+- Scheduled tasks and task run history
+- Integration installations (Slack, Teams, Discord, Telegram, etc.)
+- Usage events, SLA metrics, and abuse events
+- Custom domains, sandbox credentials, and region migrations
+- SSO providers, IP allowlists, custom roles, and approval workflows
+- Workspace branding, onboarding emails, and PII classifications
+- Members, invitations, and the organization record itself
+- **Orphaned users** — users with no remaining workspace memberships are also deleted (sessions, accounts, and user record)
+
+All operations run in a single database transaction — either everything is purged or nothing changes.
+
+#### Prerequisites
+
+The workspace **must be soft-deleted first** using the Delete action (`DELETE /api/v1/platform/workspaces/:id`). Attempting to purge an active or suspended workspace returns a `409 Conflict` error:
+
+```
+Workspace must be soft-deleted before purging. Delete the workspace first, then purge.
+```
+
+#### Confirmation
+
+In the platform admin UI, the purge button appears only on workspaces with `deleted` status. Clicking it opens a confirmation dialog that requires you to **type the workspace name** to proceed. This prevents accidental purges.
+
+#### API Reference
+
+```
+POST /api/v1/platform/workspaces/:id/purge
+```
+
+**Auth:** Requires `platform_admin` role.
+
+**Responses:**
+
+| Status | Description |
+|--------|-------------|
+| `200` | Workspace purged successfully |
+| `401` | Authentication required |
+| `403` | Platform admin role required |
+| `404` | Workspace not found or internal database not configured |
+| `409` | Workspace must be soft-deleted first |
+
+**Success response:**
+
+```json
+{
+  "message": "Workspace permanently purged. All data has been irreversibly removed.",
+  "workspaceId": "org_abc123",
+  "purged": {
+    "auditLog": 1250,
+    "conversations": 84,
+    "messages": 3201,
+    "connections": 3,
+    "members": 12,
+    "organization": 1
+  },
+  "totalRows": 4551
+}
+```
+
+The `purged` object contains row counts for each table, useful for audit purposes. The `totalRows` field is the sum of all deleted rows.
 
 ## Noisy Neighbor Detection
 
@@ -82,6 +155,7 @@ All endpoints are gated on `user.role === "platform_admin"`. In no-auth mode (lo
 | `POST` | `/api/v1/platform/workspaces/:id/suspend` | Suspend workspace |
 | `POST` | `/api/v1/platform/workspaces/:id/unsuspend` | Unsuspend workspace |
 | `DELETE` | `/api/v1/platform/workspaces/:id` | Delete workspace |
+| `POST` | `/api/v1/platform/workspaces/:id/purge` | GDPR hard delete (permanent) |
 | `PATCH` | `/api/v1/platform/workspaces/:id/plan` | Change plan tier |
 | `GET` | `/api/v1/platform/stats` | Platform-wide statistics |
 | `GET` | `/api/v1/platform/noisy-neighbors` | Noisy neighbor detection |


### PR DESCRIPTION
## Summary
- **Settings split (#1369):** Updated admin-console guide to reflect the page split from PR #1358 — workspace settings at `/admin/settings` (per-org: query limits, rate limiting, sessions, sandbox, agent) and platform settings at `/admin/platform/settings` (global: security, LLM, deploy mode, branding, secrets). Updated workspace-settings guide with cross-link to platform settings.
- **GDPR purge (#1370):** Added comprehensive documentation to the platform-admin guide for the `POST /api/v1/platform/workspaces/:id/purge` endpoint from PR #1360 — covers prerequisites (soft-delete first), data scope (53 tables including orphaned users), confirmation dialog (type workspace name), irreversibility warning, GDPR context, and full API reference with response shape.

Closes #1369, closes #1370

## Test plan
- [ ] Verify admin-console.mdx renders correctly with the two settings subsections
- [ ] Verify platform-admin.mdx GDPR purge section renders with callouts, tables, and code blocks
- [ ] Verify workspace-settings.mdx cross-link to platform settings resolves
- [ ] CI passes (lint, type, test, syncpack, template drift)