### PR TITLE
refactor(web): ScrollArea on sidebar, admin layout, conversation list

### DIFF
--- a/packages/web/src/components/ui/sidebar.tsx
+++ b/packages/web/src/components/ui/sidebar.tsx
@@ -9,6 +9,7 @@ import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { ScrollArea } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
 import {
   Sheet,
@@ -368,17 +369,19 @@ function SidebarSeparator({
   )
 }
 
-function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+function SidebarContent({ className, children, ...props }: React.ComponentProps<"div">) {
   return (
-    <div
+    <ScrollArea
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(
-        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        "min-h-0 flex-1 group-data-[collapsible=icon]:overflow-hidden",
         className
       )}
       {...props}
-    />
+    >
+      <div className="flex flex-col gap-2">{children}</div>
+    </ScrollArea>
   )
 }
 

--- a/packages/web/src/components/ui/sidebar.tsx
+++ b/packages/web/src/components/ui/sidebar.tsx
@@ -378,9 +378,10 @@ function SidebarContent({ className, children, ...props }: React.ComponentProps<
         "min-h-0 flex-1 group-data-[collapsible=icon]:overflow-hidden",
         className
       )}
-      {...props}
     >
-      <div className="flex flex-col gap-2">{children}</div>
+      <div className="flex flex-col gap-2" {...props}>
+        {children}
+      </div>
     </ScrollArea>
   )
 }

--- a/packages/web/src/ui/components/admin/admin-layout.tsx
+++ b/packages/web/src/ui/components/admin/admin-layout.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { SidebarProvider, SidebarInset, SidebarTrigger } from "@/components/ui/sidebar";
 import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
@@ -88,7 +89,7 @@ export function AdminLayout({ children }: { children: ReactNode }) {
             <span className="text-sm font-medium text-muted-foreground">Admin Console</span>
           </div>
         </header>
-        <div className="flex-1 overflow-auto">{children}</div>
+        <ScrollArea className="flex-1">{children}</ScrollArea>
       </SidebarInset>
 
       <ChangePasswordDialog

--- a/packages/web/src/ui/components/conversations/conversation-sidebar.tsx
+++ b/packages/web/src/ui/components/conversations/conversation-sidebar.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { Star } from "lucide-react";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { Conversation } from "../../lib/types";
 import { ConversationList } from "./conversation-list";
@@ -87,31 +88,33 @@ export function ConversationSidebar({
         </ToggleGroup>
       </div>
 
-      <div className="flex-1 overflow-y-auto p-2">
-        {loading && conversations.length === 0 ? (
-          <div className="space-y-2 p-1">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <div key={i} className="flex items-center gap-2 rounded-lg px-3 py-2.5">
-                <div className="min-w-0 flex-1 space-y-2">
-                  <Skeleton className="h-3.5 w-3/4" />
-                  <Skeleton className="h-2.5 w-1/3" />
+      <ScrollArea className="flex-1">
+        <div className="p-2">
+          {loading && conversations.length === 0 ? (
+            <div className="space-y-2 p-1">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <div key={i} className="flex items-center gap-2 rounded-lg px-3 py-2.5">
+                  <div className="min-w-0 flex-1 space-y-2">
+                    <Skeleton className="h-3.5 w-3/4" />
+                    <Skeleton className="h-2.5 w-1/3" />
+                  </div>
                 </div>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <ConversationList
-            conversations={filteredConversations}
-            selectedId={selectedId}
-            onSelect={onSelect}
-            onDelete={onDelete}
-            onStar={onStar}
-            onConvertToNotebook={onConvertToNotebook}
-            showSections={filter === "all"}
-            emptyMessage={filter === "saved" ? "Star conversations to save them here" : undefined}
-          />
-        )}
-      </div>
+              ))}
+            </div>
+          ) : (
+            <ConversationList
+              conversations={filteredConversations}
+              selectedId={selectedId}
+              onSelect={onSelect}
+              onDelete={onDelete}
+              onStar={onStar}
+              onConvertToNotebook={onConvertToNotebook}
+              showSections={filter === "all"}
+              emptyMessage={filter === "saved" ? "Star conversations to save them here" : undefined}
+            />
+          )}
+        </div>
+      </ScrollArea>
     </div>
   );
 


### PR DESCRIPTION
## Summary

Swaps native browser scrollbar for the shadcn / Radix `ScrollArea` on the three highest-visibility scroll containers in the app. Atlas-chat already uses ScrollArea for the main conversation scroll — this catches up the surfaces surrounding it.

**Changed surfaces:**
- `components/ui/sidebar.tsx` — `SidebarContent` primitive. Every page that renders a Sidebar (admin console left nav, main app) picks this up.
- `ui/components/admin/admin-layout.tsx` — main `/admin/*` content area.
- `ui/components/conversations/conversation-sidebar.tsx` — chat / notebook conversation list.

## Scoping rationale

The three swapped surfaces share a shape: **`flex-1 overflow-*` child of a flex column**, meaning the ScrollArea's required explicit height is already satisfied by the parent's flex-basis and no DnD / programmatic-scroll refs ride on the container.

**Deliberately left on native overflow:**
- `notebook/notebook-shell.tsx` — has `scrollAreaRef` wired for programmatic scroll on new-cell + cells are draggable. Radix wraps the scrollable content in a viewport element, which changes the DOM shape and can mess with both the ref target and DnD coordinate math. Not worth the regression risk for a cosmetic win.
- `wizard/page.tsx` — three fixed-height preview boxes (`max-h-96`, `max-h-48`, `max-h-[600px]`). Native scroll is invisible unless overflow occurs; ScrollArea's bar is always-visible decoration on otherwise quiet previews.
- Inner admin page scrolls (scheduled-tasks, prompts, learned-patterns, etc.) — now nested inside the outer admin-layout ScrollArea. Native inner + styled outer reads cleaner than nested ScrollAreas.
- Dialog content, dropdown menus, short lists — too short to justify the extra layout constraint.

## Implementation notes

- **`SidebarContent`** — kept `min-h-0 flex-1` and the `group-data-[collapsible=icon]:overflow-hidden` variant on the outer (now ScrollArea Root). The `flex flex-col gap-2` layout that previously sat on the single div now lives on an inner wrapper inside the Viewport so `SidebarGroup` children still stack with the right gap.
- **Conversation sidebar** — `p-2` moved inside the viewport wrapper so padding scrolls with content (matches the previous native behavior where padding was part of the `overflow-y-auto` box).
- **Admin layout** — drop-in swap; `{children}` renders unchanged inside the Viewport.

## Test plan
- [x] `bun run --filter @atlas/web type` — clean (only unrelated bun-types noise)
- [x] `bun x eslint` on the three touched files — clean
- [x] `bun run --filter @atlas/web test` — 61/61 files pass
- [ ] Manual: admin console left nav scrolls with styled bar when screen is short
- [ ] Manual: admin page content scroll shows styled bar on `/admin/connections`, `/admin/users`, etc.
- [ ] Manual: conversation sidebar in main chat scrolls with styled bar
- [ ] Manual: semantic layer page (uses internal ScrollArea) doesn't show double scrollbars under the outer admin-layout ScrollArea
- [ ] Manual: notebook cells still draggable, auto-scroll on new cell still works (unchanged path, but verify)