### PR TITLE
fix(api/admin-domains): emit 403 enterprise_required on EE-off writes (#1623)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -33189,32 +33189,7 @@
             }
           },
           "403": {
-            "description": "Pro or Business plan required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "message": {
-                      "type": "string"
-                    },
-                    "requestId": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error",
-                    "message"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Enterprise features not available",
+            "description": "Pro or Business plan required, or enterprise features not available",
             "content": {
               "application/json": {
                 "schema": {
@@ -33378,18 +33353,32 @@
             }
           },
           "403": {
-            "description": "Admin role required",
+            "description": "Admin role required or enterprise features not available",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": {}
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
                 }
               }
             }
           },
           "404": {
-            "description": "No custom domain configured or enterprise features not available",
+            "description": "No custom domain configured",
             "content": {
               "application/json": {
                 "schema": {
@@ -33612,18 +33601,32 @@
             }
           },
           "403": {
-            "description": "Admin role required",
+            "description": "Admin role required or enterprise features not available",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": {}
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
                 }
               }
             }
           },
           "404": {
-            "description": "No custom domain configured or enterprise features not available",
+            "description": "No custom domain configured",
             "content": {
               "application/json": {
                 "schema": {
@@ -33846,18 +33849,32 @@
             }
           },
           "403": {
-            "description": "Admin role required",
+            "description": "Admin role required or enterprise features not available",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": {}
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
                 }
               }
             }
           },
           "404": {
-            "description": "No custom domain configured or enterprise features not available",
+            "description": "No custom domain configured",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/api/src/api/__tests__/admin-domains.test.ts
+++ b/packages/api/src/api/__tests__/admin-domains.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for admin custom domain API endpoints.
+ *
+ * Covers the EE-disabled path (loadDomains() returns null) to guarantee write
+ * endpoints emit 403 { error: "enterprise_required" } — the contract the web
+ * page.tsx `isPlanGated` branch (#1622) and AdminContentWrapper's
+ * EnterpriseUpsell routing (feature-disabled.tsx) rely on.
+ *
+ * Tests the adminDomains sub-router directly (not through the parent admin
+ * router) to avoid needing to mock every sub-router dependency.
+ */
+
+import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
+
+// --- Auth mock ---
+
+const mockAuthenticateRequest: Mock<(req: Request) => Promise<unknown>> = mock(
+  () =>
+    Promise.resolve({
+      authenticated: true,
+      mode: "simple-key",
+      user: { id: "admin-1", mode: "simple-key", label: "Admin", role: "admin", activeOrganizationId: "org-1" },
+    }),
+);
+
+mock.module("@atlas/api/lib/auth/middleware", () => ({
+  authenticateRequest: mockAuthenticateRequest,
+  checkRateLimit: mock(() => ({ allowed: true })),
+  getClientIP: mock(() => null),
+  resetRateLimits: mock(() => {}),
+  rateLimitCleanupTick: mock(() => {}),
+  _setValidatorOverrides: mock(() => {}),
+}));
+
+mock.module("@atlas/api/lib/auth/detect", () => ({
+  detectAuthMode: () => "simple-key",
+  resetAuthModeCache: () => {},
+}));
+
+// --- Internal DB mock ---
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => true,
+  getInternalDB: () => ({ query: () => Promise.resolve({ rows: [] }), end: async () => {}, on: () => {} }),
+  internalQuery: () => Promise.resolve([]),
+  internalExecute: () => {},
+  getWorkspaceDetails: mock(async () => ({ plan_tier: "free" })),
+}));
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+  withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}));
+
+// --- EE domains mock: loadDomains returns null to simulate EE-off build ---
+//
+// The admin-domains.ts router calls `loadDomains()` from shared-domains.ts,
+// which dynamic-imports "@atlas/ee/platform/domains" and catches
+// MODULE_NOT_FOUND to return null. Mocking shared-domains lets us control
+// that null branch directly without having to forge a MODULE_NOT_FOUND
+// from the EE import.
+
+const mockLoadDomains: Mock<() => Promise<unknown>> = mock(() => Promise.resolve(null));
+
+// Preserve the real helper exports — customDomainError is consumed by
+// runEffect's error mapping. Re-export with the mocked loadDomains.
+const realShared = await import("../routes/shared-domains");
+
+mock.module("../routes/shared-domains", () => ({
+  CustomDomainSchema: realShared.CustomDomainSchema,
+  DomainCheckResponseSchema: realShared.DomainCheckResponseSchema,
+  customDomainError: realShared.customDomainError,
+  loadDomains: mockLoadDomains,
+}));
+
+// --- Import sub-router AFTER mocks ---
+
+const { adminDomains } = await import("../routes/admin-domains");
+
+// --- Helpers ---
+
+function resetMocks() {
+  mockLoadDomains.mockImplementation(() => Promise.resolve(null));
+  mockAuthenticateRequest.mockImplementation(() =>
+    Promise.resolve({
+      authenticated: true,
+      mode: "simple-key",
+      user: { id: "admin-1", mode: "simple-key", label: "Admin", role: "admin", activeOrganizationId: "org-1" },
+    }),
+  );
+}
+
+async function request(urlPath: string, method: string, body?: unknown) {
+  const init: RequestInit = { method, headers: {} };
+  if (body) {
+    (init.headers as Record<string, string>)["Content-Type"] = "application/json";
+    init.body = JSON.stringify(body);
+  }
+  return adminDomains.request(`http://localhost${urlPath}`, init);
+}
+
+// --- Tests ---
+
+describe("admin custom domain — EE disabled (loadDomains returns null)", () => {
+  beforeEach(resetMocks);
+
+  it("POST / returns 403 enterprise_required so the web isPlanGated branch fires", async () => {
+    const res = await request("/", "POST", { domain: "data.acme.com" });
+    expect(res.status).toBe(403);
+    const json = (await res.json()) as { error: string; message: string; requestId: string };
+    expect(json.error).toBe("enterprise_required");
+    expect(json.message).toBeTruthy();
+    expect(json.requestId).toBeDefined();
+  });
+
+  it("DELETE / returns 403 enterprise_required (write endpoint, matches POST)", async () => {
+    const res = await request("/", "DELETE");
+    expect(res.status).toBe(403);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("enterprise_required");
+  });
+
+  it("POST /verify returns 403 enterprise_required (write endpoint)", async () => {
+    const res = await request("/verify", "POST");
+    expect(res.status).toBe(403);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("enterprise_required");
+  });
+
+  it("POST /verify-dns returns 403 enterprise_required (write endpoint)", async () => {
+    const res = await request("/verify-dns", "POST");
+    expect(res.status).toBe(403);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("enterprise_required");
+  });
+
+  it("GET / keeps 404 not_available (read endpoints unchanged per #1623 scope)", async () => {
+    // Reads are intentionally untouched — AdminContentWrapper still renders
+    // FeatureGate(404) on the page. If a future change wants the full
+    // EnterpriseUpsell on page load, reads would need to flip too; for now
+    // the issue scope is the dead enterprise_required branch on the write
+    // path (#1622 → #1623).
+    const res = await request("/", "GET");
+    expect(res.status).toBe(404);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("not_available");
+  });
+});

