### PR TITLE
test(web/admin/actions): pure-function tests + e2e deny flow (#1593)

### DIFF
--- a/e2e/browser/actions-approval.spec.ts
+++ b/e2e/browser/actions-approval.spec.ts
@@ -1,0 +1,244 @@
+import { test, expect, type Page, type Route } from "@playwright/test";
+
+/**
+ * Admin actions approval — covers the Deny-with-reason flow end-to-end.
+ *
+ * The flow is the single piece of admin UX that writes to the compliance-
+ * relevant audit trail on every click, and until #1593 had zero e2e
+ * coverage. A regression in the reason-passthrough (e.g. dropping the
+ * trimmed reason and substituting a hardcoded default) would silently
+ * corrupt the audit log without any existing test catching it.
+ *
+ * Design note: the spec mocks `/api/v1/actions*` endpoints at the page
+ * level rather than seeding real DB rows — mirrors the admin-sessions
+ * pattern (see `admin-sessions.spec.ts` for rationale). Two reasons:
+ *   1. Seeding a pending action against a real backend requires a
+ *      dev-only admin route that doesn't exist today. Adding one just
+ *      for e2e would widen the attack surface.
+ *   2. Deterministic deny-body assertion is the core of this spec —
+ *      intercepting the request lets us pin the exact body shape the
+ *      page sends (reason included, not substituted).
+ *
+ * Tagged `@llm` for suite segmentation even though no model calls are
+ * made — keeps the spec alongside `starter-prompts-moderation.spec.ts`
+ * (the sibling compliance-sensitive moderation spec) per project
+ * convention.
+ */
+
+interface MockAction {
+  id: string;
+  requested_at: string;
+  resolved_at: string | null;
+  executed_at: string | null;
+  requested_by: string | null;
+  approved_by: string | null;
+  auth_mode: string;
+  action_type: string;
+  target: string;
+  summary: string;
+  payload: Record<string, unknown>;
+  status: string;
+  result: unknown;
+  error: string | null;
+  rollback_info: unknown;
+  conversation_id: string | null;
+  request_id: string | null;
+  denial_reason?: string;
+}
+
+function buildPendingAction(): MockAction {
+  return {
+    id: "00000000-0000-0000-0000-0000000000aa",
+    requested_at: "2026-04-19T12:00:00.000Z",
+    resolved_at: null,
+    executed_at: null,
+    requested_by: "agent",
+    approved_by: null,
+    auth_mode: "simple-key",
+    action_type: "sql_write",
+    target: "orders",
+    summary: "UPDATE orders SET status='cancelled' WHERE id = 42",
+    payload: { sql: "UPDATE orders SET status='cancelled' WHERE id = 42" },
+    status: "pending",
+    result: null,
+    error: null,
+    rollback_info: null,
+    conversation_id: null,
+    request_id: null,
+  };
+}
+
+interface InstalledMocks {
+  /** Shared mutable state so tests can assert final ordering. */
+  state: Map<string, MockAction>;
+  /** Reason captured by the deny mock — null until a deny POST arrives. */
+  lastDenyReason: { value: string | null };
+}
+
+/**
+ * Mock the three routes the admin actions page hits.
+ *   - GET /api/v1/actions?status=…    → filtered list
+ *   - POST /api/v1/actions/:id/approve → 200 { result }
+ *   - POST /api/v1/actions/:id/deny    → 200, captures body.reason
+ *
+ * Non-matching methods on the id path `route.abort` rather than fall
+ * through, so an unexpected request is a loud failure in CI.
+ */
+async function installActionMocks(page: Page): Promise<InstalledMocks> {
+  const state = new Map<string, MockAction>();
+  state.set("00000000-0000-0000-0000-0000000000aa", buildPendingAction());
+  const lastDenyReason: { value: string | null } = { value: null };
+
+  await page.route(/\/api\/v1\/actions\/[^/?]+\/(approve|deny|rollback)(?:\?|$)/, async (route: Route) => {
+    const req = route.request();
+    if (req.method() !== "POST") {
+      await route.abort("failed");
+      return;
+    }
+    const url = new URL(req.url());
+    const parts = url.pathname.split("/");
+    const endpoint = parts.pop()!;
+    const id = parts.pop()!;
+    const action = state.get(id);
+    if (!action) {
+      await route.fulfill({
+        status: 404,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "not_found", requestId: `req_${id}` }),
+      });
+      return;
+    }
+    if (endpoint === "deny") {
+      const body = (() => {
+        try {
+          return JSON.parse(req.postData() ?? "{}") as { reason?: string };
+        } catch {
+          return {};
+        }
+      })();
+      lastDenyReason.value =
+        typeof body.reason === "string" ? body.reason : "";
+      action.status = "denied";
+      action.resolved_at = "2026-04-19T12:05:00.000Z";
+      action.approved_by = "admin@useatlas.dev";
+      action.denial_reason = lastDenyReason.value;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          status: "denied",
+          actionId: id,
+          reason: lastDenyReason.value,
+        }),
+      });
+      return;
+    }
+    if (endpoint === "approve") {
+      action.status = "executed";
+      action.resolved_at = "2026-04-19T12:05:00.000Z";
+      action.executed_at = "2026-04-19T12:05:00.000Z";
+      action.approved_by = "admin@useatlas.dev";
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          status: "executed",
+          actionId: id,
+          result: { ok: true },
+        }),
+      });
+      return;
+    }
+    await route.abort("failed");
+  });
+
+  await page.route(/\/api\/v1\/actions(?:\?[^/]*)?$/, async (route: Route) => {
+    const req = route.request();
+    if (req.method() !== "GET") {
+      await route.abort("failed");
+      return;
+    }
+    const url = new URL(req.url());
+    const status = url.searchParams.get("status");
+    const actions = [...state.values()]
+      .filter((a) => {
+        if (!status || status === "all") return true;
+        return a.status === status;
+      })
+      .sort((a, b) => (a.requested_at < b.requested_at ? 1 : -1));
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ actions }),
+    });
+  });
+
+  return { state, lastDenyReason };
+}
+
+test.describe("Admin actions approval @llm", () => {
+  test.describe.configure({ timeout: 45_000 });
+
+  test("operator denies a pending action with a reason; row moves to Denied and the reason is sent to the server", async ({
+    page,
+  }) => {
+    const { state, lastDenyReason } = await installActionMocks(page);
+
+    // 1. Navigate to /admin/actions (default status filter is "pending").
+    await page.goto("/admin/actions");
+    await expect(page.locator("h1", { hasText: "Actions" })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // 2. Row renders in the Pending list. The summary is the distinctive
+    //    text we scope the row lookup to.
+    const pendingRow = page
+      .getByRole("row")
+      .filter({ hasText: "UPDATE orders SET status='cancelled'" });
+    await expect(pendingRow).toBeVisible({ timeout: 10_000 });
+
+    // 3. Open the deny dialog from the row-level "Deny action" button.
+    //    Two deny buttons can render (row + expanded detail); scoping to
+    //    the row is important for stability.
+    const denyRowButton = pendingRow.getByRole("button", {
+      name: "Deny action",
+    });
+    await denyRowButton.click();
+
+    // 4. Dialog appears, fill the reason, confirm.
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByText("Deny action")).toBeVisible({
+      timeout: 5_000,
+    });
+    await dialog.locator("#reason-dialog-reason").fill("Conflicts with policy");
+    await dialog.getByRole("button", { name: "Deny" }).click();
+
+    // 5. Assert the server received the reason verbatim — this is the
+    //    compliance-sensitive assertion. A regression that substituted
+    //    `reason || "Denied by admin"` (the bug #1592 fixed) would fail
+    //    this check.
+    await expect
+      .poll(() => lastDenyReason.value, { timeout: 10_000 })
+      .toBe("Conflicts with policy");
+
+    // 6. Row leaves Pending tab.
+    await expect(pendingRow).toHaveCount(0, { timeout: 10_000 });
+
+    // 7. Switch to Denied filter — row appears there.
+    await page.getByRole("button", { name: "Denied" }).click();
+    const deniedRow = page
+      .getByRole("row")
+      .filter({ hasText: "UPDATE orders SET status='cancelled'" });
+    await expect(deniedRow).toBeVisible({ timeout: 10_000 });
+
+    // 8. Audit-log equivalent: server state reflects the actor + reason
+    //    on the row. The admin_actions audit table would be written by
+    //    the same transaction the route handler uses; asserting on the
+    //    mock's captured state exercises the wire contract the page
+    //    depends on for the audit trail.
+    const finalAction = state.get("00000000-0000-0000-0000-0000000000aa");
+    expect(finalAction?.status).toBe("denied");
+    expect(finalAction?.approved_by).toBe("admin@useatlas.dev");
+    expect(finalAction?.denial_reason).toBe("Conflicts with policy");
+  });
+});

