### PR TITLE
docs: close /docs-audit gaps (#1532, #1533, #1534, #1535, #1536)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -144,6 +144,7 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # ATLAS_DEMO_ENABLED=false               # Enable demo mode at /demo (requires BETTER_AUTH_SECRET for token signing)
 # ATLAS_DEMO_RATE_LIMIT_RPM=10           # Max requests per minute per demo user (default: 10)
 # ATLAS_DEMO_MAX_STEPS=10                # Max agent steps per demo request (default: 10)
+# ATLAS_DEMO_INDUSTRY=                   # Industry for the seeded __demo__ connection (e.g. cybersecurity, ecommerce). Set at signup via onboarding — drives prompt-library filtering + publish archival cascade
 
 # === Encryption ===
 # ATLAS_ENCRYPTION_KEY=        # Dedicated encryption key for connection URLs at rest (takes precedence over BETTER_AUTH_SECRET)
@@ -226,6 +227,7 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 ATLAS_SANDBOX_URL=http://localhost:8080
 # ATLAS_SANDBOX=nsjail    # Process isolation for explore tool (auto-detected when nsjail is on PATH)
 # ATLAS_SANDBOX_PRIORITY=                        # Custom backend priority (comma-separated: vercel-sandbox,nsjail,sidecar,just-bash)
+# ATLAS_SANDBOX_BACKEND=                         # SaaS admin-facing selector: vercel-sandbox | sidecar | e2b-sandbox | daytona-sandbox | <plugin-id>. Self-hosted operators typically use ATLAS_SANDBOX_PRIORITY instead
 # SIDECAR_AUTH_TOKEN=                            # Optional shared secret for sidecar auth (set on both API and sidecar)
 # ATLAS_NSJAIL_PATH=      # Explicit path to nsjail binary (auto-detected on PATH otherwise)
 # ATLAS_NSJAIL_TIME_LIMIT=10     # nsjail per-command time limit in seconds

--- a/apps/docs/content/docs/architecture/content-mode.mdx
+++ b/apps/docs/content/docs/architecture/content-mode.mdx
@@ -1,0 +1,293 @@
+---
+title: Content Mode Registry
+description: The draft/published mode system — how to add a new mode-participating content table in one line, and the type-level drift detection that keeps the wire contract honest.
+---
+
+> Design doc for the `ContentModeRegistry` library (#1515) that drives the 1.2.0 developer/published mode system. Covers the static-tuple architecture, the type derivation, and the end-to-end flow for adding a new mode-participating table.
+
+## Problem
+
+The 1.2.0 mode system worked but was shallow. Four content tables participated — `connections`, `prompt_collections`, `query_suggestions`, and `semantic_entities` — and each surface (read filter, draft counts, publish path) had its own hand-written policy:
+
+| Concern | Pre-registry state |
+|---------|--------------------|
+| Read filter | Three drifting styles: `buildUnionStatusClause()` helper for connections, inline `statusClauseFor()` in prompt scoping, `listEntitiesWithOverlay()` CTE for semantic entities, inline `status='published'` filter for query_suggestions. |
+| Draft counts | Hand-written 6-branch `UNION ALL` in `routes/mode.ts:97–127`. |
+| Publish transaction | Four parallel `UPDATE` statements in `admin-publish.ts` plus inline `applyTombstones()` + `promoteDraftEntities()` calls. |
+| Wire type | `ModeDraftCounts` in `@useatlas/types/mode` had to stay in lockstep with all three surfaces by hand. |
+| Type safety | None. A contributor adding a fifth table (dashboards, reports) had to coordinate edits across 6+ files with **zero compile-time enforcement**. A well-intentioned omission of a publish `UPDATE` would leave orphan drafts forever. |
+
+CLAUDE.md's Content Mode System rules documented the contract as prose. Nothing enforced it.
+
+## Solution
+
+A static `as const satisfies ReadonlyArray<ContentModeEntry>` tuple paired with a compile-time derived wire type and an Effect service wrapper. Three pillars:
+
+1. **The tuple is the source of truth.** Every mode-participating table has one entry. Adding a row updates every consumer.
+2. **The wire type is derived.** `InferDraftCounts<typeof CONTENT_MODE_TABLES>` produces the exact shape of `ModeDraftCounts`. A compile-time equality assertion fails CI on any drift.
+3. **Exhaustiveness is enforced.** Discriminated `SimpleModeTable` | `ExoticModeAdapter` union with `assertNever` guards at every `switch`. Adding a new `kind` fails to compile at every site.
+
+## Architecture
+
+The library lives at `packages/api/src/lib/content-mode/`:
+
+```
+content-mode/
+├── index.ts              # Barrel
+├── port.ts               # SimpleModeTable / ExoticModeAdapter / errors — pure types
+├── tables.ts             # CONTENT_MODE_TABLES static tuple
+├── infer.ts              # InferDraftCounts<T> type machinery
+├── registry.ts           # makeService(tables) + Effect Context.Tag
+├── adapters/
+│   ├── semantic-entities.ts   # Exotic adapter composing applyTombstones + promoteDraftEntities
+│   └── __tests__/
+└── __tests__/registry.test.ts # Boundary tests
+```
+
+### The tuple
+
+```typescript
+// tables.ts
+export const CONTENT_MODE_TABLES = [
+  { kind: "simple", key: "connections" },
+  { kind: "simple", key: "prompts", table: "prompt_collections" },
+  { kind: "simple", key: "starterPrompts", table: "query_suggestions" },
+  {
+    kind: "exotic",
+    key: "semantic_entities",
+    countSegments: [
+      { key: "entities",      sql: (p) => `SELECT 'entities' AS key, COUNT(*)::int AS n FROM semantic_entities WHERE org_id = ${p} AND status = 'draft'` },
+      { key: "entityEdits",   sql: (p) => /* INNER JOIN against published for supersession count */ },
+      { key: "entityDeletes", sql: (p) => `SELECT 'entityDeletes' AS key, COUNT(*)::int AS n FROM semantic_entities WHERE org_id = ${p} AND status = 'draft_delete'` },
+    ],
+    promote: promoteSemanticEntities,
+  },
+] as const satisfies ReadonlyArray<ContentModeEntry>;
+```
+
+Every field is load-bearing:
+
+- `as const` preserves the `key` and `kind` literals for `InferDraftCounts`.
+- `satisfies ReadonlyArray<ContentModeEntry>` enforces the port shape without widening.
+- `kind: "simple"` uses defaults everywhere — physical table name = `key` unless overridden, UPDATE SQL is `UPDATE {table} SET status='published' WHERE org_id=$1 AND status='draft'`, COUNT SQL is parallel.
+- `kind: "exotic"` plugs in table-specific SQL for counts and a caller-supplied `promote` Effect.
+
+Order matters: `runPublishPhases` iterates the tuple in order inside the caller's transaction. Tables with FK dependencies on later entries must be declared earlier.
+
+### The derived wire type
+
+```typescript
+// infer.ts
+export type InferDraftCounts<T extends ReadonlyArray<ContentModeEntry>> =
+  UnionToIntersection<EntryToRecord<T[number]>> extends infer R
+    ? { readonly [K in keyof R]: R[K] }
+    : never;
+```
+
+Walks the tuple. `simple` entries contribute `{ [key]: number }`, `exotic` entries contribute `{ [countSegments[i].key]: number }`. The homomorphic remap at the end flattens the intersection into a plain object so structural equality tests see an identical type (not merely a mutually-assignable one).
+
+Paired with a CI-time assertion in `__tests__/registry.test.ts`:
+
+```typescript
+type _assertInferredEqualsWire = Equal<
+  ModeDraftCounts,
+  InferDraftCounts<typeof CONTENT_MODE_TABLES>
+>;
+const _check: _assertInferredEqualsWire = true;
+```
+
+Adding a key to one side without the other fails to type-check.
+
+### The service
+
+```typescript
+// registry.ts
+export interface ContentModeRegistryService {
+  readonly readFilter: (
+    table: string,
+    mode: AtlasMode,
+    alias: string,
+  ) => Effect.Effect<string, UnknownTableError | ExoticReadFilterUnavailableError, never>;
+
+  readonly countAllDrafts: (
+    orgId: string,
+  ) => Effect.Effect<ModeDraftCounts, PublishPhaseError, InternalDB>;
+
+  readonly runPublishPhases: (
+    tx: PoolClient,
+    orgId: string,
+  ) => Effect.Effect<ReadonlyArray<PromotionReport>, PublishPhaseError, never>;
+}
+```
+
+Three methods, narrow by design:
+
+- `readFilter` returns a WHERE-clause fragment (`"c.status = 'published'"` or `"c.status IN ('published', 'draft')"`). Accepts either the segment key (`"prompts"`) or the physical table name (`"prompt_collections"`) for simple entries; exotic entries lookup by `key` only. Fails with `UnknownTableError` on unregistered tables or `ExoticReadFilterUnavailableError` when an exotic entry didn't ship a `readFilter` adapter (prevents silent fallback to wrong semantics).
+- `countAllDrafts` emits one `UNION ALL` query against `InternalDB`, zero-fills every registered segment, and returns the derived `ModeDraftCounts`. Fails loudly on unknown keys or non-finite counts (guards against tuple/UNION drift).
+- `runPublishPhases` iterates the tuple in order inside the caller's transactional `PoolClient`. Never issues `BEGIN` / `COMMIT` / `ROLLBACK` — caller owns the transaction. Returns a `PromotionReport[]` with per-table counts.
+
+### Usage patterns
+
+Two consumer shapes:
+
+**Sync caller (SQL builders like `lib/prompts/scoping.ts`):**
+
+```typescript
+import { CONTENT_MODE_TABLES, makeService } from "@atlas/api/lib/content-mode";
+
+const registry = makeService(CONTENT_MODE_TABLES);
+
+function statusClauseFor(mode: AtlasMode): string {
+  return Effect.runSync(
+    registry.readFilter("prompt_collections", mode, "pc"),
+  );
+}
+```
+
+Safe because `readFilter` is pure (no I/O) and the key is known-simple — `Effect.runSync` never throws for a registered simple entry.
+
+**Effect caller (route handlers like `routes/mode.ts`):**
+
+```typescript
+import { ContentModeRegistry, ContentModeRegistryLive } from "@atlas/api/lib/content-mode";
+import { makeInternalDBShimLayer } from "@atlas/api/lib/db/internal";
+
+const modeRouteLayer = Layer.merge(ContentModeRegistryLive, makeInternalDBShimLayer());
+
+mode.openapi(getModeRoute, async (c) => {
+  const program = Effect.gen(function* () {
+    const registry = yield* ContentModeRegistry;
+    const counts = yield* registry.countAllDrafts(orgId);
+    return { mode: atlasMode, draftCounts: counts };
+  }).pipe(Effect.provide(modeRouteLayer));
+
+  return c.json(await runEffect(c, program), 200);
+});
+```
+
+`makeInternalDBShimLayer` wraps the module-level `internalQuery` helper into an `InternalDB` Layer, so route handlers don't need to thread the AppLayer's `ManagedRuntime` to use services that require `InternalDB` in context.
+
+## Adding a new mode-participating table
+
+End-to-end walkthrough for adding a hypothetical `dashboards` table.
+
+### 1. Database migration
+
+Add a migration with the `status` column + CHECK constraint matching the existing pattern:
+
+```sql
+-- migrations/0031_dashboards_mode.sql
+
+ALTER TABLE dashboards ADD COLUMN status TEXT NOT NULL DEFAULT 'published'
+  CHECK (status IN ('draft', 'published', 'archived'));
+
+CREATE INDEX idx_dashboards_org_status ON dashboards (org_id, status);
+```
+
+Every mode-participating table uses the same three status values. The CHECK is load-bearing — the registry's default SQL assumes it.
+
+### 2. One-line tuple addition
+
+```typescript
+// packages/api/src/lib/content-mode/tables.ts
+export const CONTENT_MODE_TABLES = [
+  { kind: "simple", key: "connections" },
+  { kind: "simple", key: "prompts", table: "prompt_collections" },
+  { kind: "simple", key: "starterPrompts", table: "query_suggestions" },
+  { kind: "simple", key: "dashboards" },           // ← new
+  { kind: "exotic", key: "semantic_entities", ... },
+] as const satisfies ReadonlyArray<ContentModeEntry>;
+```
+
+If the `key` differs from the physical table name (e.g. wire-facing `"reports"` backed by table `report_cards`), supply `table`:
+
+```typescript
+{ kind: "simple", key: "reports", table: "report_cards" }
+```
+
+### 3. Extend the wire type
+
+Update `@useatlas/types/mode.ts` to add the new segment to `ModeDraftCounts`:
+
+```typescript
+export interface ModeDraftCounts {
+  readonly connections: number;
+  readonly prompts: number;
+  readonly starterPrompts: number;
+  readonly entities: number;
+  readonly entityEdits: number;
+  readonly entityDeletes: number;
+  readonly dashboards: number;    // ← new
+}
+```
+
+The CI-time `Equal<ModeDraftCounts, InferDraftCounts<typeof CONTENT_MODE_TABLES>>` assertion catches mismatches. Omit the new key and the tests fail at compile time.
+
+### 4. Update the admin UI
+
+The `pending-changes-summary.tsx` component iterates a typed `Record` over `ModeDraftCounts`, so it picks up the new segment automatically. Add a display label if the default `<key>` rendering isn't right.
+
+### Nothing else to change
+
+- `GET /api/v1/mode` automatically counts drafts for `dashboards` via `registry.countAllDrafts`.
+- `/api/v1/admin/publish` automatically promotes `dashboards` drafts in the same transaction via `registry.runPublishPhases`.
+- Read handlers on `dashboards` call `registry.readFilter("dashboards", mode, "d")` to get the status clause — the same dispatch logic as every other simple table.
+- Failure in any phase surfaces as `PublishPhaseError` with `{ table: "dashboards", phase: "promote" }`.
+
+## Exotic adapters — when to reach for them
+
+Most tables are "simple": one status column, default UPDATE to promote, default COUNT to count drafts. If that's not enough, register an exotic entry.
+
+Reach for exotic when any of these apply:
+
+- **Multi-segment counts.** `semantic_entities` counts `entities`, `entityEdits`, and `entityDeletes` separately — one table, three wire keys.
+- **Tombstones.** A status like `draft_delete` needs a dedicated DELETE phase before promote.
+- **Overlay CTEs.** The table's read semantics aren't a simple WHERE fragment (supersession joins, for example).
+- **Custom promote logic.** Whatever `UPDATE ... SET status='published'` can't express.
+
+The `ExoticModeAdapter` port requires:
+
+- `key` — the wire-facing identifier (used for the report `table` field and for `readFilter` lookup).
+- `countSegments[]` — one or more `{ key, sql }` entries that each contribute a branch to the `UNION ALL`.
+- `promote(tx, orgId)` — an `Effect.Effect<PromotionReport, PublishPhaseError, never>` that runs in the caller's transaction.
+- `readFilter` (optional) — `{ published, developerOverlay }` functions returning WHERE-clause fragments. **Omit at your peril** — the registry fails with `ExoticReadFilterUnavailableError` if a caller requests a read filter on an exotic entry without this, on the theory that silently serving wrong rows is worse than failing loudly.
+
+Keep adapter logic under `adapters/<table-name>.ts`. See `adapters/semantic-entities.ts` for the canonical example — it composes `applyTombstones` + `promoteDraftEntities` from `lib/semantic/entities.ts` with `Effect.tryPromise` wrapping each helper.
+
+## Errors
+
+Three tagged errors, all folded into the central `AtlasError` union and mapped to HTTP via `mapTaggedError` in `lib/effect/hono.ts`:
+
+| Error | Raised by | HTTP mapping | User-visible message |
+|-------|-----------|--------------|---------------------|
+| `PublishPhaseError` | `countAllDrafts`, `runPublishPhases` | 500 `upstream_error` | For `phase: "count"` — `"Failed to count pending drafts"`; for `"promote"` / `"tombstone"` — `'Publish phase "X" failed for table "Y"'` |
+| `UnknownTableError` | `readFilter` on unregistered table | 500 `upstream_error` | `'Unknown content-mode table "X"'` — indicates caller-side bug |
+| `ExoticReadFilterUnavailableError` | `readFilter` on exotic entry missing `readFilter` adapter | 500 `upstream_error` | `'No read filter registered for exotic table "X"'` — indicates a phase 2 gap |
+
+`PublishPhaseError.cause` carries the original driver error (e.g. `pg.DatabaseError`). The HTTP response never leaks `cause` — callers correlate via `requestId` instead.
+
+## What's not in scope
+
+Deliberately out of scope so the registry stays focused:
+
+- **Demo-industry prompt scoping.** Stays in `lib/prompts/scoping.ts`. The registry returns the status clause; the caller ANDs in industry + `is_builtin` + demo filters. Conflating the two would drag `SettingsService` into the registry and break the purity constraint.
+- **Connection archival cascade.** `archiveSingleConnection` + the demo-prompt cascade stay in `lib/semantic/entities.ts`. Archival is lifecycle, not promotion. The atomic publish endpoint runs archive as phase 4, after `runPublishPhases` returns.
+- **Plugin-registered content tables.** The tuple is static. If plugins ever need to register a mode-participating table, extend — don't pre-build.
+- **Generic content-type registry.** This isn't a CMS. Routing, auth, CRUD schemas, and UI rendering stay where they are.
+
+## Invariants the registry must preserve
+
+These are locked by tests and CLAUDE.md rules:
+
+- **Only `admin-publish.ts` imports `runPublishPhases`.** Grep for the symbol in CI.
+- **`/api/v1/mode` stays a single round-trip.** A boundary test asserts `countAllDrafts` produces exactly one SQL string.
+- **Publish still happens in one `BEGIN ... COMMIT`.** `runPublishPhases` takes the transactional `PoolClient`; it never opens its own transaction.
+- **`packages/api/src/lib/content-mode/*` imports nothing from `packages/api/src/api/routes/*`.** Preserves the purity constraint documented in `lib/mode.ts` — low-level modules can depend on mode semantics without pulling the Hono route layer.
+- **`port.ts` has no `InternalDB` dependency.** Effect callers that only need `readFilter` can import `port.ts` without dragging the full `InternalDB` graph through their module.
+
+## See also
+
+- [Developer Mode](/guides/developer-mode) — end-user view of the mode system
+- [Starter Prompts](/guides/starter-prompts) — one of the four mode-participating content types
+- [Environment Variables](/reference/environment-variables) — `ATLAS_DEMO_INDUSTRY` and friends
+- [Error Codes](/reference/error-codes#content-mode-registry-1515) — `upstream_error` for content-mode failures

--- a/apps/docs/content/docs/architecture/meta.json
+++ b/apps/docs/content/docs/architecture/meta.json
@@ -3,6 +3,7 @@
   "description": "Internals, design decisions, and system diagrams",
   "icon": "Layers",
   "pages": [
-    "sandbox"
+    "sandbox",
+    "content-mode"
   ]
 }

--- a/apps/docs/content/docs/guides/developer-mode.mdx
+++ b/apps/docs/content/docs/guides/developer-mode.mdx
@@ -105,6 +105,31 @@ After a successful response, **no `draft` or `draft_delete` rows remain for the 
 
 Orgs that picked a demo during onboarding have a seeded `__demo__` connection with matching published entities and built-in prompts. On the first publish, the admin UI pre-selects `__demo__` in the `archiveConnections` list — the admin clicks through to move from demo data to their real configuration in one atomic step. The admin can uncheck to keep the demo visible alongside their real data.
 
+### The `__demo__` connection and `demo_industry`
+
+At signup, onboarding seeds two artifacts that drive the demo UX for the first-run workspace:
+
+| Artifact | Where it lives | What it does |
+|----------|----------------|--------------|
+| Connection with `id = "__demo__"` | `connections` table, `status = "published"` | A read-only demo datasource (SQLite file or managed sample DB) the new admin can query immediately without touching their own warehouse |
+| `ATLAS_DEMO_INDUSTRY` setting | `settings` table, keyed `ATLAS_DEMO_INDUSTRY` — value is the industry the admin picked (`cybersecurity`, `ecommerce`, or similar) | Filters the prompt library to industry-matched built-ins; controls which built-in prompts archive alongside `__demo__` |
+
+These are **not** set for self-hosted deployments that don't run the onboarding flow. Self-hosted operators who want demo content can create a `__demo__` connection manually and set `ATLAS_DEMO_INDUSTRY` in their environment — see the [environment variables reference](/reference/environment-variables#demo-mode).
+
+### Why archiving `__demo__` cascades
+
+The publish endpoint's archival path treats `__demo__` as one logical unit. When `archiveConnections` includes `__demo__`:
+
+1. The connection row flips to `archived` — the UI hides the datasource from the switcher.
+2. Every `semantic_entity` row scoped to that connection cascades to `archived`.
+3. Every `prompt_collection` where `is_builtin = true` AND `industry = <demo_industry>` cascades to `archived`.
+
+The third step is what `demo_industry` enables. Built-in prompts ship with an `industry` tag; the cascade filters to the industry the admin picked at signup. An e-commerce admin archiving the demo doesn't hide cybersecurity built-ins (they weren't surfaced in the first place), and vice versa.
+
+### Restoring brings everything back together
+
+`POST /api/v1/admin/restore-connection` is the reverse operation — the connection, its entities, and its matching demo built-ins all flip back to `published` in one transaction. This is the "onboard a new hire on demo data" flow covered in the section below.
+
 ---
 
 ## Archive and Restore After Go-Live

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -34,6 +34,7 @@
     "team-management",
     "dashboards",
     "admin-console",
+    "starter-prompts",
     "starter-prompt-moderation",
     "api-keys",
     "integrations",

--- a/apps/docs/content/docs/guides/starter-prompts.mdx
+++ b/apps/docs/content/docs/guides/starter-prompts.mdx
@@ -1,0 +1,154 @@
+---
+title: Starter Prompts
+description: How the adaptive empty-state prompt surface works end-to-end — favorites, popular, library, and cold-start tiers, with pin UX and widget overrides.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+The chat empty state doesn't ship with a hardcoded list of example questions. It composes an **adaptive surface** that learns from actual usage and adapts per user. This page explains how the four-tier composition works, how pinning behaves, and how to override the surface in embedded contexts.
+
+For admin moderation of the popular tier, see [Starter Prompt Moderation](/guides/starter-prompt-moderation). For the programmatic API, see [SDK · Starter Prompts](/sdk/starter-prompts).
+
+---
+
+## What appears in the empty state
+
+Atlas composes four tiers in order until the target count is filled:
+
+| Tier | Source | Provenance badge |
+|------|--------|-----------------|
+| 1. **Favorites** | Prompts the current user has explicitly pinned | `Pin` |
+| 2. **Popular** | Admin-approved queries that crossed the click threshold | `Popular` |
+| 3. **Library** | Built-in prompts for the workspace's demo industry | (no badge) |
+| 4. **Cold-start** | Generic fallback examples when everything above is empty | (no badge) |
+
+Each tier stops at the target count — if you've pinned enough favorites to fill the surface, the other tiers don't render. If favorites are thin, popular fills the remainder, and so on down to cold-start.
+
+<Callout title="Why four tiers">
+Empty states decay fast. A grid of hardcoded example questions goes stale within weeks — the AI improves, the schema changes, the team's questions evolve. The adaptive surface stays relevant because it's driven by what users actually ask and what admins explicitly promote. The cold-start tier guarantees newcomers never see an empty page.
+</Callout>
+
+---
+
+## Pin / unpin favorites
+
+Favorites are per-user, scoped to the current workspace, and persist across devices. Pin a prompt by hovering any example in the empty state and clicking the pin icon, or by hovering any user-authored message in a conversation and clicking the pin affordance on it.
+
+- **Cap**: configurable via `ATLAS_STARTER_PROMPT_MAX_FAVORITES` (default: 20 per user). Attempting to pin past the cap returns `favorite_cap_exceeded` — unpin one first.
+- **Duplicates**: attempting to pin a prompt whose text is already in your favorites returns `duplicate_favorite`. Pin text is normalized with whitespace trimming before comparison.
+- **Unpin**: hover a pinned prompt in the empty state — the pin icon becomes an unpin affordance.
+- **Cross-surface cache**: pinning in chat immediately updates the notebook empty state and the widget (if embedded on the same origin) without a re-fetch. The TanStack Query cache shares across surfaces.
+
+API surface: `POST` / `DELETE` `/api/v1/starter-prompts/favorites` (see [API Reference](/api-reference/starter-prompts)).
+
+---
+
+## How a query becomes "popular"
+
+The popular tier is admin-moderated and click-driven. The flow:
+
+1. A user clicks a prompt in the empty state (or sends a message that matches a learned pattern).
+2. Atlas increments a **distinct-user click counter** for that text. One user clicking the same prompt 10 times counts as one click — only unique `(user, text)` pairs register.
+3. When the distinct-user count crosses `ATLAS_STARTER_PROMPT_AUTO_PROMOTE_CLICKS` (default: 3), the prompt enters the moderation queue as `approval_status='pending'`.
+4. An admin opens `/admin/starter-prompts` and approves, hides, or ignores the pending entry. Approval flips `approval_status='approved'`, which makes the prompt eligible for the popular tier.
+5. Once approved, the prompt appears in the popular tier for all users in the workspace.
+
+`ATLAS_STARTER_PROMPT_COLD_WINDOW_DAYS` (default: 90) controls how far back the click counter looks. Older clicks decay out — a prompt has to stay relevant to stay popular.
+
+---
+
+## Library tier — industry-filtered built-ins
+
+The library tier surfaces **built-in prompts** that match the workspace's `ATLAS_DEMO_INDUSTRY` setting. This is typically set at signup via the onboarding flow (e.g., `cybersecurity`, `ecommerce`).
+
+When you archive the `__demo__` connection via the publish flow, the industry-matched built-ins flip to `archived` — removing them from the library tier. At that point the empty state shows only custom prompts (ones your workspace authored) plus cold-start fallback for new users.
+
+See [Developer Mode](/guides/developer-mode) for the full demo lifecycle.
+
+---
+
+## Cold-start — new workspaces and empty states
+
+When favorites + popular + library all return zero prompts (brand-new workspace, no industry set, demo archived), the empty state falls back to a generic cold-start set. These are hardcoded examples like "What tables are available?" and "Show me the schema of the users table" — phrased to work against any datasource.
+
+Once a user clicks any prompt and a learning pattern triggers the distinct-click counter, the popular tier starts populating and cold-start rows drop out of rotation.
+
+---
+
+## Overriding the surface in embedded contexts
+
+Embedded widgets have a **privacy concern**: the adaptive surface is identified (favorites require a user context), and fetching it from a host page that doesn't need it leaks a request. The widget API lets you bypass the fetch entirely.
+
+### React component prop
+
+```tsx
+import { AtlasChat } from "@useatlas/react";
+
+<AtlasChat
+  apiUrl="https://api.useatlas.dev"
+  starterPrompts={["What are our top customers?", "Show me revenue by month"]}
+/>
+```
+
+Passing `starterPrompts` skips the `/api/v1/starter-prompts` request entirely — no network call is made from the embedded context. Pass `[]` to show no suggestions and still skip the fetch.
+
+### Script-tag attribute
+
+```html
+<script
+  src="https://app.useatlas.dev/widget.js"
+  data-api-url="https://api.useatlas.dev"
+  data-starter-prompts='["What are our top customers?", "Show me revenue by month"]'
+></script>
+```
+
+The `data-starter-prompts` attribute accepts a JSON array and is forwarded to the iframe as a query param. Same privacy guarantee as the React prop.
+
+### Omit to use the adaptive surface
+
+Omitting the prop / attribute is the default — the widget fetches the resolved favorites + popular + library list from `/api/v1/starter-prompts`, same as the web app.
+
+---
+
+## Programmatic access (SDK)
+
+```typescript
+import { Atlas } from "@useatlas/sdk";
+
+const atlas = new Atlas({
+  apiUrl: "https://api.useatlas.dev",
+  apiKey: "sk_live_...",
+});
+
+const { prompts, total } = await atlas.getStarterPrompts({ limit: 10 });
+
+for (const p of prompts) {
+  console.log(`[${p.provenance}] ${p.text}`);
+}
+```
+
+API keys map to a synthetic user context, so favorites tied to the API key's owner appear. See [SDK · Starter Prompts](/sdk/starter-prompts) for the full integration guide.
+
+For framework-agnostic fetch code, `fetchStarterPrompts()` is the headless helper — [SDK reference](/reference/sdk#fetchstarterprompts--headless-helper) has the details.
+
+---
+
+## Configuration reference
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `ATLAS_STARTER_PROMPT_MAX_FAVORITES` | `20` | Cap on favorites per user |
+| `ATLAS_STARTER_PROMPT_AUTO_PROMOTE_CLICKS` | `3` | Distinct-user clicks before a prompt enters the moderation queue |
+| `ATLAS_STARTER_PROMPT_COLD_WINDOW_DAYS` | `90` | How far back the click counter looks — older clicks decay out |
+| `ATLAS_DEMO_INDUSTRY` | — | Industry label for library-tier filtering (seeded at signup) |
+
+See [Environment Variables](/reference/environment-variables) for the full list.
+
+---
+
+## See also
+
+- [Starter Prompt Moderation](/guides/starter-prompt-moderation) — admin side: approve/hide/author
+- [SDK · Starter Prompts](/sdk/starter-prompts) — programmatic access
+- [Embedding the Widget](/guides/embedding-widget) — widget-level prop override
+- [Developer Mode](/guides/developer-mode) — demo-industry + `__demo__` lifecycle that feeds the library tier

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -413,6 +413,7 @@ Explore tool isolation backends. See [Sandbox Architecture](/architecture/sandbo
 | `ATLAS_NSJAIL_TIME_LIMIT` | `10` | nsjail per-command time limit in seconds |
 | `ATLAS_NSJAIL_MEMORY_LIMIT` | `256` | nsjail per-command memory limit in MB |
 | `ATLAS_SANDBOX_PRIORITY` | — | Comma-separated backend priority order (e.g. `sidecar,nsjail,just-bash`). Valid values: `vercel-sandbox`, `nsjail`, `sidecar`, `just-bash`. Plugin backends always take highest priority. See [Configuration](/reference/config#sandbox) |
+| `ATLAS_SANDBOX_BACKEND` | — | SaaS admin-facing selector for the workspace's sandbox backend: `vercel-sandbox`, `sidecar`, `e2b-sandbox`, `daytona-sandbox`, or a plugin ID. Set via the Settings UI in the hosted product; self-hosted operators typically use `ATLAS_SANDBOX_PRIORITY` instead |
 
 <Tabs items={["Docker Compose (dev)", "Production sidecar", "nsjail (self-hosted)"]}>
 <Tab value="Docker Compose (dev)">
@@ -489,8 +490,8 @@ Action framework settings. These can also be configured via [`atlas.config.ts`](
 |----------|---------|-------------|
 | `ATLAS_ACTIONS_ENABLED` | — | Set `true` to enable the action framework (approval-gated write operations) |
 | `ATLAS_ACTION_APPROVAL` | `manual` | Default approval mode for actions: `auto`, `manual`, or `admin-only` |
-| `ATLAS_ACTION_TIMEOUT` | — | Per-action execution timeout in milliseconds |
-| `ATLAS_ACTION_MAX_PER_CONVERSATION` | — | Maximum number of actions allowed per conversation |
+| `ATLAS_ACTION_TIMEOUT` | — | Per-action execution timeout in milliseconds. No default — the action runs until it returns or the request is cancelled. `.env.example` shows `300000` (5 min) as a reasonable starting point |
+| `ATLAS_ACTION_MAX_PER_CONVERSATION` | — | Reserved — not yet enforced. `.env.example` shows `10` as a future default. Currently accepts any value without effect |
 | `ATLAS_EMAIL_ALLOWED_DOMAINS` | — | Comma-separated list of allowed email recipient domains for the email action plugin. When unset, all domains are allowed |
 
 ```bash
@@ -706,6 +707,7 @@ SaaS only. Required for custom domain support via Railway.
 | `ATLAS_DEMO_ENABLED` | `false` | Enable demo mode at `/demo`. Allows unauthenticated users to try Atlas against the sample database with an email gate |
 | `ATLAS_DEMO_RATE_LIMIT_RPM` | `10` | Max requests per minute per demo user |
 | `ATLAS_DEMO_MAX_STEPS` | `10` | Max agent steps per demo request (lower than authenticated default of 25) |
+| `ATLAS_DEMO_INDUSTRY` | — | Industry label for the seeded `__demo__` connection (e.g. `cybersecurity`, `ecommerce`). Set at signup via onboarding; drives prompt-library industry filtering and the publish flow's demo-prompt archival cascade. See [Developer Mode](/guides/developer-mode) for the full demo lifecycle |
 
 Requires `BETTER_AUTH_SECRET` for demo token signing.
 

--- a/apps/docs/content/docs/reference/react.mdx
+++ b/apps/docs/content/docs/reference/react.mdx
@@ -1002,8 +1002,25 @@ import type {
 import type {
   UseConversationsOptions,
   UseConversationsReturn,
+  FavoriteStarterPrompt,
 } from "@useatlas/react";
 ```
+
+### Starter-prompt types
+
+```typescript
+import type { FavoriteStarterPrompt } from "@useatlas/react";
+
+// A pinned favorite — text + optional collection grouping
+interface FavoriteStarterPrompt {
+  id: string;
+  text: string;
+  collection: string | null;
+  createdAt: string;
+}
+```
+
+The `AtlasChat` widget also accepts a [`starterPrompts` prop](#atlaschat-props) that overrides the adaptive empty-state list. For script-tag embeds, the same list can be supplied via the `data-starter-prompts` JSON attribute — see [Embedding the Widget](/guides/embedding-widget) for details.
 
 ---
 

--- a/apps/docs/content/docs/reference/sdk.mdx
+++ b/apps/docs/content/docs/reference/sdk.mdx
@@ -159,6 +159,33 @@ for (const p of prompts) {
 }
 ```
 
+### `fetchStarterPrompts()` — headless helper
+
+For framework-agnostic data-fetching code (UI hooks, custom integrations) that doesn't need an `AtlasClient`, import the standalone helper directly:
+
+```typescript
+import { fetchStarterPrompts } from "@useatlas/sdk";
+
+const prompts = await fetchStarterPrompts({
+  apiUrl: "https://api.useatlas.dev",
+  credentials: { apiKey: "sk_live_..." },
+  limit: 10,
+  signal: abortController.signal,
+});
+```
+
+The helper differs from `atlas.getStarterPrompts()` on purpose:
+
+| Behavior | `atlas.getStarterPrompts()` | `fetchStarterPrompts()` |
+|----------|----------------------------|------------------------|
+| 5xx response | Throws | Returns `[]` (soft-fail) |
+| 4xx response | Throws | Throws with `requestId` |
+| Malformed JSON | Throws | Returns `[]` + logs warning |
+| `AbortError` | Re-throws | Swallows silently |
+| Return shape | `{ prompts, total }` | `StarterPrompt[]` |
+
+Use `atlas.getStarterPrompts()` when you want typed errors bubbling up to your app. Use `fetchStarterPrompts()` when building an empty-state UI surface that should gracefully render nothing on outage instead of flashing an error.
+
 ---
 
 ## Chat
@@ -908,6 +935,14 @@ import type {
   // Actions
   ActionStatus,
   RollbackActionResponse,
+
+  // Starter prompts
+  StarterPrompt,
+  StarterPromptProvenance,
+  StarterPromptsResponse,
+  GetStarterPromptsOptions,
+  FetchStarterPromptsConfig,
+  FetchStarterPromptsCredentials,
 } from "@useatlas/sdk";
 ```
 


### PR DESCRIPTION
## Summary
Five audit findings from the \`/docs-audit\` pass after phase 2 of #1515, all addressed in one PR since they're all docs-only and independent.

| Issue | Change |
|-------|--------|
| #1532 | New \`architecture/content-mode.mdx\` — contributor-facing reference for \`ContentModeRegistry\` |
| #1533 | New subsection in \`guides/developer-mode.mdx\` explaining \`__demo__\` connection + \`ATLAS_DEMO_INDUSTRY\` seeding, archival cascade, and self-hosted semantics |
| #1534 | New \`guides/starter-prompts.mdx\` — user-facing companion to the admin moderation guide |
| #1535 | Add \`ATLAS_SANDBOX_BACKEND\` + \`ATLAS_DEMO_INDUSTRY\` to env-vars reference and \`.env.example\`; align \`ATLAS_ACTION_*\` docs with example values |
| #1536 | Document \`fetchStarterPrompts()\` helper in sdk.mdx; add 6 starter-prompt types to Type Exports; add \`FavoriteStarterPrompt\` to react.mdx |

## Test plan
- [x] \`bun run type\` clean
- [x] \`bun run lint\` clean
- [ ] Visual review of new pages in docs dev server
- [ ] Verify meta.json nav placements render correctly

## Notes
- Two \`meta.json\` files updated (`architecture/meta.json` adds \`content-mode\`; `guides/meta.json` adds \`starter-prompts\` before \`starter-prompt-moderation\`).
- No source code changes — pure docs.

Closes #1532
Closes #1533
Closes #1534
Closes #1535
Closes #1536