### PR TITLE
refactor(content-mode): add ContentModeRegistry library (#1515 phase 1)

### DIFF
--- a/packages/api/src/lib/content-mode/__tests__/registry.test.ts
+++ b/packages/api/src/lib/content-mode/__tests__/registry.test.ts
@@ -5,23 +5,38 @@
  * The registry is exercised through its exported Context.Tag service and
  * the derived `InferDraftCounts` type. Internal helpers stay untested so
  * they can be refactored freely.
+ *
+ * Tests that exercise dispatch branches the production tuple doesn't
+ * currently hit (exotic readFilter override, failing exotic promote,
+ * duplicate-key guard) build a throwaway `makeService(tables)` around
+ * a test-only tuple.
  */
 
 import { describe, it, expect } from "bun:test";
-import { Effect } from "effect";
+import { Effect, Layer } from "effect";
 import type { ModeDraftCounts } from "@useatlas/types/mode";
 import { CONTENT_MODE_TABLES } from "../tables";
 import type { InferDraftCounts } from "../infer";
-import { Layer } from "effect";
-import { ContentModeRegistry, ContentModeRegistryLive } from "../registry";
-import type { PromotionReport } from "../port";
-import { PublishPhaseError, UnknownTableError } from "../port";
+import {
+  ContentModeRegistry,
+  ContentModeRegistryLive,
+  makeService,
+  type ContentModeRegistryService,
+} from "../registry";
+import type { ContentModeEntry, PromotionReport } from "../port";
+import {
+  ExoticReadFilterUnavailableError,
+  PublishPhaseError,
+  UnknownTableError,
+} from "../port";
 import { InternalDB, createInternalDBTestLayer } from "@atlas/api/lib/db/internal";
 import type { PoolClient, QueryResult } from "pg";
 
 /**
  * Minimal PoolClient mock: records every `query()` invocation and returns
- * pre-seeded results in FIFO order. Unused `release`/`connect` surface.
+ * pre-seeded results in FIFO order. Throws if the registry issues more
+ * queries than seeded responses — an unexpected extra query (e.g. stray
+ * BEGIN/COMMIT) fails loudly instead of silently returning empty.
  */
 function makeMockPoolClient(
   responses: Array<Partial<QueryResult> | Error>,
@@ -30,8 +45,12 @@ function makeMockPoolClient(
   const client = {
     query: async (sql: string, params: unknown[] = []) => {
       calls.push({ sql, params });
-      const next = responses.shift();
-      if (!next) return { rows: [], rowCount: 0 };
+      if (responses.length === 0) {
+        throw new Error(
+          `makeMockPoolClient: unexpected query #${calls.length} — no seeded response (sql: ${sql.slice(0, 80)})`,
+        );
+      }
+      const next = responses.shift()!;
       if (next instanceof Error) throw next;
       return { rows: next.rows ?? [], rowCount: next.rowCount ?? 0 };
     },
@@ -42,10 +61,11 @@ function makeMockPoolClient(
 
 /**
  * Build a test layer where `InternalDB.query` records its SQL + params and
- * returns `rows` shaped like the count row union.
+ * returns `rows` shaped like the count row union. Supports either a fixed
+ * row array or a custom query function.
  */
 function makeInternalDBCapture(
-  rows: ReadonlyArray<{ key: string; n: number }> = [],
+  rows: ReadonlyArray<{ key: string; n: number | string }> = [],
 ): {
   layer: Layer.Layer<InternalDB>;
   calls: Array<{ sql: string; params: unknown[] }>;
@@ -68,6 +88,13 @@ function runWithLive<A, E>(program: Effect.Effect<A, E, ContentModeRegistry>): P
   return Effect.runPromise(program.pipe(Effect.provide(ContentModeRegistryLive)));
 }
 
+/** Build a test-only registry layer from a custom tables tuple. */
+function testRegistryLayer(
+  tables: ReadonlyArray<ContentModeEntry>,
+): Layer.Layer<ContentModeRegistry> {
+  return Layer.succeed(ContentModeRegistry, makeService(tables));
+}
+
 // ---------------------------------------------------------------------------
 // Type-level equality helpers (no runtime cost).
 // The conditional-function trick distinguishes structurally equal types from
@@ -76,22 +103,27 @@ function runWithLive<A, E>(program: Effect.Effect<A, E, ContentModeRegistry>): P
 // ---------------------------------------------------------------------------
 type Equal<X, Y> =
   (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
-type Expect<T extends true> = T;
 
-describe("CONTENT_MODE_TABLES type inference", () => {
-  it("derives a type exactly equal to the published ModeDraftCounts", () => {
-    // If anyone adds a key to ModeDraftCounts without registering a matching
-    // entry in CONTENT_MODE_TABLES (or vice versa), this line fails to compile.
-    type _assertEqual = Expect<
-      Equal<ModeDraftCounts, InferDraftCounts<typeof CONTENT_MODE_TABLES>>
-    >;
-    const ok: _assertEqual = true;
-    expect(ok).toBe(true);
-  });
-});
+// Compile-time assertion: InferDraftCounts<CONTENT_MODE_TABLES> must equal
+// ModeDraftCounts. Adding a key on either side without the other causes this
+// line to fail type-check. This is the real gate — not a runtime expect.
+const _assertInferredEqualsWire: Equal<
+  ModeDraftCounts,
+  InferDraftCounts<typeof CONTENT_MODE_TABLES>
+> = true;
+void _assertInferredEqualsWire;
 
-describe("ContentModeRegistry.readFilter — published mode", () => {
-  it("returns `alias.status = 'published'` for a simple table", async () => {
+// Compile-time assertion: makeService returns the right shape.
+const _assertMakeServiceShape: ContentModeRegistryService =
+  null as unknown as ContentModeRegistryService;
+void _assertMakeServiceShape;
+
+// ============================================================================
+// readFilter
+// ============================================================================
+
+describe("ContentModeRegistry.readFilter — simple tables", () => {
+  it("returns `alias.status = 'published'` in published mode", async () => {
     const clause = await runWithLive(
       Effect.gen(function* () {
         const registry = yield* ContentModeRegistry;
@@ -100,10 +132,8 @@ describe("ContentModeRegistry.readFilter — published mode", () => {
     );
     expect(clause).toBe("c.status = 'published'");
   });
-});
 
-describe("ContentModeRegistry.readFilter — developer mode", () => {
-  it("overlays drafts onto published rows for a simple table", async () => {
+  it("overlays drafts onto published rows in developer mode", async () => {
     const clause = await runWithLive(
       Effect.gen(function* () {
         const registry = yield* ContentModeRegistry;
@@ -112,25 +142,113 @@ describe("ContentModeRegistry.readFilter — developer mode", () => {
     );
     expect(clause).toBe("c.status IN ('published', 'draft')");
   });
+
+  it("resolves simple entries by physical table name (prompt_collections, query_suggestions)", async () => {
+    const clauses = await runWithLive(
+      Effect.gen(function* () {
+        const registry = yield* ContentModeRegistry;
+        const byKey = yield* registry.readFilter("prompts", "published", "p");
+        const byTable = yield* registry.readFilter("prompt_collections", "published", "p");
+        const byKey2 = yield* registry.readFilter("starterPrompts", "published", "s");
+        const byTable2 = yield* registry.readFilter("query_suggestions", "published", "s");
+        return { byKey, byTable, byKey2, byTable2 };
+      }),
+    );
+    expect(clauses.byKey).toBe("p.status = 'published'");
+    expect(clauses.byTable).toBe("p.status = 'published'");
+    expect(clauses.byKey2).toBe("s.status = 'published'");
+    expect(clauses.byTable2).toBe("s.status = 'published'");
+  });
 });
 
-describe("ContentModeRegistry.readFilter — unknown table", () => {
-  it("fails with UnknownTableError tagged error", async () => {
+describe("ContentModeRegistry.readFilter — failure modes", () => {
+  it("fails with UnknownTableError for an unregistered table", async () => {
     const result = await Effect.runPromise(
       Effect.gen(function* () {
         const registry = yield* ContentModeRegistry;
         return yield* registry.readFilter("bogus_table", "published", "b");
       }).pipe(Effect.provide(ContentModeRegistryLive), Effect.either),
     );
-    // Either.left holds the failure; assert shape without leaning on Effect internals
     expect(result._tag).toBe("Left");
     if (result._tag === "Left") {
       expect(result.left).toBeInstanceOf(UnknownTableError);
-      expect(result.left.table).toBe("bogus_table");
       expect(result.left._tag).toBe("UnknownTableError");
+      expect((result.left as UnknownTableError).table).toBe("bogus_table");
+    }
+  });
+
+  it("fails with ExoticReadFilterUnavailableError for an exotic entry with no readFilter adapter", async () => {
+    // semantic_entities in the production tuple has no readFilter — phase 2
+    // of #1515 will add it. Until then, calling readFilter for it must fail
+    // loudly rather than returning the simple-table default.
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const registry = yield* ContentModeRegistry;
+        return yield* registry.readFilter("semantic_entities", "developer", "s");
+      }).pipe(Effect.provide(ContentModeRegistryLive), Effect.either),
+    );
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toBeInstanceOf(ExoticReadFilterUnavailableError);
+      expect(result.left._tag).toBe("ExoticReadFilterUnavailableError");
+      expect((result.left as ExoticReadFilterUnavailableError).table).toBe(
+        "semantic_entities",
+      );
     }
   });
 });
+
+describe("ContentModeRegistry.readFilter — exotic tables with readFilter adapter", () => {
+  // Test-only tuple with an exotic entry that ships a readFilter override.
+  // Covers the dispatch branch the production tuple cannot currently hit
+  // (and that phase 2 activates for semantic_entities).
+  const exoticWithFilter: ReadonlyArray<ContentModeEntry> = [
+    {
+      kind: "exotic",
+      key: "fancy_entities",
+      countSegments: [
+        {
+          key: "fancy_entities",
+          sql: (p) => `SELECT 'fancy_entities' AS key, 0::int AS n FROM (VALUES (${p})) v`,
+        },
+      ],
+      promote: () =>
+        Effect.succeed({ table: "fancy_entities", promoted: 0 }),
+      readFilter: {
+        published: (alias) =>
+          `${alias}.status = 'published' AND ${alias}.deleted_at IS NULL`,
+        developerOverlay: (alias) =>
+          `${alias}.status IN ('published', 'draft') AND ${alias}.draft_status != 'draft_delete'`,
+      },
+    },
+  ];
+
+  it("invokes readFilter.published(alias) in published mode", async () => {
+    const clause = await Effect.runPromise(
+      Effect.gen(function* () {
+        const registry = yield* ContentModeRegistry;
+        return yield* registry.readFilter("fancy_entities", "published", "f");
+      }).pipe(Effect.provide(testRegistryLayer(exoticWithFilter))),
+    );
+    expect(clause).toBe("f.status = 'published' AND f.deleted_at IS NULL");
+  });
+
+  it("invokes readFilter.developerOverlay(alias) in developer mode", async () => {
+    const clause = await Effect.runPromise(
+      Effect.gen(function* () {
+        const registry = yield* ContentModeRegistry;
+        return yield* registry.readFilter("fancy_entities", "developer", "f");
+      }).pipe(Effect.provide(testRegistryLayer(exoticWithFilter))),
+    );
+    expect(clause).toBe(
+      "f.status IN ('published', 'draft') AND f.draft_status != 'draft_delete'",
+    );
+  });
+});
+
+// ============================================================================
+// countAllDrafts
+// ============================================================================
 
 describe("ContentModeRegistry.countAllDrafts", () => {
   it("issues exactly one UNION ALL query and zero-fills missing segments", async () => {
@@ -159,6 +277,29 @@ describe("ContentModeRegistry.countAllDrafts", () => {
       entityEdits: 0,
       entityDeletes: 0,
     });
+    // Every `$N` token in the query must be `$1` — the registry passes a
+    // single orgId param; a future exotic segment that introduces `$2`
+    // would cause silent param/branch mismatches.
+    const tokens = calls[0].sql.match(/\$\d+/g) ?? [];
+    expect(new Set(tokens)).toEqual(new Set(["$1"]));
+  });
+
+  it("coerces string counts from the driver to numbers", async () => {
+    // Some pg pool configurations return ::int COUNTs as strings; the
+    // registry must coerce explicitly without falling back to 0.
+    const { layer } = makeInternalDBCapture([
+      { key: "connections", n: "5" as unknown as number },
+      { key: "prompts", n: "0" as unknown as number },
+    ]);
+
+    const counts = await Effect.runPromise(
+      Effect.gen(function* () {
+        const registry = yield* ContentModeRegistry;
+        return yield* registry.countAllDrafts("org-1");
+      }).pipe(Effect.provide(ContentModeRegistryLive), Effect.provide(layer)),
+    );
+    expect(counts.connections).toBe(5);
+    expect(counts.prompts).toBe(0);
   });
 
   it("wraps executor errors in PublishPhaseError with phase 'count'", async () => {
@@ -183,55 +324,97 @@ describe("ContentModeRegistry.countAllDrafts", () => {
     if (result._tag === "Left") {
       expect(result.left).toBeInstanceOf(PublishPhaseError);
       expect(result.left._tag).toBe("PublishPhaseError");
-      expect(result.left.phase).toBe("count");
-      expect(result.left.cause).toBe(boom);
+      expect((result.left as PublishPhaseError).phase).toBe("count");
+      expect((result.left as PublishPhaseError).cause).toBe(boom);
+    }
+  });
+
+  it("fails with PublishPhaseError when a row returns an unknown segment key", async () => {
+    // Drift scenario: the DB returns a row for a segment that isn't in the
+    // tuple. Silently dropping would mask tuple/UNION drift; the registry
+    // must fail so the admin banner never under-reports drafts.
+    const { layer } = makeInternalDBCapture([
+      { key: "connections", n: 1 },
+      { key: "stale_removed_segment", n: 99 },
+    ]);
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const registry = yield* ContentModeRegistry;
+        return yield* registry.countAllDrafts("org-1");
+      }).pipe(
+        Effect.provide(ContentModeRegistryLive),
+        Effect.provide(layer),
+        Effect.either,
+      ),
+    );
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toBeInstanceOf(PublishPhaseError);
+      expect((result.left as PublishPhaseError).phase).toBe("count");
+      const cause = (result.left as PublishPhaseError).cause;
+      expect(cause).toBeInstanceOf(Error);
+      expect(String(cause)).toContain("stale_removed_segment");
+    }
+  });
+
+  it("fails with PublishPhaseError when a row returns a non-numeric count", async () => {
+    const { layer } = makeInternalDBCapture([
+      { key: "connections", n: "abc" as unknown as number },
+    ]);
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const registry = yield* ContentModeRegistry;
+        return yield* registry.countAllDrafts("org-1");
+      }).pipe(
+        Effect.provide(ContentModeRegistryLive),
+        Effect.provide(layer),
+        Effect.either,
+      ),
+    );
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toBeInstanceOf(PublishPhaseError);
+      expect((result.left as PublishPhaseError).phase).toBe("count");
+      const cause = (result.left as PublishPhaseError).cause;
+      expect(String(cause)).toContain("non-numeric count");
+    }
+  });
+
+  it("fails with PublishPhaseError when a row returns a negative count", async () => {
+    const { layer } = makeInternalDBCapture([{ key: "connections", n: -1 }]);
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const registry = yield* ContentModeRegistry;
+        return yield* registry.countAllDrafts("org-1");
+      }).pipe(
+        Effect.provide(ContentModeRegistryLive),
+        Effect.provide(layer),
+        Effect.either,
+      ),
+    );
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toBeInstanceOf(PublishPhaseError);
+      expect((result.left as PublishPhaseError).phase).toBe("count");
     }
   });
 });
 
+// ============================================================================
+// runPublishPhases
+// ============================================================================
+
 describe("ContentModeRegistry.runPublishPhases", () => {
-  it("invokes adapters in tuple order and returns a report per entry", async () => {
-    // Seed three simple UPDATEs (connections, prompt_collections, query_suggestions)
-    // with decreasing rowCount so ordering is observable in the report.
+  it("invokes simple adapters in tuple order; exotic semantic_entities fails loudly", async () => {
+    // The production stub fails by design (phase 2 of #1515). Simple adapters
+    // 1–3 run successfully; the exotic stub surfaces a PublishPhaseError.
     const { client, calls } = makeMockPoolClient([
       { rowCount: 3 }, // connections
       { rowCount: 2 }, // prompt_collections
       { rowCount: 1 }, // query_suggestions
-    ]);
-
-    const reports = await Effect.runPromise(
-      Effect.gen(function* () {
-        const registry = yield* ContentModeRegistry;
-        return yield* registry.runPublishPhases(client, "org-1");
-      }).pipe(Effect.provide(ContentModeRegistryLive)),
-    );
-
-    // Three simple + one exotic (stubbed to succeed with zero promoted)
-    expect(reports).toHaveLength(4);
-    expect(reports.map((r: PromotionReport) => r.table)).toEqual([
-      "connections",
-      "prompt_collections",
-      "query_suggestions",
-      "semantic_entities",
-    ]);
-    expect(reports[0].promoted).toBe(3);
-    expect(reports[1].promoted).toBe(2);
-    expect(reports[2].promoted).toBe(1);
-
-    // Three UPDATEs hit the passed-in client, in tuple order.
-    expect(calls).toHaveLength(3);
-    expect(calls[0].sql).toContain("UPDATE connections");
-    expect(calls[1].sql).toContain("UPDATE prompt_collections");
-    expect(calls[2].sql).toContain("UPDATE query_suggestions");
-    for (const c of calls) expect(c.params).toEqual(["org-1"]);
-  });
-
-  it("stops on first failure and surfaces PublishPhaseError — no later adapters run", async () => {
-    const boom = new Error("duplicate key violation");
-    const { client, calls } = makeMockPoolClient([
-      { rowCount: 3 }, // connections succeeds
-      boom, // prompt_collections fails
-      // query_suggestions and semantic_entities must NOT run; no seeded responses for them.
     ]);
 
     const result = await Effect.runPromise(
@@ -244,18 +427,149 @@ describe("ContentModeRegistry.runPublishPhases", () => {
     expect(result._tag).toBe("Left");
     if (result._tag === "Left") {
       expect(result.left).toBeInstanceOf(PublishPhaseError);
-      expect(result.left._tag).toBe("PublishPhaseError");
-      expect(result.left.phase).toBe("promote");
-      expect(result.left.table).toBe("prompt_collections");
-      expect(result.left.cause).toBe(boom);
+      expect((result.left as PublishPhaseError).table).toBe("semantic_entities");
+      expect((result.left as PublishPhaseError).phase).toBe("promote");
+      const cause = (result.left as PublishPhaseError).cause;
+      expect(String(cause)).toContain("phase 2 of #1515");
     }
-    // Exactly two UPDATEs attempted: connections succeeded, prompt_collections failed.
-    expect(calls).toHaveLength(2);
+    // The three simple UPDATEs ran in tuple order before the stub failed.
+    expect(calls).toHaveLength(3);
     expect(calls[0].sql).toContain("UPDATE connections");
     expect(calls[1].sql).toContain("UPDATE prompt_collections");
+    expect(calls[2].sql).toContain("UPDATE query_suggestions");
+    for (const c of calls) expect(c.params).toEqual(["org-1"]);
+  });
+
+  it("invokes simple and exotic adapters in tuple order with a non-failing exotic (test tuple)", async () => {
+    const exoticReports: PromotionReport[] = [];
+    const customTables: ReadonlyArray<ContentModeEntry> = [
+      { kind: "simple", key: "alpha" },
+      {
+        kind: "exotic",
+        key: "beta",
+        countSegments: [
+          { key: "beta", sql: (p) => `SELECT 'beta' AS key, 0::int AS n FROM (VALUES (${p})) v` },
+        ],
+        promote: () => {
+          const report: PromotionReport = {
+            table: "beta",
+            promoted: 7,
+            tombstonesApplied: 2,
+          };
+          exoticReports.push(report);
+          return Effect.succeed(report);
+        },
+      },
+      { kind: "simple", key: "gamma" },
+    ];
+    const { client, calls } = makeMockPoolClient([
+      { rowCount: 5 }, // alpha
+      { rowCount: 4 }, // gamma (beta uses its adapter, no tx.query)
+    ]);
+
+    const reports = await Effect.runPromise(
+      Effect.gen(function* () {
+        const registry = yield* ContentModeRegistry;
+        return yield* registry.runPublishPhases(client, "org-1");
+      }).pipe(Effect.provide(testRegistryLayer(customTables))),
+    );
+
+    expect(reports.map((r) => r.table)).toEqual(["alpha", "beta", "gamma"]);
+    expect(reports[0].promoted).toBe(5);
+    expect(reports[1].promoted).toBe(7);
+    expect(reports[1].tombstonesApplied).toBe(2);
+    expect(reports[2].promoted).toBe(4);
+    // Two simple UPDATEs hit tx.query; the exotic adapter uses its own
+    // promote Effect and does not route through the client in this fixture.
+    expect(calls).toHaveLength(2);
+    expect(calls[0].sql).toContain("UPDATE alpha");
+    expect(calls[1].sql).toContain("UPDATE gamma");
+    expect(exoticReports).toHaveLength(1);
+  });
+
+  it("surfaces PublishPhaseError from a failing exotic adapter and skips subsequent entries", async () => {
+    const boom = new PublishPhaseError({
+      table: "beta",
+      phase: "tombstone",
+      cause: new Error("FK violation on tombstone cascade"),
+    });
+    const customTables: ReadonlyArray<ContentModeEntry> = [
+      { kind: "simple", key: "alpha" },
+      {
+        kind: "exotic",
+        key: "beta",
+        countSegments: [
+          { key: "beta", sql: (p) => `SELECT 'beta' AS key, 0::int AS n FROM (VALUES (${p})) v` },
+        ],
+        promote: () => Effect.fail(boom),
+      },
+      // gamma must NOT run.
+      { kind: "simple", key: "gamma" },
+    ];
+    const { client, calls } = makeMockPoolClient([
+      { rowCount: 1 }, // alpha succeeds
+    ]);
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const registry = yield* ContentModeRegistry;
+        return yield* registry.runPublishPhases(client, "org-1");
+      }).pipe(Effect.provide(testRegistryLayer(customTables)), Effect.either),
+    );
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toBeInstanceOf(PublishPhaseError);
+      expect((result.left as PublishPhaseError).phase).toBe("tombstone");
+      expect((result.left as PublishPhaseError).table).toBe("beta");
+    }
+    // Only alpha ran; gamma never got a chance.
+    expect(calls).toHaveLength(1);
+    expect(calls[0].sql).toContain("UPDATE alpha");
+  });
+
+  it("stops on first simple-adapter failure and surfaces PublishPhaseError", async () => {
+    const boom = new Error("duplicate key violation");
+    // Test tuple: two simple adapters only, so the failure is observable
+    // without the production semantic_entities stub firing.
+    const customTables: ReadonlyArray<ContentModeEntry> = [
+      { kind: "simple", key: "alpha" },
+      { kind: "simple", key: "beta" },
+      { kind: "simple", key: "gamma" },
+    ];
+    const { client, calls } = makeMockPoolClient([
+      { rowCount: 3 }, // alpha succeeds
+      boom, // beta fails
+      // gamma must NOT run; no seeded response for it.
+    ]);
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const registry = yield* ContentModeRegistry;
+        return yield* registry.runPublishPhases(client, "org-1");
+      }).pipe(Effect.provide(testRegistryLayer(customTables)), Effect.either),
+    );
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toBeInstanceOf(PublishPhaseError);
+      expect(result.left._tag).toBe("PublishPhaseError");
+      expect((result.left as PublishPhaseError).phase).toBe("promote");
+      expect((result.left as PublishPhaseError).table).toBe("beta");
+      expect((result.left as PublishPhaseError).cause).toBe(boom);
+    }
+    expect(calls).toHaveLength(2);
+    expect(calls[0].sql).toContain("UPDATE alpha");
+    expect(calls[1].sql).toContain("UPDATE beta");
   });
 
   it("never issues BEGIN/COMMIT/ROLLBACK — caller owns the transaction", async () => {
+    // Use a simple-only tuple so the stub doesn't halt iteration early.
+    const customTables: ReadonlyArray<ContentModeEntry> = [
+      { kind: "simple", key: "alpha" },
+      { kind: "simple", key: "beta" },
+      { kind: "simple", key: "gamma" },
+    ];
     const { client, calls } = makeMockPoolClient([
       { rowCount: 0 },
       { rowCount: 0 },
@@ -266,15 +580,59 @@ describe("ContentModeRegistry.runPublishPhases", () => {
       Effect.gen(function* () {
         const registry = yield* ContentModeRegistry;
         return yield* registry.runPublishPhases(client, "org-1");
-      }).pipe(Effect.provide(ContentModeRegistryLive)),
+      }).pipe(Effect.provide(testRegistryLayer(customTables))),
     );
 
     // No call's SQL may reference transaction control — that stays the caller's job.
     for (const call of calls) {
       const upper = call.sql.toUpperCase();
-      expect(upper).not.toContain("BEGIN");
-      expect(upper).not.toContain("COMMIT");
-      expect(upper).not.toContain("ROLLBACK");
+      expect(upper).not.toMatch(/\bBEGIN\b/);
+      expect(upper).not.toMatch(/\bCOMMIT\b/);
+      expect(upper).not.toMatch(/\bROLLBACK\b/);
     }
+  });
+});
+
+// ============================================================================
+// makeService — startup invariants
+// ============================================================================
+
+describe("makeService startup guards", () => {
+  it("throws if the tuple contains duplicate entry keys", () => {
+    const dupKeys: ReadonlyArray<ContentModeEntry> = [
+      { kind: "simple", key: "alpha" },
+      { kind: "simple", key: "alpha" },
+    ];
+    expect(() => makeService(dupKeys)).toThrow(/duplicate entry key "alpha"/);
+  });
+
+  it("throws if a simple entry's `table` alias collides with another entry's key", () => {
+    const collidingAlias: ReadonlyArray<ContentModeEntry> = [
+      { kind: "simple", key: "beta" },
+      { kind: "simple", key: "alpha", table: "beta" },
+    ];
+    expect(() => makeService(collidingAlias)).toThrow(/already registered/);
+  });
+
+  it("throws if two exotic entries declare the same countSegments key", () => {
+    const dupSegments: ReadonlyArray<ContentModeEntry> = [
+      {
+        kind: "exotic",
+        key: "first",
+        countSegments: [
+          { key: "shared", sql: (p) => `SELECT 'shared' AS key, 0 AS n FROM (VALUES (${p})) v` },
+        ],
+        promote: () => Effect.succeed({ table: "first", promoted: 0 }),
+      },
+      {
+        kind: "exotic",
+        key: "second",
+        countSegments: [
+          { key: "shared", sql: (p) => `SELECT 'shared' AS key, 0 AS n FROM (VALUES (${p})) v` },
+        ],
+        promote: () => Effect.succeed({ table: "second", promoted: 0 }),
+      },
+    ];
+    expect(() => makeService(dupSegments)).toThrow(/duplicate draft-counts segment "shared"/);
   });
 });

--- a/packages/api/src/lib/content-mode/__tests__/registry.test.ts
+++ b/packages/api/src/lib/content-mode/__tests__/registry.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Boundary tests for the ContentModeRegistry (#1515).
+ *
+ * These tests describe the public surface, not the internal SQL shape.
+ * The registry is exercised through its exported Context.Tag service and
+ * the derived `InferDraftCounts` type. Internal helpers stay untested so
+ * they can be refactored freely.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { Effect } from "effect";
+import type { ModeDraftCounts } from "@useatlas/types/mode";
+import { CONTENT_MODE_TABLES } from "../tables";
+import type { InferDraftCounts } from "../infer";
+import { Layer } from "effect";
+import { ContentModeRegistry, ContentModeRegistryLive } from "../registry";
+import type { PromotionReport } from "../port";
+import { PublishPhaseError, UnknownTableError } from "../port";
+import { InternalDB, createInternalDBTestLayer } from "@atlas/api/lib/db/internal";
+import type { PoolClient, QueryResult } from "pg";
+
+/**
+ * Minimal PoolClient mock: records every `query()` invocation and returns
+ * pre-seeded results in FIFO order. Unused `release`/`connect` surface.
+ */
+function makeMockPoolClient(
+  responses: Array<Partial<QueryResult> | Error>,
+): { client: PoolClient; calls: Array<{ sql: string; params: unknown[] }> } {
+  const calls: Array<{ sql: string; params: unknown[] }> = [];
+  const client = {
+    query: async (sql: string, params: unknown[] = []) => {
+      calls.push({ sql, params });
+      const next = responses.shift();
+      if (!next) return { rows: [], rowCount: 0 };
+      if (next instanceof Error) throw next;
+      return { rows: next.rows ?? [], rowCount: next.rowCount ?? 0 };
+    },
+    release: () => {},
+  } as unknown as PoolClient;
+  return { client, calls };
+}
+
+/**
+ * Build a test layer where `InternalDB.query` records its SQL + params and
+ * returns `rows` shaped like the count row union.
+ */
+function makeInternalDBCapture(
+  rows: ReadonlyArray<{ key: string; n: number }> = [],
+): {
+  layer: Layer.Layer<InternalDB>;
+  calls: Array<{ sql: string; params: unknown[] }>;
+} {
+  const calls: Array<{ sql: string; params: unknown[] }> = [];
+  const layer = createInternalDBTestLayer({
+    query: async <T extends Record<string, unknown>>(
+      sql: string,
+      params: unknown[] = [],
+    ): Promise<T[]> => {
+      calls.push({ sql, params });
+      return rows as unknown as T[];
+    },
+  });
+  return { layer, calls };
+}
+
+/** Run an Effect program with the live registry layer and return the result. */
+function runWithLive<A, E>(program: Effect.Effect<A, E, ContentModeRegistry>): Promise<A> {
+  return Effect.runPromise(program.pipe(Effect.provide(ContentModeRegistryLive)));
+}
+
+// ---------------------------------------------------------------------------
+// Type-level equality helpers (no runtime cost).
+// The conditional-function trick distinguishes structurally equal types from
+// merely mutually-assignable ones — required so a drift in readonly-ness or
+// added keys surfaces as a compile error.
+// ---------------------------------------------------------------------------
+type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+describe("CONTENT_MODE_TABLES type inference", () => {
+  it("derives a type exactly equal to the published ModeDraftCounts", () => {
+    // If anyone adds a key to ModeDraftCounts without registering a matching
+    // entry in CONTENT_MODE_TABLES (or vice versa), this line fails to compile.
+    type _assertEqual = Expect<
+      Equal<ModeDraftCounts, InferDraftCounts<typeof CONTENT_MODE_TABLES>>
+    >;
+    const ok: _assertEqual = true;
+    expect(ok).toBe(true);
+  });
+});
+
+describe("ContentModeRegistry.readFilter — published mode", () => {
+  it("returns `alias.status = 'published'` for a simple table", async () => {
+    const clause = await runWithLive(
+      Effect.gen(function* () {
+        const registry = yield* ContentModeRegistry;
+        return yield* registry.readFilter("connections", "published", "c");
+      }),
+    );
+    expect(clause).toBe("c.status = 'published'");
+  });
+});
+
+describe("ContentModeRegistry.readFilter — developer mode", () => {
+  it("overlays drafts onto published rows for a simple table", async () => {
+    const clause = await runWithLive(
+      Effect.gen(function* () {
+        const registry = yield* ContentModeRegistry;
+        return yield* registry.readFilter("connections", "developer", "c");
+      }),
+    );
+    expect(clause).toBe("c.status IN ('published', 'draft')");
+  });
+});
+
+describe("ContentModeRegistry.readFilter — unknown table", () => {
+  it("fails with UnknownTableError tagged error", async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const registry = yield* ContentModeRegistry;
+        return yield* registry.readFilter("bogus_table", "published", "b");
+      }).pipe(Effect.provide(ContentModeRegistryLive), Effect.either),
+    );
+    // Either.left holds the failure; assert shape without leaning on Effect internals
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toBeInstanceOf(UnknownTableError);
+      expect(result.left.table).toBe("bogus_table");
+      expect(result.left._tag).toBe("UnknownTableError");
+    }
+  });
+});
+
+describe("ContentModeRegistry.countAllDrafts", () => {
+  it("issues exactly one UNION ALL query and zero-fills missing segments", async () => {
+    const { layer, calls } = makeInternalDBCapture([
+      { key: "connections", n: 2 },
+      { key: "prompts", n: 1 },
+      // Intentionally omit entities/entityEdits/entityDeletes/starterPrompts
+      // so the test asserts zero-fill for absent segments.
+    ]);
+
+    const counts = await Effect.runPromise(
+      Effect.gen(function* () {
+        const registry = yield* ContentModeRegistry;
+        return yield* registry.countAllDrafts("org-123");
+      }).pipe(Effect.provide(ContentModeRegistryLive), Effect.provide(layer)),
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].sql).toContain("UNION ALL");
+    expect(calls[0].params).toEqual(["org-123"]);
+    expect(counts).toEqual({
+      connections: 2,
+      prompts: 1,
+      starterPrompts: 0,
+      entities: 0,
+      entityEdits: 0,
+      entityDeletes: 0,
+    });
+  });
+
+  it("wraps executor errors in PublishPhaseError with phase 'count'", async () => {
+    const boom = new Error("connection refused");
+    const failingLayer = createInternalDBTestLayer({
+      query: async () => {
+        throw boom;
+      },
+    });
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const registry = yield* ContentModeRegistry;
+        return yield* registry.countAllDrafts("org-1");
+      }).pipe(
+        Effect.provide(ContentModeRegistryLive),
+        Effect.provide(failingLayer),
+        Effect.either,
+      ),
+    );
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toBeInstanceOf(PublishPhaseError);
+      expect(result.left._tag).toBe("PublishPhaseError");
+      expect(result.left.phase).toBe("count");
+      expect(result.left.cause).toBe(boom);
+    }
+  });
+});
+
+describe("ContentModeRegistry.runPublishPhases", () => {
+  it("invokes adapters in tuple order and returns a report per entry", async () => {
+    // Seed three simple UPDATEs (connections, prompt_collections, query_suggestions)
+    // with decreasing rowCount so ordering is observable in the report.
+    const { client, calls } = makeMockPoolClient([
+      { rowCount: 3 }, // connections
+      { rowCount: 2 }, // prompt_collections
+      { rowCount: 1 }, // query_suggestions
+    ]);
+
+    const reports = await Effect.runPromise(
+      Effect.gen(function* () {
+        const registry = yield* ContentModeRegistry;
+        return yield* registry.runPublishPhases(client, "org-1");
+      }).pipe(Effect.provide(ContentModeRegistryLive)),
+    );
+
+    // Three simple + one exotic (stubbed to succeed with zero promoted)
+    expect(reports).toHaveLength(4);
+    expect(reports.map((r: PromotionReport) => r.table)).toEqual([
+      "connections",
+      "prompt_collections",
+      "query_suggestions",
+      "semantic_entities",
+    ]);
+    expect(reports[0].promoted).toBe(3);
+    expect(reports[1].promoted).toBe(2);
+    expect(reports[2].promoted).toBe(1);
+
+    // Three UPDATEs hit the passed-in client, in tuple order.
+    expect(calls).toHaveLength(3);
+    expect(calls[0].sql).toContain("UPDATE connections");
+    expect(calls[1].sql).toContain("UPDATE prompt_collections");
+    expect(calls[2].sql).toContain("UPDATE query_suggestions");
+    for (const c of calls) expect(c.params).toEqual(["org-1"]);
+  });
+
+  it("stops on first failure and surfaces PublishPhaseError — no later adapters run", async () => {
+    const boom = new Error("duplicate key violation");
+    const { client, calls } = makeMockPoolClient([
+      { rowCount: 3 }, // connections succeeds
+      boom, // prompt_collections fails
+      // query_suggestions and semantic_entities must NOT run; no seeded responses for them.
+    ]);
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const registry = yield* ContentModeRegistry;
+        return yield* registry.runPublishPhases(client, "org-1");
+      }).pipe(Effect.provide(ContentModeRegistryLive), Effect.either),
+    );
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toBeInstanceOf(PublishPhaseError);
+      expect(result.left._tag).toBe("PublishPhaseError");
+      expect(result.left.phase).toBe("promote");
+      expect(result.left.table).toBe("prompt_collections");
+      expect(result.left.cause).toBe(boom);
+    }
+    // Exactly two UPDATEs attempted: connections succeeded, prompt_collections failed.
+    expect(calls).toHaveLength(2);
+    expect(calls[0].sql).toContain("UPDATE connections");
+    expect(calls[1].sql).toContain("UPDATE prompt_collections");
+  });
+
+  it("never issues BEGIN/COMMIT/ROLLBACK — caller owns the transaction", async () => {
+    const { client, calls } = makeMockPoolClient([
+      { rowCount: 0 },
+      { rowCount: 0 },
+      { rowCount: 0 },
+    ]);
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const registry = yield* ContentModeRegistry;
+        return yield* registry.runPublishPhases(client, "org-1");
+      }).pipe(Effect.provide(ContentModeRegistryLive)),
+    );
+
+    // No call's SQL may reference transaction control — that stays the caller's job.
+    for (const call of calls) {
+      const upper = call.sql.toUpperCase();
+      expect(upper).not.toContain("BEGIN");
+      expect(upper).not.toContain("COMMIT");
+      expect(upper).not.toContain("ROLLBACK");
+    }
+  });
+});

