### PR TITLE
fix: add missing p-6 padding to admin-actions page

### DIFF
--- a/packages/web/src/app/admin/admin-actions/page.tsx
+++ b/packages/web/src/app/admin/admin-actions/page.tsx
@@ -215,7 +215,7 @@ function AdminActionsPageContent() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-2xl font-bold tracking-tight">Admin Action Log</h2>


### PR DESCRIPTION
## Summary
- Add `p-6` padding to the admin-actions page wrapper to match all other admin pages

## Test plan
- [ ] Navigate to `/admin/admin-actions` — content has consistent padding with other admin pages