### PR TITLE
refactor(content-mode): migrate admin-publish.ts to registry.runPublishPhases (#1515 phase 2e)

### DIFF
--- a/packages/api/src/api/routes/admin-publish.ts
+++ b/packages/api/src/api/routes/admin-publish.ts
@@ -21,19 +21,41 @@
  */
 
 import { createRoute, z } from "@hono/zod-openapi";
+import { Effect } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { getInternalDB } from "@atlas/api/lib/db/internal";
 import { readDemoIndustry } from "@atlas/api/lib/demo-industry";
 import {
-  applyTombstones,
-  promoteDraftEntities,
   archiveSingleConnection,
   DEMO_CONNECTION_ID,
 } from "@atlas/api/lib/semantic/entities";
 import { runHandler } from "@atlas/api/lib/effect/hono";
+import {
+  CONTENT_MODE_TABLES,
+  makeService,
+  type PromotionReport,
+} from "@atlas/api/lib/content-mode";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
+
+/**
+ * Module-level content-mode registry (#1515 phase 2e).
+ *
+ * `runPublishPhases` iterates `CONTENT_MODE_TABLES` in tuple order inside
+ * the caller's transaction — this route still owns BEGIN/COMMIT/ROLLBACK.
+ * The registry's `PromotionReport[]` return gives per-table counts that
+ * are projected back into the wire schema below.
+ */
+const contentModeRegistry = makeService(CONTENT_MODE_TABLES);
+
+/** Look up the promotion report for a specific physical table name. */
+function findReport(
+  reports: ReadonlyArray<PromotionReport>,
+  table: string,
+): PromotionReport | undefined {
+  return reports.find((r) => r.table === table);
+}
 
 const log = createLogger("admin-publish");
 
@@ -189,41 +211,33 @@ adminPublish.openapi(publishRoute, async (c) =>
     try {
       await client.query("BEGIN");
 
-      // Phase 1: apply tombstones (delete targeted published rows + tombstones)
-      deletedEntityCount = await applyTombstones(client, orgId);
-
-      // Phase 2 + 3a: remove superseded published entities, promote drafts
-      promotedEntityCount = await promoteDraftEntities(client, orgId);
-
-      // Phase 3b: promote draft connections
-      const promotedConns = await client.query(
-        `UPDATE connections SET status = 'published', updated_at = now()
-         WHERE org_id = $1 AND status = 'draft'
-         RETURNING id`,
-        [orgId],
+      // Phases 1–3 — delegate to the content-mode registry. It runs every
+      // registered adapter in tuple order inside this transaction: the
+      // simple connections / prompt_collections / query_suggestions
+      // UPDATEs, then the exotic semantic_entities adapter composes
+      // applyTombstones + promoteDraftEntities. A failure surfaces as
+      // `PublishPhaseError` tagged with `{ table, phase }`; `Effect.runPromise`
+      // throws on failure and the outer catch rolls back.
+      // InternalPoolClient is the minimal `{ query, release }` shape the
+      // registry's adapters consume; the full `pg.PoolClient` extends it
+      // with EventEmitter methods the registry never touches. Cast is
+      // safe — both `applyTombstones`/`promoteDraftEntities` and the
+      // simple UPDATE adapters only call `.query()`.
+      const reports = await Effect.runPromise(
+        contentModeRegistry.runPublishPhases(
+          client as unknown as import("pg").PoolClient,
+          orgId,
+        ),
       );
-      promotedConnectionCount = promotedConns.rows.length;
 
-      // Phase 3c: promote draft prompt collections
-      const promotedPrompts = await client.query(
-        `UPDATE prompt_collections SET status = 'published', updated_at = now()
-         WHERE org_id = $1 AND status = 'draft'
-         RETURNING id`,
-        [orgId],
-      );
-      promotedPromptCount = promotedPrompts.rows.length;
+      promotedConnectionCount = findReport(reports, "connections")?.promoted ?? 0;
+      promotedPromptCount = findReport(reports, "prompt_collections")?.promoted ?? 0;
+      promotedStarterPromptCount =
+        findReport(reports, "query_suggestions")?.promoted ?? 0;
 
-      // Phase 3d: promote draft starter-prompt suggestions. Runs in the
-      // same transaction as entities/connections/prompt collections so a
-      // partial failure rolls all four promotions back — the admin never
-      // sees some draft edits go live while others remain unpublished.
-      const promotedStarterPrompts = await client.query(
-        `UPDATE query_suggestions SET status = 'published', updated_at = now()
-         WHERE org_id = $1 AND status = 'draft'
-         RETURNING id`,
-        [orgId],
-      );
-      promotedStarterPromptCount = promotedStarterPrompts.rows.length;
+      const entitiesReport = findReport(reports, "semantic_entities");
+      promotedEntityCount = entitiesReport?.promoted ?? 0;
+      deletedEntityCount = entitiesReport?.tombstonesApplied ?? 0;
 
       // Phase 4: archive requested connections (+ cascade to their entities +
       // demo prompt collections when the id is `__demo__`). Loops the shared

--- a/packages/api/src/lib/content-mode/registry.ts
+++ b/packages/api/src/lib/content-mode/registry.ts
@@ -136,7 +136,13 @@ function promoteSimpleTable(
   return Effect.tryPromise({
     try: async () => {
       const result = await tx.query(simplePromoteSql(entry), [orgId]);
-      return { table, promoted: result.rowCount ?? 0 } satisfies PromotionReport;
+      // `pg` sets both `rowCount` and `rows`. `rowCount` is authoritative
+      // for non-RETURNING UPDATEs (`rows` is empty); callers that add
+      // RETURNING still work because `rowCount === rows.length` in that
+      // case. Falling back to `rows.length` keeps test mocks that only
+      // populate one of the two fields from silently returning zero.
+      const promoted = result.rowCount ?? result.rows?.length ?? 0;
+      return { table, promoted } satisfies PromotionReport;
     },
     catch: (cause) => new PublishPhaseError({ table, phase: "promote", cause }),
   });


### PR DESCRIPTION
## Summary
Final phase 2 migration of #1515. Collapses the four parallel UPDATEs + \`applyTombstones\` + \`promoteDraftEntities\` inline calls in \`admin-publish.ts\` phases 1–3 into a single \`contentModeRegistry.runPublishPhases(client, orgId)\`.

## Behavior preservation
- Transaction boundary unchanged — this route still owns BEGIN/COMMIT/ROLLBACK; the registry only runs adapters against the caller's \`PoolClient\`
- Atomicity guarantee preserved — \`PublishPhaseError\` surfaces through \`Effect.runPromise\`, the outer catch rolls back
- Phase 4 (archiveConnections cascade) stays outside the registry (lifecycle, not promotion)
- Response shape unchanged (PromotionReport[] is projected back via \`findReport\` helper)

## Design win
Adding a new mode-participating content table is now a one-line change to \`CONTENT_MODE_TABLES\` — no \`admin-publish.ts\` edit needed. The registry owns the publish phase ordering, the draft-counts SQL, and the read filter; adding \`dashboards\` (or similar) just extends the tuple.

## Incidental fix in registry.ts
The simple-table \`promoted\` count now falls back to \`rows.length\` when \`rowCount\` is absent. \`pg\` sets both on UPDATE, but test mocks commonly set only one — the fallback keeps them tolerant without changing production behavior.

## Test plan
- [x] \`bun test packages/api/src/api/__tests__/admin-publish.test.ts\` — 26/26 pass
- [x] \`bun run test packages/api\` — 238/238 files green
- [x] \`bun run type\` clean
- [x] \`bun run lint\` clean

## Phase 2 of #1515 complete
| Phase | Status | PR |
|-------|--------|------|
| 2a — mode.ts → countAllDrafts | ✅ | #1525 |
| 2b — prompts/scoping.ts → readFilter | ✅ | #1527 |
| 2c — admin-connections → readFilter | ✅ | #1528 |
| 2d — semantic_entities adapter | ✅ | #1529 |
| 2e — admin-publish → runPublishPhases | this PR | #1530 |

Plus test-mock hygiene (#1524 / #1526).

Closes #1523