### PR TITLE
fix(security): 1.2.3 phase 4 — F-30 BYOT credential audit emission

### DIFF
--- a/.claude/research/security-audit-1-2-3.md
+++ b/.claude/research/security-audit-1-2-3.md
@@ -1077,14 +1077,14 @@ Totals at the file level; individual uncovered writes are enumerated under the f
 | `admin-compliance.ts` | 2 | 0 | ❌ | PUT retention policy + DELETE PII config (F-32) |
 | `admin-connections.ts` | 7 | 3 | 🟡 | Create/update/delete audited; **test / /:id/test / pool drain unaudited** (F-34) |
 | `admin-domains.ts` | 4 | 0 | ❌ | Workspace custom domain + verify (F-32) |
-| `admin-email-provider.ts` | 3 | 0 | ❌ | **BYOT credential mgmt unaudited** (F-30) |
+| `admin-email-provider.ts` | 3 | 3 | ✅ | F-30 fixed (PR for #1785) — `email_provider.update` / `delete` / `test` emitted with success + failure paths; update carries `hasSecret: true` marker, delete captures prior provider pre-delete, test includes recipient + delivery outcome |
 | `admin-integrations.ts` | 19 | 18 | 🟡 | Most install/uninstall emit `integration.*`; **one handler missing an audit call** — see F-29 |
 | `admin-invitations.ts` | 2 | 1 | 🟡 | `user.invite` audited; **`DELETE /users/invitations/{id}` revoke is silent** — see F-29 |
 | `admin-ip-allowlist.ts` | 2 | 0 | ❌ | **Per phase-4 scope: CRITICAL** (F-24) |
 | `admin-learned-patterns.ts` | 3 | 3 | ✅ | `pattern.approve` / `pattern.reject` / `pattern.delete` |
 | `admin-marketplace.ts` | 6 | 6 | ✅ | `plugin.catalog_create` / `catalog_update` / `catalog_delete` + `catalog_cascade_uninstall` / `plugin.install` / `plugin.uninstall` / `plugin.config_update` — F-22 fixed |
 | `admin-migrate.ts` | 1 | 0 | ❌ | Schema migration trigger (F-37) |
-| `admin-model-config.ts` | 3 | 0 | ❌ | **LLM API key storage + deletion unaudited** (F-30) |
+| `admin-model-config.ts` | 3 | 3 | ✅ | F-30 fixed (PR for #1785) — `model_config.update` / `delete` / `test` emitted with success + failure paths; metadata carries `hasSecret` marker and never the apiKey value; test route audits success + failure to close the credential-oracle gap |
 | `admin-orgs.ts` | 4 | 4 | ✅ | F-31 fixed (PR #1804) — `workspace.suspend` / `workspace.unsuspend` / `workspace.change_plan` / `workspace.delete` emitted with `scope: "platform"`, matching `platform-admin.ts` canonical fields exactly. Regression test compares entries directly across both surfaces |
 | `admin-plugins.ts` | 4 | 3 | ✅ | `plugin.enable` / `plugin.disable` / `plugin.config_update` audited; read-only health check stays silent — F-22 fixed |
 | `admin-prompts.ts` | 7 | 0 | ❌ | Content governance — collection + prompt CRUD (F-35) |
@@ -1562,7 +1562,7 @@ Grep every `metadata: { ... }` literal on the admin-audit call sites. Sampled pa
 | F-27 | P1 | Self-audit | EE purge scheduler + retention mutations (`ee/audit/*`) | #1782 | open |
 | F-28 | P1 | Audit gap | Admin session revocation (`admin-sessions.ts`, `admin.ts`) | #1783 | fixed (PR #1801) |
 | F-29 | P2 | Partial coverage | `admin-sso.ts`, `admin-connections.ts`, `scheduled-tasks.ts`, `admin-approval.ts`, `admin.ts` stragglers | #1784 | open |
-| F-30 | P1 | Credential-provenance | Email provider + model config (`admin-email-provider.ts`, `admin-model-config.ts`) | #1785 | open |
+| F-30 | P1 | Credential-provenance | Email provider + model config (`admin-email-provider.ts`, `admin-model-config.ts`) | #1785 | fixed (PR for #1785) |
 | F-31 | P1 | Audit gap | Platform-admin workspace CRUD via `admin-orgs.ts` (post-F-08 drift) | #1786 | fixed (PR #1804) |
 | F-32 | P1 | Audit gap | Workspace enterprise config (`admin-domains.ts`, `admin-branding.ts`, `admin-residency.ts`, `admin-compliance.ts`) | #1787 | open |
 | F-33 | P2 | Split trail | Abuse reinstate writes to `abuse_events`, not `admin_action_log` | #1788 | open |

--- a/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
+++ b/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
@@ -305,12 +305,35 @@ mock.module("@atlas/api/lib/auth/server", () => ({
   getAuthServer: mock(() => ({ handler: mock(() => Promise.resolve(new Response("{}"))) })),
 }));
 
-mock.module("@atlas/api/lib/audit", () => ({
-  logAdminAction: mock(() => {}),
-  logAdminActionAwait: mock(async () => {}),
-  ADMIN_ACTIONS: new Proxy({}, { get: () => new Proxy({}, { get: () => "noop" }) }),
-  _resetAuditLog: () => {},
-}));
+// --- Audit capture ---
+// Intercept every logAdminAction so tests can assert audit shape without
+// booting the internal DB. The real ADMIN_ACTIONS catalog is re-exported so
+// route emissions use the canonical string values — a drift catches both
+// the route and the catalog at once.
+
+interface CapturedAuditEntry {
+  actionType: string;
+  targetType: string;
+  targetId: string;
+  status?: "success" | "failure";
+  metadata?: Record<string, unknown>;
+  scope?: "platform" | "workspace";
+  ipAddress?: string | null;
+}
+
+const mockLogAdminAction: Mock<(entry: CapturedAuditEntry) => void> = mock(
+  () => {},
+);
+
+mock.module("@atlas/api/lib/audit", async () => {
+  const actual = await import("@atlas/api/lib/audit/actions");
+  return {
+    logAdminAction: mockLogAdminAction,
+    logAdminActionAwait: mock(async () => {}),
+    ADMIN_ACTIONS: actual.ADMIN_ACTIONS,
+    _resetAuditLog: () => {},
+  };
+});
 
 mock.module("@atlas/api/lib/scheduler-store", () => ({
   listScheduledTasks: mock(async () => []),
@@ -369,6 +392,7 @@ describe("admin email-provider route", () => {
     mockHasInternalDB = true;
     delete process.env.ATLAS_SMTP_URL;
     mockInternalQuery.mockClear();
+    mockLogAdminAction.mockClear();
     mockSaveEmailInstallation.mockReset();
     mockSaveEmailInstallation.mockImplementation(async () => {});
     mockGetEmailInstallationByOrg.mockReset();
@@ -830,6 +854,225 @@ describe("admin email-provider route", () => {
         recipientEmail: "you@example.com",
       });
       expect(res.status).toBe(404);
+    });
+  });
+
+  // ─── Audit emission (F-30) ─────────────────────────────────────────
+  // Every write route — PUT, DELETE, POST /test — must emit an audit row.
+  // The test route is especially material: an attacker with admin can use
+  // it as a free credential oracle without these entries.
+
+  describe("audit emission — PUT /email-provider", () => {
+    it("emits email_provider.update with hasSecret marker but no secret value", async () => {
+      mockGetEmailInstallationByOrg
+        .mockImplementationOnce(async () => null)
+        .mockImplementationOnce(async () => ({
+          config_id: "cfg-1",
+          provider: "resend",
+          sender_address: "Acme <noreply@acme.com>",
+          config: { provider: "resend", apiKey: "re_abcdefghijklmnop" },
+          org_id: "org-1",
+          installed_at: "2026-04-18T00:00:00Z",
+        }));
+
+      const res = await jsonReq("/api/v1/admin/email-provider", "PUT", {
+        provider: "resend",
+        fromAddress: "Acme <noreply@acme.com>",
+        config: { provider: "resend", apiKey: "re_super_secret_live_value" },
+      });
+      expect(res.status).toBe(200);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("email_provider.update");
+      expect(entry.targetType).toBe("email_provider");
+      // scope defaults to "workspace" in the logger when unset — either
+      // explicit or implicit is fine, both resolve the same on write.
+      expect(entry.scope ?? "workspace").toBe("workspace");
+      expect(entry.metadata).toMatchObject({
+        provider: "resend",
+        fromAddress: "Acme <noreply@acme.com>",
+        hasSecret: true,
+      });
+      // Redaction invariant: no credential material anywhere in the entry.
+      const serialized = JSON.stringify(entry);
+      expect(serialized).not.toContain("re_super_secret_live_value");
+      expect(entry.metadata).not.toHaveProperty("apiKey");
+      expect(entry.metadata).not.toHaveProperty("password");
+      expect(entry.metadata).not.toHaveProperty("secretAccessKey");
+      expect(entry.metadata).not.toHaveProperty("serverToken");
+      expect(entry.metadata).not.toHaveProperty("config");
+    });
+
+    it("redacts SMTP password + SES secret from metadata", async () => {
+      process.env.ATLAS_SMTP_URL = "https://bridge.example.com";
+      const smtpPassword = "super-long-smtp-password-9999";
+      await jsonReq("/api/v1/admin/email-provider", "PUT", {
+        provider: "smtp",
+        fromAddress: "Acme <noreply@acme.com>",
+        config: {
+          provider: "smtp",
+          host: "smtp.example.com",
+          port: 587,
+          username: "user@company.com",
+          password: smtpPassword,
+          tls: true,
+        },
+      });
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const smtpEntry = mockLogAdminAction.mock.calls[0]![0];
+      expect(smtpEntry.metadata!.hasSecret).toBe(true);
+      const smtpSerialized = JSON.stringify(smtpEntry);
+      expect(smtpSerialized).not.toContain(smtpPassword);
+      expect(smtpSerialized).not.toContain("user@company.com");
+
+      mockLogAdminAction.mockClear();
+      const sesSecret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+      await jsonReq("/api/v1/admin/email-provider", "PUT", {
+        provider: "ses",
+        fromAddress: "Acme <noreply@acme.com>",
+        config: { provider: "ses", region: "us-east-1", accessKeyId: "AKIA", secretAccessKey: sesSecret },
+      });
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const sesEntry = mockLogAdminAction.mock.calls[0]![0];
+      expect(sesEntry.metadata!.hasSecret).toBe(true);
+      const sesSerialized = JSON.stringify(sesEntry);
+      expect(sesSerialized).not.toContain(sesSecret);
+    });
+
+    it("does not emit audit when validation short-circuits the handler", async () => {
+      // provider: smtp without ATLAS_SMTP_URL returns 400 before any state change
+      const res = await jsonReq("/api/v1/admin/email-provider", "PUT", {
+        provider: "smtp",
+        fromAddress: "Acme <noreply@acme.com>",
+        config: { provider: "smtp", host: "smtp.example.com", port: 587, username: "u", password: "p", tls: true },
+      });
+      expect(res.status).toBe(400);
+      expect(mockLogAdminAction).not.toHaveBeenCalled();
+    });
+
+    it("emits email_provider.update with status=failure when save throws", async () => {
+      mockSaveEmailInstallation.mockImplementation(async () => {
+        throw new Error("saveEmailInstallation DB error");
+      });
+      const res = await jsonReq("/api/v1/admin/email-provider", "PUT", {
+        provider: "resend",
+        fromAddress: "Acme <noreply@acme.com>",
+        config: { provider: "resend", apiKey: "re_abcdefghijklmnop" },
+      });
+      expect(res.status).toBe(500);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("email_provider.update");
+      expect(entry.status).toBe("failure");
+      expect(entry.metadata).toMatchObject({
+        provider: "resend",
+        fromAddress: "Acme <noreply@acme.com>",
+        hasSecret: true,
+      });
+      expect(entry.metadata!.error).toContain("saveEmailInstallation DB error");
+    });
+  });
+
+  describe("audit emission — DELETE /email-provider", () => {
+    it("emits email_provider.delete with the prior provider when one existed", async () => {
+      mockGetEmailInstallationByOrg.mockImplementation(async () => ({
+        config_id: "cfg-sg",
+        provider: "sendgrid",
+        sender_address: "Acme <noreply@acme.com>",
+        config: { provider: "sendgrid", apiKey: "SG.abcdefghijklmnop" },
+        org_id: "org-1",
+        installed_at: "2026-04-18T00:00:00Z",
+      }));
+
+      const res = await request("/api/v1/admin/email-provider", { method: "DELETE" });
+      expect(res.status).toBe(200);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("email_provider.delete");
+      expect(entry.targetType).toBe("email_provider");
+      expect(entry.scope ?? "workspace").toBe("workspace");
+      expect(entry.metadata).toMatchObject({ provider: "sendgrid" });
+      // No credential keys leak even when reading the prior install row.
+      expect(entry.metadata).not.toHaveProperty("apiKey");
+      expect(entry.metadata).not.toHaveProperty("config");
+    });
+
+    it("emits email_provider.delete with null provider when no override existed", async () => {
+      mockGetEmailInstallationByOrg.mockImplementation(async () => null);
+      mockDeleteEmailInstallationByOrg.mockImplementation(async () => false);
+      const res = await request("/api/v1/admin/email-provider", { method: "DELETE" });
+      expect(res.status).toBe(200);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("email_provider.delete");
+      expect(entry.metadata).toMatchObject({ provider: null });
+    });
+  });
+
+  describe("audit emission — POST /email-provider/test", () => {
+    it("emits email_provider.test with success + recipient when fresh-creds path succeeds", async () => {
+      mockSendEmailWithTransport.mockImplementation(async () => ({
+        success: true,
+        provider: "resend",
+      }));
+      const res = await jsonReq("/api/v1/admin/email-provider/test", "POST", {
+        recipientEmail: "you@example.com",
+        provider: "resend",
+        fromAddress: "Acme <noreply@acme.com>",
+        config: { provider: "resend", apiKey: "re_test_live_value_99" },
+      });
+      expect(res.status).toBe(200);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("email_provider.test");
+      expect(entry.scope ?? "workspace").toBe("workspace");
+      expect(entry.metadata).toMatchObject({
+        provider: "resend",
+        success: true,
+        recipientEmail: "you@example.com",
+      });
+      const serialized = JSON.stringify(entry);
+      expect(serialized).not.toContain("re_test_live_value_99");
+      expect(entry.metadata).not.toHaveProperty("apiKey");
+      expect(entry.metadata).not.toHaveProperty("config");
+    });
+
+    it("emits email_provider.test with success=false on delivery failure", async () => {
+      // The credential-oracle threat: without this emission an attacker can
+      // call /test with stolen creds and read the pass/fail from the body
+      // without leaving a trace. Make the failing branch loud.
+      mockSendEmail.mockImplementation(async () => ({
+        success: false,
+        provider: "resend",
+        error: "auth failed",
+      }));
+      const res = await jsonReq("/api/v1/admin/email-provider/test", "POST", {
+        recipientEmail: "you@example.com",
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { success: boolean };
+      expect(body.success).toBe(false);
+
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("email_provider.test");
+      expect(entry.status).toBe("failure");
+      expect(entry.metadata).toMatchObject({
+        provider: "resend",
+        success: false,
+        recipientEmail: "you@example.com",
+      });
+    });
+
+    it("does not emit audit on wire-schema validation (422) — body never reached the handler", async () => {
+      const res = await jsonReq("/api/v1/admin/email-provider/test", "POST", {
+        recipientEmail: "you@example.com",
+        provider: "smtp",
+        fromAddress: "Acme <noreply@acme.com>",
+        config: { apiKey: "re_wrong_shape" },
+      });
+      expect(res.status).toBe(422);
+      expect(mockLogAdminAction).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
+++ b/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
@@ -857,7 +857,7 @@ describe("admin email-provider route", () => {
     });
   });
 
-  // ─── Audit emission (F-30) ─────────────────────────────────────────
+  // ─── Audit emission — BYOT credential redaction ───────────────────
   // Every write route — PUT, DELETE, POST /test — must emit an audit row.
   // The test route is especially material: an attacker with admin can use
   // it as a free credential oracle without these entries.
@@ -885,8 +885,6 @@ describe("admin email-provider route", () => {
       const entry = mockLogAdminAction.mock.calls[0]![0];
       expect(entry.actionType).toBe("email_provider.update");
       expect(entry.targetType).toBe("email_provider");
-      // scope defaults to "workspace" in the logger when unset — either
-      // explicit or implicit is fine, both resolve the same on write.
       expect(entry.scope ?? "workspace").toBe("workspace");
       expect(entry.metadata).toMatchObject({
         provider: "resend",
@@ -927,16 +925,21 @@ describe("admin email-provider route", () => {
 
       mockLogAdminAction.mockClear();
       const sesSecret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+      const sesKeyId = "AKIAIOSFODNN7EXAMPLE";
       await jsonReq("/api/v1/admin/email-provider", "PUT", {
         provider: "ses",
         fromAddress: "Acme <noreply@acme.com>",
-        config: { provider: "ses", region: "us-east-1", accessKeyId: "AKIA", secretAccessKey: sesSecret },
+        config: { provider: "ses", region: "us-east-1", accessKeyId: sesKeyId, secretAccessKey: sesSecret },
       });
       expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
       const sesEntry = mockLogAdminAction.mock.calls[0]![0];
       expect(sesEntry.metadata!.hasSecret).toBe(true);
       const sesSerialized = JSON.stringify(sesEntry);
       expect(sesSerialized).not.toContain(sesSecret);
+      // accessKeyId pairs with the secret and leaks identity/tenancy — AWS
+      // treats it as semi-sensitive. Lock in that it stays out of audit
+      // metadata even though it's not a "secret" strictly speaking.
+      expect(sesSerialized).not.toContain(sesKeyId);
     });
 
     it("does not emit audit when validation short-circuits the handler", async () => {
@@ -1000,6 +1003,47 @@ describe("admin email-provider route", () => {
     it("emits email_provider.delete with null provider when no override existed", async () => {
       mockGetEmailInstallationByOrg.mockImplementation(async () => null);
       mockDeleteEmailInstallationByOrg.mockImplementation(async () => false);
+      const res = await request("/api/v1/admin/email-provider", { method: "DELETE" });
+      expect(res.status).toBe(200);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("email_provider.delete");
+      expect(entry.metadata).toMatchObject({ provider: null });
+    });
+
+    it("emits email_provider.delete with status=failure when deleteEmailInstallationByOrg throws", async () => {
+      mockGetEmailInstallationByOrg.mockImplementation(async () => ({
+        config_id: "cfg-sg",
+        provider: "sendgrid",
+        sender_address: "Acme <noreply@acme.com>",
+        config: { provider: "sendgrid", apiKey: "SG.abc" },
+        org_id: "org-1",
+        installed_at: "2026-04-18T00:00:00Z",
+      }));
+      mockDeleteEmailInstallationByOrg.mockImplementation(async () => {
+        throw new Error("deleteEmailInstallationByOrg DB error");
+      });
+      const res = await request("/api/v1/admin/email-provider", { method: "DELETE" });
+      expect(res.status).toBe(500);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("email_provider.delete");
+      expect(entry.status).toBe("failure");
+      // Prior provider still captured before the delete failed — key
+      // forensic signal if a hostile admin tries to force delete and fail.
+      expect(entry.metadata).toMatchObject({ provider: "sendgrid" });
+      expect(entry.metadata!.error).toContain("deleteEmailInstallationByOrg DB error");
+    });
+
+    it("degrades to provider:null when prior-lookup throws before delete", async () => {
+      // The route's catchAll wraps the pre-delete lookup so a pool failure
+      // doesn't block the deletion. The audit row must still fire with
+      // provider:null rather than either (a) silently skipping audit or
+      // (b) crashing the whole request.
+      mockGetEmailInstallationByOrg.mockImplementation(async () => {
+        throw new Error("lookup pool timeout");
+      });
+      mockDeleteEmailInstallationByOrg.mockImplementation(async () => true);
       const res = await request("/api/v1/admin/email-provider", { method: "DELETE" });
       expect(res.status).toBe(200);
       expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
@@ -1073,6 +1117,57 @@ describe("admin email-provider route", () => {
       });
       expect(res.status).toBe(422);
       expect(mockLogAdminAction).not.toHaveBeenCalled();
+    });
+
+    it("emits email_provider.test with status=failure when the delivery helper throws", async () => {
+      // Unlike `success: false` (structured provider error), an actual
+      // throw from sendEmailWithTransport / sendEmail bypasses the trailing
+      // logAdminAction call. The Effect.tapError wrap must catch it so
+      // the credential oracle stays closed even on pool / SDK failures.
+      mockSendEmailWithTransport.mockImplementation(async () => {
+        throw new Error("transport pool exhausted");
+      });
+      const res = await jsonReq("/api/v1/admin/email-provider/test", "POST", {
+        recipientEmail: "you@example.com",
+        provider: "resend",
+        fromAddress: "Acme <noreply@acme.com>",
+        config: { provider: "resend", apiKey: "re_stolen_key_for_oracle" },
+      });
+      expect(res.status).toBe(500);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("email_provider.test");
+      expect(entry.status).toBe("failure");
+      expect(entry.metadata).toMatchObject({
+        provider: "resend",
+        success: false,
+        recipientEmail: "you@example.com",
+      });
+      expect(entry.metadata!.error).toContain("transport pool exhausted");
+      // The apiKey must not leak even on the throw path.
+      expect(JSON.stringify(entry)).not.toContain("re_stolen_key_for_oracle");
+    });
+
+    it("emits email_provider.test with status=failure when saved-config path throws", async () => {
+      // Saved-config branch uses `sendEmail` and takes no request body
+      // credentials, but still must emit on throw so the failed-probe
+      // signal isn't lost.
+      mockSendEmail.mockImplementation(async () => {
+        throw new Error("saved config fetch failed");
+      });
+      const res = await jsonReq("/api/v1/admin/email-provider/test", "POST", {
+        recipientEmail: "you@example.com",
+      });
+      expect(res.status).toBe(500);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("email_provider.test");
+      expect(entry.status).toBe("failure");
+      expect(entry.metadata).toMatchObject({
+        success: false,
+        recipientEmail: "you@example.com",
+      });
+      expect(entry.metadata!.error).toContain("saved config fetch failed");
     });
   });
 });

--- a/packages/api/src/api/__tests__/admin-model-config.test.ts
+++ b/packages/api/src/api/__tests__/admin-model-config.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Tests for admin workspace model-config route audit emission (F-30).
+ *
+ * The three write routes (PUT, DELETE, POST /test) each mutate or probe
+ * BYOT credential material. The /test route is especially material —
+ * without audit emission, an attacker with admin credentials can replay
+ * stolen apiKeys against it and read the pass/fail from the response body
+ * with zero forensic trail. These tests lock in the audit shape, including
+ * the redaction invariant that apiKey / baseUrl values never leak into
+ * metadata.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterAll,
+  mock,
+  type Mock,
+} from "bun:test";
+import { Effect } from "effect";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+
+// --- Unified mocks with admin user in org-1 ---
+
+const mocks = createApiTestMocks({
+  authUser: {
+    id: "admin-1",
+    mode: "managed",
+    label: "admin@test.com",
+    role: "admin",
+    activeOrganizationId: "org-1",
+  },
+  authMode: "managed",
+});
+
+// --- Enterprise gate: flip the env var so the real `isEnterpriseEnabled`
+// resolves true without reshaping the whole `@atlas/ee/index` surface. ---
+process.env.ATLAS_ENTERPRISE_ENABLED = "true";
+
+// --- EE model-routing mocks. Return Effect values matching the real
+// signatures so `yield*` unwraps them in the handler. ---
+
+class MockModelConfigError extends Error {
+  public readonly _tag = "ModelConfigError" as const;
+  public readonly code: "validation" | "not_found" | "test_failed";
+  constructor(message: string, code: "validation" | "not_found" | "test_failed") {
+    super(message);
+    this.name = "ModelConfigError";
+    this.code = code;
+  }
+}
+
+const mockGetWorkspaceModelConfig: Mock<(orgId: string) => unknown> = mock(() =>
+  Effect.succeed(null),
+);
+const mockSetWorkspaceModelConfig: Mock<(...args: unknown[]) => unknown> = mock(
+  () =>
+    Effect.succeed({
+      id: "cfg-1",
+      orgId: "org-1",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      apiKeyMasked: "************7890",
+      baseUrl: null,
+      createdAt: "2026-04-23T00:00:00Z",
+      updatedAt: "2026-04-23T00:00:00Z",
+    }),
+);
+const mockDeleteWorkspaceModelConfig: Mock<(orgId: string) => unknown> = mock(
+  () => Effect.succeed(true),
+);
+const mockTestModelConfig: Mock<(...args: unknown[]) => unknown> = mock(() =>
+  Effect.succeed({
+    success: true,
+    message: "Connection successful.",
+    modelName: "claude-opus-4-6",
+  }),
+);
+
+mock.module("@atlas/ee/platform/model-routing", () => ({
+  getWorkspaceModelConfig: mockGetWorkspaceModelConfig,
+  setWorkspaceModelConfig: mockSetWorkspaceModelConfig,
+  deleteWorkspaceModelConfig: mockDeleteWorkspaceModelConfig,
+  testModelConfig: mockTestModelConfig,
+  ModelConfigError: MockModelConfigError,
+}));
+
+// --- Audit capture: use the real ADMIN_ACTIONS catalog so route emissions
+// bind to the canonical string values. ---
+
+interface CapturedAuditEntry {
+  actionType: string;
+  targetType: string;
+  targetId: string;
+  status?: "success" | "failure";
+  metadata?: Record<string, unknown>;
+  scope?: "platform" | "workspace";
+  ipAddress?: string | null;
+}
+
+const mockLogAdminAction: Mock<(entry: CapturedAuditEntry) => void> = mock(
+  () => {},
+);
+
+mock.module("@atlas/api/lib/audit", async () => {
+  const actual = await import("@atlas/api/lib/audit/actions");
+  return {
+    logAdminAction: mockLogAdminAction,
+    logAdminActionAwait: mock(async () => {}),
+    ADMIN_ACTIONS: actual.ADMIN_ACTIONS,
+  };
+});
+
+// --- Import the app AFTER all mocks ---
+const { app } = await import("../index");
+
+afterAll(() => mocks.cleanup());
+
+function adminRequest(method: string, path: string, body?: unknown): Request {
+  const opts: RequestInit = {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer test-key",
+    },
+  };
+  if (body !== undefined) opts.body = JSON.stringify(body);
+  return new Request(`http://localhost${path}`, opts);
+}
+
+function lastAuditCall(): CapturedAuditEntry {
+  const calls = mockLogAdminAction.mock.calls;
+  if (calls.length === 0) throw new Error("logAdminAction was not called");
+  return calls[calls.length - 1]![0]!;
+}
+
+beforeEach(() => {
+  mocks.hasInternalDB = true;
+  mockLogAdminAction.mockClear();
+  mockGetWorkspaceModelConfig.mockClear();
+  mockSetWorkspaceModelConfig.mockClear();
+  mockDeleteWorkspaceModelConfig.mockClear();
+  mockTestModelConfig.mockClear();
+
+  mockGetWorkspaceModelConfig.mockImplementation(() => Effect.succeed(null));
+  mockSetWorkspaceModelConfig.mockImplementation(() =>
+    Effect.succeed({
+      id: "cfg-1",
+      orgId: "org-1",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      apiKeyMasked: "************7890",
+      baseUrl: null,
+      createdAt: "2026-04-23T00:00:00Z",
+      updatedAt: "2026-04-23T00:00:00Z",
+    }),
+  );
+  mockDeleteWorkspaceModelConfig.mockImplementation(() => Effect.succeed(true));
+  mockTestModelConfig.mockImplementation(() =>
+    Effect.succeed({
+      success: true,
+      message: "Connection successful.",
+      modelName: "claude-opus-4-6",
+    }),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// PUT /api/v1/admin/model-config
+// ---------------------------------------------------------------------------
+
+describe("audit emission — PUT /api/v1/admin/model-config", () => {
+  it("emits model_config.update with provider/model + hasSecret marker", async () => {
+    const res = await app.fetch(
+      adminRequest("PUT", "/api/v1/admin/model-config", {
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        apiKey: "sk-ant-super-secret-live-value-99",
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("model_config.update");
+    expect(entry.targetType).toBe("model_config");
+    expect(entry.scope ?? "workspace").toBe("workspace");
+    expect(entry.status ?? "success").toBe("success");
+    expect(entry.metadata).toMatchObject({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      hasSecret: true,
+    });
+  });
+
+  it("never includes the apiKey value in metadata", async () => {
+    const apiKey = "sk-ant-super-secret-live-value-99";
+    await app.fetch(
+      adminRequest("PUT", "/api/v1/admin/model-config", {
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        apiKey,
+      }),
+    );
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    const serialized = JSON.stringify(entry);
+    // Redaction invariant: the live apiKey value MUST NOT appear anywhere.
+    expect(serialized).not.toContain(apiKey);
+    expect(entry.metadata).not.toHaveProperty("apiKey");
+    expect(entry.metadata).not.toHaveProperty("password");
+    expect(entry.metadata).not.toHaveProperty("secret");
+    expect(entry.metadata).not.toHaveProperty("secretAccessKey");
+  });
+
+  it("records hasSecret:false when apiKey is omitted (key-preservation path)", async () => {
+    // Caller submits an update WITHOUT apiKey → server keeps the existing
+    // encrypted key. The audit row must mark this case distinctly so
+    // forensic queries can separate rotations from metadata-only edits.
+    mockGetWorkspaceModelConfig.mockImplementation(() =>
+      Effect.succeed({
+        id: "cfg-1",
+        orgId: "org-1",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        apiKeyMasked: "************7890",
+        baseUrl: null,
+        createdAt: "2026-04-23T00:00:00Z",
+        updatedAt: "2026-04-23T00:00:00Z",
+      }),
+    );
+
+    const res = await app.fetch(
+      adminRequest("PUT", "/api/v1/admin/model-config", {
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.metadata).toMatchObject({
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+      hasSecret: false,
+    });
+  });
+
+  it("emits model_config.update with status=failure when set throws", async () => {
+    mockSetWorkspaceModelConfig.mockImplementation(() =>
+      Effect.fail(new MockModelConfigError("encryption failed", "validation")),
+    );
+
+    const res = await app.fetch(
+      adminRequest("PUT", "/api/v1/admin/model-config", {
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        apiKey: "sk-ant-oops",
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("model_config.update");
+    expect(entry.status).toBe("failure");
+    expect(entry.metadata).toMatchObject({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      hasSecret: true,
+    });
+    expect(entry.metadata!.error).toContain("encryption failed");
+    expect(JSON.stringify(entry)).not.toContain("sk-ant-oops");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/v1/admin/model-config
+// ---------------------------------------------------------------------------
+
+describe("audit emission — DELETE /api/v1/admin/model-config", () => {
+  it("emits model_config.delete on success", async () => {
+    const res = await app.fetch(adminRequest("DELETE", "/api/v1/admin/model-config"));
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("model_config.delete");
+    expect(entry.targetType).toBe("model_config");
+    expect(entry.scope ?? "workspace").toBe("workspace");
+    expect(entry.status ?? "success").toBe("success");
+    // DELETE metadata intentionally empty — the actor/org context already
+    // identifies the target via the audit row's actor_id/org_id columns.
+    expect(entry.metadata ?? {}).toEqual({});
+  });
+
+  it("does not emit audit when no config existed (404 short-circuit)", async () => {
+    mockDeleteWorkspaceModelConfig.mockImplementation(() => Effect.succeed(false));
+    const res = await app.fetch(adminRequest("DELETE", "/api/v1/admin/model-config"));
+    expect(res.status).toBe(404);
+    // No-op delete → no state change → no audit row. This matches the
+    // `plugin.enable` pre-handler-rejection pattern in F-22.
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/admin/model-config/test
+// ---------------------------------------------------------------------------
+
+describe("audit emission — POST /api/v1/admin/model-config/test", () => {
+  it("emits model_config.test with success:true on passing probe", async () => {
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/model-config/test", {
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        apiKey: "sk-ant-live-key-for-test-oracle",
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("model_config.test");
+    expect(entry.targetType).toBe("model_config");
+    expect(entry.scope ?? "workspace").toBe("workspace");
+    expect(entry.status ?? "success").toBe("success");
+    expect(entry.metadata).toMatchObject({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      success: true,
+    });
+    // The credential-oracle threat: the apiKey value must NOT land in the
+    // audit trail even though the handler reads it from the body.
+    expect(JSON.stringify(entry)).not.toContain("sk-ant-live-key-for-test-oracle");
+    expect(entry.metadata).not.toHaveProperty("apiKey");
+  });
+
+  it("emits model_config.test with success:false and status=failure on failing probe", async () => {
+    // Deny-by-default for the /test route: without this emission an
+    // attacker replays stolen keys and reads auth failures from the response
+    // body. Make failing probes loud.
+    mockTestModelConfig.mockImplementation(() =>
+      Effect.succeed({
+        success: false,
+        message: "Connection test failed: invalid API key",
+      }),
+    );
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/model-config/test", {
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        apiKey: "sk-ant-stolen-and-revoked",
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean };
+    expect(body.success).toBe(false);
+
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("model_config.test");
+    expect(entry.status).toBe("failure");
+    expect(entry.metadata).toMatchObject({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      success: false,
+    });
+    // Even on failure, the apiKey value must not leak.
+    expect(JSON.stringify(entry)).not.toContain("sk-ant-stolen-and-revoked");
+  });
+
+  it("emits model_config.test with status=failure when validate rejects (422)", async () => {
+    mockTestModelConfig.mockImplementation(() =>
+      Effect.fail(new MockModelConfigError("invalid provider", "validation")),
+    );
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/model-config/test", {
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        apiKey: "sk-ant-probe",
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("model_config.test");
+    expect(entry.status).toBe("failure");
+    expect(entry.metadata).toMatchObject({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    });
+    expect(JSON.stringify(entry)).not.toContain("sk-ant-probe");
+  });
+});

--- a/packages/api/src/api/__tests__/admin-model-config.test.ts
+++ b/packages/api/src/api/__tests__/admin-model-config.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for admin workspace model-config route audit emission (F-30).
+ * Tests for admin workspace model-config route audit emission.
  *
  * The three write routes (PUT, DELETE, POST /test) each mutate or probe
  * BYOT credential material. The /test route is especially material —
@@ -214,6 +214,26 @@ describe("audit emission — PUT /api/v1/admin/model-config", () => {
     expect(entry.metadata).not.toHaveProperty("secretAccessKey");
   });
 
+  it("does not leak baseUrl into audit metadata (self-hosted endpoint disclosure)", async () => {
+    // Self-hosted OpenAI-compatible deployments supply `baseUrl`. Even if
+    // it's not a "secret" by the strict definition, an internal URL in
+    // the audit trail leaks infrastructure topology (VPN endpoints,
+    // internal DNS names) — keep it out.
+    const internalBaseUrl = "https://llm.internal.corp.example/v1";
+    await app.fetch(
+      adminRequest("PUT", "/api/v1/admin/model-config", {
+        provider: "custom",
+        model: "custom-llm",
+        apiKey: "sk-anything",
+        baseUrl: internalBaseUrl,
+      }),
+    );
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(JSON.stringify(entry)).not.toContain(internalBaseUrl);
+    expect(entry.metadata).not.toHaveProperty("baseUrl");
+  });
+
   it("records hasSecret:false when apiKey is omitted (key-preservation path)", async () => {
     // Caller submits an update WITHOUT apiKey → server keeps the existing
     // encrypted key. The audit row must mark this case distinctly so
@@ -297,9 +317,22 @@ describe("audit emission — DELETE /api/v1/admin/model-config", () => {
     mockDeleteWorkspaceModelConfig.mockImplementation(() => Effect.succeed(false));
     const res = await app.fetch(adminRequest("DELETE", "/api/v1/admin/model-config"));
     expect(res.status).toBe(404);
-    // No-op delete → no state change → no audit row. This matches the
-    // `plugin.enable` pre-handler-rejection pattern in F-22.
+    // No-op delete → no state change → no audit row. Matches the
+    // pre-handler-rejection pattern used on unknown-target writes.
     expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+
+  it("emits model_config.delete with status=failure when deleteWorkspaceModelConfig fails", async () => {
+    mockDeleteWorkspaceModelConfig.mockImplementation(() =>
+      Effect.fail(new MockModelConfigError("internal DB unreachable", "validation")),
+    );
+    const res = await app.fetch(adminRequest("DELETE", "/api/v1/admin/model-config"));
+    expect(res.status).toBe(400);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("model_config.delete");
+    expect(entry.status).toBe("failure");
+    expect(entry.metadata!.error).toContain("internal DB unreachable");
   });
 });
 

--- a/packages/api/src/api/routes/admin-email-provider.ts
+++ b/packages/api/src/api/routes/admin-email-provider.ts
@@ -26,6 +26,7 @@ import {
   type EmailProvider,
   type ProviderConfig,
 } from "@atlas/api/lib/integrations/types";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
 
@@ -361,13 +362,37 @@ adminEmailProvider.openapi(setConfigRoute, async (c) => {
       }, 400);
     }
 
+    // NEVER log credential material here — the `hasSecret: true` marker is
+    // the load-bearing signal; the raw apiKey / password / secretAccessKey
+    // must not leak into admin_action_log metadata (F-30).
+    const fromAddress = body.fromAddress.trim();
+    const auditBase = { provider: body.provider, fromAddress, hasSecret: true };
     yield* Effect.tryPromise({
       try: () => saveEmailInstallation(orgId, {
         provider: body.provider,
-        senderAddress: body.fromAddress.trim(),
+        senderAddress: fromAddress,
         config: validated.config,
       }),
       catch: (err) => err instanceof Error ? err : new Error(String(err)),
+    }).pipe(
+      Effect.tapError((err) =>
+        Effect.sync(() =>
+          logAdminAction({
+            actionType: ADMIN_ACTIONS.email_provider.update,
+            targetType: "email_provider",
+            targetId: orgId,
+            status: "failure",
+            metadata: { ...auditBase, error: err.message },
+          }),
+        ),
+      ),
+    );
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.email_provider.update,
+      targetType: "email_provider",
+      targetId: orgId,
+      metadata: auditBase,
     });
 
     const saved = yield* Effect.tryPromise({
@@ -403,9 +428,37 @@ adminEmailProvider.openapi(deleteConfigRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = c.get("orgContext");
 
+    // Capture the prior provider BEFORE the row is gone so the audit trail
+    // records which BYOT credential was removed. A pool failure here
+    // degrades to `provider: null` in metadata rather than blocking the
+    // delete — the deletion itself is still the load-bearing event.
+    const prior = yield* Effect.tryPromise({
+      try: () => getEmailInstallationByOrg(orgId),
+      catch: (err) => err instanceof Error ? err : new Error(String(err)),
+    }).pipe(Effect.catchAll(() => Effect.succeed(null)));
+
     yield* Effect.tryPromise({
       try: () => deleteEmailInstallationByOrg(orgId),
       catch: (err) => err instanceof Error ? err : new Error(String(err)),
+    }).pipe(
+      Effect.tapError((err) =>
+        Effect.sync(() =>
+          logAdminAction({
+            actionType: ADMIN_ACTIONS.email_provider.delete,
+            targetType: "email_provider",
+            targetId: orgId,
+            status: "failure",
+            metadata: { provider: prior?.provider ?? null, error: err.message },
+          }),
+        ),
+      ),
+    );
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.email_provider.delete,
+      targetType: "email_provider",
+      targetId: orgId,
+      metadata: { provider: prior?.provider ?? null },
     });
 
     return c.json({ message: "Email provider override removed." }, 200);
@@ -439,13 +492,19 @@ adminEmailProvider.openapi(testConfigRoute, async (c) => {
       }, 400);
     }
 
+    // Two delivery branches share one audit shape: both record the provider
+    // that was actually exercised + success/failure + the recipient. The
+    // apiKey / password / secretAccessKey in body.config MUST NOT land in
+    // the audit row — an attacker with admin would otherwise use this
+    // endpoint as a credential oracle (F-30).
+    let result: { success: boolean; provider: string; error?: string };
     if (hasProvider && hasConfig) {
       const validated = validateProviderConfig(body.provider!, body.config!);
       if (!validated.ok) {
         return c.json({ error: "validation", message: validated.error, requestId }, 400);
       }
       const fromAddress = body.fromAddress?.trim() || BASELINE_FROM_ADDRESS;
-      const result = yield* Effect.tryPromise({
+      result = yield* Effect.tryPromise({
         try: () => sendEmailWithTransport(testMessage, {
           provider: body.provider!,
           senderAddress: fromAddress,
@@ -456,21 +515,29 @@ adminEmailProvider.openapi(testConfigRoute, async (c) => {
       if (!result.success) {
         log.warn({ requestId, orgId, provider: result.provider, err: result.error }, "Test email delivery failed (fresh creds)");
       }
-      return c.json(
-        result.success
-          ? { success: true, message: `Test email sent successfully via ${result.provider}.` }
-          : { success: false, message: result.error ?? `Email delivery failed via ${result.provider}.` },
-        200,
-      );
+    } else {
+      result = yield* Effect.tryPromise({
+        try: () => sendEmail(testMessage, orgId),
+        catch: (err) => err instanceof Error ? err : new Error(String(err)),
+      });
+      if (!result.success) {
+        log.warn({ requestId, orgId, provider: result.provider, err: result.error }, "Test email delivery failed (saved config)");
+      }
     }
 
-    const result = yield* Effect.tryPromise({
-      try: () => sendEmail(testMessage, orgId),
-      catch: (err) => err instanceof Error ? err : new Error(String(err)),
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.email_provider.test,
+      targetType: "email_provider",
+      targetId: orgId,
+      status: result.success ? "success" : "failure",
+      metadata: {
+        provider: result.provider,
+        success: result.success,
+        recipientEmail: body.recipientEmail,
+        ...(result.success ? {} : { error: result.error ?? "delivery failed" }),
+      },
     });
-    if (!result.success) {
-      log.warn({ requestId, orgId, provider: result.provider, err: result.error }, "Test email delivery failed (saved config)");
-    }
+
     return c.json(
       result.success
         ? { success: true, message: `Test email sent successfully via ${result.provider}.` }

--- a/packages/api/src/api/routes/admin-email-provider.ts
+++ b/packages/api/src/api/routes/admin-email-provider.ts
@@ -364,7 +364,7 @@ adminEmailProvider.openapi(setConfigRoute, async (c) => {
 
     // NEVER log credential material here — the `hasSecret: true` marker is
     // the load-bearing signal; the raw apiKey / password / secretAccessKey
-    // must not leak into admin_action_log metadata (F-30).
+    // must not leak into admin_action_log metadata.
     const fromAddress = body.fromAddress.trim();
     const auditBase = { provider: body.provider, fromAddress, hasSecret: true };
     yield* Effect.tryPromise({
@@ -431,11 +431,24 @@ adminEmailProvider.openapi(deleteConfigRoute, async (c) => {
     // Capture the prior provider BEFORE the row is gone so the audit trail
     // records which BYOT credential was removed. A pool failure here
     // degrades to `provider: null` in metadata rather than blocking the
-    // delete — the deletion itself is still the load-bearing event.
+    // delete — the deletion itself is still the load-bearing event. The
+    // swallow is intentional: we log a breadcrumb so ops can correlate the
+    // null-provider audit row to the underlying store error without having
+    // to join two unrelated log lines by requestId.
     const prior = yield* Effect.tryPromise({
       try: () => getEmailInstallationByOrg(orgId),
       catch: (err) => err instanceof Error ? err : new Error(String(err)),
-    }).pipe(Effect.catchAll(() => Effect.succeed(null)));
+    }).pipe(
+      Effect.catchAll((err) =>
+        Effect.sync(() => {
+          log.warn(
+            { orgId, err: err.message },
+            "prior email install lookup failed in delete path — audit will record provider: null",
+          );
+          return null;
+        }),
+      ),
+    );
 
     yield* Effect.tryPromise({
       try: () => deleteEmailInstallationByOrg(orgId),
@@ -492,11 +505,32 @@ adminEmailProvider.openapi(testConfigRoute, async (c) => {
       }, 400);
     }
 
-    // Two delivery branches share one audit shape: both record the provider
-    // that was actually exercised + success/failure + the recipient. The
-    // apiKey / password / secretAccessKey in body.config MUST NOT land in
-    // the audit row — an attacker with admin would otherwise use this
-    // endpoint as a credential oracle (F-30).
+    // All delivery branches share one audit shape: every probe records the
+    // provider that was actually exercised + success/failure + the
+    // recipient. The apiKey / password / secretAccessKey in body.config
+    // MUST NOT land in the audit row — an attacker with admin would
+    // otherwise use this endpoint as a credential oracle.
+    //
+    // `emitFailureAudit` is shared by both the fresh-creds and saved-creds
+    // branches so an unexpected throw from the delivery helper (pool failure,
+    // unwrapped provider SDK error) still lands a forensic row before the
+    // error bubbles out via `runEffect`.
+    const emitFailureAudit = (err: Error, provider: string | null) =>
+      Effect.sync(() =>
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.email_provider.test,
+          targetType: "email_provider",
+          targetId: orgId,
+          status: "failure",
+          metadata: {
+            provider,
+            success: false,
+            recipientEmail: body.recipientEmail,
+            error: err.message,
+          },
+        }),
+      );
+
     let result: { success: boolean; provider: string; error?: string };
     if (hasProvider && hasConfig) {
       const validated = validateProviderConfig(body.provider!, body.config!);
@@ -511,7 +545,7 @@ adminEmailProvider.openapi(testConfigRoute, async (c) => {
           config: validated.config,
         }),
         catch: (err) => err instanceof Error ? err : new Error(String(err)),
-      });
+      }).pipe(Effect.tapError((err) => emitFailureAudit(err, body.provider!)));
       if (!result.success) {
         log.warn({ requestId, orgId, provider: result.provider, err: result.error }, "Test email delivery failed (fresh creds)");
       }
@@ -519,7 +553,7 @@ adminEmailProvider.openapi(testConfigRoute, async (c) => {
       result = yield* Effect.tryPromise({
         try: () => sendEmail(testMessage, orgId),
         catch: (err) => err instanceof Error ? err : new Error(String(err)),
-      });
+      }).pipe(Effect.tapError((err) => emitFailureAudit(err, null)));
       if (!result.success) {
         log.warn({ requestId, orgId, provider: result.provider, err: result.error }, "Test email delivery failed (saved config)");
       }

--- a/packages/api/src/api/routes/admin-model-config.ts
+++ b/packages/api/src/api/routes/admin-model-config.ts
@@ -190,8 +190,8 @@ adminModelConfig.openapi(setConfigRoute, async (c) => {
     }
 
     // Audit metadata NEVER includes apiKey / baseUrl values — `hasSecret`
-    // distinguishes a rotation from a metadata-only edit (F-30). Keeping
-    // the raw key out of admin_action_log is the whole point of the F-30
+    // distinguishes a rotation from a metadata-only edit. Keeping the raw
+    // key out of admin_action_log is the whole point of the `model_config.*`
     // catalog entries; do not relax this without a security review.
     const auditBase = {
       provider: body.provider,
@@ -259,8 +259,8 @@ adminModelConfig.openapi(deleteConfigRoute, async (c) => {
       ),
     );
     if (!deleted) {
-      // No-op delete: no state change → no audit row (matches the F-22
-      // pre-handler-rejection pattern for plugin.enable on unknown id).
+      // No-op delete: no state change → no audit row (matches the
+      // pre-handler-rejection pattern used on unknown-target writes).
       return c.json({ error: "not_found", message: "No custom model configuration found." }, 404);
     }
 
@@ -288,8 +288,8 @@ adminModelConfig.openapi(testConfigRoute, async (c) => {
 
     // Every /test is audited. Without an audit row an attacker with admin
     // credentials can replay stolen apiKeys here and read pass/fail from
-    // the response body with zero forensic trail (F-30 credential oracle).
-    // Metadata excludes apiKey / baseUrl values by construction.
+    // the response body with zero forensic trail — the credential-oracle
+    // threat. Metadata excludes apiKey / baseUrl values by construction.
     const auditBase = { provider: body.provider, model: body.model };
     const result = yield* testModelConfig({
       provider: body.provider,

--- a/packages/api/src/api/routes/admin-model-config.ts
+++ b/packages/api/src/api/routes/admin-model-config.ts
@@ -18,6 +18,7 @@ import {
   ModelConfigError,
 } from "@atlas/ee/platform/model-routing";
 import { WorkspaceModelConfigSchema as ModelConfigSchema } from "@useatlas/schemas";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter } from "./admin-router";
 
@@ -188,12 +189,44 @@ adminModelConfig.openapi(setConfigRoute, async (c) => {
       }
     }
 
+    // Audit metadata NEVER includes apiKey / baseUrl values — `hasSecret`
+    // distinguishes a rotation from a metadata-only edit (F-30). Keeping
+    // the raw key out of admin_action_log is the whole point of the F-30
+    // catalog entries; do not relax this without a security review.
+    const auditBase = {
+      provider: body.provider,
+      model: body.model,
+      hasSecret: body.apiKey !== undefined,
+    };
     const config = yield* setWorkspaceModelConfig(orgId, {
       provider: body.provider,
       model: body.model,
       apiKey: body.apiKey,
       baseUrl: body.baseUrl,
+    }).pipe(
+      Effect.tapError((err) =>
+        Effect.sync(() =>
+          logAdminAction({
+            actionType: ADMIN_ACTIONS.model_config.update,
+            targetType: "model_config",
+            targetId: orgId,
+            status: "failure",
+            metadata: {
+              ...auditBase,
+              error: err instanceof Error ? err.message : String(err),
+            },
+          }),
+        ),
+      ),
+    );
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.model_config.update,
+      targetType: "model_config",
+      targetId: orgId,
+      metadata: auditBase,
     });
+
     return c.json({ config }, 200);
   }), { label: "set workspace model config", domainErrors: [modelConfigDomainError] });
 });
@@ -212,10 +245,31 @@ adminModelConfig.openapi(deleteConfigRoute, async (c) => {
       return c.json({ error: "bad_request", message: "No active organization. Set an active org first.", requestId }, 400);
     }
 
-    const deleted = yield* deleteWorkspaceModelConfig(orgId);
+    const deleted = yield* deleteWorkspaceModelConfig(orgId).pipe(
+      Effect.tapError((err) =>
+        Effect.sync(() =>
+          logAdminAction({
+            actionType: ADMIN_ACTIONS.model_config.delete,
+            targetType: "model_config",
+            targetId: orgId,
+            status: "failure",
+            metadata: { error: err instanceof Error ? err.message : String(err) },
+          }),
+        ),
+      ),
+    );
     if (!deleted) {
+      // No-op delete: no state change → no audit row (matches the F-22
+      // pre-handler-rejection pattern for plugin.enable on unknown id).
       return c.json({ error: "not_found", message: "No custom model configuration found." }, 404);
     }
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.model_config.delete,
+      targetType: "model_config",
+      targetId: orgId,
+    });
+
     return c.json({ message: "Model configuration reset to platform default." }, 200);
   }), { label: "delete workspace model config", domainErrors: [modelConfigDomainError] });
 });
@@ -232,12 +286,45 @@ adminModelConfig.openapi(testConfigRoute, async (c) => {
 
     const body = c.req.valid("json");
 
+    // Every /test is audited. Without an audit row an attacker with admin
+    // credentials can replay stolen apiKeys here and read pass/fail from
+    // the response body with zero forensic trail (F-30 credential oracle).
+    // Metadata excludes apiKey / baseUrl values by construction.
+    const auditBase = { provider: body.provider, model: body.model };
     const result = yield* testModelConfig({
       provider: body.provider,
       model: body.model,
       apiKey: body.apiKey,
       baseUrl: body.baseUrl,
+    }).pipe(
+      Effect.tapError((err) =>
+        Effect.sync(() =>
+          logAdminAction({
+            actionType: ADMIN_ACTIONS.model_config.test,
+            targetType: "model_config",
+            targetId: orgId,
+            status: "failure",
+            metadata: {
+              ...auditBase,
+              error: err instanceof Error ? err.message : String(err),
+            },
+          }),
+        ),
+      ),
+    );
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.model_config.test,
+      targetType: "model_config",
+      targetId: orgId,
+      status: result.success ? "success" : "failure",
+      metadata: {
+        ...auditBase,
+        success: result.success,
+        ...(result.success ? {} : { error: result.message }),
+      },
     });
+
     return c.json(result, 200);
   }), { label: "test model config", domainErrors: [modelConfigDomainError] });
 });

--- a/packages/api/src/lib/audit/__tests__/admin.test.ts
+++ b/packages/api/src/lib/audit/__tests__/admin.test.ts
@@ -281,3 +281,24 @@ describe("logAdminActionAwait()", () => {
     expect(queryCalls).toHaveLength(0);
   });
 });
+
+/**
+ * F-30 catalog — BYOT credential management (email provider + LLM model
+ * config) must audit every write. These entries backstop the route
+ * emissions: if anyone removes an action type from the catalog, the
+ * consuming route file stops compiling, so a silent drift back to the
+ * no-audit baseline is impossible.
+ */
+describe("ADMIN_ACTIONS catalog — F-30 BYOT credential audit", () => {
+  it("defines email_provider.update / delete / test", () => {
+    expect(ADMIN_ACTIONS.email_provider.update).toBe("email_provider.update");
+    expect(ADMIN_ACTIONS.email_provider.delete).toBe("email_provider.delete");
+    expect(ADMIN_ACTIONS.email_provider.test).toBe("email_provider.test");
+  });
+
+  it("defines model_config.update / delete / test", () => {
+    expect(ADMIN_ACTIONS.model_config.update).toBe("model_config.update");
+    expect(ADMIN_ACTIONS.model_config.delete).toBe("model_config.delete");
+    expect(ADMIN_ACTIONS.model_config.test).toBe("model_config.test");
+  });
+});

--- a/packages/api/src/lib/audit/__tests__/admin.test.ts
+++ b/packages/api/src/lib/audit/__tests__/admin.test.ts
@@ -283,13 +283,13 @@ describe("logAdminActionAwait()", () => {
 });
 
 /**
- * F-30 catalog — BYOT credential management (email provider + LLM model
- * config) must audit every write. These entries backstop the route
- * emissions: if anyone removes an action type from the catalog, the
- * consuming route file stops compiling, so a silent drift back to the
- * no-audit baseline is impossible.
+ * BYOT credential management (email provider + LLM model config) must
+ * audit every write. These catalog entries backstop the route emissions:
+ * if anyone removes an action type from the catalog, the consuming route
+ * file stops compiling, so a silent drift back to the no-audit baseline
+ * is impossible.
  */
-describe("ADMIN_ACTIONS catalog — F-30 BYOT credential audit", () => {
+describe("ADMIN_ACTIONS catalog — BYOT credential audit", () => {
   it("defines email_provider.update / delete / test", () => {
     expect(ADMIN_ACTIONS.email_provider.update).toBe("email_provider.update");
     expect(ADMIN_ACTIONS.email_provider.delete).toBe("email_provider.delete");

--- a/packages/api/src/lib/audit/actions.ts
+++ b/packages/api/src/lib/audit/actions.ts
@@ -164,6 +164,30 @@ export const ADMIN_ACTIONS = {
     manualPurge: "audit_retention.manual_purge",
     manualHardDelete: "audit_retention.manual_hard_delete",
   },
+  /**
+   * BYOT email provider mutations (Resend / SendGrid / Postmark / SMTP / SES).
+   * Without these entries an admin could swap the workspace sender to a
+   * phishing-friendly domain (or harvest working API keys via the /test
+   * route) with zero forensic record. Metadata never carries credential
+   * material — `hasSecret: true` is the marker that a secret was supplied.
+   */
+  email_provider: {
+    update: "email_provider.update",
+    delete: "email_provider.delete",
+    test: "email_provider.test",
+  },
+  /**
+   * BYOT workspace LLM model-config mutations. Same threat as
+   * `email_provider.*`: the test route accepts an apiKey in the body and
+   * returns a delivery result, making it a free credential oracle for an
+   * attacker with admin. Metadata never includes `apiKey` — use
+   * `hasSecret: true` as the marker.
+   */
+  model_config: {
+    update: "model_config.update",
+    delete: "model_config.delete",
+    test: "model_config.test",
+  },
 } as const;
 
 /** Union of all admin action type string values. */

--- a/packages/api/src/lib/audit/actions.ts
+++ b/packages/api/src/lib/audit/actions.ts
@@ -165,8 +165,9 @@ export const ADMIN_ACTIONS = {
     manualHardDelete: "audit_retention.manual_hard_delete",
   },
   /**
-   * BYOT email provider mutations (Resend / SendGrid / Postmark / SMTP / SES).
-   * Without these entries an admin could swap the workspace sender to a
+   * BYOT email-provider mutations — workspace admin swaps the outbound
+   * email transport (current providers live in `EMAIL_PROVIDERS`). Without
+   * these entries an admin could swap the workspace sender to a
    * phishing-friendly domain (or harvest working API keys via the /test
    * route) with zero forensic record. Metadata never carries credential
    * material — `hasSecret: true` is the marker that a secret was supplied.


### PR DESCRIPTION
## Summary

All 6 write routes in `admin-email-provider.ts` + `admin-model-config.ts` now emit `admin_action_log` entries. Adds `email_provider.*` + `model_config.*` domains to `ADMIN_ACTIONS` (update / delete / test in each).

Metadata never carries credential material — `hasSecret: true` is the marker that a secret was supplied. `apiKey` / `password` / `secretAccessKey` / `serverToken` / `baseUrl` values stay out of the audit trail.

The `/test` routes are especially material: without emission an attacker with admin credentials can replay stolen `apiKeys` against `/email-provider/test` or `/model-config/test` and read pass/fail from the response body as a free credential oracle. Both routes now emit on success AND failure (including validation-time rejections before the upstream call runs).

Closes #1785.

## What shipped

| Route | Action | Metadata |
|---|---|---|
| `PUT /admin/email-provider` | `email_provider.update` | `{ provider, fromAddress, hasSecret: true }` |
| `DELETE /admin/email-provider` | `email_provider.delete` | `{ provider }` (captured pre-delete) |
| `POST /admin/email-provider/test` | `email_provider.test` | `{ provider, success, recipientEmail }` |
| `PUT /admin/model-config` | `model_config.update` | `{ provider, model, hasSecret }` |
| `DELETE /admin/model-config` | `model_config.delete` | `{}` (actor + org cover the target) |
| `POST /admin/model-config/test` | `model_config.test` | `{ provider, model, success }` |

Failure paths (both domain errors + validation errors from the EE layer) emit a second row with `status: "failure"` and an `error` field.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun run test` — all packages green (including new `admin-model-config.test.ts` — 9 tests + audit emission blocks added to `admin-email-provider-route.test.ts`)
- [x] `bun x syncpack lint` — no issues
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — clean

### Test coverage

- **Redaction invariant:** No `apiKey` / `password` / `secretAccessKey` / `serverToken` / `config` key ever lands in `metadata`. Serialized entry body never contains the raw credential value.
- **Fresh-creds credential oracle:** `POST /test` emits success AND failure paths; `success: false` from delivery → `status: "failure"` audit row.
- **Validation short-circuits:** No audit row when wire-schema validation (422) or pre-handler business validation (400 SMTP-without-ATLAS_SMTP_URL) rejects before state change.
- **DELETE idempotency:** model-config 404 (nothing to delete) → no audit row, matching the F-22 pre-handler-rejection pattern. Email-provider DELETE is idempotent and always emits.
- **Catalog drift guard:** `ADMIN_ACTIONS` entries are referenced in the route files, so a catalog rename fails compilation before it can reach production.

## Docs

- `.claude/research/security-audit-1-2-3.md` — F-30 row in phase-4 scoreboard + finding table flipped to `fixed`.