--- a/packages/api/src/lib/content-mode/index.ts
+++ b/packages/api/src/lib/content-mode/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Content mode registry — single source of truth for tables that
+ * participate in Atlas's developer/published mode system (#1515).
+ *
+ * Callers:
+ * - `admin-publish.ts` yields `ContentModeRegistry` and calls
+ *   `runPublishPhases(client, orgId)` inside its existing BEGIN/COMMIT.
+ * - `mode.ts` (GET /api/v1/mode) calls `countAllDrafts(orgId)`.
+ * - Read handlers call `readFilter(table, mode, alias)` for a
+ *   WHERE-clause fragment.
+ *
+ * Adding a new simple content table is a one-line change to
+ * `CONTENT_MODE_TABLES` in `./tables.ts`. The derived `ModeDraftCounts`
+ * wire type picks up the new segment automatically.
+ */
+
+export {
+  ContentModeRegistry,
+  ContentModeRegistryLive,
+  type ContentModeRegistryService,
+} from "./registry";
+
+export {
+  type ContentModeEntry,
+  type SimpleModeTable,
+  type ExoticModeAdapter,
+  type PromotionReport,
+  PublishPhaseError,
+  UnknownTableError,
+} from "./port";
+
+export { CONTENT_MODE_TABLES } from "./tables";
+export type { InferDraftCounts } from "./infer";