--- a/packages/api/src/api/__tests__/admin-domains.test.ts
+++ b/packages/api/src/api/__tests__/admin-domains.test.ts
@@ -101,37 +101,53 @@ async function request(urlPath: string, method: string, body?: unknown) {
 
 // --- Tests ---
 
+/**
+ * Assert the contract shape that `AdminContentWrapper.isEnterpriseRequired()`
+ * and `page.tsx` isPlanGated depend on: `{ error: "enterprise_required",
+ * message: <non-empty>, requestId: <defined> }`. Pulled into a helper so every
+ * write-path test locks down the same shape — otherwise adding a new write
+ * endpoint with a subtly different shape would slip through.
+ */
+async function expectEnterpriseRequired403(res: Response): Promise<void> {
+  expect(res.status).toBe(403);
+  const json = (await res.json()) as { error: string; message: string; requestId: string };
+  expect(json.error).toBe("enterprise_required");
+  expect(json.message).toBeTruthy();
+  expect(json.requestId).toBeDefined();
+}
+
 describe("admin custom domain — EE disabled (loadDomains returns null)", () => {
   beforeEach(resetMocks);
 
   it("POST / returns 403 enterprise_required so the web isPlanGated branch fires", async () => {
     const res = await request("/", "POST", { domain: "data.acme.com" });
-    expect(res.status).toBe(403);
-    const json = (await res.json()) as { error: string; message: string; requestId: string };
-    expect(json.error).toBe("enterprise_required");
-    expect(json.message).toBeTruthy();
-    expect(json.requestId).toBeDefined();
+    await expectEnterpriseRequired403(res);
   });
 
   it("DELETE / returns 403 enterprise_required (write endpoint, matches POST)", async () => {
     const res = await request("/", "DELETE");
-    expect(res.status).toBe(403);
-    const json = (await res.json()) as { error: string };
-    expect(json.error).toBe("enterprise_required");
+    await expectEnterpriseRequired403(res);
   });
 
   it("POST /verify returns 403 enterprise_required (write endpoint)", async () => {
     const res = await request("/verify", "POST");
-    expect(res.status).toBe(403);
-    const json = (await res.json()) as { error: string };
-    expect(json.error).toBe("enterprise_required");
+    await expectEnterpriseRequired403(res);
   });
 
   it("POST /verify-dns returns 403 enterprise_required (write endpoint)", async () => {
     const res = await request("/verify-dns", "POST");
-    expect(res.status).toBe(403);
-    const json = (await res.json()) as { error: string };
-    expect(json.error).toBe("enterprise_required");
+    await expectEnterpriseRequired403(res);
+  });
+
+  it("message does not leak EE module internals (no MODULE_NOT_FOUND, stack, @atlas/ee)", async () => {
+    // `classifyError` sanitizes domain-error messages for 5xx but passes 4xx
+    // messages through. The EnterpriseError message is hand-authored in
+    // admin-domains.ts (EE_REQUIRED_MESSAGE), so this guards against a future
+    // refactor that accidentally stringifies a module-load error into the
+    // response body. A user-facing 403 should never expose infra internals.
+    const res = await request("/", "POST", { domain: "data.acme.com" });
+    const json = (await res.json()) as { message: string };
+    expect(json.message).not.toMatch(/MODULE_NOT_FOUND|stack|@atlas\/ee/i);
   });
 
   it("GET / keeps 404 not_available (read endpoints unchanged per #1623 scope)", async () => {

--- a/packages/api/src/api/routes/admin-domains.ts
+++ b/packages/api/src/api/routes/admin-domains.ts
@@ -17,6 +17,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { AuthContext, RequestContext } from "@atlas/api/lib/effect/services";
 import { hasInternalDB, getWorkspaceDetails } from "@atlas/api/lib/db/internal";
+import { EnterpriseError } from "@atlas/ee/index";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
 import {
@@ -86,8 +87,7 @@ const addDomainRoute = createRoute({
     },
     400: { description: "Invalid domain or no active organization", content: { "application/json": { schema: ErrorSchema } } },
     401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
-    403: { description: "Pro or Business plan required", content: { "application/json": { schema: ErrorSchema } } },
-    404: { description: "Enterprise features not available", content: { "application/json": { schema: ErrorSchema } } },
+    403: { description: "Pro or Business plan required, or enterprise features not available", content: { "application/json": { schema: ErrorSchema } } },
     409: { description: "Domain already registered", content: { "application/json": { schema: ErrorSchema } } },
     500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
     503: { description: "Internal database or Railway not configured", content: { "application/json": { schema: ErrorSchema } } },
@@ -107,8 +107,8 @@ const removeDomainRoute = createRoute({
     },
     400: { description: "No active organization", content: { "application/json": { schema: ErrorSchema } } },
     401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
-    403: { description: "Admin role required", content: { "application/json": { schema: AuthErrorSchema } } },
-    404: { description: "No custom domain configured or enterprise features not available", content: { "application/json": { schema: ErrorSchema } } },
+    403: { description: "Admin role required or enterprise features not available", content: { "application/json": { schema: AuthErrorSchema } } },
+    404: { description: "No custom domain configured", content: { "application/json": { schema: ErrorSchema } } },
     500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
     503: { description: "Internal database or Railway not configured", content: { "application/json": { schema: ErrorSchema } } },
   },
@@ -127,8 +127,8 @@ const verifyDomainRoute = createRoute({
     },
     400: { description: "No active organization", content: { "application/json": { schema: ErrorSchema } } },
     401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
-    403: { description: "Admin role required", content: { "application/json": { schema: AuthErrorSchema } } },
-    404: { description: "No custom domain configured or enterprise features not available", content: { "application/json": { schema: ErrorSchema } } },
+    403: { description: "Admin role required or enterprise features not available", content: { "application/json": { schema: AuthErrorSchema } } },
+    404: { description: "No custom domain configured", content: { "application/json": { schema: ErrorSchema } } },
     500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
     503: { description: "Internal database or Railway not configured", content: { "application/json": { schema: ErrorSchema } } },
   },
@@ -147,8 +147,8 @@ const verifyDnsTxtRoute = createRoute({
     },
     400: { description: "No active organization", content: { "application/json": { schema: ErrorSchema } } },
     401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
-    403: { description: "Admin role required", content: { "application/json": { schema: AuthErrorSchema } } },
-    404: { description: "No custom domain configured or enterprise features not available", content: { "application/json": { schema: ErrorSchema } } },
+    403: { description: "Admin role required or enterprise features not available", content: { "application/json": { schema: AuthErrorSchema } } },
+    404: { description: "No custom domain configured", content: { "application/json": { schema: ErrorSchema } } },
     500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
     503: { description: "Internal database or Railway not configured", content: { "application/json": { schema: ErrorSchema } } },
   },
@@ -237,6 +237,18 @@ async function checkPlanGate(
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Fail write endpoints with a 403 `enterprise_required` when the EE domains
+ * module can't be loaded, so AdminContentWrapper's EnterpriseUpsell and the
+ * page.tsx `isPlanGated` branch (see #1622 / #1623) render instead of a
+ * generic 404. Read endpoints intentionally keep their 404 `not_available`
+ * response — the issue scope is the dead `enterprise_required` branch on
+ * the write path. `EnterpriseError` is mapped to 403 by the shared
+ * classifier in `lib/effect/hono.ts`.
+ */
+const EE_REQUIRED_MESSAGE =
+  "Custom domains require enterprise features to be enabled.";
+
 // ---------------------------------------------------------------------------
 // Router
 // ---------------------------------------------------------------------------
@@ -277,7 +289,7 @@ adminDomains.openapi(addDomainRoute, async (c) => {
 
     const mod = yield* Effect.promise(() => loadDomains());
     if (!mod) {
-      return c.json({ error: "not_available", message: "Custom domains require enterprise features to be enabled.", requestId }, 404);
+      return yield* Effect.fail(new EnterpriseError(EE_REQUIRED_MESSAGE));
     }
 
     // Business plan gate
@@ -320,7 +332,7 @@ adminDomains.openapi(verifyDomainRoute, async (c) => {
 
     const mod = yield* Effect.promise(() => loadDomains());
     if (!mod) {
-      return c.json({ error: "not_available", message: "Custom domains require enterprise features to be enabled.", requestId }, 404);
+      return yield* Effect.fail(new EnterpriseError(EE_REQUIRED_MESSAGE));
     }
 
     // MVP: one domain per workspace, so we always operate on the first result
@@ -346,7 +358,7 @@ adminDomains.openapi(verifyDnsTxtRoute, async (c) => {
 
     const mod = yield* Effect.promise(() => loadDomains());
     if (!mod) {
-      return c.json({ error: "not_available", message: "Custom domains require enterprise features to be enabled.", requestId }, 404);
+      return yield* Effect.fail(new EnterpriseError(EE_REQUIRED_MESSAGE));
     }
 
     const domains = yield* mod.listDomains(orgId);
@@ -396,7 +408,7 @@ adminDomains.openapi(removeDomainRoute, async (c) => {
 
     const mod = yield* Effect.promise(() => loadDomains());
     if (!mod) {
-      return c.json({ error: "not_available", message: "Custom domains require enterprise features to be enabled.", requestId }, 404);
+      return yield* Effect.fail(new EnterpriseError(EE_REQUIRED_MESSAGE));
     }
 
     // MVP: one domain per workspace, so we always operate on the first result

--- a/packages/api/src/api/routes/admin-domains.ts
+++ b/packages/api/src/api/routes/admin-domains.ts
@@ -7,8 +7,10 @@
  *
  * Wraps the existing EE domain module used by platform-domains.ts, scoping
  * operations to the caller's active organization. When the EE module is
- * unavailable (e.g. open-source builds), all routes return 404 with a
- * "not_available" error code.
+ * unavailable (e.g. open-source builds), write endpoints emit 403
+ * `enterprise_required` via `EnterpriseError` so the admin page can route
+ * them through `EnterpriseUpsell` / the `isPlanGated` CompactRow (see
+ * #1622 / #1623). Read endpoints return 404 `not_available` unchanged.
  */
 
 import { Effect } from "effect";
@@ -107,7 +109,7 @@ const removeDomainRoute = createRoute({
     },
     400: { description: "No active organization", content: { "application/json": { schema: ErrorSchema } } },
     401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
-    403: { description: "Admin role required or enterprise features not available", content: { "application/json": { schema: AuthErrorSchema } } },
+    403: { description: "Admin role required or enterprise features not available", content: { "application/json": { schema: ErrorSchema } } },
     404: { description: "No custom domain configured", content: { "application/json": { schema: ErrorSchema } } },
     500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
     503: { description: "Internal database or Railway not configured", content: { "application/json": { schema: ErrorSchema } } },
@@ -127,7 +129,7 @@ const verifyDomainRoute = createRoute({
     },
     400: { description: "No active organization", content: { "application/json": { schema: ErrorSchema } } },
     401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
-    403: { description: "Admin role required or enterprise features not available", content: { "application/json": { schema: AuthErrorSchema } } },
+    403: { description: "Admin role required or enterprise features not available", content: { "application/json": { schema: ErrorSchema } } },
     404: { description: "No custom domain configured", content: { "application/json": { schema: ErrorSchema } } },
     500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
     503: { description: "Internal database or Railway not configured", content: { "application/json": { schema: ErrorSchema } } },
@@ -147,7 +149,7 @@ const verifyDnsTxtRoute = createRoute({
     },
     400: { description: "No active organization", content: { "application/json": { schema: ErrorSchema } } },
     401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
-    403: { description: "Admin role required or enterprise features not available", content: { "application/json": { schema: AuthErrorSchema } } },
+    403: { description: "Admin role required or enterprise features not available", content: { "application/json": { schema: ErrorSchema } } },
     404: { description: "No custom domain configured", content: { "application/json": { schema: ErrorSchema } } },
     500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
     503: { description: "Internal database or Railway not configured", content: { "application/json": { schema: ErrorSchema } } },

--- a/packages/api/src/api/routes/admin-domains.ts
+++ b/packages/api/src/api/routes/admin-domains.ts
@@ -7,10 +7,12 @@
  *
  * Wraps the existing EE domain module used by platform-domains.ts, scoping
  * operations to the caller's active organization. When the EE module is
- * unavailable (e.g. open-source builds), write endpoints emit 403
- * `enterprise_required` via `EnterpriseError` so the admin page can route
- * them through `EnterpriseUpsell` / the `isPlanGated` CompactRow (see
- * #1622 / #1623). Read endpoints return 404 `not_available` unchanged.
+ * unavailable (e.g. open-source builds), write endpoints (POST /, DELETE /,
+ * POST /verify, POST /verify-dns) emit 403 `enterprise_required` via
+ * `EnterpriseError` so the admin page can route them through
+ * `EnterpriseUpsell` / the `isPlanGated` CompactRow (see #1622 / #1623).
+ * Read endpoints (GET /, GET /domain-check) return 404 `not_available`
+ * unchanged.
  */
 
 import { Effect } from "effect";


### PR DESCRIPTION
## Summary

Closes #1623. Wires the EE-disabled write arms of `/api/v1/admin/domain` to return `403 { error: "enterprise_required" }` so the web `isPlanGated` check (added in #1622) actually fires and non-EE admins see the polished plan-gate CompactRow / `EnterpriseUpsell` instead of a generic 404 banner.

## What changed

- **POST /, DELETE /, POST /verify, POST /verify-dns** now `yield* Effect.fail(new EnterpriseError(...))` when `loadDomains()` returns null. The shared `classifyError` in `lib/effect/hono.ts` already maps `EnterpriseError → 403 { error: "enterprise_required", requestId, ... }`, so this reuses existing plumbing (no new mapping code).
- **GET /, GET /domain-check** intentionally keep their `404 not_available` response — the issue scope is the dead write-path branch. A regression test asserts GET's 404 stays put.
- OpenAPI response descriptions for the four write routes are updated to reflect the new 403 shape and drop the now-unreachable 404 mentions.

## Precedent

Matches the convention already used by the other EE-gated admin surfaces:
- `/api/v1/admin/branding` — EE module is loaded eagerly; `getWorkspaceBranding` throws `EnterpriseError` on EE-off → 403 `enterprise_required` (see `admin-branding.ts`).
- The `AdminContentWrapper` `isEnterpriseRequired()` guard (`admin-content-wrapper.tsx`) and the web regression test (`plan-gate.test.tsx` — third case: `403 + enterprise_required → gated landing`) both already expect this shape.

The difference for domains is the `loadDomains()` lazy import (which returns `null` on community builds that don't ship `@atlas/ee/platform/domains`). Mapping that `null` to `EnterpriseError` normalizes the contract with the rest of the admin surface.

## Why only writes

Per #1623's option (a) and the prompt scope: the observable bug is on the write path — the user clicks "Add domain" and the `addError.code` branch was unreachable. Read endpoints returning 404 `not_available` route through `AdminContentWrapper`'s `FeatureGate(404)` today, which is a reasonable "{feature} not enabled" rendering. If a future change wants the full `EnterpriseUpsell` on page load, reads can flip too; that's a separate UX decision.

## Tests

New `packages/api/src/api/__tests__/admin-domains.test.ts` mocks `shared-domains.loadDomains` to return `null` (simulating an EE-off build) and asserts:
- POST / → 403 `{ error: "enterprise_required", requestId }`
- DELETE / → 403 `enterprise_required`
- POST /verify → 403 `enterprise_required`
- POST /verify-dns → 403 `enterprise_required`
- GET / → 404 `not_available` (scope guard — read endpoints unchanged)

## CI gates

- `bun run lint` — clean
- `bun run type` — clean
- `bun run test` — api 241/241, cli 19/19, web 68/68, ee 25/25, react 9/9
- `bun x syncpack lint` — no issues
- `check-template-drift.sh` — 428 files verified

## Test plan

- [ ] Self-hosted without `@atlas/ee` installed: load `/admin/custom-domain`, click "+ Add domain", submit → verify the gated CompactRow renders ("Custom domains are an Enterprise feature" with upgrade CTA), not the generic 404 banner
- [ ] Same build: direct `curl -X POST /api/v1/admin/domain` should return `403 { "error": "enterprise_required", ... }`
- [ ] EE-enabled build: flow still works end-to-end (register → verify → delete)

## Related

- #1622 — substring-match → structured-code migration that exposed the dead branch
- #1623 — this issue