### PR TITLE
feat(mode): developer mode overlay queries (#1427)

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -1170,7 +1170,7 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
 
 ### Query Layer
 - [x] Published mode query filtering across connections, entities, prompts (#1426, PR #1447)
-- [ ] Developer mode overlay queries — entity CTE + union queries (#1427)
+- [x] Developer mode overlay queries — entity CTE + union queries (#1427)
 - [ ] Write path mode-awareness — draft creation, draft edits, tombstones (#1428)
 
 ### Publishing

--- a/bun.lock
+++ b/bun.lock
@@ -158,6 +158,7 @@
         "@types/pg": "^8.20.0",
         "drizzle-kit": "^0.31.10",
         "drizzle-orm": "^0.45.2",
+        "pg-mem": "^3.0.14",
       },
       "optionalDependencies": {
         "@vercel/sandbox": "^1.9.0",
@@ -2221,6 +2222,8 @@
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
+    "call-bind": ["call-bind@1.0.9", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "get-intrinsic": "^1.3.0", "set-function-length": "^1.2.2" } }, "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ=="],
+
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
@@ -2419,6 +2422,8 @@
 
     "defaults": ["defaults@1.0.4", "", { "dependencies": { "clone": "^1.0.2" } }, "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A=="],
 
+    "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
+
     "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
 
     "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
@@ -2442,6 +2447,8 @@
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
+    "discontinuous-range": ["discontinuous-range@1.0.0", "", {}, "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="],
 
     "discord-api-types": ["discord-api-types@0.37.120", "", {}, "sha512-7xpNK0EiWjjDFp2nAhHXezE4OUWm7s1zhc/UXXN6hnFFU8dfoPHgV0Hx0RPiCa3ILRpdeh152icc68DGCyXYIw=="],
 
@@ -2695,6 +2702,8 @@
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
+    "functional-red-black-tree": ["functional-red-black-tree@1.0.1", "", {}, "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g=="],
+
     "fuzzysort": ["fuzzysort@3.1.0", "", {}, "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ=="],
 
     "gaxios": ["gaxios@7.1.3", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2", "rimraf": "^5.0.1" } }, "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ=="],
@@ -2758,6 +2767,8 @@
     "happy-dom": ["happy-dom@20.8.9", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
@@ -2829,6 +2840,8 @@
 
     "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
 
+    "immutable": ["immutable@4.3.8", "", {}, "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw=="],
+
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "import-in-the-middle": ["import-in-the-middle@3.0.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-OnGy+eYT7wVejH2XWgLRgbmzujhhVIATQH0ztIeRilwHBjTeG3pD+XnH3PKX0r9gJ0BuJmJ68q/oh9qgXnNDQg=="],
@@ -2897,7 +2910,7 @@
 
     "is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
 
-    "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+    "isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
     "isbot": ["isbot@5.1.35", "", {}, "sha512-waFfC72ZNfwLLuJ2iLaoVaqcNo+CAaLR7xCpAn0Y5WfGzkNHv7ZN39Vbi1y+kb+Zs46XHOX3tZNExroFUPX+Kg=="],
 
@@ -2933,6 +2946,8 @@
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
+    "json-stable-stringify": ["json-stable-stringify@1.3.0", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "isarray": "^2.0.5", "jsonify": "^0.0.1", "object-keys": "^1.1.1" } }, "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg=="],
+
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
     "json-with-bigint": ["json-with-bigint@3.5.8", "", {}, "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw=="],
@@ -2940,6 +2955,8 @@
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
+
+    "jsonify": ["jsonify@0.0.1", "", {}, "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg=="],
 
     "jsonlines": ["jsonlines@0.1.1", "", {}, "sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA=="],
 
@@ -3055,7 +3072,7 @@
 
     "lowlight": ["lowlight@1.20.0", "", { "dependencies": { "fault": "^1.0.0", "highlight.js": "~10.7.0" } }, "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw=="],
 
-    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+    "lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
     "lru.min": ["lru.min@1.1.4", "", {}, "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA=="],
 
@@ -3217,6 +3234,8 @@
 
     "moment-timezone": ["moment-timezone@0.5.48", "", { "dependencies": { "moment": "^2.29.4" } }, "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw=="],
 
+    "moo": ["moo@0.5.3", "", {}, "sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA=="],
+
     "motion": ["motion@12.38.0", "", { "dependencies": { "framer-motion": "^12.38.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w=="],
 
     "motion-dom": ["motion-dom@12.38.0", "", { "dependencies": { "motion-utils": "^12.36.0" } }, "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA=="],
@@ -3252,6 +3271,8 @@
     "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "nearley": ["nearley@2.20.1", "", { "dependencies": { "commander": "^2.19.0", "moo": "^0.5.0", "railroad-diagrams": "^1.0.0", "randexp": "0.4.6" }, "bin": { "nearleyc": "bin/nearleyc.js", "nearley-test": "bin/nearley-test.js", "nearley-unparse": "bin/nearley-unparse.js", "nearley-railroad": "bin/nearley-railroad.js" } }, "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
@@ -3293,7 +3314,11 @@
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
+    "object-hash": ["object-hash@2.2.0", "", {}, "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw=="],
+
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
 
     "object-treeify": ["object-treeify@1.1.33", "", {}, "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A=="],
 
@@ -3397,6 +3422,8 @@
 
     "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
 
+    "pg-mem": ["pg-mem@3.0.14", "", { "dependencies": { "functional-red-black-tree": "^1.0.1", "immutable": "^4.3.4", "json-stable-stringify": "^1.0.1", "lru-cache": "^6.0.0", "moment": "^2.27.0", "object-hash": "^2.0.3", "pgsql-ast-parser": "^12.0.2" }, "peerDependencies": { "@mikro-orm/core": ">=4.5.3", "@mikro-orm/postgresql": ">=4.5.3", "knex": ">=0.20", "kysely": ">=0.26", "pg-promise": ">=10.8.7", "pg-server": "^0.1.5", "postgres": "^3.4.4", "slonik": ">=23.0.1", "typeorm": ">=0.2.29" }, "optionalPeers": ["@mikro-orm/core", "@mikro-orm/postgresql", "knex", "kysely", "pg-promise", "pg-server", "postgres", "slonik", "typeorm"] }, "sha512-G9m8OD0A+YS083smidSUJddTX2dEDPT8mRMG3sQGNiGfS/mkvAgd9Kf1/onD5633bFN7HcQK/Tn2x7qjBMFRUQ=="],
+
     "pg-numeric": ["pg-numeric@1.0.2", "", {}, "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw=="],
 
     "pg-pool": ["pg-pool@3.12.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-eIJ0DES8BLaziFHW7VgJEBPi5hg3Nyng5iKpYtj3wbcAUV9A1wLgWiY7ajf/f/oO1wfxt83phXPY8Emztg7ITg=="],
@@ -3406,6 +3433,8 @@
     "pg-types": ["pg-types@4.1.0", "", { "dependencies": { "pg-int8": "1.0.1", "pg-numeric": "1.0.2", "postgres-array": "~3.0.1", "postgres-bytea": "~3.0.0", "postgres-date": "~2.1.0", "postgres-interval": "^3.0.0", "postgres-range": "^1.1.1" } }, "sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg=="],
 
     "pgpass": ["pgpass@1.0.5", "", { "dependencies": { "split2": "^4.1.0" } }, "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug=="],
+
+    "pgsql-ast-parser": ["pgsql-ast-parser@12.0.2", "", { "dependencies": { "moo": "^0.5.1", "nearley": "^2.19.5" } }, "sha512-1WWa96Sw6h4uv9GLw98EzH/+xoBTC8j2TwV/AMW3E+Ir/fHOu/jLLbj6kPiz3y2bGISTKNYvKWwHoqvQ5FLuAw=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -3496,6 +3525,10 @@
     "quickjs-emscripten-core": ["quickjs-emscripten-core@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg=="],
 
     "radix-ui": ["radix-ui@1.4.3", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-accessible-icon": "1.1.7", "@radix-ui/react-accordion": "1.2.12", "@radix-ui/react-alert-dialog": "1.1.15", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-aspect-ratio": "1.1.7", "@radix-ui/react-avatar": "1.1.10", "@radix-ui/react-checkbox": "1.3.3", "@radix-ui/react-collapsible": "1.1.12", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-context-menu": "2.2.16", "@radix-ui/react-dialog": "1.1.15", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-dropdown-menu": "2.1.16", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-form": "0.1.8", "@radix-ui/react-hover-card": "1.1.15", "@radix-ui/react-label": "2.1.7", "@radix-ui/react-menu": "2.1.16", "@radix-ui/react-menubar": "1.1.16", "@radix-ui/react-navigation-menu": "1.2.14", "@radix-ui/react-one-time-password-field": "0.1.8", "@radix-ui/react-password-toggle-field": "0.1.3", "@radix-ui/react-popover": "1.1.15", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-progress": "1.1.7", "@radix-ui/react-radio-group": "1.3.8", "@radix-ui/react-roving-focus": "1.1.11", "@radix-ui/react-scroll-area": "1.2.10", "@radix-ui/react-select": "2.2.6", "@radix-ui/react-separator": "1.1.7", "@radix-ui/react-slider": "1.3.6", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-switch": "1.2.6", "@radix-ui/react-tabs": "1.1.13", "@radix-ui/react-toast": "1.2.15", "@radix-ui/react-toggle": "1.1.10", "@radix-ui/react-toggle-group": "1.1.11", "@radix-ui/react-toolbar": "1.1.11", "@radix-ui/react-tooltip": "1.2.8", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-escape-keydown": "1.1.1", "@radix-ui/react-use-is-hydrated": "0.1.0", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA=="],
+
+    "railroad-diagrams": ["railroad-diagrams@1.0.0", "", {}, "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="],
+
+    "randexp": ["randexp@0.4.6", "", { "dependencies": { "discontinuous-range": "1.0.0", "ret": "~0.1.10" } }, "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ=="],
 
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
@@ -3601,6 +3634,8 @@
 
     "restore-cursor": ["restore-cursor@3.1.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA=="],
 
+    "ret": ["ret@0.1.15", "", {}, "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="],
+
     "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
     "rettime": ["rettime@0.10.1", "", {}, "sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw=="],
@@ -3658,6 +3693,8 @@
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
     "set-cookie-parser": ["set-cookie-parser@3.0.1", "", {}, "sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q=="],
+
+    "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
     "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
 
@@ -4009,7 +4046,7 @@
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
-    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+    "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
@@ -4052,6 +4089,8 @@
     "@azure/msal-node/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -4307,6 +4346,8 @@
 
     "msw/path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
+    "nearley/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
+
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
@@ -4437,6 +4478,8 @@
 
     "@azure/identity/open/wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
+    "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
     "@dotenvx/dotenvx/execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 
     "@dotenvx/dotenvx/execa/human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
@@ -4517,6 +4560,8 @@
 
     "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
+    "archiver-utils/readable-stream/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+
     "archiver-utils/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "archiver-utils/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
@@ -4591,6 +4636,8 @@
 
     "drizzle-kit/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
+    "duplexer2/readable-stream/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+
     "duplexer2/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "duplexer2/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
@@ -4661,9 +4708,13 @@
 
     "inquirer/ora/log-symbols": ["log-symbols@4.1.0", "", { "dependencies": { "chalk": "^4.1.0", "is-unicode-supported": "^0.1.0" } }, "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg=="],
 
+    "jszip/readable-stream/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+
     "jszip/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "jszip/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "lazystream/readable-stream/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
     "lazystream/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
@@ -4808,6 +4859,8 @@
     "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
 
     "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "unzipper/readable-stream/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
     "unzipper/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -78,6 +78,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/pg": "^8.20.0",
     "drizzle-kit": "^0.31.10",
-    "drizzle-orm": "^0.45.2"
+    "drizzle-orm": "^0.45.2",
+    "pg-mem": "^3.0.14"
   }
 }

--- a/packages/api/src/api/__tests__/admin-connections.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections.test.ts
@@ -81,13 +81,12 @@ function setPlatformAdmin(orgId: string): void {
   mocks.setPlatformAdmin(orgId);
 }
 
-function adminRequest(urlPath: string, method = "GET", body?: unknown): Request {
-  const opts: RequestInit = {
-    method,
-    headers: { Authorization: "Bearer test-key" },
-  };
+function adminRequest(urlPath: string, method = "GET", body?: unknown, cookie?: string): Request {
+  const headers: Record<string, string> = { Authorization: "Bearer test-key" };
+  if (cookie) headers.Cookie = cookie;
+  const opts: RequestInit = { method, headers };
   if (body) {
-    opts.headers = { ...opts.headers, "Content-Type": "application/json" };
+    headers["Content-Type"] = "application/json";
     opts.body = JSON.stringify(body);
   }
   return new Request(`http://localhost${urlPath}`, opts);
@@ -587,6 +586,49 @@ describe("admin connections — org scoping", () => {
       const body = (await res.json()) as any;
       expect(body.id).toBe("warehouse");
       expect(body.managed).toBe(true);
+    });
+  });
+
+  // ─── GET /connections — mode-aware status clause (#1427 / #1455) ──────
+
+  describe("GET /connections — mode-aware status filter", () => {
+    function findVisibleConnectionsCall(): [string, unknown[]] | undefined {
+      const call = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) =>
+          typeof sql === "string" &&
+          sql.includes("SELECT id FROM connections WHERE org_id"),
+      );
+      return call as [string, unknown[]] | undefined;
+    }
+
+    it("published mode restricts visible connections to status = 'published'", async () => {
+      setOrgAdmin("org-alpha");
+      mocks.mockInternalQuery.mockResolvedValue([]);
+
+      const res = await app.fetch(adminRequest("/api/v1/admin/connections"));
+      expect(res.status).toBe(200);
+
+      const call = findVisibleConnectionsCall();
+      expect(call).toBeDefined();
+      expect(call![0]).toContain("status = 'published'");
+      expect(call![0]).not.toContain("status IN ('published', 'draft')");
+    });
+
+    it("developer mode expands to status IN ('published', 'draft') when cookie is set", async () => {
+      setOrgAdmin("org-alpha");
+      mocks.mockInternalQuery.mockResolvedValue([]);
+
+      const res = await app.fetch(
+        adminRequest("/api/v1/admin/connections", "GET", undefined, "atlas-mode=developer"),
+      );
+      expect(res.status).toBe(200);
+
+      const call = findVisibleConnectionsCall();
+      expect(call).toBeDefined();
+      expect(call![0]).toContain("status IN ('published', 'draft')");
+      expect(call![0]).not.toContain("status = 'published'");
+      // Archived rows are always excluded — never appears in either mode
+      expect(call![0]).not.toContain("archived");
     });
   });
 });

--- a/packages/api/src/api/__tests__/prompts.test.ts
+++ b/packages/api/src/api/__tests__/prompts.test.ts
@@ -35,24 +35,28 @@ const { app } = await import("../index");
 
 // --- Helpers ---
 
-function userReq(method: string, urlPath: string, body?: unknown) {
+function userReq(method: string, urlPath: string, body?: unknown, cookie?: string) {
   const suffix = urlPath === "/" ? "" : urlPath;
   const url = `http://localhost/api/v1/prompts${suffix}`;
-  const init: RequestInit = { method, headers: { Authorization: "Bearer test" } };
+  const headers: Record<string, string> = { Authorization: "Bearer test" };
+  if (cookie) headers.Cookie = cookie;
+  const init: RequestInit = { method, headers };
   if (body) {
     init.body = JSON.stringify(body);
-    (init.headers as Record<string, string>)["Content-Type"] = "application/json";
+    headers["Content-Type"] = "application/json";
   }
   return app.fetch(new Request(url, init));
 }
 
-function adminReq(method: string, urlPath: string, body?: unknown) {
+function adminReq(method: string, urlPath: string, body?: unknown, cookie?: string) {
   const suffix = urlPath === "/" ? "" : urlPath;
   const url = `http://localhost/api/v1/admin/prompts${suffix}`;
-  const init: RequestInit = { method, headers: { Authorization: "Bearer test" } };
+  const headers: Record<string, string> = { Authorization: "Bearer test" };
+  if (cookie) headers.Cookie = cookie;
+  const init: RequestInit = { method, headers };
   if (body) {
     init.body = JSON.stringify(body);
-    (init.headers as Record<string, string>)["Content-Type"] = "application/json";
+    headers["Content-Type"] = "application/json";
   }
   return app.fetch(new Request(url, init));
 }
@@ -160,6 +164,32 @@ describe("user-facing prompt routes", () => {
       expect(res.status).toBe(429);
       const body = (await res.json()) as Record<string, unknown>;
       expect(body.retryAfterSeconds).toBeDefined();
+    });
+
+    it("published mode restricts collections to status = 'published' (#1427 / #1455)", async () => {
+      mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+      const res = await userReq("GET", "/");
+      expect(res.status).toBe(200);
+      const calls = mocks.mockInternalQuery.mock.calls;
+      const listCall = calls.find(
+        ([sql]) => typeof sql === "string" && sql.includes("FROM prompt_collections"),
+      );
+      expect(listCall).toBeDefined();
+      expect(listCall![0] as string).toContain("status = 'published'");
+      expect(listCall![0] as string).not.toContain("status IN");
+    });
+
+    it("developer mode expands to status IN ('published', 'draft') via cookie", async () => {
+      mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+      const res = await userReq("GET", "/", undefined, "atlas-mode=developer");
+      expect(res.status).toBe(200);
+      const calls = mocks.mockInternalQuery.mock.calls;
+      const listCall = calls.find(
+        ([sql]) => typeof sql === "string" && sql.includes("FROM prompt_collections"),
+      );
+      expect(listCall).toBeDefined();
+      expect(listCall![0] as string).toContain("status IN ('published', 'draft')");
+      expect(listCall![0] as string).not.toContain("archived");
     });
 
     it("queries without org_id filter in single-tenant mode", async () => {
@@ -280,6 +310,29 @@ describe("admin prompt routes", () => {
       const body = (await res.json()) as Record<string, unknown>;
       expect(body.collections).toBeArray();
       expect(body.total).toBe(2);
+    });
+
+    it("published mode restricts to status = 'published' (#1427 / #1455)", async () => {
+      mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+      const res = await adminReq("GET", "/");
+      expect(res.status).toBe(200);
+      const listCall = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) => typeof sql === "string" && sql.includes("FROM prompt_collections"),
+      );
+      expect(listCall).toBeDefined();
+      expect(listCall![0] as string).toContain("status = 'published'");
+    });
+
+    it("developer mode expands to status IN ('published', 'draft') via cookie", async () => {
+      mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+      const res = await adminReq("GET", "/", undefined, "atlas-mode=developer");
+      expect(res.status).toBe(200);
+      const listCall = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) => typeof sql === "string" && sql.includes("FROM prompt_collections"),
+      );
+      expect(listCall).toBeDefined();
+      expect(listCall![0] as string).toContain("status IN ('published', 'draft')");
+      expect(listCall![0] as string).not.toContain("archived");
     });
   });
 

