### PR TITLE
fix(security): P0 — block bootstrap platform_admin race (#1728)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,7 +65,17 @@ ATLAS_DATASOURCE_URL=postgresql://atlas:atlas@localhost:5432/atlas_demo
 BETTER_AUTH_SECRET=atlas-dev-secret-do-not-use-in-production!!
 BETTER_AUTH_URL=http://localhost:3001
 BETTER_AUTH_TRUSTED_ORIGINS=http://localhost:3000
+#
+# ATLAS_ADMIN_EMAIL — REQUIRED for managed auth in production.
+# When set, the user signing up with this exact email is promoted to
+# platform_admin on creation. All other signups become regular members.
+# Leave unset only for CI / ephemeral demos that also set
+# ATLAS_ALLOW_FIRST_SIGNUP_ADMIN=true (see below).
 ATLAS_ADMIN_EMAIL=admin@useatlas.dev
+#
+# ATLAS_ALLOW_FIRST_SIGNUP_ADMIN=true       # Opt-in fallback: when ATLAS_ADMIN_EMAIL is unset AND no admin user exists, promote the
+                                            # first signup to platform_admin. DO NOT use in production — any unauthenticated visitor
+                                            # could race the operator and claim platform_admin with a single signup request.
 #
 # ATLAS_AUTH_MODE=                          # Force auth mode: managed | api-key | byot | none (auto-detected by default)
 #

--- a/packages/api/src/lib/auth/__tests__/bootstrap.test.ts
+++ b/packages/api/src/lib/auth/__tests__/bootstrap.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "bun:test";
+import { computeBootstrapRole } from "../server";
+
+/**
+ * Regression tests for #1728 / F-02 — the bootstrap platform_admin race.
+ *
+ * Before 1.2.3 the "no admin exists → promote first signup to platform_admin"
+ * branch fired unconditionally. Any unauthenticated visitor could POST to
+ * /api/auth/sign-up/email on a fresh deployment and claim platform_admin in
+ * a single request. These tests pin the current safe behavior so future
+ * refactors don't reintroduce the race.
+ */
+describe("computeBootstrapRole", () => {
+  const countZero = () => Promise.resolve(0);
+  const countOne = () => Promise.resolve(1);
+
+  it("promotes when ATLAS_ADMIN_EMAIL matches the user email (case-insensitive)", async () => {
+    const decision = await computeBootstrapRole(
+      { email: "Admin@Example.Com" },
+      {
+        adminEmail: "admin@example.com",
+        allowFirstSignupAdmin: false,
+        internalDbAvailable: true,
+        countExistingAdmins: countZero,
+      },
+    );
+
+    expect(decision.promote).toBe(true);
+    if (decision.promote) expect(decision.role).toBe("platform_admin");
+  });
+
+  it("promotes when ATLAS_ADMIN_EMAIL matches after trimming whitespace", async () => {
+    const decision = await computeBootstrapRole(
+      { email: "  admin@example.com  " },
+      {
+        adminEmail: "admin@example.com",
+        allowFirstSignupAdmin: false,
+        internalDbAvailable: true,
+        countExistingAdmins: countZero,
+      },
+    );
+
+    expect(decision.promote).toBe(true);
+  });
+
+  it("does NOT promote when the email doesn't match ATLAS_ADMIN_EMAIL", async () => {
+    const decision = await computeBootstrapRole(
+      { email: "attacker@evil.invalid" },
+      {
+        adminEmail: "admin@example.com",
+        allowFirstSignupAdmin: false,
+        internalDbAvailable: true,
+        countExistingAdmins: countZero,
+      },
+    );
+
+    expect(decision.promote).toBe(false);
+  });
+
+  it("does NOT promote when ATLAS_ADMIN_EMAIL is set but the user email is missing", async () => {
+    const decision = await computeBootstrapRole(
+      { email: null },
+      {
+        adminEmail: "admin@example.com",
+        allowFirstSignupAdmin: false,
+        internalDbAvailable: true,
+        countExistingAdmins: countZero,
+      },
+    );
+
+    expect(decision.promote).toBe(false);
+  });
+
+  // ----- F-02 regression: the attacker's happy path must fail ---------------
+
+  it("F-02: does NOT promote an arbitrary signup when ATLAS_ADMIN_EMAIL is unset and the opt-in flag is off", async () => {
+    const decision = await computeBootstrapRole(
+      { email: "attacker@evil.invalid" },
+      {
+        adminEmail: undefined,
+        allowFirstSignupAdmin: false, // the fix: default false
+        internalDbAvailable: true,
+        countExistingAdmins: countZero, // zero admins — this USED to auto-promote
+      },
+    );
+
+    expect(decision.promote).toBe(false);
+    expect(decision.reason).toContain("ATLAS_ALLOW_FIRST_SIGNUP_ADMIN");
+  });
+
+  it("F-02: opt-in fallback does NOT promote when the DB is unreachable", async () => {
+    // Paranoid: even with the opt-in flag on, an attacker shouldn't get
+    // platform_admin just because our DB probe can't prove no admin exists.
+    // internalDbAvailable=false represents the signal that we cannot trust
+    // the probe. The implementation also treats a throwing probe as fail-closed
+    // (caught by the outer hook try/catch and logged).
+    const decision = await computeBootstrapRole(
+      { email: "attacker@evil.invalid" },
+      {
+        adminEmail: undefined,
+        allowFirstSignupAdmin: true, // opt-in ON so we test the DB-availability guard
+        internalDbAvailable: false,
+        countExistingAdmins: () => {
+          throw new Error("probe should not be called when internalDbAvailable=false");
+        },
+      },
+    );
+
+    expect(decision.promote).toBe(false);
+  });
+
+  // ----- Opt-in fallback path still works (CI, ephemeral demos) -------------
+
+  it("promotes when the opt-in flag is set AND no admin exists AND DB is available", async () => {
+    const decision = await computeBootstrapRole(
+      { email: "first-user@demo.test" },
+      {
+        adminEmail: undefined,
+        allowFirstSignupAdmin: true,
+        internalDbAvailable: true,
+        countExistingAdmins: countZero,
+      },
+    );
+
+    expect(decision.promote).toBe(true);
+    if (decision.promote) {
+      expect(decision.role).toBe("platform_admin");
+      expect(decision.reason).toContain("first-signup fallback");
+    }
+  });
+
+  it("does NOT promote via the opt-in fallback when an admin already exists", async () => {
+    const decision = await computeBootstrapRole(
+      { email: "second-user@demo.test" },
+      {
+        adminEmail: undefined,
+        allowFirstSignupAdmin: true,
+        internalDbAvailable: true,
+        countExistingAdmins: countOne,
+      },
+    );
+
+    expect(decision.promote).toBe(false);
+    expect(decision.reason).toContain("admin already exists");
+  });
+
+  it("does NOT promote via the opt-in fallback when the internal DB is not available", async () => {
+    // Without a DB we can't prove there's no existing admin, so refuse.
+    const decision = await computeBootstrapRole(
+      { email: "first-user@demo.test" },
+      {
+        adminEmail: undefined,
+        allowFirstSignupAdmin: true,
+        internalDbAvailable: false,
+        countExistingAdmins: countZero,
+      },
+    );
+
+    expect(decision.promote).toBe(false);
+  });
+
+  it("ATLAS_ADMIN_EMAIL match takes precedence over the opt-in fallback", async () => {
+    const decision = await computeBootstrapRole(
+      { email: "admin@example.com" },
+      {
+        adminEmail: "admin@example.com",
+        allowFirstSignupAdmin: true,
+        internalDbAvailable: true,
+        countExistingAdmins: countOne, // existing admin — fallback would skip
+      },
+    );
+
+    expect(decision.promote).toBe(true);
+    if (decision.promote) expect(decision.reason).toBe("ATLAS_ADMIN_EMAIL match");
+  });
+});

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -330,6 +330,83 @@ type AuthInstance = ReturnType<typeof betterAuth>;
 let _instance: AuthInstance | null = null;
 
 /**
+ * Decision returned by {@link computeBootstrapRole} describing whether the
+ * signing-up user should be promoted to `platform_admin` during the
+ * Better Auth `user.create.before` hook.
+ */
+export type BootstrapRoleDecision =
+  | { promote: false; reason: string }
+  | { promote: true; role: "platform_admin"; reason: string };
+
+/**
+ * Inputs to {@link computeBootstrapRole}. Split out so tests can drive every
+ * branch without a live database.
+ *
+ * - `adminEmail` — normalized (lowercased + trimmed) value of `ATLAS_ADMIN_EMAIL`
+ *   or `undefined` when unset.
+ * - `allowFirstSignupAdmin` — `true` when `ATLAS_ALLOW_FIRST_SIGNUP_ADMIN=true`.
+ *   Required for the no-admin-exists fallback to fire.
+ * - `internalDbAvailable` — `true` when the internal DB is configured; the
+ *   fallback is a no-op without it (we can't query the user table).
+ * - `countExistingAdmins` — lazy probe that runs only when the fallback is
+ *   otherwise allowed.
+ */
+export interface BootstrapRoleEnv {
+  adminEmail: string | undefined;
+  allowFirstSignupAdmin: boolean;
+  internalDbAvailable: boolean;
+  countExistingAdmins: () => Promise<number>;
+}
+
+/**
+ * Decide whether to promote a signing-up user to `platform_admin`.
+ *
+ * Two paths promote:
+ *   1. The user's email (case-insensitive, trimmed) matches `ATLAS_ADMIN_EMAIL`.
+ *   2. `ATLAS_ADMIN_EMAIL` is unset, `ATLAS_ALLOW_FIRST_SIGNUP_ADMIN=true`, the
+ *      internal DB is available, and no admin user exists yet.
+ *
+ * Path 2 is gated behind the explicit opt-in because before 1.2.3 it could be
+ * weaponized into a one-request platform takeover on any fresh deployment that
+ * hadn't set `ATLAS_ADMIN_EMAIL` yet (see #1728 / F-02).
+ */
+export async function computeBootstrapRole(
+  user: { email: string | null | undefined },
+  env: BootstrapRoleEnv,
+): Promise<BootstrapRoleDecision> {
+  const userEmail = user.email?.toLowerCase().trim();
+
+  if (env.adminEmail && userEmail && userEmail === env.adminEmail) {
+    return {
+      promote: true,
+      role: "platform_admin",
+      reason: "ATLAS_ADMIN_EMAIL match",
+    };
+  }
+
+  if (!env.adminEmail && env.allowFirstSignupAdmin && env.internalDbAvailable) {
+    const existing = await env.countExistingAdmins();
+    if (existing === 0) {
+      return {
+        promote: true,
+        role: "platform_admin",
+        reason: "first-signup fallback (ATLAS_ALLOW_FIRST_SIGNUP_ADMIN=true, no admin exists)",
+      };
+    }
+    return { promote: false, reason: "an admin already exists — fallback skipped" };
+  }
+
+  if (!env.adminEmail) {
+    return {
+      promote: false,
+      reason: "ATLAS_ADMIN_EMAIL is unset and ATLAS_ALLOW_FIRST_SIGNUP_ADMIN is not enabled",
+    };
+  }
+
+  return { promote: false, reason: "email does not match ATLAS_ADMIN_EMAIL" };
+}
+
+/**
  * SSO domain-based auto-provisioning: if the user's email domain matches an
  * enabled SSO provider, auto-add them to that org (respecting the member seat
  * limit, failing open on billing infrastructure errors).
@@ -433,6 +510,24 @@ export function getAuthInstance(): AuthInstance {
   }
 
   const adminEmail = process.env.ATLAS_ADMIN_EMAIL?.toLowerCase().trim();
+
+  // Resolve ATLAS_ALLOW_FIRST_SIGNUP_ADMIN once at boot. Accept the common
+  // truthy spellings (true/1/yes/on, case-insensitive, trimmed) — operators
+  // who type "TRUE" or "1" should not silently get the off path. Warn on
+  // non-empty values we don't recognize so misconfiguration is visible.
+  const rawAllowFlag = process.env.ATLAS_ALLOW_FIRST_SIGNUP_ADMIN?.trim();
+  const allowFirstSignupAdmin =
+    rawAllowFlag !== undefined && ["true", "1", "yes", "on"].includes(rawAllowFlag.toLowerCase());
+  if (rawAllowFlag && !allowFirstSignupAdmin) {
+    log.warn(
+      { value: rawAllowFlag },
+      "ATLAS_ALLOW_FIRST_SIGNUP_ADMIN is set to an unrecognized value — treating as off. Valid: true, 1, yes, on (case-insensitive).",
+    );
+  } else if (allowFirstSignupAdmin) {
+    log.warn(
+      "ATLAS_ALLOW_FIRST_SIGNUP_ADMIN is enabled — the first signup when no admin exists will be promoted to platform_admin. Set ATLAS_ADMIN_EMAIL for production deployments.",
+    );
+  }
 
   // Derive parent domain for cross-subdomain cookies (e.g. "useatlas.dev" from
   // BETTER_AUTH_URL="https://api.useatlas.dev"). Only enabled when CORS origin
@@ -605,25 +700,48 @@ export function getAuthInstance(): AuthInstance {
       user: {
         create: {
           before: async (user) => {
+            const internalDbAvailable = hasInternalDB();
             try {
-              if (adminEmail && user.email?.toLowerCase().trim() === adminEmail) {
-                log.info({ email: user.email }, "Bootstrap: promoting signup to platform_admin (ATLAS_ADMIN_EMAIL match)");
-                return { data: { ...user, role: "platform_admin" } };
-              }
+              const decision = await computeBootstrapRole(user, {
+                adminEmail,
+                allowFirstSignupAdmin,
+                internalDbAvailable,
+                countExistingAdmins: async () => {
+                  const rows = await internalQuery<{ id: string }>(
+                    `SELECT id FROM "user" WHERE role IN ('admin', 'platform_admin') LIMIT 1`,
+                  );
+                  return rows.length;
+                },
+              });
 
-              if (!adminEmail) {
-                if (!hasInternalDB()) return;
-                const rows = await internalQuery<{ id: string }>(
-                  `SELECT id FROM "user" WHERE role IN ('admin', 'platform_admin') LIMIT 1`,
+              if (decision.promote) {
+                // Fallback path uses warn so operators running with the opt-in
+                // flag see a nudge toward the safer ATLAS_ADMIN_EMAIL config.
+                const logFn = decision.reason.startsWith("first-signup fallback") ? log.warn : log.info;
+                logFn.call(
+                  log,
+                  { email: user.email, reason: decision.reason },
+                  "Bootstrap: promoting signup to platform_admin",
                 );
-                if (rows.length === 0) {
-                  log.info({ email: user.email }, "Bootstrap: no admin exists — promoting first signup to platform_admin");
-                  return { data: { ...user, role: "platform_admin" } };
-                }
+                return { data: { ...user, role: decision.role } };
               }
 
             } catch (err) {
-              log.error({ err: err instanceof Error ? err.message : String(err) }, "Bootstrap admin check failed — defaulting to normal role assignment");
+              // Include the full env state in the log so operators who expected
+              // their signup to be promoted (ATLAS_ADMIN_EMAIL match or opt-in
+              // fallback) can see WHY it fell through. Without this context, a
+              // DB outage or schema drift during legitimate bootstrap would
+              // silently lock out the operator with one opaque log line.
+              log.error(
+                {
+                  err: err instanceof Error ? err.message : String(err),
+                  email: user.email,
+                  hasAdminEmail: !!adminEmail,
+                  allowFirstSignupAdmin,
+                  internalDbAvailable,
+                },
+                "Bootstrap admin check failed — defaulting to normal role assignment. Check DB connectivity and env configuration.",
+              );
             }
           },
           after: async (user) => {


### PR DESCRIPTION
Closes #1728 (F-02, P0).

## What was broken

Before this fix, Better Auth's `user.create.before` hook auto-promoted the first signup to `platform_admin` whenever `ATLAS_ADMIN_EMAIL` was unset and no admin user existed yet. Any deployment that became reachable before the operator had signed up could be taken over with a single unauthenticated request:

```
POST /api/auth/sign-up/email
{"email":"attacker@evil.invalid","password":"..."}

HTTP 200
{"token":"...", "user":{"role":"platform_admin","emailVerified":false, ...}}
```

Live-reproduced against a local stack during the 1.2.3 Phase 1.5 empirical validation — see #1728 for the transcript.

## The fix

- Extract the decision into a new exported pure function `computeBootstrapRole()` with an injectable `BootstrapRoleEnv` interface. The Better Auth hook calls it instead of inlining the branches.
- Gate the "no admin exists → promote first signup" fallback behind `ATLAS_ALLOW_FIRST_SIGNUP_ADMIN=true`. Accepts `true`/`1`/`yes`/`on` (case-insensitive, trimmed); unrecognized non-empty values warn at boot so misconfiguration is visible.
- Resolve the flag once at `getAuthInstance()` boot, alongside `adminEmail`, so per-request parsing can't drift.
- Enrich the hook's outer catch with `hasAdminEmail`, `allowFirstSignupAdmin`, `internalDbAvailable`, and `email` so a DB flake during legitimate bootstrap is diagnosable instead of an opaque "defaulting to normal role assignment".
- Document `ATLAS_ALLOW_FIRST_SIGNUP_ADMIN` in `.env.example` with a production warning.

The `ATLAS_ADMIN_EMAIL`-match path is unchanged — production deployments that set that env var continue to work exactly as before.

## Review passes

- **code-reviewer:** "Ship it. No P0 issues found." Confirmed email normalization symmetric, opt-in gate strict, check ordering correct, DB probe fails closed.
- **silent-failure-hunter:** Flagged (1) strict `=== "true"` rejecting common truthy variants and (2) the outer catch message being too opaque. Both folded into this commit.

## Tests

`packages/api/src/lib/auth/__tests__/bootstrap.test.ts` — 10/10 passing:

- ATLAS_ADMIN_EMAIL match (exact / case-insensitive / whitespace-trimmed)
- **F-02 attacker path:** email unset + flag off → `role=member` (the fix)
- **F-02 paranoid:** opt-in flag on + DB unavailable → still denies
- Opt-in fallback happy path → `platform_admin` on first signup
- Opt-in fallback skipped when admin already exists
- Opt-in fallback skipped when internal DB unavailable
- Precedence: ATLAS_ADMIN_EMAIL match wins over fallback

## Live smoke test

Wiped DB, stripped `ATLAS_ADMIN_EMAIL` from `.env`, booted the fix branch:

| Scenario | Expected | Actual |
|---|---|---|
| Flag off, no admin email, attacker signs up | `role=member` | ✅ `role=member` |
| Flag on, first signup (no admin) | `role=platform_admin` | ✅ `role=platform_admin` |
| Flag on, second signup (admin exists) | `role=member` | ✅ `role=member` |

## Test plan
- [x] `bun test src/lib/auth/__tests__/bootstrap.test.ts` — 10/10 pass
- [x] Live repro post-fix confirms attack is blocked
- [x] Opt-in fallback still works for legitimate CI/demo bootstraps
- [x] Dev workflow unaffected (ATLAS_ADMIN_EMAIL path unchanged)
- [ ] CI type + lint pass (open to run here if needed)