### PR TITLE
fix(web/hooks): per-item error slots in useAdminMutation (#1629)

### DIFF
--- a/packages/web/src/ui/__tests__/use-admin-mutation.test.ts
+++ b/packages/web/src/ui/__tests__/use-admin-mutation.test.ts
@@ -784,11 +784,12 @@ describe("useAdminMutation", () => {
     expect(result.current.error).toBeNull();
   });
 
-  test("non-itemized successful call after an itemized failure does NOT clear the hook-level error", async () => {
-    // Subtle case: once an itemized failure owns the hook slot, only that
-    // itemId's success (or explicit clearError / clearErrorFor / reset)
-    // should dismiss it. A non-itemized success running afterward must not
-    // silently wipe it — the caller pointed at a different surface.
+  test("non-itemized successful call clears the hook-level slot but preserves per-item records", async () => {
+    // Non-itemized `mutate()` IS documented to clear hook-level `error` at
+    // start (implicit-retry-dismiss for single-slot surfaces). The subtle
+    // point this test pins is that the per-item record for a failed itemized
+    // call is NOT touched by that clear — bulk surfaces reading
+    // `errorsByItemId` stay accurate across unrelated non-itemized actions.
     let phase: "fail" | "succeed" = "fail";
     globalThis.fetch = mock(() => {
       if (phase === "fail") {
@@ -889,6 +890,172 @@ describe("useAdminMutation", () => {
     expect(result.current.errorsByItemId).toEqual({});
     expect(result.current.errorFor("r1")).toBeUndefined();
     expect(result.current.error).toBeNull();
+  });
+
+  test("three-party handoff: owner-success promotes a surviving error into the hook slot", async () => {
+    // A fails → B fails → B retries successfully. Without the promote-on-
+    // clear logic, B's success would clear the hook-level slot (because B
+    // owned it) and the banner would go empty WHILE row A is still
+    // broken in errorsByItemId. Promote keeps the banner in sync with the
+    // map — the user sees "A is still failing" instead of false all-clear.
+    let phase: "fail" | "succeed" = "fail";
+    globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+      if (phase === "succeed") return Promise.resolve(jsonResponse({ ok: true }));
+      const body = init?.body ? (JSON.parse(init.body as string) as { id: string }) : { id: "?" };
+      return Promise.resolve(jsonResponse({ message: `Failed ${body.id}` }, 500));
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(
+      () => useAdminMutation({ path: "/api/v1/admin/items" }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.mutate({ body: { id: "A" }, itemId: "A" });
+    });
+    await act(async () => {
+      await result.current.mutate({ body: { id: "B" }, itemId: "B" });
+    });
+    expect(result.current.error?.message).toBe("Failed B");
+
+    // B retries successfully.
+    phase = "succeed";
+    await act(async () => {
+      await result.current.mutate({ body: { id: "B" }, itemId: "B" });
+    });
+
+    // Banner tracks the surviving failure, not the cleared one.
+    expect(result.current.errorFor("B")).toBeUndefined();
+    expect(result.current.errorFor("A")?.message).toBe("Failed A");
+    expect(result.current.error?.message).toBe("Failed A");
+  });
+
+  test("clearErrorFor with surviving failures promotes another item into the hook slot", async () => {
+    // Same promote invariant, triggered by explicit dismissal instead of
+    // success. Dismissing a row-level error while another row is still
+    // broken must not silently empty the banner.
+    //
+    // Fresh Response per call — Response bodies are single-read, so reusing
+    // one instance across back-to-back fetches trips happy-dom's
+    // already-consumed guard and makes `extractFetchError` fall back to
+    // "HTTP 500".
+    globalThis.fetch = mock(() =>
+      Promise.resolve(jsonResponse({ message: "nope" }, 500)),
+    ) as unknown as typeof fetch;
+
+    const { result } = renderHook(
+      () => useAdminMutation({ path: "/api/v1/admin/items" }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.mutate({ itemId: "A" });
+    });
+    await act(async () => {
+      await result.current.mutate({ itemId: "B" });
+    });
+    expect(result.current.error?.message).toBe("nope");
+
+    act(() => {
+      result.current.clearErrorFor("B");
+    });
+    // B's slot gone; A still holds an error; banner tracks A.
+    expect(result.current.errorFor("B")).toBeUndefined();
+    expect(result.current.errorFor("A")?.message).toBe("nope");
+    expect(result.current.error?.message).toBe("nope");
+  });
+
+  test("clearError() dismisses only the hook-level slot and leaves errorsByItemId intact", async () => {
+    // Contract: `clearError` is a narrow banner-dismiss. Per-item state is
+    // managed separately — callers that want to wipe everything reach for
+    // `reset()`. Without this contract, a banner-dismiss would silently
+    // mark rows as "recovered" in the per-item map.
+    mockFetch(jsonResponse({ message: "row bad" }, 500));
+
+    const { result } = renderHook(
+      () => useAdminMutation({ path: "/api/v1/admin/items" }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.mutate({ itemId: "r-1" });
+    });
+    expect(result.current.error?.message).toBe("row bad");
+    expect(result.current.errorFor("r-1")?.message).toBe("row bad");
+
+    act(() => {
+      result.current.clearError();
+    });
+    expect(result.current.error).toBeNull();
+    // Per-item record persists — bulk surfaces still see r-1 as broken.
+    expect(result.current.errorFor("r-1")?.message).toBe("row bad");
+  });
+
+  test("mutate({ itemId }) with no path populates errorsByItemId, not just hook-level", async () => {
+    // Regression guard: bulk callers reading exclusively via `errorFor(id)`
+    // for a given row must see a no-path config error on that row. Earlier
+    // the missing-path early-return only set hook-level `error`, so a bulk
+    // surface would silently treat the row as healthy.
+    const { result } = renderHook(
+      () => useAdminMutation(), // no path configured
+      { wrapper },
+    );
+
+    let mutateResult: MutateResult<unknown>;
+    await act(async () => {
+      mutateResult = await result.current.mutate({ itemId: "row-z" });
+    });
+
+    expect(mutateResult!.ok).toBe(false);
+    if (!mutateResult!.ok) {
+      expect(mutateResult!.error.message).toContain("no path");
+    }
+    expect(result.current.errorFor("row-z")?.message).toContain("no path");
+    expect(result.current.error?.message).toContain("no path");
+  });
+
+  test("reset() during flight: a late-settling mutation does not repopulate cleared slots", async () => {
+    // Dialog contract: callers invoke `reset()` on close to wipe state.
+    // Any in-flight request that settles afterward (network slow, tab
+    // backgrounded) must honor that intent — otherwise a phantom banner
+    // re-appears on the next open with an error from the prior session.
+    let respondFail!: (res: Response) => void;
+    globalThis.fetch = mock(() =>
+      new Promise<Response>((resolve) => {
+        respondFail = resolve;
+      }),
+    ) as unknown as typeof fetch;
+
+    const { result } = renderHook(
+      () => useAdminMutation({ path: "/api/v1/admin/items" }),
+      { wrapper },
+    );
+
+    let pending!: Promise<MutateResult<unknown>>;
+    await act(async () => {
+      pending = result.current.mutate({ itemId: "late" });
+      // Let TanStack dispatch the fetch so `respondFail` is populated.
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(result.current.isMutating("late")).toBe(true);
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.errorsByItemId).toEqual({});
+
+    // Now let the in-flight mutation reject.
+    await act(async () => {
+      respondFail(jsonResponse({ message: "Too late" }, 500));
+      await pending;
+    });
+    // Slots stay clean — the generation guard short-circuited the catch-
+    // path state writes. The resolved result still reports the failure to
+    // whoever was awaiting it, which is fine: that caller is accountable
+    // for its own local state, not the hook's.
+    expect(result.current.error).toBeNull();
+    expect(result.current.errorsByItemId).toEqual({});
   });
 
   test("a throwing onSuccess callback does not flip result.ok or populate hook error", async () => {

--- a/packages/web/src/ui/__tests__/use-admin-mutation.test.ts
+++ b/packages/web/src/ui/__tests__/use-admin-mutation.test.ts
@@ -613,6 +613,284 @@ describe("useAdminMutation", () => {
     }
   });
 
+  /* ---------------------------------------------------------------- */
+  /*  Per-item error tracking (#1629)                                  */
+  /*                                                                    */
+  /*  Before the fix: every `mutate()` call unconditionally cleared     */
+  /*  hook-level `error` at start, so a concurrent bulk fan-out         */
+  /*  (`Promise.all`/`allSettled`) with itemIds would silently lose all  */
+  /*  but the last-resolved failure. The hook advertised a `error` slot */
+  /*  callers couldn't trust for anything except single-row flows.      */
+  /* ---------------------------------------------------------------- */
+
+  test("itemized failure populates errorsByItemId and errorFor", async () => {
+    mockFetch(jsonResponse({ message: "Denied" }, 403));
+
+    const { result } = renderHook(
+      () => useAdminMutation({ path: "/api/v1/admin/items/x" }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.mutate({ itemId: "row-7" });
+    });
+
+    await waitFor(() => {
+      expect(result.current.errorFor("row-7")?.message).toBe("Denied");
+      expect(result.current.errorFor("row-7")?.status).toBe(403);
+    });
+    expect(result.current.errorsByItemId).toEqual({
+      "row-7": { message: "Denied", status: 403 },
+    });
+    // Unknown ids return undefined (no spurious entries).
+    expect(result.current.errorFor("row-other")).toBeUndefined();
+    // Hook-level error still set (single-row callers reading `.error` keep
+    // working without migration — documented "last wins" for concurrent
+    // itemized calls).
+    expect(result.current.error?.message).toBe("Denied");
+  });
+
+  test("concurrent itemized failures all survive in errorsByItemId (no start-of-mutate stomp)", async () => {
+    // The regression this test pins: call A fails, call B starts (used to
+    // clear hook-level via `setError(null)`), call B succeeds → errA was lost.
+    // With the fix, per-item slots are the authoritative record and survive
+    // any ordering — concurrent bulk fan-out can now trust errorsByItemId.
+    globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+      // Tag the failure body with the request body so the test can recover
+      // which itemId the response corresponds to — concurrent resolution
+      // order is non-deterministic.
+      const body = init?.body ? (JSON.parse(init.body as string) as { id: string }) : { id: "?" };
+      return Promise.resolve(
+        jsonResponse({ message: `Failed ${body.id}`, error: "denied" }, 500),
+      );
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(
+      () => useAdminMutation({ path: "/api/v1/admin/items" }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await Promise.all([
+        result.current.mutate({ body: { id: "A" }, itemId: "A" }),
+        result.current.mutate({ body: { id: "B" }, itemId: "B" }),
+        result.current.mutate({ body: { id: "C" }, itemId: "C" }),
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(Object.keys(result.current.errorsByItemId).sort()).toEqual([
+        "A",
+        "B",
+        "C",
+      ]);
+    });
+    expect(result.current.errorFor("A")?.message).toBe("Failed A");
+    expect(result.current.errorFor("B")?.message).toBe("Failed B");
+    expect(result.current.errorFor("C")?.message).toBe("Failed C");
+    // Hook-level `error` is "last wins" — one of the three, but whichever it
+    // is, it must NOT be null (would prove it was stomped by a concurrent
+    // start-of-mutate clear).
+    expect(result.current.error).not.toBeNull();
+  });
+
+  test("successful itemized call on a different itemId does not clear a prior item's error", async () => {
+    // Original #1629 timeline step 3: "Call B succeeds → no setError → errA
+    // is silently gone". The fix ensures errA stays in errorsByItemId AND
+    // in the hook-level slot (since A still owns it).
+    let respond: (res: Response) => void = () => {};
+    globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+      const body = init?.body ? (JSON.parse(init.body as string) as { id: string }) : { id: "?" };
+      if (body.id === "A") return Promise.resolve(jsonResponse({ message: "A bad" }, 500));
+      return new Promise<Response>((resolve) => {
+        respond = resolve;
+      });
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(
+      () => useAdminMutation({ path: "/api/v1/admin/items" }),
+      { wrapper },
+    );
+
+    // A fails first — hook-level `error` and errorsByItemId.A both populated.
+    await act(async () => {
+      await result.current.mutate({ body: { id: "A" }, itemId: "A" });
+    });
+    expect(result.current.error?.message).toBe("A bad");
+
+    // B is in-flight; won't flush until respond() is called. It must NOT
+    // clear hook-level `error` at start (that's the stomp bug).
+    let bPromise!: Promise<MutateResult<unknown>>;
+    await act(async () => {
+      bPromise = result.current.mutate({ body: { id: "B" }, itemId: "B" });
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(result.current.error?.message).toBe("A bad");
+    expect(result.current.errorFor("A")?.message).toBe("A bad");
+
+    // B succeeds — A's banner must remain.
+    await act(async () => {
+      respond(jsonResponse({ ok: true }));
+      await bPromise;
+    });
+    expect(result.current.error?.message).toBe("A bad");
+    expect(result.current.errorFor("A")?.message).toBe("A bad");
+    expect(result.current.errorFor("B")).toBeUndefined();
+  });
+
+  test("successful retry of the same itemId clears its per-item slot AND the hook-level slot it owns", async () => {
+    // Single-row UX: row failed once, user retries, retry succeeds — banner
+    // must dismiss. Without the errorItemId ownership check, the hook-level
+    // slot would linger even after the row that set it recovered.
+    let respond: (res: Response) => void = () => {};
+    let callCount = 0;
+    globalThis.fetch = mock(() => {
+      callCount++;
+      if (callCount === 1) return Promise.resolve(jsonResponse({ message: "Flaky" }, 500));
+      return new Promise<Response>((resolve) => {
+        respond = resolve;
+      });
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(
+      () => useAdminMutation({ path: "/api/v1/admin/items" }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.mutate({ itemId: "row-5" });
+    });
+    expect(result.current.error?.message).toBe("Flaky");
+    expect(result.current.errorFor("row-5")?.message).toBe("Flaky");
+
+    // Retry — succeeds this time.
+    let retryPromise!: Promise<MutateResult<unknown>>;
+    await act(async () => {
+      retryPromise = result.current.mutate({ itemId: "row-5" });
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    // Start-of-mutate clears the per-item slot; hook-level slot still shows
+    // the prior error until resolution — the "don't reset during in-flight"
+    // behaviour is intentional (see comment in mutate()).
+    expect(result.current.errorFor("row-5")).toBeUndefined();
+
+    await act(async () => {
+      respond(jsonResponse({ ok: true }));
+      await retryPromise;
+    });
+    expect(result.current.errorFor("row-5")).toBeUndefined();
+    // Banner dismisses on successful retry because row-5 also owned the hook
+    // slot at entry (`errorItemIdRef`).
+    expect(result.current.error).toBeNull();
+  });
+
+  test("non-itemized successful call after an itemized failure does NOT clear the hook-level error", async () => {
+    // Subtle case: once an itemized failure owns the hook slot, only that
+    // itemId's success (or explicit clearError / clearErrorFor / reset)
+    // should dismiss it. A non-itemized success running afterward must not
+    // silently wipe it — the caller pointed at a different surface.
+    let phase: "fail" | "succeed" = "fail";
+    globalThis.fetch = mock(() => {
+      if (phase === "fail") {
+        return Promise.resolve(jsonResponse({ message: "row bad" }, 500));
+      }
+      return Promise.resolve(jsonResponse({ ok: true }));
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(
+      () => useAdminMutation({ path: "/api/v1/admin/items" }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.mutate({ itemId: "row-9" });
+    });
+    expect(result.current.error?.message).toBe("row bad");
+
+    // Non-itemized call — should clear hook slot at start (that IS
+    // documented behavior for non-itemized mutate) and stay cleared on
+    // success. The per-item slot for row-9 must remain so the bulk surface
+    // still knows row-9 is still broken.
+    phase = "succeed";
+    await act(async () => {
+      await result.current.mutate();
+    });
+    expect(result.current.error).toBeNull();
+    // Per-item record for row-9 untouched by the non-itemized clear.
+    expect(result.current.errorFor("row-9")?.message).toBe("row bad");
+  });
+
+  test("clearErrorFor clears the per-item slot and the hook-level slot when the id owns it", async () => {
+    mockFetch(jsonResponse({ message: "Nope" }, 403));
+
+    const { result } = renderHook(
+      () => useAdminMutation({ path: "/api/v1/admin/items" }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.mutate({ itemId: "row-1" });
+    });
+    expect(result.current.error?.message).toBe("Nope");
+    expect(result.current.errorFor("row-1")?.message).toBe("Nope");
+
+    act(() => {
+      result.current.clearErrorFor("row-1");
+    });
+    expect(result.current.errorFor("row-1")).toBeUndefined();
+    // row-1 owned the hook slot, so clearing the per-item error also
+    // dismisses the shared banner — otherwise a stale banner would outlive
+    // the per-item state it reflected.
+    expect(result.current.error).toBeNull();
+  });
+
+  test("clearErrorFor on a non-owning id leaves the hook-level slot intact", async () => {
+    // A failing itemized call takes ownership of the hook slot. Later,
+    // clearing a DIFFERENT (non-failing) id via clearErrorFor is a no-op for
+    // hook-level.
+    mockFetch(jsonResponse({ message: "Nope" }, 403));
+
+    const { result } = renderHook(
+      () => useAdminMutation({ path: "/api/v1/admin/items" }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.mutate({ itemId: "row-A" });
+    });
+    expect(result.current.error?.message).toBe("Nope");
+
+    act(() => {
+      result.current.clearErrorFor("row-unrelated");
+    });
+    expect(result.current.error?.message).toBe("Nope");
+    expect(result.current.errorFor("row-A")?.message).toBe("Nope");
+  });
+
+  test("reset() clears errorsByItemId along with error/saving/in-flight", async () => {
+    mockFetch(jsonResponse({ message: "Boom" }, 500));
+
+    const { result } = renderHook(
+      () => useAdminMutation({ path: "/api/v1/admin/items" }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.mutate({ itemId: "r1" });
+    });
+    await act(async () => {
+      await result.current.mutate({ itemId: "r2" });
+    });
+    expect(Object.keys(result.current.errorsByItemId).sort()).toEqual(["r1", "r2"]);
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.errorsByItemId).toEqual({});
+    expect(result.current.errorFor("r1")).toBeUndefined();
+    expect(result.current.error).toBeNull();
+  });
+
   test("a throwing onSuccess callback does not flip result.ok or populate hook error", async () => {
     // Same invariant as invalidates — onSuccess is user code that may throw
     // (e.g. a dialog close handler that races with unmount). The mutation

--- a/packages/web/src/ui/hooks/use-admin-mutation.ts
+++ b/packages/web/src/ui/hooks/use-admin-mutation.ts
@@ -76,8 +76,11 @@ interface UseAdminMutationReturn<TResponse> {
    *   For bulk readers, prefer the per-item map via `errorFor(id)` — this
    *   slot still surfaces a last-wins banner for single-row UX.
    * - An itemized call that **succeeds** clears this slot only when it was
-   *   the same itemId that last populated it, so a successful retry of the
-   *   failed row dismisses its banner while failures on other rows persist.
+   *   the same itemId that last populated it. If other itemIds still hold
+   *   errors, one is promoted into this slot so the banner tracks the map
+   *   instead of going empty while `errorsByItemId` still reports failures.
+   * - `clearError()` dismisses this slot only — per-item state is managed
+   *   independently via `clearErrorFor(id)` or `reset()`.
    */
   error: FetchError | null;
   /**
@@ -120,47 +123,104 @@ export function useAdminMutation<TResponse = unknown>(
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<FetchError | null>(null);
   const [inFlight, setInFlight] = useState<Set<string>>(new Set());
-  const [errorsByItemId, setErrorsByItemId] = useState<Record<string, FetchError>>({});
+  const [errorsByItemId, setErrorsByItemIdState] =
+    useState<Record<string, FetchError>>({});
 
-  // Tracks which itemId (if any) last populated hook-level `error`. Kept in a
-  // ref so an itemized success can clear the hook-level slot only when IT was
-  // the one that last wrote to it — otherwise a newer failure on a DIFFERENT
-  // itemId stays visible in the banner. Null when the slot was last written
-  // by a non-itemized call (or is already empty).
+  // Synchronous mirror of `errorsByItemId`. The promote-on-clear logic needs
+  // to read the map *after* a delete to decide whether to clear the hook-level
+  // slot or promote a surviving entry into it. A functional `setState` updater
+  // alone can't do both — the updated value is only observable after React
+  // schedules the re-render. Pairing state with a ref keeps both in lockstep
+  // and makes `updateErrorsByItemId` synchronously readable.
+  const errorsByItemIdRef = useRef<Record<string, FetchError>>({});
+
+  // Tracks which itemId (if any) last populated hook-level `error`. Used to
+  // decide whether an itemized success/clear should dismiss the shared banner:
+  // only the current owner may clear it, and if other itemIds still have
+  // errors, ownership promotes to one of them instead of leaving the banner
+  // empty while the map still reports failures.
   const errorItemIdRef = useRef<string | null>(null);
+
+  // Generation counter that increments on `reset()`. An in-flight mutation's
+  // catch/success handlers check this before writing state — if the caller
+  // reset the hook after the request was dispatched, any late settlement
+  // must NOT repopulate the slots the reset just cleared. Without this, a
+  // dialog that calls `reset()` on close would see a phantom banner reappear
+  // on its next open when the stale request finally settles.
+  const generationRef = useRef(0);
 
   // Ref to read latest hook-level options inside mutationFn without recreating the mutation.
   const optionsRef = useRef(options);
   optionsRef.current = options;
 
-  const clearError = useCallback(() => {
-    setError(null);
-    errorItemIdRef.current = null;
-  }, []);
+  const updateErrorsByItemId = useCallback(
+    (next: Record<string, FetchError>) => {
+      errorsByItemIdRef.current = next;
+      setErrorsByItemIdState(next);
+    },
+    [],
+  );
 
-  const clearErrorFor = useCallback((itemId: string) => {
-    setErrorsByItemId((prev) => {
-      if (!(itemId in prev)) return prev;
-      const next = { ...prev };
-      delete next[itemId];
-      return next;
-    });
-    // If this itemId also owns the hook-level slot, clear it — otherwise a
-    // caller dismissing a per-item banner would leave a stale shared banner
-    // behind.
-    if (errorItemIdRef.current === itemId) {
+  // Called when the current hook-level owner's slot is being removed. If any
+  // itemId still has a per-item error, one is promoted into the shared slot
+  // so the banner stays consistent with `errorsByItemId`; otherwise the slot
+  // is cleared. Never called for non-owning clears (the hook-level slot isn't
+  // ours to touch in that case).
+  const promoteOrClearHookLevel = useCallback(() => {
+    const remaining = errorsByItemIdRef.current;
+    let nextId: string | undefined;
+    for (const key in remaining) {
+      nextId = key;
+      break;
+    }
+    if (nextId !== undefined) {
+      setError(remaining[nextId]!);
+      errorItemIdRef.current = nextId;
+    } else {
       setError(null);
       errorItemIdRef.current = null;
     }
   }, []);
 
+  const clearError = useCallback(() => {
+    // Narrow dismissal: the user dismissed the shared banner, but per-item
+    // state is a separate surface (row markers, retry affordances) that the
+    // caller manages independently. Clearing only the hook-level slot leaves
+    // `errorsByItemId` untouched so bulk surfaces stay in sync with which
+    // rows are still broken. Use `clearErrorFor(id)` or `reset()` to dismiss
+    // per-item entries.
+    setError(null);
+    errorItemIdRef.current = null;
+  }, []);
+
+  const clearErrorFor = useCallback(
+    (itemId: string) => {
+      const prev = errorsByItemIdRef.current;
+      if (itemId in prev) {
+        const next = { ...prev };
+        delete next[itemId];
+        updateErrorsByItemId(next);
+      }
+      // If this itemId owned the hook slot, let another surviving item take
+      // over — otherwise the banner goes empty while the map still reports
+      // failures elsewhere.
+      if (errorItemIdRef.current === itemId) {
+        promoteOrClearHookLevel();
+      }
+    },
+    [updateErrorsByItemId, promoteOrClearHookLevel],
+  );
+
   const reset = useCallback(() => {
+    // Bump the generation so any currently in-flight mutation that settles
+    // after this point declines to write state (its `callGen` won't match).
+    generationRef.current += 1;
     setError(null);
     setSaving(false);
     setInFlight(new Set());
-    setErrorsByItemId({});
+    updateErrorsByItemId({});
     errorItemIdRef.current = null;
-  }, []);
+  }, [updateErrorsByItemId]);
 
   const isMutating = useCallback(
     (itemId: string) => inFlight.has(itemId),
@@ -233,14 +293,21 @@ export function useAdminMutation<TResponse = unknown>(
     async (callOpts?: MutateOptions<TResponse>): Promise<MutateResult<TResponse>> => {
       const opts = optionsRef.current;
       const itemId = callOpts?.itemId;
+      // Snapshot at dispatch time; any late settlement that arrives after a
+      // `reset()` (which bumps this) declines to write state.
+      const callGen = generationRef.current;
 
       if (!callOpts?.path && !opts?.path) {
         const fetchError: FetchError = { message: "useAdminMutation: no path provided" };
-        // A missing-path bug is a caller error and not itemized — always
-        // populate the hook-level slot so the surface notices it regardless
-        // of how the caller reads errors.
+        // Populate both slots for itemized callers — a bulk surface reading
+        // only `errorFor(id)` would otherwise miss the failure and the row
+        // would silently look healthy.
+        if (itemId) {
+          const next = { ...errorsByItemIdRef.current, [itemId]: fetchError };
+          updateErrorsByItemId(next);
+        }
         setError(fetchError);
-        errorItemIdRef.current = null;
+        errorItemIdRef.current = itemId ?? null;
         return { ok: false, error: fetchError };
       }
 
@@ -252,12 +319,12 @@ export function useAdminMutation<TResponse = unknown>(
       // stomp each other's errors (#1629).
       if (itemId) {
         setInFlight((prev) => new Set(prev).add(itemId));
-        setErrorsByItemId((prev) => {
-          if (!(itemId in prev)) return prev;
+        const prev = errorsByItemIdRef.current;
+        if (itemId in prev) {
           const next = { ...prev };
           delete next[itemId];
-          return next;
-        });
+          updateErrorsByItemId(next);
+        }
       } else {
         setSaving(true);
         setError(null);
@@ -275,8 +342,19 @@ export function useAdminMutation<TResponse = unknown>(
         const fetchError =
           (err as { fetchError?: FetchError }).fetchError ??
           ({ message: msg || "Request failed" } satisfies FetchError);
+
+        if (generationRef.current !== callGen) {
+          // `reset()` ran after this mutation was dispatched — swallow the
+          // state writes so the caller's clean slate holds. The promise still
+          // resolves to `{ ok: false, error }` so the direct `await` path
+          // reports the failure; the discrepancy is the hook-level state,
+          // which the caller explicitly asked to clear.
+          return { ok: false, error: fetchError };
+        }
+
         if (itemId) {
-          setErrorsByItemId((prev) => ({ ...prev, [itemId]: fetchError }));
+          const nextMap = { ...errorsByItemIdRef.current, [itemId]: fetchError };
+          updateErrorsByItemId(nextMap);
         }
         // Mirror to hook-level `error` in both cases so the many single-row
         // callers that read `mutation.error` continue to surface failures
@@ -289,6 +367,7 @@ export function useAdminMutation<TResponse = unknown>(
       } finally {
         if (itemId) {
           setInFlight((prev) => {
+            if (!prev.has(itemId)) return prev;
             const next = new Set(prev);
             next.delete(itemId);
             return next;
@@ -298,21 +377,25 @@ export function useAdminMutation<TResponse = unknown>(
         }
       }
 
-      // Successful itemized mutation: clear that itemId's per-item slot, and
-      // if this itemId also owns the hook-level slot (e.g. a retry of the
-      // failed row that just succeeded), clear the hook slot too so the
-      // banner doesn't linger on success. Failures on OTHER itemIds stay
-      // visible — their ownership of the hook slot is unchanged.
+      if (generationRef.current !== callGen) {
+        // Reset during flight — same rationale as the catch path.
+        return { ok: true, data };
+      }
+
+      // Successful itemized mutation: clear that itemId's per-item slot. If
+      // this itemId owns the hook-level slot, promote a surviving entry into
+      // it so the banner tracks the map — otherwise the three-party handoff
+      // (A fails, B fails, B retries to success) would silently blank the
+      // banner while A is still broken.
       if (itemId) {
-        setErrorsByItemId((prev) => {
-          if (!(itemId in prev)) return prev;
+        const prev = errorsByItemIdRef.current;
+        if (itemId in prev) {
           const next = { ...prev };
           delete next[itemId];
-          return next;
-        });
+          updateErrorsByItemId(next);
+        }
         if (errorItemIdRef.current === itemId) {
-          setError(null);
-          errorItemIdRef.current = null;
+          promoteOrClearHookLevel();
         }
       }
 

--- a/packages/web/src/ui/hooks/use-admin-mutation.ts
+++ b/packages/web/src/ui/hooks/use-admin-mutation.ts
@@ -56,19 +56,48 @@ interface UseAdminMutationReturn<TResponse> {
   saving: boolean;
   /**
    * Last mutation error as a structured {@link FetchError}, or null.
-   * Cleared on next `mutate()` call. Feed into `friendlyError()` for banner
-   * copy, or branch on `code === "enterprise_required"` / `status` directly —
-   * the structured fields stay intact so `AdminContentWrapper` can route EE
-   * 403s into `EnterpriseUpsell` instead of a generic banner. Stays
-   * `FetchError` (not flattened to `string`) specifically so the `code`,
-   * `status`, and `requestId` fields survive the hook boundary — wrapping it
-   * as `{ message: error.message }` re-flattens and is guarded by an ESLint
+   * Feed into `friendlyError()` for banner copy, or branch on
+   * `code === "enterprise_required"` / `status` directly — the structured
+   * fields stay intact so `AdminContentWrapper` can route EE 403s into
+   * `EnterpriseUpsell` instead of a generic banner. Stays `FetchError`
+   * (not flattened to `string`) specifically so the `code`, `status`, and
+   * `requestId` fields survive the hook boundary — wrapping it as
+   * `{ message: error.message }` re-flattens and is guarded by an ESLint
    * rule in `eslint.config.mjs`.
+   *
+   * Clearing semantics intentionally differ for itemized vs non-itemized
+   * calls:
+   * - **Non-itemized** `mutate()` — cleared at the start of the next call
+   *   (stale error from a prior failed attempt is implicitly dismissed when
+   *   the user retries).
+   * - **Itemized** `mutate({ itemId })` — NOT cleared at the start of the
+   *   next call, so concurrent bulk fan-out (`Promise.all` / `allSettled`)
+   *   can't stomp a prior item's error via the start-of-mutate reset (#1629).
+   *   For bulk readers, prefer the per-item map via `errorFor(id)` — this
+   *   slot still surfaces a last-wins banner for single-row UX.
+   * - An itemized call that **succeeds** clears this slot only when it was
+   *   the same itemId that last populated it, so a successful retry of the
+   *   failed row dismisses its banner while failures on other rows persist.
    */
   error: FetchError | null;
-  /** Clear the error manually. */
+  /**
+   * Per-item error map — populated when `mutate({ itemId })` fails, cleared
+   * when the same itemId's next mutate call starts or succeeds. Reliable
+   * under concurrent fan-out (each itemId owns its own slot), unlike the
+   * shared hook-level `error`.
+   *
+   * Prefer `errorFor(id)` for lookup; the raw map is exposed for callers
+   * that need to render multiple per-item banners in one pass (e.g. bulk
+   * summaries) or iterate over failed ids.
+   */
+  errorsByItemId: Readonly<Record<string, FetchError>>;
+  /** Lookup helper for {@link errorsByItemId}. */
+  errorFor: (itemId: string) => FetchError | undefined;
+  /** Clear the hook-level error manually. */
   clearError: () => void;
-  /** Reset both error and saving state (e.g. when a dialog reopens). */
+  /** Clear a single itemId's error without touching other slots. */
+  clearErrorFor: (itemId: string) => void;
+  /** Reset all error slots and in-flight state (e.g. when a dialog reopens). */
   reset: () => void;
   /** Check whether a per-item mutation is in flight. */
   isMutating: (itemId: string) => boolean;
@@ -91,22 +120,59 @@ export function useAdminMutation<TResponse = unknown>(
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<FetchError | null>(null);
   const [inFlight, setInFlight] = useState<Set<string>>(new Set());
+  const [errorsByItemId, setErrorsByItemId] = useState<Record<string, FetchError>>({});
+
+  // Tracks which itemId (if any) last populated hook-level `error`. Kept in a
+  // ref so an itemized success can clear the hook-level slot only when IT was
+  // the one that last wrote to it — otherwise a newer failure on a DIFFERENT
+  // itemId stays visible in the banner. Null when the slot was last written
+  // by a non-itemized call (or is already empty).
+  const errorItemIdRef = useRef<string | null>(null);
 
   // Ref to read latest hook-level options inside mutationFn without recreating the mutation.
   const optionsRef = useRef(options);
   optionsRef.current = options;
 
-  const clearError = useCallback(() => setError(null), []);
+  const clearError = useCallback(() => {
+    setError(null);
+    errorItemIdRef.current = null;
+  }, []);
+
+  const clearErrorFor = useCallback((itemId: string) => {
+    setErrorsByItemId((prev) => {
+      if (!(itemId in prev)) return prev;
+      const next = { ...prev };
+      delete next[itemId];
+      return next;
+    });
+    // If this itemId also owns the hook-level slot, clear it — otherwise a
+    // caller dismissing a per-item banner would leave a stale shared banner
+    // behind.
+    if (errorItemIdRef.current === itemId) {
+      setError(null);
+      errorItemIdRef.current = null;
+    }
+  }, []);
 
   const reset = useCallback(() => {
     setError(null);
     setSaving(false);
     setInFlight(new Set());
+    setErrorsByItemId({});
+    errorItemIdRef.current = null;
   }, []);
 
   const isMutating = useCallback(
     (itemId: string) => inFlight.has(itemId),
     [inFlight],
+  );
+
+  // `errorsByItemId` is already a stable Record snapshot per render — a
+  // straight closure avoids an extra memo + dep and matches how `isMutating`
+  // reads `inFlight`.
+  const errorFor = useCallback(
+    (itemId: string): FetchError | undefined => errorsByItemId[itemId],
+    [errorsByItemId],
   );
 
   const mutation = useMutation<TResponse | undefined, Error, MutateOptions<TResponse> | undefined>({
@@ -170,17 +236,33 @@ export function useAdminMutation<TResponse = unknown>(
 
       if (!callOpts?.path && !opts?.path) {
         const fetchError: FetchError = { message: "useAdminMutation: no path provided" };
+        // A missing-path bug is a caller error and not itemized — always
+        // populate the hook-level slot so the surface notices it regardless
+        // of how the caller reads errors.
         setError(fetchError);
+        errorItemIdRef.current = null;
         return { ok: false, error: fetchError };
       }
 
-      // Track loading state
+      // Start-of-mutate clearing is deliberately asymmetric between itemized
+      // and non-itemized calls. Non-itemized: clear hook-level `error` so a
+      // new attempt dismisses the stale banner for this mutation slot.
+      // Itemized: clear ONLY this itemId's per-item slot. Touching the
+      // hook-level slot here is what caused concurrent bulk fan-out to
+      // stomp each other's errors (#1629).
       if (itemId) {
         setInFlight((prev) => new Set(prev).add(itemId));
+        setErrorsByItemId((prev) => {
+          if (!(itemId in prev)) return prev;
+          const next = { ...prev };
+          delete next[itemId];
+          return next;
+        });
       } else {
         setSaving(true);
+        setError(null);
+        errorItemIdRef.current = null;
       }
-      setError(null);
 
       let data: TResponse | undefined;
       try {
@@ -193,7 +275,16 @@ export function useAdminMutation<TResponse = unknown>(
         const fetchError =
           (err as { fetchError?: FetchError }).fetchError ??
           ({ message: msg || "Request failed" } satisfies FetchError);
+        if (itemId) {
+          setErrorsByItemId((prev) => ({ ...prev, [itemId]: fetchError }));
+        }
+        // Mirror to hook-level `error` in both cases so the many single-row
+        // callers that read `mutation.error` continue to surface failures
+        // without migration. Concurrent itemized failures are "last wins"
+        // here (documented on the `error` field) — bulk callers should read
+        // `errorsByItemId` / `errorFor(id)` for per-item resolution.
         setError(fetchError);
+        errorItemIdRef.current = itemId ?? null;
         return { ok: false, error: fetchError };
       } finally {
         if (itemId) {
@@ -204,6 +295,24 @@ export function useAdminMutation<TResponse = unknown>(
           });
         } else {
           setSaving(false);
+        }
+      }
+
+      // Successful itemized mutation: clear that itemId's per-item slot, and
+      // if this itemId also owns the hook-level slot (e.g. a retry of the
+      // failed row that just succeeded), clear the hook slot too so the
+      // banner doesn't linger on success. Failures on OTHER itemIds stay
+      // visible — their ownership of the hook slot is unchanged.
+      if (itemId) {
+        setErrorsByItemId((prev) => {
+          if (!(itemId in prev)) return prev;
+          const next = { ...prev };
+          delete next[itemId];
+          return next;
+        });
+        if (errorItemIdRef.current === itemId) {
+          setError(null);
+          errorItemIdRef.current = null;
         }
       }
 
@@ -242,5 +351,15 @@ export function useAdminMutation<TResponse = unknown>(
     [], // Stable — reads all mutable state via refs
   );
 
-  return { mutate, saving, error, clearError, reset, isMutating };
+  return {
+    mutate,
+    saving,
+    error,
+    errorsByItemId,
+    errorFor,
+    clearError,
+    clearErrorFor,
+    reset,
+    isMutating,
+  };
 }


### PR DESCRIPTION
## Summary

Fixes #1629. \`useAdminMutation\` no longer stomps concurrent itemized errors via its start-of-mutate reset, and exposes a reliable per-item error map for bulk fan-out surfaces.

## Problem (from #1629)

Every \`mutate()\` call unconditionally cleared hook-level \`error\` at start and set it inside the catch. Concurrent itemized fan-out lost all but the last-resolved failure:

```
Call A fails → setError(errA)
Call B starts → setError(null) clears errA
Call B succeeds → no setError → errA is silently gone
```

Bulk pages (\`/admin/sessions\`, \`/admin/actions\`, \`/admin/approval\`, \`/admin/learned-patterns\`) worked around this with \`Promise.allSettled\` + \`bulkFailureSummary\` + local \`bulkError\` state — the hook \*advertised\* an \`error\` slot that bulk callers couldn't trust.

## Change

Backward-compatible — no call-site migration required.

- **\`errorsByItemId: Record<string, FetchError>\`** + **\`errorFor(id)\`** — reliable per-item record; populated on itemized failure, cleared on the same itemId's next start or success. Unlike hook-level \`error\`, it's safe under concurrent fan-out because each itemId owns its own slot.
- **Asymmetric start-of-mutate semantics**: non-itemized \`mutate()\` still clears hook \`error\` at start (preserves the implicit-retry-dismiss behaviour for single-slot surfaces). Itemized \`mutate({ itemId })\` clears **only** its own per-item slot — this is the root-cause fix.
- **\`errorItemIdRef\` ownership**: hook-level \`error\` still mirrors the most recent failure so the ~15 pages reading \`mutation.error\` directly keep working. The ref tracks which itemId last wrote to it; a successful retry on that itemId (or \`clearErrorFor(id)\` on it) dismisses the banner, while a success on a *different* itemId leaves it visible.
- **\`clearErrorFor(id)\`** — clears one slot without touching others. Also clears hook \`error\` when the id owns it (otherwise a dismissed banner would linger).
- **\`reset()\`** — now clears \`errorsByItemId\` alongside \`error\` / \`saving\` / \`inFlight\`.

## Why this shape over the alternatives

The issue proposed three directions:

1. **Queue errors (\`FetchError[]\`)** — loud API change for every caller, overkill for the single-row dialog cases.
2. **Drop hook-level state for bulk + document** — doesn't fix the surface, just moves the blame.
3. **Per-itemId error map** — picked. Scales to bulk fan-out cleanly, single-row callers keep reading \`.error\`, pairs with #1624's \`MutationErrorSurface\` primitive (per-item routing is what the primitive needs).

The one non-obvious piece is the \`errorItemIdRef\` ownership check. Without it, \"successful retry dismisses the banner\" would break (the hook slot would linger stale), or \"unrelated success clears another row's banner\" would break (a newer success would silently wipe a still-broken row's error). The ref lets the slot track which itemId last populated it so success can only clear what that itemId wrote.

## Test plan

- [x] \`bun test src/ui/__tests__/use-admin-mutation.test.ts\` — 30 pass (8 new concurrent-scenario tests on top of 22 preserved). Covers:
  - itemized failure populates \`errorsByItemId\` + \`errorFor\`
  - concurrent itemized failures all survive (no start-of-mutate stomp)
  - successful itemized call on a different itemId doesn't clear a prior item's error
  - successful retry of the same itemId clears its per-item slot and the hook slot it owns
  - non-itemized success after an itemized failure leaves the per-item record intact
  - \`clearErrorFor\` clears per-item + hook slot when owned, leaves hook slot intact otherwise
  - \`reset()\` clears \`errorsByItemId\`
- [x] \`bun run lint\` — clean
- [x] \`bun run type\` — clean
- [x] \`bun run test\` — all workspaces pass, exit 0
- [x] \`bun x syncpack lint\` — no issues
- [x] \`SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh\` — 427 files verified
- [ ] 4-agent review pass (code-reviewer, silent-failure-hunter, comment-analyzer, pr-test-analyzer) — to run after PR opens

## Follow-up

- Unblocks #1624 (\`MutationErrorSurface\` primitive) — the per-item routing that primitive wanted is now available.
- Bulk callers (\`/admin/sessions\`, \`/admin/actions\`, \`/admin/approval\`, \`/admin/learned-patterns\`) can progressively migrate off their local \`bulkError\` state to \`errorsByItemId\` / \`errorFor(id)\` in future polish passes — not in scope for this PR.

Closes #1629.