### PR TITLE
fix: scaffold types.ts — define unpublished exports locally

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -1194,7 +1194,7 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
 - [x] Bundle cybersec + ecommerce semantic directories in Docker image (#1422, PR #1441)
 - [x] Docker COPY for demo-semantic and SQL seed symlinks (#1440, PR #1441)
 - [x] Partial unique indexes on semantic_entities are NULL-unsafe for connection_id (#1444, PR #1447)
-- [x] Scaffold template layout override — strip ModeBanner for standalone deploys (PR forthcoming)
+- [x] Scaffold template layout override — strip ModeBanner for standalone deploys (079f8996)
 
 ---
 

--- a/create-atlas/scripts/prepare-templates.sh
+++ b/create-atlas/scripts/prepare-templates.sh
@@ -69,13 +69,14 @@ done
 
 # ── Step 2b: Copy Next.js app pages + catch-all route into docker template ──
 # The docker template is a full-stack Next.js + embedded Hono API.
-# page.tsx uses the template override (standalone AtlasChat widget)
-# rather than packages/web's native SaaS chat page.
+# page.tsx and layout.tsx use template overrides:
+# page.tsx: standalone AtlasChat widget (not SaaS native chat page)
+# layout.tsx: no ModeBanner (developer/published mode is SaaS-only)
 OVERRIDES="$ROOT/overrides"
 echo ":: Syncing Next.js app pages → docker"
 mkdir -p "$TEMPLATES/docker/src/app/api/[...route]"
 cp "$OVERRIDES/page.tsx"   "$TEMPLATES/docker/src/app/"
-cp "$WEB_APP/layout.tsx"   "$TEMPLATES/docker/src/app/"
+cp "$OVERRIDES/layout.tsx" "$TEMPLATES/docker/src/app/"
 cp "$WEB_APP/error.tsx"    "$TEMPLATES/docker/src/app/"
 cp "$WEB_APP/globals.css"  "$TEMPLATES/docker/src/app/"
 cp "$NEXTJS_EXAMPLE/src/app/api/[...route]/route.ts" \

--- a/create-atlas/scripts/prepare-templates.sh
+++ b/create-atlas/scripts/prepare-templates.sh
@@ -104,6 +104,18 @@ for tpl in docker nextjs-standalone; do
   find "$TEMPLATES/$tpl/src" -name '*.test.tsx' -delete 2>/dev/null || true
 done
 
+# Post-process types.ts — define unpublished @useatlas/types exports locally.
+# The monorepo types.ts re-exports from @useatlas/types, but the published npm
+# package may lag behind. Replace re-exports that aren't in the published version
+# with local definitions so scaffold builds don't break.
+# TODO: remove this block after publishing @useatlas/types with ATLAS_MODES + ADMIN_ROLES
+for tpl in docker nextjs-standalone; do
+  TYPES_FILE="$TEMPLATES/$tpl/src/ui/lib/types.ts"
+  if [ -f "$TYPES_FILE" ]; then
+    sed -i 's|export { AUTH_MODES, ATLAS_MODES, ADMIN_ROLES, DB_TYPES } from "@useatlas/types";|export { AUTH_MODES, DB_TYPES } from "@useatlas/types";\nexport const ATLAS_MODES = ["developer", "published"] as const;\nexport const ADMIN_ROLES = ["admin", "owner", "platform_admin"] as const;|' "$TYPES_FILE"
+  fi
+done
+
 # Brand CSS — globals.css imports ../../brand.css (project root)
 for tpl in docker nextjs-standalone; do
   cp "$MONOREPO/packages/web/brand.css" "$TEMPLATES/$tpl/brand.css"


### PR DESCRIPTION
## Summary
- Deploy Validation CI is failing because `types.ts` re-exports `ADMIN_ROLES` and `ATLAS_MODES` from `@useatlas/types`, but the published `0.0.10` package doesn't include them yet (added in #1442)
- Turbopack validates all re-exports at build time, so the scaffold Docker build fails regardless of whether the exports are consumed
- Post-processes `types.ts` during template sync: replaces the combined re-export with local const definitions
- Also updates ROADMAP entry for scaffold layout override

## Test plan
- [ ] Deploy Validation CI passes (Scaffold docker + nextjs-standalone)
- [ ] Remove this workaround after publishing `@useatlas/types@0.0.11`