### PR TITLE
feat: admin action audit — instrument all workspace admin mutations (#1368)

### DIFF
--- a/packages/api/src/api/routes/admin-approval.ts
+++ b/packages/api/src/api/routes/admin-approval.ts
@@ -18,6 +18,7 @@
 
 import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect, domainError } from "@atlas/api/lib/effect/hono";
 import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
 import {
@@ -411,6 +412,15 @@ adminApproval.openapi(reviewRoute, async (c) => {
       body.action,
       body.comment,
     );
+
+    logAdminAction({
+      actionType: body.action === "approve" ? ADMIN_ACTIONS.approval.approve : ADMIN_ACTIONS.approval.deny,
+      targetType: "approval",
+      targetId: itemId,
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+      metadata: { requestId: itemId },
+    });
+
     return c.json({ request: result }, 200);
   }), { label: "review approval request", domainErrors: [approvalDomainError] });
 });

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -8,6 +8,7 @@
 
 import { createRoute, z } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { connections, detectDBType } from "@atlas/api/lib/db/connection";
 import { hasInternalDB, internalQuery, encryptUrl, decryptUrl } from "@atlas/api/lib/db/internal";
 import { maskConnectionUrl } from "@atlas/api/lib/security";
@@ -567,6 +568,15 @@ adminConnections.openapi(createConnectionRoute, async (c) => runHandler(c, "crea
   }
 
   log.info({ requestId, connectionId: id, dbType, orgId, actorId: authResult.user?.id }, "Connection created");
+
+  logAdminAction({
+    actionType: ADMIN_ACTIONS.connection.create,
+    targetType: "connection",
+    targetId: id as string,
+    ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    metadata: { name: id as string, dbType },
+  });
+
   return c.json({
     id,
     dbType,
@@ -710,6 +720,15 @@ adminConnections.openapi(updateConnectionRoute, async (c) => runHandler(c, "upda
   }
 
   log.info({ requestId, connectionId: id, urlChanged, actorId: authResult.user?.id }, "Connection updated");
+
+  logAdminAction({
+    actionType: ADMIN_ACTIONS.connection.update,
+    targetType: "connection",
+    targetId: id,
+    ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    metadata: { name: id, urlChanged },
+  });
+
   return c.json({ id, dbType, description: newDescription, maskedUrl: maskConnectionUrl(newUrl) }, 200);
 }));
 
@@ -779,6 +798,15 @@ adminConnections.openapi(deleteConnectionRoute, async (c) => runHandler(c, "dele
   }
 
   log.info({ requestId, connectionId: id, actorId: authResult.user?.id }, "Connection deleted");
+
+  logAdminAction({
+    actionType: ADMIN_ACTIONS.connection.delete,
+    targetType: "connection",
+    targetId: id,
+    ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    metadata: { name: id },
+  });
+
   return c.json({ success: true }, 200);
 }));
 

--- a/packages/api/src/api/routes/admin-integrations.ts
+++ b/packages/api/src/api/routes/admin-integrations.ts
@@ -8,6 +8,7 @@
 
 import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { AuthContext } from "@atlas/api/lib/effect/services";
 import { internalQuery, hasInternalDB } from "@atlas/api/lib/db/internal";
@@ -526,6 +527,15 @@ adminIntegrations.openapi(disconnectSlackRoute, async (c) => {
       }
 
       log.info({ orgId }, "Slack installation disconnected by admin");
+
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.integration.disable,
+        targetType: "integration",
+        targetId: orgId!,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { platform: "slack" },
+      });
+
       return c.json({ message: "Slack disconnected successfully." }, 200);
     }),
     { label: "disconnect slack" },
@@ -559,6 +569,15 @@ adminIntegrations.openapi(disconnectTeamsRoute, async (c) => {
       }
 
       log.info({ orgId }, "Teams installation disconnected by admin");
+
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.integration.disable,
+        targetType: "integration",
+        targetId: orgId!,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { platform: "teams" },
+      });
+
       return c.json({ message: "Teams disconnected successfully." }, 200);
     }),
     { label: "disconnect teams" },
@@ -628,6 +647,15 @@ adminIntegrations.openapi(disconnectDiscordRoute, async (c) => {
       }
 
       log.info({ orgId }, "Discord installation disconnected by admin");
+
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.integration.disable,
+        targetType: "integration",
+        targetId: orgId!,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { platform: "discord" },
+      });
+
       return c.json({ message: "Discord disconnected successfully." }, 200);
     }),
     { label: "disconnect discord" },
