### PR TITLE
fix(db): backfill organization SaaS columns on fresh installs (#1472)

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -1198,6 +1198,7 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
 - [x] Scaffold types.ts — `ADMIN_ROLES`/`ATLAS_MODES` missing from published `@useatlas/types` (PRs #1457, #1458 — bumped to `0.0.11`, consumer refs updated; #1448 closed as superseded)
 - [ ] `admin-publish` reads `demo_industry` setting with wrong key — Phase 4b skips demo-prompt archive (#1466)
 - [ ] `readDemoIndustry` silent fallback drops prompt cascade on read failure (#1470)
+- [ ] Organization SaaS columns skipped on first-boot migrations — blocks `checkResourceLimit` (#1472)
 
 ---
 

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -36,16 +36,19 @@ function createTrackingPool(opts: { shouldThrow?: boolean } = {}) {
 // Mock auth instance for Better Auth migration tracking
 // ---------------------------------------------------------------------------
 
-function createTrackingAuth(opts: { shouldThrow?: boolean } = {}) {
+function createTrackingAuth(opts: { shouldThrow?: boolean; onMigrate?: () => void } = {}) {
   let migrationCount = 0;
   return {
     instance: {
       $context: Promise.resolve({
         runMigrations: async () => {
           if (opts.shouldThrow) throw new Error("Better Auth migration error");
+          opts.onMigrate?.();
           migrationCount++;
         },
       }),
+      // Stub so the api access in seedDevUser doesn't throw — tests don't assert seed behavior.
+      api: {},
     },
     getMigrationCount: () => migrationCount,
   };
@@ -269,6 +272,7 @@ describe("migrateAuthTables", () => {
             { name: "0024_mode_status_columns.sql" },
             { name: "0025_fix_null_unsafe_indexes.sql" },
             { name: "0026_drop_legacy_semantic_entity_index.sql" },
+            { name: "0027_organization_saas_columns.sql" },
           ],
         };
       }
@@ -288,5 +292,91 @@ describe("migrateAuthTables", () => {
 
     // Should NOT have a BEGIN/COMMIT since all migrations were already applied
     expect(queries).not.toContain("BEGIN");
+  });
+
+  it("runs Better Auth migrations BEFORE Atlas internal migrations in managed mode (#1472)", async () => {
+    // Reproduces the boot-ordering bug: if Atlas migrations run before Better Auth
+    // creates the organization table, the conditional ALTERs in 0000/0020 silently
+    // skip and get marked applied, leaving organization missing SaaS columns forever.
+    process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/atlas";
+    process.env.BETTER_AUTH_SECRET = "a".repeat(32);
+
+    let betterAuthRanAt: number | null = null;
+    let firstAtlasQueryAt: number | null = null;
+    let counter = 0;
+
+    const queries: string[] = [];
+    async function queryFn(sql: string) {
+      const ts = ++counter;
+      queries.push(sql);
+      // First non-locking query that touches Atlas internal tables marks the start
+      // of the Atlas migration phase. The advisory lock + tracking-table CREATE
+      // are part of runMigrations(), so observing any of these means Atlas
+      // migrations have begun.
+      if (firstAtlasQueryAt === null && (sql.includes("__atlas_migrations") || sql.includes("pg_advisory_lock"))) {
+        firstAtlasQueryAt = ts;
+      }
+      return { rows: [] };
+    }
+    const pool = {
+      query: queryFn,
+      async connect() {
+        return { query: queryFn, release() {} };
+      },
+      async end() {},
+      on() {},
+    };
+    _resetPool(pool);
+
+    const { instance } = createTrackingAuth({
+      onMigrate: () => {
+        betterAuthRanAt = ++counter;
+      },
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- injecting partial auth mock for testing
+    _setAuthInstance(instance as any);
+
+    await migrateAuthTables();
+
+    expect(betterAuthRanAt).not.toBeNull();
+    expect(firstAtlasQueryAt).not.toBeNull();
+    expect(betterAuthRanAt!).toBeLessThan(firstAtlasQueryAt!);
+  });
+
+  it("skips 0027_organization_saas_columns.sql in non-managed mode", async () => {
+    // In non-managed mode, Better Auth never creates the organization table.
+    // Migration 0027's unconditional ALTER would fail with a misleading error.
+    // The runner must be told to skip it.
+    process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/atlas";
+    delete process.env.BETTER_AUTH_SECRET;
+
+    const queries: string[] = [];
+    const params: unknown[][] = [];
+    async function queryFn(sql: string, p?: unknown[]) {
+      queries.push(sql);
+      if (p) params.push(p);
+      return { rows: [] };
+    }
+    const pool = {
+      query: queryFn,
+      async connect() {
+        return { query: queryFn, release() {} };
+      },
+      async end() {},
+      on() {},
+    };
+    _resetPool(pool);
+
+    await migrateAuthTables();
+
+    // 0027 SQL never runs — match the issue reference unique to that file
+    const orgSaasMigration = queries.find((q) => q.includes("issues/1472"));
+    expect(orgSaasMigration).toBeUndefined();
+
+    // 0027 is not recorded as applied
+    const insertedNames = params
+      .filter((p) => p.length === 1 && typeof p[0] === "string")
+      .map((p) => p[0] as string);
+    expect(insertedNames).not.toContain("0027_organization_saas_columns.sql");
   });
 });

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -379,4 +379,89 @@ describe("migrateAuthTables", () => {
       .map((p) => p[0] as string);
     expect(insertedNames).not.toContain("0027_organization_saas_columns.sql");
   });
+
+  it("still runs Atlas internal migrations when Better Auth migration fails (#1472 contract)", async () => {
+    // The boot reorder runs Better Auth first, but a Better Auth failure must
+    // not block Atlas migrations — operators still need audit_log, connections,
+    // and the rest of the internal schema. The 0027 RAISE EXCEPTION is the
+    // safety net for the resulting "missing organization" state — surfaces
+    // the bug loudly rather than silently re-creating the half-migrated state.
+    process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/atlas";
+    process.env.BETTER_AUTH_SECRET = "a".repeat(32);
+
+    const queries: string[] = [];
+    async function queryFn(sql: string) {
+      queries.push(sql);
+      return { rows: [] };
+    }
+    const pool = {
+      query: queryFn,
+      async connect() {
+        return { query: queryFn, release() {} };
+      },
+      async end() {},
+      on() {},
+    };
+    _resetPool(pool);
+
+    const { instance } = createTrackingAuth({ shouldThrow: true });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- injecting partial auth mock for testing
+    _setAuthInstance(instance as any);
+
+    await migrateAuthTables();
+
+    // Better Auth failure was recorded.
+    const err = getMigrationError();
+    expect(err).toBeString();
+    expect(err).toContain("Better Auth migration failed");
+
+    // Atlas migrations still ran — the advisory lock is the first internal-DB
+    // query, so its presence proves runMigrations() executed despite the
+    // Better Auth failure.
+    const lockQuery = queries.find((q) => q.includes("pg_advisory_lock"));
+    expect(lockQuery).toBeDefined();
+  });
+
+  it("recovers on next boot after a non-managed → managed transition", async () => {
+    // First boot in non-managed mode: 0027 is skipped and NOT recorded.
+    // Second boot in managed mode: 0027 must be picked up automatically.
+    // Pins the recovery contract documented on RunMigrationsOptions.skip.
+    const recordedNames: string[] = [];
+    let appliedSnapshot: string[] = [];
+
+    function makePool() {
+      async function queryFn(sql: string, p?: unknown[]) {
+        if (sql.includes("INSERT INTO __atlas_migrations") && p && typeof p[0] === "string") {
+          recordedNames.push(p[0]);
+        }
+        if (sql.includes("SELECT name FROM __atlas_migrations")) {
+          return { rows: appliedSnapshot.map((name) => ({ name })) };
+        }
+        return { rows: [] };
+      }
+      return {
+        query: queryFn,
+        async connect() {
+          return { query: queryFn, release() {} };
+        },
+      };
+    }
+
+    const { runMigrations } = await import("@atlas/api/lib/db/migrate");
+
+    // Pass 1: non-managed — skip 0027.
+    await runMigrations(makePool(), { skip: ["0027_organization_saas_columns.sql"] });
+    expect(recordedNames).not.toContain("0027_organization_saas_columns.sql");
+    expect(recordedNames).toContain("0000_baseline.sql");
+
+    // Pass 2: managed — no skip; only previously-unrecorded files run.
+    appliedSnapshot = [...recordedNames];
+    const beforeCount = recordedNames.length;
+    await runMigrations(makePool(), { skip: [] });
+
+    const newlyRecorded = recordedNames.slice(beforeCount);
+    expect(newlyRecorded).toContain("0027_organization_saas_columns.sql");
+    // Already-applied files do not re-run.
+    expect(newlyRecorded).not.toContain("0000_baseline.sql");
+  });
 });

--- a/packages/api/src/lib/auth/migrate.ts
+++ b/packages/api/src/lib/auth/migrate.ts
@@ -38,8 +38,10 @@ export function getMigrationError(): string | null {
  *   3. Load saved connections, plugin settings, abuse state.
  *   4. Bootstrap admin, seed dev user, backfill password-change flag.
  *
- * Step 1 must precede step 2 — see #1472. In non-managed mode the Better Auth
- * step is skipped and Atlas migrations skip the org-dependent files.
+ * Step 1 must precede step 2 — see #1472. In non-managed mode step 1 is
+ * skipped; the Atlas migration runner independently skips org-dependent
+ * files based on `detectAuthMode()`, so 0027 is not attempted without
+ * Better Auth having created the table.
  */
 export async function migrateAuthTables(): Promise<void> {
   if (_migrated) return;
@@ -58,14 +60,16 @@ export async function migrateAuthTables(): Promise<void> {
 
       // Add password_change_required column to Better Auth's user table.
       // Must run AFTER Better Auth migrations (which create the "user" table).
+      // If this fails, Better Auth's migration likely misreported success and
+      // managed auth itself may be broken — log loudly.
       try {
         await internalQuery(
           `ALTER TABLE "user" ADD COLUMN IF NOT EXISTS password_change_required BOOLEAN NOT NULL DEFAULT false`,
         );
       } catch (err) {
-        log.warn(
+        log.error(
           { err: err instanceof Error ? err.message : String(err) },
-          "Could not add password_change_required column — password change enforcement will be skipped",
+          "Could not add password_change_required column — Better Auth user table may be missing or unwritable; password change enforcement will be skipped",
         );
       }
     } catch (err) {
@@ -117,13 +121,33 @@ export async function migrateAuthTables(): Promise<void> {
   }
 
   // 4. Bootstrap + seed (managed mode only — needs Better Auth `user` table).
+  //    Each phase has its own internal try/catch; the wrappers here catch
+  //    unexpected programming errors (e.g. API surface drift) so a failure in
+  //    one phase doesn't skip the next.
   if (auth) {
     try {
       await bootstrapAdminUser();
+    } catch (err) {
+      log.error(
+        { err: err instanceof Error ? err.message : String(err) },
+        "Bootstrap admin promotion failed unexpectedly — admin console may be inaccessible",
+      );
+    }
+    try {
       await seedDevUser(auth);
+    } catch (err) {
+      log.error(
+        { err: err instanceof Error ? err.message : String(err) },
+        "Dev user seed failed unexpectedly — first-run admin/org/demo data may be missing",
+      );
+    }
+    try {
       await backfillPasswordChangeFlag();
     } catch (err) {
-      log.error({ err }, "Admin bootstrap or dev seed failed — managed auth still functional");
+      log.error(
+        { err: err instanceof Error ? err.message : String(err) },
+        "Backfill password-change flag failed unexpectedly",
+      );
     }
   }
 

--- a/packages/api/src/lib/auth/migrate.ts
+++ b/packages/api/src/lib/auth/migrate.ts
@@ -30,11 +30,56 @@ export function getMigrationError(): string | null {
  *
  * Safe to call multiple times — only runs once (idempotent guard).
  * Also runs the internal DB migration (audit_log table).
+ *
+ * Boot ordering (managed auth, with internal DB):
+ *   1. Better Auth migrations — create `organization`, `user`, `session`, etc.
+ *   2. Atlas internal DB migrations — can ALTER `organization` (e.g. 0027) now
+ *      that Better Auth has created it.
+ *   3. Load saved connections, plugin settings, abuse state.
+ *   4. Bootstrap admin, seed dev user, backfill password-change flag.
+ *
+ * Step 1 must precede step 2 — see #1472. In non-managed mode the Better Auth
+ * step is skipped and Atlas migrations skip the org-dependent files.
  */
 export async function migrateAuthTables(): Promise<void> {
   if (_migrated) return;
 
-  // Internal DB migration (audit_log) — runs regardless of auth mode
+  const authMode = detectAuthMode();
+  let auth: Awaited<ReturnType<typeof getAuthInstanceLazy>> | null = null;
+
+  // 1. Better Auth migrations — must run BEFORE Atlas internal migrations so
+  //    that Atlas's organization-table ALTERs (e.g. 0027) find the table.
+  if (authMode === "managed" && hasInternalDB()) {
+    try {
+      auth = await getAuthInstanceLazy();
+      const ctx = await auth.$context;
+      await ctx.runMigrations();
+      log.info("Better Auth migration complete");
+
+      // Add password_change_required column to Better Auth's user table.
+      // Must run AFTER Better Auth migrations (which create the "user" table).
+      try {
+        await internalQuery(
+          `ALTER TABLE "user" ADD COLUMN IF NOT EXISTS password_change_required BOOLEAN NOT NULL DEFAULT false`,
+        );
+      } catch (err) {
+        log.warn(
+          { err: err instanceof Error ? err.message : String(err) },
+          "Could not add password_change_required column — password change enforcement will be skipped",
+        );
+      }
+    } catch (err) {
+      log.error({ err }, "Better Auth migration failed — managed auth may not work");
+      _migrationError = "Connected to the internal database but Better Auth migration failed. Managed auth may not work. Check database permissions (CREATE TABLE).";
+    }
+  } else if (authMode === "managed" && !hasInternalDB()) {
+    log.error(
+      "Managed auth mode requires DATABASE_URL for session storage. Skipping auth migration.",
+    );
+  }
+
+  // 2. Internal DB migration (audit_log, etc.) — runs regardless of auth mode.
+  //    In non-managed modes the runner skips org-dependent migrations (#1472).
   if (hasInternalDB()) {
     try {
       const { migrateInternalDB } = await import("@atlas/api/lib/db/internal");
@@ -45,7 +90,7 @@ export async function migrateAuthTables(): Promise<void> {
       // Don't block server start — audit will fall back to pino-only
     }
 
-    // Load admin-managed connections (separate from migration so failures don't conflate)
+    // 3. Load admin-managed connections (separate from migration so failures don't conflate)
     try {
       const { loadSavedConnections } = await import("@atlas/api/lib/db/internal");
       await loadSavedConnections();
@@ -71,47 +116,23 @@ export async function migrateAuthTables(): Promise<void> {
     }
   }
 
-  // Better Auth migration — only in managed mode
-  const authMode = detectAuthMode();
-  if (authMode !== "managed") {
-    _migrated = true;
-    return;
-  }
-
-  if (!hasInternalDB()) {
-    log.error(
-      "Managed auth mode requires DATABASE_URL for session storage. Skipping auth migration.",
-    );
-    _migrated = true;
-    return;
-  }
-
-  try {
-    const { getAuthInstance } = await import("@atlas/api/lib/auth/server");
-    const auth = getAuthInstance();
-    const ctx = await auth.$context;
-    await ctx.runMigrations();
-    log.info("Better Auth migration complete");
-
-    // Add password_change_required column to Better Auth's user table.
-    // Must run AFTER Better Auth migrations (which create the "user" table).
+  // 4. Bootstrap + seed (managed mode only — needs Better Auth `user` table).
+  if (auth) {
     try {
-      await internalQuery(
-        `ALTER TABLE "user" ADD COLUMN IF NOT EXISTS password_change_required BOOLEAN NOT NULL DEFAULT false`,
-      );
-    } catch {
-      log.warn("Could not add password_change_required column — password change enforcement will be skipped");
+      await bootstrapAdminUser();
+      await seedDevUser(auth);
+      await backfillPasswordChangeFlag();
+    } catch (err) {
+      log.error({ err }, "Admin bootstrap or dev seed failed — managed auth still functional");
     }
-
-    await bootstrapAdminUser();
-    await seedDevUser(auth);
-    await backfillPasswordChangeFlag();
-  } catch (err) {
-    log.error({ err }, "Better Auth migration failed — managed auth may not work");
-    _migrationError = "Connected to the internal database but Better Auth migration failed. Managed auth may not work. Check database permissions (CREATE TABLE).";
   }
 
   _migrated = true;
+}
+
+async function getAuthInstanceLazy() {
+  const { getAuthInstance } = await import("@atlas/api/lib/auth/server");
+  return getAuthInstance();
 }
 
 /**

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "bun:test";
+import * as fs from "fs";
+import * as path from "path";
 import { runMigrations, runSeeds } from "@atlas/api/lib/db/migrate";
+
+const MIGRATIONS_DIR = path.join(import.meta.dir, "..", "migrations");
 
 // ---------------------------------------------------------------------------
 // Mock pool
@@ -62,7 +66,7 @@ describe("runMigrations", () => {
 
     const count = await runMigrations(pool);
 
-    expect(count).toBe(27);
+    expect(count).toBe(28);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -118,6 +122,7 @@ describe("runMigrations", () => {
         "0024_mode_status_columns.sql",
         "0025_fix_null_unsafe_indexes.sql",
         "0026_drop_legacy_semantic_entity_index.sql",
+        "0027_organization_saas_columns.sql",
       ],
     });
 
@@ -221,6 +226,73 @@ describe("runMigrations", () => {
     for (const table of expectedTables) {
       expect(baselineSql).toContain(table);
     }
+  });
+
+  it("skips files listed in options.skip without recording them", async () => {
+    const { pool, queries, params } = createMockPool();
+
+    const skip = ["0027_organization_saas_columns.sql"];
+    await runMigrations(pool, { skip });
+
+    // The 0027 SQL never runs — match the issue reference unique to 0027.
+    const orgSaasMigration = queries.find((q) => q.includes("issues/1472"));
+    expect(orgSaasMigration).toBeUndefined();
+
+    // The 0027 row is not recorded as applied
+    const insertedNames = params
+      .filter((p) => p.length === 1 && typeof p[0] === "string")
+      .map((p) => p[0] as string);
+    expect(insertedNames).not.toContain("0027_organization_saas_columns.sql");
+
+    // Other migrations still applied (baseline recorded)
+    expect(insertedNames).toContain("0000_baseline.sql");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: 0027_organization_saas_columns.sql
+// ---------------------------------------------------------------------------
+
+describe("0027_organization_saas_columns.sql", () => {
+  const filePath = path.join(MIGRATIONS_DIR, "0027_organization_saas_columns.sql");
+
+  it("file exists in the migrations directory", () => {
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  it("ALTERs organization unconditionally with all SaaS columns", () => {
+    const sql = fs.readFileSync(filePath, "utf-8");
+
+    // The point of 0027 is that it does NOT silently skip when organization
+    // is missing — that was the bug in 0000/0020. So the SQL must NOT wrap
+    // ALTERs in a conditional `IF EXISTS (... table_name = 'organization')` skip.
+    // It may use IF NOT EXISTS at the column level for idempotency on existing installs.
+    const hasSilentSkip = /IF EXISTS\s*\(\s*SELECT\s+1\s+FROM\s+information_schema\.tables\s+WHERE\s+table_name\s*=\s*'organization'\s*\)\s+THEN\s+ALTER/i.test(sql);
+    expect(hasSilentSkip).toBe(false);
+
+    // All required SaaS columns
+    expect(sql).toContain("workspace_status");
+    expect(sql).toContain("plan_tier");
+    expect(sql).toContain("byot");
+    expect(sql).toContain("stripe_customer_id");
+    expect(sql).toContain("trial_ends_at");
+    expect(sql).toContain("suspended_at");
+    expect(sql).toContain("deleted_at");
+    expect(sql).toContain("region");
+    expect(sql).toContain("region_assigned_at");
+
+    // Idempotent on existing installs
+    expect(sql).toMatch(/ADD COLUMN IF NOT EXISTS/i);
+  });
+
+  it("raises a clear error if organization table is missing", () => {
+    const sql = fs.readFileSync(filePath, "utf-8");
+
+    // Must fail loudly — surface the boot-ordering bug rather than silently
+    // marking the migration applied with no columns added (the 0000/0020 bug).
+    expect(sql).toMatch(/RAISE\s+EXCEPTION/i);
+    expect(sql).toContain("organization");
+    expect(sql).toContain("1472");
   });
 });
 

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -247,6 +247,21 @@ describe("runMigrations", () => {
     // Other migrations still applied (baseline recorded)
     expect(insertedNames).toContain("0000_baseline.sql");
   });
+
+  it("does not crash when skip-list entries don't match any migration file", async () => {
+    // A typo in the skip list (#1472) silently no-ops the safeguard. The
+    // runner emits a warning but must not fail the boot; otherwise a stale
+    // entry would bring the server down.
+    const { pool, params } = createMockPool();
+
+    await expect(runMigrations(pool, { skip: ["0099_does_not_exist.sql"] })).resolves.toBeNumber();
+
+    // Real migrations still recorded.
+    const insertedNames = params
+      .filter((p) => p.length === 1 && typeof p[0] === "string")
+      .map((p) => p[0] as string);
+    expect(insertedNames).toContain("0000_baseline.sql");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -22,6 +22,7 @@ import { PgClient } from "@effect/sql-pg";
 import type { Pool as PgPool } from "pg";
 import { createLogger } from "@atlas/api/lib/logger";
 import { normalizeError } from "@atlas/api/lib/effect/errors";
+import { detectAuthMode } from "@atlas/api/lib/auth/detect";
 
 const log = createLogger("internal-db");
 
@@ -625,7 +626,6 @@ export async function migrateInternalDB(): Promise<void> {
   const pool = getInternalDB();
 
   const { runMigrations, runSeeds } = await import("@atlas/api/lib/db/migrate");
-  const { detectAuthMode } = await import("@atlas/api/lib/auth/detect");
   const skip = detectAuthMode() === "managed" ? [] : ORG_DEPENDENT_MIGRATIONS;
 
   // Retry with backoff for serverless Postgres cold starts (Railway).

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -22,7 +22,6 @@ import { PgClient } from "@effect/sql-pg";
 import type { Pool as PgPool } from "pg";
 import { createLogger } from "@atlas/api/lib/logger";
 import { normalizeError } from "@atlas/api/lib/effect/errors";
-import { detectAuthMode } from "@atlas/api/lib/auth/detect";
 
 const log = createLogger("internal-db");
 
@@ -626,6 +625,11 @@ export async function migrateInternalDB(): Promise<void> {
   const pool = getInternalDB();
 
   const { runMigrations, runSeeds } = await import("@atlas/api/lib/db/migrate");
+  // Dynamic import — db/internal is imported by lower-level modules in the
+  // dependency graph (e.g. logger sinks, effect services), so a static import
+  // of auth/detect → config triggers a circular evaluation order that breaks
+  // module-link in some test runners (mcp test suite). See #1487.
+  const { detectAuthMode } = await import("@atlas/api/lib/auth/detect");
   const skip = detectAuthMode() === "managed" ? [] : ORG_DEPENDENT_MIGRATIONS;
 
   // Retry with backoff for serverless Postgres cold starts (Railway).

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -596,6 +596,9 @@ function warnIfSharedDatabase(): void {
   }
 }
 
+/** Migrations that depend on Better Auth's organization table (#1472). */
+const ORG_DEPENDENT_MIGRATIONS = ["0027_organization_saas_columns.sql"];
+
 /**
  * Idempotent migration: runs versioned SQL migrations from `migrations/`
  * directory, then applies data seeds.
@@ -606,6 +609,11 @@ function warnIfSharedDatabase(): void {
  * Retries up to 5 times with exponential backoff (1s, 2s, 4s, 8s, 16s) to
  * handle serverless Postgres cold starts on Railway where the DB may take
  * several seconds to wake up.
+ *
+ * In non-managed auth modes, migrations that depend on Better Auth's
+ * `organization` table are skipped — Better Auth never creates it, so
+ * applying them would fail. They get picked up automatically if the
+ * deployment later switches to managed auth. See #1472.
  */
 export async function migrateInternalDB(): Promise<void> {
   // Warn when DATABASE_URL and ATLAS_DATASOURCE_URL resolve to the same
@@ -617,13 +625,15 @@ export async function migrateInternalDB(): Promise<void> {
   const pool = getInternalDB();
 
   const { runMigrations, runSeeds } = await import("@atlas/api/lib/db/migrate");
+  const { detectAuthMode } = await import("@atlas/api/lib/auth/detect");
+  const skip = detectAuthMode() === "managed" ? [] : ORG_DEPENDENT_MIGRATIONS;
 
   // Retry with backoff for serverless Postgres cold starts (Railway).
   // Set ATLAS_MIGRATION_RETRIES=0 to disable retries (e.g. in tests).
   const maxRetries = parseInt(process.env.ATLAS_MIGRATION_RETRIES ?? "5", 10);
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      await runMigrations(pool);
+      await runMigrations(pool, { skip });
       break;
     } catch (err) {
       if (attempt === maxRetries) throw err;

--- a/packages/api/src/lib/db/migrate.ts
+++ b/packages/api/src/lib/db/migrate.ts
@@ -37,17 +37,29 @@ interface MigrationClient extends Queryable {
 
 const MIGRATIONS_DIR = path.join(import.meta.dir, "migrations");
 
+/** Options for `runMigrations`. */
+export interface RunMigrationsOptions {
+  /**
+   * Filenames to skip without recording in `__atlas_migrations`. Used to keep
+   * migrations that depend on tables created by external systems (e.g. Better
+   * Auth's `organization` table) out of deployments where those tables do not
+   * exist. Skipped files are picked up automatically on a future boot once the
+   * dependency is in place. See #1472.
+   */
+  skip?: string[];
+}
+
 /**
  * Run all pending migrations against the given pool.
  *
  * 1. Creates the tracking table if it doesn't exist.
  * 2. Reads all `*.sql` files from the migrations directory, sorted by name.
- * 3. Skips files already recorded in `__atlas_migrations`.
+ * 3. Skips files already recorded in `__atlas_migrations` and any in `options.skip`.
  * 4. Executes each pending file inside a transaction.
  *
  * Returns the number of migrations applied (0 if already up-to-date).
  */
-export async function runMigrations(pool: MigrationPool): Promise<number> {
+export async function runMigrations(pool: MigrationPool, options: RunMigrationsOptions = {}): Promise<number> {
   // Use a dedicated connection so the advisory lock, all transactions,
   // and the unlock all happen on the same session. Without this, pg pool
   // could dispatch queries to different connections, breaking lock and
@@ -60,7 +72,7 @@ export async function runMigrations(pool: MigrationPool): Promise<number> {
     await client.query("SELECT pg_advisory_lock(hashtext('atlas_migrations'))");
 
     try {
-      return await _runMigrationsLocked(client);
+      return await _runMigrationsLocked(client, options.skip ?? []);
     } finally {
       await client.query("SELECT pg_advisory_unlock(hashtext('atlas_migrations'))").catch(() => {
         // intentionally ignored: unlock may fail if connection was broken
@@ -71,7 +83,8 @@ export async function runMigrations(pool: MigrationPool): Promise<number> {
   }
 }
 
-async function _runMigrationsLocked(client: MigrationClient): Promise<number> {
+async function _runMigrationsLocked(client: MigrationClient, skip: string[]): Promise<number> {
+  const skipSet = new Set(skip);
   // Ensure tracking table exists
   await client.query(`
     CREATE TABLE IF NOT EXISTS __atlas_migrations (
@@ -100,6 +113,10 @@ async function _runMigrationsLocked(client: MigrationClient): Promise<number> {
   let count = 0;
   for (const file of files) {
     if (applied.has(file)) continue;
+    if (skipSet.has(file)) {
+      log.debug({ migration: file }, "Skipping migration (caller-supplied skip list)");
+      continue;
+    }
 
     const filePath = path.join(MIGRATIONS_DIR, file);
     const sql = fs.readFileSync(filePath, "utf-8");

--- a/packages/api/src/lib/db/migrate.ts
+++ b/packages/api/src/lib/db/migrate.ts
@@ -106,6 +106,20 @@ async function _runMigrationsLocked(client: MigrationClient, skip: string[]): Pr
 
   if (files.length === 0) return 0;
 
+  // Surface stale skip entries — a typo here would silently no-op a guard,
+  // letting a migration that should have been skipped fall through to a
+  // misleading SQL failure. This is exactly the failure mode #1472 invented
+  // the skip list to prevent.
+  const filesSet = new Set(files);
+  for (const name of skipSet) {
+    if (!filesSet.has(name)) {
+      log.warn(
+        { migration: name },
+        "Skip-list entry does not match any migration file — typo or stale reference?",
+      );
+    }
+  }
+
   // Get already-applied migrations
   const { rows } = await client.query("SELECT name FROM __atlas_migrations ORDER BY name");
   const applied = new Set(rows.map((r) => r.name as string));

--- a/packages/api/src/lib/db/migrations/0027_organization_saas_columns.sql
+++ b/packages/api/src/lib/db/migrations/0027_organization_saas_columns.sql
@@ -1,0 +1,56 @@
+-- Backfill SaaS columns on the Better Auth organization table.
+--
+-- Background (#1472): 0000_baseline.sql and 0020_plan_tier_rename.sql wrap
+-- their organization-table ALTERs in `IF EXISTS (... table_name = 'organization')`.
+-- On a fresh boot, Atlas migrations historically ran BEFORE Better Auth created
+-- the organization table, so the conditional silently skipped and the migrations
+-- were marked applied in __atlas_migrations — leaving workspace_status, plan_tier,
+-- byot, stripe_customer_id, trial_ends_at, suspended_at, deleted_at, region, and
+-- region_assigned_at permanently missing. checkResourceLimit() then 429'd every
+-- request because getWorkspaceDetails could not select those columns.
+--
+-- This migration runs the ALTERs unconditionally. It runs after Better Auth
+-- migrations in managed mode (see migrateAuthTables in lib/auth/migrate.ts), and
+-- is skipped by the migration runner in non-managed modes where no organization
+-- table exists. If the table is missing despite that, fail loudly so the boot
+-- ordering bug surfaces immediately rather than silently re-creating the original
+-- half-migrated state.
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'organization') THEN
+    RAISE EXCEPTION 'Atlas migration 0027 requires the "organization" table to exist. In managed auth mode, Better Auth migrations must run before Atlas migrations. See https://github.com/AtlasDevHQ/atlas/issues/1472.';
+  END IF;
+END $$;
+
+ALTER TABLE organization ADD COLUMN IF NOT EXISTS workspace_status TEXT NOT NULL DEFAULT 'active';
+ALTER TABLE organization ADD COLUMN IF NOT EXISTS plan_tier TEXT NOT NULL DEFAULT 'free';
+ALTER TABLE organization ADD COLUMN IF NOT EXISTS byot BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE organization ADD COLUMN IF NOT EXISTS stripe_customer_id TEXT;
+ALTER TABLE organization ADD COLUMN IF NOT EXISTS trial_ends_at TIMESTAMPTZ;
+ALTER TABLE organization ADD COLUMN IF NOT EXISTS suspended_at TIMESTAMPTZ;
+ALTER TABLE organization ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+ALTER TABLE organization ADD COLUMN IF NOT EXISTS region TEXT;
+ALTER TABLE organization ADD COLUMN IF NOT EXISTS region_assigned_at TIMESTAMPTZ;
+
+-- Constraints (idempotent — only added if not already present).
+DO $$ BEGIN
+  ALTER TABLE organization ADD CONSTRAINT chk_workspace_status
+    CHECK (workspace_status IN ('active', 'suspended', 'deleted'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Drop legacy CHECK before re-adding (older installs may have the pre-rename version).
+ALTER TABLE organization DROP CONSTRAINT IF EXISTS chk_plan_tier;
+
+-- Rename legacy tier values that may exist on installs that ran 0020 before any
+-- rows were inserted (idempotent — no-op if no rows match).
+UPDATE organization SET plan_tier = 'starter' WHERE plan_tier = 'team';
+UPDATE organization SET plan_tier = 'business' WHERE plan_tier = 'enterprise';
+
+DO $$ BEGIN
+  ALTER TABLE organization ADD CONSTRAINT chk_plan_tier
+    CHECK (plan_tier IN ('free', 'trial', 'starter', 'pro', 'business'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_organization_workspace_status ON organization(workspace_status);


### PR DESCRIPTION
Closes #1472.

## Summary
- Reorders `migrateAuthTables()` so Better Auth migrations run BEFORE Atlas internal migrations in managed mode. Atlas migrations can now safely ALTER `organization` because the table exists by the time they run.
- Adds `0027_organization_saas_columns.sql` — unconditionally ALTERs the organization table with all SaaS columns and raises a loud, referenced error if the table is missing (rather than silently re-creating the original bug).
- Threads a `skip` list through `runMigrations()` so non-managed deployments (where Better Auth never creates `organization`) skip 0027 without marking it applied. It picks up automatically if the deployment later switches to managed auth.

## Why this happened
On first boot, the conditional ALTERs in `0000_baseline.sql:339-364` and `0020_plan_tier_rename.sql:8-43` were skipped because Better Auth's `CREATE TABLE organization` ran *after* Atlas migrations. The migrations were recorded in `__atlas_migrations` anyway, so they never re-ran. `getWorkspaceDetails` (`packages/api/src/lib/db/internal.ts:1230`) then threw on every call, and `checkResourceLimit` (`packages/api/src/lib/billing/enforcement.ts:417`) failed closed with HTTP 429.

## Test plan
- [x] `bun run lint`, `bun run type`, `bun run test`, `bun x syncpack lint`, `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` all pass
- [x] `bun test packages/api/src/lib/db/__tests__/migrate.test.ts` — 15 pass (5 new tests for skip option, 0027 file contract)
- [x] `bun test packages/api/src/lib/auth/__tests__/migrate.test.ts` — 12 pass (2 new tests: ordering + skip in non-managed)
- [ ] Manual: `bun run db:reset && bun run dev` → fresh signup → add connection should not 429
- [ ] Manual: `\d+ organization` on a fresh DB shows all SaaS columns

## Discovered during work
- Filed #1483 for a pre-existing flaky middleware test (`mode 'managed' with valid session returns authenticated`) that intermittently fails on a clean checkout of `main` — unrelated to this change.