### PR TITLE
test(web/admin/sessions): e2e smoke + shortUA + SessionsListSchema round-trip

### DIFF
--- a/e2e/browser/admin-sessions.spec.ts
+++ b/e2e/browser/admin-sessions.spec.ts
@@ -72,11 +72,23 @@ function buildFixture(): MockSession[] {
 interface MockOptions {
   /** Session ids for which DELETE should return 500 (partial-failure tests). */
   failDeleteIds?: Set<string>;
+  /** Milliseconds to sleep before fulfilling DELETE (disabled-button test). */
+  deleteDelayMs?: number;
 }
 
 /**
  * Install mocks for the three endpoints the sessions page hits. Returns
  * the mutable session map so the test can assert on remaining state.
+ *
+ * Scope limits deliberately kept narrow:
+ *  - The list handler returns the full fixture regardless of `?search=`,
+ *    `?limit=`, or `?offset=`. This spec never exercises search or
+ *    pagination; a future spec that does should either extend this mock
+ *    or build a new one that honors the query string.
+ *  - Non-DELETE on the id path and non-GET on the list path `route.abort`
+ *    rather than `route.fallback()` — falling back would hit the real
+ *    network in CI, which could mask a regression that starts issuing
+ *    unexpected requests by silently succeeding against a real admin API.
  */
 async function installSessionMocks(
   page: Page,
@@ -86,6 +98,7 @@ async function installSessionMocks(
     buildFixture().map((s) => [s.id, s]),
   );
   const failDeleteIds = opts.failDeleteIds ?? new Set<string>();
+  const deleteDelayMs = opts.deleteDelayMs ?? 0;
 
   await page.route(/\/api\/v1\/admin\/sessions\/stats(?:\?|$)/, async (route: Route) => {
     await route.fulfill({
@@ -102,15 +115,17 @@ async function installSessionMocks(
   await page.route(/\/api\/v1\/admin\/sessions\/[^/?]+(?:\?|$)/, async (route: Route) => {
     const req = route.request();
     if (req.method() !== "DELETE") {
-      // Anything that isn't a DELETE to an id path (e.g. a future GET)
-      // should fall through to the real network — the mock isn't trying
-      // to be exhaustive.
-      await route.fallback();
+      // Abort (not fallback) so an unexpected method is a loud failure
+      // in CI, not a silent real-network passthrough.
+      await route.abort("failed");
       return;
     }
     const url = new URL(req.url());
     // path is `/api/v1/admin/sessions/<id>` — take the last segment.
     const id = url.pathname.split("/").pop()!;
+    if (deleteDelayMs > 0) {
+      await new Promise<void>((r) => setTimeout(r, deleteDelayMs));
+    }
     if (failDeleteIds.has(id)) {
       await route.fulfill({
         status: 500,
@@ -140,7 +155,7 @@ async function installSessionMocks(
   await page.route(/\/api\/v1\/admin\/sessions(?:\?[^/]*)?$/, async (route: Route) => {
     const req = route.request();
     if (req.method() !== "GET") {
-      await route.fallback();
+      await route.abort("failed");
       return;
     }
     const sessions = [...state.values()].sort(
@@ -261,6 +276,65 @@ test.describe("Admin sessions revoke flow", () => {
     expect(state.has("sess_alice")).toBe(false);
     expect(state.has("sess_bob")).toBe(false);
     expect(state.has("sess_carol")).toBe(true);
+  });
+
+  test("row Revoke button is disabled while the mutation is in flight", async ({ page }) => {
+    // Delay the DELETE response so the disabled state is observable
+    // between the dialog closing and the refetch removing the row.
+    // The page wires `disabled={revoking}` to `isMutating(sessionId)` —
+    // a regression in the `useAdminMutation` per-item tracking would
+    // otherwise go silent.
+    await installSessionMocks(page, { deleteDelayMs: 800 });
+    await page.goto("/admin/sessions");
+    const aliceRow = page.getByRole("row").filter({ hasText: "alice.e2e@useatlas.dev" });
+    await expect(aliceRow).toBeVisible({ timeout: 15_000 });
+
+    const rowRevoke = aliceRow.getByRole("button", { name: "Revoke" });
+    await expect(rowRevoke).toBeEnabled();
+    await rowRevoke.click();
+    await page
+      .getByRole("alertdialog")
+      .getByRole("button", { name: "Revoke" })
+      .click();
+
+    // Dialog closes immediately; row is still visible during the 800ms
+    // mock delay. Button should flip to disabled until the DELETE
+    // resolves and the refetch removes the row.
+    await expect(rowRevoke).toBeDisabled({ timeout: 2_000 });
+    await expect(aliceRow).toHaveCount(0, { timeout: 5_000 });
+  });
+
+  test("single-row revoke failure renders the error banner", async ({ page }) => {
+    // The `revokeError` banner path (page.tsx: `revokeError && !bulkError`)
+    // was not covered by the bulk tests. A 500 on the single-row revoke
+    // must populate the hook's `error` slot and render `<ErrorBanner />`
+    // with the friendlyError message — regressions to either the
+    // `!bulkError` guard or the hook's error wiring would go silent
+    // otherwise.
+    const state = await installSessionMocks(page, {
+      failDeleteIds: new Set(["sess_alice"]),
+    });
+    await page.goto("/admin/sessions");
+    const aliceRow = page.getByRole("row").filter({ hasText: "alice.e2e@useatlas.dev" });
+    await expect(aliceRow).toBeVisible({ timeout: 15_000 });
+
+    await aliceRow.getByRole("button", { name: "Revoke" }).click();
+    await page
+      .getByRole("alertdialog")
+      .getByRole("button", { name: "Revoke" })
+      .click();
+
+    // friendlyError passes the server message through verbatim for
+    // non-mapped statuses (500 is not 401/403/404/503) and appends the
+    // request id. Assert on the banner's role + the server message so
+    // the test doesn't over-pin the exact formatting.
+    const banner = page.getByRole("alert").filter({ hasText: /Internal server error/ });
+    await expect(banner).toBeVisible({ timeout: 10_000 });
+    await expect(banner).toContainText(/Request ID: req_mock_sess_alice/);
+
+    // Row survives — failure must not remove it from the table.
+    await expect(aliceRow).toBeVisible();
+    expect(state.has("sess_alice")).toBe(true);
   });
 
   test("bulk revoke partial failure shows banner and keeps failed row selected", async ({

--- a/e2e/browser/admin-sessions.spec.ts
+++ b/e2e/browser/admin-sessions.spec.ts
@@ -131,7 +131,13 @@ async function installSessionMocks(
     });
   });
 
-  await page.route(/\/api\/v1\/admin\/sessions(?:\?|$)/, async (route: Route) => {
+  // Anchor the list-path regex to end-of-path-or-query so future relaxation
+  // of the pattern can't accidentally shadow `/stats` or `/<id>` handlers
+  // registered above. Playwright evaluates handlers in reverse-registration
+  // order, so without the anchor a broadened match here would silently
+  // intercept the more specific routes (code review flagged this as a
+  // drift hazard).
+  await page.route(/\/api\/v1\/admin\/sessions(?:\?[^/]*)?$/, async (route: Route) => {
     const req = route.request();
     if (req.method() !== "GET") {
       await route.fallback();

--- a/e2e/browser/admin-sessions.spec.ts
+++ b/e2e/browser/admin-sessions.spec.ts
@@ -1,0 +1,299 @@
+import { test, expect, type Page, type Route } from "@playwright/test";
+
+/**
+ * Admin sessions — first bucket-2 e2e (issue #1631, follow-up to PR #1628).
+ *
+ * Exercises the confirm-before-revoke dialog, single + bulk revoke, and
+ * the partial-failure banner + failed-row-stays-selected behavior.
+ *
+ * Design note: the spec mocks `/api/v1/admin/sessions*` at the page level
+ * instead of seeding real DB rows. Two reasons.
+ *   1. The persistent admin login used by `global-setup.ts` is itself a
+ *      session row — a test that revoked the wrong row would log the rest
+ *      of the suite out and cascade-fail.
+ *   2. Partial-failure coverage needs a deterministic 500 from the server
+ *      for a specific session id, which is impossible to force against a
+ *      healthy API without plumbing a fault-injection switch.
+ *
+ * The mocks mutate a local map on DELETE so subsequent GETs see the
+ * removals — the UI's `useAdminMutation` invalidates admin-fetch queries
+ * on success, so we need the mock to behave like a real server across the
+ * invalidation boundary. No `@llm` tag — no model calls.
+ */
+
+interface MockSession {
+  id: string;
+  userId: string;
+  userEmail: string;
+  createdAt: string;
+  updatedAt: string;
+  expiresAt: string;
+  ipAddress: string;
+  userAgent: string;
+}
+
+function buildFixture(): MockSession[] {
+  // Keep `updatedAt` strictly descending — the page's default sort is
+  // `updatedAt desc`, so row ordering in the DOM matches this array.
+  return [
+    {
+      id: "sess_alice",
+      userId: "user_alice",
+      userEmail: "alice.e2e@useatlas.dev",
+      createdAt: "2026-04-18T09:00:00.000Z",
+      updatedAt: "2026-04-19T12:00:00.000Z",
+      expiresAt: "2026-04-26T09:00:00.000Z",
+      ipAddress: "10.0.0.11",
+      userAgent: "Mozilla/5.0 (X11; Linux x86_64) Chrome/120.0.0.0 Safari/537.36",
+    },
+    {
+      id: "sess_bob",
+      userId: "user_bob",
+      userEmail: "bob.e2e@useatlas.dev",
+      createdAt: "2026-04-18T10:00:00.000Z",
+      updatedAt: "2026-04-19T11:00:00.000Z",
+      expiresAt: "2026-04-26T10:00:00.000Z",
+      ipAddress: "10.0.0.12",
+      userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Firefox/123.0",
+    },
+    {
+      id: "sess_carol",
+      userId: "user_carol",
+      userEmail: "carol.e2e@useatlas.dev",
+      createdAt: "2026-04-18T11:00:00.000Z",
+      updatedAt: "2026-04-19T10:00:00.000Z",
+      expiresAt: "2026-04-26T11:00:00.000Z",
+      ipAddress: "10.0.0.13",
+      userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Edge/120.0.0.0",
+    },
+  ];
+}
+
+interface MockOptions {
+  /** Session ids for which DELETE should return 500 (partial-failure tests). */
+  failDeleteIds?: Set<string>;
+}
+
+/**
+ * Install mocks for the three endpoints the sessions page hits. Returns
+ * the mutable session map so the test can assert on remaining state.
+ */
+async function installSessionMocks(
+  page: Page,
+  opts: MockOptions = {},
+): Promise<Map<string, MockSession>> {
+  const state = new Map<string, MockSession>(
+    buildFixture().map((s) => [s.id, s]),
+  );
+  const failDeleteIds = opts.failDeleteIds ?? new Set<string>();
+
+  await page.route(/\/api\/v1\/admin\/sessions\/stats(?:\?|$)/, async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        total: state.size,
+        active: state.size,
+        uniqueUsers: new Set([...state.values()].map((s) => s.userId)).size,
+      }),
+    });
+  });
+
+  await page.route(/\/api\/v1\/admin\/sessions\/[^/?]+(?:\?|$)/, async (route: Route) => {
+    const req = route.request();
+    if (req.method() !== "DELETE") {
+      // Anything that isn't a DELETE to an id path (e.g. a future GET)
+      // should fall through to the real network — the mock isn't trying
+      // to be exhaustive.
+      await route.fallback();
+      return;
+    }
+    const url = new URL(req.url());
+    // path is `/api/v1/admin/sessions/<id>` — take the last segment.
+    const id = url.pathname.split("/").pop()!;
+    if (failDeleteIds.has(id)) {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: "internal",
+          message: "Internal server error",
+          requestId: `req_mock_${id}`,
+        }),
+      });
+      return;
+    }
+    state.delete(id);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ success: true }),
+    });
+  });
+
+  await page.route(/\/api\/v1\/admin\/sessions(?:\?|$)/, async (route: Route) => {
+    const req = route.request();
+    if (req.method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    const sessions = [...state.values()].sort(
+      (a, b) => (a.updatedAt < b.updatedAt ? 1 : -1),
+    );
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        sessions,
+        total: sessions.length,
+        limit: 50,
+        offset: 0,
+      }),
+    });
+  });
+
+  return state;
+}
+
+test.describe("Admin sessions revoke flow", () => {
+  test.describe.configure({ timeout: 45_000 });
+
+  test("page loads with stats strip and seeded rows", async ({ page }) => {
+    const state = await installSessionMocks(page);
+    await page.goto("/admin/sessions");
+
+    await expect(
+      page.locator("h1", { hasText: "Sessions" }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Stats strip — three cards rendered from GET /stats
+    await expect(page.getByText("Total Sessions", { exact: true })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByText("Active Sessions", { exact: true })).toBeVisible();
+    await expect(page.getByText("Unique Users", { exact: true })).toBeVisible();
+
+    // Rows render with seeded emails
+    for (const session of state.values()) {
+      await expect(page.getByRole("cell", { name: session.userEmail })).toBeVisible({
+        timeout: 10_000,
+      });
+    }
+  });
+
+  test("cancel leaves the session intact", async ({ page }) => {
+    const state = await installSessionMocks(page);
+    await page.goto("/admin/sessions");
+    await expect(page.getByRole("cell", { name: "alice.e2e@useatlas.dev" })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const aliceRow = page.getByRole("row").filter({ hasText: "alice.e2e@useatlas.dev" });
+    await aliceRow.getByRole("button", { name: "Revoke" }).click();
+
+    await expect(
+      page.getByRole("alertdialog").getByText("Revoke session?"),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Cancel" }).click();
+
+    // Row still present, mock state untouched.
+    await expect(aliceRow).toBeVisible();
+    expect(state.has("sess_alice")).toBe(true);
+  });
+
+  test("confirm removes the row from the table", async ({ page }) => {
+    const state = await installSessionMocks(page);
+    await page.goto("/admin/sessions");
+    const aliceRow = page.getByRole("row").filter({ hasText: "alice.e2e@useatlas.dev" });
+    await expect(aliceRow).toBeVisible({ timeout: 15_000 });
+
+    await aliceRow.getByRole("button", { name: "Revoke" }).click();
+    await expect(page.getByRole("alertdialog")).toBeVisible();
+
+    // The AlertDialog's action button is also labeled "Revoke"; scope the
+    // click to the dialog so Playwright doesn't match the row button.
+    await page
+      .getByRole("alertdialog")
+      .getByRole("button", { name: "Revoke" })
+      .click();
+
+    await expect(aliceRow).toHaveCount(0, { timeout: 10_000 });
+    // Other rows remain
+    await expect(
+      page.getByRole("cell", { name: "bob.e2e@useatlas.dev" }),
+    ).toBeVisible();
+    expect(state.has("sess_alice")).toBe(false);
+    expect(state.has("sess_bob")).toBe(true);
+  });
+
+  test("bulk revoke removes every selected row", async ({ page }) => {
+    const state = await installSessionMocks(page);
+    await page.goto("/admin/sessions");
+    await expect(
+      page.getByRole("cell", { name: "alice.e2e@useatlas.dev" }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const aliceRow = page.getByRole("row").filter({ hasText: "alice.e2e@useatlas.dev" });
+    const bobRow = page.getByRole("row").filter({ hasText: "bob.e2e@useatlas.dev" });
+    await aliceRow.getByRole("checkbox", { name: "Select row" }).check();
+    await bobRow.getByRole("checkbox", { name: "Select row" }).check();
+
+    const bulkButton = page.getByRole("button", { name: /Revoke 2 selected/ });
+    await expect(bulkButton).toBeEnabled();
+    await bulkButton.click();
+
+    const dialog = page.getByRole("alertdialog");
+    await expect(dialog.getByText(/Revoke 2 session\(s\)\?/)).toBeVisible();
+    await dialog.getByRole("button", { name: "Revoke" }).click();
+
+    await expect(aliceRow).toHaveCount(0, { timeout: 10_000 });
+    await expect(bobRow).toHaveCount(0);
+    // Carol survives
+    await expect(
+      page.getByRole("cell", { name: "carol.e2e@useatlas.dev" }),
+    ).toBeVisible();
+    expect(state.has("sess_alice")).toBe(false);
+    expect(state.has("sess_bob")).toBe(false);
+    expect(state.has("sess_carol")).toBe(true);
+  });
+
+  test("bulk revoke partial failure shows banner and keeps failed row selected", async ({
+    page,
+  }) => {
+    const state = await installSessionMocks(page, {
+      failDeleteIds: new Set(["sess_alice"]),
+    });
+    await page.goto("/admin/sessions");
+    await expect(
+      page.getByRole("cell", { name: "alice.e2e@useatlas.dev" }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const aliceRow = page.getByRole("row").filter({ hasText: "alice.e2e@useatlas.dev" });
+    const bobRow = page.getByRole("row").filter({ hasText: "bob.e2e@useatlas.dev" });
+    await aliceRow.getByRole("checkbox", { name: "Select row" }).check();
+    await bobRow.getByRole("checkbox", { name: "Select row" }).check();
+
+    await page.getByRole("button", { name: /Revoke 2 selected/ }).click();
+    await page
+      .getByRole("alertdialog")
+      .getByRole("button", { name: "Revoke" })
+      .click();
+
+    // Banner shape from `bulkFailureSummary(results, selected, "revocations")`:
+    // "1 of 2 revocations failed: ..."
+    await expect(page.getByText(/1 of 2 revocations failed:/)).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Bob's revoke succeeded; Alice's failed row remains in the table and
+    // the bulk header now shows a single-selected count so the operator
+    // can retry with one click.
+    await expect(bobRow).toHaveCount(0, { timeout: 10_000 });
+    await expect(aliceRow).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Revoke 1 selected/ }),
+    ).toBeVisible();
+    expect(state.has("sess_alice")).toBe(true);
+    expect(state.has("sess_bob")).toBe(false);
+  });
+});

--- a/packages/web/src/app/admin/sessions/__tests__/columns.test.ts
+++ b/packages/web/src/app/admin/sessions/__tests__/columns.test.ts
@@ -6,13 +6,25 @@ describe("shortUA", () => {
     expect(shortUA(null)).toBe("—");
   });
 
+  test("empty string also returns the em-dash placeholder", () => {
+    // The helper uses `if (!ua)` — not a typeof/null check — so the
+    // falsy-coalesce path handles both `null` and `""`. Pinned so a
+    // refactor to a strict null check (which would render "" verbatim)
+    // would be caught.
+    expect(shortUA("")).toBe("—");
+  });
+
   test("browser match returns the Chrome/version segment only", () => {
     const ua =
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
       "(KHTML, like Gecko) Chrome/120.0.6099.129 Safari/537.36";
-    // The regex is greedy on the first browser alternation, so Chrome wins
-    // over Safari when both are present — the test pins that behavior so a
-    // refactor that reorders the alternation would be caught.
+    // When multiple browser tokens appear in the UA, the leftmost match
+    // in the input string wins — JS regex scans left-to-right and returns
+    // the first position where any alternative matches. Chrome appears
+    // before Safari in real Chromium UAs, which is what this fixture
+    // pins. A refactor that swapped the order of tokens in the input
+    // (not a reordering of the regex alternation) would change the
+    // match target, which is the actual contract worth guarding.
     expect(shortUA(ua)).toBe("Chrome/120.0.6099.129");
   });
 

--- a/packages/web/src/app/admin/sessions/__tests__/columns.test.ts
+++ b/packages/web/src/app/admin/sessions/__tests__/columns.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { shortUA } from "../columns";
+
+describe("shortUA", () => {
+  test("null input returns em-dash placeholder", () => {
+    expect(shortUA(null)).toBe("—");
+  });
+
+  test("browser match returns the Chrome/version segment only", () => {
+    const ua =
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+      "(KHTML, like Gecko) Chrome/120.0.6099.129 Safari/537.36";
+    // The regex is greedy on the first browser alternation, so Chrome wins
+    // over Safari when both are present — the test pins that behavior so a
+    // refactor that reorders the alternation would be caught.
+    expect(shortUA(ua)).toBe("Chrome/120.0.6099.129");
+  });
+
+  test("long unrecognized UA is truncated to 50 chars + ellipsis", () => {
+    const ua = "MegaCorpCrawler/1.0 (+https://example.com/bot/policy/v2/details)";
+    expect(ua.length).toBeGreaterThan(50);
+    const out = shortUA(ua);
+    expect(out.endsWith("…")).toBe(true);
+    expect(out).toBe(ua.slice(0, 50) + "…");
+  });
+
+  test("short unrecognized UA is returned verbatim", () => {
+    const ua = "curl/8.0.1";
+    expect(ua.length).toBeLessThanOrEqual(50);
+    expect(shortUA(ua)).toBe(ua);
+  });
+
+  test("bot/CLI with no browser match falls through to full UA", () => {
+    // No "Chrome|Firefox|Safari|Edge|Opera|Brave" → regex miss. Length is
+    // under 50 → passthrough. Guards the fallthrough branch from silently
+    // becoming a forced truncation.
+    const ua = "Googlebot/2.1 (+http://www.google.com/bot.html)";
+    expect(shortUA(ua)).toBe(ua);
+  });
+});

--- a/packages/web/src/app/admin/sessions/__tests__/sessions-schema.test.ts
+++ b/packages/web/src/app/admin/sessions/__tests__/sessions-schema.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test";
+import { SessionsListSchema } from "@/ui/lib/admin-schemas";
+
+/**
+ * Round-trip test for the production parse path in `/admin/sessions`.
+ * Guards against silent API drift — page.tsx feeds every `useAdminFetch`
+ * response through this schema, so a shape change here is a behavior
+ * change for the page.
+ */
+describe("SessionsListSchema round-trip", () => {
+  const FIXTURE = {
+    sessions: [
+      {
+        id: "sess_abc123",
+        userId: "user_admin",
+        userEmail: "admin@useatlas.dev",
+        createdAt: "2026-04-18T14:30:00.000Z",
+        updatedAt: "2026-04-19T09:15:00.000Z",
+        expiresAt: "2026-04-25T14:30:00.000Z",
+        ipAddress: "10.0.0.1",
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36",
+      },
+      {
+        id: "sess_def456",
+        userId: "user_bob",
+        userEmail: null,
+        createdAt: "2026-04-19T10:00:00.000Z",
+        updatedAt: "2026-04-19T10:00:00.000Z",
+        expiresAt: "2026-04-26T10:00:00.000Z",
+        ipAddress: null,
+        userAgent: null,
+      },
+    ],
+    total: 2,
+  };
+
+  test("parses a realistic API response", () => {
+    const parsed = SessionsListSchema.parse(FIXTURE);
+    expect(parsed.sessions).toHaveLength(2);
+    expect(parsed.total).toBe(2);
+    expect(parsed.sessions[0]!.id).toBe("sess_abc123");
+    expect(parsed.sessions[0]!.userId).toBe("user_admin");
+    expect(parsed.sessions[0]!.userEmail).toBe("admin@useatlas.dev");
+  });
+
+  test("ipAddress is string | null (drift guard)", () => {
+    // The admin page renders `row.getValue<string | null>("ipAddress") ?? "—"`.
+    // If the schema flipped to `.optional()` (i.e. string | undefined), the
+    // API could omit the key entirely without a parse error and the page
+    // column would suddenly receive `undefined` in a production payload.
+    // These two assertions pin the accepted shape.
+    expect(
+      SessionsListSchema.parse({
+        sessions: [{ ...FIXTURE.sessions[0], ipAddress: null }],
+        total: 1,
+      }).sessions[0]!.ipAddress,
+    ).toBeNull();
+
+    expect(
+      SessionsListSchema.safeParse({
+        sessions: [
+          {
+            ...FIXTURE.sessions[0],
+            ipAddress: undefined, // key present but undefined — shape drift
+          },
+        ],
+        total: 1,
+      }).success,
+    ).toBe(false);
+
+    expect(
+      SessionsListSchema.safeParse({
+        sessions: [
+          (() => {
+            // Key omitted entirely — also shape drift.
+            const { ipAddress: _omit, ...rest } = FIXTURE.sessions[0]!;
+            return rest;
+          })(),
+        ],
+        total: 1,
+      }).success,
+    ).toBe(false);
+  });
+
+  test("userAgent is string | null — null, string, and omission behave the same as ipAddress", () => {
+    expect(
+      SessionsListSchema.parse({
+        sessions: [{ ...FIXTURE.sessions[0], userAgent: "curl/8.0" }],
+        total: 1,
+      }).sessions[0]!.userAgent,
+    ).toBe("curl/8.0");
+
+    expect(
+      SessionsListSchema.parse({
+        sessions: [{ ...FIXTURE.sessions[0], userAgent: null }],
+        total: 1,
+      }).sessions[0]!.userAgent,
+    ).toBeNull();
+
+    expect(
+      SessionsListSchema.safeParse({
+        sessions: [
+          (() => {
+            const { userAgent: _omit, ...rest } = FIXTURE.sessions[0]!;
+            return rest;
+          })(),
+        ],
+        total: 1,
+      }).success,
+    ).toBe(false);
+  });
+
+  test("timestamps are required ISO strings", () => {
+    const parsed = SessionsListSchema.parse(FIXTURE);
+    // The schema keeps them as opaque strings (no z.string().datetime())
+    // because Postgres emits ISO already and the page only passes them
+    // to RelativeTimestamp, which does its own parsing. Pin both the
+    // presence and the passthrough so a future add of `.datetime()` is
+    // a deliberate tightening, not an accident.
+    expect(parsed.sessions[0]!.createdAt).toBe("2026-04-18T14:30:00.000Z");
+    expect(parsed.sessions[0]!.updatedAt).toBe("2026-04-19T09:15:00.000Z");
+    expect(parsed.sessions[0]!.expiresAt).toBe("2026-04-25T14:30:00.000Z");
+
+    // Missing any of the three timestamps is a parse error.
+    for (const field of ["createdAt", "updatedAt", "expiresAt"] as const) {
+      const { [field]: _omit, ...rest } = FIXTURE.sessions[0]!;
+      const res = SessionsListSchema.safeParse({
+        sessions: [rest],
+        total: 1,
+      });
+      expect(res.success).toBe(false);
+    }
+  });
+
+  test("pagination: offset/limit shape — `total: number`, no cursor field", () => {
+    // The admin/sessions endpoint uses offset/limit pagination and returns
+    // `total`. There is deliberately no `nextCursor` in the client schema;
+    // if the API ever adds one, a parse of a payload with that extra field
+    // must still succeed (z.object() strips unknown keys by default) while
+    // missing `total` must fail. Both halves of that contract are asserted.
+    const withExtra = SessionsListSchema.parse({ ...FIXTURE, nextCursor: "abc" });
+    expect(withExtra.total).toBe(2);
+    expect((withExtra as unknown as { nextCursor?: unknown }).nextCursor).toBeUndefined();
+
+    const { total: _omit, ...noTotal } = FIXTURE;
+    expect(SessionsListSchema.safeParse(noTotal).success).toBe(false);
+  });
+
+  test("rejects when `sessions` is missing", () => {
+    const { sessions: _omit, ...noSessions } = FIXTURE;
+    expect(SessionsListSchema.safeParse(noSessions).success).toBe(false);
+  });
+});

--- a/packages/web/src/app/admin/sessions/columns.tsx
+++ b/packages/web/src/app/admin/sessions/columns.tsx
@@ -17,26 +17,26 @@ import {
 } from "@/components/ui/alert-dialog";
 import { RelativeTimestamp } from "@/ui/components/admin/queue";
 import { Clock, User, Globe, Monitor, Trash2 } from "lucide-react";
+import type { SessionRow } from "@/ui/lib/admin-schemas";
 
 // ── Types ─────────────────────────────────────────────────────────
 
-export interface SessionRow {
-  id: string;
-  userId: string;
-  userEmail: string | null;
-  createdAt: string;
-  updatedAt: string;
-  expiresAt: string;
-  ipAddress: string | null;
-  userAgent: string | null;
-}
+// `SessionRow` is re-exported here so consumers can keep importing it from
+// the colocated columns module even though admin-schemas.ts owns the
+// authoritative shape (inferred from `SessionRowSchema`).
+export type { SessionRow };
 
 // ── Helpers ───────────────────────────────────────────────────────
 
 /**
  * Extract a short browser/OS label from a full user-agent string.
- * Exported for unit testing — five branches: null, browser match,
- * long UA (truncated), short UA (passthrough), unrecognized (passthrough).
+ * Exported for unit testing.
+ *
+ * Cases (pinned by `__tests__/columns.test.ts`):
+ *  - null / empty → em-dash placeholder
+ *  - browser-regex match → `Name/version` (leftmost match in UA string wins)
+ *  - long unrecognized (>50 chars) → 50-char prefix + ellipsis
+ *  - short unrecognized (≤50 chars) → passthrough
  */
 export function shortUA(ua: string | null): string {
   if (!ua) return "—";

--- a/packages/web/src/app/admin/sessions/columns.tsx
+++ b/packages/web/src/app/admin/sessions/columns.tsx
@@ -33,8 +33,12 @@ export interface SessionRow {
 
 // ── Helpers ───────────────────────────────────────────────────────
 
-/** Extract a short browser/OS label from a full user-agent string. */
-function shortUA(ua: string | null): string {
+/**
+ * Extract a short browser/OS label from a full user-agent string.
+ * Exported for unit testing — five branches: null, browser match,
+ * long UA (truncated), short UA (passthrough), unrecognized (passthrough).
+ */
+export function shortUA(ua: string | null): string {
   if (!ua) return "—";
   // Try to extract browser name + version
   const match = ua.match(/(Chrome|Firefox|Safari|Edge|Opera|Brave)\/[\d.]+/);

--- a/packages/web/src/app/admin/sessions/page.tsx
+++ b/packages/web/src/app/admin/sessions/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useQueryStates, useQueryState, parseAsInteger } from "nuqs";
-import { z } from "zod";
 import { sessionsSearchParams } from "./search-params";
 import { getSessionColumns, type SessionActions } from "./columns";
 import { DataTable } from "@/components/data-table/data-table";
@@ -19,7 +18,7 @@ import { useState } from "react";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { friendlyError } from "@/ui/lib/fetch-error";
-import { SessionStatsSchema } from "@/ui/lib/admin-schemas";
+import { SessionStatsSchema, SessionsListSchema } from "@/ui/lib/admin-schemas";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { bulkFailureSummary, failedIdsFrom } from "@/ui/components/admin/queue";
 import {
@@ -35,22 +34,6 @@ import {
 } from "@/components/ui/alert-dialog";
 
 const LIMIT = 50;
-
-const SessionRowSchema = z.object({
-  id: z.string(),
-  userId: z.string(),
-  userEmail: z.string().nullable(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
-  expiresAt: z.string(),
-  ipAddress: z.string().nullable(),
-  userAgent: z.string().nullable(),
-});
-
-const SessionsListSchema = z.object({
-  sessions: z.array(SessionRowSchema),
-  total: z.number(),
-});
 
 export default function SessionsPage() {
   const [params, setParams] = useQueryStates(sessionsSearchParams);

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -592,6 +592,14 @@ export const SessionsListSchema = z.object({
   total: z.number(),
 });
 
+/**
+ * Authoritative TypeScript shape for one admin session row. Inferred from
+ * the schema so the Zod parse at `useAdminFetch` time is the single source
+ * of truth — columns.tsx re-exports this for its `ColumnDef<SessionRow>`
+ * generic, and the inference guarantees the two stay in lockstep.
+ */
+export type SessionRow = z.infer<typeof SessionRowSchema>;
+
 // ── Token Usage ──────────────────────────────────────────────────
 
 export const TokenSummarySchema = z.object({

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -569,6 +569,29 @@ export const SessionStatsSchema = z.object({
   uniqueUsers: z.number(),
 });
 
+/**
+ * One row in the admin sessions list. `ipAddress` and `userAgent` are
+ * `.nullable()` (not `.optional()`) on purpose — the API always emits
+ * these keys with an explicit `null` when the value is unknown. The
+ * sessions-schema round-trip test guards this distinction so we notice
+ * if the API ever drifts from `string | null` to `string | undefined`.
+ */
+export const SessionRowSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  userEmail: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  expiresAt: z.string(),
+  ipAddress: z.string().nullable(),
+  userAgent: z.string().nullable(),
+});
+
+export const SessionsListSchema = z.object({
+  sessions: z.array(SessionRowSchema),
+  total: z.number(),
+});
+
 // ── Token Usage ──────────────────────────────────────────────────
 
 export const TokenSummarySchema = z.object({


### PR DESCRIPTION
## Summary

Closes #1631 — the three test-coverage gaps called out by pr-test-analyzer on PR #1628 (admin sessions AlertDialog polish). All three are small and additive; the only production change is making `shortUA` a named export and relocating `SessionRowSchema` / `SessionsListSchema` from `page.tsx` into `@/ui/lib/admin-schemas` next to the existing `SessionStatsSchema` so the round-trip test mirrors the production parse path.

### Added

- **`e2e/browser/admin-sessions.spec.ts`** — first bucket-2 e2e. Covers: page load + stats strip, cancel-revoke (row stays), confirm-revoke (row disappears), bulk revoke of 2 rows, and bulk partial failure (one row gets a mocked 500, banner shows `N of M revocations failed`, failed row remains selected so the operator can retry). Uses `page.route()` to mock the three sessions endpoints at the page level — the persistent admin login itself is a row in the sessions table, and a test that revoked the wrong one would log the rest of the suite out. No `@llm` tag, runs on the fast lane.
- **`packages/web/src/app/admin/sessions/__tests__/columns.test.ts`** — pins the five `shortUA` branches (null → em-dash, browser-match → `Chrome/120.0.6099.129`, long UA → 50-char truncation + ellipsis, short UA → passthrough, unrecognized short UA → fallthrough passthrough).
- **`packages/web/src/app/admin/sessions/__tests__/sessions-schema.test.ts`** — parses a realistic API payload and pins the `string | null` contract for `ipAddress`, `userAgent`, and `userEmail`. Explicitly rejects `string | undefined` drift (key-omitted, key-present-undefined) and missing required timestamps.

### Production refactor (minimal)

- `shortUA` → named export in `packages/web/src/app/admin/sessions/columns.tsx`.
- `SessionRowSchema` + `SessionsListSchema` moved from `page.tsx` to `packages/web/src/ui/lib/admin-schemas.ts` next to `SessionStatsSchema`. Page imports them from the shared module now.

## Test plan

- [x] `bun run --filter '@atlas/web' test` — 72/72 files pass (includes two new sessions tests).
- [x] `bun run lint` — 0 warnings.
- [x] `bun run type` — 0 errors.
- [x] `bun x syncpack lint` — no issues.
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — passes, 429 files verified.
- [ ] `bun run test:browser:fast` against a running dev stack — should include the new `admin-sessions.spec.ts` and all 5 tests pass (verify locally before merge).