### PR TITLE
feat(mode): write-path mode-awareness (#1428)

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -1171,7 +1171,7 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
 ### Query Layer
 - [x] Published mode query filtering across connections, entities, prompts (#1426, PR #1447)
 - [x] Developer mode overlay queries — entity CTE + union queries (#1427, PR #1451)
-- [ ] Write path mode-awareness — draft creation, draft edits, tombstones (#1428)
+- [x] Write path mode-awareness — draft creation, draft edits, tombstones (#1428)
 
 ### Publishing
 - [ ] Atomic publish endpoint with `archiveConnections` parameter (#1429)

--- a/packages/api/src/api/__tests__/admin-connections.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections.test.ts
@@ -709,6 +709,52 @@ describe("admin connections — org scoping", () => {
           sql.includes("status"),
       );
       expect(updateCall).toBeDefined();
+      // Revival UPDATE must be scoped to the composite PK — id AND org_id
+      expect(updateCall![0] as string).toContain("WHERE id =");
+      expect(updateCall![0] as string).toContain("org_id");
+      const updateParams = updateCall![1] as unknown[];
+      // status revives to 'published' (default mode), then id, then orgId
+      expect(updateParams).toContain("published");
+      expect(updateParams).toContain("analytics");
+      expect(updateParams).toContain("org-alpha");
+      const staleInsert = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) =>
+          typeof sql === "string" && sql.includes("INSERT INTO connections"),
+      );
+      expect(staleInsert).toBeUndefined();
+    });
+
+    it("non-demo PUT in developer mode is immediate direct UPDATE (not staged)", async () => {
+      // AC: connection edits are immediate per PRD — even in developer mode
+      setOrgAdmin("org-alpha");
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sql.includes("SELECT") && sql.includes("connections")) {
+          return Promise.resolve([{
+            id: "warehouse",
+            url: "encrypted:postgresql://user:pass@host/db",
+            type: "postgres",
+            description: "Warehouse",
+            schema_name: null,
+          }]);
+        }
+        return Promise.resolve([]);
+      });
+      const res = await app.fetch(
+        adminRequest(
+          "/api/v1/admin/connections/warehouse",
+          "PUT",
+          { description: "edited in dev" },
+          "atlas-mode=developer",
+        ),
+      );
+      expect(res.status).toBe(200);
+      // Verify we ran UPDATE — not an INSERT (draft-copy semantics would be wrong for connections)
+      const updateCall = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) =>
+          typeof sql === "string" &&
+          sql.includes("UPDATE connections SET url"),
+      );
+      expect(updateCall).toBeDefined();
       const staleInsert = mocks.mockInternalQuery.mock.calls.find(
         ([sql]) =>
           typeof sql === "string" && sql.includes("INSERT INTO connections"),

--- a/packages/api/src/api/__tests__/admin-connections.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections.test.ts
@@ -490,12 +490,16 @@ describe("admin connections — org scoping", () => {
       const body = (await res.json()) as any;
       expect(body.success).toBe(true);
 
-      // Verify DELETE includes org_id filter (composite PK scoping)
-      const deleteCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) => typeof sql === "string" && sql.includes("DELETE") && sql.includes("connections"),
+      // Delete is implemented as an archive UPDATE (#1428) — verify it
+      // includes the org_id filter (composite PK scoping)
+      const archiveCall = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) =>
+          typeof sql === "string" &&
+          sql.includes("UPDATE connections") &&
+          sql.includes("archived"),
       );
-      expect(deleteCall).toBeDefined();
-      expect(deleteCall![0]).toContain("org_id");
+      expect(archiveCall).toBeDefined();
+      expect(archiveCall![0]).toContain("org_id");
     });
   });
 
@@ -629,6 +633,149 @@ describe("admin connections — org scoping", () => {
       expect(call![0]).not.toContain("status = 'published'");
       // Archived rows are always excluded — never appears in either mode
       expect(call![0]).not.toContain("archived");
+    });
+  });
+
+  // ─── Write-path mode-awareness (#1428) ────────────────────────────────
+
+  describe("POST /connections — mode-aware create", () => {
+    beforeEach(() => {
+      setOrgAdmin("org-alpha");
+    });
+
+    it("published mode inserts status='published'", async () => {
+      mocks.mockInternalQuery.mockResolvedValue([]);
+      const res = await app.fetch(
+        adminRequest("/api/v1/admin/connections", "POST", {
+          id: "analytics",
+          url: "postgresql://user:pass@host/db",
+        }),
+      );
+      expect(res.status).toBe(201);
+      const insertCall = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) => typeof sql === "string" && sql.includes("INSERT INTO connections"),
+      );
+      expect(insertCall).toBeDefined();
+      const [sql, params] = insertCall!;
+      expect(sql).toContain("status");
+      expect((params as unknown[])[(params as unknown[]).length - 1]).toBe("published");
+    });
+
+    it("developer mode inserts status='draft'", async () => {
+      mocks.mockInternalQuery.mockResolvedValue([]);
+      const res = await app.fetch(
+        adminRequest(
+          "/api/v1/admin/connections",
+          "POST",
+          { id: "analytics", url: "postgresql://user:pass@host/db" },
+          "atlas-mode=developer",
+        ),
+      );
+      expect(res.status).toBe(201);
+      const insertCall = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) => typeof sql === "string" && sql.includes("INSERT INTO connections"),
+      );
+      expect(insertCall).toBeDefined();
+      const [sql, params] = insertCall!;
+      expect(sql).toContain("status");
+      // status is the last parameter — verify it's 'draft'
+      expect((params as unknown[])[(params as unknown[]).length - 1]).toBe("draft");
+    });
+  });
+
+  describe("PUT /connections/__demo__ — demo gating", () => {
+    it("rejects demo writes in published mode with 403 and descriptive message", async () => {
+      setOrgAdmin("org-alpha");
+      const res = await app.fetch(
+        adminRequest("/api/v1/admin/connections/__demo__", "PUT", { description: "tampered" }),
+      );
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("demo_readonly");
+      expect(String(body.message)).toMatch(/developer mode/i);
+    });
+
+    it("allows demo writes in developer mode (hits the DB select)", async () => {
+      setOrgAdmin("org-alpha");
+      // The select returns empty — we only care that the demo gate doesn't fire first
+      mocks.mockInternalQuery.mockResolvedValue([]);
+      const res = await app.fetch(
+        adminRequest(
+          "/api/v1/admin/connections/__demo__",
+          "PUT",
+          { description: "editing demo in dev" },
+          "atlas-mode=developer",
+        ),
+      );
+      // Returns 404 because we haven't seeded the row in the mock, but the demo
+      // gate didn't fire — that's what we're verifying
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("DELETE /connections — mode-aware archive", () => {
+    it("archives (status='archived') instead of hard delete", async () => {
+      setOrgAdmin("org-alpha");
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sql.includes("SELECT") && sql.includes("connections")) {
+          return Promise.resolve([{ id: "warehouse" }]);
+        }
+        return Promise.resolve([{ count: "0" }]);
+      });
+      const res = await app.fetch(
+        adminRequest("/api/v1/admin/connections/warehouse", "DELETE"),
+      );
+      expect(res.status).toBe(200);
+      const archiveCall = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) =>
+          typeof sql === "string" &&
+          sql.includes("UPDATE connections") &&
+          sql.includes("status") &&
+          sql.includes("archived"),
+      );
+      expect(archiveCall).toBeDefined();
+      const hardDelete = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) =>
+          typeof sql === "string" &&
+          sql.includes("DELETE FROM connections WHERE id"),
+      );
+      expect(hardDelete).toBeUndefined();
+    });
+
+    it("rejects DELETE on __demo__ in published mode with 403", async () => {
+      setOrgAdmin("org-alpha");
+      const res = await app.fetch(
+        adminRequest("/api/v1/admin/connections/__demo__", "DELETE"),
+      );
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("demo_readonly");
+    });
+
+    it("allows DELETE on __demo__ in developer mode (archives instead of hard delete)", async () => {
+      setOrgAdmin("org-alpha");
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sql.includes("SELECT") && sql.includes("connections")) {
+          return Promise.resolve([{ id: "__demo__" }]);
+        }
+        return Promise.resolve([{ count: "0" }]);
+      });
+      const res = await app.fetch(
+        adminRequest(
+          "/api/v1/admin/connections/__demo__",
+          "DELETE",
+          undefined,
+          "atlas-mode=developer",
+        ),
+      );
+      expect(res.status).toBe(200);
+      const archiveCall = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) =>
+          typeof sql === "string" &&
+          sql.includes("UPDATE connections") &&
+          sql.includes("archived"),
+      );
+      expect(archiveCall).toBeDefined();
     });
   });
 });

