### PR TITLE
feat: admin action audit — filtering + CSV export (#1366, #1386)

### DIFF
--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -381,6 +381,9 @@ export function createApiTestMocks(
     getExploreBackendType: () => "just-bash",
     getActiveSandboxPluginId: () => null,
     explore: { type: "function" },
+    invalidateExploreBackend: mock(() => {}),
+    markNsjailFailed: mock(() => {}),
+    markSidecarFailed: mock(() => {}),
   }));
 
   mock.module("@atlas/api/lib/tools/actions", () => ({}));

--- a/packages/api/src/api/__tests__/admin-actions.test.ts
+++ b/packages/api/src/api/__tests__/admin-actions.test.ts
@@ -1,8 +1,9 @@
 /**
- * Tests for workspace admin action audit log endpoint.
+ * Tests for workspace admin action audit log endpoints.
  *
  * Covers: GET /api/v1/admin/admin-actions (org isolation, scope filtering,
- * pagination, auth, response shape).
+ * pagination, auth, response shape, filters)
+ *         GET /api/v1/admin/admin-actions/export (CSV export, org-scoped, headers)
  */
 
 import {
@@ -192,8 +193,10 @@ describe("GET /api/v1/admin/admin-actions", () => {
   it("respects limit and offset query params", async () => {
     mocks.mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
       if (sql.includes("COUNT(*)")) return [{ count: 100 }];
-      // Verify correct params: orgId=$1, limit=$2, offset=$3
-      expect(params).toEqual(["org-1", 10, 20]);
+      // orgId=$1, then limit and offset are the last two params
+      const pArr = params ?? [];
+      expect(pArr[pArr.length - 2]).toBe(10);
+      expect(pArr[pArr.length - 1]).toBe(20);
       return [];
     });
 
@@ -233,6 +236,198 @@ describe("GET /api/v1/admin/admin-actions", () => {
     mocks.hasInternalDB = false;
 
     const res = await app.request(adminRequest("GET", "/api/v1/admin/admin-actions"));
+    expect(res.status).toBe(404);
+  });
+
+  it("passes actor filter to SQL query", async () => {
+    let capturedSql = "";
+    let capturedParams: unknown[] = [];
+    mocks.mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+      capturedSql = sql;
+      capturedParams = params ?? [];
+      if (sql.includes("COUNT(*)")) return [{ count: 0 }];
+      return [];
+    });
+
+    await app.request(adminRequest("GET", "/api/v1/admin/admin-actions?actor=admin"));
+    expect(capturedSql).toContain("actor_email ILIKE");
+    expect(capturedParams).toContain("%admin%");
+  });
+
+  it("passes actionType filter to SQL query", async () => {
+    let capturedSql = "";
+    let capturedParams: unknown[] = [];
+    mocks.mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+      capturedSql = sql;
+      capturedParams = params ?? [];
+      if (sql.includes("COUNT(*)")) return [{ count: 0 }];
+      return [];
+    });
+
+    await app.request(adminRequest("GET", "/api/v1/admin/admin-actions?actionType=settings.update"));
+    expect(capturedSql).toContain("action_type =");
+    expect(capturedParams).toContain("settings.update");
+  });
+
+  it("passes date range filters to SQL query", async () => {
+    let capturedSql = "";
+    let capturedParams: unknown[] = [];
+    mocks.mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+      capturedSql = sql;
+      capturedParams = params ?? [];
+      if (sql.includes("COUNT(*)")) return [{ count: 0 }];
+      return [];
+    });
+
+    await app.request(adminRequest("GET", "/api/v1/admin/admin-actions?from=2026-01-01&to=2026-03-01"));
+    expect(capturedSql).toContain("timestamp >=");
+    expect(capturedSql).toContain("timestamp <=");
+    expect(capturedParams).toContain("2026-01-01");
+    expect(capturedParams).toContain("2026-03-01");
+  });
+
+  it("passes metadata search filter to SQL query", async () => {
+    let capturedSql = "";
+    let capturedParams: unknown[] = [];
+    mocks.mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+      capturedSql = sql;
+      capturedParams = params ?? [];
+      if (sql.includes("COUNT(*)")) return [{ count: 0 }];
+      return [];
+    });
+
+    await app.request(adminRequest("GET", "/api/v1/admin/admin-actions?search=test-data"));
+    expect(capturedSql).toContain("metadata::text ILIKE");
+    expect(capturedParams).toContain("%test-data%");
+  });
+
+  it("composes multiple filters together", async () => {
+    let capturedSql = "";
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      capturedSql = sql;
+      if (sql.includes("COUNT(*)")) return [{ count: 0 }];
+      return [];
+    });
+
+    await app.request(adminRequest("GET", "/api/v1/admin/admin-actions?actor=admin&actionType=settings.update&targetType=settings"));
+    expect(capturedSql).toContain("actor_email ILIKE");
+    expect(capturedSql).toContain("action_type =");
+    expect(capturedSql).toContain("target_type =");
+  });
+
+  it("returns 400 for invalid date filter", async () => {
+    const res = await app.request(adminRequest("GET", "/api/v1/admin/admin-actions?from=not-a-date"));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/v1/admin/admin-actions/export", () => {
+  beforeEach(() => {
+    mocks.setOrgAdmin("org-1");
+    mocks.hasInternalDB = true;
+  });
+
+  it("returns CSV with correct Content-Type header", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("COUNT(*)")) return [{ count: 1 }];
+      return [SAMPLE_WORKSPACE_ACTION];
+    });
+
+    const res = await app.request(adminRequest("GET", "/api/v1/admin/admin-actions/export"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/csv; charset=utf-8");
+  });
+
+  it("returns CSV with correct Content-Disposition header", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("COUNT(*)")) return [{ count: 1 }];
+      return [SAMPLE_WORKSPACE_ACTION];
+    });
+
+    const res = await app.request(adminRequest("GET", "/api/v1/admin/admin-actions/export"));
+    expect(res.status).toBe(200);
+    const disposition = res.headers.get("Content-Disposition");
+    expect(disposition).toContain("attachment");
+    expect(disposition).toContain("admin-actions-");
+    expect(disposition).toContain(".csv");
+  });
+
+  it("includes CSV header row and data rows", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("COUNT(*)")) return [{ count: 1 }];
+      return [SAMPLE_WORKSPACE_ACTION];
+    });
+
+    const res = await app.request(adminRequest("GET", "/api/v1/admin/admin-actions/export"));
+    const csv = await res.text();
+    const lines = csv.split("\n");
+    expect(lines[0]).toBe("timestamp,actor_email,action_type,target_type,target_id,scope,org_id,status,metadata,ip_address,request_id");
+    expect(lines[1]).toContain("admin@test.com");
+    expect(lines[1]).toContain("settings.update");
+  });
+
+  it("is org-scoped in SQL query", async () => {
+    let capturedSql = "";
+    let capturedParams: unknown[] = [];
+    mocks.mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+      capturedSql = sql;
+      capturedParams = params ?? [];
+      if (sql.includes("COUNT(*)")) return [{ count: 0 }];
+      return [];
+    });
+
+    await app.request(adminRequest("GET", "/api/v1/admin/admin-actions/export"));
+    expect(capturedSql).toContain("org_id = $1");
+    expect(capturedSql).toContain("scope = 'workspace'");
+    expect(capturedParams[0]).toBe("org-1");
+  });
+
+  it("sets truncation headers when over 10,000 rows", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("COUNT(*)")) return [{ count: 15000 }];
+      return [SAMPLE_WORKSPACE_ACTION];
+    });
+
+    const res = await app.request(adminRequest("GET", "/api/v1/admin/admin-actions/export"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Truncated")).toBe("true");
+    expect(res.headers.get("X-Total-Count")).toBe("15000");
+  });
+
+  it("does not set truncation headers when under limit", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("COUNT(*)")) return [{ count: 5 }];
+      return [SAMPLE_WORKSPACE_ACTION];
+    });
+
+    const res = await app.request(adminRequest("GET", "/api/v1/admin/admin-actions/export"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Truncated")).toBeNull();
+    expect(res.headers.get("X-Total-Count")).toBeNull();
+  });
+
+  it("applies filters to CSV export", async () => {
+    let capturedSql = "";
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      capturedSql = sql;
+      if (sql.includes("COUNT(*)")) return [{ count: 0 }];
+      return [];
+    });
+
+    await app.request(adminRequest("GET", "/api/v1/admin/admin-actions/export?actor=admin&actionType=settings.update"));
+    expect(capturedSql).toContain("actor_email ILIKE");
+    expect(capturedSql).toContain("action_type =");
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    mocks.setMember("org-1");
+    const res = await app.request(adminRequest("GET", "/api/v1/admin/admin-actions/export"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when internal DB is not configured", async () => {
+    mocks.hasInternalDB = false;
+    const res = await app.request(adminRequest("GET", "/api/v1/admin/admin-actions/export"));
     expect(res.status).toBe(404);
   });
 });

