### PR TITLE
feat: admin action audit — tracer bullet

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -5,6 +5,8 @@
   "license": "AGPL-3.0-or-later",
   "exports": {
     "./app": "./src/api/index.ts",
+    "./lib/audit": "./src/lib/audit/index.ts",
+    "./lib/audit/*": "./src/lib/audit/*.ts",
     "./lib/semantic": "./src/lib/semantic/index.ts",
     "./lib/semantic/expert": "./src/lib/semantic/expert/index.ts",
     "./lib/semantic/*": "./src/lib/semantic/*.ts",

--- a/packages/api/src/api/__tests__/platform-actions.test.ts
+++ b/packages/api/src/api/__tests__/platform-actions.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for platform admin action log endpoint.
+ *
+ * Covers: GET /api/v1/platform/actions (pagination, auth, response shape).
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterAll,
+  mock,
+} from "bun:test";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+
+// --- Unified mocks ---
+
+const mocks = createApiTestMocks();
+
+// --- Mock the audit module (imported by platform-admin) ---
+
+mock.module("@atlas/api/lib/audit", () => ({
+  logAdminAction: mock(() => {}),
+  ADMIN_ACTIONS: {
+    workspace: { suspend: "workspace.suspend", unsuspend: "workspace.unsuspend", delete: "workspace.delete", purge: "workspace.purge", changePlan: "workspace.change_plan" },
+    domain: { register: "domain.register", verify: "domain.verify", delete: "domain.delete" },
+    residency: { assign: "residency.assign" },
+    sla: { updateThresholds: "sla.update_thresholds", acknowledgeAlert: "sla.acknowledge_alert" },
+    backup: { create: "backup.create", verify: "backup.verify", requestRestore: "backup.request_restore", confirmRestore: "backup.confirm_restore", updateConfig: "backup.update_config" },
+    settings: { update: "settings.update" },
+    connection: { create: "connection.create", update: "connection.update", delete: "connection.delete" },
+    user: { invite: "user.invite", remove: "user.remove", changeRole: "user.change_role" },
+    sso: { configure: "sso.configure", update: "sso.update", delete: "sso.delete", test: "sso.test" },
+    semantic: { createEntity: "semantic.create_entity", updateEntity: "semantic.update_entity", deleteEntity: "semantic.delete_entity", updateMetric: "semantic.update_metric", updateGlossary: "semantic.update_glossary" },
+    pattern: { approve: "pattern.approve", reject: "pattern.reject", delete: "pattern.delete" },
+    integration: { enable: "integration.enable", disable: "integration.disable", configure: "integration.configure" },
+    schedule: { create: "schedule.create", update: "schedule.update", delete: "schedule.delete", toggle: "schedule.toggle" },
+    apikey: { create: "apikey.create", revoke: "apikey.revoke" },
+    approval: { approve: "approval.approve", deny: "approval.deny" },
+  },
+}));
+
+mock.module("@atlas/api/lib/audit/admin", () => ({
+  logAdminAction: mock(() => {}),
+}));
+
+mock.module("@atlas/api/lib/audit/actions", () => ({
+  ADMIN_ACTIONS: {
+    workspace: { suspend: "workspace.suspend" },
+  },
+}));
+
+// --- Import app after mocks ---
+
+const { app } = await import("../index");
+
+afterAll(() => mocks.cleanup());
+
+// --- Helpers ---
+
+function platformRequest(method: string, path: string): Request {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: { "Content-Type": "application/json", "x-api-key": "test-key" },
+  });
+}
+
+const SAMPLE_ACTION = {
+  id: "act-1",
+  timestamp: "2026-04-07T12:00:00Z",
+  actor_id: "admin-1",
+  actor_email: "admin@test.com",
+  scope: "platform",
+  org_id: null,
+  action_type: "workspace.suspend",
+  target_type: "workspace",
+  target_id: "ws-1",
+  status: "success",
+  metadata: null,
+  ip_address: "10.0.0.1",
+  request_id: "req-1",
+};
+
+// --- Tests ---
+
+describe("GET /api/v1/platform/actions", () => {
+  beforeEach(() => {
+    mocks.setPlatformAdmin();
+    mocks.hasInternalDB = true;
+  });
+
+  it("returns paginated action log entries", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("COUNT(*)")) return [{ count: 1 }];
+      return [SAMPLE_ACTION];
+    });
+
+    const res = await app.request(platformRequest("GET", "/api/v1/platform/actions"));
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { actions: Array<Record<string, unknown>>; total: number; limit: number; offset: number };
+    expect(body.actions).toHaveLength(1);
+    expect(body.total).toBe(1);
+    expect(body.limit).toBe(50);
+    expect(body.offset).toBe(0);
+
+    const action = body.actions[0];
+    expect(action.id).toBe("act-1");
+    expect(action.actorEmail).toBe("admin@test.com");
+    expect(action.actionType).toBe("workspace.suspend");
+    expect(action.targetType).toBe("workspace");
+    expect(action.targetId).toBe("ws-1");
+    expect(action.status).toBe("success");
+    expect(action.scope).toBe("platform");
+  });
+
+  it("respects limit and offset query params", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes("COUNT(*)")) return [{ count: 100 }];
+      // Verify correct params are passed
+      expect(params).toEqual([10, 20]);
+      return [];
+    });
+
+    const res = await app.request(
+      platformRequest("GET", "/api/v1/platform/actions?limit=10&offset=20"),
+    );
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { actions: unknown[]; total: number; limit: number; offset: number };
+    expect(body.limit).toBe(10);
+    expect(body.offset).toBe(20);
+    expect(body.total).toBe(100);
+  });
+
+  it("returns empty list when no actions exist", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("COUNT(*)")) return [{ count: 0 }];
+      return [];
+    });
+
+    const res = await app.request(platformRequest("GET", "/api/v1/platform/actions"));
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { actions: unknown[]; total: number };
+    expect(body.actions).toEqual([]);
+    expect(body.total).toBe(0);
+  });
+
+  it("returns 403 for non-platform-admin users", async () => {
+    mocks.setOrgAdmin("org-1");
+
+    const res = await app.request(platformRequest("GET", "/api/v1/platform/actions"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when internal DB is not configured", async () => {
+    mocks.hasInternalDB = false;
+
+    const res = await app.request(platformRequest("GET", "/api/v1/platform/actions"));
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -282,6 +282,18 @@ try {
   );
 }
 
+// Platform admin action log routes — cross-tenant action audit.
+try {
+  const { platformActions } = await import("./routes/platform-actions");
+  app.route("/api/v1/platform/actions", platformActions);
+  log.info("Platform action log routes enabled");
+} catch (err) {
+  log.error(
+    { err: err instanceof Error ? err : new Error(String(err)) },
+    "Failed to load platform action log routes",
+  );
+}
+
 // Platform SLA monitoring routes — enterprise-gated, platform_admin role.
 try {
   const { platformSLA } = await import("./routes/platform-sla");

--- a/packages/api/src/api/routes/platform-actions.ts
+++ b/packages/api/src/api/routes/platform-actions.ts
@@ -1,0 +1,141 @@
+/**
+ * Platform admin action log routes.
+ *
+ * Mounted at /api/v1/platform/actions. Provides a paginated list of all
+ * admin action log entries across the platform.
+ */
+
+import { createRoute, z } from "@hono/zod-openapi";
+import { createPlatformRouter } from "./admin-router";
+import { Effect } from "effect";
+import { runEffect } from "@atlas/api/lib/effect/hono";
+import { RequestContext } from "@atlas/api/lib/effect/services";
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import {
+  ErrorSchema,
+  AuthErrorSchema,
+  PaginationQuerySchema,
+  parsePagination,
+} from "./shared-schemas";
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+const AdminActionSchema = z.object({
+  id: z.string(),
+  timestamp: z.string(),
+  actorId: z.string(),
+  actorEmail: z.string(),
+  scope: z.enum(["platform", "workspace"]),
+  orgId: z.string().nullable(),
+  actionType: z.string(),
+  targetType: z.string(),
+  targetId: z.string(),
+  status: z.enum(["success", "failure"]),
+  metadata: z.record(z.string(), z.unknown()).nullable(),
+  ipAddress: z.string().nullable(),
+  requestId: z.string(),
+});
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+const listActionsRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["Platform Admin"],
+  summary: "List admin action log",
+  description: "SaaS only. Returns a paginated list of all admin action log entries across the platform.",
+  request: { query: PaginationQuerySchema },
+  responses: {
+    200: {
+      description: "Admin action log entries",
+      content: {
+        "application/json": {
+          schema: z.object({
+            actions: z.array(AdminActionSchema),
+            total: z.number(),
+            limit: z.number(),
+            offset: z.number(),
+          }),
+        },
+      },
+    },
+    401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
+    403: { description: "Platform admin role required", content: { "application/json": { schema: AuthErrorSchema } } },
+    404: { description: "Internal database not configured", content: { "application/json": { schema: ErrorSchema } } },
+    500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+const platformActions = createPlatformRouter();
+
+platformActions.openapi(listActionsRoute, async (c) => {
+  return runEffect(c, Effect.gen(function* () {
+    const { requestId } = yield* RequestContext;
+
+    if (!hasInternalDB()) {
+      return c.json({ error: "not_configured", message: "Internal database not configured.", requestId }, 404);
+    }
+
+    const { limit, offset } = parsePagination(c, { limit: 50, maxLimit: 200 });
+
+    const [rows, countRows] = yield* Effect.promise(() => Promise.all([
+      internalQuery<{
+        id: string;
+        timestamp: string;
+        actor_id: string;
+        actor_email: string;
+        scope: "platform" | "workspace";
+        org_id: string | null;
+        action_type: string;
+        target_type: string;
+        target_id: string;
+        status: "success" | "failure";
+        metadata: Record<string, unknown> | null;
+        ip_address: string | null;
+        request_id: string;
+      }>(
+        `SELECT id, timestamp, actor_id, actor_email, scope, org_id, action_type, target_type, target_id, status, metadata, ip_address, request_id
+         FROM admin_action_log
+         ORDER BY timestamp DESC
+         LIMIT $1 OFFSET $2`,
+        [limit, offset],
+      ),
+      internalQuery<{ count: number }>(
+        `SELECT COUNT(*)::int AS count FROM admin_action_log`,
+      ),
+    ]));
+
+    const actions = rows.map((row) => ({
+      id: row.id,
+      timestamp: row.timestamp,
+      actorId: row.actor_id,
+      actorEmail: row.actor_email,
+      scope: row.scope,
+      orgId: row.org_id,
+      actionType: row.action_type,
+      targetType: row.target_type,
+      targetId: row.target_id,
+      status: row.status,
+      metadata: row.metadata,
+      ipAddress: row.ip_address,
+      requestId: row.request_id,
+    }));
+
+    return c.json({
+      actions,
+      total: countRows[0]?.count ?? 0,
+      limit,
+      offset,
+    }, 200);
+  }), { label: "list admin actions" });
+});
+
+export { platformActions };

--- a/packages/api/src/api/routes/platform-admin.ts
+++ b/packages/api/src/api/routes/platform-admin.ts
@@ -21,6 +21,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createPlatformRouter } from "./admin-router";
 import { Effect } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import {
   RequestContext,
@@ -536,6 +537,14 @@ platformAdmin.openapi(suspendWorkspaceRoute, async (c) => {
 
     yield* Effect.promise(() => updateWorkspaceStatus(workspaceId, "suspended"));
     log.info({ workspaceId, requestId }, "Workspace suspended by platform admin");
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.workspace.suspend,
+      targetType: "workspace",
+      targetId: workspaceId,
+      scope: "platform",
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    });
 
     return c.json({ message: "Workspace suspended.", workspaceId }, 200);
   }), { label: "suspend workspace" });

--- a/packages/api/src/lib/audit/__tests__/admin.test.ts
+++ b/packages/api/src/lib/audit/__tests__/admin.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { withRequestContext } from "@atlas/api/lib/logger";
+import { _resetPool, type InternalPool } from "@atlas/api/lib/db/internal";
+import type { AtlasUser } from "@atlas/api/lib/auth/types";
+import { logAdminAction } from "../admin";
+import { ADMIN_ACTIONS } from "../actions";
+
+/**
+ * Admin audit tests use _resetPool() to inject a mock pg.Pool into the real
+ * internal.ts module. This matches the pattern from audit.test.ts.
+ */
+
+let queryCalls: Array<{ sql: string; params?: unknown[] }> = [];
+let queryThrow: Error | null = null;
+
+const mockPool: InternalPool = {
+  query: async (sql: string, params?: unknown[]) => {
+    if (queryThrow) throw queryThrow;
+    queryCalls.push({ sql, params });
+    return { rows: [] };
+  },
+  async connect() {
+    return { query: async () => ({ rows: [] }), release() {} };
+  },
+  end: async () => {},
+  on: () => {},
+};
+
+describe("logAdminAction()", () => {
+  const origDbUrl = process.env.DATABASE_URL;
+
+  beforeEach(() => {
+    queryCalls = [];
+    queryThrow = null;
+  });
+
+  afterEach(() => {
+    if (origDbUrl) {
+      process.env.DATABASE_URL = origDbUrl;
+    } else {
+      delete process.env.DATABASE_URL;
+    }
+    _resetPool(null);
+  });
+
+  function enableInternalDB() {
+    process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+    _resetPool(mockPool);
+  }
+
+  it("inserts into admin_action_log with correct params when internal DB is available", () => {
+    enableInternalDB();
+    const user: AtlasUser = {
+      id: "admin-1",
+      label: "admin@example.com",
+      mode: "managed",
+      role: "platform_admin",
+      activeOrganizationId: "org-123",
+    };
+
+    withRequestContext({ requestId: "req-1", user }, () => {
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.workspace.suspend,
+        targetType: "workspace",
+        targetId: "ws-abc",
+        scope: "platform",
+        ipAddress: "10.0.0.1",
+        metadata: { reason: "abuse" },
+      });
+    });
+
+    expect(queryCalls).toHaveLength(1);
+    expect(queryCalls[0].sql).toContain("INSERT INTO admin_action_log");
+    expect(queryCalls[0].params).toEqual([
+      "admin-1",           // actor_id
+      "admin@example.com", // actor_email
+      "platform",          // scope
+      "org-123",           // org_id
+      "workspace.suspend", // action_type
+      "workspace",         // target_type
+      "ws-abc",            // target_id
+      "success",           // status
+      JSON.stringify({ reason: "abuse" }), // metadata
+      "10.0.0.1",          // ip_address
+      "req-1",             // request_id
+    ]);
+  });
+
+  it("auto-populates actor and context from request context", () => {
+    enableInternalDB();
+    const user: AtlasUser = {
+      id: "user-42",
+      label: "user@test.com",
+      mode: "managed",
+      role: "admin",
+      activeOrganizationId: "org-xyz",
+    };
+
+    withRequestContext({ requestId: "req-42", user }, () => {
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.connection.create,
+        targetType: "connection",
+        targetId: "conn-1",
+      });
+    });
+
+    expect(queryCalls).toHaveLength(1);
+    const params = queryCalls[0].params!;
+    expect(params[0]).toBe("user-42");       // actor_id
+    expect(params[1]).toBe("user@test.com"); // actor_email
+    expect(params[2]).toBe("workspace");     // default scope
+    expect(params[3]).toBe("org-xyz");       // org_id from context
+    expect(params[10]).toBe("req-42");       // request_id from context
+  });
+
+  it("uses fallback values when no request context exists", () => {
+    enableInternalDB();
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.settings.update,
+      targetType: "settings",
+      targetId: "ATLAS_MODEL",
+    });
+
+    expect(queryCalls).toHaveLength(1);
+    const params = queryCalls[0].params!;
+    expect(params[0]).toBe("unknown");   // actor_id
+    expect(params[1]).toBe("unknown");   // actor_email
+    expect(params[3]).toBeNull();        // org_id
+    expect(params[10]).toBe("unknown");  // request_id
+  });
+
+  it("does not insert when internal DB is not available", () => {
+    delete process.env.DATABASE_URL;
+    _resetPool(null);
+
+    expect(() =>
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.workspace.delete,
+        targetType: "workspace",
+        targetId: "ws-1",
+      }),
+    ).not.toThrow();
+
+    expect(queryCalls).toHaveLength(0);
+  });
+
+  it("never throws when DB insert fails synchronously", () => {
+    enableInternalDB();
+    queryThrow = new Error("connection lost");
+
+    expect(() =>
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.workspace.purge,
+        targetType: "workspace",
+        targetId: "ws-1",
+        scope: "platform",
+      }),
+    ).not.toThrow();
+  });
+
+  it("defaults status to 'success' and scope to 'workspace'", () => {
+    enableInternalDB();
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.user.invite,
+      targetType: "user",
+      targetId: "user-new",
+    });
+
+    expect(queryCalls).toHaveLength(1);
+    const params = queryCalls[0].params!;
+    expect(params[2]).toBe("workspace"); // scope
+    expect(params[7]).toBe("success");   // status
+  });
+
+  it("records failure status when provided", () => {
+    enableInternalDB();
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.sso.configure,
+      targetType: "sso",
+      targetId: "provider-1",
+      status: "failure",
+    });
+
+    expect(queryCalls).toHaveLength(1);
+    expect(queryCalls[0].params![7]).toBe("failure");
+  });
+
+  it("stores null metadata when not provided", () => {
+    enableInternalDB();
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.apikey.create,
+      targetType: "apikey",
+      targetId: "key-1",
+    });
+
+    expect(queryCalls).toHaveLength(1);
+    expect(queryCalls[0].params![8]).toBeNull(); // metadata
+  });
+
+  it("stores null ip_address when not provided", () => {
+    enableInternalDB();
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.schedule.toggle,
+      targetType: "schedule",
+      targetId: "task-1",
+    });
+
+    expect(queryCalls).toHaveLength(1);
+    expect(queryCalls[0].params![9]).toBeNull(); // ip_address
+  });
+});

