### PR TITLE
feat(web): MutationErrorSurface + migrate 5 admin pages (phase 1 of #1624)

### DIFF
--- a/.claude/research/architecture-wins.md
+++ b/.claude/research/architecture-wins.md
@@ -727,3 +727,36 @@ A pre-existing bug also hid in the hook: `invalidates()` callbacks ran inside th
 - **Follow-up filed: #1621** (pre-existing `demo/page.tsx` type error using stale `chatEndpoint`/`conversationsEndpoint` props on `<AtlasChat>` — surfaced by `tsgo --noEmit -p packages/web/tsconfig.json` when auditing web-package type-check output; unrelated to this PR but noticed during the review).
 
 **Category:** Completion pass on a two-phase data-structure migration. Win #29 unblocked the primary code path (`result.error`); win #30 sweeps the ~40 pages that read the *secondary* hook-level surface the first pass left flattened, plus adds ESLint enforcement so the invariant survives churn. The #1617 callback-isolation fix rides along because silent-failure-hunter flagged it during #1614 review — cheap to fix atomically with the hook widening, since both touch the same `mutate()` body. Generalizes: when you're partway through a migration and the follow-up is "same class of bug, different surface," do the full sweep plus a lint rule; the ESLint `no-restricted-syntax` AST selector is a cheap safety net for any `X.something` shape you need to prevent callers from re-flattening.
+
+
+---
+
+## 31. `<MutationErrorSurface>` — write-path parity with `AdminContentWrapper` feature-gate routing
+
+**Date:** 2026-04-19
+**Issue:** #1624
+**PR:** TBD (phase 1 of 2 — 5 admin pages migrated, follow-up issue tracks the remaining ~35)
+
+**Problem:** Wins #29 and #30 widened `MutateResult.error` and `mutation.error` to `FetchError`, preserving `code` / `status` / `requestId` across the hook boundary. But `AdminContentWrapper`'s `isEnterpriseRequired()` + `FeatureGate` decision tree — the code that routes `403 + code: "enterprise_required"` to `EnterpriseUpsell` and known status codes to `FeatureGate` — was still only reachable from the read path (`useAdminFetch`). Admin pages rendering mutation errors wrote `<ErrorBanner message={friendlyError(mutation.error)} />` at their render boundary, which flattens the structured `FetchError` to a string *again* before any gating can fire. A non-EE admin clicking "Enable SSO enforcement" on a gated workspace saw the translated 403 copy ("Access denied. Admin role required.") — wrong message, wrong CTA, no path to the upsell.
+
+Same as the #1595 / #1614 pattern but at the render boundary instead of the hook boundary: structured error survives the transport layer, gets flattened one step later because the UI primitive accepts a `string`, not a `FetchError`.
+
+**Solution:** `<MutationErrorSurface>` in `packages/web/src/ui/components/admin/mutation-error-surface.tsx` accepts `FetchError | null` and encapsulates the same decision tree `AdminContentWrapper` applies to fetch errors — moved up a level from the wrapper into a dedicated component so the write path doesn't have to thread its errors back through `AdminContentWrapper`'s fetch-oriented API.
+
+Two variants:
+- **`variant="banner"` (default)** — mirrors `AdminContentWrapper` exactly: `enterprise_required` → `<EnterpriseUpsell>`, status in {401, 403, 404, 503} → `<FeatureGate>`, else → `<ErrorBanner>` with `friendlyError` copy + retry.
+- **`variant="inline"`** — for compact rows and dialog bodies that can't host a full-page upsell card. `enterprise_required` routes to a condensed `<InlineError>` that keeps the enterprise link ("… requires Enterprise. Learn more →") so the routing win isn't lost; other errors render as `<InlineError>` with an optional bold prefix ("Save failed." etc.). Inline variant intentionally does *not* route other 401/403/404/503 through `<FeatureGate>` — replacing a tiny row-level error slot with a full-page gate would be more disruptive than useful, and the page-level wrapper still handles those on refresh.
+
+Phase 1 migration (this PR) covers 5 highest-value pages — the ones called out explicitly in #1624 as the surfaces where the gap is most visible:
+- `/admin/sso` — 3 `ErrorBanner` sites (enforcement, toggle, verify) + 1 in the enforce-confirmation dialog.
+- `/admin/scim` — 1 page-level `ErrorBanner`. Per-row `InlineError` (with synthesized "Revoke failed —" prefix) stays as-is — that's a different concern (last-wins row pinning) punted to phase 2.
+- `/admin/branding` — 2 `InlineError` sites (save + reset).
+- `/admin/billing` — 2 `InlineError` sites (model change + BYOT toggle). `PlanShell.combinedError` deliberately skipped — blends a mutation error with local `portalError` state; phase 2.
+- `/admin/ip-allowlist` — inline div in delete dialog.
+
+**Impact:**
+- **One component, five pages, ~35 remaining.** Component itself is 107 lines (70 of which are the docstring explaining the decision tree and why the inline variant opts out of FeatureGate routing). Each call site dropped 3–5 lines — `{err && <ErrorBanner … />}` → `<MutationErrorSurface error={err} feature="…" />` plus the null-render handling moves into the component.
+- **10 component tests, full branch coverage.** Enterprise_required (banner + inline), all 4 FeatureGate status codes, plain error with requestId, retry button wiring, inline prefix rendering, null → null. Inline + `enterprise_required` asserts the compact upsell link is present AND the full `EnterpriseUpsell` button is *not* — guards the variant separation.
+- **Phase 2 is mechanical.** ~35 admin pages still write `<ErrorBanner message={friendlyError(mutation.error)} />` or the equivalent. Follow-up issue enumerates the full list so the second PR can sweep them in one pass without re-analysis.
+
+**Category:** Render-boundary completion of the structured-error migration line (wins #29 → #30 → #31). Each win moves the invariant one step further through the stack: hook result → hook state → render output. The pattern generalizes — if a UI primitive accepts a flattened type (`string`, `number`) where the caller has a structured type (`FetchError`, `Money`, `Duration`), the decision tree *on* the structured fields belongs in a dedicated component, not at every call site. Call sites otherwise drop the structure before gating can fire.

--- a/.claude/research/architecture-wins.md
+++ b/.claude/research/architecture-wins.md
@@ -755,7 +755,7 @@ Phase 1 migration (this PR) covers 5 highest-value pages — the ones called out
 - `/admin/ip-allowlist` — inline div in delete dialog.
 
 **Impact:**
-- **One component, five pages, ~35 remaining.** Component itself is 107 lines (70 of which are the docstring explaining the decision tree and why the inline variant opts out of FeatureGate routing). Each call site dropped 3–5 lines — `{err && <ErrorBanner … />}` → `<MutationErrorSurface error={err} feature="…" />` plus the null-render handling moves into the component.
+- **One component, five pages, ~35 remaining.** Component itself is small — most of it is the docstring explaining the decision tree and why the inline variant opts out of FeatureGate routing. Each call site dropped 3–5 lines — `{err && <ErrorBanner … />}` → `<MutationErrorSurface error={err} feature="…" />` plus the null-render handling moves into the component.
 - **10 component tests, full branch coverage.** Enterprise_required (banner + inline), all 4 FeatureGate status codes, plain error with requestId, retry button wiring, inline prefix rendering, null → null. Inline + `enterprise_required` asserts the compact upsell link is present AND the full `EnterpriseUpsell` button is *not* — guards the variant separation.
 - **Phase 2 is mechanical.** ~35 admin pages still write `<ErrorBanner message={friendlyError(mutation.error)} />` or the equivalent. Follow-up issue enumerates the full list so the second PR can sweep them in one pass without re-analysis.
 

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -27,6 +27,7 @@ import {
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { friendlyError } from "@/ui/lib/fetch-error";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { BillingStatusSchema } from "@/ui/lib/admin-schemas";
 import { formatDate, formatNumber } from "@/lib/format";
 import { cn } from "@/lib/utils";
@@ -546,7 +547,7 @@ function ModelRow({ data, onSaved }: { data: BillingStatus; onSaved: () => void 
           Saving…
         </p>
       )}
-      <InlineError>{error ? friendlyError(error) : null}</InlineError>
+      <MutationErrorSurface error={error} feature="AI Model" variant="inline" />
     </Shell>
   );
 }
@@ -598,7 +599,7 @@ function ByotRow({
           </div>
         }
       />
-      <InlineError>{error ? friendlyError(error) : null}</InlineError>
+      <MutationErrorSurface error={error} feature="BYOT" variant="inline" />
     </div>
   );
 }

