### PR TITLE
refactor(web): useAdminMutation returns structured FetchError (#1595)

### DIFF
--- a/packages/web/src/app/admin/actions/page.tsx
+++ b/packages/web/src/app/admin/actions/page.tsx
@@ -35,7 +35,7 @@ import {
   bulkFailureSummary,
   failedIdsFrom,
 } from "@/ui/components/admin/queue";
-import { extractFetchError, type FetchError } from "@/ui/lib/fetch-error";
+import { extractFetchError, friendlyError, type FetchError } from "@/ui/lib/fetch-error";
 import {
   Zap,
   Check,
@@ -278,7 +278,7 @@ export default function ActionsPage() {
       body: {},
       itemId: id,
     });
-    if (!result.ok) setMutationError(result.error);
+    if (!result.ok) setMutationError(friendlyError(result.error));
   }
 
   async function confirmSingleDeny(reason: string) {
@@ -310,7 +310,7 @@ export default function ActionsPage() {
         }
       },
     });
-    if (!result.ok) setMutationError(result.error);
+    if (!result.ok) setMutationError(friendlyError(result.error));
   }
 
   async function handleBulkApprove() {

--- a/packages/web/src/app/admin/approval/page.tsx
+++ b/packages/web/src/app/admin/approval/page.tsx
@@ -532,7 +532,7 @@ function QueueSection() {
         }),
     );
     if (!result.ok) {
-      setMutationError(result.error);
+      setMutationError(friendlyError(result.error));
     }
   }
 

--- a/packages/web/src/app/admin/learned-patterns/page.tsx
+++ b/packages/web/src/app/admin/learned-patterns/page.tsx
@@ -243,7 +243,7 @@ export default function LearnedPatternsPage() {
       // optimistic state from a concurrent mutation on another row.
       setPatterns((curr) => curr.map((p) => (p.id === id && originalRow ? originalRow : p)));
       setDetailPattern((curr) => (curr?.id === id ? originalDetail : curr));
-      setError({ message: result.error });
+      setError(result.error);
     }
     setFetchKey((k) => k + 1);
     inProgress.stop(id);
@@ -261,7 +261,7 @@ export default function LearnedPatternsPage() {
       if (detailPattern?.id === id) setDetailPattern(null);
       setFetchKey((k) => k + 1);
     } else {
-      setError({ message: result.error });
+      setError(result.error);
     }
     setDeleteTarget(null);
     inProgress.stop(id);
@@ -296,7 +296,7 @@ export default function LearnedPatternsPage() {
       // operator can retry.
       setPatterns((curr) => curr.map((p) => originalRows.get(p.id) ?? p));
       setDetailPattern((curr) => (curr && ids.has(curr.id) ? originalDetail : curr));
-      setError({ message: result.error });
+      setError(result.error);
       setFetchKey((k) => k + 1);
       return;
     }

