### PR TITLE
fix(ci): add @atlas/web to root type check (#1613)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build:docs": "bun run --filter '@atlas/docs' build",
     "start": "sh scripts/start.sh",
     "lint": "eslint packages/ ee/",
-    "type": "bun run --filter '@useatlas/types' build && bun run --filter '@useatlas/plugin-sdk' build && bun run --filter '@useatlas/sdk' build && tsgo --noEmit",
+    "type": "bun run --filter '@useatlas/types' build && bun run --filter '@useatlas/plugin-sdk' build && bun run --filter '@useatlas/sdk' build && bun run --filter '@useatlas/react' build && tsgo --noEmit && bun run --filter '@atlas/web' type",
     "atlas": "bun packages/cli/bin/atlas.ts",
     "mcp": "bun packages/mcp/bin/serve.ts",
     "db:up": "bash scripts/db-up.sh",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "type": "tsc --noEmit",
+    "type": "tsgo --noEmit",
     "test": "bun scripts/test-isolated.ts"
   },
   "exports": {


### PR DESCRIPTION
## Summary

Issue #1613 reported a `tsgo` error in `packages/web/src/app/demo/page.tsx` where `chatEndpoint` / `conversationsEndpoint` were rejected as unknown props on `AtlasChatProps`. Investigation showed the props **are** defined on `@useatlas/react`'s `AtlasChatProps` (and in the compiled `dist/index.js`), but `dist/index.d.ts` was stale at the time the issue was filed. The `/api/v1/demo/*` endpoints the demo page targets are real — the props were legitimate, runtime was fine, only the type surface had drifted.

The deeper bug is that root `bun run type` excluded `packages/web`, so this kind of drift can't be caught by CI — the issue says so directly: _"The root `bun run type` excludes `packages/web`, so this only surfaces when running `tsgo` inside the web package directly — that's why it slipped past CI."_

## Changes

- **Root `type` script** now builds `@useatlas/react` (same pattern as `@useatlas/types` / `@useatlas/plugin-sdk` / `@useatlas/sdk`) so web consumes fresh `.d.ts` instead of whatever happens to be in a gitignored `dist/`, then runs `bun run --filter '@atlas/web' type` after root `tsgo --noEmit`.
- **`@atlas/web` `type` script** flips `tsc --noEmit` → `tsgo --noEmit` — `tsc` chokes on `bun-types`'s generic syntax and `tsgo` is already the root choice.

## Verification

- `bun run type` from repo root exits 0 and now covers `packages/web`.
- Canary: temporarily reintroduced `nonExistentProp="canary"` on `<AtlasChat>` → root `bun run type` exits 2 with `TS2322: Property 'nonExistentProp' does not exist on type 'AtlasChatProps'`. Removed.
- No unrelated latent type errors surfaced in web (clean pass after the @useatlas/react rebuild).

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run type` — clean (now includes web)
- [x] `bun run test` — all packages pass
- [x] `bun x syncpack lint` — no issues
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — passed
- [x] Canary verified: removing the bad prop makes root `type` pass; reintroducing it makes root `type` fail.

Closes #1613.