### PR TITLE
fix(db): destroy poisoned client on failed ROLLBACK in hardDeleteWorkspace

### DIFF
--- a/packages/api/src/lib/db/__tests__/internal.test.ts
+++ b/packages/api/src/lib/db/__tests__/internal.test.ts
@@ -15,6 +15,7 @@ import {
   migrateInternalDB,
   loadSavedConnections,
   cascadeWorkspaceDelete,
+  hardDeleteWorkspace,
   _resetPool,
   _resetCircuitBreaker,
   encryptUrl,
@@ -593,6 +594,86 @@ describe("cascadeWorkspaceDelete()", () => {
     _resetPool(failPool);
 
     await expect(cascadeWorkspaceDelete("org-fail")).rejects.toThrow("primary mutation failure");
+
+    expect(calls.releaseCount).toBe(1);
+    expect(calls.lastReleaseArg).toBeInstanceOf(Error);
+    expect((calls.lastReleaseArg as Error).message).toContain("ROLLBACK failed");
+  });
+});
+
+describe("hardDeleteWorkspace()", () => {
+  it("destroys the client when ROLLBACK fails after a purge transaction error", async () => {
+    const { pool: basePool } = createMockPool();
+    const calls = {
+      queries: [] as { sql: string }[],
+      releaseCount: 0,
+      lastReleaseArg: undefined as unknown,
+    };
+    let queryNum = 0;
+    const failPool = {
+      ...basePool,
+      async connect() {
+        return {
+          async query(sql: string) {
+            calls.queries.push({ sql });
+            queryNum++;
+            // BEGIN (1) passes, status check (2) returns "deleted" so purge proceeds,
+            // first cascade DELETE (3) throws, then ROLLBACK (4) also fails
+            if (queryNum === 2) return { rows: [{ workspace_status: "deleted" }] };
+            if (queryNum === 3) throw new Error("relation does not exist");
+            if (sql.trim().toUpperCase() === "ROLLBACK") {
+              throw new Error("ROLLBACK failed — socket dirty");
+            }
+            return { rows: [] };
+          },
+          release(err?: Error) {
+            calls.releaseCount++;
+            calls.lastReleaseArg = err;
+          },
+        };
+      },
+    };
+    _resetPool(failPool);
+
+    await expect(hardDeleteWorkspace("org-fail")).rejects.toThrow("relation does not exist");
+
+    expect(calls.releaseCount).toBe(1);
+    expect(calls.lastReleaseArg).toBeInstanceOf(Error);
+    expect((calls.lastReleaseArg as Error).message).toContain("ROLLBACK failed");
+  });
+
+  it("destroys the client when the pre-lock status check ROLLBACK fails", async () => {
+    // Workspace isn't in "deleted" status — the pre-transaction ROLLBACK must
+    // also be guarded. If it fails, the client is poisoned and must be destroyed.
+    const { pool: basePool } = createMockPool();
+    const calls = {
+      releaseCount: 0,
+      lastReleaseArg: undefined as unknown,
+    };
+    let queryNum = 0;
+    const failPool = {
+      ...basePool,
+      async connect() {
+        return {
+          async query(sql: string) {
+            queryNum++;
+            // BEGIN passes, status check returns "active" (not deleted), ROLLBACK fails
+            if (queryNum === 2) return { rows: [{ workspace_status: "active" }] };
+            if (sql.trim().toUpperCase() === "ROLLBACK") {
+              throw new Error("ROLLBACK failed during status guard");
+            }
+            return { rows: [] };
+          },
+          release(err?: Error) {
+            calls.releaseCount++;
+            calls.lastReleaseArg = err;
+          },
+        };
+      },
+    };
+    _resetPool(failPool);
+
+    await expect(hardDeleteWorkspace("org-active")).rejects.toThrow("not in deleted status");
 
     expect(calls.releaseCount).toBe(1);
     expect(calls.lastReleaseArg).toBeInstanceOf(Error);

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1592,6 +1592,9 @@ export interface HardDeleteResult {
 export async function hardDeleteWorkspace(orgId: string): Promise<HardDeleteResult> {
   const pool = getInternalDB();
   const client = await pool.connect();
+  // Destroy the client on a failed ROLLBACK so a dirty socket doesn't poison
+  // the next borrower (matches cascadeWorkspaceDelete + admin-archive/publish).
+  let rollbackErr: Error | null = null;
 
   try {
     await client.query("BEGIN");
@@ -1605,7 +1608,13 @@ export async function hardDeleteWorkspace(orgId: string): Promise<HardDeleteResu
     );
     const status = (statusCheck.rows[0] as Record<string, unknown> | undefined)?.workspace_status;
     if (statusCheck.rows.length === 0 || status !== "deleted") {
-      await client.query("ROLLBACK");
+      await client.query("ROLLBACK").catch((rbErr: unknown) => {
+        rollbackErr = rbErr instanceof Error ? rbErr : new Error(String(rbErr));
+        log.warn(
+          { orgId, err: rollbackErr.message },
+          "ROLLBACK failed during hardDeleteWorkspace status check — client will be destroyed",
+        );
+      });
       throw new Error("Workspace is not in deleted status — purge aborted");
     }
 
@@ -1817,14 +1826,15 @@ export async function hardDeleteWorkspace(orgId: string): Promise<HardDeleteResu
       organization,
     };
   } catch (err) {
-    await client.query("ROLLBACK").catch((rollbackErr) => {
+    await client.query("ROLLBACK").catch((rbErr: unknown) => {
+      rollbackErr = rbErr instanceof Error ? rbErr : new Error(String(rbErr));
       log.warn(
-        { err: rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr), orgId },
-        "ROLLBACK failed after purge transaction error — verify data integrity",
+        { orgId, err: rollbackErr.message },
+        "ROLLBACK failed after purge transaction error — client will be destroyed",
       );
     });
     throw err;
   } finally {
-    client.release();
+    client.release(rollbackErr ?? undefined);
   }
 }


### PR DESCRIPTION
Closes #1485.

Follow-up to #1471 — same pattern applied to two additional sites in `internal.ts` that were out of scope in PR #1486:

### 1. `hardDeleteWorkspace` catch/finally (~line 1820)

The ROLLBACK `.catch` handler now tracks `rollbackErr` and passes it to `client.release(err)` in `finally` so pg destroys a dirty socket instead of pooling it. Matches the cascadeWorkspaceDelete pattern shipped in #1486.

### 2. Pre-lock status guard (~line 1608)

The naked `await client.query("ROLLBACK")` before the "Workspace is not in deleted status" throw is now guarded with `.catch()` that tracks `rollbackErr`. If this ROLLBACK fails, the subsequent release in `finally` passes the error.

Before, if that ROLLBACK threw, the exception would propagate into the outer `catch` which would try to ROLLBACK again (pg: `no transaction in progress`) and then the finally released the client cleanly — masking the original issue and poisoning the pool.

## Impact

Both sites are in the SaaS-only platform-admin hard-delete flow. Low occurrence but the failure mode is sneaky — a poisoned client from a purge affects unrelated workspace requests that borrow the same connection next.

## Test plan

- [x] 2 new tests in `internal.test.ts` mirror the cascadeWorkspaceDelete rollback-poisoning tests:
  - ROLLBACK failure after the purge transaction errors → `release(err)`
  - Pre-lock status guard ROLLBACK failure → `release(err)`
- [x] `bun run lint` / `bun run type` / `bun test packages/api/src/lib/db/__tests__/internal.test.ts` all pass locally