### PR TITLE
fix: replace console usage with Pino logger in server code (#1512, #1513)

### DIFF
--- a/packages/api/src/api/__tests__/widget.test.ts
+++ b/packages/api/src/api/__tests__/widget.test.ts
@@ -12,7 +12,7 @@
  * require a prior `bun run build` in packages/react/.
  */
 
-import { describe, it, expect, mock, beforeAll, afterAll, beforeEach } from "bun:test";
+import { describe, it, expect, mock, beforeEach } from "bun:test";
 import { Hono } from "hono";
 import * as realFs from "node:fs";
 
@@ -30,6 +30,35 @@ const mockedFs = {
   },
 };
 mock.module("node:fs", () => ({ ...mockedFs, default: mockedFs }));
+
+// Capture Pino warn calls from the widget module for observability tests.
+const capturedWarnings: string[] = [];
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: () => {},
+    warn: (...args: unknown[]) => {
+      capturedWarnings.push(
+        args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" "),
+      );
+    },
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+  }),
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+  }),
+  withRequestContext: <T>(_ctx: unknown, fn: () => T) => fn(),
+  getRequestContext: () => undefined,
+  redactPaths: [],
+  setLogLevel: () => true,
+}));
 
 const { widget, sanitizeLogoUrl, sanitizeAccent, sanitizeStarterPrompts } = await import(
   "../routes/widget"
@@ -883,40 +912,31 @@ describe("sanitizeStarterPrompts", () => {
 });
 
 describe("sanitizeStarterPrompts — observability", () => {
-  // Suppress console noise from intentional log paths under test.
-  const originalWarn = console.warn;
-  const captured: string[] = [];
-  beforeAll(() => {
-    console.warn = (...args: unknown[]) => {
-      captured.push(args.map((a) => (typeof a === "string" ? a : String(a))).join(" "));
-    };
-  });
-  afterAll(() => {
-    console.warn = originalWarn;
-  });
+  // Uses the module-scoped capturedWarnings array populated by the mocked
+  // Pino logger at the top of this file. See that mock for wiring details.
   beforeEach(() => {
-    captured.length = 0;
+    capturedWarnings.length = 0;
   });
 
   it("logs a warning when raw input exceeds 8KB", () => {
     const giant = "x".repeat(9 * 1024);
     sanitizeStarterPrompts(JSON.stringify([giant]));
-    expect(captured.some((m) => m.includes("exceeds 8KB"))).toBe(true);
+    expect(capturedWarnings.some((m) => m.includes("exceeds 8KB"))).toBe(true);
   });
 
   it("logs a warning when JSON is malformed", () => {
     sanitizeStarterPrompts("not-json-at-all");
-    expect(captured.some((m) => m.includes("not valid JSON"))).toBe(true);
+    expect(capturedWarnings.some((m) => m.includes("not valid JSON"))).toBe(true);
   });
 
   it("logs a warning when JSON is a non-array value", () => {
     sanitizeStarterPrompts('{"prompts":["x"]}');
-    expect(captured.some((m) => m.includes("non-array"))).toBe(true);
+    expect(capturedWarnings.some((m) => m.includes("non-array"))).toBe(true);
   });
 
   it("does NOT log when the input is absent (no override is the default)", () => {
     sanitizeStarterPrompts("");
-    expect(captured).toHaveLength(0);
+    expect(capturedWarnings).toHaveLength(0);
   });
 });
 

--- a/packages/api/src/api/routes/widget.ts
+++ b/packages/api/src/api/routes/widget.ts
@@ -168,8 +168,9 @@ function sanitizeStarterPrompts(raw: string): StarterPromptsOverride {
   // embedder / open-redirect chain. ~32 prompts × 200 chars ≈ 6.4KB upper
   // bound; the per-string slice below enforces the rest.
   if (raw.length > 8 * 1024) {
-    console.warn(
-      `[Atlas] starterPrompts query param exceeds 8KB (${raw.length} bytes); dropping override — widget will fetch the adaptive list instead`,
+    log.warn(
+      { bytes: raw.length, limit: 8 * 1024 },
+      "starterPrompts query param exceeds 8KB; dropping override — widget will fetch the adaptive list instead",
     );
     return null;
   }
@@ -177,15 +178,15 @@ function sanitizeStarterPrompts(raw: string): StarterPromptsOverride {
   try {
     parsed = JSON.parse(raw);
   } catch (err) {
-    console.warn(
-      "[Atlas] starterPrompts query param is not valid JSON; dropping override:",
-      err instanceof Error ? err.message : String(err),
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "starterPrompts query param is not valid JSON; dropping override",
     );
     return null;
   }
   if (!Array.isArray(parsed)) {
-    console.warn(
-      "[Atlas] starterPrompts query param parsed to non-array; expected JSON array of strings",
+    log.warn(
+      "starterPrompts query param parsed to non-array; expected JSON array of strings",
     );
     return null;
   }

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -488,8 +488,12 @@ function isSaasMode(): boolean {
     const { getConfig } = require("@atlas/api/lib/config") as { getConfig: () => { deployMode?: string } | null };
     return getConfig()?.deployMode === "saas";
   } catch (err) {
-    // intentionally ignored: config module may not be ready during early module init
-    console.debug("isSaasMode: config not yet available:", err instanceof Error ? err.message : String(err));
+    // Config module may not be ready during early module init — that's expected.
+    // Log at debug so it's quiet in normal operation but visible when diagnosing.
+    log.debug(
+      { err: err instanceof Error ? err.message : String(err) },
+      "isSaasMode: config not yet available; treating as non-SaaS",
+    );
     return false;
   }
 }


### PR DESCRIPTION
Closes #1512. Closes #1513.

Both issues surfaced during the post-1.2.1 /health-check audit: CLAUDE.md rule D2 requires non-test code in \`packages/api/src/\` to use the Pino logger, not raw console.

## Changes

- **\`packages/api/src/api/routes/widget.ts\`** — three \`console.warn\` calls in \`sanitizeStarterPrompts()\` (lines 171, 180, 187) run on the server when the widget HTML is rendered. Switched to structured \`log.warn\` using the existing module-scoped logger. Introduced in #1498 (1.2.1 widget empty state).
- **\`packages/api/src/lib/settings.ts\`** — \`console.debug\` in \`isSaasMode()\` fallback (line 492). Switched to \`log.debug\` using the existing module-scoped logger. Kept the \"config may not be ready during early init\" rationale comment.

## Not changed

The many \`console.*\` calls later in \`widget.ts\` (lines 255+) live inside template-literal IIFEs that get embedded into the widget's HTML shipped to browsers — those are legitimate client-side console usage.

## Test fix

The observability tests in \`widget.test.ts\` (lines 885–921) hooked \`console.warn\` directly to assert warnings were emitted. Swapped to \`mock.module()\` on \`@atlas/api/lib/logger\` with a capturing warn implementation. Behavioral assertions unchanged (same substring checks: \"exceeds 8KB\", \"not valid JSON\", \"non-array\").

## Test plan

- [x] \`bun run lint\` — 0 warnings
- [x] \`bun run type\` — 0 errors
- [x] \`bun run --filter '@atlas/api' test\` — 236 files pass, 0 fail
- [x] \`bun x syncpack lint\` — clean
- [x] Template drift check — clean
- [x] The 4 \`sanitizeStarterPrompts — observability\` tests still pass with the new logger wiring