### PR TITLE
refactor(web/admin/custom-domain): migrate to @/ui/components/admin/compact (#1551)

### DIFF
--- a/packages/web/src/app/admin/custom-domain/page.tsx
+++ b/packages/web/src/app/admin/custom-domain/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type ComponentType, type ReactNode } from "react";
+import { useState } from "react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -17,6 +17,15 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import {
+  CompactRow,
+  DetailList,
+  DetailRow,
+  SectionHeading,
+  Shell,
+  StatusDot,
+  type StatusKind,
+} from "@/ui/components/admin/compact";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
@@ -35,213 +44,8 @@ import {
   Lock,
   RefreshCw,
   Trash2,
-  X,
   XCircle,
 } from "lucide-react";
-
-// ── Design primitives ─────────────────────────────────────────────
-
-type StatusKind = "connected" | "pending" | "failed" | "disconnected" | "unavailable";
-
-function StatusDot({ kind }: { kind: StatusKind }) {
-  return (
-    <span
-      aria-hidden
-      className={cn(
-        "relative inline-flex size-1.5 shrink-0 rounded-full",
-        kind === "connected" &&
-          "bg-primary shadow-[0_0_0_3px_color-mix(in_oklch,var(--primary)_15%,transparent)]",
-        kind === "pending" && "bg-amber-500/80",
-        kind === "failed" && "bg-destructive",
-        kind === "disconnected" && "bg-muted-foreground/40",
-        kind === "unavailable" && "bg-muted-foreground/30",
-      )}
-    >
-      {kind === "connected" && (
-        <span className="absolute inset-0 rounded-full bg-primary/60 motion-safe:animate-ping" />
-      )}
-    </span>
-  );
-}
-
-function SectionHeading({ title, description }: { title: string; description: string }) {
-  return (
-    <div className="mb-3">
-      <h2 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-        {title}
-      </h2>
-      <p className="mt-0.5 text-xs text-muted-foreground/80">{description}</p>
-    </div>
-  );
-}
-
-function CompactRow({
-  icon: Icon,
-  title,
-  description,
-  status,
-  trailingLabel,
-  action,
-}: {
-  icon: ComponentType<{ className?: string }>;
-  title: string;
-  description: string;
-  status: StatusKind;
-  trailingLabel?: ReactNode;
-  action?: ReactNode;
-}) {
-  return (
-    <div className="group flex items-center gap-3 rounded-xl border bg-card/40 px-3.5 py-2.5 transition-colors hover:bg-card/70 hover:border-border/80">
-      <span className="grid size-8 shrink-0 place-items-center rounded-lg border bg-background/40 text-muted-foreground">
-        <Icon className="size-4" />
-      </span>
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <h3 className="truncate text-sm font-semibold leading-tight tracking-tight">{title}</h3>
-          <StatusDot kind={status} />
-        </div>
-        <p className="mt-0.5 truncate text-xs text-muted-foreground">{description}</p>
-      </div>
-      {trailingLabel && (
-        <span className="shrink-0 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
-          {trailingLabel}
-        </span>
-      )}
-      {action && <div className="shrink-0">{action}</div>}
-    </div>
-  );
-}
-
-function DomainShell({
-  status,
-  title,
-  description,
-  mono,
-  trailing,
-  onCollapse,
-  children,
-  actions,
-}: {
-  status: StatusKind;
-  title: string;
-  description: string;
-  mono?: boolean;
-  trailing?: ReactNode;
-  onCollapse?: () => void;
-  children?: ReactNode;
-  actions?: ReactNode;
-}) {
-  return (
-    <section
-      className={cn(
-        "relative flex flex-col overflow-hidden rounded-xl border bg-card/60 transition-colors",
-        status === "connected" && "border-primary/20",
-        status === "failed" && "border-destructive/30",
-        status === "pending" && "border-amber-500/30",
-      )}
-    >
-      {status === "connected" && (
-        <span
-          aria-hidden
-          className="pointer-events-none absolute left-0 top-4 bottom-4 w-px bg-linear-to-b from-transparent via-primary to-transparent opacity-70"
-        />
-      )}
-      <header className="flex items-start gap-3 p-4 pb-3">
-        <span
-          className={cn(
-            "grid size-9 shrink-0 place-items-center rounded-lg border bg-background/40",
-            status === "connected" && "border-primary/30 text-primary",
-            status === "pending" && "border-amber-500/30 text-amber-600 dark:text-amber-400",
-            status === "failed" && "border-destructive/30 text-destructive",
-            (status === "disconnected" || status === "unavailable") && "text-muted-foreground",
-          )}
-        >
-          <Globe className="size-4" />
-        </span>
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <h3
-              className={cn(
-                "truncate text-sm font-semibold leading-tight tracking-tight",
-                mono && "font-mono text-sm",
-              )}
-            >
-              {title}
-            </h3>
-            {trailing ? (
-              <div className="ml-auto flex items-center gap-1.5">{trailing}</div>
-            ) : status === "connected" ? (
-              <span className="ml-auto flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.08em] text-primary">
-                <StatusDot kind="connected" />
-                Live
-              </span>
-            ) : onCollapse ? (
-              <button
-                type="button"
-                aria-label="Cancel"
-                onClick={onCollapse}
-                className="ml-auto -m-1 grid size-6 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              >
-                <X className="size-3.5" />
-              </button>
-            ) : null}
-          </div>
-          <p className="mt-0.5 text-xs leading-snug text-muted-foreground">{description}</p>
-        </div>
-      </header>
-      {children != null && <div className="flex-1 space-y-4 px-4 pb-3 text-sm">{children}</div>}
-      {actions && (
-        <footer className="flex flex-wrap items-center justify-end gap-2 border-t border-border/50 bg-muted/20 px-4 py-2.5">
-          {actions}
-        </footer>
-      )}
-    </section>
-  );
-}
-
-function DetailRow({
-  label,
-  value,
-  mono,
-}: {
-  label: string;
-  value: ReactNode;
-  mono?: boolean;
-}) {
-  return (
-    <div className="flex items-baseline justify-between gap-3 py-1 text-xs">
-      <span className="shrink-0 text-muted-foreground">{label}</span>
-      <span className={cn("min-w-0 text-right", mono ? "font-mono text-[11px]" : "font-medium")}>
-        {value}
-      </span>
-    </div>
-  );
-}
-
-function DetailList({ children }: { children: ReactNode }) {
-  return (
-    <div className="rounded-lg border bg-muted/20 px-3 py-1.5 divide-y divide-border/50">
-      {children}
-    </div>
-  );
-}
-
-function StatusPill({ kind, label }: { kind: StatusKind; label: string }) {
-  return (
-    <span
-      className={cn(
-        "flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.08em]",
-        kind === "connected" && "text-primary",
-        kind === "pending" && "text-amber-600 dark:text-amber-400",
-        kind === "failed" && "text-destructive",
-        (kind === "disconnected" || kind === "unavailable") && "text-muted-foreground",
-      )}
-    >
-      <StatusDot kind={kind} />
-      {label}
-    </span>
-  );
-}
 
 // ── Page ──────────────────────────────────────────────────────────
 
