### PR TITLE
polish(web/admin): bucket-2 remainder — audit/admin-actions/usage

### DIFF
--- a/packages/web/src/app/admin/admin-actions/page.tsx
+++ b/packages/web/src/app/admin/admin-actions/page.tsx
@@ -23,6 +23,8 @@ import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAtlasConfig } from "@/ui/context";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { RelativeTimestamp } from "@/ui/components/admin/queue";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import {
   ChevronLeft,
   ChevronRight,
@@ -105,21 +107,6 @@ const TARGET_TYPE_OPTIONS = [
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatTimestamp(iso: string): string {
-  try {
-    return new Date(iso).toLocaleString(undefined, {
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-    });
-  } catch {
-    // intentionally ignored: invalid date string — fall back to raw ISO
-    return iso;
-  }
-}
 
 function statusBadge(status: string) {
   return status === "success"
@@ -343,7 +330,7 @@ function AdminActionsPageContent() {
               {actions.map((action) => (
                 <TableRow key={action.id}>
                   <TableCell className="text-xs text-muted-foreground whitespace-nowrap">
-                    {formatTimestamp(action.timestamp)}
+                    <RelativeTimestamp iso={action.timestamp} />
                   </TableCell>
                   <TableCell className="text-sm">{action.actorEmail}</TableCell>
                   <TableCell>
@@ -400,7 +387,9 @@ function AdminActionsPageContent() {
 export default function AdminActionsPage() {
   return (
     <ErrorBoundary>
-      <AdminActionsPageContent />
+      <TooltipProvider>
+        <AdminActionsPageContent />
+      </TooltipProvider>
     </ErrorBoundary>
   );
 }

--- a/packages/web/src/app/admin/audit/__tests__/columns.test.ts
+++ b/packages/web/src/app/admin/audit/__tests__/columns.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { getAuditColumns } from "../columns";
+
+describe("getAuditColumns", () => {
+  test("returns the documented column ids in order", () => {
+    // Column ids are the wire contract for the DataTable toolbar (sort list,
+    // visibility menu) and `page.tsx` defaults sort to `{ id: "timestamp",
+    // desc: true }` — a silent rename breaks the default sort. The `user`
+    // and `success` columns carry `enableColumnFilter: true`, so the toolbar
+    // filter UI depends on those ids too.
+    const ids = getAuditColumns().map((c) => c.id);
+    expect(ids).toEqual([
+      "timestamp",
+      "user",
+      "sql",
+      "tables_accessed",
+      "duration_ms",
+      "row_count",
+      "success",
+    ]);
+  });
+});

--- a/packages/web/src/app/admin/audit/columns.tsx
+++ b/packages/web/src/app/admin/audit/columns.tsx
@@ -3,6 +3,7 @@
 import type { ColumnDef } from "@tanstack/react-table";
 import { Badge } from "@/components/ui/badge";
 import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
+import { RelativeTimestamp } from "@/ui/components/admin/queue";
 import { Clock, User, Code, Timer, Rows3, CheckCircle, Table2 } from "lucide-react";
 
 // ── Types ─────────────────────────────────────────────────────────
@@ -34,15 +35,7 @@ export function getAuditColumns(): ColumnDef<AuditRow>[] {
       ),
       cell: ({ row }) => (
         <span className="text-xs text-muted-foreground whitespace-nowrap">
-          {new Date(row.getValue<string>("timestamp")).toLocaleString(
-            undefined,
-            {
-              month: "short",
-              day: "numeric",
-              hour: "2-digit",
-              minute: "2-digit",
-            },
-          )}
+          <RelativeTimestamp iso={row.getValue<string>("timestamp")} />
         </span>
       ),
       meta: {

--- a/packages/web/src/app/admin/audit/page.tsx
+++ b/packages/web/src/app/admin/audit/page.tsx
@@ -29,6 +29,7 @@ import { useAdminFetch, type FetchError } from "@/ui/hooks/use-admin-fetch";
 import { extractFetchError } from "@/ui/lib/fetch-error";
 import { AuditStatsSchema, AuditFacetsSchema, AuditConnectionMetaSchema } from "@/ui/lib/admin-schemas";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 const LIMIT = 50;
 
@@ -224,6 +225,7 @@ export default function AuditPage() {
   }
 
   return (
+    <TooltipProvider>
     <div className="p-6">
       <ErrorBoundary>
       <Tabs
@@ -490,5 +492,6 @@ export default function AuditPage() {
       </Tabs>
       </ErrorBoundary>
     </div>
+    </TooltipProvider>
   );
 }

--- a/packages/web/src/app/admin/audit/retention-panel.tsx
+++ b/packages/web/src/app/admin/audit/retention-panel.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useAtlasConfig } from "@/ui/context";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { extractFetchError, friendlyError } from "@/ui/lib/fetch-error";
+import { extractFetchError } from "@/ui/lib/fetch-error";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -21,8 +21,21 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { StatCard } from "@/ui/components/admin/stat-card";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
+import { RelativeTimestamp } from "@/ui/components/admin/queue";
 import { LoadingState } from "@/ui/components/admin/loading-state";
 import { Shield, Clock, Trash2, Download } from "lucide-react";
 
@@ -223,8 +236,13 @@ export function RetentionPanel() {
         <StatCard
           title="Last Purge"
           value={policy?.lastPurgeAt
-            ? `${policy.lastPurgeCount?.toLocaleString() ?? 0} entries at ${new Date(policy.lastPurgeAt).toLocaleDateString()}`
+            ? `${policy.lastPurgeCount?.toLocaleString() ?? 0} entries`
             : "Never"
+          }
+          description={
+            policy?.lastPurgeAt
+              ? <RelativeTimestamp iso={policy.lastPurgeAt} />
+              : undefined
           }
           icon={<Trash2 className="size-4" />}
         />
@@ -290,7 +308,11 @@ export function RetentionPanel() {
             </div>
           </div>
 
-          {saveError && <ErrorBanner message={friendlyError(saveError)} />}
+          <MutationErrorSurface
+            error={saveError}
+            feature="Audit Retention"
+            onRetry={clearSaveError}
+          />
           {saveSuccess && (
             <p className="text-sm text-green-600">Retention policy saved successfully.</p>
           )}
@@ -299,13 +321,30 @@ export function RetentionPanel() {
             <Button onClick={handleSave} disabled={saving}>
               {saving ? "Saving..." : "Save Policy"}
             </Button>
-            <Button variant="outline" onClick={handlePurge} disabled={purging}>
-              <Trash2 className="mr-1.5 size-3.5" />
-              {purging ? "Purging..." : "Run Purge Now"}
-            </Button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="outline" disabled={purging}>
+                  <Trash2 className="mr-1.5 size-3.5" />
+                  {purging ? "Purging..." : "Run Purge Now"}
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Purge expired audit entries?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Soft-deletes all entries past the retention window. Entries become
+                    permanently unrecoverable after the hard-delete delay elapses.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction onClick={handlePurge}>Run purge</AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           </div>
 
-          {purgeError && <ErrorBanner message={friendlyError(purgeError)} />}
+          <MutationErrorSurface error={purgeError} feature="Audit Retention" />
           {purgeResult && (
             <p className="text-sm text-muted-foreground">{purgeResult}</p>
           )}

--- a/packages/web/src/app/admin/audit/retention-panel.tsx
+++ b/packages/web/src/app/admin/audit/retention-panel.tsx
@@ -102,7 +102,7 @@ export function RetentionPanel() {
       method: "PUT",
     });
 
-  const { mutate: purgeMutate, saving: purging, error: purgeError } =
+  const { mutate: purgeMutate, saving: purging, error: purgeError, clearError: clearPurgeError } =
     useAdminMutation<{ results: Array<{ orgId: string; softDeletedCount: number }> }>({
       path: "/api/v1/admin/audit/retention/purge",
       method: "POST",
@@ -344,7 +344,11 @@ export function RetentionPanel() {
             </AlertDialog>
           </div>
 
-          <MutationErrorSurface error={purgeError} feature="Audit Retention" />
+          <MutationErrorSurface
+            error={purgeError}
+            feature="Audit Retention"
+            onRetry={clearPurgeError}
+          />
           {purgeResult && (
             <p className="text-sm text-muted-foreground">{purgeResult}</p>
           )}

--- a/packages/web/src/app/admin/usage/page.tsx
+++ b/packages/web/src/app/admin/usage/page.tsx
@@ -90,6 +90,7 @@ export default function UsageDashboardPage() {
   });
 
   async function openBillingPortal() {
+    setPortalUrlError(null);
     const result = await portalMutate({
       body: { returnUrl: window.location.href },
     });
@@ -130,12 +131,15 @@ export default function UsageDashboardPage() {
       <div className="space-y-6">
         {/* Billing portal: FetchError routes through MutationErrorSurface;
             portalUrlError is the local-fallback string for "200 OK but no URL"
-            edge case (not a FetchError, so kept as a plain ErrorBanner). */}
+            edge case (not a FetchError, so kept as a plain ErrorBanner). Each
+            retry clears both slots — a stale banner from the prior attempt
+            mustn't co-render with the one the current attempt raised. */}
         <MutationErrorSurface
           error={portalError}
           feature="Billing Portal"
           onRetry={() => {
             clearPortalError();
+            setPortalUrlError(null);
             openBillingPortal();
           }}
         />
@@ -143,6 +147,7 @@ export default function UsageDashboardPage() {
           <ErrorBanner
             message={portalUrlError}
             onRetry={() => {
+              clearPortalError();
               setPortalUrlError(null);
               openBillingPortal();
             }}

--- a/packages/web/src/app/admin/usage/page.tsx
+++ b/packages/web/src/app/admin/usage/page.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import dynamic from "next/dynamic";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError } from "@/ui/lib/fetch-error";
 import { UsageSummarySchema } from "@/ui/lib/admin-schemas";
 import { useDarkMode } from "@/ui/hooks/use-dark-mode";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -13,6 +12,9 @@ import { Progress } from "@/components/ui/progress";
 import { StatCard } from "@/ui/components/admin/stat-card";
 import { EmptyState } from "@/ui/components/admin/empty-state";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
+import { RelativeTimestamp } from "@/ui/components/admin/queue";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { DataTable } from "@/components/data-table/data-table";
 import { DataTableToolbar } from "@/components/data-table/data-table-toolbar";
@@ -66,7 +68,7 @@ export default function UsageDashboardPage() {
     { schema: UsageSummarySchema },
   );
 
-  const { mutate: portalMutate, saving: portalLoading, error: portalError } =
+  const { mutate: portalMutate, saving: portalLoading, error: portalError, clearError: clearPortalError } =
     useAdminMutation<{ url?: string }>({
       path: "/api/v1/billing/portal",
       method: "POST",
@@ -100,6 +102,7 @@ export default function UsageDashboardPage() {
 
   return (
     <ErrorBoundary>
+    <TooltipProvider>
     <div className="p-6">
       <div className="mb-6 flex items-center justify-between">
         <div>
@@ -125,8 +128,26 @@ export default function UsageDashboardPage() {
       </div>
 
       <div className="space-y-6">
-        {/* Portal error */}
-        {(portalError ?? portalUrlError) && <ErrorBanner message={(portalError ? friendlyError(portalError) : portalUrlError)!} onRetry={() => { setPortalUrlError(null); openBillingPortal(); }} />}
+        {/* Billing portal: FetchError routes through MutationErrorSurface;
+            portalUrlError is the local-fallback string for "200 OK but no URL"
+            edge case (not a FetchError, so kept as a plain ErrorBanner). */}
+        <MutationErrorSurface
+          error={portalError}
+          feature="Billing Portal"
+          onRetry={() => {
+            clearPortalError();
+            openBillingPortal();
+          }}
+        />
+        {portalUrlError && (
+          <ErrorBanner
+            message={portalUrlError}
+            onRetry={() => {
+              setPortalUrlError(null);
+              openBillingPortal();
+            }}
+          />
+        )}
 
         <AdminContentWrapper
           loading={loading}
@@ -159,9 +180,12 @@ export default function UsageDashboardPage() {
                 value={data.plan.displayName}
                 icon={<CreditCard className="size-4" />}
                 description={
-                  data.plan.trialEndsAt
-                    ? `Trial ends ${new Date(data.plan.trialEndsAt).toLocaleDateString()}`
-                    : undefined
+                  data.plan.trialEndsAt ? (
+                    <RelativeTimestamp
+                      iso={data.plan.trialEndsAt}
+                      label="Trial ends"
+                    />
+                  ) : undefined
                 }
               />
             </div>
@@ -207,6 +231,7 @@ export default function UsageDashboardPage() {
         </AdminContentWrapper>
       </div>
     </div>
+    </TooltipProvider>
     </ErrorBoundary>
   );
 }

--- a/packages/web/src/ui/components/admin/queue/relative-timestamp.tsx
+++ b/packages/web/src/ui/components/admin/queue/relative-timestamp.tsx
@@ -8,8 +8,8 @@ import {
 
 const RTF = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
 
-function absoluteTimestamp(iso: string): string {
-  return new Date(iso).toLocaleString(undefined, {
+function absoluteTimestamp(ms: number): string {
+  return new Date(ms).toLocaleString(undefined, {
     year: "numeric",
     month: "short",
     day: "numeric",
@@ -18,8 +18,8 @@ function absoluteTimestamp(iso: string): string {
   });
 }
 
-function relativeTime(iso: string): string {
-  const diffMs = new Date(iso).getTime() - Date.now();
+function relativeTime(ms: number): string {
+  const diffMs = ms - Date.now();
   const absSec = Math.abs(Math.round(diffMs / 1000));
   if (absSec < 60) return RTF.format(Math.round(diffMs / 1000), "second");
   const absMin = Math.abs(Math.round(diffMs / 60000));
@@ -34,6 +34,10 @@ function relativeTime(iso: string): string {
  * Caller must wrap the tree in `<TooltipProvider>` — this component
  * reuses the existing shadcn Tooltip primitives and does not create
  * its own provider.
+ *
+ * Invalid ISO strings render a dash rather than `"NaN days ago"` /
+ * `"Invalid Date"`. Servers should emit valid ISO; the guard is a
+ * belt-and-braces floor so a single bad row never degrades the table.
  */
 export function RelativeTimestamp({
   iso,
@@ -42,16 +46,19 @@ export function RelativeTimestamp({
   iso: string;
   label?: string;
 }) {
+  const ms = new Date(iso).getTime();
+  if (Number.isNaN(ms)) return <span className="text-muted-foreground">—</span>;
+
   return (
     <Tooltip>
       <TooltipTrigger asChild>
         <span>
           {label ? `${label}: ` : ""}
-          {relativeTime(iso)}
+          {relativeTime(ms)}
         </span>
       </TooltipTrigger>
       <TooltipContent>
-        <time dateTime={iso}>{absoluteTimestamp(iso)}</time>
+        <time dateTime={iso}>{absoluteTimestamp(ms)}</time>
       </TooltipContent>
     </Tooltip>
   );

--- a/packages/web/src/ui/components/admin/stat-card.tsx
+++ b/packages/web/src/ui/components/admin/stat-card.tsx
@@ -14,7 +14,7 @@ export function StatCard({
   title: string;
   value: string | number;
   icon?: ReactNode;
-  description?: string;
+  description?: ReactNode;
   className?: string;
 }) {
   return (


### PR DESCRIPTION
## Summary

Finish bucket 2 of the admin console final pass (tracker #1588). Polish-only, no structural redesign — matches the `/users` (PR #1665), `/sessions` (PR #1628), `/organizations` (PR #1668) precedent.

### `/admin/audit`
- Timestamp column → `<RelativeTimestamp>`; page wraps in `TooltipProvider` so absolute datetime renders on hover.
- Retention panel's **Last Purge** stat card splits count from timestamp; the timestamp rides in the description slot as `<RelativeTimestamp>`.
- **Save policy** and **Run purge** mutation errors migrate from `ErrorBanner + friendlyError` to `<MutationErrorSurface>` (covers #1649 subset) so a non-EE admin hitting retention-only controls gets `EnterpriseUpsell` routing.
- **Run Purge Now** is now gated by an `AlertDialog` — soft-deletes become permanently unrecoverable once the hard-delete delay elapses, and the old one-click button had no recovery affordance.

### `/admin/admin-actions`
- Timestamp column → `<RelativeTimestamp>`; page wraps in `TooltipProvider`. Drops the local `formatTimestamp` helper.
- Read-only page; no mutation sites (`exportError` is a bespoke fetch error, already has an ErrorBanner retry affordance).

### `/admin/token-usage`
- Reviewed — no timestamps in columns, no mutations, column alignment and empty-state copy already clean. **No changes needed.**

### `/admin/usage`
- `portalError` (FetchError from `useAdminMutation`) migrates to `<MutationErrorSurface>`; picks up `EnterpriseUpsell` routing for gated billing portals.
- `portalUrlError` (local string fallback for the "200 OK but no URL" edge case) keeps its `ErrorBanner` with a brief inline comment explaining why it stayed — preserves the phase-1 carve-out for non-FetchError surfaces.
- Plan card's "Trial ends {date}" description → `<RelativeTimestamp>` so operators read trial urgency at a glance; page wraps in `TooltipProvider`.

### StatCard
- `description` prop widened from `string` to `ReactNode` so the Usage Plan card and Retention Last Purge card can host a `<RelativeTimestamp>` rather than a raw `toLocaleDateString()`. No runtime change for the existing string callers.

## Scope carve-outs

- **`/admin/audit/retention-panel` policy load** still uses bespoke `fetch` + `useEffect`. Same plumbing carve-out as `/admin/users` (#1666 precedent). Not widening this PR.
- **`/admin/token-usage` section errors** pass `err.message` directly rather than `friendlyError(err)`. Minor drift — the page's `gateError` already routes auth/availability through `AdminContentWrapper`, so non-gate errors are the 400/500 class where `friendlyError` is effectively a no-op. Not scope-creep territory.

## Test plan

- [x] `bun run lint` — 0 errors
- [x] `bun run type` — 0 errors
- [x] `bun run test` — all pass (no test-suite churn; polish-only change to existing pages)
- [x] `bun x syncpack lint` — no issues
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — passed (430 files)
- [ ] Browser spot-check — reviewer should verify:
  - `/admin/audit` timestamps read relative + show absolute on hover
  - Retention panel: **Save** with a 403 (EE-gated) renders `EnterpriseUpsell`, not a flat banner; **Run Purge Now** opens the new AlertDialog confirm
  - `/admin/admin-actions` timestamps read relative + show absolute on hover
  - `/admin/usage`: **Manage Plan** button with a 403 (EE-gated) renders `EnterpriseUpsell`; Plan card shows "Trial ends {relative}" when on a trial

Refs tracker #1588 bucket-2, #1649 MutationErrorSurface phase.