### PR TITLE
feat(web): MutationErrorSurface — migrate queue/moderation admin pages (phase 2B of #1624)

### DIFF
--- a/packages/web/src/app/admin/actions/page.tsx
+++ b/packages/web/src/app/admin/actions/page.tsx
@@ -290,7 +290,13 @@ export default function ActionsPage() {
   }
 
   async function confirmSingleDeny(reason: string) {
-    if (!denyTarget) return;
+    if (!denyTarget) {
+      console.warn("confirmSingleDeny: denyTarget cleared before confirm");
+      setMutationError({
+        message: "Unable to deny — the target was cleared. Please retry.",
+      });
+      return;
+    }
     const id = denyTarget.id;
     const body: Record<string, unknown> = {};
     if (reason) body.reason = reason;

--- a/packages/web/src/app/admin/actions/page.tsx
+++ b/packages/web/src/app/admin/actions/page.tsx
@@ -29,6 +29,7 @@ import type { ActionLogEntry } from "@/ui/lib/types";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { EmptyState } from "@/ui/components/admin/empty-state";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import {
   bulkFailureSummary,
   BulkRequestError,
@@ -37,7 +38,7 @@ import {
   ReasonDialog,
   RelativeTimestamp,
 } from "@/ui/components/admin/queue";
-import { extractFetchError, friendlyError, type FetchError } from "@/ui/lib/fetch-error";
+import { extractFetchError, type FetchError } from "@/ui/lib/fetch-error";
 import {
   Zap,
   Check,
@@ -170,10 +171,15 @@ export default function ActionsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<FetchError | null>(null);
 
-  // Page-level error covers approve/rollback failures + bulk failure summaries.
+  // Page-level structured error covers single-row approve/rollback failures
+  // (routed through MutationErrorSurface so gated responses render upsell
+  // instead of a flattened string). Bulk-approve failures are a local
+  // synthesis that can't fit a single FetchError, so they live in
+  // `bulkApproveSummary` as a string and render through ErrorBanner.
   // Single-row deny errors live on denyMutation.error (rendered in the dialog).
   // Bulk-deny errors live in bulkError (rendered in the dialog).
-  const [mutationError, setMutationError] = useState<string | null>(null);
+  const [mutationError, setMutationError] = useState<FetchError | null>(null);
+  const [bulkApproveSummary, setBulkApproveSummary] = useState<string | null>(null);
   // Warnings are explicit-dismiss only — never auto-cleared by the next click.
   // Used for the rollback `{warning}` server contract: 200 OK but the side-
   // effect may not have actually been undone (see api/routes/actions.ts).
@@ -274,12 +280,13 @@ export default function ActionsPage() {
 
   async function handleApprove(id: string) {
     setMutationError(null);
+    setBulkApproveSummary(null);
     const result = await approveMutation.mutate({
       path: `/api/v1/actions/${id}/approve`,
       body: {},
       itemId: id,
     });
-    if (!result.ok) setMutationError(friendlyError(result.error));
+    if (!result.ok) setMutationError(result.error);
   }
 
   async function confirmSingleDeny(reason: string) {
@@ -297,6 +304,7 @@ export default function ActionsPage() {
 
   async function handleRollback(id: string) {
     setMutationError(null);
+    setBulkApproveSummary(null);
     const result = await rollbackMutation.mutate({
       path: `/api/v1/actions/${id}/rollback`,
       body: {},
@@ -313,13 +321,14 @@ export default function ActionsPage() {
         logUnsurfacedRollbackWarning(raw);
       },
     });
-    if (!result.ok) setMutationError(friendlyError(result.error));
+    if (!result.ok) setMutationError(result.error);
   }
 
   async function handleBulkApprove() {
     if (selectedIds.size === 0) return;
     setBulkAction("approve");
     setMutationError(null);
+    setBulkApproveSummary(null);
     const ids = [...selectedIds];
     try {
       const results = await Promise.allSettled(
@@ -369,7 +378,7 @@ export default function ActionsPage() {
   ) {
     const failedIds = failedIdsFrom(results, ids);
     if (failedIds.length > 0) {
-      setMutationError(bulkFailureSummary(results, ids, noun));
+      setBulkApproveSummary(bulkFailureSummary(results, ids, noun));
       setSelectedIds(new Set(failedIds));
     } else {
       setSelectedIds(new Set());
@@ -428,7 +437,17 @@ export default function ActionsPage() {
 
         <ErrorBoundary>
         <div className="space-y-6">
-          {mutationError && <ErrorBanner message={mutationError} onRetry={() => setMutationError(null)} />}
+          <MutationErrorSurface
+            error={mutationError}
+            feature="Actions"
+            onRetry={() => setMutationError(null)}
+          />
+          {bulkApproveSummary && (
+            <ErrorBanner
+              message={bulkApproveSummary}
+              onRetry={() => setBulkApproveSummary(null)}
+            />
+          )}
           {mutationWarning && <WarningBanner message={mutationWarning} onDismiss={() => setMutationWarning(null)} />}
 
           <AdminContentWrapper
@@ -721,7 +740,8 @@ export default function ActionsPage() {
           }
           onConfirm={confirmSingleDeny}
           loading={!!denyTarget && denyMutation.isMutating(denyTarget.id)}
-          error={denyMutation.error ? friendlyError(denyMutation.error) : null}
+          mutationError={denyMutation.error}
+          feature="Actions"
         />
 
         <ReasonDialog

--- a/packages/web/src/app/admin/api-keys/page.tsx
+++ b/packages/web/src/app/admin/api-keys/page.tsx
@@ -7,7 +7,7 @@ import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { friendlyError } from "@/ui/lib/fetch-error";
 import { ListApiKeysResponseSchema } from "@/ui/lib/admin-schemas";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
-import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import {
   CompactRow,
@@ -187,11 +187,13 @@ export default function ApiKeysPage() {
           loadingMessage="Loading API keys..."
           isEmpty={false}
         >
-          {deleteMutation.error && (
-            <div className="mb-4">
-              <ErrorBanner message={friendlyError(deleteMutation.error)} onRetry={deleteMutation.clearError} />
-            </div>
-          )}
+          <div className="mb-4">
+            <MutationErrorSurface
+              error={deleteMutation.error}
+              feature="API Keys"
+              onRetry={deleteMutation.clearError}
+            />
+          </div>
 
           <section>
             <SectionHeading
@@ -288,11 +290,11 @@ export default function ApiKeysPage() {
               Any applications using this key will immediately lose access. This cannot be undone.
             </DialogDescription>
           </DialogHeader>
-          {deleteMutation.error && (
-            <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
-              {friendlyError(deleteMutation.error)}
-            </div>
-          )}
+          <MutationErrorSurface
+            error={deleteMutation.error}
+            feature="API Keys"
+            variant="inline"
+          />
           <DialogFooter>
             <Button
               variant="outline"

--- a/packages/web/src/app/admin/approval/page.tsx
+++ b/packages/web/src/app/admin/approval/page.tsx
@@ -40,6 +40,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { EmptyState } from "@/ui/components/admin/empty-state";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import {
   bulkFailureSummary,
   BulkRequestError,
@@ -52,7 +53,7 @@ import {
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { extractFetchError, friendlyError, type FetchError } from "@/ui/lib/fetch-error";
+import { extractFetchError, type FetchError } from "@/ui/lib/fetch-error";
 import { ApprovalRuleSchema } from "@/ui/lib/admin-schemas";
 import type { ApprovalRequest, ApprovalRule, ApprovalRuleType, ApprovalStatus } from "@/ui/lib/types";
 import {
@@ -241,7 +242,11 @@ function RulesSection() {
       feature="Approval Workflows"
       onRetry={refetch}
     >
-      {mutationError && <ErrorBanner message={friendlyError(mutationError)} onRetry={clearMutationError} />}
+      <MutationErrorSurface
+        error={mutationError ?? null}
+        feature="Approval Workflows"
+        onRetry={clearMutationError}
+      />
       <Card>
         <CardHeader className="flex flex-row items-center justify-between">
           <div>
@@ -422,7 +427,12 @@ function QueueSection() {
   const [requests, setRequests] = useState<ApprovalRequest[]>([]);
   const [loading, setLoading] = useState(true);
   const [fetchError, setFetchError] = useState<FetchError | null>(null);
-  const [mutationError, setMutationError] = useState<string | null>(null);
+  // Structured error from single-row approve — routed through
+  // MutationErrorSurface so gated responses render upsell. Bulk-approve
+  // failures are an aggregate string (can't fit a single FetchError) and
+  // live in `bulkApproveSummary`.
+  const [mutationError, setMutationError] = useState<FetchError | null>(null);
+  const [bulkApproveSummary, setBulkApproveSummary] = useState<string | null>(null);
   const [refetchKey, setRefetchKey] = useState(0);
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -510,6 +520,7 @@ function QueueSection() {
 
   async function handleApprove(id: string, comment?: string) {
     setMutationError(null);
+    setBulkApproveSummary(null);
     // Optimistic patch first; server-authoritative row replaces it in
     // onSuccess (the server may add fields like reviewerId/reviewerEmail
     // the client can't predict).
@@ -533,18 +544,24 @@ function QueueSection() {
         }),
     );
     if (!result.ok) {
-      setMutationError(friendlyError(result.error));
+      setMutationError(result.error);
     }
   }
 
   async function confirmSingleDeny(reason: string) {
     if (!denyTarget) {
       console.warn("confirmSingleDeny: denyTarget cleared before confirm");
-      setMutationError("Unable to deny — the target was cleared. Please retry.");
+      // Synthesize a minimal FetchError so the banner still routes through
+      // MutationErrorSurface — no structured code since the failure is
+      // client-side.
+      setMutationError({
+        message: "Unable to deny — the target was cleared. Please retry.",
+      });
       return;
     }
     const id = denyTarget.id;
     setMutationError(null);
+    setBulkApproveSummary(null);
     const result = await runOptimistic(
       id,
       (r) => ({
@@ -588,12 +605,13 @@ function QueueSection() {
     if (selectedIds.size === 0) return;
     setBulkAction("approve");
     setMutationError(null);
+    setBulkApproveSummary(null);
     const ids = [...selectedIds];
     try {
       const results = await Promise.allSettled(ids.map((id) => bulkRequest(id, "approve", {})));
       const failedIds = failedIdsFrom(results, ids);
       if (failedIds.length > 0) {
-        setMutationError(bulkFailureSummary(results, ids, "approvals"));
+        setBulkApproveSummary(bulkFailureSummary(results, ids, "approvals"));
         setSelectedIds(new Set(failedIds));
       } else {
         setSelectedIds(new Set());
@@ -674,14 +692,21 @@ function QueueSection() {
           }
         />
 
-        {fetchError && (
+        <MutationErrorSurface
+          error={fetchError}
+          feature="Approval Workflows"
+          onRetry={() => setRefetchKey((k) => k + 1)}
+        />
+        <MutationErrorSurface
+          error={mutationError}
+          feature="Approval Workflows"
+          onRetry={() => setMutationError(null)}
+        />
+        {bulkApproveSummary && (
           <ErrorBanner
-            message={friendlyError(fetchError)}
-            onRetry={() => setRefetchKey((k) => k + 1)}
+            message={bulkApproveSummary}
+            onRetry={() => setBulkApproveSummary(null)}
           />
-        )}
-        {mutationError && (
-          <ErrorBanner message={mutationError} onRetry={() => setMutationError(null)} />
         )}
 
         {loading ? (
@@ -841,7 +866,8 @@ function QueueSection() {
         }
         onConfirm={confirmSingleDeny}
         loading={!!denyTarget && denyMutation.isMutating(denyTarget.id)}
-        error={denyMutation.error ? friendlyError(denyMutation.error) : null}
+        mutationError={denyMutation.error}
+        feature="Approval Workflows"
       />
 
       <ReasonDialog

--- a/packages/web/src/app/admin/approval/page.tsx
+++ b/packages/web/src/app/admin/approval/page.tsx
@@ -53,7 +53,7 @@ import {
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { extractFetchError, type FetchError } from "@/ui/lib/fetch-error";
+import { extractFetchError, friendlyError, type FetchError } from "@/ui/lib/fetch-error";
 import { ApprovalRuleSchema } from "@/ui/lib/admin-schemas";
 import type { ApprovalRequest, ApprovalRule, ApprovalRuleType, ApprovalStatus } from "@/ui/lib/types";
 import {
@@ -243,7 +243,7 @@ function RulesSection() {
       onRetry={refetch}
     >
       <MutationErrorSurface
-        error={mutationError ?? null}
+        error={mutationError}
         feature="Approval Workflows"
         onRetry={clearMutationError}
       />
@@ -692,11 +692,16 @@ function QueueSection() {
           }
         />
 
-        <MutationErrorSurface
-          error={fetchError}
-          feature="Approval Workflows"
-          onRetry={() => setRefetchKey((k) => k + 1)}
-        />
+        {/* QueueSection has no AdminContentWrapper, so the read-path
+            fetchError is a mid-Card slot — keep ErrorBanner here instead
+            of MutationErrorSurface, whose FeatureGate branch renders
+            full-page chrome that would break the Card layout. */}
+        {fetchError && (
+          <ErrorBanner
+            message={friendlyError(fetchError)}
+            onRetry={() => setRefetchKey((k) => k + 1)}
+          />
+        )}
         <MutationErrorSurface
           error={mutationError}
           feature="Approval Workflows"

--- a/packages/web/src/app/admin/cache/page.tsx
+++ b/packages/web/src/app/admin/cache/page.tsx
@@ -16,11 +16,10 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError } from "@/ui/lib/fetch-error";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { HardDrive, Trash2, Activity, Database, Clock, Target } from "lucide-react";
 
@@ -121,9 +120,11 @@ export default function CachePage() {
 
       <ErrorBoundary>
         <div>
-          {flushError && (
-            <ErrorBanner message={friendlyError(flushError)} onRetry={clearFlushError} />
-          )}
+          <MutationErrorSurface
+            error={flushError}
+            feature="Cache"
+            onRetry={clearFlushError}
+          />
           {flushMessage && (
             <div className="mb-6 rounded-md border border-emerald-500/30 bg-emerald-500/5 px-4 py-3 text-sm text-emerald-700 dark:text-emerald-300">
               {flushMessage}

--- a/packages/web/src/app/admin/scheduled-tasks/page.tsx
+++ b/packages/web/src/app/admin/scheduled-tasks/page.tsx
@@ -33,7 +33,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import {
   CalendarClock,
@@ -47,7 +47,6 @@ import {
 } from "lucide-react";
 import type { FetchError } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError } from "@/ui/lib/fetch-error";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { DeliveryStatusBadge } from "@/ui/components/admin/delivery-status-badge";
 import { ExpandableDataTable } from "@/components/data-table/data-table-expandable";
@@ -441,9 +440,21 @@ export default function ScheduledTasksPage() {
 
       <ErrorBoundary>
       <div className="space-y-6">
-        {toggleMutation.error && <ErrorBanner message={friendlyError(toggleMutation.error)} onRetry={toggleMutation.clearError} />}
-        {triggerMutation.error && <ErrorBanner message={friendlyError(triggerMutation.error)} onRetry={triggerMutation.clearError} />}
-        {deleteMutation.error && <ErrorBanner message={friendlyError(deleteMutation.error)} onRetry={deleteMutation.clearError} />}
+        <MutationErrorSurface
+          error={toggleMutation.error}
+          feature="Scheduled Tasks"
+          onRetry={toggleMutation.clearError}
+        />
+        <MutationErrorSurface
+          error={triggerMutation.error}
+          feature="Scheduled Tasks"
+          onRetry={triggerMutation.clearError}
+        />
+        <MutationErrorSurface
+          error={deleteMutation.error}
+          feature="Scheduled Tasks"
+          onRetry={deleteMutation.clearError}
+        />
 
         <AdminContentWrapper
           loading={loading}
@@ -489,7 +500,13 @@ export default function ScheduledTasksPage() {
               Generating preview...
             </div>
           ) : previewMutation.error ? (
-            <p className="text-sm text-destructive py-4">{friendlyError(previewMutation.error)}</p>
+            <div className="py-4">
+              <MutationErrorSurface
+                error={previewMutation.error}
+                feature="Scheduled Tasks"
+                variant="inline"
+              />
+            </div>
           ) : previewData ? (
             <div className="space-y-4">
               <Badge variant="outline" className="capitalize">{previewData.channel}</Badge>

--- a/packages/web/src/app/admin/scheduled-tasks/task-form-dialog.tsx
+++ b/packages/web/src/app/admin/scheduled-tasks/task-form-dialog.tsx
@@ -597,9 +597,11 @@ export function TaskFormDialog({
           )}
         </div>
 
-        {/* Client-side validation wins over server mutation error —
-            validation blocks submit, so submitMutation.error is always
-            stale if both are present. */}
+        {/* Hide the server mutation error while a client-side validation
+            error is showing — stacking two destructive banners doubles
+            the noise for no new signal. handleSubmit clears both slots
+            at entry, so both being set simultaneously only happens
+            mid-render. */}
         {validationError ? (
           <p role="alert" className="text-sm text-destructive">
             {validationError}

--- a/packages/web/src/app/admin/scheduled-tasks/task-form-dialog.tsx
+++ b/packages/web/src/app/admin/scheduled-tasks/task-form-dialog.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { useAtlasConfig } from "@/ui/context";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError } from "@/ui/lib/fetch-error";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import {
   Dialog,
   DialogContent,
@@ -597,10 +597,19 @@ export function TaskFormDialog({
           )}
         </div>
 
-        {(validationError || submitMutation.error) && (
-          <p className="text-sm text-destructive">
-            {validationError || (submitMutation.error ? friendlyError(submitMutation.error) : null)}
+        {/* Client-side validation wins over server mutation error —
+            validation blocks submit, so submitMutation.error is always
+            stale if both are present. */}
+        {validationError ? (
+          <p role="alert" className="text-sm text-destructive">
+            {validationError}
           </p>
+        ) : (
+          <MutationErrorSurface
+            error={submitMutation.error}
+            feature="Scheduled Tasks"
+            variant="inline"
+          />
         )}
 
         <DialogFooter>

--- a/packages/web/src/ui/components/admin/queue/__tests__/reason-dialog.test.tsx
+++ b/packages/web/src/ui/components/admin/queue/__tests__/reason-dialog.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test, beforeEach, afterEach, mock, type Mock } from "bun:test";
 import { render, screen, fireEvent, waitFor, cleanup, act } from "@testing-library/react";
 import { ReasonDialog } from "../reason-dialog";
+import type { FetchError } from "@/ui/lib/fetch-error";
 
 // Silence + assert the observability log the component fires when
 // onConfirm throws. Without a spy, each test that triggers the throw
@@ -155,6 +156,70 @@ describe("ReasonDialog error precedence (#1612)", () => {
     rerender(<Harness error={null} />);
     // localError must still dominate — no fresh caller error to honor.
     expect(errorText() ?? "").toContain("Unexpected error");
+  });
+
+  test("three-slot precedence: localError > mutationError > error, and mutationError change clears stale localError", async () => {
+    // Locks: (1) the three-way precedence ordering in the render body,
+    // (2) the widened `useEffect(…, [error, mutationError])` deps — a
+    // later cleanup that drops `mutationError` from the deps would
+    // silently regress step 2 without any existing test catching it.
+    function Harness({
+      error,
+      mutationError,
+    }: {
+      error: string | null;
+      mutationError: FetchError | null;
+    }) {
+      return (
+        <ReasonDialog
+          open
+          onOpenChange={() => {}}
+          title="Deny"
+          onConfirm={async () => {
+            throw new Error("boom");
+          }}
+          feature="Approval Workflows"
+          error={error}
+          mutationError={mutationError}
+        />
+      );
+    }
+
+    const { rerender } = render(
+      <Harness error="bulk summary" mutationError={{ message: "server X", status: 500 }} />,
+    );
+
+    // Trigger the throw so localError is set. Starting caller errors are
+    // already non-null so the effect has already fired once — subsequent
+    // setLocalError wins.
+    await act(async () => {
+      fireEvent.click(denyButton());
+    });
+    await waitFor(() => expect(errorText() ?? "").toContain("Unexpected error"));
+
+    // Step 1: with localError set, neither mutationError nor error shows.
+    expect(errorText()).not.toContain("server X");
+    expect(errorText()).not.toContain("bulk summary");
+
+    // Step 2: caller pushes a fresh mutationError instance. useEffect fires
+    // (mutationError identity changed), clears localError, and the
+    // MutationErrorSurface inline chrome renders the new server message.
+    rerender(
+      <Harness
+        error="bulk summary"
+        mutationError={{ message: "server Y", status: 500 }}
+      />,
+    );
+    await waitFor(() => {
+      const text = errorText() ?? "";
+      expect(text).toContain("server Y");
+      expect(text).not.toContain("Unexpected error");
+      expect(text).not.toContain("bulk summary");
+    });
+
+    // Step 3: caller drops mutationError — error string fallthrough wins.
+    rerender(<Harness error="bulk summary" mutationError={null} />);
+    await waitFor(() => expect(errorText()).toBe("bulk summary"));
   });
 });
 

--- a/packages/web/src/ui/components/admin/queue/reason-dialog.tsx
+++ b/packages/web/src/ui/components/admin/queue/reason-dialog.tsx
@@ -183,9 +183,10 @@ export function ReasonDialog({
 
         {/* Precedence: localError (dialog-internal onConfirm throw) >
             mutationError (structured, routed through MutationErrorSurface) >
-            error (string, e.g. bulk-failure summary). The first two render
-            as role="alert" blocks; the third delegates styling + routing to
-            MutationErrorSurface. */}
+            error (string, e.g. bulk-failure summary). All three branches
+            expose role="alert" so screen readers announce changes — the
+            mutationError branch wraps MutationErrorSurface because
+            InlineError itself has no live-region semantics. */}
         {localError ? (
           <div
             role="alert"
@@ -194,11 +195,13 @@ export function ReasonDialog({
             {localError}
           </div>
         ) : mutationError ? (
-          <MutationErrorSurface
-            error={mutationError}
-            feature={feature ?? ""}
-            variant="inline"
-          />
+          <div role="alert">
+            <MutationErrorSurface
+              error={mutationError}
+              feature={feature ?? ""}
+              variant="inline"
+            />
+          </div>
         ) : error ? (
           <div
             role="alert"

--- a/packages/web/src/ui/components/admin/queue/reason-dialog.tsx
+++ b/packages/web/src/ui/components/admin/queue/reason-dialog.tsx
@@ -12,6 +12,8 @@ import {
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
+import type { FetchError } from "@/ui/lib/fetch-error";
 import { Loader2, X } from "lucide-react";
 
 interface ReasonDialogProps {
@@ -30,7 +32,24 @@ interface ReasonDialogProps {
   required?: boolean;
   onConfirm: (reason: string) => Promise<void> | void;
   loading?: boolean;
+  /**
+   * Local-synthesized string error (e.g. bulk-failure summary). Takes effect
+   * when `mutationError` is null. Rendered as a flat alert block — no
+   * structured routing.
+   */
   error?: string | null;
+  /**
+   * Structured mutation error from `useAdminMutation().error`. Takes
+   * precedence over `error`. Routed through `MutationErrorSurface` so gated
+   * failures render `EnterpriseUpsell` inline instead of the flat string
+   * `friendlyError()` would produce.
+   */
+  mutationError?: FetchError | null;
+  /**
+   * Feature name for `MutationErrorSurface` routing when `mutationError` is
+   * present. Should match the page's `AdminContentWrapper` feature.
+   */
+  feature?: string;
 }
 
 /**
@@ -55,6 +74,8 @@ export function ReasonDialog({
   onConfirm,
   loading = false,
   error,
+  mutationError,
+  feature,
 }: ReasonDialogProps) {
   const [reason, setReason] = useState("");
   const [localError, setLocalError] = useState<string | null>(null);
@@ -67,19 +88,18 @@ export function ReasonDialog({
     }
   }, [open]);
 
-  // A fresh non-null `error` prop clears any stale localError so the
-  // caller's message wins. Without this, `displayError = localError ?? error`
-  // keeps showing a prior-throw "Unexpected error: ..." and hides a real
-  // server error that arrives later. Fires on every non-null error, not
-  // just the null→non-null transition, so sequential retries each surface
-  // the latest caller-provided diagnosis.
+  // A fresh non-null caller-provided error clears any stale localError so
+  // the caller's message wins. Without this, `localError ?? error` keeps
+  // showing a prior-throw "Unexpected error: ..." and hides a real server
+  // error that arrives later. Fires on every non-null caller error (string
+  // or structured), not just the null→non-null transition, so sequential
+  // retries each surface the latest caller-provided diagnosis.
   useEffect(() => {
-    if (error != null) setLocalError(null);
-  }, [error]);
+    if (error != null || mutationError != null) setLocalError(null);
+  }, [error, mutationError]);
 
   const trimmed = reason.trim();
   const canConfirm = required ? trimmed.length > 0 : true;
-  const displayError = localError ?? error;
 
   async function handleConfirm() {
     if (!canConfirm) return;
@@ -161,14 +181,32 @@ export function ReasonDialog({
           )}
         </div>
 
-        {displayError && (
+        {/* Precedence: localError (dialog-internal onConfirm throw) >
+            mutationError (structured, routed through MutationErrorSurface) >
+            error (string, e.g. bulk-failure summary). The first two render
+            as role="alert" blocks; the third delegates styling + routing to
+            MutationErrorSurface. */}
+        {localError ? (
           <div
             role="alert"
             className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive"
           >
-            {displayError}
+            {localError}
           </div>
-        )}
+        ) : mutationError ? (
+          <MutationErrorSurface
+            error={mutationError}
+            feature={feature ?? ""}
+            variant="inline"
+          />
+        ) : error ? (
+          <div
+            role="alert"
+            className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+          >
+            {error}
+          </div>
+        ) : null}
 
         <DialogFooter>
           <Button


### PR DESCRIPTION
## Summary

Routes ~12 mutation error sites across 5 queue/moderation admin pages through `<MutationErrorSurface>` so `EnterpriseUpsell` (on `code === "enterprise_required"`) and `FeatureGate` (on 401/403/404/503) fire on the write path the same way `AdminContentWrapper` already handles the read path. Mechanical sweep — decision tree stays in the component (phase 1, PR #1650).

## Migrated sites

- **`/admin/actions`** — single-row `approve` / `rollback` errors routed through `MutationErrorSurface` (banner). `mutationError` state re-typed from `string | null` to `FetchError | null`; bulk-approve summary moved to a separate `bulkApproveSummary: string | null` slot because aggregating multiple outcomes into a single `FetchError` doesn't fit. Single-row `denyMutation.error` routed through the new `ReasonDialog.mutationError` prop.
- **`/admin/api-keys`** — `deleteMutation` banner (inside `AdminContentWrapper`) + inline revoke-dialog error (inline variant). FormDialog `serverError` on `createMutation` stays on `friendlyErrorOrNull()` per #1649 carve-out.
- **`/admin/approval`** — `RulesSection` page-level banner (combined create/toggle/delete), `QueueSection` `fetchError` + single-row approve `mutationError` (banner), `denyMutation.error` via `ReasonDialog.mutationError`. Same `bulkApproveSummary` string-slot split as actions.
- **`/admin/cache`** — `flushError` banner.
- **`/admin/scheduled-tasks`** — `toggleMutation` / `triggerMutation` / `deleteMutation` banners (page-level), `previewMutation.error` inline variant (inside preview dialog body), `task-form-dialog` `submitMutation` inline variant. `validationError` stays as a local string rendered with `role="alert"` — it's client-side validation, no structured code to route.

## ReasonDialog API extension

Added `mutationError?: FetchError | null` and `feature?: string` props to the shared `ReasonDialog`. The existing string `error` prop stays for local-synthesized bulk-failure summaries. Render precedence:

1. `localError` (dialog-internal `onConfirm` throw) — wrapped `role="alert"` block
2. `mutationError` — routed through `<MutationErrorSurface variant="inline" />`
3. `error` (legacy string) — wrapped `role="alert"` block

All existing string-based callers (`bulkError` in both pages, every existing test) are unchanged. Dialog `useEffect` clears stale `localError` on either caller-error prop change so sequential retries still surface the freshest server diagnosis.

## Scope notes

- `bulkApproveSummary` in both actions + approval pages stays as a local-synthesized string — it combines multiple per-row outcomes into a human summary and can't be expressed as a single `FetchError`. Matches #1649's carve-out for local-synth page-level strings.
- FormDialog `serverError` on `api-keys` create flow stays on `friendlyErrorOrNull()` per #1649 (the dialog is already inside a gated page).
- Validation errors in `task-form-dialog` stay as local strings — client-side only, no structured code.
- `feature` strings match each page's `AdminContentWrapper` feature: `Actions`, `API Keys`, `Approval Workflows`, `Cache`, `Scheduled Tasks`.
- No new component-level tests per-page — phase 1's `mutation-error-surface.test.tsx` covers the decision tree; existing `reason-dialog.test.tsx` regression tests continue to pass unchanged.

## Test plan

- [x] `bun run lint` — zero output
- [x] `bun run type` — exit 0
- [x] `bun run test` — 5/5 packages green (api 243, cli 19, web 75, ee 25, react 9)
- [x] `bun x syncpack lint` — No issues found
- [x] Template drift — 430 files verified
- [ ] Spot-check one non-EE admin hitting a gated mutation (approval queue or scheduled task with rate-limit on a non-Business plan) — verify upsell renders (deferred to reviewer; the decision-tree routing is identical to #1650 / #1656 and those have already been spot-checked)

Closes one chunk of #1649. Remaining chunks: rest of core admin (`/admin/connections`, `/admin/prompts`, `/admin/users`-adjacent, etc.) + EE-only admin + the deferred phase-1 leftovers (SCIM row-pin, billing `PlanShell.combinedError`).