### PR TITLE
fix(security): P1 — block cross-tenant org-scoped share reads (#1727)

### DIFF
--- a/.claude/research/security-audit-1-2-3.md
+++ b/.claude/research/security-audit-1-2-3.md
@@ -161,7 +161,7 @@ undefined` and the callback saves an installation bound to no org.
 
 | ID | P | Summary | GH issue | Status |
 |---|---|---|---|---|
-| F-01 | P1 | `publicConversations` org-scoped share missing org-membership check (cross-tenant leak) | #1727 | open |
+| F-01 | P1 | `publicConversations` org-scoped share missing org-membership check (cross-tenant leak) | #1727 | fixed (PR [[TBD]]) |
 | F-02 | P1 | First-signup bootstrap platform_admin race (email unverified, auto-signin) | #1728 | open |
 | F-03 | P2 | Onboarding-email `/unsubscribe` + `/resubscribe` accept arbitrary `userId` without signature | #1729 | open |
 | F-04 | P2 | Slack/Teams/Discord `/install` + `/callback` are unauthenticated — org binding + admin role not enforced | #1730 | open |
@@ -185,7 +185,7 @@ P3: 4 (F-08..F-11) — held here for the cleanup tail.
 **Status:** complete (2026-04-20)
 **Scope:** Live repro of P1 + select P2 findings against a locally-running Atlas stack (`bun run db:up` + API on :3001). The static audit scored each finding based on code reading alone; this phase attacks the actual endpoints to confirm severity.
 
-### F-01 — cross-tenant conversation leak ✅ confirmed
+### F-01 — cross-tenant conversation leak ✅ confirmed → 🔒 FIXED
 
 Repro (after inserting a conversation into Org A with `share_mode='org'`):
 
@@ -206,6 +206,19 @@ HTTP 200
 ```
 
 User B was **not** a member of Org A, had `orgs=0` in the member table, and still received the full conversation body including the sensitive message content. Severity stays **P1**. Dashboard equivalent was not tested but already has the org-membership check in code.
+
+**Fix:** `publicConversations.openapi(getSharedConversationRoute, ...)` now performs a fail-closed org-membership check after the auth check — `if (!result.data.orgId || authResult.user?.activeOrganizationId !== result.data.orgId) → 403 forbidden`. The lib layer `getSharedConversation` was extended to return `orgId` (SELECT `org_id`) so the route can enforce membership. Fail-closed rather than truthy-check because the schema allows `share_mode='org'` with `org_id IS NULL` and `createShareLink` never stamps `org_id` — see follow-ups #1736 (dashboards has the same truthy-check bug) and #1737 (add `share_mode='org' → org_id IS NOT NULL` CHECK constraint).
+
+Post-fix smoke test on live stack (`/api/public/conversations/<org-scoped-token>`):
+
+| Case | Status |
+|---|---|
+| Unauthenticated | HTTP 403 `auth_required` |
+| User B, no active org | HTTP 403 `forbidden` |
+| User B, active org = `org-B-smoke` (different org) | HTTP 403 `forbidden` |
+| User B, active org = `org-A-smoke` (conversation's org) | HTTP 200 (positive control) |
+
+Regression tests at `packages/api/src/api/__tests__/conversations.test.ts` pin all four cases plus the `orgId=null` fail-closed branch.
 
 ### F-02 — bootstrap platform_admin race ⬆ upgraded to **P0**
 

--- a/packages/api/src/api/__tests__/conversations.test.ts
+++ b/packages/api/src/api/__tests__/conversations.test.ts
@@ -930,6 +930,7 @@ describe("conversations routes", () => {
           connectionId: null,
           starred: false,
           shareMode: "public" as const,
+          orgId: null,
           createdAt: "2024-01-01",
           updatedAt: "2024-01-01",
           messages: [
@@ -970,6 +971,7 @@ describe("conversations routes", () => {
           connectionId: null,
           starred: false,
           shareMode: "public" as const,
+          orgId: null,
           createdAt: "2024-01-01",
           updatedAt: "2024-01-01",
           messages: [],
@@ -1026,6 +1028,7 @@ describe("conversations routes", () => {
           connectionId: null,
           starred: false,
           shareMode: "org" as const,
+          orgId: "org-A",
           createdAt: "2024-01-01",
           updatedAt: "2024-01-01",
           messages: [],
@@ -1047,7 +1050,7 @@ describe("conversations routes", () => {
       expect(body.error).toBe("auth_required");
     });
 
-    it("returns 200 for org-scoped shares when authenticated", async () => {
+    it("returns 200 for org-scoped shares when requester belongs to the conversation's org", async () => {
       mockGetSharedConversation.mockResolvedValueOnce({
         ok: true,
         data: {
@@ -1058,6 +1061,7 @@ describe("conversations routes", () => {
           connectionId: null,
           starred: false,
           shareMode: "org" as const,
+          orgId: "org-A",
           createdAt: "2024-01-01",
           updatedAt: "2024-01-01",
           messages: [],
@@ -1066,7 +1070,12 @@ describe("conversations routes", () => {
       mockAuthenticateRequest.mockResolvedValueOnce({
         authenticated: true as const,
         mode: "simple-key" as const,
-        user: { id: "u2", label: "org-user@test.com", mode: "simple-key" as const },
+        user: {
+          id: "u2",
+          label: "org-a-member@test.com",
+          mode: "simple-key" as const,
+          activeOrganizationId: "org-A",
+        },
       });
 
       const response = await app.fetch(
@@ -1077,6 +1086,130 @@ describe("conversations routes", () => {
       const body = await response.json() as Record<string, unknown>;
       expect(body.title).toBe("Org share");
       expect(body.shareMode).toBe("org");
+    });
+
+    // Regression for #1727 (F-01): before the fix, any authenticated caller
+    // could read an org-scoped share regardless of which org they belonged to.
+    it("returns 403 for org-scoped shares when requester belongs to a different org (#1727)", async () => {
+      mockGetSharedConversation.mockResolvedValueOnce({
+        ok: true,
+        data: {
+          id: VALID_ID,
+          userId: "u1",
+          title: "Org A secret",
+          surface: "web",
+          connectionId: null,
+          starred: false,
+          shareMode: "org" as const,
+          orgId: "org-A",
+          createdAt: "2024-01-01",
+          updatedAt: "2024-01-01",
+          messages: [
+            { id: "m1", conversationId: VALID_ID, role: "user", content: "confidential", createdAt: "2024-01-01" },
+          ],
+        },
+      });
+      mockAuthenticateRequest.mockResolvedValueOnce({
+        authenticated: true as const,
+        mode: "simple-key" as const,
+        user: {
+          id: "u-other",
+          label: "other-org-user@test.com",
+          mode: "simple-key" as const,
+          activeOrganizationId: "org-B",
+        },
+      });
+
+      const response = await app.fetch(
+        new Request("http://localhost/api/public/conversations/abcdefghij1234567890x"),
+      );
+      expect(response.status).toBe(403);
+
+      const body = await response.json() as Record<string, unknown>;
+      expect(body.error).toBe("forbidden");
+      // Confirm content did not leak into the response
+      expect(body).not.toHaveProperty("messages");
+      expect(body).not.toHaveProperty("title");
+    });
+
+    // Fail-closed regression for #1727 — the schema allows share_mode='org'
+    // with org_id=NULL (createShareLink does not stamp orgId). Without a
+    // fail-closed check, any authenticated caller could read such a row.
+    it("returns 403 for org-scoped shares when the conversation has no orgId (#1727)", async () => {
+      mockGetSharedConversation.mockResolvedValueOnce({
+        ok: true,
+        data: {
+          id: VALID_ID,
+          userId: "u1",
+          title: "Legacy org share",
+          surface: "web",
+          connectionId: null,
+          starred: false,
+          shareMode: "org" as const,
+          orgId: null,
+          createdAt: "2024-01-01",
+          updatedAt: "2024-01-01",
+          messages: [
+            { id: "m1", conversationId: VALID_ID, role: "user", content: "confidential", createdAt: "2024-01-01" },
+          ],
+        },
+      });
+      mockAuthenticateRequest.mockResolvedValueOnce({
+        authenticated: true as const,
+        mode: "simple-key" as const,
+        user: {
+          id: "u-any",
+          label: "any-user@test.com",
+          mode: "simple-key" as const,
+          activeOrganizationId: "org-A",
+        },
+      });
+
+      const response = await app.fetch(
+        new Request("http://localhost/api/public/conversations/abcdefghij1234567890x"),
+      );
+      expect(response.status).toBe(403);
+
+      const body = await response.json() as Record<string, unknown>;
+      expect(body.error).toBe("forbidden");
+      expect(body).not.toHaveProperty("messages");
+    });
+
+    it("returns 403 for org-scoped shares when requester has no active org (#1727)", async () => {
+      mockGetSharedConversation.mockResolvedValueOnce({
+        ok: true,
+        data: {
+          id: VALID_ID,
+          userId: "u1",
+          title: "Org A secret",
+          surface: "web",
+          connectionId: null,
+          starred: false,
+          shareMode: "org" as const,
+          orgId: "org-A",
+          createdAt: "2024-01-01",
+          updatedAt: "2024-01-01",
+          messages: [],
+        },
+      });
+      mockAuthenticateRequest.mockResolvedValueOnce({
+        authenticated: true as const,
+        mode: "simple-key" as const,
+        user: {
+          id: "u-orphan",
+          label: "no-org@test.com",
+          mode: "simple-key" as const,
+          // No activeOrganizationId — freshly signed-up user with zero memberships
+        },
+      });
+
+      const response = await app.fetch(
+        new Request("http://localhost/api/public/conversations/abcdefghij1234567890x"),
+      );
+      expect(response.status).toBe(403);
+
+      const body = await response.json() as Record<string, unknown>;
+      expect(body.error).toBe("forbidden");
     });
 
     it("returns 500 for org-scoped shares when authenticateRequest throws", async () => {
@@ -1090,6 +1223,7 @@ describe("conversations routes", () => {
           connectionId: null,
           starred: false,
           shareMode: "org" as const,
+          orgId: "org-A",
           createdAt: "2024-01-01",
           updatedAt: "2024-01-01",
           messages: [],
@@ -1151,6 +1285,7 @@ describe("conversations routes", () => {
           connectionId: null,
           starred: false,
           shareMode: "public" as const,
+          orgId: null,
           createdAt: "2024-01-01",
           updatedAt: "2024-01-01",
           messages: [

--- a/packages/api/src/api/routes/conversations.ts
+++ b/packages/api/src/api/routes/conversations.ts
@@ -1341,7 +1341,9 @@ publicConversations.openapi(getSharedConversationRoute, async (c) => {
     return c.json(fail.body, fail.status);
   }
 
-  // Org-scoped shares require the requester to be authenticated
+  // Org-scoped shares require the requester to be authenticated AND a member
+  // of the conversation's owning workspace. Without this membership check an
+  // authenticated caller from any other org could read the share — see #1727.
   if (result.data.shareMode === "org") {
     let authResult: AuthResult;
     try {
@@ -1355,6 +1357,17 @@ publicConversations.openapi(getSharedConversationRoute, async (c) => {
     }
     if (!authResult.authenticated) {
       return c.json({ error: "auth_required", message: "This shared conversation requires authentication.", requestId }, 403);
+    }
+    // Verify authenticated user belongs to the conversation's org. Fail closed
+    // when the conversation row has no orgId: the schema allows NULL org_id with
+    // share_mode='org' (createShareLink does not stamp orgId), so a truthy-check
+    // here would silently fall through and reintroduce the #1727 leak.
+    if (!result.data.orgId || authResult.user?.activeOrganizationId !== result.data.orgId) {
+      log.warn(
+        { requestId, token, hasOrgId: Boolean(result.data.orgId) },
+        "Org-scoped share access denied — requester is not a member of the conversation's org",
+      );
+      return c.json({ error: "forbidden", message: "You do not have access to this conversation.", requestId }, 403);
     }
   }
 

--- a/packages/api/src/lib/__tests__/conversations.test.ts
+++ b/packages/api/src/lib/__tests__/conversations.test.ts
@@ -916,13 +916,14 @@ describe("conversations module", () => {
       }
     });
 
-    it("returns org shareMode when set", async () => {
+    it("returns org shareMode and orgId when set", async () => {
       enableInternalDB();
       setResults(
         {
           rows: [{
             id: "c1",
             user_id: "u1",
+            org_id: "org-A",
             title: "Org conv",
             surface: "web",
             connection_id: null,
@@ -940,6 +941,36 @@ describe("conversations module", () => {
       expect(result.ok).toBe(true);
       if (result.ok) {
         expect(result.data.shareMode).toBe("org");
+        // orgId is required for the route layer's membership check (#1727)
+        expect(result.data.orgId).toBe("org-A");
+      }
+    });
+
+    it("returns orgId=null when org_id column is null (public / legacy conversations)", async () => {
+      enableInternalDB();
+      setResults(
+        {
+          rows: [{
+            id: "c1",
+            user_id: "u1",
+            org_id: null,
+            title: "Public conv",
+            surface: "web",
+            connection_id: null,
+            starred: false,
+            share_expires_at: null,
+            share_mode: "public",
+            created_at: "2024-01-01T00:00:00Z",
+            updated_at: "2024-01-01T00:00:00Z",
+          }],
+        },
+        { rows: [] },
+      );
+
+      const result = await getSharedConversation("public-token");
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data.orgId).toBeNull();
       }
     });
 

--- a/packages/api/src/lib/conversations.ts
+++ b/packages/api/src/lib/conversations.ts
@@ -785,15 +785,22 @@ export async function cleanupExpiredShares(): Promise<number> {
 /** Failure reason for shared conversation access (extends CrudFailReason). */
 export type SharedConversationFailReason = CrudFailReason | "expired";
 
-/** Result type for shared conversation access. */
+/**
+ * Result type for shared conversation access.
+ *
+ * `orgId` is the owning workspace for org-scoped shares. The route layer
+ * must verify the caller belongs to this org before returning content; it
+ * is NOT part of the public wire type and must be stripped from responses.
+ */
 export type SharedConversationResult =
-  | { ok: true; data: ConversationWithMessages & { shareMode: ShareMode } }
+  | { ok: true; data: ConversationWithMessages & { shareMode: ShareMode; orgId: string | null } }
   | { ok: false; reason: SharedConversationFailReason };
 
 /**
  * Fetch a shared conversation by token. Returns `expired` if the share link
  * has passed its expiry time (distinct from `not_found` for missing tokens).
- * Returns `shareMode` so the route layer can enforce org-scoped access.
+ * Returns `shareMode` and `orgId` so the route layer can enforce org-scoped
+ * access against the caller's active organization.
  */
 export async function getSharedConversation(
   token: string,
@@ -801,7 +808,7 @@ export async function getSharedConversation(
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
   try {
     const convRows = await internalQuery<Record<string, unknown>>(
-      `SELECT id, user_id, title, surface, connection_id, starred, share_expires_at, share_mode, notebook_state, created_at, updated_at
+      `SELECT id, user_id, org_id, title, surface, connection_id, starred, share_expires_at, share_mode, notebook_state, created_at, updated_at
        FROM conversations
        WHERE share_token = $1`,
       [token],
@@ -815,6 +822,7 @@ export async function getSharedConversation(
     }
 
     const shareMode = (convRows[0].share_mode as ShareMode) ?? "public";
+    const orgId = (convRows[0].org_id as string | null) ?? null;
     const convId = convRows[0].id as string;
     const msgRows = await internalQuery<Record<string, unknown>>(
       `SELECT id, conversation_id, role, content, created_at
@@ -827,6 +835,7 @@ export async function getSharedConversation(
       data: {
         ...rowToConversation(convRows[0]),
         shareMode,
+        orgId,
         messages: msgRows.map((m) => ({
           id: m.id as string,
           conversationId: m.conversation_id as string,


### PR DESCRIPTION
## What broke
The public shared-conversation route (`GET /api/public/conversations/:token`) accepted `share_mode='org'` but only verified the caller was authenticated — it did NOT check that the caller belonged to the conversation's owning workspace. Any authenticated user with a share token could read an org-scoped conversation from an org they didn't belong to.

F-01 in the [1.2.3 security sweep](https://github.com/AtlasDevHQ/atlas/issues/1718), live-reproduced in Phase 1.5. Closes #1727.

## Fix shape
Mirror the existing `dashboards.ts:1171` membership check, but **fail-closed** instead of truthy-checking `orgId` — the schema allows `share_mode='org'` with `org_id IS NULL` (createShareLink never stamps `org_id`), so a truthy short-circuit would leave the same class of hole for legacy rows.

```diff
 if (!authResult.authenticated) {
   return c.json({ error: "auth_required", ... }, 403);
 }
+// Verify authenticated user belongs to the conversation's org
+if (!result.data.orgId || authResult.user?.activeOrganizationId !== result.data.orgId) {
+  log.warn({ requestId, token, hasOrgId: Boolean(result.data.orgId) }, "Org-scoped share access denied");
+  return c.json({ error: "forbidden", ... }, 403);
+}
```

The lib layer `getSharedConversation` was extended to return `orgId` (SELECT `org_id`); the existing explicit-field destructure in the route already strips it from the public response, so there's no wire leak.

## Live smoke test
Fresh stack (`bun run db:up` + `bun run dev:api`), org-scoped seed conversation inserted with `share_token='abcdefghij1234567890x'`, `org_id='org-A-smoke'`:

```
== Case 1: UNAUTHENTICATED
$ curl /api/public/conversations/abcdefghij1234567890x
HTTP 403 {"error":"auth_required","message":"This shared conversation requires authentication.",...}

== Case 2: User B authenticated, NO active org
$ curl -b 'better-auth.session_token=...' ...
HTTP 403 {"error":"forbidden","message":"You do not have access to this conversation.",...}

== Case 3: User B authenticated, activeOrganizationId='org-B-smoke' (different org)
$ curl -b 'better-auth.session_token=...' ...
HTTP 403 {"error":"forbidden","message":"You do not have access to this conversation.",...}

== Positive control: User B's activeOrganizationId flipped to 'org-A-smoke' (matches conversation)
$ curl -b 'better-auth.session_token=...' ...
HTTP 200 {"title":"Seed org-A secret conversation","shareMode":"org","messages":[...]}
```

Before the fix, Case 2 and Case 3 would return HTTP 200 with the confidential body.

## Regression tests
`packages/api/src/api/__tests__/conversations.test.ts` pins all four cases plus one extra fail-closed branch:
- member of the conversation's org → 200
- cross-org → 403 `forbidden`
- no active org → 403 `forbidden`
- conversation `orgId=null` with `shareMode='org'` → 403 `forbidden` (fail-closed)
- unauthenticated → 403 `auth_required`

Lib test asserts `orgId` correctly propagates through `SharedConversationResult.data`.

## Review agent summary
Both `code-reviewer` and `silent-failure-hunter` flagged the truthy-check on `orgId &&` as a silent fail-open — the schema lets `share_mode='org'` + `org_id=NULL` coexist, and `createShareLink` doesn't stamp `org_id`. Fix folded into this commit. Follow-ups filed:
- **#1736** — `dashboards.ts:1171` has the same truthy-check bug (same class of leak for dashboard shares)
- **#1737** — add `CHECK (share_mode <> 'org' OR org_id IS NOT NULL)` on `conversations` and `dashboards` + backfill / defensive write path

## Verification
- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] Route tests (`conversations.test.ts`): 76 pass, 0 fail (3 new)
- [x] Lib tests (`conversations.test.ts`): 96 pass, 0 fail (1 new)
- [x] Full API test suite: 246 files pass
- [x] Live smoke test on local stack (four cases above)

## Test plan for reviewer
- [ ] Re-read `packages/api/src/api/routes/conversations.ts:1344-1373` — confirm fail-closed shape
- [ ] Re-read `packages/api/src/lib/conversations.ts:785-848` — confirm `orgId` returned, not leaked
- [ ] Confirm the four regression cases in `packages/api/src/api/__tests__/conversations.test.ts` cover the original attack path + the fail-closed branch
- [ ] Spot-check that the follow-up issues (#1736, #1737) are sufficient — neither should be bundled into this PR