### PR TITLE
feat(web): MutationErrorSurface — finish core admin sweep (phase 2D of #1624) (#1649)

### DIFF
--- a/packages/web/src/app/admin/compliance/page.tsx
+++ b/packages/web/src/app/admin/compliance/page.tsx
@@ -253,7 +253,13 @@ function ClassificationsTab() {
         </div>
       )}
 
-      <MutationErrorSurface error={actionError} feature="PII Compliance" />
+      {!editingId && (
+        <MutationErrorSurface
+          error={actionError}
+          feature="PII Compliance"
+          onRetry={resetAction}
+        />
+      )}
 
       {/* Stats */}
       <div className="grid gap-4 md:grid-cols-4">

--- a/packages/web/src/app/admin/compliance/page.tsx
+++ b/packages/web/src/app/admin/compliance/page.tsx
@@ -34,10 +34,11 @@ import { z } from "zod";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { LoadingState } from "@/ui/components/admin/loading-state";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError } from "@/ui/lib/fetch-error";
+import { friendlyErrorOrNull } from "@/ui/lib/fetch-error";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import {
   ShieldCheck,
@@ -252,7 +253,7 @@ function ClassificationsTab() {
         </div>
       )}
 
-      {actionError && <ErrorBanner message={friendlyError(actionError)} />}
+      <MutationErrorSurface error={actionError} feature="Compliance" />
 
       {/* Stats */}
       <div className="grid gap-4 md:grid-cols-4">
@@ -384,7 +385,7 @@ function ClassificationsTab() {
         }}
         submitLabel="Save Changes"
         saving={saving}
