### PR TITLE
refactor(effect): migrate internalQuery call sites to tryPromise (#1468)

### DIFF
--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -31,6 +31,21 @@ import {
 import * as fs from "fs";
 import * as path from "path";
 
+/**
+ * Wraps a Promise-returning `internalQuery` mock as an `Effect` so tests
+ * that override `@atlas/api/lib/db/internal` via `mock.module()` can
+ * supply a `queryEffect` export without repeating the tryPromise boilerplate.
+ */
+export function makeQueryEffectMock(
+  internalQueryMock: (sql: string, params?: unknown[]) => Promise<unknown[]>,
+) {
+  return <T extends Record<string, unknown>>(sql: string, params?: unknown[]) =>
+    Effect.tryPromise({
+      try: () => internalQueryMock(sql, params) as Promise<T[]>,
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    });
+}
+
 // ── Types ───────────────────────────────────────────────────────────
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentionally generic mock function type for test overrides
@@ -218,6 +233,11 @@ export function createApiTestMocks(
   const internalDefaults: Record<string, unknown> = {
     hasInternalDB: () => _hasInternalDB,
     internalQuery: mockInternalQuery,
+    queryEffect: (sql: string, params?: unknown[]) =>
+      Effect.tryPromise({
+        try: () => mockInternalQuery(sql, params),
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }),
     internalExecute: mockInternalExecute,
     getInternalDB: mock(() => ({})),
     closeInternalDB: mock(async () => {}),

--- a/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
@@ -17,6 +17,7 @@ import {
   type Mock,
 } from "bun:test";
 import { createConnectionMock } from "@atlas/api/testing/connection";
+import { makeQueryEffectMock } from "@atlas/api/testing/api-test-mocks";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -106,6 +107,7 @@ const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unkno
 mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => mockHasInternalDB,
   internalQuery: mockInternalQuery,
+  queryEffect: makeQueryEffectMock(mockInternalQuery),
   internalExecute: mock(() => {}),
   getInternalDB: mock(() => ({})),
   closeInternalDB: mock(async () => {}),

--- a/packages/api/src/api/__tests__/admin-integrations.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations.test.ts
@@ -14,6 +14,7 @@ import {
   type Mock,
 } from "bun:test";
 import { createConnectionMock } from "@atlas/api/testing/connection";
+import { makeQueryEffectMock } from "@atlas/api/testing/api-test-mocks";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -103,6 +104,7 @@ const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unkno
 mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => mockHasInternalDB,
   internalQuery: mockInternalQuery,
+  queryEffect: makeQueryEffectMock(mockInternalQuery),
   internalExecute: mock(() => {}),
   getInternalDB: mock(() => ({})),
   closeInternalDB: mock(async () => {}),

--- a/packages/api/src/api/__tests__/admin-invitations.test.ts
+++ b/packages/api/src/api/__tests__/admin-invitations.test.ts
@@ -14,6 +14,7 @@ import {
   type Mock,
 } from "bun:test";
 import { createConnectionMock } from "@atlas/api/testing/connection";
+import { makeQueryEffectMock } from "@atlas/api/testing/api-test-mocks";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -113,6 +114,7 @@ const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unkno
 mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => mockHasInternalDB,
   internalQuery: mockInternalQuery,
+  queryEffect: makeQueryEffectMock(mockInternalQuery),
   internalExecute: mock(() => {}),
   getInternalDB: mock(() => ({})),
   closeInternalDB: mock(async () => {}),

--- a/packages/api/src/api/__tests__/admin-marketplace.test.ts
+++ b/packages/api/src/api/__tests__/admin-marketplace.test.ts
@@ -124,17 +124,25 @@ mock.module("@atlas/ee/auth/ip-allowlist", () => ({
 // --- Internal DB mock ---
 
 let mockHasInternalDB = true;
-let mockQueryResults: Map<string, unknown[]> = new Map();
+// Map SQL fragment → rows (normal case) or Error (rejection). Using a union
+// means tests can set `mockQueryResults.set("prompt_catalog", new Error("db down"))`
+// and drive both the internalQuery and queryEffect mocks down the failure path.
+let mockQueryResults: Map<string, unknown[] | Error> = new Map();
 
-function setQueryResult(pattern: string, rows: unknown[]) {
+function setQueryResult(pattern: string, rows: unknown[] | Error) {
   mockQueryResults.set(pattern, rows);
 }
 
-function findQueryResult(sql: string): unknown[] {
+function findQueryResult(sql: string): unknown[] | Error {
   for (const [pattern, rows] of mockQueryResults) {
     if (sql.includes(pattern)) return rows;
   }
   return [];
+}
+
+function invokeInternalQueryMock(sql: string): Promise<unknown[]> {
+  const result = findQueryResult(sql);
+  return result instanceof Error ? Promise.reject(result) : Promise.resolve(result);
 }
 
 mock.module("@atlas/api/lib/db/internal", () => ({
@@ -144,10 +152,10 @@ mock.module("@atlas/api/lib/db/internal", () => ({
     end: async () => {},
     on: () => {},
   }),
-  internalQuery: (_sql: string, _params?: unknown[]) => Promise.resolve(findQueryResult(_sql)),
+  internalQuery: (sql: string, _params?: unknown[]) => invokeInternalQueryMock(sql),
   queryEffect: (sql: string) => ({
     [Symbol.iterator]: function* (): Generator<unknown, unknown> {
-      return yield { _tag: "EffectPromise", fn: () => Promise.resolve(findQueryResult(sql)) };
+      return yield { _tag: "EffectPromise", fn: () => invokeInternalQueryMock(sql) };
     },
   }),
   internalExecute: () => {},

--- a/packages/api/src/api/__tests__/admin-marketplace.test.ts
+++ b/packages/api/src/api/__tests__/admin-marketplace.test.ts
@@ -145,6 +145,11 @@ mock.module("@atlas/api/lib/db/internal", () => ({
     on: () => {},
   }),
   internalQuery: (_sql: string, _params?: unknown[]) => Promise.resolve(findQueryResult(_sql)),
+  queryEffect: (sql: string) => ({
+    [Symbol.iterator]: function* (): Generator<unknown, unknown> {
+      return yield { _tag: "EffectPromise", fn: () => Promise.resolve(findQueryResult(sql)) };
+    },
+  }),
   internalExecute: () => {},
   setWorkspaceRegion: mock(async () => {}),
   insertSemanticAmendment: mock(async () => "mock-amendment-id"),

--- a/packages/api/src/api/__tests__/admin-password.test.ts
+++ b/packages/api/src/api/__tests__/admin-password.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { createConnectionMock } from "@atlas/api/testing/connection";
+import { makeQueryEffectMock } from "@atlas/api/testing/api-test-mocks";
 import {
   describe,
   it,
@@ -71,6 +72,7 @@ const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unkno
 mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => mockHasInternalDB,
   internalQuery: mockInternalQuery,
+  queryEffect: makeQueryEffectMock(mockInternalQuery),
   internalExecute: mock(() => {}),
   getInternalDB: mock(() => ({})),
   closeInternalDB: mock(async () => {}),

--- a/packages/api/src/api/__tests__/admin-residency.test.ts
+++ b/packages/api/src/api/__tests__/admin-residency.test.ts
@@ -144,6 +144,11 @@ mock.module("@atlas/api/lib/db/internal", () => ({
     on: () => {},
   }),
   internalQuery: () => Promise.resolve(mockInternalQueryResult),
+  queryEffect: () => ({
+    [Symbol.iterator]: function* (): Generator<unknown, unknown> {
+      return yield { _tag: "EffectPromise", fn: () => Promise.resolve(mockInternalQueryResult) };
+    },
+  }),
   internalExecute: () => {},
   getWorkspaceRegion: () => Promise.resolve(null),
   setWorkspaceRegion: () => Promise.resolve({ assigned: true }),

--- a/packages/api/src/api/__tests__/admin-residency.test.ts
+++ b/packages/api/src/api/__tests__/admin-residency.test.ts
@@ -134,7 +134,15 @@ mock.module("@atlas/api/lib/auth/detect", () => ({
 // --- Internal DB mock ---
 
 let mockHasInternalDB = true;
-let mockInternalQueryResult: unknown[] = [];
+// Either a data array (resolves) or an Error (rejects) — shared between the
+// internalQuery and queryEffect mocks so tests can exercise DB rejection paths.
+let mockInternalQueryResult: unknown[] | Error = [];
+
+function invokeInternalQueryMock(): Promise<unknown[]> {
+  return mockInternalQueryResult instanceof Error
+    ? Promise.reject(mockInternalQueryResult)
+    : Promise.resolve(mockInternalQueryResult);
+}
 
 mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => mockHasInternalDB,
@@ -143,10 +151,10 @@ mock.module("@atlas/api/lib/db/internal", () => ({
     end: async () => {},
     on: () => {},
   }),
-  internalQuery: () => Promise.resolve(mockInternalQueryResult),
+  internalQuery: invokeInternalQueryMock,
   queryEffect: () => ({
     [Symbol.iterator]: function* (): Generator<unknown, unknown> {
-      return yield { _tag: "EffectPromise", fn: () => Promise.resolve(mockInternalQueryResult) };
+      return yield { _tag: "EffectPromise", fn: invokeInternalQueryMock };
     },
   }),
   internalExecute: () => {},

--- a/packages/api/src/api/__tests__/admin-usage.test.ts
+++ b/packages/api/src/api/__tests__/admin-usage.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { createConnectionMock } from "@atlas/api/testing/connection";
+import { makeQueryEffectMock } from "@atlas/api/testing/api-test-mocks";
 import {
   describe,
   it,
@@ -92,10 +93,12 @@ mock.module("@atlas/api/lib/metering", () => ({
 // --- Internal DB mock ---
 
 let mockHasInternalDB = true;
+const mockInternalQueryUsage: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(() => Promise.resolve([]));
 
 mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => mockHasInternalDB,
-  internalQuery: mock(() => Promise.resolve([])),
+  internalQuery: mockInternalQueryUsage,
+  queryEffect: makeQueryEffectMock(mockInternalQueryUsage),
   internalExecute: mock(() => {}),
   getInternalDB: mock(() => ({})),
   closeInternalDB: mock(() => Promise.resolve()),

--- a/packages/api/src/api/__tests__/admin-workspace.test.ts
+++ b/packages/api/src/api/__tests__/admin-workspace.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { createConnectionMock } from "@atlas/api/testing/connection";
+import { makeQueryEffectMock } from "@atlas/api/testing/api-test-mocks";
 import {
   describe,
   it,
@@ -149,6 +150,7 @@ const mockGetWorkspaceHealthSummary: Mock<(orgId: string) => Promise<unknown>> =
 mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => mockHasInternalDB,
   internalQuery: mockInternalQuery,
+  queryEffect: makeQueryEffectMock(mockInternalQuery),
   internalExecute: mock(() => {}),
   getInternalDB: mock(() => ({})),
   closeInternalDB: mock(async () => {}),

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { createConnectionMock } from "@atlas/api/testing/connection";
+import { makeQueryEffectMock } from "@atlas/api/testing/api-test-mocks";
 import {
   describe,
   it,
@@ -209,6 +210,7 @@ const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unkno
 mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => mockHasInternalDB,
   internalQuery: mockInternalQuery,
+  queryEffect: makeQueryEffectMock(mockInternalQuery),
   internalExecute: mock(() => {}),
   getInternalDB: mock(() => ({})),
   closeInternalDB: mock(async () => {}),

--- a/packages/api/src/api/__tests__/onboarding.test.ts
+++ b/packages/api/src/api/__tests__/onboarding.test.ts
@@ -13,6 +13,7 @@
 import { describe, it, expect, beforeEach, afterEach, mock, type Mock } from "bun:test";
 import { Effect } from "effect";
 import { createConnectionMock } from "@atlas/api/testing/connection";
+import { makeQueryEffectMock } from "@atlas/api/testing/api-test-mocks";
 
 // --- Mocks ---
 
@@ -77,6 +78,7 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: mockHasInternalDB,
   getInternalDB: () => ({ query: async () => ({ rows: [] }) }),
   internalQuery: mockInternalQuery,
+  queryEffect: makeQueryEffectMock(mockInternalQuery),
   internalExecute: () => {},
   encryptUrl: mockEncryptUrl,
   decryptUrl: (url: string) => url,

--- a/packages/api/src/api/routes/admin-audit.ts
+++ b/packages/api/src/api/routes/admin-audit.ts
@@ -13,7 +13,7 @@ import { HTTPException } from "hono/http-exception";
 import { createLogger } from "@atlas/api/lib/logger";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { AuthContext } from "@atlas/api/lib/effect/services";
-import { internalQuery } from "@atlas/api/lib/db/internal";
+import { internalQuery, queryEffect } from "@atlas/api/lib/db/internal";
 import { ErrorSchema, AuthErrorSchema, parsePagination, escapeIlike } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
 
@@ -475,12 +475,12 @@ adminAudit.openapi(auditVolumeRoute, async (c) => {
       throw new HTTPException(400, { res: Response.json({ error: "invalid_request", message: range.error, requestId: c.get("requestId") as string }, { status: 400 }) });
     }
 
-    const rows = yield* Effect.promise(() => internalQuery<{ day: string; count: string; errors: string }>(
+    const rows = yield* queryEffect<{ day: string; count: string; errors: string }>(
       `SELECT DATE(timestamp) as day, COUNT(*) as count, COUNT(*) FILTER (WHERE NOT success) as errors
        FROM audit_log ${range.where}
        GROUP BY DATE(timestamp) ORDER BY day`,
       range.params,
-    ));
+    );
 
     return c.json({
       volume: rows.map((r) => ({
@@ -501,7 +501,7 @@ adminAudit.openapi(auditSlowRoute, async (c) => {
       throw new HTTPException(400, { res: Response.json({ error: "invalid_request", message: range.error, requestId: c.get("requestId") as string }, { status: 400 }) });
     }
 
-    const rows = yield* Effect.promise(() => internalQuery<{
+    const rows = yield* queryEffect<{
       query: string; avg_duration: string; max_duration: string; count: string;
     }>(
       `SELECT LEFT(sql, 200) as query, ROUND(AVG(duration_ms)) as avg_duration,
@@ -509,7 +509,7 @@ adminAudit.openapi(auditSlowRoute, async (c) => {
        FROM audit_log ${range.where}
        GROUP BY LEFT(sql, 200) ORDER BY AVG(duration_ms) DESC LIMIT 20`,
       range.params,
-    ));
+    );
 
     return c.json({
       queries: rows.map((r) => ({
@@ -531,7 +531,7 @@ adminAudit.openapi(auditFrequentRoute, async (c) => {
       throw new HTTPException(400, { res: Response.json({ error: "invalid_request", message: range.error, requestId: c.get("requestId") as string }, { status: 400 }) });
     }
 
-    const rows = yield* Effect.promise(() => internalQuery<{
+    const rows = yield* queryEffect<{
       query: string; count: string; avg_duration: string; error_count: string;
     }>(
       `SELECT LEFT(sql, 200) as query, COUNT(*) as count,
@@ -540,7 +540,7 @@ adminAudit.openapi(auditFrequentRoute, async (c) => {
        FROM audit_log ${range.where}
        GROUP BY LEFT(sql, 200) ORDER BY COUNT(*) DESC LIMIT 20`,
       range.params,
-    ));
+    );
 
     return c.json({
       queries: rows.map((r) => ({
@@ -563,13 +563,13 @@ adminAudit.openapi(auditErrorsRoute, async (c) => {
     }
 
     const errorCondition = `${range.where} AND NOT success`;
-    const rows = yield* Effect.promise(() => internalQuery<{ error: string; count: string }>(
+    const rows = yield* queryEffect<{ error: string; count: string }>(
       `SELECT COALESCE(LEFT(error, 150), 'Unknown error') as error, COUNT(*) as count
        FROM audit_log ${errorCondition}
        GROUP BY COALESCE(LEFT(error, 150), 'Unknown error')
        ORDER BY COUNT(*) DESC LIMIT 20`,
       range.params,
-    ));
+    );
 
     return c.json({
       errors: rows.map((r) => ({
@@ -589,7 +589,7 @@ adminAudit.openapi(auditUsersRoute, async (c) => {
       throw new HTTPException(400, { res: Response.json({ error: "invalid_request", message: range.error, requestId: c.get("requestId") as string }, { status: 400 }) });
     }
 
-    const rows = yield* Effect.promise(() => internalQuery<{
+    const rows = yield* queryEffect<{
       user_id: string; user_email: string | null; count: string;
       avg_duration: string; error_count: string;
     }>(
@@ -602,7 +602,7 @@ adminAudit.openapi(auditUsersRoute, async (c) => {
        GROUP BY COALESCE(a.user_id, 'anonymous'), u.email
        ORDER BY COUNT(*) DESC LIMIT 50`,
       range.params,
-    ));
+    );
 
     return c.json({
       users: rows.map((r) => {

--- a/packages/api/src/api/routes/admin-learned-patterns.ts
+++ b/packages/api/src/api/routes/admin-learned-patterns.ts
@@ -12,7 +12,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
-import { internalQuery } from "@atlas/api/lib/db/internal";
+import { internalQuery, queryEffect } from "@atlas/api/lib/db/internal";
 import { LEARNED_PATTERN_STATUSES, type LearnedPattern } from "@useatlas/types";
 import { invalidatePatternCache } from "@atlas/api/lib/learn/pattern-cache";
 import { ErrorSchema, AuthErrorSchema, parsePagination, createIdParamSchema, createListResponseSchema, DeletedResponseSchema } from "./shared-schemas";
@@ -408,7 +408,7 @@ adminLearnedPatterns.openapi(listPatternsRoute, async (c) => {
 
     const whereClause = `WHERE ${whereParts.join(" AND ")}`;
     const countParams = [...params];
-    const countRows = yield* Effect.promise(() => internalQuery<{ count: string }>(`SELECT COUNT(*) as count FROM learned_patterns ${whereClause}`, countParams));
+    const countRows = yield* queryEffect<{ count: string }>(`SELECT COUNT(*) as count FROM learned_patterns ${whereClause}`, countParams);
     const total = parseInt(countRows[0]?.count ?? "0", 10);
 
     const selectParams = [...params];
@@ -416,7 +416,7 @@ adminLearnedPatterns.openapi(listPatternsRoute, async (c) => {
     const limitIdx = nextIdx;
     selectParams.push(offset);
     const offsetIdx = limitIdx + 1;
-    const rows = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(`SELECT * FROM learned_patterns ${whereClause} ORDER BY created_at DESC LIMIT $${limitIdx} OFFSET $${offsetIdx}`, selectParams));
+    const rows = yield* queryEffect<Record<string, unknown>>(`SELECT * FROM learned_patterns ${whereClause} ORDER BY created_at DESC LIMIT $${limitIdx} OFFSET $${offsetIdx}`, selectParams);
 
     return c.json({ patterns: rows.map(toLearnedPattern), total, limit, offset }, 200);
   }), { label: "list learned patterns" });
@@ -433,7 +433,7 @@ adminLearnedPatterns.openapi(getPatternRoute, async (c) => {
     const { id } = c.req.valid("param");
     const params: unknown[] = [id];
     const org = orgFilter(orgId, params, params.length + 1);
-    const rows = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(`SELECT * FROM learned_patterns WHERE id = $1 AND ${org.clause}`, params));
+    const rows = yield* queryEffect<Record<string, unknown>>(`SELECT * FROM learned_patterns WHERE id = $1 AND ${org.clause}`, params);
     if (rows.length === 0) return c.json({ error: "not_found", message: "Learned pattern not found." }, 404);
     return c.json(toLearnedPattern(rows[0]), 200);
   }), { label: "get learned pattern" });
@@ -453,7 +453,7 @@ adminLearnedPatterns.openapi(updatePatternRoute, async (c) => {
 
     const checkParams: unknown[] = [id];
     const org = orgFilter(orgId, checkParams, checkParams.length + 1);
-    const existing = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(`SELECT * FROM learned_patterns WHERE id = $1 AND ${org.clause}`, checkParams));
+    const existing = yield* queryEffect<Record<string, unknown>>(`SELECT * FROM learned_patterns WHERE id = $1 AND ${org.clause}`, checkParams);
     if (existing.length === 0) return c.json({ error: "not_found", message: "Learned pattern not found." }, 404);
 
     const setClauses: string[] = ["updated_at = now()"];
@@ -466,7 +466,7 @@ adminLearnedPatterns.openapi(updatePatternRoute, async (c) => {
     const idIdx = paramIdx;
     paramIdx++;
     const updateOrg = orgFilter(orgId, updateParams, paramIdx);
-    const updated = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(`UPDATE learned_patterns SET ${setClauses.join(", ")} WHERE id = $${idIdx} AND ${updateOrg.clause} RETURNING *`, updateParams));
+    const updated = yield* queryEffect<Record<string, unknown>>(`UPDATE learned_patterns SET ${setClauses.join(", ")} WHERE id = $${idIdx} AND ${updateOrg.clause} RETURNING *`, updateParams);
     if (updated.length === 0) return c.json({ error: "not_found", message: "Pattern was deleted before update completed." }, 404);
 
     if (status === "approved") {
@@ -502,12 +502,12 @@ adminLearnedPatterns.openapi(deletePatternRoute, async (c) => {
     const { id } = c.req.valid("param");
     const checkParams: unknown[] = [id];
     const org = orgFilter(orgId, checkParams, checkParams.length + 1);
-    const existing = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(`SELECT id FROM learned_patterns WHERE id = $1 AND ${org.clause}`, checkParams));
+    const existing = yield* queryEffect<Record<string, unknown>>(`SELECT id FROM learned_patterns WHERE id = $1 AND ${org.clause}`, checkParams);
     if (existing.length === 0) return c.json({ error: "not_found", message: "Learned pattern not found." }, 404);
 
     const deleteParams: unknown[] = [id];
     const deleteOrg = orgFilter(orgId, deleteParams, deleteParams.length + 1);
-    yield* Effect.promise(() => internalQuery(`DELETE FROM learned_patterns WHERE id = $1 AND ${deleteOrg.clause}`, deleteParams));
+    yield* queryEffect(`DELETE FROM learned_patterns WHERE id = $1 AND ${deleteOrg.clause}`, deleteParams);
     invalidatePatternCache(orgId ?? null);
 
     logAdminAction({

--- a/packages/api/src/api/routes/admin-marketplace.ts
+++ b/packages/api/src/api/routes/admin-marketplace.ts
@@ -14,7 +14,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext } from "@atlas/api/lib/effect/services";
 import { createLogger } from "@atlas/api/lib/logger";
-import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { hasInternalDB, internalQuery, queryEffect } from "@atlas/api/lib/db/internal";
 import { PLAN_TIERS, type PlanTier } from "@useatlas/types";
 import {
   ErrorSchema,
@@ -291,9 +291,7 @@ platformCatalog.openapi(listCatalogRoute, async (c) => {
       if (!hasInternalDB()) {
         return c.json({ error: "not_available", message: "No internal database configured.", requestId }, 404);
       }
-      const rows = yield* Effect.promise(() =>
-        internalQuery<CatalogRow>("SELECT * FROM plugin_catalog ORDER BY created_at DESC"),
-      );
+      const rows = yield* queryEffect<CatalogRow>("SELECT * FROM plugin_catalog ORDER BY created_at DESC");
       return c.json({ entries: rows.map(catalogRowToJson), total: rows.length }, 200);
     }),
     { label: "list plugin catalog" },
@@ -313,31 +311,27 @@ platformCatalog.openapi(createCatalogRoute, async (c) => {
       const id = crypto.randomUUID();
 
       // Check slug uniqueness
-      const existing = yield* Effect.promise(() =>
-        internalQuery<{ id: string }>("SELECT id FROM plugin_catalog WHERE slug = $1", [body.slug]),
-      );
+      const existing = yield* queryEffect<{ id: string }>("SELECT id FROM plugin_catalog WHERE slug = $1", [body.slug]);
       if (existing.length > 0) {
         return c.json({ error: "conflict", message: `A catalog entry with slug "${body.slug}" already exists.`, requestId }, 409);
       }
 
-      const rows = yield* Effect.promise(() =>
-        internalQuery<CatalogRow>(
-          `INSERT INTO plugin_catalog (id, name, slug, description, type, npm_package, icon_url, config_schema, min_plan, enabled)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-           RETURNING *`,
-          [
-            id,
-            body.name,
-            body.slug,
-            body.description ?? null,
-            body.type,
-            body.npmPackage ?? null,
-            body.iconUrl ?? null,
-            body.configSchema ? JSON.stringify(body.configSchema) : null,
-            body.minPlan,
-            body.enabled,
-          ],
-        ),
+      const rows = yield* queryEffect<CatalogRow>(
+        `INSERT INTO plugin_catalog (id, name, slug, description, type, npm_package, icon_url, config_schema, min_plan, enabled)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+         RETURNING *`,
+        [
+          id,
+          body.name,
+          body.slug,
+          body.description ?? null,
+          body.type,
+          body.npmPackage ?? null,
+          body.iconUrl ?? null,
+          body.configSchema ? JSON.stringify(body.configSchema) : null,
+          body.minPlan,
+          body.enabled,
+        ],
       );
       if (rows.length === 0) {
         return c.json({ error: "internal_error", message: "Failed to create catalog entry — no row returned.", requestId }, 500);
@@ -382,11 +376,9 @@ platformCatalog.openapi(updateCatalogRoute, async (c) => {
       setClauses.push(`updated_at = now()`);
       params.push(id);
 
-      const rows = yield* Effect.promise(() =>
-        internalQuery<CatalogRow>(
-          `UPDATE plugin_catalog SET ${setClauses.join(", ")} WHERE id = $${paramIdx} RETURNING *`,
-          params,
-        ),
+      const rows = yield* queryEffect<CatalogRow>(
+        `UPDATE plugin_catalog SET ${setClauses.join(", ")} WHERE id = $${paramIdx} RETURNING *`,
+        params,
       );
 
       if (rows.length === 0) {
@@ -410,9 +402,7 @@ platformCatalog.openapi(deleteCatalogRoute, async (c) => {
       }
 
       const { id } = c.req.valid("param");
-      const rows = yield* Effect.promise(() =>
-        internalQuery<{ id: string }>("DELETE FROM plugin_catalog WHERE id = $1 RETURNING id", [id]),
-      );
+      const rows = yield* queryEffect<{ id: string }>("DELETE FROM plugin_catalog WHERE id = $1 RETURNING id", [id]);
 
       if (rows.length === 0) {
         return c.json({ error: "not_found", message: `Catalog entry "${id}" not found.`, requestId }, 404);
@@ -583,11 +573,9 @@ workspaceMarketplace.openapi(installRoute, async (c) => {
       const body = c.req.valid("json");
 
       // Fetch catalog entry
-      const catalogRows = yield* Effect.promise(() =>
-        internalQuery<CatalogRow>(
-          "SELECT * FROM plugin_catalog WHERE id = $1 AND enabled = true",
-          [body.catalogId],
-        ),
+      const catalogRows = yield* queryEffect<CatalogRow>(
+        "SELECT * FROM plugin_catalog WHERE id = $1 AND enabled = true",
+        [body.catalogId],
       );
       if (catalogRows.length === 0) {
         return c.json({ error: "not_found", message: `Catalog entry "${body.catalogId}" not found or disabled.`, requestId }, 404);
@@ -622,16 +610,14 @@ workspaceMarketplace.openapi(installRoute, async (c) => {
       const userId = authResult?.user?.id ?? null;
 
       const id = crypto.randomUUID();
-      const rows = yield* Effect.promise(() =>
-        internalQuery<WorkspacePluginRow>(
-          `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, config, installed_by)
-           VALUES ($1, $2, $3, $4, $5)
-           RETURNING *, (SELECT name FROM plugin_catalog WHERE id = $3) AS name,
-                       (SELECT slug FROM plugin_catalog WHERE id = $3) AS slug,
-                       (SELECT type FROM plugin_catalog WHERE id = $3) AS type,
-                       (SELECT description FROM plugin_catalog WHERE id = $3) AS description`,
-          [id, orgId, body.catalogId, JSON.stringify(body.config ?? {}), userId],
-        ),
+      const rows = yield* queryEffect<WorkspacePluginRow>(
+        `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, config, installed_by)
+         VALUES ($1, $2, $3, $4, $5)
+         RETURNING *, (SELECT name FROM plugin_catalog WHERE id = $3) AS name,
+                     (SELECT slug FROM plugin_catalog WHERE id = $3) AS slug,
+                     (SELECT type FROM plugin_catalog WHERE id = $3) AS type,
+                     (SELECT description FROM plugin_catalog WHERE id = $3) AS description`,
+        [id, orgId, body.catalogId, JSON.stringify(body.config ?? {}), userId],
       );
 
       if (rows.length === 0) {
@@ -653,11 +639,9 @@ workspaceMarketplace.openapi(uninstallRoute, async (c) => {
       const { orgId } = c.var.orgContext;
       const { id } = c.req.valid("param");
 
-      const rows = yield* Effect.promise(() =>
-        internalQuery<{ id: string }>(
-          "DELETE FROM workspace_plugins WHERE id = $1 AND workspace_id = $2 RETURNING id",
-          [id, orgId],
-        ),
+      const rows = yield* queryEffect<{ id: string }>(
+        "DELETE FROM workspace_plugins WHERE id = $1 AND workspace_id = $2 RETURNING id",
+        [id, orgId],
       );
 
       if (rows.length === 0) {
@@ -681,16 +665,14 @@ workspaceMarketplace.openapi(updateConfigRoute, async (c) => {
       const { id } = c.req.valid("param");
       const body = c.req.valid("json");
 
-      const rows = yield* Effect.promise(() =>
-        internalQuery<WorkspacePluginRow>(
-          `UPDATE workspace_plugins SET config = $1
-           WHERE id = $2 AND workspace_id = $3
-           RETURNING *, (SELECT name FROM plugin_catalog WHERE id = workspace_plugins.catalog_id) AS name,
-                       (SELECT slug FROM plugin_catalog WHERE id = workspace_plugins.catalog_id) AS slug,
-                       (SELECT type FROM plugin_catalog WHERE id = workspace_plugins.catalog_id) AS type,
-                       (SELECT description FROM plugin_catalog WHERE id = workspace_plugins.catalog_id) AS description`,
-          [JSON.stringify(body.config), id, orgId],
-        ),
+      const rows = yield* queryEffect<WorkspacePluginRow>(
+        `UPDATE workspace_plugins SET config = $1
+         WHERE id = $2 AND workspace_id = $3
+         RETURNING *, (SELECT name FROM plugin_catalog WHERE id = workspace_plugins.catalog_id) AS name,
+                     (SELECT slug FROM plugin_catalog WHERE id = workspace_plugins.catalog_id) AS slug,
+                     (SELECT type FROM plugin_catalog WHERE id = workspace_plugins.catalog_id) AS type,
+                     (SELECT description FROM plugin_catalog WHERE id = workspace_plugins.catalog_id) AS description`,
+        [JSON.stringify(body.config), id, orgId],
       );
 
       if (rows.length === 0) {

--- a/packages/api/src/api/routes/admin-orgs.ts
+++ b/packages/api/src/api/routes/admin-orgs.ts
@@ -11,6 +11,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import {
   hasInternalDB,
   internalQuery,
+  queryEffect,
   getWorkspaceDetails,
   updateWorkspaceStatus,
   updateWorkspacePlanTier,
@@ -545,9 +546,9 @@ adminOrgs.openapi(getOrgRoute, async (c) => {
     const { id: orgId } = c.req.valid("param");
     if (!hasInternalDB()) return c.json({ error: "not_available", message: "No internal database configured." }, 404);
 
-    const orgs = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(
+    const orgs = yield* queryEffect<Record<string, unknown>>(
       `SELECT id, name, slug, logo, metadata, "createdAt", workspace_status, plan_tier, suspended_at, deleted_at FROM organization WHERE id = $1`, [orgId],
-    ));
+    );
     if (orgs.length === 0) return c.json({ error: "not_found", message: "Organization not found." }, 404);
     const org = orgs[0];
 

--- a/packages/api/src/api/routes/admin-prompts.ts
+++ b/packages/api/src/api/routes/admin-prompts.ts
@@ -11,7 +11,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
-import { internalQuery } from "@atlas/api/lib/db/internal";
+import { internalQuery, queryEffect } from "@atlas/api/lib/db/internal";
 import type { PromptCollection, PromptItem } from "@useatlas/types";
 import { ErrorSchema, AuthErrorSchema, createIdParamSchema, createParamSchema, createListResponseSchema, DeletedResponseSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
@@ -497,10 +497,7 @@ adminPrompts.openapi(listCollectionsRoute, async (c) => {
       catch: (err) => (err instanceof Error ? err : new Error(String(err))),
     });
     const { sql, params } = buildCollectionsListQuery(scope);
-    const rows = yield* Effect.tryPromise({
-      try: () => internalQuery<Record<string, unknown>>(sql, params),
-      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-    });
+    const rows = yield* queryEffect<Record<string, unknown>>(sql, params);
     return c.json({ collections: rows.map(toPromptCollection), total: rows.length }, 200);
   }), { label: "list prompt collections" });
 });
@@ -528,7 +525,7 @@ adminPrompts.openapi(createCollectionRoute, async (c) => {
     // until the admin publishes; published mode creates them live.
     const status = atlasMode === "developer" ? "draft" : "published";
 
-    const rows = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(`INSERT INTO prompt_collections (org_id, name, industry, description, is_builtin, status) VALUES ($1, $2, $3, $4, false, $5) RETURNING *`, [orgId ?? null, name, industry, description, status]));
+    const rows = yield* queryEffect<Record<string, unknown>>(`INSERT INTO prompt_collections (org_id, name, industry, description, is_builtin, status) VALUES ($1, $2, $3, $4, false, $5) RETURNING *`, [orgId ?? null, name, industry, description, status]);
     return c.json(toPromptCollection(rows[0]), 201);
   }), { label: "create prompt collection" });
 });
@@ -565,7 +562,7 @@ adminPrompts.openapi(updateCollectionRoute, async (c) => {
     updateParams.push(id);
     const idIdx = paramIdx;
 
-    const updated = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(`UPDATE prompt_collections SET ${setClauses.join(", ")} WHERE id = $${idIdx} RETURNING *`, updateParams));
+    const updated = yield* queryEffect<Record<string, unknown>>(`UPDATE prompt_collections SET ${setClauses.join(", ")} WHERE id = $${idIdx} RETURNING *`, updateParams);
     if (updated.length === 0) return c.json({ error: "not_found", message: "Collection was deleted before update completed." }, 404);
     return c.json(toPromptCollection(updated[0]), 200);
   }), { label: "update prompt collection" });
@@ -582,7 +579,7 @@ adminPrompts.openapi(deleteCollectionRoute, async (c) => {
     if (existing.length === 0) return c.json({ error: "not_found", message: "Prompt collection not found." }, 404);
     if (existing[0].is_builtin === true) return c.json({ error: "forbidden", message: "Built-in collections cannot be modified.", requestId }, 403);
 
-    yield* Effect.promise(() => internalQuery(`DELETE FROM prompt_collections WHERE id = $1`, [id]));
+    yield* queryEffect(`DELETE FROM prompt_collections WHERE id = $1`, [id]);
     return c.json({ deleted: true }, 200);
   }), { label: "delete prompt collection" });
 });
@@ -612,11 +609,11 @@ adminPrompts.openapi(createItemRoute, async (c) => {
 
     let sortOrder: number;
     if (typeof body.sort_order === "number") { sortOrder = body.sort_order; } else {
-      const maxRows = yield* Effect.promise(() => internalQuery<{ max: number | null }>(`SELECT MAX(sort_order) as max FROM prompt_items WHERE collection_id = $1`, [collectionId]));
+      const maxRows = yield* queryEffect<{ max: number | null }>(`SELECT MAX(sort_order) as max FROM prompt_items WHERE collection_id = $1`, [collectionId]);
       sortOrder = (maxRows[0]?.max ?? -1) + 1;
     }
 
-    const rows = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(`INSERT INTO prompt_items (collection_id, question, description, category, sort_order) VALUES ($1, $2, $3, $4, $5) RETURNING *`, [collectionId, question, description, category, sortOrder]));
+    const rows = yield* queryEffect<Record<string, unknown>>(`INSERT INTO prompt_items (collection_id, question, description, category, sort_order) VALUES ($1, $2, $3, $4, $5) RETURNING *`, [collectionId, question, description, category, sortOrder]);
     return c.json(toPromptItem(rows[0]), 201);
   }), { label: "create prompt item" });
 });
@@ -632,7 +629,7 @@ adminPrompts.openapi(updateItemRoute, async (c) => {
     if (collection.length === 0) return c.json({ error: "not_found", message: "Prompt collection not found." }, 404);
     if (collection[0].is_builtin === true) return c.json({ error: "forbidden", message: "Built-in collections cannot be modified.", requestId }, 403);
 
-    const existingItem = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(`SELECT * FROM prompt_items WHERE id = $1 AND collection_id = $2`, [itemId, collectionId]));
+    const existingItem = yield* queryEffect<Record<string, unknown>>(`SELECT * FROM prompt_items WHERE id = $1 AND collection_id = $2`, [itemId, collectionId]);
     if (existingItem.length === 0) return c.json({ error: "not_found", message: "Prompt item not found." }, 404);
 
     const bodyResult = yield* Effect.tryPromise({
@@ -656,7 +653,7 @@ adminPrompts.openapi(updateItemRoute, async (c) => {
     updateParams.push(itemId);
     const idIdx = paramIdx;
 
-    const updated = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(`UPDATE prompt_items SET ${setClauses.join(", ")} WHERE id = $${idIdx} RETURNING *`, updateParams));
+    const updated = yield* queryEffect<Record<string, unknown>>(`UPDATE prompt_items SET ${setClauses.join(", ")} WHERE id = $${idIdx} RETURNING *`, updateParams);
     if (updated.length === 0) return c.json({ error: "not_found", message: "Item was deleted before update completed." }, 404);
     return c.json(toPromptItem(updated[0]), 200);
   }), { label: "update prompt item" });
@@ -673,10 +670,10 @@ adminPrompts.openapi(deleteItemRoute, async (c) => {
     if (collection.length === 0) return c.json({ error: "not_found", message: "Prompt collection not found." }, 404);
     if (collection[0].is_builtin === true) return c.json({ error: "forbidden", message: "Built-in collections cannot be modified.", requestId }, 403);
 
-    const existingItem = yield* Effect.promise(() => internalQuery<Record<string, unknown>>(`SELECT id FROM prompt_items WHERE id = $1 AND collection_id = $2`, [itemId, collectionId]));
+    const existingItem = yield* queryEffect<Record<string, unknown>>(`SELECT id FROM prompt_items WHERE id = $1 AND collection_id = $2`, [itemId, collectionId]);
     if (existingItem.length === 0) return c.json({ error: "not_found", message: "Prompt item not found." }, 404);
 
-    yield* Effect.promise(() => internalQuery(`DELETE FROM prompt_items WHERE id = $1`, [itemId]));
+    yield* queryEffect(`DELETE FROM prompt_items WHERE id = $1`, [itemId]);
     return c.json({ deleted: true }, 200);
   }), { label: "delete prompt item" });
 });
@@ -702,7 +699,7 @@ adminPrompts.openapi(reorderItemsRoute, async (c) => {
     const itemIds = body.itemIds as string[] | undefined;
     if (!Array.isArray(itemIds) || itemIds.length === 0) return c.json({ error: "bad_request", message: "itemIds must be a non-empty array of item IDs." }, 400);
 
-    const existingItems = yield* Effect.promise(() => internalQuery<{ id: string }>(`SELECT id FROM prompt_items WHERE collection_id = $1`, [collectionId]));
+    const existingItems = yield* queryEffect<{ id: string }>(`SELECT id FROM prompt_items WHERE collection_id = $1`, [collectionId]);
     const existingIds = new Set(existingItems.map((r) => r.id));
     const providedIds = new Set(itemIds);
 
@@ -710,7 +707,7 @@ adminPrompts.openapi(reorderItemsRoute, async (c) => {
     for (const id of itemIds) { if (!existingIds.has(id)) return c.json({ error: "bad_request", message: `Item ID "${id}" does not belong to this collection.` }, 400); }
 
     for (let i = 0; i < itemIds.length; i++) {
-      yield* Effect.promise(() => internalQuery(`UPDATE prompt_items SET sort_order = $1, updated_at = now() WHERE id = $2`, [i, itemIds[i]]));
+      yield* queryEffect(`UPDATE prompt_items SET sort_order = $1, updated_at = now() WHERE id = $2`, [i, itemIds[i]]);
     }
     return c.json({ reordered: true }, 200);
   }), { label: "reorder prompt items" });

--- a/packages/api/src/api/routes/admin-residency.ts
+++ b/packages/api/src/api/routes/admin-residency.ts
@@ -12,7 +12,7 @@ import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
-import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { hasInternalDB, queryEffect } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
 import {
   triggerMigrationExecution,
@@ -439,25 +439,23 @@ adminResidency.openapi(getMigrationStatusRoute, async (c) => {
         return c.json({ error: "not_available", message: "Migration tracking requires an internal database.", requestId }, 404);
       }
 
-      const rows = yield* Effect.promise(() =>
-        internalQuery<{
-          id: string;
-          workspace_id: string;
-          source_region: string;
-          target_region: string;
-          status: string;
-          requested_by: string | null;
-          requested_at: string;
-          completed_at: string | null;
-          error_message: string | null;
-        }>(
-          `SELECT id, workspace_id, source_region, target_region, status, requested_by, requested_at, completed_at, error_message
-           FROM region_migrations
-           WHERE workspace_id = $1
-           ORDER BY requested_at DESC
-           LIMIT 1`,
-          [orgId],
-        ),
+      const rows = yield* queryEffect<{
+        id: string;
+        workspace_id: string;
+        source_region: string;
+        target_region: string;
+        status: string;
+        requested_by: string | null;
+        requested_at: string;
+        completed_at: string | null;
+        error_message: string | null;
+      }>(
+        `SELECT id, workspace_id, source_region, target_region, status, requested_by, requested_at, completed_at, error_message
+         FROM region_migrations
+         WHERE workspace_id = $1
+         ORDER BY requested_at DESC
+         LIMIT 1`,
+        [orgId],
       );
 
       const row = rows[0];
@@ -534,13 +532,11 @@ adminResidency.openapi(requestMigrationRoute, async (c) => {
       }
 
       // Check for existing pending/in_progress migration
-      const existing = yield* Effect.promise(() =>
-        internalQuery<{ id: string; status: string }>(
-          `SELECT id, status FROM region_migrations
-           WHERE workspace_id = $1 AND status IN ('pending', 'in_progress')
-           LIMIT 1`,
-          [orgId],
-        ),
+      const existing = yield* queryEffect<{ id: string; status: string }>(
+        `SELECT id, status FROM region_migrations
+         WHERE workspace_id = $1 AND status IN ('pending', 'in_progress')
+         LIMIT 1`,
+        [orgId],
       );
       if (existing.length > 0) {
         return c.json({
@@ -551,13 +547,11 @@ adminResidency.openapi(requestMigrationRoute, async (c) => {
       }
 
       // Rate limit: one migration per 30 days
-      const recent = yield* Effect.promise(() =>
-        internalQuery<{ id: string }>(
-          `SELECT id FROM region_migrations
-           WHERE workspace_id = $1 AND requested_at > NOW() - INTERVAL '30 days'
-           LIMIT 1`,
-          [orgId],
-        ),
+      const recent = yield* queryEffect<{ id: string }>(
+        `SELECT id FROM region_migrations
+         WHERE workspace_id = $1 AND requested_at > NOW() - INTERVAL '30 days'
+         LIMIT 1`,
+        [orgId],
       );
       if (recent.length > 0) {
         return c.json({
@@ -573,12 +567,10 @@ adminResidency.openapi(requestMigrationRoute, async (c) => {
 
       const requestedBy = user?.id ?? null;
 
-      yield* Effect.promise(() =>
-        internalQuery(
-          `INSERT INTO region_migrations (id, workspace_id, source_region, target_region, status, requested_by, requested_at)
-           VALUES ($1, $2, $3, $4, 'pending', $5, $6)`,
-          [migrationId, orgId, assignment.region, targetRegion, requestedBy, now],
-        ),
+      yield* queryEffect(
+        `INSERT INTO region_migrations (id, workspace_id, source_region, target_region, status, requested_by, requested_at)
+         VALUES ($1, $2, $3, $4, 'pending', $5, $6)`,
+        [migrationId, orgId, assignment.region, targetRegion, requestedBy, now],
       );
 
       log.info(
@@ -638,22 +630,20 @@ adminResidency.openapi(retryMigrationRoute, async (c) => {
       triggerMigrationExecution(id);
 
       // Fetch updated migration to return
-      const rows = yield* Effect.promise(() =>
-        internalQuery<{
-          id: string;
-          workspace_id: string;
-          source_region: string;
-          target_region: string;
-          status: string;
-          requested_by: string | null;
-          requested_at: string;
-          completed_at: string | null;
-          error_message: string | null;
-        }>(
-          `SELECT id, workspace_id, source_region, target_region, status, requested_by, requested_at, completed_at, error_message
-           FROM region_migrations WHERE id = $1 AND workspace_id = $2`,
-          [id, orgId],
-        ),
+      const rows = yield* queryEffect<{
+        id: string;
+        workspace_id: string;
+        source_region: string;
+        target_region: string;
+        status: string;
+        requested_by: string | null;
+        requested_at: string;
+        completed_at: string | null;
+        error_message: string | null;
+      }>(
+        `SELECT id, workspace_id, source_region, target_region, status, requested_by, requested_at, completed_at, error_message
+         FROM region_migrations WHERE id = $1 AND workspace_id = $2`,
+        [id, orgId],
       );
 
       const row = rows[0];

--- a/packages/api/src/api/routes/admin-sessions.ts
+++ b/packages/api/src/api/routes/admin-sessions.ts
@@ -10,7 +10,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { AuthContext } from "@atlas/api/lib/effect/services";
-import { internalQuery } from "@atlas/api/lib/db/internal";
+import { internalQuery, queryEffect } from "@atlas/api/lib/db/internal";
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
 import { ErrorSchema, AuthErrorSchema, parsePagination, escapeIlike } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
@@ -250,7 +250,7 @@ adminSessions.openapi(deleteSessionRoute, async (c) => {
     }
 
     // Only delete if the session belongs to a member of the active org
-    const deleted = yield* Effect.promise(() => internalQuery<{ id: string }>(
+    const deleted = yield* queryEffect<{ id: string }>(
       `DELETE FROM session s
        USING member m
        WHERE s.id = $1
@@ -258,7 +258,7 @@ adminSessions.openapi(deleteSessionRoute, async (c) => {
          AND m."organizationId" = $2
        RETURNING s.id`,
       [sessionId, orgId],
-    ));
+    );
     if (deleted.length === 0) {
       return c.json({ error: "not_found", message: "Session not found.", requestId }, 404);
     }
@@ -280,7 +280,7 @@ adminSessions.openapi(deleteUserSessionsRoute, async (c) => {
     }
 
     // Only delete sessions where the user is a member of the active org
-    const deleted = yield* Effect.promise(() => internalQuery<{ id: string }>(
+    const deleted = yield* queryEffect<{ id: string }>(
       `DELETE FROM session s
        USING member m
        WHERE s."userId" = $1
@@ -288,7 +288,7 @@ adminSessions.openapi(deleteUserSessionsRoute, async (c) => {
          AND m."organizationId" = $2
        RETURNING s.id`,
       [userId, orgId],
-    ));
+    );
     if (deleted.length === 0) {
       return c.json({ error: "not_found", message: "No sessions found for this user.", requestId }, 404);
     }

--- a/packages/api/src/api/routes/admin-suggestions.ts
+++ b/packages/api/src/api/routes/admin-suggestions.ts
@@ -9,7 +9,7 @@ import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { AuthContext } from "@atlas/api/lib/effect/services";
-import { internalQuery, deleteSuggestion } from "@atlas/api/lib/db/internal";
+import { deleteSuggestion, queryEffect } from "@atlas/api/lib/db/internal";
 import { toQuerySuggestion } from "@atlas/api/lib/learn/suggestion-helpers";
 import type { QuerySuggestionRow } from "@atlas/api/lib/db/internal";
 import { ErrorSchema, AuthErrorSchema, parsePagination, createIdParamSchema, createListResponseSchema } from "./shared-schemas";
@@ -138,15 +138,15 @@ adminSuggestions.openapi(listSuggestionsRoute, async (c) => {
     params.push(limit, offset);
     const limitIdx = idx;
     const offsetIdx = idx + 1;
-    const rows = yield* Effect.promise(() => internalQuery<QuerySuggestionRow>(
+    const rows = yield* queryEffect<QuerySuggestionRow>(
       `SELECT * FROM query_suggestions ${where} ORDER BY score DESC LIMIT $${limitIdx} OFFSET $${offsetIdx}`,
       params
-    ));
+    );
 
-    const countRows = yield* Effect.promise(() => internalQuery<{ count: string }>(
+    const countRows = yield* queryEffect<{ count: string }>(
       `SELECT COUNT(*) as count FROM query_suggestions ${where}`,
       filterParams
-    ));
+    );
 
     const total = parseInt(countRows[0]?.count ?? "0", 10);
 

--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -19,7 +19,7 @@ import { z } from "zod";
 import { createLogger } from "@atlas/api/lib/logger";
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
 import { connections, detectDBType, resolveDatasourceUrl } from "@atlas/api/lib/db/connection";
-import { hasInternalDB, internalQuery, encryptUrl } from "@atlas/api/lib/db/internal";
+import { hasInternalDB, internalQuery, queryEffect, encryptUrl } from "@atlas/api/lib/db/internal";
 import { maskConnectionUrl } from "@atlas/api/lib/security";
 import { _resetWhitelists } from "@atlas/api/lib/semantic";
 import { importFromDisk } from "@atlas/api/lib/semantic/sync";
@@ -1074,10 +1074,10 @@ onboarding.openapi(tourStatusRoute, async (c) => {
       return c.json({ error: "auth_error", message: "No user ID in session.", requestId }, 401);
     }
 
-    const rows = yield* Effect.promise(() => internalQuery<{ tour_completed_at: string | null }>(
+    const rows = yield* queryEffect<{ tour_completed_at: string | null }>(
       `SELECT tour_completed_at FROM user_onboarding WHERE user_id = $1`,
       [userId],
-    ));
+    );
     const row = rows[0];
     return c.json({
       tourCompleted: !!row?.tour_completed_at,
@@ -1108,12 +1108,12 @@ onboarding.openapi(tourCompleteRoute, async (c) => {
     }
 
     const now = new Date().toISOString();
-    yield* Effect.promise(() => internalQuery(
+    yield* queryEffect(
       `INSERT INTO user_onboarding (user_id, tour_completed_at)
        VALUES ($1, $2)
        ON CONFLICT (user_id) DO UPDATE SET tour_completed_at = $2`,
       [userId, now],
-    ));
+    );
     log.info({ requestId, userId }, "Tour marked as completed");
     return c.json({ tourCompleted: true, tourCompletedAt: now }, 200);
   }), { label: "save tour completion" });
@@ -1140,10 +1140,10 @@ onboarding.openapi(tourResetRoute, async (c) => {
       return c.json({ error: "auth_error", message: "No user ID in session.", requestId }, 401);
     }
 
-    yield* Effect.promise(() => internalQuery(
+    yield* queryEffect(
       `UPDATE user_onboarding SET tour_completed_at = NULL WHERE user_id = $1`,
       [userId],
-    ));
+    );
     log.info({ requestId, userId }, "Tour reset for replay");
     return c.json({ tourCompleted: false, tourCompletedAt: null }, 200);
   }), { label: "reset tour" });

--- a/packages/api/src/api/routes/platform-admin.ts
+++ b/packages/api/src/api/routes/platform-admin.ts
@@ -29,6 +29,7 @@ import {
 import {
   hasInternalDB,
   internalQuery,
+  queryEffect,
   getWorkspaceDetails,
   updateWorkspaceStatus,
   updateWorkspacePlanTier,
@@ -379,7 +380,7 @@ platformAdmin.openapi(listWorkspacesRoute, async (c) => {
       return c.json({ error: "not_configured", message: "Internal database not configured.", requestId }, 404);
     }
 
-    const rows = yield* Effect.promise(() => internalQuery<{
+    const rows = yield* queryEffect<{
       id: string;
       name: string;
       slug: string;
@@ -415,7 +416,7 @@ platformAdmin.openapi(listWorkspacesRoute, async (c) => {
        LEFT JOIN (SELECT org_id, COUNT(*)::int AS cnt FROM connections GROUP BY org_id) cn ON cn.org_id = o.id
        LEFT JOIN (SELECT org_id, COUNT(*)::int AS cnt FROM scheduled_tasks WHERE enabled = true GROUP BY org_id) st ON st.org_id = o.id
        ORDER BY o."createdAt" DESC`,
-    ));
+    );
 
     const workspaces = rows.map((row) => ({
       id: row.id,
@@ -774,9 +775,9 @@ platformAdmin.openapi(platformStatsRoute, async (c) => {
     ]));
 
     // MRR: sum of PLAN_MRR for each active workspace's plan tier
-    const mrrRows = yield* Effect.promise(() => internalQuery<{ plan_tier: string; cnt: number }>(
+    const mrrRows = yield* queryEffect<{ plan_tier: string; cnt: number }>(
       `SELECT plan_tier, COUNT(*)::int AS cnt FROM organization WHERE workspace_status = 'active' GROUP BY plan_tier`,
-    ));
+    );
     const mrr = mrrRows.reduce((sum, row) => sum + (PLAN_MRR[row.plan_tier] ?? 0) * row.cnt, 0);
 
     return c.json({
@@ -801,7 +802,7 @@ platformAdmin.openapi(noisyNeighborsRoute, async (c) => {
     }
 
     // Get current period usage for each active workspace
-    const rows = yield* Effect.promise(() => internalQuery<{
+    const rows = yield* queryEffect<{
       id: string;
       name: string;
       plan_tier: PlanTier;
@@ -820,7 +821,7 @@ platformAdmin.openapi(noisyNeighborsRoute, async (c) => {
          AND us.period = 'monthly'
          AND us.period_start = date_trunc('month', now())
        WHERE o.workspace_status = 'active'`,
-    ));
+    );
 
     if (rows.length === 0) {
       return c.json({ neighbors: [], medians: { queries: 0, tokens: 0, storage: 0 } }, 200);

--- a/packages/api/src/api/routes/sessions.ts
+++ b/packages/api/src/api/routes/sessions.ts
@@ -13,7 +13,7 @@ import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
 import { validationHook } from "./validation-hook";
 import { z } from "zod";
 import { createLogger } from "@atlas/api/lib/logger";
-import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { hasInternalDB, queryEffect } from "@atlas/api/lib/db/internal";
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
 import { ErrorSchema } from "./shared-schemas";
 import { standardAuth, requestContext, type AuthEnv } from "./middleware";
@@ -142,7 +142,7 @@ sessions.openapi(listSessionsRoute, async (c) => {
 
     const userId = user.id;
 
-    const rows = yield* Effect.promise(() => internalQuery<{
+    const rows = yield* queryEffect<{
       id: string;
       createdAt: string;
       updatedAt: string;
@@ -156,7 +156,7 @@ sessions.openapi(listSessionsRoute, async (c) => {
        ORDER BY "updatedAt" DESC
        LIMIT 100`,
       [userId],
-    ));
+    );
 
     return c.json({
       sessions: rows.map((r) => ({
@@ -186,16 +186,16 @@ sessions.openapi(revokeSessionRoute, async (c) => {
 
     // Atomic delete scoped to the current user — returns empty if
     // the session doesn't exist or belongs to another user.
-    const deleted = yield* Effect.promise(() => internalQuery<{ id: string }>(
+    const deleted = yield* queryEffect<{ id: string }>(
       `DELETE FROM session WHERE id = $1 AND "userId" = $2 RETURNING id`,
       [sessionId, userId],
-    ));
+    );
     if (deleted.length === 0) {
       // Distinguish "not found" from "wrong user" for a clear error message
-      const exists = yield* Effect.promise(() => internalQuery<{ userId: string }>(
+      const exists = yield* queryEffect<{ userId: string }>(
         `SELECT "userId" FROM session WHERE id = $1`,
         [sessionId],
-      ));
+      );
       if (exists.length === 0) {
         return c.json({ error: "not_found", message: "Session not found." }, 404);
       }

--- a/packages/api/src/lib/auth/__tests__/sessions.test.ts
+++ b/packages/api/src/lib/auth/__tests__/sessions.test.ts
@@ -14,6 +14,7 @@ import {
   type Mock,
 } from "bun:test";
 import { createConnectionMock } from "@atlas/api/testing/connection";
+import { makeQueryEffectMock } from "@atlas/api/testing/api-test-mocks";
 
 // --- Mocks (before any import that touches the modules) ---
 
@@ -97,6 +98,7 @@ const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unkno
 mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => true,
   internalQuery: mockInternalQuery,
+  queryEffect: makeQueryEffectMock(mockInternalQuery),
   internalExecute: mock(() => {}),
   getInternalDB: mock(() => ({})),
   closeInternalDB: mock(async () => {}),

--- a/packages/api/src/lib/db/__tests__/internal.test.ts
+++ b/packages/api/src/lib/db/__tests__/internal.test.ts
@@ -12,6 +12,7 @@ import {
   closeInternalDB,
   internalQuery,
   internalExecute,
+  queryEffect,
   migrateInternalDB,
   loadSavedConnections,
   cascadeWorkspaceDelete,
@@ -167,6 +168,57 @@ describe("internal DB module", () => {
       await expect(internalQuery("SELECT * FROM missing")).rejects.toThrow(
         "relation does not exist",
       );
+    });
+  });
+
+  describe("queryEffect()", () => {
+    it("resolves with typed rows on success", async () => {
+      process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/atlas";
+      const { pool } = createMockPool();
+      pool._setResult({ rows: [{ id: "abc", count: 42 }] });
+      _resetPool(pool);
+
+      const rows = await Effect.runPromise(
+        queryEffect<{ id: string; count: number }>("SELECT id, count FROM t WHERE id = $1", ["abc"]),
+      );
+      expect(rows).toEqual([{ id: "abc", count: 42 }]);
+    });
+
+    it("surfaces rejection in the typed error channel", async () => {
+      process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/atlas";
+      const { pool } = createMockPool();
+      pool._setError(new Error("connection terminated"));
+      _resetPool(pool);
+
+      const exit = await Effect.runPromiseExit(queryEffect("SELECT 1"));
+      expect(exit._tag).toBe("Failure");
+      // Fail cause — the typed E: Error channel, not a defect
+      const result = await Effect.runPromise(Effect.either(queryEffect("SELECT 1")));
+      expect(result._tag).toBe("Left");
+      if (result._tag === "Left") {
+        expect(result.left).toBeInstanceOf(Error);
+        expect(result.left.message).toBe("connection terminated");
+      }
+    });
+
+    it("normalizes non-Error thrown values", async () => {
+      process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/atlas";
+      const { pool: base } = createMockPool();
+      const pool = {
+        ...base,
+        async query() {
+          // Throw a plain string — queryEffect should normalize via normalizeError
+          throw "raw string thrown";
+        },
+      };
+      _resetPool(pool);
+
+      const result = await Effect.runPromise(Effect.either(queryEffect("SELECT 1")));
+      expect(result._tag).toBe("Left");
+      if (result._tag === "Left") {
+        expect(result.left).toBeInstanceOf(Error);
+        expect(result.left.message).toBe("raw string thrown");
+      }
     });
   });
 

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -436,6 +436,24 @@ export async function internalQuery<T extends Record<string, unknown>>(
   return result.rows as T[];
 }
 
+/**
+ * Effect-wrapped `internalQuery`.
+ *
+ * Use in `Effect.gen` route handlers instead of `Effect.promise(() => internalQuery(...))`:
+ * `Effect.promise` hides rejections from the Effect error channel (they become unchecked
+ * defects). `queryEffect` uses `Effect.tryPromise` with normalized catch so DB errors
+ * stay typed as `Error` and can be caught / mapped downstream.
+ */
+export function queryEffect<T extends Record<string, unknown>>(
+  sqlStr: string,
+  params?: unknown[],
+): Effect.Effect<T[], Error> {
+  return Effect.tryPromise({
+    try: () => internalQuery<T>(sqlStr, params),
+    catch: normalizeError,
+  });
+}
+
 let _consecutiveFailures = 0;
 const MAX_CONSECUTIVE_FAILURES = 5;
 let _circuitOpen = false;

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -437,12 +437,9 @@ export async function internalQuery<T extends Record<string, unknown>>(
 }
 
 /**
- * Effect-wrapped `internalQuery`.
- *
- * Use in `Effect.gen` route handlers instead of `Effect.promise(() => internalQuery(...))`:
- * `Effect.promise` hides rejections from the Effect error channel (they become unchecked
- * defects). `queryEffect` uses `Effect.tryPromise` with normalized catch so DB errors
- * stay typed as `Error` and can be caught / mapped downstream.
+ * `Effect.promise(() => internalQuery(...))` hides DB rejections in the defect
+ * channel; route handlers should use `queryEffect` so failures land in the
+ * typed `E: Error` channel and can be caught or mapped downstream.
  */
 export function queryEffect<T extends Record<string, unknown>>(
   sqlStr: string,

--- a/packages/api/src/lib/effect/index.ts
+++ b/packages/api/src/lib/effect/index.ts
@@ -135,5 +135,6 @@ export {
   InternalDB,
   makeInternalDBLive,
   createInternalDBTestLayer,
+  queryEffect,
   type InternalDBShape,
 } from "@atlas/api/lib/db/internal";


### PR DESCRIPTION
## Summary
- Adds `queryEffect<T>()` helper in `lib/db/internal.ts` that wraps `internalQuery` in `Effect.tryPromise` with normalized catch
- Migrates 37 `Effect.promise(() => internalQuery(...))` call sites across 15 route files to `yield* queryEffect(...)`
- Matches the CLAUDE.md rule for Effect DB calls (`tryPromise` with normalized catch, not `Effect.promise`), so DB rejections stay typed instead of surfacing as unchecked defects

## Why
`Effect.promise` tells the Effect type system the promise cannot reject — rejections become defects rather than typed failures in the `E` channel. `internalQuery` can absolutely reject (pool exhausted, migration not yet run, query timeout, SQL error). Future typed error channels (e.g. `DatabaseError`) would miss DB errors entirely. Currently saved only by `runHandler`'s top-level defect catch mapping everything to generic 500s.

## Scope
- `queryEffect` helper: `packages/api/src/lib/db/internal.ts` (+ re-export from `lib/effect/index.ts`)
- 15 route files migrated: `admin-audit`, `admin-learned-patterns`, `admin-marketplace`, `admin-orgs`, `admin-prompts`, `admin-residency`, `admin-sessions`, `admin-suggestions`, `onboarding`, `platform-admin`, `sessions`
- Tests: `makeQueryEffectMock` helper added to `api-test-mocks.ts`; 11 test files that override `@atlas/api/lib/db/internal` via `mock.module()` now provide a `queryEffect` export
- `Promise.all`/`Promise.allSettled` batched query patterns left alone — separate refactor to `Effect.all([queryEffect(...)])`

Closes #1468.

## Test plan
- [x] `bun run type` — clean
- [x] `bun run lint` — clean
- [x] `bun run test` — 227 API + 17 CLI + 56 web + 25 EE + 8 react all pass