### PR TITLE
feat(mode): onboarding demo identity with __demo__ connection

### DIFF
--- a/packages/api/src/api/__tests__/onboarding.test.ts
+++ b/packages/api/src/api/__tests__/onboarding.test.ts
@@ -830,7 +830,38 @@ describe("POST /api/v1/onboarding/use-demo", () => {
     expect(res.status).toBe(201);
     const data = await json(res);
     expect(data.connectionId).toBe("__demo__");
-    mockSetSetting.mockImplementation(async () => {});
+  });
+
+  it("succeeds even when prompt collection seeding fails (non-fatal)", async () => {
+    const originalImpl = mockInternalQuery.getMockImplementation();
+    mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (typeof sql === "string" && sql.includes("is_builtin = true")) {
+        throw new Error("prompt_collections table missing");
+      }
+      return [{ id: "__demo__" }];
+    });
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ demoType: "cybersec" }),
+    });
+    expect(res.status).toBe(201);
+    const data = await json(res);
+    expect(data.connectionId).toBe("__demo__");
+    if (originalImpl) mockInternalQuery.mockImplementation(originalImpl);
+  });
+
+  it("returns 500 with requestId when DB upsert fails", async () => {
+    mockInternalQuery.mockImplementation(async () => { throw new Error("connection reset"); });
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ demoType: "cybersec" }),
+    });
+    expect(res.status).toBe(500);
+    const data = await json(res);
+    expect(data.error).toBe("internal_error");
+    expect(data.requestId).toBeDefined();
   });
 });
 

--- a/packages/api/src/api/__tests__/onboarding.test.ts
+++ b/packages/api/src/api/__tests__/onboarding.test.ts
@@ -104,6 +104,30 @@ mock.module("@atlas/api/lib/semantic", () => ({
   _resetWhitelists: () => {},
 }));
 
+const mockImportFromDisk: Mock<(orgId: string, options?: { connectionId?: string; sourceDir?: string }) => Promise<{ imported: number; skipped: number; errors: unknown[]; total: number }>> = mock(
+  async () => ({ imported: 5, skipped: 0, errors: [], total: 5 }),
+);
+
+mock.module("@atlas/api/lib/semantic/sync", () => ({
+  importFromDisk: mockImportFromDisk,
+}));
+
+mock.module("@atlas/api/lib/semantic/files", () => ({
+  getSemanticRoot: () => "/mock/semantic",
+}));
+
+// Mock fs.existsSync so getDemoSemanticDir can resolve paths without real filesystem
+mock.module("fs", () => ({
+  existsSync: () => true,
+  promises: {
+    readFile: async () => "",
+    readdir: async () => [],
+    stat: async () => ({ isDirectory: () => true }),
+    mkdir: async () => undefined,
+    writeFile: async () => undefined,
+  },
+}));
+
 mock.module("@atlas/api/lib/security", () => ({
   maskConnectionUrl: (url: string) => url.replace(/\/\/.*@/, "//***@"),
 }));
@@ -122,6 +146,8 @@ mock.module("@atlas/api/lib/plugins/hooks", () => ({
   dispatchHook: async () => {},
 }));
 
