### PR TITLE
docs: add route-response error codes section (#1507)

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -1238,6 +1238,7 @@ Parent: #757. Replace per-platform interaction plugins with a single `@useatlas/
 - [ ] Migrate `atlas-chat.tsx` to `useStarterPromptsQuery` + TanStack pin/unpin (#1504 — chat still uses `useEffect`+`useState` pattern; scoped as follow-up per "no behavior change in chat" in PR #1501)
 - [ ] Consolidate duplicated fetch logic between `@useatlas/react` and `packages/web` hooks (#1505 — both encode the same 5xx soft-fail / 4xx throw discipline; extract to SDK or types)
 - [ ] Migration 0030 internal header still reads `-- 0029` (#1502 — pre-existing drift from #1476 rebase; filename-based runner is unaffected)
+- [ ] Document 1.2.0 / 1.2.1 route-response error codes (#1507 — surfaced by /docs-audit; new "Route-Response Error Codes" section in `error-codes.mdx` with `demo_readonly`, `workspace_migrating`, `misdirected_request`, `duplicate_favorite`, `favorite_cap_exceeded`, `invalid_favorite_text`, plus cross-ref comment in `packages/types/src/errors.ts` pointing readers to the broader docs page when adding future non-chat codes)
 
 ---
 

--- a/apps/docs/content/docs/reference/error-codes.mdx
+++ b/apps/docs/content/docs/reference/error-codes.mdx
@@ -86,7 +86,7 @@ The `ChatErrorCode` catalog above is scoped to the chat-stream endpoint — the 
 | `invalid_favorite_text` | 400 | Favorite text is empty, too long, or otherwise malformed | Fix the client-side validation; trim whitespace and enforce length limits before POSTing | No |
 
 <Callout>
-These codes appear only on the specific endpoints listed — they won't reach the chat stream. If you're only consuming the chat API via `@useatlas/sdk`'s `query()` / `stream()` methods, you won't see them. They surface on `GET /api/v1/admin/connections`, `POST /api/v1/starter-prompts/favorites`, any write that hits the regional middleware, and other admin-scoped routes.
+These codes aren't part of the exhaustively-typed `ChatErrorCode` catalog, so the SDK's `isChatErrorCode()` / `isRetryableError()` guards return `false` / `undefined` for them. Parse the raw `error` field yourself when calling endpoints that may return them: `POST /api/v1/starter-prompts/favorites`, `/api/v1/admin/connections/*`, `/api/v1/admin/semantic/*`, and any write request that hits the regional-routing or migration middleware (including the chat stream itself for `workspace_migrating` / `misdirected_request`).
 </Callout>
 
 ---

--- a/apps/docs/content/docs/reference/error-codes.mdx
+++ b/apps/docs/content/docs/reference/error-codes.mdx
@@ -65,6 +65,32 @@ These codes are returned by billing enforcement and workspace status middleware.
 
 ---
 
+## Route-Response Error Codes
+
+The `ChatErrorCode` catalog above is scoped to the chat-stream endpoint — the agent loop enforces it exhaustively at compile time via `Record<ChatErrorCode, boolean>` in [`packages/types/src/errors.ts`](https://github.com/AtlasDevHQ/atlas/blob/main/packages/types/src/errors.ts). Admin, mode, favorites, and regional-routing endpoints return additional codes that follow the same `{ error, message, requestId }` envelope but aren't consumed by the agent's retry logic. Clients parsing responses from those endpoints should handle the codes below.
+
+### Mode & workspace state
+
+| Code | HTTP Status | Trigger | Fix | Retryable |
+|------|-------------|---------|-----|-----------|
+| `demo_readonly` | 403 | Write against the `__demo__` connection while in published mode | Switch to developer mode to manage demo content. See [Developer Mode](/guides/developer-mode) | No |
+| `workspace_migrating` | 409 | Write attempted while the workspace's data is being moved to a new region | Transient — retry once the migration completes (typically minutes). See [Data Residency](/platform-ops/data-residency) | Yes |
+| `misdirected_request` | 421 | Request reached a regional API that doesn't hold this workspace's data | Use the `correctApiUrl` field in the response body to retarget. The SDK can be initialized with the correct regional URL once and cached. See [Regional API](/platform-ops/regional-api) | No |
+
+### Starter-prompt favorites
+
+| Code | HTTP Status | Trigger | Fix | Retryable |
+|------|-------------|---------|-----|-----------|
+| `duplicate_favorite` | 409 | Pinning a prompt whose text already exists in the caller's favorites | Already pinned — no action needed | No |
+| `favorite_cap_exceeded` | 400 | User has pinned the maximum number of favorites | Unpin a prompt first, or raise `ATLAS_STARTER_PROMPT_MAX_FAVORITES` (self-hosted) | No |
+| `invalid_favorite_text` | 400 | Favorite text is empty, too long, or otherwise malformed | Fix the client-side validation; trim whitespace and enforce length limits before POSTing | No |
+
+<Callout>
+These codes appear only on the specific endpoints listed — they won't reach the chat stream. If you're only consuming the chat API via `@useatlas/sdk`'s `query()` / `stream()` methods, you won't see them. They surface on `GET /api/v1/admin/connections`, `POST /api/v1/starter-prompts/favorites`, any write that hits the regional middleware, and other admin-scoped routes.
+</Callout>
+
+---
+
 ## Client Error Codes (ClientErrorCode)
 
 These codes are detected **client-side** by the SDK and chat UI before parsing a server response. They represent network-level failures or HTTP status patterns.

--- a/packages/types/src/errors.ts
+++ b/packages/types/src/errors.ts
@@ -11,6 +11,16 @@ declare const navigator: { onLine?: boolean } | undefined;
 
 // Note: `not_available` is intentionally excluded — it is an admin/CRUD code,
 // not a chat error code. The SDK defines it separately in AtlasErrorCode.
+//
+// Scope: this catalog covers codes the chat-stream endpoint emits. Admin / mode /
+// favorites / regional-routing routes return their own codes (`demo_readonly`,
+// `workspace_migrating`, `misdirected_request`, `duplicate_favorite`,
+// `favorite_cap_exceeded`, `invalid_favorite_text`, etc.). Those are catalogued
+// in `apps/docs/content/docs/reference/error-codes.mdx` under the
+// "Route-Response Error Codes" section. When adding a non-chat error code to a
+// route, document it there rather than widening CHAT_ERROR_CODES — the
+// compile-time exhaustiveness check here exists specifically to keep the chat
+// surface tight.
 export const CHAT_ERROR_CODES = [
   "auth_error",
   "session_expired",


### PR DESCRIPTION
## Summary

Adds a **Route-Response Error Codes** section to \`apps/docs/content/docs/reference/error-codes.mdx\` documenting six codes that 1.2.0 / 1.2.1 routes return but aren't in the chat-stream \`CHAT_ERROR_CODES\` catalog:

### Mode & workspace state
- \`demo_readonly\` (403) — write against \`__demo__\` in published mode
- \`workspace_migrating\` (409) — retry after region migration
- \`misdirected_request\` (421) — client should use \`correctApiUrl\`

### Starter-prompt favorites
- \`duplicate_favorite\` (409) — prompt already pinned
- \`favorite_cap_exceeded\` (400) — unpin or raise \`ATLAS_STARTER_PROMPT_MAX_FAVORITES\`
- \`invalid_favorite_text\` (400) — trim / validate before POST

Also adds a cross-reference comment near \`CHAT_ERROR_CODES\` in \`packages/types/src/errors.ts\` directing future contributors to the broader docs page rather than widening the chat catalog.

## Why this matters

The chat error catalog is intentionally scoped — the \`Record<ChatErrorCode, boolean>\` exhaustiveness check keeps the chat surface tight. But clients calling admin / favorites / regional endpoints see additional codes that they need documented to handle correctly. Before this PR, those 6 codes surfaced in responses with no reference-page explanation.

## Test plan

- [x] \`bun run lint\` — clean
- [x] \`bun run type\` — clean
- [x] \`bun x syncpack lint\` — clean
- [x] \`SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh\` — passed (413 files)
- [x] MDX renders correctly (manual read of the new section)
- [x] No existing error codes reorganized — new section is purely additive

Closes #1507.