--- a/packages/api/src/api/__tests__/admin-connections.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections.test.ts
@@ -681,6 +681,58 @@ describe("admin connections — org scoping", () => {
       // status is the last parameter — verify it's 'draft'
       expect((params as unknown[])[(params as unknown[]).length - 1]).toBe("draft");
     });
+
+    it("revives an archived row (UPDATE, not INSERT) when PK collides", async () => {
+      // After a DELETE archives a connection, the (id, org_id) PK row remains
+      // while the in-memory registry is unregistered. Recreating with the
+      // same id must revive via UPDATE rather than 500 on PK conflict.
+      // Using id="analytics" which isn't in the default mock registry, so
+      // `connections.has("analytics")` returns false as it would in prod
+      // after unregister.
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sql.includes("SELECT status FROM connections")) {
+          return Promise.resolve([{ status: "archived" }]);
+        }
+        return Promise.resolve([]);
+      });
+      const res = await app.fetch(
+        adminRequest("/api/v1/admin/connections", "POST", {
+          id: "analytics",
+          url: "postgresql://user:pass@host/db",
+        }),
+      );
+      expect(res.status).toBe(201);
+      const updateCall = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) =>
+          typeof sql === "string" &&
+          sql.includes("UPDATE connections") &&
+          sql.includes("status"),
+      );
+      expect(updateCall).toBeDefined();
+      const staleInsert = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) =>
+          typeof sql === "string" && sql.includes("INSERT INTO connections"),
+      );
+      expect(staleInsert).toBeUndefined();
+    });
+
+    it("returns 409 when PK collides with a non-archived row", async () => {
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sql.includes("SELECT status FROM connections")) {
+          return Promise.resolve([{ status: "published" }]);
+        }
+        return Promise.resolve([]);
+      });
+      const res = await app.fetch(
+        adminRequest("/api/v1/admin/connections", "POST", {
+          id: "analytics",
+          url: "postgresql://user:pass@host/db",
+        }),
+      );
+      expect(res.status).toBe(409);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("conflict");
+    });
   });
 
   describe("PUT /connections/__demo__ — demo gating", () => {

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -270,6 +270,9 @@ const mockListEntitiesAdmin: Mock<(orgId: string, type?: string) => Promise<unkn
 const mockGetEntityAdmin: Mock<(orgId: string, type: string, name: string) => Promise<unknown>> = mock(() => Promise.resolve(null));
 const mockUpsertEntityAdmin: Mock<(...args: unknown[]) => Promise<void>> = mock(() => Promise.resolve());
 const mockDeleteEntityAdmin: Mock<(orgId: string, type: string, name: string) => Promise<boolean>> = mock(() => Promise.resolve(false));
+const mockUpsertDraftEntityAdmin: Mock<(...args: unknown[]) => Promise<void>> = mock(() => Promise.resolve());
+const mockUpsertTombstoneAdmin: Mock<(...args: unknown[]) => Promise<void>> = mock(() => Promise.resolve());
+const mockDeleteDraftEntityAdmin: Mock<(...args: unknown[]) => Promise<boolean>> = mock(() => Promise.resolve(true));
 const mockCreateVersion: Mock<(...args: unknown[]) => Promise<string>> = mock(() => Promise.resolve("version-1"));
 const mockListVersions: Mock<(...args: unknown[]) => Promise<{ versions: unknown[]; total: number }>> = mock(() => Promise.resolve({ versions: [], total: 0 }));
 const mockGetVersion: Mock<(...args: unknown[]) => Promise<unknown>> = mock(() => Promise.resolve(null));
@@ -280,6 +283,9 @@ mock.module("@atlas/api/lib/semantic/entities", () => ({
   getEntity: mockGetEntityAdmin,
   upsertEntity: mockUpsertEntityAdmin,
   deleteEntity: mockDeleteEntityAdmin,
+  upsertDraftEntity: mockUpsertDraftEntityAdmin,
+  upsertTombstone: mockUpsertTombstoneAdmin,
+  deleteDraftEntity: mockDeleteDraftEntityAdmin,
   countEntities: mock(() => Promise.resolve(0)),
   bulkUpsertEntities: mock(() => Promise.resolve(0)),
   createVersion: mockCreateVersion,
@@ -2456,6 +2462,162 @@ describe("PUT /api/v1/admin/semantic/entities/edit/:name — version creation", 
     // Save still succeeds
     expect(res.status).toBe(200);
     expect(mockUpsertEntityAdmin).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Semantic entity write-path mode awareness (#1428)
+// ---------------------------------------------------------------------------
+
+describe("PUT /api/v1/admin/semantic/entities/edit/:name — mode-aware writes (#1428)", () => {
+  beforeEach(() => {
+    mockHasInternalDB = true;
+    mockUpsertEntityAdmin.mockReset();
+    mockUpsertEntityAdmin.mockResolvedValue(undefined);
+    mockUpsertDraftEntityAdmin.mockReset();
+    mockUpsertDraftEntityAdmin.mockResolvedValue(undefined);
+    mockGetEntityAdmin.mockReset();
+    mockSyncEntityToDisk.mockReset();
+    mockSyncEntityToDisk.mockResolvedValue(undefined);
+  });
+
+  it("published mode upserts the published row (calls upsertEntity)", async () => {
+    setOrgAdmin("org-1");
+    mockGetEntityAdmin.mockResolvedValue(null);
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/semantic/entities/edit/users", "PUT", {
+        table: "users",
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockUpsertEntityAdmin).toHaveBeenCalledTimes(1);
+    expect(mockUpsertDraftEntityAdmin).not.toHaveBeenCalled();
+  });
+
+  it("developer mode creates a draft for a new entity (calls upsertDraftEntity)", async () => {
+    setOrgAdmin("org-1");
+    mockGetEntityAdmin.mockResolvedValue(null);
+    const req = new Request("http://localhost/api/v1/admin/semantic/entities/edit/users", {
+      method: "PUT",
+      headers: {
+        Authorization: "Bearer test-key",
+        "Content-Type": "application/json",
+        Cookie: "atlas-mode=developer",
+      },
+      body: JSON.stringify({ table: "users" }),
+    });
+    const res = await app.fetch(req);
+    expect(res.status).toBe(200);
+    expect(mockUpsertDraftEntityAdmin).toHaveBeenCalledTimes(1);
+    expect(mockUpsertEntityAdmin).not.toHaveBeenCalled();
+  });
+
+  it("developer mode — editing a published entity inserts a draft copy (published untouched)", async () => {
+    setOrgAdmin("org-1");
+    // There's already a published row with the same name
+    mockGetEntityAdmin.mockResolvedValue({
+      id: "e-published", org_id: "org-1", entity_type: "entity", name: "users",
+      yaml_content: "table: users\n", connection_id: null, status: "published",
+      created_at: "2026-04-01T10:00:00Z", updated_at: "2026-04-01T10:00:00Z",
+    });
+    const req = new Request("http://localhost/api/v1/admin/semantic/entities/edit/users", {
+      method: "PUT",
+      headers: {
+        Authorization: "Bearer test-key",
+        "Content-Type": "application/json",
+        Cookie: "atlas-mode=developer",
+      },
+      body: JSON.stringify({ table: "users", description: "edited" }),
+    });
+    const res = await app.fetch(req);
+    expect(res.status).toBe(200);
+    expect(mockUpsertDraftEntityAdmin).toHaveBeenCalledTimes(1);
+    // The published upsert must NOT be called — the published row must remain untouched
+    expect(mockUpsertEntityAdmin).not.toHaveBeenCalled();
+  });
+
+  it("developer mode — editing an existing draft updates the draft row in place", async () => {
+    setOrgAdmin("org-1");
+    mockGetEntityAdmin.mockResolvedValue({
+      id: "e-draft", org_id: "org-1", entity_type: "entity", name: "users",
+      yaml_content: "table: users\n", connection_id: null, status: "draft",
+      created_at: "2026-04-01T10:00:00Z", updated_at: "2026-04-01T10:00:00Z",
+    });
+    const req = new Request("http://localhost/api/v1/admin/semantic/entities/edit/users", {
+      method: "PUT",
+      headers: {
+        Authorization: "Bearer test-key",
+        "Content-Type": "application/json",
+        Cookie: "atlas-mode=developer",
+      },
+      body: JSON.stringify({ table: "users", description: "edited again" }),
+    });
+    const res = await app.fetch(req);
+    expect(res.status).toBe(200);
+    expect(mockUpsertDraftEntityAdmin).toHaveBeenCalledTimes(1);
+    // ON CONFLICT on the draft partial index handles update-in-place; we don't
+    // need a different function — just assert that draft upsert is called once
+  });
+});
+
+describe("DELETE /api/v1/admin/semantic/entities/edit/:name — mode-aware deletes (#1428)", () => {
+  beforeEach(() => {
+    mockHasInternalDB = true;
+    mockDeleteEntityAdmin.mockReset();
+    mockUpsertTombstoneAdmin.mockReset();
+    mockDeleteDraftEntityAdmin.mockReset();
+    mockGetEntityAdmin.mockReset();
+    mockSyncEntityDeleteFromDisk.mockReset();
+    mockSyncEntityDeleteFromDisk.mockResolvedValue(undefined);
+  });
+
+  it("published mode performs a hard delete", async () => {
+    setOrgAdmin("org-1");
+    mockDeleteEntityAdmin.mockResolvedValue(true);
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/semantic/entities/edit/users", "DELETE"),
+    );
+    expect(res.status).toBe(200);
+    expect(mockDeleteEntityAdmin).toHaveBeenCalledTimes(1);
+    expect(mockUpsertTombstoneAdmin).not.toHaveBeenCalled();
+  });
+
+  it("developer mode — deleting a published entity inserts a draft_delete tombstone", async () => {
+    setOrgAdmin("org-1");
+    mockGetEntityAdmin.mockResolvedValue({
+      id: "e-published", org_id: "org-1", entity_type: "entity", name: "users",
+      yaml_content: "table: users\n", connection_id: null, status: "published",
+      created_at: "2026-04-01T10:00:00Z", updated_at: "2026-04-01T10:00:00Z",
+    });
+    mockUpsertTombstoneAdmin.mockResolvedValue(undefined);
+    const req = new Request("http://localhost/api/v1/admin/semantic/entities/edit/users", {
+      method: "DELETE",
+      headers: { Authorization: "Bearer test-key", Cookie: "atlas-mode=developer" },
+    });
+    const res = await app.fetch(req);
+    expect(res.status).toBe(200);
+    expect(mockUpsertTombstoneAdmin).toHaveBeenCalledTimes(1);
+    // Published row must remain untouched
+    expect(mockDeleteEntityAdmin).not.toHaveBeenCalled();
+  });
+
+  it("developer mode — deleting an existing draft row removes the draft only", async () => {
+    setOrgAdmin("org-1");
+    mockGetEntityAdmin.mockResolvedValue({
+      id: "e-draft", org_id: "org-1", entity_type: "entity", name: "users",
+      yaml_content: "table: users\n", connection_id: null, status: "draft",
+      created_at: "2026-04-01T10:00:00Z", updated_at: "2026-04-01T10:00:00Z",
+    });
+    mockDeleteDraftEntityAdmin.mockResolvedValue(true);
+    const req = new Request("http://localhost/api/v1/admin/semantic/entities/edit/users", {
+      method: "DELETE",
+      headers: { Authorization: "Bearer test-key", Cookie: "atlas-mode=developer" },
+    });
+    const res = await app.fetch(req);
+    expect(res.status).toBe(200);
+    expect(mockDeleteDraftEntityAdmin).toHaveBeenCalledTimes(1);
+    expect(mockUpsertTombstoneAdmin).not.toHaveBeenCalled();
+    expect(mockDeleteEntityAdmin).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -2558,6 +2558,62 @@ describe("PUT /api/v1/admin/semantic/entities/edit/:name — mode-aware writes (
     // ON CONFLICT on the draft partial index handles update-in-place; we don't
     // need a different function — just assert that draft upsert is called once
   });
+
+  it("published mode rejects writes to demo entity via body.connectionId (403)", async () => {
+    setOrgAdmin("org-1");
+    mockGetEntityAdmin.mockResolvedValue(null);
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/semantic/entities/edit/users", "PUT", {
+        table: "users",
+        connectionId: "__demo__",
+      }),
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("demo_readonly");
+    expect(mockUpsertEntityAdmin).not.toHaveBeenCalled();
+    expect(mockUpsertDraftEntityAdmin).not.toHaveBeenCalled();
+  });
+
+  it("published mode rejects writes when existing row belongs to __demo__ (403)", async () => {
+    setOrgAdmin("org-1");
+    // No body.connectionId provided — the existing row's connection_id is
+    // the demo, so the edit must still be blocked.
+    mockGetEntityAdmin.mockResolvedValue({
+      id: "e-1", org_id: "org-1", entity_type: "entity", name: "users",
+      yaml_content: "table: users\n", connection_id: "__demo__", status: "published",
+      created_at: "2026-04-01T10:00:00Z", updated_at: "2026-04-01T10:00:00Z",
+    });
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/semantic/entities/edit/users", "PUT", {
+        table: "users",
+        description: "sneaky edit",
+      }),
+    );
+    expect(res.status).toBe(403);
+    expect(mockUpsertEntityAdmin).not.toHaveBeenCalled();
+  });
+
+  it("developer mode allows writes to demo entities (no 403)", async () => {
+    setOrgAdmin("org-1");
+    mockGetEntityAdmin.mockResolvedValue({
+      id: "e-1", org_id: "org-1", entity_type: "entity", name: "users",
+      yaml_content: "table: users\n", connection_id: "__demo__", status: "published",
+      created_at: "2026-04-01T10:00:00Z", updated_at: "2026-04-01T10:00:00Z",
+    });
+    const req = new Request("http://localhost/api/v1/admin/semantic/entities/edit/users", {
+      method: "PUT",
+      headers: {
+        Authorization: "Bearer test-key",
+        "Content-Type": "application/json",
+        Cookie: "atlas-mode=developer",
+      },
+      body: JSON.stringify({ table: "users", connectionId: "__demo__" }),
+    });
+    const res = await app.fetch(req);
+    expect(res.status).toBe(200);
+    expect(mockUpsertDraftEntityAdmin).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("DELETE /api/v1/admin/semantic/entities/edit/:name — mode-aware deletes (#1428)", () => {
@@ -2618,6 +2674,58 @@ describe("DELETE /api/v1/admin/semantic/entities/edit/:name — mode-aware delet
     expect(mockDeleteDraftEntityAdmin).toHaveBeenCalledTimes(1);
     expect(mockUpsertTombstoneAdmin).not.toHaveBeenCalled();
     expect(mockDeleteEntityAdmin).not.toHaveBeenCalled();
+  });
+
+  it("developer mode — discarding a tombstone calls deleteDraftEntity", async () => {
+    setOrgAdmin("org-1");
+    mockGetEntityAdmin.mockResolvedValue({
+      id: "e-tomb", org_id: "org-1", entity_type: "entity", name: "users",
+      yaml_content: "", connection_id: null, status: "draft_delete",
+      created_at: "2026-04-01T10:00:00Z", updated_at: "2026-04-01T10:00:00Z",
+    });
+    mockDeleteDraftEntityAdmin.mockResolvedValue(true);
+    const req = new Request("http://localhost/api/v1/admin/semantic/entities/edit/users", {
+      method: "DELETE",
+      headers: { Authorization: "Bearer test-key", Cookie: "atlas-mode=developer" },
+    });
+    const res = await app.fetch(req);
+    expect(res.status).toBe(200);
+    expect(mockDeleteDraftEntityAdmin).toHaveBeenCalledTimes(1);
+    expect(mockUpsertTombstoneAdmin).not.toHaveBeenCalled();
+  });
+
+  it("published mode rejects DELETE on demo-connection entity (403)", async () => {
+    setOrgAdmin("org-1");
+    mockGetEntityAdmin.mockResolvedValue({
+      id: "e-demo", org_id: "org-1", entity_type: "entity", name: "users",
+      yaml_content: "table: users\n", connection_id: "__demo__", status: "published",
+      created_at: "2026-04-01T10:00:00Z", updated_at: "2026-04-01T10:00:00Z",
+    });
+    mockDeleteEntityAdmin.mockResolvedValue(true);
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/semantic/entities/edit/users", "DELETE"),
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("demo_readonly");
+    expect(mockDeleteEntityAdmin).not.toHaveBeenCalled();
+  });
+
+  it("developer mode allows DELETE on demo-connection entity (tombstones it)", async () => {
+    setOrgAdmin("org-1");
+    mockGetEntityAdmin.mockResolvedValue({
+      id: "e-demo", org_id: "org-1", entity_type: "entity", name: "users",
+      yaml_content: "table: users\n", connection_id: "__demo__", status: "published",
+      created_at: "2026-04-01T10:00:00Z", updated_at: "2026-04-01T10:00:00Z",
+    });
+    mockUpsertTombstoneAdmin.mockResolvedValue(undefined);
+    const req = new Request("http://localhost/api/v1/admin/semantic/entities/edit/users", {
+      method: "DELETE",
+      headers: { Authorization: "Bearer test-key", Cookie: "atlas-mode=developer" },
+    });
+    const res = await app.fetch(req);
+    expect(res.status).toBe(200);
+    expect(mockUpsertTombstoneAdmin).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/api/src/api/__tests__/prompts.test.ts
+++ b/packages/api/src/api/__tests__/prompts.test.ts
@@ -367,6 +367,35 @@ describe("admin prompt routes", () => {
       const body = (await res.json()) as Record<string, unknown>;
       expect(body.error).toBe("bad_request");
     });
+
+    // ─── Mode-aware create (#1428) ─────────────────────────────────
+
+    it("published mode inserts status='published'", async () => {
+      mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([mockCollectionRow()]));
+      const res = await adminReq("POST", "/", { name: "Test", industry: "saas" });
+      expect(res.status).toBe(201);
+      const insertCall = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) => typeof sql === "string" && sql.includes("INSERT INTO prompt_collections"),
+      );
+      expect(insertCall).toBeDefined();
+      const [sql, params] = insertCall!;
+      expect(sql).toContain("status");
+      const paramList = params as unknown[];
+      expect(paramList[paramList.length - 1]).toBe("published");
+    });
+
+    it("developer mode inserts status='draft'", async () => {
+      mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([mockCollectionRow({ status: "draft" })]));
+      const res = await adminReq("POST", "/", { name: "Test", industry: "saas" }, "atlas-mode=developer");
+      expect(res.status).toBe(201);
+      const insertCall = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) => typeof sql === "string" && sql.includes("INSERT INTO prompt_collections"),
+      );
+      expect(insertCall).toBeDefined();
+      const [, params] = insertCall!;
+      const paramList = params as unknown[];
+      expect(paramList[paramList.length - 1]).toBe("draft");
+    });
   });
 
   // ─── PATCH /:id (update) ──────────────────────────────────────
