### PR TITLE
fix: cors test explore mock missing exports

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -1084,6 +1084,12 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
 - [x] Settings split + GDPR workspace purge docs (PR #1371)
 - [x] Billing per-seat pricing, SSO domain verification & test connection docs (PR #1347)
 
+### Follow-ups
+- [x] Health check findings — PG readonly, sidecar healthchecks, whitelist warning (PR #1374)
+- [x] Docs audit — critical/high findings across docs site (PR #1379)
+- [x] Docs audit — OpenAPI params, SDK docs, plugin directory (PR #1380)
+- [x] CORS on streaming responses, Bun idle timeout, PG read-only (PR #1381)
+
 ---
 
 ## Admin Action Audit

--- a/packages/api/src/api/__tests__/cors.test.ts
+++ b/packages/api/src/api/__tests__/cors.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { createConnectionMock } from "../../__mocks__/connection";
 
 // --- Mocks (same set as auth.test.ts / chat.test.ts) ---
 
@@ -46,6 +47,10 @@ mock.module("@atlas/api/lib/semantic", () => ({
   getWhitelistedTables: () => new Set(),
   _resetWhitelists: () => {},
 }));
+
+mock.module("@atlas/api/lib/db/connection", () =>
+  createConnectionMock({ resolveDatasourceUrl: () => "postgresql://mock:5432/test" }),
+);
 
 mock.module("@atlas/api/lib/tools/explore", () => ({
   getExploreBackendType: () => "just-bash",

--- a/packages/api/src/api/__tests__/cors.test.ts
+++ b/packages/api/src/api/__tests__/cors.test.ts
@@ -50,6 +50,10 @@ mock.module("@atlas/api/lib/semantic", () => ({
 mock.module("@atlas/api/lib/tools/explore", () => ({
   getExploreBackendType: () => "just-bash",
   getActiveSandboxPluginId: () => null,
+  explore: { type: "function" },
+  invalidateExploreBackend: mock(() => {}),
+  markNsjailFailed: mock(() => {}),
+  markSidecarFailed: mock(() => {}),
 }));
 
 mock.module("@atlas/api/lib/auth/detect", () => ({


### PR DESCRIPTION
## Summary
- Adds missing `explore`, `invalidateExploreBackend`, `markNsjailFailed`, `markSidecarFailed` exports to the cors test's explore module mock
- Fixes CI failure on main where the streaming chat test got `application/json` instead of `text/event-stream` because the incomplete mock caused the tool registry build to fail

## Test plan
- [x] `bun test packages/api/src/api/__tests__/cors.test.ts` passes locally (5/5)
- [ ] CI passes on this PR