### PR TITLE
fix(web/admin/api-keys): surface clipboard failures, drop readOnly

### DIFF
--- a/packages/web/src/app/admin/api-keys/__tests__/copy-api-key-to-clipboard.test.ts
+++ b/packages/web/src/app/admin/api-keys/__tests__/copy-api-key-to-clipboard.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
-import { copyApiKeyToClipboard, COPY_FALLBACK_MESSAGE } from "../page";
+import {
+  copyApiKeyToClipboard,
+  COPY_FALLBACK_MESSAGE,
+} from "../copy-api-key";
 
 const KEY = "atlas_live_abc123def456";
 
-let originalClipboard: typeof navigator.clipboard | undefined;
+let originalClipboard: PropertyDescriptor | undefined;
 let originalConsoleWarn: typeof console.warn;
+let warnMock: ReturnType<typeof mock>;
 
 function stubClipboard(writeText: (text: string) => Promise<void>) {
   Object.defineProperty(navigator, "clipboard", {
@@ -16,18 +20,17 @@ function stubClipboard(writeText: (text: string) => Promise<void>) {
 
 describe("copyApiKeyToClipboard", () => {
   beforeEach(() => {
-    originalClipboard = navigator.clipboard;
+    originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
     originalConsoleWarn = console.warn;
-    console.warn = mock(() => {});
+    warnMock = mock(() => {});
+    console.warn = warnMock;
   });
 
   afterEach(() => {
     if (originalClipboard) {
-      Object.defineProperty(navigator, "clipboard", {
-        value: originalClipboard,
-        writable: true,
-        configurable: true,
-      });
+      Object.defineProperty(navigator, "clipboard", originalClipboard);
+    } else {
+      delete (navigator as unknown as { clipboard?: unknown }).clipboard;
     }
     console.warn = originalConsoleWarn;
   });
@@ -44,15 +47,13 @@ describe("copyApiKeyToClipboard", () => {
     expect(writeText).toHaveBeenCalledWith(KEY);
     expect(setCopied).toHaveBeenCalledWith(true);
     expect(setCopyError).toHaveBeenCalledWith(null);
-    // Failure-path side effects must not fire on success.
     expect(setCopyError).not.toHaveBeenCalledWith(COPY_FALLBACK_MESSAGE);
-    expect(console.warn).not.toHaveBeenCalled();
+    expect(warnMock).not.toHaveBeenCalled();
   });
 
   test("failure: surfaces fallback message, logs the error, clears copied", async () => {
     const denial = new Error("Permissions-Policy: clipboard-write denied");
-    const writeText = mock(() => Promise.reject(denial));
-    stubClipboard(writeText);
+    stubClipboard(() => Promise.reject(denial));
 
     const setCopied = mock(() => {});
     const setCopyError = mock(() => {});
@@ -61,15 +62,14 @@ describe("copyApiKeyToClipboard", () => {
 
     expect(setCopyError).toHaveBeenCalledWith(COPY_FALLBACK_MESSAGE);
     expect(setCopied).toHaveBeenCalledWith(false);
-    expect(console.warn).toHaveBeenCalledTimes(1);
-    const [label, message] = (console.warn as unknown as ReturnType<typeof mock>).mock.calls[0] as [string, string];
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    const [label, message] = warnMock.mock.calls[0] as [string, string];
     expect(label).toBe("API key clipboard write failed:");
     expect(message).toBe(denial.message);
   });
 
   test("failure: handles non-Error rejections by stringifying them", async () => {
-    const writeText = mock(() => Promise.reject("clipboard unavailable"));
-    stubClipboard(writeText);
+    stubClipboard(() => Promise.reject("clipboard unavailable"));
 
     const setCopied = mock(() => {});
     const setCopyError = mock(() => {});
@@ -77,7 +77,7 @@ describe("copyApiKeyToClipboard", () => {
     await copyApiKeyToClipboard({ text: KEY, setCopied, setCopyError });
 
     expect(setCopyError).toHaveBeenCalledWith(COPY_FALLBACK_MESSAGE);
-    const [, message] = (console.warn as unknown as ReturnType<typeof mock>).mock.calls[0] as [string, string];
+    const [, message] = warnMock.mock.calls[0] as [string, string];
     expect(message).toBe("clipboard unavailable");
   });
 });

--- a/packages/web/src/app/admin/api-keys/__tests__/copy-api-key-to-clipboard.test.ts
+++ b/packages/web/src/app/admin/api-keys/__tests__/copy-api-key-to-clipboard.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { copyApiKeyToClipboard, COPY_FALLBACK_MESSAGE } from "../page";
+
+const KEY = "atlas_live_abc123def456";
+
+let originalClipboard: typeof navigator.clipboard | undefined;
+let originalConsoleWarn: typeof console.warn;
+
+function stubClipboard(writeText: (text: string) => Promise<void>) {
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    writable: true,
+    configurable: true,
+  });
+}
+
+describe("copyApiKeyToClipboard", () => {
+  beforeEach(() => {
+    originalClipboard = navigator.clipboard;
+    originalConsoleWarn = console.warn;
+    console.warn = mock(() => {});
+  });
+
+  afterEach(() => {
+    if (originalClipboard) {
+      Object.defineProperty(navigator, "clipboard", {
+        value: originalClipboard,
+        writable: true,
+        configurable: true,
+      });
+    }
+    console.warn = originalConsoleWarn;
+  });
+
+  test("success: writes text, marks copied, clears any prior error", async () => {
+    const writeText = mock(() => Promise.resolve());
+    stubClipboard(writeText);
+
+    const setCopied = mock(() => {});
+    const setCopyError = mock(() => {});
+
+    await copyApiKeyToClipboard({ text: KEY, setCopied, setCopyError });
+
+    expect(writeText).toHaveBeenCalledWith(KEY);
+    expect(setCopied).toHaveBeenCalledWith(true);
+    expect(setCopyError).toHaveBeenCalledWith(null);
+    // Failure-path side effects must not fire on success.
+    expect(setCopyError).not.toHaveBeenCalledWith(COPY_FALLBACK_MESSAGE);
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  test("failure: surfaces fallback message, logs the error, clears copied", async () => {
+    const denial = new Error("Permissions-Policy: clipboard-write denied");
+    const writeText = mock(() => Promise.reject(denial));
+    stubClipboard(writeText);
+
+    const setCopied = mock(() => {});
+    const setCopyError = mock(() => {});
+
+    await copyApiKeyToClipboard({ text: KEY, setCopied, setCopyError });
+
+    expect(setCopyError).toHaveBeenCalledWith(COPY_FALLBACK_MESSAGE);
+    expect(setCopied).toHaveBeenCalledWith(false);
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    const [label, message] = (console.warn as unknown as ReturnType<typeof mock>).mock.calls[0] as [string, string];
+    expect(label).toBe("API key clipboard write failed:");
+    expect(message).toBe(denial.message);
+  });
+
+  test("failure: handles non-Error rejections by stringifying them", async () => {
+    const writeText = mock(() => Promise.reject("clipboard unavailable"));
+    stubClipboard(writeText);
+
+    const setCopied = mock(() => {});
+    const setCopyError = mock(() => {});
+
+    await copyApiKeyToClipboard({ text: KEY, setCopied, setCopyError });
+
+    expect(setCopyError).toHaveBeenCalledWith(COPY_FALLBACK_MESSAGE);
+    const [, message] = (console.warn as unknown as ReturnType<typeof mock>).mock.calls[0] as [string, string];
+    expect(message).toBe("clipboard unavailable");
+  });
+});

--- a/packages/web/src/app/admin/api-keys/copy-api-key.ts
+++ b/packages/web/src/app/admin/api-keys/copy-api-key.ts
@@ -1,0 +1,20 @@
+export const COPY_FALLBACK_MESSAGE =
+  "Copy failed — select the key below and copy manually.";
+
+export async function copyApiKeyToClipboard(args: {
+  text: string;
+  setCopied: (copied: boolean) => void;
+  setCopyError: (msg: string | null) => void;
+}): Promise<void> {
+  const { text, setCopied, setCopyError } = args;
+  try {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setCopyError(null);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn("API key clipboard write failed:", msg);
+    setCopied(false);
+    setCopyError(COPY_FALLBACK_MESSAGE);
+  }
+}

--- a/packages/web/src/app/admin/api-keys/page.tsx
+++ b/packages/web/src/app/admin/api-keys/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { z } from "zod";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
@@ -39,6 +39,7 @@ import {
 import { cn } from "@/lib/utils";
 import { formatDate, formatDateTime } from "@/lib/format";
 import { KeyRound, Plus, Copy, Check, Loader2, Trash2 } from "lucide-react";
+import { copyApiKeyToClipboard } from "./copy-api-key";
 
 // -- Types --
 
@@ -78,30 +79,6 @@ function isExpired(expiresAt: string | null): boolean {
   return new Date(expiresAt).getTime() < Date.now();
 }
 
-export const COPY_FALLBACK_MESSAGE =
-  "Copy failed — select the key below and copy manually.";
-
-// Exported so the success / failure branches stay unit-testable without
-// mounting the full page.
-export async function copyApiKeyToClipboard(args: {
-  text: string;
-  setCopied: (copied: boolean) => void;
-  setCopyError: (msg: string | null) => void;
-}): Promise<void> {
-  const { text, setCopied, setCopyError } = args;
-  try {
-    await navigator.clipboard.writeText(text);
-    setCopied(true);
-    setCopyError(null);
-    setTimeout(() => setCopied(false), 2000);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.warn("API key clipboard write failed:", msg);
-    setCopied(false);
-    setCopyError(COPY_FALLBACK_MESSAGE);
-  }
-}
-
 // -- Component --
 
 export default function ApiKeysPage() {
@@ -131,10 +108,6 @@ export default function ApiKeysPage() {
   // -- Dialog state --
   const [createOpen, setCreateOpen] = useState(false);
   const [createdKey, setCreatedKey] = useState<{ key: string; name: string } | null>(null);
-  const [copied, setCopied] = useState(false);
-  // Surfaces clipboard failures (insecure origin, Permissions-Policy, private
-  // mode) — silent no-op is unrecoverable on a one-time-reveal surface.
-  const [copyError, setCopyError] = useState<string | null>(null);
   const [revokeTarget, setRevokeTarget] = useState<ApiKeyRow | null>(null);
 
   // -- Handlers --
@@ -142,8 +115,6 @@ export default function ApiKeysPage() {
   function openCreateDialog() {
     createMutation.reset();
     setCreatedKey(null);
-    setCopied(false);
-    setCopyError(null);
     setCreateOpen(true);
   }
 
@@ -258,63 +229,11 @@ export default function ApiKeysPage() {
 
       {/* Create dialog — result phase (show full key) */}
       {createdKey && (
-        <Dialog
+        <RevealKeyDialog
           open={createOpen && !!createdKey}
           onOpenChange={(open) => { if (!open) setCreateOpen(false); }}
-        >
-          <DialogContent className="sm:max-w-md">
-            <DialogHeader>
-              <DialogTitle>API key created</DialogTitle>
-              <DialogDescription>
-                Copy your API key now. You will not be able to see it again.
-              </DialogDescription>
-            </DialogHeader>
-            <div className="space-y-4">
-              <div className="space-y-1.5">
-                <Label>API Key</Label>
-                <div className="flex gap-2">
-                  {/* No readOnly: keeps manual select → Ctrl+C as a fallback
-                      when navigator.clipboard.writeText is blocked. */}
-                  <Input
-                    value={createdKey.key}
-                    onChange={() => { /* server-issued; ignore edits */ }}
-                    className="h-9 font-mono text-xs"
-                    aria-describedby={copyError ? "copy-error" : undefined}
-                  />
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-9 shrink-0"
-                    onClick={() =>
-                      copyApiKeyToClipboard({
-                        text: createdKey.key,
-                        setCopied,
-                        setCopyError,
-                      })
-                    }
-                  >
-                    {copied ? <Check className="mr-1.5 size-3.5" /> : <Copy className="mr-1.5 size-3.5" />}
-                    {copied ? "Copied" : "Copy"}
-                  </Button>
-                </div>
-                {copyError && (
-                  <p id="copy-error" role="alert" className="text-xs text-destructive">
-                    {copyError}
-                  </p>
-                )}
-              </div>
-              <div className="flex items-start gap-3 rounded-md border border-amber-200 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-950">
-                <KeyRound className="mt-0.5 size-4 text-amber-600 dark:text-amber-400" />
-                <p className="text-sm text-amber-700 dark:text-amber-400">
-                  Store this key securely. It will only be displayed once.
-                </p>
-              </div>
-            </div>
-            <DialogFooter>
-              <Button onClick={() => setCreateOpen(false)}>Done</Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
+          apiKey={createdKey}
+        />
       )}
 
       {/* Create dialog — form phase */}
@@ -393,6 +312,87 @@ export default function ApiKeysPage() {
         </DialogContent>
       </Dialog>
     </div>
+  );
+}
+
+// ── Reveal dialog (one-time key display) ─────────────────────────
+
+function RevealKeyDialog({
+  open,
+  onOpenChange,
+  apiKey,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  apiKey: { key: string; name: string };
+}) {
+  const [copied, setCopied] = useState(false);
+  // Surfaces clipboard failures (insecure origin, Permissions-Policy, private
+  // mode) — silent no-op is unrecoverable on a one-time-reveal surface.
+  const [copyError, setCopyError] = useState<string | null>(null);
+
+  // Auto-reset the "Copied" affordance. Co-locating the timer with the
+  // component lifecycle ensures the cleanup fires on unmount, so a stale
+  // timer can't flip the next dialog instance's state.
+  useEffect(() => {
+    if (!copied) return;
+    const t = setTimeout(() => setCopied(false), 2000);
+    return () => clearTimeout(t);
+  }, [copied]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>API key created</DialogTitle>
+          <DialogDescription>
+            Copy your API key now. You will not be able to see it again.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label>API Key</Label>
+            <div className="flex gap-2">
+              <Input
+                readOnly
+                value={apiKey.key}
+                className="h-9 font-mono text-xs"
+                aria-describedby={copyError ? "copy-error" : undefined}
+              />
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-9 shrink-0"
+                onClick={() =>
+                  copyApiKeyToClipboard({
+                    text: apiKey.key,
+                    setCopied,
+                    setCopyError,
+                  })
+                }
+              >
+                {copied ? <Check className="mr-1.5 size-3.5" /> : <Copy className="mr-1.5 size-3.5" />}
+                {copied ? "Copied" : "Copy"}
+              </Button>
+            </div>
+            {copyError && (
+              <p id="copy-error" role="alert" className="text-xs text-destructive">
+                {copyError}
+              </p>
+            )}
+          </div>
+          <div className="flex items-start gap-3 rounded-md border border-amber-200 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-950">
+            <KeyRound className="mt-0.5 size-4 text-amber-600 dark:text-amber-400" />
+            <p className="text-sm text-amber-700 dark:text-amber-400">
+              Store this key securely. It will only be displayed once.
+            </p>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button onClick={() => onOpenChange(false)}>Done</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/packages/web/src/app/admin/api-keys/page.tsx
+++ b/packages/web/src/app/admin/api-keys/page.tsx
@@ -78,6 +78,30 @@ function isExpired(expiresAt: string | null): boolean {
   return new Date(expiresAt).getTime() < Date.now();
 }
 
+export const COPY_FALLBACK_MESSAGE =
+  "Copy failed — select the key below and copy manually.";
+
+// Exported so the success / failure branches stay unit-testable without
+// mounting the full page.
+export async function copyApiKeyToClipboard(args: {
+  text: string;
+  setCopied: (copied: boolean) => void;
+  setCopyError: (msg: string | null) => void;
+}): Promise<void> {
+  const { text, setCopied, setCopyError } = args;
+  try {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setCopyError(null);
+    setTimeout(() => setCopied(false), 2000);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn("API key clipboard write failed:", msg);
+    setCopied(false);
+    setCopyError(COPY_FALLBACK_MESSAGE);
+  }
+}
+
 // -- Component --
 
 export default function ApiKeysPage() {
@@ -108,6 +132,9 @@ export default function ApiKeysPage() {
   const [createOpen, setCreateOpen] = useState(false);
   const [createdKey, setCreatedKey] = useState<{ key: string; name: string } | null>(null);
   const [copied, setCopied] = useState(false);
+  // Surfaces clipboard failures (insecure origin, Permissions-Policy, private
+  // mode) — silent no-op is unrecoverable on a one-time-reveal surface.
+  const [copyError, setCopyError] = useState<string | null>(null);
   const [revokeTarget, setRevokeTarget] = useState<ApiKeyRow | null>(null);
 
   // -- Handlers --
@@ -116,6 +143,7 @@ export default function ApiKeysPage() {
     createMutation.reset();
     setCreatedKey(null);
     setCopied(false);
+    setCopyError(null);
     setCreateOpen(true);
   }
 
@@ -128,16 +156,6 @@ export default function ApiKeysPage() {
         refetch();
       },
     });
-  }
-
-  async function handleCopy(text: string) {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // intentionally ignored: clipboard API not available — user can select and copy manually
-    }
   }
 
   async function handleRevoke() {
@@ -255,21 +273,35 @@ export default function ApiKeysPage() {
               <div className="space-y-1.5">
                 <Label>API Key</Label>
                 <div className="flex gap-2">
+                  {/* No readOnly: keeps manual select → Ctrl+C as a fallback
+                      when navigator.clipboard.writeText is blocked. */}
                   <Input
-                    readOnly
                     value={createdKey.key}
+                    onChange={() => { /* server-issued; ignore edits */ }}
                     className="h-9 font-mono text-xs"
+                    aria-describedby={copyError ? "copy-error" : undefined}
                   />
                   <Button
                     variant="outline"
                     size="sm"
                     className="h-9 shrink-0"
-                    onClick={() => handleCopy(createdKey.key)}
+                    onClick={() =>
+                      copyApiKeyToClipboard({
+                        text: createdKey.key,
+                        setCopied,
+                        setCopyError,
+                      })
+                    }
                   >
                     {copied ? <Check className="mr-1.5 size-3.5" /> : <Copy className="mr-1.5 size-3.5" />}
                     {copied ? "Copied" : "Copy"}
                   </Button>
                 </div>
+                {copyError && (
+                  <p id="copy-error" role="alert" className="text-xs text-destructive">
+                    {copyError}
+                  </p>
+                )}
               </div>
               <div className="flex items-start gap-3 rounded-md border border-amber-200 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-950">
                 <KeyRound className="mt-0.5 size-4 text-amber-600 dark:text-amber-400" />


### PR DESCRIPTION
## Summary
- Replaces the silent `try { ... } catch {}` around `navigator.clipboard.writeText` on the one-time-reveal Copy button. Failures (insecure origin, Permissions-Policy, sandboxed private mode) now log a type-narrowed warning and render a destructive inline message wired up via `aria-describedby` on the key input.
- Drops `readOnly` from the key `<Input>` (with a no-op `onChange` to keep the controlled-input value pinned) so the user can always select-and-copy as a fallback when the Clipboard API is blocked.
- Extracts `copyApiKeyToClipboard` (top-level, exported) so the success/failure branches stay unit-testable without mounting the page.

This bug pre-dates PR #1586 and was flagged in the post-revamp silent-failure review.

## Test plan
- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun run --filter '@atlas/web' test` — 62 files, 0 failures (incl. new `copy-api-key-to-clipboard.test.ts`)
- [x] `bun x syncpack lint` — no issues
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — no drift
- [ ] Manual: in dev, create an API key, click Copy with the Permissions-Policy header denying `clipboard-write` → confirm the inline error appears and the key is still selectable.

Closes #1587