### PR TITLE
fix(mode): admin archive/publish hardening — canonical key, discriminated read, no poisoned pool

### DIFF
--- a/packages/api/src/api/__tests__/admin-archive-restore.test.ts
+++ b/packages/api/src/api/__tests__/admin-archive-restore.test.ts
@@ -92,8 +92,14 @@ mock.module("@atlas/api/lib/settings", () => ({
   deleteSetting: async () => {},
   getSetting: () => undefined,
   getSettingAuto: (key: string) => {
-    if (throwOnGet) throw throwOnGet;
-    return key === "ATLAS_DEMO_INDUSTRY" ? (demoIndustryFixture ?? undefined) : undefined;
+    // Gate throw on the specific key under test — otherwise a future
+    // unrelated getSettingAuto read inside the handler would silently
+    // trip this and produce a false positive.
+    if (key === "ATLAS_DEMO_INDUSTRY") {
+      if (throwOnGet) throw throwOnGet;
+      return demoIndustryFixture ?? undefined;
+    }
+    return undefined;
   },
   getSettingLive: async () => undefined,
   loadSettings: async () => 0,
@@ -527,12 +533,10 @@ describe("POST /api/v1/admin/archive-connection — errors", () => {
     expect(promptUpdate).toBeUndefined();
   });
 
-  it("archive __demo__ when demo_industry read throws — surfaces 500 (#1470), does NOT open the transaction", async () => {
-    // readDemoIndustry now returns { ok: false, err } on a transient
-    // settings read failure. The handler must 500 with a requestId rather
-    // than silently committing with prompts: 0, which would leave demo
-    // prompts stuck at `published` after an archive. No transaction must
-    // be opened — the pre-transaction read is what failed.
+  it("surfaces 500 when settings read fails — no transaction is opened", async () => {
+    // A transient settings read failure must 500 rather than silently
+    // committing with prompts: 0 — otherwise demo prompts stay
+    // `published` while the connection flips to `archived`.
     throwOnGet = new Error("transient settings read failure");
 
     const res = await app.fetch(
@@ -540,6 +544,7 @@ describe("POST /api/v1/admin/archive-connection — errors", () => {
     );
     expect(res.status).toBe(500);
     const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("archive_failed");
     expect(typeof body.requestId).toBe("string");
     // Raw cause must not leak
     expect(String(body.message ?? "")).not.toContain("transient settings");
@@ -572,11 +577,9 @@ describe("POST /api/v1/admin/archive-connection — errors", () => {
     expect(clientReleaseArg).toBeUndefined();
   });
 
-  it("rollback-failure poisons the pool — release(err) destroys instead of returns (#1471)", async () => {
-    // ROLLBACK itself throws after the primary mutation fails. The dirty
-    // client must be passed to `release(err)` so node-postgres destroys
-    // the socket rather than returning it to the pool (which would poison
-    // the next borrower).
+  it("destroys the client on failed ROLLBACK — release(err) called with the rollback error", async () => {
+    // When ROLLBACK itself throws, the socket is dirty. release(err)
+    // tells pg to destroy the client instead of pooling it.
     queryHandler = async (sql) => {
       if (/SELECT\s+status\s+FROM\s+connections/i.test(sql)) {
         return { rows: [{ status: "published" }] };
@@ -775,7 +778,7 @@ describe("POST /api/v1/admin/restore-connection — errors", () => {
     mocks.hasInternalDB = true;
   });
 
-  it("restore __demo__ when demo_industry read throws — surfaces 500 (#1470)", async () => {
+  it("surfaces 500 when settings read fails — no transaction is opened", async () => {
     throwOnGet = new Error("transient settings read failure");
 
     const res = await app.fetch(
@@ -783,6 +786,7 @@ describe("POST /api/v1/admin/restore-connection — errors", () => {
     );
     expect(res.status).toBe(500);
     const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("restore_failed");
     expect(typeof body.requestId).toBe("string");
 
     // No transaction opened
@@ -790,7 +794,7 @@ describe("POST /api/v1/admin/restore-connection — errors", () => {
     expect(sqls.includes("BEGIN")).toBe(false);
   });
 
-  it("rollback-failure poisons the pool — release(err) destroys (#1471)", async () => {
+  it("destroys the client on failed ROLLBACK — release(err) called with the rollback error", async () => {
     queryHandler = async (sql) => {
       if (/SELECT\s+status\s+FROM\s+connections/i.test(sql)) {
         return { rows: [{ status: "archived" }] };

--- a/packages/api/src/api/__tests__/admin-archive-restore.test.ts
+++ b/packages/api/src/api/__tests__/admin-archive-restore.test.ts
@@ -18,6 +18,16 @@ import { describe, it, expect, beforeEach, afterAll, mock } from "bun:test";
 import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
 import { makeArchiveRestoreStubs } from "@atlas/api/testing/archive-restore";
 
+// Controls `getSettingAuto("ATLAS_DEMO_INDUSTRY", orgId)` per test. Tests
+// that need to drive the demo-prompt cascade mutate these before invoking
+// the route. `throwOnGet` simulates a transient cache-read failure so the
+// route can surface 500 (issue #1470) rather than silently swallowing it.
+// Declared here; the `mock.module` override is registered AFTER
+// `createApiTestMocks` below — otherwise the factory's own mock overrides
+// ours.
+let demoIndustryFixture: string | null = null;
+let throwOnGet: Error | null = null;
+
 // ── Transactional client mock ─────────────────────────────────────────
 
 interface ClientQuery {
@@ -27,11 +37,15 @@ interface ClientQuery {
 
 interface MockClient {
   query: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>;
-  release: () => void;
+  release: (err?: unknown) => void;
 }
 
 let clientQueries: ClientQuery[] = [];
 let clientReleased = false;
+// Captures the argument passed to `client.release(err?)`. When non-undefined,
+// node-postgres destroys the socket instead of returning it to the pool —
+// this is what we assert for issue #1471 (ROLLBACK-failure poisoning).
+let clientReleaseArg: unknown = undefined;
 let queryHandler: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }> = async () => ({ rows: [] });
 
 function makeMockClient(): MockClient {
@@ -40,8 +54,9 @@ function makeMockClient(): MockClient {
       clientQueries.push({ sql, params });
       return queryHandler(sql, params);
     },
-    release: () => {
+    release: (err?: unknown) => {
       clientReleased = true;
+      clientReleaseArg = err;
     },
   };
 }
@@ -65,6 +80,26 @@ const mocks = createApiTestMocks({
     getInternalDB: mockGetInternalDB,
   },
 });
+
+// Override the default settings mock from createApiTestMocks so tests
+// can drive getSettingAuto("ATLAS_DEMO_INDUSTRY") and simulate a transient
+// read failure. Registered AFTER createApiTestMocks so it wins.
+mock.module("@atlas/api/lib/settings", () => ({
+  getSettingsForAdmin: () => [],
+  getSettingsRegistry: () => [],
+  getSettingDefinition: () => undefined,
+  setSetting: async () => {},
+  deleteSetting: async () => {},
+  getSetting: () => undefined,
+  getSettingAuto: (key: string) => {
+    if (throwOnGet) throw throwOnGet;
+    return key === "ATLAS_DEMO_INDUSTRY" ? (demoIndustryFixture ?? undefined) : undefined;
+  },
+  getSettingLive: async () => undefined,
+  loadSettings: async () => 0,
+  getAllSettingOverrides: async () => [],
+  _resetSettingsCache: () => {},
+}));
 
 // Replace the default no-op semantic/entities mock with full-fidelity
 // archive/restore stubs that issue real SQL against our transactional
@@ -111,7 +146,10 @@ function makeReq(path: "archive-connection" | "restore-connection", body?: unkno
 function resetClient(): void {
   clientQueries = [];
   clientReleased = false;
+  clientReleaseArg = undefined;
   queryHandler = async () => ({ rows: [] });
+  demoIndustryFixture = null;
+  throwOnGet = null;
 }
 
 afterAll(() => {
@@ -205,13 +243,8 @@ describe("POST /api/v1/admin/archive-connection — cascade", () => {
   });
 
   it("archives __demo__ and cascades to entities + demo builtin prompts", async () => {
-    // Pre-transaction read of demo_industry
-    mocks.mockInternalQuery.mockImplementation((sql: string) => {
-      if (sql.includes("demo_industry")) {
-        return Promise.resolve([{ value: "cybersecurity" }]);
-      }
-      return Promise.resolve([]);
-    });
+    // Pre-transaction read of ATLAS_DEMO_INDUSTRY via getSettingAuto cache
+    demoIndustryFixture = "cybersecurity";
 
     queryHandler = async (sql) => {
       if (/SELECT\s+status\s+FROM\s+connections/i.test(sql)) {
@@ -462,10 +495,10 @@ describe("POST /api/v1/admin/archive-connection — errors", () => {
   });
 
   it("archive __demo__ with no demo_industry setting — skips prompt cascade, still returns 200", async () => {
-    // The readDemoIndustry helper returns null when the setting row is
-    // missing. The endpoint proceeds without touching prompt_collections
+    // readDemoIndustry returns { ok: true, value: null } when the setting
+    // is unset. The endpoint proceeds without touching prompt_collections
     // (no UPDATE fires) and reports prompts: 0.
-    mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+    demoIndustryFixture = null;
 
     queryHandler = async (sql) => {
       if (/SELECT\s+status\s+FROM\s+connections/i.test(sql)) {
@@ -494,35 +527,78 @@ describe("POST /api/v1/admin/archive-connection — errors", () => {
     expect(promptUpdate).toBeUndefined();
   });
 
-  it("archive __demo__ when demo_industry read throws — logs warn, skips prompt cascade, still returns 200", async () => {
-    // readDemoIndustry catches failures from internalQuery and returns
-    // null. A transient settings read failure should NOT fail the
-    // archive — the connection + entity cascade still commits.
-    mocks.mockInternalQuery.mockImplementation(() =>
-      Promise.reject(new Error("transient settings read failure")),
-    );
+  it("archive __demo__ when demo_industry read throws — surfaces 500 (#1470), does NOT open the transaction", async () => {
+    // readDemoIndustry now returns { ok: false, err } on a transient
+    // settings read failure. The handler must 500 with a requestId rather
+    // than silently committing with prompts: 0, which would leave demo
+    // prompts stuck at `published` after an archive. No transaction must
+    // be opened — the pre-transaction read is what failed.
+    throwOnGet = new Error("transient settings read failure");
 
+    const res = await app.fetch(
+      makeReq("archive-connection", { connectionId: "__demo__" }),
+    );
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(typeof body.requestId).toBe("string");
+    // Raw cause must not leak
+    expect(String(body.message ?? "")).not.toContain("transient settings");
+
+    // No BEGIN — the failure happened before the transaction started
+    const sqls = clientQueries.map((q) => q.sql.trim().toUpperCase());
+    expect(sqls.includes("BEGIN")).toBe(false);
+    expect(sqls.includes("ROLLBACK")).toBe(false);
+    expect(sqls.includes("COMMIT")).toBe(false);
+  });
+
+  it("clean rollback — release() called with no argument (client safe to pool)", async () => {
+    // Primary UPDATE fails, but ROLLBACK succeeds. Client is clean, so
+    // release() must be called without an error arg.
     queryHandler = async (sql) => {
       if (/SELECT\s+status\s+FROM\s+connections/i.test(sql)) {
         return { rows: [{ status: "published" }] };
+      }
+      if (/^\s*UPDATE/i.test(sql)) {
+        throw new Error("primary mutation failure");
       }
       return { rows: [] };
     };
 
     const res = await app.fetch(
-      makeReq("archive-connection", { connectionId: "__demo__" }),
+      makeReq("archive-connection", { connectionId: "warehouse" }),
     );
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as {
-      archived: { connection: boolean; entities: number; prompts: number };
-    };
-    expect(body.archived.connection).toBe(true);
-    expect(body.archived.prompts).toBe(0);
+    expect(res.status).toBe(500);
+    expect(clientReleased).toBe(true);
+    expect(clientReleaseArg).toBeUndefined();
+  });
 
-    const promptUpdate = clientQueries.find((q) =>
-      /UPDATE\s+prompt_collections/i.test(q.sql),
+  it("rollback-failure poisons the pool — release(err) destroys instead of returns (#1471)", async () => {
+    // ROLLBACK itself throws after the primary mutation fails. The dirty
+    // client must be passed to `release(err)` so node-postgres destroys
+    // the socket rather than returning it to the pool (which would poison
+    // the next borrower).
+    queryHandler = async (sql) => {
+      if (/SELECT\s+status\s+FROM\s+connections/i.test(sql)) {
+        return { rows: [{ status: "published" }] };
+      }
+      if (/^\s*UPDATE/i.test(sql)) {
+        throw new Error("primary mutation failure");
+      }
+      if (/^\s*ROLLBACK/i.test(sql)) {
+        throw new Error("ROLLBACK failed — socket dirty");
+      }
+      return { rows: [] };
+    };
+
+    const res = await app.fetch(
+      makeReq("archive-connection", { connectionId: "warehouse" }),
     );
-    expect(promptUpdate).toBeUndefined();
+    expect(res.status).toBe(500);
+    expect(clientReleased).toBe(true);
+    // The argument to release() must be a Error instance — node-postgres
+    // treats any truthy value as "destroy me".
+    expect(clientReleaseArg).toBeInstanceOf(Error);
+    expect((clientReleaseArg as Error).message).toContain("ROLLBACK failed");
   });
 });
 
@@ -538,12 +614,7 @@ describe("POST /api/v1/admin/restore-connection — cascade", () => {
   });
 
   it("restores __demo__ and brings entities + demo prompts back to published", async () => {
-    mocks.mockInternalQuery.mockImplementation((sql: string) => {
-      if (sql.includes("demo_industry")) {
-        return Promise.resolve([{ value: "cybersecurity" }]);
-      }
-      return Promise.resolve([]);
-    });
+    demoIndustryFixture = "cybersecurity";
 
     queryHandler = async (sql) => {
       if (/SELECT\s+status\s+FROM\s+connections/i.test(sql)) {
@@ -702,5 +773,43 @@ describe("POST /api/v1/admin/restore-connection — errors", () => {
     );
     expect(res.status).toBe(404);
     mocks.hasInternalDB = true;
+  });
+
+  it("restore __demo__ when demo_industry read throws — surfaces 500 (#1470)", async () => {
+    throwOnGet = new Error("transient settings read failure");
+
+    const res = await app.fetch(
+      makeReq("restore-connection", { connectionId: "__demo__" }),
+    );
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(typeof body.requestId).toBe("string");
+
+    // No transaction opened
+    const sqls = clientQueries.map((q) => q.sql.trim().toUpperCase());
+    expect(sqls.includes("BEGIN")).toBe(false);
+  });
+
+  it("rollback-failure poisons the pool — release(err) destroys (#1471)", async () => {
+    queryHandler = async (sql) => {
+      if (/SELECT\s+status\s+FROM\s+connections/i.test(sql)) {
+        return { rows: [{ status: "archived" }] };
+      }
+      if (/^\s*UPDATE/i.test(sql)) {
+        throw new Error("primary mutation failure");
+      }
+      if (/^\s*ROLLBACK/i.test(sql)) {
+        throw new Error("ROLLBACK failed — socket dirty");
+      }
+      return { rows: [] };
+    };
+
+    const res = await app.fetch(
+      makeReq("restore-connection", { connectionId: "warehouse" }),
+    );
+    expect(res.status).toBe(500);
+    expect(clientReleased).toBe(true);
+    expect(clientReleaseArg).toBeInstanceOf(Error);
+    expect((clientReleaseArg as Error).message).toContain("ROLLBACK failed");
   });
 });

--- a/packages/api/src/api/__tests__/admin-publish.test.ts
+++ b/packages/api/src/api/__tests__/admin-publish.test.ts
@@ -13,6 +13,14 @@ import { describe, it, expect, beforeEach, afterAll, mock } from "bun:test";
 import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
 import { makeArchiveRestoreStubs } from "@atlas/api/testing/archive-restore";
 
+// Controls the value `getSettingAuto("ATLAS_DEMO_INDUSTRY", orgId)` returns
+// per test. `throwOnGet` simulates a transient settings cache failure so the
+// route can surface 500 per issue #1470 (discriminated result).
+// The `mock.module` override is registered AFTER createApiTestMocks below
+// so it wins over the factory's default undefined-returning stub.
+let demoIndustryFixture: string | null = null;
+let throwOnGet: Error | null = null;
+
 // ── Transactional client mock ─────────────────────────────────────────
 // Each test captures the sequence of queries issued against the pool's
 // checked-out client so we can assert BEGIN/COMMIT/ROLLBACK + per-step SQL.
@@ -24,11 +32,14 @@ interface ClientQuery {
 
 interface MockClient {
   query: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>;
-  release: () => void;
+  release: (err?: unknown) => void;
 }
 
 let clientQueries: ClientQuery[] = [];
 let clientReleased = false;
+// Captures the argument passed to `client.release(err?)`. node-postgres
+// destroys the socket when this is truthy — asserted for issue #1471.
+let clientReleaseArg: unknown = undefined;
 let queryHandler: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }> = async () => ({ rows: [] });
 
 function makeMockClient(): MockClient {
@@ -37,8 +48,9 @@ function makeMockClient(): MockClient {
       clientQueries.push({ sql, params });
       return queryHandler(sql, params);
     },
-    release: () => {
+    release: (err?: unknown) => {
       clientReleased = true;
+      clientReleaseArg = err;
     },
   };
 }
@@ -62,6 +74,27 @@ const mocks = createApiTestMocks({
     getInternalDB: mockGetInternalDB,
   },
 });
+
+// Override the default settings mock from createApiTestMocks so tests
+// can drive getSettingAuto("ATLAS_DEMO_INDUSTRY") via `demoIndustryFixture`
+// and simulate a transient read failure via `throwOnGet`. Registered
+// AFTER createApiTestMocks so this override wins.
+mock.module("@atlas/api/lib/settings", () => ({
+  getSettingsForAdmin: () => [],
+  getSettingsRegistry: () => [],
+  getSettingDefinition: () => undefined,
+  setSetting: async () => {},
+  deleteSetting: async () => {},
+  getSetting: () => undefined,
+  getSettingAuto: (key: string) => {
+    if (throwOnGet) throw throwOnGet;
+    return key === "ATLAS_DEMO_INDUSTRY" ? (demoIndustryFixture ?? undefined) : undefined;
+  },
+  getSettingLive: async () => undefined,
+  loadSettings: async () => 0,
+  getAllSettingOverrides: async () => [],
+  _resetSettingsCache: () => {},
+}));
 
 // Override the semantic/entities mock with full-fidelity stubs matching
 // the real helper signatures. The factory mocks semantic/entities with
@@ -158,7 +191,10 @@ function publishReq(body?: unknown, cookie?: string): Request {
 function resetClient(): void {
   clientQueries = [];
   clientReleased = false;
+  clientReleaseArg = undefined;
   queryHandler = async () => ({ rows: [] });
+  demoIndustryFixture = null;
+  throwOnGet = null;
 }
 
 afterAll(() => {
@@ -312,13 +348,10 @@ describe("POST /api/v1/admin/publish — archiveConnections", () => {
   });
 
   it("archives listed connections, cascades entities, and archives demo prompts", async () => {
-    // Mock internalQuery used to read demo_industry setting (outside txn)
-    mocks.mockInternalQuery.mockImplementation((sql: string) => {
-      if (sql.includes("demo_industry")) {
-        return Promise.resolve([{ value: "cybersecurity" }]);
-      }
-      return Promise.resolve([]);
-    });
+    // Demo industry is read via getSettingAuto("ATLAS_DEMO_INDUSTRY", orgId)
+    // — the canonical key (#1466). Prior code hit a lowercase SQL literal
+    // which silently missed the row.
+    demoIndustryFixture = "cybersecurity";
 
     queryHandler = async (sql) => {
       // Single-connection helper locks the row first — report "published"
@@ -385,12 +418,7 @@ describe("POST /api/v1/admin/publish — archiveConnections", () => {
   });
 
   it("skips prompt-archival step when the __demo__ connection is NOT in archiveConnections", async () => {
-    mocks.mockInternalQuery.mockImplementation((sql: string) => {
-      if (sql.includes("demo_industry")) {
-        return Promise.resolve([{ value: "cybersecurity" }]);
-      }
-      return Promise.resolve([]);
-    });
+    demoIndustryFixture = "cybersecurity";
 
     const res = await app.fetch(publishReq({ archiveConnections: ["warehouse"] }));
     expect(res.status).toBe(200);
@@ -489,12 +517,7 @@ describe("POST /api/v1/admin/publish — archiveConnections", () => {
     // and return non-zero counts. Publish must accumulate those counts
     // into archived.entities / archived.prompts while keeping
     // archived.connections at 0, and emit the "cascade reconciled" warn.
-    mocks.mockInternalQuery.mockImplementation((sql: string) => {
-      if (sql.includes("demo_industry")) {
-        return Promise.resolve([{ value: "cybersecurity" }]);
-      }
-      return Promise.resolve([]);
-    });
+    demoIndustryFixture = "cybersecurity";
 
     queryHandler = async (sql) => {
       if (/SELECT\s+status\s+FROM\s+connections/i.test(sql)) {
@@ -573,6 +596,84 @@ describe("POST /api/v1/admin/publish — archiveConnections", () => {
   });
 });
 
+describe("POST /api/v1/admin/publish — demo industry read (#1466, #1470)", () => {
+  beforeEach(() => {
+    mocks.hasInternalDB = true;
+    mocks.mockInternalQuery.mockReset();
+    mocks.mockInternalQuery.mockResolvedValue([]);
+    resetClient();
+    mocks.setOrgAdmin("org-alpha");
+  });
+
+  it("reads ATLAS_DEMO_INDUSTRY (canonical key) via the settings cache — not a lowercase SQL literal (#1466)", async () => {
+    // Regression guard for #1466. Prior code queried `SELECT value FROM
+    // settings WHERE key = 'demo_industry'` — the lowercase key never
+    // matched the canonical `ATLAS_DEMO_INDUSTRY` row, so publish silently
+    // skipped archiving built-in demo prompts. Now the route must call
+    // getSettingAuto("ATLAS_DEMO_INDUSTRY", orgId), pick up "cybersecurity",
+    // and pass it through to the prompt-collections UPDATE.
+    demoIndustryFixture = "cybersecurity";
+
+    queryHandler = async (sql) => {
+      if (/SELECT\s+status\s+FROM\s+connections/i.test(sql)) {
+        return { rows: [{ status: "published" }] };
+      }
+      if (/UPDATE\s+connections\s+SET\s+status\s*=\s*'archived'/i.test(sql)) {
+        return { rows: [{ id: "__demo__" }] };
+      }
+      if (/UPDATE\s+prompt_collections\s+SET\s+status\s*=\s*'archived'/i.test(sql)) {
+        return { rows: [{ id: "prompt-1" }] };
+      }
+      return { rows: [] };
+    };
+
+    const res = await app.fetch(publishReq({ archiveConnections: ["__demo__"] }));
+    expect(res.status).toBe(200);
+
+    // The pre-transaction read must NOT hit the settings table directly.
+    // Route pulls from the cache via getSettingAuto — internalQuery should
+    // never see a demo_industry query.
+    const calls = mocks.mockInternalQuery.mock.calls.map((c) => String(c[0] ?? ""));
+    expect(calls.some((sql) => /demo_industry/i.test(sql))).toBe(false);
+
+    // Prompt cascade fired with the industry parameter
+    const archivePromptsSql = clientQueries.find((q) =>
+      /UPDATE\s+prompt_collections\s+SET\s+status\s*=\s*'archived'/i.test(q.sql),
+    );
+    expect(archivePromptsSql).toBeDefined();
+    expect((archivePromptsSql!.params as unknown[])).toContain("cybersecurity");
+  });
+
+  it("surfaces 500 when the settings read fails — does NOT open the transaction (#1470)", async () => {
+    // readDemoIndustry now returns a discriminated { ok: false, err }.
+    // Callers must 500 rather than silently committing with prompts: 0 —
+    // that would leave demo prompts stranded at `published` after publish.
+    throwOnGet = new Error("transient cache read failure");
+
+    const res = await app.fetch(publishReq({ archiveConnections: ["__demo__"] }));
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(typeof body.requestId).toBe("string");
+    // Raw cause must not leak to the caller
+    expect(String(body.message ?? "")).not.toContain("transient cache read failure");
+
+    // Transaction must not open — the failure is pre-transaction
+    const sqls = clientQueries.map((q) => q.sql.trim().toUpperCase());
+    expect(sqls.includes("BEGIN")).toBe(false);
+    expect(sqls.includes("ROLLBACK")).toBe(false);
+  });
+
+  it("does NOT read demo industry when archiveConnections excludes __demo__", async () => {
+    // Only runs the read when __demo__ is being archived — otherwise the
+    // setting is irrelevant to this publish.
+    throwOnGet = new Error("should not be called");
+
+    const res = await app.fetch(publishReq({ archiveConnections: ["warehouse"] }));
+    // Must 200 — the settings read was never attempted
+    expect(res.status).toBe(200);
+  });
+});
+
 describe("POST /api/v1/admin/publish — atomicity", () => {
   beforeEach(() => {
     mocks.hasInternalDB = true;
@@ -621,6 +722,47 @@ describe("POST /api/v1/admin/publish — atomicity", () => {
     const body = (await res.json()) as Record<string, unknown>;
     expect(body.requestId).toBeDefined();
     expect(typeof body.requestId).toBe("string");
+  });
+
+  it("rollback-failure poisons the pool — release(err) destroys the client (#1471)", async () => {
+    // Primary mutation throws, then ROLLBACK itself throws (broken socket).
+    // The handler must pass the rollback error to `client.release(err)` so
+    // node-postgres destroys the socket rather than returning a dirty
+    // client to the pool.
+    queryHandler = async (sql) => {
+      if (/^\s*DELETE/i.test(sql)) {
+        throw new Error("primary mutation failure");
+      }
+      if (/^\s*ROLLBACK/i.test(sql)) {
+        throw new Error("ROLLBACK failed — socket dirty");
+      }
+      return { rows: [] };
+    };
+
+    const res = await app.fetch(publishReq());
+    expect(res.status).toBe(500);
+    expect(clientReleased).toBe(true);
+    expect(clientReleaseArg).toBeInstanceOf(Error);
+    expect((clientReleaseArg as Error).message).toContain("ROLLBACK failed");
+  });
+
+  it("clean rollback (ROLLBACK succeeds) — release() called without an error arg", async () => {
+    // When ROLLBACK succeeds, the client is still safe to pool. release()
+    // must be called with no argument so node-postgres returns the client
+    // to the pool normally.
+    queryHandler = async (sql) => {
+      if (/^\s*DELETE/i.test(sql)) {
+        throw new Error("primary mutation failure");
+      }
+      return { rows: [] };
+    };
+
+    const res = await app.fetch(publishReq());
+    expect(res.status).toBe(500);
+    expect(clientReleased).toBe(true);
+    // release() called with no arg means "return to pool" — the client is
+    // clean because ROLLBACK succeeded.
+    expect(clientReleaseArg).toBeUndefined();
   });
 });
 

--- a/packages/api/src/api/__tests__/admin-publish.test.ts
+++ b/packages/api/src/api/__tests__/admin-publish.test.ts
@@ -87,8 +87,11 @@ mock.module("@atlas/api/lib/settings", () => ({
   deleteSetting: async () => {},
   getSetting: () => undefined,
   getSettingAuto: (key: string) => {
-    if (throwOnGet) throw throwOnGet;
-    return key === "ATLAS_DEMO_INDUSTRY" ? (demoIndustryFixture ?? undefined) : undefined;
+    if (key === "ATLAS_DEMO_INDUSTRY") {
+      if (throwOnGet) throw throwOnGet;
+      return demoIndustryFixture ?? undefined;
+    }
+    return undefined;
   },
   getSettingLive: async () => undefined,
   loadSettings: async () => 0,
@@ -596,7 +599,7 @@ describe("POST /api/v1/admin/publish — archiveConnections", () => {
   });
 });
 
-describe("POST /api/v1/admin/publish — demo industry read (#1466, #1470)", () => {
+describe("POST /api/v1/admin/publish — demo industry read", () => {
   beforeEach(() => {
     mocks.hasInternalDB = true;
     mocks.mockInternalQuery.mockReset();
@@ -605,13 +608,10 @@ describe("POST /api/v1/admin/publish — demo industry read (#1466, #1470)", () 
     mocks.setOrgAdmin("org-alpha");
   });
 
-  it("reads ATLAS_DEMO_INDUSTRY (canonical key) via the settings cache — not a lowercase SQL literal (#1466)", async () => {
-    // Regression guard for #1466. Prior code queried `SELECT value FROM
-    // settings WHERE key = 'demo_industry'` — the lowercase key never
-    // matched the canonical `ATLAS_DEMO_INDUSTRY` row, so publish silently
-    // skipped archiving built-in demo prompts. Now the route must call
-    // getSettingAuto("ATLAS_DEMO_INDUSTRY", orgId), pick up "cybersecurity",
-    // and pass it through to the prompt-collections UPDATE.
+  it("reads via the settings cache — not via a hand-rolled SQL query against the settings table", async () => {
+    // Regression guard: a hand-rolled `SELECT … WHERE key = 'demo_industry'`
+    // missed the canonical `ATLAS_DEMO_INDUSTRY` row entirely. The route
+    // must resolve industry through getSettingAuto.
     demoIndustryFixture = "cybersecurity";
 
     queryHandler = async (sql) => {
@@ -644,15 +644,16 @@ describe("POST /api/v1/admin/publish — demo industry read (#1466, #1470)", () 
     expect((archivePromptsSql!.params as unknown[])).toContain("cybersecurity");
   });
 
-  it("surfaces 500 when the settings read fails — does NOT open the transaction (#1470)", async () => {
-    // readDemoIndustry now returns a discriminated { ok: false, err }.
-    // Callers must 500 rather than silently committing with prompts: 0 —
-    // that would leave demo prompts stranded at `published` after publish.
+  it("surfaces 500 when the settings read fails — no transaction is opened", async () => {
+    // A transient read failure must 500 rather than silently committing
+    // with prompts: 0 — otherwise demo prompts stay stranded at
+    // `published` after publish.
     throwOnGet = new Error("transient cache read failure");
 
     const res = await app.fetch(publishReq({ archiveConnections: ["__demo__"] }));
     expect(res.status).toBe(500);
     const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("publish_failed");
     expect(typeof body.requestId).toBe("string");
     // Raw cause must not leak to the caller
     expect(String(body.message ?? "")).not.toContain("transient cache read failure");
@@ -724,11 +725,10 @@ describe("POST /api/v1/admin/publish — atomicity", () => {
     expect(typeof body.requestId).toBe("string");
   });
 
-  it("rollback-failure poisons the pool — release(err) destroys the client (#1471)", async () => {
-    // Primary mutation throws, then ROLLBACK itself throws (broken socket).
-    // The handler must pass the rollback error to `client.release(err)` so
-    // node-postgres destroys the socket rather than returning a dirty
-    // client to the pool.
+  it("destroys the client on failed ROLLBACK — release(err) called with the rollback error", async () => {
+    // Primary mutation throws, then ROLLBACK itself throws (broken
+    // socket). The handler must pass the rollback error to
+    // `client.release(err)` so pg destroys the socket.
     queryHandler = async (sql) => {
       if (/^\s*DELETE/i.test(sql)) {
         throw new Error("primary mutation failure");
@@ -746,10 +746,9 @@ describe("POST /api/v1/admin/publish — atomicity", () => {
     expect((clientReleaseArg as Error).message).toContain("ROLLBACK failed");
   });
 
-  it("clean rollback (ROLLBACK succeeds) — release() called without an error arg", async () => {
-    // When ROLLBACK succeeds, the client is still safe to pool. release()
-    // must be called with no argument so node-postgres returns the client
-    // to the pool normally.
+  it("pools the client on clean ROLLBACK — release() called without an error arg", async () => {
+    // When ROLLBACK succeeds the client is safe to pool. release() must
+    // be called with no argument.
     queryHandler = async (sql) => {
       if (/^\s*DELETE/i.test(sql)) {
         throw new Error("primary mutation failure");

--- a/packages/api/src/api/routes/admin-archive.ts
+++ b/packages/api/src/api/routes/admin-archive.ts
@@ -21,7 +21,8 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
-import { internalQuery, getInternalDB } from "@atlas/api/lib/db/internal";
+import { getInternalDB } from "@atlas/api/lib/db/internal";
+import { getSettingAuto } from "@atlas/api/lib/settings";
 import {
   DEMO_CONNECTION_ID,
   archiveSingleConnection,
@@ -32,6 +33,24 @@ import {
 import { runHandler } from "@atlas/api/lib/effect/hono";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
+
+/**
+ * Canonical setting key for the onboarding demo industry. Mirrors the
+ * constant in `routes/mode.ts` and `lib/prompts/scoping.ts`. Prior callers
+ * used the lowercase literal `demo_industry` in hand-rolled SQL against
+ * the settings table — that was issue #1466 and silently missed every row.
+ */
+const DEMO_INDUSTRY_SETTING = "ATLAS_DEMO_INDUSTRY";
+
+/**
+ * Discriminated result for `readDemoIndustry`. Distinguishes "setting
+ * absent" (expected, value === null) from "read failed" (unexpected,
+ * surfaced as 500 by callers) so a transient failure can't quietly leave
+ * demo prompts at `published` after archive/publish commits.
+ */
+type ReadDemoIndustryResult =
+  | { ok: true; value: string | null }
+  | { ok: false; err: Error };
 
 const log = createLogger("admin-archive");
 
@@ -67,30 +86,33 @@ type RestoreResponse = z.infer<typeof RestoreResponseSchema>;
 // ---------------------------------------------------------------------------
 
 /**
- * Read the org's `demo_industry` setting (if any). Failures are logged and
- * treated as "no industry" — the route proceeds without a demo prompt
- * cascade in that case.
+ * Read the org's `ATLAS_DEMO_INDUSTRY` setting (if any). Returns a
+ * discriminated result so callers can distinguish "setting absent"
+ * (`ok: true, value: null` — expected, cascade skipped) from "read
+ * failed" (`ok: false` — surface as 500, see issue #1470).
+ *
+ * Reads go through the in-process settings cache via `getSettingAuto` —
+ * using a hand-rolled SQL literal was issue #1466, which hit the wrong
+ * key (`demo_industry`) and silently missed every row.
  */
-async function readDemoIndustry(
+function readDemoIndustry(
   orgId: string,
   requestId: string,
-): Promise<string | null> {
+): ReadDemoIndustryResult {
   try {
-    const rows = await internalQuery<{ value: string }>(
-      `SELECT value FROM settings WHERE org_id = $1 AND key = 'demo_industry'`,
-      [orgId],
-    );
-    return rows[0]?.value ?? null;
+    const value = getSettingAuto(DEMO_INDUSTRY_SETTING, orgId) ?? null;
+    return { ok: true, value };
   } catch (err) {
-    log.warn(
+    const normalized = err instanceof Error ? err : new Error(String(err));
+    log.error(
       {
-        err: err instanceof Error ? err.message : String(err),
+        err: normalized.message,
         orgId,
         requestId,
       },
-      "Failed to read demo_industry setting — demo prompt cascade skipped",
+      "Failed to read ATLAS_DEMO_INDUSTRY setting — archive/restore aborted before transaction",
     );
-    return null;
+    return { ok: false, err: normalized };
   }
 }
 
@@ -270,14 +292,34 @@ adminArchive.openapi(archiveRoute, async (c) =>
     const authResult = c.get("authResult");
     const { connectionId } = c.req.valid("json");
 
-    const demoIndustry =
-      connectionId === DEMO_CONNECTION_ID
-        ? await readDemoIndustry(orgId, requestId)
-        : null;
+    // Resolve demo industry BEFORE opening the transaction. A failure here
+    // surfaces as 500 (issue #1470) rather than silently committing with
+    // prompts = 0 — the prior behaviour could leave demo prompts stuck at
+    // `published` while the connection flipped to `archived`.
+    let demoIndustry: string | null = null;
+    if (connectionId === DEMO_CONNECTION_ID) {
+      const industryResult = readDemoIndustry(orgId, requestId);
+      if (!industryResult.ok) {
+        return c.json(
+          {
+            error: "archive_failed",
+            message:
+              "Archive failed — could not read demo industry setting. See server logs for details.",
+            requestId,
+          },
+          500,
+        );
+      }
+      demoIndustry = industryResult.value;
+    }
 
     const pool = getInternalDB();
     const client = await pool.connect();
     let result: ArchiveConnectionResult;
+    // Track whether ROLLBACK itself fails. If so we pass the error into
+    // `release(err)` so node-postgres destroys the socket rather than
+    // returning a dirty client to the pool (issue #1471).
+    let rollbackErr: Error | null = null;
 
     try {
       await client.query("BEGIN");
@@ -286,18 +328,16 @@ adminArchive.openapi(archiveRoute, async (c) =>
       });
       await client.query("COMMIT");
     } catch (err) {
-      await client.query("ROLLBACK").catch((rollbackErr: unknown) => {
+      await client.query("ROLLBACK").catch((rbErr: unknown) => {
+        rollbackErr = rbErr instanceof Error ? rbErr : new Error(String(rbErr));
         log.warn(
           {
-            err:
-              rollbackErr instanceof Error
-                ? rollbackErr.message
-                : String(rollbackErr),
+            err: rollbackErr.message,
             orgId,
             connectionId,
             requestId,
           },
-          "ROLLBACK failed after archive error",
+          "ROLLBACK failed after archive error — client will be destroyed",
         );
       });
       log.error(
@@ -319,7 +359,10 @@ adminArchive.openapi(archiveRoute, async (c) =>
         500,
       );
     } finally {
-      client.release();
+      // Pass a non-null error to `release(err)` so pg destroys the
+      // socket on a failed ROLLBACK. A clean ROLLBACK (or a successful
+      // COMMIT) passes `undefined`, returning the client to the pool.
+      client.release(rollbackErr ?? undefined);
     }
 
     // Exhaustive switch on the tagged result — adding a new variant to
@@ -395,14 +438,31 @@ adminRestore.openapi(restoreRoute, async (c) =>
     const authResult = c.get("authResult");
     const { connectionId } = c.req.valid("json");
 
-    const demoIndustry =
-      connectionId === DEMO_CONNECTION_ID
-        ? await readDemoIndustry(orgId, requestId)
-        : null;
+    // Resolve demo industry BEFORE opening the transaction — see the
+    // matching comment in the archive handler (#1470).
+    let demoIndustry: string | null = null;
+    if (connectionId === DEMO_CONNECTION_ID) {
+      const industryResult = readDemoIndustry(orgId, requestId);
+      if (!industryResult.ok) {
+        return c.json(
+          {
+            error: "restore_failed",
+            message:
+              "Restore failed — could not read demo industry setting. See server logs for details.",
+            requestId,
+          },
+          500,
+        );
+      }
+      demoIndustry = industryResult.value;
+    }
 
     const pool = getInternalDB();
     const client = await pool.connect();
     let result: RestoreConnectionResult;
+    // Mirror the archive handler — ROLLBACK-failure poisons the pool
+    // unless we pass the error into `release(err)` (issue #1471).
+    let rollbackErr: Error | null = null;
 
     try {
       await client.query("BEGIN");
@@ -411,18 +471,16 @@ adminRestore.openapi(restoreRoute, async (c) =>
       });
       await client.query("COMMIT");
     } catch (err) {
-      await client.query("ROLLBACK").catch((rollbackErr: unknown) => {
+      await client.query("ROLLBACK").catch((rbErr: unknown) => {
+        rollbackErr = rbErr instanceof Error ? rbErr : new Error(String(rbErr));
         log.warn(
           {
-            err:
-              rollbackErr instanceof Error
-                ? rollbackErr.message
-                : String(rollbackErr),
+            err: rollbackErr.message,
             orgId,
             connectionId,
             requestId,
           },
-          "ROLLBACK failed after restore error",
+          "ROLLBACK failed after restore error — client will be destroyed",
         );
       });
       log.error(
@@ -444,7 +502,7 @@ adminRestore.openapi(restoreRoute, async (c) =>
         500,
       );
     } finally {
-      client.release();
+      client.release(rollbackErr ?? undefined);
     }
 
     // Exhaustive switch — adding a new RestoreConnectionResult variant

--- a/packages/api/src/api/routes/admin-archive.ts
+++ b/packages/api/src/api/routes/admin-archive.ts
@@ -22,7 +22,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { getInternalDB } from "@atlas/api/lib/db/internal";
-import { getSettingAuto } from "@atlas/api/lib/settings";
+import { readDemoIndustry } from "@atlas/api/lib/demo-industry";
 import {
   DEMO_CONNECTION_ID,
   archiveSingleConnection,
@@ -33,24 +33,6 @@ import {
 import { runHandler } from "@atlas/api/lib/effect/hono";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
-
-/**
- * Canonical setting key for the onboarding demo industry. Mirrors the
- * constant in `routes/mode.ts` and `lib/prompts/scoping.ts`. Prior callers
- * used the lowercase literal `demo_industry` in hand-rolled SQL against
- * the settings table — that was issue #1466 and silently missed every row.
- */
-const DEMO_INDUSTRY_SETTING = "ATLAS_DEMO_INDUSTRY";
-
-/**
- * Discriminated result for `readDemoIndustry`. Distinguishes "setting
- * absent" (expected, value === null) from "read failed" (unexpected,
- * surfaced as 500 by callers) so a transient failure can't quietly leave
- * demo prompts at `published` after archive/publish commits.
- */
-type ReadDemoIndustryResult =
-  | { ok: true; value: string | null }
-  | { ok: false; err: Error };
 
 const log = createLogger("admin-archive");
 
@@ -84,37 +66,6 @@ type RestoreResponse = z.infer<typeof RestoreResponseSchema>;
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Read the org's `ATLAS_DEMO_INDUSTRY` setting (if any). Returns a
- * discriminated result so callers can distinguish "setting absent"
- * (`ok: true, value: null` — expected, cascade skipped) from "read
- * failed" (`ok: false` — surface as 500, see issue #1470).
- *
- * Reads go through the in-process settings cache via `getSettingAuto` —
- * using a hand-rolled SQL literal was issue #1466, which hit the wrong
- * key (`demo_industry`) and silently missed every row.
- */
-function readDemoIndustry(
-  orgId: string,
-  requestId: string,
-): ReadDemoIndustryResult {
-  try {
-    const value = getSettingAuto(DEMO_INDUSTRY_SETTING, orgId) ?? null;
-    return { ok: true, value };
-  } catch (err) {
-    const normalized = err instanceof Error ? err : new Error(String(err));
-    log.error(
-      {
-        err: normalized.message,
-        orgId,
-        requestId,
-      },
-      "Failed to read ATLAS_DEMO_INDUSTRY setting — archive/restore aborted before transaction",
-    );
-    return { ok: false, err: normalized };
-  }
-}
 
 /**
  * Map an archive helper result with cascade counts to the wire response.
@@ -292,9 +243,9 @@ adminArchive.openapi(archiveRoute, async (c) =>
     const authResult = c.get("authResult");
     const { connectionId } = c.req.valid("json");
 
-    // Resolve demo industry BEFORE opening the transaction. A failure here
-    // surfaces as 500 (issue #1470) rather than silently committing with
-    // prompts = 0 — the prior behaviour could leave demo prompts stuck at
+    // Resolve demo industry before opening the transaction. A read
+    // failure surfaces as 500 here — otherwise we'd commit the archive
+    // with prompts = 0 and strand the built-in demo prompts at
     // `published` while the connection flipped to `archived`.
     let demoIndustry: string | null = null;
     if (connectionId === DEMO_CONNECTION_ID) {
@@ -316,9 +267,10 @@ adminArchive.openapi(archiveRoute, async (c) =>
     const pool = getInternalDB();
     const client = await pool.connect();
     let result: ArchiveConnectionResult;
-    // Track whether ROLLBACK itself fails. If so we pass the error into
-    // `release(err)` so node-postgres destroys the socket rather than
-    // returning a dirty client to the pool (issue #1471).
+    // pg destroys the socket when `release(err)` is called with a truthy
+    // arg, and pools it on `release()` / `release(undefined)`. We need to
+    // destroy on a failed ROLLBACK so a dirty client doesn't poison the
+    // next borrower.
     let rollbackErr: Error | null = null;
 
     try {
@@ -359,9 +311,6 @@ adminArchive.openapi(archiveRoute, async (c) =>
         500,
       );
     } finally {
-      // Pass a non-null error to `release(err)` so pg destroys the
-      // socket on a failed ROLLBACK. A clean ROLLBACK (or a successful
-      // COMMIT) passes `undefined`, returning the client to the pool.
       client.release(rollbackErr ?? undefined);
     }
 
@@ -438,8 +387,8 @@ adminRestore.openapi(restoreRoute, async (c) =>
     const authResult = c.get("authResult");
     const { connectionId } = c.req.valid("json");
 
-    // Resolve demo industry BEFORE opening the transaction — see the
-    // matching comment in the archive handler (#1470).
+    // Mirrors the archive handler: resolve demo industry before BEGIN so
+    // a read failure surfaces as 500 without opening a transaction.
     let demoIndustry: string | null = null;
     if (connectionId === DEMO_CONNECTION_ID) {
       const industryResult = readDemoIndustry(orgId, requestId);
@@ -460,8 +409,6 @@ adminRestore.openapi(restoreRoute, async (c) =>
     const pool = getInternalDB();
     const client = await pool.connect();
     let result: RestoreConnectionResult;
-    // Mirror the archive handler — ROLLBACK-failure poisons the pool
-    // unless we pass the error into `release(err)` (issue #1471).
     let rollbackErr: Error | null = null;
 
     try {

--- a/packages/api/src/api/routes/admin-publish.ts
+++ b/packages/api/src/api/routes/admin-publish.ts
@@ -21,7 +21,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { getInternalDB } from "@atlas/api/lib/db/internal";
-import { getSettingAuto } from "@atlas/api/lib/settings";
+import { readDemoIndustry } from "@atlas/api/lib/demo-industry";
 import {
   applyTombstones,
   promoteDraftEntities,
@@ -33,48 +33,6 @@ import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
 
 const log = createLogger("admin-publish");
-
-/** Canonical setting key — mirrors `admin-archive.ts` and `mode.ts`. */
-const DEMO_INDUSTRY_SETTING = "ATLAS_DEMO_INDUSTRY";
-
-/**
- * Discriminated result for `readDemoIndustry` — see admin-archive.ts for
- * the shared rationale (issue #1470).
- */
-type ReadDemoIndustryResult =
-  | { ok: true; value: string | null }
-  | { ok: false; err: Error };
-
-/**
- * Read the org's `ATLAS_DEMO_INDUSTRY` setting through the in-process
- * settings cache. Returns `ok: false` on a transient failure so publish
- * surfaces a 500 instead of silently committing with demo prompts stuck
- * at `published` after an archive.
- *
- * Prior code hand-rolled a `SELECT … WHERE key = 'demo_industry'` query
- * that used the wrong (lowercase) key and silently skipped every row —
- * that was issue #1466.
- */
-function readDemoIndustry(
-  orgId: string,
-  requestId: string,
-): ReadDemoIndustryResult {
-  try {
-    const value = getSettingAuto(DEMO_INDUSTRY_SETTING, orgId) ?? null;
-    return { ok: true, value };
-  } catch (err) {
-    const normalized = err instanceof Error ? err : new Error(String(err));
-    log.error(
-      {
-        err: normalized.message,
-        orgId,
-        requestId,
-      },
-      "Failed to read ATLAS_DEMO_INDUSTRY setting — publish aborted before transaction",
-    );
-    return { ok: false, err: normalized };
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Request / response schemas
@@ -185,12 +143,9 @@ adminPublish.openapi(publishRoute, async (c) =>
     const archiveIds = archiveConnections ?? [];
     const archiveDemo = archiveIds.includes(DEMO_CONNECTION_ID);
 
-    // ── Pre-transaction: resolve demo industry if we'll archive demo ─
-    // Kept outside the transaction because it's a simple cached read that
-    // informs whether we run the builtin-demo-prompts archive step.
-    // A failed read surfaces as 500 (not a silent `null` fallback) — see
-    // issue #1470: otherwise publish would commit with prompts = 0 and
-    // demo prompts would stay published after archive.
+    // Resolve demo industry before opening the transaction. A read
+    // failure must 500 here — otherwise publish would commit with
+    // prompts = 0 and demo prompts would stay published after archive.
     let demoIndustry: string | null = null;
     if (archiveDemo) {
       const industryResult = readDemoIndustry(orgId, requestId);
@@ -211,9 +166,9 @@ adminPublish.openapi(publishRoute, async (c) =>
     // ── Transaction ────────────────────────────────────────────────
     const pool = getInternalDB();
     const client = await pool.connect();
-    // Track whether ROLLBACK itself fails so we can pass the error into
-    // `release(err)` below — a dirty socket returned to the pool poisons
-    // the next borrower (issue #1471).
+    // pg destroys the socket when `release(err)` is called with a truthy
+    // arg. We need to destroy on a failed ROLLBACK so a dirty client
+    // doesn't poison the next borrower.
     let rollbackErr: Error | null = null;
     // Values are assigned inside the try block before either the 200
     // response or a 500 (which doesn't read them) — start as numbers for

--- a/packages/api/src/api/routes/admin-publish.ts
+++ b/packages/api/src/api/routes/admin-publish.ts
@@ -20,7 +20,8 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
-import { internalQuery, getInternalDB } from "@atlas/api/lib/db/internal";
+import { getInternalDB } from "@atlas/api/lib/db/internal";
+import { getSettingAuto } from "@atlas/api/lib/settings";
 import {
   applyTombstones,
   promoteDraftEntities,
@@ -32,6 +33,48 @@ import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
 
 const log = createLogger("admin-publish");
+
+/** Canonical setting key — mirrors `admin-archive.ts` and `mode.ts`. */
+const DEMO_INDUSTRY_SETTING = "ATLAS_DEMO_INDUSTRY";
+
+/**
+ * Discriminated result for `readDemoIndustry` — see admin-archive.ts for
+ * the shared rationale (issue #1470).
+ */
+type ReadDemoIndustryResult =
+  | { ok: true; value: string | null }
+  | { ok: false; err: Error };
+
+/**
+ * Read the org's `ATLAS_DEMO_INDUSTRY` setting through the in-process
+ * settings cache. Returns `ok: false` on a transient failure so publish
+ * surfaces a 500 instead of silently committing with demo prompts stuck
+ * at `published` after an archive.
+ *
+ * Prior code hand-rolled a `SELECT … WHERE key = 'demo_industry'` query
+ * that used the wrong (lowercase) key and silently skipped every row —
+ * that was issue #1466.
+ */
+function readDemoIndustry(
+  orgId: string,
+  requestId: string,
+): ReadDemoIndustryResult {
+  try {
+    const value = getSettingAuto(DEMO_INDUSTRY_SETTING, orgId) ?? null;
+    return { ok: true, value };
+  } catch (err) {
+    const normalized = err instanceof Error ? err : new Error(String(err));
+    log.error(
+      {
+        err: normalized.message,
+        orgId,
+        requestId,
+      },
+      "Failed to read ATLAS_DEMO_INDUSTRY setting — publish aborted before transaction",
+    );
+    return { ok: false, err: normalized };
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Request / response schemas
@@ -143,31 +186,35 @@ adminPublish.openapi(publishRoute, async (c) =>
     const archiveDemo = archiveIds.includes(DEMO_CONNECTION_ID);
 
     // ── Pre-transaction: resolve demo industry if we'll archive demo ─
-    // Kept outside the transaction because it's a simple read that informs
-    // whether we run the builtin-demo-prompts archive step.
+    // Kept outside the transaction because it's a simple cached read that
+    // informs whether we run the builtin-demo-prompts archive step.
+    // A failed read surfaces as 500 (not a silent `null` fallback) — see
+    // issue #1470: otherwise publish would commit with prompts = 0 and
+    // demo prompts would stay published after archive.
     let demoIndustry: string | null = null;
     if (archiveDemo) {
-      try {
-        const rows = await internalQuery<{ value: string }>(
-          `SELECT value FROM settings WHERE org_id = $1 AND key = 'demo_industry'`,
-          [orgId],
-        );
-        demoIndustry = rows[0]?.value ?? null;
-      } catch (err) {
-        log.warn(
+      const industryResult = readDemoIndustry(orgId, requestId);
+      if (!industryResult.ok) {
+        return c.json(
           {
-            err: err instanceof Error ? err.message : String(err),
-            orgId,
+            error: "publish_failed",
+            message:
+              "Publish failed — could not read demo industry setting. See server logs for details.",
             requestId,
           },
-          "Failed to read demo_industry setting — demo prompts will not be archived",
+          500,
         );
       }
+      demoIndustry = industryResult.value;
     }
 
     // ── Transaction ────────────────────────────────────────────────
     const pool = getInternalDB();
     const client = await pool.connect();
+    // Track whether ROLLBACK itself fails so we can pass the error into
+    // `release(err)` below — a dirty socket returned to the pool poisons
+    // the next borrower (issue #1471).
+    let rollbackErr: Error | null = null;
     // Values are assigned inside the try block before either the 200
     // response or a 500 (which doesn't read them) — start as numbers for
     // type inference without seeding a read-before-write warning.
@@ -263,17 +310,15 @@ adminPublish.openapi(publishRoute, async (c) =>
 
       await client.query("COMMIT");
     } catch (err) {
-      await client.query("ROLLBACK").catch((rollbackErr: unknown) => {
+      await client.query("ROLLBACK").catch((rbErr: unknown) => {
+        rollbackErr = rbErr instanceof Error ? rbErr : new Error(String(rbErr));
         log.warn(
           {
-            err:
-              rollbackErr instanceof Error
-                ? rollbackErr.message
-                : String(rollbackErr),
+            err: rollbackErr.message,
             orgId,
             requestId,
           },
-          "ROLLBACK failed after publish error",
+          "ROLLBACK failed after publish error — client will be destroyed",
         );
       });
       log.error(
@@ -294,7 +339,7 @@ adminPublish.openapi(publishRoute, async (c) =>
         500,
       );
     } finally {
-      client.release();
+      client.release(rollbackErr ?? undefined);
     }
 
     // ── Audit + response ────────────────────────────────────────────

--- a/packages/api/src/lib/db/__tests__/internal.test.ts
+++ b/packages/api/src/lib/db/__tests__/internal.test.ts
@@ -33,6 +33,9 @@ function createMockPool() {
     onEvents: [] as { event: "error"; listener: (err: Error) => void }[],
     connectCount: 0,
     releaseCount: 0,
+    // The last argument passed to `client.release(err?)`. Truthy means pg
+    // destroys the socket instead of pooling it.
+    lastReleaseArg: undefined as unknown,
   };
   let queryResult: { rows: Record<string, unknown>[] } = { rows: [] };
   let queryError: Error | null = null;
@@ -52,7 +55,10 @@ function createMockPool() {
       calls.connectCount++;
       return {
         query: queryFn,
-        release() { calls.releaseCount++; },
+        release(err?: Error) {
+          calls.releaseCount++;
+          calls.lastReleaseArg = err;
+        },
       };
     },
     on(event: "error", listener: (err: Error) => void) {
@@ -533,7 +539,10 @@ describe("cascadeWorkspaceDelete()", () => {
             if (queryNum === 2) throw new Error("relation does not exist");
             return { rows: [] };
           },
-          release() { calls.releaseCount++; },
+          release(err?: Error) {
+            calls.releaseCount++;
+            calls.lastReleaseArg = err;
+          },
         };
       },
       on: txPool.on,
@@ -546,6 +555,48 @@ describe("cascadeWorkspaceDelete()", () => {
     const rollbackQuery = calls.queries.find((q) => q.sql === "ROLLBACK");
     expect(rollbackQuery).toBeDefined();
     expect(calls.releaseCount).toBe(1);
+    // Clean ROLLBACK — client pooled (no error arg)
+    expect(calls.lastReleaseArg).toBeUndefined();
+  });
+
+  it("destroys the client on failed ROLLBACK — release(err) called with the rollback error", async () => {
+    // Primary query fails AND ROLLBACK itself throws. The dirty socket
+    // must be destroyed via release(err) rather than pooled.
+    const { pool: txPool } = createMockPool();
+    const calls = {
+      queries: [] as { sql: string }[],
+      releaseCount: 0,
+      lastReleaseArg: undefined as unknown,
+    };
+    let queryNum = 0;
+    const failPool = {
+      ...txPool,
+      async connect() {
+        return {
+          async query(sql: string) {
+            calls.queries.push({ sql });
+            queryNum++;
+            // Let BEGIN pass; fail on first cascade query; also fail ROLLBACK
+            if (queryNum === 2) throw new Error("primary mutation failure");
+            if (sql.trim().toUpperCase() === "ROLLBACK") {
+              throw new Error("ROLLBACK failed — socket dirty");
+            }
+            return { rows: [] };
+          },
+          release(err?: Error) {
+            calls.releaseCount++;
+            calls.lastReleaseArg = err;
+          },
+        };
+      },
+    };
+    _resetPool(failPool);
+
+    await expect(cascadeWorkspaceDelete("org-fail")).rejects.toThrow("primary mutation failure");
+
+    expect(calls.releaseCount).toBe(1);
+    expect(calls.lastReleaseArg).toBeInstanceOf(Error);
+    expect((calls.lastReleaseArg as Error).message).toContain("ROLLBACK failed");
   });
 });
 

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -5,13 +5,22 @@ import { runMigrations, runSeeds } from "@atlas/api/lib/db/migrate";
 // Mock pool
 // ---------------------------------------------------------------------------
 
-function createMockPool(opts: { applied?: string[]; failOn?: string } = {}) {
+function createMockPool(
+  opts: { applied?: string[]; failOn?: string; failOnRollback?: boolean } = {},
+) {
   const queries: string[] = [];
   const params: unknown[][] = [];
+  const release = { called: false, arg: undefined as unknown };
 
   async function queryFn(sql: string, p?: unknown[]) {
     queries.push(sql);
     if (p) params.push(p);
+
+    // Simulate a broken socket on ROLLBACK to exercise the
+    // release(err)-on-failed-rollback path.
+    if (opts.failOnRollback && sql.trim().toUpperCase() === "ROLLBACK") {
+      throw new Error("Mock ROLLBACK failure — socket dirty");
+    }
 
     if (opts.failOn && sql.includes(opts.failOn)) {
       throw new Error(`Mock failure on: ${opts.failOn}`);
@@ -44,12 +53,15 @@ function createMockPool(opts: { applied?: string[]; failOn?: string } = {}) {
     async connect() {
       return {
         query: queryFn,
-        release() { /* no-op for mock */ },
+        release(err?: Error) {
+          release.called = true;
+          release.arg = err;
+        },
       };
     },
   };
 
-  return { pool, queries, params };
+  return { pool, queries, params, release };
 }
 
 // ---------------------------------------------------------------------------
@@ -145,7 +157,7 @@ describe("runMigrations", () => {
   });
 
   it("rolls back on failure and still releases lock", async () => {
-    const { pool, queries } = createMockPool({ failOn: "CREATE TABLE IF NOT EXISTS audit_log" });
+    const { pool, queries, release } = createMockPool({ failOn: "CREATE TABLE IF NOT EXISTS audit_log" });
 
     await expect(runMigrations(pool)).rejects.toThrow("Migration 0000_baseline.sql failed");
     expect(queries).toContain("BEGIN");
@@ -155,6 +167,26 @@ describe("runMigrations", () => {
     // Lock is released even on failure
     const unlockQuery = queries.find((q) => q.includes("pg_advisory_unlock"));
     expect(unlockQuery).toBeDefined();
+
+    // Clean ROLLBACK — client is safe to pool, so release() takes no arg
+    expect(release.called).toBe(true);
+    expect(release.arg).toBeUndefined();
+  });
+
+  it("destroys the client on failed ROLLBACK — release(err) called with the rollback error", async () => {
+    // Migration SQL fails AND ROLLBACK itself throws. The client must
+    // be released with the rollback error so pg destroys the socket
+    // rather than pooling a dirty connection.
+    const { pool, release } = createMockPool({
+      failOn: "CREATE TABLE IF NOT EXISTS audit_log",
+      failOnRollback: true,
+    });
+
+    await expect(runMigrations(pool)).rejects.toThrow("Migration 0000_baseline.sql failed");
+
+    expect(release.called).toBe(true);
+    expect(release.arg).toBeInstanceOf(Error);
+    expect((release.arg as Error).message).toContain("ROLLBACK failure");
   });
 
   it("rolls back when INSERT into tracking table fails", async () => {

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -118,13 +118,14 @@ export function isPlaintextUrl(value: string): boolean {
   return /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(value);
 }
 
-/** Typed interface for the internal pg.Pool — avoids importing pg at module level. */
+/**
+ * Typed interface for the internal pg.Pool — avoids importing pg at
+ * module level. Passing a truthy `err` to `release` tells node-postgres
+ * to destroy the socket instead of returning it to the pool.
+ */
 export interface InternalPoolClient {
   query(sql: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[] }>;
-  // Matches pg.PoolClient.release(err?) — passing a truthy value tells
-  // node-postgres to destroy the socket instead of returning it to the
-  // pool. Used to avoid poisoning on a failed ROLLBACK (issue #1471).
-  release(err?: Error | boolean): void;
+  release(err?: Error): void;
 }
 
 export interface InternalPool {
@@ -1365,9 +1366,8 @@ export async function cascadeWorkspaceDelete(orgId: string): Promise<{
   // Fallback: raw pool with manual transaction
   const pool = getInternalDB();
   const client = await pool.connect();
-  // If ROLLBACK itself fails the socket is dirty — pass the error to
-  // `release(err)` so pg destroys it instead of pooling a poisoned
-  // client (issue #1471).
+  // Destroy the client on a failed ROLLBACK so a dirty socket doesn't
+  // poison the next borrower.
   let rollbackErr: Error | null = null;
   try {
     await client.query("BEGIN");

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -121,7 +121,10 @@ export function isPlaintextUrl(value: string): boolean {
 /** Typed interface for the internal pg.Pool — avoids importing pg at module level. */
 export interface InternalPoolClient {
   query(sql: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[] }>;
-  release(): void;
+  // Matches pg.PoolClient.release(err?) — passing a truthy value tells
+  // node-postgres to destroy the socket instead of returning it to the
+  // pool. Used to avoid poisoning on a failed ROLLBACK (issue #1471).
+  release(err?: Error | boolean): void;
 }
 
 export interface InternalPool {
@@ -1362,6 +1365,10 @@ export async function cascadeWorkspaceDelete(orgId: string): Promise<{
   // Fallback: raw pool with manual transaction
   const pool = getInternalDB();
   const client = await pool.connect();
+  // If ROLLBACK itself fails the socket is dirty — pass the error to
+  // `release(err)` so pg destroys it instead of pooling a poisoned
+  // client (issue #1471).
+  let rollbackErr: Error | null = null;
   try {
     await client.query("BEGIN");
     const [convResult, seResult, lpResult, qsResult, stResult, settingsResult] = await Promise.all([
@@ -1382,12 +1389,16 @@ export async function cascadeWorkspaceDelete(orgId: string): Promise<{
       settings: settingsResult.rows.length,
     };
   } catch (err) {
-    await client.query("ROLLBACK").catch(() => {
-      // intentionally ignored: ROLLBACK failure after a failed transaction is non-actionable
+    await client.query("ROLLBACK").catch((rbErr: unknown) => {
+      rollbackErr = rbErr instanceof Error ? rbErr : new Error(String(rbErr));
+      log.warn(
+        { orgId, err: rollbackErr.message },
+        "ROLLBACK failed during cascadeWorkspaceDelete — client will be destroyed",
+      );
     });
     throw err;
   } finally {
-    client.release();
+    client.release(rollbackErr ?? undefined);
   }
 }
 

--- a/packages/api/src/lib/db/migrate.ts
+++ b/packages/api/src/lib/db/migrate.ts
@@ -32,7 +32,10 @@ interface MigrationPool extends Queryable {
 
 /** Minimal client interface — matches pg.PoolClient. */
 interface MigrationClient extends Queryable {
-  release(): void;
+  // Matches the pg.PoolClient `release(err?)` overload: passing a truthy
+  // value tells node-postgres to destroy the socket instead of returning
+  // it to the pool — see issue #1471.
+  release(err?: unknown): void;
 }
 
 const MIGRATIONS_DIR = path.join(import.meta.dir, "migrations");
@@ -54,24 +57,35 @@ export async function runMigrations(pool: MigrationPool): Promise<number> {
   // transaction semantics.
   const client = await pool.connect();
 
+  // If any per-migration ROLLBACK fails inside the loop, we stash the
+  // error here and pass it to `client.release(err)` so pg destroys the
+  // socket instead of pooling a dirty client (#1471). Mutated via the
+  // onRollbackFailure callback passed to `_runMigrationsLocked`.
+  let rollbackErr: Error | null = null;
+
   try {
     // Acquire an advisory lock so concurrent server instances don't race.
     // hashtext('atlas_migrations') produces a stable int4 key.
     await client.query("SELECT pg_advisory_lock(hashtext('atlas_migrations'))");
 
     try {
-      return await _runMigrationsLocked(client);
+      return await _runMigrationsLocked(client, (err) => {
+        rollbackErr = err;
+      });
     } finally {
       await client.query("SELECT pg_advisory_unlock(hashtext('atlas_migrations'))").catch(() => {
         // intentionally ignored: unlock may fail if connection was broken
       });
     }
   } finally {
-    client.release();
+    client.release(rollbackErr ?? undefined);
   }
 }
 
-async function _runMigrationsLocked(client: MigrationClient): Promise<number> {
+async function _runMigrationsLocked(
+  client: MigrationClient,
+  onRollbackFailure?: (err: Error) => void,
+): Promise<number> {
   // Ensure tracking table exists
   await client.query(`
     CREATE TABLE IF NOT EXISTS __atlas_migrations (
@@ -119,8 +133,17 @@ async function _runMigrationsLocked(client: MigrationClient): Promise<number> {
       await client.query("COMMIT");
       count++;
     } catch (err) {
-      await client.query("ROLLBACK").catch(() => {
-        // intentionally ignored: ROLLBACK may fail if connection is broken
+      await client.query("ROLLBACK").catch((rbErr: unknown) => {
+        // ROLLBACK itself can fail if the connection is broken — we report
+        // that up to the caller so the shared client gets destroyed via
+        // `release(err)` (#1471), not returned to the pool dirty.
+        const normalized =
+          rbErr instanceof Error ? rbErr : new Error(String(rbErr));
+        log.warn(
+          { migration: file, err: normalized.message },
+          "ROLLBACK failed during migration — client will be destroyed",
+        );
+        onRollbackFailure?.(normalized);
       });
       const detail = err instanceof Error ? err.message : String(err);
       log.error({ migration: file, err: detail }, "Migration failed");

--- a/packages/api/src/lib/db/migrate.ts
+++ b/packages/api/src/lib/db/migrate.ts
@@ -30,12 +30,13 @@ interface MigrationPool extends Queryable {
   connect(): Promise<MigrationClient>;
 }
 
-/** Minimal client interface — matches pg.PoolClient. */
+/**
+ * Minimal client interface — matches pg.PoolClient. Passing a truthy
+ * `err` to `release` tells node-postgres to destroy the socket instead
+ * of returning it to the pool.
+ */
 interface MigrationClient extends Queryable {
-  // Matches the pg.PoolClient `release(err?)` overload: passing a truthy
-  // value tells node-postgres to destroy the socket instead of returning
-  // it to the pool — see issue #1471.
-  release(err?: unknown): void;
+  release(err?: Error): void;
 }
 
 const MIGRATIONS_DIR = path.join(import.meta.dir, "migrations");
@@ -57,10 +58,8 @@ export async function runMigrations(pool: MigrationPool): Promise<number> {
   // transaction semantics.
   const client = await pool.connect();
 
-  // If any per-migration ROLLBACK fails inside the loop, we stash the
-  // error here and pass it to `client.release(err)` so pg destroys the
-  // socket instead of pooling a dirty client (#1471). Mutated via the
-  // onRollbackFailure callback passed to `_runMigrationsLocked`.
+  // A failed per-migration ROLLBACK propagates here via the callback so
+  // the client gets destroyed on release instead of pooled dirty.
   let rollbackErr: Error | null = null;
 
   try {
@@ -73,8 +72,14 @@ export async function runMigrations(pool: MigrationPool): Promise<number> {
         rollbackErr = err;
       });
     } finally {
-      await client.query("SELECT pg_advisory_unlock(hashtext('atlas_migrations'))").catch(() => {
-        // intentionally ignored: unlock may fail if connection was broken
+      await client.query("SELECT pg_advisory_unlock(hashtext('atlas_migrations'))").catch((err: unknown) => {
+        // Unlock may legitimately fail if the connection is broken (in
+        // which case the client is about to be destroyed anyway). Debug
+        // so a genuine SQL-level failure still leaves a trace.
+        log.debug(
+          { err: err instanceof Error ? err.message : String(err) },
+          "pg_advisory_unlock failed — continuing to release",
+        );
       });
     }
   } finally {
@@ -84,7 +89,7 @@ export async function runMigrations(pool: MigrationPool): Promise<number> {
 
 async function _runMigrationsLocked(
   client: MigrationClient,
-  onRollbackFailure?: (err: Error) => void,
+  onRollbackFailure: (err: Error) => void,
 ): Promise<number> {
   // Ensure tracking table exists
   await client.query(`
@@ -134,16 +139,15 @@ async function _runMigrationsLocked(
       count++;
     } catch (err) {
       await client.query("ROLLBACK").catch((rbErr: unknown) => {
-        // ROLLBACK itself can fail if the connection is broken — we report
-        // that up to the caller so the shared client gets destroyed via
-        // `release(err)` (#1471), not returned to the pool dirty.
+        // A failed ROLLBACK means the socket is dirty — propagate the
+        // error so the shared client gets destroyed on release.
         const normalized =
           rbErr instanceof Error ? rbErr : new Error(String(rbErr));
         log.warn(
           { migration: file, err: normalized.message },
           "ROLLBACK failed during migration — client will be destroyed",
         );
-        onRollbackFailure?.(normalized);
+        onRollbackFailure(normalized);
       });
       const detail = err instanceof Error ? err.message : String(err);
       log.error({ migration: file, err: detail }, "Migration failed");

--- a/packages/api/src/lib/demo-industry.ts
+++ b/packages/api/src/lib/demo-industry.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared helpers for reading the onboarding `ATLAS_DEMO_INDUSTRY` setting.
+ *
+ * Used by prompt scoping (user-facing list/get) and the admin
+ * archive / restore / publish flows to decide whether built-in demo
+ * prompt collections for the org's industry are visible or should be
+ * cascaded alongside the `__demo__` connection.
+ *
+ * The read goes through the in-process settings cache. A transient
+ * failure surfaces as `{ ok: false, err }` so callers can abort the
+ * transaction rather than silently committing with "no industry" —
+ * otherwise a read blip would strand demo prompts at `published` while
+ * the connection flipped to `archived`.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { getSettingAuto } from "@atlas/api/lib/settings";
+
+const log = createLogger("demo-industry");
+
+/** Canonical key for the onboarding-chosen demo industry. */
+export const DEMO_INDUSTRY_SETTING = "ATLAS_DEMO_INDUSTRY";
+
+/**
+ * Discriminated outcome of a demo-industry read.
+ *
+ * `ok: true, value: null` means the row is absent (expected — no demo
+ * industry configured for this org). Callers should skip the cascade.
+ *
+ * `ok: false` means the read itself failed. Callers must NOT treat this
+ * as "absent" — archive/publish would otherwise commit with the demo
+ * prompts stuck at `published`.
+ */
+export type ReadDemoIndustryResult =
+  | { ok: true; value: string | null }
+  | { ok: false; err: Error };
+
+/**
+ * Read the org's `ATLAS_DEMO_INDUSTRY` through the settings cache. Sync
+ * because `getSettingAuto` is a cache read. The try/catch is defensive —
+ * if `getSettingAuto` ever starts throwing, callers get the failure
+ * surfaced instead of a silent `null`.
+ */
+export function readDemoIndustry(
+  orgId: string,
+  requestId: string,
+): ReadDemoIndustryResult {
+  try {
+    const value = getSettingAuto(DEMO_INDUSTRY_SETTING, orgId) ?? null;
+    return { ok: true, value };
+  } catch (err) {
+    const normalized = err instanceof Error ? err : new Error(String(err));
+    log.error(
+      { err: normalized.message, orgId, requestId },
+      "Failed to read ATLAS_DEMO_INDUSTRY setting",
+    );
+    return { ok: false, err: normalized };
+  }
+}

--- a/packages/api/src/lib/prompts/scoping.ts
+++ b/packages/api/src/lib/prompts/scoping.ts
@@ -36,8 +36,11 @@
 import type { AtlasMode } from "@useatlas/types/auth";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { getSettingAuto } from "@atlas/api/lib/settings";
+import { DEMO_INDUSTRY_SETTING } from "@atlas/api/lib/demo-industry";
 
-export const DEMO_INDUSTRY_SETTING = "ATLAS_DEMO_INDUSTRY";
+// Re-exported so existing importers (`resolvePromptScope` callers, tests)
+// don't need to switch paths.
+export { DEMO_INDUSTRY_SETTING };
 
 /**
  * Tagged union of the three prompt-scoping scenarios.


### PR DESCRIPTION
Bundles three related bugs that all touch `admin-archive.ts` + `admin-publish.ts`. Closes the two remaining 1.2.0 bugs plus a newly-filed rollback-poisoning bug that was also a cleanup win for migrate.ts and internal.ts.

Closes #1466 #1470 #1471

## #1466 — publish skipped demo prompts silently (wrong key)

`admin-publish.ts:153` hand-rolled `SELECT value FROM settings WHERE key = 'demo_industry'`. The canonical key is `ATLAS_DEMO_INDUSTRY` — every row missed, every publish quietly left built-in demo prompts at `published` while the `__demo__` connection flipped to `archived`. `mode.ts:191` uses `getSettingAuto(\"ATLAS_DEMO_INDUSTRY\", orgId)` correctly; both admin routes now do the same.

## #1470 — transient read failure indistinguishable from \"setting absent\"

Old `readDemoIndustry`:

```ts
try { ... return rows[0]?.value ?? null; }
catch (err) { log.warn(...); return null; }
```

A transient DB/cache failure returned `null`, the caller proceeded into the transaction, archived the connection, committed — and demo prompts stayed published. Helper now returns `{ ok: true, value: string | null } | { ok: false, err: Error }`. Callers 500 with `requestId` on `ok: false`; the 500 happens *before* BEGIN, so there's no half-committed state.

## #1471 — dirty `pg` client returned to the pool on ROLLBACK failure

Each transactional handler had:

```ts
} finally { client.release(); }
```

When ROLLBACK itself fails (broken socket), the client was pooled dirty and the next borrower inherited it. Fixed at four call sites — track `rollbackErr` in the ROLLBACK `.catch`, pass to `release(err)` so node-postgres destroys instead of pools:

- `packages/api/src/api/routes/admin-archive.ts` — archive handler
- `packages/api/src/api/routes/admin-archive.ts` — restore handler
- `packages/api/src/api/routes/admin-publish.ts` — publish handler
- `packages/api/src/lib/db/migrate.ts` — migration loop (rollbackErr propagates via callback to outer release)
- `packages/api/src/lib/db/internal.ts` — `cascadeWorkspaceDelete`

`InternalPoolClient.release` signature widened to `(err?: Error | boolean)` to match `pg.PoolClient`.

### Incidental finding (filed separately)

`hardDeleteWorkspace` (internal.ts:~1803) and a naked `await client.query(\"ROLLBACK\")` at :~1591 have the same poisoning pattern. Out of scope here per project convention — filed #1485.

## Operator-visible behaviour change

Previously a transient settings read failure would succeed the archive/publish with `prompts: 0`. Now it returns 500 with a `requestId` before the transaction opens. This is the intent of the ticket — operators should see the failure, not have it masked.

## Test plan

- [x] `bun run lint`
- [x] `bun run type`
- [x] `bun run test` — full suite passes
- [x] `bun x syncpack lint`
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh`
- [x] New test: publish reads via canonical key (regression guard for #1466)
- [x] New test: publish + archive + restore return 500 on settings read failure (#1470)
- [x] New tests: clean-rollback calls `release()`, failed-rollback calls `release(err)` (#1471)
- [x] Updated test: transient settings read no longer silently returns 200 — expects 500