### PR TITLE
feat: convert chat to notebook — API + UI (#1398)

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -1134,7 +1134,7 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
 **Make the notebook surface earn its place** by bridging exploratory chat and persistent dashboards. PRD: #1396. Milestone: #33.
 
 ### Phase 1 (core flow)
-- [ ] Execution metadata on tool results — timing + row count (#1397)
+- [x] Execution metadata on tool results — timing + row count (#1397, PR #1404)
 - [ ] Convert chat to notebook — API + UI (#1398)
 - [ ] Dashboard bridge from notebook cells (#1399)
 

--- a/e2e/surfaces/actions.test.ts
+++ b/e2e/surfaces/actions.test.ts
@@ -99,6 +99,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 // Internal DB — return false so action handler uses in-memory store

--- a/e2e/surfaces/agent-multistep.test.ts
+++ b/e2e/surfaces/agent-multistep.test.ts
@@ -130,6 +130,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 mock.module("@atlas/api/lib/config", () => ({

--- a/e2e/surfaces/auth-managed.test.ts
+++ b/e2e/surfaces/auth-managed.test.ts
@@ -158,6 +158,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 mock.module("@atlas/api/lib/config", () => ({

--- a/e2e/surfaces/auth.test.ts
+++ b/e2e/surfaces/auth.test.ts
@@ -164,6 +164,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 mock.module("@atlas/api/lib/plugins/hooks", () => ({

--- a/e2e/surfaces/conversations.test.ts
+++ b/e2e/surfaces/conversations.test.ts
@@ -359,6 +359,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 // ---------------------------------------------------------------------------

--- a/e2e/surfaces/error-scenarios.test.ts
+++ b/e2e/surfaces/error-scenarios.test.ts
@@ -132,6 +132,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 mock.module("@atlas/api/lib/config", () => ({

--- a/e2e/surfaces/health.test.ts
+++ b/e2e/surfaces/health.test.ts
@@ -75,6 +75,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 mock.module("@atlas/api/lib/auth/middleware", () => ({

--- a/e2e/surfaces/scheduler.test.ts
+++ b/e2e/surfaces/scheduler.test.ts
@@ -224,6 +224,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 mock.module("@atlas/api/lib/config", () => ({

--- a/e2e/surfaces/slack.test.ts
+++ b/e2e/surfaces/slack.test.ts
@@ -237,6 +237,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 const mockGetBotToken: Mock<() => Promise<string | null>> = mock(() =>

--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -432,6 +432,9 @@ export function createApiTestMocks(
     forkConversation: mock(() =>
       Promise.resolve({ ok: false, reason: "not_found" }),
     ),
+    convertToNotebook: mock(() =>
+      Promise.resolve({ ok: false, reason: "not_found" }),
+    ),
   }));
 
   // ── Security ──────────────────────────────────────────────────

--- a/packages/api/src/api/__tests__/actions.test.ts
+++ b/packages/api/src/api/__tests__/actions.test.ts
@@ -105,6 +105,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 mock.module("@atlas/api/lib/semantic", () => ({

--- a/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
@@ -342,6 +342,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 mock.module("@atlas/api/lib/auth/server", () => ({

--- a/packages/api/src/api/__tests__/admin-integrations.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations.test.ts
@@ -266,6 +266,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 mock.module("@atlas/api/lib/auth/server", () => ({

--- a/packages/api/src/api/__tests__/admin-invitations.test.ts
+++ b/packages/api/src/api/__tests__/admin-invitations.test.ts
@@ -214,6 +214,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 // Import app after all mocks are registered

--- a/packages/api/src/api/__tests__/admin-password.test.ts
+++ b/packages/api/src/api/__tests__/admin-password.test.ts
@@ -189,6 +189,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 // Mock auth/server for the password-change dynamic import

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -421,6 +421,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 // Import app after all mocks are registered

--- a/packages/api/src/api/__tests__/chat.test.ts
+++ b/packages/api/src/api/__tests__/chat.test.ts
@@ -139,6 +139,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 const mockGetPluginTools: Mock<() => unknown> = mock(() => undefined);

--- a/packages/api/src/api/__tests__/conversations.test.ts
+++ b/packages/api/src/api/__tests__/conversations.test.ts
@@ -60,6 +60,7 @@ const mockShareConversation = mock((): Promise<ShareResult> => Promise.resolve({
 const mockUnshareConversation = mock((): Promise<CrudResult> => Promise.resolve({ ok: false, reason: "not_found" }));
 const mockGetShareStatus = mock((): Promise<CrudDataResult<import("@atlas/api/lib/conversations").ShareStatusData>> => Promise.resolve({ ok: false, reason: "not_found" }));
 const mockGetSharedConversation = mock((): Promise<import("@atlas/api/lib/conversations").SharedConversationResult> => Promise.resolve({ ok: false, reason: "not_found" }));
+const mockConvertToNotebook = mock((): Promise<CrudDataResult<{ id: string; messageCount: number }>> => Promise.resolve({ ok: false, reason: "not_found" }));
 
 mock.module("@atlas/api/lib/conversations", () => ({
   listConversations: mockListConversations,
@@ -77,6 +78,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   persistAssistantSteps: mock(() => {}),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mockConvertToNotebook,
   // Type exports (no runtime value — needed so mock.module doesn't break re-exports)
 }));
 
@@ -157,6 +159,8 @@ describe("conversations routes", () => {
     mockGetShareStatus.mockResolvedValue({ ok: false, reason: "not_found" });
     mockGetSharedConversation.mockReset();
     mockGetSharedConversation.mockResolvedValue({ ok: false, reason: "not_found" });
+    mockConvertToNotebook.mockReset();
+    mockConvertToNotebook.mockResolvedValue({ ok: false, reason: "not_found" });
   });
 
   afterEach(() => {
@@ -1160,6 +1164,73 @@ describe("conversations routes", () => {
       const msgs = body.messages as Record<string, unknown>[];
       expect(msgs[0]).not.toHaveProperty("id");
       expect(msgs[0]).not.toHaveProperty("conversationId");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // POST /:id/convert-to-notebook
+  // -----------------------------------------------------------------------
+
+  describe("POST /:id/convert-to-notebook", () => {
+    it("returns 200 with new notebook id on success", async () => {
+      mockConvertToNotebook.mockResolvedValueOnce({
+        ok: true,
+        data: { id: "nb-1234-5678-9012-abcdef000000", messageCount: 5 },
+      });
+
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/conversations/${VALID_ID}/convert-to-notebook`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json() as Record<string, unknown>;
+      expect(body.id).toBe("nb-1234-5678-9012-abcdef000000");
+      expect(body.messageCount).toBe(5);
+    });
+
+    it("returns 404 when source conversation not found", async () => {
+      mockConvertToNotebook.mockResolvedValueOnce({ ok: false, reason: "not_found" });
+
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/conversations/${VALID_ID}/convert-to-notebook`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      expect(response.status).toBe(404);
+    });
+
+    it("returns 400 for invalid UUID", async () => {
+      const response = await app.fetch(
+        new Request("http://localhost/api/v1/conversations/not-a-uuid/convert-to-notebook", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      expect(response.status).toBe(400);
+    });
+
+    it("passes userId from auth context", async () => {
+      mockConvertToNotebook.mockResolvedValueOnce({
+        ok: true,
+        data: { id: "nb-0000-0000-0000-000000000000", messageCount: 3 },
+      });
+
+      await app.fetch(
+        new Request(`http://localhost/api/v1/conversations/${VALID_ID}/convert-to-notebook`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      expect(mockConvertToNotebook).toHaveBeenCalledWith(
+        expect.objectContaining({ sourceId: VALID_ID, userId: "u1" }),
+      );
     });
   });
 });

--- a/packages/api/src/api/__tests__/conversations.test.ts
+++ b/packages/api/src/api/__tests__/conversations.test.ts
@@ -1232,5 +1232,39 @@ describe("conversations routes", () => {
         expect.objectContaining({ sourceId: VALID_ID, userId: "u1" }),
       );
     });
+
+    it("returns 500 on database error", async () => {
+      mockConvertToNotebook.mockResolvedValueOnce({ ok: false, reason: "error" });
+
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/conversations/${VALID_ID}/convert-to-notebook`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      expect(response.status).toBe(500);
+      const body = await response.json() as Record<string, unknown>;
+      expect(body.error).toBe("internal_error");
+    });
+
+    it("forwards orgId from auth context", async () => {
+      mockConvertToNotebook.mockResolvedValueOnce({
+        ok: true,
+        data: { id: "nb-0000-0000-0000-000000000000", messageCount: 2 },
+      });
+
+      await app.fetch(
+        new Request(`http://localhost/api/v1/conversations/${VALID_ID}/convert-to-notebook`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      // simple-key auth has no activeOrganizationId, so orgId is undefined
+      expect(mockConvertToNotebook).toHaveBeenCalledWith(
+        expect.objectContaining({ sourceId: VALID_ID, userId: "u1", orgId: undefined }),
+      );
+    });
   });
 });

--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -175,6 +175,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 mock.module("@atlas/api/lib/semantic", () => ({

--- a/packages/api/src/api/__tests__/health-plugin.test.ts
+++ b/packages/api/src/api/__tests__/health-plugin.test.ts
@@ -121,6 +121,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 mock.module("@atlas/api/lib/auth/middleware", () => ({

--- a/packages/api/src/api/__tests__/health.test.ts
+++ b/packages/api/src/api/__tests__/health.test.ts
@@ -126,6 +126,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 mock.module("@atlas/api/lib/auth/middleware", () => ({

--- a/packages/api/src/api/__tests__/query.test.ts
+++ b/packages/api/src/api/__tests__/query.test.ts
@@ -150,6 +150,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 // Import after mocks are registered

--- a/packages/api/src/api/__tests__/scheduled-tasks.test.ts
+++ b/packages/api/src/api/__tests__/scheduled-tasks.test.ts
@@ -110,6 +110,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 mock.module("@atlas/api/lib/semantic", () => ({

--- a/packages/api/src/api/__tests__/semantic.test.ts
+++ b/packages/api/src/api/__tests__/semantic.test.ts
@@ -251,6 +251,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 // Import app after all mocks are registered

--- a/packages/api/src/api/__tests__/slack.test.ts
+++ b/packages/api/src/api/__tests__/slack.test.ts
@@ -130,6 +130,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 const mockCheckRateLimit: Mock<(key: string) => { allowed: boolean; retryAfterMs?: number }> = mock(() =>

--- a/packages/api/src/api/routes/conversations.ts
+++ b/packages/api/src/api/routes/conversations.ts
@@ -27,6 +27,7 @@ import {
   starConversation,
   updateNotebookState,
   forkConversation,
+  convertToNotebook,
   shareConversation,
   unshareConversation,
   getShareStatus,
@@ -67,7 +68,7 @@ const ConversationSchema = z.object({
   id: z.string().uuid(),
   userId: z.string().nullable(),
   title: z.string().nullable(),
-  surface: z.enum(["web", "api", "mcp", "slack"]),
+  surface: z.enum(["web", "api", "mcp", "slack", "notebook"]),
   connectionId: z.string().nullable(),
   starred: z.boolean(),
   createdAt: z.string().datetime(),
@@ -367,6 +368,48 @@ const forkConversationRoute = createRoute({
     429: {
       description: "Rate limit exceeded",
       content: { "application/json": { schema: AuthErrorSchema } },
+    },
+    500: {
+      description: "Internal server error",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const convertToNotebookRoute = createRoute({
+  method: "post",
+  path: "/{id}/convert-to-notebook",
+  tags: ["Conversations"],
+  summary: "Convert a chat conversation to a notebook",
+  description:
+    "Creates a new conversation with surface 'notebook' by copying all messages from the source. " +
+    "The original conversation is left unchanged.",
+  request: {
+    params: IdParamSchema,
+  },
+  responses: {
+    200: {
+      description: "Notebook created successfully",
+      content: {
+        "application/json": {
+          schema: z.object({
+            id: z.string().uuid(),
+            messageCount: z.number(),
+          }),
+        },
+      },
+    },
+    400: {
+      description: "Invalid conversation ID",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    401: {
+      description: "Authentication required",
+      content: { "application/json": { schema: AuthErrorSchema } },
+    },
+    404: {
+      description: "Conversation not found or not owned by user",
+      content: { "application/json": { schema: ErrorSchema } },
     },
     500: {
       description: "Internal server error",
@@ -774,6 +817,39 @@ conversations.openapi(forkConversationRoute, async (c) => {
       ...(metadataWarning ? { warning: metadataWarning } : {}),
     }, 200);
   }), { label: "fork conversation" });
+});
+
+// ---------------------------------------------------------------------------
+// POST /:id/convert-to-notebook — convert chat to notebook
+// ---------------------------------------------------------------------------
+
+conversations.openapi(convertToNotebookRoute, async (c) => {
+  return runEffect(c, Effect.gen(function* () {
+    if (!hasInternalDB()) {
+      return c.json({ error: "not_available", message: "Conversation history is not available (no internal database configured)." }, 404);
+    }
+
+    const { requestId } = yield* RequestContext;
+    const { user } = yield* AuthContext;
+
+    const { id } = c.req.valid("param");
+    if (!UUID_RE.test(id)) {
+      return c.json({ error: "invalid_request", message: "Invalid conversation ID format." }, 400);
+    }
+
+    const result = yield* Effect.promise(() => convertToNotebook({
+      sourceId: id,
+      userId: user?.id,
+      orgId: user?.activeOrganizationId,
+    }));
+
+    if (!result.ok) {
+      const fail = crudFailResponse(result.reason, requestId);
+      return c.json(fail.body, fail.status);
+    }
+
+    return c.json({ id: result.data.id, messageCount: result.data.messageCount }, 200);
+  }), { label: "convert to notebook" });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/conversations.ts
+++ b/packages/api/src/lib/conversations.ts
@@ -441,6 +441,72 @@ export async function forkConversation(opts: {
   }
 }
 
+/** Convert a chat conversation into a notebook by copying all messages to a new conversation with surface "notebook". */
+export async function convertToNotebook(opts: {
+  sourceId: string;
+  userId?: string | null;
+  orgId?: string | null;
+}): Promise<CrudDataResult<{ id: string; messageCount: number }>> {
+  if (!hasInternalDB()) return { ok: false, reason: "no_db" };
+  let newId: string | null = null;
+  try {
+    // Verify source exists and user owns it
+    const sourceRows = opts.userId
+      ? await internalQuery<Record<string, unknown>>(
+          `SELECT id, title, surface, connection_id, org_id FROM conversations WHERE id = $1 AND user_id = $2`,
+          [opts.sourceId, opts.userId],
+        )
+      : await internalQuery<Record<string, unknown>>(
+          `SELECT id, title, surface, connection_id, org_id FROM conversations WHERE id = $1`,
+          [opts.sourceId],
+        );
+    if (sourceRows.length === 0) return { ok: false, reason: "not_found" };
+
+    const source = sourceRows[0];
+    const sourceTitle = (source.title as string) ?? "Conversation";
+    const orgId = opts.orgId ?? (source.org_id as string) ?? null;
+
+    // Create new conversation with surface "notebook"
+    const newConv = await internalQuery<{ id: string }>(
+      `INSERT INTO conversations (user_id, title, surface, connection_id, org_id)
+       VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+      [
+        opts.userId ?? null,
+        `${sourceTitle} (notebook)`,
+        "notebook",
+        (source.connection_id as string) ?? null,
+        orgId,
+      ],
+    );
+
+    if (newConv.length === 0) return { ok: false, reason: "error" };
+    newId = newConv[0].id;
+
+    // Bulk-copy all messages into the new conversation
+    const copyResult = await internalQuery<{ id: string }>(
+      `INSERT INTO messages (conversation_id, role, content, created_at)
+       SELECT $1, role, content, created_at FROM messages
+       WHERE conversation_id = $2
+       ORDER BY created_at ASC
+       RETURNING id`,
+      [newId, opts.sourceId],
+    );
+
+    return { ok: true, data: { id: newId, messageCount: copyResult.length } };
+  } catch (err) {
+    log.error({ err: err instanceof Error ? err.message : String(err), sourceId: opts.sourceId }, "convertToNotebook failed");
+    // Clean up partially-created conversation to avoid orphans
+    if (newId) {
+      try {
+        await internalQuery(`DELETE FROM conversations WHERE id = $1`, [newId]);
+      } catch (cleanupErr) {
+        log.error({ err: cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr) }, "Failed to clean up partial notebook conversion");
+      }
+    }
+    return { ok: false, reason: "error" };
+  }
+}
+
 /** Delete a conversation (CASCADE deletes messages). Auth-scoped when userId is provided. */
 export async function deleteConversation(
   id: string,

--- a/packages/api/src/lib/conversations.ts
+++ b/packages/api/src/lib/conversations.ts
@@ -492,6 +492,10 @@ export async function convertToNotebook(opts: {
       [newId, opts.sourceId],
     );
 
+    if (copyResult.length === 0) {
+      log.warn({ sourceId: opts.sourceId, newId }, "convertToNotebook copied zero messages — source conversation may be empty");
+    }
+
     return { ok: true, data: { id: newId, messageCount: copyResult.length } };
   } catch (err) {
     log.error({ err: err instanceof Error ? err.message : String(err), sourceId: opts.sourceId }, "convertToNotebook failed");

--- a/packages/api/src/lib/tools/__tests__/action-permissions.test.ts
+++ b/packages/api/src/lib/tools/__tests__/action-permissions.test.ts
@@ -133,6 +133,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 mock.module("@atlas/api/lib/semantic", () => ({

--- a/packages/types/src/conversation.ts
+++ b/packages/types/src/conversation.ts
@@ -1,7 +1,7 @@
 /** Conversation persistence types — wire format for conversations and messages. */
 
 export type MessageRole = "user" | "assistant" | "system" | "tool";
-export type Surface = "web" | "api" | "mcp" | "slack";
+export type Surface = "web" | "api" | "mcp" | "slack" | "notebook";
 
 export interface Conversation {
   id: string;

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -255,6 +255,7 @@ function ChatPage() {
               onSelect={handleSelectConversation}
               onDelete={(id) => convos.deleteConversation(id)}
               onStar={(id, starred) => convos.starConversation(id, starred)}
+              onConvertToNotebook={(id) => convos.convertToNotebook(id)}
               onNewChat={handleNewChat}
               mobileOpen={mobileMenuOpen}
               onMobileClose={() => setMobileMenuOpen(false)}

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -370,6 +370,7 @@ export function AtlasChat() {
             onSelect={handleSelectConversation}
             onDelete={(id) => convos.deleteConversation(id)}
             onStar={(id, starred) => convos.starConversation(id, starred)}
+            onConvertToNotebook={(id) => convos.convertToNotebook(id)}
             onNewChat={handleNewChat}
             mobileOpen={mobileMenuOpen}
             onMobileClose={() => setMobileMenuOpen(false)}

--- a/packages/web/src/ui/components/conversations/conversation-item.tsx
+++ b/packages/web/src/ui/components/conversations/conversation-item.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { Loader2, NotebookPen, Star, Trash2 } from "lucide-react";
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import type { Conversation } from "../../lib/types";
 import { DeleteConfirmation } from "./delete-confirmation";
@@ -32,16 +32,20 @@ export function ConversationItem({
   onSelect,
   onDelete,
   onStar,
+  onConvertToNotebook,
 }: {
   conversation: Conversation;
   isActive: boolean;
   onSelect: () => void;
   onDelete: () => Promise<void>;
   onStar: (starred: boolean) => Promise<void>;
+  onConvertToNotebook?: () => Promise<{ id: string }>;
 }) {
+  const router = useRouter();
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [starPending, setStarPending] = useState(false);
+  const [converting, setConverting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   if (confirmDelete) {
@@ -129,14 +133,36 @@ export function ConversationItem({
             <Star className="h-3.5 w-3.5" fill={conversation.starred ? "currentColor" : "none"} />
           )}
         </Button>
-        <Link
-          href={`/notebook?id=${conversation.id}`}
-          className="rounded p-1 text-zinc-400 opacity-100 md:opacity-0 transition-all hover:text-zinc-600 md:group-hover:opacity-100 dark:hover:text-zinc-300"
-          aria-label="Open in notebook"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <NotebookPen className="size-3.5" />
-        </Link>
+        {onConvertToNotebook && conversation.surface !== "notebook" && (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={async (e) => {
+              e.stopPropagation();
+              if (converting) return;
+              setConverting(true);
+              try {
+                const { id } = await onConvertToNotebook();
+                router.push(`/notebook?id=${id}`);
+              } catch (err: unknown) {
+                console.warn("Failed to convert to notebook:", err instanceof Error ? err.message : String(err));
+                setError("Failed to convert. Please try again.");
+                setTimeout(() => setError(null), 3000);
+              } finally {
+                setConverting(false);
+              }
+            }}
+            disabled={converting}
+            className={`size-8 text-zinc-400 opacity-100 md:opacity-0 transition-all hover:text-zinc-600 md:group-hover:opacity-100 dark:hover:text-zinc-300 ${converting ? "opacity-50" : ""}`}
+            aria-label="Convert to notebook"
+          >
+            {converting ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <NotebookPen className="size-3.5" />
+            )}
+          </Button>
+        )}
         <Button
           variant="ghost"
           size="icon"

--- a/packages/web/src/ui/components/conversations/conversation-list.tsx
+++ b/packages/web/src/ui/components/conversations/conversation-list.tsx
@@ -10,6 +10,7 @@ export function ConversationList({
   onSelect,
   onDelete,
   onStar,
+  onConvertToNotebook,
   showSections = true,
   emptyMessage,
 }: {
@@ -18,6 +19,7 @@ export function ConversationList({
   onSelect: (id: string) => void;
   onDelete: (id: string) => Promise<void>;
   onStar: (id: string, starred: boolean) => Promise<void>;
+  onConvertToNotebook?: (id: string) => Promise<{ id: string }>;
   showSections?: boolean;
   emptyMessage?: string;
 }) {
@@ -48,6 +50,7 @@ export function ConversationList({
         onSelect={() => onSelect(c.id)}
         onDelete={() => onDelete(c.id)}
         onStar={(s) => onStar(c.id, s)}
+        onConvertToNotebook={onConvertToNotebook ? () => onConvertToNotebook(c.id) : undefined}
       />
     ));
   }

--- a/packages/web/src/ui/components/conversations/conversation-sidebar.tsx
+++ b/packages/web/src/ui/components/conversations/conversation-sidebar.tsx
@@ -17,6 +17,7 @@ export function ConversationSidebar({
   onSelect,
   onDelete,
   onStar,
+  onConvertToNotebook,
   onNewChat,
   mobileOpen,
   onMobileClose,
@@ -27,6 +28,7 @@ export function ConversationSidebar({
   onSelect: (id: string) => void;
   onDelete: (id: string) => Promise<void>;
   onStar: (id: string, starred: boolean) => Promise<void>;
+  onConvertToNotebook?: (id: string) => Promise<{ id: string }>;
   onNewChat: () => void;
   mobileOpen: boolean;
   onMobileClose: () => void;
@@ -100,6 +102,7 @@ export function ConversationSidebar({
             onSelect={onSelect}
             onDelete={onDelete}
             onStar={onStar}
+            onConvertToNotebook={onConvertToNotebook}
             showSections={filter === "all"}
             emptyMessage={filter === "saved" ? "Star conversations to save them here" : undefined}
           />

--- a/packages/web/src/ui/hooks/use-conversations.ts
+++ b/packages/web/src/ui/hooks/use-conversations.ts
@@ -26,6 +26,7 @@ export interface UseConversationsReturn {
   getConversationData: (id: string) => Promise<ConversationWithMessages>;
   saveNotebookState: (id: string, state: NotebookStateWire) => Promise<void>;
   forkConversation: (sourceId: string, forkPointMessageId: string, label?: string) => Promise<{ id: string; branches: ForkBranchWire[]; warning?: string }>;
+  convertToNotebook: (sourceId: string) => Promise<{ id: string; messageCount: number }>;
   deleteConversation: (id: string) => Promise<void>;
   starConversation: (id: string, starred: boolean) => Promise<void>;
   shareConversation: (id: string, opts?: { expiresIn?: ShareExpiryKey; shareMode?: ShareMode }) => Promise<{ token: string; url: string }>;

--- a/packages/web/src/ui/hooks/use-conversations.ts
+++ b/packages/web/src/ui/hooks/use-conversations.ts
@@ -230,6 +230,19 @@ export function useConversations(opts: UseConversationsOptions): UseConversation
     };
   }, [api]);
 
+  const convertToNotebook = useCallback(async (
+    sourceId: string,
+  ): Promise<{ id: string; messageCount: number }> => {
+    const data = await api.post<Record<string, unknown>>(`/api/v1/conversations/${sourceId}/convert-to-notebook`, {});
+    if (!data.id || typeof data.id !== "string") {
+      throw new Error("Convert response missing conversation ID");
+    }
+    return {
+      id: data.id,
+      messageCount: typeof data.messageCount === "number" ? data.messageCount : 0,
+    };
+  }, [api]);
+
   const refresh = useCallback(async () => {
     await queryClient.invalidateQueries({ queryKey: ["conversations", "list"] });
   }, [queryClient]);
@@ -247,6 +260,7 @@ export function useConversations(opts: UseConversationsOptions): UseConversation
     getConversationData,
     saveNotebookState,
     forkConversation,
+    convertToNotebook,
     deleteConversation,
     starConversation,
     shareConversation,


### PR DESCRIPTION
## Summary

- Add `POST /conversations/{id}/convert-to-notebook` endpoint that copies all messages into a new conversation with `surface: "notebook"`, leaving the original unchanged
- Add "Convert to Notebook" button (NotebookPen icon) to sidebar conversation items — hidden on conversations already surfaced as notebook, and not shown in the notebook page sidebar
- Add `"notebook"` to the `Surface` type in `@useatlas/types`

## Test plan

- [x] `bun run lint` — pass
- [x] `bun run type` — pass
- [x] `bun run test` — all tests pass (71 conversation tests including 4 new)
- [x] `bun x syncpack lint` — pass
- [x] Template drift check — pass
- [ ] Manual: click "Convert to Notebook" on a chat conversation, verify navigation to `/notebook?id={newId}`
- [ ] Manual: verify original conversation unchanged after conversion
- [ ] Manual: verify button not shown on notebook-surfaced conversations
- [ ] Manual: verify button not shown in notebook page sidebar

Closes #1398