### PR TITLE
chore(deps): regenerate bun.lock for @useatlas/types 0.0.15

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -299,7 +299,7 @@
     },
     "packages/types": {
       "name": "@useatlas/types",
-      "version": "0.0.14",
+      "version": "0.0.15",
     },
     "packages/web": {
       "name": "@atlas/web",
@@ -4227,6 +4227,10 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typespec/ts-http-runtime/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "@useatlas/react/@useatlas/types": ["@useatlas/types@0.0.14", "", {}, "sha512-FHojA4aeljyqJc1hYYVGMPlRpz61vg3/e5qrtlm+bDqoDGLPsGVerLZvahCR0+Au81iq1xmExqohxei6OscHrA=="],
+
+    "@useatlas/sdk/@useatlas/types": ["@useatlas/types@0.0.14", "", {}, "sha512-FHojA4aeljyqJc1hYYVGMPlRpz61vg3/e5qrtlm+bDqoDGLPsGVerLZvahCR0+Au81iq1xmExqohxei6OscHrA=="],
 
     "@vercel/sandbox/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 


### PR DESCRIPTION
## Summary

**Fixes Railway deploy failure on main** from PR #1758.

I bumped `@useatlas/types` 0.0.14 → 0.0.15 in its own package.json (per the version-bump ordering rule) but forgot to regenerate `bun.lock`. Railway uses `bun ci --frozen-lockfile` and aborts:

```
error: lockfile had changes, but lockfile is frozen
```

Status at time of fix (from `gh api repos/AtlasDevHQ/atlas/commits/main/statuses`):
- satisfied-creation — api: failure
- satisfied-creation — api-eu: failure
- satisfied-creation — api-apac: failure
- satisfied-creation — web: failure
- satisfied-creation — docs: success (unaffected; different build)

## Change

Ran `bun install` locally and committed the lockfile diff. Exactly 5 lines of change, all expected:
- workspace `@useatlas/types` version: 0.0.14 → 0.0.15
- Two explicit pins for `@useatlas/sdk` / `@useatlas/react` to still-published `@useatlas/types@0.0.14` (their package.json deps stayed at `^0.0.14` per the PR #1758 intent — sibling refs roll forward after the types publish workflow ships 0.0.15)

## Test plan

- [x] `bun install` produces only the lockfile changes shown in the diff (no stray package updates)
- [x] Local workspace resolves — `bun run type` still passes (verified before #1758 merge, no change in resolution here)
- [ ] Railway redeploys api/api-eu/api-apac/web successfully after merge

## Lesson learned

Adding this to the merge-guard list in memory so it doesn't recur: any time a package.json version is bumped in a PR, bun.lock must be regenerated and committed in the same PR. This was caught in CLAUDE.md's rules — I missed it in the final pre-merge check.