### PR TITLE
test(web/admin): structured mutation error regression tests (#1626 + #1627)

### DIFF
--- a/packages/web/src/app/admin/custom-domain/__tests__/plan-gate.test.tsx
+++ b/packages/web/src/app/admin/custom-domain/__tests__/plan-gate.test.tsx
@@ -1,0 +1,202 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { render, fireEvent, waitFor, cleanup, act } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AtlasProvider, type AtlasAuthClient } from "@/ui/context";
+import CustomDomainPage from "../page";
+
+/**
+ * Regression guard for the structured plan-gate on `/admin/custom-domain`.
+ *
+ * `isPlanGated` branches on `addError.code === "plan_required" |
+ * "enterprise_required"` — not on substring-matching the human message.
+ * A future edit that reverts to `.message.includes(...)`, drops `.code`
+ * extraction in `extractFetchError`, or renames the server enum would
+ * silently un-gate the page (the add form would render and POSTs would 403).
+ * These tests exercise the rendered branch so that regression is caught here,
+ * not by a confused user.
+ */
+
+const stubAuthClient: AtlasAuthClient = {
+  signIn: { email: async () => ({}) },
+  signUp: { email: async () => ({}) },
+  signOut: async () => {},
+  useSession: () => ({ data: null }),
+};
+
+let testQueryClient: QueryClient;
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return createElement(
+    QueryClientProvider,
+    { client: testQueryClient },
+    createElement(
+      AtlasProvider,
+      {
+        config: {
+          apiUrl: "http://localhost:3001",
+          isCrossOrigin: false as const,
+          authClient: stubAuthClient,
+        },
+      },
+      children,
+    ),
+  );
+}
+
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * Route GET → empty domain (so the "+ Add domain" affordance renders), POST →
+ * the caller-provided error body. Covers both the plan-gated and non-gated
+ * add-domain flows without re-scripting the mock between test cases.
+ */
+function mockDomainApi(postError: { status: number; body: Record<string, unknown> }) {
+  globalThis.fetch = mock((input: RequestInfo | URL, init?: RequestInit) => {
+    const method = init?.method ?? "GET";
+    if (method === "GET") return Promise.resolve(jsonResponse({ domain: null }));
+    if (method === "POST")
+      return Promise.resolve(jsonResponse(postError.body, postError.status));
+    return Promise.resolve(jsonResponse({}, 500));
+  }) as unknown as typeof fetch;
+}
+
+async function submitAddDomain() {
+  const addTrigger = Array.from(document.querySelectorAll("button")).find((b) =>
+    b.textContent?.includes("+ Add domain"),
+  );
+  expect(addTrigger).toBeDefined();
+  await act(async () => {
+    fireEvent.click(addTrigger!);
+  });
+
+  const input = document.querySelector<HTMLInputElement>("input#domain");
+  expect(input).not.toBeNull();
+  await act(async () => {
+    fireEvent.change(input!, { target: { value: "data.acme.com" } });
+  });
+
+  const submit = Array.from(document.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === "Add domain",
+  );
+  expect(submit).toBeDefined();
+  await act(async () => {
+    fireEvent.click(submit!);
+  });
+}
+
+describe("/admin/custom-domain plan-gate (structured code, not message)", () => {
+  beforeEach(() => {
+    testQueryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    });
+  });
+
+  afterEach(() => {
+    testQueryClient.clear();
+    cleanup();
+    globalThis.fetch = originalFetch;
+  });
+
+  test("403 + plan_required → gated landing renders, add form is gone", async () => {
+    mockDomainApi({
+      status: 403,
+      body: { error: "plan_required", message: "Upgrade required" },
+    });
+
+    const { container } = render(<CustomDomainPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(
+        Array.from(document.querySelectorAll("button")).some((b) =>
+          b.textContent?.includes("+ Add domain"),
+        ),
+      ).toBe(true);
+    });
+
+    await submitAddDomain();
+
+    await waitFor(() => {
+      expect(container.textContent).toContain(
+        "Custom domains are an Enterprise feature",
+      );
+    });
+    // Gated landing replaces the editor — the domain input must NOT remain
+    // mounted, otherwise a gated admin could still fill in and re-submit.
+    expect(document.querySelector("input#domain")).toBeNull();
+  });
+
+  test("403 + enterprise_required → same gated landing", async () => {
+    mockDomainApi({
+      status: 403,
+      body: { error: "enterprise_required", message: "Enterprise required" },
+    });
+
+    const { container } = render(<CustomDomainPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(
+        Array.from(document.querySelectorAll("button")).some((b) =>
+          b.textContent?.includes("+ Add domain"),
+        ),
+      ).toBe(true);
+    });
+
+    await submitAddDomain();
+
+    await waitFor(() => {
+      expect(container.textContent).toContain(
+        "Custom domains are an Enterprise feature",
+      );
+    });
+    expect(document.querySelector("input#domain")).toBeNull();
+  });
+
+  test("403 + unrelated code → add form stays open, gated landing does NOT render", async () => {
+    // Negative case — the gate must key on the enum, not on the 403 status
+    // alone. An unrelated forbidden response (e.g. role check failure) should
+    // surface the inline error banner and leave the editor intact so the
+    // admin can correct it, not redirect to an upsell surface.
+    //
+    // A 422 is used on purpose: `friendlyError` rewrites 401/403/404/503 to
+    // canned copy, so a 403 "something_else" would render as "Access denied"
+    // and indistinguishably match the admin-role path. 422 lets the raw body
+    // message reach the DOM so we can positively assert the banner — not the
+    // gated landing — rendered.
+    mockDomainApi({
+      status: 422,
+      body: { error: "something_else", message: "Validation failed" },
+    });
+
+    const { container } = render(<CustomDomainPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(
+        Array.from(document.querySelectorAll("button")).some((b) =>
+          b.textContent?.includes("+ Add domain"),
+        ),
+      ).toBe(true);
+    });
+
+    await submitAddDomain();
+
+    // Error banner surfaces inline; the editor + submit button stay mounted.
+    await waitFor(() => {
+      expect(container.textContent).toContain("Validation failed");
+    });
+    expect(container.textContent).not.toContain(
+      "Custom domains are an Enterprise feature",
+    );
+    expect(document.querySelector("input#domain")).not.toBeNull();
+  });
+});

