### PR TITLE
fix(web/admin/queue): ReasonDialog surfaces thrown onConfirm as local error

### DIFF
--- a/packages/web/src/ui/__tests__/reason-dialog.test.tsx
+++ b/packages/web/src/ui/__tests__/reason-dialog.test.tsx
@@ -3,10 +3,16 @@ import { render, screen, cleanup, fireEvent, act } from "@testing-library/react"
 import { ReasonDialog } from "../components/admin/queue";
 
 /**
- * Regression guard for the compliance contract: the reason captured in
- * the audit log must be exactly what the user typed (whitespace-trimmed),
- * including the empty string. The dialog must NOT substitute a
- * hardcoded placeholder like "Denied by admin".
+ * Regression guards for two invariants this dialog owns:
+ *
+ * 1. Compliance contract — the reason captured in the audit log must be
+ *    exactly what the user typed (whitespace-trimmed), including the
+ *    empty string. The dialog must NOT substitute a hardcoded
+ *    placeholder like "Denied by admin".
+ *
+ * 2. Error surfacing — a throwing `onConfirm` must be visible to the
+ *    operator (alert + dialog stays mounted) and still reach
+ *    observability, rather than failing silently.
  */
 
 afterEach(() => cleanup());
@@ -26,7 +32,7 @@ function renderDialog(props: Partial<React.ComponentProps<typeof ReasonDialog>> 
   return { onConfirm, onOpenChange, ...utils };
 }
 
