### PR TITLE
feat(web/admin/abuse): investigation panel with counters + timeline + reinstate-on-evidence

### DIFF
--- a/apps/docs/content/docs/platform-ops/abuse-prevention.mdx
+++ b/apps/docs/content/docs/platform-ops/abuse-prevention.mdx
@@ -46,9 +46,18 @@ All thresholds are configurable via environment variables:
 
 The **Abuse Prevention** page in the admin console (`/admin/abuse`) shows:
 
-- **Detection Thresholds** — Current configuration values
-- **Flagged Workspaces** — Table of workspaces with active flags (warning, throttled, or suspended)
-- **Reinstate** — Button to clear abuse flags and restore normal access
+- **Detection Thresholds** — Current configuration values (read-only; edit via env vars)
+- **Filter chips** — All / Warning / Throttled / Suspended
+- **Flagged Workspaces** — Row per active flag (warning, throttled, or suspended)
+
+### Investigation panel
+
+Click a workspace row to expand an inline investigation panel. The panel is lazy-loaded so opening one workspace doesn't refetch another. It shows:
+
+- **Current counters** — Live sliding-window stats annotated against thresholds (e.g. "147 / 200 queries in 300s"). The counter turns red once it's over the line.
+- **Current flag timeline** — Every escalation event for the active flag instance, newest-first, with relative timestamps.
+- **Prior flag history** — Up to 5 previous flag instances this workspace has gone through, with peak level and reinstatement time.
+- **Reinstate button** — In the panel footer, *after* the evidence. Investigate first, then decide.
 
 ### Reinstatement
 