+const mockSetSetting: Mock<(key: string, value: string, userId?: string, orgId?: string) => Promise<void>> = mock(async () => {});
+
 mock.module("@atlas/api/lib/settings", () => ({
   getSetting: () => undefined,
   getSettingAuto: () => undefined,
@@ -129,7 +155,7 @@ mock.module("@atlas/api/lib/settings", () => ({
   getSettingsForAdmin: () => [],
   getSettingsRegistry: () => [],
   getSettingDefinition: () => undefined,
-  setSetting: async () => {},
+  setSetting: mockSetSetting,
   deleteSetting: async () => {},
   loadSettings: async () => 0,
   getAllSettingOverrides: async () => [],
@@ -585,6 +611,226 @@ describe("POST /api/v1/onboarding/tour-reset", () => {
       method: "POST",
     });
     expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/onboarding/use-demo
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/onboarding/use-demo", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    mockAuthMode = "managed";
+    mockAuthenticate.mockImplementation(() =>
+      Promise.resolve({
+        authenticated: true,
+        mode: "managed",
+        user: { id: "user-1", mode: "managed", label: "test@example.com", role: "admin", activeOrganizationId: "org-1" },
+      }),
+    );
+    mockHasInternalDB.mockImplementation(() => true);
+    mockInternalQuery.mockClear();
+    mockInternalQuery.mockImplementation(async () => [{ id: "__demo__" }]);
+    mockEncryptUrl.mockClear();
+    mockEncryptUrl.mockImplementation((url: string) => `encrypted:${url}`);
+    mockRegister.mockClear();
+    mockUnregister.mockClear();
+    mockHas.mockImplementation(() => true);
+    mockImportFromDisk.mockClear();
+    mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5 }));
+    mockSetSetting.mockClear();
+    process.env.ATLAS_DATASOURCE_URL = "postgresql://demo:pass@localhost:5432/demo";
+  });
+
+  afterEach(() => {
+    Object.assign(process.env, originalEnv);
+  });
+
+  it("creates demo connection with id='__demo__'", async () => {
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ demoType: "cybersec" }),
+    });
+    expect(res.status).toBe(201);
+    const data = await json(res);
+    expect(data.connectionId).toBe("__demo__");
+    expect(data.dbType).toBe("postgres");
+    expect(data.entitiesImported).toBe(5);
+  });
+
+  it("saves connection with status='published' in upsert SQL", async () => {
+    await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ demoType: "cybersec" }),
+    });
+
+    // Find the INSERT INTO connections call
+    const connectionInsertCall = mockInternalQuery.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("INSERT INTO connections"),
+    );
+    expect(connectionInsertCall).toBeDefined();
+    const sql = connectionInsertCall![0] as string;
+    expect(sql).toContain("'published'");
+    const params = connectionInsertCall![1] as unknown[];
+    expect(params[0]).toBe("__demo__");
+  });
+
+  it("imports semantic entities with connectionId='__demo__'", async () => {
+    await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ demoType: "cybersec" }),
+    });
+
+    expect(mockImportFromDisk).toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({ connectionId: "__demo__" }),
+    );
+  });
+
+  it("writes demo_industry setting for the org", async () => {
+    await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ demoType: "cybersec" }),
+    });
+
+    expect(mockSetSetting).toHaveBeenCalledWith(
+      "ATLAS_DEMO_INDUSTRY",
+      "cybersecurity",
+      "user-1",
+      "org-1",
+    );
+  });
+
+  it("maps demo type 'ecommerce' to industry 'ecommerce'", async () => {
+    await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ demoType: "ecommerce" }),
+    });
+
+    expect(mockSetSetting).toHaveBeenCalledWith(
+      "ATLAS_DEMO_INDUSTRY",
+      "ecommerce",
+      "user-1",
+      "org-1",
+    );
+  });
+
+  it("maps demo type 'demo' to industry 'saas'", async () => {
+    await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(mockSetSetting).toHaveBeenCalledWith(
+      "ATLAS_DEMO_INDUSTRY",
+      "saas",
+      "user-1",
+      "org-1",
+    );
+  });
+
+  it("seeds demo prompt collections for matching industry", async () => {
+    await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ demoType: "cybersec" }),
+    });
+
+    // The seedDemoPromptCollections function queries for builtin collections
+    const builtinQuery = mockInternalQuery.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("is_builtin = true") && call[0].includes("industry"),
+    );
+    expect(builtinQuery).toBeDefined();
+    const params = builtinQuery![1] as unknown[];
+    expect(params[0]).toBe("cybersecurity");
+  });
+
+  it("rejects when auth mode is not managed", async () => {
+    mockAuthMode = "none";
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ demoType: "cybersec" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects when no active organization", async () => {
+    mockAuthenticate.mockImplementation(() =>
+      Promise.resolve({
+        authenticated: true,
+        mode: "managed",
+        user: { id: "user-1", mode: "managed", label: "test@example.com", role: "member" },
+      }),
+    );
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ demoType: "cybersec" }),
+    });
+    expect(res.status).toBe(400);
+    const data = await json(res);
+    expect(data.error).toBe("no_organization");
+  });
+
+  it("returns 400 when no datasource URL is configured", async () => {
+    delete process.env.ATLAS_DATASOURCE_URL;
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ demoType: "cybersec" }),
+    });
+    expect(res.status).toBe(400);
+    const data = await json(res);
+    expect(data.error).toBe("no_demo_datasource");
+  });
+
+  it("returns 500 when semantic import fails", async () => {
+    mockImportFromDisk.mockImplementation(async () => { throw new Error("import boom"); });
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ demoType: "cybersec" }),
+    });
+    expect(res.status).toBe(500);
+    const data = await json(res);
+    expect(data.error).toBe("import_failed");
+    mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5 }));
+  });
+
+  it("returns 500 with requestId when encryption fails", async () => {
+    mockEncryptUrl.mockImplementation(() => { throw new Error("bad key"); });
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ demoType: "cybersec" }),
+    });
+    expect(res.status).toBe(500);
+    const data = await json(res);
+    expect(data.error).toBe("encryption_failed");
+    expect(data.requestId).toBeDefined();
+    mockEncryptUrl.mockImplementation((url: string) => `encrypted:${url}`);
+  });
+
+  it("succeeds even when setSetting fails (non-fatal)", async () => {
+    mockSetSetting.mockImplementation(async () => { throw new Error("settings db down"); });
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ demoType: "cybersec" }),
+    });
+    expect(res.status).toBe(201);
+    const data = await json(res);
+    expect(data.connectionId).toBe("__demo__");
+    mockSetSetting.mockImplementation(async () => {});
   });
 });
 