@@ -407,6 +436,26 @@ describe("admin prompt routes", () => {
       );
       const res = await adminReq("PATCH", "/col-1", { foo: "bar" });
       expect(res.status).toBe(400);
+    });
+
+    it("developer mode edits are immediate — direct UPDATE on existing row (#1428)", async () => {
+      let callCount = 0;
+      mocks.mockInternalQuery.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return Promise.resolve([mockCollectionRow()]);
+        return Promise.resolve([mockCollectionRow({ name: "Updated in dev" })]);
+      });
+      const res = await adminReq("PATCH", "/col-1", { name: "Updated in dev" }, "atlas-mode=developer");
+      expect(res.status).toBe(200);
+      // Verify the UPDATE ran — no new INSERT
+      const updateCall = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) => typeof sql === "string" && sql.includes("UPDATE prompt_collections"),
+      );
+      expect(updateCall).toBeDefined();
+      const staleInsert = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) => typeof sql === "string" && sql.includes("INSERT INTO prompt_collections"),
+      );
+      expect(staleInsert).toBeUndefined();
     });
   });
 

--- a/packages/api/src/api/__tests__/prompts.test.ts
+++ b/packages/api/src/api/__tests__/prompts.test.ts
@@ -447,11 +447,15 @@ describe("admin prompt routes", () => {
       });
       const res = await adminReq("PATCH", "/col-1", { name: "Updated in dev" }, "atlas-mode=developer");
       expect(res.status).toBe(200);
