### PR TITLE
fix(web/admin): 204 onSuccess + combineMutationErrors helper (#1555, #1557)

### DIFF
--- a/packages/web/src/app/admin/api-keys/page.tsx
+++ b/packages/web/src/app/admin/api-keys/page.tsx
@@ -109,6 +109,7 @@ export default function ApiKeysPage() {
     await createMutation.mutate({
       body: { name: values.name },
       onSuccess: (data) => {
+        if (!data) return;
         setCreatedKey({ key: data.key, name: data.name ?? values.name });
         refetch();
       },

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -164,6 +164,7 @@ function ConnectionFormDialog({
     const data = await testMutation.mutate({
       body: { url, schema: schemaVal || undefined },
       onSuccess: (d) => {
+        if (!d) return;
         setTestResult({
           ok: d.status === "healthy",
           message: d.status === "healthy"

--- a/packages/web/src/app/admin/custom-domain/page.tsx
+++ b/packages/web/src/app/admin/custom-domain/page.tsx
@@ -20,6 +20,7 @@ import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
+import { combineMutationErrors } from "@/ui/lib/mutation-errors";
 import { DomainResponseSchema } from "@/ui/lib/admin-schemas";
 import { cn } from "@/lib/utils";
 import { formatDateTime } from "@/lib/format";
@@ -361,7 +362,7 @@ function CustomDomainPageContent() {
     );
   }
 
-  const mutationError = verifyError ?? removeError;
+  const mutationError = combineMutationErrors([verifyError, removeError]);
   function clearMutationError() {
     clearVerifyError();
     clearRemoveError();

--- a/packages/web/src/app/admin/prompts/page.tsx
+++ b/packages/web/src/app/admin/prompts/page.tsx
@@ -318,6 +318,7 @@ export default function PromptsPage() {
         description: values.description,
       },
       onSuccess: (updated) => {
+        if (!updated) return;
         if (detailCollection?.id === updated.id) {
           setDetailCollection(updated);
         }
@@ -347,6 +348,7 @@ export default function PromptsPage() {
         description: addItemDescription.trim() || null,
       },
       onSuccess: (newItem) => {
+        if (!newItem) return;
         setDetailItems((prev) => [...prev, newItem]);
         setItemCounts((prev) => {
           const next = new Map(prev);

--- a/packages/web/src/app/admin/residency/page.tsx
+++ b/packages/web/src/app/admin/residency/page.tsx
@@ -25,6 +25,7 @@ import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { useAdminFetch, friendlyError } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
+import { combineMutationErrors } from "@/ui/lib/mutation-errors";
 import { useDeployMode } from "@/ui/hooks/use-deploy-mode";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import {
@@ -400,11 +401,12 @@ function ResidencyPageContent() {
     },
   });
 
-  const mutationError =
-    assignMutation.error ??
-    migrateMutation.error ??
-    retryMutation.error ??
-    cancelMutation.error;
+  const mutationError = combineMutationErrors([
+    assignMutation.error,
+    migrateMutation.error,
+    retryMutation.error,
+    cancelMutation.error,
+  ]);
 
   function clearMutationError() {
     assignMutation.clearError();

--- a/packages/web/src/app/admin/sandbox/page.tsx
+++ b/packages/web/src/app/admin/sandbox/page.tsx
@@ -35,6 +35,7 @@ import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
+import { combineMutationErrors } from "@/ui/lib/mutation-errors";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { useDeployMode } from "@/ui/hooks/use-deploy-mode";
 import { formatDateTime } from "@/lib/format";
@@ -412,8 +413,11 @@ export default function SandboxPage() {
     invalidates: refetch,
   });
 
-  const mutationError =
-    saveMutation.error ?? saveUrlMutation.error ?? resetMutation.error;
+  const mutationError = combineMutationErrors([
+    saveMutation.error,
+    saveUrlMutation.error,
+    resetMutation.error,
+  ]);
 
   function clearMutationError() {
     saveMutation.clearError();

--- a/packages/web/src/app/admin/scheduled-tasks/page.tsx
+++ b/packages/web/src/app/admin/scheduled-tasks/page.tsx
@@ -128,7 +128,9 @@ export default function ScheduledTasksPage() {
     await previewMutation.mutate({
       path: `/api/v1/scheduled-tasks/${encodeURIComponent(taskId)}/preview`,
       body: {},
-      onSuccess: (data) => setPreviewData(data),
+      onSuccess: (data) => {
+        if (data) setPreviewData(data);
+      },
     });
   }
 
@@ -212,6 +214,7 @@ export default function ScheduledTasksPage() {
       body: { enabled: !task.enabled },
       itemId: task.id,
       onSuccess: (updated) => {
+        if (!updated) return;
         setTasks((prev) =>
           prev.map((t) => (t.id === updated.id ? updated : t)),
         );

--- a/packages/web/src/app/admin/users/page.tsx
+++ b/packages/web/src/app/admin/users/page.tsx
@@ -393,6 +393,7 @@ export default function UsersPage() {
     await invite.mutate({
       body: { email: values.email, role: values.role },
       onSuccess: (data) => {
+        if (!data) return;
         setInviteResult({ inviteUrl: data.inviteUrl, emailSent: data.emailSent, emailError: data.emailError, email: values.email });
         setInvitationsVersion((v) => v + 1);
       },

--- a/packages/web/src/ui/__tests__/mutation-errors.test.ts
+++ b/packages/web/src/ui/__tests__/mutation-errors.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { combineMutationErrors } from "../lib/mutation-errors";
+
+describe("combineMutationErrors", () => {
+  test("returns null when all slots are empty", () => {
+    expect(combineMutationErrors([])).toBeNull();
+    expect(combineMutationErrors([null, undefined])).toBeNull();
+    expect(combineMutationErrors([null, undefined, ""])).toBeNull();
+  });
+
+  test("returns the single message when only one slot is set", () => {
+    expect(combineMutationErrors([null, "boom", undefined])).toBe("boom");
+  });
+
+  test("appends a '+N more' suffix when multiple distinct messages are present", () => {
+    expect(combineMutationErrors(["one", "two"])).toBe("one (+1 more)");
+    expect(combineMutationErrors(["one", "two", "three"])).toBe("one (+2 more)");
+  });
+
+  test("deduplicates identical messages so the suffix reflects distinct failures", () => {
+    expect(combineMutationErrors(["same", "same"])).toBe("same");
+    expect(combineMutationErrors(["a", "b", "a"])).toBe("a (+1 more)");
+  });
+
+  test("skips empty strings and keeps the first real message as primary", () => {
+    expect(combineMutationErrors(["", "first", "", "second"])).toBe(
+      "first (+1 more)",
+    );
+  });
+
+  test("preserves insertion order across the banner", () => {
+    expect(combineMutationErrors(["later", "earlier"])).toBe("later (+1 more)");
+  });
+});

--- a/packages/web/src/ui/__tests__/use-admin-mutation.test.ts
+++ b/packages/web/src/ui/__tests__/use-admin-mutation.test.ts
@@ -120,10 +120,13 @@ describe("useAdminMutation", () => {
     expect(refetch).toHaveBeenCalledTimes(1);
   });
 
-  test("204 No Content does NOT fire onSuccess (no data to pass)", async () => {
+  test("204 No Content fires onSuccess with undefined data", async () => {
+    // Regression guard for #1555: dialog-closing callers
+    // (`onSuccess: () => onOpenChange(false)`) must fire on 204 or the
+    // surface stays stuck open with no error feedback.
     mockFetch(new Response(null, { status: 204 }));
 
-    const onSuccess = mock(() => {});
+    const onSuccess = mock((_: unknown) => {});
     const { result } = renderHook(
       () => useAdminMutation({ path: "/api/v1/admin/test", method: "DELETE" }),
       { wrapper },
@@ -133,7 +136,28 @@ describe("useAdminMutation", () => {
       await result.current.mutate({ onSuccess });
     });
 
-    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledWith(undefined);
+  });
+
+  test("non-JSON 200 fires onSuccess with undefined data", async () => {
+    mockFetch(new Response("OK", {
+      status: 200,
+      headers: { "Content-Type": "text/plain" },
+    }));
+
+    const onSuccess = mock((_: unknown) => {});
+    const { result } = renderHook(
+      () => useAdminMutation({ path: "/api/v1/admin/test" }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.mutate({ onSuccess });
+    });
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledWith(undefined);
   });
 
   /* ---------------------------------------------------------------- */

--- a/packages/web/src/ui/hooks/use-admin-mutation.ts
+++ b/packages/web/src/ui/hooks/use-admin-mutation.ts
@@ -28,8 +28,12 @@ interface MutateOptions<TResponse = unknown> {
   body?: Record<string, unknown>;
   /** Track this mutation under an ID for per-item loading state. */
   itemId?: string;
-  /** Called on success when the server returns a JSON body. Not called for 204 No Content. */
-  onSuccess?: (data: TResponse) => void;
+  /**
+   * Called on any 2xx response. Data is `undefined` for 204 No Content or non-JSON
+   * responses — consumers that need the parsed body should narrow or use the
+   * `MutateResult` returned from `mutate()`.
+   */
+  onSuccess?: (data: TResponse | undefined) => void;
 }
 
 /** Hook-level configuration. */
@@ -194,12 +198,11 @@ export function useAdminMutation<TResponse = unknown>(
         }
       }
 
-      // Call onSuccess outside try/catch so callback bugs don't
-      // get misreported as mutation failures.
-      // Only called when data is present — 204/non-JSON callers use result.ok instead.
-      if (data !== undefined) {
-        callOpts?.onSuccess?.(data);
-      }
+      // Call onSuccess outside try/catch so callback bugs don't get misreported
+      // as mutation failures. Fires on all 2xx responses — passes `undefined`
+      // for 204 / non-JSON so dialog-closing callers aren't stuck when the
+      // server returns No Content.
+      callOpts?.onSuccess?.(data);
 
       return { ok: true, data };
     },

--- a/packages/web/src/ui/lib/mutation-errors.ts
+++ b/packages/web/src/ui/lib/mutation-errors.ts
@@ -1,0 +1,25 @@
+/**
+ * Combine multiple mutation error slots into a single banner message.
+ *
+ * Admin pages that run several mutations against the same surface (e.g.
+ * residency: assign + migrate + retry + cancel) collapse their errors into
+ * one page-level `ErrorBanner`. Using `a.error ?? b.error ?? ...` silently
+ * hides any failure past the first — this helper preserves all distinct
+ * messages so concurrent failures stay visible.
+ */
+export function combineMutationErrors(
+  errors: ReadonlyArray<string | null | undefined>,
+): string | null {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  for (const err of errors) {
+    if (typeof err !== "string" || err.length === 0) continue;
+    if (seen.has(err)) continue;
+    seen.add(err);
+    unique.push(err);
+  }
+
+  if (unique.length === 0) return null;
+  if (unique.length === 1) return unique[0];
+  return `${unique[0]} (+${unique.length - 1} more)`;
+}


### PR DESCRIPTION
Closes #1555.
Closes #1557.

## Summary

Two admin-mutation bugs flagged during the admin-revamp review pass.

**#1555 — `useAdminMutation.onSuccess` never fired on 204 No Content.** Dialog-closing callers (`onSuccess: () => onOpenChange(false)`) left the surface stuck open when the server returned an empty body. The hook now fires `onSuccess` on any 2xx (data is `undefined` for 204 / non-JSON), and the callback signature widens to match so existing callers that destructure `data` get a compile-time nudge if they ever point at a 204 endpoint.

**#1557 — concurrent mutation failures got silently narrowed to the first error.** `residency`, `sandbox`, and `custom-domain` each collapsed their per-mutation errors via `a.error ?? b.error ?? ...`, so a failed retry followed by a failed cancel would hide the second message. Added `combineMutationErrors()` that dedupes and renders `<first> (+N more)` when multiple distinct messages are live, and routed the three pages through it.

## Files

- `packages/web/src/ui/hooks/use-admin-mutation.ts` — drop the `data !== undefined` gate around `onSuccess`; widen callback to `(data: TResponse | undefined)`
- `packages/web/src/ui/lib/mutation-errors.ts` — new `combineMutationErrors` helper (dedupe + `+N more` suffix)
- `packages/web/src/ui/__tests__/mutation-errors.test.ts` — 6 unit tests
- `packages/web/src/ui/__tests__/use-admin-mutation.test.ts` — flip the 204 test; add a `text/plain` variant
- `packages/web/src/app/admin/residency/page.tsx` — 4-way narrowing → helper
- `packages/web/src/app/admin/sandbox/page.tsx` — 3-way narrowing → helper
- `packages/web/src/app/admin/custom-domain/page.tsx` — 2-way narrowing → helper (verify + remove; add stays separate for plan-gated detection)

## Test plan

- [x] `bun test packages/web/src/ui/__tests__/mutation-errors.test.ts packages/web/src/ui/__tests__/use-admin-mutation.test.ts` — 23 pass
- [x] `bun run --filter @atlas/web test` — 61/61 files pass
- [x] `bun x eslint` on all touched files — clean
- [x] `bun run type` — clean (pre-existing bun-types noise unchanged)
- [ ] Manual: admin settings dialog with a 204 response — dialog closes
- [ ] Manual: trigger two residency failures in quick succession — banner shows `first (+1 more)` instead of only the first

## Not in scope

- Other callers of `useAdminMutation` that use `onSuccess` to read parsed data (prompts, users, api-keys, actions, plugins, etc.) are unaffected — those endpoints return JSON, not 204.
- Integrations / branding pages render per-card error banners instead of narrowing; they don't need the helper.