### PR TITLE
fix: custom_domains DNS verification schema drift + admin-cache e2e (#1707 #1708)

### DIFF
--- a/e2e/browser/admin-cache.spec.ts
+++ b/e2e/browser/admin-cache.spec.ts
@@ -1,0 +1,177 @@
+import { test, expect, type Page, type Route } from "@playwright/test";
+
+/**
+ * Admin cache flush flow — e2e coverage for the Bucket-4 polish page
+ * (#1708, follow-up to PR #1705). Rated 4/10 criticality by the
+ * test-analyzer: pure CSS/a11y polish, but `/admin/cache` had zero
+ * prior browser coverage.
+ *
+ * Mocks `/api/v1/admin/cache/{stats,flush}` at the page level and
+ * mutates a local stats object on POST so the refetch after a
+ * successful flush reflects `entryCount: 0`. No `@llm` tag — no
+ * model calls.
+ *
+ * Mirrors the shape of `admin-sessions.spec.ts` (route-mock pattern,
+ * `route.abort("failed")` on unexpected methods so real-network
+ * passthrough can't mask a regression in CI).
+ */
+
+interface MockCacheStats {
+  enabled: boolean;
+  hits: number;
+  misses: number;
+  hitRate: number;
+  missRate: number;
+  entryCount: number;
+  maxSize: number;
+  ttl: number;
+}
+
+function buildStats(overrides: Partial<MockCacheStats> = {}): MockCacheStats {
+  return {
+    enabled: true,
+    hits: 8_500,
+    misses: 1_500,
+    hitRate: 0.85,
+    missRate: 0.15,
+    entryCount: 420,
+    maxSize: 1_000,
+    ttl: 60_000,
+    ...overrides,
+  };
+}
+
+interface MockOptions {
+  initial?: Partial<MockCacheStats>;
+  /** If set, POST /flush returns a 500 with this requestId. */
+  flushFailRequestId?: string;
+}
+
+async function installCacheMocks(
+  page: Page,
+  opts: MockOptions = {},
+): Promise<{ stats: MockCacheStats }> {
+  const stats: MockCacheStats = buildStats(opts.initial);
+
+  await page.route(/\/api\/v1\/admin\/cache\/stats(?:\?|$)/, async (route: Route) => {
+    if (route.request().method() !== "GET") {
+      await route.abort("failed");
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(stats),
+    });
+  });
+
+  await page.route(/\/api\/v1\/admin\/cache\/flush(?:\?|$)/, async (route: Route) => {
+    if (route.request().method() !== "POST") {
+      await route.abort("failed");
+      return;
+    }
+    if (opts.flushFailRequestId) {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: "internal",
+          message: "Cache flush failed on the backend",
+          requestId: opts.flushFailRequestId,
+        }),
+      });
+      return;
+    }
+    // Successful flush — drop entries so the subsequent refetch shows
+    // an empty cache, which in turn disables the flush button + flips
+    // the tooltip copy.
+    stats.entryCount = 0;
+    stats.hits = 0;
+    stats.misses = 0;
+    stats.hitRate = 0;
+    stats.missRate = 0;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ message: "Cache flushed (420 entries removed)" }),
+    });
+  });
+
+  return { stats };
+}
+
+test.describe("Admin cache flush flow", () => {
+  test.describe.configure({ timeout: 30_000 });
+
+  test("golden path: flush → success banner → empty cache disables button", async ({ page }) => {
+    await installCacheMocks(page);
+    await page.goto("/admin/cache");
+
+    await expect(page.locator("h1", { hasText: "Cache" })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Stats render from the initial GET.
+    await expect(page.getByText("Hit Rate", { exact: true })).toBeVisible();
+    await expect(page.getByText("85.0%")).toBeVisible();
+    await expect(page.getByText("420 / 1,000")).toBeVisible();
+
+    // Flush button enabled; click opens the confirm dialog.
+    const flushButton = page.getByRole("button", { name: "Flush Cache", exact: true });
+    await expect(flushButton).toBeEnabled();
+    await flushButton.click();
+
+    await expect(page.getByRole("heading", { name: "Flush cache?" })).toBeVisible();
+    // Confirm dialog describes the entry count accurately.
+    await expect(
+      page.getByText("This will remove 420 cached entries", { exact: false }),
+    ).toBeVisible();
+
+    // Confirm → POST fires → success banner appears via role=status.
+    await page.getByRole("button", { name: /flush/i, exact: false }).last().click();
+
+    await expect(
+      page.getByRole("status").filter({ hasText: /flushed/i }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // After refetch, the flush button is disabled (entryCount === 0) and
+    // hovering reveals the "Cache is empty" tooltip.
+    const disabledFlush = page.getByRole("button", { name: "Flush Cache", exact: true });
+    await expect(disabledFlush).toBeDisabled({ timeout: 10_000 });
+  });
+
+  test("disabled cache renders env-var notice + tooltip explains why flush is gated", async ({ page }) => {
+    await installCacheMocks(page, { initial: { enabled: false, entryCount: 0, hits: 0, misses: 0, hitRate: 0 } });
+    await page.goto("/admin/cache");
+
+    await expect(page.locator("h1", { hasText: "Cache" })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Amber notice for disabled cache with the env var code-literal.
+    await expect(page.getByText(/ATLAS_CACHE_ENABLED/)).toBeVisible();
+
+    // Flush button is disabled (no POST should fire even if clicked).
+    const flushButton = page.getByRole("button", { name: "Flush Cache", exact: true });
+    await expect(flushButton).toBeDisabled();
+  });
+
+  test("flush failure routes through MutationErrorSurface with requestId", async ({ page }) => {
+    await installCacheMocks(page, { flushFailRequestId: "req_mock_fail_abc" });
+    await page.goto("/admin/cache");
+
+    await expect(page.locator("h1", { hasText: "Cache" })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await page.getByRole("button", { name: "Flush Cache", exact: true }).click();
+    await expect(page.getByRole("heading", { name: "Flush cache?" })).toBeVisible();
+    await page.getByRole("button", { name: /flush/i, exact: false }).last().click();
+
+    // MutationErrorSurface renders the error message; no success banner.
+    await expect(page.getByText(/cache flush failed/i)).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByRole("status").filter({ hasText: /flushed \(/i })).toHaveCount(0);
+  });
+});

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -278,6 +278,7 @@ describe("migrateAuthTables", () => {
             { name: "0030_starter_prompt_approval.sql" },
             { name: "0031_abuse_events_enum_checks.sql" },
             { name: "0032_backups_status_check.sql" },
+            { name: "0033_custom_domains_dns_verification.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -79,7 +79,7 @@ describe("runMigrations", () => {
 
     const count = await runMigrations(pool);
 
-    expect(count).toBe(33);
+    expect(count).toBe(34);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -141,6 +141,7 @@ describe("runMigrations", () => {
         "0030_starter_prompt_approval.sql",
         "0031_abuse_events_enum_checks.sql",
         "0032_backups_status_check.sql",
+        "0033_custom_domains_dns_verification.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0033_custom_domains_dns_verification.sql
+++ b/packages/api/src/lib/db/migrations/0033_custom_domains_dns_verification.sql
@@ -1,0 +1,31 @@
+-- 0033 — Add DNS TXT ownership verification columns to custom_domains
+--
+-- `ee/src/platform/domains.ts` (registerDomain + verifyDomainDnsTxt +
+-- rowToDomain + hasVerifiedCustomDomain) has been reading and writing these
+-- four columns via raw SQL, but `packages/api/src/lib/db/schema.ts` didn't
+-- declare them. Drizzle-generated migrations therefore didn't create them
+-- on fresh DBs. Surfaced during #1661 audit; tracked as #1707.
+--
+-- Mirrors the pattern from 0022_sso_domain_verification.sql so the two
+-- domain-verified surfaces stay parallel.
+
+ALTER TABLE custom_domains ADD COLUMN IF NOT EXISTS verification_token TEXT;
+ALTER TABLE custom_domains ADD COLUMN IF NOT EXISTS domain_verified BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE custom_domains ADD COLUMN IF NOT EXISTS domain_verified_at TIMESTAMPTZ;
+ALTER TABLE custom_domains ADD COLUMN IF NOT EXISTS domain_verification_status TEXT NOT NULL DEFAULT 'pending';
+
+-- Grandfather existing domains whose outer status is already 'verified' —
+-- they were created before DNS TXT verification existed so their ownership
+-- was implicitly trusted via the Railway-domain-id path. Matches 0022's
+-- `WHERE enabled = true` grandfathering.
+UPDATE custom_domains
+SET domain_verified = true,
+    domain_verified_at = COALESCE(verified_at, now()),
+    domain_verification_status = 'verified'
+WHERE status = 'verified';
+
+DO $$ BEGIN
+  ALTER TABLE custom_domains ADD CONSTRAINT chk_custom_domain_verification_status
+    CHECK (domain_verification_status IN ('pending', 'verified', 'failed'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -894,11 +894,22 @@ export const customDomains = pgTable(
     railwayDomainId: text("railway_domain_id"),
     cnameTarget: text("cname_target"),
     certificateStatus: text("certificate_status"),
+    // DNS TXT ownership verification — mirrors sso_providers (migration 0022).
+    // Written by ee/src/platform/domains.ts (registerDomain + verifyDomainDnsTxt)
+    // and read by rowToDomain + hasVerifiedCustomDomain.
+    verificationToken: text("verification_token"),
+    domainVerified: boolean("domain_verified").notNull().default(false),
+    domainVerifiedAt: timestamp("domain_verified_at", { withTimezone: true }),
+    domainVerificationStatus: text("domain_verification_status").notNull().default("pending"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     verifiedAt: timestamp("verified_at", { withTimezone: true }),
   },
   (t) => [
     check("chk_domain_status", sql`status IN ('pending', 'verified', 'failed')`),
+    check(
+      "chk_custom_domain_verification_status",
+      sql`domain_verification_status IN ('pending', 'verified', 'failed')`,
+    ),
     index("idx_custom_domains_workspace").on(t.workspaceId),
     index("idx_custom_domains_status").on(t.status),
   ],


### PR DESCRIPTION
## Summary

Two closeout items for 1.2.2: one real bug + one test gap.

### #1707 — Drizzle schema drift for `custom_domains`

`ee/src/platform/domains.ts` has been reading and writing four DNS TXT verification columns via raw SQL but `packages/api/src/lib/db/schema.ts` didn't declare them. Drizzle-generated migrations therefore never created the columns on fresh DBs — `INSERT`s from `registerDomain` would have failed at runtime.

- `schema.ts` adds `verification_token`, `domain_verified`, `domain_verified_at`, `domain_verification_status` to `customDomains` + `chk_custom_domain_verification_status` check constraint
- New migration `0033_custom_domains_dns_verification.sql` mirrors `0022_sso_domain_verification.sql`'s pattern: `ADD COLUMN IF NOT EXISTS` idempotent, grandfathers existing rows whose outer `status === 'verified'`, adds the check constraint with `DO $$ EXCEPTION` re-run guards

Surfaced during #1661 audit of the 3-way verification invariant.

### #1708 — Admin cache e2e browser coverage

`/admin/cache` had zero prior browser coverage despite shipping Bucket-4 polish in PR #1705. New `e2e/browser/admin-cache.spec.ts` mirrors the `admin-sessions.spec.ts` route-mock pattern. 3 cases:

- **Golden path**: 420 entries → Flush → confirm dialog → success banner → refetch empties cache → flush button disables
- **Disabled cache**: `enabled=false` → amber `ATLAS_CACHE_ENABLED` notice, flush button disabled
- **Flush failure**: POST returns 500 → `MutationErrorSurface` renders, no success banner

No `@llm` tag (deterministic mocks, no model calls). Unexpected HTTP methods `route.abort("failed")` instead of falling back to real network (same CI hazard guard as admin-sessions.spec).

## Test plan

- [x] `bun run lint` — clean
- [x] `bun test packages/api/src/lib/db` — 285 pass (3 failures pre-exist on main per `git stash` verification; unrelated to this PR)
- [ ] Admin-cache e2e spec runs green in the browser-test suite alongside admin-sessions.spec

Closes #1707, #1708.