### PR TITLE
refactor(web/admin/scim): migrate to @/ui/components/admin/compact (#1551)

### DIFF
--- a/packages/web/src/app/admin/scim/page.tsx
+++ b/packages/web/src/app/admin/scim/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, type ComponentType, type ReactNode } from "react";
+import { useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -29,6 +29,16 @@ import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
+import {
+  CompactRow,
+  DetailList,
+  DetailRow,
+  InlineError,
+  SectionHeading,
+  Shell,
+  StatusDot,
+  type StatusKind,
+} from "@/ui/components/admin/compact";
 import { formatDateTime } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import {
@@ -87,223 +97,6 @@ const GroupMappingsResponseSchema = z.object({
   mappings: z.array(SCIMGroupMappingSchema),
   total: z.number(),
 });
-
-// ── Shared Design Primitives (locally duplicated per #1551) ──────────────
-
-type StatusKind = "connected" | "transitioning" | "disconnected" | "unavailable";
-
-function StatusDot({ kind, className }: { kind: StatusKind; className?: string }) {
-  return (
-    <span
-      aria-hidden
-      className={cn(
-        "relative inline-flex size-1.5 shrink-0 rounded-full",
-        kind === "connected" &&
-          "bg-primary shadow-[0_0_0_3px_color-mix(in_oklch,_var(--primary)_15%,_transparent)]",
-        // `--warning` isn't part of the shadcn neutral base — hardcode amber-500
-        // to stay self-contained, same convention as /admin/plugins (see #1551).
-        kind === "transitioning" &&
-          "bg-amber-500 shadow-[0_0_0_3px_color-mix(in_oklch,_oklch(0.75_0.17_70)_15%,_transparent)]",
-        kind === "disconnected" && "bg-muted-foreground/40",
-        kind === "unavailable" && "bg-muted-foreground/20 outline-1 outline-dashed outline-muted-foreground/30",
-        className,
-      )}
-    >
-      {kind === "connected" && (
-        <span className="absolute inset-0 rounded-full bg-primary/60 motion-safe:animate-ping" />
-      )}
-    </span>
-  );
-}
-
-const STATUS_LABEL: Record<StatusKind, string> = {
-  connected: "Active",
-  transitioning: "Transitioning",
-  disconnected: "Inactive",
-  unavailable: "Unavailable",
-};
-
-function CompactRow({
-  icon: Icon,
-  title,
-  description,
-  status,
-  action,
-}: {
-  icon: ComponentType<{ className?: string }>;
-  title: string;
-  description: string;
-  status: StatusKind;
-  action?: ReactNode;
-}) {
-  return (
-    <div
-      className={cn(
-        "group flex items-center gap-3 rounded-xl border bg-card/40 px-3.5 py-2.5 transition-colors",
-        "hover:bg-card/70 hover:border-border/80",
-        status === "transitioning" && "border-amber-500/20",
-        status === "unavailable" && "opacity-60",
-      )}
-    >
-      <span
-        className={cn(
-          "grid size-8 shrink-0 place-items-center rounded-lg border bg-background/40 text-muted-foreground",
-        )}
-      >
-        <Icon className="size-4" />
-      </span>
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <h3 className="truncate text-sm font-semibold leading-tight tracking-tight">
-            {title}
-          </h3>
-          <StatusDot kind={status} className="shrink-0" />
-          <span className="sr-only">Status: {STATUS_LABEL[status]}</span>
-        </div>
-        <p className="mt-0.5 truncate text-xs text-muted-foreground">
-          {description}
-        </p>
-      </div>
-      {action && <div className="shrink-0">{action}</div>}
-    </div>
-  );
-}
-
-function IntegrationShell({
-  icon: Icon,
-  title,
-  description,
-  status,
-  titleAccessory,
-  children,
-  actions,
-}: {
-  icon: ComponentType<{ className?: string }>;
-  title: string;
-  description: string;
-  status: StatusKind;
-  titleAccessory?: ReactNode;
-  children?: ReactNode;
-  actions?: ReactNode;
-}) {
-  return (
-    <section
-      className={cn(
-        "relative flex flex-col overflow-hidden rounded-xl border bg-card/60 backdrop-blur-[1px] transition-colors",
-        "hover:border-border/80",
-        status === "connected" && "border-primary/20",
-      )}
-    >
-      {status === "connected" && (
-        <span
-          aria-hidden
-          className="pointer-events-none absolute left-0 top-4 bottom-4 w-px bg-gradient-to-b from-transparent via-primary to-transparent opacity-70"
-        />
-      )}
-
-      <header className="flex items-start gap-3 p-4 pb-3">
-        <span
-          className={cn(
-            "grid size-9 shrink-0 place-items-center rounded-lg border bg-background/40",
-            status === "connected" && "border-primary/30 text-primary",
-            status !== "connected" && "text-muted-foreground",
-          )}
-        >
-          <Icon className="size-4" />
-        </span>
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <h3 className="truncate text-sm font-semibold leading-tight tracking-tight">
-              {title}
-            </h3>
-            {titleAccessory}
-            {status === "connected" && (
-              <span className="ml-auto flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.08em] text-primary">
-                <StatusDot kind="connected" />
-                Live
-              </span>
-            )}
-          </div>
-          <p className="mt-0.5 truncate text-xs leading-snug text-muted-foreground">
-            {description}
-          </p>
-        </div>
-      </header>
-
-      {children != null && (
-        <div className="flex-1 space-y-3 px-4 pb-3 text-sm">{children}</div>
-      )}
-
-      {actions && (
-        <footer className="flex flex-wrap items-center justify-end gap-2 border-t border-border/50 bg-muted/20 px-4 py-2.5">
-          {actions}
-        </footer>
-      )}
-    </section>
-  );
-}
-
-function DetailRow({
-  label,
-  value,
-  mono,
-  truncate,
-}: {
-  label: string;
-  value: ReactNode;
-  mono?: boolean;
-  truncate?: boolean;
-}) {
-  return (
-    <div className="flex items-baseline justify-between gap-3 py-1 text-xs">
-      <span className="shrink-0 text-muted-foreground">{label}</span>
-      <span
-        className={cn(
-          "min-w-0 text-right",
-          mono && "font-mono text-[11px]",
-          truncate && "truncate",
-          !mono && "font-medium",
-        )}
-      >
-        {value}
-      </span>
-    </div>
-  );
-}
-
-function DetailList({ children }: { children: ReactNode }) {
-  return (
-    <div className="rounded-lg border bg-muted/20 px-3 py-1.5 divide-y divide-border/50">
-      {children}
-    </div>
-  );
-}
-
-function InlineError({ children }: { children: ReactNode }) {
-  if (!children) return null;
-  return (
-    <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
-      {children}
-    </div>
-  );
-}
-
-function SectionHeading({
-  title,
-  description,
-}: {
-  title: string;
-  description: string;
-}) {
-  return (
-    <div className="mb-3">
-      <h2 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-        {title}
-      </h2>
-      <p className="mt-0.5 text-xs text-muted-foreground/80">{description}</p>
-    </div>
-  );
-}
 
 // ── Main Page ─────────────────────────────────────────────────────
 
@@ -564,13 +357,13 @@ export default function SCIMPage() {
                   const rowHasError =
                     rowError?.kind === "connection" && rowError.id === conn.id;
                   return (
-                    <IntegrationShell
+                    <Shell
                       key={conn.id}
                       icon={KeyRound}
                       title={conn.providerId}
                       description="Bearer token issued via the SCIM token API"
                       status="connected"
-                      titleAccessory={
+                      titleBadge={
                         <Badge variant="secondary" className="shrink-0 font-mono text-[10px] uppercase">
                           SCIM
                         </Badge>
@@ -610,7 +403,7 @@ export default function SCIMPage() {
                           Revoke failed — {rowError.message}
                         </InlineError>
                       )}
-                    </IntegrationShell>
+                    </Shell>
                   );
                 })}
 
@@ -646,13 +439,13 @@ export default function SCIMPage() {
                   const rowHasError =
                     rowError?.kind === "mapping" && rowError.id === mapping.id;
                   return (
-                    <IntegrationShell
+                    <Shell
                       key={mapping.id}
                       icon={ArrowRightLeft}
                       title={mapping.scimGroupName}
                       description={`→ ${mapping.roleName}`}
                       status="connected"
-                      titleAccessory={
+                      titleBadge={
                         <Badge variant="secondary" className="shrink-0 text-[10px]">
                           {mapping.roleName}
                         </Badge>
@@ -680,7 +473,7 @@ export default function SCIMPage() {
                           Remove failed — {rowError.message}
                         </InlineError>
                       )}
-                    </IntegrationShell>
+                    </Shell>
                   );
                 })}
 


