### PR TITLE
fix(db): rebuild semantic_entities unique indexes to include entity_type

### DIFF
--- a/e2e/browser/global-setup.ts
+++ b/e2e/browser/global-setup.ts
@@ -55,12 +55,14 @@ setup("authenticate as admin", async ({ page }) => {
   }
 
   let loggedIn = await tryLogin(E2E_PASSWORD);
+  let usedDefaultPassword = false;
 
   if (!loggedIn) {
     // Clear the error and try with default password
     await page.goto("/");
     await emailInput.waitFor({ timeout: 15_000 });
     loggedIn = await tryLogin(DEFAULT_PASSWORD);
+    usedDefaultPassword = loggedIn;
   }
 
   if (!loggedIn) {
@@ -71,18 +73,27 @@ setup("authenticate as admin", async ({ page }) => {
     );
   }
 
-  // Handle password change dialog if it appears (only on first login with default password)
-  const changePasswordTitle = page.locator("text=Change your password");
-  if (await changePasswordTitle.isVisible({ timeout: 3_000 }).catch(() => false)) {
-    const newPwInput = page.locator('input[placeholder="At least 8 characters"]');
-    await newPwInput.fill(E2E_PASSWORD);
-
-    // Confirm password — 3rd password input in the form
-    const passwordInputs = page.locator('form input[type="password"]');
-    await passwordInputs.nth(2).fill(E2E_PASSWORD);
-
-    await page.locator('button:has-text("Change password")').click();
-    await expect(changePasswordTitle).toBeHidden({ timeout: 10_000 });
+  // When login succeeded with the default password, rotate it to E2E_PASSWORD so
+  // all subsequent tests can log in deterministically. The UI may or may not
+  // surface a "Change your password" dialog depending on session state — call
+  // the admin API directly so we don't depend on that UI flow.
+  if (usedDefaultPassword) {
+    const res = await page.request.post("/api/v1/admin/me/password", {
+      data: { currentPassword: DEFAULT_PASSWORD, newPassword: E2E_PASSWORD },
+    });
+    if (!res.ok()) {
+      throw new Error(
+        `Failed to rotate admin password from default to e2e via API. ` +
+        `Status: ${res.status()}. Body: ${await res.text()}`,
+      );
+    }
+    // If the rotation dialog is modal-blocking the app, dismiss it now — it should
+    // auto-close once the password_change_required flag is cleared, but be defensive.
+    const changeDialog = page.locator("text=Change your password");
+    if (await changeDialog.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await page.reload();
+      await page.locator('input[placeholder="Ask a question about your data..."]').waitFor({ timeout: 15_000 });
+    }
   }
 
   // Dismiss the guided tour if it appears (fresh DB / first login)

--- a/e2e/browser/signup-connect.spec.ts
+++ b/e2e/browser/signup-connect.spec.ts
@@ -102,6 +102,9 @@ test.describe("Signup connect — demo availability", () => {
 });
 
 test.describe("Signup connect — error isolation", () => {
+  // Scope alert queries to <main> — Next.js dev tools inject a root-level
+  // role="alert" indicator for build errors/warnings that would otherwise be
+  // counted alongside the app's alerts.
   test("demo failure produces exactly one alert on the demo card", async ({ page }) => {
     await mockHealth(page, "ok");
     await mockOnboarding(page, {
@@ -109,13 +112,15 @@ test.describe("Signup connect — error isolation", () => {
     });
     await page.goto(PATH);
 
+    const main = page.getByRole("main");
+
     // Before: no alerts
-    await expect(page.getByRole("alert")).toHaveCount(0);
+    await expect(main.getByRole("alert")).toHaveCount(0);
 
     await page.getByRole("button", { name: /Use SaaS CRM demo dataset/ }).click();
 
     // After: exactly one alert, carrying the demo error
-    const alert = page.getByRole("alert");
+    const alert = main.getByRole("alert");
     await expect(alert).toHaveCount(1);
     await expect(alert).toContainText("demo setup failed");
   });
@@ -127,12 +132,13 @@ test.describe("Signup connect — error isolation", () => {
     });
     await page.goto(PATH);
 
-    await expect(page.getByRole("alert")).toHaveCount(0);
+    const main = page.getByRole("main");
+    await expect(main.getByRole("alert")).toHaveCount(0);
 
     await page.getByLabel("Connection URL").fill("postgresql://u:p@h:5432/db");
     await page.getByRole("button", { name: "Test connection" }).click();
 
-    const alert = page.getByRole("alert");
+    const alert = main.getByRole("alert");
     await expect(alert).toHaveCount(1);
     await expect(alert).toContainText("connection refused");
   });
@@ -148,16 +154,18 @@ test.describe("Signup connect — error isolation", () => {
     });
     await page.goto(PATH);
 
+    const main = page.getByRole("main");
+
     await page.getByLabel("Connection URL").fill("postgresql://u:p@h:5432/db");
     await page.getByRole("button", { name: "Test connection" }).click();
 
     // Success status pill appears
-    await expect(page.getByRole("status")).toContainText(/Connected to PostgreSQL in 12ms/);
+    await expect(main.getByRole("status")).toContainText(/Connected to PostgreSQL in 12ms/);
 
     await page.getByRole("button", { name: "Continue" }).click();
 
     // Error alert appears and the success pill is gone — never both
-    await expect(page.getByRole("alert")).toContainText("save failed");
-    await expect(page.getByRole("status")).toHaveCount(0);
+    await expect(main.getByRole("alert")).toContainText("save failed");
+    await expect(main.getByRole("status")).toHaveCount(0);
   });
 });

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -273,6 +273,7 @@ describe("migrateAuthTables", () => {
             { name: "0025_fix_null_unsafe_indexes.sql" },
             { name: "0026_drop_legacy_semantic_entity_index.sql" },
             { name: "0027_organization_saas_columns.sql" },
+            { name: "0028_fix_semantic_entity_uniqueness.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -78,7 +78,7 @@ describe("runMigrations", () => {
 
     const count = await runMigrations(pool);
 
-    expect(count).toBe(28);
+    expect(count).toBe(29);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -135,6 +135,7 @@ describe("runMigrations", () => {
         "0025_fix_null_unsafe_indexes.sql",
         "0026_drop_legacy_semantic_entity_index.sql",
         "0027_organization_saas_columns.sql",
+        "0028_fix_semantic_entity_uniqueness.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0028_fix_semantic_entity_uniqueness.sql
+++ b/packages/api/src/lib/db/migrations/0028_fix_semantic_entity_uniqueness.sql
@@ -1,0 +1,28 @@
+-- 0028 — Rebuild semantic_entities partial unique indexes to include entity_type
+--
+-- 0024/0025 indexed (org_id, name, connection_id) filtered by status — but the
+-- original uniqueness key was (org_id, entity_type, name). 'accounts' exists as
+-- both an entity_type='entity' row AND an entity_type='metric' row for the same
+-- org + connection, so the 0024/0025 indexes rejected perfectly legitimate data.
+--
+-- Prod regions us + apac boot-crashed on 0024/0025 because of this; eu passed
+-- only because it had zero rows at migration time.
+--
+-- Fix: drop and recreate with entity_type in the key. COALESCE(connection_id,
+-- '__default__') is preserved from 0025 for NULL-safety.
+
+DROP INDEX IF EXISTS uq_semantic_entity_published;
+DROP INDEX IF EXISTS uq_semantic_entity_draft;
+DROP INDEX IF EXISTS uq_semantic_entity_tombstone;
+
+CREATE UNIQUE INDEX uq_semantic_entity_published
+  ON semantic_entities(org_id, entity_type, name, COALESCE(connection_id, '__default__'))
+  WHERE status = 'published';
+
+CREATE UNIQUE INDEX uq_semantic_entity_draft
+  ON semantic_entities(org_id, entity_type, name, COALESCE(connection_id, '__default__'))
+  WHERE status = 'draft';
+
+CREATE UNIQUE INDEX uq_semantic_entity_tombstone
+  ON semantic_entities(org_id, entity_type, name, COALESCE(connection_id, '__default__'))
+  WHERE status = 'draft_delete';


### PR DESCRIPTION
## Summary

Production incident: **us + apac internal DB `down` / `INTERNAL_DB_UNREACHABLE`** — both services boot-crashed on the 1.2.0 mode migrations.

Migration 0024 (added for #1421 dual-mode) indexed `semantic_entities` on `(org_id, name, connection_id)` filtered by `status`, dropping `entity_type` from the baseline uniqueness key. The original `idx_semantic_entities_org_type_name` is `(org_id, entity_type, name)` — `accounts` legitimately exists as both `entity_type='entity'` and `entity_type='metric'` for the same org + connection, so the new partial indexes rejected real data with duplicate key violations.

| Region | Stuck on | Why |
|---|---|---|
| us | `0024_mode_status_columns.sql` | non-NULL dupes `(org, accounts, default)` defeated even the NULL-unsafe index |
| apac | `0025_fix_null_unsafe_indexes.sql` | NULLs collapsed to `__default__` sentinel, collided |
| eu | ✅ passed | zero rows at migration time |

Boot aborted before the pool was usable, so `/api/health` returned `internalDb: { status: "down", message: "INTERNAL_DB_UNREACHABLE" }` for us + apac.

## Fix

New migration `0028_fix_semantic_entity_uniqueness.sql` drops and recreates the three partial unique indexes with `(org_id, entity_type, name, COALESCE(connection_id, '__default__'))`. COALESCE is kept from 0025 for NULL-safety.

**Prod already restored:** applied the equivalent SQL directly to us/eu/apac internal DBs; both failing regions redeployed and all three now report `status: "ok"` + `internalDb: healthy`. `0028` inserted into `__atlas_migrations` on each so this PR is a no-op for existing regions and a normal-flow migration for fresh installs.

## Also

- `e2e/browser/global-setup.ts` — rotate admin password via `POST /api/v1/admin/me/password` instead of the forced-change dialog (which doesn't always render within 3s window). Fresh `db:reset` → e2e tests now work without `ATLAS_ADMIN_PASSWORD=atlas-dev` override.
- `e2e/browser/signup-connect.spec.ts` — scope `getByRole("alert")` queries to `<main>` so Next.js 15's dev-tools indicator alert isn't double-counted in the error-isolation assertions. Fixes 3 signup-connect tests.
- `migrate.test.ts` — bump expected migration count 28 → 29.

## Test plan

- [x] `bun run lint` / `bun run type` / `bun test packages/api/src/lib/db/__tests__/migrate.test.ts` all pass
- [x] Manual: all 3 prod regions return `status: "ok"` with `internalDb: healthy`
- [x] Local: fresh `bun run db:reset` → full 0000–0028 migration chain applies cleanly, admin login works, signup-connect tests pass with alert scoping
- [ ] Post-merge: confirm next deploy sees `0028` already applied on prod (no-op) and any future region provisioning runs 0024–0028 clean