### PR TITLE
fix: persist tool results in demo route conversations

### DIFF
--- a/e2e/surfaces/actions.test.ts
+++ b/e2e/surfaces/actions.test.ts
@@ -88,6 +88,7 @@ mock.module("@atlas/api/lib/agent", () => ({
 mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
+  persistAssistantSteps: mock(() => {}),
   getConversation: mock(() => Promise.resolve(null)),
   generateTitle: mock((q: string) => q.slice(0, 80)),
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/e2e/surfaces/agent-multistep.test.ts
+++ b/e2e/surfaces/agent-multistep.test.ts
@@ -119,6 +119,7 @@ mock.module("@atlas/api/lib/tools/actions", () => ({
 mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
+  persistAssistantSteps: mock(() => {}),
   getConversation: mock(() => Promise.resolve(null)),
   generateTitle: mock((q: string) => q.slice(0, 80)),
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/e2e/surfaces/auth-managed.test.ts
+++ b/e2e/surfaces/auth-managed.test.ts
@@ -147,6 +147,7 @@ mock.module("@atlas/api/lib/tools/actions", () => ({
 mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
+  persistAssistantSteps: mock(() => {}),
   getConversation: mock(() => Promise.resolve(null)),
   generateTitle: mock((q: string) => q.slice(0, 80)),
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/e2e/surfaces/auth.test.ts
+++ b/e2e/surfaces/auth.test.ts
@@ -151,6 +151,7 @@ mock.module("@atlas/api/lib/tools/actions", () => ({
 mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
+  persistAssistantSteps: mock(() => {}),
   getConversation: mock(() => Promise.resolve(null)),
   generateTitle: mock((q: string) => q.slice(0, 80)),
   listConversations: mock(() =>

--- a/e2e/surfaces/conversations.test.ts
+++ b/e2e/surfaces/conversations.test.ts
@@ -264,6 +264,8 @@ mock.module("@atlas/api/lib/conversations", () => ({
     });
   }),
 
+  persistAssistantSteps: mock(() => {}),
+
   getConversation: mock((id: string, userId?: string | null): Promise<CrudDataResult<unknown>> => {
     const conv = conversations.find((c) =>
       c.id === id && (userId == null || c.user_id === userId),

--- a/e2e/surfaces/error-scenarios.test.ts
+++ b/e2e/surfaces/error-scenarios.test.ts
@@ -121,6 +121,7 @@ mock.module("@atlas/api/lib/tools/actions", () => ({
 mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
+  persistAssistantSteps: mock(() => {}),
   getConversation: mock(() => Promise.resolve(null)),
   generateTitle: mock((q: string) => q.slice(0, 80)),
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/e2e/surfaces/health.test.ts
+++ b/e2e/surfaces/health.test.ts
@@ -64,6 +64,7 @@ mock.module("@atlas/api/lib/tools/actions", () => ({
 mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
+  persistAssistantSteps: mock(() => {}),
   getConversation: mock(() => Promise.resolve(null)),
   generateTitle: mock((q: string) => q.slice(0, 80)),
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/e2e/surfaces/scheduler.test.ts
+++ b/e2e/surfaces/scheduler.test.ts
@@ -213,6 +213,7 @@ mock.module("@atlas/api/lib/tools/actions", () => ({
 mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
+  persistAssistantSteps: mock(() => {}),
   getConversation: mock(() => Promise.resolve(null)),
   generateTitle: mock((q: string) => q.slice(0, 80)),
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/e2e/surfaces/slack.test.ts
+++ b/e2e/surfaces/slack.test.ts
@@ -214,6 +214,7 @@ mock.module("@atlas/api/lib/tools/actions/handler", () => ({
 mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
+  persistAssistantSteps: mock(() => {}),
   getConversation: mock(() =>
     Promise.resolve({
       ok: true as const,

--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -405,6 +405,7 @@ export function createApiTestMocks(
   mock.module("@atlas/api/lib/conversations", () => ({
     createConversation: mock(() => Promise.resolve(null)),
     addMessage: mock(() => {}),
+    persistAssistantSteps: mock(() => {}),
     getConversation: mock(() => Promise.resolve(null)),
     generateTitle: mock((q: string) => q.slice(0, 80)),
     listConversations: mock(() =>

--- a/packages/api/src/api/__tests__/actions.test.ts
+++ b/packages/api/src/api/__tests__/actions.test.ts
@@ -95,6 +95,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   deleteConversation: mock(() => Promise.resolve(false)),
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
+  persistAssistantSteps: mock(() => {}),
   generateTitle: mock(() => "Test title"),
   starConversation: async () => false,
   shareConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),

--- a/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
@@ -329,6 +329,7 @@ mock.module("@atlas/api/lib/tools/actions", () => ({}));
 mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
+  persistAssistantSteps: mock(() => {}),
   getConversation: mock(() => Promise.resolve(null)),
   generateTitle: mock((q: string) => q.slice(0, 80)),
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/packages/api/src/api/__tests__/admin-integrations.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations.test.ts
@@ -253,6 +253,7 @@ mock.module("@atlas/api/lib/tools/actions", () => ({}));
 mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
+  persistAssistantSteps: mock(() => {}),
   getConversation: mock(() => Promise.resolve(null)),
   generateTitle: mock((q: string) => q.slice(0, 80)),
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/packages/api/src/api/__tests__/admin-invitations.test.ts
+++ b/packages/api/src/api/__tests__/admin-invitations.test.ts
@@ -201,6 +201,7 @@ mock.module("@atlas/api/lib/tools/actions", () => ({}));
 mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
+  persistAssistantSteps: mock(() => {}),
   getConversation: mock(() => Promise.resolve(null)),
   generateTitle: mock((q: string) => q.slice(0, 80)),
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/packages/api/src/api/__tests__/admin-password.test.ts
+++ b/packages/api/src/api/__tests__/admin-password.test.ts
@@ -176,6 +176,7 @@ mock.module("@atlas/api/lib/semantic/diff", () => ({
 mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
+  persistAssistantSteps: mock(() => {}),
   getConversation: mock(() => Promise.resolve(null)),
   generateTitle: mock((q: string) => q.slice(0, 80)),
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -408,6 +408,7 @@ mock.module("@atlas/api/lib/semantic/diff", () => ({
 mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
+  persistAssistantSteps: mock(() => {}),
   getConversation: mock(() => Promise.resolve(null)),
   generateTitle: mock((q: string) => q.slice(0, 80)),
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/packages/api/src/api/__tests__/chat.test.ts
+++ b/packages/api/src/api/__tests__/chat.test.ts
@@ -126,6 +126,7 @@ const mockGenerateTitle = mock((q: string) => q.slice(0, 80));
 mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mockCreateConversation,
   addMessage: mockAddMessage,
+  persistAssistantSteps: mock(() => {}),
   getConversation: mockGetConversationChat,
   generateTitle: mockGenerateTitle,
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/packages/api/src/api/__tests__/conversations.test.ts
+++ b/packages/api/src/api/__tests__/conversations.test.ts
@@ -74,6 +74,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mockCreateConversation,
   addMessage: mockAddMessage,
   generateTitle: mockGenerateTitle,
+  persistAssistantSteps: mock(() => {}),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   // Type exports (no runtime value — needed so mock.module doesn't break re-exports)

--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -165,6 +165,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   deleteConversation: mock(() => Promise.resolve(false)),
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
+  persistAssistantSteps: mock(() => {}),
   generateTitle: mock(() => "Test title"),
   starConversation: async () => false,
   shareConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),

--- a/packages/api/src/api/__tests__/health-plugin.test.ts
+++ b/packages/api/src/api/__tests__/health-plugin.test.ts
@@ -108,6 +108,7 @@ mock.module("@atlas/api/lib/tools/actions", () => ({
 mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
+  persistAssistantSteps: mock(() => {}),
   getConversation: mock(() => Promise.resolve(null)),
   generateTitle: mock((q: string) => q.slice(0, 80)),
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/packages/api/src/api/__tests__/health.test.ts
+++ b/packages/api/src/api/__tests__/health.test.ts
@@ -113,6 +113,7 @@ mock.module("@atlas/api/lib/tools/actions", () => ({
 mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
+  persistAssistantSteps: mock(() => {}),
   getConversation: mock(() => Promise.resolve(null)),
   generateTitle: mock((q: string) => q.slice(0, 80)),
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/packages/api/src/api/__tests__/query.test.ts
+++ b/packages/api/src/api/__tests__/query.test.ts
@@ -137,6 +137,7 @@ const mockGenerateTitleQuery = mock((q: string) => q.slice(0, 80));
 mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mockCreateConversationQuery,
   addMessage: mockAddMessageQuery,
+  persistAssistantSteps: mock(() => {}),
   getConversation: mockGetConversationQuery,
   generateTitle: mockGenerateTitleQuery,
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/packages/api/src/api/__tests__/scheduled-tasks.test.ts
+++ b/packages/api/src/api/__tests__/scheduled-tasks.test.ts
@@ -100,6 +100,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   deleteConversation: mock(() => Promise.resolve(false)),
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
+  persistAssistantSteps: mock(() => {}),
   generateTitle: mock(() => "Test title"),
   starConversation: async () => false,
   shareConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),

--- a/packages/api/src/api/__tests__/semantic.test.ts
+++ b/packages/api/src/api/__tests__/semantic.test.ts
@@ -238,6 +238,7 @@ mock.module("@atlas/api/lib/tools/actions", () => ({
 mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
+  persistAssistantSteps: mock(() => {}),
   getConversation: mock(() => Promise.resolve(null)),
   generateTitle: mock((q: string) => q.slice(0, 80)),
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/packages/api/src/api/__tests__/slack.test.ts
+++ b/packages/api/src/api/__tests__/slack.test.ts
@@ -117,6 +117,7 @@ const mockGenerateTitle: Mock<(question: string) => string> = mock((q: string) =
 mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mockCreateConversation,
   addMessage: mockAddMessage,
+  persistAssistantSteps: mock(() => {}),
   getConversation: mockGetConversation,
   generateTitle: mockGenerateTitle,
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -35,6 +35,7 @@ import {
   addMessage,
   getConversation,
   generateTitle,
+  persistAssistantSteps,
 } from "@atlas/api/lib/conversations";
 import { setStreamWriter, clearStreamWriter } from "@atlas/api/lib/tools/python-stream";
 import { ErrorSchema } from "./shared-schemas";
@@ -524,46 +525,7 @@ chat.openapi(chatRoute, async (c) => {
   
           // Fire-and-forget: persist assistant response (text + tool results) after stream completes.
           if (conversationId) {
-            const cid = conversationId;
-            void Promise.resolve(agentResult.steps)
-              .then((steps) => {
-                try {
-                  const content: unknown[] = [];
-                  for (const step of steps) {
-                    if (step.text) {
-                      content.push({ type: "text", text: step.text });
-                    }
-                    if (step.toolResults) {
-                      for (const tr of step.toolResults) {
-                        try {
-                          content.push({
-                            type: "tool-invocation",
-                            toolCallId: tr.toolCallId,
-                            toolName: tr.toolName,
-                            args: tr.input,
-                            result: tr.output,
-                          });
-                        } catch (trErr) {
-                          log.warn(
-                            { err: trErr instanceof Error ? trErr.message : String(trErr), conversationId: cid },
-                            "Skipped malformed tool result during persistence",
-                          );
-                        }
-                      }
-                    }
-                  }
-                  if (content.length === 0) {
-                    log.warn({ conversationId: cid, stepCount: steps.length }, "Agent produced no text or tool results — persisting empty message");
-                    content.push({ type: "text", text: "" });
-                  }
-                  addMessage({ conversationId: cid, role: "assistant", content });
-                } catch (persistErr) {
-                  log.warn({ err: persistErr instanceof Error ? persistErr.message : String(persistErr), conversationId: cid }, "Failed to persist assistant message");
-                }
-              })
-              .catch((err: unknown) => {
-                log.error({ err: err instanceof Error ? err.message : String(err), conversationId: cid }, "Agent stream failed — assistant response not available");
-              });
+            persistAssistantSteps({ conversationId, steps: agentResult.steps, label: "chat" });
           }
   
           // The streaming response is a raw Response from createUIMessageStreamResponse.

--- a/packages/api/src/api/routes/demo.ts
+++ b/packages/api/src/api/routes/demo.ts
@@ -532,13 +532,41 @@ demo.openapi(demoChatRoute, async (c) => {
           },
         });
 
-        // Fire-and-forget: persist assistant response
+        // Fire-and-forget: persist assistant response (text + tool results) after stream completes.
         if (conversationId) {
           const cid = conversationId;
-          void Promise.resolve(agentResult.text)
-            .then((text) => {
+          void Promise.resolve(agentResult.steps)
+            .then((steps) => {
               try {
-                addMessage({ conversationId: cid, role: "assistant", content: [{ type: "text", text }] });
+                const content: unknown[] = [];
+                for (const step of steps) {
+                  if (step.text) {
+                    content.push({ type: "text", text: step.text });
+                  }
+                  if (step.toolResults) {
+                    for (const tr of step.toolResults) {
+                      try {
+                        content.push({
+                          type: "tool-invocation",
+                          toolCallId: tr.toolCallId,
+                          toolName: tr.toolName,
+                          args: tr.input,
+                          result: tr.output,
+                        });
+                      } catch (trErr) {
+                        log.warn(
+                          { err: trErr instanceof Error ? trErr.message : String(trErr), conversationId: cid },
+                          "Skipped malformed tool result during persistence",
+                        );
+                      }
+                    }
+                  }
+                }
+                if (content.length === 0) {
+                  log.warn({ conversationId: cid, stepCount: steps.length }, "Agent produced no text or tool results — persisting empty message");
+                  content.push({ type: "text", text: "" });
+                }
+                addMessage({ conversationId: cid, role: "assistant", content });
               } catch (persistErr) {
                 log.warn({ err: persistErr instanceof Error ? persistErr.message : String(persistErr), conversationId: cid }, "Failed to persist assistant message");
               }

--- a/packages/api/src/api/routes/demo.ts
+++ b/packages/api/src/api/routes/demo.ts
@@ -32,6 +32,7 @@ import {
   getConversation,
   listConversations,
   generateTitle,
+  persistAssistantSteps,
 } from "@atlas/api/lib/conversations";
 import { setStreamWriter, clearStreamWriter } from "@atlas/api/lib/tools/python-stream";
 import {
@@ -534,46 +535,7 @@ demo.openapi(demoChatRoute, async (c) => {
 
         // Fire-and-forget: persist assistant response (text + tool results) after stream completes.
         if (conversationId) {
-          const cid = conversationId;
-          void Promise.resolve(agentResult.steps)
-            .then((steps) => {
-              try {
-                const content: unknown[] = [];
-                for (const step of steps) {
-                  if (step.text) {
-                    content.push({ type: "text", text: step.text });
-                  }
-                  if (step.toolResults) {
-                    for (const tr of step.toolResults) {
-                      try {
-                        content.push({
-                          type: "tool-invocation",
-                          toolCallId: tr.toolCallId,
-                          toolName: tr.toolName,
-                          args: tr.input,
-                          result: tr.output,
-                        });
-                      } catch (trErr) {
-                        log.warn(
-                          { err: trErr instanceof Error ? trErr.message : String(trErr), conversationId: cid },
-                          "Skipped malformed tool result during persistence",
-                        );
-                      }
-                    }
-                  }
-                }
-                if (content.length === 0) {
-                  log.warn({ conversationId: cid, stepCount: steps.length }, "Agent produced no text or tool results — persisting empty message");
-                  content.push({ type: "text", text: "" });
-                }
-                addMessage({ conversationId: cid, role: "assistant", content });
-              } catch (persistErr) {
-                log.warn({ err: persistErr instanceof Error ? persistErr.message : String(persistErr), conversationId: cid }, "Failed to persist assistant message");
-              }
-            })
-            .catch((err: unknown) => {
-              log.error({ err: err instanceof Error ? err.message : String(err), conversationId: cid }, "Demo agent stream failed");
-            });
+          persistAssistantSteps({ conversationId, steps: agentResult.steps, label: "demo" });
         }
 
         // Streaming response bypasses OpenAPI typed returns via HTTPException + res

--- a/packages/api/src/lib/conversations.ts
+++ b/packages/api/src/lib/conversations.ts
@@ -115,6 +115,63 @@ export async function createConversation(opts: {
   }
 }
 
+/**
+ * Fire-and-forget: persist assistant text + tool results after the agent stream completes.
+ * Iterates steps, builds a content array, and calls addMessage. Skips
+ * persistence with an error log if no text or tool results are found.
+ * Logs and returns on failure — never throws.
+ */
+export function persistAssistantSteps(opts: {
+  conversationId: string;
+  steps: PromiseLike<{ text: string; toolResults?: readonly { toolCallId: string; toolName: string; input: unknown; output: unknown }[] }[]>;
+  label: string;
+}): void {
+  const { conversationId, label } = opts;
+  void Promise.resolve(opts.steps)
+    .then((steps) => {
+      try {
+        const content: unknown[] = steps.flatMap((step) => {
+          const parts: unknown[] = [];
+          if (step.text) {
+            parts.push({ type: "text", text: step.text });
+          }
+          for (const tr of step.toolResults ?? []) {
+            parts.push({
+              type: "tool-invocation",
+              toolCallId: tr.toolCallId,
+              toolName: tr.toolName,
+              args: tr.input,
+              result: tr.output,
+            });
+          }
+          return parts;
+        });
+        if (content.length === 0) {
+          log.error(
+            { conversationId, stepCount: steps.length },
+            "[%s] Agent produced steps but no text or tool results — skipping persistence",
+            label,
+          );
+          return;
+        }
+        addMessage({ conversationId, role: "assistant", content });
+      } catch (persistErr) {
+        log.error(
+          { err: persistErr instanceof Error ? persistErr.message : String(persistErr), conversationId },
+          "[%s] Failed to persist assistant message",
+          label,
+        );
+      }
+    })
+    .catch((err: unknown) => {
+      log.error(
+        { err: err instanceof Error ? err.message : String(err), conversationId },
+        "[%s] Agent stream failed — assistant response not available",
+        label,
+      );
+    });
+}
+
 /** Fire-and-forget — inserts the message and bumps updated_at in two separate non-transactional writes. */
 export function addMessage(opts: {
   conversationId: string;

--- a/packages/api/src/lib/tools/__tests__/action-permissions.test.ts
+++ b/packages/api/src/lib/tools/__tests__/action-permissions.test.ts
@@ -123,6 +123,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   deleteConversation: mock(() => Promise.resolve(false)),
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
+  persistAssistantSteps: mock(() => {}),
   generateTitle: mock(() => "Test title"),
   starConversation: async () => false,
   shareConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),


### PR DESCRIPTION
## Summary
- Apply the same `agentResult.steps` persistence pattern from `chat.ts` to `demo.ts`
- Demo conversations now persist tool call/result data alongside text, so loaded conversations render SQL cards, charts, explore output, and the "Add to Dashboard" button

Closes #1392

## Test plan
- [ ] Start a demo conversation, ask a query that triggers `executeSQL`
- [ ] Reload the page or navigate away and back — tool result cards should render
- [ ] Verify old demo conversations (text-only) still load without errors