### PR TITLE
fix(security): P1 — rate-limit Better Auth + close signup enumeration oracle (#1732)

### DIFF
--- a/.claude/research/security-audit-1-2-3.md
+++ b/.claude/research/security-audit-1-2-3.md
@@ -165,8 +165,8 @@ undefined` and the callback saves an installation bound to no org.
 | F-02 | P1 | First-signup bootstrap platform_admin race (email unverified, auto-signin) | #1728 | open |
 | F-03 | P2 | Onboarding-email `/unsubscribe` + `/resubscribe` accept arbitrary `userId` without signature | #1729 | open |
 | F-04 | P2 | Slack/Teams/Discord `/install` + `/callback` are unauthenticated — org binding + admin role not enforced | #1730 | open |
-| F-05 | P2 | `emailAndPassword.requireEmailVerification: false` — compounds F-02 and allows unverified signups to trigger workflows | #1731 | open |
-| F-06 | P2 | Better Auth signin/signup rate limiting not explicitly configured — verify built-in defaults vs. Atlas threat model | #1732 | open |
+| F-05 | P2 | `emailAndPassword.requireEmailVerification: false` — compounds F-02 and allows unverified signups to trigger workflows | #1731 | fixed (bundled into PR for #1732) |
+| F-06 | P1 | Better Auth signin/signup rate limiting not explicitly configured; signup enumeration oracle | #1732 | fixed |
 | F-07 | P2 | `session.cookieCache.maxAge = 5 min` delays session revocation (ban / revokeSessions) | #1733 | open |
 | F-08 | P3 | `ATLAS_API_KEY_ROLE` defaults to `admin` — surprising default for simple-key deployments | — | p3-pending |
 | F-09 | P3 | BYOT `ATLAS_AUTH_AUDIENCE=""` silently disables audience check (should reject empty string) | — | p3-pending |
@@ -282,6 +282,20 @@ HTTP 422 {"message":"User already exists. Use another email.",
 ```
 
 No throttling whatsoever at any point during 100 sequential authentication failures from the same source. The 429 bucket remained empty. A `code: USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL` response gives a reliable email-enumeration oracle. This is a live, exploitable gap — not "defense-in-depth". Upgrades from P2 → **P1**.
+
+**Fix:** Explicit `rateLimit` configuration on `betterAuth()` with per-endpoint `customRules` (signin ≤10/min, signup/forget-password/reset-password/send-verification-email ≤5/min, verify-email ≤10/min), DB-backed shared store when the internal DB is available. F-05 (`requireEmailVerification: false`) was bundled into the fix — flipping it to `true` with `autoSignIn: false` activates Better Auth's OWASP-aligned enumeration protection (same 200 response for new and existing emails). Verification emails are delivered via the existing `@atlas/api/lib/email/delivery` chain. A middleware in `packages/api/src/api/routes/auth.ts` injects a trusted `x-atlas-client-ip` header (stripping any inbound value to block spoofing) so Better Auth's rate limiter can resolve the client IP in dev / non-proxied deployments.
+
+Post-fix smoke test on live stack:
+
+| Case | Before fix | After fix |
+|---|---|---|
+| 100 sequential `/api/auth/sign-in/email` | 100×401, 0×429 | 10×401, 90×429 |
+| Signup with existing email | HTTP 422 `USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL` | HTTP 200 (same shape as new-email signup) |
+| 6th `/api/auth/sign-up/email` from same IP | HTTP 200 | HTTP 429 |
+| 6th `/api/auth/forget-password` from same IP | HTTP 200/404 | HTTP 429 |
+| New-email signup returns session token | `token: "..."` (auto-signin) | `token: null` (verification required) |
+
+Regression tests at `packages/api/src/lib/auth/__tests__/rate-limit.test.ts` pin `resolveAuthRateLimitConfig`, `resolveRequireEmailVerification`, and the `_sendVerificationEmail` failure path (which must never throw — throwing would reintroduce the enumeration oracle through a 500-vs-200 side channel).
 
 ### Severity summary after Phase 1.5
 

--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,17 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # ATLAS_API_KEY_ROLE=analyst              # Role for simple-key auth (viewer/analyst/admin)
 # ATLAS_RATE_LIMIT_RPM=30                 # Max requests per minute per user (0 = disabled)
 # ATLAS_TRUST_PROXY=false                 # Trust X-Forwarded-For for client IP (set "true" behind a reverse proxy)
+#
+# === Better Auth hardening (managed auth only) ===
+# ATLAS_REQUIRE_EMAIL_VERIFICATION=true   # Require email verification on signup. Default: true.
+#                                         # Setting "false" re-enables the signup USER_ALREADY_EXISTS error
+#                                         # (email enumeration oracle) — only acceptable for self-hosted
+#                                         # single-tenant deployments without an email provider.
+# ATLAS_AUTH_RATE_LIMIT_ENABLED=true      # Rate limit /api/auth/* endpoints. Default: true.
+# ATLAS_AUTH_RATE_LIMIT_WINDOW=60         # Global rate-limit window (seconds). Default: 60.
+# ATLAS_AUTH_RATE_LIMIT_MAX=100           # Global rate-limit ceiling. Per-endpoint rules are tighter
+#                                         # (signin ≤10/min, signup/forget ≤5/min) — those are not
+#                                         # overridable via env by design.
 # ATLAS_ABUSE_QUERY_RATE=200              # Max queries per workspace per sliding window (abuse prevention)
 # ATLAS_ABUSE_WINDOW_SECONDS=300          # Sliding window duration in seconds
 # ATLAS_ABUSE_ERROR_RATE=0.5              # Max error rate (0-1) before escalation

--- a/packages/api/src/api/__tests__/auth-client-ip.test.ts
+++ b/packages/api/src/api/__tests__/auth-client-ip.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { withClientIpHeader, shouldTrustProxyHeaders, stripPortSuffix } from "../routes/auth";
+
+/**
+ * Regression tests for the F-06 IP-injection middleware.
+ *
+ * `withClientIpHeader` is the trust boundary for Better Auth's rate
+ * limiter: if it resolves the wrong IP, or lets an attacker spoof it,
+ * or silently skips writing the header, the rate limits stop working.
+ * These tests pin the behaviors the security audit called out.
+ */
+
+const ORIGINAL_ENV = { ...process.env };
+
+// `withClientIpHeader` takes a Hono `Context`. For unit testing we only
+// need the shape the function actually touches — `c.req.raw` and, when
+// falling back to socket resolution, the underlying Bun `server` that
+// Hono's `getConnInfo` reads via `c.env`. A plain object with those two
+// fields is enough and keeps the tests off the real Hono app.
+interface FakeCtx {
+  req: { raw: Request };
+  env: unknown;
+}
+
+function makeCtx(init: { headers?: Record<string, string>; serverIp?: string }): FakeCtx {
+  const req = new Request("http://localhost/auth/sign-in/email", {
+    method: "POST",
+    headers: init.headers,
+  });
+  // Hono's getConnInfo calls server.requestIP(req). A minimal stub
+  // returns { address } when we want to simulate a Bun socket, or
+  // throws to simulate the "no server" case (Next.js standalone).
+  const env = init.serverIp === undefined
+    ? { requestIP: () => { throw new Error("no Bun server in env"); } }
+    : { requestIP: () => ({ address: init.serverIp!, family: "IPv4", port: 54321 }) };
+  return { req: { raw: req }, env };
+}
+
+beforeEach(() => {
+  // Reset the env variables the middleware reads so tests don't leak
+  // into each other.
+  delete process.env.ATLAS_TRUST_PROXY;
+  delete process.env.VERCEL;
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe("shouldTrustProxyHeaders", () => {
+  it("defaults to false", () => {
+    expect(shouldTrustProxyHeaders({} as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  it("trusts when ATLAS_TRUST_PROXY is 'true' or '1'", () => {
+    expect(shouldTrustProxyHeaders({ ATLAS_TRUST_PROXY: "true" } as NodeJS.ProcessEnv)).toBe(true);
+    expect(shouldTrustProxyHeaders({ ATLAS_TRUST_PROXY: "1" } as NodeJS.ProcessEnv)).toBe(true);
+  });
+
+  it("ignores other truthy spellings to avoid accidental trust", () => {
+    // Deliberately stricter than resolveRequireEmailVerification —
+    // accidentally trusting a proxy that isn't actually in front of
+    // you makes X-Forwarded-For client-spoofable.
+    expect(shouldTrustProxyHeaders({ ATLAS_TRUST_PROXY: "yes" } as NodeJS.ProcessEnv)).toBe(false);
+    expect(shouldTrustProxyHeaders({ ATLAS_TRUST_PROXY: "TRUE" } as NodeJS.ProcessEnv)).toBe(false);
+    expect(shouldTrustProxyHeaders({ ATLAS_TRUST_PROXY: "on" } as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  it("auto-enables trust on Vercel (VERCEL=1)", () => {
+    // Vercel's edge always sets X-Forwarded-For and never exposes a
+    // Bun socket; without auto-trust, rate limiting would silently
+    // no-op for every Vercel deploy.
+    expect(shouldTrustProxyHeaders({ VERCEL: "1" } as NodeJS.ProcessEnv)).toBe(true);
+  });
+});
+
+describe("stripPortSuffix", () => {
+  it("strips a trailing port from an IPv4 address", () => {
+    expect(stripPortSuffix("1.2.3.4:54321")).toBe("1.2.3.4");
+  });
+
+  it("strips the bracketed port form from IPv6", () => {
+    expect(stripPortSuffix("[2001:db8::1]:54321")).toBe("2001:db8::1");
+    expect(stripPortSuffix("[::1]:54321")).toBe("::1");
+  });
+
+  it("leaves bare IPv6 untouched (no trailing port)", () => {
+    // These must pass through unmangled — rate-limit buckets key on
+    // the exact string, and rewriting `::1` to `::` would clobber it.
+    expect(stripPortSuffix("::1")).toBe("::1");
+    expect(stripPortSuffix("2001:db8::1")).toBe("2001:db8::1");
+  });
+
+  it("leaves bare IPv4 untouched", () => {
+    expect(stripPortSuffix("1.2.3.4")).toBe("1.2.3.4");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(stripPortSuffix("  1.2.3.4  ")).toBe("1.2.3.4");
+  });
+});
+
+describe("withClientIpHeader", () => {
+  it("strips any inbound x-atlas-client-ip header (spoof prevention)", () => {
+    // An attacker cannot pick their own rate-limit bucket.
+    const ctx = makeCtx({
+      headers: { "x-atlas-client-ip": "99.99.99.99" },
+      serverIp: "203.0.113.5",
+    });
+    const out = withClientIpHeader(ctx as never);
+    expect(out.headers.get("x-atlas-client-ip")).toBe("203.0.113.5");
+    expect(out.headers.get("x-atlas-client-ip")).not.toBe("99.99.99.99");
+  });
+
+  it("leaves x-atlas-client-ip unset when no IP source resolves", () => {
+    // Better Auth will log a warn and skip rate limiting for this
+    // request — preferable to writing "unknown" which would make one
+    // attacker exhaust every other caller's bucket.
+    const ctx = makeCtx({ serverIp: undefined });
+    const out = withClientIpHeader(ctx as never);
+    expect(out.headers.get("x-atlas-client-ip")).toBeNull();
+  });
+
+  it("does NOT consult X-Forwarded-For when ATLAS_TRUST_PROXY is unset", () => {
+    // Without an explicit trust signal, any client can set
+    // X-Forwarded-For to spoof their IP. The middleware must ignore
+    // the header and fall back to the socket address.
+    const ctx = makeCtx({
+      headers: { "x-forwarded-for": "1.2.3.4" },
+      serverIp: "203.0.113.5",
+    });
+    const out = withClientIpHeader(ctx as never);
+    expect(out.headers.get("x-atlas-client-ip")).toBe("203.0.113.5");
+  });
+
+  it("uses X-Forwarded-For when ATLAS_TRUST_PROXY=true", () => {
+    process.env.ATLAS_TRUST_PROXY = "true";
+    const ctx = makeCtx({
+      headers: { "x-forwarded-for": "1.2.3.4" },
+      serverIp: "203.0.113.5",
+    });
+    const out = withClientIpHeader(ctx as never);
+    expect(out.headers.get("x-atlas-client-ip")).toBe("1.2.3.4");
+  });
+
+  it("picks the first (client-most) entry of a multi-hop X-Forwarded-For", () => {
+    // XFF chain: "<client>, <proxy1>, <proxy2>". Picking the last
+    // entry would rate-limit by proxy IP, pooling every user behind
+    // the same CDN into one bucket.
+    process.env.ATLAS_TRUST_PROXY = "true";
+    const ctx = makeCtx({
+      headers: { "x-forwarded-for": "203.0.113.5, 10.0.0.1, 10.0.0.2" },
+      serverIp: "127.0.0.1",
+    });
+    const out = withClientIpHeader(ctx as never);
+    expect(out.headers.get("x-atlas-client-ip")).toBe("203.0.113.5");
+  });
+
+  it("falls back to X-Real-IP when XFF is absent and proxy is trusted", () => {
+    process.env.ATLAS_TRUST_PROXY = "true";
+    const ctx = makeCtx({
+      headers: { "x-real-ip": "203.0.113.5" },
+      serverIp: "127.0.0.1",
+    });
+    const out = withClientIpHeader(ctx as never);
+    expect(out.headers.get("x-atlas-client-ip")).toBe("203.0.113.5");
+  });
+
+  it("passes IPv6 addresses through unmangled", () => {
+    const ctx = makeCtx({ serverIp: "2001:db8::1" });
+    const out = withClientIpHeader(ctx as never);
+    expect(out.headers.get("x-atlas-client-ip")).toBe("2001:db8::1");
+  });
+
+  it("strips port suffixes from resolved IPs (per-bucket integrity)", () => {
+    // Bun's server.requestIP sometimes returns "address:port" style
+    // for forwarded sockets; leaving the port in would create one
+    // bucket per ephemeral source port, silently defeating the limit.
+    const ctx = makeCtx({ serverIp: "1.2.3.4:54321" });
+    const out = withClientIpHeader(ctx as never);
+    expect(out.headers.get("x-atlas-client-ip")).toBe("1.2.3.4");
+  });
+
+  it("strips port suffixes from X-Forwarded-For entries", () => {
+    process.env.ATLAS_TRUST_PROXY = "true";
+    const ctx = makeCtx({
+      headers: { "x-forwarded-for": "203.0.113.5:443" },
+    });
+    const out = withClientIpHeader(ctx as never);
+    expect(out.headers.get("x-atlas-client-ip")).toBe("203.0.113.5");
+  });
+
+  it("does not crash when getConnInfo throws (Next.js standalone / test harness)", () => {
+    // On Vercel, `app.fetch(req)` is called without the Bun server,
+    // so getConnInfo has nothing to read. The middleware must not
+    // 500 the request — it falls back to leaving the header unset.
+    const ctx = makeCtx({ serverIp: undefined });
+    expect(() => withClientIpHeader(ctx as never)).not.toThrow();
+  });
+});

--- a/packages/api/src/api/__tests__/auth-client-ip.test.ts
+++ b/packages/api/src/api/__tests__/auth-client-ip.test.ts
@@ -91,6 +91,23 @@ describe("stripPortSuffix", () => {
     expect(stripPortSuffix("2001:db8::1")).toBe("2001:db8::1");
   });
 
+  it("leaves IPv6 with zone identifier untouched", () => {
+    // Link-local IPv6 (fe80::1%eth0) has multiple colons so the IPv4
+    // port-strip heuristic doesn't fire. A future refactor that
+    // simplifies to split-on-first-colon would silently mangle this.
+    expect(stripPortSuffix("fe80::1%eth0")).toBe("fe80::1%eth0");
+  });
+
+  it("leaves non-numeric trailing segments untouched", () => {
+    // Docstring promises "port suffix" not "anything after a colon".
+    // A misconfigured proxy forwarding `host:something` or a malformed
+    // `1.2.3.4:abc` must pass through — silently lopping off `:abc`
+    // would hide a misconfiguration AND put the request in a bucket
+    // the operator didn't expect.
+    expect(stripPortSuffix("host:something")).toBe("host:something");
+    expect(stripPortSuffix("1.2.3.4:abc")).toBe("1.2.3.4:abc");
+  });
+
   it("leaves bare IPv4 untouched", () => {
     expect(stripPortSuffix("1.2.3.4")).toBe("1.2.3.4");
   });

--- a/packages/api/src/api/routes/auth.ts
+++ b/packages/api/src/api/routes/auth.ts
@@ -7,7 +7,6 @@
  */
 
 import { Hono, type Context } from "hono";
-import { getConnInfo } from "hono/bun";
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
 import { createLogger } from "@atlas/api/lib/logger";
 
@@ -20,10 +19,10 @@ const log = createLogger("auth-route");
  * X-Forwarded-For when ATLAS_TRUST_PROXY=true). Any inbound value on the
  * header is stripped first so end users can't spoof the IP bucket.
  *
- * Paired with `advanced.ipAddress.ipAddressHeaders: ["x-atlas-client-ip"]`
- * in `getAuthInstance()` — Better Auth will skip rate limiting (log warn)
- * whenever this header is missing, which protects us if the middleware
- * chain is ever bypassed.
+ * The other half of the pairing lives in `buildAdvancedConfig` in
+ * `packages/api/src/lib/auth/server.ts`, which tells Better Auth to
+ * read ONLY this header for client IPs — without that pin, Better
+ * Auth would also accept X-Forwarded-For directly and reopen F-06.
  */
 const CLIENT_IP_HEADER = "x-atlas-client-ip";
 
@@ -123,21 +122,24 @@ export function withClientIpHeader(c: Context): Request {
     }
   }
   if (!clientIp) {
-    // `hono/bun`'s getConnInfo reads server.requestIP() via c.env.
-    // It expects c.env to be the Bun server (or an object with a
-    // `server` property). When the auth catch-all runs without a
-    // server context — Next.js standalone on Vercel, the Hono test
-    // harness calling app.fetch(req) with no 2nd arg — c.env is
-    // undefined and `"server" in c.env` would throw a TypeError.
-    // The pre-check avoids spamming the warn log for that expected
-    // case; `getConnInfo` throwing for any other reason still
-    // surfaces as a warn so a future adapter swap doesn't silently
-    // disable rate limiting.
-    const hasServerContext = typeof c.env === "object" && c.env !== null;
-    if (hasServerContext) {
+    // Resolve the Bun socket IP via `server.requestIP(req)`. We
+    // replicate `hono/bun`'s getConnInfo inline rather than importing
+    // it — that module references the `Bun` global at evaluation
+    // time, which breaks the Next.js standalone example's build
+    // (Next tries to collect page data under a Node runtime where
+    // Bun is not defined). The inline version has zero Bun-global
+    // dependency and runs as a no-op in non-Bun environments.
+    //
+    // When the auth catch-all runs without a server context
+    // (Next.js standalone on Vercel, the Hono test harness calling
+    // app.fetch(req) with no 2nd arg), `c.env` is undefined or lacks
+    // `requestIP`, and we leave `clientIp` unset so Better Auth
+    // skips rate limiting for that request.
+    const server = resolveBunServer(c.env);
+    if (server) {
       try {
-        const info = getConnInfo(c);
-        if (info.remote?.address) clientIp = info.remote.address;
+        const info = server.requestIP(c.req.raw);
+        if (info?.address) clientIp = info.address;
       } catch (err) {
         log.warn(
           { err: err instanceof Error ? err.message : String(err) },
@@ -159,6 +161,37 @@ export function withClientIpHeader(c: Context): Request {
 }
 
 /**
+ * Platform-neutral Bun server resolver. Mirrors `hono/bun`'s
+ * `getBunServer` / `getConnInfo` without importing the Bun adapter —
+ * the adapter's top-level code references the `Bun` global, which
+ * throws `ReferenceError: Bun is not defined` during Next.js
+ * standalone build when Next collects page data under a Node runtime.
+ *
+ * Returns `null` when `env` isn't a plausible Bun server (test
+ * harness with no 2nd fetch arg, Next.js route handlers, Node-only
+ * deploys). Returns a minimal interface otherwise so the caller can
+ * extract `.address` without pulling in Bun-specific types.
+ */
+interface BunLikeServer {
+  requestIP: (req: Request) => { address?: string; family?: string; port?: number } | null;
+}
+function resolveBunServer(env: unknown): BunLikeServer | null {
+  if (typeof env !== "object" || env === null) return null;
+  const candidate =
+    "server" in env && typeof (env as Record<string, unknown>).server === "object"
+      ? (env as Record<string, unknown>).server
+      : env;
+  if (
+    candidate !== null
+    && typeof candidate === "object"
+    && typeof (candidate as { requestIP?: unknown }).requestIP === "function"
+  ) {
+    return candidate as BunLikeServer;
+  }
+  return null;
+}
+
+/**
  * Determine whether to trust proxy-set headers (X-Forwarded-For /
  * X-Real-IP) for the client IP.
  *
@@ -177,10 +210,21 @@ export function shouldTrustProxyHeaders(env: NodeJS.ProcessEnv): boolean {
 }
 
 /**
- * Strip a trailing `:<port>` from an IP literal. Handles bracketed
- * IPv6 (`[::1]:5678` → `::1`) and IPv4-with-port (`1.2.3.4:5678` →
- * `1.2.3.4`). A bare IPv6 address containing colons (e.g. `::1`) is
- * left untouched because it has no trailing port.
+ * Strip a trailing `:<port>` from an IP literal.
+ *
+ * Handled cases:
+ *   - Bracketed IPv6 with port: `[::1]:5678`          → `::1`
+ *   - IPv4 with numeric port:   `1.2.3.4:5678`        → `1.2.3.4`
+ *
+ * Left untouched:
+ *   - Bare IPv6 (multiple colons): `::1`, `fe80::1%eth0`, `::ffff:1.2.3.4`
+ *   - Non-numeric trailing segments: `host:something`, `1.2.3.4:abc`
+ *     (these are not port suffixes and silently dropping them would
+ *     hide a misconfiguration AND place the request in an unexpected
+ *     rate-limit bucket).
+ *
+ * Only the exactly-one-colon-with-digits-after signature counts as
+ * IPv4:port; anything else passes through unchanged.
  *
  * Exported for testing.
  */
@@ -195,13 +239,13 @@ export function stripPortSuffix(raw: string): string {
     return trimmed;
   }
 
-  // IPv4 with port: 1.2.3.4:54321 → 1.2.3.4. A single colon with digits
-  // after is the signature; IPv6 addresses have multiple colons so this
-  // check leaves them intact.
+  // IPv4 with port: exactly one colon AND the suffix is all digits.
+  // Any multi-colon form (bare IPv6, zone-id, IPv4-mapped IPv6) has
+  // colonCount > 1 so the heuristic leaves it alone.
   const colonCount = (trimmed.match(/:/g) ?? []).length;
   if (colonCount === 1) {
-    const [host] = trimmed.split(":");
-    return host;
+    const [host, portSuffix] = trimmed.split(":");
+    if (portSuffix !== undefined && /^\d+$/.test(portSuffix)) return host;
   }
 
   return trimmed;

--- a/packages/api/src/api/routes/auth.ts
+++ b/packages/api/src/api/routes/auth.ts
@@ -6,11 +6,26 @@
  * Returns 404 for all auth routes when managed mode is not active.
  */
 
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
+import { getConnInfo } from "hono/bun";
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
 import { createLogger } from "@atlas/api/lib/logger";
 
 const log = createLogger("auth-route");
+
+/**
+ * Custom header Better Auth reads for rate-limit IP bucketing.
+ *
+ * Set only by this middleware from the Bun socket address (or a proxied
+ * X-Forwarded-For when ATLAS_TRUST_PROXY=true). Any inbound value on the
+ * header is stripped first so end users can't spoof the IP bucket.
+ *
+ * Paired with `advanced.ipAddress.ipAddressHeaders: ["x-atlas-client-ip"]`
+ * in `getAuthInstance()` — Better Auth will skip rate limiting (log warn)
+ * whenever this header is missing, which protects us if the middleware
+ * chain is ever bypassed.
+ */
+const CLIENT_IP_HEADER = "x-atlas-client-ip";
 
 const auth = new Hono();
 
@@ -25,7 +40,8 @@ auth.all("/*", async (c) => {
   try {
     const { getAuthInstance } = await import("@atlas/api/lib/auth/server");
     const authInstance = getAuthInstance();
-    const response = await authInstance.handler(c.req.raw);
+    const authRequest = withClientIpHeader(c);
+    const response = await authInstance.handler(authRequest);
 
     // Better Auth returns a raw Response, bypassing Hono's response
     // pipeline. Copy CORS headers set by the upstream middleware so
@@ -57,5 +73,138 @@ auth.all("/*", async (c) => {
     );
   }
 });
+
+/**
+ * Resolve the real client IP and attach it to {@link CLIENT_IP_HEADER}
+ * on a cloned Request before handing to Better Auth. Strips any inbound
+ * value of the header to prevent spoofing.
+ *
+ * Resolution order:
+ *   1. When {@link shouldTrustProxyHeaders} is on: first entry of
+ *      X-Forwarded-For, then X-Real-IP. This is what runs in Railway /
+ *      Vercel / nginx — those platforms set X-Forwarded-For on every
+ *      request and Vercel is auto-detected even without the env var
+ *      because `fetch(req)` on their edge never carries a Bun socket.
+ *   2. Otherwise: the Bun socket-level peer address via `hono/bun`'s
+ *      getConnInfo. This is what runs in local dev and single-node
+ *      Docker deployments.
+ *
+ * Whichever source yields an IP, the port suffix (IPv4 `1.2.3.4:5678`,
+ * bracketed IPv6 `[::1]:5678`) is stripped — leaving it in would let
+ * one attacker's connections occupy distinct rate-limit buckets per
+ * ephemeral source port, silently defeating the quota.
+ *
+ * When no source yields an IP, the header is left unset and Better
+ * Auth skips rate limiting for that request (logging a warn). That is
+ * preferable to writing `"unknown"` — a shared bucket would let one
+ * attacker exhaust the quota for every unrelated request.
+ *
+ * Exported for testing: this is the trust boundary for F-06 and the
+ * unit tests pin the spoof-strip, trust-proxy toggle, multi-hop XFF,
+ * IPv6, and missing-socket cases.
+ */
+export function withClientIpHeader(c: Context): Request {
+  const original = c.req.raw;
+  const incoming = new Headers(original.headers);
+  incoming.delete(CLIENT_IP_HEADER);
+
+  const trustProxy = shouldTrustProxyHeaders(process.env);
+
+  let clientIp: string | undefined;
+  if (trustProxy) {
+    const xff = original.headers.get("x-forwarded-for");
+    if (xff) {
+      const first = xff.split(",")[0]?.trim();
+      if (first) clientIp = first;
+    }
+    if (!clientIp) {
+      const realIp = original.headers.get("x-real-ip")?.trim();
+      if (realIp) clientIp = realIp;
+    }
+  }
+  if (!clientIp) {
+    // `hono/bun`'s getConnInfo reads server.requestIP() via c.env.
+    // It expects c.env to be the Bun server (or an object with a
+    // `server` property). When the auth catch-all runs without a
+    // server context — Next.js standalone on Vercel, the Hono test
+    // harness calling app.fetch(req) with no 2nd arg — c.env is
+    // undefined and `"server" in c.env` would throw a TypeError.
+    // The pre-check avoids spamming the warn log for that expected
+    // case; `getConnInfo` throwing for any other reason still
+    // surfaces as a warn so a future adapter swap doesn't silently
+    // disable rate limiting.
+    const hasServerContext = typeof c.env === "object" && c.env !== null;
+    if (hasServerContext) {
+      try {
+        const info = getConnInfo(c);
+        if (info.remote?.address) clientIp = info.remote.address;
+      } catch (err) {
+        log.warn(
+          { err: err instanceof Error ? err.message : String(err) },
+          "Could not resolve socket client IP — Better Auth rate limiter will skip this request. "
+            + "If running behind a proxy, set ATLAS_TRUST_PROXY=true so X-Forwarded-For is consulted.",
+        );
+      }
+    }
+  }
+
+  if (clientIp) {
+    const normalized = stripPortSuffix(clientIp);
+    if (normalized) incoming.set(CLIENT_IP_HEADER, normalized);
+  }
+
+  // A Request body is a one-shot stream; `new Request(original, { headers })`
+  // re-uses the original body reference, which is what we want.
+  return new Request(original, { headers: incoming });
+}
+
+/**
+ * Determine whether to trust proxy-set headers (X-Forwarded-For /
+ * X-Real-IP) for the client IP.
+ *
+ * Trust is enabled when:
+ *   - ATLAS_TRUST_PROXY is `"true"` or `"1"` (explicit operator opt-in), or
+ *   - `VERCEL=1` is set (Vercel's edge always sets X-Forwarded-For and
+ *     no Bun socket is available — without this auto-detect, rate
+ *     limiting would silently no-op on Vercel deploys).
+ *
+ * Exported for testing.
+ */
+export function shouldTrustProxyHeaders(env: NodeJS.ProcessEnv): boolean {
+  if (env.ATLAS_TRUST_PROXY === "true" || env.ATLAS_TRUST_PROXY === "1") return true;
+  if (env.VERCEL === "1") return true;
+  return false;
+}
+
+/**
+ * Strip a trailing `:<port>` from an IP literal. Handles bracketed
+ * IPv6 (`[::1]:5678` → `::1`) and IPv4-with-port (`1.2.3.4:5678` →
+ * `1.2.3.4`). A bare IPv6 address containing colons (e.g. `::1`) is
+ * left untouched because it has no trailing port.
+ *
+ * Exported for testing.
+ */
+export function stripPortSuffix(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return trimmed;
+
+  // Bracketed IPv6: [2001:db8::1]:54321 → 2001:db8::1
+  if (trimmed.startsWith("[")) {
+    const end = trimmed.indexOf("]");
+    if (end > 0) return trimmed.slice(1, end);
+    return trimmed;
+  }
+
+  // IPv4 with port: 1.2.3.4:54321 → 1.2.3.4. A single colon with digits
+  // after is the signature; IPv6 addresses have multiple colons so this
+  // check leaves them intact.
+  const colonCount = (trimmed.match(/:/g) ?? []).length;
+  if (colonCount === 1) {
+    const [host] = trimmed.split(":");
+    return host;
+  }
+
+  return trimmed;
+}
 
 export { auth };

--- a/packages/api/src/lib/auth/__tests__/rate-limit.test.ts
+++ b/packages/api/src/lib/auth/__tests__/rate-limit.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, mock } from "bun:test";
+import {
+  resolveAuthRateLimitConfig,
+  resolveRequireEmailVerification,
+  buildEmailAndPasswordConfig,
+  buildAdvancedConfig,
+  _sendVerificationEmail,
+} from "../server";
+
+/**
+ * Regression tests for #1732 (F-06) and #1731 (F-05).
+ *
+ * Before 1.2.3 the Better Auth config did not configure rate limits or
+ * email verification. Phase 1.5 of the security audit repro'd:
+ *
+ *   1. 100 sequential /api/auth/sign-in/email from one IP — all 401, no
+ *      429. Brute-force wide open.
+ *   2. POST /api/auth/sign-up/email with an existing email returns HTTP
+ *      422 with code USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL — reliable
+ *      email-enumeration oracle.
+ *
+ * These tests pin the pure helpers that resolve the fix so a future
+ * refactor can't silently reintroduce either attack surface.
+ */
+
+describe("resolveRequireEmailVerification", () => {
+  it("defaults to true when unset", () => {
+    expect(resolveRequireEmailVerification({} as NodeJS.ProcessEnv)).toBe(true);
+  });
+
+  it("defaults to true when empty string", () => {
+    expect(
+      resolveRequireEmailVerification({ ATLAS_REQUIRE_EMAIL_VERIFICATION: "" } as NodeJS.ProcessEnv),
+    ).toBe(true);
+  });
+
+  it.each(["true", "TRUE", "1", "yes", "on", "anything-else"])(
+    "stays true for affirmative or unrecognized value %j",
+    (value: string) => {
+      expect(
+        resolveRequireEmailVerification({
+          ATLAS_REQUIRE_EMAIL_VERIFICATION: value,
+        } as NodeJS.ProcessEnv),
+      ).toBe(true);
+    },
+  );
+
+  it.each(["false", "FALSE", "0", "no", "NO", "off", "  false  "])(
+    "flips to false for explicit opt-out %j",
+    (value: string) => {
+      expect(
+        resolveRequireEmailVerification({
+          ATLAS_REQUIRE_EMAIL_VERIFICATION: value,
+        } as NodeJS.ProcessEnv),
+      ).toBe(false);
+    },
+  );
+});
+
+describe("resolveAuthRateLimitConfig", () => {
+  it("defaults to enabled regardless of NODE_ENV", () => {
+    const devConfig = resolveAuthRateLimitConfig(
+      { NODE_ENV: "development" } as NodeJS.ProcessEnv,
+      true,
+    );
+    const prodConfig = resolveAuthRateLimitConfig(
+      { NODE_ENV: "production" } as NodeJS.ProcessEnv,
+      true,
+    );
+
+    expect(devConfig.enabled).toBe(true);
+    expect(prodConfig.enabled).toBe(true);
+  });
+
+  it("opts out only when ATLAS_AUTH_RATE_LIMIT_ENABLED='false'", () => {
+    expect(
+      resolveAuthRateLimitConfig(
+        { ATLAS_AUTH_RATE_LIMIT_ENABLED: "false" } as NodeJS.ProcessEnv,
+        true,
+      ).enabled,
+    ).toBe(false);
+
+    expect(
+      resolveAuthRateLimitConfig(
+        { ATLAS_AUTH_RATE_LIMIT_ENABLED: "FALSE" } as NodeJS.ProcessEnv,
+        true,
+      ).enabled,
+    ).toBe(false);
+  });
+
+  it("ignores unrecognized opt-out values (stays enabled)", () => {
+    // "0" and "no" are not accepted for the rate-limit flag — only
+    // literal "false". Different convention than requireEmailVerification
+    // because rate limiting is strictly opt-out and the ambiguity of "0"
+    // (disabled? zero requests?) is worse than a slightly stricter flag.
+    expect(
+      resolveAuthRateLimitConfig(
+        { ATLAS_AUTH_RATE_LIMIT_ENABLED: "0" } as NodeJS.ProcessEnv,
+        true,
+      ).enabled,
+    ).toBe(true);
+  });
+
+  it("uses database storage when internal DB is available, memory otherwise", () => {
+    expect(resolveAuthRateLimitConfig({} as NodeJS.ProcessEnv, true).storage).toBe("database");
+    expect(resolveAuthRateLimitConfig({} as NodeJS.ProcessEnv, false).storage).toBe("memory");
+  });
+
+  it("respects env overrides for window/max", () => {
+    const config = resolveAuthRateLimitConfig(
+      {
+        ATLAS_AUTH_RATE_LIMIT_WINDOW: "120",
+        ATLAS_AUTH_RATE_LIMIT_MAX: "50",
+      } as NodeJS.ProcessEnv,
+      true,
+    );
+
+    expect(config.window).toBe(120);
+    expect(config.max).toBe(50);
+  });
+
+  it("falls back to defaults on invalid env values", () => {
+    const config = resolveAuthRateLimitConfig(
+      {
+        ATLAS_AUTH_RATE_LIMIT_WINDOW: "not-a-number",
+        ATLAS_AUTH_RATE_LIMIT_MAX: "-5",
+      } as NodeJS.ProcessEnv,
+      true,
+    );
+
+    expect(config.window).toBe(60);
+    expect(config.max).toBe(100);
+  });
+
+  it("pins per-endpoint rules that cannot be loosened by env", () => {
+    // These are the surfaces an attacker targets (signin, signup,
+    // password-reset, verification-email resend). Relaxing any of them
+    // would reintroduce the F-06 brute-force surface.
+    const config = resolveAuthRateLimitConfig(
+      {
+        ATLAS_AUTH_RATE_LIMIT_WINDOW: "9999",
+        ATLAS_AUTH_RATE_LIMIT_MAX: "9999",
+      } as NodeJS.ProcessEnv,
+      true,
+    );
+
+    expect(config.customRules["/sign-in/email"]).toEqual({ window: 60, max: 10 });
+    expect(config.customRules["/sign-up/email"]).toEqual({ window: 60, max: 5 });
+    expect(config.customRules["/forget-password"]).toEqual({ window: 60, max: 5 });
+    expect(config.customRules["/reset-password"]).toEqual({ window: 60, max: 5 });
+    expect(config.customRules["/send-verification-email"]).toEqual({ window: 60, max: 5 });
+    expect(config.customRules["/verify-email"]).toEqual({ window: 60, max: 10 });
+  });
+
+  it("uses the default modelName so Better Auth's auto-migration creates the rateLimit table", () => {
+    const config = resolveAuthRateLimitConfig({} as NodeJS.ProcessEnv, true);
+    expect(config.modelName).toBe("rateLimit");
+  });
+});
+
+describe("buildEmailAndPasswordConfig", () => {
+  it("pins autoSignIn OFF whenever requireEmailVerification is ON (F-05 invariant)", () => {
+    const config = buildEmailAndPasswordConfig(true);
+    expect(config.enabled).toBe(true);
+    expect(config.requireEmailVerification).toBe(true);
+    // If this flips to true the signup flow becomes a login oracle —
+    // attacker signs up with a victim's email, gets a session whether
+    // or not the account existed.
+    expect(config.autoSignIn).toBe(false);
+  });
+
+  it("allows autoSignIn when verification is disabled (self-hosted opt-out)", () => {
+    const config = buildEmailAndPasswordConfig(false);
+    expect(config.enabled).toBe(true);
+    expect(config.requireEmailVerification).toBe(false);
+    expect(config.autoSignIn).toBe(true);
+  });
+});
+
+describe("buildAdvancedConfig", () => {
+  it("pins ipAddressHeaders to exactly ['x-atlas-client-ip'] (F-06 invariant)", () => {
+    const config = buildAdvancedConfig(undefined);
+    // Adding 'x-forwarded-for' here would make the IP bucket client-
+    // spoofable and reopen F-06. Removing the list entirely would
+    // fall back to Better Auth's default (x-forwarded-for) — same
+    // result. The list must be exactly our one custom header.
+    expect(config.ipAddress.ipAddressHeaders).toEqual(["x-atlas-client-ip"]);
+  });
+
+  it("omits defaultCookieAttributes when cookieDomain is undefined", () => {
+    const config = buildAdvancedConfig(undefined);
+    expect(config.defaultCookieAttributes).toBeUndefined();
+  });
+
+  it("sets a subdomain cookie when cookieDomain is provided", () => {
+    const config = buildAdvancedConfig("useatlas.dev");
+    expect(config.defaultCookieAttributes).toEqual({ domain: ".useatlas.dev" });
+  });
+});
+
+describe("_sendVerificationEmail", () => {
+  // Mock ALL runtime exports of the delivery module — partial mocks
+  // can surface as SyntaxError in sibling test files that import
+  // `sendEmailWithTransport` after this file mutates the module cache.
+  const installDeliveryMock = (sendEmail: (msg: { to: string; subject: string; html: string }) => Promise<{ success: boolean; provider: string; error?: string }>): void => {
+    mock.module("@atlas/api/lib/email/delivery", () => ({
+      sendEmail,
+      sendEmailWithTransport: async () => ({ success: true, provider: "resend" as const }),
+      getEmailTransport: async () => null,
+    }));
+  };
+
+  it("calls sendEmail with the verification URL in an <a href>", async () => {
+    const calls: Array<{ to: string; subject: string; html: string }> = [];
+    installDeliveryMock(async (msg) => {
+      calls.push(msg);
+      return { success: true, provider: "resend" };
+    });
+
+    await _sendVerificationEmail({
+      to: "verify@example.com",
+      url: "https://example.com/verify?token=abc123",
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].to).toBe("verify@example.com");
+    expect(calls[0].subject).toContain("Verify");
+    // & is HTML-escaped in attribute values; the literal URL becomes
+    // `...?token=abc123` with `&amp;` separators, but a single-arg
+    // URL has no & to escape. Assert containment on a unique token
+    // substring instead so the escaper is allowed to change.
+    expect(calls[0].html).toContain("token=abc123");
+    expect(calls[0].html).toContain("<a href=");
+  });
+
+  it("HTML-escapes URLs that contain attribute-breaking characters", async () => {
+    const calls: Array<{ html: string }> = [];
+    installDeliveryMock(async (msg) => {
+      calls.push({ html: msg.html });
+      return { success: true, provider: "resend" };
+    });
+
+    // If a malformed Better Auth URL somehow contained a quote or &,
+    // the raw interpolation would break the href attribute. The
+    // escape pass prevents that from rendering as broken markup.
+    await _sendVerificationEmail({
+      to: "verify@example.com",
+      url: 'https://example.com/verify?a=1&b="2"',
+    });
+
+    expect(calls[0].html).not.toContain('b="2"');
+    expect(calls[0].html).toContain("&amp;");
+    expect(calls[0].html).toContain("&quot;");
+  });
+
+  it("does not throw when delivery returns success: false (preserves enumeration protection)", async () => {
+    installDeliveryMock(async () => ({
+      success: false,
+      provider: "log" as const,
+      error: "No email delivery backend configured",
+    }));
+
+    // If this throws, the Better Auth handler would 500 and the
+    // attacker could distinguish "new email + no provider" (500)
+    // from "existing email" (200) — resurrecting the enumeration
+    // oracle through a different channel.
+    await expect(
+      _sendVerificationEmail({
+        to: "verify@example.com",
+        url: "https://example.com/verify?token=abc123",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not throw when sendEmail itself throws (provider SDK crash / network error)", async () => {
+    installDeliveryMock(async () => {
+      throw new Error("Simulated provider crash");
+    });
+
+    // Same contract: thrown rejections must NOT propagate, otherwise
+    // the Better Auth callback becomes an unhandled rejection that
+    // either spams stderr or — with --unhandled-rejections=strict —
+    // terminates the process mid-signup.
+    await expect(
+      _sendVerificationEmail({
+        to: "verify@example.com",
+        url: "https://example.com/verify?token=abc123",
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/auth/__tests__/rate-limit.test.ts
+++ b/packages/api/src/lib/auth/__tests__/rate-limit.test.ts
@@ -253,6 +253,36 @@ describe("_sendVerificationEmail", () => {
     expect(calls[0].html).toContain("&quot;");
   });
 
+  // Each XML-special character must round-trip through the href
+  // attribute as its HTML entity. Dropping any of these would either
+  // break attribute parsing in email clients (rendering the link
+  // inert) or, worst case, create an XSS vector if a future Better
+  // Auth URL carried user-controlled data.
+  it.each([
+    { char: "'", entity: "&#39;", fragment: "?x='y" },
+    { char: "<", entity: "&lt;", fragment: "?x=<y" },
+    { char: ">", entity: "&gt;", fragment: "?x=>y" },
+  ] as const)("escapes $char to $entity inside the href attribute", async ({ char, entity, fragment }: { char: string; entity: string; fragment: string }) => {
+    const calls: Array<{ html: string }> = [];
+    installDeliveryMock(async (msg) => {
+      calls.push({ html: msg.html });
+      return { success: true, provider: "resend" };
+    });
+
+    await _sendVerificationEmail({
+      to: "verify@example.com",
+      url: `https://example.com/verify${fragment}`,
+    });
+
+    // Extract the href="..." attribute value and assert on it only —
+    // the surrounding template legitimately contains <, >, and '.
+    const hrefMatch = calls[0].html.match(/href="([^"]+)"/);
+    expect(hrefMatch).not.toBeNull();
+    const hrefValue = hrefMatch![1];
+    expect(hrefValue).not.toContain(char);
+    expect(hrefValue).toContain(entity);
+  });
+
   it("does not throw when delivery returns success: false (preserves enumeration protection)", async () => {
     installDeliveryMock(async () => ({
       success: false,

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -64,6 +64,239 @@ const log = createLogger("auth:server");
 const billingLog = createLogger("billing");
 
 /**
+ * Built-in rate-limit ceilings for Better Auth endpoints. Chosen to slow
+ * online brute force and email-verification abuse while tolerating
+ * legitimate retry patterns (user fat-fingers password 2–3 times, clicks
+ * "resend" a couple of times). Global `max` is the fallback for endpoints
+ * without a custom rule; specific surfaces below are tighter.
+ *
+ * Windows are in seconds. Env vars can override the global window/max at
+ * boot — see {@link resolveAuthRateLimitConfig} — but the per-endpoint
+ * rules below are constants because relaxing them is almost always a
+ * misconfiguration (signup at 100/min eliminates enumeration protection).
+ */
+const AUTH_RATE_LIMIT_DEFAULTS = {
+  window: 60,
+  max: 100,
+  signInEmail: { window: 60, max: 10 },
+  signUpEmail: { window: 60, max: 5 },
+  forgetPassword: { window: 60, max: 5 },
+  resetPassword: { window: 60, max: 5 },
+  sendVerificationEmail: { window: 60, max: 5 },
+  verifyEmail: { window: 60, max: 10 },
+} as const;
+
+export interface ResolvedAuthRateLimitConfig {
+  enabled: boolean;
+  window: number;
+  max: number;
+  storage: "memory" | "database";
+  modelName: string;
+  customRules: Record<string, { window: number; max: number }>;
+}
+
+/**
+ * Resolve Better Auth rate-limit configuration from the environment.
+ *
+ * Better Auth's built-in default is `enabled: true in production, false
+ * in development`, and its in-memory store does not share state across
+ * processes (Railway autoscale, Vercel serverless, multi-replica Docker).
+ * Atlas's threat model (signin brute-force, signup enumeration, password-
+ * reset spam) does not line up with either default, so this function:
+ *
+ * 1. Defaults `enabled: true` regardless of NODE_ENV. Test envs can opt
+ *    out with `ATLAS_AUTH_RATE_LIMIT_ENABLED=false`.
+ * 2. Uses the DB-backed store when the internal DB is available — shared
+ *    counters across replicas. Falls back to `memory` for single-node
+ *    self-hosted deployments without an internal DB.
+ * 3. Sets tight per-endpoint rules on the surfaces an attacker actually
+ *    targets (signin, signup, password-reset, verification-email resend).
+ *    The global window/max is the fallback ceiling for other auth paths.
+ */
+export function resolveAuthRateLimitConfig(
+  env: NodeJS.ProcessEnv,
+  internalDbAvailable: boolean,
+): ResolvedAuthRateLimitConfig {
+  const enabled = env.ATLAS_AUTH_RATE_LIMIT_ENABLED?.trim().toLowerCase() !== "false";
+
+  // Surface invalid env values at boot. Operators who set
+  // ATLAS_AUTH_RATE_LIMIT_MAX=0 (expecting "disable") or =100x (typo)
+  // silently fell back to the default before this warn — a
+  // misconfiguration that's easy to miss because it fails toward the
+  // safer value. Name the var so grep and log aggregation surface it.
+  const parsePositiveInt = (raw: string | undefined, fallback: number, varName: string): number => {
+    if (raw === undefined) return fallback;
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed > 0) return Math.floor(parsed);
+    log.warn(
+      { var: varName, value: raw, fallback },
+      "Invalid env value — not a positive number. Falling back to the default.",
+    );
+    return fallback;
+  };
+
+  return {
+    enabled,
+    window: parsePositiveInt(
+      env.ATLAS_AUTH_RATE_LIMIT_WINDOW,
+      AUTH_RATE_LIMIT_DEFAULTS.window,
+      "ATLAS_AUTH_RATE_LIMIT_WINDOW",
+    ),
+    max: parsePositiveInt(
+      env.ATLAS_AUTH_RATE_LIMIT_MAX,
+      AUTH_RATE_LIMIT_DEFAULTS.max,
+      "ATLAS_AUTH_RATE_LIMIT_MAX",
+    ),
+    storage: internalDbAvailable ? "database" : "memory",
+    modelName: "rateLimit",
+    customRules: {
+      "/sign-in/email": { ...AUTH_RATE_LIMIT_DEFAULTS.signInEmail },
+      "/sign-up/email": { ...AUTH_RATE_LIMIT_DEFAULTS.signUpEmail },
+      "/forget-password": { ...AUTH_RATE_LIMIT_DEFAULTS.forgetPassword },
+      "/reset-password": { ...AUTH_RATE_LIMIT_DEFAULTS.resetPassword },
+      "/send-verification-email": { ...AUTH_RATE_LIMIT_DEFAULTS.sendVerificationEmail },
+      "/verify-email": { ...AUTH_RATE_LIMIT_DEFAULTS.verifyEmail },
+    },
+  };
+}
+
+/**
+ * Build the Better Auth `emailAndPassword` config block.
+ *
+ * Pins the F-05 invariant: whenever `requireEmailVerification` is true,
+ * `autoSignIn` MUST be false. Sign-in is blocked until the user clicks
+ * the verification link anyway, but an accidental `autoSignIn: true` in
+ * a future refactor would silently turn signup into a login oracle
+ * (attacker signs up with a victim's email → gets a session regardless
+ * of whether the account existed). The unit tests pin this exactly.
+ */
+export function buildEmailAndPasswordConfig(requireEmailVerification: boolean): {
+  enabled: true;
+  requireEmailVerification: boolean;
+  autoSignIn: boolean;
+} {
+  return {
+    enabled: true,
+    requireEmailVerification,
+    autoSignIn: !requireEmailVerification,
+  };
+}
+
+/**
+ * Build the Better Auth `advanced` config block.
+ *
+ * Pins `ipAddress.ipAddressHeaders = ["x-atlas-client-ip"]` — this is
+ * the single knob the rate limiter reads. Adding `x-forwarded-for` to
+ * the list would make every request's IP client-spoofable and silently
+ * reopens F-06. The tests assert this list is exactly the one custom
+ * header we set in `withClientIpHeader`.
+ *
+ * `cookieDomain` is optional; when present the returned block also sets
+ * the shared-subdomain cookie attribute for SaaS deployments.
+ */
+export function buildAdvancedConfig(cookieDomain: string | undefined): {
+  ipAddress: { ipAddressHeaders: string[] };
+  defaultCookieAttributes?: { domain: string };
+} {
+  return {
+    ipAddress: {
+      ipAddressHeaders: ["x-atlas-client-ip"],
+    },
+    ...(cookieDomain
+      ? { defaultCookieAttributes: { domain: `.${cookieDomain}` } }
+      : {}),
+  };
+}
+
+/**
+ * Resolve whether email verification is required from the environment.
+ *
+ * Defaults to `true` for security hardening. Multi-tenant deployments
+ * must leave it on — verification closes the signup-enumeration oracle
+ * (OWASP A07 authentication failures) and prevents unverified accounts
+ * from triggering email-keyed workflows (SSO domain auto-provision,
+ * invitation claim, bootstrap admin race).
+ *
+ * Self-hosted single-tenant deployments that run without an email
+ * provider can opt out with `ATLAS_REQUIRE_EMAIL_VERIFICATION=false`.
+ * Accepts `false`, `0`, `no`, `off` (case-insensitive) as opt-out.
+ */
+export function resolveRequireEmailVerification(env: NodeJS.ProcessEnv): boolean {
+  const raw = env.ATLAS_REQUIRE_EMAIL_VERIFICATION?.trim().toLowerCase();
+  if (raw === undefined) return true;
+  return !["false", "0", "no", "off"].includes(raw);
+}
+
+/**
+ * Send the email verification message via Atlas's email delivery layer.
+ *
+ * Kept thin so the Better Auth `sendVerificationEmail` callback stays
+ * simple and tests can mock this single function without standing up
+ * the whole provider chain.
+ *
+ * Delivery failures are logged but never thrown — blocking the signup
+ * or signin handler on a transient SMTP outage is worse UX than letting
+ * the user retry via `/send-verification-email`, and Better Auth already
+ * returns the same 200 response for new and existing emails regardless
+ * of whether send succeeds (OWASP enumeration protection hinges on
+ * response parity, not delivery).
+ *
+ * @internal — exported for testing.
+ */
+export async function _sendVerificationEmail(opts: { to: string; url: string }): Promise<void> {
+  // All failure paths (dynamic import rejection, provider SDK throwing,
+  // template assembly) must be caught here. The Better Auth callback
+  // uses `void _sendVerificationEmail(...)` for timing-attack mitigation
+  // and a floating rejection would either print to stderr with no
+  // correlation or, on `--unhandled-rejections=strict`, terminate the
+  // process — re-introducing the enumeration oracle through a 500 side
+  // channel.
+  try {
+    const { sendEmail } = await import("@atlas/api/lib/email/delivery");
+    const result = await sendEmail({
+      to: opts.to,
+      subject: "Verify your Atlas email address",
+      html: `<!doctype html>
+<html>
+  <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif; max-width: 560px; margin: 0 auto; padding: 24px; color: #222;">
+    <p>Welcome to Atlas. Click the link below to verify your email address:</p>
+    <p><a href="${encodeAttributeValue(opts.url)}" style="color:#0ea5e9;">Verify email</a></p>
+    <p style="color:#666; font-size:13px;">If you did not try to create an account, you can safely ignore this message.</p>
+    <p>— Atlas</p>
+  </body>
+</html>`,
+    });
+    if (!result.success) {
+      log.warn(
+        { to: opts.to, provider: result.provider, error: result.error },
+        "Email verification delivery did not complete — user may need to retry via /send-verification-email",
+      );
+    }
+  } catch (err) {
+    log.warn(
+      { to: opts.to, err: err instanceof Error ? err.message : String(err) },
+      "Email verification dispatch crashed — signup response is still 200 to preserve enumeration protection; user may need to retry via /send-verification-email",
+    );
+  }
+}
+
+/**
+ * Minimal HTML attribute-value escape for the verification URL. Better
+ * Auth URLs are well-formed, but a `"` in the token would break the
+ * `<a href="...">` attribute and — absent this — could produce a
+ * malformed email that some clients render inert. Replaces the five
+ * XML-special characters; anything else passes through as-is.
+ */
+function encodeAttributeValue(raw: string): string {
+  return raw
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+/**
  * Build the Better Auth plugins array.
  *
  * Stripe plugin is conditionally included when STRIPE_SECRET_KEY is set.
@@ -561,16 +794,64 @@ export function getAuthInstance(): AuthInstance {
     log.info({ providers: Object.keys(socialProviders) }, "Social login providers configured");
   }
 
+  // F-05 + F-06 — resolve security-sensitive auth config at boot so the
+  // values are visible in the singleton's memory and, on failure, the
+  // server fails at startup rather than on the first attacker request.
+  const internalDbAvailable = hasInternalDB();
+  const requireEmailVerification = resolveRequireEmailVerification(process.env);
+  const rateLimitConfig = resolveAuthRateLimitConfig(process.env, internalDbAvailable);
+
+  if (!requireEmailVerification) {
+    log.warn(
+      "ATLAS_REQUIRE_EMAIL_VERIFICATION is disabled — signups do not require email confirmation and "
+        + "Better Auth's signup-enumeration protection is off (existing emails return a distinct "
+        + "USER_ALREADY_EXISTS error). Leave this enabled for any multi-tenant deployment.",
+    );
+  }
+  if (!rateLimitConfig.enabled) {
+    log.warn(
+      "ATLAS_AUTH_RATE_LIMIT_ENABLED=false — /api/auth/* endpoints are not rate-limited. "
+        + "Only use this in isolated test environments.",
+    );
+  } else {
+    log.info(
+      { storage: rateLimitConfig.storage, window: rateLimitConfig.window, max: rateLimitConfig.max },
+      "Better Auth rate limiting enabled",
+    );
+  }
+
   const instance = betterAuth({
     // getInternalDB() returns a pg.Pool typed as InternalPool.
     // Cast needed because Better Auth expects its own pool/adapter type.
     database: getInternalDB() as unknown as Parameters<typeof betterAuth>[0]["database"],
     secret,
     baseURL,
-    emailAndPassword: {
-      enabled: true,
-      requireEmailVerification: false,
-      autoSignIn: true,
+    // F-05: closes the signup-enumeration oracle and blocks unverified
+    // accounts from claiming SSO auto-provision / invitation workflows.
+    // See `buildEmailAndPasswordConfig` for the `autoSignIn` invariant.
+    emailAndPassword: buildEmailAndPasswordConfig(requireEmailVerification),
+    emailVerification: {
+      sendVerificationEmail: async ({ user, url }) => {
+        // Do not await. Better Auth's enumeration protection depends on
+        // the signup/signin handler returning the same 200 response in
+        // the same time window regardless of whether the email exists;
+        // awaiting SMTP would extend the attacker's timing oracle and
+        // create a DoS vector (email provider outage => signup blocked).
+        //
+        // `.catch()` is belt-and-suspenders — `_sendVerificationEmail`
+        // already wraps everything in try/catch, but an unhandled
+        // rejection from any future refactor would either spam stderr
+        // with no correlation or (with --unhandled-rejections=strict)
+        // crash the process and reintroduce the enumeration oracle as
+        // a 500-vs-200 side channel.
+        _sendVerificationEmail({ to: user.email, url }).catch((err) => {
+          log.warn(
+            { to: user.email, err: err instanceof Error ? err.message : String(err) },
+            "Verification email dispatch threw — signup response is still 200 to preserve enumeration protection",
+          );
+        });
+      },
+      autoSignInAfterVerification: true,
     },
     socialProviders,
     session: {
@@ -583,11 +864,13 @@ export function getAuthInstance(): AuthInstance {
       process.env.BETTER_AUTH_TRUSTED_ORIGINS?.split(",")
         .map((s) => s.trim())
         .filter(Boolean) || [],
-    advanced: cookieDomain ? {
-      defaultCookieAttributes: {
-        domain: `.${cookieDomain}`,
-      },
-    } : undefined,
+    // F-06 — explicit rate limits on /api/auth/*. Built-in defaults are
+    // NODE_ENV-gated and in-memory-only; see resolveAuthRateLimitConfig.
+    rateLimit: rateLimitConfig,
+    // F-06: the `advanced` block wires Better Auth's rate limiter to
+    // read only the trusted `x-atlas-client-ip` header that our
+    // middleware injects. See `buildAdvancedConfig` for the invariant.
+    advanced: buildAdvancedConfig(cookieDomain),
     databaseHooks: {
       member: {
         create: {

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -246,11 +246,11 @@ export function resolveRequireEmailVerification(env: NodeJS.ProcessEnv): boolean
 export async function _sendVerificationEmail(opts: { to: string; url: string }): Promise<void> {
   // All failure paths (dynamic import rejection, provider SDK throwing,
   // template assembly) must be caught here. The Better Auth callback
-  // uses `void _sendVerificationEmail(...)` for timing-attack mitigation
-  // and a floating rejection would either print to stderr with no
-  // correlation or, on `--unhandled-rejections=strict`, terminate the
-  // process — re-introducing the enumeration oracle through a 500 side
-  // channel.
+  // fires this function as fire-and-forget (with an outer `.catch(...)`
+  // for belt-and-suspenders) for timing-attack mitigation, and a
+  // floating rejection would either print to stderr with no correlation
+  // or, on `--unhandled-rejections=strict`, terminate the process —
+  // re-introducing the enumeration oracle through a 500 side channel.
   try {
     const { sendEmail } = await import("@atlas/api/lib/email/delivery");
     const result = await sendEmail({


### PR DESCRIPTION
## Summary

Bundles **F-06 (#1732)** and **F-05 (#1731)** from the [1.2.3 security sweep](https://github.com/AtlasDevHQ/atlas/issues/1718). Phase 1.5 upgraded F-06 from P2 → **P1** after reproducing 100 sequential sign-in attempts from one IP with zero throttling, and F-05's signup with an existing email returning `USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL` as a reliable enumeration oracle.

F-05 was bundled rather than deferred because Better Auth's built-in OWASP enumeration protection only activates when `requireEmailVerification: true` or `autoSignIn: false` — both are F-05's fix. Flipping them here is what actually closes the oracle; the rate limit alone only slows it down.

## What broke

**Bug 1 — no rate limiting on /api/auth/*.** Atlas's Hono `checkRateLimit` only covers `/api/v1/*`. Better Auth's catch-all had no `rateLimit` config, so its built-in defaults (disabled in dev, per-process in-memory in prod, no custom rules) were in effect. Phase 1.5 repro: 100 × POST `/api/auth/sign-in/email` from one IP → 100×401, 0×429.

**Bug 2 — signup enumerates users.** `POST /api/auth/sign-up/email` with an existing email returned HTTP 422 `{"code":"USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL"}`. New emails returned HTTP 200 with a `user` object. Same endpoint, same IP, distinguishable responses — a working oracle for testing whether any email is registered.

**Bug 3 (discovered mid-fix) — Better Auth silently skips rate limiting when it can't resolve the client IP.** Its default resolver reads `X-Forwarded-For`, which is absent in local dev / single-node Docker without a reverse proxy. Without this fix, rate limits were configured but not enforced.

## Fix shape

`packages/api/src/lib/auth/server.ts` — new pure helpers (`resolveAuthRateLimitConfig`, `resolveRequireEmailVerification`, `buildEmailAndPasswordConfig`, `buildAdvancedConfig`, `_sendVerificationEmail`) feed the Better Auth config:

\`\`\`ts
emailAndPassword: buildEmailAndPasswordConfig(requireEmailVerification),
//  enabled: true, requireEmailVerification, autoSignIn: !requireEmailVerification

emailVerification: {
  sendVerificationEmail: async ({ user, url }) => {
    // Fire-and-forget (timing-attack mitigation). _sendVerificationEmail
    // already try/catches everything; the outer .catch() is defense in
    // depth against a future refactor.
    _sendVerificationEmail({ to: user.email, url }).catch((err) => { log.warn(...) });
  },
  autoSignInAfterVerification: true,
},

rateLimit: resolveAuthRateLimitConfig(process.env, hasInternalDB()),
//  enabled (default true, env-overridable), window 60s, max 100,
//  storage: DB when available else memory,
//  customRules: /sign-in/email ≤10/min, /sign-up/email ≤5/min,
//               /forget-password ≤5/min, /reset-password ≤5/min,
//               /send-verification-email ≤5/min, /verify-email ≤10/min

advanced: buildAdvancedConfig(cookieDomain),
//  ipAddress.ipAddressHeaders: ["x-atlas-client-ip"]   // ONLY this header
\`\`\`

`packages/api/src/api/routes/auth.ts` — new middleware `withClientIpHeader(c)`:

- Strips any inbound `x-atlas-client-ip` (spoof prevention).
- When `ATLAS_TRUST_PROXY=true` or `VERCEL=1`: uses the first X-Forwarded-For entry, then X-Real-IP.
- Otherwise: uses the Bun socket address via `hono/bun`'s `getConnInfo`.
- Strips port suffixes (`1.2.3.4:54321` → `1.2.3.4`, `[::1]:54321` → `::1`) so ephemeral ports don't fragment rate-limit buckets.
- Leaves the header unset when nothing resolves — Better Auth then skips rate limiting rather than pooling attackers into a shared "unknown" bucket.

New env vars (see `.env.example`): `ATLAS_REQUIRE_EMAIL_VERIFICATION`, `ATLAS_AUTH_RATE_LIMIT_ENABLED`, `ATLAS_AUTH_RATE_LIMIT_WINDOW`, `ATLAS_AUTH_RATE_LIMIT_MAX`. All default to the secure value; overrides are strictly opt-out.

## Live smoke test (main vs. this branch)

\`\`\`
== Case 1: 100 sequential POST /api/auth/sign-in/email (wrong passwords)
main    : 100×401, 0×429
branch  :  10×401, 90×429

== Case 2: POST /api/auth/sign-up/email with an EXISTING email
main    : HTTP 422 {"message":"User already exists. Use another email.",
                    "code":"USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL"}
branch  : HTTP 200 {"token":null,"user":{"name":"T","email":"...","banned":false,"id":"..."}}
          (same shape as a new-email signup — no USER_ALREADY_EXISTS code)

== Case 3: 6 sequential POST /api/auth/sign-up/email with fresh emails from same IP
main    : all 6 × HTTP 200
branch  : 5 × 200, 6th × HTTP 429

== Case 4: POST /api/auth/sign-up/email with a NEW email
main    : `"token":"..."`        (autoSignIn creates session immediately)
branch  : `"token":null`          (verification required before session)

== Case 5: verification email dispatch
branch  : _sendVerificationEmail fires on every signup; logs a warn
          "Email verification delivery did not complete" when no
          email provider is configured (dev fallback).
\`\`\`

## Review agents

Three agents ran in parallel on the staged diff before merge — code-reviewer, silent-failure-hunter, pr-test-analyzer. Findings folded in:

- **HIGH** (code-reviewer + silent-failure-hunter): Unhandled promise rejection in the `void _sendVerificationEmail(...)` callback — the dynamic import or `sendEmail` could reject before the try/catch, and `void` doesn't attach a rejection handler. Fix: wrapped `_sendVerificationEmail`'s body in try/catch + added a belt-and-suspenders `.catch()` at the caller.
- **HIGH** (code-reviewer): Vercel/Next.js-standalone path loses the client IP because `app.fetch(req)` on their edge has no Bun server in `c.env`. Fix: auto-detect `VERCEL=1` in `shouldTrustProxyHeaders` so X-Forwarded-For is consulted.
- **HIGH** (code-reviewer): IPv6 / port-suffixed addresses fragment buckets per ephemeral port. Fix: `stripPortSuffix()` handles `IPv4:port` and bracketed IPv6, leaves bare addresses untouched.
- **HIGH** (pr-test-analyzer): `advanced.ipAddress.ipAddressHeaders` and the `autoSignIn: !requireEmailVerification` invariant had no unit coverage. Fix: extracted `buildAdvancedConfig` + `buildEmailAndPasswordConfig` as pure helpers with 7 new tests pinning both invariants.
- **HIGH** (pr-test-analyzer): `withClientIpHeader` (the trust boundary) had zero tests. Fix: 13 new tests in `auth-client-ip.test.ts` covering spoof-strip, trust-proxy toggle, multi-hop XFF, IPv6, port strip, fail-closed when nothing resolves, and `getConnInfo` throwing.
- **MEDIUM** (silent-failure-hunter): IP resolution failure logged at `debug` — a regression disabling rate limiting would vanish from production log aggregation. Fix: bumped to `warn` with a stable message, gated behind a check that `c.env` is a real object so the warn only fires on unexpected failures (not the legitimate "no server context" case in tests / Vercel).
- **LOW** (silent-failure-hunter): Invalid `ATLAS_AUTH_RATE_LIMIT_MAX`/`_WINDOW` values silently clamped to defaults. Fix: `parsePositiveInt` now `log.warn`s with the env var name when falling back.
- **LOW** (code-reviewer): `mock.module("@atlas/api/lib/email/delivery", ...)` was a partial mock — CLAUDE.md requires mocking every export. Fix: test helper now mocks `sendEmail`, `sendEmailWithTransport`, and `getEmailTransport`.

51 new unit tests total (32 in `rate-limit.test.ts` + 19 in `auth-client-ip.test.ts`), all passing.

## F-05 bundle decision

Confirmed with the user at session start: **bundle F-05**. F-05's fix is what actually activates Better Auth's enumeration protection — doing F-06 alone would only slow the oracle, not close it. Bundling risk (scope creep) was real but manageable because Atlas already has an email delivery chain — wiring `sendVerificationEmail` was ~15 lines plus test coverage.

## Audit doc

`.claude/research/security-audit-1-2-3.md` F-05 + F-06 rows flipped to fixed with this PR. F-06 post-fix smoke transcript table included inline.

## Out of scope (filed as follow-ups where noted)

- **Per-email failure throttle** (Phase 1.5 prompt mentioned "signin ≤ 5 failures / 15 min before longer lockout"). Better Auth rate limits per-IP only; per-email would need custom logic. File a follow-up if needed — the per-IP signin limit already forces attackers to rotate IPs.
- **`/forget-password` returning 404** rather than 200 in smoke case 4 — the endpoint isn't wired because `sendResetPassword` isn't configured. Rate limit still fires before the route handler, so this fix works correctly, but the endpoint itself should be enabled separately (passwords reset are currently non-functional).
- **`sessions.test.ts` pre-existing failure** — `SENSITIVE_PATTERNS` not exported from `packages/api/src/lib/security.ts`. Predates this branch (confirmed via `git stash` check). Will file an issue.

## Test plan

- [x] Unit tests: `bun test packages/api/src/lib/auth/__tests__/rate-limit.test.ts` — 32 pass
- [x] Unit tests: `bun test packages/api/src/api/__tests__/auth-client-ip.test.ts` — 19 pass
- [x] Sibling auth tests: `auth.test.ts`, `server.test.ts`, `bootstrap.test.ts` — all pass
- [x] `bun run lint` — clean
- [x] `bun x tsgo --noEmit -p packages/api/tsconfig.json` — no new errors
- [x] Live smoke test (all 3 Phase 1.5 cases) — pass
- [ ] CI green