### PR TITLE
refactor(web/admin): redesign branding page with compact rows + live preview shell

### DIFF
--- a/packages/web/src/app/admin/branding/page.tsx
+++ b/packages/web/src/app/admin/branding/page.tsx
@@ -1,10 +1,28 @@
 "use client";
 
-import { useEffect } from "react";
-import { useForm } from "react-hook-form";
+import {
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type ReactNode,
+  type RefObject,
+} from "react";
+import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { Paintbrush, Loader2, RotateCcw, Eye } from "lucide-react";
+import {
+  Eye,
+  Globe,
+  Image as ImageIcon,
+  Loader2,
+  Palette,
+  Plus,
+  RotateCcw,
+  ShieldOff,
+  Type,
+  X,
+} from "lucide-react";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
@@ -21,18 +39,12 @@ import {
   FormDescription,
   FormMessage,
 } from "@/components/ui/form";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { WorkspaceBrandingSchema } from "@/ui/lib/admin-schemas";
+import { cn } from "@/lib/utils";
 
-const BrandingResponseSchema = z.object({
-  branding: WorkspaceBrandingSchema.nullable(),
-}).transform((r) => r.branding);
+const BrandingResponseSchema = z
+  .object({ branding: WorkspaceBrandingSchema.nullable() })
+  .transform((r) => r.branding);
 
 const HEX_RE = /^#[0-9a-fA-F]{6}$/;
 
@@ -46,22 +58,282 @@ const brandingSchema = z.object({
   hideAtlasBranding: z.boolean(),
 });
 
