### PR TITLE
fix(web/admin/plugins): move SaaS redirect into useEffect (#1563)

### DIFF
--- a/packages/web/src/app/admin/plugins/page.tsx
+++ b/packages/web/src/app/admin/plugins/page.tsx
@@ -870,13 +870,16 @@ function SelfHostedPlugins() {
 export default function PluginsPage() {
   const { deployMode } = useDeployMode();
   const router = useRouter();
+  const isSaas = deployMode === "saas";
 
   // SaaS mode: plugins are managed via dedicated admin pages (Connections,
-  // Integrations, Sandbox, etc.) — redirect to admin overview.
-  if (deployMode === "saas") {
-    router.replace("/admin");
-    return null;
-  }
+  // Integrations, Sandbox, etc.) — redirect to admin overview. Must live in
+  // an effect so we don't setState on Router during render.
+  useEffect(() => {
+    if (isSaas) router.replace("/admin");
+  }, [isSaas, router]);
+
+  if (isSaas) return null;
 
   return (
     <div className="mx-auto max-w-3xl px-6 py-10">


### PR DESCRIPTION
Closes #1563.

## Why

`PluginsPage` called `router.replace("/admin")` during render when `deployMode === "saas"`, triggering React's "Cannot update a component (\`Router\`) while rendering a different component (\`PluginsPage\`)" warning. In dev this also meant the partial fetch for `/api/v1/admin/plugins` fired, then got aborted by the redirect — a flash of load-then-redirect instead of a clean navigation.

## Fix

Move the redirect into `useEffect` so the Router mutation happens after paint. The early-return `null` stays so nothing renders while the redirect is in flight.

```tsx
const isSaas = deployMode === "saas";
useEffect(() => { if (isSaas) router.replace("/admin"); }, [isSaas, router]);
if (isSaas) return null;
```

## Scope

- `packages/web/src/app/admin/plugins/page.tsx` only.
- No behavioral change for self-hosted deploys (the branch where everything actually renders).

## Test plan

- [ ] `ATLAS_DEPLOY_MODE=saas` → navigate to `/admin/plugins` → observe clean redirect to `/admin` without console warnings
- [ ] Self-hosted default → `/admin/plugins` still renders the plugins revamp
- [x] `bun x eslint` clean on the touched file