### PR TITLE
fix(security): 1.2.3 phase 4 — F-22 plugin install/uninstall/config audit emission

### DIFF
--- a/.claude/research/security-audit-1-2-3.md
+++ b/.claude/research/security-audit-1-2-3.md
@@ -1082,11 +1082,11 @@ Totals at the file level; individual uncovered writes are enumerated under the f
 | `admin-invitations.ts` | 2 | 1 | 🟡 | `user.invite` audited; **`DELETE /users/invitations/{id}` revoke is silent** — see F-29 |
 | `admin-ip-allowlist.ts` | 2 | 0 | ❌ | **Per phase-4 scope: CRITICAL** (F-24) |
 | `admin-learned-patterns.ts` | 3 | 3 | ✅ | `pattern.approve` / `pattern.reject` / `pattern.delete` |
-| `admin-marketplace.ts` | 6 | 0 | ❌ | **Per phase-4 scope: CRITICAL — plugin install/uninstall unaudited** (F-22) |
+| `admin-marketplace.ts` | 6 | 6 | ✅ | `plugin.catalog_create` / `catalog_update` / `catalog_delete` + `catalog_cascade_uninstall` / `plugin.install` / `plugin.uninstall` / `plugin.config_update` — F-22 fixed |
 | `admin-migrate.ts` | 1 | 0 | ❌ | Schema migration trigger (F-37) |
 | `admin-model-config.ts` | 3 | 0 | ❌ | **LLM API key storage + deletion unaudited** (F-30) |
 | `admin-orgs.ts` | 4 | 0 | ❌ | Post-F-08 this is platform-admin only — but still unaudited (F-31) |
-| `admin-plugins.ts` | 4 | 0 | ❌ | **Per phase-4 scope: CRITICAL — enable/disable/config unaudited** (F-22) |
+| `admin-plugins.ts` | 4 | 3 | ✅ | `plugin.enable` / `plugin.disable` / `plugin.config_update` audited; read-only health check stays silent — F-22 fixed |
 | `admin-prompts.ts` | 7 | 0 | ❌ | Content governance — collection + prompt CRUD (F-35) |
 | `admin-publish.ts` | 1 | 1 | ✅ | `mode.publish` |
 | `admin-residency.ts` | 4 | 0 | ❌ | **Workspace residency assign is permanent and unaudited** (F-32) |
@@ -1552,7 +1552,7 @@ Grep every `metadata: { ... }` literal on the admin-audit call sites. Sampled pa
 
 | ID | Severity | Type | Surface | Issue | Status |
 |---|---|---|---|---|---|
-| F-22 | P0 | Audit gap | Plugin install/uninstall (`admin-plugins.ts`, `admin-marketplace.ts`) | #1777 | open |
+| F-22 | P0 | Audit gap | Plugin install/uninstall (`admin-plugins.ts`, `admin-marketplace.ts`) | #1777 | fixed (PR pending) |
 | F-23 | P0 | Audit gap | SCIM management (`admin-scim.ts`) | #1778 | open |
 | F-24 | P0 | Audit gap | IP allowlist (`admin-ip-allowlist.ts`) | #1779 | fixed (PR #1797) |
 | F-25 | P0 | Audit gap | EE custom-role CRUD + assignment (`admin-roles.ts`) | #1780 | fixed (PR #1800) |

--- a/.claude/research/security-audit-1-2-3.md
+++ b/.claude/research/security-audit-1-2-3.md
@@ -1552,7 +1552,7 @@ Grep every `metadata: { ... }` literal on the admin-audit call sites. Sampled pa
 
 | ID | Severity | Type | Surface | Issue | Status |
 |---|---|---|---|---|---|
-| F-22 | P0 | Audit gap | Plugin install/uninstall (`admin-plugins.ts`, `admin-marketplace.ts`) | #1777 | fixed (PR pending) |
+| F-22 | P0 | Audit gap | Plugin install/uninstall (`admin-plugins.ts`, `admin-marketplace.ts`) | #1777 | fixed (PR #1802) |
 | F-23 | P0 | Audit gap | SCIM management (`admin-scim.ts`) | #1778 | open |
 | F-24 | P0 | Audit gap | IP allowlist (`admin-ip-allowlist.ts`) | #1779 | fixed (PR #1797) |
 | F-25 | P0 | Audit gap | EE custom-role CRUD + assignment (`admin-roles.ts`) | #1780 | fixed (PR #1800) |

--- a/packages/api/src/api/__tests__/admin-marketplace.test.ts
+++ b/packages/api/src/api/__tests__/admin-marketplace.test.ts
@@ -6,7 +6,35 @@
  * sub-router dependency.
  */
 
-import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
+
+// --- Audit capture ---
+// Intercept every logAdminAction emission so tests can assert audit shape.
+// Mocked at module level so the route module binds to this mock when first
+// imported below.
+
+interface CapturedAuditEntry {
+  actionType: string;
+  targetType: string;
+  targetId: string;
+  status?: "success" | "failure";
+  metadata?: Record<string, unknown>;
+  scope?: "platform" | "workspace";
+  ipAddress?: string | null;
+}
+
+const mockLogAdminAction: Mock<(entry: CapturedAuditEntry) => void> = mock(
+  () => {},
+);
+
+mock.module("@atlas/api/lib/audit", async () => {
+  const actual = await import("@atlas/api/lib/audit/actions");
+  return {
+    logAdminAction: mockLogAdminAction,
+    logAdminActionAwait: mock(async () => {}),
+    ADMIN_ACTIONS: actual.ADMIN_ACTIONS,
+  };
+});
 
 // --- Effect mock ---
 // Mock the Effect bridge so the route file can load and execute without
@@ -28,21 +56,73 @@ const fakeAuthContext = {
   },
 };
 
