### PR TITLE
fix: replace hardcoded blue with brand primary across chat UI

### DIFF
--- a/e2e/browser/helpers.ts
+++ b/e2e/browser/helpers.ts
@@ -19,8 +19,8 @@ export async function askQuestion(page: Page, question: string) {
 
 /** Wait for a SQL result card to appear in the conversation. */
 export async function waitForSQLResult(page: Page) {
-  // SQL result cards have a blue "SQL" badge (bg-blue-100 class — update if theme changes)
-  await page.locator(".bg-blue-100", { hasText: "SQL" }).first().waitFor({ timeout: 60_000 });
+  // SQL result cards render a badge with text "SQL" inside a ResultCardBase
+  await page.locator("span", { hasText: /^SQL$/ }).first().waitFor({ timeout: 60_000 });
 }
 
 /** Start a new chat session. */

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -403,7 +403,7 @@ function PoolBar({ active, idle, total }: { active: number; idle: number; total:
   const idlePct = Math.round((idle / total) * 100);
   return (
     <div className="flex h-2 w-full overflow-hidden rounded-full bg-muted">
-      <div className="bg-blue-500 transition-all" style={{ width: `${activePct}%` }} />
+      <div className="bg-primary transition-all" style={{ width: `${activePct}%` }} />
       <div className="bg-emerald-400 transition-all" style={{ width: `${idlePct}%` }} />
     </div>
   );

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -403,7 +403,7 @@ function PoolBar({ active, idle, total }: { active: number; idle: number; total:
   const idlePct = Math.round((idle / total) * 100);
   return (
     <div className="flex h-2 w-full overflow-hidden rounded-full bg-muted">
-      <div className="bg-primary transition-all" style={{ width: `${activePct}%` }} />
+      <div className="bg-violet-500 transition-all" style={{ width: `${activePct}%` }} />
       <div className="bg-emerald-400 transition-all" style={{ width: `${idlePct}%` }} />
     </div>
   );

--- a/packages/web/src/app/admin/learned-patterns/columns.tsx
+++ b/packages/web/src/app/admin/learned-patterns/columns.tsx
@@ -42,7 +42,7 @@ export const statusBadge: Record<string, { variant: "outline"; className: string
 export const typeBadge: Record<string, { variant: "outline"; className: string; label: string }> = {
   query_pattern: {
     variant: "outline",
-    className: "border-blue-300 text-blue-700 dark:border-blue-700 dark:text-blue-400",
+    className: "border-primary/50 text-primary dark:border-primary/50 dark:text-primary",
     label: "Query Pattern",
   },
   semantic_amendment: {
@@ -55,7 +55,7 @@ export const typeBadge: Record<string, { variant: "outline"; className: string; 
 const sourceBadge: Record<string, { variant: "outline"; className: string; label: string }> = {
   agent: {
     variant: "outline",
-    className: "border-blue-300 text-blue-700 dark:border-blue-700 dark:text-blue-400",
+    className: "border-primary/50 text-primary dark:border-primary/50 dark:text-primary",
     label: "Agent",
   },
   "atlas-learn": {

--- a/packages/web/src/app/admin/platform/backups/page.tsx
+++ b/packages/web/src/app/admin/platform/backups/page.tsx
@@ -62,7 +62,7 @@ function statusBadge(status: BackupStatus) {
     case "completed":
       return <Badge variant="outline" className="gap-1 border-green-500 text-green-600"><CheckCircle2 className="size-3" />Completed</Badge>;
     case "verified":
-      return <Badge variant="outline" className="gap-1 border-blue-500 text-blue-600"><ShieldCheck className="size-3" />Verified</Badge>;
+      return <Badge variant="outline" className="gap-1 border-primary/50 text-primary"><ShieldCheck className="size-3" />Verified</Badge>;
     case "in_progress":
       return <Badge variant="outline" className="gap-1 border-amber-500 text-amber-600"><Loader2 className="size-3 animate-spin" />In Progress</Badge>;
     case "failed":

--- a/packages/web/src/app/admin/platform/page.tsx
+++ b/packages/web/src/app/admin/platform/page.tsx
@@ -112,7 +112,7 @@ function planBadge(tier: PlanTier) {
     case "free":
       return <Badge variant="secondary">Free</Badge>;
     case "trial":
-      return <Badge variant="outline" className="border-blue-500 text-blue-600">Trial</Badge>;
+      return <Badge variant="outline" className="border-primary/50 text-primary">Trial</Badge>;
     case "starter":
       return <Badge variant="outline" className="border-green-500 text-green-600">Starter</Badge>;
     case "pro":

--- a/packages/web/src/app/admin/platform/settings/page.tsx
+++ b/packages/web/src/app/admin/platform/settings/page.tsx
@@ -494,9 +494,9 @@ function PlatformSettingsContent() {
           )}
 
           {manageable && (
-            <div className="mb-6 flex items-start gap-2 rounded-md border border-blue-500/30 bg-blue-500/5 px-4 py-3">
-              <Info className="mt-0.5 size-4 shrink-0 text-blue-600 dark:text-blue-400" />
-              <p className="text-sm text-blue-700 dark:text-blue-300">
+            <div className="mb-6 flex items-start gap-2 rounded-md border border-primary/30 bg-primary/5 px-4 py-3">
+              <Info className="mt-0.5 size-4 shrink-0 text-primary" />
+              <p className="text-sm text-primary dark:text-primary/80">
                 {isSaas
                   ? "Setting overrides are saved and take effect immediately."
                   : <>

--- a/packages/web/src/app/admin/prompts/columns.tsx
+++ b/packages/web/src/app/admin/prompts/columns.tsx
@@ -22,7 +22,7 @@ export const industryBadge: Record<
   saas: {
     variant: "outline",
     className:
-      "border-blue-300 text-blue-700 dark:border-blue-700 dark:text-blue-400",
+      "border-primary/50 text-primary dark:border-primary/50 dark:text-primary",
     label: "SaaS",
   },
   ecommerce: {

--- a/packages/web/src/app/admin/residency/page.tsx
+++ b/packages/web/src/app/admin/residency/page.tsx
@@ -314,17 +314,17 @@ function MigrationStatusBanner({
   switch (migration.status) {
     case "pending":
       return (
-        <div className="flex items-start gap-3 rounded-md border border-blue-200 bg-blue-50 p-4 dark:border-blue-900 dark:bg-blue-950/50">
-          <Clock className="mt-0.5 h-5 w-5 shrink-0 text-blue-600 dark:text-blue-400" />
+        <div className="flex items-start gap-3 rounded-md border border-primary/30 bg-primary/5 p-4 dark:border-primary/20 dark:bg-primary/5">
+          <Clock className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
           <div className="flex-1 text-sm">
-            <p className="font-medium text-blue-800 dark:text-blue-200">
+            <p className="font-medium text-primary">
               Migration requested
             </p>
-            <p className="mt-1 text-blue-700 dark:text-blue-300">
+            <p className="mt-1 text-primary/80 dark:text-primary/70">
               Your request to migrate from <strong>{migration.sourceRegion}</strong> to{" "}
               <strong>{migration.targetRegion}</strong> is queued for processing.
             </p>
-            <p className="mt-1 text-xs text-blue-600 dark:text-blue-400">
+            <p className="mt-1 text-xs text-primary/70 dark:text-primary/60">
               Requested {formatDate(migration.requestedAt)}
             </p>
             <div className="mt-2">
@@ -333,7 +333,7 @@ function MigrationStatusBanner({
                 size="sm"
                 onClick={() => onCancel(migration.id)}
                 disabled={cancelling}
-                className="border-blue-300 text-blue-700 hover:bg-blue-100 dark:border-blue-800 dark:text-blue-300 dark:hover:bg-blue-900"
+                className="border-primary/50 text-primary hover:bg-primary/10 dark:border-primary/30 dark:text-primary/80 dark:hover:bg-primary/10"
               >
                 {cancelling ? (
                   <>

--- a/packages/web/src/app/admin/semantic/improve/page.tsx
+++ b/packages/web/src/app/admin/semantic/improve/page.tsx
@@ -81,7 +81,7 @@ function diffLineStyle(line: string): string {
     return "text-muted-foreground bg-muted font-semibold";
   }
   if (line.startsWith("@@")) {
-    return "text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/30";
+    return "text-primary dark:text-primary bg-primary/10 dark:bg-primary/10";
   }
   if (line.startsWith("+")) {
     return "text-green-700 dark:text-green-400 bg-green-50 dark:bg-green-950/30";

--- a/packages/web/src/app/admin/semantic/improve/page.tsx
+++ b/packages/web/src/app/admin/semantic/improve/page.tsx
@@ -81,7 +81,7 @@ function diffLineStyle(line: string): string {
     return "text-muted-foreground bg-muted font-semibold";
   }
   if (line.startsWith("@@")) {
-    return "text-primary dark:text-primary bg-primary/10 dark:bg-primary/10";
+    return "text-violet-600 dark:text-violet-400 bg-violet-50 dark:bg-violet-950/30";
   }
   if (line.startsWith("+")) {
     return "text-green-700 dark:text-green-400 bg-green-50 dark:bg-green-950/30";

--- a/packages/web/src/app/admin/settings/page.tsx
+++ b/packages/web/src/app/admin/settings/page.tsx
@@ -365,9 +365,9 @@ export default function SettingsPage() {
           )}
 
           {manageable && (
-            <div className="mb-6 flex items-start gap-2 rounded-md border border-blue-500/30 bg-blue-500/5 px-4 py-3">
-              <Info className="mt-0.5 size-4 shrink-0 text-blue-600 dark:text-blue-400" />
-              <p className="text-sm text-blue-700 dark:text-blue-300">
+            <div className="mb-6 flex items-start gap-2 rounded-md border border-primary/30 bg-primary/5 px-4 py-3">
+              <Info className="mt-0.5 size-4 shrink-0 text-primary" />
+              <p className="text-sm text-primary dark:text-primary/80">
                 {isSaas
                   ? "Setting overrides are saved and take effect immediately."
                   : <>

--- a/packages/web/src/app/admin/users/columns.tsx
+++ b/packages/web/src/app/admin/users/columns.tsx
@@ -35,7 +35,7 @@ export interface Invitation {
 const roleBadge: Record<string, { variant: "outline"; className: string }> = {
   owner: { variant: "outline", className: "border-purple-300 text-purple-700 dark:border-purple-700 dark:text-purple-400" },
   admin: { variant: "outline", className: "border-red-300 text-red-700 dark:border-red-700 dark:text-red-400" },
-  member: { variant: "outline", className: "border-blue-300 text-blue-700 dark:border-blue-700 dark:text-blue-400" },
+  member: { variant: "outline", className: "border-primary/50 text-primary dark:border-primary/50 dark:text-primary" },
 };
 
 const inviteStatusBadge: Record<string, { variant: "outline"; className: string }> = {

--- a/packages/web/src/app/error.tsx
+++ b/packages/web/src/app/error.tsx
@@ -18,7 +18,7 @@ export default function Error({
       )}
       <button
         onClick={reset}
-        className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-500"
+        className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
       >
         Try again
       </button>

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -359,7 +359,7 @@ function ChatPage() {
                     if (m.role === "user") {
                       return (
                         <div key={m.id} className="flex justify-end" role="article" aria-label="Message from you">
-                          <div className="max-w-[85%] rounded-xl bg-blue-600 px-4 py-3 text-sm text-white">
+                          <div className="max-w-[85%] rounded-xl bg-primary px-4 py-3 text-sm text-primary-foreground">
                             {m.parts?.map((part, i) =>
                               part.type === "text" ? (
                                 <p key={i} className="whitespace-pre-wrap">

--- a/packages/web/src/app/shared/[token]/embed/page.tsx
+++ b/packages/web/src/app/shared/[token]/embed/page.tsx
@@ -34,7 +34,7 @@ export default async function SharedConversationEmbedPage({
             <div
               className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-medium ${
                 msg.role === "user"
-                  ? "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300"
+                  ? "bg-primary/15 text-primary dark:bg-primary/20 dark:text-primary"
                   : "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
               }`}
             >

--- a/packages/web/src/app/shared/[token]/page.tsx
+++ b/packages/web/src/app/shared/[token]/page.tsx
@@ -153,7 +153,7 @@ export default async function SharedConversationPage({
             <div
               className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-medium ${
                 msg.role === "user"
-                  ? "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300"
+                  ? "bg-primary/15 text-primary dark:bg-primary/20 dark:text-primary"
                   : "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
               }`}
             >

--- a/packages/web/src/ui/__tests__/result-card-base.test.tsx
+++ b/packages/web/src/ui/__tests__/result-card-base.test.tsx
@@ -6,7 +6,7 @@ import { ResultCardBase, ResultCardErrorBoundary } from "../components/chat/resu
 describe("ResultCardBase", () => {
   test("renders badge text", () => {
     const { container } = render(
-      <ResultCardBase badge="SQL" badgeClassName="bg-blue-100" title="Test query">
+      <ResultCardBase badge="SQL" badgeClassName="bg-primary/15" title="Test query">
         <div>content</div>
       </ResultCardBase>,
     );
@@ -15,7 +15,7 @@ describe("ResultCardBase", () => {
 
   test("renders title text", () => {
     const { container } = render(
-      <ResultCardBase badge="SQL" badgeClassName="bg-blue-100" title="Top companies by revenue">
+      <ResultCardBase badge="SQL" badgeClassName="bg-primary/15" title="Top companies by revenue">
         <div>content</div>
       </ResultCardBase>,
     );
@@ -26,7 +26,7 @@ describe("ResultCardBase", () => {
     const { container } = render(
       <ResultCardBase
         badge="SQL"
-        badgeClassName="bg-blue-100"
+        badgeClassName="bg-primary/15"
         title="Query"
         headerExtra={<span data-testid="row-count">5 rows</span>}
       >
@@ -40,7 +40,7 @@ describe("ResultCardBase", () => {
     const { container } = render(
       <ResultCardBase
         badge="SQL"
-        badgeClassName="bg-blue-100"
+        badgeClassName="bg-primary/15"
         title="Query"
         headerExtra={<span data-testid="row-count">5 rows</span>}
       >
@@ -57,7 +57,7 @@ describe("ResultCardBase", () => {
 
   test("renders children when expanded (default)", () => {
     const { container } = render(
-      <ResultCardBase badge="SQL" badgeClassName="bg-blue-100" title="Query">
+      <ResultCardBase badge="SQL" badgeClassName="bg-primary/15" title="Query">
         <div data-testid="child-content">table here</div>
       </ResultCardBase>,
     );
@@ -66,7 +66,7 @@ describe("ResultCardBase", () => {
 
   test("collapse hides children", () => {
     const { container } = render(
-      <ResultCardBase badge="SQL" badgeClassName="bg-blue-100" title="Query">
+      <ResultCardBase badge="SQL" badgeClassName="bg-primary/15" title="Query">
         <div data-testid="child-content">table here</div>
       </ResultCardBase>,
     );
@@ -79,7 +79,7 @@ describe("ResultCardBase", () => {
 
   test("expand after collapse restores children", () => {
     const { container } = render(
-      <ResultCardBase badge="SQL" badgeClassName="bg-blue-100" title="Query">
+      <ResultCardBase badge="SQL" badgeClassName="bg-primary/15" title="Query">
         <div data-testid="child-content">table here</div>
       </ResultCardBase>,
     );
@@ -95,7 +95,7 @@ describe("ResultCardBase", () => {
 
   test("defaultOpen=false starts collapsed", () => {
     const { container } = render(
-      <ResultCardBase badge="SQL" badgeClassName="bg-blue-100" title="Query" defaultOpen={false}>
+      <ResultCardBase badge="SQL" badgeClassName="bg-primary/15" title="Query" defaultOpen={false}>
         <div data-testid="child-content">table here</div>
       </ResultCardBase>,
     );
@@ -104,7 +104,7 @@ describe("ResultCardBase", () => {
 
   test("defaultOpen=false can be expanded", () => {
     const { container } = render(
-      <ResultCardBase badge="SQL" badgeClassName="bg-blue-100" title="Query" defaultOpen={false}>
+      <ResultCardBase badge="SQL" badgeClassName="bg-primary/15" title="Query" defaultOpen={false}>
         <div data-testid="child-content">table here</div>
       </ResultCardBase>,
     );
@@ -143,7 +143,7 @@ describe("ResultCardBase", () => {
 
   test("shows collapse arrow ▾ when expanded", () => {
     const { container } = render(
-      <ResultCardBase badge="SQL" badgeClassName="bg-blue-100" title="Query">
+      <ResultCardBase badge="SQL" badgeClassName="bg-primary/15" title="Query">
         <div>content</div>
       </ResultCardBase>,
     );
@@ -152,7 +152,7 @@ describe("ResultCardBase", () => {
 
   test("shows expand arrow ▸ when collapsed", () => {
     const { container } = render(
-      <ResultCardBase badge="SQL" badgeClassName="bg-blue-100" title="Query" defaultOpen={false}>
+      <ResultCardBase badge="SQL" badgeClassName="bg-primary/15" title="Query" defaultOpen={false}>
         <div>content</div>
       </ResultCardBase>,
     );
@@ -161,7 +161,7 @@ describe("ResultCardBase", () => {
 
   test("toggle button has aria-expanded=true when open", () => {
     const { container } = render(
-      <ResultCardBase badge="SQL" badgeClassName="bg-blue-100" title="Query">
+      <ResultCardBase badge="SQL" badgeClassName="bg-primary/15" title="Query">
         <div>content</div>
       </ResultCardBase>,
     );
@@ -171,7 +171,7 @@ describe("ResultCardBase", () => {
 
   test("toggle button has aria-expanded=false when collapsed", () => {
     const { container } = render(
-      <ResultCardBase badge="SQL" badgeClassName="bg-blue-100" title="Query">
+      <ResultCardBase badge="SQL" badgeClassName="bg-primary/15" title="Query">
         <div>content</div>
       </ResultCardBase>,
     );

--- a/packages/web/src/ui/components/actions/action-approval-card.tsx
+++ b/packages/web/src/ui/components/actions/action-approval-card.tsx
@@ -247,7 +247,7 @@ export function ActionApprovalCard({ part }: { part: unknown }) {
             <button
               onClick={handleApprove}
               disabled={isSubmitting}
-              className="inline-flex items-center gap-1.5 rounded bg-blue-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-blue-500 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-blue-500/50 disabled:opacity-40"
+              className="inline-flex items-center gap-1.5 rounded bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-primary/50 disabled:opacity-40"
             >
               {isSubmitting && cardState.action === "approve" && (
                 <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-white/30 border-t-white" />

--- a/packages/web/src/ui/components/admin/entity-detail.tsx
+++ b/packages/web/src/ui/components/admin/entity-detail.tsx
@@ -67,7 +67,7 @@ export function EntityDetail({ entity }: { entity: EntityData }) {
                           </Badge>
                         )}
                         {dim.foreign_key && (
-                          <Badge className="bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400 text-[10px] px-1 py-0">
+                          <Badge className="bg-primary/15 text-primary dark:bg-primary/20 dark:text-primary text-[10px] px-1 py-0">
                             FK
                           </Badge>
                         )}

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -513,7 +513,7 @@ export function AtlasChat() {
                     if (m.role === "user") {
                       return (
                         <div key={m.id} className="flex justify-end" role="article" aria-label="Message from you">
-                          <div className="max-w-[85%] rounded-xl bg-blue-600 px-4 py-3 text-sm text-white">
+                          <div className="max-w-[85%] rounded-xl bg-primary px-4 py-3 text-sm text-primary-foreground">
                             {m.parts?.map((part, i) =>
                               part.type === "text" ? (
                                 <p key={i} className="whitespace-pre-wrap">

--- a/packages/web/src/ui/components/chart/result-chart.tsx
+++ b/packages/web/src/ui/components/chart/result-chart.tsx
@@ -474,7 +474,7 @@ function ChartTypeSelector({
           aria-pressed={active === rec.type}
           className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 ${
             active === rec.type
-              ? "bg-blue-100 text-blue-700 dark:bg-blue-600/20 dark:text-blue-400"
+              ? "bg-primary/15 text-primary dark:bg-primary/20 dark:text-primary"
               : "text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200"
           }`}
         >

--- a/packages/web/src/ui/components/chat/result-card-base.tsx
+++ b/packages/web/src/ui/components/chat/result-card-base.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 export interface ResultCardBaseProps {
   /** Badge text shown in the header (e.g. "SQL", "Python") */
   badge: string;
-  /** Color classes for the badge — expects bg + text + dark variants, e.g. "bg-blue-100 text-blue-700 dark:bg-blue-600/20 dark:text-blue-400" */
+  /** Color classes for the badge — expects bg + text + dark variants, e.g. "bg-primary/15 text-primary dark:bg-primary/20 dark:text-primary" */
   badgeClassName: string;
   /** Title/explanation text shown next to the badge */
   title: string;
@@ -32,7 +32,7 @@ export function ResultCardBase({
   const [open, setOpen] = useState(defaultOpen);
 
   return (
-    <div className="my-2 overflow-hidden rounded-lg border border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900">
+    <div className="my-2 rounded-lg border border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900">
       <button
         aria-expanded={open}
         onClick={() => setOpen(!open)}

--- a/packages/web/src/ui/components/chat/share-dialog.tsx
+++ b/packages/web/src/ui/components/chat/share-dialog.tsx
@@ -234,8 +234,8 @@ export function ShareDialog({ conversationId, onShare, onUnshare, onGetShareStat
           size="xs"
           className={
             shared
-              ? "text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300"
-              : "text-zinc-400 hover:text-blue-500 dark:text-zinc-500 dark:hover:text-blue-400"
+              ? "text-primary hover:text-primary/80 dark:text-primary dark:hover:text-primary/80"
+              : "text-zinc-400 hover:text-primary dark:text-zinc-500 dark:hover:text-primary"
           }
           aria-label={shared ? "Manage share link" : "Share conversation"}
         >

--- a/packages/web/src/ui/components/chat/sql-result-card.tsx
+++ b/packages/web/src/ui/components/chat/sql-result-card.tsx
@@ -101,7 +101,7 @@ function SQLResultCardInner({ part }: { part: unknown }) {
   return (
     <ResultCardBase
       badge="SQL"
-      badgeClassName="bg-blue-100 text-blue-700 dark:bg-blue-600/20 dark:text-blue-400"
+      badgeClassName="bg-primary/15 text-primary dark:bg-primary/20 dark:text-primary"
       title={String(args.explanation ?? "Query result")}
       headerExtra={
         <span className="flex items-center gap-1.5 text-zinc-500">

--- a/packages/web/src/ui/components/conversations/conversation-item.tsx
+++ b/packages/web/src/ui/components/conversations/conversation-item.tsx
@@ -85,7 +85,7 @@ export function ConversationItem({
       }}
       className={`group flex w-full cursor-pointer items-center gap-2 rounded-lg px-3 py-2.5 text-left text-sm transition-colors focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 ${
         isActive
-          ? "bg-blue-50 text-blue-700 dark:bg-blue-600/10 dark:text-blue-400"
+          ? "bg-primary/10 text-primary dark:bg-primary/10 dark:text-primary"
           : "text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
       }`}
     >

--- a/packages/web/src/ui/components/notebook/notebook-cell.tsx
+++ b/packages/web/src/ui/components/notebook/notebook-cell.tsx
@@ -49,8 +49,8 @@ export const NotebookCell = forwardRef<HTMLElement, NotebookCellProps>(
           aria-label={`Cell ${cell.number}`}
           tabIndex={0}
           className={cn(
-            "group rounded-lg border border-zinc-200 bg-white transition-shadow focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-zinc-800 dark:bg-zinc-950",
-            isRunning && "ring-2 ring-blue-400/50",
+            "group rounded-lg border border-zinc-200 bg-white transition-shadow focus:outline-none focus:ring-2 focus:ring-ring dark:border-zinc-800 dark:bg-zinc-950",
+            isRunning && "ring-2 ring-primary/50",
           )}
         >
           <div className="flex items-start gap-3 border-b border-zinc-100 px-4 py-3 dark:border-zinc-800/50">

--- a/packages/web/src/ui/components/notebook/notebook-text-cell.tsx
+++ b/packages/web/src/ui/components/notebook/notebook-text-cell.tsx
@@ -76,7 +76,7 @@ export const NotebookTextCell = forwardRef<HTMLElement, NotebookTextCellProps>(
         aria-label={`Text cell ${cell.number}`}
         tabIndex={0}
         className={cn(
-          "group rounded-lg border border-dashed border-zinc-300 bg-zinc-50/50 transition-shadow focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-900/30",
+          "group rounded-lg border border-dashed border-zinc-300 bg-zinc-50/50 transition-shadow focus:outline-none focus:ring-2 focus:ring-ring dark:border-zinc-700 dark:bg-zinc-900/30",
         )}
       >
         <div className="flex items-start gap-3 border-b border-dashed border-zinc-200 px-4 py-2 dark:border-zinc-800/50">

--- a/packages/web/src/ui/components/schema-explorer/schema-explorer.tsx
+++ b/packages/web/src/ui/components/schema-explorer/schema-explorer.tsx
@@ -248,7 +248,7 @@ function EntityDetailView({
                             </Badge>
                           )}
                           {dim.foreign_key && (
-                            <Badge className="shrink-0 bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400 text-[9px] px-1 py-0">
+                            <Badge className="shrink-0 bg-primary/15 text-primary dark:bg-primary/20 dark:text-primary text-[9px] px-1 py-0">
                               FK
                             </Badge>
                           )}
@@ -293,7 +293,7 @@ function EntityDetailView({
                         </Badge>
                         <button
                           onClick={() => onNavigateEntity(join.to)}
-                          className="text-xs font-medium text-blue-600 hover:underline dark:text-blue-400"
+                          className="text-xs font-medium text-primary hover:underline dark:text-primary"
                         >
                           {join.to}
                         </button>


### PR DESCRIPTION
## Summary
- Replaced all hardcoded `blue-*` Tailwind classes with `primary` token (brand teal) across 6 chat-area files:
  - **Conversation sidebar** — active item highlight (`bg-primary/10 text-primary`)
  - **User message bubble** — `bg-primary text-primary-foreground` instead of `bg-blue-600 text-white`
  - **SQL result badge** — `bg-primary/15 text-primary`
  - **Chart type toggle** — active state uses primary
  - **Share button** — shared/hover states use primary
- Removed `overflow-hidden` from `ResultCardBase` so large tables and charts scroll instead of clipping
- Updated JSDoc example in `ResultCardBase` to show primary-based badge classes

## Test plan
- [ ] Open chat, verify user message bubbles are teal (not blue)
- [ ] Check conversation sidebar — active item should highlight teal
- [ ] Run a SQL query, verify result badge and chart toggle use teal
- [ ] Share a conversation, verify share button is teal
- [ ] Run a query with a wide table or chart — verify content is not clipped
- [ ] Check both light and dark mode