### PR TITLE
refactor(content-mode): migrate prompts/scoping.ts to registry.readFilter (#1515 phase 2b)

### DIFF
--- a/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
@@ -17,7 +17,11 @@ import {
   type Mock,
 } from "bun:test";
 import { createConnectionMock } from "@atlas/api/testing/connection";
-import { makeQueryEffectMock } from "@atlas/api/testing/api-test-mocks";
+import {
+  makeQueryEffectMock,
+  MockInternalDB,
+  makeMockInternalDBShimLayer,
+} from "@atlas/api/testing/api-test-mocks";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -105,6 +109,9 @@ const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unkno
 );
 
 mock.module("@atlas/api/lib/db/internal", () => ({
+  InternalDB: MockInternalDB,
+  makeInternalDBShimLayer: () =>
+    makeMockInternalDBShimLayer(mockInternalQuery, { available: mockHasInternalDB }),
   hasInternalDB: () => mockHasInternalDB,
   internalQuery: mockInternalQuery,
   queryEffect: makeQueryEffectMock(mockInternalQuery),

--- a/packages/api/src/api/__tests__/admin-integrations.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations.test.ts
@@ -14,7 +14,11 @@ import {
   type Mock,
 } from "bun:test";
 import { createConnectionMock } from "@atlas/api/testing/connection";
-import { makeQueryEffectMock } from "@atlas/api/testing/api-test-mocks";
+import {
+  makeQueryEffectMock,
+  MockInternalDB,
+  makeMockInternalDBShimLayer,
+} from "@atlas/api/testing/api-test-mocks";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -102,6 +106,9 @@ const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unkno
 );
 
 mock.module("@atlas/api/lib/db/internal", () => ({
+  InternalDB: MockInternalDB,
+  makeInternalDBShimLayer: () =>
+    makeMockInternalDBShimLayer(mockInternalQuery, { available: mockHasInternalDB }),
   hasInternalDB: () => mockHasInternalDB,
   internalQuery: mockInternalQuery,
   queryEffect: makeQueryEffectMock(mockInternalQuery),

--- a/packages/api/src/api/__tests__/prompts.test.ts
+++ b/packages/api/src/api/__tests__/prompts.test.ts
@@ -264,8 +264,8 @@ describe("user-facing prompt routes", () => {
         expect(listCall).toBeDefined();
         const sql = listCall![0] as string;
         expect(sql).toContain("status = 'published'");
-        expect(sql).toContain("is_builtin = true AND industry = $2");
-        expect(sql).toContain("is_builtin = false AND org_id = $1");
+        expect(sql).toContain("pc.is_builtin = true AND pc.industry = $2");
+        expect(sql).toContain("pc.is_builtin = false AND pc.org_id = $1");
         expect(listCall![1]).toEqual(["org-1", "cybersecurity"]);
       });
 
@@ -303,7 +303,7 @@ describe("user-facing prompt routes", () => {
         const sql = findListCall()![0] as string;
         expect(sql).toContain("status IN ('published', 'draft')");
         expect(sql).not.toContain("archived");
-        expect(sql).toContain("is_builtin = true AND industry = $2");
+        expect(sql).toContain("pc.is_builtin = true AND pc.industry = $2");
       });
 
       it("developer + no demo: draft custom collections only (built-ins hidden)", async () => {
@@ -466,8 +466,8 @@ describe("admin prompt routes", () => {
         const listCall = findListCall();
         expect(listCall).toBeDefined();
         const sql = listCall![0] as string;
-        expect(sql).toContain("is_builtin = true AND industry = $2");
-        expect(sql).toContain("is_builtin = false AND org_id = $1");
+        expect(sql).toContain("pc.is_builtin = true AND pc.industry = $2");
+        expect(sql).toContain("pc.is_builtin = false AND pc.org_id = $1");
         expect(listCall![1]).toEqual(["org-1", "cybersecurity"]);
       });
 
@@ -490,7 +490,7 @@ describe("admin prompt routes", () => {
 
         const sql = findListCall()![0] as string;
         expect(sql).toContain("status IN ('published', 'draft')");
-        expect(sql).toContain("is_builtin = true AND industry = $2");
+        expect(sql).toContain("pc.is_builtin = true AND pc.industry = $2");
       });
     });
   });

--- a/packages/api/src/lib/auth/__tests__/sessions.test.ts
+++ b/packages/api/src/lib/auth/__tests__/sessions.test.ts
@@ -14,7 +14,11 @@ import {
   type Mock,
 } from "bun:test";
 import { createConnectionMock } from "@atlas/api/testing/connection";
-import { makeQueryEffectMock } from "@atlas/api/testing/api-test-mocks";
+import {
+  makeQueryEffectMock,
+  MockInternalDB,
+  makeMockInternalDBShimLayer,
+} from "@atlas/api/testing/api-test-mocks";
 
 // --- Mocks (before any import that touches the modules) ---
 
@@ -96,6 +100,9 @@ const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unkno
 );
 
 mock.module("@atlas/api/lib/db/internal", () => ({
+  InternalDB: MockInternalDB,
+  makeInternalDBShimLayer: () =>
+    makeMockInternalDBShimLayer(mockInternalQuery, { available: true }),
   hasInternalDB: () => true,
   internalQuery: mockInternalQuery,
   queryEffect: makeQueryEffectMock(mockInternalQuery),

--- a/packages/api/src/lib/prompts/__tests__/scoping.test.ts
+++ b/packages/api/src/lib/prompts/__tests__/scoping.test.ts
@@ -18,7 +18,19 @@ const mockInternalQuery = mock(
   async (_sql: string, _params?: unknown[]) => [] as unknown[],
 );
 
+// Scoping.ts imports @atlas/api/lib/content-mode, which transitively
+// imports `InternalDB` from this module (#1524). The mock must preserve
+// the tag identity so the registry's `yield* InternalDB` resolves.
+const { MockInternalDB, makeMockInternalDBShimLayer } = await import(
+  "@atlas/api/testing/api-test-mocks"
+);
+
 mock.module("@atlas/api/lib/db/internal", () => ({
+  InternalDB: MockInternalDB,
+  makeInternalDBShimLayer: () =>
+    makeMockInternalDBShimLayer(mockInternalQuery, {
+      available: hasInternalDBFixture,
+    }),
   hasInternalDB: () => hasInternalDBFixture,
   internalQuery: mockInternalQuery,
 }));
@@ -61,19 +73,19 @@ function withDemoScope(
 describe("buildCollectionsListQuery", () => {
   it("org-with-demo (published): industry-filtered built-ins + custom published", () => {
     const q = buildCollectionsListQuery(withDemoScope());
-    expect(q.sql).toContain("status = 'published'");
+    expect(q.sql).toContain("pc.status = 'published'");
     expect(q.sql).not.toContain("status IN");
-    expect(q.sql).toContain("is_builtin = true AND industry = $2");
-    expect(q.sql).toContain("(org_id IS NULL OR org_id = $1)");
-    expect(q.sql).toContain("is_builtin = false AND org_id = $1");
+    expect(q.sql).toContain("pc.is_builtin = true AND pc.industry = $2");
+    expect(q.sql).toContain("(pc.org_id IS NULL OR pc.org_id = $1)");
+    expect(q.sql).toContain("pc.is_builtin = false AND pc.org_id = $1");
     expect(q.params).toEqual(["org-1", "cybersecurity"]);
   });
 
   it("org-custom-only (published): hides all built-ins, only custom published", () => {
     const q = buildCollectionsListQuery(customOnlyScope());
-    expect(q.sql).toContain("status = 'published'");
-    expect(q.sql).toContain("org_id = $1");
-    expect(q.sql).toContain("is_builtin = false");
+    expect(q.sql).toContain("pc.status = 'published'");
+    expect(q.sql).toContain("pc.org_id = $1");
+    expect(q.sql).toContain("pc.is_builtin = false");
     expect(q.sql).not.toContain("industry =");
     expect(q.sql).not.toContain("org_id IS NULL OR");
     expect(q.params).toEqual(["org-1"]);
@@ -83,26 +95,26 @@ describe("buildCollectionsListQuery", () => {
     const q = buildCollectionsListQuery(
       withDemoScope("org-1", "cybersecurity", "developer"),
     );
-    expect(q.sql).toContain("status IN ('published', 'draft')");
+    expect(q.sql).toContain("pc.status IN ('published', 'draft')");
     expect(q.sql).not.toContain("archived");
-    expect(q.sql).toContain("is_builtin = true AND industry = $2");
-    expect(q.sql).toContain("is_builtin = false AND org_id = $1");
+    expect(q.sql).toContain("pc.is_builtin = true AND pc.industry = $2");
+    expect(q.sql).toContain("pc.is_builtin = false AND pc.org_id = $1");
     expect(q.params).toEqual(["org-1", "cybersecurity"]);
   });
 
   it("org-custom-only (developer): only custom (published + draft)", () => {
     const q = buildCollectionsListQuery(customOnlyScope("org-1", "developer"));
-    expect(q.sql).toContain("status IN ('published', 'draft')");
-    expect(q.sql).toContain("org_id = $1");
-    expect(q.sql).toContain("is_builtin = false");
+    expect(q.sql).toContain("pc.status IN ('published', 'draft')");
+    expect(q.sql).toContain("pc.org_id = $1");
+    expect(q.sql).toContain("pc.is_builtin = false");
     expect(q.sql).not.toContain("industry =");
     expect(q.params).toEqual(["org-1"]);
   });
 
   it("global (published): global built-ins only, no industry/custom filter", () => {
     const q = buildCollectionsListQuery(globalScope());
-    expect(q.sql).toContain("org_id IS NULL");
-    expect(q.sql).toContain("status = 'published'");
+    expect(q.sql).toContain("pc.org_id IS NULL");
+    expect(q.sql).toContain("pc.status = 'published'");
     expect(q.sql).not.toContain("industry =");
     expect(q.sql).not.toContain("is_builtin = false");
     expect(q.params).toEqual([]);
@@ -110,14 +122,14 @@ describe("buildCollectionsListQuery", () => {
 
   it("global (developer): global built-ins, status IN", () => {
     const q = buildCollectionsListQuery(globalScope("developer"));
-    expect(q.sql).toContain("org_id IS NULL");
-    expect(q.sql).toContain("status IN ('published', 'draft')");
+    expect(q.sql).toContain("pc.org_id IS NULL");
+    expect(q.sql).toContain("pc.status IN ('published', 'draft')");
     expect(q.params).toEqual([]);
   });
 
   it("includes ORDER BY on list queries", () => {
     const q = buildCollectionsListQuery(customOnlyScope());
-    expect(q.sql).toContain("ORDER BY sort_order ASC, created_at ASC");
+    expect(q.sql).toContain("ORDER BY pc.sort_order ASC, pc.created_at ASC");
   });
 });
 
@@ -125,31 +137,31 @@ describe("buildCollectionGetQuery", () => {
   it("org-with-demo: appends id as $3 after orgId + industry", () => {
     const q = buildCollectionGetQuery(withDemoScope(), "col-1");
     expect(q.sql).not.toContain("ORDER BY");
-    expect(q.sql).toContain("AND id = $3");
-    expect(q.sql).toContain("is_builtin = true AND industry = $2");
+    expect(q.sql).toContain("AND pc.id = $3");
+    expect(q.sql).toContain("pc.is_builtin = true AND pc.industry = $2");
     expect(q.params).toEqual(["org-1", "cybersecurity", "col-1"]);
   });
 
   it("org-custom-only: appends id as $2 after orgId", () => {
     const q = buildCollectionGetQuery(customOnlyScope(), "col-2");
     expect(q.sql).not.toContain("ORDER BY");
-    expect(q.sql).toContain("AND id = $2");
-    expect(q.sql).toContain("org_id = $1");
-    expect(q.sql).toContain("is_builtin = false");
+    expect(q.sql).toContain("AND pc.id = $2");
+    expect(q.sql).toContain("pc.org_id = $1");
+    expect(q.sql).toContain("pc.is_builtin = false");
     expect(q.params).toEqual(["org-1", "col-2"]);
   });
 
   it("global: id as $1, no org filter", () => {
     const q = buildCollectionGetQuery(globalScope(), "col-3");
     expect(q.sql).not.toContain("ORDER BY");
-    expect(q.sql).toContain("AND id = $1");
-    expect(q.sql).toContain("org_id IS NULL");
+    expect(q.sql).toContain("AND pc.id = $1");
+    expect(q.sql).toContain("pc.org_id IS NULL");
     expect(q.params).toEqual(["col-3"]);
   });
 
   it("inherits developer status clause", () => {
     const q = buildCollectionGetQuery(customOnlyScope("org-1", "developer"), "col-x");
-    expect(q.sql).toContain("status IN ('published', 'draft')");
+    expect(q.sql).toContain("pc.status IN ('published', 'draft')");
   });
 });
 

--- a/packages/api/src/lib/prompts/scoping.ts
+++ b/packages/api/src/lib/prompts/scoping.ts
@@ -31,16 +31,35 @@
  * orgs whose archival race left them out of sync with the industry
  * filter.
  *
- * See: #1438, PRD #1421.
+ * The status-lifecycle clause (`status = 'published'` vs
+ * `status IN ('published', 'draft')`) is delegated to
+ * `ContentModeRegistry.readFilter` (#1515 phase 2b). The registry owns
+ * the single source of truth for mode-participating tables; this
+ * module only assembles the demo-industry and custom-vs-builtin
+ * scoping around it.
+ *
+ * See: #1438, PRD #1421, #1515.
  */
+import { Effect } from "effect";
 import type { AtlasMode } from "@useatlas/types/auth";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { getSettingAuto } from "@atlas/api/lib/settings";
 import { DEMO_INDUSTRY_SETTING } from "@atlas/api/lib/demo-industry";
+import {
+  CONTENT_MODE_TABLES,
+  makeService,
+} from "@atlas/api/lib/content-mode";
 
 // Re-exported so existing importers (`resolvePromptScope` callers, tests)
 // don't need to switch paths.
 export { DEMO_INDUSTRY_SETTING };
+
+/**
+ * Module-level synchronous registry — the tuple is static and the
+ * `readFilter` method is pure, so a single `makeService` instance
+ * shared across callers is safe. No Effect layer provision needed.
+ */
+const contentModeRegistry = makeService(CONTENT_MODE_TABLES);
 
 /**
  * Tagged union of the three prompt-scoping scenarios.
@@ -72,12 +91,18 @@ export interface PromptCollectionQuery {
 }
 
 /** Ordering shared across list queries (get queries don't need it). */
-const LIST_ORDER_BY = "ORDER BY sort_order ASC, created_at ASC";
+const LIST_ORDER_BY = "ORDER BY pc.sort_order ASC, pc.created_at ASC";
 
+/**
+ * Resolve the mode-participating status clause for `prompt_collections`
+ * via the content-mode registry. The registry call is pure (no I/O,
+ * no async), so `Effect.runSync` is safe — the `prompt_collections`
+ * key is a known simple entry that never fails.
+ */
 function statusClauseFor(mode: AtlasMode): string {
-  return mode === "developer"
-    ? "status IN ('published', 'draft')"
-    : "status = 'published'";
+  return Effect.runSync(
+    contentModeRegistry.readFilter("prompt_collections", mode, "pc"),
+  );
 }
 
 /**
@@ -131,25 +156,25 @@ export function buildCollectionsListQuery(
   switch (scope.kind) {
     case "global":
       return {
-        sql: `SELECT * FROM prompt_collections WHERE org_id IS NULL AND ${statusClause} ${LIST_ORDER_BY}`,
+        sql: `SELECT pc.* FROM prompt_collections pc WHERE pc.org_id IS NULL AND ${statusClause} ${LIST_ORDER_BY}`,
         params: [],
       };
     case "org-with-demo":
       return {
-        sql: `SELECT * FROM prompt_collections
+        sql: `SELECT pc.* FROM prompt_collections pc
               WHERE ${statusClause}
                 AND (
-                  (is_builtin = true AND industry = $2 AND (org_id IS NULL OR org_id = $1))
-                  OR (is_builtin = false AND org_id = $1)
+                  (pc.is_builtin = true AND pc.industry = $2 AND (pc.org_id IS NULL OR pc.org_id = $1))
+                  OR (pc.is_builtin = false AND pc.org_id = $1)
                 )
               ${LIST_ORDER_BY}`,
         params: [scope.orgId, scope.demoIndustry],
       };
     case "org-custom-only":
       return {
-        sql: `SELECT * FROM prompt_collections
-              WHERE org_id = $1
-                AND is_builtin = false
+        sql: `SELECT pc.* FROM prompt_collections pc
+              WHERE pc.org_id = $1
+                AND pc.is_builtin = false
                 AND ${statusClause}
               ${LIST_ORDER_BY}`,
         params: [scope.orgId],
@@ -172,27 +197,27 @@ export function buildCollectionGetQuery(
   switch (scope.kind) {
     case "global":
       return {
-        sql: `SELECT * FROM prompt_collections WHERE org_id IS NULL AND ${statusClause} AND id = $1`,
+        sql: `SELECT pc.* FROM prompt_collections pc WHERE pc.org_id IS NULL AND ${statusClause} AND pc.id = $1`,
         params: [id],
       };
     case "org-with-demo":
       return {
-        sql: `SELECT * FROM prompt_collections
+        sql: `SELECT pc.* FROM prompt_collections pc
               WHERE ${statusClause}
                 AND (
-                  (is_builtin = true AND industry = $2 AND (org_id IS NULL OR org_id = $1))
-                  OR (is_builtin = false AND org_id = $1)
+                  (pc.is_builtin = true AND pc.industry = $2 AND (pc.org_id IS NULL OR pc.org_id = $1))
+                  OR (pc.is_builtin = false AND pc.org_id = $1)
                 )
-                AND id = $3`,
+                AND pc.id = $3`,
         params: [scope.orgId, scope.demoIndustry, id],
       };
     case "org-custom-only":
       return {
-        sql: `SELECT * FROM prompt_collections
-              WHERE org_id = $1
-                AND is_builtin = false
+        sql: `SELECT pc.* FROM prompt_collections pc
+              WHERE pc.org_id = $1
+                AND pc.is_builtin = false
                 AND ${statusClause}
-                AND id = $2`,
+                AND pc.id = $2`,
         params: [scope.orgId, id],
       };
   }


### PR DESCRIPTION
## Summary
- Replaces hand-rolled \`statusClauseFor\` in \`lib/prompts/scoping.ts\` with \`contentModeRegistry.readFilter("prompt_collections", mode, "pc")\`
- Adds \`pc.\` alias to every prompt_collections column reference so the registry's aliased clause slots cleanly into the WHERE
- Module-level \`makeService(CONTENT_MODE_TABLES)\` + \`Effect.runSync\` — safe because \`readFilter\` is pure and the key is known-simple

## Scope
Phase 2b of #1515. Second of 5 caller migrations.

Demo-industry scoping and custom-vs-builtin branching stay in scoping.ts. The registry only owns the status-lifecycle clause per the parent issue's design ("registry returns the status clause, the caller ANDs in additional scopes").

## Side effects of the module graph
scoping.ts now imports \`@atlas/api/lib/content-mode\` at module top, which transitively pulls in \`InternalDB\` from \`lib/db/internal\`. Three tests that load scoping.ts transitively (admin-integrations, admin-integrations-byot, sessions) and one that tests it directly (scoping.test.ts) needed the #1524 InternalDB + shim-layer patch applied to their partial mocks. All use the shared \`MockInternalDB\` + \`makeMockInternalDBShimLayer\` from \`api-test-mocks\`.

## Test plan
- [x] \`bun test packages/api/src/lib/prompts/__tests__/scoping.test.ts\` — 19/19 pass
- [x] \`bun test packages/api/src/api/__tests__/prompts.test.ts\` — all scoping assertions updated for \`pc.\` alias
- [x] \`bun run test packages/api\` — 237/237 files green
- [x] \`bun run type\` clean
- [x] \`bun run lint\` clean

## Follow-ups
- #1521 phase 2c — admin-connections + admin-starter-prompts
- #1522 phase 2d — semantic_entities adapter
- #1523 phase 2e — admin-publish.ts

Closes #1520