### PR TITLE
fix(mode): extract buildUnionStatusClause to lib/mode.ts — unbreak CI

### DIFF
--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -17,7 +17,7 @@ import { runHandler } from "@atlas/api/lib/effect/hono";
 import { checkResourceLimit } from "@atlas/api/lib/billing/enforcement";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
-import { buildUnionStatusClause } from "./middleware";
+import { buildUnionStatusClause } from "@atlas/api/lib/mode";
 
 const log = createLogger("admin-connections");
 

--- a/packages/api/src/api/routes/middleware.ts
+++ b/packages/api/src/api/routes/middleware.ts
@@ -377,25 +377,7 @@ export function parseModeFromCookie(cookieHeader: string | null): string | undef
   return undefined;
 }
 
-/**
- * Build the SQL status clause for a query over `connections` or
- * `prompt_collections`.
- *
- * - Published mode: `AND status = 'published'`
- * - Developer mode: `AND status IN ('published', 'draft')` — drafts overlay,
- *   archived rows always excluded
- *
- * Returns a leading-space string ready to concatenate into a WHERE clause.
- * Not used for `semantic_entities`; that table needs the full CTE overlay
- * (see `listEntitiesWithOverlay` in `lib/semantic/entities.ts`).
- */
-export function buildUnionStatusClause(
-  mode: import("@useatlas/types/auth").AtlasMode | undefined,
-): string {
-  return mode === "developer"
-    ? " AND status IN ('published', 'draft')"
-    : " AND status = 'published'";
-}
+export { buildUnionStatusClause } from "@atlas/api/lib/mode";
 
 /**
  * Resolve the effective atlas mode for this request.

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -22,7 +22,7 @@ import { PgClient } from "@effect/sql-pg";
 import type { Pool as PgPool } from "pg";
 import { createLogger } from "@atlas/api/lib/logger";
 import { normalizeError } from "@atlas/api/lib/effect/errors";
-import { buildUnionStatusClause } from "@atlas/api/api/routes/middleware";
+import { buildUnionStatusClause } from "@atlas/api/lib/mode";
 
 const log = createLogger("internal-db");
 

--- a/packages/api/src/lib/mode.ts
+++ b/packages/api/src/lib/mode.ts
@@ -1,0 +1,27 @@
+/**
+ * Pure helpers for the 1.2.0 developer/published mode system.
+ *
+ * Kept free of auth / logger / middleware imports so low-level modules
+ * (e.g. `lib/db/internal.ts`) can depend on mode semantics without
+ * pulling the Hono route layer into their import graph.
+ */
+
+import type { AtlasMode } from "@useatlas/types/auth";
+
+/**
+ * Build the SQL status clause for a query over `connections`,
+ * `prompt_collections`, or `query_suggestions`.
+ *
+ * - Published mode: `AND status = 'published'`
+ * - Developer mode: `AND status IN ('published', 'draft')` — drafts overlay,
+ *   archived rows always excluded
+ *
+ * Returns a leading-space string ready to concatenate into a WHERE clause.
+ * Not used for `semantic_entities`; that table needs the full CTE overlay
+ * (see `listEntitiesWithOverlay` in `lib/semantic/entities.ts`).
+ */
+export function buildUnionStatusClause(mode: AtlasMode | undefined): string {
+  return mode === "developer"
+    ? " AND status IN ('published', 'draft')"
+    : " AND status = 'published'";
+}


### PR DESCRIPTION
## Summary
- Extracts the pure `buildUnionStatusClause` helper out of `api/routes/middleware.ts` into a new pure module `packages/api/src/lib/mode.ts`.
- Unbreaks CI on main: PR #1503 (#1478) had `lib/db/internal.ts` import `buildUnionStatusClause` from the route layer, which transitively pulled the Hono auth middleware → byot → rls chain into the import graph of every module that touches `internal.ts`. That exposed three pre-existing partial `mock.module()` calls as broken.
- `middleware.ts` now re-exports the helper for existing route callers. `internal.ts` and `admin-connections.ts` import from the new pure module.

## Failing tests now green
- `src/lib/db/__tests__/auto-approve-types.test.ts`
- `src/lib/tools/__tests__/sql-org-routing.test.ts`
- `src/lib/tools/__tests__/sql-rls-settings.test.ts`

## Why extract instead of fixing the mocks
The partial mocks are a symptom. The root cause is a data-layer file (`lib/db/internal.ts`) importing from the route layer (`api/routes/middleware.ts`), which is an inverted dependency. Moving the pure helper to `lib/mode.ts` eliminates the inversion and prevents the same class of breakage from recurring.

## Test plan
- [x] `bun run test src/lib/db/__tests__/auto-approve-types.test.ts` — passes
- [x] `bun run test src/lib/tools/__tests__/sql-org-routing.test.ts` — passes
- [x] `bun run test src/lib/tools/__tests__/sql-rls-settings.test.ts` — passes
- [x] `bun run test src/api/routes/__tests__/mode-resolution.test.ts` — passes (exercises the re-export)
- [x] Full `packages/api` suite: 236/236 green
- [x] `bun run lint` — clean
- [x] `bun run type` — clean

Refs: #1478, PR #1503