### PR TITLE
fix(security): P0 F-10 — reject platform_admin in role + invite routes (#1752)

### DIFF
--- a/.claude/research/security-audit-1-2-3.md
+++ b/.claude/research/security-audit-1-2-3.md
@@ -517,6 +517,13 @@ platform-admin-gated endpoint. Two options:
     && authResult.user?.role !== "platform_admin") return 403`.
 Option (a) is preferred because it also closes the invitation path.
 
+**Status: fixed (PR #1758).** Option (a) implemented: new `ORG_ROLES` tuple in
+`@useatlas/types/auth` (`["member", "admin", "owner"]`), an `OrgRoleSchema =
+z.enum(ORG_ROLES)` parsed at both `changeUserRoleRoute` and the invitation POST.
+The test-fixture `ATLAS_ROLES` mock (which was masking the bug by omitting
+`platform_admin`) was realigned with the production tuple and now includes
+`ORG_ROLES`. Regression tests cover both routes.
+
 **F-11 — Conversation CRUD by `:id` filters by `user_id` only, not by the caller's active `org_id`** — P2
 
 `packages/api/src/lib/conversations.ts` `getConversation`, `starConversation`,
@@ -657,7 +664,7 @@ No new consumers since 1.2.2.
 |---|---|---|---|---|
 | F-08 | P0 | Cross-tenant admin | `/api/v1/admin/organizations/**` | #1750 |
 | F-09 | P0 | Cross-tenant admin | `/api/v1/admin/abuse/**` | #1751 |
-| F-10 | P0 | Privilege escalation | `/api/v1/admin/users/:id/role`, `/api/v1/admin/invitations` | #1752 |
+| F-10 | P0 | Privilege escalation | `/api/v1/admin/users/:id/role`, `/api/v1/admin/invitations` | #1752 — fixed (PR #1758) |
 | F-11 | P2 | Retention / scope | Conversation CRUD | #1753 |
 | F-12 | P2 | Retention / scope | Pending-action CRUD | #1754 |
 | F-13 | P2 | Cross-tenant write | `/api/v1/admin/approval/expire` | #1755 |

--- a/ee/src/auth/roles.test.ts
+++ b/ee/src/auth/roles.test.ts
@@ -352,6 +352,26 @@ describe("CRUD operations", () => {
       ).rejects.toThrow("reserved role name");
     });
 
+    // Regression test for F-10 (#1752): workspace admin cannot create a
+    // custom role named `platform_admin`, which — combined with assignRole
+    // — would otherwise promote any org member to cross-org governance.
+    it("rejects platform_admin as a reserved role name", async () => {
+      await expect(
+        run(createRole("org-1", { name: "platform_admin", permissions: ["query"] })),
+      ).rejects.toThrow("reserved role name");
+    });
+
+    it("rejects every ATLAS_ROLES built-in name (case-insensitive)", async () => {
+      const { ATLAS_ROLES } = await import("@atlas/api/lib/auth/types");
+      for (const builtin of ATLAS_ROLES) {
+        // Lower-cased by the validator before matching, so any case of the
+        // reserved name is rejected.
+        await expect(
+          run(createRole("org-1", { name: builtin.toUpperCase(), permissions: ["query"] })),
+        ).rejects.toThrow("reserved role name");
+      }
+    });
+
     it("rejects duplicate names", async () => {
       ee.queueMockRows([{ id: "existing" }]); // uniqueness check finds existing
 
@@ -498,6 +518,22 @@ describe("Role assignment", () => {
       await expect(
         run(assignRole("org-1", "user-1", "analyst")),
       ).rejects.toThrow("not a member");
+    });
+
+    // Regression test for F-10 (#1752): belt-and-suspenders against a legacy
+    // custom_roles row named `platform_admin`. Even if createRole's reservation
+    // check was bypassed historically, assignRole refuses to write a built-in
+    // role name into member.role from the custom-role path.
+    it("rejects any ATLAS_ROLES built-in name as a custom role assignment (case-insensitive)", async () => {
+      const { ATLAS_ROLES } = await import("@atlas/api/lib/auth/types");
+      for (const builtin of ATLAS_ROLES) {
+        await expect(
+          run(assignRole("org-1", "user-1", builtin)),
+        ).rejects.toThrow("built-in Atlas role");
+        await expect(
+          run(assignRole("org-1", "user-1", builtin.toUpperCase())),
+        ).rejects.toThrow("built-in Atlas role");
+      }
     });
   });
 });

--- a/ee/src/auth/roles.ts
+++ b/ee/src/auth/roles.ts
@@ -20,6 +20,22 @@ import {
 } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
 import type { AtlasUser } from "@atlas/api/lib/auth/types";
+import { ATLAS_ROLES } from "@atlas/api/lib/auth/types";
+
+/**
+ * Lower-cased set of every built-in Atlas role name. Kept in lockstep with
+ * `ATLAS_ROLES` (single source of truth in `@useatlas/types/auth`) so that
+ * adding a platform-level role in the future automatically widens what the
+ * custom-role surface refuses to shadow. See F-10 in
+ * .claude/research/security-audit-1-2-3.md — a workspace admin could
+ * previously create a custom role literally named `platform_admin`, then
+ * assign it via this same module's `assignRole` path, which writes the name
+ * into `member.role`; `resolveEffectiveRole` would then promote the target
+ * user to cross-org governance.
+ */
+const RESERVED_ATLAS_ROLE_NAMES: ReadonlySet<string> = new Set(
+  ATLAS_ROLES.map((r) => r.toLowerCase()),
+);
 
 const log = createLogger("ee:roles");
 