--- a/packages/web/src/app/admin/platform/plugins/page.tsx
+++ b/packages/web/src/app/admin/platform/plugins/page.tsx
@@ -57,6 +57,7 @@ import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { LoadingState } from "@/ui/components/admin/loading-state";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
+import { friendlyError } from "@/ui/lib/fetch-error";
 import { usePlatformAdminGuard } from "@/ui/hooks/use-platform-admin-guard";
 import {
   PlatformCatalogResponseSchema,
@@ -455,7 +456,7 @@ function PlatformPluginCatalogPageContent() {
     if (result.ok) {
       refetch();
     } else {
-      setMutationError(`Failed to ${entry.enabled ? "disable" : "enable"} "${entry.name}": ${result.error}`);
+      setMutationError(`Failed to ${entry.enabled ? "disable" : "enable"} "${entry.name}": ${friendlyError(result.error)}`);
     }
   }
 
@@ -468,7 +469,7 @@ function PlatformPluginCatalogPageContent() {
     if (result.ok) {
       refetch();
     } else {
-      setMutationError(`Failed to delete "${deleteTarget.name}": ${result.error}`);
+      setMutationError(`Failed to delete "${deleteTarget.name}": ${friendlyError(result.error)}`);
     }
     setDeleteTarget(null);
   }

--- a/packages/web/src/app/admin/sandbox/page.tsx
+++ b/packages/web/src/app/admin/sandbox/page.tsx
@@ -38,6 +38,7 @@ import {
 } from "@/ui/components/admin/compact";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
+import { friendlyError } from "@/ui/lib/fetch-error";
 import { combineMutationErrors } from "@/ui/lib/mutation-errors";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { useDeployMode } from "@/ui/hooks/use-deploy-mode";
@@ -471,7 +472,7 @@ function ProviderRow({
       if (val) credentials[field.key] = val;
     }
     const result = await connectMutation.mutate({ body: { credentials } });
-    if (!result.ok) setValidationError(result.error);
+    if (!result.ok) setValidationError(friendlyError(result.error));
   }
 
   return (

--- a/packages/web/src/app/admin/scim/page.tsx
+++ b/packages/web/src/app/admin/scim/page.tsx
@@ -28,6 +28,7 @@ import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
+import { friendlyError } from "@/ui/lib/fetch-error";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import {
   CompactRow,
@@ -152,7 +153,7 @@ export default function SCIMPage() {
     const result = await deleteMutate({ path });
     setDeleteTarget(null);
     if (!result.ok) {
-      setRowError({ message: result.error, id: target.id, kind: target.type });
+      setRowError({ message: friendlyError(result.error), id: target.id, kind: target.type });
     }
   }
 

--- a/packages/web/src/app/admin/starter-prompts/page.tsx
+++ b/packages/web/src/app/admin/starter-prompts/page.tsx
@@ -38,6 +38,7 @@ import {
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
+import { friendlyError } from "@/ui/lib/fetch-error";
 import { Loader2, Plus } from "lucide-react";
 import type {
   SuggestionApprovalStatus,
@@ -361,7 +362,7 @@ function StarterPromptsContent() {
       // the row didn't move between tabs. Without this branch, the
       // spinner stops and the UI appears to succeed.
       if (!result.ok) {
-        setRowActionError(result.error);
+        setRowActionError(friendlyError(result.error));
       }
     } finally {
       setPendingRowId(null);

--- a/packages/web/src/app/dashboards/[id]/share-dialog.tsx
+++ b/packages/web/src/app/dashboards/[id]/share-dialog.tsx
@@ -21,6 +21,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
+import { friendlyError } from "@/ui/lib/fetch-error";
 import type { ShareMode, ShareExpiryKey } from "@/ui/lib/types";
 import { SHARE_EXPIRY_OPTIONS } from "@/ui/lib/types";
 import { useAtlasConfig } from "@/ui/context";
@@ -111,7 +112,7 @@ export function DashboardShareDialog({ dashboardId }: DashboardShareDialogProps)
         body: { expiresIn, shareMode },
       });
       if (!result.ok) {
-        setError(result.error ?? "Failed to create share link.");
+        setError(friendlyError(result.error) || "Failed to create share link.");
         return;
       }
       setShared(true);
@@ -134,7 +135,7 @@ export function DashboardShareDialog({ dashboardId }: DashboardShareDialogProps)
         method: "DELETE",
       });
       if (!result.ok) {
-        setError(result.error ?? "Failed to revoke share link.");
+        setError(friendlyError(result.error) || "Failed to revoke share link.");
         return;
       }
       setShared(false);

--- a/packages/web/src/app/dashboards/[id]/share-dialog.tsx
+++ b/packages/web/src/app/dashboards/[id]/share-dialog.tsx
@@ -112,7 +112,7 @@ export function DashboardShareDialog({ dashboardId }: DashboardShareDialogProps)
         body: { expiresIn, shareMode },
       });
       if (!result.ok) {
-        setError(friendlyError(result.error) || "Failed to create share link.");
+        setError(friendlyError(result.error));
         return;
       }
       setShared(true);
@@ -135,7 +135,7 @@ export function DashboardShareDialog({ dashboardId }: DashboardShareDialogProps)
         method: "DELETE",
       });
       if (!result.ok) {
-        setError(friendlyError(result.error) || "Failed to revoke share link.");
+        setError(friendlyError(result.error));
         return;
       }
       setShared(false);

