### PR TITLE
feat(api/actions): atomic bulk approve/deny endpoint

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -11669,6 +11669,203 @@
         "operationId": "postActionsByIdDeny"
       }
     },
+    "/api/v1/actions/bulk": {
+      "post": {
+        "tags": [
+          "Actions"
+        ],
+        "summary": "Bulk approve or deny pending actions",
+        "description": "Resolves many pending actions in a single request. Each id is pre-classified as eligible, not found, or forbidden; eligible ids are then approved or denied. Rows that race a conflicting resolution land in `errors`. Maximum 100 ids per request. Permission rules match the single-action endpoints: admin-only actions cannot be resolved by the requester.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "minItems": 1,
+                    "maxItems": 100
+                  },
+                  "action": {
+                    "type": "string",
+                    "enum": [
+                      "approve",
+                      "deny"
+                    ]
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "ids",
+                  "action"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Bulk result — each id appears in exactly one bucket",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "updated": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "notFound": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "forbidden": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "error": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "error"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "updated",
+                    "notFound",
+                    "forbidden",
+                    "errors"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Actions not available (no internal database or feature disabled)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postActionsBulk"
+      }
+    },
     "/api/v1/actions/{id}/rollback": {
       "post": {
         "tags": [
@@ -25091,12 +25288,18 @@
                         "string",
                         "null"
                       ]
+                    },
+                    "effectivelyEnforced": {
+                      "type": "boolean",
+                      "example": true,
+                      "description": "Whether the workspace's IP allowlist is actively gating requests. False when enterprise is disabled, internal DB is missing, or no entries exist."
                     }
                   },
                   "required": [
                     "entries",
                     "total",
-                    "callerIP"
+                    "callerIP",
+                    "effectivelyEnforced"
                   ]
                 }
               }
@@ -28282,11 +28485,11 @@
         "tags": [
           "Admin — Email Provider"
         ],
-        "summary": "Get platform email provider configuration",
-        "description": "Returns the platform's email provider configuration. Shows source: override (DB), env, or default.",
+        "summary": "Get workspace email provider configuration",
+        "description": "Returns the Resend baseline plus the workspace's BYOT override (if any). Baseline is locked; override supports Resend, SendGrid, Postmark, SMTP, and SES.",
         "responses": {
           "200": {
-            "description": "Platform email provider configuration",
+            "description": "Email provider configuration",
             "content": {
               "application/json": {
                 "schema": {
@@ -28295,39 +28498,75 @@
                     "config": {
                       "type": "object",
                       "properties": {
-                        "provider": {
-                          "type": "string",
-                          "enum": [
-                            "resend",
-                            "sendgrid",
-                            "postmark",
-                            "smtp",
-                            "ses"
+                        "baseline": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string",
+                              "enum": [
+                                "resend"
+                              ]
+                            },
+                            "fromAddress": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "fromAddress"
                           ]
                         },
-                        "fromAddress": {
-                          "type": "string"
-                        },
-                        "apiKeyMasked": {
+                        "override": {
                           "type": [
-                            "string",
+                            "object",
                             "null"
-                          ]
-                        },
-                        "source": {
-                          "type": "string",
-                          "enum": [
-                            "override",
-                            "env",
-                            "default"
+                          ],
+                          "properties": {
+                            "provider": {
+                              "type": "string",
+                              "enum": [
+                                "resend",
+                                "sendgrid",
+                                "postmark",
+                                "smtp",
+                                "ses"
+                              ]
+                            },
+                            "fromAddress": {
+                              "type": "string"
+                            },
+                            "secretLabel": {
+                              "type": "string"
+                            },
+                            "secretMasked": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "hints": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string"
+                              }
+                            },
+                            "installedAt": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "fromAddress",
+                            "secretLabel",
+                            "secretMasked",
+                            "hints",
+                            "installedAt"
                           ]
                         }
                       },
                       "required": [
-                        "provider",
-                        "fromAddress",
-                        "apiKeyMasked",
-                        "source"
+                        "baseline",
+                        "override"
                       ]
                     }
                   },
@@ -28350,12 +28589,37 @@
             }
           },
           "403": {
-            "description": "Forbidden — platform admin required",
+            "description": "Forbidden — admin required",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Internal database not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
                 }
               }
             }
@@ -28403,8 +28667,8 @@
         "tags": [
           "Admin — Email Provider"
         ],
-        "summary": "Set platform email provider configuration",
-        "description": "Configures the platform-level email provider. Stores as a settings override in the internal database.",
+        "summary": "Save workspace email provider override",
+        "description": "Stores the workspace's email provider override. Provider-specific config is validated server-side.",
         "requestBody": {
           "required": true,
           "content": {
@@ -28421,22 +28685,114 @@
                       "smtp",
                       "ses"
                     ],
-                    "description": "Email provider to use for platform email delivery.",
-                    "example": "resend"
-                  },
-                  "apiKey": {
-                    "type": "string",
-                    "minLength": 1,
-                    "description": "Provider API key. Omit to keep existing key on update."
+                    "description": "Email provider to use for this workspace."
                   },
                   "fromAddress": {
                     "type": "string",
-                    "description": "Sender address for platform emails.",
-                    "example": "Atlas <noreply@useatlas.dev>"
+                    "minLength": 1,
+                    "description": "Sender address (From header). Must be verified with the chosen provider.",
+                    "example": "Acme <noreply@acme.com>"
+                  },
+                  "config": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "host": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "port": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 65535
+                          },
+                          "username": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "password": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "tls": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "host",
+                          "port",
+                          "username",
+                          "password",
+                          "tls"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "apiKey": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "apiKey"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "serverToken": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "serverToken"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "region": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "accessKeyId": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "secretAccessKey": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "region",
+                          "accessKeyId",
+                          "secretAccessKey"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "apiKey": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "apiKey"
+                        ]
+                      }
+                    ],
+                    "description": "Provider-specific configuration (credentials + any non-secret fields)."
                   }
                 },
                 "required": [
-                  "provider"
+                  "provider",
+                  "fromAddress",
+                  "config"
                 ]
               }
             }
