### PR TITLE
refactor(web/admin/actions): reason-on-deny + payload rendering + bucket-1 polish

### DIFF
--- a/packages/web/src/app/admin/actions/deny-dialog.tsx
+++ b/packages/web/src/app/admin/actions/deny-dialog.tsx
@@ -16,30 +16,15 @@ import { Loader2, X } from "lucide-react";
 import type { ActionLogEntry } from "@/ui/lib/types";
 import { ACTION_TYPE_LABELS } from "./labels";
 
-/* ────────────────────────────────────────────────────────────────────────
- *  DenyActionDialog
- *
- *  Captures an optional reason at deny time. Used for both single-row
- *  deny and bulk deny so audit history records *why* an action was
- *  rejected — replacing the legacy hardcoded "Denied by admin" string.
- *
- *  Reason is optional (low-friction triage), but the dialog shape forces
- *  a deliberate moment for a consequential action and the empty-state
- *  hint warns operators that audit history will reflect the absence.
- * ──────────────────────────────────────────────────────────────────────── */
-
 interface DenyActionDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /** Single-row deny target. Mutually exclusive with `bulkCount`. */
+  /** Mutually exclusive with `bulkCount`. */
   action?: ActionLogEntry | null;
-  /** Bulk deny count. Mutually exclusive with `action`. */
+  /** Mutually exclusive with `action`. */
   bulkCount?: number;
-  /** Fired with the reason (or empty string) when the user confirms. */
   onConfirm: (reason: string) => Promise<void> | void;
-  /** Disables the confirm button while the parent fires the mutation. */
   loading?: boolean;
-  /** Inline error to surface (server message, etc). */
   error?: string | null;
 }
 
@@ -55,43 +40,46 @@ export function DenyActionDialog({
   const [reason, setReason] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
-  // Reset reason when the dialog closes so the next open starts clean.
-  // Reset *after* close, not on open, so a re-fired Confirm during a
-  // network hiccup keeps the operator's text.
   useEffect(() => {
     if (!open) setReason("");
-  }, [open]);
-
-  // Focus the textarea on open so the keyboard-driven flow is one step:
-  // type reason (or skip) → Enter / Cmd+Enter to confirm.
-  useEffect(() => {
-    if (open) {
-      // Defer to next tick — Dialog's open animation can intercept focus.
-      const t = setTimeout(() => textareaRef.current?.focus(), 50);
-      return () => clearTimeout(t);
-    }
   }, [open]);
 
   const isBulk = bulkCount !== undefined && bulkCount > 0;
   const title = isBulk ? `Deny ${bulkCount} action${bulkCount === 1 ? "" : "s"}` : "Deny action";
 
   async function handleConfirm() {
-    await onConfirm(reason.trim());
+    try {
+      await onConfirm(reason.trim());
+    } catch (err) {
+      console.error("DenyActionDialog: onConfirm threw", err);
+    }
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    // Cmd+Enter / Ctrl+Enter submits — matches the comment-textarea
-    // convention used elsewhere in the admin console (chat composer,
-    // approval comment box, etc.).
     if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
       e.preventDefault();
-      if (!loading) handleConfirm();
+      if (!loading) void handleConfirm();
     }
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md">
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        // Block close while in flight — prevents the cancel-doesn't-cancel
+        // race where the operator believes they aborted but the request still
+        // resolves server-side.
+        if (!next && loading) return;
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent
+        className="max-w-md"
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          textareaRef.current?.focus();
+        }}
+      >
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>

