### PR TITLE
fix: bucket-1 bug sweep — 5 open bugs in one PR

### DIFF
--- a/apps/docs/content/docs/guides/plugin-marketplace.mdx
+++ b/apps/docs/content/docs/guides/plugin-marketplace.mdx
@@ -1,80 +1,79 @@
 ---
 title: Plugin Marketplace
-description: Browse, install, configure, and uninstall plugins from the workspace plugin marketplace.
+description: Manage installed plugins from the workspace admin console. Self-service browse-and-install is not yet available.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-The plugin marketplace lets workspace admins discover and install plugins without editing configuration files. Browse available plugins, install them with one click, configure settings, and uninstall when no longer needed.
+The plugins admin page lets workspace admins view, configure, health-check, enable, and disable plugins that are already loaded in their workspace. Install and uninstall happen outside the admin UI today — see [Installing plugins](#installing-plugins) below.
 
 <Callout title="Prerequisites">
 - [Managed auth](/deployment/authentication#managed-auth) enabled
-- An internal database configured (`DATABASE_URL`)
+- An internal database configured (`DATABASE_URL`) — required for enable/disable state
 - A user with the `admin` role
-- **SaaS mode** — the marketplace is available on app.useatlas.dev. In self-hosted mode, manage plugins via `atlas.config.ts`
+</Callout>
+
+<Callout type="warn" title="Self-service browse is not shipped yet">
+Earlier drafts of this guide described an **Available** tab and **Enterprise badge** on a browse-and-install surface. That UI does **not** exist in the admin console today — the page renders only the **Installed** list. Install/uninstall happens through `atlas.config.ts` (self-hosted) or platform admin (SaaS). The marketplace API exists but has no web consumer; self-service browse is tracked as a future enhancement.
 </Callout>
 
 ---
 
-## Accessing the Marketplace
+## Accessing the plugins page
 
-Navigate to **Admin > Plugins** (`/admin/plugins`). In SaaS mode, the page shows two tabs:
-
-- **Installed** — Plugins currently active in your workspace (both config-loaded and marketplace-installed)
-- **Available** — Plugins in the platform catalog that you haven't installed yet
-
-In self-hosted mode, only config-loaded plugins are shown with a note to manage them via `atlas.config.ts`.
+Navigate to **Admin → Plugins** (`/admin/plugins`). The page lists every plugin loaded in your workspace (from `atlas.config.ts` and, on SaaS, any plugins installed by a platform admin on your behalf). Each row shows the plugin's name, type badge, enable/disable state, and a toggle to expand configuration and health details.
 
 ---
 
-## Browsing Available Plugins
+## What the page shows for each plugin
 
-Switch to the **Available** tab to see plugins you can install. Each card shows:
-
-- **Name** and **type badge** (Datasource, Context, Interaction, Action, Sandbox)
-- **Description** of what the plugin does
-- **Enterprise badge** — if the plugin requires a Business plan
-- **Install button**
-
-Use the **search bar** to filter by name or the **type dropdown** to filter by plugin category.
+- **Name** and **type badge** — Datasource, Context, Interaction, Action, or Sandbox
+- **Status** — healthy, unhealthy, or unknown (based on the last health check)
+- **Enable/disable toggle** — turn a plugin on or off without restarting; disabled plugins are excluded from the agent loop
+- **Configure** — edit the plugin's runtime configuration (typed form if `getConfigSchema()` is defined, read-only JSON otherwise)
+- **Health** — run a live probe and see the plugin's status
 
 <Callout type="info">
-Plugins are filtered by your workspace's plan tier. Each plugin has a minimum plan requirement — only plugins your tier qualifies for are shown.
+The enable/disable toggle and configuration edits require an internal database (`DATABASE_URL`). Without one, plugins always run with the values baked into `atlas.config.ts` and the toggle is a no-op.
 </Callout>
 
 ---
 
-## Installing a Plugin
+## Installing plugins
 
-1. Find the plugin in the **Available** tab
-2. Click **Install**
-3. If the plugin has a config schema, a dialog appears with configuration fields — fill them in
-4. If no config is needed, a confirmation dialog appears
-5. Click **Install** to confirm
+There is no self-service install UI today. Pick the path that matches your deployment:
 
-The plugin is immediately available in your workspace. It appears in the **Installed** tab with a **marketplace** badge.
+### Self-hosted (`atlas.config.ts`)
+
+1. Add the plugin package to `package.json` (`bun add @useatlas/bigquery`, etc.)
+2. Import and register it in `atlas.config.ts`:
+
+   ```ts
+   import { defineConfig } from "@atlas/api/lib/config";
+   import bigquery from "@useatlas/bigquery";
+
+   export default defineConfig({
+     plugins: [bigquery({ /* plugin-specific config */ })],
+     // ...
+   });
+   ```
+
+3. Restart the server. The plugin appears on `/admin/plugins`.
+
+See the [Plugin Authoring Guide](/plugins/authoring-guide) for the full `definePlugin()` API and the published plugins on [npm](https://www.npmjs.com/search?q=%40useatlas) for what's available.
+
+### SaaS (app.useatlas.dev)
+
+SaaS workspaces don't edit `atlas.config.ts` directly. To request a plugin be installed on your workspace, contact your account manager or platform admin. Platform admins install plugins via the platform catalog (tracked under [Plugin Catalog](/platform-ops/plugin-catalog)). Plan gating is evaluated server-side — each plugin has a `minPlan` (default `"starter"`); plugins above your workspace's plan tier are not offered.
 
 ---
 
-## Configuring Installed Plugins
+## Configuring an installed plugin
 
-### Marketplace Plugins
-
-1. In the **Installed** tab, find the marketplace plugin (marked with a "marketplace" badge)
-2. Click the **gear icon** (Configure)
-3. If the plugin defines a config schema, typed form fields appear (text, number, boolean). If not, a JSON editor is shown
-4. Edit the configuration values
-5. Click **Save**
-
-Changes take effect immediately.
-
-### Config-Loaded Plugins
-
-Config-loaded plugins (from `atlas.config.ts`) also appear in the Installed tab. Click the **gear icon** to open the config dialog:
-
-- If the plugin exposes a `getConfigSchema()`, a typed form is shown
-- If not, current config is displayed as read-only JSON
-- Config changes are saved to the internal database and take effect on restart
+1. Expand the plugin row
+2. Click **Configure**
+3. If the plugin exposes `getConfigSchema()`, a typed form is shown (text, number, boolean fields). Otherwise the current config is displayed as editable JSON
+4. Click **Save** — changes take effect immediately (no restart)
 
 <Callout type="info">
 Without an internal database, plugin configuration is read-only — all values come from `atlas.config.ts`.
@@ -82,47 +81,46 @@ Without an internal database, plugin configuration is read-only — all values c
 
 ---
 
-## Managing Plugin State
+## Enable / disable
 
-For config-loaded plugins:
-
-- **Enable/disable toggle** — Toggle a plugin on or off without restarting. Disabled plugins are excluded from the agent loop
-- **Health check** — Click **Health** to run a live probe and see the plugin's status
+The **enable/disable toggle** flips a plugin on or off for the current workspace without editing `atlas.config.ts`. Disabled plugins are excluded from the agent loop on the next request; no restart is needed.
 
 <Callout type="info">
-The enable/disable toggle requires an internal database (`DATABASE_URL`). Without it, all plugins are always enabled.
+Disabling a datasource plugin **does not** revoke access to already-open queries — it prevents the plugin from being selected for new queries. Existing conversations that referenced the plugin's tables will continue to function against cached semantic context until a refresh.
 </Callout>
 
 ---
 
-## Uninstalling a Plugin
+## Uninstalling
 
-1. In the **Installed** tab, find the marketplace plugin
-2. Click the **trash icon** (Uninstall)
-3. Confirm in the dialog
+### Self-hosted
 
-The plugin is removed from your workspace. You can reinstall it later from the Available tab. Config-loaded plugins cannot be uninstalled from the UI — remove them from `atlas.config.ts`.
+Remove the plugin from `atlas.config.ts` and restart. The admin UI does not offer an uninstall button for config-loaded plugins.
+
+### SaaS
+
+Contact your platform admin. Platform-installed plugins are uninstalled through the platform catalog.
 
 ---
 
-## API Endpoints
+## API endpoints
+
+The endpoints consumed by the admin page today:
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/api/v1/admin/plugins/marketplace/available` | List available plugins for this workspace |
-| `POST` | `/api/v1/admin/plugins/marketplace/install` | Install a plugin (body: `{ catalogId, config? }`) |
-| `DELETE` | `/api/v1/admin/plugins/marketplace/:id` | Uninstall a marketplace plugin |
-| `PUT` | `/api/v1/admin/plugins/marketplace/:id/config` | Update marketplace plugin config |
-| `GET` | `/api/v1/admin/plugins` | List all installed plugins (config + marketplace) |
+| `GET` | `/api/v1/admin/plugins` | List all loaded plugins (config + platform) |
 | `POST` | `/api/v1/admin/plugins/:id/health` | Run health check |
 | `POST` | `/api/v1/admin/plugins/:id/enable` | Enable a plugin |
 | `POST` | `/api/v1/admin/plugins/:id/disable` | Disable a plugin |
-| `GET` | `/api/v1/admin/plugins/:id/schema` | Get config schema and values |
-| `PUT` | `/api/v1/admin/plugins/:id/config` | Update config-loaded plugin config |
+| `GET` | `/api/v1/admin/plugins/:id/schema` | Get config schema and current values |
+| `PUT` | `/api/v1/admin/plugins/:id/config` | Update plugin config |
+
+The marketplace catalog API (`GET /api/v1/admin/plugins/marketplace/available`, etc.) exists on the server but has no web consumer yet. Programmatic clients can still call it — responses honor the same `minPlan` gating.
 
 ---
 
-## See Also
+## See also
 
 - [Admin Console — Plugins](/guides/admin-console#plugins) — Overview of the plugins admin page
 - [Plugin Catalog](/platform-ops/plugin-catalog) — Platform operator guide for managing the catalog

--- a/apps/docs/content/docs/guides/plugin-marketplace.mdx
+++ b/apps/docs/content/docs/guides/plugin-marketplace.mdx
@@ -13,8 +13,9 @@ The plugins admin page lets workspace admins view, configure, health-check, enab
 - A user with the `admin` role
 </Callout>
 
+{/* When self-service browse ships (marketplace catalog UI + plan-required badge), update both this callout AND the "no web consumer yet" note under API endpoints below. */}
 <Callout type="warn" title="Self-service browse is not shipped yet">
-Earlier drafts of this guide described an **Available** tab and **Enterprise badge** on a browse-and-install surface. That UI does **not** exist in the admin console today — the page renders only the **Installed** list. Install/uninstall happens through `atlas.config.ts` (self-hosted) or platform admin (SaaS). The marketplace API exists but has no web consumer; self-service browse is tracked as a future enhancement.
+The admin console renders only the **Installed** list today — there is no Available/browse tab and no separate tier badges on plugin cards. Install/uninstall happens through `atlas.config.ts` (self-hosted) or platform admin (SaaS). The marketplace API exists but has no web consumer; self-service browse is tracked as a future enhancement.
 </Callout>
 
 ---
@@ -116,7 +117,7 @@ The endpoints consumed by the admin page today:
 | `GET` | `/api/v1/admin/plugins/:id/schema` | Get config schema and current values |
 | `PUT` | `/api/v1/admin/plugins/:id/config` | Update plugin config |
 
-The marketplace catalog API (`GET /api/v1/admin/plugins/marketplace/available`, etc.) exists on the server but has no web consumer yet. Programmatic clients can still call it — responses honor the same `minPlan` gating.
+The marketplace catalog API (`GET /api/v1/admin/plugins/marketplace/available`, etc.) has no web consumer yet — see the callout at the top of this page. Programmatic clients can still call it directly; responses honor the same `minPlan` gating.
 
 ---
 

--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -322,6 +322,11 @@ export function createApiTestMocks(
     getAuditLogQueries: mock(() => Promise.resolve([])),
     getWorkspaceStatus: mock(async () => "active"),
     getWorkspaceDetails: mock(async () => null),
+    getWorkspaceNamesByIds: mock(async (ids: string[]) => {
+      const map = new Map<string, string | null>();
+      for (const id of ids) map.set(id, null);
+      return map;
+    }),
     updateWorkspaceStatus: mock(async () => true),
     updateWorkspacePlanTier: mock(async () => true),
     cascadeWorkspaceDelete: mock(async () => ({

--- a/packages/api/src/api/__tests__/admin-abuse.test.ts
+++ b/packages/api/src/api/__tests__/admin-abuse.test.ts
@@ -278,6 +278,32 @@ describe("Admin Abuse API", () => {
       expect((body.counters as Record<string, unknown>).queryCount).toBe(250);
     });
 
+    it("detail route falls back to null workspaceName when resolution rejects (#1640)", async () => {
+      mockGetAbuseDetail.mockImplementation(async () => ({
+        workspaceId: "org-1",
+        workspaceName: null,
+        level: "warning",
+        trigger: "query_rate",
+        message: "boom",
+        updatedAt: "2026-03-23T00:00:00.000Z",
+        counters: { queryCount: 1, errorCount: 0, errorRatePct: null, uniqueTablesAccessed: 0, escalations: 0 },
+        thresholds: { queryRateLimit: 200, queryRateWindowSeconds: 300, errorRateThreshold: 0.5, uniqueTablesLimit: 50, throttleDelayMs: 2000 },
+        currentInstance: { startedAt: "2026-03-23T00:00:00.000Z", endedAt: null, peakLevel: "warning", events: [] },
+        priorInstances: [],
+      }));
+      mockGetWorkspaceNamesByIds.mockImplementation(async () => {
+        throw new Error("internal DB unreachable");
+      });
+      const res = await app.fetch(
+        adminRequest("GET", "/api/v1/admin/abuse/org-1/detail"),
+      );
+      // Must still 200 — name resolution is advisory for the detail panel
+      // just as it is for the list (regression guard for #1640 follow-up).
+      expect(res.status).toBe(200);
+      const body = await res.json() as { workspaceName: string | null };
+      expect(body.workspaceName).toBeNull();
+    });
+
     it("resolves workspaceName on the detail route (#1640)", async () => {
       mockGetAbuseDetail.mockImplementation(async () => ({
         workspaceId: "org-1",

--- a/packages/api/src/api/__tests__/admin-abuse.test.ts
+++ b/packages/api/src/api/__tests__/admin-abuse.test.ts
@@ -162,6 +162,10 @@ describe("Admin Abuse API", () => {
       expect(mockGetWorkspaceNamesByIds.mock.calls[0]?.[0]).toEqual(["org-1", "org-2"]);
       const byId = Object.fromEntries(body.workspaces.map((w) => [w.workspaceId, w.workspaceName]));
       expect(byId).toEqual({ "org-1": "Acme Corp", "org-2": null });
+      // Admin table expects most-recent-first ordering from listFlaggedWorkspaces.
+      // Enrichment must preserve input order — a refactor that traversed
+      // Map.keys() on names instead of workspaces would scramble this silently.
+      expect(body.workspaces.map((w) => w.workspaceId)).toEqual(["org-1", "org-2"]);
     });
 
     it("falls back to null when name resolution rejects (#1640)", async () => {

--- a/packages/api/src/api/__tests__/admin-abuse.test.ts
+++ b/packages/api/src/api/__tests__/admin-abuse.test.ts
@@ -17,7 +17,18 @@ import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
 
 // --- Unified mocks ---
 
-const mocks = createApiTestMocks();
+const mockGetWorkspaceNamesByIds: Mock<(ids: string[]) => Promise<Map<string, string | null>>> =
+  mock(async (ids) => {
+    const m = new Map<string, string | null>();
+    for (const id of ids) m.set(id, null);
+    return m;
+  });
+
+const mocks = createApiTestMocks({
+  internal: {
+    getWorkspaceNamesByIds: mockGetWorkspaceNamesByIds,
+  },
+});
 
 // --- Abuse mock overrides (test-specific) ---
 
@@ -46,6 +57,7 @@ mock.module("@atlas/api/lib/security/abuse", () => ({
   abuseCleanupTick: mock(() => {}),
   ABUSE_CLEANUP_INTERVAL_MS: 300_000,
 }));
+
 
 // --- Import app after mocks ---
 
@@ -78,6 +90,12 @@ describe("Admin Abuse API", () => {
     mockListFlagged.mockImplementation(() => []);
     mockReinstateWorkspace.mockImplementation(() => true);
     mockGetAbuseEvents.mockImplementation(async () => []);
+    mockGetWorkspaceNamesByIds.mockClear();
+    mockGetWorkspaceNamesByIds.mockImplementation(async (ids) => {
+      const m = new Map<string, string | null>();
+      for (const id of ids) m.set(id, null);
+      return m;
+    });
   });
 
   // --- GET /api/v1/admin/abuse ---
@@ -108,6 +126,65 @@ describe("Admin Abuse API", () => {
       const body = await res.json() as Record<string, unknown>;
       expect((body.workspaces as unknown[]).length).toBe(1);
       expect(body.total).toBe(1);
+    });
+
+    it("resolves workspaceName from the internal DB (#1640)", async () => {
+      mockListFlagged.mockImplementation(() => [
+        {
+          workspaceId: "org-1",
+          workspaceName: null,
+          level: "warning",
+          trigger: "query_rate",
+          message: "Excessive queries",
+          updatedAt: "2026-03-23T00:00:00.000Z",
+          events: [],
+        },
+        {
+          workspaceId: "org-2",
+          workspaceName: null,
+          level: "throttled",
+          trigger: "query_rate",
+          message: "Still too many",
+          updatedAt: "2026-03-23T00:01:00.000Z",
+          events: [],
+        },
+      ]);
+      mockGetWorkspaceNamesByIds.mockImplementation(async (ids) => {
+        const m = new Map<string, string | null>();
+        // Return a name for org-1 and a missing/null for org-2 so we assert both branches.
+        for (const id of ids) m.set(id, id === "org-1" ? "Acme Corp" : null);
+        return m;
+      });
+      const res = await app.fetch(adminRequest("GET", "/api/v1/admin/abuse"));
+      expect(res.status).toBe(200);
+      const body = await res.json() as { workspaces: Array<{ workspaceId: string; workspaceName: string | null }> };
+      expect(mockGetWorkspaceNamesByIds).toHaveBeenCalledTimes(1);
+      expect(mockGetWorkspaceNamesByIds.mock.calls[0]?.[0]).toEqual(["org-1", "org-2"]);
+      const byId = Object.fromEntries(body.workspaces.map((w) => [w.workspaceId, w.workspaceName]));
+      expect(byId).toEqual({ "org-1": "Acme Corp", "org-2": null });
+    });
+
+    it("falls back to null when name resolution rejects (#1640)", async () => {
+      mockListFlagged.mockImplementation(() => [
+        {
+          workspaceId: "org-1",
+          workspaceName: null,
+          level: "warning",
+          trigger: "query_rate",
+          message: "boom",
+          updatedAt: "2026-03-23T00:00:00.000Z",
+          events: [],
+        },
+      ]);
+      mockGetWorkspaceNamesByIds.mockImplementation(async () => {
+        throw new Error("internal DB unreachable");
+      });
+      const res = await app.fetch(adminRequest("GET", "/api/v1/admin/abuse"));
+      // Must still 200 — name resolution is advisory. The page renders the
+      // opaque id rather than 500'ing the admin.
+      expect(res.status).toBe(200);
+      const body = await res.json() as { workspaces: Array<{ workspaceId: string; workspaceName: string | null }> };
+      expect(body.workspaces[0]?.workspaceName).toBeNull();
     });
 
     it("returns 403 for non-admin", async () => {
@@ -199,6 +276,45 @@ describe("Admin Abuse API", () => {
       const body = await res.json() as Record<string, unknown>;
       expect(body.workspaceId).toBe("org-1");
       expect((body.counters as Record<string, unknown>).queryCount).toBe(250);
+    });
+
+    it("resolves workspaceName on the detail route (#1640)", async () => {
+      mockGetAbuseDetail.mockImplementation(async () => ({
+        workspaceId: "org-1",
+        workspaceName: null,
+        level: "warning",
+        trigger: "query_rate",
+        message: "Excessive queries",
+        updatedAt: "2026-03-23T00:00:00.000Z",
+        counters: {
+          queryCount: 1,
+          errorCount: 0,
+          errorRatePct: null,
+          uniqueTablesAccessed: 0,
+          escalations: 0,
+        },
+        thresholds: {
+          queryRateLimit: 200,
+          queryRateWindowSeconds: 300,
+          errorRateThreshold: 0.5,
+          uniqueTablesLimit: 50,
+          throttleDelayMs: 2000,
+        },
+        currentInstance: { startedAt: "2026-03-23T00:00:00.000Z", endedAt: null, peakLevel: "warning", events: [] },
+        priorInstances: [],
+      }));
+      mockGetWorkspaceNamesByIds.mockImplementation(async (ids) => {
+        const m = new Map<string, string | null>();
+        for (const id of ids) m.set(id, "Acme Corp");
+        return m;
+      });
+      const res = await app.fetch(
+        adminRequest("GET", "/api/v1/admin/abuse/org-1/detail"),
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json() as { workspaceName: string | null; workspaceId: string };
+      expect(body.workspaceName).toBe("Acme Corp");
+      expect(body.workspaceId).toBe("org-1");
     });
 
     it("returns 404 when workspace is not flagged", async () => {

--- a/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
+++ b/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
@@ -141,6 +141,7 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getAuditLogQueries: mock(() => Promise.resolve([])),
   getWorkspaceStatus: mock(async () => "active"),
   getWorkspaceDetails: mock(async () => null),
+  getWorkspaceNamesByIds: mock(async () => new Map<string, string | null>()),
   updateWorkspaceStatus: mock(async () => true),
   updateWorkspacePlanTier: mock(async () => true),
   cascadeWorkspaceDelete: mock(async () => ({ conversations: 0, semanticEntities: 0, learnedPatterns: 0, suggestions: 0, scheduledTasks: 0, settings: 0 })),

--- a/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
@@ -136,6 +136,7 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getAuditLogQueries: mock(() => Promise.resolve([])),
   getWorkspaceStatus: mock(async () => "active"),
   getWorkspaceDetails: mock(async () => null),
+  getWorkspaceNamesByIds: mock(async () => new Map<string, string | null>()),
   updateWorkspaceStatus: mock(async () => true),
   updateWorkspacePlanTier: mock(async () => true),
   cascadeWorkspaceDelete: mock(async () => ({ conversations: 0, semanticEntities: 0, learnedPatterns: 0, suggestions: 0, scheduledTasks: 0, settings: 0 })),

--- a/packages/api/src/api/__tests__/admin-integrations.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations.test.ts
@@ -133,6 +133,7 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getAuditLogQueries: mock(() => Promise.resolve([])),
   getWorkspaceStatus: mock(async () => "active"),
   getWorkspaceDetails: mock(async () => null),
+  getWorkspaceNamesByIds: mock(async () => new Map<string, string | null>()),
   updateWorkspaceStatus: mock(async () => true),
   updateWorkspacePlanTier: mock(async () => true),
   cascadeWorkspaceDelete: mock(async () => ({ conversations: 0, semanticEntities: 0, learnedPatterns: 0, suggestions: 0, scheduledTasks: 0, settings: 0 })),

--- a/packages/api/src/api/__tests__/admin-invitations.test.ts
+++ b/packages/api/src/api/__tests__/admin-invitations.test.ts
@@ -146,6 +146,7 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getAuditLogQueries: mock(() => Promise.resolve([])),
   getWorkspaceStatus: mock(async () => "active"),
   getWorkspaceDetails: mock(async () => null),
+  getWorkspaceNamesByIds: mock(async () => new Map<string, string | null>()),
   updateWorkspaceStatus: mock(async () => true),
   updateWorkspacePlanTier: mock(async () => true),
   cascadeWorkspaceDelete: mock(async () => ({ conversations: 0, semanticEntities: 0, learnedPatterns: 0, suggestions: 0, scheduledTasks: 0, settings: 0 })),

--- a/packages/api/src/api/__tests__/admin-password.test.ts
+++ b/packages/api/src/api/__tests__/admin-password.test.ts
@@ -104,6 +104,7 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getAuditLogQueries: mock(() => Promise.resolve([])),
   getWorkspaceStatus: mock(async () => "active"),
   getWorkspaceDetails: mock(async () => null),
+  getWorkspaceNamesByIds: mock(async () => new Map<string, string | null>()),
   updateWorkspaceStatus: mock(async () => true),
   updateWorkspacePlanTier: mock(async () => true),
   cascadeWorkspaceDelete: mock(async () => ({ conversations: 0, semanticEntities: 0, learnedPatterns: 0, suggestions: 0, scheduledTasks: 0, settings: 0 })),

--- a/packages/api/src/api/__tests__/admin-usage.test.ts
+++ b/packages/api/src/api/__tests__/admin-usage.test.ts
@@ -130,6 +130,7 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getAuditLogQueries: mock(() => Promise.resolve([])),
   getWorkspaceStatus: mock(() => Promise.resolve(null)),
   getWorkspaceDetails: mock(() => Promise.resolve(null)),
+  getWorkspaceNamesByIds: mock(() => Promise.resolve(new Map<string, string | null>())),
   updateWorkspaceStatus: mock(() => Promise.resolve(false)),
   updateWorkspacePlanTier: mock(() => Promise.resolve(false)),
   cascadeWorkspaceDelete: mock(async () => ({ conversations: 0, semanticEntities: 0, learnedPatterns: 0, suggestions: 0, scheduledTasks: 0, settings: 0 })),

--- a/packages/api/src/api/__tests__/admin-workspace.test.ts
+++ b/packages/api/src/api/__tests__/admin-workspace.test.ts
@@ -185,6 +185,7 @@ mock.module("@atlas/api/lib/db/internal", () => ({
     return Promise.resolve(workspaceState.workspace_status);
   }),
   getWorkspaceDetails: mockGetWorkspaceDetails,
+  getWorkspaceNamesByIds: mock(async () => new Map<string, string | null>()),
   updateWorkspaceStatus: mockUpdateWorkspaceStatus,
   updateWorkspacePlanTier: mockUpdateWorkspacePlanTier,
   cascadeWorkspaceDelete: mockCascadeWorkspaceDelete,

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -242,6 +242,7 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getAuditLogQueries: mock(() => Promise.resolve([])),
   getWorkspaceStatus: mock(async () => "active"),
   getWorkspaceDetails: mock(async () => null),
+  getWorkspaceNamesByIds: mock(async () => new Map<string, string | null>()),
   updateWorkspaceStatus: mock(async () => true),
   updateWorkspacePlanTier: mock(async () => true),
   cascadeWorkspaceDelete: mock(async () => ({ conversations: 0, semanticEntities: 0, learnedPatterns: 0, suggestions: 0, scheduledTasks: 0, settings: 0 })),

--- a/packages/api/src/api/routes/admin-abuse.ts
+++ b/packages/api/src/api/routes/admin-abuse.ts
@@ -263,8 +263,17 @@ adminAbuse.openapi(listFlaggedRoute, async (c) => {
         getWorkspaceNamesByIds(orgIds).catch((err) => {
           // Name resolution is advisory — if the DB hiccups, fall back to
           // null so the page still renders with opaque ids rather than 500.
-          log.warn({ err: err instanceof Error ? err.message : String(err) },
-            "abuse list: workspace name resolution failed");
+          log.warn(
+            {
+              err: err instanceof Error
+                ? { message: err.message, stack: err.stack }
+                : String(err),
+              orgIdCount: orgIds.length,
+              // First 5 ids for on-call correlation without flooding logs.
+              sampleOrgIds: orgIds.slice(0, 5),
+            },
+            "abuse list: workspace name resolution failed",
+          );
           return new Map<string, string | null>();
         }),
       ]);
@@ -321,12 +330,18 @@ adminAbuse.openapi(getDetailRoute, async (c) => {
       );
     }
 
-    // Resolve the workspace display name. Advisory — if the lookup fails
-    // we log and return the id-only shape rather than 500'ing the panel.
+    // Resolve the workspace display name. Advisory — see list route above.
     const nameMap = yield* Effect.promise(() =>
       getWorkspaceNamesByIds([workspaceId]).catch((err) => {
-        log.warn({ err: err instanceof Error ? err.message : String(err) },
-          "abuse detail: workspace name resolution failed");
+        log.warn(
+          {
+            err: err instanceof Error
+              ? { message: err.message, stack: err.stack }
+              : String(err),
+            workspaceId,
+          },
+          "abuse detail: workspace name resolution failed",
+        );
         return new Map<string, string | null>();
       }),
     );

--- a/packages/api/src/api/routes/admin-abuse.ts
+++ b/packages/api/src/api/routes/admin-abuse.ts
@@ -14,6 +14,10 @@ import {
   getAbuseConfig,
   getAbuseDetail,
 } from "@atlas/api/lib/security/abuse";
+import { getWorkspaceNamesByIds } from "@atlas/api/lib/db/internal";
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("admin-abuse");
 import { ABUSE_LEVELS, ABUSE_TRIGGERS } from "@useatlas/types";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
@@ -249,13 +253,27 @@ adminAbuse.openapi(listFlaggedRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const workspaces = listFlaggedWorkspaces();
 
-    // Enrich with recent events from DB
-    const enriched = yield* Effect.promise(() => Promise.all(
-      workspaces.map(async (ws) => {
-        const events = await getAbuseEvents(ws.workspaceId, 10);
-        return { ...ws, events };
-      }),
-    ));
+    // Enrich with recent events from DB + resolve workspace names so the
+    // admin table shows "Acme Corp" instead of "org_01K...". Names are a
+    // batch fetch to avoid N+1; missing/deleted orgs fall back to null.
+    const enriched = yield* Effect.promise(async () => {
+      const orgIds = workspaces.map((ws) => ws.workspaceId);
+      const [events, names] = await Promise.all([
+        Promise.all(workspaces.map((ws) => getAbuseEvents(ws.workspaceId, 10))),
+        getWorkspaceNamesByIds(orgIds).catch((err) => {
+          // Name resolution is advisory — if the DB hiccups, fall back to
+          // null so the page still renders with opaque ids rather than 500.
+          log.warn({ err: err instanceof Error ? err.message : String(err) },
+            "abuse list: workspace name resolution failed");
+          return new Map<string, string | null>();
+        }),
+      ]);
+      return workspaces.map((ws, i) => ({
+        ...ws,
+        workspaceName: names.get(ws.workspaceId) ?? null,
+        events: events[i],
+      }));
+    });
 
     return c.json({ workspaces: enriched, total: enriched.length }, 200);
   }), { label: "list flagged workspaces" });
@@ -303,7 +321,18 @@ adminAbuse.openapi(getDetailRoute, async (c) => {
       );
     }
 
-    return c.json(detail, 200);
+    // Resolve the workspace display name. Advisory — if the lookup fails
+    // we log and return the id-only shape rather than 500'ing the panel.
+    const nameMap = yield* Effect.promise(() =>
+      getWorkspaceNamesByIds([workspaceId]).catch((err) => {
+        log.warn({ err: err instanceof Error ? err.message : String(err) },
+          "abuse detail: workspace name resolution failed");
+        return new Map<string, string | null>();
+      }),
+    );
+    const enriched = { ...detail, workspaceName: nameMap.get(workspaceId) ?? null };
+
+    return c.json(enriched, 200);
   }), { label: "read abuse detail" });
 });
 

--- a/packages/api/src/lib/auth/__tests__/sessions.test.ts
+++ b/packages/api/src/lib/auth/__tests__/sessions.test.ts
@@ -127,6 +127,7 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getAuditLogQueries: mock(() => Promise.resolve([])),
   getWorkspaceStatus: mock(async () => "active"),
   getWorkspaceDetails: mock(async () => null),
+  getWorkspaceNamesByIds: mock(async () => new Map<string, string | null>()),
   updateWorkspaceStatus: mock(async () => true),
   updateWorkspacePlanTier: mock(async () => true),
   cascadeWorkspaceDelete: mock(async () => ({ conversations: 0, semanticEntities: 0, learnedPatterns: 0, suggestions: 0, scheduledTasks: 0, settings: 0 })),

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1394,12 +1394,11 @@ export async function getWorkspaceStatus(orgId: string): Promise<WorkspaceStatus
 }
 
 /**
- * Batch-resolve display names for a list of organization ids. Missing rows
- * map to `null` (org deleted / lookup skipped / internal DB unavailable).
- *
- * Callers that need multiple names (e.g. admin list views) should prefer
- * this over N×`getWorkspaceDetails` to avoid N+1 round-trips. Safe to call
- * with an empty list — returns an empty map without touching the DB.
+ * Batch-resolve display names for a list of organization ids. Every
+ * requested id is present in the returned map; the value is `null` when the
+ * row is missing (deleted / unknown), when the internal DB is unavailable,
+ * or when the row exists but its `name` column is itself `null`. Safe to
+ * call with an empty list — returns an empty map without touching the DB.
  */
 export async function getWorkspaceNamesByIds(
   orgIds: string[],

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1394,6 +1394,29 @@ export async function getWorkspaceStatus(orgId: string): Promise<WorkspaceStatus
 }
 
 /**
+ * Batch-resolve display names for a list of organization ids. Missing rows
+ * map to `null` (org deleted / lookup skipped / internal DB unavailable).
+ *
+ * Callers that need multiple names (e.g. admin list views) should prefer
+ * this over N×`getWorkspaceDetails` to avoid N+1 round-trips. Safe to call
+ * with an empty list — returns an empty map without touching the DB.
+ */
+export async function getWorkspaceNamesByIds(
+  orgIds: string[],
+): Promise<Map<string, string | null>> {
+  const byId = new Map<string, string | null>();
+  if (orgIds.length === 0) return byId;
+  for (const id of orgIds) byId.set(id, null);
+  if (!hasInternalDB()) return byId;
+  const rows = await internalQuery<{ id: string; name: string | null }>(
+    `SELECT id, name FROM organization WHERE id = ANY($1::text[])`,
+    [orgIds],
+  );
+  for (const row of rows) byId.set(row.id, row.name);
+  return byId;
+}
+
+/**
  * Get full workspace details for an organization.
  */
 export async function getWorkspaceDetails(orgId: string): Promise<WorkspaceRow | null> {

--- a/packages/web/src/app/admin/actions/__tests__/rollback-warning.test.ts
+++ b/packages/web/src/app/admin/actions/__tests__/rollback-warning.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { coerceRollbackWarning } from "../rollback-warning";
+
+describe("coerceRollbackWarning", () => {
+  test("returns null for null/undefined", () => {
+    expect(coerceRollbackWarning(null)).toBeNull();
+    expect(coerceRollbackWarning(undefined)).toBeNull();
+  });
+
+  test("returns trimmed string when non-empty", () => {
+    expect(coerceRollbackWarning("rollback may not have reversed")).toBe(
+      "rollback may not have reversed",
+    );
+    expect(coerceRollbackWarning("  padded  ")).toBe("padded");
+  });
+
+  test("returns null for empty / whitespace-only string", () => {
+    expect(coerceRollbackWarning("")).toBeNull();
+    expect(coerceRollbackWarning("   ")).toBeNull();
+  });
+
+  test("extracts .message from an object shape", () => {
+    expect(
+      coerceRollbackWarning({ code: "partial_reversal", message: "external API has no undo" }),
+    ).toBe("external API has no undo");
+  });
+
+  test("returns fallback when object has no usable message", () => {
+    expect(coerceRollbackWarning({ code: "x" })).toContain("unrecognized shape");
+    expect(coerceRollbackWarning({ message: 42 })).toContain("unrecognized shape");
+    expect(coerceRollbackWarning({ message: "   " })).toContain("unrecognized shape");
+  });
+
+  test("returns fallback for arrays", () => {
+    expect(coerceRollbackWarning(["a", "b"])).toContain("unrecognized shape");
+  });
+
+  test("returns fallback for primitives that aren't strings", () => {
+    expect(coerceRollbackWarning(42)).toContain("unrecognized shape");
+    expect(coerceRollbackWarning(true)).toContain("unrecognized shape");
+  });
+
+  test("never returns empty string for non-null input", () => {
+    // Compliance contract: if the server said "warning", the operator must
+    // see something in the banner. Returning "" would hide the signal.
+    const inputs = [{}, [], 0, false, { message: "" }];
+    for (const input of inputs) {
+      const result = coerceRollbackWarning(input);
+      expect(result === null || (typeof result === "string" && result.length > 0)).toBe(true);
+    }
+  });
+});

--- a/packages/web/src/app/admin/actions/__tests__/rollback-warning.test.ts
+++ b/packages/web/src/app/admin/actions/__tests__/rollback-warning.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from "bun:test";
-import { coerceRollbackWarning } from "../rollback-warning";
+import { describe, expect, test, mock } from "bun:test";
+import { coerceRollbackWarning, logUnsurfacedRollbackWarning } from "../rollback-warning";
 
 describe("coerceRollbackWarning", () => {
   test("returns null for null/undefined", () => {
@@ -48,5 +48,44 @@ describe("coerceRollbackWarning", () => {
       const result = coerceRollbackWarning(input);
       expect(result === null || (typeof result === "string" && result.length > 0)).toBe(true);
     }
+  });
+});
+
+describe("logUnsurfacedRollbackWarning", () => {
+  test("does not log null / undefined (no warning to drift)", () => {
+    const logger = mock(() => {});
+    logUnsurfacedRollbackWarning(null, logger);
+    logUnsurfacedRollbackWarning(undefined, logger);
+    expect(logger).not.toHaveBeenCalled();
+  });
+
+  test("does not log well-formed non-empty strings (surfaced verbatim)", () => {
+    const logger = mock(() => {});
+    logUnsurfacedRollbackWarning("rollback may not have reversed", logger);
+    expect(logger).not.toHaveBeenCalled();
+  });
+
+  test("logs non-string shapes with the raw value (schema-drift signal)", () => {
+    const logger = mock(() => {});
+    logUnsurfacedRollbackWarning({ code: "partial", message: "x" }, logger);
+    expect(logger).toHaveBeenCalledTimes(1);
+    const [msg, value] = logger.mock.calls[0] ?? [];
+    expect(msg).toBe("handleRollback: non-string warning shape");
+    expect(value).toEqual({ code: "partial", message: "x" });
+  });
+
+  test("logs blank strings separately from non-string shapes", () => {
+    const logger = mock(() => {});
+    logUnsurfacedRollbackWarning("   ", logger);
+    logUnsurfacedRollbackWarning("", logger);
+    expect(logger).toHaveBeenCalledTimes(2);
+    expect(logger.mock.calls.every((call) => call[0] === "handleRollback: blank warning string")).toBe(true);
+  });
+
+  test("logs arrays as non-string shape (not blank string)", () => {
+    const logger = mock(() => {});
+    logUnsurfacedRollbackWarning(["a", "b"], logger);
+    expect(logger).toHaveBeenCalledTimes(1);
+    expect(logger.mock.calls[0]?.[0]).toBe("handleRollback: non-string warning shape");
   });
 });

--- a/packages/web/src/app/admin/actions/page.tsx
+++ b/packages/web/src/app/admin/actions/page.tsx
@@ -29,11 +29,12 @@ import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { EmptyState } from "@/ui/components/admin/empty-state";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import {
+  bulkFailureSummary,
+  BulkRequestError,
+  failedIdsFrom,
   QueueFilterRow,
   ReasonDialog,
   RelativeTimestamp,
-  bulkFailureSummary,
-  failedIdsFrom,
 } from "@/ui/components/admin/queue";
 import { extractFetchError, friendlyError, type FetchError } from "@/ui/lib/fetch-error";
 import {
@@ -266,8 +267,7 @@ export default function ActionsPage() {
     });
     if (!res.ok) {
       const fe = await extractFetchError(res);
-      const msg = fe.requestId ? `${fe.message} (Request ID: ${fe.requestId})` : fe.message;
-      throw new Error(msg);
+      throw new BulkRequestError(fe.message, fe.requestId);
     }
   }
 

--- a/packages/web/src/app/admin/actions/page.tsx
+++ b/packages/web/src/app/admin/actions/page.tsx
@@ -4,6 +4,7 @@ import { Fragment, useEffect, useState } from "react";
 import { useQueryStates } from "nuqs";
 import { actionsSearchParams } from "./search-params";
 import { ACTION_TYPE_LABELS, actionTypeIcon, actionTypeLabel } from "./labels";
+import { coerceRollbackWarning } from "./rollback-warning";
 import { useAtlasConfig } from "@/ui/context";
 import {
   Table,
@@ -305,8 +306,14 @@ export default function ActionsPage() {
         // side-effect may not have actually reversed (e.g. external API has no
         // true undo). Surface to a dismissible warning, not an error.
         const body = data as Record<string, unknown> | undefined;
-        if (body?.warning && typeof body.warning === "string") {
-          setMutationWarning(body.warning);
+        const warning = coerceRollbackWarning(body?.warning);
+        if (warning) {
+          setMutationWarning(warning);
+          // Log the raw shape so observability catches server-side schema drift
+          // without silently dropping the compliance signal in the UI.
+          if (typeof body?.warning !== "string") {
+            console.warn("handleRollback: non-string warning shape", body?.warning);
+          }
         }
       },
     });

--- a/packages/web/src/app/admin/actions/page.tsx
+++ b/packages/web/src/app/admin/actions/page.tsx
@@ -306,13 +306,20 @@ export default function ActionsPage() {
         // side-effect may not have actually reversed (e.g. external API has no
         // true undo). Surface to a dismissible warning, not an error.
         const body = data as Record<string, unknown> | undefined;
-        const warning = coerceRollbackWarning(body?.warning);
-        if (warning) {
-          setMutationWarning(warning);
-          // Log the raw shape so observability catches server-side schema drift
-          // without silently dropping the compliance signal in the UI.
-          if (typeof body?.warning !== "string") {
-            console.warn("handleRollback: non-string warning shape", body?.warning);
+        const raw = body?.warning;
+        const warning = coerceRollbackWarning(raw);
+        if (warning) setMutationWarning(warning);
+        // Observability: log any non-null raw value we couldn't surface
+        // verbatim (non-string shapes, whitespace-only/empty strings, or
+        // object shapes that forced the generic fallback). Catches server-
+        // side schema drift that would otherwise silently drop the
+        // compliance signal — a whitespace-only "   " used to slip through
+        // the prior `typeof !== "string"` gate.
+        if (raw != null) {
+          if (typeof raw !== "string") {
+            console.warn("handleRollback: non-string warning shape", raw);
+          } else if (raw.trim().length === 0) {
+            console.warn("handleRollback: blank warning string", JSON.stringify(raw));
           }
         }
       },

--- a/packages/web/src/app/admin/actions/page.tsx
+++ b/packages/web/src/app/admin/actions/page.tsx
@@ -4,7 +4,7 @@ import { Fragment, useEffect, useState } from "react";
 import { useQueryStates } from "nuqs";
 import { actionsSearchParams } from "./search-params";
 import { ACTION_TYPE_LABELS, actionTypeIcon, actionTypeLabel } from "./labels";
-import { coerceRollbackWarning } from "./rollback-warning";
+import { coerceRollbackWarning, logUnsurfacedRollbackWarning } from "./rollback-warning";
 import { useAtlasConfig } from "@/ui/context";
 import {
   Table,
@@ -304,24 +304,13 @@ export default function ActionsPage() {
       onSuccess: (data) => {
         // Server returns { warning } on 200 when the rollback persisted but the
         // side-effect may not have actually reversed (e.g. external API has no
-        // true undo). Surface to a dismissible warning, not an error.
+        // true undo). Surface to a dismissible warning, not an error; log
+        // anything we couldn't surface verbatim for schema-drift detection.
         const body = data as Record<string, unknown> | undefined;
         const raw = body?.warning;
         const warning = coerceRollbackWarning(raw);
         if (warning) setMutationWarning(warning);
-        // Observability: log any non-null raw value we couldn't surface
-        // verbatim (non-string shapes, whitespace-only/empty strings, or
-        // object shapes that forced the generic fallback). Catches server-
-        // side schema drift that would otherwise silently drop the
-        // compliance signal — a whitespace-only "   " used to slip through
-        // the prior `typeof !== "string"` gate.
-        if (raw != null) {
-          if (typeof raw !== "string") {
-            console.warn("handleRollback: non-string warning shape", raw);
-          } else if (raw.trim().length === 0) {
-            console.warn("handleRollback: blank warning string", JSON.stringify(raw));
-          }
-        }
+        logUnsurfacedRollbackWarning(raw);
       },
     });
     if (!result.ok) setMutationError(friendlyError(result.error));

--- a/packages/web/src/app/admin/actions/rollback-warning.ts
+++ b/packages/web/src/app/admin/actions/rollback-warning.ts
@@ -1,21 +1,33 @@
 /**
- * Normalize the `warning` field on a rollback 200 response into a banner
- * string. The server currently emits `{ warning: string }` when a rollback
- * persisted but the side-effect may not have actually reversed. Operators
- * rely on this signal for compliance — silently dropping a non-string
- * shape would hide "rollback may not have fully reversed" from the audit
- * trail.
- *
- * Returns `null` when the field is absent/null/undefined/empty — there's
- * genuinely no warning to show.
- *
- * For unknown shapes (object, array, number, boolean), returns a generic
- * fallback string so the operator still sees that something warned, and
- * the raw value is logged for follow-up. Callers should surface the
- * returned string in the warning banner as-is.
+ * Normalize the server's rollback `warning` field into a banner string.
+ * The signal is compliance-critical — a rollback may have persisted
+ * without actually reversing the side-effect — so unknown shapes fall
+ * back to a generic "something warned" banner rather than silently
+ * returning null. Absent/empty values return null (no warning to show).
  */
 const GENERIC_FALLBACK =
   "Rollback persisted, but the server returned a warning in an unrecognized shape. Check logs for details.";
+
+/**
+ * Log any non-null raw `warning` value that the caller couldn't surface
+ * verbatim — non-string shapes, whitespace-only strings, or empty strings.
+ * Called alongside `coerceRollbackWarning` so server-side schema drift is
+ * observable even when the UI gracefully degrades. Accepts a logger so
+ * tests can assert the call without wiring up console interception.
+ */
+export function logUnsurfacedRollbackWarning(
+  raw: unknown,
+  logger: (message: string, value: unknown) => void = console.warn,
+): void {
+  if (raw == null) return;
+  if (typeof raw !== "string") {
+    logger("handleRollback: non-string warning shape", raw);
+    return;
+  }
+  if (raw.trim().length === 0) {
+    logger("handleRollback: blank warning string", JSON.stringify(raw));
+  }
+}
 
 export function coerceRollbackWarning(raw: unknown): string | null {
   if (raw === null || raw === undefined) return null;
@@ -23,9 +35,9 @@ export function coerceRollbackWarning(raw: unknown): string | null {
     const trimmed = raw.trim();
     return trimmed.length > 0 ? trimmed : null;
   }
-  // Best-effort extraction from the most common object shape the server
-  // might grow into: `{ message: string, code?: string }`. Everything
-  // else falls back to the generic banner; the caller logs the raw value.
+  // If the server grows the warning field into an object, prefer a string
+  // `message` field. Other keys are ignored; unknown shapes fall through
+  // to the generic fallback below.
   if (typeof raw === "object" && !Array.isArray(raw)) {
     const message = (raw as { message?: unknown }).message;
     if (typeof message === "string" && message.trim().length > 0) {

--- a/packages/web/src/app/admin/actions/rollback-warning.ts
+++ b/packages/web/src/app/admin/actions/rollback-warning.ts
@@ -1,0 +1,36 @@
+/**
+ * Normalize the `warning` field on a rollback 200 response into a banner
+ * string. The server currently emits `{ warning: string }` when a rollback
+ * persisted but the side-effect may not have actually reversed. Operators
+ * rely on this signal for compliance — silently dropping a non-string
+ * shape would hide "rollback may not have fully reversed" from the audit
+ * trail.
+ *
+ * Returns `null` when the field is absent/null/undefined/empty — there's
+ * genuinely no warning to show.
+ *
+ * For unknown shapes (object, array, number, boolean), returns a generic
+ * fallback string so the operator still sees that something warned, and
+ * the raw value is logged for follow-up. Callers should surface the
+ * returned string in the warning banner as-is.
+ */
+const GENERIC_FALLBACK =
+  "Rollback persisted, but the server returned a warning in an unrecognized shape. Check logs for details.";
+
+export function coerceRollbackWarning(raw: unknown): string | null {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  // Best-effort extraction from the most common object shape the server
+  // might grow into: `{ message: string, code?: string }`. Everything
+  // else falls back to the generic banner; the caller logs the raw value.
+  if (typeof raw === "object" && !Array.isArray(raw)) {
+    const message = (raw as { message?: unknown }).message;
+    if (typeof message === "string" && message.trim().length > 0) {
+      return message.trim();
+    }
+  }
+  return GENERIC_FALLBACK;
+}

--- a/packages/web/src/app/admin/approval/page.tsx
+++ b/packages/web/src/app/admin/approval/page.tsx
@@ -42,6 +42,7 @@ import { EmptyState } from "@/ui/components/admin/empty-state";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import {
   bulkFailureSummary,
+  BulkRequestError,
   failedIdsFrom,
   QueueFilterRow,
   ReasonDialog,
@@ -579,8 +580,7 @@ function QueueSection() {
     });
     if (!res.ok) {
       const fe = await extractFetchError(res);
-      const msg = fe.requestId ? `${fe.message} (Request ID: ${fe.requestId})` : fe.message;
-      throw new Error(msg);
+      throw new BulkRequestError(fe.message, fe.requestId);
     }
   }
 

--- a/packages/web/src/ui/components/admin/queue/__tests__/bulk-summary.test.ts
+++ b/packages/web/src/ui/components/admin/queue/__tests__/bulk-summary.test.ts
@@ -3,6 +3,7 @@ import {
   bulkFailureSummary,
   BulkRequestError,
   bulkPartialSummary,
+  extractBulkRequestId,
   failedIdsFrom,
   type BulkPartialResult,
 } from "../bulk-summary";
@@ -141,6 +142,70 @@ describe("bulkFailureSummary", () => {
     expect(bulkFailureSummary(results, ["a", "b"], "denials")).toBe(
       "2 of 2 denials failed: 2× HTTP 500 (ID: req-abc)",
     );
+  });
+
+  test("all-success produces the empty-summary baseline (callers guard with failedIdsFrom)", async () => {
+    const results = await Promise.allSettled([Promise.resolve("ok"), Promise.resolve("ok")]);
+    // Production callers skip rendering when failedIdsFrom is empty, but the
+    // pure-function shape should still be well-defined on the zero-failure path.
+    expect(bulkFailureSummary(results, ["a", "b"], "denials")).toBe(
+      "0 of 2 denials failed: ",
+    );
+  });
+
+  test("requestId from useAdminMutation-style { fetchError: { requestId } } attachments is picked up", async () => {
+    // Future-proofs against callers that attach requestId via the mutation
+    // fetchError pattern instead of throwing BulkRequestError directly (#1646).
+    const mutationError = Object.assign(new Error("HTTP 500"), {
+      fetchError: { requestId: "req-mut" },
+    });
+    const results = await Promise.allSettled([Promise.reject(mutationError)]);
+    expect(bulkFailureSummary(results, ["a"], "denials")).toBe(
+      "1 of 1 denials failed: 1× HTTP 500 (ID: req-mut)",
+    );
+  });
+
+  test("requestId from a direct .requestId property is picked up", async () => {
+    const err = Object.assign(new Error("HTTP 500"), { requestId: "req-direct" });
+    const results = await Promise.allSettled([Promise.reject(err)]);
+    expect(bulkFailureSummary(results, ["a"], "denials")).toBe(
+      "1 of 1 denials failed: 1× HTTP 500 (ID: req-direct)",
+    );
+  });
+});
+
+describe("extractBulkRequestId", () => {
+  test("returns requestId from BulkRequestError instance", () => {
+    expect(extractBulkRequestId(new BulkRequestError("x", "req-a"))).toBe("req-a");
+    expect(extractBulkRequestId(new BulkRequestError("x"))).toBeUndefined();
+  });
+
+  test("returns requestId from { fetchError: { requestId } } attachment", () => {
+    const err = Object.assign(new Error("x"), { fetchError: { requestId: "req-b" } });
+    expect(extractBulkRequestId(err)).toBe("req-b");
+  });
+
+  test("returns requestId from a direct .requestId string property", () => {
+    expect(extractBulkRequestId({ requestId: "req-c" })).toBe("req-c");
+  });
+
+  test("fetchError attachment wins over a conflicting direct .requestId", () => {
+    const err = {
+      fetchError: { requestId: "req-fetch" },
+      requestId: "req-direct",
+    };
+    expect(extractBulkRequestId(err)).toBe("req-fetch");
+  });
+
+  test("returns undefined for unrecognized shapes", () => {
+    expect(extractBulkRequestId(null)).toBeUndefined();
+    expect(extractBulkRequestId(undefined)).toBeUndefined();
+    expect(extractBulkRequestId("just a string")).toBeUndefined();
+    expect(extractBulkRequestId(42)).toBeUndefined();
+    expect(extractBulkRequestId({})).toBeUndefined();
+    // Non-string requestId value is ignored (can't splice a number into the banner).
+    expect(extractBulkRequestId({ requestId: 42 })).toBeUndefined();
+    expect(extractBulkRequestId({ fetchError: { requestId: 42 } })).toBeUndefined();
   });
 });
 

--- a/packages/web/src/ui/components/admin/queue/__tests__/bulk-summary.test.ts
+++ b/packages/web/src/ui/components/admin/queue/__tests__/bulk-summary.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   bulkFailureSummary,
+  BulkRequestError,
   bulkPartialSummary,
   failedIdsFrom,
   type BulkPartialResult,
@@ -87,6 +88,58 @@ describe("bulkFailureSummary", () => {
     ]);
     expect(bulkFailureSummary(results, ["a", "b"], "denials")).toBe(
       "2 of 2 denials failed: 2× Forbidden",
+    );
+  });
+
+  test("BulkRequestError with identical messages collapses to one group with trailing IDs", async () => {
+    const results = await Promise.allSettled([
+      Promise.reject(new BulkRequestError("HTTP 500", "req-abc")),
+      Promise.reject(new BulkRequestError("HTTP 500", "req-def")),
+      Promise.reject(new BulkRequestError("HTTP 500", "req-ghi")),
+    ]);
+    expect(bulkFailureSummary(results, ["a", "b", "c"], "denials")).toBe(
+      "3 of 3 denials failed: 3× HTTP 500 (IDs: req-abc, req-def, req-ghi)",
+    );
+  });
+
+  test("BulkRequestError single-id group uses singular 'ID' label", async () => {
+    const results = await Promise.allSettled([
+      Promise.reject(new BulkRequestError("HTTP 500", "req-only")),
+    ]);
+    expect(bulkFailureSummary(results, ["a"], "denials")).toBe(
+      "1 of 1 denials failed: 1× HTTP 500 (ID: req-only)",
+    );
+  });
+
+  test("BulkRequestError without requestId drops the trailing slot", async () => {
+    const results = await Promise.allSettled([
+      Promise.reject(new BulkRequestError("HTTP 500")),
+      Promise.reject(new BulkRequestError("HTTP 500")),
+    ]);
+    expect(bulkFailureSummary(results, ["a", "b"], "denials")).toBe(
+      "2 of 2 denials failed: 2× HTTP 500",
+    );
+  });
+
+  test("BulkRequestError groups separately by message and carries only its own ids", async () => {
+    const results = await Promise.allSettled([
+      Promise.reject(new BulkRequestError("Forbidden", "req-1")),
+      Promise.reject(new BulkRequestError("HTTP 500", "req-2")),
+      Promise.reject(new BulkRequestError("HTTP 500", "req-3")),
+    ]);
+    expect(bulkFailureSummary(results, ["a", "b", "c"], "denials")).toBe(
+      "3 of 3 denials failed: 1× Forbidden (ID: req-1); 2× HTTP 500 (IDs: req-2, req-3)",
+    );
+  });
+
+  test("mixed BulkRequestError and plain Error merge by message; only the typed one contributes an ID", async () => {
+    const results = await Promise.allSettled([
+      Promise.reject(new BulkRequestError("HTTP 500", "req-abc")),
+      Promise.reject(new Error("HTTP 500")),
+    ]);
+    // Plain Error has no requestId, so the group shows only the typed one's id.
+    expect(bulkFailureSummary(results, ["a", "b"], "denials")).toBe(
+      "2 of 2 denials failed: 2× HTTP 500 (ID: req-abc)",
     );
   });
 });

--- a/packages/web/src/ui/components/admin/queue/__tests__/reason-dialog.test.tsx
+++ b/packages/web/src/ui/components/admin/queue/__tests__/reason-dialog.test.tsx
@@ -1,0 +1,105 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { render, screen, fireEvent, waitFor, cleanup, act } from "@testing-library/react";
+import { ReasonDialog } from "../reason-dialog";
+
+afterEach(() => cleanup());
+
+function errorText(): string | null {
+  // Radix Dialog portals outside `container` — query from document.body.
+  return document.body.querySelector('[role="alert"]')?.textContent?.trim() ?? null;
+}
+
+function denyButton(): HTMLButtonElement {
+  // The destructive confirm button carries the `confirmLabel` text (default "Deny").
+  // Radix portals the footer — scope to the document, not the render container.
+  const buttons = [...document.body.querySelectorAll("button")] as HTMLButtonElement[];
+  const btn = buttons.find((b) => b.textContent?.trim() === "Deny");
+  if (!btn) throw new Error("Deny button not found in dialog");
+  return btn;
+}
+
+describe("ReasonDialog error precedence (#1612)", () => {
+  test("renders the `error` prop when no localError is set", () => {
+    render(
+      <ReasonDialog
+        open
+        onOpenChange={() => {}}
+        title="Deny"
+        onConfirm={async () => {}}
+        error="server rejected the retry"
+      />,
+    );
+    expect(errorText()).toBe("server rejected the retry");
+  });
+
+  test("fresh caller `error` prop clears stale localError from a prior throw", async () => {
+    // Retry-flow scenario:
+    //  1. onConfirm throws → localError "Unexpected error: boom"
+    //  2. Caller fixes its bug, a real server error arrives via `error` prop
+    //  3. The fresh server error should win, not the stale local one.
+    // Without the useEffect on `error`, displayError stays on the stale
+    // localError because `localError ?? error` picks local first.
+    function Harness({ error }: { error: string | null }) {
+      return (
+        <ReasonDialog
+          open
+          onOpenChange={() => {}}
+          title="Deny"
+          onConfirm={async () => {
+            throw new Error("boom");
+          }}
+          error={error}
+        />
+      );
+    }
+
+    const { rerender } = render(<Harness error={null} />);
+
+    await act(async () => {
+      fireEvent.click(denyButton());
+    });
+
+    await waitFor(() => {
+      expect(errorText() ?? "").toContain("Unexpected error");
+    });
+
+    rerender(<Harness error="server rejected the retry" />);
+
+    await waitFor(() => {
+      expect(errorText()).toBe("server rejected the retry");
+    });
+  });
+
+  test("error prop going null → null does not clobber localError", async () => {
+    // Guard against an over-eager effect clearing localError on every prop
+    // change — we only clear when a non-null error arrives.
+    function Harness({ error }: { error: string | null }) {
+      return (
+        <ReasonDialog
+          open
+          onOpenChange={() => {}}
+          title="Deny"
+          onConfirm={async () => {
+            throw new Error("boom");
+          }}
+          error={error}
+        />
+      );
+    }
+
+    const { rerender } = render(<Harness error={null} />);
+    await act(async () => {
+      fireEvent.click(denyButton());
+    });
+    await waitFor(() => {
+      expect(errorText() ?? "").toContain("Unexpected error");
+    });
+
+    rerender(<Harness error={null} />);
+    // localError must still dominate — no fresh caller error to honor.
+    expect(errorText() ?? "").toContain("Unexpected error");
+  });
+});
+
+// Suppress unused-import warning: `screen` is kept available for future tests.
+void screen;

--- a/packages/web/src/ui/components/admin/queue/__tests__/reason-dialog.test.tsx
+++ b/packages/web/src/ui/components/admin/queue/__tests__/reason-dialog.test.tsx
@@ -1,8 +1,23 @@
-import { describe, expect, test, afterEach } from "bun:test";
+import { describe, expect, test, beforeEach, afterEach, mock, type Mock } from "bun:test";
 import { render, screen, fireEvent, waitFor, cleanup, act } from "@testing-library/react";
 import { ReasonDialog } from "../reason-dialog";
 
-afterEach(() => cleanup());
+// Silence + assert the observability log the component fires when
+// onConfirm throws. Without a spy, each test that triggers the throw
+// path emits the stack to stderr and muddles CI output. Spying also
+// enforces the "log so observability still sees it" contract.
+let consoleWarnSpy: Mock<(...args: unknown[]) => void>;
+const originalConsoleWarn = console.warn;
+
+beforeEach(() => {
+  consoleWarnSpy = mock(() => {});
+  console.warn = consoleWarnSpy as unknown as typeof console.warn;
+});
+
+afterEach(() => {
+  console.warn = originalConsoleWarn;
+  cleanup();
+});
 
 function errorText(): string | null {
   // Radix Dialog portals outside `container` — query from document.body.
@@ -62,6 +77,11 @@ describe("ReasonDialog error precedence (#1612)", () => {
     await waitFor(() => {
       expect(errorText() ?? "").toContain("Unexpected error");
     });
+
+    // Component promises to log when onConfirm throws — enforce that contract.
+    expect(consoleWarnSpy).toHaveBeenCalled();
+    const firstCallArgs = consoleWarnSpy.mock.calls[0] ?? [];
+    expect(firstCallArgs[0]).toBe("ReasonDialog: onConfirm threw");
 
     rerender(<Harness error="server rejected the retry" />);
 

--- a/packages/web/src/ui/components/admin/queue/__tests__/reason-dialog.test.tsx
+++ b/packages/web/src/ui/components/admin/queue/__tests__/reason-dialog.test.tsx
@@ -70,6 +70,43 @@ describe("ReasonDialog error precedence (#1612)", () => {
     });
   });
 
+  test("error prop transitioning between distinct non-null values still clears localError on each retry", async () => {
+    // A future refactor that guards `if (prevError == null && error != null)`
+    // would pass the null→non-null test but break the sequential retry flow:
+    //   - retry 1: onConfirm throws → localError set, caller surfaces serverA
+    //   - retry 2: onConfirm throws again → localError re-set, caller surfaces serverB
+    //   - the fresh serverB must win, not the stale localError from retry 2.
+    function Harness({ error }: { error: string | null }) {
+      return (
+        <ReasonDialog
+          open
+          onOpenChange={() => {}}
+          title="Deny"
+          onConfirm={async () => {
+            throw new Error("boom");
+          }}
+          error={error}
+        />
+      );
+    }
+
+    const { rerender } = render(<Harness error={null} />);
+    // Retry 1 — throw → localError; caller pushes first error prop → cleared
+    await act(async () => {
+      fireEvent.click(denyButton());
+    });
+    await waitFor(() => expect(errorText() ?? "").toContain("Unexpected error"));
+    rerender(<Harness error="first server error" />);
+    await waitFor(() => expect(errorText()).toBe("first server error"));
+    // Retry 2 — throw → localError; caller pushes second (distinct) error prop
+    await act(async () => {
+      fireEvent.click(denyButton());
+    });
+    await waitFor(() => expect(errorText() ?? "").toContain("Unexpected error"));
+    rerender(<Harness error="second server error" />);
+    await waitFor(() => expect(errorText()).toBe("second server error"));
+  });
+
   test("error prop going null → null does not clobber localError", async () => {
     // Guard against an over-eager effect clearing localError on every prop
     // change — we only clear when a non-null error arrives.

--- a/packages/web/src/ui/components/admin/queue/bulk-summary.ts
+++ b/packages/web/src/ui/components/admin/queue/bulk-summary.ts
@@ -17,6 +17,22 @@ export interface BulkPartialResult {
   errors?: Array<{ id: string; error: string }>;
 }
 
+/**
+ * Rejection carrying the server's user-facing message and its requestId as
+ * separate fields. Callers in fan-out bulk flows should throw this instead
+ * of `new Error("${message} (Request ID: ${requestId})")` — that embedded
+ * form causes `bulkFailureSummary` to group every row into its own bucket
+ * (one per unique requestId) instead of collapsing identical failures.
+ */
+export class BulkRequestError extends Error {
+  readonly requestId?: string;
+  constructor(message: string, requestId?: string) {
+    super(message);
+    this.name = "BulkRequestError";
+    this.requestId = requestId;
+  }
+}
+
 /** Indices of `results` that rejected, mapped back to their input ids. */
 export function failedIdsFrom(
   results: PromiseSettledResult<unknown>[],
@@ -25,22 +41,37 @@ export function failedIdsFrom(
   return results.flatMap((r, i) => (r.status === "rejected" ? [ids[i]] : []));
 }
 
-/** "3 of 5 denials failed: 2× Forbidden; 1× Internal error" — counts per reason. */
+/**
+ * "3 of 5 denials failed: 2× Forbidden (IDs: abc, def); 1× Internal error (ID: ghi)"
+ *
+ * Groups by message (so N identical failures collapse to one line). When any
+ * grouped rejection carries a requestId, appends a trailing `(ID: …)` slot
+ * per group so on-call still has the correlation token without splintering
+ * the grouping.
+ */
 export function bulkFailureSummary(
   results: PromiseSettledResult<unknown>[],
   ids: string[],
   noun: string,
 ): string {
-  const reasonCounts = new Map<string, number>();
+  const groups = new Map<string, { count: number; requestIds: string[] }>();
   for (const r of results) {
-    if (r.status === "rejected") {
-      const msg = r.reason instanceof Error ? r.reason.message : String(r.reason);
-      reasonCounts.set(msg, (reasonCounts.get(msg) ?? 0) + 1);
-    }
+    if (r.status !== "rejected") continue;
+    const reason = r.reason;
+    const msg = reason instanceof Error ? reason.message : String(reason);
+    const requestId = reason instanceof BulkRequestError ? reason.requestId : undefined;
+    const group = groups.get(msg) ?? { count: 0, requestIds: [] };
+    group.count += 1;
+    if (requestId) group.requestIds.push(requestId);
+    groups.set(msg, group);
   }
-  const failedCount = [...reasonCounts.values()].reduce((a, b) => a + b, 0);
-  const summary = [...reasonCounts.entries()]
-    .map(([msg, n]) => `${n}× ${msg}`)
+  const failedCount = [...groups.values()].reduce((a, g) => a + g.count, 0);
+  const summary = [...groups.entries()]
+    .map(([msg, { count, requestIds }]) => {
+      if (requestIds.length === 0) return `${count}× ${msg}`;
+      const label = requestIds.length === 1 ? "ID" : "IDs";
+      return `${count}× ${msg} (${label}: ${requestIds.join(", ")})`;
+    })
     .join("; ");
   return `${failedCount} of ${ids.length} ${noun} failed: ${summary}`;
 }

--- a/packages/web/src/ui/components/admin/queue/bulk-summary.ts
+++ b/packages/web/src/ui/components/admin/queue/bulk-summary.ts
@@ -19,10 +19,9 @@ export interface BulkPartialResult {
 
 /**
  * Rejection carrying the server's user-facing message and its requestId as
- * separate fields. Callers in fan-out bulk flows should throw this instead
- * of `new Error("${message} (Request ID: ${requestId})")` — that embedded
- * form causes `bulkFailureSummary` to group every row into its own bucket
- * (one per unique requestId) instead of collapsing identical failures.
+ * separate fields so `bulkFailureSummary` groups rejections by message
+ * alone. Embedding the requestId into `message` would splinter each group
+ * into a bucket of one, since no two requestIds repeat.
  */
 export class BulkRequestError extends Error {
   readonly requestId?: string;
@@ -31,6 +30,27 @@ export class BulkRequestError extends Error {
     this.name = "BulkRequestError";
     this.requestId = requestId;
   }
+}
+
+/**
+ * Extract a correlated requestId from a Promise-rejection value. Accepts
+ * BulkRequestError instances, `useAdminMutation`-style `{ fetchError:
+ * { requestId } }` attachments, and direct `.requestId` string properties.
+ * Returns undefined when no recognizable id is present. Exported so tests
+ * can pin the union of accepted shapes.
+ */
+export function extractBulkRequestId(reason: unknown): string | undefined {
+  if (reason instanceof BulkRequestError) return reason.requestId;
+  if (reason != null && typeof reason === "object") {
+    const fetchError = (reason as { fetchError?: unknown }).fetchError;
+    if (fetchError != null && typeof fetchError === "object") {
+      const id = (fetchError as { requestId?: unknown }).requestId;
+      if (typeof id === "string") return id;
+    }
+    const direct = (reason as { requestId?: unknown }).requestId;
+    if (typeof direct === "string") return direct;
+  }
+  return undefined;
 }
 
 /** Indices of `results` that rejected, mapped back to their input ids. */
@@ -44,10 +64,11 @@ export function failedIdsFrom(
 /**
  * "3 of 5 denials failed: 2× Forbidden (IDs: abc, def); 1× Internal error (ID: ghi)"
  *
- * Groups by message (so N identical failures collapse to one line). When any
- * grouped rejection carries a requestId, appends a trailing `(ID: …)` slot
- * per group so on-call still has the correlation token without splintering
- * the grouping.
+ * Groups rejections by message; appends requestIds per group so identical
+ * failures stay collapsed. RequestIds are extracted via
+ * `extractBulkRequestId` so any rejection shape carrying a correlated id
+ * (BulkRequestError, mutation fetchError attachment, direct .requestId)
+ * contributes it.
  */
 export function bulkFailureSummary(
   results: PromiseSettledResult<unknown>[],
@@ -59,7 +80,7 @@ export function bulkFailureSummary(
     if (r.status !== "rejected") continue;
     const reason = r.reason;
     const msg = reason instanceof Error ? reason.message : String(reason);
-    const requestId = reason instanceof BulkRequestError ? reason.requestId : undefined;
+    const requestId = extractBulkRequestId(reason);
     const group = groups.get(msg) ?? { count: 0, requestIds: [] };
     group.count += 1;
     if (requestId) group.requestIds.push(requestId);
@@ -80,8 +101,8 @@ export function bulkFailureSummary(
  * Summarize a partial-success bulk response.
  * "3 of 10 approvals failed: 2 not found; 1× db timeout"
  *
- * `total` is the number of rows originally requested (so the ratio shows
- * "failed / requested", not "failed / touched").
+ * `total` is the caller-supplied request count — pass in the input size,
+ * not the server's touched count.
  */
 export function bulkPartialSummary(
   data: BulkPartialResult,

--- a/packages/web/src/ui/components/admin/queue/index.ts
+++ b/packages/web/src/ui/components/admin/queue/index.ts
@@ -7,6 +7,7 @@ export {
   bulkFailureSummary,
   bulkPartialSummary,
   BulkRequestError,
+  extractBulkRequestId,
   failedIdsFrom,
   type BulkPartialResult,
 } from "./bulk-summary";

--- a/packages/web/src/ui/components/admin/queue/index.ts
+++ b/packages/web/src/ui/components/admin/queue/index.ts
@@ -6,6 +6,7 @@
 export {
   bulkFailureSummary,
   bulkPartialSummary,
+  BulkRequestError,
   failedIdsFrom,
   type BulkPartialResult,
 } from "./bulk-summary";

--- a/packages/web/src/ui/components/admin/queue/reason-dialog.tsx
+++ b/packages/web/src/ui/components/admin/queue/reason-dialog.tsx
@@ -67,14 +67,12 @@ export function ReasonDialog({
     }
   }, [open]);
 
-  // When the caller pushes a fresh `error` prop (typically after fixing the
-  // onConfirm bug and surfacing a real server error on retry), clear any
-  // stale localError so the caller's message wins. Without this the local
-  // "Unexpected error: ..." from a prior throw keeps displaying via
-  // `localError ?? error` and hides the server's diagnosis until the
-  // operator reopens the dialog. Safe in the rare same-frame collision:
-  // if both errors appear together, the caller-provided one is at least
-  // equally informative.
+  // A fresh non-null `error` prop clears any stale localError so the
+  // caller's message wins. Without this, `displayError = localError ?? error`
+  // keeps showing a prior-throw "Unexpected error: ..." and hides a real
+  // server error that arrives later. Fires on every non-null error, not
+  // just the null→non-null transition, so sequential retries each surface
+  // the latest caller-provided diagnosis.
   useEffect(() => {
     if (error != null) setLocalError(null);
   }, [error]);

--- a/packages/web/src/ui/components/admin/queue/reason-dialog.tsx
+++ b/packages/web/src/ui/components/admin/queue/reason-dialog.tsx
@@ -67,6 +67,18 @@ export function ReasonDialog({
     }
   }, [open]);
 
+  // When the caller pushes a fresh `error` prop (typically after fixing the
+  // onConfirm bug and surfacing a real server error on retry), clear any
+  // stale localError so the caller's message wins. Without this the local
+  // "Unexpected error: ..." from a prior throw keeps displaying via
+  // `localError ?? error` and hides the server's diagnosis until the
+  // operator reopens the dialog. Safe in the rare same-frame collision:
+  // if both errors appear together, the caller-provided one is at least
+  // equally informative.
+  useEffect(() => {
+    if (error != null) setLocalError(null);
+  }, [error]);
+
   const trimmed = reason.trim();
   const canConfirm = required ? trimmed.length > 0 : true;
   const displayError = localError ?? error;

--- a/packages/web/src/ui/components/admin/queue/reason-dialog.tsx
+++ b/packages/web/src/ui/components/admin/queue/reason-dialog.tsx
@@ -37,11 +37,11 @@ interface ReasonDialogProps {
  * Compliance-grade reason capture dialog shared across queue/moderation
  * surfaces. Records the reason in the audit log alongside the reviewer.
  *
- * **Never substitutes a hardcoded placeholder** — if the reason is empty
- * and `required: false`, the audit log must reflect "no reason given"
- * rather than fabricating one. Passing `onConfirm(reason || "Denied")`
- * silently corrupts the audit trail; callers must receive exactly what
- * the user typed (whitespace-trimmed), including the empty string.
+ * **Caller contract:** pass the `reason` through to the audit log
+ * unchanged. Substituting a hardcoded fallback (e.g. `reason || "Denied"`)
+ * corrupts the trail — the empty string is semantically distinct from
+ * "no reason given" only if callers preserve it. The dialog emits exactly
+ * what the user typed, whitespace-trimmed, including the empty string.
  */
 export function ReasonDialog({
   open,


### PR DESCRIPTION
Closes #1602, #1603, #1610, #1612, #1640.

All 5 open bugs at the time of this PR were low-severity paper-cuts from bucket-1 follow-up reviews. They touch different files with no shared interfaces, so bundling keeps review overhead proportional to the fix size (one PR, one CI pass, one merge).

## Commits (one per bug)

| Commit | Issue | Area | What |
|---|---|---|---|
| 9be057c1 | #1602 | web/admin/queue | `BulkRequestError` carries `requestId` separately so `bulkFailureSummary` groups identical failures with a trailing `(IDs: ...)` slot instead of splintering into one bucket per requestId |
| cc73ee49 | #1603 | web/admin/actions | `coerceRollbackWarning()` handles non-string rollback warning shapes (object with `.message`, arrays, numbers) so the compliance-critical signal never silently drops |
| ed5d019c | #1612 | web/admin/queue | `ReasonDialog` clears stale `localError` when a fresh non-null `error` prop arrives, so retry-flow server errors win over the local `"Unexpected error"` from a prior throw |
| dd7b2f8c | #1640 | api | `getWorkspaceNamesByIds()` batch lookup resolves `workspaceName` in both `/admin/abuse` list and detail routes so admins see display names instead of opaque `org_01K...` ids |
| 8256cf36 | #1610 | docs | Rewrote `plugin-marketplace.mdx` (Option 1 from the issue) to match the shipped admin UI — no Available tab / Enterprise badge / self-service browse exists today, so the guide describes what admins can actually do and splits install paths by self-hosted vs SaaS |
| f6e1a4b2 | — | testing | Per CLAUDE.md 'mock every named export' — added `getWorkspaceNamesByIds` to 9 inline `mock.module("@atlas/api/lib/db/internal")` call sites so they don't SyntaxError on the new export |

## Test coverage

- 5 new cases in `bulk-summary.test.ts` for the `BulkRequestError` decision tree (singular vs plural 'ID' label, mixed typed+plain Error grouping, absent requestId, multi-group splits)
- New `__tests__/rollback-warning.test.ts` with 8 cases covering the coercion branches and the 'never return empty string for non-null input' compliance contract
- New `__tests__/reason-dialog.test.tsx` with 3 RTL cases proving the error-prop → clear-localError effect fires on fresh errors and no-ops on null → null
- 3 new cases in `admin-abuse.test.ts` proving the resolved-name path (per-row non-null, per-row null, DB-rejection fallback to null) + 1 for the detail route
- 9 inline-mock updates keep the full api suite at 242/242 green

## CI gates (all green locally)

- `bun run lint` clean
- `bun run type` clean  
- `bun run test` — api 242/242, cli 19/19, web 70/70, ee 25/25, react 9/9
- `bun x syncpack lint` clean
- Template drift check passed (429 files)

Note: `duckdb-ingest.test.ts` flaked once on the first full test run with `malloc(): unsorted double linked list corrupted`. This is the known pre-existing DuckDB segfault flake; the retry ran green and my branch doesn't touch cli.

## Test plan

- [ ] Non-EE admin on `/admin/custom-domain` sees EnterpriseUpsell (sanity — already shipped in #1637, still verified by this branch's tests)
- [ ] Operator on `/admin/approval` bulk-denying 3 rows that all 500 sees `3× HTTP 500 (IDs: req-abc, req-def, req-ghi)` instead of 3 separate groups
- [ ] Server sends `warning: { code, message }` on a rollback — operator sees the `.message` text in the warning banner; server sends `warning: ["a","b"]` — operator sees the generic fallback and console.warn fires
- [ ] ReasonDialog retry flow — first click throws from onConfirm, parent fixes bug and surfaces a real error via the prop, dialog swaps from the local `Unexpected error` message to the fresh server message
- [ ] `/admin/abuse` list shows `Acme Corp` instead of `org_01K...` when the org has a name; falls back to the id when the name is null / missing; still renders (no 500) if internal DB is down
- [ ] Follow `plugin-marketplace.mdx` — no mention of an Available tab or self-service browse; install paths match reality