--- a/e2e/browser/actions-approval.spec.ts
+++ b/e2e/browser/actions-approval.spec.ts
@@ -3,10 +3,10 @@ import { test, expect, type Page, type Route } from "@playwright/test";
 /**
  * Admin actions approval — covers the Deny-with-reason flow end-to-end.
  *
- * The flow is the single piece of admin UX that writes to the compliance-
- * relevant audit trail on every click, and until #1593 had zero e2e
- * coverage. A regression in the reason-passthrough (e.g. dropping the
- * trimmed reason and substituting a hardcoded default) would silently
+ * The Deny-with-reason path is the single piece of admin UX that writes
+ * to the compliance-relevant audit trail on every click. A regression in
+ * the reason-passthrough (e.g. dropping the trimmed reason and
+ * substituting a hardcoded default like "Denied by admin") would silently
  * corrupt the audit log without any existing test catching it.
  *
  * Design note: the spec mocks `/api/v1/actions*` endpoints at the page
@@ -15,9 +15,10 @@ import { test, expect, type Page, type Route } from "@playwright/test";
  *   1. Seeding a pending action against a real backend requires a
  *      dev-only admin route that doesn't exist today. Adding one just
  *      for e2e would widen the attack surface.
- *   2. Deterministic deny-body assertion is the core of this spec —
- *      intercepting the request lets us pin the exact body shape the
- *      page sends (reason included, not substituted).
+ *   2. Deterministic deny-body + partial-failure assertions are the core
+ *      of this spec — intercepting the request lets us pin the exact
+ *      body shape the page sends (reason included, not substituted) and
+ *      force a single row's deny to fail on demand.
  *
  * Tagged `@llm` for suite segmentation even though no model calls are
  * made — keeps the spec alongside `starter-prompts-moderation.spec.ts`
@@ -46,7 +47,7 @@ interface MockAction {
   denial_reason?: string;
 }
 
-function buildPendingAction(): MockAction {
+function buildPendingAction(overrides: Partial<MockAction> = {}): MockAction {
   return {
     id: "00000000-0000-0000-0000-0000000000aa",
     requested_at: "2026-04-19T12:00:00.000Z",
@@ -65,29 +66,42 @@ function buildPendingAction(): MockAction {
     rollback_info: null,
     conversation_id: null,
     request_id: null,
+    ...overrides,
   };
 }
 
 interface InstalledMocks {
   /** Shared mutable state so tests can assert final ordering. */
   state: Map<string, MockAction>;
-  /** Reason captured by the deny mock — null until a deny POST arrives. */
-  lastDenyReason: { value: string | null };
+  /** Reasons captured by the deny mock, in request-order. */
+  denyCalls: Array<{ id: string; reason: string }>;
+}
+
+interface MockOptions {
+  /** Action fixtures to preload. Defaults to a single pending action. */
+  fixtures?: MockAction[];
+  /** Ids for which POST …/deny should return 500 (partial-failure tests). */
+  failDenyIds?: Set<string>;
 }
 
 /**
- * Mock the three routes the admin actions page hits.
- *   - GET /api/v1/actions?status=…    → filtered list
+ * Mock the routes the admin actions page hits.
+ *   - GET  /api/v1/actions?status=…    → filtered list
  *   - POST /api/v1/actions/:id/approve → 200 { result }
  *   - POST /api/v1/actions/:id/deny    → 200, captures body.reason
  *
  * Non-matching methods on the id path `route.abort` rather than fall
  * through, so an unexpected request is a loud failure in CI.
  */
-async function installActionMocks(page: Page): Promise<InstalledMocks> {
+async function installActionMocks(
+  page: Page,
+  opts: MockOptions = {},
+): Promise<InstalledMocks> {
   const state = new Map<string, MockAction>();
-  state.set("00000000-0000-0000-0000-0000000000aa", buildPendingAction());
-  const lastDenyReason: { value: string | null } = { value: null };
+  const fixtures = opts.fixtures ?? [buildPendingAction()];
+  for (const f of fixtures) state.set(f.id, f);
+  const failDenyIds = opts.failDenyIds ?? new Set<string>();
+  const denyCalls: Array<{ id: string; reason: string }> = [];
 
   await page.route(/\/api\/v1\/actions\/[^/?]+\/(approve|deny|rollback)(?:\?|$)/, async (route: Route) => {
     const req = route.request();
@@ -113,23 +127,34 @@ async function installActionMocks(page: Page): Promise<InstalledMocks> {
         try {
           return JSON.parse(req.postData() ?? "{}") as { reason?: string };
         } catch {
+          // intentionally ignored: malformed post body is treated as empty —
+          // the reason-extraction path still runs and the assertion downstream
+          // fails loudly rather than silently passing.
           return {};
         }
       })();
-      lastDenyReason.value =
-        typeof body.reason === "string" ? body.reason : "";
+      const reason = typeof body.reason === "string" ? body.reason : "";
+      denyCalls.push({ id, reason });
+      if (failDenyIds.has(id)) {
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({
+            error: "internal",
+            message: "Internal server error",
+            requestId: `req_${id}`,
+          }),
+        });
+        return;
+      }
       action.status = "denied";
       action.resolved_at = "2026-04-19T12:05:00.000Z";
       action.approved_by = "admin@useatlas.dev";
-      action.denial_reason = lastDenyReason.value;
+      action.denial_reason = reason;
       await route.fulfill({
         status: 200,
         contentType: "application/json",
-        body: JSON.stringify({
-          status: "denied",
-          actionId: id,
-          reason: lastDenyReason.value,
-        }),
+        body: JSON.stringify({ status: "denied", actionId: id, reason }),
       });
       return;
     }
@@ -173,7 +198,7 @@ async function installActionMocks(page: Page): Promise<InstalledMocks> {
     });
   });
 
