### PR TITLE
fix(api/admin-approval): zod-openapi enum validation for ?status= (#1662)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -30298,6 +30298,25 @@
         ],
         "summary": "List approval requests",
         "description": "Returns approval requests for the organization. Filterable by status via query parameter.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "pending",
+                "approved",
+                "denied",
+                "expired"
+              ],
+              "description": "Filter requests by status.",
+              "example": "pending"
+            },
+            "required": false,
+            "description": "Filter requests by status.",
+            "name": "status",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Approval requests list",
@@ -30475,6 +30494,31 @@
           },
           "404": {
             "description": "Internal database not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Invalid query parameters",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/api/src/api/routes/__tests__/admin-approval.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-approval.test.ts
@@ -1,20 +1,16 @@
 /**
- * Tests for admin approval routes — specifically the ?status= query validation
- * on GET /queue (#1662).
- *
- * Tests the `adminApproval` sub-router directly. We exercise the
- * @hono/zod-openapi query validation by hitting the route with an invalid
- * `status` enum value and asserting the 422 validation_error response from
- * the shared `validationHook`. The 400 in the issue description corresponds
- * to "validation failed", but this project's convention is 422 via
- * `validationHook` (see packages/api/src/api/routes/validation-hook.ts).
+ * Tests for GET /api/v1/admin/approval/queue — exercises the
+ * @hono/zod-openapi query validation on `?status=` and the shared
+ * `validationHook` which surfaces zod errors as 422 (see
+ * packages/api/src/api/routes/validation-hook.ts).
  */
 
 import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
 import { Data, Effect } from "effect";
 
-// Domain error class matching the real ApprovalError from @atlas/ee/governance/approval.
-// Declared here so the mock module can return a constructor without a hoisted require().
+// Declared at module scope so `mock.module()` factories — which run before
+// imported module code — can capture this class reference. An inline require()
+// inside the factory would violate the @typescript-eslint/no-require-imports rule.
 class MockApprovalError extends Data.TaggedError("ApprovalError")<{
   message: string;
   code: "validation" | "not_found" | "conflict" | "expired";
@@ -35,19 +31,21 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getPendingAmendmentCount: async () => 0,
 }));
 
