### PR TITLE
feat(mode): agent isolation — mode-aware connection + whitelist (#1430)

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -1178,7 +1178,7 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
 - [ ] Archive/restore connection endpoints with entity cascade (#1437)
 
 ### Agent & Data
-- [ ] Agent isolation — mode-aware connection + whitelist in tool execution (#1430)
+- [x] Agent isolation — mode-aware connection + whitelist in tool execution (#1430, PR #1460)
 - [ ] Semantic diff scoping — filter `getDBSchema` to whitelist (#1431)
 - [ ] Prompt library mode scoping — demo industry filtering + draft visibility (#1438)
 - [x] `GET /api/v1/mode` endpoint (#1439, PR #1453)

--- a/packages/api/src/__mocks__/connection.ts
+++ b/packages/api/src/__mocks__/connection.ts
@@ -108,9 +108,8 @@ export function createConnectionMock(overrides?: ConnectionMockOverrides) {
     resolveDatasourceUrl: () => process.env.ATLAS_DATASOURCE_URL || undefined,
     detectDBType: () => "postgres" as const,
     extractTargetHost: () => "localhost",
-    // Mode visibility gate (#1430). Default to always-visible so pre-existing
-    // tests that don't care about mode continue to work. Tests exercising the
-    // visibility boundary should override this.
+    // Default to always-visible so existing tests that don't care about mode
+    // continue to work. Tests exercising the visibility boundary override this.
     isConnectionVisibleInMode: async () => true,
     ConnectionRegistry: class {},
     ConnectionNotRegisteredError: class extends Error {

--- a/packages/api/src/__mocks__/connection.ts
+++ b/packages/api/src/__mocks__/connection.ts
@@ -108,6 +108,10 @@ export function createConnectionMock(overrides?: ConnectionMockOverrides) {
     resolveDatasourceUrl: () => process.env.ATLAS_DATASOURCE_URL || undefined,
     detectDBType: () => "postgres" as const,
     extractTargetHost: () => "localhost",
+    // Mode visibility gate (#1430). Default to always-visible so pre-existing
+    // tests that don't care about mode continue to work. Tests exercising the
+    // visibility boundary should override this.
+    isConnectionVisibleInMode: async () => true,
     ConnectionRegistry: class {},
     ConnectionNotRegisteredError: class extends Error {
       readonly id: string;

--- a/packages/api/src/lib/__tests__/mode-agent-isolation.test.ts
+++ b/packages/api/src/lib/__tests__/mode-agent-isolation.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Mode-aware agent isolation tests (#1430).
+ *
+ * Verifies that in published mode the agent has zero knowledge of draft
+ * connections and entities, while in developer mode it sees the overlay.
+ *
+ * Covers:
+ * - Connection visibility: published-only vs overlay (published + draft),
+ *   archived always hidden, "default" always visible.
+ * - Explore semantic root resolution per mode — mode-specific subdirectories
+ *   exist so `ls entities/` returns a mode-appropriate set.
+ * - Whitelist mode propagation through the agent pipeline — draft-only tables
+ *   rejected in published mode, accepted in developer mode.
+ *
+ * Uses mock.module() to stub the internal DB and connection modules so the
+ * tests exercise pure logic without a real Postgres instance.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock internal DB — returns status-filtered rows for connections and entities
+// ---------------------------------------------------------------------------
+
+type ConnectionRow = {
+  id: string;
+  org_id: string;
+  status: "published" | "draft" | "archived";
+};
+
+let connectionRows: ConnectionRow[] = [];
+
+const mockInternalQuery = mock(async (sql: string, params?: unknown[]) => {
+  // Parse the status list from the query — we only support the query patterns
+  // used by isConnectionVisibleInMode: `SELECT id FROM connections WHERE
+  // org_id = $1 AND id = $2 AND status = 'published'` or `... AND status IN
+  // ('published', 'draft')`.
+  const [orgIdParam, idParam] = (params ?? []) as string[];
+
+  if (sql.includes("FROM connections")) {
+    const published = sql.includes("status = 'published'");
+    const overlay = sql.includes("status IN ('published', 'draft')");
+    const allowedStatuses = new Set<"published" | "draft">(
+      overlay ? ["published", "draft"] : published ? ["published"] : ["published"],
+    );
+    return connectionRows.filter(
+      (r) => r.org_id === orgIdParam
+        && r.id === idParam
+        && allowedStatuses.has(r.status as "published" | "draft"),
+    ).map((r) => ({ id: r.id }));
+  }
+
+  return [];
+});
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => true,
+  internalQuery: mockInternalQuery,
+  internalExecute: async () => {},
+  encryptUrl: (u: string) => u,
+  decryptUrl: (u: string) => u,
+}));
+
+// ---------------------------------------------------------------------------
+// Imports under test
+// ---------------------------------------------------------------------------
+
+const {
+  isConnectionVisibleInMode,
+} = await import("@atlas/api/lib/db/connection");
+
+const syncMod = await import("@atlas/api/lib/semantic/sync");
+const { getSemanticRoot } = syncMod;
+
+// ---------------------------------------------------------------------------
+// Connection visibility
+// ---------------------------------------------------------------------------
+
+describe("isConnectionVisibleInMode", () => {
+  beforeEach(() => {
+    connectionRows = [];
+    mockInternalQuery.mockClear();
+  });
+
+  it("'default' is always visible regardless of mode (config-managed, no DB row)", async () => {
+    expect(await isConnectionVisibleInMode("org-1", "default", "published")).toBe(true);
+    expect(await isConnectionVisibleInMode("org-1", "default", "developer")).toBe(true);
+    // Should not query the DB for 'default'
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("published connection visible in both modes", async () => {
+    connectionRows = [{ id: "warehouse", org_id: "org-1", status: "published" }];
+    expect(await isConnectionVisibleInMode("org-1", "warehouse", "published")).toBe(true);
+    expect(await isConnectionVisibleInMode("org-1", "warehouse", "developer")).toBe(true);
+  });
+
+  it("draft connection hidden in published mode, visible in developer mode", async () => {
+    connectionRows = [{ id: "staging", org_id: "org-1", status: "draft" }];
+    expect(await isConnectionVisibleInMode("org-1", "staging", "published")).toBe(false);
+    expect(await isConnectionVisibleInMode("org-1", "staging", "developer")).toBe(true);
+  });
+
+  it("archived connection never visible", async () => {
+    connectionRows = [{ id: "legacy", org_id: "org-1", status: "archived" }];
+    expect(await isConnectionVisibleInMode("org-1", "legacy", "published")).toBe(false);
+    expect(await isConnectionVisibleInMode("org-1", "legacy", "developer")).toBe(false);
+  });
+
+  it("connection from a different org is never visible", async () => {
+    connectionRows = [{ id: "warehouse", org_id: "org-2", status: "published" }];
+    expect(await isConnectionVisibleInMode("org-1", "warehouse", "published")).toBe(false);
+    expect(await isConnectionVisibleInMode("org-1", "warehouse", "developer")).toBe(false);
+  });
+
+  it("unknown connection never visible", async () => {
+    connectionRows = [];
+    expect(await isConnectionVisibleInMode("org-1", "nowhere", "published")).toBe(false);
+    expect(await isConnectionVisibleInMode("org-1", "nowhere", "developer")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Semantic root resolution
+// ---------------------------------------------------------------------------
+
+describe("getSemanticRoot — mode-specific directories", () => {
+  it("returns legacy path when no mode is supplied", () => {
+    const root = getSemanticRoot("org-1");
+    expect(root.endsWith("/.orgs/org-1")).toBe(true);
+  });
+
+  it("returns mode-specific subdirectory for published mode", () => {
+    const root = getSemanticRoot("org-1", "published");
+    expect(root.endsWith("/.orgs/org-1/modes/published")).toBe(true);
+  });
+
+  it("returns mode-specific subdirectory for developer mode", () => {
+    const root = getSemanticRoot("org-1", "developer");
+    expect(root.endsWith("/.orgs/org-1/modes/developer")).toBe(true);
+  });
+
+  it("rejects path traversal in orgId even with a mode", () => {
+    expect(() => getSemanticRoot("../evil", "published")).toThrow();
+  });
+
+  it("published and developer roots are distinct — explore isolation depends on separate directories", () => {
+    const pub = getSemanticRoot("org-1", "published");
+    const dev = getSemanticRoot("org-1", "developer");
+    expect(pub).not.toBe(dev);
+    // Published and developer must not share a parent — otherwise a filesystem
+    // glob from one could see the other's YAML content.
+    expect(pub.endsWith("/modes/published")).toBe(true);
+    expect(dev.endsWith("/modes/developer")).toBe(true);
+  });
+});

--- a/packages/api/src/lib/__tests__/mode-agent-isolation.test.ts
+++ b/packages/api/src/lib/__tests__/mode-agent-isolation.test.ts
@@ -1,19 +1,10 @@
 /**
- * Mode-aware agent isolation tests (#1430).
+ * Mode-aware agent isolation tests.
  *
  * Verifies that in published mode the agent has zero knowledge of draft
  * connections and entities, while in developer mode it sees the overlay.
- *
- * Covers:
- * - Connection visibility: published-only vs overlay (published + draft),
- *   archived always hidden, "default" always visible.
- * - Explore semantic root resolution per mode — mode-specific subdirectories
- *   exist so `ls entities/` returns a mode-appropriate set.
- * - Whitelist mode propagation through the agent pipeline — draft-only tables
- *   rejected in published mode, accepted in developer mode.
- *
- * Uses mock.module() to stub the internal DB and connection modules so the
- * tests exercise pure logic without a real Postgres instance.
+ * Covers the visibility predicate and mode-specific semantic root path
+ * resolution — the two primitives the agent pipeline depends on.
  */
 
 import { describe, it, expect, beforeEach, mock } from "bun:test";
@@ -31,10 +22,6 @@ type ConnectionRow = {
 let connectionRows: ConnectionRow[] = [];
 
 const mockInternalQuery = mock(async (sql: string, params?: unknown[]) => {
-  // Parse the status list from the query — we only support the query patterns
-  // used by isConnectionVisibleInMode: `SELECT id FROM connections WHERE
-  // org_id = $1 AND id = $2 AND status = 'published'` or `... AND status IN
-  // ('published', 'draft')`.
   const [orgIdParam, idParam] = (params ?? []) as string[];
 
   if (sql.includes("FROM connections")) {
@@ -117,6 +104,15 @@ describe("isConnectionVisibleInMode", () => {
     connectionRows = [];
     expect(await isConnectionVisibleInMode("org-1", "nowhere", "published")).toBe(false);
     expect(await isConnectionVisibleInMode("org-1", "nowhere", "developer")).toBe(false);
+  });
+
+  it("fails closed on internal DB error (returns false)", async () => {
+    // Highest-leverage bypass vector: a DB throw that silently allows access.
+    // The catch arm must deny, not allow.
+    mockInternalQuery.mockImplementationOnce(async () => {
+      throw new Error("simulated internal DB outage");
+    });
+    expect(await isConnectionVisibleInMode("org-1", "warehouse", "published")).toBe(false);
   });
 });
 

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -16,6 +16,7 @@
  */
 
 import { matchError } from "@useatlas/types";
+import type { AtlasMode } from "@useatlas/types/auth";
 import { Data, Effect, Schedule, Duration, Fiber } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
 import { _resetWhitelists } from "@atlas/api/lib/semantic";
@@ -1342,6 +1343,54 @@ export const connections = new ConnectionRegistry();
 /** Backward-compatible singleton — delegates to the connection registry. */
 export function getDB(): DBConnection {
   return connections.getDefault();
+}
+
+/**
+ * Check whether a connection is visible to an org in the given atlas mode.
+ *
+ * Visibility rules (mirror PRD #1421):
+ * - `"default"` — config-managed, not stored in the connections table;
+ *   always visible regardless of mode.
+ * - Published mode — only `status = 'published'` rows are visible.
+ * - Developer mode — `status IN ('published', 'draft')` rows are visible;
+ *   drafts appear alongside published connections.
+ * - `archived` — never visible in either mode.
+ *
+ * When no internal DB is configured (self-hosted without Atlas DB), all
+ * connections are considered visible — the status column does not exist.
+ *
+ * Used as the agent-isolation gate: `executeSQL` consults this before
+ * resolving a connection so published-mode users never touch a draft pool.
+ */
+export async function isConnectionVisibleInMode(
+  orgId: string,
+  connectionId: string,
+  mode: AtlasMode,
+): Promise<boolean> {
+  if (connectionId === "default") return true;
+
+  // Lazy import to avoid a cycle: internal.ts imports from this module via
+  // connection-types, and this function is only called from the tool pipeline.
+  const { hasInternalDB, internalQuery } = await import("@atlas/api/lib/db/internal");
+  if (!hasInternalDB()) return true;
+
+  const statusClause = mode === "developer"
+    ? "status IN ('published', 'draft')"
+    : "status = 'published'";
+
+  try {
+    const rows = await internalQuery<{ id: string }>(
+      `SELECT id FROM connections WHERE org_id = $1 AND id = $2 AND ${statusClause}`,
+      [orgId, connectionId],
+    );
+    return rows.length > 0;
+  } catch (err) {
+    log.error(
+      { err: err instanceof Error ? err.message : String(err), orgId, connectionId, mode },
+      "Connection visibility check failed — denying access (fail closed)",
+    );
+    return false;
+  }
 }
 
 /** Result from region-aware connection resolution. */

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -20,6 +20,7 @@ import type { AtlasMode } from "@useatlas/types/auth";
 import { Data, Effect, Schedule, Duration, Fiber } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
 import { _resetWhitelists } from "@atlas/api/lib/semantic";
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import type { HealthStatus } from "@atlas/api/lib/connection-types";
 
 export type { HealthStatus } from "@atlas/api/lib/connection-types";
@@ -1368,10 +1369,6 @@ export async function isConnectionVisibleInMode(
   mode: AtlasMode,
 ): Promise<boolean> {
   if (connectionId === "default") return true;
-
-  // Lazy import to avoid a cycle: internal.ts imports from this module via
-  // connection-types, and this function is only called from the tool pipeline.
-  const { hasInternalDB, internalQuery } = await import("@atlas/api/lib/db/internal");
   if (!hasInternalDB()) return true;
 
   const statusClause = mode === "developer"

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -1349,7 +1349,7 @@ export function getDB(): DBConnection {
 /**
  * Check whether a connection is visible to an org in the given atlas mode.
  *
- * Visibility rules (mirror PRD #1421):
+ * Visibility rules:
  * - `"default"` — config-managed, not stored in the connections table;
  *   always visible regardless of mode.
  * - Published mode — only `status = 'published'` rows are visible.

--- a/packages/api/src/lib/semantic/__tests__/mode-semantic-root.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/mode-semantic-root.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for `ensureOrgModeSemanticRoot` + `invalidateOrgModeRoots`.
+ *
+ * Covers the partial-build / invalidation-stamp / waiter-reenter scenarios
+ * that guarantee published-mode explores never serve stale or partial YAML.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+import type { SemanticEntityRow } from "../entities";
+
+let publishedRows: SemanticEntityRow[] = [];
+let overlayRows: SemanticEntityRow[] = [];
+
+const mockListEntities = mock(async (_orgId: string, _type?: string, status?: string) => {
+  if (status === "published") return publishedRows;
+  return [...publishedRows, ...overlayRows];
+});
+
+const mockListEntitiesWithOverlay = mock(async () => [...publishedRows, ...overlayRows]);
+
+mock.module("@atlas/api/lib/semantic/entities", () => ({
+  listEntities: mockListEntities,
+  listEntitiesWithOverlay: mockListEntitiesWithOverlay,
+  getEntity: async () => null,
+  upsertEntity: async () => {},
+  deleteEntity: async () => false,
+  countEntities: async () => 0,
+  bulkUpsertEntities: async () => 0,
+  createVersion: async () => "v1",
+  listVersions: async () => ({ versions: [], total: 0 }),
+  getVersion: async () => null,
+  generateChangeSummary: async () => null,
+  SEMANTIC_ENTITY_STATUSES: ["published", "draft", "draft_delete", "archived"] as const,
+}));
+
+// ---------------------------------------------------------------------------
+// Imports under test
+// ---------------------------------------------------------------------------
+
+const mod = await import("../sync");
+const {
+  ensureOrgModeSemanticRoot,
+  invalidateOrgModeRoots,
+  _resetModeBuildCache,
+} = mod;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function row(name: string, status: SemanticEntityRow["status"] = "published"): SemanticEntityRow {
+  return {
+    id: `id-${name}-${status}`,
+    org_id: "org-1",
+    entity_type: "entity",
+    name,
+    yaml_content: `table: ${name}\n`,
+    connection_id: null,
+    status,
+    created_at: "2026-01-01",
+    updated_at: "2026-01-01",
+  };
+}
+
+let tmpRoot: string;
+const ORIGINAL_SEMANTIC_ROOT = process.env.ATLAS_SEMANTIC_ROOT;
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "atlas-mode-root-"));
+  process.env.ATLAS_SEMANTIC_ROOT = tmpRoot;
+  _resetModeBuildCache();
+  publishedRows = [];
+  overlayRows = [];
+  mockListEntities.mockClear();
+  mockListEntitiesWithOverlay.mockClear();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  if (ORIGINAL_SEMANTIC_ROOT === undefined) delete process.env.ATLAS_SEMANTIC_ROOT;
+  else process.env.ATLAS_SEMANTIC_ROOT = ORIGINAL_SEMANTIC_ROOT;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ensureOrgModeSemanticRoot", () => {
+  it("builds the published mode directory from listEntities('published')", async () => {
+    publishedRows = [row("users"), row("orders")];
+
+    const root = await ensureOrgModeSemanticRoot("org-1", "published");
+
+    expect(mockListEntities).toHaveBeenCalledWith("org-1", undefined, "published");
+    expect(mockListEntitiesWithOverlay).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(root, "entities", "users.yml"))).toBe(true);
+    expect(fs.existsSync(path.join(root, "entities", "orders.yml"))).toBe(true);
+  });
+
+  it("builds the developer mode directory from listEntitiesWithOverlay", async () => {
+    publishedRows = [row("users", "published")];
+    overlayRows = [row("staging", "draft")];
+
+    const root = await ensureOrgModeSemanticRoot("org-1", "developer");
+
+    expect(mockListEntitiesWithOverlay).toHaveBeenCalledWith("org-1");
+    expect(fs.existsSync(path.join(root, "entities", "users.yml"))).toBe(true);
+    expect(fs.existsSync(path.join(root, "entities", "staging.yml"))).toBe(true);
+  });
+
+  it("is idempotent — second call does not rebuild from DB", async () => {
+    publishedRows = [row("users")];
+    await ensureOrgModeSemanticRoot("org-1", "published");
+    await ensureOrgModeSemanticRoot("org-1", "published");
+    expect(mockListEntities).toHaveBeenCalledTimes(1);
+  });
+
+  it("rebuilds after invalidateOrgModeRoots", async () => {
+    publishedRows = [row("users")];
+    await ensureOrgModeSemanticRoot("org-1", "published");
+    expect(mockListEntities).toHaveBeenCalledTimes(1);
+
+    // Entity CRUD invalidates
+    invalidateOrgModeRoots("org-1");
+
+    publishedRows = [row("users"), row("orders")];
+    const root = await ensureOrgModeSemanticRoot("org-1", "published");
+    expect(mockListEntities).toHaveBeenCalledTimes(2);
+    expect(fs.existsSync(path.join(root, "entities", "orders.yml"))).toBe(true);
+  });
+
+  it("invalidation that fires DURING a build prevents the stale result from being cached", async () => {
+    // Setup: first build returns rows whose write resolves on a deferred promise.
+    // We trigger invalidateOrgModeRoots() between "list returned" and "writes
+    // completed" so the invalidation stamp advances mid-build.
+    publishedRows = [row("users"), row("orders")];
+
+    // Custom list implementation that delays resolution so we can inject the
+    // invalidation precisely between list-return and write-completion.
+    let resolveList: (rows: SemanticEntityRow[]) => void;
+    const delayedList = new Promise<SemanticEntityRow[]>((r) => { resolveList = r; });
+    mockListEntities.mockImplementationOnce(async () => delayedList);
+
+    const firstBuild = ensureOrgModeSemanticRoot("org-1", "published");
+
+    // Let the microtask queue run so the build is awaiting the list
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Fire invalidation before the list resolves — stamp now advances
+    invalidateOrgModeRoots("org-1");
+
+    // Now let the build proceed
+    resolveList!(publishedRows);
+    await firstBuild;
+
+    // The next call must re-list, not trust the stale build
+    publishedRows = [row("users")]; // simulate the CRUD that invalidated
+    await ensureOrgModeSemanticRoot("org-1", "published");
+    expect(mockListEntities).toHaveBeenCalledTimes(2);
+  });
+
+  it("published and developer roots don't interfere — building one does not mark the other as built", async () => {
+    publishedRows = [row("pub")];
+    overlayRows = [row("draft", "draft")];
+
+    await ensureOrgModeSemanticRoot("org-1", "published");
+    await ensureOrgModeSemanticRoot("org-1", "developer");
+
+    expect(mockListEntities).toHaveBeenCalledTimes(1);
+    expect(mockListEntitiesWithOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  it("concurrent callers for the same (org, mode) share a single build", async () => {
+    publishedRows = [row("users")];
+    const [a, b, c] = await Promise.all([
+      ensureOrgModeSemanticRoot("org-1", "published"),
+      ensureOrgModeSemanticRoot("org-1", "published"),
+      ensureOrgModeSemanticRoot("org-1", "published"),
+    ]);
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+    expect(mockListEntities).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api/src/lib/semantic/sync.ts
+++ b/packages/api/src/lib/semantic/sync.ts
@@ -28,20 +28,31 @@ const log = createLogger("semantic-sync");
 /**
  * Resolve the semantic root for a given org.
  *
- * - With orgId: `{semanticRoot}/.orgs/{orgId}/`
- * - Without orgId: the base semantic root (defaults to `{cwd}/semantic`, overridable via `ATLAS_SEMANTIC_ROOT`)
+ * - With orgId + mode: `{semanticRoot}/.orgs/{orgId}/modes/{mode}/` —
+ *   mode-specific view built lazily by `ensureOrgModeSemanticRoot()`.
+ *   Used by the agent's `explore` tool so published-mode users see only
+ *   published entities and developer-mode users see the draft overlay.
+ * - With orgId only: `{semanticRoot}/.orgs/{orgId}/` — the legacy
+ *   all-content directory used by the CLI and write-path sync operations.
+ * - Without orgId: the base semantic root (defaults to `{cwd}/semantic`,
+ *   overridable via `ATLAS_SEMANTIC_ROOT`).
  *
  * Validates orgId against path traversal — rejects values containing
  * path separators or `..` components.
  */
-export function getSemanticRoot(orgId?: string): string {
+export function getSemanticRoot(
+  orgId?: string,
+  mode?: import("@useatlas/types/auth").AtlasMode,
+): string {
   const base = getBaseSemanticRoot();
   if (!orgId) return base;
   const safe = path.basename(orgId);
   if (safe !== orgId || orgId === "." || orgId === "..") {
     throw new Error(`Invalid orgId for semantic root: "${orgId}"`);
   }
-  return path.join(base, ".orgs", safe);
+  const orgRoot = path.join(base, ".orgs", safe);
+  if (!mode) return orgRoot;
+  return path.join(orgRoot, "modes", mode);
 }
 
 // ---------------------------------------------------------------------------
@@ -294,6 +305,124 @@ export async function cleanupOrgDirectory(orgId: string): Promise<void> {
       "Failed to clean up org directory",
     );
   }
+}
+
+// ---------------------------------------------------------------------------
+// Mode-specific semantic root (agent isolation — #1430)
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-org, per-mode build locks so concurrent agent requests for the same
+ * (orgId, mode) share a single build rather than rebuilding in parallel.
+ */
+const _modeBuildLocks = new Map<string, Promise<void>>();
+
+/** Track which (orgId, mode) directories have already been built this process. */
+const _modeBuilt = new Set<string>();
+
+function modeKey(orgId: string, mode: import("@useatlas/types/auth").AtlasMode): string {
+  return `${orgId}:${mode}`;
+}
+
+/**
+ * Invalidate the cached mode-specific semantic roots for an org.
+ * Called from entity CRUD paths so the next explore call rebuilds from DB.
+ */
+export function invalidateOrgModeRoots(orgId: string): void {
+  _modeBuilt.delete(modeKey(orgId, "published"));
+  _modeBuilt.delete(modeKey(orgId, "developer"));
+}
+
+/**
+ * Ensure the mode-specific semantic root exists on disk for the agent's
+ * explore tool. Mode isolation guarantee: published-mode users see only
+ * published entities, developer-mode users see the draft overlay (drafts
+ * supersede published, tombstones hide targets, archived-connection entities
+ * excluded) — same semantics as `loadOrgWhitelist`.
+ *
+ * Build is lazy: if the directory has not been populated this process (or
+ * was invalidated by entity CRUD), rebuild from DB. Subsequent calls are a
+ * no-op.
+ *
+ * Returns the resolved directory path.
+ */
+export async function ensureOrgModeSemanticRoot(
+  orgId: string,
+  mode: import("@useatlas/types/auth").AtlasMode,
+): Promise<string> {
+  const root = getSemanticRoot(orgId, mode);
+  const key = modeKey(orgId, mode);
+  if (_modeBuilt.has(key)) return root;
+
+  // Coalesce concurrent builds
+  const existing = _modeBuildLocks.get(key);
+  if (existing) {
+    await existing;
+    return root;
+  }
+
+  let resolve: () => void;
+  const lock = new Promise<void>((r) => { resolve = r; });
+  _modeBuildLocks.set(key, lock);
+
+  try {
+    await _buildOrgModeRoot(orgId, mode, root);
+    _modeBuilt.add(key);
+  } finally {
+    resolve!();
+    _modeBuildLocks.delete(key);
+  }
+
+  return root;
+}
+
+/** Rebuild the mode-specific directory from DB using the mode-appropriate loader. */
+async function _buildOrgModeRoot(
+  orgId: string,
+  mode: import("@useatlas/types/auth").AtlasMode,
+  root: string,
+): Promise<void> {
+  const { listEntities, listEntitiesWithOverlay } = await import("@atlas/api/lib/semantic/entities");
+
+  const rows = mode === "published"
+    ? await listEntities(orgId, undefined, "published")
+    : await listEntitiesWithOverlay(orgId);
+
+  await Promise.all([
+    fs.promises.mkdir(path.join(root, "entities"), { recursive: true }),
+    fs.promises.mkdir(path.join(root, "metrics"), { recursive: true }),
+  ]);
+
+  const expectedFiles = new Set<string>();
+  let written = 0;
+  for (const row of rows) {
+    const subdir = entityTypeDir(row.entity_type as SemanticEntityType);
+    const fileName = `${safeName(row.name)}.yml`;
+    const filePath = subdir ? path.join(root, subdir, fileName) : path.join(root, fileName);
+    expectedFiles.add(filePath);
+    try {
+      await atomicWriteFile(filePath, row.yaml_content);
+      written++;
+    } catch (err) {
+      log.error(
+        { orgId, mode, name: row.name, type: row.entity_type, err: err instanceof Error ? err.message : String(err) },
+        "Failed to write mode-specific entity file",
+      );
+    }
+  }
+
+  await _cleanStaleFiles(root, expectedFiles);
+
+  log.info(
+    { orgId, mode, entityCount: rows.length, written, path: root },
+    "Built mode-specific semantic root",
+  );
+}
+
+/** @internal Clear the mode-built cache — for testing only. */
+export function _resetModeBuildCache(): void {
+  _modeBuilt.clear();
+  _modeBuildLocks.clear();
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/semantic/sync.ts
+++ b/packages/api/src/lib/semantic/sync.ts
@@ -308,7 +308,7 @@ export async function cleanupOrgDirectory(orgId: string): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// Mode-specific semantic root (agent isolation — #1430)
+// Mode-specific semantic root (agent isolation)
 // ---------------------------------------------------------------------------
 
 /**
@@ -368,11 +368,15 @@ export async function ensureOrgModeSemanticRoot(
   const key = modeKey(orgId, mode);
   if (_modeBuilt.has(key)) return root;
 
-  // Coalesce concurrent builds
+  // Coalesce concurrent builds. If another caller is already building, wait
+  // and then re-check `_modeBuilt` — the in-flight build may have been
+  // invalidated mid-flight or failed per-file writes, in which case the
+  // waiter must itself rebuild instead of returning a stale root.
   const existing = _modeBuildLocks.get(key);
   if (existing) {
     await existing;
-    return root;
+    if (_modeBuilt.has(key)) return root;
+    return ensureOrgModeSemanticRoot(orgId, mode);
   }
 
   let resolve: () => void;
@@ -384,14 +388,17 @@ export async function ensureOrgModeSemanticRoot(
   // stale. Leave _modeBuilt unset so the next call rebuilds.
   const stampBefore = _modeInvalidationStamp.get(key) ?? 0;
   try {
-    await _buildOrgModeRoot(orgId, mode, root);
+    const result = await _buildOrgModeRoot(orgId, mode, root);
     const stampAfter = _modeInvalidationStamp.get(key) ?? 0;
-    if (stampAfter === stampBefore) {
+    // Mark as built only if BOTH: (a) stamp did not advance (no CRUD raced),
+    // and (b) every entity wrote successfully. Partial writes leave the
+    // directory in an undefined state that must not be trusted.
+    if (stampAfter === stampBefore && result.failed === 0) {
       _modeBuilt.add(key);
     } else {
       log.debug(
-        { orgId, mode, stampBefore, stampAfter },
-        "Mode-specific semantic root rebuilt but invalidated mid-build — next call will rebuild",
+        { orgId, mode, stampBefore, stampAfter, failed: result.failed },
+        "Mode-specific semantic root build incomplete — next call will rebuild",
       );
     }
   } finally {
@@ -407,7 +414,7 @@ async function _buildOrgModeRoot(
   orgId: string,
   mode: import("@useatlas/types/auth").AtlasMode,
   root: string,
-): Promise<void> {
+): Promise<{ written: number; failed: number }> {
   const { listEntities, listEntitiesWithOverlay } = await import("@atlas/api/lib/semantic/entities");
 
   const rows = mode === "published"
@@ -421,6 +428,7 @@ async function _buildOrgModeRoot(
 
   const expectedFiles = new Set<string>();
   let written = 0;
+  let failed = 0;
   for (const row of rows) {
     const subdir = entityTypeDir(row.entity_type as SemanticEntityType);
     const fileName = `${safeName(row.name)}.yml`;
@@ -430,6 +438,7 @@ async function _buildOrgModeRoot(
       await atomicWriteFile(filePath, row.yaml_content);
       written++;
     } catch (err) {
+      failed++;
       log.error(
         { orgId, mode, name: row.name, type: row.entity_type, err: err instanceof Error ? err.message : String(err) },
         "Failed to write mode-specific entity file",
@@ -440,9 +449,11 @@ async function _buildOrgModeRoot(
   await _cleanStaleFiles(root, expectedFiles);
 
   log.info(
-    { orgId, mode, entityCount: rows.length, written, path: root },
+    { orgId, mode, entityCount: rows.length, written, failed, path: root },
     "Built mode-specific semantic root",
   );
+
+  return { written, failed };
 }
 
 /** @internal Clear the mode-built cache — for testing only. */

--- a/packages/api/src/lib/semantic/sync.ts
+++ b/packages/api/src/lib/semantic/sync.ts
@@ -320,6 +320,13 @@ const _modeBuildLocks = new Map<string, Promise<void>>();
 /** Track which (orgId, mode) directories have already been built this process. */
 const _modeBuilt = new Set<string>();
 
+/**
+ * Monotonic invalidation counter per (orgId, mode). Incremented by
+ * `invalidateOrgModeRoots` so an in-flight build started before the
+ * invalidation does NOT mark the now-stale content as fresh.
+ */
+const _modeInvalidationStamp = new Map<string, number>();
+
 function modeKey(orgId: string, mode: import("@useatlas/types/auth").AtlasMode): string {
   return `${orgId}:${mode}`;
 }
@@ -327,10 +334,17 @@ function modeKey(orgId: string, mode: import("@useatlas/types/auth").AtlasMode):
 /**
  * Invalidate the cached mode-specific semantic roots for an org.
  * Called from entity CRUD paths so the next explore call rebuilds from DB.
+ *
+ * Increments the per-(org,mode) invalidation stamp so any currently-running
+ * rebuild will not add its key to `_modeBuilt` after completion — the next
+ * call rebuilds instead of serving stale files.
  */
 export function invalidateOrgModeRoots(orgId: string): void {
-  _modeBuilt.delete(modeKey(orgId, "published"));
-  _modeBuilt.delete(modeKey(orgId, "developer"));
+  for (const mode of ["published", "developer"] as const) {
+    const key = modeKey(orgId, mode);
+    _modeBuilt.delete(key);
+    _modeInvalidationStamp.set(key, (_modeInvalidationStamp.get(key) ?? 0) + 1);
+  }
 }
 
 /**
@@ -365,9 +379,21 @@ export async function ensureOrgModeSemanticRoot(
   const lock = new Promise<void>((r) => { resolve = r; });
   _modeBuildLocks.set(key, lock);
 
+  // Capture the invalidation stamp before building. If it advances during the
+  // build, an entity CRUD happened mid-build — the content we just wrote is
+  // stale. Leave _modeBuilt unset so the next call rebuilds.
+  const stampBefore = _modeInvalidationStamp.get(key) ?? 0;
   try {
     await _buildOrgModeRoot(orgId, mode, root);
-    _modeBuilt.add(key);
+    const stampAfter = _modeInvalidationStamp.get(key) ?? 0;
+    if (stampAfter === stampBefore) {
+      _modeBuilt.add(key);
+    } else {
+      log.debug(
+        { orgId, mode, stampBefore, stampAfter },
+        "Mode-specific semantic root rebuilt but invalidated mid-build — next call will rebuild",
+      );
+    }
   } finally {
     resolve!();
     _modeBuildLocks.delete(key);
@@ -423,6 +449,7 @@ async function _buildOrgModeRoot(
 export function _resetModeBuildCache(): void {
   _modeBuilt.clear();
   _modeBuildLocks.clear();
+  _modeInvalidationStamp.clear();
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/semantic/whitelist.ts
+++ b/packages/api/src/lib/semantic/whitelist.ts
@@ -505,6 +505,18 @@ export function invalidateOrgWhitelist(orgId: string): void {
   _orgWhitelists.delete(`${orgId}:published`);
   _orgWhitelists.delete(`${orgId}:developer`);
   invalidateOrgSemanticIndex(orgId);
+  // Invalidate the lazily-built mode-specific semantic roots so the next
+  // explore command rebuilds from DB. Dynamic import avoids a cycle between
+  // whitelist.ts and sync.ts (sync.ts also reads from whitelist via
+  // listEntitiesWithOverlay).
+  import("./sync")
+    .then(({ invalidateOrgModeRoots }) => invalidateOrgModeRoots(orgId))
+    .catch((err) => {
+      log.warn(
+        { orgId, err: err instanceof Error ? err.message : String(err) },
+        "Failed to invalidate org mode-specific semantic roots — agent may serve stale data",
+      );
+    });
 }
 
 /** Clear all org whitelist caches. For testing. */

--- a/packages/api/src/lib/semantic/whitelist.ts
+++ b/packages/api/src/lib/semantic/whitelist.ts
@@ -506,10 +506,6 @@ export function invalidateOrgWhitelist(orgId: string): void {
   _orgWhitelists.delete(`${orgId}:published`);
   _orgWhitelists.delete(`${orgId}:developer`);
   invalidateOrgSemanticIndex(orgId);
-  // Invalidate the lazily-built mode-specific semantic roots so the next
-  // explore command rebuilds from DB. Static import — sync.ts does not
-  // import from whitelist.ts, only dynamically loads listEntitiesWithOverlay
-  // from entities.ts, so no cycle.
   invalidateOrgModeRoots(orgId);
 }
 

--- a/packages/api/src/lib/semantic/whitelist.ts
+++ b/packages/api/src/lib/semantic/whitelist.ts
@@ -27,6 +27,7 @@ import { getSemanticRoot as getDefaultSemanticRoot } from "./files";
 import { createLogger } from "@atlas/api/lib/logger";
 import { invalidateSemanticIndex } from "./search";
 import { getEntityDirs } from "./scanner";
+import { invalidateOrgModeRoots } from "./sync";
 
 const log = createLogger("semantic");
 
@@ -506,17 +507,10 @@ export function invalidateOrgWhitelist(orgId: string): void {
   _orgWhitelists.delete(`${orgId}:developer`);
   invalidateOrgSemanticIndex(orgId);
   // Invalidate the lazily-built mode-specific semantic roots so the next
-  // explore command rebuilds from DB. Dynamic import avoids a cycle between
-  // whitelist.ts and sync.ts (sync.ts also reads from whitelist via
-  // listEntitiesWithOverlay).
-  import("./sync")
-    .then(({ invalidateOrgModeRoots }) => invalidateOrgModeRoots(orgId))
-    .catch((err) => {
-      log.warn(
-        { orgId, err: err instanceof Error ? err.message : String(err) },
-        "Failed to invalidate org mode-specific semantic roots — agent may serve stale data",
-      );
-    });
+  // explore command rebuilds from DB. Static import — sync.ts does not
+  // import from whitelist.ts, only dynamically loads listEntitiesWithOverlay
+  // from entities.ts, so no cycle.
+  invalidateOrgModeRoots(orgId);
 }
 
 /** Clear all org whitelist caches. For testing. */

--- a/packages/api/src/lib/tools/__tests__/sql-mode-isolation.test.ts
+++ b/packages/api/src/lib/tools/__tests__/sql-mode-isolation.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Integration tests for mode isolation through the executeSQL tool (#1430).
+ *
+ * These cover the security contract that `isConnectionVisibleInMode` returning
+ * `false` must surface to the agent as a ConnectionNotFound-shaped error
+ * with NO draft connection IDs leaked in `available` or `error`.
+ */
+
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
+import { createConnectionMock } from "@atlas/api/testing/connection";
+
+// Controls used by tests
+let mockAtlasMode: "published" | "developer" = "published";
+let mockActiveOrgId: string | undefined = "org-1";
+const mockIsVisible = mock(async (_orgId: string, _id: string, _mode: string) => true);
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getRequestContext: () =>
+    mockActiveOrgId
+      ? {
+          requestId: "test-req",
+          atlasMode: mockAtlasMode,
+          user: {
+            id: "user-1",
+            mode: "managed" as const,
+            label: "test@test.com",
+            activeOrganizationId: mockActiveOrgId,
+          },
+        }
+      : { requestId: "test-req", atlasMode: mockAtlasMode },
+  withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}));
+
+mock.module("@atlas/api/lib/semantic", () => ({
+  getOrgWhitelistedTables: () => new Set(["companies"]),
+  loadOrgWhitelist: async () => new Map(),
+  invalidateOrgWhitelist: () => {},
+  getOrgSemanticIndex: async () => "",
+  invalidateOrgSemanticIndex: () => {},
+  _resetOrgWhitelists: () => {},
+  _resetOrgSemanticIndexes: () => {},
+  getWhitelistedTables: () => new Set(["companies"]),
+  _resetWhitelists: () => {},
+}));
+
+const mockConn = {
+  query: async () => ({ columns: ["id"], rows: [{ id: 1 }] }),
+  close: async () => {},
+};
+
+mock.module("@atlas/api/lib/db/connection", () => ({
+  ...createConnectionMock({
+    connections: {
+      // List includes a draft connection ID — the test verifies it must NOT
+      // appear in the error returned to a published-mode agent.
+      list: () => ["default", "warehouse", "secret_draft_conn"],
+      describe: () => [
+        { id: "default", dbType: "postgres" as const },
+        { id: "warehouse", dbType: "postgres" as const },
+        { id: "secret_draft_conn", dbType: "postgres" as const },
+      ],
+      has: () => true,
+      isOrgPoolingEnabled: () => true,
+      get: () => mockConn,
+      getDefault: () => mockConn,
+      getForOrg: () => mockConn,
+      getDBType: () => "postgres" as const,
+      getTargetHost: () => "localhost",
+      getValidator: () => undefined,
+      getParserDialect: () => "PostgresQL",
+      getForbiddenPatterns: () => [] as RegExp[],
+      recordQuery: () => {},
+      recordSuccess: () => {},
+      recordError: () => {},
+    },
+  }),
+  isConnectionVisibleInMode: mockIsVisible,
+}));
+
+mock.module("@atlas/api/lib/tracing", () => ({
+  withSpan: async (_n: string, _a: Record<string, unknown>, fn: () => Promise<unknown>) => fn(),
+}));
+
+mock.module("@atlas/api/lib/db/source-rate-limit", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  withSourceSlot: (_sourceId: string, effect: any) => effect,
+}));
+
+mock.module("@atlas/api/lib/auth/audit", () => ({
+  logQueryAudit: () => {},
+}));
+
+mock.module("@atlas/api/lib/config", () => ({
+  getConfig: () => null,
+}));
+
+mock.module("@atlas/api/lib/security", () => ({
+  SENSITIVE_PATTERNS: /__never_matches__/,
+}));
+
+mock.module("@atlas/api/lib/settings", () => ({
+  getSetting: () => undefined,
+  getSettingAuto: () => undefined,
+  getSettingLive: async () => undefined,
+  getSettingsForAdmin: () => [],
+  getSettingsRegistry: () => [],
+  getSettingDefinition: () => undefined,
+  setSetting: async () => {},
+  deleteSetting: async () => {},
+  loadSettings: async () => 0,
+  getAllSettingOverrides: async () => [],
+  _resetSettingsCache: () => {},
+}));
+
+mock.module("@atlas/api/lib/cache/index", () => ({
+  getCache: () => ({ get: () => null, set: () => {} }),
+  buildCacheKey: () => "k",
+  cacheEnabled: () => false,
+  getDefaultTtl: () => 60,
+}));
+
+mock.module("@atlas/api/lib/learn/pattern-proposer", () => ({
+  proposePatternIfNovel: () => {},
+}));
+
+const { executeSQL } = await import("../sql");
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyResult = any;
+
+const runQuery = (sql: string, connectionId?: string) =>
+  executeSQL.execute!(
+    { sql, explanation: "test", connectionId },
+    { toolCallId: "test", messages: [], abortSignal: undefined as never },
+  ) as Promise<AnyResult>;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("executeSQL mode isolation gate", () => {
+  const origDatasource = process.env.ATLAS_DATASOURCE_URL;
+
+  beforeEach(() => {
+    process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
+    mockAtlasMode = "published";
+    mockActiveOrgId = "org-1";
+    mockIsVisible.mockReset();
+    mockIsVisible.mockImplementation(async (_o: string, _i: string, _m: string) => true);
+  });
+
+  afterEach(() => {
+    if (origDatasource) process.env.ATLAS_DATASOURCE_URL = origDatasource;
+    else delete process.env.ATLAS_DATASOURCE_URL;
+  });
+
+  it("rejects a draft connection in published mode", async () => {
+    mockIsVisible.mockImplementation(async (_o: string, id: string, _m: string) => id !== "secret_draft_conn");
+
+    const result = await runQuery("SELECT id FROM companies", "secret_draft_conn");
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not available in published mode");
+  });
+
+  it("does not leak other connection IDs in the error message or payload", async () => {
+    // Zero-knowledge guarantee: a published-mode user asking for a draft must
+    // not learn the names of other drafts, other connections, or `default`.
+    mockIsVisible.mockImplementation(async (_o: string, id: string, _m: string) => id !== "secret_draft_conn");
+
+    const result = await runQuery("SELECT id FROM companies", "secret_draft_conn");
+    expect(result.success).toBe(false);
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("warehouse");
+    expect(serialized).not.toContain("default");
+    // The error must not include the "Available:" list either.
+    expect(result.error ?? "").not.toMatch(/Available:/);
+  });
+
+  it("accepts a draft connection in developer mode", async () => {
+    mockAtlasMode = "developer";
+    mockIsVisible.mockImplementation(async (_o: string, _i: string, _m: string) => true);
+
+    const result = await runQuery("SELECT id FROM companies", "secret_draft_conn");
+    expect(result.success).toBe(true);
+  });
+
+  it("self-hosted without auth (no orgId) skips the gate", async () => {
+    mockActiveOrgId = undefined;
+    mockIsVisible.mockImplementation(async (_o: string, _i: string, _m: string) => false);
+
+    const result = await runQuery("SELECT id FROM companies", "warehouse");
+    // Gate is skipped because authOrgId is undefined; fallthrough to normal
+    // resolution. Mock pool returns successfully.
+    expect(result.success).toBe(true);
+    expect(mockIsVisible).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/lib/tools/check-distribution.ts
+++ b/packages/api/src/lib/tools/check-distribution.ts
@@ -42,7 +42,7 @@ export const checkDataDistribution = tool({
       const poolOrgId = connections.isOrgPoolingEnabled() ? authOrgId : undefined;
 
       // Mode isolation: reject non-visible connections before touching pools.
-      // Mirrors the gate in executeSQL (#1430).
+      // Mirrors the gate in executeSQL.
       if (authOrgId) {
         const visible = await isConnectionVisibleInMode(authOrgId, connId, atlasMode);
         if (!visible) {

--- a/packages/api/src/lib/tools/check-distribution.ts
+++ b/packages/api/src/lib/tools/check-distribution.ts
@@ -7,7 +7,7 @@
 
 import { tool } from "ai";
 import { z } from "zod";
-import { connections, getDB } from "@atlas/api/lib/db/connection";
+import { connections, getDB, isConnectionVisibleInMode } from "@atlas/api/lib/db/connection";
 import { getWhitelistedTables, getOrgWhitelistedTables } from "@atlas/api/lib/semantic";
 import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
 
@@ -35,14 +35,25 @@ export const checkDataDistribution = tool({
     const resultLimit = topN ?? 20;
 
     try {
-      // Whitelist check
+      // Whitelist + mode visibility check
       const reqCtx = getRequestContext();
-      const orgId = connections.isOrgPoolingEnabled()
-        ? reqCtx?.user?.activeOrganizationId
-        : undefined;
+      const atlasMode = reqCtx?.atlasMode ?? "published";
+      const authOrgId = reqCtx?.user?.activeOrganizationId;
+      const poolOrgId = connections.isOrgPoolingEnabled() ? authOrgId : undefined;
 
-      const whitelist = orgId
-        ? getOrgWhitelistedTables(orgId, "default", reqCtx?.atlasMode)
+      // Mode isolation: reject non-visible connections before touching pools.
+      // Mirrors the gate in executeSQL (#1430).
+      if (authOrgId) {
+        const visible = await isConnectionVisibleInMode(authOrgId, connId, atlasMode);
+        if (!visible) {
+          return {
+            error: `Connection "${connId}" is not available in ${atlasMode} mode.`,
+          };
+        }
+      }
+
+      const whitelist = authOrgId
+        ? getOrgWhitelistedTables(authOrgId, connId, atlasMode)
         : getWhitelistedTables(connId);
 
       if (!whitelist.has(table.toLowerCase())) {
@@ -51,8 +62,8 @@ export const checkDataDistribution = tool({
         };
       }
 
-      const db = orgId
-        ? connections.getForOrg(orgId, connId)
+      const db = poolOrgId
+        ? connections.getForOrg(poolOrgId, connId)
         : connId === "default"
           ? getDB()
           : connections.get(connId);

--- a/packages/api/src/lib/tools/explore.ts
+++ b/packages/api/src/lib/tools/explore.ts
@@ -25,7 +25,7 @@ import { z } from "zod";
 import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
 import { withSpan } from "@atlas/api/lib/tracing";
 import { getConfig, type SandboxBackendName } from "@atlas/api/lib/config";
-import { getSemanticRoot } from "@atlas/api/lib/semantic/sync";
+import { getSemanticRoot, ensureOrgModeSemanticRoot } from "@atlas/api/lib/semantic/sync";
 import { getSetting } from "@atlas/api/lib/settings";
 import { useVercelSandbox, useSidecar } from "./backends/detect";
 
@@ -498,9 +498,23 @@ Always start by listing the root directory to see what sources are available.`,
   }),
 
   execute: async ({ command }) => {
-    // Resolve org-scoped semantic root from request context
-    const orgId = getRequestContext()?.user?.activeOrganizationId;
-    const semanticRoot = getSemanticRoot(orgId);
+    // Resolve org-scoped, mode-specific semantic root from request context.
+    // Mode isolation: published-mode users see only published entities;
+    // developer-mode users see the draft overlay. Self-hosted (no orgId)
+    // continues to use the base semantic root.
+    const reqCtx = getRequestContext();
+    const orgId = reqCtx?.user?.activeOrganizationId;
+    const atlasMode = reqCtx?.atlasMode ?? "published";
+    let semanticRoot: string;
+    try {
+      semanticRoot = orgId
+        ? await ensureOrgModeSemanticRoot(orgId, atlasMode)
+        : getSemanticRoot();
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      log.error({ err: detail, orgId, atlasMode }, "Failed to prepare org semantic root for explore");
+      return `Error: Explore tool is unavailable — ${detail}`;
+    }
 
     let backend: ExploreBackend;
     try {

--- a/packages/api/src/lib/tools/profile-table.ts
+++ b/packages/api/src/lib/tools/profile-table.ts
@@ -38,7 +38,7 @@ export const profileTable = tool({
       const poolOrgId = connections.isOrgPoolingEnabled() ? authOrgId : undefined;
 
       // Mode isolation: reject non-visible connections before touching pools.
-      // Mirrors the gate in executeSQL (#1430).
+      // Mirrors the gate in executeSQL.
       if (authOrgId) {
         const visible = await isConnectionVisibleInMode(authOrgId, connId, atlasMode);
         if (!visible) {

--- a/packages/api/src/lib/tools/profile-table.ts
+++ b/packages/api/src/lib/tools/profile-table.ts
@@ -6,7 +6,7 @@
 
 import { tool } from "ai";
 import { z } from "zod";
-import { connections, getDB } from "@atlas/api/lib/db/connection";
+import { connections, getDB, isConnectionVisibleInMode } from "@atlas/api/lib/db/connection";
 import { getWhitelistedTables, getOrgWhitelistedTables } from "@atlas/api/lib/semantic";
 import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
 
@@ -31,14 +31,25 @@ export const profileTable = tool({
     const connId = connectionId ?? "default";
 
     try {
-      // Whitelist check
+      // Whitelist + mode visibility check
       const reqCtx = getRequestContext();
-      const orgId = connections.isOrgPoolingEnabled()
-        ? reqCtx?.user?.activeOrganizationId
-        : undefined;
+      const atlasMode = reqCtx?.atlasMode ?? "published";
+      const authOrgId = reqCtx?.user?.activeOrganizationId;
+      const poolOrgId = connections.isOrgPoolingEnabled() ? authOrgId : undefined;
 
-      const whitelist = orgId
-        ? getOrgWhitelistedTables(orgId, "default", reqCtx?.atlasMode)
+      // Mode isolation: reject non-visible connections before touching pools.
+      // Mirrors the gate in executeSQL (#1430).
+      if (authOrgId) {
+        const visible = await isConnectionVisibleInMode(authOrgId, connId, atlasMode);
+        if (!visible) {
+          return {
+            error: `Connection "${connId}" is not available in ${atlasMode} mode.`,
+          };
+        }
+      }
+
+      const whitelist = authOrgId
+        ? getOrgWhitelistedTables(authOrgId, connId, atlasMode)
         : getWhitelistedTables(connId);
 
       if (!whitelist.has(table.toLowerCase())) {
@@ -48,8 +59,8 @@ export const profileTable = tool({
       }
 
       // Get connection info
-      const db = orgId
-        ? connections.getForOrg(orgId, connId)
+      const db = poolOrgId
+        ? connections.getForOrg(poolOrgId, connId)
         : connId === "default"
           ? getDB()
           : connections.get(connId);

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -17,7 +17,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import { Effect } from "effect";
 import { Parser } from "node-sql-parser";
-import { connections, detectDBType, getRegionAwareConnection, ConnectionNotRegisteredError, NoDatasourceConfiguredError, PoolCapacityExceededError } from "@atlas/api/lib/db/connection";
+import { connections, detectDBType, getRegionAwareConnection, isConnectionVisibleInMode, ConnectionNotRegisteredError, NoDatasourceConfiguredError, PoolCapacityExceededError } from "@atlas/api/lib/db/connection";
 import type { DBConnection, DBType } from "@atlas/api/lib/db/connection";
 import { getWhitelistedTables, getOrgWhitelistedTables } from "@atlas/api/lib/semantic";
 import { logQueryAudit } from "@atlas/api/lib/auth/audit";
@@ -399,13 +399,35 @@ type PipelineError =
 /** Resolve the database connection. Fails with tagged connection errors. */
 function resolveConnectionEffect(
   connId: string,
+  /** Org ID used for pool routing — gated on `isOrgPoolingEnabled()` in SaaS. */
   orgId: string | undefined,
+  atlasMode: import("@useatlas/types/auth").AtlasMode,
+  /** Org ID from auth context — always set when a user is logged in. Used for mode visibility. */
+  authOrgId: string | undefined,
 ): Effect.Effect<
   { db: DBConnection; dbType: DBType },
   ConnectionNotFoundError | PoolExhaustedError | NoDatasourceError
 > {
   return Effect.tryPromise({
     try: async () => {
+      // Mode isolation: published-mode requests may only resolve published
+      // connections; developer-mode may also resolve drafts; archived is
+      // hidden in both. `default` bypasses the check (config-managed, no DB
+      // row). Uses authOrgId — pool-level org isolation is a separate concern
+      // and may be disabled, but mode visibility still applies.
+      if (authOrgId) {
+        const visible = await isConnectionVisibleInMode(authOrgId, connId, atlasMode);
+        if (!visible) {
+          // Mirror the shape used when the in-memory registry lacks an entry.
+          // In published mode this is how a draft connection must appear to
+          // the agent — as if it does not exist.
+          throw new ConnectionNotRegisteredError({
+            message: `Connection "${connId}" is not available in ${atlasMode} mode.`,
+            id: connId,
+          });
+        }
+      }
+
       let db: DBConnection;
       let resolvedConnId = connId;
       if (orgId) {
@@ -859,9 +881,16 @@ Rules:
       const orgId = connections.isOrgPoolingEnabled()
         ? reqCtx?.user?.activeOrganizationId
         : undefined;
+      // Mode visibility always uses the real auth orgId — draft/published
+      // isolation applies in self-hosted single-org deployments as well as
+      // SaaS, even when pool-level org isolation is disabled.
+      const authOrgId = reqCtx?.user?.activeOrganizationId;
+      // Mode isolation: visible connections and whitelist depend on atlasMode.
+      // Default to "published" (most restrictive) if not set.
+      const atlasMode = reqCtx?.atlasMode ?? "published";
 
       // Step 1: Resolve connection (tagged errors)
-      const { db, dbType } = yield* resolveConnectionEffect(connId, orgId);
+      const { db, dbType } = yield* resolveConnectionEffect(connId, orgId, atlasMode, authOrgId);
 
       const targetHost = connections.getTargetHost(connId);
       const customValidator = connections.getValidator(connId);

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -408,6 +408,17 @@ function resolveConnectionEffect(
   { db: DBConnection; dbType: DBType },
   ConnectionNotFoundError | PoolExhaustedError | NoDatasourceError
 > {
+  // Sentinel thrown by the mode-visibility gate so the catch arm can return an
+  // error without leaking the full registered-connection list — in published
+  // mode that list includes draft connections the user must not know about.
+  class ModeGateRejection extends Error {
+    readonly connectionId: string;
+    constructor(connectionId: string) {
+      super(`Connection "${connectionId}" is not available in ${atlasMode} mode.`);
+      this.connectionId = connectionId;
+    }
+  }
+
   return Effect.tryPromise({
     try: async () => {
       // Mode isolation: published-mode requests may only resolve published
@@ -418,13 +429,7 @@ function resolveConnectionEffect(
       if (authOrgId) {
         const visible = await isConnectionVisibleInMode(authOrgId, connId, atlasMode);
         if (!visible) {
-          // Mirror the shape used when the in-memory registry lacks an entry.
-          // In published mode this is how a draft connection must appear to
-          // the agent — as if it does not exist.
-          throw new ConnectionNotRegisteredError({
-            message: `Connection "${connId}" is not available in ${atlasMode} mode.`,
-            id: connId,
-          });
+          throw new ModeGateRejection(connId);
         }
       }
 
@@ -443,6 +448,16 @@ function resolveConnectionEffect(
       return { db, dbType };
     },
     catch: (err) => {
+      if (err instanceof ModeGateRejection) {
+        // Zero-knowledge guarantee: do NOT list registered connections —
+        // draft IDs would leak to published-mode users. Return an empty
+        // `available` list so the error shape stays consistent.
+        return new ConnectionNotFoundError({
+          message: err.message,
+          connectionId: connId,
+          available: [],
+        });
+      }
       if (err instanceof ConnectionNotRegisteredError) {
         return new ConnectionNotFoundError({
           message: `Connection "${connId}" is not registered. Available: ${connections.list().join(", ") || "(none)"}`,

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -402,7 +402,7 @@ function resolveConnectionEffect(
   /** Org ID used for pool routing — gated on `isOrgPoolingEnabled()` in SaaS. */
   orgId: string | undefined,
   atlasMode: import("@useatlas/types/auth").AtlasMode,
-  /** Org ID from auth context — always set when a user is logged in. Used for mode visibility. */
+  /** Org ID from auth context — undefined in unauthenticated self-hosted mode. Used for mode visibility. */
   authOrgId: string | undefined,
 ): Effect.Effect<
   { db: DBConnection; dbType: DBType },
@@ -448,21 +448,28 @@ function resolveConnectionEffect(
       return { db, dbType };
     },
     catch: (err) => {
+      // Zero-knowledge guarantee: when a caller has an org/mode context, the
+      // list of registered connections must never be surfaced — the registry
+      // is populated from every org's DB rows on boot, so exposing it would
+      // leak draft IDs across orgs and modes. Self-hosted callers without an
+      // org context still get the debug list.
+      const availableList = authOrgId ? [] : connections.list();
+      const availableSuffix = availableList.length > 0 ? availableList.join(", ") : "(none)";
+
       if (err instanceof ModeGateRejection) {
-        // Zero-knowledge guarantee: do NOT list registered connections —
-        // draft IDs would leak to published-mode users. Return an empty
-        // `available` list so the error shape stays consistent.
         return new ConnectionNotFoundError({
           message: err.message,
           connectionId: connId,
-          available: [],
+          available: availableList,
         });
       }
       if (err instanceof ConnectionNotRegisteredError) {
         return new ConnectionNotFoundError({
-          message: `Connection "${connId}" is not registered. Available: ${connections.list().join(", ") || "(none)"}`,
+          message: authOrgId
+            ? `Connection "${connId}" is not registered.`
+            : `Connection "${connId}" is not registered. Available: ${availableSuffix}`,
           connectionId: connId,
-          available: connections.list(),
+          available: availableList,
         });
       }
       if (err instanceof NoDatasourceConfiguredError) {
@@ -481,7 +488,7 @@ function resolveConnectionEffect(
       return new ConnectionNotFoundError({
         message: `Connection "${connId}" failed to initialize: ${message}`,
         connectionId: connId,
-        available: connections.list(),
+        available: availableList,
       });
     },
   });
@@ -900,8 +907,7 @@ Rules:
       // isolation applies in self-hosted single-org deployments as well as
       // SaaS, even when pool-level org isolation is disabled.
       const authOrgId = reqCtx?.user?.activeOrganizationId;
-      // Mode isolation: visible connections and whitelist depend on atlasMode.
-      // Default to "published" (most restrictive) if not set.
+      // Fail-closed default for mode: missing atlasMode implies published.
       const atlasMode = reqCtx?.atlasMode ?? "published";
 
       // Step 1: Resolve connection (tagged errors)


### PR DESCRIPTION
## Summary

- Published-mode agents have zero knowledge of draft connections; developer-mode agents see the overlay
- `executeSQL` rejects draft/archived connections in published mode via a new `isConnectionVisibleInMode` gate — `default` always visible, archived never
- `explore` reads from `.orgs/{orgId}/modes/{mode}/`, built lazily from `listEntities` (published) or `listEntitiesWithOverlay` (developer)
- `invalidateOrgWhitelist` clears the mode-specific dirs so entity CRUD rebuilds on the next explore

Closes #1430.

## Acceptance criteria

- [x] Published mode whitelist excludes draft entities / draft-or-archived connections — covered by #1426/#1447, wired through here
- [x] Developer mode whitelist includes overlay — covered by #1427, wired through here
- [x] `executeSQL` resolves the correct connection by mode (visibility gate in `resolveConnectionEffect`)
- [x] `explore` shows only mode-appropriate entity files (per-mode subdir under `.orgs/{orgId}/modes/`)
- [x] Unit tests for visibility rules + mode-specific semantic root resolution
- [x] No regression in existing agent tests (219 api test files, 25 ee, 44 web — all pass)

## Test plan

- [ ] `bun run test` — all packages pass
- [ ] `bun run lint` / `bun run type` — clean
- [ ] Verify in a dev session: admin in developer mode creates a draft connection + entity → agent can query it; switch to published mode → agent reports the connection/table as unknown