### PR TITLE
fix(deploy): Railway watchPatterns — add bun.lock + ee/** so F-10 fix actually ships

### DIFF
--- a/deploy/api-apac/railway.json
+++ b/deploy/api-apac/railway.json
@@ -5,11 +5,16 @@
     "dockerfilePath": "deploy/api/Dockerfile",
     "dockerfileContext": "../..",
     "watchPatterns": [
+      "bun.lock",
+      "package.json",
       "packages/api/**",
       "packages/react/**",
+      "packages/types/**",
+      "packages/schemas/**",
       "packages/cli/data/**",
       "packages/plugin-sdk/**",
       "plugins/**",
+      "ee/**",
       "semantic/**",
       "deploy/api/**",
       "deploy/api-apac/**"

--- a/deploy/api-eu/railway.json
+++ b/deploy/api-eu/railway.json
@@ -5,11 +5,16 @@
     "dockerfilePath": "deploy/api/Dockerfile",
     "dockerfileContext": "../..",
     "watchPatterns": [
+      "bun.lock",
+      "package.json",
       "packages/api/**",
       "packages/react/**",
+      "packages/types/**",
+      "packages/schemas/**",
       "packages/cli/data/**",
       "packages/plugin-sdk/**",
       "plugins/**",
+      "ee/**",
       "semantic/**",
       "deploy/api/**",
       "deploy/api-eu/**"

--- a/deploy/api/railway.json
+++ b/deploy/api/railway.json
@@ -5,11 +5,16 @@
     "dockerfilePath": "deploy/api/Dockerfile",
     "dockerfileContext": "../..",
     "watchPatterns": [
+      "bun.lock",
+      "package.json",
       "packages/api/**",
       "packages/react/**",
+      "packages/types/**",
+      "packages/schemas/**",
       "packages/cli/data/**",
       "packages/plugin-sdk/**",
       "plugins/**",
+      "ee/**",
       "semantic/**",
       "deploy/api/**"
     ]

--- a/deploy/web/railway.json
+++ b/deploy/web/railway.json
@@ -5,10 +5,14 @@
     "dockerfilePath": "deploy/web/Dockerfile",
     "dockerfileContext": "../..",
     "watchPatterns": [
+      "bun.lock",
+      "package.json",
       "packages/web/**",
       "packages/api/**",
       "packages/react/**",
       "packages/types/**",
+      "packages/schemas/**",
+      "ee/**",
       "deploy/web/**"
     ]
   },


### PR DESCRIPTION
## Summary

**Production incident follow-up.** PR #1758 (F-10 security fix) + PR #1759 (bun.lock) merged to main, but the api / api-eu / api-apac / web Railway services never actually redeployed. Root cause: their \`watchPatterns\` don't list \`bun.lock\` or root \`package.json\`, so a lockfile-only commit — which is exactly what the CLAUDE.md version-bump ordering produces — reports \`No deployment needed - watched paths not modified\`. The services are still running the pre-#1758 code → **F-10 is still exploitable in production**.

## Gaps fixed

1. **\`bun.lock\` + root \`package.json\`** not in api/web watchPatterns. Dep bumps via lockfile changes were invisible to Railway.
2. **\`ee/**\`** not in api/web watchPatterns. \`@atlas/ee\` is imported by \`packages/api\` (and used for admin UX branching in web). Pure EE changes — including the EE half of PR #1758's F-10 fix — would not have triggered a rebuild.
3. **\`packages/schemas/**\`** missing from both; **\`packages/types/**\`** missing from api (web already had it).

## Why this PR also ships the F-10 fix

The edits touch \`deploy/api/**\` and \`deploy/web/**\`, which are already in the watchPatterns. So merging this PR forces Railway to rebuild api / api-eu / api-apac / web with the (now fixed) bun.lock — which is what should have happened when #1759 merged. The F-10 fix actually goes live.

## Testing

- [x] All four service configs read back clean (\`cat deploy/*/railway.json\`)
- [x] Syntactically valid JSON
- [ ] After merge: Railway shows build started for api / api-eu / api-apac / web (verify via \`gh api repos/AtlasDevHQ/atlas/commits/main/statuses\`)
- [ ] After build: \`curl https://api.useatlas.dev/api/health\` returns 200

## Follow-up

Worth considering a CI gate that cross-references dependency-related files against Railway watchPatterns — if \`bun.lock\` changes in a PR, require at least one service's watchPatterns to match. Filing as a separate issue if it hasn't been raised.