### PR TITLE
docs: fix critical/high docs audit findings

### DIFF
--- a/apps/docs/content/docs/guides/admin-console.mdx
+++ b/apps/docs/content/docs/guides/admin-console.mdx
@@ -525,7 +525,7 @@ Manage workspaces (organizations) across the platform:
 - **Suspend** — Block all queries for a workspace. Drains the org's connection pools immediately. Use this for billing holds, abuse prevention, or maintenance windows
 - **Activate** — Reactivate a suspended workspace. Queries resume immediately
 - **Delete** — Soft-delete with cascading cleanup: drain pools, flush caches, cascade database cleanup, mark as deleted. This is not reversible from the UI
-- **Change plan** — Set a workspace's plan tier: `free`, `team`, or `enterprise`
+- **Change plan** — Set a workspace's plan tier: `free`, `trial`, `starter`, `pro`, or `business`
 
 ### Health Status
 
@@ -653,8 +653,8 @@ Once submitted, a migration progresses through these phases:
 
 **Route:** `/admin/custom-domain`
 
-<Callout type="info" title="Enterprise Feature">
-Custom domains require an Enterprise plan on [app.useatlas.dev](https://app.useatlas.dev). The page shows an upgrade prompt if your workspace is on a lower plan.
+<Callout type="info" title="Pro+ Feature">
+Custom domains are available on the Pro and Business plans on [app.useatlas.dev](https://app.useatlas.dev). The page shows an upgrade prompt if your workspace is on a lower plan.
 </Callout>
 
 Serve Atlas from your own domain (e.g. `data.acme.com`) with automatic TLS certificate provisioning.

--- a/apps/docs/content/docs/guides/billing-and-plans.mdx
+++ b/apps/docs/content/docs/guides/billing-and-plans.mdx
@@ -43,15 +43,15 @@ Annual billing is available for Starter and Pro (pay for 10 months, get 12).
 - **Business** — Unlimited seats and connections. Includes SSO, SCIM, data residency, and SLA.
 - **Self-Hosted** (free) — No billing enforcement. All features available, no Stripe needed. Uses your own API keys (BYOK).
 
-### Per-Seat Query Budgets
+### Per-Seat Token Budgets
 
-Query budgets scale with your team size. Each seat adds its tier's allocation to your workspace total. The per-query cost adjusts automatically based on the model — a more expensive model uses more budget per query, a cheaper one uses less.
+Token budgets scale with your team size. Each seat adds its tier's token allocation to your workspace total. The actual query cost varies by model — a more capable model uses more tokens per query than a smaller one.
 
-| Plan | 5 seats | 10 seats | 25 seats |
-|------|---------|----------|----------|
-| **Starter** | ~500 queries | ~1,000 queries | — (max 10) |
-| **Pro** | ~1,250 queries | ~2,500 queries | ~6,250 queries |
-| **Business** | ~3,750 queries | ~7,500 queries | ~18,750 queries |
+| Plan | Token budget per seat | 5 seats | 10 seats |
+|------|----------------------|---------|----------|
+| **Starter** | 2M tokens | 10M tokens | 20M tokens (max 10 seats) |
+| **Pro** | 5M tokens | 25M tokens | 50M tokens |
+| **Business** | 15M tokens | 75M tokens | 150M tokens |
 
 The budget is computed dynamically from your actual member count — no manual configuration needed.
 
@@ -108,13 +108,11 @@ Atlas uses a 4-tier degradation model instead of a hard cutoff. Enforcement runs
 | **Soft limit** | 100–109% | 10% grace buffer. Request allowed with overage warning |
 | **Hard limit** | 110%+ | Request blocked with HTTP 429. Upgrade or add-seats CTA in error message |
 
-When usage exceeds the included budget, overage charges apply per plan:
+When usage exceeds the included token budget, overage charges apply at a flat rate across all paid plans:
 
-| Plan | Overage rate |
+| Rate | Description |
 |------|-------------|
-| **Starter** | $0.10 / query |
-| **Pro** | $0.08 / query |
-| **Business** | $0.06 / query |
+| **$1.00 / 1M tokens** | Applies to Starter, Pro, and Business plans equally |
 
 To avoid overages entirely, enable [BYOT](#byot-bring-your-own-token) and use your own API keys.
 

--- a/apps/docs/content/docs/guides/dashboards.mdx
+++ b/apps/docs/content/docs/guides/dashboards.mdx
@@ -70,7 +70,7 @@ Auto-refresh requires `ATLAS_SCHEDULER_ENABLED=true`. See [Scheduled Tasks](/gui
 
 ## AI Suggestions
 
-Click **Suggest Cards** to have the AI analyze your existing cards and propose 2–3 complementary metrics. Suggestions are grounded in your [semantic layer](/concepts/semantic-layer) — the AI only references tables and columns it knows about.
+Click **Suggest Cards** to have the AI analyze your existing cards and propose 2–3 complementary metrics. Suggestions are grounded in your [semantic layer](/getting-started/semantic-layer) — the AI only references tables and columns it knows about.
 
 Each suggestion shows:
 

--- a/apps/docs/content/docs/guides/onboarding-emails.mdx
+++ b/apps/docs/content/docs/guides/onboarding-emails.mdx
@@ -62,7 +62,7 @@ Admins can view onboarding email status for their organization via the admin API
 - **List statuses** — `GET /api/v1/admin/onboarding-emails` returns per-user progress (sent steps, pending steps, unsubscribe status)
 - **View sequence** — `GET /api/v1/admin/onboarding-emails/sequence` returns the configured sequence steps with triggers and timing
 
-See the [API Reference](/docs/api-reference/admin-onboarding-emails/getAdminOnboardingEmails) for full endpoint documentation.
+See the [API Reference](/api-reference/admin-onboarding-emails/getAdminOnboardingEmails) for full endpoint documentation.
 
 ---
 

--- a/apps/docs/content/docs/guides/semantic-expert.mdx
+++ b/apps/docs/content/docs/guides/semantic-expert.mdx
@@ -225,7 +225,7 @@ atlas migrate rollback <hash>
 
 Snapshots are stored in `semantic/.history/` as JSON files. Each snapshot captures all entity YAMLs, glossary, metrics, and catalog at that point in time. Use `atlas migrate log` to see the full history with hashes, timestamps, and trigger labels.
 
-See the [CLI reference](/docs/reference/cli#migrate) for the full `atlas migrate` documentation.
+See the [CLI reference](/reference/cli#migrate) for the full `atlas migrate` documentation.
 
 ## Web Interactive Mode
 

--- a/apps/docs/content/docs/reference/cli.mdx
+++ b/apps/docs/content/docs/reference/cli.mdx
@@ -585,7 +585,7 @@ atlas improve --min-confidence 0.7
 atlas improve --entities orders,users,products
 ```
 
-See the [Semantic Expert guide](/docs/guides/semantic-expert) for full documentation.
+See the [Semantic Expert guide](/guides/semantic-expert) for full documentation.
 
 ## benchmark
 

--- a/apps/docs/content/docs/reference/config.mdx
+++ b/apps/docs/content/docs/reference/config.mdx
@@ -798,7 +798,7 @@ ATLAS_ENTERPRISE_LICENSE_KEY=your-key-here
 ```
 
 <Callout type="info">
-Planned enterprise features include SSO (SAML/OIDC), SCIM provisioning, PII detection, custom roles, and advanced audit capabilities. The AGPL-licensed core is fully functional without enterprise features enabled.
+Enterprise features include SSO (SAML/OIDC), SCIM provisioning, PII detection, custom roles, approval workflows, and advanced audit capabilities. The AGPL-licensed core is fully functional without enterprise features enabled.
 </Callout>
 
 ---

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -625,9 +625,12 @@ Stripe billing integration for SaaS deployments. Self-hosted deployments do not 
 |----------|---------|-------------|
 | `STRIPE_SECRET_KEY` | — | Stripe secret key (test or live). Enables billing routes and Better Auth Stripe plugin when set |
 | `STRIPE_WEBHOOK_SECRET` | — | Stripe webhook signing secret for verifying webhook events |
-| `STRIPE_TEAM_PRICE_ID` | — | Stripe Price ID for the Team plan (monthly) |
-| `STRIPE_TEAM_ANNUAL_PRICE_ID` | — | Stripe Price ID for the Team plan (annual discount) |
-| `STRIPE_ENTERPRISE_PRICE_ID` | — | Stripe Price ID for the Enterprise plan |
+| `STRIPE_STARTER_PRICE_ID` | — | Stripe Price ID for the Starter plan (monthly, $29/seat) |
+| `STRIPE_STARTER_ANNUAL_PRICE_ID` | — | Stripe Price ID for the Starter plan (annual) |
+| `STRIPE_PRO_PRICE_ID` | — | Stripe Price ID for the Pro plan (monthly, $59/seat) |
+| `STRIPE_PRO_ANNUAL_PRICE_ID` | — | Stripe Price ID for the Pro plan (annual) |
+| `STRIPE_BUSINESS_PRICE_ID` | — | Stripe Price ID for the Business plan (monthly, $99/seat) |
+| `STRIPE_BUSINESS_ANNUAL_PRICE_ID` | — | Stripe Price ID for the Business plan (annual) |
 
 When `STRIPE_SECRET_KEY` is set, billing routes are mounted at `/api/v1/billing` and the Better Auth Stripe plugin handles checkout, webhooks, and subscription lifecycle at `/api/auth/stripe/*`.
 


### PR DESCRIPTION
## Summary
- **Stripe env vars**: Fix wrong names (`TEAM`/`ENTERPRISE` → `STARTER`/`PRO`/`BUSINESS`, 3→6 vars)
- **Billing overage**: Fix stale per-query rates → flat $1.00/1M tokens; fix budget framing from query-based to token-based
- **Plan tiers**: Fix `team`/`enterprise` → `starter`/`pro`/`business` in admin-console guide
- **Custom domains**: Fix "Enterprise plan" requirement → Pro+ (both Pro and Business have `customDomain: true`)
- **Dead/broken links**: Fix 4 dead links (`/concepts/semantic-layer`, 3x `/docs/` prefix)
- **Stale language**: "Planned enterprise features" → already shipped

## Filed issues for remaining findings
- #1375 — 16 OpenAPI paths use invalid `:param` syntax
- #1376 — Regenerate OpenAPI spec (missing platform-actions + GDPR purge)
- #1377 — SDK docs missing `listTables()`, `share()`/`unshare()`
- #1378 — 4 plugins missing from directory component

## Test plan
- [x] All edits are docs-only (MDX content)
- [x] No code changes — no lint/type/test impact