### PR TITLE
refactor(web/admin): redesign settings with compact rows + per-section icons

### DIFF
--- a/packages/web/src/app/admin/settings/page.tsx
+++ b/packages/web/src/app/admin/settings/page.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type ComponentType } from "react";
 import { z } from "zod";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
@@ -21,16 +19,34 @@ import {
   FormControl,
   FormMessage,
 } from "@/components/form-dialog";
-import { Separator } from "@/components/ui/separator";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { useDeployMode } from "@/ui/hooks/use-deploy-mode";
-import { Settings, Pencil, RotateCcw, Loader2, Info, Lock, RefreshCw } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  Bot,
+  Brain,
+  Cpu,
+  Database,
+  FlaskConical,
+  Gauge,
+  Info,
+  Loader2,
+  Lock,
+  Pencil,
+  RefreshCw,
+  RotateCcw,
+  Settings,
+  Timer,
+} from "lucide-react";
 
 // ── Schemas ───────────────────────────────────────────────────────
+
+const SettingSourceSchema = z.enum(["env", "override", "workspace-override", "default"]);
+type SettingSource = z.infer<typeof SettingSourceSchema>;
 
 const SettingWithValueSchema = z.object({
   key: z.string(),
@@ -45,7 +61,7 @@ const SettingWithValueSchema = z.object({
   requiresRestart: z.boolean().optional(),
   scope: z.enum(["platform", "workspace"]),
   currentValue: z.string().optional(),
-  source: z.enum(["env", "override", "workspace-override", "default"]),
+  source: SettingSourceSchema,
 });
 type SettingWithValue = z.infer<typeof SettingWithValueSchema>;
 
@@ -54,38 +70,65 @@ const SettingsResponseSchema = z.object({
   manageable: z.boolean(),
 });
 
-// ── Source badge ───────────────────────────────────────────────────
+// ── Section metadata ──────────────────────────────────────────────
 
-function SourceBadge({ source }: { source: "env" | "override" | "workspace-override" | "default" }) {
-  if (source === "workspace-override") {
-    return (
-      <Badge variant="default" className="bg-violet-600 text-[10px]">
-        workspace override
-      </Badge>
-    );
-  }
-  if (source === "override") {
-    return (
-      <Badge variant="default" className="text-[10px]">
-        override
-      </Badge>
-    );
-  }
-  if (source === "env") {
-    return (
-      <Badge variant="secondary" className="bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 text-[10px]">
-        env
-      </Badge>
-    );
-  }
+const SECTION_ICONS: Record<string, ComponentType<{ className?: string }>> = {
+  "Query Limits": Database,
+  "Rate Limiting": Gauge,
+  Sessions: Timer,
+  Sandbox: Cpu,
+  Agent: Bot,
+  Intelligence: Brain,
+  Demo: FlaskConical,
+};
+
+const SECTION_ORDER = [
+  "Query Limits",
+  "Rate Limiting",
+  "Sessions",
+  "Sandbox",
+  "Agent",
+  "Intelligence",
+  "Demo",
+];
+
+function sectionIcon(section: string): ComponentType<{ className?: string }> {
+  return SECTION_ICONS[section] ?? Settings;
+}
+
+// ── Source pill ───────────────────────────────────────────────────
+// Only rendered when source !== "default" — default is the default state,
+// and labeling it on every row was pure noise.
+
+function SourcePill({ source }: { source: Exclude<SettingSource, "default"> }) {
+  const tone =
+    source === "workspace-override"
+      ? "text-violet-600 dark:text-violet-400"
+      : source === "override"
+        ? "text-primary"
+        : "text-emerald-600 dark:text-emerald-400";
+  const dotTone =
+    source === "workspace-override"
+      ? "bg-violet-500"
+      : source === "override"
+        ? "bg-primary"
+        : "bg-emerald-500";
+  const label =
+    source === "workspace-override" ? "Workspace" : source === "override" ? "Override" : "Env";
   return (
-    <Badge variant="outline" className="text-[10px] text-muted-foreground">
-      default
-    </Badge>
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.08em]",
+        tone,
+      )}
+    >
+      <span className={cn("size-1.5 rounded-full", dotTone)} />
+      {label}
+    </span>
   );
 }
 