-        serverError={actionError ? friendlyError(actionError) : null}
+        serverError={friendlyErrorOrNull(actionError)}
       >
         {(form) => (
           <>

--- a/packages/web/src/app/admin/compliance/page.tsx
+++ b/packages/web/src/app/admin/compliance/page.tsx
@@ -253,7 +253,7 @@ function ClassificationsTab() {
         </div>
       )}
 
-      <MutationErrorSurface error={actionError} feature="Compliance" />
+      <MutationErrorSurface error={actionError} feature="PII Compliance" />
 
       {/* Stats */}
       <div className="grid gap-4 md:grid-cols-4">

--- a/packages/web/src/app/admin/prompts/page.tsx
+++ b/packages/web/src/app/admin/prompts/page.tsx
@@ -52,7 +52,7 @@ import {
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { StatCard } from "@/ui/components/admin/stat-card";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
-import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import {
   FormDialog,
   FormField,
@@ -63,7 +63,7 @@ import {
 } from "@/components/form-dialog";
 import type { FetchError } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError, friendlyErrorOrNull } from "@/ui/lib/fetch-error";
+import { friendlyErrorOrNull } from "@/ui/lib/fetch-error";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { useDevModeNoDrafts } from "@/ui/hooks/use-dev-mode-no-drafts";
 import { DeveloperEmptyState } from "@/ui/components/admin/developer-empty-state";
@@ -543,10 +543,10 @@ export default function PromptsPage() {
           </div>
 
           {/* Content */}
-          {collectionMutation.error && <ErrorBanner message={friendlyError(collectionMutation.error)} onRetry={collectionMutation.clearError} />}
-          {deleteCollectionMutation.error && <ErrorBanner message={friendlyError(deleteCollectionMutation.error)} onRetry={deleteCollectionMutation.clearError} />}
-          {addItemMutation.error && <ErrorBanner message={friendlyError(addItemMutation.error)} onRetry={addItemMutation.clearError} />}
-          {deleteItemMutation.error && <ErrorBanner message={friendlyError(deleteItemMutation.error)} onRetry={deleteItemMutation.clearError} />}
+          <MutationErrorSurface error={collectionMutation.error} feature="Prompts" onRetry={collectionMutation.clearError} />
+          <MutationErrorSurface error={deleteCollectionMutation.error} feature="Prompts" onRetry={deleteCollectionMutation.clearError} />
+          <MutationErrorSurface error={addItemMutation.error} feature="Prompts" onRetry={addItemMutation.clearError} />
+          <MutationErrorSurface error={deleteItemMutation.error} feature="Prompts" onRetry={deleteItemMutation.clearError} />
 
           <AdminContentWrapper
             loading={loading}

--- a/packages/web/src/app/admin/prompts/page.tsx
+++ b/packages/web/src/app/admin/prompts/page.tsx
@@ -543,10 +543,10 @@ export default function PromptsPage() {
           </div>
 
           {/* Content */}
-          <MutationErrorSurface error={collectionMutation.error} feature="Prompts" onRetry={collectionMutation.clearError} />
-          <MutationErrorSurface error={deleteCollectionMutation.error} feature="Prompts" onRetry={deleteCollectionMutation.clearError} />
-          <MutationErrorSurface error={addItemMutation.error} feature="Prompts" onRetry={addItemMutation.clearError} />
-          <MutationErrorSurface error={deleteItemMutation.error} feature="Prompts" onRetry={deleteItemMutation.clearError} />
+          <MutationErrorSurface error={collectionMutation.error} feature="Prompt Library" onRetry={collectionMutation.clearError} />
+          <MutationErrorSurface error={deleteCollectionMutation.error} feature="Prompt Library" onRetry={deleteCollectionMutation.clearError} />
+          <MutationErrorSurface error={addItemMutation.error} feature="Prompt Library" onRetry={addItemMutation.clearError} />
+          <MutationErrorSurface error={deleteItemMutation.error} feature="Prompt Library" onRetry={deleteItemMutation.clearError} />
 
           <AdminContentWrapper
             loading={loading}

--- a/packages/web/src/app/admin/roles/page.tsx
+++ b/packages/web/src/app/admin/roles/page.tsx
@@ -35,9 +35,10 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError, friendlyErrorOrNull } from "@/ui/lib/fetch-error";
+import { friendlyErrorOrNull } from "@/ui/lib/fetch-error";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { KeyRound, Plus, Pencil, Trash2, Loader2, Lock, Users } from "lucide-react";
 
@@ -299,11 +300,7 @@ function DeleteRoleDialog({
           </AlertDialogDescription>
         </AlertDialogHeader>
 
-        {error && (
-          <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
-            {friendlyError(error)}
-          </div>
-        )}
+        <MutationErrorSurface error={error} feature="Custom Roles" variant="inline" />
 
         <AlertDialogFooter>
           <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>

--- a/packages/web/src/app/admin/semantic/improve/page.tsx
+++ b/packages/web/src/app/admin/semantic/improve/page.tsx
@@ -560,7 +560,7 @@ export default function SemanticImprovePage() {
                   {pendingError && (
                     <ErrorBanner message={pendingError.message} />
                   )}
-                  <MutationErrorSurface error={mutationError} feature="Semantic" />
+                  <MutationErrorSurface error={mutationError} feature="Semantic Layer" />
                   {proposals.length === 0 && !pendingLoading && (
                     <div className="py-12 text-center text-xs text-muted-foreground">
                       {messages.length === 0

--- a/packages/web/src/app/admin/semantic/improve/page.tsx
+++ b/packages/web/src/app/admin/semantic/improve/page.tsx
@@ -7,8 +7,8 @@ import { getToolArgs, getToolResult } from "@/ui/lib/helpers";
 import { useAtlasConfig } from "@/ui/context";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError } from "@/ui/lib/fetch-error";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -560,9 +560,7 @@ export default function SemanticImprovePage() {
                   {pendingError && (
                     <ErrorBanner message={pendingError.message} />
                   )}
-                  {mutationError && (
-                    <ErrorBanner message={friendlyError(mutationError)} />
-                  )}
+                  <MutationErrorSurface error={mutationError} feature="Semantic" />
                   {proposals.length === 0 && !pendingLoading && (
                     <div className="py-12 text-center text-xs text-muted-foreground">
                       {messages.length === 0

--- a/packages/web/src/app/admin/semantic/improve/page.tsx
+++ b/packages/web/src/app/admin/semantic/improve/page.tsx
@@ -7,7 +7,6 @@ import { getToolArgs, getToolResult } from "@/ui/lib/helpers";
 import { useAtlasConfig } from "@/ui/context";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -557,9 +556,7 @@ export default function SemanticImprovePage() {
               </div>
               <ScrollArea className="min-h-0 flex-1 p-4">
                 <div className="space-y-3">
-                  {pendingError && (
-                    <ErrorBanner message={pendingError.message} />
-                  )}
+                  <MutationErrorSurface error={pendingError} feature="Semantic Layer" onRetry={refetchPending} />
                   <MutationErrorSurface error={mutationError} feature="Semantic Layer" />
                   {proposals.length === 0 && !pendingLoading && (
                     <div className="py-12 text-center text-xs text-muted-foreground">

--- a/packages/web/src/app/admin/semantic/page.tsx
+++ b/packages/web/src/app/admin/semantic/page.tsx
@@ -30,13 +30,14 @@ import { EmptyState } from "@/ui/components/admin/empty-state";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { LoadingState } from "@/ui/components/admin/loading-state";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import {
   SemanticFileTree,
   type SemanticSelection,
 } from "@/ui/components/admin/semantic-file-tree";
 import { type FetchError } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError, friendlyErrorOrNull } from "@/ui/lib/fetch-error";
+import { friendlyErrorOrNull } from "@/ui/lib/fetch-error";
 import { useDeployMode } from "@/ui/hooks/use-deploy-mode";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { EntityVersionHistory } from "@/ui/components/admin/entity-version-history";
@@ -855,11 +856,7 @@ export default function SemanticPage() {
               The agent will no longer be able to query this table. This action cannot be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
-          {deleteError && (
-            <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
-              {friendlyError(deleteError)}
-            </div>
-          )}
+          <MutationErrorSurface error={deleteError} feature="Semantic" variant="inline" />
           <AlertDialogFooter>
             <AlertDialogCancel disabled={deletingEntity}>Cancel</AlertDialogCancel>
             <AlertDialogAction

--- a/packages/web/src/app/admin/semantic/page.tsx
+++ b/packages/web/src/app/admin/semantic/page.tsx
@@ -856,7 +856,7 @@ export default function SemanticPage() {
               The agent will no longer be able to query this table. This action cannot be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
-          <MutationErrorSurface error={deleteError} feature="Semantic" variant="inline" />
+          <MutationErrorSurface error={deleteError} feature="Semantic Layer" variant="inline" />
           <AlertDialogFooter>
             <AlertDialogCancel disabled={deletingEntity}>Cancel</AlertDialogCancel>
             <AlertDialogAction

--- a/packages/web/src/app/admin/sessions/page.tsx
+++ b/packages/web/src/app/admin/sessions/page.tsx
@@ -11,13 +11,13 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { StatCard } from "@/ui/components/admin/stat-card";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Monitor, Search, X, Users, Activity, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError } from "@/ui/lib/fetch-error";
 import { SessionStatsSchema, SessionsListSchema } from "@/ui/lib/admin-schemas";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { bulkFailureSummary, failedIdsFrom } from "@/ui/components/admin/queue";
@@ -212,9 +212,7 @@ export default function SessionsPage() {
             </div>
 
             {bulkError && <ErrorBanner message={bulkError} />}
-            {revokeError && !bulkError && (
-              <ErrorBanner message={friendlyError(revokeError)} />
-            )}
+            {!bulkError && <MutationErrorSurface error={revokeError} feature="Sessions" />}
             <AdminContentWrapper
               loading={loading}
               error={error}


### PR DESCRIPTION
Closes #1649 (phase 2 of #1624). With the two explicit carve-outs filed as follow-ups (#1675 SCIM row-pin, #1676 billing PlanShell), this PR lands the last mechanical migrations — parent #1624 can close once those two ship.

## Summary

Routes mutation error sites across 6 core admin pages through `<MutationErrorSurface>` so `EnterpriseUpsell` (on `code === "enterprise_required"`) and `FeatureGate` (on 401/403/404/503) fire on the write path, matching the read-path routing `AdminContentWrapper` already provides.

## Migrated sites

- **`/admin/compliance`** — `actionError` banner. `FormDialog serverError` simplified to `friendlyErrorOrNull(actionError)`.
- **`/admin/prompts`** — 4 sites (collection create/delete, item add/delete), all banner variants with `clearError` onRetry.
- **`/admin/roles`** — `DeleteRoleDialog` inline error → inline variant (`feature="Custom Roles"`).
- **`/admin/semantic`** — entity delete confirmation inline error → inline variant. `detailError` `ErrorBanner` kept (pure-client-synth string, not a `FetchError`).
- **`/admin/semantic/improve`** — `mutationError` banner. `pendingError` (`useAdminFetch`) left as-is per scope — the page doesn't use `AdminContentWrapper`, so the read-path flatten is a structural gap, not a mechanical swap.
- **`/admin/sessions`** — `revokeError` banner. `bulkError` local string kept with precedence (matches sessions' existing mutually-exclusive banner pattern).

## Out of scope (filed as follow-ups)

- **#1675** — `/admin/scim` row-pin migration. `setRowError({ message: friendlyError(…) })` flattens `FetchError → string` at pin time; migrating needs a `rowError: { error: FetchError, … }` retype so the inline variant can route `enterprise_required`.
- **#1676** — `/admin/billing` `PlanShell`. `combinedError = mutationCopy || portalError` blends structured + local-state errors; precedence + the "200 but no URL" carve-out need a judgment call beyond a mechanical swap.

## Scope notes

Strictly mechanical — decision tree stays in `<MutationErrorSurface>` (phase 1, PR #1650). Per-page judgment calls: banner vs inline variant (matches what the caller was using), and `feature` string (matches the page's `AdminContentWrapper`). No new per-page tests per #1649's acceptance — `mutation-error-surface.test.tsx` covers the decision tree.

After merge, the only remaining `friendlyError(` call sites in `packages/web/src/app/admin/` are:
- `FormDialog` `serverError` props (string-accepting, already gated)
- Pure-client-synth strings (no structured `FetchError` upstream)
- The two filed carve-outs (#1675, #1676)
- `/admin/abuse/detail-panel.tsx` 404-rewrite carve-out (intentional — see inline comment)
- `/admin/plugins` throw-and-catch local synth (not a render flatten)
- `/admin/organizations/detail-sheet.tsx` + `/admin/approval/page.tsx` fetch error renders (pre-existing, outside #1649's scope — useAdminFetch errors on pages that don't use `AdminContentWrapper`)
- `/admin/platform/plugins` row-level local string synth (per-row last-wins pin)

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun run test` — all suites pass (243 api, 19 cli, 65 mcp, 78 web, 25 ee, + sandbox/chat adapters)
- [x] `bun x syncpack lint` — no issues
- [x] `bash scripts/check-template-drift.sh` — 430 files verified, no drift
- [ ] Manual spot-check: provoke a 403 `enterprise_required` on `/admin/roles` in non-EE and confirm the inline upsell renders inside the `DeleteRoleDialog` rather than a generic inline error.