### PR TITLE
fix(ip-allowlist): effectivelyEnforced in response (#1567)

### DIFF
--- a/packages/api/src/api/routes/admin-ip-allowlist.ts
+++ b/packages/api/src/api/routes/admin-ip-allowlist.ts
@@ -13,12 +13,19 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { AuthContext } from "@atlas/api/lib/effect/services";
 import { getClientIP } from "@atlas/api/lib/auth/middleware";
+import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import { ErrorSchema, AuthErrorSchema, isValidId, createIdParamSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
 
 // Lazy-load EE module to break circular @atlas/api ↔ @atlas/ee dependency
 async function loadEE() {
   return import("@atlas/ee/auth/ip-allowlist");
+}
+
+// Lazy-load the enterprise gate for the same reason. Mirrors the pattern in
+// ee/src/auth/ip-allowlist.ts which dynamically imports `isEnterpriseEnabled`.
+async function loadEnterpriseGate() {
+  return import("@atlas/ee/index");
 }
 
 /** Map IPAllowlistError codes to HTTP responses. */
@@ -74,6 +81,16 @@ const listEntriesRoute = createRoute({
             entries: z.array(IPAllowlistEntrySchema),
             total: z.number(),
             callerIP: z.string().nullable(),
+            // True iff enterprise is enabled, the internal DB is configured,
+            // AND at least one CIDR entry exists. The IP allowlist middleware
+            // short-circuits to `{ allowed: true }` when either gate is off,
+            // so admins need a way to tell "we have rules but they aren't
+            // actually being enforced" apart from "rules are being enforced".
+            effectivelyEnforced: z.boolean().openapi({
+              example: true,
+              description:
+                "Whether the workspace's IP allowlist is actively gating requests. False when enterprise is disabled, internal DB is missing, or no entries exist.",
+            }),
           }),
         },
       },
