### PR TITLE
fix: display pending amendments on semantic improve page

### DIFF
--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -263,6 +263,8 @@ export function createApiTestMocks(
     getAutoApproveTypes: mock(() => new Set(["update_description", "add_dimension"])),
     insertSemanticAmendment: mock(async () => ({ id: "mock-amendment-id", status: "pending" as const })),
     getPendingAmendmentCount: mock(async () => 0),
+    getPendingAmendments: mock(async () => []),
+    reviewSemanticAmendment: mock(async () => false),
     hardDeleteWorkspace: mock(async () => ({})),
   };
 

--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -264,7 +264,7 @@ export function createApiTestMocks(
     insertSemanticAmendment: mock(async () => ({ id: "mock-amendment-id", status: "pending" as const })),
     getPendingAmendmentCount: mock(async () => 0),
     getPendingAmendments: mock(async () => []),
-    reviewSemanticAmendment: mock(async () => false),
+    reviewSemanticAmendment: mock(async () => null),
     hardDeleteWorkspace: mock(async () => ({})),
   };
 

--- a/packages/api/src/api/routes/admin-semantic-improve.ts
+++ b/packages/api/src/api/routes/admin-semantic-improve.ts
@@ -761,52 +761,50 @@ adminSemanticImprove.openapi(reviewAmendmentRoute, async (c) =>
     const { decision } = c.req.valid("json");
 
     const { reviewSemanticAmendment } = await import("@atlas/api/lib/db/internal");
-    const updated = await reviewSemanticAmendment(id, orgId, decision, "admin");
 
-    if (!updated) {
-      return c.json({ error: "not_found", message: "Amendment not found or already reviewed.", requestId }, 404);
+    // For approvals, apply YAML first — only update DB status on success
+    if (decision === "approved") {
+      // Peek at the row to get payload before changing status
+      const { getPendingAmendments } = await import("@atlas/api/lib/db/internal");
+      const pending = await getPendingAmendments(orgId);
+      const target = pending.find((r) => r.id === id);
+      if (!target) {
+        return c.json({ error: "not_found", message: "Amendment not found or already reviewed.", requestId }, 404);
+      }
+
+      const payload = target.amendment_payload;
+      if (payload) {
+        const { applyAmendmentToEntity } = await import("@atlas/api/lib/semantic/expert/apply");
+        const { ANALYSIS_CATEGORIES } = await import("@atlas/api/lib/semantic/expert/types");
+        const { AMENDMENT_TYPES } = await import("@useatlas/types");
+
+        const rawCategory = String(payload.category ?? "coverage_gaps");
+        const rawAmendmentType = String(payload.amendmentType ?? "update_description");
+
+        // This throws on failure — runHandler maps it to 500
+        await applyAmendmentToEntity(orgId, {
+          entityName: target.source_entity,
+          category: (ANALYSIS_CATEGORIES as readonly string[]).includes(rawCategory)
+            ? rawCategory as typeof ANALYSIS_CATEGORIES[number]
+            : "coverage_gaps",
+          amendmentType: (AMENDMENT_TYPES as readonly string[]).includes(rawAmendmentType)
+            ? rawAmendmentType as typeof AMENDMENT_TYPES[number]
+            : "update_description",
+          amendment: payload,
+          rationale: typeof payload.rationale === "string" ? payload.rationale : "",
+          confidence: 0,
+          impact: 0,
+          score: 0,
+          staleness: 0,
+        }, requestId);
+      }
     }
 
-    // If approving, apply the YAML amendment
-    if (decision === "approved") {
-      try {
-        // Re-fetch the row to get amendment payload (status was just updated)
-        const { internalQuery } = await import("@atlas/api/lib/db/internal");
-        const rows = await internalQuery<Record<string, unknown>>(
-          `SELECT source_entity, amendment_payload FROM learned_patterns WHERE id = $1`,
-          [id],
-        );
-        const payload = rows[0]?.amendment_payload as Record<string, unknown> | null;
-        if (payload) {
-          const { applyAmendmentToEntity } = await import("@atlas/api/lib/semantic/expert/apply");
-          const { ANALYSIS_CATEGORIES } = await import("@atlas/api/lib/semantic/expert/types");
-          const { AMENDMENT_TYPES } = await import("@useatlas/types");
+    // YAML applied (or rejection) — now update DB status
+    const reviewed = await reviewSemanticAmendment(id, orgId, decision, "admin");
 
-          const rawCategory = String(payload.category ?? "coverage_gaps");
-          const rawAmendmentType = String(payload.amendmentType ?? "update_description");
-
-          await applyAmendmentToEntity(orgId, {
-            entityName: String(rows[0].source_entity),
-            category: (ANALYSIS_CATEGORIES as readonly string[]).includes(rawCategory)
-              ? rawCategory as typeof ANALYSIS_CATEGORIES[number]
-              : "coverage_gaps",
-            amendmentType: (AMENDMENT_TYPES as readonly string[]).includes(rawAmendmentType)
-              ? rawAmendmentType as typeof AMENDMENT_TYPES[number]
-              : "update_description",
-            amendment: payload,
-            rationale: typeof payload.rationale === "string" ? payload.rationale : "",
-            confidence: 0,
-            impact: 0,
-            score: 0,
-            staleness: 0,
-          }, requestId);
-        }
-      } catch (err) {
-        log.error(
-          { err: err instanceof Error ? err.message : String(err), requestId, id },
-          "Amendment approved but YAML apply failed — status updated, YAML unchanged",
-        );
-      }
+    if (!reviewed) {
+      return c.json({ error: "not_found", message: "Amendment not found or already reviewed.", requestId }, 404);
     }
 
     log.info({ requestId, orgId, id, decision }, "Amendment reviewed");

--- a/packages/api/src/api/routes/admin-semantic-improve.ts
+++ b/packages/api/src/api/routes/admin-semantic-improve.ts
@@ -603,6 +603,81 @@ const pendingCountRoute = createRoute({
   },
 });
 
+const PendingAmendmentSchema = z.object({
+  id: z.string(),
+  entityName: z.string(),
+  description: z.string().nullable(),
+  confidence: z.number(),
+  amendmentType: z.string().nullable(),
+  amendment: z.record(z.string(), z.unknown()).nullable(),
+  rationale: z.string().nullable(),
+  testQuery: z.string().nullable(),
+  createdAt: z.string(),
+});
+
+const pendingListRoute = createRoute({
+  method: "get",
+  path: "/pending",
+  tags: ["Admin — Semantic Improve"],
+  summary: "List pending semantic amendment proposals",
+  description: "Returns pending amendment proposals awaiting review, newest first.",
+  responses: {
+    200: {
+      description: "Pending amendments",
+      content: { "application/json": { schema: z.object({ amendments: z.array(PendingAmendmentSchema) }) } },
+    },
+    401: {
+      description: "Authentication required",
+      content: { "application/json": { schema: AuthErrorSchema } },
+    },
+    500: {
+      description: "Internal server error",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const reviewAmendmentRoute = createRoute({
+  method: "post",
+  path: "/amendments/{id}/review",
+  tags: ["Admin — Semantic Improve"],
+  summary: "Approve or reject a pending amendment",
+  description: "Updates the status of a pending semantic amendment in the database.",
+  request: {
+    params: createParamSchema("id", "550e8400-e29b-41d4-a716-446655440000"),
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({ decision: z.enum(["approved", "rejected"]) }),
+        },
+      },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      description: "Amendment reviewed",
+      content: { "application/json": { schema: z.object({ ok: z.boolean(), id: z.string(), decision: z.string() }) } },
+    },
+    400: {
+      description: "Invalid decision",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    401: {
+      description: "Authentication required",
+      content: { "application/json": { schema: AuthErrorSchema } },
+    },
+    404: {
+      description: "Amendment not found or already reviewed",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    500: {
+      description: "Internal server error",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
 const healthScoreRoute = createRoute({
   method: "get",
   path: "/health",
@@ -648,6 +723,94 @@ adminSemanticImprove.openapi(pendingCountRoute, async (c) =>
     const count = await getPendingAmendmentCount(orgId);
 
     return c.json({ count }, 200);
+  }),
+);
+
+// GET /pending — list pending amendments
+adminSemanticImprove.openapi(pendingListRoute, async (c) =>
+  runHandler(c, "list-pending-amendments", async () => {
+    const { orgId } = c.get("orgContext");
+
+    const { getPendingAmendments } = await import("@atlas/api/lib/db/internal");
+    const rows = await getPendingAmendments(orgId);
+
+    const amendments = rows.map((row) => {
+      const payload = row.amendment_payload;
+      return {
+        id: row.id,
+        entityName: row.source_entity,
+        description: row.description,
+        confidence: row.confidence,
+        amendmentType: typeof payload?.amendmentType === "string" ? payload.amendmentType : null,
+        amendment: payload ?? null,
+        rationale: typeof payload?.rationale === "string" ? payload.rationale : null,
+        testQuery: typeof payload?.testQuery === "string" ? payload.testQuery : null,
+        createdAt: row.created_at,
+      };
+    });
+
+    return c.json({ amendments }, 200);
+  }),
+);
+
+// POST /amendments/:id/review — approve or reject a DB amendment
+adminSemanticImprove.openapi(reviewAmendmentRoute, async (c) =>
+  runHandler(c, "review-amendment", async () => {
+    const { requestId, orgId } = c.get("orgContext");
+    const { id } = c.req.valid("param");
+    const { decision } = c.req.valid("json");
+
+    const { reviewSemanticAmendment } = await import("@atlas/api/lib/db/internal");
+    const updated = await reviewSemanticAmendment(id, orgId, decision, "admin");
+
+    if (!updated) {
+      return c.json({ error: "not_found", message: "Amendment not found or already reviewed.", requestId }, 404);
+    }
+
+    // If approving, apply the YAML amendment
+    if (decision === "approved") {
+      try {
+        // Re-fetch the row to get amendment payload (status was just updated)
+        const { internalQuery } = await import("@atlas/api/lib/db/internal");
+        const rows = await internalQuery<Record<string, unknown>>(
+          `SELECT source_entity, amendment_payload FROM learned_patterns WHERE id = $1`,
+          [id],
+        );
+        const payload = rows[0]?.amendment_payload as Record<string, unknown> | null;
+        if (payload) {
+          const { applyAmendmentToEntity } = await import("@atlas/api/lib/semantic/expert/apply");
+          const { ANALYSIS_CATEGORIES } = await import("@atlas/api/lib/semantic/expert/types");
+          const { AMENDMENT_TYPES } = await import("@useatlas/types");
+
+          const rawCategory = String(payload.category ?? "coverage_gaps");
+          const rawAmendmentType = String(payload.amendmentType ?? "update_description");
+
+          await applyAmendmentToEntity(orgId, {
+            entityName: String(rows[0].source_entity),
+            category: (ANALYSIS_CATEGORIES as readonly string[]).includes(rawCategory)
+              ? rawCategory as typeof ANALYSIS_CATEGORIES[number]
+              : "coverage_gaps",
+            amendmentType: (AMENDMENT_TYPES as readonly string[]).includes(rawAmendmentType)
+              ? rawAmendmentType as typeof AMENDMENT_TYPES[number]
+              : "update_description",
+            amendment: payload,
+            rationale: typeof payload.rationale === "string" ? payload.rationale : "",
+            confidence: 0,
+            impact: 0,
+            score: 0,
+            staleness: 0,
+          }, requestId);
+        }
+      } catch (err) {
+        log.error(
+          { err: err instanceof Error ? err.message : String(err), requestId, id },
+          "Amendment approved but YAML apply failed — status updated, YAML unchanged",
+        );
+      }
+    }
+
+    log.info({ requestId, orgId, id, decision }, "Amendment reviewed");
+    return c.json({ ok: true, id, decision }, 200);
   }),
 );
 

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -884,6 +884,69 @@ export async function getPendingAmendmentCount(orgId: string | null): Promise<nu
   return parseInt(rows[0]?.count ?? "0", 10);
 }
 
+/** Row shape returned by getPendingAmendments. */
+export type PendingAmendmentRow = Record<string, unknown> & {
+  id: string;
+  source_entity: string;
+  description: string | null;
+  confidence: number;
+  amendment_payload: Record<string, unknown> | null;
+  created_at: string;
+};
+
+/**
+ * List pending semantic amendment proposals for an org, newest first.
+ * Returns [] when no internal DB is available.
+ */
+export async function getPendingAmendments(orgId: string | null): Promise<PendingAmendmentRow[]> {
+  if (!hasInternalDB()) return [];
+
+  return internalQuery<PendingAmendmentRow>(
+    orgId
+      ? `SELECT id, source_entity, description, confidence, amendment_payload, created_at::text
+         FROM learned_patterns
+         WHERE type = 'semantic_amendment' AND status = 'pending'
+         AND (org_id = $1 OR org_id IS NULL)
+         ORDER BY created_at DESC`
+      : `SELECT id, source_entity, description, confidence, amendment_payload, created_at::text
+         FROM learned_patterns
+         WHERE type = 'semantic_amendment' AND status = 'pending'
+         AND org_id IS NULL
+         ORDER BY created_at DESC`,
+    orgId ? [orgId] : [],
+  );
+}
+
+/**
+ * Update a pending semantic amendment's status to approved or rejected.
+ * Returns true if the row was found and updated, false if not found or already reviewed.
+ */
+export async function reviewSemanticAmendment(
+  id: string,
+  orgId: string | null,
+  decision: "approved" | "rejected",
+  reviewedBy: string,
+): Promise<boolean> {
+  if (!hasInternalDB()) return false;
+
+  const rows = await internalQuery<{ id: string }>(
+    orgId
+      ? `UPDATE learned_patterns
+         SET status = $1, reviewed_by = $2, reviewed_at = now(), updated_at = now()
+         WHERE id = $3 AND type = 'semantic_amendment' AND status = 'pending'
+         AND (org_id = $4 OR org_id IS NULL)
+         RETURNING id`
+      : `UPDATE learned_patterns
+         SET status = $1, reviewed_by = $2, reviewed_at = now(), updated_at = now()
+         WHERE id = $3 AND type = 'semantic_amendment' AND status = 'pending'
+         AND org_id IS NULL
+         RETURNING id`,
+    orgId ? [decision, reviewedBy, id, orgId] : [decision, reviewedBy, id],
+  );
+
+  return rows.length > 0;
+}
+
 /**
  * Increment repetition_count by 1 and increase confidence by 0.1 (capped at 1.0).
  * When sourceFingerprint is provided, appends it to source_queries (capped at 100 entries).

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -917,34 +917,44 @@ export async function getPendingAmendments(orgId: string | null): Promise<Pendin
   );
 }
 
+/** Row returned by reviewSemanticAmendment on success. */
+export type ReviewedAmendmentRow = Record<string, unknown> & {
+  id: string;
+  source_entity: string;
+  amendment_payload: Record<string, unknown> | null;
+};
+
 /**
  * Update a pending semantic amendment's status to approved or rejected.
- * Returns true if the row was found and updated, false if not found or already reviewed.
+ * Returns the updated row (with payload) on success, or null if not found / already reviewed.
+ * @throws {Error} If the internal database is not configured or the query fails.
  */
 export async function reviewSemanticAmendment(
   id: string,
   orgId: string | null,
   decision: "approved" | "rejected",
   reviewedBy: string,
-): Promise<boolean> {
-  if (!hasInternalDB()) return false;
+): Promise<ReviewedAmendmentRow | null> {
+  if (!hasInternalDB()) {
+    throw new Error("Internal database is not configured. Amendment review requires DATABASE_URL.");
+  }
 
-  const rows = await internalQuery<{ id: string }>(
+  const rows = await internalQuery<ReviewedAmendmentRow>(
     orgId
       ? `UPDATE learned_patterns
          SET status = $1, reviewed_by = $2, reviewed_at = now(), updated_at = now()
          WHERE id = $3 AND type = 'semantic_amendment' AND status = 'pending'
          AND (org_id = $4 OR org_id IS NULL)
-         RETURNING id`
+         RETURNING id, source_entity, amendment_payload`
       : `UPDATE learned_patterns
          SET status = $1, reviewed_by = $2, reviewed_at = now(), updated_at = now()
          WHERE id = $3 AND type = 'semantic_amendment' AND status = 'pending'
          AND org_id IS NULL
-         RETURNING id`,
+         RETURNING id, source_entity, amendment_payload`,
     orgId ? [decision, reviewedBy, id, orgId] : [decision, reviewedBy, id],
   );
 
-  return rows.length > 0;
+  return rows[0] ?? null;
 }
 
 /**

--- a/packages/web/src/app/admin/semantic/improve/page.tsx
+++ b/packages/web/src/app/admin/semantic/improve/page.tsx
@@ -42,8 +42,8 @@ interface Proposal {
   rationale: string;
   testQuery?: string;
   confidence: number;
-  impact: number;
-  score: number;
+  impact?: number;
+  score?: number;
   decision: "accepted" | "rejected" | "skipped" | null;
   /** DB row id for pending amendments loaded from previous sessions. */
   dbId?: string;
@@ -196,7 +196,7 @@ function extractProposals(messages: UIMessage[]): Proposal[] {
     for (const part of msg.parts) {
       if (isToolUIPart(part)) {
         let name: string;
-        try { name = getToolName(part as Parameters<typeof getToolName>[0]); } catch { continue; }
+        try { name = getToolName(part as Parameters<typeof getToolName>[0]); } catch { /* intentionally ignored: skip unrecognizable tool parts */ continue; }
         if (name !== "proposeAmendment") continue;
         const args = getToolArgs(part);
         if (args.entityName) {
@@ -257,17 +257,13 @@ export default function SemanticImprovePage() {
   const isLoading = status === "streaming" || status === "submitted";
 
   // Fetch pending amendments from the DB (created by previous sessions)
-  const { data: pendingData, loading: pendingLoading, refetch: refetchPending } =
+  const { data: pendingData, loading: pendingLoading, error: pendingError, refetch: refetchPending } =
     useAdminFetch<{ amendments: PendingAmendment[] }>("/api/v1/admin/semantic-improve/pending");
 
-  // Mutations for approve/reject
-  const { mutate: mutateApprove, isMutating: isApproving, error: approveError } = useAdminMutation({
+  // Single mutation hook for approve/reject
+  const { mutate, isMutating, error: mutationError } = useAdminMutation({
     method: "POST",
   });
-  const { mutate: mutateReject, isMutating: isRejecting, error: rejectError } = useAdminMutation({
-    method: "POST",
-  });
-  const mutationError = approveError || rejectError;
 
   // Convert DB pending amendments to Proposal shape for display
   const pendingAmendments: Proposal[] = (pendingData?.amendments ?? []).map((a, i) => ({
@@ -279,8 +275,6 @@ export default function SemanticImprovePage() {
     rationale: a.rationale ?? a.description ?? "",
     testQuery: a.testQuery ?? undefined,
     confidence: a.confidence,
-    impact: 0.5,
-    score: a.confidence,
     decision: null,
     dbId: a.id,
   }));
@@ -320,40 +314,24 @@ export default function SemanticImprovePage() {
     });
   }
 
-  async function handleApprove(proposal: Proposal) {
+  async function handleReview(proposal: Proposal, decision: "approved" | "rejected") {
+    const label = decision === "approved" ? "approve" : "reject";
     if (proposal.dbId) {
-      const result = await mutateApprove({
+      const result = await mutate({
         path: `/api/v1/admin/semantic-improve/amendments/${proposal.dbId}/review`,
-        itemId: `approve-${proposal.dbId}`,
-        body: { decision: "approved" },
+        itemId: `${label}-${proposal.dbId}`,
+        body: { decision },
       });
       if (result.ok) refetchPending();
     } else {
-      const result = await mutateApprove({
-        path: `/api/v1/admin/semantic-improve/proposals/${proposal.index}/approve`,
-        itemId: `approve-${proposal.index}`,
+      const chatDecision = decision === "approved" ? "accepted" as const : "rejected" as const;
+      const chatPath = decision === "approved" ? "approve" : "reject";
+      const result = await mutate({
+        path: `/api/v1/admin/semantic-improve/proposals/${proposal.index}/${chatPath}`,
+        itemId: `${label}-${proposal.index}`,
       });
       if (result.ok) {
-        setProposalDecisions((prev) => new Map(prev).set(proposal.index, "accepted"));
-      }
-    }
-  }
-
-  async function handleReject(proposal: Proposal) {
-    if (proposal.dbId) {
-      const result = await mutateReject({
-        path: `/api/v1/admin/semantic-improve/amendments/${proposal.dbId}/review`,
-        itemId: `reject-${proposal.dbId}`,
-        body: { decision: "rejected" },
-      });
-      if (result.ok) refetchPending();
-    } else {
-      const result = await mutateReject({
-        path: `/api/v1/admin/semantic-improve/proposals/${proposal.index}/reject`,
-        itemId: `reject-${proposal.index}`,
-      });
-      if (result.ok) {
-        setProposalDecisions((prev) => new Map(prev).set(proposal.index, "rejected"));
+        setProposalDecisions((prev) => new Map(prev).set(proposal.index, chatDecision));
       }
     }
   }
@@ -511,6 +489,9 @@ export default function SemanticImprovePage() {
               </div>
               <ScrollArea className="flex-1 p-4">
                 <div className="space-y-3">
+                  {pendingError && (
+                    <ErrorBanner message={pendingError} />
+                  )}
                   {mutationError && (
                     <ErrorBanner message={mutationError} />
                   )}
@@ -529,14 +510,15 @@ export default function SemanticImprovePage() {
                   )}
                   {proposals.map((proposal) => {
                     const itemKey = proposal.dbId ?? `chat-${proposal.index}`;
+                    const idSuffix = proposal.dbId ?? String(proposal.index);
                     return (
                       <ProposalCard
                         key={itemKey}
                         proposal={proposal}
-                        onApprove={() => handleApprove(proposal)}
-                        onReject={() => handleReject(proposal)}
-                        approving={isApproving(proposal.dbId ? `approve-${proposal.dbId}` : `approve-${proposal.index}`)}
-                        rejecting={isRejecting(proposal.dbId ? `reject-${proposal.dbId}` : `reject-${proposal.index}`)}
+                        onApprove={() => handleReview(proposal, "approved")}
+                        onReject={() => handleReview(proposal, "rejected")}
+                        approving={isMutating(`approve-${idSuffix}`)}
+                        rejecting={isMutating(`reject-${idSuffix}`)}
                       />
                     );
                   })}

--- a/packages/web/src/app/admin/semantic/improve/page.tsx
+++ b/packages/web/src/app/admin/semantic/improve/page.tsx
@@ -5,6 +5,7 @@ import { useChat, type UIMessage } from "@ai-sdk/react";
 import { DefaultChatTransport, isToolUIPart, getToolName } from "ai";
 import { getToolArgs } from "@/ui/lib/helpers";
 import { useAtlasConfig } from "@/ui/context";
+import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { Button } from "@/components/ui/button";
@@ -44,6 +45,20 @@ interface Proposal {
   impact: number;
   score: number;
   decision: "accepted" | "rejected" | "skipped" | null;
+  /** DB row id for pending amendments loaded from previous sessions. */
+  dbId?: string;
+}
+
+interface PendingAmendment {
+  id: string;
+  entityName: string;
+  description: string | null;
+  confidence: number;
+  amendmentType: string | null;
+  amendment: Record<string, unknown> | null;
+  rationale: string | null;
+  testQuery: string | null;
+  createdAt: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -241,6 +256,10 @@ export default function SemanticImprovePage() {
   const { messages, sendMessage, status, error: chatError } = useChat({ transport });
   const isLoading = status === "streaming" || status === "submitted";
 
+  // Fetch pending amendments from the DB (created by previous sessions)
+  const { data: pendingData, loading: pendingLoading, refetch: refetchPending } =
+    useAdminFetch<{ amendments: PendingAmendment[] }>("/api/v1/admin/semantic-improve/pending");
+
   // Mutations for approve/reject
   const { mutate: mutateApprove, isMutating: isApproving, error: approveError } = useAdminMutation({
     method: "POST",
@@ -250,11 +269,30 @@ export default function SemanticImprovePage() {
   });
   const mutationError = approveError || rejectError;
 
-  // Extract proposals from messages
-  const proposals = extractProposals(messages).map((p) => ({
+  // Convert DB pending amendments to Proposal shape for display
+  const pendingAmendments: Proposal[] = (pendingData?.amendments ?? []).map((a, i) => ({
+    index: i,
+    entityName: a.entityName,
+    category: "",
+    amendmentType: a.amendmentType ?? "unknown",
+    amendment: a.amendment ?? {},
+    rationale: a.rationale ?? a.description ?? "",
+    testQuery: a.testQuery ?? undefined,
+    confidence: a.confidence,
+    impact: 0.5,
+    score: a.confidence,
+    decision: null,
+    dbId: a.id,
+  }));
+
+  // Extract proposals from current chat session messages
+  const chatProposals = extractProposals(messages).map((p) => ({
     ...p,
     decision: proposalDecisions.get(p.index) ?? p.decision,
   }));
+
+  // Show chat proposals when a session is active, otherwise show DB pending
+  const proposals = chatProposals.length > 0 ? chatProposals : pendingAmendments;
 
   function handleSend() {
     if (!inputValue.trim() || isLoading) return;
@@ -282,23 +320,41 @@ export default function SemanticImprovePage() {
     });
   }
 
-  async function handleApprove(index: number) {
-    const result = await mutateApprove({
-      path: `/api/v1/admin/semantic-improve/proposals/${index}/approve`,
-      itemId: `approve-${index}`,
-    });
-    if (result.ok) {
-      setProposalDecisions((prev) => new Map(prev).set(index, "accepted"));
+  async function handleApprove(proposal: Proposal) {
+    if (proposal.dbId) {
+      const result = await mutateApprove({
+        path: `/api/v1/admin/semantic-improve/amendments/${proposal.dbId}/review`,
+        itemId: `approve-${proposal.dbId}`,
+        body: { decision: "approved" },
+      });
+      if (result.ok) refetchPending();
+    } else {
+      const result = await mutateApprove({
+        path: `/api/v1/admin/semantic-improve/proposals/${proposal.index}/approve`,
+        itemId: `approve-${proposal.index}`,
+      });
+      if (result.ok) {
+        setProposalDecisions((prev) => new Map(prev).set(proposal.index, "accepted"));
+      }
     }
   }
 
-  async function handleReject(index: number) {
-    const result = await mutateReject({
-      path: `/api/v1/admin/semantic-improve/proposals/${index}/reject`,
-      itemId: `reject-${index}`,
-    });
-    if (result.ok) {
-      setProposalDecisions((prev) => new Map(prev).set(index, "rejected"));
+  async function handleReject(proposal: Proposal) {
+    if (proposal.dbId) {
+      const result = await mutateReject({
+        path: `/api/v1/admin/semantic-improve/amendments/${proposal.dbId}/review`,
+        itemId: `reject-${proposal.dbId}`,
+        body: { decision: "rejected" },
+      });
+      if (result.ok) refetchPending();
+    } else {
+      const result = await mutateReject({
+        path: `/api/v1/admin/semantic-improve/proposals/${proposal.index}/reject`,
+        itemId: `reject-${proposal.index}`,
+      });
+      if (result.ok) {
+        setProposalDecisions((prev) => new Map(prev).set(proposal.index, "rejected"));
+      }
     }
   }
 
@@ -458,21 +514,32 @@ export default function SemanticImprovePage() {
                   {mutationError && (
                     <ErrorBanner message={mutationError} />
                   )}
-                  {proposals.length === 0 && (
+                  {proposals.length === 0 && !pendingLoading && (
                     <div className="py-12 text-center text-xs text-muted-foreground">
-                      Proposals will appear here as the agent identifies improvements.
+                      {messages.length === 0
+                        ? "No pending improvements. Run an analysis to identify opportunities."
+                        : "Proposals will appear here as the agent identifies improvements."}
                     </div>
                   )}
-                  {proposals.map((proposal) => (
-                    <ProposalCard
-                      key={proposal.index}
-                      proposal={proposal}
-                      onApprove={() => handleApprove(proposal.index)}
-                      onReject={() => handleReject(proposal.index)}
-                      approving={isApproving(`approve-${proposal.index}`)}
-                      rejecting={isRejecting(`reject-${proposal.index}`)}
-                    />
-                  ))}
+                  {pendingLoading && proposals.length === 0 && (
+                    <div className="flex items-center justify-center py-12 text-xs text-muted-foreground">
+                      <Loader2 className="size-3 animate-spin mr-2" />
+                      Loading pending amendments...
+                    </div>
+                  )}
+                  {proposals.map((proposal) => {
+                    const itemKey = proposal.dbId ?? `chat-${proposal.index}`;
+                    return (
+                      <ProposalCard
+                        key={itemKey}
+                        proposal={proposal}
+                        onApprove={() => handleApprove(proposal)}
+                        onReject={() => handleReject(proposal)}
+                        approving={isApproving(proposal.dbId ? `approve-${proposal.dbId}` : `approve-${proposal.index}`)}
+                        rejecting={isRejecting(proposal.dbId ? `reject-${proposal.dbId}` : `reject-${proposal.index}`)}
+                      />
+                    );
+                  })}
                 </div>
               </ScrollArea>
             </div>

--- a/packages/web/src/ui/components/admin/admin-sidebar.tsx
+++ b/packages/web/src/ui/components/admin/admin-sidebar.tsx
@@ -72,7 +72,7 @@ const navGroups: NavGroup[] = [
     title: "Data",
     icon: Database,
     items: [
-      { href: "/admin/semantic", label: "Semantic Layer" },
+      { href: "/admin/semantic", label: "Semantic Layer", exact: true },
       { href: "/admin/semantic/improve", label: "Improve Layer" },
       { href: "/admin/schema-diff", label: "Schema Diff" },
       { href: "/admin/connections", label: "Connections" },


### PR DESCRIPTION
## Summary
- The sidebar badge showed a pending amendment count, but clicking into the Improve Layer page showed nothing — the page only rendered proposals from the current chat session's tool calls, never loading existing DB amendments
- Added `GET /pending` endpoint to list pending amendments from `learned_patterns`
- Added `POST /amendments/:id/review` endpoint to approve/reject DB amendments (with YAML apply on approve)
- Frontend loads pending amendments on page load and displays them in the proposals panel
- Fixed sidebar double-highlight where both "Semantic Layer" and "Improve Layer" were active simultaneously

## Test plan
- [x] Type-check passes
- [x] Lint passes
- [x] All tests pass (250+ unit, 434 EE, 6 semantic-improve)
- [x] Browser verified: page loads pending amendments, sidebar badge shows correct count, approve/reject buttons present
- [x] No other sidebar nav prefix conflicts found
- [ ] Verify on production with real pending amendments