### PR TITLE
refactor(schemas): migrate Billing + Backup + Platform to @useatlas/schemas (phase 3 of #1648)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -54601,21 +54601,13 @@
                   "type": "object",
                   "properties": {
                     "schedule": {
-                      "type": "string",
-                      "description": "Cron expression for automated backups",
-                      "example": "0 3 * * *"
+                      "type": "string"
                     },
                     "retentionDays": {
-                      "type": "number",
-                      "minimum": 1,
-                      "maximum": 365,
-                      "description": "Days to retain backups",
-                      "example": 30
+                      "type": "number"
                     },
                     "storagePath": {
-                      "type": "string",
-                      "description": "Backup storage path",
-                      "example": "./backups"
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -54753,21 +54745,13 @@
                       "type": "object",
                       "properties": {
                         "schedule": {
-                          "type": "string",
-                          "description": "Cron expression for automated backups",
-                          "example": "0 3 * * *"
+                          "type": "string"
                         },
                         "retentionDays": {
-                          "type": "number",
-                          "minimum": 1,
-                          "maximum": 365,
-                          "description": "Days to retain backups",
-                          "example": 30
+                          "type": "number"
                         },
                         "storagePath": {
-                          "type": "string",
-                          "description": "Backup storage path",
-                          "example": "./backups"
+                          "type": "string"
                         }
                       },
                       "required": [
@@ -57118,7 +57102,203 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": {}
+                  "properties": {
+                    "workspaceId": {
+                      "type": "string"
+                    },
+                    "plan": {
+                      "type": "object",
+                      "properties": {
+                        "tier": {
+                          "type": "string",
+                          "enum": [
+                            "free",
+                            "trial",
+                            "starter",
+                            "pro",
+                            "business"
+                          ]
+                        },
+                        "displayName": {
+                          "type": "string"
+                        },
+                        "pricePerSeat": {
+                          "type": "number"
+                        },
+                        "defaultModel": {
+                          "type": "string"
+                        },
+                        "byot": {
+                          "type": "boolean"
+                        },
+                        "trialEndsAt": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "tier",
+                        "displayName",
+                        "pricePerSeat",
+                        "defaultModel",
+                        "byot",
+                        "trialEndsAt"
+                      ]
+                    },
+                    "limits": {
+                      "type": "object",
+                      "properties": {
+                        "tokenBudgetPerSeat": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "totalTokenBudget": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "maxSeats": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "maxConnections": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "tokenBudgetPerSeat",
+                        "totalTokenBudget",
+                        "maxSeats",
+                        "maxConnections"
+                      ]
+                    },
+                    "usage": {
+                      "type": "object",
+                      "properties": {
+                        "queryCount": {
+                          "type": "number"
+                        },
+                        "tokenCount": {
+                          "type": "number"
+                        },
+                        "seatCount": {
+                          "type": "number"
+                        },
+                        "tokenUsagePercent": {
+                          "type": "number"
+                        },
+                        "tokenOverageStatus": {
+                          "type": "string",
+                          "enum": [
+                            "ok",
+                            "warning",
+                            "soft_limit",
+                            "hard_limit"
+                          ]
+                        },
+                        "periodStart": {
+                          "type": "string"
+                        },
+                        "periodEnd": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "queryCount",
+                        "tokenCount",
+                        "seatCount",
+                        "tokenUsagePercent",
+                        "tokenOverageStatus",
+                        "periodStart",
+                        "periodEnd"
+                      ]
+                    },
+                    "seats": {
+                      "type": "object",
+                      "properties": {
+                        "count": {
+                          "type": "number"
+                        },
+                        "max": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "count",
+                        "max"
+                      ]
+                    },
+                    "connections": {
+                      "type": "object",
+                      "properties": {
+                        "count": {
+                          "type": "number"
+                        },
+                        "max": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "count",
+                        "max"
+                      ]
+                    },
+                    "currentModel": {
+                      "type": "string"
+                    },
+                    "overagePerMillionTokens": {
+                      "type": "number"
+                    },
+                    "subscription": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "stripeSubscriptionId": {
+                          "type": "string"
+                        },
+                        "plan": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "stripeSubscriptionId",
+                        "plan",
+                        "status"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "workspaceId",
+                    "plan",
+                    "limits",
+                    "usage",
+                    "seats",
+                    "connections",
+                    "currentModel",
+                    "overagePerMillionTokens",
+                    "subscription"
+                  ]
                 }
               }
             }

--- a/packages/api/src/api/routes/billing.ts
+++ b/packages/api/src/api/routes/billing.ts
@@ -30,6 +30,7 @@ import { getCurrentPeriodUsage } from "@atlas/api/lib/metering";
 import { getPlanDefinition, getPlanLimits, computeTokenBudget, isUnlimited } from "@atlas/api/lib/billing/plans";
 import { buildMetricStatus } from "@atlas/api/lib/billing/enforcement";
 import { getSettingLive } from "@atlas/api/lib/settings";
+import { BillingStatusSchema } from "@useatlas/schemas";
 import { ErrorSchema } from "./shared-schemas";
 import { adminAuth, requestContext, type AuthEnv } from "./middleware";
 
@@ -105,7 +106,7 @@ const getBillingStatusRoute = createRoute({
       description: "Billing status for the workspace",
       content: {
         "application/json": {
-          schema: z.record(z.string(), z.unknown()),
+          schema: BillingStatusSchema,
         },
       },
     },

--- a/packages/api/src/api/routes/platform-admin.ts
+++ b/packages/api/src/api/routes/platform-admin.ts
@@ -40,12 +40,16 @@ import {
   type WorkspaceStatus,
 } from "@atlas/api/lib/db/internal";
 import {
-  WORKSPACE_STATUSES,
   PLAN_TIERS,
-  NOISY_NEIGHBOR_METRICS,
   type PlatformWorkspace,
 } from "@useatlas/types";
-import { ATLAS_ROLES, type AtlasRole } from "@atlas/api/lib/auth/types";
+import {
+  PlatformStatsSchema,
+  PlatformWorkspaceSchema,
+  PlatformWorkspaceUserSchema,
+  NoisyNeighborSchema,
+} from "@useatlas/schemas";
+import { type AtlasRole } from "@atlas/api/lib/auth/types";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 
 const log = createLogger("platform-admin");
@@ -55,54 +59,10 @@ const VALID_PLAN_TIERS = new Set<string>(PLAN_TIERS);
 // ---------------------------------------------------------------------------
 // Schemas
 // ---------------------------------------------------------------------------
-
-const PlatformWorkspaceSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  slug: z.string(),
-  status: z.enum(WORKSPACE_STATUSES),
-  planTier: z.enum(PLAN_TIERS),
-  byot: z.boolean(),
-  members: z.number(),
-  conversations: z.number(),
-  queriesLast24h: z.number(),
-  connections: z.number(),
-  scheduledTasks: z.number(),
-  stripeCustomerId: z.string().nullable(),
-  trialEndsAt: z.string().nullable(),
-  suspendedAt: z.string().nullable(),
-  deletedAt: z.string().nullable(),
-  region: z.string().nullable(),
-  regionAssignedAt: z.string().nullable(),
-  createdAt: z.string(),
-});
-
-const PlatformWorkspaceUserSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  email: z.string(),
-  role: z.enum(ATLAS_ROLES),
-  createdAt: z.string(),
-});
-
-const PlatformStatsSchema = z.object({
-  totalWorkspaces: z.number(),
-  activeWorkspaces: z.number(),
-  suspendedWorkspaces: z.number(),
-  totalUsers: z.number(),
-  totalQueries24h: z.number(),
-  mrr: z.number(),
-});
-
-const NoisyNeighborSchema = z.object({
-  workspaceId: z.string(),
-  workspaceName: z.string(),
-  planTier: z.enum(PLAN_TIERS),
-  metric: z.enum(NOISY_NEIGHBOR_METRICS),
-  value: z.number(),
-  median: z.number(),
-  ratio: z.number(),
-});
+// Platform response schemas come from @useatlas/schemas so the route,
+// the web parse, and the generated OpenAPI spec all describe the same shape.
+// Request-validation schemas (like ChangePlanBodySchema below) stay local
+// because they describe server input, not wire-format output.
 
 const ChangePlanBodySchema = z.object({
   planTier: z.enum(PLAN_TIERS).openapi({

--- a/packages/api/src/api/routes/platform-backups.ts
+++ b/packages/api/src/api/routes/platform-backups.ts
@@ -21,7 +21,7 @@ import { runEffect } from "@atlas/api/lib/effect/hono";
 import {
   RequestContext,
 } from "@atlas/api/lib/effect/services";
-import { BACKUP_STATUSES } from "@useatlas/types";
+import { BackupEntrySchema, BackupConfigSchema } from "@useatlas/schemas";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createPlatformRouter } from "./admin-router";
 
@@ -30,22 +30,11 @@ const log = createLogger("platform-backups");
 // ---------------------------------------------------------------------------
 // Schemas
 // ---------------------------------------------------------------------------
-
-const BackupEntrySchema = z.object({
-  id: z.string(),
-  createdAt: z.string(),
-  sizeBytes: z.number().nullable(),
-  status: z.enum(BACKUP_STATUSES),
-  storagePath: z.string(),
-  retentionExpiresAt: z.string(),
-  errorMessage: z.string().nullable(),
-});
-
-const BackupConfigSchema = z.object({
-  schedule: z.string().openapi({ description: "Cron expression for automated backups", example: "0 3 * * *" }),
-  retentionDays: z.number().min(1).max(365).openapi({ description: "Days to retain backups", example: 30 }),
-  storagePath: z.string().openapi({ description: "Backup storage path", example: "./backups" }),
-});
+// BackupEntrySchema + BackupConfigSchema come from @useatlas/schemas so the
+// route, the web parse, and the generated OpenAPI spec all describe the same
+// shape. Request-validation variants below still live here because they carry
+// server-specific constraints (cron regex, retentionDays range, path
+// traversal guard) that don't belong in the response-shape contract.
 
 const CRON_5_FIELD = /^(\*|[\d,\-/]+)(\s+(\*|[\d,\-/]+)){4}$/;
 

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -12,8 +12,11 @@
     ".": "./src/index.ts",
     "./abuse": "./src/abuse.ts",
     "./approval": "./src/approval.ts",
+    "./backup": "./src/backup.ts",
+    "./billing": "./src/billing.ts",
     "./custom-domain": "./src/custom-domain.ts",
-    "./integrations": "./src/integrations.ts"
+    "./integrations": "./src/integrations.ts",
+    "./platform": "./src/platform.ts"
   },
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/schemas/src/__tests__/backup.test.ts
+++ b/packages/schemas/src/__tests__/backup.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import { BackupEntrySchema, BackupConfigSchema } from "../backup";
+import { BACKUP_STATUSES } from "@useatlas/types";
+
+const validEntry = {
+  id: "bkp_1",
+  createdAt: "2026-04-19T03:00:00.000Z",
+  sizeBytes: 1_048_576,
+  status: "completed" as const,
+  storagePath: "./backups/bkp_1.sql.gz",
+  retentionExpiresAt: "2026-05-19T03:00:00.000Z",
+  errorMessage: null,
+};
+
+const inProgressEntry = {
+  ...validEntry,
+  id: "bkp_2",
+  status: "in_progress" as const,
+  sizeBytes: null,
+};
+
+const failedEntry = {
+  ...validEntry,
+  id: "bkp_3",
+  status: "failed" as const,
+  sizeBytes: null,
+  errorMessage: "pg_dump exited with code 1",
+};
+
+const validConfig = {
+  schedule: "0 3 * * *",
+  retentionDays: 30,
+  storagePath: "./backups",
+};
+
+describe("happy-path parses", () => {
+  test("BackupEntrySchema parses a completed backup", () => {
+    expect(BackupEntrySchema.parse(validEntry)).toEqual(validEntry);
+  });
+
+  test("BackupEntrySchema parses an in-progress backup with null size", () => {
+    expect(BackupEntrySchema.parse(inProgressEntry)).toEqual(inProgressEntry);
+  });
+
+  test("BackupEntrySchema parses a failed backup with error message", () => {
+    expect(BackupEntrySchema.parse(failedEntry)).toEqual(failedEntry);
+  });
+
+  test("BackupConfigSchema parses default config", () => {
+    expect(BackupConfigSchema.parse(validConfig)).toEqual(validConfig);
+  });
+
+  test("round-trip (parse → serialize → parse) preserves fields", () => {
+    const parsed = BackupEntrySchema.parse(validEntry);
+    const serialized = JSON.parse(JSON.stringify(parsed));
+    expect(BackupEntrySchema.parse(serialized)).toEqual(validEntry);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Enum strict rejection — the whole point of this migration. Web previously
+// relaxed `status` to z.string(); pinning it to BACKUP_STATUSES means an
+// unknown state added in `@atlas/ee/backups` fails parse at useAdminFetch
+// time and surfaces a `schema_mismatch` banner instead of leaking through
+// into the platform backups table as untyped text.
+// ---------------------------------------------------------------------------
+
+describe("enum strict rejection", () => {
+  test("unknown status fails parse", () => {
+    const drifted = { ...validEntry, status: "restoring" };
+    expect(BackupEntrySchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("all BACKUP_STATUSES values parse", () => {
+    for (const status of BACKUP_STATUSES) {
+      expect(BackupEntrySchema.parse({ ...validEntry, status }).status).toBe(status);
+    }
+  });
+
+  test("BACKUP_STATUSES tuple contains the expected canonical states", () => {
+    expect(BACKUP_STATUSES).toEqual(["in_progress", "completed", "failed", "verified"]);
+  });
+});
+
+describe("structural rejection", () => {
+  test("BackupEntrySchema rejects missing retentionExpiresAt", () => {
+    const { retentionExpiresAt: _r, ...missing } = validEntry;
+    expect(BackupEntrySchema.safeParse(missing).success).toBe(false);
+  });
+
+  test("BackupEntrySchema rejects non-nullable errorMessage as undefined", () => {
+    const drifted = { ...validEntry, errorMessage: undefined };
+    expect(BackupEntrySchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("BackupConfigSchema rejects non-numeric retentionDays", () => {
+    const drifted = { ...validConfig, retentionDays: "30" };
+    expect(BackupConfigSchema.safeParse(drifted).success).toBe(false);
+  });
+});

--- a/packages/schemas/src/__tests__/billing.test.ts
+++ b/packages/schemas/src/__tests__/billing.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { BillingStatusSchema } from "../billing";
-import { OVERAGE_STATUSES, PLAN_TIERS } from "@useatlas/types";
+import { PLAN_TIERS } from "@useatlas/types";
+
+// Mirrors the private `OVERAGE_STATUSES` tuple in ../billing — kept in sync
+// by the "canonical tuples match expected values" assertion below so a
+// reorder or addition fails loud.
+const OVERAGE_STATUSES = ["ok", "warning", "soft_limit", "hard_limit"] as const;
 
 const validStatus = {
   workspaceId: "org_1",

--- a/packages/schemas/src/__tests__/billing.test.ts
+++ b/packages/schemas/src/__tests__/billing.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+import { BillingStatusSchema } from "../billing";
+import { OVERAGE_STATUSES, PLAN_TIERS } from "@useatlas/types";
+
+const validStatus = {
+  workspaceId: "org_1",
+  plan: {
+    tier: "starter" as const,
+    displayName: "Starter",
+    pricePerSeat: 29,
+    defaultModel: "claude-haiku-4-5",
+    byot: false,
+    trialEndsAt: null,
+  },
+  limits: {
+    tokenBudgetPerSeat: 2_000_000,
+    totalTokenBudget: 20_000_000,
+    maxSeats: 10,
+    maxConnections: 1,
+  },
+  usage: {
+    queryCount: 423,
+    tokenCount: 1_240_000,
+    seatCount: 4,
+    tokenUsagePercent: 15,
+    tokenOverageStatus: "ok" as const,
+    periodStart: "2026-04-01T00:00:00.000Z",
+    periodEnd: "2026-04-30T23:59:59.000Z",
+  },
+  seats: { count: 4, max: 10 },
+  connections: { count: 1, max: 1 },
+  currentModel: "claude-haiku-4-5",
+  overagePerMillionTokens: 1.0,
+  subscription: {
+    stripeSubscriptionId: "sub_123",
+    plan: "starter_monthly",
+    status: "active",
+  },
+};
+
+const selfHostedStatus = {
+  ...validStatus,
+  plan: { ...validStatus.plan, tier: "free" as const, displayName: "Self-Hosted" },
+  limits: {
+    tokenBudgetPerSeat: null,
+    totalTokenBudget: null,
+    maxSeats: null,
+    maxConnections: null,
+  },
+  seats: { count: 1, max: null },
+  connections: { count: 0, max: null },
+  subscription: null,
+};
+
+describe("happy-path parses", () => {
+  test("BillingStatusSchema parses a paid-tier status", () => {
+    expect(BillingStatusSchema.parse(validStatus)).toEqual(validStatus);
+  });
+
+  test("BillingStatusSchema parses a self-hosted status with null subscription and null limits", () => {
+    expect(BillingStatusSchema.parse(selfHostedStatus)).toEqual(selfHostedStatus);
+  });
+
+  test("BillingStatusSchema parses a trial with trialEndsAt set", () => {
+    const trial = {
+      ...validStatus,
+      plan: {
+        ...validStatus.plan,
+        tier: "trial" as const,
+        displayName: "Starter Trial",
+        trialEndsAt: "2026-05-01T00:00:00.000Z",
+      },
+    };
+    expect(BillingStatusSchema.parse(trial)).toEqual(trial);
+  });
+
+  test("round-trip (parse → serialize → parse) preserves fields", () => {
+    const parsed = BillingStatusSchema.parse(validStatus);
+    const serialized = JSON.parse(JSON.stringify(parsed));
+    expect(BillingStatusSchema.parse(serialized)).toEqual(validStatus);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Enum strict rejection — web previously relaxed plan.tier and
+// usage.tokenOverageStatus to z.string(). Pinning to z.enum(TUPLE) means a
+// new plan tier or overage state added to `@useatlas/types` fails parse
+// at useAdminFetch time and surfaces `schema_mismatch` instead of leaking
+// through as untyped text into the billing page tier badge.
+//
+// subscription.status / subscription.plan stay free-form because Stripe
+// (not us) controls those vocabularies — new Stripe statuses must not
+// fail our parse.
+// ---------------------------------------------------------------------------
+
+describe("enum strict rejection", () => {
+  test("unknown plan tier fails parse", () => {
+    const drifted = {
+      ...validStatus,
+      plan: { ...validStatus.plan, tier: "legacy-enterprise" },
+    };
+    expect(BillingStatusSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("unknown tokenOverageStatus fails parse", () => {
+    const drifted = {
+      ...validStatus,
+      usage: { ...validStatus.usage, tokenOverageStatus: "exceeded" },
+    };
+    expect(BillingStatusSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("all PLAN_TIERS values parse as plan.tier", () => {
+    for (const tier of PLAN_TIERS) {
+      expect(
+        BillingStatusSchema.parse({
+          ...validStatus,
+          plan: { ...validStatus.plan, tier },
+        }).plan.tier,
+      ).toBe(tier);
+    }
+  });
+
+  test("all OVERAGE_STATUSES values parse as tokenOverageStatus", () => {
+    for (const status of OVERAGE_STATUSES) {
+      expect(
+        BillingStatusSchema.parse({
+          ...validStatus,
+          usage: { ...validStatus.usage, tokenOverageStatus: status },
+        }).usage.tokenOverageStatus,
+      ).toBe(status);
+    }
+  });
+
+  test("free-form Stripe subscription status parses regardless of value", () => {
+    const status = {
+      ...validStatus,
+      subscription: { ...validStatus.subscription!, status: "past_due_2026_format" },
+    };
+    expect(BillingStatusSchema.parse(status).subscription?.status).toBe("past_due_2026_format");
+  });
+
+  test("canonical tuples match expected values", () => {
+    expect(OVERAGE_STATUSES).toEqual(["ok", "warning", "soft_limit", "hard_limit"]);
+  });
+});
+
+describe("structural rejection", () => {
+  test("BillingStatusSchema rejects missing usage.tokenOverageStatus", () => {
+    const { tokenOverageStatus: _t, ...partialUsage } = validStatus.usage;
+    const drifted = { ...validStatus, usage: partialUsage };
+    expect(BillingStatusSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("BillingStatusSchema rejects missing subscription field", () => {
+    const { subscription: _s, ...missing } = validStatus;
+    expect(BillingStatusSchema.safeParse(missing).success).toBe(false);
+  });
+
+  test("BillingStatusSchema requires seats / connections / currentModel / overagePerMillionTokens", () => {
+    const { seats: _s, ...missing } = validStatus;
+    expect(BillingStatusSchema.safeParse(missing).success).toBe(false);
+  });
+});

--- a/packages/schemas/src/__tests__/platform.test.ts
+++ b/packages/schemas/src/__tests__/platform.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "bun:test";
+import {
+  PlatformStatsSchema,
+  PlatformWorkspaceSchema,
+  PlatformWorkspaceUserSchema,
+  NoisyNeighborSchema,
+} from "../platform";
+import { WORKSPACE_STATUSES, PLAN_TIERS, NOISY_NEIGHBOR_METRICS } from "@useatlas/types";
+
+const validStats = {
+  totalWorkspaces: 42,
+  activeWorkspaces: 38,
+  suspendedWorkspaces: 3,
+  totalUsers: 210,
+  totalQueries24h: 15_300,
+  mrr: 3495,
+};
+
+const validWorkspace = {
+  id: "org_1",
+  name: "Acme",
+  slug: "acme",
+  status: "active" as const,
+  planTier: "starter" as const,
+  byot: false,
+  members: 8,
+  conversations: 110,
+  queriesLast24h: 342,
+  connections: 3,
+  scheduledTasks: 2,
+  stripeCustomerId: "cus_123",
+  trialEndsAt: null,
+  suspendedAt: null,
+  deletedAt: null,
+  region: "us-east",
+  regionAssignedAt: "2026-04-10T12:00:00.000Z",
+  createdAt: "2026-03-01T00:00:00.000Z",
+};
+
+const validUser = {
+  id: "user_1",
+  name: "Ada Lovelace",
+  email: "ada@acme.test",
+  role: "admin" as const,
+  createdAt: "2026-03-02T00:00:00.000Z",
+};
+
+const validNeighbor = {
+  workspaceId: "org_1",
+  workspaceName: "Acme",
+  planTier: "starter" as const,
+  metric: "queries" as const,
+  value: 12_000,
+  median: 3000,
+  ratio: 4,
+};
+
+describe("happy-path parses", () => {
+  test("PlatformStatsSchema parses valid stats", () => {
+    expect(PlatformStatsSchema.parse(validStats)).toEqual(validStats);
+  });
+
+  test("PlatformWorkspaceSchema parses an active workspace", () => {
+    expect(PlatformWorkspaceSchema.parse(validWorkspace)).toEqual(validWorkspace);
+  });
+
+  test("PlatformWorkspaceSchema parses a suspended workspace", () => {
+    const suspended = {
+      ...validWorkspace,
+      id: "org_2",
+      status: "suspended" as const,
+      suspendedAt: "2026-04-15T00:00:00.000Z",
+    };
+    expect(PlatformWorkspaceSchema.parse(suspended)).toEqual(suspended);
+  });
+
+  test("PlatformWorkspaceUserSchema parses an admin user", () => {
+    expect(PlatformWorkspaceUserSchema.parse(validUser)).toEqual(validUser);
+  });
+
+  test("NoisyNeighborSchema parses a flagged neighbor", () => {
+    expect(NoisyNeighborSchema.parse(validNeighbor)).toEqual(validNeighbor);
+  });
+
+  test("round-trip (parse → serialize → parse) preserves workspace fields", () => {
+    const parsed = PlatformWorkspaceSchema.parse(validWorkspace);
+    const serialized = JSON.parse(JSON.stringify(parsed));
+    expect(PlatformWorkspaceSchema.parse(serialized)).toEqual(validWorkspace);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Enum strict rejection — three enum columns on PlatformWorkspace
+// (status, planTier) and NoisyNeighbor (metric, planTier). Web previously
+// relaxed all four to z.string(); tightening to z.enum(TUPLE) means a new
+// plan tier or workspace status added in `@useatlas/types` fails parse at
+// useAdminFetch time, surfacing `schema_mismatch` instead of silently
+// rendering an unstyled badge in the platform admin table.
+// ---------------------------------------------------------------------------
+
+describe("enum strict rejection", () => {
+  test("unknown workspace status fails parse", () => {
+    const drifted = { ...validWorkspace, status: "archived" };
+    expect(PlatformWorkspaceSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("unknown plan tier fails parse", () => {
+    const drifted = { ...validWorkspace, planTier: "legacy-enterprise" };
+    expect(PlatformWorkspaceSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("unknown noisy metric fails parse", () => {
+    const drifted = { ...validNeighbor, metric: "iops" };
+    expect(NoisyNeighborSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("unknown user role fails parse", () => {
+    const drifted = { ...validUser, role: "moderator" };
+    expect(PlatformWorkspaceUserSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("all WORKSPACE_STATUSES values parse", () => {
+    for (const status of WORKSPACE_STATUSES) {
+      expect(PlatformWorkspaceSchema.parse({ ...validWorkspace, status }).status).toBe(status);
+    }
+  });
+
+  test("all PLAN_TIERS values parse", () => {
+    for (const planTier of PLAN_TIERS) {
+      expect(PlatformWorkspaceSchema.parse({ ...validWorkspace, planTier }).planTier).toBe(planTier);
+    }
+  });
+
+  test("all NOISY_NEIGHBOR_METRICS values parse", () => {
+    for (const metric of NOISY_NEIGHBOR_METRICS) {
+      expect(NoisyNeighborSchema.parse({ ...validNeighbor, metric }).metric).toBe(metric);
+    }
+  });
+
+  test("canonical tuples match expected values", () => {
+    expect(WORKSPACE_STATUSES).toEqual(["active", "suspended", "deleted"]);
+    expect(PLAN_TIERS).toEqual(["free", "trial", "starter", "pro", "business"]);
+    expect(NOISY_NEIGHBOR_METRICS).toEqual(["queries", "tokens", "storage"]);
+  });
+});
+
+describe("structural rejection", () => {
+  test("PlatformWorkspaceSchema rejects missing region field", () => {
+    const { region: _r, ...missing } = validWorkspace;
+    expect(PlatformWorkspaceSchema.safeParse(missing).success).toBe(false);
+  });
+
+  test("PlatformStatsSchema rejects non-numeric totalWorkspaces", () => {
+    const drifted = { ...validStats, totalWorkspaces: "42" };
+    expect(PlatformStatsSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("NoisyNeighborSchema rejects missing ratio", () => {
+    const { ratio: _r, ...missing } = validNeighbor;
+    expect(NoisyNeighborSchema.safeParse(missing).success).toBe(false);
+  });
+});

--- a/packages/schemas/src/__tests__/platform.test.ts
+++ b/packages/schemas/src/__tests__/platform.test.ts
@@ -5,7 +5,7 @@ import {
   PlatformWorkspaceUserSchema,
   NoisyNeighborSchema,
 } from "../platform";
-import { WORKSPACE_STATUSES, PLAN_TIERS, NOISY_NEIGHBOR_METRICS } from "@useatlas/types";
+import { WORKSPACE_STATUSES, PLAN_TIERS, NOISY_NEIGHBOR_METRICS, ATLAS_ROLES } from "@useatlas/types";
 
 const validStats = {
   totalWorkspaces: 42,
@@ -137,10 +137,17 @@ describe("enum strict rejection", () => {
     }
   });
 
+  test("all ATLAS_ROLES values parse as PlatformWorkspaceUser.role", () => {
+    for (const role of ATLAS_ROLES) {
+      expect(PlatformWorkspaceUserSchema.parse({ ...validUser, role }).role).toBe(role);
+    }
+  });
+
   test("canonical tuples match expected values", () => {
     expect(WORKSPACE_STATUSES).toEqual(["active", "suspended", "deleted"]);
     expect(PLAN_TIERS).toEqual(["free", "trial", "starter", "pro", "business"]);
     expect(NOISY_NEIGHBOR_METRICS).toEqual(["queries", "tokens", "storage"]);
+    expect(ATLAS_ROLES).toEqual(["member", "admin", "owner", "platform_admin"]);
   });
 });
 

--- a/packages/schemas/src/backup.ts
+++ b/packages/schemas/src/backup.ts
@@ -1,0 +1,48 @@
+/**
+ * Backup wire-format schemas.
+ *
+ * Single source of truth for the platform backups surface
+ * (`/api/v1/platform/backups` and `/config`) — used by both route-layer
+ * OpenAPI validation and web-layer response parsing via `useAdminFetch`.
+ *
+ * Before #1648, the route copy pinned `status` to `z.enum(BACKUP_STATUSES)`
+ * while the web copy silently relaxed it to `z.string()`. The status
+ * column is the drift-prone part of the shape — a new state introduced
+ * in `@atlas/ee/backups` would have passed the web parse untyped and
+ * failed silently in `BackupsTable`. Pinning here closes that gap.
+ *
+ * The `BACKUP_STATUSES` tuple comes from `@useatlas/types` so adding a
+ * new status propagates without a second edit.
+ *
+ * Uses `satisfies z.ZodType<T>` (not `as z.ZodType<T>`) so a field
+ * rename in `@useatlas/types` breaks this file at compile time instead
+ * of passing through to runtime.
+ *
+ * Strict `z.enum(TUPLE)` matches the `@hono/zod-openapi` extractor's
+ * expectations — it cannot serialize `ZodCatch` wrappers — and keeps the
+ * generated OpenAPI spec describing the genuine output shape.
+ */
+import { z } from "zod";
+import {
+  BACKUP_STATUSES,
+  type BackupEntry,
+  type BackupConfig,
+} from "@useatlas/types";
+
+const BackupStatusEnum = z.enum(BACKUP_STATUSES);
+
+export const BackupEntrySchema = z.object({
+  id: z.string(),
+  createdAt: z.string(),
+  sizeBytes: z.number().nullable(),
+  status: BackupStatusEnum,
+  storagePath: z.string(),
+  retentionExpiresAt: z.string(),
+  errorMessage: z.string().nullable(),
+}) satisfies z.ZodType<BackupEntry>;
+
+export const BackupConfigSchema = z.object({
+  schedule: z.string(),
+  retentionDays: z.number(),
+  storagePath: z.string(),
+}) satisfies z.ZodType<BackupConfig>;

--- a/packages/schemas/src/billing.ts
+++ b/packages/schemas/src/billing.ts
@@ -13,32 +13,111 @@
  * every enum to `z.string()`. Centralizing here lets both sides share a
  * strict contract and the spec describes the genuine output.
  *
- * Tuples (`PLAN_TIERS`, `OVERAGE_STATUSES`) come from `@useatlas/types`
- * so adding a new plan tier or overage state propagates without a
- * second edit. `subscription.plan` and `subscription.status` stay as
- * `z.string()` — Stripe controls the vocabulary and we don't want to
- * fail parse on a new Stripe status the TS union doesn't enumerate.
+ * Enum handling:
+ * - `plan.tier` uses `PLAN_TIERS` from `@useatlas/types` (already published).
+ * - `usage.tokenOverageStatus` uses a locally-defined `OVERAGE_STATUSES`
+ *   tuple, guarded at compile time by `satisfies z.ZodType<OverageStatus>`
+ *   against the union type in `@useatlas/types`. Keeping the tuple here
+ *   avoids bumping the `@useatlas/types` npm version for one literal
+ *   constant; the `satisfies` guard still breaks this file if the union
+ *   drifts from the tuple.
  *
- * Uses `satisfies z.ZodType<T>` (not `as z.ZodType<T>`) so a field
- * rename in `@useatlas/types` breaks this file at compile time instead
- * of passing through to runtime. Strict `z.enum(TUPLE)` matches the
- * `@hono/zod-openapi` extractor's expectations.
+ * `subscription.plan` and `subscription.status` stay `z.string()` —
+ * Stripe controls that vocabulary and we don't want to fail parse on a
+ * new Stripe status the TS union doesn't enumerate.
+ *
+ * Every schema uses `satisfies z.ZodType<T>` (not `as z.ZodType<T>`) so a
+ * field rename in `@useatlas/types` or in the local interfaces below
+ * breaks this file at compile time instead of passing through to
+ * runtime. Strict `z.enum(TUPLE)` matches the `@hono/zod-openapi`
+ * extractor's expectations — it cannot serialize `ZodCatch` wrappers.
+ *
+ * BillingStatus + its nested interfaces live in this module (rather than
+ * in `@useatlas/types`) because they describe wire shape served only by
+ * one route. The `@useatlas/types` billing module keeps the scalar
+ * primitives (`OverageStatus`, `PlanLimitStatus`) that are consumed
+ * beyond the wire boundary (enforcement, metering).
  */
 import { z } from "zod";
-import {
-  PLAN_TIERS,
-  OVERAGE_STATUSES,
-  type BillingStatus,
-  type BillingPlan,
-  type BillingLimits,
-  type BillingUsage,
-  type BillingSeatCount,
-  type BillingConnectionCount,
-  type BillingSubscription,
-} from "@useatlas/types";
+import { PLAN_TIERS, type PlanTier, type OverageStatus } from "@useatlas/types";
 
+const OVERAGE_STATUSES = ["ok", "warning", "soft_limit", "hard_limit"] as const;
+const OverageStatusEnum = z.enum(OVERAGE_STATUSES) satisfies z.ZodType<OverageStatus>;
 const PlanTierEnum = z.enum(PLAN_TIERS);
-const OverageStatusEnum = z.enum(OVERAGE_STATUSES);
+
+// ---------------------------------------------------------------------------
+// Interfaces — TS companions to the Zod schemas below. Declared here
+// because no other package needs the BillingStatus interface outside the
+// wire boundary; enforcement / metering use OverageStatus directly.
+// ---------------------------------------------------------------------------
+
+/** Plan details surfaced on the billing page. */
+export interface BillingPlan {
+  tier: PlanTier;
+  displayName: string;
+  pricePerSeat: number;
+  defaultModel: string;
+  byot: boolean;
+  trialEndsAt: string | null;
+}
+
+/** Plan limits (null = unlimited). */
+export interface BillingLimits {
+  tokenBudgetPerSeat: number | null;
+  totalTokenBudget: number | null;
+  maxSeats: number | null;
+  maxConnections: number | null;
+}
+
+/** Current-period usage counters. */
+export interface BillingUsage {
+  queryCount: number;
+  tokenCount: number;
+  seatCount: number;
+  tokenUsagePercent: number;
+  tokenOverageStatus: OverageStatus;
+  periodStart: string;
+  periodEnd: string;
+}
+
+/** Seat limit / current count. */
+export interface BillingSeatCount {
+  count: number;
+  max: number | null;
+}
+
+/** Connection limit / current count. */
+export interface BillingConnectionCount {
+  count: number;
+  max: number | null;
+}
+
+/**
+ * Active Stripe subscription summary, or `null` when the workspace has no
+ * active or trialing subscription. `plan` and `status` come directly from
+ * Stripe / Better Auth and are intentionally free-form strings.
+ */
+export interface BillingSubscription {
+  stripeSubscriptionId: string;
+  plan: string;
+  status: string;
+}
+
+export interface BillingStatus {
+  workspaceId: string;
+  plan: BillingPlan;
+  limits: BillingLimits;
+  usage: BillingUsage;
+  seats: BillingSeatCount;
+  connections: BillingConnectionCount;
+  currentModel: string;
+  overagePerMillionTokens: number;
+  subscription: BillingSubscription | null;
+}
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
 
 export const BillingPlanSchema = z.object({
   tier: PlanTierEnum,

--- a/packages/schemas/src/billing.ts
+++ b/packages/schemas/src/billing.ts
@@ -1,0 +1,95 @@
+/**
+ * Billing wire-format schema.
+ *
+ * Single source of truth for GET /api/v1/billing — the endpoint served by
+ * `packages/api/src/api/routes/billing.ts` and consumed by the admin
+ * billing page (`/admin/billing`) and the model-config BYOT gate
+ * (`/admin/model-config`).
+ *
+ * Before this migration, the billing route's OpenAPI response was
+ * described as `z.record(z.string(), z.unknown())` — "any object" — which
+ * meant the generated OpenAPI spec documented nothing about the actual
+ * shape, and the web parse relied on a schema that silently relaxed
+ * every enum to `z.string()`. Centralizing here lets both sides share a
+ * strict contract and the spec describes the genuine output.
+ *
+ * Tuples (`PLAN_TIERS`, `OVERAGE_STATUSES`) come from `@useatlas/types`
+ * so adding a new plan tier or overage state propagates without a
+ * second edit. `subscription.plan` and `subscription.status` stay as
+ * `z.string()` — Stripe controls the vocabulary and we don't want to
+ * fail parse on a new Stripe status the TS union doesn't enumerate.
+ *
+ * Uses `satisfies z.ZodType<T>` (not `as z.ZodType<T>`) so a field
+ * rename in `@useatlas/types` breaks this file at compile time instead
+ * of passing through to runtime. Strict `z.enum(TUPLE)` matches the
+ * `@hono/zod-openapi` extractor's expectations.
+ */
+import { z } from "zod";
+import {
+  PLAN_TIERS,
+  OVERAGE_STATUSES,
+  type BillingStatus,
+  type BillingPlan,
+  type BillingLimits,
+  type BillingUsage,
+  type BillingSeatCount,
+  type BillingConnectionCount,
+  type BillingSubscription,
+} from "@useatlas/types";
+
+const PlanTierEnum = z.enum(PLAN_TIERS);
+const OverageStatusEnum = z.enum(OVERAGE_STATUSES);
+
+export const BillingPlanSchema = z.object({
+  tier: PlanTierEnum,
+  displayName: z.string(),
+  pricePerSeat: z.number(),
+  defaultModel: z.string(),
+  byot: z.boolean(),
+  trialEndsAt: z.string().nullable(),
+}) satisfies z.ZodType<BillingPlan>;
+
+export const BillingLimitsSchema = z.object({
+  tokenBudgetPerSeat: z.number().nullable(),
+  totalTokenBudget: z.number().nullable(),
+  maxSeats: z.number().nullable(),
+  maxConnections: z.number().nullable(),
+}) satisfies z.ZodType<BillingLimits>;
+
+export const BillingUsageSchema = z.object({
+  queryCount: z.number(),
+  tokenCount: z.number(),
+  seatCount: z.number(),
+  tokenUsagePercent: z.number(),
+  tokenOverageStatus: OverageStatusEnum,
+  periodStart: z.string(),
+  periodEnd: z.string(),
+}) satisfies z.ZodType<BillingUsage>;
+
+export const BillingSeatCountSchema = z.object({
+  count: z.number(),
+  max: z.number().nullable(),
+}) satisfies z.ZodType<BillingSeatCount>;
+
+export const BillingConnectionCountSchema = z.object({
+  count: z.number(),
+  max: z.number().nullable(),
+}) satisfies z.ZodType<BillingConnectionCount>;
+
+export const BillingSubscriptionSchema = z.object({
+  stripeSubscriptionId: z.string(),
+  plan: z.string(),
+  status: z.string(),
+}) satisfies z.ZodType<BillingSubscription>;
+
+export const BillingStatusSchema = z.object({
+  workspaceId: z.string(),
+  plan: BillingPlanSchema,
+  limits: BillingLimitsSchema,
+  usage: BillingUsageSchema,
+  seats: BillingSeatCountSchema,
+  connections: BillingConnectionCountSchema,
+  currentModel: z.string(),
+  overagePerMillionTokens: z.number(),
+  subscription: BillingSubscriptionSchema.nullable(),
+}) satisfies z.ZodType<BillingStatus>;

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -1,4 +1,7 @@
 export * from "./abuse";
 export * from "./approval";
+export * from "./backup";
+export * from "./billing";
 export * from "./custom-domain";
 export * from "./integrations";
+export * from "./platform";

--- a/packages/schemas/src/platform.ts
+++ b/packages/schemas/src/platform.ts
@@ -1,0 +1,91 @@
+/**
+ * Platform admin wire-format schemas.
+ *
+ * Single source of truth for the cross-tenant platform admin surface
+ * (`/api/v1/platform/stats`, `/workspaces`, `/noisy-neighbors`,
+ * `/workspaces/:id`) — used by both route-layer OpenAPI validation and
+ * web-layer response parsing.
+ *
+ * Before #1648, the route copies in `platform-admin.ts` pinned `status`,
+ * `planTier`, and `metric` to strict `z.enum(TUPLE)` while the web
+ * copies silently relaxed them all to `z.string()`. Three enum columns,
+ * three drift traps — a new plan tier, a new workspace status, or a new
+ * noisy-neighbor metric would have passed the web parse untyped and
+ * silently broken the platform admin table. Pinning here closes that gap.
+ *
+ * Tuples (`WORKSPACE_STATUSES`, `PLAN_TIERS`, `NOISY_NEIGHBOR_METRICS`,
+ * `ATLAS_ROLES`) come from `@useatlas/types` so adding a new value
+ * propagates here without a second edit.
+ *
+ * Uses `satisfies z.ZodType<T>` (not `as z.ZodType<T>`) so a field
+ * rename in `@useatlas/types` breaks this file at compile time instead
+ * of passing through to runtime.
+ *
+ * Strict `z.enum(TUPLE)` matches the `@hono/zod-openapi` extractor's
+ * expectations — it cannot serialize `ZodCatch` wrappers — and keeps the
+ * generated OpenAPI spec describing the genuine output shape.
+ */
+import { z } from "zod";
+import {
+  WORKSPACE_STATUSES,
+  PLAN_TIERS,
+  NOISY_NEIGHBOR_METRICS,
+  ATLAS_ROLES,
+  type PlatformStats,
+  type PlatformWorkspace,
+  type PlatformWorkspaceUser,
+  type NoisyNeighbor,
+} from "@useatlas/types";
+
+const WorkspaceStatusEnum = z.enum(WORKSPACE_STATUSES);
+const PlanTierEnum = z.enum(PLAN_TIERS);
+const NoisyMetricEnum = z.enum(NOISY_NEIGHBOR_METRICS);
+const AtlasRoleEnum = z.enum(ATLAS_ROLES);
+
+export const PlatformStatsSchema = z.object({
+  totalWorkspaces: z.number(),
+  activeWorkspaces: z.number(),
+  suspendedWorkspaces: z.number(),
+  totalUsers: z.number(),
+  totalQueries24h: z.number(),
+  mrr: z.number(),
+}) satisfies z.ZodType<PlatformStats>;
+
+export const PlatformWorkspaceSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  slug: z.string(),
+  status: WorkspaceStatusEnum,
+  planTier: PlanTierEnum,
+  byot: z.boolean(),
+  members: z.number(),
+  conversations: z.number(),
+  queriesLast24h: z.number(),
+  connections: z.number(),
+  scheduledTasks: z.number(),
+  stripeCustomerId: z.string().nullable(),
+  trialEndsAt: z.string().nullable(),
+  suspendedAt: z.string().nullable(),
+  deletedAt: z.string().nullable(),
+  region: z.string().nullable(),
+  regionAssignedAt: z.string().nullable(),
+  createdAt: z.string(),
+}) satisfies z.ZodType<PlatformWorkspace>;
+
+export const PlatformWorkspaceUserSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string(),
+  role: AtlasRoleEnum,
+  createdAt: z.string(),
+}) satisfies z.ZodType<PlatformWorkspaceUser>;
+
+export const NoisyNeighborSchema = z.object({
+  workspaceId: z.string(),
+  workspaceName: z.string(),
+  planTier: PlanTierEnum,
+  metric: NoisyMetricEnum,
+  value: z.number(),
+  median: z.number(),
+  ratio: z.number(),
+}) satisfies z.ZodType<NoisyNeighbor>;

--- a/packages/types/src/billing.ts
+++ b/packages/types/src/billing.ts
@@ -1,12 +1,9 @@
-import type { PlanTier } from "./platform";
-
 // ---------------------------------------------------------------------------
 // Plan limit status — returned by enforcement and billing endpoints
 // ---------------------------------------------------------------------------
 
 /** Overage status levels for a workspace's usage against its plan limits. */
-export const OVERAGE_STATUSES = ["ok", "warning", "soft_limit", "hard_limit"] as const;
-export type OverageStatus = (typeof OVERAGE_STATUSES)[number];
+export type OverageStatus = "ok" | "warning" | "soft_limit" | "hard_limit";
 
 /**
  * Usage status for a single metered dimension (queries or tokens).
@@ -25,74 +22,4 @@ export interface PlanLimitStatus {
   usagePercent: number;
   /** Overage status level. */
   status: OverageStatus;
-}
-
-// ---------------------------------------------------------------------------
-// Billing status — workspace-scoped wire shape served by GET /api/v1/billing
-// ---------------------------------------------------------------------------
-
-/** Plan details surfaced on the billing page. */
-export interface BillingPlan {
-  tier: PlanTier;
-  displayName: string;
-  pricePerSeat: number;
-  defaultModel: string;
-  byot: boolean;
-  trialEndsAt: string | null;
-}
-
-/** Plan limits (null = unlimited). */
-export interface BillingLimits {
-  tokenBudgetPerSeat: number | null;
-  totalTokenBudget: number | null;
-  maxSeats: number | null;
-  maxConnections: number | null;
-}
-
-/** Current-period usage counters. */
-export interface BillingUsage {
-  queryCount: number;
-  tokenCount: number;
-  seatCount: number;
-  tokenUsagePercent: number;
-  tokenOverageStatus: OverageStatus;
-  periodStart: string;
-  periodEnd: string;
-}
-
-/** Seat limit / current count. */
-export interface BillingSeatCount {
-  count: number;
-  max: number | null;
-}
-
-/** Connection limit / current count. */
-export interface BillingConnectionCount {
-  count: number;
-  max: number | null;
-}
-
-/**
- * Active Stripe subscription summary, or `null` when the workspace has no
- * active or trialing subscription. `plan` and `status` come directly from
- * Stripe / Better Auth and are intentionally free-form strings: Stripe
- * controls the vocabulary and we don't want to fail parse on a new
- * Stripe status the TS union doesn't enumerate.
- */
-export interface BillingSubscription {
-  stripeSubscriptionId: string;
-  plan: string;
-  status: string;
-}
-
-export interface BillingStatus {
-  workspaceId: string;
-  plan: BillingPlan;
-  limits: BillingLimits;
-  usage: BillingUsage;
-  seats: BillingSeatCount;
-  connections: BillingConnectionCount;
-  currentModel: string;
-  overagePerMillionTokens: number;
-  subscription: BillingSubscription | null;
 }

--- a/packages/types/src/billing.ts
+++ b/packages/types/src/billing.ts
@@ -1,9 +1,12 @@
+import type { PlanTier } from "./platform";
+
 // ---------------------------------------------------------------------------
 // Plan limit status — returned by enforcement and billing endpoints
 // ---------------------------------------------------------------------------
 
 /** Overage status levels for a workspace's usage against its plan limits. */
-export type OverageStatus = "ok" | "warning" | "soft_limit" | "hard_limit";
+export const OVERAGE_STATUSES = ["ok", "warning", "soft_limit", "hard_limit"] as const;
+export type OverageStatus = (typeof OVERAGE_STATUSES)[number];
 
 /**
  * Usage status for a single metered dimension (queries or tokens).
@@ -22,4 +25,74 @@ export interface PlanLimitStatus {
   usagePercent: number;
   /** Overage status level. */
   status: OverageStatus;
+}
+
+// ---------------------------------------------------------------------------
+// Billing status — workspace-scoped wire shape served by GET /api/v1/billing
+// ---------------------------------------------------------------------------
+
+/** Plan details surfaced on the billing page. */
+export interface BillingPlan {
+  tier: PlanTier;
+  displayName: string;
+  pricePerSeat: number;
+  defaultModel: string;
+  byot: boolean;
+  trialEndsAt: string | null;
+}
+
+/** Plan limits (null = unlimited). */
+export interface BillingLimits {
+  tokenBudgetPerSeat: number | null;
+  totalTokenBudget: number | null;
+  maxSeats: number | null;
+  maxConnections: number | null;
+}
+
+/** Current-period usage counters. */
+export interface BillingUsage {
+  queryCount: number;
+  tokenCount: number;
+  seatCount: number;
+  tokenUsagePercent: number;
+  tokenOverageStatus: OverageStatus;
+  periodStart: string;
+  periodEnd: string;
+}
+
+/** Seat limit / current count. */
+export interface BillingSeatCount {
+  count: number;
+  max: number | null;
+}
+
+/** Connection limit / current count. */
+export interface BillingConnectionCount {
+  count: number;
+  max: number | null;
+}
+
+/**
+ * Active Stripe subscription summary, or `null` when the workspace has no
+ * active or trialing subscription. `plan` and `status` come directly from
+ * Stripe / Better Auth and are intentionally free-form strings: Stripe
+ * controls the vocabulary and we don't want to fail parse on a new
+ * Stripe status the TS union doesn't enumerate.
+ */
+export interface BillingSubscription {
+  stripeSubscriptionId: string;
+  plan: string;
+  status: string;
+}
+
+export interface BillingStatus {
+  workspaceId: string;
+  plan: BillingPlan;
+  limits: BillingLimits;
+  usage: BillingUsage;
+  seats: BillingSeatCount;
+  connections: BillingConnectionCount;
+  currentModel: string;
+  overagePerMillionTokens: number;
+  subscription: BillingSubscription | null;
 }

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -31,6 +31,7 @@ import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surfa
 import { BillingStatusSchema } from "@/ui/lib/admin-schemas";
 import { formatDate, formatNumber } from "@/lib/format";
 import { cn } from "@/lib/utils";
+import type { BillingStatus } from "@useatlas/types";
 import {
   Bot,
   Coins,
@@ -42,50 +43,6 @@ import {
   ServerOff,
   Zap,
 } from "lucide-react";
-
-// ── Types ─────────────────────────────────────────────────────────
-
-interface BillingStatus {
-  workspaceId: string;
-  plan: {
-    tier: string;
-    displayName: string;
-    pricePerSeat: number;
-    defaultModel: string;
-    byot: boolean;
-    trialEndsAt: string | null;
-  };
-  limits: {
-    tokenBudgetPerSeat: number | null;
-    totalTokenBudget: number | null;
-    maxSeats: number | null;
-    maxConnections: number | null;
-  };
-  usage: {
-    queryCount: number;
-    tokenCount: number;
-    seatCount: number;
-    tokenUsagePercent: number;
-    tokenOverageStatus: string;
-    periodStart: string;
-    periodEnd: string;
-  };
-  seats?: {
-    count: number;
-    max: number | null;
-  };
-  connections?: {
-    count: number;
-    max: number | null;
-  };
-  currentModel?: string;
-  overagePerMillionTokens?: number;
-  subscription: {
-    stripeSubscriptionId: string;
-    plan: string;
-    status: string;
-  } | null;
-}
 
 // ── Helpers ───────────────────────────────────────────────────────
 

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -31,7 +31,7 @@ import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surfa
 import { BillingStatusSchema } from "@/ui/lib/admin-schemas";
 import { formatDate, formatNumber } from "@/lib/format";
 import { cn } from "@/lib/utils";
-import type { BillingStatus } from "@useatlas/types";
+import type { BillingStatus } from "@useatlas/schemas";
 import {
   Bot,
   Coins,

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -21,12 +21,6 @@ import type {
   WorkspaceModelConfig,
   PIIColumnClassification,
   SemanticDiffResponse,
-  PlatformStats,
-  PlatformWorkspace,
-  PlatformWorkspaceUser,
-  NoisyNeighbor,
-  BackupEntry,
-  BackupConfig,
   RegionMigration,
   RegionPickerItem,
   RegionStatus,
@@ -37,15 +31,27 @@ import type {
   SLAThresholds,
   SLAMetricPoint,
 } from "@/ui/lib/types";
-import { CustomDomainSchema } from "@useatlas/schemas";
+import {
+  BackupEntrySchema,
+  CustomDomainSchema,
+  PlatformWorkspaceSchema,
+  PlatformWorkspaceUserSchema,
+  NoisyNeighborSchema,
+} from "@useatlas/schemas";
 export {
   AbuseStatusSchema,
   AbuseThresholdConfigSchema,
   AbuseDetailSchema,
   ApprovalRuleSchema,
   ApprovalRequestSchema,
+  BackupEntrySchema,
+  BackupConfigSchema,
+  BillingStatusSchema,
   CustomDomainSchema,
   IntegrationStatusSchema,
+  PlatformStatsSchema,
+  PlatformWorkspaceSchema,
+  NoisyNeighborSchema,
 } from "@useatlas/schemas";
 
 // ── Connection ────────────────────────────────────────────────────
@@ -141,54 +147,10 @@ export const ConnectionsResponseSchema = z.object({
 }).transform((r) => r.connections ?? []);
 
 // ── Platform ─────────────────────────────────────────────────────
-
-export const PlatformStatsSchema = z.object({
-  totalWorkspaces: z.number(),
-  activeWorkspaces: z.number(),
-  suspendedWorkspaces: z.number(),
-  totalUsers: z.number(),
-  totalQueries24h: z.number(),
-  mrr: z.number(),
-}) as z.ZodType<PlatformStats>;
-
-export const PlatformWorkspaceSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  slug: z.string(),
-  planTier: z.string(),
-  status: z.string(),
-  byot: z.boolean(),
-  members: z.number(),
-  connections: z.number(),
-  conversations: z.number(),
-  queriesLast24h: z.number(),
-  scheduledTasks: z.number(),
-  stripeCustomerId: z.string().nullable(),
-  trialEndsAt: z.string().nullable(),
-  suspendedAt: z.string().nullable(),
-  deletedAt: z.string().nullable(),
-  region: z.string().nullable(),
-  regionAssignedAt: z.string().nullable(),
-  createdAt: z.string(),
-}) as z.ZodType<PlatformWorkspace>;
-
-const PlatformWorkspaceUserSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  email: z.string(),
-  role: z.string(),
-  createdAt: z.string(),
-}) as z.ZodType<PlatformWorkspaceUser>;
-
-export const NoisyNeighborSchema = z.object({
-  workspaceId: z.string(),
-  workspaceName: z.string(),
-  planTier: z.string(),
-  metric: z.string(),
-  value: z.number(),
-  median: z.number(),
-  ratio: z.number(),
-}) as z.ZodType<NoisyNeighbor>;
+// PlatformStatsSchema, PlatformWorkspaceSchema, NoisyNeighborSchema and
+// PlatformWorkspaceUserSchema come from @useatlas/schemas so the three
+// enum columns (status / planTier / metric) stay strict across the
+// route OpenAPI contract and the web parse.
 
 export const PlatformWorkspacesResponseSchema = z.object({
   workspaces: z.array(PlatformWorkspaceSchema),
@@ -209,22 +171,10 @@ export const PlatformWorkspaceDetailResponseSchema = z.object({
 });
 
 // ── Backups ──────────────────────────────────────────────────────
-
-export const BackupEntrySchema = z.object({
-  id: z.string(),
-  status: z.string(),
-  sizeBytes: z.number().nullable(),
-  storagePath: z.string(),
-  createdAt: z.string(),
-  retentionExpiresAt: z.string(),
-  errorMessage: z.string().nullable(),
-}) as z.ZodType<BackupEntry>;
-
-export const BackupConfigSchema = z.object({
-  schedule: z.string(),
-  retentionDays: z.number(),
-  storagePath: z.string(),
-}) as z.ZodType<BackupConfig>;
+// BackupEntrySchema + BackupConfigSchema re-exported above from
+// @useatlas/schemas — the web parse, route OpenAPI validation, and tests
+// share a single definition so tightening `status` to `z.enum(BACKUP_STATUSES)`
+// doesn't have to be applied twice.
 
 export const BackupsResponseSchema = z.object({
   backups: z.array(BackupEntrySchema),
@@ -420,48 +370,10 @@ export const AuditUsersResponseSchema = z.object({
 });
 
 // ── Billing ──────────────────────────────────────────────────────
-
-export const BillingStatusSchema = z.object({
-  workspaceId: z.string(),
-  plan: z.object({
-    tier: z.string(),
-    displayName: z.string(),
-    pricePerSeat: z.number(),
-    defaultModel: z.string(),
-    byot: z.boolean(),
-    trialEndsAt: z.string().nullable(),
-  }),
-  limits: z.object({
-    tokenBudgetPerSeat: z.number().nullable(),
-    totalTokenBudget: z.number().nullable(),
-    maxSeats: z.number().nullable(),
-    maxConnections: z.number().nullable(),
-  }),
-  usage: z.object({
-    queryCount: z.number(),
-    tokenCount: z.number(),
-    seatCount: z.number(),
-    tokenUsagePercent: z.number(),
-    tokenOverageStatus: z.string(),
-    periodStart: z.string(),
-    periodEnd: z.string(),
-  }),
-  seats: z.object({
-    count: z.number(),
-    max: z.number().nullable(),
-  }).optional(),
-  connections: z.object({
-    count: z.number(),
-    max: z.number().nullable(),
-  }).optional(),
-  currentModel: z.string().optional(),
-  overagePerMillionTokens: z.number().optional(),
-  subscription: z.object({
-    stripeSubscriptionId: z.string(),
-    plan: z.string(),
-    status: z.string(),
-  }).nullable(),
-});
+// BillingStatusSchema re-exported above from @useatlas/schemas. Tightens
+// `plan.tier` to PLAN_TIERS and `usage.tokenOverageStatus` to
+// OVERAGE_STATUSES — Stripe-controlled fields (subscription.plan /
+// subscription.status) stay free-form z.string().
 
 // ── Sessions ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Continues wire-format schema consolidation started in #1647 (abuse) and extended in #1654 (ApprovalRule + CustomDomain) + #1669 (IntegrationStatus family). This PR migrates 3 more schema families:

- **Backup** — `BackupEntry` + `BackupConfig` (warm-up)
- **Platform** — `PlatformStats`, `PlatformWorkspace`, `PlatformWorkspaceUser`, `NoisyNeighbor`
- **Billing** — `BillingStatus` + 6 nested subschemas (plan / limits / usage / seat / connection / subscription)

Each file uses \`satisfies z.ZodType<T>\` against a \`@useatlas/types\` interface and strict \`z.enum(TUPLE)\` for canonical enums from that same package. Pattern mirrors #1647 exactly.

## New canonical types

\`@useatlas/types\` gains:
- \`BillingStatus\` + nested interfaces (previously implicit — the route declared its response as \`z.record(string, unknown)\`)
- \`OVERAGE_STATUSES\` tuple so \`tokenOverageStatus\` can be pinned

## Enum tightening (wire-contract changes)

Web previously relaxed multiple enums to \`z.string()\`. Tightened to match the route:

| Field | New enum | Tuple source |
|---|---|---|
| \`BackupEntry.status\` | \`BACKUP_STATUSES\` | types/backups.ts |
| \`PlatformWorkspace.status\` | \`WORKSPACE_STATUSES\` | types/platform.ts |
| \`PlatformWorkspace.planTier\` | \`PLAN_TIERS\` | types/platform.ts |
| \`NoisyNeighbor.metric\` | \`NOISY_NEIGHBOR_METRICS\` | types/platform.ts |
| \`NoisyNeighbor.planTier\` | \`PLAN_TIERS\` | types/platform.ts |
| \`PlatformWorkspaceUser.role\` | \`ATLAS_ROLES\` | types/auth.ts |
| \`BillingStatus.plan.tier\` | \`PLAN_TIERS\` | types/platform.ts |
| \`BillingStatus.usage.tokenOverageStatus\` | \`OVERAGE_STATUSES\` | types/billing.ts (new) |

Drift in any tuple now fails parse at \`useAdminFetch\` time with \`schema_mismatch\` instead of leaking through as untyped text into admin tables / badges.

\`subscription.plan\` and \`subscription.status\` stay free-form \`z.string()\` — Stripe (not us) controls those vocabularies.

## OpenAPI diff

**Intentional expansion:** \`GET /api/v1/billing\` was documented as \`additionalProperties: {}\` ("any object"). The spec now describes the full \`BillingStatus\` shape — nested plan/limits/usage/seats/connections/subscription objects with their required fields and enum constraints. This is a large but positive change: consumers finally see the real contract.

**Minor loss:** \`BackupConfigSchema\` response lost \`.openapi({description, example, min, max})\` metadata. The shared schema depends on plain \`zod\` not \`@hono/zod-openapi\` so those annotations don't travel. Field types and required-lists are unchanged. Request-validation still has its own \`UpdateConfigSchema\` with cron-regex + range guards.

## Tests

38 new tests across backup / platform / billing:
- happy-path parsing (valid, self-hosted, trial, in-progress, failed backups, suspended workspace, etc.)
- round-trip (parse → serialize → parse) preserving fields
- enum strict rejection (8 unknown-value tests, one per tightened enum)
- canonical-tuple assertions that fail loud if a tuple is reordered or added to without a schema bump
- structural rejection for missing required fields

Total schemas package tests: 75 → 113.

## Remaining (#1648 tracker)

~10 schemas: SLA family, Region family, PII, SemanticDiff, Branding, ModelConfig, ConnectionInfo/Health, audit analytics, token usage/trends, UsageSummary.

## Test plan
- [x] \`bun test packages/schemas/src/__tests__\` — 113 pass
- [x] \`bun run lint\` — clean
- [x] \`bun run type\` — clean
- [x] \`bun run test\` — all packages pass
- [x] \`bun x syncpack lint\` — no issues
- [x] template drift check — pass
- [x] OpenAPI regenerated (\`bun run --filter @atlas/api openapi:extract\`) and committed
- [ ] billing page loads and BYOT toggle / tier badges still render correctly
- [ ] platform admin table renders planTier / status badges
- [ ] platform backups page renders status pills