### PR TITLE
fix: CORS on streaming responses, Bun idle timeout, PG read-only

### DIFF
--- a/packages/api/src/api/__tests__/cors.test.ts
+++ b/packages/api/src/api/__tests__/cors.test.ts
@@ -22,7 +22,11 @@ mock.module("@atlas/api/lib/auth/middleware", () => ({
 mock.module("@atlas/api/lib/agent", () => ({
   runAgent: () =>
     Promise.resolve({
-      toUIMessageStreamResponse: () => new Response("stream", { status: 200 }),
+      // Must provide toUIMessageStream (not toUIMessageStreamResponse) —
+      // the chat route calls agentResult.toUIMessageStream() to merge into
+      // createUIMessageStream, then throws HTTPException(200, { res }).
+      toUIMessageStream: () => new ReadableStream({ start(c) { c.close(); } }),
+      text: Promise.resolve(""),
     }),
 }));
 
@@ -138,9 +142,10 @@ describe("CORS middleware", () => {
   });
 
   it("streaming chat POST response includes CORS headers (HTTPException path)", async () => {
-    // The chat route throws HTTPException(200, { res: streamResponse }) which
-    // bypasses Hono's middleware response headers. The onError handler must
-    // copy CORS headers from the context to the raw Response.
+    // The chat route creates a streaming Response via createUIMessageStreamResponse
+    // and throws it as HTTPException(200, { res }). This bypasses Hono's middleware
+    // header pipeline. The onError handler must copy CORS headers from the context
+    // to the raw Response for cross-origin browsers to accept the stream.
     const res = await app.fetch(
       new Request("http://localhost/api/v1/chat", {
         method: "POST",
@@ -156,8 +161,10 @@ describe("CORS middleware", () => {
       }),
     );
 
-    // The response should have CORS headers regardless of whether it's
-    // a normal response or a streaming HTTPException response
+    // Verify this is a streaming response (SSE), not a JSON error fallback —
+    // confirms we're testing the HTTPException path, not the normal c.json() path.
+    expect(res.headers.get("Content-Type")).toContain("text/event-stream");
+    // CORS headers must be present on the streaming response
     expect(res.headers.get("Access-Control-Allow-Origin")).toBeTruthy();
   });
 

--- a/packages/api/src/api/__tests__/cors.test.ts
+++ b/packages/api/src/api/__tests__/cors.test.ts
@@ -137,6 +137,30 @@ describe("CORS middleware", () => {
     expect(exposeHeaders).toContain("Retry-After");
   });
 
+  it("streaming chat POST response includes CORS headers (HTTPException path)", async () => {
+    // The chat route throws HTTPException(200, { res: streamResponse }) which
+    // bypasses Hono's middleware response headers. The onError handler must
+    // copy CORS headers from the context to the raw Response.
+    const res = await app.fetch(
+      new Request("http://localhost/api/v1/chat", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "http://example.com",
+        },
+        body: JSON.stringify({
+          messages: [
+            { id: "1", role: "user", parts: [{ type: "text", text: "hello" }] },
+          ],
+        }),
+      }),
+    );
+
+    // The response should have CORS headers regardless of whether it's
+    // a normal response or a streaming HTTPException response
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBeTruthy();
+  });
+
   // NOTE: Testing ATLAS_CORS_ORIGIN with a specific value would require
   // re-importing the app module after setting the env var, since Hono's
   // cors() middleware captures the origin config at app creation time.

--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -411,11 +411,15 @@ app.onError((err, c) => {
     const corsOrigin = c.res.headers.get("Access-Control-Allow-Origin");
     if (corsOrigin && !res.headers.has("Access-Control-Allow-Origin")) {
       const patched = new Response(res.body, res);
-      patched.headers.set("Access-Control-Allow-Origin", corsOrigin);
-      const creds = c.res.headers.get("Access-Control-Allow-Credentials");
-      if (creds) patched.headers.set("Access-Control-Allow-Credentials", creds);
-      const expose = c.res.headers.get("Access-Control-Expose-Headers");
-      if (expose) patched.headers.set("Access-Control-Expose-Headers", expose);
+      for (const h of [
+        "Access-Control-Allow-Origin",
+        "Access-Control-Allow-Credentials",
+        "Access-Control-Allow-Headers",
+        "Access-Control-Expose-Headers",
+      ]) {
+        const v = c.res.headers.get(h);
+        if (v) patched.headers.set(h, v);
+      }
       return patched;
     }
     return res;

--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -404,8 +404,21 @@ if (process.env.DISCORD_CLIENT_ID) {
 app.onError((err, c) => {
   // Framework HTTP exceptions (e.g., malformed JSON from @hono/zod-openapi) carry
   // their own status code and response — forward them instead of converting to 500.
+  // CORS headers must be copied from the middleware context because the raw Response
+  // from HTTPException(200, { res }) bypasses Hono's header pipeline.
   if (err instanceof HTTPException) {
-    return err.getResponse();
+    const res = err.getResponse();
+    const corsOrigin = c.res.headers.get("Access-Control-Allow-Origin");
+    if (corsOrigin && !res.headers.has("Access-Control-Allow-Origin")) {
+      const patched = new Response(res.body, res);
+      patched.headers.set("Access-Control-Allow-Origin", corsOrigin);
+      const creds = c.res.headers.get("Access-Control-Allow-Credentials");
+      if (creds) patched.headers.set("Access-Control-Allow-Credentials", creds);
+      const expose = c.res.headers.get("Access-Control-Expose-Headers");
+      if (expose) patched.headers.set("Access-Control-Expose-Headers", expose);
+      return patched;
+    }
+    return res;
   }
   const requestId = crypto.randomUUID();
   log.error({ err, path: c.req.path, requestId }, "Unhandled error");

--- a/packages/api/src/api/server.ts
+++ b/packages/api/src/api/server.ts
@@ -276,6 +276,10 @@ await Effect.runPromise(runtime.runtimeEffect).catch((err) => {
 const server = Bun.serve({
   port,
   fetch: app.fetch,
+  // Bun's default idleTimeout is 10s — too short for SSE/streaming responses.
+  // Agent runs can take 60-90s with gaps >10s between stream writes (LLM thinking,
+  // tool execution). Setting to 0 disables the idle timeout entirely.
+  idleTimeout: 0,
 });
 
 // ── Graceful shutdown ───────────────────────────────────────────────

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -276,7 +276,7 @@ function createPostgresDB(config: ConnectionConfig): DBConnection {
         }
 
         await client.query(`SET statement_timeout = ${timeoutMs}`);
-        await client.query("SET TRANSACTION READ ONLY");
+        await client.query("SET default_transaction_read_only = on");
         const result = await client.query(sql);
         const columns = result.fields.map(
           (f: { name: string }) => f.name

--- a/packages/api/src/lib/tools/explore-sidecar.ts
+++ b/packages/api/src/lib/tools/explore-sidecar.ts
@@ -70,6 +70,18 @@ export async function createSidecarBackend(
       );
     } else {
       log.info({ url: baseUrl.origin }, "Sidecar health check passed");
+      // Warn if bash is missing — explore commands will fail with ENOENT
+      try {
+        const body = await healthRes.clone().json() as Record<string, unknown>;
+        if (body && body.bashAvailable === false) {
+          log.error(
+            { url: baseUrl.origin },
+            "Sidecar is running but bash is not installed — explore commands will fail. Rebuild the sidecar image.",
+          );
+        }
+      } catch {
+        // intentionally ignored: health response parsing — non-critical
+      }
     }
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);

--- a/packages/mcp/src/sse.ts
+++ b/packages/mcp/src/sse.ts
@@ -162,6 +162,7 @@ export async function startSseServer(
   const bunServer = Bun.serve({
     port,
     hostname,
+    idleTimeout: 0, // SSE streaming — no idle timeout
     error(err) {
       log.error({ err }, "Unhandled server error");
       return new Response(

--- a/packages/sandbox-sidecar/src/server.ts
+++ b/packages/sandbox-sidecar/src/server.ts
@@ -733,6 +733,15 @@ function handleHealth(): Response {
   try {
     const entries = readdirSync(SEMANTIC_DIR);
 
+    // Check bash availability (required for explore commands)
+    let bashAvailable = false;
+    try {
+      const proc = Bun.spawnSync(["bash", "--version"]);
+      bashAvailable = proc.exitCode === 0;
+    } catch {
+      // intentionally ignored: bash availability check
+    }
+
     // Check python3 availability
     let pythonAvailable = false;
     try {
@@ -743,10 +752,12 @@ function handleHealth(): Response {
     }
 
     return Response.json({
-      status: "ok",
+      status: bashAvailable ? "ok" : "degraded",
       semanticDir: SEMANTIC_DIR,
       fileCount: entries.length,
+      bashAvailable,
       pythonAvailable,
+      ...(!bashAvailable && { warning: "bash not found — explore commands will fail. Rebuild the sidecar image." }),
     });
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- **CORS headers missing on SSE streams** — `HTTPException(200, { res })` pattern bypasses Hono middleware headers. `onError` handler now copies CORS headers from context to raw Response. This was the root cause of "Unable to connect to Atlas" errors in production.
- **Bun.serve idle timeout (10s default) killing streams** — LLM thinking gaps >10s caused Bun to close the TCP connection. Set `idleTimeout: 0` on API server and MCP SSE transport.
- **`SET TRANSACTION READ ONLY` PG warnings** — issued outside transaction blocks on every query + health check. Changed to `SET default_transaction_read_only = on`.
- **Sidecar bash detection** — health endpoint now reports `bashAvailable`, API logs error when bash is missing.

## Test plan
- [x] All 5 CI gates pass (lint, type, test, syncpack, drift)
- [x] New CORS test covers streaming POST path (`HTTPException` response)
- [x] Existing CORS + chat tests pass
- [ ] Deploy to Railway — verify no more `SET TRANSACTION` warnings in PG logs
- [ ] Redeploy sidecar service to get bash installed (stale image)
- [ ] Verify chat streaming works without "Unable to connect" error