### PR TITLE
refactor(starter-prompts): migrate chat empty state to TanStack cache (#1504)

### DIFF
--- a/packages/web/src/ui/__tests__/starter-prompts-cache-contract.test.tsx
+++ b/packages/web/src/ui/__tests__/starter-prompts-cache-contract.test.tsx
@@ -1,0 +1,150 @@
+import { describe, expect, test, afterEach, mock } from "bun:test";
+import { render, cleanup, waitFor, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import type { StarterPrompt } from "@useatlas/types/starter-prompt";
+import { NotebookEmptyState } from "../components/notebook/notebook-empty-state";
+
+/**
+ * Cross-surface cache contract for starter prompts.
+ *
+ * AtlasChat's pin/unpin handlers mutate the TanStack cache directly via
+ * `queryClient.setQueryData(["atlas", "starter-prompts", apiUrl], ...)`
+ * instead of local component state. The notebook empty state reads the
+ * same queryKey via `useStarterPromptsQuery`, so pins made in chat must
+ * surface on the notebook without a network refetch.
+ *
+ * We simulate the pin-side mutation here (no need to mount AtlasChat's
+ * full dependency tree) and assert the notebook surface reflects the
+ * new data while fetch is only called once.
+ */
+
+const QUERY_KEY = ["atlas", "starter-prompts", ""] as const;
+
+function buildWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("starter prompts cache contract", () => {
+  afterEach(() => {
+    cleanup();
+    mock.restore();
+  });
+
+  test("setQueryData on the shared key surfaces in useStarterPromptsQuery readers without refetch", async () => {
+    const fetchCalls: string[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      fetchCalls.push(typeof input === "string" ? input : input.toString());
+      return new Response(
+        JSON.stringify({
+          prompts: [
+            { id: "library:base", text: "Library row", provenance: "library" },
+          ],
+          total: 1,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    try {
+      const client = new QueryClient({
+        defaultOptions: { queries: { retry: false, gcTime: 0 } },
+      });
+
+      const { findByText, queryByText } = render(
+        <NotebookEmptyState
+          apiUrl=""
+          isCrossOrigin={false}
+          getHeaders={() => ({})}
+          onSelectPrompt={() => {}}
+          enabled
+        />,
+        { wrapper: buildWrapper(client) },
+      );
+
+      // Initial fetch populates the cache with the library row.
+      expect(await findByText("Library row")).toBeTruthy();
+      expect(fetchCalls.length).toBe(1);
+
+      // Simulate what AtlasChat.handlePin does after a successful POST —
+      // prepend the new favorite via setQueryData on the shared key.
+      act(() => {
+        client.setQueryData<StarterPrompt[]>(QUERY_KEY, (prev) => {
+          const base = prev ?? [];
+          return [
+            { id: "favorite:new", text: "Freshly pinned", provenance: "favorite" },
+            ...base,
+          ];
+        });
+      });
+
+      // Reader reflects the mutation immediately.
+      expect(await findByText("Freshly pinned")).toBeTruthy();
+      expect(queryByText("Library row")).toBeTruthy();
+
+      // No additional fetch — proves the reader pulled from cache, not
+      // the network. A regression that drops setQueryData in favor of
+      // `invalidate + refetch` would bump this count.
+      await waitFor(() => {
+        expect(fetchCalls.length).toBe(1);
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("unpin mutation via setQueryData removes the row from other surfaces", async () => {
+    const fetchCalls: string[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      fetchCalls.push(typeof input === "string" ? input : input.toString());
+      return new Response(
+        JSON.stringify({
+          prompts: [
+            { id: "favorite:existing", text: "Already pinned", provenance: "favorite" },
+            { id: "library:base", text: "Library row", provenance: "library" },
+          ],
+          total: 2,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    try {
+      const client = new QueryClient({
+        defaultOptions: { queries: { retry: false, gcTime: 0 } },
+      });
+
+      const { findByText, queryByText } = render(
+        <NotebookEmptyState
+          apiUrl=""
+          isCrossOrigin={false}
+          getHeaders={() => ({})}
+          onSelectPrompt={() => {}}
+          enabled
+        />,
+        { wrapper: buildWrapper(client) },
+      );
+
+      expect(await findByText("Already pinned")).toBeTruthy();
+
+      // Simulate AtlasChat.handleUnpin — drop the row by id.
+      act(() => {
+        client.setQueryData<StarterPrompt[]>(QUERY_KEY, (prev) =>
+          (prev ?? []).filter((p) => p.id !== "favorite:existing"),
+        );
+      });
+
+      await waitFor(() => {
+        expect(queryByText("Already pinned")).toBeNull();
+      });
+      expect(queryByText("Library row")).toBeTruthy();
+      expect(fetchCalls.length).toBe(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -3,11 +3,13 @@
 import { useChat } from "@ai-sdk/react";
 import { isToolUIPart, getToolName } from "ai";
 import { useState, useRef, useEffect, useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import type { PythonProgressData } from "./chat/python-result-card";
 import { useAtlasConfig } from "../context";
 import { useThemeMode, setTheme, type ThemeMode } from "../hooks/use-dark-mode";
 import { useAtlasTransport } from "../hooks/use-atlas-transport";
 import { useConversations } from "../hooks/use-conversations";
+import { useStarterPromptsQuery } from "../hooks/use-starter-prompts-query";
 import { ErrorBanner } from "./chat/error-banner";
 import { ApiKeyBar } from "./chat/api-key-bar";
 import { TypingIndicator } from "./chat/typing-indicator";
@@ -26,7 +28,7 @@ import { Sun, Moon, Monitor, Star, TableProperties, BookOpen, Send, Pin } from "
 import { SchemaExplorer } from "./schema-explorer/schema-explorer";
 import { PromptLibrary } from "./chat/prompt-library";
 import { StarterPromptList } from "./chat/starter-prompt-list";
-import type { StarterPrompt, StarterPromptsResponse } from "@useatlas/types/starter-prompt";
+import type { StarterPrompt } from "@useatlas/types/starter-prompt";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -143,14 +145,10 @@ export function AtlasChat() {
   const [passwordDialogDismissed, setPasswordDialogDismissed] = useState(false);
   const [schemaExplorerOpen, setSchemaExplorerOpen] = useState(false);
   const [promptLibraryOpen, setPromptLibraryOpen] = useState(false);
-  // Adaptive empty-chat starter surface — backend composes the ranked
-  // prompt list from favorites / popular / library tiers.
-  const [starterPrompts, setStarterPrompts] = useState<StarterPrompt[]>([]);
   // Tracks the message text being pinned so the affordance disables
   // mid-flight — without this, a quick double-click fires two POSTs and
   // the second 409s after a visible success toast.
   const [pinningText, setPinningText] = useState<string | null>(null);
-  const [suggestionsLoading, setSuggestionsLoading] = useState(false);
   const [relatedSuggestions, setRelatedSuggestions] = useState<QuerySuggestion[]>([]);
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -233,45 +231,20 @@ export function AtlasChat() {
 
   const isLoading = status === "streaming" || status === "submitted";
 
-  // Fetch adaptive starter prompts for the empty state
-  useEffect(() => {
-    if (messages.length > 0) return;
-    let cancelled = false;
-    setSuggestionsLoading(true);
-    fetch(`${apiUrl}/api/v1/starter-prompts?limit=6`, {
-      credentials,
-      headers: getHeaders(),
-    })
-      .then(async (res): Promise<Partial<StarterPromptsResponse> | null> => {
-        if (res.ok) return res.json() as Promise<Partial<StarterPromptsResponse>>;
-        // Settings read failure propagates as 500 with requestId — surface
-        // the correlation id so operators can trace; the UI still falls
-        // through to the cold-start CTA rather than erroring the whole
-        // empty state.
-        const body = (await res.json().catch(() => ({}))) as { requestId?: string };
-        console.warn(
-          "starter-prompts endpoint returned",
-          res.status,
-          "requestId:",
-          body.requestId,
-        );
-        return null;
-      })
-      .then((data) => {
-        if (!cancelled && Array.isArray(data?.prompts)) {
-          setStarterPrompts([...data.prompts]);
-        }
-      })
-      .catch(() => {
-        // intentionally ignored: network/parse failures on starter prompts
-        // are non-critical — HTTP 5xx is logged above, and an empty list
-        // renders the single-CTA cold-start UI.
-      })
-      .finally(() => {
-        if (!cancelled) setSuggestionsLoading(false);
-      });
-    return () => { cancelled = true; };
-  }, [messages.length, apiUrl, credentials, getHeaders]);
+  // Adaptive empty-chat starter surface — backend composes the ranked
+  // prompt list from favorites / popular / library tiers. TanStack Query
+  // handles 4xx/5xx fallback (5xx soft-fails to []) and is shared with
+  // the notebook empty state via a stable queryKey so pins made here
+  // reflect immediately when the user navigates between surfaces.
+  const queryClient = useQueryClient();
+  const starterPromptsQueryKey = ["atlas", "starter-prompts", apiUrl] as const;
+  const starterPromptsQuery = useStarterPromptsQuery({
+    apiUrl,
+    isCrossOrigin,
+    getHeaders,
+    enabled: messages.length === 0 && authResolved,
+  });
+  const starterPrompts = starterPromptsQuery.data ?? [];
 
   // Fetch related suggestions after a completed query with SQL results
   useEffect(() => {
@@ -347,12 +320,11 @@ export function AtlasChat() {
           requestId?: string;
         };
         if (res.status === 409) {
-          // Duplicate: the pin already exists server-side, so our local
-          // `starterPrompts` is stale. Force a refetch on next empty-state
-          // entry by clearing it — the useEffect watching messages.length
-          // will repopulate.
+          // Duplicate: the pin already exists server-side, so our cache
+          // is stale. Invalidate so the next empty-state render refetches
+          // the authoritative list.
           console.warn("pin duplicate:", body.requestId);
-          setStarterPrompts([]);
+          await queryClient.invalidateQueries({ queryKey: starterPromptsQueryKey });
           setTransientWarning("Already pinned — it'll show up in a new chat.");
           setTimeout(() => setTransientWarning(""), 4000);
           return;
@@ -367,12 +339,20 @@ export function AtlasChat() {
         favorite: { id: string; text: string; position: number };
       };
       // Optimistic insert: prepend favorite at the top of the empty-state
-      // grid so the user sees it immediately without a refetch. The full
-      // refetch on next empty-state entry reconciles.
-      setStarterPrompts((prev) => [
-        { id: `favorite:${body.favorite.id}`, text: body.favorite.text, provenance: "favorite" },
-        ...prev.filter((p) => !(p.provenance === "favorite" && p.text === body.favorite.text)),
-      ]);
+      // grid so the user sees it immediately without a refetch. The next
+      // empty-state re-entry reconciles via the hook's own refetch
+      // semantics.
+      queryClient.setQueryData<StarterPrompt[]>(starterPromptsQueryKey, (prev) => {
+        const base = prev ?? [];
+        return [
+          {
+            id: `favorite:${body.favorite.id}`,
+            text: body.favorite.text,
+            provenance: "favorite",
+          },
+          ...base.filter((p) => !(p.provenance === "favorite" && p.text === body.favorite.text)),
+        ];
+      });
       setTransientWarning("Pinned as starter prompt.");
       setTimeout(() => setTransientWarning(""), 3000);
     } catch (err) {
@@ -414,7 +394,9 @@ export function AtlasChat() {
         setTimeout(() => setTransientWarning(""), 5000);
         return;
       }
-      setStarterPrompts((prev) => prev.filter((p) => p.id !== favoriteId));
+      queryClient.setQueryData<StarterPrompt[]>(starterPromptsQueryKey, (prev) =>
+        (prev ?? []).filter((p) => p.id !== favoriteId),
+      );
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.warn("unpin request failed:", msg);
@@ -609,7 +591,7 @@ export function AtlasChat() {
                         prompts={starterPrompts}
                         onSelect={handleSend}
                         onUnpin={(id) => { void handleUnpin(id); }}
-                        isLoading={suggestionsLoading}
+                        isLoading={starterPromptsQuery.isLoading}
                       />
                       <Button
                         variant="link"


### PR DESCRIPTION
## Summary

Closes #1504. Migrates `packages/web/src/ui/components/atlas-chat.tsx` off local `useState<StarterPrompt[]>` + inline `useEffect` fetch onto the shared `useStarterPromptsQuery` TanStack hook introduced in PR #1501 for the notebook empty state.

Pin/unpin handlers now mutate the TanStack cache directly via `queryClient.setQueryData` on the shared queryKey `["atlas", "starter-prompts", apiUrl]` — no more local `starterPrompts` array. The 409-duplicate path now `invalidateQueries` so the next empty-state render reconciles with the server.

## Behavior preserved
- "Pinned as starter prompt." toast on successful pin
- 409 duplicate → "Already pinned — it'll show up in a new chat." hint + cache invalidated
- Optimistic unpin filters the row immediately
- Empty-state re-entry reconciles via the hook's own staleTime/refetch semantics
- Provenance badges (Pinned / Popular / library / cold-start) render identically — no `StarterPromptList` changes

## Cross-surface cache
Because the notebook empty state already uses the same hook and queryKey, a pin in chat now surfaces in the notebook without a network refetch — the top-level `QueryProvider` in `app/layout.tsx` keeps a single `QueryClient` across routes.

Note on test scope: `e2e/browser/starter-prompts-favorites.spec.ts` exercises `/` (rendered by `app/page.tsx`, which still uses an inline fetch). A full end-to-end "pin in chat → navigate to /notebook → see pinned row without refetch" browser test will become possible once that surface is migrated too (looks like a natural #1505 follow-up). In the meantime the cross-surface contract is covered by a new unit test that drives the pin-side mutation against a shared `QueryClient` and asserts a second reader (`NotebookEmptyState`) reflects the change without an additional fetch.

## Test plan
- [x] `bun run test` — 59/59 web tests pass, all workspaces green
- [x] `bun run type` — clean
- [x] `bun run lint` — clean
- [x] `bun x syncpack lint` — no issues
- [x] `scripts/check-template-drift.sh` — 413 files verified
- [x] `scripts/check-schema-drift.sh` — 60 tables found
- [x] New: `starter-prompts-cache-contract.test.tsx` — verifies `setQueryData` on the shared key surfaces in `useStarterPromptsQuery` readers without a refetch (both pin insert + unpin filter)
- [x] Existing `notebook-empty-state.test.tsx` and `starter-prompt-list.test.tsx` still pass

## Follow-ups
- Unblocks #1505.