### PR TITLE
fix: persist and reconstruct tool results in loaded conversations

### DIFF
--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -535,17 +535,25 @@ chat.openapi(chatRoute, async (c) => {
                     }
                     if (step.toolResults) {
                       for (const tr of step.toolResults) {
-                        content.push({
-                          type: "tool-invocation",
-                          toolCallId: tr.toolCallId,
-                          toolName: tr.toolName,
-                          args: tr.input,
-                          result: tr.output,
-                        });
+                        try {
+                          content.push({
+                            type: "tool-invocation",
+                            toolCallId: tr.toolCallId,
+                            toolName: tr.toolName,
+                            args: tr.input,
+                            result: tr.output,
+                          });
+                        } catch (trErr) {
+                          log.warn(
+                            { err: trErr instanceof Error ? trErr.message : String(trErr), conversationId: cid },
+                            "Skipped malformed tool result during persistence",
+                          );
+                        }
                       }
                     }
                   }
                   if (content.length === 0) {
+                    log.warn({ conversationId: cid, stepCount: steps.length }, "Agent produced no text or tool results — persisting empty message");
                     content.push({ type: "text", text: "" });
                   }
                   addMessage({ conversationId: cid, role: "assistant", content });

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -522,13 +522,33 @@ chat.openapi(chatRoute, async (c) => {
               });
           }
   
