### PR TITLE
feat: admin action audit — instrument all platform admin mutations (#1367)

### DIFF
--- a/packages/api/src/api/routes/platform-admin.ts
+++ b/packages/api/src/api/routes/platform-admin.ts
@@ -574,6 +574,14 @@ platformAdmin.openapi(unsuspendWorkspaceRoute, async (c) => {
     yield* Effect.promise(() => updateWorkspaceStatus(workspaceId, "active"));
     log.info({ workspaceId, requestId }, "Workspace unsuspended by platform admin");
 
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.workspace.unsuspend,
+      targetType: "workspace",
+      targetId: workspaceId,
+      scope: "platform",
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    });
+
     return c.json({ message: "Workspace reactivated.", workspaceId }, 200);
   }), { label: "unsuspend workspace" });
 });
@@ -611,6 +619,15 @@ platformAdmin.openapi(deleteWorkspaceRoute, async (c) => {
     });
 
     log.info({ workspaceId, cleanup, requestId }, "Workspace deleted by platform admin");
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.workspace.delete,
+      targetType: "workspace",
+      targetId: workspaceId,
+      scope: "platform",
+      metadata: { cleanup },
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    });
 
     return c.json({
       message: "Workspace deleted.",
@@ -653,6 +670,15 @@ platformAdmin.openapi(purgeWorkspaceRoute, async (c) => {
     const totalRows = Object.values(purged).reduce((sum, n) => sum + n, 0);
 
     log.info({ workspaceId, totalRows, requestId }, "Workspace purged (GDPR hard delete)");
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.workspace.purge,
+      targetType: "workspace",
+      targetId: workspaceId,
+      scope: "platform",
+      metadata: { purged, totalRows },
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    });
 
     return c.json({
       message: "Workspace permanently purged. All data has been irreversibly removed.",
@@ -707,6 +733,15 @@ platformAdmin.openapi(changePlanRoute, async (c) => {
     }));
 
     log.info({ workspaceId, planTier, previousTier: workspace.plan_tier, requestId }, "Workspace plan changed by platform admin");
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.workspace.changePlan,
+      targetType: "workspace",
+      targetId: workspaceId,
+      scope: "platform",
+      metadata: { previousPlan: workspace.plan_tier, newPlan: planTier },
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    });
 
     return c.json({ message: "Plan updated.", workspaceId, planTier }, 200);
   }), { label: "change workspace plan" });

--- a/packages/api/src/api/routes/platform-backups.ts
+++ b/packages/api/src/api/routes/platform-backups.ts
@@ -16,6 +16,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { Effect } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import {
   RequestContext,
@@ -278,6 +279,16 @@ platformBackups.openapi(createBackupRoute, async (c) => {
 
     const result = yield* backupsMod.createBackup();
     log.info({ backupId: result.id, requestId }, "Manual backup created by platform admin");
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.backup.create,
+      targetType: "backup",
+      targetId: result.id,
+      scope: "platform",
+      metadata: { backupId: result.id },
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    });
+
     const row = yield* backupsMod.getBackupById(result.id);
     const backup = row ? toBackupEntry(row) : {
       id: result.id,
@@ -317,6 +328,16 @@ platformBackups.openapi(verifyBackupRoute, async (c) => {
       throw verifyResult.left;
     }
     log.info({ backupId, verified: verifyResult.right.verified, requestId }, "Backup verification completed");
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.backup.verify,
+      targetType: "backup",
+      targetId: backupId,
+      scope: "platform",
+      metadata: { verified: verifyResult.right.verified, message: verifyResult.right.message },
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    });
+
     return c.json(verifyResult.right, 200);
   }), { label: "verify backup" });
 });
@@ -346,6 +367,15 @@ platformBackups.openapi(requestRestoreRoute, async (c) => {
       throw restoreResult.left;
     }
     log.warn({ backupId, requestId }, "Restore requested by platform admin");
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.backup.requestRestore,
+      targetType: "backup",
+      targetId: backupId,
+      scope: "platform",
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    });
+
     return c.json(restoreResult.right, 200);
   }), { label: "request restore" });
 });