--- a/packages/api/src/lib/audit/actions.ts
+++ b/packages/api/src/lib/audit/actions.ts
@@ -1,0 +1,98 @@
+/**
+ * Admin action type constants.
+ *
+ * Typed catalog of every admin action that gets logged. Organized by domain
+ * so action types are compile-time checked. New actions can be added here
+ * and immediately used with logAdminAction().
+ *
+ * Format: "domain.verb" — e.g. "workspace.suspend", "connection.create"
+ */
+
+export const ADMIN_ACTIONS = {
+  workspace: {
+    suspend: "workspace.suspend",
+    unsuspend: "workspace.unsuspend",
+    delete: "workspace.delete",
+    purge: "workspace.purge",
+    changePlan: "workspace.change_plan",
+  },
+  domain: {
+    register: "domain.register",
+    verify: "domain.verify",
+    delete: "domain.delete",
+  },
+  residency: {
+    assign: "residency.assign",
+  },
+  sla: {
+    updateThresholds: "sla.update_thresholds",
+    acknowledgeAlert: "sla.acknowledge_alert",
+  },
+  backup: {
+    create: "backup.create",
+    verify: "backup.verify",
+    requestRestore: "backup.request_restore",
+    confirmRestore: "backup.confirm_restore",
+    updateConfig: "backup.update_config",
+  },
+  settings: {
+    update: "settings.update",
+  },
+  connection: {
+    create: "connection.create",
+    update: "connection.update",
+    delete: "connection.delete",
+  },
+  user: {
+    invite: "user.invite",
+    remove: "user.remove",
+    changeRole: "user.change_role",
+  },
+  sso: {
+    configure: "sso.configure",
+    update: "sso.update",
+    delete: "sso.delete",
+    test: "sso.test",
+  },
+  semantic: {
+    createEntity: "semantic.create_entity",
+    updateEntity: "semantic.update_entity",
+    deleteEntity: "semantic.delete_entity",
+    updateMetric: "semantic.update_metric",
+    updateGlossary: "semantic.update_glossary",
+  },
+  pattern: {
+    approve: "pattern.approve",
+    reject: "pattern.reject",
+    delete: "pattern.delete",
+  },
+  integration: {
+    enable: "integration.enable",
+    disable: "integration.disable",
+    configure: "integration.configure",
+  },
+  schedule: {
+    create: "schedule.create",
+    update: "schedule.update",
+    delete: "schedule.delete",
+    toggle: "schedule.toggle",
+  },
+  apikey: {
+    create: "apikey.create",
+    revoke: "apikey.revoke",
+  },
+  approval: {
+    approve: "approval.approve",
+    deny: "approval.deny",
+  },
+} as const;
+
+/** Union of all admin action type string values. */
+type AdminActionValues = {
+  [D in keyof typeof ADMIN_ACTIONS]: (typeof ADMIN_ACTIONS)[D][keyof (typeof ADMIN_ACTIONS)[D]];
+}[keyof typeof ADMIN_ACTIONS];
+
+export type AdminActionType = AdminActionValues;
+
+/** Target type is the domain prefix of the action type. */
+export type AdminTargetType = keyof typeof ADMIN_ACTIONS;

