### PR TITLE
fix(security): 1.2.3 phase 4 — F-31 admin-orgs audit emission

### DIFF
--- a/.claude/research/security-audit-1-2-3.md
+++ b/.claude/research/security-audit-1-2-3.md
@@ -1085,7 +1085,7 @@ Totals at the file level; individual uncovered writes are enumerated under the f
 | `admin-marketplace.ts` | 6 | 6 | ✅ | `plugin.catalog_create` / `catalog_update` / `catalog_delete` + `catalog_cascade_uninstall` / `plugin.install` / `plugin.uninstall` / `plugin.config_update` — F-22 fixed |
 | `admin-migrate.ts` | 1 | 0 | ❌ | Schema migration trigger (F-37) |
 | `admin-model-config.ts` | 3 | 0 | ❌ | **LLM API key storage + deletion unaudited** (F-30) |
-| `admin-orgs.ts` | 4 | 4 | ✅ | F-31 fixed (PR for #1786, option b) — `workspace.suspend` / `workspace.unsuspend` / `workspace.change_plan` / `workspace.delete` emitted with `scope: "platform"`, matching `platform-admin.ts` contract exactly (same action_type, same metadata shape). Regression test locks canonical action types + parity with `/api/v1/platform/workspaces` endpoints |
+| `admin-orgs.ts` | 4 | 4 | ✅ | F-31 fixed (PR #1804) — `workspace.suspend` / `workspace.unsuspend` / `workspace.change_plan` / `workspace.delete` emitted with `scope: "platform"`, matching `platform-admin.ts` canonical fields exactly. Regression test compares entries directly across both surfaces |
 | `admin-plugins.ts` | 4 | 3 | ✅ | `plugin.enable` / `plugin.disable` / `plugin.config_update` audited; read-only health check stays silent — F-22 fixed |
 | `admin-prompts.ts` | 7 | 0 | ❌ | Content governance — collection + prompt CRUD (F-35) |
 | `admin-publish.ts` | 1 | 1 | ✅ | `mode.publish` |
@@ -1359,7 +1359,7 @@ None of these six routes call `logAdminAction`. All six write or test credential
 
 ---
 
-**F-31 — `admin-orgs.ts` is platform-gated post-F-08 but still emits no audit** — P1 — **FIXED (option b)**
+**F-31 — `admin-orgs.ts` is platform-gated post-F-08 but still emits no audit** — P1
 
 **Repro:** Phase-2 F-08 (PR #1762) moved workspace CRUD under `createPlatformRouter`. The role gate was fixed; the audit gap was not. Four writes remain silent: suspend / activate / delete / change plan.
 
@@ -1367,19 +1367,11 @@ Overlap with `platform-admin.ts` — which DOES audit `workspace.suspend` / `uns
 
 **Fix sketch:** Either (a) delete the overlap — route every admin-orgs mutation through `platform-admin.ts` internally — or (b) add `logAdminAction` calls to `admin-orgs.ts` matching the `platform-admin.ts` contract. Option (a) is preferred: a single workspace-mutation surface reduces the chance of future drift.
 
-**Fix:** Option (b) shipped. `admin-orgs.ts` now emits `logAdminAction` at all four writes, reusing the `ADMIN_ACTIONS.workspace.*` catalog values unchanged (no new action types added — stays compatible with F-30 / F-32 parallel work). Canonical mapping:
-- `PATCH /:id/suspend` → `workspace.suspend`
-- `PATCH /:id/activate` → `workspace.unsuspend` (same action_type as platform-admin `POST /unsuspend`)
-- `PATCH /:id/plan` → `workspace.change_plan` with `metadata: { previousPlan, newPlan }`
-- `DELETE /:id` → `workspace.delete` with `metadata: { cleanup, poolsDrained, warnings? }`
-
-All emissions carry `scope: "platform"` and the same `x-forwarded-for`/`x-real-ip` IP extraction as `platform-admin.ts`. Regression test (`admin-orgs-audit.test.ts`) parametrises both surfaces and asserts identical action_type + scope + target for each, so a future divergence on either side breaks the suite.
-
-**Follow-up:** Option (a) — collapse the two workspace-mutation surfaces into a shared `lib/workspace-mutations.ts` helper so the drift window closes at the write layer, not just the audit layer — remains a candidate refactor. The parity test makes future drift observable but does not prevent it; a dedicated `refactor` issue should be filed separately if we want to pursue consolidation.
-
 **Severity:** P1 — drift between two parallel admin surfaces is a classic compliance pitfall. The write path exists, the audit path is forgotten.
 
 **Issue:** #1786.
+
+**Status:** fixed (PR #1804, closes #1786). Option (b) shipped — no new `ADMIN_ACTIONS` entries, stays compatible with F-30 / F-32 parallel work. Canonical mapping: `PATCH /:id/suspend` → `workspace.suspend`; `PATCH /:id/activate` → `workspace.unsuspend` (same action_type as platform-admin `POST /unsuspend` — the endpoint path `/activate` deliberately differs from the canonical action_type so compliance queries filtering `action_type = 'workspace.unsuspend'` see one row shape per intent, not two); `PATCH /:id/plan` → `workspace.change_plan` with `metadata: { previousPlan, newPlan }` captured from the pre-mutation fetch; `DELETE /:id` → `workspace.delete` with `metadata: { cleanup, poolsDrained, warnings? }` where `cleanup` mirrors platform-admin's shape verbatim and `poolsDrained`/`warnings` are admin-orgs-specific additives (platform-admin does no pool drain). All emissions carry `scope: "platform"` and a `clientIpFor(c)` helper reusing the `x-forwarded-for`/`x-real-ip` extraction from `platform-admin.ts`. Suspend emits audit BEFORE the drain call so a transient `drainOrg` rejection doesn't silently drop the row after the DB mutation already committed. Regression suite (`admin-orgs-audit.test.ts`) parametrises all four surfaces, calls the admin-orgs and platform-admin equivalents back-to-back with the same workspace stub, and compares canonical audit fields directly between entries (not against literal expectations) — a one-sided regression where both surfaces silently agree on the wrong value still breaks the suite. Pool-drain enabled path covered: `isOrgPoolingEnabled()` + `drainOrg()` overrides exercise both the success (`poolsDrained: N`) and failure (`warnings: ["pool_drain_failed: ..."]`) branches so a future rename of those metadata keys fails the suite. Option (a) — consolidating both surfaces into a shared `lib/workspace-mutations.ts` helper so the drift window closes at the write layer, not just the audit layer — remains a candidate refactor; the parity test makes future drift observable but does not prevent it.
 
 ---
 
@@ -1571,7 +1563,7 @@ Grep every `metadata: { ... }` literal on the admin-audit call sites. Sampled pa
 | F-28 | P1 | Audit gap | Admin session revocation (`admin-sessions.ts`, `admin.ts`) | #1783 | fixed (PR #1801) |
 | F-29 | P2 | Partial coverage | `admin-sso.ts`, `admin-connections.ts`, `scheduled-tasks.ts`, `admin-approval.ts`, `admin.ts` stragglers | #1784 | open |
 | F-30 | P1 | Credential-provenance | Email provider + model config (`admin-email-provider.ts`, `admin-model-config.ts`) | #1785 | open |
-| F-31 | P1 | Audit gap | Platform-admin workspace CRUD via `admin-orgs.ts` (post-F-08 drift) | #1786 | fixed (PR for #1786, option b) |
+| F-31 | P1 | Audit gap | Platform-admin workspace CRUD via `admin-orgs.ts` (post-F-08 drift) | #1786 | fixed (PR #1804) |
 | F-32 | P1 | Audit gap | Workspace enterprise config (`admin-domains.ts`, `admin-branding.ts`, `admin-residency.ts`, `admin-compliance.ts`) | #1787 | open |
 | F-33 | P2 | Split trail | Abuse reinstate writes to `abuse_events`, not `admin_action_log` | #1788 | open |
 | F-34 | P2 | Audit gap | Wizard connection path bypasses `connection.create` (`wizard.ts`, plus connection test/drain in `admin-connections.ts`) | #1789 | open |

--- a/.claude/research/security-audit-1-2-3.md
+++ b/.claude/research/security-audit-1-2-3.md
@@ -1085,7 +1085,7 @@ Totals at the file level; individual uncovered writes are enumerated under the f
 | `admin-marketplace.ts` | 6 | 6 | ✅ | `plugin.catalog_create` / `catalog_update` / `catalog_delete` + `catalog_cascade_uninstall` / `plugin.install` / `plugin.uninstall` / `plugin.config_update` — F-22 fixed |
 | `admin-migrate.ts` | 1 | 0 | ❌ | Schema migration trigger (F-37) |
 | `admin-model-config.ts` | 3 | 0 | ❌ | **LLM API key storage + deletion unaudited** (F-30) |
-| `admin-orgs.ts` | 4 | 0 | ❌ | Post-F-08 this is platform-admin only — but still unaudited (F-31) |
+| `admin-orgs.ts` | 4 | 4 | ✅ | F-31 fixed (PR for #1786, option b) — `workspace.suspend` / `workspace.unsuspend` / `workspace.change_plan` / `workspace.delete` emitted with `scope: "platform"`, matching `platform-admin.ts` contract exactly (same action_type, same metadata shape). Regression test locks canonical action types + parity with `/api/v1/platform/workspaces` endpoints |
 | `admin-plugins.ts` | 4 | 3 | ✅ | `plugin.enable` / `plugin.disable` / `plugin.config_update` audited; read-only health check stays silent — F-22 fixed |
 | `admin-prompts.ts` | 7 | 0 | ❌ | Content governance — collection + prompt CRUD (F-35) |
 | `admin-publish.ts` | 1 | 1 | ✅ | `mode.publish` |
@@ -1359,13 +1359,23 @@ None of these six routes call `logAdminAction`. All six write or test credential
 
 ---
 
-**F-31 — `admin-orgs.ts` is platform-gated post-F-08 but still emits no audit** — P1
+**F-31 — `admin-orgs.ts` is platform-gated post-F-08 but still emits no audit** — P1 — **FIXED (option b)**
 
 **Repro:** Phase-2 F-08 (PR #1762) moved workspace CRUD under `createPlatformRouter`. The role gate was fixed; the audit gap was not. Four writes remain silent: suspend / activate / delete / change plan.
 
 Overlap with `platform-admin.ts` — which DOES audit `workspace.suspend` / `unsuspend` / `delete` / `purge` / `change_plan`. There are now two workspace-mutation surfaces: `platform-admin.ts` (audited) and `admin-orgs.ts` (silent). Platform admins can pick the unaudited path and no one knows.
 
 **Fix sketch:** Either (a) delete the overlap — route every admin-orgs mutation through `platform-admin.ts` internally — or (b) add `logAdminAction` calls to `admin-orgs.ts` matching the `platform-admin.ts` contract. Option (a) is preferred: a single workspace-mutation surface reduces the chance of future drift.
+
+**Fix:** Option (b) shipped. `admin-orgs.ts` now emits `logAdminAction` at all four writes, reusing the `ADMIN_ACTIONS.workspace.*` catalog values unchanged (no new action types added — stays compatible with F-30 / F-32 parallel work). Canonical mapping:
+- `PATCH /:id/suspend` → `workspace.suspend`
+- `PATCH /:id/activate` → `workspace.unsuspend` (same action_type as platform-admin `POST /unsuspend`)
+- `PATCH /:id/plan` → `workspace.change_plan` with `metadata: { previousPlan, newPlan }`
+- `DELETE /:id` → `workspace.delete` with `metadata: { cleanup, poolsDrained, warnings? }`
+
+All emissions carry `scope: "platform"` and the same `x-forwarded-for`/`x-real-ip` IP extraction as `platform-admin.ts`. Regression test (`admin-orgs-audit.test.ts`) parametrises both surfaces and asserts identical action_type + scope + target for each, so a future divergence on either side breaks the suite.
+
+**Follow-up:** Option (a) — collapse the two workspace-mutation surfaces into a shared `lib/workspace-mutations.ts` helper so the drift window closes at the write layer, not just the audit layer — remains a candidate refactor. The parity test makes future drift observable but does not prevent it; a dedicated `refactor` issue should be filed separately if we want to pursue consolidation.
 
 **Severity:** P1 — drift between two parallel admin surfaces is a classic compliance pitfall. The write path exists, the audit path is forgotten.
 
@@ -1561,7 +1571,7 @@ Grep every `metadata: { ... }` literal on the admin-audit call sites. Sampled pa
 | F-28 | P1 | Audit gap | Admin session revocation (`admin-sessions.ts`, `admin.ts`) | #1783 | fixed (PR #1801) |
 | F-29 | P2 | Partial coverage | `admin-sso.ts`, `admin-connections.ts`, `scheduled-tasks.ts`, `admin-approval.ts`, `admin.ts` stragglers | #1784 | open |
 | F-30 | P1 | Credential-provenance | Email provider + model config (`admin-email-provider.ts`, `admin-model-config.ts`) | #1785 | open |
-| F-31 | P1 | Audit gap | Platform-admin workspace CRUD via `admin-orgs.ts` (post-F-08 drift) | #1786 | open |
+| F-31 | P1 | Audit gap | Platform-admin workspace CRUD via `admin-orgs.ts` (post-F-08 drift) | #1786 | fixed (PR for #1786, option b) |
 | F-32 | P1 | Audit gap | Workspace enterprise config (`admin-domains.ts`, `admin-branding.ts`, `admin-residency.ts`, `admin-compliance.ts`) | #1787 | open |
 | F-33 | P2 | Split trail | Abuse reinstate writes to `abuse_events`, not `admin_action_log` | #1788 | open |
 | F-34 | P2 | Audit gap | Wizard connection path bypasses `connection.create` (`wizard.ts`, plus connection test/drain in `admin-connections.ts`) | #1789 | open |

--- a/packages/api/src/api/__tests__/admin-orgs-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-orgs-audit.test.ts
@@ -1,0 +1,540 @@
+/**
+ * F-31 (#1786) — `admin-orgs.ts` workspace-mutation routes must emit the
+ * same `admin_action_log` rows as the parallel `platform-admin.ts` surface.
+ * Phase-2 F-08 (PR #1762) moved these routes under `createPlatformRouter`
+ * but left the audit trail silent, leaving two workspace-mutation surfaces
+ * in lockstep on authz and divergent on forensic coverage: a platform
+ * admin who wants to avoid an audit row just picks `admin-orgs`.
+ *
+ * Each admin-orgs write is tested both standalone (emits the right
+ * action_type / target / metadata) and against the platform-admin
+ * equivalent (identical canonical fields when exercised back-to-back).
+ * The parity pass locks the drift shut: future diverging metadata
+ * between the two routers makes the test scream.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterAll,
+  mock,
+  type Mock,
+} from "bun:test";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+
+// ---------------------------------------------------------------------------
+// Mocks — set up before app import
+// ---------------------------------------------------------------------------
+
+/**
+ * We manage `getWorkspaceDetails`, `updateWorkspaceStatus`,
+ * `updateWorkspacePlanTier`, and `cascadeWorkspaceDelete` ourselves so tests
+ * can stage a resolvable workspace for each route. Everything else stays on
+ * the shared factory defaults.
+ */
+interface WorkspaceStub {
+  id: string;
+  workspace_status: "active" | "suspended" | "deleted";
+  plan_tier: string;
+  [key: string]: unknown;
+}
+
+const mockGetWorkspaceDetails: Mock<
+  (orgId: string) => Promise<WorkspaceStub | null>
+> = mock(async () => null);
+const mockUpdateWorkspaceStatus = mock(async () => true);
+const mockUpdateWorkspacePlanTier = mock(async () => true);
+const mockCascadeWorkspaceDelete = mock(async () => ({
+  conversations: 3,
+  semanticEntities: 2,
+  learnedPatterns: 1,
+  suggestions: 0,
+  scheduledTasks: 0,
+  settings: 0,
+}));
+
+const mocks = createApiTestMocks({
+  authUser: {
+    id: "platform-admin-1",
+    mode: "managed",
+    label: "platform@test.com",
+    role: "platform_admin",
+    activeOrganizationId: "org-test",
+  },
+  authMode: "managed",
+  internal: {
+    getWorkspaceDetails: mockGetWorkspaceDetails,
+    updateWorkspaceStatus: mockUpdateWorkspaceStatus,
+    updateWorkspacePlanTier: mockUpdateWorkspacePlanTier,
+    cascadeWorkspaceDelete: mockCascadeWorkspaceDelete,
+  },
+});
+
+// Capture `logAdminAction` calls. Pass through the real `ADMIN_ACTIONS`
+// catalog so assertions pin to canonical string values — a drift in the
+// catalog would break this suite before hitting the audited route.
+interface AuditEntry {
+  actionType: string;
+  targetType: string;
+  targetId: string;
+  status?: "success" | "failure";
+  scope?: "platform" | "workspace";
+  ipAddress?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+const mockLogAdminAction: Mock<(entry: AuditEntry) => void> = mock(() => {});
+
+mock.module("@atlas/api/lib/audit", async () => {
+  const actual = await import("@atlas/api/lib/audit/actions");
+  return {
+    logAdminAction: mockLogAdminAction,
+    logAdminActionAwait: mock(async () => {}),
+    ADMIN_ACTIONS: actual.ADMIN_ACTIONS,
+  };
+});
+
+// Import the app AFTER mocks.
+const { app } = await import("../index");
+
+afterAll(() => mocks.cleanup());
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function platformRequest(
+  method: string,
+  path: string,
+  body?: unknown,
+  extraHeaders?: Record<string, string>,
+): Request {
+  const opts: RequestInit = {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer test-key",
+      ...extraHeaders,
+    },
+  };
+  if (body !== undefined) opts.body = JSON.stringify(body);
+  return new Request(`http://localhost${path}`, opts);
+}
+
+function makeWorkspace(overrides: Partial<WorkspaceStub> = {}): WorkspaceStub {
+  return {
+    id: "org-parity",
+    workspace_status: "active",
+    plan_tier: "starter",
+    name: "Parity Co",
+    slug: "parity-co",
+    ...overrides,
+  };
+}
+
+function lastAuditCall(): AuditEntry {
+  const calls = mockLogAdminAction.mock.calls;
+  if (calls.length === 0) throw new Error("logAdminAction was not called");
+  return calls[calls.length - 1]![0]!;
+}
+
+// Core parity invariants — every emission must agree on these fields
+// regardless of the surface. `metadata` is compared separately per route
+// because per-action-type metadata legitimately differs (e.g. `cleanup` on
+// delete vs. `previousPlan` on changePlan) but must match platform-admin's.
+function assertCoreAuditShape(entry: AuditEntry, expected: {
+  actionType: string;
+  targetId: string;
+}): void {
+  expect(entry.actionType).toBe(expected.actionType);
+  expect(entry.targetType).toBe("workspace");
+  expect(entry.targetId).toBe(expected.targetId);
+  expect(entry.scope).toBe("platform");
+  expect(entry.status ?? "success").toBe("success");
+}
+
+// ---------------------------------------------------------------------------
+// Reset state between tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mocks.hasInternalDB = true;
+  mocks.setPlatformAdmin("org-test");
+  mockLogAdminAction.mockClear();
+  mockGetWorkspaceDetails.mockReset();
+  mockUpdateWorkspaceStatus.mockReset();
+  mockUpdateWorkspacePlanTier.mockReset();
+  mockCascadeWorkspaceDelete.mockReset();
+  mockUpdateWorkspaceStatus.mockResolvedValue(true);
+  mockUpdateWorkspacePlanTier.mockResolvedValue(true);
+  mockCascadeWorkspaceDelete.mockResolvedValue({
+    conversations: 3,
+    semanticEntities: 2,
+    learnedPatterns: 1,
+    suggestions: 0,
+    scheduledTasks: 0,
+    settings: 0,
+  });
+  mocks.mockInternalQuery.mockReset();
+  mocks.mockInternalQuery.mockResolvedValue([]);
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /api/v1/admin/organizations/:id/suspend
+// ---------------------------------------------------------------------------
+
+describe("admin-orgs PATCH /:id/suspend — audit emission (F-31)", () => {
+  it("emits workspace.suspend with platform scope and targetId", async () => {
+    mockGetWorkspaceDetails
+      .mockResolvedValueOnce(makeWorkspace({ id: "org-parity", workspace_status: "active" }))
+      .mockResolvedValueOnce(makeWorkspace({ id: "org-parity", workspace_status: "suspended" }));
+
+    const res = await app.fetch(
+      platformRequest("PATCH", "/api/v1/admin/organizations/org-parity/suspend"),
+    );
+    expect(res.status).toBe(200);
+
+    const entry = lastAuditCall();
+    assertCoreAuditShape(entry, {
+      actionType: "workspace.suspend",
+      targetId: "org-parity",
+    });
+  });
+
+  it("does not emit when the workspace is already suspended (409)", async () => {
+    mockGetWorkspaceDetails.mockResolvedValue(
+      makeWorkspace({ id: "org-parity", workspace_status: "suspended" }),
+    );
+
+    const res = await app.fetch(
+      platformRequest("PATCH", "/api/v1/admin/organizations/org-parity/suspend"),
+    );
+    expect(res.status).toBe(409);
+    expect(mockLogAdminAction.mock.calls.length).toBe(0);
+  });
+
+  it("does not emit when the workspace is not found (404)", async () => {
+    mockGetWorkspaceDetails.mockResolvedValue(null);
+
+    const res = await app.fetch(
+      platformRequest("PATCH", "/api/v1/admin/organizations/org-missing/suspend"),
+    );
+    expect(res.status).toBe(404);
+    expect(mockLogAdminAction.mock.calls.length).toBe(0);
+  });
+
+  it("threads x-forwarded-for into ipAddress", async () => {
+    mockGetWorkspaceDetails
+      .mockResolvedValueOnce(makeWorkspace({ id: "org-parity", workspace_status: "active" }))
+      .mockResolvedValueOnce(makeWorkspace({ id: "org-parity", workspace_status: "suspended" }));
+
+    const res = await app.fetch(
+      platformRequest(
+        "PATCH",
+        "/api/v1/admin/organizations/org-parity/suspend",
+        undefined,
+        { "x-forwarded-for": "203.0.113.5" },
+      ),
+    );
+    expect(res.status).toBe(200);
+    expect(lastAuditCall().ipAddress).toBe("203.0.113.5");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /api/v1/admin/organizations/:id/activate
+// ---------------------------------------------------------------------------
+
+describe("admin-orgs PATCH /:id/activate — audit emission (F-31)", () => {
+  it("emits workspace.unsuspend (not workspace.activate) with platform scope", async () => {
+    mockGetWorkspaceDetails
+      .mockResolvedValueOnce(makeWorkspace({ id: "org-parity", workspace_status: "suspended" }))
+      .mockResolvedValueOnce(makeWorkspace({ id: "org-parity", workspace_status: "active" }));
+
+    const res = await app.fetch(
+      platformRequest("PATCH", "/api/v1/admin/organizations/org-parity/activate"),
+    );
+    expect(res.status).toBe(200);
+
+    // The canonical action_type is `workspace.unsuspend` (matching
+    // platform-admin.ts) — NOT `workspace.activate`. Compliance queries
+    // filtering on `action_type = 'workspace.unsuspend'` depend on this.
+    assertCoreAuditShape(lastAuditCall(), {
+      actionType: "workspace.unsuspend",
+      targetId: "org-parity",
+    });
+  });
+
+  it("does not emit when workspace is already active (409)", async () => {
+    mockGetWorkspaceDetails.mockResolvedValue(
+      makeWorkspace({ id: "org-parity", workspace_status: "active" }),
+    );
+
+    const res = await app.fetch(
+      platformRequest("PATCH", "/api/v1/admin/organizations/org-parity/activate"),
+    );
+    expect(res.status).toBe(409);
+    expect(mockLogAdminAction.mock.calls.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /api/v1/admin/organizations/:id/plan
+// ---------------------------------------------------------------------------
+
+describe("admin-orgs PATCH /:id/plan — audit emission (F-31)", () => {
+  it("emits workspace.change_plan with { previousPlan, newPlan } metadata", async () => {
+    mockGetWorkspaceDetails
+      .mockResolvedValueOnce(
+        makeWorkspace({ id: "org-parity", workspace_status: "active", plan_tier: "starter" }),
+      )
+      .mockResolvedValueOnce(
+        makeWorkspace({ id: "org-parity", workspace_status: "active", plan_tier: "pro" }),
+      );
+
+    const res = await app.fetch(
+      platformRequest(
+        "PATCH",
+        "/api/v1/admin/organizations/org-parity/plan",
+        { planTier: "pro" },
+      ),
+    );
+    expect(res.status).toBe(200);
+
+    const entry = lastAuditCall();
+    assertCoreAuditShape(entry, {
+      actionType: "workspace.change_plan",
+      targetId: "org-parity",
+    });
+    // Metadata shape mirrors platform-admin.ts:
+    //   { previousPlan: <old tier>, newPlan: <new tier> }
+    expect(entry.metadata).toEqual({ previousPlan: "starter", newPlan: "pro" });
+  });
+
+  it("does not emit on invalid plan tier (400)", async () => {
+    mockGetWorkspaceDetails.mockResolvedValue(
+      makeWorkspace({ id: "org-parity", workspace_status: "active", plan_tier: "starter" }),
+    );
+
+    const res = await app.fetch(
+      platformRequest(
+        "PATCH",
+        "/api/v1/admin/organizations/org-parity/plan",
+        { planTier: "not-a-tier" },
+      ),
+    );
+    expect(res.status).toBe(400);
+    expect(mockLogAdminAction.mock.calls.length).toBe(0);
+  });
+
+  it("does not emit when workspace is deleted (409)", async () => {
+    mockGetWorkspaceDetails.mockResolvedValue(
+      makeWorkspace({ id: "org-parity", workspace_status: "deleted", plan_tier: "starter" }),
+    );
+
+    const res = await app.fetch(
+      platformRequest(
+        "PATCH",
+        "/api/v1/admin/organizations/org-parity/plan",
+        { planTier: "pro" },
+      ),
+    );
+    expect(res.status).toBe(409);
+    expect(mockLogAdminAction.mock.calls.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/v1/admin/organizations/:id
+// ---------------------------------------------------------------------------
+
+describe("admin-orgs DELETE /:id — audit emission (F-31)", () => {
+  it("emits workspace.delete with cleanup metadata after a successful cascade", async () => {
+    mockGetWorkspaceDetails.mockResolvedValue(
+      makeWorkspace({ id: "org-parity", workspace_status: "active" }),
+    );
+
+    const res = await app.fetch(
+      platformRequest("DELETE", "/api/v1/admin/organizations/org-parity"),
+    );
+    expect(res.status).toBe(200);
+
+    const entry = lastAuditCall();
+    assertCoreAuditShape(entry, {
+      actionType: "workspace.delete",
+      targetId: "org-parity",
+    });
+    // `cleanup` matches platform-admin.ts — the cascade return shape flows
+    // into metadata.cleanup verbatim.
+    expect(entry.metadata).toMatchObject({
+      cleanup: {
+        conversations: 3,
+        semanticEntities: 2,
+        learnedPatterns: 1,
+        suggestions: 0,
+        scheduledTasks: 0,
+        settings: 0,
+      },
+    });
+  });
+
+  it("does not emit when workspace is already deleted (409)", async () => {
+    mockGetWorkspaceDetails.mockResolvedValue(
+      makeWorkspace({ id: "org-parity", workspace_status: "deleted" }),
+    );
+
+    const res = await app.fetch(
+      platformRequest("DELETE", "/api/v1/admin/organizations/org-parity"),
+    );
+    expect(res.status).toBe(409);
+    expect(mockLogAdminAction.mock.calls.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Parity with /api/v1/platform/workspaces — same action_type per surface
+// ---------------------------------------------------------------------------
+
+describe("admin-orgs ↔ platform-admin parity (F-31)", () => {
+  const SURFACES: ReadonlyArray<{
+    name: string;
+    adminOrgs: { method: string; path: (id: string) => string; body?: unknown };
+    platform: { method: string; path: (id: string) => string; body?: unknown };
+    expected: { actionType: string; metadataKeys?: ReadonlyArray<string> };
+    preFetchCount: number;
+  }> = [
+    {
+      name: "suspend",
+      adminOrgs: {
+        method: "PATCH",
+        path: (id) => `/api/v1/admin/organizations/${id}/suspend`,
+      },
+      platform: {
+        method: "POST",
+        path: (id) => `/api/v1/platform/workspaces/${id}/suspend`,
+      },
+      expected: { actionType: "workspace.suspend" },
+      preFetchCount: 2,
+    },
+    {
+      name: "unsuspend / activate",
+      adminOrgs: {
+        method: "PATCH",
+        path: (id) => `/api/v1/admin/organizations/${id}/activate`,
+      },
+      platform: {
+        method: "POST",
+        path: (id) => `/api/v1/platform/workspaces/${id}/unsuspend`,
+      },
+      expected: { actionType: "workspace.unsuspend" },
+      preFetchCount: 2,
+    },
+    {
+      name: "change plan",
+      adminOrgs: {
+        method: "PATCH",
+        path: (id) => `/api/v1/admin/organizations/${id}/plan`,
+        body: { planTier: "pro" },
+      },
+      platform: {
+        method: "PATCH",
+        path: (id) => `/api/v1/platform/workspaces/${id}/plan`,
+        body: { planTier: "pro" },
+      },
+      expected: {
+        actionType: "workspace.change_plan",
+        metadataKeys: ["previousPlan", "newPlan"],
+      },
+      preFetchCount: 2,
+    },
+    {
+      name: "delete",
+      adminOrgs: {
+        method: "DELETE",
+        path: (id) => `/api/v1/admin/organizations/${id}`,
+      },
+      platform: {
+        method: "DELETE",
+        path: (id) => `/api/v1/platform/workspaces/${id}`,
+      },
+      expected: {
+        actionType: "workspace.delete",
+        metadataKeys: ["cleanup"],
+      },
+      preFetchCount: 1,
+    },
+  ];
+
+  for (const surface of SURFACES) {
+    it(`${surface.name} emits identical action_type + scope on both surfaces`, async () => {
+      // ── Call admin-orgs surface ────────────────────────────────
+      const wsForAdminOrgs: WorkspaceStub =
+        surface.name === "unsuspend / activate"
+          ? makeWorkspace({
+              id: "org-parity",
+              workspace_status: "suspended",
+              plan_tier: "starter",
+            })
+          : makeWorkspace({
+              id: "org-parity",
+              workspace_status: "active",
+              plan_tier: "starter",
+            });
+
+      mockGetWorkspaceDetails.mockReset();
+      // admin-orgs pre-fetches the workspace; suspend/activate/plan also
+      // re-fetch after the mutation for the response body.
+      for (let i = 0; i < surface.preFetchCount; i++) {
+        mockGetWorkspaceDetails.mockResolvedValueOnce(wsForAdminOrgs);
+      }
+      mockLogAdminAction.mockClear();
+
+      const res1 = await app.fetch(
+        platformRequest(
+          surface.adminOrgs.method,
+          surface.adminOrgs.path("org-parity"),
+          surface.adminOrgs.body,
+        ),
+      );
+      expect(res1.status).toBe(200);
+      const adminOrgsEntry = lastAuditCall();
+
+      // ── Call platform-admin surface ────────────────────────────
+      mockGetWorkspaceDetails.mockReset();
+      mockGetWorkspaceDetails.mockResolvedValue(wsForAdminOrgs);
+      mockLogAdminAction.mockClear();
+
+      const res2 = await app.fetch(
+        platformRequest(
+          surface.platform.method,
+          surface.platform.path("org-parity"),
+          surface.platform.body,
+        ),
+      );
+      expect(res2.status).toBe(200);
+      const platformEntry = lastAuditCall();
+
+      // ── Assert parity on canonical fields ──────────────────────
+      expect(adminOrgsEntry.actionType).toBe(surface.expected.actionType);
+      expect(platformEntry.actionType).toBe(surface.expected.actionType);
+      expect(adminOrgsEntry.targetType).toBe(platformEntry.targetType);
+      expect(adminOrgsEntry.targetType).toBe("workspace");
+      expect(adminOrgsEntry.targetId).toBe(platformEntry.targetId);
+      expect(adminOrgsEntry.scope).toBe(platformEntry.scope);
+      expect(adminOrgsEntry.scope).toBe("platform");
+      expect(adminOrgsEntry.status ?? "success").toBe(
+        platformEntry.status ?? "success",
+      );
+
+      // ── Assert metadata-key parity where applicable ────────────
+      if (surface.expected.metadataKeys) {
+        for (const k of surface.expected.metadataKeys) {
+          expect(adminOrgsEntry.metadata).toHaveProperty(k);
+          expect(platformEntry.metadata).toHaveProperty(k);
+        }
+      }
+    });
+  }
+});

--- a/packages/api/src/api/__tests__/admin-orgs-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-orgs-audit.test.ts
@@ -1,16 +1,12 @@
 /**
- * F-31 (#1786) — `admin-orgs.ts` workspace-mutation routes must emit the
- * same `admin_action_log` rows as the parallel `platform-admin.ts` surface.
- * Phase-2 F-08 (PR #1762) moved these routes under `createPlatformRouter`
- * but left the audit trail silent, leaving two workspace-mutation surfaces
- * in lockstep on authz and divergent on forensic coverage: a platform
- * admin who wants to avoid an audit row just picks `admin-orgs`.
+ * Parity suite: every `admin-orgs.ts` workspace write must emit the same
+ * canonical `admin_action_log` fields (`action_type`, `target_type`,
+ * `target_id`, `scope`) as the matching `/api/v1/platform/workspaces`
+ * route. Each surface is tested standalone for shape + failure silence,
+ * then the parity block hits both back-to-back and compares entries
+ * directly. Future drift on either router breaks the suite.
  *
- * Each admin-orgs write is tested both standalone (emits the right
- * action_type / target / metadata) and against the platform-admin
- * equivalent (identical canonical fields when exercised back-to-back).
- * The parity pass locks the drift shut: future diverging metadata
- * between the two routers makes the test scream.
+ * Backstory: F-31 (#1786) of the 1.2.3 security sweep.
  */
 
 import {
@@ -55,6 +51,14 @@ const mockCascadeWorkspaceDelete = mock(async () => ({
   settings: 0,
 }));
 
+// Pool mocks are overridable per-test so the delete-handler `poolsDrained`
+// / `warnings` metadata branches can be exercised. Default: pooling off
+// (matches the rest of the factory defaults so existing assertions hold).
+const mockIsOrgPoolingEnabled: Mock<() => boolean> = mock(() => false);
+const mockDrainOrg: Mock<(orgId: string) => Promise<{ drained: number }>> = mock(
+  async () => ({ drained: 0 }),
+);
+
 const mocks = createApiTestMocks({
   authUser: {
     id: "platform-admin-1",
@@ -69,6 +73,23 @@ const mocks = createApiTestMocks({
     updateWorkspaceStatus: mockUpdateWorkspaceStatus,
     updateWorkspacePlanTier: mockUpdateWorkspacePlanTier,
     cascadeWorkspaceDelete: mockCascadeWorkspaceDelete,
+  },
+  connection: {
+    connections: {
+      get: () => null,
+      getDefault: () => null,
+      describe: () => [{ id: "default", dbType: "postgres" }],
+      healthCheck: mock(() =>
+        Promise.resolve({ status: "healthy", latencyMs: 1, checkedAt: new Date() }),
+      ),
+      register: mock(() => {}),
+      unregister: mock(() => {}),
+      has: mock(() => false),
+      getForOrg: () => null,
+      isOrgPoolingEnabled: mockIsOrgPoolingEnabled,
+      drainOrg: mockDrainOrg,
+    },
+    resolveDatasourceUrl: () => "postgresql://stub",
   },
 });
 
@@ -177,6 +198,10 @@ beforeEach(() => {
     scheduledTasks: 0,
     settings: 0,
   });
+  mockIsOrgPoolingEnabled.mockReset();
+  mockIsOrgPoolingEnabled.mockReturnValue(false);
+  mockDrainOrg.mockReset();
+  mockDrainOrg.mockResolvedValue({ drained: 0 });
   mocks.mockInternalQuery.mockReset();
   mocks.mockInternalQuery.mockResolvedValue([]);
 });
@@ -241,6 +266,32 @@ describe("admin-orgs PATCH /:id/suspend — audit emission (F-31)", () => {
     expect(res.status).toBe(200);
     expect(lastAuditCall().ipAddress).toBe("203.0.113.5");
   });
+
+  it("emits the audit row even when pool drain fails after the mutation commits", async () => {
+    // The motivating bug for F-31: if `updateWorkspaceStatus` commits
+    // and `drainOrg` then throws, the workspace is suspended in the DB
+    // but no audit row is emitted. Proved by placing the audit call
+    // BEFORE the drain in the handler — a drain rejection still fails
+    // the response but the `admin_action_log` row has landed.
+    mockGetWorkspaceDetails.mockResolvedValue(
+      makeWorkspace({ id: "org-parity", workspace_status: "active" }),
+    );
+    mockIsOrgPoolingEnabled.mockReturnValue(true);
+    mockDrainOrg.mockRejectedValue(new Error("pool stuck"));
+
+    const res = await app.fetch(
+      platformRequest("PATCH", "/api/v1/admin/organizations/org-parity/suspend"),
+    );
+    // Drain failure still surfaces as a 500 — the caller retries —
+    // but the audit row must persist regardless.
+    expect(res.status).toBe(500);
+    expect(mockLogAdminAction.mock.calls.length).toBe(1);
+    expect(lastAuditCall().actionType).toBe("workspace.suspend");
+    expect(mockUpdateWorkspaceStatus).toHaveBeenCalledWith(
+      "org-parity",
+      "suspended",
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -276,6 +327,16 @@ describe("admin-orgs PATCH /:id/activate — audit emission (F-31)", () => {
       platformRequest("PATCH", "/api/v1/admin/organizations/org-parity/activate"),
     );
     expect(res.status).toBe(409);
+    expect(mockLogAdminAction.mock.calls.length).toBe(0);
+  });
+
+  it("does not emit when the workspace is not found (404)", async () => {
+    mockGetWorkspaceDetails.mockResolvedValue(null);
+
+    const res = await app.fetch(
+      platformRequest("PATCH", "/api/v1/admin/organizations/org-missing/activate"),
+    );
+    expect(res.status).toBe(404);
     expect(mockLogAdminAction.mock.calls.length).toBe(0);
   });
 });
@@ -390,6 +451,66 @@ describe("admin-orgs DELETE /:id — audit emission (F-31)", () => {
     );
     expect(res.status).toBe(409);
     expect(mockLogAdminAction.mock.calls.length).toBe(0);
+  });
+
+  it("does not emit when the workspace is not found (404)", async () => {
+    mockGetWorkspaceDetails.mockResolvedValue(null);
+
+    const res = await app.fetch(
+      platformRequest("DELETE", "/api/v1/admin/organizations/org-missing"),
+    );
+    expect(res.status).toBe(404);
+    expect(mockLogAdminAction.mock.calls.length).toBe(0);
+  });
+
+  it("records poolsDrained in metadata when org pooling is enabled", async () => {
+    // Default mock has pooling off, so the happy-path test above never
+    // exercises the `poolsDrained` branch. Turn pooling on here and
+    // assert the count flows from `drainOrg`'s return into metadata —
+    // catches a rename of this metadata key.
+    mockGetWorkspaceDetails.mockResolvedValue(
+      makeWorkspace({ id: "org-parity", workspace_status: "active" }),
+    );
+    mockIsOrgPoolingEnabled.mockReturnValue(true);
+    mockDrainOrg.mockResolvedValue({ drained: 3 });
+
+    const res = await app.fetch(
+      platformRequest("DELETE", "/api/v1/admin/organizations/org-parity"),
+    );
+    expect(res.status).toBe(200);
+    expect(mockDrainOrg).toHaveBeenCalledWith("org-parity");
+
+    const entry = lastAuditCall();
+    expect(entry.metadata).toMatchObject({ poolsDrained: 3 });
+    // `warnings` only appears on drain failure — happy path omits it.
+    expect(entry.metadata).not.toHaveProperty("warnings");
+  });
+
+  it("records a warnings array in metadata when drainOrg fails", async () => {
+    // The delete handler is fail-open on drain (distinct from suspend,
+    // which is fail-closed): the cascade still commits, the status
+    // still flips to "deleted", and the audit row records a
+    // `pool_drain_failed: <message>` warning so partial cleanup is
+    // visible in the trail.
+    mockGetWorkspaceDetails.mockResolvedValue(
+      makeWorkspace({ id: "org-parity", workspace_status: "active" }),
+    );
+    mockIsOrgPoolingEnabled.mockReturnValue(true);
+    mockDrainOrg.mockRejectedValue(new Error("pool was stuck"));
+
+    const res = await app.fetch(
+      platformRequest("DELETE", "/api/v1/admin/organizations/org-parity"),
+    );
+    expect(res.status).toBe(200);
+
+    const entry = lastAuditCall();
+    expect(entry.metadata).toHaveProperty("warnings");
+    const warnings = (entry.metadata as { warnings: unknown }).warnings as string[];
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/^pool_drain_failed: /);
+    expect(warnings[0]).toContain("pool was stuck");
+    // poolsDrained still recorded (stays 0 on failure).
+    expect(entry.metadata).toMatchObject({ poolsDrained: 0 });
   });
 });
 
@@ -516,23 +637,35 @@ describe("admin-orgs ↔ platform-admin parity (F-31)", () => {
       expect(res2.status).toBe(200);
       const platformEntry = lastAuditCall();
 
-      // ── Assert parity on canonical fields ──────────────────────
-      expect(adminOrgsEntry.actionType).toBe(surface.expected.actionType);
-      expect(platformEntry.actionType).toBe(surface.expected.actionType);
-      expect(adminOrgsEntry.targetType).toBe(platformEntry.targetType);
-      expect(adminOrgsEntry.targetType).toBe("workspace");
-      expect(adminOrgsEntry.targetId).toBe(platformEntry.targetId);
-      expect(adminOrgsEntry.scope).toBe(platformEntry.scope);
-      expect(adminOrgsEntry.scope).toBe("platform");
-      expect(adminOrgsEntry.status ?? "success").toBe(
-        platformEntry.status ?? "success",
-      );
+      // Snapshot the canonical fields from each surface and compare
+      // entries DIRECTLY. Per-route describe blocks above already pin
+      // each surface to its expected literal values — this block pins
+      // the two surfaces to each other so a one-sided regression where
+      // both agree on the wrong value (e.g. both scope: "workspace")
+      // still breaks the suite.
+      const canonical = (entry: AuditEntry) => ({
+        actionType: entry.actionType,
+        targetType: entry.targetType,
+        targetId: entry.targetId,
+        scope: entry.scope,
+        status: entry.status ?? "success",
+      });
+      expect(canonical(adminOrgsEntry)).toEqual(canonical(platformEntry));
 
-      // ── Assert metadata-key parity where applicable ────────────
+      // Metadata-key + value parity for canonical keys. Both surfaces
+      // read the same pre-mutation workspace stub and call the same
+      // cascade mock, so canonical metadata values must be identical;
+      // a surface-specific divergence on e.g. `previousPlan` capture
+      // point would break this.
       if (surface.expected.metadataKeys) {
         for (const k of surface.expected.metadataKeys) {
           expect(adminOrgsEntry.metadata).toHaveProperty(k);
           expect(platformEntry.metadata).toHaveProperty(k);
+          expect(
+            (adminOrgsEntry.metadata as Record<string, unknown>)[k],
+          ).toEqual(
+            (platformEntry.metadata as Record<string, unknown>)[k],
+          );
         }
       }
     });

--- a/packages/api/src/api/routes/admin-orgs.ts
+++ b/packages/api/src/api/routes/admin-orgs.ts
@@ -8,6 +8,7 @@
 
 import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
+import type { Context } from "hono";
 import { createLogger } from "@atlas/api/lib/logger";
 import {
   hasInternalDB,
@@ -23,6 +24,7 @@ import {
 import { connections } from "@atlas/api/lib/db/connection";
 import { flushCache } from "@atlas/api/lib/cache/index";
 import { invalidatePlanCache } from "@atlas/api/lib/billing/enforcement";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
 import { ErrorSchema, AuthErrorSchema, createIdParamSchema } from "./shared-schemas";
@@ -511,6 +513,15 @@ const updatePlanRoute = createRoute({
 // Router
 // ---------------------------------------------------------------------------
 
+/**
+ * Extract the client IP the same way platform-admin.ts does so both
+ * surfaces stamp `admin_action_log.ip_address` identically — required
+ * for F-31 parity (#1786).
+ */
+function clientIpFor(c: Context): string | null {
+  return c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null;
+}
+
 const adminOrgs = createPlatformRouter();
 
 // GET / — list all organizations
@@ -600,6 +611,13 @@ adminOrgs.openapi(suspendOrgRoute, async (c) => {
     if (connections.isOrgPoolingEnabled()) yield* Effect.promise(() => connections.drainOrg(orgId));
 
     log.info({ orgId, requestId, admin: user?.id }, "Workspace suspended");
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.workspace.suspend,
+      targetType: "workspace",
+      targetId: orgId,
+      scope: "platform",
+      ipAddress: clientIpFor(c),
+    });
     const updated = yield* Effect.promise(() => getWorkspaceDetails(orgId));
     return c.json({ message: "Workspace suspended. All queries are blocked until reactivation.", organization: updated }, 200);
   }), { label: "suspend workspace" });
@@ -620,6 +638,16 @@ adminOrgs.openapi(activateOrgRoute, async (c) => {
 
     yield* Effect.promise(() => updateWorkspaceStatus(orgId, "active"));
     log.info({ orgId, requestId, admin: user?.id }, "Workspace activated");
+    // Canonical action_type is `workspace.unsuspend` — matches
+    // platform-admin.ts so compliance queries see one row shape per
+    // intent, not two (F-31, #1786).
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.workspace.unsuspend,
+      targetType: "workspace",
+      targetId: orgId,
+      scope: "platform",
+      ipAddress: clientIpFor(c),
+    });
     const updated = yield* Effect.promise(() => getWorkspaceDetails(orgId));
     return c.json({ message: "Workspace activated. Normal operations resumed.", organization: updated }, 200);
   }), { label: "activate workspace" });
@@ -668,6 +696,23 @@ adminOrgs.openapi(deleteOrgRoute, async (c) => {
     });
 
     log.info({ orgId, requestId, admin: user?.id, cascade, poolsDrained, warnings }, "Workspace soft-deleted with cascading cleanup");
+    // `cleanup` key mirrors platform-admin.ts exactly. `poolsDrained` /
+    // `warnings` are admin-orgs-specific (pool drain has no equivalent
+    // in platform-admin.ts) but are additive — the parity contract is
+    // "same action_type + same `cleanup` subshape", not "identical
+    // metadata keyset".
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.workspace.delete,
+      targetType: "workspace",
+      targetId: orgId,
+      scope: "platform",
+      metadata: {
+        cleanup: cascade,
+        poolsDrained,
+        ...(warnings.length > 0 ? { warnings } : {}),
+      },
+      ipAddress: clientIpFor(c),
+    });
     return c.json({
       message: warnings.length > 0
         ? "Workspace deleted, but cleanup was partial — see warnings."
@@ -714,9 +759,18 @@ adminOrgs.openapi(updatePlanRoute, async (c) => {
     if (!workspace) return c.json({ error: "not_found", message: "Organization not found." }, 404);
     if (workspace.workspace_status === "deleted") return c.json({ error: "conflict", message: "Cannot update plan for a deleted workspace." }, 409);
 
+    const previousPlan = workspace.plan_tier;
     yield* Effect.promise(() => updateWorkspacePlanTier(orgId, body.planTier as PlanTier));
     invalidatePlanCache(orgId);
     log.info({ orgId, requestId, admin: user?.id, planTier: body.planTier }, "Workspace plan tier updated");
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.workspace.changePlan,
+      targetType: "workspace",
+      targetId: orgId,
+      scope: "platform",
+      metadata: { previousPlan, newPlan: body.planTier },
+      ipAddress: clientIpFor(c),
+    });
 
     const updated = yield* Effect.promise(() => getWorkspaceDetails(orgId));
     return c.json({ message: `Plan tier updated to ${body.planTier}.`, organization: updated }, 200);

--- a/packages/api/src/api/routes/admin-orgs.ts
+++ b/packages/api/src/api/routes/admin-orgs.ts
@@ -608,9 +608,10 @@ adminOrgs.openapi(suspendOrgRoute, async (c) => {
     if (workspace.workspace_status === "suspended") return c.json({ error: "conflict", message: "Workspace is already suspended." }, 409);
 
     yield* Effect.promise(() => updateWorkspaceStatus(orgId, "suspended"));
-    if (connections.isOrgPoolingEnabled()) yield* Effect.promise(() => connections.drainOrg(orgId));
-
-    log.info({ orgId, requestId, admin: user?.id }, "Workspace suspended");
+    // Audit the mutation commit BEFORE the pool drain — a transient
+    // `drainOrg` rejection must not silently drop the audit row after
+    // the DB already flipped to suspended. Drain failure still fails
+    // the response (the caller retries); the audit trail persists.
     logAdminAction({
       actionType: ADMIN_ACTIONS.workspace.suspend,
       targetType: "workspace",
@@ -618,6 +619,9 @@ adminOrgs.openapi(suspendOrgRoute, async (c) => {
       scope: "platform",
       ipAddress: clientIpFor(c),
     });
+    if (connections.isOrgPoolingEnabled()) yield* Effect.promise(() => connections.drainOrg(orgId));
+
+    log.info({ orgId, requestId, admin: user?.id }, "Workspace suspended");
     const updated = yield* Effect.promise(() => getWorkspaceDetails(orgId));
     return c.json({ message: "Workspace suspended. All queries are blocked until reactivation.", organization: updated }, 200);
   }), { label: "suspend workspace" });
@@ -638,9 +642,10 @@ adminOrgs.openapi(activateOrgRoute, async (c) => {
 
     yield* Effect.promise(() => updateWorkspaceStatus(orgId, "active"));
     log.info({ orgId, requestId, admin: user?.id }, "Workspace activated");
-    // Canonical action_type is `workspace.unsuspend` — matches
-    // platform-admin.ts so compliance queries see one row shape per
-    // intent, not two (F-31, #1786).
+    // Canonical action_type is `workspace.unsuspend` (not
+    // `workspace.activate`) — the endpoint path deliberately differs
+    // from the audit event so compliance queries filtering on a single
+    // action_type catch both the platform-admin and admin-orgs paths.
     logAdminAction({
       actionType: ADMIN_ACTIONS.workspace.unsuspend,
       targetType: "workspace",
@@ -696,11 +701,8 @@ adminOrgs.openapi(deleteOrgRoute, async (c) => {
     });
 
     log.info({ orgId, requestId, admin: user?.id, cascade, poolsDrained, warnings }, "Workspace soft-deleted with cascading cleanup");
-    // `cleanup` key mirrors platform-admin.ts exactly. `poolsDrained` /
-    // `warnings` are admin-orgs-specific (pool drain has no equivalent
-    // in platform-admin.ts) but are additive — the parity contract is
-    // "same action_type + same `cleanup` subshape", not "identical
-    // metadata keyset".
+    // `cleanup` mirrors platform-admin.ts. `poolsDrained`/`warnings`
+    // are additive — admin-orgs drains pools, platform-admin doesn't.
     logAdminAction({
       actionType: ADMIN_ACTIONS.workspace.delete,
       targetType: "workspace",


### PR DESCRIPTION
## Summary

- Closes #1786 — F-31 of the 1.2.3 security sweep.
- `admin-orgs.ts` was platform-gated in phase-2 F-08 (PR #1762) but its four workspace writes still emitted no `admin_action_log` rows, diverging from the equivalent `platform-admin.ts` surface. A platform admin who wanted to avoid an audit trail could just pick `admin-orgs`.
- Option (b) from the issue — add `logAdminAction` to all four writes reusing the existing `ADMIN_ACTIONS.workspace.*` catalog values. No new action types, no conflict with F-30 / F-32 parallel sessions.

## Canonical emissions

| Route | Action type | Metadata |
| --- | --- | --- |
| `PATCH /:id/suspend` | `workspace.suspend` | — |
| `PATCH /:id/activate` | `workspace.unsuspend` | — |
| `PATCH /:id/plan` | `workspace.change_plan` | `{ previousPlan, newPlan }` |
| `DELETE /:id` | `workspace.delete` | `{ cleanup, poolsDrained, warnings? }` |

All emissions carry `scope: "platform"` and the same `x-forwarded-for`/`x-real-ip` IP extraction as `platform-admin.ts`, so rows land with identical canonical fields regardless of which surface the admin hit.

Activate → `workspace.unsuspend` (not a new `workspace.activate` type) so compliance queries filtering on `action_type = 'workspace.unsuspend'` stay correct across both surfaces.

## Regression guard

`packages/api/src/api/__tests__/admin-orgs-audit.test.ts` does three things:

1. Asserts each of the four admin-orgs writes emits the right action type + scope + target + metadata.
2. Asserts no emission on 404 / 409 / 400 paths (failure cases don't pollute the audit trail).
3. **Parity pass** — parametrises over all four surfaces, calls both the admin-orgs route and the equivalent `/api/v1/platform/workspaces` route with the same workspace, then asserts identical action_type / target_type / scope on the two emissions. Future drift on either router breaks the suite.

## Follow-up

Option (a) — consolidate both surfaces into a shared `lib/workspace-mutations.ts` helper so the drift window closes at the write layer, not just the audit layer — stays open as a separate `refactor` candidate. The parity test makes divergence observable but does not prevent it.

## Test plan

- [x] `bun run lint`
- [x] `bun run type`
- [x] `bun run test` — all packages green, 15/15 new audit tests pass, 49/49 existing admin-orgs gate tests still pass
- [x] `bun x syncpack lint`
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh`