### PR TITLE
refactor: extract shared transformMessages to @useatlas/types

### DIFF
--- a/packages/react/src/hooks/use-conversations.ts
+++ b/packages/react/src/hooks/use-conversations.ts
@@ -2,8 +2,9 @@
 
 import { useState, useCallback, useRef } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import type { Conversation, ConversationWithMessages, Message } from "../lib/types";
+import type { Conversation, ConversationWithMessages } from "../lib/types";
 import type { UIMessage } from "@ai-sdk/react";
+import { transformMessages } from "@useatlas/types/conversation";
 
 export interface UseConversationsOptions {
   apiUrl: string;
@@ -29,39 +30,7 @@ export interface UseConversationsReturn {
   refresh: () => Promise<void>;
 }
 
-export function transformMessages(messages: Message[]): UIMessage[] {
-  return messages
-    .filter((m) => m.role === "user" || m.role === "assistant")
-    .map((m) => {
-      const parts: UIMessage["parts"] = Array.isArray(m.content)
-        ? (m.content as Record<string, unknown>[])
-            .filter((p) => p.type === "text" || p.type === "tool-invocation")
-            .map((p, idx) => {
-              if (p.type === "tool-invocation") {
-                const toolCallId = typeof p.toolCallId === "string" && p.toolCallId
-                  ? p.toolCallId
-                  : `unknown-${idx}`;
-                return {
-                  type: "dynamic-tool" as const,
-                  toolName: typeof p.toolName === "string" ? p.toolName : "unknown",
-                  toolCallId,
-                  toolInvocationId: toolCallId,
-                  state: "output-available" as const,
-                  input: p.args,
-                  output: p.result,
-                };
-              }
-              return { type: "text" as const, text: String(p.text ?? "") };
-            })
-        : [{ type: "text" as const, text: String(m.content) }];
-
-      return {
-        id: m.id,
-        role: m.role as "user" | "assistant",
-        parts,
-      };
-    });
-}
+export { transformMessages } from "@useatlas/types/conversation";
 
 interface ConversationListData {
   conversations: Conversation[];

--- a/packages/types/src/conversation.test.ts
+++ b/packages/types/src/conversation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { transformMessages } from "../hooks/use-conversations";
-import type { Message } from "../lib/types";
+import { transformMessages } from "./conversation";
+import type { Message } from "./conversation";
 
 /* ------------------------------------------------------------------ */
 /*  transformMessages                                                   */
@@ -66,7 +66,7 @@ describe("transformMessages", () => {
     ]);
   });
 