--- a/packages/web/src/app/admin/actions/deny-dialog.tsx
+++ b/packages/web/src/app/admin/actions/deny-dialog.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Loader2, X } from "lucide-react";
+import type { ActionLogEntry } from "@/ui/lib/types";
+import { ACTION_TYPE_LABELS } from "./labels";
+
+/* ────────────────────────────────────────────────────────────────────────
+ *  DenyActionDialog
+ *
+ *  Captures an optional reason at deny time. Used for both single-row
+ *  deny and bulk deny so audit history records *why* an action was
+ *  rejected — replacing the legacy hardcoded "Denied by admin" string.
+ *
+ *  Reason is optional (low-friction triage), but the dialog shape forces
+ *  a deliberate moment for a consequential action and the empty-state
+ *  hint warns operators that audit history will reflect the absence.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+interface DenyActionDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Single-row deny target. Mutually exclusive with `bulkCount`. */
+  action?: ActionLogEntry | null;
+  /** Bulk deny count. Mutually exclusive with `action`. */
+  bulkCount?: number;
+  /** Fired with the reason (or empty string) when the user confirms. */
+  onConfirm: (reason: string) => Promise<void> | void;
+  /** Disables the confirm button while the parent fires the mutation. */
+  loading?: boolean;
+  /** Inline error to surface (server message, etc). */
+  error?: string | null;
+}
+
+export function DenyActionDialog({
+  open,
+  onOpenChange,
+  action,
+  bulkCount,
+  onConfirm,
+  loading = false,
+  error,
+}: DenyActionDialogProps) {
+  const [reason, setReason] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // Reset reason when the dialog closes so the next open starts clean.
+  // Reset *after* close, not on open, so a re-fired Confirm during a
+  // network hiccup keeps the operator's text.
+  useEffect(() => {
+    if (!open) setReason("");
+  }, [open]);
+
+  // Focus the textarea on open so the keyboard-driven flow is one step:
+  // type reason (or skip) → Enter / Cmd+Enter to confirm.
+  useEffect(() => {
+    if (open) {
+      // Defer to next tick — Dialog's open animation can intercept focus.
+      const t = setTimeout(() => textareaRef.current?.focus(), 50);
+      return () => clearTimeout(t);
+    }
+  }, [open]);
+
+  const isBulk = bulkCount !== undefined && bulkCount > 0;
+  const title = isBulk ? `Deny ${bulkCount} action${bulkCount === 1 ? "" : "s"}` : "Deny action";
+
+  async function handleConfirm() {
+    await onConfirm(reason.trim());
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    // Cmd+Enter / Ctrl+Enter submits — matches the comment-textarea
+    // convention used elsewhere in the admin console (chat composer,
+    // approval comment box, etc.).
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      if (!loading) handleConfirm();
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
+            Recorded in the audit log alongside your account. Reason is optional but recommended for traceability.
+          </DialogDescription>
+        </DialogHeader>
+
+        {action && !isBulk && (
+          <div className="rounded-md border bg-muted/40 px-3 py-2 text-xs">
+            <div className="flex items-center gap-1.5">
+              <span className="rounded border bg-background px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+                {ACTION_TYPE_LABELS[action.action_type] ?? action.action_type}
+              </span>
+              <span className="truncate font-mono text-muted-foreground">{action.target}</span>
+            </div>
+            <p className="mt-1.5 line-clamp-2 text-muted-foreground/80">{action.summary}</p>
+          </div>
+        )}
+
+        <div className="space-y-1.5">
+          <Label htmlFor="deny-reason" className="text-xs">
+            Reason (optional)
+          </Label>
+          <Textarea
+            ref={textareaRef}
+            id="deny-reason"
+            placeholder="e.g., Action conflicts with security policy"
+            className="min-h-20 text-sm"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            onKeyDown={handleKeyDown}
+            disabled={loading}
+          />
+          {!reason.trim() && (
+            <p className="text-[11px] text-muted-foreground/70">
+              No reason will be recorded. Audit history will show only the denier and timestamp.
+            </p>
+          )}
+        </div>
+
+        {error && (
+          <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+            {error}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={loading}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={handleConfirm} disabled={loading}>
+            {loading ? (
+              <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+            ) : (
+              <X className="mr-1.5 size-3.5" />
+            )}
+            {isBulk ? `Deny ${bulkCount}` : "Deny"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/web/src/app/admin/actions/labels.tsx
+++ b/packages/web/src/app/admin/actions/labels.tsx
@@ -7,17 +7,6 @@ import {
   type LucideIcon,
 } from "lucide-react";
 
-/* ────────────────────────────────────────────────────────────────────────
- *  Action type metadata
- *
- *  `action_type` is a free-form string on the wire — the agent emits the
- *  values defined in its tool registry. The UI side keeps a mapping for
- *  the well-known kinds so the badges read as English ("SQL Write")
- *  rather than enum (`sql_write`). Unknown types fall back to the raw
- *  string + a generic Zap icon so a new tool added in `packages/api`
- *  remains visible without a UI roundtrip.
- * ──────────────────────────────────────────────────────────────────────── */
-
 export const ACTION_TYPE_ICONS: Record<string, LucideIcon> = {
   sql_write: Database,
   sql: Database,

--- a/packages/web/src/app/admin/actions/labels.tsx
+++ b/packages/web/src/app/admin/actions/labels.tsx
@@ -1,0 +1,49 @@
+import {
+  Database,
+  Globe,
+  FilePenLine,
+  Terminal,
+  Zap,
+  type LucideIcon,
+} from "lucide-react";
+
+/* ────────────────────────────────────────────────────────────────────────
+ *  Action type metadata
+ *
+ *  `action_type` is a free-form string on the wire — the agent emits the
+ *  values defined in its tool registry. The UI side keeps a mapping for
+ *  the well-known kinds so the badges read as English ("SQL Write")
+ *  rather than enum (`sql_write`). Unknown types fall back to the raw
+ *  string + a generic Zap icon so a new tool added in `packages/api`
+ *  remains visible without a UI roundtrip.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export const ACTION_TYPE_ICONS: Record<string, LucideIcon> = {
+  sql_write: Database,
+  sql: Database,
+  api_call: Globe,
+  api: Globe,
+  file_write: FilePenLine,
+  file: FilePenLine,
+  shell: Terminal,
+  command: Terminal,
+};
+
+export const ACTION_TYPE_LABELS: Record<string, string> = {
+  sql_write: "SQL Write",
+  sql: "SQL",
+  api_call: "API Call",
+  api: "API",
+  file_write: "File Write",
+  file: "File",
+  shell: "Shell",
+  command: "Command",
+};
+
+export function actionTypeIcon(type: string): LucideIcon {
+  return ACTION_TYPE_ICONS[type.toLowerCase()] ?? Zap;
+}
+
+export function actionTypeLabel(type: string): string {
+  return ACTION_TYPE_LABELS[type.toLowerCase()] ?? type;
+}

--- a/packages/web/src/app/admin/actions/page.tsx
+++ b/packages/web/src/app/admin/actions/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment, useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 import { useQueryStates } from "nuqs";
 import { actionsSearchParams } from "./search-params";
 import { actionTypeIcon, actionTypeLabel } from "./labels";
@@ -29,6 +29,7 @@ import type { ActionLogEntry } from "@/ui/lib/types";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { EmptyState } from "@/ui/components/admin/empty-state";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { extractFetchError, type FetchError } from "@/ui/lib/fetch-error";
 import {
   Zap,
   Check,
@@ -39,8 +40,8 @@ import {
   XCircle,
   Inbox,
   Undo2,
+  AlertTriangle,
 } from "lucide-react";
-import type { FetchError } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 
@@ -108,21 +109,18 @@ const EMPTY_MESSAGES: Record<StatusFilter, string> = {
   all: "No actions recorded yet.",
 };
 
-/* ────────────────────────────────────────────────────────────────────────
- *  PayloadView — branches on action_type to render structured payload
- *  fields when the shape is known. Falls back to JSON for unknown
- *  shapes so a new tool's payload is never silently hidden.
- * ──────────────────────────────────────────────────────────────────────── */
-
 function PayloadView({ type, payload }: { type: string; payload: Record<string, unknown> }) {
   const t = type.toLowerCase();
 
-  if ((t === "sql_write" || t === "sql") && typeof payload.sql === "string") {
-    return (
-      <pre className="overflow-auto rounded border bg-muted/60 p-2 font-mono text-xs leading-relaxed">
-        {payload.sql}
-      </pre>
-    );
+  if (t === "sql_write" || t === "sql") {
+    if (typeof payload.sql === "string") {
+      return (
+        <pre className="overflow-auto rounded border bg-muted/60 p-2 font-mono text-xs leading-relaxed">
+          {payload.sql}
+        </pre>
+      );
+    }
+    console.warn(`PayloadView: ${type} payload missing string .sql`, payload);
   }
 
   if (t === "api_call" || t === "api") {
@@ -148,27 +146,46 @@ function PayloadView({ type, payload }: { type: string; payload: Record<string, 
         </div>
       );
     }
+    console.warn(`PayloadView: ${type} payload missing method/url`, payload);
   }
 
-  if ((t === "file_write" || t === "file") && typeof payload.path === "string") {
-    return (
-      <div className="space-y-1.5">
-        <div className="rounded border bg-muted/60 px-2 py-1.5 font-mono text-xs">
-          {payload.path}
+  if (t === "file_write" || t === "file") {
+    if (typeof payload.path === "string") {
+      return (
+        <div className="space-y-1.5">
+          <div className="rounded border bg-muted/60 px-2 py-1.5 font-mono text-xs">
+            {payload.path}
+          </div>
+          {typeof payload.content === "string" && (
+            <pre className="overflow-auto rounded border bg-muted/40 p-2 font-mono text-xs">
+              {payload.content}
+            </pre>
+          )}
         </div>
-        {typeof payload.content === "string" && (
-          <pre className="overflow-auto rounded border bg-muted/40 p-2 font-mono text-xs">
-            {payload.content}
-          </pre>
-        )}
-      </div>
-    );
+      );
+    }
+    console.warn(`PayloadView: ${type} payload missing string .path`, payload);
   }
 
+  // Fallback so payloads from new tools surface unformatted instead of disappearing.
   return (
     <pre className="overflow-auto rounded border bg-muted/40 p-2 text-xs">
       {JSON.stringify(payload, null, 2)}
     </pre>
+  );
+}
+
+function WarningBanner({ message, onDismiss }: { message: string; onDismiss: () => void }) {
+  return (
+    <div role="status" className="flex items-start justify-between gap-4 rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-3">
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" />
+        <p className="text-sm text-amber-800 dark:text-amber-300">{message}</p>
+      </div>
+      <Button variant="outline" size="sm" onClick={onDismiss} className="shrink-0">
+        Dismiss
+      </Button>
+    </div>
   );
 }
 
@@ -179,21 +196,26 @@ export default function ActionsPage() {
   const [actions, setActions] = useState<ActionLogEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<FetchError | null>(null);
-  // Page-level mutation error — funnels approve/deny/rollback failures into
-  // a single banner instead of stacking up to four. Resets on next mutation.
+
+  // Page-level error covers approve/rollback failures + bulk failure summaries.
+  // Single-row deny errors live on denyMutation.error (rendered in the dialog).
+  // Bulk-deny errors live in bulkError (rendered in the dialog).
   const [mutationError, setMutationError] = useState<string | null>(null);
+  // Warnings are explicit-dismiss only — never auto-cleared by the next click.
+  // Used for the rollback `{warning}` server contract: 200 OK but the side-
+  // effect may not have actually been undone (see api/routes/actions.ts).
+  const [mutationWarning, setMutationWarning] = useState<string | null>(null);
+  const [bulkError, setBulkError] = useState<string | null>(null);
+
   const [{ status: statusFilter, expanded: expandedId }, setParams] = useQueryStates(actionsSearchParams);
 
   const [refetchKey, setRefetchKey] = useState(0);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [bulkAction, setBulkAction] = useState<"approve" | "deny" | null>(null);
 
-  // Deny dialog state — single-row deny opens with `denyTarget` set;
-  // bulk deny opens with `bulkDenyOpen` true.
   const [denyTarget, setDenyTarget] = useState<ActionLogEntry | null>(null);
   const [bulkDenyOpen, setBulkDenyOpen] = useState(false);
 
-  // Mutation hooks for per-item actions
   const approveMutation = useAdminMutation({
     method: "POST",
     invalidates: () => setRefetchKey((k) => k + 1),
@@ -209,7 +231,6 @@ export default function ActionsPage() {
 
   const bulkInProgress = bulkAction !== null;
 
-  // Clear selection when filter changes
   useEffect(() => {
     setSelectedIds(new Set());
   }, [statusFilter]);
@@ -225,12 +246,7 @@ export default function ActionsPage() {
         const res = await fetch(`${apiUrl}/api/v1/actions?${params}`, { credentials });
         if (cancelled) return;
         if (!res.ok) {
-          let serverMessage = `HTTP ${res.status}`;
-          try {
-            const body = await res.json();
-            if (body?.message) serverMessage = body.message;
-          } catch { /* intentionally ignored: response may not be JSON */ }
-          setError({ message: serverMessage, status: res.status });
+          setError(await extractFetchError(res));
           return;
         }
         const data = await res.json();
@@ -248,7 +264,7 @@ export default function ActionsPage() {
     return () => { cancelled = true; };
   }, [apiUrl, statusFilter, refetchKey, credentials]);
 
-  const pendingActions = useMemo(() => actions.filter((a) => a.status === "pending"), [actions]);
+  const pendingActions = actions.filter((a) => a.status === "pending");
   const allSelectableSelected = pendingActions.length > 0 && pendingActions.every((a) => selectedIds.has(a.id));
   const someSelected = selectedIds.size > 0;
 
@@ -269,6 +285,21 @@ export default function ActionsPage() {
     }
   }
 
+  /** Single bulk fetch; throws on non-2xx with the same shape useAdminMutation surfaces. */
+  async function bulkRequest(id: string, endpoint: "approve" | "deny", body: Record<string, unknown>) {
+    const res = await fetch(`${apiUrl}/api/v1/actions/${id}/${endpoint}`, {
+      credentials,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const fe = await extractFetchError(res);
+      const msg = fe.requestId ? `${fe.message} (Request ID: ${fe.requestId})` : fe.message;
+      throw new Error(msg);
+    }
+  }
+
   async function handleApprove(id: string) {
     setMutationError(null);
     const result = await approveMutation.mutate({
@@ -281,7 +312,6 @@ export default function ActionsPage() {
 
   async function confirmSingleDeny(reason: string) {
     if (!denyTarget) return;
-    setMutationError(null);
     const id = denyTarget.id;
     const body: Record<string, unknown> = {};
     if (reason) body.reason = reason;
@@ -290,11 +320,8 @@ export default function ActionsPage() {
       body,
       itemId: id,
     });
-    if (!result.ok) {
-      setMutationError(result.error);
-      return;
-    }
-    setDenyTarget(null);
+    if (result.ok) setDenyTarget(null);
+    // On failure, denyMutation.error is set automatically — dialog renders it.
   }
 
   async function handleRollback(id: string) {
@@ -304,12 +331,12 @@ export default function ActionsPage() {
       body: {},
       itemId: id,
       onSuccess: (data) => {
-        // Server returns { warning } when rollback succeeded but with caveats
-        // (e.g. external API didn't expose a true undo). Surface as a warning
-        // banner so the operator can investigate.
+        // Server returns { warning } on 200 when the rollback persisted but the
+        // side-effect may not have actually reversed (e.g. external API has no
+        // true undo). Surface to a dismissible warning, not an error.
         const body = data as Record<string, unknown> | undefined;
         if (body?.warning && typeof body.warning === "string") {
-          setMutationError(body.warning);
+          setMutationWarning(body.warning);
         }
       },
     });
@@ -323,27 +350,9 @@ export default function ActionsPage() {
     const ids = [...selectedIds];
     try {
       const results = await Promise.allSettled(
-        ids.map((id) =>
-          fetch(`${apiUrl}/api/v1/actions/${id}/approve`, {
-            credentials,
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: "{}",
-          }).then(async (res) => {
-            if (!res.ok) {
-              let serverMessage = `HTTP ${res.status}`;
-              try {
-                const errBody = await res.json();
-                if (errBody?.message) serverMessage = errBody.message;
-              } catch { /* intentionally ignored: response may not be JSON */ }
-              throw new Error(serverMessage);
-            }
-          }),
-        ),
+        ids.map((id) => bulkRequest(id, "approve", {})),
       );
       handleBulkResult(results, ids, "approvals");
-    } catch (err) {
-      setMutationError(err instanceof Error ? err.message : `Bulk approve failed`);
     } finally {
       setBulkAction(null);
     }
@@ -352,72 +361,47 @@ export default function ActionsPage() {
   async function confirmBulkDeny(reason: string) {
     if (selectedIds.size === 0) return;
     setBulkAction("deny");
-    setMutationError(null);
+    setBulkError(null);
     const ids = [...selectedIds];
     const body: Record<string, unknown> = {};
     if (reason) body.reason = reason;
-    const bodyJson = JSON.stringify(body);
     try {
       const results = await Promise.allSettled(
-        ids.map((id) =>
-          fetch(`${apiUrl}/api/v1/actions/${id}/deny`, {
-            credentials,
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: bodyJson,
-          }).then(async (res) => {
-            if (!res.ok) {
-              let serverMessage = `HTTP ${res.status}`;
-              try {
-                const errBody = await res.json();
-                if (errBody?.message) serverMessage = errBody.message;
-              } catch { /* intentionally ignored: response may not be JSON */ }
-              throw new Error(serverMessage);
-            }
-          }),
-        ),
+        ids.map((id) => bulkRequest(id, "deny", body)),
       );
-      handleBulkResult(results, ids, "denials");
-      // Close the dialog only on full success; partial failure leaves the
-      // selection narrowed to failed IDs so operator can see what's left.
       const failedCount = results.filter((r) => r.status === "rejected").length;
-      if (failedCount === 0) setBulkDenyOpen(false);
-    } catch (err) {
-      setMutationError(err instanceof Error ? err.message : `Bulk deny failed`);
+      if (failedCount === 0) {
+        setSelectedIds(new Set());
+        setBulkDenyOpen(false);
+        setRefetchKey((k) => k + 1);
+        return;
+      }
+      // Partial / total failure: narrow selection to failed IDs and surface
+      // the summary inside the dialog so a retry click sees the *current*
+      // attempt's stats, not the prior one (bulkError clears at fn entry).
+      const summary = bulkFailureSummary(results, ids, "denials");
+      setBulkError(summary);
+      setSelectedIds(new Set(failedIdsFrom(results, ids)));
+      setRefetchKey((k) => k + 1);
     } finally {
       setBulkAction(null);
     }
   }
 
-  /** Shared partial-failure handling for bulk approve / deny. */
+  /** Page-level summary for bulk approve (no dialog to show it in). */
   function handleBulkResult(
     results: PromiseSettledResult<unknown>[],
     ids: string[],
     noun: string,
   ) {
-    const failedIds = new Set(
-      results
-        .map((r, i) => (r.status === "rejected" ? ids[i] : null))
-        .filter((id): id is string => id !== null),
-    );
-    if (failedIds.size > 0) {
-      const reasons = [...new Set(
-        results
-          .filter((r): r is PromiseRejectedResult => r.status === "rejected")
-          .map((r) => (r.reason instanceof Error ? r.reason.message : "Unknown error")),
-      )];
-      setMutationError(`${failedIds.size} of ${ids.length} ${noun} failed: ${reasons.join(", ")}`);
-      setSelectedIds(failedIds);
+    const failedIds = failedIdsFrom(results, ids);
+    if (failedIds.length > 0) {
+      setMutationError(bulkFailureSummary(results, ids, noun));
+      setSelectedIds(new Set(failedIds));
     } else {
       setSelectedIds(new Set());
     }
     setRefetchKey((k) => k + 1);
-  }
-
-  // Single banner — fetch error is rendered by AdminContentWrapper, this
-  // covers all mutation paths (approve/deny/rollback + bulk + warnings).
-  function clearMutationError() {
-    setMutationError(null);
   }
 
   return (
@@ -476,7 +460,8 @@ export default function ActionsPage() {
 
         <ErrorBoundary>
         <div className="space-y-6">
-          {mutationError && <ErrorBanner message={mutationError} onRetry={clearMutationError} />}
+          {mutationError && <ErrorBanner message={mutationError} onRetry={() => setMutationError(null)} />}
+          {mutationWarning && <WarningBanner message={mutationWarning} onDismiss={() => setMutationWarning(null)} />}
 
           <AdminContentWrapper
             loading={loading}
@@ -741,22 +726,57 @@ export default function ActionsPage() {
 
         <DenyActionDialog
           open={!!denyTarget}
-          onOpenChange={(open) => { if (!open) setDenyTarget(null); }}
+          onOpenChange={(open) => {
+            if (!open) {
+              setDenyTarget(null);
+              denyMutation.clearError();
+            }
+          }}
           action={denyTarget}
           onConfirm={confirmSingleDeny}
           loading={!!denyTarget && denyMutation.isMutating(denyTarget.id)}
-          error={mutationError}
+          error={denyMutation.error}
         />
 
         <DenyActionDialog
           open={bulkDenyOpen}
-          onOpenChange={(open) => { if (!open) setBulkDenyOpen(false); }}
+          onOpenChange={(open) => {
+            if (!open) {
+              setBulkDenyOpen(false);
+              setBulkError(null);
+            }
+          }}
           bulkCount={selectedIds.size}
           onConfirm={confirmBulkDeny}
           loading={bulkAction === "deny"}
-          error={mutationError}
+          error={bulkError}
         />
       </div>
     </TooltipProvider>
   );
+}
+
+/** Indices of `results` that rejected, mapped back to their input ids. */
+function failedIdsFrom(results: PromiseSettledResult<unknown>[], ids: string[]): string[] {
+  return results.flatMap((r, i) => (r.status === "rejected" ? [ids[i]] : []));
+}
+
+/** "3 of 5 denials failed: 2× Forbidden; 1× Internal error" — counts per reason. */
+function bulkFailureSummary(
+  results: PromiseSettledResult<unknown>[],
+  ids: string[],
+  noun: string,
+): string {
+  const reasonCounts = new Map<string, number>();
+  for (const r of results) {
+    if (r.status === "rejected") {
+      const msg = r.reason instanceof Error ? r.reason.message : "Unknown error";
+      reasonCounts.set(msg, (reasonCounts.get(msg) ?? 0) + 1);
+    }
+  }
+  const failedCount = [...reasonCounts.values()].reduce((a, b) => a + b, 0);
+  const summary = [...reasonCounts.entries()]
+    .map(([msg, n]) => `${n}× ${msg}`)
+    .join("; ");
+  return `${failedCount} of ${ids.length} ${noun} failed: ${summary}`;
 }

--- a/packages/web/src/app/admin/actions/page.tsx
+++ b/packages/web/src/app/admin/actions/page.tsx
@@ -536,7 +536,7 @@ export default function ActionsPage() {
                             {actionTypeLabel(action.action_type)}
                           </Badge>
                         </TableCell>
-                        <TableCell className="max-w-[220px] truncate font-mono text-xs">
+                        <TableCell className="max-w-55 truncate font-mono text-xs">
                           <Tooltip>
                             <TooltipTrigger asChild>
                               <span className="block truncate">{action.target}</span>

--- a/packages/web/src/app/admin/actions/page.tsx
+++ b/packages/web/src/app/admin/actions/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { Fragment, useEffect, useState, useTransition } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { useQueryStates } from "nuqs";
 import { actionsSearchParams } from "./search-params";
+import { actionTypeIcon, actionTypeLabel } from "./labels";
+import { DenyActionDialog } from "./deny-dialog";
 import { useAtlasConfig } from "@/ui/context";
 import {
   Table,
@@ -32,12 +34,6 @@ import {
   Check,
   X,
   Loader2,
-  ChevronDown,
-  ChevronRight,
-  Database,
-  Globe,
-  FilePenLine,
-  Terminal,
   MessageSquare,
   CheckCheck,
   XCircle,
@@ -58,17 +54,6 @@ const FILTER_OPTIONS: { value: StatusFilter; label: string }[] = [
   { value: "rolled_back", label: "Rolled Back" },
   { value: "all", label: "All" },
 ];
-
-const ACTION_TYPE_ICONS: Record<string, typeof Database> = {
-  sql_write: Database,
-  sql: Database,
-  api_call: Globe,
-  api: Globe,
-  file_write: FilePenLine,
-  file: FilePenLine,
-  shell: Terminal,
-  command: Terminal,
-};
 
 function mapStatus(status: ActionLogEntry["status"]): ActionDisplayStatus {
   return status === "pending" ? "pending_approval" : status;
@@ -110,7 +95,7 @@ function RelativeTimestamp({ iso, label }: { iso: string; label?: string }) {
 }
 
 function ActionTypeIcon({ type }: { type: string }) {
-  const Icon = ACTION_TYPE_ICONS[type.toLowerCase()] ?? Zap;
+  const Icon = actionTypeIcon(type);
   return <Icon className="size-3.5" />;
 }
 
@@ -123,6 +108,70 @@ const EMPTY_MESSAGES: Record<StatusFilter, string> = {
   all: "No actions recorded yet.",
 };
 
+/* ────────────────────────────────────────────────────────────────────────
+ *  PayloadView — branches on action_type to render structured payload
+ *  fields when the shape is known. Falls back to JSON for unknown
+ *  shapes so a new tool's payload is never silently hidden.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+function PayloadView({ type, payload }: { type: string; payload: Record<string, unknown> }) {
+  const t = type.toLowerCase();
+
+  if ((t === "sql_write" || t === "sql") && typeof payload.sql === "string") {
+    return (
+      <pre className="overflow-auto rounded border bg-muted/60 p-2 font-mono text-xs leading-relaxed">
+        {payload.sql}
+      </pre>
+    );
+  }
+
+  if (t === "api_call" || t === "api") {
+    const method = typeof payload.method === "string" ? payload.method : null;
+    const url = typeof payload.url === "string" ? payload.url : null;
+    if (method || url) {
+      const body = payload.body;
+      return (
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-2 rounded border bg-muted/60 px-2 py-1.5 font-mono text-xs">
+            {method && (
+              <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
+                {method}
+              </span>
+            )}
+            {url && <span className="truncate text-foreground">{url}</span>}
+          </div>
+          {body != null && (
+            <pre className="overflow-auto rounded border bg-muted/40 p-2 text-xs">
+              {typeof body === "string" ? body : JSON.stringify(body, null, 2)}
+            </pre>
+          )}
+        </div>
+      );
+    }
+  }
+
+  if ((t === "file_write" || t === "file") && typeof payload.path === "string") {
+    return (
+      <div className="space-y-1.5">
+        <div className="rounded border bg-muted/60 px-2 py-1.5 font-mono text-xs">
+          {payload.path}
+        </div>
+        {typeof payload.content === "string" && (
+          <pre className="overflow-auto rounded border bg-muted/40 p-2 font-mono text-xs">
+            {payload.content}
+          </pre>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <pre className="overflow-auto rounded border bg-muted/40 p-2 text-xs">
+      {JSON.stringify(payload, null, 2)}
+    </pre>
+  );
+}
+
 export default function ActionsPage() {
   const { apiUrl, isCrossOrigin } = useAtlasConfig();
   const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
@@ -130,13 +179,19 @@ export default function ActionsPage() {
   const [actions, setActions] = useState<ActionLogEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<FetchError | null>(null);
+  // Page-level mutation error — funnels approve/deny/rollback failures into
+  // a single banner instead of stacking up to four. Resets on next mutation.
   const [mutationError, setMutationError] = useState<string | null>(null);
   const [{ status: statusFilter, expanded: expandedId }, setParams] = useQueryStates(actionsSearchParams);
-  const [, startTransition] = useTransition();
 
   const [refetchKey, setRefetchKey] = useState(0);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [bulkAction, setBulkAction] = useState<"approve" | "deny" | null>(null);
+
+  // Deny dialog state — single-row deny opens with `denyTarget` set;
+  // bulk deny opens with `bulkDenyOpen` true.
+  const [denyTarget, setDenyTarget] = useState<ActionLogEntry | null>(null);
+  const [bulkDenyOpen, setBulkDenyOpen] = useState(false);
 
   // Mutation hooks for per-item actions
   const approveMutation = useAdminMutation({
@@ -193,7 +248,7 @@ export default function ActionsPage() {
     return () => { cancelled = true; };
   }, [apiUrl, statusFilter, refetchKey, credentials]);
 
-  const pendingActions = actions.filter((a) => a.status === "pending");
+  const pendingActions = useMemo(() => actions.filter((a) => a.status === "pending"), [actions]);
   const allSelectableSelected = pendingActions.length > 0 && pendingActions.every((a) => selectedIds.has(a.id));
   const someSelected = selectedIds.size > 0;
 
@@ -216,53 +271,64 @@ export default function ActionsPage() {
 
   async function handleApprove(id: string) {
     setMutationError(null);
-    await approveMutation.mutate({
+    const result = await approveMutation.mutate({
       path: `/api/v1/actions/${id}/approve`,
       body: {},
       itemId: id,
     });
+    if (!result.ok) setMutationError(result.error);
   }
 
-  async function handleDeny(id: string) {
+  async function confirmSingleDeny(reason: string) {
+    if (!denyTarget) return;
     setMutationError(null);
-    await denyMutation.mutate({
+    const id = denyTarget.id;
+    const body: Record<string, unknown> = {};
+    if (reason) body.reason = reason;
+    const result = await denyMutation.mutate({
       path: `/api/v1/actions/${id}/deny`,
-      body: { reason: "Denied by admin" },
+      body,
       itemId: id,
     });
+    if (!result.ok) {
+      setMutationError(result.error);
+      return;
+    }
+    setDenyTarget(null);
   }
 
   async function handleRollback(id: string) {
     setMutationError(null);
-    await rollbackMutation.mutate({
+    const result = await rollbackMutation.mutate({
       path: `/api/v1/actions/${id}/rollback`,
       body: {},
       itemId: id,
       onSuccess: (data) => {
+        // Server returns { warning } when rollback succeeded but with caveats
+        // (e.g. external API didn't expose a true undo). Surface as a warning
+        // banner so the operator can investigate.
         const body = data as Record<string, unknown> | undefined;
         if (body?.warning && typeof body.warning === "string") {
           setMutationError(body.warning);
         }
       },
     });
+    if (!result.ok) setMutationError(result.error);
   }
 
-  async function handleBulkAction(action: "approve" | "deny") {
+  async function handleBulkApprove() {
     if (selectedIds.size === 0) return;
-    setBulkAction(action);
+    setBulkAction("approve");
     setMutationError(null);
     const ids = [...selectedIds];
-    const endpoint = action === "approve" ? "approve" : "deny";
-    const body = action === "approve" ? {} : { reason: "Bulk denied by admin" };
-    const noun = action === "approve" ? "approvals" : "denials";
     try {
       const results = await Promise.allSettled(
         ids.map((id) =>
-          fetch(`${apiUrl}/api/v1/actions/${id}/${endpoint}`, {
+          fetch(`${apiUrl}/api/v1/actions/${id}/approve`, {
             credentials,
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(body),
+            body: "{}",
           }).then(async (res) => {
             if (!res.ok) {
               let serverMessage = `HTTP ${res.status}`;
@@ -275,28 +341,83 @@ export default function ActionsPage() {
           }),
         ),
       );
-      const failedIds = new Set(
-        results
-          .map((r, i) => (r.status === "rejected" ? ids[i] : null))
-          .filter((id): id is string => id !== null),
-      );
-      if (failedIds.size > 0) {
-        const reasons = [...new Set(
-          results
-            .filter((r): r is PromiseRejectedResult => r.status === "rejected")
-            .map((r) => (r.reason instanceof Error ? r.reason.message : "Unknown error")),
-        )];
-        setMutationError(`${failedIds.size} of ${ids.length} ${noun} failed: ${reasons.join(", ")}`);
-        setSelectedIds(failedIds);
-      } else {
-        setSelectedIds(new Set());
-      }
-      setRefetchKey((k) => k + 1);
+      handleBulkResult(results, ids, "approvals");
     } catch (err) {
-      setMutationError(err instanceof Error ? err.message : `Bulk ${action} failed`);
+      setMutationError(err instanceof Error ? err.message : `Bulk approve failed`);
     } finally {
       setBulkAction(null);
     }
+  }
+
+  async function confirmBulkDeny(reason: string) {
+    if (selectedIds.size === 0) return;
+    setBulkAction("deny");
+    setMutationError(null);
+    const ids = [...selectedIds];
+    const body: Record<string, unknown> = {};
+    if (reason) body.reason = reason;
+    const bodyJson = JSON.stringify(body);
+    try {
+      const results = await Promise.allSettled(
+        ids.map((id) =>
+          fetch(`${apiUrl}/api/v1/actions/${id}/deny`, {
+            credentials,
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: bodyJson,
+          }).then(async (res) => {
+            if (!res.ok) {
+              let serverMessage = `HTTP ${res.status}`;
+              try {
+                const errBody = await res.json();
+                if (errBody?.message) serverMessage = errBody.message;
+              } catch { /* intentionally ignored: response may not be JSON */ }
+              throw new Error(serverMessage);
+            }
+          }),
+        ),
+      );
+      handleBulkResult(results, ids, "denials");
+      // Close the dialog only on full success; partial failure leaves the
+      // selection narrowed to failed IDs so operator can see what's left.
+      const failedCount = results.filter((r) => r.status === "rejected").length;
+      if (failedCount === 0) setBulkDenyOpen(false);
+    } catch (err) {
+      setMutationError(err instanceof Error ? err.message : `Bulk deny failed`);
+    } finally {
+      setBulkAction(null);
+    }
+  }
+
+  /** Shared partial-failure handling for bulk approve / deny. */
+  function handleBulkResult(
+    results: PromiseSettledResult<unknown>[],
+    ids: string[],
+    noun: string,
+  ) {
+    const failedIds = new Set(
+      results
+        .map((r, i) => (r.status === "rejected" ? ids[i] : null))
+        .filter((id): id is string => id !== null),
+    );
+    if (failedIds.size > 0) {
+      const reasons = [...new Set(
+        results
+          .filter((r): r is PromiseRejectedResult => r.status === "rejected")
+          .map((r) => (r.reason instanceof Error ? r.reason.message : "Unknown error")),
+      )];
+      setMutationError(`${failedIds.size} of ${ids.length} ${noun} failed: ${reasons.join(", ")}`);
+      setSelectedIds(failedIds);
+    } else {
+      setSelectedIds(new Set());
+    }
+    setRefetchKey((k) => k + 1);
+  }
+
+  // Single banner — fetch error is rendered by AdminContentWrapper, this
+  // covers all mutation paths (approve/deny/rollback + bulk + warnings).
+  function clearMutationError() {
+    setMutationError(null);
   }
 
   return (
@@ -309,17 +430,13 @@ export default function ActionsPage() {
           </p>
         </div>
 
-        <div className="mb-4 flex items-center gap-2">
+        <div className="mb-4 flex flex-wrap items-center gap-2">
           {FILTER_OPTIONS.map((opt) => (
             <Button
               key={opt.value}
               size="sm"
               variant={statusFilter === opt.value ? "secondary" : "ghost"}
-              onClick={() => {
-                startTransition(() => {
-                  setParams({ status: opt.value, expanded: null });
-                });
-              }}
+              onClick={() => setParams({ status: opt.value, expanded: null })}
             >
               {opt.label}
             </Button>
@@ -335,7 +452,7 @@ export default function ActionsPage() {
                 size="sm"
                 variant="default"
                 disabled={bulkInProgress}
-                onClick={() => handleBulkAction("approve")}
+                onClick={handleBulkApprove}
               >
                 {bulkAction === "approve" ? (
                   <Loader2 className="mr-1 size-4 animate-spin" />
@@ -348,13 +465,9 @@ export default function ActionsPage() {
                 size="sm"
                 variant="destructive"
                 disabled={bulkInProgress}
-                onClick={() => handleBulkAction("deny")}
+                onClick={() => setBulkDenyOpen(true)}
               >
-                {bulkAction === "deny" ? (
-                  <Loader2 className="mr-1 size-4 animate-spin" />
-                ) : (
-                  <XCircle className="mr-1 size-4" />
-                )}
+                <XCircle className="mr-1 size-4" />
                 Deny selected
               </Button>
             </>
@@ -363,10 +476,7 @@ export default function ActionsPage() {
 
         <ErrorBoundary>
         <div className="space-y-6">
-          {mutationError && <ErrorBanner message={mutationError} onRetry={() => setMutationError(null)} />}
-          {approveMutation.error && <ErrorBanner message={approveMutation.error} onRetry={approveMutation.clearError} />}
-          {denyMutation.error && <ErrorBanner message={denyMutation.error} onRetry={denyMutation.clearError} />}
-          {rollbackMutation.error && <ErrorBanner message={rollbackMutation.error} onRetry={rollbackMutation.clearError} />}
+          {mutationError && <ErrorBanner message={mutationError} onRetry={clearMutationError} />}
 
           <AdminContentWrapper
             loading={loading}
@@ -401,7 +511,6 @@ export default function ActionsPage() {
                       />
                     )}
                   </TableHead>
-                  <TableHead className="w-8" />
                   <TableHead>Timestamp</TableHead>
                   <TableHead>Type</TableHead>
                   <TableHead>Target</TableHead>
@@ -433,25 +542,30 @@ export default function ActionsPage() {
                             />
                           )}
                         </TableCell>
-                        <TableCell>
-                          {isExpanded ? (
-                            <ChevronDown className="size-4 text-muted-foreground" />
-                          ) : (
-                            <ChevronRight className="size-4 text-muted-foreground" />
-                          )}
-                        </TableCell>
                         <TableCell className="whitespace-nowrap text-sm">
                           <RelativeTimestamp iso={action.requested_at} />
                         </TableCell>
                         <TableCell>
                           <Badge variant="outline" className="gap-1">
                             <ActionTypeIcon type={action.action_type} />
-                            {action.action_type}
+                            {actionTypeLabel(action.action_type)}
                           </Badge>
                         </TableCell>
-                        <TableCell className="text-sm">{action.target}</TableCell>
+                        <TableCell className="max-w-[220px] truncate font-mono text-xs">
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span className="block truncate">{action.target}</span>
+                            </TooltipTrigger>
+                            <TooltipContent>{action.target}</TooltipContent>
+                          </Tooltip>
+                        </TableCell>
                         <TableCell className="max-w-xs truncate text-sm">
-                          {action.summary}
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span className="block truncate">{action.summary}</span>
+                            </TooltipTrigger>
+                            <TooltipContent className="max-w-md">{action.summary}</TooltipContent>
+                          </Tooltip>
                         </TableCell>
                         <TableCell>
                           <ActionStatusBadge status={mapStatus(action.status)} />
@@ -462,30 +576,42 @@ export default function ActionsPage() {
                               className="flex justify-end gap-1"
                               onClick={(e) => e.stopPropagation()}
                             >
-                              <Button
-                                size="sm"
-                                variant="ghost"
-                                disabled={approveMutation.isMutating(action.id) || bulkInProgress}
-                                onClick={() => handleApprove(action.id)}
-                              >
-                                {approveMutation.isMutating(action.id) ? (
-                                  <Loader2 className="size-4 animate-spin" />
-                                ) : (
-                                  <Check className="size-4" />
-                                )}
-                              </Button>
-                              <Button
-                                size="sm"
-                                variant="ghost"
-                                disabled={denyMutation.isMutating(action.id) || bulkInProgress}
-                                onClick={() => handleDeny(action.id)}
-                              >
-                                {denyMutation.isMutating(action.id) ? (
-                                  <Loader2 className="size-4 animate-spin" />
-                                ) : (
-                                  <X className="size-4" />
-                                )}
-                              </Button>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <Button
+                                    size="sm"
+                                    variant="ghost"
+                                    disabled={approveMutation.isMutating(action.id) || bulkInProgress}
+                                    onClick={() => handleApprove(action.id)}
+                                    aria-label="Approve action"
+                                  >
+                                    {approveMutation.isMutating(action.id) ? (
+                                      <Loader2 className="size-4 animate-spin" />
+                                    ) : (
+                                      <Check className="size-4" />
+                                    )}
+                                  </Button>
+                                </TooltipTrigger>
+                                <TooltipContent>Approve</TooltipContent>
+                              </Tooltip>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <Button
+                                    size="sm"
+                                    variant="ghost"
+                                    disabled={denyMutation.isMutating(action.id) || bulkInProgress}
+                                    onClick={() => setDenyTarget(action)}
+                                    aria-label="Deny action"
+                                  >
+                                    {denyMutation.isMutating(action.id) ? (
+                                      <Loader2 className="size-4 animate-spin" />
+                                    ) : (
+                                      <X className="size-4" />
+                                    )}
+                                  </Button>
+                                </TooltipTrigger>
+                                <TooltipContent>Deny with reason</TooltipContent>
+                              </Tooltip>
                             </div>
                           )}
                           {(action.status === "executed" || action.status === "auto_approved") && action.rollback_info && (
@@ -500,6 +626,7 @@ export default function ActionsPage() {
                                     variant="ghost"
                                     disabled={rollbackMutation.isMutating(action.id)}
                                     onClick={() => handleRollback(action.id)}
+                                    aria-label="Rollback action"
                                   >
                                     {rollbackMutation.isMutating(action.id) ? (
                                       <Loader2 className="size-4 animate-spin" />
@@ -516,7 +643,7 @@ export default function ActionsPage() {
                       </TableRow>
                       {isExpanded && (
                         <TableRow>
-                          <TableCell colSpan={8} className="bg-muted/30 p-4">
+                          <TableCell colSpan={7} className="bg-muted/30 p-4">
                             <div className="space-y-3 text-sm">
                               <div>
                                 <span className="font-medium">Summary:</span>{" "}
@@ -524,9 +651,9 @@ export default function ActionsPage() {
                               </div>
                               <div>
                                 <span className="font-medium">Payload:</span>
-                                <pre className="mt-1 overflow-auto rounded bg-muted p-2 text-xs">
-                                  {JSON.stringify(action.payload, null, 2)}
-                                </pre>
+                                <div className="mt-1">
+                                  <PayloadView type={action.action_type} payload={action.payload} />
+                                </div>
                               </div>
                               <div className="flex flex-wrap gap-x-6 gap-y-1 text-muted-foreground">
                                 <RelativeTimestamp iso={action.requested_at} label="Requested" />
@@ -573,13 +700,9 @@ export default function ActionsPage() {
                                     size="sm"
                                     variant="destructive"
                                     disabled={denyMutation.isMutating(action.id) || bulkInProgress}
-                                    onClick={() => handleDeny(action.id)}
+                                    onClick={() => setDenyTarget(action)}
                                   >
-                                    {denyMutation.isMutating(action.id) ? (
-                                      <Loader2 className="mr-1 size-4 animate-spin" />
-                                    ) : (
-                                      <X className="mr-1 size-4" />
-                                    )}
+                                    <X className="mr-1 size-4" />
                                     Deny
                                   </Button>
                                 </div>
@@ -615,6 +738,24 @@ export default function ActionsPage() {
           </AdminContentWrapper>
         </div>
         </ErrorBoundary>
+
+        <DenyActionDialog
+          open={!!denyTarget}
+          onOpenChange={(open) => { if (!open) setDenyTarget(null); }}
+          action={denyTarget}
+          onConfirm={confirmSingleDeny}
+          loading={!!denyTarget && denyMutation.isMutating(denyTarget.id)}
+          error={mutationError}
+        />
+
+        <DenyActionDialog
+          open={bulkDenyOpen}
+          onOpenChange={(open) => { if (!open) setBulkDenyOpen(false); }}
+          bulkCount={selectedIds.size}
+          onConfirm={confirmBulkDeny}
+          loading={bulkAction === "deny"}
+          error={mutationError}
+        />
       </div>
     </TooltipProvider>
   );


### PR DESCRIPTION
First of three queue-page revamps for #1588 (admin console final-pass coverage). Validates the bucket-1 target shape (button-row filter, inline expand, RelativeTimestamp, reason-on-deny, single-banner errors) before primitives extract on the third adopter (per the #1551 rule).

## Why this one first

`/admin/actions` was already closest to ideal — defaults to `pending`, has bulk select with partial-failure preservation, relative timestamps with absolute tooltip, inline expand. Smallest delta to the target shape. Perfect to validate the pattern before porting it to `/admin/learned-patterns` (PR 2) and `/admin/approval` (PR 3).

## What changed

### Compliance — reason-on-deny (P0)
- New \`deny-dialog.tsx\` (\`DenyActionDialog\`) handles both single and bulk deny
- Captures an optional reason; dialog shows audit-history hint when blank
- Cmd/Ctrl+Enter submits; textarea autofocused on open
- Persists actual reason text to \`action_log.error\` instead of the legacy hardcoded \"Denied by admin\" / \"Bulk denied by admin\"

### Clarity — type labels
- New \`labels.tsx\` (\`ACTION_TYPE_LABELS\`, \`actionTypeLabel\`, \`actionTypeIcon\`)
- Badges now read \"SQL Write\" / \"API Call\" / \"File Write\" / \"Shell\" instead of \`sql_write\` / \`api_call\` / \`file_write\` / \`shell\`

### Inline expand — payload by type
- New \`PayloadView\` component branches on \`action_type\`:
  - \`sql_write\`/\`sql\` with \`payload.sql\` → highlighted SQL
  - \`api_call\`/\`api\` with \`payload.method\`/\`url\` → method chip + URL + structured body
  - \`file_write\`/\`file\` with \`payload.path\` → path + content blocks
  - Unknown types → JSON fallback (so a new agent tool's payload is never silently hidden)

### Resilience — single error banner
- Funnels approve / deny / rollback / bulk errors into one \`mutationError\` state instead of stacking up to 4 \`ErrorBanner\`s (aligns with #1557)

### Cleanup
- Dropped chevron column — \`cursor-pointer\` row class is sufficient indication
- Removed cargo-cult \`useTransition\` wrapping a synchronous \`setState\`
- Added \`Tooltip\` on truncated Target / Summary cells
- Removed unused \`Database\` / \`Globe\` lucide imports (now in \`labels.tsx\`)

## Verified end-to-end

Tested via Playwright + psql verification of \`action_log\` rows:
1. Single deny with reason \"Email change requires SOC2 ticket — please file via #security\" → row's \`error\` column contains the actual reason string ✓
2. Bulk deny on 2 selected rows with reason \"Bulk deny test — duplicate Stripe charges + duplicate config writes\" → both rows' \`error\` columns contain the actual reason ✓
3. Inline expand renders SQL Write payload as highlighted SQL ✓
4. Inline expand renders API Call payload as method chip + URL + structured body ✓
5. Default filter loads as \`pending\` (operator-first) ✓
6. Empty state shows the helpful subtitle on \`pending\` ✓

\`bun run lint\` clean, \`bun run type\` clean, \`bun test action-types action-approval-helpers\` 51 pass.

## Filed alongside

- #1589 — \`/admin/abuse\` investigation depth (parallel track per the bucket-1 plan)
- #1590 — atomic \`POST /api/v1/actions/bulk\` endpoint (replaces N parallel fetches)
- #1591 — unify \`ActionStatus\` / \`ActionDisplayStatus\` (drop \`mapStatus\` adapter)

## Not in this PR (deferred to bucket-1 sequence)

- \`RelativeTimestamp\` extraction to \`@/ui/components/admin/\` — happens in PR 3 per the \"extract after third adopter\" rule (#1551)
- Cross-page filter affordance unification — same reason
- Keyboard nav (J/K, A/D shortcuts) — feature, file separately if desired

## Related

- #1588 (admin console final-pass coverage tracker)
- #1551 (extract primitives after third adopter — applied here)
- #1557 (narrow concurrent admin error banners — applied here)

## Test plan

- [ ] Pull branch, \`bun install\`, \`bun run dev\`
- [ ] Sign in as admin, navigate to \`/admin/actions\`
- [ ] Trigger a deny on a pending action — verify the dialog opens, capture a reason, confirm
- [ ] Verify the row's \`error\` column persists the reason: \`SELECT id, status, error FROM action_log ORDER BY resolved_at DESC LIMIT 1;\`
- [ ] Select 2+ pending actions, click \"Deny selected\" — verify the bulk dialog title pluralizes (\"Deny N actions\")
- [ ] Confirm with a reason — verify all selected rows get the same reason in \`action_log.error\`
- [ ] Expand a SQL Write row — verify the SQL renders highlighted in the expand body
- [ ] Expand an API Call row — verify method + URL + body render as separate blocks
- [ ] Expand a Shell row (no known payload shape) — verify JSON fallback renders
- [ ] Trigger an approve failure (e.g., already-resolved action) — verify only one ErrorBanner appears
- [ ] Verify the chevron column is gone — table is now 7 columns wide