-describe("ReasonDialog compliance contract", () => {
+describe("ReasonDialog", () => {
   test("empty textarea → onConfirm receives empty string, not a placeholder", async () => {
     const { onConfirm } = renderDialog();
 
@@ -239,6 +245,41 @@ describe("ReasonDialog compliance contract", () => {
     );
 
     expect(screen.queryByRole("alert")).toBeNull();
+    warnSpy.mockRestore();
+  });
+
+  test("retry after failure clears localError within the same open session", async () => {
+    // First call rejects, second resolves — simulates the operator fixing
+    // the reason and retrying without closing the dialog.
+    let attempt = 0;
+    const onConfirm = mock(() => {
+      attempt++;
+      return attempt === 1 ? Promise.reject(new Error("boom")) : Promise.resolve();
+    });
+    const warnSpy = (await import("bun:test")).spyOn(console, "warn").mockImplementation(() => {});
+
+    render(
+      <ReasonDialog
+        open
+        onOpenChange={() => {}}
+        title="Deny action"
+        onConfirm={onConfirm}
+      />,
+    );
+
+    const confirm = screen.getByRole("button", { name: /deny/i });
+    await act(async () => {
+      fireEvent.click(confirm);
+    });
+    expect(screen.getByRole("alert").textContent).toBe("Unexpected error: boom");
+
+    // Retry — alert must clear at the start of the new attempt, not linger
+    // behind a now-succeeding call.
+    await act(async () => {
+      fireEvent.click(confirm);
+    });
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(onConfirm).toHaveBeenCalledTimes(2);
     warnSpy.mockRestore();
   });
 });

--- a/packages/web/src/ui/__tests__/reason-dialog.test.tsx
+++ b/packages/web/src/ui/__tests__/reason-dialog.test.tsx
@@ -116,10 +116,40 @@ describe("ReasonDialog compliance contract", () => {
     expect(screen.getByLabelText(/reason/i)).not.toBeNull();
   });
 
-  test("onConfirm throwing does not bubble — dialog catches and logs", async () => {
-    const thrown = new Error("kaboom");
+  test("onConfirm throwing surfaces in alert AND logs — dialog stays open", async () => {
+    const thrown = new Error("boom");
     const onConfirm = mock(() => Promise.reject(thrown));
-    const errSpy = (await import("bun:test")).spyOn(console, "error").mockImplementation(() => {});
+    const onOpenChange = mock((_open: boolean) => {});
+    const warnSpy = (await import("bun:test")).spyOn(console, "warn").mockImplementation(() => {});
+
+    render(
+      <ReasonDialog
+        open
+        onOpenChange={onOpenChange}
+        title="Deny action"
+        onConfirm={onConfirm}
+      />,
+    );
+
+    const confirm = screen.getByRole("button", { name: /deny/i });
+    await act(async () => {
+      fireEvent.click(confirm);
+    });
+
+    expect(onConfirm).toHaveBeenCalled();
+    // UI surface — operator sees the failure
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toBe("Unexpected error: boom");
+    // Dialog must NOT close on its own — caller owns close via onOpenChange
+    expect(onOpenChange).not.toHaveBeenCalled();
+    // Observability — still reaches dev tools
+    expect(warnSpy).toHaveBeenCalledWith("ReasonDialog: onConfirm threw", thrown);
+    warnSpy.mockRestore();
+  });
+
+  test("onConfirm rejecting non-Error → stringified in alert", async () => {
+    const onConfirm = mock(() => Promise.reject("raw string"));
+    const warnSpy = (await import("bun:test")).spyOn(console, "warn").mockImplementation(() => {});
 
     render(
       <ReasonDialog
@@ -135,11 +165,80 @@ describe("ReasonDialog compliance contract", () => {
       fireEvent.click(confirm);
     });
 
-    expect(onConfirm).toHaveBeenCalled();
-    expect(errSpy).toHaveBeenCalledWith(
-      "ReasonDialog: onConfirm threw",
-      thrown,
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toBe("Unexpected error: raw string");
+    warnSpy.mockRestore();
+  });
+
+  test("localError takes precedence over caller-provided error prop", async () => {
+    const thrown = new Error("local failure");
+    const onConfirm = mock(() => Promise.reject(thrown));
+    const warnSpy = (await import("bun:test")).spyOn(console, "warn").mockImplementation(() => {});
+
+    render(
+      <ReasonDialog
+        open
+        onOpenChange={() => {}}
+        title="Deny action"
+        onConfirm={onConfirm}
+        error="caller-provided error"
+      />,
     );
-    errSpy.mockRestore();
+
+    // Before confirm — caller error shows
+    expect(screen.getByRole("alert").textContent).toBe("caller-provided error");
+
+    const confirm = screen.getByRole("button", { name: /deny/i });
+    await act(async () => {
+      fireEvent.click(confirm);
+    });
+
+    // After throw — local error takes over
+    expect(screen.getByRole("alert").textContent).toBe("Unexpected error: local failure");
+    warnSpy.mockRestore();
+  });
+
+  test("localError cleared when dialog reopens", async () => {
+    const thrown = new Error("first attempt");
+    const onConfirm = mock(() => Promise.reject(thrown));
+    const warnSpy = (await import("bun:test")).spyOn(console, "warn").mockImplementation(() => {});
+
+    const { rerender } = render(
+      <ReasonDialog
+        open
+        onOpenChange={() => {}}
+        title="Deny action"
+        onConfirm={onConfirm}
+      />,
+    );
+
+    const confirm = screen.getByRole("button", { name: /deny/i });
+    await act(async () => {
+      fireEvent.click(confirm);
+    });
+    expect(screen.getByRole("alert").textContent).toBe("Unexpected error: first attempt");
+
+    // Close
+    rerender(
+      <ReasonDialog
+        open={false}
+        onOpenChange={() => {}}
+        title="Deny action"
+        onConfirm={onConfirm}
+      />,
+    );
+
+    // Reopen — alert should be gone
+    rerender(
+      <ReasonDialog
+        open
+        onOpenChange={() => {}}
+        title="Deny action"
+        onConfirm={onConfirm}
+      />,
+    );
+
+    expect(screen.queryByRole("alert")).toBeNull();
+    warnSpy.mockRestore();
   });
 });

--- a/packages/web/src/ui/components/admin/queue/reason-dialog.tsx
+++ b/packages/web/src/ui/components/admin/queue/reason-dialog.tsx
@@ -77,9 +77,10 @@ export function ReasonDialog({
     try {
       await onConfirm(trimmed);
     } catch (err) {
-      // Caller bug — their onConfirm leaked an exception instead of
-      // setting the error prop. Surface to the operator so the dialog
-      // doesn't appear to stall, and log so observability still sees it.
+      // Caller bug — onConfirm rejected instead of resolving and
+      // surfacing the failure through the parent's `error` prop. Show
+      // it here so the dialog doesn't appear to stall, and log so
+      // observability still sees it.
       const msg = err instanceof Error ? err.message : String(err);
       setLocalError(`Unexpected error: ${msg}`);
       console.warn("ReasonDialog: onConfirm threw", err);

--- a/packages/web/src/ui/components/admin/queue/reason-dialog.tsx
+++ b/packages/web/src/ui/components/admin/queue/reason-dialog.tsx
@@ -57,24 +57,32 @@ export function ReasonDialog({
   error,
 }: ReasonDialogProps) {
   const [reason, setReason] = useState("");
+  const [localError, setLocalError] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   useEffect(() => {
-    if (!open) setReason("");
+    if (!open) {
+      setReason("");
+      setLocalError(null);
+    }
   }, [open]);
 
   const trimmed = reason.trim();
   const canConfirm = required ? trimmed.length > 0 : true;
+  const displayError = localError ?? error;
 
   async function handleConfirm() {
     if (!canConfirm) return;
+    setLocalError(null);
     try {
       await onConfirm(trimmed);
     } catch (err) {
-      // Never silently swallow — parent's loading/error state owns the
-      // surface, but a throwing onConfirm is a bug in the caller, not the
-      // dialog. Log so dev tools pick it up.
-      console.error("ReasonDialog: onConfirm threw", err);
+      // Caller bug — their onConfirm leaked an exception instead of
+      // setting the error prop. Surface to the operator so the dialog
+      // doesn't appear to stall, and log so observability still sees it.
+      const msg = err instanceof Error ? err.message : String(err);
+      setLocalError(`Unexpected error: ${msg}`);
+      console.warn("ReasonDialog: onConfirm threw", err);
     }
   }
 
@@ -142,12 +150,12 @@ export function ReasonDialog({
           )}
         </div>
 
-        {error && (
+        {displayError && (
           <div
             role="alert"
             className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive"
           >
-            {error}
+            {displayError}
           </div>
         )}
 


### PR DESCRIPTION
## Summary

- `ReasonDialog.handleConfirm` previously logged thrown `onConfirm` errors to `console.error` but left the dialog open with `loading=false` and no error prop update — a silent failure for callers that don't catch their own mutation errors (surfaced by PR #1600 silent-failure-hunter review).
- Adds internal `localError` state rendered as `localError ?? error` in the existing alert block. Caller-provided `error` still wins when the caller handled the failure themselves; local takes over when their `onConfirm` leaked.
- Cleared on reopen (existing open-effect) and at the start of each confirm attempt so retries start fresh.
- Log downgraded from `console.error` to `console.warn` per CLAUDE.md — the UI now recovers the failure, and observability still sees the original `err`.

Closes #1604.

## Test plan

- [x] TDD: added failing component tests first, then implemented. Verified red → green locally.
- [x] New tests cover: Error rejection surfaces in alert + logs + dialog stays mounted, non-Error rejection is stringified, `localError` takes precedence over caller-provided `error` prop, `localError` cleared when dialog reopens.
- [x] Existing compliance-contract tests (empty → empty, whitespace → trimmed, verbatim, required gating, loading-close-block) unchanged and passing.
- [x] `bun run lint` / `bun run type` / `bun run test` / `bun x syncpack lint` / template drift — all pass.
- [x] No public API change — internal primitive fix only; no docs impact.