@@ -75,6 +84,14 @@ GET /api/v1/admin/abuse
 ```
 
 Returns all workspaces with active abuse flags, including recent events.
+
+### Investigation detail
+
+```
+GET /api/v1/admin/abuse/:workspaceId/detail
+```
+
+Returns the live counters, thresholds, current flag timeline, and up to 5 prior flag instances for a single flagged workspace. Returns `404 not_flagged` if the workspace is not currently flagged.
 
 ### Reinstate a workspace
 

--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -637,6 +637,7 @@ export function createApiTestMocks(
       uniqueTablesLimit: 50,
       throttleDelayMs: 2000,
     })),
+    getAbuseDetail: mock(async () => null),
     checkAbuseStatus: mock(() => ({ level: "none" })),
     recordQueryEvent: mock(() => {}),
     restoreAbuseState: mock(async () => {}),

--- a/packages/api/src/api/__tests__/admin-abuse.test.ts
+++ b/packages/api/src/api/__tests__/admin-abuse.test.ts
@@ -31,12 +31,14 @@ const mockGetAbuseConfig: Mock<() => unknown> = mock(() => ({
   uniqueTablesLimit: 50,
   throttleDelayMs: 2000,
 }));
+const mockGetAbuseDetail: Mock<(wsId: string) => Promise<unknown | null>> = mock(async () => null);
 
 mock.module("@atlas/api/lib/security/abuse", () => ({
   listFlaggedWorkspaces: mockListFlagged,
   reinstateWorkspace: mockReinstateWorkspace,
   getAbuseEvents: mockGetAbuseEvents,
   getAbuseConfig: mockGetAbuseConfig,
+  getAbuseDetail: mockGetAbuseDetail,
   checkAbuseStatus: mock(() => ({ level: "none" })),
   recordQueryEvent: mock(() => {}),
   restoreAbuseState: mock(async () => {}),
@@ -152,6 +154,75 @@ describe("Admin Abuse API", () => {
       );
       const res = await app.fetch(
         adminRequest("POST", "/api/v1/admin/abuse/org-1/reinstate"),
+      );
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // --- GET /api/v1/admin/abuse/:id/detail ---
+
+  describe("GET /api/v1/admin/abuse/:id/detail", () => {
+    it("returns detail for a flagged workspace", async () => {
+      mockGetAbuseDetail.mockImplementation(async () => ({
+        workspaceId: "org-1",
+        workspaceName: null,
+        level: "warning",
+        trigger: "query_rate",
+        message: "Excessive queries",
+        updatedAt: "2026-03-23T00:00:00.000Z",
+        counters: {
+          queryCount: 250,
+          errorCount: 0,
+          errorRatePct: 0,
+          uniqueTablesAccessed: 3,
+          escalations: 1,
+        },
+        thresholds: {
+          queryRateLimit: 200,
+          queryRateWindowSeconds: 300,
+          errorRateThreshold: 0.5,
+          uniqueTablesLimit: 50,
+          throttleDelayMs: 2000,
+        },
+        currentInstance: {
+          startedAt: "2026-03-23T00:00:00.000Z",
+          endedAt: null,
+          peakLevel: "warning",
+          events: [],
+        },
+        priorInstances: [],
+      }));
+      const res = await app.fetch(
+        adminRequest("GET", "/api/v1/admin/abuse/org-1/detail"),
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body.workspaceId).toBe("org-1");
+      expect((body.counters as Record<string, unknown>).queryCount).toBe(250);
+    });
+
+    it("returns 404 when workspace is not flagged", async () => {
+      mockGetAbuseDetail.mockImplementation(async () => null);
+      const res = await app.fetch(
+        adminRequest("GET", "/api/v1/admin/abuse/org-clean/detail"),
+      );
+      expect(res.status).toBe(404);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body.error).toBe("not_flagged");
+      // 4xx responses must carry requestId for log correlation.
+      expect(typeof body.requestId).toBe("string");
+    });
+
+    it("returns 403 for non-admin", async () => {
+      mocks.mockAuthenticateRequest.mockImplementation(() =>
+        Promise.resolve({
+          authenticated: true,
+          mode: "simple-key",
+          user: { id: "user-1", mode: "simple-key", label: "User", role: "member", activeOrganizationId: "org-1" },
+        }),
+      );
+      const res = await app.fetch(
+        adminRequest("GET", "/api/v1/admin/abuse/org-1/detail"),
       );
       expect(res.status).toBe(403);
     });

--- a/packages/api/src/api/routes/admin-abuse.ts
+++ b/packages/api/src/api/routes/admin-abuse.ts
@@ -12,6 +12,7 @@ import {
   reinstateWorkspace,
   getAbuseEvents,
   getAbuseConfig,
+  getAbuseDetail,
 } from "@atlas/api/lib/security/abuse";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
@@ -57,6 +58,34 @@ const ConfigResponseSchema = z.object({
   errorRateThreshold: z.number(),
   uniqueTablesLimit: z.number(),
   throttleDelayMs: z.number(),
+});
+
+const AbuseCountersSchema = z.object({
+  queryCount: z.number(),
+  errorCount: z.number(),
+  errorRatePct: z.number().nullable(),
+  uniqueTablesAccessed: z.number(),
+  escalations: z.number(),
+});
+
+const AbuseInstanceSchema = z.object({
+  startedAt: z.string(),
+  endedAt: z.string().nullable(),
+  peakLevel: z.enum(["none", "warning", "throttled", "suspended"]),
+  events: z.array(AbuseEventSchema),
+});
+
+const AbuseDetailResponseSchema = z.object({
+  workspaceId: z.string(),
+  workspaceName: z.string().nullable(),
+  level: z.enum(["none", "warning", "throttled", "suspended"]),
+  trigger: z.enum(["query_rate", "error_rate", "unique_tables", "manual"]).nullable(),
+  message: z.string().nullable(),
+  updatedAt: z.string(),
+  counters: AbuseCountersSchema,
+  thresholds: ConfigResponseSchema,
+  currentInstance: AbuseInstanceSchema,
+  priorInstances: z.array(AbuseInstanceSchema),
 });
 
 // ---------------------------------------------------------------------------
@@ -110,6 +139,46 @@ const reinstateRoute = createRoute({
       content: { "application/json": { schema: ReinstateResponseSchema } },
     },
     400: {
+      description: "Workspace not flagged",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    401: {
+      description: "Authentication required",
+      content: { "application/json": { schema: AuthErrorSchema } },
+    },
+    403: {
+      description: "Forbidden — admin role required",
+      content: { "application/json": { schema: AuthErrorSchema } },
+    },
+    429: {
+      description: "Rate limit exceeded",
+      content: { "application/json": { schema: AuthErrorSchema } },
+    },
+    500: {
+      description: "Internal server error",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const getDetailRoute = createRoute({
+  method: "get",
+  path: "/{workspaceId}/detail",
+  tags: ["Admin — Abuse Prevention"],
+  summary: "Investigation detail for a flagged workspace",
+  description:
+    "SaaS only. Returns live counters, thresholds, the current flag instance, and up to 5 prior flag instances so operators can investigate without leaving the page.",
+  request: {
+    params: z.object({
+      workspaceId: z.string(),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Investigation detail",
+      content: { "application/json": { schema: AbuseDetailResponseSchema } },
+    },
+    404: {
       description: "Workspace not flagged",
       content: { "application/json": { schema: ErrorSchema } },
     },
@@ -207,6 +276,28 @@ adminAbuse.openapi(reinstateRoute, async (c) => {
       message: "Workspace reinstated successfully.",
     }, 200);
   }), { label: "reinstate workspace" });
+});
+
+// GET /:workspaceId/detail — investigation detail for a flagged workspace
+adminAbuse.openapi(getDetailRoute, async (c) => {
+  return runEffect(c, Effect.gen(function* () {
+    const { requestId } = yield* RequestContext;
+    const { workspaceId } = c.req.valid("param");
+
+    const detail = yield* Effect.promise(() => getAbuseDetail(workspaceId));
+    if (!detail) {
+      return c.json(
+        {
+          error: "not_flagged",
+          message: "Workspace is not currently flagged for abuse.",
+          requestId,
+        },
+        404,
+      );
+    }
+
+    return c.json(detail, 200);
+  }), { label: "read abuse detail" });
 });
 
 // GET /config — current threshold configuration

--- a/packages/api/src/api/routes/admin-abuse.ts
+++ b/packages/api/src/api/routes/admin-abuse.ts
@@ -14,6 +14,7 @@ import {
   getAbuseConfig,
   getAbuseDetail,
 } from "@atlas/api/lib/security/abuse";
+import { ABUSE_LEVELS, ABUSE_TRIGGERS } from "@useatlas/types";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
 import { ErrorSchema, AuthErrorSchema, createListResponseSchema } from "./shared-schemas";
@@ -23,11 +24,17 @@ import { createAdminRouter } from "./admin-router";
 // Schemas
 // ---------------------------------------------------------------------------
 
+// Sourced from `@useatlas/types` so the enum values stay structurally
+// coupled to the TS unions — adding a new level or trigger in `types/abuse.ts`
+// propagates here without manual duplication.
+const LevelEnum = z.enum(ABUSE_LEVELS);
+const TriggerEnum = z.enum(ABUSE_TRIGGERS);
+
 const AbuseEventSchema = z.object({
   id: z.string(),
   workspaceId: z.string(),
-  level: z.enum(["none", "warning", "throttled", "suspended"]),
-  trigger: z.enum(["query_rate", "error_rate", "unique_tables", "manual"]),
+  level: LevelEnum,
+  trigger: TriggerEnum,
   message: z.string(),
   metadata: z.record(z.string(), z.unknown()),
   createdAt: z.string(),
@@ -37,8 +44,8 @@ const AbuseEventSchema = z.object({
 const AbuseStatusSchema = z.object({
   workspaceId: z.string(),
   workspaceName: z.string().nullable(),
-  level: z.enum(["none", "warning", "throttled", "suspended"]),
-  trigger: z.enum(["query_rate", "error_rate", "unique_tables", "manual"]).nullable(),
+  level: LevelEnum,
+  trigger: TriggerEnum.nullable(),
   message: z.string().nullable(),
   updatedAt: z.string(),
   events: z.array(AbuseEventSchema),
@@ -71,15 +78,15 @@ const AbuseCountersSchema = z.object({
 const AbuseInstanceSchema = z.object({
   startedAt: z.string(),
   endedAt: z.string().nullable(),
-  peakLevel: z.enum(["none", "warning", "throttled", "suspended"]),
+  peakLevel: LevelEnum,
   events: z.array(AbuseEventSchema),
 });
 
 const AbuseDetailResponseSchema = z.object({
   workspaceId: z.string(),
   workspaceName: z.string().nullable(),
-  level: z.enum(["none", "warning", "throttled", "suspended"]),
-  trigger: z.enum(["query_rate", "error_rate", "unique_tables", "manual"]).nullable(),
+  level: LevelEnum,
+  trigger: TriggerEnum.nullable(),
   message: z.string().nullable(),
   updatedAt: z.string(),
   counters: AbuseCountersSchema,

--- a/packages/api/src/lib/security/__tests__/abuse-instances.test.ts
+++ b/packages/api/src/lib/security/__tests__/abuse-instances.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Pure-function tests for `splitIntoInstances`. No DB, no mocks — the helper
+ * lives in its own module specifically so the grouping logic can be verified
+ * without the engine/state machine.
+ */
+
+import { describe, it, expect } from "bun:test";
+import type { AbuseEvent } from "@useatlas/types";
+import { splitIntoInstances } from "../abuse-instances";
+
+function ev(overrides: Partial<AbuseEvent> & { createdAt: string }): AbuseEvent {
+  return {
+    id: `e-${overrides.createdAt}`,
+    workspaceId: "ws-1",
+    level: "warning",
+    trigger: "query_rate",
+    message: "",
+    metadata: {},
+    actor: "system",
+    ...overrides,
+  };
+}
+
+describe("splitIntoInstances", () => {
+  it("returns empty current + empty priors when there are no events", () => {
+    const { currentInstance, priorInstances } = splitIntoInstances([], 5);
+    expect(currentInstance.events).toEqual([]);
+    expect(currentInstance.endedAt).toBeNull();
+    expect(currentInstance.peakLevel).toBe("none");
+    expect(priorInstances).toEqual([]);
+  });
+
+  it("treats all events as current when workspace has never been reinstated", () => {
+    // DB order: DESC by createdAt → newest first.
+    const events: AbuseEvent[] = [
+      ev({ createdAt: "2026-04-19T10:10:00Z", level: "throttled" }),
+      ev({ createdAt: "2026-04-19T10:05:00Z", level: "warning" }),
+    ];
+    const { currentInstance, priorInstances } = splitIntoInstances(events, 5);
+    expect(priorInstances).toEqual([]);
+    expect(currentInstance.endedAt).toBeNull();
+    expect(currentInstance.peakLevel).toBe("throttled");
+    // Events are flipped to chronological for rendering.
+    expect(currentInstance.events.map((e) => e.createdAt)).toEqual([
+      "2026-04-19T10:05:00Z",
+      "2026-04-19T10:10:00Z",
+    ]);
+  });
+
+  it("splits prior instance from current when a reinstatement separates them", () => {
+    // Chronological: warn → throttle → suspend → reinstate → warn → throttle
+    // DB order: DESC by createdAt.
+    const events: AbuseEvent[] = [
+      ev({ createdAt: "2026-04-19T11:10:00Z", level: "throttled" }),
+      ev({ createdAt: "2026-04-19T11:05:00Z", level: "warning" }),
+      ev({
+        createdAt: "2026-04-19T11:00:00Z",
+        level: "none",
+        trigger: "manual",
+        actor: "admin-1",
+      }),
+      ev({ createdAt: "2026-04-19T10:15:00Z", level: "suspended" }),
+      ev({ createdAt: "2026-04-19T10:10:00Z", level: "throttled" }),
+      ev({ createdAt: "2026-04-19T10:05:00Z", level: "warning" }),
+    ];
+    const { currentInstance, priorInstances } = splitIntoInstances(events, 5);
+
+    // Current: everything after the reinstatement, chronological.
+    expect(currentInstance.endedAt).toBeNull();
+    expect(currentInstance.peakLevel).toBe("throttled");
+    expect(currentInstance.startedAt).toBe("2026-04-19T11:05:00Z");
+    expect(currentInstance.events.map((e) => e.level)).toEqual(["warning", "throttled"]);
+
+    // Prior: the closed instance. peakLevel = suspended, endedAt = reinstatement timestamp.
+    expect(priorInstances).toHaveLength(1);
+    const prior = priorInstances[0]!;
+    expect(prior.peakLevel).toBe("suspended");
+    expect(prior.endedAt).toBe("2026-04-19T11:00:00Z");
+    expect(prior.startedAt).toBe("2026-04-19T10:05:00Z");
+    // The reinstatement event itself is included as the closing event.
+    expect(prior.events.map((e) => e.level)).toEqual([
+      "warning",
+      "throttled",
+      "suspended",
+      "none",
+    ]);
+  });
+
+  it("returns prior instances newest-first", () => {
+    // Three closed instances, no current activity.
+    const events: AbuseEvent[] = [
+      // Instance 3 (newest, closed)
+      ev({
+        createdAt: "2026-04-19T12:00:00Z",
+        level: "none",
+        trigger: "manual",
+        actor: "admin-3",
+      }),
+      ev({ createdAt: "2026-04-19T11:55:00Z", level: "warning" }),
+      // Instance 2 (closed)
+      ev({
+        createdAt: "2026-04-19T11:00:00Z",
+        level: "none",
+        trigger: "manual",
+        actor: "admin-2",
+      }),
+      ev({ createdAt: "2026-04-19T10:55:00Z", level: "warning" }),
+      // Instance 1 (oldest, closed)
+      ev({
+        createdAt: "2026-04-19T10:00:00Z",
+        level: "none",
+        trigger: "manual",
+        actor: "admin-1",
+      }),
+      ev({ createdAt: "2026-04-19T09:55:00Z", level: "warning" }),
+    ];
+    const { currentInstance, priorInstances } = splitIntoInstances(events, 5);
+
+    expect(currentInstance.events).toEqual([]);
+    expect(priorInstances.map((p) => p.endedAt)).toEqual([
+      "2026-04-19T12:00:00Z", // newest reinstatement first
+      "2026-04-19T11:00:00Z",
+      "2026-04-19T10:00:00Z",
+    ]);
+  });
+
+  it("caps prior instances at priorLimit", () => {
+    // Four closed instances, limit 2.
+    const events: AbuseEvent[] = [];
+    for (let i = 4; i >= 1; i--) {
+      events.push(
+        ev({
+          createdAt: `2026-04-19T${String(10 + i).padStart(2, "0")}:00:00Z`,
+          level: "none",
+          trigger: "manual",
+          actor: `admin-${i}`,
+        }),
+        ev({
+          createdAt: `2026-04-19T${String(10 + i).padStart(2, "0")}:00:00Z`,
+          level: "warning",
+        }),
+      );
+    }
+    const { priorInstances } = splitIntoInstances(events, 2);
+    expect(priorInstances).toHaveLength(2);
+  });
+
+  it("computes peakLevel by escalation rank, not order of appearance", () => {
+    // Events arrive warning → suspended → throttled chronologically. Peak is
+    // still "suspended" even though a lower level arrives after it.
+    const events: AbuseEvent[] = [
+      ev({ createdAt: "2026-04-19T10:20:00Z", level: "throttled" }),
+      ev({ createdAt: "2026-04-19T10:15:00Z", level: "suspended" }),
+      ev({ createdAt: "2026-04-19T10:10:00Z", level: "warning" }),
+    ];
+    const { currentInstance } = splitIntoInstances(events, 5);
+    expect(currentInstance.peakLevel).toBe("suspended");
+  });
+
+  it("does NOT treat a system-generated 'none' event as a reinstatement", () => {
+    // Hypothetical corrupt row: level=none with trigger=query_rate. Only
+    // manual-triggered 'none' is treated as a reinstatement boundary.
+    const events: AbuseEvent[] = [
+      ev({ createdAt: "2026-04-19T10:10:00Z", level: "throttled" }),
+      ev({
+        createdAt: "2026-04-19T10:05:00Z",
+        level: "none",
+        trigger: "query_rate",
+      }),
+      ev({ createdAt: "2026-04-19T10:00:00Z", level: "warning" }),
+    ];
+    const { priorInstances, currentInstance } = splitIntoInstances(events, 5);
+    expect(priorInstances).toEqual([]);
+    expect(currentInstance.events).toHaveLength(3);
+  });
+});

--- a/packages/api/src/lib/security/abuse-instances.ts
+++ b/packages/api/src/lib/security/abuse-instances.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure grouping of abuse events into "instances" for the admin detail panel.
+ *
+ * An *instance* is one continuous stretch of non-"none" activity bookended by
+ * an escalation event and (optionally) a manual reinstatement. The current
+ * (unreinstated) instance is returned separately from prior closed instances
+ * so the UI can render them differently — active incident vs history.
+ *
+ * Kept pure and mock-free so it can be unit-tested without a DB.
+ */
+
+import type { AbuseEvent, AbuseInstance, AbuseLevel } from "@useatlas/types";
+
+const LEVEL_RANK: Record<AbuseLevel, number> = {
+  none: 0,
+  warning: 1,
+  throttled: 2,
+  suspended: 3,
+};
+
+/** Reinstatement sentinel — system-generated events never use `trigger: "manual"`. */
+function isReinstatement(e: AbuseEvent): boolean {
+  return e.level === "none" && e.trigger === "manual";
+}
+
+function makeInstance(eventsChrono: AbuseEvent[]): AbuseInstance {
+  if (eventsChrono.length === 0) {
+    return { startedAt: "", endedAt: null, peakLevel: "none", events: [] };
+  }
+  const last = eventsChrono[eventsChrono.length - 1]!;
+  const endedAt = isReinstatement(last) ? last.createdAt : null;
+  let peak: AbuseLevel = "none";
+  for (const e of eventsChrono) {
+    if (LEVEL_RANK[e.level] > LEVEL_RANK[peak]) peak = e.level;
+  }
+  return {
+    startedAt: eventsChrono[0]!.createdAt,
+    endedAt,
+    peakLevel: peak,
+    events: eventsChrono,
+  };
+}
+
+/**
+ * Split a workspace's abuse-event stream into its current instance and prior
+ * instances.
+ *
+ * @param events Events ordered DESC by `createdAt` (the DB's natural order).
+ * @param priorLimit Max number of prior instances to return (newest-first).
+ */
+export function splitIntoInstances(
+  events: AbuseEvent[],
+  priorLimit: number,
+): { currentInstance: AbuseInstance; priorInstances: AbuseInstance[] } {
+  // Flip to chronological so a forward walk can close instances on
+  // reinstatement events naturally.
+  const chronological = events.toReversed();
+  const closed: AbuseInstance[] = [];
+  let buffer: AbuseEvent[] = [];
+
+  for (const e of chronological) {
+    buffer.push(e);
+    if (isReinstatement(e)) {
+      closed.push(makeInstance(buffer));
+      buffer = [];
+    }
+  }
+
+  const currentInstance = makeInstance(buffer);
+  const priorInstances = closed.toReversed().slice(0, priorLimit);
+
+  return { currentInstance, priorInstances };
+}

--- a/packages/api/src/lib/security/abuse.ts
+++ b/packages/api/src/lib/security/abuse.ts
@@ -14,7 +14,15 @@
 
 import { createLogger } from "@atlas/api/lib/logger";
 import { hasInternalDB, internalExecute, internalQuery } from "@atlas/api/lib/db/internal";
-import type { AbuseLevel, AbuseTrigger, AbuseEvent, AbuseStatus, AbuseThresholdConfig } from "@useatlas/types";
+import type {
+  AbuseLevel,
+  AbuseTrigger,
+  AbuseEvent,
+  AbuseStatus,
+  AbuseThresholdConfig,
+  AbuseDetail,
+} from "@useatlas/types";
+import { splitIntoInstances } from "./abuse-instances";
 
 const log = createLogger("abuse");
 
@@ -275,6 +283,55 @@ export function listFlaggedWorkspaces(): AbuseStatus[] {
     });
   }
   return results.toSorted((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
+/**
+ * Read the full investigation context for a single flagged workspace:
+ * current in-memory counters, thresholds, and the split of persisted events
+ * into current/prior instances.
+ *
+ * Returns `null` when the workspace is not currently flagged (level = "none"
+ * or unknown workspace) — callers should 404. DB persistence failures degrade
+ * to empty `events` rather than throwing: the in-memory status is still worth
+ * returning even if the audit trail is momentarily unreachable.
+ */
+export async function getAbuseDetail(
+  workspaceId: string,
+  priorLimit = 5,
+  eventLimit = 50,
+): Promise<AbuseDetail | null> {
+  const state = workspaceState.get(workspaceId);
+  if (!state || state.level === "none") return null;
+
+  const config = getAbuseConfig();
+  const w = state.window;
+  const queryCount = w.timestamps.length;
+  // Mirrors the check in `checkThresholds` — error rate is only meaningful
+  // once we've got a small baseline. Surface `null` so the UI can show
+  // "baseline pending" rather than a misleading 0% / 100%.
+  const errorRatePct = queryCount >= 10 ? (w.errorCount / queryCount) * 100 : null;
+
+  const events = await getAbuseEvents(workspaceId, eventLimit);
+  const { currentInstance, priorInstances } = splitIntoInstances(events, priorLimit);
+
+  return {
+    workspaceId,
+    workspaceName: null, // Resolved by the admin route (same as listFlaggedWorkspaces).
+    level: state.level,
+    trigger: state.trigger,
+    message: state.message,
+    updatedAt: new Date(state.updatedAt).toISOString(),
+    counters: {
+      queryCount,
+      errorCount: w.errorCount,
+      errorRatePct,
+      uniqueTablesAccessed: w.tables.size,
+      escalations: state.escalations,
+    },
+    thresholds: config,
+    currentInstance,
+    priorInstances,
+  };
 }
 
 /** Manually reinstate a suspended or throttled workspace. */

--- a/packages/types/src/abuse.ts
+++ b/packages/types/src/abuse.ts
@@ -53,3 +53,59 @@ export interface AbuseThresholdConfig {
   /** Delay injected for throttled workspaces, in milliseconds. */
   throttleDelayMs: number;
 }
+
+/** Live sliding-window counters for the admin detail panel. */
+export interface AbuseCounters {
+  queryCount: number;
+  errorCount: number;
+  /** Null when queryCount < 10 (the engine only evaluates error rate once it has a baseline). */
+  errorRatePct: number | null;
+  uniqueTablesAccessed: number;
+  /** Consecutive escalation count currently driving the level. */
+  escalations: number;
+}
+
+/**
+ * A flag "instance" — one continuous stretch of non-"none" activity for a
+ * workspace, bookended by an escalation event and (optionally) a reinstatement
+ * event.
+ *
+ * `events` are chronological (oldest first). `endedAt` is null while the
+ * instance is still active (no reinstatement yet).
+ */
+export interface AbuseInstance {
+  startedAt: string;
+  endedAt: string | null;
+  /** Highest level reached during the instance. */
+  peakLevel: AbuseLevel;
+  events: AbuseEvent[];
+}
+
+/**
+ * Full investigation context for a single flagged workspace.
+ *
+ * Returned from `GET /api/v1/admin/abuse/:workspaceId/detail`. Lazy-loaded on
+ * row expand — the list endpoint stays lightweight.
+ */
+export interface AbuseDetail {
+  workspaceId: string;
+  workspaceName: string | null;
+  level: AbuseLevel;
+  trigger: AbuseTrigger | null;
+  message: string | null;
+  updatedAt: string;
+  counters: AbuseCounters;
+  thresholds: AbuseThresholdConfig;
+  /**
+   * Current (unreinstated) flag instance.
+   *
+   * May be empty if the workspace is flagged in memory but no persisted event
+   * is yet readable — e.g. `DATABASE_URL` isn't set on a self-hosted deploy,
+   * the write is still in flight, or `persistAbuseEvent` failed and was
+   * swallowed. The detail-panel empty copy deliberately doesn't assume the DB
+   * is broken in this case.
+   */
+  currentInstance: AbuseInstance;
+  /** Prior closed instances, newest-first. Capped server-side. */
+  priorInstances: AbuseInstance[];
+}

--- a/packages/types/src/abuse.ts
+++ b/packages/types/src/abuse.ts
@@ -86,14 +86,15 @@ export interface AbuseInstance {
  *
  * Returned from `GET /api/v1/admin/abuse/:workspaceId/detail`. Lazy-loaded on
  * row expand — the list endpoint stays lightweight.
+ *
+ * Extends `Omit<AbuseStatus, "events">` so the identity fields
+ * (workspaceId, workspaceName, level, trigger, message, updatedAt) stay
+ * structurally coupled to the list response. Events move into
+ * `currentInstance.events` / `priorInstances[i].events` — the detail panel
+ * splits them by flag instance so the list's flat `events` array is the
+ * wrong shape here.
  */
-export interface AbuseDetail {
-  workspaceId: string;
-  workspaceName: string | null;
-  level: AbuseLevel;
-  trigger: AbuseTrigger | null;
-  message: string | null;
-  updatedAt: string;
+export interface AbuseDetail extends Omit<AbuseStatus, "events"> {
   counters: AbuseCounters;
   thresholds: AbuseThresholdConfig;
   /**

--- a/packages/web/src/app/admin/abuse/detail-panel.tsx
+++ b/packages/web/src/app/admin/abuse/detail-panel.tsx
@@ -1,0 +1,380 @@
+"use client";
+
+import { Fragment } from "react";
+import { AlertTriangle, Loader2, RotateCcw } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
+import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
+import { friendlyError } from "@/ui/lib/fetch-error";
+import { RelativeTimestamp } from "@/ui/components/admin/queue";
+import { AbuseDetailSchema } from "@/ui/lib/admin-schemas";
+import type {
+  AbuseCounters,
+  AbuseInstance,
+  AbuseLevel,
+  AbuseThresholdConfig,
+} from "@/ui/lib/types";
+
+// Keep the inline-expand layout usable when the panel is still loading.
+const SKELETON_HEIGHT = "min-h-40";
+
+function levelBadge(level: AbuseLevel) {
+  switch (level) {
+    case "warning":
+      return (
+        <Badge
+          variant="outline"
+          className="border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+        >
+          Warning
+        </Badge>
+      );
+    case "throttled":
+      return (
+        <Badge
+          variant="outline"
+          className="border-orange-500/30 bg-orange-500/10 text-orange-700 dark:text-orange-300"
+        >
+          Throttled
+        </Badge>
+      );
+    case "suspended":
+      return <Badge variant="destructive">Suspended</Badge>;
+    default:
+      return <Badge variant="outline">None</Badge>;
+  }
+}
+
+function triggerLabel(trigger: string | null): string {
+  switch (trigger) {
+    case "query_rate":
+      return "Excessive queries";
+    case "error_rate":
+      return "High error rate";
+    case "unique_tables":
+      return "Unusual table access";
+    case "manual":
+      return "Manual action";
+    default:
+      return "—";
+  }
+}
+
+/**
+ * "147 / 100 queries in 60s" — formats a counter against its threshold so the
+ * operator can see how close to the line the workspace is without reaching
+ * for a calculator.
+ */
+function CounterRow({
+  label,
+  value,
+  threshold,
+  suffix,
+  over,
+}: {
+  label: string;
+  value: string;
+  threshold: string;
+  suffix?: string;
+  over: boolean;
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-2">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className="font-mono text-xs tabular-nums">
+        <span className={over ? "font-semibold text-destructive" : "text-foreground"}>
+          {value}
+        </span>
+        <span className="text-muted-foreground"> / {threshold}</span>
+        {suffix && <span className="text-muted-foreground"> {suffix}</span>}
+      </span>
+    </div>
+  );
+}
+
+function CountersSection({
+  counters,
+  thresholds,
+}: {
+  counters: AbuseCounters;
+  thresholds: AbuseThresholdConfig;
+}) {
+  const errorRatePctDisplay =
+    counters.errorRatePct !== null ? counters.errorRatePct.toFixed(0) : null;
+  const errorRateThresholdPct = (thresholds.errorRateThreshold * 100).toFixed(0);
+
+  return (
+    <section>
+      <h4 className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        Current counters
+      </h4>
+      <div className="space-y-1.5 rounded-md border bg-background p-3">
+        <CounterRow
+          label="Queries"
+          value={counters.queryCount.toString()}
+          threshold={thresholds.queryRateLimit.toString()}
+          suffix={`in ${thresholds.queryRateWindowSeconds}s`}
+          over={counters.queryCount > thresholds.queryRateLimit}
+        />
+        <CounterRow
+          label="Error rate"
+          value={errorRatePctDisplay !== null ? `${errorRatePctDisplay}%` : "—"}
+          threshold={`${errorRateThresholdPct}%`}
+          over={
+            counters.errorRatePct !== null &&
+            counters.errorRatePct / 100 > thresholds.errorRateThreshold
+          }
+        />
+        <CounterRow
+          label="Unique tables"
+          value={counters.uniqueTablesAccessed.toString()}
+          threshold={thresholds.uniqueTablesLimit.toString()}
+          over={counters.uniqueTablesAccessed > thresholds.uniqueTablesLimit}
+        />
+        <div className="flex items-baseline justify-between gap-2 pt-1">
+          <span className="text-xs text-muted-foreground">Consecutive escalations</span>
+          <span className="font-mono text-xs tabular-nums">{counters.escalations}</span>
+        </div>
+      </div>
+      {counters.errorRatePct === null && counters.queryCount > 0 && (
+        <p className="mt-1 text-[11px] text-muted-foreground/70">
+          Error rate is evaluated after 10 queries in the current window.
+        </p>
+      )}
+    </section>
+  );
+}
+
+function TimelineSection({
+  title,
+  instance,
+  emptyMessage,
+}: {
+  title: string;
+  instance: AbuseInstance;
+  emptyMessage: string;
+}) {
+  if (instance.events.length === 0) {
+    return (
+      <section>
+        <h4 className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          {title}
+        </h4>
+        <p className="rounded-md border bg-background p-3 text-xs text-muted-foreground">
+          {emptyMessage}
+        </p>
+      </section>
+    );
+  }
+  return (
+    <section>
+      <h4 className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {title}
+      </h4>
+      <ol className="space-y-1.5 rounded-md border bg-background p-3">
+        {instance.events.map((e) => (
+          <li
+            key={e.id}
+            className="flex items-baseline gap-2 text-xs"
+          >
+            <span className="w-16 shrink-0 text-muted-foreground">
+              <RelativeTimestamp iso={e.createdAt} />
+            </span>
+            <span className="shrink-0">{levelBadge(e.level)}</span>
+            <span className="flex-1 truncate text-muted-foreground">
+              {e.message || triggerLabel(e.trigger)}
+            </span>
+            {e.actor !== "system" && (
+              <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+                {e.actor}
+              </span>
+            )}
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+function PriorInstancesSection({ instances }: { instances: AbuseInstance[] }) {
+  if (instances.length === 0) {
+    return (
+      <section>
+        <h4 className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Prior flag history
+        </h4>
+        <p className="rounded-md border bg-background p-3 text-xs text-muted-foreground">
+          First time this workspace has been flagged.
+        </p>
+      </section>
+    );
+  }
+  return (
+    <section>
+      <h4 className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        Prior flag history ({instances.length})
+      </h4>
+      <ul className="space-y-1.5 rounded-md border bg-background p-3">
+        {instances.map((inst, i) => (
+          <li
+            key={`${inst.startedAt}-${i}`}
+            className="flex items-baseline gap-2 text-xs"
+          >
+            <span className="shrink-0">{levelBadge(inst.peakLevel)}</span>
+            <span className="flex-1 text-muted-foreground">
+              {inst.events.length} event{inst.events.length === 1 ? "" : "s"}
+            </span>
+            <span className="shrink-0 text-muted-foreground">
+              <RelativeTimestamp iso={inst.startedAt} />
+              {inst.endedAt && (
+                <Fragment>
+                  {" → "}
+                  <RelativeTimestamp iso={inst.endedAt} />
+                </Fragment>
+              )}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+/**
+ * Lazy-loaded investigation panel for a single flagged workspace.
+ *
+ * Owns its own `useAdminFetch` so expanding workspace A doesn't refetch
+ * workspace B's detail. The Reinstate mutation lives here too — it's an
+ * action *after* investigation, not the only affordance the row offered
+ * before the revamp.
+ */
+export function AbuseDetailPanel({
+  workspaceId,
+  onReinstated,
+}: {
+  workspaceId: string;
+  onReinstated: () => void;
+}) {
+  const { data, loading, error, refetch } = useAdminFetch(
+    `/api/v1/admin/abuse/${encodeURIComponent(workspaceId)}/detail`,
+    { schema: AbuseDetailSchema },
+  );
+
+  const reinstate = useAdminMutation({
+    method: "POST",
+    // Intentionally NOT refetching our own detail after reinstate — the
+    // workspace's level flips to "none" server-side, so the detail endpoint
+    // would 404 and flash an error banner before the parent's `onReinstated`
+    // refetch removes the row and unmounts this panel.
+    invalidates: onReinstated,
+  });
+
+  async function handleReinstate() {
+    const result = await reinstate.mutate({
+      path: `/api/v1/admin/abuse/${encodeURIComponent(workspaceId)}/reinstate`,
+    });
+    // Errors surface via reinstate.error in the banner below; explicit early
+    // return so future success-only UI work (toast, focus management) doesn't
+    // need to re-read the hook state.
+    if (!result.ok) return;
+  }
+
+  if (loading && !data) {
+    return (
+      <div
+        className={`flex items-center justify-center gap-2 rounded-md border bg-background p-4 text-sm text-muted-foreground ${SKELETON_HEIGHT}`}
+      >
+        <Loader2 className="size-4 animate-spin" />
+        Loading investigation detail...
+      </div>
+    );
+  }
+
+  if (error) {
+    // 404 `not_flagged` fires on a benign race — the workspace was reinstated
+    // from another tab (or aged out of the in-memory window) between the
+    // list fetch and this detail fetch. Don't funnel it through the generic
+    // `friendlyError()` mapping, which rewrites all 404s to
+    // "This feature is not enabled on this server." — that's correct for the
+    // top-level SaaS-gated page, and actively misleading here. Render the
+    // server's own message and refresh the parent list instead of showing a
+    // Retry button that will 404 again.
+    if (error.code === "not_flagged") {
+      return (
+        <div className="rounded-md border bg-background p-3 text-sm">
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+            <div className="flex-1">
+              <p className="font-medium">Workspace is no longer flagged</p>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                It was reinstated elsewhere or returned to normal. The list may be out of date.
+              </p>
+            </div>
+            <Button size="sm" variant="outline" onClick={onReinstated}>
+              Refresh list
+            </Button>
+          </div>
+        </div>
+      );
+    }
+    return (
+      <div className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm">
+        <div className="flex items-start gap-2">
+          <AlertTriangle className="mt-0.5 size-4 shrink-0 text-destructive" />
+          <div className="flex-1">
+            <p className="font-medium text-destructive">Couldn't load investigation detail</p>
+            <p className="mt-0.5 text-xs text-muted-foreground">{friendlyError(error)}</p>
+          </div>
+          <Button size="sm" variant="outline" onClick={() => refetch()}>
+            Retry
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      <CountersSection counters={data.counters} thresholds={data.thresholds} />
+      <TimelineSection
+        title="Current flag timeline"
+        instance={data.currentInstance}
+        emptyMessage="No persisted events yet for this flag. Recent events will appear here once they are written to the audit trail."
+      />
+      <div className="lg:col-span-2">
+        <PriorInstancesSection instances={data.priorInstances} />
+      </div>
+
+      {reinstate.error && (
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive lg:col-span-2"
+        >
+          {friendlyError(reinstate.error)}
+        </div>
+      )}
+
+      <footer className="flex flex-wrap items-center justify-between gap-2 border-t pt-3 lg:col-span-2">
+        <p className="text-xs text-muted-foreground">
+          Reinstating resets counters. If the pattern continues the workspace will be
+          flagged again.
+        </p>
+        <Button
+          onClick={handleReinstate}
+          disabled={reinstate.saving}
+          size="sm"
+        >
+          {reinstate.saving ? (
+            <Loader2 className="mr-1 size-3 animate-spin" />
+          ) : (
+            <RotateCcw className="mr-1 size-3" />
+          )}
+          Reinstate workspace
+        </Button>
+      </footer>
+    </div>
+  );
+}

--- a/packages/web/src/app/admin/abuse/detail-panel.tsx
+++ b/packages/web/src/app/admin/abuse/detail-panel.tsx
@@ -2,7 +2,6 @@
 
 import { Fragment } from "react";
 import { AlertTriangle, Loader2, RotateCcw } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
@@ -12,54 +11,12 @@ import { AbuseDetailSchema } from "@/ui/lib/admin-schemas";
 import type {
   AbuseCounters,
   AbuseInstance,
-  AbuseLevel,
   AbuseThresholdConfig,
 } from "@/ui/lib/types";
+import { levelBadge, triggerLabel } from "./helpers";
 
 // Keep the inline-expand layout usable when the panel is still loading.
 const SKELETON_HEIGHT = "min-h-40";
-
-function levelBadge(level: AbuseLevel) {
-  switch (level) {
-    case "warning":
-      return (
-        <Badge
-          variant="outline"
-          className="border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
-        >
-          Warning
-        </Badge>
-      );
-    case "throttled":
-      return (
-        <Badge
-          variant="outline"
-          className="border-orange-500/30 bg-orange-500/10 text-orange-700 dark:text-orange-300"
-        >
-          Throttled
-        </Badge>
-      );
-    case "suspended":
-      return <Badge variant="destructive">Suspended</Badge>;
-    default:
-      return <Badge variant="outline">None</Badge>;
-  }
-}
-
-function triggerLabel(trigger: string | null): string {
-  switch (trigger) {
-    case "query_rate":
-      return "Excessive queries";
-    case "error_rate":
-      return "High error rate";
-    case "unique_tables":
-      return "Unusual table access";
-    case "manual":
-      return "Manual action";
-    default:
-      return "—";
-  }
-}
 
 /**
  * "147 / 100 queries in 60s" — formats a counter against its threshold so the
@@ -271,13 +228,12 @@ export function AbuseDetailPanel({
   });
 
   async function handleReinstate() {
-    const result = await reinstate.mutate({
+    // Errors surface via `reinstate.error` in the banner below. On success the
+    // parent's `onReinstated` refetch drops this workspace from the list and
+    // unmounts the panel.
+    await reinstate.mutate({
       path: `/api/v1/admin/abuse/${encodeURIComponent(workspaceId)}/reinstate`,
     });
-    // Errors surface via reinstate.error in the banner below; explicit early
-    // return so future success-only UI work (toast, focus management) doesn't
-    // need to re-read the hook state.
-    if (!result.ok) return;
   }
 
   if (loading && !data) {

--- a/packages/web/src/app/admin/abuse/helpers.tsx
+++ b/packages/web/src/app/admin/abuse/helpers.tsx
@@ -1,0 +1,49 @@
+import { Badge } from "@/components/ui/badge";
+import type { AbuseLevel } from "@/ui/lib/types";
+
+/**
+ * Renders a color-coded badge for an abuse level. Accepts any string so list
+ * responses (where the server types the field as a string union) and strictly
+ * typed `AbuseLevel` callers can share the same helper.
+ */
+export function levelBadge(level: AbuseLevel | string) {
+  switch (level) {
+    case "warning":
+      return (
+        <Badge
+          variant="outline"
+          className="border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+        >
+          Warning
+        </Badge>
+      );
+    case "throttled":
+      return (
+        <Badge
+          variant="outline"
+          className="border-orange-500/30 bg-orange-500/10 text-orange-700 dark:text-orange-300"
+        >
+          Throttled
+        </Badge>
+      );
+    case "suspended":
+      return <Badge variant="destructive">Suspended</Badge>;
+    default:
+      return <Badge variant="outline">None</Badge>;
+  }
+}
+
+export function triggerLabel(trigger: string | null): string {
+  switch (trigger) {
+    case "query_rate":
+      return "Excessive queries";
+    case "error_rate":
+      return "High error rate";
+    case "unique_tables":
+      return "Unusual table access";
+    case "manual":
+      return "Manual action";
+    default:
+      return "—";
+  }
+}

--- a/packages/web/src/app/admin/abuse/page.tsx
+++ b/packages/web/src/app/admin/abuse/page.tsx
@@ -10,7 +10,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import {
   Table,
   TableBody,
@@ -40,6 +39,7 @@ import type { AbuseStatus } from "@/ui/lib/types";
 import { AbuseStatusSchema, AbuseThresholdConfigSchema } from "@/ui/lib/admin-schemas";
 import { abuseSearchParams } from "./search-params";
 import { AbuseDetailPanel } from "./detail-panel";
+import { levelBadge, triggerLabel } from "./helpers";
 
 // ── Schemas ───────────────────────────────────────────────────────
 
@@ -56,48 +56,6 @@ const FILTER_OPTIONS: { value: LevelFilter; label: string }[] = [
   { value: "throttled", label: "Throttled" },
   { value: "suspended", label: "Suspended" },
 ];
-
-function levelBadge(level: string) {
-  switch (level) {
-    case "warning":
-      return (
-        <Badge
-          variant="outline"
-          className="border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
-        >
-          Warning
-        </Badge>
-      );
-    case "throttled":
-      return (
-        <Badge
-          variant="outline"
-          className="border-orange-500/30 bg-orange-500/10 text-orange-700 dark:text-orange-300"
-        >
-          Throttled
-        </Badge>
-      );
-    case "suspended":
-      return <Badge variant="destructive">Suspended</Badge>;
-    default:
-      return <Badge variant="outline">None</Badge>;
-  }
-}
-
-function triggerLabel(trigger: string | null): string {
-  switch (trigger) {
-    case "query_rate":
-      return "Excessive queries";
-    case "error_rate":
-      return "High error rate";
-    case "unique_tables":
-      return "Unusual table access";
-    case "manual":
-      return "Manual action";
-    default:
-      return "—";
-  }
-}
 
 // ── Main Page ─────────────────────────────────────────────────────
 

--- a/packages/web/src/app/admin/abuse/page.tsx
+++ b/packages/web/src/app/admin/abuse/page.tsx
@@ -1,9 +1,16 @@
 "use client";
 
-import { useState } from "react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Fragment } from "react";
+import { useQueryStates } from "nuqs";
+import { z } from "zod";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import {
   Table,
   TableBody,
@@ -12,32 +19,27 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
-import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError } from "@/ui/lib/fetch-error";
 import { usePlatformAdminGuard } from "@/ui/hooks/use-platform-admin-guard";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { LoadingState } from "@/ui/components/admin/loading-state";
 import {
-  ShieldAlert,
-  RotateCcw,
-  Loader2,
-  AlertTriangle,
+  QueueFilterRow,
+  RelativeTimestamp,
+} from "@/ui/components/admin/queue";
+import {
   Activity,
+  ChevronDown,
+  ChevronRight,
   Settings2,
+  ShieldAlert,
 } from "lucide-react";
-import { z } from "zod";
 import type { AbuseStatus } from "@/ui/lib/types";
 import { AbuseStatusSchema, AbuseThresholdConfigSchema } from "@/ui/lib/admin-schemas";
+import { abuseSearchParams } from "./search-params";
+import { AbuseDetailPanel } from "./detail-panel";
 
 // ── Schemas ───────────────────────────────────────────────────────
 
@@ -46,14 +48,35 @@ const AbuseListResponseSchema = z.object({
   total: z.number(),
 });
 
-// ── Level badge colors ────────────────────────────────────────────
+type LevelFilter = "all" | "warning" | "throttled" | "suspended";
+
+const FILTER_OPTIONS: { value: LevelFilter; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "warning", label: "Warning" },
+  { value: "throttled", label: "Throttled" },
+  { value: "suspended", label: "Suspended" },
+];
 
 function levelBadge(level: string) {
   switch (level) {
     case "warning":
-      return <Badge variant="outline" className="border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300">Warning</Badge>;
+      return (
+        <Badge
+          variant="outline"
+          className="border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+        >
+          Warning
+        </Badge>
+      );
     case "throttled":
-      return <Badge variant="outline" className="border-orange-500/30 bg-orange-500/10 text-orange-700 dark:text-orange-300">Throttled</Badge>;
+      return (
+        <Badge
+          variant="outline"
+          className="border-orange-500/30 bg-orange-500/10 text-orange-700 dark:text-orange-300"
+        >
+          Throttled
+        </Badge>
+      );
     case "suspended":
       return <Badge variant="destructive">Suspended</Badge>;
     default:
@@ -61,106 +84,38 @@ function levelBadge(level: string) {
   }
 }
 
-function triggerLabel(trigger: string | null) {
+function triggerLabel(trigger: string | null): string {
   switch (trigger) {
-    case "query_rate": return "Excessive queries";
-    case "error_rate": return "High error rate";
-    case "unique_tables": return "Unusual table access";
-    case "manual": return "Manual action";
-    default: return "-";
+    case "query_rate":
+      return "Excessive queries";
+    case "error_rate":
+      return "High error rate";
+    case "unique_tables":
+      return "Unusual table access";
+    case "manual":
+      return "Manual action";
+    default:
+      return "—";
   }
-}
-
-// ── Reinstate Dialog ──────────────────────────────────────────────
-
-function ReinstateDialog({
-  workspace,
-  open,
-  onOpenChange,
-  onReinstated,
-}: {
-  workspace: AbuseStatus | null;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  onReinstated: () => void;
-}) {
-  const { mutate, saving: loading, error, reset } = useAdminMutation({
-    method: "POST",
-    invalidates: onReinstated,
-  });
-
-  function handleOpen(next: boolean) {
-    if (!next) reset();
-    onOpenChange(next);
-  }
-
-  async function handleReinstate() {
-    if (!workspace) return;
-    const result = await mutate({
-      path: `/api/v1/admin/abuse/${encodeURIComponent(workspace.workspaceId)}/reinstate`,
-    });
-    if (result.ok) {
-      handleOpen(false);
-    }
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={handleOpen}>
-      <DialogContent className="max-w-md">
-        <DialogHeader>
-          <DialogTitle>Reinstate Workspace</DialogTitle>
-          <DialogDescription>
-            This will clear the abuse flag and allow the workspace to resume normal operations.
-          </DialogDescription>
-        </DialogHeader>
-
-        {workspace && (
-          <div className="space-y-3 py-2">
-            <div className="rounded-md bg-muted p-3">
-              <p className="text-sm font-medium">{workspace.workspaceName ?? workspace.workspaceId}</p>
-              <div className="mt-1 flex items-center gap-2">
-                {levelBadge(workspace.level)}
-                <span className="text-xs text-muted-foreground">{triggerLabel(workspace.trigger)}</span>
-              </div>
-              {workspace.message && (
-                <p className="mt-1 text-xs text-muted-foreground">{workspace.message}</p>
-              )}
-            </div>
-
-            <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2">
-              <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" />
-              <p className="text-xs text-amber-700 dark:text-amber-300">
-                Reinstating resets all abuse counters for this workspace. If the abusive pattern continues, the workspace will be flagged again.
-              </p>
-            </div>
-
-            {error && (
-              <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                {friendlyError(error)}
-              </div>
-            )}
-          </div>
-        )}
-
-        <DialogFooter>
-          <Button variant="outline" onClick={() => handleOpen(false)}>
-            Cancel
-          </Button>
-          <Button onClick={handleReinstate} disabled={loading}>
-            {loading && <Loader2 className="mr-1 size-3 animate-spin" />}
-            Reinstate
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
 }
 
 // ── Main Page ─────────────────────────────────────────────────────
 
 export default function AbusePage() {
+  return (
+    <ErrorBoundary>
+      <TooltipProvider>
+        <AbusePageContent />
+      </TooltipProvider>
+    </ErrorBoundary>
+  );
+}
+
+function AbusePageContent() {
   const { blocked } = usePlatformAdminGuard();
-  const [reinstateTarget, setReinstateTarget] = useState<AbuseStatus | null>(null);
+  const [{ level: levelFilter, expanded: expandedId }, setParams] = useQueryStates(
+    abuseSearchParams,
+  );
 
   const { data, loading, error, refetch } = useAdminFetch(
     "/api/v1/admin/abuse",
@@ -172,7 +127,11 @@ export default function AbusePage() {
     { schema: AbuseThresholdConfigSchema },
   );
 
-  const workspaces = data?.workspaces ?? [];
+  const workspaces: AbuseStatus[] = data?.workspaces ?? [];
+  const filtered =
+    levelFilter === "all"
+      ? workspaces
+      : workspaces.filter((w) => w.level === levelFilter);
 
   if (blocked) {
     return <LoadingState message="Checking access..." />;
@@ -183,48 +142,58 @@ export default function AbusePage() {
       <div className="mb-6">
         <h1 className="text-2xl font-bold tracking-tight">Abuse Prevention</h1>
         <p className="text-sm text-muted-foreground">
-          Monitor anomalous query patterns and manage workspace suspensions
+          Monitor anomalous query patterns and manage workspace suspensions.
         </p>
       </div>
 
-      <ErrorBoundary>
-        <div className="space-y-6">
-          {/* Threshold config summary */}
-          {config && (
-            <Card className="shadow-none">
-              <CardHeader className="pb-2">
-                <CardTitle className="flex items-center gap-2 text-base">
-                  <Settings2 className="size-4" />
-                  Detection Thresholds
-                </CardTitle>
-                <CardDescription>
-                  Configure via environment variables. See the abuse prevention guide for details.
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-                  <div>
-                    <p className="text-xs text-muted-foreground">Query Rate Limit</p>
-                    <p className="text-sm font-medium">{config.queryRateLimit} / {config.queryRateWindowSeconds}s</p>
-                  </div>
-                  <div>
-                    <p className="text-xs text-muted-foreground">Error Rate Threshold</p>
-                    <p className="text-sm font-medium">{(config.errorRateThreshold * 100).toFixed(0)}%</p>
-                  </div>
-                  <div>
-                    <p className="text-xs text-muted-foreground">Unique Tables Limit</p>
-                    <p className="text-sm font-medium">{config.uniqueTablesLimit}</p>
-                  </div>
-                  <div>
-                    <p className="text-xs text-muted-foreground">Throttle Delay</p>
-                    <p className="text-sm font-medium">{config.throttleDelayMs}ms</p>
-                  </div>
+      <div className="space-y-6">
+        {/* Threshold config summary — env-only, read-only. */}
+        {config && (
+          <Card className="shadow-none">
+            <CardHeader className="pb-2">
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Settings2 className="size-4" />
+                Detection Thresholds
+              </CardTitle>
+              <CardDescription>
+                Configured via environment variables. See the abuse prevention guide for details.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+                <div>
+                  <p className="text-xs text-muted-foreground">Query Rate Limit</p>
+                  <p className="text-sm font-medium">
+                    {config.queryRateLimit} / {config.queryRateWindowSeconds}s
+                  </p>
                 </div>
-              </CardContent>
-            </Card>
-          )}
+                <div>
+                  <p className="text-xs text-muted-foreground">Error Rate Threshold</p>
+                  <p className="text-sm font-medium">
+                    {(config.errorRateThreshold * 100).toFixed(0)}%
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs text-muted-foreground">Unique Tables Limit</p>
+                  <p className="text-sm font-medium">{config.uniqueTablesLimit}</p>
+                </div>
+                <div>
+                  <p className="text-xs text-muted-foreground">Throttle Delay</p>
+                  <p className="text-sm font-medium">{config.throttleDelayMs}ms</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        )}
 
-          {/* Flagged workspaces */}
+        {/* Flagged workspaces */}
+        <div className="space-y-3">
+          <QueueFilterRow
+            options={FILTER_OPTIONS}
+            value={levelFilter}
+            onChange={(next) => setParams({ level: next, expanded: null })}
+          />
+
           <AdminContentWrapper
             loading={loading}
             error={error}
@@ -232,9 +201,17 @@ export default function AbusePage() {
             onRetry={refetch}
             loadingMessage="Loading abuse flags..."
             emptyIcon={ShieldAlert}
-            emptyTitle="No workspaces flagged"
-            emptyDescription="All workspaces are operating within normal parameters. Anomalous query patterns will be automatically detected and shown here."
-            isEmpty={workspaces.length === 0}
+            emptyTitle={
+              levelFilter === "all"
+                ? "No workspaces flagged"
+                : `No workspaces at level ${levelFilter}`
+            }
+            emptyDescription={
+              levelFilter === "all"
+                ? "All workspaces are operating within normal parameters. Anomalous query patterns will be automatically detected and shown here."
+                : "Try a different filter, or switch to All to see other flagged workspaces."
+            }
+            isEmpty={filtered.length === 0}
           >
             <Card className="shadow-none">
               <CardHeader className="pb-2">
@@ -243,64 +220,79 @@ export default function AbusePage() {
                   Flagged Workspaces
                 </CardTitle>
                 <CardDescription>
-                  Workspaces with active abuse warnings, throttling, or suspensions.
+                  Click a row to open the investigation panel. Reinstate from the panel footer
+                  after reviewing counters and timeline.
                 </CardDescription>
               </CardHeader>
               <CardContent>
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Workspace</TableHead>
-                      <TableHead>Status</TableHead>
-                      <TableHead>Trigger</TableHead>
-                      <TableHead>Details</TableHead>
-                      <TableHead>Updated</TableHead>
-                      <TableHead className="w-[80px]" />
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {workspaces.map((ws) => (
-                      <TableRow key={ws.workspaceId}>
-                        <TableCell className="font-mono text-sm">
-                          {ws.workspaceName ?? ws.workspaceId}
-                        </TableCell>
-                        <TableCell>{levelBadge(ws.level)}</TableCell>
-                        <TableCell className="text-sm text-muted-foreground">
-                          {triggerLabel(ws.trigger)}
-                        </TableCell>
-                        <TableCell className="max-w-[200px] truncate text-xs text-muted-foreground">
-                          {ws.message ?? "-"}
-                        </TableCell>
-                        <TableCell className="text-sm text-muted-foreground">
-                          {new Date(ws.updatedAt).toLocaleString()}
-                        </TableCell>
-                        <TableCell>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-7 px-2 text-xs"
-                            onClick={() => setReinstateTarget(ws)}
-                          >
-                            <RotateCcw className="mr-1 size-3" />
-                            Reinstate
-                          </Button>
-                        </TableCell>
+                <div className="rounded-md border">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead className="w-6" />
+                        <TableHead>Workspace</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead>Trigger</TableHead>
+                        <TableHead>Details</TableHead>
+                        <TableHead>Updated</TableHead>
                       </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
+                    </TableHeader>
+                    <TableBody>
+                      {filtered.map((ws) => {
+                        const isExpanded = expandedId === ws.workspaceId;
+                        return (
+                          <Fragment key={ws.workspaceId}>
+                            <TableRow
+                              className="cursor-pointer"
+                              onClick={() =>
+                                setParams({
+                                  expanded: isExpanded ? null : ws.workspaceId,
+                                })
+                              }
+                              aria-expanded={isExpanded}
+                            >
+                              <TableCell>
+                                {isExpanded ? (
+                                  <ChevronDown className="size-4 text-muted-foreground" />
+                                ) : (
+                                  <ChevronRight className="size-4 text-muted-foreground" />
+                                )}
+                              </TableCell>
+                              <TableCell className="font-mono text-sm">
+                                {ws.workspaceName ?? ws.workspaceId}
+                              </TableCell>
+                              <TableCell>{levelBadge(ws.level)}</TableCell>
+                              <TableCell className="text-sm text-muted-foreground">
+                                {triggerLabel(ws.trigger)}
+                              </TableCell>
+                              <TableCell className="max-w-[260px] truncate text-xs text-muted-foreground">
+                                {ws.message ?? "—"}
+                              </TableCell>
+                              <TableCell className="whitespace-nowrap text-sm text-muted-foreground">
+                                <RelativeTimestamp iso={ws.updatedAt} />
+                              </TableCell>
+                            </TableRow>
+                            {isExpanded && (
+                              <TableRow>
+                                <TableCell colSpan={6} className="bg-muted/30 p-4">
+                                  <AbuseDetailPanel
+                                    workspaceId={ws.workspaceId}
+                                    onReinstated={refetch}
+                                  />
+                                </TableCell>
+                              </TableRow>
+                            )}
+                          </Fragment>
+                        );
+                      })}
+                    </TableBody>
+                  </Table>
+                </div>
               </CardContent>
             </Card>
           </AdminContentWrapper>
         </div>
-      </ErrorBoundary>
-
-      <ReinstateDialog
-        workspace={reinstateTarget}
-        open={!!reinstateTarget}
-        onOpenChange={(open) => !open && setReinstateTarget(null)}
-        onReinstated={refetch}
-      />
+      </div>
     </div>
   );
 }

--- a/packages/web/src/app/admin/abuse/search-params.ts
+++ b/packages/web/src/app/admin/abuse/search-params.ts
@@ -1,0 +1,19 @@
+import { parseAsString, parseAsStringLiteral } from "nuqs";
+
+/**
+ * URL state for /admin/abuse.
+ *
+ * `level` — filter chips (all / warning / throttled / suspended). The list
+ * endpoint returns all non-"none" flagged workspaces — filtering happens
+ * client-side since the flagged set is always small.
+ * `expanded` — workspaceId of the currently-expanded investigation panel.
+ */
+export const abuseSearchParams = {
+  level: parseAsStringLiteral([
+    "all",
+    "warning",
+    "throttled",
+    "suspended",
+  ] as const).withDefault("all"),
+  expanded: parseAsString,
+};

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -16,6 +16,7 @@ import type {
   ApprovalRequest,
   AbuseStatus,
   AbuseThresholdConfig,
+  AbuseDetail,
   PIIColumnClassification,
   SemanticDiffResponse,
   PlatformStats,
@@ -145,6 +146,34 @@ export const AbuseThresholdConfigSchema = z.object({
   uniqueTablesLimit: z.number(),
   throttleDelayMs: z.number(),
 }) as z.ZodType<AbuseThresholdConfig>;
+
+const AbuseCountersSchema = z.object({
+  queryCount: z.number(),
+  errorCount: z.number(),
+  errorRatePct: z.number().nullable(),
+  uniqueTablesAccessed: z.number(),
+  escalations: z.number(),
+});
+
+const AbuseInstanceSchema = z.object({
+  startedAt: z.string(),
+  endedAt: z.string().nullable(),
+  peakLevel: z.string(),
+  events: z.array(AbuseEventSchema),
+});
+
+export const AbuseDetailSchema = z.object({
+  workspaceId: z.string(),
+  workspaceName: z.string().nullable(),
+  level: z.string(),
+  trigger: z.string().nullable(),
+  message: z.string().nullable(),
+  updatedAt: z.string(),
+  counters: AbuseCountersSchema,
+  thresholds: AbuseThresholdConfigSchema,
+  currentInstance: AbuseInstanceSchema,
+  priorInstances: z.array(AbuseInstanceSchema),
+}) as z.ZodType<AbuseDetail>;
 
 // ── Compliance ────────────────────────────────────────────────────
 

--- a/packages/web/src/ui/lib/types.ts
+++ b/packages/web/src/ui/lib/types.ts
@@ -114,6 +114,9 @@ export type {
   AbuseEvent,
   AbuseStatus,
   AbuseThresholdConfig,
+  AbuseCounters,
+  AbuseInstance,
+  AbuseDetail,
 } from "@useatlas/types";
 export type {
   WorkspaceSLASummary,


### PR DESCRIPTION
Closes #1589. Bucket-1 follow-up tracked by #1588.

## Summary

Replaces the blind Reinstate row on `/admin/abuse` with an inline-expand investigation panel. Matches the bucket-1 queue pattern — CompactRow + QueueFilterRow + inline detail — extracted during PR #1600.

| Before | After |
|---|---|
| Row = 200px-truncated message + direct Reinstate dialog | Row expands inline into `AbuseDetailPanel` |
| Operator leaves for audit log / Grafana / customer dashboard to investigate | Current counters (annotated against thresholds), current flag timeline, and up to 5 prior instances rendered in place |
| Reinstate is the only affordance the row offers | Reinstate moves to the expanded footer — action **after** investigation |

## Backend

- `packages/api/src/lib/security/abuse-instances.ts` — pure `splitIntoInstances()` helper. Groups events into current vs prior flag instances, bounded by manual reinstatement events. Mock-free → unit-testable in isolation.
- `packages/api/src/lib/security/abuse.ts` — `getAbuseDetail(workspaceId, priorLimit=5)` returns status + live counters + thresholds + split instance history. `null` when workspace isn't flagged.
- `packages/api/src/api/routes/admin-abuse.ts` — `GET /api/v1/admin/abuse/:workspaceId/detail`. Effect.gen + runEffect. `404 not_flagged` with requestId when workspace is absent or reinstated.
- `packages/api/src/__mocks__/api-test-mocks.ts` — shared mock factory updated with `getAbuseDetail` per CLAUDE.md "mock every named export" rule (partial-mock SyntaxError would otherwise cascade into ~15 admin test files).

## Types (new `@useatlas/types` exports)

- `AbuseCounters` — live sliding-window stats (`queryCount`, `errorCount`, `errorRatePct | null`, `uniqueTablesAccessed`, `escalations`).
- `AbuseInstance` — `{ startedAt, endedAt | null, peakLevel, events[] }` with chronological events.
- `AbuseDetail` — top-level response shape. JSDoc on `currentInstance.events` is explicit that empty can mean no internal DB / write in flight / persist failed — not only "lost writes".

## Frontend

- `packages/web/src/app/admin/abuse/page.tsx` — full rewrite. nuqs-driven `{ level, expanded }` URL state. QueueFilterRow chips (`all | warning | throttled | suspended`), client-side filter (flagged set is small). `AbuseDetailPanel` mounts only when row is expanded.
- `packages/web/src/app/admin/abuse/detail-panel.tsx` — lazy-loaded. Owns its own `useAdminFetch` so expanding workspace A doesn't refetch B (TanStack keys on path). Reinstate via `useAdminMutation` with structured `FetchError` → `friendlyError()` (arch win #29).
- `packages/web/src/app/admin/abuse/search-params.ts` — nuqs params.
- `packages/web/src/ui/lib/admin-schemas.ts` — `AbuseDetailSchema` for `useAdminFetch({ schema })` runtime validation.

## Silent-failure-hunter fixes applied pre-merge

1. **HIGH — 404 `not_flagged` was rewritten to "feature not enabled" by shared `friendlyError()`.** Misleading on the benign race where admin B reinstates the workspace from another tab. Detail panel now branches on `error.code === "not_flagged"` and renders the server's own "Workspace is no longer flagged" message + a Refresh button. `friendlyError()` itself is untouched — the mapping remains correct for the top-level SaaS-gated page.
2. **MEDIUM — Empty timeline copy ("audit trail is momentarily unreachable") implied DB trouble for a benign empty state.** Reworded to "No persisted events yet... Recent events will appear here once they are written." JSDoc on `AbuseDetail.currentInstance` matches.
3. **LOW — Reinstate's `invalidates: [refetch, onReinstated]` would trigger a 404 flash on the detail panel before the parent list refetch removed the row.** Dropped `refetch` from `invalidates` — the workspace is no longer flagged after reinstate so re-reading detail is wasted work. Comment anchors the decision.
4. **LOW — `handleReinstate` discarded `MutateResult`.** Now captures `result.ok` so future success-only affordances (toast, focus management) don't have to re-read hook state.

Code-reviewer: clean, no critical/important findings. Comment-analyzer: zero misleading comments, two nits applied. Pr-test-analyzer: mergeable on coverage; matches bucket-1 precedent (#1592/#1594/#1600) — pure-function tests + route tests, no component tests for the revamped page.

## Tests

- `packages/api/src/lib/security/__tests__/abuse-instances.test.ts` — 7 cases covering the full decision tree (empty, current-only, split by reinstatement, newest-first prior ordering, priorLimit cap, peakLevel by rank not order, non-manual 'none' is not a reinstatement).
- `packages/api/src/api/__tests__/admin-abuse.test.ts` — 3 new cases for the detail route (200 success path, 404 `not_flagged` with requestId assertion, 403 non-admin). Existing 8 tests still pass after the shared-mock update.

## Docs

`apps/docs/content/docs/platform-ops/abuse-prevention.mdx` — admin console section now describes the investigation panel (counters + timeline + history + footer-Reinstate), API reference documents the new endpoint.

## CI

All five gates pass locally:
- `bun run lint` ✓
- `bun run type` ✓
- `bun run test` ✓ (all packages)
- `bun x syncpack lint` ✓
- `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` ✓ (429 files verified)

## Follow-ups filed during review

- #1638 — refactor: extract + unit-test `errorRatePct` branch (P2, low severity)
- #1639 — test: integration test for `getAbuseDetail` against real in-memory state (P2)
- #1640 — fix: resolve `workspaceName` in list + detail routes (pre-existing list-path bug mirrored into detail)

## Out of scope (per #1589)

- Manual flag-from-UI affordance
- Editable thresholds (env-var-only is correct for security)
- Snooze / acknowledge as Reinstate alternatives
- Reinstate-with-reason audit capture

## Test plan

- [ ] Visit `/admin/abuse` in developer mode with a seeded flagged workspace
- [ ] Click a row → panel expands, counters + timeline load, Reinstate button sits in footer
- [ ] Click a different row → panel swaps, no duplicate network calls for the first row
- [ ] Click same row again → panel collapses, URL `?expanded=...` clears
- [ ] Filter chip to `suspended` → list narrows, `?level=suspended` persists in URL
- [ ] Reinstate a workspace → row disappears from list, no error flash in the panel
- [ ] From a second session, reinstate the currently-expanded workspace → panel shows "Workspace is no longer flagged" message with Refresh button (not "This feature is not enabled")
- [ ] Hover timestamp → absolute tooltip shows via `RelativeTimestamp` primitive