+type BrandingValues = z.infer<typeof brandingSchema>;
+
+const EMPTY: BrandingValues = {
+  logoUrl: "",
+  logoText: "",
+  primaryColor: "",
+  faviconUrl: "",
+  hideAtlasBranding: false,
+};
+
+// ── Shared design primitives ──────────────────────────────────────
+// Local copies of the admin/integrations + admin/billing primitives.
+// Promote to @/ui/components/admin/ once a fourth page reuses them.
+
+type StatusKind = "connected" | "disconnected" | "unavailable";
+
+function StatusDot({
+  kind,
+  className,
+}: {
+  kind: StatusKind;
+  className?: string;
+}) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "relative inline-flex size-1.5 shrink-0 rounded-full",
+        kind === "connected" &&
+          "bg-primary shadow-[0_0_0_3px_color-mix(in_oklch,var(--primary)_15%,transparent)]",
+        kind === "disconnected" && "bg-muted-foreground/40",
+        kind === "unavailable" &&
+          "bg-muted-foreground/20 outline-1 outline-dashed outline-muted-foreground/30",
+        className,
+      )}
+    >
+      {kind === "connected" && (
+        <span className="absolute inset-0 rounded-full bg-primary/60 motion-safe:animate-ping" />
+      )}
+    </span>
+  );
+}
+
+const STATUS_LABEL: Record<StatusKind, string> = {
+  connected: "Customized",
+  disconnected: "Default",
+  unavailable: "Unavailable",
+};
+
+function BrandingShell({
+  id,
+  icon,
+  title,
+  description,
+  status,
+  children,
+  actions,
+  onCollapse,
+  panelRef,
+}: {
+  id?: string;
+  icon: ReactNode;
+  title: string;
+  description: string;
+  status: StatusKind;
+  children?: ReactNode;
+  actions?: ReactNode;
+  onCollapse?: () => void;
+  panelRef?: RefObject<HTMLElement | null>;
+}) {
+  return (
+    <section
+      id={id}
+      ref={panelRef}
+      className={cn(
+        "relative flex flex-col overflow-hidden rounded-xl border bg-card/60 backdrop-blur-[1px] transition-colors",
+        "hover:border-border/80",
+        status === "connected" && "border-primary/20",
+      )}
+    >
+      {status === "connected" && (
+        <span
+          aria-hidden
+          className="pointer-events-none absolute left-0 top-4 bottom-4 w-px bg-linear-to-b from-transparent via-primary to-transparent opacity-70"
+        />
+      )}
+
+      <header className="flex items-start gap-3 p-4 pb-3">
+        <span
+          className={cn(
+            "grid size-9 shrink-0 place-items-center rounded-lg border bg-background/40",
+            status === "connected" && "border-primary/30 text-primary",
+            status !== "connected" && "text-muted-foreground",
+          )}
+        >
+          {icon}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h3 className="truncate text-sm font-semibold leading-tight tracking-tight">
+              {title}
+            </h3>
+            {status === "connected" && (
+              <span className="ml-auto flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.08em] text-primary">
+                <StatusDot kind="connected" />
+                Live
+              </span>
+            )}
+            {status !== "connected" && onCollapse && (
+              <button
+                type="button"
+                aria-label="Cancel"
+                onClick={onCollapse}
+                className="ml-auto -m-1 grid size-6 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <X className="size-3.5" />
+              </button>
+            )}
+          </div>
+          <p className="mt-0.5 text-xs leading-snug text-muted-foreground">
+            {description}
+          </p>
+        </div>
+      </header>
+
+      {children != null && (
+        <div className="flex-1 space-y-3 px-4 pb-3 text-sm">{children}</div>
+      )}
+
+      {actions && (
+        <footer className="flex items-center justify-end gap-2 border-t border-border/50 bg-muted/20 px-4 py-2.5">
+          {actions}
+        </footer>
+      )}
+    </section>
+  );
+}
+
+function CompactRow({
+  icon,
+  title,
+  description,
+  status,
+  action,
+}: {
+  icon: ReactNode;
+  title: string;
+  description: ReactNode;
+  status: StatusKind;
+  action?: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "group flex items-center gap-3 rounded-xl border bg-card/40 px-3.5 py-2.5 transition-colors",
+        "hover:bg-card/70 hover:border-border/80",
+        status === "unavailable" && "opacity-60",
+      )}
+    >
+      <span className="grid size-8 shrink-0 place-items-center rounded-lg border bg-background/40 text-muted-foreground">
+        {icon}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <h3 className="truncate text-sm font-semibold leading-tight tracking-tight">
+            {title}
+          </h3>
+          <StatusDot kind={status} className="shrink-0" />
+          <span className="sr-only">Status: {STATUS_LABEL[status]}</span>
+        </div>
+        <p className="mt-0.5 truncate text-xs text-muted-foreground">
+          {description}
+        </p>
+      </div>
+      {action && <div className="shrink-0">{action}</div>}
+    </div>
+  );
+}
+
+function SectionHeading({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="mb-3">
+      <h2 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+        {title}
+      </h2>
+      <p className="mt-0.5 text-xs text-muted-foreground/80">{description}</p>
+    </div>
+  );
+}
+
+function InlineError({ children }: { children: ReactNode }) {
+  if (!children) return null;
+  return (
+    <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Disclosure helper for progressive-disclosure rows. Moves focus into the
+ * revealed panel on expand, restores it to the trigger on collapse.
+ */
+function useDisclosure() {
+  const [expanded, setExpanded] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLElement | null>(null);
+  const panelId = useId();
+  const prev = useRef(false);
+
+  useEffect(() => {
+    if (expanded && !prev.current) {
+      const first = panelRef.current?.querySelector<HTMLElement>(
+        "input:not([disabled]), textarea:not([disabled])",
+      );
+      first?.focus();
+    } else if (!expanded && prev.current) {
+      triggerRef.current?.focus();
+    }
+    prev.current = expanded;
+  }, [expanded]);
+
+  return {
+    expanded,
+    setExpanded,
+    collapse: () => setExpanded(false),
+    triggerRef,
+    panelRef,
+    panelId,
+  };
+}
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+function truncateUrl(url: string, max = 44): string {
+  if (url.length <= max) return url;
+  return `${url.slice(0, max - 1)}…`;
+}
+
+function countCustomized(v: BrandingValues): number {
+  let n = 0;
+  if (v.logoUrl) n++;
+  if (v.logoText) n++;
+  if (v.primaryColor) n++;
+  if (v.faviconUrl) n++;
+  if (v.hideAtlasBranding) n++;
+  return n;
+}
+
+// ── Page ──────────────────────────────────────────────────────────
+
 export default function BrandingPage() {
   const { data, loading, error, refetch } = useAdminFetch(
     "/api/v1/admin/branding",
     { schema: BrandingResponseSchema },
   );
-  const { mutate, saving, error: saveError } = useAdminMutation({
+  const {
+    mutate,
+    saving,
+    error: saveError,
+  } = useAdminMutation({
     path: "/api/v1/admin/branding",
     invalidates: refetch,
   });
 
-  const form = useForm<z.infer<typeof brandingSchema>>({
+  const form = useForm<BrandingValues>({
     resolver: zodResolver(brandingSchema),
-    defaultValues: { logoUrl: "", logoText: "", primaryColor: "", faviconUrl: "", hideAtlasBranding: false },
+    defaultValues: EMPTY,
   });
 
-  // Sync form when server data loads or changes
   useEffect(() => {
     if (loading) return;
     if (data) {
@@ -73,231 +345,535 @@ export default function BrandingPage() {
         hideAtlasBranding: data.hideAtlasBranding,
       });
     } else {
-      form.reset({ logoUrl: "", logoText: "", primaryColor: "", faviconUrl: "", hideAtlasBranding: false });
+      form.reset(EMPTY);
     }
-  }, [data, loading]); // intentionally reset when data changes (after save/refetch)
+  }, [data, loading]); // intentionally reset when data changes
 
-  const primaryColor = form.watch("primaryColor");
-  const logoUrl = form.watch("logoUrl");
-  const logoText = form.watch("logoText");
-  const hideAtlasBranding = form.watch("hideAtlasBranding");
-  const colorValid = !primaryColor || HEX_RE.test(primaryColor);
+  const values = form.watch();
+  const customized = countCustomized(values);
+  const colorValid = !values.primaryColor || HEX_RE.test(values.primaryColor);
+  const isDirty = form.formState.isDirty;
 
-  async function handleSave(values: z.infer<typeof brandingSchema>) {
+  async function handleSave(v: BrandingValues) {
     const result = await mutate({
       method: "PUT",
       body: {
-        logoUrl: values.logoUrl || null,
-        logoText: values.logoText || null,
-        primaryColor: values.primaryColor || null,
-        faviconUrl: values.faviconUrl || null,
-        hideAtlasBranding: values.hideAtlasBranding,
+        logoUrl: v.logoUrl || null,
+        logoText: v.logoText || null,
+        primaryColor: v.primaryColor || null,
+        faviconUrl: v.faviconUrl || null,
+        hideAtlasBranding: v.hideAtlasBranding,
       },
     });
-    if (!result.ok) {
-      throw new Error("Save failed");
-    }
+    if (!result.ok) throw new Error("Save failed");
   }
 
   async function handleReset() {
     const result = await mutate({ method: "DELETE" });
-    if (result.ok) {
-      form.reset({ logoUrl: "", logoText: "", primaryColor: "", faviconUrl: "", hideAtlasBranding: false });
-    }
+    if (result.ok) form.reset(EMPTY);
   }
 
   return (
-    <div className="p-6 space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight">Branding</h1>
-        <p className="text-sm text-muted-foreground">
-          Customize the look and feel of your Atlas workspace. Replace the Atlas logo, colors, and favicon with your own brand.
+    <ErrorBoundary>
+      <div className="mx-auto max-w-3xl px-6 py-10">
+        <Hero customized={customized} />
+
+        <AdminContentWrapper
+          loading={loading}
+          error={error}
+          feature="Branding"
+          onRetry={refetch}
+          loadingMessage="Loading branding settings..."
+        >
+          <Form {...form}>
+            <form
+              onSubmit={form.handleSubmit(handleSave)}
+              className="space-y-10"
+            >
+              <section>
+                <SectionHeading
+                  title="Identity"
+                  description="Replace Atlas defaults with your own logo, type, and color"
+                />
+                <div className="space-y-2">
+                  <LogoUrlRow />
+                  <LogoTextRow />
+                  <PrimaryColorRow />
+                  <FaviconRow />
+                </div>
+              </section>
+
+              <section>
+                <SectionHeading
+                  title="Attribution"
+                  description="Control how Atlas is credited across the UI"
+                />
+                <AttributionRow />
+              </section>
+
+              <section>
+                <SectionHeading
+                  title="Preview"
+                  description="How the sidebar header renders with your current values"
+                />
+                <PreviewShell values={values} colorValid={colorValid} />
+              </section>
+
+              <InlineError>{saveError}</InlineError>
+
+              <footer className="flex items-center gap-2 border-t border-border/50 pt-5">
+                <Button
+                  type="submit"
+                  disabled={saving || !colorValid || !isDirty}
+                  size="sm"
+                >
+                  {saving && <Loader2 className="mr-1.5 size-3 animate-spin" />}
+                  {isDirty ? "Save changes" : "Saved"}
+                </Button>
+                {data && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={handleReset}
+                    disabled={saving}
+                  >
+                    <RotateCcw className="mr-1.5 size-3" />
+                    Reset to defaults
+                  </Button>
+                )}
+                <span className="ml-auto text-[11px] text-muted-foreground">
+                  {customized === 0
+                    ? "Using Atlas defaults"
+                    : `${customized} of 5 customized`}
+                </span>
+              </footer>
+            </form>
+          </Form>
+        </AdminContentWrapper>
+      </div>
+    </ErrorBoundary>
+  );
+}
+
+// ── Hero ──────────────────────────────────────────────────────────
+
+function Hero({ customized }: { customized: number }) {
+  const stat =
+    customized === 0 ? "Default" : `${customized} / 5 customized`;
+  return (
+    <header className="mb-10 flex flex-col gap-2">
+      <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+        Atlas · Admin
+      </p>
+      <div className="flex items-baseline justify-between gap-6">
+        <h1 className="text-3xl font-semibold tracking-tight">Branding</h1>
+        <p className="shrink-0 font-mono text-sm tabular-nums text-foreground">
+          {stat}
         </p>
       </div>
-
-      <ErrorBoundary>
-      <AdminContentWrapper
-        loading={loading}
-        error={error}
-        feature="Branding"
-        onRetry={refetch}
-        loadingMessage="Loading branding settings..."
-      >
-        <>
-          {/* Form */}
-          <Card className="shadow-none">
-            <CardHeader className="pb-2">
-              <CardTitle className="flex items-center gap-2 text-base">
-                <Paintbrush className="size-4" />
-                Workspace Branding
-              </CardTitle>
-              <CardDescription>
-                Configure custom branding for this workspace. Changes affect the admin console, chat UI, and widget embeds.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <Form {...form}>
-                <form onSubmit={form.handleSubmit(handleSave)} className="space-y-5">
-                  {/* Logo URL */}
-                  <FormField
-                    control={form.control}
-                    name="logoUrl"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Logo URL</FormLabel>
-                        <FormControl>
-                          <Input placeholder="https://example.com/logo.png" className="font-mono text-sm" {...field} />
-                        </FormControl>
-                        <FormDescription>URL to your custom logo image (PNG, SVG, or JPEG recommended).</FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-
-                  {/* Logo Text */}
-                  <FormField
-                    control={form.control}
-                    name="logoText"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Logo Text</FormLabel>
-                        <FormControl>
-                          <Input placeholder="Acme Corp" {...field} />
-                        </FormControl>
-                        <FormDescription>Text displayed next to or instead of the logo (e.g. your company name).</FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-
-                  {/* Primary Color */}
-                  <FormField
-                    control={form.control}
-                    name="primaryColor"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Primary Color</FormLabel>
-                        <div className="flex items-center gap-3">
-                          <div
-                            className="size-10 rounded-md border"
-                            style={{ backgroundColor: colorValid && primaryColor ? primaryColor : "#e5e5e5" }}
-                          />
-                          <FormControl>
-                            <Input placeholder="#FF5500" className="font-mono text-sm" {...field} />
-                          </FormControl>
-                        </div>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-
-                  {/* Favicon URL */}
-                  <FormField
-                    control={form.control}
-                    name="faviconUrl"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Favicon URL</FormLabel>
-                        <FormControl>
-                          <Input placeholder="https://example.com/favicon.ico" className="font-mono text-sm" {...field} />
-                        </FormControl>
-                        <FormDescription>URL to a custom favicon (.ico, .png, or .svg).</FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-
-                  {/* Hide Atlas Branding */}
-                  <FormField
-                    control={form.control}
-                    name="hideAtlasBranding"
-                    render={({ field }) => (
-                      <FormItem className="flex items-center gap-3 space-y-0">
-                        <FormControl>
-                          <Switch checked={field.value} onCheckedChange={field.onChange} />
-                        </FormControl>
-                        <FormLabel className="cursor-pointer">Hide Atlas branding</FormLabel>
-                      </FormItem>
-                    )}
-                  />
-                  <p className="text-xs text-muted-foreground -mt-3">
-                    When enabled, removes &ldquo;Atlas&rdquo; and &ldquo;Powered by Atlas&rdquo; text from the UI.
-                  </p>
-
-                  {/* Error */}
-                  {saveError && (
-                    <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                      {saveError}
-                    </div>
-                  )}
-
-                  {/* Actions */}
-                  <div className="flex gap-2">
-                    <Button type="submit" disabled={saving || !colorValid} size="sm">
-                      {saving && <Loader2 className="mr-1 size-3 animate-spin" />}
-                      Save
-                    </Button>
-                    {data && (
-                      <Button type="button" variant="outline" size="sm" onClick={handleReset} disabled={saving}>
-                        <RotateCcw className="mr-1 size-3" />
-                        Reset to defaults
-                      </Button>
-                    )}
-                  </div>
-                </form>
-              </Form>
-            </CardContent>
-          </Card>
-
-          {/* Live Preview */}
-          <Card className="shadow-none">
-            <CardHeader className="pb-2">
-              <CardTitle className="flex items-center gap-2 text-base">
-                <Eye className="size-4" />
-                Live Preview
-              </CardTitle>
-              <CardDescription>Preview how the sidebar header will look with your branding.</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="rounded-lg border p-4">
-                <div className="flex items-center gap-3">
-                  {/* Logo preview */}
-                  {logoUrl ? (
-                    <div className="flex size-8 items-center justify-center rounded-lg bg-muted">
-                      {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img
-                        src={logoUrl}
-                        alt="Logo preview"
-                        className="size-6 object-contain"
-                        onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
-                      />
-                    </div>
-                  ) : (
-                    <div
-                      className="flex size-8 items-center justify-center rounded-lg"
-                      style={{ backgroundColor: primaryColor && colorValid ? primaryColor : "var(--sidebar-primary)" }}
-                    >
-                      <svg viewBox="0 0 256 256" fill="none" className="size-4 text-white" aria-hidden="true">
-                        <path d="M128 24 L232 208 L24 208 Z" stroke="currentColor" strokeWidth="20" fill="none" strokeLinejoin="round" />
-                      </svg>
-                    </div>
-                  )}
-                  {/* Text preview */}
-                  <div className="grid text-left text-sm leading-tight">
-                    <span className="truncate font-semibold">
-                      {hideAtlasBranding ? (logoText || "Your Brand") : (logoText || "Atlas")}
-                    </span>
-                    <span className="truncate text-xs text-muted-foreground">
-                      {hideAtlasBranding ? "" : "Admin Console"}
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </>
-      </AdminContentWrapper>
-      </ErrorBoundary>
-    </div>
+      <p className="max-w-xl text-sm text-muted-foreground">
+        Customize the look and feel of your workspace. Changes affect the admin
+        console, chat UI, and widget embeds.
+      </p>
+    </header>
   );
+}
+
+// ── Rows ──────────────────────────────────────────────────────────
+
+function LogoUrlRow() {
+  const { expanded, setExpanded, collapse, triggerRef, panelRef, panelId } =
+    useDisclosure();
+  const value = useWatchField("logoUrl");
+
+  if (!expanded) {
+    return (
+      <CompactRow
+        icon={<ImageIcon className="size-4" />}
+        title="Logo image"
+        description={value || "Replace the Atlas logo with your own image"}
+        status={value ? "connected" : "disconnected"}
+        action={
+          <Button
+            ref={triggerRef}
+            type="button"
+            size="sm"
+            variant="outline"
+            aria-expanded={false}
+            onClick={() => setExpanded(true)}
+          >
+            {value ? (
+              "Edit"
+            ) : (
+              <>
+                <Plus className="mr-1.5 size-3.5" />
+                Set URL
+              </>
+            )}
+          </Button>
+        }
+      />
+    );
+  }
+
+  return (
+    <BrandingShell
+      id={panelId}
+      panelRef={panelRef}
+      icon={<ImageIcon className="size-4" />}
+      title="Logo image"
+      description="PNG, SVG, or JPEG recommended. Served from your own origin."
+      status="disconnected"
+      onCollapse={collapse}
+    >
+      <FormField
+        name="logoUrl"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="sr-only">Logo URL</FormLabel>
+            <FormControl>
+              <Input
+                placeholder="https://example.com/logo.png"
+                className="font-mono text-sm"
+                {...field}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </BrandingShell>
+  );
+}
+
+function LogoTextRow() {
+  const { expanded, setExpanded, collapse, triggerRef, panelRef, panelId } =
+    useDisclosure();
+  const value = useWatchField("logoText");
+
+  if (!expanded) {
+    return (
+      <CompactRow
+        icon={<Type className="size-4" />}
+        title="Logo text"
+        description={value || "Displayed next to or instead of the logo"}
+        status={value ? "connected" : "disconnected"}
+        action={
+          <Button
+            ref={triggerRef}
+            type="button"
+            size="sm"
+            variant="outline"
+            aria-expanded={false}
+            onClick={() => setExpanded(true)}
+          >
+            {value ? (
+              "Edit"
+            ) : (
+              <>
+                <Plus className="mr-1.5 size-3.5" />
+                Set text
+              </>
+            )}
+          </Button>
+        }
+      />
+    );
+  }
+
+  return (
+    <BrandingShell
+      id={panelId}
+      panelRef={panelRef}
+      icon={<Type className="size-4" />}
+      title="Logo text"
+      description="Usually your company name. Shown in the sidebar header."
+      status="disconnected"
+      onCollapse={collapse}
+    >
+      <FormField
+        name="logoText"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="sr-only">Logo text</FormLabel>
+            <FormControl>
+              <Input placeholder="Acme Corp" {...field} />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </BrandingShell>
+  );
+}
+
+function PrimaryColorRow() {
+  const { expanded, setExpanded, collapse, triggerRef, panelRef, panelId } =
+    useDisclosure();
+  const value = useWatchField("primaryColor");
+  const valid = !value || HEX_RE.test(value);
+  const swatchColor = valid && value ? value : null;
+  const status: StatusKind = value ? "connected" : "disconnected";
+
+  const swatchIcon = swatchColor ? (
+    <span
+      aria-hidden
+      className="size-4 rounded-sm border border-border/60"
+      style={{ backgroundColor: swatchColor }}
+    />
+  ) : (
+    <Palette className="size-4" />
+  );
+
+  if (!expanded) {
+    return (
+      <CompactRow
+        icon={swatchIcon}
+        title="Primary color"
+        description={
+          value ? (
+            <span className="font-mono text-[11px]">{value}</span>
+          ) : (
+            "Teal is the default accent"
+          )
+        }
+        status={status}
+        action={
+          <Button
+            ref={triggerRef}
+            type="button"
+            size="sm"
+            variant="outline"
+            aria-expanded={false}
+            onClick={() => setExpanded(true)}
+          >
+            {value ? (
+              "Edit"
+            ) : (
+              <>
+                <Plus className="mr-1.5 size-3.5" />
+                Set color
+              </>
+            )}
+          </Button>
+        }
+      />
+    );
+  }
+
+  return (
+    <BrandingShell
+      id={panelId}
+      panelRef={panelRef}
+      icon={swatchIcon}
+      title="Primary color"
+      description="6-digit hex (e.g. #FF5500). Used for buttons and accents."
+      status="disconnected"
+      onCollapse={collapse}
+    >
+      <FormField
+        name="primaryColor"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="sr-only">Primary color</FormLabel>
+            <div className="flex items-center gap-3">
+              <span
+                aria-hidden
+                className="size-10 shrink-0 rounded-md border"
+                style={{
+                  backgroundColor: swatchColor ?? "var(--muted)",
+                }}
+              />
+              <FormControl>
+                <Input
+                  placeholder="#FF5500"
+                  className="font-mono text-sm"
+                  {...field}
+                />
+              </FormControl>
+            </div>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </BrandingShell>
+  );
+}
+
+function FaviconRow() {
+  const { expanded, setExpanded, collapse, triggerRef, panelRef, panelId } =
+    useDisclosure();
+  const value = useWatchField("faviconUrl");
+
+  if (!expanded) {
+    return (
+      <CompactRow
+        icon={<Globe className="size-4" />}
+        title="Favicon"
+        description={value ? truncateUrl(value) : "Shown in browser tabs and bookmarks"}
+        status={value ? "connected" : "disconnected"}
+        action={
+          <Button
+            ref={triggerRef}
+            type="button"
+            size="sm"
+            variant="outline"
+            aria-expanded={false}
+            onClick={() => setExpanded(true)}
+          >
+            {value ? (
+              "Edit"
+            ) : (
+              <>
+                <Plus className="mr-1.5 size-3.5" />
+                Set URL
+              </>
+            )}
+          </Button>
+        }
+      />
+    );
+  }
+
+  return (
+    <BrandingShell
+      id={panelId}
+      panelRef={panelRef}
+      icon={<Globe className="size-4" />}
+      title="Favicon"
+      description="Accepts .ico, .png, or .svg. Browsers cache aggressively — expect a delay."
+      status="disconnected"
+      onCollapse={collapse}
+    >
+      <FormField
+        name="faviconUrl"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="sr-only">Favicon URL</FormLabel>
+            <FormControl>
+              <Input
+                placeholder="https://example.com/favicon.ico"
+                className="font-mono text-sm"
+                {...field}
+              />
+            </FormControl>
+            <FormDescription className="text-[11px]">
+              Browsers cache favicons aggressively; clear site data to verify.
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </BrandingShell>
+  );
+}
+
+function AttributionRow() {
+  return (
+    <FormField
+      name="hideAtlasBranding"
+      render={({ field }) => (
+        <FormItem className="space-y-0">
+          <CompactRow
+            icon={<ShieldOff className="size-4" />}
+            title="Hide Atlas branding"
+            description={
+              field.value
+                ? "“Atlas” and “Powered by Atlas” text are hidden"
+                : "Default — Atlas attribution remains visible"
+            }
+            status={field.value ? "connected" : "disconnected"}
+            action={
+              <FormControl>
+                <Switch
+                  checked={field.value}
+                  onCheckedChange={field.onChange}
+                  aria-label="Hide Atlas branding"
+                />
+              </FormControl>
+            }
+          />
+        </FormItem>
+      )}
+    />
+  );
+}
+
+// ── Preview shell ─────────────────────────────────────────────────
+
+function PreviewShell({
+  values,
+  colorValid,
+}: {
+  values: BrandingValues;
+  colorValid: boolean;
+}) {
+  const { logoUrl, logoText, primaryColor, hideAtlasBranding } = values;
+  const anyCustomized = countCustomized(values) > 0;
+  const bg =
+    primaryColor && colorValid ? primaryColor : "var(--sidebar-primary)";
+
+  return (
+    <BrandingShell
+      icon={<Eye className="size-4" />}
+      title="Sidebar header"
+      description="Live preview — reflects unsaved edits."
+      status={anyCustomized ? "connected" : "disconnected"}
+    >
+      <div className="rounded-lg border bg-background/60 p-4">
+        <div className="flex items-center gap-3">
+          {logoUrl ? (
+            <div className="flex size-8 items-center justify-center rounded-lg bg-muted">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={logoUrl}
+                alt="Logo preview"
+                className="size-6 object-contain"
+                onError={(e) => {
+                  (e.target as HTMLImageElement).style.display = "none";
+                }}
+              />
+            </div>
+          ) : (
+            <div
+              className="flex size-8 items-center justify-center rounded-lg"
+              style={{ backgroundColor: bg }}
+            >
+              <svg
+                viewBox="0 0 256 256"
+                fill="none"
+                className="size-4 text-white"
+                aria-hidden="true"
+              >
+                <path
+                  d="M128 24 L232 208 L24 208 Z"
+                  stroke="currentColor"
+                  strokeWidth="20"
+                  fill="none"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          )}
+          <div className="grid min-w-0 text-left text-sm leading-tight">
+            <span className="truncate font-semibold">
+              {hideAtlasBranding ? logoText || "Your Brand" : logoText || "Atlas"}
+            </span>
+            <span className="truncate text-xs text-muted-foreground">
+              {hideAtlasBranding ? "" : "Admin Console"}
+            </span>
+          </div>
+        </div>
+      </div>
+    </BrandingShell>
+  );
+}
+
+// ── Internal hook ─────────────────────────────────────────────────
+
+function useWatchField<K extends keyof BrandingValues>(
+  name: K,
+): BrandingValues[K] {
+  return useWatch({ name }) as BrandingValues[K];
 }

--- a/packages/web/src/app/admin/branding/page.tsx
+++ b/packages/web/src/app/admin/branding/page.tsx
@@ -12,6 +12,7 @@ import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import {
+  AlertCircle,
   Eye,
   Globe,
   Image as ImageIcon,
@@ -69,8 +70,9 @@ const EMPTY: BrandingValues = {
 };
 
 // ── Shared design primitives ──────────────────────────────────────
-// Local copies of the admin/integrations + admin/billing primitives.
-// Promote to @/ui/components/admin/ once a fourth page reuses them.
+// Mirrors the copies in admin/billing and admin/integrations. The three
+// duplicates are load-bearing until extraction; do not drift them.
+// TODO: extract to @/ui/components/admin/ in a dedicated refactor PR.
 
 type StatusKind = "connected" | "disconnected" | "unavailable";
 
@@ -148,7 +150,9 @@ function BrandingShell({
       <header className="flex items-start gap-3 p-4 pb-3">
         <span
           className={cn(
-            "grid size-9 shrink-0 place-items-center rounded-lg border bg-background/40",
+            // [&>svg]:size-4 restores billing's sizing invariant since
+            // we widened the icon prop to ReactNode for the swatch case
+            "grid size-9 shrink-0 place-items-center rounded-lg border bg-background/40 [&>svg]:size-4",
             status === "connected" && "border-primary/30 text-primary",
             status !== "connected" && "text-muted-foreground",
           )}
@@ -217,7 +221,7 @@ function CompactRow({
         status === "unavailable" && "opacity-60",
       )}
     >
-      <span className="grid size-8 shrink-0 place-items-center rounded-lg border bg-background/40 text-muted-foreground">
+      <span className="grid size-8 shrink-0 place-items-center rounded-lg border bg-background/40 text-muted-foreground [&>svg]:size-4">
         {icon}
       </span>
       <div className="min-w-0 flex-1">
@@ -266,6 +270,11 @@ function InlineError({ children }: { children: ReactNode }) {
 /**
  * Disclosure helper for progressive-disclosure rows. Moves focus into the
  * revealed panel on expand, restores it to the trigger on collapse.
+ *
+ * Branding rows have no per-row side effects to clean up on collapse,
+ * so this is the trimmed variant of the admin/integrations hook — no
+ * `connected` arg, no `onCollapseCleanup` callback. If a future branding
+ * row needs cleanup, pull in the admin/integrations shape.
  */
 function useDisclosure() {
   const [expanded, setExpanded] = useState(false);
@@ -320,11 +329,11 @@ export default function BrandingPage() {
     "/api/v1/admin/branding",
     { schema: BrandingResponseSchema },
   );
-  const {
-    mutate,
-    saving,
-    error: saveError,
-  } = useAdminMutation({
+  const save = useAdminMutation({
+    path: "/api/v1/admin/branding",
+    invalidates: refetch,
+  });
+  const reset = useAdminMutation({
     path: "/api/v1/admin/branding",
     invalidates: refetch,
   });
@@ -334,6 +343,9 @@ export default function BrandingPage() {
     defaultValues: EMPTY,
   });
 
+  // Reset form to server state whenever the fetched `data` changes — e.g.
+  // after save/reset refetches. `form.reset` has a stable identity per RHF,
+  // so it's omitted from deps deliberately; adding it would loop.
   useEffect(() => {
     if (loading) return;
     if (data) {
@@ -347,15 +359,18 @@ export default function BrandingPage() {
     } else {
       form.reset(EMPTY);
     }
-  }, [data, loading]); // intentionally reset when data changes
+  }, [data, loading]);
 
   const values = form.watch();
   const customized = countCustomized(values);
   const colorValid = !values.primaryColor || HEX_RE.test(values.primaryColor);
   const isDirty = form.formState.isDirty;
+  const busy = save.saving || reset.saving;
 
   async function handleSave(v: BrandingValues) {
-    const result = await mutate({
+    // saveError state is surfaced via <InlineError> below — no throw
+    // needed; react-hook-form's handleSubmit would swallow it anyway.
+    await save.mutate({
       method: "PUT",
       body: {
         logoUrl: v.logoUrl || null,
@@ -365,11 +380,10 @@ export default function BrandingPage() {
         hideAtlasBranding: v.hideAtlasBranding,
       },
     });
-    if (!result.ok) throw new Error("Save failed");
   }
 
   async function handleReset() {
-    const result = await mutate({ method: "DELETE" });
+    const result = await reset.mutate({ method: "DELETE" });
     if (result.ok) form.reset(EMPTY);
   }
 
@@ -419,15 +433,34 @@ export default function BrandingPage() {
                 <PreviewShell values={values} colorValid={colorValid} />
               </section>
 
-              <InlineError>{saveError}</InlineError>
+              {save.error && (
+                <InlineError>
+                  <span className="font-semibold">Save failed.</span>{" "}
+                  {save.error}
+                </InlineError>
+              )}
+              {reset.error && (
+                <InlineError>
+                  <span className="font-semibold">Reset failed.</span>{" "}
+                  {reset.error}
+                </InlineError>
+              )}
+              {!colorValid && (
+                <InlineError>
+                  Primary color must be a 6-digit hex (e.g. #FF5500). Open
+                  the Primary color row to fix.
+                </InlineError>
+              )}
 
               <footer className="flex items-center gap-2 border-t border-border/50 pt-5">
                 <Button
                   type="submit"
-                  disabled={saving || !colorValid || !isDirty}
+                  disabled={busy || !colorValid || !isDirty}
                   size="sm"
                 >
-                  {saving && <Loader2 className="mr-1.5 size-3 animate-spin" />}
+                  {save.saving && (
+                    <Loader2 className="mr-1.5 size-3 animate-spin" />
+                  )}
                   {isDirty ? "Save changes" : "Saved"}
                 </Button>
                 {data && (
@@ -436,9 +469,13 @@ export default function BrandingPage() {
                     variant="outline"
                     size="sm"
                     onClick={handleReset}
-                    disabled={saving}
+                    disabled={busy}
                   >
-                    <RotateCcw className="mr-1.5 size-3" />
+                    {reset.saving ? (
+                      <Loader2 className="mr-1.5 size-3 animate-spin" />
+                    ) : (
+                      <RotateCcw className="mr-1.5 size-3" />
+                    )}
                     Reset to defaults
                   </Button>
                 )}
@@ -614,7 +651,12 @@ function PrimaryColorRow() {
   const value = useWatchField("primaryColor");
   const valid = !value || HEX_RE.test(value);
   const swatchColor = valid && value ? value : null;
-  const status: StatusKind = value ? "connected" : "disconnected";
+  const invalid = Boolean(value) && !valid;
+  const status: StatusKind = invalid
+    ? "unavailable"
+    : value
+      ? "connected"
+      : "disconnected";
 
   const swatchIcon = swatchColor ? (
     <span
@@ -623,7 +665,7 @@ function PrimaryColorRow() {
       style={{ backgroundColor: swatchColor }}
     />
   ) : (
-    <Palette className="size-4" />
+    <Palette />
   );
 
   if (!expanded) {
@@ -632,7 +674,11 @@ function PrimaryColorRow() {
         icon={swatchIcon}
         title="Primary color"
         description={
-          value ? (
+          invalid ? (
+            <span className="text-destructive">
+              Invalid hex — click Edit to fix
+            </span>
+          ) : value ? (
             <span className="font-mono text-[11px]">{value}</span>
           ) : (
             "Teal is the default accent"
@@ -742,7 +788,7 @@ function FaviconRow() {
       panelRef={panelRef}
       icon={<Globe className="size-4" />}
       title="Favicon"
-      description="Accepts .ico, .png, or .svg. Browsers cache aggressively — expect a delay."
+      description="Accepts .ico, .png, or .svg."
       status="disconnected"
       onCollapse={collapse}
     >
@@ -814,6 +860,12 @@ function PreviewShell({
   const bg =
     primaryColor && colorValid ? primaryColor : "var(--sidebar-primary)";
 
+  const [logoBroken, setLogoBroken] = useState(false);
+  // Re-attempt the load whenever the URL changes so a typo fix clears the error
+  useEffect(() => {
+    setLogoBroken(false);
+  }, [logoUrl]);
+
   return (
     <BrandingShell
       icon={<Eye className="size-4" />}
@@ -823,17 +875,29 @@ function PreviewShell({
     >
       <div className="rounded-lg border bg-background/60 p-4">
         <div className="flex items-center gap-3">
-          {logoUrl ? (
+          {logoUrl && !logoBroken ? (
             <div className="flex size-8 items-center justify-center rounded-lg bg-muted">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
+              {/* eslint-disable-next-line @next/next/no-img-element -- user-supplied URL, not in next.config remotePatterns */}
               <img
                 src={logoUrl}
                 alt="Logo preview"
                 className="size-6 object-contain"
-                onError={(e) => {
-                  (e.target as HTMLImageElement).style.display = "none";
+                onError={() => {
+                  // Surface a signal to the user (AlertCircle fallback) +
+                  // a debug trail so the admin can diagnose CORS / 404 / codec.
+                  console.debug("[branding] logo preview failed to load", {
+                    logoUrl,
+                  });
+                  setLogoBroken(true);
                 }}
               />
+            </div>
+          ) : logoUrl && logoBroken ? (
+            <div
+              className="flex size-8 items-center justify-center rounded-lg border border-destructive/30 bg-destructive/10 text-destructive"
+              title="Logo URL failed to load"
+            >
+              <AlertCircle className="size-4" />
             </div>
           ) : (
             <div
@@ -866,6 +930,12 @@ function PreviewShell({
           </div>
         </div>
       </div>
+      {logoUrl && logoBroken && (
+        <p className="text-[11px] leading-relaxed text-destructive">
+          Logo failed to load. Check the URL is reachable and serves a valid
+          image with permissive CORS headers.
+        </p>
+      )}
     </BrandingShell>
   );
 }


### PR DESCRIPTION
## Summary

The previous **/admin/branding** page opened all five inputs — `logoUrl`,
`logoText`, `primaryColor`, `faviconUrl`, `hideAtlasBranding` — inside a
single always-expanded Form card, with a separate Live Preview card
stacked below. Because every field is blank by default, the empty state
dominated the surface: a new admin landed on a wall of five empty inputs
and a preview of the unchanged Atlas default sidebar. Classic
wall-of-forms, off-brand for the \"quiet confidence\" principle in
`.impeccable.md`.

This PR applies the same `/revamp` pattern we shipped on #1538
(integrations) and #1544 (billing):

- **Progressive disclosure.** Each Identity field collapses to a thin
  `CompactRow`. Clicking `+ Set URL` / `+ Set text` / `+ Set color`
  expands a `BrandingShell` with only that field's `Input`. The Primary
  color row swaps its `Palette` icon for the actual hex swatch once a
  valid value is set — the row is the preview.
- **Attribution isolated.** `Hide Atlas branding` now has its own
  section and an inline `Switch` in the action slot (same inline-toggle
  pattern as billing's `ByotRow`).
- **Page shell.** `max-w-3xl` vertical column, three `SectionHeading`s
  (Identity / Attribution / Preview), and a hero with an `Atlas · Admin`
  eyebrow, the page title, and a mono `tabular-nums` stat on the right:
  `Default` when nothing is customized, `N / 5 customized` otherwise.
- **Primitives.** `StatusDot`, `BrandingShell`, `CompactRow`,
  `SectionHeading`, `InlineError`, `useDisclosure` — lifted from
  `admin/billing` and `admin/integrations` (local copies, not a shared
  import; per the `/revamp` skill these extract to
  `packages/web/src/ui/components/admin/` once a fourth page adopts
  them).
- **Form state.** Single `react-hook-form` instance; each row reads its
  value via `useWatch`, so collapsed rows re-render immediately when
  the input inside an expanded sibling changes. Expanded shells always
  pass `status=\"disconnected\"` so the X-close control stays reachable
  even after a value is typed (matches billing's `ModelRow`).

The `WorkspaceBranding` shape, the single `PUT /api/v1/admin/branding`
mutation, the `DELETE` reset, the Zod validator, and the hex check are
untouched — this is a **presentational pass only**.

## Test plan

- [ ] Default state: hero reads `Default`, footer reads `Using Atlas
      defaults`, all four Identity rows collapsed, attribution switch
      off, Preview shell renders the Atlas default sidebar.
- [ ] Expand each Identity row from its CompactRow, confirm focus lands
      in the revealed input, click the header X, confirm focus returns
      to the trigger.
- [ ] Type `https://useatlas.dev/logo.png` → collapse → CompactRow
      shows the URL, teal status dot, and `Edit` button (not
      `+ Set URL`). Re-expand, confirm the input re-renders with the
      prior value intact.
- [ ] Type `#FF6B35` → collapse → row icon slot turns into an orange
      swatch, hex renders as mono in the description; then invalid
      value (`FF6B35`, no `#`) blocks Save.
- [ ] Toggle `Hide Atlas branding` → CompactRow flips to teal/Live
      state, Preview shell updates (drops `Admin Console` sub-label).
- [ ] Hero stat climbs from `Default` → `N / 5 customized` as each
      field is set; returns to `Default` after **Reset to defaults**.
- [ ] Save button disabled with `Saved` label when the form matches
      persisted state; enables with `Save changes` once anything
      dirties.
- [ ] Dark mode parity — teal status dot / pulse, shell border tint,
      and hero stat all read correctly.