### PR TITLE
fix(security): P2 F-11/F-12 — scope conversation + action CRUD by org_id

### DIFF
--- a/.claude/research/security-audit-1-2-3.md
+++ b/.claude/research/security-audit-1-2-3.md
@@ -686,8 +686,8 @@ No new consumers since 1.2.2.
 | F-08 | P0 | Cross-tenant admin | `/api/v1/admin/organizations/**` | #1750 — fixed (PR #1762) |
 | F-09 | P0 | Cross-tenant admin | `/api/v1/admin/abuse/**` | #1751 — fixed (PR #1763) |
 | F-10 | P0 | Privilege escalation | `/api/v1/admin/users/:id/role`, `/api/v1/admin/invitations` | #1752 — fixed (PR #1758) |
-| F-11 | P2 | Retention / scope | Conversation CRUD | #1753 |
-| F-12 | P2 | Retention / scope | Pending-action CRUD | #1754 |
+| F-11 | P2 | Retention / scope | Conversation CRUD | #1753 — fixed (this PR) |
+| F-12 | P2 | Retention / scope | Pending-action CRUD | #1754 — fixed (this PR) |
 | F-13 | P2 | Cross-tenant write | `/api/v1/admin/approval/expire` | #1755 |
 | F-14 | P2 | Scope overreach | User ban | #1756 |
 | F-15 | P3 | Info leak | `/api/v1/validate-sql` connectionId | — (P3, stays in doc) |

--- a/packages/api/src/api/__tests__/actions.test.ts
+++ b/packages/api/src/api/__tests__/actions.test.ts
@@ -161,6 +161,14 @@ mock.module("@atlas/api/lib/startup", () => ({
   getStartupWarnings: () => [],
 }));
 
+// EE IP-allowlist middleware runs when auth mock sets `activeOrganizationId`.
+// Stub with `{ allowed: true }` so route tests can assert orgId propagation
+// without hitting a real postgres.
+import { Effect as _EffectForAllowlistMock } from "effect";
+mock.module("@atlas/ee/auth/ip-allowlist", () => ({
+  checkIPAllowlist: () => _EffectForAllowlistMock.succeed({ allowed: true as const }),
+}));
+
 // Enable actions route before importing the app — the route mounts conditionally
 process.env.ATLAS_ACTIONS_ENABLED = "true";
 
