### PR TITLE
feat(mode): prompt library mode scoping (#1438)

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -1180,7 +1180,7 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
 ### Agent & Data
 - [x] Agent isolation — mode-aware connection + whitelist in tool execution (#1430, PR #1460)
 - [x] Semantic diff scoping — filter `getDBSchema` to whitelist (#1431, PR #1462)
-- [ ] Prompt library mode scoping — demo industry filtering + draft visibility (#1438)
+- [x] Prompt library mode scoping — demo industry filtering + draft visibility (#1438)
 - [x] `GET /api/v1/mode` endpoint (#1439, PR #1453)
 
 ### Frontend

--- a/apps/docs/content/docs/guides/admin-console.mdx
+++ b/apps/docs/content/docs/guides/admin-console.mdx
@@ -380,7 +380,7 @@ Atlas seeds three built-in collections on first boot:
 - **E-commerce KPIs** — GMV, AOV, conversion rates, inventory, and fulfillment metrics
 - **Cybersecurity Compliance** — vulnerability tracking, incident response, and compliance scores
 
-Built-in collections are read-only and visible to all users.
+Built-in collections are read-only. They surface in the prompt library only while the org's `__demo__` connection is active and only for the org's demo industry — after the admin archives the demo during publish, the built-ins hide automatically. See [Developer / Published Mode](/guides/developer-mode#prompt-library-scoping) for the full scoping rules.
 
 ### Custom Collections
 

--- a/apps/docs/content/docs/guides/developer-mode.mdx
+++ b/apps/docs/content/docs/guides/developer-mode.mdx
@@ -112,6 +112,18 @@ Publishing clears every draft for the org. The admin's next edit — a new entit
 
 ---
 
+## Prompt Library Scoping
+
+The prompt library (`GET /api/v1/prompts` and `GET /api/v1/admin/prompts`) filters its response based on the effective mode and the org's demo state:
+
+- **Published mode + active `__demo__` connection**: returns built-in collections matching the org's `demo_industry` setting plus any custom published collections.
+- **Published mode, demo archived**: returns only custom published collections — all built-ins are hidden regardless of industry.
+- **Developer mode**: same `(industry, custom)` split as published, but the status filter expands to include `draft` rows so admins see in-progress collections too.
+
+The frontend just renders what the API returns — there is no client-side demo-state branching to maintain.
+
+---
+
 ## Related
 
 - [Admin Console overview](/guides/admin-console)

--- a/packages/api/src/api/__tests__/prompts.test.ts
+++ b/packages/api/src/api/__tests__/prompts.test.ts
@@ -29,6 +29,24 @@ const mocks = createApiTestMocks({
   },
 });
 
+// Controls `getSettingAuto("ATLAS_DEMO_INDUSTRY")` per test — set in beforeEach
+// and mutated by individual it() blocks that exercise mode-aware demo scoping.
+let demoIndustryFixture: string | undefined;
+mock.module("@atlas/api/lib/settings", () => ({
+  getSettingsForAdmin: () => [],
+  getSettingsRegistry: () => [],
+  getSettingDefinition: () => undefined,
+  setSetting: async () => {},
+  deleteSetting: async () => {},
+  getSetting: () => undefined,
+  getSettingAuto: (key: string) =>
+    key === "ATLAS_DEMO_INDUSTRY" ? demoIndustryFixture : undefined,
+  getSettingLive: async () => undefined,
+  loadSettings: async () => 0,
+  getAllSettingOverrides: async () => [],
+  _resetSettingsCache: () => {},
+}));
+
 // --- Import the app AFTER mocks ---
 
 const { app } = await import("../index");
@@ -113,7 +131,19 @@ beforeEach(() => {
   mockGetInternalDB.mockImplementation(() => ({
     query: mock(async () => ({ rows: [] })),
   }));
+  demoIndustryFixture = undefined;
 });
+
+// Drive `resolvePromptDemoContext`: returns true when the mocked query asks
+// whether `__demo__` exists for this org. Other queries resolve to `[]`.
+function mockDemoActive(active: boolean): void {
+  mocks.mockInternalQuery.mockImplementation((sql: string) => {
+    if (sql.includes("FROM connections") && sql.includes("__demo__")) {
+      return Promise.resolve([{ active }]);
+    }
+    return Promise.resolve([]);
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -205,8 +235,88 @@ describe("user-facing prompt routes", () => {
       expect(res.status).toBe(200);
       const calls = mocks.mockInternalQuery.mock.calls;
       expect(calls.length).toBeGreaterThanOrEqual(1);
-      const sql = calls[0][0] as string;
-      expect(sql).toContain("org_id IS NULL");
+      const listCall = calls.find(
+        ([sql]) => typeof sql === "string" && sql.includes("FROM prompt_collections"),
+      );
+      expect(listCall).toBeDefined();
+      expect(listCall![0] as string).toContain("org_id IS NULL");
+    });
+
+    // ─── Mode-aware demo scoping (#1438) ────────────────────────────
+
+    describe("mode + demo scoping (#1438)", () => {
+      function findListCall() {
+        return mocks.mockInternalQuery.mock.calls.find(
+          ([sql]) =>
+            typeof sql === "string" &&
+            sql.includes("FROM prompt_collections") &&
+            !sql.includes("EXISTS"),
+        );
+      }
+
+      it("published + demo active + industry: returns industry built-ins + custom", async () => {
+        demoIndustryFixture = "cybersecurity";
+        mockDemoActive(true);
+        const res = await userReq("GET", "/");
+        expect(res.status).toBe(200);
+
+        const listCall = findListCall();
+        expect(listCall).toBeDefined();
+        const sql = listCall![0] as string;
+        expect(sql).toContain("status = 'published'");
+        expect(sql).toContain("is_builtin = true AND industry = $2");
+        expect(sql).toContain("is_builtin = false AND org_id = $1");
+        expect(listCall![1]).toEqual(["org-1", "cybersecurity"]);
+      });
+
+      it("published + demo archived: hides all built-ins, returns only custom", async () => {
+        demoIndustryFixture = "cybersecurity";
+        mockDemoActive(false);
+        const res = await userReq("GET", "/");
+        expect(res.status).toBe(200);
+
+        const listCall = findListCall();
+        expect(listCall).toBeDefined();
+        const sql = listCall![0] as string;
+        expect(sql).toContain("is_builtin = false");
+        expect(sql).not.toContain("industry =");
+        expect(sql).not.toContain("org_id IS NULL OR");
+        expect(listCall![1]).toEqual(["org-1"]);
+      });
+
+      it("published + no demo industry set: hides all built-ins", async () => {
+        demoIndustryFixture = undefined;
+        mockDemoActive(false);
+        const res = await userReq("GET", "/");
+        expect(res.status).toBe(200);
+        const sql = findListCall()![0] as string;
+        expect(sql).toContain("is_builtin = false");
+        expect(sql).not.toContain("industry =");
+      });
+
+      it("developer + demo active: expands status + keeps industry filter", async () => {
+        demoIndustryFixture = "cybersecurity";
+        mockDemoActive(true);
+        const res = await userReq("GET", "/", undefined, "atlas-mode=developer");
+        expect(res.status).toBe(200);
+
+        const sql = findListCall()![0] as string;
+        expect(sql).toContain("status IN ('published', 'draft')");
+        expect(sql).not.toContain("archived");
+        expect(sql).toContain("is_builtin = true AND industry = $2");
+      });
+
+      it("developer + no demo: draft custom collections only (built-ins hidden)", async () => {
+        demoIndustryFixture = undefined;
+        mockDemoActive(false);
+        const res = await userReq("GET", "/", undefined, "atlas-mode=developer");
+        expect(res.status).toBe(200);
+
+        const sql = findListCall()![0] as string;
+        expect(sql).toContain("status IN ('published', 'draft')");
+        expect(sql).toContain("is_builtin = false");
+        expect(sql).not.toContain("industry =");
+      });
     });
   });
 
@@ -333,6 +443,55 @@ describe("admin prompt routes", () => {
       expect(listCall).toBeDefined();
       expect(listCall![0] as string).toContain("status IN ('published', 'draft')");
       expect(listCall![0] as string).not.toContain("archived");
+    });
+
+    // ─── Mode-aware demo scoping for admin list (#1438) ─────────────
+
+    describe("mode + demo scoping (#1438)", () => {
+      function findListCall() {
+        return mocks.mockInternalQuery.mock.calls.find(
+          ([sql]) =>
+            typeof sql === "string" &&
+            sql.includes("FROM prompt_collections") &&
+            !sql.includes("EXISTS"),
+        );
+      }
+
+      it("published + demo active + industry: built-ins scoped to industry + custom", async () => {
+        demoIndustryFixture = "cybersecurity";
+        mockDemoActive(true);
+        const res = await adminReq("GET", "/");
+        expect(res.status).toBe(200);
+
+        const listCall = findListCall();
+        expect(listCall).toBeDefined();
+        const sql = listCall![0] as string;
+        expect(sql).toContain("is_builtin = true AND industry = $2");
+        expect(sql).toContain("is_builtin = false AND org_id = $1");
+        expect(listCall![1]).toEqual(["org-1", "cybersecurity"]);
+      });
+
+      it("published + demo archived: only custom published", async () => {
+        demoIndustryFixture = "cybersecurity";
+        mockDemoActive(false);
+        const res = await adminReq("GET", "/");
+        expect(res.status).toBe(200);
+
+        const sql = findListCall()![0] as string;
+        expect(sql).toContain("is_builtin = false");
+        expect(sql).not.toContain("industry =");
+      });
+
+      it("developer + demo active: status IN + industry filter + custom drafts", async () => {
+        demoIndustryFixture = "cybersecurity";
+        mockDemoActive(true);
+        const res = await adminReq("GET", "/", undefined, "atlas-mode=developer");
+        expect(res.status).toBe(200);
+
+        const sql = findListCall()![0] as string;
+        expect(sql).toContain("status IN ('published', 'draft')");
+        expect(sql).toContain("is_builtin = true AND industry = $2");
+      });
     });
   });
 

--- a/packages/api/src/api/routes/admin-prompts.ts
+++ b/packages/api/src/api/routes/admin-prompts.ts
@@ -17,7 +17,7 @@ import { ErrorSchema, AuthErrorSchema, createIdParamSchema, createParamSchema, c
 import { createAdminRouter, requireOrgContext } from "./admin-router";
 import {
   buildCollectionsListQuery,
-  resolvePromptDemoContext,
+  resolvePromptScope,
 } from "@atlas/api/lib/prompts/scoping";
 
 const log = createLogger("admin-prompts");
@@ -490,20 +490,17 @@ adminPrompts.openapi(listCollectionsRoute, async (c) => {
     const { orgId } = yield* AuthContext;
     const { atlasMode } = yield* RequestContext;
 
-    // requireOrgContext upstream guarantees orgId is set here. resolvePromptDemoContext
-    // still handles `undefined` defensively so typing stays permissive.
-    const { demoIndustry, demoConnectionActive } = yield* Effect.promise(() =>
-      resolvePromptDemoContext(orgId),
-    );
-    const { sql, params } = buildCollectionsListQuery({
-      orgId,
-      mode: atlasMode,
-      demoIndustry,
-      demoConnectionActive,
+    // requireOrgContext upstream guarantees orgId is set; resolvePromptScope
+    // falls back to the `global` variant defensively if it is not.
+    const scope = yield* Effect.tryPromise({
+      try: () => resolvePromptScope({ orgId, mode: atlasMode }),
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
     });
-    const rows = yield* Effect.promise(() =>
-      internalQuery<Record<string, unknown>>(sql, params),
-    );
+    const { sql, params } = buildCollectionsListQuery(scope);
+    const rows = yield* Effect.tryPromise({
+      try: () => internalQuery<Record<string, unknown>>(sql, params),
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    });
     return c.json({ collections: rows.map(toPromptCollection), total: rows.length }, 200);
   }), { label: "list prompt collections" });
 });

--- a/packages/api/src/api/routes/admin-prompts.ts
+++ b/packages/api/src/api/routes/admin-prompts.ts
@@ -15,7 +15,10 @@ import { internalQuery } from "@atlas/api/lib/db/internal";
 import type { PromptCollection, PromptItem } from "@useatlas/types";
 import { ErrorSchema, AuthErrorSchema, createIdParamSchema, createParamSchema, createListResponseSchema, DeletedResponseSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
-import { buildUnionStatusClause } from "./middleware";
+import {
+  buildCollectionsListQuery,
+  resolvePromptDemoContext,
+} from "@atlas/api/lib/prompts/scoping";
 
 const log = createLogger("admin-prompts");
 
@@ -487,14 +490,20 @@ adminPrompts.openapi(listCollectionsRoute, async (c) => {
     const { orgId } = yield* AuthContext;
     const { atlasMode } = yield* RequestContext;
 
-    const statusClause = buildUnionStatusClause(atlasMode);
-
-    let rows: Record<string, unknown>[];
-    if (orgId) {
-      rows = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(`SELECT * FROM prompt_collections WHERE (org_id IS NULL OR org_id = $1)${statusClause} ORDER BY sort_order ASC, created_at ASC`, [orgId]));
-    } else {
-      rows = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(`SELECT * FROM prompt_collections WHERE 1=1${statusClause} ORDER BY sort_order ASC, created_at ASC`));
-    }
+    // requireOrgContext upstream guarantees orgId is set here. resolvePromptDemoContext
+    // still handles `undefined` defensively so typing stays permissive.
+    const { demoIndustry, demoConnectionActive } = yield* Effect.promise(() =>
+      resolvePromptDemoContext(orgId),
+    );
+    const { sql, params } = buildCollectionsListQuery({
+      orgId,
+      mode: atlasMode,
+      demoIndustry,
+      demoConnectionActive,
+    });
+    const rows = yield* Effect.promise(() =>
+      internalQuery<Record<string, unknown>>(sql, params),
+    );
     return c.json({ collections: rows.map(toPromptCollection), total: rows.length }, 200);
   }), { label: "list prompt collections" });
 });

--- a/packages/api/src/api/routes/prompts.ts
+++ b/packages/api/src/api/routes/prompts.ts
@@ -23,7 +23,7 @@ import { standardAuth, requestContext, type AuthEnv } from "./middleware";
 import {
   buildCollectionsListQuery,
   buildCollectionGetQuery,
-  resolvePromptDemoContext,
+  resolvePromptScope,
 } from "@atlas/api/lib/prompts/scoping";
 
 // ---------------------------------------------------------------------------
@@ -178,18 +178,15 @@ prompts.openapi(listCollectionsRoute, async (c) => {
       return c.json({ collections: [] }, 200);
     }
 
-    const { demoIndustry, demoConnectionActive } = yield* Effect.promise(() =>
-      resolvePromptDemoContext(orgId),
-    );
-    const { sql, params } = buildCollectionsListQuery({
-      orgId,
-      mode: atlasMode,
-      demoIndustry,
-      demoConnectionActive,
+    const scope = yield* Effect.tryPromise({
+      try: () => resolvePromptScope({ orgId, mode: atlasMode }),
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
     });
-    const rows = yield* Effect.promise(() =>
-      internalQuery<Record<string, unknown>>(sql, params),
-    );
+    const { sql, params } = buildCollectionsListQuery(scope);
+    const rows = yield* Effect.tryPromise({
+      try: () => internalQuery<Record<string, unknown>>(sql, params),
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    });
 
     return c.json({ collections: rows.map(toPromptCollection) }, 200);
   }), { label: "list prompt collections" });
@@ -210,25 +207,27 @@ prompts.openapi(getCollectionRoute, async (c) => {
 
     const { id } = c.req.valid("param");
 
-    const { demoIndustry, demoConnectionActive } = yield* Effect.promise(() =>
-      resolvePromptDemoContext(orgId),
-    );
-    const { sql, params } = buildCollectionGetQuery(
-      { orgId, mode: atlasMode, demoIndustry, demoConnectionActive },
-      id,
-    );
-    const collectionRows = yield* Effect.promise(() =>
-      internalQuery<Record<string, unknown>>(sql, params),
-    );
+    const scope = yield* Effect.tryPromise({
+      try: () => resolvePromptScope({ orgId, mode: atlasMode }),
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    });
+    const { sql, params } = buildCollectionGetQuery(scope, id);
+    const collectionRows = yield* Effect.tryPromise({
+      try: () => internalQuery<Record<string, unknown>>(sql, params),
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    });
 
     if (collectionRows.length === 0) {
       return c.json({ error: "not_found", message: "Prompt collection not found." }, 404);
     }
 
-    const items = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(
-      `SELECT * FROM prompt_items WHERE collection_id = $1 ORDER BY sort_order ASC, created_at ASC`,
-      [id],
-    ));
+    const items = yield* Effect.tryPromise({
+      try: () => internalQuery<Record<string, unknown>>(
+        `SELECT * FROM prompt_items WHERE collection_id = $1 ORDER BY sort_order ASC, created_at ASC`,
+        [id],
+      ),
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    });
 
     return c.json({
       collection: toPromptCollection(collectionRows[0]),

--- a/packages/api/src/api/routes/prompts.ts
+++ b/packages/api/src/api/routes/prompts.ts
@@ -19,7 +19,12 @@ import type { PromptCollection, PromptItem } from "@useatlas/types";
 
 const log = createLogger("prompts");
 import { ErrorSchema } from "./shared-schemas";
-import { standardAuth, requestContext, buildUnionStatusClause, type AuthEnv } from "./middleware";
+import { standardAuth, requestContext, type AuthEnv } from "./middleware";
+import {
+  buildCollectionsListQuery,
+  buildCollectionGetQuery,
+  resolvePromptDemoContext,
+} from "@atlas/api/lib/prompts/scoping";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -173,19 +178,18 @@ prompts.openapi(listCollectionsRoute, async (c) => {
       return c.json({ collections: [] }, 200);
     }
 
-    const statusClause = buildUnionStatusClause(atlasMode);
-
-    let rows: Record<string, unknown>[];
-    if (orgId) {
-      rows = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(
-        `SELECT * FROM prompt_collections WHERE (org_id IS NULL OR org_id = $1)${statusClause} ORDER BY sort_order ASC, created_at ASC`,
-        [orgId],
-      ));
-    } else {
-      rows = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(
-        `SELECT * FROM prompt_collections WHERE org_id IS NULL${statusClause} ORDER BY sort_order ASC, created_at ASC`,
-      ));
-    }
+    const { demoIndustry, demoConnectionActive } = yield* Effect.promise(() =>
+      resolvePromptDemoContext(orgId),
+    );
+    const { sql, params } = buildCollectionsListQuery({
+      orgId,
+      mode: atlasMode,
+      demoIndustry,
+      demoConnectionActive,
+    });
+    const rows = yield* Effect.promise(() =>
+      internalQuery<Record<string, unknown>>(sql, params),
+    );
 
     return c.json({ collections: rows.map(toPromptCollection) }, 200);
   }), { label: "list prompt collections" });
