### PR TITLE
feat(web/admin/organizations): useAdminFetch migration + workspace actions (#1666 #1667)

### DIFF
--- a/packages/web/src/app/admin/organizations/__tests__/statuses.test.ts
+++ b/packages/web/src/app/admin/organizations/__tests__/statuses.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { CheckCircle2, CreditCard, Pause, Trash2 } from "lucide-react";
+import { planBadge, statusBadge } from "../statuses";
+
+describe("statusBadge", () => {
+  let warnSpy: ReturnType<typeof spyOn<Console, "warn">>;
+
+  afterEach(() => {
+    warnSpy?.mockRestore();
+  });
+
+  test("active resolves to CheckCircle2 + emerald classes", () => {
+    warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    const { Icon, className, label } = statusBadge("active");
+    expect(Icon).toBe(CheckCircle2);
+    expect(className).toContain("text-emerald-700");
+    expect(label).toBe("Active");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("suspended resolves to Pause + amber classes", () => {
+    warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    const { Icon, className, label } = statusBadge("suspended");
+    expect(Icon).toBe(Pause);
+    expect(className).toContain("text-amber-700");
+    expect(label).toBe("Suspended");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("deleted resolves to Trash2 + red classes", () => {
+    warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    const { Icon, className, label } = statusBadge("deleted");
+    expect(Icon).toBe(Trash2);
+    expect(className).toContain("text-red-700");
+    expect(label).toBe("Deleted");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("unknown statuses render the raw value as the label and warn once", () => {
+    // Fail-safe rendering: a server that ships a new workspace_status enum
+    // value before the web bundle catches up must not crash the row. The
+    // neutral fallback labels with the raw value so the operator can see
+    // what came back; the one-time `console.warn` lets devtools / Sentry
+    // surface the drift without spamming on every render.
+    warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+
+    const unknown = statusBadge("hibernating-test-status");
+    expect(unknown.label).toBe("hibernating-test-status");
+    expect(unknown.className).toContain("text-muted-foreground");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain("hibernating-test-status");
+
+    // Same value second time — dedup suppresses the warn.
+    statusBadge("hibernating-test-status");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    // A different unknown value warns exactly once more.
+    statusBadge("another-test-status");
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("empty status falls back to 'Unknown' label", () => {
+    warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    const { label } = statusBadge("");
+    expect(label).toBe("Unknown");
+  });
+});
+
+describe("planBadge", () => {
+  let warnSpy: ReturnType<typeof spyOn<Console, "warn">>;
+
+  afterEach(() => {
+    warnSpy?.mockRestore();
+  });
+
+  test("free resolves to CreditCard + muted classes", () => {
+    warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    const { Icon, className, label } = planBadge("free");
+    expect(Icon).toBe(CreditCard);
+    expect(className).toContain("text-muted-foreground");
+    expect(label).toBe("Free");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("trial resolves to blue classes", () => {
+    warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    const { className, label } = planBadge("trial");
+    expect(className).toContain("text-blue-700");
+    expect(label).toBe("Trial");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("starter resolves to primary classes", () => {
+    warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    const { className, label } = planBadge("starter");
+    expect(className).toContain("text-primary");
+    expect(label).toBe("Starter");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("pro resolves to violet classes", () => {
+    warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    const { className, label } = planBadge("pro");
+    expect(className).toContain("text-violet-700");
+    expect(label).toBe("Pro");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("business resolves to purple classes", () => {
+    warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    const { className, label } = planBadge("business");
+    expect(className).toContain("text-purple-700");
+    expect(label).toBe("Business");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("unknown plan tiers render the raw value as the label and warn once", () => {
+    warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+
+    const unknown = planBadge("enterprise-tier-test");
+    expect(unknown.label).toBe("enterprise-tier-test");
+    expect(unknown.className).toContain("text-muted-foreground");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain("enterprise-tier-test");
+
+    planBadge("enterprise-tier-test");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    planBadge("another-plan-test");
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("empty plan tier falls back to 'Unknown' label", () => {
+    warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    const { label } = planBadge("");
+    expect(label).toBe("Unknown");
+  });
+});

--- a/packages/web/src/app/admin/organizations/detail-sheet.tsx
+++ b/packages/web/src/app/admin/organizations/detail-sheet.tsx
@@ -47,13 +47,12 @@ interface OrgDetail {
 }
 
 /**
- * Lazy-loaded organization detail content. Owns its own `useAdminFetch`
- * keyed by `orgId`, so the request only fires when the parent mounts this
- * component (i.e. when the sheet opens with a selected org). This mirrors
- * `AbuseDetailPanel`'s pattern — opening org A doesn't refetch org B.
+ * Owns its own `useAdminFetch` keyed by `orgId` so the request only fires
+ * when the parent mounts this component (i.e. on selection) — opening
+ * workspace A doesn't refetch workspace B.
  */
 function OrgDetailContent({ orgId }: { orgId: string }) {
-  const { data, loading, error } = useAdminFetch<OrgDetail>(
+  const { data, loading, error, refetch } = useAdminFetch<OrgDetail>(
     `/api/v1/admin/organizations/${orgId}`,
   );
 
@@ -68,7 +67,7 @@ function OrgDetailContent({ orgId }: { orgId: string }) {
   if (error) {
     return (
       <div className="px-4">
-        <ErrorBanner message={friendlyError(error)} />
+        <ErrorBanner message={friendlyError(error)} onRetry={() => refetch()} />
       </div>
     );
   }
@@ -89,7 +88,6 @@ function OrgDetailContent({ orgId }: { orgId: string }) {
 
   return (
     <div className="space-y-6 px-4">
-      {/* Status + plan badges (header carve-out) */}
       <div className="flex flex-wrap items-center gap-2">
         <Badge variant="outline" className={status.className}>
           <StatusIcon className="mr-1 size-3" />
@@ -111,7 +109,6 @@ function OrgDetailContent({ orgId }: { orgId: string }) {
         )}
       </div>
 
-      {/* Members */}
       <div className="space-y-3">
         <h3 className="flex items-center gap-2 text-sm font-semibold">
           <Users className="size-4" />
@@ -155,7 +152,6 @@ function OrgDetailContent({ orgId }: { orgId: string }) {
         </div>
       </div>
 
-      {/* Pending invitations */}
       {pending.length > 0 && (
         <div className="space-y-3">
           <h3 className="flex items-center gap-2 text-sm font-semibold">

--- a/packages/web/src/app/admin/organizations/detail-sheet.tsx
+++ b/packages/web/src/app/admin/organizations/detail-sheet.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { LoadingState } from "@/ui/components/admin/loading-state";
+import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { friendlyError } from "@/ui/lib/fetch-error";
+import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Mail, Users } from "lucide-react";
+import { RelativeTimestamp } from "@/ui/components/admin/queue";
+import { roleBadge } from "./roles";
+import { planBadge, statusBadge } from "./statuses";
+
+interface OrgDetail {
+  organization: {
+    id: string;
+    name: string;
+    slug: string;
+    logo: string | null;
+    createdAt: string;
+    workspaceStatus: string;
+    planTier: string;
+    suspendedAt: string | null;
+    deletedAt: string | null;
+  };
+  members: Array<{
+    id: string;
+    userId: string;
+    role: string;
+    createdAt: string;
+    user: { id: string; name: string; email: string; image: string | null };
+  }>;
+  invitations: Array<{
+    id: string;
+    email: string;
+    role: string;
+    status: string;
+    expiresAt: string;
+    createdAt: string;
+  }>;
+}
+
+/**
+ * Lazy-loaded organization detail content. Owns its own `useAdminFetch`
+ * keyed by `orgId`, so the request only fires when the parent mounts this
+ * component (i.e. when the sheet opens with a selected org). This mirrors
+ * `AbuseDetailPanel`'s pattern — opening org A doesn't refetch org B.
+ */
+function OrgDetailContent({ orgId }: { orgId: string }) {
+  const { data, loading, error } = useAdminFetch<OrgDetail>(
+    `/api/v1/admin/organizations/${orgId}`,
+  );
+
+  if (loading) {
+    return (
+      <div className="flex h-32 items-center justify-center">
+        <LoadingState message="Loading organization..." />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="px-4">
+        <ErrorBanner message={friendlyError(error)} />
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
+        No organization data to display.
+      </div>
+    );
+  }
+
+  const status = statusBadge(data.organization.workspaceStatus);
+  const plan = planBadge(data.organization.planTier);
+  const StatusIcon = status.Icon;
+  const PlanIcon = plan.Icon;
+  const pending = data.invitations.filter((i) => i.status === "pending");
+
+  return (
+    <div className="space-y-6 px-4">
+      {/* Status + plan badges (header carve-out) */}
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant="outline" className={status.className}>
+          <StatusIcon className="mr-1 size-3" />
+          {status.label}
+        </Badge>
+        <Badge variant="outline" className={plan.className}>
+          <PlanIcon className="mr-1 size-3" />
+          {plan.label}
+        </Badge>
+        {data.organization.suspendedAt && (
+          <span className="text-xs text-muted-foreground">
+            Suspended <RelativeTimestamp iso={data.organization.suspendedAt} />
+          </span>
+        )}
+        {data.organization.deletedAt && (
+          <span className="text-xs text-muted-foreground">
+            Deleted <RelativeTimestamp iso={data.organization.deletedAt} />
+          </span>
+        )}
+      </div>
+
+      {/* Members */}
+      <div className="space-y-3">
+        <h3 className="flex items-center gap-2 text-sm font-semibold">
+          <Users className="size-4" />
+          Members ({data.members.length})
+        </h3>
+        <div className="space-y-2">
+          {data.members.map((m) => {
+            const { Icon: RoleIcon, className: badgeClass } = roleBadge(m.role);
+            return (
+              <div
+                key={m.id}
+                className="flex items-center justify-between rounded-md border p-3"
+              >
+                <div className="flex min-w-0 items-center gap-3">
+                  <div className="bg-muted flex size-8 shrink-0 items-center justify-center rounded-full text-xs font-medium">
+                    {m.user.name?.charAt(0)?.toUpperCase() ??
+                      m.user.email.charAt(0).toUpperCase()}
+                  </div>
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium">
+                      {m.user.name || m.user.email}
+                    </div>
+                    <div className="truncate text-xs text-muted-foreground">
+                      <span>{m.user.email}</span>
+                      <span aria-hidden="true"> · </span>
+                      <span>Joined </span>
+                      <RelativeTimestamp iso={m.createdAt} />
+                    </div>
+                  </div>
+                </div>
+                <Badge
+                  variant="outline"
+                  className={`capitalize shrink-0 ${badgeClass}`}
+                >
+                  <RoleIcon className="mr-1 size-3" />
+                  {m.role}
+                </Badge>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Pending invitations */}
+      {pending.length > 0 && (
+        <div className="space-y-3">
+          <h3 className="flex items-center gap-2 text-sm font-semibold">
+            <Mail className="size-4" />
+            Pending Invitations
+            <Badge variant="outline" className="ml-1 font-normal">
+              {pending.length}
+            </Badge>
+          </h3>
+          <div className="space-y-2">
+            {pending.map((inv) => {
+              const { className: badgeClass } = roleBadge(inv.role);
+              return (
+                <div
+                  key={inv.id}
+                  className="flex items-center justify-between rounded-md border p-3"
+                >
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium">
+                      {inv.email}
+                    </div>
+                    <div className="truncate text-xs text-muted-foreground">
+                      <span>Expires </span>
+                      <RelativeTimestamp iso={inv.expiresAt} />
+                      <span aria-hidden="true"> · </span>
+                      <span>Sent </span>
+                      <RelativeTimestamp iso={inv.createdAt} />
+                    </div>
+                  </div>
+                  <Badge
+                    variant="outline"
+                    className={`capitalize shrink-0 ${badgeClass}`}
+                  >
+                    {inv.role}
+                  </Badge>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface OrgDetailSheetProps {
+  orgId: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Header fallback when detail hasn't loaded yet — name from the list row. */
+  fallbackName?: string;
+  fallbackSlug?: string;
+}
+
+export function OrgDetailSheet({
+  orgId,
+  open,
+  onOpenChange,
+  fallbackName,
+  fallbackSlug,
+}: OrgDetailSheetProps) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="w-full sm:max-w-lg overflow-auto">
+        <SheetHeader>
+          <SheetTitle>{fallbackName ?? "Organization details"}</SheetTitle>
+          <SheetDescription>{fallbackSlug ?? ""}</SheetDescription>
+        </SheetHeader>
+        {orgId ? <OrgDetailContent orgId={orgId} /> : null}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/packages/web/src/app/admin/organizations/page.tsx
+++ b/packages/web/src/app/admin/organizations/page.tsx
@@ -102,12 +102,11 @@ export default function OrganizationsPage() {
   const [params, setParams] = useQueryStates(orgsSearchParams);
   const [searchInput, setSearchInput] = useState(params.search);
 
-  // Detail sheet — open + selected row tracked separately so the sheet keeps
-  // the row's name visible during the load (no "Loading…" placeholder header).
+  // Open + selected tracked separately so the sheet header keeps the row's
+  // name visible during the detail fetch instead of flashing "Loading…".
   const [selectedOrg, setSelectedOrg] = useState<Org | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
 
-  // Plan-change dialog selection — null until the operator picks a tier.
   const [planTierSelection, setPlanTierSelection] = useState<PlanTier | "">("");
 
   const [confirmAction, setConfirmAction] = useState<ConfirmAction>(null);
@@ -117,14 +116,12 @@ export default function OrganizationsPage() {
   );
   const allOrgs = data?.organizations ?? [];
 
-  // Single mutation hook — all four endpoints share the same in-flight slot
-  // and per-row error map. Banner uses `MutationErrorSurface` so a 403 gets
-  // routed through `EnterpriseUpsell` automatically.
+  // Single hook so all four actions share one in-flight set and one per-row
+  // error map — `errorFor(org.id)` works across actions for any given row.
   const orgAction = useAdminMutation<{ message: string }>({
     invalidates: refetch,
   });
 
-  // Client-side search filtering (search stays client-side per scope).
   const orgs = params.search
     ? allOrgs.filter((o) => {
         const q = params.search.toLowerCase();
@@ -141,8 +138,8 @@ export default function OrganizationsPage() {
     setParams({ search: searchInput, page: 1 });
   }
 
-  // Mutation handlers — return the discriminated `ok` so destructive
-  // confirms can stay open on failure (mirrors /admin/users handlers).
+  // Returns `ok` so destructive confirms stay open on failure — the inline
+  // `MutationErrorSurface` inside each dialog body shows the operator why.
   async function handleSuspend(org: Org): Promise<boolean> {
     const result = await orgAction.mutate({
       path: `/api/v1/admin/organizations/${org.id}/suspend`,
@@ -246,8 +243,7 @@ export default function OrganizationsPage() {
       header: () => null,
       cell: ({ row }) => {
         const org = row.original;
-        // Soft-deleted workspaces have no further actions other than view —
-        // suspend/activate/plan all 409 server-side, and delete also 409s.
+        // Soft-deleted workspaces 409 on every action except view.
         const isDeleted = org.workspaceStatus === "deleted";
         return (
           <div className="flex items-center justify-end gap-1">
@@ -380,7 +376,6 @@ export default function OrganizationsPage() {
             </div>
           </div>
 
-          {/* Mutation error surface — routes 403/EE upsell, falls back to banner */}
           <MutationErrorSurface
             error={orgAction.error}
             feature="Organizations"
@@ -436,9 +431,21 @@ export default function OrganizationsPage() {
               and drain its connection pools. You can reactivate it at any time.
             </AlertDialogDescription>
           </AlertDialogHeader>
+          {confirmAction?.type === "suspend" && (
+            <MutationErrorSurface
+              error={orgAction.errorFor(confirmAction.org.id) ?? null}
+              feature="Suspend workspace"
+              variant="inline"
+              inlinePrefix="Suspend failed."
+            />
+          )}
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
+              disabled={
+                confirmAction?.type === "suspend" &&
+                orgAction.isMutating(confirmAction.org.id)
+              }
               onClick={async () => {
                 if (confirmAction?.type !== "suspend") return;
                 const ok = await handleSuspend(confirmAction.org);
@@ -464,9 +471,21 @@ export default function OrganizationsPage() {
               will resume normal operations and queries will be unblocked immediately.
             </AlertDialogDescription>
           </AlertDialogHeader>
+          {confirmAction?.type === "activate" && (
+            <MutationErrorSurface
+              error={orgAction.errorFor(confirmAction.org.id) ?? null}
+              feature="Activate workspace"
+              variant="inline"
+              inlinePrefix="Activate failed."
+            />
+          )}
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
+              disabled={
+                confirmAction?.type === "activate" &&
+                orgAction.isMutating(confirmAction.org.id)
+              }
               onClick={async () => {
                 if (confirmAction?.type !== "activate") return;
                 const ok = await handleActivate(confirmAction.org);
@@ -494,10 +513,22 @@ export default function OrganizationsPage() {
               The workspace cannot be reactivated after deletion.
             </AlertDialogDescription>
           </AlertDialogHeader>
+          {confirmAction?.type === "delete" && (
+            <MutationErrorSurface
+              error={orgAction.errorFor(confirmAction.org.id) ?? null}
+              feature="Delete workspace"
+              variant="inline"
+              inlinePrefix="Delete failed."
+            />
+          )}
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              disabled={
+                confirmAction?.type === "delete" &&
+                orgAction.isMutating(confirmAction.org.id)
+              }
               onClick={async () => {
                 if (confirmAction?.type !== "delete") return;
                 const ok = await handleDelete(confirmAction.org);
@@ -510,7 +541,7 @@ export default function OrganizationsPage() {
         </AlertDialogContent>
       </AlertDialog>
 
-      {/* Plan-change dialog (Select + confirm — not destructive, so plain Dialog) */}
+      {/* Plain Dialog — not destructive (sibling actions use AlertDialog). */}
       <Dialog
         open={confirmAction?.type === "plan"}
         onOpenChange={(open) => {
@@ -552,6 +583,14 @@ export default function OrganizationsPage() {
                   This is already the workspace's current plan.
                 </p>
               )}
+            {confirmAction?.type === "plan" && (
+              <MutationErrorSurface
+                error={orgAction.errorFor(confirmAction.org.id) ?? null}
+                feature="Change plan"
+                variant="inline"
+                inlinePrefix="Plan change failed."
+              />
+            )}
           </div>
           <DialogFooter>
             <Button
@@ -567,10 +606,8 @@ export default function OrganizationsPage() {
               disabled={
                 !planTierSelection ||
                 (confirmAction?.type === "plan" &&
-                  planTierSelection === confirmAction.org.planTier) ||
-                orgAction.saving ||
-                (confirmAction?.type === "plan" &&
-                  orgAction.isMutating(confirmAction.org.id))
+                  (planTierSelection === confirmAction.org.planTier ||
+                    orgAction.isMutating(confirmAction.org.id)))
               }
               onClick={async () => {
                 if (confirmAction?.type !== "plan" || !planTierSelection) return;

--- a/packages/web/src/app/admin/organizations/page.tsx
+++ b/packages/web/src/app/admin/organizations/page.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useQueryStates } from "nuqs";
 import { orgsSearchParams } from "./search-params";
 import type { ColumnDef } from "@tanstack/react-table";
-import { useAtlasConfig } from "@/ui/context";
 import { LoadingState } from "@/ui/components/admin/loading-state";
 import { usePlatformAdminGuard } from "@/ui/hooks/use-platform-admin-guard";
 import { Badge } from "@/components/ui/badge";
@@ -15,25 +14,59 @@ import { useDataTable } from "@/hooks/use-data-table";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { StatCard } from "@/ui/components/admin/stat-card";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
-import type { FetchError } from "@/ui/hooks/use-admin-fetch";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
+import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
+import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { RelativeTimestamp } from "@/ui/components/admin/queue";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { roleBadge } from "./roles";
+import { PLAN_TIERS } from "@useatlas/types";
+import type { PlanTier } from "@useatlas/types";
+import { OrgDetailSheet } from "./detail-sheet";
+import { planBadge, statusBadge } from "./statuses";
 import {
   Building2,
   Search,
   Users,
   Eye,
-  Mail,
+  MoreHorizontal,
+  Pause,
+  Play,
+  Trash2,
+  CreditCard,
 } from "lucide-react";
 
 // -- Types --
@@ -45,83 +78,53 @@ interface Org {
   logo: string | null;
   createdAt: string;
   memberCount: number;
+  workspaceStatus: string;
+  planTier: string;
+  suspendedAt: string | null;
+  deletedAt: string | null;
 }
 
-interface OrgDetail {
-  organization: {
-    id: string;
-    name: string;
-    slug: string;
-    logo: string | null;
-    createdAt: string;
-  };
-  members: Array<{
-    id: string;
-    userId: string;
-    role: string;
-    createdAt: string;
-    user: { id: string; name: string; email: string; image: string | null };
-  }>;
-  invitations: Array<{
-    id: string;
-    email: string;
-    role: string;
-    status: string;
-    expiresAt: string;
-    createdAt: string;
-  }>;
+interface OrgListResponse {
+  organizations: Org[];
+  total: number;
 }
+
+type ConfirmAction =
+  | { type: "suspend"; org: Org }
+  | { type: "activate"; org: Org }
+  | { type: "delete"; org: Org }
+  | { type: "plan"; org: Org }
+  | null;
 
 export default function OrganizationsPage() {
   const { blocked } = usePlatformAdminGuard();
-  const { apiUrl, isCrossOrigin } = useAtlasConfig();
-  const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
 
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<FetchError | null>(null);
   const [params, setParams] = useQueryStates(orgsSearchParams);
   const [searchInput, setSearchInput] = useState(params.search);
 
-  // Detail sheet
-  const [selectedOrg, setSelectedOrg] = useState<OrgDetail | null>(null);
-  const [detailLoading, setDetailLoading] = useState(false);
+  // Detail sheet — open + selected row tracked separately so the sheet keeps
+  // the row's name visible during the load (no "Loading…" placeholder header).
+  const [selectedOrg, setSelectedOrg] = useState<Org | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
-  const [detailError, setDetailError] = useState<string | null>(null);
 
-  // Fetch all organizations once — search is client-side
-  const [allOrgs, setAllOrgs] = useState<Org[]>([]);
-  useEffect(() => {
-    let cancelled = false;
-    async function fetchOrgs() {
-      setLoading(true);
-      setError(null);
-      try {
-        const res = await fetch(`${apiUrl}/api/v1/admin/organizations`, { credentials });
-        if (!res.ok) {
-          // intentionally ignored: body may be empty or non-JSON on error —
-          // status-code message is the fallback.
-          const body = (await res.json().catch(() => ({}))) as { message?: string };
-          const message = body.message ?? `Failed to load organizations (HTTP ${res.status})`;
-          if (!cancelled) setError({ message, status: res.status });
-          return;
-        }
-        const data = await res.json();
-        if (!cancelled) {
-          setAllOrgs(data.organizations ?? []);
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setError({ message: err instanceof Error ? err.message : "Failed to load organizations" });
-        }
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
-    fetchOrgs();
-    return () => { cancelled = true; };
-  }, [apiUrl, credentials]);
+  // Plan-change dialog selection — null until the operator picks a tier.
+  const [planTierSelection, setPlanTierSelection] = useState<PlanTier | "">("");
 
-  // Client-side search filtering
+  const [confirmAction, setConfirmAction] = useState<ConfirmAction>(null);
+
+  const { data, loading, error, refetch } = useAdminFetch<OrgListResponse>(
+    "/api/v1/admin/organizations",
+  );
+  const allOrgs = data?.organizations ?? [];
+
+  // Single mutation hook — all four endpoints share the same in-flight slot
+  // and per-row error map. Banner uses `MutationErrorSurface` so a 403 gets
+  // routed through `EnterpriseUpsell` automatically.
+  const orgAction = useAdminMutation<{ message: string }>({
+    invalidates: refetch,
+  });
+
+  // Client-side search filtering (search stays client-side per scope).
   const orgs = params.search
     ? allOrgs.filter((o) => {
         const q = params.search.toLowerCase();
@@ -129,32 +132,52 @@ export default function OrganizationsPage() {
       })
     : allOrgs;
 
-  async function openDetail(orgId: string) {
+  function openDetail(org: Org) {
+    setSelectedOrg(org);
     setDetailOpen(true);
-    setDetailLoading(true);
-    setDetailError(null);
-    try {
-      const res = await fetch(`${apiUrl}/api/v1/admin/organizations/${orgId}`, { credentials });
-      if (!res.ok) {
-        // intentionally ignored: body may be empty or non-JSON on error — we
-        // fall back to the status-code message below.
-        const body = (await res.json().catch(() => ({}))) as { message?: string };
-        setDetailError(body.message ?? `Failed to load organization (HTTP ${res.status})`);
-        setSelectedOrg(null);
-        return;
-      }
-      const data = await res.json();
-      setSelectedOrg(data);
-    } catch (err) {
-      setDetailError(err instanceof Error ? err.message : "Network error loading organization");
-      setSelectedOrg(null);
-    } finally {
-      setDetailLoading(false);
-    }
   }
 
   function handleSearch() {
     setParams({ search: searchInput, page: 1 });
+  }
+
+  // Mutation handlers — return the discriminated `ok` so destructive
+  // confirms can stay open on failure (mirrors /admin/users handlers).
+  async function handleSuspend(org: Org): Promise<boolean> {
+    const result = await orgAction.mutate({
+      path: `/api/v1/admin/organizations/${org.id}/suspend`,
+      method: "PATCH",
+      itemId: org.id,
+    });
+    return result.ok;
+  }
+
+  async function handleActivate(org: Org): Promise<boolean> {
+    const result = await orgAction.mutate({
+      path: `/api/v1/admin/organizations/${org.id}/activate`,
+      method: "PATCH",
+      itemId: org.id,
+    });
+    return result.ok;
+  }
+
+  async function handleDelete(org: Org): Promise<boolean> {
+    const result = await orgAction.mutate({
+      path: `/api/v1/admin/organizations/${org.id}`,
+      method: "DELETE",
+      itemId: org.id,
+    });
+    return result.ok;
+  }
+
+  async function handleChangePlan(org: Org, tier: PlanTier): Promise<boolean> {
+    const result = await orgAction.mutate({
+      path: `/api/v1/admin/organizations/${org.id}/plan`,
+      method: "PATCH",
+      body: { planTier: tier },
+      itemId: org.id,
+    });
+    return result.ok;
   }
 
   const columns: ColumnDef<Org>[] = [
@@ -172,6 +195,32 @@ export default function OrganizationsPage() {
           </div>
         </div>
       ),
+    },
+    {
+      accessorKey: "workspaceStatus",
+      header: "Status",
+      cell: ({ row }) => {
+        const { Icon, className, label } = statusBadge(row.original.workspaceStatus);
+        return (
+          <Badge variant="outline" className={className}>
+            <Icon className="mr-1 size-3" />
+            {label}
+          </Badge>
+        );
+      },
+    },
+    {
+      accessorKey: "planTier",
+      header: "Plan",
+      cell: ({ row }) => {
+        const { Icon, className, label } = planBadge(row.original.planTier);
+        return (
+          <Badge variant="outline" className={className}>
+            <Icon className="mr-1 size-3" />
+            {label}
+          </Badge>
+        );
+      },
     },
     {
       accessorKey: "memberCount",
@@ -195,18 +244,80 @@ export default function OrganizationsPage() {
     {
       id: "actions",
       header: () => null,
-      cell: ({ row }) => (
-        <Button
-          variant="ghost"
-          size="sm"
-          className="size-8 p-0"
-          onClick={() => openDetail(row.original.id)}
-        >
-          <Eye className="size-4" />
-        </Button>
-      ),
+      cell: ({ row }) => {
+        const org = row.original;
+        // Soft-deleted workspaces have no further actions other than view —
+        // suspend/activate/plan all 409 server-side, and delete also 409s.
+        const isDeleted = org.workspaceStatus === "deleted";
+        return (
+          <div className="flex items-center justify-end gap-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="size-8 p-0"
+              onClick={() => openDetail(org)}
+              aria-label={`View ${org.name}`}
+            >
+              <Eye className="size-4" />
+            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="size-8 p-0"
+                  disabled={isDeleted}
+                  aria-label={`Actions for ${org.name}`}
+                >
+                  <MoreHorizontal className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {org.workspaceStatus === "active" && (
+                  <DropdownMenuItem
+                    onClick={() => setConfirmAction({ type: "suspend", org })}
+                  >
+                    <Pause className="mr-2 size-4" />
+                    Suspend workspace
+                  </DropdownMenuItem>
+                )}
+                {org.workspaceStatus === "suspended" && (
+                  <DropdownMenuItem
+                    onClick={() => setConfirmAction({ type: "activate", org })}
+                  >
+                    <Play className="mr-2 size-4" />
+                    Activate workspace
+                  </DropdownMenuItem>
+                )}
+                <DropdownMenuItem
+                  onClick={() => {
+                    setPlanTierSelection(
+                      (PLAN_TIERS as readonly string[]).includes(org.planTier)
+                        ? (org.planTier as PlanTier)
+                        : "",
+                    );
+                    setConfirmAction({ type: "plan", org });
+                  }}
+                >
+                  <CreditCard className="mr-2 size-4" />
+                  Change plan
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  className="text-destructive"
+                  onClick={() => setConfirmAction({ type: "delete", org })}
+                >
+                  <Trash2 className="mr-2 size-4" />
+                  Delete workspace
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        );
+      },
       enableSorting: false,
-      size: 64,
+      enableHiding: false,
+      size: 96,
     },
   ];
 
@@ -269,12 +380,19 @@ export default function OrganizationsPage() {
             </div>
           </div>
 
+          {/* Mutation error surface — routes 403/EE upsell, falls back to banner */}
+          <MutationErrorSurface
+            error={orgAction.error}
+            feature="Organizations"
+            onRetry={orgAction.clearError}
+          />
+
           {/* Content */}
           <AdminContentWrapper
             loading={loading}
             error={error}
             feature="Organization Management"
-            onRetry={() => setParams({ page: 1 })}
+            onRetry={refetch}
             loadingMessage="Loading organizations..."
             emptyIcon={Building2}
             emptyTitle="No organizations yet"
@@ -293,116 +411,184 @@ export default function OrganizationsPage() {
       </ErrorBoundary>
 
       {/* Organization detail sheet */}
-      <Sheet open={detailOpen} onOpenChange={setDetailOpen}>
-        <SheetContent className="w-full sm:max-w-lg overflow-auto">
-          <SheetHeader>
-            <SheetTitle>
-              {detailLoading
-                ? "Loading organization…"
-                : detailError
-                  ? "Could not load organization"
-                  : selectedOrg?.organization.name ?? "Organization details"}
-            </SheetTitle>
-            <SheetDescription>
-              {detailLoading
-                ? "Fetching members and invitations…"
-                : detailError
-                  ? "The organization could not be loaded. Try again in a moment."
-                  : selectedOrg?.organization.slug ?? ""}
-            </SheetDescription>
-          </SheetHeader>
+      <OrgDetailSheet
+        orgId={selectedOrg?.id ?? null}
+        open={detailOpen}
+        onOpenChange={(open) => {
+          setDetailOpen(open);
+          if (!open) setSelectedOrg(null);
+        }}
+        fallbackName={selectedOrg?.name}
+        fallbackSlug={selectedOrg?.slug}
+      />
 
-          {detailLoading ? (
-            <div className="flex h-32 items-center justify-center">
-              <LoadingState message="Loading organization..." />
-            </div>
-          ) : detailError ? (
-            <div className="flex h-32 items-center justify-center px-4 text-center text-sm text-destructive">
-              {detailError}
-            </div>
-          ) : selectedOrg ? (
-            <div className="space-y-6 px-4">
-              {/* Members */}
-              <div className="space-y-3">
-                <h3 className="flex items-center gap-2 text-sm font-semibold">
-                  <Users className="size-4" />
-                  Members ({selectedOrg.members.length})
-                </h3>
-                <div className="space-y-2">
-                  {selectedOrg.members.map((m) => {
-                    const { Icon: RoleIcon, className: badgeClass } = roleBadge(m.role);
-                    return (
-                      <div key={m.id} className="flex items-center justify-between rounded-md border p-3">
-                        <div className="flex min-w-0 items-center gap-3">
-                          <div className="bg-muted flex size-8 shrink-0 items-center justify-center rounded-full text-xs font-medium">
-                            {m.user.name?.charAt(0)?.toUpperCase() ?? m.user.email.charAt(0).toUpperCase()}
-                          </div>
-                          <div className="min-w-0">
-                            <div className="truncate text-sm font-medium">{m.user.name || m.user.email}</div>
-                            <div className="truncate text-xs text-muted-foreground">
-                              <span>{m.user.email}</span>
-                              <span aria-hidden="true"> · </span>
-                              <span>Joined </span>
-                              <RelativeTimestamp iso={m.createdAt} />
-                            </div>
-                          </div>
-                        </div>
-                        <Badge variant="outline" className={`capitalize shrink-0 ${badgeClass}`}>
-                          <RoleIcon className="mr-1 size-3" />
-                          {m.role}
-                        </Badge>
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
+      {/* Suspend confirmation dialog */}
+      <AlertDialog
+        open={confirmAction?.type === "suspend"}
+        onOpenChange={(open) => { if (!open) setConfirmAction(null); }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Suspend workspace</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will block all queries from{" "}
+              <strong>{confirmAction?.type === "suspend" ? confirmAction.org.name : ""}</strong>{" "}
+              and drain its connection pools. You can reactivate it at any time.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={async () => {
+                if (confirmAction?.type !== "suspend") return;
+                const ok = await handleSuspend(confirmAction.org);
+                if (ok) setConfirmAction(null);
+              }}
+            >
+              Suspend
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
-              {/* Pending invitations */}
-              {(() => {
-                const pending = selectedOrg.invitations.filter((i) => i.status === "pending");
-                if (pending.length === 0) return null;
-                return (
-                  <div className="space-y-3">
-                    <h3 className="flex items-center gap-2 text-sm font-semibold">
-                      <Mail className="size-4" />
-                      Pending Invitations
-                      <Badge variant="outline" className="ml-1 font-normal">
-                        {pending.length}
-                      </Badge>
-                    </h3>
-                    <div className="space-y-2">
-                      {pending.map((inv) => {
-                        const { className: badgeClass } = roleBadge(inv.role);
-                        return (
-                          <div key={inv.id} className="flex items-center justify-between rounded-md border p-3">
-                            <div className="min-w-0">
-                              <div className="truncate text-sm font-medium">{inv.email}</div>
-                              <div className="truncate text-xs text-muted-foreground">
-                                <span>Expires </span>
-                                <RelativeTimestamp iso={inv.expiresAt} />
-                                <span aria-hidden="true"> · </span>
-                                <span>Sent </span>
-                                <RelativeTimestamp iso={inv.createdAt} />
-                              </div>
-                            </div>
-                            <Badge variant="outline" className={`capitalize shrink-0 ${badgeClass}`}>
-                              {inv.role}
-                            </Badge>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </div>
+      {/* Activate confirmation dialog */}
+      <AlertDialog
+        open={confirmAction?.type === "activate"}
+        onOpenChange={(open) => { if (!open) setConfirmAction(null); }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Activate workspace</AlertDialogTitle>
+            <AlertDialogDescription>
+              <strong>{confirmAction?.type === "activate" ? confirmAction.org.name : ""}</strong>{" "}
+              will resume normal operations and queries will be unblocked immediately.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={async () => {
+                if (confirmAction?.type !== "activate") return;
+                const ok = await handleActivate(confirmAction.org);
+                if (ok) setConfirmAction(null);
+              }}
+            >
+              Activate
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Delete confirmation dialog */}
+      <AlertDialog
+        open={confirmAction?.type === "delete"}
+        onOpenChange={(open) => { if (!open) setConfirmAction(null); }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete workspace</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will soft-delete{" "}
+              <strong>{confirmAction?.type === "delete" ? confirmAction.org.name : ""}</strong>{" "}
+              and run cascading cleanup (drain pools, flush cache, remove associated data).
+              The workspace cannot be reactivated after deletion.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={async () => {
+                if (confirmAction?.type !== "delete") return;
+                const ok = await handleDelete(confirmAction.org);
+                if (ok) setConfirmAction(null);
+              }}
+            >
+              Delete workspace
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Plan-change dialog (Select + confirm — not destructive, so plain Dialog) */}
+      <Dialog
+        open={confirmAction?.type === "plan"}
+        onOpenChange={(open) => {
+          if (!open) {
+            setConfirmAction(null);
+            setPlanTierSelection("");
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Change plan tier</DialogTitle>
+            <DialogDescription>
+              Update the plan tier for{" "}
+              <strong>{confirmAction?.type === "plan" ? confirmAction.org.name : ""}</strong>.
+              This takes effect immediately and invalidates the workspace's plan cache.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <Select
+              value={planTierSelection}
+              onValueChange={(v) => setPlanTierSelection(v as PlanTier)}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select a plan tier" />
+              </SelectTrigger>
+              <SelectContent>
+                {PLAN_TIERS.map((t) => (
+                  <SelectItem key={t} value={t} className="capitalize">
+                    {t}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {confirmAction?.type === "plan" &&
+              planTierSelection &&
+              planTierSelection === confirmAction.org.planTier && (
+                <p className="text-xs text-muted-foreground">
+                  This is already the workspace's current plan.
+                </p>
+              )}
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setConfirmAction(null);
+                setPlanTierSelection("");
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              disabled={
+                !planTierSelection ||
+                (confirmAction?.type === "plan" &&
+                  planTierSelection === confirmAction.org.planTier) ||
+                orgAction.saving ||
+                (confirmAction?.type === "plan" &&
+                  orgAction.isMutating(confirmAction.org.id))
+              }
+              onClick={async () => {
+                if (confirmAction?.type !== "plan" || !planTierSelection) return;
+                const ok = await handleChangePlan(
+                  confirmAction.org,
+                  planTierSelection,
                 );
-              })()}
-            </div>
-          ) : (
-            <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
-              No organization data to display.
-            </div>
-          )}
-        </SheetContent>
-      </Sheet>
+                if (ok) {
+                  setConfirmAction(null);
+                  setPlanTierSelection("");
+                }
+              }}
+            >
+              Update plan
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
     </TooltipProvider>
   );

--- a/packages/web/src/app/admin/organizations/statuses.ts
+++ b/packages/web/src/app/admin/organizations/statuses.ts
@@ -1,0 +1,120 @@
+// Display-only helpers for workspace status + plan-tier badges, mirrored
+// after `roles.ts` (member roles) but for the workspace-level enums.
+//
+// Both helpers are **fail-safe** — unknown server values render a neutral
+// fallback badge with a one-time `console.warn` rather than crashing the
+// row. This protects the operator surface against server drift (a future
+// plan tier added before the web bundle ships, an enterprise enum value
+// leaking into the community type).
+//
+// Pair `statusBadge` with the `WorkspaceStatus` enum from `@useatlas/types`
+// (`active`, `suspended`, `deleted`); pair `planBadge` with `PlanTier`
+// (`free`, `trial`, `starter`, `pro`, `business`).
+
+import { CheckCircle2, Pause, Trash2, CreditCard } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { WORKSPACE_STATUSES, PLAN_TIERS } from "@useatlas/types";
+import type { WorkspaceStatus, PlanTier } from "@useatlas/types";
+
+interface BadgeDescriptor {
+  readonly Icon: LucideIcon;
+  readonly className: string;
+  readonly label: string;
+}
+
+const STATUS_BADGES: Record<WorkspaceStatus, BadgeDescriptor> = {
+  active: {
+    Icon: CheckCircle2,
+    className:
+      "border-emerald-300 text-emerald-700 dark:border-emerald-700 dark:text-emerald-400",
+    label: "Active",
+  },
+  suspended: {
+    Icon: Pause,
+    className:
+      "border-amber-300 text-amber-700 dark:border-amber-700 dark:text-amber-400",
+    label: "Suspended",
+  },
+  deleted: {
+    Icon: Trash2,
+    className:
+      "border-red-300 text-red-700 dark:border-red-700 dark:text-red-400",
+    label: "Deleted",
+  },
+};
+
+const PLAN_BADGES: Record<PlanTier, BadgeDescriptor> = {
+  free: {
+    Icon: CreditCard,
+    className: "border-muted-foreground/30 text-muted-foreground",
+    label: "Free",
+  },
+  trial: {
+    Icon: CreditCard,
+    className:
+      "border-blue-300 text-blue-700 dark:border-blue-700 dark:text-blue-400",
+    label: "Trial",
+  },
+  starter: {
+    Icon: CreditCard,
+    className: "border-primary/50 text-primary",
+    label: "Starter",
+  },
+  pro: {
+    Icon: CreditCard,
+    className:
+      "border-violet-300 text-violet-700 dark:border-violet-700 dark:text-violet-400",
+    label: "Pro",
+  },
+  business: {
+    Icon: CreditCard,
+    className:
+      "border-purple-300 text-purple-700 dark:border-purple-700 dark:text-purple-400",
+    label: "Business",
+  },
+};
+
+const NEUTRAL_BADGE: BadgeDescriptor = {
+  Icon: CheckCircle2,
+  className: "border-muted-foreground/30 text-muted-foreground",
+  label: "Unknown",
+};
+
+const warnedUnknownStatuses = new Set<string>();
+const warnedUnknownPlans = new Set<string>();
+
+/**
+ * Resolve icon + classes for a workspace status. Unknown values render a
+ * neutral badge labeled with the raw value (so operators can read what came
+ * back) and emit one `console.warn` per unknown value per session.
+ */
+export function statusBadge(status: string): BadgeDescriptor {
+  if ((WORKSPACE_STATUSES as readonly string[]).includes(status)) {
+    return STATUS_BADGES[status as WorkspaceStatus];
+  }
+  if (!warnedUnknownStatuses.has(status)) {
+    warnedUnknownStatuses.add(status);
+    console.warn(
+      `[admin/organizations] Unknown workspace status "${status}" — rendering neutral fallback. Investigate server drift or update WORKSPACE_STATUSES.`,
+    );
+  }
+  return { ...NEUTRAL_BADGE, label: status || "Unknown" };
+}
+
+/**
+ * Resolve icon + classes for a plan tier. Same fail-safe semantics as
+ * `statusBadge` — unknown tiers render a neutral badge with a one-time
+ * warning so a server-side enum addition doesn't break the operator UI.
+ */
+export function planBadge(planTier: string): BadgeDescriptor {
+  if ((PLAN_TIERS as readonly string[]).includes(planTier)) {
+    return PLAN_BADGES[planTier as PlanTier];
+  }
+  if (!warnedUnknownPlans.has(planTier)) {
+    warnedUnknownPlans.add(planTier);
+    console.warn(
+      `[admin/organizations] Unknown plan tier "${planTier}" — rendering neutral fallback. Investigate server drift or update PLAN_TIERS.`,
+    );
+  }
+  return { ...NEUTRAL_BADGE, label: planTier || "Unknown" };
+}


### PR DESCRIPTION
## Summary

Bundles **#1666** (Phase A — fetch plumbing migration) and **#1667** (Phase B — surface suspend / activate / delete / plan actions) on a single branch, with Phase A first in the diff so the mutation plumbing in Phase B sits on a clean fetch layer.

- **Phase A** — replaces bespoke `useEffect` + cancelled-flag list fetch with `useAdminFetch<OrgListResponse>`; extracts `OrgDetailSheet` + lazy `OrgDetailContent` so the detail request only fires on selection (mirrors `AbuseDetailPanel`); drops the bespoke `body.message ?? \`HTTP $status\`` concat.
- **Phase B** — adds Status + Plan columns, per-row actions dropdown (Suspend / Activate / Change plan / Delete), AlertDialog confirms for destructive paths and a Dialog + Select for plan changes, all mutations routed through one `useAdminMutation` hook with `itemId` per-row error slots and `MutationErrorSurface` for the page-level banner. Detail sheet header surfaces the same status + plan badges with relative `suspendedAt` / `deletedAt` timestamps when present.
- New pure helpers `statusBadge()` + `planBadge()` in `statuses.ts` — fail-safe rendering on unknown enum values (neutral badge labeled with the raw value + one-time `console.warn` per unknown), pattern matched after `roles.ts`. Covered by 12 unit tests.

### Notes
- Plan tiers come from `PLAN_TIERS` in `@useatlas/types` (`free`, `trial`, `starter`, `pro`, `business`). The issue text mentioned `team` / `enterprise` but the canonical server-side `PlanTier` in `packages/api/src/lib/db/internal.ts` is the source of truth — the Select stays drift-free against the server enum by importing the const tuple.
- `WorkspaceStatus` + `PlanTier` are already re-exported through `packages/web/src/ui/lib/types.ts`; the local `Org` interface in `page.tsx` was extended with `workspaceStatus`, `planTier`, `suspendedAt`, `deletedAt` (server already returns these).
- Search stays client-side per the #1666 scope guard.
- `usePlatformAdminGuard` early-return preserved — no regression in platform-admin guard.

Closes #1666
Closes #1667

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run type` — clean (`tsgo --noEmit`)
- [x] `bun run test` — full suite passes (incl. new 12 tests in `__tests__/statuses.test.ts`)
- [x] `bun x syncpack lint` — no issues
- [x] `bash scripts/check-template-drift.sh` — passed
- [ ] Verify in browser: list loads via `useAdminFetch`, suspend/activate/delete/plan all confirm and refetch, per-row error slot on simulated 409, status + plan badges render in detail sheet header, deleted workspaces have actions dropdown disabled.