### PR TITLE
refactor(types): 0.0.14 discriminated-union cluster (PR A — type shapes only)

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/types",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {

--- a/packages/types/src/action.test.ts
+++ b/packages/types/src/action.test.ts
@@ -4,9 +4,9 @@ import { isActionToolResult } from "./action";
 describe("isActionToolResult", () => {
   // ── Valid variants ──────────────────────────────────────────────────
 
-  test("pending_approval with summary", () => {
+  test("pending with summary", () => {
     expect(
-      isActionToolResult({ status: "pending_approval", actionId: "a1", summary: "Do the thing" }),
+      isActionToolResult({ status: "pending", actionId: "a1", summary: "Do the thing" }),
     ).toBe(true);
   });
 
@@ -54,8 +54,8 @@ describe("isActionToolResult", () => {
 
   // ── Missing variant-specific required fields ────────────────────────
 
-  test("pending_approval missing summary", () => {
-    expect(isActionToolResult({ status: "pending_approval", actionId: "a1" })).toBe(false);
+  test("pending missing summary", () => {
+    expect(isActionToolResult({ status: "pending", actionId: "a1" })).toBe(false);
   });
 
   test("approved missing result", () => {
@@ -76,9 +76,9 @@ describe("isActionToolResult", () => {
 
   // ── Wrong types for required fields ─────────────────────────────────
 
-  test("pending_approval with non-string summary", () => {
+  test("pending with non-string summary", () => {
     expect(
-      isActionToolResult({ status: "pending_approval", actionId: "a1", summary: 42 }),
+      isActionToolResult({ status: "pending", actionId: "a1", summary: 42 }),
     ).toBe(false);
   });
 

--- a/packages/types/src/action.ts
+++ b/packages/types/src/action.ts
@@ -8,17 +8,18 @@ export const ACTION_APPROVAL_MODES = ["auto", "manual", "admin-only"] as const;
 export type ActionApprovalMode = (typeof ACTION_APPROVAL_MODES)[number];
 
 // ---------------------------------------------------------------------------
-// Client-facing action display status lifecycle (frontend wire format)
+// Action status lifecycle (single unified enum for wire + DB)
 // ---------------------------------------------------------------------------
 
 /**
- * Display status lifecycle for action tools that require user approval.
- *
- * Distinct from the server-internal `ActionStatus` which uses "pending"
- * instead of "pending_approval".
+ * Action lifecycle status — the same value is persisted in action_log.status,
+ * emitted by action tools, and rendered in admin queues. Before #1591 the
+ * server used "pending" while the display layer used "pending_approval",
+ * requiring a `mapStatus` shim at every call site. Unifying the tuples
+ * removes the drift surface entirely.
  */
 export type ActionDisplayStatus =
-  | "pending_approval"
+  | "pending"
   | "approved"
   | "executed"
   | "auto_approved"
@@ -28,11 +29,11 @@ export type ActionDisplayStatus =
   | "timed_out";
 
 /** A display status that is terminal (no longer pending). */
-export type ResolvedDisplayStatus = Exclude<ActionDisplayStatus, "pending_approval">;
+export type ResolvedDisplayStatus = Exclude<ActionDisplayStatus, "pending">;
 
 /** Single source of truth for every ActionDisplayStatus value. */
 export const ALL_STATUSES = [
-  "pending_approval",
+  "pending",
   "approved",
   "executed",
   "auto_approved",
@@ -44,12 +45,12 @@ export const ALL_STATUSES = [
 
 /** All statuses that are terminal (no longer pending). */
 export const RESOLVED_STATUSES: ReadonlySet<ActionDisplayStatus> = new Set<ActionDisplayStatus>(
-  ALL_STATUSES.filter((s): s is ResolvedDisplayStatus => s !== "pending_approval"),
+  ALL_STATUSES.filter((s): s is ResolvedDisplayStatus => s !== "pending"),
 );
 
 /** Discriminated union returned by action tools in the tool result. */
 export type ActionToolResultShape =
-  | { status: "pending_approval"; actionId: string; summary: string; details?: Record<string, unknown> }
+  | { status: "pending"; actionId: string; summary: string; details?: Record<string, unknown> }
   | { status: "approved" | "executed" | "auto_approved"; actionId: string; result: unknown; summary?: string; details?: Record<string, unknown> }
   | { status: "denied"; actionId: string; reason?: string; summary?: string; details?: Record<string, unknown> }
   | { status: "failed"; actionId: string; error: string; summary?: string; details?: Record<string, unknown> }
@@ -80,10 +81,17 @@ export const ACTION_STATUSES = [
 export type ActionStatus = (typeof ACTION_STATUSES)[number];
 
 /**
- * Compile-time check: every non-pending ActionStatus must be a valid
- * ActionDisplayStatus. Prevents drift between server and display enums.
+ * Compile-time invariant: ActionStatus and ActionDisplayStatus describe the
+ * same closed set. If a new status is added to one tuple without the other,
+ * this type expression collapses to `never` and `_statusAlignmentCheck` fails
+ * to type-check.
  */
-type _AssertStatusAlignment = Exclude<ActionStatus, "pending"> extends ActionDisplayStatus ? true : never;
+type _AssertStatusAlignment =
+  [Exclude<ActionStatus, ActionDisplayStatus>] extends [never]
+    ? [Exclude<ActionDisplayStatus, ActionStatus>] extends [never]
+      ? true
+      : never
+    : never;
 const _statusAlignmentCheck: _AssertStatusAlignment = true;
 
 /** Information needed to undo an executed action. */
@@ -126,7 +134,7 @@ export function isActionToolResult(result: unknown): result is ActionToolResultS
   if (!VALID_STATUSES.has(r.status as ActionDisplayStatus)) return false;
 
   switch (r.status) {
-    case "pending_approval":
+    case "pending":
       return typeof r.summary === "string";
     case "approved":
     case "executed":

--- a/packages/types/src/approval.ts
+++ b/packages/types/src/approval.ts
@@ -4,6 +4,13 @@
  * Enterprise customers can configure approval rules that intercept sensitive
  * queries (by table, column, or cost threshold) and require sign-off before
  * execution.
+ *
+ * `ApprovalRule` and `ApprovalRequest` are discriminated unions — the
+ * variants encode cross-field invariants at the wire layer so a malformed
+ * row (e.g. a cost rule missing its threshold, or a pending request with a
+ * populated reviewerId) is a compile-time error on construction and a
+ * parse-time rejection on read. Before #1660 these invariants were
+ * documented in the field JSDoc but not enforced structurally.
  */
 
 // ── Rule types ──────────────────────────────────────────────────────
@@ -16,23 +23,44 @@ export type ApprovalStatus = (typeof APPROVAL_STATUSES)[number];
 
 // ── Approval rule ───────────────────────────────────────────────────
 
-export interface ApprovalRule {
+/**
+ * Fields common to every approval rule. The `ruleType`-keyed variants below
+ * intersect with this base to produce the full `ApprovalRule` shape.
+ */
+interface ApprovalRuleBase {
   id: string;
   orgId: string;
   name: string;
-  ruleType: ApprovalRuleType;
-  /** For table rules: table name pattern. For column rules: column name pattern. For cost: unused. */
-  pattern: string;
-  /** For cost rules: threshold value. Null for table/column rules. */
-  threshold: number | null;
   enabled: boolean;
   createdAt: string;
   updatedAt: string;
 }
 
+/**
+ * Approval rule — three kinds, distinguished by `ruleType`.
+ *
+ * - `cost` rules match when estimated row count exceeds `threshold`; pattern
+ *   is unused and stored as the empty string.
+ * - `table` / `column` rules match when a query accesses a name matching
+ *   `pattern`; threshold is unused and stored as null.
+ *
+ * The union encodes the "threshold XOR pattern" invariant at the type level
+ * so handlers that construct a rule must name the variant explicitly.
+ */
+export type ApprovalRule = ApprovalRuleBase & (
+  | { ruleType: "cost"; threshold: number; pattern: "" }
+  | { ruleType: "table"; pattern: string; threshold: null }
+  | { ruleType: "column"; pattern: string; threshold: null }
+);
+
 // ── Approval request (queue item) ───────────────────────────────────
 
-export interface ApprovalRequest {
+/**
+ * Fields common to every approval request — the query, requester, and
+ * timing metadata. The `status`-keyed variants below intersect with this
+ * base to encode reviewer-field nullness invariants.
+ */
+interface ApprovalRequestBase {
   id: string;
   orgId: string;
   ruleId: string;
@@ -45,24 +73,58 @@ export interface ApprovalRequest {
   connectionId: string;
   tablesAccessed: string[];
   columnsAccessed: string[];
-  status: ApprovalStatus;
-  reviewerId: string | null;
-  reviewerEmail: string | null;
-  reviewComment: string | null;
-  reviewedAt: string | null;
   createdAt: string;
   expiresAt: string;
 }
 
+/**
+ * Approval request — four lifecycle states. The reviewer-related columns
+ * (`reviewerId`, `reviewerEmail`, `reviewComment`, `reviewedAt`) are only
+ * populated after a reviewer takes action; the discriminated union encodes
+ * this so `pending`/`expired` rows cannot construct with a reviewer set.
+ */
+export type ApprovalRequest = ApprovalRequestBase & (
+  | {
+      status: "pending";
+      reviewerId: null;
+      reviewerEmail: null;
+      reviewComment: null;
+      reviewedAt: null;
+    }
+  | {
+      status: "approved";
+      reviewerId: string;
+      reviewerEmail: string | null;
+      reviewComment: string | null;
+      reviewedAt: string;
+    }
+  | {
+      status: "denied";
+      reviewerId: string;
+      reviewerEmail: string | null;
+      reviewComment: string | null;
+      reviewedAt: string;
+    }
+  | {
+      status: "expired";
+      reviewerId: null;
+      reviewerEmail: null;
+      reviewComment: null;
+      reviewedAt: null;
+    }
+);
+
 // ── Request / response shapes ───────────────────────────────────────
 
-export interface CreateApprovalRuleRequest {
-  name: string;
-  ruleType: ApprovalRuleType;
-  pattern: string;
-  threshold?: number | null;
-  enabled?: boolean;
-}
+/**
+ * Create-rule request — mirrors the `ApprovalRule` discriminated union so
+ * a cost rule without a threshold is a compile-time error, not a 400 from
+ * runtime validation alone.
+ */
+export type CreateApprovalRuleRequest =
+  | { ruleType: "cost"; threshold: number; name: string; pattern?: ""; enabled?: boolean }
+  | { ruleType: "table"; pattern: string; name: string; threshold?: null; enabled?: boolean }
+  | { ruleType: "column"; pattern: string; name: string; threshold?: null; enabled?: boolean };
 
 export interface UpdateApprovalRuleRequest {
   name?: string;

--- a/packages/types/src/email-provider.ts
+++ b/packages/types/src/email-provider.ts
@@ -1,3 +1,62 @@
+/**
+ * Email provider types shared across API, frontend, and SDK.
+ *
+ * `ProviderConfig` is a discriminated union keyed on `provider`. Before
+ * #1542 it was a structural union (`SmtpConfig | SendGridConfig | ...`)
+ * with `provider` carried on a sibling column — TypeScript could not
+ * narrow the config from the provider string, forcing `as` casts at every
+ * read site. Embedding the tag closes that gap: handlers `switch` on
+ * `config.provider` and the compiler narrows.
+ *
+ * JSONB rows in `email_installations.config` do not store the `provider`
+ * field today — the parser in `lib/email/store.ts` injects it at read
+ * time from the sibling `provider` column, which is the authoritative
+ * source.
+ */
+
 /** Supported email provider keys for transactional email integrations. */
 export const EMAIL_PROVIDERS = ["resend", "sendgrid", "postmark", "smtp", "ses"] as const;
 export type EmailProvider = (typeof EMAIL_PROVIDERS)[number];
+
+// ---------------------------------------------------------------------------
+// Provider-specific config shapes — each carries the `provider` discriminator
+// ---------------------------------------------------------------------------
+
+export interface SmtpConfig {
+  provider: "smtp";
+  host: string;
+  port: number;
+  username: string;
+  password: string;
+  tls: boolean;
+}
+
+export interface SendGridConfig {
+  provider: "sendgrid";
+  apiKey: string;
+}
+
+export interface PostmarkConfig {
+  provider: "postmark";
+  serverToken: string;
+}
+
+export interface SesConfig {
+  provider: "ses";
+  region: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+}
+
+export interface ResendConfig {
+  provider: "resend";
+  apiKey: string;
+}
+
+/** Discriminated union of provider-specific credential shapes. */
+export type ProviderConfig =
+  | SmtpConfig
+  | SendGridConfig
+  | PostmarkConfig
+  | SesConfig
+  | ResendConfig;

--- a/packages/types/src/residency.ts
+++ b/packages/types/src/residency.ts
@@ -81,22 +81,45 @@ export const MIGRATION_STATUSES = ["pending", "in_progress", "completed", "faile
 /** Status of a region migration request. */
 export type MigrationStatus = (typeof MIGRATION_STATUSES)[number];
 
-/** A workspace region migration request. */
-export interface RegionMigration {
+/**
+ * Fields common to every region migration. The `status`-keyed variants in
+ * `RegionMigration` intersect with this base to encode terminal-vs-in-flight
+ * timestamp and error-message invariants (#1696).
+ */
+interface RegionMigrationBase {
   id: string;
   workspaceId: string;
   sourceRegion: Region;
   targetRegion: Region;
-  status: MigrationStatus;
   /** User ID of who requested the migration. */
   requestedBy: string | null;
   /** ISO 8601 timestamp of when the migration was requested. */
   requestedAt: string;
-  /** ISO 8601 timestamp of when the migration completed (or failed). */
-  completedAt: string | null;
-  /** Error message if the migration failed. */
-  errorMessage: string | null;
 }
+
+/**
+ * A workspace region migration request.
+ *
+ * The discriminated union encodes two cross-field invariants the writer
+ * enforces atomically but the structural shape alone cannot express:
+ *
+ * - `pending` / `in_progress` rows have `completedAt === null` and
+ *   `errorMessage === null` — no terminal timestamp has been stamped.
+ * - `completed` rows have `completedAt: string` and `errorMessage === null`
+ *   — success path leaves errorMessage empty.
+ * - `failed` rows have `completedAt: string` and a populated
+ *   `errorMessage: string` — the failure reason is required.
+ * - `cancelled` rows have `completedAt: string`; `errorMessage` is
+ *   `string | null` because legacy cancellations stamped 'Cancelled by admin'
+ *   while newer code is free to leave it null.
+ */
+export type RegionMigration = RegionMigrationBase & (
+  | { status: "pending"; completedAt: null; errorMessage: null }
+  | { status: "in_progress"; completedAt: null; errorMessage: null }
+  | { status: "completed"; completedAt: string; errorMessage: null }
+  | { status: "failed"; completedAt: string; errorMessage: string }
+  | { status: "cancelled"; completedAt: string; errorMessage: string | null }
+);
 
 // ---------------------------------------------------------------------------
 // Region status (admin view)


### PR DESCRIPTION
## Summary

PR A of the @useatlas/types 0.0.14 publish cycle. Bundles four
discriminated-union shape changes (#1542, #1591, #1660, #1696) that close
four separate drift surfaces at the wire layer, then bumps the package to
0.0.14.

**Scope is intentionally narrow** — only `packages/types/` changes here:

- **#1542 ProviderConfig tagged union** — `ProviderConfig` in
  `packages/types/src/email-provider.ts` becomes a discriminated union
  keyed on `provider`, embedding the tag in every variant. Consumers will
  drop the `as` casts scattered across `lib/email/*` and
  `admin-integrations` / `admin-email-provider` routes in PR B.
- **#1591 ActionStatus unification** — `ActionDisplayStatus.pending_approval`
  renames to `pending` (the value the server already emits). The
  `_AssertStatusAlignment` check at the bottom of `action.ts` flips to
  assert exact equality of `ActionStatus` and `ActionDisplayStatus` — they
  are now one enum. Consumers drop the `mapStatus` shim in the admin page
  in PR B.
- **#1660 ApprovalRule + ApprovalRequest discriminated unions** —
  `ApprovalRule` variants keyed on `ruleType` encode the "threshold XOR
  pattern" invariant; `ApprovalRequest` variants keyed on `status` encode
  the "reviewer columns populated iff reviewed" invariant. Consumers
  migrate the Zod schemas to `z.discriminatedUnion` in PR B.
- **#1696 RegionMigration discriminated union** — variants keyed on
  `status` encode the "in-flight rows have null terminal timestamps",
  "failed rows require errorMessage: string" invariants. `cancelled`
  keeps `errorMessage: string | null` for legacy 'Cancelled by admin'
  rows.

## CI expectation — red by design

`@atlas/api` and `@atlas/web` won't compile against the new shapes yet —
that's the whole point of sequencing A/B. This PR doesn't bump consumer
refs (templates, sdk, react stay at `^0.0.13`) and doesn't touch any
consumer call sites. Do **not** merge until PR B is ready.

## Release sequence

1. Land this PR (after PR B is ready to go behind it).
2. Tag + publish: `git tag types-v0.0.14 && git push origin types-v0.0.14`.
3. Land PR B (`chore/types-0-0-14-consumer-migrations`) — consumer ref
   bumps + the four subsystem migrations.

Per `memory/feedback_version_bump_ordering.md` — consumer refs must bump
**after** publish, not in PR A.

## Test plan

- [x] `bun run build` in `packages/types` succeeds — 15 entry points
      emit; `.d.ts` regenerates.
- [x] `bun test` in `packages/types` — 130 pass (unchanged count; tests
      renamed from `pending_approval` → `pending` in `action.test.ts`).
- [x] `bun x syncpack lint` — clean.
- [ ] Merged behind PR B only.

Relates to #1542, #1591, #1660, #1696. The closing `Closes #...` body
lives on PR B, because that's the PR that ships the full migration.