### PR TITLE
feat(web): MutationErrorSurface — migrate platform/* admin pages (phase 2A of #1624)

### DIFF
--- a/packages/web/src/app/admin/platform/backups/page.tsx
+++ b/packages/web/src/app/admin/platform/backups/page.tsx
@@ -32,12 +32,11 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Label } from "@/components/ui/label";
-import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { StatCard } from "@/ui/components/admin/stat-card";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError } from "@/ui/lib/fetch-error";
 import { BackupsResponseSchema, BackupConfigSchema } from "@/ui/lib/admin-schemas";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { LoadingState } from "@/ui/components/admin/loading-state";
@@ -309,7 +308,7 @@ function BackupsPageContent() {
               Configure automated backup schedule, retention policy, and storage location.
             </DialogDescription>
           </DialogHeader>
-          {configError && <ErrorBanner message={friendlyError(configError)} />}
+          <MutationErrorSurface error={configError} feature="Backups" />
           {editConfig && (
             <div className="space-y-4">
               <div className="space-y-2">

--- a/packages/web/src/app/admin/platform/domains/page.tsx
+++ b/packages/web/src/app/admin/platform/domains/page.tsx
@@ -22,12 +22,11 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { StatCard } from "@/ui/components/admin/stat-card";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError } from "@/ui/lib/fetch-error";
 import { DomainsResponseSchema } from "@/ui/lib/admin-schemas";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { LoadingState } from "@/ui/components/admin/loading-state";
@@ -289,8 +288,8 @@ function DomainsPageContent() {
         </Card>
 
         {/* Verify/delete error banners */}
-        {verifyError && <ErrorBanner message={friendlyError(verifyError)} />}
-        {deleteError && <ErrorBanner message={friendlyError(deleteError)} />}
+        <MutationErrorSurface error={verifyError} feature="Custom Domains" onRetry={clearVerifyError} />
+        <MutationErrorSurface error={deleteError} feature="Custom Domains" onRetry={clearDeleteError} />
 
         {/* Add domain dialog */}
       <Dialog open={addDialog} onOpenChange={(open) => { if (!open) { setAddDialog(false); setNewDomain(""); setNewWorkspaceId(""); clearRegisterError(); } }}>
@@ -320,7 +319,7 @@ function DomainsPageContent() {
                 onChange={(e) => setNewDomain(e.target.value)}
               />
             </div>
-            {registerError && <ErrorBanner message={friendlyError(registerError)} />}
+            <MutationErrorSurface error={registerError} feature="Custom Domains" onRetry={clearRegisterError} />
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => { setAddDialog(false); setNewDomain(""); setNewWorkspaceId(""); clearRegisterError(); }}>

--- a/packages/web/src/app/admin/platform/page.tsx
+++ b/packages/web/src/app/admin/platform/page.tsx
@@ -31,11 +31,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { LoadingState } from "@/ui/components/admin/loading-state";
 import { usePlatformAdminGuard } from "@/ui/hooks/use-platform-admin-guard";
 import { StatCard } from "@/ui/components/admin/stat-card";