-  return { state, lastDenyReason };
+  return { state, denyCalls };
 }
 
 test.describe("Admin actions approval @llm", () => {
@@ -182,30 +207,27 @@ test.describe("Admin actions approval @llm", () => {
   test("operator denies a pending action with a reason; row moves to Denied and the reason is sent to the server", async ({
     page,
   }) => {
-    const { state, lastDenyReason } = await installActionMocks(page);
+    const { state, denyCalls } = await installActionMocks(page);
 
-    // 1. Navigate to /admin/actions (default status filter is "pending").
     await page.goto("/admin/actions");
     await expect(page.locator("h1", { hasText: "Actions" })).toBeVisible({
       timeout: 15_000,
     });
 
-    // 2. Row renders in the Pending list. The summary is the distinctive
-    //    text we scope the row lookup to.
+    // Row renders in the Pending list. The summary is the distinctive
+    // text we scope the row lookup to.
     const pendingRow = page
       .getByRole("row")
       .filter({ hasText: "UPDATE orders SET status='cancelled'" });
     await expect(pendingRow).toBeVisible({ timeout: 10_000 });
 
-    // 3. Open the deny dialog from the row-level "Deny action" button.
-    //    Two deny buttons can render (row + expanded detail); scoping to
-    //    the row is important for stability.
+    // Two deny buttons can render (row-level + expanded detail); scoping
+    // to the row is important for stability.
     const denyRowButton = pendingRow.getByRole("button", {
       name: "Deny action",
     });
     await denyRowButton.click();
 
-    // 4. Dialog appears, fill the reason, confirm.
     const dialog = page.getByRole("dialog");
     await expect(dialog.getByText("Deny action")).toBeVisible({
       timeout: 5_000,
@@ -213,32 +235,116 @@ test.describe("Admin actions approval @llm", () => {
     await dialog.locator("#reason-dialog-reason").fill("Conflicts with policy");
     await dialog.getByRole("button", { name: "Deny" }).click();
 
-    // 5. Assert the server received the reason verbatim — this is the
-    //    compliance-sensitive assertion. A regression that substituted
-    //    `reason || "Denied by admin"` (the bug #1592 fixed) would fail
-    //    this check.
+    // Compliance-sensitive assertion: the server received the reason
+    // verbatim. A regression that substituted a hardcoded default (the
+    // class of bug that predates this spec) would fail this check.
     await expect
-      .poll(() => lastDenyReason.value, { timeout: 10_000 })
+      .poll(() => denyCalls.at(-1)?.reason, { timeout: 10_000 })
       .toBe("Conflicts with policy");
 
-    // 6. Row leaves Pending tab.
     await expect(pendingRow).toHaveCount(0, { timeout: 10_000 });
 
-    // 7. Switch to Denied filter — row appears there.
     await page.getByRole("button", { name: "Denied" }).click();
     const deniedRow = page
       .getByRole("row")
       .filter({ hasText: "UPDATE orders SET status='cancelled'" });
     await expect(deniedRow).toBeVisible({ timeout: 10_000 });
 
-    // 8. Audit-log equivalent: server state reflects the actor + reason
-    //    on the row. The admin_actions audit table would be written by
-    //    the same transaction the route handler uses; asserting on the
-    //    mock's captured state exercises the wire contract the page
-    //    depends on for the audit trail.
+    // Audit-log equivalent: server state reflects the actor + reason
+    // on the row. The admin_actions audit table would be written by the
+    // same transaction the route handler uses; asserting on the mock's
+    // captured state exercises the wire contract the page depends on
+    // for the audit trail.
     const finalAction = state.get("00000000-0000-0000-0000-0000000000aa");
     expect(finalAction?.status).toBe("denied");
     expect(finalAction?.approved_by).toBe("admin@useatlas.dev");
     expect(finalAction?.denial_reason).toBe("Conflicts with policy");
+  });
+
+  test("bulk-deny partial failure: successful rows clear, failed row stays selected with its reason preserved", async ({
+    page,
+  }) => {
+    // Three pending rows, one configured to 500 on deny. Exercises the
+    // `summarizeBulkResult` → selection-narrowing path end-to-end:
+    // the two successful ids drop out of the selection, the one failed
+    // id stays selected so a retry click targets exactly that row.
+    // A reorder regression in the index pairing (compliance-sensitive)
+    // would narrow to the wrong row and this test would fail.
+    const { state, denyCalls } = await installActionMocks(page, {
+      fixtures: [
+        buildPendingAction({
+          id: "00000000-0000-0000-0000-000000000001",
+          summary: "bulk-target-1",
+          payload: { sql: "bulk-target-1" },
+          requested_at: "2026-04-19T12:00:01.000Z",
+        }),
+        buildPendingAction({
+          id: "00000000-0000-0000-0000-000000000002",
+          summary: "bulk-target-2",
+          payload: { sql: "bulk-target-2" },
+          requested_at: "2026-04-19T12:00:02.000Z",
+        }),
+        buildPendingAction({
+          id: "00000000-0000-0000-0000-000000000003",
+          summary: "bulk-target-3",
+          payload: { sql: "bulk-target-3" },
+          requested_at: "2026-04-19T12:00:03.000Z",
+        }),
+      ],
+      failDenyIds: new Set(["00000000-0000-0000-0000-000000000002"]),
+    });
+
+    await page.goto("/admin/actions");
+    await expect(page.locator("h1", { hasText: "Actions" })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Select all three rows via the header "Select all pending actions"
+    // checkbox — exercises the exact same selection path operators use.
+    await page.getByRole("checkbox", { name: "Select all pending actions" }).check();
+
+    await page.getByRole("button", { name: "Deny selected" }).click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByText("Deny 3 actions")).toBeVisible({
+      timeout: 5_000,
+    });
+    await dialog.locator("#reason-dialog-reason").fill("Policy review");
+    await dialog.getByRole("button", { name: "Deny 3" }).click();
+
+    // Bulk failure summary renders inside the dialog. Format from
+    // bulkFailureSummary: "1 of 3 denials failed: 1× Internal server error (ID: req_…)".
+    await expect(
+      dialog.getByText(/1 of 3 denials failed:/),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // All three deny requests fired with the same reason (server received
+    // "Policy review" verbatim for every row — no substitution).
+    expect(denyCalls.length).toBe(3);
+    for (const call of denyCalls) expect(call.reason).toBe("Policy review");
+
+    // Server state: two rows denied, one untouched (still pending).
+    expect(state.get("00000000-0000-0000-0000-000000000001")?.status).toBe(
+      "denied",
+    );
+    expect(state.get("00000000-0000-0000-0000-000000000002")?.status).toBe(
+      "pending",
+    );
+    expect(state.get("00000000-0000-0000-0000-000000000003")?.status).toBe(
+      "denied",
+    );
+
+    // Close the dialog to see the filtered row list. The failed row stays
+    // pending and stays selected — the operator can retry with one click.
+    await dialog.getByRole("button", { name: "Cancel" }).click();
+
+    const remainingPending = page
+      .getByRole("row")
+      .filter({ hasText: "bulk-target-2" });
+    await expect(remainingPending).toBeVisible({ timeout: 10_000 });
+
+    // Selection narrowed to the failed row — the Deny-selected button
+    // should now say "1 selected" worth.
+    await expect(page.getByText(/^1 selected$/)).toBeVisible();
   });
 });

--- a/packages/web/src/app/admin/actions/__tests__/bulk-result.test.ts
+++ b/packages/web/src/app/admin/actions/__tests__/bulk-result.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import { summarizeBulkResult } from "../bulk-result";
+
+/**
+ * `summarizeBulkResult` is the pure core of the page's `handleBulkResult`
+ * callback. The page layer routes the returned summary string to its banner
+ * state and narrows selection to `remainingIds` so a retry click targets
+ * exactly the rows that still need action.
+ *
+ * The index-based pairing between `results` and `ids` is the compliance-
+ * sensitive bit — a reorder bug would narrow selection to the *wrong* rows
+ * and the operator would re-deny the wrong actions.
+ */
+describe("summarizeBulkResult", () => {
+  test("all-fulfilled returns null summary and empty remainingIds", async () => {
+    const results = await Promise.allSettled([
+      Promise.resolve("ok"),
+      Promise.resolve("ok"),
+    ]);
+    const out = summarizeBulkResult(results, ["a", "b"], "approvals");
+    expect(out.summary).toBeNull();
+    expect([...out.remainingIds]).toEqual([]);
+  });
+
+  test("all-rejected returns every input id in remainingIds", async () => {
+    const results = await Promise.allSettled([
+      Promise.reject(new Error("Forbidden")),
+      Promise.reject(new Error("Forbidden")),
+    ]);
+    const out = summarizeBulkResult(results, ["a", "b"], "denials");
+    expect(out.summary).toBe("2 of 2 denials failed: 2× Forbidden");
+    expect([...out.remainingIds].sort()).toEqual(["a", "b"]);
+  });
+
+  test("partial failure preserves ids by index (reject indices 1 and 3 of 4 → {ids[1], ids[3]})", async () => {
+    const results = await Promise.allSettled([
+      Promise.resolve("ok"),
+      Promise.reject(new Error("nope")),
+      Promise.resolve("ok"),
+      Promise.reject(new Error("nope")),
+    ]);
+    const out = summarizeBulkResult(
+      results,
+      ["first", "second", "third", "fourth"],
+      "denials",
+    );
+    // Locks the index pairing — a reorder in the flatMap pipeline would
+    // narrow to the wrong rows and compliance-relevant re-denies would
+    // target the wrong actions.
+    expect([...out.remainingIds].sort()).toEqual(["fourth", "second"]);
+    expect(out.summary).toBe("2 of 4 denials failed: 2× nope");
+  });
+
+  test("groups failures by reason with counts", async () => {
+    const results = await Promise.allSettled([
+      Promise.reject(new Error("Forbidden")),
+      Promise.reject(new Error("Forbidden")),
+      Promise.reject(new Error("Forbidden")),
+      Promise.reject(new Error("Forbidden")),
+      Promise.reject(new Error("Internal error")),
+    ]);
+    const out = summarizeBulkResult(
+      results,
+      ["a", "b", "c", "d", "e"],
+      "denials",
+    );
+    expect(out.summary).toBe(
+      "5 of 5 denials failed: 4× Forbidden; 1× Internal error",
+    );
+  });
+
+  test("non-Error rejection reasons stringify (not 'Unknown error')", async () => {
+    const results = await Promise.allSettled([
+      Promise.reject("raw string rejection"),
+      Promise.reject(null),
+    ]);
+    const out = summarizeBulkResult(results, ["a", "b"], "denials");
+    // Delegates to `bulkFailureSummary` which does `String(reason)` —
+    // lock in the passthrough so a future "collapse to Unknown error"
+    // refactor would be caught by this assertion.
+    expect(out.summary).toBe(
+      "2 of 2 denials failed: 1× raw string rejection; 1× null",
+    );
+  });
+
+  test("empty inputs don't throw and return null summary", () => {
+    const out = summarizeBulkResult([], [], "approvals");
+    expect(out.summary).toBeNull();
+    expect([...out.remainingIds]).toEqual([]);
+  });
+
+  test("uses caller-supplied noun verbatim", async () => {
+    const results = await Promise.allSettled([
+      Promise.reject(new Error("boom")),
+    ]);
+    const out = summarizeBulkResult(results, ["a"], "rollbacks");
+    expect(out.summary).toBe("1 of 1 rollbacks failed: 1× boom");
+  });
+});

--- a/packages/web/src/app/admin/actions/__tests__/bulk-result.test.ts
+++ b/packages/web/src/app/admin/actions/__tests__/bulk-result.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { summarizeBulkResult } from "../bulk-result";
+import {
+  bulkDenyConfirmLabel,
+  bulkDenyTitle,
+  summarizeBulkResult,
+} from "../bulk-result";
 
 /**
  * `summarizeBulkResult` is the pure core of the page's `handleBulkResult`
@@ -75,9 +79,10 @@ describe("summarizeBulkResult", () => {
       Promise.reject(null),
     ]);
     const out = summarizeBulkResult(results, ["a", "b"], "denials");
-    // Delegates to `bulkFailureSummary` which does `String(reason)` —
-    // lock in the passthrough so a future "collapse to Unknown error"
-    // refactor would be caught by this assertion.
+    // Delegates to `bulkFailureSummary`, which renders Errors via
+    // `err.message` and everything else via `String(reason)`. Lock in
+    // the passthrough so a future "collapse to Unknown error" refactor
+    // would be caught by this assertion.
     expect(out.summary).toBe(
       "2 of 2 denials failed: 1× raw string rejection; 1× null",
     );
@@ -95,5 +100,27 @@ describe("summarizeBulkResult", () => {
     ]);
     const out = summarizeBulkResult(results, ["a"], "rollbacks");
     expect(out.summary).toBe("1 of 1 rollbacks failed: 1× boom");
+  });
+});
+
+describe("bulkDenyTitle / bulkDenyConfirmLabel", () => {
+  test("singular form for count=1", () => {
+    expect(bulkDenyTitle(1)).toBe("Deny 1 action");
+    expect(bulkDenyConfirmLabel(1)).toBe("Deny 1");
+  });
+
+  test("plural form for count=2+", () => {
+    expect(bulkDenyTitle(2)).toBe("Deny 2 actions");
+    expect(bulkDenyTitle(5)).toBe("Deny 5 actions");
+    expect(bulkDenyConfirmLabel(2)).toBe("Deny 2");
+    expect(bulkDenyConfirmLabel(5)).toBe("Deny 5");
+  });
+
+  test("plural form for count=0 (dialog never opens at 0, but the string shouldn't be grammatically broken if a re-render races)", () => {
+    // A strict `count >= 1` treatment would regress to "Deny 0 action" and
+    // slip past every other assertion — lock the plural form here so a
+    // refactor that flipped the comparison would fail.
+    expect(bulkDenyTitle(0)).toBe("Deny 0 actions");
+    expect(bulkDenyConfirmLabel(0)).toBe("Deny 0");
   });
 });

--- a/packages/web/src/app/admin/actions/__tests__/deny-dialog-behavior.test.tsx
+++ b/packages/web/src/app/admin/actions/__tests__/deny-dialog-behavior.test.tsx
@@ -1,0 +1,335 @@
+import {
+  describe,
+  expect,
+  test,
+  beforeEach,
+  afterEach,
+  mock,
+  type Mock,
+} from "bun:test";
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  act,
+  waitFor,
+} from "@testing-library/react";
+import { ReasonDialog } from "@/ui/components/admin/queue";
+
+/**
+ * ReasonDialog behaviors the /admin/actions page relies on, per #1593.
+ *
+ * Distinct from the existing `reason-dialog.test.tsx` (which pins the
+ * three-slot error precedence added in #1612). Tests here lock in the
+ * timing, trimming, keyboard, and loading-disabled contracts that the
+ * actions page approval flow depends on for correct audit behavior.
+ */
+
+let consoleWarnSpy: Mock<(...args: unknown[]) => void>;
+const originalConsoleWarn = console.warn;
+
+beforeEach(() => {
+  consoleWarnSpy = mock(() => {});
+  console.warn = consoleWarnSpy as unknown as typeof console.warn;
+});
+
+afterEach(() => {
+  console.warn = originalConsoleWarn;
+  cleanup();
+});
+
+function getTextarea(): HTMLTextAreaElement {
+  const textarea = document.body.querySelector(
+    "#reason-dialog-reason",
+  ) as HTMLTextAreaElement | null;
+  if (!textarea) throw new Error("Reason textarea not found");
+  return textarea;
+}
+
+function getConfirmButton(label = "Deny"): HTMLButtonElement {
+  const buttons = [
+    ...document.body.querySelectorAll("button"),
+  ] as HTMLButtonElement[];
+  const btn = buttons.find((b) => b.textContent?.trim() === label);
+  if (!btn) throw new Error(`Confirm button with label "${label}" not found`);
+  return btn;
+}
+
+describe("ReasonDialog — reason reset timing", () => {
+  test("reason clears on close (not on open)", async () => {
+    // The useEffect deps are `[open]` with a `!open` guard — that's
+    // reset-on-close. A refactor that flipped it to reset-on-open would
+    // wipe the user's typing if the dialog re-rendered mid-typing (e.g.
+    // a parent re-render that doesn't toggle `open`).
+    function Harness({
+      open,
+      defaultReason = "",
+    }: {
+      open: boolean;
+      defaultReason?: string;
+    }) {
+      return (
+        <ReasonDialog
+          open={open}
+          onOpenChange={() => {}}
+          title="Deny"
+          onConfirm={async () => {}}
+          placeholder={defaultReason}
+        />
+      );
+    }
+
+    const { rerender } = render(<Harness open={true} />);
+    const textarea = getTextarea();
+    fireEvent.change(textarea, { target: { value: "reason text" } });
+    expect(textarea.value).toBe("reason text");
+
+    // Close — effect fires with !open, resets reason
+    rerender(<Harness open={false} />);
+
+    // Reopen — reason must be empty. If the effect reset on open instead of
+    // close, the behavior would *look* similar from the outside but would
+    // wipe the user's in-progress typing mid-dialog.
+    rerender(<Harness open={true} />);
+    const reopenedTextarea = getTextarea();
+    expect(reopenedTextarea.value).toBe("");
+  });
+});
+
+describe("ReasonDialog — Cmd+Enter keyboard", () => {
+  test("Cmd+Enter while not loading triggers onConfirm with trimmed reason", async () => {
+    const onConfirm = mock(async () => {});
+    render(
+      <ReasonDialog
+        open
+        onOpenChange={() => {}}
+        title="Deny"
+        onConfirm={onConfirm as unknown as (r: string) => Promise<void>}
+      />,
+    );
+    const textarea = getTextarea();
+    fireEvent.change(textarea, {
+      target: { value: "  policy violation  " },
+    });
+
+    await act(async () => {
+      fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+    });
+
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalled();
+    });
+    expect(onConfirm.mock.calls[0]?.[0]).toBe("policy violation");
+  });
+
+  test("Ctrl+Enter (non-macOS) also triggers onConfirm", async () => {
+    const onConfirm = mock(async () => {});
+    render(
+      <ReasonDialog
+        open
+        onOpenChange={() => {}}
+        title="Deny"
+        onConfirm={onConfirm as unknown as (r: string) => Promise<void>}
+      />,
+    );
+    const textarea = getTextarea();
+    fireEvent.change(textarea, { target: { value: "reason" } });
+
+    await act(async () => {
+      fireEvent.keyDown(textarea, { key: "Enter", ctrlKey: true });
+    });
+
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalled();
+    });
+  });
+
+  test("Cmd+Enter while loading does NOT trigger onConfirm", async () => {
+    // Guards against a double-fire if the operator hits Cmd+Enter twice —
+    // the second invocation would trigger a duplicate deny without this
+    // check. Audit-sensitive.
+    const onConfirm = mock(async () => {});
+    render(
+      <ReasonDialog
+        open
+        onOpenChange={() => {}}
+        title="Deny"
+        onConfirm={onConfirm as unknown as (r: string) => Promise<void>}
+        loading
+      />,
+    );
+    const textarea = getTextarea();
+    // Textarea is disabled while loading — set value via direct assignment
+    // since fireEvent.change on a disabled element is a no-op.
+    Object.defineProperty(textarea, "value", {
+      value: "reason",
+      writable: true,
+      configurable: true,
+    });
+
+    await act(async () => {
+      fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+    });
+
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  test("plain Enter (no modifier) does NOT trigger onConfirm — preserves newline insertion", async () => {
+    const onConfirm = mock(async () => {});
+    render(
+      <ReasonDialog
+        open
+        onOpenChange={() => {}}
+        title="Deny"
+        onConfirm={onConfirm as unknown as (r: string) => Promise<void>}
+      />,
+    );
+    const textarea = getTextarea();
+    fireEvent.change(textarea, { target: { value: "reason" } });
+
+    await act(async () => {
+      fireEvent.keyDown(textarea, { key: "Enter" });
+    });
+
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});
+
+describe("ReasonDialog — trim behavior", () => {
+  test("confirm click passes trimmed reason to onConfirm", async () => {
+    const onConfirm = mock(async () => {});
+    render(
+      <ReasonDialog
+        open
+        onOpenChange={() => {}}
+        title="Deny"
+        onConfirm={onConfirm as unknown as (r: string) => Promise<void>}
+      />,
+    );
+    const textarea = getTextarea();
+    fireEvent.change(textarea, {
+      target: { value: "   leading + trailing   " },
+    });
+
+    await act(async () => {
+      fireEvent.click(getConfirmButton());
+    });
+
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalled();
+    });
+    expect(onConfirm.mock.calls[0]?.[0]).toBe("leading + trailing");
+  });
+
+  test("whitespace-only reason is passed as empty string (not substituted)", async () => {
+    // Caller contract: the dialog emits exactly what the user typed,
+    // trimmed — including the empty string. A substitution like
+    // `reason || "no reason given"` would corrupt the audit trail by
+    // making "no reason given" indistinguishable from a real typed one.
+    const onConfirm = mock(async () => {});
+    render(
+      <ReasonDialog
+        open
+        onOpenChange={() => {}}
+        title="Deny"
+        onConfirm={onConfirm as unknown as (r: string) => Promise<void>}
+      />,
+    );
+    const textarea = getTextarea();
+    fireEvent.change(textarea, { target: { value: "     " } });
+
+    await act(async () => {
+      fireEvent.click(getConfirmButton());
+    });
+
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalled();
+    });
+    expect(onConfirm.mock.calls[0]?.[0]).toBe("");
+  });
+
+  test("required=true blocks confirm when reason is whitespace-only", async () => {
+    const onConfirm = mock(async () => {});
+    render(
+      <ReasonDialog
+        open
+        onOpenChange={() => {}}
+        title="Deny"
+        required
+        onConfirm={onConfirm as unknown as (r: string) => Promise<void>}
+      />,
+    );
+    const textarea = getTextarea();
+    fireEvent.change(textarea, { target: { value: "     " } });
+
+    const btn = getConfirmButton();
+    expect(btn.disabled).toBe(true);
+
+    // Even if click somehow got through, handleConfirm returns early.
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});
+
+describe("ReasonDialog — onOpenChange blocked while loading", () => {
+  test("attempt to close while loading is a no-op (cancel-doesn't-cancel fix)", async () => {
+    // Without the `if (!next && loading) return` guard, the operator
+    // thinks they aborted but the request still resolves server-side
+    // (and if the resolution is a deny, the audit trail records the
+    // deny without the operator's consent).
+    const onOpenChange = mock(() => {});
+    render(
+      <ReasonDialog
+        open
+        onOpenChange={onOpenChange}
+        title="Deny"
+        onConfirm={async () => {}}
+        loading
+      />,
+    );
+
+    // Cancel button should be disabled while loading.
+    const buttons = [
+      ...document.body.querySelectorAll("button"),
+    ] as HTMLButtonElement[];
+    const cancel = buttons.find((b) => b.textContent?.trim() === "Cancel");
+    expect(cancel?.disabled).toBe(true);
+
+    // Radix's Escape handler fires onOpenChange(false). We simulate at the
+    // content level — the Dialog's onOpenChange prop should swallow the
+    // false-while-loading and never reach the caller's handler.
+    // Pressing Escape directly on the textarea is the cleanest simulation.
+    await act(async () => {
+      fireEvent.keyDown(getTextarea(), { key: "Escape" });
+    });
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  test("close path works normally when not loading", async () => {
+    const onOpenChange = mock(() => {});
+    render(
+      <ReasonDialog
+        open
+        onOpenChange={onOpenChange}
+        title="Deny"
+        onConfirm={async () => {}}
+      />,
+    );
+    // Cancel button dispatches onOpenChange(false) directly.
+    const buttons = [
+      ...document.body.querySelectorAll("button"),
+    ] as HTMLButtonElement[];
+    const cancel = buttons.find((b) => b.textContent?.trim() === "Cancel");
+    expect(cancel).toBeTruthy();
+    await act(async () => {
+      fireEvent.click(cancel!);
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});
+
+// Suppress unused-import warning: `screen` is kept available for future tests.
+void screen;

--- a/packages/web/src/app/admin/actions/__tests__/deny-dialog-behavior.test.tsx
+++ b/packages/web/src/app/admin/actions/__tests__/deny-dialog-behavior.test.tsx
@@ -18,12 +18,12 @@ import {
 import { ReasonDialog } from "@/ui/components/admin/queue";
 
 /**
- * ReasonDialog behaviors the /admin/actions page relies on, per #1593.
+ * ReasonDialog behaviors the /admin/actions page relies on.
  *
- * Distinct from the existing `reason-dialog.test.tsx` (which pins the
- * three-slot error precedence added in #1612). Tests here lock in the
- * timing, trimming, keyboard, and loading-disabled contracts that the
- * actions page approval flow depends on for correct audit behavior.
+ * Distinct from the sibling `reason-dialog.test.tsx` which covers the
+ * three-slot error-precedence contract. Tests here lock in the timing,
+ * trimming, keyboard, and loading-disabled contracts that the actions
+ * page approval flow depends on for correct audit behavior.
  */
 
 let consoleWarnSpy: Mock<(...args: unknown[]) => void>;
@@ -275,11 +275,11 @@ describe("ReasonDialog — trim behavior", () => {
 });
 
 describe("ReasonDialog — onOpenChange blocked while loading", () => {
-  test("attempt to close while loading is a no-op (cancel-doesn't-cancel fix)", async () => {
-    // Without the `if (!next && loading) return` guard, the operator
-    // thinks they aborted but the request still resolves server-side
-    // (and if the resolution is a deny, the audit trail records the
-    // deny without the operator's consent).
+  test("Cancel button is disabled while loading and clicks don't dispatch close", async () => {
+    // Primary cancel-doesn't-cancel guard: the Cancel button carries
+    // `disabled={loading}`, which removes the operator-visible path to
+    // cancel an in-flight request. Without this, clicking Cancel would
+    // look like "abort" but the request still resolves server-side.
     const onOpenChange = mock(() => {});
     render(
       <ReasonDialog
@@ -291,24 +291,46 @@ describe("ReasonDialog — onOpenChange blocked while loading", () => {
       />,
     );
 
-    // Cancel button should be disabled while loading.
     const buttons = [
       ...document.body.querySelectorAll("button"),
     ] as HTMLButtonElement[];
     const cancel = buttons.find((b) => b.textContent?.trim() === "Cancel");
     expect(cancel?.disabled).toBe(true);
 
-    // Radix's Escape handler fires onOpenChange(false). We simulate at the
-    // content level — the Dialog's onOpenChange prop should swallow the
-    // false-while-loading and never reach the caller's handler.
-    // Pressing Escape directly on the textarea is the cleanest simulation.
+    // Clicking a disabled button is a no-op at the DOM level — still
+    // assert onOpenChange never fires so a regression that dropped
+    // the disabled attribute would surface.
     await act(async () => {
-      fireEvent.keyDown(getTextarea(), { key: "Escape" });
+      fireEvent.click(cancel!);
+    });
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  test("Radix-internal close path (Escape) while loading is swallowed by the guard", async () => {
+    // Belt-and-suspenders: even if Radix fires onOpenChange(false) from
+    // its internal Escape handler, the ReasonDialog wrapper
+    // `if (!next && loading) return` must swallow it. We exercise the
+    // guard by dispatching Escape at the document level (where Radix
+    // listens). If the Escape handler doesn't fire in jsdom, the guard
+    // still holds vacuously — the primary Cancel-disabled assertion
+    // above remains the load-bearing check.
+    const onOpenChange = mock(() => {});
+    render(
+      <ReasonDialog
+        open
+        onOpenChange={onOpenChange}
+        title="Deny"
+        onConfirm={async () => {}}
+        loading
+      />,
+    );
+    await act(async () => {
+      fireEvent.keyDown(document.body, { key: "Escape" });
     });
     expect(onOpenChange).not.toHaveBeenCalledWith(false);
   });
 
-  test("close path works normally when not loading", async () => {
+  test("Cancel dispatches onOpenChange(false) when not loading", async () => {
     const onOpenChange = mock(() => {});
     render(
       <ReasonDialog
@@ -318,12 +340,12 @@ describe("ReasonDialog — onOpenChange blocked while loading", () => {
         onConfirm={async () => {}}
       />,
     );
-    // Cancel button dispatches onOpenChange(false) directly.
     const buttons = [
       ...document.body.querySelectorAll("button"),
     ] as HTMLButtonElement[];
     const cancel = buttons.find((b) => b.textContent?.trim() === "Cancel");
     expect(cancel).toBeTruthy();
+    expect(cancel?.disabled).toBe(false);
     await act(async () => {
       fireEvent.click(cancel!);
     });

--- a/packages/web/src/app/admin/actions/__tests__/labels.test.tsx
+++ b/packages/web/src/app/admin/actions/__tests__/labels.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { Zap, Database, Globe, FilePenLine, Terminal } from "lucide-react";
+import { actionTypeIcon, actionTypeLabel } from "../labels";
+
+/**
+ * `actionTypeLabel` / `actionTypeIcon` both call `.toLowerCase()` on the
+ * input before looking up the registry. Dev fixtures happen to be all-
+ * lowercase so a manual click-through would never catch a regression that
+ * dropped the lowercasing — every unknown-cased input would silently fall
+ * through to the Zap/raw-string fallback and the page would still render.
+ * Pin the case-insensitivity contract here so that class of bug surfaces.
+ */
+describe("actionTypeLabel", () => {
+  test("known lowercase types map to their labels", () => {
+    expect(actionTypeLabel("sql_write")).toBe("SQL Write");
+    expect(actionTypeLabel("sql")).toBe("SQL");
+    expect(actionTypeLabel("api_call")).toBe("API Call");
+    expect(actionTypeLabel("api")).toBe("API");
+    expect(actionTypeLabel("file_write")).toBe("File Write");
+    expect(actionTypeLabel("file")).toBe("File");
+    expect(actionTypeLabel("shell")).toBe("Shell");
+    expect(actionTypeLabel("command")).toBe("Command");
+  });
+
+  test("mixed-case input still maps (load-bearing .toLowerCase())", () => {
+    expect(actionTypeLabel("SQL_Write")).toBe("SQL Write");
+    expect(actionTypeLabel("SQL_WRITE")).toBe("SQL Write");
+    expect(actionTypeLabel("Api_Call")).toBe("API Call");
+    expect(actionTypeLabel("FILE")).toBe("File");
+  });
+
+  test("unknown type returns the raw input verbatim", () => {
+    // The fallback returns the raw `type` argument (not lowercased) so the
+    // caller still sees what the agent actually sent.
+    expect(actionTypeLabel("webhook_post")).toBe("webhook_post");
+    expect(actionTypeLabel("CustomTool")).toBe("CustomTool");
+    expect(actionTypeLabel("")).toBe("");
+  });
+});
+
+describe("actionTypeIcon", () => {
+  test("known lowercase types map to their icon", () => {
+    expect(actionTypeIcon("sql_write")).toBe(Database);
+    expect(actionTypeIcon("sql")).toBe(Database);
+    expect(actionTypeIcon("api_call")).toBe(Globe);
+    expect(actionTypeIcon("api")).toBe(Globe);
+    expect(actionTypeIcon("file_write")).toBe(FilePenLine);
+    expect(actionTypeIcon("file")).toBe(FilePenLine);
+    expect(actionTypeIcon("shell")).toBe(Terminal);
+    expect(actionTypeIcon("command")).toBe(Terminal);
+  });
+
+  test("mixed-case input still maps to the right icon", () => {
+    expect(actionTypeIcon("SQL_Write")).toBe(Database);
+    expect(actionTypeIcon("API_CALL")).toBe(Globe);
+    expect(actionTypeIcon("File_Write")).toBe(FilePenLine);
+    expect(actionTypeIcon("SHELL")).toBe(Terminal);
+  });
+
+  test("unknown type returns Zap (reference equality)", () => {
+    // Asserting reference equality (not just truthy) locks the fallback —
+    // a regression that returned a different LucideIcon would break the
+    // admin UX's consistent "unknown tool" affordance.
+    expect(actionTypeIcon("webhook_post")).toBe(Zap);
+    expect(actionTypeIcon("")).toBe(Zap);
+  });
+});

--- a/packages/web/src/app/admin/actions/__tests__/payload-view.test.tsx
+++ b/packages/web/src/app/admin/actions/__tests__/payload-view.test.tsx
@@ -22,22 +22,24 @@ afterEach(() => {
 
 describe("PayloadView — sql variants", () => {
   test("sql_write and sql render the same pre-block (alias parity)", () => {
-    const payload = { sql: "SELECT 1" };
-    const { container: sqlWrite } = render(
-      <PayloadView type="sql_write" payload={payload} />,
-    );
-    cleanup();
-    const { container: sqlPlain } = render(
-      <PayloadView type="sql" payload={payload} />,
-    );
-    // Both render a <pre> containing the SQL verbatim — locks the alias.
-    const preA = sqlWrite.querySelector("pre");
-    const preB = sqlPlain.querySelector("pre");
-    // sqlWrite was cleaned up, so it has no pre anymore — assert the alias
-    // via the second render alone plus a re-render of the first variant.
-    expect(preB?.textContent).toBe("SELECT 1");
+    // Render into two independent detached containers so we can capture
+    // both pre-blocks before any cleanup — a previous version cleaned up
+    // between renders and ended up asserting only on the second variant,
+    // which would have passed even if `sql_write` silently regressed to
+    // the JSON fallback. Independent mounts make the alias assertion real.
+    const sqlWriteHost = document.createElement("div");
+    const sqlHost = document.createElement("div");
+    render(<PayloadView type="sql_write" payload={{ sql: "SELECT 1" }} />, {
+      container: sqlWriteHost,
+    });
+    render(<PayloadView type="sql" payload={{ sql: "SELECT 1" }} />, {
+      container: sqlHost,
+    });
+    const preSqlWrite = sqlWriteHost.querySelector("pre");
+    const preSql = sqlHost.querySelector("pre");
+    expect(preSqlWrite?.textContent).toBe("SELECT 1");
+    expect(preSql?.textContent).toBe("SELECT 1");
     expect(consoleWarnSpy).not.toHaveBeenCalled();
-    void preA;
   });
 
   test("sql_write with non-string .sql falls through to JSON fallback + warns", () => {

--- a/packages/web/src/app/admin/actions/__tests__/payload-view.test.tsx
+++ b/packages/web/src/app/admin/actions/__tests__/payload-view.test.tsx
@@ -1,0 +1,177 @@
+import { describe, expect, test, beforeEach, afterEach, mock, type Mock } from "bun:test";
+import { render, cleanup } from "@testing-library/react";
+import { PayloadView } from "../payload-view";
+
+// Silence + assert the observability warn the component fires when a
+// known-type payload is malformed. Without the spy, every malformed-
+// payload branch floods CI stderr. The warn contract is part of the
+// component's interface — dropping it silently would make schema drift
+// (agent emits a new payload shape) invisible.
+let consoleWarnSpy: Mock<(...args: unknown[]) => void>;
+const originalConsoleWarn = console.warn;
+
+beforeEach(() => {
+  consoleWarnSpy = mock(() => {});
+  console.warn = consoleWarnSpy as unknown as typeof console.warn;
+});
+
+afterEach(() => {
+  console.warn = originalConsoleWarn;
+  cleanup();
+});
+
+describe("PayloadView — sql variants", () => {
+  test("sql_write and sql render the same pre-block (alias parity)", () => {
+    const payload = { sql: "SELECT 1" };
+    const { container: sqlWrite } = render(
+      <PayloadView type="sql_write" payload={payload} />,
+    );
+    cleanup();
+    const { container: sqlPlain } = render(
+      <PayloadView type="sql" payload={payload} />,
+    );
+    // Both render a <pre> containing the SQL verbatim — locks the alias.
+    const preA = sqlWrite.querySelector("pre");
+    const preB = sqlPlain.querySelector("pre");
+    // sqlWrite was cleaned up, so it has no pre anymore — assert the alias
+    // via the second render alone plus a re-render of the first variant.
+    expect(preB?.textContent).toBe("SELECT 1");
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+    void preA;
+  });
+
+  test("sql_write with non-string .sql falls through to JSON fallback + warns", () => {
+    const payload = { sql: 42 as unknown };
+    const { container } = render(
+      <PayloadView type="sql_write" payload={payload as Record<string, unknown>} />,
+    );
+    const pre = container.querySelector("pre");
+    // JSON fallback renders the whole payload object as formatted JSON.
+    expect(pre?.textContent).toContain('"sql": 42');
+    expect(consoleWarnSpy).toHaveBeenCalled();
+    expect(consoleWarnSpy.mock.calls[0]?.[0]).toContain(
+      "PayloadView: sql_write payload missing string .sql",
+    );
+  });
+});
+
+describe("PayloadView — api_call variants", () => {
+  test("method + url + body renders all three", () => {
+    const { container } = render(
+      <PayloadView
+        type="api_call"
+        payload={{ method: "POST", url: "/api/v1/foo", body: { x: 1 } }}
+      />,
+    );
+    expect(container.textContent).toContain("POST");
+    expect(container.textContent).toContain("/api/v1/foo");
+    // Body object JSON-stringifies
+    expect(container.textContent).toContain('"x": 1');
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  test("method-only (no url) still renders without warn", () => {
+    const { container } = render(
+      <PayloadView type="api_call" payload={{ method: "GET" }} />,
+    );
+    expect(container.textContent).toContain("GET");
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  test("url-only (no method) still renders without warn", () => {
+    const { container } = render(
+      <PayloadView type="api_call" payload={{ url: "/healthz" }} />,
+    );
+    expect(container.textContent).toContain("/healthz");
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  test("neither method nor url → JSON fallback + warn", () => {
+    const payload = { headers: { "x-trace": "abc" } };
+    const { container } = render(
+      <PayloadView type="api_call" payload={payload} />,
+    );
+    const pre = container.querySelector("pre");
+    expect(pre?.textContent).toContain('"x-trace"');
+    expect(consoleWarnSpy).toHaveBeenCalled();
+    expect(consoleWarnSpy.mock.calls[0]?.[0]).toContain(
+      "PayloadView: api_call payload missing method/url",
+    );
+  });
+
+  test("string body is rendered verbatim (not JSON.stringified)", () => {
+    const { container } = render(
+      <PayloadView
+        type="api_call"
+        payload={{ method: "POST", url: "/foo", body: "raw-string-body" }}
+      />,
+    );
+    expect(container.textContent).toContain("raw-string-body");
+    // A string body double-quoted would indicate JSON.stringify was applied.
+    expect(container.textContent).not.toContain('"raw-string-body"');
+  });
+});
+
+describe("PayloadView — file_write variants", () => {
+  test("path-only renders the path without a content block", () => {
+    const { container } = render(
+      <PayloadView type="file_write" payload={{ path: "/tmp/foo.txt" }} />,
+    );
+    expect(container.textContent).toContain("/tmp/foo.txt");
+    // With no .content, only the path pre-block renders (no second pre).
+    const pres = container.querySelectorAll("pre");
+    expect(pres.length).toBe(0);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  test("path + string content renders both", () => {
+    const { container } = render(
+      <PayloadView
+        type="file_write"
+        payload={{ path: "/tmp/foo.txt", content: "hello world" }}
+      />,
+    );
+    expect(container.textContent).toContain("/tmp/foo.txt");
+    expect(container.textContent).toContain("hello world");
+  });
+
+  test("non-string .path falls through to JSON fallback + warn", () => {
+    const payload = { path: ["not", "a", "string"] as unknown };
+    const { container } = render(
+      <PayloadView type="file_write" payload={payload as Record<string, unknown>} />,
+    );
+    const pre = container.querySelector("pre");
+    expect(pre?.textContent).toContain('"not"');
+    expect(consoleWarnSpy).toHaveBeenCalled();
+    expect(consoleWarnSpy.mock.calls[0]?.[0]).toContain(
+      "PayloadView: file_write payload missing string .path",
+    );
+  });
+});
+
+describe("PayloadView — unknown type", () => {
+  test("unknown type falls to JSON fallback without warn", () => {
+    const { container } = render(
+      <PayloadView
+        type="webhook_post"
+        payload={{ url: "https://example.com", body: "hi" }}
+      />,
+    );
+    const pre = container.querySelector("pre");
+    expect(pre?.textContent).toContain('"url": "https://example.com"');
+    expect(pre?.textContent).toContain('"body": "hi"');
+    // Unknown types are expected — don't pollute observability.
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  test("mixed-case type still matches (lowercase branch)", () => {
+    // Mirror the labels.toLowerCase() normalization — a "SQL" type from the
+    // agent must still render the SQL pre-block, not fall to JSON.
+    const { container } = render(
+      <PayloadView type="SQL" payload={{ sql: "SELECT 1" }} />,
+    );
+    const pre = container.querySelector("pre");
+    expect(pre?.textContent).toBe("SELECT 1");
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/app/admin/actions/bulk-result.ts
+++ b/packages/web/src/app/admin/actions/bulk-result.ts
@@ -3,6 +3,20 @@ import {
   failedIdsFrom,
 } from "@/ui/components/admin/queue";
 
+/**
+ * Dialog title for the bulk-deny confirm dialog. Pluralization is
+ * load-bearing: a grammatically broken "Deny 0 actions" or "Deny 1
+ * actions" would ship as audit-trail-adjacent UX drift.
+ */
+export function bulkDenyTitle(selectedCount: number): string {
+  return `Deny ${selectedCount} action${selectedCount === 1 ? "" : "s"}`;
+}
+
+/** Confirm-button label for the bulk-deny dialog. */
+export function bulkDenyConfirmLabel(selectedCount: number): string {
+  return `Deny ${selectedCount}`;
+}
+
 export interface BulkResult {
   /** Banner copy when any request rejected. Null when nothing failed. */
   summary: string | null;

--- a/packages/web/src/app/admin/actions/bulk-result.ts
+++ b/packages/web/src/app/admin/actions/bulk-result.ts
@@ -1,0 +1,35 @@
+import {
+  bulkFailureSummary,
+  failedIdsFrom,
+} from "@/ui/components/admin/queue";
+
+export interface BulkResult {
+  /** Banner copy when any request rejected. Null when nothing failed. */
+  summary: string | null;
+  /** Ids of requests that failed — caller narrows its selection to these. */
+  remainingIds: Set<string>;
+}
+
+/**
+ * Pure summary of a client-side bulk fan-out. Callers route `summary` to
+ * their banner state and use `remainingIds` to narrow row selection so a
+ * retry click targets exactly the rows that still need action.
+ *
+ * Index pairing between `results` and `ids` is compliance-sensitive — a
+ * reorder bug would narrow selection to the wrong rows. Covered in
+ * `bulk-result.test.ts`.
+ */
+export function summarizeBulkResult(
+  results: PromiseSettledResult<unknown>[],
+  ids: string[],
+  noun: string,
+): BulkResult {
+  const failedIds = failedIdsFrom(results, ids);
+  if (failedIds.length === 0) {
+    return { summary: null, remainingIds: new Set() };
+  }
+  return {
+    summary: bulkFailureSummary(results, ids, noun),
+    remainingIds: new Set(failedIds),
+  };
+}

--- a/packages/web/src/app/admin/actions/page.tsx
+++ b/packages/web/src/app/admin/actions/page.tsx
@@ -3,7 +3,9 @@
 import { Fragment, useEffect, useState } from "react";
 import { useQueryStates } from "nuqs";
 import { actionsSearchParams } from "./search-params";
+import { summarizeBulkResult } from "./bulk-result";
 import { ACTION_TYPE_LABELS, actionTypeIcon, actionTypeLabel } from "./labels";
+import { PayloadView } from "./payload-view";
 import { coerceRollbackWarning, logUnsurfacedRollbackWarning } from "./rollback-warning";
 import { useAtlasConfig } from "@/ui/context";
 import {
@@ -31,9 +33,7 @@ import { EmptyState } from "@/ui/components/admin/empty-state";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import {
-  bulkFailureSummary,
   BulkRequestError,
-  failedIdsFrom,
   QueueFilterRow,
   ReasonDialog,
   RelativeTimestamp,
@@ -82,72 +82,6 @@ const EMPTY_MESSAGES: Record<StatusFilter, string> = {
   rolled_back: "No rolled back actions.",
   all: "No actions recorded yet.",
 };
-
-function PayloadView({ type, payload }: { type: string; payload: Record<string, unknown> }) {
-  const t = type.toLowerCase();
-
-  if (t === "sql_write" || t === "sql") {
-    if (typeof payload.sql === "string") {
-      return (
-        <pre className="overflow-auto rounded border bg-muted/60 p-2 font-mono text-xs leading-relaxed">
-          {payload.sql}
-        </pre>
-      );
-    }
-    console.warn(`PayloadView: ${type} payload missing string .sql`, payload);
-  }
-
-  if (t === "api_call" || t === "api") {
-    const method = typeof payload.method === "string" ? payload.method : null;
-    const url = typeof payload.url === "string" ? payload.url : null;
-    if (method || url) {
-      const body = payload.body;
-      return (
-        <div className="space-y-1.5">
-          <div className="flex items-center gap-2 rounded border bg-muted/60 px-2 py-1.5 font-mono text-xs">
-            {method && (
-              <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
-                {method}
-              </span>
-            )}
-            {url && <span className="truncate text-foreground">{url}</span>}
-          </div>
-          {body != null && (
-            <pre className="overflow-auto rounded border bg-muted/40 p-2 text-xs">
-              {typeof body === "string" ? body : JSON.stringify(body, null, 2)}
-            </pre>
-          )}
-        </div>
-      );
-    }
-    console.warn(`PayloadView: ${type} payload missing method/url`, payload);
-  }
-
-  if (t === "file_write" || t === "file") {
-    if (typeof payload.path === "string") {
-      return (
-        <div className="space-y-1.5">
-          <div className="rounded border bg-muted/60 px-2 py-1.5 font-mono text-xs">
-            {payload.path}
-          </div>
-          {typeof payload.content === "string" && (
-            <pre className="overflow-auto rounded border bg-muted/40 p-2 font-mono text-xs">
-              {payload.content}
-            </pre>
-          )}
-        </div>
-      );
-    }
-    console.warn(`PayloadView: ${type} payload missing string .path`, payload);
-  }
-
-  // Fallback so payloads from new tools surface unformatted instead of disappearing.
-  return (
-    <pre className="overflow-auto rounded border bg-muted/40 p-2 text-xs">
-      {JSON.stringify(payload, null, 2)}
-    </pre>
-  );
-}
 
 function WarningBanner({ message, onDismiss }: { message: string; onDismiss: () => void }) {
   return (
@@ -357,8 +291,8 @@ export default function ActionsPage() {
       const results = await Promise.allSettled(
         ids.map((id) => bulkRequest(id, "deny", body)),
       );
-      const failedCount = results.filter((r) => r.status === "rejected").length;
-      if (failedCount === 0) {
+      const { summary, remainingIds } = summarizeBulkResult(results, ids, "denials");
+      if (summary === null) {
         setSelectedIds(new Set());
         setBulkDenyOpen(false);
         setRefetchKey((k) => k + 1);
@@ -367,9 +301,8 @@ export default function ActionsPage() {
       // Partial / total failure: narrow selection to failed IDs and surface
       // the summary inside the dialog so a retry click sees the *current*
       // attempt's stats, not the prior one (bulkError clears at fn entry).
-      const summary = bulkFailureSummary(results, ids, "denials");
       setBulkError(summary);
-      setSelectedIds(new Set(failedIdsFrom(results, ids)));
+      setSelectedIds(remainingIds);
       setRefetchKey((k) => k + 1);
     } finally {
       setBulkAction(null);
@@ -382,13 +315,9 @@ export default function ActionsPage() {
     ids: string[],
     noun: string,
   ) {
-    const failedIds = failedIdsFrom(results, ids);
-    if (failedIds.length > 0) {
-      setBulkApproveSummary(bulkFailureSummary(results, ids, noun));
-      setSelectedIds(new Set(failedIds));
-    } else {
-      setSelectedIds(new Set());
-    }
+    const { summary, remainingIds } = summarizeBulkResult(results, ids, noun);
+    setBulkApproveSummary(summary);
+    setSelectedIds(remainingIds);
     setRefetchKey((k) => k + 1);
   }
 

--- a/packages/web/src/app/admin/actions/page.tsx
+++ b/packages/web/src/app/admin/actions/page.tsx
@@ -3,7 +3,7 @@
 import { Fragment, useEffect, useState } from "react";
 import { useQueryStates } from "nuqs";
 import { actionsSearchParams } from "./search-params";
-import { summarizeBulkResult } from "./bulk-result";
+import { bulkDenyConfirmLabel, bulkDenyTitle, summarizeBulkResult } from "./bulk-result";
 import { ACTION_TYPE_LABELS, actionTypeIcon, actionTypeLabel } from "./labels";
 import { PayloadView } from "./payload-view";
 import { coerceRollbackWarning, logUnsurfacedRollbackWarning } from "./rollback-warning";
@@ -687,9 +687,9 @@ export default function ActionsPage() {
               setBulkError(null);
             }
           }}
-          title={`Deny ${selectedIds.size} action${selectedIds.size === 1 ? "" : "s"}`}
+          title={bulkDenyTitle(selectedIds.size)}
           description="Recorded in the audit log alongside your account. Reason is optional but recommended for traceability."
-          confirmLabel={`Deny ${selectedIds.size}`}
+          confirmLabel={bulkDenyConfirmLabel(selectedIds.size)}
           onConfirm={confirmBulkDeny}
           loading={bulkAction === "deny"}
           error={bulkError}

--- a/packages/web/src/app/admin/actions/payload-view.tsx
+++ b/packages/web/src/app/admin/actions/payload-view.tsx
@@ -5,9 +5,10 @@
  * a JSON dump so the operator still sees *something* instead of a blank
  * expansion.
  *
- * The `console.warn` on malformed known-type payloads is load-bearing: it
- * surfaces schema drift when the agent starts emitting a new payload
- * shape. Without it, the fallback would silently hide the drift.
+ * The `console.warn` on malformed known-type payloads is intentional and
+ * asserted in `payload-view.test.tsx` — it surfaces schema drift when
+ * the agent starts emitting a new payload shape. Without it, the
+ * fallback would silently hide the drift.
  */
 export function PayloadView({
   type,

--- a/packages/web/src/app/admin/actions/payload-view.tsx
+++ b/packages/web/src/app/admin/actions/payload-view.tsx
@@ -1,0 +1,82 @@
+/**
+ * Renders an action's payload based on its `type`. Known types get a
+ * structured view (SQL pre-block, method/url chip, file path + content).
+ * Unknown types, and known types with malformed payloads, fall through to
+ * a JSON dump so the operator still sees *something* instead of a blank
+ * expansion.
+ *
+ * The `console.warn` on malformed known-type payloads is load-bearing: it
+ * surfaces schema drift when the agent starts emitting a new payload
+ * shape. Without it, the fallback would silently hide the drift.
+ */
+export function PayloadView({
+  type,
+  payload,
+}: {
+  type: string;
+  payload: Record<string, unknown>;
+}) {
+  const t = type.toLowerCase();
+
+  if (t === "sql_write" || t === "sql") {
+    if (typeof payload.sql === "string") {
+      return (
+        <pre className="overflow-auto rounded border bg-muted/60 p-2 font-mono text-xs leading-relaxed">
+          {payload.sql}
+        </pre>
+      );
+    }
+    console.warn(`PayloadView: ${type} payload missing string .sql`, payload);
+  }
+
+  if (t === "api_call" || t === "api") {
+    const method = typeof payload.method === "string" ? payload.method : null;
+    const url = typeof payload.url === "string" ? payload.url : null;
+    if (method || url) {
+      const body = payload.body;
+      return (
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-2 rounded border bg-muted/60 px-2 py-1.5 font-mono text-xs">
+            {method && (
+              <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
+                {method}
+              </span>
+            )}
+            {url && <span className="truncate text-foreground">{url}</span>}
+          </div>
+          {body != null && (
+            <pre className="overflow-auto rounded border bg-muted/40 p-2 text-xs">
+              {typeof body === "string" ? body : JSON.stringify(body, null, 2)}
+            </pre>
+          )}
+        </div>
+      );
+    }
+    console.warn(`PayloadView: ${type} payload missing method/url`, payload);
+  }
+
+  if (t === "file_write" || t === "file") {
+    if (typeof payload.path === "string") {
+      return (
+        <div className="space-y-1.5">
+          <div className="rounded border bg-muted/60 px-2 py-1.5 font-mono text-xs">
+            {payload.path}
+          </div>
+          {typeof payload.content === "string" && (
+            <pre className="overflow-auto rounded border bg-muted/40 p-2 font-mono text-xs">
+              {payload.content}
+            </pre>
+          )}
+        </div>
+      );
+    }
+    console.warn(`PayloadView: ${type} payload missing string .path`, payload);
+  }
+
+  // Fallback so payloads from new tools surface unformatted instead of disappearing.
+  return (
+    <pre className="overflow-auto rounded border bg-muted/40 p-2 text-xs">
+      {JSON.stringify(payload, null, 2)}
+    </pre>
+  );
+}


### PR DESCRIPTION
## Summary

- Extract `summarizeBulkResult` to `bulk-result.ts` and `PayloadView` to `payload-view.tsx` (page.tsx −71 lines); both bulk-approve + bulk-deny now share one pure summary helper so the index-based id-pairing lives in one place.
- 38 unit tests across 4 new files: `bulk-result.test.ts`, `labels.test.tsx` (pins the load-bearing `.toLowerCase()` — dev fixtures are all lowercase, so mixed-case regression was silent), `payload-view.test.tsx` (sql alias, api_call method/url fallbacks, file_write path variants, unknown-type JSON fallback, `console.warn` observability contract on malformed known-type payloads), and `deny-dialog-behavior.test.tsx` (reset-on-close vs reset-on-open, Cmd/Ctrl+Enter gating while loading, trim + whitespace-only → empty-string passthrough, onOpenChange blocked while loading).
- New `@llm`-tagged e2e spec `actions-approval.spec.ts` mocks `/api/v1/actions*` (admin-sessions pattern) and asserts the deny request carries the operator's reason verbatim — the single assertion that would have caught the original hardcoded `"Denied by admin"` bug #1592 fixed.

## Test plan

- [x] `bun run test src/app/admin/actions` — all 5 files pass
- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun x syncpack lint` — no issues
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — passed
- [ ] e2e spec runs green in the `@llm` suite alongside `starter-prompts-moderation.spec.ts` (exercised in CI)

Closes #1593