-// ── Edit Dialog ───────────────────────────────────────────────────
+// ── Setting control (reused for dialog) ───────────────────────────
 
 const editSettingSchema = z.object({
   value: z.string(),
@@ -210,7 +253,20 @@ function EditDialog({
   );
 }
 
-// ── Setting Row ───────────────────────────────────────────────────
+// ── Section + row primitives ──────────────────────────────────────
+
+function SectionHeading({ title, description }: { title: string; description?: string }) {
+  return (
+    <div className="mb-3">
+      <h2 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+        {title}
+      </h2>
+      {description && (
+        <p className="mt-0.5 text-xs text-muted-foreground/80">{description}</p>
+      )}
+    </div>
+  );
+}
 
 function SettingRow({
   setting,
@@ -228,38 +284,56 @@ function SettingRow({
   deployMode: "saas" | "self-hosted";
 }) {
   const isSaas = deployMode === "saas";
-  const displayValue = setting.currentValue ?? (
-    <span className="text-muted-foreground italic">not set</span>
-  );
+  const Icon = sectionIcon(setting.section);
+  const isOverride =
+    setting.source === "override" || setting.source === "workspace-override";
+  const showRestart = !isSaas && setting.requiresRestart && isOverride;
+  const valueText = setting.currentValue ?? "—";
 
   return (
-    <div className="flex items-start justify-between gap-4 py-3">
+    <div
+      className={cn(
+        "group flex items-start gap-3 rounded-xl border bg-card/40 px-3.5 py-3 transition-colors",
+        "hover:border-border/80 hover:bg-card/70",
+        isOverride && "border-primary/15",
+      )}
+    >
+      <span
+        className={cn(
+          "mt-0.5 grid size-8 shrink-0 place-items-center rounded-lg border bg-background/40",
+          isOverride ? "border-primary/20 text-primary" : "text-muted-foreground",
+        )}
+      >
+        <Icon className="size-4" />
+      </span>
       <div className="min-w-0 flex-1 space-y-1">
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-medium">{setting.label}</span>
-          <SourceBadge source={setting.source} />
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <h3 className="truncate text-sm font-semibold leading-tight tracking-tight">
+            {setting.label}
+          </h3>
           {setting.secret && <Lock className="size-3 text-muted-foreground" />}
-          {!isSaas && setting.requiresRestart ? (
-            <Badge variant="outline" className="gap-1 text-[10px] text-amber-600 border-amber-500/30 dark:text-amber-400">
+          {setting.source !== "default" && <SourcePill source={setting.source} />}
+          {showRestart && (
+            <span className="inline-flex items-center gap-1 text-[10px] font-medium uppercase tracking-[0.08em] text-amber-600 dark:text-amber-400">
               <RefreshCw className="size-2.5" />
-              Requires restart
-            </Badge>
-          ) : !setting.secret ? (
-            <span className="text-[10px] text-emerald-600 dark:text-emerald-400">
-              Live
+              Restart
             </span>
-          ) : null}
-        </div>
-        <p className="text-xs text-muted-foreground">{setting.description}</p>
-        <div className="flex items-center gap-1.5">
-          {!isSaas && (
-            <>
-              <code className="rounded bg-muted px-1.5 py-0.5 text-xs">{setting.envVar}</code>
-              <span className="text-xs text-muted-foreground">=</span>
-            </>
           )}
-          <span className="truncate text-xs font-mono">
-            {typeof displayValue === "string" ? displayValue : displayValue}
+        </div>
+        <p className="text-xs leading-snug text-muted-foreground">{setting.description}</p>
+        <div className="flex flex-wrap items-baseline gap-x-2 pt-0.5">
+          {!isSaas && (
+            <code className="rounded bg-muted/70 px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground">
+              {setting.envVar}
+            </code>
+          )}
+          <span
+            className={cn(
+              "truncate font-mono text-[11px]",
+              setting.currentValue ? "text-foreground/80" : "text-muted-foreground/70",
+            )}
+          >
+            {valueText}
           </span>
         </div>
       </div>
@@ -270,13 +344,14 @@ function SettingRow({
             Edit
           </Button>
         )}
-        {(setting.source === "override" || setting.source === "workspace-override") && manageable && (
+        {isOverride && manageable && (
           <Button
             variant="ghost"
             size="sm"
             className="h-7 text-xs text-muted-foreground"
             onClick={onReset}
             disabled={resetting}
+            aria-label={`Reset ${setting.label} to default`}
           >
             {resetting ? (
               <Loader2 className="mr-1 size-3 animate-spin" />
@@ -303,16 +378,20 @@ export default function SettingsPage() {
     { schema: SettingsResponseSchema },
   );
 
-  const { mutate: resetSetting, error: mutationError, clearError: clearMutationError, isMutating } =
-    useAdminMutation({
-      method: "DELETE",
-      invalidates: refetch,
-    });
+  const {
+    mutate: resetSetting,
+    error: mutationError,
+    clearError: clearMutationError,
+    isMutating,
+  } = useAdminMutation({
+    method: "DELETE",
+    invalidates: refetch,
+  });
 
   const settings = data?.settings ?? [];
   const manageable = data?.manageable ?? false;
 
-  // Only show workspace-scoped settings — platform settings live at /admin/platform/settings
+  // Only workspace-scoped settings — platform settings live at /admin/platform/settings
   const workspaceSections = new Map<string, SettingWithValue[]>();
   for (const s of settings) {
     if (s.scope !== "workspace") continue;
@@ -321,6 +400,17 @@ export default function SettingsPage() {
     workspaceSections.set(s.section, list);
   }
 
+  const orderedSections = SECTION_ORDER.filter((s) => workspaceSections.has(s)).concat(
+    [...workspaceSections.keys()].filter((s) => !SECTION_ORDER.includes(s)),
+  );
+
+  const overrideCount = settings.filter(
+    (s) =>
+      s.scope === "workspace" &&
+      (s.source === "override" || s.source === "workspace-override"),
+  ).length;
+  const totalCount = settings.filter((s) => s.scope === "workspace").length;
+
   async function handleReset(key: string) {
     await resetSetting({
       path: `/api/v1/admin/settings/${encodeURIComponent(key)}`,
@@ -328,20 +418,27 @@ export default function SettingsPage() {
     });
   }
 
+  const subtitle = !manageable
+    ? "Read-only — configure an internal database to enable overrides."
+    : isSaas
+      ? "Overrides save and take effect immediately."
+      : "Overrides persist to the internal database. Some keys require a server restart.";
+
   return (
     <div className="p-6">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold tracking-tight">Workspace Settings</h1>
-        <p className="text-sm text-muted-foreground">
-          Settings that apply to this workspace
-        </p>
-      </div>
-
       <ErrorBoundary>
-      <div>
-        {mutationError && (
-          <ErrorBanner message={mutationError} onRetry={clearMutationError} />
-        )}
+        <div className="mx-auto mb-8 flex max-w-3xl items-end justify-between gap-4">
+          <div className="min-w-0">
+            <h1 className="text-2xl font-semibold tracking-tight">Workspace Settings</h1>
+            <p className="mt-1 text-sm text-muted-foreground">{subtitle}</p>
+          </div>
+          {totalCount > 0 && (
+            <div className="shrink-0 text-right font-mono text-xs tabular-nums text-muted-foreground">
+              {String(overrideCount).padStart(2, "0")} / {String(totalCount).padStart(2, "0")}{" "}
+              <span className="text-muted-foreground/60">overridden</span>
+            </div>
+          )}
+        </div>
 
         <AdminContentWrapper
           loading={loading}
@@ -353,46 +450,33 @@ export default function SettingsPage() {
           emptyTitle="No settings available"
           isEmpty={workspaceSections.size === 0}
         >
-          {!manageable && !isSaas && (
-            <div className="mb-6 flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/5 px-4 py-3">
-              <Info className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" />
-              <p className="text-sm text-amber-700 dark:text-amber-300">
-                Settings are read-only. To enable overrides, configure{" "}
-                <code className="rounded bg-amber-500/10 px-1 font-mono text-xs">DATABASE_URL</code>{" "}
-                for the internal database.
-              </p>
-            </div>
-          )}
+          <div className="mx-auto max-w-3xl space-y-8">
+            {mutationError && (
+              <ErrorBanner message={mutationError} onRetry={clearMutationError} />
+            )}
 
-          {manageable && (
-            <div className="mb-6 flex items-start gap-2 rounded-md border border-primary/30 bg-primary/5 px-4 py-3">
-              <Info className="mt-0.5 size-4 shrink-0 text-primary" />
-              <p className="text-sm text-primary dark:text-primary/80">
-                {isSaas
-                  ? "Setting overrides are saved and take effect immediately."
-                  : <>
-                      Setting overrides are saved to the database. Settings marked{" "}
-                      <span className="font-medium">Live</span> take effect immediately.
-                      Settings marked{" "}
-                      <span className="font-medium">Requires restart</span> need a server
-                      restart.
-                    </>
-                }
-              </p>
-            </div>
-          )}
+            {!manageable && !isSaas && (
+              <div className="flex items-start gap-2 rounded-xl border border-amber-500/30 bg-amber-500/5 px-4 py-3">
+                <Info className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" />
+                <p className="text-sm text-amber-700 dark:text-amber-300">
+                  Settings are read-only. To enable overrides, configure{" "}
+                  <code className="rounded bg-amber-500/10 px-1 font-mono text-xs">
+                    DATABASE_URL
+                  </code>{" "}
+                  for the internal database.
+                </p>
+              </div>
+            )}
 
-          <div className="space-y-4">
-            {Array.from(workspaceSections.entries()).map(([section, items]) => (
-              <Card key={section} className="shadow-none">
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-base">{section}</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  {items.map((setting, i) => (
-                    <div key={setting.key}>
-                      {i > 0 && <Separator />}
+            {orderedSections.map((section) => {
+              const items = workspaceSections.get(section) ?? [];
+              return (
+                <section key={section}>
+                  <SectionHeading title={section} />
+                  <div className="space-y-2">
+                    {items.map((setting) => (
                       <SettingRow
+                        key={setting.key}
                         setting={setting}
                         manageable={manageable}
                         onEdit={() => setEditSetting(setting)}
@@ -400,14 +484,13 @@ export default function SettingsPage() {
                         resetting={isMutating(setting.key)}
                         deployMode={deployMode}
                       />
-                    </div>
-                  ))}
-                </CardContent>
-              </Card>
-            ))}
+                    ))}
+                  </div>
+                </section>
+              );
+            })}
           </div>
         </AdminContentWrapper>
-      </div>
       </ErrorBoundary>
 
       {editSetting && (

--- a/packages/web/src/app/admin/settings/page.tsx
+++ b/packages/web/src/app/admin/settings/page.tsx
@@ -408,9 +408,11 @@ export default function SettingsPage() {
     workspaceSections.set(s.section, list);
   }
 
-  const orderedSections = SECTION_ORDER.filter((s) => workspaceSections.has(s)).concat(
-    [...workspaceSections.keys()].filter((s) => !SECTION_ORDER.includes(s)),
-  );
+  const knownOrder: readonly string[] = SECTION_ORDER;
+  const orderedSections: string[] = [
+    ...SECTION_ORDER.filter((s) => workspaceSections.has(s)),
+    ...[...workspaceSections.keys()].filter((s) => !knownOrder.includes(s)),
+  ];
 
   const overrideCount = settings.filter(
     (s) =>

--- a/packages/web/src/app/admin/settings/page.tsx
+++ b/packages/web/src/app/admin/settings/page.tsx
@@ -214,10 +214,8 @@ function EditDialog({
   }
 
   async function handleSubmit(values: z.infer<typeof editSettingSchema>) {
-    await saveMutation.mutate({
-      body: { value: values.value },
-      onSuccess: () => onOpenChange(false),
-    });
+    const result = await saveMutation.mutate({ body: { value: values.value } });
+    if (result.ok) onOpenChange(false);
   }
 
   return (

--- a/packages/web/src/app/admin/settings/page.tsx
+++ b/packages/web/src/app/admin/settings/page.tsx
@@ -72,7 +72,18 @@ const SettingsResponseSchema = z.object({
 
 // ── Section metadata ──────────────────────────────────────────────
 
-const SECTION_ICONS: Record<string, ComponentType<{ className?: string }>> = {
+const SECTION_ORDER = [
+  "Query Limits",
+  "Rate Limiting",
+  "Sessions",
+  "Sandbox",
+  "Agent",
+  "Intelligence",
+  "Demo",
+] as const;
+type KnownSection = (typeof SECTION_ORDER)[number];
+
+const SECTION_ICONS: Record<KnownSection, ComponentType<{ className?: string }>> = {
   "Query Limits": Database,
   "Rate Limiting": Gauge,
   Sessions: Timer,
@@ -82,23 +93,15 @@ const SECTION_ICONS: Record<string, ComponentType<{ className?: string }>> = {
   Demo: FlaskConical,
 };
 
-const SECTION_ORDER = [
-  "Query Limits",
-  "Rate Limiting",
-  "Sessions",
-  "Sandbox",
-  "Agent",
-  "Intelligence",
-  "Demo",
-];
-
 function sectionIcon(section: string): ComponentType<{ className?: string }> {
-  return SECTION_ICONS[section] ?? Settings;
+  if (section in SECTION_ICONS) return SECTION_ICONS[section as KnownSection];
+  if (process.env.NODE_ENV !== "production") {
+    console.warn(`[admin/settings] unknown section "${section}" — falling back to generic icon`);
+  }
+  return Settings;
 }
 
 // ── Source pill ───────────────────────────────────────────────────
-// Only rendered when source !== "default" — default is the default state,
-// and labeling it on every row was pure noise.
 
 function SourcePill({ source }: { source: Exclude<SettingSource, "default"> }) {
   const tone =
@@ -128,7 +131,7 @@ function SourcePill({ source }: { source: Exclude<SettingSource, "default"> }) {
   );
 }
 
-// ── Setting control (reused for dialog) ───────────────────────────
+// ── Edit dialog ───────────────────────────────────────────────────
 
 const editSettingSchema = z.object({
   value: z.string(),
@@ -288,7 +291,14 @@ function SettingRow({
   const isOverride =
     setting.source === "override" || setting.source === "workspace-override";
   const showRestart = !isSaas && setting.requiresRestart && isOverride;
-  const valueText = setting.currentValue ?? "—";
+  // Render "not set" and "" distinctly so an admin clearing an override to the
+  // empty string can tell it apart from "never configured."
+  const valueDisplay =
+    setting.currentValue === undefined
+      ? { text: "not set", muted: true }
+      : setting.currentValue === ""
+        ? { text: '""', muted: false }
+        : { text: setting.currentValue, muted: false };
 
   return (
     <div
@@ -330,10 +340,10 @@ function SettingRow({
           <span
             className={cn(
               "truncate font-mono text-[11px]",
-              setting.currentValue ? "text-foreground/80" : "text-muted-foreground/70",
+              valueDisplay.muted ? "italic text-muted-foreground/70" : "text-foreground/80",
             )}
           >
-            {valueText}
+            {valueDisplay.text}
           </span>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Replaces the wall-of-cards workspace-settings layout with a single-column, `max-w-3xl` stack of CompactRows, each with a per-section icon tile (Database / Gauge / Timer / Cpu / Bot / Brain / FlaskConical).
- Drops the `default` + green `Live` badges that fired on every row (visual tinnitus — everything was a default and everything was live, which is what made the page feel like a grid of empty states). Overrides now earn a teal/violet/emerald dot + uppercase source pill and a primary-tinted row border, so customized settings actually pop.
- Folds the info banner into the hero subtitle and adds a right-aligned mono counter (`00 / 13 overridden`, `tabular-nums`) for total context. The amber read-only warning stays for the self-hosted-without-`DATABASE_URL` case since that one is genuinely actionable.
- `Requires restart` now only fires when the setting is actually overridden on self-hosted — flagged rows at their default don't need a restart, and the old behavior was noise.
- `"not set"` italic → muted em-dash.

The edit dialog, mutations, and the `/api/v1/admin/settings` surface are untouched — this is presentational only.

Sticks to the primitives established by the integrations / billing / branding / custom-domain / sandbox revamps (`CompactRow`, `SectionHeading`, `StatusDot`-style source pill), so a future lift into `packages/web/src/ui/components/admin/` is a one-import job.

## Test plan
- [ ] Load `/admin/settings` in SaaS mode — verify sections render in the canonical order (Query Limits → Rate Limiting → Sessions → Sandbox → Agent → Intelligence → Demo), each row shows icon + name + description + mono value, no redundant badges.
- [ ] Click Edit on any row — dialog opens with the current value, Save/Cancel work, refetch updates the row in place.
- [ ] Override a setting → verify the teal `Override` pill + primary-tinted row border + Reset button appear; reset it → pill disappears, counter decrements.
- [ ] Self-hosted mode — verify env-var code chip renders inline per row, and `Sidecar URL` (env-sourced) shows an emerald `Env` pill.
- [ ] Self-hosted without `DATABASE_URL` — amber read-only banner still renders above the list, Edit / Reset buttons are hidden.
- [ ] Dark mode — all pills, dot colors, and eyebrow headings remain legible.
- [ ] Keyboard — tab through rows, Edit button is focusable, dialog traps focus, Escape closes.