### PR TITLE
feat(mode): non-admin demo indicator chip (#1434)

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -1186,7 +1186,7 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
 ### Frontend
 - [x] Connect page redesign — two equal-weight paths (#1432, PRs #1449, #1456)
 - [x] Developer mode banner + cookie-based toggle (#1433, PR #1445)
-- [ ] Non-admin demo indicator chip (#1434)
+- [x] Non-admin demo indicator chip (#1434, PR #1459)
 - [ ] Admin surface — draft/demo badges, read-only published, pending changes summary (#1435)
 - [ ] Empty states in developer mode (#1436)
 

--- a/packages/web/src/ui/__tests__/demo-indicator-chip.test.tsx
+++ b/packages/web/src/ui/__tests__/demo-indicator-chip.test.tsx
@@ -1,0 +1,125 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { render, cleanup, waitFor } from "@testing-library/react";
+import type { ModeStatusResponse } from "@useatlas/types/mode";
+
+// Controls for the mocked hooks — mutate per-test before rendering.
+const modeState = {
+  isAdmin: false,
+  isLoading: false,
+};
+let modeStatusState: {
+  data: ModeStatusResponse | null;
+  loading: boolean;
+} = { data: null, loading: false };
+
+mock.module("@/ui/hooks/use-mode", () => ({
+  useMode: () => ({ ...modeState, mode: "published", setMode: () => {} }),
+}));
+
+mock.module("@/ui/hooks/use-mode-status", () => ({
+  useModeStatus: () => modeStatusState,
+}));
+
+// Import AFTER mocks so the module binds to the mocked hooks.
+import { DemoIndicatorChip } from "../components/demo-indicator-chip";
+
+function activeMode(industry: string | null): ModeStatusResponse {
+  return {
+    mode: "published",
+    canToggle: false,
+    demoIndustry: industry,
+    demoConnectionActive: industry !== null,
+    hasDrafts: false,
+    draftCounts: null,
+  };
+}
+
+describe("DemoIndicatorChip", () => {
+  beforeEach(() => {
+    modeState.isAdmin = false;
+    modeState.isLoading = false;
+    modeStatusState = { data: null, loading: false };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("renders label when demoConnectionActive with known industry", () => {
+    modeStatusState = { data: activeMode("cybersecurity"), loading: false };
+    const { container } = render(<DemoIndicatorChip />);
+    expect(container.textContent).toContain("Sentinel Security demo");
+  });
+
+  test("renders SaaS CRM label for saas industry", () => {
+    modeStatusState = { data: activeMode("saas"), loading: false };
+    const { container } = render(<DemoIndicatorChip />);
+    expect(container.textContent).toContain("SaaS CRM demo");
+  });
+
+  test("renders NovaMart label for ecommerce industry", () => {
+    modeStatusState = { data: activeMode("ecommerce"), loading: false };
+    const { container } = render(<DemoIndicatorChip />);
+    expect(container.textContent).toContain("NovaMart demo");
+  });
+
+  test("hides when no demo connection is active (archived)", () => {
+    modeStatusState = {
+      data: {
+        mode: "published",
+        canToggle: false,
+        demoIndustry: "cybersecurity",
+        demoConnectionActive: false,
+        hasDrafts: false,
+        draftCounts: null,
+      },
+      loading: false,
+    };
+    const { container } = render(<DemoIndicatorChip />);
+    expect(container.textContent).toBe("");
+  });
+
+  test("hides when org never selected demo data (null industry)", () => {
+    modeStatusState = { data: activeMode(null), loading: false };
+    const { container } = render(<DemoIndicatorChip />);
+    expect(container.textContent).toBe("");
+  });
+
+  test("hides for admin users", () => {
+    modeState.isAdmin = true;
+    modeStatusState = { data: activeMode("cybersecurity"), loading: false };
+    const { container } = render(<DemoIndicatorChip />);
+    expect(container.textContent).toBe("");
+  });
+
+  test("hides while session is loading to avoid flash of wrong state", () => {
+    modeState.isLoading = true;
+    modeStatusState = { data: activeMode("cybersecurity"), loading: false };
+    const { container } = render(<DemoIndicatorChip />);
+    expect(container.textContent).toBe("");
+  });
+
+  test("hides while mode status is loading", () => {
+    modeStatusState = { data: null, loading: true };
+    const { container } = render(<DemoIndicatorChip />);
+    expect(container.textContent).toBe("");
+  });
+
+  test("hides for unknown industry slug to avoid leaking raw slugs", () => {
+    modeStatusState = { data: activeMode("unknown-vertical"), loading: false };
+    const { container } = render(<DemoIndicatorChip />);
+    expect(container.textContent).toBe("");
+  });
+
+  test("updates when mode status transitions to active", async () => {
+    modeStatusState = { data: activeMode(null), loading: false };
+    const { container, rerender } = render(<DemoIndicatorChip />);
+    expect(container.textContent).toBe("");
+
+    modeStatusState = { data: activeMode("cybersecurity"), loading: false };
+    rerender(<DemoIndicatorChip />);
+    await waitFor(() => {
+      expect(container.textContent).toContain("Sentinel Security demo");
+    });
+  });
+});

--- a/packages/web/src/ui/__tests__/demo-indicator-chip.test.tsx
+++ b/packages/web/src/ui/__tests__/demo-indicator-chip.test.tsx
@@ -47,8 +47,12 @@ describe("DemoIndicatorChip", () => {
 
   test("renders label when demoConnectionActive with known industry", () => {
     modeStatusState = { data: activeMode("cybersecurity"), loading: false };
-    const { container } = render(<DemoIndicatorChip />);
+    const { container, getByLabelText } = render(<DemoIndicatorChip />);
     expect(container.textContent).toContain("Sentinel Security demo");
+    // Assert the accessibility attributes so a regression that drops them
+    // (e.g. switching to a generic span) fails loudly.
+    const chip = getByLabelText("Demo dataset: Sentinel Security");
+    expect(chip.getAttribute("title")).toBe("You are viewing the Sentinel Security demo dataset");
   });
 
   test("renders SaaS CRM label for saas industry", () => {

--- a/packages/web/src/ui/components/conversations/conversation-sidebar.tsx
+++ b/packages/web/src/ui/components/conversations/conversation-sidebar.tsx
@@ -53,12 +53,12 @@ export function ConversationSidebar({
     <div className="flex h-full flex-col border-r border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950">
       <div className="flex items-center justify-between gap-2 border-b border-zinc-200 px-3 py-3 dark:border-zinc-800">
         <div className="flex min-w-0 items-center gap-2">
-          <span className="text-sm font-medium text-zinc-700 dark:text-zinc-300">History</span>
+          <span className="shrink-0 text-sm font-medium text-zinc-700 dark:text-zinc-300">History</span>
           <DemoIndicatorChip />
         </div>
         <button
           onClick={onNewChat}
-          className="rounded-lg border border-zinc-200 px-3 py-1.5 text-xs font-medium text-zinc-600 transition-colors hover:border-zinc-400 hover:text-zinc-900 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-200"
+          className="shrink-0 rounded-lg border border-zinc-200 px-3 py-1.5 text-xs font-medium text-zinc-600 transition-colors hover:border-zinc-400 hover:text-zinc-900 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-200"
         >
           + New
         </button>

--- a/packages/web/src/ui/components/conversations/conversation-sidebar.tsx
+++ b/packages/web/src/ui/components/conversations/conversation-sidebar.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { Conversation } from "../../lib/types";
 import { ConversationList } from "./conversation-list";
+import { DemoIndicatorChip } from "../demo-indicator-chip";
 
 type SidebarFilter = "all" | "saved";
 
@@ -50,8 +51,11 @@ export function ConversationSidebar({
 
   const sidebar = (
     <div className="flex h-full flex-col border-r border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950">
-      <div className="flex items-center justify-between border-b border-zinc-200 px-3 py-3 dark:border-zinc-800">
-        <span className="text-sm font-medium text-zinc-700 dark:text-zinc-300">History</span>
+      <div className="flex items-center justify-between gap-2 border-b border-zinc-200 px-3 py-3 dark:border-zinc-800">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="text-sm font-medium text-zinc-700 dark:text-zinc-300">History</span>
+          <DemoIndicatorChip />
+        </div>
         <button
           onClick={onNewChat}
           className="rounded-lg border border-zinc-200 px-3 py-1.5 text-xs font-medium text-zinc-600 transition-colors hover:border-zinc-400 hover:text-zinc-900 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-200"

--- a/packages/web/src/ui/components/demo-indicator-chip.tsx
+++ b/packages/web/src/ui/components/demo-indicator-chip.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { useMode } from "@/ui/hooks/use-mode";
+import { useModeStatus } from "@/ui/hooks/use-mode-status";
+
+/**
+ * Display labels keyed by the `demo_industry` setting written during
+ * onboarding (see `DEMO_INDUSTRIES` in `packages/api/src/api/routes/onboarding.ts`).
+ *
+ * Keep in sync with onboarding — a new industry without an entry here falls
+ * through to "no chip rendered" rather than showing a raw slug to users.
+ */
+const DEMO_INDUSTRY_LABELS: Record<string, string> = {
+  saas: "SaaS CRM",
+  cybersecurity: "Sentinel Security",
+  ecommerce: "NovaMart",
+};
+
+/**
+ * Subtle indicator shown to non-admin users when the org's workspace is
+ * running on a demo dataset. Admins already see the amber developer banner
+ * when toggled into developer mode — the chip keeps those surfaces distinct.
+ *
+ * Renders nothing when:
+ * - Mode status is loading or unavailable
+ * - The user is an admin (they have the developer banner)
+ * - The org has no active `__demo__` connection
+ * - The industry slug has no label mapping
+ */
+export function DemoIndicatorChip() {
+  const { isAdmin, isLoading: modeLoading } = useMode();
+  const { data, loading } = useModeStatus();
+
+  if (loading || modeLoading) return null;
+  if (isAdmin) return null;
+  if (!data?.demoConnectionActive) return null;
+
+  const industry = data.demoIndustry;
+  if (!industry) return null;
+
+  const label = DEMO_INDUSTRY_LABELS[industry];
+  if (!label) return null;
+
+  return (
+    <Badge
+      variant="secondary"
+      className="h-5 border-zinc-200 bg-zinc-100 px-1.5 text-[10px] font-medium text-zinc-600 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400"
+      aria-label={`Demo dataset: ${label}`}
+      title={`You are viewing the ${label} demo dataset`}
+    >
+      {label} demo
+    </Badge>
+  );
+}

--- a/packages/web/src/ui/components/demo-indicator-chip.tsx
+++ b/packages/web/src/ui/components/demo-indicator-chip.tsx
@@ -26,7 +26,8 @@ const DEMO_INDUSTRY_LABELS: Record<string, string> = {
  * - Mode status is loading or unavailable
  * - The user is an admin (they have the developer banner)
  * - The org has no active `__demo__` connection
- * - The industry slug has no label mapping
+ * - The org never selected a demo industry (null slug)
+ * - The industry slug isn't in `DEMO_INDUSTRY_LABELS` (fail-closed)
  */
 export function DemoIndicatorChip() {
   const { isAdmin, isLoading: modeLoading } = useMode();

--- a/packages/web/src/ui/components/demo-indicator-chip.tsx
+++ b/packages/web/src/ui/components/demo-indicator-chip.tsx
@@ -6,10 +6,10 @@ import { useModeStatus } from "@/ui/hooks/use-mode-status";
 
 /**
  * Display labels keyed by the `demo_industry` setting written during
- * onboarding (see `DEMO_INDUSTRIES` in `packages/api/src/api/routes/onboarding.ts`).
+ * onboarding (see `DEMO_INDUSTRIES` in `packages/api/src/api/routes/onboarding.ts:48`).
  *
- * Keep in sync with onboarding — a new industry without an entry here falls
- * through to "no chip rendered" rather than showing a raw slug to users.
+ * Fail-closed: a new industry without an entry here renders nothing rather
+ * than showing a raw slug to users.
  */
 const DEMO_INDUSTRY_LABELS: Record<string, string> = {
   saas: "SaaS CRM",

--- a/packages/web/src/ui/hooks/use-mode-status.ts
+++ b/packages/web/src/ui/hooks/use-mode-status.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useAtlasConfig } from "@/ui/context";
+import type { ModeStatusResponse } from "@useatlas/types/mode";
+
+/**
+ * Fetches `GET /api/v1/mode` for the current session. Used by UI surfaces
+ * that need to know the resolved mode, demo workspace state, or per-table
+ * draft counts (chip indicator, banner, publish button, pending-changes UI).
+ *
+ * Returns null while loading or on error — callers render nothing in that
+ * case. Errors are non-fatal: a failed fetch should never block chat.
+ */
+export function useModeStatus(): {
+  data: ModeStatusResponse | null;
+  loading: boolean;
+} {
+  const { apiUrl, isCrossOrigin } = useAtlasConfig();
+  const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
+
+  const query = useQuery<ModeStatusResponse>({
+    queryKey: ["mode-status", apiUrl],
+    queryFn: async ({ signal }) => {
+      const res = await fetch(`${apiUrl}/api/v1/mode`, { credentials, signal });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return (await res.json()) as ModeStatusResponse;
+    },
+    retry: false,
+  });
+
+  return {
+    data: query.data ?? null,
+    loading: query.isPending,
+  };
+}

--- a/packages/web/src/ui/hooks/use-mode-status.ts
+++ b/packages/web/src/ui/hooks/use-mode-status.ts
@@ -22,8 +22,23 @@ export function useModeStatus(): {
   const query = useQuery<ModeStatusResponse>({
     queryKey: ["mode-status", apiUrl],
     queryFn: async ({ signal }) => {
-      const res = await fetch(`${apiUrl}/api/v1/mode`, { credentials, signal });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      let res: Response;
+      try {
+        res = await fetch(`${apiUrl}/api/v1/mode`, { credentials, signal });
+      } catch (err) {
+        // Network failure (offline, DNS, CORS) or AbortError on unmount —
+        // log at debug so React Query devtools + browser console agree without
+        // spamming users' consoles for expected cancellations.
+        console.debug("useModeStatus fetch failed:", err instanceof Error ? err.message : String(err));
+        throw err;
+      }
+      if (!res.ok) {
+        // Read body best-effort to preserve server-provided requestId / error
+        // code when surfacing via devtools. Parse failures are non-fatal.
+        const body = await res.text().catch(() => "");
+        console.debug(`useModeStatus HTTP ${res.status}:`, body);
+        throw new Error(`HTTP ${res.status}`);
+      }
       return (await res.json()) as ModeStatusResponse;
     },
     retry: false,

--- a/packages/web/src/ui/hooks/use-mode-status.ts
+++ b/packages/web/src/ui/hooks/use-mode-status.ts
@@ -26,9 +26,12 @@ export function useModeStatus(): {
       try {
         res = await fetch(`${apiUrl}/api/v1/mode`, { credentials, signal });
       } catch (err) {
-        // Network failure (offline, DNS, CORS) or AbortError on unmount —
-        // log at debug so React Query devtools + browser console agree without
-        // spamming users' consoles for expected cancellations.
+        // Unmount / refetch abort is expected — re-throw without logging so
+        // devtools and the browser console stay quiet on normal navigation.
+        if (err instanceof DOMException && err.name === "AbortError") throw err;
+        // Network failure (offline, DNS, CORS) — log at debug so developers
+        // inspecting the browser console can correlate a missing chip to the
+        // root cause, without spamming users' consoles for expected errors.
         console.debug("useModeStatus fetch failed:", err instanceof Error ? err.message : String(err));
         throw err;
       }


### PR DESCRIPTION
## Summary
- Adds a subtle Badge in the chat sidebar header that reads `demoIndustry` + `demoConnectionActive` from `GET /api/v1/mode` and renders e.g. "Sentinel Security demo" when the org is on a demo workspace.
- Hidden for admins (they already see the amber developer banner when toggled), hidden when the demo connection is archived, and hidden for orgs that never selected demo data or for unknown industry slugs.
- No API changes — `/api/v1/mode` (#1439) already exposes both fields.

## Test plan
- [x] New `demo-indicator-chip.test.tsx` — renders labels for saas/cybersecurity/ecommerce, hides when demo archived, hides for null industry, hides for admins, hides while loading, hides for unknown slug, reacts to status transitions (10 tests).
- [x] All web tests pass (45 files).
- [x] Lint, type, full test suite, syncpack, template drift — all green.
- [ ] Manual: sign up with cybersec demo, confirm "Sentinel Security demo" chip appears in sidebar for non-admin member; admin sees no chip; archive demo → chip disappears.

Closes #1434