-import { useAdminFetch, friendlyError, useInProgressSet } from "@/ui/hooks/use-admin-fetch";
+import { useAdminFetch, useInProgressSet } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import {
   PlatformStatsSchema,
@@ -256,7 +256,7 @@ function PlatformPageContent() {
   // ── Render ───────────────────────────────────────────────────────
 
   if (statsError && wsError) {
-    return <ErrorBanner message={friendlyError(statsError)} />;
+    return <MutationErrorSurface error={statsError} feature="Platform Admin" />;
   }
 
   return (
@@ -283,7 +283,7 @@ function PlatformPageContent() {
           {statsLoading ? (
             <LoadingState message="Loading platform stats..." />
           ) : statsError ? (
-            <ErrorBanner message={friendlyError(statsError)} />
+            <MutationErrorSurface error={statsError} feature="Platform Admin" />
           ) : stats ? (
             <>
               <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
@@ -366,7 +366,7 @@ function PlatformPageContent() {
           {wsLoading ? (
             <LoadingState message="Loading workspaces..." />
           ) : wsError ? (
-            <ErrorBanner message={friendlyError(wsError)} />
+            <MutationErrorSurface error={wsError} feature="Platform Admin" />
           ) : (
             <Card className="shadow-none">
               <Table>
@@ -496,7 +496,7 @@ function PlatformPageContent() {
           {neighborsLoading ? (
             <LoadingState message="Analyzing resource usage..." />
           ) : neighborsError ? (
-            <ErrorBanner message={friendlyError(neighborsError)} />
+            <MutationErrorSurface error={neighborsError} feature="Platform Admin" />
           ) : neighborsData && neighborsData.neighbors.length === 0 ? (
             <Card className="shadow-none">
               <CardContent className="flex flex-col items-center justify-center py-12 text-muted-foreground">
@@ -573,7 +573,7 @@ function PlatformPageContent() {
           {detailLoading ? (
             <LoadingState message="Loading details..." />
           ) : detailError ? (
-            <ErrorBanner message={friendlyError(detailError)} />
+            <MutationErrorSurface error={detailError} feature="Platform Admin" />
           ) : detailData ? (
             <div className="space-y-4">
               <div className="grid grid-cols-2 gap-4">
@@ -687,7 +687,7 @@ function PlatformPageContent() {
               />
             </div>
           )}
-          {actionError && <ErrorBanner message={friendlyError(actionError)} />}
+          <MutationErrorSurface error={actionError} feature="Platform Admin" onRetry={clearActionError} />
           <DialogFooter>
             <Button variant="outline" onClick={() => { setConfirmAction(null); clearActionError(); setPurgeConfirmName(""); }}>Cancel</Button>
             <Button
@@ -722,7 +722,7 @@ function PlatformPageContent() {
               Update the plan tier for &quot;{planChange?.workspace.name}&quot;.
             </DialogDescription>
           </DialogHeader>
-          {planError && <ErrorBanner message={friendlyError(planError)} />}
+          <MutationErrorSurface error={planError} feature="Platform Admin" onRetry={clearPlanError} />
           <Select
             value={planChange?.newTier ?? "free"}
             onValueChange={(v) => planChange && setPlanChange({ ...planChange, newTier: v as PlanTier })}

--- a/packages/web/src/app/admin/platform/plugins/page.tsx
+++ b/packages/web/src/app/admin/platform/plugins/page.tsx
@@ -53,6 +53,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { LoadingState } from "@/ui/components/admin/loading-state";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
@@ -386,11 +387,11 @@ function CatalogFormDialog({
               )}
             />
 
-            {mutation.error && (
-              <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                {friendlyError(mutation.error)}
-              </div>
-            )}
+            <MutationErrorSurface
+              error={mutation.error}
+              feature="Plugin Catalog"
+              variant="inline"
+            />
 
             <DialogFooter>
               <Button type="button" variant="outline" onClick={() => handleOpenChange(false)}>

--- a/packages/web/src/app/admin/platform/residency/page.tsx
+++ b/packages/web/src/app/admin/platform/residency/page.tsx
@@ -29,13 +29,13 @@ import {
 } from "@/components/ui/select";
 import { Label } from "@/components/ui/label";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { LoadingState } from "@/ui/components/admin/loading-state";
 import { usePlatformAdminGuard } from "@/ui/hooks/use-platform-admin-guard";
 import { StatCard } from "@/ui/components/admin/stat-card";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError } from "@/ui/lib/fetch-error";
 import { RegionsResponseSchema, AssignmentsResponseSchema } from "@/ui/lib/admin-schemas";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import type { WorkspaceRegion } from "@/ui/lib/types";
@@ -276,7 +276,7 @@ function ResidencyPageContent() {
                 </SelectContent>
               </Select>
             </div>
-            {assignError && <ErrorBanner message={friendlyError(assignError)} />}
+            <MutationErrorSurface error={assignError} feature="Data Residency" onRetry={clearAssignError} />
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => { setAssignDialog(null); setSelectedRegion(""); clearAssignError(); }}>

--- a/packages/web/src/app/admin/platform/settings/page.tsx
+++ b/packages/web/src/app/admin/platform/settings/page.tsx
@@ -22,12 +22,12 @@ import {
   FormMessage,
 } from "@/components/form-dialog";
 import { Separator } from "@/components/ui/separator";
-import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { LoadingState } from "@/ui/components/admin/loading-state";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError, friendlyErrorOrNull } from "@/ui/lib/fetch-error";
+import { friendlyErrorOrNull } from "@/ui/lib/fetch-error";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { usePlatformAdminGuard } from "@/ui/hooks/use-platform-admin-guard";
 import { useDeployMode } from "@/ui/hooks/use-deploy-mode";
@@ -382,11 +382,11 @@ function BrandColorCard({
           </p>
         )}
 
-        {error && (
-          <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
-            {friendlyError(error)}
-          </div>
-        )}
+        <MutationErrorSurface
+          error={error}
+          feature="Platform Settings"
+          variant="inline"
+        />
 
         {manageable && (
           <div className="flex gap-2">
@@ -469,9 +469,11 @@ function PlatformSettingsContent() {
       </div>
 
       <div>
-        {mutationError && (
-          <ErrorBanner message={friendlyError(mutationError)} onRetry={clearMutationError} />
-        )}
+        <MutationErrorSurface
+          error={mutationError}
+          feature="Platform Settings"
+          onRetry={clearMutationError}
+        />
 
         <AdminContentWrapper
           loading={loading}

--- a/packages/web/src/app/admin/platform/sla/page.tsx
+++ b/packages/web/src/app/admin/platform/sla/page.tsx
@@ -25,14 +25,13 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
-import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { LoadingState } from "@/ui/components/admin/loading-state";
 import { usePlatformAdminGuard } from "@/ui/hooks/use-platform-admin-guard";
 import { StatCard } from "@/ui/components/admin/stat-card";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError } from "@/ui/lib/fetch-error";
 import {
   SLAWorkspacesResponseSchema,
   SLAAlertsResponseSchema,
@@ -298,7 +297,7 @@ function SLAPageContent() {
           {slaLoading ? (
             <LoadingState message="Loading SLA metrics..." />
           ) : slaError ? (
-            <ErrorBanner message={friendlyError(slaError)} />
+            <MutationErrorSurface error={slaError} feature="SLA Monitoring" />
           ) : workspaces.length === 0 ? (
             <Card className="shadow-none">
               <CardContent className="flex flex-col items-center justify-center py-12 text-muted-foreground">
@@ -373,7 +372,7 @@ function SLAPageContent() {
           {alertsLoading ? (
             <LoadingState message="Loading alerts..." />
           ) : alertsError ? (
-            <ErrorBanner message={friendlyError(alertsError)} />
+            <MutationErrorSurface error={alertsError} feature="SLA Monitoring" />
           ) : (alertsData?.alerts ?? []).length === 0 ? (
             <Card className="shadow-none">
               <CardContent className="flex flex-col items-center justify-center py-12 text-muted-foreground">
@@ -440,7 +439,7 @@ function SLAPageContent() {
           {detailLoading ? (
             <LoadingState message="Loading detail..." />
           ) : detailError ? (
-            <ErrorBanner message={friendlyError(detailError)} />
+            <MutationErrorSurface error={detailError} feature="SLA Monitoring" />
           ) : detailData ? (
             <div className="space-y-6">
               {/* Summary stats */}
@@ -516,7 +515,7 @@ function SLAPageContent() {
               Configure the default SLA alert thresholds. Alerts fire when metrics exceed these values.
             </DialogDescription>
           </DialogHeader>
-          {thresholdError && <ErrorBanner message={friendlyError(thresholdError)} />}
+          <MutationErrorSurface error={thresholdError} feature="SLA Monitoring" onRetry={clearThresholdError} />
           {editThresholds && (
             <div className="space-y-4">
               <div className="space-y-2">


### PR DESCRIPTION
## Summary

Routes ~16 mutation/fetch error sites across the `/admin/platform/*` subtree through `<MutationErrorSurface>` so `EnterpriseUpsell` (on `code === "enterprise_required"`) and `FeatureGate` (on 401/403/404/503) fire on the write path the same way `AdminContentWrapper` already handles the read path. Mechanical sweep — decision tree stays in the component (phase 1, PR #1650).

## Migrated sites

- `/admin/platform/backups` — `configError` (banner)
- `/admin/platform/domains` — `registerError`, `verifyError`, `deleteError` (banner)
- `/admin/platform/page.tsx` — `statsError` (×2 — early-return + dashboard tab), `wsError`, `neighborsError`, `detailError` (banner), `actionError`, `planError` (banner + `onRetry`)
- `/admin/platform/plugins` — `mutation.error` in catalog form (inline). Local-synthesized last-wins toggle/delete strings preserved per #1649 ("not a migration candidate")
- `/admin/platform/residency` — `assignError` (banner + `onRetry`). The pre-existing `assignmentsError.message` site uses `.message` directly (not `friendlyError`) and is out of scope per the issue
- `/admin/platform/settings` — `mutationError` (banner + `onRetry`), `BrandColorCard` inline error (inline). FormDialog `serverError` stays on `friendlyErrorOrNull()` per #1649
- `/admin/platform/sla` — `slaError`, `alertsError`, `detailError` (banner), `thresholdError` (banner + `onRetry`)

## Scope notes

- `/admin/platform/actions` is **not** in chunk A's file list and was left alone
- Carve-outs documented in #1649 are honored: local-synthesized strings (plugins last-wins toggle/delete) and `friendlyErrorOrNull()` FormDialog props stay as-is
- `feature` strings match each page's `AdminContentWrapper` feature: `Backups`, `Custom Domains`, `Platform Admin`, `Plugin Catalog`, `Data Residency`, `Platform Settings`, `SLA Monitoring`
- No new component-level tests — phase 1's `mutation-error-surface.test.tsx` covers the decision tree

## Test plan

- [x] `bun run lint` — zero output
- [x] `bun run type` — exit 0
- [x] `bun run test` — 26 / 26 packages green, 0 failures
- [x] `bun x syncpack lint` — No issues found
- [x] Template drift — passed
- [ ] Spot-check at least one platform endpoint with EE disabled — verify `enterprise_required` renders `EnterpriseUpsell` (deferred to reviewer; non-EE platform admins can hit `/api/v1/platform/sla` etc. and confirm the upsell card vs. flat error)

Closes one chunk of #1649. Remaining chunks: core admin (`/admin/connections`, `/admin/prompts`, `/admin/scheduled-tasks`, etc.) + EE-only admin + the deferred phase-1 leftovers (SCIM row-pin, billing `PlanShell.combinedError`).