--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -557,7 +557,7 @@ onboarding.openapi(
         ),
         catch: (err) => err instanceof Error ? err : new Error(String(err)),
       }).pipe(Effect.catchAll((err) => {
-        log.error({ err, requestId }, "Failed to persist onboarding connection");
+        log.error({ err: err.message, requestId }, "Failed to persist onboarding connection");
         return Effect.succeed(null);
       }));
 
@@ -677,7 +677,7 @@ onboarding.openapi(
         ),
         catch: (err) => err instanceof Error ? err : new Error(String(err)),
       }).pipe(Effect.catchAll((err) => {
-        log.error({ err, requestId }, "Failed to persist demo connection");
+        log.error({ err: err.message, requestId }, "Failed to persist demo connection");
         return Effect.succeed(null);
       }));
 
@@ -731,23 +731,23 @@ onboarding.openapi(
         log.info({ orgId, demoType, imported: importResult.imported, skipped: importResult.skipped, requestId }, "Imported semantic layer for demo workspace");
       }
 
-      // Write demo_industry setting for the org
-      yield* Effect.tryPromise({
-        try: () => setSetting("ATLAS_DEMO_INDUSTRY", industry, user?.id, orgId),
-        catch: (err) => err instanceof Error ? err : new Error(String(err)),
-      }).pipe(Effect.catchAll((err) => {
-        log.warn({ err: err.message, requestId, orgId, industry }, "Failed to write demo_industry setting — non-fatal");
-        return Effect.void;
-      }));
-
-      // Seed built-in prompt collections for the matching industry
-      yield* Effect.tryPromise({
-        try: () => seedDemoPromptCollections(orgId, industry),
-        catch: (err) => err instanceof Error ? err : new Error(String(err)),
-      }).pipe(Effect.catchAll((err) => {
-        log.warn({ err: err.message, requestId, orgId, industry }, "Failed to seed demo prompt collections — non-fatal");
-        return Effect.void;
-      }));
+      // Write demo_industry setting + seed prompt collections concurrently (independent, non-fatal)
+      yield* Effect.all([
+        Effect.tryPromise({
+          try: () => setSetting("ATLAS_DEMO_INDUSTRY", industry, user?.id, orgId),
+          catch: (err) => err instanceof Error ? err : new Error(String(err)),
+        }).pipe(Effect.catchAll((err) => {
+          log.warn({ err: err.message, requestId, orgId, industry }, "Failed to write demo_industry setting — non-fatal");
+          return Effect.void;
+        })),
+        Effect.tryPromise({
+          try: () => seedDemoPromptCollections(orgId, industry),
+          catch: (err) => err instanceof Error ? err : new Error(String(err)),
+        }).pipe(Effect.catchAll((err) => {
+          log.warn({ err: err.message, requestId, orgId, industry }, "Failed to seed demo prompt collections — non-fatal");
+          return Effect.void;
+        })),
+      ], { concurrency: "unbounded" });
 
       _resetWhitelists();
 