--- a/packages/web/src/app/admin/custom-domain/__tests__/plan-gate.test.tsx
+++ b/packages/web/src/app/admin/custom-domain/__tests__/plan-gate.test.tsx
@@ -13,8 +13,6 @@ import CustomDomainPage from "../page";
  * A future edit that reverts to `.message.includes(...)`, drops `.code`
  * extraction in `extractFetchError`, or renames the server enum would
  * silently un-gate the page (the add form would render and POSTs would 403).
- * These tests exercise the rendered branch so that regression is caught here,
- * not by a confused user.
  */
 
 const stubAuthClient: AtlasAuthClient = {
@@ -53,18 +51,16 @@ function jsonResponse(body: unknown, status = 200) {
   });
 }
 
-/**
- * Route GET → empty domain (so the "+ Add domain" affordance renders), POST →
- * the caller-provided error body. Covers both the plan-gated and non-gated
- * add-domain flows without re-scripting the mock between test cases.
- */
 function mockDomainApi(postError: { status: number; body: Record<string, unknown> }) {
   globalThis.fetch = mock((input: RequestInfo | URL, init?: RequestInit) => {
     const method = init?.method ?? "GET";
     if (method === "GET") return Promise.resolve(jsonResponse({ domain: null }));
     if (method === "POST")
       return Promise.resolve(jsonResponse(postError.body, postError.status));
-    return Promise.resolve(jsonResponse({}, 500));
+    // Throw instead of returning a fallthrough 2xx — if the page starts issuing
+    // an unexpected request (e.g. auto-verify on save), the test surfaces it
+    // loudly instead of silently passing.
+    throw new Error(`unexpected ${method} ${String(input)}`);
   }) as unknown as typeof fetch;
 }
 