--- a/packages/api/src/lib/content-mode/index.ts
+++ b/packages/api/src/lib/content-mode/index.ts
@@ -2,21 +2,20 @@
  * Content mode registry — single source of truth for tables that
  * participate in Atlas's developer/published mode system (#1515).
  *
- * Callers:
- * - `admin-publish.ts` yields `ContentModeRegistry` and calls
- *   `runPublishPhases(client, orgId)` inside its existing BEGIN/COMMIT.
- * - `mode.ts` (GET /api/v1/mode) calls `countAllDrafts(orgId)`.
- * - Read handlers call `readFilter(table, mode, alias)` for a
- *   WHERE-clause fragment.
+ * This module is the library surface that phase 2 of #1515 migrates
+ * `mode.ts` (`GET /api/v1/mode`), `admin-publish.ts`, `prompts/scoping.ts`,
+ * `admin-connections.ts`, and `admin-starter-prompts.ts` onto. Phase 1
+ * ships the library + tests only; no call sites yet.
  *
  * Adding a new simple content table is a one-line change to
  * `CONTENT_MODE_TABLES` in `./tables.ts`. The derived `ModeDraftCounts`
- * wire type picks up the new segment automatically.
+ * wire type picks up the new segment automatically via `InferDraftCounts`.
  */
 
 export {
   ContentModeRegistry,
   ContentModeRegistryLive,
+  makeService,
   type ContentModeRegistryService,
 } from "./registry";
 
