### PR TITLE
polish(web/admin/organizations): relative timestamps + sheet header + role badges

### DIFF
--- a/packages/web/src/app/admin/organizations/__tests__/roles.test.ts
+++ b/packages/web/src/app/admin/organizations/__tests__/roles.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { Crown, Shield, ShieldCheck } from "lucide-react";
+import { roleBadge } from "../roles";
+
+describe("roleBadge", () => {
+  test("owner resolves to Crown + purple classes", () => {
+    const { Icon, className } = roleBadge("owner");
+    expect(Icon).toBe(Crown);
+    expect(className).toContain("text-purple-700");
+  });
+
+  test("admin resolves to ShieldCheck + red classes", () => {
+    const { Icon, className } = roleBadge("admin");
+    expect(Icon).toBe(ShieldCheck);
+    expect(className).toContain("text-red-700");
+  });
+
+  test("member resolves to Shield + primary classes", () => {
+    const { Icon, className } = roleBadge("member");
+    expect(Icon).toBe(Shield);
+    expect(className).toContain("text-primary");
+  });
+
+  test("unknown roles fall back to the neutral member variant", () => {
+    // If the server returns a role the UI doesn't know about (legacy
+    // "guest", future "billing-admin", DB drift), the sheet must still
+    // render a readable badge instead of an empty className. The member
+    // variant is the safe default — it's the lowest-privilege role and
+    // matches the rendering an operator would expect for "unknown".
+    const unknown = roleBadge("billing-admin");
+    expect(unknown.Icon).toBe(Shield);
+    expect(unknown.className).toContain("text-primary");
+
+    const empty = roleBadge("");
+    expect(empty.Icon).toBe(Shield);
+    expect(empty.className).toContain("text-primary");
+  });
+});

