### PR TITLE
feat(sdk): add getStarterPrompts() method (#1481)

### DIFF
--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -6,6 +6,7 @@
     "getting-started",
     "guides",
     "reference",
+    "sdk",
     "plugins",
     "api-reference",
     "deployment",

--- a/apps/docs/content/docs/reference/sdk.mdx
+++ b/apps/docs/content/docs/reference/sdk.mdx
@@ -147,6 +147,20 @@ interface TableColumn {
 
 ---
 
+## Starter Prompts
+
+Fetch the adaptive starter-prompt list for the current user — the same list the web empty state renders. See the [dedicated guide](/docs/sdk/starter-prompts) for tier ordering, provenance semantics, and API-key to user mapping.
+
+```typescript
+const { prompts, total } = await atlas.getStarterPrompts({ limit: 5 });
+
+for (const p of prompts) {
+  console.log(`[${p.provenance}] ${p.text}`);
+}
+```
+
+---
+
 ## Chat
 
 Stream a chat response using the AI SDK UI Message Stream Protocol.

--- a/apps/docs/content/docs/sdk/meta.json
+++ b/apps/docs/content/docs/sdk/meta.json
@@ -1,0 +1,8 @@
+{
+  "title": "SDK Guides",
+  "description": "Task-focused guides for the @useatlas/sdk TypeScript client",
+  "icon": "Code",
+  "pages": [
+    "starter-prompts"
+  ]
+}

--- a/apps/docs/content/docs/sdk/starter-prompts.mdx
+++ b/apps/docs/content/docs/sdk/starter-prompts.mdx
@@ -9,15 +9,23 @@ custom surfaces — embedded experiences, Slack slash commands, internal
 tools — so users see personalized first-run suggestions anywhere Atlas
 runs, not only in the web chat.
 
-The list composes three tiers in display order:
+The list composes tiers in display order:
 
 1. **Favorites** — prompts the user has pinned (per-user, per-workspace).
-2. **Popular** — admin-approved suggestions derived from past usage.
-3. **Library** — curated prompts for the active demo industry, shown when
-   not enough favorites or popular items exist.
+   Requires both a user and workspace context; callers without either
+   (unauthenticated local dev, keys not bound to a user) simply skip this
+   tier.
+2. **Library** — curated prompts for the active workspace's demo industry,
+   used to fill any remaining slots after favorites.
 
-An empty response signals the cold-start state — the UI should render a
-single-CTA empty state rather than a prompt list.
+A **popular** tier (admin-approved suggestions from past usage) is reserved
+in the wire format and will slot in between favorites and library in a
+future release — it is not yet emitted.
+
+An empty `prompts` array signals the cold-start state — the UI should
+render a single-CTA empty state rather than a prompt list. The `cold-start`
+value in `StarterPromptProvenance` is reserved for future use; the current
+server never returns a row with that provenance.
 
 ---
 
@@ -92,14 +100,17 @@ The list is resolved from the caller's user and workspace context — the
 API key (or bearer token) you pass to `createAtlasClient` maps to a single
 user, and that user's pinned favorites appear first in the response.
 
-This has two practical implications:
+This has three practical implications:
 
 - **One key per user** — share a key across users and they will all see
   the same user's favorites. Provision one key per seat when favorites
   matter.
-- **Workspace scoping** — popular suggestions and the demo-industry
-  library are resolved against the key's workspace. Switch keys to
-  switch workspaces.
+- **Workspace scoping** — the demo-industry library is resolved against
+  the key's workspace. Switch keys to switch workspaces.
+- **Self-hosted / dev mode** — credentials that don't bind to a specific
+  user (or bind without a workspace) silently skip the favorites tier
+  and fall through to the library. You'll still get a list; it just
+  won't include any pins.
 
 For background on API-key to user binding, see
 [API Keys](/docs/guides/api-keys).

--- a/apps/docs/content/docs/sdk/starter-prompts.mdx
+++ b/apps/docs/content/docs/sdk/starter-prompts.mdx
@@ -1,0 +1,113 @@
+---
+title: Starter Prompts
+description: Fetch the adaptive starter-prompt list from @useatlas/sdk.
+---
+
+Use `atlas.getStarterPrompts()` to fetch the same resolved list of starter
+prompts that the Atlas web empty state renders. This is the bridge for
+custom surfaces — embedded experiences, Slack slash commands, internal
+tools — so users see personalized first-run suggestions anywhere Atlas
+runs, not only in the web chat.
+
+The list composes three tiers in display order:
+
+1. **Favorites** — prompts the user has pinned (per-user, per-workspace).
+2. **Popular** — admin-approved suggestions derived from past usage.
+3. **Library** — curated prompts for the active demo industry, shown when
+   not enough favorites or popular items exist.
+
+An empty response signals the cold-start state — the UI should render a
+single-CTA empty state rather than a prompt list.
+
+---
+
+## Method
+
+```typescript
+atlas.getStarterPrompts(options?: { limit?: number }): Promise<StarterPromptsResponse>
+```
+
+### Options
+
+| Field   | Type     | Default | Notes                                            |
+| ------- | -------- | ------- | ------------------------------------------------ |
+| `limit` | `number` | `6`     | Maximum number of prompts. Server clamps to 1–50. |
+
+### Response
+
+```typescript
+interface StarterPromptsResponse {
+  readonly prompts: ReadonlyArray<StarterPrompt>;
+  readonly total: number;
+}
+
+interface StarterPrompt {
+  readonly id: string;
+  readonly text: string;
+  readonly provenance: StarterPromptProvenance;
+}
+
+type StarterPromptProvenance =
+  | "favorite"
+  | "popular"
+  | "library"
+  | "cold-start";
+```
+
+The `id` is namespaced by tier (e.g. `library:<uuid>`, `favorite:<pinId>`)
+so two tiers returning rows with the same raw id never collide on
+client-side keys.
+
+`provenance` is useful for badging or telemetry — e.g. render a pin icon
+next to favorites, or track which tier a user clicked.
+
+---
+
+## Example
+
+```typescript
+import { createAtlasClient } from "@useatlas/sdk";
+
+const atlas = createAtlasClient({
+  baseUrl: "https://api.example.com",
+  apiKey: process.env.ATLAS_API_KEY!,
+});
+
+const { prompts, total } = await atlas.getStarterPrompts({ limit: 5 });
+
+if (total === 0) {
+  renderColdStartCta();
+} else {
+  for (const p of prompts) {
+    console.log(`[${p.provenance}] ${p.text}`);
+  }
+}
+```
+
+---
+
+## User context
+
+The list is resolved from the caller's user and workspace context — the
+API key (or bearer token) you pass to `createAtlasClient` maps to a single
+user, and that user's pinned favorites appear first in the response.
+
+This has two practical implications:
+
+- **One key per user** — share a key across users and they will all see
+  the same user's favorites. Provision one key per seat when favorites
+  matter.
+- **Workspace scoping** — popular suggestions and the demo-industry
+  library are resolved against the key's workspace. Switch keys to
+  switch workspaces.
+
+For background on API-key to user binding, see
+[API Keys](/docs/guides/api-keys).
+
+---
+
+## See also
+
+- [SDK Reference](/docs/reference/sdk) — full method index
+- [API Keys](/docs/guides/api-keys) — creating and managing keys
+- `GET /api/v1/starter-prompts` — underlying REST endpoint

--- a/bun.lock
+++ b/bun.lock
@@ -282,7 +282,7 @@
     },
     "packages/sdk": {
       "name": "@useatlas/sdk",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "dependencies": {
         "@useatlas/types": "^0.0.11",
       },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/sdk",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "TypeScript SDK for the Atlas text-to-SQL agent API",
   "type": "module",
   "scripts": {

--- a/packages/sdk/src/__tests__/integration.test.ts
+++ b/packages/sdk/src/__tests__/integration.test.ts
@@ -21,6 +21,7 @@ import {
   MOCK_SCHEDULED_TASK_RUNS,
   MOCK_TABLES_RESPONSE,
   MOCK_VALIDATE_SQL_VALID,
+  MOCK_STARTER_PROMPTS,
   type MockServer,
 } from "./mock-server";
 
@@ -475,6 +476,57 @@ describe("listTables()", () => {
   test("401 unauthorized → AtlasError", async () => {
     try {
       await badClient().listTables();
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(AtlasError);
+      expect((err as AtlasError).status).toBe(401);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getStarterPrompts()
+// ---------------------------------------------------------------------------
+
+describe("getStarterPrompts()", () => {
+  test("returns resolved prompts with { text, provenance } preserving server order", async () => {
+    const result = await client().getStarterPrompts();
+
+    expect(result.total).toBe(MOCK_STARTER_PROMPTS.total);
+    expect(result.prompts).toHaveLength(MOCK_STARTER_PROMPTS.prompts.length);
+    expect(result.prompts.map((p) => p.provenance)).toEqual([
+      "favorite",
+      "popular",
+      "library",
+      "library",
+    ]);
+    expect(result.prompts.map((p) => p.text)).toEqual(
+      MOCK_STARTER_PROMPTS.prompts.map((p) => p.text),
+    );
+  });
+
+  test("ordering matches a direct HTTP fetch against the same endpoint", async () => {
+    const sdkResult = await client().getStarterPrompts({ limit: 3 });
+    const direct = await fetch(`${baseUrl}/api/v1/starter-prompts?limit=3`, {
+      headers: { Authorization: `Bearer ${VALID_API_KEY}` },
+    });
+    const directBody = (await direct.json()) as typeof sdkResult;
+
+    expect(sdkResult.total).toBe(directBody.total);
+    expect(sdkResult.prompts).toEqual(directBody.prompts);
+  });
+
+  test("respects limit param via query string", async () => {
+    const result = await client().getStarterPrompts({ limit: 2 });
+
+    expect(result.prompts).toHaveLength(2);
+    expect(result.prompts[0].text).toBe(MOCK_STARTER_PROMPTS.prompts[0].text);
+    expect(result.prompts[1].text).toBe(MOCK_STARTER_PROMPTS.prompts[1].text);
+  });
+
+  test("401 unauthorized → AtlasError", async () => {
+    try {
+      await badClient().getStarterPrompts();
       expect.unreachable("should have thrown");
     } catch (err) {
       expect(err).toBeInstanceOf(AtlasError);

--- a/packages/sdk/src/__tests__/integration.test.ts
+++ b/packages/sdk/src/__tests__/integration.test.ts
@@ -22,6 +22,8 @@ import {
   MOCK_TABLES_RESPONSE,
   MOCK_VALIDATE_SQL_VALID,
   MOCK_STARTER_PROMPTS,
+  getLastStarterPromptsRequestUrl,
+  resetStarterPromptsCapture,
   type MockServer,
 } from "./mock-server";
 
@@ -503,6 +505,25 @@ describe("getStarterPrompts()", () => {
     expect(result.prompts.map((p) => p.text)).toEqual(
       MOCK_STARTER_PROMPTS.prompts.map((p) => p.text),
     );
+  });
+
+  test("no-args call does not send a `limit` query param", async () => {
+    resetStarterPromptsCapture();
+    await client().getStarterPrompts();
+
+    const captured = getLastStarterPromptsRequestUrl();
+    expect(captured).not.toBeNull();
+    const url = new URL(captured as string);
+    expect(url.searchParams.has("limit")).toBe(false);
+    expect(url.search).toBe("");
+  });
+
+  test("empty server response surfaces as cold-start shape { prompts: [], total: 0 }", async () => {
+    // mock-server returns `slice(0, 0)` → [] when limit=0 is forwarded
+    const result = await client().getStarterPrompts({ limit: 0 });
+
+    expect(result.prompts).toEqual([]);
+    expect(result.total).toBe(0);
   });
 
   test("ordering matches a direct HTTP fetch against the same endpoint", async () => {

--- a/packages/sdk/src/__tests__/mock-server.ts
+++ b/packages/sdk/src/__tests__/mock-server.ts
@@ -224,6 +224,22 @@ export const MOCK_VALIDATE_SQL_VALID = {
   tables: ["users"],
 };
 
+/**
+ * Most-recent-request capture for `GET /api/v1/starter-prompts`. Tests
+ * assert on the URL to verify the SDK forwards (or omits) query params
+ * correctly. Wrapped in a getter + setter so consumers always read the
+ * current value rather than a stale import binding.
+ */
+let lastStarterPromptsRequestUrl: string | null = null;
+
+export function getLastStarterPromptsRequestUrl(): string | null {
+  return lastStarterPromptsRequestUrl;
+}
+
+export function resetStarterPromptsCapture(): void {
+  lastStarterPromptsRequestUrl = null;
+}
+
 export const MOCK_STARTER_PROMPTS = {
   prompts: [
     { id: "favorite:fav-1", text: "Top users by revenue", provenance: "favorite" as const },
@@ -685,6 +701,7 @@ async function handleRequest(req: Request): Promise<Response> {
   if (method === "GET" && pathname === "/api/v1/starter-prompts") {
     const authErr = checkAuth(req);
     if (authErr) return authErr;
+    lastStarterPromptsRequestUrl = req.url;
     const rawLimit = url.searchParams.get("limit");
     const all = MOCK_STARTER_PROMPTS.prompts;
     const sliced = rawLimit != null ? all.slice(0, Number(rawLimit)) : all;

--- a/packages/sdk/src/__tests__/mock-server.ts
+++ b/packages/sdk/src/__tests__/mock-server.ts
@@ -224,6 +224,16 @@ export const MOCK_VALIDATE_SQL_VALID = {
   tables: ["users"],
 };
 
+export const MOCK_STARTER_PROMPTS = {
+  prompts: [
+    { id: "favorite:fav-1", text: "Top users by revenue", provenance: "favorite" as const },
+    { id: "popular:pop-1", text: "Daily active users this week", provenance: "popular" as const },
+    { id: "library:lib-1", text: "Recent signup trend", provenance: "library" as const },
+    { id: "library:lib-2", text: "Churn rate by plan", provenance: "library" as const },
+  ],
+  total: 4,
+};
+
 export const MOCK_VALIDATE_SQL_INVALID = {
   valid: false,
   errors: [
@@ -669,6 +679,16 @@ async function handleRequest(req: Request): Promise<Response> {
     const authErr = checkAuth(req);
     if (authErr) return authErr;
     return json(MOCK_TABLES_RESPONSE);
+  }
+
+  // ---- GET /api/v1/starter-prompts ----
+  if (method === "GET" && pathname === "/api/v1/starter-prompts") {
+    const authErr = checkAuth(req);
+    if (authErr) return authErr;
+    const rawLimit = url.searchParams.get("limit");
+    const all = MOCK_STARTER_PROMPTS.prompts;
+    const sliced = rawLimit != null ? all.slice(0, Number(rawLimit)) : all;
+    return json({ prompts: sliced, total: sliced.length });
   }
 
   // ---- POST /api/v1/validate-sql ----

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -654,10 +654,13 @@ export function createAtlasClient(options: AtlasClientOptions) {
     /**
      * Fetch the adaptive list of starter prompts for the current user.
      *
-     * The list composes favorites, approved popular suggestions, and the
-     * demo-industry library — the server returns them in final display
-     * order. User context (org, favorites) is resolved from the API key,
-     * so SDK callers see the same list the web empty state renders.
+     * The list composes favorites and the demo-industry library (a popular
+     * tier is reserved in the wire format but not yet wired on the server).
+     * The server returns prompts in final display order. User context (org,
+     * favorites) is resolved from the caller's credentials, so SDK callers
+     * see the same list the web empty state renders. An empty `prompts`
+     * array signals the cold-start state — no row with
+     * `provenance: "cold-start"` is emitted.
      */
     async getStarterPrompts(
       opts?: GetStarterPromptsOptions,

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -31,6 +31,9 @@ export type {
   ScheduledTaskRun,
   TableInfo,
   TableColumn,
+  StarterPrompt,
+  StarterPromptProvenance,
+  StarterPromptsResponse,
 } from "@useatlas/types";
 
 import type {
@@ -48,6 +51,7 @@ import type {
   ScheduledTask,
   ScheduledTaskWithRuns,
   ScheduledTaskRun,
+  StarterPromptsResponse,
   TableInfo,
 } from "@useatlas/types";
 import { isChatErrorCode, isRetryableError } from "@useatlas/types";
@@ -162,6 +166,15 @@ export interface ShareConversationResponse {
 
 export interface ListTablesResponse {
   tables: TableInfo[];
+}
+
+// ---------------------------------------------------------------------------
+// Starter prompts
+// ---------------------------------------------------------------------------
+
+export interface GetStarterPromptsOptions {
+  /** Maximum number of prompts to return (server clamps to 1–50, default 6). */
+  limit?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -636,6 +649,24 @@ export function createAtlasClient(options: AtlasClientOptions) {
     async listTables(): Promise<ListTablesResponse> {
       const res = await get("/api/v1/tables");
       return unwrap<ListTablesResponse>(res);
+    },
+
+    /**
+     * Fetch the adaptive list of starter prompts for the current user.
+     *
+     * The list composes favorites, approved popular suggestions, and the
+     * demo-industry library — the server returns them in final display
+     * order. User context (org, favorites) is resolved from the API key,
+     * so SDK callers see the same list the web empty state renders.
+     */
+    async getStarterPrompts(
+      opts?: GetStarterPromptsOptions,
+    ): Promise<StarterPromptsResponse> {
+      const params = new URLSearchParams();
+      if (opts?.limit != null) params.set("limit", String(opts.limit));
+      const qs = params.toString();
+      const res = await get(`/api/v1/starter-prompts${qs ? `?${qs}` : ""}`);
+      return unwrap<StarterPromptsResponse>(res);
     },
 
     /**

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -69,4 +69,8 @@ export {
   type ListTablesResponse,
   type TableInfo,
   type TableColumn,
+  type StarterPrompt,
+  type StarterPromptProvenance,
+  type StarterPromptsResponse,
+  type GetStarterPromptsOptions,
 } from "./client";


### PR DESCRIPTION
## Summary

- Adds `atlas.getStarterPrompts(options?)` to `@useatlas/sdk`, wrapping `GET /api/v1/starter-prompts`.
- Re-exports `StarterPrompt`, `StarterPromptProvenance`, `StarterPromptsResponse` from `@useatlas/types` via the SDK index.
- Integration-tests ordering parity with a direct HTTP fetch and validates the `limit` query forwarding + 401 behavior.
- Adds a dedicated docs page at `docs/sdk/starter-prompts.mdx` (+ nav registration) and cross-links from `reference/sdk.mdx`.
- Bumps `@useatlas/sdk` 0.0.9 → 0.0.10. Per the version-bump-ordering feedback, template/package refs are **not** updated in this PR — they follow in a post-publish PR after the `sdk-v0.0.10` tag publishes.

Closes #1481.

## Design notes

- **User context**: the SDK already resolves favorites + workspace via the API key → user mapping used everywhere else; no new auth code is required. This is called out explicitly in the docs page so callers understand why favorites appear only when they provision one key per seat.
- **TDD flow**: integration test landed first (failing red-bar with `client().getStarterPrompts is not a function`), then the client method + type re-exports, then docs.
- **Published-package rules**: no `workspace:*` deps, no `"bun"` export condition pointing at `src/` — the existing SDK layout was already compliant.

## Test plan

- [x] `bun run lint`
- [x] `bun run type`
- [x] `bun run test` (all packages exit 0)
- [x] `bun x syncpack lint`
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh`
- [x] New SDK integration tests (4) all green against the mock HTTP server
- [ ] After merge: tag `sdk-v0.0.10` to trigger OIDC publish, then open follow-up PR to bump refs in `packages/react`, `packages/web`, and `create-atlas/templates/*/package.json`