--- a/packages/api/src/api/__tests__/cors-origin.test.ts
+++ b/packages/api/src/api/__tests__/cors-origin.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { describe, it, expect, mock } from "bun:test";
+import { createConnectionMock } from "../../__mocks__/connection";
 
 // --- Mocks (same set as cors.test.ts, but with explicit CORS origin) ---
 
@@ -46,7 +47,15 @@ mock.module("@atlas/api/lib/semantic", () => ({
 mock.module("@atlas/api/lib/tools/explore", () => ({
   getExploreBackendType: () => "just-bash",
   getActiveSandboxPluginId: () => null,
+  explore: { type: "function" },
+  invalidateExploreBackend: mock(() => {}),
+  markNsjailFailed: mock(() => {}),
+  markSidecarFailed: mock(() => {}),
 }));
+
+mock.module("@atlas/api/lib/db/connection", () =>
+  createConnectionMock({ resolveDatasourceUrl: () => "postgresql://mock:5432/test" }),
+);
 
 mock.module("@atlas/api/lib/auth/detect", () => ({
   detectAuthMode: () => "none",

--- a/packages/api/src/api/__tests__/platform-actions.test.ts
+++ b/packages/api/src/api/__tests__/platform-actions.test.ts
@@ -1,7 +1,8 @@
 /**
- * Tests for platform admin action log endpoint.
+ * Tests for platform admin action log endpoints.
  *
- * Covers: GET /api/v1/platform/actions (pagination, auth, response shape).
+ * Covers: GET /api/v1/platform/actions (pagination, auth, response shape, filters)
+ *         GET /api/v1/platform/actions/export (CSV export, headers, truncation)
  */
 
 import {
@@ -118,8 +119,10 @@ describe("GET /api/v1/platform/actions", () => {
   it("respects limit and offset query params", async () => {
     mocks.mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
       if (sql.includes("COUNT(*)")) return [{ count: 100 }];
-      // Verify correct params are passed
-      expect(params).toEqual([10, 20]);
+      // Verify correct params: limit and offset are last
+      const pArr = params ?? [];
+      expect(pArr[pArr.length - 2]).toBe(10);
+      expect(pArr[pArr.length - 1]).toBe(20);
       return [];
     });
 
@@ -159,6 +162,182 @@ describe("GET /api/v1/platform/actions", () => {
     mocks.hasInternalDB = false;
 
     const res = await app.request(platformRequest("GET", "/api/v1/platform/actions"));
+    expect(res.status).toBe(404);
+  });
+
+  it("passes actor filter to SQL query", async () => {
+    let capturedSql = "";
+    let capturedParams: unknown[] = [];
+    mocks.mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+      capturedSql = sql;
+      capturedParams = params ?? [];
+      if (sql.includes("COUNT(*)")) return [{ count: 0 }];
+      return [];
+    });
+
+    await app.request(platformRequest("GET", "/api/v1/platform/actions?actor=admin"));
+    expect(capturedSql).toContain("actor_email ILIKE");
+    expect(capturedParams).toContain("%admin%");
+  });
+
+  it("passes actionType filter to SQL query", async () => {
+    let capturedSql = "";
+    let capturedParams: unknown[] = [];
+    mocks.mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+      capturedSql = sql;
+      capturedParams = params ?? [];
+      if (sql.includes("COUNT(*)")) return [{ count: 0 }];
+      return [];
+    });
+
+    await app.request(platformRequest("GET", "/api/v1/platform/actions?actionType=settings.update"));
+    expect(capturedSql).toContain("action_type =");
+    expect(capturedParams).toContain("settings.update");
+  });
+
+  it("passes date range filters to SQL query", async () => {
+    let capturedSql = "";
+    let capturedParams: unknown[] = [];
+    mocks.mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+      capturedSql = sql;
+      capturedParams = params ?? [];
+      if (sql.includes("COUNT(*)")) return [{ count: 0 }];
+      return [];
+    });
+
+    await app.request(platformRequest("GET", "/api/v1/platform/actions?from=2026-01-01&to=2026-03-01"));
+    expect(capturedSql).toContain("timestamp >=");
+    expect(capturedSql).toContain("timestamp <=");
+    expect(capturedParams).toContain("2026-01-01");
+    expect(capturedParams).toContain("2026-03-01");
+  });
+
+  it("passes metadata search filter to SQL query", async () => {
+    let capturedSql = "";
+    let capturedParams: unknown[] = [];
+    mocks.mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+      capturedSql = sql;
+      capturedParams = params ?? [];
+      if (sql.includes("COUNT(*)")) return [{ count: 0 }];
+      return [];
+    });
+
+    await app.request(platformRequest("GET", "/api/v1/platform/actions?search=test-data"));
+    expect(capturedSql).toContain("metadata::text ILIKE");
+    expect(capturedParams).toContain("%test-data%");
+  });
+
+  it("composes multiple filters together", async () => {
+    let capturedSql = "";
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      capturedSql = sql;
+      if (sql.includes("COUNT(*)")) return [{ count: 0 }];
+      return [];
+    });
+
+    await app.request(platformRequest("GET", "/api/v1/platform/actions?actor=admin&actionType=settings.update&targetType=settings"));
+    expect(capturedSql).toContain("actor_email ILIKE");
+    expect(capturedSql).toContain("action_type =");
+    expect(capturedSql).toContain("target_type =");
+  });
+
+  it("returns 400 for invalid date filter", async () => {
+    const res = await app.request(platformRequest("GET", "/api/v1/platform/actions?from=not-a-date"));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/v1/platform/actions/export", () => {
+  beforeEach(() => {
+    mocks.setPlatformAdmin();
+    mocks.hasInternalDB = true;
+  });
+
+  it("returns CSV with correct Content-Type header", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("COUNT(*)")) return [{ count: 1 }];
+      return [SAMPLE_ACTION];
+    });
+
+    const res = await app.request(platformRequest("GET", "/api/v1/platform/actions/export"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/csv; charset=utf-8");
+  });
+
+  it("returns CSV with correct Content-Disposition header", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("COUNT(*)")) return [{ count: 1 }];
+      return [SAMPLE_ACTION];
+    });
+
+    const res = await app.request(platformRequest("GET", "/api/v1/platform/actions/export"));
+    expect(res.status).toBe(200);
+    const disposition = res.headers.get("Content-Disposition");
+    expect(disposition).toContain("attachment");
+    expect(disposition).toContain("platform-actions-");
+    expect(disposition).toContain(".csv");
+  });
+
+  it("includes CSV header row and data rows", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("COUNT(*)")) return [{ count: 1 }];
+      return [SAMPLE_ACTION];
+    });
+
+    const res = await app.request(platformRequest("GET", "/api/v1/platform/actions/export"));
+    const csv = await res.text();
+    const lines = csv.split("\n");
+    expect(lines[0]).toBe("timestamp,actor_email,action_type,target_type,target_id,scope,org_id,status,metadata,ip_address,request_id");
+    expect(lines[1]).toContain("admin@test.com");
+    expect(lines[1]).toContain("workspace.suspend");
+  });
+
+  it("sets truncation headers when over 10,000 rows", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("COUNT(*)")) return [{ count: 15000 }];
+      return [SAMPLE_ACTION];
+    });
+
+    const res = await app.request(platformRequest("GET", "/api/v1/platform/actions/export"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Truncated")).toBe("true");
+    expect(res.headers.get("X-Total-Count")).toBe("15000");
+  });
+
+  it("does not set truncation headers when under limit", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("COUNT(*)")) return [{ count: 5 }];
+      return [SAMPLE_ACTION];
+    });
+
+    const res = await app.request(platformRequest("GET", "/api/v1/platform/actions/export"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Truncated")).toBeNull();
+    expect(res.headers.get("X-Total-Count")).toBeNull();
+  });
+
+  it("applies filters to CSV export", async () => {
+    let capturedSql = "";
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      capturedSql = sql;
+      if (sql.includes("COUNT(*)")) return [{ count: 0 }];
+      return [];
+    });
+
+    await app.request(platformRequest("GET", "/api/v1/platform/actions/export?actor=admin&actionType=settings.update"));
+    expect(capturedSql).toContain("actor_email ILIKE");
+    expect(capturedSql).toContain("action_type =");
+  });
+
+  it("returns 403 for non-platform-admin", async () => {
+    mocks.setOrgAdmin("org-1");
+    const res = await app.request(platformRequest("GET", "/api/v1/platform/actions/export"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when internal DB is not configured", async () => {
+    mocks.hasInternalDB = false;
+    const res = await app.request(platformRequest("GET", "/api/v1/platform/actions/export"));
     expect(res.status).toBe(404);
   });
 });

