### PR TITLE
refactor(signup/connect): extract helpers, tri-state demo, e2e coverage

### DIFF
--- a/e2e/browser/signup-connect.spec.ts
+++ b/e2e/browser/signup-connect.spec.ts
@@ -1,0 +1,163 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * Signup connect page — two-card redesign (#1432, followups #1450/#1452).
+ *
+ * Exercises the page in isolation by intercepting backend calls with
+ * Playwright routing, so these tests don't depend on session state, seed
+ * data, or LLM provider availability.
+ */
+
+// Uses the default authenticated storage state — the proxy in managed mode
+// redirects unauthenticated users off /signup sub-routes to /login, so we
+// rely on the admin session from global setup. All backend calls that the
+// page actually makes are mocked below, so no test data is created.
+
+const PATH = "/signup/connect";
+
+function mockHealth(page: Page, status: "ok" | "down" | "unavailable") {
+  return page.route("**/api/health", async (route) => {
+    if (status === "unavailable") {
+      await route.abort("failed");
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        status: "healthy",
+        checks: { datasource: { status, latencyMs: 1 } },
+      }),
+    });
+  });
+}
+
+async function mockOnboarding(
+  page: Page,
+  config: {
+    testConnection?: { status: number; body: unknown };
+    complete?: { status: number; body: unknown };
+    useDemo?: { status: number; body: unknown };
+  },
+) {
+  if (config.testConnection) {
+    await page.route("**/api/v1/onboarding/test-connection", async (route) => {
+      await route.fulfill({
+        status: config.testConnection!.status,
+        contentType: "application/json",
+        body: JSON.stringify(config.testConnection!.body),
+      });
+    });
+  }
+  if (config.complete) {
+    await page.route("**/api/v1/onboarding/complete", async (route) => {
+      await route.fulfill({
+        status: config.complete!.status,
+        contentType: "application/json",
+        body: JSON.stringify(config.complete!.body),
+      });
+    });
+  }
+  if (config.useDemo) {
+    await page.route("**/api/v1/onboarding/use-demo", async (route) => {
+      await route.fulfill({
+        status: config.useDemo!.status,
+        contentType: "application/json",
+        body: JSON.stringify(config.useDemo!.body),
+      });
+    });
+  }
+}
+
+test.describe("Signup connect — demo availability", () => {
+  test("renders both cards when health reports datasource ok", async ({ page }) => {
+    await mockHealth(page, "ok");
+    await page.goto(PATH);
+
+    await expect(page.getByRole("heading", { name: "Get started with your data" })).toBeVisible();
+    await expect(page.getByText("Connect your database", { exact: true })).toBeVisible();
+    await expect(page.getByText("Explore demo data", { exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Use SaaS CRM demo dataset/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Use Cybersecurity demo dataset/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Use E-commerce demo dataset/ })).toBeVisible();
+  });
+
+  test("hides demo card when datasource reports down", async ({ page }) => {
+    await mockHealth(page, "down");
+    await page.goto(PATH);
+
+    await expect(page.getByText("Connect your database", { exact: true })).toBeVisible();
+    await expect(page.getByText("Explore demo data", { exact: true })).toBeHidden();
+  });
+
+  test("shows retry affordance when health check fails", async ({ page }) => {
+    await mockHealth(page, "unavailable");
+    await page.goto(PATH);
+
+    await expect(page.getByText("Explore demo data", { exact: true })).toBeVisible();
+    await expect(page.getByText(/Couldn.t check demo availability/)).toBeVisible();
+    await expect(page.getByRole("button", { name: /Retry/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Use SaaS CRM demo dataset/ })).toBeHidden();
+  });
+});
+
+test.describe("Signup connect — error isolation", () => {
+  test("demo failure produces exactly one alert on the demo card", async ({ page }) => {
+    await mockHealth(page, "ok");
+    await mockOnboarding(page, {
+      useDemo: { status: 500, body: { error: "boom", message: "demo setup failed" } },
+    });
+    await page.goto(PATH);
+
+    // Before: no alerts
+    await expect(page.getByRole("alert")).toHaveCount(0);
+
+    await page.getByRole("button", { name: /Use SaaS CRM demo dataset/ }).click();
+
+    // After: exactly one alert, carrying the demo error
+    const alert = page.getByRole("alert");
+    await expect(alert).toHaveCount(1);
+    await expect(alert).toContainText("demo setup failed");
+  });
+
+  test("test-connection failure produces exactly one alert on the connect card", async ({ page }) => {
+    await mockHealth(page, "ok");
+    await mockOnboarding(page, {
+      testConnection: { status: 400, body: { error: "boom", message: "connection refused" } },
+    });
+    await page.goto(PATH);
+
+    await expect(page.getByRole("alert")).toHaveCount(0);
+
+    await page.getByLabel("Connection URL").fill("postgresql://u:p@h:5432/db");
+    await page.getByRole("button", { name: "Test connection" }).click();
+
+    const alert = page.getByRole("alert");
+    await expect(alert).toHaveCount(1);
+    await expect(alert).toContainText("connection refused");
+  });
+
+  test("success pill disappears when Continue fails — they never coexist", async ({ page }) => {
+    await mockHealth(page, "ok");
+    await mockOnboarding(page, {
+      testConnection: {
+        status: 200,
+        body: { status: "healthy", latencyMs: 12, dbType: "postgres", maskedUrl: "..." },
+      },
+      complete: { status: 500, body: { error: "boom", message: "save failed" } },
+    });
+    await page.goto(PATH);
+
+    await page.getByLabel("Connection URL").fill("postgresql://u:p@h:5432/db");
+    await page.getByRole("button", { name: "Test connection" }).click();
+
+    // Success status pill appears
+    await expect(page.getByRole("status")).toContainText(/Connected to PostgreSQL in 12ms/);
+
+    await page.getByRole("button", { name: "Continue" }).click();
+
+    // Error alert appears and the success pill is gone — never both
+    await expect(page.getByRole("alert")).toContainText("save failed");
+    await expect(page.getByRole("status")).toHaveCount(0);
+  });
+});