--- a/packages/web/src/app/admin/organizations/__tests__/roles.test.ts
+++ b/packages/web/src/app/admin/organizations/__tests__/roles.test.ts
@@ -1,38 +1,69 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { Crown, Shield, ShieldCheck } from "lucide-react";
 import { roleBadge } from "../roles";
 
 describe("roleBadge", () => {
+  let warnSpy: ReturnType<typeof spyOn<Console, "warn">>;
+
+  afterEach(() => {
+    warnSpy?.mockRestore();
+  });
+
   test("owner resolves to Crown + purple classes", () => {
+    warnSpy = spyOn(console, "warn").mockImplementation(() => {});
     const { Icon, className } = roleBadge("owner");
     expect(Icon).toBe(Crown);
     expect(className).toContain("text-purple-700");
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   test("admin resolves to ShieldCheck + red classes", () => {
+    warnSpy = spyOn(console, "warn").mockImplementation(() => {});
     const { Icon, className } = roleBadge("admin");
     expect(Icon).toBe(ShieldCheck);
     expect(className).toContain("text-red-700");
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   test("member resolves to Shield + primary classes", () => {
+    warnSpy = spyOn(console, "warn").mockImplementation(() => {});
     const { Icon, className } = roleBadge("member");
     expect(Icon).toBe(Shield);
     expect(className).toContain("text-primary");
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  test("unknown roles fall back to the neutral member variant", () => {
-    // If the server returns a role the UI doesn't know about (legacy
-    // "guest", future "billing-admin", DB drift), the sheet must still
-    // render a readable badge instead of an empty className. The member
-    // variant is the safe default — it's the lowest-privilege role and
-    // matches the rendering an operator would expect for "unknown".
-    const unknown = roleBadge("billing-admin");
+  test("unknown roles fall back to the neutral member variant and warn once", () => {
+    // Fail-safe rendering: if the server returns a role the UI doesn't know
+    // about (legacy "guest", future "billing-admin", DB drift, an enterprise
+    // role leaking into the community enum), the sheet must still render a
+    // readable badge instead of an empty className. The member variant is
+    // the safe default — it's the lowest-privilege role and matches what an
+    // operator would expect for "unknown."
+    //
+    // The `console.warn` is the drift-detection signal for operators / Sentry
+    // breadcrumbs. One warn per unique unknown role per session avoids
+    // spamming the console when a workspace has many members with the same
+    // drifted role.
+    //
+    // Note: this is the *opposite* safety posture from
+    // `app/admin/users/roles.ts`'s `isDemotion`, which is fail-*closed*
+    // (unknown → always confirm). Display fails safe; permission-change
+    // gates fail closed.
+    warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+
+    const unknown = roleBadge("fail-safe-rendering-test-role");
     expect(unknown.Icon).toBe(Shield);
     expect(unknown.className).toContain("text-primary");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain("fail-safe-rendering-test-role");
 
-    const empty = roleBadge("");
-    expect(empty.Icon).toBe(Shield);
-    expect(empty.className).toContain("text-primary");
+    // Same unknown role a second time — dedup should suppress the warn.
+    roleBadge("fail-safe-rendering-test-role");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    // A different unknown role warns exactly once more.
+    roleBadge("another-unknown-role");
+    expect(warnSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/web/src/app/admin/organizations/page.tsx
+++ b/packages/web/src/app/admin/organizations/page.tsx
@@ -14,10 +14,6 @@ import { DataTableSortList } from "@/components/data-table/data-table-sort-list"
 import { useDataTable } from "@/hooks/use-data-table";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-
-
-
-
 import {
   Sheet,
   SheetContent,
@@ -29,18 +25,16 @@ import { StatCard } from "@/ui/components/admin/stat-card";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import type { FetchError } from "@/ui/hooks/use-admin-fetch";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
+import { RelativeTimestamp } from "@/ui/components/admin/queue";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { roleBadge } from "./roles";
 import {
   Building2,
   Search,
   Users,
   Eye,
-  Shield,
-  ShieldCheck,
-  Crown,
   Mail,
 } from "lucide-react";
-
-
 
 // -- Types --
 
@@ -77,12 +71,6 @@ interface OrgDetail {
     createdAt: string;
   }>;
 }
-
-const ROLE_ICONS: Record<string, typeof Crown> = {
-  owner: Crown,
-  admin: ShieldCheck,
-  member: Shield,
-};
 
 export default function OrganizationsPage() {
   const { blocked } = usePlatformAdminGuard();
@@ -192,7 +180,11 @@ export default function OrganizationsPage() {
     {
       accessorKey: "createdAt",
       header: "Created",
-      cell: ({ row }) => new Date(row.original.createdAt).toLocaleDateString(),
+      cell: ({ row }) => (
+        <span className="text-xs text-muted-foreground whitespace-nowrap">
+          <RelativeTimestamp iso={row.original.createdAt} />
+        </span>
+      ),
     },
     {
       id: "actions",
@@ -226,6 +218,7 @@ export default function OrganizationsPage() {
   if (blocked) return <LoadingState message="Checking access..." />;
 
   return (
+    <TooltipProvider>
     <div className="p-6">
       {/* Header */}
       <div className="mb-6">
@@ -236,7 +229,7 @@ export default function OrganizationsPage() {
       <ErrorBoundary>
         <div className="space-y-6">
           {/* Stats row */}
-          <div className="grid gap-4 sm:grid-cols-3">
+          <div className="grid gap-4 sm:grid-cols-2">
             <StatCard
               title="Total Organizations"
               value={loading ? "..." : orgs.length.toLocaleString()}
@@ -279,7 +272,7 @@ export default function OrganizationsPage() {
             loadingMessage="Loading organizations..."
             emptyIcon={Building2}
             emptyTitle="No organizations yet"
-            emptyDescription="Organizations are created when users sign up and go through the first-run flow"
+            emptyDescription="Organizations are created when a new user completes signup."
             isEmpty={orgs.length === 0}
             hasFilters={!!params.search}
             onClearFilters={() => setParams({ search: "", page: 1 })}
@@ -298,16 +291,24 @@ export default function OrganizationsPage() {
         <SheetContent className="w-full sm:max-w-lg overflow-auto">
           <SheetHeader>
             <SheetTitle>
-              {selectedOrg?.organization.name ?? "Organization Details"}
+              {detailLoading
+                ? "Loading organization…"
+                : detailError
+                  ? "Could not load organization"
+                  : selectedOrg?.organization.name ?? "Organization details"}
             </SheetTitle>
             <SheetDescription>
-              {selectedOrg?.organization.slug ?? "Loading..."}
+              {detailLoading
+                ? "Fetching members and invitations…"
+                : detailError
+                  ? "The organization could not be loaded. Try again in a moment."
+                  : selectedOrg?.organization.slug ?? ""}
             </SheetDescription>
           </SheetHeader>
 
           {detailLoading ? (
             <div className="flex h-32 items-center justify-center">
-              <LoadingState message="Loading..." />
+              <LoadingState message="Loading organization..." />
             </div>
           ) : selectedOrg ? (
             <div className="space-y-6 px-4">
@@ -319,19 +320,24 @@ export default function OrganizationsPage() {
                 </h3>
                 <div className="space-y-2">
                   {selectedOrg.members.map((m) => {
-                    const RoleIcon = ROLE_ICONS[m.role] ?? Shield;
+                    const { Icon: RoleIcon, className: badgeClass } = roleBadge(m.role);
                     return (
                       <div key={m.id} className="flex items-center justify-between rounded-md border p-3">
-                        <div className="flex items-center gap-3">
-                          <div className="bg-muted flex size-8 items-center justify-center rounded-full text-xs font-medium">
+                        <div className="flex min-w-0 items-center gap-3">
+                          <div className="bg-muted flex size-8 shrink-0 items-center justify-center rounded-full text-xs font-medium">
                             {m.user.name?.charAt(0)?.toUpperCase() ?? m.user.email.charAt(0).toUpperCase()}
                           </div>
-                          <div>
-                            <div className="text-sm font-medium">{m.user.name || m.user.email}</div>
-                            <div className="text-xs text-muted-foreground">{m.user.email}</div>
+                          <div className="min-w-0">
+                            <div className="truncate text-sm font-medium">{m.user.name || m.user.email}</div>
+                            <div className="truncate text-xs text-muted-foreground">
+                              <span>{m.user.email}</span>
+                              <span aria-hidden="true"> · </span>
+                              <span>Joined </span>
+                              <RelativeTimestamp iso={m.createdAt} />
+                            </div>
                           </div>
                         </div>
-                        <Badge variant="outline" className="capitalize">
+                        <Badge variant="outline" className={`capitalize shrink-0 ${badgeClass}`}>
                           <RoleIcon className="mr-1 size-3" />
                           {m.role}
                         </Badge>
@@ -342,41 +348,56 @@ export default function OrganizationsPage() {
               </div>
 
               {/* Pending invitations */}
-              {selectedOrg.invitations.filter((i) => i.status === "pending").length > 0 && (
-                <div className="space-y-3">
-                  <h3 className="flex items-center gap-2 text-sm font-semibold">
-                    <Mail className="size-4" />
-                    Pending Invitations
-                  </h3>
-                  <div className="space-y-2">
-                    {selectedOrg.invitations
-                      .filter((i) => i.status === "pending")
-                      .map((inv) => (
-                        <div key={inv.id} className="flex items-center justify-between rounded-md border p-3">
-                          <div>
-                            <div className="text-sm font-medium">{inv.email}</div>
-                            <div className="text-xs text-muted-foreground">
-                              Expires {new Date(inv.expiresAt).toLocaleDateString()}
+              {(() => {
+                const pending = selectedOrg.invitations.filter((i) => i.status === "pending");
+                if (pending.length === 0) return null;
+                return (
+                  <div className="space-y-3">
+                    <h3 className="flex items-center gap-2 text-sm font-semibold">
+                      <Mail className="size-4" />
+                      Pending Invitations
+                      <Badge variant="outline" className="ml-1 font-normal">
+                        {pending.length}
+                      </Badge>
+                    </h3>
+                    <div className="space-y-2">
+                      {pending.map((inv) => {
+                        const { className: badgeClass } = roleBadge(inv.role);
+                        return (
+                          <div key={inv.id} className="flex items-center justify-between rounded-md border p-3">
+                            <div className="min-w-0">
+                              <div className="truncate text-sm font-medium">{inv.email}</div>
+                              <div className="truncate text-xs text-muted-foreground">
+                                <span>Expires </span>
+                                <RelativeTimestamp iso={inv.expiresAt} />
+                                <span aria-hidden="true"> · </span>
+                                <span>Sent </span>
+                                <RelativeTimestamp iso={inv.createdAt} />
+                              </div>
                             </div>
+                            <Badge variant="outline" className={`capitalize shrink-0 ${badgeClass}`}>
+                              {inv.role}
+                            </Badge>
                           </div>
-                          <Badge variant="outline" className="capitalize">{inv.role}</Badge>
-                        </div>
-                      ))}
+                        );
+                      })}
+                    </div>
                   </div>
-                </div>
-              )}
+                );
+              })()}
             </div>
           ) : detailError ? (
-            <div className="flex h-32 items-center justify-center text-sm text-destructive">
+            <div className="flex h-32 items-center justify-center px-4 text-center text-sm text-destructive">
               {detailError}
             </div>
           ) : (
-            <div className="flex h-32 items-center justify-center text-muted-foreground">
-              No data available
+            <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
+              No organization data to display.
             </div>
           )}
         </SheetContent>
       </Sheet>
     </div>
+    </TooltipProvider>
   );
 }

--- a/packages/web/src/app/admin/organizations/page.tsx
+++ b/packages/web/src/app/admin/organizations/page.tsx
@@ -98,7 +98,11 @@ export default function OrganizationsPage() {
       try {
         const res = await fetch(`${apiUrl}/api/v1/admin/organizations`, { credentials });
         if (!res.ok) {
-          if (!cancelled) setError({ message: `HTTP ${res.status}`, status: res.status });
+          // intentionally ignored: body may be empty or non-JSON on error —
+          // status-code message is the fallback.
+          const body = (await res.json().catch(() => ({}))) as { message?: string };
+          const message = body.message ?? `Failed to load organizations (HTTP ${res.status})`;
+          if (!cancelled) setError({ message, status: res.status });
           return;
         }
         const data = await res.json();
@@ -132,7 +136,9 @@ export default function OrganizationsPage() {
     try {
       const res = await fetch(`${apiUrl}/api/v1/admin/organizations/${orgId}`, { credentials });
       if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
+        // intentionally ignored: body may be empty or non-JSON on error — we
+        // fall back to the status-code message below.
+        const body = (await res.json().catch(() => ({}))) as { message?: string };
         setDetailError(body.message ?? `Failed to load organization (HTTP ${res.status})`);
         setSelectedOrg(null);
         return;
@@ -310,6 +316,10 @@ export default function OrganizationsPage() {
             <div className="flex h-32 items-center justify-center">
               <LoadingState message="Loading organization..." />
             </div>
+          ) : detailError ? (
+            <div className="flex h-32 items-center justify-center px-4 text-center text-sm text-destructive">
+              {detailError}
+            </div>
           ) : selectedOrg ? (
             <div className="space-y-6 px-4">
               {/* Members */}
@@ -385,10 +395,6 @@ export default function OrganizationsPage() {
                   </div>
                 );
               })()}
-            </div>
-          ) : detailError ? (
-            <div className="flex h-32 items-center justify-center px-4 text-center text-sm text-destructive">
-              {detailError}
             </div>
           ) : (
             <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">

--- a/packages/web/src/app/admin/organizations/roles.ts
+++ b/packages/web/src/app/admin/organizations/roles.ts
@@ -1,0 +1,48 @@
+// Display-only helpers for org-member role badges used by the detail sheet.
+// Extracted so the fallback behavior on unknown roles is exercised by a unit
+// test without mounting the page (see __tests__/roles.test.ts). The server
+// is authoritative on the role enum, but the UI must render safely if the
+// server ever ships a value Atlas doesn't recognize (legacy "guest", a
+// future "billing-admin", DB drift) — fallback to the neutral member
+// variant keeps the sheet readable instead of rendering a bare class name.
+
+import { Crown, Shield, ShieldCheck } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+export const KNOWN_ORG_ROLES = ["owner", "admin", "member"] as const;
+export type KnownOrgRole = (typeof KNOWN_ORG_ROLES)[number];
+
+const ROLE_ICONS: Record<KnownOrgRole, LucideIcon> = {
+  owner: Crown,
+  admin: ShieldCheck,
+  member: Shield,
+};
+
+// Mirrors the color-coded role badges on /admin/users so the two operator
+// surfaces stay visually consistent. Keyed on the known enum; anything else
+// routes through the neutral fallback in `roleBadge()`.
+const ROLE_BADGE_CLASS: Record<KnownOrgRole, string> = {
+  owner: "border-purple-300 text-purple-700 dark:border-purple-700 dark:text-purple-400",
+  admin: "border-red-300 text-red-700 dark:border-red-700 dark:text-red-400",
+  member: "border-primary/50 text-primary",
+};
+
+export interface RoleBadge {
+  Icon: LucideIcon;
+  className: string;
+}
+
+/**
+ * Resolve icon + badge classes for a workspace-member role. Unknown roles
+ * fall back to the neutral member variant so the sheet renders safely
+ * regardless of server drift.
+ */
+export function roleBadge(role: string): RoleBadge {
+  const known = (KNOWN_ORG_ROLES as readonly string[]).includes(role)
+    ? (role as KnownOrgRole)
+    : "member";
+  return {
+    Icon: ROLE_ICONS[known],
+    className: ROLE_BADGE_CLASS[known],
+  };
+}

--- a/packages/web/src/app/admin/organizations/roles.ts
+++ b/packages/web/src/app/admin/organizations/roles.ts
@@ -1,16 +1,25 @@
 // Display-only helpers for org-member role badges used by the detail sheet.
 // Extracted so the fallback behavior on unknown roles is exercised by a unit
-// test without mounting the page (see __tests__/roles.test.ts). The server
-// is authoritative on the role enum, but the UI must render safely if the
-// server ever ships a value Atlas doesn't recognize (legacy "guest", a
-// future "billing-admin", DB drift) — fallback to the neutral member
-// variant keeps the sheet readable instead of rendering a bare class name.
+// test without mounting the page (see __tests__/roles.test.ts).
+//
+// The server is authoritative on the role enum, but the UI must still render
+// safely if it ever ships a value Atlas doesn't recognize (legacy "guest", a
+// future "billing-admin", DB drift). This helper is **fail-safe** (render a
+// readable default), not fail-closed in the security sense — compare with
+// `app/admin/users/roles.ts`'s `isDemotion`, which is fail-*closed* (unknown
+// → always route through the confirm dialog). Same pattern shape, opposite
+// safety posture: the demote gate protects against accidental privilege
+// strip; this gate protects against an unreadable sheet.
+//
+// Unknown roles trigger a one-time `console.warn` per role so server drift
+// is detectable in browser devtools without spamming the console on every
+// render.
 
 import { Crown, Shield, ShieldCheck } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
-export const KNOWN_ORG_ROLES = ["owner", "admin", "member"] as const;
-export type KnownOrgRole = (typeof KNOWN_ORG_ROLES)[number];
+const KNOWN_ORG_ROLES = ["owner", "admin", "member"] as const;
+type KnownOrgRole = (typeof KNOWN_ORG_ROLES)[number];
 
 const ROLE_ICONS: Record<KnownOrgRole, LucideIcon> = {
   owner: Crown,
@@ -18,31 +27,40 @@ const ROLE_ICONS: Record<KnownOrgRole, LucideIcon> = {
   member: Shield,
 };
 
-// Mirrors the color-coded role badges on /admin/users so the two operator
-// surfaces stay visually consistent. Keyed on the known enum; anything else
-// routes through the neutral fallback in `roleBadge()`.
+// Mirrors the color-coded role badges in `app/admin/users/columns.tsx` so the
+// two operator surfaces stay visually consistent. If those classes drift,
+// update this map too — there's no single source today.
 const ROLE_BADGE_CLASS: Record<KnownOrgRole, string> = {
   owner: "border-purple-300 text-purple-700 dark:border-purple-700 dark:text-purple-400",
   admin: "border-red-300 text-red-700 dark:border-red-700 dark:text-red-400",
   member: "border-primary/50 text-primary",
 };
 
-export interface RoleBadge {
-  Icon: LucideIcon;
-  className: string;
+interface RoleBadge {
+  readonly Icon: LucideIcon;
+  readonly className: string;
 }
+
+// Module-scoped so repeated renders of the same unknown role only warn once.
+// Cleared on full page reload (fine — drift is a "once you see it, you
+// investigate" signal, not a rate-limited alert).
+const warnedUnknownRoles = new Set<string>();
 
 /**
  * Resolve icon + badge classes for a workspace-member role. Unknown roles
- * fall back to the neutral member variant so the sheet renders safely
- * regardless of server drift.
+ * fall back to the neutral member variant (fail-safe rendering) and emit a
+ * one-time `console.warn` so server drift is detectable in devtools.
  */
 export function roleBadge(role: string): RoleBadge {
-  const known = (KNOWN_ORG_ROLES as readonly string[]).includes(role)
-    ? (role as KnownOrgRole)
-    : "member";
-  return {
-    Icon: ROLE_ICONS[known],
-    className: ROLE_BADGE_CLASS[known],
-  };
+  if (!(KNOWN_ORG_ROLES as readonly string[]).includes(role)) {
+    if (!warnedUnknownRoles.has(role)) {
+      warnedUnknownRoles.add(role);
+      console.warn(
+        `[admin/organizations] Unknown workspace role "${role}" — rendering neutral fallback. Investigate server drift or update KNOWN_ORG_ROLES.`,
+      );
+    }
+    return { Icon: ROLE_ICONS.member, className: ROLE_BADGE_CLASS.member };
+  }
+  const known = role as KnownOrgRole;
+  return { Icon: ROLE_ICONS[known], className: ROLE_BADGE_CLASS[known] };
 }


### PR DESCRIPTION
## Summary

Bucket 2 polish pass for `/admin/organizations` — tracker #1588. Continues after `/admin/users` (PR #1665) and `/admin/sessions` (PR #1628). Polish only, no structural revamp, per the tracker plan.

- Raw `toLocaleDateString()` → `<RelativeTimestamp>` with absolute-datetime tooltip (Created column + member joined + invitation expires/sent).
- Detail sheet: split loading / error / loaded branches cleanly (no more "Loading..." stuck in the SheetDescription on fetch failure). Added member Joined timestamp and invitation Sent timestamp.
- Fixed stats-grid imbalance (`sm:grid-cols-3` with 2 cards → `sm:grid-cols-2`).
- Extracted `roleBadge()` helper + unit test (same carve-out pattern as `/admin/users/roles.ts`). Fail-closed on unknown server roles — returns the neutral member variant instead of crashing.
- Applied color-coded role badges (owner / admin / member) to the detail sheet for visual consistency with `/admin/users`.
- Tightened empty-state copy.

## Scope carve-outs

- **No destructive UI** — the API supports suspend / activate / delete / plan but the UI doesn't surface them. Filed #1667 to wire them up with `AlertDialog` confirms + `MutationErrorSurface`.
- **Bespoke fetch + `useEffect`** — file still uses the pre-`useAdminFetch` pattern. Same carve-out as `/admin/users`. Filed #1666 for the migration.

## Test plan

- [x] `bun run lint` — 0 errors
- [x] `bun run type` — 0 errors
- [x] `bun run test` — 76/76 web tests green (4 new in `organizations/__tests__/roles.test.ts`)
- [x] `bun x syncpack lint` — no issues
- [x] template drift — passed
- [ ] Visual spot-check: load `/admin/organizations`, hover a Created timestamp (absolute datetime), open the detail sheet, confirm members show Joined + colored role badge and invitations show Expires / Sent.

## Follow-ups filed

- #1666 — migrate to `useAdminFetch` + `useAdminMutation` (plumbing)
- #1667 — surface suspend / activate / delete / plan admin actions (feature)

Refs #1588, #1665, #1628