### PR TITLE
refactor(content-mode): replace semantic_entities stub with real adapter (#1515 phase 2d)

### DIFF
--- a/packages/api/src/lib/content-mode/__tests__/registry.test.ts
+++ b/packages/api/src/lib/content-mode/__tests__/registry.test.ts
@@ -408,35 +408,53 @@ describe("ContentModeRegistry.countAllDrafts", () => {
 // ============================================================================
 
 describe("ContentModeRegistry.runPublishPhases", () => {
-  it("invokes simple adapters in tuple order; exotic semantic_entities fails loudly", async () => {
-    // The production stub fails by design (phase 2 of #1515). Simple adapters
-    // 1–3 run successfully; the exotic stub surfaces a PublishPhaseError.
+  it("invokes simple adapters in tuple order followed by semantic_entities tombstone+promote", async () => {
+    // Production tuple flow (phase 2d of #1515):
+    // 1. connections       → UPDATE (1 SQL)
+    // 2. prompt_collections → UPDATE (1 SQL)
+    // 3. query_suggestions  → UPDATE (1 SQL)
+    // 4. semantic_entities  → applyTombstones (2 SQL) + promoteDraftEntities (2 SQL)
     const { client, calls } = makeMockPoolClient([
       { rowCount: 3 }, // connections
       { rowCount: 2 }, // prompt_collections
       { rowCount: 1 }, // query_suggestions
+      // semantic_entities.applyTombstones:
+      { rows: [{ id: "e1" }, { id: "e2" }], rowCount: 2 }, //   DELETE published via tombstone join
+      { rowCount: 2 }, //                                        DELETE tombstones
+      // semantic_entities.promoteDraftEntities:
+      { rowCount: 1 }, //                                        DELETE superseded published
+      { rows: [{ id: "e3" }, { id: "e4" }, { id: "e5" }], rowCount: 3 }, // UPDATE promote
     ]);
 
-    const result = await Effect.runPromise(
+    const reports = await Effect.runPromise(
       Effect.gen(function* () {
         const registry = yield* ContentModeRegistry;
         return yield* registry.runPublishPhases(client, "org-1");
-      }).pipe(Effect.provide(ContentModeRegistryLive), Effect.either),
+      }).pipe(Effect.provide(ContentModeRegistryLive)),
     );
 
-    expect(result._tag).toBe("Left");
-    if (result._tag === "Left") {
-      expect(result.left).toBeInstanceOf(PublishPhaseError);
-      expect((result.left as PublishPhaseError).table).toBe("semantic_entities");
-      expect((result.left as PublishPhaseError).phase).toBe("promote");
-      const cause = (result.left as PublishPhaseError).cause;
-      expect(String(cause)).toContain("phase 2 of #1515");
-    }
-    // The three simple UPDATEs ran in tuple order before the stub failed.
-    expect(calls).toHaveLength(3);
+    expect(reports.map((r: PromotionReport) => r.table)).toEqual([
+      "connections",
+      "prompt_collections",
+      "query_suggestions",
+      "semantic_entities",
+    ]);
+    expect(reports[0].promoted).toBe(3);
+    expect(reports[1].promoted).toBe(2);
+    expect(reports[2].promoted).toBe(1);
+    // semantic_entities report composes both phases' counts.
+    expect(reports[3].promoted).toBe(3);
+    expect(reports[3].tombstonesApplied).toBe(2);
+
+    expect(calls).toHaveLength(7);
     expect(calls[0].sql).toContain("UPDATE connections");
     expect(calls[1].sql).toContain("UPDATE prompt_collections");
     expect(calls[2].sql).toContain("UPDATE query_suggestions");
+    // Tombstones before promote.
+    expect(calls[3].sql).toContain("draft_delete");
+    expect(calls[4].sql).toContain("draft_delete");
+    expect(calls[5].sql).toMatch(/DELETE FROM semantic_entities/);
+    expect(calls[6].sql).toContain("UPDATE semantic_entities");
     for (const c of calls) expect(c.params).toEqual(["org-1"]);
   });
 

--- a/packages/api/src/lib/content-mode/adapters/__tests__/semantic-entities.test.ts
+++ b/packages/api/src/lib/content-mode/adapters/__tests__/semantic-entities.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Boundary tests for the semantic_entities exotic adapter (#1515 phase 2d).
+ *
+ * Focuses on the adapter's contract with its caller:
+ * - Runs tombstones before promote (ordering is load-bearing — promote
+ *   would otherwise re-materialize rows the tombstones intended to
+ *   delete).
+ * - Reports both counts in the PromotionReport.
+ * - Surfaces PublishPhaseError with the correct phase on failure so the
+ *   admin-publish handler can attribute partial failures.
+ * - Never issues BEGIN/COMMIT/ROLLBACK — caller owns the transaction.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { Effect } from "effect";
+import type { PoolClient, QueryResult } from "pg";
+import { promoteSemanticEntities } from "../semantic-entities";
+import { PublishPhaseError } from "../../port";
+
+function makeMockPoolClient(
+  responses: Array<Partial<QueryResult> | Error>,
+): { client: PoolClient; calls: Array<{ sql: string; params: unknown[] }> } {
+  const calls: Array<{ sql: string; params: unknown[] }> = [];
+  const client = {
+    query: async (sql: string, params: unknown[] = []) => {
+      calls.push({ sql, params });
+      if (responses.length === 0) {
+        throw new Error(
+          `makeMockPoolClient: unexpected query #${calls.length} — no seeded response (sql: ${sql.slice(0, 80)})`,
+        );
+      }
+      const next = responses.shift()!;
+      if (next instanceof Error) throw next;
+      return { rows: next.rows ?? [], rowCount: next.rowCount ?? 0 };
+    },
+    release: () => {},
+  } as unknown as PoolClient;
+  return { client, calls };
+}
+
+describe("promoteSemanticEntities", () => {
+  it("runs tombstones before promote and returns both counts", async () => {
+    const { client, calls } = makeMockPoolClient([
+      // applyTombstones
+      { rows: [{ id: "a" }, { id: "b" }], rowCount: 2 }, // DELETE published targeted
+      { rowCount: 2 }, //                                  DELETE tombstones
+      // promoteDraftEntities
+      { rowCount: 1 }, //                                  DELETE superseded published
+      { rows: [{ id: "c" }, { id: "d" }, { id: "e" }], rowCount: 3 }, // UPDATE promote
+    ]);
+
+    const report = await Effect.runPromise(promoteSemanticEntities(client, "org-1"));
+
+    expect(report.table).toBe("semantic_entities");
+    expect(report.tombstonesApplied).toBe(2);
+    expect(report.promoted).toBe(3);
+
+    // Ordering: both tombstone DELETEs must fire before the promote path.
+    expect(calls[0].sql).toContain("draft_delete");
+    expect(calls[1].sql).toContain("draft_delete");
+    expect(calls[2].sql).toMatch(/DELETE FROM semantic_entities/);
+    expect(calls[3].sql).toContain("UPDATE semantic_entities");
+
+    for (const c of calls) expect(c.params).toEqual(["org-1"]);
+  });
+
+  it("surfaces PublishPhaseError { phase: 'tombstone' } when applyTombstones fails", async () => {
+    const boom = new Error("tombstone FK violation");
+    const { client, calls } = makeMockPoolClient([boom]);
+
+    const result = await Effect.runPromise(
+      promoteSemanticEntities(client, "org-1").pipe(Effect.either),
+    );
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toBeInstanceOf(PublishPhaseError);
+      expect(result.left._tag).toBe("PublishPhaseError");
+      expect(result.left.table).toBe("semantic_entities");
+      expect(result.left.phase).toBe("tombstone");
+      expect(result.left.cause).toBe(boom);
+    }
+    // Promote must not run after tombstones fail.
+    expect(calls).toHaveLength(1);
+  });
+
+  it("surfaces PublishPhaseError { phase: 'promote' } when promoteDraftEntities fails", async () => {
+    const boom = new Error("promote unique violation");
+    const { client, calls } = makeMockPoolClient([
+      { rowCount: 0 }, // applyTombstones.DELETE published
+      { rowCount: 0 }, // applyTombstones.DELETE tombstones
+      boom, //          promoteDraftEntities.DELETE superseded FAILS
+    ]);
+
+    const result = await Effect.runPromise(
+      promoteSemanticEntities(client, "org-1").pipe(Effect.either),
+    );
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toBeInstanceOf(PublishPhaseError);
+      expect(result.left.phase).toBe("promote");
+      expect(result.left.table).toBe("semantic_entities");
+      expect(result.left.cause).toBe(boom);
+    }
+    expect(calls).toHaveLength(3);
+  });
+
+  it("never issues BEGIN/COMMIT/ROLLBACK — caller owns the transaction", async () => {
+    const { client, calls } = makeMockPoolClient([
+      { rowCount: 0 },
+      { rowCount: 0 },
+      { rowCount: 0 },
+      { rowCount: 0 },
+    ]);
+
+    await Effect.runPromise(promoteSemanticEntities(client, "org-1"));
+
+    for (const call of calls) {
+      const upper = call.sql.toUpperCase();
+      expect(upper).not.toMatch(/\bBEGIN\b/);
+      expect(upper).not.toMatch(/\bCOMMIT\b/);
+      expect(upper).not.toMatch(/\bROLLBACK\b/);
+    }
+  });
+});

--- a/packages/api/src/lib/content-mode/adapters/semantic-entities.ts
+++ b/packages/api/src/lib/content-mode/adapters/semantic-entities.ts
@@ -1,0 +1,74 @@
+/**
+ * Exotic adapter for the `semantic_entities` table (#1515 phase 2d).
+ *
+ * Composes the two existing publish helpers from
+ * `lib/semantic/entities.ts`:
+ * - `applyTombstones` — delete published rows targeted by
+ *   `status = 'draft_delete'` rows, then remove the tombstones.
+ * - `promoteDraftEntities` — delete published rows superseded by a
+ *   same-key draft, then flip `status = 'draft' → 'published'`.
+ *
+ * Order matters: tombstones first, promote second. Matches the
+ * existing `admin-publish.ts` ordering so the refactor preserves
+ * behavior when a caller migrates to `registry.runPublishPhases`.
+ *
+ * Runs under the caller's `PoolClient` — never opens its own
+ * transaction. The helpers are pure async functions; this module
+ * wraps them in Effect + `PublishPhaseError` so the registry's
+ * error channel stays uniform across simple and exotic entries.
+ */
+
+import { Effect } from "effect";
+import type { PoolClient } from "pg";
+import {
+  applyTombstones,
+  promoteDraftEntities,
+  type TransactionalClient,
+} from "@atlas/api/lib/semantic/entities";
+import {
+  PublishPhaseError,
+  type PromotionReport,
+} from "@atlas/api/lib/content-mode/port";
+
+/**
+ * Promote drafts for `semantic_entities` and apply tombstones in the
+ * caller's transaction. Surfaces `PublishPhaseError` with the offending
+ * phase (`"tombstone"` or `"promote"`) so the admin-publish handler can
+ * attribute partial failures.
+ */
+export function promoteSemanticEntities(
+  tx: PoolClient,
+  orgId: string,
+): Effect.Effect<PromotionReport, PublishPhaseError, never> {
+  // `PoolClient.query` is compatible with the `TransactionalClient`
+  // shape the helpers consume (both expose `query(sql, params) => Promise<{ rows }>`).
+  const client = tx as unknown as TransactionalClient;
+
+  return Effect.gen(function* () {
+    const tombstonesApplied = yield* Effect.tryPromise({
+      try: () => applyTombstones(client, orgId),
+      catch: (cause) =>
+        new PublishPhaseError({
+          table: "semantic_entities",
+          phase: "tombstone",
+          cause,
+        }),
+    });
+
+    const promoted = yield* Effect.tryPromise({
+      try: () => promoteDraftEntities(client, orgId),
+      catch: (cause) =>
+        new PublishPhaseError({
+          table: "semantic_entities",
+          phase: "promote",
+          cause,
+        }),
+    });
+
+    return {
+      table: "semantic_entities",
+      promoted,
+      tombstonesApplied,
+    } satisfies PromotionReport;
+  });
+}

--- a/packages/api/src/lib/content-mode/tables.ts
+++ b/packages/api/src/lib/content-mode/tables.ts
@@ -11,38 +11,13 @@
  * inside the caller's transaction. Tables with foreign-key dependencies
  * on later entries must be declared earlier.
  *
- * The `semantic_entities` entry is exotic — its promote path needs
- * phase 2 of #1515 to compose `promoteDraftEntities` + `applyTombstones`
- * from `lib/semantic/entities.ts`. Until then, `promoteSemanticEntitiesUnimplemented`
- * fails loudly rather than succeeding silently so a premature wiring of
- * `runPublishPhases` into `admin-publish.ts` goes red in tests.
+ * The `semantic_entities` entry is exotic — its promote path composes
+ * `applyTombstones` + `promoteDraftEntities` from
+ * `lib/semantic/entities.ts`. See `./adapters/semantic-entities.ts`.
  */
 
-import { Effect } from "effect";
-import type { PoolClient } from "pg";
-import { PublishPhaseError, type ContentModeEntry, type PromotionReport } from "./port";
-
-/**
- * Phase-2 placeholder for the exotic `semantic_entities` promote adapter.
- *
- * Fails with `PublishPhaseError` so any caller that wires `runPublishPhases`
- * into `admin-publish.ts` before phase 2 lands sees a loud failure rather
- * than a silent `{ promoted: 0 }` success.
- */
-const promoteSemanticEntitiesUnimplemented = (
-  _tx: PoolClient,
-  _orgId: string,
-): Effect.Effect<PromotionReport, PublishPhaseError, never> =>
-  Effect.fail(
-    new PublishPhaseError({
-      table: "semantic_entities",
-      phase: "promote",
-      cause: new Error(
-        "promoteSemanticEntitiesUnimplemented: phase 2 of #1515 has not shipped — " +
-          "do not wire ContentModeRegistry.runPublishPhases into admin-publish.ts yet",
-      ),
-    }),
-  );
+import type { ContentModeEntry } from "./port";
+import { promoteSemanticEntities } from "./adapters/semantic-entities";
 
 // `as const` is load-bearing: preserves key + kind literals for
 // InferDraftCounts; `satisfies` enforces the port shape without widening.
@@ -76,6 +51,6 @@ export const CONTENT_MODE_TABLES = [
           `SELECT 'entityDeletes' AS key, COUNT(*)::int AS n FROM semantic_entities WHERE org_id = ${p} AND status = 'draft_delete'`,
       },
     ],
-    promote: promoteSemanticEntitiesUnimplemented,
+    promote: promoteSemanticEntities,
   },
 ] as const satisfies ReadonlyArray<ContentModeEntry>;


### PR DESCRIPTION
## Summary
- New \`content-mode/adapters/semantic-entities.ts\` — composes \`applyTombstones\` + \`promoteDraftEntities\` from \`lib/semantic/entities\`. Runs tombstones first, then promote (matches existing admin-publish ordering).
- Wraps each helper in \`Effect.tryPromise\` with \`PublishPhaseError\` tagged by phase (\`"tombstone"\` or \`"promote"\`) so partial failures are attributable.
- \`tables.ts\` drops \`promoteSemanticEntitiesUnimplemented\` (the fail-loud stub from phase 1 review) and wires in the real adapter.
- 4 new adapter boundary tests: happy-path ordering, tombstone failure, promote failure, no transaction control.
- Registry test updated: the "stub fails loudly" test becomes a happy-path test showing the real tuple order (connections, prompt_collections, query_suggestions, semantic_entities) with 7 SQL calls total (3 simple UPDATEs + 2 tombstone + 2 promote).

## Scope
Phase 2d of #1515. Unblocks phase 2e (#1523) — \`runPublishPhases\` is now safe to wire into \`admin-publish.ts\`.

## Test plan
- [x] \`bun test packages/api/src/lib/content-mode/\` — 25/25 pass (21 registry + 4 adapter)
- [x] \`bun run test packages/api\` — 238/238 files green
- [x] \`bun run type\` clean
- [x] \`bun run lint\` clean

## Follow-ups
- #1523 phase 2e — migrate \`admin-publish.ts\` to use \`runPublishPhases\`

Closes #1522