### PR TITLE
feat: fork UX — What if? button, gutter indicators, branch management

### DIFF
--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -435,6 +435,12 @@ export function createApiTestMocks(
     convertToNotebook: mock(() =>
       Promise.resolve({ ok: false, reason: "not_found" }),
     ),
+    deleteBranch: mock(() =>
+      Promise.resolve({ ok: false, reason: "not_found" }),
+    ),
+    renameBranch: mock(() =>
+      Promise.resolve({ ok: false, reason: "not_found" }),
+    ),
   }));
 
   // ── Security ──────────────────────────────────────────────────

--- a/packages/api/src/api/__tests__/actions.test.ts
+++ b/packages/api/src/api/__tests__/actions.test.ts
@@ -106,6 +106,8 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  deleteBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 mock.module("@atlas/api/lib/semantic", () => ({

--- a/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
@@ -343,6 +343,8 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  deleteBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 mock.module("@atlas/api/lib/auth/server", () => ({

--- a/packages/api/src/api/__tests__/admin-integrations.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations.test.ts
@@ -267,6 +267,8 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  deleteBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 mock.module("@atlas/api/lib/auth/server", () => ({

--- a/packages/api/src/api/__tests__/admin-invitations.test.ts
+++ b/packages/api/src/api/__tests__/admin-invitations.test.ts
@@ -215,6 +215,8 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  deleteBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 // Import app after all mocks are registered

--- a/packages/api/src/api/__tests__/admin-password.test.ts
+++ b/packages/api/src/api/__tests__/admin-password.test.ts
@@ -190,6 +190,8 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  deleteBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 // Mock auth/server for the password-change dynamic import

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -422,6 +422,8 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  deleteBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 // Import app after all mocks are registered

--- a/packages/api/src/api/__tests__/chat.test.ts
+++ b/packages/api/src/api/__tests__/chat.test.ts
@@ -140,6 +140,8 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  deleteBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 const mockGetPluginTools: Mock<() => unknown> = mock(() => undefined);

--- a/packages/api/src/api/__tests__/conversations.test.ts
+++ b/packages/api/src/api/__tests__/conversations.test.ts
@@ -79,6 +79,8 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   convertToNotebook: mockConvertToNotebook,
+  deleteBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   // Type exports (no runtime value — needed so mock.module doesn't break re-exports)
 }));
 

--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -176,6 +176,8 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  deleteBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 mock.module("@atlas/api/lib/semantic", () => ({

--- a/packages/api/src/api/__tests__/health-plugin.test.ts
+++ b/packages/api/src/api/__tests__/health-plugin.test.ts
@@ -122,6 +122,8 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  deleteBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 mock.module("@atlas/api/lib/auth/middleware", () => ({

--- a/packages/api/src/api/__tests__/health.test.ts
+++ b/packages/api/src/api/__tests__/health.test.ts
@@ -127,6 +127,8 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  deleteBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 mock.module("@atlas/api/lib/auth/middleware", () => ({

--- a/packages/api/src/api/__tests__/query.test.ts
+++ b/packages/api/src/api/__tests__/query.test.ts
@@ -151,6 +151,8 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  deleteBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 // Import after mocks are registered

--- a/packages/api/src/api/__tests__/scheduled-tasks.test.ts
+++ b/packages/api/src/api/__tests__/scheduled-tasks.test.ts
@@ -111,6 +111,8 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  deleteBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 mock.module("@atlas/api/lib/semantic", () => ({

--- a/packages/api/src/api/__tests__/semantic.test.ts
+++ b/packages/api/src/api/__tests__/semantic.test.ts
@@ -252,6 +252,8 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  deleteBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 // Import app after all mocks are registered

--- a/packages/api/src/api/__tests__/slack.test.ts
+++ b/packages/api/src/api/__tests__/slack.test.ts
@@ -131,6 +131,8 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  deleteBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 const mockCheckRateLimit: Mock<(key: string) => { allowed: boolean; retryAfterMs?: number }> = mock(() =>

--- a/packages/api/src/api/routes/conversations.ts
+++ b/packages/api/src/api/routes/conversations.ts
@@ -28,6 +28,8 @@ import {
   updateNotebookState,
   forkConversation,
   convertToNotebook,
+  deleteBranch,
+  renameBranch,
   shareConversation,
   unshareConversation,
   getShareStatus,
@@ -410,6 +412,110 @@ const convertToNotebookRoute = createRoute({
     404: {
       description: "Conversation not found or not owned by user",
       content: { "application/json": { schema: ErrorSchema } },
+    },
+    500: {
+      description: "Internal server error",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Branch management route definitions
+// ---------------------------------------------------------------------------
+
+const BranchParamsSchema = z.object({
+  id: z.string().openapi({ param: { name: "id", in: "path" }, example: "550e8400-e29b-41d4-a716-446655440000" }),
+  branchId: z.string().openapi({ param: { name: "branchId", in: "path" }, example: "660e8400-e29b-41d4-a716-446655440000" }),
+});
+
+const deleteBranchRoute = createRoute({
+  method: "delete",
+  path: "/{id}/branches/{branchId}",
+  tags: ["Conversations"],
+  summary: "Delete a branch",
+  description:
+    "Deletes a branch conversation and removes it from the root conversation's notebookState.branches array.",
+  request: {
+    params: BranchParamsSchema,
+  },
+  responses: {
+    204: {
+      description: "Branch deleted successfully",
+    },
+    400: {
+      description: "Invalid conversation or branch ID format",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    401: {
+      description: "Authentication required",
+      content: { "application/json": { schema: AuthErrorSchema } },
+    },
+    403: {
+      description: "Forbidden — insufficient permissions",
+      content: { "application/json": { schema: AuthErrorSchema } },
+    },
+    404: {
+      description: "Conversation or branch not found",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    429: {
+      description: "Rate limit exceeded",
+      content: { "application/json": { schema: AuthErrorSchema } },
+    },
+    500: {
+      description: "Internal server error",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const RenameBranchBodySchema = z.object({
+  label: z.string().min(1).max(200),
+});
+
+const renameBranchRoute = createRoute({
+  method: "patch",
+  path: "/{id}/branches/{branchId}",
+  tags: ["Conversations"],
+  summary: "Rename a branch",
+  description:
+    "Updates the label of a branch in the root conversation's notebookState.branches array.",
+  request: {
+    params: BranchParamsSchema,
+    body: {
+      content: { "application/json": { schema: RenameBranchBodySchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      description: "Branch renamed successfully",
+      content: {
+        "application/json": {
+          schema: z.object({ id: z.string(), label: z.string() }),
+        },
+      },
+    },
+    400: {
+      description: "Invalid request",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    401: {
+      description: "Authentication required",
+      content: { "application/json": { schema: AuthErrorSchema } },
+    },
+    403: {
+      description: "Forbidden — insufficient permissions",
+      content: { "application/json": { schema: AuthErrorSchema } },
+    },
+    404: {
+      description: "Conversation or branch not found",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    429: {
+      description: "Rate limit exceeded",
+      content: { "application/json": { schema: AuthErrorSchema } },
     },
     500: {
       description: "Internal server error",
@@ -850,6 +956,71 @@ conversations.openapi(convertToNotebookRoute, async (c) => {
 
     return c.json({ id: result.data.id, messageCount: result.data.messageCount }, 200);
   }), { label: "convert to notebook" });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /:id/branches/:branchId — delete a branch
+// ---------------------------------------------------------------------------
+
+conversations.openapi(deleteBranchRoute, async (c) => {
+  return runEffect(c, Effect.gen(function* () {
+    if (!hasInternalDB()) {
+      return c.json({ error: "not_available", message: "Conversation history is not available (no internal database configured)." }, 404);
+    }
+
+    const { requestId } = yield* RequestContext;
+    const { user } = yield* AuthContext;
+
+    const { id, branchId } = c.req.valid("param");
+    if (!UUID_RE.test(id) || !UUID_RE.test(branchId)) {
+      return c.json({ error: "invalid_request", message: "Invalid conversation or branch ID format." }, 400);
+    }
+
+    const result = yield* Effect.promise(() => deleteBranch({
+      rootId: id,
+      branchId,
+      userId: user?.id,
+    }));
+    if (!result.ok) {
+      const fail = crudFailResponse(result.reason, requestId);
+      return c.json(fail.body, fail.status);
+    }
+    return c.body(null, 204);
+  }), { label: "delete branch" });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /:id/branches/:branchId — rename a branch
+// ---------------------------------------------------------------------------
+
+conversations.openapi(renameBranchRoute, async (c) => {
+  return runEffect(c, Effect.gen(function* () {
+    if (!hasInternalDB()) {
+      return c.json({ error: "not_available", message: "Conversation history is not available (no internal database configured)." }, 404);
+    }
+
+    const { requestId } = yield* RequestContext;
+    const { user } = yield* AuthContext;
+
+    const { id, branchId } = c.req.valid("param");
+    if (!UUID_RE.test(id) || !UUID_RE.test(branchId)) {
+      return c.json({ error: "invalid_request", message: "Invalid conversation or branch ID format." }, 400);
+    }
+
+    const parsed = c.req.valid("json");
+
+    const result = yield* Effect.promise(() => renameBranch({
+      rootId: id,
+      branchId,
+      label: parsed.label,
+      userId: user?.id,
+    }));
+    if (!result.ok) {
+      const fail = crudFailResponse(result.reason, requestId);
+      return c.json(fail.body, fail.status);
+    }
+    return c.json({ id: branchId, label: parsed.label }, 200);
+  }), { label: "rename branch" });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/api/routes/conversations.ts
+++ b/packages/api/src/api/routes/conversations.ts
@@ -471,7 +471,7 @@ const deleteBranchRoute = createRoute({
 });
 
 const RenameBranchBodySchema = z.object({
-  label: z.string().min(1).max(200),
+  label: z.string().trim().min(1).max(200),
 });
 
 const renameBranchRoute = createRoute({

--- a/packages/api/src/lib/__tests__/conversations.test.ts
+++ b/packages/api/src/lib/__tests__/conversations.test.ts
@@ -19,6 +19,8 @@ import {
   getShareStatus,
   getSharedConversation,
   cleanupExpiredShares,
+  deleteBranch,
+  renameBranch,
 } from "../conversations";
 
 // ---------------------------------------------------------------------------
@@ -1044,6 +1046,141 @@ describe("conversations module", () => {
 
       const count = await cleanupExpiredShares();
       expect(count).toBe(-1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // deleteBranch
+  // -------------------------------------------------------------------------
+
+  describe("deleteBranch()", () => {
+    it("returns no_db when DATABASE_URL is not set", async () => {
+      const result = await deleteBranch({ rootId: "r1", branchId: "b1" });
+      expect(result).toEqual({ ok: false, reason: "no_db" });
+    });
+
+    it("returns not_found when root conversation does not exist", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      const result = await deleteBranch({ rootId: "r1", branchId: "b1", userId: "u1" });
+      expect(result).toEqual({ ok: false, reason: "not_found" });
+    });
+
+    it("returns not_found when branch is not in root's branches array", async () => {
+      enableInternalDB();
+      setResults(
+        // Root conversation found, but no matching branch
+        { rows: [{ id: "r1", notebook_state: { version: 3, branches: [{ conversationId: "other", forkPointCellId: "c1", label: "Other", createdAt: "2026-01-01" }] } }] },
+      );
+
+      const result = await deleteBranch({ rootId: "r1", branchId: "b1" });
+      expect(result).toEqual({ ok: false, reason: "not_found" });
+    });
+
+    it("deletes branch conversation and updates root state", async () => {
+      enableInternalDB();
+      setResults(
+        // Root conversation with branch
+        { rows: [{ id: "r1", notebook_state: { version: 3, branches: [{ conversationId: "b1", forkPointCellId: "c1", label: "Branch 1", createdAt: "2026-01-01" }] } }] },
+        // DELETE branch conversation
+        { rows: [{ id: "b1" }] },
+        // UPDATE root notebook_state
+        { rows: [] },
+      );
+
+      const result = await deleteBranch({ rootId: "r1", branchId: "b1" });
+      expect(result).toEqual({ ok: true });
+      // Should have called DELETE on the branch conversation
+      expect(queryCalls[1].sql).toContain("DELETE FROM conversations");
+      expect(queryCalls[1].params).toEqual(["b1"]);
+      // Should have updated root's notebook_state with branches removed
+      expect(queryCalls[2].sql).toContain("UPDATE conversations SET notebook_state");
+      const updatedState = JSON.parse(queryCalls[2].params![0] as string);
+      expect(updatedState.branches).toBeUndefined();
+    });
+
+    it("removes only the target branch when multiple branches exist", async () => {
+      enableInternalDB();
+      const branches = [
+        { conversationId: "b1", forkPointCellId: "c1", label: "Branch 1", createdAt: "2026-01-01" },
+        { conversationId: "b2", forkPointCellId: "c2", label: "Branch 2", createdAt: "2026-01-02" },
+      ];
+      setResults(
+        { rows: [{ id: "r1", notebook_state: { version: 3, branches } }] },
+        { rows: [{ id: "b1" }] },
+        { rows: [] },
+      );
+
+      const result = await deleteBranch({ rootId: "r1", branchId: "b1" });
+      expect(result).toEqual({ ok: true });
+      const updatedState = JSON.parse(queryCalls[2].params![0] as string);
+      expect(updatedState.branches).toHaveLength(1);
+      expect(updatedState.branches[0].conversationId).toBe("b2");
+    });
+
+    it("returns error on DB failure", async () => {
+      enableInternalDB();
+      queryThrow = new Error("connection reset");
+
+      const result = await deleteBranch({ rootId: "r1", branchId: "b1" });
+      expect(result).toEqual({ ok: false, reason: "error" });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // renameBranch
+  // -------------------------------------------------------------------------
+
+  describe("renameBranch()", () => {
+    it("returns no_db when DATABASE_URL is not set", async () => {
+      const result = await renameBranch({ rootId: "r1", branchId: "b1", label: "New name" });
+      expect(result).toEqual({ ok: false, reason: "no_db" });
+    });
+
+    it("returns not_found when root conversation does not exist", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      const result = await renameBranch({ rootId: "r1", branchId: "b1", label: "New name", userId: "u1" });
+      expect(result).toEqual({ ok: false, reason: "not_found" });
+    });
+
+    it("returns not_found when branch is not in root's branches array", async () => {
+      enableInternalDB();
+      setResults(
+        { rows: [{ id: "r1", notebook_state: { version: 3, branches: [] } }] },
+      );
+
+      const result = await renameBranch({ rootId: "r1", branchId: "b1", label: "New" });
+      expect(result).toEqual({ ok: false, reason: "not_found" });
+    });
+
+    it("updates the branch label in root's notebook_state", async () => {
+      enableInternalDB();
+      const branches = [
+        { conversationId: "b1", forkPointCellId: "c1", label: "Old name", createdAt: "2026-01-01" },
+        { conversationId: "b2", forkPointCellId: "c2", label: "Branch 2", createdAt: "2026-01-02" },
+      ];
+      setResults(
+        { rows: [{ id: "r1", notebook_state: { version: 3, branches } }] },
+        { rows: [] },
+      );
+
+      const result = await renameBranch({ rootId: "r1", branchId: "b1", label: "New name" });
+      expect(result).toEqual({ ok: true });
+      expect(queryCalls[1].sql).toContain("UPDATE conversations SET notebook_state");
+      const updatedState = JSON.parse(queryCalls[1].params![0] as string);
+      expect(updatedState.branches[0].label).toBe("New name");
+      expect(updatedState.branches[1].label).toBe("Branch 2");
+    });
+
+    it("returns error on DB failure", async () => {
+      enableInternalDB();
+      queryThrow = new Error("timeout");
+
+      const result = await renameBranch({ rootId: "r1", branchId: "b1", label: "New" });
+      expect(result).toEqual({ ok: false, reason: "error" });
     });
   });
 });

--- a/packages/api/src/lib/conversations.ts
+++ b/packages/api/src/lib/conversations.ts
@@ -441,6 +441,106 @@ export async function forkConversation(opts: {
   }
 }
 
+/** Delete a branch conversation and remove it from the root's notebookState.branches array. */
+export async function deleteBranch(opts: {
+  rootId: string;
+  branchId: string;
+  userId?: string | null;
+}): Promise<CrudResult> {
+  if (!hasInternalDB()) return { ok: false, reason: "no_db" };
+  try {
+    // Read root conversation's notebook_state
+    const rootRows = opts.userId
+      ? await internalQuery<Record<string, unknown>>(
+          `SELECT id, notebook_state FROM conversations WHERE id = $1 AND user_id = $2`,
+          [opts.rootId, opts.userId],
+        )
+      : await internalQuery<Record<string, unknown>>(
+          `SELECT id, notebook_state FROM conversations WHERE id = $1`,
+          [opts.rootId],
+        );
+    if (rootRows.length === 0) return { ok: false, reason: "not_found" };
+
+    const state = (rootRows[0].notebook_state ?? {}) as NotebookStateWire;
+    const branches = state.branches ?? [];
+    const branchIndex = branches.findIndex((b) => b.conversationId === opts.branchId);
+    if (branchIndex === -1) return { ok: false, reason: "not_found" };
+
+    // Remove from branches array
+    const updatedBranches = branches.filter((b) => b.conversationId !== opts.branchId);
+    const updatedState: NotebookStateWire = {
+      ...state,
+      branches: updatedBranches.length > 0 ? updatedBranches : undefined,
+    };
+
+    // Delete the branch conversation (CASCADE deletes messages)
+    const delRows = await internalQuery<{ id: string }>(
+      `DELETE FROM conversations WHERE id = $1 RETURNING id`,
+      [opts.branchId],
+    );
+    if (delRows.length === 0) {
+      log.warn({ rootId: opts.rootId, branchId: opts.branchId }, "Branch conversation not found during delete — removing from root state anyway");
+    }
+
+    // Update root's notebook_state
+    await internalQuery(
+      `UPDATE conversations SET notebook_state = $1, updated_at = NOW()
+       WHERE id = $2`,
+      [JSON.stringify(updatedState), opts.rootId],
+    );
+
+    return { ok: true };
+  } catch (err) {
+    log.error({ err: err instanceof Error ? err.message : String(err), rootId: opts.rootId, branchId: opts.branchId }, "deleteBranch failed");
+    return { ok: false, reason: "error" };
+  }
+}
+
+/** Rename a branch by updating its label in the root's notebookState.branches array. */
+export async function renameBranch(opts: {
+  rootId: string;
+  branchId: string;
+  label: string;
+  userId?: string | null;
+}): Promise<CrudResult> {
+  if (!hasInternalDB()) return { ok: false, reason: "no_db" };
+  try {
+    // Read root conversation's notebook_state
+    const rootRows = opts.userId
+      ? await internalQuery<Record<string, unknown>>(
+          `SELECT id, notebook_state FROM conversations WHERE id = $1 AND user_id = $2`,
+          [opts.rootId, opts.userId],
+        )
+      : await internalQuery<Record<string, unknown>>(
+          `SELECT id, notebook_state FROM conversations WHERE id = $1`,
+          [opts.rootId],
+        );
+    if (rootRows.length === 0) return { ok: false, reason: "not_found" };
+
+    const state = (rootRows[0].notebook_state ?? {}) as NotebookStateWire;
+    const branches = state.branches ?? [];
+    const branchIndex = branches.findIndex((b) => b.conversationId === opts.branchId);
+    if (branchIndex === -1) return { ok: false, reason: "not_found" };
+
+    // Update the label
+    const updatedBranches = branches.map((b) =>
+      b.conversationId === opts.branchId ? { ...b, label: opts.label } : b,
+    );
+    const updatedState: NotebookStateWire = { ...state, branches: updatedBranches };
+
+    await internalQuery(
+      `UPDATE conversations SET notebook_state = $1, updated_at = NOW()
+       WHERE id = $2`,
+      [JSON.stringify(updatedState), opts.rootId],
+    );
+
+    return { ok: true };
+  } catch (err) {
+    log.error({ err: err instanceof Error ? err.message : String(err), rootId: opts.rootId, branchId: opts.branchId }, "renameBranch failed");
+    return { ok: false, reason: "error" };
+  }
+}
+
 /** Convert a chat conversation into a notebook by copying all messages to a new conversation with surface "notebook". */
 export async function convertToNotebook(opts: {
   sourceId: string;

--- a/packages/api/src/lib/conversations.ts
+++ b/packages/api/src/lib/conversations.ts
@@ -474,10 +474,15 @@ export async function deleteBranch(opts: {
     };
 
     // Delete the branch conversation (CASCADE deletes messages)
-    const delRows = await internalQuery<{ id: string }>(
-      `DELETE FROM conversations WHERE id = $1 RETURNING id`,
-      [opts.branchId],
-    );
+    const delRows = opts.userId
+      ? await internalQuery<{ id: string }>(
+          `DELETE FROM conversations WHERE id = $1 AND user_id = $2 RETURNING id`,
+          [opts.branchId, opts.userId],
+        )
+      : await internalQuery<{ id: string }>(
+          `DELETE FROM conversations WHERE id = $1 RETURNING id`,
+          [opts.branchId],
+        );
     if (delRows.length === 0) {
       log.warn({ rootId: opts.rootId, branchId: opts.branchId }, "Branch conversation not found during delete — removing from root state anyway");
     }

--- a/packages/api/src/lib/tools/__tests__/action-permissions.test.ts
+++ b/packages/api/src/lib/tools/__tests__/action-permissions.test.ts
@@ -134,6 +134,8 @@ mock.module("@atlas/api/lib/conversations", () => ({
   updateNotebookState: mock(() => Promise.resolve({ ok: true })),
   forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  deleteBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
 }));
 
 mock.module("@atlas/api/lib/semantic", () => ({

--- a/packages/web/src/app/notebook/page.tsx
+++ b/packages/web/src/app/notebook/page.tsx
@@ -226,6 +226,8 @@ function NotebookContent() {
     forkConversation: convos.forkConversation,
     onNavigateToBranch: handleNavigateToBranch,
     forkInfo,
+    deleteBranch: convos.deleteBranch,
+    renameBranch: convos.renameBranch,
   });
 
   // Share as Report — creates a share link and returns the token

--- a/packages/web/src/app/notebook/page.tsx
+++ b/packages/web/src/app/notebook/page.tsx
@@ -228,6 +228,7 @@ function NotebookContent() {
     forkInfo,
     deleteBranch: convos.deleteBranch,
     renameBranch: convos.renameBranch,
+    onForkInfoChanged: setForkInfo,
   });
 
   // Share as Report — creates a share link and returns the token

--- a/packages/web/src/ui/components/notebook/fork-branch-selector.tsx
+++ b/packages/web/src/ui/components/notebook/fork-branch-selector.tsx
@@ -1,21 +1,48 @@
 "use client";
 
-import { GitBranch, ChevronDown } from "lucide-react";
+import { useState, useRef, useEffect } from "react";
+import { GitBranch, ChevronDown, Pencil, Trash2, Check, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import type { ForkInfo } from "./types";
+
+/** Extract the cell number from a forkPointCellId like "msg-uuid" → look up by index. */
+function formatForkPoint(forkPointCellId: string): string {
+  // forkPointCellId is a message ID — we can't resolve it to a cell number
+  // without the full cell list, so we show a truncated ID
+  return forkPointCellId.slice(0, 8);
+}
 
 interface ForkBranchSelectorProps {
   forkInfo: ForkInfo;
   onSwitchBranch: (conversationId: string) => void;
+  onDeleteBranch?: (branchId: string) => Promise<void>;
+  onRenameBranch?: (branchId: string, label: string) => Promise<void>;
 }
 
-export function ForkBranchSelector({ forkInfo, onSwitchBranch }: ForkBranchSelectorProps) {
+export function ForkBranchSelector({
+  forkInfo,
+  onSwitchBranch,
+  onDeleteBranch,
+  onRenameBranch,
+}: ForkBranchSelectorProps) {
   const isRoot = forkInfo.currentId === forkInfo.rootId;
   const totalBranches = forkInfo.branches.length + 1; // +1 for the root
   const branchIdx = forkInfo.branches.findIndex((b) => b.conversationId === forkInfo.currentId);
@@ -25,44 +52,185 @@ export function ForkBranchSelector({ forkInfo, onSwitchBranch }: ForkBranchSelec
       ? (forkInfo.branches[branchIdx].label || `Branch ${branchIdx + 1}`)
       : "Branch";
 
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState("");
+  const [deleteTarget, setDeleteTarget] = useState<{ id: string; label: string } | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editingId && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editingId]);
+
+  function startRename(branchId: string, currentLabel: string) {
+    setEditingId(branchId);
+    setEditValue(currentLabel);
+  }
+
+  async function commitRename() {
+    if (!editingId || !editValue.trim() || !onRenameBranch) return;
+    await onRenameBranch(editingId, editValue.trim());
+    setEditingId(null);
+  }
+
+  function cancelRename() {
+    setEditingId(null);
+    setEditValue("");
+  }
+
   return (
-    <div className="flex items-center gap-2 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm dark:border-zinc-800 dark:bg-zinc-900">
-      <GitBranch className="size-4 text-zinc-500" />
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-auto gap-1 px-2 py-1 text-sm font-medium"
-          >
-            {currentLabel}
-            <span className="text-zinc-400">({totalBranches} total)</span>
-            <ChevronDown className="size-3.5" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start">
-          <DropdownMenuItem
-            onClick={() => onSwitchBranch(forkInfo.rootId)}
-            className={isRoot ? "bg-zinc-100 dark:bg-zinc-800" : ""}
-          >
-            <GitBranch className="mr-2 size-3.5" />
-            Main (root)
-          </DropdownMenuItem>
-          {forkInfo.branches.map((branch, i) => {
-            const isCurrent = branch.conversationId === forkInfo.currentId;
-            return (
-              <DropdownMenuItem
-                key={branch.conversationId}
-                onClick={() => onSwitchBranch(branch.conversationId)}
-                className={isCurrent ? "bg-zinc-100 dark:bg-zinc-800" : ""}
-              >
-                <GitBranch className="mr-2 size-3.5" />
-                {branch.label || `Branch ${i + 1}`}
-              </DropdownMenuItem>
-            );
-          })}
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
+    <>
+      <div className="flex items-center gap-2 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm dark:border-zinc-800 dark:bg-zinc-900">
+        <GitBranch className="size-4 text-zinc-500" />
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-auto gap-1 px-2 py-1 text-sm font-medium"
+            >
+              {currentLabel}
+              <span className="text-zinc-400">({totalBranches} total)</span>
+              <ChevronDown className="size-3.5" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="min-w-[240px]">
+            <DropdownMenuItem
+              onClick={() => onSwitchBranch(forkInfo.rootId)}
+              className={isRoot ? "bg-zinc-100 dark:bg-zinc-800" : ""}
+            >
+              <GitBranch className="mr-2 size-3.5" />
+              <span className="flex-1">Main (root)</span>
+              {isRoot && (
+                <span className="ml-2 rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
+                  current
+                </span>
+              )}
+            </DropdownMenuItem>
+            {forkInfo.branches.length > 0 && <DropdownMenuSeparator />}
+            {forkInfo.branches.map((branch, i) => {
+              const isCurrent = branch.conversationId === forkInfo.currentId;
+              const label = branch.label || `Branch ${i + 1}`;
+              const isEditing = editingId === branch.conversationId;
+
+              if (isEditing) {
+                return (
+                  <div
+                    key={branch.conversationId}
+                    className="flex items-center gap-1 px-2 py-1.5"
+                    onClick={(e) => e.stopPropagation()}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") commitRename();
+                      if (e.key === "Escape") cancelRename();
+                    }}
+                  >
+                    <Input
+                      ref={inputRef}
+                      value={editValue}
+                      onChange={(e) => setEditValue(e.target.value)}
+                      className="h-7 flex-1 text-xs"
+                    />
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="size-6"
+                      onClick={commitRename}
+                      aria-label="Save"
+                    >
+                      <Check className="size-3" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="size-6"
+                      onClick={cancelRename}
+                      aria-label="Cancel"
+                    >
+                      <X className="size-3" />
+                    </Button>
+                  </div>
+                );
+              }
+
+              return (
+                <DropdownMenuItem
+                  key={branch.conversationId}
+                  onClick={() => onSwitchBranch(branch.conversationId)}
+                  className={isCurrent ? "bg-zinc-100 dark:bg-zinc-800" : ""}
+                >
+                  <GitBranch className="mr-2 size-3.5 shrink-0" />
+                  <div className="flex min-w-0 flex-1 flex-col">
+                    <span className="truncate">{label}</span>
+                    <span className="text-[10px] text-zinc-400">
+                      from {formatForkPoint(branch.forkPointCellId)}
+                    </span>
+                  </div>
+                  {isCurrent && (
+                    <span className="ml-2 shrink-0 rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
+                      current
+                    </span>
+                  )}
+                  {onRenameBranch && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="ml-1 size-6 shrink-0 opacity-0 group-hover:opacity-100"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        startRename(branch.conversationId, label);
+                      }}
+                      aria-label="Rename branch"
+                    >
+                      <Pencil className="size-3" />
+                    </Button>
+                  )}
+                  {onDeleteBranch && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="size-6 shrink-0 text-red-500 opacity-0 hover:text-red-600 group-hover:opacity-100"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setDeleteTarget({ id: branch.conversationId, label });
+                      }}
+                      aria-label="Delete branch"
+                    >
+                      <Trash2 className="size-3" />
+                    </Button>
+                  )}
+                </DropdownMenuItem>
+              );
+            })}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <AlertDialog open={deleteTarget !== null} onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete branch &quot;{deleteTarget?.label}&quot;?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete this branch and all its messages. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-red-600 text-white hover:bg-red-700"
+              onClick={async () => {
+                if (deleteTarget && onDeleteBranch) {
+                  await onDeleteBranch(deleteTarget.id);
+                }
+                setDeleteTarget(null);
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/packages/web/src/ui/components/notebook/fork-branch-selector.tsx
+++ b/packages/web/src/ui/components/notebook/fork-branch-selector.tsx
@@ -23,10 +23,8 @@ import {
 } from "@/components/ui/alert-dialog";
 import type { ForkInfo } from "./types";
 
-/** Extract the cell number from a forkPointCellId like "msg-uuid" → look up by index. */
+/** Truncate a forkPointCellId (message UUID) for compact display in the branch selector. */
 function formatForkPoint(forkPointCellId: string): string {
-  // forkPointCellId is a message ID — we can't resolve it to a cell number
-  // without the full cell list, so we show a truncated ID
   return forkPointCellId.slice(0, 8);
 }
 
@@ -71,8 +69,12 @@ export function ForkBranchSelector({
 
   async function commitRename() {
     if (!editingId || !editValue.trim() || !onRenameBranch) return;
-    await onRenameBranch(editingId, editValue.trim());
-    setEditingId(null);
+    try {
+      await onRenameBranch(editingId, editValue.trim());
+      setEditingId(null);
+    } catch {
+      // Keep editing state open — the parent hook shows a warning toast
+    }
   }
 
   function cancelRename() {

--- a/packages/web/src/ui/components/notebook/fork-gutter-indicator.tsx
+++ b/packages/web/src/ui/components/notebook/fork-gutter-indicator.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { GitBranch } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { ForkBranchWire } from "@/ui/lib/types";
+
+interface ForkGutterIndicatorProps {
+  /** Branches that fork from this cell's message ID. */
+  branches: ForkBranchWire[];
+}
+
+export function ForkGutterIndicator({ branches }: ForkGutterIndicatorProps) {
+  if (branches.length === 0) return null;
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className="absolute -left-5 top-3 flex items-center"
+            aria-label={`${branches.length} branch${branches.length === 1 ? "" : "es"} from this cell`}
+          >
+            <div className="flex size-4 items-center justify-center rounded-full border border-zinc-300 bg-white dark:border-zinc-600 dark:bg-zinc-900">
+              <GitBranch className="size-2.5 text-zinc-500 dark:text-zinc-400" />
+            </div>
+            <div className="h-px w-2 bg-zinc-300 dark:bg-zinc-600" />
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="left">
+          <p className="text-xs">
+            {branches.length} branch{branches.length === 1 ? "" : "es"} from this cell
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/packages/web/src/ui/components/notebook/notebook-cell-toolbar.tsx
+++ b/packages/web/src/ui/components/notebook/notebook-cell-toolbar.tsx
@@ -1,13 +1,20 @@
 "use client";
 
-import { Pencil, Play, Copy, GitFork, Trash2, Loader2 } from "lucide-react";
+import { Pencil, Play, Copy, GitBranch, Trash2, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import type { CellStatus } from "./types";
 
 interface CellToolbarProps {
   status: CellStatus;
   editing: boolean;
   disabled: boolean;
+  hasOutput: boolean;
   onEdit: () => void;
   onRun: () => void;
   onCopy: () => void;
@@ -19,6 +26,7 @@ export function NotebookCellToolbar({
   status,
   editing,
   disabled,
+  hasOutput,
   onEdit,
   onRun,
   onCopy,
@@ -66,16 +74,28 @@ export function NotebookCellToolbar({
       >
         <Copy className="size-3.5" />
       </Button>
-      <Button
-        variant="ghost"
-        size="icon"
-        className="size-7"
-        onClick={onFork}
-        disabled={isRunning || disabled}
-        aria-label="Fork from this cell"
-      >
-        <GitFork className="size-3.5" />
-      </Button>
+      {hasOutput && (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 gap-1 px-2 text-xs font-normal text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
+                onClick={onFork}
+                disabled={isRunning || disabled}
+                aria-label="Create a branch from this cell to explore an alternative"
+              >
+                <GitBranch className="size-3.5" />
+                What if?
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              <p>Branch from this cell to explore a different direction</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      )}
       <Button
         variant="ghost"
         size="icon"

--- a/packages/web/src/ui/components/notebook/notebook-cell.tsx
+++ b/packages/web/src/ui/components/notebook/notebook-cell.tsx
@@ -10,12 +10,16 @@ import { NotebookCellToolbar } from "./notebook-cell-toolbar";
 import { NotebookCellInput } from "./notebook-cell-input";
 import { NotebookCellOutput } from "./notebook-cell-output";
 import { DeleteCellDialog } from "./delete-cell-dialog";
+import { ForkGutterIndicator } from "./fork-gutter-indicator";
 import { extractTextContent } from "./use-notebook";
 import { DashboardBridgeProvider, type DashboardCardEntry } from "./dashboard-bridge-context";
+import type { ForkBranchWire } from "@/ui/lib/types";
 
 interface NotebookCellProps {
   cell: ResolvedCell;
   anyRunning: boolean;
+  /** Branches that originate from this cell's message. */
+  cellBranches: ForkBranchWire[];
   onRerun: (cellId: string, newQuestion: string) => void;
   onDelete: (cellId: string) => void;
   onToggleEdit: (cellId: string) => void;
@@ -28,7 +32,7 @@ interface NotebookCellProps {
 
 export const NotebookCell = forwardRef<HTMLElement, NotebookCellProps>(
   function NotebookCell(
-    { cell, anyRunning, onRerun, onDelete, onToggleEdit, onToggleCollapse, onCopy, onFork, dashboardCards, onDashboardCardAdded },
+    { cell, anyRunning, cellBranches, onRerun, onDelete, onToggleEdit, onToggleCollapse, onCopy, onFork, dashboardCards, onDashboardCardAdded },
     ref,
   ) {
     const [showDeleteDialog, setShowDeleteDialog] = useState(false);
@@ -49,10 +53,11 @@ export const NotebookCell = forwardRef<HTMLElement, NotebookCellProps>(
           aria-label={`Cell ${cell.number}`}
           tabIndex={0}
           className={cn(
-            "group rounded-lg border border-zinc-200 bg-white transition-shadow focus:outline-none focus:ring-2 focus:ring-ring dark:border-zinc-800 dark:bg-zinc-950",
+            "group relative rounded-lg border border-zinc-200 bg-white transition-shadow focus:outline-none focus:ring-2 focus:ring-ring dark:border-zinc-800 dark:bg-zinc-950",
             isRunning && "ring-2 ring-primary/50",
           )}
         >
+          <ForkGutterIndicator branches={cellBranches} />
           <div className="flex items-start gap-3 border-b border-zinc-100 px-4 py-3 dark:border-zinc-800/50">
             <SortableItemHandle asChild>
               <button
@@ -94,6 +99,7 @@ export const NotebookCell = forwardRef<HTMLElement, NotebookCellProps>(
                 status={cell.status}
                 editing={cell.editing}
                 disabled={anyRunning && !isRunning}
+                hasOutput={cell.assistantMessage !== null}
                 onEdit={() => onToggleEdit(cell.id)}
                 onRun={() => onRerun(cell.id, question)}
                 onCopy={() => onCopy(cell.id)}

--- a/packages/web/src/ui/components/notebook/notebook-shell.tsx
+++ b/packages/web/src/ui/components/notebook/notebook-shell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useEffect, useState } from "react";
+import { useRef, useEffect, useState, useMemo } from "react";
 import { Plus, Download, FileText, Check } from "lucide-react";
 import type { UseNotebookReturn } from "./use-notebook";
 import { useKeyboardNav } from "./use-keyboard-nav";
@@ -11,6 +11,7 @@ import { NotebookInputBar } from "./notebook-input-bar";
 import { DeleteCellDialog } from "./delete-cell-dialog";
 import { ForkBranchSelector } from "./fork-branch-selector";
 import { exportToMarkdown, exportToHTML, downloadFile } from "./notebook-export";
+import type { ForkBranchWire } from "@/ui/lib/types";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { Button } from "@/components/ui/button";
 import {
@@ -40,6 +41,22 @@ export function NotebookShell({ notebook, focusCellId, onShareAsReport }: Notebo
   const [pendingDeleteIndex, setPendingDeleteIndex] = useState<number | null>(null);
   const [dismissedError, setDismissedError] = useState<Error | null>(null);
   const [shareState, setShareState] = useState<"idle" | "sharing" | "copied" | "error">("idle");
+
+  // Build a map from forkPointCellId (message ID) → branches for gutter indicators.
+  // Correctness: useMemo is needed here for a stable reference identity across renders.
+  const branchesByMessageId = useMemo(() => {
+    const map = new Map<string, ForkBranchWire[]>();
+    if (!notebook.forkInfo?.branches) return map;
+    for (const branch of notebook.forkInfo.branches) {
+      const existing = map.get(branch.forkPointCellId);
+      if (existing) {
+        existing.push(branch);
+      } else {
+        map.set(branch.forkPointCellId, [branch]);
+      }
+    }
+    return map;
+  }, [notebook.forkInfo?.branches]);
 
   const { setRef, focusCell } = useKeyboardNav({
     cellCount: notebook.cells.length,
@@ -108,6 +125,8 @@ export function NotebookShell({ notebook, focusCellId, onShareAsReport }: Notebo
             <ForkBranchSelector
               forkInfo={notebook.forkInfo}
               onSwitchBranch={notebook.switchBranch}
+              onDeleteBranch={notebook.deleteBranch}
+              onRenameBranch={notebook.renameBranch}
             />
           )}
 
@@ -269,6 +288,7 @@ export function NotebookShell({ notebook, focusCellId, onShareAsReport }: Notebo
                           ref={setRef(i)}
                           cell={cell}
                           anyRunning={anyRunning}
+                          cellBranches={branchesByMessageId.get(cell.messageId) ?? []}
                           onRerun={notebook.rerunCell}
                           onDelete={notebook.deleteCell}
                           onToggleEdit={notebook.toggleEdit}

--- a/packages/web/src/ui/components/notebook/use-notebook.ts
+++ b/packages/web/src/ui/components/notebook/use-notebook.ts
@@ -207,6 +207,8 @@ export interface UseNotebookOptions {
   deleteBranch?: (rootId: string, branchId: string) => Promise<void>;
   /** Rename a branch label. */
   renameBranch?: (rootId: string, branchId: string, label: string) => Promise<void>;
+  /** Called after a branch mutation (delete/rename) so the parent can refresh fork info. */
+  onForkInfoChanged?: (updatedForkInfo: ForkInfo) => void;
 }
 
 export type { DashboardCardEntry } from "./dashboard-bridge-context";
@@ -249,6 +251,7 @@ export function useNotebook({
   forkInfo: forkInfoProp,
   deleteBranch: deleteBranchFn,
   renameBranch: renameBranchFn,
+  onForkInfoChanged,
 }: UseNotebookOptions): UseNotebookReturn {
   const [input, setInput] = useState("");
   const [warning, setWarning] = useState<string | null>(null);
@@ -732,6 +735,12 @@ export function useNotebook({
         // If we're viewing the deleted branch, navigate to root
         if (forkInfoProp.currentId === branchId) {
           onNavigateToBranch?.(forkInfoProp.rootId);
+        } else {
+          // Update forkInfo optimistically so the UI reflects the removal
+          onForkInfoChanged?.({
+            ...forkInfoProp,
+            branches: forkInfoProp.branches.filter((b) => b.conversationId !== branchId),
+          });
         }
       } catch (err: unknown) {
         console.warn(
@@ -741,7 +750,7 @@ export function useNotebook({
         showWarning("Failed to delete branch. Please try again.");
       }
     },
-    [deleteBranchFn, forkInfoProp, onNavigateToBranch],
+    [deleteBranchFn, forkInfoProp, onNavigateToBranch, onForkInfoChanged],
   );
 
   const renameBranch = useCallback(
@@ -752,15 +761,23 @@ export function useNotebook({
       }
       try {
         await renameBranchFn(forkInfoProp.rootId, branchId, label);
+        // Update forkInfo optimistically so the UI reflects the new label
+        onForkInfoChanged?.({
+          ...forkInfoProp,
+          branches: forkInfoProp.branches.map((b) =>
+            b.conversationId === branchId ? { ...b, label } : b,
+          ),
+        });
       } catch (err: unknown) {
         console.warn(
           "Failed to rename branch:",
           err instanceof Error ? err.message : String(err),
         );
         showWarning("Failed to rename branch. Please try again.");
+        throw err; // Re-throw so callers (e.g. inline edit UI) can keep their state
       }
     },
-    [renameBranchFn, forkInfoProp],
+    [renameBranchFn, forkInfoProp, onForkInfoChanged],
   );
 
   /** Insert a new text cell. If afterCellId is provided, inserts after that cell; otherwise appends to the end. */

--- a/packages/web/src/ui/components/notebook/use-notebook.ts
+++ b/packages/web/src/ui/components/notebook/use-notebook.ts
@@ -203,6 +203,10 @@ export interface UseNotebookOptions {
   onNavigateToBranch?: (conversationId: string) => void;
   /** Fork info from server state (branches, root, etc.). */
   forkInfo?: ForkInfo | null;
+  /** Delete a branch conversation. */
+  deleteBranch?: (rootId: string, branchId: string) => Promise<void>;
+  /** Rename a branch label. */
+  renameBranch?: (rootId: string, branchId: string, label: string) => Promise<void>;
 }
 
 export type { DashboardCardEntry } from "./dashboard-bridge-context";
@@ -222,6 +226,8 @@ export interface UseNotebookReturn {
   reorderCells: (orderedIds: string[]) => void;
   forkCell: (cellId: string) => Promise<void>;
   switchBranch: (conversationId: string) => void;
+  deleteBranch: (branchId: string) => Promise<void>;
+  renameBranch: (branchId: string, label: string) => Promise<void>;
   forkInfo: ForkInfo | null;
   input: string;
   setInput: (value: string) => void;
@@ -241,6 +247,8 @@ export function useNotebook({
   forkConversation: forkConversationFn,
   onNavigateToBranch,
   forkInfo: forkInfoProp,
+  deleteBranch: deleteBranchFn,
+  renameBranch: renameBranchFn,
 }: UseNotebookOptions): UseNotebookReturn {
   const [input, setInput] = useState("");
   const [warning, setWarning] = useState<string | null>(null);
@@ -713,6 +721,48 @@ export function useNotebook({
     [onNavigateToBranch],
   );
 
+  const deleteBranch = useCallback(
+    async (branchId: string) => {
+      if (!deleteBranchFn || !forkInfoProp) {
+        showWarning("Branch deletion is not available.");
+        return;
+      }
+      try {
+        await deleteBranchFn(forkInfoProp.rootId, branchId);
+        // If we're viewing the deleted branch, navigate to root
+        if (forkInfoProp.currentId === branchId) {
+          onNavigateToBranch?.(forkInfoProp.rootId);
+        }
+      } catch (err: unknown) {
+        console.warn(
+          "Failed to delete branch:",
+          err instanceof Error ? err.message : String(err),
+        );
+        showWarning("Failed to delete branch. Please try again.");
+      }
+    },
+    [deleteBranchFn, forkInfoProp, onNavigateToBranch],
+  );
+
+  const renameBranch = useCallback(
+    async (branchId: string, label: string) => {
+      if (!renameBranchFn || !forkInfoProp) {
+        showWarning("Branch renaming is not available.");
+        return;
+      }
+      try {
+        await renameBranchFn(forkInfoProp.rootId, branchId, label);
+      } catch (err: unknown) {
+        console.warn(
+          "Failed to rename branch:",
+          err instanceof Error ? err.message : String(err),
+        );
+        showWarning("Failed to rename branch. Please try again.");
+      }
+    },
+    [renameBranchFn, forkInfoProp],
+  );
+
   /** Insert a new text cell. If afterCellId is provided, inserts after that cell; otherwise appends to the end. */
   const insertTextCell = useCallback(
     (afterCellId?: string) => {
@@ -773,6 +823,8 @@ export function useNotebook({
     reorderCells,
     forkCell,
     switchBranch,
+    deleteBranch,
+    renameBranch,
     forkInfo: forkInfoProp ?? null,
     input,
     setInput,

--- a/packages/web/src/ui/hooks/use-conversations.ts
+++ b/packages/web/src/ui/hooks/use-conversations.ts
@@ -27,6 +27,8 @@ export interface UseConversationsReturn {
   saveNotebookState: (id: string, state: NotebookStateWire) => Promise<void>;
   forkConversation: (sourceId: string, forkPointMessageId: string, label?: string) => Promise<{ id: string; branches: ForkBranchWire[]; warning?: string }>;
   convertToNotebook: (sourceId: string) => Promise<{ id: string; messageCount: number }>;
+  deleteBranch: (rootId: string, branchId: string) => Promise<void>;
+  renameBranch: (rootId: string, branchId: string, label: string) => Promise<void>;
   deleteConversation: (id: string) => Promise<void>;
   starConversation: (id: string, starred: boolean) => Promise<void>;
   shareConversation: (id: string, opts?: { expiresIn?: ShareExpiryKey; shareMode?: ShareMode }) => Promise<{ token: string; url: string }>;
@@ -231,6 +233,21 @@ export function useConversations(opts: UseConversationsOptions): UseConversation
     };
   }, [api]);
 
+  const deleteBranch = useCallback(async (
+    rootId: string,
+    branchId: string,
+  ): Promise<void> => {
+    await api.del(`/api/v1/conversations/${rootId}/branches/${branchId}`);
+  }, [api]);
+
+  const renameBranch = useCallback(async (
+    rootId: string,
+    branchId: string,
+    label: string,
+  ): Promise<void> => {
+    await api.patch(`/api/v1/conversations/${rootId}/branches/${branchId}`, { label });
+  }, [api]);
+
   const convertToNotebook = useCallback(async (
     sourceId: string,
   ): Promise<{ id: string; messageCount: number }> => {
@@ -262,6 +279,8 @@ export function useConversations(opts: UseConversationsOptions): UseConversation
     saveNotebookState,
     forkConversation,
     convertToNotebook,
+    deleteBranch,
+    renameBranch,
     deleteConversation,
     starConversation,
     shareConversation,


### PR DESCRIPTION
## Summary
- **"What if?" button** — replaces the hidden fork icon with a visible ghost button on cells that have output, with tooltip explaining the feature
- **Gutter indicators** — subtle dot+line at fork points in the cell margin; shows branch count on hover
- **Branch selector polish** — shows fork-point context, highlights active branch with badge, supports inline rename and delete with confirmation dialog
- **Branch delete API** — `DELETE /api/v1/conversations/{id}/branches/{branchId}` cascades to delete the branch conversation and removes it from root's `notebookState.branches`
- **Branch rename API** — `PATCH /api/v1/conversations/{id}/branches/{branchId}` updates the branch label in root's `notebookState.branches`
- **10 unit tests** for `deleteBranch` and `renameBranch` data-layer functions
- Updated all 17 `mock.module()` test files with new conversation exports

Closes #1401

## Test plan
- [x] `bun run lint` — clean
- [x] `bun run type` — clean  
- [x] `bun run test` — all pass (2 pre-existing failures in report-view.test.ts, filed as #1418)
- [x] `bun x syncpack lint` — no issues
- [x] Template drift check — 387 files verified
- [ ] Manual: open notebook, verify "What if?" button appears on cells with output
- [ ] Manual: fork a cell, verify gutter indicator appears at fork point
- [ ] Manual: rename a branch via inline edit in branch selector
- [ ] Manual: delete a branch via branch selector, confirm dialog appears
- [ ] Manual: verify branch selector shows "current" badge on active branch