### PR TITLE
feat: rerun comparison — show execution delta after notebook cell rerun

### DIFF
--- a/packages/types/src/conversation.ts
+++ b/packages/types/src/conversation.ts
@@ -20,8 +20,11 @@ export interface NotebookStateWire {
   version: number;
   /** Custom display order of cell IDs (empty = natural message order). */
   cellOrder?: string[];
-  /** Per-cell persisted properties (only collapsed; editing/status are transient). */
-  cellProps?: Record<string, { collapsed?: boolean }>;
+  /** Per-cell persisted properties (collapsed + transient rerun comparison). */
+  cellProps?: Record<string, {
+    collapsed?: boolean;
+    previousExecution?: { executionMs?: number; rowCount?: number };
+  }>;
   /** Fork branches originating from this conversation (stored on root only). */
   branches?: ForkBranchWire[];
   /** If this conversation is a fork, the root conversation ID. */

--- a/packages/types/src/conversation.ts
+++ b/packages/types/src/conversation.ts
@@ -20,11 +20,8 @@ export interface NotebookStateWire {
   version: number;
   /** Custom display order of cell IDs (empty = natural message order). */
   cellOrder?: string[];
-  /** Per-cell persisted properties (collapsed + transient rerun comparison). */
-  cellProps?: Record<string, {
-    collapsed?: boolean;
-    previousExecution?: { executionMs?: number; rowCount?: number };
-  }>;
+  /** Per-cell persisted properties (only collapsed; editing/status are transient). */
+  cellProps?: Record<string, { collapsed?: boolean }>;
   /** Fork branches originating from this conversation (stored on root only). */
   branches?: ForkBranchWire[];
   /** If this conversation is a fork, the root conversation ID. */

--- a/packages/web/src/ui/components/chat/sql-result-card.tsx
+++ b/packages/web/src/ui/components/chat/sql-result-card.tsx
@@ -7,6 +7,7 @@ import { useDarkMode } from "../../hooks/use-dark-mode";
 import { detectCharts } from "../chart/chart-detection";
 import dynamic from "next/dynamic";
 import { useDashboardBridge } from "../notebook/dashboard-bridge-context";
+import type { PreviousExecution } from "../notebook/types";
 
 const ResultChart = dynamic(
   () => import("../chart/result-chart").then((m) => ({ default: m.ResultChart })),
@@ -23,7 +24,7 @@ function toStringRows(columns: string[], rows: Record<string, unknown>[]): strin
 }
 
 
-export function SQLResultCard({ part, previousExecution }: { part: unknown; previousExecution?: { executionMs?: number; rowCount?: number } }) {
+export function SQLResultCard({ part, previousExecution }: { part: unknown; previousExecution?: PreviousExecution }) {
   return (
     <ResultCardErrorBoundary label="SQL">
       <SQLResultCardInner part={part} previousExecution={previousExecution} />
@@ -36,9 +37,9 @@ const AddToDashboardDialog = dynamic(
   { ssr: false, loading: () => null },
 );
 
-/** Build a human-readable comparison string like "was 512 rows · 3.4s". */
+/** Build a human-readable comparison string, e.g. "was 3.4s" or "was 512 rows · 3.4s" (row count shown only when changed). */
 function formatPreviousExecution(
-  prev: { executionMs?: number; rowCount?: number },
+  prev: PreviousExecution,
   currentRowCount: number,
 ): string | null {
   const parts: string[] = [];
@@ -48,14 +49,14 @@ function formatPreviousExecution(
     parts.push(`${prev.rowCount} row${prev.rowCount !== 1 ? "s" : ""}`);
   }
 
-  if (prev.executionMs != null) {
-    parts.push(`${(prev.executionMs / 1000).toFixed(1)}s`);
+  if (Number.isFinite(prev.executionMs)) {
+    parts.push(`${(prev.executionMs! / 1000).toFixed(1)}s`);
   }
 
   return parts.length > 0 ? `was ${parts.join(" · ")}` : null;
 }
 
-function SQLResultCardInner({ part, previousExecution }: { part: unknown; previousExecution?: { executionMs?: number; rowCount?: number } }) {
+function SQLResultCardInner({ part, previousExecution }: { part: unknown; previousExecution?: PreviousExecution }) {
   const dark = useDarkMode();
   const bridge = useDashboardBridge();
   const args = getToolArgs(part);

--- a/packages/web/src/ui/components/chat/sql-result-card.tsx
+++ b/packages/web/src/ui/components/chat/sql-result-card.tsx
@@ -23,10 +23,10 @@ function toStringRows(columns: string[], rows: Record<string, unknown>[]): strin
 }
 
 
-export function SQLResultCard({ part }: { part: unknown }) {
+export function SQLResultCard({ part, previousExecution }: { part: unknown; previousExecution?: { executionMs?: number; rowCount?: number } }) {
   return (
     <ResultCardErrorBoundary label="SQL">
-      <SQLResultCardInner part={part} />
+      <SQLResultCardInner part={part} previousExecution={previousExecution} />
     </ResultCardErrorBoundary>
   );
 }
@@ -36,7 +36,26 @@ const AddToDashboardDialog = dynamic(
   { ssr: false, loading: () => null },
 );
 
-function SQLResultCardInner({ part }: { part: unknown }) {
+/** Build a human-readable comparison string like "was 512 rows · 3.4s". */
+function formatPreviousExecution(
+  prev: { executionMs?: number; rowCount?: number },
+  currentRowCount: number,
+): string | null {
+  const parts: string[] = [];
+
+  // Show previous row count only if it differs from current
+  if (prev.rowCount != null && prev.rowCount !== currentRowCount) {
+    parts.push(`${prev.rowCount} row${prev.rowCount !== 1 ? "s" : ""}`);
+  }
+
+  if (prev.executionMs != null) {
+    parts.push(`${(prev.executionMs / 1000).toFixed(1)}s`);
+  }
+
+  return parts.length > 0 ? `was ${parts.join(" · ")}` : null;
+}
+
+function SQLResultCardInner({ part, previousExecution }: { part: unknown; previousExecution?: { executionMs?: number; rowCount?: number } }) {
   const dark = useDarkMode();
   const bridge = useDashboardBridge();
   const args = getToolArgs(part);
@@ -118,6 +137,10 @@ function SQLResultCardInner({ part }: { part: unknown }) {
           {Number.isFinite(result.executionMs) && (
             <> · {result.cached ? "cached" : `${(result.executionMs / 1000).toFixed(1)}s`}</>
           )}
+          {previousExecution && (() => {
+            const comparison = formatPreviousExecution(previousExecution, rows.length);
+            return comparison ? <span className="text-zinc-400 dark:text-zinc-500"> ({comparison})</span> : null;
+          })()}
         </span>
       }
     >

--- a/packages/web/src/ui/components/chat/tool-part.tsx
+++ b/packages/web/src/ui/components/chat/tool-part.tsx
@@ -8,6 +8,7 @@ import { ExploreCard } from "./explore-card";
 import { SQLResultCard } from "./sql-result-card";
 import { ActionApprovalCard } from "../actions/action-approval-card";
 import { PythonResultCard, type PythonProgressData } from "./python-result-card";
+import type { PreviousExecution } from "../notebook/types";
 
 /** Extract the tool invocation ID from an AI SDK tool part. */
 function getToolInvocationId(part: unknown): string | undefined {
@@ -16,7 +17,7 @@ function getToolInvocationId(part: unknown): string | undefined {
   return typeof p.toolInvocationId === "string" ? p.toolInvocationId : undefined;
 }
 
-export const ToolPart = memo(function ToolPart({ part, pythonProgress, previousExecution }: { part: unknown; pythonProgress?: Map<string, PythonProgressData[]>; previousExecution?: { executionMs?: number; rowCount?: number } }) {
+export const ToolPart = memo(function ToolPart({ part, pythonProgress, previousExecution }: { part: unknown; pythonProgress?: Map<string, PythonProgressData[]>; previousExecution?: PreviousExecution }) {
   let name: string;
   try {
     name = getToolName(part as Parameters<typeof getToolName>[0]);

--- a/packages/web/src/ui/components/chat/tool-part.tsx
+++ b/packages/web/src/ui/components/chat/tool-part.tsx
@@ -16,7 +16,7 @@ function getToolInvocationId(part: unknown): string | undefined {
   return typeof p.toolInvocationId === "string" ? p.toolInvocationId : undefined;
 }
 
-export const ToolPart = memo(function ToolPart({ part, pythonProgress }: { part: unknown; pythonProgress?: Map<string, PythonProgressData[]> }) {
+export const ToolPart = memo(function ToolPart({ part, pythonProgress, previousExecution }: { part: unknown; pythonProgress?: Map<string, PythonProgressData[]>; previousExecution?: { executionMs?: number; rowCount?: number } }) {
   let name: string;
   try {
     name = getToolName(part as Parameters<typeof getToolName>[0]);
@@ -33,7 +33,7 @@ export const ToolPart = memo(function ToolPart({ part, pythonProgress }: { part:
     case "explore":
       return <ExploreCard part={part} />;
     case "executeSQL":
-      return <SQLResultCard part={part} />;
+      return <SQLResultCard part={part} previousExecution={previousExecution} />;
     case "executePython": {
       const invocationId = getToolInvocationId(part);
       const events = invocationId ? pythonProgress?.get(invocationId) : undefined;
@@ -52,6 +52,8 @@ export const ToolPart = memo(function ToolPart({ part, pythonProgress }: { part:
     }
   }
 }, (prev, next) => {
+  // Re-render when previousExecution comparison changes (rerun metadata display)
+  if (prev.previousExecution !== next.previousExecution) return false;
   // Once a tool part is complete, its output won't change — skip re-renders.
   // This prevents the Recharts render tree from contributing to React's update depth limit.
   if (isToolComplete(prev.part) && isToolComplete(next.part)) return true;

--- a/packages/web/src/ui/components/notebook/notebook-cell-output.tsx
+++ b/packages/web/src/ui/components/notebook/notebook-cell-output.tsx
@@ -12,9 +12,10 @@ interface CellOutputProps {
   assistantMessage: UIMessage | null;
   status: CellStatus;
   collapsed: boolean;
+  previousExecution?: { executionMs?: number; rowCount?: number };
 }
 
-export function NotebookCellOutput({ assistantMessage, status, collapsed }: CellOutputProps) {
+export function NotebookCellOutput({ assistantMessage, status, collapsed, previousExecution }: CellOutputProps) {
   if (status === "running" && !assistantMessage) {
     return <TypingIndicator />;
   }
@@ -50,7 +51,7 @@ export function NotebookCellOutput({ assistantMessage, status, collapsed }: Cell
           return <Markdown key={i} content={displayText} />;
         }
         if (isToolUIPart(part)) {
-          return <ToolPart key={i} part={part} />;
+          return <ToolPart key={i} part={part} previousExecution={previousExecution} />;
         }
         return null;
       })}

--- a/packages/web/src/ui/components/notebook/notebook-cell-output.tsx
+++ b/packages/web/src/ui/components/notebook/notebook-cell-output.tsx
@@ -2,7 +2,7 @@
 
 import type { UIMessage } from "@ai-sdk/react";
 import { isToolUIPart } from "ai";
-import type { CellStatus } from "./types";
+import type { CellStatus, PreviousExecution } from "./types";
 import { ToolPart } from "@/ui/components/chat/tool-part";
 import { Markdown } from "@/ui/components/chat/markdown";
 import { TypingIndicator } from "@/ui/components/chat/typing-indicator";
@@ -12,7 +12,7 @@ interface CellOutputProps {
   assistantMessage: UIMessage | null;
   status: CellStatus;
   collapsed: boolean;
-  previousExecution?: { executionMs?: number; rowCount?: number };
+  previousExecution?: PreviousExecution;
 }
 
 export function NotebookCellOutput({ assistantMessage, status, collapsed, previousExecution }: CellOutputProps) {

--- a/packages/web/src/ui/components/notebook/notebook-cell.tsx
+++ b/packages/web/src/ui/components/notebook/notebook-cell.tsx
@@ -113,6 +113,7 @@ export const NotebookCell = forwardRef<HTMLElement, NotebookCellProps>(
                 assistantMessage={cell.assistantMessage}
                 status={cell.status}
                 collapsed={cell.collapsed}
+                previousExecution={cell.previousExecution}
               />
             </DashboardBridgeProvider>
           </div>

--- a/packages/web/src/ui/components/notebook/types.ts
+++ b/packages/web/src/ui/components/notebook/types.ts
@@ -16,6 +16,8 @@ export interface NotebookCell {
   type?: CellType;
   /** Markdown content for text cells. */
   content?: string;
+  /** Snapshot of previous execution metadata — set before rerun, auto-cleared after 30s. */
+  previousExecution?: { executionMs?: number; rowCount?: number };
 }
 
 export interface NotebookState {

--- a/packages/web/src/ui/components/notebook/types.ts
+++ b/packages/web/src/ui/components/notebook/types.ts
@@ -4,6 +4,12 @@ import type { ForkBranchWire } from "@/ui/lib/types";
 export type CellStatus = "idle" | "running" | "error";
 export type CellType = "query" | "text";
 
+/** Snapshot of a prior SQL execution for rerun comparison display. */
+export interface PreviousExecution {
+  executionMs?: number;
+  rowCount?: number;
+}
+
 export interface NotebookCell {
   id: string;
   /** Message ID for query cells; empty string for text cells. */
@@ -17,7 +23,7 @@ export interface NotebookCell {
   /** Markdown content for text cells. */
   content?: string;
   /** Snapshot of previous execution metadata — set before rerun, auto-cleared after 30s. */
-  previousExecution?: { executionMs?: number; rowCount?: number };
+  previousExecution?: PreviousExecution;
 }
 
 export interface NotebookState {

--- a/packages/web/src/ui/components/notebook/use-notebook.ts
+++ b/packages/web/src/ui/components/notebook/use-notebook.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import type { UIMessage } from "@ai-sdk/react";
+import { isToolUIPart } from "ai";
 import type { NotebookStateWire, ForkBranchWire } from "@/ui/lib/types";
 import type { NotebookCell, NotebookState, ResolvedCell, ForkInfo } from "./types";
 import type { DashboardCardEntry } from "./dashboard-bridge-context";
@@ -148,6 +149,37 @@ export function extractTextContent(message: UIMessage): string {
     .join("\n");
 }
 
+/**
+ * Extracts executionMs and rowCount from the executeSQL tool result in a cell's
+ * assistant response. Returns undefined if the cell has no SQL result.
+ */
+function extractExecutionMetadata(
+  messages: UIMessage[],
+  cellMessageId: string,
+): { executionMs?: number; rowCount?: number } | undefined {
+  const userIdx = messages.findIndex((m) => m.id === cellMessageId);
+  if (userIdx === -1) return undefined;
+
+  const nextMsg = messages[userIdx + 1];
+  if (!nextMsg || nextMsg.role !== "assistant") return undefined;
+
+  for (const part of nextMsg.parts) {
+    if (!isToolUIPart(part)) continue;
+    const p = part as Record<string, unknown>;
+    if (p.toolName !== "executeSQL" || p.state !== "output-available") continue;
+
+    const result = p.output as Record<string, unknown> | undefined;
+    if (!result?.success) continue;
+
+    return {
+      executionMs: typeof result.executionMs === "number" ? result.executionMs : undefined,
+      rowCount: Array.isArray(result.rows) ? result.rows.length : undefined,
+    };
+  }
+
+  return undefined;
+}
+
 // ---------------------------------------------------------------------------
 // React hook
 // ---------------------------------------------------------------------------
@@ -225,10 +257,13 @@ export function useNotebook({
     setWarning(null);
   }
 
-  // Clean up warning timer on unmount
+  // Clean up timers on unmount
   useEffect(() => {
+    const timers = comparisonTimers.current;
     return () => {
       if (warningTimer.current) clearTimeout(warningTimer.current);
+      for (const timer of timers.values()) clearTimeout(timer);
+      timers.clear();
     };
   }, []);
 
@@ -244,6 +279,7 @@ export function useNotebook({
       for (const cell of freshCells) {
         const props = initialServerState.cellProps[cell.id];
         if (props?.collapsed) cell.collapsed = true;
+        if (props?.previousExecution) cell.previousExecution = props.previousExecution;
       }
       // Restore text cells from server state
       if (initialServerState.textCells) {
@@ -301,6 +337,8 @@ export function useNotebook({
   // fallback during reconciliation so collapsed/editing state survives the
   // intermediate truncation step where the re-run cell is temporarily absent.
   const preRerunCells = useRef<NotebookCell[]>([]);
+  // Timers for auto-clearing previousExecution comparison after 30s
+  const comparisonTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
 
   // Track which conversation's server state we last applied, so we can
   // detect when new server state arrives (after the async fetch completes).
@@ -334,11 +372,12 @@ export function useNotebook({
         }
       }
 
-      // Restore collapsed state from server
+      // Restore persisted cell props from server
       if (initialServerState?.cellProps) {
         for (const cell of freshCells) {
           const props = initialServerState.cellProps[cell.id];
           if (props?.collapsed) cell.collapsed = true;
+          if (props?.previousExecution) cell.previousExecution = props.previousExecution;
         }
       }
 
@@ -360,12 +399,12 @@ export function useNotebook({
       const queryCells = fresh.map((fc) => {
         const existing = prev.find((pc) => pc.id === fc.id && pc.type !== "text");
         if (existing) {
-          return { ...fc, collapsed: existing.collapsed, editing: existing.editing };
+          return { ...fc, collapsed: existing.collapsed, editing: existing.editing, previousExecution: existing.previousExecution };
         }
         const fallback = preRerunCells.current.find((pc) => pc.id === fc.id);
         if (fallback) {
           usedFallback = true;
-          return { ...fc, collapsed: fallback.collapsed, editing: fallback.editing };
+          return { ...fc, collapsed: fallback.collapsed, editing: fallback.editing, previousExecution: fallback.previousExecution };
         }
         return fc;
       });
@@ -393,10 +432,13 @@ export function useNotebook({
     if (Date.now() < suppressSaveUntil.current) return;
 
     const timer = setTimeout(() => {
-      const cellProps: Record<string, { collapsed?: boolean }> = {};
+      const cellProps: Record<string, { collapsed?: boolean; previousExecution?: { executionMs?: number; rowCount?: number } }> = {};
       for (const cell of cellState) {
-        if (cell.collapsed) {
-          cellProps[cell.id] = { collapsed: true };
+        if (cell.collapsed || cell.previousExecution) {
+          cellProps[cell.id] = {
+            ...(cell.collapsed && { collapsed: true }),
+            ...(cell.previousExecution && { previousExecution: cell.previousExecution }),
+          };
         }
       }
 
@@ -514,7 +556,31 @@ export function useNotebook({
         console.warn(`rerunCell: cell ${cellId} not found`);
         return;
       }
-      preRerunCells.current = [...cellState];
+
+      // Snapshot current execution metadata for comparison display
+      const prevMeta = extractExecutionMetadata(chat.messages, cell.messageId);
+      if (prevMeta) {
+        setCellState((prev) =>
+          prev.map((c) => (c.id === cellId ? { ...c, previousExecution: prevMeta } : c)),
+        );
+
+        // Auto-clear comparison after 30s
+        const existing = comparisonTimers.current.get(cellId);
+        if (existing) clearTimeout(existing);
+        comparisonTimers.current.set(
+          cellId,
+          setTimeout(() => {
+            comparisonTimers.current.delete(cellId);
+            setCellState((prev) =>
+              prev.map((c) => (c.id === cellId ? { ...c, previousExecution: undefined } : c)),
+            );
+          }, 30_000),
+        );
+      }
+
+      preRerunCells.current = [...cellState.map((c) =>
+        c.id === cellId && prevMeta ? { ...c, previousExecution: prevMeta } : c,
+      )];
       const truncated = truncateMessagesForRerun(chat.messages, cell.messageId);
       chat.setMessages(truncated);
       pendingRerun.current = newQuestion;

--- a/packages/web/src/ui/components/notebook/use-notebook.ts
+++ b/packages/web/src/ui/components/notebook/use-notebook.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import type { UIMessage } from "@ai-sdk/react";
 import { isToolUIPart } from "ai";
 import type { NotebookStateWire, ForkBranchWire } from "@/ui/lib/types";
-import type { NotebookCell, NotebookState, ResolvedCell, ForkInfo } from "./types";
+import type { NotebookCell, NotebookState, ResolvedCell, ForkInfo, PreviousExecution } from "./types";
 import type { DashboardCardEntry } from "./dashboard-bridge-context";
 
 const STORAGE_PREFIX = "atlas:notebook:";
@@ -156,7 +156,7 @@ export function extractTextContent(message: UIMessage): string {
 function extractExecutionMetadata(
   messages: UIMessage[],
   cellMessageId: string,
-): { executionMs?: number; rowCount?: number } | undefined {
+): PreviousExecution | undefined {
   const userIdx = messages.findIndex((m) => m.id === cellMessageId);
   if (userIdx === -1) return undefined;
 
@@ -245,6 +245,8 @@ export function useNotebook({
   const [input, setInput] = useState("");
   const [warning, setWarning] = useState<string | null>(null);
   const warningTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Timers for auto-clearing previousExecution comparison after 30s
+  const comparisonTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
 
   function showWarning(msg: string): void {
     if (warningTimer.current) clearTimeout(warningTimer.current);
@@ -279,7 +281,6 @@ export function useNotebook({
       for (const cell of freshCells) {
         const props = initialServerState.cellProps[cell.id];
         if (props?.collapsed) cell.collapsed = true;
-        if (props?.previousExecution) cell.previousExecution = props.previousExecution;
       }
       // Restore text cells from server state
       if (initialServerState.textCells) {
@@ -337,8 +338,6 @@ export function useNotebook({
   // fallback during reconciliation so collapsed/editing state survives the
   // intermediate truncation step where the re-run cell is temporarily absent.
   const preRerunCells = useRef<NotebookCell[]>([]);
-  // Timers for auto-clearing previousExecution comparison after 30s
-  const comparisonTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
 
   // Track which conversation's server state we last applied, so we can
   // detect when new server state arrives (after the async fetch completes).
@@ -377,7 +376,6 @@ export function useNotebook({
         for (const cell of freshCells) {
           const props = initialServerState.cellProps[cell.id];
           if (props?.collapsed) cell.collapsed = true;
-          if (props?.previousExecution) cell.previousExecution = props.previousExecution;
         }
       }
 
@@ -432,13 +430,10 @@ export function useNotebook({
     if (Date.now() < suppressSaveUntil.current) return;
 
     const timer = setTimeout(() => {
-      const cellProps: Record<string, { collapsed?: boolean; previousExecution?: { executionMs?: number; rowCount?: number } }> = {};
+      const cellProps: Record<string, { collapsed?: boolean }> = {};
       for (const cell of cellState) {
-        if (cell.collapsed || cell.previousExecution) {
-          cellProps[cell.id] = {
-            ...(cell.collapsed && { collapsed: true }),
-            ...(cell.previousExecution && { previousExecution: cell.previousExecution }),
-          };
+        if (cell.collapsed) {
+          cellProps[cell.id] = { collapsed: true };
         }
       }
 


### PR DESCRIPTION
## Summary

Closes #1402

- Before a notebook cell rerun, captures the current `executionMs` and `rowCount` from the SQL tool result into `cellProps.previousExecution`
- After rerun completes, the metadata line shows the delta: `"247 rows · 1.2s (was 512 rows · 3.4s)"`
- Comparison auto-clears after 30 seconds via timer managed in `use-notebook`
- Gracefully handles missing previous metadata (no comparison shown)
- Persisted in `NotebookStateWire.cellProps` so it survives reconciliation during the rerun message truncation cycle

### Files changed
- `packages/types/src/conversation.ts` — extended `cellProps` type with `previousExecution`
- `packages/web/src/ui/components/notebook/types.ts` — added `previousExecution` to `NotebookCell`
- `packages/web/src/ui/components/notebook/use-notebook.ts` — metadata extraction, rerun capture, auto-clear timer, reconciliation preservation
- `packages/web/src/ui/components/notebook/notebook-cell.tsx` — pass prop to output
- `packages/web/src/ui/components/notebook/notebook-cell-output.tsx` — thread prop to `ToolPart`
- `packages/web/src/ui/components/chat/tool-part.tsx` — thread prop to `SQLResultCard`, updated memo comparator
- `packages/web/src/ui/components/chat/sql-result-card.tsx` — comparison display in `headerExtra`

## Test plan

- [ ] Open notebook, run a SQL query, verify metadata line shows `"N rows · X.Xs"`
- [ ] Rerun the same cell, verify comparison appears: `"N rows · X.Xs (was M rows · Y.Ys)"`
- [ ] Wait 30 seconds, verify comparison text disappears
- [ ] Rerun a cell with no previous SQL result — no comparison shown
- [ ] Verify regular (non-notebook) chat SQL results are unaffected
- [ ] CI passes: lint, type-check, tests, syncpack, template drift