--- a/packages/web/src/app/dashboards/page.tsx
+++ b/packages/web/src/app/dashboards/page.tsx
@@ -33,6 +33,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
+import { friendlyError } from "@/ui/lib/fetch-error";
 import { NavBar } from "@/ui/components/tour/nav-bar";
 import { authClient } from "@/lib/auth/client";
 import type { Dashboard } from "@/ui/lib/types";
@@ -90,7 +91,7 @@ export default function DashboardsPage() {
       body: { title: newTitle.trim() },
     });
     if (!result.ok) {
-      setCreateError(result.error ?? "Failed to create dashboard.");
+      setCreateError(friendlyError(result.error) || "Failed to create dashboard.");
       return;
     }
     setNewTitle("");

--- a/packages/web/src/app/dashboards/page.tsx
+++ b/packages/web/src/app/dashboards/page.tsx
@@ -91,7 +91,7 @@ export default function DashboardsPage() {
       body: { title: newTitle.trim() },
     });
     if (!result.ok) {
-      setCreateError(friendlyError(result.error) || "Failed to create dashboard.");
+      setCreateError(friendlyError(result.error));
       return;
     }
     setNewTitle("");

--- a/packages/web/src/ui/__tests__/admin-mutation-error-passthrough.test.tsx
+++ b/packages/web/src/ui/__tests__/admin-mutation-error-passthrough.test.tsx
@@ -1,0 +1,190 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { render, waitFor, act, cleanup } from "@testing-library/react";
+import { createElement, useState, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AtlasProvider, type AtlasAuthClient } from "../context";
+import { useAdminMutation } from "../hooks/use-admin-mutation";
+import { AdminContentWrapper } from "../components/admin-content-wrapper";
+import type { FetchError } from "../lib/fetch-error";
+
+/**
+ * Regression guard for #1595 — asserts the full passthrough from a mutation
+ * failure through `MutateResult.error` into `AdminContentWrapper`:
+ *
+ * - 403 + `{ error: "enterprise_required" }` → renders `EnterpriseUpsell`,
+ *   not the generic error banner (requires `error.code` to survive the
+ *   hook's catch, which the pre-#1595 string-flattened shape destroyed).
+ * - 401/403/404/503 → renders the `friendlyError`-translated copy, not the
+ *   raw `HTTP 4xx` status the hook used to emit.
+ */
+
+const stubAuthClient: AtlasAuthClient = {
+  signIn: { email: async () => ({}) },
+  signUp: { email: async () => ({}) },
+  signOut: async () => {},
+  useSession: () => ({ data: null }),
+};
+
+let testQueryClient: QueryClient;
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return createElement(
+    QueryClientProvider,
+    { client: testQueryClient },
+    createElement(
+      AtlasProvider,
+      {
+        config: {
+          apiUrl: "http://localhost:3001",
+          isCrossOrigin: false as const,
+          authClient: stubAuthClient,
+        },
+      },
+      children,
+    ),
+  );
+}
+
+/**
+ * Minimal page that mirrors the #1595 acceptance surface: runs one mutation
+ * on mount, stores the structured `FetchError`, and feeds it straight to
+ * `AdminContentWrapper` so the component's EE/FriendlyError branches execute.
+ */
+function MutationHarness({ feature }: { feature: string }) {
+  const [error, setError] = useState<FetchError | null>(null);
+  const [settled, setSettled] = useState(false);
+  const { mutate } = useAdminMutation({ path: "/api/v1/admin/test", method: "POST" });
+
+  // Fire once on mount — test drives the fetch mock before rendering.
+  if (!settled) {
+    setSettled(true);
+    mutate().then((result) => {
+      if (!result.ok) setError(result.error);
+    });
+  }
+
+  return (
+    <AdminContentWrapper loading={false} error={error} feature={feature}>
+      <div>children</div>
+    </AdminContentWrapper>
+  );
+}
+
+const originalFetch = globalThis.fetch;
+
+function mockFailure(status: number, body: Record<string, unknown>) {
+  globalThis.fetch = mock(() =>
+    Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ),
+  ) as unknown as typeof fetch;
+}
+
+describe("admin mutation error passthrough (#1595)", () => {
+  beforeEach(() => {
+    testQueryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    });
+  });
+
+  afterEach(() => {
+    testQueryClient.clear();
+    cleanup();
+    globalThis.fetch = originalFetch;
+  });
+
+  test("403 + enterprise_required renders EnterpriseUpsell, not the generic banner", async () => {
+    mockFailure(403, {
+      message: "Enterprise features required",
+      error: "enterprise_required",
+      requestId: "req-ee-123",
+    });
+
+    let utils!: ReturnType<typeof render>;
+    await act(async () => {
+      utils = render(<MutationHarness feature="SSO" />, { wrapper: Wrapper });
+    });
+
+    await waitFor(() => {
+      expect(utils.container.textContent).toContain("SSO requires an enterprise plan");
+    });
+    // Must not fall through to the generic banner copy.
+    expect(utils.container.textContent).not.toContain("Request failed");
+    expect(utils.container.textContent).not.toContain("HTTP 403");
+  });
+
+  test("403 (no enterprise code) renders friendlyError admin-role copy, not 'HTTP 403'", async () => {
+    mockFailure(403, { message: "Forbidden" });
+
+    let utils!: ReturnType<typeof render>;
+    await act(async () => {
+      utils = render(<MutationHarness feature="Users" />, { wrapper: Wrapper });
+    });
+
+    // AdminContentWrapper routes 403 to <FeatureGate> when a `feature` prop is
+    // set — that path also relies on `error.status` surviving, which is the
+    // same data the pre-#1595 string flatten erased. Either the FeatureGate
+    // access-denied copy or the friendlyError fallback is acceptable; both
+    // prove the structured status reached the component.
+    await waitFor(() => {
+      const text = utils.container.textContent ?? "";
+      expect(
+        text.includes("Access denied") || text.includes("admin role"),
+      ).toBe(true);
+    });
+    expect(utils.container.textContent).not.toContain("HTTP 403");
+  });
+
+  test("401 surfaces friendlyError 'sign in' copy, not 'HTTP 401'", async () => {
+    mockFailure(401, { message: "Unauthorized" });
+
+    let utils!: ReturnType<typeof render>;
+    await act(async () => {
+      utils = render(<MutationHarness feature="Audit" />, { wrapper: Wrapper });
+    });
+
+    await waitFor(() => {
+      const text = utils.container.textContent ?? "";
+      expect(
+        text.includes("Authentication required") || text.includes("sign in"),
+      ).toBe(true);
+    });
+    expect(utils.container.textContent).not.toContain("HTTP 401");
+  });
+
+  test("404 surfaces friendlyError feature-not-enabled copy, not 'HTTP 404'", async () => {
+    mockFailure(404, { message: "Not found" });
+
+    let utils!: ReturnType<typeof render>;
+    await act(async () => {
+      utils = render(<MutationHarness feature="Scheduled Tasks" />, { wrapper: Wrapper });
+    });
+
+    await waitFor(() => {
+      const text = utils.container.textContent ?? "";
+      expect(text).toContain("Scheduled Tasks not enabled");
+    });
+    expect(utils.container.textContent).not.toContain("HTTP 404");
+  });
+
+  test("503 surfaces friendlyError service-unavailable copy, not 'HTTP 503'", async () => {
+    mockFailure(503, { message: "Unavailable" });
+
+    let utils!: ReturnType<typeof render>;
+    await act(async () => {
+      utils = render(<MutationHarness feature="Custom Domains" />, { wrapper: Wrapper });
+    });
+
+    await waitFor(() => {
+      const text = utils.container.textContent ?? "";
+      expect(text).toContain("Internal database not configured");
+    });
+    expect(utils.container.textContent).not.toContain("HTTP 503");
+  });
+});