@@ -758,6 +786,15 @@ adminIntegrations.openapi(connectSlackByotRoute, async (c) => {
       });
 
       log.info({ orgId, teamId: authResult.teamId, workspaceName: authResult.workspaceName }, "Slack BYOT installation saved by admin");
+
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.integration.enable,
+        targetType: "integration",
+        targetId: orgId!,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { platform: "slack", mode: "byot" },
+      });
+
       return c.json(
         { message: "Slack connected successfully.", workspaceName: authResult.workspaceName, teamId: authResult.teamId },
         200,
@@ -893,6 +930,15 @@ adminIntegrations.openapi(connectTeamsByotRoute, async (c) => {
       });
 
       log.info({ orgId, appId }, "Teams BYOT installation saved by admin");
+
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.integration.enable,
+        targetType: "integration",
+        targetId: orgId!,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { platform: "teams", mode: "byot" },
+      });
+
       return c.json(
         { message: "Teams connected successfully.", appId },
         200,
@@ -1033,6 +1079,15 @@ adminIntegrations.openapi(connectDiscordByotRoute, async (c) => {
       });
 
       log.info({ orgId, applicationId, botUsername: meResult.botUsername }, "Discord BYOT installation saved by admin");
+
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.integration.enable,
+        targetType: "integration",
+        targetId: orgId!,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { platform: "discord", mode: "byot" },
+      });
+
       return c.json(
         { message: "Discord connected successfully.", botUsername: meResult.botUsername },
         200,
@@ -1158,6 +1213,15 @@ adminIntegrations.openapi(connectTelegramRoute, async (c) => {
       });
 
       log.info({ orgId, botId: getMeResult.botId, botUsername: getMeResult.botUsername }, "Telegram installation saved by admin");
+
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.integration.enable,
+        targetType: "integration",
+        targetId: orgId!,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { platform: "telegram" },
+      });
+
       return c.json(
         { message: "Telegram connected successfully.", botUsername: getMeResult.botUsername },
         200,
@@ -1230,6 +1294,15 @@ adminIntegrations.openapi(disconnectTelegramRoute, async (c) => {
       }
 
       log.info({ orgId }, "Telegram installation disconnected by admin");
+
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.integration.disable,
+        targetType: "integration",
+        targetId: orgId!,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { platform: "telegram" },
+      });
+
       return c.json({ message: "Telegram disconnected successfully." }, 200);
     }),
     { label: "disconnect telegram" },
@@ -1376,6 +1449,15 @@ adminIntegrations.openapi(connectGChatRoute, async (c) => {
       }
 
       log.info({ orgId, projectId, serviceAccountEmail: clientEmail }, "Google Chat installation saved by admin");
+
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.integration.enable,
+        targetType: "integration",
+        targetId: orgId!,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { platform: "gchat" },
+      });
+
       return c.json(
         { message: "Google Chat connected successfully.", projectId, serviceAccountEmail: clientEmail },
         200,
@@ -1447,6 +1529,15 @@ adminIntegrations.openapi(disconnectGChatRoute, async (c) => {
       }
 
       log.info({ orgId }, "Google Chat installation disconnected by admin");
+
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.integration.disable,
+        targetType: "integration",
+        targetId: orgId!,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { platform: "gchat" },
+      });
+
       return c.json({ message: "Google Chat disconnected successfully." }, 200);
     }),
     { label: "disconnect gchat" },
@@ -1601,6 +1692,15 @@ adminIntegrations.openapi(connectGitHubRoute, async (c) => {
       }
 
       log.info({ orgId, userId: userResult.userId, username: userResult.username }, "GitHub installation saved by admin");
+
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.integration.enable,
+        targetType: "integration",
+        targetId: orgId!,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { platform: "github" },
+      });
+
       return c.json(
         { message: "GitHub connected successfully.", username: userResult.username },
         200,
@@ -1672,6 +1772,15 @@ adminIntegrations.openapi(disconnectGitHubRoute, async (c) => {
       }
 
       log.info({ orgId }, "GitHub installation disconnected by admin");
+
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.integration.disable,
+        targetType: "integration",
+        targetId: orgId!,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { platform: "github" },
+      });
+
       return c.json({ message: "GitHub disconnected successfully." }, 200);
     }),
     { label: "disconnect github" },
