### PR TITLE
chore(types): bump to 0.0.13 — add EMAIL_PROVIDERS + HEALTH_STATUSES tuples (PR A)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -299,7 +299,7 @@
     },
     "packages/types": {
       "name": "@useatlas/types",
-      "version": "0.0.12",
+      "version": "0.0.13",
     },
     "packages/web": {
       "name": "@atlas/web",
@@ -4227,6 +4227,10 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typespec/ts-http-runtime/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "@useatlas/react/@useatlas/types": ["@useatlas/types@0.0.12", "", {}, "sha512-4Qffa3tsg+eOArlR0U0cCcmrgFzRDdk+5X+ZO8sGf5OPzA3ltlf0xFNckdXAIrHUPC/Fu1Zj8Tx2W0mjWFjs/A=="],
+
+    "@useatlas/sdk/@useatlas/types": ["@useatlas/types@0.0.12", "", {}, "sha512-4Qffa3tsg+eOArlR0U0cCcmrgFzRDdk+5X+ZO8sGf5OPzA3ltlf0xFNckdXAIrHUPC/Fu1Zj8Tx2W0mjWFjs/A=="],
 
     "@vercel/sandbox/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@useatlas/types",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {
-    "build": "rm -rf dist && bun build src/index.ts src/auth.ts src/conversation.ts src/connection.ts src/action.ts src/scheduled-task.ts src/errors.ts src/semantic.ts src/share.ts src/billing.ts src/dashboard.ts src/mode.ts src/starter-prompt.ts src/integrations.ts --outdir dist --root src --target node --packages external && bun x tsc -p tsconfig.build.json"
+    "build": "rm -rf dist && bun build src/index.ts src/auth.ts src/conversation.ts src/connection.ts src/action.ts src/scheduled-task.ts src/errors.ts src/semantic.ts src/share.ts src/billing.ts src/dashboard.ts src/mode.ts src/starter-prompt.ts src/integrations.ts src/email-provider.ts --outdir dist --root src --target node --packages external && bun x tsc -p tsconfig.build.json"
   },
   "exports": {
     ".": {
@@ -76,6 +76,11 @@
       "types": "./dist/integrations.d.ts",
       "import": "./dist/integrations.js",
       "default": "./dist/integrations.js"
+    },
+    "./email-provider": {
+      "types": "./dist/email-provider.d.ts",
+      "import": "./dist/email-provider.js",
+      "default": "./dist/email-provider.js"
     }
   },
   "main": "./dist/index.js",

--- a/packages/types/src/connection.ts
+++ b/packages/types/src/connection.ts
@@ -15,8 +15,11 @@ export type DBType = (typeof DB_TYPES)[number]["value"];
 export const CONNECTION_STATUSES = ["published", "draft", "archived"] as const;
 export type ConnectionStatus = (typeof CONNECTION_STATUSES)[number];
 
+/** Valid health-check status values for a connection. */
+export const HEALTH_STATUSES = ["healthy", "degraded", "unhealthy"] as const;
+
 /** Health check status for a connection. */
-export type HealthStatus = "healthy" | "degraded" | "unhealthy";
+export type HealthStatus = (typeof HEALTH_STATUSES)[number];
 
 /** Wire format for a connection health check result (JSON-serialized). */
 export interface ConnectionHealth {

--- a/packages/types/src/email-provider.ts
+++ b/packages/types/src/email-provider.ts
@@ -1,0 +1,3 @@
+/** Supported email provider keys for transactional email integrations. */
+export const EMAIL_PROVIDERS = ["resend", "sendgrid", "postmark", "smtp", "ses"] as const;
+export type EmailProvider = (typeof EMAIL_PROVIDERS)[number];

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -30,3 +30,4 @@ export * from "./dashboard";
 export * from "./mode";
 export * from "./starter-prompt";
 export * from "./integrations";
+export * from "./email-provider";


### PR DESCRIPTION
## Summary

PR A of the documented two-step publish sequence for additive-only `@useatlas/types` changes. Closes the `chore:` half of #1543 and #1703.

- New `EMAIL_PROVIDERS` tuple + `EmailProvider` type in `packages/types/src/email-provider.ts` — mirrors the inline tuple at `packages/api/src/lib/integrations/types.ts:132`. PR B will replace the API copy with an import.
- New `HEALTH_STATUSES` tuple in `packages/types/src/connection.ts`. Existing `HealthStatus` alias is now derived from the tuple (same three string literals — structurally identical, no consumer breakage). Lets `packages/schemas/src/connection.ts` drop its inline `z.enum(["healthy", "degraded", "unhealthy"])` in PR B.
- Bumped `@useatlas/types` 0.0.12 → 0.0.13.
- Build script + package exports updated to emit `dist/email-provider.{js,d.ts}` and expose `@useatlas/types/email-provider`.
- **No consumer ref bumps in this PR.** `packages/sdk`, `packages/react`, and `create-atlas/templates/*/package.json` stay pinned at `^0.0.12`.

## Merge protocol

1. Merge this PR
2. `git tag types-v0.0.13 && git push origin types-v0.0.13`
3. Wait for the publish workflow to land 0.0.13 on npm
4. Open PR B (separate session / follow-up) that:
   - Bumps consumer refs `^0.0.12` → `^0.0.13` in `packages/sdk`, `packages/react`, `create-atlas/templates/*/package.json`
   - Replaces the inline `EMAIL_PROVIDERS` tuple in `packages/api/src/lib/integrations/types.ts` with `import { EMAIL_PROVIDERS } from "@useatlas/types/email-provider"`
   - Replaces the inline `z.enum(["healthy", "degraded", "unhealthy"])` in `packages/schemas/src/connection.ts` with `z.enum(HEALTH_STATUSES)` from `@useatlas/types`

> **Deploy Validation will remain red between merge and PR B.** This is the documented two-step sequence — see `memory/feedback_version_bump_ordering.md`. Scaffolds resolve `^0.0.12` from npm until PR B bumps refs to `^0.0.13`, which can only happen after the publish workflow lands `0.0.13`.

## Test plan

- [x] `bun run lint` — 0 errors
- [x] `bun run type` — 0 errors
- [x] `bun run test` — all packages green
- [x] `bun x syncpack lint` — no issues
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — passed
- [x] `bun run build` in `packages/types` — `dist/email-provider.{js,d.ts}` emitted, `EMAIL_PROVIDERS` + `HEALTH_STATUSES` re-exported from index
- [ ] After merge: tag `types-v0.0.13` and confirm publish workflow lands on npm
- [ ] After publish: open PR B with consumer-ref bumps and call-site migrations

Issues: closes the `chore:` half of #1543 and #1703 (consumer migrations land in PR B).
Milestone: 1.2.2