### PR TITLE
refactor(schemas): ApprovalRule/Request + CustomDomain → @useatlas/schemas (#1648)

### DIFF
--- a/packages/api/src/api/routes/admin-approval.ts
+++ b/packages/api/src/api/routes/admin-approval.ts
@@ -18,6 +18,8 @@
 
 import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
+import { APPROVAL_RULE_TYPES } from "@useatlas/types";
+import { ApprovalRuleSchema, ApprovalRequestSchema } from "@useatlas/schemas";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect, domainError } from "@atlas/api/lib/effect/hono";
 import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
@@ -39,27 +41,15 @@ import { createAdminRouter, requireOrgContext } from "./admin-router";
 const approvalDomainError = domainError(ApprovalError, { validation: 400, not_found: 404, conflict: 409, expired: 410 });
 
 // ---------------------------------------------------------------------------
-// Schemas
+// Request body schemas — response shapes live in @useatlas/schemas.
 // ---------------------------------------------------------------------------
-
-const ApprovalRuleSchema = z.object({
-  id: z.string(),
-  orgId: z.string(),
-  name: z.string(),
-  ruleType: z.enum(["table", "column", "cost"]),
-  pattern: z.string(),
-  threshold: z.number().nullable(),
-  enabled: z.boolean(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
-});
 
 const CreateRuleBodySchema = z.object({
   name: z.string().min(1).openapi({
     description: "Human-readable rule name.",
     example: "Require approval for PII tables",
   }),
-  ruleType: z.enum(["table", "column", "cost"]).openapi({
+  ruleType: z.enum(APPROVAL_RULE_TYPES).openapi({
     description: "Type of rule: table name match, column name match, or cost threshold.",
     example: "table",
   }),
@@ -82,27 +72,6 @@ const UpdateRuleBodySchema = z.object({
   pattern: z.string().optional(),
   threshold: z.number().nullable().optional(),
   enabled: z.boolean().optional(),
-});
-
-const ApprovalRequestSchema = z.object({
-  id: z.string(),
-  orgId: z.string(),
-  ruleId: z.string(),
-  ruleName: z.string(),
-  requesterId: z.string(),
-  requesterEmail: z.string().nullable(),
-  querySql: z.string(),
-  explanation: z.string().nullable(),
-  connectionId: z.string(),
-  tablesAccessed: z.array(z.string()),
-  columnsAccessed: z.array(z.string()),
-  status: z.enum(["pending", "approved", "denied", "expired"]),
-  reviewerId: z.string().nullable(),
-  reviewerEmail: z.string().nullable(),
-  reviewComment: z.string().nullable(),
-  reviewedAt: z.string().nullable(),
-  createdAt: z.string(),
-  expiresAt: z.string(),
 });
 
 const ReviewBodySchema = z.object({

--- a/packages/api/src/api/routes/shared-domains.ts
+++ b/packages/api/src/api/routes/shared-domains.ts
@@ -9,27 +9,13 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { domainError } from "@atlas/api/lib/effect/hono";
 import { DomainError } from "@atlas/ee/platform/domains";
 
+// Re-export the shared wire shape so existing callers (admin-domains,
+// platform-domains) keep their `./shared-domains` import path. The single
+// source of truth lives in @useatlas/schemas — this module now owns only
+// the domain-error mapping and the EE module loader.
+export { CustomDomainSchema } from "@useatlas/schemas";
+
 const log = createLogger("domains-shared");
-
-// ---------------------------------------------------------------------------
-// Schemas
-// ---------------------------------------------------------------------------
-
-export const CustomDomainSchema = z.object({
-  id: z.string(),
-  workspaceId: z.string(),
-  domain: z.string(),
-  status: z.enum(["pending", "verified", "failed"]),
-  railwayDomainId: z.string().nullable(),
-  cnameTarget: z.string().nullable(),
-  certificateStatus: z.enum(["PENDING", "ISSUED", "FAILED"]).nullable(),
-  verificationToken: z.string().nullable(),
-  domainVerified: z.boolean(),
-  domainVerifiedAt: z.string().nullable(),
-  domainVerificationStatus: z.enum(["pending", "verified", "failed"]),
-  createdAt: z.string(),
-  verifiedAt: z.string().nullable(),
-});
 
 // ---------------------------------------------------------------------------
 // Error mapping

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -10,7 +10,9 @@
   },
   "exports": {
     ".": "./src/index.ts",
-    "./abuse": "./src/abuse.ts"
+    "./abuse": "./src/abuse.ts",
+    "./approval": "./src/approval.ts",
+    "./custom-domain": "./src/custom-domain.ts"
   },
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/schemas/src/__tests__/approval.test.ts
+++ b/packages/schemas/src/__tests__/approval.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+import { ApprovalRuleSchema, ApprovalRequestSchema } from "../approval";
+
+const validRule = {
+  id: "rule_1",
+  orgId: "org_1",
+  name: "Require approval for PII tables",
+  ruleType: "table" as const,
+  pattern: "users",
+  threshold: null,
+  enabled: true,
+  createdAt: "2026-04-19T12:00:00.000Z",
+  updatedAt: "2026-04-19T12:00:00.000Z",
+};
+
+const validCostRule = {
+  ...validRule,
+  id: "rule_2",
+  name: "Flag expensive queries",
+  ruleType: "cost" as const,
+  pattern: "",
+  threshold: 1000,
+};
+
+const validRequest = {
+  id: "req_1",
+  orgId: "org_1",
+  ruleId: "rule_1",
+  ruleName: "Require approval for PII tables",
+  requesterId: "user_1",
+  requesterEmail: "alice@example.com",
+  querySql: "SELECT * FROM users",
+  explanation: "Quarterly audit",
+  connectionId: "conn_1",
+  tablesAccessed: ["users"],
+  columnsAccessed: ["users.email"],
+  status: "pending" as const,
+  reviewerId: null,
+  reviewerEmail: null,
+  reviewComment: null,
+  reviewedAt: null,
+  createdAt: "2026-04-19T12:00:00.000Z",
+  expiresAt: "2026-04-20T12:00:00.000Z",
+};
+
+// ---------------------------------------------------------------------------
+// Happy-path round-trips
+// ---------------------------------------------------------------------------
+
+describe("happy-path parses", () => {
+  test("ApprovalRuleSchema parses a table rule", () => {
+    expect(ApprovalRuleSchema.parse(validRule)).toEqual(validRule);
+  });
+
+  test("ApprovalRuleSchema parses a cost rule with numeric threshold", () => {
+    expect(ApprovalRuleSchema.parse(validCostRule)).toEqual(validCostRule);
+  });
+
+  test("ApprovalRequestSchema parses a pending request with null reviewer fields", () => {
+    expect(ApprovalRequestSchema.parse(validRequest)).toEqual(validRequest);
+  });
+
+  test("ApprovalRequestSchema parses each non-pending status", () => {
+    for (const status of ["approved", "denied", "expired"] as const) {
+      const reviewed = {
+        ...validRequest,
+        status,
+        reviewerId: "user_admin",
+        reviewerEmail: "admin@example.com",
+        reviewComment: "seen",
+        reviewedAt: "2026-04-19T13:00:00.000Z",
+      };
+      expect(ApprovalRequestSchema.parse(reviewed).status).toBe(status);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Enum strict rejection — proves the drift risk the shared schema closes
+//
+// Web previously relaxed these to `z.string()`, so a backend that started
+// emitting a new rule type or status would sail past parse at the admin
+// page boundary and surface as undefined UI behavior downstream. The
+// strict enum now matches the route layer and fails loudly at
+// `useAdminFetch` time, surfacing a `schema_mismatch` banner with a
+// request ID operators can correlate to logs.
+// ---------------------------------------------------------------------------
+
+describe("enum strict rejection", () => {
+  test("unknown ruleType fails parse", () => {
+    const drifted = { ...validRule, ruleType: "region" };
+    expect(ApprovalRuleSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("unknown status on ApprovalRequest fails parse", () => {
+    const drifted = { ...validRequest, status: "pending_review" };
+    expect(ApprovalRequestSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("all APPROVAL_RULE_TYPES values parse", () => {
+    for (const ruleType of ["table", "column", "cost"] as const) {
+      expect(
+        ApprovalRuleSchema.parse({ ...validRule, ruleType }).ruleType,
+      ).toBe(ruleType);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Structural validation — proves schemas still reject genuinely broken shapes
+// ---------------------------------------------------------------------------
+
+describe("structural rejection", () => {
+  test("ApprovalRuleSchema rejects missing id", () => {
+    const { id: _id, ...missing } = validRule;
+    expect(ApprovalRuleSchema.safeParse(missing).success).toBe(false);
+  });
+
+  test("ApprovalRuleSchema rejects string threshold", () => {
+    const drifted = { ...validRule, threshold: "1000" };
+    expect(ApprovalRuleSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("ApprovalRequestSchema rejects missing querySql", () => {
+    const { querySql: _querySql, ...missing } = validRequest;
+    expect(ApprovalRequestSchema.safeParse(missing).success).toBe(false);
+  });
+
+  test("ApprovalRequestSchema rejects non-array tablesAccessed", () => {
+    const drifted = { ...validRequest, tablesAccessed: "users,orders" };
+    expect(ApprovalRequestSchema.safeParse(drifted).success).toBe(false);
+  });
+});

--- a/packages/schemas/src/__tests__/approval.test.ts
+++ b/packages/schemas/src/__tests__/approval.test.ts
@@ -43,10 +43,6 @@ const validRequest = {
   expiresAt: "2026-04-20T12:00:00.000Z",
 };
 
-// ---------------------------------------------------------------------------
-// Happy-path round-trips
-// ---------------------------------------------------------------------------
-
 describe("happy-path parses", () => {
   test("ApprovalRuleSchema parses a table rule", () => {
     expect(ApprovalRuleSchema.parse(validRule)).toEqual(validRule);
@@ -58,6 +54,13 @@ describe("happy-path parses", () => {
 
   test("ApprovalRequestSchema parses a pending request with null reviewer fields", () => {
     expect(ApprovalRequestSchema.parse(validRequest)).toEqual(validRequest);
+  });
+
+  test("ApprovalRequestSchema parses an anonymous request (null requesterEmail + explanation)", () => {
+    const anon = { ...validRequest, requesterEmail: null, explanation: null };
+    const parsed = ApprovalRequestSchema.parse(anon);
+    expect(parsed.requesterEmail).toBeNull();
+    expect(parsed.explanation).toBeNull();
   });
 
   test("ApprovalRequestSchema parses each non-pending status", () => {
@@ -105,10 +108,6 @@ describe("enum strict rejection", () => {
     }
   });
 });
-
-// ---------------------------------------------------------------------------
-// Structural validation — proves schemas still reject genuinely broken shapes
-// ---------------------------------------------------------------------------
 
 describe("structural rejection", () => {
   test("ApprovalRuleSchema rejects missing id", () => {

--- a/packages/schemas/src/__tests__/custom-domain.test.ts
+++ b/packages/schemas/src/__tests__/custom-domain.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import { CustomDomainSchema } from "../custom-domain";
+
+const validDomain = {
+  id: "dom_1",
+  workspaceId: "org_1",
+  domain: "data.acme.com",
+  status: "pending" as const,
+  railwayDomainId: "rw_abc",
+  cnameTarget: "abc123.up.railway.app",
+  certificateStatus: "PENDING" as const,
+  verificationToken: "atlas-verify=uuid-xyz",
+  domainVerified: false,
+  domainVerifiedAt: null,
+  domainVerificationStatus: "pending" as const,
+  createdAt: "2026-04-19T12:00:00.000Z",
+  verifiedAt: null,
+};
+
+const verifiedDomain = {
+  ...validDomain,
+  id: "dom_2",
+  status: "verified" as const,
+  certificateStatus: "ISSUED" as const,
+  domainVerified: true,
+  domainVerifiedAt: "2026-04-19T12:30:00.000Z",
+  domainVerificationStatus: "verified" as const,
+  verifiedAt: "2026-04-19T12:30:00.000Z",
+};
+
+// ---------------------------------------------------------------------------
+// Happy-path round-trips
+// ---------------------------------------------------------------------------
+
+describe("happy-path parses", () => {
+  test("CustomDomainSchema parses a pending domain (null optionals)", () => {
+    expect(CustomDomainSchema.parse(validDomain)).toEqual(validDomain);
+  });
+
+  test("CustomDomainSchema parses a fully verified domain", () => {
+    expect(CustomDomainSchema.parse(verifiedDomain)).toEqual(verifiedDomain);
+  });
+
+  test("CustomDomainSchema permits null certificateStatus (pre-Railway row)", () => {
+    const nullCert = { ...validDomain, certificateStatus: null };
+    expect(CustomDomainSchema.parse(nullCert).certificateStatus).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Enum strict rejection — three enum columns, three drift traps.
+//
+// Web previously relaxed `status` and `certificateStatus` to z.string() —
+// `domainVerificationStatus` was already strict, which is what this
+// migration generalizes. A drifted Railway status (e.g. new "REVOKED"
+// cert state) now fails parse at `useAdminFetch` time and surfaces a
+// `schema_mismatch` banner instead of leaking through as untyped text
+// into the domain-detail UI.
+// ---------------------------------------------------------------------------
+
+describe("enum strict rejection", () => {
+  test("unknown status fails parse", () => {
+    const drifted = { ...validDomain, status: "propagating" };
+    expect(CustomDomainSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("unknown certificateStatus fails parse", () => {
+    const drifted = { ...validDomain, certificateStatus: "REVOKED" };
+    expect(CustomDomainSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("unknown domainVerificationStatus fails parse", () => {
+    const drifted = { ...validDomain, domainVerificationStatus: "unknown" };
+    expect(CustomDomainSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("all DOMAIN_STATUSES values parse", () => {
+    for (const status of ["pending", "verified", "failed"] as const) {
+      expect(CustomDomainSchema.parse({ ...validDomain, status }).status).toBe(status);
+    }
+  });
+
+  test("all CERTIFICATE_STATUSES values parse", () => {
+    for (const certificateStatus of ["PENDING", "ISSUED", "FAILED"] as const) {
+      expect(
+        CustomDomainSchema.parse({ ...validDomain, certificateStatus }).certificateStatus,
+      ).toBe(certificateStatus);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Structural validation — proves schemas still reject genuinely broken shapes
+// ---------------------------------------------------------------------------
+
+describe("structural rejection", () => {
+  test("CustomDomainSchema rejects missing workspaceId", () => {
+    const { workspaceId: _wid, ...missing } = validDomain;
+    expect(CustomDomainSchema.safeParse(missing).success).toBe(false);
+  });
+
+  test("CustomDomainSchema rejects non-boolean domainVerified", () => {
+    const drifted = { ...validDomain, domainVerified: "true" };
+    expect(CustomDomainSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("CustomDomainSchema rejects missing domainVerificationStatus", () => {
+    const { domainVerificationStatus: _dvs, ...missing } = validDomain;
+    expect(CustomDomainSchema.safeParse(missing).success).toBe(false);
+  });
+});

--- a/packages/schemas/src/__tests__/custom-domain.test.ts
+++ b/packages/schemas/src/__tests__/custom-domain.test.ts
@@ -28,12 +28,8 @@ const verifiedDomain = {
   verifiedAt: "2026-04-19T12:30:00.000Z",
 };
 
-// ---------------------------------------------------------------------------
-// Happy-path round-trips
-// ---------------------------------------------------------------------------
-
 describe("happy-path parses", () => {
-  test("CustomDomainSchema parses a pending domain (null optionals)", () => {
+  test("CustomDomainSchema parses a pending domain", () => {
     expect(CustomDomainSchema.parse(validDomain)).toEqual(validDomain);
   });
 
@@ -44,6 +40,19 @@ describe("happy-path parses", () => {
   test("CustomDomainSchema permits null certificateStatus (pre-Railway row)", () => {
     const nullCert = { ...validDomain, certificateStatus: null };
     expect(CustomDomainSchema.parse(nullCert).certificateStatus).toBeNull();
+  });
+
+  test("CustomDomainSchema permits null railwayDomainId / cnameTarget / verificationToken (pre-migration row)", () => {
+    const preMigration = {
+      ...validDomain,
+      railwayDomainId: null,
+      cnameTarget: null,
+      verificationToken: null,
+    };
+    const parsed = CustomDomainSchema.parse(preMigration);
+    expect(parsed.railwayDomainId).toBeNull();
+    expect(parsed.cnameTarget).toBeNull();
+    expect(parsed.verificationToken).toBeNull();
   });
 });
 
@@ -87,11 +96,16 @@ describe("enum strict rejection", () => {
       ).toBe(certificateStatus);
     }
   });
-});
 
-// ---------------------------------------------------------------------------
-// Structural validation — proves schemas still reject genuinely broken shapes
-// ---------------------------------------------------------------------------
+  test("all DOMAIN_VERIFICATION_STATUSES values parse", () => {
+    for (const domainVerificationStatus of ["pending", "verified", "failed"] as const) {
+      expect(
+        CustomDomainSchema.parse({ ...validDomain, domainVerificationStatus })
+          .domainVerificationStatus,
+      ).toBe(domainVerificationStatus);
+    }
+  });
+});
 
 describe("structural rejection", () => {
   test("CustomDomainSchema rejects missing workspaceId", () => {

--- a/packages/schemas/src/approval.ts
+++ b/packages/schemas/src/approval.ts
@@ -1,0 +1,66 @@
+/**
+ * Approval-workflow wire-format schemas.
+ *
+ * Single source of truth for the admin approval surface
+ * (`/api/v1/admin/approval`). The route layer imports these for OpenAPI
+ * response validation; the web layer imports them for `useAdminFetch`
+ * response parsing. Before this module, each layer kept its own Zod
+ * copy — with the route enforcing strict `z.enum(...)` while the web
+ * copy silently relaxed `ruleType` / `status` to `z.string()`. That
+ * asymmetry is exactly the drift surface this package exists to close.
+ *
+ * The enum tuples (`APPROVAL_RULE_TYPES`, `APPROVAL_STATUSES`) come from
+ * `@useatlas/types` so adding a new rule type or status to the TS union
+ * propagates here without manual duplication.
+ *
+ * Every schema uses `satisfies z.ZodType<T>` (not `as z.ZodType<T>`) so
+ * a field rename in `@useatlas/types` breaks this file at compile time
+ * instead of passing through to runtime.
+ *
+ * Strict `z.enum(TUPLE)` matches the `@hono/zod-openapi` extractor's
+ * expectations — it cannot serialize `ZodCatch` wrappers (#1653) — and
+ * keeps the generated OpenAPI spec describing the genuine output shape.
+ */
+import { z } from "zod";
+import {
+  APPROVAL_RULE_TYPES,
+  APPROVAL_STATUSES,
+  type ApprovalRule,
+  type ApprovalRequest,
+} from "@useatlas/types";
+
+const RuleTypeEnum = z.enum(APPROVAL_RULE_TYPES);
+const StatusEnum = z.enum(APPROVAL_STATUSES);
+
+export const ApprovalRuleSchema = z.object({
+  id: z.string(),
+  orgId: z.string(),
+  name: z.string(),
+  ruleType: RuleTypeEnum,
+  pattern: z.string(),
+  threshold: z.number().nullable(),
+  enabled: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+}) satisfies z.ZodType<ApprovalRule>;
+
+export const ApprovalRequestSchema = z.object({
+  id: z.string(),
+  orgId: z.string(),
+  ruleId: z.string(),
+  ruleName: z.string(),
+  requesterId: z.string(),
+  requesterEmail: z.string().nullable(),
+  querySql: z.string(),
+  explanation: z.string().nullable(),
+  connectionId: z.string(),
+  tablesAccessed: z.array(z.string()),
+  columnsAccessed: z.array(z.string()),
+  status: StatusEnum,
+  reviewerId: z.string().nullable(),
+  reviewerEmail: z.string().nullable(),
+  reviewComment: z.string().nullable(),
+  reviewedAt: z.string().nullable(),
+  createdAt: z.string(),
+  expiresAt: z.string(),
+}) satisfies z.ZodType<ApprovalRequest>;

--- a/packages/schemas/src/approval.ts
+++ b/packages/schemas/src/approval.ts
@@ -4,9 +4,9 @@
  * Single source of truth for the admin approval surface
  * (`/api/v1/admin/approval`). The route layer imports these for OpenAPI
  * response validation; the web layer imports them for `useAdminFetch`
- * response parsing. Before this module, each layer kept its own Zod
- * copy — with the route enforcing strict `z.enum(...)` while the web
- * copy silently relaxed `ruleType` / `status` to `z.string()`. That
+ * response parsing. Before #1648, each layer kept its own Zod copy —
+ * with the route enforcing strict `z.enum(...)` while the web copy
+ * silently relaxed `ruleType` / `status` to `z.string()`. That
  * asymmetry is exactly the drift surface this package exists to close.
  *
  * The enum tuples (`APPROVAL_RULE_TYPES`, `APPROVAL_STATUSES`) come from

--- a/packages/schemas/src/custom-domain.ts
+++ b/packages/schemas/src/custom-domain.ts
@@ -5,13 +5,13 @@
  * admin surface (`/api/v1/admin/domain`) and the platform surface
  * (`/api/v1/platform/domains`). The route layer imports this for
  * OpenAPI response validation; the web layer imports it for
- * `useAdminFetch` response parsing. Before this module lived here, the
- * route copies used strict `z.enum(...)` on every status column while
- * the web copy silently relaxed `status` / `certificateStatus` to
- * `z.string()` and only kept `domainVerificationStatus` strict. The
- * three enum columns are the most drift-prone part of the shape —
- * pinning them to the tuples from `@useatlas/types` is the point of
- * moving this schema here.
+ * `useAdminFetch` response parsing. Before #1648, the route copies
+ * used strict `z.enum(...)` on every status column while the web copy
+ * silently relaxed `status` / `certificateStatus` to `z.string()` and
+ * only kept `domainVerificationStatus` strict. The three enum columns
+ * are the most drift-prone part of the shape — pinning them to the
+ * tuples from `@useatlas/types` is the point of moving this schema
+ * here.
  *
  * Tuples (`DOMAIN_STATUSES`, `CERTIFICATE_STATUSES`,
  * `DOMAIN_VERIFICATION_STATUSES`) come from `@useatlas/types` so adding

--- a/packages/schemas/src/custom-domain.ts
+++ b/packages/schemas/src/custom-domain.ts
@@ -1,0 +1,54 @@
+/**
+ * Custom-domain wire-format schema.
+ *
+ * Single source of truth for custom-domain responses served by both the
+ * admin surface (`/api/v1/admin/domain`) and the platform surface
+ * (`/api/v1/platform/domains`). The route layer imports this for
+ * OpenAPI response validation; the web layer imports it for
+ * `useAdminFetch` response parsing. Before this module lived here, the
+ * route copies used strict `z.enum(...)` on every status column while
+ * the web copy silently relaxed `status` / `certificateStatus` to
+ * `z.string()` and only kept `domainVerificationStatus` strict. The
+ * three enum columns are the most drift-prone part of the shape —
+ * pinning them to the tuples from `@useatlas/types` is the point of
+ * moving this schema here.
+ *
+ * Tuples (`DOMAIN_STATUSES`, `CERTIFICATE_STATUSES`,
+ * `DOMAIN_VERIFICATION_STATUSES`) come from `@useatlas/types` so adding
+ * a new status to the TS union propagates here without a second edit.
+ *
+ * Uses `satisfies z.ZodType<T>` (not `as z.ZodType<T>`) so a field
+ * rename in `@useatlas/types` breaks this file at compile time instead
+ * of passing through to runtime.
+ *
+ * Strict `z.enum(TUPLE)` matches the `@hono/zod-openapi` extractor's
+ * expectations — it cannot serialize `ZodCatch` wrappers (#1653) — and
+ * keeps the generated OpenAPI spec describing the genuine output shape.
+ */
+import { z } from "zod";
+import {
+  DOMAIN_STATUSES,
+  CERTIFICATE_STATUSES,
+  DOMAIN_VERIFICATION_STATUSES,
+  type CustomDomain,
+} from "@useatlas/types";
+
+const DomainStatusEnum = z.enum(DOMAIN_STATUSES);
+const CertificateStatusEnum = z.enum(CERTIFICATE_STATUSES);
+const DomainVerificationStatusEnum = z.enum(DOMAIN_VERIFICATION_STATUSES);
+
+export const CustomDomainSchema = z.object({
+  id: z.string(),
+  workspaceId: z.string(),
+  domain: z.string(),
+  status: DomainStatusEnum,
+  railwayDomainId: z.string().nullable(),
+  cnameTarget: z.string().nullable(),
+  certificateStatus: CertificateStatusEnum.nullable(),
+  verificationToken: z.string().nullable(),
+  domainVerified: z.boolean(),
+  domainVerifiedAt: z.string().nullable(),
+  domainVerificationStatus: DomainVerificationStatusEnum,
+  createdAt: z.string(),
+  verifiedAt: z.string().nullable(),
+}) satisfies z.ZodType<CustomDomain>;

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -1,1 +1,3 @@
 export * from "./abuse";
+export * from "./approval";
+export * from "./custom-domain";

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -19,8 +19,6 @@ import type {
   ConnectionHealth,
   WorkspaceBranding,
   WorkspaceModelConfig,
-  ApprovalRule,
-  ApprovalRequest,
   PIIColumnClassification,
   SemanticDiffResponse,
   PlatformStats,
@@ -29,7 +27,6 @@ import type {
   NoisyNeighbor,
   BackupEntry,
   BackupConfig,
-  CustomDomain,
   RegionMigration,
   RegionPickerItem,
   RegionStatus,
@@ -40,10 +37,14 @@ import type {
   SLAThresholds,
   SLAMetricPoint,
 } from "@/ui/lib/types";
+import { CustomDomainSchema } from "@useatlas/schemas";
 export {
   AbuseStatusSchema,
   AbuseThresholdConfigSchema,
   AbuseDetailSchema,
+  ApprovalRuleSchema,
+  ApprovalRequestSchema,
+  CustomDomainSchema,
 } from "@useatlas/schemas";
 
 // ── Connection ────────────────────────────────────────────────────
@@ -89,41 +90,6 @@ export const WorkspaceModelConfigSchema = z.object({
   createdAt: z.string(),
   updatedAt: z.string(),
 }) as z.ZodType<WorkspaceModelConfig>;
-
-// ── Approval ──────────────────────────────────────────────────────
-
-export const ApprovalRuleSchema = z.object({
-  id: z.string(),
-  orgId: z.string(),
-  name: z.string(),
-  ruleType: z.string(),
-  pattern: z.string(),
-  threshold: z.number().nullable(),
-  enabled: z.boolean(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
-}) as z.ZodType<ApprovalRule>;
-
-export const ApprovalRequestSchema = z.object({
-  id: z.string(),
-  orgId: z.string(),
-  ruleId: z.string(),
-  ruleName: z.string(),
-  requesterId: z.string(),
-  requesterEmail: z.string().nullable(),
-  querySql: z.string(),
-  explanation: z.string().nullable(),
-  connectionId: z.string(),
-  tablesAccessed: z.array(z.string()),
-  columnsAccessed: z.array(z.string()),
-  status: z.string(),
-  reviewerId: z.string().nullable(),
-  reviewerEmail: z.string().nullable(),
-  reviewComment: z.string().nullable(),
-  reviewedAt: z.string().nullable(),
-  createdAt: z.string(),
-  expiresAt: z.string(),
-}) as z.ZodType<ApprovalRequest>;
 
 // ── Compliance ────────────────────────────────────────────────────
 
@@ -264,22 +230,7 @@ export const BackupsResponseSchema = z.object({
 });
 
 // ── Custom Domain ────────────────────────────────────────────────
-
-export const CustomDomainSchema = z.object({
-  id: z.string(),
-  workspaceId: z.string(),
-  domain: z.string(),
-  status: z.string(),
-  railwayDomainId: z.string().nullable(),
-  cnameTarget: z.string().nullable(),
-  certificateStatus: z.string().nullable(),
-  createdAt: z.string(),
-  verifiedAt: z.string().nullable(),
-  verificationToken: z.string().nullable(),
-  domainVerified: z.boolean(),
-  domainVerifiedAt: z.string().nullable(),
-  domainVerificationStatus: z.enum(["pending", "verified", "failed"]),
-}) as z.ZodType<CustomDomain>;
+// CustomDomainSchema re-exported above from @useatlas/schemas.
 
 export const DomainResponseSchema = z.object({
   domain: CustomDomainSchema.nullable(),


### PR DESCRIPTION
## Summary
- Adds `approval.ts` + `custom-domain.ts` to `@useatlas/schemas` — second consumer of the package after `AbuseDetail` (#1647).
- Deletes the route-level Zod copies in `admin-approval.ts` + `shared-domains.ts` and the web-level copies in `admin-schemas.ts`. Each wire shape now has a single source of truth.
- Tightens web-side parse from `z.string()` to strict `z.enum()` for `ApprovalRule.ruleType`, `ApprovalRequest.status`, `CustomDomain.status`, and `CustomDomain.certificateStatus`. Backend drift now fails loudly at `useAdminFetch` time instead of leaking through untyped.

Closes #1648.

## Why it matters
Before this PR each shape was defined twice — strict `z.enum(...)` in the API route, relaxed `z.string()` in `packages/web/src/ui/lib/admin-schemas.ts`. A new rule type added to the TS union wouldn't have been caught on the web side; the same for a new certificate status. Pinning both layers to the tuples from `@useatlas/types` via `@useatlas/schemas` makes the next addition a one-line change to the tuple.

## Changes
- **New**: `packages/schemas/src/approval.ts` (ApprovalRuleSchema, ApprovalRequestSchema).
- **New**: `packages/schemas/src/custom-domain.ts` (CustomDomainSchema).
- **New**: `packages/schemas/src/__tests__/approval.test.ts` + `custom-domain.test.ts` — 22 tests covering golden-input parse, enum drift rejection, and structural rejection.
- **Updated**: `packages/schemas/src/index.ts`, `packages/schemas/package.json` (per-subpath exports).
- **Updated**: `packages/api/src/api/routes/admin-approval.ts`, `shared-domains.ts` — import from `@useatlas/schemas`.
- **Updated**: `packages/web/src/ui/lib/admin-schemas.ts` — re-export from `@useatlas/schemas`, delete inline copies.

## Test plan
- [x] `bun test packages/schemas/src/__tests__/approval.test.ts packages/schemas/src/__tests__/custom-domain.test.ts` — 22/22 pass
- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun run test` — all packages green (no pre-existing test touched)
- [x] `bun x syncpack lint` — No issues found
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — 430 files verified
- [x] `bash scripts/check-openapi-drift.sh` — zero diff (wire shapes unchanged, only duplication removed)

## Labels
refactor, architecture, area: api, area: web