### PR TITLE
polish(web/admin/users): relative timestamps + destructive confirms + MutationErrorSurface

### DIFF
--- a/packages/web/src/app/admin/users/__tests__/columns.test.ts
+++ b/packages/web/src/app/admin/users/__tests__/columns.test.ts
@@ -3,12 +3,10 @@ import { getUserColumns, getInvitationColumns } from "../columns";
 
 describe("getUserColumns", () => {
   test("returns the documented column ids in order", () => {
+    // Column ids are the wire contract for the DataTable toolbar (sort list,
+    // visibility menu) and `page.tsx` defaults sort to `{ id: "createdAt",
+    // desc: true }` — a silent rename breaks the default sort.
     const ids = getUserColumns().map((c) => c.id);
-    // The wire contract the DataTable toolbar sort list + visibility menu key
-    // off of. Bucket-2 polish swapped the `createdAt` cell to RelativeTimestamp
-    // — pin the id + position so a future polish pass can't accidentally
-    // rename it (breaks the default sort `{ id: "createdAt", desc: true }` in
-    // page.tsx) or drop the column entirely.
     expect(ids).toEqual(["email", "name", "role", "status", "createdAt"]);
   });
 });
@@ -16,10 +14,6 @@ describe("getUserColumns", () => {
 describe("getInvitationColumns", () => {
   test("returns the documented column ids in order", () => {
     const ids = getInvitationColumns().map((c) => c.id);
-    // Same pinning intent as the users table: `expires_at` and `created_at`
-    // both now render through RelativeTimestamp, and the column order is the
-    // reading-order operators expect (email → role → status → expiration →
-    // sent date). Rename/reorder should be a deliberate change.
     expect(ids).toEqual(["email", "role", "status", "expires_at", "created_at"]);
   });
 });

--- a/packages/web/src/app/admin/users/__tests__/columns.test.ts
+++ b/packages/web/src/app/admin/users/__tests__/columns.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { getUserColumns, getInvitationColumns } from "../columns";
+
+describe("getUserColumns", () => {
+  test("returns the documented column ids in order", () => {
+    const ids = getUserColumns().map((c) => c.id);
+    // The wire contract the DataTable toolbar sort list + visibility menu key
+    // off of. Bucket-2 polish swapped the `createdAt` cell to RelativeTimestamp
+    // — pin the id + position so a future polish pass can't accidentally
+    // rename it (breaks the default sort `{ id: "createdAt", desc: true }` in
+    // page.tsx) or drop the column entirely.
+    expect(ids).toEqual(["email", "name", "role", "status", "createdAt"]);
+  });
+});
+
+describe("getInvitationColumns", () => {
+  test("returns the documented column ids in order", () => {
+    const ids = getInvitationColumns().map((c) => c.id);
+    // Same pinning intent as the users table: `expires_at` and `created_at`
+    // both now render through RelativeTimestamp, and the column order is the
+    // reading-order operators expect (email → role → status → expiration →
+    // sent date). Rename/reorder should be a deliberate change.
+    expect(ids).toEqual(["email", "role", "status", "expires_at", "created_at"]);
+  });
+});

--- a/packages/web/src/app/admin/users/__tests__/roles.test.ts
+++ b/packages/web/src/app/admin/users/__tests__/roles.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { isDemotion } from "../roles";
+
+describe("isDemotion", () => {
+  test("promotions are not demotions", () => {
+    expect(isDemotion("member", "admin")).toBe(false);
+    expect(isDemotion("member", "owner")).toBe(false);
+    expect(isDemotion("admin", "owner")).toBe(false);
+  });
+
+  test("strict rank drops are demotions", () => {
+    expect(isDemotion("owner", "admin")).toBe(true);
+    expect(isDemotion("owner", "member")).toBe(true);
+    expect(isDemotion("admin", "member")).toBe(true);
+  });
+
+  test("unknown `from` role fails closed — always a demotion", () => {
+    // If the server returns a role Atlas doesn't know about (legacy "guest",
+    // future "billing-admin", DB drift, a platform-only role leaking into
+    // the workspace API), we route every change through the confirm
+    // AlertDialog. Silently bucketing unknown as `member` would let an
+    // operator strip privileges with a single click — exactly the class
+    // of accidental-demote the dialog exists to prevent.
+    expect(isDemotion("guest", "member")).toBe(true);
+    expect(isDemotion("platform_admin", "admin")).toBe(true);
+    expect(isDemotion("", "owner")).toBe(true);
+  });
+});

--- a/packages/web/src/app/admin/users/columns.tsx
+++ b/packages/web/src/app/admin/users/columns.tsx
@@ -3,6 +3,7 @@
 import type { ColumnDef } from "@tanstack/react-table";
 import { Badge } from "@/components/ui/badge";
 import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
+import { RelativeTimestamp } from "@/ui/components/admin/queue";
 import { Mail, UserIcon, Shield, Activity, Calendar } from "lucide-react";
 
 // ── Types ─────────────────────────────────────────────────────────
@@ -126,11 +127,8 @@ export function getUserColumns(): ColumnDef<User>[] {
         <DataTableColumnHeader column={column} label="Created" />
       ),
       cell: ({ row }) => (
-        <span className="text-xs text-muted-foreground">
-          {new Date(row.getValue<string>("createdAt")).toLocaleDateString(
-            undefined,
-            { month: "short", day: "numeric", year: "numeric" },
-          )}
+        <span className="text-xs text-muted-foreground whitespace-nowrap">
+          <RelativeTimestamp iso={row.getValue<string>("createdAt")} />
         </span>
       ),
       meta: { label: "Created", icon: Calendar },
@@ -197,11 +195,8 @@ export function getInvitationColumns(): ColumnDef<Invitation>[] {
         <DataTableColumnHeader column={column} label="Expires" />
       ),
       cell: ({ row }) => (
-        <span className="text-xs text-muted-foreground">
-          {new Date(row.getValue<string>("expires_at")).toLocaleDateString(
-            undefined,
-            { month: "short", day: "numeric", year: "numeric" },
-          )}
+        <span className="text-xs text-muted-foreground whitespace-nowrap">
+          <RelativeTimestamp iso={row.getValue<string>("expires_at")} />
         </span>
       ),
       meta: { label: "Expires", icon: Calendar },
@@ -214,11 +209,8 @@ export function getInvitationColumns(): ColumnDef<Invitation>[] {
         <DataTableColumnHeader column={column} label="Sent" />
       ),
       cell: ({ row }) => (
-        <span className="text-xs text-muted-foreground">
-          {new Date(row.getValue<string>("created_at")).toLocaleDateString(
-            undefined,
-            { month: "short", day: "numeric", year: "numeric" },
-          )}
+        <span className="text-xs text-muted-foreground whitespace-nowrap">
+          <RelativeTimestamp iso={row.getValue<string>("created_at")} />
         </span>
       ),
       meta: { label: "Sent", icon: Calendar },

--- a/packages/web/src/app/admin/users/page.tsx
+++ b/packages/web/src/app/admin/users/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useQueryStates } from "nuqs";
 import { z } from "zod";
 import { usersSearchParams } from "./search-params";
+import { ROLES, isDemotion, type Role } from "./roles";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useAtlasConfig } from "@/ui/context";
 import { useUserRole } from "@/ui/hooks/use-platform-admin-guard";