@@ -204,7 +212,12 @@ describe("actions routes", () => {
     mockAuthenticateRequest.mockResolvedValue({
       authenticated: true as const,
       mode: "simple-key" as const,
-      user: { id: "u1", label: "test@test.com", mode: "simple-key" as const },
+      user: {
+        id: "u1",
+        label: "test@test.com",
+        mode: "simple-key" as const,
+        activeOrganizationId: "org-u1",
+      },
     });
     mockCheckRateLimit.mockReset();
     mockCheckRateLimit.mockReturnValue({ allowed: true });
@@ -1125,6 +1138,79 @@ describe("actions routes", () => {
 
       const call = mockBulkApproveActions.mock.calls[0] as unknown as [{ orgId?: string | null }];
       expect(call[0].orgId).toBe("org-42");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Route-layer orgId scoping (F-12) — regression guard for the single-action
+  // endpoints. A refactor that drops `user?.activeOrganizationId` at any call
+  // site silently regresses the security invariant; these tests catch it.
+  // -----------------------------------------------------------------------
+
+  describe("route-layer orgId scoping (F-12)", () => {
+    it("GET / forwards orgId to listPendingActions", async () => {
+      await app.fetch(new Request("http://localhost/api/v1/actions?status=pending"));
+      const call = mockListPendingActions.mock.calls[0] as unknown as [{ orgId?: string | null }];
+      expect(call[0].orgId).toBe("org-u1");
+    });
+
+    it("GET /:id forwards orgId to getAction", async () => {
+      mockGetAction.mockResolvedValueOnce(makeAction({ requested_by: "u1" }));
+      await app.fetch(new Request(`http://localhost/api/v1/actions/${VALID_ID}`));
+      const call = mockGetAction.mock.calls[0] as unknown as [string, string | undefined];
+      expect(call[0]).toBe(VALID_ID);
+      expect(call[1]).toBe("org-u1");
+    });
+
+    it("POST /:id/approve forwards orgId to getAction and approveAction", async () => {
+      mockGetAction.mockResolvedValueOnce(makeAction({ requested_by: "other-user" }));
+      mockApproveAction.mockResolvedValueOnce(makeAction({ status: "executed" }));
+
+      await app.fetch(
+        new Request(`http://localhost/api/v1/actions/${VALID_ID}/approve`, {
+          method: "POST",
+        }),
+      );
+      const getCall = mockGetAction.mock.calls[0] as unknown as [string, string | undefined];
+      expect(getCall[1]).toBe("org-u1");
+      const approveCall = mockApproveAction.mock.calls[0] as unknown as [string, string, unknown, string | undefined];
+      expect(approveCall[3]).toBe("org-u1");
+    });
+
+    it("POST /:id/deny forwards orgId to getAction and denyAction", async () => {
+      mockGetAction.mockResolvedValueOnce(makeAction({ requested_by: "other-user" }));
+      mockDenyAction.mockResolvedValueOnce(makeAction({ status: "denied" }));
+
+      await app.fetch(
+        new Request(`http://localhost/api/v1/actions/${VALID_ID}/deny`, {
+          method: "POST",
+        }),
+      );
+      const getCall = mockGetAction.mock.calls[0] as unknown as [string, string | undefined];
+      expect(getCall[1]).toBe("org-u1");
+      const denyCall = mockDenyAction.mock.calls[0] as unknown as [string, string, string | undefined, string | undefined];
+      expect(denyCall[3]).toBe("org-u1");
+    });
+
+    it("POST /:id/rollback forwards orgId to getAction and rollbackAction", async () => {
+      mockGetAction.mockResolvedValueOnce(
+        makeAction({
+          status: "executed",
+          rollback_info: { method: "test", params: {} },
+          requested_by: "other-user",
+        }),
+      );
+      mockRollbackAction.mockResolvedValueOnce(makeAction({ status: "rolled_back" }));
+
+      await app.fetch(
+        new Request(`http://localhost/api/v1/actions/${VALID_ID}/rollback`, {
+          method: "POST",
+        }),
+      );
+      const getCall = mockGetAction.mock.calls[0] as unknown as [string, string | undefined];
+      expect(getCall[1]).toBe("org-u1");
+      const rollbackCall = mockRollbackAction.mock.calls[0] as unknown as [string, string, string | undefined];
+      expect(rollbackCall[2]).toBe("org-u1");
     });
   });
 });

--- a/packages/api/src/api/__tests__/actions.test.ts
+++ b/packages/api/src/api/__tests__/actions.test.ts
@@ -189,6 +189,7 @@ function makeAction(overrides: Partial<ActionLogEntry> = {}): ActionLogEntry {
     rollback_info: null,
     conversation_id: null,
     request_id: null,
+    org_id: null,
     ...overrides,
   };
 }

--- a/packages/api/src/api/__tests__/conversations.test.ts
+++ b/packages/api/src/api/__tests__/conversations.test.ts
@@ -62,6 +62,10 @@ const mockUnshareConversation = mock((): Promise<CrudResult> => Promise.resolve(
 const mockGetShareStatus = mock((): Promise<CrudDataResult<import("@atlas/api/lib/conversations").ShareStatusData>> => Promise.resolve({ ok: false, reason: "not_found" }));
 const mockGetSharedConversation = mock((): Promise<import("@atlas/api/lib/conversations").SharedConversationResult> => Promise.resolve({ ok: false, reason: "not_found" }));
 const mockConvertToNotebook = mock((): Promise<CrudDataResult<{ id: string; messageCount: number }>> => Promise.resolve({ ok: false, reason: "not_found" }));
+const mockUpdateNotebookState = mock((): Promise<CrudResult> => Promise.resolve({ ok: true }));
+const mockForkConversation = mock((): Promise<CrudDataResult<{ id: string; messageCount: number }>> => Promise.resolve({ ok: false, reason: "not_found" }));
+const mockDeleteBranch = mock((): Promise<CrudResult> => Promise.resolve({ ok: false, reason: "not_found" }));
+const mockRenameBranch = mock((): Promise<CrudResult> => Promise.resolve({ ok: false, reason: "not_found" }));
 
 mock.module("@atlas/api/lib/conversations", () => ({
   listConversations: mockListConversations,
@@ -77,11 +81,11 @@ mock.module("@atlas/api/lib/conversations", () => ({
   addMessage: mockAddMessage,
   generateTitle: mockGenerateTitle,
   persistAssistantSteps: mock(() => {}),
-  updateNotebookState: mock(() => Promise.resolve({ ok: true })),
-  forkConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  updateNotebookState: mockUpdateNotebookState,
+  forkConversation: mockForkConversation,
   convertToNotebook: mockConvertToNotebook,
-  deleteBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
-  renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  deleteBranch: mockDeleteBranch,
+  renameBranch: mockRenameBranch,
   // Type exports (no runtime value — needed so mock.module doesn't break re-exports)
 }));
 
@@ -124,6 +128,15 @@ mock.module("@atlas/api/lib/startup", () => ({
   getStartupWarnings: () => [],
 }));
 
+// EE IP-allowlist middleware is triggered whenever the auth mock sets
+// `activeOrganizationId`. Stub it with `{ allowed: true }` so tests can
+// assert the user + orgId are forwarded to lib helpers without hitting a
+// real postgres. The same stub unblocks F-11 route-layer assertions.
+import { Effect as _EffectForAllowlistMock } from "effect";
+mock.module("@atlas/ee/auth/ip-allowlist", () => ({
+  checkIPAllowlist: () => _EffectForAllowlistMock.succeed({ allowed: true as const }),
+}));
+
 // Import after mocks
 const { app } = await import("../index");
 
@@ -140,7 +153,12 @@ describe("conversations routes", () => {
     mockAuthenticateRequest.mockResolvedValue({
       authenticated: true as const,
       mode: "simple-key" as const,
-      user: { id: "u1", label: "test@test.com", mode: "simple-key" as const },
+      user: {
+        id: "u1",
+        label: "test@test.com",
+        mode: "simple-key" as const,
+        activeOrganizationId: "org-u1",
+      },
     });
     mockCheckRateLimit.mockReset();
     mockCheckRateLimit.mockReturnValue({ allowed: true });
@@ -164,6 +182,14 @@ describe("conversations routes", () => {
     mockGetSharedConversation.mockResolvedValue({ ok: false, reason: "not_found" });
     mockConvertToNotebook.mockReset();
     mockConvertToNotebook.mockResolvedValue({ ok: false, reason: "not_found" });
+    mockUpdateNotebookState.mockReset();
+    mockUpdateNotebookState.mockResolvedValue({ ok: true });
+    mockForkConversation.mockReset();
+    mockForkConversation.mockResolvedValue({ ok: false, reason: "not_found" });
+    mockDeleteBranch.mockReset();
+    mockDeleteBranch.mockResolvedValue({ ok: false, reason: "not_found" });
+    mockRenameBranch.mockReset();
+    mockRenameBranch.mockResolvedValue({ ok: false, reason: "not_found" });
   });
 
   afterEach(() => {
@@ -325,15 +351,16 @@ describe("conversations routes", () => {
       expect(response.status).toBe(404);
     });
 
-    it("passes userId for auth scoping", async () => {
+    it("passes userId + orgId for auth scoping", async () => {
       mockGetConversation.mockResolvedValueOnce({ ok: false, reason: "not_found" });
 
       await app.fetch(
         new Request(`http://localhost/api/v1/conversations/${VALID_ID}`),
       );
-      const call = mockGetConversation.mock.calls[0] as unknown as [string, string | undefined];
+      const call = mockGetConversation.mock.calls[0] as unknown as [string, string | undefined, string | undefined];
       expect(call[0]).toBe(VALID_ID);
       expect(call[1]).toBe("u1");
+      expect(call[2]).toBe("org-u1");
     });
 
     it("returns 400 for invalid conversation ID format", async () => {
@@ -399,7 +426,7 @@ describe("conversations routes", () => {
       expect(response.status).toBe(404);
     });
 
-    it("passes userId for auth scoping", async () => {
+    it("passes userId + orgId for auth scoping", async () => {
       mockDeleteConversation.mockResolvedValueOnce({ ok: false, reason: "not_found" });
 
       await app.fetch(
@@ -407,9 +434,10 @@ describe("conversations routes", () => {
           method: "DELETE",
         }),
       );
-      const call = mockDeleteConversation.mock.calls[0] as unknown as [string, string | undefined];
+      const call = mockDeleteConversation.mock.calls[0] as unknown as [string, string | undefined, string | undefined];
       expect(call[0]).toBe(VALID_ID);
       expect(call[1]).toBe("u1");
+      expect(call[2]).toBe("org-u1");
     });
 
     it("returns 400 for invalid conversation ID format", async () => {
@@ -574,7 +602,7 @@ describe("conversations routes", () => {
       expect(response.status).toBe(404);
     });
 
-    it("passes userId for auth scoping", async () => {
+    it("passes userId + orgId for auth scoping", async () => {
       mockStarConversation.mockResolvedValueOnce({ ok: true });
 
       await app.fetch(
@@ -584,10 +612,11 @@ describe("conversations routes", () => {
           body: JSON.stringify({ starred: true }),
         }),
       );
-      const call = mockStarConversation.mock.calls[0] as unknown as [string, boolean, string | undefined];
+      const call = mockStarConversation.mock.calls[0] as unknown as [string, boolean, string | undefined, string | undefined];
       expect(call[0]).toBe(VALID_ID);
       expect(call[1]).toBe(true);
       expect(call[2]).toBe("u1");
+      expect(call[3]).toBe("org-u1");
     });
   });
 
@@ -649,7 +678,7 @@ describe("conversations routes", () => {
       expect(response.status).toBe(400);
     });
 
-    it("passes userId for auth scoping", async () => {
+    it("passes userId + orgId for auth scoping", async () => {
       mockGetShareStatus.mockResolvedValueOnce({
         ok: true,
         data: { shared: false as const, token: null, expiresAt: null, shareMode: null },
@@ -658,9 +687,10 @@ describe("conversations routes", () => {
       await app.fetch(
         new Request(`http://localhost/api/v1/conversations/${VALID_ID}/share`),
       );
-      const call = mockGetShareStatus.mock.calls[0] as unknown as [string, string | undefined];
+      const call = mockGetShareStatus.mock.calls[0] as unknown as [string, string | undefined, string | undefined];
       expect(call[0]).toBe(VALID_ID);
       expect(call[1]).toBe("u1");
+      expect(call[2]).toBe("org-u1");
     });
 
     it("returns 404 when no internal DB", async () => {
@@ -733,8 +763,8 @@ describe("conversations routes", () => {
         }),
       );
       expect(response.status).toBe(200);
-      const call = mockShareConversation.mock.calls[0] as unknown as [string, string | undefined, { expiresIn?: string; shareMode?: string }];
-      expect(call[2]).toEqual({ expiresIn: "7d", shareMode: "org" });
+      const call = mockShareConversation.mock.calls[0] as unknown as [string, string | undefined, { orgId?: string | null; expiresIn?: string; shareMode?: string }];
+      expect(call[2]).toEqual({ orgId: "org-u1", expiresIn: "7d", shareMode: "org" });
     });
 
     it("returns 404 when conversation not found", async () => {
@@ -757,7 +787,7 @@ describe("conversations routes", () => {
       expect(response.status).toBe(400);
     });
 
-    it("passes userId for auth scoping", async () => {
+    it("passes userId + orgId for auth scoping", async () => {
       mockShareConversation.mockResolvedValueOnce({ ok: true, data: { token: "tok", expiresAt: null, shareMode: "public" } });
 
       await app.fetch(
@@ -765,9 +795,11 @@ describe("conversations routes", () => {
           method: "POST",
         }),
       );
-      const call = mockShareConversation.mock.calls[0] as unknown as [string, string | undefined, unknown];
+      // shareConversation stores orgId inside opts rather than as a positional arg.
+      const call = mockShareConversation.mock.calls[0] as unknown as [string, string | undefined, { orgId?: string | null }];
       expect(call[0]).toBe(VALID_ID);
       expect(call[1]).toBe("u1");
+      expect(call[2]?.orgId).toBe("org-u1");
     });
 
     it("returns 404 when no internal DB", async () => {
@@ -896,7 +928,7 @@ describe("conversations routes", () => {
       expect(response.status).toBe(400);
     });
 
-    it("passes userId for auth scoping", async () => {
+    it("passes userId + orgId for auth scoping", async () => {
       mockUnshareConversation.mockResolvedValueOnce({ ok: true });
 
       await app.fetch(
@@ -904,9 +936,10 @@ describe("conversations routes", () => {
           method: "DELETE",
         }),
       );
-      const call = mockUnshareConversation.mock.calls[0] as unknown as [string, string | undefined];
+      const call = mockUnshareConversation.mock.calls[0] as unknown as [string, string | undefined, string | undefined];
       expect(call[0]).toBe(VALID_ID);
       expect(call[1]).toBe("u1");
+      expect(call[2]).toBe("org-u1");
     });
 
     it("returns 500 on database error", async () => {
@@ -1419,9 +1452,98 @@ describe("conversations routes", () => {
         }),
       );
 
-      // simple-key auth has no activeOrganizationId, so orgId is undefined
       expect(mockConvertToNotebook).toHaveBeenCalledWith(
-        expect.objectContaining({ sourceId: VALID_ID, userId: "u1", orgId: undefined }),
+        expect.objectContaining({ sourceId: VALID_ID, userId: "u1", orgId: "org-u1" }),
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Route-layer orgId scoping (F-11) — regression guard for the 5 routes
+  // below which previously had no route test. A refactor that drops
+  // `user?.activeOrganizationId` at any call site silently regresses the
+  // security invariant; these tests catch it.
+  // -----------------------------------------------------------------------
+
+  describe("route-layer orgId scoping (F-11)", () => {
+    it("PATCH /:id/notebook-state forwards orgId", async () => {
+      mockUpdateNotebookState.mockResolvedValueOnce({ ok: true });
+
+      await app.fetch(
+        new Request(`http://localhost/api/v1/conversations/${VALID_ID}/notebook-state`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ version: 3 }),
+        }),
+      );
+      const call = mockUpdateNotebookState.mock.calls[0] as unknown as [string, unknown, string | undefined, string | undefined];
+      expect(call[0]).toBe(VALID_ID);
+      expect(call[2]).toBe("u1");
+      expect(call[3]).toBe("org-u1");
+    });
+
+    it("POST /:id/fork forwards orgId via opts", async () => {
+      // Fork returns a new conversation id for the source update paths to proceed.
+      mockForkConversation.mockResolvedValueOnce({
+        ok: true,
+        data: { id: "b1b2c3d4-e5f6-7890-abcd-ef1234567890", messageCount: 1 },
+      });
+      // The fork handler also re-reads the source conversation for branch metadata.
+      mockGetConversation.mockResolvedValueOnce({
+        ok: true,
+        data: {
+          id: VALID_ID,
+          userId: "u1",
+          title: null,
+          surface: "web",
+          connectionId: null,
+          starred: false,
+          notebookState: null,
+          createdAt: "2024-01-01T00:00:00Z",
+          updatedAt: "2024-01-01T00:00:00Z",
+          messages: [],
+        },
+      });
+
+      await app.fetch(
+        new Request(`http://localhost/api/v1/conversations/${VALID_ID}/fork`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ forkPointMessageId: "m1" }),
+        }),
+      );
+      expect(mockForkConversation).toHaveBeenCalledWith(
+        expect.objectContaining({ sourceId: VALID_ID, userId: "u1", orgId: "org-u1" }),
+      );
+    });
+
+    it("DELETE /:id/branches/:branchId forwards orgId via opts", async () => {
+      mockDeleteBranch.mockResolvedValueOnce({ ok: true });
+      const BRANCH_ID = "b1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+      await app.fetch(
+        new Request(`http://localhost/api/v1/conversations/${VALID_ID}/branches/${BRANCH_ID}`, {
+          method: "DELETE",
+        }),
+      );
+      expect(mockDeleteBranch).toHaveBeenCalledWith(
+        expect.objectContaining({ rootId: VALID_ID, branchId: BRANCH_ID, userId: "u1", orgId: "org-u1" }),
+      );
+    });
+
+    it("PATCH /:id/branches/:branchId forwards orgId via opts", async () => {
+      mockRenameBranch.mockResolvedValueOnce({ ok: true });
+      const BRANCH_ID = "b1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+      await app.fetch(
+        new Request(`http://localhost/api/v1/conversations/${VALID_ID}/branches/${BRANCH_ID}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ label: "renamed" }),
+        }),
+      );
+      expect(mockRenameBranch).toHaveBeenCalledWith(
+        expect.objectContaining({ rootId: VALID_ID, branchId: BRANCH_ID, label: "renamed", userId: "u1", orgId: "org-u1" }),
       );
     });
   });

--- a/packages/api/src/api/routes/actions.ts
+++ b/packages/api/src/api/routes/actions.ts
@@ -408,6 +408,7 @@ actions.openapi(listActionsRoute, async (c) => {
     const items = yield* Effect.promise(() => listPendingActions({
       status,
       userId: user?.id,
+      orgId: user?.activeOrganizationId,
       limit,
     }));
     return c.json({ actions: items }, 200);
@@ -432,7 +433,7 @@ actions.openapi(getActionRoute, async (c) => {
       return c.json({ error: "invalid_request", message: "Invalid action ID format." }, 400);
     }
 
-    const action = yield* Effect.promise(() => getAction(id));
+    const action = yield* Effect.promise(() => getAction(id, user?.activeOrganizationId));
     if (!action || action.requested_by !== user?.id) {
       return c.json({ error: "not_found", message: "Action not found." }, 404);
     }
@@ -459,9 +460,11 @@ actions.openapi(approveActionRoute, async (c) => {
     }
 
     const approverId = user?.id ?? "anonymous";
+    const orgId = user?.activeOrganizationId;
 
-    // Look up action and executor
-    const action = yield* Effect.promise(() => getAction(id));
+    // Look up action and executor — scoped to caller's active org so cross-org
+    // access surfaces as 404 rather than 403 (don't leak existence).
+    const action = yield* Effect.promise(() => getAction(id, orgId));
     if (!action) {
       return c.json({ error: "not_found", message: "Action not found." }, 404);
     }
@@ -479,7 +482,7 @@ actions.openapi(approveActionRoute, async (c) => {
 
     const executor = getActionExecutor(id);
 
-    const approveResult = yield* Effect.promise(() => approveAction(id, approverId, executor));
+    const approveResult = yield* Effect.promise(() => approveAction(id, approverId, executor, orgId));
     if (!approveResult) {
       return c.json({ error: "conflict", message: "Action has already been resolved." }, 409);
     }
@@ -508,9 +511,10 @@ actions.openapi(
       }
 
       const denierId = user?.id ?? "anonymous";
+      const orgId = user?.activeOrganizationId;
 
-      // Look up action for permission enforcement
-      const action = yield* Effect.promise(() => getAction(id));
+      // Look up action for permission enforcement — org-scoped (cross-org → 404).
+      const action = yield* Effect.promise(() => getAction(id, orgId));
       if (!action) {
         return c.json({ error: "not_found", message: "Action not found." }, 404);
       }
@@ -546,7 +550,7 @@ actions.openapi(
         }
       }
 
-      const denyResult = yield* Effect.promise(() => denyAction(id, denierId, reason));
+      const denyResult = yield* Effect.promise(() => denyAction(id, denierId, reason, orgId));
       if (!denyResult) {
         return c.json({ error: "conflict", message: "Action has already been resolved." }, 409);
       }
@@ -633,7 +637,8 @@ actions.openapi(rollbackActionRoute, async (c) => {
       return c.json({ error: "invalid_request", message: "Invalid action ID format." }, 400);
     }
 
-    const action = yield* Effect.promise(() => getAction(id));
+    const orgId = user?.activeOrganizationId;
+    const action = yield* Effect.promise(() => getAction(id, orgId));
     if (!action) {
       return c.json({ error: "not_found", message: "Action not found." }, 404);
     }
@@ -649,7 +654,7 @@ actions.openapi(rollbackActionRoute, async (c) => {
     }
 
     const rollbackerId = user?.id ?? "anonymous";
-    const rollbackResult = yield* Effect.promise(() => rollbackAction(id, rollbackerId));
+    const rollbackResult = yield* Effect.promise(() => rollbackAction(id, rollbackerId, orgId));
     if (!rollbackResult) {
       return c.json({ error: "conflict", message: "Action cannot be rolled back. It may have been rolled back already or changed state." }, 409);
     }

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -380,7 +380,7 @@ chat.openapi(chatRoute, async (c) => {
         if (hasInternalDB()) {
           if (conversationId) {
             // Ownership verification — NOT best-effort, this is a security check
-            const existing = await getConversation(conversationId, authResult.user?.id);
+            const existing = await getConversation(conversationId, authResult.user?.id, authResult.user?.activeOrganizationId);
             if (!existing.ok) {
               return c.json({ error: "not_found", message: "Conversation not found.", retryable: false, requestId }, 404);
             }

--- a/packages/api/src/api/routes/conversations.ts
+++ b/packages/api/src/api/routes/conversations.ts
@@ -765,7 +765,7 @@ conversations.openapi(getConversationRoute, async (c) => {
       return c.json({ error: "invalid_request", message: "Invalid conversation ID format." }, 400);
     }
 
-    const conv = yield* Effect.promise(() => getConversation(id, user?.id));
+    const conv = yield* Effect.promise(() => getConversation(id, user?.id, user?.activeOrganizationId));
     if (!conv.ok) {
       const fail = crudFailResponse(conv.reason, requestId);
       return c.json(fail.body, fail.status);
@@ -794,7 +794,7 @@ conversations.openapi(starConversationRoute, async (c) => {
 
     const parsed = c.req.valid("json");
 
-    const starResult = yield* Effect.promise(() => starConversation(id, parsed.starred, user?.id));
+    const starResult = yield* Effect.promise(() => starConversation(id, parsed.starred, user?.id, user?.activeOrganizationId));
     if (!starResult.ok) {
       const fail = crudFailResponse(starResult.reason, requestId);
       return c.json(fail.body, fail.status);
@@ -823,7 +823,7 @@ conversations.openapi(notebookStateRoute, async (c) => {
 
     const parsed = c.req.valid("json");
 
-    const nbResult = yield* Effect.promise(() => updateNotebookState(id, parsed, user?.id));
+    const nbResult = yield* Effect.promise(() => updateNotebookState(id, parsed, user?.id, user?.activeOrganizationId));
     if (!nbResult.ok) {
       const fail = crudFailResponse(nbResult.reason, requestId);
       return c.json(fail.body, fail.status);
@@ -873,7 +873,7 @@ conversations.openapi(forkConversationRoute, async (c) => {
     };
 
     // Read current notebook_state from source to preserve existing data
-    const sourceConv = yield* Effect.promise(() => getConversation(id, user?.id));
+    const sourceConv = yield* Effect.promise(() => getConversation(id, user?.id, user?.activeOrganizationId));
     if (!sourceConv.ok) {
       log.error({ requestId, conversationId: id, reason: sourceConv.reason }, "Failed to read source conversation for branch metadata");
       return c.json({
@@ -902,8 +902,8 @@ conversations.openapi(forkConversationRoute, async (c) => {
 
     // Write both notebook_state updates in parallel
     const [sourceResult, forkMetaResult] = yield* Effect.promise(() => Promise.all([
-      updateNotebookState(id, updatedSourceState, user?.id),
-      updateNotebookState(forkResult.data.id, forkChildState, user?.id),
+      updateNotebookState(id, updatedSourceState, user?.id, user?.activeOrganizationId),
+      updateNotebookState(forkResult.data.id, forkChildState, user?.id, user?.activeOrganizationId),
     ]));
 
     let metadataWarning: string | undefined;
@@ -980,6 +980,7 @@ conversations.openapi(deleteBranchRoute, async (c) => {
       rootId: id,
       branchId,
       userId: user?.id,
+      orgId: user?.activeOrganizationId,
     }));
     if (!result.ok) {
       const fail = crudFailResponse(result.reason, requestId);
@@ -1014,6 +1015,7 @@ conversations.openapi(renameBranchRoute, async (c) => {
       branchId,
       label: parsed.label,
       userId: user?.id,
+      orgId: user?.activeOrganizationId,
     }));
     if (!result.ok) {
       const fail = crudFailResponse(result.reason, requestId);
@@ -1041,7 +1043,7 @@ conversations.openapi(getShareStatusRoute, async (c) => {
       return c.json({ error: "invalid_request", message: "Invalid conversation ID format." }, 400);
     }
 
-    const shareResult = yield* Effect.promise(() => getShareStatus(id, user?.id));
+    const shareResult = yield* Effect.promise(() => getShareStatus(id, user?.id, user?.activeOrganizationId));
     if (!shareResult.ok) {
       if (shareResult.reason === "error") {
         log.error({ requestId, conversationId: id }, "Share status fetch failed due to DB error");
@@ -1101,6 +1103,7 @@ conversations.openapi(shareConversationRoute, async (c) => {
 
     const opts = parsed.data;
     const shareResult = yield* Effect.promise(() => shareConversation(id, user?.id, {
+      orgId: user?.activeOrganizationId,
       expiresIn: opts?.expiresIn,
       shareMode: opts?.shareMode,
     }));
@@ -1142,7 +1145,7 @@ conversations.openapi(unshareConversationRoute, async (c) => {
       return c.json({ error: "invalid_request", message: "Invalid conversation ID format." }, 400);
     }
 
-    const unshareResult = yield* Effect.promise(() => unshareConversation(id, user?.id));
+    const unshareResult = yield* Effect.promise(() => unshareConversation(id, user?.id, user?.activeOrganizationId));
     if (!unshareResult.ok) {
       const fail = crudFailResponse(unshareResult.reason, requestId);
       return c.json(fail.body, fail.status);
@@ -1169,7 +1172,7 @@ conversations.openapi(deleteConversationRoute, async (c) => {
       return c.json({ error: "invalid_request", message: "Invalid conversation ID format." }, 400);
     }
 
-    const delResult = yield* Effect.promise(() => deleteConversation(id, user?.id));
+    const delResult = yield* Effect.promise(() => deleteConversation(id, user?.id, user?.activeOrganizationId));
     if (!delResult.ok) {
       const fail = crudFailResponse(delResult.reason, requestId);
       return c.json(fail.body, fail.status);

--- a/packages/api/src/api/routes/query.ts
+++ b/packages/api/src/api/routes/query.ts
@@ -299,7 +299,7 @@ query.openapi(
             try {
               if (conversationId) {
                 // Verify ownership before appending to existing conversation
-                const existing = await getConversation(conversationId, authResult.user?.id);
+                const existing = await getConversation(conversationId, authResult.user?.id, authResult.user?.activeOrganizationId);
                 if (!existing.ok) {
                   log.warn({ conversationId, userId: authResult.user?.id }, "Conversation not found or not owned — skipping persistence");
                   conversationId = undefined;

--- a/packages/api/src/lib/__tests__/conversations.test.ts
+++ b/packages/api/src/lib/__tests__/conversations.test.ts
@@ -22,6 +22,8 @@ import {
   cleanupExpiredShares,
   deleteBranch,
   renameBranch,
+  forkConversation,
+  convertToNotebook,
 } from "../conversations";
 
 // ---------------------------------------------------------------------------
@@ -1397,6 +1399,38 @@ describe("conversations module", () => {
       expect(queryCalls[0].params).toEqual(["r1", "u1", "org-B"]);
     });
 
+    it("forkConversation scopes the source lookup by orgId", async () => {
+      enableInternalDB();
+      // Source row lookup returns empty because org filter rejects cross-org row.
+      setResults({ rows: [] });
+
+      const result = await forkConversation({
+        sourceId: "src-c1",
+        forkPointMessageId: "m1",
+        userId: "u1",
+        orgId: "org-B",
+      });
+      expect(result).toEqual({ ok: false, reason: "not_found" });
+      expect(queryCalls[0].sql).toContain("SELECT id, title, surface, connection_id, org_id");
+      expect(queryCalls[0].sql).toContain("(org_id = $3 OR org_id IS NULL)");
+      expect(queryCalls[0].params).toEqual(["src-c1", "u1", "org-B"]);
+    });
+
+    it("convertToNotebook scopes the source lookup by orgId", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      const result = await convertToNotebook({
+        sourceId: "src-c1",
+        userId: "u1",
+        orgId: "org-B",
+      });
+      expect(result).toEqual({ ok: false, reason: "not_found" });
+      expect(queryCalls[0].sql).toContain("SELECT id, title, surface, connection_id, org_id");
+      expect(queryCalls[0].sql).toContain("(org_id = $3 OR org_id IS NULL)");
+      expect(queryCalls[0].params).toEqual(["src-c1", "u1", "org-B"]);
+    });
+
     it("org_id IS NULL branch allows access to legacy rows (self-hosted back-compat)", async () => {
       enableInternalDB();
       // Row has NULL org_id (pre-1.2.0 legacy) but matches on user_id.
@@ -1420,6 +1454,19 @@ describe("conversations module", () => {
       const result = await getConversation("legacy-c1", "u1", "org-B");
       // Legacy row has NULL org_id — the OR clause allows the match.
       expect(result.ok).toBe(true);
+    });
+
+    it("legacy-row back-compat covers mutation path (deleteConversation)", async () => {
+      // Regression guard: a helper that inlined scopeClause but dropped
+      // `OR org_id IS NULL` would leave self-hosted / pre-1.2.0 users
+      // unable to delete their legacy conversations. This test pins the
+      // NULL-safe branch for a representative mutation helper.
+      enableInternalDB();
+      setResults({ rows: [{ id: "legacy-c1" }] });
+
+      const result = await deleteConversation("legacy-c1", "u1", "org-B");
+      expect(result).toEqual({ ok: true });
+      expect(queryCalls[0].sql).toContain("(org_id = $3 OR org_id IS NULL)");
     });
   });
 });

--- a/packages/api/src/lib/__tests__/conversations.test.ts
+++ b/packages/api/src/lib/__tests__/conversations.test.ts
@@ -14,6 +14,7 @@ import {
   listConversations,
   deleteConversation,
   starConversation,
+  updateNotebookState,
   shareConversation,
   unshareConversation,
   getShareStatus,
@@ -1245,6 +1246,180 @@ describe("conversations module", () => {
 
       const result = await renameBranch({ rootId: "r1", branchId: "b1", label: "New" });
       expect(result).toEqual({ ok: false, reason: "error" });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Cross-org scoping (F-11 security invariant, 1.2.3 phase 2)
+  // -------------------------------------------------------------------------
+  //
+  // Every helper that accepts a conversation id must filter on the caller's
+  // active org_id. Without this, a user who switches workspaces retains
+  // access to conversations they created in a previous org. The NULL-safe
+  // form `(org_id = $N OR org_id IS NULL)` preserves access to legacy rows
+  // written before the column was stamped.
+  //
+  // Each test sets up an empty result set (the DB would reject the row for
+  // org mismatch) and asserts two things:
+  //   1. the SQL contains the org_id filter,
+  //   2. the orgId param is forwarded to the query.
+
+  describe("cross-org scoping (F-11)", () => {
+    it("getConversation scopes by orgId when provided", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      const result = await getConversation("c1", "u1", "org-B");
+      expect(result).toEqual({ ok: false, reason: "not_found" });
+      expect(queryCalls[0].sql).toContain("user_id = $2");
+      expect(queryCalls[0].sql).toContain("(org_id = $3 OR org_id IS NULL)");
+      expect(queryCalls[0].params).toEqual(["c1", "u1", "org-B"]);
+    });
+
+    it("getConversation does not add org_id filter when orgId is undefined", async () => {
+      enableInternalDB();
+      setResults({ rows: [] }, { rows: [] });
+
+      await getConversation("c1", "u1");
+      expect(queryCalls[0].sql).not.toContain("org_id");
+    });
+
+    it("deleteConversation scopes by orgId when provided", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      const result = await deleteConversation("c1", "u1", "org-B");
+      expect(result).toEqual({ ok: false, reason: "not_found" });
+      expect(queryCalls[0].sql).toContain("(org_id = $3 OR org_id IS NULL)");
+      expect(queryCalls[0].params).toEqual(["c1", "u1", "org-B"]);
+    });
+
+    it("starConversation scopes by orgId when provided", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      const result = await starConversation("c1", true, "u1", "org-B");
+      expect(result).toEqual({ ok: false, reason: "not_found" });
+      expect(queryCalls[0].sql).toContain("(org_id = $4 OR org_id IS NULL)");
+      expect(queryCalls[0].params).toEqual([true, "c1", "u1", "org-B"]);
+    });
+
+    it("updateNotebookState scopes by orgId when provided", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      const result = await updateNotebookState("c1", { version: 3 }, "u1", "org-B");
+      expect(result).toEqual({ ok: false, reason: "not_found" });
+      expect(queryCalls[0].sql).toContain("(org_id = $4 OR org_id IS NULL)");
+      expect(queryCalls[0].params?.[2]).toBe("u1");
+      expect(queryCalls[0].params?.[3]).toBe("org-B");
+    });
+
+    it("shareConversation scopes the preflight SELECT by orgId (shareMode='org')", async () => {
+      enableInternalDB();
+      // Preflight sees no matching row because of cross-org filter.
+      setResults({ rows: [] });
+
+      const result = await shareConversation("c1", "u1", {
+        orgId: "org-B",
+        shareMode: "org",
+      });
+      expect(result).toEqual({ ok: false, reason: "not_found" });
+      expect(queryCalls[0].sql).toContain("SELECT org_id FROM conversations");
+      expect(queryCalls[0].sql).toContain("(org_id = $3 OR org_id IS NULL)");
+      expect(queryCalls[0].params).toEqual(["c1", "u1", "org-B"]);
+    });
+
+    it("shareConversation scopes the UPDATE by orgId (public shareMode)", async () => {
+      enableInternalDB();
+      // No preflight for public shares — UPDATE runs directly.
+      setResults({ rows: [] });
+
+      const result = await shareConversation("c1", "u1", { orgId: "org-B" });
+      expect(result).toEqual({ ok: false, reason: "not_found" });
+      expect(queryCalls[0].sql).toContain("UPDATE conversations");
+      expect(queryCalls[0].sql).toContain("(org_id = $6 OR org_id IS NULL)");
+      // params = [token, expiresAt, shareMode, id, userId, orgId]
+      expect(queryCalls[0].params?.[3]).toBe("c1");
+      expect(queryCalls[0].params?.[4]).toBe("u1");
+      expect(queryCalls[0].params?.[5]).toBe("org-B");
+    });
+
+    it("unshareConversation scopes by orgId when provided", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      const result = await unshareConversation("c1", "u1", "org-B");
+      expect(result).toEqual({ ok: false, reason: "not_found" });
+      expect(queryCalls[0].sql).toContain("(org_id = $3 OR org_id IS NULL)");
+      expect(queryCalls[0].params).toEqual(["c1", "u1", "org-B"]);
+    });
+
+    it("getShareStatus scopes by orgId when provided", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      const result = await getShareStatus("c1", "u1", "org-B");
+      expect(result).toEqual({ ok: false, reason: "not_found" });
+      expect(queryCalls[0].sql).toContain("(org_id = $3 OR org_id IS NULL)");
+      expect(queryCalls[0].params).toEqual(["c1", "u1", "org-B"]);
+    });
+
+    it("deleteBranch scopes the root lookup by orgId", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      const result = await deleteBranch({
+        rootId: "r1",
+        branchId: "b1",
+        userId: "u1",
+        orgId: "org-B",
+      });
+      expect(result).toEqual({ ok: false, reason: "not_found" });
+      expect(queryCalls[0].sql).toContain("SELECT id, notebook_state");
+      expect(queryCalls[0].sql).toContain("(org_id = $3 OR org_id IS NULL)");
+      expect(queryCalls[0].params).toEqual(["r1", "u1", "org-B"]);
+    });
+
+    it("renameBranch scopes the root lookup by orgId", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      const result = await renameBranch({
+        rootId: "r1",
+        branchId: "b1",
+        label: "New",
+        userId: "u1",
+        orgId: "org-B",
+      });
+      expect(result).toEqual({ ok: false, reason: "not_found" });
+      expect(queryCalls[0].sql).toContain("(org_id = $3 OR org_id IS NULL)");
+      expect(queryCalls[0].params).toEqual(["r1", "u1", "org-B"]);
+    });
+
+    it("org_id IS NULL branch allows access to legacy rows (self-hosted back-compat)", async () => {
+      enableInternalDB();
+      // Row has NULL org_id (pre-1.2.0 legacy) but matches on user_id.
+      setResults(
+        {
+          rows: [{
+            id: "legacy-c1",
+            user_id: "u1",
+            title: "Legacy",
+            surface: "web",
+            connection_id: null,
+            starred: false,
+            notebook_state: null,
+            created_at: "2024-01-01T00:00:00Z",
+            updated_at: "2024-01-01T00:00:00Z",
+          }],
+        },
+        { rows: [] },
+      );
+
+      const result = await getConversation("legacy-c1", "u1", "org-B");
+      // Legacy row has NULL org_id — the OR clause allows the match.
+      expect(result.ok).toBe(true);
     });
   });
 });

--- a/packages/api/src/lib/conversations.ts
+++ b/packages/api/src/lib/conversations.ts
@@ -29,6 +29,43 @@ function toISOTimestamp(value: unknown): string {
   return String(value);
 }
 
+/**
+ * Build a parameterized WHERE-suffix that scopes a conversation query to the
+ * caller's auth context.
+ *
+ * - `user_id = $N` when a userId is provided.
+ * - `(org_id = $N OR org_id IS NULL)` when an orgId is provided. The NULL
+ *   branch preserves access to rows written before `org_id` was stamped
+ *   (self-hosted / legacy conversations) — matches the back-compat convention
+ *   established for bulk actions in `tools/actions/bulk.ts`.
+ *
+ * See F-11 in `.claude/research/security-audit-1-2-3.md`. The shape mirrors
+ * `listConversations`'s dynamic WHERE so callers can stack filters without
+ * branching on every combination.
+ */
+function scopeClause(
+  startIdx: number,
+  userId?: string | null,
+  orgId?: string | null,
+): { sql: string; params: unknown[]; nextIdx: number } {
+  const parts: string[] = [];
+  const params: unknown[] = [];
+  let idx = startIdx;
+  if (userId) {
+    parts.push(`user_id = $${idx++}`);
+    params.push(userId);
+  }
+  if (orgId) {
+    parts.push(`(org_id = $${idx++} OR org_id IS NULL)`);
+    params.push(orgId);
+  }
+  return {
+    sql: parts.length > 0 ? ` AND ${parts.join(" AND ")}` : "",
+    params,
+    nextIdx: idx,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -201,24 +238,25 @@ export function addMessage(opts: {
   );
 }
 
-/** Fetches a conversation with its messages. When userId is provided, enforces ownership (AND user_id = $2); when omitted, fetches without ownership check. */
+/**
+ * Fetches a conversation with its messages. Scope filters are composed via
+ * `scopeClause()` — `userId` enforces ownership, `orgId` restricts access to
+ * the caller's active workspace (or legacy rows with NULL org_id). Omitting
+ * both fetches without scoping.
+ */
 export async function getConversation(
   id: string,
   userId?: string | null,
+  orgId?: string | null,
 ): Promise<CrudDataResult<ConversationWithMessages>> {
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
   try {
-    const convRows = userId
-      ? await internalQuery<Record<string, unknown>>(
-          `SELECT id, user_id, title, surface, connection_id, starred, notebook_state, created_at, updated_at
-           FROM conversations WHERE id = $1 AND user_id = $2`,
-          [id, userId],
-        )
-      : await internalQuery<Record<string, unknown>>(
-          `SELECT id, user_id, title, surface, connection_id, starred, notebook_state, created_at, updated_at
-           FROM conversations WHERE id = $1`,
-          [id],
-        );
+    const scope = scopeClause(2, userId, orgId);
+    const convRows = await internalQuery<Record<string, unknown>>(
+      `SELECT id, user_id, title, surface, connection_id, starred, notebook_state, created_at, updated_at
+       FROM conversations WHERE id = $1${scope.sql}`,
+      [id, ...scope.params],
+    );
 
     if (convRows.length === 0) return { ok: false, reason: "not_found" };
 
@@ -305,25 +343,21 @@ export async function listConversations(opts?: {
   }
 }
 
-/** Set the starred flag on a conversation. Auth-scoped when userId is provided. */
+/** Set the starred flag on a conversation. Scoped via userId + orgId (see `scopeClause`). */
 export async function starConversation(
   id: string,
   starred: boolean,
   userId?: string | null,
+  orgId?: string | null,
 ): Promise<CrudResult> {
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
   try {
-    const rows = userId
-      ? await internalQuery<{ id: string }>(
-          `UPDATE conversations SET starred = $1, updated_at = now()
-           WHERE id = $2 AND user_id = $3 RETURNING id`,
-          [starred, id, userId],
-        )
-      : await internalQuery<{ id: string }>(
-          `UPDATE conversations SET starred = $1, updated_at = now()
-           WHERE id = $2 RETURNING id`,
-          [starred, id],
-        );
+    const scope = scopeClause(3, userId, orgId);
+    const rows = await internalQuery<{ id: string }>(
+      `UPDATE conversations SET starred = $1, updated_at = now()
+       WHERE id = $2${scope.sql} RETURNING id`,
+      [starred, id, ...scope.params],
+    );
     return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
   } catch (err) {
     log.error({ err: err instanceof Error ? err.message : String(err) }, "starConversation failed");
@@ -331,25 +365,21 @@ export async function starConversation(
   }
 }
 
-/** Update notebook state on a conversation. Auth-scoped when userId is provided. */
+/** Update notebook state on a conversation. Scoped via userId + orgId (see `scopeClause`). */
 export async function updateNotebookState(
   id: string,
   notebookState: NotebookStateWire,
   userId?: string | null,
+  orgId?: string | null,
 ): Promise<CrudResult> {
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
   try {
-    const rows = userId
-      ? await internalQuery<{ id: string }>(
-          `UPDATE conversations SET notebook_state = $1, updated_at = now()
-           WHERE id = $2 AND user_id = $3 RETURNING id`,
-          [JSON.stringify(notebookState), id, userId],
-        )
-      : await internalQuery<{ id: string }>(
-          `UPDATE conversations SET notebook_state = $1, updated_at = now()
-           WHERE id = $2 RETURNING id`,
-          [JSON.stringify(notebookState), id],
-        );
+    const scope = scopeClause(3, userId, orgId);
+    const rows = await internalQuery<{ id: string }>(
+      `UPDATE conversations SET notebook_state = $1, updated_at = now()
+       WHERE id = $2${scope.sql} RETURNING id`,
+      [JSON.stringify(notebookState), id, ...scope.params],
+    );
     return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
   } catch (err) {
     log.error({ err: err instanceof Error ? err.message : String(err) }, "updateNotebookState failed");
@@ -367,16 +397,14 @@ export async function forkConversation(opts: {
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
   let newId: string | null = null;
   try {
-    // Verify source exists and user owns it
-    const sourceRows = opts.userId
-      ? await internalQuery<Record<string, unknown>>(
-          `SELECT id, title, surface, connection_id, org_id FROM conversations WHERE id = $1 AND user_id = $2`,
-          [opts.sourceId, opts.userId],
-        )
-      : await internalQuery<Record<string, unknown>>(
-          `SELECT id, title, surface, connection_id, org_id FROM conversations WHERE id = $1`,
-          [opts.sourceId],
-        );
+    // Verify source exists and caller has access in both the user + org dimensions.
+    // orgId from opts is the caller's *active* org — may or may not match the
+    // source row's org_id; scopeClause rejects mismatches (NULL-safe for legacy rows).
+    const sourceScope = scopeClause(2, opts.userId, opts.orgId);
+    const sourceRows = await internalQuery<Record<string, unknown>>(
+      `SELECT id, title, surface, connection_id, org_id FROM conversations WHERE id = $1${sourceScope.sql}`,
+      [opts.sourceId, ...sourceScope.params],
+    );
     if (sourceRows.length === 0) return { ok: false, reason: "not_found" };
 
     const source = sourceRows[0];
@@ -456,19 +484,16 @@ export async function deleteBranch(opts: {
   rootId: string;
   branchId: string;
   userId?: string | null;
+  orgId?: string | null;
 }): Promise<CrudResult> {
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
   try {
-    // Read root conversation's notebook_state
-    const rootRows = opts.userId
-      ? await internalQuery<Record<string, unknown>>(
-          `SELECT id, notebook_state FROM conversations WHERE id = $1 AND user_id = $2`,
-          [opts.rootId, opts.userId],
-        )
-      : await internalQuery<Record<string, unknown>>(
-          `SELECT id, notebook_state FROM conversations WHERE id = $1`,
-          [opts.rootId],
-        );
+    // Read root conversation's notebook_state — scoped to caller's auth context.
+    const rootScope = scopeClause(2, opts.userId, opts.orgId);
+    const rootRows = await internalQuery<Record<string, unknown>>(
+      `SELECT id, notebook_state FROM conversations WHERE id = $1${rootScope.sql}`,
+      [opts.rootId, ...rootScope.params],
+    );
     if (rootRows.length === 0) return { ok: false, reason: "not_found" };
 
     const state = (rootRows[0].notebook_state ?? {}) as NotebookStateWire;
@@ -483,16 +508,12 @@ export async function deleteBranch(opts: {
       branches: updatedBranches.length > 0 ? updatedBranches : undefined,
     };
 
-    // Delete the branch conversation (CASCADE deletes messages)
-    const delRows = opts.userId
-      ? await internalQuery<{ id: string }>(
-          `DELETE FROM conversations WHERE id = $1 AND user_id = $2 RETURNING id`,
-          [opts.branchId, opts.userId],
-        )
-      : await internalQuery<{ id: string }>(
-          `DELETE FROM conversations WHERE id = $1 RETURNING id`,
-          [opts.branchId],
-        );
+    // Delete the branch conversation (CASCADE deletes messages) — scoped to the same auth context.
+    const branchScope = scopeClause(2, opts.userId, opts.orgId);
+    const delRows = await internalQuery<{ id: string }>(
+      `DELETE FROM conversations WHERE id = $1${branchScope.sql} RETURNING id`,
+      [opts.branchId, ...branchScope.params],
+    );
     if (delRows.length === 0) {
       log.warn({ rootId: opts.rootId, branchId: opts.branchId }, "Branch conversation not found during delete — removing from root state anyway");
     }
@@ -517,19 +538,16 @@ export async function renameBranch(opts: {
   branchId: string;
   label: string;
   userId?: string | null;
+  orgId?: string | null;
 }): Promise<CrudResult> {
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
   try {
-    // Read root conversation's notebook_state
-    const rootRows = opts.userId
-      ? await internalQuery<Record<string, unknown>>(
-          `SELECT id, notebook_state FROM conversations WHERE id = $1 AND user_id = $2`,
-          [opts.rootId, opts.userId],
-        )
-      : await internalQuery<Record<string, unknown>>(
-          `SELECT id, notebook_state FROM conversations WHERE id = $1`,
-          [opts.rootId],
-        );
+    // Read root conversation's notebook_state — scoped to caller's auth context.
+    const scope = scopeClause(2, opts.userId, opts.orgId);
+    const rootRows = await internalQuery<Record<string, unknown>>(
+      `SELECT id, notebook_state FROM conversations WHERE id = $1${scope.sql}`,
+      [opts.rootId, ...scope.params],
+    );
     if (rootRows.length === 0) return { ok: false, reason: "not_found" };
 
     const state = (rootRows[0].notebook_state ?? {}) as NotebookStateWire;
@@ -565,16 +583,12 @@ export async function convertToNotebook(opts: {
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
   let newId: string | null = null;
   try {
-    // Verify source exists and user owns it
-    const sourceRows = opts.userId
-      ? await internalQuery<Record<string, unknown>>(
-          `SELECT id, title, surface, connection_id, org_id FROM conversations WHERE id = $1 AND user_id = $2`,
-          [opts.sourceId, opts.userId],
-        )
-      : await internalQuery<Record<string, unknown>>(
-          `SELECT id, title, surface, connection_id, org_id FROM conversations WHERE id = $1`,
-          [opts.sourceId],
-        );
+    // Verify source exists and caller has access in both the user + org dimensions.
+    const sourceScope = scopeClause(2, opts.userId, opts.orgId);
+    const sourceRows = await internalQuery<Record<string, unknown>>(
+      `SELECT id, title, surface, connection_id, org_id FROM conversations WHERE id = $1${sourceScope.sql}`,
+      [opts.sourceId, ...sourceScope.params],
+    );
     if (sourceRows.length === 0) return { ok: false, reason: "not_found" };
 
     const source = sourceRows[0];
@@ -626,22 +640,19 @@ export async function convertToNotebook(opts: {
   }
 }
 
-/** Delete a conversation (CASCADE deletes messages). Auth-scoped when userId is provided. */
+/** Delete a conversation (CASCADE deletes messages). Scoped via userId + orgId (see `scopeClause`). */
 export async function deleteConversation(
   id: string,
   userId?: string | null,
+  orgId?: string | null,
 ): Promise<CrudResult> {
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
   try {
-    const rows = userId
-      ? await internalQuery<{ id: string }>(
-          `DELETE FROM conversations WHERE id = $1 AND user_id = $2 RETURNING id`,
-          [id, userId],
-        )
-      : await internalQuery<{ id: string }>(
-          `DELETE FROM conversations WHERE id = $1 RETURNING id`,
-          [id],
-        );
+    const scope = scopeClause(2, userId, orgId);
+    const rows = await internalQuery<{ id: string }>(
+      `DELETE FROM conversations WHERE id = $1${scope.sql} RETURNING id`,
+      [id, ...scope.params],
+    );
     return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
   } catch (err) {
     log.error({ err: err instanceof Error ? err.message : String(err) }, "deleteConversation failed");
@@ -687,27 +698,24 @@ export type ShareConversationResult =
 export async function shareConversation(
   id: string,
   userId?: string | null,
-  opts?: { expiresIn?: ShareExpiryKey | null; shareMode?: ShareMode },
+  opts?: { orgId?: string | null; expiresIn?: ShareExpiryKey | null; shareMode?: ShareMode },
 ): Promise<ShareConversationResult> {
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
   try {
     const token = generateShareToken();
     const expiresAt = computeExpiresAt(opts?.expiresIn);
     const shareMode: ShareMode = opts?.shareMode ?? "public";
+    const orgId = opts?.orgId;
 
     // Belt-and-suspenders for the DB CHECK (#1737): if the caller asks for
     // org-scoped sharing, the target conversation must already have an
     // org_id, otherwise the share is meaningless and opens F-01.
     if (shareMode === "org") {
-      const orgRows = userId
-        ? await internalQuery<{ org_id: string | null }>(
-            `SELECT org_id FROM conversations WHERE id = $1 AND user_id = $2`,
-            [id, userId],
-          )
-        : await internalQuery<{ org_id: string | null }>(
-            `SELECT org_id FROM conversations WHERE id = $1`,
-            [id],
-          );
+      const preflightScope = scopeClause(2, userId, orgId);
+      const orgRows = await internalQuery<{ org_id: string | null }>(
+        `SELECT org_id FROM conversations WHERE id = $1${preflightScope.sql}`,
+        [id, ...preflightScope.params],
+      );
       if (orgRows.length === 0) return { ok: false, reason: "not_found" };
       if (!orgRows[0].org_id) {
         log.warn(
@@ -718,17 +726,12 @@ export async function shareConversation(
       }
     }
 
-    const rows = userId
-      ? await internalQuery<{ share_token: string }>(
-          `UPDATE conversations SET share_token = $1, share_expires_at = $2, share_mode = $3, updated_at = now()
-           WHERE id = $4 AND user_id = $5 RETURNING share_token`,
-          [token, expiresAt, shareMode, id, userId],
-        )
-      : await internalQuery<{ share_token: string }>(
-          `UPDATE conversations SET share_token = $1, share_expires_at = $2, share_mode = $3, updated_at = now()
-           WHERE id = $4 RETURNING share_token`,
-          [token, expiresAt, shareMode, id],
-        );
+    const scope = scopeClause(5, userId, orgId);
+    const rows = await internalQuery<{ share_token: string }>(
+      `UPDATE conversations SET share_token = $1, share_expires_at = $2, share_mode = $3, updated_at = now()
+       WHERE id = $4${scope.sql} RETURNING share_token`,
+      [token, expiresAt, shareMode, id, ...scope.params],
+    );
     if (rows.length === 0) return { ok: false, reason: "not_found" };
     return { ok: true, data: { token: rows[0].share_token, expiresAt, shareMode } };
   } catch (err) {
@@ -737,24 +740,20 @@ export async function shareConversation(
   }
 }
 
-/** Revoke sharing for a conversation. Auth-scoped when userId is provided. */
+/** Revoke sharing for a conversation. Scoped via userId + orgId (see `scopeClause`). */
 export async function unshareConversation(
   id: string,
   userId?: string | null,
+  orgId?: string | null,
 ): Promise<CrudResult> {
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
   try {
-    const rows = userId
-      ? await internalQuery<{ id: string }>(
-          `UPDATE conversations SET share_token = NULL, share_expires_at = NULL, share_mode = 'public', updated_at = now()
-           WHERE id = $1 AND user_id = $2 RETURNING id`,
-          [id, userId],
-        )
-      : await internalQuery<{ id: string }>(
-          `UPDATE conversations SET share_token = NULL, share_expires_at = NULL, share_mode = 'public', updated_at = now()
-           WHERE id = $1 RETURNING id`,
-          [id],
-        );
+    const scope = scopeClause(2, userId, orgId);
+    const rows = await internalQuery<{ id: string }>(
+      `UPDATE conversations SET share_token = NULL, share_expires_at = NULL, share_mode = 'public', updated_at = now()
+       WHERE id = $1${scope.sql} RETURNING id`,
+      [id, ...scope.params],
+    );
     return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
   } catch (err) {
     log.error({ err: err instanceof Error ? err.message : String(err) }, "unshareConversation failed");
@@ -767,22 +766,19 @@ export type ShareStatusData =
   | { shared: false; token: null; expiresAt: null; shareMode: null }
   | { shared: true; token: string; expiresAt: string | null; shareMode: ShareMode };
 
-/** Fetch the share status of a conversation. Auth-scoped when userId is provided. Expired tokens are treated as not shared. */
+/** Fetch the share status of a conversation. Scoped via userId + orgId (see `scopeClause`). Expired tokens are treated as not shared. */
 export async function getShareStatus(
   id: string,
   userId?: string | null,
+  orgId?: string | null,
 ): Promise<CrudDataResult<ShareStatusData>> {
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
   try {
-    const rows = userId
-      ? await internalQuery<Record<string, unknown>>(
-          `SELECT share_token, share_expires_at, share_mode FROM conversations WHERE id = $1 AND user_id = $2`,
-          [id, userId],
-        )
-      : await internalQuery<Record<string, unknown>>(
-          `SELECT share_token, share_expires_at, share_mode FROM conversations WHERE id = $1`,
-          [id],
-        );
+    const scope = scopeClause(2, userId, orgId);
+    const rows = await internalQuery<Record<string, unknown>>(
+      `SELECT share_token, share_expires_at, share_mode FROM conversations WHERE id = $1${scope.sql}`,
+      [id, ...scope.params],
+    );
     if (rows.length === 0) return { ok: false, reason: "not_found" };
     const token = (rows[0].share_token as string) ?? null;
     const expiresAt = token && rows[0].share_expires_at ? String(rows[0].share_expires_at) : null;

--- a/packages/api/src/lib/conversations.ts
+++ b/packages/api/src/lib/conversations.ts
@@ -39,9 +39,15 @@ function toISOTimestamp(value: unknown): string {
  *   (self-hosted / legacy conversations) — matches the back-compat convention
  *   established for bulk actions in `tools/actions/bulk.ts`.
  *
- * See F-11 in `.claude/research/security-audit-1-2-3.md`. The shape mirrors
- * `listConversations`'s dynamic WHERE so callers can stack filters without
- * branching on every combination.
+ * Note: `listConversations` below uses a stricter `org_id = $N` (no NULL
+ * fallback) for the list view — legacy rows stay reachable by direct id but
+ * are filtered out of workspace-scoped lists. Divergence is intentional.
+ *
+ * @security Every CRUD helper in this file takes `orgId` as an optional
+ * trailing param. Routes that serve authenticated users **must** forward
+ * `user?.activeOrganizationId` — omitting it silently drops the workspace
+ * scope filter. Route-layer tests in `packages/api/src/api/__tests__/`
+ * assert orgId is threaded through at every call site (F-11, 1.2.3).
  */
 function scopeClause(
   startIdx: number,

--- a/packages/api/src/lib/tools/__tests__/action-permissions.test.ts
+++ b/packages/api/src/lib/tools/__tests__/action-permissions.test.ts
@@ -192,6 +192,7 @@ function makeAction(overrides: Partial<ActionLogEntry> = {}): ActionLogEntry {
     rollback_info: null,
     conversation_id: null,
     request_id: null,
+    org_id: null,
     ...overrides,
   };
 }

--- a/packages/api/src/lib/tools/actions/__tests__/handler.test.ts
+++ b/packages/api/src/lib/tools/actions/__tests__/handler.test.ts
@@ -1135,3 +1135,122 @@ describe("rollbackAction()", () => {
     expect(result!.error).toContain("No rollback handler registered for method: unregistered:method");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Cross-org scoping (F-12 security invariant, 1.2.3 phase 2)
+// ---------------------------------------------------------------------------
+//
+// Pending actions must be isolated by org_id. A user who approves / denies /
+// rollbacks / views an action from a session active in a different workspace
+// must see the action as not-found, never as an actionable row. The filter is
+// NULL-safe so rows written before org-stamping existed remain accessible.
+
+describe("cross-org scoping (F-12)", () => {
+  async function seedOrgScoped(actionType: string, orgId: string, userId = "alice") {
+    const request = buildActionRequest({
+      actionType,
+      target: `t-${Math.random()}`,
+      summary: "Test action",
+      payload: {},
+      reversible: false,
+    });
+    await withRequestContext(
+      {
+        requestId: "req-seed",
+        user: {
+          id: userId,
+          label: `${userId}@test.com`,
+          mode: "simple-key",
+          activeOrganizationId: orgId,
+        },
+      },
+      () => handleAction(request, async () => "done"),
+    );
+    return request.id;
+  }
+
+  it("handleAction stamps org_id from request context", async () => {
+    const id = await seedOrgScoped("test:stamped", "org-A");
+    // Read back without orgId filter — the row itself carries the stamp.
+    const entry = await getAction(id);
+    expect(entry).not.toBeNull();
+    expect(entry!.org_id).toBe("org-A");
+  });
+
+  it("getAction returns null for cross-org caller", async () => {
+    const id = await seedOrgScoped("test:xorg", "org-A");
+    const fromOtherOrg = await getAction(id, "org-B");
+    expect(fromOtherOrg).toBeNull();
+    const fromOwnOrg = await getAction(id, "org-A");
+    expect(fromOwnOrg).not.toBeNull();
+  });
+
+  it("getAction returns legacy (org_id=null) rows to any org (back-compat)", async () => {
+    // Seed a row then null out org_id to simulate pre-F-12 data.
+    const id = await seedOrgScoped("test:legacy", "org-A");
+    const row = await getAction(id);
+    row!.org_id = null;
+    const fromAnyOrg = await getAction(id, "org-Z");
+    expect(fromAnyOrg).not.toBeNull();
+  });
+
+  it("approveAction loses CAS for cross-org caller (returns null)", async () => {
+    const id = await seedOrgScoped("test:xapprove", "org-A");
+    const result = await approveAction(id, "admin-1", async () => "ok", "org-B");
+    expect(result).toBeNull();
+    // Row is still pending — the cross-org approve didn't touch it.
+    const row = await getAction(id, "org-A");
+    expect(row!.status).toBe("pending");
+  });
+
+  it("approveAction succeeds for same-org caller", async () => {
+    const id = await seedOrgScoped("test:approve-ok", "org-A");
+    const result = await approveAction(id, "admin-1", async () => "ok", "org-A");
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe("executed");
+  });
+
+  it("denyAction loses CAS for cross-org caller (returns null)", async () => {
+    const id = await seedOrgScoped("test:xdeny", "org-A");
+    const result = await denyAction(id, "admin-1", "no", "org-B");
+    expect(result).toBeNull();
+    const row = await getAction(id, "org-A");
+    expect(row!.status).toBe("pending");
+  });
+
+  it("rollbackAction returns null for cross-org caller", async () => {
+    const id = await seedOrgScoped("test:xrollback", "org-A");
+    // Approve in-org so the action becomes executed with rollback info.
+    await approveAction(
+      id,
+      "admin-1",
+      async () => ({
+        key: "Z-1",
+        rollbackInfo: { method: "m", params: {} },
+      }),
+      "org-A",
+    );
+
+    const xorg = await rollbackAction(id, "admin-1", "org-B");
+    expect(xorg).toBeNull();
+
+    const same = await rollbackAction(id, "admin-1", "org-A");
+    expect(same).not.toBeNull();
+    expect(same!.status).toBe("rolled_back");
+  });
+
+  it("listPendingActions filters out cross-org rows", async () => {
+    const idA = await seedOrgScoped("test:list-a", "org-A", "alice");
+    const idB = await seedOrgScoped("test:list-b", "org-B", "bob");
+
+    const fromA = await listPendingActions({ orgId: "org-A" });
+    const fromAIds = fromA.map((e) => e.id);
+    expect(fromAIds).toContain(idA);
+    expect(fromAIds).not.toContain(idB);
+
+    const fromB = await listPendingActions({ orgId: "org-B" });
+    const fromBIds = fromB.map((e) => e.id);
+    expect(fromBIds).toContain(idB);
+    expect(fromBIds).not.toContain(idA);
+  });
+});

--- a/packages/api/src/lib/tools/actions/bulk.ts
+++ b/packages/api/src/lib/tools/actions/bulk.ts
@@ -114,12 +114,9 @@ async function preClassify(
       notFound.push(id);
       continue;
     }
-    // `org_id` is present on the action_log row (schema.ts) but not yet
-    // surfaced on `ActionLogEntry`; read defensively via record access.
     // Missing / null org_id disables the filter — matches the single-action
-    // endpoints' behavior for rows written before org-scoping existed.
-    const rowOrgId = (action as unknown as Record<string, unknown>).org_id;
-    if (orgId && typeof rowOrgId === "string" && rowOrgId !== orgId) {
+    // endpoints' behavior for rows written before org-stamping existed.
+    if (orgId && typeof action.org_id === "string" && action.org_id !== orgId) {
       notFound.push(id);
       continue;
     }
@@ -158,7 +155,9 @@ export async function bulkApproveActions(
   for (const id of eligible) {
     try {
       const executor = getActionExecutor(id);
-      const result = await approveAction(id, approverId, executor);
+      // Pass orgId to the CAS so the UPDATE carries the same org-scope guard
+      // as preClassify — defense in depth against TOCTOU between the two steps.
+      const result = await approveAction(id, approverId, executor, orgId);
       if (result === null) {
         log.warn(
           { actionId: id, orgId, userId: user?.id, requestId },
@@ -199,7 +198,7 @@ export async function bulkDenyActions(
 
   for (const id of eligible) {
     try {
-      const result = await denyAction(id, denierId, reason);
+      const result = await denyAction(id, denierId, reason, orgId);
       if (result === null) {
         log.warn(
           { actionId: id, orgId, userId: user?.id, requestId },

--- a/packages/api/src/lib/tools/actions/handler.ts
+++ b/packages/api/src/lib/tools/actions/handler.ts
@@ -154,8 +154,8 @@ async function persistAction(entry: ActionLogEntry): Promise<void> {
   if (hasInternalDB()) {
     try {
       await internalQuery(
-        `INSERT INTO action_log (id, requested_by, approved_by, auth_mode, action_type, target, summary, payload, status, result, error, rollback_info, conversation_id, request_id)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
+        `INSERT INTO action_log (id, requested_by, approved_by, auth_mode, action_type, target, summary, payload, status, result, error, rollback_info, conversation_id, request_id, org_id)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`,
         [
           entry.id,
           entry.requested_by,
@@ -171,12 +171,36 @@ async function persistAction(entry: ActionLogEntry): Promise<void> {
           entry.rollback_info ? JSON.stringify(entry.rollback_info) : null,
           entry.conversation_id,
           entry.request_id,
+          entry.org_id,
         ],
       );
     } catch (err) {
       log.error({ err, actionId: entry.id }, "Failed to persist action to DB — stored in memory only");
     }
   }
+}
+
+/**
+ * Build a parameterized `AND (org_id = $N OR org_id IS NULL)` clause for
+ * action_log CRUD queries. NULL-safe so rows written before org-stamping
+ * existed remain accessible. See F-12 in security audit 1.2.3.
+ */
+function orgScopeClause(
+  startIdx: number,
+  orgId: string | null | undefined,
+): { sql: string; params: unknown[] } {
+  if (!orgId) return { sql: "", params: [] };
+  return {
+    sql: ` AND (org_id = $${startIdx} OR org_id IS NULL)`,
+    params: [orgId],
+  };
+}
+
+/** In-memory equivalent of `orgScopeClause` — NULL-safe match. */
+function inMemoryOrgMatch(rowOrgId: unknown, callerOrgId: string | null | undefined): boolean {
+  if (!callerOrgId) return true;
+  if (rowOrgId === null || rowOrgId === undefined) return true;
+  return rowOrgId === callerOrgId;
 }
 
 const COLUMN_MAP: Record<string, string> = {
@@ -248,6 +272,9 @@ export async function handleAction(
   const userId = ctx?.user?.id;
   const authMode = ctx?.user?.mode ?? "none";
   const requestId = ctx?.requestId ?? null;
+  // Stamp the caller's active workspace so cross-org CRUD filters can work.
+  // See F-12 in security audit 1.2.3.
+  const orgId = ctx?.user?.activeOrganizationId ?? null;
   const now = new Date().toISOString();
 
   const entry: ActionLogEntry = {
@@ -268,6 +295,7 @@ export async function handleAction(
     rollback_info: null,
     conversation_id: opts?.conversationId ?? null,
     request_id: requestId,
+    org_id: orgId,
   };
 
   await persistAction(entry);
@@ -435,22 +463,29 @@ async function executeApprovedAction(
 /**
  * Approve a pending action. Returns the updated entry, or null if CAS failed
  * (action already resolved — 409 scenario).
+ *
+ * When `orgId` is provided, the CAS filter also requires the row's org_id
+ * to match (NULL-safe for legacy rows). A cross-org caller sees the same
+ * null return as a CAS race, consistent with the "don't leak existence"
+ * convention established in bulk.ts.
  */
 export async function approveAction(
   actionId: string,
   approverId: string,
   executeFn?: ActionExecutor,
+  orgId?: string | null,
 ): Promise<ActionLogEntry | null> {
   const resolveFn = executeFn ?? getActionExecutor(actionId);
 
   // CAS in DB (atomic via WHERE status = 'pending' RETURNING *)
   if (hasInternalDB()) {
+    const scope = orgScopeClause(3, orgId);
     const rows = await internalQuery(
       `UPDATE action_log
        SET status = 'approved', resolved_at = now(), approved_by = $1
-       WHERE id = $2 AND status = 'pending'
+       WHERE id = $2 AND status = 'pending'${scope.sql}
        RETURNING *`,
-      [approverId, actionId],
+      [approverId, actionId, ...scope.params],
     ) as unknown as ActionLogEntry[];
     if (rows.length === 0) return null;
 
@@ -475,6 +510,7 @@ export async function approveAction(
   // Memory-only fallback
   const entry = memoryStore.get(actionId);
   if (!entry || entry.status !== "pending") return null;
+  if (!inMemoryOrgMatch(entry.org_id, orgId)) return null;
 
   const approved: ActionLogEntry = {
     ...entry,
@@ -501,20 +537,23 @@ export async function approveAction(
 
 /**
  * Deny a pending action. Returns the updated entry, or null if CAS failed.
+ * Cross-org semantics mirror `approveAction` — see that doc.
  */
 export async function denyAction(
   actionId: string,
   denierId: string,
   reason?: string,
+  orgId?: string | null,
 ): Promise<ActionLogEntry | null> {
   if (hasInternalDB()) {
+    const scope = orgScopeClause(4, orgId);
     const rows = await internalQuery(
       `UPDATE action_log
        -- approved_by is overloaded: stores approver for approved actions, denier for denied actions
        SET status = 'denied', resolved_at = now(), approved_by = $1, error = $2
-       WHERE id = $3 AND status = 'pending'
+       WHERE id = $3 AND status = 'pending'${scope.sql}
        RETURNING *`,
-      [denierId, reason ?? null, actionId],
+      [denierId, reason ?? null, actionId, ...scope.params],
     ) as unknown as ActionLogEntry[];
     if (rows.length === 0) return null;
 
@@ -534,6 +573,7 @@ export async function denyAction(
   // Memory-only fallback
   const entry = memoryStore.get(actionId);
   if (!entry || entry.status !== "pending") return null;
+  if (!inMemoryOrgMatch(entry.org_id, orgId)) return null;
 
   const denied: ActionLogEntry = {
     ...entry,
@@ -558,27 +598,38 @@ export async function denyAction(
 // Read operations
 // ---------------------------------------------------------------------------
 
-export async function getAction(actionId: string): Promise<ActionLogEntry | null> {
+export async function getAction(
+  actionId: string,
+  orgId?: string | null,
+): Promise<ActionLogEntry | null> {
   if (hasInternalDB()) {
+    const scope = orgScopeClause(2, orgId);
     const rows = await internalQuery(
-      `SELECT * FROM action_log WHERE id = $1`,
-      [actionId],
+      `SELECT * FROM action_log WHERE id = $1${scope.sql}`,
+      [actionId, ...scope.params],
     ) as unknown as ActionLogEntry[];
     return rows[0] ?? null;
   }
-  return memoryStore.get(actionId) ?? null;
+  const entry = memoryStore.get(actionId);
+  if (!entry) return null;
+  if (!inMemoryOrgMatch(entry.org_id, orgId)) return null;
+  return entry;
 }
 
 export interface ListActionsOptions {
   status?: ActionStatus;
   userId?: string;
   conversationId?: string;
+  orgId?: string | null;
   limit?: number;
 }
 
 /**
  * Despite the name, supports filtering by any ActionStatus via opts.status.
  * Defaults to "pending" when no status filter is provided.
+ *
+ * When `orgId` is provided, restricts to rows matching that org (or legacy
+ * rows with NULL org_id). Matches the bulk.ts cross-org convention.
  */
 export async function listPendingActions(opts?: ListActionsOptions): Promise<ActionLogEntry[]> {
   const limit = Math.min(opts?.limit ?? 50, 100);
@@ -606,6 +657,11 @@ export async function listPendingActions(opts?: ListActionsOptions): Promise<Act
       params.push(opts.conversationId);
     }
 
+    if (opts?.orgId) {
+      conditions.push(`(org_id = $${paramIdx++} OR org_id IS NULL)`);
+      params.push(opts.orgId);
+    }
+
     params.push(limit);
     const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
     const rows = await internalQuery(
@@ -625,6 +681,9 @@ export async function listPendingActions(opts?: ListActionsOptions): Promise<Act
   }
   if (opts?.conversationId) {
     results = results.filter((e) => e.conversation_id === opts.conversationId);
+  }
+  if (opts?.orgId) {
+    results = results.filter((e) => inMemoryOrgMatch(e.org_id, opts.orgId));
   }
 
   return results
@@ -698,8 +757,9 @@ async function dispatchRollback(
 export async function rollbackAction(
   actionId: string,
   userId: string,
+  orgId?: string | null,
 ): Promise<ActionLogEntry | null> {
-  const action = await getAction(actionId);
+  const action = await getAction(actionId, orgId);
   if (!action) return null;
 
   if (!ROLLBACKABLE_STATUSES.has(action.status)) {
@@ -714,12 +774,13 @@ export async function rollbackAction(
 
   // CAS: transition to rolled_back
   if (hasInternalDB()) {
+    const scope = orgScopeClause(2, orgId);
     const rows = await internalQuery(
       `UPDATE action_log
        SET status = 'rolled_back', resolved_at = now()
-       WHERE id = $1 AND status IN ('executed', 'auto_approved')
+       WHERE id = $1 AND status IN ('executed', 'auto_approved')${scope.sql}
        RETURNING *`,
-      [actionId],
+      [actionId, ...scope.params],
     ) as unknown as ActionLogEntry[];
     if (rows.length === 0) return null;
 
@@ -740,6 +801,7 @@ export async function rollbackAction(
   // Memory-only fallback
   const entry = memoryStore.get(actionId);
   if (!entry || !ROLLBACKABLE_STATUSES.has(entry.status)) return null;
+  if (!inMemoryOrgMatch(entry.org_id, orgId)) return null;
 
   const rolledBack: ActionLogEntry = {
     ...entry,

--- a/packages/api/src/lib/tools/actions/handler.ts
+++ b/packages/api/src/lib/tools/actions/handler.ts
@@ -175,7 +175,14 @@ async function persistAction(entry: ActionLogEntry): Promise<void> {
         ],
       );
     } catch (err) {
-      log.error({ err, actionId: entry.id }, "Failed to persist action to DB — stored in memory only");
+      // Surface the failure: a silent DB INSERT error leaves the memoryStore
+      // entry divergent from the DB (caller thinks "pending" exists, admin
+      // console can't find it). Drop the orphan memory entry and propagate so
+      // auto-approve flows fail loudly and manual flows never register a
+      // phantom pending action.
+      memoryStore.delete(entry.id);
+      log.error({ err, actionId: entry.id }, "Failed to persist action to DB");
+      throw err instanceof Error ? err : new Error(String(err));
     }
   }
 }
@@ -184,6 +191,13 @@ async function persistAction(entry: ActionLogEntry): Promise<void> {
  * Build a parameterized `AND (org_id = $N OR org_id IS NULL)` clause for
  * action_log CRUD queries. NULL-safe so rows written before org-stamping
  * existed remain accessible. See F-12 in security audit 1.2.3.
+ *
+ * @security Every CRUD helper in this file (`getAction`, `approveAction`,
+ * `denyAction`, `rollbackAction`, `listPendingActions`) takes `orgId` as
+ * an optional trailing param. Authenticated routes **must** forward
+ * `user?.activeOrganizationId` — omitting it silently drops the workspace
+ * scope filter. Route-layer tests in `packages/api/src/api/__tests__/`
+ * assert orgId is threaded through at every call site.
  */
 function orgScopeClause(
   startIdx: number,
@@ -629,7 +643,9 @@ export interface ListActionsOptions {
  * Defaults to "pending" when no status filter is provided.
  *
  * When `orgId` is provided, restricts to rows matching that org (or legacy
- * rows with NULL org_id). Matches the bulk.ts cross-org convention.
+ * rows with NULL org_id). Uses the same NULL-safe shape as `orgScopeClause`
+ * above — not the helper itself, because `listPendingActions` builds the
+ * whole WHERE clause dynamically with multiple optional conditions.
  */
 export async function listPendingActions(opts?: ListActionsOptions): Promise<ActionLogEntry[]> {
   const limit = Math.min(opts?.limit ?? 50, 100);

--- a/packages/types/src/action.ts
+++ b/packages/types/src/action.ts
@@ -124,7 +124,12 @@ export interface ActionLogEntry {
    * Owning workspace for the action. Rows written before org-scoping was
    * added to persistAction have NULL org_id; the CRUD filter is NULL-safe
    * so legacy rows remain accessible to their original requester.
-   * See F-12 in security audit 1.2.3.
+   *
+   * @security F-12 (security audit 1.2.3). Every CRUD path through
+   * `packages/api/src/lib/tools/actions/handler.ts` must filter by this
+   * column against the caller's active organization. See
+   * `.claude/research/security-audit-1-2-3.md` and `orgScopeClause` in
+   * handler.ts for the NULL-safe filter shape.
    */
   org_id: string | null;
 }

--- a/packages/types/src/action.ts
+++ b/packages/types/src/action.ts
@@ -120,6 +120,13 @@ export interface ActionLogEntry {
   rollback_info: RollbackInfo | null;
   conversation_id: string | null;
   request_id: string | null;
+  /**
+   * Owning workspace for the action. Rows written before org-scoping was
+   * added to persistAction have NULL org_id; the CRUD filter is NULL-safe
+   * so legacy rows remain accessible to their original requester.
+   * See F-12 in security audit 1.2.3.
+   */
+  org_id: string | null;
 }
 
 /** All valid ActionDisplayStatus values (derived from ALL_STATUSES). */


### PR DESCRIPTION
## Summary

Phase 2 P2 tail of the 1.2.3 security sweep. Before this PR, a user who switched workspaces retained read/write/approve access to conversations and pending actions they created in their *previous* org. Both CRUD surfaces now filter on the caller's active org via a NULL-safe clause — legacy rows written before org-stamping existed remain accessible to their original owner.

- **F-11 — conversations CRUD by `:id`** filtered by `user_id` only. User who switches orgs could still read/delete/share their old-org conversations.
- **F-12 — pending actions CRUD by `:id`** filtered by `requested_by` only. Same class of bug — user could still approve/deny/rollback old-org actions.

Closes #1753
Closes #1754

## Changes

**`packages/api/src/lib/conversations.ts`** — new `scopeClause(startIdx, userId?, orgId?)` helper builds a parameterized `AND user_id = $N AND (org_id = $M OR org_id IS NULL)` fragment, replacing the 2-way `userId ? … : …` branching with a single SQL template per helper. Threads orgId through `getConversation`, `starConversation`, `updateNotebookState`, `forkConversation` (source lookup), `deleteConversation`, `shareConversation`, `unshareConversation`, `getShareStatus`, `deleteBranch`, `renameBranch`, `convertToNotebook`. `listConversations` already filtered correctly (listing-surface scope was in place from 0.7.0). `shareConversation` takes `orgId` inside its `opts` bag to preserve existing positional-arg call sites.

**`packages/api/src/lib/tools/actions/handler.ts`** — stamps `org_id` on INSERT in `persistAction` (pulled from `getRequestContext()?.user?.activeOrganizationId`). Adds the NULL-safe filter to `getAction`, `approveAction`, `denyAction`, `rollbackAction`, `listPendingActions`. Two helper utilities `orgScopeClause` + `inMemoryOrgMatch` centralize the filter semantics for the DB and in-memory fallback paths.

**`packages/api/src/lib/tools/actions/bulk.ts`** — now forwards `orgId` into `approveAction` / `denyAction` so the CAS UPDATE carries the same org-scope guard as `preClassify` (defense-in-depth against TOCTOU).

**`packages/types/src/action.ts`** — `ActionLogEntry.org_id: string | null` promoted from "on the row but not on the type" to first-class. Drops the unknown-cast in bulk.ts.

**Route layer** — `packages/api/src/api/routes/{conversations.ts, actions.ts, chat.ts, query.ts}` pass `user?.activeOrganizationId` at every call site.

**Audit doc** — `.claude/research/security-audit-1-2-3.md` marks F-11 / F-12 as fixed.

## Test plan
- [x] `bun test packages/api/src/lib/__tests__/conversations.test.ts` — 110 pass (98 existing + 12 new cross-org for F-11)
- [x] `bun test packages/api/src/lib/tools/actions/__tests__/handler.test.ts` — 61 pass (54 existing + 7 new cross-org for F-12)
- [x] `bun test packages/api/src/lib/tools/actions/__tests__/bulk.test.ts` — 17 pass (no regressions from forwarding orgId into the CAS)
- [x] `bun run type` clean (`ActionLogEntry.org_id` propagated to test fixtures in `actions.test.ts` + `action-permissions.test.ts`)
- [x] `bun run lint` clean
- [x] `bun x syncpack lint` clean
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` clean
- [x] `bun run test` full suite — api 254, cli 19, web 84, ee 25, react 9, + all plugin packages green

## Back-compat

The `(org_id = $N OR org_id IS NULL)` shape preserves access for:
- Self-hosted installs where legacy conversations predate the `org_id` column
- Action rows written before this PR (no org stamp)

The bulk.ts convention already established this back-compat semantics and this PR keeps it in lockstep.

## Incidental findings filed

- #1768 — flaky `bun test packages/api/src/api/__tests__/actions.test.ts -t "passes orgId"` in isolation (pre-existing; EE IP allowlist hits real DB). Not caused by this PR — reproduces on main at 08311760.