-          // Fire-and-forget: persist assistant response after stream completes.
+          // Fire-and-forget: persist assistant response (text + tool results) after stream completes.
           if (conversationId) {
             const cid = conversationId;
-            void Promise.resolve(agentResult.text)
-              .then((text) => {
+            void Promise.resolve(agentResult.steps)
+              .then((steps) => {
                 try {
-                  addMessage({ conversationId: cid, role: "assistant", content: [{ type: "text", text }] });
+                  const content: unknown[] = [];
+                  for (const step of steps) {
+                    if (step.text) {
+                      content.push({ type: "text", text: step.text });
+                    }
+                    if (step.toolResults) {
+                      for (const tr of step.toolResults) {
+                        content.push({
+                          type: "tool-invocation",
+                          toolCallId: tr.toolCallId,
+                          toolName: tr.toolName,
+                          args: tr.input,
+                          result: tr.output,
+                        });
+                      }
+                    }
+                  }
+                  if (content.length === 0) {
+                    content.push({ type: "text", text: "" });
+                  }
+                  addMessage({ conversationId: cid, role: "assistant", content });
                 } catch (persistErr) {
                   log.warn({ err: persistErr instanceof Error ? persistErr.message : String(persistErr), conversationId: cid }, "Failed to persist assistant message");
                 }

--- a/packages/react/src/hooks/use-conversations.ts
+++ b/packages/react/src/hooks/use-conversations.ts
@@ -36,12 +36,14 @@ export function transformMessages(messages: Message[]): UIMessage[] {
       const parts: UIMessage["parts"] = Array.isArray(m.content)
         ? (m.content as Record<string, unknown>[])
             .filter((p) => p.type === "text" || p.type === "tool-invocation")
-            .map((p) => {
+            .map((p, idx) => {
               if (p.type === "tool-invocation") {
-                const toolCallId = String(p.toolCallId ?? "");
+                const toolCallId = typeof p.toolCallId === "string" && p.toolCallId
+                  ? p.toolCallId
+                  : `unknown-${idx}`;
                 return {
                   type: "dynamic-tool" as const,
-                  toolName: String(p.toolName ?? ""),
+                  toolName: typeof p.toolName === "string" ? p.toolName : "unknown",
                   toolCallId,
                   toolInvocationId: toolCallId,
                   state: "output-available" as const,
@@ -49,7 +51,7 @@ export function transformMessages(messages: Message[]): UIMessage[] {
                   output: p.result,
                 };
               }
-              return { type: "text" as const, text: String((p as { text?: string }).text ?? "") };
+              return { type: "text" as const, text: String(p.text ?? "") };
             })
         : [{ type: "text" as const, text: String(m.content) }];
 

--- a/packages/react/src/hooks/use-conversations.ts
+++ b/packages/react/src/hooks/use-conversations.ts
@@ -34,9 +34,23 @@ export function transformMessages(messages: Message[]): UIMessage[] {
     .filter((m) => m.role === "user" || m.role === "assistant")
     .map((m) => {
       const parts: UIMessage["parts"] = Array.isArray(m.content)
-        ? m.content
-            .filter((p: { type?: string }) => p.type === "text")
-            .map((p: { text?: string }) => ({ type: "text" as const, text: p.text ?? "" }))
+        ? (m.content as Record<string, unknown>[])
+            .filter((p) => p.type === "text" || p.type === "tool-invocation")
+            .map((p) => {
+              if (p.type === "tool-invocation") {
+                const toolCallId = String(p.toolCallId ?? "");
+                return {
+                  type: "dynamic-tool" as const,
+                  toolName: String(p.toolName ?? ""),
+                  toolCallId,
+                  toolInvocationId: toolCallId,
+                  state: "output-available" as const,
+                  input: p.args,
+                  output: p.result,
+                };
+              }
+              return { type: "text" as const, text: String((p as { text?: string }).text ?? "") };
+            })
         : [{ type: "text" as const, text: String(m.content) }];
 
       return {

--- a/packages/web/src/ui/__tests__/use-conversations.test.ts
+++ b/packages/web/src/ui/__tests__/use-conversations.test.ts
@@ -66,16 +66,58 @@ describe("transformMessages", () => {
     ]);
   });
 
-  test("filters out non-text parts from content array", () => {
+  test("reconstructs tool-invocation parts as DynamicToolUIPart", () => {
     const messages: Message[] = [
       msg({ id: "1", role: "assistant", content: [
-        { type: "text", text: "answer" },
-        { type: "tool-invocation", toolName: "executeSQL" },
+        { type: "tool-invocation", toolCallId: "tc1", toolName: "executeSQL", args: { sql: "SELECT 1" }, result: { columns: ["?column?"], rows: [{ "?column?": 1 }] } },
       ] }),
     ];
 
     const result = transformMessages(messages);
-    expect(result[0].parts).toEqual([{ type: "text", text: "answer" }]);
+    expect(result[0].parts).toEqual([
+      {
+        type: "dynamic-tool",
+        toolName: "executeSQL",
+        toolCallId: "tc1",
+        toolInvocationId: "tc1",
+        state: "output-available",
+        input: { sql: "SELECT 1" },
+        output: { columns: ["?column?"], rows: [{ "?column?": 1 }] },
+      },
+    ]);
+  });
+
+  test("handles mixed text and tool-invocation parts", () => {
+    const messages: Message[] = [
+      msg({ id: "1", role: "assistant", content: [
+        { type: "text", text: "Let me run that query." },
+        { type: "tool-invocation", toolCallId: "tc1", toolName: "executeSQL", args: { sql: "SELECT 1" }, result: { columns: ["n"], rows: [{ n: 1 }] } },
+        { type: "text", text: "Here are the results." },
+      ] }),
+    ];
+
+    const result = transformMessages(messages);
+    expect(result[0].parts).toHaveLength(3);
+    expect(result[0].parts[0]).toEqual({ type: "text", text: "Let me run that query." });
+    expect(result[0].parts[1]).toEqual({
+      type: "dynamic-tool",
+      toolName: "executeSQL",
+      toolCallId: "tc1",
+      toolInvocationId: "tc1",
+      state: "output-available",
+      input: { sql: "SELECT 1" },
+      output: { columns: ["n"], rows: [{ n: 1 }] },
+    });
+    expect(result[0].parts[2]).toEqual({ type: "text", text: "Here are the results." });
+  });
+
+  test("falls back gracefully for old conversations with only text parts", () => {
+    const messages: Message[] = [
+      msg({ id: "1", role: "assistant", content: [{ type: "text", text: "old format answer" }] }),
+    ];
+
+    const result = transformMessages(messages);
+    expect(result[0].parts).toEqual([{ type: "text", text: "old format answer" }]);
   });
 
   test("preserves string content as-is", () => {

--- a/packages/web/src/ui/__tests__/use-conversations.test.ts
+++ b/packages/web/src/ui/__tests__/use-conversations.test.ts
@@ -111,6 +111,37 @@ describe("transformMessages", () => {
     expect(result[0].parts[2]).toEqual({ type: "text", text: "Here are the results." });
   });
 
+  test("filters out unknown content part types", () => {
+    const messages: Message[] = [
+      msg({ id: "1", role: "assistant", content: [
+        { type: "text", text: "hello" },
+        { type: "image", url: "https://example.com/img.png" },
+        { type: "reasoning", text: "thinking..." },
+      ] }),
+    ];
+
+    const result = transformMessages(messages);
+    expect(result[0].parts).toEqual([{ type: "text", text: "hello" }]);
+  });
+
+  test("handles tool-invocation with missing fields", () => {
+    const messages: Message[] = [
+      msg({ id: "1", role: "assistant", content: [
+        { type: "tool-invocation" },
+      ] }),
+    ];
+
+    const result = transformMessages(messages);
+    const part = result[0].parts[0] as Record<string, unknown>;
+    expect(part.type).toBe("dynamic-tool");
+    expect(part.toolName).toBe("unknown");
+    expect(part.toolCallId).toBe("unknown-0");
+    expect(part.toolInvocationId).toBe("unknown-0");
+    expect(part.state).toBe("output-available");
+    expect(part.input).toBeUndefined();
+    expect(part.output).toBeUndefined();
+  });
+
   test("falls back gracefully for old conversations with only text parts", () => {
     const messages: Message[] = [
       msg({ id: "1", role: "assistant", content: [{ type: "text", text: "old format answer" }] }),

--- a/packages/web/src/ui/components/notebook/notebook-cell-output.tsx
+++ b/packages/web/src/ui/components/notebook/notebook-cell-output.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { UIMessage } from "@ai-sdk/react";
+import { isToolUIPart } from "ai";
 import type { CellStatus } from "./types";
 import { ToolPart } from "@/ui/components/chat/tool-part";
 import { Markdown } from "@/ui/components/chat/markdown";
@@ -48,7 +49,7 @@ export function NotebookCellOutput({ assistantMessage, status, collapsed }: Cell
           const displayText = parseSuggestions(part.text).text;
           return <Markdown key={i} content={displayText} />;
         }
-        if (part.type === "tool-invocation") {
+        if (isToolUIPart(part)) {
           return <ToolPart key={i} part={part} />;
         }
         return null;

--- a/packages/web/src/ui/hooks/use-conversations.ts
+++ b/packages/web/src/ui/hooks/use-conversations.ts
@@ -39,9 +39,23 @@ export function transformMessages(messages: Message[]): UIMessage[] {
     .filter((m) => m.role === "user" || m.role === "assistant")
     .map((m) => {
       const parts: UIMessage["parts"] = Array.isArray(m.content)
-        ? m.content
-            .filter((p: { type?: string }) => p.type === "text")
-            .map((p: { text?: string }) => ({ type: "text" as const, text: p.text ?? "" }))
+        ? (m.content as Record<string, unknown>[])
+            .filter((p) => p.type === "text" || p.type === "tool-invocation")
+            .map((p) => {
+              if (p.type === "tool-invocation") {
+                const toolCallId = String(p.toolCallId ?? "");
+                return {
+                  type: "dynamic-tool" as const,
+                  toolName: String(p.toolName ?? ""),
+                  toolCallId,
+                  toolInvocationId: toolCallId,
+                  state: "output-available" as const,
+                  input: p.args,
+                  output: p.result,
+                };
+              }
+              return { type: "text" as const, text: String((p as { text?: string }).text ?? "") };
+            })
         : [{ type: "text" as const, text: String(m.content) }];
 
       return {

--- a/packages/web/src/ui/hooks/use-conversations.ts
+++ b/packages/web/src/ui/hooks/use-conversations.ts
@@ -41,12 +41,14 @@ export function transformMessages(messages: Message[]): UIMessage[] {
       const parts: UIMessage["parts"] = Array.isArray(m.content)
         ? (m.content as Record<string, unknown>[])
             .filter((p) => p.type === "text" || p.type === "tool-invocation")
-            .map((p) => {
+            .map((p, idx) => {
               if (p.type === "tool-invocation") {
-                const toolCallId = String(p.toolCallId ?? "");
+                const toolCallId = typeof p.toolCallId === "string" && p.toolCallId
+                  ? p.toolCallId
+                  : `unknown-${idx}`;
                 return {
                   type: "dynamic-tool" as const,
-                  toolName: String(p.toolName ?? ""),
+                  toolName: typeof p.toolName === "string" ? p.toolName : "unknown",
                   toolCallId,
                   toolInvocationId: toolCallId,
                   state: "output-available" as const,
@@ -54,7 +56,7 @@ export function transformMessages(messages: Message[]): UIMessage[] {
                   output: p.result,
                 };
               }
-              return { type: "text" as const, text: String((p as { text?: string }).text ?? "") };
+              return { type: "text" as const, text: String(p.text ?? "") };
             })
         : [{ type: "text" as const, text: String(m.content) }];
 


### PR DESCRIPTION
## Summary
- **Backend** (`chat.ts`): Awaits `agentResult.steps` instead of `agentResult.text` to capture tool call/result data. Each step's text and tool results are persisted as interleaved content parts (`type: "text"` + `type: "tool-invocation"`)
- **Frontend** (`use-conversations.ts` in both `packages/web` and `packages/react`): `transformMessages()` reconstructs `tool-invocation` parts as `DynamicToolUIPart` objects with `type: "dynamic-tool"`, `state: "output-available"`, mapping `args→input` and `result→output` so the existing `ToolPart` component renders SQL cards, explore cards, and charts
- **Backward compatible**: Old conversations with text-only content still load correctly

Fixes #1390

## Test plan
- [x] Updated existing "filters out non-text parts" test → now verifies tool-invocation reconstruction
- [x] New test: "reconstructs tool-invocation parts as DynamicToolUIPart"
- [x] New test: "handles mixed text and tool-invocation parts"
- [x] New test: "falls back gracefully for old conversations with only text parts"
- [x] All 10 use-conversations tests pass
- [x] Full test suite passes (250+ unit tests)
- [x] Lint, type-check, syncpack, template drift all pass