### PR TITLE
chore(deploy): unblock Deploy Validation scaffolds (cli/lib + types@0.0.15 refs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ tsconfig.tsbuildinfo
 .expert-cache/
 create-atlas/templates/*/semantic/
 create-atlas/templates/*/bin/
+create-atlas/templates/*/lib/
 create-atlas/templates/*/data/
 create-atlas/templates/*/docs/
 create-atlas/templates/*/src/

--- a/bun.lock
+++ b/bun.lock
@@ -227,7 +227,7 @@
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^5.96.2",
-        "@useatlas/types": "^0.0.14",
+        "@useatlas/types": "^0.0.15",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "radix-ui": "^1.4.3",
@@ -294,7 +294,7 @@
       "name": "@useatlas/sdk",
       "version": "0.0.11",
       "dependencies": {
-        "@useatlas/types": "^0.0.14",
+        "@useatlas/types": "^0.0.15",
       },
     },
     "packages/types": {
@@ -4227,10 +4227,6 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typespec/ts-http-runtime/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
-    "@useatlas/react/@useatlas/types": ["@useatlas/types@0.0.14", "", {}, "sha512-FHojA4aeljyqJc1hYYVGMPlRpz61vg3/e5qrtlm+bDqoDGLPsGVerLZvahCR0+Au81iq1xmExqohxei6OscHrA=="],
-
-    "@useatlas/sdk/@useatlas/types": ["@useatlas/types@0.0.14", "", {}, "sha512-FHojA4aeljyqJc1hYYVGMPlRpz61vg3/e5qrtlm+bDqoDGLPsGVerLZvahCR0+Au81iq1xmExqohxei6OscHrA=="],
 
     "@vercel/sandbox/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 

--- a/create-atlas/scripts/prepare-templates.sh
+++ b/create-atlas/scripts/prepare-templates.sh
@@ -11,6 +11,7 @@ MONOREPO="$ROOT/.."            # repo root
 
 TEMPLATES="$ROOT/templates"
 CLI_BIN="$MONOREPO/packages/cli/bin"
+CLI_LIB="$MONOREPO/packages/cli/lib"
 CLI_DATA="$MONOREPO/packages/cli/data"
 API_SRC="$MONOREPO/packages/api/src"
 WEB_SRC="$MONOREPO/packages/web/src"
@@ -31,14 +32,18 @@ for seed in simple cybersec ecommerce; do
 done
 
 # ── Step 1: Copy shared assets into ALL templates ─────────────────────
-# Every template gets: cli/bin, cli/data (seeds + init SQL), and docs/deploy.md
+# Every template gets: cli/bin, cli/lib, cli/data (seeds + init SQL), and docs/deploy.md
+# bin/atlas.ts imports from "../lib/help"; without lib/ the scaffolded
+# `bun run atlas` exits with "Cannot find module" at scaffold smoke-test time.
 for tpl in docker nextjs-standalone; do
   echo ":: Syncing shared assets → $tpl"
   rm -rf "$TEMPLATES/$tpl/bin" \
+         "$TEMPLATES/$tpl/lib" \
          "$TEMPLATES/$tpl/data" \
          "$TEMPLATES/$tpl/docs"
 
   cp -r "$CLI_BIN"      "$TEMPLATES/$tpl/bin"
+  cp -r "$CLI_LIB"      "$TEMPLATES/$tpl/lib"
   # Copy seed data (structured layout + backward-compat symlinks)
   mkdir -p "$TEMPLATES/$tpl/data/seeds"
   cp -r "$CLI_DATA"/seeds/* "$TEMPLATES/$tpl/data/seeds/"

--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -24,7 +24,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.0.7",
     "@useatlas/sdk": "^0.0.11",
-    "@useatlas/types": "^0.0.14",
+    "@useatlas/types": "^0.0.15",
     "@better-auth/api-key": "^1.5.6",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -21,7 +21,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.0.7",
     "@useatlas/sdk": "^0.0.11",
-    "@useatlas/types": "^0.0.14",
+    "@useatlas/types": "^0.0.15",
     "ai": "^6.0.141",
     "@better-auth/api-key": "^1.5.6",
     "@dnd-kit/core": "^6.3.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -82,7 +82,7 @@
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^5.96.2",
-    "@useatlas/types": "^0.0.14",
+    "@useatlas/types": "^0.0.15",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "radix-ui": "^1.4.3",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -44,6 +44,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@useatlas/types": "^0.0.14"
+    "@useatlas/types": "^0.0.15"
   }
 }


### PR DESCRIPTION
## Summary

Fixes the pre-existing Deploy Validation scaffold failures that have been
riding along since PR #1758 (F-10). These are the failures visible on
PR #1762 (F-08) and PR #1763 (F-09) at merge time.

Two root causes, one bundled fix:

### 1. Missing cli/lib sync in templates

\`packages/cli/bin/atlas.ts\` imports \`from \"../lib/help\"\`. The
\`prepare-templates.sh\` script copies \`cli/bin\` into every template but
never copied \`cli/lib\`. Scaffolded projects therefore exit with:

\`\`\`
error: Cannot find module '../lib/help' from '/tmp/.../smoke-test-app/bin/atlas.ts'
\`\`\`

Fix: add \`cp -r \"\$CLI_LIB\"\` alongside \`cp -r \"\$CLI_BIN\"\` and
gitignore the generated \`lib/\` directory under each template.

### 2. @useatlas/types 0.0.15 publish race

PR #1758 bumped \`packages/types/package.json\` to 0.0.15 and added
\`ORG_ROLES\` to the \`/auth\` subpath, but \`types-v0.0.15\` was never
tagged — so the publish workflow never fired and npm still served 0.0.14.
Scaffold builds failed with:

\`\`\`
./src/api/routes/shared-schemas.ts:3:1
Export ORG_ROLES doesn't exist in target module
\`\`\`

Fix (already done before this PR):
- Tagged \`types-v0.0.15\` on \`dc9a59a7\` (the lockfile-regen commit,
  not the F-10 merge directly — \`bun install --frozen-lockfile\` at the
  F-10 commit fails because the lockfile drift was fixed in #1759).
- OIDC publish workflow succeeded: \`bun x npm view @useatlas/types versions\`
  now lists \`0.0.15\`.

This PR completes step 3 of the version-bump ordering rule in CLAUDE.md:
bump consumer refs \`^0.0.14\` → \`^0.0.15\` in \`packages/sdk\`,
\`packages/react\`, and both \`create-atlas\` templates, and regenerate
\`bun.lock\`. Because 0.0.x semver pins exactly, consumers wouldn't have
picked up 0.0.15 without this step.

## CI gates passed locally

- [x] \`bun run lint\`
- [x] \`bun run type\`
- [x] \`bun x syncpack lint\`
- [x] \`SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh\` (ran template generator, drift clean)
- [x] \`bun x npm view @useatlas/types versions\` — 0.0.15 listed

## Follow-ups

None. This PR closes the publish race for 0.0.15. If the next minor bump
happens, the existing CLAUDE.md ordering rule still applies: bump
package.json in feature PR → tag after merge → bump refs in a follow-up.

## Test plan

- [ ] Wait for Deploy Validation (\`Scaffold (docker)\`, \`Scaffold (vercel)\`) to turn green on this PR.
- [ ] After merge, verify the next unrelated PR's Deploy Validation checks also pass without F-10-era failures.