--- a/packages/web/src/ui/__tests__/admin-mutation-error-passthrough.test.tsx
+++ b/packages/web/src/ui/__tests__/admin-mutation-error-passthrough.test.tsx
@@ -8,14 +8,13 @@ import { AdminContentWrapper } from "../components/admin-content-wrapper";
 import type { FetchError } from "../lib/fetch-error";
 
 /**
- * Regression guard for #1595 — asserts the full passthrough from a mutation
- * failure through `MutateResult.error` into `AdminContentWrapper`:
+ * Asserts `MutateResult.error` preserves the structured `FetchError` shape
+ * end-to-end so `AdminContentWrapper` can:
  *
- * - 403 + `{ error: "enterprise_required" }` → renders `EnterpriseUpsell`,
- *   not the generic error banner (requires `error.code` to survive the
- *   hook's catch, which the pre-#1595 string-flattened shape destroyed).
- * - 401/403/404/503 → renders the `friendlyError`-translated copy, not the
- *   raw `HTTP 4xx` status the hook used to emit.
+ * - Render `EnterpriseUpsell` on 403 + `{ error: "enterprise_required" }`
+ *   (requires `error.code` to survive the hook's catch).
+ * - Render the `friendlyError`-translated copy on 401/403/404/503 (requires
+ *   `error.status` to survive), not the raw `HTTP 4xx` string.
  */
 
 const stubAuthClient: AtlasAuthClient = {
@@ -55,7 +54,8 @@ function MutationHarness({ feature }: { feature: string }) {
   const [settled, setSettled] = useState(false);
   const { mutate } = useAdminMutation({ path: "/api/v1/admin/test", method: "POST" });
 
-  // Fire once on mount — test drives the fetch mock before rendering.
+  // Test arms the fetch mock before rendering; first render kicks off the
+  // mutation so each case observes a single deterministic outcome.
   if (!settled) {
     setSettled(true);
     mutate().then((result) => {
@@ -83,7 +83,7 @@ function mockFailure(status: number, body: Record<string, unknown>) {
   ) as unknown as typeof fetch;
 }
 
-describe("admin mutation error passthrough (#1595)", () => {
+describe("admin mutation error passthrough", () => {
   beforeEach(() => {
     testQueryClient = new QueryClient({
       defaultOptions: {
@@ -127,11 +127,9 @@ describe("admin mutation error passthrough (#1595)", () => {
       utils = render(<MutationHarness feature="Users" />, { wrapper: Wrapper });
     });
 
-    // AdminContentWrapper routes 403 to <FeatureGate> when a `feature` prop is
-    // set — that path also relies on `error.status` surviving, which is the
-    // same data the pre-#1595 string flatten erased. Either the FeatureGate
-    // access-denied copy or the friendlyError fallback is acceptable; both
-    // prove the structured status reached the component.
+    // Either the FeatureGate access-denied copy or the friendlyError fallback
+    // is acceptable — both prove `error.status` reached the component, which
+    // is the property that would have been lost under a flattened error.
     await waitFor(() => {
       const text = utils.container.textContent ?? "";
       expect(

--- a/packages/web/src/ui/__tests__/use-admin-mutation.test.ts
+++ b/packages/web/src/ui/__tests__/use-admin-mutation.test.ts
@@ -179,11 +179,45 @@ describe("useAdminMutation", () => {
 
     expect(mutateResult!.ok).toBe(false);
     if (!mutateResult!.ok) {
-      expect(mutateResult!.error).toBe("Not found");
+      expect(mutateResult!.error.message).toBe("Not found");
+      expect(mutateResult!.error.status).toBe(404);
     }
     await waitFor(() => {
       expect(result.current.error).toBe("Not found");
     });
+  });
+
+  test("MutateResult.error preserves FetchError fields (code, status, requestId)", async () => {
+    // Regression guard for #1595 — structured fields must reach the caller
+    // so friendlyError() and EnterpriseUpsell branching can fire.
+    mockFetch(
+      jsonResponse(
+        {
+          message: "Enterprise features required",
+          error: "enterprise_required",
+          requestId: "req-abc-123",
+        },
+        403,
+      ),
+    );
+
+    const { result } = renderHook(
+      () => useAdminMutation({ path: "/api/v1/admin/test" }),
+      { wrapper },
+    );
+
+    let mutateResult: MutateResult<unknown>;
+    await act(async () => {
+      mutateResult = await result.current.mutate();
+    });
+
+    expect(mutateResult!.ok).toBe(false);
+    if (!mutateResult!.ok) {
+      expect(mutateResult!.error.message).toBe("Enterprise features required");
+      expect(mutateResult!.error.status).toBe(403);
+      expect(mutateResult!.error.code).toBe("enterprise_required");
+      expect(mutateResult!.error.requestId).toBe("req-abc-123");
+    }
   });
 
   test("returns { ok: false, error } for network failure", async () => {
@@ -203,7 +237,9 @@ describe("useAdminMutation", () => {
 
     expect(mutateResult!.ok).toBe(false);
     if (!mutateResult!.ok) {
-      expect(mutateResult!.error).toBe("Network error");
+      expect(mutateResult!.error.message).toBe("Network error");
+      // Non-HTTP failures have no status — callers can detect via `status === undefined`.
+      expect(mutateResult!.error.status).toBeUndefined();
     }
   });
 
@@ -220,7 +256,7 @@ describe("useAdminMutation", () => {
 
     expect(mutateResult!.ok).toBe(false);
     if (!mutateResult!.ok) {
-      expect(mutateResult!.error).toContain("no path");
+      expect(mutateResult!.error.message).toContain("no path");
     }
   });
 

--- a/packages/web/src/ui/__tests__/use-admin-mutation.test.ts
+++ b/packages/web/src/ui/__tests__/use-admin-mutation.test.ts
@@ -188,8 +188,9 @@ describe("useAdminMutation", () => {
   });
 
   test("MutateResult.error preserves FetchError fields (code, status, requestId)", async () => {
-    // Regression guard for #1595 — structured fields must reach the caller
-    // so friendlyError() and EnterpriseUpsell branching can fire.
+    // Structured fields must reach the caller so friendlyError() and
+    // EnterpriseUpsell branching can fire — without them, mutation failures
+    // render as raw "HTTP 403" and generic banners on EE-gated endpoints.
     mockFetch(
       jsonResponse(
         {

--- a/packages/web/src/ui/components/admin/sso/create-provider-dialog.tsx
+++ b/packages/web/src/ui/components/admin/sso/create-provider-dialog.tsx
@@ -27,6 +27,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
+import { friendlyError } from "@/ui/lib/fetch-error";
 import {
   Loader2,
   CheckCircle2,
@@ -203,7 +204,7 @@ export function CreateProviderDialog({
       if (result.ok && result.data) {
         setTestResult(result.data);
       } else if (!result.ok) {
-        setTestError(result.error);
+        setTestError(friendlyError(result.error));
       }
     } finally {
       setTesting(false);

--- a/packages/web/src/ui/components/admin/sso/edit-provider-dialog.tsx
+++ b/packages/web/src/ui/components/admin/sso/edit-provider-dialog.tsx
@@ -27,6 +27,7 @@ import { Badge } from "@/components/ui/badge";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
+import { friendlyError } from "@/ui/lib/fetch-error";
 import {
   Loader2,
   Upload,
@@ -213,7 +214,7 @@ function EditProviderDialogInner({
       if (result.ok && result.data) {
         setTestResult(result.data);
       } else if (!result.ok) {
-        setTestError(result.error);
+        setTestError(friendlyError(result.error));
       }
     } finally {
       setTesting(false);

--- a/packages/web/src/ui/components/chat/add-to-dashboard-dialog.tsx
+++ b/packages/web/src/ui/components/chat/add-to-dashboard-dialog.tsx
@@ -23,6 +23,7 @@ import {
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { useAdminFetch } from "../../hooks/use-admin-fetch";
 import { useAdminMutation } from "../../hooks/use-admin-mutation";
+import { friendlyError } from "../../lib/fetch-error";
 import type { Dashboard, DashboardChartConfig, ChartType } from "../../lib/types";
 import { CHART_TYPES } from "../../lib/types";
 import type { ChartDetectionResult } from "../chart/chart-detection";
@@ -166,7 +167,7 @@ export function AddToDashboardDialog({
           body: { title: newDashboardTitle.trim() },
         });
         if (!result.ok) {
-          setError(result.error ?? "Failed to create dashboard.");
+          setError(friendlyError(result.error) || "Failed to create dashboard.");
           return;
         }
         dashboardId = (result.data as Dashboard).id;
@@ -195,13 +196,13 @@ export function AddToDashboardDialog({
         if (createdNewDashboard) {
           // Dashboard was created but card failed — guide user to retry
           setError(
-            `Dashboard "${newDashboardTitle.trim()}" was created, but adding the card failed: ${cardResult.error ?? "Unknown error"}. ` +
+            `Dashboard "${newDashboardTitle.trim()}" was created, but adding the card failed: ${friendlyError(cardResult.error) || "Unknown error"}. ` +
             `Select it from "Existing" to retry.`
           );
           setMode("existing");
           setSelectedDashboardId(dashboardId);
         } else {
-          setError(cardResult.error ?? "Failed to add card.");
+          setError(friendlyError(cardResult.error) || "Failed to add card.");
         }
         return;
       }

--- a/packages/web/src/ui/components/chat/add-to-dashboard-dialog.tsx
+++ b/packages/web/src/ui/components/chat/add-to-dashboard-dialog.tsx
@@ -167,7 +167,7 @@ export function AddToDashboardDialog({
           body: { title: newDashboardTitle.trim() },
         });
         if (!result.ok) {
-          setError(friendlyError(result.error) || "Failed to create dashboard.");
+          setError(friendlyError(result.error));
           return;
         }
         dashboardId = (result.data as Dashboard).id;
@@ -196,13 +196,13 @@ export function AddToDashboardDialog({
         if (createdNewDashboard) {
           // Dashboard was created but card failed — guide user to retry
           setError(
-            `Dashboard "${newDashboardTitle.trim()}" was created, but adding the card failed: ${friendlyError(cardResult.error) || "Unknown error"}. ` +
+            `Dashboard "${newDashboardTitle.trim()}" was created, but adding the card failed: ${friendlyError(cardResult.error)}. ` +
             `Select it from "Existing" to retry.`
           );
           setMode("existing");
           setSelectedDashboardId(dashboardId);
         } else {
-          setError(friendlyError(cardResult.error) || "Failed to add card.");
+          setError(friendlyError(cardResult.error));
         }
         return;
       }

--- a/packages/web/src/ui/hooks/use-admin-mutation.ts
+++ b/packages/web/src/ui/hooks/use-admin-mutation.ts
@@ -3,7 +3,7 @@
 import { useState, useCallback, useRef } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAtlasConfig } from "@/ui/context";
-import { extractFetchError } from "@/ui/lib/fetch-error";
+import { extractFetchError, type FetchError } from "@/ui/lib/fetch-error";
 
 /** HTTP methods supported by admin mutations. */
 type MutationMethod = "POST" | "PUT" | "PATCH" | "DELETE";
@@ -12,11 +12,13 @@ type MutationMethod = "POST" | "PUT" | "PATCH" | "DELETE";
  * Discriminated result returned by `mutate()`.
  * Discriminates on `ok`: true means the request succeeded (data is
  * undefined for 204 No Content or non-JSON responses), false means
- * an error occurred.
+ * an error occurred. `error` is the structured {@link FetchError} so callers
+ * can pass it to `friendlyError()` or branch on `code === "enterprise_required"`
+ * without re-parsing the message string.
  */
 export type MutateResult<T> =
   | { ok: true; data: T | undefined }
-  | { ok: false; error: string };
+  | { ok: false; error: FetchError };
 
 /** Options for a single mutate() call. */
 interface MutateOptions<TResponse = unknown> {
@@ -123,10 +125,14 @@ export function useAdminMutation<TResponse = unknown>(
 
       if (!res.ok) {
         const fetchError = await extractFetchError(res);
+        // Preserve the structured FetchError across the throw boundary so the
+        // catch in `mutate()` can return it as `MutateResult.error`. The bare
+        // `Error.message` is kept human-readable as a fallback for anything
+        // that inspects the thrown error directly (e.g. TanStack's own logs).
         const msg = fetchError.requestId
           ? `${fetchError.message} (Request ID: ${fetchError.requestId})`
           : fetchError.message;
-        throw new Error(msg);
+        throw Object.assign(new Error(msg), { fetchError });
       }
 
       // Parse response (handle 204 No Content)
@@ -155,7 +161,7 @@ export function useAdminMutation<TResponse = unknown>(
       if (!callOpts?.path && !opts?.path) {
         const msg = "useAdminMutation: no path provided";
         setError(msg);
-        return { ok: false, error: msg };
+        return { ok: false, error: { message: msg } };
       }
 
       // Track loading state
@@ -184,8 +190,12 @@ export function useAdminMutation<TResponse = unknown>(
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         const errorMessage = msg || "Request failed";
+        // Recover the structured FetchError the mutationFn attached before
+        // throwing (non-HTTP failures like network errors reach this path with
+        // no attachment — fall back to a minimal FetchError preserving message).
+        const fetchError = (err as { fetchError?: FetchError }).fetchError;
         setError(errorMessage);
-        return { ok: false, error: errorMessage };
+        return { ok: false, error: fetchError ?? { message: errorMessage } };
       } finally {
         if (itemId) {
           setInFlight((prev) => {


### PR DESCRIPTION
## Summary

Closes #1595.

`useAdminMutation`'s `MutateResult.error` changes from `string` to the structured `FetchError` so `status`, `requestId`, and `code` survive the hook's catch boundary. This restores two downstream behaviors that silently broke when the hook flattened the error:

- `AdminContentWrapper` renders `EnterpriseUpsell` when a mutation returns `403` + `{ error: "enterprise_required" }` (was falling through to the generic banner because `error.code` was `undefined`).
- `friendlyError(result.error)` fires its 401/403/404/503 translations (was rendering raw `HTTP 403 (Request ID: …)` because `error.status` was gone).

The wire shape from the backend didn't change — only the hook/caller contract.

## What changed

### Hook (`packages/web/src/ui/hooks/use-admin-mutation.ts`)
- `MutateResult.error: string` → `FetchError`.
- The mutationFn now throws `Object.assign(new Error(msg), { fetchError })` so the structured error rides along with the plain `Error` message TanStack already logs.
- The `mutate()` catch unpacks the attached `fetchError`; non-HTTP failures (network errors) fall back to a minimal `{ message }` `FetchError`.
- Hook-level `error: string | null` state is **unchanged** — out of scope per issue.

### Callers — migrated in this PR (breaking shape change, atomic migration required)
- `/admin/actions`, `/admin/approval`, `/admin/sandbox`, `/admin/scim`, `/admin/starter-prompts`, `/admin/learned-patterns`, `/admin/platform/plugins`
- `/dashboards`, `/dashboards/[id]/share-dialog`
- SSO `create-provider-dialog`, `edit-provider-dialog`
- `add-to-dashboard-dialog`

Pattern:
- String-typed error state → `setError(friendlyError(result.error))` (canonical wrap; gets the translated copy).
- `FetchError | null` state (`/admin/learned-patterns`) → `setError(result.error)` (passes straight through to `AdminContentWrapper` so `EnterpriseUpsell` can fire).
- `{ message: result.error }` wrap pattern — 0 occurrences remain; grep verified.

### Tests
- **Unit test** in `use-admin-mutation.test.ts` asserting `MutateResult.error` carries `code`, `status`, and `requestId` from `extractFetchError` (the regression guard for #1595).
- **Integration test** in new `admin-mutation-error-passthrough.test.tsx` drives the full flow through `AdminContentWrapper`:
  - `403 + enterprise_required` → `EnterpriseUpsell` renders, not the generic banner.
  - `401/403/404/503` → the translated copy renders (`"sign in"`, `"admin role"`, `"not enabled"`, `"Internal database not configured"`), not raw `HTTP 4xx`.

## Out of scope

- The hook's own `error: string | null` state shape (explicit in #1595's "out of scope").
- Sentry / OTel breadcrumb attachment of `requestId`.

## CI gates (local)

Lint, type, test, syncpack, template drift — all pass.

## Incidental finding

Filed #1613: `packages/web/src/app/demo/page.tsx:196` passes `chatEndpoint` / `conversationsEndpoint` to `<AtlasChat>` but the props aren't in `AtlasChatProps`. Pre-existing; not addressed here. Root `bun run type` excludes `packages/web` so this was never caught by CI.

## Test plan

- [ ] Admin page with a string-typed error state surfaces a 403 mutation failure as the `friendlyError` copy (`"Access denied. Admin role required…"`) not `"HTTP 403 …"`.
- [ ] Admin page using `FetchError | null` state + `AdminContentWrapper` (`/admin/learned-patterns`) renders `EnterpriseUpsell` on a mutation 403 + `enterprise_required`, not the generic banner.
- [ ] Network-error path (e.g., offline) still surfaces the plain message — no stack trace, no structured fields required.
- [ ] Hook unit tests + passthrough integration tests green (`bun run test` in `packages/web`).