### PR TITLE
fix: Docker COPY for cybersec/ecommerce semantic seed dirs

### DIFF
--- a/deploy/api/Dockerfile
+++ b/deploy/api/Dockerfile
@@ -55,8 +55,8 @@ WORKDIR /app
 COPY --from=deps /app ./
 COPY . .
 COPY packages/cli/data/demo-semantic semantic
-COPY packages/cli/data/cybersec-semantic data/cybersec-semantic
-COPY packages/cli/data/ecommerce-semantic data/ecommerce-semantic
+COPY packages/cli/data/seeds/cybersec/semantic data/cybersec-semantic
+COPY packages/cli/data/seeds/ecommerce/semantic data/ecommerce-semantic
 # Build @useatlas/types first (exports point to dist/) then the react widget bundle
 RUN cd packages/types && bun run build
 RUN cd packages/react && bun run build

--- a/deploy/api/Dockerfile
+++ b/deploy/api/Dockerfile
@@ -54,7 +54,7 @@ FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app ./
 COPY . .
-COPY packages/cli/data/demo-semantic semantic
+COPY packages/cli/data/seeds/simple/semantic semantic
 COPY packages/cli/data/seeds/cybersec/semantic data/cybersec-semantic
 COPY packages/cli/data/seeds/ecommerce/semantic data/ecommerce-semantic
 # Build @useatlas/types first (exports point to dist/) then the react widget bundle
@@ -104,9 +104,9 @@ COPY --from=builder --chown=atlas:atlas /app/ee ./ee
 # Plugins (loaded at runtime by the plugin system)
 COPY --from=builder --chown=atlas:atlas /app/plugins ./plugins
 # Demo seeding (ATLAS_SEED_DEMO=true) — all three datasets coexist in the same DB
-COPY --from=builder --chown=atlas:atlas /app/packages/cli/data/demo.sql ./data/demo.sql
-COPY --from=builder --chown=atlas:atlas /app/packages/cli/data/cybersec.sql ./data/cybersec.sql
-COPY --from=builder --chown=atlas:atlas /app/packages/cli/data/ecommerce.sql ./data/ecommerce.sql
+COPY --from=builder --chown=atlas:atlas /app/packages/cli/data/seeds/simple/seed.sql ./data/demo.sql
+COPY --from=builder --chown=atlas:atlas /app/packages/cli/data/seeds/cybersec/seed.sql ./data/cybersec.sql
+COPY --from=builder --chown=atlas:atlas /app/packages/cli/data/seeds/ecommerce/seed.sql ./data/ecommerce.sql
 COPY --chown=atlas:atlas examples/docker/scripts/seed-demo.ts ./scripts/seed-demo.ts
 COPY --chown=atlas:atlas deploy/api/atlas.config.ts ./atlas.config.ts
 COPY --chown=atlas:atlas deploy/api/scripts/start.sh ./scripts/start.sh

--- a/deploy/sidecar/railway.json
+++ b/deploy/sidecar/railway.json
@@ -6,7 +6,7 @@
     "dockerfileContext": "../..",
     "watchPatterns": [
       "packages/sandbox-sidecar/**",
-      "packages/cli/data/demo-semantic/**"
+      "packages/cli/data/seeds/simple/semantic/**"
     ]
   },
   "deploy": {

--- a/packages/sandbox-sidecar/Dockerfile
+++ b/packages/sandbox-sidecar/Dockerfile
@@ -35,7 +35,7 @@ COPY packages/sandbox-sidecar/src/ ./src/
 
 # Semantic layer — baked in from demo data (matches other Railway services).
 # For custom datasets, rebuild with a volume mount or replace semantic/ in CI.
-COPY packages/cli/data/demo-semantic/ /semantic/
+COPY packages/cli/data/seeds/simple/semantic/ /semantic/
 RUN chmod -R a-w /semantic/
 
 # No secrets, no database drivers, no node_modules beyond bun runtime


### PR DESCRIPTION
## Summary
- Replace **all** symlink-based paths in Docker builds with canonical seed paths under `packages/cli/data/seeds/`
- Symlinks don't resolve during Docker `COPY`, causing missing semantic dirs and seed SQL in final images

### Changes
| File | What changed |
|------|-------------|
| `deploy/api/Dockerfile` | Lines 57-59: semantic dir COPYs → `seeds/{simple,cybersec,ecommerce}/semantic` |
| `deploy/api/Dockerfile` | Lines 107-109: SQL seed COPYs → `seeds/{simple,cybersec,ecommerce}/seed.sql` |
| `packages/sandbox-sidecar/Dockerfile` | Line 38: `demo-semantic` → `seeds/simple/semantic` |
| `deploy/sidecar/railway.json` | watchPattern: `demo-semantic` → `seeds/simple/semantic` |

## Related
- Fixes #1422
- Closes #1440

## Test plan
- [ ] `docker build -f deploy/api/Dockerfile .` completes without COPY errors
- [ ] In API image: `semantic/`, `data/cybersec-semantic/entities/`, `data/ecommerce-semantic/entities/` all contain YAML files
- [ ] In API image: `data/demo.sql`, `data/cybersec.sql`, `data/ecommerce.sql` are non-empty SQL files
- [ ] `docker build -f packages/sandbox-sidecar/Dockerfile .` (from repo root) completes
- [ ] In sidecar image: `/semantic/entities/` contains YAML files
- [ ] `bun run lint` passes