### PR TITLE
refactor(schemas): encode CustomDomain 3-way verification invariant at wire (closes #1661)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -32912,7 +32912,8 @@
                           "type": "string"
                         },
                         "domain": {
-                          "type": "string"
+                          "type": "string",
+                          "minLength": 1
                         },
                         "status": {
                           "type": "string",
@@ -33170,7 +33171,8 @@
                       "type": "string"
                     },
                     "domain": {
-                      "type": "string"
+                      "type": "string",
+                      "minLength": 1
                     },
                     "status": {
                       "type": "string",
@@ -33582,7 +33584,8 @@
                       "type": "string"
                     },
                     "domain": {
-                      "type": "string"
+                      "type": "string",
+                      "minLength": 1
                     },
                     "status": {
                       "type": "string",
@@ -33830,7 +33833,8 @@
                       "type": "string"
                     },
                     "domain": {
-                      "type": "string"
+                      "type": "string",
+                      "minLength": 1
                     },
                     "status": {
                       "type": "string",
@@ -55589,7 +55593,8 @@
                             "type": "string"
                           },
                           "domain": {
-                            "type": "string"
+                            "type": "string",
+                            "minLength": 1
                           },
                           "status": {
                             "type": "string",
@@ -55830,7 +55835,8 @@
                       "type": "string"
                     },
                     "domain": {
-                      "type": "string"
+                      "type": "string",
+                      "minLength": 1
                     },
                     "status": {
                       "type": "string",
@@ -56089,7 +56095,8 @@
                       "type": "string"
                     },
                     "domain": {
-                      "type": "string"
+                      "type": "string",
+                      "minLength": 1
                     },
                     "status": {
                       "type": "string",

--- a/packages/schemas/src/__tests__/custom-domain.test.ts
+++ b/packages/schemas/src/__tests__/custom-domain.test.ts
@@ -84,9 +84,12 @@ describe("enum strict rejection", () => {
   });
 
   test("all DOMAIN_STATUSES values parse", () => {
-    for (const status of ["pending", "verified", "failed"] as const) {
+    // `verified` needs the `verifiedAt` stamp per the #1661 invariant; the
+    // other two tests use the pending-state base row.
+    for (const status of ["pending", "failed"] as const) {
       expect(CustomDomainSchema.parse({ ...validDomain, status }).status).toBe(status);
     }
+    expect(CustomDomainSchema.parse(verifiedDomain).status).toBe("verified");
   });
 
   test("all CERTIFICATE_STATUSES values parse", () => {
@@ -98,12 +101,15 @@ describe("enum strict rejection", () => {
   });
 
   test("all DOMAIN_VERIFICATION_STATUSES values parse", () => {
-    for (const domainVerificationStatus of ["pending", "verified", "failed"] as const) {
+    // `verified` must agree with `domainVerified=true` + `domainVerifiedAt`
+    // set per the #1661 invariant — use `verifiedDomain` for that case.
+    for (const domainVerificationStatus of ["pending", "failed"] as const) {
       expect(
         CustomDomainSchema.parse({ ...validDomain, domainVerificationStatus })
           .domainVerificationStatus,
       ).toBe(domainVerificationStatus);
     }
+    expect(CustomDomainSchema.parse(verifiedDomain).domainVerificationStatus).toBe("verified");
   });
 });
 
@@ -121,5 +127,62 @@ describe("structural rejection", () => {
   test("CustomDomainSchema rejects missing domainVerificationStatus", () => {
     const { domainVerificationStatus: _dvs, ...missing } = validDomain;
     expect(CustomDomainSchema.safeParse(missing).success).toBe(false);
+  });
+
+  test("CustomDomainSchema rejects empty domain string", () => {
+    const drifted = { ...validDomain, domain: "" };
+    expect(CustomDomainSchema.safeParse(drifted).success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invariant rejection — see #1661.
+//
+// DNS TXT verification writes `domain_verified`, `domain_verified_at`, and
+// `domain_verification_status` atomically in `ee/src/platform/domains.ts`
+// (see `verifyDomainDnsTxt`). The row-to-wire mapper defaults pre-migration
+// rows to the all-unverified state. A row that shows `domainVerified=true`
+// but `domainVerifiedAt=null` (or vice versa) is a bug somewhere upstream —
+// either the DB or a partial hand-edit — and should fail parse at
+// `useAdminFetch` time, not leak into the domain-detail UI as a silent
+// mismatch.
+//
+// Railway CNAME/cert verification separately sets `status='verified'`
+// together with `verified_at = now()` (same UPDATE statement in
+// `verifyDomain`). A `verified` status without a `verifiedAt` stamp is
+// drift.
+// ---------------------------------------------------------------------------
+
+describe("3-way verification invariant", () => {
+  test("rejects domainVerified=true with domainVerifiedAt=null", () => {
+    const drifted = {
+      ...verifiedDomain,
+      domainVerifiedAt: null,
+    };
+    expect(CustomDomainSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("rejects domainVerified=true with domainVerificationStatus!=='verified'", () => {
+    const drifted = {
+      ...verifiedDomain,
+      domainVerificationStatus: "pending" as const,
+    };
+    expect(CustomDomainSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("rejects domainVerified=false with domainVerificationStatus='verified'", () => {
+    const drifted = {
+      ...validDomain,
+      domainVerificationStatus: "verified" as const,
+    };
+    expect(CustomDomainSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("rejects status='verified' with verifiedAt=null", () => {
+    const drifted = {
+      ...verifiedDomain,
+      verifiedAt: null,
+    };
+    expect(CustomDomainSchema.safeParse(drifted).success).toBe(false);
   });
 });

--- a/packages/schemas/src/__tests__/custom-domain.test.ts
+++ b/packages/schemas/src/__tests__/custom-domain.test.ts
@@ -185,4 +185,29 @@ describe("3-way verification invariant", () => {
     };
     expect(CustomDomainSchema.safeParse(drifted).success).toBe(false);
   });
+
+  test("rejects domainVerificationStatus='verified' with domainVerifiedAt=null", () => {
+    // Transitively covered by the two `domainVerified` pairings, but if a
+    // future refactor removes just one of those refines this direct pairing
+    // would catch the remaining drift.
+    const drifted = {
+      ...verifiedDomain,
+      domainVerified: false,
+      domainVerifiedAt: null,
+    };
+    expect(CustomDomainSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("accepts status='failed' with verifiedAt set (one-way Railway check)", () => {
+    // `verifyDomain` preserves `verified_at` when status regresses away
+    // from 'verified', so a previously-verified-then-failed row must
+    // still parse. Guards against a future "tighten to biconditional"
+    // refactor.
+    const regressed = {
+      ...validDomain,
+      status: "failed" as const,
+      verifiedAt: "2026-04-19T12:30:00.000Z",
+    };
+    expect(CustomDomainSchema.safeParse(regressed).success).toBe(true);
+  });
 });

--- a/packages/schemas/src/custom-domain.ts
+++ b/packages/schemas/src/custom-domain.ts
@@ -33,6 +33,16 @@
  * in another. A half-reconciled row would parse cleanly against the
  * plain object shape and leak UI inconsistency; the refine turns it
  * into a `schema_mismatch` banner at `useAdminFetch` time.
+ *
+ * The DNS TXT trio is decomposed as two pairwise checks
+ * (`domainVerified ↔ domainVerifiedAt!=null` and
+ * `domainVerified ↔ domainVerificationStatus==='verified'`); the third
+ * edge follows by transitivity. A `discriminatedUnion` would express
+ * this structurally but splinters every `CustomDomain` response into
+ * multiple OpenAPI schemas, which tips the extractor into the same
+ * `ZodCatch`-style limitation documented around #1653. The pairwise
+ * refine also emits per-field `path` errors so `useAdminFetch`'s
+ * `schema_mismatch` banner can point at the exact broken field.
  */
 import { z } from "zod";
 import {

--- a/packages/schemas/src/custom-domain.ts
+++ b/packages/schemas/src/custom-domain.ts
@@ -24,6 +24,15 @@
  * Strict `z.enum(TUPLE)` matches the `@hono/zod-openapi` extractor's
  * expectations — it cannot serialize `ZodCatch` wrappers (#1653) — and
  * keeps the generated OpenAPI spec describing the genuine output shape.
+ *
+ * The `superRefine()` at the bottom encodes two invariants that the server
+ * enforces atomically but the structural schema alone can't express
+ * (see #1661). `verifyDomainDnsTxt` writes `domain_verified`,
+ * `domain_verified_at`, and `domain_verification_status` in one UPDATE,
+ * and `verifyDomain` pairs `status='verified'` with `verified_at=now()`
+ * in another. A half-reconciled row would parse cleanly against the
+ * plain object shape and leak UI inconsistency; the refine turns it
+ * into a `schema_mismatch` banner at `useAdminFetch` time.
  */
 import { z } from "zod";
 import {
@@ -37,18 +46,48 @@ const DomainStatusEnum = z.enum(DOMAIN_STATUSES);
 const CertificateStatusEnum = z.enum(CERTIFICATE_STATUSES);
 const DomainVerificationStatusEnum = z.enum(DOMAIN_VERIFICATION_STATUSES);
 
-export const CustomDomainSchema = z.object({
-  id: z.string(),
-  workspaceId: z.string(),
-  domain: z.string(),
-  status: DomainStatusEnum,
-  railwayDomainId: z.string().nullable(),
-  cnameTarget: z.string().nullable(),
-  certificateStatus: CertificateStatusEnum.nullable(),
-  verificationToken: z.string().nullable(),
-  domainVerified: z.boolean(),
-  domainVerifiedAt: z.string().nullable(),
-  domainVerificationStatus: DomainVerificationStatusEnum,
-  createdAt: z.string(),
-  verifiedAt: z.string().nullable(),
-}) satisfies z.ZodType<CustomDomain>;
+export const CustomDomainSchema = z
+  .object({
+    id: z.string(),
+    workspaceId: z.string(),
+    domain: z.string().min(1),
+    status: DomainStatusEnum,
+    railwayDomainId: z.string().nullable(),
+    cnameTarget: z.string().nullable(),
+    certificateStatus: CertificateStatusEnum.nullable(),
+    verificationToken: z.string().nullable(),
+    domainVerified: z.boolean(),
+    domainVerifiedAt: z.string().nullable(),
+    domainVerificationStatus: DomainVerificationStatusEnum,
+    createdAt: z.string(),
+    verifiedAt: z.string().nullable(),
+  })
+  .superRefine((d, ctx) => {
+    // DNS TXT trio: verifyDomainDnsTxt writes these three columns together.
+    if (d.domainVerified !== (d.domainVerifiedAt !== null)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "domainVerified and domainVerifiedAt must agree (both set or both unset).",
+        path: ["domainVerifiedAt"],
+      });
+    }
+    if (d.domainVerified !== (d.domainVerificationStatus === "verified")) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "domainVerified must be true iff domainVerificationStatus === 'verified'.",
+        path: ["domainVerificationStatus"],
+      });
+    }
+    // Railway CNAME/cert: verifyDomain stamps verified_at when status flips to
+    // 'verified'. The reverse doesn't hold — verified_at is preserved when
+    // status regresses to 'pending'/'failed' — so this is a one-way check.
+    if (d.status === "verified" && d.verifiedAt === null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "verifiedAt must be set when status === 'verified'.",
+        path: ["verifiedAt"],
+      });
+    }
+  }) satisfies z.ZodType<CustomDomain>;

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -30,6 +30,11 @@ export type DomainVerificationStatus = (typeof DOMAIN_VERIFICATION_STATUSES)[num
 
 // ---------------------------------------------------------------------------
 // Custom domain record
+//
+// Structural shape only — invariants (DNS TXT trio coupling, Railway
+// status→verifiedAt implication, non-empty domain) are enforced at the
+// wire boundary by `CustomDomainSchema` in `@useatlas/schemas`.
+// Code-only constructors of `CustomDomain` bypass those invariants.
 // ---------------------------------------------------------------------------
 
 export interface CustomDomain {


### PR DESCRIPTION
Closes #1661.

## Summary

- Audited every write path to `custom_domains` in `ee/src/platform/domains.ts`. The DNS TXT trio (`domain_verified` / `domain_verified_at` / `domain_verification_status`) is always written atomically in `verifyDomainDnsTxt`, and the Railway trio (`status` / `verified_at`) is written together in `verifyDomain`. `rowToDomain` defaults pre-migration rows to the all-unverified state, so no reachable path can emit a half-reconciled row.
- Added a `superRefine()` to `CustomDomainSchema` enforcing:
  - `domainVerified === (domainVerifiedAt !== null)`
  - `domainVerified === (domainVerificationStatus === 'verified')`
  - `status === 'verified' → verifiedAt !== null` (one-way — Railway preserves `verified_at` across regressions)
- Tightened `domain: z.string().min(1)` at zero cost (matches `CreateRuleBodySchema`).
- Added 4 negative-path tests for half-reconciled rows + 1 empty-domain test. Adjusted two existing enum-coverage tests to use `verifiedDomain` as the base row when iterating over `verified` values so they still satisfy the invariant.

## Test plan
- [x] `bun test packages/schemas/src/__tests__/custom-domain.test.ts` — 18 pass, 0 fail (11 existing + 4 invariant + 1 empty-domain + 2 existing enum tests adjusted)
- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun run test` (all packages) — exit 0
- [x] `bun x syncpack lint` — no issues
- [x] `bash scripts/check-template-drift.sh` — passed (429 files)

## Incidental finding

`custom_domains` in `packages/api/src/lib/db/schema.ts:887-905` is missing `domain_verified`, `domain_verified_at`, `domain_verification_status`, and `verification_token`, but `ee/src/platform/domains.ts` reads and writes them via raw SQL. No migration adds these columns to `custom_domains` (migration 0022 only adds them to `sso_providers`). Filing a separate bug — not in scope for this PR.