@@ -1843,6 +1952,15 @@ adminIntegrations.openapi(connectLinearRoute, async (c) => {
       }
 
       log.info({ orgId, userId: viewerResult.userId, userName: viewerResult.userName }, "Linear installation saved by admin");
+
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.integration.enable,
+        targetType: "integration",
+        targetId: orgId!,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { platform: "linear" },
+      });
+
       return c.json(
         { message: "Linear connected successfully.", userName: viewerResult.userName, userEmail: viewerResult.userEmail },
         200,
@@ -1914,6 +2032,15 @@ adminIntegrations.openapi(disconnectLinearRoute, async (c) => {
       }
 
       log.info({ orgId }, "Linear installation disconnected by admin");
+
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.integration.disable,
+        targetType: "integration",
+        targetId: orgId!,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { platform: "linear" },
+      });
+
       return c.json({ message: "Linear disconnected successfully." }, 200);
     }),
     { label: "disconnect linear" },
@@ -2075,6 +2202,15 @@ adminIntegrations.openapi(connectWhatsAppRoute, async (c) => {
       }
 
       log.info({ orgId, phoneNumberId, displayPhone: phoneResult.displayPhone }, "WhatsApp installation saved by admin");
+
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.integration.enable,
+        targetType: "integration",
+        targetId: orgId!,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { platform: "whatsapp" },
+      });
+
       return c.json(
         { message: "WhatsApp connected successfully.", displayPhone: phoneResult.displayPhone },
         200,
@@ -2146,6 +2282,15 @@ adminIntegrations.openapi(disconnectWhatsAppRoute, async (c) => {
       }
 
       log.info({ orgId }, "WhatsApp installation disconnected by admin");
+
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.integration.disable,
+        targetType: "integration",
+        targetId: orgId!,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { platform: "whatsapp" },
+      });
+
       return c.json({ message: "WhatsApp disconnected successfully." }, 200);
     }),
     { label: "disconnect whatsapp" },
@@ -2279,6 +2424,15 @@ adminIntegrations.openapi(connectEmailRoute, async (c) => {
       });
 
       log.info({ orgId, provider, senderAddress }, "Email installation saved by admin");
+
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.integration.configure,
+        targetType: "integration",
+        targetId: orgId!,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { platform: "email", provider },
+      });
+
       return c.json(
         { message: "Email connected successfully.", provider, senderAddress },
         200,
@@ -2455,6 +2609,15 @@ adminIntegrations.openapi(disconnectEmailRoute, async (c) => {
       }
 
       log.info({ orgId }, "Email installation disconnected by admin");
+
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.integration.disable,
+        targetType: "integration",
+        targetId: orgId!,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { platform: "email" },
+      });
+
       return c.json({ message: "Email disconnected successfully." }, 200);
     }),
     { label: "disconnect email" },

--- a/packages/api/src/api/routes/admin-invitations.ts
+++ b/packages/api/src/api/routes/admin-invitations.ts
@@ -9,6 +9,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import type { OpenAPIHono } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
 import type { AtlasRole } from "@atlas/api/lib/auth/types";
@@ -234,6 +235,14 @@ export function registerInvitationRoutes(
     }
 
     log.info({ requestId, invitationId: invitation.id, email, role, emailSent, orgId, actorId: authResult.user?.id }, "User invited");
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.user.invite,
+      targetType: "user",
+      targetId: invitation.id,
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+      metadata: { email, role },
+    });
 
     return c.json({
       id: invitation.id,

--- a/packages/api/src/api/routes/admin-learned-patterns.ts
+++ b/packages/api/src/api/routes/admin-learned-patterns.ts
@@ -9,6 +9,7 @@ import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { createLogger } from "@atlas/api/lib/logger";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
 import { internalQuery } from "@atlas/api/lib/db/internal";
@@ -467,6 +468,25 @@ adminLearnedPatterns.openapi(updatePatternRoute, async (c) => {
     const updateOrg = orgFilter(orgId, updateParams, paramIdx);
     const updated = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(`UPDATE learned_patterns SET ${setClauses.join(", ")} WHERE id = $${idIdx} AND ${updateOrg.clause} RETURNING *`, updateParams));
     if (updated.length === 0) return c.json({ error: "not_found", message: "Pattern was deleted before update completed." }, 404);
+
+    if (status === "approved") {
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.pattern.approve,
+        targetType: "pattern",
+        targetId: id,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { patternId: id },
+      });
+    } else if (status === "rejected") {
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.pattern.reject,
+        targetType: "pattern",
+        targetId: id,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { patternId: id },
+      });
+    }
+
     return c.json(toLearnedPattern(updated[0]), 200);
   }), { label: "update learned pattern" });
 });
