### PR TITLE
refactor(web/admin/residency): migrate to @/ui/components/admin/compact (#1551)

### DIFF
--- a/packages/web/src/app/admin/residency/page.tsx
+++ b/packages/web/src/app/admin/residency/page.tsx
@@ -23,6 +23,15 @@ import {
 } from "@/components/ui/select";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import {
+  CompactRow,
+  DetailList,
+  DetailRow,
+  SectionHeading,
+  Shell,
+  StatusDot,
+  type StatusKind,
+} from "@/ui/components/admin/compact";
 import { useAdminFetch, friendlyError } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { combineMutationErrors } from "@/ui/lib/mutation-errors";
@@ -59,41 +68,10 @@ const ResidencyStatusSchema = z.object({
 });
 type ResidencyStatus = z.infer<typeof ResidencyStatusSchema>;
 
-// ── Shared design primitives ──────────────────────────────────────
-// Intentionally duplicated from admin/sandbox and admin/custom-domain
-// until the shape is stable enough to extract. Tracked in #1551.
-
-type StatusKind =
-  | "connected"
-  | "ready"
-  | "pending"
-  | "failed"
-  | "disconnected"
-  | "unavailable";
-
-function StatusDot({ kind }: { kind: StatusKind }) {
-  return (
-    <span
-      aria-hidden
-      className={cn(
-        "relative inline-flex size-1.5 shrink-0 rounded-full",
-        kind === "connected" &&
-          "bg-primary shadow-[0_0_0_3px_color-mix(in_oklch,var(--primary)_15%,transparent)]",
-        kind === "ready" && "bg-primary/70",
-        kind === "pending" && "bg-amber-500/80",
-        kind === "failed" && "bg-destructive",
-        kind === "disconnected" && "bg-muted-foreground/40",
-        kind === "unavailable" &&
-          "bg-muted-foreground/20 outline-1 outline-dashed outline-muted-foreground/30",
-      )}
-    >
-      {kind === "connected" && (
-        <span className="absolute inset-0 rounded-full bg-primary/60 motion-safe:animate-ping" />
-      )}
-    </span>
-  );
-}
-
+// ── Page-local status pill ────────────────────────────────────────
+// The compact Shell only renders default pills for `connected` / `unhealthy`.
+// Residency needs custom migration-state pills ("Queued", "Migrating",
+// "Migrated", "Cancelled", "Unassigned") which we pass via `trailing`.
 function StatusPill({ kind, label }: { kind: StatusKind; label: string }) {
   return (
     <span
@@ -101,9 +79,10 @@ function StatusPill({ kind, label }: { kind: StatusKind; label: string }) {
         "flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.08em]",
         kind === "connected" && "text-primary",
         kind === "ready" && "text-primary/80",
-        kind === "pending" && "text-amber-600 dark:text-amber-400",
-        kind === "failed" && "text-destructive",
-        (kind === "disconnected" || kind === "unavailable") && "text-muted-foreground",
+        kind === "transitioning" && "text-amber-600 dark:text-amber-400",
+        kind === "unhealthy" && "text-destructive",
+        (kind === "disconnected" || kind === "unavailable") &&
+          "text-muted-foreground",
       )}
     >
       <StatusDot kind={kind} />
@@ -112,184 +91,8 @@ function StatusPill({ kind, label }: { kind: StatusKind; label: string }) {
   );
 }
 
-function SectionHeading({
-  title,
-  description,
-}: {
-  title: string;
-  description: string;
-}) {
-  return (
-    <div className="mb-3">
-      <h2 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-        {title}
-      </h2>
-      <p className="mt-0.5 text-xs text-muted-foreground/80">{description}</p>
-    </div>
-  );
-}
-
-function CompactRow({
-  icon: Icon,
-  title,
-  description,
-  status,
-  action,
-}: {
-  icon: ComponentType<{ className?: string }>;
-  title: string;
-  description: ReactNode;
-  status: StatusKind;
-  action?: ReactNode;
-}) {
-  return (
-    <div
-      className={cn(
-        "group flex items-center gap-3 rounded-xl border bg-card/40 px-3.5 py-2.5 transition-colors",
-        "hover:bg-card/70 hover:border-border/80",
-        status === "unavailable" && "opacity-70",
-      )}
-    >
-      <span className="grid size-8 shrink-0 place-items-center rounded-lg border bg-background/40 text-muted-foreground">
-        <Icon className="size-4" />
-      </span>
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <h3 className="truncate text-sm font-semibold leading-tight tracking-tight">
-            {title}
-          </h3>
-          <StatusDot kind={status} />
-        </div>
-        <p className="mt-0.5 truncate text-xs text-muted-foreground">{description}</p>
-      </div>
-      {action && <div className="shrink-0">{action}</div>}
-    </div>
-  );
-}
-
-function ResidencyShell({
-  icon: Icon,
-  title,
-  description,
-  status,
-  trailing,
-  mono,
-  onCollapse,
-  children,
-  actions,
-}: {
-  icon: ComponentType<{ className?: string }>;
-  title: string;
-  description: ReactNode;
-  status: StatusKind;
-  trailing?: ReactNode;
-  mono?: boolean;
-  onCollapse?: () => void;
-  children?: ReactNode;
-  actions?: ReactNode;
-}) {
-  return (
-    <section
-      className={cn(
-        "relative flex flex-col overflow-hidden rounded-xl border bg-card/60 transition-colors",
-        status === "connected" && "border-primary/20",
-        status === "ready" && "border-primary/10",
-        status === "pending" && "border-amber-500/30",
-        status === "failed" && "border-destructive/30",
-      )}
-    >
-      {status === "connected" && (
-        <span
-          aria-hidden
-          className="pointer-events-none absolute left-0 top-4 bottom-4 w-px bg-linear-to-b from-transparent via-primary to-transparent opacity-70"
-        />
-      )}
-      <header className="flex items-start gap-3 p-4 pb-3">
-        <span
-          className={cn(
-            "grid size-9 shrink-0 place-items-center rounded-lg border bg-background/40",
-            status === "connected" && "border-primary/30 text-primary",
-            status === "ready" && "border-primary/20 text-primary/80",
-            status === "pending" && "border-amber-500/30 text-amber-600 dark:text-amber-400",
-            status === "failed" && "border-destructive/30 text-destructive",
-            (status === "disconnected" || status === "unavailable") && "text-muted-foreground",
-          )}
-        >
-          <Icon className="size-4" />
-        </span>
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <h3
-              className={cn(
-                "truncate text-sm font-semibold leading-tight tracking-tight",
-                mono && "font-mono",
-              )}
-            >
-              {title}
-            </h3>
-            {trailing ? (
-              <div className="ml-auto flex items-center gap-1.5">{trailing}</div>
-            ) : status === "connected" ? (
-              <span className="ml-auto">
-                <StatusPill kind="connected" label="Live" />
-              </span>
-            ) : onCollapse ? (
-              <button
-                type="button"
-                aria-label="Cancel"
-                onClick={onCollapse}
-                className="ml-auto -m-1 grid size-6 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              >
-                <XCircle className="size-3.5" />
-              </button>
-            ) : null}
-          </div>
-          <p className="mt-0.5 text-xs leading-snug text-muted-foreground">{description}</p>
-        </div>
-      </header>
-      {children != null && (
-        <div className="flex-1 space-y-4 px-4 pb-3 text-sm">{children}</div>
-      )}
-      {actions && (
-        <footer className="flex flex-wrap items-center justify-end gap-2 border-t border-border/50 bg-muted/20 px-4 py-2.5">
-          {actions}
-        </footer>
-      )}
-    </section>
-  );
-}
-
-function DetailRow({
-  label,
-  value,
-  mono,
-}: {
-  label: string;
-  value: ReactNode;
-  mono?: boolean;
-}) {
-  return (
-    <div className="flex items-baseline justify-between gap-3 py-1 text-xs">
-      <span className="shrink-0 text-muted-foreground">{label}</span>
-      <span
-        className={cn(
-          "min-w-0 text-right",
-          mono ? "font-mono text-[11px]" : "font-medium",
-        )}
-      >
-        {value}
-      </span>
-    </div>
-  );
-}
-
-function DetailList({ children }: { children: ReactNode }) {
-  return (
-    <div className="rounded-lg border bg-muted/20 px-3 py-1.5 divide-y divide-border/50">
-      {children}
-    </div>
-  );
-}
+// ── Region picker tile ────────────────────────────────────────────
+// Page-specific: the region grid is not a general admin primitive.
 
 function RegionTile({
   region,
@@ -567,7 +370,7 @@ function UnassignedRegionShell({
   const hasRegions = status.availableRegions.length > 0;
 
   return (
-    <ResidencyShell
+    <Shell
       icon={MapPin}
       title="Choose a region"
       description="Permanent once assigned. All workspace data will be stored in the region you pick."
@@ -646,7 +449,7 @@ function UnassignedRegionShell({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </ResidencyShell>
+    </Shell>
   );
 }
 
@@ -681,14 +484,14 @@ function AssignedRegionShell({
   const canMigrate = isSaas && otherRegions.length > 0 && !hasPending;
   const shellStatus: StatusKind =
     migration?.status === "in_progress" || migration?.status === "pending"
-      ? "pending"
+      ? "transitioning"
       : migration?.status === "failed"
-        ? "failed"
+        ? "unhealthy"
         : "connected";
   const pillFor = pillForMigration(migration);
 
   return (
-    <ResidencyShell
+    <Shell
       icon={MapPin}
       title={displayLabel}
       description={
@@ -727,7 +530,7 @@ function AssignedRegionShell({
           cancelling={cancelling}
         />
       )}
-    </ResidencyShell>
+    </Shell>
   );
 }
 
@@ -738,12 +541,12 @@ function pillForMigration(migration: RegionMigration | null): ReactNode {
     case "in_progress":
       return (
         <StatusPill
-          kind="pending"
+          kind="transitioning"
           label={migration.status === "pending" ? "Queued" : "Migrating"}
         />
       );
     case "failed":
-      return <StatusPill kind="failed" label="Failed" />;
+      return <StatusPill kind="unhealthy" label="Failed" />;
     case "completed":
       return <StatusPill kind="connected" label="Migrated" />;
     case "cancelled":


### PR DESCRIPTION
## Summary

- Migrate `packages/web/src/app/admin/residency/page.tsx` to the shared compact primitives in `@/ui/components/admin/compact`.
- Deletes inline copies of `StatusDot`, `SectionHeading`, `CompactRow`, `ResidencyShell` (renamed to the canonical `Shell`), `DetailRow`, `DetailList`.
- Maps the local `StatusKind` values (`pending`, `failed`) to the canonical vocabulary (`transitioning`, `unhealthy`).
- Keeps a page-local `StatusPill` helper since migration states ("Queued" / "Migrating" / "Migrated" / "Cancelled" / "Unassigned") need custom pills the canonical `Shell` does not render by default — it's passed via `trailing`.
- Preserves `combineMutationErrors` and all four mutations (assign / migrate / retry / cancel) untouched.
- Net −197 lines.

Part of #1551.

## Test plan

- [ ] `bun x eslint packages/web/src/app/admin/residency/page.tsx` is clean (verified locally).
- [ ] `/admin/residency` renders the not-configured compact row, the unassigned shell, and the assigned shell without regressions.
- [ ] Region assign mutation (`PUT /api/v1/admin/residency`) still fires from the Unassigned card's confirm dialog.
- [ ] Region migrate mutation (`POST /api/v1/admin/residency/migrate`) still fires from the `MigrationDialog` confirm step.
- [ ] Retry mutation (`POST /api/v1/admin/residency/migrate/:id/retry`) still fires on a `failed` migration.
- [ ] Cancel mutation (`POST /api/v1/admin/residency/migrate/:id/cancel`) still fires on a `pending` migration.
- [ ] Migration trailing pills render correctly for each status (Queued, Migrating, Failed, Migrated, Cancelled).