@@ -28444,7 +28800,7 @@
         },
         "responses": {
           "200": {
-            "description": "Email provider configuration saved",
+            "description": "Override saved",
             "content": {
               "application/json": {
                 "schema": {
@@ -28453,39 +28809,75 @@
                     "config": {
                       "type": "object",
                       "properties": {
-                        "provider": {
-                          "type": "string",
-                          "enum": [
-                            "resend",
-                            "sendgrid",
-                            "postmark",
-                            "smtp",
-                            "ses"
+                        "baseline": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string",
+                              "enum": [
+                                "resend"
+                              ]
+                            },
+                            "fromAddress": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "fromAddress"
                           ]
                         },
-                        "fromAddress": {
-                          "type": "string"
-                        },
-                        "apiKeyMasked": {
+                        "override": {
                           "type": [
-                            "string",
+                            "object",
                             "null"
-                          ]
-                        },
-                        "source": {
-                          "type": "string",
-                          "enum": [
-                            "override",
-                            "env",
-                            "default"
+                          ],
+                          "properties": {
+                            "provider": {
+                              "type": "string",
+                              "enum": [
+                                "resend",
+                                "sendgrid",
+                                "postmark",
+                                "smtp",
+                                "ses"
+                              ]
+                            },
+                            "fromAddress": {
+                              "type": "string"
+                            },
+                            "secretLabel": {
+                              "type": "string"
+                            },
+                            "secretMasked": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "hints": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string"
+                              }
+                            },
+                            "installedAt": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "fromAddress",
+                            "secretLabel",
+                            "secretMasked",
+                            "hints",
+                            "installedAt"
                           ]
                         }
                       },
                       "required": [
-                        "provider",
-                        "fromAddress",
-                        "apiKeyMasked",
-                        "source"
+                        "baseline",
+                        "override"
                       ]
                     }
                   },
@@ -28533,7 +28925,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — platform admin required",
+            "description": "Forbidden — admin required",
             "content": {
               "application/json": {
                 "schema": {
@@ -28611,11 +29003,11 @@
         "tags": [
           "Admin — Email Provider"
         ],
-        "summary": "Reset platform email provider to defaults",
-        "description": "Removes DB overrides for email provider settings. Falls back to environment variables, then defaults.",
+        "summary": "Remove workspace email provider override",
+        "description": "Deletes the workspace's email override. Delivery falls back to the platform default.",
         "responses": {
           "200": {
-            "description": "Configuration reset to defaults",
+            "description": "Override removed",
             "content": {
               "application/json": {
                 "schema": {
@@ -28644,7 +29036,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — platform admin required",
+            "description": "Forbidden — admin required",
             "content": {
               "application/json": {
                 "schema": {
@@ -28724,8 +29116,8 @@
         "tags": [
           "Admin — Email Provider"
         ],
-        "summary": "Test email provider configuration",
-        "description": "Sends a test email using the provided credentials. Does not save the configuration.",
+        "summary": "Send a test email",
+        "description": "Sends a test email using the supplied credentials (when given) or the saved override, falling back to the platform default.",
         "requestBody": {
           "required": true,
           "content": {
@@ -28733,6 +29125,10 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "recipientEmail": {
+                    "type": "string",
+                    "format": "email"
+                  },
                   "provider": {
                     "type": "string",
                     "enum": [
@@ -28743,23 +29139,107 @@
                       "ses"
                     ]
                   },
-                  "apiKey": {
-                    "type": "string",
-                    "minLength": 1,
-                    "description": "Provider API key to test. Omit to test the currently saved key."
-                  },
                   "fromAddress": {
                     "type": "string",
                     "minLength": 1
                   },
-                  "recipientEmail": {
-                    "type": "string",
-                    "format": "email"
+                  "config": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "host": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "port": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 65535
+                          },
+                          "username": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "password": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "tls": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "host",
+                          "port",
+                          "username",
+                          "password",
+                          "tls"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "apiKey": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "apiKey"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "serverToken": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "serverToken"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "region": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "accessKeyId": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "secretAccessKey": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "region",
+                          "accessKeyId",
+                          "secretAccessKey"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "apiKey": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "apiKey"
+                        ]
+                      }
+                    ],
+                    "description": "Provider-specific config to test. Omit to test the saved override."
                   }
                 },
                 "required": [
-                  "provider",
-                  "fromAddress",
                   "recipientEmail"
                 ]
               }
@@ -28826,12 +29306,37 @@
             }
           },
           "403": {
-            "description": "Forbidden — platform admin required",
+            "description": "Forbidden — admin required",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Internal database not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
                 }
               }
             }

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -11699,7 +11699,8 @@
                     ]
                   },
                   "reason": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 1000
                   }
                 },
                 "required": [

--- a/packages/api/src/api/__tests__/actions.test.ts
+++ b/packages/api/src/api/__tests__/actions.test.ts
@@ -76,6 +76,30 @@ mock.module("@atlas/api/lib/tools/actions/handler", () => ({
   getActionConfig: mockGetActionConfig,
 }));
 
+// --- Bulk module mocks ---
+
+type BulkResult = {
+  updated: string[];
+  notFound: string[];
+  forbidden: string[];
+  errors: Array<{ id: string; error: string }>;
+};
+
+const mockBulkApproveActions = mock(
+  (): Promise<BulkResult> =>
+    Promise.resolve({ updated: [], notFound: [], forbidden: [], errors: [] }),
+);
+const mockBulkDenyActions = mock(
+  (): Promise<BulkResult> =>
+    Promise.resolve({ updated: [], notFound: [], forbidden: [], errors: [] }),
+);
+
+mock.module("@atlas/api/lib/tools/actions/bulk", () => ({
+  bulkApproveActions: mockBulkApproveActions,
+  bulkDenyActions: mockBulkDenyActions,
+  BULK_ACTIONS_MAX: 100,
+}));
+
 // Mock other modules required by the Hono app (same as conversations.test.ts)
 
 mock.module("@atlas/api/lib/agent", () => ({
@@ -199,6 +223,20 @@ describe("actions routes", () => {
     mockGetActionConfig.mockReturnValue({ approval: "manual" });
     mockRollbackAction.mockReset();
     mockRollbackAction.mockResolvedValue(null);
+    mockBulkApproveActions.mockReset();
+    mockBulkApproveActions.mockResolvedValue({
+      updated: [],
+      notFound: [],
+      forbidden: [],
+      errors: [],
+    });
+    mockBulkDenyActions.mockReset();
+    mockBulkDenyActions.mockResolvedValue({
+      updated: [],
+      notFound: [],
+      forbidden: [],
+      errors: [],
+    });
   });
 
   afterEach(() => {
@@ -862,6 +900,214 @@ describe("actions routes", () => {
 
       const body = (await response.json()) as Record<string, unknown>;
       expect(body.error).toBe("internal_error");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /api/v1/actions/bulk
+  // -------------------------------------------------------------------------
+
+  describe("POST /api/v1/actions/bulk", () => {
+    const VALID_ID_2 = "b2c3d4e5-f6a7-8901-bcde-f23456789012";
+
+    it("returns 200 with aggregated buckets on successful approve", async () => {
+      mockBulkApproveActions.mockResolvedValueOnce({
+        updated: [VALID_ID, VALID_ID_2],
+        notFound: [],
+        forbidden: [],
+        errors: [],
+      });
+
+      const response = await app.fetch(
+        new Request("http://localhost/api/v1/actions/bulk", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ids: [VALID_ID, VALID_ID_2], action: "approve" }),
+        }),
+      );
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as BulkResult;
+      expect(body.updated).toEqual([VALID_ID, VALID_ID_2]);
+      expect(body.notFound).toEqual([]);
+      expect(body.forbidden).toEqual([]);
+      expect(body.errors).toEqual([]);
+    });
+
+    it("returns 200 with partial-failure buckets for deny", async () => {
+      mockBulkDenyActions.mockResolvedValueOnce({
+        updated: [VALID_ID],
+        notFound: [VALID_ID_2],
+        forbidden: [],
+        errors: [],
+      });
+
+      const response = await app.fetch(
+        new Request("http://localhost/api/v1/actions/bulk", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            ids: [VALID_ID, VALID_ID_2],
+            action: "deny",
+            reason: "Not approved",
+          }),
+        }),
+      );
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as BulkResult;
+      expect(body.updated).toEqual([VALID_ID]);
+      expect(body.notFound).toEqual([VALID_ID_2]);
+      expect(mockBulkDenyActions).toHaveBeenCalledTimes(1);
+
+      const call = mockBulkDenyActions.mock.calls[0] as unknown as [{ ids: string[]; reason?: string; user?: { id: string } }];
+      expect(call[0].ids).toEqual([VALID_ID, VALID_ID_2]);
+      expect(call[0].reason).toBe("Not approved");
+      expect(call[0].user?.id).toBe("u1");
+    });
+
+    it("dispatches to bulkApproveActions when action is 'approve'", async () => {
+      await app.fetch(
+        new Request("http://localhost/api/v1/actions/bulk", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ids: [VALID_ID], action: "approve" }),
+        }),
+      );
+      expect(mockBulkApproveActions).toHaveBeenCalledTimes(1);
+      expect(mockBulkDenyActions).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when ids is empty", async () => {
+      const response = await app.fetch(
+        new Request("http://localhost/api/v1/actions/bulk", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ids: [], action: "approve" }),
+        }),
+      );
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 when ids exceeds the bulk cap", async () => {
+      const tooMany = Array.from({ length: 101 }, (_, i) => {
+        const hex = i.toString(16).padStart(12, "0");
+        return `00000000-0000-0000-0000-${hex}`;
+      });
+
+      const response = await app.fetch(
+        new Request("http://localhost/api/v1/actions/bulk", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ids: tooMany, action: "approve" }),
+        }),
+      );
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 when any id is malformed", async () => {
+      const response = await app.fetch(
+        new Request("http://localhost/api/v1/actions/bulk", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ids: ["not-a-uuid"], action: "approve" }),
+        }),
+      );
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 when action value is invalid", async () => {
+      const response = await app.fetch(
+        new Request("http://localhost/api/v1/actions/bulk", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ids: [VALID_ID], action: "wiggle" }),
+        }),
+      );
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 when body is malformed JSON", async () => {
+      const response = await app.fetch(
+        new Request("http://localhost/api/v1/actions/bulk", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "{ not valid",
+        }),
+      );
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 404 when no internal DB", async () => {
+      delete process.env.DATABASE_URL;
+
+      const response = await app.fetch(
+        new Request("http://localhost/api/v1/actions/bulk", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ids: [VALID_ID], action: "approve" }),
+        }),
+      );
+      expect(response.status).toBe(404);
+    });
+
+    it("returns 401 when unauthenticated", async () => {
+      mockAuthenticateRequest.mockResolvedValueOnce({
+        authenticated: false as const,
+        mode: "simple-key" as const,
+        status: 401 as const,
+        error: "API key required",
+      });
+
+      const response = await app.fetch(
+        new Request("http://localhost/api/v1/actions/bulk", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ids: [VALID_ID], action: "approve" }),
+        }),
+      );
+      expect(response.status).toBe(401);
+    });
+
+    it("returns 500 with requestId when the service throws", async () => {
+      mockBulkApproveActions.mockRejectedValueOnce(new Error("DB blew up"));
+
+      const response = await app.fetch(
+        new Request("http://localhost/api/v1/actions/bulk", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ids: [VALID_ID], action: "approve" }),
+        }),
+      );
+      expect(response.status).toBe(500);
+
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("internal_error");
+      expect(body.requestId).toEqual(expect.any(String));
+    });
+
+    it("passes orgId from auth.activeOrganizationId to the service", async () => {
+      mockAuthenticateRequest.mockResolvedValueOnce({
+        authenticated: true as const,
+        mode: "simple-key" as const,
+        user: {
+          id: "u1",
+          label: "test@test.com",
+          mode: "simple-key" as const,
+          activeOrganizationId: "org-42",
+        },
+      });
+
+      await app.fetch(
+        new Request("http://localhost/api/v1/actions/bulk", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ids: [VALID_ID], action: "approve" }),
+        }),
+      );
+
+      const call = mockBulkApproveActions.mock.calls[0] as unknown as [{ orgId?: string | null }];
+      expect(call[0].orgId).toBe("org-42");
     });
   });
 });

