### PR TITLE
fix(security): F-25 EE custom-role audit emission (closes #1780)

### DIFF
--- a/.claude/research/security-audit-1-2-3.md
+++ b/.claude/research/security-audit-1-2-3.md
@@ -1090,7 +1090,7 @@ Totals at the file level; individual uncovered writes are enumerated under the f
 | `admin-prompts.ts` | 7 | 0 | ❌ | Content governance — collection + prompt CRUD (F-35) |
 | `admin-publish.ts` | 1 | 1 | ✅ | `mode.publish` |
 | `admin-residency.ts` | 4 | 0 | ❌ | **Workspace residency assign is permanent and unaudited** (F-32) |
-| `admin-roles.ts` | 4 | 4 | ✅ | F-25 fixed (PR for #1780) — `role.create` / `role.update` / `role.delete` / `role.assign` emitted with success + failure paths; update captures previousPermissions, delete pre-fetches so metadata retains the deleted role, assign captures previousRole |
+| `admin-roles.ts` | 4 | 4 | ✅ | F-25 fixed (PR #1800) — `role.create` / `role.update` / `role.delete` / `role.assign` emitted with success + failure paths; update captures previousPermissions, delete pre-fetches so metadata retains the deleted role, assign captures previousRole |
 | `admin-sandbox.ts` | 2 | 0 | ❌ | Connect/disconnect BYOC sandbox (F-37) |
 | `admin-scim.ts` | 3 | 3 | ✅ | `scim.connection_delete` / `scim.group_mapping_create` / `scim.group_mapping_delete` — F-23 fixed |
 | `admin-semantic-improve.ts` | 4 | 0 | ❌ | AI-assisted semantic layer edits (F-35) |
@@ -1555,7 +1555,7 @@ Grep every `metadata: { ... }` literal on the admin-audit call sites. Sampled pa
 | F-22 | P0 | Audit gap | Plugin install/uninstall (`admin-plugins.ts`, `admin-marketplace.ts`) | #1777 | open |
 | F-23 | P0 | Audit gap | SCIM management (`admin-scim.ts`) | #1778 | open |
 | F-24 | P0 | Audit gap | IP allowlist (`admin-ip-allowlist.ts`) | #1779 | fixed (PR #1797) |
-| F-25 | P0 | Audit gap | EE custom-role CRUD + assignment (`admin-roles.ts`) | #1780 | fixed (PR for #1780) |
+| F-25 | P0 | Audit gap | EE custom-role CRUD + assignment (`admin-roles.ts`) | #1780 | fixed (PR #1800) |
 | F-26 | P0 | Meta-audit | Audit retention config + manual purge / hard-delete / export (`admin-audit-retention.ts`) | #1781 | fixed (PR #1799) |
 | F-27 | P1 | Self-audit | EE purge scheduler + retention mutations (`ee/audit/*`) | #1782 | open |
 | F-28 | P1 | Audit gap | Admin session revocation (`admin-sessions.ts`, `admin.ts`) | #1783 | open |

--- a/.claude/research/security-audit-1-2-3.md
+++ b/.claude/research/security-audit-1-2-3.md
@@ -1090,7 +1090,7 @@ Totals at the file level; individual uncovered writes are enumerated under the f
 | `admin-prompts.ts` | 7 | 0 | ❌ | Content governance — collection + prompt CRUD (F-35) |
 | `admin-publish.ts` | 1 | 1 | ✅ | `mode.publish` |
 | `admin-residency.ts` | 4 | 0 | ❌ | **Workspace residency assign is permanent and unaudited** (F-32) |
-| `admin-roles.ts` | 4 | 0 | ❌ | **Per phase-4 scope: CRITICAL — role CRUD + assignment unaudited** (F-25) |
+| `admin-roles.ts` | 4 | 4 | ✅ | F-25 fixed (PR for #1780) — `role.create` / `role.update` / `role.delete` / `role.assign` emitted with success + failure paths; update captures previousPermissions, delete pre-fetches so metadata retains the deleted role, assign captures previousRole |
 | `admin-sandbox.ts` | 2 | 0 | ❌ | Connect/disconnect BYOC sandbox (F-37) |
 | `admin-scim.ts` | 3 | 3 | ✅ | `scim.connection_delete` / `scim.group_mapping_create` / `scim.group_mapping_delete` — F-23 fixed |
 | `admin-semantic-improve.ts` | 4 | 0 | ❌ | AI-assisted semantic layer edits (F-35) |
@@ -1555,7 +1555,7 @@ Grep every `metadata: { ... }` literal on the admin-audit call sites. Sampled pa
 | F-22 | P0 | Audit gap | Plugin install/uninstall (`admin-plugins.ts`, `admin-marketplace.ts`) | #1777 | open |
 | F-23 | P0 | Audit gap | SCIM management (`admin-scim.ts`) | #1778 | open |
 | F-24 | P0 | Audit gap | IP allowlist (`admin-ip-allowlist.ts`) | #1779 | fixed (PR #1797) |
-| F-25 | P0 | Audit gap | EE custom-role CRUD + assignment (`admin-roles.ts`) | #1780 | open |
+| F-25 | P0 | Audit gap | EE custom-role CRUD + assignment (`admin-roles.ts`) | #1780 | fixed (PR for #1780) |
 | F-26 | P0 | Meta-audit | Audit retention config + manual purge / hard-delete / export (`admin-audit-retention.ts`) | #1781 | fixed (PR #1799) |
 | F-27 | P1 | Self-audit | EE purge scheduler + retention mutations (`ee/audit/*`) | #1782 | open |
 | F-28 | P1 | Audit gap | Admin session revocation (`admin-sessions.ts`, `admin.ts`) | #1783 | open |

--- a/ee/src/auth/roles.ts
+++ b/ee/src/auth/roles.ts
@@ -320,6 +320,26 @@ export const getRole = (orgId: string, roleId: string): Effect.Effect<CustomRole
   });
 
 /**
+ * Get a single role by name, scoped to org. Used by the audit path for
+ * role.assign to resolve the caller's `roleName` body param into the row id
+ * so the audit row ties the assignment to a stable primary key rather than
+ * a string that tenant admins can rename later.
+ */
+export const getRoleByName = (orgId: string, name: string): Effect.Effect<CustomRole | null, EnterpriseError> =>
+  Effect.gen(function* () {
+    yield* requireEnterpriseEffect("roles");
+    if (!hasInternalDB()) return null;
+
+    const rows = yield* Effect.promise(() => internalQuery<CustomRoleRow>(
+      `SELECT id, org_id, name, description, permissions, is_builtin, created_at, updated_at
+       FROM custom_roles
+       WHERE org_id = $1 AND name = $2`,
+      [orgId, name.toLowerCase()],
+    ));
+    return rows[0] ? rowToRole(rows[0]) : null;
+  });
+
+/**
  * Create a custom role for an organization.
  */
 export const createRole = (

--- a/packages/api/src/api/__tests__/admin-roles.test.ts
+++ b/packages/api/src/api/__tests__/admin-roles.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for admin custom-role audit emission (F-25 / #1780).
+ * Tests for admin custom-role audit emission (F-25).
  *
  * Covers the four write routes under /api/v1/admin/roles:
  *   - POST   /                          (role.create)
@@ -243,6 +243,10 @@ describe("admin roles — POST / (role.create)", () => {
     const metadata = entry.metadata as Record<string, unknown>;
     expect(metadata.roleName).toBe("auditor");
     expect(metadata.error).toContain("already exists");
+    // `roleId: null` keeps the create failure row shape-compatible with
+    // update/delete/assign so compliance queries can UNION across the
+    // four `role.*` actions without special-casing create.
+    expect(metadata.roleId).toBeNull();
   });
 
   it("emits failure audit when EE call dies (defect path)", async () => {
@@ -382,7 +386,7 @@ describe("admin roles — DELETE /{id} (role.delete)", () => {
     expect(entry.status).toBeUndefined();
   });
 
-  it("emits { roleId, found: false } when the role does not exist", async () => {
+  it("emits status:failure with { roleId, found: false } when the role does not exist", async () => {
     mockGetRole.mockImplementation(() => Effect.succeed(null));
 
     const res = await app.fetch(
@@ -392,10 +396,13 @@ describe("admin roles — DELETE /{id} (role.delete)", () => {
     expect(res.status).toBe(404);
     expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
     const entry = mockLogAdminAction.mock.calls[0][0];
+    // Not-found deletes must record as failure — a `status='failure'`
+    // filter in forensic queries would otherwise miss probe attempts.
     expect(entry).toMatchObject({
       actionType: "role.delete",
       targetType: "role",
       targetId: "role_missing",
+      status: "failure",
       metadata: { roleId: "role_missing", found: false },
     });
     // deleteRole should NOT have been invoked when pre-fetch showed nothing.
@@ -636,6 +643,159 @@ describe("admin roles — non-admin callers don't emit audit", () => {
     expect(mockLogAdminAction).not.toHaveBeenCalled();
     // Service was never invoked — a non-admin caller must not trigger a DB
     // write even when the audit emission is already guarded.
+    expect(mockCreateRole).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /{id} — race between pre-fetch and delete
+// ---------------------------------------------------------------------------
+
+describe("admin roles — DELETE /{id} race handling", () => {
+  it("emits status:failure with race reason when deleteRole returns false", async () => {
+    // Pre-fetch sees the row → existing is populated.
+    // deleteRole races and returns false (row gone).
+    // Audit must NOT claim a successful revoke that didn't happen.
+    mockGetRole.mockImplementation(() => Effect.succeed(existingRole));
+    mockDeleteRole.mockImplementation(() => Effect.succeed(false));
+
+    const res = await app.fetch(
+      rolesRequest("/api/v1/admin/roles/role_abc123", "DELETE"),
+    );
+
+    expect(res.status).toBe(404);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0][0];
+    expect(entry).toMatchObject({
+      actionType: "role.delete",
+      targetType: "role",
+      targetId: "role_abc123",
+      status: "failure",
+      metadata: {
+        roleId: "role_abc123",
+        roleName: "auditor",
+        permissions: ["query", "admin:audit"],
+        reason: "race_deleted_between_fetch_and_delete",
+      },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Credential scrubbing in error metadata
+// ---------------------------------------------------------------------------
+
+describe("admin roles — audit payload hygiene", () => {
+  it("scrubs connection-string credentials from create failure metadata", async () => {
+    mockCreateRole.mockImplementation(() =>
+      Effect.die(
+        new Error("pg error: connect ECONNREFUSED postgres://admin:hunter2@10.0.0.1:5432/atlas"),
+      ),
+    );
+
+    await app.fetch(
+      rolesRequest("/api/v1/admin/roles", "POST", {
+        name: "auditor",
+        permissions: ["query"],
+      }),
+    );
+
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0][0];
+    const errorText = (entry.metadata as Record<string, unknown>).error as string;
+    // Userinfo replaced; scheme + host retained for forensics.
+    expect(errorText).not.toContain("hunter2");
+    expect(errorText).not.toContain("admin:");
+    expect(errorText).toContain("postgres://***@10.0.0.1");
+  });
+
+  it("captures x-forwarded-for into ipAddress on success audit", async () => {
+    const created = { ...existingRole, id: "role_ip1" };
+    mockCreateRole.mockImplementation(() => Effect.succeed(created));
+
+    await app.fetch(
+      new Request("http://localhost/api/v1/admin/roles", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-forwarded-for": "198.51.100.42",
+        },
+        body: JSON.stringify({ name: "auditor", permissions: ["query"] }),
+      }),
+    );
+
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    expect(mockLogAdminAction.mock.calls[0][0].ipAddress).toBe("198.51.100.42");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Middleware short-circuits — audit contract at the edge
+// ---------------------------------------------------------------------------
+//
+// The "every write attempt is traced" contract must not leak into
+// middleware that runs before the handler. If a caller hits the route with
+// an invalid body (422 Zod) OR without an internal DB (404 short-circuit)
+// OR without an active organization (400 short-circuit), no audit row
+// should emit — there is no admin write to audit yet. A future refactor
+// that moves audit emission into middleware could silently break this;
+// these tests pin the current contract.
+
+describe("admin roles — middleware short-circuits don't emit audit", () => {
+  it("POST / with an invalid body returns 4xx and no audit row", async () => {
+    // `name` missing fails the `min(1)` zod constraint.
+    const res = await app.fetch(
+      rolesRequest("/api/v1/admin/roles", "POST", { permissions: ["query"] }),
+    );
+
+    // `@hono/zod-openapi` returns 400 via validationHook for this repo.
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).toBeLessThan(500);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+    expect(mockCreateRole).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 and no audit row when internal DB is not configured", async () => {
+    mocks.hasInternalDB = false;
+    mockCreateRole.mockImplementation(() => Effect.succeed(existingRole));
+
+    const res = await app.fetch(
+      rolesRequest("/api/v1/admin/roles", "POST", {
+        name: "auditor",
+        permissions: ["query"],
+      }),
+    );
+
+    expect(res.status).toBe(404);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+    expect(mockCreateRole).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 and no audit row when admin has no active organization", async () => {
+    mocks.mockAuthenticateRequest.mockImplementation(() =>
+      Promise.resolve({
+        authenticated: true,
+        mode: "managed",
+        user: {
+          id: "admin-1",
+          mode: "managed",
+          label: "admin@test.com",
+          role: "admin",
+          // no activeOrganizationId
+        },
+      }),
+    );
+    mockCreateRole.mockImplementation(() => Effect.succeed(existingRole));
+
+    const res = await app.fetch(
+      rolesRequest("/api/v1/admin/roles", "POST", {
+        name: "auditor",
+        permissions: ["query"],
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
     expect(mockCreateRole).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/api/__tests__/admin-roles.test.ts
+++ b/packages/api/src/api/__tests__/admin-roles.test.ts
@@ -1,0 +1,641 @@
+/**
+ * Tests for admin custom-role audit emission (F-25 / #1780).
+ *
+ * Covers the four write routes under /api/v1/admin/roles:
+ *   - POST   /                          (role.create)
+ *   - PUT    /{id}                      (role.update)
+ *   - DELETE /{id}                      (role.delete)
+ *   - PUT    /users/{userId}/role       (role.assign)
+ *
+ * Verifies that every write handler emits exactly one logAdminAction with
+ * the correct action type + metadata shape on success, that the three
+ * mutation-with-prior-state paths (update / delete / assign) pre-fetch state
+ * so the audit row captures what was removed or replaced, and that RoleError
+ * / defect / EnterpriseError paths all produce a failure-status audit row.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterAll,
+  mock,
+  type Mock,
+} from "bun:test";
+import { Effect } from "effect";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+// Real ADMIN_ACTIONS values so assertions pin to the canonical strings,
+// not hand-typed copies that drift when the catalog changes.
+import { ADMIN_ACTIONS as REAL_ADMIN_ACTIONS } from "@atlas/api/lib/audit/actions";
+
+// ── Unified mocks ───────────────────────────────────────────────────
+
+const mocks = createApiTestMocks({
+  authUser: {
+    id: "admin-1",
+    mode: "managed",
+    label: "admin@test.com",
+    role: "admin",
+    activeOrganizationId: "org-alpha",
+  },
+});
+
+// ── Audit mock ──────────────────────────────────────────────────────
+
+const mockLogAdminAction: Mock<(entry: Record<string, unknown>) => void> = mock(() => {});
+
+mock.module("@atlas/api/lib/audit", () => ({
+  logAdminAction: mockLogAdminAction,
+  logAdminActionAwait: mock(async () => {}),
+  ADMIN_ACTIONS: REAL_ADMIN_ACTIONS,
+}));
+
+// ── EE roles mock ───────────────────────────────────────────────────
+
+// Stable RoleError stand-in. `domainError()` uses `instanceof`, so the class
+// referenced by the route at module-load time must match the instances the
+// mocks throw. `_tag: "RoleError"` mirrors the real `Data.TaggedError` shape.
+class MockRoleError extends Error {
+  public readonly _tag = "RoleError" as const;
+  public readonly code: "not_found" | "conflict" | "validation" | "builtin_protected";
+  constructor(
+    message: string,
+    code: "not_found" | "conflict" | "validation" | "builtin_protected",
+  ) {
+    super(message);
+    this.name = "RoleError";
+    this.code = code;
+  }
+}
+
+class MockEnterpriseError extends Error {
+  public readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "EnterpriseError";
+    this.code = code;
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- mocks flex across success/failure Effects
+const mockListRoles: Mock<(orgId: string) => Effect.Effect<any, any>> = mock(
+  () => Effect.succeed([]),
+);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see above
+const mockGetRole: Mock<(orgId: string, roleId: string) => Effect.Effect<any, any>> = mock(
+  () => Effect.succeed(null),
+);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see above
+const mockGetRoleByName: Mock<(orgId: string, name: string) => Effect.Effect<any, any>> = mock(
+  () => Effect.succeed(null),
+);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see above
+const mockCreateRole: Mock<(orgId: string, input: Record<string, unknown>) => Effect.Effect<any, any>> = mock(
+  () => Effect.die(new Error("not configured")),
+);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see above
+const mockUpdateRole: Mock<(orgId: string, roleId: string, input: Record<string, unknown>) => Effect.Effect<any, any>> = mock(
+  () => Effect.die(new Error("not configured")),
+);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see above
+const mockDeleteRole: Mock<(orgId: string, roleId: string) => Effect.Effect<any, any>> = mock(
+  () => Effect.succeed(true),
+);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see above
+const mockListRoleMembers: Mock<(orgId: string, roleId: string) => Effect.Effect<any, any>> = mock(
+  () => Effect.succeed([]),
+);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see above
+const mockAssignRole: Mock<(orgId: string, userId: string, roleName: string) => Effect.Effect<any, any>> = mock(
+  () => Effect.die(new Error("not configured")),
+);
+
+mock.module("@atlas/ee/auth/roles", () => ({
+  RoleError: MockRoleError,
+  listRoles: mockListRoles,
+  getRole: mockGetRole,
+  getRoleByName: mockGetRoleByName,
+  createRole: mockCreateRole,
+  updateRole: mockUpdateRole,
+  deleteRole: mockDeleteRole,
+  listRoleMembers: mockListRoleMembers,
+  assignRole: mockAssignRole,
+  PERMISSIONS: [
+    "query",
+    "query:raw_data",
+    "admin:users",
+    "admin:connections",
+    "admin:settings",
+    "admin:audit",
+    "admin:roles",
+    "admin:semantic",
+  ] as const,
+  isValidPermission: () => true,
+  isValidRoleName: () => true,
+  BUILTIN_ROLES: [],
+  resolvePermissions: mock(() => Effect.succeed(new Set())),
+  hasPermission: mock(() => Effect.succeed(true)),
+  checkPermission: mock(() => Effect.succeed(null)),
+  seedBuiltinRoles: mock(() => Effect.succeed(undefined)),
+}));
+
+// ── Import app AFTER mocks ──────────────────────────────────────────
+
+const { app } = await import("../index");
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function rolesRequest(urlPath: string, method = "GET", body?: unknown): Request {
+  const opts: RequestInit = {
+    method,
+    headers: { "Content-Type": "application/json" },
+  };
+  if (body) opts.body = JSON.stringify(body);
+  return new Request(`http://localhost${urlPath}`, opts);
+}
+
+const existingRole = {
+  id: "role_abc123",
+  orgId: "org-alpha",
+  name: "auditor",
+  description: "Read-only audit access",
+  permissions: ["query", "admin:audit"],
+  isBuiltin: false,
+  createdAt: "2026-04-20T00:00:00.000Z",
+  updatedAt: "2026-04-20T00:00:00.000Z",
+};
+
+// ── Cleanup / reset ─────────────────────────────────────────────────
+
+afterAll(() => mocks.cleanup());
+
+beforeEach(() => {
+  mocks.hasInternalDB = true;
+  mocks.setOrgAdmin("org-alpha");
+  mockLogAdminAction.mockReset();
+  mockListRoles.mockReset();
+  mockGetRole.mockReset();
+  mockGetRoleByName.mockReset();
+  mockCreateRole.mockReset();
+  mockUpdateRole.mockReset();
+  mockDeleteRole.mockReset();
+  mockListRoleMembers.mockReset();
+  mockAssignRole.mockReset();
+  mocks.mockInternalQuery.mockReset();
+  mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+});
+
+// ---------------------------------------------------------------------------
+// POST / — role.create
+// ---------------------------------------------------------------------------
+
+describe("admin roles — POST / (role.create)", () => {
+  it("emits role.create audit on success", async () => {
+    const created = { ...existingRole, id: "role_new1", name: "auditor", permissions: ["query", "admin:audit"] };
+    mockCreateRole.mockImplementation(() => Effect.succeed(created));
+
+    const res = await app.fetch(
+      rolesRequest("/api/v1/admin/roles", "POST", {
+        name: "auditor",
+        description: "Read-only audit access",
+        permissions: ["query", "admin:audit"],
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+
+    const entry = mockLogAdminAction.mock.calls[0][0];
+    expect(entry).toMatchObject({
+      actionType: "role.create",
+      targetType: "role",
+      targetId: "role_new1",
+      metadata: {
+        roleId: "role_new1",
+        roleName: "auditor",
+        permissions: ["query", "admin:audit"],
+      },
+    });
+    expect(entry.status).toBeUndefined(); // default "success"
+  });
+
+  it("emits status:failure audit when RoleError.conflict is thrown", async () => {
+    mockCreateRole.mockImplementation(() =>
+      Effect.fail(new MockRoleError('Role "auditor" already exists in this organization.', "conflict")),
+    );
+
+    const res = await app.fetch(
+      rolesRequest("/api/v1/admin/roles", "POST", {
+        name: "auditor",
+        permissions: ["query"],
+      }),
+    );
+
+    expect(res.status).toBe(409);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0][0];
+    expect(entry).toMatchObject({
+      actionType: "role.create",
+      targetType: "role",
+      status: "failure",
+    });
+    const metadata = entry.metadata as Record<string, unknown>;
+    expect(metadata.roleName).toBe("auditor");
+    expect(metadata.error).toContain("already exists");
+  });
+
+  it("emits failure audit when EE call dies (defect path)", async () => {
+    mockCreateRole.mockImplementation(() =>
+      Effect.die(new Error("pool exhausted")),
+    );
+
+    const res = await app.fetch(
+      rolesRequest("/api/v1/admin/roles", "POST", {
+        name: "auditor",
+        permissions: ["query"],
+      }),
+    );
+
+    expect(res.status).toBe(500);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0][0];
+    expect(entry).toMatchObject({
+      actionType: "role.create",
+      status: "failure",
+    });
+    expect((entry.metadata as Record<string, unknown>).error).toBe("pool exhausted");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PUT /{id} — role.update
+// ---------------------------------------------------------------------------
+
+describe("admin roles — PUT /{id} (role.update)", () => {
+  it("captures previousPermissions AND new permissions", async () => {
+    mockGetRole.mockImplementation(() => Effect.succeed(existingRole));
+    const updated = { ...existingRole, permissions: ["query", "admin:audit", "admin:users"] };
+    mockUpdateRole.mockImplementation(() => Effect.succeed(updated));
+
+    const res = await app.fetch(
+      rolesRequest("/api/v1/admin/roles/role_abc123", "PUT", {
+        permissions: ["query", "admin:audit", "admin:users"],
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+
+    const entry = mockLogAdminAction.mock.calls[0][0];
+    expect(entry).toMatchObject({
+      actionType: "role.update",
+      targetType: "role",
+      targetId: "role_abc123",
+    });
+    const metadata = entry.metadata as Record<string, unknown>;
+    expect(metadata.roleId).toBe("role_abc123");
+    expect(metadata.roleName).toBe("auditor");
+    // Both old and new captured so forensic reconstruction sees the delta.
+    expect(metadata.previousPermissions).toEqual(["query", "admin:audit"]);
+    expect(metadata.permissions).toEqual(["query", "admin:audit", "admin:users"]);
+    expect(entry.status).toBeUndefined();
+  });
+
+  it("emits previousPermissions:null when pre-fetch returns nothing", async () => {
+    // Guard case: prior row doesn't exist. Route still emits best-effort audit.
+    mockGetRole.mockImplementation(() => Effect.succeed(null));
+    mockUpdateRole.mockImplementation(() =>
+      Effect.fail(new MockRoleError("Role not found.", "not_found")),
+    );
+
+    const res = await app.fetch(
+      rolesRequest("/api/v1/admin/roles/role_missing", "PUT", {
+        permissions: ["query"],
+      }),
+    );
+
+    expect(res.status).toBe(404);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0][0];
+    expect(entry).toMatchObject({
+      actionType: "role.update",
+      status: "failure",
+    });
+    const metadata = entry.metadata as Record<string, unknown>;
+    expect(metadata.previousPermissions).toBeNull();
+  });
+
+  it("emits status:failure audit when updateRole throws RoleError", async () => {
+    mockGetRole.mockImplementation(() => Effect.succeed(existingRole));
+    mockUpdateRole.mockImplementation(() =>
+      Effect.fail(new MockRoleError("Built-in roles cannot be modified.", "builtin_protected")),
+    );
+
+    const res = await app.fetch(
+      rolesRequest("/api/v1/admin/roles/role_abc123", "PUT", {
+        permissions: ["query"],
+      }),
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0][0];
+    expect(entry).toMatchObject({
+      actionType: "role.update",
+      status: "failure",
+    });
+    // Pre-fetch succeeded → previousPermissions should still be present on failure.
+    const metadata = entry.metadata as Record<string, unknown>;
+    expect(metadata.previousPermissions).toEqual(["query", "admin:audit"]);
+    expect(metadata.error).toContain("Built-in roles");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /{id} — role.delete
+// ---------------------------------------------------------------------------
+
+describe("admin roles — DELETE /{id} (role.delete)", () => {
+  it("pre-fetches and emits metadata with the deleted role's permissions", async () => {
+    mockGetRole.mockImplementation(() => Effect.succeed(existingRole));
+    mockDeleteRole.mockImplementation(() => Effect.succeed(true));
+
+    const res = await app.fetch(
+      rolesRequest("/api/v1/admin/roles/role_abc123", "DELETE"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+
+    const entry = mockLogAdminAction.mock.calls[0][0];
+    expect(entry).toMatchObject({
+      actionType: "role.delete",
+      targetType: "role",
+      targetId: "role_abc123",
+      metadata: {
+        roleId: "role_abc123",
+        roleName: "auditor",
+        permissions: ["query", "admin:audit"],
+      },
+    });
+    expect(entry.status).toBeUndefined();
+  });
+
+  it("emits { roleId, found: false } when the role does not exist", async () => {
+    mockGetRole.mockImplementation(() => Effect.succeed(null));
+
+    const res = await app.fetch(
+      rolesRequest("/api/v1/admin/roles/role_missing", "DELETE"),
+    );
+
+    expect(res.status).toBe(404);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0][0];
+    expect(entry).toMatchObject({
+      actionType: "role.delete",
+      targetType: "role",
+      targetId: "role_missing",
+      metadata: { roleId: "role_missing", found: false },
+    });
+    // deleteRole should NOT have been invoked when pre-fetch showed nothing.
+    expect(mockDeleteRole).not.toHaveBeenCalled();
+  });
+
+  it("emits status:failure when deleteRole throws RoleError", async () => {
+    mockGetRole.mockImplementation(() => Effect.succeed(existingRole));
+    mockDeleteRole.mockImplementation(() =>
+      Effect.fail(
+        new MockRoleError("Cannot delete role with 3 active member(s). Reassign them first.", "validation"),
+      ),
+    );
+
+    const res = await app.fetch(
+      rolesRequest("/api/v1/admin/roles/role_abc123", "DELETE"),
+    );
+
+    expect(res.status).toBe(400);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0][0];
+    expect(entry).toMatchObject({
+      actionType: "role.delete",
+      status: "failure",
+    });
+    const metadata = entry.metadata as Record<string, unknown>;
+    // Pre-fetch captured the role even on failure — compliance knows what the
+    // attempt was aimed at.
+    expect(metadata.roleId).toBe("role_abc123");
+    expect(metadata.roleName).toBe("auditor");
+    expect(metadata.permissions).toEqual(["query", "admin:audit"]);
+    expect(metadata.error).toContain("active member");
+  });
+
+  it("emits failure audit when the EE delete dies (defect path)", async () => {
+    mockGetRole.mockImplementation(() => Effect.succeed(existingRole));
+    mockDeleteRole.mockImplementation(() =>
+      Effect.die(new Error("RETURNING row missing")),
+    );
+
+    const res = await app.fetch(
+      rolesRequest("/api/v1/admin/roles/role_abc123", "DELETE"),
+    );
+
+    expect(res.status).toBe(500);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0][0];
+    expect(entry).toMatchObject({
+      actionType: "role.delete",
+      status: "failure",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PUT /users/{userId}/role — role.assign
+// ---------------------------------------------------------------------------
+
+describe("admin roles — PUT /users/{userId}/role (role.assign)", () => {
+  it("captures previousRole + roleId + roleName + userId", async () => {
+    mockGetRoleByName.mockImplementation(() => Effect.succeed(existingRole));
+    // Prior member.role via internalQuery pre-fetch.
+    mocks.mockInternalQuery.mockImplementation(() =>
+      Promise.resolve([{ role: "viewer" }]),
+    );
+    mockAssignRole.mockImplementation(() =>
+      Effect.succeed({ userId: "user_xyz", role: "auditor" }),
+    );
+
+    const res = await app.fetch(
+      rolesRequest("/api/v1/admin/roles/users/user_xyz/role", "PUT", {
+        role: "auditor",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0][0];
+    expect(entry).toMatchObject({
+      actionType: "role.assign",
+      targetType: "role",
+      targetId: "role_abc123",
+    });
+    const metadata = entry.metadata as Record<string, unknown>;
+    expect(metadata.roleId).toBe("role_abc123");
+    expect(metadata.roleName).toBe("auditor");
+    expect(metadata.userId).toBe("user_xyz");
+    expect(metadata.previousRole).toBe("viewer");
+    expect(entry.status).toBeUndefined();
+  });
+
+  it("emits previousRole:null when the user has no prior role", async () => {
+    mockGetRoleByName.mockImplementation(() => Effect.succeed(existingRole));
+    mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+    mockAssignRole.mockImplementation(() =>
+      Effect.succeed({ userId: "user_xyz", role: "auditor" }),
+    );
+
+    const res = await app.fetch(
+      rolesRequest("/api/v1/admin/roles/users/user_xyz/role", "PUT", {
+        role: "auditor",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const metadata = mockLogAdminAction.mock.calls[0][0].metadata as Record<string, unknown>;
+    expect(metadata.previousRole).toBeNull();
+  });
+
+  it("emits status:failure when assignRole throws RoleError", async () => {
+    mockGetRoleByName.mockImplementation(() => Effect.succeed(existingRole));
+    mocks.mockInternalQuery.mockImplementation(() =>
+      Promise.resolve([{ role: "member" }]),
+    );
+    mockAssignRole.mockImplementation(() =>
+      Effect.fail(new MockRoleError("User is not a member of this organization.", "not_found")),
+    );
+
+    const res = await app.fetch(
+      rolesRequest("/api/v1/admin/roles/users/user_gone/role", "PUT", {
+        role: "auditor",
+      }),
+    );
+
+    expect(res.status).toBe(404);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0][0];
+    expect(entry).toMatchObject({
+      actionType: "role.assign",
+      status: "failure",
+    });
+    const metadata = entry.metadata as Record<string, unknown>;
+    expect(metadata.userId).toBe("user_gone");
+    expect(metadata.roleName).toBe("auditor");
+    expect(metadata.previousRole).toBe("member");
+    expect(metadata.error).toContain("not a member");
+  });
+
+  it("emits failure audit when the role name does not exist", async () => {
+    mockGetRoleByName.mockImplementation(() => Effect.succeed(null));
+    mockAssignRole.mockImplementation(() =>
+      Effect.fail(
+        new MockRoleError('Role "ghost" does not exist in this organization.', "not_found"),
+      ),
+    );
+
+    const res = await app.fetch(
+      rolesRequest("/api/v1/admin/roles/users/user_xyz/role", "PUT", {
+        role: "ghost",
+      }),
+    );
+
+    expect(res.status).toBe(404);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0][0];
+    expect(entry).toMatchObject({
+      actionType: "role.assign",
+      status: "failure",
+    });
+    const metadata = entry.metadata as Record<string, unknown>;
+    // When the role name is unknown the audit row still records the attempt
+    // so forensic queries can see "admin tried to grant ghost" — roleId is
+    // null because there's no row to reference.
+    expect(metadata.roleId).toBeNull();
+    expect(metadata.roleName).toBe("ghost");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Enterprise gate — unlicensed deploys still produce a forensic trail
+// ---------------------------------------------------------------------------
+
+describe("admin roles — EnterpriseError emits failure audit", () => {
+  it("POST / emits failure audit on license gate", async () => {
+    mockCreateRole.mockImplementation(() =>
+      Effect.fail(new MockEnterpriseError("enterprise_required", "Custom roles require enterprise.")),
+    );
+
+    const res = await app.fetch(
+      rolesRequest("/api/v1/admin/roles", "POST", {
+        name: "auditor",
+        permissions: ["query"],
+      }),
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0][0];
+    expect(entry).toMatchObject({
+      actionType: "role.create",
+      status: "failure",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression — read routes stay silent
+// ---------------------------------------------------------------------------
+
+describe("admin roles — read routes don't emit audit", () => {
+  it("GET / does not call logAdminAction", async () => {
+    mockListRoles.mockImplementation(() => Effect.succeed([existingRole]));
+
+    const res = await app.fetch(rolesRequest("/api/v1/admin/roles"));
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+
+  it("GET /{id}/members does not call logAdminAction", async () => {
+    mockListRoleMembers.mockImplementation(() => Effect.succeed([]));
+
+    const res = await app.fetch(rolesRequest("/api/v1/admin/roles/role_abc123/members"));
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Authorization regression — non-admin calls must NOT emit audit rows
+// ---------------------------------------------------------------------------
+
+describe("admin roles — non-admin callers don't emit audit", () => {
+  it("POST / returns 403 for a member with no audit row", async () => {
+    mocks.setMember("org-alpha");
+    mockCreateRole.mockImplementation(() =>
+      Effect.succeed({ ...existingRole, id: "role_should_not_hit" }),
+    );
+
+    const res = await app.fetch(
+      rolesRequest("/api/v1/admin/roles", "POST", {
+        name: "auditor",
+        permissions: ["query"],
+      }),
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+    // Service was never invoked — a non-admin caller must not trigger a DB
+    // write even when the audit emission is already guarded.
+    expect(mockCreateRole).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/api/routes/admin-roles.ts
+++ b/packages/api/src/api/routes/admin-roles.ts
@@ -3,17 +3,29 @@
  *
  * Mounted under /api/v1/admin/roles. All routes require admin role AND
  * enterprise license (enforced within the roles service layer).
+ *
+ * Audit emission: every write path (`role.create|update|delete|assign`)
+ * emits a `logAdminAction` row on success AND failure. The mutation-with-
+ * prior-state handlers (update / delete / assign) pre-fetch the existing
+ * row so the audit metadata captures what was replaced or removed — a
+ * compromised admin can't stage permissions, exploit them, and purge the
+ * trail. See F-25 in .claude/research/security-audit-1-2-3.md.
  */
 
-import { Effect } from "effect";
+import { Array as Arr, Cause, Effect, Option } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
+import type { Context } from "hono";
 import { runEffect, domainError } from "@atlas/api/lib/effect/hono";
 import { AuthContext } from "@atlas/api/lib/effect/services";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
+import { internalQuery } from "@atlas/api/lib/db/internal";
 import {
   listRoles,
   createRole,
   updateRole,
   deleteRole,
+  getRole,
+  getRoleByName,
   listRoleMembers,
   assignRole,
   RoleError,
@@ -21,6 +33,37 @@ import {
 } from "@atlas/ee/auth/roles";
 import { ErrorSchema, AuthErrorSchema, isValidId, createIdParamSchema, createParamSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
+
+function clientIP(c: Context): string | null {
+  return c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null;
+}
+
+const ERROR_MESSAGE_MAX = 512;
+
+// Strip credential-bearing URI userinfo so pg error text that leaks a
+// connection string can't land in `admin_action_log.metadata`. Bounded so
+// JSONB rows stay small. Mirrors the helper in admin-scim.ts.
+function errorMessage(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  const scrubbed = raw.replace(
+    /\b([a-z][a-z0-9+.-]*):\/\/[^\s@/]*@/gi,
+    "$1://***@",
+  );
+  return scrubbed.length > ERROR_MESSAGE_MAX
+    ? `${scrubbed.slice(0, ERROR_MESSAGE_MAX - 3)}...`
+    : scrubbed;
+}
+
+// Extract the primary error from an Effect Cause — covers typed failures
+// AND defects (rejected `Effect.promise`, `Effect.die`). Returns undefined
+// on pure interrupts (no error to report).
+function causeToError(cause: Cause.Cause<unknown>): unknown | undefined {
+  if (Cause.isInterruptedOnly(cause)) return undefined;
+  const failure = Cause.failureOption(cause);
+  if (Option.isSome(failure)) return failure.value;
+  const defects = Arr.fromIterable(Cause.defects(cause));
+  return defects[0];
+}
 
 const roleDomainError = domainError(RoleError, { not_found: 404, conflict: 409, validation: 400, builtin_protected: 403 });
 
@@ -213,52 +256,214 @@ adminRoles.openapi(listRolesRoute, async (c) => {
 
 // POST / — create a custom role
 adminRoles.openapi(createRoleRoute, async (c) => {
+  const ipAddress = clientIP(c);
+  const body = c.req.valid("json");
+  const roleName = body.name?.toLowerCase().trim() ?? "";
+
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
-    const body = c.req.valid("json");
 
     if (!body.name || !body.permissions || !Array.isArray(body.permissions)) {
       return c.json({ error: "bad_request", message: "Missing required fields: name, permissions." }, 400);
     }
 
     const role = yield* createRole(orgId!, body);
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.role.create,
+      targetType: "role",
+      targetId: role.id,
+      ipAddress,
+      metadata: {
+        roleId: role.id,
+        roleName: role.name,
+        permissions: role.permissions,
+      },
+    });
+
     return c.json({ role }, 201);
-  }), { label: "create role", domainErrors: [roleDomainError] });
+  }).pipe(
+    // `tapErrorCause` sees both typed failures (RoleError / EnterpriseError
+    // from `yield*`) and defects (rejected `Effect.promise`). Earlier SCIM
+    // iterations used `tapError` and missed pool-exhaustion defects — the
+    // audit trail went blank on the exact failure mode a malicious admin
+    // would look to exploit.
+    Effect.tapErrorCause((cause) => {
+      const err = causeToError(cause);
+      if (err === undefined) return Effect.void;
+      return Effect.sync(() =>
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.role.create,
+          // No role id yet — key the row by the attempted name so forensic
+          // queries can pivot across "admin tried to create X" even when
+          // the row was never persisted.
+          targetType: "role",
+          targetId: roleName || "unknown",
+          status: "failure",
+          ipAddress,
+          metadata: {
+            roleName,
+            permissions: body.permissions,
+            error: errorMessage(err),
+          },
+        }),
+      );
+    }),
+  ), { label: "create role", domainErrors: [roleDomainError] });
 });
 
 // PUT /:id — update a custom role
 adminRoles.openapi(updateRoleRoute, async (c) => {
+  const ipAddress = clientIP(c);
+  const { id: roleId } = c.req.valid("param");
+  const body = c.req.valid("json");
+
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
-    const { id: roleId } = c.req.valid("param");
 
     if (!isValidId(roleId)) {
       return c.json({ error: "bad_request", message: "Invalid role ID." }, 400);
     }
 
-    const body = c.req.valid("json");
+    // Pre-fetch so the audit row captures what the update replaced. Without
+    // this a compromised admin could flip a role from `query` to
+    // `query,admin:audit` and the audit trail would only show the new perms
+    // — forensic reconstruction needs the delta.
+    const prior = yield* getRole(orgId!, roleId);
 
     const role = yield* updateRole(orgId!, roleId, body);
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.role.update,
+      targetType: "role",
+      targetId: role.id,
+      ipAddress,
+      metadata: {
+        roleId: role.id,
+        roleName: role.name,
+        permissions: role.permissions,
+        previousPermissions: prior?.permissions ?? null,
+      },
+    });
+
     return c.json({ role }, 200);
-  }), { label: "update role", domainErrors: [roleDomainError] });
+  }).pipe(
+    Effect.tapErrorCause((cause) =>
+      Effect.gen(function* () {
+        const err = causeToError(cause);
+        if (err === undefined) return;
+        // Best-effort pre-fetch for the failure row too. Swallow errors
+        // from this lookup so the audit emission isn't dropped when the
+        // underlying DB is the failure itself.
+        const { orgId } = yield* AuthContext;
+        const prior = yield* getRole(orgId!, roleId).pipe(
+          Effect.catchAll(() => Effect.succeed(null)),
+        );
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.role.update,
+          targetType: "role",
+          targetId: roleId,
+          status: "failure",
+          ipAddress,
+          metadata: {
+            roleId,
+            roleName: prior?.name ?? null,
+            permissions: body.permissions ?? null,
+            previousPermissions: prior?.permissions ?? null,
+            error: errorMessage(err),
+          },
+        });
+      }),
+    ),
+  ), { label: "update role", domainErrors: [roleDomainError] });
 });
 
 // DELETE /:id — delete a custom role
 adminRoles.openapi(deleteRoleRoute, async (c) => {
+  const ipAddress = clientIP(c);
+  const { id: roleId } = c.req.valid("param");
+
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
-    const { id: roleId } = c.req.valid("param");
 
     if (!isValidId(roleId)) {
       return c.json({ error: "bad_request", message: "Invalid role ID." }, 400);
     }
 
-    const deleted = yield* deleteRole(orgId!, roleId);
-    if (!deleted) {
+    // Pre-fetch the row BEFORE calling deleteRole. Without this the audit
+    // metadata can't record which permissions were revoked — the row is
+    // gone by the time we'd emit.
+    const existing = yield* getRole(orgId!, roleId);
+
+    if (!existing) {
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.role.delete,
+        targetType: "role",
+        targetId: roleId,
+        ipAddress,
+        metadata: { roleId, found: false },
+      });
       return c.json({ error: "not_found", message: "Role not found." }, 404);
     }
+
+    const deleted = yield* deleteRole(orgId!, roleId);
+
+    if (!deleted) {
+      // Race between pre-fetch and delete — audit must not claim a
+      // successful removal that didn't happen.
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.role.delete,
+        targetType: "role",
+        targetId: roleId,
+        status: "failure",
+        ipAddress,
+        metadata: {
+          roleId,
+          roleName: existing.name,
+          permissions: existing.permissions,
+          reason: "race_deleted_between_fetch_and_delete",
+        },
+      });
+      return c.json({ error: "not_found", message: "Role not found." }, 404);
+    }
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.role.delete,
+      targetType: "role",
+      targetId: roleId,
+      ipAddress,
+      metadata: {
+        roleId,
+        roleName: existing.name,
+        permissions: existing.permissions,
+      },
+    });
     return c.json({ message: "Role deleted." }, 200);
-  }), { label: "delete role", domainErrors: [roleDomainError] });
+  }).pipe(
+    Effect.tapErrorCause((cause) =>
+      Effect.gen(function* () {
+        const err = causeToError(cause);
+        if (err === undefined) return;
+        const { orgId } = yield* AuthContext;
+        const prior = yield* getRole(orgId!, roleId).pipe(
+          Effect.catchAll(() => Effect.succeed(null)),
+        );
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.role.delete,
+          targetType: "role",
+          targetId: roleId,
+          status: "failure",
+          ipAddress,
+          metadata: {
+            roleId,
+            roleName: prior?.name ?? null,
+            permissions: prior?.permissions ?? null,
+            error: errorMessage(err),
+          },
+        });
+      }),
+    ),
+  ), { label: "delete role", domainErrors: [roleDomainError] });
 });
 
 // GET /:id/members — list members with a specific role
