### PR TITLE
chore(types): bump @useatlas/types 0.0.11 → 0.0.12 (unblocks Deploy Validation)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -299,7 +299,7 @@
     },
     "packages/types": {
       "name": "@useatlas/types",
-      "version": "0.0.11",
+      "version": "0.0.12",
     },
     "packages/web": {
       "name": "@atlas/web",
@@ -4227,6 +4227,10 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typespec/ts-http-runtime/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "@useatlas/react/@useatlas/types": ["@useatlas/types@0.0.11", "", {}, "sha512-ru3mNovMfiAE2XymzU1yjBPgF6h5VOGauuy9Nc5y98dhFx7JI48u+K3fEf2keJ/DpEUbopt3fcfwSmdzL+6Idg=="],
+
+    "@useatlas/sdk/@useatlas/types": ["@useatlas/types@0.0.11", "", {}, "sha512-ru3mNovMfiAE2XymzU1yjBPgF6h5VOGauuy9Nc5y98dhFx7JI48u+K3fEf2keJ/DpEUbopt3fcfwSmdzL+6Idg=="],
 
     "@vercel/sandbox/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/types",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

PR A of the standard 2-step publish sequence for `@useatlas/types`. Unblocks **Deploy Validation** which has been failing on main since PR #1690 (13 hours, 7 red commits).

PR #1690 added `Percentage`, `Ratio`, `asRatio`, `percentageToRatio`, `ratioToPercentage` exports to `packages/types/src/index.ts` but the scaffold smoke test pulls `@useatlas/types` from **npm**, which is still on `0.0.11`:

```
The export asRatio was not found in module [project]/node_modules/@useatlas/types/dist/index.js
Did you mean to import parseChatError?
```

## What this PR does

- Bumps `packages/types/package.json` `version` from `0.0.11` → `0.0.12`
- Refreshes `bun.lock`

## What this PR deliberately does NOT do

Consumer refs in `packages/sdk`, `packages/react`, and `create-atlas/templates/*/package.json` stay at `^0.0.11`. Per `feedback_version_bump_ordering.md`, bumping refs before npm has `0.0.12` available would break scaffolded deploy validation in the opposite direction.

## Next steps (after this merges)

1. `git tag types-v0.0.12 && git push origin types-v0.0.12` — triggers the publish workflow
2. Wait for the workflow to land `0.0.12` on npm
3. Open PR B bumping consumer refs `^0.0.11` → `^0.0.12`

## Related

- Closes the blocking half of #1698
- #1690 introduced the new exports
- `.claude/memory/feedback_version_bump_ordering.md` documents this sequence

## Test plan

- [x] `bun x syncpack lint` — clean
- [ ] Deploy Validation passes on this branch against npm's `0.0.11` (scaffold still pulls the old published version — expected)
- [ ] After tag + publish: consumer-ref PR unblocks Deploy Validation on main