-const mockAuthenticateRequest: Mock<(req: Request) => Promise<unknown>> = mock(
-  () =>
-    Promise.resolve({
-      authenticated: true,
+const defaultAuthResponse = () =>
+  Promise.resolve({
+    authenticated: true,
+    mode: "managed",
+    user: {
+      id: "admin-1",
       mode: "managed",
-      user: {
-        id: "admin-1",
-        mode: "managed",
-        label: "admin@test.dev",
-        role: "admin",
-        activeOrganizationId: "org-test",
-      },
-    }),
+      label: "admin@test.dev",
+      role: "admin",
+      activeOrganizationId: "org-test",
+    },
+  });
+
+const mockAuthenticateRequest: Mock<(req: Request) => Promise<unknown>> = mock(
+  () => defaultAuthResponse(),
 );
 
 mock.module("@atlas/api/lib/auth/middleware", () => ({
@@ -123,9 +121,11 @@ const { adminApproval } = await import("../admin-approval");
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("GET /queue — ?status= query validation (#1662)", () => {
+describe("GET /queue — ?status= query validation", () => {
   beforeEach(() => {
     mockHasInternalDB = true;
+    mockAuthenticateRequest.mockReset();
+    mockAuthenticateRequest.mockImplementation(defaultAuthResponse);
     mockListApprovalRequests.mockClear();
     mockListApprovalRequests.mockImplementation(() => Effect.succeed([]));
   });

--- a/packages/api/src/api/routes/__tests__/admin-approval.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-approval.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for admin approval routes — specifically the ?status= query validation
+ * on GET /queue (#1662).
+ *
+ * Tests the `adminApproval` sub-router directly. We exercise the
+ * @hono/zod-openapi query validation by hitting the route with an invalid
+ * `status` enum value and asserting the 422 validation_error response from
+ * the shared `validationHook`. The 400 in the issue description corresponds
+ * to "validation failed", but this project's convention is 422 via
+ * `validationHook` (see packages/api/src/api/routes/validation-hook.ts).
+ */
+
+import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
+import { Data, Effect } from "effect";
+
+// Domain error class matching the real ApprovalError from @atlas/ee/governance/approval.
+// Declared here so the mock module can return a constructor without a hoisted require().
+class MockApprovalError extends Data.TaggedError("ApprovalError")<{
+  message: string;
+  code: "validation" | "not_found" | "conflict" | "expired";
+}> {}
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before importing the module under test
+// ---------------------------------------------------------------------------
+
+let mockHasInternalDB = true;
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => mockHasInternalDB,
+  internalQuery: async () => [],
+  internalExecute: async () => {},
+  setWorkspaceRegion: async () => {},
+  insertSemanticAmendment: async () => "mock-amendment-id",
+  getPendingAmendmentCount: async () => 0,
+}));
+
+const mockAuthenticateRequest: Mock<(req: Request) => Promise<unknown>> = mock(
+  () =>
+    Promise.resolve({
+      authenticated: true,
+      mode: "managed",
+      user: {
+        id: "admin-1",
+        mode: "managed",
+        label: "admin@test.dev",
+        role: "admin",
+        activeOrganizationId: "org-test",
+      },
+    }),
+);
+
+mock.module("@atlas/api/lib/auth/middleware", () => ({
+  authenticateRequest: mockAuthenticateRequest,
+  checkRateLimit: () => ({ allowed: true }),
+  getClientIP: () => null,
+  resetRateLimits: () => {},
+  rateLimitCleanupTick: () => {},
+}));
+
+mock.module("@atlas/api/lib/logger", () => {
+  const noop = () => {};
+  const logger = { info: noop, warn: noop, error: noop, debug: noop, child: () => logger };
+  return {
+    createLogger: () => logger,
+    getLogger: () => logger,
+    withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+    getRequestContext: () => undefined,
+    redactPaths: [],
+  };
+});
+
+mock.module("@atlas/api/lib/residency/misrouting", () => ({
+  detectMisrouting: async () => null,
+  isStrictRoutingEnabled: () => false,
+}));
+
+mock.module("@atlas/api/lib/residency/readonly", () => ({
+  isWorkspaceMigrating: async () => false,
+}));
+
+mock.module("@atlas/ee/auth/ip-allowlist", () => ({
+  checkIPAllowlist: () => Effect.succeed({ allowed: true }),
+}));
+
+// --- EE approval mock -----------------------------------------------------
+
+const mockListApprovalRequests: Mock<(orgId: string, status?: string) => ReturnType<typeof Effect.succeed>> = mock(
+  () => Effect.succeed([]),
+);
+
+mock.module("@atlas/ee/governance/approval", () => {
+  return {
+    ApprovalError: MockApprovalError,
+    listApprovalRules: () => Effect.succeed([]),
+    createApprovalRule: () => Effect.succeed({}),
+    updateApprovalRule: () => Effect.succeed({}),
+    deleteApprovalRule: () => Effect.succeed(true),
+    listApprovalRequests: mockListApprovalRequests,
+    getApprovalRequest: () => Effect.succeed(null),
+    reviewApprovalRequest: () => Effect.succeed({}),
+    expireStaleRequests: () => Effect.succeed(0),
+    getPendingCount: () => Effect.succeed(0),
+  };
+});
+
+// --- Audit mock -----------------------------------------------------------
+
+mock.module("@atlas/api/lib/audit", () => ({
+  logAdminAction: () => {},
+  ADMIN_ACTIONS: {
+    approval: { approve: "approval.approve", deny: "approval.deny" },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+const { adminApproval } = await import("../admin-approval");
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /queue — ?status= query validation (#1662)", () => {
+  beforeEach(() => {
+    mockHasInternalDB = true;
+    mockListApprovalRequests.mockClear();
+    mockListApprovalRequests.mockImplementation(() => Effect.succeed([]));
+  });
+
+  it("returns 422 validation_error when status is not a valid enum value", async () => {
+    const res = await adminApproval.request("/queue?status=frobozz");
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { error: string; message: string; details: unknown[] };
+    expect(body.error).toBe("validation_error");
+    expect(body.message).toContain("query");
+    expect(Array.isArray(body.details)).toBe(true);
+    // listApprovalRequests should NOT have been called — validation fails before the handler
+    expect(mockListApprovalRequests).not.toHaveBeenCalled();
+  });
+
+  it("accepts status=pending and passes it to listApprovalRequests", async () => {
+    const res = await adminApproval.request("/queue?status=pending");
+    expect(res.status).toBe(200);
+    expect(mockListApprovalRequests).toHaveBeenCalledTimes(1);
+    const [orgId, status] = mockListApprovalRequests.mock.calls[0]!;
+    expect(orgId).toBe("org-test");
+    expect(status).toBe("pending");
+  });
+
+  it("accepts all four valid statuses", async () => {
+    for (const status of ["pending", "approved", "denied", "expired"]) {
+      mockListApprovalRequests.mockClear();
+      const res = await adminApproval.request(`/queue?status=${status}`);
+      expect(res.status).toBe(200);
+      expect(mockListApprovalRequests).toHaveBeenCalledTimes(1);
+      expect(mockListApprovalRequests.mock.calls[0]![1]).toBe(status);
+    }
+  });
+
+  it("omits the status filter when no ?status= is provided", async () => {
+    const res = await adminApproval.request("/queue");
+    expect(res.status).toBe(200);
+    expect(mockListApprovalRequests).toHaveBeenCalledTimes(1);
+    const [orgId, status] = mockListApprovalRequests.mock.calls[0]!;
+    expect(orgId).toBe("org-test");
+    expect(status).toBeUndefined();
+  });
+});

--- a/packages/api/src/api/routes/admin-approval.ts
+++ b/packages/api/src/api/routes/admin-approval.ts
@@ -18,7 +18,7 @@
 
 import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
-import { APPROVAL_RULE_TYPES } from "@useatlas/types";
+import { APPROVAL_RULE_TYPES, APPROVAL_STATUSES } from "@useatlas/types";
 import { ApprovalRuleSchema, ApprovalRequestSchema } from "@useatlas/schemas";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect, domainError } from "@atlas/api/lib/effect/hono";
@@ -158,12 +158,24 @@ const deleteRuleRoute = createRoute({
   },
 });
 
+const ListQueueQuerySchema = z.object({
+  status: z
+    .enum(APPROVAL_STATUSES)
+    .optional()
+    .openapi({
+      description: "Filter requests by status.",
+      example: "pending",
+      param: { name: "status", in: "query" },
+    }),
+});
+
 const listQueueRoute = createRoute({
   method: "get",
   path: "/queue",
   tags: ["Admin — Approval Workflows"],
   summary: "List approval requests",
   description: "Returns approval requests for the organization. Filterable by status via query parameter.",
+  request: { query: ListQueueQuerySchema },
   responses: {
     200: {
       description: "Approval requests list",
@@ -173,6 +185,7 @@ const listQueueRoute = createRoute({
     401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
     403: { description: "Forbidden", content: { "application/json": { schema: AuthErrorSchema } } },
     404: { description: "Internal database not configured", content: { "application/json": { schema: ErrorSchema } } },
+    422: { description: "Invalid query parameters", content: { "application/json": { schema: ErrorSchema } } },
     500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
@@ -334,12 +347,9 @@ adminApproval.openapi(deleteRuleRoute, async (c) => {
 
 // GET /queue — list approval requests
 adminApproval.openapi(listQueueRoute, async (c) => {
+  const { status } = c.req.valid("query");
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
-
-    const statusParam = new URL(c.req.raw.url).searchParams.get("status") as import("@useatlas/types").ApprovalStatus | null;
-    const validStatuses = ["pending", "approved", "denied", "expired"];
-    const status = statusParam && validStatuses.includes(statusParam) ? statusParam as import("@useatlas/types").ApprovalStatus : undefined;
     const requests = yield* listApprovalRequests(orgId!, status);
     return c.json({ requests }, 200);
   }), { label: "list approval requests", domainErrors: [approvalDomainError] });


### PR DESCRIPTION
## Summary

- Replace manual `searchParams.get` + hardcoded `validStatuses` fallback on `GET /api/v1/admin/approval/queue` with a `z.enum(APPROVAL_STATUSES)` query schema — invalid values now fail validation instead of silently returning all statuses.
- Surface the valid `status` enum in the OpenAPI spec automatically.
- 422 response shape added to the route (project convention via `validationHook` at `packages/api/src/api/routes/validation-hook.ts` — the issue description calls this "400" loosely; the 422 vs 400 choice matches how every other route in this codebase handles zod validation errors).

Closes #1662. Milestone: `1.2.2 — Admin Console Polish & Schema Consolidation`.

## What changed

`packages/api/src/api/routes/admin-approval.ts`:
- Import `APPROVAL_STATUSES` from `@useatlas/types`.
- New `ListQueueQuerySchema` with `status: z.enum(APPROVAL_STATUSES).optional()` + OpenAPI param metadata.
- `listQueueRoute` now declares `request: { query: ListQueueQuerySchema }` and a `422` response.
- Handler reads `c.req.valid("query").status` — the double-cast (`as ApprovalStatus | null`), the hardcoded list, and the `new URL(c.req.raw.url).searchParams.get(...)` call are gone.

`packages/api/src/api/routes/__tests__/admin-approval.test.ts` (new — TDD):
- `?status=frobozz` → 422 `validation_error`, handler never called.
- `?status=pending` → 200, forwarded to `listApprovalRequests` as `"pending"`.
- All four valid statuses accepted: `pending`, `approved`, `denied`, `expired`.
- No `?status=` → 200, `status` forwarded as `undefined` (no filter).

`apps/docs/openapi.json`:
- Regenerated. `/api/v1/admin/approval/queue` now exposes the `status` param as `enum: [pending, approved, denied, expired]` plus the 422 response.

## CI gates

- Lint: 0 errors / 0 warnings
- Type: 0 errors
- Test: 243/243 api, 73/73 web, 25/25 ee — all packages green
- Syncpack: No issues
- Template drift: passed
- OpenAPI drift: passed (regen included in this PR)

## Test plan

- [ ] `bun test packages/api/src/api/routes/__tests__/admin-approval.test.ts` — 4 pass
- [ ] `bash scripts/check-openapi-drift.sh` — passes
- [ ] Manual: `curl /api/v1/admin/approval/queue?status=frobozz` → 422 with `{ error: "validation_error", details: [...] }`
- [ ] Manual: `curl /api/v1/admin/approval/queue?status=pending` → 200 with pending-only subset
- [ ] Manual: `curl /api/v1/admin/approval/queue` → 200 with all statuses (unchanged behavior)

## Reference

Follow-on to #1654 (`@useatlas/schemas` with `ApprovalRule`/`ApprovalRequest`). This PR completes the request-side validation story for the approval queue.