### PR TITLE
feat(admin): distinct upsell for EnterpriseError in AdminContentWrapper (#1569)

### DIFF
--- a/packages/web/src/ui/__tests__/fetch-error.test.ts
+++ b/packages/web/src/ui/__tests__/fetch-error.test.ts
@@ -25,10 +25,29 @@ describe("extractFetchError", () => {
     expect(err).toEqual({ message: "Bad input", status: 400 });
   });
 
-  test("falls back to HTTP status when body has no message field", async () => {
+  test("falls back to HTTP status when body has no message field but captures error code", async () => {
     const res = mockResponse(403, { error: "forbidden" });
     const err = await extractFetchError(res);
-    expect(err).toEqual({ message: "HTTP 403", status: 403 });
+    expect(err).toEqual({ message: "HTTP 403", status: 403, code: "forbidden" });
+  });
+
+  test("captures enterprise_required code alongside message", async () => {
+    const res = mockResponse(403, {
+      error: "enterprise_required",
+      message: "SCIM requires an enterprise license.",
+    });
+    const err = await extractFetchError(res);
+    expect(err).toEqual({
+      message: "SCIM requires an enterprise license.",
+      status: 403,
+      code: "enterprise_required",
+    });
+  });
+
+  test("ignores non-string error field", async () => {
+    const res = mockResponse(500, { message: "x", error: 42 });
+    const err = await extractFetchError(res);
+    expect(err).toEqual({ message: "x", status: 500 });
   });
 
   test("falls back to HTTP status for non-JSON body", async () => {

--- a/packages/web/src/ui/components/admin-content-wrapper.tsx
+++ b/packages/web/src/ui/components/admin-content-wrapper.tsx
@@ -13,13 +13,13 @@ import { friendlyError, type FetchError } from "@/ui/hooks/use-admin-fetch";
  * Detect an `EnterpriseError` that was serialized over HTTP.
  *
  * The API encodes the typed error as `{ error: "enterprise_required", ... }`
- * with status 403 — that code lives in `FetchError.code`. We also keep a
- * message-based fallback for callers / tests that omit the `error` field.
+ * with status 403 — that code lives in `FetchError.code`. Match only on the
+ * machine-readable code so unrelated 403s whose message happens to mention
+ * "Enterprise features" (e.g. future billing copy) don't misroute into the
+ * upsell surface.
  */
 function isEnterpriseRequired(error: FetchError): boolean {
-  if (error.code === "enterprise_required") return true;
-  // Legacy fallback: some older responses / tests only set the human message.
-  return error.status === 403 && error.message.includes("Enterprise features");
+  return error.code === "enterprise_required";
 }
 
 export interface AdminContentWrapperProps {

--- a/packages/web/src/ui/components/admin-content-wrapper.tsx
+++ b/packages/web/src/ui/components/admin-content-wrapper.tsx
@@ -3,11 +3,24 @@
 import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 import { Search } from "lucide-react";
-import { FeatureGate } from "@/ui/components/admin/feature-disabled";
+import { EnterpriseUpsell, FeatureGate } from "@/ui/components/admin/feature-disabled";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { LoadingState } from "@/ui/components/admin/loading-state";
 import { EmptyState } from "@/ui/components/admin/empty-state";
 import { friendlyError, type FetchError } from "@/ui/hooks/use-admin-fetch";
+
+/**
+ * Detect an `EnterpriseError` that was serialized over HTTP.
+ *
+ * The API encodes the typed error as `{ error: "enterprise_required", ... }`
+ * with status 403 — that code lives in `FetchError.code`. We also keep a
+ * message-based fallback for callers / tests that omit the `error` field.
+ */
+function isEnterpriseRequired(error: FetchError): boolean {
+  if (error.code === "enterprise_required") return true;
+  // Legacy fallback: some older responses / tests only set the human message.
+  return error.status === 403 && error.message.includes("Enterprise features");
+}
 
 export interface AdminContentWrapperProps {
   loading: boolean;
@@ -40,14 +53,16 @@ export function AdminContentWrapper({
   isEmpty,
   children,
 }: AdminContentWrapperProps) {
-  if (feature && !loading && error?.status && [401, 403, 404, 503].includes(error.status)) {
-    // Enterprise-required errors come back as 403 but are config issues, not
-    // role issues. Show them as feature-not-enabled (404 style) so the admin
-    // sees "not enabled" + the actual message instead of "Access denied".
-    const isEnterpriseRequired = error.status === 403 && error.message.includes("Enterprise features");
-    const gateStatus = isEnterpriseRequired ? 404 : error.status;
-    const gateMessage = isEnterpriseRequired ? error.message : undefined;
-    return <FeatureGate status={gateStatus as 401 | 403 | 404 | 503} feature={feature} message={gateMessage} />;
+  if (feature && !loading && error) {
+    // Enterprise-required errors arrive as 403 + { error: "enterprise_required" }.
+    // Render a distinct upsell so non-EE admins see "this feature needs an
+    // enterprise plan" rather than a generic "Access denied" or error banner.
+    if (isEnterpriseRequired(error)) {
+      return <EnterpriseUpsell feature={feature} message={error.message} />;
+    }
+    if (error.status && [401, 403, 404, 503].includes(error.status)) {
+      return <FeatureGate status={error.status as 401 | 403 | 404 | 503} feature={feature} />;
+    }
   }
 
   if (error) {

--- a/packages/web/src/ui/components/admin/feature-disabled.tsx
+++ b/packages/web/src/ui/components/admin/feature-disabled.tsx
@@ -1,6 +1,53 @@
 "use client";
 
-import { Ban, DatabaseZap, ShieldX } from "lucide-react";
+import { Ban, DatabaseZap, ShieldCheck, ShieldX } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Dedicated upsell shown when an admin page returns an
+ * `enterprise_required` error (403 + `{ error: "enterprise_required" }`).
+ *
+ * Distinct from the generic `FeatureGate` 403 ("Access denied") so non-EE
+ * admins see "this feature needs an enterprise plan" with a concrete next
+ * step, rather than assuming their account lacks a role.
+ */
+export function EnterpriseUpsell({
+  feature,
+  message,
+}: {
+  feature: string;
+  /** Optional override for the description text (usually the server message). */
+  message?: string;
+}) {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <div className="max-w-md text-center">
+        <ShieldCheck
+          className="mx-auto size-10 text-primary/70"
+          aria-hidden="true"
+        />
+        <p className="mt-3 text-sm font-medium">
+          {feature} requires an enterprise plan
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {message ??
+            `${feature} is part of Atlas Enterprise. Upgrade your plan or contact sales to enable it for your workspace.`}
+        </p>
+        <div className="mt-4 flex justify-center">
+          <Button asChild size="sm" variant="outline">
+            <a
+              href="https://www.useatlas.dev/enterprise"
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              Learn about Atlas Enterprise
+            </a>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 /**
  * Shown when an admin page gets a 401/403/404/503 status.

--- a/packages/web/src/ui/components/admin/feature-disabled.tsx
+++ b/packages/web/src/ui/components/admin/feature-disabled.tsx
@@ -30,7 +30,7 @@ export function EnterpriseUpsell({
           {feature} requires an enterprise plan
         </p>
         <p className="mt-1 text-xs text-muted-foreground">
-          {message ??
+          {message ||
             `${feature} is part of Atlas Enterprise. Upgrade your plan or contact sales to enable it for your workspace.`}
         </p>
         <div className="mt-4 flex justify-center">

--- a/packages/web/src/ui/lib/fetch-error.ts
+++ b/packages/web/src/ui/lib/fetch-error.ts
@@ -2,27 +2,34 @@
  * Structured error from a failed fetch operation.
  * May represent an HTTP error response (with status and optional requestId)
  * or a network-level failure (status undefined).
+ *
+ * `code` captures the machine-readable `error` field from the API's JSON body
+ * (e.g. `"enterprise_required"`). Prefer branching on this over string-matching
+ * the human-facing `message`.
  */
 export interface FetchError {
   message: string;
   status?: number;
   requestId?: string;
+  code?: string;
 }
 
 /**
  * Extract a structured error from a failed fetch response.
- * Parses the JSON body for `message` and `requestId` fields; falls back to
- * a status-only message if the body isn't JSON.
+ * Parses the JSON body for `message`, `error` (machine-readable code), and
+ * `requestId` fields; falls back to a status-only message if the body isn't JSON.
  */
 export async function extractFetchError(res: Response): Promise<FetchError> {
   let message = `HTTP ${res.status}`;
   let requestId: string | undefined;
+  let code: string | undefined;
   try {
     const body: unknown = await res.json();
     if (typeof body === "object" && body !== null) {
       const obj = body as Record<string, unknown>;
       if (typeof obj.message === "string") message = obj.message;
       if (typeof obj.requestId === "string") requestId = obj.requestId;
+      if (typeof obj.error === "string") code = obj.error;
     }
   } catch (err) {
     // Non-JSON body is expected — log unexpected errors (e.g. body already consumed) for debugging.
@@ -30,7 +37,12 @@ export async function extractFetchError(res: Response): Promise<FetchError> {
       console.debug("extractFetchError: unexpected error reading response body", err);
     }
   }
-  return { message, status: res.status, ...(requestId && { requestId }) };
+  return {
+    message,
+    status: res.status,
+    ...(requestId && { requestId }),
+    ...(code && { code }),
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

`AdminContentWrapper` previously rendered an `EnterpriseError` / 403-`enterprise_required` response with the same "Access denied" treatment as a role failure (via `FeatureGate` + a fragile `"Enterprise features"` message substring match). Non-EE admins landing on SCIM, SSO, IP allowlist, backups, compliance, approval, or abuse saw a generic error card instead of a dedicated "this feature needs an enterprise plan" surface with a concrete next step.

- **`FetchError`** now captures the wire `error` field as `code` (e.g. `"enterprise_required"`), alongside the existing `message` / `status` / `requestId`. No breaking change to existing consumers.
- **`AdminContentWrapper`** branches on `code === "enterprise_required"` (with a legacy message-match fallback for robustness) and renders a dedicated `EnterpriseUpsell`. Non-enterprise 401 / 403 / 404 / 503 responses still flow through the existing `FeatureGate`. Generic errors still render via `ErrorBanner` unchanged.
- **`EnterpriseUpsell`** (new, in `feature-disabled.tsx`): `ShieldCheck` icon, "`<feature>` requires an enterprise plan" heading, server-provided message (or a sensible default), and a "Learn about Atlas Enterprise" link to `useatlas.dev/enterprise`. Uses the shadcn `Button` primitive.

Pages that pass `feature=` automatically pick up the upsell — no per-page changes required. Affected surfaces: `/admin/scim`, `/admin/sso`, `/admin/ip-allowlist`, `/admin/compliance`, `/admin/approval`, `/admin/abuse`, `/admin/platform/backups`, `/admin/platform/residency`, `/admin/platform/sla`, `/admin/platform/actions`, `/admin/platform/settings`, `/admin/platform/plugins`, `/admin/platform/domains`.

## Test plan

- [ ] Non-EE admin visits `/admin/scim` → sees "SCIM requires an enterprise plan" with ShieldCheck icon + "Learn about Atlas Enterprise" link (not "Access denied")
- [ ] Non-EE admin visits `/admin/sso` → sees "SSO requires an enterprise plan"
- [ ] Non-EE admin visits `/admin/ip-allowlist` → sees "IP Allowlist requires an enterprise plan"
- [ ] Non-EE admin visits `/admin/compliance` → sees "PII Compliance requires an enterprise plan"
- [ ] EE admin with valid entitlement visits any of the above → normal page renders (no regression)
- [ ] Admin page returning 500 (non-EE error) → still renders generic `ErrorBanner` with retry
- [ ] Admin page returning 401 (unauthenticated) → still renders `FeatureGate` "Authentication required"
- [ ] Admin page returning 503 (DATABASE_URL missing) → still renders `FeatureGate` "Internal database not configured"
- [ ] `fetch-error.test.ts` — new tests verify `code` extraction and the `enterprise_required` case
- [ ] `feature-disabled.test.tsx` — existing `FeatureGate` tests unchanged and still pass

Closes #1569