@@ -342,19 +146,20 @@ function CustomDomainPageContent() {
             title="Custom domains are an Enterprise feature"
             description="Upgrade to serve Atlas from a subdomain you control with automatic TLS."
             status="unavailable"
-            trailingLabel={
-              <span className="flex items-center gap-1">
-                <Lock className="size-3" />
-                Locked
-              </span>
-            }
+            statusLabel="Locked"
             action={
-              <Button variant="outline" size="sm" asChild>
-                <a href="/admin/usage">
-                  View plan
-                  <ArrowUpRight className="ml-1.5 size-3.5" />
-                </a>
-              </Button>
+              <div className="flex items-center gap-2">
+                <span className="flex items-center gap-1 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+                  <Lock className="size-3" />
+                  Locked
+                </span>
+                <Button variant="outline" size="sm" asChild>
+                  <a href="/admin/usage">
+                    View plan
+                    <ArrowUpRight className="ml-1.5 size-3.5" />
+                  </a>
+                </Button>
+              </div>
             }
           />
         </div>
@@ -370,8 +175,8 @@ function CustomDomainPageContent() {
 
   function statusKindFor(d: CustomDomain): StatusKind {
     if (d.status === "verified") return "connected";
-    if (d.status === "failed") return "failed";
-    return "pending";
+    if (d.status === "failed") return "unhealthy";
+    return "transitioning";
   }
 
   return (
@@ -425,7 +230,8 @@ function CustomDomainPageContent() {
             )}
 
             {!domain && expanded && (
-              <DomainShell
+              <Shell
+                icon={Globe}
                 status="disconnected"
                 title="Add a custom domain"
                 description="We'll give you a CNAME target to add at your DNS provider."
@@ -456,13 +262,15 @@ function CustomDomainPageContent() {
                   </p>
                 </div>
                 {addError && <ErrorBanner message={addError} />}
-              </DomainShell>
+              </Shell>
             )}
 
             {domain && (
-              <DomainShell
+              <Shell
+                icon={Globe}
                 status={statusKindFor(domain)}
-                title={domain.domain}
+                title={<span className="font-mono">{domain.domain}</span>}
+                titleText={domain.domain}
                 description={
                   domain.status === "verified"
                     ? "TLS is issued — your domain is serving traffic."
@@ -470,15 +278,26 @@ function CustomDomainPageContent() {
                       ? "Verification failed. Recheck your CNAME and try again."
                       : "Waiting for DNS. Add the CNAME below, then check status."
                 }
-                mono
                 trailing={
-                  domain.status === "verified" ? (
-                    <StatusPill kind="connected" label="Live" />
-                  ) : domain.status === "failed" ? (
-                    <StatusPill kind="failed" label="Failed" />
-                  ) : (
-                    <StatusPill kind="pending" label="Pending" />
-                  )
+                  domain.status === "failed" ? (
+                    <span
+                      className={cn(
+                        "flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.08em] text-destructive",
+                      )}
+                    >
+                      <StatusDot kind="unhealthy" />
+                      Failed
+                    </span>
+                  ) : domain.status !== "verified" ? (
+                    <span
+                      className={cn(
+                        "flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.08em] text-amber-600 dark:text-amber-400",
+                      )}
+                    >
+                      <StatusDot kind="transitioning" />
+                      Pending
+                    </span>
+                  ) : undefined
                 }
                 actions={
                   <>
@@ -602,7 +421,7 @@ function CustomDomainPageContent() {
                     </span>
                   </div>
                 )}
-              </DomainShell>
+              </Shell>
             )}
           </section>
         </div>


### PR DESCRIPTION
## Summary

- Replace the inline `StatusDot` / `SectionHeading` / `CompactRow` / `DomainShell` / `DetailRow` / `DetailList` / `StatusPill` primitives with the shared `@/ui/components/admin/compact` module.
- Rename `DomainShell` → `Shell` and map the page's `pending` / `failed` status kinds to the shared vocabulary (`transitioning` / `unhealthy`).
- Fold the `trailingLabel` "Locked" pill into the CompactRow `action` slot on the plan-gated path — the shared CompactRow doesn't carry a separate trailing label.
- Preserve `combineMutationErrors`, `cn`, and `useState`. Drop the now-unused `X` import.

Part of #1551

## Test plan

- [x] `bun x eslint packages/web/src/app/admin/custom-domain/page.tsx` — clean
- [ ] CI covers type + build
- [ ] Manual: verify plan-gated state, disconnected CompactRow, add-domain Shell, verified/pending/failed Shell variants render with correct trailing ornaments