@@ -366,6 +396,16 @@ platformBackups.openapi(confirmRestoreRoute, async (c) => {
     return yield* backupsMod.executeRestore(body.confirmationToken).pipe(
       Effect.map((result) => {
         log.warn({ backupId: c.req.param("id"), preRestoreBackupId: result.preRestoreBackupId, requestId }, "Database restore executed by platform admin");
+
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.backup.confirmRestore,
+          targetType: "backup",
+          targetId: c.req.param("id"),
+          scope: "platform",
+          metadata: { preRestoreBackupId: result.preRestoreBackupId },
+          ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        });
+
         return c.json(result, 200);
       }),
       Effect.catchAll((err) => {
@@ -412,9 +452,31 @@ platformBackups.openapi(updateConfigRoute, async (c) => {
 
     const body = c.req.valid("json");
 
+    const oldConfig = yield* backupsMod.getBackupConfig();
     yield* backupsMod.updateBackupConfig(body);
     const config = yield* backupsMod.getBackupConfig();
     log.info({ config, requestId }, "Backup config updated by platform admin");
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.backup.updateConfig,
+      targetType: "backup",
+      targetId: "config",
+      scope: "platform",
+      metadata: {
+        previousConfig: {
+          schedule: oldConfig.schedule,
+          retentionDays: oldConfig.retention_days,
+          storagePath: oldConfig.storage_path,
+        },
+        newConfig: {
+          schedule: config.schedule,
+          retentionDays: config.retention_days,
+          storagePath: config.storage_path,
+        },
+      },
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    });
+
     return c.json({
       message: "Configuration updated.",
       config: {

--- a/packages/api/src/api/routes/platform-domains.ts
+++ b/packages/api/src/api/routes/platform-domains.ts
@@ -13,6 +13,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { Effect } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext } from "@atlas/api/lib/effect/services";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
@@ -168,6 +169,16 @@ platformDomains.openapi(registerDomainRoute, async (c) => {
 
     const domain = yield* mod.registerDomain(body.workspaceId, body.domain);
     log.info({ workspaceId: body.workspaceId, domain: body.domain, requestId }, "Custom domain registered");
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.domain.register,
+      targetType: "domain",
+      targetId: domain.id,
+      scope: "platform",
+      metadata: { workspaceId: body.workspaceId, domain: body.domain },
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    });
+
     return c.json(mod.redactDomain(domain, true), 201);
   }), { label: "register domain", domainErrors: [customDomainError] });
 });
@@ -185,6 +196,15 @@ platformDomains.openapi(verifyDomainRoute, async (c) => {
     }
 
     const domain = yield* mod.verifyDomain(domainId);
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.domain.verify,
+      targetType: "domain",
+      targetId: domainId,
+      scope: "platform",
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    });
+
     return c.json(mod.redactDomain(domain), 200);
   }), { label: "verify domain", domainErrors: [customDomainError] });
 });
@@ -203,6 +223,15 @@ platformDomains.openapi(deleteDomainRoute, async (c) => {
 
     yield* mod.deleteDomain(domainId);
     log.info({ domainId, requestId }, "Custom domain deleted");
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.domain.delete,
+      targetType: "domain",
+      targetId: domainId,
+      scope: "platform",
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    });
+
     return c.json({ deleted: true }, 200);
   }), { label: "delete domain", domainErrors: [customDomainError] });
 });

--- a/packages/api/src/api/routes/platform-residency.ts
+++ b/packages/api/src/api/routes/platform-residency.ts
@@ -13,6 +13,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { Effect } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect, domainError } from "@atlas/api/lib/effect/hono";
 import {
   RequestContext,
@@ -230,6 +231,16 @@ platformResidency.openapi(assignRegionRoute, async (c) => {
 
     const assignment = yield* mod.assignWorkspaceRegion(workspaceId, body.region);
     log.info({ workspaceId, region: body.region, requestId }, "Region assigned to workspace");
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.residency.assign,
+      targetType: "residency",
+      targetId: workspaceId,
+      scope: "platform",
+      metadata: { region: body.region },
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    });
+
     return c.json(assignment, 200);
   }), { label: "assign region", domainErrors: [residencyDomainError] });
 });

