### PR TITLE
fix(ee/auth): narrow parseCIDR input to defend against non-string DB rows

### DIFF
--- a/ee/src/auth/ip-allowlist.test.ts
+++ b/ee/src/auth/ip-allowlist.test.ts
@@ -149,6 +149,12 @@ describe("parseCIDR", () => {
   it("returns null for garbage input", () => {
     expect(parseCIDR("not-a-cidr")).toBeNull();
   });
+
+  it("returns null for non-string input (e.g. undefined row from a mocked DB)", () => {
+    expect(parseCIDR(undefined)).toBeNull();
+    expect(parseCIDR(null)).toBeNull();
+    expect(parseCIDR(123)).toBeNull();
+  });
 });
 
 // ── Tests: IP Range Matching ────────────────────────────────────────

--- a/ee/src/auth/ip-allowlist.ts
+++ b/ee/src/auth/ip-allowlist.ts
@@ -119,7 +119,8 @@ function networkAddress(addr: ipaddr.IPv4 | ipaddr.IPv6, prefixLen: number): ipa
  *
  * Returns null for invalid input.
  */
-export function parseCIDR(cidr: string): ParsedCIDR | null {
+export function parseCIDR(cidr: unknown): ParsedCIDR | null {
+  if (typeof cidr !== "string") return null;
   const trimmed = cidr.trim();
   if (!trimmed) return null;
 


### PR DESCRIPTION
Closes #1541.

## Why

\`parseCIDR\` (\`ee/src/auth/ip-allowlist.ts:122\`) called \`cidr.trim()\` directly, so a row where the \`cidr\` field is undefined (bad DB data, or a test mock reusing \`[{ count: 0 }]\` across queries) took down the whole \`checkIPAllowlist\` path with:

\`\`\`
TypeError: undefined is not an object (evaluating 'cidr.trim')
    at parseCIDR (ee/src/auth/ip-allowlist.ts:123:19)
    at <anonymous> (ee/src/auth/ip-allowlist.ts:348:24)
\`\`\`

That crashed auth middleware and returned 500, not the expected 200/404 — which is how it surfaced as 6 failing tests in \`packages/api/src/api/__tests__/admin-integrations.test.ts\`.

## What

- \`parseCIDR\` now accepts \`unknown\` and returns \`null\` for non-strings. The caller at \`:349\` already treats \`null\` as "invalid CIDR — skip with log.warn," which is the right fail-open-on-bad-data stance per the function's existing "Returns null for invalid input" contract.
- Added explicit coverage for \`undefined\` / \`null\` / number input in \`ip-allowlist.test.ts\`.
- Did NOT modify the test mock in \`admin-integrations.test.ts\` — the runtime fix makes the tests pass as-is. Tightening the mock to differentiate \`ip_allowlist\` vs \`webhook_configurations\` queries is adjacent tech debt, out of scope for this bug fix (CLAUDE.md: don't bundle cleanup with a bug fix).

## Test plan

- [x] \`bun test packages/api/src/api/__tests__/admin-integrations.test.ts\` → 7 pass / 0 fail
- [x] \`bun test ee/src/auth/ip-allowlist.test.ts\` → 58 pass / 0 fail (includes 1 new test for non-string input)
- [x] \`bun run type\` clean
- [x] No change to behavior for any valid string input — signature widening only