### PR TITLE
fix(security): add CHECK constraint share_mode='org' requires org_id (#1737)

### DIFF
--- a/packages/api/src/api/__tests__/conversations.test.ts
+++ b/packages/api/src/api/__tests__/conversations.test.ts
@@ -14,12 +14,13 @@ import {
   type Mock,
 } from "bun:test";
 import type { AuthResult } from "@atlas/api/lib/auth/types";
-import type { CrudResult, CrudDataResult } from "@atlas/api/lib/conversations";
+import type { CrudResult, CrudDataResult, ShareConversationResult } from "@atlas/api/lib/conversations";
 import type { ConversationWithMessages } from "@atlas/api/lib/conversation-types";
 
-import type { ShareMode } from "@useatlas/types/share";
-
-type ShareResult = CrudDataResult<{ token: string; expiresAt: string | null; shareMode: ShareMode }>;
+// ShareConversationResult is a superset of CrudDataResult with an extra
+// `invalid_org_scope` reason (#1737). Use the canonical type so fake
+// results can exercise the new failure mode.
+type ShareResult = ShareConversationResult;
 
 // --- Mocks ---
 
@@ -792,6 +793,26 @@ describe("conversations routes", () => {
 
       const body = await response.json() as Record<string, unknown>;
       expect(body.error).toBe("internal_error");
+    });
+
+    // Regression for #1737 — the DB CHECK (chk_org_scoped_share, 0034)
+    // forbids share_mode='org' with org_id=NULL, but the route should
+    // surface a structured 400 instead of a Postgres error when
+    // shareConversation reports `invalid_org_scope`.
+    it("returns 400 when shareConversation reports invalid_org_scope (#1737)", async () => {
+      mockShareConversation.mockResolvedValueOnce({ ok: false, reason: "invalid_org_scope" });
+
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/conversations/${VALID_ID}/share`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ shareMode: "org" }),
+        }),
+      );
+      expect(response.status).toBe(400);
+      const body = await response.json() as Record<string, unknown>;
+      expect(body.error).toBe("invalid_request");
+      expect((body.message as string).toLowerCase()).toContain("organization");
     });
 
     it("returns 400 for malformed JSON body", async () => {

--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -609,6 +609,28 @@ describe("dashboard routes", () => {
       const body = (await response.json()) as { token: string };
       expect(body.token).toBe("share-token-123");
     });
+
+    // Regression for #1737 — the DB CHECK (chk_org_scoped_share, 0034)
+    // forbids share_mode='org' with org_id=NULL, but the route should
+    // return a structured 400 instead of surfacing a Postgres error when
+    // shareDashboard reports `invalid_org_scope`.
+    it("returns 400 when shareDashboard reports invalid_org_scope (#1737)", async () => {
+      mockShareDashboard.mockResolvedValueOnce({
+        ok: false,
+        reason: "invalid_org_scope",
+      });
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/share`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ shareMode: "org" }),
+        }),
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string; message: string };
+      expect(body.error).toBe("invalid_request");
+      expect(body.message).toContain("no organization");
+    });
   });
 
   describe("DELETE /api/v1/dashboards/:id/share", () => {

--- a/packages/api/src/api/routes/conversations.ts
+++ b/packages/api/src/api/routes/conversations.ts
@@ -1105,6 +1105,12 @@ conversations.openapi(shareConversationRoute, async (c) => {
       shareMode: opts?.shareMode,
     }));
     if (!shareResult.ok) {
+      if (shareResult.reason === "invalid_org_scope") {
+        return c.json({
+          error: "invalid_request",
+          message: "Cannot create an org-scoped share for a conversation with no organization.",
+        }, 400);
+      }
       const fail = crudFailResponse(shareResult.reason, requestId);
       return c.json(fail.body, fail.status);
     }

--- a/packages/api/src/api/routes/dashboards.ts
+++ b/packages/api/src/api/routes/dashboards.ts
@@ -906,6 +906,12 @@ authed.openapi(
       }));
 
       if (!result.ok) {
+        if (result.reason === "invalid_org_scope") {
+          return c.json({
+            error: "invalid_request",
+            message: "Cannot create an org-scoped share for a dashboard with no organization.",
+          }, 400);
+        }
         const fail = crudFailResponse(result.reason, requestId);
         return c.json(fail.body, fail.status);
       }

--- a/packages/api/src/lib/__tests__/conversations.test.ts
+++ b/packages/api/src/lib/__tests__/conversations.test.ts
@@ -674,17 +674,50 @@ describe("conversations module", () => {
       }
     });
 
