### PR TITLE
fix(web/admin): drop aria-controls from integrations CompactRow triggers

### DIFF
--- a/packages/web/src/app/admin/integrations/page.tsx
+++ b/packages/web/src/app/admin/integrations/page.tsx
@@ -364,7 +364,7 @@ function InlineError({ children }: { children: ReactNode }) {
  * Disclosure state for a progressive-disclosure integration card.
  *
  * Encapsulates four concerns that would otherwise repeat across every card:
- *  - expand/collapse state and a stable panel id for `aria-controls`
+ *  - expand/collapse state and a stable id applied to the rendered panel
  *  - moving focus into the revealed panel's first field on expand
  *  - returning focus to the trigger button on collapse
  *  - auto-collapsing once the integration becomes `connected` so a future
@@ -892,7 +892,6 @@ function SlackCard({
               size="sm"
               variant="outline"
               aria-expanded={false}
-              aria-controls={panelId}
               onClick={() => setExpanded(true)}
             >
               <Plus className="mr-1.5 size-3.5" />
@@ -1031,7 +1030,6 @@ function TeamsCard({
               size="sm"
               variant="outline"
               aria-expanded={false}
-              aria-controls={panelId}
               onClick={() => setExpanded(true)}
             >
               <Plus className="mr-1.5 size-3.5" />
@@ -1160,7 +1158,6 @@ function DiscordCard({
               size="sm"
               variant="outline"
               aria-expanded={false}
-              aria-controls={panelId}
               onClick={() => setExpanded(true)}
             >
               <Plus className="mr-1.5 size-3.5" />
@@ -1279,7 +1276,6 @@ function TelegramCard({
               size="sm"
               variant="outline"
               aria-expanded={false}
-              aria-controls={panelId}
               onClick={() => setExpanded(true)}
             >
               <Plus className="mr-1.5 size-3.5" />
@@ -1446,7 +1442,6 @@ function GChatCard({
               size="sm"
               variant="outline"
               aria-expanded={false}
-              aria-controls={panelId}
               onClick={() => setExpanded(true)}
             >
               <Plus className="mr-1.5 size-3.5" />
@@ -1621,7 +1616,6 @@ function GitHubCard({
               size="sm"
               variant="outline"
               aria-expanded={false}
-              aria-controls={panelId}
               onClick={() => setExpanded(true)}
             >
               <Plus className="mr-1.5 size-3.5" />
@@ -1785,7 +1779,6 @@ function LinearCard({
               size="sm"
               variant="outline"
               aria-expanded={false}
-              aria-controls={panelId}
               onClick={() => setExpanded(true)}
             >
               <Plus className="mr-1.5 size-3.5" />
@@ -1950,7 +1943,6 @@ function WhatsAppCard({
               size="sm"
               variant="outline"
               aria-expanded={false}
-              aria-controls={panelId}
               onClick={() => setExpanded(true)}
             >
               <Plus className="mr-1.5 size-3.5" />


### PR DESCRIPTION
Closes #1545.

## Why

The trigger in each disconnected-integration CompactRow declared \`aria-controls={panelId}\`, but the panel with that id only mounts after \`setExpanded(true)\` flips the branch. Assistive tech that resolves \`aria-controls\` on focus (before activation) finds nothing in the DOM — this violates the WAI-ARIA disclosure pattern, which expects the controlled element to exist (possibly \`hidden\`) even when collapsed.

Surfaced during the PR #1544 review.

## What

- Drops \`aria-controls\` from all 8 CompactRow triggers (Slack, Teams, Discord, Telegram, GChat, GitHub, Linear, WhatsApp). \`aria-expanded\` alone is the correct contract when the panel is not in the tree.
- The \`panelId\` remains wired to the expanded IntegrationShell via \`id={panelId}\`, so if we ever render both branches and toggle with \`hidden\` / CSS, restoring \`aria-controls\` is a one-line change per site.
- Updated the \`useDisclosure\` docstring to drop the now-stale "stable panel id for aria-controls" phrasing.

Matches the pattern shipped in PR #1544 for the billing page.

## Test plan

- [ ] \`bun x eslint src/app/admin/integrations/page.tsx\` — clean
- [ ] \`bun run type\` — clean
- [ ] Screen-reader smoke: focus a CompactRow trigger in \`/admin/integrations\` — \`aria-expanded="false"\` is announced; no dangling \`aria-controls\` reference.
- [ ] Expand a card — focus lands in the first form field (unchanged)
- [ ] Collapse via Cancel X — focus returns to the trigger (unchanged)