### PR TITLE
feat(mode): semantic diff scoping — filter getDBSchema to whitelist (#1431)

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -1179,7 +1179,7 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
 
 ### Agent & Data
 - [x] Agent isolation — mode-aware connection + whitelist in tool execution (#1430, PR #1460)
-- [x] Semantic diff scoping — filter `getDBSchema` to whitelist (#1431, PR TBD)
+- [x] Semantic diff scoping — filter `getDBSchema` to whitelist (#1431, PR #1462)
 - [ ] Prompt library mode scoping — demo industry filtering + draft visibility (#1438)
 - [x] `GET /api/v1/mode` endpoint (#1439, PR #1453)
 

--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -1179,7 +1179,7 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
 
 ### Agent & Data
 - [x] Agent isolation — mode-aware connection + whitelist in tool execution (#1430, PR #1460)
-- [ ] Semantic diff scoping — filter `getDBSchema` to whitelist (#1431)
+- [x] Semantic diff scoping — filter `getDBSchema` to whitelist (#1431, PR TBD)
 - [ ] Prompt library mode scoping — demo industry filtering + draft visibility (#1438)
 - [x] `GET /api/v1/mode` endpoint (#1439, PR #1453)
 

--- a/apps/docs/content/docs/guides/admin-console.mdx
+++ b/apps/docs/content/docs/guides/admin-console.mdx
@@ -99,6 +99,8 @@ Compares the live database schema against the semantic layer YAML files to detec
 
 **Multiple connections:** If multiple datasource connections are registered, a connection selector dropdown appears in the page header. The diff is re-computed when you switch connections.
 
+**Scoped to your semantic layer:** The diff only considers tables present in your organization's semantic whitelist for the active mode. In developer mode, drafts are included via the overlay; in published mode, only published entities count. This prevents phantom tables from appearing when multiple tenants share a physical database (e.g. demo orgs) and hides system tables that aren't part of the semantic layer.
+
 **API endpoint:** `GET /api/v1/admin/semantic/diff?connection=<id>` — returns structured JSON with `newTables`, `removedTables`, `tableDiffs`, `unchangedCount`, and a `summary` object.
 
 ---

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -1698,10 +1698,13 @@ describe("Admin routes — semantic diff", () => {
     expect(body.summary).toEqual({ total: 5, new: 1, removed: 1, changed: 1, unchanged: 2 });
   });
 
-  it("passes connection query param to runDiff", async () => {
+  it("passes connection query param and mode/org context to runDiff", async () => {
     const res = await app.fetch(adminRequest("/api/v1/admin/semantic/diff?connection=default"));
     expect(res.status).toBe(200);
-    expect(mockRunDiff).toHaveBeenCalledWith("default");
+    expect(mockRunDiff).toHaveBeenCalledWith(
+      "default",
+      expect.objectContaining({ atlasMode: expect.any(String) }),
+    );
   });
 
   it("returns 404 for unknown connection", async () => {

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -1699,11 +1699,18 @@ describe("Admin routes — semantic diff", () => {
   });
 
   it("passes connection query param and mode/org context to runDiff", async () => {
+    // Use org-scoped admin so runDiff receives a concrete orgId; this guards
+    // the cross-tenant isolation property delivered by #1431 — if the handler
+    // ever regresses and stops forwarding `orgId`, this assertion fails.
+    setOrgScopedAdmin("org-diff-test");
     const res = await app.fetch(adminRequest("/api/v1/admin/semantic/diff?connection=default"));
     expect(res.status).toBe(200);
     expect(mockRunDiff).toHaveBeenCalledWith(
       "default",
-      expect.objectContaining({ atlasMode: expect.any(String) }),
+      expect.objectContaining({
+        atlasMode: expect.any(String),
+        orgId: "org-diff-test",
+      }),
     );
   });
 

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -1250,7 +1250,7 @@ admin.openapi(getSemanticStatsRoute, async (c) => {
 });
 
 admin.openapi(getSemanticDiffRoute, async (c) => {
-  const { requestId } = await adminAuthAndContext(c);
+  const { authResult, requestId } = await adminAuthAndContext(c);
   const connectionId = c.req.query("connection") ?? "default";
 
   // Validate connection exists
@@ -1259,13 +1259,19 @@ admin.openapi(getSemanticDiffRoute, async (c) => {
     return c.json({ error: "not_found", message: `Connection "${connectionId}" not found.` }, 404);
   }
 
+  // Scope the diff to the caller's org + mode so demo orgs sharing a DB don't
+  // see phantom tables from other tenants. `adminAuthAndContext` has already
+  // resolved the mode and bound the user onto the request context.
+  const orgId = authResult.user?.activeOrganizationId;
+  const atlasMode = getAtlasMode(c);
+
   try {
-    const result = await runDiff(connectionId);
+    const result = await runDiff(connectionId, { orgId, atlasMode });
     return c.json(result, 200);
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";
     log.error(
-      { err: err instanceof Error ? err : new Error(String(err)), connectionId, requestId },
+      { err: err instanceof Error ? err : new Error(String(err)), connectionId, orgId, atlasMode, requestId },
       "Schema diff failed",
     );
     return c.json({ error: "internal_error", message: `Schema diff failed: ${message}` , requestId}, 500);

--- a/packages/api/src/lib/__tests__/diff-whitelist-scoping.test.ts
+++ b/packages/api/src/lib/__tests__/diff-whitelist-scoping.test.ts
@@ -1,0 +1,388 @@
+/**
+ * Tests for semantic diff whitelist scoping (#1431).
+ *
+ * Covers the phantom-tables fix: `getDBSchema` and `runDiff` now filter the
+ * DB snapshot to only include tables present in the org's mode-aware semantic
+ * whitelist. Before this fix, demo orgs sharing a physical DB saw tables from
+ * every tenant's dataset (cybersec + ecommerce + SaaS).
+ *
+ * Structure:
+ * 1. `filterSnapshotsByWhitelist` — pure unit tests (bare + schema-qualified).
+ * 2. `runDiff` — integration tests with mocked connection + internal DB that
+ *    verify the right whitelist source is consulted per (orgId, mode) tuple.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Shared in-memory DB schema — what information_schema returns for tests
+// ---------------------------------------------------------------------------
+
+type ColumnRow = { table_name: string; column_name: string; data_type: string };
+let dbRows: ColumnRow[] = [];
+
+function setDBTables(tables: Record<string, Record<string, string>>): void {
+  dbRows = [];
+  for (const [table, cols] of Object.entries(tables)) {
+    for (const [col, dt] of Object.entries(cols)) {
+      dbRows.push({ table_name: table, column_name: col, data_type: dt });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mock internal DB — backs loadOrgWhitelist via listEntities/…WithOverlay
+// ---------------------------------------------------------------------------
+
+type EntityRow = {
+  name: string;
+  table: string;
+  status: "published" | "draft" | "draft_delete" | "archived";
+  org_id: string;
+  connection_id?: string | null;
+};
+
+let entityRows: EntityRow[] = [];
+let internalDBAvailable = true;
+
+const mockListEntities = mock(
+  async (orgId: string, _type?: string, statusFilter?: string) => {
+    return entityRows
+      .filter((r) => r.org_id === orgId)
+      .filter((r) => (statusFilter ? r.status === statusFilter : true))
+      .map((r) => ({
+        id: `id-${r.name}-${r.status}`,
+        org_id: r.org_id,
+        entity_type: "entity" as const,
+        name: r.name,
+        yaml_content: `table: ${r.table}\n`,
+        connection_id: r.connection_id ?? null,
+        status: r.status,
+        created_at: "2026-01-01",
+        updated_at: "2026-01-01",
+      }));
+  },
+);
+
+// Developer-mode overlay: published + draft, tombstones/archived excluded.
+const mockListEntitiesWithOverlay = mock(
+  async (orgId: string, _type?: string) => {
+    return entityRows
+      .filter((r) => r.org_id === orgId)
+      .filter((r) => r.status === "published" || r.status === "draft")
+      .map((r) => ({
+        id: `id-${r.name}-${r.status}`,
+        org_id: r.org_id,
+        entity_type: "entity" as const,
+        name: r.name,
+        yaml_content: `table: ${r.table}\n`,
+        connection_id: r.connection_id ?? null,
+        status: r.status,
+        created_at: "2026-01-01",
+        updated_at: "2026-01-01",
+      }));
+  },
+);
+
+mock.module("@atlas/api/lib/semantic/entities", () => ({
+  listEntities: mockListEntities,
+  listEntitiesWithOverlay: mockListEntitiesWithOverlay,
+  getEntity: async () => null,
+  upsertEntity: async () => {},
+  deleteEntity: async () => false,
+  countEntities: async () => 0,
+  bulkUpsertEntities: async () => 0,
+  createVersion: async () => "v1",
+  listVersions: async () => ({ versions: [], total: 0 }),
+  getVersion: async () => null,
+  generateChangeSummary: async () => null,
+  SEMANTIC_ENTITY_STATUSES: ["published", "draft", "draft_delete", "archived"] as const,
+}));
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => internalDBAvailable,
+  internalQuery: async () => [],
+  internalExecute: async () => {},
+  encryptUrl: (u: string) => u,
+  decryptUrl: (u: string) => u,
+  getInternalDB: () => {
+    throw new Error("not configured");
+  },
+  _resetPool: () => {},
+}));
+
+// ---------------------------------------------------------------------------
+// Mock the datasource connection — returns dbRows for information_schema
+// ---------------------------------------------------------------------------
+
+const mockDBConnection = {
+  query: async (_sql: string, _timeoutMs?: number) => ({
+    columns: ["table_name", "column_name", "data_type"],
+    rows: dbRows as unknown as Record<string, unknown>[],
+  }),
+  close: async () => {},
+};
+
+mock.module("@atlas/api/lib/db/connection", () => ({
+  getDB: () => mockDBConnection,
+  connections: {
+    get: () => mockDBConnection,
+    getDefault: () => mockDBConnection,
+    getDBType: () => "postgres" as const,
+    getTargetHost: () => "localhost",
+    list: () => ["default"],
+    has: () => true,
+  },
+  detectDBType: () => "postgres" as const,
+  extractTargetHost: () => "localhost",
+}));
+
+// ---------------------------------------------------------------------------
+// Imports under test — mock.module registrations above take effect here
+// ---------------------------------------------------------------------------
+
+const { filterSnapshotsByWhitelist, runDiff, getDBSchema } = await import("../semantic/diff");
+const { _resetOrgWhitelists } = await import("../semantic/whitelist");
+
+// ---------------------------------------------------------------------------
+// filterSnapshotsByWhitelist — pure
+// ---------------------------------------------------------------------------
+
+function snapshot(table: string, cols: string[] = ["id"]): import("../semantic/diff").EntitySnapshot {
+  return {
+    table,
+    columns: new Map(cols.map((c) => [c, "string"])),
+    foreignKeys: new Set(),
+  };
+}
+
+describe("filterSnapshotsByWhitelist", () => {
+  it("returns the input unchanged when allowed is undefined", () => {
+    const input = new Map([["users", snapshot("users")]]);
+    const out = filterSnapshotsByWhitelist(input, undefined);
+    expect(out).toBe(input);
+  });
+
+  it("returns an empty map when allowed is an empty set", () => {
+    const input = new Map([["users", snapshot("users")]]);
+    const out = filterSnapshotsByWhitelist(input, new Set());
+    expect(out.size).toBe(0);
+  });
+
+  it("filters out tables missing from the whitelist", () => {
+    const input = new Map([
+      ["users", snapshot("users")],
+      ["orders", snapshot("orders")],
+      ["phantom", snapshot("phantom")],
+    ]);
+    const out = filterSnapshotsByWhitelist(input, new Set(["users", "orders"]));
+    expect(out.size).toBe(2);
+    expect(out.has("users")).toBe(true);
+    expect(out.has("orders")).toBe(true);
+    expect(out.has("phantom")).toBe(false);
+  });
+
+  it("matches case-insensitively — DB returns any case, whitelist is lowercased", () => {
+    const input = new Map([["Users", snapshot("Users")]]);
+    const out = filterSnapshotsByWhitelist(input, new Set(["users"]));
+    expect(out.has("Users")).toBe(true);
+  });
+
+  it("matches a bare DB table against a schema-qualified whitelist entry", () => {
+    // Simulates a whitelist that only stored `public.users` — the DB-returned
+    // bare `users` should still match so schema-prefixed entities work.
+    const input = new Map([["users", snapshot("users")]]);
+    const out = filterSnapshotsByWhitelist(input, new Set(["public.users"]));
+    expect(out.has("users")).toBe(true);
+  });
+
+  it("excludes system tables that aren't in the semantic layer", () => {
+    const input = new Map([
+      ["users", snapshot("users")],
+      ["_migrations", snapshot("_migrations")],
+      ["pg_stat_statements", snapshot("pg_stat_statements")],
+    ]);
+    const out = filterSnapshotsByWhitelist(input, new Set(["users"]));
+    expect(out.size).toBe(1);
+    expect(out.has("_migrations")).toBe(false);
+    expect(out.has("pg_stat_statements")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getDBSchema — applies the allowed filter to its output
+// ---------------------------------------------------------------------------
+
+describe("getDBSchema — allowedTables filter", () => {
+  beforeEach(() => {
+    setDBTables({
+      users: { id: "integer", email: "text" },
+      orders: { id: "integer", total: "numeric" },
+      phantom: { id: "integer" },
+    });
+  });
+
+  it("returns every table when no filter is given (legacy behavior)", async () => {
+    const out = await getDBSchema("default");
+    expect(out.size).toBe(3);
+    expect(out.has("phantom")).toBe(true);
+  });
+
+  it("filters to the whitelist when allowedTables is provided", async () => {
+    const out = await getDBSchema("default", new Set(["users", "orders"]));
+    expect(out.size).toBe(2);
+    expect(out.has("phantom")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runDiff — mode + org scoping
+// ---------------------------------------------------------------------------
+
+describe("runDiff — org+mode scoping (#1431)", () => {
+  beforeEach(() => {
+    _resetOrgWhitelists();
+    entityRows = [];
+    internalDBAvailable = true;
+    mockListEntities.mockClear();
+    mockListEntitiesWithOverlay.mockClear();
+    // Default DB: 100 tables, only 10 in the semantic layer.
+    const tables: Record<string, Record<string, string>> = {};
+    for (let i = 0; i < 100; i++) {
+      tables[`t${i}`] = { id: "integer" };
+    }
+    setDBTables(tables);
+  });
+
+  it("scopes DB snapshot to the 10 whitelisted tables when 100 exist", async () => {
+    entityRows = Array.from({ length: 10 }, (_, i) => ({
+      name: `t${i}`,
+      table: `t${i}`,
+      status: "published" as const,
+      org_id: "org-1",
+    }));
+
+    const result = await runDiff("default", { orgId: "org-1", atlasMode: "published" });
+    // Only the 10 whitelisted tables should be considered.
+    // All 10 are "new" because no YAML snapshots exist in this test setup.
+    expect(result.newTables.length).toBe(10);
+    expect(result.summary.total).toBe(10);
+  });
+
+  it("cybersec org does not see ecommerce or SaaS tables in a shared DB", async () => {
+    // Shared DB with 3 datasets. Cybersec org only has cybersec entities.
+    setDBTables({
+      // cybersec tables
+      threat_events: { id: "integer", severity: "text" },
+      vulnerabilities: { id: "integer", cvss_score: "numeric" },
+      // ecommerce tables (NOT in cybersec org's whitelist)
+      orders: { id: "integer", total: "numeric" },
+      products: { id: "integer", sku: "text" },
+      // saas tables (NOT in cybersec org's whitelist)
+      accounts: { id: "integer", plan: "text" },
+      subscriptions: { id: "integer", status: "text" },
+    });
+
+    entityRows = [
+      { name: "threat_events", table: "threat_events", status: "published", org_id: "cybersec-org" },
+      { name: "vulnerabilities", table: "vulnerabilities", status: "published", org_id: "cybersec-org" },
+    ];
+
+    const result = await runDiff("default", {
+      orgId: "cybersec-org",
+      atlasMode: "published",
+    });
+
+    // Only cybersec tables should surface — no phantom tables from other tenants.
+    expect(result.newTables.sort()).toEqual(["threat_events", "vulnerabilities"]);
+    expect(result.newTables).not.toContain("orders");
+    expect(result.newTables).not.toContain("products");
+    expect(result.newTables).not.toContain("accounts");
+    expect(result.newTables).not.toContain("subscriptions");
+  });
+
+  it("developer mode includes draft-only tables via overlay", async () => {
+    setDBTables({
+      users: { id: "integer" },
+      draft_table: { id: "integer" },
+    });
+    entityRows = [
+      { name: "users", table: "users", status: "published", org_id: "org-1" },
+      { name: "draft_table", table: "draft_table", status: "draft", org_id: "org-1" },
+    ];
+
+    const result = await runDiff("default", { orgId: "org-1", atlasMode: "developer" });
+
+    // Developer mode's overlay should include both published + draft entities.
+    expect(result.newTables.sort()).toEqual(["draft_table", "users"]);
+  });
+
+  it("published mode excludes draft-only tables (drafts are invisible to end users)", async () => {
+    setDBTables({
+      users: { id: "integer" },
+      draft_table: { id: "integer" },
+    });
+    entityRows = [
+      { name: "users", table: "users", status: "published", org_id: "org-1" },
+      { name: "draft_table", table: "draft_table", status: "draft", org_id: "org-1" },
+    ];
+
+    const result = await runDiff("default", { orgId: "org-1", atlasMode: "published" });
+
+    // Published mode only sees the published entity — the draft table should
+    // be treated as if it isn't part of the semantic layer.
+    expect(result.newTables).toEqual(["users"]);
+    expect(result.newTables).not.toContain("draft_table");
+  });
+
+  it("non-demo org — system tables not in the semantic layer are excluded", async () => {
+    setDBTables({
+      users: { id: "integer" },
+      _drizzle_migrations: { id: "integer" },
+      pg_stat_statements: { queryid: "integer" },
+    });
+    entityRows = [
+      { name: "users", table: "users", status: "published", org_id: "solo-org" },
+    ];
+
+    const result = await runDiff("default", { orgId: "solo-org", atlasMode: "published" });
+
+    expect(result.newTables).toEqual(["users"]);
+    expect(result.newTables).not.toContain("_drizzle_migrations");
+    expect(result.newTables).not.toContain("pg_stat_statements");
+  });
+
+  it("fails closed when loadOrgWhitelist throws — returns no DB tables", async () => {
+    // Simulate a DB outage during whitelist loading.
+    mockListEntities.mockImplementationOnce(async () => {
+      throw new Error("simulated DB outage");
+    });
+    setDBTables({
+      users: { id: "integer" },
+      sensitive_table: { id: "integer" },
+    });
+    entityRows = [
+      { name: "users", table: "users", status: "published", org_id: "org-1" },
+    ];
+
+    const result = await runDiff("default", { orgId: "org-1", atlasMode: "published" });
+
+    // Empty whitelist on error beats leaking the full schema across tenants.
+    expect(result.newTables).toEqual([]);
+    expect(result.unchangedCount).toBe(0);
+  });
+
+  it("runs without an orgId (self-hosted CLI path) without throwing", async () => {
+    // Self-hosted with no internal DB — falls back to the file-based whitelist
+    // path. In this test environment there are no YAML files, so the file
+    // whitelist is empty and the diff should report no DB tables.
+    internalDBAvailable = false;
+    setDBTables({ users: { id: "integer" } });
+
+    const result = await runDiff("default");
+    expect(result).toBeDefined();
+    expect(result.connection).toBe("default");
+    // With an empty file-based whitelist, the DB snapshot is filtered to empty.
+    expect(result.newTables).toEqual([]);
+  });
+});

--- a/packages/api/src/lib/semantic/diff.ts
+++ b/packages/api/src/lib/semantic/diff.ts
@@ -8,9 +8,16 @@
 import * as fs from "fs";
 import * as path from "path";
 import type { SemanticTableDiff, SemanticDiffResponse } from "@useatlas/types";
+import type { AtlasMode } from "@useatlas/types/auth";
 import { createLogger } from "@atlas/api/lib/logger";
 import { connections } from "@atlas/api/lib/db/connection";
+import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import { getSemanticRoot, readYamlFile, discoverEntities } from "./files";
+import {
+  getOrgWhitelistedTables,
+  getWhitelistedTables,
+  loadOrgWhitelist,
+} from "./whitelist";
 
 const log = createLogger("semantic-diff");
 
@@ -144,10 +151,61 @@ export function computeDiff(
 }
 
 // ---------------------------------------------------------------------------
+// filterSnapshotsByWhitelist — scope DB snapshots to semantic layer tables
+// ---------------------------------------------------------------------------
+
+/**
+ * Filter a DB snapshot map to only include tables present in the semantic
+ * whitelist. Matches both the bare table name and any schema-qualified form
+ * (e.g. `public.users`) so whitelists that record one, the other, or both
+ * continue to work.
+ *
+ * When `allowed` is undefined, the snapshots are returned unchanged — callers
+ * that don't want scoping should pass `undefined` rather than an empty set.
+ * An empty `allowed` set means "nothing is allowed" and returns an empty map.
+ */
+export function filterSnapshotsByWhitelist(
+  snapshots: Map<string, EntitySnapshot>,
+  allowed: Set<string> | undefined,
+): Map<string, EntitySnapshot> {
+  if (!allowed) return snapshots;
+  const filtered = new Map<string, EntitySnapshot>();
+  for (const [tableName, snapshot] of snapshots) {
+    const bare = tableName.toLowerCase();
+    if (allowed.has(bare)) {
+      filtered.set(tableName, snapshot);
+      continue;
+    }
+    // Schema-qualified match — loadEntitiesFromDir stores both forms, but a
+    // future whitelist shape might only include the qualified name. Treat the
+    // DB-returned bare name as matching any `schema.tableName` form too.
+    for (const allowedName of allowed) {
+      const dot = allowedName.lastIndexOf(".");
+      if (dot >= 0 && allowedName.slice(dot + 1) === bare) {
+        filtered.set(tableName, snapshot);
+        break;
+      }
+    }
+  }
+  return filtered;
+}
+
+// ---------------------------------------------------------------------------
 // getDBSchema — query information_schema for table/column metadata
 // ---------------------------------------------------------------------------
 
-export async function getDBSchema(connectionId: string = "default"): Promise<Map<string, EntitySnapshot>> {
+/**
+ * Query information_schema for table/column metadata for a connection.
+ *
+ * When `allowedTables` is provided, the result map is filtered to only include
+ * tables present in the whitelist (both bare and schema-qualified matches).
+ * When omitted, every table in the DB is returned (legacy behavior — retained
+ * for callers that do their own scoping).
+ */
+export async function getDBSchema(
+  connectionId: string = "default",
+  allowedTables?: Set<string>,
+): Promise<Map<string, EntitySnapshot>> {
   const conn = connections.get(connectionId);
   const dbType = connections.getDBType(connectionId);
 
@@ -180,7 +238,7 @@ export async function getDBSchema(connectionId: string = "default"): Promise<Map
     snapshots.get(tableName)!.columns.set(columnName, mapSQLType(dataType));
   }
 
-  return snapshots;
+  return filterSnapshotsByWhitelist(snapshots, allowedTables);
 }
 
 // ---------------------------------------------------------------------------
@@ -241,8 +299,58 @@ export function getYAMLSnapshots(
 // runDiff — orchestrates the full diff for a connection
 // ---------------------------------------------------------------------------
 
-export async function runDiff(connectionId: string = "default"): Promise<SemanticDiffResponse> {
-  const dbSnapshots = await getDBSchema(connectionId);
+/**
+ * Options for scoping a schema diff to a specific org + mode.
+ *
+ * When `orgId` is provided, the DB snapshot is filtered to only include
+ * tables present in the org's mode-aware semantic whitelist. This prevents
+ * phantom tables from appearing in the diff when multiple orgs share a
+ * physical database (e.g. demo orgs sharing the same Postgres).
+ *
+ * When `orgId` is omitted, falls back to the file-based whitelist
+ * (`getWhitelistedTables(connectionId)`) — same source of truth the
+ * SQL execution path uses for self-hosted single-tenant deployments.
+ *
+ * Mode semantics:
+ *   - `published` — only published entities count as whitelisted
+ *   - `developer` — draft overlay is included (drafts supersede published,
+ *     tombstones hide tables, archived-connection entities are excluded)
+ *   - omitted — legacy path (no status filter, all rows including tombstones)
+ */
+export interface DiffOptions {
+  /** Organization ID for org-scoped semantic whitelist. */
+  orgId?: string;
+  /** Atlas mode — `published` (end-user) or `developer` (overlay with drafts). */
+  atlasMode?: AtlasMode;
+}
+
+export async function runDiff(
+  connectionId: string = "default",
+  options: DiffOptions = {},
+): Promise<SemanticDiffResponse> {
+  const { orgId, atlasMode } = options;
+
+  // Resolve the mode-aware whitelist for this org+connection. Falls back to
+  // the file-based whitelist when no org context is available (self-hosted).
+  let allowedTables: Set<string> | undefined;
+  if (orgId && hasInternalDB()) {
+    try {
+      await loadOrgWhitelist(orgId, atlasMode);
+      allowedTables = getOrgWhitelistedTables(orgId, connectionId, atlasMode);
+    } catch (err) {
+      // Fail closed — an empty allowed set means the diff returns no tables,
+      // which is safer than leaking the whole DB schema across tenants.
+      log.error(
+        { orgId, connectionId, atlasMode, err: err instanceof Error ? err.message : String(err) },
+        "Failed to load org whitelist — scoping diff to empty set",
+      );
+      allowedTables = new Set();
+    }
+  } else {
+    allowedTables = getWhitelistedTables(connectionId);
+  }
+
+  const dbSnapshots = await getDBSchema(connectionId, allowedTables);
   const { snapshots: yamlSnapshots, warnings } = getYAMLSnapshots(connectionId);
 
   const diff = computeDiff(dbSnapshots, yamlSnapshots);


### PR DESCRIPTION
## Summary

Fix the phantom-tables bug in the admin schema diff. `getDBSchema()` previously returned every table in the physical database via `information_schema.columns` — for demo orgs sharing a Postgres instance this surfaced cybersec + ecommerce + SaaS tables together, and for any org it surfaced system tables like `_drizzle_migrations` and `pg_stat_statements` that aren't part of the semantic layer.

- `runDiff()` now takes `{ orgId, atlasMode }` and scopes the DB snapshot to the org's mode-aware semantic whitelist — same source of truth the SQL execution path (`sql.ts`) already uses.
- Uses `loadOrgWhitelist(orgId, mode)` + `getOrgWhitelistedTables(orgId, conn, mode)` when an org + internal DB are available; falls back to the file-based `getWhitelistedTables(connectionId)` for self-hosted single-tenant setups.
- Fails closed: if the org whitelist can't be loaded (e.g. transient DB outage) the diff returns an empty allowed set rather than leaking the full schema across tenants.
- Admin `GET /api/v1/admin/semantic/diff` threads `orgId` (from `authResult.user.activeOrganizationId`) and `atlasMode` (from the already-resolved Hono context) through to `runDiff`.

Factored out `filterSnapshotsByWhitelist()` as a pure helper so the matching logic (bare name, schema-qualified form, case-insensitive) is independently testable.

## Acceptance criteria

- [x] Cybersec demo org sees only cybersec tables — not ecommerce/SaaS tables from the shared DB
- [x] Non-demo orgs no longer see system tables that aren't in the semantic layer
- [x] Developer mode diff includes draft entities via the overlay
- [x] Published mode diff excludes draft entities
- [x] DB with 100 tables + whitelist with 10 → diff considers only those 10
- [x] Existing semantic diff unit tests still pass
- [x] Admin route test still asserts the right `runDiff` signature

## Test plan

- [x] New suite: `packages/api/src/lib/__tests__/diff-whitelist-scoping.test.ts` — 15 tests covering `filterSnapshotsByWhitelist`, `getDBSchema` filter, cybersec/ecommerce isolation, dev-vs-published mode scoping, system table exclusion, fail-closed behaviour, and the self-hosted no-org fallback path
- [x] `bun run test semantic` — 23/23 pass (includes existing `semantic-diff.test.ts`, `published-mode-filtering.test.ts`, overlay queries)
- [x] `bun run test admin` — 26/26 pass (includes `admin.test.ts` schema-diff assertions)
- [x] `bun run test mode` — 6/6 mode-related suites pass
- [x] Full `bun run test` — 222/222 api + 17/17 cli + 45/45 web + 25/25 ee + 8/8 react
- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun x syncpack lint` — clean
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — clean

Closes #1431