### PR TITLE
chore(docs): regenerate OpenAPI spec for F-28 session ID maxLength

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -17068,6 +17068,7 @@
             "schema": {
               "type": "string",
               "minLength": 1,
+              "maxLength": 255,
               "example": "sess_abc123"
             },
             "required": true,
@@ -17193,6 +17194,7 @@
             "schema": {
               "type": "string",
               "minLength": 1,
+              "maxLength": 255,
               "example": "user_abc123"
             },
             "required": true,


### PR DESCRIPTION
## Summary

- Main went red on the OpenAPI-drift CI gate after PR #1801 merged — the F-28 session-audit PR added \`maxLength: 255\` to the \`:id\` and \`:userId\` path-param schemas on \`/api/v1/admin/sessions/*\` but skipped \`openapi:extract\`
- Regenerated \`apps/docs/openapi.json\`; MDX output is unchanged (no schema delta big enough to touch \`api-reference/\`)

## Diff

Two lines added to \`apps/docs/openapi.json\` — the two session ID param schemas now carry their route-level \`maxLength: 255\` constraint

## Test plan

- [x] \`bun run --filter '@atlas/api' openapi:extract\` clean
- [x] \`bun run --filter '@atlas/docs' generate:api\` regenerates without content diff
- [x] \`git status\` shows only \`apps/docs/openapi.json\` modified
- [x] No production code touched