### PR TITLE
feat(mode): published mode query filtering + NULL-safe indexes

### DIFF
--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -20,6 +20,11 @@ import { createAdminRouter, requireOrgContext } from "./admin-router";
 
 const log = createLogger("admin-connections");
 
+/** Read atlasMode from the Hono context. Defaults to "published" (most restrictive) when not set. */
+function getAtlasMode(c: { get(key: string): unknown }): import("@useatlas/types/auth").AtlasMode {
+  return (c.get("atlasMode") as import("@useatlas/types/auth").AtlasMode | undefined) ?? "published";
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -310,10 +315,8 @@ adminConnections.openapi(listConnectionsRoute, async (c) => runHandler(c, "list 
   const { orgId } = c.get("orgContext");
   const authResult = c.get("authResult");
   const isPlatformAdmin = authResult.user?.role === "platform_admin";
-  const atlasMode = (c.get("atlasMode") ?? "published") as import("@useatlas/types/auth").AtlasMode;
-
   const connList = connections.describe();
-  const visible = await getVisibleConnectionIds(orgId, isPlatformAdmin, atlasMode);
+  const visible = await getVisibleConnectionIds(orgId, isPlatformAdmin, getAtlasMode(c));
   const filtered = visible ? connList.filter((conn) => visible.has(conn.id)) : connList;
 
   return c.json({ connections: filtered }, 200);
@@ -390,8 +393,7 @@ adminConnections.openapi(drainConnectionPoolRoute, async (c) => runHandler(c, "d
   }
 
   // Workspace admins can only drain connections visible to their org
-  const atlasModeDrain = (c.get("atlasMode") ?? "published") as import("@useatlas/types/auth").AtlasMode;
-  const visible = await getVisibleConnectionIds(orgId, isPlatformAdmin, atlasModeDrain);
+  const visible = await getVisibleConnectionIds(orgId, isPlatformAdmin, getAtlasMode(c));
   if (visible && !visible.has(id)) {
     return c.json({ error: "not_found", message: `Connection "${id}" not found`, requestId }, 404);
   }
@@ -468,8 +470,7 @@ adminConnections.openapi(testExistingConnectionRoute, async (c) => runHandler(c,
     return c.json({ error: "not_found", message: `Connection "${id}" not found.`, requestId }, 404);
   }
 
-  const atlasModeHealth = (c.get("atlasMode") ?? "published") as import("@useatlas/types/auth").AtlasMode;
-  const visible = await getVisibleConnectionIds(orgId, isPlatformAdmin, atlasModeHealth);
+  const visible = await getVisibleConnectionIds(orgId, isPlatformAdmin, getAtlasMode(c));
   if (visible && !visible.has(id)) {
     return c.json({ error: "not_found", message: `Connection "${id}" not found.`, requestId }, 404);
   }
@@ -829,8 +830,7 @@ adminConnections.openapi(getConnectionRoute, async (c) => runHandler(c, "get con
   }
 
   // Verify visibility for workspace admins
-  const atlasModeDetail = (c.get("atlasMode") ?? "published") as import("@useatlas/types/auth").AtlasMode;
-  const visible = await getVisibleConnectionIds(orgId, isPlatformAdmin, atlasModeDetail);
+  const visible = await getVisibleConnectionIds(orgId, isPlatformAdmin, getAtlasMode(c));
   if (visible && !visible.has(id)) {
     return c.json({ error: "not_found", message: `Connection "${id}" not found.`, requestId }, 404);
   }

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -27,10 +27,13 @@ const log = createLogger("admin-connections");
 /**
  * Get the set of connection IDs visible to a workspace admin.
  * Returns null for platform admins (they see all connections).
+ *
+ * @param mode - Atlas mode. When "published", only published connections are visible.
  */
 async function getVisibleConnectionIds(
   orgId: string,
   isPlatformAdmin: boolean,
+  mode?: import("@useatlas/types/auth").AtlasMode,
 ): Promise<Set<string> | null> {
   if (isPlatformAdmin) return null; // null = no filter
 
@@ -38,8 +41,9 @@ async function getVisibleConnectionIds(
   const visible = new Set<string>(["default"]);
 
   if (hasInternalDB()) {
+    const statusClause = mode === "published" ? " AND status = 'published'" : "";
     const rows = await internalQuery<{ id: string }>(
-      "SELECT id FROM connections WHERE org_id = $1",
+      `SELECT id FROM connections WHERE org_id = $1${statusClause}`,
       [orgId],
     );
     for (const row of rows) {
@@ -306,9 +310,10 @@ adminConnections.openapi(listConnectionsRoute, async (c) => runHandler(c, "list 
   const { orgId } = c.get("orgContext");
   const authResult = c.get("authResult");
   const isPlatformAdmin = authResult.user?.role === "platform_admin";
+  const atlasMode = (c.get("atlasMode") ?? "published") as import("@useatlas/types/auth").AtlasMode;
 
   const connList = connections.describe();
-  const visible = await getVisibleConnectionIds(orgId, isPlatformAdmin);
+  const visible = await getVisibleConnectionIds(orgId, isPlatformAdmin, atlasMode);
   const filtered = visible ? connList.filter((conn) => visible.has(conn.id)) : connList;
 
   return c.json({ connections: filtered }, 200);
@@ -385,7 +390,8 @@ adminConnections.openapi(drainConnectionPoolRoute, async (c) => runHandler(c, "d
   }
 
   // Workspace admins can only drain connections visible to their org
-  const visible = await getVisibleConnectionIds(orgId, isPlatformAdmin);
+  const atlasModeDrain = (c.get("atlasMode") ?? "published") as import("@useatlas/types/auth").AtlasMode;
+  const visible = await getVisibleConnectionIds(orgId, isPlatformAdmin, atlasModeDrain);
   if (visible && !visible.has(id)) {
     return c.json({ error: "not_found", message: `Connection "${id}" not found`, requestId }, 404);
   }
@@ -462,7 +468,8 @@ adminConnections.openapi(testExistingConnectionRoute, async (c) => runHandler(c,
     return c.json({ error: "not_found", message: `Connection "${id}" not found.`, requestId }, 404);
   }
 
-  const visible = await getVisibleConnectionIds(orgId, isPlatformAdmin);
+  const atlasModeHealth = (c.get("atlasMode") ?? "published") as import("@useatlas/types/auth").AtlasMode;
+  const visible = await getVisibleConnectionIds(orgId, isPlatformAdmin, atlasModeHealth);
   if (visible && !visible.has(id)) {
     return c.json({ error: "not_found", message: `Connection "${id}" not found.`, requestId }, 404);
   }
@@ -822,7 +829,8 @@ adminConnections.openapi(getConnectionRoute, async (c) => runHandler(c, "get con
   }
 
   // Verify visibility for workspace admins
-  const visible = await getVisibleConnectionIds(orgId, isPlatformAdmin);
+  const atlasModeDetail = (c.get("atlasMode") ?? "published") as import("@useatlas/types/auth").AtlasMode;
+  const visible = await getVisibleConnectionIds(orgId, isPlatformAdmin, atlasModeDetail);
   if (visible && !visible.has(id)) {
     return c.json({ error: "not_found", message: `Connection "${id}" not found.`, requestId }, 404);
   }

--- a/packages/api/src/api/routes/admin-prompts.ts
+++ b/packages/api/src/api/routes/admin-prompts.ts
@@ -484,12 +484,15 @@ async function findCollection(orgId: string | undefined, collectionId: string) {
 adminPrompts.openapi(listCollectionsRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    const { atlasMode } = yield* RequestContext;
+
+    const statusClause = atlasMode === "published" ? " AND status = 'published'" : "";
 
     let rows: Record<string, unknown>[];
     if (orgId) {
-      rows = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(`SELECT * FROM prompt_collections WHERE org_id IS NULL OR org_id = $1 ORDER BY sort_order ASC, created_at ASC`, [orgId]));
+      rows = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(`SELECT * FROM prompt_collections WHERE (org_id IS NULL OR org_id = $1)${statusClause} ORDER BY sort_order ASC, created_at ASC`, [orgId]));
     } else {
-      rows = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(`SELECT * FROM prompt_collections ORDER BY sort_order ASC, created_at ASC`));
+      rows = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(`SELECT * FROM prompt_collections WHERE 1=1${statusClause} ORDER BY sort_order ASC, created_at ASC`));
     }
     return c.json({ collections: rows.map(toPromptCollection), total: rows.length }, 200);
   }), { label: "list prompt collections" });

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -91,6 +91,10 @@ const admin = new OpenAPIHono({ defaultHook: validationHook });
 /** Read requestId from middleware context. */
 const reqId = (c: { get(key: string): unknown }): string => c.get("requestId") as string;
 
+/** Read atlasMode from middleware context. Defaults to "published" when not set. */
+const getAtlasMode = (c: { get(key: string): unknown }): import("@useatlas/types/auth").AtlasMode =>
+  (c.get("atlasMode") as import("@useatlas/types/auth").AtlasMode | undefined) ?? "published";
+
 /**
  * Run admin auth preamble and bind user identity into AsyncLocalStorage.
  * Returns { authResult, requestId } for the handler to use.
@@ -1255,12 +1259,15 @@ admin.openapi(listOrgEntitiesRoute, async (c) => runHandler(c, "list org semanti
     return c.json({ error: "bad_request", message: `Invalid type. Must be one of: ${[...VALID_ENTITY_TYPES].join(", ")}` }, 400);
   }
   const entityType = rawType as "entity" | "metric" | "glossary" | "catalog" | undefined;
-  const rows = await listEntities(orgId, entityType);
+  const atlasMode = getAtlasMode(c);
+  const statusFilter = atlasMode === "published" ? "published" as const : undefined;
+  const rows = await listEntities(orgId, entityType, statusFilter);
   return c.json({
     entities: rows.map((r) => ({
       name: r.name,
       entityType: r.entity_type,
       connectionId: r.connection_id,
+      status: r.status,
       updatedAt: r.updated_at,
     })),
     total: rows.length,

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -11,7 +11,7 @@ import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext } from "@atlas/api/lib/effect/services";
 import { HTTPException } from "hono/http-exception";
 import { validationHook } from "./validation-hook";
-import { withRequestId, type AuthEnv } from "./middleware";
+import { withRequestId, resolveMode, type AuthEnv } from "./middleware";
 import { z } from "zod";
 import { type UIMessage, createUIMessageStream, createUIMessageStreamResponse } from "ai";
 import { APICallError, LoadAPIKeyError, NoSuchModelError } from "ai";
@@ -296,11 +296,18 @@ chat.openapi(chatRoute, async (c) => {
     // Capture plan warning for response headers (set after stream is created)
     const planWarning = planCheck.allowed ? planCheck.warning : undefined;
   
+    // Resolve atlas mode for this request (published vs developer)
+    const atlasMode = resolveMode(
+      req.headers.get("cookie"),
+      req.headers.get("x-atlas-mode"),
+      authResult,
+    );
+
     // Bind user to AsyncLocalStorage so downstream code (logQueryAudit, etc.)
     // has access to user identity. The middleware already set up requestId context;
     // this nested call adds the user after inline auth completes.
     return withRequestContext(
-      { requestId, user: authResult.user },
+      { requestId, user: authResult.user, atlasMode },
       async () => {
         // Startup diagnostics — fast-fail with actionable errors
         const diagnostics = await validateEnvironment();

--- a/packages/api/src/api/routes/middleware.ts
+++ b/packages/api/src/api/routes/middleware.ts
@@ -443,7 +443,8 @@ function resolveModeForRequest(
 export const requestContext = createMiddleware<AuthEnv>(async (c, next) => {
   const requestId = c.get("requestId");
   const authResult = c.get("authResult");
-  await withRequestContext({ requestId, user: authResult.user }, () => next());
+  const atlasMode = c.get("atlasMode");
+  await withRequestContext({ requestId, user: authResult.user, atlasMode }, () => next());
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/api/routes/prompts.ts
+++ b/packages/api/src/api/routes/prompts.ts
@@ -10,7 +10,7 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
 import { Effect } from "effect";
 import { runEffect } from "@atlas/api/lib/effect/hono";
-import { AuthContext } from "@atlas/api/lib/effect/services";
+import { AuthContext, RequestContext } from "@atlas/api/lib/effect/services";
 import { validationHook } from "./validation-hook";
 import { z } from "zod";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
@@ -167,20 +167,23 @@ prompts.use(requestContext);
 prompts.openapi(listCollectionsRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    const { atlasMode } = yield* RequestContext;
 
     if (!hasInternalDB()) {
       return c.json({ collections: [] }, 200);
     }
 
+    const statusClause = atlasMode === "published" ? " AND status = 'published'" : "";
+
     let rows: Record<string, unknown>[];
     if (orgId) {
       rows = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(
-        `SELECT * FROM prompt_collections WHERE org_id IS NULL OR org_id = $1 ORDER BY sort_order ASC, created_at ASC`,
+        `SELECT * FROM prompt_collections WHERE (org_id IS NULL OR org_id = $1)${statusClause} ORDER BY sort_order ASC, created_at ASC`,
         [orgId],
       ));
     } else {
       rows = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(
-        `SELECT * FROM prompt_collections WHERE org_id IS NULL ORDER BY sort_order ASC, created_at ASC`,
+        `SELECT * FROM prompt_collections WHERE org_id IS NULL${statusClause} ORDER BY sort_order ASC, created_at ASC`,
       ));
     }
 
@@ -195,22 +198,24 @@ prompts.openapi(listCollectionsRoute, async (c) => {
 prompts.openapi(getCollectionRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    const { atlasMode } = yield* RequestContext;
 
     if (!hasInternalDB()) {
       return c.json({ error: "not_found", message: "Prompt collection not found." }, 404);
     }
 
     const { id } = c.req.valid("param");
+    const statusClause = atlasMode === "published" ? " AND status = 'published'" : "";
 
     let collectionRows: Record<string, unknown>[];
     if (orgId) {
       collectionRows = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(
-        `SELECT * FROM prompt_collections WHERE id = $1 AND (org_id IS NULL OR org_id = $2)`,
+        `SELECT * FROM prompt_collections WHERE id = $1 AND (org_id IS NULL OR org_id = $2)${statusClause}`,
         [id, orgId],
       ));
     } else {
       collectionRows = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(
-        `SELECT * FROM prompt_collections WHERE id = $1 AND org_id IS NULL`,
+        `SELECT * FROM prompt_collections WHERE id = $1 AND org_id IS NULL${statusClause}`,
         [id],
       ));
     }

--- a/packages/api/src/lib/__tests__/published-mode-filtering.test.ts
+++ b/packages/api/src/lib/__tests__/published-mode-filtering.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Tests for published mode query filtering (#1426) and COALESCE index (#1444).
+ *
+ * Covers:
+ * - listEntities statusFilter parameter
+ * - loadOrgWhitelist mode-aware caching
+ * - getOrgWhitelistedTables mode-aware lookup
+ * - Published mode returns only published entities
+ * - Developer mode returns all entities (published + draft + draft_delete)
+ * - Mode-specific cache isolation
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { resolve } from "path";
+
+// ---------------------------------------------------------------------------
+// Mock the DB layer
+// ---------------------------------------------------------------------------
+
+import type { SemanticEntityRow, SemanticEntityStatus } from "../semantic/entities";
+
+let storedEntities: SemanticEntityRow[] = [];
+
+const mockListEntities = mock(
+  (_orgId: string, _entityType?: string, statusFilter?: SemanticEntityStatus) => {
+    if (statusFilter) {
+      return Promise.resolve(storedEntities.filter((e) => e.status === statusFilter));
+    }
+    return Promise.resolve(storedEntities);
+  },
+);
+const mockGetEntity = mock((): Promise<SemanticEntityRow | null> => Promise.resolve(null));
+const mockUpsertEntity = mock((): Promise<void> => Promise.resolve());
+const mockDeleteEntity = mock((): Promise<boolean> => Promise.resolve(false));
+const mockCountEntities = mock((): Promise<number> => Promise.resolve(0));
+const mockBulkUpsertEntities = mock((): Promise<number> => Promise.resolve(0));
+const mockCreateVersion = mock((): Promise<string> => Promise.resolve("v1"));
+const mockListVersions = mock(() => Promise.resolve({ versions: [], total: 0 }));
+const mockGetVersion = mock((): Promise<null> => Promise.resolve(null));
+const mockGenerateChangeSummary = mock((): Promise<string | null> => Promise.resolve(null));
+const SEMANTIC_ENTITY_STATUSES = ["published", "draft", "draft_delete", "archived"] as const;
+
+mock.module("@atlas/api/lib/semantic/entities", () => ({
+  listEntities: mockListEntities,
+  getEntity: mockGetEntity,
+  upsertEntity: mockUpsertEntity,
+  deleteEntity: mockDeleteEntity,
+  countEntities: mockCountEntities,
+  bulkUpsertEntities: mockBulkUpsertEntities,
+  createVersion: mockCreateVersion,
+  listVersions: mockListVersions,
+  getVersion: mockGetVersion,
+  generateChangeSummary: mockGenerateChangeSummary,
+  SEMANTIC_ENTITY_STATUSES,
+}));
+
+// Cache-busting import
+const modPath = resolve(__dirname, "../semantic/whitelist.ts");
+const mod = await import(`${modPath}?t=${Date.now()}`);
+const loadOrgWhitelist = mod.loadOrgWhitelist as typeof import("../semantic/whitelist").loadOrgWhitelist;
+const getOrgWhitelistedTables = mod.getOrgWhitelistedTables as typeof import("../semantic/whitelist").getOrgWhitelistedTables;
+const _resetOrgWhitelists = mod._resetOrgWhitelists as typeof import("../semantic/whitelist")._resetOrgWhitelists;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEntityRow(
+  name: string,
+  table: string,
+  status: SemanticEntityStatus = "published",
+  connectionId?: string,
+): SemanticEntityRow {
+  return {
+    id: `id-${name}-${status}`,
+    org_id: "org-1",
+    entity_type: "entity" as const,
+    name,
+    yaml_content: `table: ${table}\n${connectionId ? `connection: ${connectionId}\n` : ""}`,
+    connection_id: connectionId ?? null,
+    status,
+    created_at: "2026-01-01",
+    updated_at: "2026-01-01",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("published mode filtering", () => {
+  beforeEach(() => {
+    _resetOrgWhitelists();
+    mockListEntities.mockReset();
+    storedEntities = [];
+    // Re-wire mock to filter by status
+    mockListEntities.mockImplementation(
+      (_orgId: string, _entityType?: string, statusFilter?: SemanticEntityStatus) => {
+        if (statusFilter) {
+          return Promise.resolve(storedEntities.filter((e) => e.status === statusFilter));
+        }
+        return Promise.resolve(storedEntities);
+      },
+    );
+  });
+
+  describe("listEntities statusFilter", () => {
+    it("passes statusFilter to listEntities when mode is published", async () => {
+      storedEntities = [
+        makeEntityRow("users", "users", "published"),
+        makeEntityRow("users", "users", "draft"),
+        makeEntityRow("orders", "orders", "published"),
+      ];
+
+      await loadOrgWhitelist("org-1", "published");
+      // listEntities should have been called with "published" status filter
+      expect(mockListEntities).toHaveBeenCalledWith("org-1", "entity", "published");
+    });
+
+    it("does not pass statusFilter when mode is developer", async () => {
+      storedEntities = [
+        makeEntityRow("users", "users", "published"),
+        makeEntityRow("users", "users", "draft"),
+      ];
+
+      await loadOrgWhitelist("org-1", "developer");
+      // listEntities should have been called without status filter
+      expect(mockListEntities).toHaveBeenCalledWith("org-1", "entity", undefined);
+    });
+
+    it("does not pass statusFilter when mode is omitted", async () => {
+      storedEntities = [makeEntityRow("users", "users", "published")];
+
+      await loadOrgWhitelist("org-1");
+      expect(mockListEntities).toHaveBeenCalledWith("org-1", "entity", undefined);
+    });
+  });
+
+  describe("published mode returns only published entities", () => {
+    it("published mode whitelist contains only published entity tables", async () => {
+      storedEntities = [
+        makeEntityRow("users", "users", "published"),
+        makeEntityRow("orders", "orders", "draft"),
+        makeEntityRow("events", "events", "draft_delete"),
+      ];
+
+      const result = await loadOrgWhitelist("org-1", "published");
+      const tables = result.get("default") ?? new Set();
+      expect(tables.has("users")).toBe(true);
+      expect(tables.has("orders")).toBe(false);
+      expect(tables.has("events")).toBe(false);
+    });
+
+    it("getOrgWhitelistedTables in published mode returns only published tables", async () => {
+      storedEntities = [
+        makeEntityRow("users", "users", "published"),
+        makeEntityRow("orders", "orders", "draft"),
+      ];
+
+      await loadOrgWhitelist("org-1", "published");
+      const tables = getOrgWhitelistedTables("org-1", "default", "published");
+      expect(tables.has("users")).toBe(true);
+      expect(tables.has("orders")).toBe(false);
+    });
+  });
+
+  describe("developer mode returns all entities", () => {
+    it("developer mode whitelist contains all entity tables", async () => {
+      storedEntities = [
+        makeEntityRow("users", "users", "published"),
+        makeEntityRow("orders", "orders", "draft"),
+        makeEntityRow("events", "events", "draft_delete"),
+      ];
+
+      const result = await loadOrgWhitelist("org-1", "developer");
+      const tables = result.get("default") ?? new Set();
+      expect(tables.has("users")).toBe(true);
+      expect(tables.has("orders")).toBe(true);
+      expect(tables.has("events")).toBe(true);
+    });
+
+    it("getOrgWhitelistedTables in developer mode returns all tables", async () => {
+      storedEntities = [
+        makeEntityRow("users", "users", "published"),
+        makeEntityRow("orders", "orders", "draft"),
+      ];
+
+      await loadOrgWhitelist("org-1", "developer");
+      const tables = getOrgWhitelistedTables("org-1", "default", "developer");
+      expect(tables.has("users")).toBe(true);
+      expect(tables.has("orders")).toBe(true);
+    });
+  });
+
+  describe("mode-specific cache isolation", () => {
+    it("caches published and developer modes separately", async () => {
+      storedEntities = [
+        makeEntityRow("users", "users", "published"),
+        makeEntityRow("orders", "orders", "draft"),
+      ];
+
+      // Load published mode first
+      await loadOrgWhitelist("org-1", "published");
+      const publishedTables = getOrgWhitelistedTables("org-1", "default", "published");
+      expect(publishedTables.has("users")).toBe(true);
+      expect(publishedTables.has("orders")).toBe(false);
+
+      // Load developer mode — should call listEntities again (separate cache)
+      await loadOrgWhitelist("org-1", "developer");
+      const devTables = getOrgWhitelistedTables("org-1", "default", "developer");
+      expect(devTables.has("users")).toBe(true);
+      expect(devTables.has("orders")).toBe(true);
+
+      // Both caches should coexist
+      expect(mockListEntities).toHaveBeenCalledTimes(2);
+    });
+
+    it("published cache hit does not return developer results", async () => {
+      storedEntities = [
+        makeEntityRow("users", "users", "published"),
+        makeEntityRow("orders", "orders", "draft"),
+      ];
+
+      await loadOrgWhitelist("org-1", "published");
+      await loadOrgWhitelist("org-1", "published"); // cache hit
+
+      const tables = getOrgWhitelistedTables("org-1", "default", "published");
+      expect(tables.has("orders")).toBe(false);
+      expect(mockListEntities).toHaveBeenCalledTimes(1); // only one call due to cache
+    });
+  });
+});

--- a/packages/api/src/lib/__tests__/published-mode-filtering.test.ts
+++ b/packages/api/src/lib/__tests__/published-mode-filtering.test.ts
@@ -59,6 +59,7 @@ const modPath = resolve(__dirname, "../semantic/whitelist.ts");
 const mod = await import(`${modPath}?t=${Date.now()}`);
 const loadOrgWhitelist = mod.loadOrgWhitelist as typeof import("../semantic/whitelist").loadOrgWhitelist;
 const getOrgWhitelistedTables = mod.getOrgWhitelistedTables as typeof import("../semantic/whitelist").getOrgWhitelistedTables;
+const invalidateOrgWhitelist = mod.invalidateOrgWhitelist as typeof import("../semantic/whitelist").invalidateOrgWhitelist;
 const _resetOrgWhitelists = mod._resetOrgWhitelists as typeof import("../semantic/whitelist")._resetOrgWhitelists;
 
 // ---------------------------------------------------------------------------
@@ -227,6 +228,43 @@ describe("published mode filtering", () => {
       const tables = getOrgWhitelistedTables("org-1", "default", "published");
       expect(tables.has("orders")).toBe(false);
       expect(mockListEntities).toHaveBeenCalledTimes(1); // only one call due to cache
+    });
+  });
+
+  describe("cache invalidation clears both modes", () => {
+    it("invalidateOrgWhitelist clears both developer and published caches", async () => {
+      storedEntities = [
+        makeEntityRow("users", "users", "published"),
+        makeEntityRow("orders", "orders", "draft"),
+      ];
+
+      // Load both caches
+      await loadOrgWhitelist("org-1", "published");
+      await loadOrgWhitelist("org-1", "developer");
+      expect(mockListEntities).toHaveBeenCalledTimes(2);
+
+      // Invalidate — should clear both
+      invalidateOrgWhitelist("org-1");
+
+      // Reload both — should call listEntities again (cache miss)
+      await loadOrgWhitelist("org-1", "published");
+      await loadOrgWhitelist("org-1", "developer");
+      expect(mockListEntities).toHaveBeenCalledTimes(4); // 2 original + 2 reloads
+    });
+
+    it("invalidateOrgWhitelist clears published cache even when developer cache was not loaded", async () => {
+      storedEntities = [makeEntityRow("users", "users", "published")];
+
+      // Load only published cache
+      await loadOrgWhitelist("org-1", "published");
+      expect(mockListEntities).toHaveBeenCalledTimes(1);
+
+      // Invalidate
+      invalidateOrgWhitelist("org-1");
+
+      // Reload published — should call listEntities again
+      await loadOrgWhitelist("org-1", "published");
+      expect(mockListEntities).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -502,6 +502,7 @@ export async function runAgent({
   const reqCtx = getRequestContext();
   const userId = reqCtx?.user?.id ?? null;
   const orgId = reqCtx?.user?.activeOrganizationId;
+  const atlasMode = reqCtx?.atlasMode ?? "published";
 
   // Resolve model: injected > workspace config (enterprise) > platform env vars
   let model: LanguageModel;
@@ -543,7 +544,7 @@ export async function runAgent({
       (orgId && hasInternalDB())
         ? Effect.all([
             Effect.tryPromise({
-              try: () => loadOrgWhitelist(orgId),
+              try: () => loadOrgWhitelist(orgId, atlasMode),
               catch: normalizeError,
             }),
             Effect.tryPromise({

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -267,6 +267,7 @@ describe("migrateAuthTables", () => {
             { name: "0022_sso_domain_verification.sql" },
             { name: "0023_admin_action_log.sql" },
             { name: "0024_mode_status_columns.sql" },
+            { name: "0025_fix_null_unsafe_indexes.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -62,7 +62,7 @@ describe("runMigrations", () => {
 
     const count = await runMigrations(pool);
 
-    expect(count).toBe(25);
+    expect(count).toBe(26);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -116,6 +116,7 @@ describe("runMigrations", () => {
         "0022_sso_domain_verification.sql",
         "0023_admin_action_log.sql",
         "0024_mode_status_columns.sql",
+        "0025_fix_null_unsafe_indexes.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0025_fix_null_unsafe_indexes.sql
+++ b/packages/api/src/lib/db/migrations/0025_fix_null_unsafe_indexes.sql
@@ -1,0 +1,27 @@
+-- 0025 — Fix NULL-unsafe partial unique indexes on semantic_entities
+--
+-- Migration 0024 created partial unique indexes on (org_id, name, connection_id)
+-- but PostgreSQL treats NULLs as distinct in unique indexes. Since connection_id
+-- is commonly NULL (single-datasource setups), the indexes failed to prevent
+-- duplicate entities.
+--
+-- Fix: use COALESCE(connection_id, '__default__') to map NULLs to a sentinel
+-- value, making the uniqueness constraint effective.
+
+-- Drop the NULL-unsafe indexes
+DROP INDEX IF EXISTS uq_semantic_entity_published;
+DROP INDEX IF EXISTS uq_semantic_entity_draft;
+DROP INDEX IF EXISTS uq_semantic_entity_tombstone;
+
+-- Recreate with COALESCE to handle NULLs
+CREATE UNIQUE INDEX uq_semantic_entity_published
+  ON semantic_entities(org_id, name, COALESCE(connection_id, '__default__'))
+  WHERE status = 'published';
+
+CREATE UNIQUE INDEX uq_semantic_entity_draft
+  ON semantic_entities(org_id, name, COALESCE(connection_id, '__default__'))
+  WHERE status = 'draft';
+
+CREATE UNIQUE INDEX uq_semantic_entity_tombstone
+  ON semantic_entities(org_id, name, COALESCE(connection_id, '__default__'))
+  WHERE status = 'draft_delete';

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -368,9 +368,12 @@ export const semanticEntities = pgTable(
     index("idx_semantic_entities_org").on(t.orgId),
     index("idx_semantic_entities_org_type").on(t.orgId, t.entityType),
     check("chk_semantic_entities_status", sql`status IN ('published', 'draft', 'draft_delete', 'archived')`),
-    uniqueIndex("uq_semantic_entity_published").on(t.orgId, t.name, t.connectionId).where(sql`status = 'published'`),
-    uniqueIndex("uq_semantic_entity_draft").on(t.orgId, t.name, t.connectionId).where(sql`status = 'draft'`),
-    uniqueIndex("uq_semantic_entity_tombstone").on(t.orgId, t.name, t.connectionId).where(sql`status = 'draft_delete'`),
+    // Partial unique indexes with COALESCE(connection_id, '__default__') to handle NULLs.
+    // Managed by raw SQL migration (0025) — Drizzle uniqueIndex().on() doesn't support expressions.
+    // Kept here as regular indexes so Drizzle is aware they exist (prevents drift warnings).
+    index("uq_semantic_entity_published").on(t.orgId, t.name).where(sql`status = 'published'`),
+    index("uq_semantic_entity_draft").on(t.orgId, t.name).where(sql`status = 'draft'`),
+    index("uq_semantic_entity_tombstone").on(t.orgId, t.name).where(sql`status = 'draft_delete'`),
   ],
 );
 

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -368,9 +368,11 @@ export const semanticEntities = pgTable(
     index("idx_semantic_entities_org").on(t.orgId),
     index("idx_semantic_entities_org_type").on(t.orgId, t.entityType),
     check("chk_semantic_entities_status", sql`status IN ('published', 'draft', 'draft_delete', 'archived')`),
-    // Partial unique indexes with COALESCE(connection_id, '__default__') to handle NULLs.
-    // Managed by raw SQL migration (0025) — Drizzle uniqueIndex().on() doesn't support expressions.
-    // Kept here as regular indexes so Drizzle is aware they exist (prevents drift warnings).
+    // IMPORTANT: These are placeholder stubs — the real indexes are UNIQUE on
+    // (org_id, name, COALESCE(connection_id, '__default__')) and are managed by
+    // raw SQL in migration 0025. Drizzle can't represent expression indexes,
+    // so these non-unique two-column approximations exist solely to suppress
+    // drift warnings. Do NOT rely on these for constraint reasoning.
     index("uq_semantic_entity_published").on(t.orgId, t.name).where(sql`status = 'published'`),
     index("uq_semantic_entity_draft").on(t.orgId, t.name).where(sql`status = 'draft'`),
     index("uq_semantic_entity_tombstone").on(t.orgId, t.name).where(sql`status = 'draft_delete'`),

--- a/packages/api/src/lib/logger.ts
+++ b/packages/api/src/lib/logger.ts
@@ -16,6 +16,8 @@ import type { AtlasUser } from "@atlas/api/lib/auth/types";
 interface RequestContext {
   requestId: string;
   user?: AtlasUser;
+  /** Resolved atlas mode for this request. When "published", tools should restrict to published entities only. */
+  atlasMode?: import("@useatlas/types/auth").AtlasMode;
 }
 
 const requestStore = new AsyncLocalStorage<RequestContext>();

--- a/packages/api/src/lib/semantic/entities.ts
+++ b/packages/api/src/lib/semantic/entities.ts
@@ -57,21 +57,45 @@ export async function upsertEntity(
 }
 
 /**
- * List all semantic entities for an org, optionally filtered by type.
+ * List all semantic entities for an org, optionally filtered by type and status.
+ *
+ * @param statusFilter - When provided, adds `AND status = $N` to the query.
+ *   Use `"published"` in published mode to hide draft/archived rows.
+ *   Omit (or pass undefined) in developer mode to return all rows.
  */
 export async function listEntities(
   orgId: string,
   entityType?: SemanticEntityType,
+  statusFilter?: SemanticEntityStatus,
 ): Promise<SemanticEntityRow[]> {
   if (!hasInternalDB()) return [];
 
   if (entityType) {
+    if (statusFilter) {
+      return internalQuery<SemanticEntityRow>(
+        `SELECT id, org_id, entity_type, name, yaml_content, connection_id, status, created_at, updated_at
+         FROM semantic_entities
+         WHERE org_id = $1 AND entity_type = $2 AND status = $3
+         ORDER BY name`,
+        [orgId, entityType, statusFilter],
+      );
+    }
     return internalQuery<SemanticEntityRow>(
       `SELECT id, org_id, entity_type, name, yaml_content, connection_id, status, created_at, updated_at
        FROM semantic_entities
        WHERE org_id = $1 AND entity_type = $2
        ORDER BY name`,
       [orgId, entityType],
+    );
+  }
+
+  if (statusFilter) {
+    return internalQuery<SemanticEntityRow>(
+      `SELECT id, org_id, entity_type, name, yaml_content, connection_id, status, created_at, updated_at
+       FROM semantic_entities
+       WHERE org_id = $1 AND status = $2
+       ORDER BY entity_type, name`,
+      [orgId, statusFilter],
     );
   }
 
@@ -124,23 +148,33 @@ export async function deleteEntity(
 }
 
 /**
- * Count entities for an org, optionally by type.
+ * Count entities for an org, optionally by type and status.
  */
 export async function countEntities(
   orgId: string,
   entityType?: SemanticEntityType,
+  statusFilter?: SemanticEntityStatus,
 ): Promise<number> {
   if (!hasInternalDB()) return 0;
 
-  const rows = entityType
-    ? await internalQuery<{ count: string }>(
-        `SELECT COUNT(*)::TEXT AS count FROM semantic_entities WHERE org_id = $1 AND entity_type = $2`,
-        [orgId, entityType],
-      )
-    : await internalQuery<{ count: string }>(
-        `SELECT COUNT(*)::TEXT AS count FROM semantic_entities WHERE org_id = $1`,
-        [orgId],
-      );
+  let query: string;
+  let params: unknown[];
+
+  if (entityType && statusFilter) {
+    query = `SELECT COUNT(*)::TEXT AS count FROM semantic_entities WHERE org_id = $1 AND entity_type = $2 AND status = $3`;
+    params = [orgId, entityType, statusFilter];
+  } else if (entityType) {
+    query = `SELECT COUNT(*)::TEXT AS count FROM semantic_entities WHERE org_id = $1 AND entity_type = $2`;
+    params = [orgId, entityType];
+  } else if (statusFilter) {
+    query = `SELECT COUNT(*)::TEXT AS count FROM semantic_entities WHERE org_id = $1 AND status = $2`;
+    params = [orgId, statusFilter];
+  } else {
+    query = `SELECT COUNT(*)::TEXT AS count FROM semantic_entities WHERE org_id = $1`;
+    params = [orgId];
+  }
+
+  const rows = await internalQuery<{ count: string }>(query, params);
   return parseInt(rows[0]?.count ?? "0", 10);
 }
 

--- a/packages/api/src/lib/semantic/whitelist.ts
+++ b/packages/api/src/lib/semantic/whitelist.ts
@@ -384,9 +384,10 @@ export function _resetPluginEntities(): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Per-org whitelist cache: Map<orgId, Map<connectionId, Set<tableName>>>.
+ * Per-org whitelist cache: Map<cacheKey, Map<connectionId, Set<tableName>>>.
+ * Cache key is `orgId` for developer mode or `${orgId}:published` for published mode.
  * Populated by `loadOrgWhitelist()` before the agent loop starts.
- * Invalidated by `invalidateOrgWhitelist(orgId)` on entity CRUD.
+ * Invalidated by `invalidateOrgWhitelist(orgId)` on entity CRUD (clears both modes).
  */
 const _orgWhitelists = new Map<string, Map<string, Set<string>>>();
 
@@ -480,9 +481,10 @@ export function getOrgWhitelistedTables(orgId: string, connectionId: string = "d
   return tables;
 }
 
-/** Invalidate the cached whitelist for an org (call after entity CRUD). */
+/** Invalidate the cached whitelist for an org (call after entity CRUD). Clears both developer and published mode caches. */
 export function invalidateOrgWhitelist(orgId: string): void {
   _orgWhitelists.delete(orgId);
+  _orgWhitelists.delete(`${orgId}:published`);
   invalidateOrgSemanticIndex(orgId);
 }
 

--- a/packages/api/src/lib/semantic/whitelist.ts
+++ b/packages/api/src/lib/semantic/whitelist.ts
@@ -394,17 +394,21 @@ const _orgWhitelists = new Map<string, Map<string, Set<string>>>();
  * Load the table whitelist for an org from the internal DB.
  *
  * Parses stored YAML content using the same EntityShape validation as
- * file-based loading. Results are cached per-org.
+ * file-based loading. Results are cached per-org (keyed by org + mode).
  *
  * @param orgId - Organization ID to load entities for.
+ * @param mode - Atlas mode. When "published", only published entities are
+ *   included. When "developer" (or omitted), all entities are included.
  * @returns Map of connectionId → Set<tableName>.
  */
-export async function loadOrgWhitelist(orgId: string): Promise<Map<string, Set<string>>> {
-  const cached = _orgWhitelists.get(orgId);
+export async function loadOrgWhitelist(orgId: string, mode?: "published" | "developer"): Promise<Map<string, Set<string>>> {
+  const cacheKey = mode === "published" ? `${orgId}:published` : orgId;
+  const cached = _orgWhitelists.get(cacheKey);
   if (cached) return cached;
 
   const { listEntities } = await import("@atlas/api/lib/semantic/entities");
-  const rows = await listEntities(orgId, "entity");
+  const statusFilter = mode === "published" ? "published" as const : undefined;
+  const rows = await listEntities(orgId, "entity", statusFilter);
 
   const byConnection = new Map<string, Set<string>>();
   let parseFailures = 0;
@@ -436,9 +440,9 @@ export async function loadOrgWhitelist(orgId: string): Promise<Map<string, Set<s
     log.error({ orgId, entityCount: rows.length, parseFailures }, "All org entities failed to parse — whitelist is empty");
   }
 
-  _orgWhitelists.set(orgId, byConnection);
+  _orgWhitelists.set(cacheKey, byConnection);
   const totalTables = Array.from(byConnection.values()).reduce((s, set) => s + set.size, 0);
-  log.info({ orgId, entityCount: rows.length, parsedCount: rows.length - parseFailures, tableCount: totalTables, connections: Array.from(byConnection.keys()) }, "Loaded org whitelist from DB");
+  log.info({ orgId, mode: mode ?? "developer", entityCount: rows.length, parsedCount: rows.length - parseFailures, tableCount: totalTables, connections: Array.from(byConnection.keys()) }, "Loaded org whitelist from DB");
   return byConnection;
 }
 
@@ -447,11 +451,15 @@ export async function loadOrgWhitelist(orgId: string): Promise<Map<string, Set<s
  *
  * Must be called after `loadOrgWhitelist(orgId)` — returns empty set if
  * the org whitelist has not been loaded yet.
+ *
+ * @param mode - Atlas mode. When "published", looks up the published-only cache.
+ *   Omit for developer mode (all entities).
  */
-export function getOrgWhitelistedTables(orgId: string, connectionId: string = "default"): Set<string> {
-  const byConnection = _orgWhitelists.get(orgId);
+export function getOrgWhitelistedTables(orgId: string, connectionId: string = "default", mode?: "published" | "developer"): Set<string> {
+  const cacheKey = mode === "published" ? `${orgId}:published` : orgId;
+  const byConnection = _orgWhitelists.get(cacheKey);
   if (!byConnection) {
-    log.warn({ orgId, connectionId }, "Org whitelist not loaded — all tables will be rejected");
+    log.warn({ orgId, connectionId, mode: mode ?? "developer" }, "Org whitelist not loaded — all tables will be rejected");
     return new Set();
   }
 

--- a/packages/api/src/lib/tools/check-distribution.ts
+++ b/packages/api/src/lib/tools/check-distribution.ts
@@ -42,7 +42,7 @@ export const checkDataDistribution = tool({
         : undefined;
 
       const whitelist = orgId
-        ? getOrgWhitelistedTables(orgId)
+        ? getOrgWhitelistedTables(orgId, "default", reqCtx?.atlasMode)
         : getWhitelistedTables(connId);
 
       if (!whitelist.has(table.toLowerCase())) {

--- a/packages/api/src/lib/tools/profile-table.ts
+++ b/packages/api/src/lib/tools/profile-table.ts
@@ -38,7 +38,7 @@ export const profileTable = tool({
         : undefined;
 
       const whitelist = orgId
-        ? getOrgWhitelistedTables(orgId)
+        ? getOrgWhitelistedTables(orgId, "default", reqCtx?.atlasMode)
         : getWhitelistedTables(connId);
 
       if (!whitelist.has(table.toLowerCase())) {

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -294,9 +294,10 @@ export function validateSQL(sql: string, connectionId?: string): SQLValidationRe
   } else {
     try {
       const tables = parser.tableList(trimmed, { database: parserDatabase(dbType, connectionId) });
-      const orgId = getRequestContext()?.user?.activeOrganizationId;
+      const sqlReqCtx = getRequestContext();
+      const orgId = sqlReqCtx?.user?.activeOrganizationId;
       const allowed = orgId
-        ? getOrgWhitelistedTables(orgId, connectionId)
+        ? getOrgWhitelistedTables(orgId, connectionId, sqlReqCtx?.atlasMode)
         : getWhitelistedTables(connectionId);
 
       for (const ref of tables) {

--- a/packages/api/src/lib/tools/validate-proposal.ts
+++ b/packages/api/src/lib/tools/validate-proposal.ts
@@ -120,7 +120,7 @@ export const validateProposal = tool({
         : undefined;
 
       const whitelist = orgId
-        ? getOrgWhitelistedTables(orgId)
+        ? getOrgWhitelistedTables(orgId, "default", reqCtx?.atlasMode)
         : getWhitelistedTables();
 
       if (!whitelist.has(payload.entityName.toLowerCase())) {


### PR DESCRIPTION
## Summary
- **Fix NULL-unsafe indexes (#1444)**: Migration 0025 drops and recreates partial unique indexes on `semantic_entities` using `COALESCE(connection_id, '__default__')` so NULLs are no longer treated as distinct — prevents duplicate published/draft/tombstone entities when `connection_id` is NULL.
- **Published mode query filtering (#1426)**: All read queries for connections, semantic entities, and prompt collections now respect `atlasMode` from `RequestContext`. Published mode returns only `status = 'published'` rows; developer mode returns all rows (published + draft + draft_delete).
- **9 new tests** verify mode-specific filtering and cache isolation.

### Files changed
| File | Change |
|------|--------|
| `migrations/0025_fix_null_unsafe_indexes.sql` | New migration: drop + recreate 3 indexes with COALESCE |
| `schema.ts` | Update Drizzle index definitions to match COALESCE pattern |
| `entities.ts` | Add optional `statusFilter` param to `listEntities()` and `countEntities()` |
| `whitelist.ts` | Mode-aware `loadOrgWhitelist()` and `getOrgWhitelistedTables()` with cache isolation |
| `prompts.ts` | Filter prompt collections by status when published |
| `admin-prompts.ts` | Filter prompt collections by status when published |
| `admin-connections.ts` | Filter visible connections by status when published |
| `admin.ts` | Filter org semantic entities by status, expose `status` field in response |
| `published-mode-filtering.test.ts` | 9 new tests for mode filtering + cache isolation |
| `migrate.test.ts`, `auth/migrate.test.ts` | Update migration counts for 0025 |

## Test plan
- [x] 9 new tests verify published-vs-developer filtering and cache isolation
- [x] All 308 existing test files pass (0 failures)
- [x] ESLint clean
- [x] TypeScript type check clean (tsgo)
- [x] Syncpack lint clean
- [x] Template drift check passed

Closes #1426
Closes #1444