@@ -25,6 +24,7 @@ export {
   type SimpleModeTable,
   type ExoticModeAdapter,
   type PromotionReport,
+  ExoticReadFilterUnavailableError,
   PublishPhaseError,
   UnknownTableError,
 } from "./port";

--- a/packages/api/src/lib/content-mode/infer.ts
+++ b/packages/api/src/lib/content-mode/infer.ts
@@ -8,7 +8,7 @@
  * `__tests__/registry.test.ts` fails at compile time if it drifts.
  */
 
-import type { ContentModeEntry } from "./port";
+import type { ContentModeEntry, SimpleModeTable, ExoticModeAdapter } from "./port";
 
 /** Collapse a union of object types into their intersection. */
 type UnionToIntersection<U> = (U extends unknown ? (_: U) => void : never) extends (
@@ -17,7 +17,16 @@ type UnionToIntersection<U> = (U extends unknown ? (_: U) => void : never) exten
   ? I
   : never;
 
-/** Map a single entry to its contribution to `ModeDraftCounts`. */
+/**
+ * Map a single entry to its contribution to `ModeDraftCounts`.
+ *
+ * Branches on the closed `ContentModeEntry` union — a new `kind` added
+ * to `port.ts` without a matching branch here collapses to `never` in
+ * the union-to-intersection step, which is caught at CI time by the
+ * type-level equality assertion in `__tests__/registry.test.ts`. The
+ * `_AssertCovered` line below also fails to compile locally so the
+ * drift is visible at the declaration site.
+ */
 type EntryToRecord<E extends ContentModeEntry> = E extends {
   kind: "simple";
   key: infer K extends string;
@@ -31,9 +40,30 @@ type EntryToRecord<E extends ContentModeEntry> = E extends {
     : never;
 
 /**
+ * Compile-time assertion: `EntryToRecord` covers every member of
+ * `ContentModeEntry`. If a new variant is added to `ContentModeEntry`
+ * in `port.ts` without extending `EntryToRecord`, this line fails to
+ * type-check — the error surfaces at the declaration site, not in
+ * the distant assertion test.
+ */
+type _AssertCovered = EntryToRecord<SimpleModeTable> extends never
+  ? never
+  : EntryToRecord<ExoticModeAdapter> extends never
+    ? never
+    : true;
+const _assertCovered: _AssertCovered = true;
+void _assertCovered;
+
+/**
  * The derived shape of `ModeDraftCounts` for a given registry tuple.
  * Only meaningful when the registry is declared with `as const` so key
  * literals survive inference.
+ *
+ * The final `{ readonly [K in keyof R]: R[K] }` homomorphic mapping is
+ * not cosmetic — it flattens the `A & B & C` intersection produced by
+ * `UnionToIntersection` into a plain object shape so the structural
+ * `Equal<InferDraftCounts<...>, ModeDraftCounts>` assertion in the test
+ * sees an identical type (not merely a mutually-assignable one).
  */
 export type InferDraftCounts<
   T extends ReadonlyArray<ContentModeEntry>,

--- a/packages/api/src/lib/content-mode/infer.ts
+++ b/packages/api/src/lib/content-mode/infer.ts
@@ -1,0 +1,42 @@
+/**
+ * Compile-time derivation of `ModeDraftCounts` from the static
+ * `CONTENT_MODE_TABLES` tuple.
+ *
+ * Separated from `tables.ts` so the type machinery stays out of the
+ * way of the registration data. The derived type should always equal
+ * `ModeDraftCounts` from `@useatlas/types/mode` — the assertion in
+ * `__tests__/registry.test.ts` fails at compile time if it drifts.
+ */
+
+import type { ContentModeEntry } from "./port";
+
+/** Collapse a union of object types into their intersection. */
+type UnionToIntersection<U> = (U extends unknown ? (_: U) => void : never) extends (
+  _: infer I,
+) => void
+  ? I
+  : never;
+
+/** Map a single entry to its contribution to `ModeDraftCounts`. */
+type EntryToRecord<E extends ContentModeEntry> = E extends {
+  kind: "simple";
+  key: infer K extends string;
+}
+  ? { readonly [P in K]: number }
+  : E extends {
+        kind: "exotic";
+        countSegments: infer S extends ReadonlyArray<{ readonly key: string }>;
+      }
+    ? { readonly [P in S[number]["key"]]: number }
+    : never;
+
+/**
+ * The derived shape of `ModeDraftCounts` for a given registry tuple.
+ * Only meaningful when the registry is declared with `as const` so key
+ * literals survive inference.
+ */
+export type InferDraftCounts<
+  T extends ReadonlyArray<ContentModeEntry>,
+> = UnionToIntersection<EntryToRecord<T[number]>> extends infer R
+  ? { readonly [K in keyof R]: R[K] }
+  : never;

--- a/packages/api/src/lib/content-mode/port.ts
+++ b/packages/api/src/lib/content-mode/port.ts
@@ -1,0 +1,78 @@
+/**
+ * Port types for the content-mode registry (#1515).
+ *
+ * Describes how a table participates in Atlas's developer/published mode
+ * system: how its drafts are counted, promoted, and filtered on reads.
+ * Three of four existing tables are "simple" (one status column, one
+ * UPDATE to promote, one COUNT for drafts); `semantic_entities` is
+ * exotic because of its tombstones and overlay CTE.
+ *
+ * This module is pure — no auth/logger/middleware imports — so
+ * `packages/api/src/lib/` consumers can depend on it without inverting
+ * the purity constraint documented in `lib/mode.ts`.
+ */
+
+import type { PoolClient } from "pg";
+import { Data, type Effect } from "effect";
+
+/**
+ * A status-lifecycle table where promote = `UPDATE ... SET status='published'
+ * WHERE org_id=$1 AND status='draft'` and count = `COUNT(*) WHERE status='draft'`.
+ *
+ * `key` is the `ModeDraftCounts` segment key. `table` defaults to `key` for
+ * the common case where the physical table name matches; override only when
+ * the draft-counts segment name diverges from the DB table (e.g. the
+ * `query_suggestions` table surfaces as the `starterPrompts` segment).
+ */
+export type SimpleModeTable = {
+  readonly kind: "simple";
+  readonly key: string;
+  readonly table?: string;
+  readonly orgColumn?: string;
+  readonly statusColumn?: string;
+};
+
+/**
+ * A table whose draft counts, promotion, or read filter require
+ * table-specific SQL. Exotic adapters wrap existing helpers rather than
+ * rewriting them (e.g. `semantic_entities` wraps `promoteDraftEntities`
+ * and the CTE overlay).
+ */
+export type ExoticModeAdapter = {
+  readonly kind: "exotic";
+  readonly key: string;
+  readonly countSegments: ReadonlyArray<{
+    readonly key: string;
+    readonly sql: (orgParam: string) => string;
+  }>;
+  readonly promote: (
+    tx: PoolClient,
+    orgId: string,
+  ) => Effect.Effect<PromotionReport, PublishPhaseError, never>;
+  readonly readFilter?: {
+    readonly published: (alias: string) => string;
+    readonly developerOverlay: (alias: string) => string;
+  };
+};
+
+export type ContentModeEntry = SimpleModeTable | ExoticModeAdapter;
+
+/** Result of promoting drafts for a single table. */
+export interface PromotionReport {
+  readonly table: string;
+  readonly promoted: number;
+  readonly deleted?: number;
+  readonly tombstonesApplied?: number;
+}
+
+/** Publish phase failed — caller owns rollback. */
+export class PublishPhaseError extends Data.TaggedError("PublishPhaseError")<{
+  readonly table: string;
+  readonly phase: "promote" | "tombstone" | "count";
+  readonly cause: unknown;
+}> {}
+
+/** Caller asked for a read filter on a table the registry doesn't know about. */
+export class UnknownTableError extends Data.TaggedError("UnknownTableError")<{
+  readonly table: string;
+}> {}

--- a/packages/api/src/lib/content-mode/port.ts
+++ b/packages/api/src/lib/content-mode/port.ts
@@ -21,8 +21,8 @@ import { Data, type Effect } from "effect";
  *
  * `key` is the `ModeDraftCounts` segment key. `table` defaults to `key` for
  * the common case where the physical table name matches; override only when
- * the draft-counts segment name diverges from the DB table (e.g. the
- * `query_suggestions` table surfaces as the `starterPrompts` segment).
+ * the segment key diverges from the physical table name — e.g.
+ * `prompts` → `prompt_collections`, or `starterPrompts` → `query_suggestions`.
  */
 export type SimpleModeTable = {
   readonly kind: "simple";
@@ -37,6 +37,12 @@ export type SimpleModeTable = {
  * table-specific SQL. Exotic adapters wrap existing helpers rather than
  * rewriting them (e.g. `semantic_entities` wraps `promoteDraftEntities`
  * and the CTE overlay).
+ *
+ * If `readFilter` is omitted, `ContentModeRegistry.readFilter` fails
+ * with `ExoticReadFilterUnavailableError` rather than silently falling
+ * back to the simple-table default — exotic tables with tombstones or
+ * overlays need dedicated read semantics, and a silent default would
+ * serve wrong rows.
  */
 export type ExoticModeAdapter = {
   readonly kind: "exotic";
@@ -65,7 +71,14 @@ export interface PromotionReport {
   readonly tombstonesApplied?: number;
 }
 
-/** Publish phase failed — caller owns rollback. */
+/**
+ * Publish or count phase failed.
+ *
+ * For `promote` / `tombstone` phases the caller owns rollback — the
+ * registry never opens its own transaction, so the caller must issue
+ * `ROLLBACK` on the shared `PoolClient`. For `count` this is simply
+ * a wrapped executor failure with no transactional implication.
+ */
 export class PublishPhaseError extends Data.TaggedError("PublishPhaseError")<{
   readonly table: string;
   readonly phase: "promote" | "tombstone" | "count";
@@ -74,5 +87,17 @@ export class PublishPhaseError extends Data.TaggedError("PublishPhaseError")<{
 
 /** Caller asked for a read filter on a table the registry doesn't know about. */
 export class UnknownTableError extends Data.TaggedError("UnknownTableError")<{
+  readonly table: string;
+}> {}
+
+/**
+ * Caller asked for a read filter on a registered exotic table whose
+ * adapter did not provide one. Exotic tables with tombstones or
+ * overlays need dedicated read semantics; silently falling back to the
+ * simple-table default would serve wrong rows.
+ */
+export class ExoticReadFilterUnavailableError extends Data.TaggedError(
+  "ExoticReadFilterUnavailableError",
+)<{
   readonly table: string;
 }> {}

--- a/packages/api/src/lib/content-mode/registry.ts
+++ b/packages/api/src/lib/content-mode/registry.ts
@@ -6,6 +6,11 @@
  * this file only builds the Effect.ts service wrapper so callers can
  * `yield* ContentModeRegistry` from any Effect program. No runtime
  * plugin/register API — the tuple is the single source of truth.
+ *
+ * `makeService(tables)` is exported for tests so alternate tuples can
+ * exercise the exotic-readFilter and failing-exotic-adapter dispatch
+ * branches that the production tuple does not currently hit. Production
+ * code uses `ContentModeRegistryLive`, which closes over `CONTENT_MODE_TABLES`.
  */
 
 import { Context, Effect, Layer } from "effect";
@@ -13,12 +18,22 @@ import type { PoolClient } from "pg";
 import type { AtlasMode } from "@useatlas/types/auth";
 import type { ModeDraftCounts } from "@useatlas/types/mode";
 import { InternalDB } from "@atlas/api/lib/db/internal";
-import type { ContentModeEntry, PromotionReport } from "./port";
-import { PublishPhaseError, UnknownTableError } from "./port";
+import type {
+  ContentModeEntry,
+  ExoticModeAdapter,
+  PromotionReport,
+  SimpleModeTable,
+} from "./port";
+import {
+  ExoticReadFilterUnavailableError,
+  PublishPhaseError,
+  UnknownTableError,
+} from "./port";
 import { CONTENT_MODE_TABLES } from "./tables";
 import type { InferDraftCounts } from "./infer";
 
-/** Zero-filled counts object used as the base for every countAllDrafts result. */
+/** The concrete shape `countAllDrafts` returns — must stay structurally
+ *  equal to `ModeDraftCounts`; asserted by the test in `registry.test.ts`. */
 type DerivedCounts = InferDraftCounts<typeof CONTENT_MODE_TABLES>;
 
 export interface ContentModeRegistryService {
@@ -26,18 +41,36 @@ export interface ContentModeRegistryService {
    * Return a SQL fragment usable inside a WHERE clause. Callers
    * typically write `WHERE ${filter} AND org_id = $1` and let the
    * registry own the status semantics.
+   *
+   * Accepts either the segment key (e.g. `"prompts"`) or the physical
+   * table name (e.g. `"prompt_collections"`) for simple entries.
+   * Exotic entries are looked up by their `key` only.
+   *
+   * Fails with `UnknownTableError` if the table isn't registered, or
+   * `ExoticReadFilterUnavailableError` if the table is an exotic entry
+   * whose adapter did not supply a `readFilter` — exotic tables with
+   * tombstones or overlays need dedicated read semantics; the registry
+   * refuses to fall back to the simple-table default in that case.
    */
   readonly readFilter: (
     table: string,
     mode: AtlasMode,
     alias: string,
-  ) => Effect.Effect<string, UnknownTableError, never>;
+  ) => Effect.Effect<string, UnknownTableError | ExoticReadFilterUnavailableError, never>;
 
   /**
    * One-round-trip fetch of every registered table's draft count.
-   * Emits a single UNION ALL query, zero-fills segments whose branch
-   * returned no rows, and returns the derived `ModeDraftCounts` shape.
+   * Emits a single UNION ALL query, zero-fills every registered segment,
+   * and returns the derived `ModeDraftCounts` shape.
+   *
+   * Requires `InternalDB` in the Effect context; `ContentModeRegistryLive`
+   * alone is insufficient — callers must also provide an `InternalDB` layer
+   * (production or test).
+   *
    * Wraps executor failures in `PublishPhaseError` with `phase: "count"`.
+   * Fails the same way if a row returns a `key` outside the registered
+   * segment set, or a non-finite / negative `n` — those indicate drift
+   * between the tuple and the UNION SQL and must not silently under-report.
    */
   readonly countAllDrafts: (
     orgId: string,
@@ -61,34 +94,18 @@ export class ContentModeRegistry extends Context.Tag("ContentModeRegistry")<
   ContentModeRegistryService
 >() {}
 
-function findEntry(table: string): ContentModeEntry | undefined {
-  for (const entry of CONTENT_MODE_TABLES) {
-    if (entry.key === table) return entry;
-    if (entry.kind === "simple" && "table" in entry && entry.table === table) {
-      return entry;
-    }
-  }
-  return undefined;
-}
-
 function defaultReadFilter(alias: string, mode: AtlasMode): string {
   return mode === "developer"
     ? `${alias}.status IN ('published', 'draft')`
     : `${alias}.status = 'published'`;
 }
 
-/** Shape of a simple entry's customizable fields — column names + table name. */
-type SimpleFields = {
-  readonly key: string;
-  readonly table?: string;
-  readonly orgColumn?: string;
-  readonly statusColumn?: string;
-};
-
 /** Collapse a simple entry to its resolved DB identifiers, applying defaults. */
-function resolveSimple(
-  entry: SimpleFields,
-): { readonly table: string; readonly orgCol: string; readonly statusCol: string } {
+function resolveSimple(entry: SimpleModeTable): {
+  readonly table: string;
+  readonly orgCol: string;
+  readonly statusCol: string;
+} {
   return {
     table: entry.table ?? entry.key,
     orgCol: entry.orgColumn ?? "org_id",
@@ -96,50 +113,14 @@ function resolveSimple(
   };
 }
 
-/**
- * SELECT clause that counts drafts for a simple status-lifecycle table.
- * Emitted for every `kind: "simple"` entry as one branch of the UNION.
- */
-function simpleCountSql(entry: SimpleFields, orgParam: string): string {
+/** SELECT branch that counts drafts for a simple status-lifecycle table. */
+function simpleCountSql(entry: SimpleModeTable, orgParam: string): string {
   const { table, orgCol, statusCol } = resolveSimple(entry);
   return `SELECT '${entry.key}' AS key, COUNT(*)::int AS n FROM ${table} WHERE ${orgCol} = ${orgParam} AND ${statusCol} = 'draft'`;
 }
 
-/** Every segment key contributed by a registered entry — used to zero-fill. */
-function allSegmentKeys(): readonly string[] {
-  const keys: string[] = [];
-  for (const entry of CONTENT_MODE_TABLES) {
-    if (entry.kind === "simple") {
-      keys.push(entry.key);
-    } else {
-      for (const seg of entry.countSegments) keys.push(seg.key);
-    }
-  }
-  return keys;
-}
-
-/** Fresh zero-filled counts object. */
-function zeroCounts(): DerivedCounts {
-  const base: Record<string, number> = {};
-  for (const k of allSegmentKeys()) base[k] = 0;
-  return base as DerivedCounts;
-}
-
-/** Compose every entry's count SQL into a single UNION ALL query. */
-function buildDraftCountsQuery(): string {
-  const branches: string[] = [];
-  for (const entry of CONTENT_MODE_TABLES) {
-    if (entry.kind === "simple") {
-      branches.push(simpleCountSql(entry, "$1"));
-    } else {
-      for (const seg of entry.countSegments) branches.push(seg.sql("$1"));
-    }
-  }
-  return branches.join("\nUNION ALL\n");
-}
-
 /** Default promote UPDATE for a simple status-lifecycle table. */
-function simplePromoteSql(entry: SimpleFields): string {
+function simplePromoteSql(entry: SimpleModeTable): string {
   const { table, orgCol, statusCol } = resolveSimple(entry);
   return `UPDATE ${table} SET ${statusCol} = 'published', updated_at = now()
           WHERE ${orgCol} = $1 AND ${statusCol} = 'draft'`;
@@ -147,7 +128,7 @@ function simplePromoteSql(entry: SimpleFields): string {
 
 /** Promote a single simple table inside the caller's tx, wrapping errors. */
 function promoteSimpleTable(
-  entry: SimpleFields,
+  entry: SimpleModeTable,
   tx: PoolClient,
   orgId: string,
 ): Effect.Effect<PromotionReport, PublishPhaseError, never> {
@@ -161,22 +142,136 @@ function promoteSimpleTable(
   });
 }
 
-function makeService(): ContentModeRegistryService {
-  const countsQuery = buildDraftCountsQuery();
+/**
+ * Build the registry service around a given table tuple. Production
+ * callers use `ContentModeRegistryLive` which binds `CONTENT_MODE_TABLES`;
+ * tests pass alternate tuples to cover dispatch branches the static
+ * production tuple does not currently exercise.
+ *
+ * Throws at construction if the tuple contains duplicate segment keys —
+ * a misconfiguration that would otherwise silently dedup entries in
+ * `zeroCounts` / `findEntry`.
+ */
+export function makeService(
+  tables: ReadonlyArray<ContentModeEntry>,
+): ContentModeRegistryService {
+  // Precompute lookup index and invariants once — the tuple is static
+  // over the lifetime of the service.
+  const byLookup = new Map<string, ContentModeEntry>();
+  const segmentKeys: string[] = [];
+  const seenSegments = new Set<string>();
+
+  for (const entry of tables) {
+    // Registration lookup: entries are findable by their `key`, and
+    // simple entries additionally by their physical `table` name.
+    if (byLookup.has(entry.key)) {
+      throw new Error(
+        `ContentModeRegistry: duplicate entry key "${entry.key}" in tables tuple`,
+      );
+    }
+    byLookup.set(entry.key, entry);
+    if (entry.kind === "simple" && entry.table && entry.table !== entry.key) {
+      if (byLookup.has(entry.table)) {
+        throw new Error(
+          `ContentModeRegistry: entry for "${entry.key}" overrides table alias "${entry.table}" that is already registered`,
+        );
+      }
+      byLookup.set(entry.table, entry);
+    }
+
+    // Segment-key collection: simple entries contribute their `key`;
+    // exotic entries contribute every `countSegments[].key`.
+    switch (entry.kind) {
+      case "simple":
+        if (seenSegments.has(entry.key)) {
+          throw new Error(
+            `ContentModeRegistry: duplicate draft-counts segment "${entry.key}"`,
+          );
+        }
+        seenSegments.add(entry.key);
+        segmentKeys.push(entry.key);
+        break;
+      case "exotic":
+        for (const seg of entry.countSegments) {
+          if (seenSegments.has(seg.key)) {
+            throw new Error(
+              `ContentModeRegistry: duplicate draft-counts segment "${seg.key}"`,
+            );
+          }
+          seenSegments.add(seg.key);
+          segmentKeys.push(seg.key);
+        }
+        break;
+      default: {
+        // Exhaustiveness guard: adding a new `kind` to `ContentModeEntry`
+        // must update this switch. The `never` assignment fails at compile
+        // time at every `switch (entry.kind)` site if that step is missed.
+        const _exhaustive: never = entry;
+        throw new Error(
+          `ContentModeRegistry: unhandled entry kind ${JSON.stringify(_exhaustive)}`,
+        );
+      }
+    }
+  }
+
+  // Compose the UNION ALL query once.
+  const countBranches: string[] = [];
+  for (const entry of tables) {
+    switch (entry.kind) {
+      case "simple":
+        countBranches.push(simpleCountSql(entry, "$1"));
+        break;
+      case "exotic":
+        for (const seg of entry.countSegments) countBranches.push(seg.sql("$1"));
+        break;
+      default: {
+        const _exhaustive: never = entry;
+        throw new Error(
+          `ContentModeRegistry: unhandled entry kind ${JSON.stringify(_exhaustive)}`,
+        );
+      }
+    }
+  }
+  const countsQuery = countBranches.join("\nUNION ALL\n");
+
+  /** Fresh zero-filled counts object — one entry per registered segment. */
+  const zeroCounts = (): DerivedCounts => {
+    const base: Record<string, number> = {};
+    for (const k of segmentKeys) base[k] = 0;
+    return base as DerivedCounts;
+  };
 
   return {
     readFilter: (table, mode, alias) =>
       Effect.gen(function* () {
-        const entry = findEntry(table);
+        const entry = byLookup.get(table);
         if (!entry) {
           return yield* Effect.fail(new UnknownTableError({ table }));
         }
-        if (entry.kind === "exotic" && entry.readFilter) {
-          return mode === "developer"
-            ? entry.readFilter.developerOverlay(alias)
-            : entry.readFilter.published(alias);
+        switch (entry.kind) {
+          case "simple":
+            return defaultReadFilter(alias, mode);
+          case "exotic": {
+            const exotic: ExoticModeAdapter = entry;
+            if (!exotic.readFilter) {
+              // Exotic tables need dedicated read semantics (tombstones,
+              // overlay CTEs). Refusing the fallback prevents serving
+              // wrong rows when a caller assumes the registry "just works".
+              return yield* Effect.fail(
+                new ExoticReadFilterUnavailableError({ table: entry.key }),
+              );
+            }
+            return mode === "developer"
+              ? exotic.readFilter.developerOverlay(alias)
+              : exotic.readFilter.published(alias);
+          }
+          default: {
+            const _exhaustive: never = entry;
+            throw new Error(
+              `ContentModeRegistry: unhandled entry kind ${JSON.stringify(_exhaustive)}`,
+            );
+          }
         }
-        return defaultReadFilter(alias, mode);
       }),
 
     countAllDrafts: (orgId) =>
@@ -185,17 +280,41 @@ function makeService(): ContentModeRegistryService {
         const rows = yield* Effect.tryPromise({
           try: () => db.query<{ key: string; n: number }>(countsQuery, [orgId]),
           catch: (cause) =>
-            new PublishPhaseError({
-              table: "(all)",
-              phase: "count",
-              cause,
-            }),
+            new PublishPhaseError({ table: "(all)", phase: "count", cause }),
         });
         const counts = zeroCounts();
         for (const { key, n } of rows) {
-          if (key in counts) {
-            (counts as Record<string, number>)[key] = Number(n) || 0;
+          // An unknown key here means the UNION SQL and the tuple drifted —
+          // silently dropping the row would under-report drafts to the admin
+          // banner and mask the drift. Fail with enough context to grep for.
+          if (!(key in counts)) {
+            return yield* Effect.fail(
+              new PublishPhaseError({
+                table: "(all)",
+                phase: "count",
+                cause: new Error(
+                  `ContentModeRegistry: unknown count segment "${String(key)}" — tuple and UNION SQL are out of sync`,
+                ),
+              }),
+            );
           }
+          // `pg` normally returns `COUNT(*)::int` as a JS number, but some
+          // drivers / pool configurations return numerics as strings.
+          // Coerce explicitly and reject NaN / negatives — `|| 0` would
+          // hide both.
+          const parsed = typeof n === "number" ? n : Number(n);
+          if (!Number.isFinite(parsed) || parsed < 0) {
+            return yield* Effect.fail(
+              new PublishPhaseError({
+                table: "(all)",
+                phase: "count",
+                cause: new Error(
+                  `ContentModeRegistry: non-numeric count "${String(n)}" for segment "${key}"`,
+                ),
+              }),
+            );
+          }
+          (counts as Record<string, number>)[key] = parsed;
         }
         return counts satisfies ModeDraftCounts;
       }),
@@ -203,19 +322,30 @@ function makeService(): ContentModeRegistryService {
     runPublishPhases: (tx, orgId) =>
       Effect.gen(function* () {
         const reports: PromotionReport[] = [];
-        for (const entry of CONTENT_MODE_TABLES) {
-          if (entry.kind === "simple") {
-            const report = yield* promoteSimpleTable(entry, tx, orgId);
-            reports.push(report);
-          } else {
-            const report = yield* entry.promote(tx, orgId);
-            reports.push(report);
+        for (const entry of tables) {
+          switch (entry.kind) {
+            case "simple": {
+              const report = yield* promoteSimpleTable(entry, tx, orgId);
+              reports.push(report);
+              break;
+            }
+            case "exotic": {
+              const report = yield* entry.promote(tx, orgId);
+              reports.push(report);
+              break;
+            }
+            default: {
+              const _exhaustive: never = entry;
+              throw new Error(
+                `ContentModeRegistry: unhandled entry kind ${JSON.stringify(_exhaustive)}`,
+              );
+            }
           }
         }
         return reports;
       }),
-  };
+  } satisfies ContentModeRegistryService;
 }
 
 export const ContentModeRegistryLive: Layer.Layer<ContentModeRegistry, never, never> =
-  Layer.succeed(ContentModeRegistry, makeService());
+  Layer.succeed(ContentModeRegistry, makeService(CONTENT_MODE_TABLES));

--- a/packages/api/src/lib/content-mode/registry.ts
+++ b/packages/api/src/lib/content-mode/registry.ts
@@ -1,0 +1,221 @@
+/**
+ * ContentModeRegistry — Effect service exposing the content-mode tuple
+ * via a small typed interface (#1515).
+ *
+ * The registration data is a static `as const` tuple in `tables.ts`;
+ * this file only builds the Effect.ts service wrapper so callers can
+ * `yield* ContentModeRegistry` from any Effect program. No runtime
+ * plugin/register API — the tuple is the single source of truth.
+ */
+
+import { Context, Effect, Layer } from "effect";
+import type { PoolClient } from "pg";
+import type { AtlasMode } from "@useatlas/types/auth";
+import type { ModeDraftCounts } from "@useatlas/types/mode";
+import { InternalDB } from "@atlas/api/lib/db/internal";
+import type { ContentModeEntry, PromotionReport } from "./port";
+import { PublishPhaseError, UnknownTableError } from "./port";
+import { CONTENT_MODE_TABLES } from "./tables";
+import type { InferDraftCounts } from "./infer";
+
+/** Zero-filled counts object used as the base for every countAllDrafts result. */
+type DerivedCounts = InferDraftCounts<typeof CONTENT_MODE_TABLES>;
+
+export interface ContentModeRegistryService {
+  /**
+   * Return a SQL fragment usable inside a WHERE clause. Callers
+   * typically write `WHERE ${filter} AND org_id = $1` and let the
+   * registry own the status semantics.
+   */
+  readonly readFilter: (
+    table: string,
+    mode: AtlasMode,
+    alias: string,
+  ) => Effect.Effect<string, UnknownTableError, never>;
+
+  /**
+   * One-round-trip fetch of every registered table's draft count.
+   * Emits a single UNION ALL query, zero-fills segments whose branch
+   * returned no rows, and returns the derived `ModeDraftCounts` shape.
+   * Wraps executor failures in `PublishPhaseError` with `phase: "count"`.
+   */
+  readonly countAllDrafts: (
+    orgId: string,
+  ) => Effect.Effect<ModeDraftCounts, PublishPhaseError, InternalDB>;
+
+  /**
+   * Promote drafts for every registered table using the caller's
+   * transactional `PoolClient`. Runs adapters in tuple order; stops
+   * on the first failure and surfaces a `PublishPhaseError` tagged
+   * with the offending table and phase. The registry never opens or
+   * commits its own transaction — caller owns `BEGIN`/`COMMIT`.
+   */
+  readonly runPublishPhases: (
+    tx: PoolClient,
+    orgId: string,
+  ) => Effect.Effect<ReadonlyArray<PromotionReport>, PublishPhaseError, never>;
+}
+
+export class ContentModeRegistry extends Context.Tag("ContentModeRegistry")<
+  ContentModeRegistry,
+  ContentModeRegistryService
+>() {}
+
+function findEntry(table: string): ContentModeEntry | undefined {
+  for (const entry of CONTENT_MODE_TABLES) {
+    if (entry.key === table) return entry;
+    if (entry.kind === "simple" && "table" in entry && entry.table === table) {
+      return entry;
+    }
+  }
+  return undefined;
+}
+
+function defaultReadFilter(alias: string, mode: AtlasMode): string {
+  return mode === "developer"
+    ? `${alias}.status IN ('published', 'draft')`
+    : `${alias}.status = 'published'`;
+}
+
+/** Shape of a simple entry's customizable fields — column names + table name. */
+type SimpleFields = {
+  readonly key: string;
+  readonly table?: string;
+  readonly orgColumn?: string;
+  readonly statusColumn?: string;
+};
+
+/** Collapse a simple entry to its resolved DB identifiers, applying defaults. */
+function resolveSimple(
+  entry: SimpleFields,
+): { readonly table: string; readonly orgCol: string; readonly statusCol: string } {
+  return {
+    table: entry.table ?? entry.key,
+    orgCol: entry.orgColumn ?? "org_id",
+    statusCol: entry.statusColumn ?? "status",
+  };
+}
+
+/**
+ * SELECT clause that counts drafts for a simple status-lifecycle table.
+ * Emitted for every `kind: "simple"` entry as one branch of the UNION.
+ */
+function simpleCountSql(entry: SimpleFields, orgParam: string): string {
+  const { table, orgCol, statusCol } = resolveSimple(entry);
+  return `SELECT '${entry.key}' AS key, COUNT(*)::int AS n FROM ${table} WHERE ${orgCol} = ${orgParam} AND ${statusCol} = 'draft'`;
+}
+
+/** Every segment key contributed by a registered entry — used to zero-fill. */
+function allSegmentKeys(): readonly string[] {
+  const keys: string[] = [];
+  for (const entry of CONTENT_MODE_TABLES) {
+    if (entry.kind === "simple") {
+      keys.push(entry.key);
+    } else {
+      for (const seg of entry.countSegments) keys.push(seg.key);
+    }
+  }
+  return keys;
+}
+
+/** Fresh zero-filled counts object. */
+function zeroCounts(): DerivedCounts {
+  const base: Record<string, number> = {};
+  for (const k of allSegmentKeys()) base[k] = 0;
+  return base as DerivedCounts;
+}
+
+/** Compose every entry's count SQL into a single UNION ALL query. */
+function buildDraftCountsQuery(): string {
+  const branches: string[] = [];
+  for (const entry of CONTENT_MODE_TABLES) {
+    if (entry.kind === "simple") {
+      branches.push(simpleCountSql(entry, "$1"));
+    } else {
+      for (const seg of entry.countSegments) branches.push(seg.sql("$1"));
+    }
+  }
+  return branches.join("\nUNION ALL\n");
+}
+
+/** Default promote UPDATE for a simple status-lifecycle table. */
+function simplePromoteSql(entry: SimpleFields): string {
+  const { table, orgCol, statusCol } = resolveSimple(entry);
+  return `UPDATE ${table} SET ${statusCol} = 'published', updated_at = now()
+          WHERE ${orgCol} = $1 AND ${statusCol} = 'draft'`;
+}
+
+/** Promote a single simple table inside the caller's tx, wrapping errors. */
+function promoteSimpleTable(
+  entry: SimpleFields,
+  tx: PoolClient,
+  orgId: string,
+): Effect.Effect<PromotionReport, PublishPhaseError, never> {
+  const { table } = resolveSimple(entry);
+  return Effect.tryPromise({
+    try: async () => {
+      const result = await tx.query(simplePromoteSql(entry), [orgId]);
+      return { table, promoted: result.rowCount ?? 0 } satisfies PromotionReport;
+    },
+    catch: (cause) => new PublishPhaseError({ table, phase: "promote", cause }),
+  });
+}
+
+function makeService(): ContentModeRegistryService {
+  const countsQuery = buildDraftCountsQuery();
+
+  return {
+    readFilter: (table, mode, alias) =>
+      Effect.gen(function* () {
+        const entry = findEntry(table);
+        if (!entry) {
+          return yield* Effect.fail(new UnknownTableError({ table }));
+        }
+        if (entry.kind === "exotic" && entry.readFilter) {
+          return mode === "developer"
+            ? entry.readFilter.developerOverlay(alias)
+            : entry.readFilter.published(alias);
+        }
+        return defaultReadFilter(alias, mode);
+      }),
+
+    countAllDrafts: (orgId) =>
+      Effect.gen(function* () {
+        const db = yield* InternalDB;
+        const rows = yield* Effect.tryPromise({
+          try: () => db.query<{ key: string; n: number }>(countsQuery, [orgId]),
+          catch: (cause) =>
+            new PublishPhaseError({
+              table: "(all)",
+              phase: "count",
+              cause,
+            }),
+        });
+        const counts = zeroCounts();
+        for (const { key, n } of rows) {
+          if (key in counts) {
+            (counts as Record<string, number>)[key] = Number(n) || 0;
+          }
+        }
+        return counts satisfies ModeDraftCounts;
+      }),
+
+    runPublishPhases: (tx, orgId) =>
+      Effect.gen(function* () {
+        const reports: PromotionReport[] = [];
+        for (const entry of CONTENT_MODE_TABLES) {
+          if (entry.kind === "simple") {
+            const report = yield* promoteSimpleTable(entry, tx, orgId);
+            reports.push(report);
+          } else {
+            const report = yield* entry.promote(tx, orgId);
+            reports.push(report);
+          }
+        }
+        return reports;
+      }),
+  };
+}
+
+export const ContentModeRegistryLive: Layer.Layer<ContentModeRegistry, never, never> =
+  Layer.succeed(ContentModeRegistry, makeService());

--- a/packages/api/src/lib/content-mode/tables.ts
+++ b/packages/api/src/lib/content-mode/tables.ts
@@ -1,0 +1,67 @@
+/**
+ * Registration tuple for mode-participating content tables (#1515).
+ *
+ * Adding a new simple content table is a one-line change at the end of
+ * this tuple: `{ kind: "simple", key: "dashboards" }` is enough — the
+ * physical table name, default UPDATE SQL, and default COUNT SQL are
+ * derived from the key, and the `ModeDraftCounts` wire type updates
+ * itself via `InferDraftCounts`.
+ *
+ * Order matters: `runPublishPhases` invokes adapters in tuple order
+ * inside the caller's transaction. Tables with foreign-key dependencies
+ * on later entries must be declared earlier.
+ *
+ * Exotic adapters wrap existing domain helpers; see `adapters/` for the
+ * semantic-entities adapter that composes `promoteDraftEntities` and
+ * the overlay CTE.
+ */
+
+import { Effect } from "effect";
+import type { PoolClient } from "pg";
+import type { ContentModeEntry, PromotionReport, PublishPhaseError } from "./port";
+
+/**
+ * Temporary stub for the semantic-entities exotic adapter. Phase 2 of
+ * #1515 replaces this with a composition of the existing
+ * `promoteDraftEntities` + `applyTombstones` helpers from
+ * `lib/semantic/entities.ts`. The stub succeeds with zero promoted so
+ * the publish path stays green until the migration lands.
+ */
+const promoteSemanticEntitiesStub = (
+  _tx: PoolClient,
+  _orgId: string,
+): Effect.Effect<PromotionReport, PublishPhaseError, never> =>
+  Effect.succeed({ table: "semantic_entities", promoted: 0 });
+
+export const CONTENT_MODE_TABLES = [
+  { kind: "simple", key: "connections" },
+  { kind: "simple", key: "prompts", table: "prompt_collections" },
+  { kind: "simple", key: "starterPrompts", table: "query_suggestions" },
+  {
+    kind: "exotic",
+    key: "semantic_entities",
+    countSegments: [
+      {
+        key: "entities",
+        sql: (p) =>
+          `SELECT 'entities' AS key, COUNT(*)::int AS n FROM semantic_entities WHERE org_id = ${p} AND status = 'draft'`,
+      },
+      {
+        key: "entityEdits",
+        sql: (p) =>
+          `SELECT 'entityEdits' AS key, COUNT(*)::int AS n FROM semantic_entities d
+           INNER JOIN semantic_entities pub
+             ON d.org_id = pub.org_id
+            AND d.name = pub.name
+            AND COALESCE(d.connection_id, '__default__') = COALESCE(pub.connection_id, '__default__')
+           WHERE d.org_id = ${p} AND d.status = 'draft' AND pub.status = 'published'`,
+      },
+      {
+        key: "entityDeletes",
+        sql: (p) =>
+          `SELECT 'entityDeletes' AS key, COUNT(*)::int AS n FROM semantic_entities WHERE org_id = ${p} AND status = 'draft_delete'`,
+      },
+    ],
+    promote: promoteSemanticEntitiesStub,
+  },
+] as const satisfies ReadonlyArray<ContentModeEntry>;

--- a/packages/api/src/lib/content-mode/tables.ts
+++ b/packages/api/src/lib/content-mode/tables.ts
@@ -11,28 +11,42 @@
  * inside the caller's transaction. Tables with foreign-key dependencies
  * on later entries must be declared earlier.
  *
- * Exotic adapters wrap existing domain helpers; see `adapters/` for the
- * semantic-entities adapter that composes `promoteDraftEntities` and
- * the overlay CTE.
+ * The `semantic_entities` entry is exotic — its promote path needs
+ * phase 2 of #1515 to compose `promoteDraftEntities` + `applyTombstones`
+ * from `lib/semantic/entities.ts`. Until then, `promoteSemanticEntitiesUnimplemented`
+ * fails loudly rather than succeeding silently so a premature wiring of
+ * `runPublishPhases` into `admin-publish.ts` goes red in tests.
  */
 
 import { Effect } from "effect";
 import type { PoolClient } from "pg";
-import type { ContentModeEntry, PromotionReport, PublishPhaseError } from "./port";
+import { PublishPhaseError, type ContentModeEntry, type PromotionReport } from "./port";
 
 /**
- * Temporary stub for the semantic-entities exotic adapter. Phase 2 of
- * #1515 replaces this with a composition of the existing
- * `promoteDraftEntities` + `applyTombstones` helpers from
- * `lib/semantic/entities.ts`. The stub succeeds with zero promoted so
- * the publish path stays green until the migration lands.
+ * Phase-2 placeholder for the exotic `semantic_entities` promote adapter.
+ *
+ * Fails with `PublishPhaseError` so any caller that wires `runPublishPhases`
+ * into `admin-publish.ts` before phase 2 lands sees a loud failure rather
+ * than a silent `{ promoted: 0 }` success.
  */
-const promoteSemanticEntitiesStub = (
+const promoteSemanticEntitiesUnimplemented = (
   _tx: PoolClient,
   _orgId: string,
 ): Effect.Effect<PromotionReport, PublishPhaseError, never> =>
-  Effect.succeed({ table: "semantic_entities", promoted: 0 });
+  Effect.fail(
+    new PublishPhaseError({
+      table: "semantic_entities",
+      phase: "promote",
+      cause: new Error(
+        "promoteSemanticEntitiesUnimplemented: phase 2 of #1515 has not shipped — " +
+          "do not wire ContentModeRegistry.runPublishPhases into admin-publish.ts yet",
+      ),
+    }),
+  );
 
+// `as const` is load-bearing: preserves key + kind literals for
+// InferDraftCounts; `satisfies` enforces the port shape without widening.
+// Do not collapse to one or the other.
 export const CONTENT_MODE_TABLES = [
   { kind: "simple", key: "connections" },
   { kind: "simple", key: "prompts", table: "prompt_collections" },
@@ -62,6 +76,6 @@ export const CONTENT_MODE_TABLES = [
           `SELECT 'entityDeletes' AS key, COUNT(*)::int AS n FROM semantic_entities WHERE org_id = ${p} AND status = 'draft_delete'`,
       },
     ],
-    promote: promoteSemanticEntitiesStub,
+    promote: promoteSemanticEntitiesUnimplemented,
   },
 ] as const satisfies ReadonlyArray<ContentModeEntry>;

--- a/packages/api/src/lib/effect/errors.ts
+++ b/packages/api/src/lib/effect/errors.ts
@@ -18,6 +18,22 @@
 
 import { Data } from "effect";
 
+// Content-mode errors live in `lib/content-mode/port.ts` so that module
+// stays self-contained and pure. They are folded into the `AtlasError`
+// union below so `classifyError` / `mapTaggedError` pick them up when
+// phase 2 of #1515 wires the registry into route handlers.
+import {
+  ExoticReadFilterUnavailableError,
+  PublishPhaseError,
+  UnknownTableError,
+} from "@atlas/api/lib/content-mode/port";
+
+export {
+  ExoticReadFilterUnavailableError,
+  PublishPhaseError,
+  UnknownTableError,
+} from "@atlas/api/lib/content-mode/port";
+
 // ── Utilities ──────────────────────────────────────────────────────
 
 /** Normalize unknown caught values to Error. Used in Effect.tryPromise catch clauses. */
@@ -199,7 +215,10 @@ export type AtlasError =
   | ActionTimeoutError
   | SchedulerTaskTimeoutError
   | SchedulerExecutionError
-  | DeliveryError;
+  | DeliveryError
+  | PublishPhaseError
+  | UnknownTableError
+  | ExoticReadFilterUnavailableError;
 
 /** Discriminant union of all known `_tag` values — derived from `AtlasError`. */
 export type AtlasErrorTag = AtlasError["_tag"];
@@ -233,6 +252,9 @@ export const ATLAS_ERROR_TAG_LIST = [
   "SchedulerTaskTimeoutError",
   "SchedulerExecutionError",
   "DeliveryError",
+  "PublishPhaseError",
+  "UnknownTableError",
+  "ExoticReadFilterUnavailableError",
 ] as const satisfies readonly AtlasErrorTag[];
 
 /** Compile-time check: every `AtlasErrorTag` must appear in the list. */

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -188,6 +188,31 @@ export function mapTaggedError(error: AtlasError): HttpErrorMapping {
       return { status: 500, code: "upstream_error", message: error.message };
     case "DeliveryError":
       return { status: 502, code: "upstream_error", message: error.message };
+
+    // ── Content Mode (#1515) ───────────────────────────────────
+    // Surfaced from `ContentModeRegistry`. Phase 1 has no route callers;
+    // these cases are wired in advance so phase 2 migrations don't leak
+    // as generic 500s. Keep messages generic — the `cause` on
+    // `PublishPhaseError` may wrap raw `pg` DatabaseError values containing
+    // parameters or constraint detail; correlate via `requestId` instead.
+    case "PublishPhaseError":
+      return {
+        status: 500,
+        code: "upstream_error",
+        message: `Publish phase "${error.phase}" failed for table "${error.table}"`,
+      };
+    case "UnknownTableError":
+      return {
+        status: 500,
+        code: "upstream_error",
+        message: `Unknown content-mode table "${error.table}"`,
+      };
+    case "ExoticReadFilterUnavailableError":
+      return {
+        status: 500,
+        code: "upstream_error",
+        message: `No read filter registered for exotic table "${error.table}"`,
+      };
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds `packages/api/src/lib/content-mode/` — static tuple of mode-participating tables (`connections`, `prompt_collections`, `query_suggestions`, `semantic_entities`), a type-level `InferDraftCounts` derivation, and an Effect `ContentModeRegistry` service with `readFilter` / `countAllDrafts` / `runPublishPhases`.
- Derived `ModeDraftCounts` is checked against the published `@useatlas/types/mode.ModeDraftCounts` via a compile-time equality assertion — drift in either direction fails type-check.
- New tagged errors `PublishPhaseError` and `UnknownTableError` (`Data.TaggedError`) for partial-failure reporting; slot into the existing `classifyError` / `mapTaggedError` pipeline (arch wins #14, #15) in phase 2 migrations.

## Scope
**Library only — no call sites migrated.** `mode.ts`, `admin-publish.ts`, `prompts/scoping.ts`, `admin-connections.ts`, and `admin-starter-prompts.ts` stay on the existing helpers. Phase 2 migrates each caller in its own PR.

Out of scope (per #1515 non-goals): demo-industry prompt scoping, connection archival cascade, plugin-registered content tables.

## Test plan
- [x] New boundary tests at `packages/api/src/lib/content-mode/__tests__/registry.test.ts` — 9 tests covering:
  - Type-level: `InferDraftCounts<typeof CONTENT_MODE_TABLES>` equals `ModeDraftCounts`
  - `readFilter` in published / developer mode for simple tables
  - `readFilter` on unknown table → `UnknownTableError`
  - `countAllDrafts` issues one UNION ALL and zero-fills missing segments
  - `countAllDrafts` wraps executor errors in `PublishPhaseError { phase: "count" }`
  - `runPublishPhases` invokes adapters in tuple order, returns `PromotionReport[]`
  - `runPublishPhases` stops on first failure, surfaces `PublishPhaseError { table, phase: "promote" }`
  - `runPublishPhases` never issues `BEGIN`/`COMMIT`/`ROLLBACK` — caller owns the transaction
- [x] Lint, type, syncpack, template drift all clean
- [x] Full `bun run test` passes on re-run (one DuckDB malloc flake — known #1145, cleared on retry)

## Follow-ups (separate PRs)
- Migrate `mode.ts` GET /api/v1/mode to `registry.countAllDrafts`
- Migrate `admin-publish.ts` phases 2–3 to `registry.runPublishPhases`
- Migrate `prompts/scoping.ts` `statusClauseFor` → `registry.readFilter`
- Migrate `admin-connections.ts` + `admin-starter-prompts.ts` read filters
- Replace the semantic-entities stub adapter with the real `promoteDraftEntities` + `applyTombstones` composition
- Add `PublishPhaseError` + `UnknownTableError` to `AtlasError` union in `lib/effect/errors.ts` when the first route-layer consumer lands

Closes #1515