### PR TITLE
fix: anchor improve page height to viewport for independent panel scrolling

### DIFF
--- a/packages/web/src/app/admin/semantic/improve/page.tsx
+++ b/packages/web/src/app/admin/semantic/improve/page.tsx
@@ -404,7 +404,7 @@ export default function SemanticImprovePage() {
   }
 
   return (
-    <div className="flex h-full flex-col overflow-hidden">
+    <div className="flex h-[calc(100dvh-4rem)] flex-col overflow-hidden">
       {/* Header */}
       <div className="flex shrink-0 items-center gap-3 border-b px-6 py-4">
         <Link href="/admin/semantic">


### PR DESCRIPTION
## Summary
- Replace `h-full` with `h-[calc(100dvh-4rem)]` on the semantic improve page
- Root cause: the sidebar wrapper uses `min-h-svh` (growable height), so `h-full` percentage resolved against content size rather than viewport, causing the entire page to scroll instead of each panel independently
- The `4rem` offset accounts for the admin layout's `h-16` header

## Test plan
- [ ] Navigate to `/admin/semantic/improve` with 10+ proposals — panels scroll independently
- [ ] Resize the browser — layout stays viewport-constrained
- [ ] Drag the resizable handle — handle stays visible, both panels maintain independent scroll
- [ ] Chat panel input stays pinned at the bottom