### PR TITLE
fix: health check findings — PG readonly, sidecar healthchecks, whitelist warning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ bun run atlas -- diff    # Compare DB schema vs semantic layer
 | `examples/docker` | — | Self-hosted Docker deploy + optional nsjail |
 | `examples/nextjs-standalone` | — | Pure Next.js + embedded Hono API (Vercel) |
 | `create-atlas` | — | Scaffolding CLI (`bun create @useatlas`) |
+| `create-atlas-plugin` | — | Plugin scaffolding CLI (`bun create @useatlas/plugin`) |
 | `ee/` | `@atlas/ee` | Enterprise features — source-available, commercial license |
 | `plugins/` | — | Atlas plugins directory |
 

--- a/create-atlas/templates/docker/Dockerfile.sidecar
+++ b/create-atlas/templates/docker/Dockerfile.sidecar
@@ -25,4 +25,7 @@ ENV SEMANTIC_DIR=/semantic
 
 USER sandbox
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+  CMD bun -e "try { const r = await fetch('http://localhost:' + (process.env.PORT || 8080) + '/health'); if(!r.ok){console.error(r.status); process.exit(1)} } catch(e) { console.error(e.message); process.exit(1) }"
+
 CMD ["bun", "run", "server.ts"]

--- a/create-atlas/templates/docker/sidecar/Dockerfile
+++ b/create-atlas/templates/docker/sidecar/Dockerfile
@@ -24,4 +24,7 @@ ENV SEMANTIC_DIR=/semantic
 
 USER sandbox
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+  CMD bun -e "try { const r = await fetch('http://localhost:' + (process.env.PORT || 8080) + '/health'); if(!r.ok){console.error(r.status); process.exit(1)} } catch(e) { console.error(e.message); process.exit(1) }"
+
 CMD ["bun", "run", "server.ts"]

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -276,6 +276,7 @@ function createPostgresDB(config: ConnectionConfig): DBConnection {
         }
 
         await client.query(`SET statement_timeout = ${timeoutMs}`);
+        await client.query("SET TRANSACTION READ ONLY");
         const result = await client.query(sql);
         const columns = result.fields.map(
           (f: { name: string }) => f.name

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -38,6 +38,14 @@ import {
 
 const log = createLogger("sql");
 
+let whitelistWarned = false;
+function warnWhitelistDisabled() {
+  if (!whitelistWarned) {
+    log.warn("SQL table whitelist is disabled — all tables are queryable");
+    whitelistWarned = true;
+  }
+}
+
 const parser = new Parser();
 
 // ── Classification ──────────────────────────────────────────────────
@@ -281,7 +289,9 @@ export function validateSQL(sql: string, connectionId?: string): SQLValidationRe
 
   // 3. Table whitelist check — use getSettingAuto for SaaS hot-reload
   const whitelistSetting = getSettingAuto("ATLAS_TABLE_WHITELIST") ?? process.env.ATLAS_TABLE_WHITELIST;
-  if (whitelistSetting !== "false") {
+  if (whitelistSetting === "false") {
+    warnWhitelistDisabled();
+  } else {
     try {
       const tables = parser.tableList(trimmed, { database: parserDatabase(dbType, connectionId) });
       const orgId = getRequestContext()?.user?.activeOrganizationId;


### PR DESCRIPTION
## Summary
- **PostgreSQL defense-in-depth**: Add `SET TRANSACTION READ ONLY` before every query — matches MySQL's existing protection. The SQL validation pipeline is the primary control, but this adds a database-level safety net
- **Sidecar HEALTHCHECK**: Add Docker HEALTHCHECK to 2 sidecar Dockerfile templates (matching `packages/sandbox-sidecar/Dockerfile` pattern)
- **Whitelist warning**: Log once when `ATLAS_TABLE_WHITELIST=false` — operators should know when Layer 3 validation is disabled
- **CLAUDE.md**: Add `create-atlas-plugin` to the Architecture table

Note: The starter Dockerfiles (`create-atlas/starters/atlas-starter-railway/`) also need the bun version bump (1.3.10 → 1.3.11) and HEALTHCHECK, but they're gitignored and synced separately — will be picked up on next starter sync.

## Test plan
- [x] `bun run lint` — 0 warnings
- [x] `bun run type` — 0 errors
- [x] SQL validation tests — 103/103 pass
- [x] Connection tests — 23/23 pass