### PR TITLE
fix(auth): isolate middleware test from internal DB (#1483)

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -1207,7 +1207,7 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
 - [x] Signup-connect error-isolation tests double-counting Next.js dev-tools alert (#1488, PR #1489 — scoped queries to `<main>`)
 - [x] Obsidian plugin doc — stale `/api/chat` → `/api/v1/chat` (#1491, surfaced by docs audit)
 - [x] Migrate `internalQuery` call sites from `Effect.promise` to `Effect.tryPromise` (#1468, PR #1493 — 37 sites across 15 routes; extracted `queryEffect<T>()` helper in `@atlas/api/lib/effect` with normalized catch; `makeQueryEffectMock` test helper; found during #1465 silent-failure review)
-- [ ] Pre-existing flaky middleware test `mode 'managed' with valid session returns authenticated` (#1483 — not a 1.2.0 blocker; milestone stripped, tracked standalone)
+- [x] Pre-existing flaky middleware test `mode 'managed' with valid session returns authenticated` (#1483 — fixed by isolating from internal DB so SSO enforcement check short-circuits)
 
 ---
 

--- a/packages/api/src/lib/auth/__tests__/byot-integration.test.ts
+++ b/packages/api/src/lib/auth/__tests__/byot-integration.test.ts
@@ -23,6 +23,7 @@ let jwksUrl: string;
 const origJwksUrl = process.env.ATLAS_AUTH_JWKS_URL;
 const origIssuer = process.env.ATLAS_AUTH_ISSUER;
 const origAudience = process.env.ATLAS_AUTH_AUDIENCE;
+const origDatabaseUrl = process.env.DATABASE_URL;
 
 beforeAll(async () => {
   // Generate two RS256 key pairs — one for the JWKS server, one to simulate wrong-key signing
@@ -65,6 +66,10 @@ beforeEach(() => {
   process.env.ATLAS_AUTH_JWKS_URL = jwksUrl;
   process.env.ATLAS_AUTH_ISSUER = TEST_ISSUER;
   process.env.ATLAS_AUTH_AUDIENCE = TEST_AUDIENCE;
+  // Defensive: validateBYOT doesn't itself touch the internal DB, but unsetting
+  // DATABASE_URL keeps these tests immune to any future SSO/internal-DB hooks
+  // added to the BYOT path (mirrors middleware.test.ts).
+  delete process.env.DATABASE_URL;
   resetJWKSCache();
 });
 
@@ -77,6 +82,9 @@ afterEach(() => {
 
   if (origAudience !== undefined) process.env.ATLAS_AUTH_AUDIENCE = origAudience;
   else delete process.env.ATLAS_AUTH_AUDIENCE;
+
+  if (origDatabaseUrl !== undefined) process.env.DATABASE_URL = origDatabaseUrl;
+  else delete process.env.DATABASE_URL;
 
   resetJWKSCache();
 });

--- a/packages/api/src/lib/auth/__tests__/managed.test.ts
+++ b/packages/api/src/lib/auth/__tests__/managed.test.ts
@@ -6,15 +6,23 @@ import { _setAuthInstance } from "../server";
 const mockGetSession = mock((): Promise<any> => Promise.resolve(null));
 
 describe("validateManaged()", () => {
+  const origDatabaseUrl = process.env.DATABASE_URL;
+
   beforeEach(() => {
     mockGetSession.mockReset();
     // Inject a fake auth instance whose api.getSession is our mock
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- injecting partial auth mock for testing
     _setAuthInstance({ api: { getSession: mockGetSession } } as any);
+    // Defensive: validateManaged doesn't itself touch the internal DB, but
+    // unsetting DATABASE_URL keeps these tests immune to any future
+    // internal-DB hooks added to managed validation (mirrors middleware.test.ts).
+    delete process.env.DATABASE_URL;
   });
 
   afterEach(() => {
     _setAuthInstance(null);
+    if (origDatabaseUrl !== undefined) process.env.DATABASE_URL = origDatabaseUrl;
+    else delete process.env.DATABASE_URL;
   });
 
   function makeRequest(headers?: Record<string, string>): Request {

--- a/packages/api/src/lib/auth/__tests__/middleware.test.ts
+++ b/packages/api/src/lib/auth/__tests__/middleware.test.ts
@@ -34,12 +34,17 @@ describe("authenticateRequest()", () => {
   const origBetterAuth = process.env.BETTER_AUTH_SECRET;
   const origApiKey = process.env.ATLAS_API_KEY;
   const origAuthMode = process.env.ATLAS_AUTH_MODE;
+  const origDatabaseUrl = process.env.DATABASE_URL;
 
   beforeEach(() => {
     delete process.env.ATLAS_AUTH_JWKS_URL;
     delete process.env.BETTER_AUTH_SECRET;
     delete process.env.ATLAS_API_KEY;
     delete process.env.ATLAS_AUTH_MODE;
+    // Unset DATABASE_URL so checkSSOEnforcement's hasInternalDB() short-circuits.
+    // Otherwise the managed-auth path tries a real Postgres query and the
+    // fail-closed catch turns this into a flaky `authenticated: false` result.
+    delete process.env.DATABASE_URL;
     resetAuthModeCache();
     _setValidatorOverrides({
       managed: mockValidateManaged,
@@ -73,6 +78,9 @@ describe("authenticateRequest()", () => {
 
     if (origAuthMode !== undefined) process.env.ATLAS_AUTH_MODE = origAuthMode;
     else delete process.env.ATLAS_AUTH_MODE;
+
+    if (origDatabaseUrl !== undefined) process.env.DATABASE_URL = origDatabaseUrl;
+    else delete process.env.DATABASE_URL;
 
     resetAuthModeCache();
     _setValidatorOverrides({ managed: null, byot: null });

--- a/packages/api/src/lib/auth/__tests__/middleware.test.ts
+++ b/packages/api/src/lib/auth/__tests__/middleware.test.ts
@@ -8,6 +8,7 @@ import {
   rateLimitCleanupTick,
   getClientIP,
   _setValidatorOverrides,
+  _setSSOEnforcementOverride,
 } from "../middleware";
 
 // Mock validators — injected via _setValidatorOverrides (no mock.module needed)
@@ -41,9 +42,11 @@ describe("authenticateRequest()", () => {
     delete process.env.BETTER_AUTH_SECRET;
     delete process.env.ATLAS_API_KEY;
     delete process.env.ATLAS_AUTH_MODE;
-    // Unset DATABASE_URL so checkSSOEnforcement's hasInternalDB() short-circuits.
-    // Otherwise the managed-auth path tries a real Postgres query and the
-    // fail-closed catch turns this into a flaky `authenticated: false` result.
+    // Unset DATABASE_URL so the managed-auth SSO enforcement check (in
+    // ee/auth/sso) short-circuits before touching Postgres. Otherwise the
+    // fail-closed catch flips a passing test into a flaky `authenticated: false`
+    // 500. Tests that need to exercise the SSO branch use
+    // _setSSOEnforcementOverride below instead of a real DB.
     delete process.env.DATABASE_URL;
     resetAuthModeCache();
     _setValidatorOverrides({
@@ -84,6 +87,7 @@ describe("authenticateRequest()", () => {
 
     resetAuthModeCache();
     _setValidatorOverrides({ managed: null, byot: null });
+    _setSSOEnforcementOverride(null);
   });
 
   function makeRequest(headers?: Record<string, string>): Request {
@@ -195,6 +199,50 @@ describe("authenticateRequest()", () => {
     if (!result.authenticated) {
       expect(result.status).toBe(500);
       expect(result.error).toContain("Authentication service error");
+    }
+  });
+
+  it("mode 'managed' with SSO enforcement blocks login with 403 + redirect", async () => {
+    process.env.BETTER_AUTH_SECRET = "some-secret-for-managed-auth-32chars!!";
+    resetAuthModeCache();
+
+    mockValidateManaged.mockResolvedValueOnce({
+      authenticated: true as const,
+      mode: "managed" as const,
+      user: { id: "usr_1", mode: "managed" as const, label: "alice@enforced.com" },
+    });
+    _setSSOEnforcementOverride(async (domain) => {
+      expect(domain).toBe("enforced.com");
+      return { enforced: true, ssoRedirectUrl: "https://idp.enforced.com/sso" };
+    });
+
+    const result = await authenticateRequest(makeRequest());
+    expect(result.authenticated).toBe(false);
+    if (!result.authenticated) {
+      expect(result.status).toBe(403);
+      expect(result.error).toContain("SSO is required");
+      expect(result.ssoRedirectUrl).toBe("https://idp.enforced.com/sso");
+    }
+  });
+
+  it("mode 'managed' with SSO enforcement check throwing fails closed with 500", async () => {
+    process.env.BETTER_AUTH_SECRET = "some-secret-for-managed-auth-32chars!!";
+    resetAuthModeCache();
+
+    mockValidateManaged.mockResolvedValueOnce({
+      authenticated: true as const,
+      mode: "managed" as const,
+      user: { id: "usr_1", mode: "managed" as const, label: "alice@enforced.com" },
+    });
+    _setSSOEnforcementOverride(async () => {
+      throw new Error("DB unreachable");
+    });
+
+    const result = await authenticateRequest(makeRequest());
+    expect(result.authenticated).toBe(false);
+    if (!result.authenticated) {
+      expect(result.status).toBe(500);
+      expect(result.error).toContain("Unable to verify SSO enforcement");
     }
   });
 

--- a/packages/api/src/lib/auth/middleware.ts
+++ b/packages/api/src/lib/auth/middleware.ts
@@ -147,6 +147,20 @@ export function _setValidatorOverrides(overrides: {
   _byotOverride = overrides.byot ?? null;
 }
 
+type SSOEnforcementResult = { enforced: boolean; ssoRedirectUrl?: string } | null;
+
+let _ssoEnforcementOverride:
+  | ((emailDomain: string) => Promise<SSOEnforcementResult>)
+  | null = null;
+
+/** @internal — test-only. Override the SSO enforcement lookup so tests can
+ * exercise the 403/500 branches without touching the internal Postgres DB. */
+export function _setSSOEnforcementOverride(
+  override: ((emailDomain: string) => Promise<SSOEnforcementResult>) | null,
+): void {
+  _ssoEnforcementOverride = override;
+}
+
 /**
  * Categorize an auth error for diagnostic logging.
  * Helps operators quickly identify whether a failure is a database issue,
@@ -179,7 +193,9 @@ async function checkSSOEnforcement(userLabel: string): Promise<AuthResult | null
     const domain = extractEmailDomain(userLabel);
     if (!domain) return null;
 
-    const enforcement = await Effect.runPromise(isSSOEnforcedForDomain(domain));
+    const enforcement = _ssoEnforcementOverride
+      ? await _ssoEnforcementOverride(domain)
+      : await Effect.runPromise(isSSOEnforcedForDomain(domain));
     if (!enforcement || !enforcement.enforced) return null;
 
     log.warn({ domain, userId: userLabel }, "Password login blocked — SSO enforcement active for domain");


### PR DESCRIPTION
## Summary

Fixes the intermittent failure in `authenticateRequest() > mode 'managed' with valid session returns authenticated` (`packages/api/src/lib/auth/__tests__/middleware.test.ts:137`).

**Root cause (different from issue hypothesis):** The managed-auth path calls `checkSSOEnforcement` → `isSSOEnforcedForDomain`, which issues a real Postgres query whenever `DATABASE_URL` is set. When the DB isn't reachable (or transient), the fail-closed `catch` returns `{ authenticated: false, status: 500 }`, surfacing as `Expected: true / Received: false`. Mock state was a red herring — the validator mock is set up correctly via `mockResolvedValueOnce` and returns the authenticated result; the failure happens downstream in the SSO enforcement DB call.

**Fix:** Unset `DATABASE_URL` in the `authenticateRequest()` `beforeEach` (and restore in `afterEach`) so `hasInternalDB()` short-circuits and SSO enforcement returns `null` without network I/O. Mirrors the pattern already used in `chat.test.ts`, `query.test.ts`, `health.test.ts`, `dashboards.test.ts`.

## Test plan

- [x] Reproduced on `main` (Postgres not running): test fails with the exact `connect ECONNREFUSED 127.0.0.1:5432` `FiberFailure` shown in #1483.
- [x] After fix, ran 5 consecutive isolated invocations of the file — all 33 tests pass each time.
- [x] `bun run lint` ✓
- [x] `bun run type` ✓
- [x] `bun run test` ✓ (227 API files, 17 CLI, 56 web, 25 EE, 8 react — all pass)
- [x] `bun x syncpack lint` ✓
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` ✓

Closes #1483.