### PR TITLE
fix(security): P1 — block cross-tenant dashboards org-scoped share reads (#1736)

### DIFF
--- a/.claude/research/security-audit-1-2-3.md
+++ b/.claude/research/security-audit-1-2-3.md
@@ -205,9 +205,11 @@ HTTP 200
 "content":"SECRET: Org-A Q2 revenue is 12M USD (do not leak)", ...}]}
 ```
 
-User B was **not** a member of Org A, had `orgs=0` in the member table, and still received the full conversation body including the sensitive message content. Severity stays **P1**. Dashboard equivalent was not tested but already has the org-membership check in code.
+User B was **not** a member of Org A, had `orgs=0` in the member table, and still received the full conversation body including the sensitive message content. Severity stays **P1**. Dashboard equivalent was not tested at Phase 1.5 time; code-read showed the same truthy-check pattern — see the dashboards extension below.
 
-**Fix:** `publicConversations.openapi(getSharedConversationRoute, ...)` now performs a fail-closed org-membership check after the auth check — `if (!result.data.orgId || authResult.user?.activeOrganizationId !== result.data.orgId) → 403 forbidden`. The lib layer `getSharedConversation` was extended to return `orgId` (SELECT `org_id`) so the route can enforce membership. Fail-closed rather than truthy-check because the schema allows `share_mode='org'` with `org_id IS NULL` and `createShareLink` never stamps `org_id` — see follow-ups #1736 (dashboards has the same truthy-check bug) and #1737 (add `share_mode='org' → org_id IS NOT NULL` CHECK constraint).
+**Fix:** `publicConversations.openapi(getSharedConversationRoute, ...)` now performs a fail-closed org-membership check after the auth check — `if (!result.data.orgId || authResult.user?.activeOrganizationId !== result.data.orgId) → 403 forbidden`. The lib layer `getSharedConversation` was extended to return `orgId` (SELECT `org_id`) so the route can enforce membership. Fail-closed rather than truthy-check because the schema allows `share_mode='org'` with `org_id IS NULL` and `createShareLink` never stamps `org_id` — see follow-ups #1736 (dashboards had the same truthy-check bug — fixed in PR [[TBD-1736]]) and #1737 (add `share_mode='org' → org_id IS NOT NULL` CHECK constraint).
+
+**Dashboards extension (#1736):** `publicDashboards.openapi(getSharedDashboardRoute, ...)` had the structurally identical truthy-check bug at `dashboards.ts:1171` (`if (result.data.orgId && ...)`) and has been ported to the same fail-closed pattern. No lib-layer change was needed — `rowToDashboard` already maps `org_id` through to the `DashboardWithCards` type via the existing `SELECT *`. Regression tests at `packages/api/src/api/__tests__/dashboards.test.ts` pin the four attack cases (unauth, no-active-org, wrong-org, orgId=null) plus the positive control.
 
 Post-fix smoke test on live stack (`/api/public/conversations/<org-scoped-token>`):
 

--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -677,5 +677,173 @@ describe("dashboard routes", () => {
       );
       expect(response.status).toBe(404);
     });
+
+    // -----------------------------------------------------------------------
+    // Org-scoped share regression tests (#1736 — F-01 class fail-open)
+    //
+    // Mirror the conversations.ts regression set from PR #1738: before the
+    // fix, the route used a truthy-check (`result.data.orgId && ...`) that
+    // short-circuited when the row had `orgId=null`, letting any authenticated
+    // caller from any org read org-scoped dashboards. These pin the four
+    // attack cases plus the positive control.
+    // -----------------------------------------------------------------------
+
+    it("returns 403 auth_required for org-scoped shares when unauthenticated (#1736)", async () => {
+      mockGetSharedDashboard.mockResolvedValueOnce({
+        ok: true,
+        data: {
+          ...mockDashboardData,
+          orgId: "org-A",
+          cards: [mockCardData],
+          shareMode: "org",
+        },
+      });
+      mockAuthenticateRequest.mockResolvedValueOnce({
+        authenticated: false as const,
+        mode: "simple-key" as const,
+        status: 401,
+        error: "no_credentials",
+      });
+
+      const response = await app.fetch(
+        new Request("http://localhost/api/public/dashboards/abc123def456ghi789jkl"),
+      );
+      expect(response.status).toBe(403);
+
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("auth_required");
+      expect(body).not.toHaveProperty("cards");
+      expect(body).not.toHaveProperty("title");
+    });
+
+    it("returns 403 forbidden for org-scoped shares when requester has no active org (#1736)", async () => {
+      mockGetSharedDashboard.mockResolvedValueOnce({
+        ok: true,
+        data: {
+          ...mockDashboardData,
+          orgId: "org-A",
+          cards: [mockCardData],
+          shareMode: "org",
+        },
+      });
+      mockAuthenticateRequest.mockResolvedValueOnce({
+        authenticated: true as const,
+        mode: "simple-key" as const,
+        // No activeOrganizationId — freshly signed-up user with zero memberships
+        user: { id: "u-orphan", label: "no-org@test.com", mode: "simple-key" as const, role: "member" as const },
+      });
+
+      const response = await app.fetch(
+        new Request("http://localhost/api/public/dashboards/abc123def456ghi789jkl"),
+      );
+      expect(response.status).toBe(403);
+
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("forbidden");
+      expect(body).not.toHaveProperty("cards");
+      expect(body).not.toHaveProperty("title");
+    });
+
+    it("returns 403 forbidden for org-scoped shares when requester belongs to a different org (#1736)", async () => {
+      mockGetSharedDashboard.mockResolvedValueOnce({
+        ok: true,
+        data: {
+          ...mockDashboardData,
+          orgId: "org-A",
+          cards: [mockCardData],
+          shareMode: "org",
+        },
+      });
+      mockAuthenticateRequest.mockResolvedValueOnce({
+        authenticated: true as const,
+        mode: "simple-key" as const,
+        user: {
+          id: "u-other",
+          label: "other-org-user@test.com",
+          mode: "simple-key" as const,
+          role: "member" as const,
+          activeOrganizationId: "org-B",
+        },
+      });
+
+      const response = await app.fetch(
+        new Request("http://localhost/api/public/dashboards/abc123def456ghi789jkl"),
+      );
+      expect(response.status).toBe(403);
+
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("forbidden");
+      expect(body).not.toHaveProperty("cards");
+      expect(body).not.toHaveProperty("title");
+    });
+
+    it("returns 200 for org-scoped shares when requester belongs to the dashboard's org (#1736)", async () => {
+      mockGetSharedDashboard.mockResolvedValueOnce({
+        ok: true,
+        data: {
+          ...mockDashboardData,
+          orgId: "org-A",
+          cards: [mockCardData],
+          shareMode: "org",
+        },
+      });
+      mockAuthenticateRequest.mockResolvedValueOnce({
+        authenticated: true as const,
+        mode: "simple-key" as const,
+        user: {
+          id: "u-member",
+          label: "org-a-member@test.com",
+          mode: "simple-key" as const,
+          role: "member" as const,
+          activeOrganizationId: "org-A",
+        },
+      });
+
+      const response = await app.fetch(
+        new Request("http://localhost/api/public/dashboards/abc123def456ghi789jkl"),
+      );
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as { title: string; cards: unknown[]; shareMode: string };
+      expect(body.shareMode).toBe("org");
+      expect(body.title).toBe("Revenue Dashboard");
+      expect(body.cards).toHaveLength(1);
+    });
+
+    // Fail-closed regression for #1736 — the schema allows share_mode='org'
+    // with org_id=NULL (createShareLink does not stamp orgId). Without a
+    // fail-closed check, any authenticated caller could read such a row.
+    it("returns 403 for org-scoped shares when the dashboard has no orgId (#1736)", async () => {
+      mockGetSharedDashboard.mockResolvedValueOnce({
+        ok: true,
+        data: {
+          ...mockDashboardData,
+          orgId: null,
+          cards: [mockCardData],
+          shareMode: "org",
+        },
+      });
+      mockAuthenticateRequest.mockResolvedValueOnce({
+        authenticated: true as const,
+        mode: "simple-key" as const,
+        user: {
+          id: "u-any",
+          label: "any-user@test.com",
+          mode: "simple-key" as const,
+          role: "member" as const,
+          activeOrganizationId: "org-A",
+        },
+      });
+
+      const response = await app.fetch(
+        new Request("http://localhost/api/public/dashboards/abc123def456ghi789jkl"),
+      );
+      expect(response.status).toBe(403);
+
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("forbidden");
+      expect(body).not.toHaveProperty("cards");
+      expect(body).not.toHaveProperty("title");
+    });
   });
 });

--- a/packages/api/src/api/routes/dashboards.ts
+++ b/packages/api/src/api/routes/dashboards.ts
@@ -1167,8 +1167,16 @@ publicDashboards.openapi(getSharedDashboardRoute, async (c) => {
     if (!authResult.authenticated) {
       return c.json({ error: "auth_required", message: "This shared dashboard requires authentication.", requestId }, 403);
     }
-    // Verify authenticated user belongs to the dashboard's org
-    if (result.data.orgId && authResult.user?.activeOrganizationId !== result.data.orgId) {
+    // Verify authenticated user belongs to the dashboard's org. Fail closed
+    // when the dashboard row has no orgId: the schema allows NULL org_id with
+    // share_mode='org' (createShareLink does not stamp orgId), so a truthy-check
+    // here would silently fall through and leak the dashboard cross-tenant —
+    // same class of bug as #1727 (conversations). See #1736.
+    if (!result.data.orgId || authResult.user?.activeOrganizationId !== result.data.orgId) {
+      log.warn(
+        { requestId, token, hasOrgId: Boolean(result.data.orgId) },
+        "Org-scoped dashboard share access denied — requester is not a member of the dashboard's org",
+      );
       return c.json({ error: "forbidden", message: "You do not have access to this dashboard.", requestId }, 403);
     }
   }


### PR DESCRIPTION
## Summary

Port the F-01 cross-tenant share leak fix (shipped for conversations in PR #1738 / #1727) to the **structurally identical bug on the public dashboards share route**. Reviewer flagged the same truthy-check pattern during F-01's review; this is the dashboards half of that finding.

**The bug (`packages/api/src/api/routes/dashboards.ts:1171`)**:
```ts
if (result.data.orgId && authResult.user?.activeOrganizationId !== result.data.orgId) {
  return c.json({ error: "forbidden", ... }, 403);
}
```
The `result.data.orgId &&` short-circuits when `org_id IS NULL`. The schema allows `share_mode='org'` with `org_id=NULL` (no `CHECK` constraint yet — that's #1737, separate issue), and `createShareLink` never stamps `org_id` when flipping to org mode. Any authenticated caller from any org could read an org-scoped dashboard with NULL orgId.

**The fix (fail-closed)**:
```ts
if (!result.data.orgId || authResult.user?.activeOrganizationId !== result.data.orgId) {
  log.warn({ requestId, token, hasOrgId: Boolean(result.data.orgId) }, "...");
  return c.json({ error: "forbidden", ... }, 403);
}
```
No lib-layer change needed: `rowToDashboard` already maps `org_id` via the existing `SELECT *`, unlike the conversations fix which had to extend an explicit column list.

## Test-case matrix

| # | Scenario | Expected |
|---|----------|----------|
| 1 | Unauthenticated | `403 auth_required` |
| 2 | Authenticated, no active org | `403 forbidden` |
| 3 | Authenticated, different org | `403 forbidden` |
| 4 | Authenticated, correct org (positive control) | `200` |
| 5 | `orgId=null` fail-closed branch | `403 forbidden` |

All five pinned in `packages/api/src/api/__tests__/dashboards.test.ts`. Response body asserts confirm no leak of `title` / `cards` on any 403 path.

## Out of scope

- **Schema `CHECK (share_mode='org' → org_id IS NOT NULL)`** — tracked in #1737. Needs migration + backfill + write-path defense.
- **`createShareLink` write-path orgId stamp** — same ticket.

This PR is the route-layer defense-in-depth only, matching what PR #1738 landed for conversations.

## CI gates

- `bun run lint` — pass
- `bun run type` — pass
- `bun run test` — pass (34 dashboards tests, full suite green)
- `bun x syncpack lint` — pass
- template drift — pass

## Review

`code-reviewer` agent ran on the diff pre-PR — no high-confidence issues, cleared "Ship it." All five regression tests exercise the attack cases plus positive control; `mockAuthenticateRequest.mockReset()` in `beforeEach` keeps isolation.

## Test plan

- [ ] Rebuild locally: `bun install && bun run test -- packages/api/src/api/__tests__/dashboards.test.ts` → 34 pass
- [ ] After merge, smoke-test on live stack with an org-scoped dashboard share and a User B from a different org → expect 403 `forbidden`

Closes #1736
Related: #1727, PR #1738 (conversations template), #1737 (schema CHECK follow-up), #1718 (1.2.3 security sweep parent)