@@ -100,19 +101,10 @@ type ConfirmAction =
   | { type: "delete"; user: User }
   | { type: "revoke-sessions"; user: User }
   | { type: "revoke-invitation"; invitation: Invitation }
-  | { type: "role-demote"; user: User; newRole: (typeof ROLES)[number] }
+  | { type: "role-demote"; user: User; newRole: Role }
   | null;
 
 const LIMIT = 50;
-const ROLES = ["member", "admin", "owner"] as const;
-// Rank for detecting demotions — higher is more privileged. Promotions skip
-// the confirm step; demotions route through AlertDialog so an accidental
-// click doesn't strip a coworker's access.
-const ROLE_RANK: Record<(typeof ROLES)[number], number> = {
-  member: 0,
-  admin: 1,
-  owner: 2,
-};
 
 const inviteSchema = z.object({
   email: z.string().email("Valid email address is required"),
@@ -186,14 +178,11 @@ export default function UsersPage() {
             <DropdownMenuContent align="end">
               {ROLES.map((r) => {
                 if (r === user.role) return null;
-                const fromRank = ROLE_RANK[user.role as keyof typeof ROLE_RANK] ?? 0;
-                const toRank = ROLE_RANK[r];
-                const isDemotion = toRank < fromRank;
                 return (
                   <DropdownMenuItem
                     key={r}
                     onClick={() =>
-                      isDemotion
+                      isDemotion(user.role, r)
                         ? setConfirmAction({ type: "role-demote", user, newRole: r })
                         : handleRoleChange(user.id, r)
                     }
@@ -365,22 +354,29 @@ export default function UsersPage() {
     setParams({ search: searchInput, page: 1 });
   }
 
-  async function handleRoleChange(userId: string, newRole: string) {
-    await adminAction.mutate({
+  // Destructive-action handlers return `ok` so the confirm AlertDialog stays
+  // open on failure (keeping the inline context visible while the mutation
+  // error surfaces via MutationErrorSurface above the table). Closing the
+  // dialog unconditionally on await would dismiss the operator back to a
+  // list where a failure banner may be off-screen.
+
+  async function handleRoleChange(userId: string, newRole: string): Promise<boolean> {
+    const result = await adminAction.mutate({
       path: `/api/v1/admin/users/${userId}/role`,
       method: "PATCH",
       body: { role: newRole },
       itemId: userId,
     });
+    return result.ok;
   }
 
-  async function handleBan(user: User) {
-    await adminAction.mutate({
+  async function handleBan(user: User): Promise<boolean> {
+    const result = await adminAction.mutate({
       path: `/api/v1/admin/users/${user.id}/ban`,
       method: "POST",
       itemId: user.id,
     });
-    setConfirmAction(null);
+    return result.ok;
   }
 
   async function handleUnban(userId: string) {
@@ -391,21 +387,22 @@ export default function UsersPage() {
     });
   }
 
-  async function handleRevoke(userId: string) {
-    await adminAction.mutate({
+  async function handleRevoke(userId: string): Promise<boolean> {
+    const result = await adminAction.mutate({
       path: `/api/v1/admin/users/${userId}/revoke`,
       method: "POST",
       itemId: userId,
     });
+    return result.ok;
   }
 
-  async function handleDelete(user: User) {
-    await adminAction.mutate({
+  async function handleDelete(user: User): Promise<boolean> {
+    const result = await adminAction.mutate({
       path: `/api/v1/admin/users/${user.id}`,
       method: "DELETE",
       itemId: user.id,
     });
-    setConfirmAction(null);
+    return result.ok;
   }
 
   // -- Invite handlers --
@@ -437,11 +434,12 @@ export default function UsersPage() {
     }
   }
 
-  async function handleRevokeInvitation(id: string) {
-    await revokeInvitation.mutate({
+  async function handleRevokeInvitation(id: string): Promise<boolean> {
+    const result = await revokeInvitation.mutate({
       path: `/api/v1/admin/users/invitations/${id}`,
       onSuccess: () => setInvitationsVersion((v) => v + 1),
     });
+    return result.ok;
   }
 
   const pendingInvitations = invitations.filter((i) => i.status === "pending");
@@ -733,7 +731,11 @@ export default function UsersPage() {
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
-              onClick={() => { if (confirmAction?.type === "ban") handleBan(confirmAction.user); }}
+              onClick={async () => {
+                if (confirmAction?.type !== "ban") return;
+                const ok = await handleBan(confirmAction.user);
+                if (ok) setConfirmAction(null);
+              }}
             >
               Ban user
             </AlertDialogAction>
@@ -758,7 +760,11 @@ export default function UsersPage() {
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              onClick={() => { if (confirmAction?.type === "delete") handleDelete(confirmAction.user); }}
+              onClick={async () => {
+                if (confirmAction?.type !== "delete") return;
+                const ok = await handleDelete(confirmAction.user);
+                if (ok) setConfirmAction(null);
+              }}
             >
               Delete user
             </AlertDialogAction>
@@ -782,11 +788,10 @@ export default function UsersPage() {
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
-              onClick={() => {
-                if (confirmAction?.type === "revoke-sessions") {
-                  handleRevoke(confirmAction.user.id);
-                  setConfirmAction(null);
-                }
+              onClick={async () => {
+                if (confirmAction?.type !== "revoke-sessions") return;
+                const ok = await handleRevoke(confirmAction.user.id);
+                if (ok) setConfirmAction(null);
               }}
             >
               Sign out
@@ -811,11 +816,10 @@ export default function UsersPage() {
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
-              onClick={() => {
-                if (confirmAction?.type === "revoke-invitation") {
-                  handleRevokeInvitation(confirmAction.invitation.id);
-                  setConfirmAction(null);
-                }
+              onClick={async () => {
+                if (confirmAction?.type !== "revoke-invitation") return;
+                const ok = await handleRevokeInvitation(confirmAction.invitation.id);
+                if (ok) setConfirmAction(null);
               }}
             >
               Revoke
@@ -844,11 +848,13 @@ export default function UsersPage() {
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
-              onClick={() => {
-                if (confirmAction?.type === "role-demote") {
-                  handleRoleChange(confirmAction.user.id, confirmAction.newRole);
-                  setConfirmAction(null);
-                }
+              onClick={async () => {
+                if (confirmAction?.type !== "role-demote") return;
+                const ok = await handleRoleChange(
+                  confirmAction.user.id,
+                  confirmAction.newRole,
+                );
+                if (ok) setConfirmAction(null);
               }}
             >
               Change role

--- a/packages/web/src/app/admin/users/page.tsx
+++ b/packages/web/src/app/admin/users/page.tsx
@@ -53,9 +53,11 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { StatCard } from "@/ui/components/admin/stat-card";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import {
   FormDialog,
   FormField,
@@ -69,7 +71,7 @@ import {
   type FetchError,
 } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError, friendlyErrorOrNull } from "@/ui/lib/fetch-error";
+import { friendlyErrorOrNull } from "@/ui/lib/fetch-error";
 import { UserStatsSchema } from "@/ui/lib/admin-schemas";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import {
@@ -96,10 +98,21 @@ import {
 type ConfirmAction =
   | { type: "ban"; user: User }
   | { type: "delete"; user: User }
+  | { type: "revoke-sessions"; user: User }
+  | { type: "revoke-invitation"; invitation: Invitation }
+  | { type: "role-demote"; user: User; newRole: (typeof ROLES)[number] }
   | null;
 
 const LIMIT = 50;
 const ROLES = ["member", "admin", "owner"] as const;
+// Rank for detecting demotions — higher is more privileged. Promotions skip
+// the confirm step; demotions route through AlertDialog so an accidental
+// click doesn't strip a coworker's access.
+const ROLE_RANK: Record<(typeof ROLES)[number], number> = {
+  member: 0,
+  admin: 1,
+  owner: 2,
+};
 
 const inviteSchema = z.object({
   email: z.string().email("Valid email address is required"),
@@ -171,17 +184,25 @@ export default function UsersPage() {
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              {ROLES.map((r) =>
-                r !== user.role ? (
+              {ROLES.map((r) => {
+                if (r === user.role) return null;
+                const fromRank = ROLE_RANK[user.role as keyof typeof ROLE_RANK] ?? 0;
+                const toRank = ROLE_RANK[r];
+                const isDemotion = toRank < fromRank;
+                return (
                   <DropdownMenuItem
                     key={r}
-                    onClick={() => handleRoleChange(user.id, r)}
+                    onClick={() =>
+                      isDemotion
+                        ? setConfirmAction({ type: "role-demote", user, newRole: r })
+                        : handleRoleChange(user.id, r)
+                    }
                   >
                     <Shield className="mr-2 size-4" />
                     Set {r}
                   </DropdownMenuItem>
-                ) : null,
-              )}
+                );
+              })}
               <DropdownMenuSeparator />
               {user.banned ? (
                 <DropdownMenuItem onClick={() => handleUnban(user.id)}>
@@ -196,9 +217,11 @@ export default function UsersPage() {
                   Ban user
                 </DropdownMenuItem>
               )}
-              <DropdownMenuItem onClick={() => handleRevoke(user.id)}>
+              <DropdownMenuItem
+                onClick={() => setConfirmAction({ type: "revoke-sessions", user })}
+              >
                 <LogOut className="mr-2 size-4" />
-                Revoke sessions
+                Sign out all sessions
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem
@@ -245,8 +268,11 @@ export default function UsersPage() {
             variant="ghost"
             size="sm"
             className="size-8 p-0 text-muted-foreground hover:text-destructive"
-            onClick={() => handleRevokeInvitation(inv.id)}
+            onClick={() =>
+              setConfirmAction({ type: "revoke-invitation", invitation: inv })
+            }
             title="Revoke invitation"
+            aria-label={`Revoke invitation to ${inv.email}`}
           >
             <X className="size-4" />
           </Button>
@@ -421,6 +447,7 @@ export default function UsersPage() {
   const pendingInvitations = invitations.filter((i) => i.status === "pending");
 
   return (
+    <TooltipProvider>
     <div className="p-6">
       {/* Header */}
       <div className="mb-6 flex items-center justify-between">
@@ -512,8 +539,16 @@ export default function UsersPage() {
         </div>
 
         {/* Content */}
-        {adminAction.error && <ErrorBanner message={friendlyError(adminAction.error)} onRetry={adminAction.clearError} />}
-        {revokeInvitation.error && <ErrorBanner message={friendlyError(revokeInvitation.error)} onRetry={revokeInvitation.clearError} />}
+        <MutationErrorSurface
+          error={adminAction.error}
+          feature="Users"
+          onRetry={adminAction.clearError}
+        />
+        <MutationErrorSurface
+          error={revokeInvitation.error}
+          feature="Users"
+          onRetry={revokeInvitation.clearError}
+        />
 
         <AdminContentWrapper
           loading={loading}
@@ -544,9 +579,11 @@ export default function UsersPage() {
           <div className="space-y-3">
             <div className="flex items-center gap-2">
               <Mail className="size-4 text-muted-foreground" />
-              <h2 className="text-lg font-semibold">Pending Invitations</h2>
+              <h2 className="text-lg font-semibold">Invitations</h2>
               {pendingInvitations.length > 0 && (
-                <Badge variant="outline">{pendingInvitations.length}</Badge>
+                <Badge variant="outline">
+                  {pendingInvitations.length} pending
+                </Badge>
               )}
             </div>
             <DataTable table={invitationsTable} />
@@ -728,6 +765,98 @@ export default function UsersPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* Revoke sessions confirmation dialog */}
+      <AlertDialog
+        open={confirmAction?.type === "revoke-sessions"}
+        onOpenChange={(open) => { if (!open) setConfirmAction(null); }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Sign out all sessions?</AlertDialogTitle>
+            <AlertDialogDescription>
+              <strong>{confirmAction?.type === "revoke-sessions" ? confirmAction.user.email : ""}</strong> will
+              be signed out of every active session immediately. They will need to sign in again to continue.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (confirmAction?.type === "revoke-sessions") {
+                  handleRevoke(confirmAction.user.id);
+                  setConfirmAction(null);
+                }
+              }}
+            >
+              Sign out
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Revoke invitation confirmation dialog */}
+      <AlertDialog
+        open={confirmAction?.type === "revoke-invitation"}
+        onOpenChange={(open) => { if (!open) setConfirmAction(null); }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Revoke invitation?</AlertDialogTitle>
+            <AlertDialogDescription>
+              The invite link for <strong>{confirmAction?.type === "revoke-invitation" ? confirmAction.invitation.email : ""}</strong> will
+              stop working immediately. You can send a new invitation at any time.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (confirmAction?.type === "revoke-invitation") {
+                  handleRevokeInvitation(confirmAction.invitation.id);
+                  setConfirmAction(null);
+                }
+              }}
+            >
+              Revoke
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Role demote confirmation dialog */}
+      <AlertDialog
+        open={confirmAction?.type === "role-demote"}
+        onOpenChange={(open) => { if (!open) setConfirmAction(null); }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Change role to {confirmAction?.type === "role-demote" ? confirmAction.newRole : ""}?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              <strong>{confirmAction?.type === "role-demote" ? confirmAction.user.email : ""}</strong> will
+              lose access to features available at their current <strong>
+                {confirmAction?.type === "role-demote" ? confirmAction.user.role : ""}
+              </strong> role. You can restore it later.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (confirmAction?.type === "role-demote") {
+                  handleRoleChange(confirmAction.user.id, confirmAction.newRole);
+                  setConfirmAction(null);
+                }
+              }}
+            >
+              Change role
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
+    </TooltipProvider>
   );
 }

--- a/packages/web/src/app/admin/users/roles.ts
+++ b/packages/web/src/app/admin/users/roles.ts
@@ -1,0 +1,30 @@
+// Shared role constants + demotion helper used by page.tsx and tested in
+// isolation (see __tests__/roles.test.ts). Extracted so the fail-closed
+// behavior on unknown roles is exercised without mounting the page.
+
+export const ROLES = ["member", "admin", "owner"] as const;
+export type Role = (typeof ROLES)[number];
+
+// Rank for detecting demotions — higher is more privileged.
+const ROLE_RANK: Record<Role, number> = {
+  member: 0,
+  admin: 1,
+  owner: 2,
+};
+
+/**
+ * Decide whether changing `from` → `to` should route through the
+ * "confirm destructive change" AlertDialog. Promotions skip the confirm;
+ * demotions gate behind it.
+ *
+ * Fail-closed on unknown `from` roles (anything outside {member, admin,
+ * owner} — legacy "guest", a future "billing-admin", DB drift, etc.).
+ * Silently treating unknown → member as rank 0 would let a stray role
+ * skip the confirm for *every* target role, defeating the safeguard on
+ * exactly the users hardest to reason about. Unknown → always confirm.
+ */
+export function isDemotion(from: string, to: Role): boolean {
+  const fromRank = ROLE_RANK[from as Role];
+  if (fromRank === undefined) return true;
+  return ROLE_RANK[to] < fromRank;
+}


### PR DESCRIPTION
## Summary

Bucket-2 polish pass on `/admin/users` per tracker #1588, plus the #1649 phase-2 MutationErrorSurface migration folded in so we don't revisit this page. Operator-facing page gets targeted affordance fixes, not a structural revamp.

### Polish

- **Relative timestamps** — `createdAt` (users) and `expires_at` / `created_at` (invitations) swap from `toLocaleDateString` to `RelativeTimestamp` from `@/ui/components/admin/queue`. Page now wraps in `TooltipProvider` so the absolute datetime renders on hover. Mirrors /admin/sessions precedent (PR #1628).
- **Destructive confirms** — `AlertDialog` guards added for the three operator actions that previously fired on a single click:
  - "Sign out all sessions" (was one-click "Revoke sessions")
  - "Revoke invitation" (was the one-click X in the invitations row)
  - Role demotions (owner→admin, owner→member, admin→member) — promotions stay one-click
  - Unban remains one-click (non-destructive reversal of Ban, which is confirmed)
- **Clarify copy** — "Revoke sessions" → "Sign out all sessions" (what it actually does); section header "Pending Invitations" → "Invitations" with a "N pending" count badge (the table actually contains accepted/expired/revoked rows too); added aria-label on the invitation revoke X button.

### MutationErrorSurface (#1649 subset)

`adminAction.error` and `revokeInvitation.error` route through `MutationErrorSurface` so a non-EE admin hitting a gated op (role change, ban, delete) sees the `EnterpriseUpsell` instead of a flattened `friendlyError` string. The invitations-fetch `ErrorBanner` (read-path, different surface) stays as-is; `FormDialog` serverError on the invite form keeps using `friendlyErrorOrNull` per the phase-1 carve-out.

### Tests

Added `__tests__/columns.test.ts` pinning the column id sequence for both `getUserColumns` and `getInvitationColumns`. Cheap structural guard — follows the sessions precedent from PR #1651 — so a future polish pass can't accidentally drop `createdAt` (the default sort key) or reorder the reading-order columns operators expect.

### Scope guard

Per tracker #1588, bucket-2 is polish-only. Skipped:

- Migrating the users-list fetch from `useState` + `useEffect` to `useAdminFetch` (sessions did this in PR #1628 — structural, out of scope here).
- Extracting a shared confirm-dialog primitive — only two pages use this shape so far; wait for a third adopter per the "three-adopter rule" used for `@/ui/components/admin/queue/`.

## Test plan

- [x] `bun run type`
- [x] `bun run lint`
- [x] `bun run test` (users columns test added — passes)
- [x] `bun x syncpack lint`
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh`
- [ ] Browser spot-check — deferred; reviewer should verify:
  - `/admin/users` table renders, timestamps show relative + hover tooltip
  - Row actions menu: "Sign out all sessions" opens confirm dialog; demoting an owner→member opens confirm; promoting member→admin does not
  - Invitations table X button opens confirm dialog
  - Triggering an EE-gated mutation as a non-EE admin shows `EnterpriseUpsell` banner (not a flat error string)

Refs tracker #1588 bucket-2, #1649 phase-2 MutationErrorSurface migration.