@@ -205,20 +209,17 @@ prompts.openapi(getCollectionRoute, async (c) => {
     }
 
     const { id } = c.req.valid("param");
-    const statusClause = buildUnionStatusClause(atlasMode);
 
-    let collectionRows: Record<string, unknown>[];
-    if (orgId) {
-      collectionRows = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(
-        `SELECT * FROM prompt_collections WHERE id = $1 AND (org_id IS NULL OR org_id = $2)${statusClause}`,
-        [id, orgId],
-      ));
-    } else {
-      collectionRows = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(
-        `SELECT * FROM prompt_collections WHERE id = $1 AND org_id IS NULL${statusClause}`,
-        [id],
-      ));
-    }
+    const { demoIndustry, demoConnectionActive } = yield* Effect.promise(() =>
+      resolvePromptDemoContext(orgId),
+    );
+    const { sql, params } = buildCollectionGetQuery(
+      { orgId, mode: atlasMode, demoIndustry, demoConnectionActive },
+      id,
+    );
+    const collectionRows = yield* Effect.promise(() =>
+      internalQuery<Record<string, unknown>>(sql, params),
+    );
 
     if (collectionRows.length === 0) {
       return c.json({ error: "not_found", message: "Prompt collection not found." }, 404);

--- a/packages/api/src/lib/prompts/__tests__/scoping.test.ts
+++ b/packages/api/src/lib/prompts/__tests__/scoping.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for prompt collection scoping (#1438).
+ *
+ * Covers `buildCollectionsListQuery` and `buildCollectionGetQuery` under
+ * the (orgId × mode × demoIndustry × demoConnectionActive) matrix.
+ * No HTTP layer — pure query builder.
+ */
+import { describe, it, expect } from "bun:test";
+import {
+  buildCollectionsListQuery,
+  buildCollectionGetQuery,
+  type PromptScope,
+} from "../scoping";
+
+function scope(overrides: Partial<PromptScope> = {}): PromptScope {
+  return {
+    orgId: "org-1",
+    mode: "published",
+    demoIndustry: null,
+    demoConnectionActive: false,
+    ...overrides,
+  };
+}
+
+describe("buildCollectionsListQuery", () => {
+  it("published + demo active: matches industry built-ins + custom published", () => {
+    const q = buildCollectionsListQuery(
+      scope({ demoIndustry: "cybersecurity", demoConnectionActive: true }),
+    );
+    expect(q.sql).toContain("status = 'published'");
+    expect(q.sql).not.toContain("status IN");
+    expect(q.sql).toContain("is_builtin = true AND industry = $2");
+    expect(q.sql).toContain("(org_id IS NULL OR org_id = $1)");
+    expect(q.sql).toContain("is_builtin = false AND org_id = $1");
+    expect(q.params).toEqual(["org-1", "cybersecurity"]);
+  });
+
+  it("published + demo archived: only custom published, hides all built-ins", () => {
+    const q = buildCollectionsListQuery(
+      scope({ demoIndustry: "cybersecurity", demoConnectionActive: false }),
+    );
+    expect(q.sql).toContain("status = 'published'");
+    expect(q.sql).toContain("is_builtin = false");
+    expect(q.sql).not.toContain("industry =");
+    expect(q.sql).not.toContain("org_id IS NULL OR");
+    expect(q.params).toEqual(["org-1"]);
+  });
+
+  it("published + no demo industry even when connection active: hides all built-ins", () => {
+    // Edge case: __demo__ exists as published connection but industry unset.
+    // Without an industry filter we'd show every global builtin; safer to hide.
+    const q = buildCollectionsListQuery(
+      scope({ demoIndustry: null, demoConnectionActive: true }),
+    );
+    expect(q.sql).toContain("is_builtin = false");
+    expect(q.sql).not.toContain("industry =");
+    expect(q.params).toEqual(["org-1"]);
+  });
+
+  it("developer + demo active: status IN + industry + custom (incl. drafts)", () => {
+    const q = buildCollectionsListQuery(
+      scope({
+        mode: "developer",
+        demoIndustry: "cybersecurity",
+        demoConnectionActive: true,
+      }),
+    );
+    expect(q.sql).toContain("status IN ('published', 'draft')");
+    expect(q.sql).not.toContain("archived");
+    expect(q.sql).toContain("is_builtin = true AND industry = $2");
+    expect(q.sql).toContain("is_builtin = false AND org_id = $1");
+    expect(q.params).toEqual(["org-1", "cybersecurity"]);
+  });
+
+  it("developer + no demo: only custom (published + draft)", () => {
+    const q = buildCollectionsListQuery(
+      scope({ mode: "developer", demoConnectionActive: false }),
+    );
+    expect(q.sql).toContain("status IN ('published', 'draft')");
+    expect(q.sql).toContain("is_builtin = false");
+    expect(q.sql).not.toContain("industry =");
+    expect(q.params).toEqual(["org-1"]);
+  });
+
+  it("no orgId (single-tenant): global built-ins only, no industry/custom filter", () => {
+    const q = buildCollectionsListQuery(
+      scope({ orgId: undefined, demoIndustry: "cybersecurity", demoConnectionActive: true }),
+    );
+    expect(q.sql).toContain("org_id IS NULL");
+    expect(q.sql).toContain("status = 'published'");
+    expect(q.sql).not.toContain("industry =");
+    expect(q.sql).not.toContain("is_builtin = false");
+    expect(q.params).toEqual([]);
+  });
+
+  it("no orgId + developer: global built-ins, status IN", () => {
+    const q = buildCollectionsListQuery(
+      scope({ orgId: undefined, mode: "developer" }),
+    );
+    expect(q.sql).toContain("org_id IS NULL");
+    expect(q.sql).toContain("status IN ('published', 'draft')");
+    expect(q.params).toEqual([]);
+  });
+
+  it("mode defaults to published when undefined", () => {
+    const q = buildCollectionsListQuery(scope({ mode: undefined }));
+    expect(q.sql).toContain("status = 'published'");
+    expect(q.sql).not.toContain("status IN");
+  });
+
+  it("includes ORDER BY on list queries", () => {
+    const q = buildCollectionsListQuery(scope());
+    expect(q.sql).toContain("ORDER BY sort_order ASC, created_at ASC");
+  });
+});
+
+describe("buildCollectionGetQuery", () => {
+  it("appends id filter with next positional placeholder (demo active)", () => {
+    const q = buildCollectionGetQuery(
+      scope({ demoIndustry: "cybersecurity", demoConnectionActive: true }),
+      "col-1",
+    );
+    expect(q.sql).not.toContain("ORDER BY");
+    expect(q.sql).toContain("AND id = $3");
+    expect(q.params).toEqual(["org-1", "cybersecurity", "col-1"]);
+  });
+
+  it("appends id filter (custom-only branch)", () => {
+    const q = buildCollectionGetQuery(scope(), "col-2");
+    expect(q.sql).not.toContain("ORDER BY");
+    expect(q.sql).toContain("AND id = $2");
+    expect(q.params).toEqual(["org-1", "col-2"]);
+  });
+
+  it("appends id filter (no-orgId branch)", () => {
+    const q = buildCollectionGetQuery(scope({ orgId: undefined }), "col-3");
+    expect(q.sql).not.toContain("ORDER BY");
+    expect(q.sql).toContain("AND id = $1");
+    expect(q.params).toEqual(["col-3"]);
+  });
+});

--- a/packages/api/src/lib/prompts/__tests__/scoping.test.ts
+++ b/packages/api/src/lib/prompts/__tests__/scoping.test.ts
@@ -1,16 +1,38 @@
 /**
  * Unit tests for prompt collection scoping (#1438).
  *
- * Covers `buildCollectionsListQuery` and `buildCollectionGetQuery` under
- * the (orgId × mode × demoIndustry × demoConnectionActive) matrix.
- * No HTTP layer — pure query builder.
+ * Covers `buildCollectionsListQuery`, `buildCollectionGetQuery`, and
+ * `resolvePromptDemoContext` under the (orgId × mode × demoIndustry ×
+ * demoConnectionActive) matrix. No HTTP layer.
  */
-import { describe, it, expect } from "bun:test";
-import {
+import { describe, it, expect, mock } from "bun:test";
+
+// ── Module mocks (must run before importing scoping) ───────────────
+
+let hasInternalDBFixture = true;
+let demoIndustryFixture: string | undefined;
+const mockInternalQuery = mock(
+  async (_sql: string, _params?: unknown[]) => [] as unknown[],
+);
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => hasInternalDBFixture,
+  internalQuery: mockInternalQuery,
+}));
+
+mock.module("@atlas/api/lib/settings", () => ({
+  getSettingAuto: (key: string, _orgId?: string) =>
+    key === "ATLAS_DEMO_INDUSTRY" ? demoIndustryFixture : undefined,
+  getSetting: () => undefined,
+}));
+
+// Imports MUST come after mock.module calls.
+const {
   buildCollectionsListQuery,
   buildCollectionGetQuery,
-  type PromptScope,
-} from "../scoping";
+  resolvePromptDemoContext,
+} = await import("../scoping");
+import type { PromptScope } from "../scoping";
 
 function scope(overrides: Partial<PromptScope> = {}): PromptScope {
   return {
@@ -40,6 +62,7 @@ describe("buildCollectionsListQuery", () => {
       scope({ demoIndustry: "cybersecurity", demoConnectionActive: false }),
     );
     expect(q.sql).toContain("status = 'published'");
+    expect(q.sql).toContain("org_id = $1");
     expect(q.sql).toContain("is_builtin = false");
     expect(q.sql).not.toContain("industry =");
     expect(q.sql).not.toContain("org_id IS NULL OR");
@@ -52,6 +75,7 @@ describe("buildCollectionsListQuery", () => {
     const q = buildCollectionsListQuery(
       scope({ demoIndustry: null, demoConnectionActive: true }),
     );
+    expect(q.sql).toContain("org_id = $1");
     expect(q.sql).toContain("is_builtin = false");
     expect(q.sql).not.toContain("industry =");
     expect(q.params).toEqual(["org-1"]);
@@ -77,6 +101,7 @@ describe("buildCollectionsListQuery", () => {
       scope({ mode: "developer", demoConnectionActive: false }),
     );
     expect(q.sql).toContain("status IN ('published', 'draft')");
+    expect(q.sql).toContain("org_id = $1");
     expect(q.sql).toContain("is_builtin = false");
     expect(q.sql).not.toContain("industry =");
     expect(q.params).toEqual(["org-1"]);
@@ -137,5 +162,81 @@ describe("buildCollectionGetQuery", () => {
     expect(q.sql).not.toContain("ORDER BY");
     expect(q.sql).toContain("AND id = $1");
     expect(q.params).toEqual(["col-3"]);
+  });
+});
+
+describe("resolvePromptDemoContext", () => {
+  // Reset fixtures + call count before each scenario
+  function reset({
+    hasDB = true,
+    industry,
+  }: { hasDB?: boolean; industry?: string } = {}) {
+    hasInternalDBFixture = hasDB;
+    demoIndustryFixture = industry;
+    mockInternalQuery.mockClear();
+    mockInternalQuery.mockImplementation(async () => [] as unknown[]);
+  }
+
+  it("returns defaults and skips DB when orgId is undefined", async () => {
+    reset();
+    const result = await resolvePromptDemoContext(undefined);
+    expect(result).toEqual({ demoIndustry: null, demoConnectionActive: false });
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns defaults and skips DB when internal DB is unavailable", async () => {
+    reset({ hasDB: false, industry: "cybersecurity" });
+    const result = await resolvePromptDemoContext("org-1");
+    expect(result).toEqual({ demoIndustry: null, demoConnectionActive: false });
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns industry + active=true when demo exists as published connection", async () => {
+    reset({ industry: "cybersecurity" });
+    mockInternalQuery.mockImplementation(async () => [{ active: true }]);
+    const result = await resolvePromptDemoContext("org-1");
+    expect(result).toEqual({
+      demoIndustry: "cybersecurity",
+      demoConnectionActive: true,
+    });
+    const [sql, params] = mockInternalQuery.mock.calls[0]!;
+    expect(sql).toContain("__demo__");
+    expect(sql).toContain("status = 'published'");
+    expect(params).toEqual(["org-1"]);
+  });
+
+  it("returns industry + active=false when demo row reports inactive", async () => {
+    reset({ industry: "saas" });
+    mockInternalQuery.mockImplementation(async () => [{ active: false }]);
+    const result = await resolvePromptDemoContext("org-1");
+    expect(result.demoIndustry).toBe("saas");
+    expect(result.demoConnectionActive).toBe(false);
+  });
+
+  it("returns active=false when EXISTS query returns no rows", async () => {
+    reset({ industry: "saas" });
+    mockInternalQuery.mockImplementation(async () => [] as unknown[]);
+    const result = await resolvePromptDemoContext("org-1");
+    expect(result.demoConnectionActive).toBe(false);
+  });
+
+  it("normalizes a missing ATLAS_DEMO_INDUSTRY setting to null", async () => {
+    reset({ industry: undefined });
+    mockInternalQuery.mockImplementation(async () => [{ active: true }]);
+    const result = await resolvePromptDemoContext("org-1");
+    expect(result.demoIndustry).toBeNull();
+    expect(result.demoConnectionActive).toBe(true);
+  });
+
+  it("treats non-strict-true `active` values as inactive", async () => {
+    // Defense-in-depth: some drivers have returned "t" or 1 historically;
+    // strict equality keeps demoConnectionActive pinned to real booleans.
+    reset({ industry: "saas" });
+    mockInternalQuery.mockImplementation(async () =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- simulating loose driver output
+      [{ active: "t" as any }],
+    );
+    const result = await resolvePromptDemoContext("org-1");
+    expect(result.demoConnectionActive).toBe(false);
   });
 });

--- a/packages/api/src/lib/prompts/__tests__/scoping.test.ts
+++ b/packages/api/src/lib/prompts/__tests__/scoping.test.ts
@@ -1,9 +1,12 @@
 /**
- * Unit tests for prompt collection scoping (#1438).
+ * Unit tests for prompt collection scoping.
  *
  * Covers `buildCollectionsListQuery`, `buildCollectionGetQuery`, and
- * `resolvePromptDemoContext` under the (orgId × mode × demoIndustry ×
- * demoConnectionActive) matrix. No HTTP layer.
+ * `resolvePromptScope` under the (orgId × mode × demoIndustry ×
+ * demoConnectionActive) matrix expressed as the tagged scope union.
+ * No HTTP layer.
+ *
+ * See: #1438.
  */
 import { describe, it, expect, mock } from "bun:test";
 
@@ -30,25 +33,34 @@ mock.module("@atlas/api/lib/settings", () => ({
 const {
   buildCollectionsListQuery,
   buildCollectionGetQuery,
-  resolvePromptDemoContext,
+  resolvePromptScope,
 } = await import("../scoping");
 import type { PromptScope } from "../scoping";
+import type { AtlasMode } from "@useatlas/types/auth";
 
-function scope(overrides: Partial<PromptScope> = {}): PromptScope {
-  return {
-    orgId: "org-1",
-    mode: "published",
-    demoIndustry: null,
-    demoConnectionActive: false,
-    ...overrides,
-  };
+// Scope constructors — one per variant, so each test reads declaratively.
+function globalScope(mode: AtlasMode = "published"): PromptScope {
+  return { kind: "global", mode };
+}
+
+function customOnlyScope(
+  orgId = "org-1",
+  mode: AtlasMode = "published",
+): PromptScope {
+  return { kind: "org-custom-only", orgId, mode };
+}
+
+function withDemoScope(
+  orgId = "org-1",
+  demoIndustry = "cybersecurity",
+  mode: AtlasMode = "published",
+): PromptScope {
+  return { kind: "org-with-demo", orgId, mode, demoIndustry };
 }
 
 describe("buildCollectionsListQuery", () => {
-  it("published + demo active: matches industry built-ins + custom published", () => {
-    const q = buildCollectionsListQuery(
-      scope({ demoIndustry: "cybersecurity", demoConnectionActive: true }),
-    );
+  it("org-with-demo (published): industry-filtered built-ins + custom published", () => {
+    const q = buildCollectionsListQuery(withDemoScope());
     expect(q.sql).toContain("status = 'published'");
     expect(q.sql).not.toContain("status IN");
     expect(q.sql).toContain("is_builtin = true AND industry = $2");
@@ -57,10 +69,8 @@ describe("buildCollectionsListQuery", () => {
     expect(q.params).toEqual(["org-1", "cybersecurity"]);
   });
 
-  it("published + demo archived: only custom published, hides all built-ins", () => {
-    const q = buildCollectionsListQuery(
-      scope({ demoIndustry: "cybersecurity", demoConnectionActive: false }),
-    );
+  it("org-custom-only (published): hides all built-ins, only custom published", () => {
+    const q = buildCollectionsListQuery(customOnlyScope());
     expect(q.sql).toContain("status = 'published'");
     expect(q.sql).toContain("org_id = $1");
     expect(q.sql).toContain("is_builtin = false");
@@ -69,25 +79,9 @@ describe("buildCollectionsListQuery", () => {
     expect(q.params).toEqual(["org-1"]);
   });
 
-  it("published + no demo industry even when connection active: hides all built-ins", () => {
-    // Edge case: __demo__ exists as published connection but industry unset.
-    // Without an industry filter we'd show every global builtin; safer to hide.
+  it("org-with-demo (developer): status IN + industry + custom (incl. drafts)", () => {
     const q = buildCollectionsListQuery(
-      scope({ demoIndustry: null, demoConnectionActive: true }),
-    );
-    expect(q.sql).toContain("org_id = $1");
-    expect(q.sql).toContain("is_builtin = false");
-    expect(q.sql).not.toContain("industry =");
-    expect(q.params).toEqual(["org-1"]);
-  });
-
-  it("developer + demo active: status IN + industry + custom (incl. drafts)", () => {
-    const q = buildCollectionsListQuery(
-      scope({
-        mode: "developer",
-        demoIndustry: "cybersecurity",
-        demoConnectionActive: true,
-      }),
+      withDemoScope("org-1", "cybersecurity", "developer"),
     );
     expect(q.sql).toContain("status IN ('published', 'draft')");
     expect(q.sql).not.toContain("archived");
@@ -96,10 +90,8 @@ describe("buildCollectionsListQuery", () => {
     expect(q.params).toEqual(["org-1", "cybersecurity"]);
   });
 
-  it("developer + no demo: only custom (published + draft)", () => {
-    const q = buildCollectionsListQuery(
-      scope({ mode: "developer", demoConnectionActive: false }),
-    );
+  it("org-custom-only (developer): only custom (published + draft)", () => {
+    const q = buildCollectionsListQuery(customOnlyScope("org-1", "developer"));
     expect(q.sql).toContain("status IN ('published', 'draft')");
     expect(q.sql).toContain("org_id = $1");
     expect(q.sql).toContain("is_builtin = false");
@@ -107,10 +99,8 @@ describe("buildCollectionsListQuery", () => {
     expect(q.params).toEqual(["org-1"]);
   });
 
-  it("no orgId (single-tenant): global built-ins only, no industry/custom filter", () => {
-    const q = buildCollectionsListQuery(
-      scope({ orgId: undefined, demoIndustry: "cybersecurity", demoConnectionActive: true }),
-    );
+  it("global (published): global built-ins only, no industry/custom filter", () => {
+    const q = buildCollectionsListQuery(globalScope());
     expect(q.sql).toContain("org_id IS NULL");
     expect(q.sql).toContain("status = 'published'");
     expect(q.sql).not.toContain("industry =");
@@ -118,55 +108,52 @@ describe("buildCollectionsListQuery", () => {
     expect(q.params).toEqual([]);
   });
 
-  it("no orgId + developer: global built-ins, status IN", () => {
-    const q = buildCollectionsListQuery(
-      scope({ orgId: undefined, mode: "developer" }),
-    );
+  it("global (developer): global built-ins, status IN", () => {
+    const q = buildCollectionsListQuery(globalScope("developer"));
     expect(q.sql).toContain("org_id IS NULL");
     expect(q.sql).toContain("status IN ('published', 'draft')");
     expect(q.params).toEqual([]);
   });
 
-  it("mode defaults to published when undefined", () => {
-    const q = buildCollectionsListQuery(scope({ mode: undefined }));
-    expect(q.sql).toContain("status = 'published'");
-    expect(q.sql).not.toContain("status IN");
-  });
-
   it("includes ORDER BY on list queries", () => {
-    const q = buildCollectionsListQuery(scope());
+    const q = buildCollectionsListQuery(customOnlyScope());
     expect(q.sql).toContain("ORDER BY sort_order ASC, created_at ASC");
   });
 });
 
 describe("buildCollectionGetQuery", () => {
-  it("appends id filter with next positional placeholder (demo active)", () => {
-    const q = buildCollectionGetQuery(
-      scope({ demoIndustry: "cybersecurity", demoConnectionActive: true }),
-      "col-1",
-    );
+  it("org-with-demo: appends id as $3 after orgId + industry", () => {
+    const q = buildCollectionGetQuery(withDemoScope(), "col-1");
     expect(q.sql).not.toContain("ORDER BY");
     expect(q.sql).toContain("AND id = $3");
+    expect(q.sql).toContain("is_builtin = true AND industry = $2");
     expect(q.params).toEqual(["org-1", "cybersecurity", "col-1"]);
   });
 
-  it("appends id filter (custom-only branch)", () => {
-    const q = buildCollectionGetQuery(scope(), "col-2");
+  it("org-custom-only: appends id as $2 after orgId", () => {
+    const q = buildCollectionGetQuery(customOnlyScope(), "col-2");
     expect(q.sql).not.toContain("ORDER BY");
     expect(q.sql).toContain("AND id = $2");
+    expect(q.sql).toContain("org_id = $1");
+    expect(q.sql).toContain("is_builtin = false");
     expect(q.params).toEqual(["org-1", "col-2"]);
   });
 
-  it("appends id filter (no-orgId branch)", () => {
-    const q = buildCollectionGetQuery(scope({ orgId: undefined }), "col-3");
+  it("global: id as $1, no org filter", () => {
+    const q = buildCollectionGetQuery(globalScope(), "col-3");
     expect(q.sql).not.toContain("ORDER BY");
     expect(q.sql).toContain("AND id = $1");
+    expect(q.sql).toContain("org_id IS NULL");
     expect(q.params).toEqual(["col-3"]);
+  });
+
+  it("inherits developer status clause", () => {
+    const q = buildCollectionGetQuery(customOnlyScope("org-1", "developer"), "col-x");
+    expect(q.sql).toContain("status IN ('published', 'draft')");
   });
 });
 
-describe("resolvePromptDemoContext", () => {
-  // Reset fixtures + call count before each scenario
+describe("resolvePromptScope", () => {
   function reset({
     hasDB = true,
     industry,
@@ -177,66 +164,74 @@ describe("resolvePromptDemoContext", () => {
     mockInternalQuery.mockImplementation(async () => [] as unknown[]);
   }
 
-  it("returns defaults and skips DB when orgId is undefined", async () => {
+  it("returns `global` variant when orgId is undefined, skips DB", async () => {
     reset();
-    const result = await resolvePromptDemoContext(undefined);
-    expect(result).toEqual({ demoIndustry: null, demoConnectionActive: false });
+    const scope = await resolvePromptScope({ orgId: undefined, mode: "published" });
+    expect(scope.kind).toBe("global");
+    expect(scope.mode).toBe("published");
     expect(mockInternalQuery).not.toHaveBeenCalled();
   });
 
-  it("returns defaults and skips DB when internal DB is unavailable", async () => {
+  it("returns `global` variant when internal DB is unavailable, skips DB", async () => {
     reset({ hasDB: false, industry: "cybersecurity" });
-    const result = await resolvePromptDemoContext("org-1");
-    expect(result).toEqual({ demoIndustry: null, demoConnectionActive: false });
+    const scope = await resolvePromptScope({ orgId: "org-1", mode: "developer" });
+    expect(scope.kind).toBe("global");
+    expect(scope.mode).toBe("developer");
     expect(mockInternalQuery).not.toHaveBeenCalled();
   });
 
-  it("returns industry + active=true when demo exists as published connection", async () => {
+  it("returns `org-with-demo` when demo is published + industry set", async () => {
     reset({ industry: "cybersecurity" });
     mockInternalQuery.mockImplementation(async () => [{ active: true }]);
-    const result = await resolvePromptDemoContext("org-1");
-    expect(result).toEqual({
-      demoIndustry: "cybersecurity",
-      demoConnectionActive: true,
-    });
+    const scope = await resolvePromptScope({ orgId: "org-1", mode: "developer" });
+    expect(scope.kind).toBe("org-with-demo");
+    if (scope.kind === "org-with-demo") {
+      expect(scope.orgId).toBe("org-1");
+      expect(scope.demoIndustry).toBe("cybersecurity");
+      expect(scope.mode).toBe("developer");
+    }
     const [sql, params] = mockInternalQuery.mock.calls[0]!;
     expect(sql).toContain("__demo__");
     expect(sql).toContain("status = 'published'");
     expect(params).toEqual(["org-1"]);
   });
 
-  it("returns industry + active=false when demo row reports inactive", async () => {
+  it("returns `org-custom-only` when demo row reports inactive", async () => {
     reset({ industry: "saas" });
     mockInternalQuery.mockImplementation(async () => [{ active: false }]);
-    const result = await resolvePromptDemoContext("org-1");
-    expect(result.demoIndustry).toBe("saas");
-    expect(result.demoConnectionActive).toBe(false);
+    const scope = await resolvePromptScope({ orgId: "org-1", mode: "published" });
+    expect(scope.kind).toBe("org-custom-only");
   });
 
-  it("returns active=false when EXISTS query returns no rows", async () => {
+  it("returns `org-custom-only` when EXISTS query returns no rows", async () => {
     reset({ industry: "saas" });
     mockInternalQuery.mockImplementation(async () => [] as unknown[]);
-    const result = await resolvePromptDemoContext("org-1");
-    expect(result.demoConnectionActive).toBe(false);
+    const scope = await resolvePromptScope({ orgId: "org-1", mode: "published" });
+    expect(scope.kind).toBe("org-custom-only");
   });
 
-  it("normalizes a missing ATLAS_DEMO_INDUSTRY setting to null", async () => {
+  it("returns `org-custom-only` when industry setting is missing even if demo is active", async () => {
     reset({ industry: undefined });
     mockInternalQuery.mockImplementation(async () => [{ active: true }]);
-    const result = await resolvePromptDemoContext("org-1");
-    expect(result.demoIndustry).toBeNull();
-    expect(result.demoConnectionActive).toBe(true);
+    const scope = await resolvePromptScope({ orgId: "org-1", mode: "published" });
+    expect(scope.kind).toBe("org-custom-only");
   });
 
   it("treats non-strict-true `active` values as inactive", async () => {
     // Defense-in-depth: some drivers have returned "t" or 1 historically;
-    // strict equality keeps demoConnectionActive pinned to real booleans.
+    // strict equality keeps the scope decision pinned to real booleans.
     reset({ industry: "saas" });
     mockInternalQuery.mockImplementation(async () =>
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- simulating loose driver output
       [{ active: "t" as any }],
     );
-    const result = await resolvePromptDemoContext("org-1");
-    expect(result.demoConnectionActive).toBe(false);
+    const scope = await resolvePromptScope({ orgId: "org-1", mode: "published" });
+    expect(scope.kind).toBe("org-custom-only");
+  });
+
+  it("defaults mode to published when undefined", async () => {
+    reset();
+    const scope = await resolvePromptScope({ orgId: undefined, mode: undefined });
+    expect(scope.mode).toBe("published");
   });
 });

--- a/packages/api/src/lib/prompts/scoping.ts
+++ b/packages/api/src/lib/prompts/scoping.ts
@@ -1,28 +1,37 @@
 /**
- * Mode-aware prompt collection scoping (#1438).
+ * Mode-aware prompt collection scoping.
  *
  * Builds SQL + params for the user- and admin-facing prompt list / get
  * endpoints so visibility depends on:
  * - atlasMode (published | developer)
- * - whether the org's demo connection is active
- * - the org's demo_industry setting
+ * - whether the org's `__demo__` connection is active
+ * - the org's `ATLAS_DEMO_INDUSTRY` setting
  *
  * Visibility rules (see PRD #1421 user stories 3 + 8):
- * - Published mode + active `__demo__` + industry set: return built-in
- *   collections matching the demo industry *plus* custom published collections.
- * - Published mode + demo archived (or no industry): hide all built-ins,
+ * - Published + active `__demo__` + industry set: return built-in
+ *   collections matching the demo industry *plus* custom published
+ *   collections.
+ * - Published + demo archived (or no industry): hide all built-ins,
  *   return only custom published collections.
- * - Developer mode: same as published for the built-in/custom split, but
- *   expand the status filter to include draft rows.
- * - No `orgId` (single-tenant, no active org): fall back to global built-ins
+ * - Developer mode: same as published for the built-in/custom split,
+ *   but expand the status filter to include draft rows.
+ * - No `orgId` (single-tenant): fall back to global built-ins
  *   (`org_id IS NULL`) — there is no org-scoped demo setting to consult.
  *
- * Built-in demo archival is already handled by the publish flow
- * (`admin-publish.ts`): when `__demo__` is archived, org-scoped built-ins
- * for the matching industry flip to `archived`. This helper's filter on
- * `status` already excludes those. The explicit `demoConnectionActive`
- * check is a belt-and-suspenders guard for global built-ins and for orgs
- * whose archival race left them out of sync with the industry filter.
+ * The scope is modeled as a tagged union so illegal combinations
+ * (e.g. `demoConnectionActive=true` with `orgId=undefined`) cannot be
+ * expressed. `resolvePromptScope` is the single entry point that
+ * inspects settings + connections and narrows to the right variant.
+ *
+ * Built-in demo archival is handled by the publish flow
+ * (`admin-publish.ts` phase 4b): when `__demo__` is archived, org-scoped
+ * built-ins for the matching industry flip to `archived`. The `status`
+ * filter built here excludes those. The explicit `org-with-demo` guard
+ * is a belt-and-suspenders second check for global built-ins and for
+ * orgs whose archival race left them out of sync with the industry
+ * filter.
+ *
+ * See: #1438, PRD #1421.
  */
 import type { AtlasMode } from "@useatlas/types/auth";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
@@ -31,33 +40,80 @@ import { getSettingAuto } from "@atlas/api/lib/settings";
 export const DEMO_INDUSTRY_SETTING = "ATLAS_DEMO_INDUSTRY";
 
 /**
- * Inputs required to scope a prompt-collections query. Callers fetch
- * `demoIndustry` + `demoConnectionActive` via `resolvePromptDemoContext`
- * (or pass explicit values in tests).
+ * Tagged union of the three prompt-scoping scenarios.
+ *
+ * - `global`: single-tenant / no active org — only `org_id IS NULL`
+ *   built-ins are visible. Demo settings are not consulted.
+ * - `org-custom-only`: org context is known but demo is archived or has
+ *   no industry set — all built-ins hidden, only custom rows returned.
+ * - `org-with-demo`: org has an active demo connection + an industry —
+ *   built-ins matching the industry are visible alongside custom rows.
  */
-export interface PromptScope {
-  /** Active org. `undefined` = single-tenant / no active org selected. */
-  orgId: string | undefined;
-  /** Resolved atlas mode from RequestContext. `undefined` → published. */
-  mode: AtlasMode | undefined;
-  /** Demo industry from the `ATLAS_DEMO_INDUSTRY` workspace setting. */
-  demoIndustry: string | null;
-  /** Whether the `__demo__` connection exists for this org and is published. */
-  demoConnectionActive: boolean;
-}
+export type PromptScope =
+  | { readonly kind: "global"; readonly mode: AtlasMode }
+  | {
+      readonly kind: "org-custom-only";
+      readonly orgId: string;
+      readonly mode: AtlasMode;
+    }
+  | {
+      readonly kind: "org-with-demo";
+      readonly orgId: string;
+      readonly mode: AtlasMode;
+      readonly demoIndustry: string;
+    };
 
 export interface PromptCollectionQuery {
   sql: string;
   params: unknown[];
 }
 
-/** Ordering shared across both list shapes. */
+/** Ordering shared across list queries (get queries don't need it). */
 const LIST_ORDER_BY = "ORDER BY sort_order ASC, created_at ASC";
 
-function statusClauseFor(mode: AtlasMode | undefined): string {
+function statusClauseFor(mode: AtlasMode): string {
   return mode === "developer"
     ? "status IN ('published', 'draft')"
     : "status = 'published'";
+}
+
+/**
+ * Inspect the org's settings + connections table to resolve the
+ * right `PromptScope` variant for this request. `mode === undefined`
+ * defaults to `published` so non-admin requests (which never see
+ * drafts) get safe defaults.
+ */
+export async function resolvePromptScope(opts: {
+  orgId: string | undefined;
+  mode: AtlasMode | undefined;
+}): Promise<PromptScope> {
+  const mode: AtlasMode = opts.mode ?? "published";
+
+  if (!opts.orgId || !hasInternalDB()) {
+    return { kind: "global", mode };
+  }
+
+  const demoIndustry =
+    getSettingAuto(DEMO_INDUSTRY_SETTING, opts.orgId) ?? null;
+  const rows = await internalQuery<{ active: boolean }>(
+    `SELECT EXISTS (
+       SELECT 1 FROM connections
+       WHERE id = '__demo__' AND org_id = $1 AND status = 'published'
+     ) AS active`,
+    [opts.orgId],
+  );
+  const demoConnectionActive = rows[0]?.active === true;
+
+  if (demoConnectionActive && demoIndustry) {
+    return {
+      kind: "org-with-demo",
+      orgId: opts.orgId,
+      mode,
+      demoIndustry,
+    };
+  }
+
+  return { kind: "org-custom-only", orgId: opts.orgId, mode };
 }
 
 /**
@@ -69,77 +125,72 @@ export function buildCollectionsListQuery(
 ): PromptCollectionQuery {
   const statusClause = statusClauseFor(scope.mode);
 
-  if (!scope.orgId) {
-    return {
-      sql: `SELECT * FROM prompt_collections WHERE org_id IS NULL AND ${statusClause} ${LIST_ORDER_BY}`,
-      params: [],
-    };
+  switch (scope.kind) {
+    case "global":
+      return {
+        sql: `SELECT * FROM prompt_collections WHERE org_id IS NULL AND ${statusClause} ${LIST_ORDER_BY}`,
+        params: [],
+      };
+    case "org-with-demo":
+      return {
+        sql: `SELECT * FROM prompt_collections
+              WHERE ${statusClause}
+                AND (
+                  (is_builtin = true AND industry = $2 AND (org_id IS NULL OR org_id = $1))
+                  OR (is_builtin = false AND org_id = $1)
+                )
+              ${LIST_ORDER_BY}`,
+        params: [scope.orgId, scope.demoIndustry],
+      };
+    case "org-custom-only":
+      return {
+        sql: `SELECT * FROM prompt_collections
+              WHERE org_id = $1
+                AND is_builtin = false
+                AND ${statusClause}
+              ${LIST_ORDER_BY}`,
+        params: [scope.orgId],
+      };
   }
-
-  if (scope.demoConnectionActive && scope.demoIndustry) {
-    return {
-      sql: `SELECT * FROM prompt_collections
-            WHERE ${statusClause}
-              AND (
-                (is_builtin = true AND industry = $2 AND (org_id IS NULL OR org_id = $1))
-                OR (is_builtin = false AND org_id = $1)
-              )
-            ${LIST_ORDER_BY}`,
-      params: [scope.orgId, scope.demoIndustry],
-    };
-  }
-
-  return {
-    sql: `SELECT * FROM prompt_collections
-          WHERE org_id = $1
-            AND is_builtin = false
-            AND ${statusClause}
-          ${LIST_ORDER_BY}`,
-    params: [scope.orgId],
-  };
 }
 
 /**
- * Build the SQL + params to fetch a single collection by id with the same
- * mode/demo scoping. Reuses the list query's WHERE clause and appends
- * `AND id = $N`.
+ * Build the SQL + params to fetch a single collection by id with the
+ * same mode + demo scoping as the list query. Dedicated SQL per
+ * variant (not regex-stripped from the list query) so the two queries
+ * can evolve independently.
  */
 export function buildCollectionGetQuery(
   scope: PromptScope,
   id: string,
 ): PromptCollectionQuery {
-  const list = buildCollectionsListQuery(scope);
-  // Strip the shared ORDER BY — get-by-id returns at most one row.
-  const whereOnly = list.sql.replace(/\s*ORDER BY[\s\S]*$/i, "");
-  const idIdx = list.params.length + 1;
-  return {
-    sql: `${whereOnly} AND id = $${idIdx}`,
-    params: [...list.params, id],
-  };
-}
+  const statusClause = statusClauseFor(scope.mode);
 
-/**
- * Resolve `demoIndustry` + `demoConnectionActive` for an org from the
- * settings cache + connections table. Returns safe defaults when no orgId
- * or when the internal DB is unavailable.
- */
-export async function resolvePromptDemoContext(
-  orgId: string | undefined,
-): Promise<{ demoIndustry: string | null; demoConnectionActive: boolean }> {
-  if (!orgId || !hasInternalDB()) {
-    return { demoIndustry: null, demoConnectionActive: false };
+  switch (scope.kind) {
+    case "global":
+      return {
+        sql: `SELECT * FROM prompt_collections WHERE org_id IS NULL AND ${statusClause} AND id = $1`,
+        params: [id],
+      };
+    case "org-with-demo":
+      return {
+        sql: `SELECT * FROM prompt_collections
+              WHERE ${statusClause}
+                AND (
+                  (is_builtin = true AND industry = $2 AND (org_id IS NULL OR org_id = $1))
+                  OR (is_builtin = false AND org_id = $1)
+                )
+                AND id = $3`,
+        params: [scope.orgId, scope.demoIndustry, id],
+      };
+    case "org-custom-only":
+      return {
+        sql: `SELECT * FROM prompt_collections
+              WHERE org_id = $1
+                AND is_builtin = false
+                AND ${statusClause}
+                AND id = $2`,
+        params: [scope.orgId, id],
+      };
   }
-
-  const demoIndustry = getSettingAuto(DEMO_INDUSTRY_SETTING, orgId) ?? null;
-  const rows = await internalQuery<{ active: boolean }>(
-    `SELECT EXISTS (
-       SELECT 1 FROM connections
-       WHERE id = '__demo__' AND org_id = $1 AND status = 'published'
-     ) AS active`,
-    [orgId],
-  );
-  return {
-    demoIndustry,
-    demoConnectionActive: rows[0]?.active === true,
-  };
 }

--- a/packages/api/src/lib/prompts/scoping.ts
+++ b/packages/api/src/lib/prompts/scoping.ts
@@ -1,0 +1,145 @@
+/**
+ * Mode-aware prompt collection scoping (#1438).
+ *
+ * Builds SQL + params for the user- and admin-facing prompt list / get
+ * endpoints so visibility depends on:
+ * - atlasMode (published | developer)
+ * - whether the org's demo connection is active
+ * - the org's demo_industry setting
+ *
+ * Visibility rules (see PRD #1421 user stories 3 + 8):
+ * - Published mode + active `__demo__` + industry set: return built-in
+ *   collections matching the demo industry *plus* custom published collections.
+ * - Published mode + demo archived (or no industry): hide all built-ins,
+ *   return only custom published collections.
+ * - Developer mode: same as published for the built-in/custom split, but
+ *   expand the status filter to include draft rows.
+ * - No `orgId` (single-tenant, no active org): fall back to global built-ins
+ *   (`org_id IS NULL`) — there is no org-scoped demo setting to consult.
+ *
+ * Built-in demo archival is already handled by the publish flow
+ * (`admin-publish.ts`): when `__demo__` is archived, org-scoped built-ins
+ * for the matching industry flip to `archived`. This helper's filter on
+ * `status` already excludes those. The explicit `demoConnectionActive`
+ * check is a belt-and-suspenders guard for global built-ins and for orgs
+ * whose archival race left them out of sync with the industry filter.
+ */
+import type { AtlasMode } from "@useatlas/types/auth";
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { getSettingAuto } from "@atlas/api/lib/settings";
+
+export const DEMO_INDUSTRY_SETTING = "ATLAS_DEMO_INDUSTRY";
+
+/**
+ * Inputs required to scope a prompt-collections query. Callers fetch
+ * `demoIndustry` + `demoConnectionActive` via `resolvePromptDemoContext`
+ * (or pass explicit values in tests).
+ */
+export interface PromptScope {
+  /** Active org. `undefined` = single-tenant / no active org selected. */
+  orgId: string | undefined;
+  /** Resolved atlas mode from RequestContext. `undefined` → published. */
+  mode: AtlasMode | undefined;
+  /** Demo industry from the `ATLAS_DEMO_INDUSTRY` workspace setting. */
+  demoIndustry: string | null;
+  /** Whether the `__demo__` connection exists for this org and is published. */
+  demoConnectionActive: boolean;
+}
+
+export interface PromptCollectionQuery {
+  sql: string;
+  params: unknown[];
+}
+
+/** Ordering shared across both list shapes. */
+const LIST_ORDER_BY = "ORDER BY sort_order ASC, created_at ASC";
+
+function statusClauseFor(mode: AtlasMode | undefined): string {
+  return mode === "developer"
+    ? "status IN ('published', 'draft')"
+    : "status = 'published'";
+}
+
+/**
+ * Build the SQL + params for the prompt collections list endpoint.
+ * Never includes archived rows.
+ */
+export function buildCollectionsListQuery(
+  scope: PromptScope,
+): PromptCollectionQuery {
+  const statusClause = statusClauseFor(scope.mode);
+
+  if (!scope.orgId) {
+    return {
+      sql: `SELECT * FROM prompt_collections WHERE org_id IS NULL AND ${statusClause} ${LIST_ORDER_BY}`,
+      params: [],
+    };
+  }
+
+  if (scope.demoConnectionActive && scope.demoIndustry) {
+    return {
+      sql: `SELECT * FROM prompt_collections
+            WHERE ${statusClause}
+              AND (
+                (is_builtin = true AND industry = $2 AND (org_id IS NULL OR org_id = $1))
+                OR (is_builtin = false AND org_id = $1)
+              )
+            ${LIST_ORDER_BY}`,
+      params: [scope.orgId, scope.demoIndustry],
+    };
+  }
+
+  return {
+    sql: `SELECT * FROM prompt_collections
+          WHERE org_id = $1
+            AND is_builtin = false
+            AND ${statusClause}
+          ${LIST_ORDER_BY}`,
+    params: [scope.orgId],
+  };
+}
+
+/**
+ * Build the SQL + params to fetch a single collection by id with the same
+ * mode/demo scoping. Reuses the list query's WHERE clause and appends
+ * `AND id = $N`.
+ */
+export function buildCollectionGetQuery(
+  scope: PromptScope,
+  id: string,
+): PromptCollectionQuery {
+  const list = buildCollectionsListQuery(scope);
+  // Strip the shared ORDER BY — get-by-id returns at most one row.
+  const whereOnly = list.sql.replace(/\s*ORDER BY[\s\S]*$/i, "");
+  const idIdx = list.params.length + 1;
+  return {
+    sql: `${whereOnly} AND id = $${idIdx}`,
+    params: [...list.params, id],
+  };
+}
+
+/**
+ * Resolve `demoIndustry` + `demoConnectionActive` for an org from the
+ * settings cache + connections table. Returns safe defaults when no orgId
+ * or when the internal DB is unavailable.
+ */
+export async function resolvePromptDemoContext(
+  orgId: string | undefined,
+): Promise<{ demoIndustry: string | null; demoConnectionActive: boolean }> {
+  if (!orgId || !hasInternalDB()) {
+    return { demoIndustry: null, demoConnectionActive: false };
+  }
+
+  const demoIndustry = getSettingAuto(DEMO_INDUSTRY_SETTING, orgId) ?? null;
+  const rows = await internalQuery<{ active: boolean }>(
+    `SELECT EXISTS (
+       SELECT 1 FROM connections
+       WHERE id = '__demo__' AND org_id = $1 AND status = 'published'
+     ) AS active`,
+    [orgId],
+  );
+  return {
+    demoIndustry,
+    demoConnectionActive: rows[0]?.active === true,
+  };
+}


### PR DESCRIPTION
## Summary

Mode-aware scoping for the prompt library (user and admin list endpoints). Closes #1438.

- **Published + active `__demo__`**: built-ins matching the org's `demo_industry` + custom published collections.
- **Published + demo archived**: only custom published — all built-ins hidden.
- **Developer mode**: same industry + custom split, with draft rows included.

New helper at `packages/api/src/lib/prompts/scoping.ts` (`buildCollectionsListQuery`, `buildCollectionGetQuery`, `resolvePromptDemoContext`) keeps the filter SQL in one place. Both `prompts.ts` and `admin-prompts.ts` call into it so the list endpoints stay in sync.

The frontend needed no changes — `PromptLibrary` (chat sidebar) and the admin prompts page already render whatever the API returns, and the `DraftBadge` from #1435 picks up `status='draft'` automatically.

## Test plan

- [x] Unit tests (`packages/api/src/lib/prompts/__tests__/scoping.test.ts`) — full `(orgId × mode × demoIndustry × demoConnectionActive)` matrix for both list + get queries. 12 cases.
- [x] Integration tests added to `prompts.test.ts` — published-with-demo, published-archived, developer-with-demo, developer-no-demo for both user and admin routes. All existing 53 tests still pass; 8 new tests added.
- [x] `bun run lint`, `bun run type`, `bun x syncpack lint`, `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh`, full `bun run test` all pass locally.
- [x] Docs — added "Prompt Library Scoping" section to `guides/developer-mode.mdx`, updated stale "visible to all users" line in `guides/admin-console.mdx`.
- [x] ROADMAP updated — #1438 checked off under **Agent & Data**.

Closes #1438