### PR TITLE
refactor(content-mode): migrate mode.ts to registry.countAllDrafts (#1515 phase 2a)

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -7,6 +7,7 @@
     "./app": "./src/api/index.ts",
     "./lib/audit": "./src/lib/audit/index.ts",
     "./lib/audit/*": "./src/lib/audit/*.ts",
+    "./lib/content-mode": "./src/lib/content-mode/index.ts",
     "./lib/semantic": "./src/lib/semantic/index.ts",
     "./lib/semantic/expert": "./src/lib/semantic/expert/index.ts",
     "./lib/semantic/*": "./src/lib/semantic/*.ts",

--- a/packages/api/src/api/routes/__tests__/mode.test.ts
+++ b/packages/api/src/api/routes/__tests__/mode.test.ts
@@ -175,7 +175,11 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   createInternalDBTestLayer: makeMockInternalDBShimLayer,
   getInternalDB: () => ({ query: mockInternalQuery, connect: () => ({ query: mockInternalQuery, release: () => {} }), end: async () => {}, on: () => {} }),
   closeInternalDB: async () => {},
-  queryEffect: (_sql: string, _params?: unknown[]) => Effect.succeed([]),
+  queryEffect: (sql: string, params?: unknown[]) =>
+    Effect.tryPromise({
+      try: () => mockInternalQuery(sql, params),
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    }),
   migrateInternalDB: async () => {},
   loadSavedConnections: async () => 0,
   findPatternBySQL: async () => null,

--- a/packages/api/src/api/routes/__tests__/mode.test.ts
+++ b/packages/api/src/api/routes/__tests__/mode.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
-import { Effect } from "effect";
+import { Context, Effect, Layer } from "effect";
 
 // ---------------------------------------------------------------------------
 // Mocks — declared before importing the route
@@ -107,6 +107,10 @@ let draftFixture: DraftCountFixture = {
 };
 let demoActiveFixture = false;
 
+// ContentModeRegistry.countAllDrafts emits one UNION ALL query with column
+// aliases `key` / `n` (not `k` / `v` like the legacy hand-written SQL). The
+// mock returns registry-shaped rows when it sees a UNION ALL; legacy-shaped
+// rows are also supported for any remaining callers of internalQuery directly.
 const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<Record<string, unknown>[]>> = mock(
   async (sql: string) => {
     if (sql.includes("FROM connections") && sql.includes("'__demo__'")) {
@@ -114,21 +118,79 @@ const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<Recor
     }
     if (sql.includes("UNION ALL") && sql.includes("draft")) {
       return [
-        { k: "connections", v: draftFixture.connections },
-        { k: "entities", v: draftFixture.entities },
-        { k: "entityEdits", v: draftFixture.entityEdits },
-        { k: "entityDeletes", v: draftFixture.entityDeletes },
-        { k: "prompts", v: draftFixture.prompts },
-        { k: "starterPrompts", v: draftFixture.starterPrompts },
+        { key: "connections", n: draftFixture.connections },
+        { key: "entities", n: draftFixture.entities },
+        { key: "entityEdits", n: draftFixture.entityEdits },
+        { key: "entityDeletes", n: draftFixture.entityDeletes },
+        { key: "prompts", n: draftFixture.prompts },
+        { key: "starterPrompts", n: draftFixture.starterPrompts },
       ];
     }
     return [];
   },
 );
 
+// The content-mode registry yields `InternalDB` from Effect context. To keep
+// this test hermetic we preserve the real `InternalDB` Context.Tag identity
+// and route `query` / `execute` through the mocked module-level helpers.
+// Every other named export of `lib/db/internal` that either the route or
+// the registry might touch must appear here (CLAUDE.md: mock all exports).
+class MockInternalDB extends Context.Tag("InternalDB")<
+  MockInternalDB,
+  {
+    readonly sql: null;
+    query<T extends Record<string, unknown>>(sql: string, params?: unknown[]): Promise<T[]>;
+    execute(sql: string, params?: unknown[]): void;
+    readonly available: boolean;
+    readonly pool: null;
+  }
+>() {}
+
+const mockInternalExecute = mock((_sql: string, _params?: unknown[]) => {});
+
+function makeMockInternalDBShimLayer() {
+  return Layer.succeed(MockInternalDB, {
+    sql: null,
+    query: mockInternalQuery as <T extends Record<string, unknown>>(
+      sql: string,
+      params?: unknown[],
+    ) => Promise<T[]>,
+    execute: mockInternalExecute,
+    available: mockHasInternalDBValue,
+    pool: null,
+  });
+}
+
 mock.module("@atlas/api/lib/db/internal", () => ({
+  // Context.Tag: the registry imports `InternalDB` and yields it. Preserve
+  // a single class reference so both sides see the same tag identity.
+  InternalDB: MockInternalDB,
   hasInternalDB: mockHasInternalDB,
   internalQuery: mockInternalQuery,
+  internalExecute: mockInternalExecute,
+  makeInternalDBShimLayer: makeMockInternalDBShimLayer,
+  // Unused in these tests but must be present so other modules that import
+  // any of these names still resolve against the mocked module.
+  makeInternalDBLive: () => Layer.succeedContext(Context.empty()),
+  createInternalDBTestLayer: makeMockInternalDBShimLayer,
+  getInternalDB: () => ({ query: mockInternalQuery, connect: () => ({ query: mockInternalQuery, release: () => {} }), end: async () => {}, on: () => {} }),
+  closeInternalDB: async () => {},
+  queryEffect: (_sql: string, _params?: unknown[]) => Effect.succeed([]),
+  migrateInternalDB: async () => {},
+  loadSavedConnections: async () => 0,
+  findPatternBySQL: async () => null,
+  insertLearnedPattern: () => {},
+  insertSemanticAmendment: async () => {},
+  getPendingAmendmentCount: async () => 0,
+  getAutoApproveThreshold: () => 0.95,
+  getAutoApproveTypes: () => new Set<string>(),
+  getEncryptionKey: () => null,
+  encryptUrl: (v: string) => v,
+  decryptUrl: (v: string) => v,
+  isPlaintextUrl: () => true,
+  _resetEncryptionKeyCache: () => {},
+  _resetPool: () => {},
+  _resetCircuitBreaker: () => {},
 }));
 
 let demoIndustryFixture: string | undefined;

--- a/packages/api/src/api/routes/mode.ts
+++ b/packages/api/src/api/routes/mode.ts
@@ -29,7 +29,7 @@ import {
   RequestContext,
   AuthContext,
 } from "@atlas/api/lib/effect/services";
-import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import { getSettingAuto } from "@atlas/api/lib/settings";
 import { ErrorSchema } from "./shared-schemas";
 import { standardAuth, requestContext, type AuthEnv } from "./middleware";
@@ -124,11 +124,13 @@ mode.use("/", requestContext);
 
 mode.openapi(getModeRoute, async (c) => {
   // Deferred imports — see module header for rationale (#1524).
-  const [{ ContentModeRegistry, ContentModeRegistryLive }, { makeInternalDBShimLayer }] =
-    await Promise.all([
-      import("@atlas/api/lib/content-mode"),
-      import("@atlas/api/lib/db/internal"),
-    ]);
+  const [
+    { ContentModeRegistry, ContentModeRegistryLive },
+    { makeInternalDBShimLayer, queryEffect },
+  ] = await Promise.all([
+    import("@atlas/api/lib/content-mode"),
+    import("@atlas/api/lib/db/internal"),
+  ]);
   const modeRouteLayer = Layer.merge(ContentModeRegistryLive, makeInternalDBShimLayer());
 
   const program = Effect.gen(function* () {
@@ -156,13 +158,7 @@ mode.openapi(getModeRoute, async (c) => {
     const registry = yield* ContentModeRegistry;
 
     const [demoRows, counts] = yield* Effect.all(
-      [
-        Effect.tryPromise({
-          try: () => internalQuery<{ active: boolean }>(DEMO_ACTIVE_SQL, [orgId]),
-          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-        }),
-        registry.countAllDrafts(orgId),
-      ],
+      [queryEffect<{ active: boolean }>(DEMO_ACTIVE_SQL, [orgId]), registry.countAllDrafts(orgId)],
       { concurrency: "unbounded" },
     );
 

--- a/packages/api/src/api/routes/mode.ts
+++ b/packages/api/src/api/routes/mode.ts
@@ -8,10 +8,20 @@
  * Mode resolution happens upstream in the auth middleware (#1424). This route
  * just reads the resolved mode from RequestContext and adds the role + draft
  * metadata the UI needs to decide what to show.
+ *
+ * Draft counts are delegated to `ContentModeRegistry.countAllDrafts` (#1515).
+ * The UNION ALL query is derived from the static `CONTENT_MODE_TABLES` tuple;
+ * adding a new mode-participating table automatically extends this response.
+ *
+ * The registry + InternalDB-shim imports are deferred to handler time rather
+ * than module top level. Many tests in `packages/api/src/api/__tests__/` mock
+ * `@atlas/api/lib/db/internal` partially and would break on the transitive
+ * `InternalDB` import chain if we eagerly pulled in the registry. See #1524
+ * for the follow-up to tighten those mocks so this indirection can be removed.
  */
 
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
-import { Effect } from "effect";
+import { Effect, Layer } from "effect";
 import type { AtlasMode } from "@useatlas/types/auth";
 import type { ModeStatusResponse, ModeDraftCounts } from "@useatlas/types/mode";
 import { runEffect } from "@atlas/api/lib/effect/hono";
@@ -85,73 +95,12 @@ const getModeRoute = createRoute({
   },
 });
 
-// ---------------------------------------------------------------------------
-// Combined draft counts query
-//
-// One round-trip via UNION ALL keeps the response cheap. Each branch is a
-// single COUNT(*) over an indexed (org_id, status) pair, except entityEdits
-// which joins drafts to their published counterpart on the same key the
-// partial unique indexes use (org_id, name, COALESCE(connection_id, sentinel)).
-// ---------------------------------------------------------------------------
-
-const DRAFT_COUNTS_SQL = `
-  SELECT 'connections'::text   AS k, COUNT(*)::int AS v
-    FROM connections
-    WHERE org_id = $1 AND status = 'draft'
-  UNION ALL
-  SELECT 'entities'::text,            COUNT(*)::int
-    FROM semantic_entities
-    WHERE org_id = $1 AND status = 'draft'
-  UNION ALL
-  SELECT 'entityEdits'::text,         COUNT(*)::int
-    FROM semantic_entities d
-    INNER JOIN semantic_entities p
-      ON d.org_id = p.org_id
-     AND d.name = p.name
-     AND COALESCE(d.connection_id, '__default__') = COALESCE(p.connection_id, '__default__')
-    WHERE d.org_id = $1
-      AND d.status = 'draft'
-      AND p.status = 'published'
-  UNION ALL
-  SELECT 'entityDeletes'::text,       COUNT(*)::int
-    FROM semantic_entities
-    WHERE org_id = $1 AND status = 'draft_delete'
-  UNION ALL
-  SELECT 'prompts'::text,             COUNT(*)::int
-    FROM prompt_collections
-    WHERE org_id = $1 AND status = 'draft'
-  UNION ALL
-  SELECT 'starterPrompts'::text,      COUNT(*)::int
-    FROM query_suggestions
-    WHERE org_id = $1 AND status = 'draft'
-`;
-
 const DEMO_ACTIVE_SQL = `
   SELECT EXISTS (
     SELECT 1 FROM connections
     WHERE id = '__demo__' AND org_id = $1 AND status = 'published'
   ) AS active
 `;
-
-type DraftKey = keyof ModeDraftCounts;
-const ZERO_COUNTS: ModeDraftCounts = {
-  connections: 0,
-  entities: 0,
-  entityEdits: 0,
-  entityDeletes: 0,
-  prompts: 0,
-  starterPrompts: 0,
-};
-
-function rowsToCounts(rows: ReadonlyArray<{ k: string; v: number }>): ModeDraftCounts {
-  const counts: Record<DraftKey, number> = { ...ZERO_COUNTS };
-  for (const { k, v } of rows) {
-    if (k in counts) {
-      counts[k as DraftKey] = Number(v) || 0;
-    }
-  }
-  return counts;
-}
 
 function totalDrafts(counts: ModeDraftCounts): number {
   return (
@@ -174,6 +123,14 @@ mode.use("/", standardAuth);
 mode.use("/", requestContext);
 
 mode.openapi(getModeRoute, async (c) => {
+  // Deferred imports — see module header for rationale (#1524).
+  const [{ ContentModeRegistry, ContentModeRegistryLive }, { makeInternalDBShimLayer }] =
+    await Promise.all([
+      import("@atlas/api/lib/content-mode"),
+      import("@atlas/api/lib/db/internal"),
+    ]);
+  const modeRouteLayer = Layer.merge(ContentModeRegistryLive, makeInternalDBShimLayer());
+
   const program = Effect.gen(function* () {
     const { atlasMode } = yield* RequestContext;
     const { mode: authMode, user, orgId } = yield* AuthContext;
@@ -196,18 +153,20 @@ mode.openapi(getModeRoute, async (c) => {
     }
 
     const demoIndustry = getSettingAuto(DEMO_INDUSTRY_SETTING, orgId) ?? null;
+    const registry = yield* ContentModeRegistry;
 
-    const [demoRows, draftRows] = yield* Effect.tryPromise({
-      try: () =>
-        Promise.all([
-          internalQuery<{ active: boolean }>(DEMO_ACTIVE_SQL, [orgId]),
-          internalQuery<{ k: string; v: number }>(DRAFT_COUNTS_SQL, [orgId]),
-        ]),
-      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-    });
+    const [demoRows, counts] = yield* Effect.all(
+      [
+        Effect.tryPromise({
+          try: () => internalQuery<{ active: boolean }>(DEMO_ACTIVE_SQL, [orgId]),
+          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        }),
+        registry.countAllDrafts(orgId),
+      ],
+      { concurrency: "unbounded" },
+    );
 
     const demoConnectionActive = demoRows[0]?.active === true;
-    const counts = rowsToCounts(draftRows);
     const hasDrafts = totalDrafts(counts) > 0;
 
     return {
@@ -218,7 +177,7 @@ mode.openapi(getModeRoute, async (c) => {
       hasDrafts,
       draftCounts: hasDrafts ? counts : null,
     } satisfies ModeStatusResponse;
-  });
+  }).pipe(Effect.provide(modeRouteLayer));
 
   const body = await runEffect(c, program, { label: "fetch mode status" });
   return c.json(body, 200);

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -299,6 +299,40 @@ export function makeInternalDBLive(): Layer.Layer<InternalDB> {
   );
 }
 
+/**
+ * Build an `InternalDB` Layer backed by the module-level `internalQuery` /
+ * `internalExecute` helpers rather than by its own pg.Pool.
+ *
+ * The production `makeInternalDBLive()` creates a pool inside an Effect
+ * Scope. Route handlers today don't have access to the AppLayer's
+ * `ManagedRuntime`, so they can't yield Effect services that require
+ * `InternalDB` (e.g. `ContentModeRegistry.countAllDrafts`). This shim
+ * lets a route provide `InternalDB` to its own Effect program via
+ * `Layer.provide` without opening a second pool — the module-level
+ * `_pool` is shared with the AppLayer's live InternalDB (set during
+ * `makeInternalDBLive` construction).
+ *
+ * Use only from route handlers that need to `.pipe(Effect.provide(...))`
+ * a content-mode or similar service inline. Do not use in AppLayer
+ * composition — `makeInternalDBLive` is the source of truth there.
+ */
+export function makeInternalDBShimLayer(): Layer.Layer<InternalDB> {
+  return Layer.succeed(InternalDB, {
+    // `sql` is null in the shim — tagged-template SqlClient callers must
+    // use the real AppLayer InternalDB (via ManagedRuntime). Routes that
+    // need SqlClient access shouldn't be using this shim.
+    sql: null,
+    query: internalQuery,
+    execute: internalExecute,
+    get available() {
+      return hasInternalDB();
+    },
+    get pool() {
+      return _pool;
+    },
+  } satisfies InternalDBShape);
+}
+
 /** Create a test Layer for InternalDB. */
 export function createInternalDBTestLayer(
   partial: Partial<InternalDBShape> = {},

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -196,10 +196,17 @@ export function mapTaggedError(error: AtlasError): HttpErrorMapping {
     // `PublishPhaseError` may wrap raw `pg` DatabaseError values containing
     // parameters or constraint detail; correlate via `requestId` instead.
     case "PublishPhaseError":
+      // `phase: "count"` surfaces from read endpoints (e.g. GET /api/v1/mode
+      // via `ContentModeRegistry.countAllDrafts`) where "publish" in the
+      // user-visible message would be misleading. Promote and tombstone
+      // phases retain the publish-framed message.
       return {
         status: 500,
         code: "upstream_error",
-        message: `Publish phase "${error.phase}" failed for table "${error.table}"`,
+        message:
+          error.phase === "count"
+            ? "Failed to count pending drafts"
+            : `Publish phase "${error.phase}" failed for table "${error.table}"`,
       };
     case "UnknownTableError":
       return {


### PR DESCRIPTION
## Summary
- Replaces the hand-written `DRAFT_COUNTS_SQL` + `rowsToCounts` in `mode.ts` with `ContentModeRegistry.countAllDrafts` — the UNION ALL query is now derived from the static `CONTENT_MODE_TABLES` tuple
- Adds `makeInternalDBShimLayer()` in `lib/db/internal.ts` for route handlers that need to provide `InternalDB` to Effect programs without opening a second pg.Pool
- Adds `@atlas/api/lib/content-mode` to package exports

## Scope
Phase 2a of #1515. First of 5 caller migrations — each in its own PR per the phase 1 plan so each migration is reviewed against stable tests.

## Deferred imports workaround (#1524)
The registry + shim imports are lazy-loaded inside the handler rather than at module top. ~20 tests in `packages/api/src/api/__tests__/` partially mock `@atlas/api/lib/db/internal` without including the `InternalDB` Context.Tag (violates CLAUDE.md "mock all exports"). Eagerly pulling the registry through the API app module graph would crash those tests at import time. Filed #1524 as the follow-up to tighten those mocks — once it lands, the deferred imports in `mode.ts` get promoted back to module top.

## Test plan
- [x] `bun test packages/api/src/api/routes/__tests__/mode.test.ts` — 22/22 pass
- [x] `bun run test packages/api` — 237/237 files green
- [x] `bun run type` clean
- [x] `bun run lint` clean
- [ ] Manual smoke: `/api/v1/mode` returns the same response shape and counts

## Follow-ups
- #1520 phase 2b — prompts/scoping.ts → readFilter
- #1521 phase 2c — admin-connections + admin-starter-prompts → readFilter
- #1522 phase 2d — replace semantic_entities stub with real adapter
- #1523 phase 2e — admin-publish.ts → runPublishPhases
- #1524 — test-mock hygiene (unblocks module-top imports for later phase 2 PRs)

Closes #1519