### PR TITLE
fix(deploy): build @useatlas/sdk before packages/react in Railway Dockerfiles

### DIFF
--- a/deploy/api/Dockerfile
+++ b/deploy/api/Dockerfile
@@ -57,8 +57,11 @@ COPY . .
 COPY packages/cli/data/seeds/simple/semantic semantic
 COPY packages/cli/data/seeds/cybersec/semantic data/cybersec-semantic
 COPY packages/cli/data/seeds/ecommerce/semantic data/ecommerce-semantic
-# Build @useatlas/types first (exports point to dist/) then the react widget bundle
+# Build workspace deps whose exports point to dist/ in dependency order:
+# types → sdk → react. packages/react imports fetchStarterPrompts from
+# @useatlas/sdk, so sdk must be built before react's bundler resolves it.
 RUN cd packages/types && bun run build
+RUN cd packages/sdk && bun run build
 RUN cd packages/react && bun run build
 
 # --- nsjail build stage (parallel with builder) ---

--- a/deploy/web/Dockerfile
+++ b/deploy/web/Dockerfile
@@ -52,8 +52,11 @@ FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app ./
 COPY . .
-# Build workspace deps whose exports point to dist/ before the Next.js app
+# Build workspace deps whose exports point to dist/ in dependency order:
+# types → sdk → react → web. packages/react and packages/web both import
+# fetchStarterPrompts from @useatlas/sdk, so sdk must be built before them.
 RUN cd packages/types && bun run build
+RUN cd packages/sdk && bun run build
 RUN cd packages/react && bun run build
 # Bake build-time env vars into the client JS bundle
 ENV NEXT_PUBLIC_ATLAS_API_URL=https://api.useatlas.dev


### PR DESCRIPTION
## Summary
- Root cause: #1511 introduced `import { fetchStarterPrompts } from "@useatlas/sdk"` in `packages/react/src/hooks/use-starter-prompts-query.ts`, but `deploy/api/Dockerfile` and `deploy/web/Dockerfile` only built `packages/types` then `packages/react` — skipping `packages/sdk`. Railway builds for **api**, **api-eu**, **api-apac**, and **web** have all failed since that PR merged.
- Exact esbuild error from Railway build logs:
  ```
  ✘ [ERROR] Could not resolve "@useatlas/sdk"
      src/hooks/use-starter-prompts-query.ts:4:36
    The module "./dist/index.js" was not found on the file system:
      node_modules/@useatlas/sdk/package.json:14:16
  ```
- Fix: insert `RUN cd packages/sdk && bun run build` between `types` and `react` in both Dockerfiles. Build order is now `types → sdk → react → (api|web)`, matching the actual dependency graph.
- `deploy/api/Dockerfile` is shared by api, api-eu, and api-apac via their `railway.json` files, so one fix restores all four services.

## Test plan
- [x] Local build in the new order: `bun run build` in types, sdk, then react — all produce `dist/`. `packages/sdk/dist/index.js` and `packages/react/dist/index.js` exist after.
- [x] Lint / type / syncpack / template drift all clean
- [x] Confirmed `@useatlas/sdk` depends on `@useatlas/types` (already built first), so no further ordering changes needed
- [ ] Watch Railway deploy on merge for api / api-eu / api-apac / web → Success

Closes #1516.