@@ -489,6 +509,15 @@ adminLearnedPatterns.openapi(deletePatternRoute, async (c) => {
     const deleteOrg = orgFilter(orgId, deleteParams, deleteParams.length + 1);
     yield* Effect.promise(() => internalQuery(`DELETE FROM learned_patterns WHERE id = $1 AND ${deleteOrg.clause}`, deleteParams));
     invalidatePatternCache(orgId ?? null);
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.pattern.delete,
+      targetType: "pattern",
+      targetId: id,
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+      metadata: { patternId: id },
+    });
+
     return c.json({ deleted: true }, 200);
   }), { label: "delete learned pattern" });
 });

--- a/packages/api/src/api/routes/admin-semantic.ts
+++ b/packages/api/src/api/routes/admin-semantic.ts
@@ -16,6 +16,7 @@ import type { OpenAPIHono } from "@hono/zod-openapi";
 import { runHandler } from "@atlas/api/lib/effect/hono";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import type { AuthResult } from "@atlas/api/lib/auth/types";
 import { connections } from "@atlas/api/lib/db/connection";
 import { ErrorSchema, AuthErrorSchema, createParamSchema } from "./shared-schemas";
@@ -520,6 +521,15 @@ export function registerSemanticEditorRoutes(
       }
 
       log.info({ requestId, orgId, name }, "Semantic entity upserted via editor");
+
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.semantic.updateEntity,
+        targetType: "semantic",
+        targetId: name,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { name, source: "editor" },
+      });
+
       return c.json({ ok: true, name, entityType: "entity" }, 200);
     }),
   );
@@ -562,6 +572,15 @@ export function registerSemanticEditorRoutes(
       }
 
       log.info({ requestId, orgId, name }, "Semantic entity deleted via editor");
+
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.semantic.deleteEntity,
+        targetType: "semantic",
+        targetId: name,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { name, source: "editor" },
+      });
+
       return c.json({ ok: true, name, entityType: "entity" }, 200);
     }),
   );
@@ -790,6 +809,15 @@ export function registerSemanticEditorRoutes(
       }
 
       log.info({ requestId, orgId, name, targetVersion: targetVersion.version_number }, "Semantic entity rolled back");
+
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.semantic.updateEntity,
+        targetType: "semantic",
+        targetId: name,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { name, action: "rollback", targetVersion: targetVersion.version_number },
+      });
+
       return c.json({ ok: true, name, versionNumber: newVersionNumber }, 200);
     }),
   );

--- a/packages/api/src/api/routes/admin-sso.ts
+++ b/packages/api/src/api/routes/admin-sso.ts
@@ -7,6 +7,7 @@
 
 import { createRoute, z } from "@hono/zod-openapi";
 import { Effect } from "effect";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect, domainError } from "@atlas/api/lib/effect/hono";
 import {
   AuthContext,
@@ -672,6 +673,15 @@ adminSso.openapi(createProviderRoute, async (c) => {
     }
 
     const provider = yield* createSSOProvider(orgId!, body as unknown as CreateSSOProviderRequest);
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.sso.configure,
+      targetType: "sso",
+      targetId: provider.id,
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+      metadata: { providerType: body.type },
+    });
+
     return c.json({ provider: redactProvider(provider) }, 201);
   }), { label: "create SSO provider", domainErrors: [ssoEnforcementDomainError, ssoDomainError] });
 });
@@ -689,6 +699,15 @@ adminSso.openapi(updateProviderRoute, async (c) => {
     const body = c.req.valid("json") as UpdateSSOProviderRequest;
 
     const provider = yield* updateSSOProvider(orgId!, providerId, body);
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.sso.update,
+      targetType: "sso",
+      targetId: providerId,
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+      metadata: { providerType: provider.type },
+    });
+
     return c.json({ provider: redactProvider(provider) }, 200);
   }), { label: "update SSO provider", domainErrors: [ssoEnforcementDomainError, ssoDomainError] });
 });
@@ -707,6 +726,14 @@ adminSso.openapi(deleteProviderRoute, async (c) => {
     if (!deleted) {
       return c.json({ error: "not_found", message: "SSO provider not found." }, 404);
     }
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.sso.delete,
+      targetType: "sso",
+      targetId: providerId,
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    });
+
     return c.json({ message: "SSO provider deleted." }, 200);
   }), { label: "delete SSO provider", domainErrors: [ssoEnforcementDomainError, ssoDomainError] });
 });
