### PR TITLE
refactor(web/admin/connections): migrate to @/ui/components/admin/compact (#1551)

### DIFF
--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -74,8 +74,16 @@ import {
   useEffect,
   useRef,
   type ComponentType,
-  type ReactNode,
 } from "react";
+import {
+  CompactRow,
+  DetailList,
+  DetailRow,
+  InlineError,
+  SectionHeading,
+  Shell,
+  type StatusKind,
+} from "@/ui/components/admin/compact";
 import { cn } from "@/lib/utils";
 import { formatDateTime } from "@/lib/format";
 import {
@@ -695,247 +703,6 @@ function PoolStatsSection({ onError }: { onError: (msg: string) => void }) {
   );
 }
 
-// ── Shared Design Primitives ─────────────────────────────────────
-// Local copies of admin/integrations primitives (PR #1538). Promote to
-// @/ui/components/admin/ once a third page reuses them — tracked as #1551.
-
-// `"unhealthy"` is a connections-page-specific addition on top of the
-// admin/integrations primitive set — a configured connection that's currently
-// down must not visually collapse into "disconnected" (which reads as "never
-// set up"). It gets a destructive-tinted dot (no pulse — pulse is reserved for
-// the positive "live" signal) so admins notice a real outage immediately.
-type StatusKind = "connected" | "disconnected" | "unavailable" | "unhealthy";
-
-function StatusDot({ kind, className }: { kind: StatusKind; className?: string }) {
-  return (
-    <span
-      aria-hidden
-      className={cn(
-        "relative inline-flex size-1.5 shrink-0 rounded-full",
-        kind === "connected" &&
-          "bg-primary shadow-[0_0_0_3px_color-mix(in_oklch,var(--primary)_15%,transparent)]",
-        kind === "disconnected" && "bg-muted-foreground/40",
-        kind === "unavailable" &&
-          "bg-muted-foreground/20 outline-1 outline-dashed outline-muted-foreground/30",
-        kind === "unhealthy" &&
-          "bg-destructive shadow-[0_0_0_3px_color-mix(in_oklch,var(--destructive)_15%,transparent)]",
-        className,
-      )}
-    >
-      {kind === "connected" && (
-        <span className="absolute inset-0 rounded-full bg-primary/60 motion-safe:animate-ping" />
-      )}
-    </span>
-  );
-}
-
-const STATUS_LABEL: Record<StatusKind, string> = {
-  connected: "Connected",
-  disconnected: "Not connected",
-  unavailable: "Unavailable",
-  unhealthy: "Unhealthy",
-};
-
-function InlineError({ children }: { children: ReactNode }) {
-  if (!children) return null;
-  return (
-    <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
-      {children}
-    </div>
-  );
-}
-
-function ConnectionShell({
-  icon: Icon,
-  title,
-  titleText,
-  titleBadge,
-  description,
-  status,
-  statusLabel,
-  children,
-  actions,
-}: {
-  icon: ComponentType<{ className?: string }>;
-  title: ReactNode;
-  /** Plain-text title for aria-label when `title` is JSX. */
-  titleText?: string;
-  titleBadge?: ReactNode;
-  description: string;
-  status: StatusKind;
-  statusLabel?: string;
-  children?: ReactNode;
-  actions?: ReactNode;
-}) {
-  const ariaTitle = titleText ?? (typeof title === "string" ? title : "Connection");
-  return (
-    <section
-      aria-label={`${ariaTitle}: ${STATUS_LABEL[status]}`}
-      className={cn(
-        "relative flex flex-col overflow-hidden rounded-xl border bg-card/60 backdrop-blur-[1px] transition-colors",
-        "hover:border-border/80",
-        status === "connected" && "border-primary/20",
-        status === "unhealthy" && "border-destructive/30",
-      )}
-    >
-      {status === "connected" && (
-        <span
-          aria-hidden
-          className="pointer-events-none absolute left-0 top-4 bottom-4 w-px bg-linear-to-b from-transparent via-primary to-transparent opacity-70"
-        />
-      )}
-      {status === "unhealthy" && (
-        <span
-          aria-hidden
-          className="pointer-events-none absolute left-0 top-4 bottom-4 w-px bg-linear-to-b from-transparent via-destructive to-transparent opacity-70"
-        />
-      )}
-
-      <header className="flex items-start gap-3 p-4 pb-3">
-        <span
-          className={cn(
-            "grid size-9 shrink-0 place-items-center rounded-lg border bg-background/40",
-            status === "connected" && "border-primary/30 text-primary",
-            status === "unhealthy" && "border-destructive/30 text-destructive",
-            status !== "connected" &&
-              status !== "unhealthy" &&
-              "text-muted-foreground",
-          )}
-        >
-          <Icon className="size-4" />
-        </span>
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <h3 className="truncate text-sm font-semibold leading-tight tracking-tight">
-              {title}
-            </h3>
-            {titleBadge}
-            {status === "connected" && (
-              <span className="ml-auto flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.08em] text-primary">
-                <StatusDot kind="connected" />
-                {statusLabel ?? "Live"}
-              </span>
-            )}
-            {status === "unhealthy" && (
-              <span className="ml-auto flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.08em] text-destructive">
-                <StatusDot kind="unhealthy" />
-                {statusLabel ?? "Unhealthy"}
-              </span>
-            )}
-          </div>
-          <p className="mt-0.5 text-xs leading-snug text-muted-foreground">
-            {description}
-          </p>
-        </div>
-      </header>
-
-      {children != null && (
-        <div className="flex-1 space-y-3 px-4 pb-3 text-sm">{children}</div>
-      )}
-
-      {actions && (
-        <footer className="flex items-center justify-end gap-2 border-t border-border/50 bg-muted/20 px-4 py-2.5">
-          {actions}
-        </footer>
-      )}
-    </section>
-  );
-}
-
-function CompactRow({
-  icon: Icon,
-  title,
-  description,
-  status,
-  action,
-}: {
-  icon: ComponentType<{ className?: string }>;
-  title: string;
-  description: string;
-  status: StatusKind;
-  action?: ReactNode;
-}) {
-  return (
-    <div
-      className={cn(
-        "group flex items-center gap-3 rounded-xl border bg-card/40 px-3.5 py-2.5 transition-colors",
-        "hover:bg-card/70 hover:border-border/80",
-        status === "unavailable" && "opacity-60",
-      )}
-    >
-      <span className="grid size-8 shrink-0 place-items-center rounded-lg border bg-background/40 text-muted-foreground">
-        <Icon className="size-4" />
-      </span>
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <h3 className="truncate text-sm font-semibold leading-tight tracking-tight">
-            {title}
-          </h3>
-          <StatusDot kind={status} className="shrink-0" />
-          <span className="sr-only">Status: {STATUS_LABEL[status]}</span>
-        </div>
-        <p className="mt-0.5 truncate text-xs text-muted-foreground">
-          {description}
-        </p>
-      </div>
-      {action && <div className="shrink-0">{action}</div>}
-    </div>
-  );
-}
-
-function DetailRow({
-  label,
-  value,
-  mono,
-  truncate,
-}: {
-  label: string;
-  value: ReactNode;
-  mono?: boolean;
-  truncate?: boolean;
-}) {
-  return (
-    <div className="flex items-baseline justify-between gap-3 py-1 text-xs">
-      <span className="shrink-0 text-muted-foreground">{label}</span>
-      <span
-        className={cn(
-          "min-w-0 text-right",
-          mono && "font-mono text-[11px]",
-          truncate && "truncate",
-          !mono && "font-medium",
-        )}
-      >
-        {value}
-      </span>
-    </div>
-  );
-}
-
-function DetailList({ children }: { children: ReactNode }) {
-  return (
-    <div className="rounded-lg border bg-muted/20 px-3 py-1.5 divide-y divide-border/50">
-      {children}
-    </div>
-  );
-}
-
-function SectionHeading({
-  title,
-  description,
-}: {
-  title: string;
-  description: string;
-}) {
-  return (
-    <div className="mb-3">
-      <h2 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-        {title}
-      </h2>
-      <p className="mt-0.5 text-xs text-muted-foreground/80">{description}</p>
-    </div>
-  );
-}
-
 // ── Provider mapping ─────────────────────────────────────────────
 
 /** Map a dbType value to the icon used in the compact row and shell header. */
@@ -1532,7 +1299,7 @@ function ConnectionCard({
   );
 
   return (
-    <ConnectionShell
+    <Shell
       icon={icon}
       title={<span className="font-mono">{conn.id}</span>}
       titleText={conn.id}
@@ -1596,6 +1363,6 @@ function ConnectionCard({
           <DetailRow label="Last tested" value={formatDateTime(conn.health.checkedAt)} />
         ) : null}
       </DetailList>
-    </ConnectionShell>
+    </Shell>
   );
 }


### PR DESCRIPTION
## Summary

- Migrate the revamped connections page (the largest of the extraction batch at ~1,600 lines) from its inline copy of the admin "compact" primitives to the shared `@/ui/components/admin/compact` module introduced in #1551.
- Delete the local `StatusDot`, `ConnectionShell`, `CompactRow`, `DetailList`, `DetailRow`, `InlineError`, `SectionHeading`, `STATUS_LABEL`, and `StatusKind` copies. All four `StatusKind` variants used here (`connected`, `disconnected`, `unavailable`, `unhealthy`) are covered by the extracted union.
- Rename the local `ConnectionShell` call site to `Shell`. The extracted `Shell` already supports the existing `title` JSX, `titleText`, `titleBadge`, `statusLabel`, and `description` usage; no behavior change. Kept `healthToStatus`, `ProviderBlock`, `ConnectionCard`, `PoolStatsSection`, and every mutation/dialog intact.

Part of #1551.

Result: `1 file changed, 11 insertions(+), 244 deletions(-)`.

## Test plan

- [ ] Test Connection button on an existing connection shows Testing / OK / Failed states and refreshes health
- [ ] Edit Connection loads the current config into the dialog and saves changes
- [ ] Delete Connection dialog deletes and refetches the list
- [ ] Add Connection dialog opens with Postgres preselected from hero CTA
- [ ] Add Connection dialog opens with the correct provider preselected when clicking Connect on a Snowflake / ClickHouse / etc. CompactRow
- [ ] Pool stats section expands, shows per-pool metrics, and refreshes on the Refresh button
- [ ] Unhealthy connection row renders the destructive pill, destructive accent stripe, and the backend-provided health message
- [ ] Empty state (no connections) shows the "Add connection" AdminContentWrapper CTA; developer-mode-no-drafts shows `DeveloperEmptyState` / `PublishedContextWrapper` correctly