### PR TITLE
feat(mode): empty states in developer mode (#1436)

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -1188,7 +1188,7 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
 - [x] Developer mode banner + cookie-based toggle (#1433, PR #1445)
 - [x] Non-admin demo indicator chip (#1434, PR #1459)
 - [x] Admin surface — draft/demo badges, read-only published, pending changes summary (#1435, PR #1463)
-- [ ] Empty states in developer mode (#1436)
+- [x] Empty states in developer mode (#1436)
 
 ### Bug Fixes
 - [x] Bundle cybersec + ecommerce semantic directories in Docker image (#1422, PR #1441)

--- a/apps/docs/content/docs/guides/developer-mode.mdx
+++ b/apps/docs/content/docs/guides/developer-mode.mdx
@@ -112,6 +112,20 @@ Publishing clears every draft for the org. The admin's next edit — a new entit
 
 ---
 
+## What Admins See on First Toggle
+
+When an admin flips into developer mode for the first time, none of the staged resources have drafts yet — every page would otherwise show the same content the user sees in published mode. To keep the intent of the mode visible, each admin surface renders a focused empty state instead:
+
+- **Connections** — "Connect your first database to start building." A dialog CTA opens the Add Connection form.
+- **Semantic editor** — "Import your schema after connecting a database." The CTA routes to the connections page so the admin can source the schema first.
+- **Schema diff** — "Nothing to diff — no developer mode connection yet." The diff needs a draft connection to compare against.
+- **Prompts** — "Create prompt collections to help your users ask the right questions." The CTA opens the new-collection dialog.
+- **Chat** — "No connection configured in developer mode. Connect a database in the admin panel to start testing." The CTA routes to the connections page, preventing the agent from running against nothing.
+
+If published items exist for a resource (for example, a workspace with the `__demo__` connection in place), developer mode renders those items as a grayed-out read-only context with a **Published** badge and a **Create draft** CTA so admins can see the live state without editing it by mistake.
+
+---
+
 ## Related
 
 - [Admin Console overview](/guides/admin-console)

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -591,11 +591,15 @@ export default function ConnectionsPage() {
   const { mode } = useMode();
   const { data: modeStatus } = useModeStatus();
   const inDevMode = mode === "developer";
-  const connectionDrafts = modeStatus?.draftCounts?.connections ?? 0;
   // Dev-mode empty signal: admin is in developer mode but has not drafted a
   // connection yet. The empty + published-context UIs only render when this
-  // is true — in published mode the page keeps its existing behavior.
-  const showDevNoDrafts = inDevMode && connectionDrafts === 0;
+  // is true — in published mode the page keeps its existing behavior. Gate
+  // on `modeStatus !== null` so admins with drafts don't see the empty
+  // state flash while `/api/v1/mode` is in flight.
+  const showDevNoDrafts =
+    inDevMode && modeStatus !== null
+      ? (modeStatus.draftCounts?.connections ?? 0) === 0
+      : false;
 
   const testMutation = useAdminMutation<ConnectionHealth>({ method: "POST" });
   const [mutationError, setMutationError] = useState<string | null>(null);

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -34,6 +34,10 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useDemoReadonly } from "@/ui/hooks/use-demo-readonly";
+import { useMode } from "@/ui/hooks/use-mode";
+import { useModeStatus } from "@/ui/hooks/use-mode-status";
+import { DeveloperEmptyState } from "@/ui/components/admin/developer-empty-state";
+import { PublishedContextWrapper } from "@/ui/components/admin/published-context-wrapper";
 import { DEMO_CONNECTION_ID, getConnectionColumns } from "./columns";
 import { useDataTable } from "@/hooks/use-data-table";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -584,6 +588,14 @@ export default function ConnectionsPage() {
   const { apiUrl, isCrossOrigin } = useAtlasConfig();
   const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
   const { readOnly: demoReadOnly } = useDemoReadonly();
+  const { mode } = useMode();
+  const { data: modeStatus } = useModeStatus();
+  const inDevMode = mode === "developer";
+  const connectionDrafts = modeStatus?.draftCounts?.connections ?? 0;
+  // Dev-mode empty signal: admin is in developer mode but has not drafted a
+  // connection yet. The empty + published-context UIs only render when this
+  // is true — in published mode the page keeps its existing behavior.
+  const showDevNoDrafts = inDevMode && connectionDrafts === 0;
 
   const testMutation = useAdminMutation<ConnectionHealth>({ method: "POST" });
   const [mutationError, setMutationError] = useState<string | null>(null);
@@ -820,11 +832,32 @@ export default function ConnectionsPage() {
           emptyTitle="No datasource connections"
           emptyDescription="Add a connection to start querying your data"
           emptyAction={{ label: "Add connection", onClick: handleAdd }}
-          isEmpty={displayConnections.length === 0}
+          // In dev-mode-no-drafts we short-circuit to DeveloperEmptyState
+          // instead of the generic empty state so the CTA language matches
+          // "start building" rather than "add a connection".
+          isEmpty={displayConnections.length === 0 && !showDevNoDrafts}
         >
-          <DataTable table={connTable}>
-            <DataTableToolbar table={connTable} />
-          </DataTable>
+          {showDevNoDrafts && displayConnections.length === 0 ? (
+            <DeveloperEmptyState
+              icon={Cable}
+              title="Connect your first database to start building."
+              description="Add a connection in developer mode, then publish it when you're ready."
+              action={{ label: "Add connection", onClick: handleAdd }}
+            />
+          ) : showDevNoDrafts ? (
+            <PublishedContextWrapper
+              resourceLabel="connection"
+              action={{ label: "Create draft", onClick: handleAdd }}
+            >
+              <DataTable table={connTable}>
+                <DataTableToolbar table={connTable} />
+              </DataTable>
+            </PublishedContextWrapper>
+          ) : (
+            <DataTable table={connTable}>
+              <DataTableToolbar table={connTable} />
+            </DataTable>
+          )}
         </AdminContentWrapper>
       </div>
       </ErrorBoundary>

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -34,8 +34,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useDemoReadonly } from "@/ui/hooks/use-demo-readonly";
-import { useMode } from "@/ui/hooks/use-mode";
-import { useModeStatus } from "@/ui/hooks/use-mode-status";
+import { useDevModeNoDrafts } from "@/ui/hooks/use-dev-mode-no-drafts";
 import { DeveloperEmptyState } from "@/ui/components/admin/developer-empty-state";
 import { PublishedContextWrapper } from "@/ui/components/admin/published-context-wrapper";
 import { DEMO_CONNECTION_ID, getConnectionColumns } from "./columns";
@@ -588,18 +587,7 @@ export default function ConnectionsPage() {
   const { apiUrl, isCrossOrigin } = useAtlasConfig();
   const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
   const { readOnly: demoReadOnly } = useDemoReadonly();
-  const { mode } = useMode();
-  const { data: modeStatus } = useModeStatus();
-  const inDevMode = mode === "developer";
-  // Dev-mode empty signal: admin is in developer mode but has not drafted a
-  // connection yet. The empty + published-context UIs only render when this
-  // is true — in published mode the page keeps its existing behavior. Gate
-  // on `modeStatus !== null` so admins with drafts don't see the empty
-  // state flash while `/api/v1/mode` is in flight.
-  const showDevNoDrafts =
-    inDevMode && modeStatus !== null
-      ? (modeStatus.draftCounts?.connections ?? 0) === 0
-      : false;
+  const showDevNoDrafts = useDevModeNoDrafts(["connections"]);
 
   const testMutation = useAdminMutation<ConnectionHealth>({ method: "POST" });
   const [mutationError, setMutationError] = useState<string | null>(null);
@@ -846,12 +834,12 @@ export default function ConnectionsPage() {
               icon={Cable}
               title="Connect your first database to start building."
               description="Add a connection in developer mode, then publish it when you're ready."
-              action={{ label: "Add connection", onClick: handleAdd }}
+              action={{ kind: "button", label: "Add connection", onClick: handleAdd }}
             />
           ) : showDevNoDrafts ? (
             <PublishedContextWrapper
-              resourceLabel="connection"
-              action={{ label: "Create draft", onClick: handleAdd }}
+              resourceLabel={{ singular: "connection", plural: "connections" }}
+              action={{ kind: "button", label: "Create draft", onClick: handleAdd }}
             >
               <DataTable table={connTable}>
                 <DataTableToolbar table={connTable} />

--- a/packages/web/src/app/admin/prompts/page.tsx
+++ b/packages/web/src/app/admin/prompts/page.tsx
@@ -64,8 +64,7 @@ import {
 import type { FetchError } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
-import { useMode } from "@/ui/hooks/use-mode";
-import { useModeStatus } from "@/ui/hooks/use-mode-status";
+import { useDevModeNoDrafts } from "@/ui/hooks/use-dev-mode-no-drafts";
 import { DeveloperEmptyState } from "@/ui/components/admin/developer-empty-state";
 import { PublishedContextWrapper } from "@/ui/components/admin/published-context-wrapper";
 import {
@@ -456,15 +455,7 @@ export default function PromptsPage() {
 
   const hasFilters = !!params.industry;
 
-  const { mode } = useMode();
-  const { data: modeStatus } = useModeStatus();
-  const inDevMode = mode === "developer";
-  // Gate on `modeStatus !== null` so the empty state doesn't flash while
-  // /api/v1/mode is in flight (admin might already have prompt drafts).
-  const showDevNoDrafts =
-    inDevMode && modeStatus !== null
-      ? (modeStatus.draftCounts?.prompts ?? 0) === 0
-      : false;
+  const showDevNoDrafts = useDevModeNoDrafts(["prompts"]);
 
   return (
     <div className="p-6">
@@ -575,12 +566,12 @@ export default function PromptsPage() {
                 icon={BookOpen}
                 title="Create prompt collections to help your users ask the right questions."
                 description="Draft a collection now, then publish it when it's ready for users."
-                action={{ label: "Create collection", onClick: openCreateDialog }}
+                action={{ kind: "button", label: "Create collection", onClick: openCreateDialog }}
               />
             ) : showDevNoDrafts && filtered.length > 0 && !hasFilters ? (
               <PublishedContextWrapper
-                resourceLabel="prompt collection"
-                action={{ label: "Create draft collection", onClick: openCreateDialog }}
+                resourceLabel={{ singular: "prompt collection", plural: "prompt collections" }}
+                action={{ kind: "button", label: "Create draft collection", onClick: openCreateDialog }}
               >
                 <DataTable
                   table={table}

--- a/packages/web/src/app/admin/prompts/page.tsx
+++ b/packages/web/src/app/admin/prompts/page.tsx
@@ -459,8 +459,12 @@ export default function PromptsPage() {
   const { mode } = useMode();
   const { data: modeStatus } = useModeStatus();
   const inDevMode = mode === "developer";
-  const promptDrafts = modeStatus?.draftCounts?.prompts ?? 0;
-  const showDevNoDrafts = inDevMode && promptDrafts === 0;
+  // Gate on `modeStatus !== null` so the empty state doesn't flash while
+  // /api/v1/mode is in flight (admin might already have prompt drafts).
+  const showDevNoDrafts =
+    inDevMode && modeStatus !== null
+      ? (modeStatus.draftCounts?.prompts ?? 0) === 0
+      : false;
 
   return (
     <div className="p-6">

--- a/packages/web/src/app/admin/prompts/page.tsx
+++ b/packages/web/src/app/admin/prompts/page.tsx
@@ -64,6 +64,10 @@ import {
 import type { FetchError } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
+import { useMode } from "@/ui/hooks/use-mode";
+import { useModeStatus } from "@/ui/hooks/use-mode-status";
+import { DeveloperEmptyState } from "@/ui/components/admin/developer-empty-state";
+import { PublishedContextWrapper } from "@/ui/components/admin/published-context-wrapper";
 import {
   BookOpen,
   Plus,
@@ -452,6 +456,12 @@ export default function PromptsPage() {
 
   const hasFilters = !!params.industry;
 
+  const { mode } = useMode();
+  const { data: modeStatus } = useModeStatus();
+  const inDevMode = mode === "developer";
+  const promptDrafts = modeStatus?.draftCounts?.prompts ?? 0;
+  const showDevNoDrafts = inDevMode && promptDrafts === 0;
+
   return (
     <div className="p-6">
       {/* Header */}
@@ -550,26 +560,59 @@ export default function PromptsPage() {
             emptyTitle="No prompt collections"
             emptyDescription="Create a collection to add starter questions for your users."
             emptyAction={{ label: "Create collection", onClick: openCreateDialog }}
-            isEmpty={filtered.length === 0}
+            // In dev-mode-no-drafts we short-circuit to a DeveloperEmptyState
+            // so the CTA copy speaks to the drafting workflow.
+            isEmpty={filtered.length === 0 && !(showDevNoDrafts && !hasFilters)}
             hasFilters={hasFilters}
             onClearFilters={() => setParams({ industry: "", page: 1 })}
           >
-            <DataTable
-              table={table}
-              onRowClick={(row, e) => {
-                if (
-                  (e.target as HTMLElement).closest(
-                    '[role="checkbox"], button',
+            {showDevNoDrafts && filtered.length === 0 && !hasFilters ? (
+              <DeveloperEmptyState
+                icon={BookOpen}
+                title="Create prompt collections to help your users ask the right questions."
+                description="Draft a collection now, then publish it when it's ready for users."
+                action={{ label: "Create collection", onClick: openCreateDialog }}
+              />
+            ) : showDevNoDrafts && filtered.length > 0 && !hasFilters ? (
+              <PublishedContextWrapper
+                resourceLabel="prompt collection"
+                action={{ label: "Create draft collection", onClick: openCreateDialog }}
+              >
+                <DataTable
+                  table={table}
+                  onRowClick={(row, e) => {
+                    if (
+                      (e.target as HTMLElement).closest(
+                        '[role="checkbox"], button',
+                      )
+                    )
+                      return;
+                    setDetailCollection(row.original);
+                  }}
+                >
+                  <DataTableToolbar table={table}>
+                    <DataTableSortList table={table} />
+                  </DataTableToolbar>
+                </DataTable>
+              </PublishedContextWrapper>
+            ) : (
+              <DataTable
+                table={table}
+                onRowClick={(row, e) => {
+                  if (
+                    (e.target as HTMLElement).closest(
+                      '[role="checkbox"], button',
+                    )
                   )
-                )
-                  return;
-                setDetailCollection(row.original);
-              }}
-            >
-              <DataTableToolbar table={table}>
-                <DataTableSortList table={table} />
-              </DataTableToolbar>
-            </DataTable>
+                    return;
+                  setDetailCollection(row.original);
+                }}
+              >
+                <DataTableToolbar table={table}>
+                  <DataTableSortList table={table} />
+                </DataTableToolbar>
+              </DataTable>
+            )}
           </AdminContentWrapper>
         </div>
       </ErrorBoundary>

--- a/packages/web/src/app/admin/schema-diff/page.tsx
+++ b/packages/web/src/app/admin/schema-diff/page.tsx
@@ -66,12 +66,15 @@ export default function SchemaDiffPage() {
   const { mode } = useMode();
   const { data: modeStatus } = useModeStatus();
   const inDevMode = mode === "developer";
-  const connectionDrafts = modeStatus?.draftCounts?.connections ?? 0;
   // Schema diff is meaningful only against a developer-mode (draft)
   // connection. If the admin toggled into dev mode but hasn't drafted one
   // yet, short-circuit the generic "no diff data" empty state with a
-  // message that names the root cause.
-  const showDevNoConnection = inDevMode && connectionDrafts === 0;
+  // message that names the root cause. Gate on `modeStatus !== null` so the
+  // panel doesn't flash before /api/v1/mode resolves.
+  const showDevNoConnection =
+    inDevMode && modeStatus !== null
+      ? (modeStatus.draftCounts?.connections ?? 0) === 0
+      : false;
 
   const multipleConnections = connectionsData && connectionsData.length > 1;
 

--- a/packages/web/src/app/admin/schema-diff/page.tsx
+++ b/packages/web/src/app/admin/schema-diff/page.tsx
@@ -43,8 +43,7 @@ import {
 } from "lucide-react";
 import type { SemanticTableDiff, ConnectionInfo } from "@/ui/lib/types";
 import { ConnectionsResponseSchema, SemanticDiffResponseSchema } from "@/ui/lib/admin-schemas";
-import { useMode } from "@/ui/hooks/use-mode";
-import { useModeStatus } from "@/ui/hooks/use-mode-status";
+import { useDevModeNoDrafts } from "@/ui/hooks/use-dev-mode-no-drafts";
 import { DeveloperEmptyState } from "@/ui/components/admin/developer-empty-state";
 
 // ---------------------------------------------------------------------------
@@ -63,18 +62,10 @@ export default function SchemaDiffPage() {
     { schema: SemanticDiffResponseSchema, deps: [connectionId] },
   );
 
-  const { mode } = useMode();
-  const { data: modeStatus } = useModeStatus();
-  const inDevMode = mode === "developer";
   // Schema diff is meaningful only against a developer-mode (draft)
-  // connection. If the admin toggled into dev mode but hasn't drafted one
-  // yet, short-circuit the generic "no diff data" empty state with a
-  // message that names the root cause. Gate on `modeStatus !== null` so the
-  // panel doesn't flash before /api/v1/mode resolves.
-  const showDevNoConnection =
-    inDevMode && modeStatus !== null
-      ? (modeStatus.draftCounts?.connections ?? 0) === 0
-      : false;
+  // connection — route the admin to /admin/connections when they haven't
+  // drafted one yet, instead of the generic "no diff data" message.
+  const showDevNoConnection = useDevModeNoDrafts(["connections"]);
 
   const multipleConnections = connectionsData && connectionsData.length > 1;
 
@@ -93,7 +84,7 @@ export default function SchemaDiffPage() {
           icon={GitCompareArrows}
           title="Nothing to diff — no developer mode connection yet."
           description="Create a draft connection to compare its schema against the semantic layer."
-          action={{ label: "Go to connections", href: "/admin/connections" }}
+          action={{ kind: "link", label: "Go to connections", href: "/admin/connections" }}
         />
       ) : (
       <AdminContentWrapper

--- a/packages/web/src/app/admin/schema-diff/page.tsx
+++ b/packages/web/src/app/admin/schema-diff/page.tsx
@@ -43,6 +43,9 @@ import {
 } from "lucide-react";
 import type { SemanticTableDiff, ConnectionInfo } from "@/ui/lib/types";
 import { ConnectionsResponseSchema, SemanticDiffResponseSchema } from "@/ui/lib/admin-schemas";
+import { useMode } from "@/ui/hooks/use-mode";
+import { useModeStatus } from "@/ui/hooks/use-mode-status";
+import { DeveloperEmptyState } from "@/ui/components/admin/developer-empty-state";
 
 // ---------------------------------------------------------------------------
 
@@ -60,6 +63,16 @@ export default function SchemaDiffPage() {
     { schema: SemanticDiffResponseSchema, deps: [connectionId] },
   );
 
+  const { mode } = useMode();
+  const { data: modeStatus } = useModeStatus();
+  const inDevMode = mode === "developer";
+  const connectionDrafts = modeStatus?.draftCounts?.connections ?? 0;
+  // Schema diff is meaningful only against a developer-mode (draft)
+  // connection. If the admin toggled into dev mode but hasn't drafted one
+  // yet, short-circuit the generic "no diff data" empty state with a
+  // message that names the root cause.
+  const showDevNoConnection = inDevMode && connectionDrafts === 0;
+
   const multipleConnections = connectionsData && connectionsData.length > 1;
 
   const hasDrift = diff ? diff.summary.new > 0 || diff.summary.removed > 0 || diff.summary.changed > 0 : false;
@@ -72,6 +85,14 @@ export default function SchemaDiffPage() {
         onChange={setConnectionId}
       />
     ) : null}>
+      {showDevNoConnection && !diff && !loading && !error ? (
+        <DeveloperEmptyState
+          icon={GitCompareArrows}
+          title="Nothing to diff — no developer mode connection yet."
+          description="Create a draft connection to compare its schema against the semantic layer."
+          action={{ label: "Go to connections", href: "/admin/connections" }}
+        />
+      ) : (
       <AdminContentWrapper
         loading={loading}
         error={error}
@@ -232,6 +253,7 @@ export default function SchemaDiffPage() {
         </div>
       </ErrorBoundary>}
       </AdminContentWrapper>
+      )}
     </PageShell>
   );
 }

--- a/packages/web/src/app/admin/semantic/page.tsx
+++ b/packages/web/src/app/admin/semantic/page.tsx
@@ -47,6 +47,10 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useDemoReadonly, demoIndustryLabel } from "@/ui/hooks/use-demo-readonly";
+import { useMode } from "@/ui/hooks/use-mode";
+import { useModeStatus } from "@/ui/hooks/use-mode-status";
+import { DeveloperEmptyState } from "@/ui/components/admin/developer-empty-state";
+import { PublishedBadge } from "@/ui/components/admin/mode-badges";
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -348,6 +352,13 @@ export default function SemanticPage() {
   const isSaas = deployMode === "saas";
   const { readOnly: demoReadOnly, demoIndustry } = useDemoReadonly();
   const demoLabel = demoIndustryLabel(demoIndustry);
+  const { mode } = useMode();
+  const { data: modeStatus } = useModeStatus();
+  const inDevMode = mode === "developer";
+  const entityDrafts = (modeStatus?.draftCounts?.entities ?? 0)
+    + (modeStatus?.draftCounts?.entityEdits ?? 0)
+    + (modeStatus?.draftCounts?.entityDeletes ?? 0);
+  const showDevNoDrafts = inDevMode && entityDrafts === 0;
 
   const [entities, setEntities] = useState<EntitySummary[]>([]);
   const [draftEntityNames, setDraftEntityNames] = useState<Set<string>>(() => new Set());
@@ -663,6 +674,40 @@ export default function SemanticPage() {
         onRetry={() => setFetchKey((k) => k + 1)}
         loadingMessage="Loading semantic layer..."
       >
+      {/*
+        Dev-mode empty: admin is in developer mode with no entity drafts and
+        no published entities at all. Route them to /admin/connections — a
+        connection must exist before entities can be imported. Short-circuits
+        the file-tree layout below to avoid showing an empty tree next to
+        the empty state.
+      */}
+      {showDevNoDrafts && entities.length === 0 ? (
+        <div className="p-6">
+          <DeveloperEmptyState
+            icon={BookOpen}
+            title="Import your schema after connecting a database."
+            description="Entities are generated from your database schema. Add a connection first, then come back here to import."
+            action={{ label: "Go to connections", href: "/admin/connections" }}
+          />
+        </div>
+      ) : (
+      <>
+      {/*
+        Dev-mode-no-drafts with existing published entities (e.g. demo data):
+        surface a Published-tagged banner so the admin knows the tree reflects
+        live state. The file tree stays interactive so they can browse — the
+        existing demoReadOnly tooltips prevent accidental edits.
+      */}
+      {showDevNoDrafts && entities.length > 0 && !loading ? (
+        <div className="flex items-center gap-2 border-b bg-amber-50/40 px-6 py-2.5 text-xs text-muted-foreground dark:bg-amber-950/10">
+          <PublishedBadge />
+          <span>
+            You&rsquo;re viewing the live semantic layer. Use{" "}
+            <span className="font-medium">Add Entity</span> to start a draft.
+          </span>
+        </div>
+      ) : null}
+
       {!isSaas && (
         <div className="flex items-center gap-2 border-b bg-muted/30 px-6 py-2.5 text-xs text-muted-foreground">
           <Terminal className="size-3.5 shrink-0" />
@@ -792,6 +837,8 @@ export default function SemanticPage() {
         </div>
       </div>
       </ErrorBoundary>
+      </>
+      )}
       </AdminContentWrapper>
 
       {/* Entity editor dialog */}

--- a/packages/web/src/app/admin/semantic/page.tsx
+++ b/packages/web/src/app/admin/semantic/page.tsx
@@ -47,10 +47,9 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useDemoReadonly, demoIndustryLabel } from "@/ui/hooks/use-demo-readonly";
-import { useMode } from "@/ui/hooks/use-mode";
-import { useModeStatus } from "@/ui/hooks/use-mode-status";
+import { useDevModeNoDrafts } from "@/ui/hooks/use-dev-mode-no-drafts";
 import { DeveloperEmptyState } from "@/ui/components/admin/developer-empty-state";
-import { PublishedBadge } from "@/ui/components/admin/mode-badges";
+import { SemanticPublishedBanner } from "@/ui/components/admin/semantic-published-banner";
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -352,17 +351,11 @@ export default function SemanticPage() {
   const isSaas = deployMode === "saas";
   const { readOnly: demoReadOnly, demoIndustry } = useDemoReadonly();
   const demoLabel = demoIndustryLabel(demoIndustry);
-  const { mode } = useMode();
-  const { data: modeStatus } = useModeStatus();
-  const inDevMode = mode === "developer";
-  // Gate on `modeStatus !== null` to avoid flashing the dev-mode empty
-  // state while `/api/v1/mode` is in flight (admin might already have drafts).
-  const showDevNoDrafts =
-    inDevMode && modeStatus !== null
-      ? (modeStatus.draftCounts?.entities ?? 0)
-          + (modeStatus.draftCounts?.entityEdits ?? 0)
-          + (modeStatus.draftCounts?.entityDeletes ?? 0) === 0
-      : false;
+  const showDevNoDrafts = useDevModeNoDrafts([
+    "entities",
+    "entityEdits",
+    "entityDeletes",
+  ]);
 
   const [entities, setEntities] = useState<EntitySummary[]>([]);
   const [draftEntityNames, setDraftEntityNames] = useState<Set<string>>(() => new Set());
@@ -691,25 +684,19 @@ export default function SemanticPage() {
             icon={BookOpen}
             title="Import your schema after connecting a database."
             description="Entities are generated from your database schema. Add a connection first, then come back here to import."
-            action={{ label: "Go to connections", href: "/admin/connections" }}
+            action={{ kind: "link", label: "Go to connections", href: "/admin/connections" }}
           />
         </div>
       ) : (
       <>
       {/*
-        Dev-mode-no-drafts with existing published entities (e.g. demo data):
-        surface a Published-tagged banner so the admin knows the tree reflects
-        live state. The file tree stays interactive so they can browse — the
-        existing demoReadOnly tooltips prevent accidental edits.
+        When an admin is in dev-mode-no-drafts but published entities exist
+        (e.g. demo data), show a banner so they know the tree reflects
+        live state. The file tree stays interactive so they can browse —
+        the existing demoReadOnly tooltips prevent accidental edits.
       */}
       {showDevNoDrafts && entities.length > 0 && !loading ? (
-        <div className="flex items-center gap-2 border-b bg-amber-50/40 px-6 py-2.5 text-xs text-muted-foreground dark:bg-amber-950/10">
-          <PublishedBadge />
-          <span>
-            You&rsquo;re viewing the live semantic layer. Use{" "}
-            <span className="font-medium">Add Entity</span> to start a draft.
-          </span>
-        </div>
+        <SemanticPublishedBanner />
       ) : null}
 
       {!isSaas && (

--- a/packages/web/src/app/admin/semantic/page.tsx
+++ b/packages/web/src/app/admin/semantic/page.tsx
@@ -355,10 +355,14 @@ export default function SemanticPage() {
   const { mode } = useMode();
   const { data: modeStatus } = useModeStatus();
   const inDevMode = mode === "developer";
-  const entityDrafts = (modeStatus?.draftCounts?.entities ?? 0)
-    + (modeStatus?.draftCounts?.entityEdits ?? 0)
-    + (modeStatus?.draftCounts?.entityDeletes ?? 0);
-  const showDevNoDrafts = inDevMode && entityDrafts === 0;
+  // Gate on `modeStatus !== null` to avoid flashing the dev-mode empty
+  // state while `/api/v1/mode` is in flight (admin might already have drafts).
+  const showDevNoDrafts =
+    inDevMode && modeStatus !== null
+      ? (modeStatus.draftCounts?.entities ?? 0)
+          + (modeStatus.draftCounts?.entityEdits ?? 0)
+          + (modeStatus.draftCounts?.entityDeletes ?? 0) === 0
+      : false;
 
   const [entities, setEntities] = useState<EntitySummary[]>([]);
   const [draftEntityNames, setDraftEntityNames] = useState<Set<string>>(() => new Set());

--- a/packages/web/src/ui/__tests__/developer-chat-empty-state.test.tsx
+++ b/packages/web/src/ui/__tests__/developer-chat-empty-state.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { render, cleanup } from "@testing-library/react";
+import { DeveloperChatEmptyState } from "../components/chat/developer-empty-state";
+
+describe("DeveloperChatEmptyState", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("renders the dev-mode message and admin connections CTA", () => {
+    const { getByText, getByRole, getByTestId } = render(
+      <DeveloperChatEmptyState />,
+    );
+    expect(getByTestId("developer-chat-empty-state")).toBeTruthy();
+    expect(
+      getByText("No connection configured in developer mode."),
+    ).toBeTruthy();
+    expect(
+      getByText("Connect a database in the admin panel to start testing."),
+    ).toBeTruthy();
+
+    const link = getByRole("link", { name: /Go to connections/ });
+    expect(link.getAttribute("href")).toBe("/admin/connections");
+  });
+
+  test("uses amber accent so admins recognize it as a dev-mode prompt", () => {
+    const { getByTestId } = render(<DeveloperChatEmptyState />);
+    // Restyles within the amber family are fine — we only care that the
+    // developer-mode visual signal is present.
+    expect(getByTestId("developer-chat-empty-state").innerHTML).toContain("amber");
+  });
+});

--- a/packages/web/src/ui/__tests__/developer-empty-state.test.tsx
+++ b/packages/web/src/ui/__tests__/developer-empty-state.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+import { Database } from "lucide-react";
+import { DeveloperEmptyState } from "../components/admin/developer-empty-state";
+
+describe("DeveloperEmptyState", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("renders title and description", () => {
+    const { getByText } = render(
+      <DeveloperEmptyState
+        icon={Database}
+        title="Connect your first database to start building."
+        description="Add a connection to get going."
+      />,
+    );
+    expect(getByText("Connect your first database to start building.")).toBeTruthy();
+    expect(getByText("Add a connection to get going.")).toBeTruthy();
+  });
+
+  test("uses developer-mode amber styling so admins recognize it as a dev prompt", () => {
+    const { getByTestId } = render(
+      <DeveloperEmptyState icon={Database} title="Test title" />,
+    );
+    const wrapper = getByTestId("developer-empty-state");
+    // The amber accent is the signal that this is a dev-mode empty state;
+    // assert a broad "amber" match so restyles within the amber family
+    // don't break the test.
+    expect(wrapper.innerHTML).toContain("amber");
+  });
+
+  test("renders href-style CTA as a link", () => {
+    const { getByRole } = render(
+      <DeveloperEmptyState
+        icon={Database}
+        title="Connect your first database"
+        action={{ label: "Go to connections", href: "/admin/connections" }}
+      />,
+    );
+    const link = getByRole("link", { name: "Go to connections" });
+    expect(link.getAttribute("href")).toBe("/admin/connections");
+  });
+
+  test("renders onClick-style CTA as a button that fires the handler", () => {
+    let clicked = false;
+    const { getByRole } = render(
+      <DeveloperEmptyState
+        icon={Database}
+        title="Connect your first database"
+        action={{ label: "Add connection", onClick: () => { clicked = true; } }}
+      />,
+    );
+    const button = getByRole("button", { name: "Add connection" });
+    fireEvent.click(button);
+    expect(clicked).toBe(true);
+  });
+
+  test("omits the CTA when no action is provided", () => {
+    const { queryByRole } = render(
+      <DeveloperEmptyState icon={Database} title="Nothing to diff" />,
+    );
+    expect(queryByRole("button")).toBeNull();
+    expect(queryByRole("link")).toBeNull();
+  });
+});

--- a/packages/web/src/ui/__tests__/developer-empty-state.test.tsx
+++ b/packages/web/src/ui/__tests__/developer-empty-state.test.tsx
@@ -31,25 +31,29 @@ describe("DeveloperEmptyState", () => {
     expect(wrapper.innerHTML).toContain("amber");
   });
 
-  test("renders href-style CTA as a link", () => {
+  test("renders kind=link action as a link", () => {
     const { getByRole } = render(
       <DeveloperEmptyState
         icon={Database}
         title="Connect your first database"
-        action={{ label: "Go to connections", href: "/admin/connections" }}
+        action={{ kind: "link", label: "Go to connections", href: "/admin/connections" }}
       />,
     );
     const link = getByRole("link", { name: "Go to connections" });
     expect(link.getAttribute("href")).toBe("/admin/connections");
   });
 
-  test("renders onClick-style CTA as a button that fires the handler", () => {
+  test("renders kind=button action as a button that fires the handler", () => {
     let clicked = false;
     const { getByRole } = render(
       <DeveloperEmptyState
         icon={Database}
         title="Connect your first database"
-        action={{ label: "Add connection", onClick: () => { clicked = true; } }}
+        action={{
+          kind: "button",
+          label: "Add connection",
+          onClick: () => { clicked = true; },
+        }}
       />,
     );
     const button = getByRole("button", { name: "Add connection" });

--- a/packages/web/src/ui/__tests__/mode-badges.test.tsx
+++ b/packages/web/src/ui/__tests__/mode-badges.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test, afterEach } from "bun:test";
 import { render, cleanup } from "@testing-library/react";
-import { DemoBadge, DraftBadge } from "../components/admin/mode-badges";
+import { DemoBadge, DraftBadge, PublishedBadge } from "../components/admin/mode-badges";
 
 describe("DemoBadge", () => {
   afterEach(() => {
@@ -49,5 +49,29 @@ describe("DraftBadge", () => {
     // Keep assertion broad so restyles within the amber family don't break
     // the test — we only care that the amber signal is present.
     expect(el?.className).toContain("amber");
+  });
+});
+
+describe("PublishedBadge", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("renders 'Published' text", () => {
+    const { container } = render(<PublishedBadge />);
+    expect(container.textContent).toBe("Published");
+  });
+
+  test("has accessible label and title attribute", () => {
+    const { container } = render(<PublishedBadge />);
+    const el = container.querySelector("[aria-label]");
+    expect(el?.getAttribute("aria-label")).toBe("Published — live in production");
+    expect(el?.getAttribute("title")).toBe("Published — live in production");
+  });
+
+  test("uses emerald tint so it reads distinctly from the amber 'Draft' pill", () => {
+    const { container } = render(<PublishedBadge />);
+    const el = container.querySelector("[aria-label]");
+    expect(el?.className).toContain("emerald");
   });
 });

--- a/packages/web/src/ui/__tests__/published-context-wrapper.test.tsx
+++ b/packages/web/src/ui/__tests__/published-context-wrapper.test.tsx
@@ -2,6 +2,10 @@ import { describe, expect, test, afterEach } from "bun:test";
 import { render, cleanup, fireEvent } from "@testing-library/react";
 import { PublishedContextWrapper } from "../components/admin/published-context-wrapper";
 
+const CONNECTION_LABEL = { singular: "connection", plural: "connections" } as const;
+const ENTITY_LABEL = { singular: "entity", plural: "entities" } as const;
+const PROMPT_LABEL = { singular: "prompt collection", plural: "prompt collections" } as const;
+
 describe("PublishedContextWrapper", () => {
   afterEach(() => {
     cleanup();
@@ -10,45 +14,75 @@ describe("PublishedContextWrapper", () => {
   test("renders children wrapped in an inert, non-interactive container", () => {
     const { getByText, container } = render(
       <PublishedContextWrapper
-        resourceLabel="connection"
-        action={{ label: "Create draft", onClick: () => {} }}
+        resourceLabel={CONNECTION_LABEL}
+        action={{ kind: "button", label: "Create draft", onClick: () => {} }}
       >
         <div>Published demo connection</div>
       </PublishedContextWrapper>,
     );
     expect(getByText("Published demo connection")).toBeTruthy();
 
-    // `inert` on the wrapper removes the subtree from tab order AND the
-    // a11y tree. We assert inert directly because pointer-events-none alone
-    // doesn't block keyboard focus — without `inert` a tabbing admin could
-    // trigger row clicks or sort toggles on the "read-only" list.
-    const inertBox = container.querySelector('[inert]');
+    const inertBox = container.querySelector("[inert]");
     expect(inertBox).toBeTruthy();
     expect(inertBox?.className).toContain("pointer-events-none");
     expect(inertBox?.className).toContain("opacity-60");
   });
 
-  test("renders the Published badge + explanatory copy with the resource label", () => {
+  test("inert blocks focus on descendants — a tabbing admin cannot reach the read-only list", () => {
+    // `pointer-events-none` alone doesn't block keyboard focus; `inert`
+    // does. If a future refactor drops `inert` and keeps only
+    // pointer-events-none, this test is the one that fails — preserving
+    // the keyboard-a11y promise made in the wrapper's docstring.
+    const { getByTestId } = render(
+      <PublishedContextWrapper
+        resourceLabel={CONNECTION_LABEL}
+        action={{ kind: "button", label: "Create draft", onClick: () => {} }}
+      >
+        <button data-testid="inside-button" type="button">
+          Published row
+        </button>
+      </PublishedContextWrapper>,
+    );
+    const inside = getByTestId("inside-button") as HTMLButtonElement;
+    inside.focus();
+    expect(document.activeElement).not.toBe(inside);
+  });
+
+  test("renders the Published badge + copy with the singular resource label", () => {
     const { container, getByText } = render(
       <PublishedContextWrapper
-        resourceLabel="connection"
-        action={{ label: "Create draft", onClick: () => {} }}
+        resourceLabel={CONNECTION_LABEL}
+        action={{ kind: "button", label: "Create draft", onClick: () => {} }}
       >
         <div>child</div>
       </PublishedContextWrapper>,
     );
     const badge = container.querySelector('[aria-label="Published — live in production"]');
     expect(badge).toBeTruthy();
-    expect(
-      getByText(/You.*re viewing the live connection list/),
-    ).toBeTruthy();
+    expect(getByText(/You.*re viewing the live connection list/)).toBeTruthy();
   });
 
-  test("renders href-style CTA as a Next.js link", () => {
+  test("uses the plural label in the aria-label (irregular plurals supported)", () => {
+    // Entity → entities is the paradigmatic irregular plural that a naive
+    // `${label}s` implementation would mangle to "entitys".
+    const { getByTestId } = render(
+      <PublishedContextWrapper
+        resourceLabel={ENTITY_LABEL}
+        action={{ kind: "button", label: "Create draft", onClick: () => {} }}
+      >
+        <div>child</div>
+      </PublishedContextWrapper>,
+    );
+    expect(getByTestId("published-context-wrapper").getAttribute("aria-label")).toBe(
+      "Published entities, read-only while in developer mode",
+    );
+  });
+
+  test("renders kind=link action as a Next.js link", () => {
     const { getByRole } = render(
       <PublishedContextWrapper
-        resourceLabel="prompt collection"
-        action={{ label: "Create draft", href: "/admin/prompts/new" }}
+        resourceLabel={PROMPT_LABEL}
+        action={{ kind: "link", label: "Create draft", href: "/admin/prompts/new" }}
       >
         <div>child</div>
       </PublishedContextWrapper>,
@@ -57,12 +91,16 @@ describe("PublishedContextWrapper", () => {
     expect(link.getAttribute("href")).toBe("/admin/prompts/new");
   });
 
-  test("renders onClick-style CTA as a button that fires the handler", () => {
+  test("renders kind=button action as a button that fires the handler", () => {
     let clicked = false;
     const { getByRole } = render(
       <PublishedContextWrapper
-        resourceLabel="connection"
-        action={{ label: "Create draft", onClick: () => { clicked = true; } }}
+        resourceLabel={CONNECTION_LABEL}
+        action={{
+          kind: "button",
+          label: "Create draft",
+          onClick: () => { clicked = true; },
+        }}
       >
         <div>child</div>
       </PublishedContextWrapper>,
@@ -70,20 +108,5 @@ describe("PublishedContextWrapper", () => {
     const button = getByRole("button", { name: /Create draft/ });
     fireEvent.click(button);
     expect(clicked).toBe(true);
-  });
-
-  test("exposes an accessible label that notes the read-only state", () => {
-    const { getByTestId } = render(
-      <PublishedContextWrapper
-        resourceLabel="connection"
-        action={{ label: "Create draft", onClick: () => {} }}
-      >
-        <div>child</div>
-      </PublishedContextWrapper>,
-    );
-    const wrapper = getByTestId("published-context-wrapper");
-    expect(wrapper.getAttribute("aria-label")).toBe(
-      "Published connections, read-only while in developer mode",
-    );
   });
 });

--- a/packages/web/src/ui/__tests__/published-context-wrapper.test.tsx
+++ b/packages/web/src/ui/__tests__/published-context-wrapper.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+import { PublishedContextWrapper } from "../components/admin/published-context-wrapper";
+
+describe("PublishedContextWrapper", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("renders children wrapped in an aria-hidden, non-interactive container", () => {
+    const { getByText, container } = render(
+      <PublishedContextWrapper
+        resourceLabel="connection"
+        action={{ label: "Create draft", onClick: () => {} }}
+      >
+        <div>Published demo connection</div>
+      </PublishedContextWrapper>,
+    );
+    expect(getByText("Published demo connection")).toBeTruthy();
+
+    // The rendered list should be hidden from assistive tech and
+    // non-interactive so admins don't accidentally mutate the live
+    // state while in this "context-only" view.
+    const hidden = container.querySelector('[aria-hidden="true"]');
+    expect(hidden?.className).toContain("pointer-events-none");
+    expect(hidden?.className).toContain("opacity-60");
+  });
+
+  test("renders the Published badge + explanatory copy with the resource label", () => {
+    const { container, getByText } = render(
+      <PublishedContextWrapper
+        resourceLabel="connection"
+        action={{ label: "Create draft", onClick: () => {} }}
+      >
+        <div>child</div>
+      </PublishedContextWrapper>,
+    );
+    const badge = container.querySelector('[aria-label="Published — live in production"]');
+    expect(badge).toBeTruthy();
+    expect(
+      getByText(/You.*re viewing the live connection list/),
+    ).toBeTruthy();
+  });
+
+  test("renders href-style CTA as a Next.js link", () => {
+    const { getByRole } = render(
+      <PublishedContextWrapper
+        resourceLabel="prompt collection"
+        action={{ label: "Create draft", href: "/admin/prompts/new" }}
+      >
+        <div>child</div>
+      </PublishedContextWrapper>,
+    );
+    const link = getByRole("link", { name: /Create draft/ });
+    expect(link.getAttribute("href")).toBe("/admin/prompts/new");
+  });
+
+  test("renders onClick-style CTA as a button that fires the handler", () => {
+    let clicked = false;
+    const { getByRole } = render(
+      <PublishedContextWrapper
+        resourceLabel="connection"
+        action={{ label: "Create draft", onClick: () => { clicked = true; } }}
+      >
+        <div>child</div>
+      </PublishedContextWrapper>,
+    );
+    const button = getByRole("button", { name: /Create draft/ });
+    fireEvent.click(button);
+    expect(clicked).toBe(true);
+  });
+
+  test("exposes an accessible label that notes the read-only state", () => {
+    const { getByTestId } = render(
+      <PublishedContextWrapper
+        resourceLabel="connection"
+        action={{ label: "Create draft", onClick: () => {} }}
+      >
+        <div>child</div>
+      </PublishedContextWrapper>,
+    );
+    const wrapper = getByTestId("published-context-wrapper");
+    expect(wrapper.getAttribute("aria-label")).toBe(
+      "Published connections, read-only while in developer mode",
+    );
+  });
+});

--- a/packages/web/src/ui/__tests__/published-context-wrapper.test.tsx
+++ b/packages/web/src/ui/__tests__/published-context-wrapper.test.tsx
@@ -7,7 +7,7 @@ describe("PublishedContextWrapper", () => {
     cleanup();
   });
 
-  test("renders children wrapped in an aria-hidden, non-interactive container", () => {
+  test("renders children wrapped in an inert, non-interactive container", () => {
     const { getByText, container } = render(
       <PublishedContextWrapper
         resourceLabel="connection"
@@ -18,12 +18,14 @@ describe("PublishedContextWrapper", () => {
     );
     expect(getByText("Published demo connection")).toBeTruthy();
 
-    // The rendered list should be hidden from assistive tech and
-    // non-interactive so admins don't accidentally mutate the live
-    // state while in this "context-only" view.
-    const hidden = container.querySelector('[aria-hidden="true"]');
-    expect(hidden?.className).toContain("pointer-events-none");
-    expect(hidden?.className).toContain("opacity-60");
+    // `inert` on the wrapper removes the subtree from tab order AND the
+    // a11y tree. We assert inert directly because pointer-events-none alone
+    // doesn't block keyboard focus — without `inert` a tabbing admin could
+    // trigger row clicks or sort toggles on the "read-only" list.
+    const inertBox = container.querySelector('[inert]');
+    expect(inertBox).toBeTruthy();
+    expect(inertBox?.className).toContain("pointer-events-none");
+    expect(inertBox?.className).toContain("opacity-60");
   });
 
   test("renders the Published badge + explanatory copy with the resource label", () => {

--- a/packages/web/src/ui/__tests__/semantic-published-banner.test.tsx
+++ b/packages/web/src/ui/__tests__/semantic-published-banner.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { render, cleanup } from "@testing-library/react";
+import { SemanticPublishedBanner } from "../components/admin/semantic-published-banner";
+
+describe("SemanticPublishedBanner", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("renders the PublishedBadge so admins see this is live state", () => {
+    const { container } = render(<SemanticPublishedBanner />);
+    const badge = container.querySelector(
+      '[aria-label="Published — live in production"]',
+    );
+    expect(badge).toBeTruthy();
+  });
+
+  test("explains the state and points at the Add Entity action", () => {
+    const { getByTestId } = render(<SemanticPublishedBanner />);
+    const banner = getByTestId("semantic-published-banner");
+    expect(banner.textContent).toContain("You");
+    expect(banner.textContent).toContain("live semantic layer");
+    expect(banner.textContent).toContain("Add Entity");
+  });
+
+  test("uses amber tint so it visually pairs with the dev-mode banner", () => {
+    const { getByTestId } = render(<SemanticPublishedBanner />);
+    // Restyles within the amber family are acceptable — we only want
+    // the dev-mode visual signal to stick around.
+    expect(getByTestId("semantic-published-banner").className).toContain("amber");
+  });
+});

--- a/packages/web/src/ui/__tests__/use-dev-mode-no-drafts.test.tsx
+++ b/packages/web/src/ui/__tests__/use-dev-mode-no-drafts.test.tsx
@@ -1,0 +1,154 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { renderHook, cleanup } from "@testing-library/react";
+import type {
+  ModeStatusResponse,
+  ModeDraftCounts,
+} from "@useatlas/types/mode";
+
+// Mock the upstream mode hooks BEFORE importing the hook under test.
+const modeState = { mode: "developer" as "developer" | "published" };
+let modeStatusState: {
+  data: ModeStatusResponse | null;
+  loading: boolean;
+} = { data: null, loading: false };
+
+mock.module("@/ui/hooks/use-mode", () => ({
+  useMode: () => ({
+    mode: modeState.mode,
+    setMode: () => {},
+    isAdmin: true,
+    isLoading: false,
+  }),
+}));
+
+mock.module("@/ui/hooks/use-mode-status", () => ({
+  useModeStatus: () => modeStatusState,
+}));
+
+import { useDevModeNoDrafts } from "../hooks/use-dev-mode-no-drafts";
+
+function counts(partial: Partial<ModeDraftCounts> = {}): ModeDraftCounts {
+  return {
+    connections: 0,
+    entities: 0,
+    entityEdits: 0,
+    entityDeletes: 0,
+    prompts: 0,
+    ...partial,
+  };
+}
+
+function status(
+  draftCounts: ModeDraftCounts | null,
+  overrides: Partial<ModeStatusResponse> = {},
+): ModeStatusResponse {
+  return {
+    mode: "developer",
+    canToggle: true,
+    demoIndustry: null,
+    demoConnectionActive: false,
+    hasDrafts: draftCounts !== null,
+    draftCounts,
+    ...overrides,
+  };
+}
+
+describe("useDevModeNoDrafts", () => {
+  beforeEach(() => {
+    modeState.mode = "developer";
+    modeStatusState = { data: null, loading: false };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("returns false when mode is published, regardless of draft counts", () => {
+    modeState.mode = "published";
+    modeStatusState = { data: status(counts()), loading: false };
+    const { result } = renderHook(() => useDevModeNoDrafts(["connections"]));
+    expect(result.current).toBe(false);
+  });
+
+  test("returns false while modeStatus is loading (data is null)", () => {
+    // This is the regression guard: without the null gate, the hook
+    // would resolve to true here and cause a flash of the dev empty
+    // state before /api/v1/mode responds for admins who already have
+    // drafts.
+    modeStatusState = { data: null, loading: true };
+    const { result } = renderHook(() => useDevModeNoDrafts(["connections"]));
+    expect(result.current).toBe(false);
+  });
+
+  test("returns false when modeStatus fetch failed (data is null, not loading)", () => {
+    // Failed fetches surface as `data: null, loading: false`. We must
+    // fail-closed (treat as "might have drafts") so we never show the
+    // dev empty state over work admins have in progress.
+    modeStatusState = { data: null, loading: false };
+    const { result } = renderHook(() => useDevModeNoDrafts(["connections"]));
+    expect(result.current).toBe(false);
+  });
+
+  test("returns true when in developer mode and the requested counter is zero", () => {
+    modeStatusState = { data: status(counts()), loading: false };
+    const { result } = renderHook(() => useDevModeNoDrafts(["connections"]));
+    expect(result.current).toBe(true);
+  });
+
+  test("returns false when the requested counter is non-zero", () => {
+    modeStatusState = {
+      data: status(counts({ connections: 2 })),
+      loading: false,
+    };
+    const { result } = renderHook(() => useDevModeNoDrafts(["connections"]));
+    expect(result.current).toBe(false);
+  });
+
+  test("ignores counters that were not requested (prompts draft, connections gate is true)", () => {
+    modeStatusState = {
+      data: status(counts({ prompts: 3 })),
+      loading: false,
+    };
+    const { result } = renderHook(() => useDevModeNoDrafts(["connections"]));
+    expect(result.current).toBe(true);
+  });
+
+  test("sums multiple counters for the semantic-editor case", () => {
+    // Admin has a draft_delete tombstone but no new drafts or edits.
+    // The hook must still report "has drafts" because the tombstone
+    // affects the published entity list.
+    modeStatusState = {
+      data: status(counts({ entityDeletes: 1 })),
+      loading: false,
+    };
+    const { result } = renderHook(() =>
+      useDevModeNoDrafts(["entities", "entityEdits", "entityDeletes"]),
+    );
+    expect(result.current).toBe(false);
+  });
+
+  test("sums to zero returns true for the semantic-editor case", () => {
+    modeStatusState = { data: status(counts()), loading: false };
+    const { result } = renderHook(() =>
+      useDevModeNoDrafts(["entities", "entityEdits", "entityDeletes"]),
+    );
+    expect(result.current).toBe(true);
+  });
+
+  test("handles a null draftCounts field (API optimization when no drafts)", () => {
+    // The API returns draftCounts: null when there are no drafts at
+    // all. The `?? 0` must treat this the same as an all-zero object.
+    modeStatusState = { data: status(null), loading: false };
+    const { result } = renderHook(() => useDevModeNoDrafts(["connections"]));
+    expect(result.current).toBe(true);
+  });
+
+  test("a non-admin in published mode cannot trigger the empty state", () => {
+    // Non-admins are forced to published mode by useMode; the hook
+    // short-circuits at the mode check and never inspects status.
+    modeState.mode = "published";
+    modeStatusState = { data: null, loading: false };
+    const { result } = renderHook(() => useDevModeNoDrafts(["connections"]));
+    expect(result.current).toBe(false);
+  });
+});

--- a/packages/web/src/ui/components/admin/developer-empty-state.tsx
+++ b/packages/web/src/ui/components/admin/developer-empty-state.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export type DeveloperEmptyStateAction =
+  | { label: string; href: string }
+  | { label: string; onClick: () => void };
+
+export interface DeveloperEmptyStateProps {
+  icon: LucideIcon;
+  title: string;
+  description?: string;
+  action?: DeveloperEmptyStateAction;
+}
+
+/**
+ * Empty state shown to admins in developer mode when they haven't drafted
+ * anything yet for a given resource (#1436).
+ *
+ * Visually distinct from the generic `EmptyState` — an amber accent bar
+ * mirrors the developer-mode banner so admins recognize this as a dev-mode
+ * prompt rather than a real "no data" error. Supports either a link CTA
+ * (navigates to another admin surface) or an onClick CTA (opens a dialog on
+ * the current page).
+ */
+export function DeveloperEmptyState({
+  icon: Icon,
+  title,
+  description,
+  action,
+}: DeveloperEmptyStateProps) {
+  return (
+    <div
+      role="status"
+      data-testid="developer-empty-state"
+      className="flex h-64 items-center justify-center"
+    >
+      <div className="max-w-md rounded-lg border border-amber-300/60 bg-amber-50/40 px-6 py-8 text-center dark:border-amber-700/40 dark:bg-amber-950/10">
+        <Icon
+          className="mx-auto size-10 text-amber-600 opacity-80 dark:text-amber-400"
+          aria-hidden="true"
+        />
+        <p className="mt-3 text-sm font-medium text-foreground">{title}</p>
+        {description && (
+          <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+        )}
+        {action && (
+          <div className="mt-4">
+            {"href" in action ? (
+              <Button asChild size="sm" variant="default">
+                <Link href={action.href}>{action.label}</Link>
+              </Button>
+            ) : (
+              <Button size="sm" variant="default" onClick={action.onClick}>
+                {action.label}
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/ui/components/admin/developer-empty-state.tsx
+++ b/packages/web/src/ui/components/admin/developer-empty-state.tsx
@@ -3,27 +3,24 @@
 import type { LucideIcon } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-
-export type DeveloperEmptyStateAction =
-  | { label: string; href: string }
-  | { label: string; onClick: () => void };
+import type { EmptyStateAction } from "./empty-state-types";
 
 export interface DeveloperEmptyStateProps {
   icon: LucideIcon;
   title: string;
   description?: string;
-  action?: DeveloperEmptyStateAction;
+  action?: EmptyStateAction;
 }
 
 /**
  * Empty state shown to admins in developer mode when they haven't drafted
- * anything yet for a given resource (#1436).
+ * anything yet for a given resource.
  *
  * Visually distinct from the generic `EmptyState` — an amber accent bar
  * mirrors the developer-mode banner so admins recognize this as a dev-mode
  * prompt rather than a real "no data" error. Supports either a link CTA
  * (navigates to another admin surface) or an onClick CTA (opens a dialog on
- * the current page).
+ * the current page) via the tagged `EmptyStateAction` union.
  */
 export function DeveloperEmptyState({
   icon: Icon,
@@ -48,7 +45,7 @@ export function DeveloperEmptyState({
         )}
         {action && (
           <div className="mt-4">
-            {"href" in action ? (
+            {action.kind === "link" ? (
               <Button asChild size="sm" variant="default">
                 <Link href={action.href}>{action.label}</Link>
               </Button>

--- a/packages/web/src/ui/components/admin/empty-state-types.ts
+++ b/packages/web/src/ui/components/admin/empty-state-types.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared action shape for developer-mode empty states and their
+ * published-context wrapper. Tagged with `kind` so structural narrowing is
+ * exhaustive and object literals typed at a call site can't silently ship
+ * with both `href` and `onClick` fields.
+ */
+export type EmptyStateAction =
+  | { kind: "link"; label: string; href: string }
+  | { kind: "button"; label: string; onClick: () => void };
+
+/**
+ * Singular/plural pair for a resource label. Passed as a pair rather than
+ * letting the callee suffix "s", so irregular plurals ("entity" → "entities")
+ * render correctly in aria-labels and user-facing copy.
+ */
+export interface ResourceLabel {
+  readonly singular: string;
+  readonly plural: string;
+}

--- a/packages/web/src/ui/components/admin/mode-badges.tsx
+++ b/packages/web/src/ui/components/admin/mode-badges.tsx
@@ -46,3 +46,25 @@ export function DraftBadge({ className }: { className?: string }) {
     </Badge>
   );
 }
+
+/**
+ * "Published" pill shown when developer-mode surfaces render live/published
+ * items as read-only context (e.g. a demo connection shown while the admin
+ * hasn't drafted anything yet). Emerald tint reads as "live", distinct from
+ * the amber "Draft" pill and the neutral "Demo" pill.
+ */
+export function PublishedBadge({ className }: { className?: string }) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "border-emerald-300 bg-emerald-50 px-1.5 py-0 text-[10px] font-medium text-emerald-700 dark:border-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-400",
+        className,
+      )}
+      aria-label="Published — live in production"
+      title="Published — live in production"
+    >
+      Published
+    </Badge>
+  );
+}

--- a/packages/web/src/ui/components/admin/published-context-wrapper.tsx
+++ b/packages/web/src/ui/components/admin/published-context-wrapper.tsx
@@ -48,13 +48,15 @@ export function PublishedContextWrapper({
         </span>
       </div>
       {/*
-        opacity-60 + pointer-events-none signal read-only visually and
-        programmatically. aria-hidden tells assistive tech to skip the list
-        — the CTA below is where the admin should focus.
+        opacity-60 + pointer-events-none signal read-only visually.
+        `inert` removes the subtree from the tab order and the a11y tree
+        in one go — pointer-events-none alone doesn't block keyboard focus,
+        so without `inert` a tabbing admin could still trigger row clicks
+        or sort toggles on the "read-only" list.
       */}
       <div
         className="pointer-events-none select-none opacity-60"
-        aria-hidden="true"
+        inert
       >
         {children}
       </div>

--- a/packages/web/src/ui/components/admin/published-context-wrapper.tsx
+++ b/packages/web/src/ui/components/admin/published-context-wrapper.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Plus } from "lucide-react";
+import { PublishedBadge } from "@/ui/components/admin/mode-badges";
+
+export interface PublishedContextWrapperProps {
+  /** The already-rendered content (list/table of published items). */
+  children: ReactNode;
+  /** Short label describing the resource in singular form ("connection", "prompt collection"). */
+  resourceLabel: string;
+  /** CTA to start drafting — either an href (navigates) or onClick (opens a dialog on this page). */
+  action:
+    | { label: string; href: string }
+    | { label: string; onClick: () => void };
+  className?: string;
+}
+
+/**
+ * Renders a page's published items as grayed-out, non-interactive context
+ * above a "Create draft" CTA. Used in developer mode when an admin has not
+ * yet drafted anything for a resource — the current published state is still
+ * visible (so the admin can see what's live) but clearly marked as read-only
+ * (#1436).
+ *
+ * This is purely presentational: mode detection and draft-count checks live
+ * in the caller so pages remain in control of when to render it.
+ */
+export function PublishedContextWrapper({
+  children,
+  resourceLabel,
+  action,
+  className,
+}: PublishedContextWrapperProps) {
+  return (
+    <div
+      className={className}
+      data-testid="published-context-wrapper"
+      aria-label={`Published ${resourceLabel}s, read-only while in developer mode`}
+    >
+      <div className="mb-3 flex items-center gap-2 text-xs text-muted-foreground">
+        <PublishedBadge />
+        <span>
+          You&rsquo;re viewing the live {resourceLabel} list. Create a draft to
+          start editing.
+        </span>
+      </div>
+      {/*
+        opacity-60 + pointer-events-none signal read-only visually and
+        programmatically. aria-hidden tells assistive tech to skip the list
+        — the CTA below is where the admin should focus.
+      */}
+      <div
+        className="pointer-events-none select-none opacity-60"
+        aria-hidden="true"
+      >
+        {children}
+      </div>
+      <div className="mt-4 flex justify-center">
+        {"href" in action ? (
+          <Button asChild size="sm" variant="default">
+            <Link href={action.href}>
+              <Plus className="mr-1.5 size-3.5" />
+              {action.label}
+            </Link>
+          </Button>
+        ) : (
+          <Button size="sm" variant="default" onClick={action.onClick}>
+            <Plus className="mr-1.5 size-3.5" />
+            {action.label}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/ui/components/admin/published-context-wrapper.tsx
+++ b/packages/web/src/ui/components/admin/published-context-wrapper.tsx
@@ -5,16 +5,20 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
 import { PublishedBadge } from "@/ui/components/admin/mode-badges";
+import type {
+  EmptyStateAction,
+  ResourceLabel,
+} from "./empty-state-types";
 
 export interface PublishedContextWrapperProps {
   /** The already-rendered content (list/table of published items). */
   children: ReactNode;
-  /** Short label describing the resource in singular form ("connection", "prompt collection"). */
-  resourceLabel: string;
-  /** CTA to start drafting — either an href (navigates) or onClick (opens a dialog on this page). */
-  action:
-    | { label: string; href: string }
-    | { label: string; onClick: () => void };
+  /** Singular + plural label pair — plural is used in the aria-label so
+   *  irregular plurals ("entity" → "entities") render correctly. */
+  resourceLabel: ResourceLabel;
+  /** CTA to start drafting — either a link (navigates) or a button (opens
+   *  a dialog on this page). See `EmptyStateAction`. */
+  action: EmptyStateAction;
   className?: string;
 }
 
@@ -22,11 +26,11 @@ export interface PublishedContextWrapperProps {
  * Renders a page's published items as grayed-out, non-interactive context
  * above a "Create draft" CTA. Used in developer mode when an admin has not
  * yet drafted anything for a resource — the current published state is still
- * visible (so the admin can see what's live) but clearly marked as read-only
- * (#1436).
+ * visible (so the admin can see what's live) but clearly marked as read-only.
  *
  * This is purely presentational: mode detection and draft-count checks live
- * in the caller so pages remain in control of when to render it.
+ * in the caller (`useDevModeNoDrafts`) so pages remain in control of when
+ * to render it.
  */
 export function PublishedContextWrapper({
   children,
@@ -38,21 +42,21 @@ export function PublishedContextWrapper({
     <div
       className={className}
       data-testid="published-context-wrapper"
-      aria-label={`Published ${resourceLabel}s, read-only while in developer mode`}
+      aria-label={`Published ${resourceLabel.plural}, read-only while in developer mode`}
     >
       <div className="mb-3 flex items-center gap-2 text-xs text-muted-foreground">
         <PublishedBadge />
         <span>
-          You&rsquo;re viewing the live {resourceLabel} list. Create a draft to
-          start editing.
+          You&rsquo;re viewing the live {resourceLabel.singular} list. Create
+          a draft to start editing.
         </span>
       </div>
       {/*
-        opacity-60 + pointer-events-none signal read-only visually.
-        `inert` removes the subtree from the tab order and the a11y tree
-        in one go — pointer-events-none alone doesn't block keyboard focus,
-        so without `inert` a tabbing admin could still trigger row clicks
-        or sort toggles on the "read-only" list.
+        `inert` removes the subtree from tab order AND the a11y tree in one
+        go — pointer-events-none alone doesn't block keyboard focus, so
+        without `inert` a tabbing admin could trigger row clicks or sort
+        toggles on the "read-only" list. opacity-60 carries the visual
+        signal; select-none blocks accidental text selection.
       */}
       <div
         className="pointer-events-none select-none opacity-60"
@@ -61,7 +65,7 @@ export function PublishedContextWrapper({
         {children}
       </div>
       <div className="mt-4 flex justify-center">
-        {"href" in action ? (
+        {action.kind === "link" ? (
           <Button asChild size="sm" variant="default">
             <Link href={action.href}>
               <Plus className="mr-1.5 size-3.5" />

--- a/packages/web/src/ui/components/admin/semantic-published-banner.tsx
+++ b/packages/web/src/ui/components/admin/semantic-published-banner.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { PublishedBadge } from "@/ui/components/admin/mode-badges";
+
+/**
+ * Thin notice rendered above the semantic-editor file tree when an admin
+ * is in developer mode, has no entity drafts, and published entities
+ * exist (e.g. a seeded `__demo__` workspace). Makes "what you see is live"
+ * explicit without graying out the tree — admins still need to browse
+ * entities to decide what to draft.
+ */
+export function SemanticPublishedBanner() {
+  return (
+    <div
+      role="note"
+      data-testid="semantic-published-banner"
+      className="flex items-center gap-2 border-b bg-amber-50/40 px-6 py-2.5 text-xs text-muted-foreground dark:bg-amber-950/10"
+    >
+      <PublishedBadge />
+      <span>
+        You&rsquo;re viewing the live semantic layer. Use{" "}
+        <span className="font-medium">Add Entity</span> to start a draft.
+      </span>
+    </div>
+  );
+}

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -17,8 +17,7 @@ import { STARTER_PROMPTS } from "./chat/starter-prompts";
 import { FollowUpChips } from "./chat/follow-up-chips";
 import { SuggestionChips } from "./chat/suggestion-chips";
 import { DeveloperChatEmptyState } from "./chat/developer-empty-state";
-import { useMode } from "../hooks/use-mode";
-import { useModeStatus } from "../hooks/use-mode-status";
+import { useDevModeNoDrafts } from "../hooks/use-dev-mode-no-drafts";
 import type { QuerySuggestion } from "@/ui/lib/types";
 import { ShareDialog } from "./chat/share-dialog";
 import { ConversationSidebar } from "./conversations/conversation-sidebar";
@@ -131,17 +130,10 @@ function SaveButton({
 
 export function AtlasChat() {
   const { apiUrl, isCrossOrigin, authClient } = useAtlasConfig();
-  const { mode } = useMode();
-  const { data: modeStatus } = useModeStatus();
   // In developer mode the chat talks to draft connections. If the admin
-  // hasn't drafted one yet, surface a dedicated empty state (#1436) instead
-  // of letting the agent fail with a confusing "no datasource" error. Gate
-  // on `modeStatus !== null` so the composer doesn't flash hidden before
-  // /api/v1/mode resolves.
-  const showDevChatEmpty =
-    mode === "developer" && modeStatus !== null
-      ? (modeStatus.draftCounts?.connections ?? 0) === 0
-      : false;
+  // hasn't drafted one yet, surface a dedicated empty state instead of
+  // letting the agent fail with a confusing "no datasource" error.
+  const showDevChatEmpty = useDevModeNoDrafts(["connections"]);
   const [input, setInput] = useState("");
   const [conversationId, setConversationId] = useState<string | null>(null);
   const [transientWarning, setTransientWarning] = useState("");

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -16,6 +16,9 @@ import { Markdown } from "./chat/markdown";
 import { STARTER_PROMPTS } from "./chat/starter-prompts";
 import { FollowUpChips } from "./chat/follow-up-chips";
 import { SuggestionChips } from "./chat/suggestion-chips";
+import { DeveloperChatEmptyState } from "./chat/developer-empty-state";
+import { useMode } from "../hooks/use-mode";
+import { useModeStatus } from "../hooks/use-mode-status";
 import type { QuerySuggestion } from "@/ui/lib/types";
 import { ShareDialog } from "./chat/share-dialog";
 import { ConversationSidebar } from "./conversations/conversation-sidebar";
@@ -128,6 +131,13 @@ function SaveButton({
 
 export function AtlasChat() {
   const { apiUrl, isCrossOrigin, authClient } = useAtlasConfig();
+  const { mode } = useMode();
+  const { data: modeStatus } = useModeStatus();
+  // In developer mode the chat talks to draft connections. If the admin
+  // hasn't drafted one yet, surface a dedicated empty state (#1436) instead
+  // of letting the agent fail with a confusing "no datasource" error.
+  const showDevChatEmpty =
+    mode === "developer" && (modeStatus?.draftCounts?.connections ?? 0) === 0;
   const [input, setInput] = useState("");
   const [conversationId, setConversationId] = useState<string | null>(null);
   const [transientWarning, setTransientWarning] = useState("");
@@ -471,6 +481,9 @@ export function AtlasChat() {
                 >
                 <div className="space-y-4 pb-4 pr-3">
                   {messages.length === 0 && !error && (
+                    showDevChatEmpty ? (
+                      <DeveloperChatEmptyState />
+                    ) : (
                     <div className="flex h-full flex-col items-center justify-center gap-6">
                       <div className="text-center">
                         <p className="text-lg font-medium text-zinc-500 dark:text-zinc-400">
@@ -507,6 +520,7 @@ export function AtlasChat() {
                         Browse prompt library
                       </Button>
                     </div>
+                    )
                   )}
 
                   {messages.map((m, msgIndex) => {

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -135,9 +135,13 @@ export function AtlasChat() {
   const { data: modeStatus } = useModeStatus();
   // In developer mode the chat talks to draft connections. If the admin
   // hasn't drafted one yet, surface a dedicated empty state (#1436) instead
-  // of letting the agent fail with a confusing "no datasource" error.
+  // of letting the agent fail with a confusing "no datasource" error. Gate
+  // on `modeStatus !== null` so the composer doesn't flash hidden before
+  // /api/v1/mode resolves.
   const showDevChatEmpty =
-    mode === "developer" && (modeStatus?.draftCounts?.connections ?? 0) === 0;
+    mode === "developer" && modeStatus !== null
+      ? (modeStatus.draftCounts?.connections ?? 0) === 0
+      : false;
   const [input, setInput] = useState("");
   const [conversationId, setConversationId] = useState<string | null>(null);
   const [transientWarning, setTransientWarning] = useState("");

--- a/packages/web/src/ui/components/chat/developer-empty-state.tsx
+++ b/packages/web/src/ui/components/chat/developer-empty-state.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import Link from "next/link";
+import { Database, ArrowRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Shown in the chat surface when an admin is in developer mode but has no
+ * draft connections (#1436). Without this, sending a message would let the
+ * agent run against nothing and surface a confusing error — instead we
+ * redirect them to the admin connections page where they can draft one.
+ */
+export function DeveloperChatEmptyState() {
+  return (
+    <div
+      role="status"
+      data-testid="developer-chat-empty-state"
+      className="flex h-full flex-col items-center justify-center gap-4"
+    >
+      <div className="max-w-md rounded-lg border border-amber-300/60 bg-amber-50/40 px-6 py-8 text-center dark:border-amber-700/40 dark:bg-amber-950/10">
+        <Database
+          className="mx-auto size-10 text-amber-600 opacity-80 dark:text-amber-400"
+          aria-hidden="true"
+        />
+        <p className="mt-3 text-sm font-medium text-foreground">
+          No connection configured in developer mode.
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Connect a database in the admin panel to start testing.
+        </p>
+        <div className="mt-4">
+          <Button asChild size="sm" variant="default">
+            <Link href="/admin/connections">
+              Go to connections
+              <ArrowRight className="ml-1.5 size-3.5" />
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/ui/components/chat/developer-empty-state.tsx
+++ b/packages/web/src/ui/components/chat/developer-empty-state.tsx
@@ -6,9 +6,9 @@ import { Button } from "@/components/ui/button";
 
 /**
  * Shown in the chat surface when an admin is in developer mode but has no
- * draft connections (#1436). Without this, sending a message would let the
- * agent run against nothing and surface a confusing error — instead we
- * redirect them to the admin connections page where they can draft one.
+ * draft connections. Without this, sending a message would let the agent
+ * run against nothing and surface a confusing error — instead we redirect
+ * them to the admin connections page where they can draft one.
  */
 export function DeveloperChatEmptyState() {
   return (

--- a/packages/web/src/ui/hooks/use-dev-mode-no-drafts.ts
+++ b/packages/web/src/ui/hooks/use-dev-mode-no-drafts.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useMode } from "@/ui/hooks/use-mode";
+import { useModeStatus } from "@/ui/hooks/use-mode-status";
+import type { ModeDraftCounts } from "@useatlas/types/mode";
+
+/**
+ * Keys on `ModeDraftCounts` that a caller can select when computing whether
+ * the admin has any relevant drafts for a given admin surface.
+ */
+export type DraftCounter = keyof ModeDraftCounts;
+
+/**
+ * True iff the admin is in developer mode, `/api/v1/mode` has resolved, and
+ * the sum of the requested draft counters is zero.
+ *
+ * Used by admin surfaces (and the chat) that switch to a focused empty
+ * state when the admin has toggled into developer mode but hasn't drafted
+ * anything yet.
+ *
+ * The `modeStatus !== null` gate matters: `useModeStatus` returns `null`
+ * while the query is in flight AND on failure (its retry is disabled).
+ * Without the gate, admins with drafts would briefly see the dev-mode
+ * empty state flash while the fetch is pending — or indefinitely if the
+ * fetch fails.
+ *
+ * @param counters Which draft counters contribute to the "has drafts" sum.
+ *   - `["connections"]` for the connections page and chat
+ *   - `["prompts"]` for the prompts page
+ *   - `["entities", "entityEdits", "entityDeletes"]` for the semantic editor
+ */
+export function useDevModeNoDrafts(counters: readonly DraftCounter[]): boolean {
+  const { mode } = useMode();
+  const { data: modeStatus } = useModeStatus();
+
+  if (mode !== "developer") return false;
+  if (modeStatus === null) return false;
+
+  let total = 0;
+  for (const key of counters) {
+    total += modeStatus.draftCounts?.[key] ?? 0;
+  }
+  return total === 0;
+}


### PR DESCRIPTION
## Summary

- Render focused empty states on admin surfaces (connections, semantic editor, schema diff, prompts) and the chat when an admin is in developer mode but hasn't drafted anything yet.
- When published items exist (e.g. a seeded `__demo__` connection), wrap them in a grayed-out "Published" context with a "Create draft" CTA so admins can see live state without editing it by mistake.
- Adds a new `PublishedBadge`, a reusable `DeveloperEmptyState`, and a `PublishedContextWrapper` to the admin UI kit.

## What changed per surface

| Surface | Dev-mode + no drafts + no published | Dev-mode + no drafts + published exists |
|---|---|---|
| `/admin/connections` | "Connect your first database…" → opens Add Connection dialog | list grayed-out with "Create draft" CTA |
| `/admin/semantic` | "Import your schema after connecting a database." → `/admin/connections` | Published banner at top of content area; tree stays interactive |
| `/admin/schema-diff` | "Nothing to diff — no developer mode connection yet." → `/admin/connections` | n/a (no CTA case) |
| `/admin/prompts` | "Create prompt collections to help your users…" → new-collection dialog | collection list grayed-out with "Create draft collection" CTA |
| Chat | "No connection configured in developer mode…" → `/admin/connections` | (same empty state — no draft connection means chat can't function) |

All empty states use amber accent to pair visually with the developer-mode banner. Published mode surfaces are untouched.

## How it works

- `useMode()` tells us the effective mode for the current session.
- `useModeStatus().data.draftCounts` tells us the per-resource draft count sourced from `GET /api/v1/mode` (no new fetch).
- Pages compute `inDevMode && draftCounts.X === 0` locally and branch on that.

## Test plan

- [x] `bun run lint`
- [x] `bun run type`
- [x] `bun run test` (full suite — all packages green)
- [x] `bun x syncpack lint`
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh`
- [x] New unit tests:
  - `developer-empty-state.test.tsx` — icon/title/description, href CTA, onClick CTA, no CTA, amber styling
  - `published-context-wrapper.test.tsx` — children hidden + non-interactive, Published badge present, href and onClick CTAs, aria-label
  - `developer-chat-empty-state.test.tsx` — copy, CTA link, amber styling
  - `mode-badges.test.tsx` extended for `PublishedBadge` (text, a11y, emerald tint)
- [ ] Manual verification — flip into developer mode on each page, confirm empty state + published-context behavior
- [ ] Manual verification — flip back to published mode, confirm no empty states render

Closes #1436