@@ -134,6 +130,37 @@ describe("/admin/custom-domain plan-gate (structured code, not message)", () => 
     // Gated landing replaces the editor — the domain input must NOT remain
     // mounted, otherwise a gated admin could still fill in and re-submit.
     expect(document.querySelector("input#domain")).toBeNull();
+    // Gated landing renders no banner — the upsell surface IS the message.
+    expect(document.querySelectorAll('[role="alert"]')).toHaveLength(0);
+  });
+
+  test("402 + plan_required → same gated landing (status-agnostic, code-driven)", async () => {
+    // Plan-gating canonically maps to HTTP 402. `friendlyError` doesn't rewrite
+    // 402, so this is a distinct branch from the 403 case — if the server
+    // migrates `plan_required` from 403 to 402, the gate must still trigger.
+    mockDomainApi({
+      status: 402,
+      body: { error: "plan_required", message: "Payment required" },
+    });
+
+    const { container } = render(<CustomDomainPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(
+        Array.from(document.querySelectorAll("button")).some((b) =>
+          b.textContent?.includes("+ Add domain"),
+        ),
+      ).toBe(true);
+    });
+
+    await submitAddDomain();
+
+    await waitFor(() => {
+      expect(container.textContent).toContain(
+        "Custom domains are an Enterprise feature",
+      );
+    });
+    expect(document.querySelector("input#domain")).toBeNull();
   });
 
   test("403 + enterprise_required → same gated landing", async () => {
@@ -162,17 +189,13 @@ describe("/admin/custom-domain plan-gate (structured code, not message)", () => 
     expect(document.querySelector("input#domain")).toBeNull();
   });
 
-  test("403 + unrelated code → add form stays open, gated landing does NOT render", async () => {
-    // Negative case — the gate must key on the enum, not on the 403 status
-    // alone. An unrelated forbidden response (e.g. role check failure) should
-    // surface the inline error banner and leave the editor intact so the
-    // admin can correct it, not redirect to an upsell surface.
-    //
-    // A 422 is used on purpose: `friendlyError` rewrites 401/403/404/503 to
-    // canned copy, so a 403 "something_else" would render as "Access denied"
-    // and indistinguishably match the admin-role path. 422 lets the raw body
-    // message reach the DOM so we can positively assert the banner — not the
-    // gated landing — rendered.
+  test("422 + unrelated code → add form stays open, gated landing does NOT render", async () => {
+    // Negative case — the gate must key on the enum, not on any particular
+    // error status. A 422 is used on purpose: `friendlyError` rewrites
+    // 401/403/404/503 to canned copy, so a 403 "something_else" would render
+    // as "Access denied" and indistinguishably match the admin-role path.
+    // 422 lets the raw body message reach the DOM so we can positively assert
+    // the inline banner — not the gated landing — rendered.
     mockDomainApi({
       status: 422,
       body: { error: "something_else", message: "Validation failed" },
@@ -190,13 +213,21 @@ describe("/admin/custom-domain plan-gate (structured code, not message)", () => 
 
     await submitAddDomain();
 
-    // Error banner surfaces inline; the editor + submit button stay mounted.
-    await waitFor(() => {
-      expect(container.textContent).toContain("Validation failed");
+    // Scope to `[role="alert"]` — asserting on `container.textContent` would
+    // pass if the message leaked into a tooltip, title, or SR-only element.
+    const banner = await waitFor(() => {
+      const el = document.querySelector('[role="alert"]');
+      if (!el) throw new Error("alert not found");
+      return el;
     });
+    expect(banner.textContent).toContain("Validation failed");
     expect(container.textContent).not.toContain(
       "Custom domains are an Enterprise feature",
     );
     expect(document.querySelector("input#domain")).not.toBeNull();
+    // Exactly one banner — a regression that double-rendered `addError` at
+    // both the top-level `mutationError` slot and the inline Shell slot would
+    // otherwise slip through the first-match `querySelector` above.
+    expect(document.querySelectorAll('[role="alert"]')).toHaveLength(1);
   });
 });

--- a/packages/web/src/app/admin/email-provider/__tests__/mutation-error-chain.test.tsx
+++ b/packages/web/src/app/admin/email-provider/__tests__/mutation-error-chain.test.tsx
@@ -11,11 +11,11 @@ import EmailProviderPage from "../page";
  *   const structuredError = combineMutationErrors([saveError, deleteError, testError]);
  *   const mutationError = structuredError ? friendlyError(structuredError) : formError;
  *
- * Three mutation errors fall through to a local `formError` when none failed.
- * A regression — swapping the ternary arms, dropping the `formError` fallback,
- * or rewiring the composition — would silently lose either the server-side
- * requestId-bearing copy or the client-side validation hint. Both paths hit
- * the same `ErrorBanner`, so only a rendered-DOM test catches the swap.
+ * Each of the three mutation slots can produce the banner, with `formError`
+ * as the client-side fallback. Regressions — dropping one slot from the
+ * compose array, swapping the ternary arms, dropping the `formError`
+ * fallback — render the wrong surface silently, so the DOM-level branches
+ * are tested end-to-end and each mutation slot is exercised at least once.
  */
 
 const stubAuthClient: AtlasAuthClient = {
@@ -54,10 +54,6 @@ function jsonResponse(body: unknown, status = 200) {
   });
 }
 
-/**
- * Baseline payload the page expects from the initial GET — empty override so
- * the editor renders fresh and the "+ Add credentials" affordance is wired up.
- */
 const BASELINE_CONFIG = {
   config: {
     baseline: { provider: "resend", fromAddress: "noreply@atlas.dev" },
@@ -66,19 +62,29 @@ const BASELINE_CONFIG = {
 };
 
 /**
- * Mock fetch with:
- *   - GET `/email-provider`         → 200 baseline config
- *   - PUT `/email-provider`         → caller-provided save handler
- *   - POST `/email-provider/test`   → 200 (not exercised by these tests)
+ * Route GET to the baseline config and delegate PUT (save) and POST
+ * `/test` to caller-provided handlers. Unrecognized paths throw so a drifted
+ * page can't silently pass with a generic 2xx fallthrough.
  */
-function mockEmailProviderApi(
-  saveHandler: () => Response,
-) {
+function mockEmailProviderApi(handlers: {
+  save?: () => Response;
+  test?: () => Response;
+}) {
   globalThis.fetch = mock((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
     const method = init?.method ?? "GET";
-    if (method === "GET") return Promise.resolve(jsonResponse(BASELINE_CONFIG));
-    if (method === "PUT") return Promise.resolve(saveHandler());
-    return Promise.resolve(jsonResponse({ success: true, message: "ok" }));
+    if (method === "GET" && url.endsWith("/api/v1/admin/email-provider")) {
+      return Promise.resolve(jsonResponse(BASELINE_CONFIG));
+    }
+    if (method === "PUT" && url.endsWith("/api/v1/admin/email-provider")) {
+      if (!handlers.save) throw new Error(`unexpected PUT ${url}`);
+      return Promise.resolve(handlers.save());
+    }
+    if (method === "POST" && url.endsWith("/api/v1/admin/email-provider/test")) {
+      if (!handlers.test) throw new Error(`unexpected POST ${url}`);
+      return Promise.resolve(handlers.test());
+    }
+    throw new Error(`unexpected ${method} ${url}`);
   }) as unknown as typeof fetch;
 }
 
@@ -125,16 +131,14 @@ describe("/admin/email-provider mutation error chain", () => {
     globalThis.fetch = originalFetch;
   });
 
-  test("a failing save mutation surfaces friendlyError copy with requestId", async () => {
-    // Valid client input reaches the wire; server rejects it. The banner must
-    // render the translated, requestId-bearing copy — not the raw `formError`
-    // string or the unfriendly `message` from the body.
-    mockEmailProviderApi(() =>
-      jsonResponse(
-        { message: "Upstream provider rejected key", requestId: "req-email-42" },
-        500,
-      ),
-    );
+  test("a failing save (saveError slot) surfaces friendlyError copy with requestId", async () => {
+    mockEmailProviderApi({
+      save: () =>
+        jsonResponse(
+          { message: "Upstream provider rejected key", requestId: "req-email-42" },
+          500,
+        ),
+    });
 
     render(<EmailProviderPage />, { wrapper: Wrapper });
 
@@ -155,21 +159,55 @@ describe("/admin/email-provider mutation error chain", () => {
     // requestId-less copy would drop one or both halves.
     expect(banner.textContent).toContain("Upstream provider rejected key");
     expect(banner.textContent).toContain("req-email-42");
+    expect(document.querySelectorAll('[role="alert"]')).toHaveLength(1);
   });
 
-  test("client validation error with no mutation in flight surfaces formError fallback", async () => {
-    // Server is never called — empty API key short-circuits inside `handleSave`
-    // via `buildProviderConfig`, setting `formError`. The banner copy is the
-    // raw validation string, which *only* reaches the DOM if the ternary's
-    // false-arm (`formError`) is intact.
-    const saveHandler = mock(() => jsonResponse({ success: true }));
-    mockEmailProviderApi(saveHandler);
+  test("a failing test-send (testError slot) also surfaces friendlyError copy", async () => {
+    // Covers the third slot of `combineMutationErrors([saveError, deleteError,
+    // testError])`. A regression dropping the array to `[saveError]` or
+    // `[saveError, deleteError]` would make this test fail while the
+    // saveError case above still passes — so both together prove the compose
+    // array isn't being silently narrowed.
+    mockEmailProviderApi({
+      test: () =>
+        jsonResponse(
+          { message: "Test recipient unreachable", requestId: "req-test-99" },
+          502,
+        ),
+    });
 
     render(<EmailProviderPage />, { wrapper: Wrapper });
 
     await openEditor();
-    // Intentionally skip typing the API key — buildProviderConfig returns
-    // `{ ok: false, error: "API key is required." }`.
+    typeIntoInput("resendApiKey", "re_validkey");
+    typeIntoInput("fromAddress", "sender@acme.com");
+    typeIntoInput("recipientEmail", "dest@acme.com");
+    await act(async () => {
+      clickButton("Send test");
+    });
+
+    const banner = await waitFor(() => {
+      const el = document.querySelector('[role="alert"]');
+      if (!el) throw new Error("alert not found");
+      return el;
+    });
+    expect(banner.textContent).toContain("Test recipient unreachable");
+    expect(banner.textContent).toContain("req-test-99");
+    expect(document.querySelectorAll('[role="alert"]')).toHaveLength(1);
+  });
+
+  test("client validation error with no mutation in flight surfaces formError fallback", async () => {
+    // Server must not be called — empty API key short-circuits inside
+    // `handleSave` via `buildProviderConfig`, setting `formError`. The raw
+    // validation string reaches the DOM only if the ternary's false-arm
+    // (`formError`) is intact. If `save` is invoked, the mock throws and the
+    // test fails loudly — proving we took the false-arm, not a phantom
+    // mutation-failure path.
+    mockEmailProviderApi({});
+
+    render(<EmailProviderPage />, { wrapper: Wrapper });
+
+    await openEditor();
     typeIntoInput("fromAddress", "sender@acme.com");
     await act(async () => {
       clickButton("Save");
@@ -181,19 +219,13 @@ describe("/admin/email-provider mutation error chain", () => {
       return el;
     });
     expect(banner.textContent).toContain("API key is required.");
-    // No network call fired — the chain's false-arm is being exercised, not
-    // a phantom mutation failure.
-    expect(saveHandler).not.toHaveBeenCalled();
   });
 
   test("no errors → no banner renders", async () => {
-    mockEmailProviderApi(() => jsonResponse({ success: true }));
+    mockEmailProviderApi({});
 
     render(<EmailProviderPage />, { wrapper: Wrapper });
 
-    // Wait for initial GET to settle so the editor affordance is mounted and
-    // `formError` / mutation errors have had a chance to populate from any
-    // stray render cycle.
     await waitFor(() => {
       expect(
         Array.from(document.querySelectorAll("button")).some((b) =>
@@ -203,61 +235,5 @@ describe("/admin/email-provider mutation error chain", () => {
     });
 
     expect(document.querySelector('[role="alert"]')).toBeNull();
-  });
-
-  test("structured mutation error wins over a pre-existing formError", async () => {
-    // Drives the full ternary — `formError` is set first by a client-side
-    // failure, then a subsequent save triggers a server error. Once the
-    // mutation fails, `structuredError` is truthy so the banner copy MUST
-    // switch to the friendlyError arm even though `formError` was visible
-    // moments earlier. Swapping the ternary would leave the stale form copy
-    // in place and silently hide the server's requestId.
-    let saveShouldFail = false;
-    globalThis.fetch = mock((input: RequestInfo | URL, init?: RequestInit) => {
-      const method = init?.method ?? "GET";
-      if (method === "GET") return Promise.resolve(jsonResponse(BASELINE_CONFIG));
-      if (method === "PUT") {
-        if (saveShouldFail) {
-          return Promise.resolve(
-            jsonResponse(
-              { message: "SMTP auth rejected", requestId: "req-win" },
-              500,
-            ),
-          );
-        }
-        return Promise.resolve(jsonResponse({ success: true }));
-      }
-      return Promise.resolve(jsonResponse({ success: true }));
-    }) as unknown as typeof fetch;
-
-    render(<EmailProviderPage />, { wrapper: Wrapper });
-
-    await openEditor();
-    // Step 1 — client validation fires, formError renders.
-    typeIntoInput("fromAddress", "sender@acme.com");
-    await act(async () => {
-      clickButton("Save");
-    });
-    await waitFor(() => {
-      const el = document.querySelector('[role="alert"]');
-      expect(el?.textContent).toContain("API key is required.");
-    });
-
-    // Step 2 — fix the validation error and drive a server failure. The
-    // banner must now render the friendlyError copy (with requestId), not
-    // the previous formError string.
-    typeIntoInput("resendApiKey", "re_validkey");
-    saveShouldFail = true;
-    await act(async () => {
-      clickButton("Save");
-    });
-
-    await waitFor(() => {
-      const el = document.querySelector('[role="alert"]');
-      expect(el?.textContent).toContain("SMTP auth rejected");
-    });
-    const banner = document.querySelector('[role="alert"]')!;
-    expect(banner.textContent).toContain("req-win");
-    expect(banner.textContent).not.toContain("API key is required.");
   });
 });

--- a/packages/web/src/app/admin/email-provider/__tests__/mutation-error-chain.test.tsx
+++ b/packages/web/src/app/admin/email-provider/__tests__/mutation-error-chain.test.tsx
@@ -1,0 +1,263 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { render, fireEvent, waitFor, cleanup, act } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AtlasProvider, type AtlasAuthClient } from "@/ui/context";
+import EmailProviderPage from "../page";
+
+/**
+ * Regression guard for the three-way error chain at `email-provider/page.tsx`:
+ *
+ *   const structuredError = combineMutationErrors([saveError, deleteError, testError]);
+ *   const mutationError = structuredError ? friendlyError(structuredError) : formError;
+ *
+ * Three mutation errors fall through to a local `formError` when none failed.
+ * A regression — swapping the ternary arms, dropping the `formError` fallback,
+ * or rewiring the composition — would silently lose either the server-side
+ * requestId-bearing copy or the client-side validation hint. Both paths hit
+ * the same `ErrorBanner`, so only a rendered-DOM test catches the swap.
+ */
+
+const stubAuthClient: AtlasAuthClient = {
+  signIn: { email: async () => ({}) },
+  signUp: { email: async () => ({}) },
+  signOut: async () => {},
+  useSession: () => ({ data: null }),
+};
+
+let testQueryClient: QueryClient;
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return createElement(
+    QueryClientProvider,
+    { client: testQueryClient },
+    createElement(
+      AtlasProvider,
+      {
+        config: {
+          apiUrl: "http://localhost:3001",
+          isCrossOrigin: false as const,
+          authClient: stubAuthClient,
+        },
+      },
+      children,
+    ),
+  );
+}
+
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * Baseline payload the page expects from the initial GET — empty override so
+ * the editor renders fresh and the "+ Add credentials" affordance is wired up.
+ */
+const BASELINE_CONFIG = {
+  config: {
+    baseline: { provider: "resend", fromAddress: "noreply@atlas.dev" },
+    override: null,
+  },
+};
+
+/**
+ * Mock fetch with:
+ *   - GET `/email-provider`         → 200 baseline config
+ *   - PUT `/email-provider`         → caller-provided save handler
+ *   - POST `/email-provider/test`   → 200 (not exercised by these tests)
+ */
+function mockEmailProviderApi(
+  saveHandler: () => Response,
+) {
+  globalThis.fetch = mock((input: RequestInfo | URL, init?: RequestInit) => {
+    const method = init?.method ?? "GET";
+    if (method === "GET") return Promise.resolve(jsonResponse(BASELINE_CONFIG));
+    if (method === "PUT") return Promise.resolve(saveHandler());
+    return Promise.resolve(jsonResponse({ success: true, message: "ok" }));
+  }) as unknown as typeof fetch;
+}
+
+async function openEditor() {
+  const addButton = await waitFor(() => {
+    const b = Array.from(document.querySelectorAll("button")).find((btn) =>
+      btn.textContent?.includes("+ Add credentials"),
+    );
+    if (!b) throw new Error("+ Add credentials button not found");
+    return b;
+  });
+  await act(async () => {
+    fireEvent.click(addButton);
+  });
+}
+
+function typeIntoInput(id: string, value: string) {
+  const el = document.querySelector<HTMLInputElement>(`input#${id}`);
+  expect(el).not.toBeNull();
+  fireEvent.change(el!, { target: { value } });
+}
+
+function clickButton(label: string) {
+  const button = Array.from(document.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === label,
+  );
+  expect(button).toBeDefined();
+  fireEvent.click(button!);
+}
+
+describe("/admin/email-provider mutation error chain", () => {
+  beforeEach(() => {
+    testQueryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    });
+  });
+
+  afterEach(() => {
+    testQueryClient.clear();
+    cleanup();
+    globalThis.fetch = originalFetch;
+  });
+
+  test("a failing save mutation surfaces friendlyError copy with requestId", async () => {
+    // Valid client input reaches the wire; server rejects it. The banner must
+    // render the translated, requestId-bearing copy — not the raw `formError`
+    // string or the unfriendly `message` from the body.
+    mockEmailProviderApi(() =>
+      jsonResponse(
+        { message: "Upstream provider rejected key", requestId: "req-email-42" },
+        500,
+      ),
+    );
+
+    render(<EmailProviderPage />, { wrapper: Wrapper });
+
+    await openEditor();
+    typeIntoInput("resendApiKey", "re_validkey");
+    typeIntoInput("fromAddress", "sender@acme.com");
+    await act(async () => {
+      clickButton("Save");
+    });
+
+    const banner = await waitFor(() => {
+      const el = document.querySelector('[role="alert"]');
+      if (!el) throw new Error("alert not found");
+      return el;
+    });
+    // Preserves the server's body message AND the requestId — both are what
+    // `friendlyError` produces for a 500. A swap to a flattened or
+    // requestId-less copy would drop one or both halves.
+    expect(banner.textContent).toContain("Upstream provider rejected key");
+    expect(banner.textContent).toContain("req-email-42");
+  });
+
+  test("client validation error with no mutation in flight surfaces formError fallback", async () => {
+    // Server is never called — empty API key short-circuits inside `handleSave`
+    // via `buildProviderConfig`, setting `formError`. The banner copy is the
+    // raw validation string, which *only* reaches the DOM if the ternary's
+    // false-arm (`formError`) is intact.
+    const saveHandler = mock(() => jsonResponse({ success: true }));
+    mockEmailProviderApi(saveHandler);
+
+    render(<EmailProviderPage />, { wrapper: Wrapper });
+
+    await openEditor();
+    // Intentionally skip typing the API key — buildProviderConfig returns
+    // `{ ok: false, error: "API key is required." }`.
+    typeIntoInput("fromAddress", "sender@acme.com");
+    await act(async () => {
+      clickButton("Save");
+    });
+
+    const banner = await waitFor(() => {
+      const el = document.querySelector('[role="alert"]');
+      if (!el) throw new Error("alert not found");
+      return el;
+    });
+    expect(banner.textContent).toContain("API key is required.");
+    // No network call fired — the chain's false-arm is being exercised, not
+    // a phantom mutation failure.
+    expect(saveHandler).not.toHaveBeenCalled();
+  });
+
+  test("no errors → no banner renders", async () => {
+    mockEmailProviderApi(() => jsonResponse({ success: true }));
+
+    render(<EmailProviderPage />, { wrapper: Wrapper });
+
+    // Wait for initial GET to settle so the editor affordance is mounted and
+    // `formError` / mutation errors have had a chance to populate from any
+    // stray render cycle.
+    await waitFor(() => {
+      expect(
+        Array.from(document.querySelectorAll("button")).some((b) =>
+          b.textContent?.includes("+ Add credentials"),
+        ),
+      ).toBe(true);
+    });
+
+    expect(document.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  test("structured mutation error wins over a pre-existing formError", async () => {
+    // Drives the full ternary — `formError` is set first by a client-side
+    // failure, then a subsequent save triggers a server error. Once the
+    // mutation fails, `structuredError` is truthy so the banner copy MUST
+    // switch to the friendlyError arm even though `formError` was visible
+    // moments earlier. Swapping the ternary would leave the stale form copy
+    // in place and silently hide the server's requestId.
+    let saveShouldFail = false;
+    globalThis.fetch = mock((input: RequestInfo | URL, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      if (method === "GET") return Promise.resolve(jsonResponse(BASELINE_CONFIG));
+      if (method === "PUT") {
+        if (saveShouldFail) {
+          return Promise.resolve(
+            jsonResponse(
+              { message: "SMTP auth rejected", requestId: "req-win" },
+              500,
+            ),
+          );
+        }
+        return Promise.resolve(jsonResponse({ success: true }));
+      }
+      return Promise.resolve(jsonResponse({ success: true }));
+    }) as unknown as typeof fetch;
+
+    render(<EmailProviderPage />, { wrapper: Wrapper });
+
+    await openEditor();
+    // Step 1 — client validation fires, formError renders.
+    typeIntoInput("fromAddress", "sender@acme.com");
+    await act(async () => {
+      clickButton("Save");
+    });
+    await waitFor(() => {
+      const el = document.querySelector('[role="alert"]');
+      expect(el?.textContent).toContain("API key is required.");
+    });
+
+    // Step 2 — fix the validation error and drive a server failure. The
+    // banner must now render the friendlyError copy (with requestId), not
+    // the previous formError string.
+    typeIntoInput("resendApiKey", "re_validkey");
+    saveShouldFail = true;
+    await act(async () => {
+      clickButton("Save");
+    });
+
+    await waitFor(() => {
+      const el = document.querySelector('[role="alert"]');
+      expect(el?.textContent).toContain("SMTP auth rejected");
+    });
+    const banner = document.querySelector('[role="alert"]')!;
+    expect(banner.textContent).toContain("req-win");
+    expect(banner.textContent).not.toContain("API key is required.");
+  });
+});


### PR DESCRIPTION
## Summary

Test-only PR bundling the two targeted regression tests surfaced during PR #1622's review — both protect structured `FetchError` branches that TypeScript + helper unit tests don't cover on their own.

Closes #1626. Closes #1627.

- **`/admin/custom-domain` plan-gate** — three cases for `isPlanGated` keying on `error.code === "plan_required" | "enterprise_required"`. Covers both enum values (positive) plus a non-gated error (negative). The negative case uses 422 on purpose: `friendlyError` rewrites 401/403/404/503 to canned copy, so a 403 would render as "Access denied" and make the banner indistinguishable from the admin-role path.
- **`/admin/email-provider` error chain** — four cases for the ternary `structuredError ? friendlyError(structuredError) : formError`:
  1. Failing save mutation → `friendlyError` copy with requestId in banner.
  2. Client validation (empty API key) → `formError` string reaches DOM with no network call.
  3. No errors → no `[role="alert"]` banner.
  4. Both paths exercised in sequence → once the mutation fails, banner copy switches from `formError` to `friendlyError` (the ternary's true-arm wins, even with `formError` previously visible).

Follows the `admin-mutation-error-passthrough.test.tsx` pattern from #1614 — renders the real page, mocks `globalThis.fetch` by method, drives the happy path via RTL `fireEvent`, asserts on rendered DOM.

**Skipped from this bundle** (per scoping in #1628 follow-ups):
- #1629 (hook-level concurrent error stomping) — shape change, deserves its own PR.
- #1624 (`MutationErrorSurface` primitive) — 30–40 call-site migration.
- #1631 (e2e + pure-function tests for `/admin/sessions`) — e2e half blocked by the dev stack boot issue.

## Test plan
- [x] `bun run test` in `packages/web` — 68/68 files pass (includes the 2 new files, 7 new test cases).
- [x] `bun run type` — passes at repo root.
- [x] `bun run lint` — clean.
- [ ] Tests live under `src/app/admin/{custom-domain,email-provider}/__tests__/` — first page-level tests for those routes.