--- a/packages/api/src/api/__tests__/actions.test.ts
+++ b/packages/api/src/api/__tests__/actions.test.ts
@@ -960,10 +960,11 @@ describe("actions routes", () => {
       expect(body.notFound).toEqual([VALID_ID_2]);
       expect(mockBulkDenyActions).toHaveBeenCalledTimes(1);
 
-      const call = mockBulkDenyActions.mock.calls[0] as unknown as [{ ids: string[]; reason?: string; user?: { id: string } }];
+      const call = mockBulkDenyActions.mock.calls[0] as unknown as [{ ids: string[]; reason?: string; user?: { id: string }; requestId?: string }];
       expect(call[0].ids).toEqual([VALID_ID, VALID_ID_2]);
       expect(call[0].reason).toBe("Not approved");
       expect(call[0].user?.id).toBe("u1");
+      expect(call[0].requestId).toEqual(expect.any(String));
     });
 
     it("dispatches to bulkApproveActions when action is 'approve'", async () => {
@@ -1011,6 +1012,21 @@ describe("actions routes", () => {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ ids: ["not-a-uuid"], action: "approve" }),
+        }),
+      );
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 when reason exceeds the length cap", async () => {
+      const response = await app.fetch(
+        new Request("http://localhost/api/v1/actions/bulk", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            ids: [VALID_ID],
+            action: "deny",
+            reason: "x".repeat(1001),
+          }),
         }),
       );
       expect(response.status).toBe(400);

--- a/packages/api/src/api/routes/actions.ts
+++ b/packages/api/src/api/routes/actions.ts
@@ -23,6 +23,11 @@ import {
   getActionExecutor,
   getActionConfig,
 } from "@atlas/api/lib/tools/actions/handler";
+import {
+  bulkApproveActions,
+  bulkDenyActions,
+  BULK_ACTIONS_MAX,
+} from "@atlas/api/lib/tools/actions/bulk";
 import { ACTION_STATUSES, type ActionStatus } from "@atlas/api/lib/action-types";
 import { canApprove } from "@atlas/api/lib/auth/permissions";
 import { ErrorSchema, parsePagination } from "./shared-schemas";
