### PR TITLE
fix(web): platform/* migration follow-ups — MutationErrorSurface coverage

### DIFF
--- a/packages/web/src/app/admin/platform/backups/page.tsx
+++ b/packages/web/src/app/admin/platform/backups/page.tsx
@@ -308,7 +308,7 @@ function BackupsPageContent() {
               Configure automated backup schedule, retention policy, and storage location.
             </DialogDescription>
           </DialogHeader>
-          <MutationErrorSurface error={configError} feature="Backups" />
+          <MutationErrorSurface error={configError} feature="Backups" onRetry={clearConfigError} />
           {editConfig && (
             <div className="space-y-4">
               <div className="space-y-2">

--- a/packages/web/src/app/admin/platform/page.tsx
+++ b/packages/web/src/app/admin/platform/page.tsx
@@ -255,10 +255,6 @@ function PlatformPageContent() {
 
   // ── Render ───────────────────────────────────────────────────────
 
-  if (statsError && wsError) {
-    return <MutationErrorSurface error={statsError} feature="Platform Admin" />;
-  }
-
   return (
     <div className="p-6 space-y-6">
       <div>

--- a/packages/web/src/app/admin/platform/residency/page.tsx
+++ b/packages/web/src/app/admin/platform/residency/page.tsx
@@ -28,7 +28,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Label } from "@/components/ui/label";
-import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { LoadingState } from "@/ui/components/admin/loading-state";
 import { usePlatformAdminGuard } from "@/ui/hooks/use-platform-admin-guard";
@@ -211,7 +210,7 @@ function ResidencyPageContent() {
         {assignmentsLoading ? (
           <LoadingState message="Loading assignments..." />
         ) : assignmentsError ? (
-          <ErrorBanner message={assignmentsError.message} />
+          <MutationErrorSurface error={assignmentsError} feature="Data Residency" />
         ) : (
           <Card>
             <CardContent className="p-0">

--- a/packages/web/src/app/admin/platform/residency/page.tsx
+++ b/packages/web/src/app/admin/platform/residency/page.tsx
@@ -210,7 +210,7 @@ function ResidencyPageContent() {
         {assignmentsLoading ? (
           <LoadingState message="Loading assignments..." />
         ) : assignmentsError ? (
-          <MutationErrorSurface error={assignmentsError} feature="Data Residency" />
+          <MutationErrorSurface error={assignmentsError} feature="Data Residency" onRetry={refetchAssignments} />
         ) : (
           <Card>
             <CardContent className="p-0">


### PR DESCRIPTION
## Summary

Bundle three small follow-ups from PR #1656 (phase 2A migration) review into one PR. All three are out-of-scope-for-phase-2A but trivial — 9 lines of diff.

- **#1657** — `residency/page.tsx` assignments fetch error: `ErrorBanner` → `MutationErrorSurface`, matching the regions site + assign-region dialog on the same page (consistent requestId + feature copy)
- **#1658** — `platform/page.tsx` drops the `if (statsError && wsError)` early return that silently dropped `wsError`; each tab's existing single-error path handles its own error independently
- **#1659** — `backups/page.tsx` schedule-config dialog's `MutationErrorSurface` gets `onRetry={clearConfigError}` so the Retry button actually clears the error

## Test plan

- [x] `bun run lint` — 0 errors
- [x] `bun run type` — 0 errors
- [x] `bun run test` — all pass (phase-1 covers `MutationErrorSurface`'s decision tree; no new tests needed)
- [x] `bun x syncpack lint` — no issues
- [x] Template drift — passes
- [ ] Visual spot-check `/admin/platform/residency` assignments error path
- [ ] Visual spot-check `/admin/platform/` simultaneous stats + workspaces errors
- [ ] Visual spot-check `/admin/platform/backups` Retry button clears the error

Closes #1657
Closes #1658
Closes #1659