### PR TITLE
fix(security): P0 F-09 — restrict /admin/abuse/** to platform admins (#1751)

### DIFF
--- a/.claude/research/security-audit-1-2-3.md
+++ b/.claude/research/security-audit-1-2-3.md
@@ -491,6 +491,17 @@ moderation is platform-level by design; the audit log reference in
 `reinstateWorkspace(workspaceId, actorId)` already assumes the actor is a
 platform actor.
 
+**Status: fixed (PR #1763).** `admin-abuse.ts` now constructs its router via
+`createPlatformRouter()`; the `platformAdminAuth` middleware returns 403
+`forbidden_role` for any caller whose effective role is not `platform_admin`.
+Regression tests in
+`packages/api/src/api/__tests__/admin-abuse-platform-gate.test.ts`
+parametrise over every route (list flagged, detail, reinstate, config) so a
+future endpoint added to the subtree without a platform gate fails CI
+immediately. The pre-existing handler tests in `admin-abuse.test.ts` were
+implicitly asserting the bug (role `admin` succeeded cross-tenant) and are
+now authed as `platform_admin`.
+
 **F-10 — Workspace admin can escalate any org member to `platform_admin` via PATCH `/api/v1/admin/users/:id/role` and POST `/api/v1/admin/invitations`** — P0
 
 `admin.ts` `changeUserRoleRoute` validates the target user is a member of the
@@ -673,7 +684,7 @@ No new consumers since 1.2.2.
 | ID | Severity | Type | Path | Issue |
 |---|---|---|---|---|
 | F-08 | P0 | Cross-tenant admin | `/api/v1/admin/organizations/**` | #1750 — fixed (PR #1762) |
-| F-09 | P0 | Cross-tenant admin | `/api/v1/admin/abuse/**` | #1751 |
+| F-09 | P0 | Cross-tenant admin | `/api/v1/admin/abuse/**` | #1751 — fixed (PR #1763) |
 | F-10 | P0 | Privilege escalation | `/api/v1/admin/users/:id/role`, `/api/v1/admin/invitations` | #1752 — fixed (PR #1758) |
 | F-11 | P2 | Retention / scope | Conversation CRUD | #1753 |
 | F-12 | P2 | Retention / scope | Pending-action CRUD | #1754 |

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -14207,7 +14207,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — admin role required",
+            "description": "Forbidden — platform admin role required",
             "content": {
               "application/json": {
                 "schema": {
@@ -14512,7 +14512,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — admin role required",
+            "description": "Forbidden — platform admin role required",
             "content": {
               "application/json": {
                 "schema": {
@@ -14619,6 +14619,12 @@
                     "cascade": {
                       "type": "object",
                       "additionalProperties": {}
+                    },
+                    "warnings": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [
@@ -14666,7 +14672,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — admin role required",
+            "description": "Forbidden — platform admin role required",
             "content": {
               "application/json": {
                 "schema": {
@@ -14847,7 +14853,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — admin role required",
+            "description": "Forbidden — platform admin role required",
             "content": {
               "application/json": {
                 "schema": {
@@ -14999,7 +15005,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — admin role required",
+            "description": "Forbidden — platform admin role required",
             "content": {
               "application/json": {
                 "schema": {
@@ -15173,7 +15179,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — admin role required",
+            "description": "Forbidden — platform admin role required",
             "content": {
               "application/json": {
                 "schema": {
@@ -15394,7 +15400,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — admin role required",
+            "description": "Forbidden — platform admin role required",
             "content": {
               "application/json": {
                 "schema": {
@@ -15564,7 +15570,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — admin role required",
+            "description": "Forbidden — platform admin role required",
             "content": {
               "application/json": {
                 "schema": {
@@ -35943,6 +35949,12 @@
                     "total": {
                       "type": "number",
                       "description": "Total count"
+                    },
+                    "warnings": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [
@@ -35965,7 +35977,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — admin role required",
+            "description": "Forbidden — platform admin role required",
             "content": {
               "application/json": {
                 "schema": {
@@ -36048,6 +36060,12 @@
                     },
                     "message": {
                       "type": "string"
+                    },
+                    "warnings": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [
@@ -36096,7 +36114,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — admin role required",
+            "description": "Forbidden — platform admin role required",
             "content": {
               "application/json": {
                 "schema": {
@@ -36450,6 +36468,12 @@
                           "events"
                         ]
                       }
+                    },
+                    "warnings": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [
@@ -36481,7 +36505,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — admin role required",
+            "description": "Forbidden — platform admin role required",
             "content": {
               "application/json": {
                 "schema": {
@@ -36612,7 +36636,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — admin role required",
+            "description": "Forbidden — platform admin role required",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/api/src/api/__tests__/admin-abuse-platform-gate.test.ts
+++ b/packages/api/src/api/__tests__/admin-abuse-platform-gate.test.ts
@@ -7,9 +7,7 @@
  * router without a platform gate would surface here immediately.
  *
  * F-09 (#1751): pre-fix, the subtree was mounted on createAdminRouter(),
- * letting any workspace admin list flagged workspaces, pull investigation
- * detail on any target org, reinstate any suspended workspace, and read
- * platform-wide threshold config.
+ * letting any workspace admin reach every cross-tenant handler in it.
  */
 
 import {
@@ -23,7 +21,7 @@ import {
 } from "bun:test";
 import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
 
-// --- Unified mocks ---
+// --- Mocks ---
 //
 // Handler-level correctness is covered in admin-abuse.test.ts. This suite
 // only asserts the auth gate, so the abuse lib mocks are intentionally
@@ -134,9 +132,7 @@ function setPlatformAdmin(): void {
   mocks.setPlatformAdmin();
 }
 
-// Every route under the admin-abuse subtree. Parametrising here means a
-// future router addition without a platform gate surfaces immediately — the
-// F-09 fix's job is to keep this surface uniformly platform-gated.
+// Keep in sync with adminAbuse.openapi(...) calls in admin-abuse.ts.
 type RouteSpec = {
   readonly method: "GET" | "POST";
   readonly path: string;

--- a/packages/api/src/api/__tests__/admin-abuse-platform-gate.test.ts
+++ b/packages/api/src/api/__tests__/admin-abuse-platform-gate.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests for /api/v1/admin/abuse/** — the subtree provides cross-tenant abuse
+ * moderation (list flagged workspaces / investigation detail / reinstate /
+ * threshold config) and is platform-admin-only.
+ *
+ * These tests parametrize over every route so adding a new endpoint to the
+ * router without a platform gate would surface here immediately.
+ *
+ * F-09 (#1751): pre-fix, the subtree was mounted on createAdminRouter(),
+ * letting any workspace admin list flagged workspaces, pull investigation
+ * detail on any target org, reinstate any suspended workspace, and read
+ * platform-wide threshold config.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterAll,
+  mock,
+  type Mock,
+} from "bun:test";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+
+// --- Unified mocks ---
+//
+// Handler-level correctness is covered in admin-abuse.test.ts. This suite
+// only asserts the auth gate, so the abuse lib mocks are intentionally
+// minimal — they exist so platform-admin requests don't crash and confuse
+// the "not 403" assertion with a 500.
+
+const mockGetWorkspaceNamesByIds: Mock<(ids: string[]) => Promise<Map<string, string | null>>> =
+  mock(async (ids) => {
+    const m = new Map<string, string | null>();
+    for (const id of ids) m.set(id, null);
+    return m;
+  });
+
+const mocks = createApiTestMocks({
+  internal: {
+    getWorkspaceNamesByIds: mockGetWorkspaceNamesByIds,
+  },
+  authUser: {
+    id: "platform-admin-1",
+    mode: "managed",
+    label: "platform@test.com",
+    role: "platform_admin",
+    activeOrganizationId: "org-test",
+  },
+  authMode: "managed",
+});
+
+mock.module("@atlas/api/lib/security/abuse", () => ({
+  listFlaggedWorkspaces: mock(() => []),
+  reinstateWorkspace: mock(() => true),
+  getAbuseEvents: mock(async () => ({ events: [], status: "ok" })),
+  getAbuseConfig: mock(() => ({
+    queryRateLimit: 200,
+    queryRateWindowSeconds: 300,
+    errorRateThreshold: 0.5,
+    uniqueTablesLimit: 50,
+    throttleDelayMs: 2000,
+  })),
+  getAbuseDetail: mock(async () => null),
+  checkAbuseStatus: mock(() => ({ level: "none" })),
+  recordQueryEvent: mock(() => {}),
+  restoreAbuseState: mock(async () => {}),
+  _resetAbuseState: mock(() => {}),
+  abuseCleanupTick: mock(() => {}),
+  ABUSE_CLEANUP_INTERVAL_MS: 300_000,
+}));
+
+// --- Import app after mocks ---
+
+const { app } = await import("../index");
+
+afterAll(() => mocks.cleanup());
+
+// --- Helpers ---
+
+function abuseRequest(method: string, path: string, body?: unknown): Request {
+  const opts: RequestInit = {
+    method,
+    headers: { "Content-Type": "application/json", Authorization: "Bearer test-key" },
+  };
+  if (body !== undefined) opts.body = JSON.stringify(body);
+  return new Request(`http://localhost${path}`, opts);
+}
+
+function setWorkspaceAdmin(orgId = "org-1"): void {
+  mocks.mockAuthenticateRequest.mockResolvedValue({
+    authenticated: true,
+    mode: "managed",
+    user: {
+      id: "admin-1",
+      mode: "managed",
+      label: "admin@test.com",
+      role: "admin",
+      activeOrganizationId: orgId,
+    },
+  });
+}
+
+function setWorkspaceOwner(orgId = "org-1"): void {
+  mocks.mockAuthenticateRequest.mockResolvedValue({
+    authenticated: true,
+    mode: "managed",
+    user: {
+      id: "owner-1",
+      mode: "managed",
+      label: "owner@test.com",
+      role: "owner",
+      activeOrganizationId: orgId,
+    },
+  });
+}
+
+function setMember(orgId = "org-1"): void {
+  mocks.mockAuthenticateRequest.mockResolvedValue({
+    authenticated: true,
+    mode: "managed",
+    user: {
+      id: "member-1",
+      mode: "managed",
+      label: "member@test.com",
+      role: "member",
+      activeOrganizationId: orgId,
+    },
+  });
+}
+
+function setPlatformAdmin(): void {
+  mocks.setPlatformAdmin();
+}
+
+// Every route under the admin-abuse subtree. Parametrising here means a
+// future router addition without a platform gate surfaces immediately — the
+// F-09 fix's job is to keep this surface uniformly platform-gated.
+type RouteSpec = {
+  readonly method: "GET" | "POST";
+  readonly path: string;
+  readonly body?: unknown;
+};
+
+const ROUTES: ReadonlyArray<RouteSpec> = [
+  { method: "GET", path: "/api/v1/admin/abuse" },
+  { method: "GET", path: "/api/v1/admin/abuse/org_target/detail" },
+  { method: "POST", path: "/api/v1/admin/abuse/org_target/reinstate" },
+  { method: "GET", path: "/api/v1/admin/abuse/config" },
+];
+
+// --- Tests ---
+
+describe("/api/v1/admin/abuse/** — F-09 platform-admin gate (#1751)", () => {
+  beforeEach(() => {
+    mocks.mockAuthenticateRequest.mockReset();
+    mocks.hasInternalDB = true;
+    setPlatformAdmin();
+  });
+
+  describe("workspace admin (role: admin) is rejected", () => {
+    for (const route of ROUTES) {
+      it(`${route.method} ${route.path} → 403 forbidden_role`, async () => {
+        setWorkspaceAdmin("org-1");
+        const res = await app.fetch(abuseRequest(route.method, route.path, route.body));
+        expect(res.status).toBe(403);
+        const body = (await res.json()) as { error: string };
+        expect(body.error).toBe("forbidden_role");
+      });
+    }
+  });
+
+  describe("workspace owner (role: owner) is rejected", () => {
+    // Owner is still a workspace-scoped role — must not be able to reach
+    // platform-admin endpoints.
+    for (const route of ROUTES) {
+      it(`${route.method} ${route.path} → 403 forbidden_role`, async () => {
+        setWorkspaceOwner("org-1");
+        const res = await app.fetch(abuseRequest(route.method, route.path, route.body));
+        expect(res.status).toBe(403);
+        const body = (await res.json()) as { error: string };
+        expect(body.error).toBe("forbidden_role");
+      });
+    }
+  });
+
+  describe("regular member (role: member) is rejected", () => {
+    for (const route of ROUTES) {
+      it(`${route.method} ${route.path} → 401 or 403`, async () => {
+        setMember("org-1");
+        const res = await app.fetch(abuseRequest(route.method, route.path, route.body));
+        // Non-admin callers may 401 (auth pre-check) or 403 (role check);
+        // either way the handler must not run.
+        expect([401, 403]).toContain(res.status);
+      });
+    }
+  });
+
+  describe("platform admin (role: platform_admin) passes the gate", () => {
+    for (const route of ROUTES) {
+      it(`${route.method} ${route.path} → not 403`, async () => {
+        setPlatformAdmin();
+        const res = await app.fetch(abuseRequest(route.method, route.path, route.body));
+        // Handler ran — we don't care whether the target workspace is
+        // flagged in the mock (the detail route returns 404, reinstate
+        // returns 200 against the stub). The contract this test guards
+        // is "platform admin clears the auth gate"; behavioural
+        // correctness of each handler is covered elsewhere.
+        expect(res.status).not.toBe(403);
+        // Hono's default notFound returns text/plain — asserting JSON proves
+        // the handler, not a routing miss, produced the response. Without
+        // this a typo in ROUTES would let the "not 403" assertion pass
+        // vacuously on 404 text.
+        expect(res.headers.get("content-type") ?? "").toContain("application/json");
+        if (res.status >= 400) {
+          const body = (await res.json()) as { error?: string };
+          expect(body.error).not.toBe("forbidden_role");
+        }
+      });
+    }
+  });
+
+  describe("self-hosted (mode: none) bypasses the platform gate", () => {
+    // platformAdminAuth has a documented carve-out: when authResult.mode is
+    // "none" (self-hosted / local dev with no auth configured), the caller
+    // is treated as an implicit admin regardless of role. This is
+    // load-bearing for self-hosted deploys — removing the carve-out would
+    // break every self-hosted installation's access to abuse moderation.
+    // Lock it in so a future "tighten the gate" refactor surfaces the
+    // self-hosted implication.
+    for (const route of ROUTES) {
+      it(`${route.method} ${route.path} → not 403 when mode="none"`, async () => {
+        mocks.mockAuthenticateRequest.mockResolvedValue({
+          authenticated: true,
+          mode: "none",
+        });
+        const res = await app.fetch(abuseRequest(route.method, route.path, route.body));
+        expect(res.status).not.toBe(403);
+      });
+    }
+  });
+
+  describe("unauthenticated requests are rejected", () => {
+    for (const route of ROUTES) {
+      it(`${route.method} ${route.path} → 401`, async () => {
+        mocks.mockAuthenticateRequest.mockResolvedValue({
+          authenticated: false,
+          mode: "managed",
+          status: 401,
+          error: "Missing credentials",
+        });
+        const res = await app.fetch(abuseRequest(route.method, route.path, route.body));
+        expect(res.status).toBe(401);
+      });
+    }
+  });
+});

--- a/packages/api/src/api/__tests__/admin-abuse.test.ts
+++ b/packages/api/src/api/__tests__/admin-abuse.test.ts
@@ -180,7 +180,7 @@ describe("Admin Abuse API", () => {
       expect(body.workspaces.map((w) => w.workspaceId)).toEqual(["org-1", "org-2"]);
     });
 
-    it("falls back to null when name resolution rejects (#1640)", async () => {
+    it("falls back to null AND surfaces a warning when name resolution rejects (#1640, #1751)", async () => {
       mockListFlagged.mockImplementation(() => [
         {
           workspaceId: "org-1",
@@ -199,8 +199,16 @@ describe("Admin Abuse API", () => {
       // Must still 200 — name resolution is advisory. The page renders the
       // opaque id rather than 500'ing the admin.
       expect(res.status).toBe(200);
-      const body = await res.json() as { workspaces: Array<{ workspaceId: string; workspaceName: string | null }> };
+      const body = await res.json() as {
+        workspaces: Array<{ workspaceId: string; workspaceName: string | null }>;
+        warnings?: string[];
+      };
       expect(body.workspaces[0]?.workspaceName).toBeNull();
+      // F-09 follow-up: without a warnings[] channel, a platform admin can't
+      // tell "all names are genuinely null" from "DB couldn't answer" — an
+      // active wrong-row-selection hazard when reinstating by row click.
+      expect(body.warnings).toBeDefined();
+      expect(body.warnings?.[0]).toMatch(/^name_resolution_failed:/);
     });
 
     it("returns 403 for non-admin", async () => {
@@ -235,6 +243,45 @@ describe("Admin Abuse API", () => {
         adminRequest("POST", "/api/v1/admin/abuse/org-clean/reinstate"),
       );
       expect(res.status).toBe(400);
+    });
+
+    it("surfaces audit_persist_skipped warning when no internal DB (#1751)", async () => {
+      // Reinstate mutates in-memory state; the audit row goes to the
+      // internal DB via fire-and-forget `internalExecute`. When no
+      // internal DB is configured, the audit row can't exist at all —
+      // the admin needs an explicit warning rather than a successful
+      // 200 that hides a compliance gap.
+      mocks.hasInternalDB = false;
+      try {
+        const res = await app.fetch(
+          adminRequest("POST", "/api/v1/admin/abuse/org-1/reinstate"),
+        );
+        expect(res.status).toBe(200);
+        const body = await res.json() as {
+          success: boolean;
+          message: string;
+          warnings?: string[];
+        };
+        expect(body.success).toBe(true);
+        expect(body.warnings).toBeDefined();
+        expect(body.warnings?.[0]).toMatch(/^audit_persist_skipped:/);
+        expect(body.message).toMatch(/audit trail could not be written/i);
+      } finally {
+        mocks.hasInternalDB = true;
+      }
+    });
+
+    it("returns a clean success response when the internal DB is available", async () => {
+      // Counterpart to the no-DB test: when the DB is available, the
+      // response must not carry warnings — otherwise the UI shows the
+      // destructive banner for every routine reinstate.
+      const res = await app.fetch(
+        adminRequest("POST", "/api/v1/admin/abuse/org-1/reinstate"),
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json() as { warnings?: string[]; message: string };
+      expect(body.warnings).toBeUndefined();
+      expect(body.message).toBe("Workspace reinstated successfully.");
     });
 
     it("returns 403 for non-admin", async () => {
@@ -291,7 +338,7 @@ describe("Admin Abuse API", () => {
       expect(body.eventsStatus).toBe("ok");
     });
 
-    it("detail route falls back to null workspaceName when resolution rejects (#1640)", async () => {
+    it("detail falls back to null AND surfaces a warning when name resolution rejects (#1640, #1751)", async () => {
       mockGetAbuseDetail.mockImplementation(async () => ({
         workspaceId: "org-1",
         workspaceName: null,
@@ -312,10 +359,14 @@ describe("Admin Abuse API", () => {
         adminRequest("GET", "/api/v1/admin/abuse/org-1/detail"),
       );
       // Must still 200 — name resolution is advisory for the detail panel
-      // just as it is for the list (regression guard for #1640 follow-up).
+      // just as it is for the list. F-09 follow-up adds a warnings[]
+      // entry so the admin knows the identity header is degraded before
+      // clicking Reinstate.
       expect(res.status).toBe(200);
-      const body = await res.json() as { workspaceName: string | null };
+      const body = await res.json() as { workspaceName: string | null; warnings?: string[] };
       expect(body.workspaceName).toBeNull();
+      expect(body.warnings).toBeDefined();
+      expect(body.warnings?.[0]).toMatch(/^name_resolution_failed:/);
     });
 
     it("resolves workspaceName on the detail route (#1640)", async () => {

--- a/packages/api/src/api/__tests__/admin-abuse.test.ts
+++ b/packages/api/src/api/__tests__/admin-abuse.test.ts
@@ -2,6 +2,10 @@
  * Tests for admin abuse prevention API endpoints.
  *
  * Covers: GET /admin/abuse, POST /admin/abuse/:id/reinstate, GET /admin/abuse/config.
+ *
+ * These routes are platform-admin-only; workspace admins/owners are rejected
+ * at the auth gate. See admin-abuse-platform-gate.test.ts for the rejection
+ * matrix and security-audit-1-2-3.md F-09 for rationale.
  */
 
 import {
@@ -92,7 +96,7 @@ describe("Admin Abuse API", () => {
       Promise.resolve({
         authenticated: true,
         mode: "simple-key",
-        user: { id: "admin-1", mode: "simple-key", label: "Admin", role: "admin", activeOrganizationId: "org-1" },
+        user: { id: "platform-admin-1", mode: "simple-key", label: "Platform Admin", role: "platform_admin", activeOrganizationId: "org-1" },
       }),
     );
     mockListFlagged.mockImplementation(() => []);

--- a/packages/api/src/api/routes/admin-abuse.ts
+++ b/packages/api/src/api/routes/admin-abuse.ts
@@ -16,7 +16,7 @@ import {
   getAbuseConfig,
   getAbuseDetail,
 } from "@atlas/api/lib/security/abuse";
-import { getWorkspaceNamesByIds } from "@atlas/api/lib/db/internal";
+import { getWorkspaceNamesByIds, hasInternalDB } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
 
 const log = createLogger("admin-abuse");
@@ -40,12 +40,26 @@ import { createPlatformRouter } from "./admin-router";
 // schemas below are the ones that wrap the shared shapes (list envelope)
 // or describe route-only responses (reinstate).
 
-const ListResponseSchema = createListResponseSchema("workspaces", AbuseStatusSchema);
+// List/detail responses carry an optional `warnings[]` channel so the admin
+// UI can surface partial-failure state (e.g. workspace-name resolution fell
+// back to opaque ids because the internal DB hiccuped). Without it, a
+// platform admin reinstating a flagged workspace off the list can't tell
+// "the real name is missing" from "this row is just an id we can't render,"
+// which is an active wrong-row-selection hazard for a cross-tenant action.
+// Same shape as admin-orgs.ts DELETE /:id (PR #1762 follow-up commit).
+const ListResponseSchema = createListResponseSchema("workspaces", AbuseStatusSchema).extend({
+  warnings: z.array(z.string()).optional(),
+});
+
+const DetailResponseSchema = AbuseDetailSchema.extend({
+  warnings: z.array(z.string()).optional(),
+});
 
 const ReinstateResponseSchema = z.object({
   success: z.boolean(),
   workspaceId: z.string(),
   message: z.string(),
+  warnings: z.array(z.string()).optional(),
 });
 
 // ---------------------------------------------------------------------------
@@ -136,7 +150,7 @@ const getDetailRoute = createRoute({
   responses: {
     200: {
       description: "Investigation detail",
-      content: { "application/json": { schema: AbuseDetailSchema } },
+      content: { "application/json": { schema: DetailResponseSchema } },
     },
     404: {
       description: "Workspace not flagged",
@@ -200,19 +214,24 @@ const adminAbuse = createPlatformRouter();
 // GET / — list flagged workspaces
 adminAbuse.openapi(listFlaggedRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
+    const { requestId } = yield* RequestContext;
     const workspaces = listFlaggedWorkspaces();
 
     // Enrich with recent events from DB + resolve workspace names so the
     // admin table shows "Acme Corp" instead of "org_01K...". Names are a
     // batch fetch to avoid N+1; missing/deleted orgs fall back to null.
+    // If the name lookup itself fails, we still render the page (opaque
+    // ids beat a 500) but push a `warnings[]` entry so the UI can show a
+    // banner — without it a platform admin could mis-identify a row and
+    // reinstate the wrong tenant.
+    const warnings: string[] = [];
     const enriched = yield* Effect.promise(async () => {
       const orgIds = workspaces.map((ws) => ws.workspaceId);
       const [eventResults, names] = await Promise.all([
         Promise.all(workspaces.map((ws) => getAbuseEvents(ws.workspaceId, 10))),
         getWorkspaceNamesByIds(orgIds).catch((err) => {
-          // Name resolution is advisory — if the DB hiccups, fall back to
-          // null so the page still renders with opaque ids rather than 500.
-          log.warn(
+          const message = err instanceof Error ? err.message : String(err);
+          log.error(
             {
               err: err instanceof Error
                 ? { message: err.message, stack: err.stack }
@@ -220,9 +239,11 @@ adminAbuse.openapi(listFlaggedRoute, async (c) => {
               orgIdCount: orgIds.length,
               // First 5 ids for on-call correlation without flooding logs.
               sampleOrgIds: orgIds.slice(0, 5),
+              requestId,
             },
             "abuse list: workspace name resolution failed",
           );
+          warnings.push(`name_resolution_failed: ${message}`);
           return new Map<string, string | null>();
         }),
       ]);
@@ -246,7 +267,11 @@ adminAbuse.openapi(listFlaggedRoute, async (c) => {
       });
     });
 
-    return c.json({ workspaces: enriched, total: enriched.length }, 200);
+    return c.json({
+      workspaces: enriched,
+      total: enriched.length,
+      ...(warnings.length > 0 ? { warnings } : {}),
+    }, 200);
   }), { label: "list flagged workspaces" });
 });
 
@@ -266,10 +291,33 @@ adminAbuse.openapi(reinstateRoute, async (c) => {
       );
     }
 
+    // In-memory throttling is lifted by this point — customer queries are
+    // already flowing. If we can't also persist an audit row, the operator
+    // needs to know before they move on. `internalExecute` is
+    // fire-and-forget by design (it returns before the write completes),
+    // so the only silent failure we can catch *synchronously* is "there's
+    // no internal DB to persist to" — which reduces to certainty that no
+    // audit row will ever exist for this reinstate. Async persist
+    // failures are caught by `persistAbuseEvent` (now logged at error)
+    // and by `internalExecute`'s circuit breaker.
+    const warnings: string[] = [];
+    if (!hasInternalDB()) {
+      log.error(
+        { workspaceId, actorId, requestId },
+        "reinstate: audit row not persisted — no internal DB configured",
+      );
+      warnings.push(
+        "audit_persist_skipped: no internal DB configured; reinstate has no audit trail",
+      );
+    }
+
     return c.json({
       success: true,
       workspaceId,
-      message: "Workspace reinstated successfully.",
+      message: warnings.length > 0
+        ? "Workspace reinstated, but audit trail could not be written — see warnings."
+        : "Workspace reinstated successfully.",
+      ...(warnings.length > 0 ? { warnings } : {}),
     }, 200);
   }), { label: "reinstate workspace" });
 });
@@ -293,21 +341,31 @@ adminAbuse.openapi(getDetailRoute, async (c) => {
     }
 
     // Resolve the workspace display name. Advisory — see list route above.
+    // Surface a `warnings[]` entry on failure so the admin isn't flying
+    // blind on identity when about to reinstate a cross-tenant workspace.
+    const warnings: string[] = [];
     const nameMap = yield* Effect.promise(() =>
       getWorkspaceNamesByIds([workspaceId]).catch((err) => {
-        log.warn(
+        const message = err instanceof Error ? err.message : String(err);
+        log.error(
           {
             err: err instanceof Error
               ? { message: err.message, stack: err.stack }
               : String(err),
             workspaceId,
+            requestId,
           },
           "abuse detail: workspace name resolution failed",
         );
+        warnings.push(`name_resolution_failed: ${message}`);
         return new Map<string, string | null>();
       }),
     );
-    const enriched = { ...detail, workspaceName: nameMap.get(workspaceId) ?? null };
+    const enriched = {
+      ...detail,
+      workspaceName: nameMap.get(workspaceId) ?? null,
+      ...(warnings.length > 0 ? { warnings } : {}),
+    };
 
     return c.json(enriched, 200);
   }), { label: "read abuse detail" });

--- a/packages/api/src/api/routes/admin-abuse.ts
+++ b/packages/api/src/api/routes/admin-abuse.ts
@@ -1,7 +1,9 @@
 /**
  * Admin abuse prevention routes.
  *
- * Mounted under /api/v1/admin/abuse. All routes require admin role.
+ * Mounted under /api/v1/admin/abuse. Platform-admin only (see
+ * createPlatformRouter): every route takes a :workspaceId path param and acts
+ * cross-tenant, so workspace-scoped admins must not reach these handlers.
  * Provides listing of flagged workspaces, reinstatement, and threshold config.
  */
 
@@ -26,7 +28,7 @@ import {
   AbuseThresholdConfigSchema,
 } from "@useatlas/schemas";
 import { ErrorSchema, AuthErrorSchema, createListResponseSchema } from "./shared-schemas";
-import { createAdminRouter } from "./admin-router";
+import { createPlatformRouter } from "./admin-router";
 
 // ---------------------------------------------------------------------------
 // Schemas
@@ -66,7 +68,7 @@ const listFlaggedRoute = createRoute({
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     403: {
-      description: "Forbidden — admin role required",
+      description: "Forbidden — platform admin role required",
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     429: {
@@ -105,7 +107,7 @@ const reinstateRoute = createRoute({
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     403: {
-      description: "Forbidden — admin role required",
+      description: "Forbidden — platform admin role required",
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     429: {
@@ -145,7 +147,7 @@ const getDetailRoute = createRoute({
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     403: {
-      description: "Forbidden — admin role required",
+      description: "Forbidden — platform admin role required",
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     429: {
@@ -175,7 +177,7 @@ const getConfigRoute = createRoute({
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     403: {
-      description: "Forbidden — admin role required",
+      description: "Forbidden — platform admin role required",
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     429: {
@@ -193,7 +195,7 @@ const getConfigRoute = createRoute({
 // Router
 // ---------------------------------------------------------------------------
 
-const adminAbuse = createAdminRouter();
+const adminAbuse = createPlatformRouter();
 
 // GET / — list flagged workspaces
 adminAbuse.openapi(listFlaggedRoute, async (c) => {

--- a/packages/api/src/lib/security/abuse.ts
+++ b/packages/api/src/lib/security/abuse.ts
@@ -452,10 +452,12 @@ function persistAbuseEvent(event: AbuseEvent): void {
       ],
     );
   } catch (err) {
-    // Include workspaceId + eventId so on-call can correlate the lost
-    // write with the workspace it was for, rather than blind-grepping the
-    // audit trail.
-    log.warn(
+    // A lost audit row is always an error, not a warning — manual reinstate
+    // is a billing-affecting cross-tenant action and compliance reviewers
+    // need the trail. Include workspaceId + eventId so on-call can
+    // correlate the lost write with the workspace rather than grepping
+    // the whole audit table.
+    log.error(
       {
         err: err instanceof Error ? err.message : String(err),
         workspaceId: event.workspaceId,


### PR DESCRIPTION
## Summary

Closes #1751 — F-09, the last open P0 in milestone 1.2.3 phase 2.

`admin-abuse.ts` mounted its router on `createAdminRouter()` with no
`requireOrgContext()`, so every handler took `:workspaceId` from the path
and acted on that target org regardless of the caller's own org membership.
Any workspace admin on the platform could:

- `GET /api/v1/admin/abuse` — list every flagged workspace across tenants.
- `GET /api/v1/admin/abuse/:id/detail` — pull live counters, thresholds,
  current + prior instances for any target org.
- `POST /api/v1/admin/abuse/:id/reinstate` — unblock any suspended or
  throttled workspace; reset abuse counters on Atlas's bill.
- `GET /api/v1/admin/abuse/config` — read platform-wide thresholds.

Same structural bug as F-08, shipped as #1762. Same one-line fix.

## Fix

- `admin-abuse.ts`: swap `createAdminRouter()` → `createPlatformRouter()`
  (import + construction). `platformAdminAuth` returns 403 `forbidden_role`
  for any caller whose effective role is not `platform_admin`.
- Top-of-file JSDoc updated to describe the platform-only scope. Every
  OpenAPI 403 response description updated from "admin role required" →
  "platform admin role required".
- No handler changes — each route already targets `:workspaceId`, which is
  the correct behaviour for platform admins. The only caller-side data is
  `user.id` (audit actor for reinstate), which `platformAdminAuth` still
  populates.

## Tests

- **New** `packages/api/src/api/__tests__/admin-abuse-platform-gate.test.ts`
  parametrises a `ROUTES` table over every `adminAbuse.openapi(...)`
  registration. Buckets: workspace admin → 403, workspace owner → 403,
  regular member → 401/403, platform admin → not 403 (+ Content-Type
  JSON assertion to catch routing misses), self-hosted `mode: "none"` →
  not 403 (locks in the documented `platformAdminAuth` carve-out),
  unauthenticated → 401.
- **Updated** `admin-abuse.test.ts`: `beforeEach` now auths as
  `role: "platform_admin"` (was `"admin"` — implicitly asserting the bug).
  Top comment points at the new regression file + audit doc.

## Audit

- `.claude/research/security-audit-1-2-3.md` — F-09 section gets a
  `**Status: fixed (PR #1763).**` block, severity-table row updated to
  `#1751 — fixed (PR #1763)`. Pattern matches F-08 + F-10.

## CI gates passed locally

- [x] `bun run lint`
- [x] `bun run type`
- [x] `bun run test` (admin-abuse: 16 pass / admin-abuse-platform-gate: 24 pass / all suites green)
- [x] `bun x syncpack lint`
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh`

## Review

Plan is to run the 4-agent review (`/pr-review-toolkit:review-pr`) after
open and address findings in a follow-up commit before merge — same
process as #1762. The F-08 review already surfaced and fixed two
middleware concerns (`mode="none"` defense-in-depth, DELETE drain failure
surfacing); those fixes landed in shared infra and apply here.

## Notes

- No user-facing docs change — this is an admin-only surface tightening.
  Workspace admins never should have been hitting abuse moderation.
- Pre-existing Deploy Validation scaffold failures from the F-10 ORG_ROLES
  publish race are unrelated to this PR.

## Test plan

- [ ] Manual: workspace admin → 403 on each of the 4 routes (list, detail,
  reinstate, config).
- [ ] Manual: platform admin → 200 on list + config; 404 on detail for
  non-flagged org; 400 on reinstate for non-flagged org.
- [ ] Manual: self-hosted (`ATLAS_AUTH_MODE=none`) → each route still
  reachable (verified in regression test).