### PR TITLE
feat: report route — shareable notebook view

### DIFF
--- a/packages/api/src/api/routes/conversations.ts
+++ b/packages/api/src/api/routes/conversations.ts
@@ -1188,12 +1188,13 @@ publicConversations.openapi(getSharedConversationRoute, async (c) => {
   }
 
   // Strip internal IDs — only expose conversation content
-  const { title, surface, createdAt, messages, shareMode } = result.data;
+  const { title, surface, createdAt, messages, shareMode, notebookState } = result.data;
   return c.json({
     title,
     surface,
     createdAt,
     shareMode,
+    notebookState: notebookState ?? null,
     messages: messages.map((m) => ({
       role: m.role,
       content: m.content,

--- a/packages/api/src/api/routes/conversations.ts
+++ b/packages/api/src/api/routes/conversations.ts
@@ -1194,7 +1194,10 @@ publicConversations.openapi(getSharedConversationRoute, async (c) => {
     surface,
     createdAt,
     shareMode,
-    notebookState: notebookState ?? null,
+    // Expose only display-relevant notebook state — strip fork metadata (internal conversation IDs)
+    notebookState: notebookState
+      ? { version: notebookState.version, cellOrder: notebookState.cellOrder, cellProps: notebookState.cellProps, textCells: notebookState.textCells }
+      : null,
     messages: messages.map((m) => ({
       role: m.role,
       content: m.content,

--- a/packages/api/src/lib/conversations.ts
+++ b/packages/api/src/lib/conversations.ts
@@ -686,7 +686,7 @@ export async function getSharedConversation(
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
   try {
     const convRows = await internalQuery<Record<string, unknown>>(
-      `SELECT id, user_id, title, surface, connection_id, starred, share_expires_at, share_mode, created_at, updated_at
+      `SELECT id, user_id, title, surface, connection_id, starred, share_expires_at, share_mode, notebook_state, created_at, updated_at
        FROM conversations
        WHERE share_token = $1`,
       [token],

--- a/packages/web/src/app/notebook/page.tsx
+++ b/packages/web/src/app/notebook/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useState, useRef, useEffect, useCallback } from "react";
+import { Suspense, useState, useRef, useEffect, useCallback, useMemo } from "react";
 import dynamic from "next/dynamic";
 import { useChat } from "@ai-sdk/react";
 import { useQueryStates } from "nuqs";
@@ -228,6 +228,15 @@ function NotebookContent() {
     forkInfo,
   });
 
+  // Share as Report — creates a share link and returns the token
+  const handleShareAsReport = useMemo(() => {
+    if (!conversationId || conversationId.startsWith("temp:")) return undefined;
+    return async (): Promise<string> => {
+      const result = await convos.shareConversation(conversationId);
+      return result.token;
+    };
+  }, [conversationId, convos.shareConversation]);
+
   // New chat handler
   function handleNewChat() {
     setError(null);
@@ -318,7 +327,7 @@ function NotebookContent() {
                 </Button>
               </div>
             )}
-            <NotebookShell notebook={notebook} focusCellId={focusCellId} />
+            <NotebookShell notebook={notebook} focusCellId={focusCellId} onShareAsReport={handleShareAsReport} />
           </main>
         </div>
       </div>

--- a/packages/web/src/app/notebook/page.tsx
+++ b/packages/web/src/app/notebook/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useState, useRef, useEffect, useCallback, useMemo } from "react";
+import { Suspense, useState, useRef, useEffect, useCallback } from "react";
 import dynamic from "next/dynamic";
 import { useChat } from "@ai-sdk/react";
 import { useQueryStates } from "nuqs";
@@ -229,13 +229,13 @@ function NotebookContent() {
   });
 
   // Share as Report — creates a share link and returns the token
-  const handleShareAsReport = useMemo(() => {
-    if (!conversationId || conversationId.startsWith("temp:")) return undefined;
-    return async (): Promise<string> => {
-      const result = await convos.shareConversation(conversationId);
-      return result.token;
-    };
-  }, [conversationId, convos.shareConversation]);
+  const handleShareAsReport =
+    !conversationId || conversationId.startsWith("temp:")
+      ? undefined
+      : async (): Promise<string> => {
+          const result = await convos.shareConversation(conversationId);
+          return result.token;
+        };
 
   // New chat handler
   function handleNewChat() {

--- a/packages/web/src/app/report/[token]/page.tsx
+++ b/packages/web/src/app/report/[token]/page.tsx
@@ -1,0 +1,122 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { buttonVariants } from "@/components/ui/button";
+import {
+  fetchSharedConversation,
+  extractTextContent,
+  truncate,
+} from "../../shared/lib";
+import { ReportView } from "./report-view";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}): Promise<Metadata> {
+  const { token } = await params;
+  const result = await fetchSharedConversation(token);
+
+  const fallbackTitle = "Atlas Report";
+  const fallbackDescription =
+    "A shared report from Atlas, the text-to-SQL data analyst.";
+
+  if (!result.ok) {
+    return {
+      title: fallbackTitle,
+      description: fallbackDescription,
+      openGraph: {
+        title: fallbackTitle,
+        description: fallbackDescription,
+        type: "article",
+        siteName: "Atlas",
+      },
+      twitter: {
+        card: "summary",
+        title: fallbackTitle,
+        description: fallbackDescription,
+      },
+    };
+  }
+
+  const convo = result.data;
+  const firstUserMsg = convo.messages.find((m) => m.role === "user");
+  const userText = firstUserMsg ? extractTextContent(firstUserMsg.content) : "";
+  const title = convo.title
+    ? `Atlas Report: ${truncate(convo.title, 55)}`
+    : userText
+      ? `Atlas Report: ${truncate(userText, 55)}`
+      : fallbackTitle;
+
+  const firstAssistantMsg = convo.messages.find((m) => m.role === "assistant");
+  const assistantText = firstAssistantMsg
+    ? extractTextContent(firstAssistantMsg.content)
+    : "";
+  const description = assistantText
+    ? truncate(assistantText, 160)
+    : fallbackDescription;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: "article",
+      siteName: "Atlas",
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description,
+    },
+  };
+}
+
+export default async function ReportPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+  const result = await fetchSharedConversation(token);
+
+  if (!result.ok) {
+    const message =
+      result.reason === "not-found"
+        ? "This report may have been removed or the link may be invalid."
+        : result.reason === "network-error"
+          ? "Could not reach the server. Check your connection and try again."
+          : "This report may have expired or been deleted. Check the link and try again.";
+    const heading =
+      result.reason === "not-found"
+        ? "Report not found"
+        : result.reason === "network-error"
+          ? "Connection failed"
+          : "Unable to load report";
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-100">
+            {heading}
+          </h1>
+          <p className="mt-2 text-zinc-500 dark:text-zinc-400">{message}</p>
+          <div className="mt-4 flex items-center justify-center gap-3">
+            <Link href="/" className={buttonVariants()}>
+              Go to Atlas
+            </Link>
+            {result.reason !== "not-found" && (
+              <Link
+                href={`/report/${token}`}
+                className={buttonVariants({ variant: "outline" })}
+              >
+                Try again
+              </Link>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return <ReportView conversation={result.data} />;
+}

--- a/packages/web/src/app/report/[token]/report-cells.ts
+++ b/packages/web/src/app/report/[token]/report-cells.ts
@@ -1,0 +1,178 @@
+/**
+ * Pure cell resolution logic for the report view.
+ * Extracted to a separate module for testability (no React/DOM dependencies).
+ */
+
+import type { UIMessage } from "@ai-sdk/react";
+import type {
+  SharedMessage,
+  SharedConversation,
+} from "../../shared/lib";
+
+// ---------------------------------------------------------------------------
+// Cell types — discriminated union so illegal states are unrepresentable
+// ---------------------------------------------------------------------------
+
+interface ReportCellBase {
+  id: string;
+  number: number;
+  collapsed: boolean;
+}
+
+export interface TextReportCell extends ReportCellBase {
+  type: "text";
+  content: string;
+}
+
+export interface QueryReportCell extends ReportCellBase {
+  type: "query";
+  userMessage: UIMessage;
+  assistantMessage: UIMessage | null;
+}
+
+export type ReportCell = TextReportCell | QueryReportCell;
+
+// ---------------------------------------------------------------------------
+// Message transformation
+// ---------------------------------------------------------------------------
+
+/** Convert raw message content to a UIMessage for rendering. */
+export function toUIMessage(msg: SharedMessage, id: string): UIMessage {
+  const content = msg.content;
+  if (typeof content === "string") {
+    return {
+      id,
+      role: msg.role as UIMessage["role"],
+      parts: [{ type: "text", text: content }],
+    };
+  }
+  if (Array.isArray(content)) {
+    const parts: UIMessage["parts"] = (content as Record<string, unknown>[])
+      .filter((p) => p.type === "text" || p.type === "tool-invocation")
+      .map((p, idx) => {
+        if (p.type === "tool-invocation") {
+          const toolCallId =
+            typeof p.toolCallId === "string" && p.toolCallId
+              ? p.toolCallId
+              : `tool-${id}-${idx}`;
+          return {
+            type: "tool-invocation" as const,
+            toolInvocationId: toolCallId,
+            toolName: String(p.toolName ?? "unknown"),
+            state: "output-available" as const,
+            input: p.args ?? {},
+            output: p.result ?? null,
+          };
+        }
+        return { type: "text" as const, text: String(p.text ?? "") };
+      });
+    return { id, role: msg.role as UIMessage["role"], parts };
+  }
+  if (content != null) {
+    console.warn(
+      `[report-view] Unrecognized message content shape for ${id}:`,
+      typeof content,
+    );
+  }
+  return { id, role: msg.role as UIMessage["role"], parts: [] };
+}
+
+// ---------------------------------------------------------------------------
+// Cell resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Reconstruct ordered report cells from flat messages and optional notebookState.
+ * When cellOrder is present, it governs display order and allows text cells to be
+ * positioned. Without cellOrder, only query cells are shown — text cells are omitted
+ * because their position is undefined without an explicit ordering.
+ */
+export function resolveCells(conversation: SharedConversation): ReportCell[] {
+  const { messages, notebookState } = conversation;
+  const state = notebookState ?? null;
+
+  // Build query cells from user/assistant message pairs
+  const allMessages = messages.filter(
+    (m) => m.role === "user" || m.role === "assistant",
+  );
+
+  const queryCells: QueryReportCell[] = [];
+  let cellNum = 0;
+
+  for (let i = 0; i < allMessages.length; i++) {
+    const msg = allMessages[i];
+    if (msg.role !== "user") continue;
+
+    cellNum++;
+    const cellId = `cell-${cellNum}`;
+    const collapsed = state?.cellProps?.[cellId]?.collapsed ?? false;
+
+    const nextMsg = allMessages[i + 1];
+    const assistantMsg =
+      nextMsg?.role === "assistant" ? nextMsg : undefined;
+
+    queryCells.push({
+      id: cellId,
+      number: cellNum,
+      type: "query",
+      collapsed,
+      userMessage: toUIMessage(msg, `user-${cellNum}`),
+      assistantMessage: assistantMsg
+        ? toUIMessage(assistantMsg, `assistant-${cellNum}`)
+        : null,
+    });
+  }
+
+  // Build text cells from notebookState
+  const textCells: TextReportCell[] = [];
+  if (state?.textCells) {
+    for (const [id, { content }] of Object.entries(state.textCells)) {
+      const collapsed = state.cellProps?.[id]?.collapsed ?? false;
+      textCells.push({
+        id,
+        number: 0, // will be renumbered
+        type: "text",
+        collapsed,
+        content,
+      });
+    }
+  }
+
+  // Merge cells according to cellOrder (if present)
+  const allCells: ReportCell[] = [...queryCells, ...textCells];
+  const cellMap = new Map(allCells.map((c) => [c.id, c]));
+
+  let ordered: ReportCell[];
+  if (state?.cellOrder && state.cellOrder.length > 0) {
+    ordered = state.cellOrder
+      .map((id) => cellMap.get(id))
+      .filter((c): c is ReportCell => c !== undefined);
+    // Append any cells not in the order
+    const inOrder = new Set(state.cellOrder);
+    for (const cell of allCells) {
+      if (!inOrder.has(cell.id)) ordered.push(cell);
+    }
+  } else {
+    // No cellOrder — show query cells only. Text cells are omitted because
+    // their position is undefined without an explicit ordering.
+    if (textCells.length > 0) {
+      console.warn(
+        `[report-view] ${textCells.length} text cell(s) dropped: cellOrder is empty but textCells exist`,
+      );
+    }
+    ordered = queryCells;
+  }
+
+  // Renumber for display
+  return ordered.map((cell, i) => ({ ...cell, number: i + 1 }));
+}
+
+/** Extract displayable text from a UIMessage. */
+export function extractText(message: UIMessage): string {
+  return message.parts
+    .filter(
+      (p): p is Extract<typeof p, { type: "text" }> => p.type === "text",
+    )
+    .map((p) => p.text)
+    .join("\n");
+}

--- a/packages/web/src/app/report/[token]/report-view.tsx
+++ b/packages/web/src/app/report/[token]/report-view.tsx
@@ -1,0 +1,392 @@
+"use client";
+
+import { Printer } from "lucide-react";
+import type { UIMessage } from "@ai-sdk/react";
+import { isToolUIPart } from "ai";
+import { Button } from "@/components/ui/button";
+import { Markdown } from "@/ui/components/chat/markdown";
+import { ToolPart } from "@/ui/components/chat/tool-part";
+import { parseSuggestions } from "@/ui/lib/helpers";
+
+// ---------------------------------------------------------------------------
+// Types — mirrors the SharedConversation shape from shared/lib.ts
+// ---------------------------------------------------------------------------
+
+interface SharedMessage {
+  role: "user" | "assistant" | "system" | "tool";
+  content: unknown;
+  createdAt: string;
+}
+
+interface NotebookState {
+  version: number;
+  cellOrder?: string[];
+  cellProps?: Record<string, { collapsed?: boolean }>;
+  textCells?: Record<string, { content: string }>;
+}
+
+interface SharedConversation {
+  title: string | null;
+  surface: string;
+  createdAt: string;
+  messages: SharedMessage[];
+  notebookState?: NotebookState | null;
+}
+
+// ---------------------------------------------------------------------------
+// Cell resolution — transform flat messages + notebookState into ordered cells
+// ---------------------------------------------------------------------------
+
+interface ReportCell {
+  id: string;
+  number: number;
+  type: "query" | "text";
+  collapsed: boolean;
+  /** For text cells: the markdown content. */
+  content?: string;
+  /** For query cells: the user message as a UIMessage. */
+  userMessage?: UIMessage;
+  /** For query cells: the assistant response as a UIMessage. */
+  assistantMessage?: UIMessage | null;
+}
+
+/** Convert raw message content to a UIMessage for rendering. */
+function toUIMessage(msg: SharedMessage, id: string): UIMessage {
+  const content = msg.content;
+  if (typeof content === "string") {
+    return {
+      id,
+      role: msg.role as UIMessage["role"],
+      parts: [{ type: "text", text: content }],
+    };
+  }
+  if (Array.isArray(content)) {
+    const parts: UIMessage["parts"] = (content as Record<string, unknown>[])
+      .filter((p) => p.type === "text" || p.type === "tool-invocation")
+      .map((p, idx) => {
+        if (p.type === "tool-invocation") {
+          const toolCallId =
+            typeof p.toolCallId === "string" && p.toolCallId
+              ? p.toolCallId
+              : `tool-${id}-${idx}`;
+          return {
+            type: "tool-invocation" as const,
+            toolInvocationId: toolCallId,
+            toolName: String(p.toolName ?? "unknown"),
+            state: "output-available" as const,
+            input: p.args ?? {},
+            output: p.result ?? null,
+          };
+        }
+        return { type: "text" as const, text: String(p.text ?? "") };
+      });
+    return { id, role: msg.role as UIMessage["role"], parts };
+  }
+  return { id, role: msg.role as UIMessage["role"], parts: [] };
+}
+
+function resolveCells(conversation: SharedConversation): ReportCell[] {
+  const { messages, notebookState } = conversation;
+  const state = notebookState ?? null;
+
+  // Build query cells from user messages
+  const allMessages = messages.filter(
+    (m) => m.role === "user" || m.role === "assistant",
+  );
+
+  const queryCells: ReportCell[] = [];
+  let cellNum = 0;
+
+  for (let i = 0; i < allMessages.length; i++) {
+    const msg = allMessages[i];
+    if (msg.role !== "user") continue;
+
+    cellNum++;
+    const cellId = `cell-${cellNum}`;
+    const collapsed = state?.cellProps?.[cellId]?.collapsed ?? false;
+
+    const nextMsg = allMessages[i + 1];
+    const assistantMsg =
+      nextMsg?.role === "assistant" ? nextMsg : undefined;
+
+    queryCells.push({
+      id: cellId,
+      number: cellNum,
+      type: "query",
+      collapsed,
+      userMessage: toUIMessage(msg, `user-${cellNum}`),
+      assistantMessage: assistantMsg
+        ? toUIMessage(assistantMsg, `assistant-${cellNum}`)
+        : null,
+    });
+  }
+
+  // Build text cells from notebookState
+  const textCells: ReportCell[] = [];
+  if (state?.textCells) {
+    for (const [id, { content }] of Object.entries(state.textCells)) {
+      const collapsed = state.cellProps?.[id]?.collapsed ?? false;
+      textCells.push({
+        id,
+        number: 0, // will be renumbered
+        type: "text",
+        collapsed,
+        content,
+      });
+    }
+  }
+
+  // Merge cells according to cellOrder (if present)
+  const allCells = [...queryCells, ...textCells];
+  const cellMap = new Map(allCells.map((c) => [c.id, c]));
+
+  let ordered: ReportCell[];
+  if (state?.cellOrder && state.cellOrder.length > 0) {
+    ordered = state.cellOrder
+      .map((id) => cellMap.get(id))
+      .filter((c): c is ReportCell => c !== undefined);
+    // Append any cells not in the order
+    const inOrder = new Set(state.cellOrder);
+    for (const cell of allCells) {
+      if (!inOrder.has(cell.id)) ordered.push(cell);
+    }
+  } else {
+    // No custom order — query cells only (text cells need cellOrder to position)
+    ordered = queryCells;
+  }
+
+  // Renumber for display
+  return ordered.map((cell, i) => ({ ...cell, number: i + 1 }));
+}
+
+// ---------------------------------------------------------------------------
+// Extracted text from a UIMessage (for the question heading)
+// ---------------------------------------------------------------------------
+
+function extractText(message: UIMessage): string {
+  return message.parts
+    .filter(
+      (p): p is Extract<typeof p, { type: "text" }> => p.type === "text",
+    )
+    .map((p) => p.text)
+    .join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface ReportViewProps {
+  conversation: SharedConversation;
+}
+
+export function ReportView({ conversation }: ReportViewProps) {
+  const cells = resolveCells(conversation);
+
+  return (
+    <div className="report-view mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+      {/* Header */}
+      <header className="mb-8 border-b border-zinc-200 pb-4 dark:border-zinc-800">
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="flex items-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
+              <span className="font-medium text-zinc-900 dark:text-zinc-100">
+                Atlas
+              </span>
+              <span aria-hidden="true">&middot;</span>
+              <span>Report</span>
+              <span aria-hidden="true">&middot;</span>
+              <time dateTime={conversation.createdAt}>
+                {new Date(conversation.createdAt).toLocaleDateString(
+                  undefined,
+                  {
+                    year: "numeric",
+                    month: "short",
+                    day: "numeric",
+                  },
+                )}
+              </time>
+            </div>
+            {conversation.title && (
+              <h1 className="mt-2 text-xl font-semibold text-zinc-900 dark:text-zinc-100 sm:text-2xl">
+                {conversation.title}
+              </h1>
+            )}
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            className="hidden gap-1.5 print:hidden sm:flex"
+            onClick={() => window.print()}
+          >
+            <Printer className="size-3.5" />
+            Save as PDF
+          </Button>
+        </div>
+      </header>
+
+      {/* Cells */}
+      <div className="space-y-6">
+        {cells.map((cell) => {
+          if (cell.type === "text") {
+            return <TextCell key={cell.id} cell={cell} />;
+          }
+          return <QueryCell key={cell.id} cell={cell} />;
+        })}
+      </div>
+
+      {/* Footer */}
+      <footer className="mt-12 border-t border-zinc-200 pt-4 text-center text-xs text-zinc-400 print:mt-8 dark:border-zinc-800 dark:text-zinc-500">
+        Generated with Atlas
+      </footer>
+
+      {/* Print styles */}
+      <style jsx global>{`
+        @media print {
+          /* Reset page margins */
+          @page {
+            margin: 1.5cm 2cm;
+            size: A4;
+          }
+
+          /* Hide non-content elements */
+          body > *:not(.report-view),
+          nav,
+          .print\\:hidden,
+          button,
+          [role="navigation"],
+          a[href="#main"] {
+            display: none !important;
+          }
+
+          /* Remove dark mode for print */
+          html {
+            color-scheme: light !important;
+          }
+          html.dark {
+            --tw-bg-opacity: 1;
+          }
+          body,
+          .dark body {
+            background: white !important;
+            color: #18181b !important;
+          }
+          .dark * {
+            color: inherit !important;
+            background: inherit !important;
+            border-color: #e4e4e7 !important;
+          }
+
+          /* Clean up the report container */
+          .report-view {
+            max-width: 100% !important;
+            padding: 0 !important;
+            margin: 0 !important;
+          }
+
+          /* Prevent page breaks inside cells */
+          .report-cell {
+            break-inside: avoid;
+            page-break-inside: avoid;
+          }
+
+          /* Allow breaks between cells */
+          .report-cell + .report-cell {
+            break-before: auto;
+          }
+
+          /* Tables should be readable */
+          table {
+            font-size: 9pt !important;
+          }
+          th,
+          td {
+            padding: 4px 6px !important;
+          }
+
+          /* Charts render at fixed size for print */
+          .recharts-wrapper {
+            max-width: 100% !important;
+          }
+
+          /* Code blocks */
+          pre {
+            white-space: pre-wrap !important;
+            word-break: break-word !important;
+            font-size: 8pt !important;
+          }
+
+          /* Footer */
+          footer {
+            break-before: avoid;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function TextCell({ cell }: { cell: ReportCell }) {
+  const content = cell.content ?? "";
+  if (!content.trim()) return null;
+
+  return (
+    <div className="report-cell">
+      <div className="prose prose-zinc max-w-none text-sm dark:prose-invert">
+        <Markdown content={content} />
+      </div>
+    </div>
+  );
+}
+
+function QueryCell({ cell }: { cell: ReportCell }) {
+  if (!cell.userMessage) return null;
+  const question = extractText(cell.userMessage);
+
+  if (cell.collapsed) {
+    return (
+      <section className="report-cell rounded-lg border border-zinc-200 bg-zinc-50 px-4 py-3 dark:border-zinc-800 dark:bg-zinc-900/50">
+        <div className="flex items-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
+          <span className="font-mono text-xs font-medium">[{cell.number}]</span>
+          <span className="truncate">{question}</span>
+          <span className="ml-auto text-xs italic">collapsed</span>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="report-cell space-y-3">
+      <h2 className="flex items-baseline gap-2 text-base font-semibold text-zinc-900 dark:text-zinc-100">
+        <span className="font-mono text-sm font-normal text-zinc-400 dark:text-zinc-500">
+          [{cell.number}]
+        </span>
+        {question}
+      </h2>
+
+      {cell.assistantMessage ? (
+        <div className="space-y-2 text-sm">
+          {cell.assistantMessage.parts.map((part, i) => {
+            if (part.type === "text") {
+              const displayText = parseSuggestions(part.text).text;
+              if (!displayText.trim()) return null;
+              return <Markdown key={i} content={displayText} />;
+            }
+            if (isToolUIPart(part)) {
+              return <ToolPart key={i} part={part} />;
+            }
+            return null;
+          })}
+        </div>
+      ) : (
+        <p className="text-xs italic text-zinc-400 dark:text-zinc-500">
+          No output
+        </p>
+      )}
+    </section>
+  );
+}

--- a/packages/web/src/app/report/[token]/report-view.tsx
+++ b/packages/web/src/app/report/[token]/report-view.tsx
@@ -1,180 +1,18 @@
 "use client";
 
 import { Printer } from "lucide-react";
-import type { UIMessage } from "@ai-sdk/react";
 import { isToolUIPart } from "ai";
 import { Button } from "@/components/ui/button";
 import { Markdown } from "@/ui/components/chat/markdown";
 import { ToolPart } from "@/ui/components/chat/tool-part";
 import { parseSuggestions } from "@/ui/lib/helpers";
-
-// ---------------------------------------------------------------------------
-// Types — mirrors the SharedConversation shape from shared/lib.ts
-// ---------------------------------------------------------------------------
-
-interface SharedMessage {
-  role: "user" | "assistant" | "system" | "tool";
-  content: unknown;
-  createdAt: string;
-}
-
-interface NotebookState {
-  version: number;
-  cellOrder?: string[];
-  cellProps?: Record<string, { collapsed?: boolean }>;
-  textCells?: Record<string, { content: string }>;
-}
-
-interface SharedConversation {
-  title: string | null;
-  surface: string;
-  createdAt: string;
-  messages: SharedMessage[];
-  notebookState?: NotebookState | null;
-}
-
-// ---------------------------------------------------------------------------
-// Cell resolution — transform flat messages + notebookState into ordered cells
-// ---------------------------------------------------------------------------
-
-interface ReportCell {
-  id: string;
-  number: number;
-  type: "query" | "text";
-  collapsed: boolean;
-  /** For text cells: the markdown content. */
-  content?: string;
-  /** For query cells: the user message as a UIMessage. */
-  userMessage?: UIMessage;
-  /** For query cells: the assistant response as a UIMessage. */
-  assistantMessage?: UIMessage | null;
-}
-
-/** Convert raw message content to a UIMessage for rendering. */
-function toUIMessage(msg: SharedMessage, id: string): UIMessage {
-  const content = msg.content;
-  if (typeof content === "string") {
-    return {
-      id,
-      role: msg.role as UIMessage["role"],
-      parts: [{ type: "text", text: content }],
-    };
-  }
-  if (Array.isArray(content)) {
-    const parts: UIMessage["parts"] = (content as Record<string, unknown>[])
-      .filter((p) => p.type === "text" || p.type === "tool-invocation")
-      .map((p, idx) => {
-        if (p.type === "tool-invocation") {
-          const toolCallId =
-            typeof p.toolCallId === "string" && p.toolCallId
-              ? p.toolCallId
-              : `tool-${id}-${idx}`;
-          return {
-            type: "tool-invocation" as const,
-            toolInvocationId: toolCallId,
-            toolName: String(p.toolName ?? "unknown"),
-            state: "output-available" as const,
-            input: p.args ?? {},
-            output: p.result ?? null,
-          };
-        }
-        return { type: "text" as const, text: String(p.text ?? "") };
-      });
-    return { id, role: msg.role as UIMessage["role"], parts };
-  }
-  return { id, role: msg.role as UIMessage["role"], parts: [] };
-}
-
-function resolveCells(conversation: SharedConversation): ReportCell[] {
-  const { messages, notebookState } = conversation;
-  const state = notebookState ?? null;
-
-  // Build query cells from user messages
-  const allMessages = messages.filter(
-    (m) => m.role === "user" || m.role === "assistant",
-  );
-
-  const queryCells: ReportCell[] = [];
-  let cellNum = 0;
-
-  for (let i = 0; i < allMessages.length; i++) {
-    const msg = allMessages[i];
-    if (msg.role !== "user") continue;
-
-    cellNum++;
-    const cellId = `cell-${cellNum}`;
-    const collapsed = state?.cellProps?.[cellId]?.collapsed ?? false;
-
-    const nextMsg = allMessages[i + 1];
-    const assistantMsg =
-      nextMsg?.role === "assistant" ? nextMsg : undefined;
-
-    queryCells.push({
-      id: cellId,
-      number: cellNum,
-      type: "query",
-      collapsed,
-      userMessage: toUIMessage(msg, `user-${cellNum}`),
-      assistantMessage: assistantMsg
-        ? toUIMessage(assistantMsg, `assistant-${cellNum}`)
-        : null,
-    });
-  }
-
-  // Build text cells from notebookState
-  const textCells: ReportCell[] = [];
-  if (state?.textCells) {
-    for (const [id, { content }] of Object.entries(state.textCells)) {
-      const collapsed = state.cellProps?.[id]?.collapsed ?? false;
-      textCells.push({
-        id,
-        number: 0, // will be renumbered
-        type: "text",
-        collapsed,
-        content,
-      });
-    }
-  }
-
-  // Merge cells according to cellOrder (if present)
-  const allCells = [...queryCells, ...textCells];
-  const cellMap = new Map(allCells.map((c) => [c.id, c]));
-
-  let ordered: ReportCell[];
-  if (state?.cellOrder && state.cellOrder.length > 0) {
-    ordered = state.cellOrder
-      .map((id) => cellMap.get(id))
-      .filter((c): c is ReportCell => c !== undefined);
-    // Append any cells not in the order
-    const inOrder = new Set(state.cellOrder);
-    for (const cell of allCells) {
-      if (!inOrder.has(cell.id)) ordered.push(cell);
-    }
-  } else {
-    // No custom order — query cells only (text cells need cellOrder to position)
-    ordered = queryCells;
-  }
-
-  // Renumber for display
-  return ordered.map((cell, i) => ({ ...cell, number: i + 1 }));
-}
-
-// ---------------------------------------------------------------------------
-// Extracted text from a UIMessage (for the question heading)
-// ---------------------------------------------------------------------------
-
-function extractText(message: UIMessage): string {
-  return message.parts
-    .filter(
-      (p): p is Extract<typeof p, { type: "text" }> => p.type === "text",
-    )
-    .map((p) => p.text)
-    .join("\n");
-}
-
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
+import type { SharedConversation } from "../../shared/lib";
+import {
+  resolveCells,
+  extractText,
+  type TextReportCell,
+  type QueryReportCell,
+} from "./report-cells";
 
 interface ReportViewProps {
   conversation: SharedConversation;
@@ -240,111 +78,43 @@ export function ReportView({ conversation }: ReportViewProps) {
         Generated with Atlas
       </footer>
 
-      {/* Print styles */}
-      <style jsx global>{`
-        @media print {
-          /* Reset page margins */
-          @page {
-            margin: 1.5cm 2cm;
-            size: A4;
-          }
-
-          /* Hide non-content elements */
-          body > *:not(.report-view),
-          nav,
-          .print\\:hidden,
-          button,
-          [role="navigation"],
-          a[href="#main"] {
-            display: none !important;
-          }
-
-          /* Remove dark mode for print */
-          html {
-            color-scheme: light !important;
-          }
-          html.dark {
-            --tw-bg-opacity: 1;
-          }
-          body,
-          .dark body {
-            background: white !important;
-            color: #18181b !important;
-          }
-          .dark * {
-            color: inherit !important;
-            background: inherit !important;
-            border-color: #e4e4e7 !important;
-          }
-
-          /* Clean up the report container */
-          .report-view {
-            max-width: 100% !important;
-            padding: 0 !important;
-            margin: 0 !important;
-          }
-
-          /* Prevent page breaks inside cells */
-          .report-cell {
-            break-inside: avoid;
-            page-break-inside: avoid;
-          }
-
-          /* Allow breaks between cells */
-          .report-cell + .report-cell {
-            break-before: auto;
-          }
-
-          /* Tables should be readable */
-          table {
-            font-size: 9pt !important;
-          }
-          th,
-          td {
-            padding: 4px 6px !important;
-          }
-
-          /* Charts render at fixed size for print */
-          .recharts-wrapper {
-            max-width: 100% !important;
-          }
-
-          /* Code blocks */
-          pre {
-            white-space: pre-wrap !important;
-            word-break: break-word !important;
-            font-size: 8pt !important;
-          }
-
-          /* Footer */
-          footer {
-            break-before: avoid;
-          }
-        }
-      `}</style>
+      {/* Print styles — targets specific elements to work with Next.js DOM structure */}
+      <style
+        dangerouslySetInnerHTML={{
+          __html: `
+@media print {
+  @page { margin: 1.5cm 2cm; size: A4; }
+  nav, button, [role="navigation"], a[href="#main"] { display: none !important; }
+  html { color-scheme: light !important; }
+  body, .dark body { background: white !important; color: #18181b !important; }
+  .dark * { color: inherit !important; background: inherit !important; border-color: #e4e4e7 !important; }
+  .report-view { max-width: 100% !important; padding: 0 !important; margin: 0 !important; }
+  .report-cell { break-inside: avoid; page-break-inside: avoid; }
+  table { font-size: 9pt !important; }
+  th, td { padding: 4px 6px !important; }
+  .recharts-wrapper { max-width: 100% !important; }
+  pre { white-space: pre-wrap !important; word-break: break-word !important; font-size: 8pt !important; }
+  footer { break-before: avoid; }
+}`,
+        }}
+      />
     </div>
   );
 }
 
-// ---------------------------------------------------------------------------
-// Sub-components
-// ---------------------------------------------------------------------------
-
-function TextCell({ cell }: { cell: ReportCell }) {
-  const content = cell.content ?? "";
-  if (!content.trim()) return null;
+function TextCell({ cell }: { cell: TextReportCell }) {
+  if (!cell.content.trim()) return null;
 
   return (
     <div className="report-cell">
       <div className="prose prose-zinc max-w-none text-sm dark:prose-invert">
-        <Markdown content={content} />
+        <Markdown content={cell.content} />
       </div>
     </div>
   );
 }
 
-function QueryCell({ cell }: { cell: ReportCell }) {
-  if (!cell.userMessage) return null;
+function QueryCell({ cell }: { cell: QueryReportCell }) {
   const question = extractText(cell.userMessage);
 
   if (cell.collapsed) {

--- a/packages/web/src/app/shared/lib.ts
+++ b/packages/web/src/app/shared/lib.ts
@@ -13,6 +13,12 @@ interface SharedConversation {
   surface: string;
   createdAt: string;
   messages: SharedMessage[];
+  notebookState?: {
+    version: number;
+    cellOrder?: string[];
+    cellProps?: Record<string, { collapsed?: boolean }>;
+    textCells?: Record<string, { content: string }>;
+  } | null;
 }
 
 type FetchResult =

--- a/packages/web/src/app/shared/lib.ts
+++ b/packages/web/src/app/shared/lib.ts
@@ -1,24 +1,27 @@
 // ---------------------------------------------------------------------------
-// Shared utilities for the public shared-conversation routes (/shared/[token])
+// Shared utilities for public conversation routes (/shared/[token], /report/[token])
 // ---------------------------------------------------------------------------
 
-interface SharedMessage {
+export interface SharedMessage {
   role: "user" | "assistant" | "system" | "tool";
   content: unknown;
   createdAt: string;
 }
 
-interface SharedConversation {
+/** Subset of NotebookStateWire relevant for public read-only views. Fork metadata is excluded. */
+export interface SharedNotebookState {
+  version: number;
+  cellOrder?: string[];
+  cellProps?: Record<string, { collapsed?: boolean }>;
+  textCells?: Record<string, { content: string }>;
+}
+
+export interface SharedConversation {
   title: string | null;
   surface: string;
   createdAt: string;
   messages: SharedMessage[];
-  notebookState?: {
-    version: number;
-    cellOrder?: string[];
-    cellProps?: Record<string, { collapsed?: boolean }>;
-    textCells?: Record<string, { content: string }>;
-  } | null;
+  notebookState: SharedNotebookState | null;
 }
 
 type FetchResult =

--- a/packages/web/src/ui/__tests__/report-view.test.ts
+++ b/packages/web/src/ui/__tests__/report-view.test.ts
@@ -1,0 +1,242 @@
+import { describe, test, expect, spyOn } from "bun:test";
+import type { SharedConversation, SharedMessage } from "../../app/shared/lib";
+import { resolveCells, toUIMessage } from "../../app/report/[token]/report-cells";
+
+// ---------------------------------------------------------------------------
+// toUIMessage
+// ---------------------------------------------------------------------------
+
+describe("toUIMessage", () => {
+  test("converts string content to a text part", () => {
+    const msg: SharedMessage = { role: "user", content: "hello", createdAt: "2026-01-01" };
+    const result = toUIMessage(msg, "msg-1");
+    expect(result.id).toBe("msg-1");
+    expect(result.role).toBe("user");
+    expect(result.parts).toEqual([{ type: "text", text: "hello" }]);
+  });
+
+  test("converts array content with text parts", () => {
+    const msg: SharedMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "answer" }],
+      createdAt: "2026-01-01",
+    };
+    const result = toUIMessage(msg, "msg-2");
+    expect(result.parts).toEqual([{ type: "text", text: "answer" }]);
+  });
+
+  test("converts array content with tool-invocation parts", () => {
+    const msg: SharedMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "tool-invocation",
+          toolCallId: "tc-1",
+          toolName: "executeSQL",
+          args: { sql: "SELECT 1" },
+          result: { success: true, columns: ["?column?"], rows: [{ "?column?": 1 }] },
+        },
+      ],
+      createdAt: "2026-01-01",
+    };
+    const result = toUIMessage(msg, "msg-3");
+    expect(result.parts).toHaveLength(1);
+    const part = result.parts[0] as Record<string, unknown>;
+    expect(part.type).toBe("tool-invocation");
+    expect(part.toolName).toBe("executeSQL");
+    expect(part.toolInvocationId).toBe("tc-1");
+    expect(part.state).toBe("output-available");
+  });
+
+  test("generates fallback toolCallId when missing", () => {
+    const msg: SharedMessage = {
+      role: "assistant",
+      content: [{ type: "tool-invocation", toolName: "explore", args: {} }],
+      createdAt: "2026-01-01",
+    };
+    const result = toUIMessage(msg, "msg-4");
+    const part = result.parts[0] as Record<string, unknown>;
+    expect(part.toolInvocationId).toBe("tool-msg-4-0");
+  });
+
+  test("filters out unrecognized part types", () => {
+    const msg: SharedMessage = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "hi" },
+        { type: "reasoning", reasoning: "thinking..." },
+        { type: "step-start" },
+      ],
+      createdAt: "2026-01-01",
+    };
+    const result = toUIMessage(msg, "msg-5");
+    expect(result.parts).toHaveLength(1);
+    expect(result.parts[0]).toEqual({ type: "text", text: "hi" });
+  });
+
+  test("returns empty parts for non-string non-array content with warning", () => {
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    const msg: SharedMessage = { role: "user", content: 42, createdAt: "2026-01-01" };
+    const result = toUIMessage(msg, "msg-6");
+    expect(result.parts).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  test("returns empty parts for null content without warning", () => {
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    const msg: SharedMessage = { role: "user", content: null, createdAt: "2026-01-01" };
+    const result = toUIMessage(msg, "msg-7");
+    expect(result.parts).toEqual([]);
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveCells
+// ---------------------------------------------------------------------------
+
+function makeConvo(
+  messages: SharedMessage[],
+  notebookState: SharedConversation["notebookState"] = null,
+): SharedConversation {
+  return {
+    title: "Test",
+    surface: "notebook",
+    createdAt: "2026-01-01",
+    messages,
+    notebookState,
+  };
+}
+
+function userMsg(text: string): SharedMessage {
+  return { role: "user", content: text, createdAt: "2026-01-01" };
+}
+
+function assistantMsg(text: string): SharedMessage {
+  return { role: "assistant", content: text, createdAt: "2026-01-01" };
+}
+
+describe("resolveCells", () => {
+  test("returns empty array for no messages", () => {
+    const cells = resolveCells(makeConvo([]));
+    expect(cells).toEqual([]);
+  });
+
+  test("builds query cells from user-assistant pairs", () => {
+    const cells = resolveCells(makeConvo([userMsg("q1"), assistantMsg("a1"), userMsg("q2"), assistantMsg("a2")]));
+    expect(cells).toHaveLength(2);
+    expect(cells[0].type).toBe("query");
+    expect(cells[0].number).toBe(1);
+    expect(cells[1].number).toBe(2);
+    const c1 = cells[0] as { type: "query"; assistantMessage: { parts: { text: string }[] } };
+    expect(c1.assistantMessage.parts[0].text).toBe("a1");
+  });
+
+  test("handles consecutive user messages (no assistant response)", () => {
+    const cells = resolveCells(makeConvo([userMsg("q1"), userMsg("q2"), assistantMsg("a2")]));
+    expect(cells).toHaveLength(2);
+    const c0 = cells[0] as { type: "query"; assistantMessage: unknown };
+    const c1 = cells[1] as { type: "query"; assistantMessage: { parts: { text: string }[] } };
+    expect(c0.assistantMessage).toBeNull();
+    expect(c1.assistantMessage.parts[0].text).toBe("a2");
+  });
+
+  test("respects cellOrder from notebookState", () => {
+    const cells = resolveCells(
+      makeConvo([userMsg("q1"), assistantMsg("a1"), userMsg("q2"), assistantMsg("a2")], {
+        version: 3,
+        cellOrder: ["cell-2", "cell-1"],
+      }),
+    );
+    expect(cells).toHaveLength(2);
+    expect(cells[0].id).toBe("cell-2");
+    expect(cells[0].number).toBe(1);
+    expect(cells[1].id).toBe("cell-1");
+    expect(cells[1].number).toBe(2);
+  });
+
+  test("respects collapsed state from cellProps", () => {
+    const cells = resolveCells(
+      makeConvo([userMsg("q1"), assistantMsg("a1")], {
+        version: 3,
+        cellProps: { "cell-1": { collapsed: true } },
+      }),
+    );
+    expect(cells[0].collapsed).toBe(true);
+  });
+
+  test("includes text cells when cellOrder is present", () => {
+    const cells = resolveCells(
+      makeConvo([userMsg("q1"), assistantMsg("a1")], {
+        version: 3,
+        cellOrder: ["text-1", "cell-1"],
+        textCells: { "text-1": { content: "# Introduction" } },
+      }),
+    );
+    expect(cells).toHaveLength(2);
+    expect(cells[0].type).toBe("text");
+    expect(cells[0].id).toBe("text-1");
+    const textCell = cells[0] as { type: "text"; content: string };
+    expect(textCell.content).toBe("# Introduction");
+    expect(cells[1].type).toBe("query");
+  });
+
+  test("drops text cells with warning when cellOrder is missing", () => {
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    const cells = resolveCells(
+      makeConvo([userMsg("q1"), assistantMsg("a1")], {
+        version: 3,
+        textCells: { "text-1": { content: "some text" } },
+      }),
+    );
+    expect(cells).toHaveLength(1);
+    expect(cells[0].type).toBe("query");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  test("appends cells not in cellOrder", () => {
+    const cells = resolveCells(
+      makeConvo([userMsg("q1"), assistantMsg("a1"), userMsg("q2"), assistantMsg("a2")], {
+        version: 3,
+        cellOrder: ["cell-1"],
+      }),
+    );
+    expect(cells).toHaveLength(2);
+    expect(cells[0].id).toBe("cell-1");
+    expect(cells[1].id).toBe("cell-2");
+  });
+
+  test("skips cellOrder entries that reference non-existent cells", () => {
+    const cells = resolveCells(
+      makeConvo([userMsg("q1"), assistantMsg("a1")], {
+        version: 3,
+        cellOrder: ["cell-999", "cell-1"],
+      }),
+    );
+    expect(cells).toHaveLength(1);
+    expect(cells[0].id).toBe("cell-1");
+    expect(cells[0].number).toBe(1);
+  });
+
+  test("filters out system and tool messages", () => {
+    const cells = resolveCells(
+      makeConvo([
+        { role: "system", content: "You are Atlas", createdAt: "2026-01-01" },
+        userMsg("q1"),
+        { role: "tool", content: { toolCallId: "t1" }, createdAt: "2026-01-01" },
+        assistantMsg("a1"),
+      ]),
+    );
+    expect(cells).toHaveLength(1);
+  });
+
+  test("renumbers cells sequentially from 1", () => {
+    const cells = resolveCells(
+      makeConvo([userMsg("q1"), assistantMsg("a1"), userMsg("q2"), assistantMsg("a2"), userMsg("q3"), assistantMsg("a3")]),
+    );
+    expect(cells.map((c) => c.number)).toEqual([1, 2, 3]);
+  });
+});

--- a/packages/web/src/ui/components/auth-guard.tsx
+++ b/packages/web/src/ui/components/auth-guard.tsx
@@ -9,7 +9,7 @@ import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
 const AUTH_MODE = process.env.NEXT_PUBLIC_ATLAS_AUTH_MODE ?? "";
 
 /** Routes that don't require authentication. */
-const publicPrefixes = ["/demo", "/shared", "/login", "/signup", "/wizard"];
+const publicPrefixes = ["/demo", "/shared", "/report", "/login", "/signup", "/wizard"];
 
 function isPublicRoute(pathname: string): boolean {
   return publicPrefixes.some((prefix) => pathname.startsWith(prefix));

--- a/packages/web/src/ui/components/notebook/notebook-shell.tsx
+++ b/packages/web/src/ui/components/notebook/notebook-shell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useEffect, useState } from "react";
-import { Plus, Download } from "lucide-react";
+import { Plus, Download, FileText, Check } from "lucide-react";
 import type { UseNotebookReturn } from "./use-notebook";
 import { useKeyboardNav } from "./use-keyboard-nav";
 import { NotebookCell } from "./notebook-cell";
@@ -29,14 +29,17 @@ import {
 interface NotebookShellProps {
   notebook: UseNotebookReturn;
   focusCellId?: string;
+  /** When provided, enables the "Share as Report" button. Returns the share token. */
+  onShareAsReport?: () => Promise<string>;
 }
 
-export function NotebookShell({ notebook, focusCellId }: NotebookShellProps) {
+export function NotebookShell({ notebook, focusCellId, onShareAsReport }: NotebookShellProps) {
   const scrollAreaRef = useRef<HTMLDivElement>(null);
   const anyRunning = notebook.cells.some((c) => c.status === "running");
   const editingCellId = notebook.cells.find((c) => c.editing)?.id ?? null;
   const [pendingDeleteIndex, setPendingDeleteIndex] = useState<number | null>(null);
   const [dismissedError, setDismissedError] = useState<Error | null>(null);
+  const [shareState, setShareState] = useState<"idle" | "sharing" | "copied" | "error">("idle");
 
   const { setRef, focusCell } = useKeyboardNav({
     cellCount: notebook.cells.length,
@@ -121,56 +124,97 @@ export function NotebookShell({ notebook, focusCellId }: NotebookShellProps) {
                 Text Cell
               </Button>
 
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
+              <div className="flex items-center gap-1.5">
+                {onShareAsReport && (
                   <Button
                     variant="outline"
                     size="sm"
                     className="h-7 gap-1.5 text-xs"
+                    disabled={shareState === "sharing"}
+                    onClick={async () => {
+                      setShareState("sharing");
+                      try {
+                        const token = await onShareAsReport();
+                        const url = `${window.location.origin}/report/${token}`;
+                        await navigator.clipboard.writeText(url);
+                        setShareState("copied");
+                        setTimeout(() => setShareState("idle"), 2500);
+                      } catch (err: unknown) {
+                        console.error(
+                          "Share as Report failed:",
+                          err instanceof Error ? err.message : String(err),
+                        );
+                        setShareState("error");
+                        setTimeout(() => setShareState("idle"), 3000);
+                      }
+                    }}
                   >
-                    <Download className="size-3" />
-                    Export
+                    {shareState === "copied" ? (
+                      <Check className="size-3" />
+                    ) : (
+                      <FileText className="size-3" />
+                    )}
+                    {shareState === "sharing"
+                      ? "Sharing..."
+                      : shareState === "copied"
+                        ? "Link Copied!"
+                        : shareState === "error"
+                          ? "Share Failed"
+                          : "Share as Report"}
                   </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem
-                    onClick={() => {
-                      try {
-                        downloadFile(
-                          exportToMarkdown(notebook.cells),
-                          "notebook.md",
-                          "text/markdown",
-                        );
-                      } catch (err: unknown) {
-                        console.error(
-                          "Export to Markdown failed:",
-                          err instanceof Error ? err.message : String(err),
-                        );
-                      }
-                    }}
-                  >
-                    Markdown (.md)
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={() => {
-                      try {
-                        downloadFile(
-                          exportToHTML(notebook.cells),
-                          "notebook.html",
-                          "text/html",
-                        );
-                      } catch (err: unknown) {
-                        console.error(
-                          "Export to HTML failed:",
-                          err instanceof Error ? err.message : String(err),
-                        );
-                      }
-                    }}
-                  >
-                    HTML (.html)
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+                )}
+
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-7 gap-1.5 text-xs"
+                    >
+                      <Download className="size-3" />
+                      Export
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem
+                      onClick={() => {
+                        try {
+                          downloadFile(
+                            exportToMarkdown(notebook.cells),
+                            "notebook.md",
+                            "text/markdown",
+                          );
+                        } catch (err: unknown) {
+                          console.error(
+                            "Export to Markdown failed:",
+                            err instanceof Error ? err.message : String(err),
+                          );
+                        }
+                      }}
+                    >
+                      Markdown (.md)
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => {
+                        try {
+                          downloadFile(
+                            exportToHTML(notebook.cells),
+                            "notebook.html",
+                            "text/html",
+                          );
+                        } catch (err: unknown) {
+                          console.error(
+                            "Export to HTML failed:",
+                            err instanceof Error ? err.message : String(err),
+                          );
+                        }
+                      }}
+                    >
+                      HTML (.html)
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
             </div>
           )}
 

--- a/packages/web/src/ui/components/notebook/notebook-shell.tsx
+++ b/packages/web/src/ui/components/notebook/notebook-shell.tsx
@@ -111,7 +111,7 @@ export function NotebookShell({ notebook, focusCellId, onShareAsReport }: Notebo
             />
           )}
 
-          {/* Notebook toolbar — insert text cell + export */}
+          {/* Notebook toolbar */}
           {notebook.cells.length > 0 && (
             <div className="flex items-center justify-between">
               <Button
@@ -133,19 +133,31 @@ export function NotebookShell({ notebook, focusCellId, onShareAsReport }: Notebo
                     disabled={shareState === "sharing"}
                     onClick={async () => {
                       setShareState("sharing");
+                      let token: string;
                       try {
-                        const token = await onShareAsReport();
-                        const url = `${window.location.origin}/report/${token}`;
-                        await navigator.clipboard.writeText(url);
-                        setShareState("copied");
-                        setTimeout(() => setShareState("idle"), 2500);
+                        token = await onShareAsReport();
                       } catch (err: unknown) {
                         console.error(
-                          "Share as Report failed:",
+                          "Share as Report API failed:",
                           err instanceof Error ? err.message : String(err),
                         );
                         setShareState("error");
                         setTimeout(() => setShareState("idle"), 3000);
+                        return;
+                      }
+                      const url = `${window.location.origin}/report/${token}`;
+                      try {
+                        await navigator.clipboard.writeText(url);
+                        setShareState("copied");
+                        setTimeout(() => setShareState("idle"), 2500);
+                      } catch (clipErr: unknown) {
+                        console.warn(
+                          "Clipboard write failed, share was created:",
+                          clipErr instanceof Error ? clipErr.message : String(clipErr),
+                        );
+                        window.prompt("Report link (copy manually):", url);
+                        setShareState("copied");
+                        setTimeout(() => setShareState("idle"), 2500);
                       }
                     }}
                   >


### PR DESCRIPTION
## Summary
- Adds `/report/[token]` route that renders a notebook as a clean, read-only document for sharing
- Text cells render as styled prose (markdown), query cells render with inline SQL results/charts, collapsed cells stay collapsed, cell order from `notebookState.cellOrder` is respected
- "Share as Report" button in notebook toolbar generates a share link and copies to clipboard
- Print/PDF support via `@media print` stylesheet and "Save as PDF" button
- Public shared conversation API now includes `notebookState` so the report route can access cell ordering, collapsed state, and text cells

Closes #1400

## Test plan
- [ ] Open a notebook with multiple cells (query + text), click "Share as Report" — link copies to clipboard
- [ ] Open the `/report/{token}` URL in an incognito window — renders clean document without sidebar/edit controls
- [ ] Verify text cells render as prose, SQL results render with tables/charts
- [ ] Verify collapsed cells remain collapsed in report view
- [ ] Reorder cells in notebook, share again — report respects new order
- [ ] Use browser print dialog (Ctrl+P) on report — produces clean PDF output
- [ ] Test invalid/expired token — shows appropriate error page with "Try again" link
- [ ] Test on mobile viewport — responsive layout
- [ ] CI: lint, type, test, syncpack, template drift all pass