### PR TITLE
chore(types): bump consumer refs to @useatlas/types@^0.0.11

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -226,7 +226,7 @@
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^5.96.2",
-        "@useatlas/types": "^0.0.10",
+        "@useatlas/types": "^0.0.11",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "radix-ui": "^1.4.3",
@@ -284,7 +284,7 @@
       "name": "@useatlas/sdk",
       "version": "0.0.9",
       "dependencies": {
-        "@useatlas/types": "^0.0.10",
+        "@useatlas/types": "^0.0.11",
       },
     },
     "packages/types": {
@@ -4213,10 +4213,6 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typespec/ts-http-runtime/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
-    "@useatlas/react/@useatlas/types": ["@useatlas/types@0.0.10", "", {}, "sha512-7vXyn/diiXCuFK6LK6ONl+WwlH8BFR1ANIzrA++B6qeBKz8Fmcsrb85Yl7ywR2FTZuPqVizmSHMzdLaSoBWOhA=="],
-
-    "@useatlas/sdk/@useatlas/types": ["@useatlas/types@0.0.10", "", {}, "sha512-7vXyn/diiXCuFK6LK6ONl+WwlH8BFR1ANIzrA++B6qeBKz8Fmcsrb85Yl7ywR2FTZuPqVizmSHMzdLaSoBWOhA=="],
 
     "@vercel/sandbox/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 

--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -23,7 +23,7 @@
     "@ai-sdk/provider": "^3.0.8",
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.0.7",
-    "@useatlas/types": "^0.0.10",
+    "@useatlas/types": "^0.0.11",
     "@better-auth/api-key": "^1.5.6",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -20,7 +20,7 @@
     "@ai-sdk/provider": "^3.0.8",
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.0.7",
-    "@useatlas/types": "^0.0.10",
+    "@useatlas/types": "^0.0.11",
     "ai": "^6.0.141",
     "@better-auth/api-key": "^1.5.6",
     "@dnd-kit/core": "^6.3.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -82,7 +82,7 @@
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^5.96.2",
-    "@useatlas/types": "^0.0.10",
+    "@useatlas/types": "^0.0.11",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "radix-ui": "^1.4.3",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -44,6 +44,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@useatlas/types": "^0.0.10"
+    "@useatlas/types": "^0.0.11"
   }
 }


### PR DESCRIPTION
## Summary
- Follow-up to #1457. `@useatlas/types@0.0.11` was published from tag `types-v0.0.11` after that merged ([npm](https://www.npmjs.com/package/@useatlas/types)).
- Points four consumers at `^0.0.11`:
  - `packages/sdk`
  - `packages/react`
  - `create-atlas/templates/docker`
  - `create-atlas/templates/nextjs-standalone`
- **Supersedes #1448.** With the scaffold now resolving `@useatlas/types@0.0.11` from npm, `ADMIN_ROLES` / `ATLAS_MODES` / `ConnectionStatus` / `./mode` are available directly — the template-sync workaround (post-processing `types.ts` re-exports) is no longer needed. Closing #1448 once this merges.

## Why this fixes Deploy Validation
Main's Deploy Validation was failing because the scaffold's `src/ui/lib/types.ts` re-exports `ADMIN_ROLES` and `ATLAS_MODES` from `@useatlas/types`. Those were added to the source package in #1442 but weren't on npm yet. Turbopack validates all static re-exports at build time → scaffold Docker build failed → Deploy Validation red. Bumping consumer refs to `^0.0.11` resolves this cleanly without a template workaround.

## Test plan
- [ ] `bun run lint`, `bun run type`, `bun run test` all green
- [ ] `bun x syncpack lint` passes (verified locally ✓)
- [ ] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` passes (verified locally — 390 files verified ✓)
- [ ] Deploy Validation green on this PR (the actual fix we're shipping)
- [ ] Scaffold smoke tests (docker + vercel) pass

Closes #1448.