### PR TITLE
chore(types): bump consumer refs to @useatlas/types@^0.0.12 (PR B — unblocks Deploy Validation)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -39078,13 +39078,15 @@
                           ]
                         },
                         "requestedAt": {
-                          "type": "string"
+                          "type": "string",
+                          "format": "date-time"
                         },
                         "completedAt": {
                           "type": [
                             "string",
                             "null"
-                          ]
+                          ],
+                          "format": "date-time"
                         },
                         "errorMessage": {
                           "type": [
@@ -39266,13 +39268,15 @@
                       ]
                     },
                     "requestedAt": {
-                      "type": "string"
+                      "type": "string",
+                      "format": "date-time"
                     },
                     "completedAt": {
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "format": "date-time"
                     },
                     "errorMessage": {
                       "type": [
@@ -39490,13 +39494,15 @@
                       ]
                     },
                     "requestedAt": {
-                      "type": "string"
+                      "type": "string",
+                      "format": "date-time"
                     },
                     "completedAt": {
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "format": "date-time"
                     },
                     "errorMessage": {
                       "type": [
@@ -55045,7 +55051,8 @@
                       "type": "string"
                     },
                     "assignedAt": {
-                      "type": "string"
+                      "type": "string",
+                      "format": "date-time"
                     }
                   },
                   "required": [
@@ -55199,7 +55206,8 @@
                       "type": "string"
                     },
                     "assignedAt": {
-                      "type": "string"
+                      "type": "string",
+                      "format": "date-time"
                     }
                   },
                   "required": [
@@ -55389,7 +55397,8 @@
                             "type": "string"
                           },
                           "assignedAt": {
-                            "type": "string"
+                            "type": "string",
+                            "format": "date-time"
                           }
                         },
                         "required": [

--- a/bun.lock
+++ b/bun.lock
@@ -227,7 +227,7 @@
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^5.96.2",
-        "@useatlas/types": "^0.0.11",
+        "@useatlas/types": "^0.0.12",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "radix-ui": "^1.4.3",
@@ -294,7 +294,7 @@
       "name": "@useatlas/sdk",
       "version": "0.0.11",
       "dependencies": {
-        "@useatlas/types": "^0.0.11",
+        "@useatlas/types": "^0.0.12",
       },
     },
     "packages/types": {
@@ -4227,10 +4227,6 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typespec/ts-http-runtime/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
-    "@useatlas/react/@useatlas/types": ["@useatlas/types@0.0.11", "", {}, "sha512-ru3mNovMfiAE2XymzU1yjBPgF6h5VOGauuy9Nc5y98dhFx7JI48u+K3fEf2keJ/DpEUbopt3fcfwSmdzL+6Idg=="],
-
-    "@useatlas/sdk/@useatlas/types": ["@useatlas/types@0.0.11", "", {}, "sha512-ru3mNovMfiAE2XymzU1yjBPgF6h5VOGauuy9Nc5y98dhFx7JI48u+K3fEf2keJ/DpEUbopt3fcfwSmdzL+6Idg=="],
 
     "@vercel/sandbox/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 

--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -24,7 +24,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.0.7",
     "@useatlas/sdk": "^0.0.11",
-    "@useatlas/types": "^0.0.11",
+    "@useatlas/types": "^0.0.12",
     "@better-auth/api-key": "^1.5.6",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -21,7 +21,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.0.7",
     "@useatlas/sdk": "^0.0.11",
-    "@useatlas/types": "^0.0.11",
+    "@useatlas/types": "^0.0.12",
     "ai": "^6.0.141",
     "@better-auth/api-key": "^1.5.6",
     "@dnd-kit/core": "^6.3.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -82,7 +82,7 @@
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^5.96.2",
-    "@useatlas/types": "^0.0.11",
+    "@useatlas/types": "^0.0.12",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "radix-ui": "^1.4.3",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -44,6 +44,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@useatlas/types": "^0.0.11"
+    "@useatlas/types": "^0.0.12"
   }
 }


### PR DESCRIPTION
## Summary

PR B of the 2-step publish sequence started in #1699. Bumps consumer refs from `^0.0.11` → `^0.0.12` now that `@useatlas/types@0.0.12` is live on npm (publish succeeded 2026-04-20 16:01 UTC).

## What bumped

- `packages/sdk/package.json`
- `packages/react/package.json`
- `create-atlas/templates/docker/package.json`
- `create-atlas/templates/nextjs-standalone/package.json`

## Why

Deploy Validation has been red on main since PR #1690 merged (~14 hours) because the scaffold smoke test pulls `@useatlas/types` from npm and `0.0.11` was missing the `Percentage` / `Ratio` / `asRatio` / `percentageToRatio` / `ratioToPercentage` exports (introduced in source by PR #1690 but not on the registry). `0.0.12` now has them, plus the `starter-prompt` and `integrations` modules that were also missing.

## Test plan

- [x] `bun install` — lockfile refreshed
- [x] `bun x syncpack lint` — clean
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — 429 files verified
- [ ] Deploy Validation passes on this branch (scaffold now resolves `0.0.12` from npm)

Closes #1698.