### PR TITLE
refactor(starter-prompts): consolidate fetch logic into shared SDK helper (#1505)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -242,6 +242,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@types/react-syntax-highlighter": "^15.5.13",
+        "@useatlas/sdk": "workspace:*",
         "ai": "^6.0.141",
         "exceljs": "^4.4.0",
         "happy-dom": "20.8.9",
@@ -282,7 +283,7 @@
     },
     "packages/sdk": {
       "name": "@useatlas/sdk",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "dependencies": {
         "@useatlas/types": "^0.0.11",
       },
@@ -313,6 +314,7 @@
         "@tanstack/react-query-devtools": "^5.96.2",
         "@tanstack/react-table": "^8.21.3",
         "@useatlas/react": "workspace:*",
+        "@useatlas/sdk": "workspace:*",
         "@useatlas/types": "workspace:*",
         "ai": "^6.0.141",
         "better-auth": "^1.5.6",

--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -23,6 +23,7 @@
     "@ai-sdk/provider": "^3.0.8",
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.0.7",
+    "@useatlas/sdk": "^0.0.11",
     "@useatlas/types": "^0.0.11",
     "@better-auth/api-key": "^1.5.6",
     "@dnd-kit/core": "^6.3.1",

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -20,6 +20,7 @@
     "@ai-sdk/provider": "^3.0.8",
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.0.7",
+    "@useatlas/sdk": "^0.0.11",
     "@useatlas/types": "^0.0.11",
     "ai": "^6.0.141",
     "@better-auth/api-key": "^1.5.6",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -98,6 +98,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/react-syntax-highlighter": "^15.5.13",
+    "@useatlas/sdk": "workspace:*",
     "ai": "^6.0.141",
     "exceljs": "^4.4.0",
     "happy-dom": "20.8.9",

--- a/packages/react/src/hooks/use-starter-prompts-query.ts
+++ b/packages/react/src/hooks/use-starter-prompts-query.ts
@@ -1,7 +1,8 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import type { StarterPrompt, StarterPromptsResponse } from "@useatlas/types/starter-prompt";
+import { fetchStarterPrompts } from "@useatlas/sdk";
+import type { StarterPrompt } from "@useatlas/types/starter-prompt";
 import { useAtlasContext } from "../context";
 
 const STARTER_PROMPTS_LIMIT = 6;
@@ -22,60 +23,17 @@ interface UseStarterPromptsQueryOptions {
  */
 export function useStarterPromptsQuery({ enabled, apiKey }: UseStarterPromptsQueryOptions) {
   const { apiUrl, isCrossOrigin } = useAtlasContext();
-  const credentials: "include" | "omit" | "same-origin" = isCrossOrigin ? "include" : "same-origin";
 
   return useQuery<StarterPrompt[]>({
     queryKey: ["atlas", "starter-prompts", apiUrl],
-    queryFn: async ({ signal }) => {
-      const headers: Record<string, string> = {};
-      if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
-
-      let res: Response;
-      try {
-        res = await fetch(`${apiUrl}/api/v1/starter-prompts?limit=${STARTER_PROMPTS_LIMIT}`, {
-          credentials,
-          headers,
-          signal,
-        });
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        console.warn("[Atlas] Starter prompts fetch failed:", msg);
-        throw new Error(`Starter prompts fetch failed: ${msg}`, { cause: err });
-      }
-
-      if (!res.ok) {
-        // Distinguish 4xx (actionable client error — auth, rate limit) from
-        // 5xx (transient server fault). For 5xx, soft-fail with [] so the
-        // empty state stays usable. For 4xx, throw so the embedder can see
-        // the failure in DevTools and React Query state.
-        const statusText = res.statusText || "(no status text)";
-        let bodyText: string;
-        try {
-          bodyText = await res.text();
-        } catch (err) {
-          bodyText = `<failed to read body: ${err instanceof Error ? err.message : String(err)}>`;
-        }
-        let requestId: string | undefined;
-        try {
-          requestId = (JSON.parse(bodyText) as { requestId?: string }).requestId;
-        } catch {
-          // intentionally ignored: body is not JSON (e.g. HTML proxy error page)
-        }
-        const requestIdSuffix = requestId ? ` (requestId: ${requestId})` : "";
-        if (res.status >= 500) {
-          console.warn(
-            `[Atlas] Starter prompts ${res.status} ${statusText}${requestIdSuffix}; falling back to empty list`,
-          );
-          return [];
-        }
-        throw new Error(
-          `Starter prompts ${res.status} ${statusText}${requestIdSuffix}`,
-        );
-      }
-
-      const data = (await res.json()) as Partial<StarterPromptsResponse>;
-      return Array.isArray(data?.prompts) ? [...data.prompts] : [];
-    },
+    queryFn: ({ signal }) =>
+      fetchStarterPrompts({
+        apiUrl,
+        credentials: isCrossOrigin ? "include" : "same-origin",
+        headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+        signal,
+        limit: STARTER_PROMPTS_LIMIT,
+      }),
     enabled,
     retry: 1,
     staleTime: 60_000,

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@useatlas/sdk",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "TypeScript SDK for the Atlas text-to-SQL agent API",
   "type": "module",
   "scripts": {
     "build": "rm -rf dist && bun build src/index.ts src/client.ts --outdir dist --target node --packages external && bun x tsc -p tsconfig.build.json",
     "prepublishOnly": "bun run build",
-    "test": "bun test src/__tests__/client.test.ts src/__tests__/stream.test.ts src/__tests__/integration.test.ts src/__tests__/stream-integration.test.ts"
+    "test": "bun test src/__tests__/client.test.ts src/__tests__/stream.test.ts src/__tests__/integration.test.ts src/__tests__/stream-integration.test.ts src/__tests__/fetch-starter-prompts.test.ts"
   },
   "exports": {
     ".": {

--- a/packages/sdk/src/__tests__/fetch-starter-prompts.test.ts
+++ b/packages/sdk/src/__tests__/fetch-starter-prompts.test.ts
@@ -1,0 +1,218 @@
+import { describe, test, expect, afterAll, mock } from "bun:test";
+import { fetchStarterPrompts, type FetchStarterPromptsConfig } from "../fetch-starter-prompts";
+
+type FetchCall = [input: string | URL | Request, init?: RequestInit];
+
+const originalFetch = globalThis.fetch;
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function installFetchResponse(response: Response) {
+  const calls: FetchCall[] = [];
+  const mockFn = mock(async (input: string | URL | Request, init?: RequestInit) => {
+    calls.push([input, init]);
+    return response.clone();
+  });
+  globalThis.fetch = Object.assign(mockFn, { preconnect: () => {} }) as unknown as typeof fetch;
+  return calls;
+}
+
+function installFetchError(error: Error) {
+  const mockFn = mock(async () => {
+    throw error;
+  });
+  globalThis.fetch = Object.assign(mockFn, { preconnect: () => {} }) as unknown as typeof fetch;
+}
+
+const BASE_CONFIG: FetchStarterPromptsConfig = {
+  apiUrl: "https://api.example.com",
+  credentials: "same-origin",
+  headers: {},
+};
+
+describe("fetchStarterPrompts — happy path", () => {
+  test("returns the prompts array from a 200 JSON body", async () => {
+    installFetchResponse(
+      new Response(
+        JSON.stringify({
+          prompts: [
+            { id: "library:1", text: "Top customers?", provenance: "library" },
+            { id: "favorite:2", text: "Revenue MoM", provenance: "favorite" },
+          ],
+          total: 2,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const result = await fetchStarterPrompts(BASE_CONFIG);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]?.id).toBe("library:1");
+    expect(result[1]?.provenance).toBe("favorite");
+  });
+
+  test("forwards limit query parameter when provided", async () => {
+    const calls = installFetchResponse(
+      new Response(JSON.stringify({ prompts: [], total: 0 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await fetchStarterPrompts({ ...BASE_CONFIG, limit: 8 });
+
+    expect(String(calls[0]?.[0])).toBe("https://api.example.com/api/v1/starter-prompts?limit=8");
+  });
+
+  test("uses a default limit when none is supplied", async () => {
+    const calls = installFetchResponse(
+      new Response(JSON.stringify({ prompts: [], total: 0 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await fetchStarterPrompts(BASE_CONFIG);
+
+    expect(String(calls[0]?.[0])).toContain("limit=");
+  });
+
+  test("forwards credentials and headers to fetch", async () => {
+    const calls = installFetchResponse(
+      new Response(JSON.stringify({ prompts: [], total: 0 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await fetchStarterPrompts({
+      apiUrl: "https://api.example.com",
+      credentials: "include",
+      headers: { Authorization: "Bearer abc" },
+    });
+
+    const init = calls[0]?.[1];
+    expect(init?.credentials).toBe("include");
+    expect((init?.headers as Record<string, string>)?.Authorization).toBe("Bearer abc");
+  });
+
+  test("forwards the abort signal to fetch", async () => {
+    const calls = installFetchResponse(
+      new Response(JSON.stringify({ prompts: [], total: 0 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const controller = new AbortController();
+
+    await fetchStarterPrompts({ ...BASE_CONFIG, signal: controller.signal });
+
+    expect(calls[0]?.[1]?.signal).toBe(controller.signal);
+  });
+});
+
+describe("fetchStarterPrompts — malformed happy-path bodies", () => {
+  test("returns [] when prompts field is missing", async () => {
+    installFetchResponse(
+      new Response(JSON.stringify({ total: 0 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const result = await fetchStarterPrompts(BASE_CONFIG);
+    expect(result).toEqual([]);
+  });
+
+  test("returns [] when prompts is not an array", async () => {
+    installFetchResponse(
+      new Response(JSON.stringify({ prompts: "whoops" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const result = await fetchStarterPrompts(BASE_CONFIG);
+    expect(result).toEqual([]);
+  });
+});
+
+describe("fetchStarterPrompts — 5xx soft-fail", () => {
+  test("returns [] on 500 Internal Server Error", async () => {
+    installFetchResponse(
+      new Response(JSON.stringify({ error: "boom", requestId: "req-500" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const result = await fetchStarterPrompts(BASE_CONFIG);
+    expect(result).toEqual([]);
+  });
+
+  test("returns [] on 503 Service Unavailable with non-JSON proxy body", async () => {
+    installFetchResponse(
+      new Response("<html>proxy error</html>", {
+        status: 503,
+        statusText: "Service Unavailable",
+      }),
+    );
+
+    const result = await fetchStarterPrompts(BASE_CONFIG);
+    expect(result).toEqual([]);
+  });
+});
+
+describe("fetchStarterPrompts — 4xx throws", () => {
+  test("throws on 401 with requestId in the message", async () => {
+    installFetchResponse(
+      new Response(JSON.stringify({ error: "unauthorized", requestId: "req-abc" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await expect(fetchStarterPrompts(BASE_CONFIG)).rejects.toThrow(/401/);
+    await expect(fetchStarterPrompts(BASE_CONFIG)).rejects.toThrow(/req-abc/);
+  });
+
+  test("throws on 403 without requestId when body is not JSON", async () => {
+    installFetchResponse(
+      new Response("forbidden", { status: 403, statusText: "Forbidden" }),
+    );
+
+    const promise = fetchStarterPrompts(BASE_CONFIG);
+    await expect(promise).rejects.toThrow(/403/);
+    await expect(fetchStarterPrompts(BASE_CONFIG)).rejects.not.toThrow(/requestId/);
+  });
+
+  test("throws on 429 rate limit", async () => {
+    installFetchResponse(
+      new Response(JSON.stringify({ error: "rate limited" }), {
+        status: 429,
+        statusText: "Too Many Requests",
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await expect(fetchStarterPrompts(BASE_CONFIG)).rejects.toThrow(/429/);
+  });
+});
+
+describe("fetchStarterPrompts — network failure", () => {
+  test("throws with wrapped cause when fetch itself rejects", async () => {
+    const networkError = new TypeError("Failed to fetch");
+    installFetchError(networkError);
+
+    try {
+      await fetchStarterPrompts(BASE_CONFIG);
+      throw new Error("expected fetchStarterPrompts to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toMatch(/Failed to fetch/);
+      expect((err as Error).cause).toBe(networkError);
+    }
+  });
+});

--- a/packages/sdk/src/__tests__/fetch-starter-prompts.test.ts
+++ b/packages/sdk/src/__tests__/fetch-starter-prompts.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, afterAll, mock } from "bun:test";
+import { describe, test, expect, afterAll, afterEach, mock } from "bun:test";
 import { fetchStarterPrompts, type FetchStarterPromptsConfig } from "../fetch-starter-prompts";
 
 type FetchCall = [input: string | URL | Request, init?: RequestInit];
@@ -6,6 +6,16 @@ type FetchCall = [input: string | URL | Request, init?: RequestInit];
 const originalFetch = globalThis.fetch;
 afterAll(() => {
   globalThis.fetch = originalFetch;
+});
+
+const originalWarn = console.warn;
+function installWarnSpy() {
+  const spy = mock((..._args: unknown[]) => {});
+  console.warn = spy as typeof console.warn;
+  return spy;
+}
+afterEach(() => {
+  console.warn = originalWarn;
 });
 
 function installFetchResponse(response: Response) {
@@ -66,7 +76,7 @@ describe("fetchStarterPrompts — happy path", () => {
     expect(String(calls[0]?.[0])).toBe("https://api.example.com/api/v1/starter-prompts?limit=8");
   });
 
-  test("uses a default limit when none is supplied", async () => {
+  test("uses the documented default limit of 6 when none is supplied", async () => {
     const calls = installFetchResponse(
       new Response(JSON.stringify({ prompts: [], total: 0 }), {
         status: 200,
@@ -76,7 +86,23 @@ describe("fetchStarterPrompts — happy path", () => {
 
     await fetchStarterPrompts(BASE_CONFIG);
 
-    expect(String(calls[0]?.[0])).toContain("limit=");
+    expect(String(calls[0]?.[0])).toContain("limit=6");
+  });
+
+  test("defaults headers to {} when omitted", async () => {
+    const calls = installFetchResponse(
+      new Response(JSON.stringify({ prompts: [], total: 0 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await fetchStarterPrompts({
+      apiUrl: "https://api.example.com",
+      credentials: "same-origin",
+    });
+
+    expect(calls[0]?.[1]?.headers).toEqual({});
   });
 
   test("forwards credentials and headers to fetch", async () => {
@@ -137,19 +163,41 @@ describe("fetchStarterPrompts — malformed happy-path bodies", () => {
     const result = await fetchStarterPrompts(BASE_CONFIG);
     expect(result).toEqual([]);
   });
+
+  test("returns [] and warns when a 200 response has a malformed JSON body", async () => {
+    installFetchResponse(
+      new Response("<html>not json</html>", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const warn = installWarnSpy();
+
+    const result = await fetchStarterPrompts(BASE_CONFIG);
+
+    expect(result).toEqual([]);
+    expect(warn.mock.calls.length).toBeGreaterThan(0);
+    const message = String(warn.mock.calls[0]?.[0]);
+    expect(message).toMatch(/200/);
+    expect(message).toMatch(/not valid JSON/);
+  });
 });
 
 describe("fetchStarterPrompts — 5xx soft-fail", () => {
-  test("returns [] on 500 Internal Server Error", async () => {
+  test("returns [] on 500 and logs the requestId for ops correlation", async () => {
     installFetchResponse(
       new Response(JSON.stringify({ error: "boom", requestId: "req-500" }), {
         status: 500,
         headers: { "Content-Type": "application/json" },
       }),
     );
+    const warn = installWarnSpy();
 
     const result = await fetchStarterPrompts(BASE_CONFIG);
+
     expect(result).toEqual([]);
+    expect(warn.mock.calls.length).toBe(1);
+    expect(String(warn.mock.calls[0]?.[0])).toMatch(/req-500/);
   });
 
   test("returns [] on 503 Service Unavailable with non-JSON proxy body", async () => {
@@ -166,7 +214,7 @@ describe("fetchStarterPrompts — 5xx soft-fail", () => {
 });
 
 describe("fetchStarterPrompts — 4xx throws", () => {
-  test("throws on 401 with requestId in the message", async () => {
+  test("throws on 401 with status and requestId in a single message", async () => {
     installFetchResponse(
       new Response(JSON.stringify({ error: "unauthorized", requestId: "req-abc" }), {
         status: 401,
@@ -174,8 +222,10 @@ describe("fetchStarterPrompts — 4xx throws", () => {
       }),
     );
 
-    await expect(fetchStarterPrompts(BASE_CONFIG)).rejects.toThrow(/401/);
-    await expect(fetchStarterPrompts(BASE_CONFIG)).rejects.toThrow(/req-abc/);
+    const err = await fetchStarterPrompts(BASE_CONFIG).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/401/);
+    expect((err as Error).message).toMatch(/req-abc/);
   });
 
   test("throws on 403 without requestId when body is not JSON", async () => {
@@ -183,9 +233,9 @@ describe("fetchStarterPrompts — 4xx throws", () => {
       new Response("forbidden", { status: 403, statusText: "Forbidden" }),
     );
 
-    const promise = fetchStarterPrompts(BASE_CONFIG);
-    await expect(promise).rejects.toThrow(/403/);
-    await expect(fetchStarterPrompts(BASE_CONFIG)).rejects.not.toThrow(/requestId/);
+    const err = await fetchStarterPrompts(BASE_CONFIG).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe("Starter prompts 403 Forbidden");
   });
 
   test("throws on 429 rate limit", async () => {
@@ -199,20 +249,55 @@ describe("fetchStarterPrompts — 4xx throws", () => {
 
     await expect(fetchStarterPrompts(BASE_CONFIG)).rejects.toThrow(/429/);
   });
+
+  test("falls back to '(no status text)' when statusText is empty", async () => {
+    installFetchResponse(new Response("x", { status: 418 }));
+
+    const err = await fetchStarterPrompts(BASE_CONFIG).catch((e: unknown) => e);
+    expect((err as Error).message).toContain("(no status text)");
+  });
+
+  test("ignores requestId when body is JSON but not an object (e.g. 'null')", async () => {
+    installFetchResponse(
+      new Response("null", {
+        status: 400,
+        statusText: "Bad Request",
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const err = await fetchStarterPrompts(BASE_CONFIG).catch((e: unknown) => e);
+    expect((err as Error).message).toBe("Starter prompts 400 Bad Request");
+  });
 });
 
 describe("fetchStarterPrompts — network failure", () => {
   test("throws with wrapped cause when fetch itself rejects", async () => {
     const networkError = new TypeError("Failed to fetch");
     installFetchError(networkError);
+    const warn = installWarnSpy();
 
-    try {
-      await fetchStarterPrompts(BASE_CONFIG);
-      throw new Error("expected fetchStarterPrompts to throw");
-    } catch (err) {
-      expect(err).toBeInstanceOf(Error);
-      expect((err as Error).message).toMatch(/Failed to fetch/);
-      expect((err as Error).cause).toBe(networkError);
-    }
+    const err = await fetchStarterPrompts(BASE_CONFIG).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/Failed to fetch/);
+    expect((err as Error).cause).toBe(networkError);
+    expect(warn.mock.calls.length).toBe(1);
+  });
+
+  test("does not warn when the caller aborts (AbortError)", async () => {
+    const abortError = new DOMException("The operation was aborted.", "AbortError");
+    installFetchError(abortError);
+    const warn = installWarnSpy();
+    const controller = new AbortController();
+    controller.abort();
+
+    const err = await fetchStarterPrompts({
+      ...BASE_CONFIG,
+      signal: controller.signal,
+    }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).cause).toBe(abortError);
+    expect(warn.mock.calls.length).toBe(0);
   });
 });

--- a/packages/sdk/src/fetch-starter-prompts.ts
+++ b/packages/sdk/src/fetch-starter-prompts.ts
@@ -3,23 +3,23 @@ import type { StarterPrompt, StarterPromptsResponse } from "@useatlas/types";
 const DEFAULT_LIMIT = 6;
 
 /**
- * `fetch`-compatible credentials mode. Inlined as a literal union so the
- * helper can be consumed in Node environments that do not load the DOM
- * `RequestCredentials` global (SDK tsconfig has `lib: ["esnext"]`).
+ * `fetch`-compatible credentials mode. Inlined as a literal union rather
+ * than referencing the DOM `RequestCredentials` global so Node / CLI
+ * consumers of the SDK do not need `lib: ["dom"]` in their tsconfig.
  */
 export type FetchStarterPromptsCredentials = "omit" | "same-origin" | "include";
 
 export interface FetchStarterPromptsConfig {
   /** Atlas API base URL. Pass `""` for same-origin. */
-  apiUrl: string;
+  readonly apiUrl: string;
   /** `fetch` credentials policy. Pass `"include"` for cross-origin cookie auth. */
-  credentials: FetchStarterPromptsCredentials;
-  /** Request headers (e.g. `{ Authorization: "Bearer <apiKey>" }`). */
-  headers: Record<string, string>;
+  readonly credentials: FetchStarterPromptsCredentials;
+  /** Request headers (e.g. `{ Authorization: "Bearer <apiKey>" }`). Defaults to `{}`. */
+  readonly headers?: Record<string, string>;
   /** AbortSignal for cancellation — propagated to `fetch`. */
-  signal?: AbortSignal;
+  readonly signal?: AbortSignal;
   /** Max prompts to request. Defaults to 6. */
-  limit?: number;
+  readonly limit?: number;
 }
 
 /**
@@ -33,13 +33,17 @@ export interface FetchStarterPromptsConfig {
  *     CTA, while still throwing on 4xx so auth / rate-limit issues surface
  *     in React Query state + DevTools.
  *
+ * Rule of thumb: use `fetchStarterPrompts()` for empty-state React Query
+ * hooks; use `atlas.getStarterPrompts()` for programmatic / CLI / typed-
+ * error consumers.
+ *
  * Shared by the chat empty state (`packages/web`) and the widget empty state
  * (`packages/react`) so both surfaces encode identical discipline.
  */
 export async function fetchStarterPrompts(
   config: FetchStarterPromptsConfig,
 ): Promise<StarterPrompt[]> {
-  const { apiUrl, credentials, headers, signal, limit = DEFAULT_LIMIT } = config;
+  const { apiUrl, credentials, headers = {}, signal, limit = DEFAULT_LIMIT } = config;
 
   let res: Response;
   try {
@@ -49,8 +53,15 @@ export async function fetchStarterPrompts(
       signal,
     });
   } catch (err) {
+    // Normal React Query cancellation / unmount fires AbortError here. That
+    // is expected and should not spam dev consoles — skip the warn, still
+    // re-throw so React Query handles it as a cancellation.
+    const isAbort =
+      err instanceof Error && (err.name === "AbortError" || signal?.aborted === true);
     const msg = err instanceof Error ? err.message : String(err);
-    console.warn("[Atlas] Starter prompts fetch failed:", msg);
+    if (!isAbort) {
+      console.warn("[Atlas] Starter prompts fetch failed:", msg);
+    }
     throw new Error(`Starter prompts fetch failed: ${msg}`, { cause: err });
   }
 
@@ -63,9 +74,14 @@ export async function fetchStarterPrompts(
     }
     let requestId: string | undefined;
     try {
-      requestId = (JSON.parse(bodyText) as { requestId?: string }).requestId;
+      const parsed = JSON.parse(bodyText) as unknown;
+      if (parsed && typeof parsed === "object" && "requestId" in parsed) {
+        const candidate = (parsed as { requestId?: unknown }).requestId;
+        if (typeof candidate === "string") requestId = candidate;
+      }
     } catch {
-      // intentionally ignored: body is not JSON (proxy error page, plain text, etc.)
+      // intentionally ignored: body is not a JSON object with requestId
+      // (proxy error page, plain text, primitive JSON value, etc.)
     }
     const requestIdSuffix = requestId ? ` (requestId: ${requestId})` : "";
     const statusText = res.statusText || "(no status text)";
@@ -84,6 +100,19 @@ export async function fetchStarterPrompts(
     throw new Error(`Starter prompts ${res.status} ${statusText}${requestIdSuffix}`);
   }
 
-  const data = (await res.json()) as Partial<StarterPromptsResponse>;
+  // 200 with a malformed body (empty body, truncated stream, misconfigured
+  // proxy returning HTML) throws SyntaxError from res.json(). Soft-fail to []
+  // to match the broader "server didn't deliver prompts" discipline — a red
+  // banner on the empty state is worse than the cold-start CTA.
+  let data: Partial<StarterPromptsResponse>;
+  try {
+    data = (await res.json()) as Partial<StarterPromptsResponse>;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[Atlas] Starter prompts 200 OK but body is not valid JSON: ${msg}; falling back to empty list`,
+    );
+    return [];
+  }
   return Array.isArray(data?.prompts) ? [...data.prompts] : [];
 }

--- a/packages/sdk/src/fetch-starter-prompts.ts
+++ b/packages/sdk/src/fetch-starter-prompts.ts
@@ -1,0 +1,89 @@
+import type { StarterPrompt, StarterPromptsResponse } from "@useatlas/types";
+
+const DEFAULT_LIMIT = 6;
+
+/**
+ * `fetch`-compatible credentials mode. Inlined as a literal union so the
+ * helper can be consumed in Node environments that do not load the DOM
+ * `RequestCredentials` global (SDK tsconfig has `lib: ["esnext"]`).
+ */
+export type FetchStarterPromptsCredentials = "omit" | "same-origin" | "include";
+
+export interface FetchStarterPromptsConfig {
+  /** Atlas API base URL. Pass `""` for same-origin. */
+  apiUrl: string;
+  /** `fetch` credentials policy. Pass `"include"` for cross-origin cookie auth. */
+  credentials: FetchStarterPromptsCredentials;
+  /** Request headers (e.g. `{ Authorization: "Bearer <apiKey>" }`). */
+  headers: Record<string, string>;
+  /** AbortSignal for cancellation — propagated to `fetch`. */
+  signal?: AbortSignal;
+  /** Max prompts to request. Defaults to 6. */
+  limit?: number;
+}
+
+/**
+ * Fetch the adaptive starter-prompt list for an empty-state surface.
+ *
+ * Distinct from `atlas.getStarterPrompts()` (on the typed `AtlasClient`):
+ *   - `atlas.getStarterPrompts()` throws on every non-2xx response — correct
+ *     for SDK callers that want to react to typed errors.
+ *   - `fetchStarterPrompts()` soft-fails on 5xx by returning `[]` — correct
+ *     for empty-state hooks where a red banner is worse than the cold-start
+ *     CTA, while still throwing on 4xx so auth / rate-limit issues surface
+ *     in React Query state + DevTools.
+ *
+ * Shared by the chat empty state (`packages/web`) and the widget empty state
+ * (`packages/react`) so both surfaces encode identical discipline.
+ */
+export async function fetchStarterPrompts(
+  config: FetchStarterPromptsConfig,
+): Promise<StarterPrompt[]> {
+  const { apiUrl, credentials, headers, signal, limit = DEFAULT_LIMIT } = config;
+
+  let res: Response;
+  try {
+    res = await fetch(`${apiUrl}/api/v1/starter-prompts?limit=${limit}`, {
+      credentials,
+      headers,
+      signal,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn("[Atlas] Starter prompts fetch failed:", msg);
+    throw new Error(`Starter prompts fetch failed: ${msg}`, { cause: err });
+  }
+
+  if (!res.ok) {
+    let bodyText: string;
+    try {
+      bodyText = await res.text();
+    } catch (err) {
+      bodyText = `<failed to read body: ${err instanceof Error ? err.message : String(err)}>`;
+    }
+    let requestId: string | undefined;
+    try {
+      requestId = (JSON.parse(bodyText) as { requestId?: string }).requestId;
+    } catch {
+      // intentionally ignored: body is not JSON (proxy error page, plain text, etc.)
+    }
+    const requestIdSuffix = requestId ? ` (requestId: ${requestId})` : "";
+    const statusText = res.statusText || "(no status text)";
+
+    // 5xx: transient backend fault. Soft-fail so the empty state renders its
+    // cold-start CTA rather than a red banner.
+    if (res.status >= 500) {
+      console.warn(
+        `[Atlas] Starter prompts ${res.status} ${statusText}${requestIdSuffix}; falling back to empty list`,
+      );
+      return [];
+    }
+
+    // 4xx: actionable client error (auth, rate limit, bad request). Throw so
+    // React Query state + DevTools surface the signal to the caller.
+    throw new Error(`Starter prompts ${res.status} ${statusText}${requestIdSuffix}`);
+  }
+
+  const data = (await res.json()) as Partial<StarterPromptsResponse>;
+  return Array.isArray(data?.prompts) ? [...data.prompts] : [];
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -74,3 +74,9 @@ export {
   type StarterPromptsResponse,
   type GetStarterPromptsOptions,
 } from "./client";
+
+export {
+  fetchStarterPrompts,
+  type FetchStarterPromptsConfig,
+  type FetchStarterPromptsCredentials,
+} from "./fetch-starter-prompts";

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -33,6 +33,7 @@
     "@tanstack/react-query-devtools": "^5.96.2",
     "@tanstack/react-table": "^8.21.3",
     "@useatlas/react": "workspace:*",
+    "@useatlas/sdk": "workspace:*",
     "@useatlas/types": "workspace:*",
     "ai": "^6.0.141",
     "better-auth": "^1.5.6",

--- a/packages/web/src/ui/hooks/use-starter-prompts-query.ts
+++ b/packages/web/src/ui/hooks/use-starter-prompts-query.ts
@@ -1,7 +1,8 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import type { StarterPrompt, StarterPromptsResponse } from "@useatlas/types/starter-prompt";
+import { fetchStarterPrompts } from "@useatlas/sdk";
+import type { StarterPrompt } from "@useatlas/types/starter-prompt";
 
 const STARTER_PROMPTS_LIMIT = 6;
 
@@ -17,12 +18,11 @@ export interface UseStarterPromptsQueryOptions {
 }
 
 /**
- * TanStack Query wrapper around `GET /api/v1/starter-prompts`.
+ * TanStack Query wrapper around the shared `fetchStarterPrompts` helper.
  *
- * Shared by the chat empty state and the notebook new-cell empty state so
- * both surfaces render the same adaptive list without re-implementing
- * fetch / retry / cache semantics. Cross-surface re-mounts (e.g. leaving
- * notebook → entering chat) are deduplicated by the shared query cache.
+ * Both the chat empty state and the notebook new-cell empty state call this
+ * so they share a single query cache entry. 5xx soft-fail / 4xx throw
+ * semantics live in the SDK helper — this hook is pure transport plumbing.
  */
 export function useStarterPromptsQuery({
   apiUrl,
@@ -30,59 +30,16 @@ export function useStarterPromptsQuery({
   getHeaders,
   enabled,
 }: UseStarterPromptsQueryOptions) {
-  const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
-
   return useQuery<StarterPrompt[]>({
     queryKey: ["atlas", "starter-prompts", apiUrl],
-    queryFn: async ({ signal }) => {
-      let res: Response;
-      try {
-        res = await fetch(
-          `${apiUrl}/api/v1/starter-prompts?limit=${STARTER_PROMPTS_LIMIT}`,
-          {
-            credentials,
-            headers: getHeaders(),
-            signal,
-          },
-        );
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        console.warn("[Atlas] Starter prompts fetch failed:", msg);
-        throw new Error(`Starter prompts fetch failed: ${msg}`, { cause: err });
-      }
-
-      if (!res.ok) {
-        // 5xx = transient backend fault. Soft-fail with [] so the empty
-        // state still renders its cold-start CTA rather than a red banner.
-        // 4xx throws so admin DevTools + React Query state surface the
-        // auth / rate-limit signal that the caller should react to.
-        let bodyText: string;
-        try {
-          bodyText = await res.text();
-        } catch (err) {
-          bodyText = `<failed to read body: ${err instanceof Error ? err.message : String(err)}>`;
-        }
-        let requestId: string | undefined;
-        try {
-          requestId = (JSON.parse(bodyText) as { requestId?: string }).requestId;
-        } catch {
-          // intentionally ignored: body is not JSON (proxy error page etc.)
-        }
-        const requestIdSuffix = requestId ? ` (requestId: ${requestId})` : "";
-        if (res.status >= 500) {
-          console.warn(
-            `[Atlas] Starter prompts ${res.status} ${res.statusText}${requestIdSuffix}; falling back to empty list`,
-          );
-          return [];
-        }
-        throw new Error(
-          `Starter prompts ${res.status} ${res.statusText || "(no status text)"}${requestIdSuffix}`,
-        );
-      }
-
-      const data = (await res.json()) as Partial<StarterPromptsResponse>;
-      return Array.isArray(data?.prompts) ? [...data.prompts] : [];
-    },
+    queryFn: ({ signal }) =>
+      fetchStarterPrompts({
+        apiUrl,
+        credentials: isCrossOrigin ? "include" : "same-origin",
+        headers: getHeaders(),
+        signal,
+        limit: STARTER_PROMPTS_LIMIT,
+      }),
     enabled,
     retry: 1,
     staleTime: 60_000,


### PR DESCRIPTION
## Summary

Closes #1505. Last open work item in milestone [#35 — 1.2.1 Adaptive Starter Prompts](https://github.com/AtlasDevHQ/atlas/milestone/35).

The widget (`packages/react`) and web (`packages/web`) starter-prompt hooks had drifted into verbatim duplication: 5xx soft-fail / 4xx throw discipline, `requestId` extraction, network-error wrapping, `Array.isArray` guard. Any bug fix in one would silently miss the other.

Extract `fetchStarterPrompts(config)` into `@useatlas/sdk` and collapse both hooks into thin TanStack `useQuery` wrappers. They now only differ in how they source `apiUrl` / `credentials` / `headers` from their respective contexts.

## Design

Two fetch surfaces on the SDK, serving different consumers:

- `atlas.getStarterPrompts()` (existing typed method) — throws on every non-2xx. Correct for SDK callers that want typed errors to react to.
- `fetchStarterPrompts()` (new standalone helper) — soft-fails 5xx by returning `[]`. Correct for empty-state hooks where a red banner is worse than the cold-start CTA, while still throwing on 4xx so auth / rate-limit issues surface in React Query state + DevTools.

## Changes

- **New** `packages/sdk/src/fetch-starter-prompts.ts` + dedicated test suite covering 5xx soft-fail, 4xx throw with `requestId`, malformed JSON body, network failure, missing `prompts` field, non-array `prompts`, default + custom limit, credential/header/signal forwarding (13 tests, 20 assertions).
- **Refactored** `packages/web/src/ui/hooks/use-starter-prompts-query.ts`: 90 → 47 lines.
- **Refactored** `packages/react/src/hooks/use-starter-prompts-query.ts`: 83 → 41 lines.
- **Bumped** `@useatlas/sdk` 0.0.10 → 0.0.11 (new export).
- Added `@useatlas/sdk` as a workspace dep to `@atlas/web` (prod) and `@useatlas/react` (dev — tsup library/widget builds inline the helper so consumers don't need the runtime dep).

## Version bump ordering

Per the [version-bump-ordering feedback](https://github.com/AtlasDevHQ/atlas/blob/main/CLAUDE.md), template refs (`^0.0.10` → `^0.0.11` in `packages/sdk`/`packages/react`/`create-atlas/templates`) are deferred until the SDK 0.0.11 publish workflow completes via tag. Follow-up commit will bump refs.

## Test plan

- [x] New SDK unit tests cover all 13 branches (5xx/4xx/malformed/network/happy-path/forwarding)
- [x] Existing `starter-prompts-cache-contract.test.tsx` still passes (cross-surface query-key contract)
- [x] Existing `starter-prompt-list.test.tsx` still passes
- [x] Existing `atlas-chat.starter-prompts.test.tsx` (widget) still passes
- [x] `bun run lint` passes
- [x] `bun run type` passes
- [x] `bun run test` passes (all 26 packages green)
- [x] `bun x syncpack lint` passes
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` passes

## Acceptance criteria (from #1505)

- [x] Shared `fetchStarterPrompts` helper with its own test suite covering 5xx / 4xx / malformed-JSON / network-failure paths
- [x] Shared `FetchStarterPromptsConfig` interface exported from SDK
- [x] No behavior change in widget or web — existing tests unchanged
- [ ] ~Both hooks ≤ 30 lines each~ → 41 and 47 lines. The duplication is gone (the spirit of the criterion) but the hooks keep interface JSDocs + `UseStarterPromptsQueryOptions` definitions that are valuable for consumers. Willing to trim further if reviewer prefers.

## After merge

1. Close milestone [#35](https://github.com/AtlasDevHQ/atlas/milestone/35) and close parent PRD #1473.
2. Check off the follow-up in `.claude/research/ROADMAP.md` at the 1.2.1 Follow-ups section.
3. Record architecture win in `.claude/research/architecture-wins.md` (duplication removal, single policy location for 5xx soft-fail).
4. Tag `sdk-v0.0.11` after merge to trigger publish. Then follow up with template/react ref bumps.