### PR TITLE
fix(security): 1.2.3 phase 4 — F-28 session revocation audit emission

### DIFF
--- a/.claude/research/security-audit-1-2-3.md
+++ b/.claude/research/security-audit-1-2-3.md
@@ -1099,7 +1099,7 @@ Totals at the file level; individual uncovered writes are enumerated under the f
 | `admin-sso.ts` | 6 | 4 | 🟡 | Configure / update / delete / test audited; **`POST /providers/{id}/verify` + `PUT /enforcement` unaudited** (F-29) |
 | `admin-starter-prompts.ts` | 4 | 0 | ❌ | Queue moderation — approve/hide/unhide/author (F-36) |
 | `admin-suggestions.ts` | 1 | 0 | ❌ | DELETE suggestion (F-37) |
-| `admin.ts` | 12 | 10 | 🟡 | User role / ban / unban / remove-membership / delete-user / revoke-sessions / settings update + delete + semantic put/delete audited; **`POST /me/password`, `POST /semantic/org/import` unaudited** — tracked in F-29. `POST /users/{id}/revoke-sessions` now emits `user.session_revoke_all` (F-28 fixed, PR #NNNN) |
+| `admin.ts` | 12 | 10 | 🟡 | User role / ban / unban / remove-membership / delete-user / revoke-sessions / settings update + delete + semantic put/delete audited; **`POST /me/password`, `POST /semantic/org/import` unaudited** — tracked in F-29. `POST /users/{id}/revoke-sessions` now emits `user.session_revoke_all` (F-28 fixed, PR #1801) |
 | `billing.ts` | 2 | 0 | ✳︎ | Stripe portal redirects — Stripe event log is the authoritative trail; both routes are admin-gated |
 | `chat.ts` | 1 | 0 | ✳︎ | Agent messages; SQL executed via the tool is audited in `audit_log` |
 | `conversations.ts` | 9 | 0 | ✳︎ | User content — out of scope for phase-4 |
@@ -1558,7 +1558,7 @@ Grep every `metadata: { ... }` literal on the admin-audit call sites. Sampled pa
 | F-25 | P0 | Audit gap | EE custom-role CRUD + assignment (`admin-roles.ts`) | #1780 | open |
 | F-26 | P0 | Meta-audit | Audit retention config + manual purge / hard-delete / export (`admin-audit-retention.ts`) | #1781 | fixed (PR #1799) |
 | F-27 | P1 | Self-audit | EE purge scheduler + retention mutations (`ee/audit/*`) | #1782 | open |
-| F-28 | P1 | Audit gap | Admin session revocation (`admin-sessions.ts`, `admin.ts`) | #1783 | fixed (PR #NNNN) |
+| F-28 | P1 | Audit gap | Admin session revocation (`admin-sessions.ts`, `admin.ts`) | #1783 | fixed (PR #1801) |
 | F-29 | P2 | Partial coverage | `admin-sso.ts`, `admin-connections.ts`, `scheduled-tasks.ts`, `admin-approval.ts`, `admin.ts` stragglers | #1784 | open |
 | F-30 | P1 | Credential-provenance | Email provider + model config (`admin-email-provider.ts`, `admin-model-config.ts`) | #1785 | open |
 | F-31 | P1 | Audit gap | Platform-admin workspace CRUD via `admin-orgs.ts` (post-F-08 drift) | #1786 | open |

--- a/.claude/research/security-audit-1-2-3.md
+++ b/.claude/research/security-audit-1-2-3.md
@@ -1095,11 +1095,11 @@ Totals at the file level; individual uncovered writes are enumerated under the f
 | `admin-scim.ts` | 3 | 3 | ✅ | `scim.connection_delete` / `scim.group_mapping_create` / `scim.group_mapping_delete` — F-23 fixed |
 | `admin-semantic-improve.ts` | 4 | 0 | ❌ | AI-assisted semantic layer edits (F-35) |
 | `admin-semantic.ts` | 3 | 3 | ✅ | `semantic.update_entity` / `semantic.delete_entity` |
-| `admin-sessions.ts` | 2 | 0 | ❌ | **Session revocation unaudited** (F-28) — pino-only, not in `admin_action_log` |
+| `admin-sessions.ts` | 2 | 2 | ✅ | F-28 fixed (PR for #1783) — `user.session_revoke` / `user.session_revoke_all` emitted with success + failure paths; single-session path pre-fetches target userId and records `wasCurrentUser` |
 | `admin-sso.ts` | 6 | 4 | 🟡 | Configure / update / delete / test audited; **`POST /providers/{id}/verify` + `PUT /enforcement` unaudited** (F-29) |
 | `admin-starter-prompts.ts` | 4 | 0 | ❌ | Queue moderation — approve/hide/unhide/author (F-36) |
 | `admin-suggestions.ts` | 1 | 0 | ❌ | DELETE suggestion (F-37) |
-| `admin.ts` | 12 | 9 | 🟡 | User role / ban / unban / remove-membership / delete-user / settings update + delete + semantic put/delete audited; **`POST /me/password`, `POST /semantic/org/import`, `POST /users/{id}/revoke-sessions` unaudited** — first two tracked in F-29, third in F-28 |
+| `admin.ts` | 12 | 10 | 🟡 | User role / ban / unban / remove-membership / delete-user / revoke-sessions / settings update + delete + semantic put/delete audited; **`POST /me/password`, `POST /semantic/org/import` unaudited** — tracked in F-29. `POST /users/{id}/revoke-sessions` now emits `user.session_revoke_all` (F-28 fixed, PR #NNNN) |
 | `billing.ts` | 2 | 0 | ✳︎ | Stripe portal redirects — Stripe event log is the authoritative trail; both routes are admin-gated |
 | `chat.ts` | 1 | 0 | ✳︎ | Agent messages; SQL executed via the tool is audited in `audit_log` |
 | `conversations.ts` | 9 | 0 | ✳︎ | User content — out of scope for phase-4 |
@@ -1316,7 +1316,7 @@ Several files have *most* of their writes covered but leave stragglers. Coverage
 - `admin-connections.ts` (3/7 audited): `POST /test` (ephemeral URL), `POST /{id}/test` (health check), `POST /{id}/drain` (single pool drain, line 172), and `POST /pool/orgs/{orgId}/drain` (all pools for an org, line 149) — no audit. The 3 present calls cover create / update / delete.
 - `scheduled-tasks.ts` (4/6 audited): `POST /{id}/run` (trigger immediate execution), `POST /{id}/preview` (dry-run), `POST /tick` (scheduler tick) — no audit. `schedule.toggle` fires from a branch inside the PUT update handler when only `enabled` changes, not a discrete route.
 - `admin-approval.ts` (1/5 audited): `POST /rules`, `PUT /rules/{id}`, `DELETE /rules/{id}`, `POST /expire` — no audit. The 1 present call covers review (approve/deny).
-- `admin.ts` (9/12 audited): `POST /me/password` (change password), `POST /semantic/org/import` (bulk import) — no audit. (`POST /users/{id}/revoke-sessions` is the third gap and is tracked separately under F-28.)
+- `admin.ts` (10/12 audited): `POST /me/password` (change password), `POST /semantic/org/import` (bulk import) — no audit. (`POST /users/{id}/revoke-sessions` was the third gap, fixed under F-28 and now emits `user.session_revoke_all`.)
 - `admin-integrations.ts` (18/19 audited): one install/uninstall handler around lines 2353 (POST) or 2458 (DELETE) is missing its `logAdminAction` call. Cross-reference the 19 `method:` declarations against the 18 `logAdminAction({` call sites to find the orphaned write.
 - `admin-invitations.ts` (1/2 audited): `DELETE /users/invitations/{id}` at line 313 runs `UPDATE invitations SET status = 'revoked'` with only `log.info` — no admin-action row. The route ships no `user.remove` or `user.revoke_invitation` audit despite being the primary invitation-revocation path.
 - `platform-sla.ts` (2/3 audited): `POST /evaluate` (`evaluateAlertsRoute`, line 157) triggers alert evaluation across SLA targets without an audit row.
@@ -1558,7 +1558,7 @@ Grep every `metadata: { ... }` literal on the admin-audit call sites. Sampled pa
 | F-25 | P0 | Audit gap | EE custom-role CRUD + assignment (`admin-roles.ts`) | #1780 | open |
 | F-26 | P0 | Meta-audit | Audit retention config + manual purge / hard-delete / export (`admin-audit-retention.ts`) | #1781 | fixed (PR #1799) |
 | F-27 | P1 | Self-audit | EE purge scheduler + retention mutations (`ee/audit/*`) | #1782 | open |
-| F-28 | P1 | Audit gap | Admin session revocation (`admin-sessions.ts`, `admin.ts`) | #1783 | open |
+| F-28 | P1 | Audit gap | Admin session revocation (`admin-sessions.ts`, `admin.ts`) | #1783 | fixed (PR #NNNN) |
 | F-29 | P2 | Partial coverage | `admin-sso.ts`, `admin-connections.ts`, `scheduled-tasks.ts`, `admin-approval.ts`, `admin.ts` stragglers | #1784 | open |
 | F-30 | P1 | Credential-provenance | Email provider + model config (`admin-email-provider.ts`, `admin-model-config.ts`) | #1785 | open |
 | F-31 | P1 | Audit gap | Platform-admin workspace CRUD via `admin-orgs.ts` (post-F-08 drift) | #1786 | open |

--- a/packages/api/src/api/__tests__/admin-sessions.test.ts
+++ b/packages/api/src/api/__tests__/admin-sessions.test.ts
@@ -1,0 +1,607 @@
+/**
+ * Tests for admin session revocation audit emission (F-28 / #1783).
+ *
+ * Covers the three write routes that revoke sessions:
+ *   - DELETE /api/v1/admin/sessions/:id          → user.session_revoke
+ *   - DELETE /api/v1/admin/sessions/user/:uid    → user.session_revoke_all
+ *   - POST   /api/v1/admin/users/:id/revoke      → user.session_revoke_all
+ *
+ * Verifies that every handler emits exactly one `logAdminAction` with the
+ * correct action type + metadata on success, that the single-session path
+ * pre-fetches the row so `targetUserId` is captured, that the bulk paths
+ * record the actual revoked count, that `wasCurrentUser` reflects whether
+ * the acting admin revoked their own session, that session tokens / cookie
+ * bytes never land in audit metadata (asserted by **key absence**, not just
+ * empty-string), and that internal failures emit a `status: "failure"` row.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterAll,
+  mock,
+  type Mock,
+} from "bun:test";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+
+// ---------------------------------------------------------------------------
+// Unified mocks (authUser = workspace admin in org-alpha, mode = managed).
+// ---------------------------------------------------------------------------
+
+const mocks = createApiTestMocks({
+  authUser: {
+    id: "admin-1",
+    mode: "managed",
+    label: "admin@test.com",
+    role: "admin",
+    activeOrganizationId: "org-alpha",
+  },
+  authMode: "managed",
+});
+
+// ---------------------------------------------------------------------------
+// Better Auth admin API mock — the admin.ts `revokeUserSessionsRoute` calls
+// `getAdminApi()` which reads from `getAuthInstance().api`. The default
+// mock in api-test-mocks returns `null`, which would cause the route to
+// 404 before emitting any audit. Replace it here with a real mock surface.
+// ---------------------------------------------------------------------------
+
+const mockRevokeSessions: Mock<(opts: unknown) => Promise<unknown>> = mock(
+  () => Promise.resolve({}),
+);
+
+mock.module("@atlas/api/lib/auth/server", () => ({
+  getAuthInstance: () => ({
+    api: {
+      listUsers: mock(() => Promise.resolve({ users: [], total: 0 })),
+      setRole: mock(() => Promise.resolve({})),
+      banUser: mock(() => Promise.resolve({})),
+      unbanUser: mock(() => Promise.resolve({})),
+      removeUser: mock(() => Promise.resolve({})),
+      revokeSessions: mockRevokeSessions,
+    },
+  }),
+  listAllUsers: mock(() => Promise.resolve([])),
+  setUserRole: mock(async () => {}),
+  setBanStatus: mock(async () => {}),
+  setPasswordChangeRequired: mock(async () => {}),
+  deleteUser: mock(async () => {}),
+}));
+
+// ---------------------------------------------------------------------------
+// Audit mock — capture `logAdminAction` calls but pass through the real
+// ADMIN_ACTIONS catalog so assertions pin to canonical string values.
+// ---------------------------------------------------------------------------
+
+interface AuditEntry {
+  actionType: string;
+  targetType: string;
+  targetId: string;
+  status?: "success" | "failure";
+  ipAddress?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+const mockLogAdminAction: Mock<(entry: AuditEntry) => void> = mock(() => {});
+
+mock.module("@atlas/api/lib/audit", async () => {
+  const actual = await import("@atlas/api/lib/audit/actions");
+  return {
+    logAdminAction: mockLogAdminAction,
+    logAdminActionAwait: mock(async () => {}),
+    ADMIN_ACTIONS: actual.ADMIN_ACTIONS,
+  };
+});
+
+// Import the app AFTER all mocks.
+const { app } = await import("../index");
+
+afterAll(() => mocks.cleanup());
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Sentinel value placed in the request Authorization header so an accidental
+// token leak into audit metadata is easy to spot in both key-scan and
+// full-payload string assertions.
+const SESSION_TOKEN_SENTINEL = "session-token-SHOULD-NOT-APPEAR-IN-AUDIT";
+
+function adminRequest(
+  method: string,
+  path: string,
+  body?: unknown,
+  extraHeaders?: Record<string, string>,
+): Request {
+  const opts: RequestInit = {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${SESSION_TOKEN_SENTINEL}`,
+      Cookie: `better-auth.session_token=${SESSION_TOKEN_SENTINEL}`,
+      ...extraHeaders,
+    },
+  };
+  if (body) opts.body = JSON.stringify(body);
+  return new Request(`http://localhost${path}`, opts);
+}
+
+function lastAuditCall(): AuditEntry {
+  const calls = mockLogAdminAction.mock.calls;
+  if (calls.length === 0) throw new Error("logAdminAction was not called");
+  return calls[calls.length - 1]![0]!;
+}
+
+// Flatten top-level + metadata keys for key-presence assertions.
+function collectKeys(entry: AuditEntry): string[] {
+  const keys = Object.keys(entry);
+  if (entry.metadata && typeof entry.metadata === "object") {
+    keys.push(...Object.keys(entry.metadata));
+  }
+  return keys;
+}
+
+// `mockMembershipFor` matches the `verifyOrgMembership` query in admin.ts —
+// returns a row when the target user is the allowed member, empty otherwise.
+function mockMembershipFor(allowedUserId: string): void {
+  mocks.mockInternalQuery.mockImplementation(
+    async (sql: string, params?: unknown[]) => {
+      if (
+        sql.includes("member") &&
+        sql.includes("userId") &&
+        sql.includes("organizationId") &&
+        !sql.includes("session")
+      ) {
+        return params?.[0] === allowedUserId
+          ? [{ userId: allowedUserId }]
+          : [];
+      }
+      return [];
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Reset state between tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mocks.hasInternalDB = true;
+  mocks.setOrgAdmin("org-alpha");
+  mockLogAdminAction.mockClear();
+  mocks.mockInternalQuery.mockReset();
+  mocks.mockInternalQuery.mockResolvedValue([]);
+  mockRevokeSessions.mockReset();
+  mockRevokeSessions.mockResolvedValue({});
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/v1/admin/sessions/:id
+// ---------------------------------------------------------------------------
+
+describe("admin sessions — DELETE /sessions/:id", () => {
+  it("emits user.session_revoke with targetUserId captured from the pre-fetch", async () => {
+    // The whole point of pre-fetching is that the DELETE strips the row
+    // before the audit hook fires. Arrange the pre-fetch to return a row
+    // owned by a different user than the acting admin so we can observe
+    // both `targetUserId` and `wasCurrentUser: false`.
+    mocks.mockInternalQuery.mockImplementation(
+      async (sql: string, params?: unknown[]) => {
+        if (sql.includes("SELECT") && sql.includes("session") && sql.includes("id = $1")) {
+          expect(params?.[0]).toBe("sess_target_123");
+          expect(params?.[1]).toBe("org-alpha");
+          return [{ id: "sess_target_123", userId: "user_other" }];
+        }
+        if (sql.includes("DELETE FROM session")) {
+          return [{ id: "sess_target_123" }];
+        }
+        return [];
+      },
+    );
+
+    const res = await app.fetch(
+      adminRequest("DELETE", "/api/v1/admin/sessions/sess_target_123"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("user.session_revoke");
+    expect(entry.targetType).toBe("user");
+    expect(entry.targetId).toBe("sess_target_123");
+    expect(entry.status ?? "success").toBe("success");
+    expect(entry.metadata).toEqual({
+      sessionId: "sess_target_123",
+      targetUserId: "user_other",
+      wasCurrentUser: false,
+    });
+  });
+
+  it("sets wasCurrentUser: true when the revoked session belongs to the acting admin", async () => {
+    mocks.mockInternalQuery.mockImplementation(
+      async (sql: string) => {
+        if (sql.includes("SELECT") && sql.includes("session")) {
+          return [{ id: "sess_own_1", userId: "admin-1" }];
+        }
+        if (sql.includes("DELETE FROM session")) {
+          return [{ id: "sess_own_1" }];
+        }
+        return [];
+      },
+    );
+
+    const res = await app.fetch(
+      adminRequest("DELETE", "/api/v1/admin/sessions/sess_own_1"),
+    );
+
+    expect(res.status).toBe(200);
+    const entry = lastAuditCall();
+    expect(entry.metadata).toEqual({
+      sessionId: "sess_own_1",
+      targetUserId: "admin-1",
+      wasCurrentUser: true,
+    });
+  });
+
+  it("emits audit with found: false when the session does not exist", async () => {
+    mocks.mockInternalQuery.mockResolvedValue([]);
+
+    const res = await app.fetch(
+      adminRequest("DELETE", "/api/v1/admin/sessions/sess_missing"),
+    );
+
+    expect(res.status).toBe(404);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("user.session_revoke");
+    expect(entry.targetId).toBe("sess_missing");
+    // `found: false` is a success-status forensic record (the admin tried to
+    // revoke something that wasn't there — we want to see that in the trail).
+    expect(entry.status ?? "success").toBe("success");
+    expect(entry.metadata).toEqual({
+      sessionId: "sess_missing",
+      found: false,
+    });
+    // No targetUserId leaks — we don't know it, so it must be absent.
+    expect(entry.metadata).not.toHaveProperty("targetUserId");
+  });
+
+  it("emits status: failure when the DELETE query throws", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT") && sql.includes("session")) {
+        return [{ id: "sess_target_123", userId: "user_other" }];
+      }
+      if (sql.includes("DELETE FROM session")) {
+        throw new Error("pool timeout");
+      }
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("DELETE", "/api/v1/admin/sessions/sess_target_123"),
+    );
+
+    expect(res.status).toBe(500);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("user.session_revoke");
+    expect(entry.status).toBe("failure");
+    expect(entry.metadata).toMatchObject({
+      sessionId: "sess_target_123",
+      error: "pool timeout",
+    });
+  });
+
+  it("scrubs pg connection-string userinfo from the error message", async () => {
+    // Simulate a pg error that echoes the connection string back — the raw
+    // message must never land in admin_action_log.metadata since it contains
+    // the DB password. Same hygiene as admin-scim.ts errorMessage.
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT") && sql.includes("session")) {
+        throw new Error(
+          "connection refused: postgres://atlas_user:supersecret@db.internal:5432/atlas",
+        );
+      }
+      return [];
+    });
+
+    await app.fetch(
+      adminRequest("DELETE", "/api/v1/admin/sessions/sess_target_123"),
+    );
+
+    const entry = lastAuditCall();
+    expect(entry.status).toBe("failure");
+    const err = String(entry.metadata?.error ?? "");
+    // Scheme survives, userinfo replaced.
+    expect(err).toContain("postgres://***@db.internal");
+    expect(err).not.toContain("atlas_user");
+    expect(err).not.toContain("supersecret");
+  });
+
+  it("does not include session token bytes or token-ish keys in audit metadata", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT") && sql.includes("session")) {
+        return [{ id: "sess_token_probe", userId: "user_other" }];
+      }
+      if (sql.includes("DELETE FROM session")) {
+        return [{ id: "sess_token_probe" }];
+      }
+      return [];
+    });
+
+    await app.fetch(
+      adminRequest("DELETE", "/api/v1/admin/sessions/sess_token_probe"),
+    );
+
+    const entry = lastAuditCall();
+    const keys = collectKeys(entry);
+
+    // Assert key ABSENCE — a `token: ""` or truncated prefix would both slip
+    // past a substring check on `serializeAudit(entry)`.
+    expect(keys).not.toContain("token");
+    expect(keys).not.toContain("sessionToken");
+    expect(keys).not.toContain("session_token");
+    expect(keys).not.toContain("cookie");
+    expect(keys).not.toContain("authorization");
+    expect(keys).not.toContain("bearer");
+    // Belt-and-braces — the sentinel bytes must not be anywhere in the payload.
+    expect(JSON.stringify(entry)).not.toContain(SESSION_TOKEN_SENTINEL);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/v1/admin/sessions/user/:userId
+// ---------------------------------------------------------------------------
+
+describe("admin sessions — DELETE /sessions/user/:userId", () => {
+  it("emits user.session_revoke_all with count matching the actual revoked rows", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("DELETE FROM session")) {
+        // Three revoked sessions — the handler derives count from the
+        // RETURNING clause so the audit row must reflect that exact number.
+        return [{ id: "s1" }, { id: "s2" }, { id: "s3" }];
+      }
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("DELETE", "/api/v1/admin/sessions/user/user_target"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean; count: number };
+    expect(body.count).toBe(3);
+
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("user.session_revoke_all");
+    expect(entry.targetType).toBe("user");
+    expect(entry.targetId).toBe("user_target");
+    expect(entry.metadata).toEqual({
+      targetUserId: "user_target",
+      count: 3,
+    });
+    expect(entry.status ?? "success").toBe("success");
+  });
+
+  it("emits audit with count: 0 when the user has no sessions", async () => {
+    mocks.mockInternalQuery.mockResolvedValue([]);
+
+    const res = await app.fetch(
+      adminRequest("DELETE", "/api/v1/admin/sessions/user/user_no_sessions"),
+    );
+
+    expect(res.status).toBe(404);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("user.session_revoke_all");
+    expect(entry.metadata).toEqual({
+      targetUserId: "user_no_sessions",
+      count: 0,
+    });
+    expect(entry.status ?? "success").toBe("success");
+  });
+
+  it("emits status: failure when the bulk DELETE throws", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("DELETE FROM session")) {
+        throw new Error("relation \"session\" does not exist");
+      }
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("DELETE", "/api/v1/admin/sessions/user/user_target"),
+    );
+
+    expect(res.status).toBe(500);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("user.session_revoke_all");
+    expect(entry.status).toBe("failure");
+    expect(entry.metadata).toMatchObject({
+      targetUserId: "user_target",
+      error: "relation \"session\" does not exist",
+    });
+  });
+
+  it("does not include session token bytes or token-ish keys in audit metadata", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("DELETE FROM session")) {
+        return [{ id: "s1" }];
+      }
+      return [];
+    });
+
+    await app.fetch(
+      adminRequest("DELETE", "/api/v1/admin/sessions/user/user_target"),
+    );
+
+    const entry = lastAuditCall();
+    const keys = collectKeys(entry);
+    expect(keys).not.toContain("token");
+    expect(keys).not.toContain("sessionToken");
+    expect(keys).not.toContain("session_token");
+    expect(keys).not.toContain("cookie");
+    expect(keys).not.toContain("authorization");
+    expect(JSON.stringify(entry)).not.toContain(SESSION_TOKEN_SENTINEL);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/admin/users/:id/revoke (admin.ts revokeUserSessionsRoute)
+// ---------------------------------------------------------------------------
+
+describe("admin users — POST /users/:id/revoke", () => {
+  it("emits user.session_revoke_all with pre-counted session count on success", async () => {
+    // The route doesn't learn the count from better-auth's revokeSessions,
+    // so it pre-queries session COUNT(*). The pre-count hits the internal DB
+    // *after* membership verification and before the revoke.
+    mocks.mockInternalQuery.mockImplementation(
+      async (sql: string, params?: unknown[]) => {
+        if (
+          sql.includes("member") &&
+          sql.includes("userId") &&
+          sql.includes("organizationId")
+        ) {
+          return params?.[0] === "user_target"
+            ? [{ userId: "user_target" }]
+            : [];
+        }
+        if (sql.includes("COUNT(*)") && sql.includes("session")) {
+          return [{ count: "2" }];
+        }
+        return [];
+      },
+    );
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/users/user_target/revoke"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockRevokeSessions).toHaveBeenCalledTimes(1);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("user.session_revoke_all");
+    expect(entry.targetType).toBe("user");
+    expect(entry.targetId).toBe("user_target");
+    expect(entry.status ?? "success").toBe("success");
+    expect(entry.metadata).toEqual({
+      targetUserId: "user_target",
+      count: 2,
+    });
+  });
+
+  it("omits count when the pre-count query fails (never blocks the revoke)", async () => {
+    mocks.mockInternalQuery.mockImplementation(
+      async (sql: string, params?: unknown[]) => {
+        if (
+          sql.includes("member") &&
+          sql.includes("userId") &&
+          sql.includes("organizationId")
+        ) {
+          return params?.[0] === "user_target"
+            ? [{ userId: "user_target" }]
+            : [];
+        }
+        if (sql.includes("COUNT(*)") && sql.includes("session")) {
+          throw new Error("pre-count failed");
+        }
+        return [];
+      },
+    );
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/users/user_target/revoke"),
+    );
+
+    // The revoke itself must still succeed — a count lookup failure cannot
+    // block the forced logout, only degrade the audit row.
+    expect(res.status).toBe(200);
+    expect(mockRevokeSessions).toHaveBeenCalledTimes(1);
+
+    const entry = lastAuditCall();
+    expect(entry.status ?? "success").toBe("success");
+    expect(entry.metadata).toMatchObject({ targetUserId: "user_target" });
+    expect(entry.metadata).not.toHaveProperty("count");
+  });
+
+  it("emits status: failure when adminApi.revokeSessions throws", async () => {
+    mockMembershipFor("user_target");
+    mockRevokeSessions.mockImplementation(() =>
+      Promise.reject(new Error("better-auth revoke failed")),
+    );
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/users/user_target/revoke"),
+    );
+
+    expect(res.status).toBe(500);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("user.session_revoke_all");
+    expect(entry.status).toBe("failure");
+    expect(entry.metadata).toMatchObject({
+      targetUserId: "user_target",
+      error: "better-auth revoke failed",
+    });
+  });
+
+  it("does not include session token bytes or token-ish keys in audit metadata", async () => {
+    mockMembershipFor("user_target");
+
+    await app.fetch(
+      adminRequest("POST", "/api/v1/admin/users/user_target/revoke"),
+    );
+
+    const entry = lastAuditCall();
+    const keys = collectKeys(entry);
+    expect(keys).not.toContain("token");
+    expect(keys).not.toContain("sessionToken");
+    expect(keys).not.toContain("session_token");
+    expect(keys).not.toContain("cookie");
+    expect(keys).not.toContain("authorization");
+    expect(JSON.stringify(entry)).not.toContain(SESSION_TOKEN_SENTINEL);
+  });
+
+  it("threads the client IP into the audit row (x-forwarded-for)", async () => {
+    mockMembershipFor("user_target");
+    mocks.mockInternalQuery.mockImplementation(
+      async (sql: string, params?: unknown[]) => {
+        if (
+          sql.includes("member") &&
+          sql.includes("userId") &&
+          sql.includes("organizationId")
+        ) {
+          return params?.[0] === "user_target"
+            ? [{ userId: "user_target" }]
+            : [];
+        }
+        if (sql.includes("COUNT(*)") && sql.includes("session")) {
+          return [{ count: "1" }];
+        }
+        return [];
+      },
+    );
+
+    await app.fetch(
+      adminRequest(
+        "POST",
+        "/api/v1/admin/users/user_target/revoke",
+        undefined,
+        { "X-Forwarded-For": "203.0.113.9" },
+      ),
+    );
+
+    const entry = lastAuditCall();
+    expect(entry.ipAddress).toBe("203.0.113.9");
+  });
+});

--- a/packages/api/src/api/__tests__/admin-sessions.test.ts
+++ b/packages/api/src/api/__tests__/admin-sessions.test.ts
@@ -1,18 +1,13 @@
 /**
- * Tests for admin session revocation audit emission (F-28 / #1783).
- *
- * Covers the three write routes that revoke sessions:
+ * Admin session revocation audit emission across three write routes:
  *   - DELETE /api/v1/admin/sessions/:id          → user.session_revoke
  *   - DELETE /api/v1/admin/sessions/user/:uid    → user.session_revoke_all
  *   - POST   /api/v1/admin/users/:id/revoke      → user.session_revoke_all
  *
- * Verifies that every handler emits exactly one `logAdminAction` with the
- * correct action type + metadata on success, that the single-session path
- * pre-fetches the row so `targetUserId` is captured, that the bulk paths
- * record the actual revoked count, that `wasCurrentUser` reflects whether
- * the acting admin revoked their own session, that session tokens / cookie
- * bytes never land in audit metadata (asserted by **key absence**, not just
- * empty-string), and that internal failures emit a `status: "failure"` row.
+ * Security-relevant assertion technique: token-leak checks use **key
+ * absence** (plus a recursive walk — any depth), not substring match on
+ * the serialized payload. A `token: ""` or a truncated prefix would slip
+ * past a naïve `.not.toContain` assertion.
  */
 
 import {
@@ -134,13 +129,25 @@ function lastAuditCall(): AuditEntry {
   return calls[calls.length - 1]![0]!;
 }
 
-// Flatten top-level + metadata keys for key-presence assertions.
-function collectKeys(entry: AuditEntry): string[] {
-  const keys = Object.keys(entry);
-  if (entry.metadata && typeof entry.metadata === "object") {
-    keys.push(...Object.keys(entry.metadata));
+// Recursively collect every key name in the audit entry + any nested
+// object under it. Depth-1 walks would miss a regression that nests
+// sensitive data like `metadata.raw.cookie`, so every level is in scope.
+function collectKeys(value: unknown, acc: string[] = []): string[] {
+  if (value === null || typeof value !== "object") return acc;
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    acc.push(k);
+    collectKeys(v, acc);
   }
-  return keys;
+  return acc;
+}
+
+// Assert that no key anywhere in the entry matches a token-ish name. Paired
+// with a sentinel-bytes substring check downstream for belt-and-braces.
+function expectNoTokenKeys(entry: AuditEntry): void {
+  const keys = collectKeys(entry);
+  for (const k of keys) {
+    expect(k).not.toMatch(/token|cookie|authorization|bearer|secret/i);
+  }
 }
 
 // `mockMembershipFor` matches the `verifyOrgMembership` query in admin.ts —
@@ -259,15 +266,46 @@ describe("admin sessions — DELETE /sessions/:id", () => {
     const entry = lastAuditCall();
     expect(entry.actionType).toBe("user.session_revoke");
     expect(entry.targetId).toBe("sess_missing");
-    // `found: false` is a success-status forensic record (the admin tried to
-    // revoke something that wasn't there — we want to see that in the trail).
     expect(entry.status ?? "success").toBe("success");
     expect(entry.metadata).toEqual({
       sessionId: "sess_missing",
       found: false,
     });
-    // No targetUserId leaks — we don't know it, so it must be absent.
-    expect(entry.metadata).not.toHaveProperty("targetUserId");
+  });
+
+  it("carries forward targetUserId when the row vanishes between pre-fetch and DELETE", async () => {
+    // Exercises the race branch at admin-sessions.ts where the pre-fetch
+    // sees a row but DELETE returns empty (concurrent revoke / user logout
+    // in-window). `targetUserId` was already captured, so dropping it would
+    // discard forensic context we paid for. `race: true` distinguishes this
+    // from a plain pre-fetch miss in the audit trail.
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT") && sql.includes("session")) {
+        return [{ id: "sess_racy", userId: "user_victim" }];
+      }
+      if (sql.includes("DELETE FROM session")) {
+        return [];
+      }
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("DELETE", "/api/v1/admin/sessions/sess_racy"),
+    );
+
+    expect(res.status).toBe(404);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("user.session_revoke");
+    expect(entry.targetId).toBe("sess_racy");
+    expect(entry.status ?? "success").toBe("success");
+    expect(entry.metadata).toEqual({
+      sessionId: "sess_racy",
+      targetUserId: "user_victim",
+      found: false,
+      race: true,
+    });
   });
 
   it("emits status: failure when the DELETE query throws", async () => {
@@ -300,7 +338,7 @@ describe("admin sessions — DELETE /sessions/:id", () => {
   it("scrubs pg connection-string userinfo from the error message", async () => {
     // Simulate a pg error that echoes the connection string back — the raw
     // message must never land in admin_action_log.metadata since it contains
-    // the DB password. Same hygiene as admin-scim.ts errorMessage.
+    // the DB password.
     mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
       if (sql.includes("SELECT") && sql.includes("session")) {
         throw new Error(
@@ -339,17 +377,7 @@ describe("admin sessions — DELETE /sessions/:id", () => {
     );
 
     const entry = lastAuditCall();
-    const keys = collectKeys(entry);
-
-    // Assert key ABSENCE — a `token: ""` or truncated prefix would both slip
-    // past a substring check on `serializeAudit(entry)`.
-    expect(keys).not.toContain("token");
-    expect(keys).not.toContain("sessionToken");
-    expect(keys).not.toContain("session_token");
-    expect(keys).not.toContain("cookie");
-    expect(keys).not.toContain("authorization");
-    expect(keys).not.toContain("bearer");
-    // Belt-and-braces — the sentinel bytes must not be anywhere in the payload.
+    expectNoTokenKeys(entry);
     expect(JSON.stringify(entry)).not.toContain(SESSION_TOKEN_SENTINEL);
   });
 });
@@ -443,12 +471,7 @@ describe("admin sessions — DELETE /sessions/user/:userId", () => {
     );
 
     const entry = lastAuditCall();
-    const keys = collectKeys(entry);
-    expect(keys).not.toContain("token");
-    expect(keys).not.toContain("sessionToken");
-    expect(keys).not.toContain("session_token");
-    expect(keys).not.toContain("cookie");
-    expect(keys).not.toContain("authorization");
+    expectNoTokenKeys(entry);
     expect(JSON.stringify(entry)).not.toContain(SESSION_TOKEN_SENTINEL);
   });
 });
@@ -499,7 +522,7 @@ describe("admin users — POST /users/:id/revoke", () => {
     });
   });
 
-  it("omits count when the pre-count query fails (never blocks the revoke)", async () => {
+  it("omits count and stamps countLookupFailed when the pre-count query fails", async () => {
     mocks.mockInternalQuery.mockImplementation(
       async (sql: string, params?: unknown[]) => {
         if (
@@ -529,8 +552,29 @@ describe("admin users — POST /users/:id/revoke", () => {
 
     const entry = lastAuditCall();
     expect(entry.status ?? "success").toBe("success");
-    expect(entry.metadata).toMatchObject({ targetUserId: "user_target" });
-    expect(entry.metadata).not.toHaveProperty("count");
+    // Tight assertion: metadata is EXACTLY {targetUserId, countLookupFailed}.
+    // `toEqual` catches a regression that silently adds `count: 0` or
+    // `count: null`, which `toMatchObject` would let slip.
+    expect(entry.metadata).toEqual({
+      targetUserId: "user_target",
+      countLookupFailed: true,
+    });
+  });
+
+  it("stamps countLookupFailed when the internal DB is unavailable", async () => {
+    mocks.hasInternalDB = false;
+    mockMembershipFor("user_target");
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/users/user_target/revoke"),
+    );
+
+    expect(res.status).toBe(200);
+    const entry = lastAuditCall();
+    expect(entry.metadata).toEqual({
+      targetUserId: "user_target",
+      countLookupFailed: true,
+    });
   });
 
   it("emits status: failure when adminApi.revokeSessions throws", async () => {
@@ -563,12 +607,7 @@ describe("admin users — POST /users/:id/revoke", () => {
     );
 
     const entry = lastAuditCall();
-    const keys = collectKeys(entry);
-    expect(keys).not.toContain("token");
-    expect(keys).not.toContain("sessionToken");
-    expect(keys).not.toContain("session_token");
-    expect(keys).not.toContain("cookie");
-    expect(keys).not.toContain("authorization");
+    expectNoTokenKeys(entry);
     expect(JSON.stringify(entry)).not.toContain(SESSION_TOKEN_SENTINEL);
   });
 

--- a/packages/api/src/api/routes/admin-sessions.ts
+++ b/packages/api/src/api/routes/admin-sessions.ts
@@ -5,17 +5,39 @@
  * Org-scoped: all queries are filtered to members of the caller's active organization.
  */
 
-import { Effect } from "effect";
+import { Cause, Effect, Option } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { AuthContext } from "@atlas/api/lib/effect/services";
 import { internalQuery, queryEffect } from "@atlas/api/lib/db/internal";
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { ErrorSchema, AuthErrorSchema, parsePagination, escapeIlike } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
 
 const log = createLogger("admin-sessions");
+
+// F-28: audit emission helpers. `Effect.tapErrorCause` catches both typed
+// failures (`queryEffect` errors) and defects (rejected promises from pg
+// pool crashes) so no session-revocation attempt escapes without an audit
+// row. `errorMessage` strips URI userinfo and truncates so pg error text
+// that embeds a connection string cannot leak into `admin_action_log.metadata`.
+const ERROR_MESSAGE_MAX = 512;
+function errorMessage(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  const scrubbed = raw.replace(/\b([a-z][a-z0-9+.-]*):\/\/[^\s@/]*@/gi, "$1://***@");
+  return scrubbed.length > ERROR_MESSAGE_MAX
+    ? `${scrubbed.slice(0, ERROR_MESSAGE_MAX - 3)}...`
+    : scrubbed;
+}
+function causeToError(cause: Cause.Cause<unknown>): unknown | undefined {
+  if (Cause.isInterruptedOnly(cause)) return undefined;
+  const failure = Cause.failureOption(cause);
+  if (Option.isSome(failure)) return failure.value;
+  for (const defect of Cause.defects(cause)) return defect;
+  return undefined;
+}
 
 // ---------------------------------------------------------------------------
 // Route definitions
@@ -240,16 +262,45 @@ adminSessions.openapi(getSessionStatsRoute, async (c) => {
 
 // DELETE /:id — revoke a single session (must belong to org member)
 adminSessions.openapi(deleteSessionRoute, async (c) => {
+  const { id: sessionId } = c.req.valid("param");
+  const ipAddress = c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null;
+
   return runEffect(c, Effect.gen(function* () {
     const { orgId, user } = yield* AuthContext;
     const { requestId } = c.get("orgContext");
-    const { id: sessionId } = c.req.valid("param");
 
     if (detectAuthMode() !== "managed") {
       return c.json({ error: "not_available", message: "Session management requires managed auth mode.", requestId }, 404);
     }
 
-    // Only delete if the session belongs to a member of the active org
+    // Pre-fetch so the audit row records `targetUserId` — once the DELETE
+    // runs the row is gone and the audit entry would be left with only the
+    // opaque `sessionId`. Scoped to the active org with the same filter as
+    // the DELETE to prevent probing sessions outside the caller's workspace.
+    const prior = yield* queryEffect<{ id: string; userId: string }>(
+      `SELECT s.id, s."userId" AS "userId"
+       FROM session s
+       JOIN member m ON m."userId" = s."userId"
+       WHERE s.id = $1 AND m."organizationId" = $2`,
+      [sessionId, orgId],
+    );
+
+    if (prior.length === 0) {
+      // Attempt still recorded — an admin targeting a missing / out-of-org
+      // session is a forensic signal, not a failure state.
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.user.sessionRevoke,
+        targetType: "user",
+        targetId: sessionId,
+        ipAddress,
+        metadata: { sessionId, found: false },
+      });
+      return c.json({ error: "not_found", message: "Session not found.", requestId }, 404);
+    }
+
+    const targetUserId = prior[0]!.userId;
+    const wasCurrentUser = targetUserId === user?.id;
+
     const deleted = yield* queryEffect<{ id: string }>(
       `DELETE FROM session s
        USING member m
@@ -260,20 +311,53 @@ adminSessions.openapi(deleteSessionRoute, async (c) => {
       [sessionId, orgId],
     );
     if (deleted.length === 0) {
+      // Race: the row vanished between the pre-fetch and the DELETE. Record
+      // the attempt with `found: false`, same shape as the pre-fetch miss.
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.user.sessionRevoke,
+        targetType: "user",
+        targetId: sessionId,
+        ipAddress,
+        metadata: { sessionId, found: false },
+      });
       return c.json({ error: "not_found", message: "Session not found.", requestId }, 404);
     }
 
     log.info({ requestId, sessionId, actorId: user?.id }, "Session revoked");
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.user.sessionRevoke,
+      targetType: "user",
+      targetId: sessionId,
+      ipAddress,
+      metadata: { sessionId, targetUserId, wasCurrentUser },
+    });
     return c.json({ success: true }, 200);
-  }), { label: "revoke session" });
+  }).pipe(
+    Effect.tapErrorCause((cause) => {
+      const err = causeToError(cause);
+      if (err === undefined) return Effect.void;
+      return Effect.sync(() =>
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.user.sessionRevoke,
+          targetType: "user",
+          targetId: sessionId,
+          status: "failure",
+          ipAddress,
+          metadata: { sessionId, error: errorMessage(err) },
+        }),
+      );
+    }),
+  ), { label: "revoke session" });
 });
 
 // DELETE /user/:userId — revoke all sessions for a user (must be org member)
 adminSessions.openapi(deleteUserSessionsRoute, async (c) => {
+  const { userId } = c.req.valid("param");
+  const ipAddress = c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null;
+
   return runEffect(c, Effect.gen(function* () {
     const { orgId, user } = yield* AuthContext;
     const { requestId } = c.get("orgContext");
-    const { userId } = c.req.valid("param");
 
     if (detectAuthMode() !== "managed") {
       return c.json({ error: "not_available", message: "Session management requires managed auth mode.", requestId }, 404);
@@ -290,13 +374,44 @@ adminSessions.openapi(deleteUserSessionsRoute, async (c) => {
       [userId, orgId],
     );
     if (deleted.length === 0) {
+      // Still record the attempt — a 0-count bulk revoke is a forensic
+      // signal (admin probed for sessions that weren't there).
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.user.sessionRevokeAll,
+        targetType: "user",
+        targetId: userId,
+        ipAddress,
+        metadata: { targetUserId: userId, count: 0 },
+      });
       return c.json({ error: "not_found", message: "No sessions found for this user.", requestId }, 404);
     }
 
     const count = deleted.length;
     log.info({ requestId, targetUserId: userId, count, actorId: user?.id }, "All user sessions revoked");
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.user.sessionRevokeAll,
+      targetType: "user",
+      targetId: userId,
+      ipAddress,
+      metadata: { targetUserId: userId, count },
+    });
     return c.json({ success: true, count }, 200);
-  }), { label: "revoke user sessions" });
+  }).pipe(
+    Effect.tapErrorCause((cause) => {
+      const err = causeToError(cause);
+      if (err === undefined) return Effect.void;
+      return Effect.sync(() =>
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.user.sessionRevokeAll,
+          targetType: "user",
+          targetId: userId,
+          status: "failure",
+          ipAddress,
+          metadata: { targetUserId: userId, error: errorMessage(err) },
+        }),
+      );
+    }),
+  ), { label: "revoke user sessions" });
 });
 
 export { adminSessions };

--- a/packages/api/src/api/routes/admin-sessions.ts
+++ b/packages/api/src/api/routes/admin-sessions.ts
@@ -5,7 +5,7 @@
  * Org-scoped: all queries are filtered to members of the caller's active organization.
  */
 
-import { Cause, Effect, Option } from "effect";
+import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
 import { runEffect } from "@atlas/api/lib/effect/hono";
@@ -13,31 +13,16 @@ import { AuthContext } from "@atlas/api/lib/effect/services";
 import { internalQuery, queryEffect } from "@atlas/api/lib/db/internal";
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
+import { errorMessage, causeToError } from "@atlas/api/lib/audit/error-scrub";
 import { ErrorSchema, AuthErrorSchema, parsePagination, escapeIlike } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
 
 const log = createLogger("admin-sessions");
 
-// F-28: audit emission helpers. `Effect.tapErrorCause` catches both typed
-// failures (`queryEffect` errors) and defects (rejected promises from pg
-// pool crashes) so no session-revocation attempt escapes without an audit
-// row. `errorMessage` strips URI userinfo and truncates so pg error text
-// that embeds a connection string cannot leak into `admin_action_log.metadata`.
-const ERROR_MESSAGE_MAX = 512;
-function errorMessage(err: unknown): string {
-  const raw = err instanceof Error ? err.message : String(err);
-  const scrubbed = raw.replace(/\b([a-z][a-z0-9+.-]*):\/\/[^\s@/]*@/gi, "$1://***@");
-  return scrubbed.length > ERROR_MESSAGE_MAX
-    ? `${scrubbed.slice(0, ERROR_MESSAGE_MAX - 3)}...`
-    : scrubbed;
-}
-function causeToError(cause: Cause.Cause<unknown>): unknown | undefined {
-  if (Cause.isInterruptedOnly(cause)) return undefined;
-  const failure = Cause.failureOption(cause);
-  if (Option.isSome(failure)) return failure.value;
-  for (const defect of Cause.defects(cause)) return defect;
-  return undefined;
-}
+// Identifier upper bound for route params — better-auth session / user ids
+// are ~32-64 chars in practice. Capping prevents adversarial inputs from
+// bloating `admin_action_log.metadata` on the `found: false` emission paths.
+const ID_MAX_LEN = 255;
 
 // ---------------------------------------------------------------------------
 // Route definitions
@@ -95,7 +80,7 @@ const deleteSessionRoute = createRoute({
   description: "Revokes a single session by ID. Must belong to a member of the active organization.",
   request: {
     params: z.object({
-      id: z.string().min(1).openapi({ param: { name: "id", in: "path" }, example: "sess_abc123" }),
+      id: z.string().min(1).max(ID_MAX_LEN).openapi({ param: { name: "id", in: "path" }, example: "sess_abc123" }),
     }),
   },
   responses: {
@@ -119,7 +104,7 @@ const deleteUserSessionsRoute = createRoute({
   description: "Revokes all sessions for a specific user. User must be a member of the active organization.",
   request: {
     params: z.object({
-      userId: z.string().min(1).openapi({ param: { name: "userId", in: "path" }, example: "user_abc123" }),
+      userId: z.string().min(1).max(ID_MAX_LEN).openapi({ param: { name: "userId", in: "path" }, example: "user_abc123" }),
     }),
   },
   responses: {
@@ -311,14 +296,15 @@ adminSessions.openapi(deleteSessionRoute, async (c) => {
       [sessionId, orgId],
     );
     if (deleted.length === 0) {
-      // Race: the row vanished between the pre-fetch and the DELETE. Record
-      // the attempt with `found: false`, same shape as the pre-fetch miss.
+      // Race: the row vanished between the pre-fetch and the DELETE. Carry
+      // forward the `targetUserId` we already captured — dropping it would
+      // discard forensic context we paid for.
       logAdminAction({
         actionType: ADMIN_ACTIONS.user.sessionRevoke,
         targetType: "user",
         targetId: sessionId,
         ipAddress,
-        metadata: { sessionId, found: false },
+        metadata: { sessionId, targetUserId, found: false, race: true },
       });
       return c.json({ error: "not_found", message: "Session not found.", requestId }, 404);
     }
@@ -333,6 +319,12 @@ adminSessions.openapi(deleteSessionRoute, async (c) => {
     });
     return c.json({ success: true }, 200);
   }).pipe(
+    // Pure-interrupt causes (fiber cancelled — client disconnect, shutdown)
+    // leave the outcome indeterminate and are intentionally not audited, in
+    // line with F-23's SCIM precedent. All other failures (typed + defect)
+    // emit a status:"failure" row. `Effect.ignoreLogged` guards against a
+    // future regression that makes logAdminAction throw — the original 500
+    // still flows through to the caller instead of being masked.
     Effect.tapErrorCause((cause) => {
       const err = causeToError(cause);
       if (err === undefined) return Effect.void;
@@ -345,7 +337,7 @@ adminSessions.openapi(deleteSessionRoute, async (c) => {
           ipAddress,
           metadata: { sessionId, error: errorMessage(err) },
         }),
-      );
+      ).pipe(Effect.ignoreLogged);
     }),
   ), { label: "revoke session" });
 });
@@ -397,6 +389,7 @@ adminSessions.openapi(deleteUserSessionsRoute, async (c) => {
     });
     return c.json({ success: true, count }, 200);
   }).pipe(
+    // Same interrupt / ignoreLogged rationale as the single-session path.
     Effect.tapErrorCause((cause) => {
       const err = causeToError(cause);
       if (err === undefined) return Effect.void;
@@ -409,7 +402,7 @@ adminSessions.openapi(deleteUserSessionsRoute, async (c) => {
           ipAddress,
           metadata: { targetUserId: userId, error: errorMessage(err) },
         }),
-      );
+      ).pipe(Effect.ignoreLogged);
     }),
   ), { label: "revoke user sessions" });
 });

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -18,6 +18,7 @@ import { withRequestId, resolveMode, parseModeFromCookie } from "./middleware";
 import type { AuthResult } from "@atlas/api/lib/auth/types";
 import { authenticateRequest } from "@atlas/api/lib/auth/middleware";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { connections } from "@atlas/api/lib/db/connection";
 import { hasInternalDB, internalQuery, getWorkspaceRegion } from "@atlas/api/lib/db/internal";
 import { plugins } from "@atlas/api/lib/plugins/registry";
@@ -2169,42 +2170,79 @@ admin.openapi(revokeUserSessionsRoute, async (c) => runHandler(c, "revoke sessio
   }
 
   // Pre-count live sessions so the audit row carries `count` — better-auth's
-  // `revokeSessions` doesn't return how many it invalidated, but the read
-  // immediately before the call is a faithful approximation (the only race
-  // window is concurrent writes from the target user, which is the interval
-  // we're closing). If the internal DB is absent, the count is unknown.
+  // `revokeSessions` doesn't return how many it invalidated. Best-effort:
+  // concurrent logins, a parallel admin, or TTL expiry can shift the true
+  // number in the window between this read and the revoke. If the internal
+  // DB is absent or the read fails, `count` stays null and
+  // `countLookupFailed: true` is stamped into the audit row so a reviewer
+  // can distinguish "zero sessions" from "pre-count errored".
   let count: number | null = null;
+  let countLookupFailed = false;
   if (hasInternalDB()) {
     try {
       const rows = await internalQuery<{ count: string }>(
         `SELECT COUNT(*) AS count FROM session WHERE "userId" = $1`,
         [userId],
       );
-      count = parseInt(String(rows[0]?.count ?? "0"), 10);
+      const parsed = parseInt(String(rows[0]?.count ?? "0"), 10);
+      count = Number.isFinite(parsed) ? parsed : null;
+      if (count === null) countLookupFailed = true;
     } catch (err: unknown) {
+      countLookupFailed = true;
       log.warn(
         { err: err instanceof Error ? err.message : String(err), requestId, userId },
-        "Session pre-count failed; audit row will lack count",
+        "Session pre-count failed; audit row will record countLookupFailed",
       );
+    }
+  } else {
+    countLookupFailed = true;
+  }
+
+  // Cap the upstream revoke so better-auth hanging (pool exhaustion, network
+  // stall) can't leave the route waiting until the proxy times the client
+  // out with zero audit trail. 30s is generous enough for a bulk revoke
+  // against a managed auth provider and short enough that a genuine hang
+  // becomes a `status: "failure"` audit row within one human-observable window.
+  const REVOKE_TIMEOUT_MS = 30_000;
+  async function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        p,
+        new Promise<T>((_, reject) => {
+          timer = setTimeout(
+            () => reject(new Error(`revokeSessions timed out after ${ms}ms`)),
+            ms,
+          );
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
     }
   }
 
   try {
-    await adminApi.revokeSessions({
-      body: { userId },
-      headers: c.req.raw.headers,
-    });
+    await withTimeout(
+      adminApi.revokeSessions({
+        body: { userId },
+        headers: c.req.raw.headers,
+      }),
+      REVOKE_TIMEOUT_MS,
+    );
     log.info({ requestId, targetUserId: userId, actorId: authResult.user?.id }, "User sessions revoked");
     logAdminAction({
       actionType: ADMIN_ACTIONS.user.sessionRevokeAll,
       targetType: "user",
       targetId: userId,
       ipAddress,
-      metadata: { targetUserId: userId, ...(count !== null && { count }) },
+      metadata: {
+        targetUserId: userId,
+        ...(count !== null && { count }),
+        ...(countLookupFailed && { countLookupFailed: true }),
+      },
     });
     return c.json({ success: true }, 200);
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
     log.error({ err: err instanceof Error ? err : new Error(String(err)), requestId, userId }, "Failed to revoke user sessions");
     logAdminAction({
       actionType: ADMIN_ACTIONS.user.sessionRevokeAll,
@@ -2212,7 +2250,11 @@ admin.openapi(revokeUserSessionsRoute, async (c) => runHandler(c, "revoke sessio
       targetId: userId,
       status: "failure",
       ipAddress,
-      metadata: { targetUserId: userId, error: message },
+      metadata: {
+        targetUserId: userId,
+        error: errorMessage(err),
+        ...(countLookupFailed && { countLookupFailed: true }),
+      },
     });
     return c.json({ error: "internal_error", message: "Failed to revoke sessions.", requestId }, 500);
   }

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -2154,6 +2154,7 @@ admin.openapi(deleteUserRoute, async (c) => {
 admin.openapi(revokeUserSessionsRoute, async (c) => runHandler(c, "revoke sessions", async () => {
 
   const { id: userId } = c.req.valid("param");
+  const ipAddress = c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null;
 
   const { authResult, requestId } = await adminAuthAndContext(c);
 
@@ -2167,12 +2168,54 @@ admin.openapi(revokeUserSessionsRoute, async (c) => runHandler(c, "revoke sessio
     return c.json({ error: "not_found", message: "User not found.", requestId }, 404);
   }
 
-  await adminApi.revokeSessions({
-    body: { userId },
-    headers: c.req.raw.headers,
-  });
-  log.info({ requestId, targetUserId: userId, actorId: authResult.user?.id }, "User sessions revoked");
-  return c.json({ success: true }, 200);
+  // Pre-count live sessions so the audit row carries `count` — better-auth's
+  // `revokeSessions` doesn't return how many it invalidated, but the read
+  // immediately before the call is a faithful approximation (the only race
+  // window is concurrent writes from the target user, which is the interval
+  // we're closing). If the internal DB is absent, the count is unknown.
+  let count: number | null = null;
+  if (hasInternalDB()) {
+    try {
+      const rows = await internalQuery<{ count: string }>(
+        `SELECT COUNT(*) AS count FROM session WHERE "userId" = $1`,
+        [userId],
+      );
+      count = parseInt(String(rows[0]?.count ?? "0"), 10);
+    } catch (err: unknown) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err), requestId, userId },
+        "Session pre-count failed; audit row will lack count",
+      );
+    }
+  }
+
+  try {
+    await adminApi.revokeSessions({
+      body: { userId },
+      headers: c.req.raw.headers,
+    });
+    log.info({ requestId, targetUserId: userId, actorId: authResult.user?.id }, "User sessions revoked");
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.user.sessionRevokeAll,
+      targetType: "user",
+      targetId: userId,
+      ipAddress,
+      metadata: { targetUserId: userId, ...(count !== null && { count }) },
+    });
+    return c.json({ success: true }, 200);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err: err instanceof Error ? err : new Error(String(err)), requestId, userId }, "Failed to revoke user sessions");
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.user.sessionRevokeAll,
+      targetType: "user",
+      targetId: userId,
+      status: "failure",
+      ipAddress,
+      metadata: { targetUserId: userId, error: message },
+    });
+    return c.json({ error: "internal_error", message: "Failed to revoke sessions.", requestId }, 500);
+  }
 }));
 
 // -- Settings ---------------------------------------------------------------

--- a/packages/api/src/lib/audit/actions.ts
+++ b/packages/api/src/lib/audit/actions.ts
@@ -50,6 +50,17 @@ export const ADMIN_ACTIONS = {
     ban: "user.ban",
     unban: "user.unban",
     removeFromWorkspace: "user.remove_from_workspace",
+    /**
+     * Session revocation (F-28). Two write paths exist:
+     *   - DELETE /api/v1/admin/sessions/:id        → single session
+     *   - DELETE /api/v1/admin/sessions/user/:uid  → all sessions for a user
+     *   - POST   /api/v1/admin/users/:id/revoke    → all sessions for a user
+     * The latter two share `session_revoke_all` intentionally so downstream
+     * queries (`action_type = 'user.session_revoke_all'`) see a single event
+     * shape regardless of which admin surface triggered it.
+     */
+    sessionRevoke: "user.session_revoke",
+    sessionRevokeAll: "user.session_revoke_all",
   },
   sso: {
     configure: "sso.configure",

--- a/packages/api/src/lib/audit/actions.ts
+++ b/packages/api/src/lib/audit/actions.ts
@@ -51,13 +51,10 @@ export const ADMIN_ACTIONS = {
     unban: "user.unban",
     removeFromWorkspace: "user.remove_from_workspace",
     /**
-     * Session revocation (F-28). Two write paths exist:
-     *   - DELETE /api/v1/admin/sessions/:id        → single session
-     *   - DELETE /api/v1/admin/sessions/user/:uid  → all sessions for a user
-     *   - POST   /api/v1/admin/users/:id/revoke    → all sessions for a user
-     * The latter two share `session_revoke_all` intentionally so downstream
-     * queries (`action_type = 'user.session_revoke_all'`) see a single event
-     * shape regardless of which admin surface triggered it.
+     * Bulk revocation (`session_revoke_all`) is emitted by two admin
+     * surfaces — the dedicated session route and the users route — so
+     * downstream queries filtering on `action_type` see one event shape
+     * per admin intent, not two.
      */
     sessionRevoke: "user.session_revoke",
     sessionRevokeAll: "user.session_revoke_all",

--- a/packages/api/src/lib/audit/error-scrub.ts
+++ b/packages/api/src/lib/audit/error-scrub.ts
@@ -1,0 +1,39 @@
+/**
+ * Error-message hygiene for audit metadata.
+ *
+ * `admin_action_log.metadata` is JSONB that compliance reviewers read
+ * directly. Two hazards to close:
+ *
+ *   1. pg / better-auth error text sometimes echoes the connection string,
+ *      so the DB password lands in the audit row verbatim. `errorMessage`
+ *      scrubs `scheme://user:pass@host` userinfo.
+ *   2. An oversized error (full stack as `.message`) bloats the JSONB column
+ *      and pushes structured fields off the end of log-aggregation size
+ *      limits. Truncated to 512 chars with an ellipsis suffix.
+ *
+ * `causeToError` walks an Effect `Cause` and returns the first underlying
+ * error — typed failure, defect, or `undefined` for pure-interrupt causes.
+ * Interrupts represent fiber cancellation (client disconnect, request
+ * timeout, shutdown) where the operation's outcome is indeterminate; the
+ * call site decides whether to emit a "status: failure" audit row or skip.
+ */
+
+import { Cause, Option } from "effect";
+
+const ERROR_MESSAGE_MAX = 512;
+
+export function errorMessage(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  const scrubbed = raw.replace(/\b([a-z][a-z0-9+.-]*):\/\/[^\s@/]*@/gi, "$1://***@");
+  return scrubbed.length > ERROR_MESSAGE_MAX
+    ? `${scrubbed.slice(0, ERROR_MESSAGE_MAX - 3)}...`
+    : scrubbed;
+}
+
+export function causeToError(cause: Cause.Cause<unknown>): unknown | undefined {
+  if (Cause.isInterruptedOnly(cause)) return undefined;
+  const failure = Cause.failureOption(cause);
+  if (Option.isSome(failure)) return failure.value;
+  for (const defect of Cause.defects(cause)) return defect;
+  return undefined;
+}

--- a/packages/api/src/lib/audit/index.ts
+++ b/packages/api/src/lib/audit/index.ts
@@ -1,2 +1,3 @@
 export { ADMIN_ACTIONS, type AdminActionType, type AdminTargetType } from "./actions";
 export { logAdminAction, logAdminActionAwait, type AdminActionEntry } from "./admin";
+export { errorMessage, causeToError } from "./error-scrub";

--- a/packages/api/src/lib/auth/__tests__/sessions.test.ts
+++ b/packages/api/src/lib/auth/__tests__/sessions.test.ts
@@ -349,8 +349,6 @@ describe("Admin session routes", () => {
 
   describe("DELETE /api/v1/admin/sessions/:id", () => {
     it("revokes a session", async () => {
-      // F-28 pre-fetch: SELECT captures target user before DELETE, then DELETE
-      // RETURNING confirms the row was removed.
       mockInternalQuery
         .mockImplementationOnce(() =>
           Promise.resolve([{ id: "sess-1", userId: "user-1" }]), // pre-fetch SELECT

--- a/packages/api/src/lib/auth/__tests__/sessions.test.ts
+++ b/packages/api/src/lib/auth/__tests__/sessions.test.ts
@@ -349,9 +349,15 @@ describe("Admin session routes", () => {
 
   describe("DELETE /api/v1/admin/sessions/:id", () => {
     it("revokes a session", async () => {
-      mockInternalQuery.mockImplementationOnce(() =>
-        Promise.resolve([{ id: "sess-1" }]), // DELETE RETURNING
-      );
+      // F-28 pre-fetch: SELECT captures target user before DELETE, then DELETE
+      // RETURNING confirms the row was removed.
+      mockInternalQuery
+        .mockImplementationOnce(() =>
+          Promise.resolve([{ id: "sess-1", userId: "user-1" }]), // pre-fetch SELECT
+        )
+        .mockImplementationOnce(() =>
+          Promise.resolve([{ id: "sess-1" }]), // DELETE RETURNING
+        );
 
       const res = await del("/api/v1/admin/sessions/sess-1");
       expect(res.status).toBe(200);


### PR DESCRIPTION
## Summary

Closes #1783 — phase 4 of the 1.2.3 security sweep (tracking #1718), P1. Workspace admins can revoke the session of another member — including the org owner — with zero audit row today; only a pino `log.info` breadcrumb exists, which SaaS routes to Loki (short retention) and self-hosted often dumps to stdout.

Adds two entries to `ADMIN_ACTIONS.user` and emits `logAdminAction` from the three write paths:

- **`admin-sessions.ts` DELETE /:id** — pre-fetches the session row so the audit row captures `targetUserId` before the DELETE strips it. Sets `wasCurrentUser: true` when the revoked session belongs to the acting admin, `false` otherwise. Emits `{sessionId, found: false}` when the id doesn't exist (still a forensic signal — admin probed a non-existent session).
- **`admin-sessions.ts` DELETE /user/:userId** — emits `{targetUserId, count}` derived from the `DELETE … RETURNING` clause. Records the attempt with `count: 0` on the no-sessions path.
- **`admin.ts` `revokeUserSessionsRoute`** — pre-counts live sessions (better-auth's `revokeSessions` doesn't return count) and emits the same shape as the admin-sessions.ts bulk path. Intentional symmetry: two admin surfaces → one event type for downstream compliance queries.

Failure modes (pool timeout, better-auth throws) emit `status: "failure"` via `Effect.tapErrorCause` on the Effect routes and try/catch on the `runHandler` route. Pg error messages are scrubbed of URI userinfo (`postgres://user:pass@…` → `postgres://***@…`) and truncated so embedded connection strings can't leak into `admin_action_log.metadata`. Session token bytes / cookie bytes / Authorization headers are never passed to `logAdminAction` — only `sessionId` / `targetUserId` / `count` / `wasCurrentUser`.

Phase-4 scoreboard row in `.claude/research/security-audit-1-2-3.md` updated; the `admin.ts` row moves from 9/12 → 10/12 and the F-28 finding summary flips to `fixed (PR #NNNN)` — will push a follow-up commit with the real PR number once this opens.

## Test plan

New test file: `packages/api/src/api/__tests__/admin-sessions.test.ts` (15 tests, all passing).

- [x] DELETE /:id success emits `user.session_revoke` with `{sessionId, targetUserId, wasCurrentUser}` (pre-fetch captures target)
- [x] `wasCurrentUser: true` when the revoked session belongs to the acting admin
- [x] DELETE /:id not-found emits `{sessionId, found: false}` with `status: success`; `targetUserId` is absent (not guessed)
- [x] DELETE /:id failure path emits `status: failure` with scrubbed pg error
- [x] Pg connection-string userinfo is scrubbed (`supersecret` / `atlas_user` gone, `postgres://***@host` remains)
- [x] DELETE /user/:userId success emits `user.session_revoke_all` with `count` matching revoked rows
- [x] DELETE /user/:userId no-sessions emits `count: 0` with `status: success`
- [x] DELETE /user/:userId failure emits `status: failure`
- [x] POST /users/:id/revoke success emits `user.session_revoke_all` with pre-counted `count`
- [x] POST /users/:id/revoke degrades gracefully (omits `count`) when pre-count throws; revoke still succeeds
- [x] POST /users/:id/revoke failure path emits `status: failure`
- [x] POST /users/:id/revoke threads `x-forwarded-for` into `ipAddress`
- [x] Session token / `Authorization: Bearer …` / `Cookie: better-auth.session_token=…` never appear as keys in audit metadata (key-absence assertion, not substring match)
- [x] Session token sentinel never appears anywhere in serialized audit payload
- [x] Regression: existing `packages/api/src/lib/auth/__tests__/sessions.test.ts` DELETE /:id test updated to mock both pre-fetch SELECT + DELETE RETURNING (13/13 pass)

CI gates (all green locally):
- [x] `bun run lint`
- [x] `bun run type`
- [x] `bun run test` (all packages: api 261 files, cli 19, web 84, ee 25, react 9)
- [x] `bun x syncpack lint`
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh`