### PR TITLE
refactor(web/admin/ip-allowlist): migrate to @/ui/components/admin/compact (#1551)

### DIFF
--- a/packages/web/src/app/admin/ip-allowlist/page.tsx
+++ b/packages/web/src/app/admin/ip-allowlist/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type ComponentType, type ReactNode } from "react";
+import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -25,6 +25,13 @@ import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
+import {
+  CompactRow,
+  InlineError,
+  SectionHeading,
+  Shell,
+  type StatusKind,
+} from "@/ui/components/admin/compact";
 import { formatDateTime } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import {
@@ -67,204 +74,6 @@ const IPAllowlistResponseSchema = z.object({
   // harmless and self-heals on the next successful deploy).
   effectivelyEnforced: z.boolean().optional(),
 });
-
-// ── Shared Design Primitives (locally duplicated per #1551) ──────────────
-
-type StatusKind = "connected" | "disconnected" | "unavailable";
-
-function StatusDot({ kind, className }: { kind: StatusKind; className?: string }) {
-  return (
-    <span
-      aria-hidden
-      className={cn(
-        "relative inline-flex size-1.5 shrink-0 rounded-full",
-        kind === "connected" &&
-          "bg-primary shadow-[0_0_0_3px_color-mix(in_oklch,_var(--primary)_15%,_transparent)]",
-        kind === "disconnected" && "bg-muted-foreground/40",
-        kind === "unavailable" && "bg-muted-foreground/20 outline-1 outline-dashed outline-muted-foreground/30",
-        className,
-      )}
-    >
-      {kind === "connected" && (
-        <span className="absolute inset-0 rounded-full bg-primary/60 motion-safe:animate-ping" />
-      )}
-    </span>
-  );
-}
-
-const STATUS_LABEL: Record<StatusKind, string> = {
-  connected: "Active",
-  disconnected: "Inactive",
-  unavailable: "Unavailable",
-};
-
-function InlineError({ children }: { children: ReactNode }) {
-  if (!children) return null;
-  return (
-    <div className="mt-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
-      {children}
-    </div>
-  );
-}
-
-function CompactRow({
-  icon: Icon,
-  title,
-  description,
-  status,
-  action,
-  titleAccessory,
-}: {
-  icon: ComponentType<{ className?: string }>;
-  title: string;
-  description: string;
-  status: StatusKind;
-  action?: ReactNode;
-  titleAccessory?: ReactNode;
-}) {
-  return (
-    <div
-      className={cn(
-        "group flex items-center gap-3 rounded-xl border bg-card/40 px-3.5 py-2.5 transition-colors",
-        "hover:bg-card/70 hover:border-border/80",
-        status === "unavailable" && "opacity-60",
-      )}
-    >
-      <span
-        className={cn(
-          "grid size-8 shrink-0 place-items-center rounded-lg border bg-background/40 text-muted-foreground",
-        )}
-      >
-        <Icon className="size-4" />
-      </span>
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <h3 className="truncate text-sm font-semibold leading-tight tracking-tight">
-            {title}
-          </h3>
-          {titleAccessory}
-          <StatusDot kind={status} className="shrink-0" />
-          <span className="sr-only">Status: {STATUS_LABEL[status]}</span>
-        </div>
-        {/* Newline-delimited descriptions render as a two-line subtitle (e.g. a
-            rule's human description on top and its added-at/by metadata below).
-            Single-line descriptions truncate as before. */}
-        {(() => {
-          const lines = description.split("\n");
-          if (lines.length > 1) {
-            return (
-              <div className="mt-0.5 space-y-0.5">
-                <p className="truncate text-xs text-muted-foreground">
-                  {lines[0]}
-                </p>
-                <p className="truncate text-[11px] text-muted-foreground/70">
-                  {lines.slice(1).join(" · ")}
-                </p>
-              </div>
-            );
-          }
-          return (
-            <p className="mt-0.5 truncate text-xs text-muted-foreground">
-              {description}
-            </p>
-          );
-        })()}
-      </div>
-      {action && <div className="shrink-0">{action}</div>}
-    </div>
-  );
-}
-
-function IntegrationShell({
-  icon: Icon,
-  title,
-  description,
-  status,
-  titleAccessory,
-  children,
-  actions,
-}: {
-  icon: ComponentType<{ className?: string }>;
-  title: string;
-  description: string;
-  status: StatusKind;
-  titleAccessory?: ReactNode;
-  children?: ReactNode;
-  actions?: ReactNode;
-}) {
-  return (
-    <section
-      className={cn(
-        "relative flex flex-col overflow-hidden rounded-xl border bg-card/60 backdrop-blur-[1px] transition-colors",
-        "hover:border-border/80",
-        status === "connected" && "border-primary/20",
-      )}
-    >
-      {status === "connected" && (
-        <span
-          aria-hidden
-          className="pointer-events-none absolute left-0 top-4 bottom-4 w-px bg-gradient-to-b from-transparent via-primary to-transparent opacity-70"
-        />
-      )}
-
-      <header className="flex items-start gap-3 p-4 pb-3">
-        <span
-          className={cn(
-            "grid size-9 shrink-0 place-items-center rounded-lg border bg-background/40",
-            status === "connected" && "border-primary/30 text-primary",
-            status !== "connected" && "text-muted-foreground",
-          )}
-        >
-          <Icon className="size-4" />
-        </span>
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <h3 className="truncate text-sm font-semibold leading-tight tracking-tight">
-              {title}
-            </h3>
-            {titleAccessory}
-            {status === "connected" && (
-              <span className="ml-auto flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.08em] text-primary">
-                <StatusDot kind="connected" />
-                Live
-              </span>
-            )}
-          </div>
-          <p className="mt-0.5 truncate text-xs leading-snug text-muted-foreground">
-            {description}
-          </p>
-        </div>
-      </header>
-
-      {children != null && (
-        <div className="flex-1 space-y-3 px-4 pb-3 text-sm">{children}</div>
-      )}
-
-      {actions && (
-        <footer className="flex flex-wrap items-center justify-end gap-2 border-t border-border/50 bg-muted/20 px-4 py-2.5">
-          {actions}
-        </footer>
-      )}
-    </section>
-  );
-}
-
-function SectionHeading({
-  title,
-  description,
-}: {
-  title: string;
-  description: string;
-}) {
-  return (
-    <div className="mb-3">
-      <h2 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-        {title}
-      </h2>
-      <p className="mt-0.5 text-xs text-muted-foreground/80">{description}</p>
-    </div>
-  );
-}
 
 // ── Add Entry Dialog ──────────────────────────────────────────────
 
@@ -538,7 +347,7 @@ export default function IPAllowlistPage() {
                 description="Access is restricted when one or more ranges are configured"
               />
               {enforcementStatus === "connected" ? (
-                <IntegrationShell
+                <Shell
                   icon={ShieldCheck}
                   title="Allowlist enforcement"
                   description={enforcementDescription}
@@ -558,12 +367,14 @@ export default function IPAllowlistPage() {
                     status={enforcementStatus}
                   />
                   {enforcementDormant && (
-                    <InlineError>
-                      These ranges aren&apos;t being enforced. IP allowlisting requires
-                      an Atlas Enterprise license and a configured internal database
-                      (<code className="rounded bg-destructive/10 px-1 font-mono">DATABASE_URL</code>).
-                      Until both are present, the workspace accepts requests from any IP.
-                    </InlineError>
+                    <div className="mt-2">
+                      <InlineError>
+                        These ranges aren&apos;t being enforced. IP allowlisting requires
+                        an Atlas Enterprise license and a configured internal database
+                        (<code className="rounded bg-destructive/10 px-1 font-mono">DATABASE_URL</code>).
+                        Until both are present, the workspace accepts requests from any IP.
+                      </InlineError>
+                    </div>
                   )}
                 </>
               )}
@@ -578,39 +389,48 @@ export default function IPAllowlistPage() {
               <div className="space-y-2">
                 {entries.map((entry) => {
                   const addedLine = `Added ${formatDateTime(entry.createdAt)}${entry.createdBy ? ` · ${entry.createdBy}` : ""}`;
-                  // Render description (when present) AND the added-at/by metadata.
-                  // Newline triggers the two-line subtitle fork inside CompactRow so
-                  // rules with a description don't drop their created metadata.
-                  const description = entry.description
-                    ? `${entry.description}\n${addedLine}`
-                    : addedLine;
+                  // When the rule has a human description, render two lines inside
+                  // CompactRow's description slot: the description on top and the
+                  // added-at/by metadata below. The extracted CompactRow wraps
+                  // `description` in a <p>, so we use <span className="block">
+                  // children instead of nested <p> tags to keep HTML valid.
+                  const description = entry.description ? (
+                    <>
+                      <span className="block truncate">{entry.description}</span>
+                      <span className="block truncate text-[11px] text-muted-foreground/80">
+                        {addedLine}
+                      </span>
+                    </>
+                  ) : (
+                    addedLine
+                  );
                   return (
-                  <CompactRow
-                    key={entry.id}
-                    icon={Network}
-                    title={entry.cidr}
-                    description={description}
-                    status="connected"
-                    titleAccessory={
-                      <Badge
-                        variant="outline"
-                        className="shrink-0 font-mono text-[10px] uppercase"
-                      >
-                        {entry.cidr.includes(":") ? "IPv6" : "IPv4"}
-                      </Badge>
-                    }
-                    action={
-                      <Button
-                        variant="ghost"
-                        size="xs"
-                        onClick={() => setDeleteEntry(entry)}
-                        className="text-muted-foreground hover:text-destructive"
-                        aria-label={`Remove ${entry.cidr}`}
-                      >
-                        <Trash2 className="size-3.5" />
-                      </Button>
-                    }
-                  />
+                    <CompactRow
+                      key={entry.id}
+                      icon={Network}
+                      title={entry.cidr}
+                      description={description}
+                      status="connected"
+                      action={
+                        <div className="flex items-center gap-2">
+                          <Badge
+                            variant="outline"
+                            className="shrink-0 font-mono text-[10px] uppercase"
+                          >
+                            {entry.cidr.includes(":") ? "IPv6" : "IPv4"}
+                          </Badge>
+                          <Button
+                            variant="ghost"
+                            size="xs"
+                            onClick={() => setDeleteEntry(entry)}
+                            className="text-muted-foreground hover:text-destructive"
+                            aria-label={`Remove ${entry.cidr}`}
+                          >
+                            <Trash2 className="size-3.5" />
+                          </Button>
+                        </div>
+                      }
+                    />
                   );
                 })}
 


### PR DESCRIPTION
## Summary

- Part of #1551 — pull the inline `Shell` / `CompactRow` / `StatusDot` / `InlineError` / `SectionHeading` duplication out of `packages/web/src/app/admin/ip-allowlist/page.tsx` and use the shared primitives at `@/ui/components/admin/compact`.
- Rewrites the two-line CompactRow subtitle (description + "Added at/by" metadata) to pass a JSX fragment with `<span className="block">` children into CompactRow's `description` prop instead of the newline-split fork that lived in the inline primitive. The extracted `CompactRow` wraps `description` in a single `<p>`, so using `<span>` block children keeps the HTML valid.
- Preserves the `effectivelyEnforced`-driven enforcement status (connected / unavailable-dormant / disconnected), the `InlineError` that surfaces when rules exist but EE or the internal DB is missing, the caller-IP warning in the delete dialog, and the IPv4 / IPv6 badge (now rendered alongside the delete button in the action slot since the extracted `CompactRow` has no `titleAccessory` prop).

Net: -180 lines (58 insertions, 238 deletions).

## Test plan

- [ ] Add a CIDR range through the "Add range" button, confirm it appears in the Ranges section.
- [ ] Delete a range; confirm the delete confirmation warns about caller IP when other entries remain.
- [ ] Enforcement section — dormant state: rules exist but EE disabled or no `DATABASE_URL` → shows unavailable `CompactRow` + the `InlineError` about EE + `DATABASE_URL`.
- [ ] Enforcement section — active: EE enabled, rules configured → shows the full `Shell` with "Requests outside these ranges are rejected" footer.
- [ ] Enforcement section — empty: no rules → shows disconnected `CompactRow` with the "No ranges configured" copy.
- [ ] Rule with a description: two-line subtitle shows the description on top and the "Added ..." metadata below, both truncated.
- [ ] Rule without a description: single-line subtitle shows only the "Added ..." metadata.
- [ ] IPv4 / IPv6 badge still renders next to the delete button for each range.