-  test("reconstructs tool-invocation parts as DynamicToolUIPart", () => {
+  test("reconstructs tool-invocation parts as dynamic-tool", () => {
     const messages: Message[] = [
       msg({ id: "1", role: "assistant", content: [
         { type: "tool-invocation", toolCallId: "tc1", toolName: "executeSQL", args: { sql: "SELECT 1" }, result: { columns: ["?column?"], rows: [{ "?column?": 1 }] } },
@@ -140,15 +140,6 @@ describe("transformMessages", () => {
     expect(part.state).toBe("output-available");
     expect(part.input).toBeUndefined();
     expect(part.output).toBeUndefined();
-  });
-
-  test("falls back gracefully for old conversations with only text parts", () => {
-    const messages: Message[] = [
-      msg({ id: "1", role: "assistant", content: [{ type: "text", text: "old format answer" }] }),
-    ];
-
-    const result = transformMessages(messages);
-    expect(result[0].parts).toEqual([{ type: "text", text: "old format answer" }]);
   });
 
   test("preserves string content as-is", () => {

--- a/packages/types/src/conversation.test.ts
+++ b/packages/types/src/conversation.test.ts
@@ -164,4 +164,70 @@ describe("transformMessages", () => {
     const result = transformMessages(messages);
     expect(result[0].parts).toEqual([{ type: "text", text: "hello world" }]);
   });
+
+  test("handles null content as empty text", () => {
+    const messages: Message[] = [
+      msg({ id: "1", role: "user", content: null }),
+    ];
+
+    const result = transformMessages(messages);
+    expect(result[0].parts).toEqual([{ type: "text", text: "" }]);
+  });
+
+  test("handles undefined content as empty text", () => {
+    const messages: Message[] = [
+      msg({ id: "1", role: "assistant", content: undefined }),
+    ];
+
+    const result = transformMessages(messages);
+    expect(result[0].parts).toEqual([{ type: "text", text: "" }]);
+  });
+
+  test("handles object content as empty text", () => {
+    const messages: Message[] = [
+      msg({ id: "1", role: "assistant", content: { unexpected: true } }),
+    ];
+
+    const result = transformMessages(messages);
+    expect(result[0].parts).toEqual([{ type: "text", text: "" }]);
+  });
+
+  test("empty-string toolCallId triggers fallback", () => {
+    const messages: Message[] = [
+      msg({ id: "1", role: "assistant", content: [
+        { type: "tool-invocation", toolCallId: "", toolName: "foo", args: {}, result: {} },
+      ] }),
+    ];
+
+    const result = transformMessages(messages);
+    const part = result[0].parts[0] as unknown as Record<string, unknown>;
+    expect(part.toolCallId).toBe("unknown-0");
+    expect(part.toolInvocationId).toBe("unknown-0");
+  });
+
+  test("content array with all unknown types produces empty parts", () => {
+    const messages: Message[] = [
+      msg({ id: "1", role: "assistant", content: [
+        { type: "image", url: "https://example.com/img.png" },
+        { type: "reasoning", text: "thinking..." },
+      ] }),
+    ];
+
+    const result = transformMessages(messages);
+    expect(result[0].parts).toEqual([]);
+  });
+
+  test("skips null and primitive elements in content array", () => {
+    const messages: Message[] = [
+      msg({ id: "1", role: "assistant", content: [
+        null,
+        42,
+        "raw string",
+        { type: "text", text: "valid" },
+      ] }),
+    ];
+
+    const result = transformMessages(messages);
+    expect(result[0].parts).toEqual([{ type: "text", text: "valid" }]);
+  });
 });

--- a/packages/types/src/conversation.ts
+++ b/packages/types/src/conversation.ts
@@ -53,3 +53,76 @@ export interface Message {
 export interface ConversationWithMessages extends Conversation {
   messages: Message[];
 }
+
+// ---------------------------------------------------------------------------
+// transformMessages — converts persisted Message[] to UI-ready format
+// ---------------------------------------------------------------------------
+
+/** A text part in a transformed message. */
+export interface TransformedTextPart {
+  readonly type: "text";
+  readonly text: string;
+}
+
+/** A tool invocation part in a transformed message. */
+export interface TransformedToolPart {
+  readonly type: "dynamic-tool";
+  readonly toolName: string;
+  readonly toolCallId: string;
+  readonly toolInvocationId: string;
+  readonly state: "output-available";
+  readonly input: unknown;
+  readonly output: unknown;
+}
+
+export type TransformedPart = TransformedTextPart | TransformedToolPart;
+
+/** A UI-ready message produced by `transformMessages`. Structurally compatible with `UIMessage`. */
+export interface TransformedMessage {
+  readonly id: string;
+  readonly role: "user" | "assistant";
+  readonly parts: TransformedPart[];
+}
+
+/**
+ * Converts persisted `Message[]` into a UI-ready array.
+ *
+ * Filters to user/assistant messages, maps content parts to text and
+ * dynamic-tool parts. The return type is structurally compatible with
+ * `UIMessage` from `@ai-sdk/react`.
+ */
+export function transformMessages(messages: Message[]): TransformedMessage[] {
+  return messages
+    .filter((m) => m.role === "user" || m.role === "assistant")
+    .map((m) => {
+      const parts: TransformedPart[] = Array.isArray(m.content)
+        ? (m.content as Record<string, unknown>[])
+            .filter((p) => p.type === "text" || p.type === "tool-invocation")
+            .map((p, idx) => {
+              if (p.type === "tool-invocation") {
+                const toolCallId =
+                  typeof p.toolCallId === "string" && p.toolCallId
+                    ? p.toolCallId
+                    : `unknown-${idx}`;
+                return {
+                  type: "dynamic-tool" as const,
+                  toolName:
+                    typeof p.toolName === "string" ? p.toolName : "unknown",
+                  toolCallId,
+                  toolInvocationId: toolCallId,
+                  state: "output-available" as const,
+                  input: p.args,
+                  output: p.result,
+                };
+              }
+              return { type: "text" as const, text: String(p.text ?? "") };
+            })
+        : [{ type: "text" as const, text: String(m.content) }];
+
+      return {
+        id: m.id,
+        role: m.role as "user" | "assistant",
+        parts,
+      };
+    });
+}

--- a/packages/types/src/conversation.ts
+++ b/packages/types/src/conversation.ts
@@ -69,6 +69,7 @@ export interface TransformedToolPart {
   readonly type: "dynamic-tool";
   readonly toolName: string;
   readonly toolCallId: string;
+  /** Legacy bridge — always equal to `toolCallId`. Some UI components read this field. */
   readonly toolInvocationId: string;
   readonly state: "output-available";
   readonly input: unknown;
@@ -84,6 +85,16 @@ export interface TransformedMessage {
   readonly parts: TransformedPart[];
 }
 
+/** Type predicate that narrows Message to user/assistant roles. */
+function isRenderable(m: Message): m is Message & { role: "user" | "assistant" } {
+  return m.role === "user" || m.role === "assistant";
+}
+
+/** Type guard for valid content part objects (filters out null, primitives, nested arrays). */
+function isContentPart(v: unknown): v is Record<string, unknown> {
+  return v != null && typeof v === "object" && !Array.isArray(v);
+}
+
 /**
  * Converts persisted `Message[]` into a UI-ready array.
  *
@@ -92,37 +103,34 @@ export interface TransformedMessage {
  * `UIMessage` from `@ai-sdk/react`.
  */
 export function transformMessages(messages: Message[]): TransformedMessage[] {
-  return messages
-    .filter((m) => m.role === "user" || m.role === "assistant")
-    .map((m) => {
-      const parts: TransformedPart[] = Array.isArray(m.content)
-        ? (m.content as Record<string, unknown>[])
-            .filter((p) => p.type === "text" || p.type === "tool-invocation")
-            .map((p, idx) => {
-              if (p.type === "tool-invocation") {
-                const toolCallId =
-                  typeof p.toolCallId === "string" && p.toolCallId
-                    ? p.toolCallId
-                    : `unknown-${idx}`;
-                return {
-                  type: "dynamic-tool" as const,
-                  toolName:
-                    typeof p.toolName === "string" ? p.toolName : "unknown",
-                  toolCallId,
-                  toolInvocationId: toolCallId,
-                  state: "output-available" as const,
-                  input: p.args,
-                  output: p.result,
-                };
-              }
-              return { type: "text" as const, text: String(p.text ?? "") };
-            })
-        : [{ type: "text" as const, text: String(m.content) }];
+  return messages.filter(isRenderable).map((m) => {
+    const parts: TransformedPart[] = Array.isArray(m.content)
+      ? (m.content as unknown[])
+          .filter(isContentPart)
+          .filter((p) => p.type === "text" || p.type === "tool-invocation")
+          .map((p, idx) => {
+            if (p.type === "tool-invocation") {
+              const toolCallId =
+                typeof p.toolCallId === "string" && p.toolCallId
+                  ? (p.toolCallId as string)
+                  : `unknown-${idx}`;
+              return {
+                type: "dynamic-tool" as const,
+                toolName:
+                  typeof p.toolName === "string" ? p.toolName : "unknown",
+                toolCallId,
+                toolInvocationId: toolCallId,
+                state: "output-available" as const,
+                input: p.args,
+                output: p.result,
+              };
+            }
+            return { type: "text" as const, text: String(p.text ?? "") };
+          })
+      : typeof m.content === "string"
+        ? [{ type: "text" as const, text: m.content }]
+        : [{ type: "text" as const, text: "" }];
 
-      return {
-        id: m.id,
-        role: m.role as "user" | "assistant",
-        parts,
-      };
-    });
+    return { id: m.id, role: m.role, parts };
+  });
 }

--- a/packages/web/src/ui/hooks/use-conversations.ts
+++ b/packages/web/src/ui/hooks/use-conversations.ts
@@ -2,8 +2,9 @@
 
 import { useState, useCallback, useMemo } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import type { Conversation, ConversationWithMessages, Message, ShareStatus, ShareMode, ShareExpiryKey, NotebookStateWire, ForkBranchWire } from "../lib/types";
+import type { Conversation, ConversationWithMessages, ShareStatus, ShareMode, ShareExpiryKey, NotebookStateWire, ForkBranchWire } from "../lib/types";
 import type { UIMessage } from "@ai-sdk/react";
+import { transformMessages } from "@useatlas/types/conversation";
 import { createAtlasFetch } from "../lib/fetch-client";
 
 export interface UseConversationsOptions {
@@ -35,39 +36,7 @@ export interface UseConversationsReturn {
   refresh: () => Promise<void>;
 }
 
-export function transformMessages(messages: Message[]): UIMessage[] {
-  return messages
-    .filter((m) => m.role === "user" || m.role === "assistant")
-    .map((m) => {
-      const parts: UIMessage["parts"] = Array.isArray(m.content)
-        ? (m.content as Record<string, unknown>[])
-            .filter((p) => p.type === "text" || p.type === "tool-invocation")
-            .map((p, idx) => {
-              if (p.type === "tool-invocation") {
-                const toolCallId = typeof p.toolCallId === "string" && p.toolCallId
-                  ? p.toolCallId
-                  : `unknown-${idx}`;
-                return {
-                  type: "dynamic-tool" as const,
-                  toolName: typeof p.toolName === "string" ? p.toolName : "unknown",
-                  toolCallId,
-                  toolInvocationId: toolCallId,
-                  state: "output-available" as const,
-                  input: p.args,
-                  output: p.result,
-                };
-              }
-              return { type: "text" as const, text: String(p.text ?? "") };
-            })
-        : [{ type: "text" as const, text: String(m.content) }];
-
-      return {
-        id: m.id,
-        role: m.role as "user" | "assistant",
-        parts,
-      };
-    });
-}
+export { transformMessages } from "@useatlas/types/conversation";
 
 interface ConversationListData {
   conversations: Conversation[];


### PR DESCRIPTION
## Summary
- Extract `transformMessages` from `packages/web` and `packages/react` into `@useatlas/types/conversation` — eliminates byte-for-byte duplication
- Define `TransformedMessage` / `TransformedPart` types that are structurally compatible with `UIMessage` from `@ai-sdk/react`, avoiding a new dependency on `@ai-sdk/react` in `@useatlas/types`
- Both consumers re-export from the shared location, so existing imports (`import { transformMessages } from "@/ui/hooks/use-conversations"`) continue to work unchanged

Closes #1393

## Test plan
- [x] New test suite in `packages/types/src/conversation.test.ts` (11 tests — same coverage as existing web tests)
- [x] Existing web test (`packages/web/src/ui/__tests__/use-conversations.test.ts`) passes unchanged
- [x] `bun run type` — structural compatibility between `TransformedMessage` and `UIMessage` verified
- [x] `bun run lint` — clean
- [x] `bun x syncpack lint` — clean
- [x] Template drift check — clean
- [x] Pre-existing test failure in `report-view.test.ts` filed as #1416 (unrelated)