--- a/packages/api/src/api/routes/platform-sla.ts
+++ b/packages/api/src/api/routes/platform-sla.ts
@@ -16,6 +16,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { Effect } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import {
   RequestContext,
@@ -326,8 +327,19 @@ platformSLA.openapi(updateThresholdsRoute, async (c) => {
 
     const body = c.req.valid("json");
 
+    const oldThresholds = yield* sla.getThresholds();
     yield* sla.updateThresholds(body);
     log.info({ thresholds: body, requestId }, "SLA thresholds updated by platform admin");
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.sla.updateThresholds,
+      targetType: "sla",
+      targetId: "default",
+      scope: "platform",
+      metadata: { previousThresholds: oldThresholds, newThresholds: body },
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    });
+
     return c.json({ message: "Thresholds updated.", thresholds: body }, 200);
   }), { label: "update SLA thresholds" });
 });
@@ -356,6 +368,15 @@ platformSLA.openapi(acknowledgeAlertRoute, async (c) => {
       return c.json({ error: "not_firing", message: "Alert is not in firing state.", requestId }, 400);
     }
     log.info({ alertId, actorId, requestId }, "SLA alert acknowledged");
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.sla.acknowledgeAlert,
+      targetType: "sla",
+      targetId: alertId,
+      scope: "platform",
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    });
+
     return c.json({ message: "Alert acknowledged.", alertId }, 200);
   }), { label: "acknowledge SLA alert" });
 });


### PR DESCRIPTION
## Summary

- Instruments all 15 remaining platform admin mutation handlers with `logAdminAction()`, completing the audit trail started in PR #1373
- Follows the exact proof-of-concept pattern from `workspace.suspend`: fire-and-forget after mutation succeeds, co-located with the existing `log.info()` call
- All calls use `scope: "platform"`, include `ipAddress` from forwarded headers, and provide meaningful metadata

## Mutations instrumented

| File | Action | Metadata |
|------|--------|----------|
| `platform-admin.ts` | `workspace.unsuspend` | — |
| `platform-admin.ts` | `workspace.delete` | `{ cleanup }` |
| `platform-admin.ts` | `workspace.purge` | `{ purged, totalRows }` |
| `platform-admin.ts` | `workspace.changePlan` | `{ previousPlan, newPlan }` |
| `platform-domains.ts` | `domain.register` | `{ workspaceId, domain }` |
| `platform-domains.ts` | `domain.verify` | — |
| `platform-domains.ts` | `domain.delete` | — |
| `platform-residency.ts` | `residency.assign` | `{ region }` |
| `platform-sla.ts` | `sla.updateThresholds` | `{ previousThresholds, newThresholds }` |
| `platform-sla.ts` | `sla.acknowledgeAlert` | — |
| `platform-backups.ts` | `backup.create` | `{ backupId }` |
| `platform-backups.ts` | `backup.verify` | `{ verified, message }` |
| `platform-backups.ts` | `backup.requestRestore` | — |
| `platform-backups.ts` | `backup.confirmRestore` | `{ preRestoreBackupId }` |
| `platform-backups.ts` | `backup.updateConfig` | `{ previousConfig, newConfig }` |

## Test plan

- [ ] `bun run lint` passes (verified)
- [ ] `bun run type` passes (pre-existing plugin-sdk errors only, no new errors)
- [ ] No functional regressions — `logAdminAction()` is fire-and-forget, never throws
- [ ] Each action uses the correct `ADMIN_ACTIONS.*` constant from the typed catalog
- [ ] `targetType` matches the domain prefix for each action
- [ ] `targetId` is the correct entity ID for each action
- [ ] Before/after state captured where applicable (plan changes, threshold changes, config changes, purge counts)

Closes #1367