@@ -145,6 +162,7 @@ adminIPAllowlist.openapi(listEntriesRoute, async (c) => {
     const callerIP = getClientIP(c.req.raw);
 
     const ee = yield* Effect.promise(loadEE);
+    const enterpriseGate = yield* Effect.promise(loadEnterpriseGate);
 
     const entries = yield* Effect.tryPromise({
       try: () => Effect.runPromise(ee.listIPAllowlistEntries(orgId!)),
@@ -160,7 +178,19 @@ adminIPAllowlist.openapi(listEntriesRoute, async (c) => {
 
     // If catchAll produced an early response, return it
     if (entries instanceof Response) return entries;
-    return c.json({ entries, total: (entries as unknown[]).length, callerIP }, 200);
+
+    // Mirror the preconditions in ee/src/auth/ip-allowlist.ts#checkIPAllowlist
+    // exactly: the middleware short-circuits to `{ allowed: true }` when EE is
+    // disabled OR the internal DB is missing, regardless of row count. So
+    // "enforcing" has to include both gates, not just entries.length > 0.
+    const list = entries as unknown[];
+    const effectivelyEnforced =
+      enterpriseGate.isEnterpriseEnabled() && hasInternalDB() && list.length > 0;
+
+    return c.json(
+      { entries, total: list.length, callerIP, effectivelyEnforced },
+      200,
+    );
   }), { label: "list IP allowlist entries" });
 });
 

--- a/packages/web/src/app/admin/ip-allowlist/page.tsx
+++ b/packages/web/src/app/admin/ip-allowlist/page.tsx
@@ -54,6 +54,11 @@ const IPAllowlistResponseSchema = z.object({
   entries: z.array(IPAllowlistEntrySchema),
   total: z.number(),
   callerIP: z.string().nullable(),
+  // Server-side truth. The middleware in ee/src/auth/ip-allowlist.ts
+  // short-circuits to `{ allowed: true }` when enterprise is disabled or
+  // the internal DB is missing, so the UI can't derive enforcement from
+  // entry count alone without lying to admins.
+  effectivelyEnforced: z.boolean(),
 });
 
 // ── Shared Design Primitives (locally duplicated per #1551) ──────────────
@@ -85,6 +90,15 @@ const STATUS_LABEL: Record<StatusKind, string> = {
   disconnected: "Inactive",
   unavailable: "Unavailable",
 };
+
+function InlineError({ children }: { children: ReactNode }) {
+  if (!children) return null;
+  return (
+    <div className="mt-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+      {children}
+    </div>
+  );
+}
 
 function CompactRow({
   icon: Icon,
@@ -444,12 +458,31 @@ export default function IPAllowlistPage() {
 
   const entries = data?.entries ?? [];
   const callerIP = data?.callerIP ?? null;
+  // Server-computed: true only when EE is enabled, the internal DB is
+  // configured, AND at least one entry exists. Never derive this from
+  // `entries.length` alone — the request-time middleware will short-circuit
+  // to allow-all when EE is off or the internal DB is missing.
+  const effectivelyEnforced = data?.effectivelyEnforced ?? false;
 
   const ruleCount = entries.length;
-  const enforcing = ruleCount > 0;
-  const enforcementDescription = enforcing
-    ? `Active — ${ruleCount} range${ruleCount !== 1 ? "s" : ""} permitted`
-    : "No ranges configured — the workspace accepts requests from any IP";
+  // "Dormant" = has rules but enforcement is off (EE disabled or no internal
+  // DB). Admins in that state must be told the rules aren't actually gating
+  // requests, instead of seeing the same green "Active" affordance as a
+  // properly-enforcing deploy.
+  const enforcementDormant = !effectivelyEnforced && ruleCount > 0;
+
+  let enforcementStatus: StatusKind;
+  let enforcementDescription: string;
+  if (effectivelyEnforced) {
+    enforcementStatus = "connected";
+    enforcementDescription = `Active — ${ruleCount} range${ruleCount !== 1 ? "s" : ""} permitted`;
+  } else if (enforcementDormant) {
+    enforcementStatus = "unavailable";
+    enforcementDescription = `${ruleCount} range${ruleCount !== 1 ? "s" : ""} configured, but not being enforced`;
+  } else {
+    enforcementStatus = "disconnected";
+    enforcementDescription = "No ranges configured — the workspace accepts requests from any IP";
+  }
 
   return (
     <div className="mx-auto max-w-3xl px-6 py-10">
@@ -497,7 +530,7 @@ export default function IPAllowlistPage() {
                 title="Enforcement"
                 description="Access is restricted when one or more ranges are configured"
               />
-              {enforcing ? (
+              {enforcementStatus === "connected" ? (
                 <IntegrationShell
                   icon={ShieldCheck}
                   title="Allowlist enforcement"
@@ -510,12 +543,22 @@ export default function IPAllowlistPage() {
                   }
                 />
               ) : (
-                <CompactRow
-                  icon={Shield}
-                  title="Allowlist enforcement"
-                  description={enforcementDescription}
-                  status="disconnected"
-                />
+                <>
+                  <CompactRow
+                    icon={enforcementStatus === "unavailable" ? ShieldCheck : Shield}
+                    title="Allowlist enforcement"
+                    description={enforcementDescription}
+                    status={enforcementStatus}
+                  />
+                  {enforcementDormant && (
+                    <InlineError>
+                      These ranges aren&apos;t being enforced. IP allowlisting requires
+                      an Atlas Enterprise license and a configured internal database
+                      (<code className="rounded bg-destructive/10 px-1 font-mono">DATABASE_URL</code>).
+                      Until both are present, the workspace accepts requests from any IP.
+                    </InlineError>
+                  )}
+                </>
               )}
             </section>
 

--- a/packages/web/src/app/admin/ip-allowlist/page.tsx
+++ b/packages/web/src/app/admin/ip-allowlist/page.tsx
@@ -58,7 +58,14 @@ const IPAllowlistResponseSchema = z.object({
   // short-circuits to `{ allowed: true }` when enterprise is disabled or
   // the internal DB is missing, so the UI can't derive enforcement from
   // entry count alone without lying to admins.
-  effectivelyEnforced: z.boolean(),
+  //
+  // `.optional()` keeps rolling deploys safe: during a web-before-api rollout
+  // an older API server returns no `effectivelyEnforced`, and a required
+  // boolean would fail safeParse and brick the whole page. Missing → treated
+  // as `false` at the read site (pessimistic — shows the dormant banner, which
+  // is technically wrong if the older server was actually enforcing but is
+  // harmless and self-heals on the next successful deploy).
+  effectivelyEnforced: z.boolean().optional(),
 });
 
 // ── Shared Design Primitives (locally duplicated per #1551) ──────────────


### PR DESCRIPTION
Closes #1567.

## Summary

`/api/v1/admin/ip-allowlist` now returns `effectivelyEnforced: boolean` computed server-side as `isEnterpriseEnabled() && hasInternalDB() && entries.length > 0`. That matches the exact preconditions in `ee/src/auth/ip-allowlist.ts#checkIPAllowlist`, which short-circuits to `{ allowed: true }` whenever EE is disabled or the internal DB is missing.

The admin page now keys enforcement state off that flag instead of `entries.length > 0`. When entries exist but enforcement is dormant (EE off or no `DATABASE_URL`), the Enforcement row renders in `unavailable` `StatusKind` with an `InlineError` explaining that allowlisting requires both an Atlas Enterprise license and a configured internal database.

## Changed files

- `packages/api/src/api/routes/admin-ip-allowlist.ts` — adds `effectivelyEnforced` to the GET `/` response schema + handler. Lazy-loads `isEnterpriseEnabled` via the same dynamic-import pattern as `loadEE()` to preserve the `@atlas/api` ↔ `@atlas/ee` circular-import avoidance.
- `packages/web/src/app/admin/ip-allowlist/page.tsx` — adds `effectivelyEnforced` to the Zod response schema, replaces `enforcing = ruleCount > 0` with three-way `enforcementStatus` (`connected` / `unavailable` / `disconnected`), adds a small `InlineError` below the compact row in the dormant state.

## Judgment calls

- **Stretch `parseable` flag skipped.** `ee/src/auth/ip-allowlist.ts:353` still silently skips CIDRs that fail `ipaddr.js` parsing at runtime. Adding per-row `parseable` would require threading a second code path through the EE lib (the existing `listIPAllowlistEntries` just returns raw rows with no parse step), and the fix here is the bigger admin-safety win. Worth a separate issue if we want to formally surface runtime-parse failures.
- **Frontend copy names both preconditions.** The client can't distinguish "EE off" from "no internal DB" without another round-trip, and the existing admin pages don't expose either flag separately. Surfacing both in the same sentence felt more honest than guessing one.

## Test plan

- [ ] Non-EE deploy (no enterprise license): add entries via DB fixture; `GET /api/v1/admin/ip-allowlist` returns `effectivelyEnforced: false`; admin page renders the "configured, but not being enforced" row with the InlineError.
- [ ] EE enabled without `DATABASE_URL`: same dormant state — `effectivelyEnforced: false`, InlineError visible.
- [ ] EE enabled + `DATABASE_URL` + 0 entries: `effectivelyEnforced: false`, InlineError hidden (this is the `disconnected` branch — "No ranges configured"), no green "Live" badge.
- [ ] EE enabled + `DATABASE_URL` + 1+ entries: `effectivelyEnforced: true`, green `IntegrationShell` with "Active — N ranges permitted" renders (unchanged from today).