### PR TITLE
fix: bucket cleanup — residency hardening + schema dedup + warn-set reset (#1695 #1697 #1674)

### DIFF
--- a/packages/api/src/api/routes/admin-residency.ts
+++ b/packages/api/src/api/routes/admin-residency.ts
@@ -27,6 +27,42 @@ import { createAdminRouter, requireOrgContext } from "./admin-router";
 
 const log = createLogger("admin-residency");
 
+// Narrow a DB-sourced migration status string to the canonical tuple.
+// Unknown values (schema drift, manual SQL update, legacy rows) are coerced
+// to "failed" + a one-time-per-warn log breadcrumb so operators can spot
+// drift instead of being silently handed a mislabeled migration.
+function narrowMigrationStatus(
+  raw: string,
+  ctx: { migrationId: string; requestId: string },
+): (typeof MIGRATION_STATUSES)[number] {
+  if ((MIGRATION_STATUSES as readonly string[]).includes(raw)) {
+    return raw as (typeof MIGRATION_STATUSES)[number];
+  }
+  log.warn(
+    { migrationId: ctx.migrationId, dbStatus: raw, requestId: ctx.requestId },
+    "coerced unknown migration status to failed",
+  );
+  return "failed";
+}
+
+// Schedule the background migration executor. `triggerMigrationExecution` is
+// synchronous (schedules via setTimeout internally) but a synchronous throw
+// here would otherwise return 201 to the client with no execution and no
+// log trail. Wrap the call so a schedule-time failure surfaces in logs.
+function scheduleMigrationExecution(
+  migrationId: string,
+  requestId: string,
+): void {
+  try {
+    triggerMigrationExecution(migrationId);
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), migrationId, requestId },
+      "Failed to schedule background migration execution",
+    );
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Lazy EE loader — fail-graceful when enterprise is disabled
 // ---------------------------------------------------------------------------
