### PR TITLE
chore(types): bump @useatlas/types to 0.0.11

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -289,7 +289,7 @@
     },
     "packages/types": {
       "name": "@useatlas/types",
-      "version": "0.0.10",
+      "version": "0.0.11",
     },
     "packages/web": {
       "name": "@atlas/web",
@@ -4213,6 +4213,10 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typespec/ts-http-runtime/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "@useatlas/react/@useatlas/types": ["@useatlas/types@0.0.10", "", {}, "sha512-7vXyn/diiXCuFK6LK6ONl+WwlH8BFR1ANIzrA++B6qeBKz8Fmcsrb85Yl7ywR2FTZuPqVizmSHMzdLaSoBWOhA=="],
+
+    "@useatlas/sdk/@useatlas/types": ["@useatlas/types@0.0.10", "", {}, "sha512-7vXyn/diiXCuFK6LK6ONl+WwlH8BFR1ANIzrA++B6qeBKz8Fmcsrb85Yl7ywR2FTZuPqVizmSHMzdLaSoBWOhA=="],
 
     "@vercel/sandbox/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/types",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bumps `@useatlas/types` from `0.0.10` → `0.0.11` so the following (already-merged) surface is actually available on npm:
  - `ATLAS_MODES`, `AtlasMode`, `ADMIN_ROLES`, `AdminRole` (auth.ts, #1442)
  - `CONNECTION_STATUSES`, `ConnectionStatus`, `status?` on `ConnectionInfo`/`ConnectionDetail` (connection.ts, #1442)
  - `./mode` subpath export — `ModeDraftCounts`, `ModeStatusResponse` for `GET /api/v1/mode` (mode.ts, #1453)
- Unblocks Deploy Validation, which is currently failing because the scaffold's `src/ui/lib/types.ts` re-exports `ADMIN_ROLES` / `ATLAS_MODES` from the published `@useatlas/types@0.0.10` (Turbopack validates static re-exports at build time).
- **Consumer refs (`packages/sdk`, `packages/react`, `create-atlas/templates/*`) intentionally stay on `^0.0.10`** per the version-bump-ordering workflow in CLAUDE.md. They bump to `^0.0.11` in a follow-up PR once the publish workflow actually puts `0.0.11` on npm — otherwise scaffold `npm install` races and fails.

## Release sequence
1. Merge this PR (bumps `packages/types/package.json` + `bun.lock` only).
2. Tag the release: `git tag types-v0.0.11 && git push origin types-v0.0.11`. Wait for the publish workflow.
3. Follow-up PR: bump `^0.0.10` → `^0.0.11` in `packages/sdk/package.json`, `packages/react/package.json`, and `create-atlas/templates/*/package.json`. Close #1448 by removing the `types.ts` template-sync workaround in the same PR (or a sibling one).

## Test plan
- [ ] `bun run lint`, `bun run type`, `bun run test` all green
- [ ] `bun x syncpack lint` passes (already verified locally — no issues)
- [ ] `bun run build` in `packages/types/` produces `dist/mode.js`, `dist/mode.d.ts`
- [ ] Deploy Validation still fails on this PR (expected — scaffold still consumes `0.0.10`); it'll clear once the follow-up PR points consumers at `^0.0.11`

Tracks: #1448