--- a/packages/api/src/lib/audit/admin.ts
+++ b/packages/api/src/lib/audit/admin.ts
@@ -1,0 +1,107 @@
+/**
+ * Admin action audit logger.
+ *
+ * Logs every admin mutation to pino (always) and to the internal Postgres
+ * admin_action_log table (when DATABASE_URL is set). Fire-and-forget DB
+ * writes — two layers of protection:
+ *
+ * 1. internalExecute() returns a promise whose rejections are swallowed
+ *    (async errors — the .catch prevents unhandled rejection crashes).
+ * 2. The surrounding try/catch covers synchronous throws from getInternalDB()
+ *    (e.g. pool not initialized).
+ *
+ * Either way, audit failures never propagate to the caller.
+ */
+
+import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
+import { hasInternalDB, internalExecute } from "@atlas/api/lib/db/internal";
+import type { AdminActionType, AdminTargetType } from "./actions";
+
+const log = createLogger("admin-audit");
+
+export interface AdminActionEntry {
+  /** The action type from ADMIN_ACTIONS catalog. */
+  actionType: AdminActionType;
+  /** The target entity type (domain prefix, e.g. "workspace", "connection"). */
+  targetType: AdminTargetType;
+  /** The ID of the target entity. */
+  targetId: string;
+  /** Whether the action succeeded or failed. Defaults to "success". */
+  status?: "success" | "failure";
+  /** Action-specific details stored as JSONB. */
+  metadata?: Record<string, unknown>;
+  /** "platform" or "workspace". Defaults to "workspace". */
+  scope?: "platform" | "workspace";
+  /** Client IP address (extracted from request headers by caller). */
+  ipAddress?: string | null;
+}
+
+/**
+ * Log an admin action to pino and the internal DB.
+ *
+ * Auto-pulls actor_id, actor_email, org_id, and request_id from
+ * the AsyncLocalStorage request context. The caller provides the
+ * action-specific fields.
+ *
+ * This function NEVER throws — it is safe to call fire-and-forget.
+ */
+export function logAdminAction(entry: AdminActionEntry): void {
+  const ctx = getRequestContext();
+  const actorId = ctx?.user?.id ?? "unknown";
+  const actorEmail = ctx?.user?.label ?? "unknown";
+  const orgId = ctx?.user?.activeOrganizationId ?? null;
+  const requestId = ctx?.requestId ?? "unknown";
+  const scope = entry.scope ?? "workspace";
+  const status = entry.status ?? "success";
+
+  // Always log to pino
+  const logFn = status === "success" ? log.info.bind(log) : log.warn.bind(log);
+  logFn(
+    {
+      actionType: entry.actionType,
+      targetType: entry.targetType,
+      targetId: entry.targetId,
+      scope,
+      status,
+      actorId,
+      actorEmail,
+      orgId,
+      requestId,
+      ...(entry.metadata && { metadata: entry.metadata }),
+      ...(entry.ipAddress && { ipAddress: entry.ipAddress }),
+    },
+    `admin_action: ${entry.actionType}`,
+  );
+
+  // Insert into admin_action_log when internal DB is available.
+  // internalExecute() is fire-and-forget (returns void, handles its own
+  // async errors via circuit breaker). The try/catch here guards against
+  // synchronous throws from pool initialization.
+  if (hasInternalDB()) {
+    try {
+      internalExecute(
+        `INSERT INTO admin_action_log
+           (actor_id, actor_email, scope, org_id, action_type, target_type, target_id, status, metadata, ip_address, request_id)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+        [
+          actorId,
+          actorEmail,
+          scope,
+          orgId,
+          entry.actionType,
+          entry.targetType,
+          entry.targetId,
+          status,
+          entry.metadata ? JSON.stringify(entry.metadata) : null,
+          entry.ipAddress ?? null,
+          requestId,
+        ],
+      );
+    } catch (err: unknown) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "admin_action_log insert failed",
+      );
+    }
+  }
+}

--- a/packages/api/src/lib/audit/index.ts
+++ b/packages/api/src/lib/audit/index.ts
@@ -1,0 +1,2 @@
+export { ADMIN_ACTIONS, type AdminActionType, type AdminTargetType } from "./actions";
+export { logAdminAction, type AdminActionEntry } from "./admin";

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -265,6 +265,7 @@ describe("migrateAuthTables", () => {
             { name: "0020_plan_tier_rename.sql" },
             { name: "0021_connection_org_scope.sql" },
             { name: "0022_sso_domain_verification.sql" },
+            { name: "0023_admin_action_log.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -62,7 +62,7 @@ describe("runMigrations", () => {
 
     const count = await runMigrations(pool);
 
-    expect(count).toBe(23);
+    expect(count).toBe(24);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -114,6 +114,7 @@ describe("runMigrations", () => {
         "0020_plan_tier_rename.sql",
         "0021_connection_org_scope.sql",
         "0022_sso_domain_verification.sql",
+        "0023_admin_action_log.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0023_admin_action_log.sql
+++ b/packages/api/src/lib/db/migrations/0023_admin_action_log.sql
@@ -1,0 +1,42 @@
+-- 0023 — Admin action audit log
+--
+-- Persistent log for all admin mutations (platform + workspace).
+-- These records are kept indefinitely — no deleted_at column.
+
+CREATE TABLE IF NOT EXISTS admin_action_log (
+  id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  timestamp     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  actor_id      TEXT        NOT NULL,
+  actor_email   TEXT        NOT NULL,
+  scope         TEXT        NOT NULL DEFAULT 'workspace',
+  org_id        TEXT,
+  action_type   TEXT        NOT NULL,
+  target_type   TEXT        NOT NULL,
+  target_id     TEXT        NOT NULL,
+  status        TEXT        NOT NULL DEFAULT 'success',
+  metadata      JSONB,
+  ip_address    TEXT,
+  request_id    TEXT        NOT NULL
+);
+
+-- Constraint: scope must be 'platform' or 'workspace'
+DO $$ BEGIN
+  ALTER TABLE admin_action_log ADD CONSTRAINT chk_admin_action_scope
+    CHECK (scope IN ('platform', 'workspace'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Constraint: status must be 'success' or 'failure'
+DO $$ BEGIN
+  ALTER TABLE admin_action_log ADD CONSTRAINT chk_admin_action_status
+    CHECK (status IN ('success', 'failure'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Indexes for common query patterns
+CREATE INDEX IF NOT EXISTS idx_admin_action_log_timestamp   ON admin_action_log (timestamp);
+CREATE INDEX IF NOT EXISTS idx_admin_action_log_actor_id    ON admin_action_log (actor_id);
+CREATE INDEX IF NOT EXISTS idx_admin_action_log_org_id      ON admin_action_log (org_id);
+CREATE INDEX IF NOT EXISTS idx_admin_action_log_action_type ON admin_action_log (action_type);
+CREATE INDEX IF NOT EXISTS idx_admin_action_log_target_type ON admin_action_log (target_type);
+CREATE INDEX IF NOT EXISTS idx_admin_action_log_org_ts      ON admin_action_log (org_id, timestamp);

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -1260,3 +1260,36 @@ export const sandboxCredentials = pgTable(
     index("idx_sandbox_credentials_org").on(t.orgId),
   ],
 );
+
+// ---------------------------------------------------------------------------
+// Admin action audit log
+// ---------------------------------------------------------------------------
+
+export const adminActionLog = pgTable(
+  "admin_action_log",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    timestamp: timestamp("timestamp", { withTimezone: true }).notNull().defaultNow(),
+    actorId: text("actor_id").notNull(),
+    actorEmail: text("actor_email").notNull(),
+    scope: text("scope").notNull().default("workspace"),
+    orgId: text("org_id"),
+    actionType: text("action_type").notNull(),
+    targetType: text("target_type").notNull(),
+    targetId: text("target_id").notNull(),
+    status: text("status").notNull().default("success"),
+    metadata: jsonb("metadata"),
+    ipAddress: text("ip_address"),
+    requestId: text("request_id").notNull(),
+  },
+  (t) => [
+    index("idx_admin_action_log_timestamp").on(t.timestamp),
+    index("idx_admin_action_log_actor_id").on(t.actorId),
+    index("idx_admin_action_log_org_id").on(t.orgId),
+    index("idx_admin_action_log_action_type").on(t.actionType),
+    index("idx_admin_action_log_target_type").on(t.targetType),
+    index("idx_admin_action_log_org_ts").on(t.orgId, t.timestamp),
+    check("chk_admin_action_scope", sql`scope IN ('platform', 'workspace')`),
+    check("chk_admin_action_status", sql`status IN ('success', 'failure')`),
+  ],
+);

--- a/packages/web/src/app/admin/platform/actions/page.tsx
+++ b/packages/web/src/app/admin/platform/actions/page.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
+import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
+import { usePlatformAdminGuard } from "@/ui/hooks/use-platform-admin-guard";
+import { ErrorBoundary } from "@/ui/components/error-boundary";
+import {
+  ChevronLeft,
+  ChevronRight,
+  ClipboardList,
+} from "lucide-react";
+import { useState } from "react";
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+const AdminActionSchema = z.object({
+  id: z.string(),
+  timestamp: z.string(),
+  actorId: z.string(),
+  actorEmail: z.string(),
+  scope: z.enum(["platform", "workspace"]),
+  orgId: z.string().nullable(),
+  actionType: z.string(),
+  targetType: z.string(),
+  targetId: z.string(),
+  status: z.enum(["success", "failure"]),
+  metadata: z.record(z.string(), z.unknown()).nullable(),
+  ipAddress: z.string().nullable(),
+  requestId: z.string(),
+});
+
+const ActionsResponseSchema = z.object({
+  actions: z.array(AdminActionSchema),
+  total: z.number(),
+  limit: z.number(),
+  offset: z.number(),
+});
+
+type AdminAction = z.infer<typeof AdminActionSchema>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatTimestamp(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function scopeBadge(scope: string) {
+  return scope === "platform"
+    ? <Badge variant="outline" className="text-xs">Platform</Badge>
+    : <Badge variant="secondary" className="text-xs">Workspace</Badge>;
+}
+
+function statusBadge(status: string) {
+  return status === "success"
+    ? <Badge variant="outline" className="gap-1 border-green-500 text-green-600 text-xs">Success</Badge>
+    : <Badge variant="destructive" className="gap-1 text-xs">Failure</Badge>;
+}
+
+function metadataPreview(metadata: Record<string, unknown> | null): string {
+  if (!metadata) return "—";
+  const entries = Object.entries(metadata).slice(0, 3);
+  return entries.map(([k, v]) => `${k}: ${String(v)}`).join(", ");
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+const PAGE_SIZE = 50;
+
+function ActionsPageContent() {
+  const [offset, setOffset] = useState(0);
+
+  const { data, loading, error, refetch } = useAdminFetch(
+    `/api/v1/platform/actions?limit=${PAGE_SIZE}&offset=${offset}`,
+    { schema: ActionsResponseSchema },
+  );
+
+  const actions: AdminAction[] = data?.actions ?? [];
+  const total = data?.total ?? 0;
+  const hasNext = offset + PAGE_SIZE < total;
+  const hasPrev = offset > 0;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold tracking-tight">Action Log</h2>
+        <p className="text-muted-foreground">
+          All admin actions across the platform. {total > 0 && `${total} total entries.`}
+        </p>
+      </div>
+
+      <AdminContentWrapper
+        loading={loading}
+        error={error}
+        feature="Action Log"
+        onRetry={refetch}
+        loadingMessage="Loading action log…"
+        emptyIcon={ClipboardList}
+        emptyTitle="No actions recorded"
+        emptyDescription="Admin actions will appear here once platform or workspace mutations are performed."
+        isEmpty={actions.length === 0}
+      >
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[140px]">Timestamp</TableHead>
+                <TableHead>Actor</TableHead>
+                <TableHead>Action</TableHead>
+                <TableHead>Target</TableHead>
+                <TableHead>Scope</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Details</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {actions.map((action) => (
+                <TableRow key={action.id}>
+                  <TableCell className="text-xs text-muted-foreground whitespace-nowrap">
+                    {formatTimestamp(action.timestamp)}
+                  </TableCell>
+                  <TableCell className="text-sm">{action.actorEmail}</TableCell>
+                  <TableCell>
+                    <code className="text-xs bg-muted px-1.5 py-0.5 rounded">
+                      {action.actionType}
+                    </code>
+                  </TableCell>
+                  <TableCell className="text-xs font-mono text-muted-foreground">
+                    {action.targetType}/{action.targetId.slice(0, 8)}
+                  </TableCell>
+                  <TableCell>{scopeBadge(action.scope)}</TableCell>
+                  <TableCell>{statusBadge(action.status)}</TableCell>
+                  <TableCell className="text-xs text-muted-foreground max-w-[200px] truncate">
+                    {metadataPreview(action.metadata)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+
+        {/* Pagination */}
+        {total > PAGE_SIZE && (
+          <div className="flex items-center justify-between pt-4">
+            <p className="text-sm text-muted-foreground">
+              Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}
+            </p>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={!hasPrev}
+                onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+              >
+                <ChevronLeft className="size-4 mr-1" />
+                Previous
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={!hasNext}
+                onClick={() => setOffset(offset + PAGE_SIZE)}
+              >
+                Next
+                <ChevronRight className="size-4 ml-1" />
+              </Button>
+            </div>
+          </div>
+        )}
+      </AdminContentWrapper>
+    </div>
+  );
+}
+
+export default function ActionsPage() {
+  const { blocked } = usePlatformAdminGuard();
+  if (blocked) return null;
+
+  return (
+    <ErrorBoundary>
+      <ActionsPageContent />
+    </ErrorBoundary>
+  );
+}

--- a/packages/web/src/ui/components/admin/admin-sidebar.tsx
+++ b/packages/web/src/ui/components/admin/admin-sidebar.tsx
@@ -143,6 +143,7 @@ const navGroups: NavGroup[] = [
     requiredRole: "platform_admin",
     items: [
       { href: "/admin/platform", label: "Overview", exact: true },
+      { href: "/admin/platform/actions", label: "Action Log" },
       { href: "/admin/platform/sla", label: "SLA Monitoring" },
       { href: "/admin/platform/backups", label: "Backups" },
       { href: "/admin/platform/residency", label: "Data Residency" },


### PR DESCRIPTION
## Summary

End-to-end tracer bullet for admin action audit logging (#1364). Cuts through every layer:

- **Migration 0023** — `admin_action_log` table with all columns (actor, scope, action_type, target, status, metadata, IP, request_id) + 6 indexes + check constraints
- **Drizzle schema** — `adminActionLog` table definition in `schema.ts`
- **Action type catalog** — `ADMIN_ACTIONS` typed constant object covering all 39 action types across 14 domains (workspace, domain, connection, sso, semantic, etc.)
- **`logAdminAction()`** — fire-and-forget writer following the exact `logQueryAudit()` pattern: pino always, DB when available, failures never propagate
- **Instrumented `workspace.suspend`** — first proof-of-concept call site in `platform-admin.ts`
- **`GET /api/v1/platform/actions`** — paginated list endpoint with OpenAPI route definition, platform admin auth required
- **Platform admin "Action Log" page** — `/admin/platform/actions` with table, pagination, status badges, metadata preview
- **14 tests** — 9 for `logAdminAction()` (DB write, fire-and-forget guarantee, auto-populated context, fallbacks) + 5 for endpoint (pagination, auth 403, response shape)

Also filed #1372 for a pre-existing missing mock export (`hardDeleteWorkspace`) discovered during testing.

Closes #1364

## Test plan

- [x] `bun run lint` — passes
- [x] `bun run type` — passes
- [x] `bun run test` — 303 files, 0 failures (211 api + 42 web + 25 ee + 17 cli + 8 react)
- [x] `bun x syncpack lint` — passes
- [x] Template drift check — passes
- [ ] Verify Action Log page renders at `/admin/platform/actions` with sample data
- [ ] Verify suspend action creates a row visible in the action log