### PR TITLE
refactor(web/admin/settings): migrate to @/ui/components/admin/compact (#1551)

### DIFF
--- a/packages/web/src/app/admin/settings/page.tsx
+++ b/packages/web/src/app/admin/settings/page.tsx
@@ -20,6 +20,7 @@ import {
   FormMessage,
 } from "@/components/form-dialog";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { SectionHeading } from "@/ui/components/admin/compact";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
@@ -91,6 +92,16 @@ const SECTION_ICONS: Record<KnownSection, ComponentType<{ className?: string }>>
   Agent: Bot,
   Intelligence: Brain,
   Demo: FlaskConical,
+};
+
+const SECTION_DESCRIPTIONS: Record<KnownSection, string> = {
+  "Query Limits": "Row caps and execution timeouts for user queries",
+  "Rate Limiting": "Request throttles per user and per workspace",
+  Sessions: "Auth session lifetimes and refresh behavior",
+  Sandbox: "Where explore and Python tools run",
+  Agent: "LLM behavior, model selection, and step caps",
+  Intelligence: "Learning and memory features",
+  Demo: "Demo mode fixtures and sample data",
 };
 
 function sectionIcon(section: string): ComponentType<{ className?: string }> {
@@ -255,19 +266,6 @@ function EditDialog({
 }
 
 // ── Section + row primitives ──────────────────────────────────────
-
-function SectionHeading({ title, description }: { title: string; description?: string }) {
-  return (
-    <div className="mb-3">
-      <h2 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-        {title}
-      </h2>
-      {description && (
-        <p className="mt-0.5 text-xs text-muted-foreground/80">{description}</p>
-      )}
-    </div>
-  );
-}
 
 function SettingRow({
   setting,
@@ -480,9 +478,13 @@ export default function SettingsPage() {
 
             {orderedSections.map((section) => {
               const items = workspaceSections.get(section) ?? [];
+              const description =
+                section in SECTION_DESCRIPTIONS
+                  ? SECTION_DESCRIPTIONS[section as KnownSection]
+                  : "Workspace overrides";
               return (
                 <section key={section}>
-                  <SectionHeading title={section} />
+                  <SectionHeading title={section} description={description} />
                   <div className="space-y-2">
                     {items.map((setting) => (
                       <SettingRow


### PR DESCRIPTION
## Summary

Part of #1551 — migrate `/admin/settings` off its inline primitive duplication and onto the shared `@/ui/components/admin/compact` module.

- Replace the local `SectionHeading` (which had `description?: string`) with the shared one (which requires `description: string`) and add a `SECTION_DESCRIPTIONS` map keyed by `SECTION_ORDER` so every known workspace section carries the short subtext the shared primitive was designed around. Brings Workspace Settings in line with the other revamped pages (integrations, billing, custom-domain, model-config) that already show section subtext.
- Unknown sections (anything not in `SECTION_ORDER`) fall back to `"Workspace overrides"` so the required-prop contract is satisfied without a warning in the wild if a new setting ever lands in a brand-new section before this map is updated.
- `SettingRow` stays page-local. It isn't a Shell/CompactRow variant — three-line layout (title row + description + `envVar` + value) with an Edit / Reset action cluster, and it uses override-source semantics (env / override / workspace-override / default) rather than the connected/disconnected `StatusKind` the shared primitives assume. Forcing it onto `CompactRow` or `Shell` would require either mutilating the shared primitives or dropping information density here.
- `type StatusKind` is not imported — this page doesn't branch on it.
- `EditDialog` is untouched (still uses `useAdminMutation` + `result.ok`).

## Test plan

- [ ] `bun x eslint packages/web/src/app/admin/settings/page.tsx` — clean.
- [ ] Visual: `/admin/settings` renders with per-section subtext beneath each section eyebrow; rows and edit/reset buttons behave identically.
- [ ] Edit dialog still opens, saves, and closes on success; reset button still clears override.