-    it("sets shareMode to org when specified", async () => {
+    it("sets shareMode to org when specified (conversation has org_id)", async () => {
       enableInternalDB();
-      setResults({ rows: [{ share_token: "tok" }] });
+      // First query: preflight org_id lookup (#1737 invariant).
+      // Second query: the UPDATE that writes the share token.
+      setResults(
+        { rows: [{ org_id: "org-A" }] },
+        { rows: [{ share_token: "tok" }] },
+      );
 
       const result = await shareConversation("c1", null, { shareMode: "org" });
       expect(result.ok).toBe(true);
       if (result.ok) {
         expect(result.data.shareMode).toBe("org");
       }
-      // Verify the SQL includes share_mode param
-      expect(queryCalls[0].params?.[2]).toBe("org");
+      // First call is the preflight SELECT, second is the UPDATE.
+      expect(queryCalls[0].sql).toContain("SELECT org_id FROM conversations");
+      expect(queryCalls[1].sql).toContain("UPDATE conversations");
+      expect(queryCalls[1].params?.[2]).toBe("org");
+    });
+
+    // Regression guard for #1737. share_mode='org' on a conversation with
+    // org_id=NULL is the F-01 bug-class — the DB CHECK constraint
+    // (chk_org_scoped_share, 0034) enforces this at the schema level; this
+    // test pins the same rejection at the application layer so the route
+    // can surface a structured 400 instead of relying on a Postgres error.
+    it("rejects shareMode='org' with invalid_org_scope when conversation has no org_id (#1737)", async () => {
+      enableInternalDB();
+      setResults({ rows: [{ org_id: null }] });
+
+      const result = await shareConversation("c1", "u1", { shareMode: "org" });
+      expect(result).toEqual({ ok: false, reason: "invalid_org_scope" });
+      // Ensure the UPDATE never ran — we short-circuited on the preflight.
+      expect(queryCalls).toHaveLength(1);
+      expect(queryCalls[0].sql).toContain("SELECT org_id FROM conversations");
+    });
+
+    it("returns not_found for shareMode='org' preflight when conversation does not exist (#1737)", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      const result = await shareConversation("missing", "u1", { shareMode: "org" });
+      expect(result).toEqual({ ok: false, reason: "not_found" });
+      // Preflight ran but no UPDATE.
+      expect(queryCalls).toHaveLength(1);
     });
 
     it("returns null expiresAt for 'never'", async () => {

--- a/packages/api/src/lib/__tests__/dashboards-share.test.ts
+++ b/packages/api/src/lib/__tests__/dashboards-share.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Application-level tests for the #1737 DB CHECK invariant at the
+ * shareDashboard callsite.
+ *
+ * The DB constraint (chk_org_scoped_share, 0034) guarantees
+ * share_mode='org' implies org_id IS NOT NULL. shareDashboard enforces
+ * the same invariant at the application layer so the route returns a
+ * structured `invalid_org_scope` reason instead of a Postgres error.
+ *
+ * Uses the _resetPool(mockPool) injection pattern from conversations.test.ts.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { _resetPool, type InternalPool } from "../db/internal";
+import { shareDashboard } from "../dashboards";
+
+// ---------------------------------------------------------------------------
+// Mock pool
+// ---------------------------------------------------------------------------
+
+let queryCalls: Array<{ sql: string; params?: unknown[] }> = [];
+let queryResults: Array<{ rows: Record<string, unknown>[] }> = [];
+let queryResultIndex = 0;
+let queryThrow: Error | null = null;
+
+const mockPool: InternalPool = {
+  query: async (sql: string, params?: unknown[]) => {
+    if (queryThrow) throw queryThrow;
+    queryCalls.push({ sql, params });
+    const result = queryResults[queryResultIndex] ?? { rows: [] };
+    queryResultIndex++;
+    return result;
+  },
+  async connect() {
+    return { query: async () => ({ rows: [] }), release() {} };
+  },
+  end: async () => {},
+  on: () => {},
+};
+
+function enableInternalDB() {
+  process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+  _resetPool(mockPool);
+}
+
+function setResults(...results: Array<{ rows: Record<string, unknown>[] }>) {
+  queryResults = results;
+  queryResultIndex = 0;
+}
+
+describe("dashboards sharing — #1737 invariant", () => {
+  const origDbUrl = process.env.DATABASE_URL;
+
+  beforeEach(() => {
+    queryCalls = [];
+    queryResults = [];
+    queryResultIndex = 0;
+    queryThrow = null;
+    delete process.env.DATABASE_URL;
+    _resetPool(null);
+  });
+
+  afterEach(() => {
+    if (origDbUrl) process.env.DATABASE_URL = origDbUrl;
+    else delete process.env.DATABASE_URL;
+    _resetPool(null);
+  });
+
+  describe("shareDashboard()", () => {
+    it("rejects shareMode='org' with invalid_org_scope when caller has no orgId (#1737)", async () => {
+      enableInternalDB();
+
+      const result = await shareDashboard("d1", { orgId: null }, { shareMode: "org" });
+      expect(result).toEqual({ ok: false, reason: "invalid_org_scope" });
+      // Short-circuited — no DB queries ran at all.
+      expect(queryCalls).toHaveLength(0);
+    });
+
+    it("rejects shareMode='org' with invalid_org_scope when dashboard row has no org_id (#1737)", async () => {
+      enableInternalDB();
+      // First query is the preflight SELECT for the dashboard's org_id.
+      setResults({ rows: [{ org_id: null }] });
+
+      const result = await shareDashboard("d1", { orgId: "org-A" }, { shareMode: "org" });
+      expect(result).toEqual({ ok: false, reason: "invalid_org_scope" });
+      // Preflight ran, UPDATE did not.
+      expect(queryCalls).toHaveLength(1);
+      expect(queryCalls[0].sql).toContain("SELECT org_id FROM dashboards");
+    });
+
+    it("returns not_found when the org-scoped share preflight finds no matching row", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      const result = await shareDashboard("missing", { orgId: "org-A" }, { shareMode: "org" });
+      expect(result).toEqual({ ok: false, reason: "not_found" });
+      expect(queryCalls).toHaveLength(1);
+    });
+
+    it("proceeds with the UPDATE when org-scoped share is valid (dashboard has org_id)", async () => {
+      enableInternalDB();
+      setResults(
+        { rows: [{ org_id: "org-A" }] },
+        { rows: [{ share_token: "token-ok" }] },
+      );
+
+      const result = await shareDashboard("d1", { orgId: "org-A" }, { shareMode: "org" });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data.shareMode).toBe("org");
+        expect(result.data.token).toBe("token-ok");
+      }
+      expect(queryCalls).toHaveLength(2);
+      expect(queryCalls[0].sql).toContain("SELECT org_id FROM dashboards");
+      expect(queryCalls[1].sql).toContain("UPDATE dashboards");
+    });
+
+    it("skips the preflight entirely for shareMode='public' (no extra query)", async () => {
+      // Public shares don't need the org_id check — the invariant only
+      // applies to share_mode='org'. Verify we don't pay the preflight
+      // cost on the common path.
+      enableInternalDB();
+      setResults({ rows: [{ share_token: "public-tok" }] });
+
+      const result = await shareDashboard("d1", { orgId: "org-A" }, { shareMode: "public" });
+      expect(result.ok).toBe(true);
+      // Exactly one query — the UPDATE.
+      expect(queryCalls).toHaveLength(1);
+      expect(queryCalls[0].sql).toContain("UPDATE dashboards");
+    });
+
+    it("returns { ok: false, reason: 'no_db' } when no DB", async () => {
+      const result = await shareDashboard("d1", { orgId: "org-A" }, { shareMode: "org" });
+      expect(result).toEqual({ ok: false, reason: "no_db" });
+    });
+
+    it("returns { ok: false, reason: 'error' } when the preflight throws", async () => {
+      enableInternalDB();
+      queryThrow = new Error("connection lost");
+      const result = await shareDashboard("d1", { orgId: "org-A" }, { shareMode: "org" });
+      expect(result).toEqual({ ok: false, reason: "error" });
+    });
+  });
+});

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -279,6 +279,7 @@ describe("migrateAuthTables", () => {
             { name: "0031_abuse_events_enum_checks.sql" },
             { name: "0032_backups_status_check.sql" },
             { name: "0033_custom_domains_dns_verification.sql" },
+            { name: "0034_share_mode_org_requires_org_id.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/conversations.ts
+++ b/packages/api/src/lib/conversations.ts
@@ -666,17 +666,58 @@ function computeExpiresAt(expiresIn?: ShareExpiryKey | null): string | null {
   return new Date(Date.now() + seconds * 1000).toISOString();
 }
 
-/** Enable sharing for a conversation. Returns the share token. Auth-scoped when userId is provided. */
+/** Failure reason for shareConversation — extends CrudFailReason with the invariant violation. */
+export type ShareConversationFailReason = CrudFailReason | "invalid_org_scope";
+
+/** Result type for shareConversation — carries the broader failure enum. */
+export type ShareConversationResult =
+  | { ok: true; data: { token: string; expiresAt: string | null; shareMode: ShareMode } }
+  | { ok: false; reason: ShareConversationFailReason };
+
+/**
+ * Enable sharing for a conversation. Returns the share token. Auth-scoped
+ * when userId is provided.
+ *
+ * Rejects `share_mode='org'` requests when the target conversation has no
+ * `org_id`. This is the same invariant the DB CHECK constraint
+ * (`chk_org_scoped_share`, 0034) enforces — raising it at the application
+ * layer surfaces a structured `invalid_org_scope` reason instead of the
+ * caller having to match on a Postgres error string. See #1737.
+ */
 export async function shareConversation(
   id: string,
   userId?: string | null,
   opts?: { expiresIn?: ShareExpiryKey | null; shareMode?: ShareMode },
-): Promise<CrudDataResult<{ token: string; expiresAt: string | null; shareMode: ShareMode }>> {
+): Promise<ShareConversationResult> {
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
   try {
     const token = generateShareToken();
     const expiresAt = computeExpiresAt(opts?.expiresIn);
     const shareMode: ShareMode = opts?.shareMode ?? "public";
+
+    // Belt-and-suspenders for the DB CHECK (#1737): if the caller asks for
+    // org-scoped sharing, the target conversation must already have an
+    // org_id, otherwise the share is meaningless and opens F-01.
+    if (shareMode === "org") {
+      const orgRows = userId
+        ? await internalQuery<{ org_id: string | null }>(
+            `SELECT org_id FROM conversations WHERE id = $1 AND user_id = $2`,
+            [id, userId],
+          )
+        : await internalQuery<{ org_id: string | null }>(
+            `SELECT org_id FROM conversations WHERE id = $1`,
+            [id],
+          );
+      if (orgRows.length === 0) return { ok: false, reason: "not_found" };
+      if (!orgRows[0].org_id) {
+        log.warn(
+          { conversationId: id },
+          "Refusing to create org-scoped share: conversation has no org_id (#1737)",
+        );
+        return { ok: false, reason: "invalid_org_scope" };
+      }
+    }
+
     const rows = userId
       ? await internalQuery<{ share_token: string }>(
           `UPDATE conversations SET share_token = $1, share_expires_at = $2, share_mode = $3, updated_at = now()

--- a/packages/api/src/lib/dashboards.ts
+++ b/packages/api/src/lib/dashboards.ts
@@ -461,16 +461,64 @@ export async function getCard(
 // Sharing
 // ---------------------------------------------------------------------------
 
+/** Failure reason for shareDashboard — extends CrudFailReason with the invariant violation. */
+export type ShareDashboardFailReason = CrudFailReason | "invalid_org_scope";
+
+/** Result type for shareDashboard — carries the broader failure enum. */
+export type ShareDashboardResult =
+  | { ok: true; data: { token: string; expiresAt: string | null; shareMode: ShareMode } }
+  | { ok: false; reason: ShareDashboardFailReason };
+
+/**
+ * Create or refresh a dashboard share link. Scope-bound to the caller's
+ * org via `orgScopeClause`.
+ *
+ * Rejects `share_mode='org'` when the caller's scope has no orgId or the
+ * dashboard row has no org_id. Mirrors the conversations check — same
+ * DB-level CHECK (`chk_org_scoped_share`, 0034) enforces the invariant,
+ * but surfacing it as `invalid_org_scope` lets the route layer respond
+ * with a friendly 400 instead of relying on a Postgres error string. See
+ * #1737.
+ */
 export async function shareDashboard(
   id: string,
   scope: { orgId?: string | null },
   opts?: { expiresIn?: ShareExpiryKey | null; shareMode?: ShareMode },
-): Promise<CrudDataResult<{ token: string; expiresAt: string | null; shareMode: ShareMode }>> {
+): Promise<ShareDashboardResult> {
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
   try {
     const token = generateShareToken();
     const expiresAt = computeExpiresAt(opts?.expiresIn);
     const shareMode: ShareMode = opts?.shareMode ?? "public";
+
+    // Belt-and-suspenders for the DB CHECK (#1737): refuse org-scoped
+    // shares without a concrete orgId, either from scope or the row.
+    if (shareMode === "org") {
+      if (!scope.orgId) {
+        log.warn(
+          { dashboardId: id },
+          "Refusing to create org-scoped dashboard share: caller has no orgId (#1737)",
+        );
+        return { ok: false, reason: "invalid_org_scope" };
+      }
+      // Verify the dashboard row itself has an org_id. orgScopeClause
+      // already filters to matching rows, but a callsite that relaxes
+      // scope in the future should still hit this guard.
+      const params: unknown[] = [id];
+      const lookupOrg = orgScopeClause(scope.orgId, params, 2);
+      const orgRows = await internalQuery<{ org_id: string | null }>(
+        `SELECT org_id FROM dashboards WHERE id = $1 AND ${lookupOrg.clause} AND deleted_at IS NULL`,
+        params,
+      );
+      if (orgRows.length === 0) return { ok: false, reason: "not_found" };
+      if (!orgRows[0].org_id) {
+        log.warn(
+          { dashboardId: id },
+          "Refusing to create org-scoped dashboard share: dashboard has no org_id (#1737)",
+        );
+        return { ok: false, reason: "invalid_org_scope" };
+      }
+    }
 
     const params: unknown[] = [token, expiresAt, shareMode, id];
     const org = orgScopeClause(scope.orgId, params, 5);

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -79,7 +79,7 @@ describe("runMigrations", () => {
 
     const count = await runMigrations(pool);
 
-    expect(count).toBe(34);
+    expect(count).toBe(35);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -142,6 +142,7 @@ describe("runMigrations", () => {
         "0031_abuse_events_enum_checks.sql",
         "0032_backups_status_check.sql",
         "0033_custom_domains_dns_verification.sql",
+        "0034_share_mode_org_requires_org_id.sql",
       ],
     });
 
@@ -451,6 +452,85 @@ describe("0032_backups_status_check.sql", () => {
       /DO\s*\$\$\s*BEGIN[\s\S]*?EXCEPTION\s+WHEN\s+duplicate_object\s+THEN\s+NULL;\s*END\s*\$\$\s*;/gi,
     ) ?? [];
     expect(idempotentBlocks.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: 0034_share_mode_org_requires_org_id.sql
+// ---------------------------------------------------------------------------
+
+describe("0034_share_mode_org_requires_org_id.sql", () => {
+  const filePath = path.join(MIGRATIONS_DIR, "0034_share_mode_org_requires_org_id.sql");
+
+  it("file exists in the migrations directory", () => {
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  it("remediates bad rows on both tables before adding the CHECK constraint", () => {
+    // Ordering is load-bearing: a pre-drifted row with share_mode='org' and
+    // org_id IS NULL would block the ADD CONSTRAINT if the remediation ran
+    // second. See 0031 / 0032 for the same pattern.
+    const sql = fs.readFileSync(filePath, "utf-8");
+
+    const updateConvIdx = sql.search(/UPDATE\s+conversations[\s\S]*?share_mode\s*=\s*'public'/i);
+    const updateDashIdx = sql.search(/UPDATE\s+dashboards[\s\S]*?share_mode\s*=\s*'public'/i);
+    const checkConvIdx = sql.search(/ALTER\s+TABLE\s+conversations[\s\S]*?CONSTRAINT\s+chk_org_scoped_share/i);
+    const checkDashIdx = sql.search(/ALTER\s+TABLE\s+dashboards[\s\S]*?CONSTRAINT\s+chk_org_scoped_share/i);
+
+    expect(updateConvIdx).toBeGreaterThan(-1);
+    expect(updateDashIdx).toBeGreaterThan(-1);
+    expect(checkConvIdx).toBeGreaterThan(-1);
+    expect(checkDashIdx).toBeGreaterThan(-1);
+
+    expect(updateConvIdx).toBeLessThan(checkConvIdx);
+    expect(updateDashIdx).toBeLessThan(checkDashIdx);
+  });
+
+  it("targets exactly the share_mode='org' AND org_id IS NULL predicate in both remediations", () => {
+    const sql = fs.readFileSync(filePath, "utf-8");
+
+    const convPredicate = /UPDATE\s+conversations\s+SET\s+share_mode\s*=\s*'public'\s+WHERE\s+share_mode\s*=\s*'org'\s+AND\s+org_id\s+IS\s+NULL/i;
+    const dashPredicate = /UPDATE\s+dashboards\s+SET\s+share_mode\s*=\s*'public'\s+WHERE\s+share_mode\s*=\s*'org'\s+AND\s+org_id\s+IS\s+NULL/i;
+
+    expect(sql).toMatch(convPredicate);
+    expect(sql).toMatch(dashPredicate);
+  });
+
+  it("encodes the CHECK as `share_mode <> 'org' OR org_id IS NOT NULL` on both tables", () => {
+    // This is the invariant from #1737 — any deviation (e.g. swapping the
+    // operator) would silently drop enforcement for rows with share_mode
+    // <> 'org', which is fine, but an equality check would block valid
+    // 'public' rows. Pin the exact shape.
+    const sql = fs.readFileSync(filePath, "utf-8");
+    const convCheck = /ALTER\s+TABLE\s+conversations\s+ADD\s+CONSTRAINT\s+chk_org_scoped_share\s+CHECK\s*\(\s*share_mode\s*<>\s*'org'\s+OR\s+org_id\s+IS\s+NOT\s+NULL\s*\)/i;
+    const dashCheck = /ALTER\s+TABLE\s+dashboards\s+ADD\s+CONSTRAINT\s+chk_org_scoped_share\s+CHECK\s*\(\s*share_mode\s*<>\s*'org'\s+OR\s+org_id\s+IS\s+NOT\s+NULL\s*\)/i;
+
+    expect(sql).toMatch(convCheck);
+    expect(sql).toMatch(dashCheck);
+  });
+
+  it("emits a RAISE NOTICE for each table when drift rows are coerced", () => {
+    // Operators need to see "we just flipped N shares back to public" —
+    // silent rewrites are the failure mode 0031 shipped with.
+    // Strip comment lines before matching so the header's prose
+    // reference to RAISE NOTICE doesn't inflate the count.
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const sql = raw.split("\n").filter((line) => !line.trim().startsWith("--")).join("\n");
+    const notices = sql.match(/RAISE\s+NOTICE\s+'[^']*coerced/gi) ?? [];
+    expect(notices.length).toBe(2);
+
+    const diagnostics = sql.match(/GET\s+DIAGNOSTICS[^;]*ROW_COUNT/gi) ?? [];
+    expect(diagnostics.length).toBe(2);
+  });
+
+  it("wraps both ADD CONSTRAINTs in idempotent DO $$ … duplicate_object guards", () => {
+    const sql = fs.readFileSync(filePath, "utf-8");
+    // Two idempotency guards — one per constraint. The RAISE NOTICE
+    // blocks are separate DO $$ without an EXCEPTION clause.
+    const idempotentBlocks = sql.match(
+      /DO\s*\$\$\s*BEGIN[\s\S]*?EXCEPTION\s+WHEN\s+duplicate_object\s+THEN\s+NULL;\s*END\s*\$\$\s*;/gi,
+    ) ?? [];
+    expect(idempotentBlocks.length).toBe(2);
   });
 });
 

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -489,11 +489,24 @@ describe("0034_share_mode_org_requires_org_id.sql", () => {
   it("targets exactly the share_mode='org' AND org_id IS NULL predicate in both remediations", () => {
     const sql = fs.readFileSync(filePath, "utf-8");
 
-    const convPredicate = /UPDATE\s+conversations\s+SET\s+share_mode\s*=\s*'public'\s+WHERE\s+share_mode\s*=\s*'org'\s+AND\s+org_id\s+IS\s+NULL/i;
-    const dashPredicate = /UPDATE\s+dashboards\s+SET\s+share_mode\s*=\s*'public'\s+WHERE\s+share_mode\s*=\s*'org'\s+AND\s+org_id\s+IS\s+NULL/i;
+    const convPredicate = /UPDATE\s+conversations\s+SET\s+share_mode\s*=\s*'public'[\s\S]*?WHERE\s+share_mode\s*=\s*'org'\s+AND\s+org_id\s+IS\s+NULL/i;
+    const dashPredicate = /UPDATE\s+dashboards\s+SET\s+share_mode\s*=\s*'public'[\s\S]*?WHERE\s+share_mode\s*=\s*'org'\s+AND\s+org_id\s+IS\s+NULL/i;
 
     expect(sql).toMatch(convPredicate);
     expect(sql).toMatch(dashPredicate);
+  });
+
+  it("revokes share_token and share_expires_at on coerced rows so drifted org-shares don't become live-as-public", () => {
+    // Without this, post-migration rows with share_mode='public' + live
+    // share_token would silently flip from F-01 fail-closed 403 to a
+    // publicly-viewable link. See #1737 PR review.
+    const sql = fs.readFileSync(filePath, "utf-8");
+
+    const convRevoke = /UPDATE\s+conversations\s+SET[\s\S]*?share_token\s*=\s*NULL[\s\S]*?share_expires_at\s*=\s*NULL[\s\S]*?WHERE\s+share_mode\s*=\s*'org'\s+AND\s+org_id\s+IS\s+NULL/i;
+    const dashRevoke = /UPDATE\s+dashboards\s+SET[\s\S]*?share_token\s*=\s*NULL[\s\S]*?share_expires_at\s*=\s*NULL[\s\S]*?WHERE\s+share_mode\s*=\s*'org'\s+AND\s+org_id\s+IS\s+NULL/i;
+
+    expect(sql).toMatch(convRevoke);
+    expect(sql).toMatch(dashRevoke);
   });
 
   it("encodes the CHECK as `share_mode <> 'org' OR org_id IS NOT NULL` on both tables", () => {

--- a/packages/api/src/lib/db/migrations/0034_share_mode_org_requires_org_id.sql
+++ b/packages/api/src/lib/db/migrations/0034_share_mode_org_requires_org_id.sql
@@ -1,0 +1,66 @@
+-- 0034 — Enforce that share_mode='org' requires org_id IS NOT NULL
+--
+-- Closes #1737. F-01 (#1727, fixed at the route layer by PR #1738 / #1742)
+-- showed that a conversation or dashboard row with share_mode='org' and
+-- org_id=NULL would silently pass a truthy org-membership check and leak
+-- cross-tenant. Route layers now fail-closed, but the schema still
+-- allowed the invalid combination — any future caller that reintroduces
+-- the truthy pattern would reopen the same class of bug.
+--
+-- This migration adds a DB-level CHECK so the invariant is impossible to
+-- violate: share_mode='org' requires org_id IS NOT NULL.
+--
+-- Ordering is load-bearing: the remediation UPDATEs must run before the
+-- ADD CONSTRAINT, otherwise any pre-drifted row would block the
+-- migration from applying. Matches the pattern used in 0031 / 0032.
+--
+-- Remediation policy: flip offending rows back to share_mode='public'
+-- (the column default). The share was already broken-by-construction —
+-- the route layer was rejecting it — so reverting to 'public' is
+-- strictly less dangerous than trying to derive org_id from user_id,
+-- which would risk assigning the share to the wrong org.
+--
+-- The RAISE NOTICE gives operators a post-mortem breadcrumb (same pattern
+-- as 0032). On a clean dev DB these UPDATEs touch 0 rows and emit no
+-- notice.
+
+-- ── 1. Remediate bad conversation rows ──────────────────────────────
+DO $$
+DECLARE
+  coerced_count INTEGER;
+BEGIN
+  UPDATE conversations
+  SET share_mode = 'public'
+  WHERE share_mode = 'org' AND org_id IS NULL;
+  GET DIAGNOSTICS coerced_count = ROW_COUNT;
+  IF coerced_count > 0 THEN
+    RAISE NOTICE 'conversations.share_mode drift: coerced % row(s) from ''org'' back to ''public'' (org_id was NULL)', coerced_count;
+  END IF;
+END $$;
+
+-- ── 2. Remediate bad dashboard rows ─────────────────────────────────
+DO $$
+DECLARE
+  coerced_count INTEGER;
+BEGIN
+  UPDATE dashboards
+  SET share_mode = 'public'
+  WHERE share_mode = 'org' AND org_id IS NULL;
+  GET DIAGNOSTICS coerced_count = ROW_COUNT;
+  IF coerced_count > 0 THEN
+    RAISE NOTICE 'dashboards.share_mode drift: coerced % row(s) from ''org'' back to ''public'' (org_id was NULL)', coerced_count;
+  END IF;
+END $$;
+
+-- ── 3. Add CHECK constraints (idempotent) ───────────────────────────
+DO $$ BEGIN
+  ALTER TABLE conversations ADD CONSTRAINT chk_org_scoped_share
+    CHECK (share_mode <> 'org' OR org_id IS NOT NULL);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  ALTER TABLE dashboards ADD CONSTRAINT chk_org_scoped_share
+    CHECK (share_mode <> 'org' OR org_id IS NOT NULL);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;

--- a/packages/api/src/lib/db/migrations/0034_share_mode_org_requires_org_id.sql
+++ b/packages/api/src/lib/db/migrations/0034_share_mode_org_requires_org_id.sql
@@ -15,14 +15,20 @@
 -- migration from applying. Matches the pattern used in 0031 / 0032.
 --
 -- Remediation policy: flip offending rows back to share_mode='public'
--- (the column default). The share was already broken-by-construction —
--- the route layer was rejecting it — so reverting to 'public' is
--- strictly less dangerous than trying to derive org_id from user_id,
--- which would risk assigning the share to the wrong org.
+-- (the column default) AND null share_token + share_expires_at on the
+-- same pass. Pre-migration, the F-01 route-layer fix returned 403 on
+-- reads of these rows (org scope with no org → fail-closed). If we only
+-- changed share_mode, the still-live share_token would start resolving
+-- as a public link — anyone holding the URL would suddenly see the
+-- content. Revoking the token forces a deliberate re-share.
+--
+-- Deriving org_id from user_id was considered and rejected: assigning
+-- the share to a guessed org could leak content into the wrong tenant.
 --
 -- The RAISE NOTICE gives operators a post-mortem breadcrumb (same pattern
--- as 0032). On a clean dev DB these UPDATEs touch 0 rows and emit no
--- notice.
+-- as 0032) and explicitly mentions token revocation so the behavior
+-- change is visible in migration logs. On a clean dev DB these UPDATEs
+-- touch 0 rows and emit no notice.
 
 -- ── 1. Remediate bad conversation rows ──────────────────────────────
 DO $$
@@ -30,11 +36,13 @@ DECLARE
   coerced_count INTEGER;
 BEGIN
   UPDATE conversations
-  SET share_mode = 'public'
+  SET share_mode = 'public',
+      share_token = NULL,
+      share_expires_at = NULL
   WHERE share_mode = 'org' AND org_id IS NULL;
   GET DIAGNOSTICS coerced_count = ROW_COUNT;
   IF coerced_count > 0 THEN
-    RAISE NOTICE 'conversations.share_mode drift: coerced % row(s) from ''org'' back to ''public'' (org_id was NULL)', coerced_count;
+    RAISE NOTICE 'conversations.share_mode drift: coerced % row(s) from ''org'' back to ''public'' and revoked their share_token (org_id was NULL)', coerced_count;
   END IF;
 END $$;
 
@@ -44,11 +52,13 @@ DECLARE
   coerced_count INTEGER;
 BEGIN
   UPDATE dashboards
-  SET share_mode = 'public'
+  SET share_mode = 'public',
+      share_token = NULL,
+      share_expires_at = NULL
   WHERE share_mode = 'org' AND org_id IS NULL;
   GET DIAGNOSTICS coerced_count = ROW_COUNT;
   IF coerced_count > 0 THEN
-    RAISE NOTICE 'dashboards.share_mode drift: coerced % row(s) from ''org'' back to ''public'' (org_id was NULL)', coerced_count;
+    RAISE NOTICE 'dashboards.share_mode drift: coerced % row(s) from ''org'' back to ''public'' and revoked their share_token (org_id was NULL)', coerced_count;
   END IF;
 END $$;
 

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -96,6 +96,8 @@ export const conversations = pgTable(
     index("idx_conversations_starred").on(t.userId, t.starred).where(sql`starred = true`),
     uniqueIndex("idx_conversations_share_token").on(t.shareToken).where(sql`share_token IS NOT NULL`),
     check("chk_share_mode", sql`share_mode IN ('public', 'org')`),
+    // share_mode='org' without an org_id is the F-01 bug class — see #1737 / 0034.
+    check("chk_org_scoped_share", sql`share_mode <> 'org' OR org_id IS NOT NULL`),
     index("idx_conversations_org").on(t.orgId),
   ],
 );
@@ -1299,6 +1301,8 @@ export const dashboards = pgTable(
     index("idx_dashboards_owner").on(t.ownerId),
     uniqueIndex("idx_dashboards_share_token").on(t.shareToken).where(sql`share_token IS NOT NULL`),
     check("chk_dashboard_share_mode", sql`share_mode IN ('public', 'org')`),
+    // share_mode='org' without an org_id is the F-01 bug class — see #1737 / 0034.
+    check("chk_org_scoped_share", sql`share_mode <> 'org' OR org_id IS NOT NULL`),
     index("idx_dashboards_next_refresh").on(t.nextRefreshAt).where(sql`refresh_schedule IS NOT NULL AND deleted_at IS NULL`),
   ],
 );


### PR DESCRIPTION
## Summary

- **F-01 hardening at the DB layer.** PR #1738 (conversations) and PR #1742 (dashboards) fixed the cross-tenant leak at the route layer by requiring an explicit org match. This change adds the DB-level invariant so the leak class cannot be reintroduced by any future caller that falls back to a truthy check on `orgId`.
- **New CHECK constraint** `chk_org_scoped_share = (share_mode <> 'org' OR org_id IS NOT NULL)` on both `conversations` and `dashboards`.
- **Write-path defense** in `shareConversation` + `shareDashboard` — rejects the invalid combo with a structured `invalid_org_scope` reason, which routes map to HTTP 400 (instead of surfacing a raw Postgres constraint error).

## Migration plan

`packages/api/src/lib/db/migrations/0034_share_mode_org_requires_org_id.sql`

1. **Remediate drift.** Flip any pre-existing `share_mode='org'` rows with `org_id IS NULL` back to the column default `share_mode='public'`. The share was already broken-by-construction (the route layer was rejecting it), so reverting to the default is strictly safer than guessing an `org_id` from the row's `user_id`. Each table's remediation block emits a `RAISE NOTICE` with the coerced row count — operators get a post-mortem breadcrumb instead of silent rewrites (same pattern as 0032).
2. **Add CHECK.** `ALTER TABLE ... ADD CONSTRAINT chk_org_scoped_share CHECK (share_mode <> 'org' OR org_id IS NOT NULL)` on both tables, wrapped in idempotent `DO $$ ... EXCEPTION WHEN duplicate_object THEN NULL END $$;` guards (same pattern as 0031 / 0032) so re-running the migration on an already-constrained DB is a no-op.

Ordering is load-bearing: the UPDATEs must run before the ALTER, otherwise a pre-drifted row would block the migration.

Drizzle schema (`schema.ts`) also gains the matching `check("chk_org_scoped_share", ...)` so future `drizzle-kit generate` runs stay in lockstep.

**Backfill impact on a clean dev DB:** 0 rows touched — the `RAISE NOTICE` only fires if coerced_count > 0.

## Write-path changes

- `shareConversation(id, userId, { shareMode: 'org' })` now does a preflight `SELECT org_id` and returns `{ ok: false, reason: 'invalid_org_scope' }` when the row has no org. Route maps to `400 { error: 'invalid_request', message: 'Cannot create an org-scoped share for a conversation with no organization.' }`.
- `shareDashboard(id, { orgId }, { shareMode: 'org' })` does the same — additionally refuses when the caller's `scope.orgId` is null.
- New discriminated union reasons `ShareConversationFailReason` / `ShareDashboardFailReason` extend `CrudFailReason` with `invalid_org_scope` and are exported from the lib modules.

## Test plan

- [x] DB migration: `packages/api/src/lib/db/__tests__/migrate.test.ts` — new `0034` describe block pins ordering (UPDATE before ALTER), exact CHECK shape, RAISE NOTICE per table, idempotency wrappers. Migration count bumped `34 → 35`.
- [x] Application layer: `packages/api/src/lib/__tests__/conversations.test.ts` — rejects `shareMode='org'` with `invalid_org_scope` when `org_id IS NULL`; happy path extended to cover the preflight SELECT.
- [x] Application layer: `packages/api/src/lib/__tests__/dashboards-share.test.ts` (new) — same invariant, plus short-circuit on null `scope.orgId`, plus proof that public shares skip the preflight (no extra query).
- [x] Route layer: `packages/api/src/api/__tests__/conversations.test.ts` + `dashboards.test.ts` — 400 regression when the lib reports `invalid_org_scope`.
- [x] Auth migrate test (`packages/api/src/lib/auth/__tests__/migrate.test.ts`) bumped to know about 0034.
- [x] `bun run lint` clean.
- [x] `bun run type` clean (no new errors).
- [x] Isolated test files pass: `bun test packages/api/src/lib/db/__tests__/migrate.test.ts`, `bun test packages/api/src/lib/__tests__/conversations.test.ts`, `bun test packages/api/src/lib/__tests__/dashboards-share.test.ts`, `bun test packages/api/src/api/__tests__/conversations.test.ts`, `bun test packages/api/src/api/__tests__/dashboards.test.ts`, `bun test packages/api/src/lib/auth/__tests__/migrate.test.ts`.

Referenced audit doc: `.claude/research/security-audit-1-2-3.md` (not edited in this PR).

Closes #1737