### PR TITLE
feat(web): MutationErrorSurface — migrate core admin pages (phase 2C of #1624)

### DIFF
--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import {
   Tooltip,
   TooltipContent,
@@ -430,11 +431,11 @@ function DeleteConnectionDialog({
             This action cannot be undone.
           </AlertDialogDescription>
         </AlertDialogHeader>
-        {deleteMutation.error && (
-          <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
-            {friendlyError(deleteMutation.error)}
-          </div>
-        )}
+        <MutationErrorSurface
+          error={deleteMutation.error}
+          feature="Connections"
+          variant="inline"
+        />
         <AlertDialogFooter>
           <AlertDialogCancel disabled={deleteMutation.saving}>Cancel</AlertDialogCancel>
           <AlertDialogAction
@@ -970,7 +971,13 @@ export default function ConnectionsPage() {
       <ErrorBoundary>
         <div className="space-y-6">
           {mutationError && <ErrorBanner message={mutationError} onRetry={() => setMutationError(null)} />}
-          {testMutation.error && !mutationError && <ErrorBanner message={friendlyError(testMutation.error)} onRetry={testMutation.clearError} />}
+          {!mutationError && (
+            <MutationErrorSurface
+              error={testMutation.error}
+              feature="Connections"
+              onRetry={testMutation.clearError}
+            />
+          )}
 
           <PoolStatsSection onError={setMutationError} />
 

--- a/packages/web/src/app/admin/custom-domain/page.tsx
+++ b/packages/web/src/app/admin/custom-domain/page.tsx
@@ -16,7 +16,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
-import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import {
   CompactRow,
   DetailList,
@@ -29,7 +29,6 @@ import {
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError } from "@/ui/lib/fetch-error";
 import { combineMutationErrors } from "@/ui/lib/mutation-errors";
 import { DomainResponseSchema } from "@/ui/lib/admin-schemas";
 import { cn } from "@/lib/utils";
@@ -201,13 +200,11 @@ function CustomDomainPageContent() {
         loadingMessage="Loading domain configuration..."
       >
         <div className="mx-auto max-w-3xl space-y-8">
-          {mutationError && (
-            <ErrorBanner
-              message={friendlyError(mutationError)}
-              onRetry={clearMutationError}
-              actionLabel="Dismiss"
-            />
-          )}
+          <MutationErrorSurface
+            error={mutationError}
+            feature="Custom Domain"
+            onRetry={clearMutationError}
+          />
 
           <section>
             <SectionHeading
@@ -266,7 +263,7 @@ function CustomDomainPageContent() {
                     root domain.
                   </p>
                 </div>
-                {addError && <ErrorBanner message={friendlyError(addError)} />}
+                <MutationErrorSurface error={addError} feature="Custom Domain" />
               </Shell>
             )}
 

--- a/packages/web/src/app/admin/email-provider/__tests__/mutation-error-chain.test.tsx
+++ b/packages/web/src/app/admin/email-provider/__tests__/mutation-error-chain.test.tsx
@@ -9,14 +9,14 @@ import EmailProviderPage from "../page";
  * Regression guard for the three-way error chain at `email-provider/page.tsx`:
  *
  *   const structuredError = combineMutationErrors([saveError, deleteError, testError]);
- *   // structuredError → MutationErrorSurface, formError → ErrorBanner fallback
+ *   // render: structuredError ? <MutationErrorSurface/> : formError && <ErrorBanner/>
  *
  * Each of the three mutation slots can produce the banner, with `formError`
  * as the client-side fallback. Regressions — dropping one slot from the
- * compose array, swapping the structured/fallback branches, dropping the
- * `formError` fallback — render the wrong surface silently, so the DOM-level
- * branches are tested end-to-end and each mutation slot is exercised at
- * least once.
+ * compose array, swapping the structured/fallback branches, rendering both
+ * surfaces at once, dropping the `formError` fallback — render the wrong
+ * surface silently, so the DOM-level branches are tested end-to-end and
+ * each mutation slot is exercised at least once.
  */
 
 const stubAuthClient: AtlasAuthClient = {

--- a/packages/web/src/app/admin/email-provider/__tests__/mutation-error-chain.test.tsx
+++ b/packages/web/src/app/admin/email-provider/__tests__/mutation-error-chain.test.tsx
@@ -9,13 +9,14 @@ import EmailProviderPage from "../page";
  * Regression guard for the three-way error chain at `email-provider/page.tsx`:
  *
  *   const structuredError = combineMutationErrors([saveError, deleteError, testError]);
- *   const mutationError = structuredError ? friendlyError(structuredError) : formError;
+ *   // structuredError → MutationErrorSurface, formError → ErrorBanner fallback
  *
  * Each of the three mutation slots can produce the banner, with `formError`
  * as the client-side fallback. Regressions — dropping one slot from the
- * compose array, swapping the ternary arms, dropping the `formError`
- * fallback — render the wrong surface silently, so the DOM-level branches
- * are tested end-to-end and each mutation slot is exercised at least once.
+ * compose array, swapping the structured/fallback branches, dropping the
+ * `formError` fallback — render the wrong surface silently, so the DOM-level
+ * branches are tested end-to-end and each mutation slot is exercised at
+ * least once.
  */
 
 const stubAuthClient: AtlasAuthClient = {

--- a/packages/web/src/app/admin/email-provider/page.tsx
+++ b/packages/web/src/app/admin/email-provider/page.tsx
@@ -24,10 +24,10 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError } from "@/ui/lib/fetch-error";
 import { combineMutationErrors } from "@/ui/lib/mutation-errors";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import {
@@ -470,7 +470,6 @@ export default function EmailProviderPage() {
     });
 
   const structuredError = combineMutationErrors([saveError, deleteError, testError]);
-  const mutationError = structuredError ? friendlyError(structuredError) : formError;
   const baseline = data?.config.baseline;
   const override = data?.config.override ?? null;
   const hasOverride = override !== null;
@@ -605,9 +604,16 @@ export default function EmailProviderPage() {
       </div>
 
       <ErrorBoundary>
-        {mutationError && (
+        {(structuredError || formError) && (
           <div className="mx-auto mb-4 max-w-3xl">
-            <ErrorBanner message={mutationError} onRetry={clearAllErrors} actionLabel="Dismiss" />
+            <MutationErrorSurface
+              error={structuredError}
+              feature="Email Provider"
+              onRetry={clearAllErrors}
+            />
+            {!structuredError && formError && (
+              <ErrorBanner message={formError} onRetry={clearAllErrors} actionLabel="Dismiss" />
+            )}
           </div>
         )}
 

--- a/packages/web/src/app/admin/model-config/page.tsx
+++ b/packages/web/src/app/admin/model-config/page.tsx
@@ -25,11 +25,10 @@ import {
   FormDescription,
   FormMessage,
 } from "@/components/ui/form";
-import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError } from "@/ui/lib/fetch-error";
 import { combineMutationErrors } from "@/ui/lib/mutation-errors";
 import { usePlatformAdminGuard } from "@/ui/hooks/use-platform-admin-guard";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
@@ -282,7 +281,11 @@ export default function ModelConfigPage() {
       <ErrorBoundary>
         {mutationError && (
           <div className="mx-auto mb-4 max-w-3xl">
-            <ErrorBanner message={friendlyError(mutationError)} onRetry={clearAllErrors} actionLabel="Dismiss" />
+            <MutationErrorSurface
+              error={mutationError}
+              feature="AI Provider"
+              onRetry={clearAllErrors}
+            />
           </div>
         )}
 

--- a/packages/web/src/app/admin/residency/page.tsx
+++ b/packages/web/src/app/admin/residency/page.tsx
@@ -680,7 +680,7 @@ function MigrationDialog({
     const success = await onMigrate(selected);
     if (success) setSelected("");
     // Close regardless of success — failures surface via the page-level
-    // ErrorBanner so the dialog doesn't trap the user over a stale form.
+    // MutationErrorSurface so the dialog doesn't trap the user over a stale form.
     setShowConfirm(false);
     setOpen(false);
   }

--- a/packages/web/src/app/admin/residency/page.tsx
+++ b/packages/web/src/app/admin/residency/page.tsx
@@ -22,7 +22,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
-import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import {
   CompactRow,
   DetailList,
@@ -32,7 +32,7 @@ import {
   StatusDot,
   type StatusKind,
 } from "@/ui/components/admin/compact";
-import { useAdminFetch, friendlyError } from "@/ui/hooks/use-admin-fetch";
+import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { combineMutationErrors } from "@/ui/lib/mutation-errors";
 import { useDeployMode } from "@/ui/hooks/use-deploy-mode";
@@ -266,20 +266,17 @@ function ResidencyPageContent() {
         emptyDescription="Data residency is not available in this deployment."
       >
         <div className="mx-auto max-w-3xl space-y-8">
-          {mutationError && (
-            <ErrorBanner
-              message={friendlyError(mutationError)}
-              onRetry={clearMutationError}
-              actionLabel="Dismiss"
-            />
-          )}
+          <MutationErrorSurface
+            error={mutationError}
+            feature="Data Residency"
+            onRetry={clearMutationError}
+          />
 
-          {migrationFetchError && (
-            <ErrorBanner
-              message={friendlyError(migrationFetchError)}
-              onRetry={refetchMigration}
-            />
-          )}
+          <MutationErrorSurface
+            error={migrationFetchError}
+            feature="Data Residency"
+            onRetry={refetchMigration}
+          />
 
           {data && (
             <section>

--- a/packages/web/src/app/admin/sandbox/page.tsx
+++ b/packages/web/src/app/admin/sandbox/page.tsx
@@ -24,7 +24,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
-import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import {
   CompactRow,
   DetailList,
@@ -38,7 +38,6 @@ import {
 } from "@/ui/components/admin/compact";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError, friendlyErrorOrNull } from "@/ui/lib/fetch-error";
 import { combineMutationErrors } from "@/ui/lib/mutation-errors";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { useDeployMode } from "@/ui/hooks/use-deploy-mode";
@@ -218,13 +217,11 @@ export default function SandboxPage() {
           emptyDescription="No sandbox status available."
         >
           <div className="mx-auto max-w-3xl space-y-8">
-            {mutationError && (
-              <ErrorBanner
-                message={friendlyError(mutationError)}
-                onRetry={clearMutationError}
-                actionLabel="Dismiss"
-              />
-            )}
+            <MutationErrorSurface
+              error={mutationError}
+              feature="Sandbox"
+              onRetry={clearMutationError}
+            />
 
             {data &&
               (isSaas ? (
@@ -471,8 +468,7 @@ function ProviderRow({
       const val = fieldValues[field.key]?.trim();
       if (val) credentials[field.key] = val;
     }
-    const result = await connectMutation.mutate({ body: { credentials } });
-    if (!result.ok) setValidationError(friendlyError(result.error));
+    await connectMutation.mutate({ body: { credentials } });
   }
 
   return (
@@ -590,8 +586,17 @@ function ProviderRow({
         </div>
       )}
 
-      <InlineError>{validationError ?? friendlyErrorOrNull(connectMutation.error)}</InlineError>
-      <InlineError>{friendlyErrorOrNull(disconnectMutation.error)}</InlineError>
+      {validationError && <InlineError>{validationError}</InlineError>}
+      <MutationErrorSurface
+        error={connectMutation.error}
+        feature="Sandbox"
+        variant="inline"
+      />
+      <MutationErrorSurface
+        error={disconnectMutation.error}
+        feature="Sandbox"
+        variant="inline"
+      />
     </Shell>
   );
 }

--- a/packages/web/src/app/admin/sandbox/page.tsx
+++ b/packages/web/src/app/admin/sandbox/page.tsx
@@ -574,7 +574,8 @@ function ProviderRow({
                 onChange={(e) => {
                   setFieldValues((prev) => ({ ...prev, [field.key]: e.target.value }));
                   // Clear prior client-side validation so a stale "required"
-                  // message can't mask a fresh server error on resubmit.
+                  // message doesn't persist after the user starts typing a
+                  // valid value.
                   if (validationError) setValidationError(null);
                 }}
               />

--- a/packages/web/src/app/admin/settings/page.tsx
+++ b/packages/web/src/app/admin/settings/page.tsx
@@ -19,12 +19,12 @@ import {
   FormControl,
   FormMessage,
 } from "@/components/form-dialog";
-import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { SectionHeading } from "@/ui/components/admin/compact";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError, friendlyErrorOrNull } from "@/ui/lib/fetch-error";
+import { friendlyErrorOrNull } from "@/ui/lib/fetch-error";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { useDeployMode } from "@/ui/hooks/use-deploy-mode";
 import { cn } from "@/lib/utils";
@@ -460,9 +460,11 @@ export default function SettingsPage() {
           isEmpty={workspaceSections.size === 0}
         >
           <div className="mx-auto max-w-3xl space-y-8">
-            {mutationError && (
-              <ErrorBanner message={friendlyError(mutationError)} onRetry={clearMutationError} />
-            )}
+            <MutationErrorSurface
+              error={mutationError}
+              feature="Settings"
+              onRetry={clearMutationError}
+            />
 
             {!manageable && !isSaas && (
               <div className="flex items-start gap-2 rounded-xl border border-amber-500/30 bg-amber-500/5 px-4 py-3">

--- a/packages/web/src/app/admin/starter-prompts/page.tsx
+++ b/packages/web/src/app/admin/starter-prompts/page.tsx
@@ -36,9 +36,10 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError } from "@/ui/lib/fetch-error";
+import type { FetchError } from "@/ui/lib/fetch-error";
 import { Loader2, Plus } from "lucide-react";
 import type {
   SuggestionApprovalStatus,
@@ -303,11 +304,11 @@ function AuthorPromptDialog({ onAuthored }: { onAuthored: () => void }) {
             autoFocus
             data-testid="starter-prompt-author-text"
           />
-          {error && (
-            <p className="text-xs text-destructive" role="alert">
-              {friendlyError(error)}
-            </p>
-          )}
+          <MutationErrorSurface
+            error={error}
+            feature="Starter Prompts"
+            variant="inline"
+          />
           <DialogFooter>
             <Button
               type="submit"
@@ -342,7 +343,7 @@ function StarterPromptsContent() {
   const coldWindowDays = data?.coldWindowDays ?? 90;
 
   const [pendingRowId, setPendingRowId] = useState<string | null>(null);
-  const [rowActionError, setRowActionError] = useState<string | null>(null);
+  const [rowActionError, setRowActionError] = useState<FetchError | null>(null);
 
   const { mutate: mutateRow } = useAdminMutation<{ suggestion: QueueItem }>({
     method: "POST",
@@ -362,7 +363,7 @@ function StarterPromptsContent() {
       // the row didn't move between tabs. Without this branch, the
       // spinner stops and the UI appears to succeed.
       if (!result.ok) {
-        setRowActionError(friendlyError(result.error));
+        setRowActionError(result.error);
       }
     } finally {
       setPendingRowId(null);
@@ -384,23 +385,11 @@ function StarterPromptsContent() {
           <AuthorPromptDialog onAuthored={refetch} />
         </div>
 
-        {rowActionError && (
-          <div
-            role="alert"
-            data-testid="starter-prompt-row-action-error"
-            className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive flex items-start justify-between gap-3"
-          >
-            <span>{rowActionError}</span>
-            <button
-              type="button"
-              onClick={() => setRowActionError(null)}
-              className="text-xs underline opacity-70 hover:opacity-100"
-              aria-label="Dismiss error"
-            >
-              Dismiss
-            </button>
-          </div>
-        )}
+        <MutationErrorSurface
+          error={rowActionError}
+          feature="Starter Prompts"
+          onRetry={() => setRowActionError(null)}
+        />
 
         <Tabs defaultValue="pending">
           <TabsList>

--- a/packages/web/src/app/admin/starter-prompts/page.tsx
+++ b/packages/web/src/app/admin/starter-prompts/page.tsx
@@ -359,8 +359,9 @@ function StarterPromptsContent() {
         body: {},
         itemId: id,
       });
-      // Surface failures (403 cross-org, 404, 500) so the admin sees why
-      // the row didn't move between tabs. Without this branch, the
+      // Hand the structured error to MutationErrorSurface so auth /
+      // not-found / enterprise cases get tailored affordances and plain
+      // 500s still render a dismissible banner. Without this branch, the
       // spinner stops and the UI appears to succeed.
       if (!result.ok) {
         setRowActionError(result.error);


### PR DESCRIPTION
## Summary

Routes ~14 mutation error sites across 9 core admin pages through `<MutationErrorSurface>` so `EnterpriseUpsell` (on `code === \"enterprise_required\"`) and `FeatureGate` (on 401/403/404/503) fire on the write path the same way `AdminContentWrapper` already handles the read path. Mechanical sweep — decision tree stays in the component (phase 1, PR #1650).

## Migrated sites

- **`/admin/connections`** — `testMutation.error` (banner, guarded by local `mutationError` string for `PoolStatsSection` errors) + `deleteMutation.error` (inline, inside the AlertDialog). `FormDialog` `saveMutation.serverError` stays on `friendlyError()` per #1649.
- **`/admin/custom-domain`** — `mutationError` (`combineMutationErrors` of verify + remove, banner) + `addError` (banner, inside the Add Shell).
- **`/admin/email-provider`** — `structuredError` (`combineMutationErrors` of save + delete + test, banner). Local `formError` string still renders through `ErrorBanner` as the false-arm fallback (pure client validation — no structured code to route).
- **`/admin/model-config`** — `mutationError` (`combineMutationErrors`, banner).
- **`/admin/residency`** — `mutationError` (banner, with `clearMutationError` retry) + `migrationFetchError` (banner, with `refetchMigration` retry).
- **`/admin/sandbox`** — page-level `mutationError` (`combineMutationErrors` of save + saveUrl + reset, banner) + per-row `ProviderConnectShell` `connectMutation` / `disconnectMutation` (inline). Local `validationError` string kept for pure client validation (\"\$field is required\") — mutation errors no longer flatten into it; they surface via `MutationErrorSurface` directly.
- **`/admin/settings`** — `mutationError` (banner). FormDialog `saveMutation.serverError` stays on `friendlyErrorOrNull()`.
- **`/admin/starter-prompts`** — `AuthorPromptDialog` create error (inline, replacing a plain `<p role=\"alert\">`) + page-level `rowActionError` (banner). `rowActionError` re-typed from `string | null` to `FetchError | null` so structured code reaches `MutationErrorSurface` — matches the `FetchError`-typed state pattern landed for `/admin/actions` `mutationError` in PR #1670.

## Scope notes

- FormDialog `serverError` props stay on `friendlyError()` / `friendlyErrorOrNull()` — strings, already inside a gated page (per #1649).
- Local synthesized strings (connections `PoolStatsSection` errors, email-provider `formError`, sandbox `validationError`) stay as-is — client validation or multi-source aggregation with no single structured code.
- `actionLabel=\"Dismiss\"` copy is silently dropped (matches phase 2A/2B).
- `feature` strings match each page's `AdminContentWrapper` feature: Connections, Custom Domain, Email Provider, AI Provider, Data Residency, Sandbox, Settings, Starter Prompts.
- No new component tests per-page — phase 1's `mutation-error-surface.test.tsx` covers the decision tree. The existing `email-provider/__tests__/mutation-error-chain.test.tsx` is still green (`role=\"alert\"` + text assertions intact); comment refreshed to describe the new `structuredError` → `MutationErrorSurface` shape.

## Test plan

- [x] \`bun run lint\` — zero output
- [x] \`bun run type\` — exit 0
- [x] \`bun run test\` — 76/76 web tests green (email-provider chain: 4/4; custom-domain plan-gate: 4/4)
- [x] \`bun x syncpack lint\` — No issues found
- [x] Template drift — 430 files verified
- [ ] Spot-check one non-EE admin hitting a gated mutation (e.g. connections create in a non-EE env) — verify `EnterpriseUpsell` renders (deferred to reviewer; the decision-tree routing is identical to #1650 / #1656 / #1670 and those have been spot-checked)

Closes another chunk of #1649. Remaining chunks: rest of core admin (audit/retention, compliance, prompts, roles, scheduled-tasks, semantic, semantic/improve, sessions, usage, users) + scim row-pin carve-out.