-      // Verify the UPDATE ran — no new INSERT
+      // Verify the UPDATE ran with the new name in the SET clause and params
       const updateCall = mocks.mockInternalQuery.mock.calls.find(
         ([sql]) => typeof sql === "string" && sql.includes("UPDATE prompt_collections"),
       );
       expect(updateCall).toBeDefined();
+      expect(updateCall![0] as string).toContain("name = $1");
+      const updateParams = updateCall![1] as unknown[];
+      expect(updateParams).toContain("Updated in dev");
+      expect(updateParams).toContain("col-1");
       const staleInsert = mocks.mockInternalQuery.mock.calls.find(
         ([sql]) => typeof sql === "string" && sql.includes("INSERT INTO prompt_collections"),
       );
@@ -487,6 +491,26 @@ describe("admin prompt routes", () => {
       mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([]));
       const res = await adminReq("DELETE", "/col-1");
       expect(res.status).toBe(404);
+    });
+
+    it("developer mode deletes are immediate — direct DELETE FROM (#1428)", async () => {
+      let callCount = 0;
+      mocks.mockInternalQuery.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return Promise.resolve([mockCollectionRow()]);
+        return Promise.resolve([]);
+      });
+      const res = await adminReq("DELETE", "/col-1", undefined, "atlas-mode=developer");
+      expect(res.status).toBe(200);
+      const deleteCall = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) => typeof sql === "string" && sql.includes("DELETE FROM prompt_collections"),
+      );
+      expect(deleteCall).toBeDefined();
+      // No staging — no tombstone / draft insert
+      const staleInsert = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) => typeof sql === "string" && sql.includes("INSERT INTO prompt_collections"),
+      );
+      expect(staleInsert).toBeUndefined();
     });
   });
 