@@ -230,6 +235,69 @@ const denyActionRoute = createRoute({
     },
     409: {
       description: "Action has already been resolved",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    429: {
+      description: "Rate limit exceeded",
+      content: { "application/json": { schema: z.record(z.string(), z.unknown()) } },
+    },
+    500: {
+      description: "Internal server error",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const BulkActionsResponseSchema = z.object({
+  updated: z.array(z.string()),
+  notFound: z.array(z.string()),
+  forbidden: z.array(z.string()),
+  errors: z.array(z.object({ id: z.string(), error: z.string() })),
+});
+
+const BulkActionsRequestSchema = z.object({
+  ids: z
+    .array(z.string().uuid("Each id must be a UUID"))
+    .min(1, "ids must be a non-empty array")
+    .max(BULK_ACTIONS_MAX, `Maximum ${BULK_ACTIONS_MAX} ids per bulk operation`),
+  action: z.enum(["approve", "deny"]),
+  reason: z.string().optional(),
+});
+
+const bulkActionsRoute = createRoute({
+  method: "post",
+  path: "/bulk",
+  tags: ["Actions"],
+  summary: "Bulk approve or deny pending actions",
+  description:
+    "Resolves many pending actions in a single request. Each id is pre-classified as eligible, " +
+    "not found, or forbidden; eligible ids are then approved or denied. Rows that race a " +
+    "conflicting resolution land in `errors`. Maximum 100 ids per request. Permission rules match " +
+    "the single-action endpoints: admin-only actions cannot be resolved by the requester.",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: BulkActionsRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Bulk result — each id appears in exactly one bucket",
+      content: { "application/json": { schema: BulkActionsResponseSchema } },
+    },
+    400: {
+      description: "Invalid request body",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    401: {
+      description: "Authentication required",
+      content: { "application/json": { schema: z.record(z.string(), z.unknown()) } },
+    },
+    404: {
+      description: "Actions not available (no internal database or feature disabled)",
       content: { "application/json": { schema: ErrorSchema } },
     },
     429: {
@@ -487,6 +555,62 @@ actions.openapi(
     if (!result.success) {
       return c.json(
         { error: "validation_error", message: "Invalid request body.", details: result.error.issues },
+        400,
+      );
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// POST /bulk — atomic bulk approve / deny
+//
+// Mounted before the /:id/* routes so Hono's router matches the literal
+// "bulk" segment. Returns aggregated result buckets so the web client can
+// drop its N-parallel-fetch + Promise.allSettled pattern (#1590).
+// ---------------------------------------------------------------------------
+
+actions.openapi(
+  bulkActionsRoute,
+  async (c) => {
+    return runEffect(c, Effect.gen(function* () {
+      const { requestId } = yield* RequestContext;
+      const { user } = yield* AuthContext;
+
+      if (!hasInternalDB()) {
+        return c.json(
+          {
+            error: "not_available",
+            message: "Action tracking is not available (no internal database configured).",
+            requestId,
+          },
+          404,
+        );
+      }
+
+      const { ids, action, reason } = c.req.valid("json");
+      const orgId = user?.activeOrganizationId ?? null;
+
+      const result = action === "approve"
+        ? yield* Effect.tryPromise({
+            try: () => bulkApproveActions({ ids, user, orgId }),
+            catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+          })
+        : yield* Effect.tryPromise({
+            try: () => bulkDenyActions({ ids, user, orgId, reason }),
+            catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+          });
+
+      return c.json(result, 200);
+    }), { label: "bulk actions" });
+  },
+  (result, c) => {
+    if (!result.success) {
+      return c.json(
+        {
+          error: "validation_error",
+          message: "Invalid request body.",
+          details: result.error.issues,
+        },
         400,
       );
     }

--- a/packages/api/src/api/routes/actions.ts
+++ b/packages/api/src/api/routes/actions.ts
@@ -255,13 +255,15 @@ const BulkActionsResponseSchema = z.object({
   errors: z.array(z.object({ id: z.string(), error: z.string() })),
 });
 
+const BULK_REASON_MAX = 1000;
+
 const BulkActionsRequestSchema = z.object({
   ids: z
     .array(z.string().uuid("Each id must be a UUID"))
     .min(1, "ids must be a non-empty array")
     .max(BULK_ACTIONS_MAX, `Maximum ${BULK_ACTIONS_MAX} ids per bulk operation`),
   action: z.enum(["approve", "deny"]),
-  reason: z.string().optional(),
+  reason: z.string().max(BULK_REASON_MAX).optional(),
 });
 
 const bulkActionsRoute = createRoute({
@@ -562,11 +564,7 @@ actions.openapi(
 );
 
 // ---------------------------------------------------------------------------
-// POST /bulk — atomic bulk approve / deny
-//
-// Mounted before the /:id/* routes so Hono's router matches the literal
-// "bulk" segment. Returns aggregated result buckets so the web client can
-// drop its N-parallel-fetch + Promise.allSettled pattern (#1590).
+// POST /bulk — mounted before /:id/* so Hono matches the literal segment.
 // ---------------------------------------------------------------------------
 
 actions.openapi(
@@ -592,11 +590,11 @@ actions.openapi(
 
       const result = action === "approve"
         ? yield* Effect.tryPromise({
-            try: () => bulkApproveActions({ ids, user, orgId }),
+            try: () => bulkApproveActions({ ids, user, orgId, requestId }),
             catch: (err) => (err instanceof Error ? err : new Error(String(err))),
           })
         : yield* Effect.tryPromise({
-            try: () => bulkDenyActions({ ids, user, orgId, reason }),
+            try: () => bulkDenyActions({ ids, user, orgId, reason, requestId }),
             catch: (err) => (err instanceof Error ? err : new Error(String(err))),
           });
 

--- a/packages/api/src/lib/tools/actions/__tests__/bulk.test.ts
+++ b/packages/api/src/lib/tools/actions/__tests__/bulk.test.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import {
   handleAction,
   buildActionRequest,
+  getAction,
   _resetActionStore,
 } from "../handler";
+import * as handler from "../handler";
 import { bulkApproveActions, bulkDenyActions, BULK_ACTIONS_MAX } from "../bulk";
 import { _resetConfig, _setConfigForTest, type ResolvedConfig, type ActionsConfig } from "@atlas/api/lib/config";
 import { withRequestContext } from "@atlas/api/lib/logger";
@@ -41,13 +43,13 @@ afterEach(() => {
 });
 
 const admin = createAtlasUser("admin-1", "simple-key", "admin@test.com", { role: "admin" });
-const viewer = createAtlasUser("viewer-1", "simple-key", "viewer@test.com", { role: "viewer" });
+const member = createAtlasUser("member-1", "simple-key", "member@test.com", { role: "member" });
 
 function setActions(actions: ActionsConfig): void {
   _setConfigForTest({
     datasources: {},
     tools: [],
-    auth: { mode: "none" },
+    auth: "none",
     semanticLayer: "./semantic",
     maxTotalConnections: 20,
     actions,
@@ -79,31 +81,39 @@ describe("bulkApproveActions()", () => {
     const id1 = await seedPending("test:action", "alice");
     const id2 = await seedPending("test:action", "bob");
 
-    const result = await bulkApproveActions({ ids: [id1, id2], user: admin });
+    const result = await bulkApproveActions({ ids: [id1, id2], user: admin, orgId: null });
 
-    expect(result.updated.sort()).toEqual([id1, id2].sort());
+    expect([...result.updated].sort()).toEqual([id1, id2].sort());
     expect(result.notFound).toEqual([]);
     expect(result.forbidden).toEqual([]);
     expect(result.errors).toEqual([]);
+  });
+
+  it("transitions action_log row to status=approved (behavioral assertion)", async () => {
+    const id = await seedPending("test:action", "alice");
+
+    await bulkApproveActions({ ids: [id], user: admin, orgId: null });
+
+    const row = await getAction(id);
+    expect(row).not.toBeNull();
+    expect(row!.status).toBe("executed"); // executor ran synchronously for manual approval
   });
 
   it("classifies missing ids as notFound", async () => {
     const existing = await seedPending("test:action", "alice");
     const ghost = "deadbeef-dead-beef-dead-beefdeadbeef";
 
-    const result = await bulkApproveActions({ ids: [existing, ghost], user: admin });
+    const result = await bulkApproveActions({ ids: [existing, ghost], user: admin, orgId: null });
 
     expect(result.updated).toEqual([existing]);
     expect(result.notFound).toEqual([ghost]);
   });
 
   it("classifies permission-blocked ids as forbidden", async () => {
-    // Configure an action_type that requires admin approval
     setActions({ "admin:only": { approval: "admin-only" } });
     const id = await seedPending("admin:only", "alice");
 
-    // Viewer lacks the admin role → forbidden
-    const result = await bulkApproveActions({ ids: [id], user: viewer });
+    const result = await bulkApproveActions({ ids: [id], user: member, orgId: null });
 
     expect(result.forbidden).toEqual([id]);
     expect(result.updated).toEqual([]);
@@ -112,10 +122,9 @@ describe("bulkApproveActions()", () => {
 
   it("blocks self-approval of admin-only actions (separation of duties)", async () => {
     setActions({ "admin:only": { approval: "admin-only" } });
-    // Admin requested the action → cannot self-approve
     const id = await seedPending("admin:only", admin.id);
 
-    const result = await bulkApproveActions({ ids: [id], user: admin });
+    const result = await bulkApproveActions({ ids: [id], user: admin, orgId: null });
 
     expect(result.forbidden).toEqual([id]);
     expect(result.updated).toEqual([]);
@@ -124,12 +133,10 @@ describe("bulkApproveActions()", () => {
   it("reports already-resolved ids in errors (CAS conflict)", async () => {
     const id = await seedPending("test:action", "alice");
 
-    // First approval transitions status to approved
-    const first = await bulkApproveActions({ ids: [id], user: admin });
+    const first = await bulkApproveActions({ ids: [id], user: admin, orgId: null });
     expect(first.updated).toEqual([id]);
 
-    // Second approval races with the now-resolved row
-    const second = await bulkApproveActions({ ids: [id], user: admin });
+    const second = await bulkApproveActions({ ids: [id], user: admin, orgId: null });
     expect(second.updated).toEqual([]);
     expect(second.errors).toEqual([{ id, error: "Action has already been resolved." }]);
   });
@@ -140,13 +147,13 @@ describe("bulkApproveActions()", () => {
     const forbiddenId = await seedPending("admin:only", admin.id);
     const ghost = "deadbeef-dead-beef-dead-beefdeadbeef";
 
-    // Pre-resolve one id to create a CAS conflict
     const resolvedId = await seedPending("test:action", "alice");
-    await bulkApproveActions({ ids: [resolvedId], user: admin });
+    await bulkApproveActions({ ids: [resolvedId], user: admin, orgId: null });
 
     const result = await bulkApproveActions({
       ids: [okId, forbiddenId, ghost, resolvedId],
       user: admin,
+      orgId: null,
     });
 
     expect(result.updated).toEqual([okId]);
@@ -155,12 +162,107 @@ describe("bulkApproveActions()", () => {
     expect(result.errors).toEqual([{ id: resolvedId, error: "Action has already been resolved." }]);
   });
 
+  it("dedups duplicate ids so each id appears in exactly one bucket", async () => {
+    const id = await seedPending("test:action", "alice");
+
+    const result = await bulkApproveActions({
+      ids: [id, id, id],
+      user: admin,
+      orgId: null,
+    });
+
+    expect(result.updated).toEqual([id]);
+    expect(result.errors).toEqual([]);
+  });
+
   it("accepts an empty id list and returns empty buckets", async () => {
-    const result = await bulkApproveActions({ ids: [], user: admin });
+    const result = await bulkApproveActions({ ids: [], user: admin, orgId: null });
     expect(result.updated).toEqual([]);
     expect(result.notFound).toEqual([]);
     expect(result.forbidden).toEqual([]);
     expect(result.errors).toEqual([]);
+  });
+
+  it("surfaces a generic user-safe message when getAction throws during preClassify", async () => {
+    const id = await seedPending("test:action", "alice");
+
+    const spy = spyOn(handler, "getAction").mockImplementationOnce(() => {
+      throw new Error("SELECT failed: relation 'action_log' does not exist, schema=internal");
+    });
+
+    try {
+      const result = await bulkApproveActions({
+        ids: [id],
+        user: admin,
+        orgId: null,
+        requestId: "req-test",
+      });
+
+      expect(result.updated).toEqual([]);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].id).toBe(id);
+      // Raw pg error message must not leak to the caller.
+      expect(result.errors[0].error).toBe("Failed to resolve action.");
+      expect(result.errors[0].error).not.toContain("SELECT");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("surfaces a generic message when approveAction throws unexpectedly", async () => {
+    const id = await seedPending("test:action", "alice");
+
+    const spy = spyOn(handler, "approveAction").mockImplementationOnce(() => {
+      throw new Error("UPDATE failed: duplicate key value violates constraint on internal_log");
+    });
+
+    try {
+      const result = await bulkApproveActions({ ids: [id], user: admin, orgId: null });
+      expect(result.updated).toEqual([]);
+      expect(result.errors).toEqual([{ id, error: "Failed to resolve action." }]);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-org scoping (security invariant)
+// ---------------------------------------------------------------------------
+
+describe("bulk cross-org scoping", () => {
+  it("surfaces cross-org ids as notFound (not forbidden) to avoid leaking existence", async () => {
+    // Seed an action with org_id: "org-A" by mutating the in-memory row.
+    const id = await seedPending("test:action", "alice");
+    const row = await getAction(id);
+    expect(row).not.toBeNull();
+    (row as unknown as Record<string, unknown>).org_id = "org-A";
+
+    // Caller is in "org-B" — must see the id as notFound, never forbidden.
+    const result = await bulkApproveActions({
+      ids: [id],
+      user: admin,
+      orgId: "org-B",
+    });
+
+    expect(result.notFound).toEqual([id]);
+    expect(result.forbidden).toEqual([]);
+    expect(result.updated).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("allows ids whose org matches the caller's orgId", async () => {
+    const id = await seedPending("test:action", "alice");
+    const row = await getAction(id);
+    (row as unknown as Record<string, unknown>).org_id = "org-A";
+
+    const result = await bulkApproveActions({
+      ids: [id],
+      user: admin,
+      orgId: "org-A",
+    });
+
+    expect(result.updated).toEqual([id]);
   });
 });
 
@@ -176,20 +278,31 @@ describe("bulkDenyActions()", () => {
     const result = await bulkDenyActions({
       ids: [id1, id2],
       user: admin,
+      orgId: null,
       reason: "Not appropriate",
     });
 
-    expect(result.updated.sort()).toEqual([id1, id2].sort());
+    expect([...result.updated].sort()).toEqual([id1, id2].sort());
     expect(result.errors).toEqual([]);
+  });
+
+  it("transitions action_log row to status=denied (behavioral assertion)", async () => {
+    const id = await seedPending("test:action", "alice");
+
+    await bulkDenyActions({ ids: [id], user: admin, orgId: null, reason: "No." });
+
+    const row = await getAction(id);
+    expect(row!.status).toBe("denied");
+    expect(row!.error).toBe("No.");
   });
 
   it("treats a second deny on the same id as an already-resolved conflict", async () => {
     const id = await seedPending("test:action", "alice");
 
-    const first = await bulkDenyActions({ ids: [id], user: admin });
+    const first = await bulkDenyActions({ ids: [id], user: admin, orgId: null });
     expect(first.updated).toEqual([id]);
 
-    const second = await bulkDenyActions({ ids: [id], user: admin });
+    const second = await bulkDenyActions({ ids: [id], user: admin, orgId: null });
     expect(second.updated).toEqual([]);
     expect(second.errors).toEqual([{ id, error: "Action has already been resolved." }]);
   });
@@ -198,19 +311,26 @@ describe("bulkDenyActions()", () => {
     setActions({ "admin:only": { approval: "admin-only" } });
     const id = await seedPending("admin:only", "alice");
 
-    const result = await bulkDenyActions({ ids: [id], user: viewer });
+    const result = await bulkDenyActions({ ids: [id], user: member, orgId: null });
 
     expect(result.forbidden).toEqual([id]);
     expect(result.updated).toEqual([]);
   });
-});
 
-// ---------------------------------------------------------------------------
-// Limit
-// ---------------------------------------------------------------------------
+  it("dedups duplicate ids", async () => {
+    const id = await seedPending("test:action", "alice");
 
-describe("BULK_ACTIONS_MAX", () => {
-  it("matches the documented ceiling in the issue", () => {
-    expect(BULK_ACTIONS_MAX).toBe(100);
+    const result = await bulkDenyActions({
+      ids: [id, id],
+      user: admin,
+      orgId: null,
+    });
+
+    expect(result.updated).toEqual([id]);
+    expect(result.errors).toEqual([]);
   });
 });
+
+// BULK_ACTIONS_MAX is exercised by the route-layer 400 test in actions.test.ts —
+// no self-referential unit check here.
+void BULK_ACTIONS_MAX;

--- a/packages/api/src/lib/tools/actions/__tests__/bulk.test.ts
+++ b/packages/api/src/lib/tools/actions/__tests__/bulk.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import {
+  handleAction,
+  buildActionRequest,
+  _resetActionStore,
+} from "../handler";
+import { bulkApproveActions, bulkDenyActions, BULK_ACTIONS_MAX } from "../bulk";
+import { _resetConfig, _setConfigForTest, type ResolvedConfig, type ActionsConfig } from "@atlas/api/lib/config";
+import { withRequestContext } from "@atlas/api/lib/logger";
+import { _resetPool } from "@atlas/api/lib/db/internal";
+import { createAtlasUser } from "@atlas/api/lib/auth/types";
+
+/**
+ * Bulk approve / deny service tests — memory-only path (no DATABASE_URL).
+ *
+ * Follows the pattern in handler.test.ts: delete DATABASE_URL + reset the
+ * pg pool so the in-memory fallback is exercised. No DB mock necessary.
+ */
+
+const origDbUrl = process.env.DATABASE_URL;
+
+beforeEach(() => {
+  delete process.env.DATABASE_URL;
+  delete process.env.ATLAS_ACTIONS_ENABLED;
+  delete process.env.ATLAS_ACTION_APPROVAL;
+  delete process.env.ATLAS_ACTION_TIMEOUT;
+  _resetPool(null);
+  _resetActionStore();
+  _resetConfig();
+});
+
+afterEach(() => {
+  delete process.env.ATLAS_ACTIONS_ENABLED;
+  delete process.env.ATLAS_ACTION_APPROVAL;
+  delete process.env.ATLAS_ACTION_TIMEOUT;
+  if (origDbUrl) process.env.DATABASE_URL = origDbUrl;
+  else delete process.env.DATABASE_URL;
+  _resetPool(null);
+  _resetActionStore();
+  _resetConfig();
+});
+
+const admin = createAtlasUser("admin-1", "simple-key", "admin@test.com", { role: "admin" });
+const viewer = createAtlasUser("viewer-1", "simple-key", "viewer@test.com", { role: "viewer" });
+
+function setActions(actions: ActionsConfig): void {
+  _setConfigForTest({
+    datasources: {},
+    tools: [],
+    auth: { mode: "none" },
+    semanticLayer: "./semantic",
+    maxTotalConnections: 20,
+    actions,
+    source: "env",
+  } as ResolvedConfig);
+}
+
+async function seedPending(actionType: string, requestedBy: string): Promise<string> {
+  const req = buildActionRequest({
+    actionType,
+    target: `target-${Math.random()}`,
+    summary: "Test action",
+    payload: {},
+    reversible: false,
+  });
+  await withRequestContext(
+    { requestId: "req-seed", user: { id: requestedBy, label: `${requestedBy}@test.com`, mode: "simple-key" } },
+    () => handleAction(req, async () => "done"),
+  );
+  return req.id;
+}
+
+// ---------------------------------------------------------------------------
+// bulkApproveActions
+// ---------------------------------------------------------------------------
+
+describe("bulkApproveActions()", () => {
+  it("approves multiple pending actions and returns them in `updated`", async () => {
+    const id1 = await seedPending("test:action", "alice");
+    const id2 = await seedPending("test:action", "bob");
+
+    const result = await bulkApproveActions({ ids: [id1, id2], user: admin });
+
+    expect(result.updated.sort()).toEqual([id1, id2].sort());
+    expect(result.notFound).toEqual([]);
+    expect(result.forbidden).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("classifies missing ids as notFound", async () => {
+    const existing = await seedPending("test:action", "alice");
+    const ghost = "deadbeef-dead-beef-dead-beefdeadbeef";
+
+    const result = await bulkApproveActions({ ids: [existing, ghost], user: admin });
+
+    expect(result.updated).toEqual([existing]);
+    expect(result.notFound).toEqual([ghost]);
+  });
+
+  it("classifies permission-blocked ids as forbidden", async () => {
+    // Configure an action_type that requires admin approval
+    setActions({ "admin:only": { approval: "admin-only" } });
+    const id = await seedPending("admin:only", "alice");
+
+    // Viewer lacks the admin role → forbidden
+    const result = await bulkApproveActions({ ids: [id], user: viewer });
+
+    expect(result.forbidden).toEqual([id]);
+    expect(result.updated).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("blocks self-approval of admin-only actions (separation of duties)", async () => {
+    setActions({ "admin:only": { approval: "admin-only" } });
+    // Admin requested the action → cannot self-approve
+    const id = await seedPending("admin:only", admin.id);
+
+    const result = await bulkApproveActions({ ids: [id], user: admin });
+
+    expect(result.forbidden).toEqual([id]);
+    expect(result.updated).toEqual([]);
+  });
+
+  it("reports already-resolved ids in errors (CAS conflict)", async () => {
+    const id = await seedPending("test:action", "alice");
+
+    // First approval transitions status to approved
+    const first = await bulkApproveActions({ ids: [id], user: admin });
+    expect(first.updated).toEqual([id]);
+
+    // Second approval races with the now-resolved row
+    const second = await bulkApproveActions({ ids: [id], user: admin });
+    expect(second.updated).toEqual([]);
+    expect(second.errors).toEqual([{ id, error: "Action has already been resolved." }]);
+  });
+
+  it("mixes all four buckets in one call", async () => {
+    setActions({ "admin:only": { approval: "admin-only" } });
+    const okId = await seedPending("test:action", "alice");
+    const forbiddenId = await seedPending("admin:only", admin.id);
+    const ghost = "deadbeef-dead-beef-dead-beefdeadbeef";
+
+    // Pre-resolve one id to create a CAS conflict
+    const resolvedId = await seedPending("test:action", "alice");
+    await bulkApproveActions({ ids: [resolvedId], user: admin });
+
+    const result = await bulkApproveActions({
+      ids: [okId, forbiddenId, ghost, resolvedId],
+      user: admin,
+    });
+
+    expect(result.updated).toEqual([okId]);
+    expect(result.forbidden).toEqual([forbiddenId]);
+    expect(result.notFound).toEqual([ghost]);
+    expect(result.errors).toEqual([{ id: resolvedId, error: "Action has already been resolved." }]);
+  });
+
+  it("accepts an empty id list and returns empty buckets", async () => {
+    const result = await bulkApproveActions({ ids: [], user: admin });
+    expect(result.updated).toEqual([]);
+    expect(result.notFound).toEqual([]);
+    expect(result.forbidden).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bulkDenyActions
+// ---------------------------------------------------------------------------
+
+describe("bulkDenyActions()", () => {
+  it("denies multiple pending actions and records the reason on each", async () => {
+    const id1 = await seedPending("test:action", "alice");
+    const id2 = await seedPending("test:action", "bob");
+
+    const result = await bulkDenyActions({
+      ids: [id1, id2],
+      user: admin,
+      reason: "Not appropriate",
+    });
+
+    expect(result.updated.sort()).toEqual([id1, id2].sort());
+    expect(result.errors).toEqual([]);
+  });
+
+  it("treats a second deny on the same id as an already-resolved conflict", async () => {
+    const id = await seedPending("test:action", "alice");
+
+    const first = await bulkDenyActions({ ids: [id], user: admin });
+    expect(first.updated).toEqual([id]);
+
+    const second = await bulkDenyActions({ ids: [id], user: admin });
+    expect(second.updated).toEqual([]);
+    expect(second.errors).toEqual([{ id, error: "Action has already been resolved." }]);
+  });
+
+  it("blocks permission-denied ids before calling denyAction", async () => {
+    setActions({ "admin:only": { approval: "admin-only" } });
+    const id = await seedPending("admin:only", "alice");
+
+    const result = await bulkDenyActions({ ids: [id], user: viewer });
+
+    expect(result.forbidden).toEqual([id]);
+    expect(result.updated).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Limit
+// ---------------------------------------------------------------------------
+
+describe("BULK_ACTIONS_MAX", () => {
+  it("matches the documented ceiling in the issue", () => {
+    expect(BULK_ACTIONS_MAX).toBe(100);
+  });
+});

--- a/packages/api/src/lib/tools/actions/bulk.ts
+++ b/packages/api/src/lib/tools/actions/bulk.ts
@@ -1,19 +1,8 @@
 /**
  * Bulk approve / deny for the action approval queue.
  *
- * Pre-classifies each requested id into one of four buckets — updated,
- * notFound, forbidden, or errors — before delegating the actual state
- * transition to the existing single-action approveAction / denyAction
- * helpers. Each inner call already performs CAS (WHERE status = 'pending'
- * RETURNING *) for row-level atomicity; aggregated response shape is what
- * replaces the web client's Promise.allSettled pattern.
- *
- * Per-action permission is enforced via canApprove() with the same role
- * rules as the single-action routes, plus admin-only separation-of-duties
- * (requester cannot resolve their own admin-only action).
- *
- * Org-scoped: ids belonging to a different org are returned as notFound so
- * cross-org identifiers never surface as forbidden or leak action metadata.
+ * Org scope: rows belonging to a different org surface as `notFound`, never
+ * `forbidden` — cross-org identifiers must not leak existence or type.
  */
 
 import type { AtlasUser } from "@atlas/api/lib/auth/types";
@@ -29,12 +18,15 @@ import {
 
 const log = createLogger("action-bulk");
 
-// ── Limits ──────────────────────────────────────────────────────────
-
-/** Hard cap matches learned-patterns bulk ceiling (#1590). */
 export const BULK_ACTIONS_MAX = 100;
 
-// ── Result shape ────────────────────────────────────────────────────
+/**
+ * Client-facing message returned when an unexpected error is caught. Raw
+ * `err.message` values from `pg` / downstream services can contain schema
+ * names or parameter values, so callers get this generic string and the
+ * real message goes only to the log.
+ */
+const GENERIC_RESOLVE_ERROR = "Failed to resolve action.";
 
 export interface BulkActionError {
   readonly id: string;
@@ -42,62 +34,90 @@ export interface BulkActionError {
 }
 
 /**
- * Aligned with the web client's `bulkPartialSummary` contract (learned-patterns
- * reuse) plus a `forbidden` bucket specific to the action queue's per-row
- * permission model. `updated` + `notFound` + `forbidden` + `errors` covers every
- * requested id exactly once.
+ * `updated` + `notFound` + `forbidden` + `errors.map(e => e.id)` partition every
+ * requested id exactly once. Invariant holds by construction because
+ * `preClassify` dedups inputs and each id takes exactly one branch.
  */
 export interface BulkActionsResult {
-  readonly updated: string[];
-  readonly notFound: string[];
-  readonly forbidden: string[];
-  readonly errors: BulkActionError[];
+  updated: string[];
+  notFound: string[];
+  forbidden: string[];
+  errors: BulkActionError[];
 }
-
-// ── Input shape ─────────────────────────────────────────────────────
 
 export interface BulkApproveInput {
   readonly ids: readonly string[];
   readonly user: AtlasUser | undefined;
-  readonly orgId?: string | null;
+  readonly orgId: string | null;
+  /** Forwarded to logs so per-row failures correlate with the originating HTTP request. */
+  readonly requestId?: string;
 }
 
-export interface BulkDenyInput extends BulkApproveInput {
+export interface BulkDenyInput {
+  readonly ids: readonly string[];
+  readonly user: AtlasUser | undefined;
+  readonly orgId: string | null;
   readonly reason?: string;
+  readonly requestId?: string;
 }
-
-// ── Classification ──────────────────────────────────────────────────
 
 type PreClassification = {
   eligible: string[];
   notFound: string[];
   forbidden: string[];
+  /** Errors captured during pre-classification (getAction throws). */
+  errors: BulkActionError[];
 };
 
 /**
- * Resolve each id to { eligible, notFound, forbidden } before the write loop.
- * Eligible = exists, caller has the right role, and (for admin-only actions)
- * caller is not the requester.
+ * Resolve each id into one of eligible / notFound / forbidden / errors.
+ * Eligible = exists in the caller's org, caller has the right role, and
+ * (for admin-only actions) caller is not the requester.
+ *
+ * Dedup is applied up front so the partition invariant holds by construction
+ * even when callers pass duplicate ids.
  */
 async function preClassify(
   ids: readonly string[],
   user: AtlasUser | undefined,
-  orgId: string | null | undefined,
+  orgId: string | null,
+  requestId: string | undefined,
 ): Promise<PreClassification> {
+  const uniqueIds: string[] = [];
+  const seen = new Set<string>();
+  for (const id of ids) {
+    if (!seen.has(id)) {
+      seen.add(id);
+      uniqueIds.push(id);
+    }
+  }
+
   const eligible: string[] = [];
   const notFound: string[] = [];
   const forbidden: string[] = [];
+  const errors: BulkActionError[] = [];
 
-  for (const id of ids) {
-    const action = await getAction(id);
+  for (const id of uniqueIds) {
+    let action;
+    try {
+      action = await getAction(id);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.error(
+        { err: message, actionId: id, orgId, userId: user?.id, requestId },
+        "Bulk preClassify failed to read action",
+      );
+      errors.push({ id, error: GENERIC_RESOLVE_ERROR });
+      continue;
+    }
     if (!action) {
       notFound.push(id);
       continue;
     }
-    // Org scope: a row belonging to a different org must look like "not found"
-    // rather than "forbidden" so cross-org ids never leak existence or type.
     // `org_id` is present on the action_log row (schema.ts) but not yet
-    // surfaced in ActionLogEntry; read defensively via record access.
+    // surfaced on `ActionLogEntry`; read defensively via record access.
+    // Missing / null org_id disables the filter — matches the single-action
+    // endpoints' behavior for rows written before org-scoping existed.
     const rowOrgId = (action as unknown as Record<string, unknown>).org_id;
     if (orgId && typeof rowOrgId === "string" && rowOrgId !== orgId) {
       notFound.push(id);
@@ -116,75 +136,86 @@ async function preClassify(
     eligible.push(id);
   }
 
-  return { eligible, notFound, forbidden };
+  return { eligible, notFound, forbidden, errors };
 }
 
-// ── Public API ──────────────────────────────────────────────────────
-
-/**
- * Approve many pending actions. For each eligible id, delegates to
- * approveAction() which performs the CAS write and runs the registered
- * executor. Ids that race a conflicting resolve land in `errors` with
- * "Action has already been resolved."
- */
 export async function bulkApproveActions(
   input: BulkApproveInput,
 ): Promise<BulkActionsResult> {
-  const { ids, user, orgId } = input;
+  const { ids, user, orgId, requestId } = input;
   const approverId = user?.id ?? "anonymous";
 
-  const { eligible, notFound, forbidden } = await preClassify(ids, user, orgId);
+  const { eligible, notFound, forbidden, errors: preErrors } = await preClassify(
+    ids,
+    user,
+    orgId,
+    requestId,
+  );
 
   const updated: string[] = [];
-  const errors: BulkActionError[] = [];
+  const errors: BulkActionError[] = [...preErrors];
 
   for (const id of eligible) {
     try {
       const executor = getActionExecutor(id);
       const result = await approveAction(id, approverId, executor);
       if (result === null) {
+        log.warn(
+          { actionId: id, orgId, userId: user?.id, requestId },
+          "Bulk approve lost CAS race — action already resolved",
+        );
         errors.push({ id, error: "Action has already been resolved." });
       } else {
         updated.push(id);
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      log.warn({ err: message, actionId: id }, "Bulk approve failed for action");
-      errors.push({ id, error: message });
+      log.error(
+        { err: message, actionId: id, orgId, userId: user?.id, requestId },
+        "Bulk approve threw for action",
+      );
+      errors.push({ id, error: GENERIC_RESOLVE_ERROR });
     }
   }
 
   return { updated, notFound, forbidden, errors };
 }
 
-/**
- * Deny many pending actions. Reason (if supplied) is recorded on every
- * denied row — callers must enforce reason-presence policy at the route
- * layer if required.
- */
 export async function bulkDenyActions(
   input: BulkDenyInput,
 ): Promise<BulkActionsResult> {
-  const { ids, user, orgId, reason } = input;
+  const { ids, user, orgId, reason, requestId } = input;
   const denierId = user?.id ?? "anonymous";
 
-  const { eligible, notFound, forbidden } = await preClassify(ids, user, orgId);
+  const { eligible, notFound, forbidden, errors: preErrors } = await preClassify(
+    ids,
+    user,
+    orgId,
+    requestId,
+  );
 
   const updated: string[] = [];
-  const errors: BulkActionError[] = [];
+  const errors: BulkActionError[] = [...preErrors];
 
   for (const id of eligible) {
     try {
       const result = await denyAction(id, denierId, reason);
       if (result === null) {
+        log.warn(
+          { actionId: id, orgId, userId: user?.id, requestId },
+          "Bulk deny lost CAS race — action already resolved",
+        );
         errors.push({ id, error: "Action has already been resolved." });
       } else {
         updated.push(id);
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      log.warn({ err: message, actionId: id }, "Bulk deny failed for action");
-      errors.push({ id, error: message });
+      log.error(
+        { err: message, actionId: id, orgId, userId: user?.id, requestId },
+        "Bulk deny threw for action",
+      );
+      errors.push({ id, error: GENERIC_RESOLVE_ERROR });
     }
   }
 

--- a/packages/api/src/lib/tools/actions/bulk.ts
+++ b/packages/api/src/lib/tools/actions/bulk.ts
@@ -1,0 +1,192 @@
+/**
+ * Bulk approve / deny for the action approval queue.
+ *
+ * Pre-classifies each requested id into one of four buckets — updated,
+ * notFound, forbidden, or errors — before delegating the actual state
+ * transition to the existing single-action approveAction / denyAction
+ * helpers. Each inner call already performs CAS (WHERE status = 'pending'
+ * RETURNING *) for row-level atomicity; aggregated response shape is what
+ * replaces the web client's Promise.allSettled pattern.
+ *
+ * Per-action permission is enforced via canApprove() with the same role
+ * rules as the single-action routes, plus admin-only separation-of-duties
+ * (requester cannot resolve their own admin-only action).
+ *
+ * Org-scoped: ids belonging to a different org are returned as notFound so
+ * cross-org identifiers never surface as forbidden or leak action metadata.
+ */
+
+import type { AtlasUser } from "@atlas/api/lib/auth/types";
+import { canApprove } from "@atlas/api/lib/auth/permissions";
+import { createLogger } from "@atlas/api/lib/logger";
+import {
+  approveAction,
+  denyAction,
+  getAction,
+  getActionConfig,
+  getActionExecutor,
+} from "./handler";
+
+const log = createLogger("action-bulk");
+
+// ── Limits ──────────────────────────────────────────────────────────
+
+/** Hard cap matches learned-patterns bulk ceiling (#1590). */
+export const BULK_ACTIONS_MAX = 100;
+
+// ── Result shape ────────────────────────────────────────────────────
+
+export interface BulkActionError {
+  readonly id: string;
+  readonly error: string;
+}
+
+/**
+ * Aligned with the web client's `bulkPartialSummary` contract (learned-patterns
+ * reuse) plus a `forbidden` bucket specific to the action queue's per-row
+ * permission model. `updated` + `notFound` + `forbidden` + `errors` covers every
+ * requested id exactly once.
+ */
+export interface BulkActionsResult {
+  readonly updated: string[];
+  readonly notFound: string[];
+  readonly forbidden: string[];
+  readonly errors: BulkActionError[];
+}
+
+// ── Input shape ─────────────────────────────────────────────────────
+
+export interface BulkApproveInput {
+  readonly ids: readonly string[];
+  readonly user: AtlasUser | undefined;
+  readonly orgId?: string | null;
+}
+
+export interface BulkDenyInput extends BulkApproveInput {
+  readonly reason?: string;
+}
+
+// ── Classification ──────────────────────────────────────────────────
+
+type PreClassification = {
+  eligible: string[];
+  notFound: string[];
+  forbidden: string[];
+};
+
+/**
+ * Resolve each id to { eligible, notFound, forbidden } before the write loop.
+ * Eligible = exists, caller has the right role, and (for admin-only actions)
+ * caller is not the requester.
+ */
+async function preClassify(
+  ids: readonly string[],
+  user: AtlasUser | undefined,
+  orgId: string | null | undefined,
+): Promise<PreClassification> {
+  const eligible: string[] = [];
+  const notFound: string[] = [];
+  const forbidden: string[] = [];
+
+  for (const id of ids) {
+    const action = await getAction(id);
+    if (!action) {
+      notFound.push(id);
+      continue;
+    }
+    // Org scope: a row belonging to a different org must look like "not found"
+    // rather than "forbidden" so cross-org ids never leak existence or type.
+    // `org_id` is present on the action_log row (schema.ts) but not yet
+    // surfaced in ActionLogEntry; read defensively via record access.
+    const rowOrgId = (action as unknown as Record<string, unknown>).org_id;
+    if (orgId && typeof rowOrgId === "string" && rowOrgId !== orgId) {
+      notFound.push(id);
+      continue;
+    }
+
+    const cfg = getActionConfig(action.action_type);
+    if (!canApprove(user, cfg.approval, cfg.requiredRole)) {
+      forbidden.push(id);
+      continue;
+    }
+    if (cfg.approval === "admin-only" && user?.id === action.requested_by) {
+      forbidden.push(id);
+      continue;
+    }
+    eligible.push(id);
+  }
+
+  return { eligible, notFound, forbidden };
+}
+
+// ── Public API ──────────────────────────────────────────────────────
+
+/**
+ * Approve many pending actions. For each eligible id, delegates to
+ * approveAction() which performs the CAS write and runs the registered
+ * executor. Ids that race a conflicting resolve land in `errors` with
+ * "Action has already been resolved."
+ */
+export async function bulkApproveActions(
+  input: BulkApproveInput,
+): Promise<BulkActionsResult> {
+  const { ids, user, orgId } = input;
+  const approverId = user?.id ?? "anonymous";
+
+  const { eligible, notFound, forbidden } = await preClassify(ids, user, orgId);
+
+  const updated: string[] = [];
+  const errors: BulkActionError[] = [];
+
+  for (const id of eligible) {
+    try {
+      const executor = getActionExecutor(id);
+      const result = await approveAction(id, approverId, executor);
+      if (result === null) {
+        errors.push({ id, error: "Action has already been resolved." });
+      } else {
+        updated.push(id);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn({ err: message, actionId: id }, "Bulk approve failed for action");
+      errors.push({ id, error: message });
+    }
+  }
+
+  return { updated, notFound, forbidden, errors };
+}
+
+/**
+ * Deny many pending actions. Reason (if supplied) is recorded on every
+ * denied row — callers must enforce reason-presence policy at the route
+ * layer if required.
+ */
+export async function bulkDenyActions(
+  input: BulkDenyInput,
+): Promise<BulkActionsResult> {
+  const { ids, user, orgId, reason } = input;
+  const denierId = user?.id ?? "anonymous";
+
+  const { eligible, notFound, forbidden } = await preClassify(ids, user, orgId);
+
+  const updated: string[] = [];
+  const errors: BulkActionError[] = [];
+
+  for (const id of eligible) {
+    try {
+      const result = await denyAction(id, denierId, reason);
+      if (result === null) {
+        errors.push({ id, error: "Action has already been resolved." });
+      } else {
+        updated.push(id);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn({ err: message, actionId: id }, "Bulk deny failed for action");
+      errors.push({ id, error: message });
+    }
+  }
+
+  return { updated, notFound, forbidden, errors };
+}


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/actions/bulk` so `/admin/actions` can stop firing N parallel HTTP requests + reading results back through `Promise.allSettled`. One auth check, one rate-limit check, one aggregated response.
- Pre-classifies every requested id into exactly one of four buckets — `updated`, `notFound`, `forbidden`, `errors` — before delegating the actual state transition to the existing `approveAction` / `denyAction` CAS writes. Per-action permission rules match the single-action routes (`canApprove` + admin-only separation-of-duties).
- Org-scoped: rows belonging to a different workspace surface as `notFound` rather than `forbidden`, so cross-org ids never leak action metadata.

### Wire format

```ts
// POST /api/v1/actions/bulk
{
  ids: string[],                    // 1..100 UUIDs
  action: "approve" | "deny",
  reason?: string                   // recorded on every denied row
}

// 200 OK
{
  updated: string[],                            // transitioned to approved/denied
  notFound: string[],                           // not in DB or belongs to another org
  forbidden: string[],                          // caller lacks role / is self on admin-only
  errors: { id: string; error: string }[]       // CAS conflicts (already resolved) + unexpected failures
}
```

Shape aligns with the existing `bulkPartialSummary` contract on the web side (learned-patterns bulk endpoint reuse) plus a `forbidden` bucket specific to the action queue's per-row permission model.

## Design notes

- **Why a loop over `approveAction` / `denyAction` instead of a single UPDATE?** Each single-action call already performs atomic CAS (`WHERE status = 'pending' RETURNING *`) and, for approve, runs the registered executor. Running a single UPDATE would skip executor invocation and leave actions stranded in `approved` state without execution. The atomicity the issue asks for is in the aggregated response shape (replacing `Promise.allSettled`), not a literal DB transaction.
- **Why classify before writing?** Forbidden checks depend on static per-type config, so we can reject permission-denied ids cleanly up front without surfacing a misleading "Already resolved" error.
- **Max 100 ids per request** matches the learned-patterns bulk ceiling (`BULK_ACTIONS_MAX`).

## Follow-ups (not in this PR)

- Web migration of `/admin/actions` to the new endpoint (bucket-1 queue revamp).
- Single-action `/approve` and `/deny` do not currently scope by `org_id`; this PR adds org-scoping only on the bulk path. Retrofitting single is worth a follow-up issue.

## Test plan

- [x] `bun run test packages/api/src/lib/tools/actions/__tests__/bulk.test.ts` — 11 new service unit tests covering all four buckets + self-approval + CAS conflict + mixed scenario
- [x] `bun run test packages/api/src/api/__tests__/actions.test.ts` — 12 new route integration tests covering happy path, every 4xx, 500 with requestId, orgId plumbing, dispatch to approve vs deny
- [x] Full suite green (`bun run test`)
- [x] Lint, type, syncpack, template drift all pass
- [x] `bun run --filter '@atlas/api' openapi:extract` — bulk route appears in `apps/docs/openapi.json` under `/api/v1/actions/bulk`

Closes #1590