--- a/packages/api/src/api/routes/__tests__/mode-resolution.test.ts
+++ b/packages/api/src/api/routes/__tests__/mode-resolution.test.ts
@@ -46,7 +46,7 @@ mock.module("@atlas/api/lib/residency/readonly", () => ({
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
 
-const { resolveMode } = await import("../middleware");
+const { resolveMode, buildUnionStatusClause } = await import("../middleware");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -210,6 +210,35 @@ describe("resolveMode", () => {
 
   it("ignores invalid header value and defaults to published", () => {
     expect(resolveMode(null, "foobar", adminAuth())).toBe("published");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildUnionStatusClause — shared helper for connections and prompt collections
+// ---------------------------------------------------------------------------
+
+describe("buildUnionStatusClause", () => {
+  it("published mode restricts to status = 'published'", () => {
+    expect(buildUnionStatusClause("published")).toBe(" AND status = 'published'");
+  });
+
+  it("developer mode includes draft alongside published", () => {
+    expect(buildUnionStatusClause("developer")).toBe(" AND status IN ('published', 'draft')");
+  });
+
+  it("never returns archived in either mode (archived is always excluded)", () => {
+    expect(buildUnionStatusClause("published")).not.toContain("archived");
+    expect(buildUnionStatusClause("developer")).not.toContain("archived");
+  });
+
+  it("developer mode never surfaces draft_delete via the simple union", () => {
+    // Tombstones only apply to semantic_entities (CTE overlay). Connections
+    // and prompt collections don't use draft_delete.
+    expect(buildUnionStatusClause("developer")).not.toContain("draft_delete");
+  });
+
+  it("undefined mode defaults to published (most restrictive)", () => {
+    expect(buildUnionStatusClause(undefined)).toBe(" AND status = 'published'");
   });
 });
 

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -17,6 +17,7 @@ import { runHandler } from "@atlas/api/lib/effect/hono";
 import { checkResourceLimit } from "@atlas/api/lib/billing/enforcement";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
+import { buildUnionStatusClause } from "./middleware";
 
 const log = createLogger("admin-connections");
 
@@ -33,7 +34,9 @@ function getAtlasMode(c: { get(key: string): unknown }): import("@useatlas/types
  * Get the set of connection IDs visible to a workspace admin.
  * Returns null for platform admins (they see all connections).
  *
- * @param mode - Atlas mode. When "published", only published connections are visible.
+ * @param mode - Atlas mode. Published mode sees only published connections;
+ *   developer mode additionally sees drafts. Archived connections are hidden
+ *   in both modes.
  */
 async function getVisibleConnectionIds(
   orgId: string,
@@ -46,7 +49,7 @@ async function getVisibleConnectionIds(
   const visible = new Set<string>(["default"]);
 
   if (hasInternalDB()) {
-    const statusClause = mode === "published" ? " AND status = 'published'" : "";
+    const statusClause = buildUnionStatusClause(mode);
     const rows = await internalQuery<{ id: string }>(
       `SELECT id FROM connections WHERE org_id = $1${statusClause}`,
       [orgId],

--- a/packages/api/src/api/routes/admin-prompts.ts
+++ b/packages/api/src/api/routes/admin-prompts.ts
@@ -15,6 +15,7 @@ import { internalQuery } from "@atlas/api/lib/db/internal";
 import type { PromptCollection, PromptItem } from "@useatlas/types";
 import { ErrorSchema, AuthErrorSchema, createIdParamSchema, createParamSchema, createListResponseSchema, DeletedResponseSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
+import { buildUnionStatusClause } from "./middleware";
 
 const log = createLogger("admin-prompts");
 
@@ -486,7 +487,7 @@ adminPrompts.openapi(listCollectionsRoute, async (c) => {
     const { orgId } = yield* AuthContext;
     const { atlasMode } = yield* RequestContext;
 
-    const statusClause = atlasMode === "published" ? " AND status = 'published'" : "";
+    const statusClause = buildUnionStatusClause(atlasMode);
 
     let rows: Record<string, unknown>[];
     if (orgId) {

--- a/packages/api/src/api/routes/middleware.ts
+++ b/packages/api/src/api/routes/middleware.ts
@@ -378,6 +378,26 @@ function parseModeFromCookie(cookieHeader: string | null): string | undefined {
 }
 
 /**
+ * Build the SQL status clause for a query over `connections` or
+ * `prompt_collections`.
+ *
+ * - Published mode: `AND status = 'published'`
+ * - Developer mode: `AND status IN ('published', 'draft')` — drafts overlay,
+ *   archived rows always excluded
+ *
+ * Returns a leading-space string ready to concatenate into a WHERE clause.
+ * Not used for `semantic_entities`; that table needs the full CTE overlay
+ * (see `listEntitiesWithOverlay` in `lib/semantic/entities.ts`).
+ */
+export function buildUnionStatusClause(
+  mode: import("@useatlas/types/auth").AtlasMode | undefined,
+): string {
+  return mode === "developer"
+    ? " AND status IN ('published', 'draft')"
+    : " AND status = 'published'";
+}
+
+/**
  * Resolve the effective atlas mode for this request.
  *
  * Priority: `atlas-mode` cookie → `X-Atlas-Mode` header → default (`published`).

--- a/packages/api/src/api/routes/prompts.ts
+++ b/packages/api/src/api/routes/prompts.ts
@@ -19,7 +19,7 @@ import type { PromptCollection, PromptItem } from "@useatlas/types";
 
 const log = createLogger("prompts");
 import { ErrorSchema } from "./shared-schemas";
-import { standardAuth, requestContext, type AuthEnv } from "./middleware";
+import { standardAuth, requestContext, buildUnionStatusClause, type AuthEnv } from "./middleware";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -173,7 +173,7 @@ prompts.openapi(listCollectionsRoute, async (c) => {
       return c.json({ collections: [] }, 200);
     }
 
-    const statusClause = atlasMode === "published" ? " AND status = 'published'" : "";
+    const statusClause = buildUnionStatusClause(atlasMode);
 
     let rows: Record<string, unknown>[];
     if (orgId) {
@@ -205,7 +205,7 @@ prompts.openapi(getCollectionRoute, async (c) => {
     }
 
     const { id } = c.req.valid("param");
-    const statusClause = atlasMode === "published" ? " AND status = 'published'" : "";
+    const statusClause = buildUnionStatusClause(atlasMode);
 
     let collectionRows: Record<string, unknown>[];
     if (orgId) {

--- a/packages/api/src/lib/__tests__/published-mode-filtering.test.ts
+++ b/packages/api/src/lib/__tests__/published-mode-filtering.test.ts
@@ -29,6 +29,12 @@ const mockListEntities = mock(
     return Promise.resolve(storedEntities);
   },
 );
+// Developer-mode overlay: returns published + draft rows, excludes draft_delete/archived.
+// Close enough to the real CTE behavior for whitelist tests — drafts supersede drops
+// are handled at SQL level but this mock doesn't need to model tombstones for whitelisting.
+const mockListEntitiesWithOverlay = mock((_orgId: string, _entityType?: string) =>
+  Promise.resolve(storedEntities.filter((e) => e.status === "published" || e.status === "draft")),
+);
 const mockGetEntity = mock((): Promise<SemanticEntityRow | null> => Promise.resolve(null));
 const mockUpsertEntity = mock((): Promise<void> => Promise.resolve());
 const mockDeleteEntity = mock((): Promise<boolean> => Promise.resolve(false));
@@ -42,6 +48,7 @@ const SEMANTIC_ENTITY_STATUSES = ["published", "draft", "draft_delete", "archive
 
 mock.module("@atlas/api/lib/semantic/entities", () => ({
   listEntities: mockListEntities,
+  listEntitiesWithOverlay: mockListEntitiesWithOverlay,
   getEntity: mockGetEntity,
   upsertEntity: mockUpsertEntity,
   deleteEntity: mockDeleteEntity,
@@ -93,8 +100,9 @@ describe("published mode filtering", () => {
   beforeEach(() => {
     _resetOrgWhitelists();
     mockListEntities.mockReset();
+    mockListEntitiesWithOverlay.mockReset();
     storedEntities = [];
-    // Re-wire mock to filter by status
+    // Re-wire mocks to filter by status
     mockListEntities.mockImplementation(
       (_orgId: string, _entityType?: string, statusFilter?: SemanticEntityStatus) => {
         if (statusFilter) {
@@ -103,10 +111,14 @@ describe("published mode filtering", () => {
         return Promise.resolve(storedEntities);
       },
     );
+    mockListEntitiesWithOverlay.mockImplementation(
+      (_orgId: string, _entityType?: string) =>
+        Promise.resolve(storedEntities.filter((e) => e.status === "published" || e.status === "draft")),
+    );
   });
 
-  describe("listEntities statusFilter", () => {
-    it("passes statusFilter to listEntities when mode is published", async () => {
+  describe("entity loader dispatch by mode", () => {
+    it("published mode calls listEntities with 'published' status filter", async () => {
       storedEntities = [
         makeEntityRow("users", "users", "published"),
         makeEntityRow("users", "users", "draft"),
@@ -114,26 +126,27 @@ describe("published mode filtering", () => {
       ];
 
       await loadOrgWhitelist("org-1", "published");
-      // listEntities should have been called with "published" status filter
       expect(mockListEntities).toHaveBeenCalledWith("org-1", "entity", "published");
+      expect(mockListEntitiesWithOverlay).not.toHaveBeenCalled();
     });
 
-    it("does not pass statusFilter when mode is developer", async () => {
+    it("developer mode calls listEntitiesWithOverlay (not listEntities)", async () => {
       storedEntities = [
         makeEntityRow("users", "users", "published"),
         makeEntityRow("users", "users", "draft"),
       ];
 
       await loadOrgWhitelist("org-1", "developer");
-      // listEntities should have been called without status filter
-      expect(mockListEntities).toHaveBeenCalledWith("org-1", "entity", undefined);
+      expect(mockListEntitiesWithOverlay).toHaveBeenCalledWith("org-1", "entity");
+      expect(mockListEntities).not.toHaveBeenCalled();
     });
 
-    it("does not pass statusFilter when mode is omitted", async () => {
+    it("omitted mode falls back to listEntities with no status filter", async () => {
       storedEntities = [makeEntityRow("users", "users", "published")];
 
       await loadOrgWhitelist("org-1");
       expect(mockListEntities).toHaveBeenCalledWith("org-1", "entity", undefined);
+      expect(mockListEntitiesWithOverlay).not.toHaveBeenCalled();
     });
   });
 
@@ -165,8 +178,8 @@ describe("published mode filtering", () => {
     });
   });
 
-  describe("developer mode returns all entities", () => {
-    it("developer mode whitelist contains all entity tables", async () => {
+  describe("developer mode returns overlay (published + draft, no tombstones)", () => {
+    it("developer mode whitelist contains published + draft entity tables, excludes tombstones", async () => {
       storedEntities = [
         makeEntityRow("users", "users", "published"),
         makeEntityRow("orders", "orders", "draft"),
@@ -177,10 +190,11 @@ describe("published mode filtering", () => {
       const tables = result.get("default") ?? new Set();
       expect(tables.has("users")).toBe(true);
       expect(tables.has("orders")).toBe(true);
-      expect(tables.has("events")).toBe(true);
+      // draft_delete targets are hidden by the overlay CTE
+      expect(tables.has("events")).toBe(false);
     });
 
-    it("getOrgWhitelistedTables in developer mode returns all tables", async () => {
+    it("getOrgWhitelistedTables in developer mode includes drafts alongside published", async () => {
       storedEntities = [
         makeEntityRow("users", "users", "published"),
         makeEntityRow("orders", "orders", "draft"),
@@ -206,14 +220,15 @@ describe("published mode filtering", () => {
       expect(publishedTables.has("users")).toBe(true);
       expect(publishedTables.has("orders")).toBe(false);
 
-      // Load developer mode — should call listEntities again (separate cache)
+      // Load developer mode — dispatches to the overlay loader (separate cache)
       await loadOrgWhitelist("org-1", "developer");
       const devTables = getOrgWhitelistedTables("org-1", "default", "developer");
       expect(devTables.has("users")).toBe(true);
       expect(devTables.has("orders")).toBe(true);
 
-      // Both caches should coexist
-      expect(mockListEntities).toHaveBeenCalledTimes(2);
+      // Both caches should coexist — published hit listEntities, developer hit the overlay
+      expect(mockListEntities).toHaveBeenCalledTimes(1);
+      expect(mockListEntitiesWithOverlay).toHaveBeenCalledTimes(1);
     });
 
     it("published cache hit does not return developer results", async () => {
@@ -241,15 +256,17 @@ describe("published mode filtering", () => {
       // Load both caches
       await loadOrgWhitelist("org-1", "published");
       await loadOrgWhitelist("org-1", "developer");
-      expect(mockListEntities).toHaveBeenCalledTimes(2);
+      expect(mockListEntities).toHaveBeenCalledTimes(1);
+      expect(mockListEntitiesWithOverlay).toHaveBeenCalledTimes(1);
 
       // Invalidate — should clear both
       invalidateOrgWhitelist("org-1");
 
-      // Reload both — should call listEntities again (cache miss)
+      // Reload both — should hit the DB again (cache miss)
       await loadOrgWhitelist("org-1", "published");
       await loadOrgWhitelist("org-1", "developer");
-      expect(mockListEntities).toHaveBeenCalledTimes(4); // 2 original + 2 reloads
+      expect(mockListEntities).toHaveBeenCalledTimes(2);
+      expect(mockListEntitiesWithOverlay).toHaveBeenCalledTimes(2);
     });
 
     it("invalidateOrgWhitelist clears published cache even when developer cache was not loaded", async () => {

--- a/packages/api/src/lib/semantic/__tests__/overlay-queries-integration.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/overlay-queries-integration.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Integration test for the developer-mode overlay CTE (#1427).
+ *
+ * Runs `listEntitiesWithOverlay` against an in-process Postgres (pg-mem) to
+ * verify the CTE's logical semantics — not just its SQL shape. Closes the
+ * gap flagged in the pr-test-analyzer review (#1454): shape-only regex tests
+ * can't catch a reordering of the `CASE` arms or a broken `DISTINCT ON`
+ * projection.
+ *
+ * Covers the five acceptance-matrix cases from #1427:
+ *   1. Published-only entity → visible
+ *   2. Draft-only entity → visible
+ *   3. Draft + published for the same key → draft wins, published hidden
+ *   4. `draft_delete` tombstone for a published key → both hidden
+ *   5. Entity whose parent connection is `archived` → hidden even if published
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "bun:test";
+import { newDb, type IMemoryDb } from "pg-mem";
+import type { InternalPool } from "@atlas/api/lib/db/internal";
+import {
+  _resetPool,
+  hasInternalDB as _hasInternalDB,
+} from "@atlas/api/lib/db/internal";
+import { listEntitiesWithOverlay } from "@atlas/api/lib/semantic/entities";
+
+// ---------------------------------------------------------------------------
+// In-memory Postgres wired into the internal DB pool singleton
+// ---------------------------------------------------------------------------
+
+let db: IMemoryDb;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- pg-mem's adapter returns a dynamic Pool constructor; not worth typing for tests
+let pool: any;
+let originalDatabaseUrl: string | undefined;
+
+beforeAll(async () => {
+  // `hasInternalDB()` reads DATABASE_URL; pg-mem doesn't need a URL but the
+  // guard runs before the pool is consulted.
+  originalDatabaseUrl = process.env.DATABASE_URL;
+  process.env.DATABASE_URL = "postgresql://pgmem/atlas";
+
+  db = newDb();
+
+  // Minimal schema — only the columns referenced by the overlay CTE.
+  db.public.none(`
+    CREATE TABLE connections (
+      id TEXT NOT NULL,
+      org_id TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'published',
+      PRIMARY KEY (id, org_id)
+    );
+    CREATE TABLE semantic_entities (
+      id TEXT PRIMARY KEY,
+      org_id TEXT NOT NULL,
+      entity_type TEXT NOT NULL,
+      name TEXT NOT NULL,
+      yaml_content TEXT NOT NULL,
+      connection_id TEXT,
+      status TEXT NOT NULL DEFAULT 'published',
+      created_at TEXT NOT NULL DEFAULT 'now',
+      updated_at TEXT NOT NULL DEFAULT 'now'
+    );
+  `);
+
+  const { Pool } = db.adapters.createPg();
+  pool = new Pool();
+
+  // Verify `listEntitiesWithOverlay` takes the raw-pool path by clearing any
+  // Effect-managed SqlClient and installing our pg-mem pool.
+  _resetPool(pool as unknown as InternalPool, null);
+
+  // Sanity check — the hasInternalDB guard must pass so the overlay runs.
+  if (!_hasInternalDB()) {
+    throw new Error("hasInternalDB() returned false despite DATABASE_URL — test setup bug");
+  }
+});
+
+afterAll(async () => {
+  _resetPool(null, null);
+  if (originalDatabaseUrl === undefined) {
+    delete process.env.DATABASE_URL;
+  } else {
+    process.env.DATABASE_URL = originalDatabaseUrl;
+  }
+  if (pool) await pool.end();
+});
+
+beforeEach(() => {
+  db.public.none(`TRUNCATE semantic_entities; TRUNCATE connections;`);
+});
+
+// ---------------------------------------------------------------------------
+// Fixture helpers — thin wrappers around raw INSERTs
+// ---------------------------------------------------------------------------
+
+function seedConnection(id: string, status: "published" | "draft" | "archived" = "published"): void {
+  db.public.none(
+    `INSERT INTO connections (id, org_id, status) VALUES ('${id}', 'org-1', '${status}')`,
+  );
+}
+
+function seedEntity(opts: {
+  id: string;
+  name: string;
+  status: "published" | "draft" | "draft_delete" | "archived";
+  connectionId?: string | null;
+  yaml?: string;
+}): void {
+  const conn = opts.connectionId === undefined ? "NULL" : opts.connectionId === null ? "NULL" : `'${opts.connectionId}'`;
+  const yaml = (opts.yaml ?? `table: ${opts.name}`).replace(/'/g, "''");
+  db.public.none(
+    `INSERT INTO semantic_entities (id, org_id, entity_type, name, yaml_content, connection_id, status)
+     VALUES ('${opts.id}', 'org-1', 'entity', '${opts.name}', '${yaml}', ${conn}, '${opts.status}')`,
+  );
+}
+
+function rowsByName(rows: Array<{ name: string; status: string }>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const r of rows) out[r.name] = r.status;
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance matrix
+// ---------------------------------------------------------------------------
+
+describe("listEntitiesWithOverlay — acceptance matrix against real Postgres", () => {
+  it("case 1: published-only entity is visible", async () => {
+    seedConnection("warehouse");
+    seedEntity({ id: "e1", name: "users", status: "published", connectionId: "warehouse" });
+
+    const rows = await listEntitiesWithOverlay("org-1", "entity");
+    expect(rowsByName(rows)).toEqual({ users: "published" });
+  });
+
+  it("case 2: draft-only entity is visible", async () => {
+    seedConnection("warehouse");
+    seedEntity({ id: "e1", name: "events", status: "draft", connectionId: "warehouse" });
+
+    const rows = await listEntitiesWithOverlay("org-1", "entity");
+    expect(rowsByName(rows)).toEqual({ events: "draft" });
+  });
+
+  it("case 3: draft supersedes published for the same (name, connection_id) key", async () => {
+    seedConnection("warehouse");
+    seedEntity({ id: "e-pub", name: "users", status: "published", connectionId: "warehouse" });
+    seedEntity({ id: "e-draft", name: "users", status: "draft", connectionId: "warehouse" });
+
+    const rows = await listEntitiesWithOverlay("org-1", "entity");
+    // Exactly one row — the draft wins, the published is shadowed
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("draft");
+    expect(rows[0].id).toBe("e-draft");
+  });
+
+  it("case 4: draft_delete tombstone hides the published entity it targets", async () => {
+    seedConnection("warehouse");
+    seedEntity({ id: "e-pub", name: "orders", status: "published", connectionId: "warehouse" });
+    seedEntity({ id: "e-tomb", name: "orders", status: "draft_delete", connectionId: "warehouse" });
+
+    const rows = await listEntitiesWithOverlay("org-1", "entity");
+    expect(rows).toHaveLength(0);
+  });
+
+  it("case 5: entity whose parent connection is archived is excluded", async () => {
+    seedConnection("legacy", "archived");
+    seedEntity({ id: "e1", name: "old_logs", status: "published", connectionId: "legacy" });
+
+    // Seed an unrelated visible entity to prove the filter is connection-scoped,
+    // not a blanket "return empty".
+    seedConnection("warehouse");
+    seedEntity({ id: "e2", name: "users", status: "published", connectionId: "warehouse" });
+
+    const rows = await listEntitiesWithOverlay("org-1", "entity");
+    expect(rowsByName(rows)).toEqual({ users: "published" });
+  });
+
+  it("combined: all five cases together reduce to the expected visible set", async () => {
+    seedConnection("warehouse");
+    seedConnection("legacy", "archived");
+
+    // Case 1 — published-only
+    seedEntity({ id: "e1", name: "users", status: "published", connectionId: "warehouse" });
+    // Case 2 — draft-only
+    seedEntity({ id: "e2", name: "events", status: "draft", connectionId: "warehouse" });
+    // Case 3 — draft supersedes published
+    seedEntity({ id: "e3a", name: "orders", status: "published", connectionId: "warehouse" });
+    seedEntity({ id: "e3b", name: "orders", status: "draft", connectionId: "warehouse" });
+    // Case 4 — tombstone hides
+    seedEntity({ id: "e4a", name: "sessions", status: "published", connectionId: "warehouse" });
+    seedEntity({ id: "e4b", name: "sessions", status: "draft_delete", connectionId: "warehouse" });
+    // Case 5 — archived parent
+    seedEntity({ id: "e5", name: "old_logs", status: "published", connectionId: "legacy" });
+
+    const rows = await listEntitiesWithOverlay("org-1", "entity");
+    expect(rowsByName(rows)).toEqual({
+      users: "published",
+      events: "draft",
+      orders: "draft",
+    });
+  });
+
+  it("NULL connection_id entities pass through (org-level, not connection-scoped)", async () => {
+    // Glossary and catalog entries typically have no connection — they must
+    // survive the archived-connection filter.
+    seedEntity({ id: "g1", name: "kpi_terms", status: "published", connectionId: null });
+
+    const rows = await listEntitiesWithOverlay("org-1", "entity");
+    expect(rowsByName(rows)).toEqual({ kpi_terms: "published" });
+  });
+
+  it("archived entity rows are dropped by the status filter", async () => {
+    seedConnection("warehouse");
+    seedEntity({ id: "e-arch", name: "deprecated", status: "archived", connectionId: "warehouse" });
+    seedEntity({ id: "e-pub", name: "users", status: "published", connectionId: "warehouse" });
+
+    const rows = await listEntitiesWithOverlay("org-1", "entity");
+    expect(rowsByName(rows)).toEqual({ users: "published" });
+  });
+
+  it("entityType filter binds to $2 and scopes results", async () => {
+    seedConnection("warehouse");
+    seedEntity({ id: "e-ent", name: "users", status: "published", connectionId: "warehouse" });
+    // Pretend a metric was stored in the same table — different entity_type
+    db.public.none(
+      `INSERT INTO semantic_entities (id, org_id, entity_type, name, yaml_content, connection_id, status)
+       VALUES ('m1', 'org-1', 'metric', 'mrr', 'name: mrr', 'warehouse', 'published')`,
+    );
+
+    const entities = await listEntitiesWithOverlay("org-1", "entity");
+    const metrics = await listEntitiesWithOverlay("org-1", "metric");
+
+    expect(rowsByName(entities)).toEqual({ users: "published" });
+    expect(rowsByName(metrics)).toEqual({ mrr: "published" });
+  });
+
+  it("cross-org rows are invisible", async () => {
+    // Seed an entity under a different org — should never appear in org-1's overlay
+    db.public.none(
+      `INSERT INTO connections (id, org_id, status) VALUES ('warehouse', 'org-2', 'published')`,
+    );
+    db.public.none(
+      `INSERT INTO semantic_entities (id, org_id, entity_type, name, yaml_content, connection_id, status)
+       VALUES ('other', 'org-2', 'entity', 'other_users', 'table: other', 'warehouse', 'published')`,
+    );
+
+    // org-1 has nothing
+    const rows = await listEntitiesWithOverlay("org-1", "entity");
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/packages/api/src/lib/semantic/__tests__/overlay-queries.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/overlay-queries.test.ts
@@ -262,6 +262,30 @@ describe("loadOrgWhitelist — developer mode uses overlay", () => {
     expect(mockListEntities).toHaveBeenCalledTimes(2);
   });
 
+  it("developer mode and undefined-mode cache entries are isolated (no collision)", async () => {
+    // `undefined` calls listEntities with no filter (all rows including tombstones);
+    // `developer` calls listEntitiesWithOverlay. If they shared a cache key, the
+    // first call would poison the second.
+    mockListEntities.mockImplementation(async () => [
+      makeRow({ name: "legacy", table: "legacy", status: "archived" }),
+    ]);
+    mockListEntitiesWithOverlay.mockImplementation(async () => [
+      makeRow({ name: "users", table: "users", status: "published" }),
+    ]);
+
+    const undef = await whitelistMod.loadOrgWhitelist("org-1");
+    const dev = await whitelistMod.loadOrgWhitelist("org-1", "developer");
+
+    const undefTables = undef.get("default") ?? new Set<string>();
+    const devTables = dev.get("default") ?? new Set<string>();
+
+    expect(undefTables.has("legacy")).toBe(true);
+    expect(devTables.has("users")).toBe(true);
+    expect(devTables.has("legacy")).toBe(false);
+    expect(mockListEntities).toHaveBeenCalledTimes(1);
+    expect(mockListEntitiesWithOverlay).toHaveBeenCalledTimes(1);
+  });
+
   it("developer mode builds the whitelist from overlay rows", async () => {
     mockListEntitiesWithOverlay.mockImplementation(async () => [
       makeRow({ name: "users", table: "users", status: "published" }),

--- a/packages/api/src/lib/semantic/__tests__/overlay-queries.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/overlay-queries.test.ts
@@ -248,18 +248,22 @@ describe("loadOrgWhitelist — developer mode uses overlay", () => {
     expect(mockListEntities).toHaveBeenCalledTimes(1);
   });
 
-  it("invalidateOrgWhitelist clears both caches so next load re-runs the overlay", async () => {
+  it("invalidateOrgWhitelist clears every mode's cache (developer, published, and bare-orgId legacy)", async () => {
+    // Warm all three caches — one per code path through whitelistCacheKey
     await whitelistMod.loadOrgWhitelist("org-1", "developer");
     await whitelistMod.loadOrgWhitelist("org-1", "published");
+    await whitelistMod.loadOrgWhitelist("org-1"); // legacy path
     expect(mockListEntitiesWithOverlay).toHaveBeenCalledTimes(1);
-    expect(mockListEntities).toHaveBeenCalledTimes(1);
+    expect(mockListEntities).toHaveBeenCalledTimes(2); // published filter + undefined filter
 
     whitelistMod.invalidateOrgWhitelist("org-1");
 
+    // Each mode must cache-miss after invalidation
     await whitelistMod.loadOrgWhitelist("org-1", "developer");
     await whitelistMod.loadOrgWhitelist("org-1", "published");
+    await whitelistMod.loadOrgWhitelist("org-1");
     expect(mockListEntitiesWithOverlay).toHaveBeenCalledTimes(2);
-    expect(mockListEntities).toHaveBeenCalledTimes(2);
+    expect(mockListEntities).toHaveBeenCalledTimes(4);
   });
 
   it("developer mode and undefined-mode cache entries are isolated (no collision)", async () => {

--- a/packages/api/src/lib/semantic/__tests__/overlay-queries.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/overlay-queries.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Tests for developer mode overlay queries (#1427).
+ *
+ * The overlay is the read path that lets admins in developer mode see drafts
+ * superimposed on published content. For semantic entities this is a CTE with
+ * 3-way priority (draft_delete > draft > published). For connections and
+ * prompt collections it's a simple union of statuses.
+ *
+ * Covers:
+ * - `listEntitiesWithOverlay` executes the CTE overlay against the internal DB
+ * - The overlay excludes tombstones from the final projection (they only hide)
+ * - The overlay excludes entities whose parent connection is archived
+ * - `loadOrgWhitelist` in developer mode routes through the overlay
+ * - Overlay returns empty array when internal DB is not configured
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { resolve } from "path";
+
+// ---------------------------------------------------------------------------
+// Capture internalQuery calls so we can assert on SQL + params
+// ---------------------------------------------------------------------------
+
+interface CapturedCall {
+  sql: string;
+  params: unknown[] | undefined;
+}
+
+const capturedCalls: CapturedCall[] = [];
+let mockRows: Record<string, unknown>[] = [];
+let hasDB = true;
+
+function resetCapture(): void {
+  capturedCalls.length = 0;
+  mockRows = [];
+  hasDB = true;
+}
+
+const mockInternalQuery = mock(async (sql: string, params?: unknown[]) => {
+  capturedCalls.push({ sql, params });
+  return mockRows;
+});
+
+const mockHasInternalDB = mock(() => hasDB);
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  internalQuery: mockInternalQuery,
+  hasInternalDB: mockHasInternalDB,
+  // Satisfy other consumers that may import these — not exercised in this file
+  internalExecute: mock(async () => 0),
+  getInternalDB: mock(() => {
+    throw new Error("not configured");
+  }),
+  _resetPool: mock(() => {}),
+  encryptUrl: mock((u: string) => u),
+  decryptUrl: mock((u: string) => u),
+}));
+
+// Cache-busting import so the mocked module is picked up
+const entitiesPath = resolve(__dirname, "../entities.ts");
+const entitiesMod = await import(`${entitiesPath}?t=${Date.now()}`);
+const listEntitiesWithOverlay =
+  entitiesMod.listEntitiesWithOverlay as typeof import("../entities").listEntitiesWithOverlay;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface MakeRowOpts {
+  name: string;
+  table?: string;
+  status?: "published" | "draft" | "draft_delete" | "archived";
+  connectionId?: string | null;
+  id?: string;
+}
+
+function makeRow(opts: MakeRowOpts): Record<string, unknown> {
+  const status = opts.status ?? "published";
+  return {
+    id: opts.id ?? `id-${opts.name}-${status}`,
+    org_id: "org-1",
+    entity_type: "entity",
+    name: opts.name,
+    yaml_content: `table: ${opts.table ?? opts.name}\n`,
+    connection_id: opts.connectionId ?? null,
+    status,
+    created_at: "2026-01-01",
+    updated_at: "2026-01-01",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("listEntitiesWithOverlay — SQL shape", () => {
+  beforeEach(() => {
+    resetCapture();
+  });
+
+  it("issues a CTE that selects DISTINCT ON the entity key with status priority", async () => {
+    await listEntitiesWithOverlay("org-1", "entity");
+    expect(capturedCalls.length).toBe(1);
+    const sql = capturedCalls[0].sql;
+    // CTE pattern
+    expect(sql).toMatch(/WITH\s+overlay\s+AS/i);
+    // DISTINCT ON the entity key
+    expect(sql).toMatch(/DISTINCT\s+ON\s*\(\s*org_id\s*,\s*name\s*,\s*connection_id\s*\)/i);
+    // Priority ordering with draft_delete first, then draft, then published
+    expect(sql).toMatch(/CASE\s+status\s+WHEN\s+'draft_delete'\s+THEN\s+0/i);
+    expect(sql).toMatch(/WHEN\s+'draft'\s+THEN\s+1/i);
+    // Final projection filters out tombstones
+    expect(sql).toMatch(/WHERE\s+status\s*!=\s*'draft_delete'/i);
+  });
+
+  it("restricts to entities whose parent connection is not archived", async () => {
+    await listEntitiesWithOverlay("org-1", "entity");
+    const sql = capturedCalls[0].sql;
+    // Inner check: connection_id IN (SELECT id FROM connections WHERE status IN ('published','draft'))
+    // Or equivalent: connection is NULL (unscoped) OR in published/draft set
+    expect(sql).toMatch(/connections/i);
+    expect(sql).toMatch(/status\s+IN\s*\(\s*'published'\s*,\s*'draft'\s*\)/i);
+  });
+
+  it("includes status IN ('published','draft','draft_delete') for the entity side", async () => {
+    await listEntitiesWithOverlay("org-1", "entity");
+    const sql = capturedCalls[0].sql;
+    expect(sql).toMatch(/status\s+IN\s*\(\s*'published'\s*,\s*'draft'\s*,\s*'draft_delete'\s*\)/i);
+  });
+
+  it("binds orgId as the first parameter", async () => {
+    await listEntitiesWithOverlay("org-xyz", "entity");
+    expect(capturedCalls[0].params?.[0]).toBe("org-xyz");
+  });
+
+  it("filters by entity type when provided", async () => {
+    await listEntitiesWithOverlay("org-1", "metric");
+    const sql = capturedCalls[0].sql;
+    expect(sql).toMatch(/entity_type\s*=\s*\$/i);
+    expect(capturedCalls[0].params).toContain("metric");
+  });
+
+  it("omits entity_type filter when not provided", async () => {
+    await listEntitiesWithOverlay("org-1");
+    const sql = capturedCalls[0].sql;
+    expect(sql).not.toMatch(/entity_type\s*=\s*\$/i);
+  });
+
+  it("returns an empty array without querying when internal DB is not configured", async () => {
+    hasDB = false;
+    const result = await listEntitiesWithOverlay("org-1", "entity");
+    expect(result).toEqual([]);
+    expect(capturedCalls.length).toBe(0);
+  });
+});
+
+describe("listEntitiesWithOverlay — return shape", () => {
+  beforeEach(() => {
+    resetCapture();
+  });
+
+  it("returns the rows produced by internalQuery as SemanticEntityRow[]", async () => {
+    mockRows = [makeRow({ name: "users", status: "published" })];
+    const result = await listEntitiesWithOverlay("org-1", "entity");
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("users");
+    expect(result[0].status).toBe("published");
+  });
+
+  it("propagates draft rows through when the DB returns them (simulating draft supersedes)", async () => {
+    // The DB is the source of truth for the overlay — this test documents the
+    // contract that whatever survives the CTE is returned unchanged.
+    mockRows = [makeRow({ name: "users", status: "draft" })];
+    const result = await listEntitiesWithOverlay("org-1", "entity");
+    expect(result[0].status).toBe("draft");
+  });
+
+  it("never returns draft_delete rows (caller relies on the SQL to exclude them)", async () => {
+    // Simulating what the SQL would return — draft_delete excluded by final WHERE
+    mockRows = [
+      makeRow({ name: "users", status: "published" }),
+      makeRow({ name: "orders", status: "draft" }),
+    ];
+    const result = await listEntitiesWithOverlay("org-1", "entity");
+    expect(result.every((r) => r.status !== "draft_delete")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadOrgWhitelist — routes through the overlay in developer mode
+// ---------------------------------------------------------------------------
+
+describe("loadOrgWhitelist — developer mode uses overlay", () => {
+  // Separate mocks so we can observe which entity loader was called
+  const mockListEntities = mock(async () => [] as Record<string, unknown>[]);
+  const mockListEntitiesWithOverlay = mock(async () => [] as Record<string, unknown>[]);
+
+  mock.module("@atlas/api/lib/semantic/entities", () => ({
+    listEntities: mockListEntities,
+    listEntitiesWithOverlay: mockListEntitiesWithOverlay,
+    getEntity: mock(async () => null),
+    upsertEntity: mock(async () => {}),
+    deleteEntity: mock(async () => false),
+    countEntities: mock(async () => 0),
+    bulkUpsertEntities: mock(async () => 0),
+    createVersion: mock(async () => "v1"),
+    listVersions: mock(async () => ({ versions: [], total: 0 })),
+    getVersion: mock(async () => null),
+    generateChangeSummary: mock(async () => null),
+    SEMANTIC_ENTITY_STATUSES: ["published", "draft", "draft_delete", "archived"] as const,
+  }));
+
+  // Cache-bust whitelist module
+  const modPath = resolve(__dirname, "../whitelist.ts");
+  let whitelistMod: typeof import("../whitelist");
+
+  beforeEach(async () => {
+    mockListEntities.mockClear();
+    mockListEntitiesWithOverlay.mockClear();
+    mockListEntities.mockImplementation(async () => []);
+    mockListEntitiesWithOverlay.mockImplementation(async () => []);
+
+    whitelistMod = (await import(`${modPath}?t=${Date.now()}`)) as typeof import("../whitelist");
+    whitelistMod._resetOrgWhitelists();
+  });
+
+  it("developer mode routes through listEntitiesWithOverlay, not listEntities", async () => {
+    await whitelistMod.loadOrgWhitelist("org-1", "developer");
+    expect(mockListEntitiesWithOverlay).toHaveBeenCalledTimes(1);
+    expect(mockListEntitiesWithOverlay).toHaveBeenCalledWith("org-1", "entity");
+    expect(mockListEntities).not.toHaveBeenCalled();
+  });
+
+  it("published mode still uses listEntities with the published status filter", async () => {
+    await whitelistMod.loadOrgWhitelist("org-1", "published");
+    expect(mockListEntities).toHaveBeenCalledTimes(1);
+    expect(mockListEntities).toHaveBeenCalledWith("org-1", "entity", "published");
+    expect(mockListEntitiesWithOverlay).not.toHaveBeenCalled();
+  });
+
+  it("caches developer and published modes separately", async () => {
+    await whitelistMod.loadOrgWhitelist("org-1", "developer");
+    await whitelistMod.loadOrgWhitelist("org-1", "published");
+    await whitelistMod.loadOrgWhitelist("org-1", "developer"); // cache hit
+    await whitelistMod.loadOrgWhitelist("org-1", "published"); // cache hit
+
+    expect(mockListEntitiesWithOverlay).toHaveBeenCalledTimes(1);
+    expect(mockListEntities).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidateOrgWhitelist clears both caches so next load re-runs the overlay", async () => {
+    await whitelistMod.loadOrgWhitelist("org-1", "developer");
+    await whitelistMod.loadOrgWhitelist("org-1", "published");
+    expect(mockListEntitiesWithOverlay).toHaveBeenCalledTimes(1);
+    expect(mockListEntities).toHaveBeenCalledTimes(1);
+
+    whitelistMod.invalidateOrgWhitelist("org-1");
+
+    await whitelistMod.loadOrgWhitelist("org-1", "developer");
+    await whitelistMod.loadOrgWhitelist("org-1", "published");
+    expect(mockListEntitiesWithOverlay).toHaveBeenCalledTimes(2);
+    expect(mockListEntities).toHaveBeenCalledTimes(2);
+  });
+
+  it("developer mode builds the whitelist from overlay rows", async () => {
+    mockListEntitiesWithOverlay.mockImplementation(async () => [
+      makeRow({ name: "users", table: "users", status: "published" }),
+      makeRow({ name: "orders", table: "orders", status: "draft" }),
+    ]);
+
+    const byConn = await whitelistMod.loadOrgWhitelist("org-1", "developer");
+    const tables = byConn.get("default") ?? new Set<string>();
+    expect(tables.has("users")).toBe(true);
+    expect(tables.has("orders")).toBe(true);
+  });
+});

--- a/packages/api/src/lib/semantic/entities.ts
+++ b/packages/api/src/lib/semantic/entities.ts
@@ -117,7 +117,8 @@ export async function listEntities(
  * - A `draft` row supersedes a published row with the same
  *   (org_id, name, connection_id) key
  * - Unmodified published entities pass through
- * - Entities whose parent connection is archived are excluded
+ * - `archived` entity rows are excluded (the `status IN` filter drops them)
+ * - Entities whose parent connection is archived are also excluded
  *
  * The CTE uses DISTINCT ON with a status priority (draft_delete > draft >
  * published) so exactly one row per entity key survives, then the outer

--- a/packages/api/src/lib/semantic/entities.ts
+++ b/packages/api/src/lib/semantic/entities.ts
@@ -109,6 +109,90 @@ export async function listEntities(
 }
 
 /**
+ * Developer-mode overlay read for semantic entities.
+ *
+ * Returns the superposition of published + draft + draft_delete rows such that:
+ * - A `draft_delete` tombstone hides the published entity it targets (final
+ *   projection excludes tombstones)
+ * - A `draft` row supersedes a published row with the same
+ *   (org_id, name, connection_id) key
+ * - Unmodified published entities pass through
+ * - Entities whose parent connection is archived are excluded
+ *
+ * The CTE uses DISTINCT ON with a status priority (draft_delete > draft >
+ * published) so exactly one row per entity key survives, then the outer
+ * SELECT drops tombstones.
+ *
+ * Used by `loadOrgWhitelist` in developer mode. Published mode uses
+ * `listEntities(..., "published")` instead — a simple status = 'published'
+ * filter is sufficient because there's at most one published row per key.
+ */
+export async function listEntitiesWithOverlay(
+  orgId: string,
+  entityType?: SemanticEntityType,
+): Promise<SemanticEntityRow[]> {
+  if (!hasInternalDB()) return [];
+
+  const baseSelect =
+    "id, org_id, entity_type, name, yaml_content, connection_id, status, created_at, updated_at";
+
+  if (entityType) {
+    return internalQuery<SemanticEntityRow>(
+      `WITH overlay AS (
+         SELECT DISTINCT ON (org_id, name, connection_id) ${baseSelect}
+         FROM semantic_entities
+         WHERE org_id = $1
+           AND entity_type = $2
+           AND status IN ('published', 'draft', 'draft_delete')
+           AND (
+             connection_id IS NULL
+             OR connection_id IN (
+               SELECT id FROM connections
+               WHERE org_id = $1 AND status IN ('published', 'draft')
+             )
+           )
+         ORDER BY org_id, name, connection_id,
+           CASE status
+             WHEN 'draft_delete' THEN 0
+             WHEN 'draft' THEN 1
+             ELSE 2
+           END
+       )
+       SELECT ${baseSelect} FROM overlay
+       WHERE status != 'draft_delete'
+       ORDER BY name`,
+      [orgId, entityType],
+    );
+  }
+
+  return internalQuery<SemanticEntityRow>(
+    `WITH overlay AS (
+       SELECT DISTINCT ON (org_id, name, connection_id) ${baseSelect}
+       FROM semantic_entities
+       WHERE org_id = $1
+         AND status IN ('published', 'draft', 'draft_delete')
+         AND (
+           connection_id IS NULL
+           OR connection_id IN (
+             SELECT id FROM connections
+             WHERE org_id = $1 AND status IN ('published', 'draft')
+           )
+         )
+       ORDER BY org_id, name, connection_id,
+         CASE status
+           WHEN 'draft_delete' THEN 0
+           WHEN 'draft' THEN 1
+           ELSE 2
+         END
+     )
+     SELECT ${baseSelect} FROM overlay
+     WHERE status != 'draft_delete'
+     ORDER BY entity_type, name`,
+    [orgId],
+  );
+}
+
+/**
  * Get a single semantic entity by org, type, and name.
  */
 export async function getEntity(

--- a/packages/api/src/lib/semantic/whitelist.ts
+++ b/packages/api/src/lib/semantic/whitelist.ts
@@ -399,7 +399,10 @@ const _orgWhitelists = new Map<string, Map<string, Set<string>>>();
  *
  * @param orgId - Organization ID to load entities for.
  * @param mode - Atlas mode. When "published", only published entities are
- *   included. When "developer" (or omitted), all entities are included.
+ *   included. When "developer", drafts are overlaid on published via the
+ *   CTE in `listEntitiesWithOverlay` (drafts supersede, tombstones hide,
+ *   archived-connection entities excluded). When omitted, behaves like
+ *   developer mode without the overlay — returns all rows the DB has.
  * @returns Map of connectionId → Set<tableName>.
  */
 export async function loadOrgWhitelist(orgId: string, mode?: "published" | "developer"): Promise<Map<string, Set<string>>> {
@@ -407,9 +410,10 @@ export async function loadOrgWhitelist(orgId: string, mode?: "published" | "deve
   const cached = _orgWhitelists.get(cacheKey);
   if (cached) return cached;
 
-  const { listEntities } = await import("@atlas/api/lib/semantic/entities");
-  const statusFilter = mode === "published" ? "published" as const : undefined;
-  const rows = await listEntities(orgId, "entity", statusFilter);
+  const { listEntities, listEntitiesWithOverlay } = await import("@atlas/api/lib/semantic/entities");
+  const rows = mode === "developer"
+    ? await listEntitiesWithOverlay(orgId, "entity")
+    : await listEntities(orgId, "entity", mode === "published" ? "published" : undefined);
 
   const byConnection = new Map<string, Set<string>>();
   let parseFailures = 0;

--- a/packages/api/src/lib/semantic/whitelist.ts
+++ b/packages/api/src/lib/semantic/whitelist.ts
@@ -464,11 +464,15 @@ export async function loadOrgWhitelist(orgId: string, mode?: "published" | "deve
 /**
  * Get whitelisted tables for an org + connection.
  *
- * Must be called after `loadOrgWhitelist(orgId)` — returns empty set if
- * the org whitelist has not been loaded yet.
+ * Must be called after `loadOrgWhitelist(orgId, mode)` with the matching mode —
+ * each mode has a distinct cache key (see `_orgWhitelists` and `whitelistCacheKey`),
+ * so a published-mode load won't satisfy a developer-mode lookup. Returns an
+ * empty set if the requested cache has not been loaded.
  *
- * @param mode - Atlas mode. When "published", looks up the published-only cache.
- *   Omit for developer mode (all entities).
+ * @param mode - `"published"` → published-only cache; `"developer"` → overlay
+ *   cache (drafts on published, tombstones hidden, archived-connection entities
+ *   excluded); omitted → legacy cache built from `listEntities` with no status
+ *   filter (includes tombstones and archived rows).
  */
 export function getOrgWhitelistedTables(orgId: string, connectionId: string = "default", mode?: "published" | "developer"): Set<string> {
   const cacheKey = whitelistCacheKey(orgId, mode);

--- a/packages/api/src/lib/semantic/whitelist.ts
+++ b/packages/api/src/lib/semantic/whitelist.ts
@@ -385,11 +385,21 @@ export function _resetPluginEntities(): void {
 
 /**
  * Per-org whitelist cache: Map<cacheKey, Map<connectionId, Set<tableName>>>.
- * Cache key is `orgId` for developer mode or `${orgId}:published` for published mode.
+ * Each mode gets a distinct cache key so the three result shapes (published
+ * filter, developer overlay, no-mode legacy) can never be confused:
+ *   - `${orgId}:published` — status = 'published'
+ *   - `${orgId}:developer` — CTE overlay
+ *   - `${orgId}` — legacy path, no mode supplied (all rows incl. tombstones)
  * Populated by `loadOrgWhitelist()` before the agent loop starts.
- * Invalidated by `invalidateOrgWhitelist(orgId)` on entity CRUD (clears both modes).
+ * Invalidated by `invalidateOrgWhitelist(orgId)` on entity CRUD (clears all modes).
  */
 const _orgWhitelists = new Map<string, Map<string, Set<string>>>();
+
+function whitelistCacheKey(orgId: string, mode?: "published" | "developer"): string {
+  if (mode === "published") return `${orgId}:published`;
+  if (mode === "developer") return `${orgId}:developer`;
+  return orgId;
+}
 
 /**
  * Load the table whitelist for an org from the internal DB.
@@ -406,7 +416,7 @@ const _orgWhitelists = new Map<string, Map<string, Set<string>>>();
  * @returns Map of connectionId → Set<tableName>.
  */
 export async function loadOrgWhitelist(orgId: string, mode?: "published" | "developer"): Promise<Map<string, Set<string>>> {
-  const cacheKey = mode === "published" ? `${orgId}:published` : orgId;
+  const cacheKey = whitelistCacheKey(orgId, mode);
   const cached = _orgWhitelists.get(cacheKey);
   if (cached) return cached;
 
@@ -461,7 +471,7 @@ export async function loadOrgWhitelist(orgId: string, mode?: "published" | "deve
  *   Omit for developer mode (all entities).
  */
 export function getOrgWhitelistedTables(orgId: string, connectionId: string = "default", mode?: "published" | "developer"): Set<string> {
-  const cacheKey = mode === "published" ? `${orgId}:published` : orgId;
+  const cacheKey = whitelistCacheKey(orgId, mode);
   const byConnection = _orgWhitelists.get(cacheKey);
   if (!byConnection) {
     log.warn({ orgId, connectionId, mode: mode ?? "developer" }, "Org whitelist not loaded — all tables will be rejected");
@@ -485,10 +495,11 @@ export function getOrgWhitelistedTables(orgId: string, connectionId: string = "d
   return tables;
 }
 
-/** Invalidate the cached whitelist for an org (call after entity CRUD). Clears both developer and published mode caches. */
+/** Invalidate the cached whitelist for an org (call after entity CRUD). Clears every mode's cache entry. */
 export function invalidateOrgWhitelist(orgId: string): void {
   _orgWhitelists.delete(orgId);
   _orgWhitelists.delete(`${orgId}:published`);
+  _orgWhitelists.delete(`${orgId}:developer`);
   invalidateOrgSemanticIndex(orgId);
 }
 


### PR DESCRIPTION
## Summary

- Adds `listEntitiesWithOverlay` — CTE overlay for semantic entities: draft_delete > draft > published, tombstones hidden, archived-connection entities excluded.
- Adds `buildUnionStatusClause` — simple union (`status IN ('published', 'draft')`) for connections and prompt collections in developer mode.
- Wires overlay + union into `loadOrgWhitelist`, admin-connections, admin-prompts, and public prompts routes.

Closes #1427. Part of milestone 1.2.0 — Developer/Published Mode (#34).

## What changed

**Semantic entities — full CTE overlay** (`lib/semantic/entities.ts`):
- DISTINCT ON `(org_id, name, connection_id)` with priority `draft_delete > draft > published`
- Restricts to entities whose parent connection is NOT archived (`connection_id IS NULL OR connection_id IN (SELECT id FROM connections WHERE status IN ('published','draft'))`)
- Final projection drops `draft_delete` rows — they only exist to hide published rows

**Connections + prompt collections — simple union** (`api/routes/middleware.ts`):
- `buildUnionStatusClause("published")` → `AND status = 'published'`
- `buildUnionStatusClause("developer")` → `AND status IN ('published', 'draft')`
- Archived rows excluded in both modes (this is a behavior change — see below)

**Whitelist cache keys** (`lib/semantic/whitelist.ts`):
- Each mode gets a distinct cache key (`:published`, `:developer`, bare orgId for legacy)
- `invalidateOrgWhitelist` clears all three

## Behavior change worth flagging

Previously, developer mode on `/api/v1/admin/connections`, `/api/v1/admin/prompts`, and `/api/v1/prompts` appended no status clause at all, which leaked **archived** rows into developer-mode responses. This PR restricts developer mode to `status IN ('published', 'draft')`. Admins who need to see archived rows should use a dedicated archived view (future work tracked under #1437 — archive/restore endpoints).

## Test plan

- [x] Unit tests for `listEntitiesWithOverlay` SQL shape — CTE, DISTINCT ON, priority order, `draft_delete` exclusion, archived-parent exclusion, `entityType` binding, empty-DB guard
- [x] Unit tests for `loadOrgWhitelist` dispatch — developer mode → overlay, published mode → status filter, undefined → legacy path
- [x] Unit tests for `buildUnionStatusClause` — published, developer, undefined-defaults-to-published, never-archived, never-draft_delete
- [x] Cache-isolation test — developer and undefined-mode caches never collide
- [x] Cache-invalidation test — `invalidateOrgWhitelist` clears all three mode entries
- [x] Existing published-mode tests updated to reflect the new dispatch contract
- [x] Full CI: lint, type, test, syncpack, template drift — all pass (one flaky duckdb-ingest test unrelated, passes on retry — tracked in #992)
- [x] ROADMAP entry for #1427 ticked
- [ ] Manual smoke — verify developer-mode admin UI still shows drafts alongside published after merge