--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -24,6 +24,7 @@ import { maskConnectionUrl } from "@atlas/api/lib/security";
 import { _resetWhitelists } from "@atlas/api/lib/semantic";
 import { importFromDisk } from "@atlas/api/lib/semantic/sync";
 import { getSemanticRoot } from "@atlas/api/lib/semantic/files";
+import { setSetting } from "@atlas/api/lib/settings";
 import { ErrorSchema } from "./shared-schemas";
 import { standardAuth, requestContext, type AuthEnv } from "./middleware";
 import path from "path";
@@ -42,6 +43,16 @@ const DEMO_LABELS: Record<DemoType, string> = {
   cybersec: "Sentinel Security (Cybersecurity SaaS)",
   ecommerce: "NovaMart (E-commerce)",
 };
+
+/** Maps demo type to the canonical industry string used in prompt_collections and settings. */
+const DEMO_INDUSTRIES: Record<DemoType, string> = {
+  demo: "saas",
+  cybersec: "cybersecurity",
+  ecommerce: "ecommerce",
+};
+
+/** Reserved connection ID for demo workspaces. */
+const DEMO_CONNECTION_ID = "__demo__";
 
 /**
  * Resolve the semantic layer source directory for a demo type.
@@ -69,6 +80,55 @@ function getDemoSemanticDir(demoType: DemoType): string {
     `Each semantic directory must contain an entities/ subdirectory. ` +
     `Checked: ${dockerPath}/entities, ${seedsPath}/entities, ${devPath}/entities`,
   );
+}
+
+/**
+ * Seed org-scoped prompt collections matching the demo industry.
+ * Copies the global builtins for that industry into the org's namespace
+ * so they appear in the prompt library immediately after demo setup.
+ */
+async function seedDemoPromptCollections(orgId: string, industry: string): Promise<void> {
+  // Find global builtin collections for this industry
+  const builtins = await internalQuery<{ id: string; name: string; description: string; sort_order: number }>(
+    `SELECT id, name, description, sort_order FROM prompt_collections
+     WHERE is_builtin = true AND industry = $1 AND org_id IS NULL`,
+    [industry],
+  );
+
+  for (const builtin of builtins) {
+    // Skip if org already has a collection with this name
+    const existing = await internalQuery<{ id: string }>(
+      `SELECT id FROM prompt_collections WHERE name = $1 AND org_id = $2`,
+      [builtin.name, orgId],
+    );
+    if (existing.length > 0) continue;
+
+    // Create org-scoped copy
+    const inserted = await internalQuery<{ id: string }>(
+      `INSERT INTO prompt_collections (name, industry, description, is_builtin, sort_order, org_id, status)
+       VALUES ($1, $2, $3, true, $4, $5, 'published')
+       RETURNING id`,
+      [builtin.name, industry, builtin.description, builtin.sort_order, orgId],
+    );
+    if (!inserted[0]) {
+      log.warn({ collection: builtin.name, orgId }, "Failed to seed demo prompt collection — INSERT returned no rows");
+      continue;
+    }
+
+    // Copy prompt items from the global collection
+    const items = await internalQuery<{ question: string; description: string; category: string; sort_order: number }>(
+      `SELECT question, description, category, sort_order FROM prompt_items
+       WHERE collection_id = $1 ORDER BY sort_order ASC`,
+      [builtin.id],
+    );
+    for (const item of items) {
+      await internalQuery(
+        `INSERT INTO prompt_items (collection_id, question, description, category, sort_order)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [inserted[0].id, item.question, item.description, item.category, item.sort_order],
+      );
+    }
+  }
 }
 
 /** Valid connection ID: lowercase alphanumeric, hyphens, underscores, 1-64 chars. Must not start with underscore (reserved for internal IDs). */
@@ -579,7 +639,8 @@ onboarding.openapi(
         return c.json({ error: "no_demo_datasource", message: "No demo datasource configured. Set ATLAS_DATASOURCE_URL." }, 400);
       }
 
-      const id = "default";
+      const id = DEMO_CONNECTION_ID;
+      const industry = DEMO_INDUSTRIES[demoType];
       let dbType: string;
       try {
         dbType = detectDBType(url);
@@ -588,7 +649,7 @@ onboarding.openapi(
         return c.json({ error: "invalid_datasource", message: "Demo datasource URL has an unsupported scheme." }, 500);
       }
 
-      // Encrypt and persist (same logic as /complete)
+      // Encrypt and persist with status='published'
       let encryptedUrl: string;
       try {
         encryptedUrl = encryptUrl(url);
@@ -600,9 +661,9 @@ onboarding.openapi(
       const demoLabel = DEMO_LABELS[demoType];
       const upsertResult = yield* Effect.tryPromise({
         try: () => internalQuery<{ id: string }>(
-          `INSERT INTO connections (id, url, type, description, org_id)
-           VALUES ($1, $2, $3, $4, $5)
-           ON CONFLICT (id, org_id) DO UPDATE SET url = $2, type = $3, description = $4, updated_at = NOW()
+          `INSERT INTO connections (id, url, type, description, org_id, status)
+           VALUES ($1, $2, $3, $4, $5, 'published')
+           ON CONFLICT (id, org_id) DO UPDATE SET url = $2, type = $3, description = $4, status = 'published', updated_at = NOW()
            RETURNING id`,
           [id, encryptedUrl, dbType, `${demoLabel} — demo ${dbType} datasource`, orgId],
         ),
@@ -642,7 +703,7 @@ onboarding.openapi(
       }
 
       const importResult = yield* Effect.tryPromise({
-        try: () => importFromDisk(orgId, { sourceDir: semanticDir, connectionId: "default" }),
+        try: () => importFromDisk(orgId, { sourceDir: semanticDir, connectionId: DEMO_CONNECTION_ID }),
         catch: (err) => err instanceof Error ? err : new Error(String(err)),
       }).pipe(Effect.catchAll((err) => {
         log.error({ err: err.message, requestId, demoType, semanticDir }, "Semantic layer import failed");
@@ -662,9 +723,27 @@ onboarding.openapi(
         log.info({ orgId, demoType, imported: importResult.imported, skipped: importResult.skipped, requestId }, "Imported semantic layer for demo workspace");
       }
 
+      // Write demo_industry setting for the org
+      yield* Effect.tryPromise({
+        try: () => setSetting("ATLAS_DEMO_INDUSTRY", industry, user?.id, orgId),
+        catch: (err) => err instanceof Error ? err : new Error(String(err)),
+      }).pipe(Effect.catchAll((err) => {
+        log.warn({ err: err.message, requestId, orgId, industry }, "Failed to write demo_industry setting — non-fatal");
+        return Effect.void;
+      }));
+
+      // Seed built-in prompt collections for the matching industry
+      yield* Effect.tryPromise({
+        try: () => seedDemoPromptCollections(orgId, industry),
+        catch: (err) => err instanceof Error ? err : new Error(String(err)),
+      }).pipe(Effect.catchAll((err) => {
+        log.warn({ err: err.message, requestId, orgId, industry }, "Failed to seed demo prompt collections — non-fatal");
+        return Effect.void;
+      }));
+
       _resetWhitelists();
 
-      log.info({ requestId, orgId, demoType, dbType, userId: user?.id, entitiesImported }, "Demo onboarding complete");
+      log.info({ requestId, orgId, demoType, dbType, userId: user?.id, entitiesImported, industry }, "Demo onboarding complete");
 
       return c.json({
         connectionId: id,

--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -96,36 +96,44 @@ async function seedDemoPromptCollections(orgId: string, industry: string): Promi
   );
 
   for (const builtin of builtins) {
-    // Skip if org already has a collection with this name
-    const existing = await internalQuery<{ id: string }>(
-      `SELECT id FROM prompt_collections WHERE name = $1 AND org_id = $2`,
-      [builtin.name, orgId],
-    );
-    if (existing.length > 0) continue;
+    try {
+      // Skip if org already has a collection with this name
+      const existing = await internalQuery<{ id: string }>(
+        `SELECT id FROM prompt_collections WHERE name = $1 AND org_id = $2`,
+        [builtin.name, orgId],
+      );
+      if (existing.length > 0) continue;
 
-    // Create org-scoped copy
-    const inserted = await internalQuery<{ id: string }>(
-      `INSERT INTO prompt_collections (name, industry, description, is_builtin, sort_order, org_id, status)
-       VALUES ($1, $2, $3, true, $4, $5, 'published')
-       RETURNING id`,
-      [builtin.name, industry, builtin.description, builtin.sort_order, orgId],
-    );
-    if (!inserted[0]) {
-      log.warn({ collection: builtin.name, orgId }, "Failed to seed demo prompt collection — INSERT returned no rows");
-      continue;
-    }
+      // Create org-scoped copy
+      const inserted = await internalQuery<{ id: string }>(
+        `INSERT INTO prompt_collections (name, industry, description, is_builtin, sort_order, org_id, status)
+         VALUES ($1, $2, $3, true, $4, $5, 'published')
+         RETURNING id`,
+        [builtin.name, industry, builtin.description, builtin.sort_order, orgId],
+      );
+      if (!inserted[0]?.id) {
+        log.warn({ collection: builtin.name, orgId }, "Failed to seed demo prompt collection — INSERT returned no rows");
+        continue;
+      }
 
-    // Copy prompt items from the global collection
-    const items = await internalQuery<{ question: string; description: string; category: string; sort_order: number }>(
-      `SELECT question, description, category, sort_order FROM prompt_items
-       WHERE collection_id = $1 ORDER BY sort_order ASC`,
-      [builtin.id],
-    );
-    for (const item of items) {
-      await internalQuery(
-        `INSERT INTO prompt_items (collection_id, question, description, category, sort_order)
-         VALUES ($1, $2, $3, $4, $5)`,
-        [inserted[0].id, item.question, item.description, item.category, item.sort_order],
+      // Copy prompt items from the global collection (independent inserts — parallelize)
+      const items = await internalQuery<{ question: string; description: string; category: string; sort_order: number }>(
+        `SELECT question, description, category, sort_order FROM prompt_items
+         WHERE collection_id = $1 ORDER BY sort_order ASC`,
+        [builtin.id],
+      );
+      const collectionId = inserted[0].id;
+      await Promise.all(items.map((item) =>
+        internalQuery(
+          `INSERT INTO prompt_items (collection_id, question, description, category, sort_order)
+           VALUES ($1, $2, $3, $4, $5)`,
+          [collectionId, item.question, item.description, item.category, item.sort_order],
+        ),
+      ));
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err), collection: builtin.name, orgId },
+        "Failed to seed demo prompt collection — skipping to next",
       );
     }
   }

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -306,6 +306,18 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     scope: "workspace",
   },
 
+  // Demo
+  {
+    key: "ATLAS_DEMO_INDUSTRY",
+    section: "Demo",
+    label: "Demo Industry",
+    description: "Industry of the demo dataset provisioned during onboarding (saas, cybersecurity, ecommerce)",
+    type: "string",
+    envVar: "ATLAS_DEMO_INDUSTRY",
+    scope: "workspace",
+    saasVisible: false,
+  },
+
   // Appearance
   {
     key: "ATLAS_BRAND_COLOR",


### PR DESCRIPTION
## Summary
- Update `/api/v1/onboarding/use-demo` to save demo connections with `id='__demo__'` and `status='published'` instead of `id='default'`, establishing a persistent demo identity
- Import semantic entities with `connection_id='__demo__'` and write `demo_industry` (saas/cybersecurity/ecommerce) to the settings table for the org
- Seed org-scoped prompt collections matching the demo industry with `status='published'`
- Register `ATLAS_DEMO_INDUSTRY` in the settings registry (workspace scope)
- `__demo__` is already reserved — both admin connection creation (`/^[a-z]/` regex) and onboarding `/complete` (`CONNECTION_ID_PATTERN`) reject IDs starting with `_`

## Test plan
- [x] 13 new tests in `onboarding.test.ts` covering all demo identity behavior
- [x] Connection id `__demo__` verified in response and SQL params
- [x] Semantic import called with `connectionId: '__demo__'`
- [x] `setSetting` called with correct industry mapping per demo type
- [x] Prompt collection seeding queries verified
- [x] Non-fatal failure paths (setSetting failure still returns 201)
- [x] Error paths (no datasource, encryption failure, import failure)
- [x] All 41 tests pass, lint clean, type check clean, syncpack clean, template drift clean

Closes #1425