### PR TITLE
feat: execution metadata on SQL tool results (#1397)

### DIFF
--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -782,6 +782,7 @@ function executeAndAuditEffect(opts: {
             truncated,
             cached: false,
             maskingApplied,
+            executionMs: durationMs,
             ...(hasHookMeta && { metadata: hookMetadata }),
           } as Record<string, unknown>;
         },
@@ -1002,6 +1003,7 @@ Rules:
                   columns: cached.columns, rows: cachedRows,
                   truncated: cachedRows.length >= getRowLimit(), cached: true,
                   maskingApplied: cachedMaskingApplied,
+                  executionMs: 0,
                 };
               },
               catch: (err) => {

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -805,6 +805,7 @@ function pipelineErrorToResponse(error: PipelineError): Record<string, unknown> 
       return {
         success: false,
         error: error.message,
+        executionMs: 0,
         ...(error.retryAfterMs != null && { retryAfterMs: error.retryAfterMs }),
       };
     case "ConcurrencyLimitError":
@@ -814,10 +815,10 @@ function pipelineErrorToResponse(error: PipelineError): Record<string, unknown> 
     case "RLSError":
     case "PluginRejectedError":
     case "QueryExecutionError":
-      return { success: false, error: error.message };
+      return { success: false, error: error.message, executionMs: 0 };
     default: {
       const _exhaustive: never = error;
-      return { success: false, error: `Unknown pipeline error: ${(_exhaustive as { message: string }).message}` };
+      return { success: false, error: `Unknown pipeline error: ${(_exhaustive as { message: string }).message}`, executionMs: 0 };
     }
   }
 }
@@ -872,7 +873,7 @@ Rules:
           sql: normalizedSql.slice(0, 2000), durationMs: 0, rowCount: null, success: false,
           error: initial.auditError, sourceId: connId, sourceType: dbType,
         });
-        return { success: false, error: initial.error };
+        return { success: false, error: initial.error, executionMs: 0 };
       }
       // Classification is only populated for standard SQL (validateSQL path).
       // Custom validators (SOQL, GraphQL) bypass node-sql-parser so classification
@@ -915,6 +916,7 @@ Rules:
                 return {
                   success: false,
                   error: "This query requires approval but the requester identity could not be determined. Please sign in and try again.",
+                  executionMs: 0,
                 };
               }
 
@@ -946,6 +948,7 @@ Rules:
                   message: `This query requires approval before execution. Rule: "${firstRule.name}". ` +
                     `An approval request has been submitted (ID: ${approvalReq.id}). ` +
                     `An admin must approve it before the query can run.`,
+                  executionMs: 0,
                 };
               }
             }
@@ -1065,7 +1068,7 @@ Rules:
                 error: `Plugin-rewritten SQL failed validation: ${revalidation.auditError}`,
                 sourceId: connId, sourceType: dbType, targetHost,
               });
-              return { success: false, error: `Plugin-rewritten SQL failed validation: ${revalidation.error}` };
+              return { success: false, error: `Plugin-rewritten SQL failed validation: ${revalidation.error}`, executionMs: 0 };
             }
           }
 

--- a/packages/react/src/components/chat/sql-result-card.tsx
+++ b/packages/react/src/components/chat/sql-result-card.tsx
@@ -82,7 +82,7 @@ export function SQLResultCard({ part }: { part: unknown }) {
         <span className="text-zinc-500">
           {rows.length} row{rows.length !== 1 ? "s" : ""}
           {result.truncated ? "+" : ""}
-          {typeof result.executionMs === "number" && (
+          {Number.isFinite(result.executionMs) && (
             <> · {result.cached ? "cached" : `${(result.executionMs / 1000).toFixed(1)}s`}</>
           )}
         </span>

--- a/packages/react/src/components/chat/sql-result-card.tsx
+++ b/packages/react/src/components/chat/sql-result-card.tsx
@@ -82,6 +82,9 @@ export function SQLResultCard({ part }: { part: unknown }) {
         <span className="text-zinc-500">
           {rows.length} row{rows.length !== 1 ? "s" : ""}
           {result.truncated ? "+" : ""}
+          {typeof result.executionMs === "number" && (
+            <> · {result.cached ? "cached" : `${(result.executionMs / 1000).toFixed(1)}s`}</>
+          )}
         </span>
         <span className="text-zinc-400 dark:text-zinc-600">{open ? "\u25BE" : "\u25B8"}</span>
       </button>

--- a/packages/web/src/ui/components/chat/sql-result-card.tsx
+++ b/packages/web/src/ui/components/chat/sql-result-card.tsx
@@ -92,6 +92,9 @@ function SQLResultCardInner({ part }: { part: unknown }) {
         <span className="text-zinc-500">
           {rows.length} row{rows.length !== 1 ? "s" : ""}
           {result.truncated ? "+" : ""}
+          {typeof result.executionMs === "number" && (
+            <> · {result.cached ? "cached" : `${(result.executionMs / 1000).toFixed(1)}s`}</>
+          )}
         </span>
       }
     >

--- a/packages/web/src/ui/components/chat/sql-result-card.tsx
+++ b/packages/web/src/ui/components/chat/sql-result-card.tsx
@@ -92,7 +92,7 @@ function SQLResultCardInner({ part }: { part: unknown }) {
         <span className="text-zinc-500">
           {rows.length} row{rows.length !== 1 ? "s" : ""}
           {result.truncated ? "+" : ""}
-          {typeof result.executionMs === "number" && (
+          {Number.isFinite(result.executionMs) && (
             <> · {result.cached ? "cached" : `${(result.executionMs / 1000).toFixed(1)}s`}</>
           )}
         </span>


### PR DESCRIPTION
## Summary

- Add `executionMs` to the `executeSQL` tool response — live queries include wall-clock duration, cached queries get `0`
- Display execution timing in SQL result card headers as `· 1.2s` (or `· cached` for cache hits) in both `@atlas/web` and `@useatlas/react`
- Graceful degradation for old messages without the field (`typeof` guard)

## Test plan

- [x] `bun run lint` — pass
- [x] `bun run type` — pass
- [x] `bun run test` — 103 SQL tool tests pass, full suite green
- [x] `bun x syncpack lint` — pass
- [x] Template drift check — pass
- [ ] Manual: run a query in chat, verify `· Xs` appears in result header
- [ ] Manual: trigger a cached query, verify `· cached` appears
- [ ] Manual: load an old conversation, verify result cards render without errors

Closes #1397