### PR TITLE
feat(mode): admin surface — badges, read-only published, pending changes (#1435)

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -1187,7 +1187,7 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
 - [x] Connect page redesign — two equal-weight paths (#1432, PRs #1449, #1456)
 - [x] Developer mode banner + cookie-based toggle (#1433, PR #1445)
 - [x] Non-admin demo indicator chip (#1434, PR #1459)
-- [x] Admin surface — draft/demo badges, read-only published, pending changes summary (#1435)
+- [x] Admin surface — draft/demo badges, read-only published, pending changes summary (#1435, PR #1463)
 - [ ] Empty states in developer mode (#1436)
 
 ### Bug Fixes

--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -1187,7 +1187,7 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
 - [x] Connect page redesign — two equal-weight paths (#1432, PRs #1449, #1456)
 - [x] Developer mode banner + cookie-based toggle (#1433, PR #1445)
 - [x] Non-admin demo indicator chip (#1434, PR #1459)
-- [ ] Admin surface — draft/demo badges, read-only published, pending changes summary (#1435)
+- [x] Admin surface — draft/demo badges, read-only published, pending changes summary (#1435)
 - [ ] Empty states in developer mode (#1436)
 
 ### Bug Fixes

--- a/packages/web/src/app/admin/connections/columns.tsx
+++ b/packages/web/src/app/admin/connections/columns.tsx
@@ -4,8 +4,12 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { Badge } from "@/components/ui/badge";
 import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
 import { HealthBadge } from "@/ui/components/admin/health-badge";
+import { DemoBadge, DraftBadge } from "@/ui/components/admin/mode-badges";
 import { Fingerprint, Database, FileText, Activity, Clock } from "lucide-react";
 import type { ConnectionHealth, ConnectionInfo } from "@/ui/lib/types";
+
+/** Reserved connection id for the onboarding demo dataset. */
+export const DEMO_CONNECTION_ID = "__demo__";
 
 function mapHealthStatus(
   status?: ConnectionHealth["status"],
@@ -23,9 +27,17 @@ export function getConnectionColumns(): ColumnDef<ConnectionInfo>[] {
       header: ({ column }) => (
         <DataTableColumnHeader column={column} label="ID" />
       ),
-      cell: ({ row }) => (
-        <span className="font-mono text-xs">{row.getValue<string>("id")}</span>
-      ),
+      cell: ({ row }) => {
+        const id = row.getValue<string>("id");
+        const status = row.original.status;
+        return (
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-xs">{id}</span>
+            {id === DEMO_CONNECTION_ID && <DemoBadge />}
+            {status === "draft" && <DraftBadge />}
+          </div>
+        );
+      },
       meta: { label: "ID", icon: Fingerprint },
       enableSorting: false,
     },

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -27,7 +27,14 @@ import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { DataTable } from "@/components/data-table/data-table";
 import { DataTableToolbar } from "@/components/data-table/data-table-toolbar";
-import { getConnectionColumns } from "./columns";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useDemoReadonly } from "@/ui/hooks/use-demo-readonly";
+import { DEMO_CONNECTION_ID, getConnectionColumns } from "./columns";
 import { useDataTable } from "@/hooks/use-data-table";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Cable, Loader2, Plus, Pencil, Trash2, Eye, EyeOff, Activity, ChevronDown, ChevronUp, Droplets, Check, X } from "lucide-react";
@@ -570,9 +577,13 @@ function PoolStatsSection({ onError }: { onError: (msg: string) => void }) {
 
 // ── Page ──────────────────────────────────────────────────────────
 
+/** Tooltip text when connection mutations are blocked by published-mode demo readonly. */
+const DEMO_READONLY_TOOLTIP = "Switch to developer mode to manage connections";
+
 export default function ConnectionsPage() {
   const { apiUrl, isCrossOrigin } = useAtlasConfig();
   const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
+  const { readOnly: demoReadOnly } = useDemoReadonly();
 
   const testMutation = useAdminMutation<ConnectionHealth>({ method: "POST" });
   const [mutationError, setMutationError] = useState<string | null>(null);
@@ -626,27 +637,55 @@ export default function ConnectionsPage() {
                 "Test"
               )}
             </Button>
-            {conn.id !== "default" && (
-              <>
+            {conn.id !== "default" && (() => {
+              // Demo connections are read-only in published mode — the only
+              // way to edit/delete them is to drop into developer mode. Show
+              // a tooltip explaining why the action is disabled.
+              const rowReadOnly = demoReadOnly && conn.id === DEMO_CONNECTION_ID;
+              const editBtn = (
                 <Button
                   variant="ghost"
                   size="sm"
                   onClick={() => handleEdit(conn.id)}
-                  disabled={loadingDetail}
+                  disabled={loadingDetail || rowReadOnly}
                   aria-label={`Edit connection ${conn.id}`}
                 >
                   <Pencil className="size-3.5" />
                 </Button>
+              );
+              const deleteBtn = (
                 <Button
                   variant="ghost"
                   size="sm"
                   onClick={() => handleDelete(conn.id)}
+                  disabled={rowReadOnly}
                   aria-label={`Delete connection ${conn.id}`}
                 >
                   <Trash2 className="size-3.5 text-destructive" />
                 </Button>
-              </>
-            )}
+              );
+              return rowReadOnly ? (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span tabIndex={0}>{editBtn}</span>
+                    </TooltipTrigger>
+                    <TooltipContent>{DEMO_READONLY_TOOLTIP}</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span tabIndex={0}>{deleteBtn}</span>
+                    </TooltipTrigger>
+                    <TooltipContent>{DEMO_READONLY_TOOLTIP}</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              ) : (
+                <>
+                  {editBtn}
+                  {deleteBtn}
+                </>
+              );
+            })()}
           </div>
         );
       },
@@ -742,10 +781,26 @@ export default function ConnectionsPage() {
           <h1 className="text-2xl font-bold tracking-tight">Connections</h1>
           <p className="text-sm text-muted-foreground">Manage datasource connections</p>
         </div>
-        <Button onClick={handleAdd} size="sm">
-          <Plus className="mr-2 size-4" />
-          Add Connection
-        </Button>
+        {demoReadOnly ? (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span tabIndex={0}>
+                  <Button onClick={handleAdd} size="sm" disabled>
+                    <Plus className="mr-2 size-4" />
+                    Add Connection
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>{DEMO_READONLY_TOOLTIP}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : (
+          <Button onClick={handleAdd} size="sm">
+            <Plus className="mr-2 size-4" />
+            Add Connection
+          </Button>
+        )}
       </div>
 
       <ErrorBoundary>

--- a/packages/web/src/app/admin/prompts/columns.tsx
+++ b/packages/web/src/app/admin/prompts/columns.tsx
@@ -4,6 +4,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 import type { PromptCollection } from "@/ui/lib/types";
 import { Badge } from "@/components/ui/badge";
 import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
+import { DemoBadge, DraftBadge } from "@/ui/components/admin/mode-badges";
 import {
   FileText,
   Tag,
@@ -64,18 +65,12 @@ export function getPromptCollectionColumns(
       ),
       cell: ({ row }) => {
         const name = row.getValue<string>("name");
-        const isBuiltin = row.original.isBuiltin;
+        const { isBuiltin, status } = row.original;
         return (
           <div className="flex items-center gap-2">
             <span className="text-sm font-medium">{name}</span>
-            {isBuiltin && (
-              <Badge
-                variant="outline"
-                className="border-amber-300 text-amber-700 dark:border-amber-700 dark:text-amber-400 text-[10px] px-1.5 py-0"
-              >
-                Built-in
-              </Badge>
-            )}
+            {isBuiltin && <DemoBadge />}
+            {status === "draft" && <DraftBadge />}
           </div>
         );
       },

--- a/packages/web/src/app/admin/semantic/page.tsx
+++ b/packages/web/src/app/admin/semantic/page.tsx
@@ -40,6 +40,13 @@ import { useDeployMode } from "@/ui/hooks/use-deploy-mode";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { EntityVersionHistory } from "@/ui/components/admin/entity-version-history";
 import { SemanticHealthWidget } from "@/ui/components/admin/semantic-health-widget";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useDemoReadonly, demoIndustryLabel } from "@/ui/hooks/use-demo-readonly";
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -332,12 +339,18 @@ function RawYamlViewer({ content }: { content: string }) {
 
 // ── Page ──────────────────────────────────────────────────────────
 
+/** Tooltip text when semantic editor mutations are blocked by published-mode demo readonly. */
+const DEMO_READONLY_TOOLTIP = "Switch to developer mode to edit demo semantic entities";
+
 export default function SemanticPage() {
   const { apiUrl, isCrossOrigin } = useAtlasConfig();
   const { deployMode } = useDeployMode();
   const isSaas = deployMode === "saas";
+  const { readOnly: demoReadOnly, demoIndustry } = useDemoReadonly();
+  const demoLabel = demoIndustryLabel(demoIndustry);
 
   const [entities, setEntities] = useState<EntitySummary[]>([]);
+  const [draftEntityNames, setDraftEntityNames] = useState<Set<string>>(() => new Set());
   const [selectedEntity, setSelectedEntity] = useState<EntityData | null>(null);
   const [glossary, setGlossary] = useState<GlossaryTerm[]>([]);
   const [metrics, setMetrics] = useState<MetricEntry[]>([]);
@@ -431,6 +444,40 @@ export default function SemanticPage() {
     });
     return () => { cancelled = true; };
   }, [apiUrl, fetchKey]);
+
+  // Fetch org-scoped draft entity names so the file tree can render the
+  // amber accent on drafts. Non-SaaS self-hosted installs without an
+  // internal DB get a 501 — we swallow that, since drafts are a SaaS-only
+  // concept there.
+  useEffect(() => {
+    if (!isSaas) return;
+    let cancelled = false;
+
+    async function fetchDrafts() {
+      try {
+        const res = await fetch(
+          `${apiUrl}/api/v1/admin/semantic/org/entities?type=entity`,
+          fetchOpts,
+        );
+        if (!res.ok) return;
+        const data = await res.json();
+        const entries = Array.isArray(data?.entities) ? data.entities as Array<{ name?: unknown; status?: unknown }> : [];
+        const names = new Set<string>();
+        for (const e of entries) {
+          if (typeof e.name === "string" && e.status === "draft") names.add(e.name);
+        }
+        if (!cancelled) setDraftEntityNames(names);
+      } catch (err) {
+        console.debug(
+          "Failed to fetch draft entity names:",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
+
+    fetchDrafts();
+    return () => { cancelled = true; };
+  }, [apiUrl, fetchKey, isSaas]);
 
   const handleSelect = (sel: SemanticSelection) => {
     startTransition(() => {
@@ -569,7 +616,11 @@ export default function SemanticPage() {
           <div>
             <h1 className="text-2xl font-bold tracking-tight">Semantic Layer</h1>
             <p className="text-sm text-muted-foreground">
-              {isSaas ? "Manage entities, glossary, metrics, and catalog" : "Browse entities, glossary, metrics, and catalog"}
+              {demoLabel
+                ? `${demoLabel} \u2014 ${entities.length} ${entities.length === 1 ? "entity" : "entities"}`
+                : isSaas
+                  ? "Manage entities, glossary, metrics, and catalog"
+                  : "Browse entities, glossary, metrics, and catalog"}
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -579,12 +630,26 @@ export default function SemanticPage() {
                 Improve
               </Button>
             </Link>
-            {isSaas && (
+            {isSaas && (demoReadOnly ? (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span tabIndex={0}>
+                      <Button onClick={handleAddEntity} className="gap-1.5" disabled>
+                        <Plus className="size-4" />
+                        Add Entity
+                      </Button>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>{DEMO_READONLY_TOOLTIP}</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            ) : (
               <Button onClick={handleAddEntity} className="gap-1.5">
                 <Plus className="size-4" />
                 Add Entity
               </Button>
-            )}
+            ))}
           </div>
         </div>
       </div>
@@ -619,6 +684,7 @@ export default function SemanticPage() {
           hasGlossary={glossary.length > 0}
           selection={selection}
           onSelect={handleSelect}
+          draftEntityNames={draftEntityNames}
           className="w-64 shrink-0 border-r"
         />
 
@@ -629,23 +695,47 @@ export default function SemanticPage() {
             <div className="flex h-[41px] items-center justify-between border-b px-4">
               {/* Edit/delete actions (SaaS mode, entity selected) */}
               <div className="flex items-center gap-1.5">
-                {isSaas && selection.type === "entity" && selectedEntity && (
-                  <>
-                    <Button variant="outline" size="sm" onClick={handleEditEntity} className="gap-1 text-xs">
+                {isSaas && selection.type === "entity" && selectedEntity && (() => {
+                  const editBtn = (
+                    <Button variant="outline" size="sm" onClick={handleEditEntity} className="gap-1 text-xs" disabled={demoReadOnly}>
                       <Pencil className="size-3" />
                       Edit
                     </Button>
+                  );
+                  const deleteBtn = (
                     <Button
                       variant="outline"
                       size="sm"
                       onClick={() => setDeleteTarget(selection.name)}
                       className="gap-1 text-xs text-destructive hover:text-destructive"
+                      disabled={demoReadOnly}
                     >
                       <Trash2 className="size-3" />
                       Delete
                     </Button>
-                  </>
-                )}
+                  );
+                  return demoReadOnly ? (
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span tabIndex={0}>{editBtn}</span>
+                        </TooltipTrigger>
+                        <TooltipContent>{DEMO_READONLY_TOOLTIP}</TooltipContent>
+                      </Tooltip>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span tabIndex={0}>{deleteBtn}</span>
+                        </TooltipTrigger>
+                        <TooltipContent>{DEMO_READONLY_TOOLTIP}</TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  ) : (
+                    <>
+                      {editBtn}
+                      {deleteBtn}
+                    </>
+                  );
+                })()}
               </div>
               <ViewToggle mode={viewMode} onChange={(m) => { startTransition(() => { setParams({ view: m }); }); }} showHistory={isSaas && selection?.type === "entity"} />
             </div>

--- a/packages/web/src/ui/__tests__/connection-columns.test.tsx
+++ b/packages/web/src/ui/__tests__/connection-columns.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { render, cleanup } from "@testing-library/react";
+import { flexRender, type Cell, type Row, type Table } from "@tanstack/react-table";
+import type { ConnectionInfo } from "@useatlas/types/connection";
+import {
+  DEMO_CONNECTION_ID,
+  getConnectionColumns,
+} from "../../app/admin/connections/columns";
+
+/**
+ * Render a single column's cell for a given row. Uses the tanstack-react-table
+ * flexRender helper so we exercise the same path the DataTable does — avoids
+ * shipping tests that pass because they bypass the library.
+ */
+function renderIdCell(row: ConnectionInfo) {
+  const columns = getConnectionColumns();
+  const idCol = columns.find((c) => c.id === "id");
+  if (!idCol) throw new Error("id column missing");
+  // Minimal fake TanStack row/cell context — we only need `getValue` and
+  // `original`. The cell renderer uses both.
+  const fakeRow = {
+    getValue: (key: string) => (row as unknown as Record<string, unknown>)[key],
+    original: row,
+  } as unknown as Row<ConnectionInfo>;
+  const fakeCell = { getContext: () => ({ row: fakeRow, table: {} as Table<ConnectionInfo>, cell: {} as Cell<ConnectionInfo, unknown>, column: idCol, getValue: () => row.id, renderValue: () => row.id }) };
+  const ctx = fakeCell.getContext();
+  return render(<>{flexRender(idCol.cell, ctx)}</>);
+}
+
+describe("connection columns — id cell", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("no demo/draft badge on a vanilla published connection", () => {
+    const { container } = renderIdCell({ id: "warehouse", dbType: "postgres", status: "published" });
+    expect(container.textContent).toContain("warehouse");
+    expect(container.textContent).not.toContain("Demo");
+    expect(container.textContent).not.toContain("Draft");
+  });
+
+  test("renders Demo badge on the reserved __demo__ id", () => {
+    const { container } = renderIdCell({ id: DEMO_CONNECTION_ID, dbType: "postgres", status: "published" });
+    expect(container.textContent).toContain(DEMO_CONNECTION_ID);
+    expect(container.textContent).toContain("Demo");
+    expect(container.textContent).not.toContain("Draft");
+  });
+
+  test("renders Draft badge on status === 'draft'", () => {
+    const { container } = renderIdCell({ id: "stage", dbType: "postgres", status: "draft" });
+    expect(container.textContent).toContain("stage");
+    expect(container.textContent).toContain("Draft");
+    expect(container.textContent).not.toContain("Demo");
+  });
+
+  test("renders both badges when a __demo__ connection is also in draft", () => {
+    const { container } = renderIdCell({ id: DEMO_CONNECTION_ID, dbType: "postgres", status: "draft" });
+    expect(container.textContent).toContain("Demo");
+    expect(container.textContent).toContain("Draft");
+  });
+});

--- a/packages/web/src/ui/__tests__/demo-indicator-chip.test.tsx
+++ b/packages/web/src/ui/__tests__/demo-indicator-chip.test.tsx
@@ -55,6 +55,12 @@ describe("DemoIndicatorChip", () => {
     expect(chip.getAttribute("title")).toBe("You are viewing the Sentinel Security demo dataset");
   });
 
+  test("renders Sentinel Security label for new `cybersec` slug (#1463 review follow-up)", () => {
+    modeStatusState = { data: activeMode("cybersec"), loading: false };
+    const { container } = render(<DemoIndicatorChip />);
+    expect(container.textContent).toContain("Sentinel Security demo");
+  });
+
   test("renders SaaS CRM label for saas industry", () => {
     modeStatusState = { data: activeMode("saas"), loading: false };
     const { container } = render(<DemoIndicatorChip />);

--- a/packages/web/src/ui/__tests__/mode-badges.test.tsx
+++ b/packages/web/src/ui/__tests__/mode-badges.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { render, cleanup } from "@testing-library/react";
+import { DemoBadge, DraftBadge } from "../components/admin/mode-badges";
+
+describe("DemoBadge", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("renders 'Demo' text", () => {
+    const { container } = render(<DemoBadge />);
+    expect(container.textContent).toBe("Demo");
+  });
+
+  test("has accessible label and title attribute", () => {
+    const { container } = render(<DemoBadge />);
+    const el = container.querySelector("[aria-label]");
+    expect(el?.getAttribute("aria-label")).toBe("Demo content");
+    expect(el?.getAttribute("title")).toBe("Part of the demo dataset");
+  });
+
+  test("applies caller-provided className in addition to defaults", () => {
+    const { container } = render(<DemoBadge className="my-custom" />);
+    const el = container.querySelector("[aria-label]");
+    expect(el?.className).toContain("my-custom");
+  });
+});
+
+describe("DraftBadge", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("renders 'Draft' text", () => {
+    const { container } = render(<DraftBadge />);
+    expect(container.textContent).toBe("Draft");
+  });
+
+  test("has accessible label and title attribute", () => {
+    const { container } = render(<DraftBadge />);
+    const el = container.querySelector("[aria-label]");
+    expect(el?.getAttribute("aria-label")).toBe("Draft — not yet published");
+    expect(el?.getAttribute("title")).toBe("Draft — not yet published");
+  });
+
+  test("uses amber tint so it pairs with developer-mode banner", () => {
+    const { container } = render(<DraftBadge />);
+    const el = container.querySelector("[aria-label]");
+    // Keep assertion broad so restyles within the amber family don't break
+    // the test — we only care that the amber signal is present.
+    expect(el?.className).toContain("amber");
+  });
+});

--- a/packages/web/src/ui/__tests__/pending-changes-summary.test.tsx
+++ b/packages/web/src/ui/__tests__/pending-changes-summary.test.tsx
@@ -1,0 +1,143 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { render, cleanup } from "@testing-library/react";
+import type { ModeStatusResponse, ModeDraftCounts } from "@useatlas/types/mode";
+
+let modeStatusState: {
+  data: ModeStatusResponse | null;
+  loading: boolean;
+} = { data: null, loading: false };
+
+mock.module("@/ui/hooks/use-mode-status", () => ({
+  useModeStatus: () => modeStatusState,
+}));
+
+// Import AFTER mocks so the module binds to the mocked hook.
+import {
+  PendingChangesSummary,
+  formatDraftSegments,
+} from "../components/pending-changes-summary";
+
+function statusWith(counts: ModeDraftCounts | null): ModeStatusResponse {
+  return {
+    mode: "developer",
+    canToggle: true,
+    demoIndustry: null,
+    demoConnectionActive: false,
+    hasDrafts: counts !== null,
+    draftCounts: counts,
+  };
+}
+
+function counts(partial: Partial<ModeDraftCounts> = {}): ModeDraftCounts {
+  return {
+    connections: 0,
+    entities: 0,
+    entityEdits: 0,
+    entityDeletes: 0,
+    prompts: 0,
+    ...partial,
+  };
+}
+
+describe("formatDraftSegments", () => {
+  test("returns empty array when all counts are zero", () => {
+    expect(formatDraftSegments(counts())).toEqual([]);
+  });
+
+  test("pluralizes entity correctly at 1 and >1", () => {
+    expect(formatDraftSegments(counts({ entities: 1 }))).toEqual(["1 entity"]);
+    expect(formatDraftSegments(counts({ entities: 2 }))).toEqual(["2 entities"]);
+  });
+
+  test("pluralizes connection correctly", () => {
+    expect(formatDraftSegments(counts({ connections: 1 }))).toEqual(["1 connection"]);
+    expect(formatDraftSegments(counts({ connections: 3 }))).toEqual(["3 connections"]);
+  });
+
+  test("pluralizes prompt correctly", () => {
+    expect(formatDraftSegments(counts({ prompts: 1 }))).toEqual(["1 prompt"]);
+    expect(formatDraftSegments(counts({ prompts: 5 }))).toEqual(["5 prompts"]);
+  });
+
+  test("folds entities + entityEdits + entityDeletes into a single entity total", () => {
+    const segments = formatDraftSegments(
+      counts({ entities: 3, entityEdits: 2, entityDeletes: 1 }),
+    );
+    expect(segments).toEqual(["6 entities"]);
+  });
+
+  test("orders segments connections -> entities -> prompts", () => {
+    const segments = formatDraftSegments(
+      counts({ connections: 1, entities: 4, prompts: 2 }),
+    );
+    expect(segments).toEqual(["1 connection", "4 entities", "2 prompts"]);
+  });
+
+  test("skips zero-count buckets", () => {
+    const segments = formatDraftSegments(
+      counts({ connections: 0, entities: 2, prompts: 1 }),
+    );
+    expect(segments).toEqual(["2 entities", "1 prompt"]);
+  });
+});
+
+describe("PendingChangesSummary", () => {
+  beforeEach(() => {
+    modeStatusState = { data: null, loading: false };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("hides when loading", () => {
+    modeStatusState = { data: null, loading: true };
+    const { container } = render(<PendingChangesSummary />);
+    expect(container.textContent).toBe("");
+  });
+
+  test("hides when no draft counts are returned", () => {
+    modeStatusState = { data: statusWith(null), loading: false };
+    const { container } = render(<PendingChangesSummary />);
+    expect(container.textContent).toBe("");
+  });
+
+  test("hides when all counts are zero", () => {
+    modeStatusState = { data: statusWith(counts()), loading: false };
+    const { container } = render(<PendingChangesSummary />);
+    expect(container.textContent).toBe("");
+  });
+
+  test("renders segments joined by middle dot for multiple resource types", () => {
+    modeStatusState = {
+      data: statusWith(counts({ connections: 1, entities: 4, prompts: 2 })),
+      loading: false,
+    };
+    const { container } = render(<PendingChangesSummary />);
+    // Default (sm:) variant shows full label; the responsive mobile
+    // variant is hidden but still in the DOM. Both are acceptable matches.
+    expect(container.textContent).toContain("1 connection");
+    expect(container.textContent).toContain("4 entities");
+    expect(container.textContent).toContain("2 prompts");
+  });
+
+  test("renders accessible label with total and breakdown", () => {
+    modeStatusState = {
+      data: statusWith(counts({ entities: 1 })),
+      loading: false,
+    };
+    const { container } = render(<PendingChangesSummary />);
+    const label = container.querySelector("[aria-label]");
+    expect(label?.getAttribute("aria-label")).toBe("1 pending change: 1 entity");
+  });
+
+  test("total pluralizes 'changes' when > 1", () => {
+    modeStatusState = {
+      data: statusWith(counts({ entities: 3 })),
+      loading: false,
+    };
+    const { container } = render(<PendingChangesSummary />);
+    const label = container.querySelector("[aria-label]");
+    expect(label?.getAttribute("aria-label")).toContain("3 pending changes");
+  });
+});

--- a/packages/web/src/ui/__tests__/prompt-columns.test.tsx
+++ b/packages/web/src/ui/__tests__/prompt-columns.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { render, cleanup } from "@testing-library/react";
+import { flexRender, type Row, type Table, type Cell } from "@tanstack/react-table";
+import type { PromptCollection } from "@useatlas/types/prompt";
+import { getPromptCollectionColumns } from "../../app/admin/prompts/columns";
+
+function baseCollection(partial: Partial<PromptCollection> = {}): PromptCollection {
+  return {
+    id: "col_1",
+    orgId: "org_1",
+    name: "Revenue",
+    industry: "saas",
+    description: "",
+    isBuiltin: false,
+    sortOrder: 0,
+    status: "published",
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...partial,
+  };
+}
+
+function renderNameCell(row: PromptCollection) {
+  const columns = getPromptCollectionColumns(new Map());
+  const nameCol = columns.find((c) => c.id === "name");
+  if (!nameCol) throw new Error("name column missing");
+  const fakeRow = {
+    getValue: (key: string) => (row as unknown as Record<string, unknown>)[key],
+    original: row,
+  } as unknown as Row<PromptCollection>;
+  const ctx = {
+    row: fakeRow,
+    table: {} as Table<PromptCollection>,
+    cell: {} as Cell<PromptCollection, unknown>,
+    column: nameCol,
+    getValue: () => row.name,
+    renderValue: () => row.name,
+  };
+  return render(<>{flexRender(nameCol.cell, ctx)}</>);
+}
+
+describe("prompt collection columns — name cell", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("renders Demo badge when isBuiltin is true", () => {
+    const { container } = renderNameCell(baseCollection({ name: "SaaS starters", isBuiltin: true }));
+    expect(container.textContent).toContain("SaaS starters");
+    expect(container.textContent).toContain("Demo");
+  });
+
+  test("renders Draft badge when status === 'draft'", () => {
+    const { container } = renderNameCell(baseCollection({ name: "WIP", status: "draft" }));
+    expect(container.textContent).toContain("WIP");
+    expect(container.textContent).toContain("Draft");
+  });
+
+  test("no badges on a non-builtin published collection", () => {
+    const { container } = renderNameCell(baseCollection({ name: "Custom", isBuiltin: false, status: "published" }));
+    expect(container.textContent).toContain("Custom");
+    expect(container.textContent).not.toContain("Demo");
+    expect(container.textContent).not.toContain("Draft");
+  });
+
+  test("renders both badges on a draft built-in collection", () => {
+    const { container } = renderNameCell(baseCollection({ name: "Both", isBuiltin: true, status: "draft" }));
+    expect(container.textContent).toContain("Demo");
+    expect(container.textContent).toContain("Draft");
+  });
+});

--- a/packages/web/src/ui/__tests__/semantic-file-tree-drafts.test.tsx
+++ b/packages/web/src/ui/__tests__/semantic-file-tree-drafts.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { render, cleanup } from "@testing-library/react";
+import { SemanticFileTree } from "../components/admin/semantic-file-tree";
+
+function findEntityButton(container: HTMLElement, fileName: string): HTMLElement | null {
+  const buttons = container.querySelectorAll("button");
+  for (const btn of buttons) {
+    if (btn.textContent?.includes(fileName)) return btn as HTMLElement;
+  }
+  return null;
+}
+
+describe("SemanticFileTree — draft accent", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("applies amber left border to draft entities", () => {
+    const { container } = render(
+      <SemanticFileTree
+        entityNames={["users", "orders"]}
+        metricFileNames={[]}
+        hasCatalog={false}
+        hasGlossary={false}
+        selection={null}
+        onSelect={() => {}}
+        draftEntityNames={new Set(["orders"])}
+      />,
+    );
+    const draftBtn = findEntityButton(container, "orders.yml");
+    const publishedBtn = findEntityButton(container, "users.yml");
+    expect(draftBtn).not.toBeNull();
+    expect(publishedBtn).not.toBeNull();
+    expect(draftBtn!.className).toContain("border-amber-400/60");
+    expect(publishedBtn!.className).not.toContain("border-amber-400/60");
+  });
+
+  test("draft entity has aria-label indicating draft status", () => {
+    const { container } = render(
+      <SemanticFileTree
+        entityNames={["orders"]}
+        metricFileNames={[]}
+        hasCatalog={false}
+        hasGlossary={false}
+        selection={null}
+        onSelect={() => {}}
+        draftEntityNames={new Set(["orders"])}
+      />,
+    );
+    const btn = findEntityButton(container, "orders.yml");
+    expect(btn!.getAttribute("aria-label")).toBe("orders.yml (draft)");
+  });
+
+  test("no accent when draftEntityNames prop is omitted", () => {
+    const { container } = render(
+      <SemanticFileTree
+        entityNames={["orders"]}
+        metricFileNames={[]}
+        hasCatalog={false}
+        hasGlossary={false}
+        selection={null}
+        onSelect={() => {}}
+      />,
+    );
+    const btn = findEntityButton(container, "orders.yml");
+    expect(btn!.className).not.toContain("border-amber-400/60");
+  });
+});

--- a/packages/web/src/ui/__tests__/use-demo-readonly.test.tsx
+++ b/packages/web/src/ui/__tests__/use-demo-readonly.test.tsx
@@ -1,0 +1,118 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { renderHook, cleanup } from "@testing-library/react";
+import type { ModeStatusResponse } from "@useatlas/types/mode";
+import type { AtlasMode } from "@useatlas/types/auth";
+
+// Controls for the mocked hooks.
+const modeState = {
+  mode: "published" as AtlasMode,
+  isLoading: false,
+  isAdmin: true,
+};
+let modeStatusState: {
+  data: ModeStatusResponse | null;
+  loading: boolean;
+} = { data: null, loading: false };
+
+mock.module("@/ui/hooks/use-mode", () => ({
+  useMode: () => ({ ...modeState, setMode: () => {} }),
+}));
+
+mock.module("@/ui/hooks/use-mode-status", () => ({
+  useModeStatus: () => modeStatusState,
+}));
+
+import { useDemoReadonly, demoIndustryLabel } from "../hooks/use-demo-readonly";
+
+function status(partial: Partial<ModeStatusResponse> = {}): ModeStatusResponse {
+  return {
+    mode: "published",
+    canToggle: true,
+    demoIndustry: null,
+    demoConnectionActive: false,
+    hasDrafts: false,
+    draftCounts: null,
+    ...partial,
+  };
+}
+
+describe("demoIndustryLabel", () => {
+  test("returns label for known slugs", () => {
+    expect(demoIndustryLabel("saas")).toBe("SaaS CRM");
+    expect(demoIndustryLabel("cybersec")).toBe("Sentinel Security");
+    expect(demoIndustryLabel("cybersecurity")).toBe("Sentinel Security");
+    expect(demoIndustryLabel("ecommerce")).toBe("NovaMart");
+  });
+
+  test("returns null for unknown / nullish", () => {
+    expect(demoIndustryLabel(null)).toBeNull();
+    expect(demoIndustryLabel(undefined)).toBeNull();
+    expect(demoIndustryLabel("")).toBeNull();
+    expect(demoIndustryLabel("unknown-vertical")).toBeNull();
+  });
+});
+
+describe("useDemoReadonly", () => {
+  beforeEach(() => {
+    modeState.mode = "published";
+    modeState.isLoading = false;
+    modeState.isAdmin = true;
+    modeStatusState = { data: null, loading: false };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("readOnly = true when published mode + demo connection active", () => {
+    modeState.mode = "published";
+    modeStatusState = {
+      data: status({ demoConnectionActive: true, demoIndustry: "cybersec" }),
+      loading: false,
+    };
+    const { result } = renderHook(() => useDemoReadonly());
+    expect(result.current.readOnly).toBe(true);
+    expect(result.current.demoIndustry).toBe("cybersec");
+  });
+
+  test("readOnly = false in developer mode even when demo is active", () => {
+    modeState.mode = "developer";
+    modeStatusState = {
+      data: status({ demoConnectionActive: true, demoIndustry: "saas" }),
+      loading: false,
+    };
+    const { result } = renderHook(() => useDemoReadonly());
+    expect(result.current.readOnly).toBe(false);
+    // demoIndustry still surfaces so callers can render subtitles.
+    expect(result.current.demoIndustry).toBe("saas");
+  });
+
+  test("readOnly = false when there's no active demo connection", () => {
+    modeState.mode = "published";
+    modeStatusState = {
+      data: status({ demoConnectionActive: false }),
+      loading: false,
+    };
+    const { result } = renderHook(() => useDemoReadonly());
+    expect(result.current.readOnly).toBe(false);
+  });
+
+  test("readOnly = false while session is still loading (fail-open)", () => {
+    modeState.isLoading = true;
+    modeStatusState = {
+      data: status({ demoConnectionActive: true }),
+      loading: false,
+    };
+    const { result } = renderHook(() => useDemoReadonly());
+    expect(result.current.readOnly).toBe(false);
+    expect(result.current.loading).toBe(true);
+  });
+
+  test("readOnly = false while mode status is still loading (fail-open)", () => {
+    modeState.mode = "published";
+    modeStatusState = { data: null, loading: true };
+    const { result } = renderHook(() => useDemoReadonly());
+    expect(result.current.readOnly).toBe(false);
+    expect(result.current.loading).toBe(true);
+  });
+});

--- a/packages/web/src/ui/components/admin/mode-badges.tsx
+++ b/packages/web/src/ui/components/admin/mode-badges.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+/**
+ * "Demo" pill shown on workspace-seeded demo resources (connections whose id
+ * is `__demo__`, prompt collections whose `isBuiltin` flag is true, etc.).
+ *
+ * Neutral zinc coloring so demo content reads as "preset" rather than
+ * "warning" — contrast with the amber "Draft" pill and the developer banner.
+ */
+export function DemoBadge({ className }: { className?: string }) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "border-zinc-300 bg-zinc-50 px-1.5 py-0 text-[10px] font-medium text-zinc-700 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400",
+        className,
+      )}
+      aria-label="Demo content"
+      title="Part of the demo dataset"
+    >
+      Demo
+    </Badge>
+  );
+}
+
+/**
+ * "Draft" pill shown on resources in `status === 'draft'`. Amber tint pairs
+ * visually with the developer-mode banner so admins can quickly scan which
+ * rows are unpublished edits.
+ */
+export function DraftBadge({ className }: { className?: string }) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "border-amber-300 bg-amber-50 px-1.5 py-0 text-[10px] font-medium text-amber-700 dark:border-amber-700 dark:bg-amber-950/30 dark:text-amber-400",
+        className,
+      )}
+      aria-label="Draft — not yet published"
+      title="Draft — not yet published"
+    >
+      Draft
+    </Badge>
+  );
+}

--- a/packages/web/src/ui/components/admin/semantic-file-tree.tsx
+++ b/packages/web/src/ui/components/admin/semantic-file-tree.tsx
@@ -20,6 +20,12 @@ interface SemanticFileTreeProps {
   hasGlossary: boolean;
   selection: SemanticSelection;
   onSelect: (selection: SemanticSelection) => void;
+  /**
+   * Names of entities with `status === 'draft'`. Rendered with a quiet
+   * amber accent so admins scanning the tree can spot unpublished edits
+   * without the treatment shouting at non-draft rows (#1435).
+   */
+  draftEntityNames?: ReadonlySet<string>;
   className?: string;
 }
 
@@ -36,11 +42,14 @@ function FileItem({
   selected,
   onClick,
   indent = 0,
+  draft = false,
 }: {
   name: string;
   selected: boolean;
   onClick: () => void;
   indent?: number;
+  /** Quiet amber accent to signal "this is a draft" without shouting. */
+  draft?: boolean;
 }) {
   return (
     <button
@@ -48,8 +57,13 @@ function FileItem({
       className={cn(
         "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
         selected ? "bg-accent text-accent-foreground" : "hover:bg-muted text-muted-foreground hover:text-foreground",
+        // A 2px amber left border reads as "marked" in peripheral vision but
+        // doesn't change the row's baseline color/contrast — important since
+        // published entities dominate the list visually.
+        draft && "border-l-2 border-amber-400/60",
       )}
       style={{ paddingLeft: `${8 + indent * 16}px` }}
+      aria-label={draft ? `${name} (draft)` : undefined}
     >
       <File className="size-4 shrink-0 opacity-60" />
       <span className="truncate">{name}</span>
@@ -94,6 +108,7 @@ export function SemanticFileTree({
   hasGlossary,
   selection,
   onSelect,
+  draftEntityNames,
   className,
 }: SemanticFileTreeProps) {
   return (
@@ -134,6 +149,7 @@ export function SemanticFileTree({
                   selected={isSelected(selection, { type: "entity", name })}
                   onClick={() => onSelect({ type: "entity", name })}
                   indent={1}
+                  draft={draftEntityNames?.has(name) ?? false}
                 />
               ))
             )}

--- a/packages/web/src/ui/components/demo-indicator-chip.tsx
+++ b/packages/web/src/ui/components/demo-indicator-chip.tsx
@@ -3,19 +3,7 @@
 import { Badge } from "@/components/ui/badge";
 import { useMode } from "@/ui/hooks/use-mode";
 import { useModeStatus } from "@/ui/hooks/use-mode-status";
-
-/**
- * Display labels keyed by the `demo_industry` setting written during
- * onboarding (see `DEMO_INDUSTRIES` in `packages/api/src/api/routes/onboarding.ts:48`).
- *
- * Fail-closed: a new industry without an entry here renders nothing rather
- * than showing a raw slug to users.
- */
-const DEMO_INDUSTRY_LABELS: Record<string, string> = {
-  saas: "SaaS CRM",
-  cybersecurity: "Sentinel Security",
-  ecommerce: "NovaMart",
-};
+import { demoIndustryLabel } from "@/ui/hooks/use-demo-readonly";
 
 /**
  * Subtle indicator shown to non-admin users when the org's workspace is
@@ -27,7 +15,7 @@ const DEMO_INDUSTRY_LABELS: Record<string, string> = {
  * - The user is an admin (they have the developer banner)
  * - The org has no active `__demo__` connection
  * - The org never selected a demo industry (null slug)
- * - The industry slug isn't in `DEMO_INDUSTRY_LABELS` (fail-closed)
+ * - The industry slug isn't recognized by `demoIndustryLabel` (fail-closed)
  */
 export function DemoIndicatorChip() {
   const { isAdmin, isLoading: modeLoading } = useMode();
@@ -37,10 +25,7 @@ export function DemoIndicatorChip() {
   if (isAdmin) return null;
   if (!data?.demoConnectionActive) return null;
 
-  const industry = data.demoIndustry;
-  if (!industry) return null;
-
-  const label = DEMO_INDUSTRY_LABELS[industry];
+  const label = demoIndustryLabel(data.demoIndustry);
   if (!label) return null;
 
   return (

--- a/packages/web/src/ui/components/mode-banner.tsx
+++ b/packages/web/src/ui/components/mode-banner.tsx
@@ -3,11 +3,14 @@
 import { useMode } from "@/ui/hooks/use-mode";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { PendingChangesSummary } from "@/ui/components/pending-changes-summary";
 import { Code, ArrowRight } from "lucide-react";
 
 /**
  * Stripe-style amber banner shown at the very top of every page when an admin
- * is in developer mode. Provides a one-click switch back to published mode.
+ * is in developer mode. Provides a one-click switch back to published mode
+ * and — when drafts exist — a pending-changes summary sourced from the
+ * `/api/v1/mode` endpoint (#1435).
  *
  * Renders nothing when the session is loading, the user is not an admin, or
  * the current mode is `published`.
@@ -22,7 +25,7 @@ export function ModeBanner() {
       role="status"
       className="flex h-8 shrink-0 items-center justify-between bg-amber-500/90 px-4 text-amber-950 dark:bg-amber-500/80 dark:text-amber-950"
     >
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 min-w-0">
         <Code className="size-3.5 shrink-0" />
         <Badge
           variant="outline"
@@ -33,6 +36,10 @@ export function ModeBanner() {
         <span className="hidden text-xs font-medium sm:inline">
           Unpublished changes are visible
         </span>
+        <span className="hidden text-amber-950/50 md:inline" aria-hidden>
+          &middot;
+        </span>
+        <PendingChangesSummary className="truncate" />
       </div>
       <Button
         variant="ghost"

--- a/packages/web/src/ui/components/pending-changes-summary.tsx
+++ b/packages/web/src/ui/components/pending-changes-summary.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useModeStatus } from "@/ui/hooks/use-mode-status";
+import { cn } from "@/lib/utils";
+import type { ModeDraftCounts } from "@useatlas/types/mode";
+
+/**
+ * Compact pending-changes chip rendered inside the developer-mode banner.
+ *
+ * Shows the number of drafts split by resource type (connections, entities,
+ * prompts) so admins can see at a glance what's in flight. The underlying
+ * counts come from `GET /api/v1/mode` which unions five `COUNT(*)` queries
+ * over indexed `(org_id, status)` pairs — cheap enough to poll on every
+ * focus via TanStack Query.
+ *
+ * Renders nothing when there are no drafts so the banner stays visually
+ * quiet in the common "admin just toggled developer mode" case.
+ */
+export function PendingChangesSummary({ className }: { className?: string }) {
+  const { data, loading } = useModeStatus();
+
+  if (loading) return null;
+  const counts = data?.draftCounts;
+  if (!counts) return null;
+
+  const segments = formatDraftSegments(counts);
+  if (segments.length === 0) return null;
+
+  const label = segments.join(" \u00b7 ");
+  const total = totalDrafts(counts);
+  const plural = total === 1 ? "change" : "changes";
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 text-xs font-medium text-amber-950/80",
+        className,
+      )}
+      aria-label={`${total} pending ${plural}: ${label}`}
+      title={`${total} pending ${plural}: ${label}`}
+    >
+      <span className="hidden sm:inline">{label}</span>
+      <span className="sm:hidden">
+        {total} pending
+      </span>
+    </span>
+  );
+}
+
+/**
+ * Build the display segments for a draft counts object, skipping zero
+ * counts. Exposed for tests so we can assert ordering and singular/plural
+ * without rendering React.
+ *
+ * Ordering (connections → entities → prompts) matches the user's mental
+ * model of the publish dependency chain: connections define data sources,
+ * entities expose them, prompts reference them. `entityEdits` and
+ * `entityDeletes` fold into `entities` so the chip stays compact — the full
+ * breakdown lives in the future Publish modal.
+ */
+export function formatDraftSegments(counts: ModeDraftCounts): string[] {
+  const segments: string[] = [];
+  const entityTotal = counts.entities + counts.entityEdits + counts.entityDeletes;
+
+  if (counts.connections > 0) {
+    segments.push(pluralize(counts.connections, "connection", "connections"));
+  }
+  if (entityTotal > 0) {
+    segments.push(pluralize(entityTotal, "entity", "entities"));
+  }
+  if (counts.prompts > 0) {
+    segments.push(pluralize(counts.prompts, "prompt", "prompts"));
+  }
+  return segments;
+}
+
+function pluralize(count: number, singular: string, plural: string): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function totalDrafts(counts: ModeDraftCounts): number {
+  return (
+    counts.connections +
+    counts.entities +
+    counts.entityEdits +
+    counts.entityDeletes +
+    counts.prompts
+  );
+}

--- a/packages/web/src/ui/hooks/use-demo-readonly.ts
+++ b/packages/web/src/ui/hooks/use-demo-readonly.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import { useMode } from "@/ui/hooks/use-mode";
+import { useModeStatus } from "@/ui/hooks/use-mode-status";
+
+/**
+ * Resolves whether demo-seeded admin surfaces should be read-only.
+ *
+ * Read-only conditions (#1435):
+ * - Resolved mode is `published`
+ * - Org has an active `__demo__` connection (`demoConnectionActive`)
+ *
+ * Callers use `readOnly` to disable add/edit/delete buttons on demo content
+ * and `demoIndustry` to render dataset-aware subtitles (e.g. "Sentinel
+ * Security — 62 entities"). While status is still loading, `readOnly` is
+ * false so admin surfaces don't flash disabled on initial paint.
+ *
+ * The hook intentionally does not infer per-row demo-ness — callers check
+ * whether a specific row is demo content (e.g. `id === "__demo__"`,
+ * `isBuiltin === true`) and combine with `readOnly`.
+ */
+export function useDemoReadonly(): {
+  readOnly: boolean;
+  demoIndustry: string | null;
+  demoConnectionActive: boolean;
+  loading: boolean;
+} {
+  const { mode, isLoading: modeLoading } = useMode();
+  const { data, loading } = useModeStatus();
+
+  const demoConnectionActive = data?.demoConnectionActive ?? false;
+  const demoIndustry = data?.demoIndustry ?? null;
+  // Fail-open on first paint so the UI doesn't flash disabled before status
+  // resolves. Once `loading` flips to false, the real value takes over.
+  const readOnly =
+    !modeLoading && !loading && mode === "published" && demoConnectionActive;
+
+  return {
+    readOnly,
+    demoIndustry,
+    demoConnectionActive,
+    loading: modeLoading || loading,
+  };
+}
+
+/**
+ * Display labels for demo datasets, matching the onboarding industry slugs
+ * written during workspace setup. Kept in sync with `DemoIndicatorChip`.
+ *
+ * Export a function rather than the map so callers get fail-closed behavior
+ * (unknown slug → null) without leaking raw slugs to users.
+ */
+const DEMO_INDUSTRY_LABELS: Record<string, string> = {
+  saas: "SaaS CRM",
+  cybersec: "Sentinel Security",
+  cybersecurity: "Sentinel Security",
+  ecommerce: "NovaMart",
+};
+
+/**
+ * Display label for a demo industry slug, or null if unknown. Used for
+ * dataset-aware subtitles (semantic editor) and indicator chips. The mapping
+ * supports both the new `cybersec` slug and the legacy `cybersecurity` one
+ * so orgs that onboarded before the rename still render correctly.
+ */
+export function demoIndustryLabel(industry: string | null | undefined): string | null {
+  if (!industry) return null;
+  return DEMO_INDUSTRY_LABELS[industry] ?? null;
+}


### PR DESCRIPTION
## Summary

- **Badges**: new `DemoBadge`/`DraftBadge` shadcn primitives (neutral zinc vs amber) wired into connections list, prompt library, and the semantic file tree.
- **Read-only in published mode**: connection add/edit/delete and semantic add/edit/delete disabled with tooltips when `mode === published` and the org has an active `__demo__` connection. Centralized behind a `useDemoReadonly()` hook.
- **Semantic subtitle**: when viewing demo data in published mode the subtitle becomes `"Sentinel Security — 62 entities"` (via `demoIndustryLabel()` — fail-closed on unknown slugs).
- **Draft accents**: quiet amber left-border on draft entities in the semantic file tree, sourced from `/admin/semantic/org/entities?type=entity`.
- **Pending-changes summary**: mode banner now shows `"1 connection · 4 entities · 2 prompts"` when drafts exist, pulled from `GET /api/v1/mode` `draftCounts` (no new endpoint needed — the field already existed from #1439).

## Files

- `packages/web/src/ui/components/admin/mode-badges.tsx` — new
- `packages/web/src/ui/components/pending-changes-summary.tsx` — new
- `packages/web/src/ui/hooks/use-demo-readonly.ts` — new
- `packages/web/src/ui/components/mode-banner.tsx` — adds the pending-changes chip
- `packages/web/src/app/admin/connections/{page,columns}.tsx` — badges, readonly gating
- `packages/web/src/app/admin/prompts/columns.tsx` — Demo/Draft badges on collections
- `packages/web/src/app/admin/semantic/page.tsx` — subtitle, readonly gating, draft fetch
- `packages/web/src/ui/components/admin/semantic-file-tree.tsx` — `draftEntityNames` prop with amber accent

## Acceptance criteria

- [x] `Demo` badge renders on `__demo__` connections
- [x] `Draft` badge renders on draft connections, entities, and prompt collections
- [x] Published mode with demo data: connections + semantic editor are read-only with tooltips
- [x] Semantic editor shows `"<Dataset> — N entities"` subtitle when viewing demo data in published mode
- [x] Pending-changes summary visible in the developer-mode banner (format: `"N resources · N resources · ..."`)
- [x] All badges use the existing shadcn/ui `Badge` primitive; tooltips use shadcn `Tooltip`
- [x] Mode-dependent rendering reads from `useMode()` / `useModeStatus()`

## Test plan

- [x] `bun run lint`
- [x] `bun run type`
- [x] `bun run test` (all 51 web tests pass + full monorepo suite)
- [x] `bun x syncpack lint`
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh`
- [x] New unit tests (6 files, ~30 cases):
  - `mode-badges.test.tsx` — badge text, aria, amber tint
  - `pending-changes-summary.test.tsx` — segment formatting, pluralization, hide-when-zero
  - `use-demo-readonly.test.tsx` — readonly gating matrix, fail-open during load, industry-label map
  - `connection-columns.test.tsx` — Demo/Draft badge rendering per row state
  - `prompt-columns.test.tsx` — Demo (isBuiltin) + Draft badge rendering
  - `semantic-file-tree-drafts.test.tsx` — amber accent on draft entity rows

## Follow-ups

- Docs for mode-aware admin surfaces can be added in the next docs pass — the auto-generated `/api/v1/mode` reference already covers `draftCounts`.
- When the atomic publish PR (#1429) lands, the pending-changes chip becomes clickable to open the Publish modal.

Closes #1435