@@ -722,6 +749,15 @@ adminSso.openapi(testProviderRoute, async (c) => {
     }
 
     const result = yield* testSSOProvider(orgId!, providerId);
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.sso.test,
+      targetType: "sso",
+      targetId: providerId,
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+      metadata: { providerType: result.type, success: result.success },
+    });
+
     return c.json(result, 200);
   }), { label: "test SSO provider", domainErrors: [ssoEnforcementDomainError, ssoDomainError] });
 });

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -17,6 +17,7 @@ import { createLogger, withRequestContext, getRequestContext } from "@atlas/api/
 import { withRequestId } from "./middleware";
 import type { AuthResult } from "@atlas/api/lib/auth/types";
 import { authenticateRequest } from "@atlas/api/lib/auth/middleware";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { connections } from "@atlas/api/lib/db/connection";
 import { hasInternalDB, internalQuery, getWorkspaceRegion } from "@atlas/api/lib/db/internal";
 import { plugins } from "@atlas/api/lib/plugins/registry";
@@ -1349,6 +1350,21 @@ admin.openapi(putOrgEntityRoute, async (c) => runHandler(c, "save org semantic e
   await syncEntityToDisk(orgId, name, entityType, body.yamlContent);
 
   log.info({ requestId, orgId, name, entityType }, "Org semantic entity upserted");
+
+  const semanticAction = entityType === "metric"
+    ? ADMIN_ACTIONS.semantic.updateMetric
+    : entityType === "glossary"
+      ? ADMIN_ACTIONS.semantic.updateGlossary
+      : ADMIN_ACTIONS.semantic.updateEntity;
+
+  logAdminAction({
+    actionType: semanticAction,
+    targetType: "semantic",
+    targetId: name,
+    ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    metadata: { name, entityType },
+  });
+
   return c.json({ ok: true, name, entityType }, 200);
 }));
 
@@ -1381,6 +1397,15 @@ admin.openapi(deleteOrgEntityRoute, async (c) => runHandler(c, "delete org seman
   await syncEntityDeleteFromDisk(orgId, name, entityType);
 
   log.info({ requestId, orgId, name, entityType }, "Org semantic entity deleted");
+
+  logAdminAction({
+    actionType: ADMIN_ACTIONS.semantic.deleteEntity,
+    targetType: "semantic",
+    targetId: name,
+    ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    metadata: { name, entityType },
+  });
+
   return c.json({ ok: true, name, entityType }, 200);
 }));
 
@@ -1744,11 +1769,34 @@ admin.openapi(changeUserRoleRoute, async (c) => {
   }
 
   try {
+    // Capture previous role for audit metadata (best-effort — may be undefined for non-DB auth)
+    let previousRole: string | undefined;
+    if (hasInternalDB()) {
+      try {
+        const roleRow = await internalQuery<{ role: string }>(
+          `SELECT role FROM "user" WHERE id = $1`,
+          [userId],
+        );
+        previousRole = roleRow[0]?.role;
+      } catch {
+        // intentionally ignored: previous role is metadata only, not critical
+      }
+    }
+
     await adminApi.setRole({
       body: { userId, role: newRole },
       headers: c.req.raw.headers,
     });
     log.info({ requestId, targetUserId: userId, newRole, actorId: authResult.user?.id }, "User role changed");
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.user.changeRole,
+      targetType: "user",
+      targetId: userId,
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+      metadata: { previousRole, newRole },
+    });
+
     return c.json({ success: true }, 200);
   } catch (err) {
     log.error({ err: err instanceof Error ? err : new Error(String(err)), userId }, "Failed to set user role");
@@ -1864,6 +1912,14 @@ admin.openapi(deleteUserRoute, async (c) => {
       headers: c.req.raw.headers,
     });
     log.info({ requestId, targetUserId: userId, actorId: authResult.user?.id }, "User deleted");
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.user.remove,
+      targetType: "user",
+      targetId: userId,
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    });
+
     return c.json({ success: true }, 200);
   } catch (err) {
     log.error({ err: err instanceof Error ? err : new Error(String(err)), userId }, "Failed to delete user");
@@ -2005,6 +2061,15 @@ admin.openapi(updateSettingRoute, async (c) => runHandler(c, "save setting", asy
   const effectiveOrgId = def.scope === "workspace" ? orgId : undefined;
   await setSetting(key, value, authResult.user?.id, effectiveOrgId);
   log.info({ requestId, key, orgId: effectiveOrgId, actorId: authResult.user?.id }, "Setting override saved via admin API");
+
+  logAdminAction({
+    actionType: ADMIN_ACTIONS.settings.update,
+    targetType: "settings",
+    targetId: key,
+    ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    metadata: { key, value },
+  });
+
   return c.json({ success: true, key, value }, 200);
 }));
 
