### PR TITLE
docs(obsidian): correct chat endpoint path /api/chat → /api/v1/chat

### DIFF
--- a/apps/docs/content/docs/plugins/interactions/obsidian.mdx
+++ b/apps/docs/content/docs/plugins/interactions/obsidian.mdx
@@ -76,7 +76,7 @@ Both the modal and code blocks display query results as HTML tables. Tables are 
 
 ## How It Works
 
-The plugin uses a lightweight streaming client (`src/client.ts`) that connects to the Atlas `/api/chat` endpoint. It parses a subset of the Vercel AI SDK data stream protocol — text deltas, tool results, errors, and finish signals — and emits typed events:
+The plugin uses a lightweight streaming client (`src/client.ts`) that connects to the Atlas `/api/v1/chat` endpoint. It parses a subset of the Vercel AI SDK data stream protocol — text deltas, tool results, errors, and finish signals — and emits typed events:
 
 | Event | Description |
 |-------|-------------|


### PR DESCRIPTION
## Summary

Audit finding was a **false positive** on both plugins — the doc pages already exist and are comprehensive:

- `apps/docs/content/docs/plugins/interactions/mcp.mdx` — fully documents `@useatlas/mcp` (stdio/SSE transports, Claude Desktop setup, troubleshooting). Verified against `plugins/mcp/README.md` and `plugins/mcp/src/index.ts`. No edits needed.
- `apps/docs/content/docs/plugins/interactions/obsidian.mdx` — fully documents the Obsidian community plugin (install, config, query modal, code blocks, streaming client). Verified against `plugins/obsidian/README.md` and `src/` (main, client, settings, query-modal).

While verifying, found one stale detail in the Obsidian page: the "How It Works" section referenced `/api/chat` but the client (`plugins/obsidian/src/client.ts:32`) actually posts to `/api/v1/chat`. This PR fixes that single line.

### Findings

- **mcp**: skipped — doc already exists and accurately reflects the plugin source.
- **obsidian**: fixed — one-line endpoint reference corrected from `/api/chat` to `/api/v1/chat`.

## Test plan

- [x] `cd apps/docs && bun run build` succeeds (471 static pages prerendered, MDX compiles clean)
- [ ] Reviewer spot-checks the updated line renders correctly on the docs site