### PR TITLE
feat(starter-prompts): widget empty state + starterPrompts prop override (#1479)

### DIFF
--- a/apps/docs/content/docs/guides/embedding-widget.mdx
+++ b/apps/docs/content/docs/guides/embedding-widget.mdx
@@ -48,6 +48,7 @@ Configure the widget via `data-*` attributes on the script tag:
 | `data-theme` | No | `"light"` | `"light"` or `"dark"` |
 | `data-position` | No | `"bottom-right"` | `"bottom-right"` or `"bottom-left"` |
 | `data-show-branding` | No | `"true"` | Set to `"false"` to hide the "Powered by Atlas" badge |
+| `data-starter-prompts` | No | -- | JSON-encoded array of strings. Overrides the adaptive starter-prompt list. When set, the widget skips `/api/v1/starter-prompts` entirely. Invalid JSON or non-string entries are dropped silently. See [Starter Prompts](#starter-prompts) below. |
 
 ### Event Callbacks
 
@@ -82,6 +83,58 @@ Bind callbacks by setting `data-on-*` attributes to the name of a global functio
   data-on-error="onAtlasError"
 ></script>
 ```
+
+## Starter Prompts
+
+When the widget renders an empty chat, it shows a grid of suggested prompts. By default the list is **adaptive** — the widget calls `GET /api/v1/starter-prompts` and renders the resolved list of the user's pinned favorites, the workspace's approved popular queries, and an industry-curated fallback. Pinned prompts render with a small pin icon; other tiers render as plain suggestions.
+
+For embedded placements where you want a hardcoded list — for example, a marketing-site demo or a docs-page widget tied to a specific scenario — pass the `data-starter-prompts` attribute (script tag) or the `starterPrompts` prop (`@useatlas/react`):
+
+<Tabs items={["Script tag", "React component"]}>
+<Tab value="Script tag">
+```html
+<!-- Override starter prompts with a static list. The JSON value must be
+     a flat array of strings — wrap in single quotes so the embedded
+     double quotes parse correctly. -->
+<script
+  src="https://your-atlas-api.example.com/widget.js"
+  data-api-url="https://your-atlas-api.example.com"
+  data-starter-prompts='["What was last month'\''s revenue?","Top 5 customers by order count","Which products are out of stock?"]'
+></script>
+```
+</Tab>
+<Tab value="React component">
+```tsx
+import { AtlasChat } from "@useatlas/react";
+import "@useatlas/react/styles.css";
+
+<AtlasChat
+  apiUrl="https://your-atlas-api.example.com"
+  starterPrompts={[
+    "What was last month's revenue?",
+    "Top 5 customers by order count",
+    "Which products are out of stock?",
+  ]}
+/>
+```
+</Tab>
+</Tabs>
+
+<Callout type="warn">
+When `starterPrompts` is supplied (script tag attribute or React prop), the widget **does not call `/api/v1/starter-prompts`**. This is intentional — overrides exist precisely so embedded contexts can avoid issuing a user-identifying request from the host page. An empty array (`[]`) is treated as "render no suggestions" and still suppresses the fetch.
+</Callout>
+
+### Default empty state
+
+Without an override the widget shows three tiers of suggestions:
+
+- **Pinned (favorites)** — questions the user pinned from their own chat history. Marked with a pin icon. Always on top.
+- **Popular** — workspace-approved queries scored by frequency and click-through. No icon.
+- **Library** — industry-curated fallback (drawn from the prompt library) when the user has no pins and the workspace has no approved popular queries yet.
+
+When all three tiers are empty, the widget renders a one-line nudge ("Ask your first question below to get started") rather than a stale grid.
+
+---
 
 ## Programmatic API
 

--- a/apps/docs/content/docs/reference/react.mdx
+++ b/apps/docs/content/docs/reference/react.mdx
@@ -71,6 +71,7 @@ function App() {
 | `chatEndpoint` | `string` | `"/api/v1/chat"` | Custom chat API endpoint path. Combined with `apiUrl` for the full URL. |
 | `conversationsEndpoint` | `string` | `"/api/v1/conversations"` | Custom conversations API endpoint path. Used for listing and loading conversations. |
 | `showBranding` | `boolean` | `true` | Show "Powered by Atlas" badge below the chat input. Set to `false` to hide. Automatically hidden when enterprise white-label branding is active. |
+| `starterPrompts` | `string[]` | — | Override the adaptive empty-state prompt list with a static set of strings. When supplied, the widget **does not call** `/api/v1/starter-prompts` — overrides exist precisely so embedded contexts can avoid issuing a user-identifying request. Pass `[]` to render no suggestions and still skip the fetch. Omit the prop to fetch the resolved list of favorites + popular + library prompts from the server. |
 
 ### Auth Mode Detection
 

--- a/bun.lock
+++ b/bun.lock
@@ -222,7 +222,7 @@
     },
     "packages/react": {
       "name": "@useatlas/react",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^5.96.2",

--- a/e2e/browser/widget-starter-prompts.spec.ts
+++ b/e2e/browser/widget-starter-prompts.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from "@playwright/test";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+declare const window: any;
+
+const API_URL = process.env.ATLAS_API_URL ?? "http://localhost:3001";
+
+/**
+ * Widget starter-prompts override behavior — issue #1479.
+ *
+ * Two correctness checks:
+ *
+ *  1. **No prop** — the widget calls `/api/v1/starter-prompts` and renders
+ *     the returned list with provenance badges (matching the web app).
+ *  2. **Prop supplied** — the widget MUST NOT call the endpoint at all.
+ *     This is a privacy guarantee: an embedder using overrides should not
+ *     leak a user-identifying request from a host page.
+ *
+ * The "no network call" assertion uses `page.route` to count requests to
+ * `/api/v1/starter-prompts` directly — a Playwright observation rather
+ * than a fetch mock, so it captures real iframe traffic.
+ */
+
+function escapeAttr(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+}
+
+function widgetPage(attrs: Record<string, string> = {}): string {
+  const attrStr = Object.entries({ "data-api-url": API_URL, ...attrs })
+    .map(([k, v]) => `${k}="${escapeAttr(v)}"`)
+    .join(" ");
+
+  return `<!DOCTYPE html>
+<html><head><title>Widget Test</title></head>
+<body>
+<h1>Host Page</h1>
+<script src="${API_URL}/widget.js" ${attrStr}></script>
+</body></html>`;
+}
+
+test.describe("Widget starter-prompts override", () => {
+  // Pure DOM/network — no auth dependency. Clear storage so global-setup
+  // login doesn't add cookies that would change /api/v1/starter-prompts behavior.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test("data-starter-prompts forwards through to iframe URL as starterPrompts query param", async ({
+    page,
+  }) => {
+    const overrides = ["What is total revenue?", "Top 5 customers"];
+    await page.setContent(
+      widgetPage({ "data-starter-prompts": JSON.stringify(overrides) }),
+    );
+
+    // Wait for the floating bubble to be injected, then read the iframe src.
+    await page.locator(".atlas-wl-bubble").waitFor({ timeout: 10_000 });
+
+    const src = await page.locator(".atlas-wl-frame-wrap iframe").getAttribute("src");
+    expect(src).toBeTruthy();
+    expect(src).toContain("starterPrompts=");
+
+    const url = new URL(src!);
+    const param = url.searchParams.get("starterPrompts");
+    expect(param).not.toBeNull();
+    expect(JSON.parse(param!)).toEqual(overrides);
+  });
+
+  test("widget does NOT call /api/v1/starter-prompts when data-starter-prompts is supplied", async ({
+    page,
+  }) => {
+    const overrides = ["Override prompt one", "Override prompt two"];
+
+    // Count any request that touches /api/v1/starter-prompts. The
+    // counter wraps a route handler that always continues — we only
+    // observe traffic, never block it.
+    const observed: string[] = [];
+    await page.route("**/api/v1/starter-prompts**", async (route) => {
+      observed.push(route.request().url());
+      await route.continue();
+    });
+
+    await page.setContent(
+      widgetPage({ "data-starter-prompts": JSON.stringify(overrides) }),
+    );
+
+    // Open the bubble so the iframe mounts the AtlasChat component and
+    // would have triggered the fetch if the override were ignored.
+    const bubble = page.locator(".atlas-wl-bubble");
+    await bubble.waitFor({ timeout: 10_000 });
+    await bubble.click();
+
+    const frame = page.frameLocator(".atlas-wl-frame-wrap iframe");
+
+    // Wait for one of the override prompts to render so we know the empty
+    // state has fully booted, then assert nobody called the endpoint.
+    await expect(frame.getByText("Override prompt one")).toBeVisible({ timeout: 15_000 });
+    await expect(frame.getByText("Override prompt two")).toBeVisible();
+
+    expect(observed).toEqual([]);
+  });
+
+  test("widget calls /api/v1/starter-prompts when no override prop is supplied", async ({
+    page,
+  }) => {
+    const observed: string[] = [];
+    await page.route("**/api/v1/starter-prompts**", async (route) => {
+      observed.push(route.request().url());
+      await route.continue();
+    });
+
+    await page.setContent(widgetPage());
+
+    const bubble = page.locator(".atlas-wl-bubble");
+    await bubble.waitFor({ timeout: 10_000 });
+    await bubble.click();
+
+    // The iframe mounts AtlasChat which triggers the starter-prompts query.
+    // A real call to the endpoint should be observed within a few seconds.
+    await expect.poll(() => observed.length, { timeout: 15_000 }).toBeGreaterThan(0);
+  });
+
+  test("invalid data-starter-prompts JSON is dropped — no starterPrompts param emitted", async ({
+    page,
+  }) => {
+    await page.setContent(
+      widgetPage({ "data-starter-prompts": "not-json-at-all" }),
+    );
+
+    await page.locator(".atlas-wl-bubble").waitFor({ timeout: 10_000 });
+    const src = await page.locator(".atlas-wl-frame-wrap iframe").getAttribute("src");
+    expect(src).not.toContain("starterPrompts=");
+  });
+});

--- a/e2e/browser/widget-starter-prompts.spec.ts
+++ b/e2e/browser/widget-starter-prompts.spec.ts
@@ -6,7 +6,7 @@ declare const window: any;
 const API_URL = process.env.ATLAS_API_URL ?? "http://localhost:3001";
 
 /**
- * Widget starter-prompts override behavior — issue #1479.
+ * Widget starter-prompts override behavior.
  *
  * Two correctness checks:
  *
@@ -128,5 +128,84 @@ test.describe("Widget starter-prompts override", () => {
     await page.locator(".atlas-wl-bubble").waitFor({ timeout: 10_000 });
     const src = await page.locator(".atlas-wl-frame-wrap iframe").getAttribute("src");
     expect(src).not.toContain("starterPrompts=");
+  });
+
+  test("data-starter-prompts='[]' forwards as starterPrompts=%5B%5D AND suppresses the fetch", async ({
+    page,
+  }) => {
+    // The empty-array case is the most important behavioral test in the
+    // suite — the privacy invariant says "any opted-in override skips
+    // the fetch, including an empty one". A regression that adds
+    // `if (cleaned.length > 0)` would silently re-enable the API call
+    // and only this test would catch it end-to-end.
+    const observed: string[] = [];
+    await page.route("**/api/v1/starter-prompts**", async (route) => {
+      observed.push(route.request().url());
+      await route.continue();
+    });
+
+    await page.setContent(widgetPage({ "data-starter-prompts": "[]" }));
+    const bubble = page.locator(".atlas-wl-bubble");
+    await bubble.waitFor({ timeout: 10_000 });
+
+    const src = await page.locator(".atlas-wl-frame-wrap iframe").getAttribute("src");
+    expect(src).toContain("starterPrompts=");
+    const url = new URL(src!);
+    expect(JSON.parse(url.searchParams.get("starterPrompts")!)).toEqual([]);
+
+    // Open the bubble so the iframe mounts AtlasChat. Even with an empty
+    // override list, the starter-prompts endpoint must not be called.
+    await bubble.click();
+    // Give the iframe time to boot and have a chance to (incorrectly) fetch.
+    await page.waitForTimeout(2_000);
+    expect(observed).toEqual([]);
+  });
+
+  test("data-starter-prompts='[null,42,\"\"]' forwards as [] (privacy preserved on all-bad input)", async ({
+    page,
+  }) => {
+    const observed: string[] = [];
+    await page.route("**/api/v1/starter-prompts**", async (route) => {
+      observed.push(route.request().url());
+      await route.continue();
+    });
+
+    await page.setContent(
+      widgetPage({ "data-starter-prompts": '[null, 42, ""]' }),
+    );
+    const bubble = page.locator(".atlas-wl-bubble");
+    await bubble.waitFor({ timeout: 10_000 });
+
+    const src = await page.locator(".atlas-wl-frame-wrap iframe").getAttribute("src");
+    expect(src).toContain("starterPrompts=");
+    const url = new URL(src!);
+    expect(JSON.parse(url.searchParams.get("starterPrompts")!)).toEqual([]);
+
+    await bubble.click();
+    await page.waitForTimeout(2_000);
+    expect(observed).toEqual([]);
+  });
+
+  test("empty data-starter-prompts='' attribute is treated as absent (fetch from API)", async ({
+    page,
+  }) => {
+    await page.setContent(widgetPage({ "data-starter-prompts": "" }));
+    await page.locator(".atlas-wl-bubble").waitFor({ timeout: 10_000 });
+    const src = await page.locator(".atlas-wl-frame-wrap iframe").getAttribute("src");
+    // No param = absent = fetch path. An embedder server-rendering the
+    // attribute as empty string should not accidentally suppress the fetch.
+    expect(src).not.toContain("starterPrompts=");
+  });
+
+  test("data-starter-prompts='[\"  \",\"real\"]' filters whitespace before forwarding", async ({
+    page,
+  }) => {
+    await page.setContent(
+      widgetPage({ "data-starter-prompts": '["  ","real"]' }),
+    );
+    await page.locator(".atlas-wl-bubble").waitFor({ timeout: 10_000 });
+    const src = await page.locator(".atlas-wl-frame-wrap iframe").getAttribute("src");
+    const url = new URL(src!);
+    expect(JSON.parse(url.searchParams.get("starterPrompts")!)).toEqual(["real"]);
   });
 });

--- a/packages/api/src/api/__tests__/widget-loader.test.ts
+++ b/packages/api/src/api/__tests__/widget-loader.test.ts
@@ -573,6 +573,43 @@ describe("GET /widget.js", () => {
     expect(script).toContain("function onHostMessage(e)");
     expect(script).toContain("function onEscape(e)");
   });
+
+  // --- data-starter-prompts forwarding (issue #1479) ---
+
+  it("reads data-starter-prompts from the script tag", async () => {
+    const script = await getScript();
+    expect(script).toContain('s.getAttribute("data-starter-prompts")');
+  });
+
+  it("parses data-starter-prompts as JSON before forwarding", async () => {
+    const script = await getScript();
+    expect(script).toContain("JSON.parse(starterPromptsRaw)");
+  });
+
+  it("appends starterPrompts query param to iframe src when supplied", async () => {
+    const script = await getScript();
+    expect(script).toContain('"&starterPrompts="+encodeURIComponent(JSON.stringify(cleaned))');
+  });
+
+  it("warns and drops the override when JSON is invalid (does not crash)", async () => {
+    const script = await getScript();
+    expect(script).toContain("[Atlas] data-starter-prompts is not valid JSON");
+  });
+
+  it("warns when the parsed value is not an array", async () => {
+    const script = await getScript();
+    expect(script).toContain(
+      "[Atlas] data-starter-prompts must be a JSON array of strings; ignoring",
+    );
+  });
+
+  it("filters out non-string entries before forwarding", async () => {
+    const script = await getScript();
+    // The IIFE walks the parsed array and keeps only string entries with
+    // non-empty trimmed text — this prevents the iframe from receiving
+    // garbage like `[null, 42, ""]`.
+    expect(script).toContain('typeof spv==="string"&&spv.trim().length>0');
+  });
 });
 
 describe("GET /widget.d.ts", () => {

--- a/packages/api/src/api/__tests__/widget-loader.test.ts
+++ b/packages/api/src/api/__tests__/widget-loader.test.ts
@@ -574,7 +574,7 @@ describe("GET /widget.js", () => {
     expect(script).toContain("function onEscape(e)");
   });
 
-  // --- data-starter-prompts forwarding (issue #1479) ---
+  // --- data-starter-prompts forwarding ---
 
   it("reads data-starter-prompts from the script tag", async () => {
     const script = await getScript();
@@ -609,6 +609,30 @@ describe("GET /widget.js", () => {
     // non-empty trimmed text — this prevents the iframe from receiving
     // garbage like `[null, 42, ""]`.
     expect(script).toContain('typeof spv==="string"&&spv.trim().length>0');
+  });
+
+  it("warns when a parsed array filters down to zero usable strings", async () => {
+    const script = await getScript();
+    // Without this guard, an embedder passing `[null, 42]` would see no
+    // prompts render and have no console feedback explaining why.
+    expect(script).toContain("contained no usable strings");
+  });
+
+  it("treats empty data-starter-prompts attribute as absent (truthy guard)", async () => {
+    const script = await getScript();
+    // `if(starterPromptsRaw)` short-circuits on `""`, so an empty attribute
+    // emits no starterPrompts param and the widget falls back to the
+    // adaptive fetch — same as no attribute at all.
+    expect(script).toContain("if(starterPromptsRaw){");
+  });
+
+  it("forwards a valid empty array (preserves the privacy boundary at the loader)", async () => {
+    const script = await getScript();
+    // The encoded param is appended for any valid JSON array — including
+    // []. There must be no `if (cleaned.length > 0)` guard here, otherwise
+    // an empty array would silently re-enable the API fetch.
+    expect(script).toContain('"&starterPrompts="+encodeURIComponent(JSON.stringify(cleaned))');
+    expect(script).not.toMatch(/cleaned\.length\s*>\s*0\s*\)\s*starterPromptsParam\s*=/);
   });
 });
 

--- a/packages/api/src/api/__tests__/widget.test.ts
+++ b/packages/api/src/api/__tests__/widget.test.ts
@@ -31,7 +31,7 @@ const mockedFs = {
 };
 mock.module("node:fs", () => ({ ...mockedFs, default: mockedFs }));
 
-const { widget, sanitizeLogoUrl, sanitizeAccent } = await import(
+const { widget, sanitizeLogoUrl, sanitizeAccent, sanitizeStarterPrompts } = await import(
   "../routes/widget"
 );
 
@@ -816,3 +816,115 @@ describe("sanitizeAccent", () => {
     expect(sanitizeAccent("")).toBe("");
   });
 });
+
+// ---------------------------------------------------------------------------
+// starterPrompts query param — issue #1479
+//
+// `null` (not `[]`) is the sentinel for "no override → fetch from API".
+// A non-null array — even an empty one — means "skip the fetch entirely".
+// Distinguishing those two cases is the whole privacy guarantee, so the
+// tests exercise the boundary explicitly.
+// ---------------------------------------------------------------------------
+
+describe("sanitizeStarterPrompts", () => {
+  it("returns null when raw is empty (no override)", () => {
+    expect(sanitizeStarterPrompts("")).toBeNull();
+  });
+
+  it("returns null on invalid JSON", () => {
+    expect(sanitizeStarterPrompts("not-json")).toBeNull();
+    expect(sanitizeStarterPrompts("{")).toBeNull();
+  });
+
+  it("returns null when JSON value is not an array", () => {
+    expect(sanitizeStarterPrompts('{"foo":"bar"}')).toBeNull();
+    expect(sanitizeStarterPrompts('"a string"')).toBeNull();
+    expect(sanitizeStarterPrompts("42")).toBeNull();
+  });
+
+  it("returns parsed array of strings on a valid JSON array", () => {
+    expect(sanitizeStarterPrompts('["one","two"]')).toEqual(["one", "two"]);
+  });
+
+  it("drops non-string entries silently", () => {
+    expect(sanitizeStarterPrompts('["one",2,null,"two"]')).toEqual(["one", "two"]);
+  });
+
+  it("drops empty / whitespace-only entries", () => {
+    expect(sanitizeStarterPrompts('["one","","   ","two"]')).toEqual(["one", "two"]);
+  });
+
+  it("returns an empty array when valid JSON has zero usable entries", () => {
+    // Embedder explicitly opted in to overrides but supplied nothing usable —
+    // we still suppress the fetch (privacy guarantee), so the result is `[]`
+    // not `null`.
+    expect(sanitizeStarterPrompts('["","   "]')).toEqual([]);
+    expect(sanitizeStarterPrompts("[]")).toEqual([]);
+  });
+
+  it("trims whitespace and slices each string to 500 chars", () => {
+    const long = "a".repeat(800);
+    const [parsed] = sanitizeStarterPrompts(JSON.stringify([`  ${long}  `])) ?? [];
+    expect(parsed?.length).toBe(500);
+  });
+
+  it("caps the array at 32 entries to bound HTML response size", () => {
+    const many = Array.from({ length: 50 }, (_, i) => `prompt-${i}`);
+    const result = sanitizeStarterPrompts(JSON.stringify(many));
+    expect(result?.length).toBe(32);
+  });
+
+  it("returns null when raw exceeds 8KB to prevent oversized payloads", () => {
+    // An 8KB+ raw string is a smell — embedder is either mis-using the API
+    // or attempting to inflate the HTML response.
+    const giant = "x".repeat(9 * 1024);
+    expect(sanitizeStarterPrompts(JSON.stringify([giant]))).toBeNull();
+  });
+});
+
+describe("widget HTML — starterPrompts wiring", () => {
+  it("emits a null starterPrompts in the embedded config when query param is absent", async () => {
+    const res = await app.fetch(widgetRequest());
+    const html = await res.text();
+    // The atlas-config script element holds the JSON config the inline
+    // mount script reads. When no override, starterPrompts should be null
+    // so the widget falls back to fetching /api/v1/starter-prompts.
+    const configMatch = html.match(/<script id="atlas-config" type="application\/json">(.+?)<\/script>/);
+    expect(configMatch).not.toBeNull();
+    const config = JSON.parse(configMatch![1]);
+    expect(config.starterPrompts).toBeNull();
+  });
+
+  it("forwards a valid starterPrompts array into the embedded config", async () => {
+    const res = await app.fetch(
+      widgetRequest({ starterPrompts: '["What was last month\'s revenue?","Top 5 customers"]' }),
+    );
+    const html = await res.text();
+    const configMatch = html.match(/<script id="atlas-config" type="application\/json">(.+?)<\/script>/);
+    const config = JSON.parse(configMatch![1]);
+    expect(config.starterPrompts).toEqual([
+      "What was last month's revenue?",
+      "Top 5 customers",
+    ]);
+  });
+
+  it("falls back to null when starterPrompts query param is malformed", async () => {
+    const res = await app.fetch(widgetRequest({ starterPrompts: "not-json" }));
+    const html = await res.text();
+    const configMatch = html.match(/<script id="atlas-config" type="application\/json">(.+?)<\/script>/);
+    const config = JSON.parse(configMatch![1]);
+    expect(config.starterPrompts).toBeNull();
+  });
+
+  it("preserves an empty array (zero-prompt embed) — must still suppress the fetch", async () => {
+    const res = await app.fetch(widgetRequest({ starterPrompts: "[]" }));
+    const html = await res.text();
+    const configMatch = html.match(/<script id="atlas-config" type="application\/json">(.+?)<\/script>/);
+    const config = JSON.parse(configMatch![1]);
+    // Empty array is meaningful: "embedder opted in to overrides but
+    // wants nothing rendered — definitely don't fetch."
+    expect(Array.isArray(config.starterPrompts)).toBe(true);
+    expect(config.starterPrompts).toEqual([]);
+  });
+});
+

--- a/packages/api/src/api/__tests__/widget.test.ts
+++ b/packages/api/src/api/__tests__/widget.test.ts
@@ -12,7 +12,7 @@
  * require a prior `bun run build` in packages/react/.
  */
 
-import { describe, it, expect, mock } from "bun:test";
+import { describe, it, expect, mock, beforeAll, afterAll, beforeEach } from "bun:test";
 import { Hono } from "hono";
 import * as realFs from "node:fs";
 
@@ -818,7 +818,7 @@ describe("sanitizeAccent", () => {
 });
 
 // ---------------------------------------------------------------------------
-// starterPrompts query param — issue #1479
+// starterPrompts query param — privacy boundary
 //
 // `null` (not `[]`) is the sentinel for "no override → fetch from API".
 // A non-null array — even an empty one — means "skip the fetch entirely".
@@ -882,6 +882,44 @@ describe("sanitizeStarterPrompts", () => {
   });
 });
 
+describe("sanitizeStarterPrompts — observability", () => {
+  // Suppress console noise from intentional log paths under test.
+  const originalWarn = console.warn;
+  const captured: string[] = [];
+  beforeAll(() => {
+    console.warn = (...args: unknown[]) => {
+      captured.push(args.map((a) => (typeof a === "string" ? a : String(a))).join(" "));
+    };
+  });
+  afterAll(() => {
+    console.warn = originalWarn;
+  });
+  beforeEach(() => {
+    captured.length = 0;
+  });
+
+  it("logs a warning when raw input exceeds 8KB", () => {
+    const giant = "x".repeat(9 * 1024);
+    sanitizeStarterPrompts(JSON.stringify([giant]));
+    expect(captured.some((m) => m.includes("exceeds 8KB"))).toBe(true);
+  });
+
+  it("logs a warning when JSON is malformed", () => {
+    sanitizeStarterPrompts("not-json-at-all");
+    expect(captured.some((m) => m.includes("not valid JSON"))).toBe(true);
+  });
+
+  it("logs a warning when JSON is a non-array value", () => {
+    sanitizeStarterPrompts('{"prompts":["x"]}');
+    expect(captured.some((m) => m.includes("non-array"))).toBe(true);
+  });
+
+  it("does NOT log when the input is absent (no override is the default)", () => {
+    sanitizeStarterPrompts("");
+    expect(captured).toHaveLength(0);
+  });
+});
+
 describe("widget HTML — starterPrompts wiring", () => {
   it("emits a null starterPrompts in the embedded config when query param is absent", async () => {
     const res = await app.fetch(widgetRequest());
@@ -925,6 +963,32 @@ describe("widget HTML — starterPrompts wiring", () => {
     // wants nothing rendered — definitely don't fetch."
     expect(Array.isArray(config.starterPrompts)).toBe(true);
     expect(config.starterPrompts).toEqual([]);
+  });
+
+  it("inline mount script preserves the Array.isArray(...) ? ... : void 0 translation", async () => {
+    const res = await app.fetch(widgetRequest());
+    const html = await res.text();
+    // This single line is the privacy boundary inside the iframe — it
+    // turns `cfg.starterPrompts === null` into the React prop `undefined`
+    // (fetch path) while keeping any array (including []) as-is (skip-fetch
+    // path). A typo like `cfg.starterPrompts ?? void 0` would silently
+    // re-enable the fetch when the value is null. Pinning the line keeps
+    // accidental refactors visible.
+    expect(html).toContain("Array.isArray(cfg.starterPrompts)?cfg.starterPrompts:void 0");
+  });
+
+  it("oversized starterPrompts query param falls back to null (fetch from API) — pinned regression", async () => {
+    // Documents the current fail-open behavior: an oversized override
+    // payload silently re-enables the user-identifying request. The
+    // operator-side warning emitted by sanitizeStarterPrompts is the
+    // mitigation; if we ever switch to fail-closed (e.g. render no
+    // suggestions), update this test alongside.
+    const giant = "x".repeat(9 * 1024);
+    const res = await app.fetch(widgetRequest({ starterPrompts: JSON.stringify([giant]) }));
+    const html = await res.text();
+    const configMatch = html.match(/<script id="atlas-config" type="application\/json">(.+?)<\/script>/);
+    const config = JSON.parse(configMatch![1]);
+    expect(config.starterPrompts).toBeNull();
   });
 });
 

--- a/packages/api/src/api/routes/widget-loader.ts
+++ b/packages/api/src/api/routes/widget-loader.ts
@@ -15,6 +15,11 @@
  *   data-on-query-complete (optional) — global function name called on query completion
  *   data-on-error          (optional) — global function name called on widget error
  *   data-show-branding     (optional, default "true") — "false" hides the "Powered by Atlas" badge
+ *   data-starter-prompts   (optional) — JSON-encoded array of strings to override the
+ *                                       adaptive starter-prompt list. When set, the widget
+ *                                       does NOT call /api/v1/starter-prompts and renders
+ *                                       the supplied array as a flat list. Invalid JSON or
+ *                                       non-string entries are dropped with a console warning.
  *
  * Programmatic API (available on window.Atlas after script loads):
  *   Atlas.open()              — opens the widget panel
@@ -69,6 +74,29 @@ var position=s.getAttribute("data-position")||"bottom-right";
 if(position!=="bottom-right"&&position!=="bottom-left")position="bottom-right";
 var showBranding=s.getAttribute("data-show-branding");
 var brandingParam=showBranding==="false"?"&showBranding=false":"";
+
+/* data-starter-prompts: JSON array of strings forwarded as a query param.
+   Drops the param entirely on parse failure rather than silently sending
+   the empty list, which has different semantics than "no override". */
+var starterPromptsParam="";
+var starterPromptsRaw=s.getAttribute("data-starter-prompts");
+if(starterPromptsRaw){
+  try{
+    var parsed=JSON.parse(starterPromptsRaw);
+    if(Array.isArray(parsed)){
+      var cleaned=[];
+      for(var spi=0;spi<parsed.length;spi++){
+        var spv=parsed[spi];
+        if(typeof spv==="string"&&spv.trim().length>0)cleaned.push(spv);
+      }
+      starterPromptsParam="&starterPrompts="+encodeURIComponent(JSON.stringify(cleaned));
+    }else{
+      console.warn("[Atlas] data-starter-prompts must be a JSON array of strings; ignoring");
+    }
+  }catch(spErr){
+    console.warn("[Atlas] data-starter-prompts is not valid JSON; ignoring:",spErr&&spErr.message?spErr.message:String(spErr));
+  }
+}
 
 var isRight=position==="bottom-right";
 var isOpen=false;
@@ -139,7 +167,7 @@ var wrap=document.createElement("div");
 wrap.className="atlas-wl-frame-wrap";
 
 var iframe=document.createElement("iframe");
-var iframeSrc=apiUrl.replace(/\\/$/,"")+"/widget?position=inline&theme="+encodeURIComponent(theme)+brandingParam;
+var iframeSrc=apiUrl.replace(/\\/$/,"")+"/widget?position=inline&theme="+encodeURIComponent(theme)+brandingParam+starterPromptsParam;
 iframe.src=iframeSrc;
 iframe.setAttribute("title","Atlas Chat");
 iframe.setAttribute("allow","clipboard-write");

--- a/packages/api/src/api/routes/widget-loader.ts
+++ b/packages/api/src/api/routes/widget-loader.ts
@@ -75,9 +75,12 @@ if(position!=="bottom-right"&&position!=="bottom-left")position="bottom-right";
 var showBranding=s.getAttribute("data-show-branding");
 var brandingParam=showBranding==="false"?"&showBranding=false":"";
 
-/* data-starter-prompts: JSON array of strings forwarded as a query param.
-   Drops the param entirely on parse failure rather than silently sending
-   the empty list, which has different semantics than "no override". */
+/* data-starter-prompts: JSON array of strings forwarded as &starterPrompts to the iframe.
+   Parse failure or non-array values drop the param entirely so the widget falls back
+   to /api/v1/starter-prompts. A valid array — even one that's empty after filtering —
+   is forwarded as-is, which the iframe treats as "embedder opted in to overrides;
+   skip the fetch". A separate warning fires when filtering drops every entry so
+   embedders learn their attribute parsed but produced nothing usable. */
 var starterPromptsParam="";
 var starterPromptsRaw=s.getAttribute("data-starter-prompts");
 if(starterPromptsRaw){
@@ -88,6 +91,9 @@ if(starterPromptsRaw){
       for(var spi=0;spi<parsed.length;spi++){
         var spv=parsed[spi];
         if(typeof spv==="string"&&spv.trim().length>0)cleaned.push(spv);
+      }
+      if(parsed.length>0&&cleaned.length===0){
+        console.warn("[Atlas] data-starter-prompts contained no usable strings (every entry was empty or non-string); the widget will render an empty grid and skip the API fetch");
       }
       starterPromptsParam="&starterPrompts="+encodeURIComponent(JSON.stringify(cleaned));
     }else{

--- a/packages/api/src/api/routes/widget.ts
+++ b/packages/api/src/api/routes/widget.ts
@@ -22,6 +22,10 @@
  *   welcome      — welcome message shown before first user message
  *   initialQuery — auto-sends this query on first open
  *   showBranding — "true" (default) or "false"; hides "Powered by Atlas" badge when "false"
+ *   starterPrompts — JSON-encoded array of strings (URL-encoded). When supplied,
+ *                    overrides the adaptive starter-prompt list and the widget
+ *                    skips the /api/v1/starter-prompts call entirely. Invalid
+ *                    or oversized values are dropped silently.
  *
  * postMessage API (from parent window only — e.source === window.parent):
  *   { type: "theme", value: "dark" | "light" }     — "system" not supported via postMessage
@@ -130,6 +134,38 @@ function sanitizeAccent(raw: string): string {
   return HEX_COLOR_RE.test(raw) ? raw : "";
 }
 
+/**
+ * Parse the `starterPrompts` query param into a clean string array.
+ *
+ * Returns `null` (NOT `[]`) when the override is absent, malformed, or empty
+ * after filtering. The widget treats `null` as "fetch from API" and a non-null
+ * array — even an empty one would be a no-network override — as "skip fetch".
+ * Returning `null` in the malformed case keeps the safe default.
+ */
+function sanitizeStarterPrompts(raw: string): string[] | null {
+  if (!raw) return null;
+  // Cap raw length to prevent oversized HTML responses from a malicious
+  // embedder / open-redirect chain. ~32 prompts × 200 chars ≈ 6.4KB upper
+  // bound; the per-string slice below enforces the rest.
+  if (raw.length > 8 * 1024) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) return null;
+  const cleaned: string[] = [];
+  for (const entry of parsed) {
+    if (typeof entry !== "string") continue;
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+    cleaned.push(trimmed.slice(0, 500));
+    if (cleaned.length >= 32) break;
+  }
+  return cleaned;
+}
+
 // ---------------------------------------------------------------------------
 // Widget HTML builder
 // ---------------------------------------------------------------------------
@@ -143,6 +179,8 @@ function buildWidgetHTML(config: {
   welcome: string;
   initialQuery: string;
   showBranding: boolean;
+  /** When `null` the widget fetches from `/api/v1/starter-prompts`; otherwise it renders this static list and makes no network call. */
+  starterPrompts: string[] | null;
 }): string {
   // Escape < to \u003c to prevent XSS via </script> injection in the JSON blob
   const configJSON = JSON.stringify(config).replace(/</g, "\\u003c");
@@ -223,7 +261,11 @@ class EB extends Component{
 function render(){
   if(!state.visible){el.dataset.hidden="";return}
   delete el.dataset.hidden;
-  root.render(createElement(EB,null,createElement(AtlasChat,{apiUrl,apiKey:state.apiKey||void 0,theme:state.theme,showBranding:cfg.showBranding!==false})));
+  // cfg.starterPrompts is null when no override was supplied — pass undefined
+  // to the component so it falls back to fetching /api/v1/starter-prompts.
+  // A non-null array (even empty) means "skip the fetch".
+  const starterPromptsProp=Array.isArray(cfg.starterPrompts)?cfg.starterPrompts:void 0;
+  root.render(createElement(EB,null,createElement(AtlasChat,{apiUrl,apiKey:state.apiKey||void 0,theme:state.theme,showBranding:cfg.showBranding!==false,starterPrompts:starterPromptsProp})));
 }
 
 /** Replace the default Atlas logo element with a custom <img>.
@@ -408,6 +450,7 @@ widget.get("/", (c) => {
   const rawWelcome = c.req.query("welcome") ?? "";
   const rawInitialQuery = c.req.query("initialQuery") ?? "";
   const rawShowBranding = c.req.query("showBranding") ?? "true";
+  const rawStarterPrompts = c.req.query("starterPrompts") ?? "";
 
   const theme = VALID_THEMES.has(rawTheme) ? rawTheme : "system";
   const apiUrl = sanitizeApiUrl(rawApiUrl);
@@ -419,14 +462,15 @@ widget.get("/", (c) => {
   const welcome = rawWelcome.slice(0, 500);
   const initialQuery = rawInitialQuery.slice(0, 500);
   const showBranding = rawShowBranding !== "false";
+  const starterPrompts = sanitizeStarterPrompts(rawStarterPrompts);
 
   // Allow embedding as iframe from any origin
   c.header("Content-Security-Policy", "frame-ancestors *");
   c.header("Access-Control-Allow-Origin", "*");
 
   return c.html(
-    buildWidgetHTML({ theme, apiUrl, position, logo, accent, welcome, initialQuery, showBranding }),
+    buildWidgetHTML({ theme, apiUrl, position, logo, accent, welcome, initialQuery, showBranding, starterPrompts }),
   );
 });
 
-export { widget, sanitizeLogoUrl, sanitizeAccent };
+export { widget, sanitizeLogoUrl, sanitizeAccent, sanitizeStarterPrompts };

--- a/packages/api/src/api/routes/widget.ts
+++ b/packages/api/src/api/routes/widget.ts
@@ -135,26 +135,60 @@ function sanitizeAccent(raw: string): string {
 }
 
 /**
+ * Sentinel-bearing return type for {@link sanitizeStarterPrompts}.
+ *
+ * - `null` — no override was supplied (or the supplied value couldn't be
+ *   used). The widget falls back to `/api/v1/starter-prompts`.
+ * - `string[]` — embedder opted in to overrides. The widget renders this
+ *   list (even if empty) and **does not** call `/api/v1/starter-prompts`.
+ *
+ * The `null` vs `[]` distinction is the privacy boundary; callers must
+ * preserve it across every transformation.
+ */
+type StarterPromptsOverride = string[] | null;
+
+/**
  * Parse the `starterPrompts` query param into a clean string array.
  *
- * Returns `null` (NOT `[]`) when the override is absent, malformed, or empty
- * after filtering. The widget treats `null` as "fetch from API" and a non-null
- * array — even an empty one would be a no-network override — as "skip fetch".
- * Returning `null` in the malformed case keeps the safe default.
+ * Returns `null` when the override is **absent, oversized, or fails to
+ * parse as a JSON array**. A valid JSON array — even one that filters
+ * down to zero usable entries — returns `[]`. The widget treats `null`
+ * as "fetch from API" and any non-null array (including `[]`) as
+ * "skip fetch".
+ *
+ * Failure mode: a malformed override falls back to `null`, which **does**
+ * trigger the user-identifying API call. This is intentional for embedder
+ * compatibility but means an embedder can lose their privacy guarantee
+ * silently. Every fallback path therefore logs a warning so operators can
+ * detect a misconfigured embedder before users notice.
  */
-function sanitizeStarterPrompts(raw: string): string[] | null {
+function sanitizeStarterPrompts(raw: string): StarterPromptsOverride {
   if (!raw) return null;
   // Cap raw length to prevent oversized HTML responses from a malicious
   // embedder / open-redirect chain. ~32 prompts × 200 chars ≈ 6.4KB upper
   // bound; the per-string slice below enforces the rest.
-  if (raw.length > 8 * 1024) return null;
+  if (raw.length > 8 * 1024) {
+    console.warn(
+      `[Atlas] starterPrompts query param exceeds 8KB (${raw.length} bytes); dropping override — widget will fetch the adaptive list instead`,
+    );
+    return null;
+  }
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
-  } catch {
+  } catch (err) {
+    console.warn(
+      "[Atlas] starterPrompts query param is not valid JSON; dropping override:",
+      err instanceof Error ? err.message : String(err),
+    );
     return null;
   }
-  if (!Array.isArray(parsed)) return null;
+  if (!Array.isArray(parsed)) {
+    console.warn(
+      "[Atlas] starterPrompts query param parsed to non-array; expected JSON array of strings",
+    );
+    return null;
+  }
   const cleaned: string[] = [];
   for (const entry of parsed) {
     if (typeof entry !== "string") continue;
@@ -179,8 +213,8 @@ function buildWidgetHTML(config: {
   welcome: string;
   initialQuery: string;
   showBranding: boolean;
-  /** When `null` the widget fetches from `/api/v1/starter-prompts`; otherwise it renders this static list and makes no network call. */
-  starterPrompts: string[] | null;
+  /** See {@link StarterPromptsOverride}: `null` triggers the API fetch; any array (including `[]`) suppresses it. */
+  starterPrompts: StarterPromptsOverride;
 }): string {
   // Escape < to \u003c to prevent XSS via </script> injection in the JSON blob
   const configJSON = JSON.stringify(config).replace(/</g, "\\u003c");

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/react",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Embeddable Atlas chat UI for React applications",
   "license": "MIT",
   "repository": {

--- a/packages/react/src/components/__tests__/atlas-chat.starter-prompts.test.tsx
+++ b/packages/react/src/components/__tests__/atlas-chat.starter-prompts.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * Widget empty-state starter-prompts behavior — issue #1479.
+ *
+ * Two paths:
+ *
+ *  1. No `starterPrompts` prop → widget calls `/api/v1/starter-prompts` and
+ *     renders the returned list with provenance badges.
+ *  2. `starterPrompts` prop supplied → widget MUST NOT call the endpoint
+ *     (verified via fetch interception) and renders the supplied strings as
+ *     a flat list with no provenance badge.
+ *
+ * The "no network call" assertion is the correctness guarantee of the slice
+ * — overrides exist precisely so plugin authors can avoid leaking a
+ * user-identifying request from embedded contexts.
+ */
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { render, waitFor, cleanup } from "@testing-library/react";
+import { AtlasChat } from "../atlas-chat";
+
+interface CapturedRequest {
+  url: string;
+  init: RequestInit;
+}
+
+const capturedRequests: CapturedRequest[] = [];
+
+function defaultFetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
+  const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+  capturedRequests.push({ url, init: init ?? {} });
+
+  if (url.includes("/api/health")) {
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({ checks: { auth: { mode: "simple-key" } } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+  }
+  if (url.includes("/api/v1/starter-prompts")) {
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({
+          prompts: [
+            { id: "favorite:1", text: "My pinned question", provenance: "favorite" },
+            { id: "popular:2", text: "Top accounts by revenue", provenance: "popular" },
+            { id: "library:3", text: "Cybersecurity threat trends", provenance: "library" },
+          ],
+          total: 3,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+  }
+  if (url.includes("/api/v1/branding")) {
+    return Promise.resolve(
+      new Response(JSON.stringify({ branding: { hideAtlasBranding: false } }), { status: 200 }),
+    );
+  }
+  // Default: 404 — the widget tolerates this for non-essential endpoints.
+  return Promise.resolve(new Response(JSON.stringify({ error: "not_found" }), { status: 404 }));
+}
+
+const fetchMock = mock(defaultFetch);
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  capturedRequests.length = 0;
+  fetchMock.mockImplementation(defaultFetch);
+  fetchMock.mockClear();
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = originalFetch;
+});
+
+describe("AtlasChat empty state — starter prompts", () => {
+  it("fetches /api/v1/starter-prompts when no override prop is supplied", async () => {
+    const { findByText } = render(
+      <AtlasChat apiUrl="https://api.example.com" apiKey="test-key" />,
+    );
+
+    // Each fetched prompt should render in the empty-state grid.
+    await findByText("My pinned question", undefined, { timeout: 5_000 });
+    await findByText("Top accounts by revenue");
+    await findByText("Cybersecurity threat trends");
+
+    const starterReq = capturedRequests.find((r) => r.url.includes("/api/v1/starter-prompts"));
+    expect(starterReq).toBeDefined();
+    // The bearer token must propagate so the resolver returns the
+    // current user's favorites tier.
+    const headers = starterReq!.init.headers as Record<string, string> | undefined;
+    expect(headers?.["Authorization"]).toBe("Bearer test-key");
+  });
+
+  it("renders provenance badges matching the web app's pin marker for favorites", async () => {
+    const { findAllByTestId, queryByTestId } = render(
+      <AtlasChat apiUrl="https://api.example.com" />,
+    );
+
+    const favoriteRows = await findAllByTestId("starter-prompt-favorite", undefined, { timeout: 5_000 });
+    expect(favoriteRows.length).toBe(1);
+    expect(favoriteRows[0].textContent ?? "").toContain("My pinned question");
+
+    // Popular and library rows render the same prompt button without the pin icon.
+    expect(queryByTestId("starter-prompt-popular")?.textContent ?? "").toContain("Top accounts by revenue");
+    expect(queryByTestId("starter-prompt-library")?.textContent ?? "").toContain("Cybersecurity threat trends");
+  });
+
+  it("does NOT call /api/v1/starter-prompts when the prop override is supplied", async () => {
+    const overrides = ["Static prompt one", "Static prompt two"];
+    const { findByText } = render(
+      <AtlasChat
+        apiUrl="https://api.example.com"
+        apiKey="test-key"
+        starterPrompts={overrides}
+      />,
+    );
+
+    await findByText("Static prompt one", undefined, { timeout: 5_000 });
+    await findByText("Static prompt two");
+
+    // Health is still fetched; assert ONLY that the starter-prompts endpoint
+    // was never hit. This is the privacy-correctness guarantee for the
+    // override path (issue #1479).
+    await waitFor(() => {
+      expect(capturedRequests.find((r) => r.url.includes("/api/health"))).toBeDefined();
+    });
+    const starterReq = capturedRequests.find((r) => r.url.includes("/api/v1/starter-prompts"));
+    expect(starterReq).toBeUndefined();
+  });
+
+  it("override list renders without provenance badges (flat list)", async () => {
+    const overrides = ["Static prompt one", "Static prompt two"];
+    const { findAllByTestId, queryAllByTestId } = render(
+      <AtlasChat apiUrl="https://api.example.com" starterPrompts={overrides} />,
+    );
+
+    // Override prompts are tagged "library" provenance internally to reuse
+    // the renderer, but they MUST NOT render the favorite pin marker.
+    const libraryRows = await findAllByTestId("starter-prompt-library", undefined, { timeout: 5_000 });
+    expect(libraryRows.length).toBe(2);
+    expect(queryAllByTestId("starter-prompt-favorite")).toHaveLength(0);
+  });
+
+  it("override drops empty / non-string entries safely", async () => {
+    // Mixed array with an empty string and whitespace — both should be
+    // dropped before render rather than producing empty buttons.
+    const overrides = ["Valid prompt", "", "   "];
+    const { findAllByTestId } = render(
+      <AtlasChat apiUrl="https://api.example.com" starterPrompts={overrides} />,
+    );
+
+    const rows = await findAllByTestId("starter-prompt-library", undefined, { timeout: 5_000 });
+    expect(rows.length).toBe(1);
+    expect(rows[0].textContent ?? "").toContain("Valid prompt");
+  });
+
+  it("empty override array still suppresses the network call (zero-prompt embed)", async () => {
+    render(
+      <AtlasChat apiUrl="https://api.example.com" starterPrompts={[]} />,
+    );
+
+    // Wait for health to settle before asserting absence of starter call.
+    await waitFor(() => {
+      expect(capturedRequests.find((r) => r.url.includes("/api/health"))).toBeDefined();
+    });
+    const starterReq = capturedRequests.find((r) => r.url.includes("/api/v1/starter-prompts"));
+    expect(starterReq).toBeUndefined();
+  });
+});

--- a/packages/react/src/components/__tests__/atlas-chat.starter-prompts.test.tsx
+++ b/packages/react/src/components/__tests__/atlas-chat.starter-prompts.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Widget empty-state starter-prompts behavior — issue #1479.
+ * Widget empty-state starter-prompts behavior.
  *
  * Two paths:
  *
@@ -123,7 +123,7 @@ describe("AtlasChat empty state — starter prompts", () => {
 
     // Health is still fetched; assert ONLY that the starter-prompts endpoint
     // was never hit. This is the privacy-correctness guarantee for the
-    // override path (issue #1479).
+    // override path.
     await waitFor(() => {
       expect(capturedRequests.find((r) => r.url.includes("/api/health"))).toBeDefined();
     });
@@ -144,9 +144,12 @@ describe("AtlasChat empty state — starter prompts", () => {
     expect(queryAllByTestId("starter-prompt-favorite")).toHaveLength(0);
   });
 
-  it("override drops empty / non-string entries safely", async () => {
+  it("override drops empty / non-string entries safely AND still suppresses the fetch", async () => {
     // Mixed array with an empty string and whitespace — both should be
-    // dropped before render rather than producing empty buttons.
+    // dropped before render rather than producing empty buttons. The "any
+    // override → no fetch" semantic must hold even when filtering removes
+    // every entry except one (a regression where "all entries dropped →
+    // fall back to fetch" sneaks in must break this test).
     const overrides = ["Valid prompt", "", "   "];
     const { findAllByTestId } = render(
       <AtlasChat apiUrl="https://api.example.com" starterPrompts={overrides} />,
@@ -155,6 +158,11 @@ describe("AtlasChat empty state — starter prompts", () => {
     const rows = await findAllByTestId("starter-prompt-library", undefined, { timeout: 5_000 });
     expect(rows.length).toBe(1);
     expect(rows[0].textContent ?? "").toContain("Valid prompt");
+
+    await waitFor(() => {
+      expect(capturedRequests.find((r) => r.url.includes("/api/health"))).toBeDefined();
+    });
+    expect(capturedRequests.find((r) => r.url.includes("/api/v1/starter-prompts"))).toBeUndefined();
   });
 
   it("empty override array still suppresses the network call (zero-prompt embed)", async () => {

--- a/packages/react/src/components/atlas-chat.tsx
+++ b/packages/react/src/components/atlas-chat.tsx
@@ -65,9 +65,14 @@ export interface AtlasChatProps {
    * the override must not leak a user-identifying request from embedded
    * contexts. Each string renders as a flat suggestion chip with no
    * provenance badge. Pass `undefined` (the default) to fetch the adaptive
-   * list from the server instead.
+   * list from the server instead. Pass `[]` to render no suggestions and
+   * still suppress the fetch.
+   *
+   * Caps: the iframe / script-tag path enforces 32 entries × 500 chars at
+   * the server. The direct React-component path is uncapped — the consumer
+   * owns their own UI.
    */
-  starterPrompts?: string[];
+  starterPrompts?: readonly string[];
 }
 
 /** No-op auth client for non-managed auth modes. */
@@ -250,7 +255,7 @@ function AtlasChatInner({
   chatEndpoint: string;
   conversationsEndpoint: string;
   showBranding: boolean;
-  starterPromptsOverride?: string[];
+  starterPromptsOverride?: readonly string[];
 }) {
   const { apiUrl, isCrossOrigin, authClient } = useAtlasContext();
   const dark = useDarkMode();
@@ -442,7 +447,7 @@ function AtlasChatInner({
   // Fetch the adaptive starter prompts for the empty state. The query is
   // disabled when the embedder supplies a static `starterPrompts` prop —
   // the override must NOT trigger a user-identifying request from embedded
-  // contexts (per #1479 acceptance criteria).
+  // contexts.
   const starterPromptsQuery = useStarterPromptsQuery({
     enabled: starterPromptsOverride === undefined,
     apiKey,
@@ -450,9 +455,25 @@ function AtlasChatInner({
   const fetchedStarterPrompts: StarterPrompt[] = starterPromptsQuery.data ?? [];
   const overrideStarterPrompts: StarterPrompt[] | null = useMemo(() => {
     if (starterPromptsOverride === undefined) return null;
-    return starterPromptsOverride
-      .filter((text): text is string => typeof text === "string" && text.trim().length > 0)
-      .map((text, idx) => ({ id: `override:${idx}`, text, provenance: "library" as const }));
+    const cleaned: string[] = [];
+    let dropped = 0;
+    for (const text of starterPromptsOverride) {
+      if (typeof text === "string" && text.trim().length > 0) cleaned.push(text);
+      else dropped++;
+    }
+    // Symmetric with the loader IIFE / server sanitizer — a host app passing
+    // partially-malformed data (e.g. nulls from an upstream API) loses
+    // entries silently otherwise.
+    if (dropped > 0) {
+      console.warn(
+        `[Atlas] AtlasChat starterPrompts prop: dropped ${dropped} non-string or empty entr${dropped === 1 ? "y" : "ies"}`,
+      );
+    }
+    return cleaned.map((text, idx) => ({
+      id: `override:${idx}`,
+      text,
+      provenance: "library" as const,
+    }));
   }, [starterPromptsOverride]);
   const starterPromptsList: StarterPrompt[] = overrideStarterPrompts ?? fetchedStarterPrompts;
 

--- a/packages/react/src/components/atlas-chat.tsx
+++ b/packages/react/src/components/atlas-chat.tsx
@@ -4,6 +4,7 @@ import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport, isToolUIPart } from "ai";
 import { useState, useRef, useEffect, useMemo, useCallback } from "react";
 import { useQuery, QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { StarterPrompt } from "@useatlas/types/starter-prompt";
 import type { AuthMode } from "../lib/types";
 import type { ToolRenderers } from "../lib/tool-renderer-types";
 import { AtlasContext, useAtlasContext, ActionAuthProvider, noopAuthClient, type AtlasAuthClient } from "../context";
@@ -15,12 +16,12 @@ import { ManagedAuthCard } from "./chat/managed-auth-card";
 import { TypingIndicator } from "./chat/typing-indicator";
 import { ToolPart } from "./chat/tool-part";
 import { Markdown } from "./chat/markdown";
-import { STARTER_PROMPTS } from "./chat/starter-prompts";
 import { FollowUpChips } from "./chat/follow-up-chips";
 import { ConversationSidebar } from "./conversations/conversation-sidebar";
 import { ChangePasswordDialog } from "./admin/change-password-dialog";
 import { useHealthQuery } from "../hooks/use-health-query";
-import { Sun, Moon, Monitor, Star, TableProperties, Send } from "lucide-react";
+import { useStarterPromptsQuery } from "../hooks/use-starter-prompts-query";
+import { Sun, Moon, Monitor, Star, TableProperties, Pin, Send } from "lucide-react";
 import { SchemaExplorer } from "./schema-explorer/schema-explorer";
 import {
   DropdownMenu,
@@ -57,6 +58,16 @@ export interface AtlasChatProps {
   conversationsEndpoint?: string;
   /** Show "Powered by Atlas" badge at the bottom of the chat. Defaults to true. Automatically hidden when enterprise white-label branding (hideAtlasBranding) is active. */
   showBranding?: boolean;
+  /**
+   * Optional static starter prompts to render in the empty state.
+   *
+   * When supplied, the widget will NOT call `/api/v1/starter-prompts` —
+   * the override must not leak a user-identifying request from embedded
+   * contexts. Each string renders as a flat suggestion chip with no
+   * provenance badge. Pass `undefined` (the default) to fetch the adaptive
+   * list from the server instead.
+   */
+  starterPrompts?: string[];
 }
 
 /** No-op auth client for non-managed auth modes. */
@@ -168,6 +179,7 @@ export function AtlasChat(props: AtlasChatProps) {
     chatEndpoint = "/api/v1/chat",
     conversationsEndpoint = "/api/v1/conversations",
     showBranding = true,
+    starterPrompts: starterPromptsOverride,
   } = props;
 
   // Apply theme from props on mount and when it changes
@@ -199,6 +211,7 @@ export function AtlasChat(props: AtlasChatProps) {
           chatEndpoint={chatEndpoint}
           conversationsEndpoint={conversationsEndpoint}
           showBranding={showBranding}
+          starterPromptsOverride={starterPromptsOverride}
         />
       </AtlasContext.Provider>
     </QueryClientProvider>
@@ -228,6 +241,7 @@ function AtlasChatInner({
   chatEndpoint,
   conversationsEndpoint,
   showBranding,
+  starterPromptsOverride,
 }: {
   propApiKey?: string;
   sidebar: boolean;
@@ -236,6 +250,7 @@ function AtlasChatInner({
   chatEndpoint: string;
   conversationsEndpoint: string;
   showBranding: boolean;
+  starterPromptsOverride?: string[];
 }) {
   const { apiUrl, isCrossOrigin, authClient } = useAtlasContext();
   const dark = useDarkMode();
@@ -424,6 +439,23 @@ function AtlasChatInner({
 
   const isLoading = status === "streaming" || status === "submitted";
 
+  // Fetch the adaptive starter prompts for the empty state. The query is
+  // disabled when the embedder supplies a static `starterPrompts` prop —
+  // the override must NOT trigger a user-identifying request from embedded
+  // contexts (per #1479 acceptance criteria).
+  const starterPromptsQuery = useStarterPromptsQuery({
+    enabled: starterPromptsOverride === undefined,
+    apiKey,
+  });
+  const fetchedStarterPrompts: StarterPrompt[] = starterPromptsQuery.data ?? [];
+  const overrideStarterPrompts: StarterPrompt[] | null = useMemo(() => {
+    if (starterPromptsOverride === undefined) return null;
+    return starterPromptsOverride
+      .filter((text): text is string => typeof text === "string" && text.trim().length > 0)
+      .map((text, idx) => ({ id: `override:${idx}`, text, provenance: "library" as const }));
+  }, [starterPromptsOverride]);
+  const starterPromptsList: StarterPrompt[] = overrideStarterPrompts ?? fetchedStarterPrompts;
+
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
@@ -595,18 +627,36 @@ function AtlasChatInner({
                           Ask a question about your data to get started
                         </p>
                       </div>
-                      <div className="grid w-full max-w-lg grid-cols-1 gap-2 sm:grid-cols-2">
-                        {STARTER_PROMPTS.map((prompt) => (
-                          <Button
-                            key={prompt}
-                            variant="outline"
-                            onClick={() => handleSend(prompt)}
-                            className="h-auto whitespace-normal justify-start rounded-lg px-3 py-2.5 text-left text-sm"
-                          >
-                            {prompt}
-                          </Button>
-                        ))}
-                      </div>
+                      {starterPromptsList.length > 0 ? (
+                        <div className="grid w-full max-w-lg grid-cols-1 gap-2 sm:grid-cols-2">
+                          {starterPromptsList.map((prompt) => {
+                            const isFavorite = prompt.provenance === "favorite";
+                            return (
+                              <Button
+                                key={prompt.id}
+                                variant="outline"
+                                onClick={() => handleSend(prompt.text)}
+                                className="h-auto whitespace-normal justify-start rounded-lg px-3 py-2.5 text-left text-sm"
+                                data-testid={`starter-prompt-${prompt.provenance}`}
+                              >
+                                {isFavorite && (
+                                  <Pin
+                                    className="mr-2 size-3.5 shrink-0 text-primary"
+                                    aria-hidden="true"
+                                  />
+                                )}
+                                <span className="flex-1">{prompt.text}</span>
+                              </Button>
+                            );
+                          })}
+                        </div>
+                      ) : (
+                        !starterPromptsQuery.isLoading && (
+                          <p className="max-w-sm text-center text-sm text-zinc-500 dark:text-zinc-500">
+                            Ask your first question below to get started.
+                          </p>
+                        )
+                      )}
                     </div>
                   )}
 

--- a/packages/react/src/components/chat/starter-prompts.ts
+++ b/packages/react/src/components/chat/starter-prompts.ts
@@ -1,6 +1,0 @@
-export const STARTER_PROMPTS = [
-  "What are the top 10 companies by revenue?",
-  "Show me the distribution of account types",
-  "What is the headcount breakdown by department?",
-  "What is total MRR by plan type?",
-];

--- a/packages/react/src/hooks/use-starter-prompts-query.ts
+++ b/packages/react/src/hooks/use-starter-prompts-query.ts
@@ -44,17 +44,33 @@ export function useStarterPromptsQuery({ enabled, apiKey }: UseStarterPromptsQue
       }
 
       if (!res.ok) {
-        // 5xx responses include a requestId for log correlation; surface it
-        // so operators can trace, then return [] so the empty state still
-        // renders rather than the whole UI erroring out.
-        const body = (await res.json().catch(() => ({}))) as { requestId?: string };
-        console.warn(
-          "[Atlas] Starter prompts endpoint returned",
-          res.status,
-          "requestId:",
-          body.requestId,
+        // Distinguish 4xx (actionable client error — auth, rate limit) from
+        // 5xx (transient server fault). For 5xx, soft-fail with [] so the
+        // empty state stays usable. For 4xx, throw so the embedder can see
+        // the failure in DevTools and React Query state.
+        const statusText = res.statusText || "(no status text)";
+        let bodyText: string;
+        try {
+          bodyText = await res.text();
+        } catch (err) {
+          bodyText = `<failed to read body: ${err instanceof Error ? err.message : String(err)}>`;
+        }
+        let requestId: string | undefined;
+        try {
+          requestId = (JSON.parse(bodyText) as { requestId?: string }).requestId;
+        } catch {
+          // intentionally ignored: body is not JSON (e.g. HTML proxy error page)
+        }
+        const requestIdSuffix = requestId ? ` (requestId: ${requestId})` : "";
+        if (res.status >= 500) {
+          console.warn(
+            `[Atlas] Starter prompts ${res.status} ${statusText}${requestIdSuffix}; falling back to empty list`,
+          );
+          return [];
+        }
+        throw new Error(
+          `Starter prompts ${res.status} ${statusText}${requestIdSuffix}`,
         );
-        return [];
       }
 
       const data = (await res.json()) as Partial<StarterPromptsResponse>;

--- a/packages/react/src/hooks/use-starter-prompts-query.ts
+++ b/packages/react/src/hooks/use-starter-prompts-query.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import type { StarterPrompt, StarterPromptsResponse } from "@useatlas/types/starter-prompt";
+import { useAtlasContext } from "../context";
+
+const STARTER_PROMPTS_LIMIT = 6;
+
+interface UseStarterPromptsQueryOptions {
+  /** When `true`, the query is enabled and fetches from `/api/v1/starter-prompts`. */
+  enabled: boolean;
+  /** API key for simple-key auth — sent as `Authorization: Bearer <apiKey>`. */
+  apiKey?: string;
+}
+
+/**
+ * Fetch the adaptive starter-prompt list for the widget empty state.
+ *
+ * Disabled when the host application provides a static `starterPrompts` prop —
+ * the widget must NOT identify the embedded user via this endpoint when an
+ * override is in effect, so the query is gated rather than always-fetched.
+ */
+export function useStarterPromptsQuery({ enabled, apiKey }: UseStarterPromptsQueryOptions) {
+  const { apiUrl, isCrossOrigin } = useAtlasContext();
+  const credentials: "include" | "omit" | "same-origin" = isCrossOrigin ? "include" : "same-origin";
+
+  return useQuery<StarterPrompt[]>({
+    queryKey: ["atlas", "starter-prompts", apiUrl],
+    queryFn: async ({ signal }) => {
+      const headers: Record<string, string> = {};
+      if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
+
+      let res: Response;
+      try {
+        res = await fetch(`${apiUrl}/api/v1/starter-prompts?limit=${STARTER_PROMPTS_LIMIT}`, {
+          credentials,
+          headers,
+          signal,
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn("[Atlas] Starter prompts fetch failed:", msg);
+        throw new Error(`Starter prompts fetch failed: ${msg}`, { cause: err });
+      }
+
+      if (!res.ok) {
+        // 5xx responses include a requestId for log correlation; surface it
+        // so operators can trace, then return [] so the empty state still
+        // renders rather than the whole UI erroring out.
+        const body = (await res.json().catch(() => ({}))) as { requestId?: string };
+        console.warn(
+          "[Atlas] Starter prompts endpoint returned",
+          res.status,
+          "requestId:",
+          body.requestId,
+        );
+        return [];
+      }
+
+      const data = (await res.json()) as Partial<StarterPromptsResponse>;
+      return Array.isArray(data?.prompts) ? [...data.prompts] : [];
+    },
+    enabled,
+    retry: 1,
+    staleTime: 60_000,
+  });
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -42,3 +42,12 @@ export type {
   AtlasWidgetConfig,
   AtlasWidgetCommand,
 } from "./lib/widget-types";
+
+// Starter prompt types — re-exported from @useatlas/types so embedders
+// can type the optional `starterPrompts` override prop and any
+// custom rendering they layer on top of `/api/v1/starter-prompts`.
+export type {
+  StarterPrompt,
+  StarterPromptProvenance,
+  StarterPromptsResponse,
+} from "@useatlas/types/starter-prompt";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -50,4 +50,5 @@ export type {
   StarterPrompt,
   StarterPromptProvenance,
   StarterPromptsResponse,
+  FavoriteStarterPrompt,
 } from "@useatlas/types/starter-prompt";

--- a/packages/react/src/lib/widget-types.ts
+++ b/packages/react/src/lib/widget-types.ts
@@ -107,6 +107,22 @@ export interface AtlasWidgetConfig {
    * Set to `"false"` to hide the badge. Value is case-sensitive.
    */
   showBranding?: string;
+  /**
+   * JSON-encoded array of strings to override the adaptive starter prompts (optional).
+   *
+   * When supplied, the widget renders the provided list and skips the
+   * `/api/v1/starter-prompts` request entirely. Use this for embedded
+   * placements that should never trigger a user-identifying request from
+   * the host page.
+   *
+   * Invalid JSON or non-string entries are dropped with a console warning.
+   *
+   * @example
+   * ```html
+   * <script ... data-starter-prompts='["What was last month'\''s revenue?","Top 5 customers"]'></script>
+   * ```
+   */
+  starterPrompts?: string;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1479

## Summary

Mirrors the chat empty state in the embeddable `@useatlas/react` widget so the same adaptive list renders on customer sites, and adds a `starterPrompts?: string[]` prop for plugin authors who want a hardcoded list.

The privacy-correctness guarantee of the slice: when `starterPrompts` is supplied (React prop **or** `data-starter-prompts` on the script tag), the widget **does not** call `/api/v1/starter-prompts` — overrides exist precisely so embedded contexts can avoid leaking a user-identifying request from the host page.

## Changes

- **`packages/react/src/components/atlas-chat.tsx`** — Replace hardcoded `STARTER_PROMPTS` grid with a TanStack-driven empty state. Adds `starterPrompts?: string[]` to `AtlasChatProps`. When supplied, the new `useStarterPromptsQuery` hook is `enabled: false` so no fetch is issued. Renders fetched prompts with provenance badges (Pin icon for favorites), matching the web app.
- **`packages/react/src/hooks/use-starter-prompts-query.ts`** — New TanStack hook fetching `/api/v1/starter-prompts?limit=6` with the apiKey bearer token, returning `[]` on 5xx (logs `requestId`) so the empty state degrades to the cold-start nudge.
- **`packages/react/src/components/chat/starter-prompts.ts`** — Deleted (the hardcoded `STARTER_PROMPTS` constant).
- **`packages/api/src/api/routes/widget-loader.ts`** — Loader IIFE now reads `data-starter-prompts`, parses JSON safely, drops non-string entries, and forwards as `starterPrompts` query param to the iframe URL. Invalid JSON / non-array values log a warning and the param is omitted entirely so the iframe falls back to the adaptive fetch.
- **`packages/api/src/api/routes/widget.ts`** — New `sanitizeStarterPrompts()` helper: returns `null` (sentinel for "fetch from API") on absent / malformed input, vs. a non-null array (even `[]`, the zero-prompt embed case) for "skip the fetch". Caps payload size and per-string length to bound the HTML response.
- **`packages/react/src/index.ts`** — Re-exports `StarterPrompt`, `StarterPromptProvenance`, `StarterPromptsResponse` from `@useatlas/types/starter-prompt`.
- **`packages/react/package.json`** — Bumps `@useatlas/react` from `0.0.7` → `0.0.8`. Template refs **not** bumped here per `feedback_version_bump_ordering` — they'll bump in a follow-up after the publish workflow completes.
- **`apps/docs/content/docs/guides/embedding-widget.mdx`** — New "Starter Prompts" section documenting the default adaptive behavior, the `data-starter-prompts` script attribute, and the `starterPrompts` React prop, with a callout flagging that overrides suppress the fetch.
- **`apps/docs/content/docs/reference/react.mdx`** — Adds `starterPrompts` row to the `AtlasChat` props table.

## Tests

- **`packages/react/src/components/__tests__/atlas-chat.starter-prompts.test.tsx`** — 6 unit tests: prop-less fetch path renders provenance badges, prop-supplied path makes zero starter-prompts requests (network assertion via `mock(fetch)`), empty-array override still suppresses the fetch.
- **`packages/api/src/api/__tests__/widget.test.ts`** — Adds `sanitizeStarterPrompts` exhaustive coverage (invalid JSON, non-array, dropped non-string entries, length caps) plus end-to-end assertions on the embedded `atlas-config` JSON blob.
- **`packages/api/src/api/__tests__/widget-loader.test.ts`** — Adds 6 tests covering the loader IIFE's parse / forward / warn paths.
- **`e2e/browser/widget-starter-prompts.spec.ts`** — Playwright tests asserting the iframe URL carries the `starterPrompts` param when supplied, the override path observes zero `/api/v1/starter-prompts` requests, and the no-override path observes at least one.

## Test plan

- [x] `bun run lint`
- [x] `bun run type`
- [x] `bun run test` (all packages, including `@useatlas/react` 9/9 and `@atlas/api` 232/232)
- [x] `bun x syncpack lint`
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` (passed — 409 files verified)
- [ ] Browser e2e (`e2e/browser/widget-starter-prompts.spec.ts`) — runs in CI