### PR TITLE
fix: replace bounce easing with smooth pulse on typing indicator

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -125,3 +125,18 @@
     @apply bg-background text-foreground;
     }
 }
+
+@theme inline {
+  --animate-typing-dot: typing-dot 1.2s ease-in-out infinite;
+}
+
+@keyframes typing-dot {
+  0%, 60%, 100% {
+    opacity: 0.3;
+    transform: translateY(0);
+  }
+  30% {
+    opacity: 1;
+    transform: translateY(-2px);
+  }
+}

--- a/packages/web/src/ui/components/chat/typing-indicator.tsx
+++ b/packages/web/src/ui/components/chat/typing-indicator.tsx
@@ -1,19 +1,19 @@
 "use client";
 
-const DELAY_1 = { animationDelay: "150ms" } as const;
-const DELAY_2 = { animationDelay: "300ms" } as const;
+const DELAY_1 = { animationDelay: "200ms" } as const;
+const DELAY_2 = { animationDelay: "400ms" } as const;
 
 export function TypingIndicator() {
   return (
     <div className="flex justify-start">
-      <div className="flex items-center gap-1 rounded-xl bg-zinc-100 px-4 py-3 dark:bg-zinc-800">
-        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-zinc-400 dark:bg-zinc-500" />
+      <div className="flex items-center gap-1.5 rounded-xl bg-zinc-100 px-4 py-3 dark:bg-zinc-800">
+        <span className="h-1.5 w-1.5 animate-typing-dot rounded-full bg-zinc-400 dark:bg-zinc-500" />
         <span
-          className="h-1.5 w-1.5 animate-bounce rounded-full bg-zinc-400 dark:bg-zinc-500"
+          className="h-1.5 w-1.5 animate-typing-dot rounded-full bg-zinc-400 dark:bg-zinc-500"
           style={DELAY_1}
         />
         <span
-          className="h-1.5 w-1.5 animate-bounce rounded-full bg-zinc-400 dark:bg-zinc-500"
+          className="h-1.5 w-1.5 animate-typing-dot rounded-full bg-zinc-400 dark:bg-zinc-500"
           style={DELAY_2}
         />
       </div>


### PR DESCRIPTION
## Summary
- Replaced `animate-bounce` with custom `animate-typing-dot` on chat typing indicator dots
- New animation uses ease-in-out opacity fade (0.3→1) with subtle 2px vertical lift — no bounce
- Widened dot gap and adjusted stagger delays for smoother cascade

Detected via `impeccable detect` — bounce easing flagged as AI-generated UI tell.

## Test plan
- [ ] Open a chat, trigger agent response, verify typing dots animate smoothly
- [ ] Check both light and dark mode