### PR DESCRIPTION
## Summary

- Migrate `packages/web/src/app/admin/scim/page.tsx` off the inline copy of `StatusDot` / `IntegrationShell` / `CompactRow` / `DetailList` / `DetailRow` / `InlineError` / `SectionHeading` / `StatusKind` / `STATUS_LABEL` to the shared module at `@/ui/components/admin/compact`.
- Rename `IntegrationShell` to `Shell` and `titleAccessory` to `titleBadge` to match the module API.
- Keep SCIM-specific logic untouched: `rowError` state + per-row `InlineError` pinning, `syncStatusKind` derivation with 24h stale threshold, `syncDivergence` + `AlertTriangle` warning, `mutationError` → `rowError` sync effect.
- Net delta: **-207 lines** (17 inserted, 224 deleted).

Local `STATUS_LABEL` was dropped because `CompactRow` is only invoked here with `status="disconnected"` — the module's default "Not connected" label fits the SCIM token and mapping CTA rows. `StatusDot` is still re-imported explicitly for the custom sync badge pill (amber "Stale" / "Running" / destructive "Error"). `useDisclosure` is not applicable (no expand/collapse flow on this page).

Part of #1551.

## Test plan

- [ ] Visit `/admin/scim` — Sync summary, Connections list, and Group mappings list render with the shared primitives.
- [ ] Click **Add mapping** — dialog opens, submitting an IdP group + role name creates a new mapping row.
- [ ] Click **Remove** on a mapping row — confirm dialog, on success the mapping disappears; on error the inline `Remove failed — …` pins under the specific row (not the top banner).
- [ ] Click **Revoke** on a SCIM connection row — same flow as above, `Revoke failed — …` inline error pins to the row.
- [ ] With `lastSyncAt` older than 24h and no `lastSyncStatus` — last-sync pill renders amber "Stale" with the transitioning dot.
- [ ] With `lastSyncStatus === "error"` — pill renders destructive "Error" and the InlineError block under the DetailList shows the backend-provided error message (or "no details provided." when empty).
- [ ] With `syncStatus.connections !== connections.length` — amber `AlertTriangle` divergence warning renders beneath the DetailList.
- [ ] `bun x eslint packages/web/src/app/admin/scim/page.tsx` — clean.