+// EffectPromise carries a list of error taps (side-effect handlers run before
+// the error propagates into the generator). `.pipe(Effect.tapError(fn))` on
+// the queryEffect return decorates this list so the catch block in runEffect
+// runs the taps before calling `gen.throw()`.
+interface TestEffectPromise {
+  _tag: "EffectPromise";
+  fn: () => Promise<unknown>;
+  errorTaps: Array<(err: unknown) => unknown>;
+}
+
+interface TestPipeable {
+  [Symbol.iterator]: () => Generator<unknown, unknown>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- pipe is variadic across operator types
+  pipe(...ops: Array<(source: TestPipeable) => any>): any;
+}
+
+function makePipeable(effectValue: TestEffectPromise): TestPipeable {
+  const pipeable: TestPipeable = {
+    [Symbol.iterator]: function* (): Generator<unknown, unknown> {
+      return yield effectValue;
+    },
+    pipe(...ops) {
+      let current: TestPipeable = pipeable;
+      for (const op of ops) current = op(current);
+      return current;
+    },
+  };
+  return pipeable;
+}
+
 mock.module("effect", () => {
   const Effect = {
     gen: (genFn: () => Generator) => {
       return { _tag: "EffectGen", genFn };
     },
     promise: (fn: () => Promise<unknown>) => {
-      return {
-        [Symbol.iterator]: function* (): Generator<unknown, unknown> {
-          return yield { _tag: "EffectPromise", fn };
-        },
-      };
+      const effectValue: TestEffectPromise = { _tag: "EffectPromise", fn, errorTaps: [] };
+      return makePipeable(effectValue);
     },
     // Support Effect.runPromise for routes that unwrap Effect-returning EE functions
     runPromise: (value: unknown) => {
       return Promise.resolve(value);
+    },
+    sync: (syncFn: () => unknown) => ({ _tag: "EffectSync", fn: syncFn }),
+    // tapError attaches a handler that runs before the error propagates.
+    // The handler returns another Effect (typically Effect.sync(...)) — if
+    // it's an EffectSync we run its fn inline for the side effect (test-only
+    // shim; real Effect composes them asynchronously).
+    tapError: (handler: (err: unknown) => unknown) => (source: TestPipeable) => {
+      const originalIterator = source[Symbol.iterator].bind(source);
+      const newPipeable: TestPipeable = {
+        [Symbol.iterator]: function* (): Generator<unknown, unknown> {
+          const gen = originalIterator();
+          let next = gen.next();
+          while (!next.done) {
+            const value = next.value;
+            if (value && typeof value === "object" && (value as { _tag?: string })._tag === "EffectPromise") {
+              (value as TestEffectPromise).errorTaps.push(handler);
+            }
+            const piped = yield value;
+            next = gen.next(piped);
+          }
+          return next.value;
+        },
+        pipe: source.pipe.bind(source),
+      };
+      return newPipeable;
     },
   };
   return { Effect };
@@ -60,12 +140,30 @@ mock.module("@atlas/api/lib/effect/hono", () => ({
     const gen = effect.genFn();
     let result = gen.next();
     while (!result.done) {
-      let value = result.value;
-      if (value && typeof value === "object" && "_tag" in value && value._tag === "EffectPromise") {
+      const value = result.value;
+      if (value && typeof value === "object" && (value as { _tag?: string })._tag === "EffectPromise") {
+        const promiseValue = value as TestEffectPromise;
         try {
-          value = await (value as unknown as { fn: () => Promise<unknown> }).fn();
-          result = gen.next(value);
+          const resolved = await promiseValue.fn();
+          result = gen.next(resolved);
         } catch (err) {
+          // Run any error taps attached via .pipe(Effect.tapError(...)) BEFORE
+          // the error enters the generator. Matches real Effect semantics:
+          // tapError is a pre-error observer, the error still propagates.
+          for (const tap of promiseValue.errorTaps) {
+            try {
+              const tapResult = tap(err);
+              if (
+                tapResult &&
+                typeof tapResult === "object" &&
+                (tapResult as { _tag?: string })._tag === "EffectSync"
+              ) {
+                (tapResult as { fn: () => unknown }).fn();
+              }
+            } catch {
+              // tap failures must not swallow the original error
+            }
+          }
           result = gen.throw(err);
         }
       } else {
@@ -153,11 +251,14 @@ mock.module("@atlas/api/lib/db/internal", () => ({
     on: () => {},
   }),
   internalQuery: (sql: string, _params?: unknown[]) => invokeInternalQueryMock(sql),
-  queryEffect: (sql: string) => ({
-    [Symbol.iterator]: function* (): Generator<unknown, unknown> {
-      return yield { _tag: "EffectPromise", fn: () => invokeInternalQueryMock(sql) };
-    },
-  }),
+  queryEffect: (sql: string) => {
+    const effectValue: TestEffectPromise = {
+      _tag: "EffectPromise",
+      fn: () => invokeInternalQueryMock(sql),
+      errorTaps: [],
+    };
+    return makePipeable(effectValue);
+  },
   internalExecute: () => {},
   setWorkspaceRegion: mock(async () => {}),
   insertSemanticAmendment: mock(async () => "mock-amendment-id"),
@@ -347,6 +448,10 @@ describe("Platform Plugin Catalog", () => {
 
   describe("DELETE /catalog/:id", () => {
     it("deletes a catalog entry", async () => {
+      // Route fetches slug + count before the delete so the audit row
+      // captures both even after FK cascade wipes the row.
+      setQueryResult("SELECT slug FROM plugin_catalog WHERE id", [{ slug: "bigquery" }]);
+      setQueryResult("SELECT COUNT(*)::int AS count FROM workspace_plugins", [{ count: 0 }]);
       setQueryResult("DELETE FROM plugin_catalog", [{ id: "cat-1" }]);
 
       const app = buildPlatformApp();
@@ -357,7 +462,8 @@ describe("Platform Plugin Catalog", () => {
     });
 
     it("returns 404 for non-existent entry", async () => {
-      setQueryResult("DELETE FROM plugin_catalog", []);
+      // Pre-lookup returns zero rows — handler short-circuits before the DELETE.
+      setQueryResult("SELECT slug FROM plugin_catalog WHERE id", []);
 
       const app = buildPlatformApp();
       const res = await app.request("/catalog/nonexistent", { method: "DELETE" });
@@ -545,6 +651,399 @@ describe("Workspace Plugin Marketplace", () => {
         body: JSON.stringify({ config: {} }),
       });
       expect(res.status).toBe(404);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F-22: audit emission across catalog + marketplace write routes
+// ---------------------------------------------------------------------------
+
+describe("F-22 audit emission — Platform catalog", () => {
+  beforeEach(() => {
+    mockHasInternalDB = true;
+    mockQueryResults = new Map();
+    mockLogAdminAction.mockClear();
+  });
+
+  describe("POST /catalog — plugin.catalog_create", () => {
+    it("emits exactly one plugin.catalog_create audit on success", async () => {
+      setQueryResult("SELECT id FROM plugin_catalog WHERE slug", []);
+      setQueryResult("INSERT INTO plugin_catalog", [sampleCatalogRow]);
+
+      const app = buildPlatformApp();
+      const res = await app.request("/catalog", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "BigQuery",
+          slug: "bigquery",
+          type: "datasource",
+          npmPackage: "@useatlas/bigquery",
+        }),
+      });
+      expect(res.status).toBe(201);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("plugin.catalog_create");
+      expect(entry.targetType).toBe("plugin");
+      expect(entry.scope).toBe("platform");
+      expect(entry.metadata).toMatchObject({ pluginSlug: "bigquery" });
+      expect(entry.metadata!.pluginId).toBeString();
+    });
+
+    it("emits status=failure when INSERT throws", async () => {
+      setQueryResult("SELECT id FROM plugin_catalog WHERE slug", []);
+      setQueryResult("INSERT INTO plugin_catalog", new Error("db insert failed"));
+
+      const app = buildPlatformApp();
+      const res = await app.request("/catalog", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "X", slug: "x", type: "datasource" }),
+      });
+      expect(res.status).toBe(500);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("plugin.catalog_create");
+      expect(entry.status).toBe("failure");
+      expect(entry.metadata!.pluginSlug).toBe("x");
+      expect(entry.metadata!.error).toContain("db insert failed");
+    });
+
+    it("does not emit audit on duplicate slug (pre-handler rejection)", async () => {
+      setQueryResult("SELECT id FROM plugin_catalog WHERE slug", [{ id: "existing" }]);
+
+      const app = buildPlatformApp();
+      const res = await app.request("/catalog", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "BigQuery", slug: "bigquery", type: "datasource" }),
+      });
+      expect(res.status).toBe(409);
+      expect(mockLogAdminAction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("PUT /catalog/:id — plugin.catalog_update", () => {
+    it("emits exactly one plugin.catalog_update audit with keysChanged", async () => {
+      setQueryResult("UPDATE plugin_catalog", [{ ...sampleCatalogRow, name: "BigQuery v2" }]);
+
+      const app = buildPlatformApp();
+      const res = await app.request("/catalog/cat-1", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "BigQuery v2", enabled: false }),
+      });
+      expect(res.status).toBe(200);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("plugin.catalog_update");
+      expect(entry.targetId).toBe("cat-1");
+      expect(entry.scope).toBe("platform");
+      expect(entry.metadata!.pluginSlug).toBe("bigquery");
+      expect(entry.metadata!.keysChanged).toEqual(["enabled", "name"]);
+    });
+
+    it("emits status=failure when UPDATE throws", async () => {
+      setQueryResult("UPDATE plugin_catalog", new Error("db update failed"));
+
+      const app = buildPlatformApp();
+      const res = await app.request("/catalog/cat-1", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "X" }),
+      });
+      expect(res.status).toBe(500);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("plugin.catalog_update");
+      expect(entry.status).toBe("failure");
+      expect(entry.metadata!.keysChanged).toEqual(["name"]);
+    });
+  });
+
+  describe("DELETE /catalog/:id — plugin.catalog_delete + cascade", () => {
+    it("emits only plugin.catalog_delete when no workspaces have it installed", async () => {
+      setQueryResult("SELECT slug FROM plugin_catalog WHERE id", [{ slug: "bigquery" }]);
+      setQueryResult("SELECT COUNT(*)::int AS count FROM workspace_plugins", [{ count: 0 }]);
+      setQueryResult("DELETE FROM plugin_catalog", [{ id: "cat-1" }]);
+
+      const app = buildPlatformApp();
+      const res = await app.request("/catalog/cat-1", { method: "DELETE" });
+      expect(res.status).toBe(200);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("plugin.catalog_delete");
+      expect(entry.targetId).toBe("cat-1");
+      expect(entry.metadata).toMatchObject({
+        pluginId: "cat-1",
+        pluginSlug: "bigquery",
+        affectedOrgCount: 0,
+      });
+    });
+
+    it("emits catalog_delete + catalog_cascade_uninstall when workspaces are affected", async () => {
+      setQueryResult("SELECT slug FROM plugin_catalog WHERE id", [{ slug: "bigquery" }]);
+      setQueryResult("SELECT COUNT(*)::int AS count FROM workspace_plugins", [{ count: 7 }]);
+      setQueryResult("DELETE FROM plugin_catalog", [{ id: "cat-1" }]);
+
+      const app = buildPlatformApp();
+      const res = await app.request("/catalog/cat-1", { method: "DELETE" });
+      expect(res.status).toBe(200);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(2);
+      const [first, second] = mockLogAdminAction.mock.calls.map((c) => c[0]);
+      expect(first!.actionType).toBe("plugin.catalog_delete");
+      expect(first!.metadata).toMatchObject({ pluginSlug: "bigquery", affectedOrgCount: 7 });
+      expect(second!.actionType).toBe("plugin.catalog_cascade_uninstall");
+      expect(second!.metadata).toMatchObject({
+        pluginSlug: "bigquery",
+        affectedOrgCount: 7,
+      });
+      // Ordering is meaningful — cascade is the follow-up to the delete.
+      expect(first!.targetId).toBe(second!.targetId);
+    });
+
+    it("emits status=failure when DELETE throws and no cascade event fires", async () => {
+      setQueryResult("SELECT slug FROM plugin_catalog WHERE id", [{ slug: "bigquery" }]);
+      setQueryResult("SELECT COUNT(*)::int AS count FROM workspace_plugins", [{ count: 3 }]);
+      setQueryResult("DELETE FROM plugin_catalog", new Error("FK violation"));
+
+      const app = buildPlatformApp();
+      const res = await app.request("/catalog/cat-1", { method: "DELETE" });
+      expect(res.status).toBe(500);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("plugin.catalog_delete");
+      expect(entry.status).toBe("failure");
+      expect(entry.metadata!.pluginSlug).toBe("bigquery");
+      expect(entry.metadata!.affectedOrgCount).toBe(3);
+      expect(entry.metadata!.error).toContain("FK violation");
+    });
+
+    it("does not emit audit when plugin not found (pre-handler rejection)", async () => {
+      setQueryResult("SELECT slug FROM plugin_catalog WHERE id", []);
+
+      const app = buildPlatformApp();
+      const res = await app.request("/catalog/nonexistent", { method: "DELETE" });
+      expect(res.status).toBe(404);
+      expect(mockLogAdminAction).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("F-22 audit emission — Workspace marketplace", () => {
+  beforeEach(() => {
+    mockHasInternalDB = true;
+    mockQueryResults = new Map();
+    mockLogAdminAction.mockClear();
+  });
+
+  describe("POST /marketplace/install — plugin.install", () => {
+    it("emits exactly one plugin.install audit with orgId scope", async () => {
+      setQueryResult("SELECT * FROM plugin_catalog WHERE id", [sampleCatalogRow]);
+      setQueryResult("SELECT plan_tier FROM organization", [{ plan_tier: "starter" }]);
+      setQueryResult("SELECT id FROM workspace_plugins WHERE workspace_id", []);
+      setQueryResult("INSERT INTO workspace_plugins", [{
+        id: "inst-1",
+        workspace_id: "org-1",
+        catalog_id: "cat-1",
+        config: {},
+        enabled: true,
+        installed_at: now,
+        installed_by: "admin-1",
+        name: "BigQuery",
+        slug: "bigquery",
+        type: "datasource",
+        description: null,
+      }]);
+
+      const app = buildWorkspaceApp();
+      const res = await app.request("/marketplace/install", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ catalogId: "cat-1" }),
+      });
+      expect(res.status).toBe(201);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("plugin.install");
+      expect(entry.targetType).toBe("plugin");
+      expect(entry.scope).toBe("workspace");
+      expect(entry.metadata).toMatchObject({
+        pluginId: "cat-1",
+        pluginSlug: "bigquery",
+        orgId: "org-1",
+      });
+    });
+
+    it("emits status=failure when INSERT throws", async () => {
+      setQueryResult("SELECT * FROM plugin_catalog WHERE id", [sampleCatalogRow]);
+      setQueryResult("SELECT plan_tier FROM organization", [{ plan_tier: "starter" }]);
+      setQueryResult("SELECT id FROM workspace_plugins WHERE workspace_id", []);
+      setQueryResult("INSERT INTO workspace_plugins", new Error("install failed"));
+
+      const app = buildWorkspaceApp();
+      const res = await app.request("/marketplace/install", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ catalogId: "cat-1" }),
+      });
+      expect(res.status).toBe(500);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("plugin.install");
+      expect(entry.status).toBe("failure");
+      expect(entry.metadata!.pluginSlug).toBe("bigquery");
+      expect(entry.metadata!.orgId).toBe("org-1");
+      expect(entry.metadata!.error).toContain("install failed");
+    });
+
+    it("does not emit audit on plan-ineligible (pre-handler rejection)", async () => {
+      setQueryResult("SELECT * FROM plugin_catalog WHERE id", [
+        { ...sampleCatalogRow, min_plan: "business" },
+      ]);
+      setQueryResult("SELECT plan_tier FROM organization", [{ plan_tier: "starter" }]);
+      setQueryResult("SELECT id FROM workspace_plugins WHERE workspace_id", []);
+
+      const app = buildWorkspaceApp();
+      const res = await app.request("/marketplace/install", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ catalogId: "cat-1" }),
+      });
+      expect(res.status).toBe(400);
+      expect(mockLogAdminAction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("DELETE /marketplace/:id — plugin.uninstall", () => {
+    it("emits exactly one plugin.uninstall audit on success", async () => {
+      setQueryResult("DELETE FROM workspace_plugins WHERE id", [
+        { id: "inst-1", catalog_id: "cat-1", slug: "bigquery" },
+      ]);
+
+      const app = buildWorkspaceApp();
+      const res = await app.request("/marketplace/inst-1", { method: "DELETE" });
+      expect(res.status).toBe(200);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("plugin.uninstall");
+      expect(entry.targetType).toBe("plugin");
+      expect(entry.targetId).toBe("inst-1");
+      expect(entry.scope).toBe("workspace");
+      expect(entry.metadata).toMatchObject({
+        pluginId: "cat-1",
+        pluginSlug: "bigquery",
+        orgId: "org-1",
+      });
+    });
+
+    it("emits status=failure when DELETE throws", async () => {
+      setQueryResult("DELETE FROM workspace_plugins WHERE id", new Error("uninstall failed"));
+
+      const app = buildWorkspaceApp();
+      const res = await app.request("/marketplace/inst-1", { method: "DELETE" });
+      expect(res.status).toBe(500);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("plugin.uninstall");
+      expect(entry.status).toBe("failure");
+      expect(entry.metadata!.error).toContain("uninstall failed");
+    });
+  });
+
+  describe("PUT /marketplace/:id/config — plugin.config_update", () => {
+    it("emits exactly one plugin.config_update audit with keysChanged only", async () => {
+      setQueryResult("UPDATE workspace_plugins", [{
+        id: "inst-1",
+        workspace_id: "org-1",
+        catalog_id: "cat-1",
+        config: {},
+        enabled: true,
+        installed_at: now,
+        installed_by: "admin-1",
+        name: "BigQuery",
+        slug: "bigquery",
+        type: "datasource",
+        description: null,
+      }]);
+
+      const app = buildWorkspaceApp();
+      const res = await app.request("/marketplace/inst-1/config", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          config: {
+            serviceAccountKey: "SECRET_JSON_BLOB",
+            projectId: "my-project",
+            location: "us-central1",
+          },
+        }),
+      });
+      expect(res.status).toBe(200);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("plugin.config_update");
+      expect(entry.targetId).toBe("inst-1");
+      expect(entry.scope).toBe("workspace");
+      expect(entry.metadata).toMatchObject({
+        pluginId: "cat-1",
+        pluginSlug: "bigquery",
+        orgId: "org-1",
+      });
+      expect(entry.metadata!.keysChanged).toEqual(["location", "projectId", "serviceAccountKey"]);
+    });
+
+    it("never includes config values in audit metadata", async () => {
+      setQueryResult("UPDATE workspace_plugins", [{
+        id: "inst-1",
+        workspace_id: "org-1",
+        catalog_id: "cat-1",
+        config: {},
+        enabled: true,
+        installed_at: now,
+        installed_by: "admin-1",
+        name: "Snowflake",
+        slug: "snowflake",
+        type: "datasource",
+        description: null,
+      }]);
+
+      await buildWorkspaceApp().request("/marketplace/inst-1/config", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          config: {
+            password: "SUPER_SECRET_SNOWFLAKE_PW",
+            account: "myacct",
+          },
+        }),
+      });
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      const serialized = JSON.stringify(entry);
+      expect(serialized).not.toContain("SUPER_SECRET_SNOWFLAKE_PW");
+      expect(entry.metadata).not.toHaveProperty("password");
+      expect(entry.metadata).not.toHaveProperty("config");
+      expect(entry.metadata).not.toHaveProperty("values");
+    });
+
+    it("emits status=failure when UPDATE throws", async () => {
+      setQueryResult("UPDATE workspace_plugins", new Error("config update failed"));
+
+      const app = buildWorkspaceApp();
+      const res = await app.request("/marketplace/inst-1/config", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ config: { key: "val" } }),
+      });
+      expect(res.status).toBe(500);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("plugin.config_update");
+      expect(entry.status).toBe("failure");
+      expect(entry.metadata!.keysChanged).toEqual(["key"]);
+      expect(entry.metadata!.error).toContain("config update failed");
     });
   });
 });