@@ -450,9 +486,7 @@ adminResidency.openapi(getMigrationStatusRoute, async (c) => {
         return c.json({ migration: null }, 200);
       }
 
-      const status = (MIGRATION_STATUSES as readonly string[]).includes(row.status)
-        ? (row.status as typeof MIGRATION_STATUSES[number])
-        : "failed";
+      const status = narrowMigrationStatus(row.status, { migrationId: row.id, requestId });
 
       return c.json({
         migration: {
@@ -566,7 +600,7 @@ adminResidency.openapi(requestMigrationRoute, async (c) => {
       );
 
       // Trigger background execution (Phase 2)
-      triggerMigrationExecution(migrationId);
+      scheduleMigrationExecution(migrationId, requestId);
 
       // Also check for stale migrations while we're here
       failStaleMigrations().catch((err) => {
@@ -614,7 +648,7 @@ adminResidency.openapi(retryMigrationRoute, async (c) => {
       }
 
       // Re-trigger execution
-      triggerMigrationExecution(id);
+      scheduleMigrationExecution(id, requestId);
 
       // Fetch updated migration to return
       const rows = yield* queryEffect<{
@@ -645,7 +679,7 @@ adminResidency.openapi(retryMigrationRoute, async (c) => {
         workspaceId: row.workspace_id,
         sourceRegion: row.source_region,
         targetRegion: row.target_region,
-        status: row.status as typeof MIGRATION_STATUSES[number],
+        status: narrowMigrationStatus(row.status, { migrationId: row.id, requestId }),
         requestedBy: row.requested_by,
         requestedAt: row.requested_at,
         completedAt: row.completed_at,

--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -776,17 +776,15 @@ onboarding.openapi(
 // ---------------------------------------------------------------------------
 
 import { loadResidency, getResidencyDomainError } from "./shared-residency";
+import { RegionPickerItemSchema } from "@useatlas/schemas";
 
-const OnboardingRegionSchema = z.object({
-  id: z.string(),
-  label: z.string(),
-  isDefault: z.boolean(),
-});
-
+// OnboardingRegionSchema previously duplicated this shape inline; the signup
+// page already imports RegionPickerItemSchema from @useatlas/schemas, so
+// route + web consumer describe the same shape from one source.
 const OnboardingRegionsResponseSchema = z.object({
   configured: z.boolean(),
   defaultRegion: z.string(),
-  availableRegions: z.array(OnboardingRegionSchema),
+  availableRegions: z.array(RegionPickerItemSchema),
 });
 
 const AssignRegionBodySchema = z.object({

--- a/packages/schemas/src/common.ts
+++ b/packages/schemas/src/common.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared primitives used across wire-format schemas.
+ *
+ * Grows with each family migration in #1648. Keep exports minimal — this
+ * module is imported everywhere, so every addition should be something
+ * reused by at least two schema families.
+ */
+import { z } from "zod";
+
+/**
+ * ISO-8601 timestamp string.
+ *
+ * Replaces bare `z.string()` for `createdAt` / `updatedAt` / `assignedAt` /
+ * `requestedAt` / `completedAt` / `firedAt` / `resolvedAt` /
+ * `acknowledgedAt` / `lastRequest` / `expiresAt` fields across the schema
+ * families. Before this helper, every timestamp field accepted arbitrary
+ * strings (including `"banana"`), which let server bugs leak through the
+ * wire boundary silently. Apply progressively as each family is touched.
+ */
+export const IsoTimestampSchema = z.string().datetime();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -2,6 +2,7 @@ export * from "./abuse";
 export * from "./approval";
 export * from "./backup";
 export * from "./billing";
+export * from "./common";
 export * from "./custom-domain";
 export * from "./integrations";
 export * from "./platform";

--- a/packages/schemas/src/residency.ts
+++ b/packages/schemas/src/residency.ts
@@ -29,6 +29,7 @@ import {
   type RegionStatus,
   type WorkspaceRegion,
 } from "@useatlas/types";
+import { IsoTimestampSchema } from "./common";
 
 const MigrationStatusEnum = z.enum(MIGRATION_STATUSES);
 
@@ -52,7 +53,7 @@ export const RegionStatusSchema = z.object({
 export const WorkspaceRegionSchema = z.object({
   workspaceId: z.string(),
   region: z.string(),
-  assignedAt: z.string(),
+  assignedAt: IsoTimestampSchema,
 }) satisfies z.ZodType<WorkspaceRegion>;
 
 export const RegionMigrationSchema = z.object({
@@ -62,8 +63,8 @@ export const RegionMigrationSchema = z.object({
   targetRegion: z.string(),
   status: MigrationStatusEnum,
   requestedBy: z.string().nullable(),
-  requestedAt: z.string(),
-  completedAt: z.string().nullable(),
+  requestedAt: IsoTimestampSchema,
+  completedAt: IsoTimestampSchema.nullable(),
   errorMessage: z.string().nullable(),
 }) satisfies z.ZodType<RegionMigration>;
 

--- a/packages/web/src/app/admin/organizations/__tests__/roles.test.ts
+++ b/packages/web/src/app/admin/organizations/__tests__/roles.test.ts
@@ -1,9 +1,13 @@
-import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { Crown, Shield, ShieldCheck } from "lucide-react";
-import { roleBadge } from "../roles";
+import { __resetWarnSets, roleBadge } from "../roles";
 
 describe("roleBadge", () => {
   let warnSpy: ReturnType<typeof spyOn<Console, "warn">>;
+
+  beforeEach(() => {
+    __resetWarnSets();
+  });
 
   afterEach(() => {
     warnSpy?.mockRestore();

--- a/packages/web/src/app/admin/organizations/__tests__/roles.test.ts
+++ b/packages/web/src/app/admin/organizations/__tests__/roles.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { Crown, Shield, ShieldCheck } from "lucide-react";
-import { __resetWarnSets, roleBadge } from "../roles";
+import { _resetWarnSets, roleBadge } from "../roles";
 
 describe("roleBadge", () => {
   let warnSpy: ReturnType<typeof spyOn<Console, "warn">>;
 
   beforeEach(() => {
-    __resetWarnSets();
+    _resetWarnSets();
   });
 
   afterEach(() => {

--- a/packages/web/src/app/admin/organizations/__tests__/statuses.test.ts
+++ b/packages/web/src/app/admin/organizations/__tests__/statuses.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { CheckCircle2, CreditCard, Pause, Trash2 } from "lucide-react";
-import { __resetWarnSets, planBadge, statusBadge } from "../statuses";
+import { _resetWarnSets, planBadge, statusBadge } from "../statuses";
 
 describe("statusBadge", () => {
   let warnSpy: ReturnType<typeof spyOn<Console, "warn">>;
 
   beforeEach(() => {
-    __resetWarnSets();
+    _resetWarnSets();
   });
 
   afterEach(() => {
@@ -74,7 +74,7 @@ describe("planBadge", () => {
   let warnSpy: ReturnType<typeof spyOn<Console, "warn">>;
 
   beforeEach(() => {
-    __resetWarnSets();
+    _resetWarnSets();
   });
 
   afterEach(() => {

--- a/packages/web/src/app/admin/organizations/__tests__/statuses.test.ts
+++ b/packages/web/src/app/admin/organizations/__tests__/statuses.test.ts
@@ -1,9 +1,13 @@
-import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { CheckCircle2, CreditCard, Pause, Trash2 } from "lucide-react";
-import { planBadge, statusBadge } from "../statuses";
+import { __resetWarnSets, planBadge, statusBadge } from "../statuses";
 
 describe("statusBadge", () => {
   let warnSpy: ReturnType<typeof spyOn<Console, "warn">>;
+
+  beforeEach(() => {
+    __resetWarnSets();
+  });
 
   afterEach(() => {
     warnSpy?.mockRestore();
@@ -68,6 +72,10 @@ describe("statusBadge", () => {
 
 describe("planBadge", () => {
   let warnSpy: ReturnType<typeof spyOn<Console, "warn">>;
+
+  beforeEach(() => {
+    __resetWarnSets();
+  });
 
   afterEach(() => {
     warnSpy?.mockRestore();

--- a/packages/web/src/app/admin/organizations/roles.ts
+++ b/packages/web/src/app/admin/organizations/roles.ts
@@ -45,12 +45,12 @@ interface RoleBadge {
 // Cleared on full page reload (fine — drift is a "once you see it, you
 // investigate" signal, not a rate-limited alert). Tests that assert
 // multiple unknown-role branches in the same file MUST call
-// `__resetWarnSets()` in `beforeEach` — Bun's isolated runner resets
+// `_resetWarnSets()` in `beforeEach` — Bun's isolated runner resets
 // module state between files, not between tests.
 const warnedUnknownRoles = new Set<string>();
 
 /** Test hook: clear dedup set so each test starts from a known state. */
-export function __resetWarnSets(): void {
+export function _resetWarnSets(): void {
   warnedUnknownRoles.clear();
 }
 

--- a/packages/web/src/app/admin/organizations/roles.ts
+++ b/packages/web/src/app/admin/organizations/roles.ts
@@ -43,8 +43,16 @@ interface RoleBadge {
 
 // Module-scoped so repeated renders of the same unknown role only warn once.
 // Cleared on full page reload (fine — drift is a "once you see it, you
-// investigate" signal, not a rate-limited alert).
+// investigate" signal, not a rate-limited alert). Tests that assert
+// multiple unknown-role branches in the same file MUST call
+// `__resetWarnSets()` in `beforeEach` — Bun's isolated runner resets
+// module state between files, not between tests.
 const warnedUnknownRoles = new Set<string>();
+
+/** Test hook: clear dedup set so each test starts from a known state. */
+export function __resetWarnSets(): void {
+  warnedUnknownRoles.clear();
+}
 
 /**
  * Resolve icon + badge classes for a workspace-member role. Unknown roles

--- a/packages/web/src/app/admin/organizations/statuses.ts
+++ b/packages/web/src/app/admin/organizations/statuses.ts
@@ -80,8 +80,18 @@ const NEUTRAL_BADGE: BadgeDescriptor = {
   label: "Unknown",
 };
 
+// Module-scoped so repeated renders of the same unknown value only warn
+// once per session. Tests that assert multiple unknown-value branches in a
+// single file MUST call `__resetWarnSets()` in `beforeEach` — Bun's
+// isolated runner resets module state between files, not between tests.
 const warnedUnknownStatuses = new Set<string>();
 const warnedUnknownPlans = new Set<string>();
+
+/** Test hook: clear dedup sets so each test starts from a known state. */
+export function __resetWarnSets(): void {
+  warnedUnknownStatuses.clear();
+  warnedUnknownPlans.clear();
+}
 
 /**
  * Resolve icon + classes for a workspace status. Unknown values render a

--- a/packages/web/src/app/admin/organizations/statuses.ts
+++ b/packages/web/src/app/admin/organizations/statuses.ts
@@ -82,13 +82,13 @@ const NEUTRAL_BADGE: BadgeDescriptor = {
 
 // Module-scoped so repeated renders of the same unknown value only warn
 // once per session. Tests that assert multiple unknown-value branches in a
-// single file MUST call `__resetWarnSets()` in `beforeEach` — Bun's
+// single file MUST call `_resetWarnSets()` in `beforeEach` — Bun's
 // isolated runner resets module state between files, not between tests.
 const warnedUnknownStatuses = new Set<string>();
 const warnedUnknownPlans = new Set<string>();
 
 /** Test hook: clear dedup sets so each test starts from a known state. */
-export function __resetWarnSets(): void {
+export function _resetWarnSets(): void {
   warnedUnknownStatuses.clear();
   warnedUnknownPlans.clear();
 }


### PR DESCRIPTION
## Summary

Three small knock-outs from the PR #1693 review follow-ups, bundled because they touch independent files with no shared surface.

### #1695 — admin-residency silent failures

- Extract `narrowMigrationStatus(raw, ctx)` helper that emits `log.warn({ migrationId, dbStatus, requestId }, \"coerced unknown migration status to failed\")` on DB drift instead of silently coercing. Applied at both read sites: GET /migration status (was the existing `.includes() ? ... : \"failed\"` branch) and POST /migrate/:id/retry (was an unchecked `as typeof MIGRATION_STATUSES[number]` cast).
- Extract `scheduleMigrationExecution(id, requestId)` helper that wraps the void-returning `triggerMigrationExecution` call in try/catch so a schedule-time throw surfaces in logs instead of returning 201 with no execution and no trace.

### #1697 — shared `IsoTimestampSchema` + `OnboardingRegionSchema` dedup

- New `packages/schemas/src/common.ts` exporting `IsoTimestampSchema = z.string().datetime()`. Applied to `WorkspaceRegion.assignedAt` and `RegionMigration.{requestedAt, completedAt}` in residency.ts as a first adopter. Remaining schema families migrate as they're touched — tracker stays open on #1648.
- `onboarding.ts` drops its local `OnboardingRegionSchema` in favor of `RegionPickerItemSchema` from `@useatlas/schemas`. The signup page already consumed the shared schema, so route + web now describe the shape exactly once.

### #1674 — warn-set reset between tests

- Export `__resetWarnSets()` from `organizations/statuses.ts` + `organizations/roles.ts`; call in `beforeEach` in both test files so a future test that re-uses a string already warned-on earlier in the same file can't silently get zero warns when it expects one.
- Scoped to the two files that actually use the module-scoped Set pattern. `users/roles.ts` (mentioned in #1674) uses fail-closed rank comparison — no warn set exists to reset.

## Test plan

- [x] `bun test packages/schemas` — 141 pass (residency timestamp tightening still accepts existing ISO-8601 fixtures)
- [x] `bun test packages/web/src/app/admin/organizations/__tests__` — 16 pass
- [x] `bun test packages/api/src/api/__tests__/admin-residency.test.ts` — 19 pass
- [x] `bun test packages/api/src/api/__tests__/onboarding.test.ts` — 43 pass
- [x] `bun run lint` — clean

Closes #1695, #1697, #1674. Part of #1648.