### PR TITLE
refactor(content-mode): migrate admin-connections.ts to registry.readFilter (#1515 phase 2c)

### DIFF
--- a/packages/api/src/api/__tests__/admin-connections.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections.test.ts
@@ -165,7 +165,7 @@ describe("admin connections — org scoping", () => {
     it("workspace admin only sees connections belonging to their org", async () => {
       // getVisibleConnectionIds queries internal DB for org's connections
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT id FROM connections WHERE org_id")) {
+        if (sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
           // org-alpha owns "warehouse" only
           return Promise.resolve([{ id: "warehouse" }]);
         }
@@ -327,7 +327,7 @@ describe("admin connections — org scoping", () => {
     it("succeeds when health-checking a connection visible to org", async () => {
       setOrgAdmin("org-alpha");
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT id FROM connections WHERE org_id")) {
+        if (sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
           return Promise.resolve([{ id: "warehouse" }]);
         }
         return Promise.resolve([]);
@@ -435,7 +435,7 @@ describe("admin connections — org scoping", () => {
 
       // getVisibleConnectionIds returns null for platform admins (no DB query), so no org filter applied
       const orgFilterCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) => typeof sql === "string" && sql.includes("SELECT id FROM connections WHERE org_id"),
+        ([sql]) => typeof sql === "string" && sql.includes("SELECT c.id FROM connections c WHERE c.org_id"),
       );
       expect(orgFilterCall).toBeUndefined();
     });
@@ -523,7 +523,7 @@ describe("admin connections — org scoping", () => {
 
     it("includes org-owned connections from internal DB", async () => {
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT id FROM connections WHERE org_id")) {
+        if (sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
           return Promise.resolve([{ id: "warehouse" }]);
         }
         return Promise.resolve([]);
@@ -571,7 +571,7 @@ describe("admin connections — org scoping", () => {
     it("get-by-id succeeds for connection visible to org", async () => {
       setOrgAdmin("org-alpha");
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT id FROM connections WHERE org_id")) {
+        if (sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
           return Promise.resolve([{ id: "warehouse" }]);
         }
         // Detail query for managed connection info
@@ -600,7 +600,7 @@ describe("admin connections — org scoping", () => {
       const call = mocks.mockInternalQuery.mock.calls.find(
         ([sql]) =>
           typeof sql === "string" &&
-          sql.includes("SELECT id FROM connections WHERE org_id"),
+          sql.includes("SELECT c.id FROM connections c WHERE c.org_id"),
       );
       return call as [string, unknown[]] | undefined;
     }

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -17,7 +17,18 @@ import { runHandler } from "@atlas/api/lib/effect/hono";
 import { checkResourceLimit } from "@atlas/api/lib/billing/enforcement";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
-import { buildUnionStatusClause } from "@atlas/api/lib/mode";
+import { Effect } from "effect";
+import {
+  CONTENT_MODE_TABLES,
+  makeService,
+} from "@atlas/api/lib/content-mode";
+
+/**
+ * Module-level synchronous content-mode registry (#1515 phase 2c).
+ * `readFilter` is a pure function of the static tuple; `Effect.runSync`
+ * is safe because no I/O and the key is a known-simple entry.
+ */
+const contentModeRegistry = makeService(CONTENT_MODE_TABLES);
 
 const log = createLogger("admin-connections");
 
@@ -61,9 +72,11 @@ async function getVisibleConnectionIds(
   const visible = new Set<string>(["default"]);
 
   if (hasInternalDB()) {
-    const statusClause = buildUnionStatusClause(mode);
+    const statusClause = Effect.runSync(
+      contentModeRegistry.readFilter("connections", mode ?? "published", "c"),
+    );
     const rows = await internalQuery<{ id: string }>(
-      `SELECT id FROM connections WHERE org_id = $1${statusClause}`,
+      `SELECT c.id FROM connections c WHERE c.org_id = $1 AND ${statusClause}`,
       [orgId],
     );
     for (const row of rows) {


### PR DESCRIPTION
## Summary
- Replaces \`buildUnionStatusClause(mode)\` in \`getVisibleConnectionIds\` (admin-connections.ts) with \`registry.readFilter("connections", mode, "c")\`
- Adds \`c.\` alias to the connections list SQL so the registry's aliased clause slots in cleanly

## Scope note
\`admin-starter-prompts.ts\` (also in #1521's original scope) has no mode-status filters — its queries filter on \`approval_status\`, not \`status\`. No migration needed there.

\`getPopularSuggestions\` in \`lib/db/internal.ts\` still uses \`buildUnionStatusClause\` because \`internal.ts\` can't import from \`@atlas/api/lib/content-mode\` (circular: \`content-mode/registry\` imports \`InternalDB\` from \`internal\`). Filing follow-up for that deeper migration — either by introducing a pure status-clause helper in \`content-mode/port.ts\` (no InternalDB dep) or by relocating the call.

## Test plan
- [x] \`bun test packages/api/src/api/__tests__/admin-connections.test.ts\` — 37/37 pass (SQL matchers updated for \`c.\` alias)
- [x] \`bun run test packages/api\` — 237/237 files green
- [x] \`bun run type\` clean
- [x] \`bun run lint\` clean

## Follow-ups
- #1522 phase 2d — semantic_entities adapter
- #1523 phase 2e — admin-publish.ts
- New: migrate \`getPopularSuggestions\` in \`lib/db/internal.ts\` once cycle is resolved

Closes #1521