--- a/packages/api/src/api/__tests__/admin-marketplace.test.ts
+++ b/packages/api/src/api/__tests__/admin-marketplace.test.ts
@@ -59,7 +59,11 @@ const fakeAuthContext = {
 // EffectPromise carries a list of error taps (side-effect handlers run before
 // the error propagates into the generator). `.pipe(Effect.tapError(fn))` on
 // the queryEffect return decorates this list so the catch block in runEffect
-// runs the taps before calling `gen.throw()`.
+// runs the taps before calling `gen.throw()`. Any operator beyond tapError
+// (map, catchAll, flatMap, zip, race) is not implemented — if a route starts
+// using one, extend the shim. For failure-path branching, routes use plain
+// try/catch around `yield* queryEffect(...)` which works under both real
+// Effect and this shim.
 interface TestEffectPromise {
   _tag: "EffectPromise";
   fn: () => Promise<unknown>;
@@ -148,8 +152,10 @@ mock.module("@atlas/api/lib/effect/hono", () => ({
           result = gen.next(resolved);
         } catch (err) {
           // Run any error taps attached via .pipe(Effect.tapError(...)) BEFORE
-          // the error enters the generator. Matches real Effect semantics:
-          // tapError is a pre-error observer, the error still propagates.
+          // the error enters the generator. Matches real Effect behavior
+          // observationally: tap runs, then error propagates. (Real Effect
+          // composes these in the error channel asynchronously; the shim
+          // inlines them — the end-state is the same for our assertions.)
           for (const tap of promiseValue.errorTaps) {
             try {
               const tapResult = tap(err);
@@ -656,10 +662,10 @@ describe("Workspace Plugin Marketplace", () => {
 });
 
 // ---------------------------------------------------------------------------
-// F-22: audit emission across catalog + marketplace write routes
+// Audit emission across catalog + marketplace write routes
 // ---------------------------------------------------------------------------
 
-describe("F-22 audit emission — Platform catalog", () => {
+describe("audit emission — Platform catalog", () => {
   beforeEach(() => {
     mockHasInternalDB = true;
     mockQueryResults = new Map();
@@ -745,7 +751,10 @@ describe("F-22 audit emission — Platform catalog", () => {
       expect(entry.metadata!.keysChanged).toEqual(["enabled", "name"]);
     });
 
-    it("emits status=failure when UPDATE throws", async () => {
+    it("emits status=failure when UPDATE throws — carries pluginSlug from pre-lookup", async () => {
+      // Pre-lookup succeeds, UPDATE fails. Failure audit includes the slug
+      // even though the UPDATE never returned a row.
+      setQueryResult("SELECT slug FROM plugin_catalog WHERE id", [{ slug: "bigquery" }]);
       setQueryResult("UPDATE plugin_catalog", new Error("db update failed"));
 
       const app = buildPlatformApp();
@@ -759,7 +768,31 @@ describe("F-22 audit emission — Platform catalog", () => {
       const entry = mockLogAdminAction.mock.calls[0]![0];
       expect(entry.actionType).toBe("plugin.catalog_update");
       expect(entry.status).toBe("failure");
+      expect(entry.metadata!.pluginSlug).toBe("bigquery");
       expect(entry.metadata!.keysChanged).toEqual(["name"]);
+    });
+
+    it("emits failure audit with priorLookupFailed when pre-lookup throws", async () => {
+      // Pre-lookup throws → degrade to priorLookupFailed sentinel and let
+      // the UPDATE throw its own failure (the pre-lookup isn't allowed to
+      // replace the UPDATE error channel). This keeps the audit trail honest
+      // even under pool-exhaustion attacks.
+      setQueryResult("SELECT slug FROM plugin_catalog WHERE id", new Error("pool exhausted"));
+      setQueryResult("UPDATE plugin_catalog", new Error("subsequent UPDATE failed"));
+
+      const app = buildPlatformApp();
+      const res = await app.request("/catalog/cat-1", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "X" }),
+      });
+      expect(res.status).toBe(500);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("plugin.catalog_update");
+      expect(entry.status).toBe("failure");
+      expect(entry.metadata!.priorLookupFailed).toBe(true);
+      expect(entry.metadata).not.toHaveProperty("pluginSlug");
     });
   });
 
@@ -829,10 +862,28 @@ describe("F-22 audit emission — Platform catalog", () => {
       expect(res.status).toBe(404);
       expect(mockLogAdminAction).not.toHaveBeenCalled();
     });
+
+    it("emits failure audit with priorLookupFailed when pre-lookup throws", async () => {
+      // The critical silent-audit-miss path: pre-delete SELECT throws, the
+      // handler must still emit a failure audit so a compromised admin
+      // can't flood transient errors to hide attempted deletes.
+      setQueryResult("SELECT slug FROM plugin_catalog WHERE id", new Error("pool exhausted"));
+      setQueryResult("DELETE FROM plugin_catalog", new Error("subsequent DELETE failed"));
+
+      const app = buildPlatformApp();
+      const res = await app.request("/catalog/cat-1", { method: "DELETE" });
+      expect(res.status).toBe(500);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("plugin.catalog_delete");
+      expect(entry.status).toBe("failure");
+      expect(entry.metadata!.priorLookupFailed).toBe(true);
+      expect(entry.metadata).not.toHaveProperty("pluginSlug");
+    });
   });
 });
 
-describe("F-22 audit emission — Workspace marketplace", () => {
+describe("audit emission — Workspace marketplace", () => {
   beforeEach(() => {
     mockHasInternalDB = true;
     mockQueryResults = new Map();
@@ -915,6 +966,59 @@ describe("F-22 audit emission — Workspace marketplace", () => {
       expect(res.status).toBe(400);
       expect(mockLogAdminAction).not.toHaveBeenCalled();
     });
+
+    it("does not emit audit when catalog entry not found (404)", async () => {
+      // Prevents log flooding from attackers brute-forcing catalogId to probe
+      // which entries exist in this deployment.
+      setQueryResult("SELECT * FROM plugin_catalog WHERE id", []);
+
+      const app = buildWorkspaceApp();
+      const res = await app.request("/marketplace/install", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ catalogId: "missing-cat" }),
+      });
+      expect(res.status).toBe(404);
+      expect(mockLogAdminAction).not.toHaveBeenCalled();
+    });
+
+    it("does not emit audit when plugin already installed (409)", async () => {
+      // Symmetric with the catalog-create duplicate-slug rejection — a
+      // workspace-level enumeration probe should not flood the audit trail.
+      setQueryResult("SELECT * FROM plugin_catalog WHERE id", [sampleCatalogRow]);
+      setQueryResult("SELECT plan_tier FROM organization", [{ plan_tier: "starter" }]);
+      setQueryResult("SELECT id FROM workspace_plugins WHERE workspace_id", [{ id: "inst-existing" }]);
+
+      const app = buildWorkspaceApp();
+      const res = await app.request("/marketplace/install", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ catalogId: "cat-1" }),
+      });
+      expect(res.status).toBe(409);
+      expect(mockLogAdminAction).not.toHaveBeenCalled();
+    });
+
+    it("emits failure audit when pre-lookup SELECT throws (F-22 pattern)", async () => {
+      // Pre-lookup failure must not silently 500 — without the failure audit
+      // an attacker could flood transient errors to probe catalog IDs.
+      setQueryResult("SELECT * FROM plugin_catalog WHERE id", new Error("pool exhausted"));
+
+      const app = buildWorkspaceApp();
+      const res = await app.request("/marketplace/install", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ catalogId: "cat-1" }),
+      });
+      expect(res.status).toBe(500);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("plugin.install");
+      expect(entry.status).toBe("failure");
+      expect(entry.metadata!.priorLookupFailed).toBe(true);
+      expect(entry.metadata!.orgId).toBe("org-1");
+      expect(entry.metadata!.error).toContain("pool exhausted");
+    });
   });
 
   describe("DELETE /marketplace/:id — plugin.uninstall", () => {
@@ -950,6 +1054,36 @@ describe("F-22 audit emission — Workspace marketplace", () => {
       expect(entry.actionType).toBe("plugin.uninstall");
       expect(entry.status).toBe("failure");
       expect(entry.metadata!.error).toContain("uninstall failed");
+    });
+
+    it("does not emit audit when installation not found (404)", async () => {
+      // 404 short-circuits after the DELETE returns zero rows — no state
+      // changed, no audit.
+      setQueryResult("DELETE FROM workspace_plugins WHERE id", []);
+
+      const app = buildWorkspaceApp();
+      const res = await app.request("/marketplace/missing-inst", { method: "DELETE" });
+      expect(res.status).toBe(404);
+      expect(mockLogAdminAction).not.toHaveBeenCalled();
+    });
+
+    it("emits audit without pluginSlug when catalog row raced away", async () => {
+      // catalog_delete cascade could fire concurrently and wipe the
+      // plugin_catalog row the subselect relies on. The audit still emits
+      // with pluginId + orgId so forensic reconstruction isn't completely
+      // blind even though the slug is gone.
+      setQueryResult("DELETE FROM workspace_plugins WHERE id", [
+        { id: "inst-1", catalog_id: "cat-1", slug: null },
+      ]);
+
+      const app = buildWorkspaceApp();
+      const res = await app.request("/marketplace/inst-1", { method: "DELETE" });
+      expect(res.status).toBe(200);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("plugin.uninstall");
+      expect(entry.metadata).toMatchObject({ pluginId: "cat-1", orgId: "org-1" });
+      expect(entry.metadata).not.toHaveProperty("pluginSlug");
     });
   });
 
@@ -1044,6 +1178,45 @@ describe("F-22 audit emission — Workspace marketplace", () => {
       expect(entry.status).toBe("failure");
       expect(entry.metadata!.keysChanged).toEqual(["key"]);
       expect(entry.metadata!.error).toContain("config update failed");
+    });
+
+    it("does not emit audit when installation not found (404)", async () => {
+      setQueryResult("UPDATE workspace_plugins", []);
+
+      const app = buildWorkspaceApp();
+      const res = await app.request("/marketplace/missing/config", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ config: { key: "val" } }),
+      });
+      expect(res.status).toBe(404);
+      expect(mockLogAdminAction).not.toHaveBeenCalled();
+    });
+
+    it("sorts keysChanged alphabetically regardless of input order", async () => {
+      setQueryResult("UPDATE workspace_plugins", [{
+        id: "inst-1",
+        workspace_id: "org-1",
+        catalog_id: "cat-1",
+        config: {},
+        enabled: true,
+        installed_at: now,
+        installed_by: "admin-1",
+        name: "BigQuery",
+        slug: "bigquery",
+        type: "datasource",
+        description: null,
+      }]);
+
+      await buildWorkspaceApp().request("/marketplace/inst-1/config", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          config: { zzz: 1, mmm: 2, aaa: 3 },
+        }),
+      });
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.metadata!.keysChanged).toEqual(["aaa", "mmm", "zzz"]);
     });
   });
 });

