### PR TITLE
chore(types): bump consumer refs to @useatlas/types@^0.0.13 (PR B)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -227,7 +227,7 @@
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^5.96.2",
-        "@useatlas/types": "^0.0.12",
+        "@useatlas/types": "^0.0.13",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "radix-ui": "^1.4.3",
@@ -294,7 +294,7 @@
       "name": "@useatlas/sdk",
       "version": "0.0.11",
       "dependencies": {
-        "@useatlas/types": "^0.0.12",
+        "@useatlas/types": "^0.0.13",
       },
     },
     "packages/types": {
@@ -4227,10 +4227,6 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typespec/ts-http-runtime/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
-    "@useatlas/react/@useatlas/types": ["@useatlas/types@0.0.12", "", {}, "sha512-4Qffa3tsg+eOArlR0U0cCcmrgFzRDdk+5X+ZO8sGf5OPzA3ltlf0xFNckdXAIrHUPC/Fu1Zj8Tx2W0mjWFjs/A=="],
-
-    "@useatlas/sdk/@useatlas/types": ["@useatlas/types@0.0.12", "", {}, "sha512-4Qffa3tsg+eOArlR0U0cCcmrgFzRDdk+5X+ZO8sGf5OPzA3ltlf0xFNckdXAIrHUPC/Fu1Zj8Tx2W0mjWFjs/A=="],
 
     "@vercel/sandbox/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 

--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -24,7 +24,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.0.7",
     "@useatlas/sdk": "^0.0.11",
-    "@useatlas/types": "^0.0.12",
+    "@useatlas/types": "^0.0.13",
     "@better-auth/api-key": "^1.5.6",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -21,7 +21,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.0.7",
     "@useatlas/sdk": "^0.0.11",
-    "@useatlas/types": "^0.0.12",
+    "@useatlas/types": "^0.0.13",
     "ai": "^6.0.141",
     "@better-auth/api-key": "^1.5.6",
     "@dnd-kit/core": "^6.3.1",

--- a/packages/api/src/lib/integrations/types.ts
+++ b/packages/api/src/lib/integrations/types.ts
@@ -129,8 +129,9 @@ export interface WhatsAppInstallationWithSecret extends WhatsAppInstallation {
 // Email
 // ---------------------------------------------------------------------------
 
-export const EMAIL_PROVIDERS = ["resend", "sendgrid", "postmark", "smtp", "ses"] as const;
-export type EmailProvider = (typeof EMAIL_PROVIDERS)[number];
+import { EMAIL_PROVIDERS, type EmailProvider } from "@useatlas/types/email-provider";
+
+export { EMAIL_PROVIDERS, type EmailProvider };
 
 export interface SmtpConfig {
   host: string;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -82,7 +82,7 @@
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^5.96.2",
-    "@useatlas/types": "^0.0.12",
+    "@useatlas/types": "^0.0.13",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "radix-ui": "^1.4.3",

--- a/packages/schemas/src/connection.ts
+++ b/packages/schemas/src/connection.ts
@@ -8,12 +8,10 @@
  * `@useatlas/types` so mode-drift (published/draft/archived) fails parse
  * at the wire boundary instead of rendering a neutral fallback.
  *
- * `ConnectionHealth.status` tightens to a local enum literal
- * (`healthy | degraded | unhealthy`) matching the canonical `HealthStatus`
- * union in `@useatlas/types`. Not imported from a tuple because
- * `@useatlas/types` doesn't yet export one — #1703 tracks adding
- * `HEALTH_STATUSES` on the next types bump so this can switch to
- * `z.enum(HEALTH_STATUSES)` for drift-free construction.
+ * `ConnectionHealth.status` uses `z.enum(HEALTH_STATUSES)` from
+ * `@useatlas/types` so a new health-status variant added to the
+ * tuple fails at the schema call site rather than silently parsing
+ * through an inline enum.
  *
  * `ConnectionInfo.dbType` deliberately stays structurally typed via `as
  * z.ZodType<...>` (not `satisfies`) because plugins can register dbType
@@ -26,13 +24,14 @@
 import { z } from "zod";
 import {
   CONNECTION_STATUSES,
+  HEALTH_STATUSES,
   type ConnectionHealth,
   type ConnectionInfo,
 } from "@useatlas/types";
 import { IsoTimestampSchema } from "./common";
 
 export const ConnectionHealthSchema = z.object({
-  status: z.enum(["healthy", "degraded", "unhealthy"]),
+  status: z.enum(HEALTH_STATUSES),
   latencyMs: z.number(),
   message: z.string().optional(),
   checkedAt: IsoTimestampSchema,

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -44,6 +44,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@useatlas/types": "^0.0.12"
+    "@useatlas/types": "^0.0.13"
   }
 }


### PR DESCRIPTION
## Summary

PR B of the documented two-step publish sequence. `@useatlas/types@0.0.13` is live on npm (tag `types-v0.0.13`, PR #1704). This PR bumps consumer refs and migrates the two call-sites to the new tuples. **Closes #1543 and #1703.**

### Ref bumps (`^0.0.12` → `^0.0.13`)

- `packages/sdk/package.json`
- `packages/react/package.json`
- `create-atlas/templates/docker/package.json`
- `create-atlas/templates/nextjs-standalone/package.json`

(`packages/schemas` and `packages/api` both use `workspace:*` — no ref change needed.)

### Call-site migrations

- `packages/api/src/lib/integrations/types.ts` — drops the inline `EMAIL_PROVIDERS` tuple + `EmailProvider` type. Both now import from `@useatlas/types/email-provider` and are re-exported in place, so the 13 downstream importers (`settings.ts`, `admin-email-provider` route, `admin-integrations` route, `email/store` re-export, and 3 test mocks) keep working unchanged.
- `packages/schemas/src/connection.ts` — inline `z.enum(["healthy", "degraded", "unhealthy"])` becomes `z.enum(HEALTH_STATUSES)` importing the tuple from `@useatlas/types`. Removes the TODO comment that was blocking on the 0.0.13 bump (see old header doc referencing #1703).

### Lockfile

`bun.lock` regenerated so CI's `--frozen-lockfile` passes.

## Test plan

- [x] `bun run lint` — 0 errors
- [x] `bun run type` — 0 errors
- [x] `bun run test` — all packages green
- [x] `bun x syncpack lint` — no issues
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — 429 files verified
- [ ] Deploy Validation (scaffold docker/vercel, standalone build) — should now be green since scaffolds can resolve `^0.0.13` from npm