@@ -278,19 +483,83 @@ adminRoles.openapi(listRoleMembersRoute, async (c) => {
 
 // PUT /users/:userId/role — assign a role to a user
 adminRoles.openapi(assignRoleRoute, async (c) => {
+  const ipAddress = clientIP(c);
+  const { userId } = c.req.valid("param");
+  const { role: roleName } = c.req.valid("json");
+
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
-    const { userId } = c.req.valid("param");
 
     if (!isValidId(userId)) {
       return c.json({ error: "bad_request", message: "Invalid user ID." }, 400);
     }
 
-    const { role: roleName } = c.req.valid("json");
+    // Pre-fetch role row (by name) to resolve a stable roleId for the audit,
+    // and the user's existing member.role so the audit captures what was
+    // replaced. Mirrors the `user.change_role` pattern in admin.ts —
+    // compliance reconstruction needs the before-state, not just the after.
+    const targetRole = yield* getRoleByName(orgId!, roleName);
+    const priorRows = yield* Effect.tryPromise({
+      try: () => internalQuery<{ role: string }>(
+        `SELECT role FROM member WHERE "organizationId" = $1 AND "userId" = $2 LIMIT 1`,
+        [orgId, userId],
+      ),
+      catch: (err) => err instanceof Error ? err : new Error(String(err)),
+    }).pipe(Effect.catchAll(() => Effect.succeed([])));
+    const previousRole = priorRows[0]?.role ?? null;
 
     const result = yield* assignRole(orgId!, userId, roleName);
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.role.assign,
+      targetType: "role",
+      targetId: targetRole?.id ?? roleName,
+      ipAddress,
+      metadata: {
+        roleId: targetRole?.id ?? null,
+        roleName: result.role,
+        userId,
+        previousRole,
+      },
+    });
+
     return c.json(result, 200);
-  }), { label: "assign role", domainErrors: [roleDomainError] });
+  }).pipe(
+    Effect.tapErrorCause((cause) =>
+      Effect.gen(function* () {
+        const err = causeToError(cause);
+        if (err === undefined) return;
+        // Re-run the same best-effort lookups so the failure row carries
+        // the same shape as the success row — compliance queries can then
+        // union on metadata keys without special-casing the failure path.
+        const { orgId } = yield* AuthContext;
+        const targetRole = yield* getRoleByName(orgId!, roleName).pipe(
+          Effect.catchAll(() => Effect.succeed(null)),
+        );
+        const priorRows = yield* Effect.tryPromise({
+          try: () => internalQuery<{ role: string }>(
+            `SELECT role FROM member WHERE "organizationId" = $1 AND "userId" = $2 LIMIT 1`,
+            [orgId, userId],
+          ),
+          catch: (e) => e instanceof Error ? e : new Error(String(e)),
+        }).pipe(Effect.catchAll(() => Effect.succeed([] as Array<{ role: string }>)));
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.role.assign,
+          targetType: "role",
+          targetId: targetRole?.id ?? roleName,
+          status: "failure",
+          ipAddress,
+          metadata: {
+            roleId: targetRole?.id ?? null,
+            roleName,
+            userId,
+            previousRole: priorRows[0]?.role ?? null,
+            error: errorMessage(err),
+          },
+        });
+      }),
+    ),
+  ), { label: "assign role", domainErrors: [roleDomainError] });
 });
 
 export { adminRoles };

