### PR TITLE
feat: dashboard bridge from notebook cells

### DIFF
--- a/packages/types/src/conversation.ts
+++ b/packages/types/src/conversation.ts
@@ -30,6 +30,8 @@ export interface NotebookStateWire {
   forkPointCellId?: string;
   /** Text cell content keyed by cell ID (text cells are not message-backed). */
   textCells?: Record<string, { content: string }>;
+  /** Tracks which notebook cells have been added to dashboards. */
+  dashboardCards?: Record<string, { dashboardId: string; cardId: string }>;
 }
 
 /** A fork branch — metadata for a forked conversation. */

--- a/packages/web/src/ui/components/chat/add-to-dashboard-dialog.tsx
+++ b/packages/web/src/ui/components/chat/add-to-dashboard-dialog.tsx
@@ -58,6 +58,8 @@ interface AddToDashboardDialogProps {
   rows: Record<string, unknown>[];
   chartResult: ChartDetectionResult;
   explanation?: string;
+  /** Called after a card is successfully added to a dashboard. */
+  onAdded?: (dashboardId: string, cardId: string) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -72,6 +74,7 @@ export function AddToDashboardDialog({
   rows,
   chartResult,
   explanation,
+  onAdded,
 }: AddToDashboardDialogProps) {
   const [mode, setMode] = useState<"existing" | "new">("existing");
   const [selectedDashboardId, setSelectedDashboardId] = useState<string>("");
@@ -90,7 +93,7 @@ export function AddToDashboardDialog({
   }>("/api/v1/dashboards");
 
   const { mutate: createDashboard, saving: creatingDashboard } = useAdminMutation<Dashboard>({});
-  const { mutate: addCard, saving: addingCard } = useAdminMutation({});
+  const { mutate: addCard, saving: addingCard } = useAdminMutation<{ id: string }>({});
 
   const saving = creatingDashboard || addingCard;
 
@@ -201,6 +204,11 @@ export function AddToDashboardDialog({
           setError(cardResult.error ?? "Failed to add card.");
         }
         return;
+      }
+
+      const cardId = (cardResult.data as { id: string } | null)?.id;
+      if (cardId) {
+        onAdded?.(dashboardId, cardId);
       }
 
       setSuccess(true);

--- a/packages/web/src/ui/components/chat/add-to-dashboard-dialog.tsx
+++ b/packages/web/src/ui/components/chat/add-to-dashboard-dialog.tsx
@@ -206,9 +206,11 @@ export function AddToDashboardDialog({
         return;
       }
 
-      const cardId = (cardResult.data as { id: string } | null)?.id;
+      const cardId = cardResult.data?.id;
       if (cardId) {
         onAdded?.(dashboardId, cardId);
+      } else {
+        console.warn("Dashboard card created but server response did not include card ID — notebook tracking skipped.");
       }
 
       setSuccess(true);

--- a/packages/web/src/ui/components/chat/sql-result-card.tsx
+++ b/packages/web/src/ui/components/chat/sql-result-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, useCallback } from "react";
+import { useMemo, useState } from "react";
 import { getToolArgs, getToolResult, isToolComplete, downloadCSV, downloadExcel, toCsvString } from "../../lib/helpers";
 import { FileDown, FileSpreadsheet, LayoutDashboard } from "lucide-react";
 import { useDarkMode } from "../../hooks/use-dark-mode";
@@ -51,11 +51,14 @@ function SQLResultCardInner({ part }: { part: unknown }) {
   const cellId = bridge?.cellId ?? null;
   const isOnDashboard = cellId ? !!bridge?.dashboardCards[cellId] : false;
 
-  const handleDashboardAdded = useCallback((dashboardId: string, cardId: string) => {
-    if (cellId && bridge) {
-      bridge.onDashboardCardAdded(cellId, { dashboardId, cardId });
+  function handleDashboardAdded(dashboardId: string, cardId: string) {
+    if (!bridge) return; // Not in notebook context
+    if (!cellId) {
+      console.warn("Dashboard card added but cellId is null in bridge context — tracking skipped.");
+      return;
     }
-  }, [cellId, bridge]);
+    bridge.onDashboardCardAdded(cellId, { dashboardId, cardId });
+  }
 
   const columns = useMemo(
     () => (done && result?.success ? ((result.columns as string[]) ?? []) : []),

--- a/packages/web/src/ui/components/chat/sql-result-card.tsx
+++ b/packages/web/src/ui/components/chat/sql-result-card.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, useCallback } from "react";
 import { getToolArgs, getToolResult, isToolComplete, downloadCSV, downloadExcel, toCsvString } from "../../lib/helpers";
 import { FileDown, FileSpreadsheet, LayoutDashboard } from "lucide-react";
 import { useDarkMode } from "../../hooks/use-dark-mode";
 import { detectCharts } from "../chart/chart-detection";
 import dynamic from "next/dynamic";
+import { useDashboardBridge } from "../notebook/dashboard-bridge-context";
 
 const ResultChart = dynamic(
   () => import("../chart/result-chart").then((m) => ({ default: m.ResultChart })),
@@ -37,6 +38,7 @@ const AddToDashboardDialog = dynamic(
 
 function SQLResultCardInner({ part }: { part: unknown }) {
   const dark = useDarkMode();
+  const bridge = useDashboardBridge();
   const args = getToolArgs(part);
   const result = getToolResult(part) as Record<string, unknown> | null;
   const done = isToolComplete(part);
@@ -44,6 +46,16 @@ function SQLResultCardInner({ part }: { part: unknown }) {
   const [viewMode, setViewMode] = useState<"both" | "chart" | "table">("both");
   const [excelError, setExcelError] = useState(false);
   const [dashboardDialogOpen, setDashboardDialogOpen] = useState(false);
+
+  // In notebook context, track which cell this result belongs to
+  const cellId = bridge?.cellId ?? null;
+  const isOnDashboard = cellId ? !!bridge?.dashboardCards[cellId] : false;
+
+  const handleDashboardAdded = useCallback((dashboardId: string, cardId: string) => {
+    if (cellId && bridge) {
+      bridge.onDashboardCardAdded(cellId, { dashboardId, cardId });
+    }
+  }, [cellId, bridge]);
 
   const columns = useMemo(
     () => (done && result?.success ? ((result.columns as string[]) ?? []) : []),
@@ -89,7 +101,15 @@ function SQLResultCardInner({ part }: { part: unknown }) {
       badgeClassName="bg-blue-100 text-blue-700 dark:bg-blue-600/20 dark:text-blue-400"
       title={String(args.explanation ?? "Query result")}
       headerExtra={
-        <span className="text-zinc-500">
+        <span className="flex items-center gap-1.5 text-zinc-500">
+          {isOnDashboard && (
+            <span
+              className="inline-flex items-center gap-1 rounded bg-emerald-100 px-1.5 py-0.5 text-emerald-700 dark:bg-emerald-600/20 dark:text-emerald-400"
+              title="Added to dashboard"
+            >
+              <LayoutDashboard className="size-3" />
+            </span>
+          )}
           {rows.length} row{rows.length !== 1 ? "s" : ""}
           {result.truncated ? "+" : ""}
           {Number.isFinite(result.executionMs) && (
@@ -189,6 +209,7 @@ function SQLResultCardInner({ part }: { part: unknown }) {
             rows={rows}
             chartResult={chartResult}
             explanation={String(args.explanation ?? "")}
+            onAdded={handleDashboardAdded}
           />
         </ResultCardErrorBoundary>
       )}

--- a/packages/web/src/ui/components/notebook/dashboard-bridge-context.tsx
+++ b/packages/web/src/ui/components/notebook/dashboard-bridge-context.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+export interface DashboardCardEntry {
+  dashboardId: string;
+  cardId: string;
+}
+
+interface DashboardBridgeContextValue {
+  /** Current notebook cell ID (set by the cell renderer). */
+  cellId: string | null;
+  /** Map of cellId → dashboard card info for cells already added to a dashboard. */
+  dashboardCards: Record<string, DashboardCardEntry>;
+  /** Callback to record that a cell was added to a dashboard. */
+  onDashboardCardAdded: (cellId: string, entry: DashboardCardEntry) => void;
+}
+
+const DashboardBridgeContext = createContext<DashboardBridgeContextValue | null>(null);
+
+export const DashboardBridgeProvider = DashboardBridgeContext.Provider;
+
+/** Returns the dashboard bridge context if inside a notebook cell, or null in chat/shared views. */
+export function useDashboardBridge(): DashboardBridgeContextValue | null {
+  return useContext(DashboardBridgeContext);
+}

--- a/packages/web/src/ui/components/notebook/notebook-cell.tsx
+++ b/packages/web/src/ui/components/notebook/notebook-cell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { forwardRef, useState, useMemo } from "react";
+import { forwardRef, useState } from "react";
 import { ChevronDown, ChevronRight, GripVertical } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SortableItemHandle } from "@/components/ui/sortable";
@@ -35,11 +35,11 @@ export const NotebookCell = forwardRef<HTMLElement, NotebookCellProps>(
     const question = extractTextContent(cell.userMessage);
     const isRunning = cell.status === "running";
 
-    const bridgeValue = useMemo(() => ({
+    const bridgeValue = {
       cellId: cell.id,
       dashboardCards,
       onDashboardCardAdded,
-    }), [cell.id, dashboardCards, onDashboardCardAdded]);
+    };
 
     return (
       <>

--- a/packages/web/src/ui/components/notebook/notebook-cell.tsx
+++ b/packages/web/src/ui/components/notebook/notebook-cell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { forwardRef, useState } from "react";
+import { forwardRef, useState, useMemo } from "react";
 import { ChevronDown, ChevronRight, GripVertical } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SortableItemHandle } from "@/components/ui/sortable";
@@ -11,6 +11,7 @@ import { NotebookCellInput } from "./notebook-cell-input";
 import { NotebookCellOutput } from "./notebook-cell-output";
 import { DeleteCellDialog } from "./delete-cell-dialog";
 import { extractTextContent } from "./use-notebook";
+import { DashboardBridgeProvider, type DashboardCardEntry } from "./dashboard-bridge-context";
 
 interface NotebookCellProps {
   cell: ResolvedCell;
@@ -21,16 +22,24 @@ interface NotebookCellProps {
   onToggleCollapse: (cellId: string) => void;
   onCopy: (cellId: string) => Promise<void>;
   onFork: (cellId: string) => Promise<void>;
+  dashboardCards: Record<string, DashboardCardEntry>;
+  onDashboardCardAdded: (cellId: string, entry: DashboardCardEntry) => void;
 }
 
 export const NotebookCell = forwardRef<HTMLElement, NotebookCellProps>(
   function NotebookCell(
-    { cell, anyRunning, onRerun, onDelete, onToggleEdit, onToggleCollapse, onCopy, onFork },
+    { cell, anyRunning, onRerun, onDelete, onToggleEdit, onToggleCollapse, onCopy, onFork, dashboardCards, onDashboardCardAdded },
     ref,
   ) {
     const [showDeleteDialog, setShowDeleteDialog] = useState(false);
     const question = extractTextContent(cell.userMessage);
     const isRunning = cell.status === "running";
+
+    const bridgeValue = useMemo(() => ({
+      cellId: cell.id,
+      dashboardCards,
+      onDashboardCardAdded,
+    }), [cell.id, dashboardCards, onDashboardCardAdded]);
 
     return (
       <>
@@ -99,11 +108,13 @@ export const NotebookCell = forwardRef<HTMLElement, NotebookCellProps>(
             aria-label={`Cell ${cell.number} output`}
             className={cn("px-4 py-3", cell.editing && "opacity-50")}
           >
-            <NotebookCellOutput
-              assistantMessage={cell.assistantMessage}
-              status={cell.status}
-              collapsed={cell.collapsed}
-            />
+            <DashboardBridgeProvider value={bridgeValue}>
+              <NotebookCellOutput
+                assistantMessage={cell.assistantMessage}
+                status={cell.status}
+                collapsed={cell.collapsed}
+              />
+            </DashboardBridgeProvider>
           </div>
         </section>
 

--- a/packages/web/src/ui/components/notebook/notebook-shell.tsx
+++ b/packages/web/src/ui/components/notebook/notebook-shell.tsx
@@ -219,6 +219,8 @@ export function NotebookShell({ notebook, focusCellId }: NotebookShellProps) {
                           onToggleCollapse={notebook.toggleCollapse}
                           onCopy={notebook.copyCell}
                           onFork={notebook.forkCell}
+                          dashboardCards={notebook.dashboardCards}
+                          onDashboardCardAdded={notebook.addDashboardCard}
                         />
                       )}
                     </ErrorBoundary>

--- a/packages/web/src/ui/components/notebook/use-notebook.ts
+++ b/packages/web/src/ui/components/notebook/use-notebook.ts
@@ -172,6 +172,11 @@ export interface UseNotebookOptions {
   forkInfo?: ForkInfo | null;
 }
 
+export interface DashboardCardEntry {
+  dashboardId: string;
+  cardId: string;
+}
+
 export interface UseNotebookReturn {
   cells: ResolvedCell[];
   status: "ready" | "streaming" | "submitted" | "error";
@@ -192,6 +197,10 @@ export interface UseNotebookReturn {
   setInput: (value: string) => void;
   insertTextCell: (afterCellId?: string) => void;
   updateTextCell: (cellId: string, content: string) => void;
+  /** Map of cellId → dashboard card info for cells added to a dashboard. */
+  dashboardCards: Record<string, DashboardCardEntry>;
+  /** Record that a cell was added to a dashboard. */
+  addDashboardCard: (cellId: string, entry: DashboardCardEntry) => void;
 }
 
 export function useNotebook({
@@ -283,6 +292,12 @@ export function useNotebook({
     return saved?.cellOrder ?? [];
   });
 
+  // Dashboard card mappings — which cells have been added to dashboards
+  const [dashboardCards, setDashboardCards] = useState<Record<string, DashboardCardEntry>>(() => {
+    if (initialServerState?.dashboardCards) return initialServerState.dashboardCards;
+    return {};
+  });
+
   const pendingRerun = useRef<string | null>(null);
   // Snapshot of cell state taken before a rerun truncates messages. Used as
   // fallback during reconciliation so collapsed/editing state survives the
@@ -333,6 +348,7 @@ export function useNotebook({
       suppressSaveUntil.current = Date.now() + 1000;
       setCellState(freshCells);
       setCellOrder(initialServerState?.cellOrder ?? []);
+      setDashboardCards(initialServerState?.dashboardCards ?? {});
       return;
     }
 
@@ -399,12 +415,13 @@ export function useNotebook({
         cellOrder: cellOrder.length > 0 ? cellOrder : undefined,
         cellProps: Object.keys(cellProps).length > 0 ? cellProps : undefined,
         textCells: Object.keys(textCells).length > 0 ? textCells : undefined,
+        dashboardCards: Object.keys(dashboardCards).length > 0 ? dashboardCards : undefined,
       };
       saveToServer(wire);
     }, 500);
 
     return () => clearTimeout(timer);
-  }, [cellState, cellOrder, conversationId, saveToServer]);
+  }, [cellState, cellOrder, dashboardCards, conversationId, saveToServer]);
 
   // Migrate localStorage key when conversationId changes from temp to real
   const prevConversationId = useRef(conversationId);
@@ -660,6 +677,11 @@ export function useNotebook({
     );
   }, []);
 
+  /** Record that a cell was added to a dashboard. */
+  const addDashboardCard = useCallback((cellId: string, entry: DashboardCardEntry) => {
+    setDashboardCards((prev) => ({ ...prev, [cellId]: entry }));
+  }, []);
+
   return {
     cells,
     status: chat.status,
@@ -680,5 +702,7 @@ export function useNotebook({
     setInput,
     insertTextCell,
     updateTextCell,
+    dashboardCards,
+    addDashboardCard,
   };
 }

--- a/packages/web/src/ui/components/notebook/use-notebook.ts
+++ b/packages/web/src/ui/components/notebook/use-notebook.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import type { UIMessage } from "@ai-sdk/react";
 import type { NotebookStateWire, ForkBranchWire } from "@/ui/lib/types";
 import type { NotebookCell, NotebookState, ResolvedCell, ForkInfo } from "./types";
+import type { DashboardCardEntry } from "./dashboard-bridge-context";
 
 const STORAGE_PREFIX = "atlas:notebook:";
 
@@ -172,10 +173,7 @@ export interface UseNotebookOptions {
   forkInfo?: ForkInfo | null;
 }
 
-export interface DashboardCardEntry {
-  dashboardId: string;
-  cardId: string;
-}
+export type { DashboardCardEntry } from "./dashboard-bridge-context";
 
 export interface UseNotebookReturn {
   cells: ResolvedCell[];
@@ -536,6 +534,12 @@ export function useNotebook({
         // Text cells: remove only this cell, no message truncation
         setCellState((prev) => prev.filter((c) => c.id !== cellId));
         setCellOrder((prev) => prev.filter((id) => id !== cellId));
+        setDashboardCards((prev) => {
+          if (!(cellId in prev)) return prev;
+          const next = { ...prev };
+          delete next[cellId];
+          return next;
+        });
         return;
       }
 
@@ -551,6 +555,17 @@ export function useNotebook({
           .map((c) => c.id),
       );
       setCellOrder((prev) => prev.filter((id) => !deletedIds.has(id)));
+      // Clean up dashboard card associations for deleted cells
+      setDashboardCards((prev) => {
+        let changed = false;
+        for (const id of deletedIds) {
+          if (id in prev) { changed = true; break; }
+        }
+        if (!changed) return prev;
+        const next = { ...prev };
+        for (const id of deletedIds) delete next[id];
+        return next;
+      });
     },
     [cellState, chat],
   );


### PR DESCRIPTION
## Summary

- Surfaces the existing "Add to Dashboard" button on SQL result cells when rendered inside notebook view, reusing `AddToDashboardDialog` with no new API endpoints
- After a cell is added to a dashboard, shows an emerald `LayoutDashboard` badge on the result card header that persists in `notebookState.dashboardCards` (survives page reload)
- Shared/report views are unaffected — they render plain text, not `ToolPart`/`SQLResultCard`

Closes #1399

## Changes

| File | Change |
|------|--------|
| `packages/types/src/conversation.ts` | Add `dashboardCards` field to `NotebookStateWire` |
| `packages/web/.../notebook/dashboard-bridge-context.tsx` | New React context carrying cell ID + dashboard card mappings |
| `packages/web/.../notebook/use-notebook.ts` | Manage `dashboardCards` state, persist to server, expose `addDashboardCard` |
| `packages/web/.../notebook/notebook-cell.tsx` | Wrap cell output in `DashboardBridgeProvider` |
| `packages/web/.../notebook/notebook-shell.tsx` | Pass `dashboardCards` and `addDashboardCard` to `NotebookCell` |
| `packages/web/.../chat/sql-result-card.tsx` | Consume bridge context, show badge, pass `onAdded` to dialog |
| `packages/web/.../chat/add-to-dashboard-dialog.tsx` | Add `onAdded` callback, type the `addCard` mutation |

## Test plan

- [ ] Open notebook view, run a SQL query, verify "Dashboard" button appears on result card
- [ ] Click "Dashboard" button, add to existing/new dashboard — verify card is created
- [ ] After adding, verify emerald dashboard icon badge appears on the result card header
- [ ] Reload the page — verify badge persists (stored in notebookState)
- [ ] Open the same conversation in chat view — verify dashboard button still works (no regression)
- [ ] Open a shared conversation link — verify no dashboard button appears
- [ ] CI: lint, type, test, syncpack, template drift all pass