### PR TITLE
chore(tests): tighten partial mocks of @atlas/api/lib/db/internal (#1524)

### DIFF
--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -23,13 +23,56 @@
  */
 
 import { mock, type Mock } from "bun:test";
-import { Effect } from "effect";
+import { Context, Effect, Layer } from "effect";
 import {
   createConnectionMock,
   type ConnectionMockOverrides,
 } from "./connection";
 import * as fs from "fs";
 import * as path from "path";
+
+/**
+ * Mock `InternalDB` Context.Tag — identity preserved for tests that load
+ * modules (e.g. `ContentModeRegistry`) which `yield* InternalDB` from
+ * Effect context. The tag is declared here so the factory can hand the
+ * same class reference to both the mock and any test-local layer
+ * provision; the real tag from `lib/db/internal.ts` is replaced wholesale
+ * when `mock.module` runs.
+ */
+export class MockInternalDB extends Context.Tag("InternalDB")<
+  MockInternalDB,
+  {
+    readonly sql: null;
+    query<T extends Record<string, unknown>>(sql: string, params?: unknown[]): Promise<T[]>;
+    execute(sql: string, params?: unknown[]): void;
+    readonly available: boolean;
+    readonly pool: null;
+  }
+>() {}
+
+/**
+ * Build a test InternalDB shim layer that routes Effect-context `query`
+ * calls through the caller's `internalQuery` mock. Exported for
+ * standalone test mocks that don't use `createApiTestMocks` but still
+ * need to satisfy the `InternalDB` tag (e.g. for routes that yield
+ * `ContentModeRegistry`).
+ */
+export function makeMockInternalDBShimLayer(
+  internalQueryMock: (sql: string, params?: unknown[]) => Promise<unknown[]>,
+  options?: { available?: boolean },
+) {
+  return Layer.succeed(MockInternalDB, {
+    sql: null,
+    query: ((sql: string, params?: unknown[]) =>
+      internalQueryMock(sql, params)) as <T extends Record<string, unknown>>(
+      sql: string,
+      params?: unknown[],
+    ) => Promise<T[]>,
+    execute: () => {},
+    available: options?.available ?? true,
+    pool: null,
+  });
+}
 
 /**
  * Wraps a Promise-returning `internalQuery` mock as an `Effect` so tests
@@ -231,6 +274,22 @@ export function createApiTestMocks(
   const mockInternalExecute: Mock<AnyFn> = mock(() => {});
 
   const internalDefaults: Record<string, unknown> = {
+    // Context.Tag and shim-layer factory — see MockInternalDB above.
+    // Tests that exercise routes using `ContentModeRegistry` (e.g.
+    // `GET /api/v1/mode`) need both so `yield* InternalDB` inside
+    // `countAllDrafts` resolves against the mocked module.
+    InternalDB: MockInternalDB,
+    makeInternalDBShimLayer: () =>
+      Layer.succeed(MockInternalDB, {
+        sql: null,
+        query: mockInternalQuery as <T extends Record<string, unknown>>(
+          sql: string,
+          params?: unknown[],
+        ) => Promise<T[]>,
+        execute: mockInternalExecute,
+        available: _hasInternalDB,
+        pool: null,
+      }),
     hasInternalDB: () => _hasInternalDB,
     internalQuery: mockInternalQuery,
     queryEffect: (sql: string, params?: unknown[]) =>

--- a/packages/api/src/api/__tests__/admin-invitations.test.ts
+++ b/packages/api/src/api/__tests__/admin-invitations.test.ts
@@ -14,7 +14,11 @@ import {
   type Mock,
 } from "bun:test";
 import { createConnectionMock } from "@atlas/api/testing/connection";
-import { makeQueryEffectMock } from "@atlas/api/testing/api-test-mocks";
+import {
+  makeQueryEffectMock,
+  MockInternalDB,
+  makeMockInternalDBShimLayer,
+} from "@atlas/api/testing/api-test-mocks";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -112,6 +116,9 @@ const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unkno
 );
 
 mock.module("@atlas/api/lib/db/internal", () => ({
+  InternalDB: MockInternalDB,
+  makeInternalDBShimLayer: () =>
+    makeMockInternalDBShimLayer(mockInternalQuery, { available: mockHasInternalDB }),
   hasInternalDB: () => mockHasInternalDB,
   internalQuery: mockInternalQuery,
   queryEffect: makeQueryEffectMock(mockInternalQuery),

--- a/packages/api/src/api/__tests__/admin-password.test.ts
+++ b/packages/api/src/api/__tests__/admin-password.test.ts
@@ -7,7 +7,11 @@
  */
 
 import { createConnectionMock } from "@atlas/api/testing/connection";
-import { makeQueryEffectMock } from "@atlas/api/testing/api-test-mocks";
+import {
+  makeQueryEffectMock,
+  MockInternalDB,
+  makeMockInternalDBShimLayer,
+} from "@atlas/api/testing/api-test-mocks";
 import {
   describe,
   it,
@@ -70,6 +74,9 @@ const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unkno
 );
 
 mock.module("@atlas/api/lib/db/internal", () => ({
+  InternalDB: MockInternalDB,
+  makeInternalDBShimLayer: () =>
+    makeMockInternalDBShimLayer(mockInternalQuery, { available: mockHasInternalDB }),
   hasInternalDB: () => mockHasInternalDB,
   internalQuery: mockInternalQuery,
   queryEffect: makeQueryEffectMock(mockInternalQuery),

--- a/packages/api/src/api/__tests__/admin-usage.test.ts
+++ b/packages/api/src/api/__tests__/admin-usage.test.ts
@@ -5,7 +5,11 @@
  */
 
 import { createConnectionMock } from "@atlas/api/testing/connection";
-import { makeQueryEffectMock } from "@atlas/api/testing/api-test-mocks";
+import {
+  makeQueryEffectMock,
+  MockInternalDB,
+  makeMockInternalDBShimLayer,
+} from "@atlas/api/testing/api-test-mocks";
 import {
   describe,
   it,
@@ -96,6 +100,9 @@ let mockHasInternalDB = true;
 const mockInternalQueryUsage: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(() => Promise.resolve([]));
 
 mock.module("@atlas/api/lib/db/internal", () => ({
+  InternalDB: MockInternalDB,
+  makeInternalDBShimLayer: () =>
+    makeMockInternalDBShimLayer(mockInternalQueryUsage, { available: mockHasInternalDB }),
   hasInternalDB: () => mockHasInternalDB,
   internalQuery: mockInternalQueryUsage,
   queryEffect: makeQueryEffectMock(mockInternalQueryUsage),

--- a/packages/api/src/api/__tests__/admin-workspace.test.ts
+++ b/packages/api/src/api/__tests__/admin-workspace.test.ts
@@ -6,7 +6,11 @@
  */
 
 import { createConnectionMock } from "@atlas/api/testing/connection";
-import { makeQueryEffectMock } from "@atlas/api/testing/api-test-mocks";
+import {
+  makeQueryEffectMock,
+  MockInternalDB,
+  makeMockInternalDBShimLayer,
+} from "@atlas/api/testing/api-test-mocks";
 import {
   describe,
   it,
@@ -148,6 +152,9 @@ const mockGetWorkspaceHealthSummary: Mock<(orgId: string) => Promise<unknown>> =
 );
 
 mock.module("@atlas/api/lib/db/internal", () => ({
+  InternalDB: MockInternalDB,
+  makeInternalDBShimLayer: () =>
+    makeMockInternalDBShimLayer(mockInternalQuery, { available: mockHasInternalDB }),
   hasInternalDB: () => mockHasInternalDB,
   internalQuery: mockInternalQuery,
   queryEffect: makeQueryEffectMock(mockInternalQuery),

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -8,7 +8,11 @@
  */
 
 import { createConnectionMock } from "@atlas/api/testing/connection";
-import { makeQueryEffectMock } from "@atlas/api/testing/api-test-mocks";
+import {
+  makeQueryEffectMock,
+  MockInternalDB,
+  makeMockInternalDBShimLayer,
+} from "@atlas/api/testing/api-test-mocks";
 import {
   describe,
   it,
@@ -208,6 +212,9 @@ const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unkno
 );
 
 mock.module("@atlas/api/lib/db/internal", () => ({
+  InternalDB: MockInternalDB,
+  makeInternalDBShimLayer: () =>
+    makeMockInternalDBShimLayer(mockInternalQuery, { available: mockHasInternalDB }),
   hasInternalDB: () => mockHasInternalDB,
   internalQuery: mockInternalQuery,
   queryEffect: makeQueryEffectMock(mockInternalQuery),

--- a/packages/api/src/api/__tests__/semantic.test.ts
+++ b/packages/api/src/api/__tests__/semantic.test.ts
@@ -15,7 +15,12 @@ import {
   mock,
   type Mock,
 } from "bun:test";
+import { Effect } from "effect";
 import { createConnectionMock } from "@atlas/api/testing/connection";
+import {
+  MockInternalDB,
+  makeMockInternalDBShimLayer,
+} from "@atlas/api/testing/api-test-mocks";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -145,8 +150,12 @@ mock.module("@atlas/api/lib/semantic", () => ({
 }));
 
 mock.module("@atlas/api/lib/db/internal", () => ({
+  InternalDB: MockInternalDB,
+  makeInternalDBShimLayer: () =>
+    makeMockInternalDBShimLayer(() => Promise.resolve([]), { available: false }),
   hasInternalDB: () => false,
   internalQuery: mock(() => Promise.resolve([])),
+  queryEffect: mock(() => Effect.succeed([])),
   internalExecute: mock(() => {}),
   getInternalDB: mock(() => ({})),
   closeInternalDB: mock(async () => {}),

--- a/packages/api/src/api/routes/__tests__/mode.test.ts
+++ b/packages/api/src/api/routes/__tests__/mode.test.ts
@@ -13,6 +13,10 @@
 
 import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
 import { Context, Effect, Layer } from "effect";
+import {
+  MockInternalDB,
+  makeMockInternalDBShimLayer,
+} from "@atlas/api/testing/api-test-mocks";
 
 // ---------------------------------------------------------------------------
 // Mocks — declared before importing the route
@@ -130,49 +134,24 @@ const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<Recor
   },
 );
 
-// The content-mode registry yields `InternalDB` from Effect context. To keep
-// this test hermetic we preserve the real `InternalDB` Context.Tag identity
-// and route `query` / `execute` through the mocked module-level helpers.
-// Every other named export of `lib/db/internal` that either the route or
-// the registry might touch must appear here (CLAUDE.md: mock all exports).
-class MockInternalDB extends Context.Tag("InternalDB")<
-  MockInternalDB,
-  {
-    readonly sql: null;
-    query<T extends Record<string, unknown>>(sql: string, params?: unknown[]): Promise<T[]>;
-    execute(sql: string, params?: unknown[]): void;
-    readonly available: boolean;
-    readonly pool: null;
-  }
->() {}
-
 const mockInternalExecute = mock((_sql: string, _params?: unknown[]) => {});
 
-function makeMockInternalDBShimLayer() {
-  return Layer.succeed(MockInternalDB, {
-    sql: null,
-    query: mockInternalQuery as <T extends Record<string, unknown>>(
-      sql: string,
-      params?: unknown[],
-    ) => Promise<T[]>,
-    execute: mockInternalExecute,
-    available: mockHasInternalDBValue,
-    pool: null,
-  });
-}
-
+// Use the shared `MockInternalDB` tag + shim-layer factory so the tag
+// identity matches whatever `ContentModeRegistry` imports transitively.
+// `makeMockInternalDBShimLayer` routes query calls through mockInternalQuery
+// so the test fixtures (demo state + draft counts) still drive behavior.
 mock.module("@atlas/api/lib/db/internal", () => ({
-  // Context.Tag: the registry imports `InternalDB` and yields it. Preserve
-  // a single class reference so both sides see the same tag identity.
   InternalDB: MockInternalDB,
   hasInternalDB: mockHasInternalDB,
   internalQuery: mockInternalQuery,
   internalExecute: mockInternalExecute,
-  makeInternalDBShimLayer: makeMockInternalDBShimLayer,
-  // Unused in these tests but must be present so other modules that import
-  // any of these names still resolve against the mocked module.
+  makeInternalDBShimLayer: () =>
+    makeMockInternalDBShimLayer(mockInternalQuery, { available: mockHasInternalDBValue }),
+  // Other named exports — present so any module that imports them against
+  // this mock still resolves (CLAUDE.md: mock all exports).
   makeInternalDBLive: () => Layer.succeedContext(Context.empty()),
-  createInternalDBTestLayer: makeMockInternalDBShimLayer,
+  createInternalDBTestLayer: () =>
+    makeMockInternalDBShimLayer(mockInternalQuery, { available: mockHasInternalDBValue }),
   getInternalDB: () => ({ query: mockInternalQuery, connect: () => ({ query: mockInternalQuery, release: () => {} }), end: async () => {}, on: () => {} }),
   closeInternalDB: async () => {},
   queryEffect: (sql: string, params?: unknown[]) =>

--- a/packages/api/src/api/routes/mode.ts
+++ b/packages/api/src/api/routes/mode.ts
@@ -12,12 +12,6 @@
  * Draft counts are delegated to `ContentModeRegistry.countAllDrafts` (#1515).
  * The UNION ALL query is derived from the static `CONTENT_MODE_TABLES` tuple;
  * adding a new mode-participating table automatically extends this response.
- *
- * The registry + InternalDB-shim imports are deferred to handler time rather
- * than module top level. Many tests in `packages/api/src/api/__tests__/` mock
- * `@atlas/api/lib/db/internal` partially and would break on the transitive
- * `InternalDB` import chain if we eagerly pulled in the registry. See #1524
- * for the follow-up to tighten those mocks so this indirection can be removed.
  */
 
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
@@ -29,7 +23,15 @@ import {
   RequestContext,
   AuthContext,
 } from "@atlas/api/lib/effect/services";
-import { hasInternalDB } from "@atlas/api/lib/db/internal";
+import {
+  hasInternalDB,
+  makeInternalDBShimLayer,
+  queryEffect,
+} from "@atlas/api/lib/db/internal";
+import {
+  ContentModeRegistry,
+  ContentModeRegistryLive,
+} from "@atlas/api/lib/content-mode";
 import { getSettingAuto } from "@atlas/api/lib/settings";
 import { ErrorSchema } from "./shared-schemas";
 import { standardAuth, requestContext, type AuthEnv } from "./middleware";
@@ -122,17 +124,9 @@ const mode = new OpenAPIHono<AuthEnv>();
 mode.use("/", standardAuth);
 mode.use("/", requestContext);
 
-mode.openapi(getModeRoute, async (c) => {
-  // Deferred imports — see module header for rationale (#1524).
-  const [
-    { ContentModeRegistry, ContentModeRegistryLive },
-    { makeInternalDBShimLayer, queryEffect },
-  ] = await Promise.all([
-    import("@atlas/api/lib/content-mode"),
-    import("@atlas/api/lib/db/internal"),
-  ]);
-  const modeRouteLayer = Layer.merge(ContentModeRegistryLive, makeInternalDBShimLayer());
+const modeRouteLayer = Layer.merge(ContentModeRegistryLive, makeInternalDBShimLayer());
 
+mode.openapi(getModeRoute, async (c) => {
   const program = Effect.gen(function* () {
     const { atlasMode } = yield* RequestContext;
     const { mode: authMode, user, orgId } = yield* AuthContext;


### PR DESCRIPTION
## Summary
- Unblocks phase 2 of #1515 (ContentModeRegistry caller migrations) by fixing the test-mock hygiene issue identified in #1525
- Adds `MockInternalDB` Context.Tag + `makeMockInternalDBShimLayer` to the shared factory; exports both
- Patches 6 standalone partial mocks that load the API app transitively
- Removes the lazy-import workaround from \`mode.ts\` — \`ContentModeRegistryLive\` + \`makeInternalDBShimLayer\` + \`queryEffect\` now imported at module top

## Context
When phase 2a (#1525) migrated \`mode.ts\` to use \`ContentModeRegistry.countAllDrafts\`, the registry's top-level \`import { InternalDB } from "@atlas/api/lib/db/internal"\` cascaded through the API app's module graph. Tests that partially mocked \`lib/db/internal\` without \`InternalDB\` failed at import time with \`SyntaxError: Export named 'InternalDB' not found\`. Phase 2a worked around it with deferred \`await import(...)\` in the handler. This PR restores module-top imports so subsequent phase 2 migrations don't need the same workaround.

## Test plan
- [x] \`bun run test packages/api\` → 237/237 files green (one CLI DuckDB flake is known #1145)
- [x] \`bun run type\` clean
- [x] \`bun run lint\` clean

## Follow-ups unblocked
- #1520 phase 2b — prompts/scoping.ts
- #1521 phase 2c — admin-connections + admin-starter-prompts
- #1522 phase 2d — semantic_entities adapter
- #1523 phase 2e — admin-publish.ts

Closes #1524