### PR TITLE
fix(security): P0 F-08 — restrict /admin/organizations/** to platform admins (#1750)

### DIFF
--- a/.claude/research/security-audit-1-2-3.md
+++ b/.claude/research/security-audit-1-2-3.md
@@ -463,7 +463,7 @@ strictly to platform admins. The workspace-scoped equivalent (view/manage your
 own org's members) is already covered by `adminUsers` + `adminInvitations`
 sub-routers.
 
-**Status: fixed (PR #1761).** `admin-orgs.ts` now constructs its router via
+**Status: fixed (PR #1762).** `admin-orgs.ts` now constructs its router via
 `createPlatformRouter()`; the `platformAdminAuth` middleware returns 403
 `forbidden_role` for any caller whose effective role is not `platform_admin`.
 Regression tests in `packages/api/src/api/__tests__/admin-orgs.test.ts`
@@ -672,7 +672,7 @@ No new consumers since 1.2.2.
 
 | ID | Severity | Type | Path | Issue |
 |---|---|---|---|---|
-| F-08 | P0 | Cross-tenant admin | `/api/v1/admin/organizations/**` | #1750 — fixed (PR #1761) |
+| F-08 | P0 | Cross-tenant admin | `/api/v1/admin/organizations/**` | #1750 — fixed (PR #1762) |
 | F-09 | P0 | Cross-tenant admin | `/api/v1/admin/abuse/**` | #1751 |
 | F-10 | P0 | Privilege escalation | `/api/v1/admin/users/:id/role`, `/api/v1/admin/invitations` | #1752 — fixed (PR #1758) |
 | F-11 | P2 | Retention / scope | Conversation CRUD | #1753 |

--- a/.claude/research/security-audit-1-2-3.md
+++ b/.claude/research/security-audit-1-2-3.md
@@ -463,6 +463,16 @@ strictly to platform admins. The workspace-scoped equivalent (view/manage your
 own org's members) is already covered by `adminUsers` + `adminInvitations`
 sub-routers.
 
+**Status: fixed (PR #1761).** `admin-orgs.ts` now constructs its router via
+`createPlatformRouter()`; the `platformAdminAuth` middleware returns 403
+`forbidden_role` for any caller whose effective role is not `platform_admin`.
+Regression tests in `packages/api/src/api/__tests__/admin-orgs.test.ts`
+parametrise over every route (list, read, stats, status, suspend, activate,
+plan, delete) so a future endpoint added to the subtree without a platform
+gate fails CI immediately. The pre-existing lifecycle tests in
+`admin-workspace.test.ts` were implicitly asserting the bug (role `admin`
+succeeded cross-tenant) and are now authed as `platform_admin`.
+
 **F-09 — Workspace admin can reinstate / read detail of any flagged workspace via `/api/v1/admin/abuse/**`** — P0
 
 `admin-abuse.ts` uses `createAdminRouter()` *without* `requireOrgContext()`.
@@ -662,7 +672,7 @@ No new consumers since 1.2.2.
 
 | ID | Severity | Type | Path | Issue |
 |---|---|---|---|---|
-| F-08 | P0 | Cross-tenant admin | `/api/v1/admin/organizations/**` | #1750 |
+| F-08 | P0 | Cross-tenant admin | `/api/v1/admin/organizations/**` | #1750 — fixed (PR #1761) |
 | F-09 | P0 | Cross-tenant admin | `/api/v1/admin/abuse/**` | #1751 |
 | F-10 | P0 | Privilege escalation | `/api/v1/admin/users/:id/role`, `/api/v1/admin/invitations` | #1752 — fixed (PR #1758) |
 | F-11 | P2 | Retention / scope | Conversation CRUD | #1753 |

--- a/packages/api/src/api/__tests__/admin-orgs.test.ts
+++ b/packages/api/src/api/__tests__/admin-orgs.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Tests for /api/v1/admin/organizations/** — F-08 regression (#1750).
+ *
+ * `admin-orgs.ts` provides cross-tenant CRUD for every workspace: list, read,
+ * stats, suspend, activate, plan-change, and cascading soft-delete. It
+ * previously used `createAdminRouter()` without `requireOrgContext()`, so any
+ * workspace admin on the platform could CRUD any other workspace by path id.
+ * The fix swapped it to `createPlatformRouter()`, restricting the subtree to
+ * `platform_admin` callers.
+ *
+ * These tests parametrize over every affected route so adding a new endpoint
+ * to the router without a platform gate would surface here immediately.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterAll,
+} from "bun:test";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+
+// --- Unified mocks ---
+
+const mocks = createApiTestMocks({
+  authUser: {
+    id: "platform-admin-1",
+    mode: "managed",
+    label: "platform@test.com",
+    role: "platform_admin",
+    activeOrganizationId: "org-test",
+  },
+  authMode: "managed",
+});
+
+// --- Import app after mocks ---
+
+const { app } = await import("../index");
+
+afterAll(() => mocks.cleanup());
+
+// --- Helpers ---
+
+function orgsRequest(method: string, path: string, body?: unknown): Request {
+  const opts: RequestInit = {
+    method,
+    headers: { "Content-Type": "application/json", Authorization: "Bearer test-key" },
+  };
+  if (body !== undefined) opts.body = JSON.stringify(body);
+  return new Request(`http://localhost${path}`, opts);
+}
+
+function setWorkspaceAdmin(orgId = "org-1"): void {
+  mocks.mockAuthenticateRequest.mockResolvedValue({
+    authenticated: true,
+    mode: "managed",
+    user: {
+      id: "admin-1",
+      mode: "managed",
+      label: "admin@test.com",
+      role: "admin",
+      activeOrganizationId: orgId,
+    },
+  });
+}
+
+function setWorkspaceOwner(orgId = "org-1"): void {
+  mocks.mockAuthenticateRequest.mockResolvedValue({
+    authenticated: true,
+    mode: "managed",
+    user: {
+      id: "owner-1",
+      mode: "managed",
+      label: "owner@test.com",
+      role: "owner",
+      activeOrganizationId: orgId,
+    },
+  });
+}
+
+function setMember(orgId = "org-1"): void {
+  mocks.mockAuthenticateRequest.mockResolvedValue({
+    authenticated: true,
+    mode: "managed",
+    user: {
+      id: "member-1",
+      mode: "managed",
+      label: "member@test.com",
+      role: "member",
+      activeOrganizationId: orgId,
+    },
+  });
+}
+
+function setPlatformAdmin(): void {
+  mocks.setPlatformAdmin();
+}
+
+// Every route under the admin-orgs subtree. Parametrising here means a
+// future router addition without a platform gate surfaces immediately — the
+// F-08 fix's job is to keep this surface uniformly platform-gated.
+type RouteSpec = {
+  readonly method: "GET" | "PATCH" | "DELETE";
+  readonly path: string;
+  readonly body?: unknown;
+};
+
+const ROUTES: ReadonlyArray<RouteSpec> = [
+  { method: "GET", path: "/api/v1/admin/organizations" },
+  { method: "GET", path: "/api/v1/admin/organizations/org_target" },
+  { method: "GET", path: "/api/v1/admin/organizations/org_target/stats" },
+  { method: "GET", path: "/api/v1/admin/organizations/org_target/status" },
+  { method: "PATCH", path: "/api/v1/admin/organizations/org_target/suspend" },
+  { method: "PATCH", path: "/api/v1/admin/organizations/org_target/activate" },
+  {
+    method: "PATCH",
+    path: "/api/v1/admin/organizations/org_target/plan",
+    body: { planTier: "starter" },
+  },
+  { method: "DELETE", path: "/api/v1/admin/organizations/org_target" },
+];
+
+// --- Tests ---
+
+describe("/api/v1/admin/organizations/** — F-08 platform-admin gate (#1750)", () => {
+  beforeEach(() => {
+    mocks.mockAuthenticateRequest.mockReset();
+    mocks.mockInternalQuery.mockReset();
+    mocks.mockInternalQuery.mockResolvedValue([]);
+    mocks.hasInternalDB = true;
+    setPlatformAdmin();
+  });
+
+  describe("workspace admin (role: admin) is rejected", () => {
+    for (const route of ROUTES) {
+      it(`${route.method} ${route.path} → 403 forbidden_role`, async () => {
+        setWorkspaceAdmin("org-1");
+        const res = await app.fetch(orgsRequest(route.method, route.path, route.body));
+        expect(res.status).toBe(403);
+        const body = (await res.json()) as { error: string };
+        expect(body.error).toBe("forbidden_role");
+      });
+    }
+  });
+
+  describe("workspace owner (role: owner) is rejected", () => {
+    // Owner is still a workspace-scoped role — must not be able to reach
+    // platform-admin endpoints. Covers the pre-fix gap where `adminAuth`
+    // accepted admin/owner alike and both leaked into cross-tenant CRUD.
+    for (const route of ROUTES) {
+      it(`${route.method} ${route.path} → 403 forbidden_role`, async () => {
+        setWorkspaceOwner("org-1");
+        const res = await app.fetch(orgsRequest(route.method, route.path, route.body));
+        expect(res.status).toBe(403);
+        const body = (await res.json()) as { error: string };
+        expect(body.error).toBe("forbidden_role");
+      });
+    }
+  });
+
+  describe("regular member (role: member) is rejected", () => {
+    for (const route of ROUTES) {
+      it(`${route.method} ${route.path} → 403`, async () => {
+        setMember("org-1");
+        const res = await app.fetch(orgsRequest(route.method, route.path, route.body));
+        // Non-admin callers may 401 (auth pre-check) or 403 (role check);
+        // either way the handler must not run.
+        expect([401, 403]).toContain(res.status);
+      });
+    }
+  });
+
+  describe("platform admin (role: platform_admin) passes the gate", () => {
+    for (const route of ROUTES) {
+      it(`${route.method} ${route.path} → not 403`, async () => {
+        setPlatformAdmin();
+        const res = await app.fetch(orgsRequest(route.method, route.path, route.body));
+        // Handler ran — we don't care whether the target org exists in the
+        // mock (most routes return 404 with empty internalQuery defaults).
+        // The contract this test guards is "platform admin clears the auth
+        // gate"; behavioural correctness of each handler is covered
+        // elsewhere.
+        expect(res.status).not.toBe(403);
+        if (res.status >= 400) {
+          const body = (await res.json()) as { error?: string };
+          expect(body.error).not.toBe("forbidden_role");
+        }
+      });
+    }
+
+    it("GET / returns 200 with empty list for platform admin", async () => {
+      setPlatformAdmin();
+      mocks.mockInternalQuery.mockResolvedValue([]);
+      const res = await app.fetch(orgsRequest("GET", "/api/v1/admin/organizations"));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { organizations: unknown[]; total: number };
+      expect(body.organizations).toEqual([]);
+      expect(body.total).toBe(0);
+    });
+  });
+
+  describe("unauthenticated requests are rejected", () => {
+    for (const route of ROUTES) {
+      it(`${route.method} ${route.path} → 401`, async () => {
+        mocks.mockAuthenticateRequest.mockResolvedValue({
+          authenticated: false,
+          mode: "managed",
+          status: 401,
+          error: "Missing credentials",
+        });
+        const res = await app.fetch(orgsRequest(route.method, route.path, route.body));
+        expect(res.status).toBe(401);
+      });
+    }
+  });
+});

--- a/packages/api/src/api/__tests__/admin-orgs.test.ts
+++ b/packages/api/src/api/__tests__/admin-orgs.test.ts
@@ -1,15 +1,13 @@
 /**
- * Tests for /api/v1/admin/organizations/** — F-08 regression (#1750).
+ * Tests for /api/v1/admin/organizations/** — the subtree provides cross-tenant
+ * workspace lifecycle CRUD (list / get / stats / status / suspend / activate /
+ * plan / delete) and is platform-admin-only.
  *
- * `admin-orgs.ts` provides cross-tenant CRUD for every workspace: list, read,
- * stats, suspend, activate, plan-change, and cascading soft-delete. It
- * previously used `createAdminRouter()` without `requireOrgContext()`, so any
- * workspace admin on the platform could CRUD any other workspace by path id.
- * The fix swapped it to `createPlatformRouter()`, restricting the subtree to
- * `platform_admin` callers.
+ * These tests parametrize over every route so adding a new endpoint to the
+ * router without a platform gate would surface here immediately.
  *
- * These tests parametrize over every affected route so adding a new endpoint
- * to the router without a platform gate would surface here immediately.
+ * F-08 (#1750): pre-fix, the subtree was mounted on createAdminRouter(),
+ * letting any workspace admin CRUD any workspace by id.
  */
 
 import {
@@ -146,8 +144,7 @@ describe("/api/v1/admin/organizations/** — F-08 platform-admin gate (#1750)", 
 
   describe("workspace owner (role: owner) is rejected", () => {
     // Owner is still a workspace-scoped role — must not be able to reach
-    // platform-admin endpoints. Covers the pre-fix gap where `adminAuth`
-    // accepted admin/owner alike and both leaked into cross-tenant CRUD.
+    // platform-admin endpoints.
     for (const route of ROUTES) {
       it(`${route.method} ${route.path} → 403 forbidden_role`, async () => {
         setWorkspaceOwner("org-1");
@@ -182,6 +179,11 @@ describe("/api/v1/admin/organizations/** — F-08 platform-admin gate (#1750)", 
         // gate"; behavioural correctness of each handler is covered
         // elsewhere.
         expect(res.status).not.toBe(403);
+        // Hono's default notFound returns text/plain — asserting JSON proves
+        // the handler, not a routing miss, produced the response. Without
+        // this a typo in ROUTES would let the "not 403" assertion pass
+        // vacuously on 404 text.
+        expect(res.headers.get("content-type") ?? "").toContain("application/json");
         if (res.status >= 400) {
           const body = (await res.json()) as { error?: string };
           expect(body.error).not.toBe("forbidden_role");
@@ -198,6 +200,26 @@ describe("/api/v1/admin/organizations/** — F-08 platform-admin gate (#1750)", 
       expect(body.organizations).toEqual([]);
       expect(body.total).toBe(0);
     });
+  });
+
+  describe("self-hosted (mode: none) bypasses the platform gate", () => {
+    // platformAdminAuth has a documented carve-out: when authResult.mode is
+    // "none" (self-hosted / local dev with no auth configured), the caller
+    // is treated as an implicit admin regardless of role. This is
+    // load-bearing for self-hosted deploys — removing the carve-out would
+    // break every self-hosted installation's access to org lifecycle
+    // routes. Lock it in so a future "tighten the gate" refactor surfaces
+    // the self-hosted implication.
+    for (const route of ROUTES) {
+      it(`${route.method} ${route.path} → not 403 when mode="none"`, async () => {
+        mocks.mockAuthenticateRequest.mockResolvedValue({
+          authenticated: true,
+          mode: "none",
+        });
+        const res = await app.fetch(orgsRequest(route.method, route.path, route.body));
+        expect(res.status).not.toBe(403);
+      });
+    }
   });
 
   describe("unauthenticated requests are rejected", () => {

--- a/packages/api/src/api/__tests__/admin-workspace.test.ts
+++ b/packages/api/src/api/__tests__/admin-workspace.test.ts
@@ -22,8 +22,9 @@ import {
 
 // --- Mocks (before any import that touches the modules) ---
 
-// Platform admin — admin-orgs.ts was tightened to createPlatformRouter()
-// after F-08 (#1750); workspace-level lifecycle management is platform-only.
+// These lifecycle routes are platform-admin-only; workspace admins/owners
+// are rejected at the auth gate. See `.claude/research/security-audit-1-2-3.md`
+// for rationale.
 const mockAuthenticateRequest: Mock<(req: Request) => Promise<unknown>> = mock(
   () =>
     Promise.resolve({

--- a/packages/api/src/api/__tests__/admin-workspace.test.ts
+++ b/packages/api/src/api/__tests__/admin-workspace.test.ts
@@ -22,12 +22,19 @@ import {
 
 // --- Mocks (before any import that touches the modules) ---
 
+// Platform admin — admin-orgs.ts was tightened to createPlatformRouter()
+// after F-08 (#1750); workspace-level lifecycle management is platform-only.
 const mockAuthenticateRequest: Mock<(req: Request) => Promise<unknown>> = mock(
   () =>
     Promise.resolve({
       authenticated: true,
       mode: "simple-key",
-      user: { id: "admin-1", mode: "simple-key", label: "Admin", role: "admin" },
+      user: {
+        id: "platform-admin-1",
+        mode: "simple-key",
+        label: "Platform Admin",
+        role: "platform_admin",
+      },
     }),
 );
 

--- a/packages/api/src/api/routes/admin-orgs.ts
+++ b/packages/api/src/api/routes/admin-orgs.ts
@@ -103,6 +103,7 @@ const WorkspaceActionResponseSchema = z.object({
 const DeleteCascadeSchema = z.object({
   message: z.string(),
   cascade: z.record(z.string(), z.unknown()),
+  warnings: z.array(z.string()).optional(),
 });
 
 const WorkspaceHealthSchema = z.object({
@@ -636,6 +637,12 @@ adminOrgs.openapi(deleteOrgRoute, async (c) => {
     if (!workspace) return c.json({ error: "not_found", message: "Organization not found." }, 404);
     if (workspace.workspace_status === "deleted") return c.json({ error: "conflict", message: "Workspace is already deleted." }, 409);
 
+    // Asymmetry with PATCH /:id/suspend (fail-closed on drain) is intentional:
+    // delete is a one-shot destructive cascade; failing the entire operation
+    // on a transient drain error would leave the workspace in an unclear
+    // half-dirty state. Instead we surface the failure on the response and
+    // log at `error` so it's visible in Sentry rather than buried in `warn`.
+    const warnings: string[] = [];
     let poolsDrained = 0;
     if (connections.isOrgPoolingEnabled()) {
       const drainResult = yield* Effect.tryPromise({
@@ -645,7 +652,8 @@ adminOrgs.openapi(deleteOrgRoute, async (c) => {
       if (drainResult._tag === "Right") {
         poolsDrained = drainResult.right.drained;
       } else {
-        log.warn({ orgId, err: drainResult.left.message }, "Failed to drain org pools during delete — continuing with cascade");
+        log.error({ orgId, requestId, err: drainResult.left.message }, "Failed to drain org pools during delete — continuing with cascade");
+        warnings.push(`pool_drain_failed: ${drainResult.left.message}`);
       }
     }
     flushCache();
@@ -659,8 +667,14 @@ adminOrgs.openapi(deleteOrgRoute, async (c) => {
       catch: (err) => err instanceof Error ? err : new Error(String(err)),
     });
 
-    log.info({ orgId, requestId, admin: user?.id, cascade, poolsDrained }, "Workspace soft-deleted with cascading cleanup");
-    return c.json({ message: "Workspace deleted. All associated data has been cleaned up.", cascade: { poolsDrained, ...cascade } }, 200);
+    log.info({ orgId, requestId, admin: user?.id, cascade, poolsDrained, warnings }, "Workspace soft-deleted with cascading cleanup");
+    return c.json({
+      message: warnings.length > 0
+        ? "Workspace deleted, but cleanup was partial — see warnings."
+        : "Workspace deleted. All associated data has been cleaned up.",
+      cascade: { poolsDrained, ...cascade },
+      ...(warnings.length > 0 ? { warnings } : {}),
+    }, 200);
   }), { label: "delete workspace" });
 });
 

--- a/packages/api/src/api/routes/admin-orgs.ts
+++ b/packages/api/src/api/routes/admin-orgs.ts
@@ -25,7 +25,7 @@ import { invalidatePlanCache } from "@atlas/api/lib/billing/enforcement";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
 import { ErrorSchema, AuthErrorSchema, createIdParamSchema } from "./shared-schemas";
-import { createAdminRouter } from "./admin-router";
+import { createPlatformRouter } from "./admin-router";
 
 const log = createLogger("admin-orgs");
 
@@ -162,7 +162,7 @@ const listOrgsRoute = createRoute({
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     403: {
-      description: "Forbidden — admin role required",
+      description: "Forbidden — platform admin role required",
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     404: {
@@ -212,7 +212,7 @@ const getOrgRoute = createRoute({
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     403: {
-      description: "Forbidden — admin role required",
+      description: "Forbidden — platform admin role required",
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     404: {
@@ -254,7 +254,7 @@ const getOrgStatsRoute = createRoute({
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     403: {
-      description: "Forbidden — admin role required",
+      description: "Forbidden — platform admin role required",
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     404: {
@@ -296,7 +296,7 @@ const suspendOrgRoute = createRoute({
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     403: {
-      description: "Forbidden — admin role required",
+      description: "Forbidden — platform admin role required",
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     404: {
@@ -342,7 +342,7 @@ const activateOrgRoute = createRoute({
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     403: {
-      description: "Forbidden — admin role required",
+      description: "Forbidden — platform admin role required",
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     404: {
@@ -388,7 +388,7 @@ const deleteOrgRoute = createRoute({
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     403: {
-      description: "Forbidden — admin role required",
+      description: "Forbidden — platform admin role required",
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     404: {
@@ -434,7 +434,7 @@ const getOrgStatusRoute = createRoute({
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     403: {
-      description: "Forbidden — admin role required",
+      description: "Forbidden — platform admin role required",
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     404: {
@@ -483,7 +483,7 @@ const updatePlanRoute = createRoute({
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     403: {
-      description: "Forbidden — admin role required",
+      description: "Forbidden — platform admin role required",
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     404: {
@@ -509,7 +509,7 @@ const updatePlanRoute = createRoute({
 // Router
 // ---------------------------------------------------------------------------
 
-const adminOrgs = createAdminRouter();
+const adminOrgs = createPlatformRouter();
 
 // GET / — list all organizations
 adminOrgs.openapi(listOrgsRoute, async (c) => {

--- a/packages/api/src/api/routes/admin-orgs.ts
+++ b/packages/api/src/api/routes/admin-orgs.ts
@@ -1,8 +1,9 @@
 /**
  * Admin organization management routes.
  *
- * Mounted under /api/v1/admin/organizations. All routes require admin role.
- * Provides CRUD for organizations and their members (platform admin view).
+ * Mounted under /api/v1/admin/organizations. Platform-admin only (see
+ * createPlatformRouter). Provides cross-tenant workspace lifecycle CRUD —
+ * list, get, stats, status, suspend/activate, plan tier, soft-delete.
  */
 
 import { Effect } from "effect";

--- a/packages/api/src/api/routes/middleware.ts
+++ b/packages/api/src/api/routes/middleware.ts
@@ -46,6 +46,24 @@ function authErrorCode(error: string): "session_expired" | "auth_error" {
   return EXPIRED_AUTH_ERRORS.has(error) ? "session_expired" : "auth_error";
 }
 
+/**
+ * Whether the current deploy mode is SaaS. Lazy-imported to avoid fighting
+ * the module graph; getConfig() is a cheap singleton read after boot and
+ * returning false if config isn't ready yet is the safe default (the gate
+ * is only *stricter* in SaaS; self-hosted behaviour is unchanged).
+ */
+function isSaasDeployMode(): boolean {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { getConfig } = require("@atlas/api/lib/config") as {
+      getConfig: () => { deployMode?: string } | null;
+    };
+    return getConfig()?.deployMode === "saas";
+  } catch {
+    return false;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Env type — declares context variables set by middleware
 // ---------------------------------------------------------------------------
@@ -277,7 +295,19 @@ export const platformAdminAuth = createMiddleware<AuthEnv>(async (c, next) => {
   }
   const { authResult } = auth;
 
-  // Enforce platform_admin role — auth mode "none" (local dev) is an implicit admin
+  // Defense-in-depth: `mode: "none"` is the no-auth local-dev carve-out and
+  // must never reach a platform gate in SaaS. If deploy mode is saas and we
+  // somehow produced mode:"none" at the auth layer (misconfigured env,
+  // regressed detect logic), fail closed — refusing is always safer than
+  // granting implicit cross-tenant admin.
+  if (authResult.mode === "none" && isSaasDeployMode()) {
+    log.error({ requestId }, "mode:\"none\" reached platformAdminAuth under SaaS deploy — rejecting");
+    return c.json({ error: "auth_misconfigured", message: "Platform auth is not configured.", requestId }, 500);
+  }
+
+  // Enforce platform_admin role — auth mode "none" (local dev / self-hosted
+  // no-auth) is an implicit admin. The SaaS guard above prevents this branch
+  // from ever being the cross-tenant escape hatch in managed deploys.
   if (authResult.mode !== "none" && (!authResult.user || authResult.user.role !== "platform_admin")) {
     log.warn({ requestId, userId: authResult.user?.id, role: authResult.user?.role }, "Non-platform-admin access attempt");
     return c.json({ error: "forbidden_role", message: "Platform admin role required.", requestId }, 403);


### PR DESCRIPTION
## Summary

Closes #1750 (F-08, P0). `admin-orgs.ts` previously used `createAdminRouter()` *without* `requireOrgContext()`, so every handler took `:id` from the path and acted on that target workspace with no check that the caller was an admin of it (or even a member). Any workspace admin on the platform could list, read, stat, suspend, activate, plan-change, or cascade soft-delete **any** workspace.

Swap to `createPlatformRouter()`: `platformAdminAuth` now returns `403 forbidden_role` for any caller whose effective role is not `platform_admin`. Pattern matches the F-10 fix in #1758; larger blast radius (direct cross-tenant CRUD vs. role escalation). Writeup: `.claude/research/security-audit-1-2-3.md` F-08.

## Changes

- **`packages/api/src/api/routes/admin-orgs.ts`** — `createAdminRouter` → `createPlatformRouter`; OpenAPI 403 response descriptions updated; top-of-file JSDoc refreshed. DELETE handler now surfaces `drainOrg` failures on the response `warnings[]` and logs at `error` (was: silently swallowed into `warn`).
- **`packages/api/src/api/routes/middleware.ts`** — `platformAdminAuth` defense-in-depth: fail-closed (500 `auth_misconfigured`) when `authResult.mode === "none"` and deploy mode is SaaS. Self-hosted unchanged.
- **`packages/api/src/api/__tests__/admin-orgs.test.ts`** (new) — parametrises over every route × every role so a future endpoint added without a platform gate fails CI. Covers:
  - workspace admin (`admin`) → 403 forbidden_role on every route
  - workspace owner (`owner`) → 403
  - regular member (`member`) → 401/403
  - platform admin (`platform_admin`) → not 403, response is JSON (proves handler ran, not a routing miss)
  - self-hosted (mode: `none`) → not 403 (locks in the documented carve-out)
  - unauthenticated → 401
  - bonus: `GET /` returns 200 + empty list for platform admin
- **`packages/api/src/api/__tests__/admin-workspace.test.ts`** — existing lifecycle tests were implicitly asserting the bug (role `admin` succeeded cross-tenant). Reauthed as `platform_admin`.
- **`.claude/research/security-audit-1-2-3.md`** — F-08 section `Status: fixed` block + severity-table row, matching the F-10 pattern.

## Review pass (4 agents)

All findings addressed:
- **comment-analyzer**: stale JSDoc "All routes require admin role" fixed; compressed rot-prone comments in test file + admin-workspace mock comment.
- **pr-test-analyzer**: added `mode="none"` carve-out lock-in test (8 routes × 1 scenario).
- **silent-failure-hunter Finding 1**: "platform admin passes the gate" suite now asserts `Content-Type: application/json` so a routing miss can't satisfy "not 403" vacuously.
- **silent-failure-hunter Finding 2**: `platformAdminAuth` now fails closed on `mode: "none"` in SaaS.
- **silent-failure-hunter Finding 3**: DELETE drain failures surface on response `warnings[]` + logged at `error`; asymmetry with fail-closed suspend now documented in-code.
- **code-reviewer**: signed off — no blockers; confirmed no adjacent `createAdminRouter`-without-`requireOrgContext` path-param routers beyond F-09 (#1751).

## Test plan

- [x] `bun run lint`
- [x] `bun run type`
- [x] `bun run test` (all packages green)
- [x] `bun x syncpack lint`
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh`
- [x] `bun test packages/api/src/api/__tests__/admin-orgs.test.ts` — 49 pass / 0 fail
- [x] `bun test packages/api/src/api/__tests__/admin-workspace.test.ts` — 25 pass / 0 fail