### PR TITLE
refactor(web/admin): redesign scim with compact rows + progressive disclosure

### DIFF
--- a/packages/web/src/app/admin/scim/page.tsx
+++ b/packages/web/src/app/admin/scim/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useState } from "react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useState, type ComponentType, type ReactNode } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -30,7 +29,17 @@ import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
-import { RefreshCw, Trash2, Plus, Cable, Users, ArrowRightLeft, Loader2 } from "lucide-react";
+import { formatDateTime } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import {
+  Cable,
+  Users,
+  ArrowRightLeft,
+  Loader2,
+  Plus,
+  Trash2,
+  KeyRound,
+} from "lucide-react";
 
 // ── Schemas ───────────────────────────────────────────────────────
 
@@ -62,6 +71,208 @@ const GroupMappingsResponseSchema = z.object({
   mappings: z.array(SCIMGroupMappingSchema),
   total: z.number(),
 });
+
+// ── Shared Design Primitives (locally duplicated per #1551) ──────────────
+
+type StatusKind = "connected" | "disconnected" | "unavailable";
+
+function StatusDot({ kind, className }: { kind: StatusKind; className?: string }) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "relative inline-flex size-1.5 shrink-0 rounded-full",
+        kind === "connected" &&
+          "bg-primary shadow-[0_0_0_3px_color-mix(in_oklch,_var(--primary)_15%,_transparent)]",
+        kind === "disconnected" && "bg-muted-foreground/40",
+        kind === "unavailable" && "bg-muted-foreground/20 outline-1 outline-dashed outline-muted-foreground/30",
+        className,
+      )}
+    >
+      {kind === "connected" && (
+        <span className="absolute inset-0 rounded-full bg-primary/60 motion-safe:animate-ping" />
+      )}
+    </span>
+  );
+}
+
+const STATUS_LABEL: Record<StatusKind, string> = {
+  connected: "Active",
+  disconnected: "Inactive",
+  unavailable: "Unavailable",
+};
+
+function CompactRow({
+  icon: Icon,
+  title,
+  description,
+  status,
+  action,
+}: {
+  icon: ComponentType<{ className?: string }>;
+  title: string;
+  description: string;
+  status: StatusKind;
+  action?: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "group flex items-center gap-3 rounded-xl border bg-card/40 px-3.5 py-2.5 transition-colors",
+        "hover:bg-card/70 hover:border-border/80",
+        status === "unavailable" && "opacity-60",
+      )}
+    >
+      <span
+        className={cn(
+          "grid size-8 shrink-0 place-items-center rounded-lg border bg-background/40 text-muted-foreground",
+        )}
+      >
+        <Icon className="size-4" />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <h3 className="truncate text-sm font-semibold leading-tight tracking-tight">
+            {title}
+          </h3>
+          <StatusDot kind={status} className="shrink-0" />
+          <span className="sr-only">Status: {STATUS_LABEL[status]}</span>
+        </div>
+        <p className="mt-0.5 truncate text-xs text-muted-foreground">
+          {description}
+        </p>
+      </div>
+      {action && <div className="shrink-0">{action}</div>}
+    </div>
+  );
+}
+
+function IntegrationShell({
+  icon: Icon,
+  title,
+  description,
+  status,
+  titleAccessory,
+  children,
+  actions,
+}: {
+  icon: ComponentType<{ className?: string }>;
+  title: string;
+  description: string;
+  status: StatusKind;
+  titleAccessory?: ReactNode;
+  children?: ReactNode;
+  actions?: ReactNode;
+}) {
+  return (
+    <section
+      className={cn(
+        "relative flex flex-col overflow-hidden rounded-xl border bg-card/60 backdrop-blur-[1px] transition-colors",
+        "hover:border-border/80",
+        status === "connected" && "border-primary/20",
+      )}
+    >
+      {status === "connected" && (
+        <span
+          aria-hidden
+          className="pointer-events-none absolute left-0 top-4 bottom-4 w-px bg-gradient-to-b from-transparent via-primary to-transparent opacity-70"
+        />
+      )}
+
+      <header className="flex items-start gap-3 p-4 pb-3">
+        <span
+          className={cn(
+            "grid size-9 shrink-0 place-items-center rounded-lg border bg-background/40",
+            status === "connected" && "border-primary/30 text-primary",
+            status !== "connected" && "text-muted-foreground",
+          )}
+        >
+          <Icon className="size-4" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h3 className="truncate text-sm font-semibold leading-tight tracking-tight">
+              {title}
+            </h3>
+            {titleAccessory}
+            {status === "connected" && (
+              <span className="ml-auto flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.08em] text-primary">
+                <StatusDot kind="connected" />
+                Live
+              </span>
+            )}
+          </div>
+          <p className="mt-0.5 truncate text-xs leading-snug text-muted-foreground">
+            {description}
+          </p>
+        </div>
+      </header>
+
+      {children != null && (
+        <div className="flex-1 space-y-3 px-4 pb-3 text-sm">{children}</div>
+      )}
+
+      {actions && (
+        <footer className="flex flex-wrap items-center justify-end gap-2 border-t border-border/50 bg-muted/20 px-4 py-2.5">
+          {actions}
+        </footer>
+      )}
+    </section>
+  );
+}
+
+function DetailRow({
+  label,
+  value,
+  mono,
+  truncate,
+}: {
+  label: string;
+  value: ReactNode;
+  mono?: boolean;
+  truncate?: boolean;
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-3 py-1 text-xs">
+      <span className="shrink-0 text-muted-foreground">{label}</span>
+      <span
+        className={cn(
+          "min-w-0 text-right",
+          mono && "font-mono text-[11px]",
+          truncate && "truncate",
+          !mono && "font-medium",
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function DetailList({ children }: { children: ReactNode }) {
+  return (
+    <div className="rounded-lg border bg-muted/20 px-3 py-1.5 divide-y divide-border/50">
+      {children}
+    </div>
+  );
+}
+
+function SectionHeading({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="mb-3">
+      <h2 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+        {title}
+      </h2>
+      <p className="mt-0.5 text-xs text-muted-foreground/80">{description}</p>
+    </div>
+  );
+}
 
 // ── Main Page ─────────────────────────────────────────────────────
 
@@ -103,196 +314,212 @@ export default function SCIMPage() {
     void result;
   }
 
+  const liveCount = connections.length;
+  const totalCount = Math.max(connections.length, syncStatus.connections);
+  const lastSyncLabel = syncStatus.lastSyncAt
+    ? formatDateTime(syncStatus.lastSyncAt)
+    : "Never";
+
   return (
-    <div className="p-6">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold tracking-tight">SCIM</h1>
-        <p className="text-sm text-muted-foreground">
-          Directory sync for automated user provisioning
+    <div className="mx-auto max-w-3xl px-6 py-10">
+      {/* Hero */}
+      <header className="mb-10 flex flex-col gap-2">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+          Atlas · Admin
         </p>
-      </div>
+        <div className="flex items-baseline justify-between gap-6">
+          <h1 className="text-3xl font-semibold tracking-tight">SCIM</h1>
+          <p className="shrink-0 font-mono text-sm tabular-nums text-muted-foreground">
+            <span className={cn(liveCount > 0 ? "text-primary" : "text-muted-foreground")}>
+              {String(liveCount).padStart(2, "0")}
+            </span>
+            <span className="opacity-50">{" / "}</span>
+            {String(totalCount).padStart(2, "0")} active
+          </p>
+        </div>
+        <p className="max-w-xl text-sm text-muted-foreground">
+          Directory sync for automated user provisioning from your identity provider.
+        </p>
+      </header>
 
       <ErrorBoundary>
-        <div>
+        <AdminContentWrapper
+          loading={loading}
+          error={error}
+          feature="SCIM"
+          onRetry={() => { refetchStatus(); refetchMappings(); }}
+          loadingMessage="Loading SCIM configuration..."
+          emptyIcon={Cable}
+          emptyTitle="No SCIM configuration"
+          isEmpty={false}
+        >
           {mutationError && (
-            <ErrorBanner message={mutationError} onRetry={clearMutationError} />
-          )}
-          <AdminContentWrapper
-            loading={loading}
-            error={error}
-            feature="SCIM"
-            onRetry={() => { refetchStatus(); refetchMappings(); }}
-            loadingMessage="Loading SCIM configuration..."
-            emptyIcon={Cable}
-            emptyTitle="No SCIM configuration"
-            isEmpty={false}
-          >
-            <div className="space-y-6">
-              {/* Sync Status Card */}
-              <Card className="shadow-none">
-                <CardHeader className="pb-2">
-                  <CardTitle className="flex items-center gap-2 text-base">
-                    <RefreshCw className="size-4" />
-                    Sync Status
-                  </CardTitle>
-                  <CardDescription>
-                    Overview of SCIM directory sync activity for this workspace.
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <div className="grid grid-cols-3 gap-4">
-                    <div className="rounded-md border px-4 py-3">
-                      <p className="text-2xl font-bold">{syncStatus.connections}</p>
-                      <p className="text-xs text-muted-foreground">Active Connections</p>
-                    </div>
-                    <div className="rounded-md border px-4 py-3">
-                      <p className="text-2xl font-bold">{syncStatus.provisionedUsers}</p>
-                      <p className="text-xs text-muted-foreground">Provisioned Users</p>
-                    </div>
-                    <div className="rounded-md border px-4 py-3">
-                      <p className="text-sm font-medium">
-                        {syncStatus.lastSyncAt
-                          ? new Date(syncStatus.lastSyncAt).toLocaleDateString(undefined, {
-                              month: "short",
-                              day: "numeric",
-                              hour: "2-digit",
-                              minute: "2-digit",
-                            })
-                          : "Never"}
-                      </p>
-                      <p className="text-xs text-muted-foreground">Last Sync</p>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-
-              {/* Connections Card */}
-              <Card className="shadow-none">
-                <CardHeader className="pb-2">
-                  <CardTitle className="flex items-center gap-2 text-base">
-                    <Cable className="size-4" />
-                    SCIM Connections
-                    <Badge variant="outline" className="text-[10px] text-muted-foreground">
-                      {connections.length}
-                    </Badge>
-                  </CardTitle>
-                  <CardDescription>
-                    Identity provider connections configured for SCIM provisioning.
-                    Generate tokens via the Better Auth SCIM API at{" "}
-                    <code className="rounded bg-muted px-1 py-0.5 text-[11px]">/api/auth/scim/generate-token</code>.
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  {connections.length === 0 ? (
-                    <div className="flex flex-col items-center justify-center py-8 text-center">
-                      <Cable className="mb-3 size-10 text-muted-foreground/50" />
-                      <p className="text-sm text-muted-foreground">
-                        No SCIM connections configured.
-                      </p>
-                      <p className="text-xs text-muted-foreground mt-1">
-                        Use the SCIM token API to generate a bearer token for your IdP.
-                      </p>
-                    </div>
-                  ) : (
-                    <div className="space-y-3">
-                      {connections.map((conn) => (
-                        <div
-                          key={conn.id}
-                          className="flex items-center justify-between rounded-md border px-4 py-3"
-                        >
-                          <div className="space-y-1">
-                            <div className="flex items-center gap-2">
-                              <span className="text-sm font-medium">{conn.providerId}</span>
-                              <Badge variant="default" className="text-[10px]">Active</Badge>
-                            </div>
-                          </div>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="text-destructive hover:text-destructive"
-                            onClick={() => setDeleteTarget({ type: "connection", id: conn.id, label: conn.providerId })}
-                          >
-                            <Trash2 className="size-4" />
-                          </Button>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
-
-              {/* Group Mappings Card */}
-              <Card className="shadow-none">
-                <CardHeader className="pb-2">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <CardTitle className="flex items-center gap-2 text-base">
-                        <ArrowRightLeft className="size-4" />
-                        Group Mappings
-                        <Badge variant="outline" className="text-[10px] text-muted-foreground">
-                          {mappings.length}
-                        </Badge>
-                      </CardTitle>
-                      <CardDescription>
-                        Map SCIM group names from your IdP to Atlas custom roles.
-                      </CardDescription>
-                    </div>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setAddMappingOpen(true)}
-                    >
-                      <Plus className="mr-1 size-3" />
-                      Add Mapping
-                    </Button>
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  {mappings.length === 0 ? (
-                    <div className="flex flex-col items-center justify-center py-8 text-center">
-                      <Users className="mb-3 size-10 text-muted-foreground/50" />
-                      <p className="text-sm text-muted-foreground">
-                        No group mappings configured.
-                      </p>
-                      <p className="text-xs text-muted-foreground mt-1">
-                        Map SCIM groups to Atlas roles so provisioned users get the correct permissions.
-                      </p>
-                    </div>
-                  ) : (
-                    <div className="space-y-3">
-                      {mappings.map((mapping) => (
-                        <div
-                          key={mapping.id}
-                          className="flex items-center justify-between rounded-md border px-4 py-3"
-                        >
-                          <div className="flex items-center gap-3">
-                            <div className="space-y-0.5">
-                              <span className="text-sm font-medium">{mapping.scimGroupName}</span>
-                              <p className="text-xs text-muted-foreground">SCIM Group</p>
-                            </div>
-                            <ArrowRightLeft className="size-3 text-muted-foreground" />
-                            <div className="space-y-0.5">
-                              <Badge variant="secondary" className="text-xs">{mapping.roleName}</Badge>
-                              <p className="text-xs text-muted-foreground">Atlas Role</p>
-                            </div>
-                          </div>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="text-destructive hover:text-destructive"
-                            onClick={() => setDeleteTarget({ type: "mapping", id: mapping.id, label: mapping.scimGroupName })}
-                          >
-                            <Trash2 className="size-4" />
-                          </Button>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
+            <div className="mb-4">
+              <ErrorBanner message={mutationError} onRetry={clearMutationError} />
             </div>
-          </AdminContentWrapper>
-        </div>
+          )}
+
+          <div className="space-y-10">
+            {/* Sync overview — compact 3-up spec sheet, no framing card */}
+            <section>
+              <SectionHeading
+                title="Sync"
+                description="Directory activity for this workspace"
+              />
+              <DetailList>
+                <DetailRow
+                  label="Active connections"
+                  value={
+                    <span className="font-mono tabular-nums">
+                      {String(syncStatus.connections).padStart(2, "0")}
+                    </span>
+                  }
+                />
+                <DetailRow
+                  label="Provisioned users"
+                  value={
+                    <span className="font-mono tabular-nums">
+                      {String(syncStatus.provisionedUsers).padStart(2, "0")}
+                    </span>
+                  }
+                />
+                <DetailRow label="Last sync" value={lastSyncLabel} />
+              </DetailList>
+            </section>
+
+            {/* Connections */}
+            <section>
+              <SectionHeading
+                title="Connections"
+                description="Identity provider bearer tokens that can sync users"
+              />
+              <div className="space-y-2">
+                {connections.map((conn) => (
+                  <IntegrationShell
+                    key={conn.id}
+                    icon={KeyRound}
+                    title={conn.providerId}
+                    description="Bearer token issued via the SCIM token API"
+                    status="connected"
+                    titleAccessory={
+                      <Badge variant="secondary" className="shrink-0 font-mono text-[10px] uppercase">
+                        SCIM
+                      </Badge>
+                    }
+                    actions={
+                      <Button
+                        variant="ghost"
+                        size="xs"
+                        className="text-destructive hover:text-destructive"
+                        onClick={() => setDeleteTarget({ type: "connection", id: conn.id, label: conn.providerId })}
+                        aria-label={`Revoke ${conn.providerId} connection`}
+                      >
+                        <Trash2 className="size-3" />
+                        Revoke
+                      </Button>
+                    }
+                  >
+                    <DetailList>
+                      <DetailRow label="Provider" value={conn.providerId} mono truncate />
+                      <DetailRow
+                        label="Connection ID"
+                        value={conn.id}
+                        mono
+                        truncate
+                      />
+                      {conn.organizationId && (
+                        <DetailRow
+                          label="Organization"
+                          value={conn.organizationId}
+                          mono
+                          truncate
+                        />
+                      )}
+                    </DetailList>
+                  </IntegrationShell>
+                ))}
+
+                <CompactRow
+                  icon={Plus}
+                  title={connections.length === 0 ? "Generate your first SCIM token" : "Generate another SCIM token"}
+                  description="Issue a bearer token via POST /api/auth/scim/generate-token for your IdP"
+                  status="disconnected"
+                  action={
+                    <Button variant="outline" size="sm" asChild>
+                      <a
+                        href="/api/auth/scim/generate-token"
+                        target="_blank"
+                        rel="noreferrer noopener"
+                      >
+                        <KeyRound className="mr-1.5 size-3.5" />
+                        Token API
+                      </a>
+                    </Button>
+                  }
+                />
+              </div>
+            </section>
+
+            {/* Group Mappings */}
+            <section>
+              <SectionHeading
+                title="Group mappings"
+                description="Map IdP group names to Atlas custom roles"
+              />
+              <div className="space-y-2">
+                {mappings.map((mapping) => (
+                  <IntegrationShell
+                    key={mapping.id}
+                    icon={ArrowRightLeft}
+                    title={mapping.scimGroupName}
+                    description={`→ ${mapping.roleName}`}
+                    status="connected"
+                    titleAccessory={
+                      <Badge variant="secondary" className="shrink-0 text-[10px]">
+                        {mapping.roleName}
+                      </Badge>
+                    }
+                    actions={
+                      <Button
+                        variant="ghost"
+                        size="xs"
+                        className="text-destructive hover:text-destructive"
+                        onClick={() => setDeleteTarget({ type: "mapping", id: mapping.id, label: mapping.scimGroupName })}
+                        aria-label={`Remove mapping for ${mapping.scimGroupName}`}
+                      >
+                        <Trash2 className="size-3" />
+                        Remove
+                      </Button>
+                    }
+                  >
+                    <DetailList>
+                      <DetailRow label="SCIM group" value={mapping.scimGroupName} mono truncate />
+                      <DetailRow label="Atlas role" value={mapping.roleName} mono truncate />
+                      <DetailRow label="Added" value={formatDateTime(mapping.createdAt)} />
+                    </DetailList>
+                  </IntegrationShell>
+                ))}
+
+                <CompactRow
+                  icon={mappings.length === 0 ? Users : Plus}
+                  title={mappings.length === 0 ? "Add your first group mapping" : "Add another group mapping"}
+                  description={
+                    mappings.length === 0
+                      ? "Map SCIM groups to roles so provisioned users land with the right permissions"
+                      : "Hook another IdP group up to an Atlas role"
+                  }
+                  status="disconnected"
+                  action={
+                    <Button size="sm" onClick={() => setAddMappingOpen(true)}>
+                      <Plus className="mr-1.5 size-3.5" />
+                      Add mapping
+                    </Button>
+                  }
+                />
+              </div>
+            </section>
+          </div>
+        </AdminContentWrapper>
       </ErrorBoundary>
 
       {/* Add Mapping Dialog */}

--- a/packages/web/src/app/admin/scim/page.tsx
+++ b/packages/web/src/app/admin/scim/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type ComponentType, type ReactNode } from "react";
+import { useEffect, useState, type ComponentType, type ReactNode } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -39,6 +39,7 @@ import {
   Plus,
   Trash2,
   KeyRound,
+  AlertTriangle,
 } from "lucide-react";
 
 // ── Schemas ───────────────────────────────────────────────────────
@@ -257,6 +258,15 @@ function DetailList({ children }: { children: ReactNode }) {
   );
 }
 
+function InlineError({ children }: { children: ReactNode }) {
+  if (!children) return null;
+  return (
+    <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+      {children}
+    </div>
+  );
+}
+
 function SectionHeading({
   title,
   description,
@@ -276,9 +286,19 @@ function SectionHeading({
 
 // ── Main Page ─────────────────────────────────────────────────────
 
+type RowError = {
+  message: string;
+  id: string;
+  kind: "connection" | "mapping";
+};
+
 export default function SCIMPage() {
   const [addMappingOpen, setAddMappingOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<{ type: "connection" | "mapping"; id: string; label: string } | null>(null);
+  // Per-row delete error — pinned to the specific shell whose Revoke/Remove
+  // click failed, so the cue sits in the footer of the failing row instead of
+  // 800px up at the top banner.
+  const [rowError, setRowError] = useState<RowError | null>(null);
 
   const { data: statusData, loading: statusLoading, error: statusError, refetch: refetchStatus } =
     useAdminFetch("/api/v1/admin/scim", {
@@ -308,17 +328,59 @@ export default function SCIMPage() {
       ? `/api/v1/admin/scim/connections/${deleteTarget.id}`
       : `/api/v1/admin/scim/group-mappings/${deleteTarget.id}`;
 
+    // Capture the target before we clear it — if the mutation fails we need
+    // the id/kind to pin the InlineError to the right row.
+    const target = deleteTarget;
+    // Clear any stale per-row error on a new attempt so a previous failure
+    // can't linger next to a now-successful row.
+    setRowError(null);
+
     const result = await deleteMutate({ path });
     setDeleteTarget(null);
-    // error is captured by the hook
-    void result;
+    if (!result.ok) {
+      setRowError({ message: result.error, id: target.id, kind: target.type });
+    }
   }
 
+  // Source of truth for the count is the connections list we actually render.
+  // If the list and syncStatus diverge we surface it below instead of hiding
+  // via Math.max(list, sync) — silently masking drift left admins asking
+  // "where are the other two?".
   const liveCount = connections.length;
-  const totalCount = Math.max(connections.length, syncStatus.connections);
+  const totalCount = connections.length;
+  const syncDivergence = statusData
+    ? syncStatus.connections - connections.length
+    : 0;
   const lastSyncLabel = syncStatus.lastSyncAt
     ? formatDateTime(syncStatus.lastSyncAt)
     : "Never";
+  // Gate the hero stat chip on loaded, error-free, present data so the chip
+  // doesn't peek out above AdminContentWrapper's loading / error / EE-gated
+  // early returns (otherwise a non-EE deployment sees "00 / 00 active" above
+  // the 404 FeatureGate screen, reading like an empty feature rather than a
+  // disabled one).
+  const showStat = !loading && !error && statusData != null;
+  // If the underlying mutation error clears (explicit dismiss, or a later
+  // successful mutation), drop the pinned row error too — otherwise a stale
+  // InlineError could survive against the wrong row after invalidation.
+  useEffect(() => {
+    if (mutationError == null && rowError != null) {
+      setRowError(null);
+    }
+  }, [mutationError, rowError]);
+
+  // A pinned row error is only useful if the row it points to still exists
+  // in the rendered list. If the row has been invalidated out (e.g. the
+  // delete half-succeeded on the server but the hook surfaced an error),
+  // fall back to the top-level banner so the admin isn't left without a cue.
+  const rowErrorIsVisible =
+    rowError != null &&
+    (rowError.kind === "connection"
+      ? connections.some((c) => c.id === rowError.id)
+      : mappings.some((m) => m.id === rowError.id));
+  // Top-level error shows only if the mutation failed but we couldn't pin it
+  // to a visible row — prevents a double-render of the same error.
+  const showTopMutationError = mutationError != null && !rowErrorIsVisible;
 
   return (
     <div className="mx-auto max-w-3xl px-6 py-10">
@@ -329,13 +391,15 @@ export default function SCIMPage() {
         </p>
         <div className="flex items-baseline justify-between gap-6">
           <h1 className="text-3xl font-semibold tracking-tight">SCIM</h1>
-          <p className="shrink-0 font-mono text-sm tabular-nums text-muted-foreground">
-            <span className={cn(liveCount > 0 ? "text-primary" : "text-muted-foreground")}>
-              {String(liveCount).padStart(2, "0")}
-            </span>
-            <span className="opacity-50">{" / "}</span>
-            {String(totalCount).padStart(2, "0")} active
-          </p>
+          {showStat && (
+            <p className="shrink-0 font-mono text-sm tabular-nums text-muted-foreground">
+              <span className={cn(liveCount > 0 ? "text-primary" : "text-muted-foreground")}>
+                {String(liveCount).padStart(2, "0")}
+              </span>
+              <span className="opacity-50">{" / "}</span>
+              {String(totalCount).padStart(2, "0")} active
+            </p>
+          )}
         </div>
         <p className="max-w-xl text-sm text-muted-foreground">
           Directory sync for automated user provisioning from your identity provider.
@@ -353,7 +417,7 @@ export default function SCIMPage() {
           emptyTitle="No SCIM configuration"
           isEmpty={false}
         >
-          {mutationError && (
+          {showTopMutationError && (
             <div className="mb-4">
               <ErrorBanner message={mutationError} onRetry={clearMutationError} />
             </div>
@@ -366,25 +430,43 @@ export default function SCIMPage() {
                 title="Sync"
                 description="Directory activity for this workspace"
               />
-              <DetailList>
-                <DetailRow
-                  label="Active connections"
-                  value={
-                    <span className="font-mono tabular-nums">
-                      {String(syncStatus.connections).padStart(2, "0")}
+              <div className="space-y-2">
+                <DetailList>
+                  <DetailRow
+                    label="Active connections"
+                    value={
+                      <span className="font-mono tabular-nums">
+                        {String(syncStatus.connections).padStart(2, "0")}
+                      </span>
+                    }
+                  />
+                  <DetailRow
+                    label="Provisioned users"
+                    value={
+                      <span className="font-mono tabular-nums">
+                        {String(syncStatus.provisionedUsers).padStart(2, "0")}
+                      </span>
+                    }
+                  />
+                  <DetailRow label="Last sync" value={lastSyncLabel} />
+                </DetailList>
+                {syncDivergence !== 0 && (
+                  <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+                    <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+                    <span>
+                      Sync reports{" "}
+                      <span className="font-mono tabular-nums">
+                        {syncStatus.connections}
+                      </span>
+                      , list shows{" "}
+                      <span className="font-mono tabular-nums">
+                        {connections.length}
+                      </span>
+                      . Refresh may resolve the drift.
                     </span>
-                  }
-                />
-                <DetailRow
-                  label="Provisioned users"
-                  value={
-                    <span className="font-mono tabular-nums">
-                      {String(syncStatus.provisionedUsers).padStart(2, "0")}
-                    </span>
-                  }
-                />
-                <DetailRow label="Last sync" value={lastSyncLabel} />
-              </DetailList>
+                  </div>
+                )}
+              </div>
             </section>
 
             {/* Connections */}
@@ -394,50 +476,59 @@ export default function SCIMPage() {
                 description="Identity provider bearer tokens that can sync users"
               />
               <div className="space-y-2">
-                {connections.map((conn) => (
-                  <IntegrationShell
-                    key={conn.id}
-                    icon={KeyRound}
-                    title={conn.providerId}
-                    description="Bearer token issued via the SCIM token API"
-                    status="connected"
-                    titleAccessory={
-                      <Badge variant="secondary" className="shrink-0 font-mono text-[10px] uppercase">
-                        SCIM
-                      </Badge>
-                    }
-                    actions={
-                      <Button
-                        variant="ghost"
-                        size="xs"
-                        className="text-destructive hover:text-destructive"
-                        onClick={() => setDeleteTarget({ type: "connection", id: conn.id, label: conn.providerId })}
-                        aria-label={`Revoke ${conn.providerId} connection`}
-                      >
-                        <Trash2 className="size-3" />
-                        Revoke
-                      </Button>
-                    }
-                  >
-                    <DetailList>
-                      <DetailRow label="Provider" value={conn.providerId} mono truncate />
-                      <DetailRow
-                        label="Connection ID"
-                        value={conn.id}
-                        mono
-                        truncate
-                      />
-                      {conn.organizationId && (
+                {connections.map((conn) => {
+                  const rowHasError =
+                    rowError?.kind === "connection" && rowError.id === conn.id;
+                  return (
+                    <IntegrationShell
+                      key={conn.id}
+                      icon={KeyRound}
+                      title={conn.providerId}
+                      description="Bearer token issued via the SCIM token API"
+                      status="connected"
+                      titleAccessory={
+                        <Badge variant="secondary" className="shrink-0 font-mono text-[10px] uppercase">
+                          SCIM
+                        </Badge>
+                      }
+                      actions={
+                        <Button
+                          variant="ghost"
+                          size="xs"
+                          className="text-destructive hover:text-destructive"
+                          onClick={() => setDeleteTarget({ type: "connection", id: conn.id, label: conn.providerId })}
+                          aria-label={`Revoke ${conn.providerId} connection`}
+                        >
+                          <Trash2 className="size-3" />
+                          Revoke
+                        </Button>
+                      }
+                    >
+                      <DetailList>
+                        <DetailRow label="Provider" value={conn.providerId} mono truncate />
                         <DetailRow
-                          label="Organization"
-                          value={conn.organizationId}
+                          label="Connection ID"
+                          value={conn.id}
                           mono
                           truncate
                         />
+                        {conn.organizationId && (
+                          <DetailRow
+                            label="Organization"
+                            value={conn.organizationId}
+                            mono
+                            truncate
+                          />
+                        )}
+                      </DetailList>
+                      {rowHasError && (
+                        <InlineError>
+                          Revoke failed — {rowError.message}
+                        </InlineError>
                       )}
-                    </DetailList>
-                  </IntegrationShell>
-                ))}
+                    </IntegrationShell>
+                  );
+                })}
 
                 <CompactRow
                   icon={Plus}
@@ -467,38 +558,47 @@ export default function SCIMPage() {
                 description="Map IdP group names to Atlas custom roles"
               />
               <div className="space-y-2">
-                {mappings.map((mapping) => (
-                  <IntegrationShell
-                    key={mapping.id}
-                    icon={ArrowRightLeft}
-                    title={mapping.scimGroupName}
-                    description={`→ ${mapping.roleName}`}
-                    status="connected"
-                    titleAccessory={
-                      <Badge variant="secondary" className="shrink-0 text-[10px]">
-                        {mapping.roleName}
-                      </Badge>
-                    }
-                    actions={
-                      <Button
-                        variant="ghost"
-                        size="xs"
-                        className="text-destructive hover:text-destructive"
-                        onClick={() => setDeleteTarget({ type: "mapping", id: mapping.id, label: mapping.scimGroupName })}
-                        aria-label={`Remove mapping for ${mapping.scimGroupName}`}
-                      >
-                        <Trash2 className="size-3" />
-                        Remove
-                      </Button>
-                    }
-                  >
-                    <DetailList>
-                      <DetailRow label="SCIM group" value={mapping.scimGroupName} mono truncate />
-                      <DetailRow label="Atlas role" value={mapping.roleName} mono truncate />
-                      <DetailRow label="Added" value={formatDateTime(mapping.createdAt)} />
-                    </DetailList>
-                  </IntegrationShell>
-                ))}
+                {mappings.map((mapping) => {
+                  const rowHasError =
+                    rowError?.kind === "mapping" && rowError.id === mapping.id;
+                  return (
+                    <IntegrationShell
+                      key={mapping.id}
+                      icon={ArrowRightLeft}
+                      title={mapping.scimGroupName}
+                      description={`→ ${mapping.roleName}`}
+                      status="connected"
+                      titleAccessory={
+                        <Badge variant="secondary" className="shrink-0 text-[10px]">
+                          {mapping.roleName}
+                        </Badge>
+                      }
+                      actions={
+                        <Button
+                          variant="ghost"
+                          size="xs"
+                          className="text-destructive hover:text-destructive"
+                          onClick={() => setDeleteTarget({ type: "mapping", id: mapping.id, label: mapping.scimGroupName })}
+                          aria-label={`Remove mapping for ${mapping.scimGroupName}`}
+                        >
+                          <Trash2 className="size-3" />
+                          Remove
+                        </Button>
+                      }
+                    >
+                      <DetailList>
+                        <DetailRow label="SCIM group" value={mapping.scimGroupName} mono truncate />
+                        <DetailRow label="Atlas role" value={mapping.roleName} mono truncate />
+                        <DetailRow label="Added" value={formatDateTime(mapping.createdAt)} />
+                      </DetailList>
+                      {rowHasError && (
+                        <InlineError>
+                          Remove failed — {rowError.message}
+                        </InlineError>
+                      )}
+                    </IntegrationShell>
+                  );
+                })}
 
                 <CompactRow
                   icon={mappings.length === 0 ? Users : Plus}


### PR DESCRIPTION
## Summary

Revamps `/admin/scim` to the CompactRow / FullShell progressive-disclosure pattern shipped on `/admin/integrations` (#1538) and `/admin/sso` (#1561). SCIM is a Security sibling of SSO, so they now share visual grammar.

- **Sync overview strip folded into a DetailList.** The outer framing Card + three bordered stat tiles is gone; counts + last-sync become a compact 3-row spec sheet. The hero carries the active-connection count in monospace.
- **Connections.** Active SCIM bearer-token connections render as `IntegrationShell` with the teal left-edge, `Live` badge, and a DetailList of provider / connection id / org id. A single `CompactRow` with a `Token API` action replaces the empty-state hero block when none exist.
- **Group mappings.** Each mapping renders as `IntegrationShell` with the role as a badge and a DetailList. Empty state collapses to one `CompactRow` with an `+ Add mapping` action.
- **Primitives are inline-duplicated** (StatusDot / CompactRow / IntegrationShell / DetailRow / DetailList / SectionHeading) per #1551. No cross-file extraction.

All mutations are byte-for-byte identical: `DELETE /api/v1/admin/scim/connections/:id`, `GET /api/v1/admin/scim/group-mappings`, `POST /api/v1/admin/scim/group-mappings`, `DELETE /api/v1/admin/scim/group-mappings/:id`. Bearer tokens are still issued out-of-band via the Better Auth endpoint `POST /api/auth/scim/generate-token`.

## Test plan

- [ ] Initial no-token state — `/admin/scim` renders hero with `00 / 00 active`, sync spec-sheet (all zeros / Never), and two `CompactRow` action prompts (Token API + Add mapping).
- [ ] Generate token out-of-band via `POST /api/auth/scim/generate-token`, reload — connection renders as a full `IntegrationShell` with `Live` badge, DetailList showing provider + connection id, and a `Revoke` action.
- [ ] Revoke token — confirm dialog fires, connection disappears, page returns to the empty `CompactRow` state.
- [ ] Add group mapping — dialog opens, mapping saves, appears as `IntegrationShell` with the role badge.
- [ ] Remove group mapping — confirm dialog, row disappears, empty state returns.
- [ ] Enterprise-gated state — if the backend returns an enterprise error, `AdminContentWrapper` surfaces it via its error slot (unchanged behavior).
- [ ] Dark-mode toggle — `--primary` teal punches through on the Live badge, status dot, and active hover on both light and dark surfaces.