--- a/packages/api/src/api/routes/__tests__/mode-resolution.test.ts
+++ b/packages/api/src/api/routes/__tests__/mode-resolution.test.ts
@@ -46,7 +46,7 @@ mock.module("@atlas/api/lib/residency/readonly", () => ({
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
 
-const { resolveMode, buildUnionStatusClause } = await import("../middleware");
+const { resolveMode, buildUnionStatusClause, parseModeFromCookie } = await import("../middleware");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -216,6 +216,37 @@ describe("resolveMode", () => {
 // ---------------------------------------------------------------------------
 // buildUnionStatusClause — shared helper for connections and prompt collections
 // ---------------------------------------------------------------------------
+
+describe("parseModeFromCookie", () => {
+  it("returns undefined for null", () => {
+    expect(parseModeFromCookie(null)).toBeUndefined();
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(parseModeFromCookie("")).toBeUndefined();
+  });
+
+  it("reads atlas-mode value when present alone", () => {
+    expect(parseModeFromCookie("atlas-mode=developer")).toBe("developer");
+  });
+
+  it("reads atlas-mode value among other cookies", () => {
+    expect(parseModeFromCookie("session=abc; atlas-mode=developer; theme=dark")).toBe("developer");
+  });
+
+  it("is exact-match — different key prefixes do not collide", () => {
+    expect(parseModeFromCookie("atlas-mode-other=developer")).toBeUndefined();
+  });
+
+  it("returns the full value verbatim — no special handling of unknown values", () => {
+    // resolveMode() filters unknown values; parseModeFromCookie just extracts
+    expect(parseModeFromCookie("atlas-mode=developer_extra")).toBe("developer_extra");
+  });
+
+  it("returns undefined when atlas-mode key is absent", () => {
+    expect(parseModeFromCookie("session=abc; theme=dark")).toBeUndefined();
+  });
+});
 
 describe("buildUnionStatusClause", () => {
   it("published mode restricts to status = 'published'", () => {

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -551,10 +551,16 @@ adminConnections.openapi(createConnectionRoute, async (c) => runHandler(c, "crea
   // If an archived row already owns this PK, the INSERT below would 500;
   // we revive it instead via UPDATE. Any other status (published/draft) is a
   // real conflict.
-  const existingRow = await internalQuery<{ status: string }>(
-    `SELECT status FROM connections WHERE id = $1 AND org_id = $2`,
-    [id, orgId],
-  );
+  let existingRow: { status: string }[];
+  try {
+    existingRow = await internalQuery<{ status: string }>(
+      `SELECT status FROM connections WHERE id = $1 AND org_id = $2`,
+      [id, orgId],
+    );
+  } catch (err) {
+    log.error({ err: err instanceof Error ? err.message : String(err), connectionId: id, requestId }, "Failed to check for existing connection row before create");
+    return c.json({ error: "internal_error", message: "Failed to check for existing connection. Try again.", requestId }, 500);
+  }
   if (existingRow.length > 0 && existingRow[0].status !== "archived") {
     return c.json({ error: "conflict", message: `Connection "${id}" already exists.`, requestId }, 409);
   }

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -546,6 +546,20 @@ adminConnections.openapi(createConnectionRoute, async (c) => runHandler(c, "crea
     return c.json({ error: "conflict", message: `Connection "${id}" already exists.`, requestId }, 409);
   }
 
+  // Archive-aware conflict check: the archive-on-delete flow preserves rows,
+  // so the (id, org_id) PK may collide even when the registry has no entry.
+  // If an archived row already owns this PK, the INSERT below would 500;
+  // we revive it instead via UPDATE. Any other status (published/draft) is a
+  // real conflict.
+  const existingRow = await internalQuery<{ status: string }>(
+    `SELECT status FROM connections WHERE id = $1 AND org_id = $2`,
+    [id, orgId],
+  );
+  if (existingRow.length > 0 && existingRow[0].status !== "archived") {
+    return c.json({ error: "conflict", message: `Connection "${id}" already exists.`, requestId }, 409);
+  }
+  const revivingArchived = existingRow.length > 0;
+
   // Test the connection before saving
   try {
     connections.register(id, {
@@ -579,10 +593,19 @@ adminConnections.openapi(createConnectionRoute, async (c) => runHandler(c, "crea
   const status = getAtlasMode(c) === "developer" ? "draft" : "published";
 
   try {
-    await internalQuery(
-      `INSERT INTO connections (id, url, type, description, schema_name, org_id, status) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-      [id, encryptedUrl, dbType, typeof description === "string" ? description : null, typeof schema === "string" ? schema : null, orgId, status],
-    );
+    if (revivingArchived) {
+      // The archived row owns the PK — revive it in place so we preserve
+      // audit/version history rather than stranding it.
+      await internalQuery(
+        `UPDATE connections SET url = $1, type = $2, description = $3, schema_name = $4, status = $5, updated_at = now() WHERE id = $6 AND org_id = $7`,
+        [encryptedUrl, dbType, typeof description === "string" ? description : null, typeof schema === "string" ? schema : null, status, id, orgId],
+      );
+    } else {
+      await internalQuery(
+        `INSERT INTO connections (id, url, type, description, schema_name, org_id, status) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        [id, encryptedUrl, dbType, typeof description === "string" ? description : null, typeof schema === "string" ? schema : null, orgId, status],
+      );
+    }
   } catch (err) {
     connections.unregister(id);
     log.error({ err: err instanceof Error ? err.message : String(err), connectionId: id, requestId }, "Failed to persist connection");

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -26,6 +26,18 @@ function getAtlasMode(c: { get(key: string): unknown }): import("@useatlas/types
   return (c.get("atlasMode") as import("@useatlas/types/auth").AtlasMode | undefined) ?? "published";
 }
 
+/** Reserved ID for the onboarding demo connection. Writes in published mode are read-only. */
+const DEMO_CONNECTION_ID = "__demo__";
+
+/** Demo-readonly response for writes in published mode against `__demo__`. */
+function demoReadonly(requestId: string): { error: string; message: string; requestId: string } {
+  return {
+    error: "demo_readonly",
+    message: "Demo connection is read-only in published mode. Switch to developer mode to manage connections.",
+    requestId,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -561,10 +573,15 @@ adminConnections.openapi(createConnectionRoute, async (c) => runHandler(c, "crea
     return c.json({ error: "encryption_failed", message: "Failed to encrypt connection URL. Check ATLAS_ENCRYPTION_KEY or BETTER_AUTH_SECRET.", requestId }, 500);
   }
 
+  // Mode-aware status: in developer mode, new connections are saved as drafts
+  // so non-admin users don't see them until publish. In published mode, new
+  // connections go live immediately (preserves existing single-mode behavior).
+  const status = getAtlasMode(c) === "developer" ? "draft" : "published";
+
   try {
     await internalQuery(
-      `INSERT INTO connections (id, url, type, description, schema_name, org_id) VALUES ($1, $2, $3, $4, $5, $6)`,
-      [id, encryptedUrl, dbType, typeof description === "string" ? description : null, typeof schema === "string" ? schema : null, orgId],
+      `INSERT INTO connections (id, url, type, description, schema_name, org_id, status) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+      [id, encryptedUrl, dbType, typeof description === "string" ? description : null, typeof schema === "string" ? schema : null, orgId, status],
     );
   } catch (err) {
     connections.unregister(id);
@@ -608,6 +625,12 @@ adminConnections.openapi(updateConnectionRoute, async (c) => runHandler(c, "upda
 
   if (id === "default") {
     return c.json({ error: "forbidden", message: "Cannot modify the default connection. Update ATLAS_DATASOURCE_URL instead.", requestId }, 403);
+  }
+
+  // Demo content is read-only in published mode — admins must toggle to
+  // developer mode to edit demo data.
+  if (id === DEMO_CONNECTION_ID && getAtlasMode(c) !== "developer") {
+    return c.json(demoReadonly(requestId), 403);
   }
 
   // Check it exists in the DB and belongs to this org
@@ -757,6 +780,12 @@ adminConnections.openapi(deleteConnectionRoute, async (c) => runHandler(c, "dele
     return c.json({ error: "forbidden", message: "Cannot delete the default connection.", requestId }, 403);
   }
 
+  // Demo content is read-only in published mode — writes in published mode
+  // against __demo__ must be blocked. Developer mode can archive the demo.
+  if (id === DEMO_CONNECTION_ID && getAtlasMode(c) !== "developer") {
+    return c.json(demoReadonly(requestId), 403);
+  }
+
   // Must exist in the DB and belong to the org
   const existing = await internalQuery<{ id: string }>(
     `SELECT id FROM connections WHERE id = $1 AND org_id = $2`,
@@ -791,15 +820,16 @@ adminConnections.openapi(deleteConnectionRoute, async (c) => runHandler(c, "dele
     log.warn({ connectionId: id, requestId }, "Scheduled tasks table does not exist — skipping reference check");
   }
 
-  // Remove from DB and registry
+  // Archive instead of hard-delete so drafts can be restored and the
+  // publish flow retains history. Cascades to entities is handled at publish time.
   try {
     await internalQuery(
-      `DELETE FROM connections WHERE id = $1 AND org_id = $2`,
+      `UPDATE connections SET status = 'archived', updated_at = now() WHERE id = $1 AND org_id = $2`,
       [id, orgId],
     );
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err), connectionId: id, requestId }, "Failed to delete connection from DB");
-    return c.json({ error: "internal_error", message: "Failed to delete connection.", requestId }, 500);
+    log.error({ err: err instanceof Error ? err.message : String(err), connectionId: id, requestId }, "Failed to archive connection");
+    return c.json({ error: "internal_error", message: "Failed to archive connection.", requestId }, 500);
   }
 
   try {
@@ -808,7 +838,7 @@ adminConnections.openapi(deleteConnectionRoute, async (c) => runHandler(c, "dele
     log.warn({ err: err instanceof Error ? err.message : String(err), connectionId: id, requestId }, "Failed to unregister connection from in-memory registry — will reconcile on restart");
   }
 
-  log.info({ requestId, connectionId: id, actorId: authResult.user?.id }, "Connection deleted");
+  log.info({ requestId, connectionId: id, actorId: authResult.user?.id }, "Connection archived");
 
   logAdminAction({
     actionType: ADMIN_ACTIONS.connection.delete,

--- a/packages/api/src/api/routes/admin-prompts.ts
+++ b/packages/api/src/api/routes/admin-prompts.ts
@@ -502,7 +502,7 @@ adminPrompts.openapi(listCollectionsRoute, async (c) => {
 // POST / — create collection
 adminPrompts.openapi(createCollectionRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
-    const { requestId } = yield* RequestContext;
+    const { requestId, atlasMode } = yield* RequestContext;
     const { orgId } = yield* AuthContext;
 
     const bodyResult = yield* Effect.tryPromise({
@@ -518,7 +518,11 @@ adminPrompts.openapi(createCollectionRoute, async (c) => {
     if (!name || typeof name !== "string") return c.json({ error: "bad_request", message: "name is required and must be a string." }, 400);
     if (!industry || typeof industry !== "string") return c.json({ error: "bad_request", message: "industry is required and must be a string." }, 400);
 
-    const rows = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(`INSERT INTO prompt_collections (org_id, name, industry, description, is_builtin) VALUES ($1, $2, $3, $4, false) RETURNING *`, [orgId ?? null, name, industry, description]));
+    // Mode-aware status: developer-mode collections are staged as drafts
+    // until the admin publishes; published mode creates them live.
+    const status = atlasMode === "developer" ? "draft" : "published";
+
+    const rows = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(`INSERT INTO prompt_collections (org_id, name, industry, description, is_builtin, status) VALUES ($1, $2, $3, $4, false, $5) RETURNING *`, [orgId ?? null, name, industry, description, status]));
     return c.json(toPromptCollection(rows[0]), 201);
   }), { label: "create prompt collection" });
 });

--- a/packages/api/src/api/routes/admin-semantic.ts
+++ b/packages/api/src/api/routes/admin-semantic.ts
@@ -503,12 +503,6 @@ export function registerSemanticEditorRoutes(
 
       const atlasMode = getAtlasMode(c);
 
-      // Demo entities are read-only in published mode — admins must toggle
-      // to developer mode to edit demo data.
-      if (atlasMode !== "developer" && body.connectionId === DEMO_CONNECTION_ID) {
-        return c.json(demoReadonlyResponse(requestId), 403);
-      }
-
       // Convert structured data to YAML
       const yamlContent = await entityToYaml(body);
 
@@ -524,6 +518,17 @@ export function registerSemanticEditorRoutes(
       // Fetch previous version for change summary (before upsert overwrites it)
       const previousEntity = await getEntity(orgId, "entity", name);
       const oldYaml = previousEntity?.yaml_content ?? null;
+
+      // Demo entities are read-only in published mode. Check both the
+      // incoming body (new entities pointed at __demo__) and the existing
+      // row (edits that omit connectionId but target a demo-owned entity).
+      if (
+        atlasMode !== "developer" &&
+        (body.connectionId === DEMO_CONNECTION_ID ||
+          previousEntity?.connection_id === DEMO_CONNECTION_ID)
+      ) {
+        return c.json(demoReadonlyResponse(requestId), 403);
+      }
 
       // Developer mode writes stage as drafts so the published row is
       // preserved until publish. Published mode writes the published row directly.

--- a/packages/api/src/api/routes/admin-semantic.ts
+++ b/packages/api/src/api/routes/admin-semantic.ts
@@ -23,6 +23,23 @@ import { ErrorSchema, AuthErrorSchema, createParamSchema } from "./shared-schema
 
 const log = createLogger("admin-semantic-editor");
 
+/** Reserved ID for the onboarding demo connection. */
+const DEMO_CONNECTION_ID = "__demo__";
+
+/** Read atlasMode from Hono context. Defaults to "published" when not set. */
+function getAtlasMode(c: { get(key: string): unknown }): import("@useatlas/types/auth").AtlasMode {
+  return (c.get("atlasMode") as import("@useatlas/types/auth").AtlasMode | undefined) ?? "published";
+}
+
+/** Demo-readonly response for writes in published mode against `__demo__`. */
+function demoReadonlyResponse(requestId: string): { error: string; message: string; requestId: string } {
+  return {
+    error: "demo_readonly",
+    message: "Demo content is read-only in published mode. Switch to developer mode to manage semantic entities.",
+    requestId,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Zod schemas — column metadata
 // ---------------------------------------------------------------------------
@@ -227,6 +244,10 @@ export const putStructuredEntityRoute = createRoute({
       description: "Authentication required",
       content: { "application/json": { schema: AuthErrorSchema } },
     },
+    403: {
+      description: "Demo content is read-only in published mode",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
     501: {
       description: "Internal database not available",
       content: { "application/json": { schema: ErrorSchema } },
@@ -259,6 +280,10 @@ export const deleteStructuredEntityRoute = createRoute({
     401: {
       description: "Authentication required",
       content: { "application/json": { schema: AuthErrorSchema } },
+    },
+    403: {
+      description: "Demo content is read-only in published mode",
+      content: { "application/json": { schema: ErrorSchema } },
     },
     404: {
       description: "Entity not found",
@@ -476,17 +501,37 @@ export function registerSemanticEditorRoutes(
         return c.json({ error: "not_available", message: "Semantic entity editor requires an internal database (DATABASE_URL).", requestId }, 501);
       }
 
+      const atlasMode = getAtlasMode(c);
+
+      // Demo entities are read-only in published mode — admins must toggle
+      // to developer mode to edit demo data.
+      if (atlasMode !== "developer" && body.connectionId === DEMO_CONNECTION_ID) {
+        return c.json(demoReadonlyResponse(requestId), 403);
+      }
+
       // Convert structured data to YAML
       const yamlContent = await entityToYaml(body);
 
       // Store in DB
-      const { upsertEntity, getEntity, createVersion, generateChangeSummary } = await import("@atlas/api/lib/semantic/entities");
+      const {
+        upsertEntity,
+        upsertDraftEntity,
+        getEntity,
+        createVersion,
+        generateChangeSummary,
+      } = await import("@atlas/api/lib/semantic/entities");
 
       // Fetch previous version for change summary (before upsert overwrites it)
       const previousEntity = await getEntity(orgId, "entity", name);
       const oldYaml = previousEntity?.yaml_content ?? null;
 
-      await upsertEntity(orgId, "entity", name, yamlContent, body.connectionId);
+      // Developer mode writes stage as drafts so the published row is
+      // preserved until publish. Published mode writes the published row directly.
+      if (atlasMode === "developer") {
+        await upsertDraftEntity(orgId, "entity", name, yamlContent, body.connectionId);
+      } else {
+        await upsertEntity(orgId, "entity", name, yamlContent, body.connectionId);
+      }
 
       // Create version snapshot — non-fatal
       try {
@@ -549,8 +594,48 @@ export function registerSemanticEditorRoutes(
         return c.json({ error: "not_available", message: "Semantic entity editor requires an internal database (DATABASE_URL).", requestId }, 501);
       }
 
-      const { deleteEntity } = await import("@atlas/api/lib/semantic/entities");
-      const deleted = await deleteEntity(orgId, "entity", name);
+      const atlasMode = getAtlasMode(c);
+      const {
+        deleteEntity,
+        getEntity,
+        upsertTombstone,
+        deleteDraftEntity,
+      } = await import("@atlas/api/lib/semantic/entities");
+
+      let deleted = true;
+      if (atlasMode === "developer") {
+        // Developer mode: stage the deletion. Resolve the existing row so we
+        // know whether to discard a draft or stamp a tombstone over a published
+        // row. If nothing matches either state, 404.
+        const existing = await getEntity(orgId, "entity", name);
+        if (!existing) {
+          return c.json({ error: "not_found", message: `Entity "${name}" not found.` }, 404);
+        }
+        if (existing.status === "draft" || existing.status === "draft_delete") {
+          deleted = await deleteDraftEntity(
+            orgId,
+            "entity",
+            name,
+            existing.connection_id ?? undefined,
+          );
+        } else {
+          await upsertTombstone(
+            orgId,
+            "entity",
+            name,
+            existing.connection_id ?? undefined,
+          );
+        }
+      } else {
+        // Published mode: hard delete preserves today's behavior. Check the
+        // demo gate before the destructive call — published mode cannot touch
+        // entities owned by the reserved demo connection.
+        const existing = await getEntity(orgId, "entity", name);
+        if (existing?.connection_id === DEMO_CONNECTION_ID) {
+          return c.json(demoReadonlyResponse(requestId), 403);
+        }
+        deleted = await deleteEntity(orgId, "entity", name);
+      }
 
       if (!deleted) {
         return c.json({ error: "not_found", message: `Entity "${name}" not found.` }, 404);

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -122,11 +122,23 @@ async function adminAuthAndContext(
   }
 
   // Resolve and publish atlas mode for downstream handlers. getAtlasMode(c)
-  // reads from c.get("atlasMode") — populate it once per request.
+  // reads from c.get("atlasMode") — populate it once per request and log any
+  // developer-mode request we downgraded due to insufficient role (matches
+  // the security signal emitted by `resolveModeForRequest` on the
+  // adminAuth/standardAuth middleware paths).
   if (typeof c.set === "function") {
     const cookieHeader = c.req.raw.headers.get("cookie");
     const xAtlasModeHeader = c.req.raw.headers.get("x-atlas-mode");
     const mode = resolveMode(cookieHeader, xAtlasModeHeader, authResult);
+    const requestedDeveloper =
+      (cookieHeader?.split(";").some((p) => p.trim().startsWith("atlas-mode=developer")) ?? false) ||
+      xAtlasModeHeader === "developer";
+    if (requestedDeveloper && mode === "published") {
+      log.warn(
+        { requestId, userId: authResult.user?.id, role: authResult.user?.role },
+        "Developer mode request downgraded to published — insufficient role",
+      );
+    }
     c.set("atlasMode", mode);
   }
 

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -14,7 +14,7 @@ import { validationHook } from "./validation-hook";
 import type { Context } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { createLogger, withRequestContext, getRequestContext } from "@atlas/api/lib/logger";
-import { withRequestId, resolveMode } from "./middleware";
+import { withRequestId, resolveMode, parseModeFromCookie } from "./middleware";
 import type { AuthResult } from "@atlas/api/lib/auth/types";
 import { authenticateRequest } from "@atlas/api/lib/auth/middleware";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
@@ -126,12 +126,17 @@ async function adminAuthAndContext(
   // developer-mode request we downgraded due to insufficient role (matches
   // the security signal emitted by `resolveModeForRequest` on the
   // adminAuth/standardAuth middleware paths).
+  //
+  // Note: the downgrade branch is defensive — `requireAdminAuth` above
+  // already 403's non-admin users before this point, so in practice the
+  // downgrade never fires for admin routes. It stays for parity with the
+  // other auth preambles in case admin gating is ever relaxed.
   if (typeof c.set === "function") {
     const cookieHeader = c.req.raw.headers.get("cookie");
     const xAtlasModeHeader = c.req.raw.headers.get("x-atlas-mode");
     const mode = resolveMode(cookieHeader, xAtlasModeHeader, authResult);
     const requestedDeveloper =
-      (cookieHeader?.split(";").some((p) => p.trim().startsWith("atlas-mode=developer")) ?? false) ||
+      parseModeFromCookie(cookieHeader) === "developer" ||
       xAtlasModeHeader === "developer";
     if (requestedDeveloper && mode === "published") {
       log.warn(

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -14,7 +14,7 @@ import { validationHook } from "./validation-hook";
 import type { Context } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { createLogger, withRequestContext, getRequestContext } from "@atlas/api/lib/logger";
-import { withRequestId } from "./middleware";
+import { withRequestId, resolveMode } from "./middleware";
 import type { AuthResult } from "@atlas/api/lib/auth/types";
 import { authenticateRequest } from "@atlas/api/lib/auth/middleware";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
@@ -99,8 +99,15 @@ const getAtlasMode = (c: { get(key: string): unknown }): import("@useatlas/types
  * Run admin auth preamble and bind user identity into AsyncLocalStorage.
  * Returns { authResult, requestId } for the handler to use.
  * Throws HTTPException on auth failure.
+ *
+ * Also resolves the effective atlas mode and stores it on the Hono context
+ * (`c.set("atlasMode", ...)`). admin.ts uses the `withRequestId` middleware
+ * — not `adminAuth` — so the mode is resolved lazily here once the auth
+ * result is known.
  */
-async function adminAuthAndContext(c: { req: { raw: Request }; get(key: string): unknown }): Promise<{ authResult: AuthResult & { authenticated: true }; requestId: string }> {
+async function adminAuthAndContext(
+  c: { req: { raw: Request }; get(key: string): unknown; set?: (key: string, value: unknown) => void },
+): Promise<{ authResult: AuthResult & { authenticated: true }; requestId: string }> {
   const requestId = reqId(c);
   const preamble = await adminAuthPreamble(c.req.raw, requestId);
   requireAdminAuth(preamble);
@@ -113,6 +120,16 @@ async function adminAuthAndContext(c: { req: { raw: Request }; get(key: string):
   if (ctx) {
     (ctx as unknown as Record<string, unknown>).user = authResult.user;
   }
+
+  // Resolve and publish atlas mode for downstream handlers. getAtlasMode(c)
+  // reads from c.get("atlasMode") — populate it once per request.
+  if (typeof c.set === "function") {
+    const cookieHeader = c.req.raw.headers.get("cookie");
+    const xAtlasModeHeader = c.req.raw.headers.get("x-atlas-mode");
+    const mode = resolveMode(cookieHeader, xAtlasModeHeader, authResult);
+    c.set("atlasMode", mode);
+  }
+
   return { authResult, requestId };
 }
 

--- a/packages/api/src/api/routes/middleware.ts
+++ b/packages/api/src/api/routes/middleware.ts
@@ -366,7 +366,7 @@ const ADMIN_ROLE_SET = new Set(["admin", "owner", "platform_admin"]);
  * Parse the `atlas-mode` cookie from the Cookie header.
  * Returns the raw cookie value, or undefined if not present.
  */
-function parseModeFromCookie(cookieHeader: string | null): string | undefined {
+export function parseModeFromCookie(cookieHeader: string | null): string | undefined {
   if (!cookieHeader) return undefined;
   for (const pair of cookieHeader.split(";")) {
     const [key, ...rest] = pair.split("=");

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -268,6 +268,7 @@ describe("migrateAuthTables", () => {
             { name: "0023_admin_action_log.sql" },
             { name: "0024_mode_status_columns.sql" },
             { name: "0025_fix_null_unsafe_indexes.sql" },
+            { name: "0026_drop_legacy_semantic_entity_index.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -62,7 +62,7 @@ describe("runMigrations", () => {
 
     const count = await runMigrations(pool);
 
-    expect(count).toBe(26);
+    expect(count).toBe(27);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -117,6 +117,7 @@ describe("runMigrations", () => {
         "0023_admin_action_log.sql",
         "0024_mode_status_columns.sql",
         "0025_fix_null_unsafe_indexes.sql",
+        "0026_drop_legacy_semantic_entity_index.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0026_drop_legacy_semantic_entity_index.sql
+++ b/packages/api/src/lib/db/migrations/0026_drop_legacy_semantic_entity_index.sql
@@ -1,0 +1,14 @@
+-- 0026 — Drop legacy unique index on semantic_entities
+--
+-- The baseline index idx_semantic_entities_org_type_name on
+-- (org_id, entity_type, name) enforced a single row per entity key
+-- across all statuses. The developer/published dual-mode system (#1421)
+-- requires draft/published rows to coexist for the same entity, so the
+-- legacy index is incompatible.
+--
+-- Uniqueness is now enforced by the partial unique indexes added in 0024/0025:
+--   uq_semantic_entity_published — at most one published row per key
+--   uq_semantic_entity_draft     — at most one draft row per key
+--   uq_semantic_entity_tombstone — at most one draft_delete row per key
+
+DROP INDEX IF EXISTS idx_semantic_entities_org_type_name;

--- a/packages/api/src/lib/semantic/entities.ts
+++ b/packages/api/src/lib/semantic/entities.ts
@@ -32,8 +32,14 @@ export interface SemanticEntityRow {
 }
 
 /**
- * Upsert a semantic entity for an org.
- * Uses ON CONFLICT on (org_id, entity_type, name) to update if exists.
+ * Upsert a semantic entity for an org at status='published'.
+ *
+ * Writes the published row — used for direct (non-draft) updates from the
+ * editor and the expert amendment flow. Uses ON CONFLICT on the partial
+ * published unique index so draft/tombstone rows for the same key are
+ * preserved untouched.
+ *
+ * For the developer-mode draft workflow, use `upsertDraftEntity` instead.
  */
 export async function upsertEntity(
   orgId: string,
@@ -46,14 +52,96 @@ export async function upsertEntity(
     throw new Error("Internal DB required for org-scoped semantic entities");
   }
   await internalQuery(
-    `INSERT INTO semantic_entities (org_id, entity_type, name, yaml_content, connection_id)
-     VALUES ($1, $2, $3, $4, $5)
-     ON CONFLICT (org_id, entity_type, name)
+    `INSERT INTO semantic_entities (org_id, entity_type, name, yaml_content, connection_id, status)
+     VALUES ($1, $2, $3, $4, $5, 'published')
+     ON CONFLICT (org_id, name, COALESCE(connection_id, '__default__')) WHERE status = 'published'
      DO UPDATE SET yaml_content = EXCLUDED.yaml_content,
+                   entity_type = EXCLUDED.entity_type,
                    connection_id = EXCLUDED.connection_id,
                    updated_at = now()`,
     [orgId, entityType, name, yamlContent, connectionId ?? null],
   );
+}
+
+/**
+ * Upsert a semantic entity at status='draft'.
+ *
+ * Used for developer-mode writes. The published row (if any) is left
+ * untouched. ON CONFLICT on the partial draft unique index updates an
+ * existing draft in place.
+ */
+export async function upsertDraftEntity(
+  orgId: string,
+  entityType: SemanticEntityType,
+  name: string,
+  yamlContent: string,
+  connectionId?: string,
+): Promise<void> {
+  if (!hasInternalDB()) {
+    throw new Error("Internal DB required for org-scoped semantic entities");
+  }
+  await internalQuery(
+    `INSERT INTO semantic_entities (org_id, entity_type, name, yaml_content, connection_id, status)
+     VALUES ($1, $2, $3, $4, $5, 'draft')
+     ON CONFLICT (org_id, name, COALESCE(connection_id, '__default__')) WHERE status = 'draft'
+     DO UPDATE SET yaml_content = EXCLUDED.yaml_content,
+                   entity_type = EXCLUDED.entity_type,
+                   connection_id = EXCLUDED.connection_id,
+                   updated_at = now()`,
+    [orgId, entityType, name, yamlContent, connectionId ?? null],
+  );
+}
+
+/**
+ * Insert a draft_delete tombstone for an entity.
+ *
+ * Used for developer-mode deletes where a published row exists — the
+ * tombstone hides the published entity via the overlay query until publish
+ * time. ON CONFLICT on the partial tombstone unique index updates the
+ * tombstone's updated_at timestamp if one already exists.
+ */
+export async function upsertTombstone(
+  orgId: string,
+  entityType: SemanticEntityType,
+  name: string,
+  connectionId?: string,
+): Promise<void> {
+  if (!hasInternalDB()) {
+    throw new Error("Internal DB required for org-scoped semantic entities");
+  }
+  await internalQuery(
+    `INSERT INTO semantic_entities (org_id, entity_type, name, yaml_content, connection_id, status)
+     VALUES ($1, $2, $3, '', $4, 'draft_delete')
+     ON CONFLICT (org_id, name, COALESCE(connection_id, '__default__')) WHERE status = 'draft_delete'
+     DO UPDATE SET updated_at = now()`,
+    [orgId, entityType, name, connectionId ?? null],
+  );
+}
+
+/**
+ * Delete the draft row (or tombstone) for an entity. Leaves any published
+ * row intact. Returns true if a draft row was removed.
+ *
+ * Used when an admin discards an in-progress draft in developer mode.
+ */
+export async function deleteDraftEntity(
+  orgId: string,
+  entityType: SemanticEntityType,
+  name: string,
+  connectionId?: string,
+): Promise<boolean> {
+  if (!hasInternalDB()) return false;
+  const rows = await internalQuery<{ id: string }>(
+    `DELETE FROM semantic_entities
+     WHERE org_id = $1
+       AND entity_type = $2
+       AND name = $3
+       AND COALESCE(connection_id, '__default__') = COALESCE($4, '__default__')
+       AND status IN ('draft', 'draft_delete')
+     RETURNING id`,
+    [orgId, entityType, name, connectionId ?? null],
+  );
+  return rows.length > 0;
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements #1428 — write-path mode-awareness for connections, semantic entities, and prompt collections. Foundation for the publish/archive endpoints (#1429, #1437) in milestone 1.2.0.

In **developer mode**, admin writes stage as drafts until a later publish. In **published mode**, writes go live immediately — but demo content (`__demo__` connection + its entities) is read-only and returns 403 with a hint to toggle to developer mode.

Per PRD #1421, staging complexity scales with risk:

| Resource | Create | Edit | Delete |
|----------|--------|------|--------|
| Connection | Staged (`status='draft'`) | Immediate `UPDATE` | Immediate `UPDATE status='archived'` |
| Semantic entity | Staged (`status='draft'`) | Staged draft copy (published untouched) | Staged `draft_delete` tombstone |
| Prompt collection | Staged (`status='draft'`) | Immediate `UPDATE` | Immediate `DELETE` |

### Changes

- **Connections** (`admin-connections.ts`)
  - POST: status is `draft` in developer mode, `published` otherwise
  - PUT/DELETE: 403 on `__demo__` in published mode (`demo_readonly`)
  - DELETE: archive (`UPDATE status='archived'`) instead of hard delete, so content can be restored during publish
- **Semantic entities** (`admin-semantic.ts` — structured editor)
  - PUT: developer mode calls new `upsertDraftEntity` (ON CONFLICT on partial draft index) so the published row is never touched; published mode still calls `upsertEntity`
  - DELETE: developer mode either discards an existing draft (`deleteDraftEntity`) or inserts a `draft_delete` tombstone (`upsertTombstone`) to hide the published row via the overlay; published mode keeps the hard-delete path
  - 403 on writes to demo-connection entities in published mode
- **Prompt collections** (`admin-prompts.ts`) — POST inserts `status='draft'` in developer mode; edit/delete stay direct per PRD
- **`lib/semantic/entities.ts`** — adds `upsertDraftEntity`, `upsertTombstone`, `deleteDraftEntity`; `upsertEntity` now conflict-targets the partial published unique index added in #1443
- **Migration 0026** drops the legacy `idx_semantic_entities_org_type_name` unique index so draft/published/tombstone rows can coexist for the same entity key (uniqueness is enforced by the partial indexes from 0024/0025)
- **`admin.ts`** — `adminAuthAndContext` resolves `atlasMode` into the Hono context, since admin.ts routes use `withRequestId` rather than `adminAuth`

### Acceptance criteria

All 9 bullets from #1428 are covered by new integration tests:

- [x] Creating a connection in developer mode produces a `draft` row
- [x] Creating a semantic entity in developer mode produces a `draft` row
- [x] Editing a published semantic entity in developer mode creates a `draft` copy (published row untouched)
- [x] Editing an existing draft entity updates the draft row in place
- [x] Deleting a published entity in developer mode creates a `draft_delete` tombstone
- [x] Creating a prompt collection in developer mode produces a `draft` row
- [x] Editing/deleting published prompts is immediate (not staged)
- [x] Demo content writes blocked in published mode (403)
- [x] Integration tests cover every write path above

## Test plan

- [x] `bun run lint` — 0 errors
- [x] `bun run type` — 0 errors
- [x] `bun run test` — 218 api + 17 cli + 44 web + 25 ee + 8 react, 0 failures
- [x] `bun x syncpack lint` — No issues
- [x] Template drift check — passed (390 files verified)
- [ ] Post-merge: verify Railway api/web deployments green

Closes #1428