### PR TITLE
refactor(api/abuse): hardening bundle — per-row JSON catch + diagnostic channel + brand + Percentage/Ratio

### DIFF
--- a/.claude/research/architecture-wins.md
+++ b/.claude/research/architecture-wins.md
@@ -969,7 +969,7 @@ export function percentageToRatio(p: Percentage): Ratio { return (p / 100) as Ra
 export function ratioToPercentage(r: Ratio): Percentage { return (r * 100) as Percentage; }
 ```
 
-The brands are zero-runtime — emitted JS is plain `number`. Only the four constructors can mint branded values; any plain-number expression fails typecheck in a branded position. Cross-scale comparison (`Percentage > Ratio`) fails typecheck without an explicit `percentageToRatio` / `ratioToPercentage` call.
+The brands are zero-runtime as types — emitted JS is plain `number`. The constructors also add a one-time range + non-finite validation pass at mint time, so `asPercentage(150)`, `asRatio(NaN)`, etc. throw instead of silently branding nonsense. Only the four constructors can produce branded values; any plain-number expression fails typecheck in a branded *position* (assignment, function argument, return type, struct field). Comparison operators (`>`, `<`, `===`) remain structural and compile freely — the defense is that the *operands* on each side must be branded first, which forces every scale in the expression chain to be declared at a constructor call site.
 
 Applied the brands through the entire stack:
 - `@useatlas/types`: `AbuseCounters.errorRatePct: Percentage | null`, `AbuseThresholdConfig.errorRateThreshold: Ratio`, `WorkspaceSLASummary.errorRatePct / uptimePct: Percentage`, `SLAThresholds.errorRatePct: Percentage`.
@@ -984,7 +984,7 @@ Applied the brands through the entire stack:
 Tests cover both layers: runtime conversions (asPercentage / asRatio identity, percentageToRatio / ratioToPercentage math, round-trip precision at the 50.04% boundary that nearly regressed PR #1681) and compile-time invariants via `@ts-expect-error` directives for every cross-assignment that should fail (plain number → Percentage, plain number → Ratio, Percentage → Ratio without conversion, Ratio → Percentage without conversion). Any future refactor that erases the brand makes the directives stop being "expected" and the build fails.
 
 **Impact:**
-- The `errorRatePct / 100` footgun is now a compile-time error. A caller who forgets the conversion or applies it twice fails typecheck at the expression, not at runtime boundary rounding.
+- The `errorRatePct / 100` footgun is prevented by the upstream discipline: every producer of `errorRatePct` brands via `asPercentage` and every consumer of `errorRateThreshold` requires a `Ratio`. A caller who forgets the conversion fails typecheck at the function-argument or assignment boundary, not at the `>` operator itself (TypeScript permits `number > number` regardless of brand). The `@ts-expect-error` tests in `percentage.test.ts` pin exactly what is and is not caught.
 - Zero runtime cost. JS output is pure `number`; the brand erases.
 - Abuse and SLA surfaces now share one vocabulary (`Percentage` = 0–100, `Ratio` = 0–1) — future code can't accidentally compare a Percentage to a Ratio the way PR #1681 nearly did.
 - One new module (`percentage.ts`) with two types + four constructors. Ten production sites updated. The convention-collision problem is resolved at the type layer, not by adding comments ("this is 0–100" vs "this is 0–1") that rot.

--- a/.claude/research/architecture-wins.md
+++ b/.claude/research/architecture-wins.md
@@ -894,3 +894,99 @@ Also extracted `errorRatePct(errorCount, totalCount): number` as a pure counter 
 - **Wire-format change: 2-decimal rounding.** `errorRatePct` now rounds to 2 decimals where it was unrounded before. The UI card in `detail-panel.tsx` displays via `.toFixed(0)` so the visible integer is unchanged, but a sibling usage in the same file computes a derived "over threshold" flag via `counters.errorRatePct / 100 > thresholds.errorRateThreshold`. Rounding to 1 decimal (the initial implementation) would have silently flipped that flag off within ±0.05% of the threshold while the engine itself still escalated on the unrounded fraction — so the UI and engine would have disagreed at boundary values. 2 decimals matches the SLA surface convention and keeps the boundary comparison faithful to 0.01%, which is well below any meaningful display resolution.
 
 **Category:** Module-deepening refactor that promotes an internal helper to a narrowed public factory. The factory pattern fits the "deep module with small interface" mold: callers pass one argument (the events array), the factory derives everything else. The caveat — and the follow-up — is that without a branded or nominal type, the factory is a convention, not a boundary. Generalizes: whenever a type has N derived fields that must agree, a single constructor function beats N scattered call sites hand-assembling the object, but the real enforcement wants a brand, a discriminated union, or a class-with-private-constructor on top.
+
+---
+
+## 35. Nominally-branded `AbuseInstance` — closes the factory's enforcement gap
+
+**Date:** 2026-04-19
+**Issue:** #1684
+**PR:** refactor/abuse-hardening-bundle
+
+**Problem:** Win #34 promoted `createAbuseInstance` to a narrowed exported factory that encodes the `AbuseInstance` invariants (peakLevel ≡ max of event levels, endedAt non-null iff last event is a manual "none" reinstatement, startedAt ≡ events[0].createdAt). The factory docstring already flagged the caveat: "`AbuseInstance` is still a structurally-typed interface, so the factory is an advisory boundary — tests and wire-format parsers can still produce the shape directly." Route-layer test fixtures in `admin-abuse.test.ts` did exactly that (lines 268–273, 295, 333 in the pre-bundle state), hand-rolling the object inline and compiling fine. A fresh call site inside `packages/api/src/lib/security/**` could produce a `peakLevel: "warning"` literal over events containing `"suspended"` and the compiler would let it through.
+
+Type-design-analyzer rated the factory at encapsulation 1/5, invariant-expression 2/5, enforcement 2/5. The factory was advisory, not nominal — exactly the shape-vs-identity distinction this codebase keeps running into.
+
+**Solution:** Added a phantom `unique symbol` brand to `AbuseInstance` in `@useatlas/types/abuse.ts`:
+
+```ts
+declare const abuseInstanceBrand: unique symbol;
+export interface AbuseInstance {
+  readonly [abuseInstanceBrand]: never;
+  startedAt: string;
+  endedAt: string | null;
+  peakLevel: AbuseLevel;
+  events: readonly AbuseEvent[];
+}
+```
+
+The required `[brand]: never` key is impossible to satisfy with a plain object literal — the key type is a module-private `unique symbol` no external caller can reference, and its value type is `never`. Only two escape hatches remain:
+
+1. `createAbuseInstance` in `abuse-instances.ts` localizes the `as unknown as AbuseInstance` cast inside the factory. The factory's documented contract (the invariants in #34) is what grants the cast its authority.
+2. `AbuseInstanceSchema` in `@useatlas/schemas/abuse.ts` adds a `.transform((v) => v as unknown as AbuseInstance)` so the wire-boundary Zod parser can mint a branded value. `satisfies z.ZodType<AbuseInstance, unknown>` (widened input) keeps the structural drift guard — a field rename in `@useatlas/types` still breaks the schema file at compile time.
+
+Also: `events: readonly AbuseEvent[]` (was mutable `AbuseEvent[]`). Mutating the array post-construction would silently invalidate the cached `peakLevel` and `endedAt` invariants — `readonly` is free and forces such mutations through an explicit copy.
+
+Migrated four hand-rolled `currentInstance: {...}` fixtures in `admin-abuse.test.ts` to `createAbuseInstance([])` and tightened the mock signature from `Promise<unknown | null>` to `Promise<AbuseDetail | null>` so inline literals now fail typecheck immediately. A new `@ts-expect-error` regression test pins that hand-rolling an `AbuseInstance` literal fails — if a future refactor relaxes the brand, the directive stops being "expected" and the build fails, flagging the regression.
+
+**Impact:**
+- The factory is now the *only* call site that can produce an `AbuseInstance` — the compiler enforces that, not a convention. Type-design rating moves from 1–2/5 → 5/5 on encapsulation + enforcement.
+- Zero runtime cost. The brand is a phantom type; emitted JS is a plain object.
+- Closes the exact enforcement gap #34 identified. The follow-up on #34 is retired.
+- Incidentally fixed an aliasing smell: `events: readonly AbuseEvent[]` — callers can't accidentally mutate the array after construction.
+
+**Category:** Type-level encapsulation. Brand-via-unique-symbol is a zero-runtime way to convert structural types into nominal ones. Generalizes: any time a factory encodes invariants that a plain object literal can bypass, brand the resulting type. The factory + schema then become the two privileged mint sites; every other path through the type system is a compile-time error.
+
+---
+
+## 36. `Percentage` / `Ratio` branded numerics — `errorRatePct` convention collision resolved at the type layer
+
+**Date:** 2026-04-19
+**Issue:** #1685
+**PR:** refactor/abuse-hardening-bundle
+
+**Problem:** `errorRatePct` appeared in four positions across the codebase with two incompatible scale conventions and nothing in the type system distinguishing them:
+
+- `AbuseCounters.errorRatePct` on 0–100 (percentage).
+- `AbuseThresholdConfig.errorRateThreshold` on 0–1 (ratio).
+- `WorkspaceSLASummary.errorRatePct` / `SLAThresholds.errorRatePct` on 0–100 (opposite scale from the abuse threshold but same field name as the abuse counter).
+- `ee/src/sla/metrics.ts` and `alerting.ts` computed / compared these with a mix of `Math.round(… / … * 10000) / 100`, raw `/ 100`, and direct comparisons.
+
+Plain `number` was identical at every position. Type-design-analyzer flagged this as the classic "same name, two scales" pattern that the type system is supposed to catch — and PR #1681 nearly shipped exactly the regression the analyzer warned about: 1-decimal rounding of a 50.04% rate silently flipped `counters.errorRatePct / 100 > thresholds.errorRateThreshold` off while `checkThresholds` kept escalating on the unrounded fraction.
+
+The specific failure mode was a boundary bug in the admin detail panel: `counters.errorRatePct / 100 > thresholds.errorRateThreshold`. Drop the `/ 100` and you're comparing a 50.04 to a 0.5 — wrong in either direction depending on the scale assumed. Nothing in the types told you which scale either side was on.
+
+**Solution:** New `packages/types/src/percentage.ts` introduces two nominally-branded numeric types via phantom `unique symbol`:
+
+```ts
+declare const percentageBrand: unique symbol;
+declare const ratioBrand: unique symbol;
+export type Percentage = number & { readonly [percentageBrand]: never };
+export type Ratio = number & { readonly [ratioBrand]: never };
+export function asPercentage(n: number): Percentage { return n as Percentage; }
+export function asRatio(n: number): Ratio { return n as Ratio; }
+export function percentageToRatio(p: Percentage): Ratio { return (p / 100) as Ratio; }
+export function ratioToPercentage(r: Ratio): Percentage { return (r * 100) as Percentage; }
+```
+
+The brands are zero-runtime — emitted JS is plain `number`. Only the four constructors can mint branded values; any plain-number expression fails typecheck in a branded position. Cross-scale comparison (`Percentage > Ratio`) fails typecheck without an explicit `percentageToRatio` / `ratioToPercentage` call.
+
+Applied the brands through the entire stack:
+- `@useatlas/types`: `AbuseCounters.errorRatePct: Percentage | null`, `AbuseThresholdConfig.errorRateThreshold: Ratio`, `WorkspaceSLASummary.errorRatePct / uptimePct: Percentage`, `SLAThresholds.errorRatePct: Percentage`.
+- `errorRatePct()` helper (from win #34) returns `Percentage`.
+- `getAbuseConfig()` wraps `envFloat("ATLAS_ABUSE_ERROR_RATE")` in `asRatio` at the env-var boundary.
+- `detail-panel.tsx` uses `percentageToRatio(counters.errorRatePct) > thresholds.errorRateThreshold` instead of raw `/ 100`. Threshold display uses `ratioToPercentage`.
+- Zod schemas transform-cast at the wire boundary: `z.number().transform((n): Percentage => asPercentage(n))` and similar for `Ratio`. `satisfies z.ZodType<…, unknown>` widens input so the schema stays drift-guarded while accepting plain-number input.
+- SLA surfaces (ee/src/sla/{metrics,alerting}.ts) wrap DB-aggregated values in `asPercentage` at the point of construction.
+- Platform SLA route brands the Zod-validated request body before calling the service layer.
+- Web admin SLA dialog brands `parseFloat(e.target.value)` on the user-input side so `editThresholds: SLAThresholds` stays typed.
+
+Tests cover both layers: runtime conversions (asPercentage / asRatio identity, percentageToRatio / ratioToPercentage math, round-trip precision at the 50.04% boundary that nearly regressed PR #1681) and compile-time invariants via `@ts-expect-error` directives for every cross-assignment that should fail (plain number → Percentage, plain number → Ratio, Percentage → Ratio without conversion, Ratio → Percentage without conversion). Any future refactor that erases the brand makes the directives stop being "expected" and the build fails.
+
+**Impact:**
+- The `errorRatePct / 100` footgun is now a compile-time error. A caller who forgets the conversion or applies it twice fails typecheck at the expression, not at runtime boundary rounding.
+- Zero runtime cost. JS output is pure `number`; the brand erases.
+- Abuse and SLA surfaces now share one vocabulary (`Percentage` = 0–100, `Ratio` = 0–1) — future code can't accidentally compare a Percentage to a Ratio the way PR #1681 nearly did.
+- One new module (`percentage.ts`) with two types + four constructors. Ten production sites updated. The convention-collision problem is resolved at the type layer, not by adding comments ("this is 0–100" vs "this is 0–1") that rot.
+
+**Category:** Type-level boundary enforcement for numeric units. Brand-via-unique-symbol converts structural `number` into nominal scale-specific types without runtime overhead. Generalizes to *any* unit-mixup risk: milliseconds vs seconds, bytes vs KB, basis points vs percentage, UTC vs local timestamps. Whenever the same primitive type means two incompatible things in different positions and the compiler silently lets you mix them, brand them. The explicit conversion call is the feature — it's where the bug would have been.

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -34562,6 +34562,14 @@
                                 "actor"
                               ]
                             }
+                          },
+                          "eventsStatus": {
+                            "type": "string",
+                            "enum": [
+                              "ok",
+                              "load_failed",
+                              "db_unavailable"
+                            ]
                           }
                         },
                         "required": [
@@ -34846,6 +34854,14 @@
                     "updatedAt": {
                       "type": "string"
                     },
+                    "eventsStatus": {
+                      "type": "string",
+                      "enum": [
+                        "ok",
+                        "load_failed",
+                        "db_unavailable"
+                      ]
+                    },
                     "counters": {
                       "type": "object",
                       "properties": {
@@ -34859,7 +34875,9 @@
                           "type": [
                             "number",
                             "null"
-                          ]
+                          ],
+                          "minimum": 0,
+                          "maximum": 100
                         },
                         "uniqueTablesAccessed": {
                           "type": "number"
@@ -34886,7 +34904,9 @@
                           "type": "number"
                         },
                         "errorRateThreshold": {
-                          "type": "number"
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1
                         },
                         "uniqueTablesLimit": {
                           "type": "number"
@@ -35073,14 +35093,6 @@
                           "events"
                         ]
                       }
-                    },
-                    "eventsStatus": {
-                      "type": "string",
-                      "enum": [
-                        "ok",
-                        "load_failed",
-                        "db_unavailable"
-                      ]
                     }
                   },
                   "required": [
@@ -35090,11 +35102,11 @@
                     "trigger",
                     "message",
                     "updatedAt",
+                    "eventsStatus",
                     "counters",
                     "thresholds",
                     "currentInstance",
-                    "priorInstances",
-                    "eventsStatus"
+                    "priorInstances"
                   ]
                 }
               }
@@ -35209,7 +35221,9 @@
                       "type": "number"
                     },
                     "errorRateThreshold": {
-                      "type": "number"
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
                     },
                     "uniqueTablesLimit": {
                       "type": "number"

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -35073,6 +35073,14 @@
                           "events"
                         ]
                       }
+                    },
+                    "eventsStatus": {
+                      "type": "string",
+                      "enum": [
+                        "ok",
+                        "load_failed",
+                        "db_unavailable"
+                      ]
                     }
                   },
                   "required": [
@@ -35085,7 +35093,8 @@
                     "counters",
                     "thresholds",
                     "currentInstance",
-                    "priorInstances"
+                    "priorInstances",
+                    "eventsStatus"
                   ]
                 }
               }

--- a/ee/src/sla/alerting.test.ts
+++ b/ee/src/sla/alerting.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { Effect } from "effect";
+import { asPercentage } from "@useatlas/types";
 import { createEEMock } from "../__mocks__/internal";
 
 // ── Mocks ──────────────────────────────────────────────────────────
@@ -51,7 +52,7 @@ describe("getThresholds", () => {
 
     const thresholds = await run(getThresholds());
     expect(thresholds.latencyP99Ms).toBe(5000);
-    expect(thresholds.errorRatePct).toBe(5);
+    expect(thresholds.errorRatePct).toBe<number>(5);
   });
 
   it("returns workspace-specific thresholds when available", async () => {
@@ -61,7 +62,7 @@ describe("getThresholds", () => {
 
     const thresholds = await run(getThresholds("ws-1"));
     expect(thresholds.latencyP99Ms).toBe(3000);
-    expect(thresholds.errorRatePct).toBe(2);
+    expect(thresholds.errorRatePct).toBe<number>(2);
   });
 
   it("falls back to defaults when workspace thresholds not found", async () => {
@@ -79,7 +80,7 @@ describe("getThresholds", () => {
     const thresholds = await run(getThresholds("ws-1"));
     // Default from env: ATLAS_SLA_LATENCY_P99_MS=5000, ATLAS_SLA_ERROR_RATE_PCT=5
     expect(thresholds.latencyP99Ms).toBe(5000);
-    expect(thresholds.errorRatePct).toBe(5);
+    expect(thresholds.errorRatePct).toBe<number>(5);
   });
 });
 
@@ -93,7 +94,7 @@ describe("updateThresholds", () => {
     // ensureTable mocked; UPSERT
     ee.queueMockRows([]);
 
-    await run(updateThresholds({ latencyP99Ms: 3000, errorRatePct: 2 }));
+    await run(updateThresholds({ latencyP99Ms: 3000, errorRatePct: asPercentage(2) }));
     const upsert = ee.capturedQueries.find((q) => q.sql.includes("sla_thresholds"));
     expect(upsert).toBeDefined();
   });

--- a/ee/src/sla/alerting.ts
+++ b/ee/src/sla/alerting.ts
@@ -14,6 +14,7 @@ import { requireInternalDBEffect } from "../lib/db-guard";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
 import type { SLAAlert, SLAAlertStatus, SLAAlertType, SLAThresholds } from "@useatlas/types";
+import { asPercentage } from "@useatlas/types";
 
 const log = createLogger("ee:sla-alerting");
 
@@ -43,7 +44,9 @@ export const getThresholds = (workspaceId?: string): Effect.Effect<SLAThresholds
       if (rows.length > 0) {
         return {
           latencyP99Ms: rows[0].latency_p99_ms,
-          errorRatePct: rows[0].error_rate_pct,
+          // DB column is stored on the 0–100 scale; `asPercentage` brands
+          // the value without changing it (#1685).
+          errorRatePct: asPercentage(rows[0].error_rate_pct),
         };
       }
     }
@@ -56,7 +59,7 @@ export const getThresholds = (workspaceId?: string): Effect.Effect<SLAThresholds
     if (defaults.length > 0) {
       return {
         latencyP99Ms: defaults[0].latency_p99_ms,
-        errorRatePct: defaults[0].error_rate_pct,
+        errorRatePct: asPercentage(defaults[0].error_rate_pct),
       };
     }
 
@@ -68,7 +71,7 @@ function defaultThresholds(): SLAThresholds {
   const errorRate = parseFloat(process.env.ATLAS_SLA_ERROR_RATE_PCT ?? "");
   return {
     latencyP99Ms: isNaN(latency) ? 5000 : latency,
-    errorRatePct: isNaN(errorRate) ? 5 : errorRate,
+    errorRatePct: asPercentage(isNaN(errorRate) ? 5 : errorRate),
   };
 }
 

--- a/ee/src/sla/alerting.ts
+++ b/ee/src/sla/alerting.ts
@@ -66,12 +66,33 @@ export const getThresholds = (workspaceId?: string): Effect.Effect<SLAThresholds
     return defaultThresholds();
   });
 
+/**
+ * Env-var fallbacks for SLA thresholds. Each value is range-checked so
+ * that a malformed operator input (negative, out-of-scale, NaN) falls
+ * back to the hardcoded default with a warn — the previous `isNaN`-only
+ * guard silently accepted `ATLAS_SLA_ERROR_RATE_PCT=0.5` (0.5%, wildly
+ * over-sensitive) as if the operator meant 50%.
+ */
 function defaultThresholds(): SLAThresholds {
   const latency = parseFloat(process.env.ATLAS_SLA_LATENCY_P99_MS ?? "");
   const errorRate = parseFloat(process.env.ATLAS_SLA_ERROR_RATE_PCT ?? "");
+  const latencyOk = Number.isFinite(latency) && latency > 0;
+  const errorRateOk = Number.isFinite(errorRate) && errorRate >= 0 && errorRate <= 100;
+  if (process.env.ATLAS_SLA_LATENCY_P99_MS && !latencyOk) {
+    log.warn(
+      { raw: process.env.ATLAS_SLA_LATENCY_P99_MS },
+      "ATLAS_SLA_LATENCY_P99_MS is not a positive finite number — falling back to 5000",
+    );
+  }
+  if (process.env.ATLAS_SLA_ERROR_RATE_PCT && !errorRateOk) {
+    log.warn(
+      { raw: process.env.ATLAS_SLA_ERROR_RATE_PCT },
+      "ATLAS_SLA_ERROR_RATE_PCT is not in 0..100 — falling back to 5",
+    );
+  }
   return {
-    latencyP99Ms: isNaN(latency) ? 5000 : latency,
-    errorRatePct: asPercentage(isNaN(errorRate) ? 5 : errorRate),
+    latencyP99Ms: latencyOk ? latency : 5000,
+    errorRatePct: asPercentage(errorRateOk ? errorRate : 5),
   };
 }
 

--- a/ee/src/sla/metrics.test.ts
+++ b/ee/src/sla/metrics.test.ts
@@ -103,8 +103,8 @@ describe("getAllWorkspaceSLA", () => {
     expect(summaries).toHaveLength(1);
     expect(summaries[0].workspaceId).toBe("ws-1");
     expect(summaries[0].totalQueries).toBe(100);
-    expect(summaries[0].errorRatePct).toBe(5);
-    expect(summaries[0].uptimePct).toBe(95);
+    expect(summaries[0].errorRatePct).toBe<number>(5);
+    expect(summaries[0].uptimePct).toBe<number>(95);
   });
 
   it("returns empty array when no metrics", async () => {

--- a/ee/src/sla/metrics.ts
+++ b/ee/src/sla/metrics.ts
@@ -20,6 +20,7 @@ import { requireInternalDB } from "../lib/db-guard";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
 import type { WorkspaceSLASummary, WorkspaceSLADetail, SLAMetricPoint } from "@useatlas/types";
+import { asPercentage } from "@useatlas/types";
 
 const log = createLogger("ee:sla-metrics");
 
@@ -185,8 +186,10 @@ export const getAllWorkspaceSLA = (
         latencyP50Ms: Math.round(r.latency_p50 ?? 0),
         latencyP95Ms: Math.round(r.latency_p95 ?? 0),
         latencyP99Ms: Math.round(r.latency_p99 ?? 0),
-        errorRatePct: total > 0 ? Math.round((failed / total) * 10000) / 100 : 0,
-        uptimePct: total > 0 ? Math.round(((total - failed) / total) * 10000) / 100 : 100,
+        // SQL aggregate is already on the 0–100 scale; `asPercentage`
+        // brands it (#1685) without changing the value.
+        errorRatePct: asPercentage(total > 0 ? Math.round((failed / total) * 10000) / 100 : 0),
+        uptimePct: asPercentage(total > 0 ? Math.round(((total - failed) / total) * 10000) / 100 : 100),
         totalQueries: total,
         failedQueries: failed,
         lastQueryAt: r.last_query_at,
@@ -239,8 +242,8 @@ export const getWorkspaceSLADetail = (
       latencyP50Ms: Math.round(r?.latency_p50 ?? 0),
       latencyP95Ms: Math.round(r?.latency_p95 ?? 0),
       latencyP99Ms: Math.round(r?.latency_p99 ?? 0),
-      errorRatePct: total > 0 ? Math.round((failed / total) * 10000) / 100 : 0,
-      uptimePct: total > 0 ? Math.round(((total - failed) / total) * 10000) / 100 : 100,
+      errorRatePct: asPercentage(total > 0 ? Math.round((failed / total) * 10000) / 100 : 0),
+      uptimePct: asPercentage(total > 0 ? Math.round(((total - failed) / total) * 10000) / 100 : 100),
       totalQueries: total,
       failedQueries: failed,
       lastQueryAt: r?.last_query_at ?? null,

--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -634,7 +634,7 @@ export function createApiTestMocks(
   mock.module("@atlas/api/lib/security/abuse", () => ({
     listFlaggedWorkspaces: mock(() => []),
     reinstateWorkspace: mock(() => true),
-    getAbuseEvents: mock(async () => []),
+    getAbuseEvents: mock(async () => ({ events: [], status: "ok" })),
     getAbuseConfig: mock(() => ({
       queryRateLimit: 200,
       queryRateWindowSeconds: 300,

--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -24,6 +24,7 @@
 
 import { mock, type Mock } from "bun:test";
 import { Context, Effect, Layer } from "effect";
+import { asRatio } from "@useatlas/types";
 import {
   createConnectionMock,
   type ConnectionMockOverrides,
@@ -635,10 +636,12 @@ export function createApiTestMocks(
     listFlaggedWorkspaces: mock(() => []),
     reinstateWorkspace: mock(() => true),
     getAbuseEvents: mock(async () => ({ events: [], status: "ok" })),
+    // `asRatio` brands the config value (#1685) — the real `getAbuseConfig`
+    // does the same at its env-var boundary, so the mock shape matches.
     getAbuseConfig: mock(() => ({
       queryRateLimit: 200,
       queryRateWindowSeconds: 300,
-      errorRateThreshold: 0.5,
+      errorRateThreshold: asRatio(0.5),
       uniqueTablesLimit: 50,
       throttleDelayMs: 2000,
     })),

--- a/packages/api/src/api/__tests__/admin-abuse.test.ts
+++ b/packages/api/src/api/__tests__/admin-abuse.test.ts
@@ -34,7 +34,9 @@ const mocks = createApiTestMocks({
 
 const mockListFlagged: Mock<() => unknown[]> = mock(() => []);
 const mockReinstateWorkspace: Mock<(wsId: string, actorId: string) => boolean> = mock(() => true);
-const mockGetAbuseEvents: Mock<(wsId: string, limit?: number) => Promise<unknown[]>> = mock(async () => []);
+const mockGetAbuseEvents: Mock<
+  (wsId: string, limit?: number) => Promise<{ events: unknown[]; status: string }>
+> = mock(async () => ({ events: [], status: "ok" }));
 const mockGetAbuseConfig: Mock<() => unknown> = mock(() => ({
   queryRateLimit: 200,
   queryRateWindowSeconds: 300,
@@ -89,7 +91,7 @@ describe("Admin Abuse API", () => {
     );
     mockListFlagged.mockImplementation(() => []);
     mockReinstateWorkspace.mockImplementation(() => true);
-    mockGetAbuseEvents.mockImplementation(async () => []);
+    mockGetAbuseEvents.mockImplementation(async () => ({ events: [], status: "ok" }));
     mockGetWorkspaceNamesByIds.mockClear();
     mockGetWorkspaceNamesByIds.mockImplementation(async (ids) => {
       const m = new Map<string, string | null>();
@@ -272,6 +274,7 @@ describe("Admin Abuse API", () => {
           events: [],
         },
         priorInstances: [],
+        eventsStatus: "ok",
       }));
       const res = await app.fetch(
         adminRequest("GET", "/api/v1/admin/abuse/org-1/detail"),
@@ -280,6 +283,7 @@ describe("Admin Abuse API", () => {
       const body = await res.json() as Record<string, unknown>;
       expect(body.workspaceId).toBe("org-1");
       expect((body.counters as Record<string, unknown>).queryCount).toBe(250);
+      expect(body.eventsStatus).toBe("ok");
     });
 
     it("detail route falls back to null workspaceName when resolution rejects (#1640)", async () => {
@@ -294,6 +298,7 @@ describe("Admin Abuse API", () => {
         thresholds: { queryRateLimit: 200, queryRateWindowSeconds: 300, errorRateThreshold: 0.5, uniqueTablesLimit: 50, throttleDelayMs: 2000 },
         currentInstance: { startedAt: "2026-03-23T00:00:00.000Z", endedAt: null, peakLevel: "warning", events: [] },
         priorInstances: [],
+        eventsStatus: "ok",
       }));
       mockGetWorkspaceNamesByIds.mockImplementation(async () => {
         throw new Error("internal DB unreachable");
@@ -332,6 +337,7 @@ describe("Admin Abuse API", () => {
         },
         currentInstance: { startedAt: "2026-03-23T00:00:00.000Z", endedAt: null, peakLevel: "warning", events: [] },
         priorInstances: [],
+        eventsStatus: "ok",
       }));
       mockGetWorkspaceNamesByIds.mockImplementation(async (ids) => {
         const m = new Map<string, string | null>();
@@ -345,6 +351,33 @@ describe("Admin Abuse API", () => {
       const body = await res.json() as { workspaceName: string | null; workspaceId: string };
       expect(body.workspaceName).toBe("Acme Corp");
       expect(body.workspaceId).toBe("org-1");
+    });
+
+    it("propagates eventsStatus='load_failed' through the detail route (#1682)", async () => {
+      // The diagnostic channel must reach the wire so the UI can render a
+      // destructive banner instead of the benign empty-history copy when
+      // the audit trail is unreachable.
+      mockGetAbuseDetail.mockImplementation(async () => ({
+        workspaceId: "org-1",
+        workspaceName: null,
+        level: "warning",
+        trigger: "query_rate",
+        message: "was flagged",
+        updatedAt: "2026-03-23T00:00:00.000Z",
+        counters: { queryCount: 201, errorCount: 0, errorRatePct: 0, uniqueTablesAccessed: 0, escalations: 1 },
+        thresholds: { queryRateLimit: 200, queryRateWindowSeconds: 300, errorRateThreshold: 0.5, uniqueTablesLimit: 50, throttleDelayMs: 2000 },
+        currentInstance: { startedAt: "", endedAt: null, peakLevel: "none", events: [] },
+        priorInstances: [],
+        eventsStatus: "load_failed",
+      }));
+      const res = await app.fetch(
+        adminRequest("GET", "/api/v1/admin/abuse/org-1/detail"),
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json() as { eventsStatus: string; counters: Record<string, unknown> };
+      expect(body.eventsStatus).toBe("load_failed");
+      // Counters still render — the banner sits alongside live state, not instead of it.
+      expect(body.counters.queryCount).toBe(201);
     });
 
     it("returns 404 when workspace is not flagged", async () => {

--- a/packages/api/src/api/__tests__/admin-abuse.test.ts
+++ b/packages/api/src/api/__tests__/admin-abuse.test.ts
@@ -14,6 +14,8 @@ import {
   type Mock,
 } from "bun:test";
 import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+import type { AbuseDetail } from "@useatlas/types";
+import { createAbuseInstance } from "@atlas/api/lib/security/abuse-instances";
 
 // --- Unified mocks ---
 
@@ -44,7 +46,10 @@ const mockGetAbuseConfig: Mock<() => unknown> = mock(() => ({
   uniqueTablesLimit: 50,
   throttleDelayMs: 2000,
 }));
-const mockGetAbuseDetail: Mock<(wsId: string) => Promise<unknown | null>> = mock(async () => null);
+// Typed `AbuseDetail | null` so hand-rolling the nested `AbuseInstance`
+// shape inline fails typecheck (#1684). Fixtures that want a current or
+// prior instance must go through `createAbuseInstance`.
+const mockGetAbuseDetail: Mock<(wsId: string) => Promise<AbuseDetail | null>> = mock(async () => null);
 
 mock.module("@atlas/api/lib/security/abuse", () => ({
   listFlaggedWorkspaces: mockListFlagged,
@@ -267,12 +272,7 @@ describe("Admin Abuse API", () => {
           uniqueTablesLimit: 50,
           throttleDelayMs: 2000,
         },
-        currentInstance: {
-          startedAt: "2026-03-23T00:00:00.000Z",
-          endedAt: null,
-          peakLevel: "warning",
-          events: [],
-        },
+        currentInstance: createAbuseInstance([]),
         priorInstances: [],
         eventsStatus: "ok",
       }));
@@ -296,7 +296,7 @@ describe("Admin Abuse API", () => {
         updatedAt: "2026-03-23T00:00:00.000Z",
         counters: { queryCount: 1, errorCount: 0, errorRatePct: null, uniqueTablesAccessed: 0, escalations: 0 },
         thresholds: { queryRateLimit: 200, queryRateWindowSeconds: 300, errorRateThreshold: 0.5, uniqueTablesLimit: 50, throttleDelayMs: 2000 },
-        currentInstance: { startedAt: "2026-03-23T00:00:00.000Z", endedAt: null, peakLevel: "warning", events: [] },
+        currentInstance: createAbuseInstance([]),
         priorInstances: [],
         eventsStatus: "ok",
       }));
@@ -335,7 +335,7 @@ describe("Admin Abuse API", () => {
           uniqueTablesLimit: 50,
           throttleDelayMs: 2000,
         },
-        currentInstance: { startedAt: "2026-03-23T00:00:00.000Z", endedAt: null, peakLevel: "warning", events: [] },
+        currentInstance: createAbuseInstance([]),
         priorInstances: [],
         eventsStatus: "ok",
       }));
@@ -366,7 +366,7 @@ describe("Admin Abuse API", () => {
         updatedAt: "2026-03-23T00:00:00.000Z",
         counters: { queryCount: 201, errorCount: 0, errorRatePct: 0, uniqueTablesAccessed: 0, escalations: 1 },
         thresholds: { queryRateLimit: 200, queryRateWindowSeconds: 300, errorRateThreshold: 0.5, uniqueTablesLimit: 50, throttleDelayMs: 2000 },
-        currentInstance: { startedAt: "", endedAt: null, peakLevel: "none", events: [] },
+        currentInstance: createAbuseInstance([]),
         priorInstances: [],
         eventsStatus: "load_failed",
       }));

--- a/packages/api/src/api/__tests__/admin-abuse.test.ts
+++ b/packages/api/src/api/__tests__/admin-abuse.test.ts
@@ -15,6 +15,7 @@ import {
 } from "bun:test";
 import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
 import type { AbuseDetail } from "@useatlas/types";
+import { asPercentage, asRatio } from "@useatlas/types";
 import { createAbuseInstance } from "@atlas/api/lib/security/abuse-instances";
 
 // --- Unified mocks ---
@@ -261,14 +262,14 @@ describe("Admin Abuse API", () => {
         counters: {
           queryCount: 250,
           errorCount: 0,
-          errorRatePct: 0,
+          errorRatePct: asPercentage(0),
           uniqueTablesAccessed: 3,
           escalations: 1,
         },
         thresholds: {
           queryRateLimit: 200,
           queryRateWindowSeconds: 300,
-          errorRateThreshold: 0.5,
+          errorRateThreshold: asRatio(0.5),
           uniqueTablesLimit: 50,
           throttleDelayMs: 2000,
         },
@@ -295,7 +296,7 @@ describe("Admin Abuse API", () => {
         message: "boom",
         updatedAt: "2026-03-23T00:00:00.000Z",
         counters: { queryCount: 1, errorCount: 0, errorRatePct: null, uniqueTablesAccessed: 0, escalations: 0 },
-        thresholds: { queryRateLimit: 200, queryRateWindowSeconds: 300, errorRateThreshold: 0.5, uniqueTablesLimit: 50, throttleDelayMs: 2000 },
+        thresholds: { queryRateLimit: 200, queryRateWindowSeconds: 300, errorRateThreshold: asRatio(0.5), uniqueTablesLimit: 50, throttleDelayMs: 2000 },
         currentInstance: createAbuseInstance([]),
         priorInstances: [],
         eventsStatus: "ok",
@@ -331,7 +332,7 @@ describe("Admin Abuse API", () => {
         thresholds: {
           queryRateLimit: 200,
           queryRateWindowSeconds: 300,
-          errorRateThreshold: 0.5,
+          errorRateThreshold: asRatio(0.5),
           uniqueTablesLimit: 50,
           throttleDelayMs: 2000,
         },
@@ -364,8 +365,8 @@ describe("Admin Abuse API", () => {
         trigger: "query_rate",
         message: "was flagged",
         updatedAt: "2026-03-23T00:00:00.000Z",
-        counters: { queryCount: 201, errorCount: 0, errorRatePct: 0, uniqueTablesAccessed: 0, escalations: 1 },
-        thresholds: { queryRateLimit: 200, queryRateWindowSeconds: 300, errorRateThreshold: 0.5, uniqueTablesLimit: 50, throttleDelayMs: 2000 },
+        counters: { queryCount: 201, errorCount: 0, errorRatePct: asPercentage(0), uniqueTablesAccessed: 0, escalations: 1 },
+        thresholds: { queryRateLimit: 200, queryRateWindowSeconds: 300, errorRateThreshold: asRatio(0.5), uniqueTablesLimit: 50, throttleDelayMs: 2000 },
         currentInstance: createAbuseInstance([]),
         priorInstances: [],
         eventsStatus: "load_failed",

--- a/packages/api/src/api/routes/admin-abuse.ts
+++ b/packages/api/src/api/routes/admin-abuse.ts
@@ -224,15 +224,24 @@ adminAbuse.openapi(listFlaggedRoute, async (c) => {
           return new Map<string, string | null>();
         }),
       ]);
-      return workspaces.map((ws, i) => ({
-        ...ws,
-        workspaceName: names.get(ws.workspaceId) ?? null,
-        // List endpoint ignores the per-workspace events status — the list
-        // view only displays recent events to hint at context. The detail
-        // endpoint surfaces `eventsStatus` where operators actually make
-        // reinstate decisions.
-        events: eventResults[i]!.events,
-      }));
+      return workspaces.map((ws, i) => {
+        // Promise.all preserves order, so `eventResults[i]` always exists —
+        // but optional chaining + nullish fallback is the CLAUDE.md-preferred
+        // shape ("minimize non-null assertions") and it also gracefully
+        // degrades if a future refactor changes the upstream shape.
+        const result = eventResults[i] ?? { events: [], status: "load_failed" as const };
+        return {
+          ...ws,
+          workspaceName: names.get(ws.workspaceId) ?? null,
+          // Surface the per-workspace load status on the list row too — a
+          // future list consumer that filters / sorts by "has history"
+          // now has an explicit signal instead of inferring from an
+          // empty `events` array, which would reintroduce the #1682 bug
+          // class at the list boundary.
+          events: result.events,
+          eventsStatus: result.status,
+        };
+      });
     });
 
     return c.json({ workspaces: enriched, total: enriched.length }, 200);

--- a/packages/api/src/api/routes/admin-abuse.ts
+++ b/packages/api/src/api/routes/admin-abuse.ts
@@ -205,7 +205,7 @@ adminAbuse.openapi(listFlaggedRoute, async (c) => {
     // batch fetch to avoid N+1; missing/deleted orgs fall back to null.
     const enriched = yield* Effect.promise(async () => {
       const orgIds = workspaces.map((ws) => ws.workspaceId);
-      const [events, names] = await Promise.all([
+      const [eventResults, names] = await Promise.all([
         Promise.all(workspaces.map((ws) => getAbuseEvents(ws.workspaceId, 10))),
         getWorkspaceNamesByIds(orgIds).catch((err) => {
           // Name resolution is advisory — if the DB hiccups, fall back to
@@ -227,7 +227,11 @@ adminAbuse.openapi(listFlaggedRoute, async (c) => {
       return workspaces.map((ws, i) => ({
         ...ws,
         workspaceName: names.get(ws.workspaceId) ?? null,
-        events: events[i],
+        // List endpoint ignores the per-workspace events status — the list
+        // view only displays recent events to hint at context. The detail
+        // endpoint surfaces `eventsStatus` where operators actually make
+        // reinstate decisions.
+        events: eventResults[i]!.events,
       }));
     });
 

--- a/packages/api/src/api/routes/platform-sla.ts
+++ b/packages/api/src/api/routes/platform-sla.ts
@@ -25,6 +25,7 @@ import {
 import {
   SLA_ALERT_STATUSES,
   SLA_ALERT_TYPES,
+  asPercentage,
 } from "@useatlas/types";
 import { ErrorSchema, AuthErrorSchema, parsePagination } from "./shared-schemas";
 import { createPlatformRouter } from "./admin-router";
@@ -328,7 +329,13 @@ platformSLA.openapi(updateThresholdsRoute, async (c) => {
     const body = c.req.valid("json");
 
     const oldThresholds = yield* sla.getThresholds();
-    yield* sla.updateThresholds(body);
+    // `body.errorRatePct` is a plain number from Zod-validated request; the
+    // service expects branded `Percentage` (#1685). `asPercentage` brands
+    // the wire value at the route boundary without changing it.
+    yield* sla.updateThresholds({
+      latencyP99Ms: body.latencyP99Ms,
+      errorRatePct: asPercentage(body.errorRatePct),
+    });
     log.info({ thresholds: body, requestId }, "SLA thresholds updated by platform admin");
 
     logAdminAction({

--- a/packages/api/src/lib/security/__tests__/abuse-instances.test.ts
+++ b/packages/api/src/lib/security/__tests__/abuse-instances.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from "bun:test";
-import type { AbuseEvent } from "@useatlas/types";
+import type { AbuseEvent, AbuseInstance } from "@useatlas/types";
 import {
   createAbuseInstance,
   errorRatePct,
@@ -271,7 +271,11 @@ describe("errorRatePct", () => {
 describe("createAbuseInstance", () => {
   it("returns the empty-instance shape when events are empty", () => {
     const inst = createAbuseInstance([]);
-    expect(inst).toEqual({
+    // `toMatchObject` — the branded AbuseInstance's phantom symbol key
+    // prevents `toEqual` against a plain object literal from typechecking
+    // (#1684). The fields we care about are pinned below; the brand is
+    // itself a compile-time invariant, not a runtime assertion.
+    expect(inst).toMatchObject({
       startedAt: "",
       endedAt: null,
       peakLevel: "none",
@@ -374,5 +378,32 @@ describe("createAbuseInstance", () => {
     // And startedAt follows events[0] even when it's the newest — this is
     // the "garbage in, garbage out" contract the docstring flags.
     expect(inst.startedAt).toBe("2026-04-19T10:10:00Z");
+  });
+
+  // Nominal brand enforcement (#1684) — the phantom `unique symbol` in
+  // `@useatlas/types/abuse.ts` makes hand-rolled object literals fail
+  // typecheck. `@ts-expect-error` is the regression guard: if a future
+  // refactor relaxes the brand back to a structural interface, the lines
+  // below will type-check and the directives will fail the build, flagging
+  // the regression. Runtime assertions are irrelevant — this is a purely
+  // compile-time invariant — but the test harness still evaluates the
+  // expressions so TS sees them.
+  it("rejects hand-rolled AbuseInstance literals at the type layer", () => {
+    // @ts-expect-error hand-rolled shape must not satisfy AbuseInstance — use createAbuseInstance
+    const handRolled: AbuseInstance = {
+      startedAt: "2026-04-19T10:00:00Z",
+      endedAt: null,
+      peakLevel: "warning",
+      events: [],
+    };
+    expect(handRolled).toBeTruthy();
+  });
+
+  it("accepts AbuseInstance values minted via the factory", () => {
+    // Positive control: the factory's localized `as AbuseInstance` cast is
+    // what allows this assignment. If this starts failing while the
+    // hand-rolled test above starts passing, the brand is broken.
+    const fromFactory: AbuseInstance = createAbuseInstance([]);
+    expect(fromFactory.peakLevel).toBe("none");
   });
 });

--- a/packages/api/src/lib/security/__tests__/abuse-instances.test.ts
+++ b/packages/api/src/lib/security/__tests__/abuse-instances.test.ts
@@ -195,46 +195,51 @@ describe("splitIntoInstances", () => {
 // engine's own check still escalated on the unrounded fraction.
 // ---------------------------------------------------------------------------
 
+// `errorRatePct` returns a branded `Percentage` (#1685). `.toBe` with a
+// plain number literal fails typecheck because the brand is nominally
+// distinct; the tests below use `toBe<number>(literal)` to assert runtime
+// numeric equality while leaving the compile-time brand intact. The brand
+// itself is pinned separately in `packages/types/src/__tests__/percentage.test.ts`.
 describe("errorRatePct", () => {
   it("returns 0 when totalCount is 0 (no baseline, avoids NaN)", () => {
-    expect(errorRatePct(0, 0)).toBe(0);
+    expect(errorRatePct(0, 0)).toBe<number>(0);
   });
 
   it("returns 0 when errorCount is 0 with a real baseline", () => {
-    expect(errorRatePct(0, 50)).toBe(0);
+    expect(errorRatePct(0, 50)).toBe<number>(0);
   });
 
   it("rounds a normal case to 2 decimal places", () => {
     // 1/3 * 100 = 33.333… → 33.33
-    expect(errorRatePct(1, 3)).toBe(33.33);
+    expect(errorRatePct(1, 3)).toBe<number>(33.33);
     // 2/3 * 100 = 66.666… → 66.67
-    expect(errorRatePct(2, 3)).toBe(66.67);
+    expect(errorRatePct(2, 3)).toBe<number>(66.67);
   });
 
   it("preserves threshold-boundary precision at the 2nd decimal", () => {
     // Guards the detail-panel "over threshold" boundary: with default
     // errorRateThreshold=0.5 (50%), a real rate of 50.04% (5004 / 10000)
-    // must serialize as > 50 so `counters.errorRatePct / 100 > 0.5` is true.
+    // must serialize as > 50 so the comparison against 0.5 stays true.
     // 1-decimal rounding silently flipped this flag off.
-    expect(errorRatePct(5004, 10000)).toBe(50.04);
+    expect(errorRatePct(5004, 10000)).toBe<number>(50.04);
     expect(errorRatePct(5004, 10000) / 100 > 0.5).toBe(true);
   });
 
   it("returns 100 for a fully-errored baseline", () => {
-    expect(errorRatePct(10, 10)).toBe(100);
+    expect(errorRatePct(10, 10)).toBe<number>(100);
   });
 
   it("clamps to 100 when errorCount exceeds totalCount (caller bug guard)", () => {
     // errorCount > totalCount is a caller bug — surfacing 150% would mislead
     // the admin more than capping at 100%.
-    expect(errorRatePct(15, 10)).toBe(100);
+    expect(errorRatePct(15, 10)).toBe<number>(100);
   });
 
   it("preserves precision for large counts", () => {
     // 1234 / 98765 ≈ 1.24943% → 1.25 (2-decimal)
-    expect(errorRatePct(1234, 98765)).toBe(1.25);
+    expect(errorRatePct(1234, 98765)).toBe<number>(1.25);
     // 12345 / 98765 ≈ 12.4994% → 12.5 (trailing zero collapsed by JS)
-    expect(errorRatePct(12345, 98765)).toBe(12.5);
+    expect(errorRatePct(12345, 98765)).toBe<number>(12.5);
   });
 
   it("throws on non-finite inputs (NaN, Infinity) rather than propagating NaN", () => {
@@ -252,7 +257,7 @@ describe("errorRatePct", () => {
   it("returns a finite number for the documented (5, 0) zero-denominator case", () => {
     const rate = errorRatePct(5, 0);
     expect(Number.isFinite(rate)).toBe(true);
-    expect(rate).toBe(0);
+    expect(rate).toBe<number>(0);
   });
 });
 

--- a/packages/api/src/lib/security/__tests__/abuse.test.ts
+++ b/packages/api/src/lib/security/__tests__/abuse.test.ts
@@ -391,6 +391,96 @@ describe("Abuse Prevention Engine", () => {
     });
   });
 
+  // ---------------------------------------------------------------------
+  // getAbuseEvents() poisoned-metadata row isolation (#1683)
+  //
+  // A single corrupt `abuse_events.metadata` value (truncated JSON, old
+  // schema) used to throw inside the row-map and get caught by the outer
+  // try/catch — wiping every valid row in the response as if the DB itself
+  // had failed. Per-row isolation narrows the blast radius: the bad row is
+  // coerced to an empty metadata object with a warn, the rest pass through.
+  // ---------------------------------------------------------------------
+
+  describe("getAbuseEvents() poisoned metadata", () => {
+    it("returns valid rows and skips the poisoned one", async () => {
+      setInternalDB(true);
+      setInternalQuery(async () => [
+        {
+          id: "clean-a",
+          workspace_id: "ws-mixed",
+          level: "warning",
+          trigger_type: "query_rate",
+          message: "ok",
+          metadata: '{"queryCount": 10}',
+          actor: "system",
+          created_at: "2026-04-19T10:00:00Z",
+        },
+        {
+          id: "poisoned-1",
+          workspace_id: "ws-mixed",
+          level: "warning",
+          trigger_type: "query_rate",
+          message: "bad metadata",
+          metadata: '{"unterminated',
+          actor: "system",
+          created_at: "2026-04-19T10:05:00Z",
+        },
+        {
+          id: "clean-b",
+          workspace_id: "ws-mixed",
+          level: "throttled",
+          trigger_type: "query_rate",
+          message: "ok",
+          metadata: '{"queryCount": 250}',
+          actor: "system",
+          created_at: "2026-04-19T10:10:00Z",
+        },
+      ]);
+
+      const events = await getAbuseEvents("ws-mixed", 50);
+
+      // All three rows survive — the poisoned one just gets an empty metadata.
+      expect(events).toHaveLength(3);
+      expect(events.map((e) => e.id)).toEqual([
+        "clean-a",
+        "poisoned-1",
+        "clean-b",
+      ]);
+      expect(events[0]!.metadata).toEqual({ queryCount: 10 });
+      expect(events[1]!.metadata).toEqual({});
+      expect(events[2]!.metadata).toEqual({ queryCount: 250 });
+
+      // One warn emitted, naming the bad row so the operator can chase it.
+      const corrupt = warnCalls.filter((c) =>
+        c.msg.includes("corrupt abuse_events.metadata"),
+      );
+      expect(corrupt).toHaveLength(1);
+      expect(corrupt[0]!.ctx.rowId).toBe("poisoned-1");
+    });
+
+    it("does not log a corrupt warn for rows whose metadata parses cleanly", async () => {
+      setInternalDB(true);
+      setInternalQuery(async () => [
+        {
+          id: "clean-1",
+          workspace_id: "ws-clean",
+          level: "warning",
+          trigger_type: "query_rate",
+          message: "ok",
+          metadata: '{"queryCount": 5}',
+          actor: "system",
+          created_at: "2026-04-19T10:00:00Z",
+        },
+      ]);
+
+      await getAbuseEvents("ws-clean", 10);
+
+      expect(
+        warnCalls.find((c) => c.msg.includes("corrupt abuse_events.metadata")),
+      ).toBeUndefined();
+    });
+  });
+
   describe("restoreAbuseState() fail-safe drift handling", () => {
     it("restores clean rows and skips drifted rows without leaking their level", async () => {
       setInternalDB(true);

--- a/packages/api/src/lib/security/__tests__/abuse.test.ts
+++ b/packages/api/src/lib/security/__tests__/abuse.test.ts
@@ -270,11 +270,12 @@ describe("Abuse Prevention Engine", () => {
         },
       ]);
 
-      const events = await getAbuseEvents("ws-drift", 10);
+      const { events, status } = await getAbuseEvents("ws-drift", 10);
 
+      expect(status).toBe("ok");
       expect(events.length).toBe(1);
-      expect(events[0].level).toBe("none");
-      expect(events[0].trigger).toBe("query_rate");
+      expect(events[0]!.level).toBe("none");
+      expect(events[0]!.trigger).toBe("query_rate");
 
       const drift = warnCalls.find((c) =>
         c.msg.includes("abuse event with drifted enum"),
@@ -299,11 +300,12 @@ describe("Abuse Prevention Engine", () => {
         },
       ]);
 
-      const events = await getAbuseEvents("ws-drift", 10);
+      const { events, status } = await getAbuseEvents("ws-drift", 10);
 
+      expect(status).toBe("ok");
       expect(events.length).toBe(1);
-      expect(events[0].level).toBe("warning");
-      expect(events[0].trigger).toBe("manual");
+      expect(events[0]!.level).toBe("warning");
+      expect(events[0]!.trigger).toBe("manual");
 
       const drift = warnCalls.find((c) =>
         c.msg.includes("abuse event with drifted enum"),
@@ -328,18 +330,18 @@ describe("Abuse Prevention Engine", () => {
         },
       ]);
 
-      const events = await getAbuseEvents("ws-drift", 10);
+      const { events } = await getAbuseEvents("ws-drift", 10);
 
-      expect(events[0].level).toBe("none");
-      expect(events[0].trigger).toBe("manual");
+      expect(events[0]!.level).toBe("none");
+      expect(events[0]!.trigger).toBe("manual");
 
       const drifts = warnCalls.filter((c) =>
         c.msg.includes("abuse event with drifted enum"),
       );
       expect(drifts.length).toBe(1);
-      expect(drifts[0].ctx.rowId).toBe("both-bad-1");
-      expect(drifts[0].ctx.rawLevel).toBe("Mystery");
-      expect(drifts[0].ctx.rawTrigger).toBe("bogus");
+      expect(drifts[0]!.ctx.rowId).toBe("both-bad-1");
+      expect(drifts[0]!.ctx.rawLevel).toBe("Mystery");
+      expect(drifts[0]!.ctx.rawTrigger).toBe("bogus");
     });
 
     it("coerces null / non-string enum values without throwing", async () => {
@@ -357,10 +359,10 @@ describe("Abuse Prevention Engine", () => {
         },
       ]);
 
-      const events = await getAbuseEvents("ws-drift", 10);
+      const { events } = await getAbuseEvents("ws-drift", 10);
 
-      expect(events[0].level).toBe("none");
-      expect(events[0].trigger).toBe("manual");
+      expect(events[0]!.level).toBe("none");
+      expect(events[0]!.trigger).toBe("manual");
       expect(
         warnCalls.find((c) => c.msg.includes("abuse event with drifted enum")),
       ).toBeDefined();
@@ -381,10 +383,10 @@ describe("Abuse Prevention Engine", () => {
         },
       ]);
 
-      const events = await getAbuseEvents("ws-clean", 10);
+      const { events } = await getAbuseEvents("ws-clean", 10);
 
-      expect(events[0].level).toBe("throttled");
-      expect(events[0].trigger).toBe("error_rate");
+      expect(events[0]!.level).toBe("throttled");
+      expect(events[0]!.trigger).toBe("error_rate");
       expect(
         warnCalls.find((c) => c.msg.includes("abuse event with drifted enum")),
       ).toBeUndefined();
@@ -437,9 +439,11 @@ describe("Abuse Prevention Engine", () => {
         },
       ]);
 
-      const events = await getAbuseEvents("ws-mixed", 50);
+      const { events, status } = await getAbuseEvents("ws-mixed", 50);
 
-      // All three rows survive — the poisoned one just gets an empty metadata.
+      // All three rows survive — the poisoned one just gets an empty
+      // metadata. Status stays "ok" because the query succeeded.
+      expect(status).toBe("ok");
       expect(events).toHaveLength(3);
       expect(events.map((e) => e.id)).toEqual([
         "clean-a",
@@ -478,6 +482,68 @@ describe("Abuse Prevention Engine", () => {
       expect(
         warnCalls.find((c) => c.msg.includes("corrupt abuse_events.metadata")),
       ).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // getAbuseEvents() diagnostic channel (#1682)
+  //
+  // Before the channel, a DB outage silently degraded events to [] — the
+  // detail panel then looked "this workspace has never been flagged" during
+  // a transient DB outage. These tests pin the three-state status so a
+  // future edit cannot collapse the states and bring the false-empty-
+  // history regression back.
+  // ---------------------------------------------------------------------
+
+  describe("getAbuseEvents() diagnostic status", () => {
+    it("returns status 'db_unavailable' when internal DB is not configured", async () => {
+      setInternalDB(false); // self-hosted without DATABASE_URL
+      let queryInvoked = false;
+      setInternalQuery(async () => {
+        queryInvoked = true;
+        return [];
+      });
+
+      const result = await getAbuseEvents("ws-any", 10);
+      expect(result.events).toEqual([]);
+      expect(result.status).toBe("db_unavailable");
+      expect(queryInvoked).toBe(false); // Short-circuits.
+    });
+
+    it("returns status 'load_failed' and warns when the DB query throws", async () => {
+      setInternalDB(true);
+      setInternalQuery(async () => {
+        throw new Error("simulated DB outage");
+      });
+
+      const { events, status } = await getAbuseEvents("ws-outage", 10);
+      expect(events).toEqual([]);
+      expect(status).toBe("load_failed");
+
+      // Loud by design — a silent [] used to be the bug.
+      expect(
+        warnCalls.find((c) => c.msg.includes("Failed to load abuse events")),
+      ).toBeDefined();
+    });
+
+    it("returns status 'ok' with a populated payload on a healthy read", async () => {
+      setInternalDB(true);
+      setInternalQuery(async () => [
+        {
+          id: "evt-ok",
+          workspace_id: "ws-ok",
+          level: "warning",
+          trigger_type: "query_rate",
+          message: "fine",
+          metadata: "{}",
+          actor: "system",
+          created_at: "2026-04-19T10:00:00Z",
+        },
+      ]);
+
+      const { events, status } = await getAbuseEvents("ws-ok", 10);
+      expect(status).toBe("ok");
+      expect(events).toHaveLength(1);
     });
   });
 
@@ -771,8 +837,12 @@ describe("Abuse Prevention Engine", () => {
       ]);
     });
 
-    it("degrades to empty events — not an exception — when the DB load fails", async () => {
-      // Flag the workspace so level != "none" and the detail path is taken.
+    it("surfaces eventsStatus='load_failed' on DB failure so the UI can warn (#1682)", async () => {
+      // Previously this test pinned a silent `events: []` fallback that
+      // was indistinguishable from "never flagged" in the UI. The
+      // diagnostic channel lets the admin detail panel render a
+      // destructive banner instead of false-empty history, so the
+      // invariant to pin is now the status tag.
       const config = getAbuseConfig();
       for (let i = 0; i <= config.queryRateLimit; i++) {
         recordQueryEvent("ws-dbfail", { success: true });
@@ -788,17 +858,61 @@ describe("Abuse Prevention Engine", () => {
       if (!detail) return;
 
       // The admin panel stays useful: in-memory counters render even when
-      // the audit trail is momentarily unreachable. Events fall back to [].
+      // the audit trail is momentarily unreachable.
+      expect(detail.counters.queryCount).toBe(config.queryRateLimit + 1);
+      // But the events payload is explicitly tagged as degraded — the UI
+      // treats this differently from an empty history.
+      expect(detail.eventsStatus).toBe("load_failed");
       expect(detail.currentInstance.events).toEqual([]);
       expect(detail.priorInstances).toEqual([]);
-      expect(detail.counters.queryCount).toBe(config.queryRateLimit + 1);
 
-      // A warn line was emitted — we don't swallow silently.
+      // Loud log line corroborates the status so ops can correlate.
       expect(
         warnCalls.find((c) =>
           c.msg.includes("Failed to load abuse events"),
         ),
       ).toBeDefined();
+    });
+
+    it("tags eventsStatus='ok' on a successful read (pins the happy-path signal)", async () => {
+      // Same workspace-flagged setup as the load_failed test, but the DB
+      // returns clean. The status must NOT collapse to the degraded value
+      // when there simply are no events yet.
+      const config = getAbuseConfig();
+      for (let i = 0; i <= config.queryRateLimit; i++) {
+        recordQueryEvent("ws-clean", { success: true });
+      }
+
+      setInternalDB(true);
+      setInternalQuery(async () => []);
+
+      const detail = await getAbuseDetail("ws-clean");
+      expect(detail).not.toBeNull();
+      if (!detail) return;
+
+      expect(detail.eventsStatus).toBe("ok");
+      // Empty history on status=ok is the benign "really never flagged" case.
+      expect(detail.currentInstance.events).toEqual([]);
+      expect(detail.priorInstances).toEqual([]);
+    });
+
+    it("tags eventsStatus='db_unavailable' on a self-hosted deploy without DATABASE_URL", async () => {
+      const config = getAbuseConfig();
+      for (let i = 0; i <= config.queryRateLimit; i++) {
+        recordQueryEvent("ws-selfhost", { success: true });
+      }
+
+      // hasInternalDB() false — the common no-DATABASE_URL case. The
+      // status tells the UI this is expected, not a DB outage.
+      setInternalDB(false);
+
+      const detail = await getAbuseDetail("ws-selfhost");
+      expect(detail).not.toBeNull();
+      if (!detail) return;
+
+      expect(detail.eventsStatus).toBe("db_unavailable");
+      expect(detail.currentInstance.events).toEqual([]);
+      expect(detail.priorInstances).toEqual([]);
     });
   });
 

--- a/packages/api/src/lib/security/__tests__/abuse.test.ts
+++ b/packages/api/src/lib/security/__tests__/abuse.test.ts
@@ -87,7 +87,7 @@ describe("Abuse Prevention Engine", () => {
       const config = getAbuseConfig();
       expect(config.queryRateLimit).toBe(200);
       expect(config.queryRateWindowSeconds).toBe(300);
-      expect(config.errorRateThreshold).toBe(0.5);
+      expect(config.errorRateThreshold).toBe<number>(0.5);
       expect(config.uniqueTablesLimit).toBe(50);
       expect(config.throttleDelayMs).toBe(2000);
     });
@@ -705,7 +705,7 @@ describe("Abuse Prevention Engine", () => {
       // Counters mirror the real in-memory window — 201 queries, 0 errors, 5 tables.
       expect(detail.counters.queryCount).toBe(config.queryRateLimit + 1);
       expect(detail.counters.errorCount).toBe(0);
-      expect(detail.counters.errorRatePct).toBe(0); // baseline met, all succeeded
+      expect(detail.counters.errorRatePct).toBe<number>(0); // baseline met, all succeeded (branded Percentage, #1685)
       expect(detail.counters.uniqueTablesAccessed).toBe(5);
       // escalate() bumps `escalations` on every call while over threshold —
       // first breach transitions to warning, subsequent bumps keep going.

--- a/packages/api/src/lib/security/abuse-instances.ts
+++ b/packages/api/src/lib/security/abuse-instances.ts
@@ -20,7 +20,7 @@
  *      preserve threshold-comparison precision at the 0.01% level.
  */
 
-import type { AbuseEvent, AbuseInstance, AbuseLevel } from "@useatlas/types";
+import { asPercentage, type AbuseEvent, type AbuseInstance, type AbuseLevel, type Percentage } from "@useatlas/types";
 
 const LEVEL_RANK: Record<AbuseLevel, number> = {
   none: 0,
@@ -100,7 +100,7 @@ export function createAbuseInstance(eventsChrono: readonly AbuseEvent[]): AbuseI
  * caller bug, but surfacing e.g. 150% would mislead the admin more than
  * displaying 100% does.
  */
-export function errorRatePct(errorCount: number, totalCount: number): number {
+export function errorRatePct(errorCount: number, totalCount: number): Percentage {
   if (!Number.isFinite(errorCount) || !Number.isFinite(totalCount)) {
     throw new Error(
       `errorRatePct: non-finite input (errorCount=${errorCount}, totalCount=${totalCount})`,
@@ -111,9 +111,9 @@ export function errorRatePct(errorCount: number, totalCount: number): number {
       `errorRatePct: negative input (errorCount=${errorCount}, totalCount=${totalCount})`,
     );
   }
-  if (totalCount === 0) return 0;
+  if (totalCount === 0) return asPercentage(0);
   const raw = (errorCount / totalCount) * 100;
-  return Math.min(100, Math.round(raw * 100) / 100);
+  return asPercentage(Math.min(100, Math.round(raw * 100) / 100));
 }
 
 /**

--- a/packages/api/src/lib/security/abuse-instances.ts
+++ b/packages/api/src/lib/security/abuse-instances.ts
@@ -8,10 +8,11 @@
  *      Encodes the invariants (peakLevel is the max of event levels, endedAt
  *      non-null iff the last event is a manual "none" reinstatement, empty
  *      events → sentinel shape) so production callers go through one place
- *      rather than hand-rolling a mismatched object. Note: `AbuseInstance`
- *      is a structurally-typed interface, so the factory is an *advisory*
- *      boundary — tests and wire-format parsers can still produce the shape
- *      directly.
+ *      rather than hand-rolling a mismatched object. `AbuseInstance` is now
+ *      nominally branded (#1684), so the factory is the only in-tree call
+ *      site that can mint the type — the localized `as AbuseInstance` cast
+ *      below is what grants it that authority. Tests that want an
+ *      `AbuseInstance` for a fixture must also go through the factory.
  *   2. `splitIntoInstances` — groups a workspace's event stream into the
  *      current (open) instance plus prior closed instances.
  *   3. `errorRatePct` — the counter arithmetic the detail panel needs for
@@ -52,9 +53,13 @@ function isReinstatement(e: AbuseEvent): boolean {
  * will then be the newest rather than oldest timestamp — the factory does
  * not sort for the caller.
  */
-export function createAbuseInstance(eventsChrono: AbuseEvent[]): AbuseInstance {
+export function createAbuseInstance(eventsChrono: readonly AbuseEvent[]): AbuseInstance {
   if (eventsChrono.length === 0) {
-    return { startedAt: "", endedAt: null, peakLevel: "none", events: [] };
+    // Localized `as AbuseInstance` cast: the brand is a phantom `never`
+    // symbol key that no plain object literal can provide. The factory's
+    // contract (invariants above) is what gives this cast its authority;
+    // external callers cannot reproduce it without going through here.
+    return { startedAt: "", endedAt: null, peakLevel: "none", events: [] } as unknown as AbuseInstance;
   }
   const last = eventsChrono[eventsChrono.length - 1]!;
   const endedAt = isReinstatement(last) ? last.createdAt : null;
@@ -67,7 +72,7 @@ export function createAbuseInstance(eventsChrono: AbuseEvent[]): AbuseInstance {
     endedAt,
     peakLevel: peak,
     events: eventsChrono,
-  };
+  } as unknown as AbuseInstance;
 }
 
 /**
@@ -119,7 +124,7 @@ export function errorRatePct(errorCount: number, totalCount: number): number {
  * @param priorLimit Max number of prior instances to return (newest-first).
  */
 export function splitIntoInstances(
-  events: AbuseEvent[],
+  events: readonly AbuseEvent[],
   priorLimit: number,
 ): { currentInstance: AbuseInstance; priorInstances: AbuseInstance[] } {
   // Flip to chronological so a forward walk can close instances on

--- a/packages/api/src/lib/security/abuse-instances.ts
+++ b/packages/api/src/lib/security/abuse-instances.ts
@@ -58,7 +58,9 @@ export function createAbuseInstance(eventsChrono: readonly AbuseEvent[]): AbuseI
     // Localized `as AbuseInstance` cast: the brand is a phantom `never`
     // symbol key that no plain object literal can provide. The factory's
     // contract (invariants above) is what gives this cast its authority;
-    // external callers cannot reproduce it without going through here.
+    // the convention is that no other module adds an `as unknown as
+    // AbuseInstance` cast, enforced by code review + the `@ts-expect-error`
+    // regression test in abuse-instances.test.ts.
     return { startedAt: "", endedAt: null, peakLevel: "none", events: [] } as unknown as AbuseInstance;
   }
   const last = eventsChrono[eventsChrono.length - 1]!;

--- a/packages/api/src/lib/security/abuse.ts
+++ b/packages/api/src/lib/security/abuse.ts
@@ -480,6 +480,26 @@ export async function getAbuseEvents(
     );
 
     return rows.map((r) => {
+      // Per-row try/catch: a single truncated-JSON / old-schema row must not
+      // take out the remaining 49 valid rows by bubbling into the outer catch
+      // where the indistinguishable "DB outage" path returns []. Mirrors the
+      // coerceAbuseEnums pattern used above for level + trigger drift.
+      let metadata: Record<string, unknown> = {};
+      if (typeof r.metadata === "string") {
+        try {
+          metadata = JSON.parse(r.metadata) as Record<string, unknown>;
+        } catch (err) {
+          log.warn(
+            {
+              rowId: r.id,
+              err: err instanceof Error ? err.message : String(err),
+            },
+            "corrupt abuse_events.metadata — using empty object",
+          );
+        }
+      } else if (r.metadata) {
+        metadata = r.metadata as Record<string, unknown>;
+      }
       const { level, trigger } = coerceAbuseEnums(r.id, r.level, r.trigger_type);
       return {
         id: r.id,
@@ -487,7 +507,7 @@ export async function getAbuseEvents(
         level,
         trigger,
         message: r.message,
-        metadata: typeof r.metadata === "string" ? JSON.parse(r.metadata) as Record<string, unknown> : (r.metadata as Record<string, unknown>),
+        metadata,
         createdAt: r.created_at,
         actor: r.actor,
       };

--- a/packages/api/src/lib/security/abuse.ts
+++ b/packages/api/src/lib/security/abuse.ts
@@ -18,7 +18,6 @@ import {
   ABUSE_LEVELS,
   ABUSE_TRIGGERS,
   asRatio,
-  percentageToRatio,
   type AbuseLevel,
   type AbuseTrigger,
   type AbuseEvent,

--- a/packages/api/src/lib/security/abuse.ts
+++ b/packages/api/src/lib/security/abuse.ts
@@ -20,6 +20,7 @@ import {
   type AbuseLevel,
   type AbuseTrigger,
   type AbuseEvent,
+  type AbuseEventsStatus,
   type AbuseStatus,
   type AbuseThresholdConfig,
   type AbuseDetail,
@@ -365,7 +366,7 @@ export async function getAbuseDetail(
   const errorRate =
     queryCount >= 10 ? errorRatePct(w.errorCount, queryCount) : null;
 
-  const events = await getAbuseEvents(workspaceId, eventLimit);
+  const { events, status: eventsStatus } = await getAbuseEvents(workspaceId, eventLimit);
   const { currentInstance, priorInstances } = splitIntoInstances(events, priorLimit);
 
   return {
@@ -385,6 +386,7 @@ export async function getAbuseDetail(
     thresholds: config,
     currentInstance,
     priorInstances,
+    eventsStatus,
   };
 }
 
@@ -453,12 +455,29 @@ function persistAbuseEvent(event: AbuseEvent): void {
   }
 }
 
-/** Load recent abuse events from DB for a workspace. */
+/**
+ * Load recent abuse events from DB for a workspace.
+ *
+ * Returns `{ events, status }` so callers can distinguish "really empty" from
+ * "DB unreachable" (#1682). Before the diagnostic channel, a DB failure
+ * silently produced `events: []` that `getAbuseDetail` passed through — an
+ * admin investigating a re-flagged workspace during a DB outage saw a clean
+ * slate and could reinstate a repeat offender based on the false empty
+ * history. Status values:
+ *
+ *   - `ok`             — query succeeded (empty is truly empty).
+ *   - `db_unavailable` — `hasInternalDB()` is false (self-hosted, no
+ *                        DATABASE_URL). Short-circuit, no query attempted.
+ *   - `load_failed`    — query threw. In-memory state is still valid; the
+ *                        audit trail is momentarily unreachable. UI must
+ *                        show a destructive banner so the operator does not
+ *                        conclude "never flagged."
+ */
 export async function getAbuseEvents(
   workspaceId: string,
   limit = 50,
-): Promise<AbuseEvent[]> {
-  if (!hasInternalDB()) return [];
+): Promise<{ events: AbuseEvent[]; status: AbuseEventsStatus }> {
+  if (!hasInternalDB()) return { events: [], status: "db_unavailable" };
 
   try {
     const rows = await internalQuery<{
@@ -479,7 +498,7 @@ export async function getAbuseEvents(
       [workspaceId, limit],
     );
 
-    return rows.map((r) => {
+    const events = rows.map((r) => {
       // Per-row try/catch: a single truncated-JSON / old-schema row must not
       // take out the remaining 49 valid rows by bubbling into the outer catch
       // where the indistinguishable "DB outage" path returns []. Mirrors the
@@ -512,12 +531,18 @@ export async function getAbuseEvents(
         actor: r.actor,
       };
     });
+
+    return { events, status: "ok" };
   } catch (err) {
+    // The .catch → [] fallback stays — in-memory counters + level in the
+    // detail payload are still worth rendering — but it is no longer silent:
+    // the `load_failed` status propagates to the UI's destructive banner so
+    // the operator treats the empty history as degraded, not benign.
     log.warn(
       { err: err instanceof Error ? err.message : String(err), workspaceId },
       "Failed to load abuse events",
     );
-    return [];
+    return { events: [], status: "load_failed" };
   }
 }
 

--- a/packages/api/src/lib/security/abuse.ts
+++ b/packages/api/src/lib/security/abuse.ts
@@ -452,8 +452,15 @@ function persistAbuseEvent(event: AbuseEvent): void {
       ],
     );
   } catch (err) {
+    // Include workspaceId + eventId so on-call can correlate the lost
+    // write with the workspace it was for, rather than blind-grepping the
+    // audit trail.
     log.warn(
-      { err: err instanceof Error ? err.message : String(err) },
+      {
+        err: err instanceof Error ? err.message : String(err),
+        workspaceId: event.workspaceId,
+        eventId: event.id,
+      },
       "Failed to persist abuse event",
     );
   }
@@ -510,7 +517,18 @@ export async function getAbuseEvents(
       let metadata: Record<string, unknown> = {};
       if (typeof r.metadata === "string") {
         try {
-          metadata = JSON.parse(r.metadata) as Record<string, unknown>;
+          const parsed = JSON.parse(r.metadata) as unknown;
+          if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+            metadata = parsed as Record<string, unknown>;
+          } else {
+            // Parsed cleanly but the value is a scalar or array — still a
+            // corrupt row from our schema's perspective. Warn + default to
+            // {} rather than pass an unusable shape to the UI.
+            log.warn(
+              { rowId: r.id, parsedType: Array.isArray(parsed) ? "array" : typeof parsed },
+              "unexpected abuse_events.metadata shape — using empty object",
+            );
+          }
         } catch (err) {
           log.warn(
             {
@@ -520,8 +538,15 @@ export async function getAbuseEvents(
             "corrupt abuse_events.metadata — using empty object",
           );
         }
-      } else if (r.metadata) {
+      } else if (r.metadata !== null && typeof r.metadata === "object" && !Array.isArray(r.metadata)) {
+        // Driver pre-parsed jsonb into a value. Only accept object shapes;
+        // arrays and scalars fall through to the empty default.
         metadata = r.metadata as Record<string, unknown>;
+      } else if (r.metadata !== null && r.metadata !== undefined) {
+        log.warn(
+          { rowId: r.id, valueType: Array.isArray(r.metadata) ? "array" : typeof r.metadata },
+          "unexpected abuse_events.metadata driver shape — using empty object",
+        );
       }
       const { level, trigger } = coerceAbuseEnums(r.id, r.level, r.trigger_type);
       return {

--- a/packages/api/src/lib/security/abuse.ts
+++ b/packages/api/src/lib/security/abuse.ts
@@ -17,6 +17,8 @@ import { hasInternalDB, internalExecute, internalQuery } from "@atlas/api/lib/db
 import {
   ABUSE_LEVELS,
   ABUSE_TRIGGERS,
+  asRatio,
+  percentageToRatio,
   type AbuseLevel,
   type AbuseTrigger,
   type AbuseEvent,
@@ -101,7 +103,10 @@ export function getAbuseConfig(): AbuseThresholdConfig {
   return {
     queryRateLimit: envInt("ATLAS_ABUSE_QUERY_RATE", 200),
     queryRateWindowSeconds: envInt("ATLAS_ABUSE_WINDOW_SECONDS", 300),
-    errorRateThreshold: envFloat("ATLAS_ABUSE_ERROR_RATE", 0.5),
+    // Env-var value is already a 0–1 fraction (e.g. ATLAS_ABUSE_ERROR_RATE=0.5);
+    // `asRatio` brands it so the cross-scale guard in `checkThresholds` +
+    // detail-panel comparisons type-checks (#1685).
+    errorRateThreshold: asRatio(envFloat("ATLAS_ABUSE_ERROR_RATE", 0.5)),
     uniqueTablesLimit: envInt("ATLAS_ABUSE_UNIQUE_TABLES", 50),
     throttleDelayMs: envInt("ATLAS_ABUSE_THROTTLE_DELAY_MS", 2000),
   };

--- a/packages/schemas/src/__tests__/abuse.test.ts
+++ b/packages/schemas/src/__tests__/abuse.test.ts
@@ -80,7 +80,11 @@ describe("happy-path parses", () => {
   });
 
   test("AbuseThresholdConfigSchema parses a valid config", () => {
-    expect(AbuseThresholdConfigSchema.parse(validThresholds)).toEqual(validThresholds);
+    // `.toMatchObject` — `errorRateThreshold` is branded `Ratio` on the
+    // parse output (#1685) but a plain number on the input literal, so
+    // structural `.toEqual` can't unify the two. Field equality is still
+    // pinned below.
+    expect(AbuseThresholdConfigSchema.parse(validThresholds)).toMatchObject(validThresholds);
   });
 
   test("AbuseCountersSchema accepts null errorRatePct (warmup)", () => {

--- a/packages/schemas/src/__tests__/abuse.test.ts
+++ b/packages/schemas/src/__tests__/abuse.test.ts
@@ -63,6 +63,7 @@ const validDetail = {
   thresholds: validThresholds,
   currentInstance: validInstance,
   priorInstances: [],
+  eventsStatus: "ok" as const,
 };
 
 // ---------------------------------------------------------------------------
@@ -156,5 +157,27 @@ describe("structural rejection", () => {
     // workspaceId is required on AbuseStatus; omitting it must fail parse.
     const { workspaceId: _workspaceId, ...missing } = validDetail;
     expect(AbuseDetailSchema.safeParse(missing).success).toBe(false);
+  });
+
+  // The diagnostic channel for DB-load failure (#1682) — operators need to
+  // distinguish "never flagged" from "history failed to load," so the
+  // schema tightens `eventsStatus` to the known tuple. A drifted value
+  // fails parse, and omitting the field entirely fails parse (the field is
+  // mandatory for every payload).
+  test("AbuseDetailSchema requires eventsStatus", () => {
+    const { eventsStatus: _eventsStatus, ...missing } = validDetail;
+    expect(AbuseDetailSchema.safeParse(missing).success).toBe(false);
+  });
+
+  test("AbuseDetailSchema rejects an unknown eventsStatus value", () => {
+    const drifted = { ...validDetail, eventsStatus: "partial" };
+    expect(AbuseDetailSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("AbuseDetailSchema accepts load_failed + db_unavailable as valid statuses", () => {
+    for (const status of ["ok", "load_failed", "db_unavailable"] as const) {
+      const parsed = AbuseDetailSchema.parse({ ...validDetail, eventsStatus: status });
+      expect(parsed.eventsStatus).toBe(status);
+    }
   });
 });

--- a/packages/schemas/src/__tests__/abuse.test.ts
+++ b/packages/schemas/src/__tests__/abuse.test.ts
@@ -89,11 +89,15 @@ describe("happy-path parses", () => {
   });
 
   test("AbuseInstanceSchema parses with null endedAt (open instance)", () => {
-    expect(AbuseInstanceSchema.parse(validInstance)).toEqual(validInstance);
+    // `.toMatchObject` — `AbuseInstance` is nominally branded (#1684), so
+    // `.toEqual(plainLiteral)` fails typecheck: the parsed output has a
+    // phantom symbol key that the literal does not. We still assert the
+    // wire fields pass through verbatim.
+    expect(AbuseInstanceSchema.parse(validInstance)).toMatchObject(validInstance);
   });
 
   test("AbuseDetailSchema parses a full detail payload", () => {
-    expect(AbuseDetailSchema.parse(validDetail)).toEqual(validDetail);
+    expect(AbuseDetailSchema.parse(validDetail)).toMatchObject(validDetail);
   });
 });
 

--- a/packages/schemas/src/abuse.ts
+++ b/packages/schemas/src/abuse.ts
@@ -81,12 +81,25 @@ export const AbuseCountersSchema = z.object({
   escalations: z.number(),
 }) satisfies z.ZodType<AbuseCounters>;
 
-export const AbuseInstanceSchema = z.object({
-  startedAt: z.string(),
-  endedAt: z.string().nullable(),
-  peakLevel: LevelEnum,
-  events: z.array(AbuseEventSchema),
-}) satisfies z.ZodType<AbuseInstance>;
+// `AbuseInstance` is nominally branded at the TS layer (#1684) so only the
+// factory + this parser may mint values. `.transform((v) => v as ...)` is
+// the wire-boundary cast: the Zod output type is a plain object, the
+// transformed output is the branded interface. `satisfies` keeps the
+// structural drift guard — a field rename in `@useatlas/types` still breaks
+// this file at compile time — while widening the Input generic to `unknown`
+// (the brand makes Input == Output impossible since we can't produce a
+// branded value to `.parse()` with).
+export const AbuseInstanceSchema = z
+  .object({
+    startedAt: z.string(),
+    endedAt: z.string().nullable(),
+    peakLevel: LevelEnum,
+    events: z.array(AbuseEventSchema),
+  })
+  .transform((v): AbuseInstance => v as unknown as AbuseInstance) satisfies z.ZodType<
+    AbuseInstance,
+    unknown
+  >;
 
 // Structurally mirrors `AbuseDetail extends Omit<AbuseStatus, "events">` —
 // using `.omit().extend()` keeps the identity fields coupled to

--- a/packages/schemas/src/abuse.ts
+++ b/packages/schemas/src/abuse.ts
@@ -31,6 +31,7 @@ import { z } from "zod";
 import {
   ABUSE_LEVELS,
   ABUSE_TRIGGERS,
+  ABUSE_EVENTS_STATUSES,
   type AbuseEvent,
   type AbuseStatus,
   type AbuseThresholdConfig,
@@ -41,6 +42,7 @@ import {
 
 const LevelEnum = z.enum(ABUSE_LEVELS);
 const TriggerEnum = z.enum(ABUSE_TRIGGERS);
+const EventsStatusEnum = z.enum(ABUSE_EVENTS_STATUSES);
 
 export const AbuseEventSchema = z.object({
   id: z.string(),
@@ -97,4 +99,5 @@ export const AbuseDetailSchema = AbuseStatusSchema.omit({ events: true }).extend
   thresholds: AbuseThresholdConfigSchema,
   currentInstance: AbuseInstanceSchema,
   priorInstances: z.array(AbuseInstanceSchema),
+  eventsStatus: EventsStatusEnum,
 }) satisfies z.ZodType<AbuseDetail>;

--- a/packages/schemas/src/abuse.ts
+++ b/packages/schemas/src/abuse.ts
@@ -67,28 +67,36 @@ export const AbuseStatusSchema = z.object({
   message: z.string().nullable(),
   updatedAt: z.string(),
   events: z.array(AbuseEventSchema),
+  // `eventsStatus` is optional on the wire so existing list consumers
+  // (pre-#1682) keep parsing; new consumers treat absent as "ok" — see the
+  // type comment on `AbuseStatus.eventsStatus`.
+  eventsStatus: EventsStatusEnum.optional(),
 }) satisfies z.ZodType<AbuseStatus>;
 
-// `errorRateThreshold` is branded `Ratio` (#1685). The Zod input is a plain
-// `number`; the `.transform` brands at the wire boundary so call sites
-// cannot accidentally pass an unbranded `number` in its place. `asRatio`
-// is a no-op at runtime (pure phantom type).
+// `errorRateThreshold` is branded `Ratio` (#1685). `z.number().min(0).max(1)`
+// enforces the 0–1 scale at the wire boundary — a drifted payload that
+// sneaks a percentage value into the ratio slot fails parse rather than
+// silently branding as a `Ratio` of 50 that would then compare wrong
+// against every `Percentage` the engine produces. `.transform` brands the
+// in-range value so call sites cannot substitute a raw `number`.
 export const AbuseThresholdConfigSchema = z.object({
   queryRateLimit: z.number(),
   queryRateWindowSeconds: z.number(),
-  errorRateThreshold: z.number().transform((n): Ratio => asRatio(n)),
+  errorRateThreshold: z.number().min(0).max(1).transform((n): Ratio => asRatio(n)),
   uniqueTablesLimit: z.number(),
   throttleDelayMs: z.number(),
 }) satisfies z.ZodType<AbuseThresholdConfig, unknown>;
 
-// `errorRatePct` is branded `Percentage` (#1685). Same wire-boundary cast
-// pattern as `errorRateThreshold` above; the `nullable` wrapper keeps the
+// `errorRatePct` is branded `Percentage` (#1685). Same wire-boundary range
+// + cast pattern as `errorRateThreshold` above; `.nullable()` keeps the
 // "baseline pending" null-pass-through for queryCount < 10.
 export const AbuseCountersSchema = z.object({
   queryCount: z.number(),
   errorCount: z.number(),
   errorRatePct: z
     .number()
+    .min(0)
+    .max(100)
     .transform((n): Percentage => asPercentage(n))
     .nullable(),
   uniqueTablesAccessed: z.number(),
@@ -97,12 +105,14 @@ export const AbuseCountersSchema = z.object({
 
 // `AbuseInstance` is nominally branded at the TS layer (#1684) so only the
 // factory + this parser may mint values. `.transform((v) => v as ...)` is
-// the wire-boundary cast: the Zod output type is a plain object, the
-// transformed output is the branded interface. `satisfies` keeps the
-// structural drift guard — a field rename in `@useatlas/types` still breaks
-// this file at compile time — while widening the Input generic to `unknown`
-// (the brand makes Input == Output impossible since we can't produce a
-// branded value to `.parse()` with).
+// the wire-boundary cast: the Zod object literal's Output is a plain
+// object, the `.transform` Output is the branded interface. `satisfies`
+// keeps the structural drift guard — a field rename in `@useatlas/types`
+// still breaks this file at compile time. Input is widened to `unknown`
+// because `.transform` produces a schema whose Input (what `.parse()`
+// accepts) differs from its Output (what `.parse()` returns); the
+// single-generic `z.ZodType<AbuseInstance>` collapses them into the same
+// type and rejects the transform.
 export const AbuseInstanceSchema = z
   .object({
     startedAt: z.string(),

--- a/packages/schemas/src/abuse.ts
+++ b/packages/schemas/src/abuse.ts
@@ -32,12 +32,16 @@ import {
   ABUSE_LEVELS,
   ABUSE_TRIGGERS,
   ABUSE_EVENTS_STATUSES,
+  asPercentage,
+  asRatio,
   type AbuseEvent,
   type AbuseStatus,
   type AbuseThresholdConfig,
   type AbuseDetail,
   type AbuseInstance,
   type AbuseCounters,
+  type Percentage,
+  type Ratio,
 } from "@useatlas/types";
 
 const LevelEnum = z.enum(ABUSE_LEVELS);
@@ -65,21 +69,31 @@ export const AbuseStatusSchema = z.object({
   events: z.array(AbuseEventSchema),
 }) satisfies z.ZodType<AbuseStatus>;
 
+// `errorRateThreshold` is branded `Ratio` (#1685). The Zod input is a plain
+// `number`; the `.transform` brands at the wire boundary so call sites
+// cannot accidentally pass an unbranded `number` in its place. `asRatio`
+// is a no-op at runtime (pure phantom type).
 export const AbuseThresholdConfigSchema = z.object({
   queryRateLimit: z.number(),
   queryRateWindowSeconds: z.number(),
-  errorRateThreshold: z.number(),
+  errorRateThreshold: z.number().transform((n): Ratio => asRatio(n)),
   uniqueTablesLimit: z.number(),
   throttleDelayMs: z.number(),
-}) satisfies z.ZodType<AbuseThresholdConfig>;
+}) satisfies z.ZodType<AbuseThresholdConfig, unknown>;
 
+// `errorRatePct` is branded `Percentage` (#1685). Same wire-boundary cast
+// pattern as `errorRateThreshold` above; the `nullable` wrapper keeps the
+// "baseline pending" null-pass-through for queryCount < 10.
 export const AbuseCountersSchema = z.object({
   queryCount: z.number(),
   errorCount: z.number(),
-  errorRatePct: z.number().nullable(),
+  errorRatePct: z
+    .number()
+    .transform((n): Percentage => asPercentage(n))
+    .nullable(),
   uniqueTablesAccessed: z.number(),
   escalations: z.number(),
-}) satisfies z.ZodType<AbuseCounters>;
+}) satisfies z.ZodType<AbuseCounters, unknown>;
 
 // `AbuseInstance` is nominally branded at the TS layer (#1684) so only the
 // factory + this parser may mint values. `.transform((v) => v as ...)` is

--- a/packages/types/src/__tests__/percentage.test.ts
+++ b/packages/types/src/__tests__/percentage.test.ts
@@ -64,6 +64,50 @@ describe("Percentage / Ratio runtime conversions", () => {
   });
 });
 
+// Runtime validation (#1685 follow-up from PR review): `asPercentage` and
+// `asRatio` used to be no-op casts. That left a real silent-failure path —
+// a corrupted DB column or a scale-drifted SQL aggregate could brand
+// nonsense values (150%, -50, NaN, Infinity) and feed them straight into
+// operator-facing gauges without warning. The constructors now validate
+// non-finite + range with a small tolerance for IEEE-754 slop.
+describe("asPercentage / asRatio runtime validation", () => {
+  test("asPercentage throws on NaN / Infinity", () => {
+    expect(() => asPercentage(NaN)).toThrow(/non-finite/);
+    expect(() => asPercentage(Infinity)).toThrow(/non-finite/);
+    expect(() => asPercentage(-Infinity)).toThrow(/non-finite/);
+  });
+
+  test("asPercentage throws on out-of-range inputs (scale mixup guard)", () => {
+    // `asPercentage(1.5)` is the exact scale mixup the brand exists to
+    // surface — a caller who confused Ratio and Percentage.
+    expect(() => asPercentage(150)).toThrow(/out of range/);
+    expect(() => asPercentage(-50)).toThrow(/out of range/);
+    expect(() => asPercentage(101)).toThrow(/out of range/);
+  });
+
+  test("asPercentage tolerates SQL rounding overshoot at the 100% boundary", () => {
+    // `ROUND(0.9999 * 100, 2)` sometimes produces 100.00000001 in IEEE-754.
+    // The tolerance must accept this without flagging a scale mixup.
+    expect(asPercentage(100.0001)).toBe<number>(100.0001);
+    expect(asPercentage(-0.0001)).toBe<number>(-0.0001);
+  });
+
+  test("asRatio throws on NaN / Infinity", () => {
+    expect(() => asRatio(NaN)).toThrow(/non-finite/);
+    expect(() => asRatio(Infinity)).toThrow(/non-finite/);
+  });
+
+  test("asRatio throws on out-of-range inputs (scale mixup guard)", () => {
+    expect(() => asRatio(1.5)).toThrow(/out of range/);
+    expect(() => asRatio(50)).toThrow(/out of range/);
+    expect(() => asRatio(-0.5)).toThrow(/out of range/);
+  });
+
+  test("asRatio tolerates tiny IEEE-754 overshoot at the 1.0 boundary", () => {
+    expect(asRatio(1.000001)).toBe<number>(1.000001);
+  });
+});
+
 describe("Percentage / Ratio compile-time invariants", () => {
   // These tests are compile-time, not runtime. `@ts-expect-error` fails
   // the build if the following lines ever typecheck — i.e., if the brand

--- a/packages/types/src/__tests__/percentage.test.ts
+++ b/packages/types/src/__tests__/percentage.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Branded-numeric helper tests (#1685).
+ *
+ * Two layers of invariant:
+ *
+ *   1. Runtime — the converters return the expected numeric values.
+ *      `asPercentage` / `asRatio` pass through without modification.
+ *      `percentageToRatio` divides by 100; `ratioToPercentage` multiplies
+ *      by 100. These are trivial but pin the conversion direction so a
+ *      future edit can't swap them.
+ *   2. Compile-time — `Percentage` and `Ratio` are nominally distinct.
+ *      The `@ts-expect-error` guards below fail the build if a future
+ *      refactor erases the brand and makes either type structurally
+ *      assignable to the other or to plain `number`.
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+  asPercentage,
+  asRatio,
+  percentageToRatio,
+  ratioToPercentage,
+  type Percentage,
+  type Ratio,
+} from "../percentage";
+
+describe("Percentage / Ratio runtime conversions", () => {
+  // `.toBe<number>(literal)` is the explicit widening for comparing a
+  // branded value against a plain number literal. The brand stays intact
+  // at compile time; this tests only the runtime math.
+  test("asPercentage brands without modifying the value", () => {
+    expect(asPercentage(0)).toBe<number>(0);
+    expect(asPercentage(50)).toBe<number>(50);
+    expect(asPercentage(100)).toBe<number>(100);
+  });
+
+  test("asRatio brands without modifying the value", () => {
+    expect(asRatio(0)).toBe<number>(0);
+    expect(asRatio(0.5)).toBe<number>(0.5);
+    expect(asRatio(1)).toBe<number>(1);
+  });
+
+  test("percentageToRatio divides by 100", () => {
+    expect(percentageToRatio(asPercentage(50))).toBe<number>(0.5);
+    expect(percentageToRatio(asPercentage(0))).toBe<number>(0);
+    expect(percentageToRatio(asPercentage(100))).toBe<number>(1);
+  });
+
+  test("ratioToPercentage multiplies by 100", () => {
+    expect(ratioToPercentage(asRatio(0.5))).toBe<number>(50);
+    expect(ratioToPercentage(asRatio(0))).toBe<number>(0);
+    expect(ratioToPercentage(asRatio(1))).toBe<number>(100);
+  });
+
+  test("round-trip conversion preserves value at 2-decimal precision", () => {
+    // 50.04% is the threshold-boundary case from PR #1681 — guard against
+    // the rounding regression that would have flipped
+    // `counters.errorRatePct / 100 > 0.5` off at 50.04%.
+    const p = asPercentage(50.04);
+    const r = percentageToRatio(p);
+    expect(r > 0.5).toBe(true);
+    const back = ratioToPercentage(r);
+    expect(back).toBeCloseTo(50.04, 10);
+  });
+});
+
+describe("Percentage / Ratio compile-time invariants", () => {
+  // These tests are compile-time, not runtime. `@ts-expect-error` fails
+  // the build if the following lines ever typecheck — i.e., if the brand
+  // is accidentally erased and cross-scale comparisons become structural.
+
+  test("plain number is not assignable to Percentage", () => {
+    // @ts-expect-error plain number must not satisfy the Percentage brand
+    const p: Percentage = 50;
+    expect(p).toBe<number>(50);
+  });
+
+  test("plain number is not assignable to Ratio", () => {
+    // @ts-expect-error plain number must not satisfy the Ratio brand
+    const r: Ratio = 0.5;
+    expect(r).toBe<number>(0.5);
+  });
+
+  test("Percentage is not assignable to Ratio without conversion", () => {
+    const p = asPercentage(50);
+    // @ts-expect-error Percentage must not cross-assign to Ratio — use percentageToRatio
+    const r: Ratio = p;
+    expect(r).toBe<number>(50);
+  });
+
+  test("Ratio is not assignable to Percentage without conversion", () => {
+    const r = asRatio(0.5);
+    // @ts-expect-error Ratio must not cross-assign to Percentage — use ratioToPercentage
+    const p: Percentage = r;
+    expect(p).toBe<number>(0.5);
+  });
+});

--- a/packages/types/src/abuse.ts
+++ b/packages/types/src/abuse.ts
@@ -86,6 +86,28 @@ export interface AbuseInstance {
 }
 
 /**
+ * Diagnostic channel for the `events` payload on `AbuseDetail` (#1682).
+ *
+ * Before this tag, a DB load failure silently degraded `events` to `[]` —
+ * indistinguishable from "this workspace has never been flagged." An
+ * operator investigating a re-flagged workspace during a transient DB
+ * outage saw a clean slate and could reinstate a repeat offender based on
+ * false-empty history. `eventsStatus` surfaces the degraded state so the UI
+ * can show a loud warning rather than the benign empty-history copy.
+ *
+ * - `ok` — events loaded successfully (empty history is truly empty).
+ * - `load_failed` — `getAbuseEvents` caught a DB error. Counters + level in
+ *   the rest of the payload are still accurate (they come from in-memory
+ *   state), but the audit trail is unreachable; do not draw conclusions
+ *   from `currentInstance` / `priorInstances` being empty.
+ * - `db_unavailable` — `hasInternalDB()` returned false. Expected on a
+ *   self-hosted deploy without `DATABASE_URL`; the engine is running in
+ *   ephemeral in-memory mode. Prior flag history does not exist to load.
+ */
+export const ABUSE_EVENTS_STATUSES = ["ok", "load_failed", "db_unavailable"] as const;
+export type AbuseEventsStatus = (typeof ABUSE_EVENTS_STATUSES)[number];
+
+/**
  * Full investigation context for a single flagged workspace.
  *
  * Returned from `GET /api/v1/admin/abuse/:workspaceId/detail`. Lazy-loaded on
@@ -105,12 +127,19 @@ export interface AbuseDetail extends Omit<AbuseStatus, "events"> {
    * Current (unreinstated) flag instance.
    *
    * May be empty if the workspace is flagged in memory but no persisted event
-   * is yet readable — e.g. `DATABASE_URL` isn't set on a self-hosted deploy,
-   * the write is still in flight, or `persistAbuseEvent` failed and was
-   * swallowed. The detail-panel empty copy deliberately doesn't assume the DB
-   * is broken in this case.
+   * is yet readable — read `eventsStatus` to distinguish the three
+   * possibilities: really-empty history, DB load failure, or a self-hosted
+   * deploy without `DATABASE_URL`. The detail-panel UI renders a loud
+   * banner when `eventsStatus !== "ok"` so an operator does not mistake a
+   * degraded audit trail for "never flagged."
    */
   currentInstance: AbuseInstance;
   /** Prior closed instances, newest-first. Capped server-side. */
   priorInstances: AbuseInstance[];
+  /**
+   * Load status for the events payload. Propagates from `getAbuseEvents` →
+   * lib → route → UI so the admin panel can distinguish empty-because-clean
+   * from empty-because-broken. See `AbuseEventsStatus`.
+   */
+  eventsStatus: AbuseEventsStatus;
 }

--- a/packages/types/src/abuse.ts
+++ b/packages/types/src/abuse.ts
@@ -70,19 +70,48 @@ export interface AbuseCounters {
 }
 
 /**
+ * Phantom brand for `AbuseInstance` (#1684).
+ *
+ * The brand is a `unique symbol` declared module-privately. Any caller that
+ * wants to mint an `AbuseInstance` must either go through
+ * `createAbuseInstance` (which localizes the `as AbuseInstance` cast and
+ * enforces invariants: peakLevel ≡ max(event levels), endedAt non-null iff
+ * last event is a manual "none" reinstatement, startedAt ≡ events[0].createdAt)
+ * or parse the wire format through `AbuseInstanceSchema` (which casts the
+ * parse result at the wire boundary).
+ *
+ * Hand-rolling `{ startedAt, endedAt, peakLevel, events }` as an
+ * `AbuseInstance` literal now fails typecheck — the mandatory brand is a
+ * `never`-typed symbol key that no plain object literal can satisfy. That
+ * breaks the previously-structural escape hatch that let test fixtures (and
+ * accidentally, new production call sites) produce mismatched instances
+ * where peakLevel disagreed with events.
+ *
+ * The brand has zero runtime cost — it is a phantom type that erases to
+ * nothing in emitted JS; the property key is never accessed at runtime.
+ */
+declare const abuseInstanceBrand: unique symbol;
+
+/**
  * A flag "instance" — one continuous stretch of non-"none" activity for a
  * workspace, bookended by an escalation event and (optionally) a reinstatement
  * event.
  *
- * `events` are chronological (oldest first). `endedAt` is null while the
- * instance is still active (no reinstatement yet).
+ * `events` are chronological (oldest first) and `readonly` — post-construction
+ * mutation would silently invalidate the cached `peakLevel` / `endedAt`
+ * invariants the factory established. `endedAt` is null while the instance
+ * is still active (no reinstatement yet).
+ *
+ * Nominally branded (see `abuseInstanceBrand` above) so only
+ * `createAbuseInstance` and the Zod parser can produce values of this type.
  */
 export interface AbuseInstance {
+  readonly [abuseInstanceBrand]: never;
   startedAt: string;
   endedAt: string | null;
   /** Highest level reached during the instance. */
   peakLevel: AbuseLevel;
-  events: AbuseEvent[];
+  events: readonly AbuseEvent[];
 }
 
 /**

--- a/packages/types/src/abuse.ts
+++ b/packages/types/src/abuse.ts
@@ -6,6 +6,8 @@
 // CHECK in `packages/api/src/lib/db/migrations/*_abuse_events_enum_checks.sql`
 // — otherwise `persistAbuseEvent` will fail at INSERT time.
 
+import type { Percentage, Ratio } from "./percentage";
+
 /** Graduated abuse response levels (escalation order). */
 export const ABUSE_LEVELS = ["none", "warning", "throttled", "suspended"] as const;
 export type AbuseLevel = (typeof ABUSE_LEVELS)[number];
@@ -50,8 +52,14 @@ export interface AbuseThresholdConfig {
   queryRateLimit: number;
   /** Sliding window duration in seconds. */
   queryRateWindowSeconds: number;
-  /** Max error rate (0–1) before escalation. */
-  errorRateThreshold: number;
+  /**
+   * Max error rate before escalation. `Ratio` (0–1) — authored in
+   * `atlas.config.ts` / env vars as a fraction because the engine's
+   * internal comparison `errorCount / totalCount > errorRateThreshold`
+   * works on fractions too. Cross-scale mixups with `AbuseCounters.errorRatePct`
+   * (a `Percentage`) are prevented by the brand (#1685).
+   */
+  errorRateThreshold: Ratio;
   /** Max unique tables accessed per window before escalation. */
   uniqueTablesLimit: number;
   /** Delay injected for throttled workspaces, in milliseconds. */
@@ -62,8 +70,14 @@ export interface AbuseThresholdConfig {
 export interface AbuseCounters {
   queryCount: number;
   errorCount: number;
-  /** Null when queryCount < 10 (the engine only evaluates error rate once it has a baseline). */
-  errorRatePct: number | null;
+  /**
+   * Error rate as a `Percentage` (0–100), matching the SLA surfaces'
+   * convention. Null when queryCount < 10 (the engine only evaluates
+   * error rate once it has a baseline). Branded (#1685) so a caller that
+   * compares against `AbuseThresholdConfig.errorRateThreshold` (a
+   * `Ratio`) must go through `percentageToRatio` explicitly.
+   */
+  errorRatePct: Percentage | null;
   uniqueTablesAccessed: number;
   /** Consecutive escalation count currently driving the level. */
   escalations: number;

--- a/packages/types/src/abuse.ts
+++ b/packages/types/src/abuse.ts
@@ -44,6 +44,13 @@ export interface AbuseStatus {
   updatedAt: string;
   /** Recent abuse events for this workspace. */
   events: AbuseEvent[];
+  /**
+   * Per-workspace load status for the `events` payload (#1682). Defaults
+   * to `"ok"` in pre-existing callers that don't yet surface the signal,
+   * so list consumers who filter on `eventsStatus === "ok"` can safely
+   * treat the absence as the happy path.
+   */
+  eventsStatus?: AbuseEventsStatus;
 }
 
 /** Abuse threshold configuration (read-only from admin API). */
@@ -73,9 +80,10 @@ export interface AbuseCounters {
   /**
    * Error rate as a `Percentage` (0–100), matching the SLA surfaces'
    * convention. Null when queryCount < 10 (the engine only evaluates
-   * error rate once it has a baseline). Branded (#1685) so a caller that
-   * compares against `AbuseThresholdConfig.errorRateThreshold` (a
-   * `Ratio`) must go through `percentageToRatio` explicitly.
+   * error rate once it has a baseline). Branded (#1685) so a caller
+   * cannot assign this value into a `Ratio`-typed slot without an
+   * explicit `percentageToRatio` — the brand catches the scale mixup at
+   * assignment, not at the `>` / `<` operator.
    */
   errorRatePct: Percentage | null;
   uniqueTablesAccessed: number;
@@ -84,40 +92,26 @@ export interface AbuseCounters {
 }
 
 /**
- * Phantom brand for `AbuseInstance` (#1684).
- *
- * The brand is a `unique symbol` declared module-privately. Any caller that
- * wants to mint an `AbuseInstance` must either go through
- * `createAbuseInstance` (which localizes the `as AbuseInstance` cast and
- * enforces invariants: peakLevel ≡ max(event levels), endedAt non-null iff
- * last event is a manual "none" reinstatement, startedAt ≡ events[0].createdAt)
- * or parse the wire format through `AbuseInstanceSchema` (which casts the
- * parse result at the wire boundary).
- *
- * Hand-rolling `{ startedAt, endedAt, peakLevel, events }` as an
- * `AbuseInstance` literal now fails typecheck — the mandatory brand is a
- * `never`-typed symbol key that no plain object literal can satisfy. That
- * breaks the previously-structural escape hatch that let test fixtures (and
- * accidentally, new production call sites) produce mismatched instances
- * where peakLevel disagreed with events.
- *
- * The brand has zero runtime cost — it is a phantom type that erases to
- * nothing in emitted JS; the property key is never accessed at runtime.
+ * Phantom brand for `AbuseInstance` (#1684). `unique symbol` declared
+ * module-privately; the required `never`-typed key rejects plain object
+ * literals, so minting requires a localized cast. Two call sites own
+ * that cast: `createAbuseInstance` (enforces peakLevel ≡ max(event
+ * levels), endedAt non-null iff last event is a manual "none"
+ * reinstatement, startedAt ≡ events[0].createdAt) and `AbuseInstanceSchema`
+ * at the wire boundary. Zero runtime cost — the brand erases.
  */
 declare const abuseInstanceBrand: unique symbol;
 
 /**
  * A flag "instance" — one continuous stretch of non-"none" activity for a
- * workspace, bookended by an escalation event and (optionally) a reinstatement
- * event.
+ * workspace, bookended by an escalation event and (optionally) a
+ * reinstatement event.
  *
- * `events` are chronological (oldest first) and `readonly` — post-construction
- * mutation would silently invalidate the cached `peakLevel` / `endedAt`
- * invariants the factory established. `endedAt` is null while the instance
- * is still active (no reinstatement yet).
- *
- * Nominally branded (see `abuseInstanceBrand` above) so only
- * `createAbuseInstance` and the Zod parser can produce values of this type.
+ * `events` are chronological (oldest first) and `readonly` — post-
+ * construction mutation would silently invalidate the cached `peakLevel`
+ * / `endedAt` invariants the factory established. `endedAt` is null while
+ * the instance is still active (no reinstatement yet). See
+ * `abuseInstanceBrand` above for the nominal-typing guarantee.
  */
 export interface AbuseInstance {
   readonly [abuseInstanceBrand]: never;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -20,6 +20,7 @@ export * from "./platform";
 export * from "./branding";
 export * from "./onboarding-email";
 export * from "./abuse";
+export * from "./percentage";
 export * from "./sla";
 export * from "./backups";
 export * from "./residency";

--- a/packages/types/src/percentage.ts
+++ b/packages/types/src/percentage.ts
@@ -16,15 +16,28 @@
  * while the engine's own `checkThresholds` kept escalating.
  *
  * `Percentage` and `Ratio` are nominally branded via `unique symbol`. The
- * brands are zero-runtime (phantom types); the emitted JS is pure `number`.
- * Only the `asPercentage`, `asRatio`, `percentageToRatio`, and
+ * brands are zero-runtime as types (phantom types; the emitted JS is pure
+ * `number`); the constructors below add a small one-time validation pass at
+ * mint time. Only the `asPercentage`, `asRatio`, `percentageToRatio`, and
  * `ratioToPercentage` constructors may mint branded values — ordinary
  * `number` expressions do not satisfy the brands.
  *
- * Conversion helpers are explicit by design. A caller writing
- * `percentageToRatio(counters.errorRatePct) > thresholds.errorRateThreshold`
- * has typechecked that both sides are `Ratio`. A caller who forgets the
- * conversion fails at compile time, not at runtime boundary rounding.
+ * What the brand *does* catch: assignment mixups. A plain `number` cannot
+ * flow into a `Percentage`-typed slot, a `Percentage` cannot flow into a
+ * `Ratio`-typed slot, and function arguments typed as `Ratio` reject raw
+ * numbers. Together with the `asPercentage` / `asRatio` boundary casts,
+ * this forces every numeric scale in the system to be declared at
+ * construction — the `errorRatePct / 100 > threshold` footgun (where both
+ * sides are raw `number`) is prevented by making `counters.errorRatePct`
+ * non-assignable to the bare-number comparison chain.
+ *
+ * What the brand does *not* catch: TypeScript permits `<` / `>` / `===`
+ * between any two number-subtype operands, so `p > r` still compiles.
+ * Defense is upstream: the branded operands can only be produced via the
+ * constructors, and they require explicit conversion (`percentageToRatio`
+ * / `ratioToPercentage`) at any site that mixes scales. The
+ * `@ts-expect-error` suite in `percentage.test.ts` pins exactly what the
+ * brand enforces (assignment) and what it does not (comparison).
  */
 
 declare const percentageBrand: unique symbol;
@@ -46,17 +59,34 @@ export type Percentage = number & { readonly [percentageBrand]: never };
  */
 export type Ratio = number & { readonly [ratioBrand]: never };
 
+// A small tolerance above the scale ceiling swallows IEEE-754 slop from
+// SQL aggregates (e.g. `ROUND(failed::float / total * 100, 2)` can overshoot
+// by a few ULPs) without permitting a genuine scale mixup like `1.5 → 150`.
+const PCT_TOLERANCE = 0.001;
+const RATIO_TOLERANCE = 0.00001;
+
 /**
  * Brand a raw number as a `Percentage` without performing a conversion.
  *
  * The caller is asserting the input is already on the 0–100 scale.
- * Typical use: wrapping an SQL aggregate that the query computed as a
- * percentage (e.g., `ROUND(failed::float / total * 100, 2)`).
+ * Typical use: wrapping an SQL aggregate (`ROUND(failed/total*100, 2)`),
+ * a DB-stored percentage column, a Zod-parsed wire value, or an operator-
+ * entered form field.
  *
- * No runtime range check — branding is a compile-time concern; validation
- * at the wire boundary is the Zod schema's job.
+ * Throws on non-finite input (NaN, Infinity) and on values outside
+ * `[0 - tolerance, 100 + tolerance]` — ruling out the silent "brand
+ * nonsense into existence" path that no-op casts would leave open. The
+ * tolerance permits SQL rounding overshoot; values like `150` or `-50`
+ * that signal a genuine scale mixup fail loudly at the cast site, not at
+ * the admin-panel comparison three modules downstream.
  */
 export function asPercentage(n: number): Percentage {
+  if (!Number.isFinite(n)) {
+    throw new Error(`asPercentage: non-finite input (${n})`);
+  }
+  if (n < -PCT_TOLERANCE || n > 100 + PCT_TOLERANCE) {
+    throw new Error(`asPercentage: out of range (${n}); expected 0..100`);
+  }
   return n as Percentage;
 }
 
@@ -65,8 +95,18 @@ export function asPercentage(n: number): Percentage {
  *
  * The caller is asserting the input is already on the 0–1 scale.
  * Typical use: wrapping config / env-var values authored as fractions.
+ *
+ * Throws on non-finite input and on values outside `[0 - ε, 1 + ε]`. Same
+ * rationale as `asPercentage`: the cast is where scale mixups should
+ * surface, not where they quietly propagate.
  */
 export function asRatio(n: number): Ratio {
+  if (!Number.isFinite(n)) {
+    throw new Error(`asRatio: non-finite input (${n})`);
+  }
+  if (n < -RATIO_TOLERANCE || n > 1 + RATIO_TOLERANCE) {
+    throw new Error(`asRatio: out of range (${n}); expected 0..1`);
+  }
   return n as Ratio;
 }
 

--- a/packages/types/src/percentage.ts
+++ b/packages/types/src/percentage.ts
@@ -1,0 +1,81 @@
+/**
+ * Branded numeric types for percentage / ratio scales (#1685).
+ *
+ * Before this module, `errorRatePct` appeared in two incompatible
+ * conventions across the codebase:
+ *
+ *   - Abuse engine: `AbuseCounters.errorRatePct` on 0–100 basis, but
+ *     `AbuseThresholdConfig.errorRateThreshold` on 0–1 ratio basis.
+ *   - SLA surfaces: `WorkspaceSLASummary.errorRatePct` and
+ *     `SLAThresholds.errorRatePct` on 0–100 basis.
+ *
+ * `number` is structurally identical in all four positions, so a caller
+ * that forgot to divide by 100 produced a latent boundary bug. PR #1681
+ * nearly shipped exactly that regression — rounding the 0–100 percentage
+ * to 1 decimal silently flipped `errorRatePct / 100 > 0.5` off at 50.04%
+ * while the engine's own `checkThresholds` kept escalating.
+ *
+ * `Percentage` and `Ratio` are nominally branded via `unique symbol`. The
+ * brands are zero-runtime (phantom types); the emitted JS is pure `number`.
+ * Only the `asPercentage`, `asRatio`, `percentageToRatio`, and
+ * `ratioToPercentage` constructors may mint branded values — ordinary
+ * `number` expressions do not satisfy the brands.
+ *
+ * Conversion helpers are explicit by design. A caller writing
+ * `percentageToRatio(counters.errorRatePct) > thresholds.errorRateThreshold`
+ * has typechecked that both sides are `Ratio`. A caller who forgets the
+ * conversion fails at compile time, not at runtime boundary rounding.
+ */
+
+declare const percentageBrand: unique symbol;
+declare const ratioBrand: unique symbol;
+
+/**
+ * A number on the 0–100 scale (e.g., `errorRatePct: 50` = 50%). Output of
+ * the `errorRatePct()` arithmetic helper and the `AbuseCounters` /
+ * `WorkspaceSLASummary` wire fields.
+ */
+export type Percentage = number & { readonly [percentageBrand]: never };
+
+/**
+ * A number on the 0–1 scale (e.g., `errorRateThreshold: 0.5` = 50%).
+ * Abuse engine thresholds are authored in config / env vars as ratios
+ * because the engine's internal escalation math is fractional. The wire
+ * type surfaces the ratio unchanged so `atlas.config.ts` edits do not
+ * need a conversion step.
+ */
+export type Ratio = number & { readonly [ratioBrand]: never };
+
+/**
+ * Brand a raw number as a `Percentage` without performing a conversion.
+ *
+ * The caller is asserting the input is already on the 0–100 scale.
+ * Typical use: wrapping an SQL aggregate that the query computed as a
+ * percentage (e.g., `ROUND(failed::float / total * 100, 2)`).
+ *
+ * No runtime range check — branding is a compile-time concern; validation
+ * at the wire boundary is the Zod schema's job.
+ */
+export function asPercentage(n: number): Percentage {
+  return n as Percentage;
+}
+
+/**
+ * Brand a raw number as a `Ratio` without performing a conversion.
+ *
+ * The caller is asserting the input is already on the 0–1 scale.
+ * Typical use: wrapping config / env-var values authored as fractions.
+ */
+export function asRatio(n: number): Ratio {
+  return n as Ratio;
+}
+
+/** Convert `50` (as Percentage) → `0.5` (as Ratio). */
+export function percentageToRatio(p: Percentage): Ratio {
+  return (p / 100) as Ratio;
+}
+
+/** Convert `0.5` (as Ratio) → `50` (as Percentage). */
+export function ratioToPercentage(r: Ratio): Percentage {
+  return (r * 100) as Percentage;
+}

--- a/packages/types/src/sla.ts
+++ b/packages/types/src/sla.ts
@@ -5,6 +5,8 @@
  * query latency, error rate tracking, and alerting.
  */
 
+import type { Percentage } from "./percentage";
+
 // ---------------------------------------------------------------------------
 // Metric types
 // ---------------------------------------------------------------------------
@@ -16,10 +18,10 @@ export interface WorkspaceSLASummary {
   latencyP50Ms: number;
   latencyP95Ms: number;
   latencyP99Ms: number;
-  /** Error rate as a percentage (0–100). */
-  errorRatePct: number;
-  /** Uptime as a percentage (0–100), derived from successful query ratio. */
-  uptimePct: number;
+  /** Error rate on a 0–100 scale, branded `Percentage` (#1685). */
+  errorRatePct: Percentage;
+  /** Uptime on a 0–100 scale, branded `Percentage`. */
+  uptimePct: Percentage;
   totalQueries: number;
   failedQueries: number;
   lastQueryAt: string | null;
@@ -72,6 +74,12 @@ export interface SLAAlert {
 export interface SLAThresholds {
   /** P99 latency threshold in milliseconds. */
   latencyP99Ms: number;
-  /** Error rate threshold as a percentage (0–100). */
-  errorRatePct: number;
+  /**
+   * Error rate threshold on a 0–100 scale, branded `Percentage` (#1685).
+   * Opposite convention from `AbuseThresholdConfig.errorRateThreshold`
+   * (which is a `Ratio`) — the SLA surface kept the legacy percentage
+   * format, and the brand makes the cross-module mixup a typecheck
+   * failure instead of a runtime boundary bug.
+   */
+  errorRatePct: Percentage;
 }

--- a/packages/types/src/sla.ts
+++ b/packages/types/src/sla.ts
@@ -78,8 +78,11 @@ export interface SLAThresholds {
    * Error rate threshold on a 0–100 scale, branded `Percentage` (#1685).
    * Opposite convention from `AbuseThresholdConfig.errorRateThreshold`
    * (which is a `Ratio`) — the SLA surface kept the legacy percentage
-   * format, and the brand makes the cross-module mixup a typecheck
-   * failure instead of a runtime boundary bug.
+   * format. The brand makes cross-module *assignment* a typecheck
+   * failure (passing an SLA threshold where an abuse threshold is
+   * expected fails immediately), while comparisons still compile — by
+   * that point the operands have been constructed via `asPercentage` /
+   * `asRatio` and a caller who mixed scales would have failed upstream.
    */
   errorRatePct: Percentage;
 }

--- a/packages/web/src/app/admin/abuse/__tests__/events-status-banner.test.tsx
+++ b/packages/web/src/app/admin/abuse/__tests__/events-status-banner.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Regression guard for `EventsStatusBanner` (#1682 diagnostic channel UI).
+ *
+ * The banner is the final mile of the diagnostic channel — it turns the
+ * wire signal (`AbuseDetail.eventsStatus`) into an operator-visible warning.
+ * The backend half is covered by integration tests in
+ * `packages/api/src/lib/security/__tests__/abuse.test.ts` and the route
+ * layer test in `packages/api/src/api/__tests__/admin-abuse.test.ts`, but
+ * the UI branch is where a prop-name typo, an early-return refactor, or a
+ * styling-severity regression would ship silently — the rest of the
+ * payload still renders, the banner just quietly doesn't.
+ *
+ * Invariants pinned below:
+ *  - status="ok" → no banner (benign empty history)
+ *  - status="load_failed" → destructive (red) banner, role=alert, the
+ *    "Do not reinstate" copy operators are supposed to read
+ *  - status="db_unavailable" → neutral advisory banner, still role=alert
+ *    for a11y, but NOT the destructive styling (to keep the operator's
+ *    attention to the genuinely dangerous `load_failed` case)
+ */
+
+import { describe, expect, test } from "bun:test";
+import { render, cleanup } from "@testing-library/react";
+import { createElement } from "react";
+import { EventsStatusBanner } from "../detail-panel";
+
+function renderBanner(status: "ok" | "load_failed" | "db_unavailable") {
+  return render(createElement(EventsStatusBanner, { status }));
+}
+
+describe("EventsStatusBanner", () => {
+  test("renders nothing when status is 'ok'", () => {
+    const { container } = renderBanner("ok");
+    expect(container.textContent).toBe("");
+    expect(container.querySelector("[role=alert]")).toBeNull();
+    cleanup();
+  });
+
+  test("renders destructive banner on 'load_failed' with 'Do not reinstate' copy", () => {
+    const { getByRole } = renderBanner("load_failed");
+    const alert = getByRole("alert");
+    expect(alert).toBeTruthy();
+    // The destructive class token is what distinguishes this severity from
+    // `db_unavailable` — a regression that reused the advisory styling
+    // would lose the operator-alerting signal.
+    expect(alert.className).toContain("border-destructive");
+    expect(alert.className).toContain("bg-destructive");
+    // Headline + actionable copy both render. The "Do not reinstate" guard
+    // is the whole point of the banner — losing it reintroduces #1682.
+    expect(alert.textContent).toContain("Event history failed to load");
+    expect(alert.textContent).toContain("Do not reinstate");
+    cleanup();
+  });
+
+  test("renders advisory (non-destructive) banner on 'db_unavailable'", () => {
+    const { getByRole } = renderBanner("db_unavailable");
+    const alert = getByRole("alert");
+    expect(alert).toBeTruthy();
+    // Advisory styling, NOT destructive — the self-hosted steady state
+    // should not scream at the operator on every page load.
+    expect(alert.className).not.toContain("border-destructive");
+    expect(alert.className).not.toContain("bg-destructive");
+    expect(alert.className).toContain("bg-muted");
+    expect(alert.textContent).toContain("Event history is not persisted");
+    expect(alert.textContent).toContain("DATABASE_URL");
+    cleanup();
+  });
+});

--- a/packages/web/src/app/admin/abuse/detail-panel.tsx
+++ b/packages/web/src/app/admin/abuse/detail-panel.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { friendlyError } from "@/ui/lib/fetch-error";
+import { percentageToRatio, ratioToPercentage } from "@useatlas/types";
 import { RelativeTimestamp } from "@/ui/components/admin/queue";
 import { AbuseDetailSchema } from "@/ui/lib/admin-schemas";
 import type {
@@ -60,7 +61,10 @@ function CountersSection({
 }) {
   const errorRatePctDisplay =
     counters.errorRatePct !== null ? counters.errorRatePct.toFixed(0) : null;
-  const errorRateThresholdPct = (thresholds.errorRateThreshold * 100).toFixed(0);
+  // `errorRateThreshold` is a `Ratio` on the wire (0–1); display as a
+  // percentage via `ratioToPercentage`. The explicit conversion is what
+  // the type system uses to catch the old 0–100 vs 0–1 mixups (#1685).
+  const errorRateThresholdPct = ratioToPercentage(thresholds.errorRateThreshold).toFixed(0);
 
   return (
     <section>
@@ -81,7 +85,11 @@ function CountersSection({
           threshold={`${errorRateThresholdPct}%`}
           over={
             counters.errorRatePct !== null &&
-            counters.errorRatePct / 100 > thresholds.errorRateThreshold
+            // Explicit scale conversion — both sides of the comparison are
+            // `Ratio` now. Replacing `counters.errorRatePct / 100` with
+            // `percentageToRatio(counters.errorRatePct)` is what made the
+            // old convention-collision footgun a compile-time error.
+            percentageToRatio(counters.errorRatePct) > thresholds.errorRateThreshold
           }
         />
         <CounterRow

--- a/packages/web/src/app/admin/abuse/detail-panel.tsx
+++ b/packages/web/src/app/admin/abuse/detail-panel.tsx
@@ -10,6 +10,7 @@ import { RelativeTimestamp } from "@/ui/components/admin/queue";
 import { AbuseDetailSchema } from "@/ui/lib/admin-schemas";
 import type {
   AbuseCounters,
+  AbuseEventsStatus,
   AbuseInstance,
   AbuseThresholdConfig,
 } from "@/ui/lib/types";
@@ -154,6 +155,49 @@ function TimelineSection({
   );
 }
 
+/**
+ * Destructive banner for a degraded event-history load (#1682).
+ *
+ * Renders above the timeline when `eventsStatus !== "ok"` so an operator
+ * sees "history is missing, not empty" before reading the benign empty-
+ * state copy below. Without the banner, a transient DB outage produced a
+ * payload indistinguishable from "never flagged" and an admin could
+ * reinstate a repeat offender based on false history.
+ *
+ * `load_failed` is the dangerous case — a DB query errored and in-memory
+ * state cannot corroborate prior flags. `db_unavailable` is the expected
+ * self-hosted case (no `DATABASE_URL`); still worth signaling so the admin
+ * knows prior history is not stored, but copy is advisory rather than
+ * alarming.
+ */
+function EventsStatusBanner({ status }: { status: AbuseEventsStatus }) {
+  if (status === "ok") return null;
+  const { title, body } =
+    status === "load_failed"
+      ? {
+          title: "Event history failed to load",
+          body: "Counters and level are live, but the audit trail is unavailable. Do not reinstate based on missing history.",
+        }
+      : {
+          title: "Event history is not persisted",
+          body: "This deploy has no internal database configured (DATABASE_URL). Prior flag events are not recorded — reinstate decisions cannot reference past history.",
+        };
+  return (
+    <div
+      role="alert"
+      className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs lg:col-span-2"
+    >
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="mt-0.5 size-4 shrink-0 text-destructive" />
+        <div className="flex-1">
+          <p className="font-medium text-destructive">{title}</p>
+          <p className="mt-0.5 text-muted-foreground">{body}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function PriorInstancesSection({ instances }: { instances: AbuseInstance[] }) {
   if (instances.length === 0) {
     return (
@@ -294,6 +338,7 @@ export function AbuseDetailPanel({
 
   return (
     <div className="grid gap-4 lg:grid-cols-2">
+      <EventsStatusBanner status={data.eventsStatus} />
       <CountersSection counters={data.counters} thresholds={data.thresholds} />
       <TimelineSection
         title="Current flag timeline"

--- a/packages/web/src/app/admin/abuse/detail-panel.tsx
+++ b/packages/web/src/app/admin/abuse/detail-panel.tsx
@@ -85,10 +85,10 @@ function CountersSection({
           threshold={`${errorRateThresholdPct}%`}
           over={
             counters.errorRatePct !== null &&
-            // Explicit scale conversion — both sides of the comparison are
-            // `Ratio` now. Replacing `counters.errorRatePct / 100` with
-            // `percentageToRatio(counters.errorRatePct)` is what made the
-            // old convention-collision footgun a compile-time error.
+            // Explicit scale conversion — `counters.errorRatePct` is
+            // `Percentage` (0–100), `thresholds.errorRateThreshold` is
+            // `Ratio` (0–1). `percentageToRatio` makes the scale mismatch
+            // obvious at the call site; both operands below are `Ratio`.
             percentageToRatio(counters.errorRatePct) > thresholds.errorRateThreshold
           }
         />
@@ -164,7 +164,7 @@ function TimelineSection({
 }
 
 /**
- * Destructive banner for a degraded event-history load (#1682).
+ * Banner for a degraded or absent event-history load (#1682).
  *
  * Renders above the timeline when `eventsStatus !== "ok"` so an operator
  * sees "history is missing, not empty" before reading the benign empty-
@@ -172,33 +172,44 @@ function TimelineSection({
  * payload indistinguishable from "never flagged" and an admin could
  * reinstate a repeat offender based on false history.
  *
- * `load_failed` is the dangerous case — a DB query errored and in-memory
- * state cannot corroborate prior flags. `db_unavailable` is the expected
- * self-hosted case (no `DATABASE_URL`); still worth signaling so the admin
- * knows prior history is not stored, but copy is advisory rather than
- * alarming.
+ * Two severities, two visual treatments — reusing one destructive red
+ * card for both would erode operator attention to the genuinely dangerous
+ * case (`load_failed`). `db_unavailable` is the expected steady state on
+ * a self-hosted deploy without DATABASE_URL, so it gets a neutral
+ * informational treatment.
+ *
+ *   - `load_failed` → destructive (red): the DB read threw; in-memory
+ *     state cannot corroborate prior flags. Admins must NOT reinstate
+ *     based on empty history.
+ *   - `db_unavailable` → advisory (muted): no internal DB is configured;
+ *     prior flag history simply does not exist to load. Reinstate
+ *     decisions still have only the current in-memory state to go on.
  */
-function EventsStatusBanner({ status }: { status: AbuseEventsStatus }) {
+export function EventsStatusBanner({ status }: { status: AbuseEventsStatus }) {
   if (status === "ok") return null;
-  const { title, body } =
-    status === "load_failed"
-      ? {
-          title: "Event history failed to load",
-          body: "Counters and level are live, but the audit trail is unavailable. Do not reinstate based on missing history.",
-        }
-      : {
-          title: "Event history is not persisted",
-          body: "This deploy has no internal database configured (DATABASE_URL). Prior flag events are not recorded — reinstate decisions cannot reference past history.",
-        };
+  const isDegraded = status === "load_failed";
+  const { title, body } = isDegraded
+    ? {
+        title: "Event history failed to load",
+        body: "Counters and level are live, but the audit trail is unavailable. Do not reinstate based on missing history.",
+      }
+    : {
+        title: "Event history is not persisted",
+        body: "This deploy has no internal database configured (DATABASE_URL). Prior flag events are not recorded — reinstate decisions cannot reference past history.",
+      };
+  const containerClass = isDegraded
+    ? "rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs lg:col-span-2"
+    : "rounded-md border bg-muted/50 px-3 py-2 text-xs lg:col-span-2";
+  const iconClass = isDegraded
+    ? "mt-0.5 size-4 shrink-0 text-destructive"
+    : "mt-0.5 size-4 shrink-0 text-muted-foreground";
+  const titleClass = isDegraded ? "font-medium text-destructive" : "font-medium";
   return (
-    <div
-      role="alert"
-      className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs lg:col-span-2"
-    >
+    <div role="alert" className={containerClass}>
       <div className="flex items-start gap-2">
-        <AlertTriangle className="mt-0.5 size-4 shrink-0 text-destructive" />
+        <AlertTriangle className={iconClass} />
         <div className="flex-1">
-          <p className="font-medium text-destructive">{title}</p>
+          <p className={titleClass}>{title}</p>
           <p className="mt-0.5 text-muted-foreground">{body}</p>
         </div>
       </div>

--- a/packages/web/src/app/admin/abuse/page.tsx
+++ b/packages/web/src/app/admin/abuse/page.tsx
@@ -36,6 +36,7 @@ import {
   ShieldAlert,
 } from "lucide-react";
 import type { AbuseStatus } from "@/ui/lib/types";
+import { ratioToPercentage } from "@useatlas/types";
 import { AbuseStatusSchema, AbuseThresholdConfigSchema } from "@/ui/lib/admin-schemas";
 import { abuseSearchParams } from "./search-params";
 import { AbuseDetailPanel } from "./detail-panel";
@@ -128,7 +129,7 @@ function AbusePageContent() {
                 <div>
                   <p className="text-xs text-muted-foreground">Error Rate Threshold</p>
                   <p className="text-sm font-medium">
-                    {(config.errorRateThreshold * 100).toFixed(0)}%
+                    {ratioToPercentage(config.errorRateThreshold).toFixed(0)}%
                   </p>
                 </div>
                 <div>

--- a/packages/web/src/app/admin/platform/sla/page.tsx
+++ b/packages/web/src/app/admin/platform/sla/page.tsx
@@ -57,6 +57,7 @@ import type {
   SLAAlertStatus,
   SLAThresholds,
 } from "@/ui/lib/types";
+import { asPercentage } from "@useatlas/types";
 
 // Dynamic import for Recharts (heavy dependency)
 const RechartsLine = dynamic(
@@ -198,7 +199,10 @@ function SLAPageContent() {
   });
 
   function openThresholdDialog() {
-    setEditThresholds(thresholdsData ?? { latencyP99Ms: 5000, errorRatePct: 5 });
+    // `asPercentage(5)` brands the fallback default so `editThresholds`
+    // stays typed as `SLAThresholds` (#1685). The Input handler below does
+    // the same when parsing user input.
+    setEditThresholds(thresholdsData ?? { latencyP99Ms: 5000, errorRatePct: asPercentage(5) });
     clearThresholdError();
     setThresholdDialogOpen(true);
   }
@@ -537,7 +541,7 @@ function SLAPageContent() {
                   max={100}
                   step={0.1}
                   value={editThresholds.errorRatePct}
-                  onChange={(e) => setEditThresholds({ ...editThresholds, errorRatePct: parseFloat(e.target.value) || 0 })}
+                  onChange={(e) => setEditThresholds({ ...editThresholds, errorRatePct: asPercentage(parseFloat(e.target.value) || 0) })}
                 />
               </div>
             </div>

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -239,6 +239,10 @@ export const MigrationStatusResponseSchema = z.object({
 
 // ── SLA ──────────────────────────────────────────────────────────
 
+// `as unknown as z.ZodType<...>` — the wire shape is plain numbers, the TS
+// type has branded `Percentage` for `errorRatePct` / `uptimePct` (#1685).
+// The brand is phantom at runtime; the double-cast is the escape hatch we
+// use only at the web `useAdminFetch` boundary.
 export const WorkspaceSLASummarySchema = z.object({
   workspaceId: z.string(),
   workspaceName: z.string(),
@@ -250,7 +254,7 @@ export const WorkspaceSLASummarySchema = z.object({
   totalQueries: z.number(),
   failedQueries: z.number(),
   lastQueryAt: z.string().nullable(),
-}) as z.ZodType<WorkspaceSLASummary>;
+}) as unknown as z.ZodType<WorkspaceSLASummary>;
 
 const SLAMetricPointSchema = z.object({
   timestamp: z.string(),
@@ -281,7 +285,7 @@ export const SLAAlertSchema = z.object({
 export const SLAThresholdsSchema = z.object({
   latencyP99Ms: z.number(),
   errorRatePct: z.number(),
-}) as z.ZodType<SLAThresholds>;
+}) as unknown as z.ZodType<SLAThresholds>;
 
 export const SLAWorkspacesResponseSchema = z.object({
   workspaces: z.array(WorkspaceSLASummarySchema),

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -38,6 +38,7 @@ import {
   PlatformWorkspaceUserSchema,
   NoisyNeighborSchema,
 } from "@useatlas/schemas";
+import { asPercentage } from "@useatlas/types";
 export {
   AbuseStatusSchema,
   AbuseThresholdConfigSchema,
@@ -239,22 +240,24 @@ export const MigrationStatusResponseSchema = z.object({
 
 // ── SLA ──────────────────────────────────────────────────────────
 
-// `as unknown as z.ZodType<...>` — the wire shape is plain numbers, the TS
-// type has branded `Percentage` for `errorRatePct` / `uptimePct` (#1685).
-// The brand is phantom at runtime; the double-cast is the escape hatch we
-// use only at the web `useAdminFetch` boundary.
+// `.min(0).max(100)` on `errorRatePct` / `uptimePct` at the wire boundary
+// so a drifted response (scale mixup, NaN, negative) fails parse instead
+// of silently branding as `Percentage` (#1685). `.transform` brands the
+// validated value, then a `satisfies z.ZodType<WorkspaceSLASummary, unknown>`
+// at the end preserves the structural-drift guard (a `workspaceName`
+// rename in `@useatlas/types` still breaks this file at compile time).
 export const WorkspaceSLASummarySchema = z.object({
   workspaceId: z.string(),
   workspaceName: z.string(),
   latencyP50Ms: z.number(),
   latencyP95Ms: z.number(),
   latencyP99Ms: z.number(),
-  errorRatePct: z.number(),
-  uptimePct: z.number(),
+  errorRatePct: z.number().min(0).max(100).transform((n) => asPercentage(n)),
+  uptimePct: z.number().min(0).max(100).transform((n) => asPercentage(n)),
   totalQueries: z.number(),
   failedQueries: z.number(),
   lastQueryAt: z.string().nullable(),
-}) as unknown as z.ZodType<WorkspaceSLASummary>;
+}) satisfies z.ZodType<WorkspaceSLASummary, unknown>;
 
 const SLAMetricPointSchema = z.object({
   timestamp: z.string(),
@@ -284,8 +287,8 @@ export const SLAAlertSchema = z.object({
 
 export const SLAThresholdsSchema = z.object({
   latencyP99Ms: z.number(),
-  errorRatePct: z.number(),
-}) as unknown as z.ZodType<SLAThresholds>;
+  errorRatePct: z.number().min(0).max(100).transform((n) => asPercentage(n)),
+}) satisfies z.ZodType<SLAThresholds, unknown>;
 
 export const SLAWorkspacesResponseSchema = z.object({
   workspaces: z.array(WorkspaceSLASummarySchema),

--- a/packages/web/src/ui/lib/types.ts
+++ b/packages/web/src/ui/lib/types.ts
@@ -119,6 +119,7 @@ export type {
   AbuseDetail,
   AbuseEventsStatus,
 } from "@useatlas/types";
+export type { Percentage, Ratio } from "@useatlas/types";
 export type {
   WorkspaceSLASummary,
   SLAMetricPoint,

--- a/packages/web/src/ui/lib/types.ts
+++ b/packages/web/src/ui/lib/types.ts
@@ -117,6 +117,7 @@ export type {
   AbuseCounters,
   AbuseInstance,
   AbuseDetail,
+  AbuseEventsStatus,
 } from "@useatlas/types";
 export type {
   WorkspaceSLASummary,


### PR DESCRIPTION
## Summary

Four related follow-ups from PR #1681's review, bundled because the bug fixes and type-design hardens share the same abuse-module surface and `@useatlas/types`/`@useatlas/schemas` touchpoints.

- **#1683 (BUG)** — `getAbuseEvents` wrapped both `internalQuery` + the `rows.map(JSON.parse)` transform in one outer try/catch. A single poisoned `abuse_events.metadata` row wiped every valid row in the response, looking identical to a DB outage. Per-row catch narrows the blast radius: poisoned row → empty metadata + warn, rest pass through.
- **#1682 (BUG)** — `getAbuseEvents` silently returned `[]` on DB failure. `getAbuseDetail` passed that through, producing a payload indistinguishable from "never flagged" and inviting admins to reinstate repeat offenders during a transient DB outage. New `eventsStatus: "ok" | "load_failed" | "db_unavailable"` diagnostic channel plumbs the degraded state from lib → route → UI. `detail-panel.tsx` renders a destructive banner on non-ok. PR #1681's integration test rewritten to pin the diagnostic channel, not the silent fallback.
- **#1684 (architecture)** — `AbuseInstance` was a structural interface; hand-rolled literals bypassed the `createAbuseInstance` invariants (peakLevel ≡ max of event levels, endedAt non-null iff reinstate, etc.). Phantom `unique symbol` brand makes the type nominal — only the factory and the Zod parser can mint one. Migrated hand-rolled fixtures in `admin-abuse.test.ts` to `createAbuseInstance([])`. Added `events: readonly AbuseEvent[]` for good measure. Regression guard via `@ts-expect-error`.
- **#1685 (architecture)** — `errorRatePct` appeared on two incompatible scales (0–100 percentage vs 0–1 ratio) with identical `number` typing at four call sites. PR #1681 nearly shipped a boundary regression here. New `Percentage` / `Ratio` branded types in `@useatlas/types` with `percentageToRatio` / `ratioToPercentage` converters. Applied to abuse counters/thresholds + SLA surfaces. Cross-scale mixups now fail typecheck instead of rounding-regressing at runtime.

Architecture wins #35 (AbuseInstance brand) and #36 (Percentage/Ratio) recorded — #1684 and #1685 are both architecture-labeled.

## Test plan

- [x] `/ci` gates: `bun run type` clean, `bun run lint` clean, `bun run test` across all 26 packages all exit 0
- [x] TDD per commit: red test before green code (per-row JSON; diagnostic status enum; `@ts-expect-error` for brand; Percentage/Ratio compile-time invariants)
- [x] Effect test layers preference — existing mocks mixed; new integration tests in `abuse.test.ts` extend the existing pattern
- [x] OpenAPI spec + MDX regenerated to capture new `eventsStatus` field on `AbuseDetail`
- [x] No regression in abuse detail rendering — banner only shows on non-ok `eventsStatus`; happy path unchanged

## Closes

- Closes #1683
- Closes #1682
- Closes #1684
- Closes #1685