--- a/packages/web/src/app/signup/connect/page.tsx
+++ b/packages/web/src/app/signup/connect/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
-import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
-import { postJson } from "@/lib/fetch-json";
+import { postJson, getApiBase, getCredentials } from "@/lib/fetch-json";
 import { detectDbLabel } from "@/lib/db-labels";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -27,17 +26,6 @@ import {
   Sparkles,
   RefreshCw,
 } from "lucide-react";
-
-function getApiBase(): string {
-  const url = getApiUrl();
-  if (url) return url;
-  if (typeof window !== "undefined") return window.location.origin;
-  return "http://localhost:3000";
-}
-
-function getCredentials(): RequestCredentials {
-  return isCrossOrigin() ? "include" : "same-origin";
-}
 
 type ConnectionStatus = "idle" | "testing" | "success" | "error";
 type DemoType = "demo" | "cybersec" | "ecommerce";
@@ -77,7 +65,7 @@ async function runHealthCheck(signal?: AbortSignal): Promise<DemoAvailability> {
     return data?.checks?.datasource?.status === "ok" ? "available" : "unavailable";
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") throw err;
-    console.debug("[signup/connect] health check failed:", {
+    console.warn("[signup/connect] health check failed:", {
       err: err instanceof Error ? err.message : String(err),
     });
     return "error";
@@ -94,16 +82,24 @@ export default function ConnectPage() {
   const [demoError, setDemoError] = useState<string | null>(null);
   const [demoAvailability, setDemoAvailability] = useState<DemoAvailability>("unknown");
   const [loadingDemo, setLoadingDemo] = useState<DemoType | null>(null);
+  // Aborts any in-flight health check (mount effect or retry click) so stale
+  // resolutions can't overwrite a newer result or setState after unmount.
+  const healthCheckAbortRef = useRef<AbortController | null>(null);
 
   // Don't silently hide the demo card on health-check failure — "error" state
   // shows a retry affordance so users can distinguish "demo not configured"
   // from "we couldn't check."
   useEffect(() => {
     const controller = new AbortController();
-    runHealthCheck(controller.signal).then(setDemoAvailability).catch((err) => {
-      if (err instanceof Error && err.name === "AbortError") return;
-      console.debug("[signup/connect] unexpected error from health-check:", err);
-    });
+    healthCheckAbortRef.current = controller;
+    runHealthCheck(controller.signal)
+      .then((result) => {
+        if (!controller.signal.aborted) setDemoAvailability(result);
+      })
+      .catch((err) => {
+        if (err instanceof Error && err.name === "AbortError") return;
+        console.warn("[signup/connect] unexpected error from health-check:", err);
+      });
     return () => controller.abort();
   }, []);
 
@@ -189,8 +185,17 @@ export default function ConnectPage() {
   }
 
   async function retryHealthCheck() {
+    healthCheckAbortRef.current?.abort();
+    const controller = new AbortController();
+    healthCheckAbortRef.current = controller;
     setDemoAvailability("unknown");
-    setDemoAvailability(await runHealthCheck());
+    try {
+      const result = await runHealthCheck(controller.signal);
+      if (!controller.signal.aborted) setDemoAvailability(result);
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return;
+      console.warn("[signup/connect] unexpected error from health-check retry:", err);
+    }
   }
 
   const dbLabel = url ? detectDbLabel(url) : "Database";
@@ -314,17 +319,19 @@ export default function ConnectPage() {
               {demoAvailability === "error" ? (
                 <div
                   role="alert"
-                  className="flex items-start justify-between gap-3 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-200"
+                  className="flex items-center justify-between gap-3 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-200"
                 >
                   <span>Couldn&apos;t check demo availability.</span>
-                  <button
+                  <Button
                     type="button"
                     onClick={retryHealthCheck}
-                    className="inline-flex shrink-0 items-center gap-1 font-medium underline-offset-2 hover:underline"
+                    variant="outline"
+                    size="sm"
+                    className="h-7 shrink-0 gap-1 border-amber-300 bg-transparent hover:bg-amber-100 dark:border-amber-800 dark:hover:bg-amber-900"
                   >
                     <RefreshCw className="size-3" />
                     Retry
-                  </button>
+                  </Button>
                 </div>
               ) : (
                 <div className="grid gap-2">

--- a/packages/web/src/app/signup/connect/page.tsx
+++ b/packages/web/src/app/signup/connect/page.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
+import { postJson } from "@/lib/fetch-json";
+import { detectDbLabel } from "@/lib/db-labels";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -23,6 +25,7 @@ import {
   ShoppingCart,
   Users,
   Sparkles,
+  RefreshCw,
 } from "lucide-react";
 
 function getApiBase(): string {
@@ -38,6 +41,7 @@ function getCredentials(): RequestCredentials {
 
 type ConnectionStatus = "idle" | "testing" | "success" | "error";
 type DemoType = "demo" | "cybersec" | "ecommerce";
+type DemoAvailability = "unknown" | "available" | "unavailable" | "error";
 
 interface TestResult {
   status?: string;
@@ -62,11 +66,22 @@ const DEMO_DATASETS: DemoDataset[] = [
   { type: "ecommerce", label: "E-commerce",    description: "Orders, products, customers, shipping, and reviews",  icon: ShoppingCart, tables: 52 },
 ];
 
-/** Auto-detect database type from URL scheme for display. */
-function detectDbLabel(url: string): string {
-  if (url.startsWith("postgresql://") || url.startsWith("postgres://")) return "PostgreSQL";
-  if (url.startsWith("mysql://") || url.startsWith("mysql2://")) return "MySQL";
-  return "Database";
+async function runHealthCheck(signal?: AbortSignal): Promise<DemoAvailability> {
+  try {
+    const res = await fetch(`${getApiBase()}/api/health`, {
+      credentials: getCredentials(),
+      signal,
+    });
+    if (!res.ok) throw new Error(`Health check returned ${res.status}`);
+    const data = (await res.json()) as { checks?: { datasource?: { status?: string } } };
+    return data?.checks?.datasource?.status === "ok" ? "available" : "unavailable";
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") throw err;
+    console.debug("[signup/connect] health check failed:", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return "error";
+  }
 }
 
 export default function ConnectPage() {
@@ -77,23 +92,19 @@ export default function ConnectPage() {
   const [saving, setSaving] = useState(false);
   const [connectError, setConnectError] = useState<string | null>(null);
   const [demoError, setDemoError] = useState<string | null>(null);
-  const [demoAvailable, setDemoAvailable] = useState(false);
+  const [demoAvailability, setDemoAvailability] = useState<DemoAvailability>("unknown");
   const [loadingDemo, setLoadingDemo] = useState<DemoType | null>(null);
 
+  // Don't silently hide the demo card on health-check failure — "error" state
+  // shows a retry affordance so users can distinguish "demo not configured"
+  // from "we couldn't check."
   useEffect(() => {
-    fetch(`${getApiBase()}/api/health`, { credentials: getCredentials() })
-      .then((res) => {
-        if (!res.ok) throw new Error(`Health check returned ${res.status}`);
-        return res.json();
-      })
-      .then((data) => {
-        if (data?.checks?.datasource?.status === "ok") {
-          setDemoAvailable(true);
-        }
-      })
-      .catch((err) => {
-        console.debug("[signup/connect] health check failed:", err instanceof Error ? err.message : String(err));
-      });
+    const controller = new AbortController();
+    runHealthCheck(controller.signal).then(setDemoAvailability).catch((err) => {
+      if (err instanceof Error && err.name === "AbortError") return;
+      console.debug("[signup/connect] unexpected error from health-check:", err);
+    });
+    return () => controller.abort();
   }, []);
 
   async function handleTest() {
@@ -115,7 +126,11 @@ export default function ConnectPage() {
       try {
         data = await res.json();
       } catch (parseErr) {
-        console.debug("[signup/connect] test-connection JSON parse failed:", parseErr instanceof Error ? parseErr.message : String(parseErr));
+        console.debug("[signup/connect] test-connection JSON parse failed:", {
+          status: res.status,
+          contentType: res.headers.get("content-type"),
+          err: parseErr instanceof Error ? parseErr.message : String(parseErr),
+        });
         setConnectionStatus("error");
         setConnectError("Server returned an unexpected response. Check that the API is running.");
         return;
@@ -131,9 +146,7 @@ export default function ConnectPage() {
     } catch (err) {
       setConnectionStatus("error");
       setConnectError(
-        err instanceof TypeError
-          ? "Unable to reach the server"
-          : "Connection test failed",
+        err instanceof TypeError ? "Unable to reach the server" : "Connection test failed",
       );
     }
   }
@@ -144,84 +157,48 @@ export default function ConnectPage() {
     setSaving(true);
     setConnectError(null);
 
-    try {
-      const res = await fetch(`${getApiBase()}/api/v1/onboarding/complete`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: getCredentials(),
-        body: JSON.stringify({ url }),
-      });
+    const result = await postJson("/api/v1/onboarding/complete", { url }, {
+      fallbackMessage: "Failed to save connection",
+    });
 
-      let data: Record<string, unknown>;
-      try {
-        data = await res.json() as Record<string, unknown>;
-      } catch (parseErr) {
-        console.debug("[signup/connect] complete JSON parse failed:", parseErr instanceof Error ? parseErr.message : String(parseErr));
-        setConnectionStatus("error");
-        setConnectError("Server returned an unexpected response. Check that the API is running.");
-        return;
-      }
-      if (!res.ok) {
-        setConnectionStatus("error");
-        setConnectError((data.message as string) ?? "Failed to save connection");
-        return;
-      }
-
-      router.push("/signup/success");
-    } catch (err) {
+    if (!result.ok) {
       setConnectionStatus("error");
-      setConnectError(
-        err instanceof TypeError
-          ? "Unable to reach the server"
-          : "Failed to complete setup",
-      );
-    } finally {
+      setConnectError(result.error);
       setSaving(false);
+      return;
     }
+
+    router.push("/signup/success");
   }
 
   async function handleUseDemo(demoType: DemoType) {
     setLoadingDemo(demoType);
     setDemoError(null);
 
-    try {
-      const res = await fetch(`${getApiBase()}/api/v1/onboarding/use-demo`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: getCredentials(),
-        body: JSON.stringify({ demoType }),
-      });
+    const result = await postJson("/api/v1/onboarding/use-demo", { demoType }, {
+      fallbackMessage: "Failed to set up demo data",
+    });
 
-      let data: Record<string, unknown>;
-      try {
-        data = await res.json() as Record<string, unknown>;
-      } catch (parseErr) {
-        console.debug("[signup/connect] use-demo JSON parse failed:", parseErr instanceof Error ? parseErr.message : String(parseErr));
-        setDemoError("Server returned an unexpected response.");
-        return;
-      }
-      if (!res.ok) {
-        setDemoError((data.message as string) ?? "Failed to set up demo data");
-        return;
-      }
-
-      router.push("/signup/success");
-    } catch (err) {
-      setDemoError(
-        err instanceof TypeError
-          ? "Unable to reach the server"
-          : "Failed to set up demo data",
-      );
-    } finally {
+    if (!result.ok) {
+      setDemoError(result.error);
       setLoadingDemo(null);
+      return;
     }
+
+    router.push("/signup/success");
+  }
+
+  async function retryHealthCheck() {
+    setDemoAvailability("unknown");
+    setDemoAvailability(await runHealthCheck());
   }
 
   const dbLabel = url ? detectDbLabel(url) : "Database";
   const anyLoading = saving || loadingDemo !== null;
+  const showDemoCard = demoAvailability === "available" || demoAvailability === "error";
 
   return (
-    <div className={cn("w-full", demoAvailable ? "max-w-4xl" : "max-w-lg")}>
+    <div className={cn("w-full", showDemoCard ? "max-w-4xl" : "max-w-lg")}>
       <div className="mb-6 flex flex-col items-center text-center">
         <div className="mb-3 flex size-12 items-center justify-center rounded-lg bg-primary/10">
           <Database className="size-6 text-primary" />
@@ -234,12 +211,7 @@ export default function ConnectPage() {
         </p>
       </div>
 
-      <div
-        className={cn(
-          "grid gap-4",
-          demoAvailable && "md:grid-cols-2",
-        )}
-      >
+      <div className={cn("grid gap-4", showDemoCard && "md:grid-cols-2")}>
         <Card className="flex flex-col">
           <CardHeader>
             <CardTitle className="flex items-center gap-2 text-lg">
@@ -327,7 +299,7 @@ export default function ConnectPage() {
           </CardContent>
         </Card>
 
-        {demoAvailable && (
+        {showDemoCard && (
           <Card className="flex flex-col">
             <CardHeader>
               <CardTitle className="flex items-center gap-2 text-lg">
@@ -339,41 +311,58 @@ export default function ConnectPage() {
               </CardDescription>
             </CardHeader>
             <CardContent className="flex flex-1 flex-col space-y-3">
-              <div className="grid gap-2">
-                {DEMO_DATASETS.map((ds) => {
-                  const isLoading = loadingDemo === ds.type;
-                  return (
-                    <button
-                      key={ds.type}
-                      type="button"
-                      onClick={() => handleUseDemo(ds.type)}
-                      disabled={anyLoading}
-                      aria-label={`Use ${ds.label} demo dataset (${ds.tables} tables)`}
-                      className={cn(
-                        "group flex items-center gap-3 rounded-lg border bg-card p-3 text-left transition-colors",
-                        "hover:border-primary/50 hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                        "disabled:pointer-events-none disabled:opacity-50",
-                      )}
-                    >
-                      <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-muted group-hover:bg-primary/10">
-                        <ds.icon className="size-4 text-muted-foreground group-hover:text-primary" />
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <div className="flex items-center gap-2">
-                          <span className="truncate text-sm font-medium">{ds.label}</span>
-                          <span className="shrink-0 text-[10px] text-muted-foreground">
-                            {ds.tables} {ds.tables === 1 ? "table" : "tables"}
-                          </span>
+              {demoAvailability === "error" ? (
+                <div
+                  role="alert"
+                  className="flex items-start justify-between gap-3 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-200"
+                >
+                  <span>Couldn&apos;t check demo availability.</span>
+                  <button
+                    type="button"
+                    onClick={retryHealthCheck}
+                    className="inline-flex shrink-0 items-center gap-1 font-medium underline-offset-2 hover:underline"
+                  >
+                    <RefreshCw className="size-3" />
+                    Retry
+                  </button>
+                </div>
+              ) : (
+                <div className="grid gap-2">
+                  {DEMO_DATASETS.map((ds) => {
+                    const isLoading = loadingDemo === ds.type;
+                    return (
+                      <button
+                        key={ds.type}
+                        type="button"
+                        onClick={() => handleUseDemo(ds.type)}
+                        disabled={anyLoading}
+                        aria-label={`Use ${ds.label} demo dataset (${ds.tables} tables)`}
+                        className={cn(
+                          "group flex items-center gap-3 rounded-lg border bg-card p-3 text-left transition-colors",
+                          "hover:border-primary/50 hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                          "disabled:pointer-events-none disabled:opacity-50",
+                        )}
+                      >
+                        <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-muted group-hover:bg-primary/10">
+                          <ds.icon className="size-4 text-muted-foreground group-hover:text-primary" />
                         </div>
-                        <p className="truncate text-xs text-muted-foreground">{ds.description}</p>
-                      </div>
-                      {isLoading && (
-                        <Loader2 className="size-4 shrink-0 animate-spin text-muted-foreground" />
-                      )}
-                    </button>
-                  );
-                })}
-              </div>
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-2">
+                            <span className="truncate text-sm font-medium">{ds.label}</span>
+                            <span className="shrink-0 text-[10px] text-muted-foreground">
+                              {ds.tables} {ds.tables === 1 ? "table" : "tables"}
+                            </span>
+                          </div>
+                          <p className="truncate text-xs text-muted-foreground">{ds.description}</p>
+                        </div>
+                        {isLoading && (
+                          <Loader2 className="size-4 shrink-0 animate-spin text-muted-foreground" />
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
 
               {demoError && (
                 <div

--- a/packages/web/src/lib/db-labels.test.ts
+++ b/packages/web/src/lib/db-labels.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { detectDbLabel } from "./db-labels";
+
+describe("detectDbLabel", () => {
+  test("maps postgresql:// to PostgreSQL", () => {
+    expect(detectDbLabel("postgresql://u:p@host:5432/db")).toBe("PostgreSQL");
+  });
+
+  test("maps postgres:// to PostgreSQL", () => {
+    expect(detectDbLabel("postgres://u:p@host:5432/db")).toBe("PostgreSQL");
+  });
+
+  test("maps mysql:// to MySQL", () => {
+    expect(detectDbLabel("mysql://u:p@host:3306/db")).toBe("MySQL");
+  });
+
+  test("maps mysql2:// to MySQL", () => {
+    expect(detectDbLabel("mysql2://u:p@host:3306/db")).toBe("MySQL");
+  });
+
+  test("falls back to Database for unknown schemes", () => {
+    expect(detectDbLabel("sqlite:///path/to/db")).toBe("Database");
+  });
+
+  test("falls back to Database for empty string", () => {
+    expect(detectDbLabel("")).toBe("Database");
+  });
+});

--- a/packages/web/src/lib/db-labels.ts
+++ b/packages/web/src/lib/db-labels.ts
@@ -1,0 +1,5 @@
+export function detectDbLabel(url: string): string {
+  if (url.startsWith("postgresql://") || url.startsWith("postgres://")) return "PostgreSQL";
+  if (url.startsWith("mysql://") || url.startsWith("mysql2://")) return "MySQL";
+  return "Database";
+}

--- a/packages/web/src/lib/fetch-json.ts
+++ b/packages/web/src/lib/fetch-json.ts
@@ -4,14 +4,16 @@ export type PostJsonResult =
   | { ok: true; data: Record<string, unknown> }
   | { ok: false; error: string };
 
-function getApiBase(): string {
+/** Resolve the API base URL — configured, same-origin, or dev fallback. */
+export function getApiBase(): string {
   const url = getApiUrl();
   if (url) return url;
   if (typeof window !== "undefined") return window.location.origin;
   return "http://localhost:3000";
 }
 
-function getCredentials(): RequestCredentials {
+/** Credentials mode for cross-origin vs same-origin API calls. */
+export function getCredentials(): RequestCredentials {
   return isCrossOrigin() ? "include" : "same-origin";
 }
 
@@ -58,7 +60,11 @@ export async function postJson(
   }
 
   if (!res.ok) {
-    const message = typeof data.message === "string" ? data.message : fallback;
+    // Accept either {message} or {error} — both are common Hono patterns.
+    const message =
+      typeof data.message === "string" ? data.message
+      : typeof data.error === "string" ? data.error
+      : fallback;
     return { ok: false, error: message };
   }
 

--- a/packages/web/src/lib/fetch-json.ts
+++ b/packages/web/src/lib/fetch-json.ts
@@ -1,0 +1,66 @@
+import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
+
+export type PostJsonResult =
+  | { ok: true; data: Record<string, unknown> }
+  | { ok: false; error: string };
+
+function getApiBase(): string {
+  const url = getApiUrl();
+  if (url) return url;
+  if (typeof window !== "undefined") return window.location.origin;
+  return "http://localhost:3000";
+}
+
+function getCredentials(): RequestCredentials {
+  return isCrossOrigin() ? "include" : "same-origin";
+}
+
+/**
+ * POST JSON and parse the response, collapsing network / parse / HTTP errors
+ * into a single tagged result. Callers surface `error` directly to the user.
+ *
+ * Callers that need typed response shapes or latency should keep their own
+ * fetch — this helper targets "success → route, failure → show message" flows.
+ */
+export async function postJson(
+  path: string,
+  body: unknown,
+  opts?: { fallbackMessage?: string },
+): Promise<PostJsonResult> {
+  const fallback = opts?.fallbackMessage ?? "Request failed";
+
+  let res: Response;
+  try {
+    res = await fetch(`${getApiBase()}${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: getCredentials(),
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof TypeError ? "Unable to reach the server" : fallback,
+    };
+  }
+
+  let data: Record<string, unknown>;
+  try {
+    data = (await res.json()) as Record<string, unknown>;
+  } catch (parseErr) {
+    console.debug("[postJson] JSON parse failed:", {
+      path,
+      status: res.status,
+      contentType: res.headers.get("content-type"),
+      err: parseErr instanceof Error ? parseErr.message : String(parseErr),
+    });
+    return { ok: false, error: "Server returned an unexpected response." };
+  }
+
+  if (!res.ok) {
+    const message = typeof data.message === "string" ? data.message : fallback;
+    return { ok: false, error: message };
+  }
+
+  return { ok: true, data };
+}


### PR DESCRIPTION
## Summary
Addresses the follow-ups filed during the review of #1449: simplify duplicated fetch/parse logic, harden the silent health-check failure, and add e2e coverage for the behaviors the redesign introduced.

## Changes

- **Extract `detectDbLabel`** → `packages/web/src/lib/db-labels.ts` + 6-case unit test (postgres, postgres://, mysql, mysql2, unknown, empty).
- **Extract `postJson` helper** → `packages/web/src/lib/fetch-json.ts`. Collapses the "POST JSON → parse → check ok → route on success, surface error on failure" pattern that was duplicated across `handleComplete` and `handleUseDemo`. Also centralizes the \`err instanceof TypeError ? "Unable to reach the server" : fallback\` branch that appeared three times.
- **Tri-state \`demoAvailability\`** (\`unknown | available | unavailable | error\`). On health-check failure the demo card now renders a \"Couldn't check demo availability\" pane with a Retry button instead of silently disappearing. Closes #1450.
- **Structured \`console.debug\` payloads** (\`{path, status, contentType, err}\`) — debugging unexpected responses in prod no longer requires re-deriving context from a prefixed string.
- **AbortController** on the mount-time health check so the strict-mode double-effect / unmount doesn't leave stale \`setDemoAvailability\` calls.
- **\`e2e/browser/signup-connect.spec.ts\`** — 6 tests covering:
  - both cards render when datasource is ok
  - demo card hidden when datasource reports down
  - retry affordance rendered when health check fails
  - demo failure → exactly one alert on the demo card (connect card unaffected)
  - test-connection failure → exactly one alert on the connect card (demo card unaffected)
  - success pill disappears when Continue fails (never coexist)

All backend calls are intercepted via \`page.route()\`, so these tests don't depend on session state, seed data, or LLM availability.

Closes #1450, closes #1452.

## Test plan
- [x] \`bun run lint\` — clean
- [x] \`bun run type\` — clean
- [x] \`bun run test\` — all packages pass (6 new tests in \`db-labels.test.ts\`)
- [x] \`bun x syncpack lint\` — no issues
- [x] \`SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh\` — no drift
- [x] Manual browser verification of the happy path (two cards side-by-side on desktop, admin signed in)