--- a/packages/api/src/api/routes/admin-roles.ts
+++ b/packages/api/src/api/routes/admin-roles.ts
@@ -42,7 +42,7 @@ const ERROR_MESSAGE_MAX = 512;
 
 // Strip credential-bearing URI userinfo so pg error text that leaks a
 // connection string can't land in `admin_action_log.metadata`. Bounded so
-// JSONB rows stay small. Mirrors the helper in admin-scim.ts.
+// JSONB rows stay small.
 function errorMessage(err: unknown): string {
   const raw = err instanceof Error ? err.message : String(err);
   const scrubbed = raw.replace(
@@ -283,11 +283,11 @@ adminRoles.openapi(createRoleRoute, async (c) => {
 
     return c.json({ role }, 201);
   }).pipe(
-    // `tapErrorCause` sees both typed failures (RoleError / EnterpriseError
-    // from `yield*`) and defects (rejected `Effect.promise`). Earlier SCIM
-    // iterations used `tapError` and missed pool-exhaustion defects — the
-    // audit trail went blank on the exact failure mode a malicious admin
-    // would look to exploit.
+    // `tapErrorCause` catches both typed failures (RoleError /
+    // EnterpriseError from `yield*`) AND defects from `Effect.promise`
+    // (rejected DB promises — pool exhaustion, network drops). `tapError`
+    // alone would miss defects, dropping the audit row on the exact
+    // failure mode a malicious admin would probe for.
     Effect.tapErrorCause((cause) => {
       const err = causeToError(cause);
       if (err === undefined) return Effect.void;
@@ -296,12 +296,15 @@ adminRoles.openapi(createRoleRoute, async (c) => {
           actionType: ADMIN_ACTIONS.role.create,
           // No role id yet — key the row by the attempted name so forensic
           // queries can pivot across "admin tried to create X" even when
-          // the row was never persisted.
+          // the row was never persisted. `roleId: null` in metadata keeps
+          // the column shape aligned with update/delete/assign so
+          // compliance queries can UNION across the four actions.
           targetType: "role",
           targetId: roleName || "unknown",
           status: "failure",
           ipAddress,
           metadata: {
+            roleId: null,
             roleName,
             permissions: body.permissions,
             error: errorMessage(err),
@@ -396,10 +399,14 @@ adminRoles.openapi(deleteRoleRoute, async (c) => {
     const existing = yield* getRole(orgId!, roleId);
 
     if (!existing) {
+      // Admin attempted to delete a role that doesn't exist — a probe
+      // pattern an attacker exercises before pivoting. Emit as failure so
+      // forensic queries filtering on `status = 'failure'` catch it.
       logAdminAction({
         actionType: ADMIN_ACTIONS.role.delete,
         targetType: "role",
         targetId: roleId,
+        status: "failure",
         ipAddress,
         metadata: { roleId, found: false },
       });

--- a/packages/api/src/lib/audit/actions.ts
+++ b/packages/api/src/lib/audit/actions.ts
@@ -110,6 +110,19 @@ export const ADMIN_ACTIONS = {
     groupMappingDelete: "scim.group_mapping_delete",
   },
   /**
+   * EE custom RBAC mutations. Without these entries the Better-Auth
+   * `user.change_role` trail covers platform-role changes but a workspace
+   * admin can define a role with `admin:audit` / `connection:delete`, assign
+   * it to any org member, and leave no forensic trace. See F-25 in
+   * .claude/research/security-audit-1-2-3.md.
+   */
+  role: {
+    create: "role.create",
+    update: "role.update",
+    delete: "role.delete",
+    assign: "role.assign",
+  },
+  /**
    * Without these entries a compromised admin could shrink retentionDays
    * and hard-delete the audit trail leaving zero forensic record.
    */


### PR DESCRIPTION
## Summary
- Phase-4 F-25 of the 1.2.3 security sweep (#1718). Closes #1780.
- `admin-roles.ts` write routes (`role.create|update|delete|assign`) now emit `logAdminAction` on success AND failure. Pre-fetches capture `previousPermissions` on update, deleted-role permissions on delete, and `previousRole` on assignment so forensic reconstruction sees the delta — a compromised admin can no longer stage → exploit → purge in silence.
- EE surface adds `getRoleByName(orgId, name)` so the assignment audit resolves to a stable row id instead of keying on a mutable display name.

## Why now
Phase-1 F-10 (#1758) hardened the Better-Auth `platform_admin` escalation path, but the EE custom RBAC path left zero trail. A workspace admin could still define a role with `admin:audit` / `connection:delete`, assign it to any member, and — combined with F-26 — shrink retention to purge any residual evidence.

## What changed
- `packages/api/src/lib/audit/actions.ts`: `role.{create,update,delete,assign}` entries in `ADMIN_ACTIONS`.
- `packages/api/src/api/routes/admin-roles.ts`: success emission on each write handler; failure emission via `Effect.tapErrorCause` (catches defects from `Effect.promise`, not just typed failures).
- `ee/src/auth/roles.ts`: new `getRoleByName` Effect mirroring existing `getRole`.
- `.claude/research/security-audit-1-2-3.md`: Phase-4 scoreboard + F-25 status flipped to fixed.

## Tests
- New file `packages/api/src/api/__tests__/admin-roles.test.ts` — 18 cases:
  - success emission + metadata shape per route (`role.create`/`update`/`delete`/`assign`)
  - `role.update` captures both `previousPermissions` and `permissions`
  - `role.update` emits `previousPermissions: null` when pre-fetch returns nothing
  - `role.delete` emits `{ roleId, found: false }` when row missing; captures permissions on success and on failure
  - `role.assign` captures `previousRole` (mirror of `user.change_role`), emits `previousRole: null` when user had no prior role, handles unknown-role-name case with `roleId: null`
  - failure emission for RoleError (typed) + defect (`Effect.die`) + EnterpriseError per route
  - regression: read routes stay silent; non-admin callers get 403 with no audit row AND no service invocation
- All 81 `expect()` calls green locally.

## CI gates (all green locally)
- [x] `bun run lint`
- [x] `bun run type`
- [x] `bun run test` — 261 files passed, 0 failed across the monorepo
- [x] `bun x syncpack lint`
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh`

## Test plan
- [ ] Merge after review
- [ ] Confirm Phase-4 scoreboard update in `.claude/research/security-audit-1-2-3.md`
- [ ] Verify F-25 closes via the `Closes #1780` footer