### PR TITLE
feat: admin action audit — workspace admin read surface (#1365, #1372)

### DIFF
--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -263,6 +263,7 @@ export function createApiTestMocks(
     getAutoApproveTypes: mock(() => new Set(["update_description", "add_dimension"])),
     insertSemanticAmendment: mock(async () => ({ id: "mock-amendment-id", status: "pending" as const })),
     getPendingAmendmentCount: mock(async () => 0),
+    hardDeleteWorkspace: mock(async () => ({})),
   };
 
   mock.module("@atlas/api/lib/db/internal", () => ({

--- a/packages/api/src/api/__tests__/admin-actions.test.ts
+++ b/packages/api/src/api/__tests__/admin-actions.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests for workspace admin action audit log endpoint.
+ *
+ * Covers: GET /api/v1/admin/admin-actions (org isolation, scope filtering,
+ * pagination, auth, response shape).
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterAll,
+  mock,
+} from "bun:test";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+
+// --- Unified mocks ---
+
+const mocks = createApiTestMocks();
+
+// --- Mock the audit module (imported by admin routes) ---
+
+mock.module("@atlas/api/lib/audit", () => ({
+  logAdminAction: mock(() => {}),
+  ADMIN_ACTIONS: {
+    workspace: { suspend: "workspace.suspend", unsuspend: "workspace.unsuspend", delete: "workspace.delete", purge: "workspace.purge", changePlan: "workspace.change_plan" },
+    domain: { register: "domain.register", verify: "domain.verify", delete: "domain.delete" },
+    residency: { assign: "residency.assign" },
+    sla: { updateThresholds: "sla.update_thresholds", acknowledgeAlert: "sla.acknowledge_alert" },
+    backup: { create: "backup.create", verify: "backup.verify", requestRestore: "backup.request_restore", confirmRestore: "backup.confirm_restore", updateConfig: "backup.update_config" },
+    settings: { update: "settings.update" },
+    connection: { create: "connection.create", update: "connection.update", delete: "connection.delete" },
+    user: { invite: "user.invite", remove: "user.remove", changeRole: "user.change_role" },
+    sso: { configure: "sso.configure", update: "sso.update", delete: "sso.delete", test: "sso.test" },
+    semantic: { createEntity: "semantic.create_entity", updateEntity: "semantic.update_entity", deleteEntity: "semantic.delete_entity", updateMetric: "semantic.update_metric", updateGlossary: "semantic.update_glossary" },
+    pattern: { approve: "pattern.approve", reject: "pattern.reject", delete: "pattern.delete" },
+    integration: { enable: "integration.enable", disable: "integration.disable", configure: "integration.configure" },
+    schedule: { create: "schedule.create", update: "schedule.update", delete: "schedule.delete", toggle: "schedule.toggle" },
+    apikey: { create: "apikey.create", revoke: "apikey.revoke" },
+    approval: { approve: "approval.approve", deny: "approval.deny" },
+  },
+}));
+
+mock.module("@atlas/api/lib/audit/admin", () => ({
+  logAdminAction: mock(() => {}),
+}));
+
+mock.module("@atlas/api/lib/audit/actions", () => ({
+  ADMIN_ACTIONS: {
+    workspace: { suspend: "workspace.suspend" },
+  },
+}));
+
+// --- Import app after mocks ---
+
+const { app } = await import("../index");
+
+afterAll(() => mocks.cleanup());
+
+// --- Helpers ---
+
+function adminRequest(method: string, path: string): Request {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: { "Content-Type": "application/json", "x-api-key": "test-key" },
+  });
+}
+
+const SAMPLE_WORKSPACE_ACTION = {
+  id: "act-ws-1",
+  timestamp: "2026-04-09T12:00:00Z",
+  actor_id: "admin-1",
+  actor_email: "admin@test.com",
+  scope: "workspace",
+  org_id: "org-1",
+  action_type: "settings.update",
+  target_type: "settings",
+  target_id: "setting-1",
+  status: "success",
+  metadata: null,
+  ip_address: "10.0.0.1",
+  request_id: "req-1",
+};
+
+// Platform-scoped actions should never be returned by the workspace endpoint
+// (the SQL filters by scope = 'workspace' and org_id = $orgId).
+// These constants document the excluded shapes for test readability.
+const _SAMPLE_PLATFORM_ACTION = {
+  id: "act-plat-1",
+  timestamp: "2026-04-09T11:00:00Z",
+  actor_id: "platform-admin-1",
+  actor_email: "platform@test.com",
+  scope: "platform",
+  org_id: null,
+  action_type: "workspace.suspend",
+  target_type: "workspace",
+  target_id: "ws-1",
+  status: "success",
+  metadata: null,
+  ip_address: "10.0.0.2",
+  request_id: "req-2",
+};
+
+const _OTHER_ORG_ACTION = {
+  id: "act-other-1",
+  timestamp: "2026-04-09T10:00:00Z",
+  actor_id: "admin-other",
+  actor_email: "other@test.com",
+  scope: "workspace",
+  org_id: "org-other",
+  action_type: "connection.create",
+  target_type: "connection",
+  target_id: "conn-1",
+  status: "success",
+  metadata: null,
+  ip_address: "10.0.0.3",
+  request_id: "req-3",
+};
+
+// --- Tests ---
+
+describe("GET /api/v1/admin/admin-actions", () => {
+  beforeEach(() => {
+    mocks.setOrgAdmin("org-1");
+    mocks.hasInternalDB = true;
+  });
+
+  it("returns paginated workspace action log entries for caller's org", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("COUNT(*)")) return [{ count: 1 }];
+      return [SAMPLE_WORKSPACE_ACTION];
+    });
+
+    const res = await app.request(adminRequest("GET", "/api/v1/admin/admin-actions"));
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { actions: Array<Record<string, unknown>>; total: number; limit: number; offset: number };
+    expect(body.actions).toHaveLength(1);
+    expect(body.total).toBe(1);
+    expect(body.limit).toBe(50);
+    expect(body.offset).toBe(0);
+
+    const action = body.actions[0];
+    expect(action.id).toBe("act-ws-1");
+    expect(action.actorEmail).toBe("admin@test.com");
+    expect(action.actionType).toBe("settings.update");
+    expect(action.targetType).toBe("settings");
+    expect(action.targetId).toBe("setting-1");
+    expect(action.status).toBe("success");
+    expect(action.scope).toBe("workspace");
+  });
+
+  it("filters by org_id in SQL query (org isolation)", async () => {
+    let capturedParams: unknown[] | undefined;
+    let capturedSql: string | undefined;
+    mocks.mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes("COUNT(*)")) {
+        capturedSql = sql;
+        capturedParams = params;
+        return [{ count: 0 }];
+      }
+      return [];
+    });
+
+    await app.request(adminRequest("GET", "/api/v1/admin/admin-actions"));
+
+    // Verify the SQL includes org_id filter and scope filter
+    expect(capturedSql).toContain("org_id = $1");
+    expect(capturedSql).toContain("scope = 'workspace'");
+    expect(capturedParams).toEqual(["org-1"]);
+  });
+
+  it("does not return platform-scoped actions", async () => {
+    // Mock returns only workspace-scoped actions (as the SQL filters by scope)
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("COUNT(*)")) return [{ count: 1 }];
+      // Only workspace actions should be returned by the query
+      return [SAMPLE_WORKSPACE_ACTION];
+    });
+
+    const res = await app.request(adminRequest("GET", "/api/v1/admin/admin-actions"));
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { actions: Array<Record<string, unknown>> };
+    // All returned actions should be workspace-scoped
+    for (const action of body.actions) {
+      expect(action.scope).toBe("workspace");
+    }
+  });
+
+  it("respects limit and offset query params", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes("COUNT(*)")) return [{ count: 100 }];
+      // Verify correct params: orgId=$1, limit=$2, offset=$3
+      expect(params).toEqual(["org-1", 10, 20]);
+      return [];
+    });
+
+    const res = await app.request(
+      adminRequest("GET", "/api/v1/admin/admin-actions?limit=10&offset=20"),
+    );
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { actions: unknown[]; total: number; limit: number; offset: number };
+    expect(body.limit).toBe(10);
+    expect(body.offset).toBe(20);
+    expect(body.total).toBe(100);
+  });
+
+  it("returns empty list when no actions exist", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("COUNT(*)")) return [{ count: 0 }];
+      return [];
+    });
+
+    const res = await app.request(adminRequest("GET", "/api/v1/admin/admin-actions"));
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { actions: unknown[]; total: number };
+    expect(body.actions).toEqual([]);
+    expect(body.total).toBe(0);
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    mocks.setMember("org-1");
+
+    const res = await app.request(adminRequest("GET", "/api/v1/admin/admin-actions"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when internal DB is not configured", async () => {
+    mocks.hasInternalDB = false;
+
+    const res = await app.request(adminRequest("GET", "/api/v1/admin/admin-actions"));
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/api/src/api/routes/admin-actions.ts
+++ b/packages/api/src/api/routes/admin-actions.ts
@@ -1,0 +1,142 @@
+/**
+ * Workspace admin action audit log routes.
+ *
+ * Mounted at /api/v1/admin/admin-actions. Provides a paginated list of
+ * admin action log entries scoped to the caller's active organization.
+ * Only workspace-scoped actions (or actions explicitly tied to the org)
+ * are returned — platform-scoped actions are excluded.
+ */
+
+import { createRoute, z } from "@hono/zod-openapi";
+import { Effect } from "effect";
+import { runEffect } from "@atlas/api/lib/effect/hono";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import { createAdminRouter, requireOrgContext } from "./admin-router";
+import {
+  ErrorSchema,
+  AuthErrorSchema,
+  PaginationQuerySchema,
+  parsePagination,
+} from "./shared-schemas";
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+const AdminActionSchema = z.object({
+  id: z.string(),
+  timestamp: z.string(),
+  actorId: z.string(),
+  actorEmail: z.string(),
+  scope: z.enum(["platform", "workspace"]),
+  orgId: z.string().nullable(),
+  actionType: z.string(),
+  targetType: z.string(),
+  targetId: z.string(),
+  status: z.enum(["success", "failure"]),
+  metadata: z.record(z.string(), z.unknown()).nullable(),
+  ipAddress: z.string().nullable(),
+  requestId: z.string(),
+});
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+const listActionsRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["Admin"],
+  summary: "List workspace admin action log",
+  description: "Returns a paginated list of admin action log entries scoped to the caller's active organization.",
+  request: { query: PaginationQuerySchema },
+  responses: {
+    200: {
+      description: "Admin action log entries for this workspace",
+      content: {
+        "application/json": {
+          schema: z.object({
+            actions: z.array(AdminActionSchema),
+            total: z.number(),
+            limit: z.number(),
+            offset: z.number(),
+          }),
+        },
+      },
+    },
+    400: { description: "No active organization", content: { "application/json": { schema: ErrorSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
+    403: { description: "Admin role required", content: { "application/json": { schema: AuthErrorSchema } } },
+    404: { description: "Internal database not configured", content: { "application/json": { schema: ErrorSchema } } },
+    500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+const adminActions = createAdminRouter();
+adminActions.use(requireOrgContext());
+
+adminActions.openapi(listActionsRoute, async (c) => {
+  return runEffect(c, Effect.gen(function* () {
+    const { orgId } = c.get("orgContext");
+
+    const { limit, offset } = parsePagination(c, { limit: 50, maxLimit: 200 });
+
+    const [rows, countRows] = yield* Effect.promise(() => Promise.all([
+      internalQuery<{
+        id: string;
+        timestamp: string;
+        actor_id: string;
+        actor_email: string;
+        scope: "platform" | "workspace";
+        org_id: string | null;
+        action_type: string;
+        target_type: string;
+        target_id: string;
+        status: "success" | "failure";
+        metadata: Record<string, unknown> | null;
+        ip_address: string | null;
+        request_id: string;
+      }>(
+        `SELECT id, timestamp, actor_id, actor_email, scope, org_id, action_type, target_type, target_id, status, metadata, ip_address, request_id
+         FROM admin_action_log
+         WHERE org_id = $1 AND scope = 'workspace'
+         ORDER BY timestamp DESC
+         LIMIT $2 OFFSET $3`,
+        [orgId, limit, offset],
+      ),
+      internalQuery<{ count: number }>(
+        `SELECT COUNT(*)::int AS count FROM admin_action_log WHERE org_id = $1 AND scope = 'workspace'`,
+        [orgId],
+      ),
+    ]));
+
+    const actions = rows.map((row) => ({
+      id: row.id,
+      timestamp: row.timestamp,
+      actorId: row.actor_id,
+      actorEmail: row.actor_email,
+      scope: row.scope,
+      orgId: row.org_id,
+      actionType: row.action_type,
+      targetType: row.target_type,
+      targetId: row.target_id,
+      status: row.status,
+      metadata: row.metadata,
+      ipAddress: row.ip_address,
+      requestId: row.request_id,
+    }));
+
+    return c.json({
+      actions,
+      total: countRows[0]?.count ?? 0,
+      limit,
+      offset,
+    }, 200);
+  }), { label: "list workspace admin actions" });
+});
+
+export { adminActions };

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -67,6 +67,7 @@ import { adminTokens } from "./admin-tokens";
 import { adminConnections } from "./admin-connections";
 import { adminPlugins } from "./admin-plugins";
 import { adminCache } from "./admin-cache";
+import { adminActions } from "./admin-actions";
 import { registerSemanticEditorRoutes } from "./admin-semantic";
 import { ErrorSchema, AuthErrorSchema, parsePagination } from "./shared-schemas";
 import { runHandler } from "@atlas/api/lib/effect/hono";
@@ -211,6 +212,8 @@ admin.route("/plugins", adminPlugins);
 admin.route("/plugins/", adminPlugins);
 admin.route("/cache", adminCache);
 admin.route("/cache/", adminCache);
+admin.route("/admin-actions", adminActions);
+admin.route("/admin-actions/", adminActions);
 // Plugin marketplace — lazy import to avoid crashing all admin routes if marketplace module fails
 try {
   const { workspaceMarketplace } = await import("./admin-marketplace");

--- a/packages/web/src/app/admin/admin-actions/page.tsx
+++ b/packages/web/src/app/admin/admin-actions/page.tsx
@@ -18,8 +18,9 @@ import {
   ChevronRight,
   ClipboardList,
 } from "lucide-react";
-import { useState } from "react";
+import { useQueryStates } from "nuqs";
 import { z } from "zod";
+import { adminActionsSearchParams } from "./search-params";
 
 // ---------------------------------------------------------------------------
 // Schema
@@ -64,6 +65,7 @@ function formatTimestamp(iso: string): string {
       second: "2-digit",
     });
   } catch {
+    // intentionally ignored: invalid date string — fall back to raw ISO
     return iso;
   }
 }
@@ -87,7 +89,8 @@ function metadataPreview(metadata: Record<string, unknown> | null): string {
 const PAGE_SIZE = 50;
 
 function AdminActionsPageContent() {
-  const [offset, setOffset] = useState(0);
+  const [params, setParams] = useQueryStates(adminActionsSearchParams);
+  const offset = (params.page - 1) * PAGE_SIZE;
 
   const { data, loading, error, refetch } = useAdminFetch(
     `/api/v1/admin/admin-actions?limit=${PAGE_SIZE}&offset=${offset}`,
@@ -167,7 +170,7 @@ function AdminActionsPageContent() {
                 variant="outline"
                 size="sm"
                 disabled={!hasPrev}
-                onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+                onClick={() => setParams({ page: Math.max(1, params.page - 1) })}
               >
                 <ChevronLeft className="size-4 mr-1" />
                 Previous
@@ -176,7 +179,7 @@ function AdminActionsPageContent() {
                 variant="outline"
                 size="sm"
                 disabled={!hasNext}
-                onClick={() => setOffset(offset + PAGE_SIZE)}
+                onClick={() => setParams({ page: params.page + 1 })}
               >
                 Next
                 <ChevronRight className="size-4 ml-1" />

--- a/packages/web/src/app/admin/admin-actions/page.tsx
+++ b/packages/web/src/app/admin/admin-actions/page.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
+import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
+import { ErrorBoundary } from "@/ui/components/error-boundary";
+import {
+  ChevronLeft,
+  ChevronRight,
+  ClipboardList,
+} from "lucide-react";
+import { useState } from "react";
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+const AdminActionSchema = z.object({
+  id: z.string(),
+  timestamp: z.string(),
+  actorId: z.string(),
+  actorEmail: z.string(),
+  scope: z.enum(["platform", "workspace"]),
+  orgId: z.string().nullable(),
+  actionType: z.string(),
+  targetType: z.string(),
+  targetId: z.string(),
+  status: z.enum(["success", "failure"]),
+  metadata: z.record(z.string(), z.unknown()).nullable(),
+  ipAddress: z.string().nullable(),
+  requestId: z.string(),
+});
+
+const ActionsResponseSchema = z.object({
+  actions: z.array(AdminActionSchema),
+  total: z.number(),
+  limit: z.number(),
+  offset: z.number(),
+});
+
+type AdminAction = z.infer<typeof AdminActionSchema>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatTimestamp(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function statusBadge(status: string) {
+  return status === "success"
+    ? <Badge variant="outline" className="gap-1 border-green-500 text-green-600 text-xs">Success</Badge>
+    : <Badge variant="destructive" className="gap-1 text-xs">Failure</Badge>;
+}
+
+function metadataPreview(metadata: Record<string, unknown> | null): string {
+  if (!metadata) return "\u2014";
+  const entries = Object.entries(metadata).slice(0, 3);
+  return entries.map(([k, v]) => `${k}: ${String(v)}`).join(", ");
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+const PAGE_SIZE = 50;
+
+function AdminActionsPageContent() {
+  const [offset, setOffset] = useState(0);
+
+  const { data, loading, error, refetch } = useAdminFetch(
+    `/api/v1/admin/admin-actions?limit=${PAGE_SIZE}&offset=${offset}`,
+    { schema: ActionsResponseSchema },
+  );
+
+  const actions: AdminAction[] = data?.actions ?? [];
+  const total = data?.total ?? 0;
+  const hasNext = offset + PAGE_SIZE < total;
+  const hasPrev = offset > 0;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold tracking-tight">Admin Action Log</h2>
+        <p className="text-muted-foreground">
+          Admin actions performed in this workspace. {total > 0 && `${total} total entries.`}
+        </p>
+      </div>
+
+      <AdminContentWrapper
+        loading={loading}
+        error={error}
+        feature="Admin Action Log"
+        onRetry={refetch}
+        loadingMessage="Loading admin action log\u2026"
+        emptyIcon={ClipboardList}
+        emptyTitle="No admin actions recorded"
+        emptyDescription="Admin actions will appear here once workspace mutations are performed."
+        isEmpty={actions.length === 0}
+      >
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[140px]">Timestamp</TableHead>
+                <TableHead>Actor</TableHead>
+                <TableHead>Action</TableHead>
+                <TableHead>Target</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Details</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {actions.map((action) => (
+                <TableRow key={action.id}>
+                  <TableCell className="text-xs text-muted-foreground whitespace-nowrap">
+                    {formatTimestamp(action.timestamp)}
+                  </TableCell>
+                  <TableCell className="text-sm">{action.actorEmail}</TableCell>
+                  <TableCell>
+                    <code className="text-xs bg-muted px-1.5 py-0.5 rounded">
+                      {action.actionType}
+                    </code>
+                  </TableCell>
+                  <TableCell className="text-xs font-mono text-muted-foreground">
+                    {action.targetType}/{action.targetId.slice(0, 8)}
+                  </TableCell>
+                  <TableCell>{statusBadge(action.status)}</TableCell>
+                  <TableCell className="text-xs text-muted-foreground max-w-[200px] truncate">
+                    {metadataPreview(action.metadata)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+
+        {/* Pagination */}
+        {total > PAGE_SIZE && (
+          <div className="flex items-center justify-between pt-4">
+            <p className="text-sm text-muted-foreground">
+              Showing {offset + 1}\u2013{Math.min(offset + PAGE_SIZE, total)} of {total}
+            </p>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={!hasPrev}
+                onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+              >
+                <ChevronLeft className="size-4 mr-1" />
+                Previous
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={!hasNext}
+                onClick={() => setOffset(offset + PAGE_SIZE)}
+              >
+                Next
+                <ChevronRight className="size-4 ml-1" />
+              </Button>
+            </div>
+          </div>
+        )}
+      </AdminContentWrapper>
+    </div>
+  );
+}
+
+export default function AdminActionsPage() {
+  return (
+    <ErrorBoundary>
+      <AdminActionsPageContent />
+    </ErrorBoundary>
+  );
+}

--- a/packages/web/src/app/admin/admin-actions/search-params.ts
+++ b/packages/web/src/app/admin/admin-actions/search-params.ts
@@ -1,0 +1,5 @@
+import { parseAsInteger } from "nuqs";
+
+export const adminActionsSearchParams = {
+  page: parseAsInteger.withDefault(1),
+};

--- a/packages/web/src/ui/components/admin/admin-sidebar.tsx
+++ b/packages/web/src/ui/components/admin/admin-sidebar.tsx
@@ -117,6 +117,7 @@ const navGroups: NavGroup[] = [
     icon: BarChart3,
     items: [
       { href: "/admin/audit", label: "Audit Log" },
+      { href: "/admin/admin-actions", label: "Admin Action Log" },
       { href: "/admin/token-usage", label: "Token Usage" },
       { href: "/admin/usage", label: "Usage" },
       { href: "/admin/scheduled-tasks", label: "Scheduled Tasks" },


### PR DESCRIPTION
## Summary

- **Bug fix (#1372):** Add missing `hardDeleteWorkspace` mock to `packages/api/src/__mocks__/api-test-mocks.ts`. This export was absent from `internalDefaults`, causing a `SyntaxError` when platform-admin routes load in tests using `createApiTestMocks()`.
- **Feature (#1365):** Build the workspace admin action audit read surface:
  - `GET /api/v1/admin/admin-actions` — paginated list of admin action log entries, auto-scoped to caller's org via `requireOrgContext()`. Only workspace-scoped actions returned (platform-scoped excluded via SQL `WHERE scope = 'workspace'`).
  - UI page at `/admin/admin-actions` with table (Timestamp, Actor, Action, Target, Status, Metadata) + Previous/Next pagination + empty state.
  - Sidebar link added under Monitoring section ("Admin Action Log").
  - 7 tests: org isolation, scope filtering, pagination, empty state, 403 for non-admin, 404 when no internal DB.

## Test plan

- [x] `bun run lint` passes (0 errors, 0 warnings)
- [x] `bun run type` passes (exit 0)
- [x] `bun test packages/api/src/api/__tests__/admin-actions.test.ts` — 7/7 pass
- [ ] Manual: visit `/admin/admin-actions` as workspace admin, verify table renders
- [ ] Manual: verify non-admin gets 403 on the API endpoint
- [ ] Manual: verify platform-scoped actions do not appear