--- a/packages/api/src/api/routes/admin-actions.ts
+++ b/packages/api/src/api/routes/admin-actions.ts
@@ -2,7 +2,8 @@
  * Workspace admin action audit log routes.
  *
  * Mounted at /api/v1/admin/admin-actions. Provides a paginated list of
- * admin action log entries scoped to the caller's active organization.
+ * admin action log entries scoped to the caller's active organization,
+ * with filtering and CSV export.
  * Only workspace-scoped actions (or actions explicitly tied to the org)
  * are returned — platform-scoped actions are excluded.
  */
@@ -18,6 +19,20 @@ import {
   PaginationQuerySchema,
   parsePagination,
 } from "./shared-schemas";
+import { buildActionFilters, type ActionFilterParams } from "@atlas/api/lib/audit/filters";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Quote a value for safe CSV output (RFC 4180). */
+function csvField(val: string | null | undefined): string {
+  const s = val ?? "";
+  if (s.includes(",") || s.includes('"') || s.includes("\n") || s.includes("\r")) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
 
 // ---------------------------------------------------------------------------
 // Schemas
@@ -39,6 +54,15 @@ const AdminActionSchema = z.object({
   requestId: z.string(),
 });
 
+const ActionFilterQuerySchema = PaginationQuerySchema.extend({
+  actor: z.string().optional().openapi({ description: "Filter by actor email (partial match)" }),
+  actionType: z.string().optional().openapi({ description: "Filter by action type (exact match)" }),
+  targetType: z.string().optional().openapi({ description: "Filter by target type (exact match)" }),
+  from: z.string().optional().openapi({ description: "Filter actions on or after this date (ISO 8601)" }),
+  to: z.string().optional().openapi({ description: "Filter actions on or before this date (ISO 8601)" }),
+  search: z.string().optional().openapi({ description: "Free-text search in metadata JSONB" }),
+});
+
 // ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
@@ -48,8 +72,8 @@ const listActionsRoute = createRoute({
   path: "/",
   tags: ["Admin"],
   summary: "List workspace admin action log",
-  description: "Returns a paginated list of admin action log entries scoped to the caller's active organization.",
-  request: { query: PaginationQuerySchema },
+  description: "Returns a paginated, filterable list of admin action log entries scoped to the caller's active organization.",
+  request: { query: ActionFilterQuerySchema },
   responses: {
     200: {
       description: "Admin action log entries for this workspace",
@@ -64,13 +88,80 @@ const listActionsRoute = createRoute({
         },
       },
     },
-    400: { description: "No active organization", content: { "application/json": { schema: ErrorSchema } } },
+    400: { description: "Invalid filter parameter", content: { "application/json": { schema: ErrorSchema } } },
     401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
     403: { description: "Admin role required", content: { "application/json": { schema: AuthErrorSchema } } },
     404: { description: "Internal database not configured", content: { "application/json": { schema: ErrorSchema } } },
     500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
+
+const exportActionsRoute = createRoute({
+  method: "get",
+  path: "/export",
+  tags: ["Admin"],
+  summary: "Export workspace admin action log as CSV",
+  description: "Exports workspace admin action log entries as a CSV file (up to 10,000 rows). Scoped to the caller's active organization.",
+  request: { query: ActionFilterQuerySchema.omit({ limit: true, offset: true }) },
+  responses: {
+    200: { description: "CSV file", content: { "text/csv": { schema: z.string() } } },
+    400: { description: "Invalid filter parameter", content: { "application/json": { schema: ErrorSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
+    403: { description: "Admin role required", content: { "application/json": { schema: AuthErrorSchema } } },
+    404: { description: "Internal database not configured", content: { "application/json": { schema: ErrorSchema } } },
+    500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Shared query helpers
+// ---------------------------------------------------------------------------
+
+interface ActionRow {
+  id: string;
+  timestamp: string;
+  actor_id: string;
+  actor_email: string;
+  scope: "platform" | "workspace";
+  org_id: string | null;
+  action_type: string;
+  target_type: string;
+  target_id: string;
+  status: "success" | "failure";
+  metadata: Record<string, unknown> | null;
+  ip_address: string | null;
+  request_id: string;
+  [key: string]: unknown;
+}
+
+function mapActionRow(row: ActionRow) {
+  return {
+    id: row.id,
+    timestamp: row.timestamp,
+    actorId: row.actor_id,
+    actorEmail: row.actor_email,
+    scope: row.scope,
+    orgId: row.org_id,
+    actionType: row.action_type,
+    targetType: row.target_type,
+    targetId: row.target_id,
+    status: row.status,
+    metadata: row.metadata,
+    ipAddress: row.ip_address,
+    requestId: row.request_id,
+  };
+}
+
+function extractFilterParams(queryFn: (key: string) => string | undefined): ActionFilterParams {
+  return {
+    actor: queryFn("actor"),
+    actionType: queryFn("actionType"),
+    targetType: queryFn("targetType"),
+    from: queryFn("from"),
+    to: queryFn("to"),
+    search: queryFn("search"),
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Router
@@ -81,54 +172,41 @@ adminActions.use(requireOrgContext());
 
 adminActions.openapi(listActionsRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
-    const { orgId } = c.get("orgContext");
+    const { orgId, requestId } = c.get("orgContext");
 
     const { limit, offset } = parsePagination(c, { limit: 50, maxLimit: 200 });
+    const filterParams = extractFilterParams((k) => c.req.query(k));
+
+    // Base conditions: org-scoped + workspace only. Filters start at $2.
+    const baseConditions = ["org_id = $1", "scope = 'workspace'"];
+    const baseParams: unknown[] = [orgId];
+
+    const filters = buildActionFilters(2, filterParams);
+    if (!filters.ok) {
+      return c.json({ error: filters.error, message: filters.message, requestId }, filters.status);
+    }
+
+    const { conditions: filterConditions, params: filterParamsArr, paramIdx } = filters;
+    const allConditions = [...baseConditions, ...filterConditions];
+    const allParams = [...baseParams, ...filterParamsArr];
+    const whereClause = `WHERE ${allConditions.join(" AND ")}`;
 
     const [rows, countRows] = yield* Effect.promise(() => Promise.all([
-      internalQuery<{
-        id: string;
-        timestamp: string;
-        actor_id: string;
-        actor_email: string;
-        scope: "platform" | "workspace";
-        org_id: string | null;
-        action_type: string;
-        target_type: string;
-        target_id: string;
-        status: "success" | "failure";
-        metadata: Record<string, unknown> | null;
-        ip_address: string | null;
-        request_id: string;
-      }>(
+      internalQuery<ActionRow>(
         `SELECT id, timestamp, actor_id, actor_email, scope, org_id, action_type, target_type, target_id, status, metadata, ip_address, request_id
          FROM admin_action_log
-         WHERE org_id = $1 AND scope = 'workspace'
+         ${whereClause}
          ORDER BY timestamp DESC
-         LIMIT $2 OFFSET $3`,
-        [orgId, limit, offset],
+         LIMIT $${paramIdx} OFFSET $${paramIdx + 1}`,
+        [...allParams, limit, offset],
       ),
       internalQuery<{ count: number }>(
-        `SELECT COUNT(*)::int AS count FROM admin_action_log WHERE org_id = $1 AND scope = 'workspace'`,
-        [orgId],
+        `SELECT COUNT(*)::int AS count FROM admin_action_log ${whereClause}`,
+        allParams,
       ),
     ]));
 
-    const actions = rows.map((row) => ({
-      id: row.id,
-      timestamp: row.timestamp,
-      actorId: row.actor_id,
-      actorEmail: row.actor_email,
-      scope: row.scope,
-      orgId: row.org_id,
-      actionType: row.action_type,
-      targetType: row.target_type,
-      targetId: row.target_id,
-      status: row.status,
-      metadata: row.metadata,
-      ipAddress: row.ip_address,
-      requestId: row.request_id,
-    }));
+    const actions = rows.map(mapActionRow);
 
     return c.json({
       actions,
@@ -137,6 +215,75 @@ adminActions.openapi(listActionsRoute, async (c) => {
       offset,
     }, 200);
   }), { label: "list workspace admin actions" });
+});
+
+// GET /export — CSV export
+adminActions.openapi(exportActionsRoute, async (c) => {
+  return runEffect(c, Effect.gen(function* () {
+    const { orgId, requestId } = c.get("orgContext");
+
+    const filterParams = extractFilterParams((k) => c.req.query(k));
+
+    const baseConditions = ["org_id = $1", "scope = 'workspace'"];
+    const baseParams: unknown[] = [orgId];
+
+    const filters = buildActionFilters(2, filterParams);
+    if (!filters.ok) {
+      return c.json({ error: filters.error, message: filters.message, requestId }, filters.status);
+    }
+
+    const { conditions: filterConditions, params: filterParamsArr, paramIdx } = filters;
+    const allConditions = [...baseConditions, ...filterConditions];
+    const allParams = [...baseParams, ...filterParamsArr];
+    const whereClause = `WHERE ${allConditions.join(" AND ")}`;
+    const exportLimit = 10000;
+
+    const [countRows, rows] = yield* Effect.promise(() => Promise.all([
+      internalQuery<{ count: number }>(
+        `SELECT COUNT(*)::int AS count FROM admin_action_log ${whereClause}`,
+        allParams,
+      ),
+      internalQuery<ActionRow>(
+        `SELECT id, timestamp, actor_id, actor_email, scope, org_id, action_type, target_type, target_id, status, metadata, ip_address, request_id
+         FROM admin_action_log
+         ${whereClause}
+         ORDER BY timestamp DESC
+         LIMIT $${paramIdx}`,
+        [...allParams, exportLimit],
+      ),
+    ]));
+
+    const totalAvailable = countRows[0]?.count ?? 0;
+    const csvHeader = "timestamp,actor_email,action_type,target_type,target_id,scope,org_id,status,metadata,ip_address,request_id\n";
+    const csvRows = rows.map((r) => [
+      csvField(r.timestamp),
+      csvField(r.actor_email),
+      csvField(r.action_type),
+      csvField(r.target_type),
+      csvField(r.target_id),
+      csvField(r.scope),
+      csvField(r.org_id),
+      csvField(r.status),
+      csvField(r.metadata ? JSON.stringify(r.metadata) : null),
+      csvField(r.ip_address),
+      csvField(r.request_id),
+    ].join(","));
+
+    const csv = csvHeader + csvRows.join("\n");
+    const filename = `admin-actions-${new Date().toISOString().slice(0, 10)}.csv`;
+    const truncated = totalAvailable > exportLimit;
+
+    return new Response(csv, {
+      headers: {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+        ...(truncated && {
+          "X-Truncated": "true",
+          "X-Total-Count": String(totalAvailable),
+        }),
+      },
+    });
+  }), { label: "export workspace admin actions" });
 });
 
 export { adminActions };

--- a/packages/api/src/api/routes/platform-actions.ts
+++ b/packages/api/src/api/routes/platform-actions.ts
@@ -2,7 +2,7 @@
  * Platform admin action log routes.
  *
  * Mounted at /api/v1/platform/actions. Provides a paginated list of all
- * admin action log entries across the platform.
+ * admin action log entries across the platform, with filtering and CSV export.
  */
 
 import { createRoute, z } from "@hono/zod-openapi";
@@ -17,6 +17,20 @@ import {
   PaginationQuerySchema,
   parsePagination,
 } from "./shared-schemas";
+import { buildActionFilters, type ActionFilterParams } from "@atlas/api/lib/audit/filters";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Quote a value for safe CSV output (RFC 4180). */
+function csvField(val: string | null | undefined): string {
+  const s = val ?? "";
+  if (s.includes(",") || s.includes('"') || s.includes("\n") || s.includes("\r")) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
 
 // ---------------------------------------------------------------------------
 // Schemas
@@ -38,6 +52,16 @@ const AdminActionSchema = z.object({
   requestId: z.string(),
 });
 
+const ActionFilterQuerySchema = PaginationQuerySchema.extend({
+  actor: z.string().optional().openapi({ description: "Filter by actor email (partial match)" }),
+  actionType: z.string().optional().openapi({ description: "Filter by action type (exact match)" }),
+  targetType: z.string().optional().openapi({ description: "Filter by target type (exact match)" }),
+  from: z.string().optional().openapi({ description: "Filter actions on or after this date (ISO 8601)" }),
+  to: z.string().optional().openapi({ description: "Filter actions on or before this date (ISO 8601)" }),
+  search: z.string().optional().openapi({ description: "Free-text search in metadata JSONB" }),
+  orgId: z.string().optional().openapi({ description: "Filter by organization ID" }),
+});
+
 // ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
@@ -47,8 +71,8 @@ const listActionsRoute = createRoute({
   path: "/",
   tags: ["Platform Admin"],
   summary: "List admin action log",
-  description: "SaaS only. Returns a paginated list of all admin action log entries across the platform.",
-  request: { query: PaginationQuerySchema },
+  description: "SaaS only. Returns a paginated, filterable list of all admin action log entries across the platform.",
+  request: { query: ActionFilterQuerySchema },
   responses: {
     200: {
       description: "Admin action log entries",
@@ -63,12 +87,81 @@ const listActionsRoute = createRoute({
         },
       },
     },
+    400: { description: "Invalid filter parameter", content: { "application/json": { schema: ErrorSchema } } },
     401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
     403: { description: "Platform admin role required", content: { "application/json": { schema: AuthErrorSchema } } },
     404: { description: "Internal database not configured", content: { "application/json": { schema: ErrorSchema } } },
     500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
+
+const exportActionsRoute = createRoute({
+  method: "get",
+  path: "/export",
+  tags: ["Platform Admin"],
+  summary: "Export admin action log as CSV",
+  description: "SaaS only. Exports admin action log entries as a CSV file (up to 10,000 rows).",
+  request: { query: ActionFilterQuerySchema.omit({ limit: true, offset: true }) },
+  responses: {
+    200: { description: "CSV file", content: { "text/csv": { schema: z.string() } } },
+    400: { description: "Invalid filter parameter", content: { "application/json": { schema: ErrorSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
+    403: { description: "Platform admin role required", content: { "application/json": { schema: AuthErrorSchema } } },
+    404: { description: "Internal database not configured", content: { "application/json": { schema: ErrorSchema } } },
+    500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Shared query helpers
+// ---------------------------------------------------------------------------
+
+interface ActionRow {
+  id: string;
+  timestamp: string;
+  actor_id: string;
+  actor_email: string;
+  scope: "platform" | "workspace";
+  org_id: string | null;
+  action_type: string;
+  target_type: string;
+  target_id: string;
+  status: "success" | "failure";
+  metadata: Record<string, unknown> | null;
+  ip_address: string | null;
+  request_id: string;
+  [key: string]: unknown;
+}
+
+function mapActionRow(row: ActionRow) {
+  return {
+    id: row.id,
+    timestamp: row.timestamp,
+    actorId: row.actor_id,
+    actorEmail: row.actor_email,
+    scope: row.scope,
+    orgId: row.org_id,
+    actionType: row.action_type,
+    targetType: row.target_type,
+    targetId: row.target_id,
+    status: row.status,
+    metadata: row.metadata,
+    ipAddress: row.ip_address,
+    requestId: row.request_id,
+  };
+}
+
+function extractFilterParams(queryFn: (key: string) => string | undefined): ActionFilterParams {
+  return {
+    actor: queryFn("actor"),
+    actionType: queryFn("actionType"),
+    targetType: queryFn("targetType"),
+    from: queryFn("from"),
+    to: queryFn("to"),
+    search: queryFn("search"),
+    orgId: queryFn("orgId"),
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Router
@@ -85,57 +178,106 @@ platformActions.openapi(listActionsRoute, async (c) => {
     }
 
     const { limit, offset } = parsePagination(c, { limit: 50, maxLimit: 200 });
+    const filterParams = extractFilterParams((k) => c.req.query(k));
+    const filters = buildActionFilters(1, filterParams);
+
+    if (!filters.ok) {
+      return c.json({ error: filters.error, message: filters.message, requestId }, filters.status);
+    }
+
+    const { conditions, params, paramIdx } = filters;
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
     const [rows, countRows] = yield* Effect.promise(() => Promise.all([
-      internalQuery<{
-        id: string;
-        timestamp: string;
-        actor_id: string;
-        actor_email: string;
-        scope: "platform" | "workspace";
-        org_id: string | null;
-        action_type: string;
-        target_type: string;
-        target_id: string;
-        status: "success" | "failure";
-        metadata: Record<string, unknown> | null;
-        ip_address: string | null;
-        request_id: string;
-      }>(
+      internalQuery<ActionRow>(
         `SELECT id, timestamp, actor_id, actor_email, scope, org_id, action_type, target_type, target_id, status, metadata, ip_address, request_id
          FROM admin_action_log
+         ${whereClause}
          ORDER BY timestamp DESC
-         LIMIT $1 OFFSET $2`,
-        [limit, offset],
+         LIMIT $${paramIdx} OFFSET $${paramIdx + 1}`,
+        [...params, limit, offset],
       ),
       internalQuery<{ count: number }>(
-        `SELECT COUNT(*)::int AS count FROM admin_action_log`,
+        `SELECT COUNT(*)::int AS count FROM admin_action_log ${whereClause}`,
+        params,
       ),
     ]));
 
-    const actions = rows.map((row) => ({
-      id: row.id,
-      timestamp: row.timestamp,
-      actorId: row.actor_id,
-      actorEmail: row.actor_email,
-      scope: row.scope,
-      orgId: row.org_id,
-      actionType: row.action_type,
-      targetType: row.target_type,
-      targetId: row.target_id,
-      status: row.status,
-      metadata: row.metadata,
-      ipAddress: row.ip_address,
-      requestId: row.request_id,
-    }));
-
     return c.json({
-      actions,
+      actions: rows.map(mapActionRow),
       total: countRows[0]?.count ?? 0,
       limit,
       offset,
     }, 200);
   }), { label: "list admin actions" });
+});
+
+// GET /export — CSV export
+platformActions.openapi(exportActionsRoute, async (c) => {
+  return runEffect(c, Effect.gen(function* () {
+    const { requestId } = yield* RequestContext;
+
+    if (!hasInternalDB()) {
+      return c.json({ error: "not_configured", message: "Internal database not configured.", requestId }, 404);
+    }
+
+    const filterParams = extractFilterParams((k) => c.req.query(k));
+    const filters = buildActionFilters(1, filterParams);
+
+    if (!filters.ok) {
+      return c.json({ error: filters.error, message: filters.message, requestId }, filters.status);
+    }
+
+    const { conditions, params, paramIdx } = filters;
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+    const exportLimit = 10000;
+
+    const [countRows, rows] = yield* Effect.promise(() => Promise.all([
+      internalQuery<{ count: number }>(
+        `SELECT COUNT(*)::int AS count FROM admin_action_log ${whereClause}`,
+        params,
+      ),
+      internalQuery<ActionRow>(
+        `SELECT id, timestamp, actor_id, actor_email, scope, org_id, action_type, target_type, target_id, status, metadata, ip_address, request_id
+         FROM admin_action_log
+         ${whereClause}
+         ORDER BY timestamp DESC
+         LIMIT $${paramIdx}`,
+        [...params, exportLimit],
+      ),
+    ]));
+
+    const totalAvailable = countRows[0]?.count ?? 0;
+    const csvHeader = "timestamp,actor_email,action_type,target_type,target_id,scope,org_id,status,metadata,ip_address,request_id\n";
+    const csvRows = rows.map((r) => [
+      csvField(r.timestamp),
+      csvField(r.actor_email),
+      csvField(r.action_type),
+      csvField(r.target_type),
+      csvField(r.target_id),
+      csvField(r.scope),
+      csvField(r.org_id),
+      csvField(r.status),
+      csvField(r.metadata ? JSON.stringify(r.metadata) : null),
+      csvField(r.ip_address),
+      csvField(r.request_id),
+    ].join(","));
+
+    const csv = csvHeader + csvRows.join("\n");
+    const filename = `platform-actions-${new Date().toISOString().slice(0, 10)}.csv`;
+    const truncated = totalAvailable > exportLimit;
+
+    return new Response(csv, {
+      headers: {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+        ...(truncated && {
+          "X-Truncated": "true",
+          "X-Total-Count": String(totalAvailable),
+        }),
+      },
+    });
+  }), { label: "export admin actions" });
 });
 
 export { platformActions };

--- a/packages/api/src/lib/audit/__tests__/filters.test.ts
+++ b/packages/api/src/lib/audit/__tests__/filters.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for the shared admin action filter builder.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { buildActionFilters } from "../filters";
+
+describe("buildActionFilters", () => {
+  it("returns empty conditions when no filters provided", () => {
+    const result = buildActionFilters(1, {});
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.conditions).toEqual([]);
+    expect(result.params).toEqual([]);
+    expect(result.paramIdx).toBe(1);
+  });
+
+  it("builds actor ILIKE filter with partial match", () => {
+    const result = buildActionFilters(1, { actor: "admin" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.conditions).toEqual(["actor_email ILIKE $1"]);
+    expect(result.params).toEqual(["%admin%"]);
+    expect(result.paramIdx).toBe(2);
+  });
+
+  it("builds actionType exact match filter", () => {
+    const result = buildActionFilters(1, { actionType: "settings.update" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.conditions).toEqual(["action_type = $1"]);
+    expect(result.params).toEqual(["settings.update"]);
+  });
+
+  it("builds targetType exact match filter", () => {
+    const result = buildActionFilters(1, { targetType: "connection" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.conditions).toEqual(["target_type = $1"]);
+    expect(result.params).toEqual(["connection"]);
+  });
+
+  it("builds from date filter", () => {
+    const result = buildActionFilters(1, { from: "2026-01-01" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.conditions).toEqual(["timestamp >= $1"]);
+    expect(result.params).toEqual(["2026-01-01"]);
+  });
+
+  it("builds to date filter", () => {
+    const result = buildActionFilters(1, { to: "2026-03-01" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.conditions).toEqual(["timestamp <= $1"]);
+    expect(result.params).toEqual(["2026-03-01"]);
+  });
+
+  it("returns error for invalid from date", () => {
+    const result = buildActionFilters(1, { from: "not-a-date" });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("invalid_request");
+    expect(result.message).toContain("not-a-date");
+    expect(result.status).toBe(400);
+  });
+
+  it("returns error for invalid to date", () => {
+    const result = buildActionFilters(1, { to: "bad-date" });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("invalid_request");
+    expect(result.message).toContain("bad-date");
+    expect(result.status).toBe(400);
+  });
+
+  it("builds search ILIKE filter on metadata", () => {
+    const result = buildActionFilters(1, { search: "test-query" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.conditions).toEqual(["metadata::text ILIKE $1"]);
+    expect(result.params).toEqual(["%test-query%"]);
+  });
+
+  it("escapes ILIKE special characters in search", () => {
+    const result = buildActionFilters(1, { search: "50%" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.params).toEqual(["%50\\%%"]);
+  });
+
+  it("escapes ILIKE special characters in actor", () => {
+    const result = buildActionFilters(1, { actor: "admin_user" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.params).toEqual(["%admin\\_user%"]);
+  });
+
+  it("builds orgId exact match filter", () => {
+    const result = buildActionFilters(1, { orgId: "org-123" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.conditions).toEqual(["org_id = $1"]);
+    expect(result.params).toEqual(["org-123"]);
+  });
+
+  it("composes multiple filters correctly", () => {
+    const result = buildActionFilters(3, {
+      actor: "admin",
+      actionType: "settings.update",
+      targetType: "settings",
+      from: "2026-01-01",
+      to: "2026-03-01",
+      search: "key",
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.conditions).toEqual([
+      "actor_email ILIKE $3",
+      "action_type = $4",
+      "target_type = $5",
+      "timestamp >= $6",
+      "timestamp <= $7",
+      "metadata::text ILIKE $8",
+    ]);
+    expect(result.params).toEqual([
+      "%admin%",
+      "settings.update",
+      "settings",
+      "2026-01-01",
+      "2026-03-01",
+      "%key%",
+    ]);
+    expect(result.paramIdx).toBe(9);
+  });
+
+  it("starts param indexing at the given startIdx", () => {
+    const result = buildActionFilters(5, { actor: "bob" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.conditions).toEqual(["actor_email ILIKE $5"]);
+    expect(result.paramIdx).toBe(6);
+  });
+});

--- a/packages/api/src/lib/audit/filters.ts
+++ b/packages/api/src/lib/audit/filters.ts
@@ -1,0 +1,111 @@
+/**
+ * Shared filter builder for admin action audit list + export endpoints.
+ *
+ * Used by both platform-actions.ts (cross-platform) and admin-actions.ts
+ * (workspace-scoped) to build WHERE clause conditions from query params.
+ *
+ * @module
+ */
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Escape ILIKE special characters so they are matched literally. */
+function escapeIlike(s: string): string {
+  return s.replace(/[%_\\]/g, "\\$&");
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ActionFilterParams {
+  actor?: string;
+  actionType?: string;
+  targetType?: string;
+  from?: string;
+  to?: string;
+  search?: string;
+  orgId?: string;
+}
+
+export type ActionFilterResult =
+  | { ok: true; conditions: string[]; params: unknown[]; paramIdx: number }
+  | { ok: false; error: string; message: string; status: 400 };
+
+// ---------------------------------------------------------------------------
+// Builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build WHERE conditions for admin action list + export endpoints.
+ *
+ * @param startIdx  The positional-parameter index to start at ($N).
+ *                  For example, if the base query already uses $1 for org_id,
+ *                  pass 2 so the first filter becomes $2.
+ * @param filters   Filter values from query params.
+ */
+export function buildActionFilters(
+  startIdx: number,
+  filters: ActionFilterParams,
+): ActionFilterResult {
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+  let paramIdx = startIdx;
+
+  if (filters.actor) {
+    const term = `%${escapeIlike(filters.actor)}%`;
+    conditions.push(`actor_email ILIKE $${paramIdx++}`);
+    params.push(term);
+  }
+
+  if (filters.actionType) {
+    conditions.push(`action_type = $${paramIdx++}`);
+    params.push(filters.actionType);
+  }
+
+  if (filters.targetType) {
+    conditions.push(`target_type = $${paramIdx++}`);
+    params.push(filters.targetType);
+  }
+
+  if (filters.from) {
+    if (isNaN(Date.parse(filters.from))) {
+      return {
+        ok: false,
+        error: "invalid_request",
+        message: `Invalid 'from' date format: "${filters.from}". Use ISO 8601 (e.g. 2026-01-01).`,
+        status: 400,
+      };
+    }
+    conditions.push(`timestamp >= $${paramIdx++}`);
+    params.push(filters.from);
+  }
+
+  if (filters.to) {
+    if (isNaN(Date.parse(filters.to))) {
+      return {
+        ok: false,
+        error: "invalid_request",
+        message: `Invalid 'to' date format: "${filters.to}". Use ISO 8601 (e.g. 2026-03-03).`,
+        status: 400,
+      };
+    }
+    conditions.push(`timestamp <= $${paramIdx++}`);
+    params.push(filters.to);
+  }
+
+  if (filters.search) {
+    const term = `%${escapeIlike(filters.search)}%`;
+    conditions.push(`metadata::text ILIKE $${paramIdx++}`);
+    params.push(term);
+  }
+
+  if (filters.orgId) {
+    conditions.push(`org_id = $${paramIdx++}`);
+    params.push(filters.orgId);
+  }
+
+  return { ok: true, conditions, params, paramIdx };
+}

--- a/packages/web/src/app/admin/admin-actions/page.tsx
+++ b/packages/web/src/app/admin/admin-actions/page.tsx
@@ -22,6 +22,7 @@ import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAtlasConfig } from "@/ui/context";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
+import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import {
   ChevronLeft,
   ChevronRight,
@@ -30,6 +31,7 @@ import {
   Search,
   X,
 } from "lucide-react";
+import { useState } from "react";
 import { useQueryStates } from "nuqs";
 import { z } from "zod";
 import { adminActionsSearchParams } from "./search-params";
@@ -146,7 +148,10 @@ function buildFilterQueryString(params: Record<string, string>): string {
 const PAGE_SIZE = 50;
 
 function AdminActionsPageContent() {
-  const { apiUrl } = useAtlasConfig();
+  const { apiUrl, isCrossOrigin } = useAtlasConfig();
+  const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
   const [params, setParams] = useQueryStates(adminActionsSearchParams);
   const offset = (params.page - 1) * PAGE_SIZE;
 
@@ -175,17 +180,38 @@ function AdminActionsPageContent() {
     setParams({ actor: "", actionType: "", targetType: "", from: "", to: "", search: "", page: 1 });
   }
 
-  function handleExport() {
-    const exportQs = buildFilterQueryString({
-      actor: params.actor,
-      actionType: params.actionType,
-      targetType: params.targetType,
-      from: params.from,
-      to: params.to,
-      search: params.search,
-    });
-    const url = `${apiUrl}/api/v1/admin/admin-actions/export${exportQs ? `?${exportQs}` : ""}`;
-    window.open(url, "_blank");
+  async function handleExport() {
+    setExporting(true);
+    setExportError(null);
+    try {
+      const exportQs = buildFilterQueryString({
+        actor: params.actor,
+        actionType: params.actionType,
+        targetType: params.targetType,
+        from: params.from,
+        to: params.to,
+        search: params.search,
+      });
+      const res = await fetch(
+        `${apiUrl}/api/v1/admin/admin-actions/export${exportQs ? `?${exportQs}` : ""}`,
+        { credentials },
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.message ?? `Export failed (${res.status})`);
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `admin-actions-${new Date().toISOString().slice(0, 10)}.csv`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setExportError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setExporting(false);
+    }
   }
 
   return (
@@ -202,12 +228,19 @@ function AdminActionsPageContent() {
           size="sm"
           className="h-9"
           onClick={handleExport}
-          disabled={loading}
+          disabled={loading || exporting}
         >
           <Download className="mr-1.5 size-3.5" />
-          Export CSV
+          {exporting ? "Exporting\u2026" : "Export CSV"}
         </Button>
       </div>
+
+      {exportError && (
+        <ErrorBanner
+          message={exportError}
+          onRetry={() => { setExportError(null); handleExport(); }}
+        />
+      )}
 
       {/* Filter bar */}
       <div className="flex flex-wrap items-end gap-3">

--- a/packages/web/src/app/admin/admin-actions/page.tsx
+++ b/packages/web/src/app/admin/admin-actions/page.tsx
@@ -2,6 +2,14 @@
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import {
   Table,
   TableBody,
@@ -12,11 +20,15 @@ import {
 } from "@/components/ui/table";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
+import { useAtlasConfig } from "@/ui/context";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import {
   ChevronLeft,
   ChevronRight,
   ClipboardList,
+  Download,
+  Search,
+  X,
 } from "lucide-react";
 import { useQueryStates } from "nuqs";
 import { z } from "zod";
@@ -52,6 +64,43 @@ const ActionsResponseSchema = z.object({
 type AdminAction = z.infer<typeof AdminActionSchema>;
 
 // ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ACTION_TYPE_OPTIONS = [
+  { value: "settings.update", label: "settings.update" },
+  { value: "connection.create", label: "connection.create" },
+  { value: "connection.update", label: "connection.update" },
+  { value: "connection.delete", label: "connection.delete" },
+  { value: "user.invite", label: "user.invite" },
+  { value: "user.remove", label: "user.remove" },
+  { value: "user.change_role", label: "user.change_role" },
+  { value: "sso.configure", label: "sso.configure" },
+  { value: "semantic.create_entity", label: "semantic.create_entity" },
+  { value: "semantic.update_entity", label: "semantic.update_entity" },
+  { value: "semantic.delete_entity", label: "semantic.delete_entity" },
+  { value: "pattern.approve", label: "pattern.approve" },
+  { value: "pattern.reject", label: "pattern.reject" },
+  { value: "integration.enable", label: "integration.enable" },
+  { value: "integration.disable", label: "integration.disable" },
+  { value: "apikey.create", label: "apikey.create" },
+  { value: "apikey.revoke", label: "apikey.revoke" },
+];
+
+const TARGET_TYPE_OPTIONS = [
+  { value: "connection", label: "Connection" },
+  { value: "user", label: "User" },
+  { value: "settings", label: "Settings" },
+  { value: "sso", label: "SSO" },
+  { value: "semantic", label: "Semantic" },
+  { value: "pattern", label: "Pattern" },
+  { value: "integration", label: "Integration" },
+  { value: "apikey", label: "API Key" },
+  { value: "schedule", label: "Schedule" },
+  { value: "approval", label: "Approval" },
+];
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -82,6 +131,14 @@ function metadataPreview(metadata: Record<string, unknown> | null): string {
   return entries.map(([k, v]) => `${k}: ${String(v)}`).join(", ");
 }
 
+function buildFilterQueryString(params: Record<string, string>): string {
+  const qs = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v) qs.set(k, v);
+  }
+  return qs.toString();
+}
+
 // ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
@@ -89,11 +146,21 @@ function metadataPreview(metadata: Record<string, unknown> | null): string {
 const PAGE_SIZE = 50;
 
 function AdminActionsPageContent() {
+  const { apiUrl } = useAtlasConfig();
   const [params, setParams] = useQueryStates(adminActionsSearchParams);
   const offset = (params.page - 1) * PAGE_SIZE;
 
+  const filterQs = buildFilterQueryString({
+    actor: params.actor,
+    actionType: params.actionType,
+    targetType: params.targetType,
+    from: params.from,
+    to: params.to,
+    search: params.search,
+  });
+
   const { data, loading, error, refetch } = useAdminFetch(
-    `/api/v1/admin/admin-actions?limit=${PAGE_SIZE}&offset=${offset}`,
+    `/api/v1/admin/admin-actions?limit=${PAGE_SIZE}&offset=${offset}${filterQs ? `&${filterQs}` : ""}`,
     { schema: ActionsResponseSchema },
   );
 
@@ -102,13 +169,116 @@ function AdminActionsPageContent() {
   const hasNext = offset + PAGE_SIZE < total;
   const hasPrev = offset > 0;
 
+  const hasFilters = !!(params.actor || params.actionType || params.targetType || params.from || params.to || params.search);
+
+  function clearFilters() {
+    setParams({ actor: "", actionType: "", targetType: "", from: "", to: "", search: "", page: 1 });
+  }
+
+  function handleExport() {
+    const exportQs = buildFilterQueryString({
+      actor: params.actor,
+      actionType: params.actionType,
+      targetType: params.targetType,
+      from: params.from,
+      to: params.to,
+      search: params.search,
+    });
+    const url = `${apiUrl}/api/v1/admin/admin-actions/export${exportQs ? `?${exportQs}` : ""}`;
+    window.open(url, "_blank");
+  }
+
   return (
     <div className="space-y-6">
-      <div>
-        <h2 className="text-2xl font-bold tracking-tight">Admin Action Log</h2>
-        <p className="text-muted-foreground">
-          Admin actions performed in this workspace. {total > 0 && `${total} total entries.`}
-        </p>
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight">Admin Action Log</h2>
+          <p className="text-muted-foreground">
+            Admin actions performed in this workspace. {total > 0 && `${total} total entries.`}
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-9"
+          onClick={handleExport}
+          disabled={loading}
+        >
+          <Download className="mr-1.5 size-3.5" />
+          Export CSV
+        </Button>
+      </div>
+
+      {/* Filter bar */}
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="relative flex-1 min-w-[180px] max-w-xs">
+          <Search className="absolute left-2.5 top-2.5 size-3.5 text-muted-foreground" />
+          <Input
+            placeholder="Search metadata..."
+            value={params.search}
+            onChange={(e) => setParams({ search: e.target.value, page: 1 })}
+            className="h-9 pl-8"
+          />
+        </div>
+
+        <Input
+          placeholder="Actor email..."
+          value={params.actor}
+          onChange={(e) => setParams({ actor: e.target.value, page: 1 })}
+          className="h-9 w-44"
+        />
+
+        <Select
+          value={params.actionType || "__all__"}
+          onValueChange={(v) => setParams({ actionType: v === "__all__" ? "" : v, page: 1 })}
+        >
+          <SelectTrigger className="h-9 w-48" aria-label="Filter by action type">
+            <SelectValue placeholder="All action types" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">All action types</SelectItem>
+            {ACTION_TYPE_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={params.targetType || "__all__"}
+          onValueChange={(v) => setParams({ targetType: v === "__all__" ? "" : v, page: 1 })}
+        >
+          <SelectTrigger className="h-9 w-40" aria-label="Filter by target type">
+            <SelectValue placeholder="All targets" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">All targets</SelectItem>
+            {TARGET_TYPE_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Input
+          type="date"
+          value={params.from}
+          onChange={(e) => setParams({ from: e.target.value, page: 1 })}
+          className="h-9 w-36"
+          aria-label="From date"
+        />
+        <Input
+          type="date"
+          value={params.to}
+          onChange={(e) => setParams({ to: e.target.value, page: 1 })}
+          className="h-9 w-36"
+          aria-label="To date"
+        />
+
+        {hasFilters && (
+          <Button variant="ghost" size="sm" className="h-9" onClick={clearFilters}>
+            <X className="mr-1.5 size-3.5" />
+            Clear
+          </Button>
+        )}
       </div>
 
       <AdminContentWrapper
@@ -121,6 +291,8 @@ function AdminActionsPageContent() {
         emptyTitle="No admin actions recorded"
         emptyDescription="Admin actions will appear here once workspace mutations are performed."
         isEmpty={actions.length === 0}
+        hasFilters={hasFilters}
+        onClearFilters={clearFilters}
       >
         <div className="rounded-md border">
           <Table>

--- a/packages/web/src/app/admin/platform/actions/page.tsx
+++ b/packages/web/src/app/admin/platform/actions/page.tsx
@@ -22,6 +22,7 @@ import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAtlasConfig } from "@/ui/context";
 import { usePlatformAdminGuard } from "@/ui/hooks/use-platform-admin-guard";
+import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import {
   ChevronLeft,
@@ -31,6 +32,7 @@ import {
   Search,
   X,
 } from "lucide-react";
+import { useState } from "react";
 import { useQueryStates } from "nuqs";
 import { z } from "zod";
 import { platformActionsSearchParams } from "./search-params";
@@ -154,7 +156,10 @@ function buildFilterQueryString(params: Record<string, string>): string {
 const PAGE_SIZE = 50;
 
 function ActionsPageContent() {
-  const { apiUrl } = useAtlasConfig();
+  const { apiUrl, isCrossOrigin } = useAtlasConfig();
+  const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
   const [params, setParams] = useQueryStates(platformActionsSearchParams);
   const offset = (params.page - 1) * PAGE_SIZE;
 
@@ -184,18 +189,39 @@ function ActionsPageContent() {
     setParams({ actor: "", actionType: "", targetType: "", from: "", to: "", search: "", orgId: "", page: 1 });
   }
 
-  function handleExport() {
-    const exportQs = buildFilterQueryString({
-      actor: params.actor,
-      actionType: params.actionType,
-      targetType: params.targetType,
-      from: params.from,
-      to: params.to,
-      search: params.search,
-      orgId: params.orgId,
-    });
-    const url = `${apiUrl}/api/v1/platform/actions/export${exportQs ? `?${exportQs}` : ""}`;
-    window.open(url, "_blank");
+  async function handleExport() {
+    setExporting(true);
+    setExportError(null);
+    try {
+      const exportQs = buildFilterQueryString({
+        actor: params.actor,
+        actionType: params.actionType,
+        targetType: params.targetType,
+        from: params.from,
+        to: params.to,
+        search: params.search,
+        orgId: params.orgId,
+      });
+      const res = await fetch(
+        `${apiUrl}/api/v1/platform/actions/export${exportQs ? `?${exportQs}` : ""}`,
+        { credentials },
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.message ?? `Export failed (${res.status})`);
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `platform-actions-${new Date().toISOString().slice(0, 10)}.csv`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setExportError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setExporting(false);
+    }
   }
 
   return (
@@ -212,12 +238,19 @@ function ActionsPageContent() {
           size="sm"
           className="h-9"
           onClick={handleExport}
-          disabled={loading}
+          disabled={loading || exporting}
         >
           <Download className="mr-1.5 size-3.5" />
-          Export CSV
+          {exporting ? "Exporting\u2026" : "Export CSV"}
         </Button>
       </div>
+
+      {exportError && (
+        <ErrorBanner
+          message={exportError}
+          onRetry={() => { setExportError(null); handleExport(); }}
+        />
+      )}
 
       {/* Filter bar */}
       <div className="flex flex-wrap items-end gap-3">

--- a/packages/web/src/app/admin/platform/actions/page.tsx
+++ b/packages/web/src/app/admin/platform/actions/page.tsx
@@ -2,6 +2,14 @@
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import {
   Table,
   TableBody,
@@ -12,15 +20,20 @@ import {
 } from "@/components/ui/table";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
+import { useAtlasConfig } from "@/ui/context";
 import { usePlatformAdminGuard } from "@/ui/hooks/use-platform-admin-guard";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import {
   ChevronLeft,
   ChevronRight,
   ClipboardList,
+  Download,
+  Search,
+  X,
 } from "lucide-react";
-import { useState } from "react";
+import { useQueryStates } from "nuqs";
 import { z } from "zod";
+import { platformActionsSearchParams } from "./search-params";
 
 // ---------------------------------------------------------------------------
 // Schema
@@ -52,6 +65,44 @@ const ActionsResponseSchema = z.object({
 type AdminAction = z.infer<typeof AdminActionSchema>;
 
 // ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ACTION_TYPE_OPTIONS = [
+  { value: "workspace.suspend", label: "workspace.suspend" },
+  { value: "workspace.unsuspend", label: "workspace.unsuspend" },
+  { value: "workspace.delete", label: "workspace.delete" },
+  { value: "connection.create", label: "connection.create" },
+  { value: "connection.update", label: "connection.update" },
+  { value: "connection.delete", label: "connection.delete" },
+  { value: "user.invite", label: "user.invite" },
+  { value: "user.remove", label: "user.remove" },
+  { value: "user.change_role", label: "user.change_role" },
+  { value: "settings.update", label: "settings.update" },
+  { value: "sso.configure", label: "sso.configure" },
+  { value: "semantic.create_entity", label: "semantic.create_entity" },
+  { value: "semantic.update_entity", label: "semantic.update_entity" },
+  { value: "pattern.approve", label: "pattern.approve" },
+  { value: "integration.enable", label: "integration.enable" },
+  { value: "apikey.create", label: "apikey.create" },
+  { value: "apikey.revoke", label: "apikey.revoke" },
+];
+
+const TARGET_TYPE_OPTIONS = [
+  { value: "workspace", label: "Workspace" },
+  { value: "connection", label: "Connection" },
+  { value: "user", label: "User" },
+  { value: "settings", label: "Settings" },
+  { value: "sso", label: "SSO" },
+  { value: "semantic", label: "Semantic" },
+  { value: "pattern", label: "Pattern" },
+  { value: "integration", label: "Integration" },
+  { value: "apikey", label: "API Key" },
+  { value: "schedule", label: "Schedule" },
+  { value: "approval", label: "Approval" },
+];
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -65,6 +116,7 @@ function formatTimestamp(iso: string): string {
       second: "2-digit",
     });
   } catch {
+    // intentionally ignored: invalid date string — fall back to raw ISO
     return iso;
   }
 }
@@ -82,9 +134,17 @@ function statusBadge(status: string) {
 }
 
 function metadataPreview(metadata: Record<string, unknown> | null): string {
-  if (!metadata) return "—";
+  if (!metadata) return "\u2014";
   const entries = Object.entries(metadata).slice(0, 3);
   return entries.map(([k, v]) => `${k}: ${String(v)}`).join(", ");
+}
+
+function buildFilterQueryString(params: Record<string, string>): string {
+  const qs = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v) qs.set(k, v);
+  }
+  return qs.toString();
 }
 
 // ---------------------------------------------------------------------------
@@ -94,10 +154,22 @@ function metadataPreview(metadata: Record<string, unknown> | null): string {
 const PAGE_SIZE = 50;
 
 function ActionsPageContent() {
-  const [offset, setOffset] = useState(0);
+  const { apiUrl } = useAtlasConfig();
+  const [params, setParams] = useQueryStates(platformActionsSearchParams);
+  const offset = (params.page - 1) * PAGE_SIZE;
+
+  const filterQs = buildFilterQueryString({
+    actor: params.actor,
+    actionType: params.actionType,
+    targetType: params.targetType,
+    from: params.from,
+    to: params.to,
+    search: params.search,
+    orgId: params.orgId,
+  });
 
   const { data, loading, error, refetch } = useAdminFetch(
-    `/api/v1/platform/actions?limit=${PAGE_SIZE}&offset=${offset}`,
+    `/api/v1/platform/actions?limit=${PAGE_SIZE}&offset=${offset}${filterQs ? `&${filterQs}` : ""}`,
     { schema: ActionsResponseSchema },
   );
 
@@ -106,13 +178,117 @@ function ActionsPageContent() {
   const hasNext = offset + PAGE_SIZE < total;
   const hasPrev = offset > 0;
 
+  const hasFilters = !!(params.actor || params.actionType || params.targetType || params.from || params.to || params.search || params.orgId);
+
+  function clearFilters() {
+    setParams({ actor: "", actionType: "", targetType: "", from: "", to: "", search: "", orgId: "", page: 1 });
+  }
+
+  function handleExport() {
+    const exportQs = buildFilterQueryString({
+      actor: params.actor,
+      actionType: params.actionType,
+      targetType: params.targetType,
+      from: params.from,
+      to: params.to,
+      search: params.search,
+      orgId: params.orgId,
+    });
+    const url = `${apiUrl}/api/v1/platform/actions/export${exportQs ? `?${exportQs}` : ""}`;
+    window.open(url, "_blank");
+  }
+
   return (
     <div className="space-y-6">
-      <div>
-        <h2 className="text-2xl font-bold tracking-tight">Action Log</h2>
-        <p className="text-muted-foreground">
-          All admin actions across the platform. {total > 0 && `${total} total entries.`}
-        </p>
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight">Action Log</h2>
+          <p className="text-muted-foreground">
+            All admin actions across the platform. {total > 0 && `${total} total entries.`}
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-9"
+          onClick={handleExport}
+          disabled={loading}
+        >
+          <Download className="mr-1.5 size-3.5" />
+          Export CSV
+        </Button>
+      </div>
+
+      {/* Filter bar */}
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="relative flex-1 min-w-[180px] max-w-xs">
+          <Search className="absolute left-2.5 top-2.5 size-3.5 text-muted-foreground" />
+          <Input
+            placeholder="Search metadata..."
+            value={params.search}
+            onChange={(e) => setParams({ search: e.target.value, page: 1 })}
+            className="h-9 pl-8"
+          />
+        </div>
+
+        <Input
+          placeholder="Actor email..."
+          value={params.actor}
+          onChange={(e) => setParams({ actor: e.target.value, page: 1 })}
+          className="h-9 w-44"
+        />
+
+        <Select
+          value={params.actionType || "__all__"}
+          onValueChange={(v) => setParams({ actionType: v === "__all__" ? "" : v, page: 1 })}
+        >
+          <SelectTrigger className="h-9 w-48" aria-label="Filter by action type">
+            <SelectValue placeholder="All action types" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">All action types</SelectItem>
+            {ACTION_TYPE_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={params.targetType || "__all__"}
+          onValueChange={(v) => setParams({ targetType: v === "__all__" ? "" : v, page: 1 })}
+        >
+          <SelectTrigger className="h-9 w-40" aria-label="Filter by target type">
+            <SelectValue placeholder="All targets" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">All targets</SelectItem>
+            {TARGET_TYPE_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Input
+          type="date"
+          value={params.from}
+          onChange={(e) => setParams({ from: e.target.value, page: 1 })}
+          className="h-9 w-36"
+          aria-label="From date"
+        />
+        <Input
+          type="date"
+          value={params.to}
+          onChange={(e) => setParams({ to: e.target.value, page: 1 })}
+          className="h-9 w-36"
+          aria-label="To date"
+        />
+
+        {hasFilters && (
+          <Button variant="ghost" size="sm" className="h-9" onClick={clearFilters}>
+            <X className="mr-1.5 size-3.5" />
+            Clear
+          </Button>
+        )}
       </div>
 
       <AdminContentWrapper
@@ -120,11 +296,13 @@ function ActionsPageContent() {
         error={error}
         feature="Action Log"
         onRetry={refetch}
-        loadingMessage="Loading action log…"
+        loadingMessage="Loading action log\u2026"
         emptyIcon={ClipboardList}
         emptyTitle="No actions recorded"
         emptyDescription="Admin actions will appear here once platform or workspace mutations are performed."
         isEmpty={actions.length === 0}
+        hasFilters={hasFilters}
+        onClearFilters={clearFilters}
       >
         <div className="rounded-md border">
           <Table>
@@ -169,14 +347,14 @@ function ActionsPageContent() {
         {total > PAGE_SIZE && (
           <div className="flex items-center justify-between pt-4">
             <p className="text-sm text-muted-foreground">
-              Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}
+              Showing {offset + 1}\u2013{Math.min(offset + PAGE_SIZE, total)} of {total}
             </p>
             <div className="flex gap-2">
               <Button
                 variant="outline"
                 size="sm"
                 disabled={!hasPrev}
-                onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+                onClick={() => setParams({ page: Math.max(1, params.page - 1) })}
               >
                 <ChevronLeft className="size-4 mr-1" />
                 Previous
@@ -185,7 +363,7 @@ function ActionsPageContent() {
                 variant="outline"
                 size="sm"
                 disabled={!hasNext}
-                onClick={() => setOffset(offset + PAGE_SIZE)}
+                onClick={() => setParams({ page: params.page + 1 })}
               >
                 Next
                 <ChevronRight className="size-4 ml-1" />

--- a/packages/web/src/app/admin/platform/actions/search-params.ts
+++ b/packages/web/src/app/admin/platform/actions/search-params.ts
@@ -1,6 +1,6 @@
 import { parseAsInteger, parseAsString } from "nuqs";
 
-export const adminActionsSearchParams = {
+export const platformActionsSearchParams = {
   page: parseAsInteger.withDefault(1),
   actor: parseAsString.withDefault(""),
   actionType: parseAsString.withDefault(""),
@@ -8,4 +8,5 @@ export const adminActionsSearchParams = {
   from: parseAsString.withDefault(""),
   to: parseAsString.withDefault(""),
   search: parseAsString.withDefault(""),
+  orgId: parseAsString.withDefault(""),
 };


### PR DESCRIPTION
## Summary
- **Bug fix (#1386)**: Add missing `invalidateExploreBackend`, `markNsjailFailed`, `markSidecarFailed` exports to explore mocks in `api-test-mocks.ts` and `cors-origin.test.ts`. Also add missing connection mock + `explore` export to `cors-origin.test.ts`.
- **Feature (#1366)**: Add filtering and CSV export to both platform (`/api/v1/platform/actions`) and workspace (`/api/v1/admin/admin-actions`) admin action audit endpoints.
- Shared `buildActionFilters()` helper in `lib/audit/filters.ts` builds parameterized WHERE conditions from actor, actionType, targetType, date range, metadata search, and orgId filters.
- CSV export endpoints cap at 10,000 rows with `X-Truncated` / `X-Total-Count` headers when truncated, RFC 4180 format.
- Both frontend pages get filter bars (actor email, action type select, target type select, date range, free-text metadata search) and "Export CSV" button, all driven by nuqs URL state.
- 58 tests across 4 files (14 filter helper, 19 platform actions, 22 admin actions, 3 cors-origin).

## Test plan
- [x] `bun run type` passes (no new errors)
- [x] `bun run lint` passes
- [x] `bun test filters.test.ts` — 14 pass
- [x] `bun test platform-actions.test.ts` — 19 pass
- [x] `bun test admin-actions.test.ts` — 22 pass
- [x] `bun test cors-origin.test.ts` — 3 pass (bug fix verified)
- [ ] Manual: verify filter bar appears on both admin action pages
- [ ] Manual: verify Export CSV downloads filtered results
- [ ] Manual: verify pagination resets to page 1 when filters change

Fixes #1386. Closes #1366.