@@ -320,9 +336,12 @@ export const createRole = (
       return yield* Effect.fail(new RoleError({ message: `Invalid role name: "${input.name}". Must start with a letter, contain only lowercase letters, numbers, hyphens, or underscores, and be 1-63 characters.`, code: "validation" }));
     }
 
-    // Reject reserved legacy role names that would shadow built-in behavior
-    const RESERVED_ROLE_NAMES = new Set(["member", "owner"]);
-    if (RESERVED_ROLE_NAMES.has(name)) {
+    // Reject any name that shadows a built-in Atlas role. Matching on the
+    // full ATLAS_ROLES set (not just the legacy ["member","owner"] pair)
+    // prevents a tenant admin from creating a custom role named
+    // `platform_admin` and then promoting any org member to cross-org
+    // governance via assignRole. See F-10.
+    if (RESERVED_ATLAS_ROLE_NAMES.has(name)) {
       return yield* Effect.fail(new RoleError({ message: `"${name}" is a reserved role name.`, code: "validation" }));
     }
 
@@ -500,6 +519,18 @@ export const assignRole = (
   Effect.gen(function* () {
     yield* requireEnterpriseEffect("roles");
     yield* requireInternalDBEffect("role assignment");
+
+    // Belt-and-suspenders: refuse to write a built-in Atlas role name into
+    // `member.role` from the custom-role assignment path. createRole already
+    // blocks these names, but a legacy row could exist from before the guard
+    // tightened; this check also defends against future callers passing a
+    // roleName they've computed rather than looked up. See F-10.
+    if (RESERVED_ATLAS_ROLE_NAMES.has(roleName.toLowerCase())) {
+      return yield* Effect.fail(new RoleError({
+        message: `"${roleName}" is a built-in Atlas role and cannot be assigned through the custom-role endpoint.`,
+        code: "validation",
+      }));
+    }
 
     // Verify the role exists in this org
     const roleRows = yield* Effect.promise(() => internalQuery<{ id: string }>(

--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -214,9 +214,13 @@ export function createApiTestMocks(
 
   // ── Auth types ────────────────────────────────────────────────
 
+  // Keep ATLAS_ROLES / ORG_ROLES aligned with the real tuples in
+  // packages/types/src/auth.ts — drift here masks role-escalation bugs
+  // like F-10 (#1752) in tests.
   mock.module("@atlas/api/lib/auth/types", () => ({
     AUTH_MODES: ["none", "simple-key", "byot", "managed"],
-    ATLAS_ROLES: ["member", "admin", "owner"],
+    ATLAS_ROLES: ["member", "admin", "owner", "platform_admin"],
+    ORG_ROLES: ["member", "admin", "owner"],
     createAtlasUser: (
       id: string,
       mode: string,

--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -214,13 +214,16 @@ export function createApiTestMocks(
 
   // ── Auth types ────────────────────────────────────────────────
 
-  // Keep ATLAS_ROLES / ORG_ROLES aligned with the real tuples in
-  // packages/types/src/auth.ts — drift here masks role-escalation bugs
-  // like F-10 (#1752) in tests.
+  // Keep ATLAS_ROLES / ORG_ROLES / PLATFORM_ROLES aligned with the real tuples
+  // in packages/types/src/auth.ts — drift masks role-escalation bugs like F-10
+  // (#1752) in tests. The invariant is enforced by the tuple assertions in
+  // packages/api/src/lib/auth/__tests__/organization.test.ts — do not trim
+  // these arrays to make a test pass.
   mock.module("@atlas/api/lib/auth/types", () => ({
     AUTH_MODES: ["none", "simple-key", "byot", "managed"],
     ATLAS_ROLES: ["member", "admin", "owner", "platform_admin"],
     ORG_ROLES: ["member", "admin", "owner"],
+    PLATFORM_ROLES: ["platform_admin"],
     createAtlasUser: (
       id: string,
       mode: string,

--- a/packages/api/src/api/__tests__/admin-invitations.test.ts
+++ b/packages/api/src/api/__tests__/admin-invitations.test.ts
@@ -348,6 +348,33 @@ describe("Admin routes — user invitations", () => {
       });
     }
 
+    for (const badRole of ["PLATFORM_ADMIN", "Platform_Admin", " platform_admin ", "ADMIN", "Member"]) {
+      it(`rejects off-tuple role string ${JSON.stringify(badRole)} in invite`, async () => {
+        const res = await app.fetch(
+          adminRequest("/api/v1/admin/users/invite", "POST", {
+            email: "x@example.com",
+            role: badRole,
+          }),
+        );
+        expect(res.status).toBe(400);
+      });
+    }
+
+    for (const badPayload of [
+      { email: "x@example.com" },
+      { email: "x@example.com", role: null },
+      { email: "x@example.com", role: 42 },
+      { email: "x@example.com", role: ["admin"] },
+      { email: "x@example.com", role: { nested: "admin" } },
+    ]) {
+      it(`rejects non-string / missing role payload ${JSON.stringify(badPayload)} in invite`, async () => {
+        const res = await app.fetch(
+          adminRequest("/api/v1/admin/users/invite", "POST", badPayload),
+        );
+        expect(res.status).toBe(400);
+      });
+    }
+
     it("rejects invitation when user already exists", async () => {
       // Route order: member count → user check → pending check (Promise.all for user+pending)
       mockInternalQuery

--- a/packages/api/src/api/__tests__/admin-invitations.test.ts
+++ b/packages/api/src/api/__tests__/admin-invitations.test.ts
@@ -313,6 +313,41 @@ describe("Admin routes — user invitations", () => {
       expect(body.message).toContain("role");
     });
 
+    // Regression test for F-10 (#1752): invitations cannot grant platform_admin.
+    // The invitee would otherwise become platform_admin on accept.
+    it("rejects platform_admin role in invitation body", async () => {
+      const res = await app.fetch(
+        adminRequest("/api/v1/admin/users/invite", "POST", {
+          email: "new@example.com",
+          role: "platform_admin",
+        }),
+      );
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string; message: string };
+      expect(body.error).toBe("invalid_request");
+      expect(body.message).toMatch(/platform_admin/);
+    });
+
+    for (const role of ["member", "admin", "owner"] as const) {
+      it(`accepts invitation with org role "${role}"`, async () => {
+        mockInternalQuery
+          .mockResolvedValueOnce([{ count: 0 }]) // member count for resource limit
+          .mockResolvedValueOnce([]) // user check
+          .mockResolvedValueOnce([]) // pending check
+          .mockResolvedValueOnce([{ id: `inv-${role}`, created_at: "2026-01-01T00:00:00Z" }]); // INSERT
+
+        const res = await app.fetch(
+          adminRequest("/api/v1/admin/users/invite", "POST", {
+            email: `${role}@example.com`,
+            role,
+          }),
+        );
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as Record<string, unknown>;
+        expect(body.role).toBe(role);
+      });
+    }
+
     it("rejects invitation when user already exists", async () => {
       // Route order: member count → user check → pending check (Promise.all for user+pending)
       mockInternalQuery

--- a/packages/api/src/api/__tests__/admin-users-org-scope.test.ts
+++ b/packages/api/src/api/__tests__/admin-users-org-scope.test.ts
@@ -156,6 +156,47 @@ describe("Org-scoped user write operations (#983)", () => {
       expect(res.status).toBe(200);
       expect(mockSetRole).toHaveBeenCalled();
     });
+
+    // Regression test for F-10 (#1752): workspace admin cannot escalate an org
+    // member to platform_admin via the role-change endpoint. The endpoint now
+    // accepts only org-level roles; platform_admin must be granted through a
+    // platform-admin-gated endpoint.
+    it("rejects platform_admin role (workspace admin cannot escalate to platform admin)", async () => {
+      setWorkspaceAdmin("org-1");
+      mockMembershipFor("user-in-org-1");
+
+      const res = await app.fetch(
+        adminRequest("PATCH", "/api/v1/admin/users/user-in-org-1/role", { role: "platform_admin" }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json() as { error: string; message: string };
+      expect(body.error).toBe("invalid_request");
+      expect(body.message).toMatch(/platform_admin/);
+      expect(mockSetRole).not.toHaveBeenCalled();
+    });
+
+    it("rejects platform_admin even when caller is already platform admin (must use platform endpoint)", async () => {
+      setPlatformAdmin();
+
+      const res = await app.fetch(
+        adminRequest("PATCH", "/api/v1/admin/users/user-in-any-org/role", { role: "platform_admin" }),
+      );
+      expect(res.status).toBe(400);
+      expect(mockSetRole).not.toHaveBeenCalled();
+    });
+
+    for (const role of ["member", "admin", "owner"] as const) {
+      it(`accepts org role "${role}"`, async () => {
+        setWorkspaceAdmin("org-1");
+        mockMembershipFor("user-in-org-1");
+
+        const res = await app.fetch(
+          adminRequest("PATCH", "/api/v1/admin/users/user-in-org-1/role", { role }),
+        );
+        expect(res.status).toBe(200);
+        expect(mockSetRole).toHaveBeenCalled();
+      });
+    }
   });
 
   describe("POST /api/v1/admin/users/:id/ban", () => {

--- a/packages/api/src/api/__tests__/admin-users-org-scope.test.ts
+++ b/packages/api/src/api/__tests__/admin-users-org-scope.test.ts
@@ -197,6 +197,36 @@ describe("Org-scoped user write operations (#983)", () => {
         expect(mockSetRole).toHaveBeenCalled();
       });
     }
+
+    // Case-sensitivity and off-tuple fuzz — z.enum is case-sensitive, so any
+    // casing other than the literal tuple members is rejected. If someone
+    // "helpfully" lowercases the input before validation in the future, these
+    // tests fail and surface the regression.
+    for (const badRole of ["PLATFORM_ADMIN", "Platform_Admin", " platform_admin ", "superadmin", "ADMIN", "Member"]) {
+      it(`rejects off-tuple role string ${JSON.stringify(badRole)}`, async () => {
+        setWorkspaceAdmin("org-1");
+        mockMembershipFor("user-in-org-1");
+
+        const res = await app.fetch(
+          adminRequest("PATCH", "/api/v1/admin/users/user-in-org-1/role", { role: badRole }),
+        );
+        expect(res.status).toBe(400);
+        expect(mockSetRole).not.toHaveBeenCalled();
+      });
+    }
+
+    for (const badPayload of [{}, { role: null }, { role: 42 }, { role: ["admin"] }, { role: { nested: "admin" } }]) {
+      it(`rejects non-string / missing role payload ${JSON.stringify(badPayload)}`, async () => {
+        setWorkspaceAdmin("org-1");
+        mockMembershipFor("user-in-org-1");
+
+        const res = await app.fetch(
+          adminRequest("PATCH", "/api/v1/admin/users/user-in-org-1/role", badPayload),
+        );
+        expect(res.status).toBe(400);
+        expect(mockSetRole).not.toHaveBeenCalled();
+      });
+    }
   });
 
   describe("POST /api/v1/admin/users/:id/ban", () => {

--- a/packages/api/src/api/routes/admin-invitations.ts
+++ b/packages/api/src/api/routes/admin-invitations.ts
@@ -12,8 +12,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
-import type { AtlasRole } from "@atlas/api/lib/auth/types";
-import { ATLAS_ROLES } from "@atlas/api/lib/auth/types";
+import { ORG_ROLES } from "@atlas/api/lib/auth/types";
 import { runHandler } from "@atlas/api/lib/effect/hono";
 import { checkResourceLimit } from "@atlas/api/lib/billing/enforcement";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
@@ -30,9 +29,13 @@ function isValidEmail(email: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 }
 
-function isValidRole(role: unknown): role is AtlasRole {
-  return typeof role === "string" && (ATLAS_ROLES as readonly string[]).includes(role);
-}
+/**
+ * Invitations may only grant org-level roles. `platform_admin` must be granted
+ * through a platform-admin-gated endpoint — otherwise any workspace admin could
+ * invite a user and have them auto-promoted to cross-org governance on accept.
+ * See F-10 / issue #1752 in .claude/research/security-audit-1-2-3.md.
+ */
+const OrgRoleSchema = z.enum(ORG_ROLES);
 
 function resolveBaseUrl(req: Request): string {
   return (
@@ -146,15 +149,23 @@ export function registerInvitationRoutes(
     }
 
     const email = typeof body.email === "string" ? body.email.toLowerCase().trim() : "";
-    const role = body.role;
 
     if (!email || !isValidEmail(email)) {
       return c.json({ error: "invalid_request", message: "A valid email address is required.", requestId }, 400);
     }
 
-    if (!isValidRole(role)) {
-      return c.json({ error: "invalid_request", message: `Invalid role. Must be one of: ${ATLAS_ROLES.join(", ")}`, requestId }, 400);
+    const roleParse = OrgRoleSchema.safeParse(body.role);
+    if (!roleParse.success) {
+      return c.json(
+        {
+          error: "invalid_request",
+          message: `Invalid role. Must be one of: ${ORG_ROLES.join(", ")}. platform_admin must be granted through platform-admin endpoints.`,
+          requestId,
+        },
+        400,
+      );
     }
+    const role = roleParse.data;
 
     // Enforce plan member limit before proceeding.
     // Count includes current members + pending invitations to prevent over-provisioning.

--- a/packages/api/src/api/routes/admin-invitations.ts
+++ b/packages/api/src/api/routes/admin-invitations.ts
@@ -12,10 +12,9 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
-import { ORG_ROLES } from "@atlas/api/lib/auth/types";
 import { runHandler } from "@atlas/api/lib/effect/hono";
 import { checkResourceLimit } from "@atlas/api/lib/billing/enforcement";
-import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
+import { ErrorSchema, AuthErrorSchema, OrgRoleSchema, ORG_ROLE_ERROR_MESSAGE } from "./shared-schemas";
 
 const log = createLogger("admin-invitations");
 
@@ -28,14 +27,6 @@ const INVITE_EXPIRY_DAYS = 7;
 function isValidEmail(email: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 }
-
-/**
- * Invitations may only grant org-level roles. `platform_admin` must be granted
- * through a platform-admin-gated endpoint — otherwise any workspace admin could
- * invite a user and have them auto-promoted to cross-org governance on accept.
- * See F-10 / issue #1752 in .claude/research/security-audit-1-2-3.md.
- */
-const OrgRoleSchema = z.enum(ORG_ROLES);
 
 function resolveBaseUrl(req: Request): string {
   return (
@@ -154,16 +145,13 @@ export function registerInvitationRoutes(
       return c.json({ error: "invalid_request", message: "A valid email address is required.", requestId }, 400);
     }
 
+    // Invitations may only grant org-level roles. platform_admin must be
+    // granted through a platform-admin-gated endpoint — otherwise any workspace
+    // admin could invite a user and have them auto-promoted to cross-org
+    // governance on accept. See F-10 in .claude/research/security-audit-1-2-3.md.
     const roleParse = OrgRoleSchema.safeParse(body.role);
     if (!roleParse.success) {
-      return c.json(
-        {
-          error: "invalid_request",
-          message: `Invalid role. Must be one of: ${ORG_ROLES.join(", ")}. platform_admin must be granted through platform-admin endpoints.`,
-          requestId,
-        },
-        400,
-      );
+      return c.json({ error: "invalid_request", message: ORG_ROLE_ERROR_MESSAGE, requestId }, 400);
     }
     const role = roleParse.data;
 

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -30,7 +30,7 @@ import {
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
 import { getConfig } from "@atlas/api/lib/config";
 import type { AtlasRole } from "@atlas/api/lib/auth/types";
-import { ATLAS_ROLES, ORG_ROLES } from "@atlas/api/lib/auth/types";
+import { ATLAS_ROLES } from "@atlas/api/lib/auth/types";
 import {
   getSemanticRoot,
   isValidEntityName,
@@ -73,7 +73,7 @@ import { adminActions } from "./admin-actions";
 import { adminPublish } from "./admin-publish";
 import { adminArchive, adminRestore } from "./admin-archive";
 import { registerSemanticEditorRoutes } from "./admin-semantic";
-import { ErrorSchema, AuthErrorSchema, parsePagination } from "./shared-schemas";
+import { ErrorSchema, AuthErrorSchema, parsePagination, OrgRoleSchema, ORG_ROLE_ERROR_MESSAGE } from "./shared-schemas";
 import { runHandler } from "@atlas/api/lib/effect/hono";
 
 const log = createLogger("admin-routes");
@@ -474,18 +474,22 @@ async function getAdminApi(): Promise<AdminApi | null> {
   return getAuthInstance().api as unknown as AdminApi;
 }
 
-/** Validate that a role string is a valid Atlas role (includes `platform_admin`). */
-function isValidRole(role: unknown): role is AtlasRole {
+/**
+ * Type guard for *any* AtlasRole — includes `platform_admin`.
+ *
+ * DANGER: Do NOT use this for authorization decisions about roles that are
+ * being assigned from request bodies. A workspace admin accepting
+ * `platform_admin` here would re-introduce F-10. Parse body role fields
+ * through `OrgRoleSchema` in `shared-schemas.ts` instead.
+ *
+ * Use cases this is appropriate for: read-only filter params on list endpoints
+ * (e.g. `GET /users?role=platform_admin` — listing platform admins is safe),
+ * and validating session-user role strings that already come from the auth
+ * layer (not untrusted input).
+ */
+function isAtlasRole(role: unknown): role is AtlasRole {
   return typeof role === "string" && (ATLAS_ROLES as readonly string[]).includes(role);
 }
-
-/**
- * Schema for roles that workspace admins are allowed to assign through the
- * admin surface (role change, invitations). Excludes `platform_admin`, which
- * must only be granted through a platform-admin-gated endpoint. See F-10 /
- * issue #1752 in .claude/research/security-audit-1-2-3.md.
- */
-const OrgRoleSchema = z.enum(ORG_ROLES);
 
 
 // ---------------------------------------------------------------------------
@@ -1653,7 +1657,7 @@ admin.openapi(listUsersRoute, async (c) => runHandler(c, "list users", async () 
       params.push(`%${search}%`);
       paramIndex++;
     }
-    if (role && isValidRole(role)) {
+    if (role && isAtlasRole(role)) {
       // Use org-level role from the member table
       conditions.push(`m.role = $${paramIndex}`);
       params.push(role);
@@ -1710,7 +1714,7 @@ admin.openapi(listUsersRoute, async (c) => runHandler(c, "list users", async () 
       limit,
       offset,
       ...(search ? { searchField: "email", searchValue: search, searchOperator: "contains" } : {}),
-      ...(role && isValidRole(role) ? { filterField: "role", filterValue: role, filterOperator: "eq" } : {}),
+      ...(role && isAtlasRole(role) ? { filterField: "role", filterValue: role, filterOperator: "eq" } : {}),
       sortBy: "createdAt",
       sortDirection: "desc",
     },
@@ -1812,18 +1816,12 @@ admin.openapi(changeUserRoleRoute, async (c) => {
     return null;
   });
 
-  // Reject platform_admin here. Granting cross-org privilege must go through a
-  // platform-admin-gated endpoint, not this per-workspace role change. See F-10.
+  // Reject platform_admin and any off-tuple value. Granting cross-org privilege
+  // must go through a platform-admin-gated endpoint, not this per-workspace
+  // role change. See F-10 in .claude/research/security-audit-1-2-3.md.
   const roleParse = OrgRoleSchema.safeParse(body?.role);
   if (!roleParse.success) {
-    return c.json(
-      {
-        error: "invalid_request",
-        message: `Invalid role. Must be one of: ${ORG_ROLES.join(", ")}. platform_admin must be granted through platform-admin endpoints.`,
-        requestId,
-      },
-      400,
-    );
+    return c.json({ error: "invalid_request", message: ORG_ROLE_ERROR_MESSAGE, requestId }, 400);
   }
   const newRole = roleParse.data;
 

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -30,7 +30,7 @@ import {
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
 import { getConfig } from "@atlas/api/lib/config";
 import type { AtlasRole } from "@atlas/api/lib/auth/types";
-import { ATLAS_ROLES } from "@atlas/api/lib/auth/types";
+import { ATLAS_ROLES, ORG_ROLES } from "@atlas/api/lib/auth/types";
 import {
   getSemanticRoot,
   isValidEntityName,
@@ -474,10 +474,18 @@ async function getAdminApi(): Promise<AdminApi | null> {
   return getAuthInstance().api as unknown as AdminApi;
 }
 
-/** Validate that a role string is a valid Atlas role. */
+/** Validate that a role string is a valid Atlas role (includes `platform_admin`). */
 function isValidRole(role: unknown): role is AtlasRole {
   return typeof role === "string" && (ATLAS_ROLES as readonly string[]).includes(role);
 }
+
+/**
+ * Schema for roles that workspace admins are allowed to assign through the
+ * admin surface (role change, invitations). Excludes `platform_admin`, which
+ * must only be granted through a platform-admin-gated endpoint. See F-10 /
+ * issue #1752 in .claude/research/security-audit-1-2-3.md.
+ */
+const OrgRoleSchema = z.enum(ORG_ROLES);
 
 
 // ---------------------------------------------------------------------------
@@ -1803,11 +1811,21 @@ admin.openapi(changeUserRoleRoute, async (c) => {
     log.warn({ err: err instanceof Error ? err.message : String(err), requestId }, "Failed to parse JSON body in role change request");
     return null;
   });
-  const newRole = body?.role;
 
-  if (!isValidRole(newRole)) {
-    return c.json({ error: "invalid_request", message: `Invalid role. Must be one of: ${ATLAS_ROLES.join(", ")}` }, 400);
+  // Reject platform_admin here. Granting cross-org privilege must go through a
+  // platform-admin-gated endpoint, not this per-workspace role change. See F-10.
+  const roleParse = OrgRoleSchema.safeParse(body?.role);
+  if (!roleParse.success) {
+    return c.json(
+      {
+        error: "invalid_request",
+        message: `Invalid role. Must be one of: ${ORG_ROLES.join(", ")}. platform_admin must be granted through platform-admin endpoints.`,
+        requestId,
+      },
+      400,
+    );
   }
+  const newRole = roleParse.data;
 
   // Self-protection: cannot change own role
   if (authResult.user?.id === userId) {

--- a/packages/api/src/api/routes/shared-schemas.ts
+++ b/packages/api/src/api/routes/shared-schemas.ts
@@ -1,5 +1,6 @@
 import { z } from "@hono/zod-openapi";
 import type { Context } from "hono";
+import { ORG_ROLES, ATLAS_ROLES } from "@atlas/api/lib/auth/types";
 
 /**
  * Standard error response schema used across all API routes.
@@ -10,6 +11,37 @@ export const ErrorSchema = z.object({
   message: z.string(),
   requestId: z.string().optional(),
 });
+
+// ---------------------------------------------------------------------------
+// Role validation
+// ---------------------------------------------------------------------------
+
+/**
+ * The canonical schema for any request body field that assigns a workspace-
+ * level role. Accepts only `member`, `admin`, `owner` — rejects `platform_admin`
+ * because cross-org privilege must only be granted through a platform-admin-
+ * gated endpoint, never a workspace admin surface.
+ *
+ * Every write path that accepts a `role` from untrusted input (body, query,
+ * SCIM attribute mapping, etc.) should parse through this schema. See F-10 in
+ * .claude/research/security-audit-1-2-3.md for the threat model.
+ */
+export const OrgRoleSchema = z.enum(ORG_ROLES);
+
+/** Human-readable error phrase used in 400 responses when an off-tuple role is rejected. */
+export const ORG_ROLE_ERROR_MESSAGE =
+  `Invalid role. Must be one of: ${ORG_ROLES.join(", ")}. ` +
+  `platform_admin must be granted through platform-admin endpoints.`;
+
+/**
+ * Case-insensitive reserved set of all Atlas built-in role names. Used by the
+ * custom-role surface (@atlas/ee/auth/roles) to prevent a tenant admin from
+ * creating a custom role that shadows `platform_admin` (or any other built-in)
+ * and then assigning it via the looser custom-role assignment path. See F-10.
+ */
+export const RESERVED_ATLAS_ROLE_NAMES: ReadonlySet<string> = new Set(
+  ATLAS_ROLES.map((r) => r.toLowerCase()),
+);
 
 /**
  * Auth error schema for Better Auth responses.

--- a/packages/api/src/lib/auth/__tests__/organization.test.ts
+++ b/packages/api/src/lib/auth/__tests__/organization.test.ts
@@ -88,13 +88,16 @@ describe("org-permissions access control", () => {
 // ---------------------------------------------------------------------------
 
 describe("ATLAS_ROLES", () => {
-  it("contains member, admin, owner (not viewer/analyst)", () => {
+  it("contains member, admin, owner, platform_admin", () => {
     expect(ATLAS_ROLES).toEqual(["member", "admin", "owner", "platform_admin"]);
   });
 
-  it("OrgRole is derived from AtlasRole (same values)", async () => {
+  // ORG_ROLES is the subset of ATLAS_ROLES that can be assigned through
+  // workspace admin endpoints (role change, invitations). `platform_admin` is
+  // intentionally excluded — see F-10 in security-audit-1-2-3.md.
+  it("ORG_ROLES is ATLAS_ROLES minus platform_admin", async () => {
     const { ORG_ROLES } = await import("@useatlas/types");
-    // ORG_ROLES is descending privilege, ATLAS_ROLES is ascending — same set
-    expect(new Set(ORG_ROLES)).toEqual(new Set(ATLAS_ROLES));
+    expect([...ORG_ROLES].sort()).toEqual(["admin", "member", "owner"]);
+    expect(new Set(ORG_ROLES)).toEqual(new Set(ATLAS_ROLES.filter((r) => r !== "platform_admin")));
   });
 });

--- a/packages/api/src/lib/auth/types.ts
+++ b/packages/api/src/lib/auth/types.ts
@@ -6,8 +6,8 @@
  * AtlasUser represents a verified identity attached to a request.
  */
 
-export { AUTH_MODES, ATLAS_ROLES, ORG_ROLES } from "@useatlas/types/auth";
-export type { AuthMode, AtlasRole, OrgRole, AtlasUser } from "@useatlas/types/auth";
+export { AUTH_MODES, ATLAS_ROLES, ORG_ROLES, PLATFORM_ROLES } from "@useatlas/types/auth";
+export type { AuthMode, AtlasRole, OrgRole, PlatformRole, AtlasUser } from "@useatlas/types/auth";
 
 import type { AuthMode, AtlasRole, AtlasUser } from "@useatlas/types/auth";
 

--- a/packages/api/src/lib/auth/types.ts
+++ b/packages/api/src/lib/auth/types.ts
@@ -6,8 +6,8 @@
  * AtlasUser represents a verified identity attached to a request.
  */
 
-export { AUTH_MODES, ATLAS_ROLES } from "@useatlas/types/auth";
-export type { AuthMode, AtlasRole, AtlasUser } from "@useatlas/types/auth";
+export { AUTH_MODES, ATLAS_ROLES, ORG_ROLES } from "@useatlas/types/auth";
+export type { AuthMode, AtlasRole, OrgRole, AtlasUser } from "@useatlas/types/auth";
 
 import type { AuthMode, AtlasRole, AtlasUser } from "@useatlas/types/auth";
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/types",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -10,17 +10,35 @@
 export const AUTH_MODES = ["none", "simple-key", "managed", "byot"] as const;
 export type AuthMode = (typeof AUTH_MODES)[number];
 
-export const ATLAS_ROLES = ["member", "admin", "owner", "platform_admin"] as const;
-export type AtlasRole = (typeof ATLAS_ROLES)[number];
-
 /**
- * Org-level roles that may be assigned through workspace admin endpoints
- * (role changes, invitations). Derived from ATLAS_ROLES minus `platform_admin`:
- * `platform_admin` is a cross-org privilege and must only be granted through
- * platform-admin-gated endpoints, never the per-workspace admin surface.
+ * Org-level roles — the assignable subset at workspace boundaries.
+ *
+ * These are the only roles a workspace admin may grant through routes like
+ * `PATCH /api/v1/admin/users/:id/role` and `POST /api/v1/admin/invitations`.
+ * Adding a role here means "workspace admins may hand this out." See F-10 in
+ * .claude/research/security-audit-1-2-3.md.
  */
 export const ORG_ROLES = ["member", "admin", "owner"] as const;
 export type OrgRole = (typeof ORG_ROLES)[number];
+
+/**
+ * Platform-level roles — cross-org privileges.
+ *
+ * Granting one of these must go through a platform-admin-gated endpoint, never
+ * the per-workspace admin surface. Adding a role here means "only platform
+ * admins may hand this out." Keep this tuple and ORG_ROLES disjoint.
+ */
+export const PLATFORM_ROLES = ["platform_admin"] as const;
+export type PlatformRole = (typeof PLATFORM_ROLES)[number];
+
+/**
+ * All Atlas role values — union of ORG_ROLES ∪ PLATFORM_ROLES. Derived so
+ * that adding a new role forces a conscious bucket choice (org-assignable
+ * vs platform-only). The user.role column may legitimately hold any of
+ * these values.
+ */
+export const ATLAS_ROLES = [...ORG_ROLES, ...PLATFORM_ROLES] as const;
+export type AtlasRole = (typeof ATLAS_ROLES)[number];
 
 export const ATLAS_MODES = ["developer", "published"] as const;
 export type AtlasMode = (typeof ATLAS_MODES)[number];

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -13,6 +13,15 @@ export type AuthMode = (typeof AUTH_MODES)[number];
 export const ATLAS_ROLES = ["member", "admin", "owner", "platform_admin"] as const;
 export type AtlasRole = (typeof ATLAS_ROLES)[number];
 
+/**
+ * Org-level roles that may be assigned through workspace admin endpoints
+ * (role changes, invitations). Derived from ATLAS_ROLES minus `platform_admin`:
+ * `platform_admin` is a cross-org privilege and must only be granted through
+ * platform-admin-gated endpoints, never the per-workspace admin surface.
+ */
+export const ORG_ROLES = ["member", "admin", "owner"] as const;
+export type OrgRole = (typeof ORG_ROLES)[number];
+
 export const ATLAS_MODES = ["developer", "published"] as const;
 export type AtlasMode = (typeof ATLAS_MODES)[number];
 

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -23,9 +23,14 @@ export interface Organization {
 }
 
 /**
- * A member row's wire shape. The DB column stores any AtlasRole value — including
- * `platform_admin` for cross-org administrators — so this field is typed as
- * AtlasRole rather than the narrower OrgRole (which is the *assignable* subset).
+ * A member row's wire shape. The DB column stores any AtlasRole value —
+ * including `platform_admin` for cross-org administrators — so this field is
+ * typed as AtlasRole rather than the narrower OrgRole (the *assignable* subset).
+ *
+ * Narrowing `role` back to `OrgRole` here will break member-list rendering for
+ * platform admins and any consumer that relies on reading the stored role
+ * verbatim. The *assignable* constraint belongs at the write boundary
+ * (`OrgRoleSchema` in shared-schemas.ts), not the read type.
  */
 export interface OrgMember {
   id: string;

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -7,7 +7,11 @@
  */
 
 import type { AtlasRole } from "./auth";
-import { ATLAS_ROLES } from "./auth";
+
+// Re-export the canonical ORG_ROLES tuple from auth.ts so consumers can keep
+// importing `OrgRole` / `ORG_ROLES` from the organization module.
+export { ORG_ROLES } from "./auth";
+export type { OrgRole } from "./auth";
 
 export interface Organization {
   id: string;
@@ -18,11 +22,16 @@ export interface Organization {
   createdAt: string;
 }
 
+/**
+ * A member row's wire shape. The DB column stores any AtlasRole value — including
+ * `platform_admin` for cross-org administrators — so this field is typed as
+ * AtlasRole rather than the narrower OrgRole (which is the *assignable* subset).
+ */
 export interface OrgMember {
   id: string;
   organizationId: string;
   userId: string;
-  role: OrgRole;
+  role: AtlasRole;
   createdAt: string;
   user?: {
     id: string;
@@ -36,7 +45,7 @@ export interface OrgInvitation {
   id: string;
   organizationId: string;
   email: string;
-  role: OrgRole;
+  role: AtlasRole;
   status: "pending" | "accepted" | "rejected" | "canceled";
   inviterId: string;
   expiresAt: string;
@@ -47,11 +56,3 @@ export interface OrgInvitation {
     slug: string;
   };
 }
-
-/**
- * Org roles in descending privilege order. Same values as AtlasRole,
- * listed high-to-low for display. Single source of truth is ATLAS_ROLES
- * in auth.ts — this is a reversed view for convenience.
- */
-export const ORG_ROLES: readonly AtlasRole[] = [...ATLAS_ROLES].reverse();
-export type OrgRole = AtlasRole;


### PR DESCRIPTION
## Summary

Fixes **F-10 (P0)** / closes #1752 — workspace admins could escalate any org
member to `platform_admin` via `PATCH /api/v1/admin/users/:id/role` or
`POST /api/v1/admin/invitations`, because both parsed `body.role` against
`ATLAS_ROLES` (which contains `platform_admin`). Combined with
`resolveEffectiveRole` = MAX(user.role, member.role), the escalated user then
passed `platformAdminAuth` on every `/api/v1/platform/**` endpoint — full
cross-org governance from a per-workspace admin token.

- Added `ORG_ROLES = ["member", "admin", "owner"]` to `@useatlas/types/auth`
  as the canonical set of assignable workspace roles
- Both routes now parse body role through `OrgRoleSchema = z.enum(ORG_ROLES)`
  and return 400 with a message that directs operators to platform-admin
  endpoints for `platform_admin` grants
- Left `isValidRole(role) / ATLAS_ROLES` in place for the `GET /users` filter
  path — filtering a list by `role=platform_admin` is legitimate read-only
  behavior and not a write surface
- The `organization.ts` ORG_ROLES re-export and `OrgMember.role` /
  `OrgInvitation.role` wire types are retargeted at the canonical tuple;
  the interface fields use `AtlasRole` because a member row can legitimately
  carry `platform_admin` in the DB

### Incidental finding folded in

`packages/api/src/__mocks__/api-test-mocks.ts` had `ATLAS_ROLES` mocked as
`["member", "admin", "owner"]` — no `platform_admin`. That drift was masking
this exact class of bug in tests. Realigned the mock with the production tuple
and added `ORG_ROLES` alongside so future regressions surface.

### Version bump

@useatlas/types 0.0.14 → 0.0.15 (new `ORG_ROLES` / `OrgRole` exports).
Template and sibling package refs stay pinned at ^0.0.14 per the version-bump
ordering in CLAUDE.md — roll them forward in a follow-up commit after the
types package is tagged + published.

### Follow-up

No new `POST /api/v1/platform/users/:id/promote` endpoint in this PR — scope
kept to the fix. File a follow-up issue if a platform-admin grant endpoint is
needed.

## Test plan

- [x] `bun run lint`
- [x] `bun run type`
- [x] `bun run test` (all packages, isolated runner — 0 failures)
- [x] `bun x syncpack lint`
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh`
- [x] Regression tests added for both routes (`admin-users-org-scope.test.ts`,
      `admin-invitations.test.ts`): `{ role: "platform_admin" }` → 400, and
      `member` / `admin` / `owner` still pass (parametrized)
- [x] `organization.test.ts` updated to match the new `ORG_ROLES` semantics
      (ATLAS_ROLES minus `platform_admin`)