--- a/packages/web/src/app/admin/branding/page.tsx
+++ b/packages/web/src/app/admin/branding/page.tsx
@@ -18,8 +18,8 @@ import {
 } from "lucide-react";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError } from "@/ui/lib/fetch-error";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import {
   CompactRow,
@@ -211,18 +211,18 @@ export default function BrandingPage() {
                 <PreviewShell values={values} colorValid={colorValid} />
               </section>
 
-              {save.error && (
-                <InlineError>
-                  <span className="font-semibold">Save failed.</span>{" "}
-                  {friendlyError(save.error)}
-                </InlineError>
-              )}
-              {reset.error && (
-                <InlineError>
-                  <span className="font-semibold">Reset failed.</span>{" "}
-                  {friendlyError(reset.error)}
-                </InlineError>
-              )}
+              <MutationErrorSurface
+                error={save.error}
+                feature="Branding"
+                variant="inline"
+                inlinePrefix="Save failed."
+              />
+              <MutationErrorSurface
+                error={reset.error}
+                feature="Branding"
+                variant="inline"
+                inlinePrefix="Reset failed."
+              />
               {!colorValid && (
                 <InlineError>
                   Primary color must be a 6-digit hex (e.g. #FF5500). Open

--- a/packages/web/src/app/admin/branding/page.tsx
+++ b/packages/web/src/app/admin/branding/page.tsx
@@ -146,7 +146,7 @@ export default function BrandingPage() {
   const busy = save.saving || reset.saving;
 
   async function handleSave(v: BrandingValues) {
-    // saveError state is surfaced via <InlineError> below — no throw
+    // saveError is surfaced by <MutationErrorSurface> below — no throw
     // needed; react-hook-form's handleSubmit would swallow it anyway.
     await save.mutate({
       method: "PUT",

--- a/packages/web/src/app/admin/ip-allowlist/page.tsx
+++ b/packages/web/src/app/admin/ip-allowlist/page.tsx
@@ -22,9 +22,10 @@ import {
 } from "@/components/form-dialog";
 import { z } from "zod";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError, friendlyErrorOrNull } from "@/ui/lib/fetch-error";
+import { friendlyErrorOrNull } from "@/ui/lib/fetch-error";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import {
   CompactRow,
@@ -240,11 +241,11 @@ function DeleteEntryDialog({
               </div>
             )}
 
-            {error && (
-              <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                {friendlyError(error)}
-              </div>
-            )}
+            <MutationErrorSurface
+              error={error}
+              feature="IP Allowlist"
+              variant="inline"
+            />
           </div>
         )}
 

--- a/packages/web/src/app/admin/scim/page.tsx
+++ b/packages/web/src/app/admin/scim/page.tsx
@@ -153,6 +153,12 @@ export default function SCIMPage() {
     const result = await deleteMutate({ path });
     setDeleteTarget(null);
     if (!result.ok) {
+      // TODO(#1649): route per-row errors through <MutationErrorSurface> too.
+      // Page-level banner already uses the surface and picks up `enterprise_required`
+      // routing; per-row pin still flattens to string so a gated row revoke renders
+      // as a plain InlineError rather than an inline upsell. Not wired here because
+      // rowError needs id/kind tracking that the surface doesn't model — phase 2
+      // reshapes this state to `{ fetchError, id, kind }` and lets the surface render.
       setRowError({ message: friendlyError(result.error), id: target.id, kind: target.type });
     }
   }

--- a/packages/web/src/app/admin/scim/page.tsx
+++ b/packages/web/src/app/admin/scim/page.tsx
@@ -24,7 +24,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
@@ -263,7 +263,11 @@ export default function SCIMPage() {
         >
           {showTopMutationError && mutationError && (
             <div className="mb-4">
-              <ErrorBanner message={friendlyError(mutationError)} onRetry={clearMutationError} />
+              <MutationErrorSurface
+                error={mutationError}
+                feature="SCIM"
+                onRetry={clearMutationError}
+              />
             </div>
           )}
 

--- a/packages/web/src/app/admin/sso/page.tsx
+++ b/packages/web/src/app/admin/sso/page.tsx
@@ -20,11 +20,10 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError } from "@/ui/lib/fetch-error";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import {
   CompactRow,
@@ -232,17 +231,29 @@ export default function SSOPage() {
         >
           {enforcementMutationError && (
             <div className="mb-4">
-              <ErrorBanner message={friendlyError(enforcementMutationError)} onRetry={clearEnforcementError} />
+              <MutationErrorSurface
+                error={enforcementMutationError}
+                feature="SSO"
+                onRetry={clearEnforcementError}
+              />
             </div>
           )}
           {toggleError && (
             <div className="mb-4">
-              <ErrorBanner message={friendlyError(toggleError)} onRetry={clearToggleError} />
+              <MutationErrorSurface
+                error={toggleError}
+                feature="SSO"
+                onRetry={clearToggleError}
+              />
             </div>
           )}
           {verifyError && (
             <div className="mb-4">
-              <ErrorBanner message={friendlyError(verifyError)} onRetry={clearVerifyError} />
+              <MutationErrorSurface
+                error={verifyError}
+                feature="SSO"
+                onRetry={clearVerifyError}
+              />
             </div>
           )}
 
@@ -364,7 +375,11 @@ export default function SSOPage() {
             </AlertDialogDescription>
           </AlertDialogHeader>
           {enforcementMutationError && (
-            <ErrorBanner message={friendlyError(enforcementMutationError)} onRetry={clearEnforcementError} />
+            <MutationErrorSurface
+              error={enforcementMutationError}
+              feature="SSO"
+              onRetry={clearEnforcementError}
+            />
           )}
           <AlertDialogFooter>
             <AlertDialogCancel disabled={enforcementSaving}>Cancel</AlertDialogCancel>

--- a/packages/web/src/ui/components/admin/__tests__/mutation-error-surface.test.tsx
+++ b/packages/web/src/ui/components/admin/__tests__/mutation-error-surface.test.tsx
@@ -72,6 +72,42 @@ describe("MutationErrorSurface", () => {
     expect(container.textContent).toContain("Custom Domains");
   });
 
+  test("enterprise_required without a status still routes to EnterpriseUpsell", () => {
+    // Locks the ordering of the two gate checks inside the banner branch.
+    // A refactor that puts the `status in {401,403,404,503}` check first
+    // would still pass the other enterprise_required tests (they all have
+    // status 403), but would silently drop a code-only error into
+    // FeatureGate instead of EnterpriseUpsell.
+    const error: FetchError = {
+      message: "Enterprise required",
+      code: "enterprise_required",
+    };
+    const { container } = render(
+      <MutationErrorSurface error={error} feature="SSO" />,
+    );
+    expect(container.textContent).toContain("SSO requires an enterprise plan");
+    expect(container.querySelector('a[href*="useatlas.dev/enterprise"]')).not.toBeNull();
+  });
+
+  test("status outside {401,403,404,503} falls through to ErrorBanner, not FeatureGate", () => {
+    // Locks the whitelist semantics on the FeatureGate gate. A refactor that
+    // replaces `[401,403,404,503].includes(error.status)` with a truthy check
+    // would render FeatureGate for 429/500/... and break the cast
+    // `as 401 | 403 | 404 | 503`. 429 is the canonical "known status code
+    // that MUST NOT route to FeatureGate" — rate-limited mutations should
+    // render the generic banner with retry.
+    const error: FetchError = { message: "Too Many Requests", status: 429 };
+    const { container } = render(
+      <MutationErrorSurface error={error} feature="Billing" />,
+    );
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert).not.toBeNull();
+    expect(alert!.textContent).toContain("Too Many Requests");
+    // FeatureGate uses h-full + centered copy — the "Access denied" text
+    // must not appear.
+    expect(container.textContent).not.toContain("Access denied");
+  });
+
   test("plain error (banner) renders ErrorBanner with friendlyError message + requestId", () => {
     const error: FetchError = {
       message: "Upstream failed",
@@ -137,7 +173,7 @@ describe("MutationErrorSurface", () => {
 
   test("inline variant + enterprise_required renders compact inline upsell (not full EnterpriseUpsell)", () => {
     const error: FetchError = {
-      message: "Enterprise required",
+      message: "Enterprise tier required — contact sales@example.com",
       status: 403,
       code: "enterprise_required",
     };
@@ -152,6 +188,12 @@ describe("MutationErrorSurface", () => {
     expect(link).not.toBeNull();
     expect(container.textContent).toContain("BYOT");
     expect(container.textContent).toContain("Enterprise");
+    // Server-provided message must survive — banner variant passes it via
+    // EnterpriseUpsell.message, inline variant must render it too or the
+    // specific guidance ("contact sales@...") silently drops.
+    expect(container.textContent).toContain(
+      "Enterprise tier required — contact sales@example.com",
+    );
     // Inline chrome (not the centered card with the shield icon and button).
     expect(container.querySelector(".bg-destructive\\/10")).not.toBeNull();
     expect(

--- a/packages/web/src/ui/components/admin/__tests__/mutation-error-surface.test.tsx
+++ b/packages/web/src/ui/components/admin/__tests__/mutation-error-surface.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, mock, spyOn } from "bun:test";
 import { render, fireEvent } from "@testing-library/react";
 import type { FetchError } from "@/ui/lib/fetch-error";
 import { MutationErrorSurface } from "../mutation-error-surface";
@@ -169,6 +169,39 @@ describe("MutationErrorSurface", () => {
     const bold = container.querySelector(".font-semibold");
     expect(bold?.textContent).toBe("Save failed.");
     expect(container.textContent).toContain("Upstream failed");
+  });
+
+  test("warns in dev when inline variant receives onRetry (cross-variant misuse)", () => {
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    const error: FetchError = { message: "Upstream failed", status: 500 };
+    render(
+      <MutationErrorSurface
+        error={error}
+        feature="SSO"
+        variant="inline"
+        onRetry={mock(() => {})}
+      />,
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("onRetry` is banner-only"),
+    );
+    warn.mockRestore();
+  });
+
+  test("warns in dev when banner variant receives inlinePrefix (cross-variant misuse)", () => {
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    const error: FetchError = { message: "Upstream failed", status: 500 };
+    render(
+      <MutationErrorSurface
+        error={error}
+        feature="SSO"
+        inlinePrefix="Save failed."
+      />,
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("inlinePrefix` is inline-only"),
+    );
+    warn.mockRestore();
   });
 
   test("inline variant + enterprise_required renders compact inline upsell (not full EnterpriseUpsell)", () => {

--- a/packages/web/src/ui/components/admin/__tests__/mutation-error-surface.test.tsx
+++ b/packages/web/src/ui/components/admin/__tests__/mutation-error-surface.test.tsx
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+import { render, fireEvent } from "@testing-library/react";
+import type { FetchError } from "@/ui/lib/fetch-error";
+import { MutationErrorSurface } from "../mutation-error-surface";
+
+/**
+ * Coverage maps to the decision tree in `mutation-error-surface.tsx`:
+ *   null → null
+ *   code="enterprise_required" → EnterpriseUpsell (banner) / compact inline upsell (inline)
+ *   status in {401,403,404,503} → FeatureGate (banner only)
+ *   otherwise → ErrorBanner (banner) or InlineError-with-optional-prefix (inline)
+ *
+ * A regression that drops `.code` routing (e.g. reverts to substring matching
+ * on `.message`) or collapses the two variants into one would fail at least
+ * one case here.
+ */
+
+describe("MutationErrorSurface", () => {
+  test("null error renders nothing", () => {
+    const { container } = render(
+      <MutationErrorSurface error={null} feature="SSO" />,
+    );
+    expect(container.textContent).toBe("");
+  });
+
+  test("enterprise_required (banner) routes to EnterpriseUpsell with feature + server message", () => {
+    const error: FetchError = {
+      message: "Enterprise tier required to use SSO.",
+      status: 403,
+      code: "enterprise_required",
+    };
+    const { container } = render(
+      <MutationErrorSurface error={error} feature="SSO" />,
+    );
+    expect(container.textContent).toContain("SSO requires an enterprise plan");
+    // Preserves the server-provided message as the description, not the
+    // generic fallback copy — this is what proves we routed through
+    // EnterpriseUpsell's `message` prop rather than ErrorBanner.
+    expect(container.textContent).toContain(
+      "Enterprise tier required to use SSO.",
+    );
+    const link = container.querySelector('a[href*="useatlas.dev/enterprise"]');
+    expect(link).not.toBeNull();
+    // Banner variant never renders inside the small InlineError chrome, so
+    // the destructive/10 background class can't appear here.
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  test("FeatureGate status codes route to FeatureGate (banner variant)", () => {
+    const error: FetchError = { message: "Forbidden", status: 403 };
+    const { container } = render(
+      <MutationErrorSurface error={error} feature="SCIM" />,
+    );
+    expect(container.textContent).toContain("Access denied");
+    expect(container.textContent).toContain("admin role");
+  });
+
+  test("401 routes to FeatureGate sign-in copy", () => {
+    const error: FetchError = { message: "Unauthorized", status: 401 };
+    const { container } = render(
+      <MutationErrorSurface error={error} feature="SCIM" />,
+    );
+    expect(container.textContent).toContain("Authentication required");
+  });
+
+  test("503 routes to FeatureGate internal-db copy", () => {
+    const error: FetchError = { message: "Unavailable", status: 503 };
+    const { container } = render(
+      <MutationErrorSurface error={error} feature="Custom Domains" />,
+    );
+    expect(container.textContent).toContain("Internal database not configured");
+    expect(container.textContent).toContain("Custom Domains");
+  });
+
+  test("plain error (banner) renders ErrorBanner with friendlyError message + requestId", () => {
+    const error: FetchError = {
+      message: "Upstream failed",
+      status: 500,
+      requestId: "req-42",
+    };
+    const { container } = render(
+      <MutationErrorSurface error={error} feature="SSO" />,
+    );
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert).not.toBeNull();
+    expect(alert!.textContent).toContain("Upstream failed");
+    expect(alert!.textContent).toContain("req-42");
+  });
+
+  test("onRetry (banner) wires Retry button to callback", () => {
+    const error: FetchError = { message: "Upstream failed", status: 500 };
+    let retried = 0;
+    const { container } = render(
+      <MutationErrorSurface
+        error={error}
+        feature="SSO"
+        onRetry={() => {
+          retried++;
+        }}
+      />,
+    );
+    const button = Array.from(container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("Retry"),
+    );
+    expect(button).toBeDefined();
+    fireEvent.click(button!);
+    expect(retried).toBe(1);
+  });
+
+  test("inline variant renders InlineError styling + friendly message", () => {
+    const error: FetchError = { message: "Upstream failed", status: 500 };
+    const { container } = render(
+      <MutationErrorSurface error={error} feature="Billing" variant="inline" />,
+    );
+    const inline = container.querySelector(".bg-destructive\\/10");
+    expect(inline).not.toBeNull();
+    expect(inline!.textContent).toContain("Upstream failed");
+    // Inline variant must NOT render the `role="alert"` chrome — that's the
+    // ErrorBanner surface and would break the visual weight inside compact rows.
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  test("inline variant with prefix renders bold prefix before message", () => {
+    const error: FetchError = { message: "Upstream failed", status: 500 };
+    const { container } = render(
+      <MutationErrorSurface
+        error={error}
+        feature="Branding"
+        variant="inline"
+        inlinePrefix="Save failed."
+      />,
+    );
+    const bold = container.querySelector(".font-semibold");
+    expect(bold?.textContent).toBe("Save failed.");
+    expect(container.textContent).toContain("Upstream failed");
+  });
+
+  test("inline variant + enterprise_required renders compact inline upsell (not full EnterpriseUpsell)", () => {
+    const error: FetchError = {
+      message: "Enterprise required",
+      status: 403,
+      code: "enterprise_required",
+    };
+    const { container } = render(
+      <MutationErrorSurface error={error} feature="BYOT" variant="inline" />,
+    );
+    // Compact upsell still points at the enterprise page, so callers don't
+    // lose the routing win at inline sites — but it sits inside the
+    // InlineError chrome, not a full-page upsell card (no "Learn about Atlas
+    // Enterprise" button, no centered card).
+    const link = container.querySelector('a[href*="useatlas.dev/enterprise"]');
+    expect(link).not.toBeNull();
+    expect(container.textContent).toContain("BYOT");
+    expect(container.textContent).toContain("Enterprise");
+    // Inline chrome (not the centered card with the shield icon and button).
+    expect(container.querySelector(".bg-destructive\\/10")).not.toBeNull();
+    expect(
+      Array.from(container.querySelectorAll("button")).some((b) =>
+        b.textContent?.includes("Learn about Atlas Enterprise"),
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/web/src/ui/components/admin/mutation-error-surface.tsx
+++ b/packages/web/src/ui/components/admin/mutation-error-surface.tsx
@@ -57,6 +57,25 @@ export function MutationErrorSurface({
   onRetry,
   inlinePrefix,
 }: MutationErrorSurfaceProps) {
+  // Dev-only check for cross-variant prop misuse. The interface allows any
+  // combination (avoids the ergonomics cost of a discriminated union — see
+  // win #31), so `variant="inline"` silently drops `onRetry` and `variant="banner"`
+  // silently drops `inlinePrefix`. Tree-shaken in production builds via the
+  // NODE_ENV check; noisy in dev so the misuse surfaces during editing, not
+  // after a user-facing regression.
+  if (process.env.NODE_ENV !== "production") {
+    if (variant === "inline" && onRetry) {
+      console.warn(
+        "MutationErrorSurface: `onRetry` is banner-only; ignored on inline variant.",
+      );
+    }
+    if (variant === "banner" && inlinePrefix) {
+      console.warn(
+        "MutationErrorSurface: `inlinePrefix` is inline-only; ignored on banner variant.",
+      );
+    }
+  }
+
   if (!error) return null;
 
   const isEnterpriseRequired = error.code === "enterprise_required";

--- a/packages/web/src/ui/components/admin/mutation-error-surface.tsx
+++ b/packages/web/src/ui/components/admin/mutation-error-surface.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import {
+  EnterpriseUpsell,
+  FeatureGate,
+} from "@/ui/components/admin/feature-disabled";
+import { InlineError } from "@/ui/components/admin/compact";
+import { friendlyError, type FetchError } from "@/ui/lib/fetch-error";
+
+type Variant = "banner" | "inline";
+
+export interface MutationErrorSurfaceProps {
+  /** Structured error from `useAdminMutation().error`, or null to render nothing. */
+  error: FetchError | null;
+  /** Feature name used in EnterpriseUpsell / FeatureGate copy (e.g. "SSO", "SCIM"). */
+  feature: string;
+  /** Visual treatment — banner (default) mirrors ErrorBanner, inline mirrors InlineError. */
+  variant?: Variant;
+  /** Banner-only: wires the ErrorBanner retry button (usually a `clearError` callback). */
+  onRetry?: () => void;
+  /** Inline-only: bold prefix rendered before the message (e.g. "Save failed."). */
+  inlinePrefix?: string;
+}
+
+/**
+ * Write-path counterpart to `AdminContentWrapper`'s read-path feature-gate
+ * routing. Mutation errors carry the same `FetchError` shape from
+ * `useAdminMutation`, so a 403 + `code: "enterprise_required"` from POSTing
+ * `/api/v1/admin/sso/enforcement` deserves the same `EnterpriseUpsell` the
+ * GET would have triggered. Callers that previously wrote
+ * `<ErrorBanner message={friendlyError(mutation.error)} />` flattened the
+ * structured code into a string and lost the routing.
+ *
+ * Decision tree (banner variant — default):
+ * - `null` → nothing
+ * - `code === "enterprise_required"` → `EnterpriseUpsell` with server message
+ * - `status` in {401, 403, 404, 503} → `FeatureGate`
+ * - else → `ErrorBanner` with `friendlyError` copy
+ *
+ * Inline variant is for sites that can't host a full-page upsell (compact
+ * rows, dialog bodies):
+ * - `code === "enterprise_required"` → condensed `InlineError` with the
+ *   same enterprise link, preserving the routing win without breaking
+ *   the row's layout
+ * - else → `InlineError` with optional bold prefix + friendly message
+ *
+ * Inline variant doesn't route the other 401/403/404/503 statuses through
+ * `FeatureGate` — a full-page gate replacing a tiny inline error slot would
+ * be more disruptive than useful, and the page-level `AdminContentWrapper`
+ * already handles those on refresh.
+ */
+export function MutationErrorSurface({
+  error,
+  feature,
+  variant = "banner",
+  onRetry,
+  inlinePrefix,
+}: MutationErrorSurfaceProps) {
+  if (!error) return null;
+
+  const isEnterpriseRequired = error.code === "enterprise_required";
+
+  if (variant === "inline") {
+    if (isEnterpriseRequired) {
+      return (
+        <InlineError>
+          <span className="font-semibold">
+            {feature} requires Enterprise.
+          </span>{" "}
+          <a
+            href="https://www.useatlas.dev/enterprise"
+            target="_blank"
+            rel="noreferrer noopener"
+            className="underline underline-offset-2"
+          >
+            Learn more
+          </a>
+        </InlineError>
+      );
+    }
+    return (
+      <InlineError>
+        {inlinePrefix && (
+          <>
+            <span className="font-semibold">{inlinePrefix}</span>{" "}
+          </>
+        )}
+        {friendlyError(error)}
+      </InlineError>
+    );
+  }
+
+  if (isEnterpriseRequired) {
+    return <EnterpriseUpsell feature={feature} message={error.message} />;
+  }
+
+  if (error.status && [401, 403, 404, 503].includes(error.status)) {
+    return (
+      <FeatureGate
+        status={error.status as 401 | 403 | 404 | 503}
+        feature={feature}
+      />
+    );
+  }
+
+  return <ErrorBanner message={friendlyError(error)} onRetry={onRetry} />;
+}

--- a/packages/web/src/ui/components/admin/mutation-error-surface.tsx
+++ b/packages/web/src/ui/components/admin/mutation-error-surface.tsx
@@ -63,11 +63,17 @@ export function MutationErrorSurface({
 
   if (variant === "inline") {
     if (isEnterpriseRequired) {
+      // Pass `error.message` through when the server sent one. Banner variant
+      // gives it to `EnterpriseUpsell.message`; the inline variant has to
+      // render it inline or the server's context-specific copy ("Enterprise
+      // tier required on hosted plans — contact sales@…") is lost. The fixed
+      // headline + Learn more link still anchor the upsell affordance.
       return (
         <InlineError>
           <span className="font-semibold">
             {feature} requires Enterprise.
           </span>{" "}
+          {error.message && <>{error.message} </>}
           <a
             href="https://www.useatlas.dev/enterprise"
             target="_blank"


### PR DESCRIPTION
## Summary

- New `<MutationErrorSurface>` component in `@/ui/components/admin/` routes mutation `FetchError` through `EnterpriseUpsell` / `FeatureGate` / `ErrorBanner` / `InlineError` based on structured fields — write-path parity with `AdminContentWrapper`'s read-path decision tree.
- Two variants: `banner` (default) mirrors `AdminContentWrapper` exactly; `inline` is for compact rows / dialog bodies where a full-page upsell would break layout (condensed inline upsell on `enterprise_required`, `InlineError` with optional bold prefix otherwise).
- Migrates 5 highest-value pages called out in #1624: `/admin/sso`, `/admin/scim`, `/admin/branding`, `/admin/billing`, `/admin/ip-allowlist`. Phase-2 follow-up (#1649) tracks the remaining ~35 pages.
- Architecture wins #31 recorded in `.claude/research/architecture-wins.md`.

## Why this matters

Wins #29 / #30 preserved `FetchError` (code / status / requestId) across the `useAdminMutation` boundary. But the render boundary still flattened it: `<ErrorBanner message={friendlyError(mutation.error)} />` drops the `code` field before `AdminContentWrapper.isEnterpriseRequired()` can see it. Result: a non-EE admin clicking "Enforce SSO" on a gated workspace saw "Access denied. Admin role required." instead of the `EnterpriseUpsell` with the upgrade CTA. Same silent-failure class as #1595, one layer deeper in the stack.

`<MutationErrorSurface>` moves the decision tree out of `AdminContentWrapper` into a dedicated component so the write path doesn't have to thread its errors back through the fetch-oriented wrapper API.

## Decision tree

**Banner variant (default):**
| Input | Output |
|-------|--------|
| `null` | nothing |
| `code === "enterprise_required"` | `<EnterpriseUpsell feature={...} message={error.message} />` |
| `status` in {401, 403, 404, 503} | `<FeatureGate status={...} feature={...} />` |
| anything else | `<ErrorBanner message={friendlyError(error)} onRetry={onRetry} />` |

**Inline variant** (`variant="inline"`):
| Input | Output |
|-------|--------|
| `null` | nothing |
| `code === "enterprise_required"` | Condensed `<InlineError>` with enterprise link ("… requires Enterprise. Learn more →") |
| anything else | `<InlineError>` with optional bold prefix + `friendlyError(error)` |

Inline variant deliberately does **not** route 401/403/404/503 to `<FeatureGate>` — a full-page gate replacing a tiny row-level error slot would be more disruptive than useful, and the page-level `AdminContentWrapper` still handles those on refresh.

## Phase 1 migrations

- **`/admin/sso`** — 3 page-level `ErrorBanner` sites (enforcement, toggle, verify) + 1 in the enforce-confirmation dialog. Banner variant.
- **`/admin/scim`** — 1 page-level `ErrorBanner`. Per-row `InlineError` with last-wins row-pin tracking stays as-is (different concern, deferred to #1649).
- **`/admin/branding`** — 2 `InlineError` sites (save, reset). Inline variant with `"Save failed."` / `"Reset failed."` bold prefix.
- **`/admin/billing`** — 2 `InlineError` sites (`ModelRow`, `ByotRow`). Inline variant. `PlanShell.combinedError` deliberately skipped — blends mutation error with local `portalError` state; phase 2.
- **`/admin/ip-allowlist`** — inline `div` in delete dialog → inline variant.

## Test coverage

`packages/web/src/ui/components/admin/__tests__/mutation-error-surface.test.tsx` — 10 tests, full branch coverage:
- `null` error → nothing
- `enterprise_required` (banner) → `EnterpriseUpsell` with server message + enterprise link, no `role="alert"`
- Each of 401 / 403 / 404 / 503 → `FeatureGate` copy
- Plain error (banner) → `ErrorBanner` with friendlyError message + requestId
- `onRetry` → wired to Retry button
- Inline variant → `InlineError` chrome, no `role="alert"`
- Inline variant + prefix → bold prefix before message
- Inline variant + `enterprise_required` → compact inline upsell (enterprise link present, full `EnterpriseUpsell` button absent — guards the variant separation)

## Architecture win

`.claude/research/architecture-wins.md` gets win #31 — render-boundary completion of the structured-error migration line (#29 → #30 → #31). Each win moves the invariant one step further through the stack: hook result → hook state → render output.

## Test plan

- [x] Component tests — 10 / 10 pass
- [x] `bun run lint` — zero output
- [x] `bun run type` — zero errors
- [x] `bun run test` — all 57 web test files pass isolated (`bun scripts/test-isolated.ts src/ui/`)
- [x] `bun x syncpack lint` — No issues found
- [x] Template drift — passed
- [x] Phase-2 follow-up issue filed (#1649) with enumerated remaining call sites

## Scope choices worth calling out

- **Inline variant intentionally opts out of `FeatureGate` routing** for non-enterprise 401/403/404/503 statuses. Mentioned above and documented in the component docstring.
- **SCIM row-pin and `/admin/billing` `PlanShell.combinedError` deferred to #1649** — these blend mutation errors with local-synthesized state, so the migration needs a pattern that combines both (not just swap `ErrorBanner` for `MutationErrorSurface`).
- **`className` prop intentionally omitted** on `MutationErrorSurface` — callers can wrap with their own layout container (current SSO pattern `<div className="mb-4"><MutationErrorSurface ... /></div>` stays).

Closes phase 1 of #1624. Phase 2: #1649.