### PR TITLE
security(abuse): DB CHECK + server-side enum drift coercion (#1653)

### DIFF
--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -276,6 +276,7 @@ describe("migrateAuthTables", () => {
             { name: "0028_fix_semantic_entity_uniqueness.sql" },
             { name: "0029_user_favorite_prompts.sql" },
             { name: "0030_starter_prompt_approval.sql" },
+            { name: "0031_abuse_events_enum_checks.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -78,7 +78,7 @@ describe("runMigrations", () => {
 
     const count = await runMigrations(pool);
 
-    expect(count).toBe(31);
+    expect(count).toBe(32);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -138,6 +138,7 @@ describe("runMigrations", () => {
         "0028_fix_semantic_entity_uniqueness.sql",
         "0029_user_favorite_prompts.sql",
         "0030_starter_prompt_approval.sql",
+        "0031_abuse_events_enum_checks.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -348,6 +348,58 @@ describe("0027_organization_saas_columns.sql", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tests: 0031_abuse_events_enum_checks.sql
+// ---------------------------------------------------------------------------
+
+describe("0031_abuse_events_enum_checks.sql", () => {
+  const filePath = path.join(MIGRATIONS_DIR, "0031_abuse_events_enum_checks.sql");
+
+  it("file exists in the migrations directory", () => {
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  it("cleans pre-drifted rows before adding CHECK constraints", () => {
+    const sql = fs.readFileSync(filePath, "utf-8");
+
+    const updateLevelIdx = sql.search(/UPDATE\s+abuse_events\s+SET\s+level\s*=\s*'none'/i);
+    const updateTriggerIdx = sql.search(/UPDATE\s+abuse_events\s+SET\s+trigger_type\s*=\s*'manual'/i);
+    const checkLevelIdx = sql.search(/CHECK\s*\(\s*level\s+IN\b/i);
+    const checkTriggerIdx = sql.search(/CHECK\s*\(\s*trigger_type\s+IN\b/i);
+
+    // All four statements must exist
+    expect(updateLevelIdx).toBeGreaterThan(-1);
+    expect(updateTriggerIdx).toBeGreaterThan(-1);
+    expect(checkLevelIdx).toBeGreaterThan(-1);
+    expect(checkTriggerIdx).toBeGreaterThan(-1);
+
+    // Ordering: cleanup UPDATEs must come before the ADD CONSTRAINTs,
+    // otherwise pre-drifted rows block the migration from applying.
+    expect(updateLevelIdx).toBeLessThan(checkLevelIdx);
+    expect(updateTriggerIdx).toBeLessThan(checkTriggerIdx);
+  });
+
+  it("enumerates all canonical values for both columns", () => {
+    const sql = fs.readFileSync(filePath, "utf-8");
+
+    for (const v of ["none", "warning", "throttled", "suspended"]) {
+      expect(sql).toContain(`'${v}'`);
+    }
+    for (const v of ["query_rate", "error_rate", "unique_tables", "manual"]) {
+      expect(sql).toContain(`'${v}'`);
+    }
+  });
+
+  it("wraps both ADD CONSTRAINTs in idempotent DO $$ … EXCEPTION guards", () => {
+    const sql = fs.readFileSync(filePath, "utf-8");
+
+    // Two DO $$ blocks — one per constraint — each catching duplicate_object
+    // so re-running the migration on an already-constrained DB is a no-op.
+    const doBlocks = sql.match(/DO\s*\$\$\s*BEGIN[\s\S]*?EXCEPTION\s+WHEN\s+duplicate_object\s+THEN\s+NULL;\s*END\s*\$\$\s*;/gi) ?? [];
+    expect(doBlocks.length).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tests: runSeeds
 // ---------------------------------------------------------------------------
 

--- a/packages/api/src/lib/db/migrations/0031_abuse_events_enum_checks.sql
+++ b/packages/api/src/lib/db/migrations/0031_abuse_events_enum_checks.sql
@@ -1,15 +1,10 @@
--- 0031 — Abuse-event enum CHECK constraints (#1653)
+-- Enforce abuse_events.level / trigger_type enums at the DB layer. The
+-- canonical tuples live in `packages/types/src/abuse.ts` — keep the values
+-- here in sync.
 --
--- `abuse_events.level` and `trigger_type` are plain TEXT columns. PR #1647
--- made the admin wire schema strict-parse via `z.enum(ABUSE_LEVELS)` /
--- `z.enum(ABUSE_TRIGGERS)`, so a single drifted row would crash the whole
--- admin investigation page with a `schema_mismatch` banner. The server-side
--- coercion in `lib/security/abuse.ts::coerceAbuseEnums` is the soft
--- backstop; this migration is the hard one — future drift attempts are
--- rejected at INSERT time.
---
--- Ordering matters: the cleanup UPDATEs must run before the ADD CONSTRAINT,
--- otherwise a pre-drifted row would make the migration fail to apply.
+-- Ordering is load-bearing: the cleanup UPDATEs must run before the ADD
+-- CONSTRAINT, otherwise a pre-drifted row would block the migration from
+-- applying.
 
 -- ── 1. Coerce any pre-drifted rows to safe defaults ───────────────────
 UPDATE abuse_events

--- a/packages/api/src/lib/db/migrations/0031_abuse_events_enum_checks.sql
+++ b/packages/api/src/lib/db/migrations/0031_abuse_events_enum_checks.sql
@@ -1,0 +1,34 @@
+-- 0031 — Abuse-event enum CHECK constraints (#1653)
+--
+-- `abuse_events.level` and `trigger_type` are plain TEXT columns. PR #1647
+-- made the admin wire schema strict-parse via `z.enum(ABUSE_LEVELS)` /
+-- `z.enum(ABUSE_TRIGGERS)`, so a single drifted row would crash the whole
+-- admin investigation page with a `schema_mismatch` banner. The server-side
+-- coercion in `lib/security/abuse.ts::coerceAbuseEnums` is the soft
+-- backstop; this migration is the hard one — future drift attempts are
+-- rejected at INSERT time.
+--
+-- Ordering matters: the cleanup UPDATEs must run before the ADD CONSTRAINT,
+-- otherwise a pre-drifted row would make the migration fail to apply.
+
+-- ── 1. Coerce any pre-drifted rows to safe defaults ───────────────────
+UPDATE abuse_events
+SET level = 'none'
+WHERE level NOT IN ('none', 'warning', 'throttled', 'suspended');
+
+UPDATE abuse_events
+SET trigger_type = 'manual'
+WHERE trigger_type NOT IN ('query_rate', 'error_rate', 'unique_tables', 'manual');
+
+-- ── 2. Add CHECK constraints (idempotent) ─────────────────────────────
+DO $$ BEGIN
+  ALTER TABLE abuse_events ADD CONSTRAINT chk_abuse_events_level
+    CHECK (level IN ('none', 'warning', 'throttled', 'suspended'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  ALTER TABLE abuse_events ADD CONSTRAINT chk_abuse_events_trigger_type
+    CHECK (trigger_type IN ('query_rate', 'error_rate', 'unique_tables', 'manual'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;

--- a/packages/api/src/lib/security/__tests__/abuse.test.ts
+++ b/packages/api/src/lib/security/__tests__/abuse.test.ts
@@ -14,10 +14,23 @@ import {
 
 // --- Mocks ---
 
+type LogCall = { msg: string; ctx: Record<string, unknown> };
+const warnCalls: LogCall[] = [];
+const infoCalls: LogCall[] = [];
+
+function resetLogCalls(): void {
+  warnCalls.length = 0;
+  infoCalls.length = 0;
+}
+
 mock.module("@atlas/api/lib/logger", () => ({
   createLogger: () => ({
-    info: () => {},
-    warn: () => {},
+    info: (ctx: Record<string, unknown>, msg: string) => {
+      infoCalls.push({ msg, ctx: ctx ?? {} });
+    },
+    warn: (ctx: Record<string, unknown>, msg: string) => {
+      warnCalls.push({ msg, ctx: ctx ?? {} });
+    },
     error: () => {},
     debug: () => {},
   }),
@@ -25,10 +38,23 @@ mock.module("@atlas/api/lib/logger", () => ({
   withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }));
 
+// Reconfigurable internal-DB mock so drift-coercion tests can swap in
+// hydration rows without tearing down the whole mock.module registration.
+let _hasInternalDB = false;
+let _internalQueryImpl: <T>(sql: string, params?: unknown[]) => Promise<T[]> =
+  async () => [];
+
+function setInternalDB(enabled: boolean): void {
+  _hasInternalDB = enabled;
+}
+function setInternalQuery<T>(impl: (sql: string, params?: unknown[]) => Promise<T[]>): void {
+  _internalQueryImpl = impl as typeof _internalQueryImpl;
+}
+
 mock.module("@atlas/api/lib/db/internal", () => ({
-  hasInternalDB: () => false,
+  hasInternalDB: () => _hasInternalDB,
   internalExecute: mock(() => {}),
-  internalQuery: mock(async () => []),
+  internalQuery: <T>(sql: string, params?: unknown[]) => _internalQueryImpl<T>(sql, params),
   setWorkspaceRegion: mock(async () => {}),
   insertSemanticAmendment: mock(async () => "mock-amendment-id"),
   getPendingAmendmentCount: mock(async () => 0),
@@ -42,12 +68,16 @@ const {
   listFlaggedWorkspaces,
   reinstateWorkspace,
   getAbuseConfig,
+  getAbuseEvents,
   _resetAbuseState,
 } = await import("../abuse");
 
 describe("Abuse Prevention Engine", () => {
   beforeEach(() => {
     _resetAbuseState();
+    resetLogCalls();
+    setInternalDB(false);
+    setInternalQuery(async () => []);
   });
 
   describe("getAbuseConfig()", () => {
@@ -219,6 +249,90 @@ describe("Abuse Prevention Engine", () => {
         recordQueryEvent("ws-counters", { success: true });
       }
       expect(checkAbuseStatus("ws-counters").level).toBe("none");
+    });
+  });
+
+  describe("getAbuseEvents() hydration enum drift", () => {
+    it("coerces an unknown level to 'none' and emits a drift warning", async () => {
+      setInternalDB(true);
+      setInternalQuery(async () => [
+        {
+          id: "drift-level-1",
+          workspace_id: "ws-drift",
+          level: "mystery-level", // not in ABUSE_LEVELS
+          trigger_type: "query_rate",
+          message: "bad row",
+          metadata: "{}",
+          actor: "system",
+          created_at: "2026-04-19T00:00:00Z",
+        },
+      ]);
+
+      const events = await getAbuseEvents("ws-drift", 10);
+
+      expect(events.length).toBe(1);
+      expect(events[0].level).toBe("none");
+      expect(events[0].trigger).toBe("query_rate");
+
+      const drift = warnCalls.find((c) =>
+        c.msg.includes("abuse event with drifted enum"),
+      );
+      expect(drift).toBeDefined();
+      expect(drift?.ctx.rowId).toBe("drift-level-1");
+      expect(drift?.ctx.rawLevel).toBe("mystery-level");
+    });
+
+    it("coerces an unknown trigger_type to 'manual' and emits a drift warning", async () => {
+      setInternalDB(true);
+      setInternalQuery(async () => [
+        {
+          id: "drift-trigger-1",
+          workspace_id: "ws-drift",
+          level: "warning",
+          trigger_type: "bogus_trigger", // not in ABUSE_TRIGGERS
+          message: "bad row",
+          metadata: "{}",
+          actor: "system",
+          created_at: "2026-04-19T00:00:00Z",
+        },
+      ]);
+
+      const events = await getAbuseEvents("ws-drift", 10);
+
+      expect(events.length).toBe(1);
+      expect(events[0].level).toBe("warning");
+      expect(events[0].trigger).toBe("manual");
+
+      const drift = warnCalls.find((c) =>
+        c.msg.includes("abuse event with drifted enum"),
+      );
+      expect(drift).toBeDefined();
+      expect(drift?.ctx.rowId).toBe("drift-trigger-1");
+      expect(drift?.ctx.rawTrigger).toBe("bogus_trigger");
+    });
+
+    it("does not warn for rows whose enums are already valid", async () => {
+      setInternalDB(true);
+      setInternalQuery(async () => [
+        {
+          id: "clean-1",
+          workspace_id: "ws-clean",
+          level: "throttled",
+          trigger_type: "error_rate",
+          message: "fine",
+          metadata: "{}",
+          actor: "system",
+          created_at: "2026-04-19T00:00:00Z",
+        },
+      ]);
+
+      const events = await getAbuseEvents("ws-clean", 10);
+
+      expect(events[0].level).toBe("throttled");
+      expect(events[0].trigger).toBe("error_rate");
+      expect(
+        warnCalls.find((c) => c.msg.includes("abuse event with drifted enum")),
+      ).toBeUndefined();
     });
   });
 

--- a/packages/api/src/lib/security/__tests__/abuse.test.ts
+++ b/packages/api/src/lib/security/__tests__/abuse.test.ts
@@ -69,6 +69,7 @@ const {
   reinstateWorkspace,
   getAbuseConfig,
   getAbuseEvents,
+  restoreAbuseState,
   _resetAbuseState,
 } = await import("../abuse");
 
@@ -311,6 +312,59 @@ describe("Abuse Prevention Engine", () => {
       expect(drift?.ctx.rawTrigger).toBe("bogus_trigger");
     });
 
+    it("emits a single drift warning per row when both enums are bad", async () => {
+      setInternalDB(true);
+      setInternalQuery(async () => [
+        {
+          id: "both-bad-1",
+          workspace_id: "ws-drift",
+          level: "Mystery",
+          trigger_type: "bogus",
+          message: "bad row",
+          metadata: "{}",
+          actor: "system",
+          created_at: "2026-04-19T00:00:00Z",
+        },
+      ]);
+
+      const events = await getAbuseEvents("ws-drift", 10);
+
+      expect(events[0].level).toBe("none");
+      expect(events[0].trigger).toBe("manual");
+
+      const drifts = warnCalls.filter((c) =>
+        c.msg.includes("abuse event with drifted enum"),
+      );
+      expect(drifts.length).toBe(1);
+      expect(drifts[0].ctx.rowId).toBe("both-bad-1");
+      expect(drifts[0].ctx.rawLevel).toBe("Mystery");
+      expect(drifts[0].ctx.rawTrigger).toBe("bogus");
+    });
+
+    it("coerces null / non-string enum values without throwing", async () => {
+      setInternalDB(true);
+      setInternalQuery(async () => [
+        {
+          id: "non-string-1",
+          workspace_id: "ws-drift",
+          level: null as unknown as string,
+          trigger_type: 42 as unknown as string,
+          message: "bad row",
+          metadata: "{}",
+          actor: "system",
+          created_at: "2026-04-19T00:00:00Z",
+        },
+      ]);
+
+      const events = await getAbuseEvents("ws-drift", 10);
+
+      expect(events[0].level).toBe("none");
+      expect(events[0].trigger).toBe("manual");
+      expect(
+        warnCalls.find((c) => c.msg.includes("abuse event with drifted enum")),
+      ).toBeDefined();
+    });
+
     it("does not warn for rows whose enums are already valid", async () => {
       setInternalDB(true);
       setInternalQuery(async () => [
@@ -333,6 +387,81 @@ describe("Abuse Prevention Engine", () => {
       expect(
         warnCalls.find((c) => c.msg.includes("abuse event with drifted enum")),
       ).toBeUndefined();
+    });
+  });
+
+  describe("restoreAbuseState() fail-safe drift handling", () => {
+    it("restores clean rows and skips drifted rows without leaking their level", async () => {
+      setInternalDB(true);
+      setInternalQuery(async () => [
+        {
+          workspace_id: "ws-clean",
+          level: "throttled",
+          trigger_type: "query_rate",
+          message: "clean workspace",
+          created_at: "2026-04-19T00:00:00Z",
+        },
+        {
+          // Drifted level — legacy "Suspended" casing that is NOT in the tuple.
+          // coerceAbuseEnums will collapse to "none"; restoreAbuseState must
+          // count this as a drift-skip rather than silently treating as reinstated.
+          workspace_id: "ws-drifted",
+          level: "Suspended",
+          trigger_type: "manual",
+          message: "drifted workspace",
+          created_at: "2026-04-19T00:00:00Z",
+        },
+      ]);
+
+      await restoreAbuseState();
+
+      const flagged = listFlaggedWorkspaces();
+      const workspaceIds = flagged.map((f) => f.workspaceId);
+      expect(workspaceIds).toContain("ws-clean");
+      expect(workspaceIds).not.toContain("ws-drifted");
+
+      // Drift warn fired for the bad row
+      expect(
+        warnCalls.find(
+          (c) =>
+            c.msg.includes("abuse event with drifted enum") &&
+            c.ctx.rawLevel === "Suspended",
+        ),
+      ).toBeDefined();
+
+      // Summary log surfaces the drift count — not hidden behind "restored N"
+      const summary = infoCalls.find((c) =>
+        c.msg.includes("Restored abuse state"),
+      );
+      expect(summary).toBeDefined();
+      expect(summary?.ctx.count).toBe(1);
+      expect(summary?.ctx.driftSkipped).toBe(1);
+    });
+
+    it("skips a genuinely reinstated 'none' row without counting it as drift", async () => {
+      setInternalDB(true);
+      setInternalQuery(async () => [
+        {
+          workspace_id: "ws-reinstated",
+          level: "none",
+          trigger_type: "manual",
+          message: "reinstated",
+          created_at: "2026-04-19T00:00:00Z",
+        },
+      ]);
+
+      await restoreAbuseState();
+
+      expect(listFlaggedWorkspaces()).toEqual([]);
+      // Genuine "none" must NOT trigger a drift warn
+      expect(
+        warnCalls.find((c) => c.msg.includes("abuse event with drifted enum")),
+      ).toBeUndefined();
+      // And should not show up in the summary as a drift-skip
+      const summary = infoCalls.find((c) =>
+        c.msg.includes("Restored abuse state"),
+      );
+      expect(summary).toBeUndefined();
     });
   });
 

--- a/packages/api/src/lib/security/abuse.ts
+++ b/packages/api/src/lib/security/abuse.ts
@@ -31,15 +31,11 @@ const log = createLogger("abuse");
 // ---------------------------------------------------------------------------
 // Enum drift coercion
 // ---------------------------------------------------------------------------
-//
-// `abuse_events.level` and `abuse_events.trigger_type` are plain TEXT columns
-// historically — PR #1653 adds a CHECK constraint, but rows predating it (or
-// written by a future code path that forgot to update the tuple) may hold
-// values that fail strict `z.enum` parsing in the admin wire schema.
-//
-// A single drifted row must not crash the admin abuse page. These helpers
-// validate a raw string against the canonical tuple, coerce unknowns to a
-// safe default, and emit a `log.warn` so operators see drift in observability.
+// A drifted abuse_events row must never crash the admin page, so we validate
+// level / trigger_type against the canonical tuples, coerce unknowns to safe
+// defaults, and warn on drift. Callers that care about the *distinction*
+// between a genuine `none` and a drift-coerced `none` (e.g. restoreAbuseState
+// — where the difference is fail-open vs fail-safe) read `levelDrifted`.
 
 const LEVEL_SET: ReadonlySet<string> = new Set(ABUSE_LEVELS);
 const TRIGGER_SET: ReadonlySet<string> = new Set(ABUSE_TRIGGERS);
@@ -52,18 +48,20 @@ function isAbuseTrigger(v: unknown): v is AbuseTrigger {
   return typeof v === "string" && TRIGGER_SET.has(v);
 }
 
-/**
- * Validate and coerce a hydrated abuse_events row's enum columns.
- *
- * Returns the coerced `{ level, trigger }` pair. Any unknown/non-string input
- * is replaced with a safe default (`none` / `manual`) and a single drift
- * warning is emitted per row so we can diagnose the source of the bad write.
- */
+interface CoercedAbuseEnums {
+  level: AbuseLevel;
+  trigger: AbuseTrigger;
+  /** True when `rawLevel` was not a member of `ABUSE_LEVELS` — caller may skip or escalate. */
+  levelDrifted: boolean;
+  /** True when `rawTrigger` was not a member of `ABUSE_TRIGGERS`. */
+  triggerDrifted: boolean;
+}
+
 function coerceAbuseEnums(
   rowId: string,
   rawLevel: unknown,
   rawTrigger: unknown,
-): { level: AbuseLevel; trigger: AbuseTrigger } {
+): CoercedAbuseEnums {
   const levelOk = isAbuseLevel(rawLevel);
   const triggerOk = isAbuseTrigger(rawTrigger);
   if (!levelOk || !triggerOk) {
@@ -75,6 +73,8 @@ function coerceAbuseEnums(
   return {
     level: levelOk ? rawLevel : "none",
     trigger: triggerOk ? rawTrigger : "manual",
+    levelDrifted: !levelOk,
+    triggerDrifted: !triggerOk,
   };
 }
 
@@ -517,12 +517,21 @@ export async function restoreAbuseState(): Promise<void> {
        ORDER BY workspace_id, created_at DESC`,
     );
 
+    let driftSkipped = 0;
     for (const row of rows) {
-      const { level, trigger } = coerceAbuseEnums(
+      const { level, trigger, levelDrifted } = coerceAbuseEnums(
         row.workspace_id,
         row.level,
         row.trigger_type,
       );
+      // A drifted level collapses to "none" — we can't trust that as "already
+      // reinstated" because the stored enforcement state is ambiguous. Skip,
+      // but count separately so the restore summary surfaces potential lost
+      // enforcement rather than silently dropping it.
+      if (levelDrifted) {
+        driftSkipped++;
+        continue;
+      }
       if (level === "none") continue; // Already reinstated
 
       const state = getState(row.workspace_id);
@@ -535,8 +544,13 @@ export async function restoreAbuseState(): Promise<void> {
     }
 
     const restored = [...workspaceState.values()].filter((s) => s.level !== "none").length;
-    if (restored > 0) {
-      log.info({ count: restored }, "Restored abuse state for %d workspaces", restored);
+    if (restored > 0 || driftSkipped > 0) {
+      log.info(
+        { count: restored, driftSkipped },
+        "Restored abuse state for %d workspaces (%d skipped due to enum drift)",
+        restored,
+        driftSkipped,
+      );
     }
   } catch (err) {
     log.warn(

--- a/packages/api/src/lib/security/abuse.ts
+++ b/packages/api/src/lib/security/abuse.ts
@@ -14,17 +14,69 @@
 
 import { createLogger } from "@atlas/api/lib/logger";
 import { hasInternalDB, internalExecute, internalQuery } from "@atlas/api/lib/db/internal";
-import type {
-  AbuseLevel,
-  AbuseTrigger,
-  AbuseEvent,
-  AbuseStatus,
-  AbuseThresholdConfig,
-  AbuseDetail,
+import {
+  ABUSE_LEVELS,
+  ABUSE_TRIGGERS,
+  type AbuseLevel,
+  type AbuseTrigger,
+  type AbuseEvent,
+  type AbuseStatus,
+  type AbuseThresholdConfig,
+  type AbuseDetail,
 } from "@useatlas/types";
 import { splitIntoInstances } from "./abuse-instances";
 
 const log = createLogger("abuse");
+
+// ---------------------------------------------------------------------------
+// Enum drift coercion
+// ---------------------------------------------------------------------------
+//
+// `abuse_events.level` and `abuse_events.trigger_type` are plain TEXT columns
+// historically — PR #1653 adds a CHECK constraint, but rows predating it (or
+// written by a future code path that forgot to update the tuple) may hold
+// values that fail strict `z.enum` parsing in the admin wire schema.
+//
+// A single drifted row must not crash the admin abuse page. These helpers
+// validate a raw string against the canonical tuple, coerce unknowns to a
+// safe default, and emit a `log.warn` so operators see drift in observability.
+
+const LEVEL_SET: ReadonlySet<string> = new Set(ABUSE_LEVELS);
+const TRIGGER_SET: ReadonlySet<string> = new Set(ABUSE_TRIGGERS);
+
+function isAbuseLevel(v: unknown): v is AbuseLevel {
+  return typeof v === "string" && LEVEL_SET.has(v);
+}
+
+function isAbuseTrigger(v: unknown): v is AbuseTrigger {
+  return typeof v === "string" && TRIGGER_SET.has(v);
+}
+
+/**
+ * Validate and coerce a hydrated abuse_events row's enum columns.
+ *
+ * Returns the coerced `{ level, trigger }` pair. Any unknown/non-string input
+ * is replaced with a safe default (`none` / `manual`) and a single drift
+ * warning is emitted per row so we can diagnose the source of the bad write.
+ */
+function coerceAbuseEnums(
+  rowId: string,
+  rawLevel: unknown,
+  rawTrigger: unknown,
+): { level: AbuseLevel; trigger: AbuseTrigger } {
+  const levelOk = isAbuseLevel(rawLevel);
+  const triggerOk = isAbuseTrigger(rawTrigger);
+  if (!levelOk || !triggerOk) {
+    log.warn(
+      { rowId, rawLevel, rawTrigger },
+      "abuse event with drifted enum",
+    );
+  }
+  return {
+    level: levelOk ? rawLevel : "none",
+    trigger: triggerOk ? rawTrigger : "manual",
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Configuration — env var thresholds
@@ -425,16 +477,19 @@ export async function getAbuseEvents(
       [workspaceId, limit],
     );
 
-    return rows.map((r) => ({
-      id: r.id,
-      workspaceId: r.workspace_id,
-      level: r.level as AbuseLevel,
-      trigger: r.trigger_type as AbuseTrigger,
-      message: r.message,
-      metadata: typeof r.metadata === "string" ? JSON.parse(r.metadata) as Record<string, unknown> : (r.metadata as Record<string, unknown>),
-      createdAt: r.created_at,
-      actor: r.actor,
-    }));
+    return rows.map((r) => {
+      const { level, trigger } = coerceAbuseEnums(r.id, r.level, r.trigger_type);
+      return {
+        id: r.id,
+        workspaceId: r.workspace_id,
+        level,
+        trigger,
+        message: r.message,
+        metadata: typeof r.metadata === "string" ? JSON.parse(r.metadata) as Record<string, unknown> : (r.metadata as Record<string, unknown>),
+        createdAt: r.created_at,
+        actor: r.actor,
+      };
+    });
   } catch (err) {
     log.warn(
       { err: err instanceof Error ? err.message : String(err), workspaceId },
@@ -463,12 +518,16 @@ export async function restoreAbuseState(): Promise<void> {
     );
 
     for (const row of rows) {
-      const level = row.level as AbuseLevel;
+      const { level, trigger } = coerceAbuseEnums(
+        row.workspace_id,
+        row.level,
+        row.trigger_type,
+      );
       if (level === "none") continue; // Already reinstated
 
       const state = getState(row.workspace_id);
       state.level = level;
-      state.trigger = row.trigger_type as AbuseTrigger;
+      state.trigger = trigger;
       state.message = row.message;
       state.updatedAt = new Date(row.created_at).getTime();
       // Set escalations based on current level to maintain correct position in the ladder

--- a/packages/types/src/abuse.ts
+++ b/packages/types/src/abuse.ts
@@ -2,6 +2,10 @@
 // Abuse prevention types — wire format for API + admin UI
 // ---------------------------------------------------------------------------
 
+// Adding a value here requires a matching migration to extend the DB
+// CHECK in `packages/api/src/lib/db/migrations/*_abuse_events_enum_checks.sql`
+// — otherwise `persistAbuseEvent` will fail at INSERT time.
+
 /** Graduated abuse response levels (escalation order). */
 export const ABUSE_LEVELS = ["none", "warning", "throttled", "suspended"] as const;
 export type AbuseLevel = (typeof ABUSE_LEVELS)[number];


### PR DESCRIPTION
Closes #1653.

## Summary

- `abuse_events.level` / `trigger_type` were plain TEXT with no CHECK constraint. PR #1647 made the admin wire schema strict-parse them via `z.enum(ABUSE_LEVELS)` / `z.enum(ABUSE_TRIGGERS)`, so a single drifted row would take the whole admin abuse investigation page down with a `schema_mismatch` banner. `.catch()` fallbacks at the Zod layer were rejected by `@hono/zod-openapi`, so the fix has to live at the DB + server.
- **DB**: Migration `0031_abuse_events_enum_checks.sql` coerces any pre-drifted rows to safe defaults (`none` / `manual`) and then adds `CHECK` constraints for both columns. Idempotent via `DO $$ BEGIN … EXCEPTION WHEN duplicate_object`.
- **Server**: `coerceAbuseEnums()` in `lib/security/abuse.ts` validates hydrated rows against the canonical tuples, coerces unknowns to safe defaults, and emits `log.warn({ rowId, rawLevel, rawTrigger }, "abuse event with drifted enum")`. Replaces the two unchecked `as AbuseLevel` / `as AbuseTrigger` casts in `getAbuseEvents` and `restoreAbuseState`.
- **Tests (TDD)**: Three hydration tests — drifted level → `none`, drifted trigger → `manual`, clean row emits no drift warning.

## Test plan

- [x] `/ci` — lint, type, test (242/242 api + 73/73 web + all other packages), syncpack, template drift all green.
- [x] Red-green confirmed: drift tests failed before the coercion helpers, green after.
- [x] `grep "as AbuseLevel|as AbuseTrigger"` in `packages/` is clean (only a reference comment in `packages/schemas`).
- [x] Migration is idempotent — `__atlas_migrations` check in `migrate.test.ts` + `auth/migrate.test.ts` updated to include `0031_abuse_events_enum_checks.sql`.

## Notes

- Labels already on #1653 (`bug`, `refactor`, `area: api`) are preserved via the issue link.
- No unrelated findings; no incidental issues filed.