### PR TITLE
feat(web): MutationErrorSurface — SCIM + Billing carve-outs (closes #1624)

### DIFF
--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -18,15 +18,14 @@ import {
   CompactRow,
   DetailList,
   DetailRow,
-  InlineError,
   SectionHeading,
   Shell,
   type StatusKind,
   useDisclosure,
 } from "@/ui/components/admin/compact";
+import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError } from "@/ui/lib/fetch-error";
 import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { BillingStatusSchema } from "@/ui/lib/admin-schemas";
 import { formatDate, formatNumber } from "@/lib/format";
@@ -222,7 +221,12 @@ function PlanShell({ data }: { data: BillingStatus }) {
   const totalMonthly = plan.pricePerSeat * seatCount;
   const overage = data.overagePerMillionTokens ?? 0;
 
-  const { mutate, saving, error: portalMutationError } = useAdminMutation<{
+  const {
+    mutate,
+    saving,
+    error: portalMutationError,
+    clearError: clearPortalMutation,
+  } = useAdminMutation<{
     url?: string;
   }>({
     path: "/api/v1/billing/portal",
@@ -243,11 +247,11 @@ function PlanShell({ data }: { data: BillingStatus }) {
 
   // portalError covers the 200-but-missing-URL edge case (set locally when
   // the server returns success but no portal link); portalMutationError
-  // covers all non-2xx responses. Use `||` so an empty-string
-  // friendlyError() result falls through to portalError rather than
-  // suppressing it.
-  const mutationCopy = portalMutationError ? friendlyError(portalMutationError) : "";
-  const combinedError = mutationCopy || portalError;
+  // covers all non-2xx responses. Structured mutation error wins over the
+  // local string — a 403 `enterprise_required` on a plan that doesn't expose
+  // a Stripe portal must route into <EnterpriseUpsell>, which means the
+  // FetchError can't be flattened here. The local "no URL" string only
+  // surfaces when there's no structured error to render.
   const status: StatusKind = subscription?.status === "active" ? "connected" : "disconnected";
 
   return (
@@ -329,7 +333,14 @@ function PlanShell({ data }: { data: BillingStatus }) {
         )}
       </DetailList>
 
-      <InlineError>{combinedError}</InlineError>
+      <MutationErrorSurface
+        error={portalMutationError}
+        feature="Billing"
+        onRetry={clearPortalMutation}
+      />
+      {!portalMutationError && portalError && (
+        <ErrorBanner message={portalError} />
+      )}
       {!subscription && plan.pricePerSeat > 0 && (
         <p className="text-[11px] leading-relaxed text-muted-foreground">
           No active subscription — portal access opens after you subscribe.

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -245,13 +245,16 @@ function PlanShell({ data }: { data: BillingStatus }) {
     }
   }
 
-  // portalError covers the 200-but-missing-URL edge case (set locally when
-  // the server returns success but no portal link); portalMutationError
-  // covers all non-2xx responses. Structured mutation error wins over the
-  // local string — a 403 `enterprise_required` on a plan that doesn't expose
-  // a Stripe portal must route into <EnterpriseUpsell>, which means the
-  // FetchError can't be flattened here. The local "no URL" string only
-  // surfaces when there's no structured error to render.
+  // Structured mutation error wins over the local string: a 403
+  // `enterprise_required` on a plan that doesn't expose a Stripe portal
+  // must route into <EnterpriseUpsell>, which means we can't flatten the
+  // FetchError into portalError's string slot. portalError (the
+  // 200-but-missing-URL degraded-success copy) only surfaces when no
+  // structured error is pinned. The two are mutually exclusive by
+  // construction — openBillingPortal() clears portalError at call start
+  // and useAdminMutation clears portalMutationError at call start — so
+  // the retry handler below clears both defensively, keeping them
+  // exclusive on a user-driven dismiss too.
   const status: StatusKind = subscription?.status === "active" ? "connected" : "disconnected";
 
   return (
@@ -336,7 +339,10 @@ function PlanShell({ data }: { data: BillingStatus }) {
       <MutationErrorSurface
         error={portalMutationError}
         feature="Billing"
-        onRetry={clearPortalMutation}
+        onRetry={() => {
+          clearPortalMutation();
+          setPortalError(null);
+        }}
       />
       {!portalMutationError && portalError && (
         <ErrorBanner message={portalError} />

--- a/packages/web/src/app/admin/scim/page.tsx
+++ b/packages/web/src/app/admin/scim/page.tsx
@@ -28,7 +28,7 @@ import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surfa
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError, friendlyErrorOrNull } from "@/ui/lib/fetch-error";
+import { friendlyErrorOrNull, type FetchError } from "@/ui/lib/fetch-error";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import {
   CompactRow,
@@ -101,8 +101,12 @@ const GroupMappingsResponseSchema = z.object({
 
 // ── Main Page ─────────────────────────────────────────────────────
 
+// Structured FetchError (not a flattened message) so MutationErrorSurface can
+// route `code === "enterprise_required"` into the compact inline upsell — a
+// gated SCIM revoke from a non-enterprise workspace otherwise degrades to a
+// generic "Revoke failed — …" string and loses the affordance.
 type RowError = {
-  message: string;
+  error: FetchError;
   id: string;
   kind: "connection" | "mapping";
 };
@@ -153,13 +157,7 @@ export default function SCIMPage() {
     const result = await deleteMutate({ path });
     setDeleteTarget(null);
     if (!result.ok) {
-      // TODO(#1649): route per-row errors through <MutationErrorSurface> too.
-      // Page-level banner already uses the surface and picks up `enterprise_required`
-      // routing; per-row pin still flattens to string so a gated row revoke renders
-      // as a plain InlineError rather than an inline upsell. Not wired here because
-      // rowError needs id/kind tracking that the surface doesn't model — phase 2
-      // reshapes this state to `{ fetchError, id, kind }` and lets the surface render.
-      setRowError({ message: friendlyError(result.error), id: target.id, kind: target.type });
+      setRowError({ error: result.error, id: target.id, kind: target.type });
     }
   }
 
@@ -410,9 +408,12 @@ export default function SCIMPage() {
                         )}
                       </DetailList>
                       {rowHasError && (
-                        <InlineError>
-                          Revoke failed — {rowError.message}
-                        </InlineError>
+                        <MutationErrorSurface
+                          error={rowError.error}
+                          feature="SCIM"
+                          variant="inline"
+                          inlinePrefix="Revoke failed."
+                        />
                       )}
                     </Shell>
                   );
@@ -480,9 +481,12 @@ export default function SCIMPage() {
                         <DetailRow label="Added" value={formatDateTime(mapping.createdAt)} />
                       </DetailList>
                       {rowHasError && (
-                        <InlineError>
-                          Remove failed — {rowError.message}
-                        </InlineError>
+                        <MutationErrorSurface
+                          error={rowError.error}
+                          feature="SCIM"
+                          variant="inline"
+                          inlinePrefix="Remove failed."
+                        />
                       )}
                     </Shell>
                   );


### PR DESCRIPTION
## Summary

Two final MutationErrorSurface carve-outs from phase 2 of #1624 — both deferred from the phase 2D sweep (#1677) because they needed more than a mechanical swap. Shipping these closes parent #1624.

- **#1675 — /admin/scim row-pin migration.** `rowError` flattened `FetchError → string` at pin time, dropping the `code === "enterprise_required"` signal. Reshape pin target to `{ error, id, kind }` so the raw `FetchError` survives to the render boundary, and render per-row failures via `<MutationErrorSurface variant="inline" feature="SCIM" inlinePrefix="Revoke failed." />`. Last-wins pin semantics preserved.
- **#1676 — /admin/billing PlanShell precedence.** `combinedError = friendlyError(portalMutationError) || portalError` flattened the structured error, so a 403 `enterprise_required` on the portal endpoint rendered a generic banner instead of `<EnterpriseUpsell>`. Remove `combinedError`; render `<MutationErrorSurface>` for the structured path and `<ErrorBanner>` only when no structured error exists. Structured error wins — but the local "200 but no URL" string still surfaces on its own.

## Test plan

- [x] `bun run lint` — 0 errors
- [x] `bun run type` — 0 errors
- [x] `bun run test` — web 78/78 pass, api + ee pass; one flaky DuckDB CLI test failed (filed #1686; unrelated — passes in isolation)
- [x] `bun x syncpack lint` — No issues found
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — 430 files verified
- [ ] Manual spot-check: provoke a 403 `enterprise_required` on a SCIM row + on billing portal — compact upsell renders inline on SCIM, full `<EnterpriseUpsell>` on billing

## Closes

- #1675
- #1676
- Closes phase 2 of #1624 (parent can close after merge)

## Incidental findings

- **#1686** — filed for a flaky `packages/cli/bin/__tests__/duckdb-ingest.test.ts` (timeout + `malloc(): unsorted double linked list corrupted`) observed in the local monorepo CI run. Passes in isolation (8/8 in 723ms), same class as #992.