@@ -2041,6 +2106,15 @@ admin.openapi(deleteSettingRoute, async (c) => runHandler(c, "delete setting", a
   const effectiveOrgId = def.scope === "workspace" ? orgId : undefined;
   await deleteSetting(key, authResult.user?.id, effectiveOrgId);
   log.info({ requestId, key, orgId: effectiveOrgId, actorId: authResult.user?.id }, "Setting override removed via admin API");
+
+  logAdminAction({
+    actionType: ADMIN_ACTIONS.settings.update,
+    targetType: "settings",
+    targetId: key,
+    ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    metadata: { key, action: "reset_to_default" },
+  });
+
   return c.json({ success: true, key }, 200);
 }));
 

--- a/packages/api/src/api/routes/scheduled-tasks.ts
+++ b/packages/api/src/api/routes/scheduled-tasks.ts
@@ -15,6 +15,7 @@ import { validationHook } from "./validation-hook";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 import { createLogger } from "@atlas/api/lib/logger";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import {
   createScheduledTask,
@@ -282,6 +283,14 @@ authed.openapi(
         return c.json(fail.body, fail.status);
       }
 
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.schedule.create,
+        targetType: "schedule",
+        targetId: createResult.data.id,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { name: parsed.name },
+      });
+
       return c.json(createResult.data, 201);
     }), { label: "create scheduled task" });
   },
@@ -439,6 +448,27 @@ authed.openapi(
 
       // Fetch updated task to return
       const updated = yield* Effect.promise(() => getScheduledTask(id, { orgId }));
+
+      // Determine if this was a toggle (enabled field changed)
+      const isToggle = parsed.enabled !== undefined && Object.keys(parsed).length === 1;
+      if (isToggle) {
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.schedule.toggle,
+          targetType: "schedule",
+          targetId: id,
+          ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+          metadata: { name: updated.ok ? updated.data.name : id, enabled: parsed.enabled },
+        });
+      } else {
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.schedule.update,
+          targetType: "schedule",
+          targetId: id,
+          ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+          metadata: { name: updated.ok ? updated.data.name : id },
+        });
+      }
+
       if (!updated.ok) {
         return c.json({ ok: true }, 200);
       }
@@ -474,6 +504,15 @@ authed.openapi(deleteTaskRoute, async (c) => {
       const fail = crudFailResponse(delResult.reason, requestId);
       return c.json(fail.body, fail.status);
     }
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.schedule.delete,
+      targetType: "schedule",
+      targetId: id,
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+      metadata: { taskId: id },
+    });
+
     return c.body(null, 204);
   }), { label: "delete scheduled task" });
 });


### PR DESCRIPTION
## Summary
- Instruments ~40 workspace admin mutation handlers with `logAdminAction()` calls across 9 route files
- Each call uses the type-safe `ADMIN_ACTIONS` catalog constant, default `"workspace"` scope, and includes `ipAddress` from request headers
- Metadata carries meaningful context (connection names, user roles, platform identifiers, entity types) but never secrets or API key values

## Route files instrumented

| File | Mutations |
|------|-----------|
| `admin.ts` | settings update/delete, user role change, user delete, semantic entity upsert/delete (with metric/glossary action type dispatch) |
| `admin-connections.ts` | connection create, update, delete |
| `admin-invitations.ts` | user invite |
| `admin-sso.ts` | SSO provider create, update, delete, test |
| `admin-learned-patterns.ts` | pattern approve, reject, delete |
| `admin-semantic.ts` | semantic entity editor save, delete, rollback |
| `admin-integrations.ts` | enable/disable for all 9 platforms (Slack, Teams, Discord, Telegram, Google Chat, GitHub, Linear, WhatsApp, Email) + email configure |
| `scheduled-tasks.ts` | task create, update, toggle, delete |
| `admin-approval.ts` | approval request approve/deny |

## Not instrumented (routes don't exist yet)
- API key create/revoke — no API key management routes in codebase

## Test plan
- [ ] `bun run lint` passes (verified)
- [ ] `bun run type` passes (no new errors; pre-existing plugin-sdk errors unchanged)
- [ ] Verify `logAdminAction()` is fire-and-forget — never throws, never blocks the response
- [ ] Confirm no secrets appear in metadata fields
- [ ] Spot-check a few mutations manually to see audit log entries in pino output

Closes #1368