--- a/packages/api/src/api/__tests__/admin-plugins.test.ts
+++ b/packages/api/src/api/__tests__/admin-plugins.test.ts
@@ -415,10 +415,10 @@ describe("POST /api/v1/admin/plugins/:id/enable — persistence warnings", () =>
 });
 
 // ---------------------------------------------------------------------------
-// F-22: audit emission
+// Audit emission
 // ---------------------------------------------------------------------------
 
-describe("F-22 audit emission — POST /api/v1/admin/plugins/:id/enable", () => {
+describe("audit emission — POST /api/v1/admin/plugins/:id/enable", () => {
   it("emits exactly one plugin.enable audit on success", async () => {
     mockPluginEnabled = false;
     const res = await request("/api/v1/admin/plugins/test-plugin/enable", {
@@ -470,7 +470,7 @@ describe("F-22 audit emission — POST /api/v1/admin/plugins/:id/enable", () => 
   });
 });
 
-describe("F-22 audit emission — POST /api/v1/admin/plugins/:id/disable", () => {
+describe("audit emission — POST /api/v1/admin/plugins/:id/disable", () => {
   it("emits exactly one plugin.disable audit on success", async () => {
     const res = await request("/api/v1/admin/plugins/test-plugin/disable", {
       method: "POST",
@@ -507,7 +507,7 @@ describe("F-22 audit emission — POST /api/v1/admin/plugins/:id/disable", () =>
   });
 });
 
-describe("F-22 audit emission — PUT /api/v1/admin/plugins/:id/config", () => {
+describe("audit emission — PUT /api/v1/admin/plugins/:id/config", () => {
   it("emits exactly one plugin.config_update audit on success with keysChanged", async () => {
     const res = await request("/api/v1/admin/plugins/test-plugin/config", {
       method: "PUT",
@@ -557,10 +557,12 @@ describe("F-22 audit emission — PUT /api/v1/admin/plugins/:id/config", () => {
     mockSavePluginConfig.mockImplementation(() =>
       Promise.reject(new Error("savePluginConfig DB error")),
     );
+    // Originals are { apiKey: "sk-secret-123", region: "us-east", debug: false };
+    // sending `eu-west` guarantees region shows up as changed.
     const res = await request("/api/v1/admin/plugins/test-plugin/config", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ apiKey: "x", region: "us-east" }),
+      body: JSON.stringify({ apiKey: "rotated", region: "eu-west" }),
     });
     expect(res.status).toBe(500);
     expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
@@ -589,5 +591,42 @@ describe("F-22 audit emission — PUT /api/v1/admin/plugins/:id/config", () => {
     });
     expect(res.status).toBe(404);
     expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+
+  it("sorts keysChanged alphabetically regardless of body insertion order", async () => {
+    // Reverse-alphabetical body — proves `.toSorted()` is load-bearing, not
+    // a coincidence of the other test cases picking alphabetical inputs.
+    const res = await request("/api/v1/admin/plugins/test-plugin/config", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        region: "eu-west",
+        debug: true,
+        apiKey: "rotated",
+      }),
+    });
+    expect(res.status).toBe(200);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.metadata!.keysChanged).toEqual(["apiKey", "debug", "region"]);
+  });
+
+  it("filters keysChanged to only fields that actually changed", async () => {
+    // Admin re-submits the masked placeholder for `apiKey` — the handler
+    // restores the original value, so `apiKey` is NOT a real change.
+    // `debug` gets sent with its original value (false). Only `region`
+    // actually changes. Without the filter, all three keys would leak
+    // into `keysChanged` and misrepresent the edit as a secret rotation.
+    const res = await request("/api/v1/admin/plugins/test-plugin/config", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        apiKey: "••••••••",
+        region: "eu-west",
+        debug: false,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.metadata!.keysChanged).toEqual(["region"]);
   });
 });

--- a/packages/api/src/api/__tests__/admin-plugins.test.ts
+++ b/packages/api/src/api/__tests__/admin-plugins.test.ts
@@ -15,6 +15,34 @@ import {
 } from "bun:test";
 import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
 
+// --- Audit capture ---
+// Intercept every logAdminAction emission so tests can assert audit shape
+// without booting the internal DB. Mocked at module level so the route
+// module binds to this mock when it's first imported below.
+
+interface CapturedAuditEntry {
+  actionType: string;
+  targetType: string;
+  targetId: string;
+  status?: "success" | "failure";
+  metadata?: Record<string, unknown>;
+  scope?: "platform" | "workspace";
+  ipAddress?: string | null;
+}
+
+const mockLogAdminAction: Mock<(entry: CapturedAuditEntry) => void> = mock(
+  () => {},
+);
+
+mock.module("@atlas/api/lib/audit", async () => {
+  const actual = await import("@atlas/api/lib/audit/actions");
+  return {
+    logAdminAction: mockLogAdminAction,
+    logAdminActionAwait: mock(async () => {}),
+    ADMIN_ACTIONS: actual.ADMIN_ACTIONS,
+  };
+});
+
 // --- Unified mocks ---
 
 const mocks = createApiTestMocks({
@@ -143,6 +171,7 @@ beforeEach(() => {
   mockSavePluginEnabled.mockImplementation(() => Promise.resolve());
   mockSavePluginConfig.mockImplementation(() => Promise.resolve());
   mockGetPluginConfig.mockImplementation(() => Promise.resolve(null));
+  mockLogAdminAction.mockClear();
 });
 
 // ---------------------------------------------------------------------------
@@ -382,5 +411,183 @@ describe("POST /api/v1/admin/plugins/:id/enable — persistence warnings", () =>
     expect(body.enabled).toBe(true);
     expect(body.persisted).toBe(false);
     expect(body.warning).toContain("could not be persisted");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F-22: audit emission
+// ---------------------------------------------------------------------------
+
+describe("F-22 audit emission — POST /api/v1/admin/plugins/:id/enable", () => {
+  it("emits exactly one plugin.enable audit on success", async () => {
+    mockPluginEnabled = false;
+    const res = await request("/api/v1/admin/plugins/test-plugin/enable", {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.actionType).toBe("plugin.enable");
+    expect(entry.targetType).toBe("plugin");
+    expect(entry.targetId).toBe("test-plugin");
+    expect(entry.scope).toBe("platform");
+    expect(entry.status ?? "success").toBe("success");
+    expect(entry.metadata).toMatchObject({
+      pluginId: "test-plugin",
+      pluginSlug: "test-plugin",
+      enabled: true,
+      persisted: true,
+    });
+  });
+
+  it("emits plugin.enable with status=failure when persistence throws", async () => {
+    mockSavePluginEnabled.mockImplementation(() =>
+      Promise.reject(new Error("savePluginEnabled DB error")),
+    );
+    const res = await request("/api/v1/admin/plugins/test-plugin/enable", {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.actionType).toBe("plugin.enable");
+    expect(entry.status).toBe("failure");
+    expect(entry.metadata).toMatchObject({
+      pluginId: "test-plugin",
+      pluginSlug: "test-plugin",
+      enabled: true,
+      persisted: false,
+    });
+    expect(entry.metadata!.error).toContain("savePluginEnabled DB error");
+  });
+
+  it("does not emit audit for unknown plugin (pre-handler rejection)", async () => {
+    const res = await request("/api/v1/admin/plugins/nonexistent/enable", {
+      method: "POST",
+    });
+    expect(res.status).toBe(404);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+});
+
+describe("F-22 audit emission — POST /api/v1/admin/plugins/:id/disable", () => {
+  it("emits exactly one plugin.disable audit on success", async () => {
+    const res = await request("/api/v1/admin/plugins/test-plugin/disable", {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.actionType).toBe("plugin.disable");
+    expect(entry.targetType).toBe("plugin");
+    expect(entry.targetId).toBe("test-plugin");
+    expect(entry.scope).toBe("platform");
+    expect(entry.metadata).toMatchObject({
+      pluginId: "test-plugin",
+      pluginSlug: "test-plugin",
+      enabled: false,
+      persisted: true,
+    });
+  });
+
+  it("emits plugin.disable with status=failure when persistence throws", async () => {
+    mockSavePluginEnabled.mockImplementation(() =>
+      Promise.reject(new Error("savePluginEnabled DB error on disable")),
+    );
+    const res = await request("/api/v1/admin/plugins/test-plugin/disable", {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.actionType).toBe("plugin.disable");
+    expect(entry.status).toBe("failure");
+    expect(entry.metadata!.persisted).toBe(false);
+    expect(entry.metadata!.error).toContain("savePluginEnabled DB error on disable");
+  });
+});
+
+describe("F-22 audit emission — PUT /api/v1/admin/plugins/:id/config", () => {
+  it("emits exactly one plugin.config_update audit on success with keysChanged", async () => {
+    const res = await request("/api/v1/admin/plugins/test-plugin/config", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        apiKey: "new-secret-value",
+        region: "eu-west",
+        debug: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.actionType).toBe("plugin.config_update");
+    expect(entry.targetType).toBe("plugin");
+    expect(entry.targetId).toBe("test-plugin");
+    expect(entry.scope).toBe("platform");
+    expect(entry.metadata!.pluginId).toBe("test-plugin");
+    expect(entry.metadata!.pluginSlug).toBe("test-plugin");
+    // Key names are captured (sorted for deterministic diffs).
+    expect(entry.metadata!.keysChanged).toEqual(["apiKey", "debug", "region"]);
+  });
+
+  it("never includes config values in audit metadata", async () => {
+    await request("/api/v1/admin/plugins/test-plugin/config", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        apiKey: "sk-super-secret-live-value",
+        region: "us-east",
+        debug: false,
+      }),
+    });
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    const serialized = JSON.stringify(entry);
+    expect(serialized).not.toContain("sk-super-secret-live-value");
+    // `metadata` must not carry the raw body. keysChanged is strings — the
+    // field-name check catches any refactor that accidentally swaps to the
+    // value map.
+    expect(entry.metadata).not.toHaveProperty("apiKey");
+    expect(entry.metadata).not.toHaveProperty("config");
+    expect(entry.metadata).not.toHaveProperty("values");
+    expect(entry.metadata).not.toHaveProperty("body");
+  });
+
+  it("emits plugin.config_update with status=failure when savePluginConfig throws", async () => {
+    mockSavePluginConfig.mockImplementation(() =>
+      Promise.reject(new Error("savePluginConfig DB error")),
+    );
+    const res = await request("/api/v1/admin/plugins/test-plugin/config", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ apiKey: "x", region: "us-east" }),
+    });
+    expect(res.status).toBe(500);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.actionType).toBe("plugin.config_update");
+    expect(entry.status).toBe("failure");
+    expect(entry.metadata!.keysChanged).toEqual(["apiKey", "region"]);
+    expect(entry.metadata!.error).toContain("savePluginConfig DB error");
+  });
+
+  it("does not emit audit on validation failure (pre-handler rejection)", async () => {
+    const res = await request("/api/v1/admin/plugins/test-plugin/config", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ region: "us-east" }),
+    });
+    expect(res.status).toBe(400);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+
+  it("does not emit audit for unknown plugin", async () => {
+    const res = await request("/api/v1/admin/plugins/nonexistent/config", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(404);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/api/routes/admin-marketplace.ts
+++ b/packages/api/src/api/routes/admin-marketplace.ts
@@ -397,11 +397,28 @@ platformCatalog.openapi(updateCatalogRoute, async (c) => {
       setClauses.push(`updated_at = now()`);
       params.push(id);
 
-      // Snapshot the fields the admin intended to update before the write.
-      // Never emit `body` values — configSchema may contain secrets / PII-ish
-      // hints and even `enabled: false` carries forensic signal that the key
-      // names alone convey.
+      // Keys only — see ADMIN_ACTIONS.plugin JSDoc. configSchema may hint at
+      // secret shapes and `enabled: false` carries forensic signal that the
+      // key name alone conveys.
       const keysChanged = Object.keys(body).toSorted();
+
+      // Pre-fetch slug so the failure-path audit row carries it even when
+      // the UPDATE throws. Lookup failure degrades to `priorLookupFailed`
+      // rather than 500ing with no audit — same rationale as catalog delete.
+      let priorLookup: { slug: string | null; failed: boolean };
+      try {
+        const priorRows = yield* queryEffect<{ slug: string }>(
+          "SELECT slug FROM plugin_catalog WHERE id = $1",
+          [id],
+        );
+        priorLookup = { slug: priorRows[0]?.slug ?? null, failed: false };
+      } catch (err) {
+        log.warn(
+          { err: err instanceof Error ? err.message : String(err), catalogId: id },
+          "catalog update pre-lookup failed; failure audit will lack slug",
+        );
+        priorLookup = { slug: null, failed: true };
+      }
 
       const rows = yield* queryEffect<CatalogRow>(
         `UPDATE plugin_catalog SET ${setClauses.join(", ")} WHERE id = $${paramIdx} RETURNING *`,
@@ -415,6 +432,8 @@ platformCatalog.openapi(updateCatalogRoute, async (c) => {
           status: "failure",
           metadata: {
             pluginId: id,
+            ...(priorLookup.slug !== null && { pluginSlug: priorLookup.slug }),
+            ...(priorLookup.failed && { priorLookupFailed: true }),
             keysChanged,
             error: err instanceof Error ? err.message : String(err),
           },
@@ -451,25 +470,58 @@ platformCatalog.openapi(deleteCatalogRoute, async (c) => {
 
       const { id } = c.req.valid("param");
 
-      // Fetch slug and count installations BEFORE the cascade fires. Forensic
-      // reconstruction needs the slug (DB FK cascade wipes it) and the count
-      // of workspaces that lost the plugin (mass uninstall is the scariest
-      // side-effect of this endpoint — F-22). Counting has to happen in the
-      // same request before DELETE cascades.
-      const priorRows = yield* queryEffect<{ slug: string }>(
-        "SELECT slug FROM plugin_catalog WHERE id = $1",
-        [id],
-      );
-      if (priorRows.length === 0) {
+      // Fetch slug and count installations BEFORE the cascade fires. Pre-lookup
+      // failures must not short-circuit the audit — if a pool error throws
+      // here and we rethrow, the request 500s with zero audit rows, letting
+      // an attacker flood transient errors to hide attempted deletes. Degrade
+      // to a sentinel (priorLookupFailed) and let the DELETE proceed; the
+      // failure audit on the DELETE path then carries the degraded metadata.
+      let priorLookup: { slug: string | null; notFound: boolean; failed: boolean };
+      try {
+        const priorRows = yield* queryEffect<{ slug: string }>(
+          "SELECT slug FROM plugin_catalog WHERE id = $1",
+          [id],
+        );
+        priorLookup = {
+          slug: priorRows[0]?.slug ?? null,
+          notFound: priorRows.length === 0,
+          failed: false,
+        };
+      } catch (err) {
+        log.warn(
+          { err: err instanceof Error ? err.message : String(err), catalogId: id },
+          "catalog delete pre-lookup failed; audit row will lack slug",
+        );
+        priorLookup = { slug: null, notFound: false, failed: true };
+      }
+      if (priorLookup.notFound) {
         return c.json({ error: "not_found", message: `Catalog entry "${id}" not found.`, requestId }, 404);
       }
-      const pluginSlug = priorRows[0]!.slug;
+      const pluginSlug = priorLookup.slug;
 
-      const installCountRows = yield* queryEffect<{ count: string | number }>(
-        "SELECT COUNT(*)::int AS count FROM workspace_plugins WHERE catalog_id = $1",
-        [id],
-      );
-      const affectedOrgCount = Number(installCountRows[0]?.count ?? 0);
+      let installCountLookup: { count: number; failed: boolean };
+      try {
+        const installCountRows = yield* queryEffect<{ count: string | number }>(
+          "SELECT COUNT(*)::int AS count FROM workspace_plugins WHERE catalog_id = $1",
+          [id],
+        );
+        installCountLookup = { count: Number(installCountRows[0]?.count ?? 0), failed: false };
+      } catch (err) {
+        log.warn(
+          { err: err instanceof Error ? err.message : String(err), catalogId: id },
+          "catalog delete install-count lookup failed; audit row will lack affectedOrgCount",
+        );
+        installCountLookup = { count: 0, failed: true };
+      }
+      const affectedOrgCount = installCountLookup.count;
+      const priorLookupFailed = priorLookup.failed || installCountLookup.failed;
+
+      const auditMetadataBase = {
+        pluginId: id,
+        ...(pluginSlug !== null && { pluginSlug }),
+        affectedOrgCount,
+        ...(priorLookupFailed && { priorLookupFailed: true }),
+      };
 
       const rows = yield* queryEffect<{ id: string }>(
         "DELETE FROM plugin_catalog WHERE id = $1 RETURNING id",
@@ -482,9 +534,7 @@ platformCatalog.openapi(deleteCatalogRoute, async (c) => {
           scope: "platform",
           status: "failure",
           metadata: {
-            pluginId: id,
-            pluginSlug,
-            affectedOrgCount,
+            ...auditMetadataBase,
             error: err instanceof Error ? err.message : String(err),
           },
         });
@@ -499,7 +549,7 @@ platformCatalog.openapi(deleteCatalogRoute, async (c) => {
         targetType: "plugin",
         targetId: id,
         scope: "platform",
-        metadata: { pluginId: id, pluginSlug, affectedOrgCount },
+        metadata: auditMetadataBase,
       });
       // Cascade event fires only when workspaces actually lost the plugin —
       // separate from catalog_delete so forensic queries can distinguish a
@@ -510,10 +560,10 @@ platformCatalog.openapi(deleteCatalogRoute, async (c) => {
           targetType: "plugin",
           targetId: id,
           scope: "platform",
-          metadata: { pluginId: id, pluginSlug, affectedOrgCount },
+          metadata: auditMetadataBase,
         });
       }
-      log.info({ catalogId: id, affectedOrgCount }, "Catalog entry deleted (cascaded to workspace installations)");
+      log.info({ catalogId: id, affectedOrgCount, priorLookupFailed }, "Catalog entry deleted (cascaded to workspace installations)");
       return c.json({ deleted: true }, 200);
     }),
     { label: "delete catalog entry" },
@@ -677,11 +727,27 @@ workspaceMarketplace.openapi(installRoute, async (c) => {
       const { orgId } = c.var.orgContext;
       const body = c.req.valid("json");
 
-      // Fetch catalog entry
+      // Fetch catalog entry. A lookup failure at this point means we cannot
+      // know the slug, but we still want an audit row — a compromised admin
+      // could otherwise flood transient errors to probe for catalog IDs.
       const catalogRows = yield* queryEffect<CatalogRow>(
         "SELECT * FROM plugin_catalog WHERE id = $1 AND enabled = true",
         [body.catalogId],
-      );
+      ).pipe(Effect.tapError((err) => Effect.sync(() => {
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.plugin.install,
+          targetType: "plugin",
+          targetId: body.catalogId,
+          scope: "workspace",
+          status: "failure",
+          metadata: {
+            pluginId: body.catalogId,
+            orgId,
+            priorLookupFailed: true,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        });
+      })));
       if (catalogRows.length === 0) {
         return c.json({ error: "not_found", message: `Catalog entry "${body.catalogId}" not found or disabled.`, requestId }, 404);
       }
@@ -769,10 +835,11 @@ workspaceMarketplace.openapi(uninstallRoute, async (c) => {
       const { orgId } = c.var.orgContext;
       const { id } = c.req.valid("param");
 
-      // Fetch slug via DELETE ... RETURNING so the audit row captures which
-      // plugin was yanked even after the row is gone. The subselect is
-      // resolved against plugin_catalog before the join (RETURNING runs
-      // after the row is deleted but the FK is already resolved).
+      // DELETE ... RETURNING exposes catalog_id from the deleted row tuple,
+      // which we scalar-lookup against plugin_catalog (untouched by this
+      // statement) to capture slug alongside the uninstall. The subselect
+      // can still return NULL if the catalog row was already gone (e.g. a
+      // catalog_delete cascade raced with this request).
       const rows = yield* queryEffect<{ id: string; catalog_id: string; slug: string | null }>(
         `DELETE FROM workspace_plugins WHERE id = $1 AND workspace_id = $2
          RETURNING id, catalog_id, (SELECT slug FROM plugin_catalog WHERE id = workspace_plugins.catalog_id) AS slug`,
@@ -804,7 +871,10 @@ workspaceMarketplace.openapi(uninstallRoute, async (c) => {
         scope: "workspace",
         metadata: {
           pluginId: deleted.catalog_id,
-          ...(deleted.slug !== null && { pluginSlug: deleted.slug }),
+          // `!= null` covers both SQL NULL (from the subselect missing the
+          // catalog row) and an absent column (defense in depth against
+          // driver-shape drift). Aligned with the config_update guard below.
+          ...(deleted.slug != null && { pluginSlug: deleted.slug }),
           orgId,
         },
       });
@@ -825,9 +895,7 @@ workspaceMarketplace.openapi(updateConfigRoute, async (c) => {
       const { id } = c.req.valid("param");
       const body = c.req.valid("json");
 
-      // Snapshot the keys the admin is changing. NEVER log values — config
-      // here carries real secrets (BigQuery service-account JSON, Snowflake
-      // passwords, etc.) and a leaked audit row would defeat the point.
+      // Keys only — see ADMIN_ACTIONS.plugin JSDoc.
       const keysChanged = Object.keys(body.config).toSorted();
 
       const rows = yield* queryEffect<WorkspacePluginRow>(
@@ -866,7 +934,10 @@ workspaceMarketplace.openapi(updateConfigRoute, async (c) => {
         scope: "workspace",
         metadata: {
           pluginId: updated.catalog_id,
-          ...(updated.slug !== undefined && { pluginSlug: updated.slug }),
+          // See uninstall-path note — `!= null` covers both SQL NULL and
+          // absent-column shapes. The `pg` driver returns SQL NULL as JS
+          // null, not undefined, so `!== undefined` would have leaked null.
+          ...(updated.slug != null && { pluginSlug: updated.slug }),
           orgId,
           keysChanged,
         },

--- a/packages/api/src/api/routes/admin-marketplace.ts
+++ b/packages/api/src/api/routes/admin-marketplace.ts
@@ -15,6 +15,7 @@ import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext } from "@atlas/api/lib/effect/services";
 import { createLogger } from "@atlas/api/lib/logger";
 import { hasInternalDB, internalQuery, queryEffect } from "@atlas/api/lib/db/internal";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { PLAN_TIERS, type PlanTier } from "@useatlas/types";
 import {
   ErrorSchema,
@@ -332,10 +333,30 @@ platformCatalog.openapi(createCatalogRoute, async (c) => {
           body.minPlan,
           body.enabled,
         ],
-      );
+      ).pipe(Effect.tapError((err) => Effect.sync(() => {
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.plugin.catalogCreate,
+          targetType: "plugin",
+          targetId: id,
+          scope: "platform",
+          status: "failure",
+          metadata: {
+            pluginId: id,
+            pluginSlug: body.slug,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        });
+      })));
       if (rows.length === 0) {
         return c.json({ error: "internal_error", message: "Failed to create catalog entry — no row returned.", requestId }, 500);
       }
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.plugin.catalogCreate,
+        targetType: "plugin",
+        targetId: id,
+        scope: "platform",
+        metadata: { pluginId: id, pluginSlug: body.slug },
+      });
       log.info({ catalogId: id, slug: body.slug }, "Plugin added to catalog");
       return c.json(catalogRowToJson(rows[0]!), 201);
     }),
@@ -376,17 +397,44 @@ platformCatalog.openapi(updateCatalogRoute, async (c) => {
       setClauses.push(`updated_at = now()`);
       params.push(id);
 
+      // Snapshot the fields the admin intended to update before the write.
+      // Never emit `body` values — configSchema may contain secrets / PII-ish
+      // hints and even `enabled: false` carries forensic signal that the key
+      // names alone convey.
+      const keysChanged = Object.keys(body).toSorted();
+
       const rows = yield* queryEffect<CatalogRow>(
         `UPDATE plugin_catalog SET ${setClauses.join(", ")} WHERE id = $${paramIdx} RETURNING *`,
         params,
-      );
+      ).pipe(Effect.tapError((err) => Effect.sync(() => {
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.plugin.catalogUpdate,
+          targetType: "plugin",
+          targetId: id,
+          scope: "platform",
+          status: "failure",
+          metadata: {
+            pluginId: id,
+            keysChanged,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        });
+      })));
 
       if (rows.length === 0) {
         return c.json({ error: "not_found", message: `Catalog entry "${id}" not found.`, requestId }, 404);
       }
 
+      const updatedRow = rows[0]!;
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.plugin.catalogUpdate,
+        targetType: "plugin",
+        targetId: id,
+        scope: "platform",
+        metadata: { pluginId: id, pluginSlug: updatedRow.slug, keysChanged },
+      });
       log.info({ catalogId: id }, "Catalog entry updated");
-      return c.json(catalogRowToJson(rows[0]!), 200);
+      return c.json(catalogRowToJson(updatedRow), 200);
     }),
     { label: "update catalog entry" },
   );
@@ -402,13 +450,70 @@ platformCatalog.openapi(deleteCatalogRoute, async (c) => {
       }
 
       const { id } = c.req.valid("param");
-      const rows = yield* queryEffect<{ id: string }>("DELETE FROM plugin_catalog WHERE id = $1 RETURNING id", [id]);
+
+      // Fetch slug and count installations BEFORE the cascade fires. Forensic
+      // reconstruction needs the slug (DB FK cascade wipes it) and the count
+      // of workspaces that lost the plugin (mass uninstall is the scariest
+      // side-effect of this endpoint — F-22). Counting has to happen in the
+      // same request before DELETE cascades.
+      const priorRows = yield* queryEffect<{ slug: string }>(
+        "SELECT slug FROM plugin_catalog WHERE id = $1",
+        [id],
+      );
+      if (priorRows.length === 0) {
+        return c.json({ error: "not_found", message: `Catalog entry "${id}" not found.`, requestId }, 404);
+      }
+      const pluginSlug = priorRows[0]!.slug;
+
+      const installCountRows = yield* queryEffect<{ count: string | number }>(
+        "SELECT COUNT(*)::int AS count FROM workspace_plugins WHERE catalog_id = $1",
+        [id],
+      );
+      const affectedOrgCount = Number(installCountRows[0]?.count ?? 0);
+
+      const rows = yield* queryEffect<{ id: string }>(
+        "DELETE FROM plugin_catalog WHERE id = $1 RETURNING id",
+        [id],
+      ).pipe(Effect.tapError((err) => Effect.sync(() => {
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.plugin.catalogDelete,
+          targetType: "plugin",
+          targetId: id,
+          scope: "platform",
+          status: "failure",
+          metadata: {
+            pluginId: id,
+            pluginSlug,
+            affectedOrgCount,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        });
+      })));
 
       if (rows.length === 0) {
         return c.json({ error: "not_found", message: `Catalog entry "${id}" not found.`, requestId }, 404);
       }
 
-      log.info({ catalogId: id }, "Catalog entry deleted (cascaded to workspace installations)");
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.plugin.catalogDelete,
+        targetType: "plugin",
+        targetId: id,
+        scope: "platform",
+        metadata: { pluginId: id, pluginSlug, affectedOrgCount },
+      });
+      // Cascade event fires only when workspaces actually lost the plugin —
+      // separate from catalog_delete so forensic queries can distinguish a
+      // cleanup delete from a mass uninstall.
+      if (affectedOrgCount > 0) {
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.plugin.catalogCascadeUninstall,
+          targetType: "plugin",
+          targetId: id,
+          scope: "platform",
+          metadata: { pluginId: id, pluginSlug, affectedOrgCount },
+        });
+      }
+      log.info({ catalogId: id, affectedOrgCount }, "Catalog entry deleted (cascaded to workspace installations)");
       return c.json({ deleted: true }, 200);
     }),
     { label: "delete catalog entry" },
@@ -618,11 +723,36 @@ workspaceMarketplace.openapi(installRoute, async (c) => {
                      (SELECT type FROM plugin_catalog WHERE id = $3) AS type,
                      (SELECT description FROM plugin_catalog WHERE id = $3) AS description`,
         [id, orgId, body.catalogId, JSON.stringify(body.config ?? {}), userId],
-      );
+      ).pipe(Effect.tapError((err) => Effect.sync(() => {
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.plugin.install,
+          targetType: "plugin",
+          targetId: id,
+          scope: "workspace",
+          status: "failure",
+          metadata: {
+            pluginId: body.catalogId,
+            pluginSlug: catalogEntry.slug,
+            orgId,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        });
+      })));
 
       if (rows.length === 0) {
         return c.json({ error: "internal_error", message: "Failed to install plugin — no row returned.", requestId }, 500);
       }
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.plugin.install,
+        targetType: "plugin",
+        targetId: id,
+        scope: "workspace",
+        metadata: {
+          pluginId: body.catalogId,
+          pluginSlug: catalogEntry.slug,
+          orgId,
+        },
+      });
       log.info({ orgId, catalogId: body.catalogId, installationId: id }, "Plugin installed in workspace");
       return c.json(installRowToJson(rows[0]!), 201);
     }),
@@ -639,15 +769,45 @@ workspaceMarketplace.openapi(uninstallRoute, async (c) => {
       const { orgId } = c.var.orgContext;
       const { id } = c.req.valid("param");
 
-      const rows = yield* queryEffect<{ id: string }>(
-        "DELETE FROM workspace_plugins WHERE id = $1 AND workspace_id = $2 RETURNING id",
+      // Fetch slug via DELETE ... RETURNING so the audit row captures which
+      // plugin was yanked even after the row is gone. The subselect is
+      // resolved against plugin_catalog before the join (RETURNING runs
+      // after the row is deleted but the FK is already resolved).
+      const rows = yield* queryEffect<{ id: string; catalog_id: string; slug: string | null }>(
+        `DELETE FROM workspace_plugins WHERE id = $1 AND workspace_id = $2
+         RETURNING id, catalog_id, (SELECT slug FROM plugin_catalog WHERE id = workspace_plugins.catalog_id) AS slug`,
         [id, orgId],
-      );
+      ).pipe(Effect.tapError((err) => Effect.sync(() => {
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.plugin.uninstall,
+          targetType: "plugin",
+          targetId: id,
+          scope: "workspace",
+          status: "failure",
+          metadata: {
+            pluginId: id,
+            orgId,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        });
+      })));
 
       if (rows.length === 0) {
         return c.json({ error: "not_found", message: `Installation "${id}" not found in this workspace.`, requestId }, 404);
       }
 
+      const deleted = rows[0]!;
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.plugin.uninstall,
+        targetType: "plugin",
+        targetId: id,
+        scope: "workspace",
+        metadata: {
+          pluginId: deleted.catalog_id,
+          ...(deleted.slug !== null && { pluginSlug: deleted.slug }),
+          orgId,
+        },
+      });
       log.info({ orgId, installationId: id }, "Plugin uninstalled from workspace");
       return c.json({ deleted: true }, 200);
     }),
@@ -665,6 +825,11 @@ workspaceMarketplace.openapi(updateConfigRoute, async (c) => {
       const { id } = c.req.valid("param");
       const body = c.req.valid("json");
 
+      // Snapshot the keys the admin is changing. NEVER log values — config
+      // here carries real secrets (BigQuery service-account JSON, Snowflake
+      // passwords, etc.) and a leaked audit row would defeat the point.
+      const keysChanged = Object.keys(body.config).toSorted();
+
       const rows = yield* queryEffect<WorkspacePluginRow>(
         `UPDATE workspace_plugins SET config = $1
          WHERE id = $2 AND workspace_id = $3
@@ -673,14 +838,41 @@ workspaceMarketplace.openapi(updateConfigRoute, async (c) => {
                      (SELECT type FROM plugin_catalog WHERE id = workspace_plugins.catalog_id) AS type,
                      (SELECT description FROM plugin_catalog WHERE id = workspace_plugins.catalog_id) AS description`,
         [JSON.stringify(body.config), id, orgId],
-      );
+      ).pipe(Effect.tapError((err) => Effect.sync(() => {
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.plugin.configUpdate,
+          targetType: "plugin",
+          targetId: id,
+          scope: "workspace",
+          status: "failure",
+          metadata: {
+            pluginId: id,
+            orgId,
+            keysChanged,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        });
+      })));
 
       if (rows.length === 0) {
         return c.json({ error: "not_found", message: `Installation "${id}" not found in this workspace.`, requestId }, 404);
       }
 
+      const updated = rows[0]!;
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.plugin.configUpdate,
+        targetType: "plugin",
+        targetId: id,
+        scope: "workspace",
+        metadata: {
+          pluginId: updated.catalog_id,
+          ...(updated.slug !== undefined && { pluginSlug: updated.slug }),
+          orgId,
+          keysChanged,
+        },
+      });
       log.info({ orgId, installationId: id }, "Plugin config updated");
-      return c.json(installRowToJson(rows[0]!), 200);
+      return c.json(installRowToJson(updated), 200);
     }),
     { label: "update plugin config" },
   );

--- a/packages/api/src/api/routes/admin-plugins.ts
+++ b/packages/api/src/api/routes/admin-plugins.ts
@@ -235,7 +235,7 @@ adminPlugins.openapi(enablePluginRoute, async (c) => {
 
   const plugin = plugins.get(id);
   if (!plugin) {
-    // 404 short-circuits before any state change — pre-handler rejection, no audit.
+    // Not-found short-circuits — no state change, no audit event.
     return c.json({ error: "not_found", message: `Plugin "${id}" not found.`, requestId }, 404);
   }
 
@@ -392,19 +392,23 @@ adminPlugins.openapi(updatePluginConfigRoute, async (c) => runHandler(c, "save p
     return c.json({ error: "invalid_request", message: "Request body must be a JSON object." }, 400);
   }
 
-  // Validate against schema if plugin provides one
+  // Validate against schema if plugin provides one. `originals` is captured
+  // so we can (a) restore masked secret placeholders to their prior value
+  // and (b) compute an accurate `keysChanged` that excludes re-submitted
+  // placeholders — otherwise every admin save would report apiKey as
+  // rotated even when they only toggled `debug`.
   const MASKED_PLACEHOLDER = "••••••••";
+  let originals: Record<string, unknown> = {};
   if (typeof plugin.getConfigSchema === "function") {
     const schema = plugin.getConfigSchema();
     const schemaKeys = new Set(schema.map((f) => f.key));
     const errors: string[] = [];
 
-    // Restore masked secret values from original config
     const pluginConfig = plugin.config != null && typeof plugin.config === "object"
       ? (plugin.config as Record<string, unknown>)
       : {};
     const dbOverrides = await getPluginConfig(id);
-    const originals = { ...pluginConfig, ...dbOverrides };
+    originals = { ...pluginConfig, ...dbOverrides };
 
     for (const field of schema) {
       const value = body[field.key];
@@ -457,11 +461,13 @@ adminPlugins.openapi(updatePluginConfigRoute, async (c) => runHandler(c, "save p
     }
   }
 
-  // Snapshot key names BEFORE persist so the audit row captures what the
-  // admin intended to change even if savePluginConfig throws. NEVER log
-  // values — the body may contain secrets (BigQuery service account JSON,
-  // Snowflake passwords).
-  const keysChanged = Object.keys(body).toSorted();
+  // Keys only — see ADMIN_ACTIONS.plugin JSDoc. Filter out keys whose final
+  // value equals the originals (happens when the admin re-submits the
+  // masked placeholder for a secret they didn't rotate). Snapshotted BEFORE
+  // persist so a savePluginConfig throw still emits the intended change set.
+  const keysChanged = Object.keys(body)
+    .filter((key) => body[key] !== originals[key])
+    .toSorted();
 
   try {
     await savePluginConfig(id, body);

--- a/packages/api/src/api/routes/admin-plugins.ts
+++ b/packages/api/src/api/routes/admin-plugins.ts
@@ -13,6 +13,7 @@ import type { ConfigSchemaField } from "@atlas/api/lib/plugins/registry";
 import { savePluginEnabled, savePluginConfig, getPluginConfig } from "@atlas/api/lib/plugins/settings";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import { runHandler } from "@atlas/api/lib/effect/hono";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createPlatformRouter } from "./admin-router";
 
@@ -234,6 +235,7 @@ adminPlugins.openapi(enablePluginRoute, async (c) => {
 
   const plugin = plugins.get(id);
   if (!plugin) {
+    // 404 short-circuits before any state change — pre-handler rejection, no audit.
     return c.json({ error: "not_found", message: `Plugin "${id}" not found.`, requestId }, 404);
   }
 
@@ -241,17 +243,34 @@ adminPlugins.openapi(enablePluginRoute, async (c) => {
 
   let persisted = false;
   let warning: string | undefined;
+  let persistError: string | undefined;
   if (hasInternalDB()) {
     try {
       await savePluginEnabled(id, true);
       persisted = true;
     } catch (err) {
+      persistError = err instanceof Error ? err.message : String(err);
       log.error({ err: err instanceof Error ? err : new Error(String(err)), pluginId: id }, "Failed to persist plugin enabled state");
       warning = "Plugin enabled in memory but could not be persisted. State will reset on restart.";
     }
   } else {
     warning = "No internal database — state will reset on restart.";
   }
+
+  logAdminAction({
+    actionType: ADMIN_ACTIONS.plugin.enable,
+    targetType: "plugin",
+    targetId: id,
+    scope: "platform",
+    status: persistError === undefined ? "success" : "failure",
+    metadata: {
+      pluginId: id,
+      pluginSlug: id,
+      enabled: true,
+      persisted,
+      ...(persistError !== undefined && { error: persistError }),
+    },
+  });
 
   return c.json({ id, enabled: true, status: plugins.getStatus(id) ?? null, persisted, warning }, 200);
 });
@@ -270,17 +289,34 @@ adminPlugins.openapi(disablePluginRoute, async (c) => {
 
   let persisted = false;
   let warning: string | undefined;
+  let persistError: string | undefined;
   if (hasInternalDB()) {
     try {
       await savePluginEnabled(id, false);
       persisted = true;
     } catch (err) {
+      persistError = err instanceof Error ? err.message : String(err);
       log.error({ err: err instanceof Error ? err : new Error(String(err)), pluginId: id }, "Failed to persist plugin disabled state");
       warning = "Plugin disabled in memory but could not be persisted. State will reset on restart.";
     }
   } else {
     warning = "No internal database — state will reset on restart.";
   }
+
+  logAdminAction({
+    actionType: ADMIN_ACTIONS.plugin.disable,
+    targetType: "plugin",
+    targetId: id,
+    scope: "platform",
+    status: persistError === undefined ? "success" : "failure",
+    metadata: {
+      pluginId: id,
+      pluginSlug: id,
+      enabled: false,
+      persisted,
+      ...(persistError !== undefined && { error: persistError }),
+    },
+  });
 
   return c.json({ id, enabled: false, status: plugins.getStatus(id) ?? null, persisted, warning }, 200);
 });
@@ -421,7 +457,35 @@ adminPlugins.openapi(updatePluginConfigRoute, async (c) => runHandler(c, "save p
     }
   }
 
-  await savePluginConfig(id, body);
+  // Snapshot key names BEFORE persist so the audit row captures what the
+  // admin intended to change even if savePluginConfig throws. NEVER log
+  // values — the body may contain secrets (BigQuery service account JSON,
+  // Snowflake passwords).
+  const keysChanged = Object.keys(body).toSorted();
+
+  try {
+    await savePluginConfig(id, body);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.plugin.configUpdate,
+      targetType: "plugin",
+      targetId: id,
+      scope: "platform",
+      status: "failure",
+      metadata: { pluginId: id, pluginSlug: id, keysChanged, error: message },
+    });
+    throw err;
+  }
+
+  logAdminAction({
+    actionType: ADMIN_ACTIONS.plugin.configUpdate,
+    targetType: "plugin",
+    targetId: id,
+    scope: "platform",
+    metadata: { pluginId: id, pluginSlug: id, keysChanged },
+  });
+
   log.info({ pluginId: id, requestId }, "Plugin config updated");
   return c.json({
     id,

--- a/packages/api/src/lib/audit/actions.ts
+++ b/packages/api/src/lib/audit/actions.ts
@@ -131,6 +131,30 @@ export const ADMIN_ACTIONS = {
     assign: "role.assign",
   },
   /**
+   * Plugin lifecycle domain. `enable` / `disable` / `config_update` cover the
+   * platform-wide plugin registry; `install` / `uninstall` / `config_update`
+   * also cover per-workspace marketplace installs. `catalog_*` covers the
+   * platform-admin catalog CRUD. `catalog_cascade_uninstall` fires once per
+   * catalog delete that actually removed workspace installations — paired
+   * with `catalog_delete` so forensic queries can distinguish no-op deletes
+   * from the ones that yanked a data source out from every workspace.
+   *
+   * `config_update` metadata never includes values — only `keysChanged:
+   * string[]`. Plugin configs carry credentials (BigQuery service-account
+   * JSON, Snowflake passwords) and logging the values would defeat the point.
+   */
+  plugin: {
+    install: "plugin.install",
+    uninstall: "plugin.uninstall",
+    enable: "plugin.enable",
+    disable: "plugin.disable",
+    configUpdate: "plugin.config_update",
+    catalogCreate: "plugin.catalog_create",
+    catalogUpdate: "plugin.catalog_update",
+    catalogDelete: "plugin.catalog_delete",
+    catalogCascadeUninstall: "plugin.catalog_cascade_uninstall",
+  },
+  /**
    * Without these entries a compromised admin could shrink retentionDays
    * and hard-delete the audit trail leaving zero forensic record.
    */


### PR DESCRIPTION
## Summary

Phase 4 of the 1.2.3 security sweep (tracking #1718). Finding F-22 from PR #1794 audit — largest file-level audit gap. All 9 write routes in `admin-plugins.ts` and `admin-marketplace.ts` now emit `admin_action_log` entries.

## Changes

- **`plugin.*` domain added to `ADMIN_ACTIONS`** (`packages/api/src/lib/audit/actions.ts`): `install`, `uninstall`, `enable`, `disable`, `config_update`, `catalog_create`, `catalog_update`, `catalog_delete`, `catalog_cascade_uninstall`.
- **`admin-plugins.ts`** emits on enable / disable / config_update. `config_update` metadata captures `keysChanged: string[]` (sorted, key names only — values never logged).
- **`admin-marketplace.ts`** emits on 6 routes: platform catalog create / update / delete, workspace install / uninstall / config_update. Workspace events carry `orgId` and `pluginSlug`.
- **Catalog delete fetches `pluginSlug` + `affectedOrgCount` BEFORE the cascade fires** so the audit row survives FK cleanup. When `affectedOrgCount > 0` a separate `plugin.catalog_cascade_uninstall` event fires — forensic queries can distinguish a cleanup delete from a mass uninstall.
- **Failure path** emits `status: "failure"` with a scrubbed error message via `Effect.tapError` (Effect routes) or a try/catch wrapper (admin-plugins.ts). No stack traces, no config bytes.
- **Scoreboard updated** in `.claude/research/security-audit-1-2-3.md` (F-22 marked fixed, `admin-plugins.ts` + `admin-marketplace.ts` rows now green).

## Audit metadata contract

| Route | actionType | metadata |
|-------|-----------|----------|
| `POST /admin/plugins/:id/enable` | `plugin.enable` | `pluginId, pluginSlug, enabled, persisted, [error]` |
| `POST /admin/plugins/:id/disable` | `plugin.disable` | `pluginId, pluginSlug, enabled, persisted, [error]` |
| `PUT /admin/plugins/:id/config` | `plugin.config_update` | `pluginId, pluginSlug, keysChanged, [error]` |
| `POST /admin/plugins/marketplace/install` | `plugin.install` | `pluginId, pluginSlug, orgId, [error]` |
| `DELETE /admin/plugins/marketplace/:id` | `plugin.uninstall` | `pluginId, pluginSlug, orgId, [error]` |
| `PUT /admin/plugins/marketplace/:id/config` | `plugin.config_update` | `pluginId, pluginSlug, orgId, keysChanged, [error]` |
| `POST /platform/plugins/catalog` | `plugin.catalog_create` | `pluginId, pluginSlug, [error]` |
| `PUT /platform/plugins/catalog/:id` | `plugin.catalog_update` | `pluginId, pluginSlug, keysChanged, [error]` |
| `DELETE /platform/plugins/catalog/:id` | `plugin.catalog_delete` + optional `plugin.catalog_cascade_uninstall` | `pluginId, pluginSlug, affectedOrgCount, [error]` |

`keysChanged` holds sorted key names only. Config values (BigQuery service-account JSON, Snowflake passwords, etc.) never appear in audit metadata.

## Test plan

- [x] `bun test packages/api/src/api/__tests__/admin-plugins.test.ts` — 31 pass, 110 expect calls
- [x] `bun test packages/api/src/api/__tests__/admin-marketplace.test.ts` — 36 pass, 128 expect calls
- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun run test` — 260/260 API, 84/84 web, 25/25 EE, 19/19 CLI all pass
- [x] `bun x syncpack lint` — no issues
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — 431 files verified

Tests cover exactly-one emission on success, `status: "failure"` on service throws, `keysChanged` without values, catalog cascade emitting both events atomically, and regression confirmation that 404s / validation rejections don't emit audit rows.

Closes #1777