### PR TITLE
fix(security): F-32 workspace enterprise config audit (closes #1787)

### DIFF
--- a/.claude/research/security-audit-1-2-3.md
+++ b/.claude/research/security-audit-1-2-3.md
@@ -1072,11 +1072,11 @@ Totals at the file level; individual uncovered writes are enumerated under the f
 | `admin-approval.ts` | 5 | 1 | 🟡 | Approve/deny audited; **rule CRUD + expire unaudited** (F-30) |
 | `admin-archive.ts` | 2 | 2 | ✅ | `mode.archive` / `mode.archive_reconcile` / `mode.restore` |
 | `admin-audit-retention.ts` | 4 | 4 | ✅ | F-26 fixed (PR for #1781) — `audit_retention.policy_update` / `export` / `manual_purge` / `manual_hard_delete` emitted with success + failure paths; policy_update captures previous values |
-| `admin-branding.ts` | 2 | 0 | ❌ | PUT / DELETE (F-32) |
+| `admin-branding.ts` | 2 | 2 | ✅ | F-32 fixed (PR for #1787) — `branding.update` / `branding.delete` emitted on success; `update` metadata preserves admin intent (only request-body fields present); `delete` intentionally silent on no-op (404 "no branding found") |
 | `admin-cache.ts` | 1 | 0 | ❌ | DELETE purge (F-37) |
-| `admin-compliance.ts` | 2 | 0 | ❌ | PUT retention policy + DELETE PII config (F-32) |
+| `admin-compliance.ts` | 2 | 2 | ✅ | F-32 fixed (PR for #1787) — `compliance.retention_update` / `compliance.pii_config_delete` emitted on success; update metadata captures only the admin's intent (request-body fields present) so compliance review can distinguish a masking-strategy shrink from a dismiss |
 | `admin-connections.ts` | 7 | 3 | 🟡 | Create/update/delete audited; **test / /:id/test / pool drain unaudited** (F-34) |
-| `admin-domains.ts` | 4 | 0 | ❌ | Workspace custom domain + verify (F-32) |
+| `admin-domains.ts` | 4 | 4 | ✅ | F-32 fixed (PR for #1787) — `domain.workspace_register` / `workspace_remove` / `workspace_verify` / `workspace_verify_dns` emitted on success; verify paths short-circuit 404 before audit emission when no domain is configured (probes don't land stale rows) |
 | `admin-email-provider.ts` | 3 | 3 | ✅ | F-30 fixed (PR for #1785) — `email_provider.update` / `delete` / `test` emitted with success + failure paths; update carries `hasSecret: true` marker, delete captures prior provider pre-delete, test includes recipient + delivery outcome |
 | `admin-integrations.ts` | 19 | 18 | 🟡 | Most install/uninstall emit `integration.*`; **one handler missing an audit call** — see F-29 |
 | `admin-invitations.ts` | 2 | 1 | 🟡 | `user.invite` audited; **`DELETE /users/invitations/{id}` revoke is silent** — see F-29 |
@@ -1089,7 +1089,7 @@ Totals at the file level; individual uncovered writes are enumerated under the f
 | `admin-plugins.ts` | 4 | 3 | ✅ | `plugin.enable` / `plugin.disable` / `plugin.config_update` audited; read-only health check stays silent — F-22 fixed |
 | `admin-prompts.ts` | 7 | 0 | ❌ | Content governance — collection + prompt CRUD (F-35) |
 | `admin-publish.ts` | 1 | 1 | ✅ | `mode.publish` |
-| `admin-residency.ts` | 4 | 0 | ❌ | **Workspace residency assign is permanent and unaudited** (F-32) |
+| `admin-residency.ts` | 4 | 4 | ✅ | F-32 fixed (PR for #1787) — `residency.workspace_assign` / `migration_request` / `migration_retry` / `migration_cancel` emitted. `workspace_assign` metadata carries explicit `permanent: true` so triage flags the irreversibility, and emits failure-status audits on validation / conflict errors so 409 probes for the current region leave a trail |
 | `admin-roles.ts` | 4 | 4 | ✅ | F-25 fixed (PR #1800) — `role.create` / `role.update` / `role.delete` / `role.assign` emitted with success + failure paths; update captures previousPermissions, delete pre-fetches so metadata retains the deleted role, assign captures previousRole |
 | `admin-sandbox.ts` | 2 | 0 | ❌ | Connect/disconnect BYOC sandbox (F-37) |
 | `admin-scim.ts` | 3 | 3 | ✅ | `scim.connection_delete` / `scim.group_mapping_create` / `scim.group_mapping_delete` — F-23 fixed |
@@ -1375,7 +1375,7 @@ Overlap with `platform-admin.ts` — which DOES audit `workspace.suspend` / `uns
 
 ---
 
-**F-32 — Workspace-scoped enterprise config writes (domains, branding, residency, compliance) are unaudited** — P1
+**F-32 — Workspace-scoped enterprise config writes (domains, branding, residency, compliance) are unaudited** — P1 — **FIXED**
 
 Four admin files with explicit enterprise-gated config surfaces and zero audit coverage:
 
@@ -1390,7 +1390,7 @@ Four admin files with explicit enterprise-gated config surfaces and zero audit c
 
 **Severity:** P1 — workspace-identity and data-residency changes are compliance-critical.
 
-**Issue:** #1787.
+**Issue:** #1787. Fixed in PR for #1787 — all 12 writes now emit `logAdminAction`. `residency.workspace_assign` metadata carries `permanent: true` and emits failure-status audits on conflict / validation paths (409 probes for the current region leave evidence). Branding / compliance / residency read endpoints intentionally stay silent. Regression coverage: `admin-domains.test.ts`, `admin-branding.test.ts`, `admin-residency.test.ts`, and new `admin-compliance.test.ts`.
 
 ---
 
@@ -1564,7 +1564,7 @@ Grep every `metadata: { ... }` literal on the admin-audit call sites. Sampled pa
 | F-29 | P2 | Partial coverage | `admin-sso.ts`, `admin-connections.ts`, `scheduled-tasks.ts`, `admin-approval.ts`, `admin.ts` stragglers | #1784 | open |
 | F-30 | P1 | Credential-provenance | Email provider + model config (`admin-email-provider.ts`, `admin-model-config.ts`) | #1785 | fixed (PR for #1785) |
 | F-31 | P1 | Audit gap | Platform-admin workspace CRUD via `admin-orgs.ts` (post-F-08 drift) | #1786 | fixed (PR #1804) |
-| F-32 | P1 | Audit gap | Workspace enterprise config (`admin-domains.ts`, `admin-branding.ts`, `admin-residency.ts`, `admin-compliance.ts`) | #1787 | open |
+| F-32 | P1 | Audit gap | Workspace enterprise config (`admin-domains.ts`, `admin-branding.ts`, `admin-residency.ts`, `admin-compliance.ts`) | #1787 | fixed (PR for #1787) |
 | F-33 | P2 | Split trail | Abuse reinstate writes to `abuse_events`, not `admin_action_log` | #1788 | open |
 | F-34 | P2 | Audit gap | Wizard connection path bypasses `connection.create` (`wizard.ts`, plus connection test/drain in `admin-connections.ts`) | #1789 | open |
 | F-35 | P2 | Audit gap | Prompt / semantic-improve / starter-prompt moderation | #1790 | open |

--- a/.claude/research/security-audit-1-2-3.md
+++ b/.claude/research/security-audit-1-2-3.md
@@ -1074,7 +1074,7 @@ Totals at the file level; individual uncovered writes are enumerated under the f
 | `admin-audit-retention.ts` | 4 | 4 | ✅ | F-26 fixed (PR for #1781) — `audit_retention.policy_update` / `export` / `manual_purge` / `manual_hard_delete` emitted with success + failure paths; policy_update captures previous values |
 | `admin-branding.ts` | 2 | 2 | ✅ | F-32 fixed (PR for #1787) — `branding.update` / `branding.delete` emitted on success; `update` metadata preserves admin intent (only request-body fields present); `delete` intentionally silent on no-op (404 "no branding found") |
 | `admin-cache.ts` | 1 | 0 | ❌ | DELETE purge (F-37) |
-| `admin-compliance.ts` | 2 | 2 | ✅ | F-32 fixed (PR for #1787) — `compliance.retention_update` / `compliance.pii_config_delete` emitted on success; update metadata captures only the admin's intent (request-body fields present) so compliance review can distinguish a masking-strategy shrink from a dismiss |
+| `admin-compliance.ts` | 2 | 2 | ✅ | F-32 fixed (PR for #1787) — `compliance.pii_config_update` / `compliance.pii_config_delete` emitted on success; update metadata captures only the admin's intent (request-body fields present) so compliance review can distinguish a masking-strategy shrink from a dismiss. Deliberately named distinct from `audit_retention.*` — these control PII-masking enforcement, not retention windows |
 | `admin-connections.ts` | 7 | 3 | 🟡 | Create/update/delete audited; **test / /:id/test / pool drain unaudited** (F-34) |
 | `admin-domains.ts` | 4 | 4 | ✅ | F-32 fixed (PR for #1787) — `domain.workspace_register` / `workspace_remove` / `workspace_verify` / `workspace_verify_dns` emitted on success; verify paths short-circuit 404 before audit emission when no domain is configured (probes don't land stale rows) |
 | `admin-email-provider.ts` | 3 | 3 | ✅ | F-30 fixed (PR for #1785) — `email_provider.update` / `delete` / `test` emitted with success + failure paths; update carries `hasSecret: true` marker, delete captures prior provider pre-delete, test includes recipient + delivery outcome |
@@ -1386,7 +1386,7 @@ Four admin files with explicit enterprise-gated config surfaces and zero audit c
 
 **Impact:** Custom-domain + residency in particular are permanent or semi-permanent workspace-identity changes. A workspace that migrates regions then experiences a data-export subpoena has no way to prove which region hosted what data when. Branding is lower risk but still governance-relevant — an admin can silently white-label the product before phishing tenant users. Compliance retention-policy changes share the class of F-26 (audit-about-audit).
 
-**Fix sketch:** Add `domain.workspace_*` (register / remove / verify / verify_dns), `branding.update` / `branding.delete`, `residency.workspace_assign` / `migration_request` / `migration_retry` / `migration_cancel`, `compliance.retention_update` / `compliance.pii_config_delete`.
+**Fix sketch:** Add `domain.workspace_*` (register / remove / verify / verify_dns), `branding.update` / `branding.delete`, `residency.workspace_assign` / `migration_request` / `migration_retry` / `migration_cancel`, `compliance.pii_config_update` / `compliance.pii_config_delete` (originally drafted as `compliance.retention_update` but renamed to avoid semantic collision with the existing `audit_retention.*` domain — the PUT route updates PII-masking enforcement on a single classification, not a retention window).
 
 **Severity:** P1 — workspace-identity and data-residency changes are compliance-critical.
 

--- a/packages/api/src/api/__tests__/admin-branding.test.ts
+++ b/packages/api/src/api/__tests__/admin-branding.test.ts
@@ -8,6 +8,9 @@
 import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
 import { Effect } from "effect";
 
+// Real ADMIN_ACTIONS values so assertions pin to the canonical strings.
+import { ADMIN_ACTIONS as REAL_ADMIN_ACTIONS } from "@atlas/api/lib/audit/actions";
+
 // --- Auth mock ---
 
 const mockAuthenticateRequest: Mock<(req: Request) => Promise<unknown>> = mock(
@@ -76,6 +79,29 @@ mock.module("@atlas/ee/branding/white-label", () => ({
 mock.module("@atlas/api/lib/logger", () => ({
   createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
   withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+  getRequestContext: () => null,
+}));
+
+// --- Audit mock — capture every logAdminAction emission ---
+
+interface CapturedAuditEntry {
+  actionType: string;
+  targetType: string;
+  targetId: string;
+  status?: "success" | "failure";
+  metadata?: Record<string, unknown>;
+  scope?: "platform" | "workspace";
+  ipAddress?: string | null;
+}
+
+const mockLogAdminAction: Mock<(entry: CapturedAuditEntry) => void> = mock(() => {});
+
+mock.module("@atlas/api/lib/audit", () => ({
+  logAdminAction: mockLogAdminAction,
+  logAdminActionAwait: mock(async () => {}),
+  ADMIN_ACTIONS: REAL_ADMIN_ACTIONS,
+  errorMessage: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+  causeToError: () => undefined,
 }));
 
 // --- Import sub-router directly ---
@@ -90,6 +116,7 @@ function resetMocks() {
   mockSetResult = null;
   mockDeleteResult = false;
   mockEeError = null;
+  mockLogAdminAction.mockClear();
   mockAuthenticateRequest.mockImplementation(() =>
     Promise.resolve({
       authenticated: true,
@@ -238,5 +265,75 @@ describe("DELETE /api/v1/admin/branding", () => {
     mockEeError = new EnterpriseError("Enterprise features (branding) are not enabled.");
     const res = await request("DELETE");
     expect(res.status).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F-32 audit-emission regression tests — admin-branding
+//
+// An admin can silently re-skin the product before phishing tenant users;
+// the audit row is the only trail. See F-32 in
+// .claude/research/security-audit-1-2-3.md.
+// ---------------------------------------------------------------------------
+
+describe("admin branding — F-32 audit emission", () => {
+  beforeEach(resetMocks);
+
+  it("PUT / emits branding.update on success", async () => {
+    mockSetResult = {
+      id: "brand_1",
+      orgId: "org-1",
+      logoUrl: null,
+      logoText: "Acme",
+      primaryColor: "#FF5500",
+      faviconUrl: null,
+      hideAtlasBranding: true,
+      createdAt: "2026-04-23T00:00:00Z",
+      updatedAt: "2026-04-23T00:00:00Z",
+    };
+    const res = await request("PUT", {
+      logoText: "Acme",
+      primaryColor: "#FF5500",
+      hideAtlasBranding: true,
+    });
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.actionType).toBe("branding.update");
+    expect(entry.targetType).toBe("branding");
+    expect(entry.targetId).toBe("org-1");
+    // `hideAtlasBranding: true` is the high-stakes field (governance: a
+    // phishing admin wants the word "Atlas" gone). Metadata must preserve
+    // the fields the admin *intended* to change so compliance review can
+    // distinguish a cosmetic logo tweak from a white-label takeover.
+    expect(entry.metadata?.hideAtlasBranding).toBe(true);
+    expect(entry.metadata?.primaryColor).toBe("#FF5500");
+  });
+
+  it("DELETE / emits branding.delete on successful reset", async () => {
+    mockDeleteResult = true;
+    const res = await request("DELETE");
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.actionType).toBe("branding.delete");
+    expect(entry.targetType).toBe("branding");
+    expect(entry.targetId).toBe("org-1");
+  });
+
+  it("DELETE / does not emit when no branding exists to reset", async () => {
+    // No custom branding = nothing to audit. Emitting a delete row for a
+    // no-op would pollute forensic queries counting actual branding changes.
+    mockDeleteResult = false;
+    const res = await request("DELETE");
+    expect(res.status).toBe(404);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+
+  it("GET / does not emit an audit row (read endpoint)", async () => {
+    mockBranding = null;
+    const res = await request("GET");
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/api/__tests__/admin-branding.test.ts
+++ b/packages/api/src/api/__tests__/admin-branding.test.ts
@@ -330,6 +330,54 @@ describe("admin branding — F-32 audit emission", () => {
     expect(mockLogAdminAction).not.toHaveBeenCalled();
   });
 
+  it("PUT / scrubs URI credentials from logoUrl/faviconUrl in audit metadata", async () => {
+    // An admin who pastes `https://user:pass@cdn/logo.png` into the logo
+    // URL field shouldn't accidentally write credentials into the audit
+    // trail. Userinfo must be scrubbed before the row lands in JSONB.
+    mockSetResult = {
+      id: "brand_1",
+      orgId: "org-1",
+      logoUrl: "https://user:p4ss@cdn.example.com/logo.png",
+      logoText: null,
+      primaryColor: null,
+      faviconUrl: "https://tok:s3cret@cdn.example.com/favicon.ico",
+      hideAtlasBranding: false,
+      createdAt: "2026-04-23T00:00:00Z",
+      updatedAt: "2026-04-23T00:00:00Z",
+    };
+    await request("PUT", {
+      logoUrl: "https://user:p4ss@cdn.example.com/logo.png",
+      faviconUrl: "https://tok:s3cret@cdn.example.com/favicon.ico",
+    });
+    const meta = mockLogAdminAction.mock.calls[0]![0].metadata!;
+    expect(meta.logoUrl).toBe("https://***@cdn.example.com/logo.png");
+    expect(meta.faviconUrl).toBe("https://***@cdn.example.com/favicon.ico");
+    // Defense in depth: serialized row shouldn't contain the secrets.
+    const serialized = JSON.stringify(mockLogAdminAction.mock.calls[0]![0]);
+    expect(serialized).not.toContain("p4ss");
+    expect(serialized).not.toContain("s3cret");
+  });
+
+  it("PUT / passes null URL values through unchanged (null = clear the field)", async () => {
+    // `null` is a semantically meaningful request-body value — it clears
+    // the field. Scrubbing must not coerce null into a string.
+    mockSetResult = {
+      id: "brand_1",
+      orgId: "org-1",
+      logoUrl: null,
+      logoText: "Acme",
+      primaryColor: null,
+      faviconUrl: null,
+      hideAtlasBranding: false,
+      createdAt: "2026-04-23T00:00:00Z",
+      updatedAt: "2026-04-23T00:00:00Z",
+    };
+    await request("PUT", { logoUrl: null, faviconUrl: null, logoText: "Acme" });
+    const meta = mockLogAdminAction.mock.calls[0]![0].metadata!;
+    expect(meta.logoUrl).toBeNull();
+    expect(meta.faviconUrl).toBeNull();
+  });
+
   it("GET / does not emit an audit row (read endpoint)", async () => {
     mockBranding = null;
     const res = await request("GET");

--- a/packages/api/src/api/__tests__/admin-compliance.test.ts
+++ b/packages/api/src/api/__tests__/admin-compliance.test.ts
@@ -2,13 +2,13 @@
  * Tests for admin compliance API endpoints — F-32 audit emission.
  *
  * Covers the two write routes under /api/v1/admin/compliance:
- *   - PUT    /classifications/{id}    (compliance.retention_update)
+ *   - PUT    /classifications/{id}    (compliance.pii_config_update)
  *   - DELETE /classifications/{id}    (compliance.pii_config_delete)
  *
- * Retention / PII-config changes are the same forensic class as F-26
- * (audit-about-audit): an admin who shrinks masking strategy from `full`
- * to `redact` on a Social Security Number column has silently relaxed the
- * workspace's PII posture, and without these rows there's no trail.
+ * PII-config changes are the same forensic class as F-26 (audit-about-audit):
+ * an admin who shrinks masking strategy from `full` to `redact` on a Social
+ * Security Number column has silently relaxed the workspace's PII posture,
+ * and without these rows there's no trail.
  *
  * Tests the adminCompliance sub-router directly so we can drive the EE
  * compliance service via mocks without booting every adjacent admin
@@ -223,7 +223,7 @@ function resetMocks(): void {
 describe("admin compliance — F-32 audit emission", () => {
   beforeEach(resetMocks);
 
-  it("PUT /classifications/:id emits compliance.retention_update on success", async () => {
+  it("PUT /classifications/:id emits compliance.pii_config_update on success", async () => {
     mockUpdateResult = makeClassification({
       id: "cls_1",
       maskingStrategy: "redact",
@@ -236,7 +236,7 @@ describe("admin compliance — F-32 audit emission", () => {
     expect(res.status).toBe(200);
     expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
     const entry = mockLogAdminAction.mock.calls[0]![0];
-    expect(entry.actionType).toBe("compliance.retention_update");
+    expect(entry.actionType).toBe("compliance.pii_config_update");
     expect(entry.targetType).toBe("compliance");
     expect(entry.targetId).toBe("cls_1");
     expect(entry.metadata?.maskingStrategy).toBe("redact");

--- a/packages/api/src/api/__tests__/admin-compliance.test.ts
+++ b/packages/api/src/api/__tests__/admin-compliance.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Tests for admin compliance API endpoints — F-32 audit emission.
+ *
+ * Covers the two write routes under /api/v1/admin/compliance:
+ *   - PUT    /classifications/{id}    (compliance.retention_update)
+ *   - DELETE /classifications/{id}    (compliance.pii_config_delete)
+ *
+ * Retention / PII-config changes are the same forensic class as F-26
+ * (audit-about-audit): an admin who shrinks masking strategy from `full`
+ * to `redact` on a Social Security Number column has silently relaxed the
+ * workspace's PII posture, and without these rows there's no trail.
+ *
+ * Tests the adminCompliance sub-router directly so we can drive the EE
+ * compliance service via mocks without booting every adjacent admin
+ * dependency. Pattern mirrors admin-audit-retention.test.ts.
+ */
+
+import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
+import { Effect } from "effect";
+
+import { ADMIN_ACTIONS as REAL_ADMIN_ACTIONS } from "@atlas/api/lib/audit/actions";
+
+// ── Auth + DB stubs ────────────────────────────────────────────────
+
+const mockAuthenticateRequest: Mock<(req: Request) => Promise<unknown>> = mock(
+  () =>
+    Promise.resolve({
+      authenticated: true,
+      mode: "managed",
+      user: {
+        id: "admin-1",
+        mode: "managed",
+        label: "admin@example.com",
+        role: "admin",
+        activeOrganizationId: "org-1",
+      },
+    }),
+);
+
+mock.module("@atlas/api/lib/auth/middleware", () => ({
+  authenticateRequest: mockAuthenticateRequest,
+  checkRateLimit: mock(() => ({ allowed: true })),
+  getClientIP: mock(() => null),
+  resetRateLimits: mock(() => {}),
+  rateLimitCleanupTick: mock(() => {}),
+  _setValidatorOverrides: mock(() => {}),
+}));
+
+mock.module("@atlas/api/lib/auth/detect", () => ({
+  detectAuthMode: () => "managed",
+  resetAuthModeCache: () => {},
+}));
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => true,
+  getInternalDB: () => ({
+    query: () => Promise.resolve({ rows: [] }),
+    end: async () => {},
+    on: () => {},
+  }),
+  internalQuery: () => Promise.resolve([]),
+  internalExecute: mock(() => {}),
+}));
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+  getRequestContext: () => null,
+}));
+
+// ── Audit logger mock — capture every emission ────────────────────
+
+interface CapturedAuditEntry {
+  actionType: string;
+  targetType: string;
+  targetId: string;
+  status?: "success" | "failure";
+  metadata?: Record<string, unknown>;
+  scope?: "platform" | "workspace";
+  ipAddress?: string | null;
+}
+
+const mockLogAdminAction: Mock<(entry: CapturedAuditEntry) => void> = mock(() => {});
+
+mock.module("@atlas/api/lib/audit", () => ({
+  logAdminAction: mockLogAdminAction,
+  logAdminActionAwait: mock(async () => {}),
+  ADMIN_ACTIONS: REAL_ADMIN_ACTIONS,
+  errorMessage: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+  causeToError: () => undefined,
+}));
+
+// ── EE compliance mock — driven per test ──────────────────────────
+
+const { ComplianceError: RealComplianceError } = await import(
+  "@atlas/ee/compliance/masking"
+);
+const { ReportError: RealReportError } = await import(
+  "@atlas/ee/compliance/reports"
+);
+
+interface PIIClassification {
+  id: string;
+  orgId: string;
+  connectionId: string;
+  tableName: string;
+  columnName: string;
+  category: string;
+  confidence: string;
+  maskingStrategy: string;
+  dismissed: boolean;
+  reviewed: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+let mockGetClassification: PIIClassification | null = null;
+let mockGetClassificationError: Error | null = null;
+let mockUpdateResult: PIIClassification | null = null;
+let mockUpdateError: Error | null = null;
+let mockDeleteError: Error | null = null;
+const mockInvalidate: Mock<(orgId: string) => void> = mock(() => {});
+
+mock.module("@atlas/ee/compliance/masking", () => ({
+  ComplianceError: RealComplianceError,
+  listPIIClassifications: () => Effect.succeed([]),
+  getPIIClassification: () => {
+    if (mockGetClassificationError) return Effect.fail(mockGetClassificationError);
+    return Effect.succeed(mockGetClassification);
+  },
+  updatePIIClassification: () => {
+    if (mockUpdateError) return Effect.fail(mockUpdateError);
+    return Effect.succeed(mockUpdateResult);
+  },
+  deletePIIClassification: () => {
+    if (mockDeleteError) return Effect.fail(mockDeleteError);
+    return Effect.succeed(true);
+  },
+  invalidateClassificationCache: mockInvalidate,
+}));
+
+mock.module("@atlas/ee/compliance/reports", () => ({
+  ReportError: RealReportError,
+  generateDataAccessReport: () => Effect.succeed({ rows: [], summary: { totalQueries: 0, uniqueUsers: 0, uniqueTables: 0, piiTablesAccessed: 0 }, filters: { startDate: "", endDate: "" }, generatedAt: "" }),
+  generateUserActivityReport: () => Effect.succeed({ rows: [], summary: { totalUsers: 0, activeUsers: 0, totalQueries: 0 }, filters: { startDate: "", endDate: "" }, generatedAt: "" }),
+  dataAccessReportToCSV: () => "",
+  userActivityReportToCSV: () => "",
+}));
+
+// ── Import sub-router AFTER mocks ─────────────────────────────────
+
+const { adminCompliance } = await import("../routes/admin-compliance");
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+async function request(
+  method: string,
+  path = "/classifications/cls_1",
+  body?: unknown,
+): Promise<Response> {
+  const init: RequestInit = {
+    method,
+    headers: { Authorization: "Bearer test-key" },
+  };
+  if (body !== undefined) {
+    (init.headers as Record<string, string>)["Content-Type"] =
+      "application/json";
+    init.body = JSON.stringify(body);
+  }
+  return adminCompliance.request(`http://localhost${path}`, init);
+}
+
+function makeClassification(
+  overrides: Partial<PIIClassification> = {},
+): PIIClassification {
+  return {
+    id: "cls_1",
+    orgId: "org-1",
+    connectionId: "default",
+    tableName: "users",
+    columnName: "email",
+    category: "email",
+    confidence: "high",
+    maskingStrategy: "full",
+    dismissed: false,
+    reviewed: false,
+    createdAt: "2026-04-20T00:00:00Z",
+    updatedAt: "2026-04-20T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function resetMocks(): void {
+  mockGetClassification = null;
+  mockGetClassificationError = null;
+  mockUpdateResult = null;
+  mockUpdateError = null;
+  mockDeleteError = null;
+  mockLogAdminAction.mockClear();
+  mockInvalidate.mockClear();
+  mockAuthenticateRequest.mockImplementation(() =>
+    Promise.resolve({
+      authenticated: true,
+      mode: "managed",
+      user: {
+        id: "admin-1",
+        mode: "managed",
+        label: "admin@example.com",
+        role: "admin",
+        activeOrganizationId: "org-1",
+      },
+    }),
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+describe("admin compliance — F-32 audit emission", () => {
+  beforeEach(resetMocks);
+
+  it("PUT /classifications/:id emits compliance.retention_update on success", async () => {
+    mockUpdateResult = makeClassification({
+      id: "cls_1",
+      maskingStrategy: "redact",
+      reviewed: true,
+    });
+    const res = await request("PUT", "/classifications/cls_1", {
+      maskingStrategy: "redact",
+      reviewed: true,
+    });
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.actionType).toBe("compliance.retention_update");
+    expect(entry.targetType).toBe("compliance");
+    expect(entry.targetId).toBe("cls_1");
+    expect(entry.metadata?.maskingStrategy).toBe("redact");
+    expect(entry.metadata?.reviewed).toBe(true);
+  });
+
+  it("PUT /classifications/:id captures only the fields the admin intended to change", async () => {
+    // Bodies that omit fields leave them untouched on the row. Metadata
+    // should reflect the intent (what the admin sent), not echo a full
+    // post-update snapshot — otherwise compliance queries can't tell a
+    // dismiss from a masking-strategy change without extra joins.
+    mockUpdateResult = makeClassification({ id: "cls_9", dismissed: true });
+    await request("PUT", "/classifications/cls_9", { dismissed: true });
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.metadata?.dismissed).toBe(true);
+    expect(entry.metadata).not.toHaveProperty("category");
+    expect(entry.metadata).not.toHaveProperty("maskingStrategy");
+    expect(entry.metadata).not.toHaveProperty("reviewed");
+  });
+
+  it("DELETE /classifications/:id emits compliance.pii_config_delete on success", async () => {
+    const res = await request("DELETE", "/classifications/cls_1");
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.actionType).toBe("compliance.pii_config_delete");
+    expect(entry.targetType).toBe("compliance");
+    expect(entry.targetId).toBe("cls_1");
+  });
+
+  it("PUT /classifications/:id does not emit audit when update throws", async () => {
+    // ComplianceError "not_found" is a probe signal, not a mutation — no
+    // classification was actually updated, so no audit row. Same as the
+    // residency retry "reject before write" semantics.
+    mockUpdateError = new RealComplianceError({
+      message: "Classification cls_missing not found.",
+      code: "not_found",
+    });
+    const res = await request("PUT", "/classifications/cls_missing", {
+      dismissed: true,
+    });
+    expect(res.status).toBe(404);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+
+  it("DELETE /classifications/:id does not emit audit when delete throws not_found", async () => {
+    mockDeleteError = new RealComplianceError({
+      message: "Classification cls_missing not found.",
+      code: "not_found",
+    });
+    const res = await request("DELETE", "/classifications/cls_missing");
+    expect(res.status).toBe(404);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+
+  it("GET /classifications does not emit an audit row (read endpoint)", async () => {
+    const res = await request("GET", "/classifications");
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+
+  it("GET /reports/data-access does not emit an audit row (read endpoint)", async () => {
+    const res = await request("GET", "/reports/data-access?startDate=2026-01-01&endDate=2026-04-01");
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/api/__tests__/admin-domains.test.ts
+++ b/packages/api/src/api/__tests__/admin-domains.test.ts
@@ -323,4 +323,13 @@ describe("admin custom domain — F-32 audit emission", () => {
     expect(res.status).toBe(404);
     expect(mockLogAdminAction).not.toHaveBeenCalled();
   });
+
+  it("POST /verify-dns on an un-configured workspace does not emit (404 short-circuit)", async () => {
+    // Symmetric to /verify — verify-dns has the same "no domain configured"
+    // pre-handler guard and must not land a stale `workspace_verify_dns` row.
+    enableEe({ listDomains: [] });
+    const res = await request("/verify-dns", "POST");
+    expect(res.status).toBe(404);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
 });

--- a/packages/api/src/api/__tests__/admin-domains.test.ts
+++ b/packages/api/src/api/__tests__/admin-domains.test.ts
@@ -11,6 +11,10 @@
  */
 
 import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
+import { Effect } from "effect";
+
+// Real ADMIN_ACTIONS values so assertions pin to the canonical strings.
+import { ADMIN_ACTIONS as REAL_ADMIN_ACTIONS } from "@atlas/api/lib/audit/actions";
 
 // --- Auth mock ---
 
@@ -50,6 +54,29 @@ mock.module("@atlas/api/lib/db/internal", () => ({
 mock.module("@atlas/api/lib/logger", () => ({
   createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
   withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+  getRequestContext: () => null,
+}));
+
+// --- Audit mock — capture every logAdminAction emission ---
+
+interface CapturedAuditEntry {
+  actionType: string;
+  targetType: string;
+  targetId: string;
+  status?: "success" | "failure";
+  metadata?: Record<string, unknown>;
+  scope?: "platform" | "workspace";
+  ipAddress?: string | null;
+}
+
+const mockLogAdminAction: Mock<(entry: CapturedAuditEntry) => void> = mock(() => {});
+
+mock.module("@atlas/api/lib/audit", () => ({
+  logAdminAction: mockLogAdminAction,
+  logAdminActionAwait: mock(async () => {}),
+  ADMIN_ACTIONS: REAL_ADMIN_ACTIONS,
+  errorMessage: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+  causeToError: () => undefined,
 }));
 
 // --- EE domains mock: loadDomains returns null to simulate EE-off build ---
@@ -81,11 +108,61 @@ const { adminDomains } = await import("../routes/admin-domains");
 
 function resetMocks() {
   mockLoadDomains.mockImplementation(() => Promise.resolve(null));
+  mockLogAdminAction.mockClear();
   mockAuthenticateRequest.mockImplementation(() =>
     Promise.resolve({
       authenticated: true,
       mode: "simple-key",
       user: { id: "admin-1", mode: "simple-key", label: "Admin", role: "admin", activeOrganizationId: "org-1" },
+    }),
+  );
+}
+
+// --- EE domains stub: load a fake module so POST / DELETE / verify routes
+// reach the audit emission path. The stub returns Effect.succeed(...) for
+// every method so the Effect.gen handlers run to completion.
+
+function makeDomainRecord(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "dom_abc123",
+    workspaceId: "org-1",
+    domain: "data.acme.com",
+    status: "pending",
+    createdAt: "2026-04-23T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function enableEe(
+  opts: {
+    listDomains?: Record<string, unknown>[];
+    registerDomain?: Record<string, unknown> | Error;
+    verifyDomain?: Record<string, unknown> | Error;
+    verifyDomainDnsTxt?: Record<string, unknown> | Error;
+    deleteDomain?: true | Error;
+    checkDomainAvailability?: Record<string, unknown>;
+  } = {},
+): void {
+  mockLoadDomains.mockImplementation(() =>
+    Promise.resolve({
+      listDomains: (_orgId: string) => Effect.succeed(opts.listDomains ?? []),
+      registerDomain: (_orgId: string, _domain: string) =>
+        opts.registerDomain instanceof Error
+          ? Effect.fail(opts.registerDomain)
+          : Effect.succeed(opts.registerDomain ?? makeDomainRecord()),
+      verifyDomain: (_id: string) =>
+        opts.verifyDomain instanceof Error
+          ? Effect.fail(opts.verifyDomain)
+          : Effect.succeed(opts.verifyDomain ?? makeDomainRecord({ status: "verified" })),
+      verifyDomainDnsTxt: (_id: string) =>
+        opts.verifyDomainDnsTxt instanceof Error
+          ? Effect.fail(opts.verifyDomainDnsTxt)
+          : Effect.succeed(opts.verifyDomainDnsTxt ?? makeDomainRecord({ status: "dns_verified" })),
+      deleteDomain: (_id: string) =>
+        opts.deleteDomain instanceof Error ? Effect.fail(opts.deleteDomain) : Effect.succeed(true),
+      checkDomainAvailability: (_domain: string, _orgId: string) =>
+        Effect.succeed(opts.checkDomainAvailability ?? { available: true }),
+      redactDomain: (d: Record<string, unknown>) => d,
     }),
   );
 }
@@ -160,5 +237,90 @@ describe("admin custom domain — EE disabled (loadDomains returns null)", () =>
     expect(res.status).toBe(404);
     const json = (await res.json()) as { error: string };
     expect(json.error).toBe("not_available");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F-32 audit-emission regression tests — admin-domains
+//
+// Every write under /api/v1/admin/domain must produce exactly one
+// admin_action_log row on success. The issue tracked four unaudited writes:
+// POST / (register), DELETE / (remove), POST /verify, POST /verify-dns.
+// ---------------------------------------------------------------------------
+
+describe("admin custom domain — F-32 audit emission", () => {
+  beforeEach(resetMocks);
+
+  it("POST / emits domain.workspace_register on success", async () => {
+    enableEe({ registerDomain: makeDomainRecord({ id: "dom_new1", domain: "data.acme.com" }) });
+    const res = await request("/", "POST", { domain: "data.acme.com" });
+    expect(res.status).toBe(201);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.actionType).toBe("domain.workspace_register");
+    expect(entry.targetType).toBe("domain");
+    expect(entry.targetId).toBe("dom_new1");
+    expect(entry.metadata?.domain).toBe("data.acme.com");
+  });
+
+  it("DELETE / emits domain.workspace_remove with the removed domain id", async () => {
+    enableEe({ listDomains: [makeDomainRecord({ id: "dom_del1" })] });
+    const res = await request("/", "DELETE");
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.actionType).toBe("domain.workspace_remove");
+    expect(entry.targetType).toBe("domain");
+    expect(entry.targetId).toBe("dom_del1");
+  });
+
+  it("POST /verify emits domain.workspace_verify", async () => {
+    enableEe({
+      listDomains: [makeDomainRecord({ id: "dom_v1" })],
+      verifyDomain: makeDomainRecord({ id: "dom_v1", status: "verified" }),
+    });
+    const res = await request("/verify", "POST");
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.actionType).toBe("domain.workspace_verify");
+    expect(entry.targetId).toBe("dom_v1");
+  });
+
+  it("POST /verify-dns emits domain.workspace_verify_dns", async () => {
+    enableEe({
+      listDomains: [makeDomainRecord({ id: "dom_vd1" })],
+      verifyDomainDnsTxt: makeDomainRecord({ id: "dom_vd1", status: "dns_verified" }),
+    });
+    const res = await request("/verify-dns", "POST");
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.actionType).toBe("domain.workspace_verify_dns");
+    expect(entry.targetId).toBe("dom_vd1");
+  });
+
+  it("GET / does not emit an audit row (read endpoint)", async () => {
+    enableEe();
+    const res = await request("/", "GET");
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+
+  it("GET /domain-check does not emit an audit row (read endpoint)", async () => {
+    enableEe({ checkDomainAvailability: { available: true } });
+    const res = await request("/domain-check?domain=test.example.com", "GET");
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+
+  it("POST /verify on an un-configured workspace does not emit (404 short-circuit)", async () => {
+    // The handler 404s before reaching verifyDomain(), so no audit row — the
+    // probe doesn't land a stale `workspace_verify` event against a domain
+    // that doesn't exist.
+    enableEe({ listDomains: [] });
+    const res = await request("/verify", "POST");
+    expect(res.status).toBe(404);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/api/__tests__/admin-residency.test.ts
+++ b/packages/api/src/api/__tests__/admin-residency.test.ts
@@ -31,21 +31,36 @@ const fakeAuthContext = {
 };
 
 // Minimal Effect shim — supports gen, promise, tryPromise, succeed, fail.
-// Also handles `.pipe(Effect.tapError(fn))` so admin-residency.ts can emit
-// failure audits (F-32): the tapError hook fires when the wrapped Effect
-// throws, before the throw propagates to the outer generator.
-interface TapErrorMarker {
-  readonly _tag: "TapError";
-  readonly fn: (err: unknown) => unknown;
+// Also handles `.pipe(Effect.tapErrorCause(fn))` so admin-residency.ts can
+// emit failure audits (F-32). `tapErrorCause` (vs `tapError`) also fires on
+// defects — the route uses the Cause variant so a rejected `Effect.promise`
+// (DB pool exhaustion, network drops) still lands a failure-audit row.
+interface TapErrorCauseMarker {
+  readonly _tag: "TapErrorCause";
+  readonly fn: (cause: MockCause) => unknown;
 }
 
-function isTapError(v: unknown): v is TapErrorMarker {
-  return typeof v === "object" && v !== null && (v as { _tag?: unknown })._tag === "TapError";
+// Minimal `Cause` shape the route's `causeToError` can walk via the
+// shimmed `Cause.isInterruptedOnly` / `Cause.failureOption` / `Cause.defects`
+// helpers. `_mockKind` distinguishes a typed failure from a defect so tests
+// can exercise either branch by flipping `mockAssignCauseKind` before the
+// throw.
+interface MockCause {
+  readonly _mockKind: "fail" | "defect";
+  readonly error: unknown;
 }
 
-// Wrap an iterable so that when Symbol.iterator's first `next()` throws, the
-// tapError hooks fire with the error before the throw propagates. Success
-// path is a passthrough — hooks only run on failure.
+function isTapErrorCause(v: unknown): v is TapErrorCauseMarker {
+  return typeof v === "object" && v !== null && (v as { _tag?: unknown })._tag === "TapErrorCause";
+}
+
+// Controls whether the synthesized Cause in withPipe's catch is a typed
+// failure or a defect. `"fail"` matches `mod.assignWorkspaceRegion` returning
+// `Effect.fail(ResidencyError)`; `"defect"` simulates a rejected
+// `Effect.promise` (the exact infrastructure-failure path `tapError` would
+// miss and `tapErrorCause` + `causeToError` closes).
+let mockAssignCauseKind: "fail" | "defect" = "fail";
+
 interface PipedIterable {
   [Symbol.iterator]: () => Iterator<unknown, unknown>;
   pipe: (...ops: unknown[]) => PipedIterable;
@@ -54,7 +69,7 @@ interface PipedIterable {
 function withPipe(iter: { [Symbol.iterator]: () => Iterator<unknown, unknown> }): PipedIterable {
   const piped = iter as PipedIterable;
   piped.pipe = (...ops: unknown[]) => {
-    const hooks = ops.filter(isTapError);
+    const hooks = ops.filter(isTapErrorCause);
     return withPipe({
       [Symbol.iterator]() {
         const inner = iter[Symbol.iterator]();
@@ -64,11 +79,13 @@ function withPipe(iter: { [Symbol.iterator]: () => Iterator<unknown, unknown> })
             try {
               return firstCall ? (firstCall = false, inner.next()) : inner.next(value);
             } catch (err) {
+              const cause: MockCause = { _mockKind: mockAssignCauseKind, error: err };
               for (const h of hooks) {
-                // Side-effect hooks return Effect.sync which has already
-                // executed by the time we get here. Swallow errors from
-                // the hook so the original failure still surfaces.
-                try { h.fn(err); } catch { /* intentionally ignored */ }
+                // Each hook invokes `Effect.sync(() => logAdminAction(...))`;
+                // in the mock `Effect.sync` executes its callback on
+                // invocation, so the audit emission lands before we re-throw.
+                // Swallow hook errors so the original failure still surfaces.
+                try { h.fn(cause); } catch { /* intentionally ignored */ }
               }
               throw err;
             }
@@ -83,6 +100,22 @@ function withPipe(iter: { [Symbol.iterator]: () => Iterator<unknown, unknown> })
 function mockEffectIterable(value: unknown) {
   return withPipe({ [Symbol.iterator]: () => ({ next: () => ({ done: true, value }) }) });
 }
+
+// Shim `Cause` + `Option` namespaces so `causeToError` in the route file
+// can walk the synthesized MockCause. Real Effect's `Cause` helpers return
+// richer types; the mock returns what `causeToError` actually reads.
+const mockCause = {
+  isInterruptedOnly: (_c: unknown) => false,
+  failureOption: (c: MockCause) =>
+    c._mockKind === "fail" ? { _tag: "Some" as const, value: c.error } : { _tag: "None" as const },
+  defects: (c: MockCause): Iterable<unknown> =>
+    c._mockKind === "defect" ? [c.error] : [],
+};
+
+const mockOption = {
+  isSome: (opt: { _tag: "Some" | "None" }): opt is { _tag: "Some"; value: unknown } =>
+    opt._tag === "Some",
+};
 
 mock.module("effect", () => {
   const Effect = {
@@ -102,13 +135,16 @@ mock.module("effect", () => {
     succeed: (value: unknown) => mockEffectIterable(value),
     fail: (error: unknown) => withPipe({ [Symbol.iterator]: () => ({ next: () => { throw error; } }) }),
     void: mockEffectIterable(undefined),
-    // Executes the side effect synchronously so audit emission lands before
-    // the throw unwinds. Returns an iterable that resolves to undefined.
+    // `Effect.sync(fn)` runs `fn` on invocation so the audit emission lands
+    // before the throw unwinds. Returns an iterable that resolves to undefined.
     sync: (fn: () => unknown) => { fn(); return mockEffectIterable(undefined); },
-    tapError: (fn: (err: unknown) => unknown): TapErrorMarker => ({ _tag: "TapError", fn }),
+    tapErrorCause: (fn: (cause: MockCause) => unknown): TapErrorCauseMarker => ({
+      _tag: "TapErrorCause",
+      fn,
+    }),
     runPromise: (value: unknown) => Promise.resolve(value),
   };
-  return { Effect };
+  return { Effect, Cause: mockCause, Option: mockOption };
 });
 
 mock.module("@atlas/api/lib/effect/services", () => ({
@@ -149,7 +185,13 @@ mock.module("@atlas/api/lib/effect/hono", () => ({
           }
         }
       }
-      throw err;
+      // Unknown / defect errors land as 500 in production. Return the same
+      // shape so tests exercising the defect audit path see the realistic
+      // 500 response rather than a raw throw.
+      return new Response(
+        JSON.stringify({ error: "internal_error", message: "Internal server error", requestId: "test-req-1" }),
+        { status: 500 },
+      );
     }
   },
   DomainErrorMapping: Array,
@@ -353,6 +395,7 @@ function resetMocks() {
   mockInternalQueryResult = [];
   mockResetResult = { ok: true };
   mockCancelResult = { ok: true };
+  mockAssignCauseKind = "fail";
   mockEffectUser = {
     id: "admin-1",
     mode: "simple-key",
@@ -805,7 +848,7 @@ describe("admin residency — F-32 audit emission", () => {
     expect(entry.metadata?.permanent).toBe(true);
   });
 
-  it("PUT / emits residency.workspace_assign with status=failure when assignment throws", async () => {
+  it("PUT / emits residency.workspace_assign with status=failure on typed failure (409 probe)", async () => {
     // Permanent decisions deserve failure audits — the attempt itself is
     // useful evidence. Without this, a 409 "already assigned" probe that
     // reveals the current region leaves no forensic record.
@@ -821,6 +864,47 @@ describe("admin residency — F-32 audit emission", () => {
     expect(entry.status).toBe("failure");
     expect(entry.metadata?.region).toBe("eu-west");
     expect(entry.metadata?.permanent).toBe(true);
+    // metadata.error must carry the conflict reason so forensic queries
+    // can distinguish a probe from a legitimate misconfiguration without
+    // cross-referencing pino logs.
+    expect(entry.metadata?.error).toContain("already assigned");
+  });
+
+  it("PUT / emits failure audit on DEFECT path (rejected Effect.promise, not typed failure)", async () => {
+    // `assignWorkspaceRegion` wraps `setWorkspaceRegion` in `Effect.promise`,
+    // so pg pool exhaustion / network drops surface as defects, not typed
+    // failures. `Effect.tapError` alone would drop the audit row on the
+    // exact infrastructure-failure path a malicious admin would probe for.
+    // `tapErrorCause` + `causeToError` closes that gap.
+    mockAssignCauseKind = "defect";
+    mockAssignError = new Error("pg connection refused");
+    const res = await request("PUT", "/", { region: "eu-west" });
+    expect(res.status).toBe(500);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.actionType).toBe("residency.workspace_assign");
+    expect(entry.status).toBe("failure");
+    expect(entry.metadata?.permanent).toBe(true);
+    expect(entry.metadata?.error).toContain("pg connection refused");
+  });
+
+  it("PUT / failure audit scrubs URI credentials from error metadata", async () => {
+    // pg error text routinely echoes the connection string. If that lands
+    // verbatim in admin_action_log.metadata, the DB password leaks into the
+    // audit row compliance reviewers read directly. The local
+    // `errorMessage` helper must scrub `proto://user:pass@host` userinfo.
+    mockAssignError = new MockResidencyError(
+      "setWorkspaceRegion failed: postgresql://admin:s3cret@db.internal/atlas — timeout",
+      "invalid_region",
+    );
+    await request("PUT", "/", { region: "eu-west" });
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    const errText = entry.metadata?.error;
+    expect(typeof errText).toBe("string");
+    expect(errText).toContain("postgresql://***@");
+    expect(errText).not.toContain("s3cret");
+    expect(errText).not.toContain("admin:s3cret");
   });
 
   it("POST /migrate emits residency.migration_request with source/target regions", async () => {
@@ -883,6 +967,19 @@ describe("admin residency — F-32 audit emission", () => {
     expect(entry.actionType).toBe("residency.migration_cancel");
     expect(entry.targetType).toBe("residency");
     expect(entry.targetId).toBe("mig-1");
+  });
+
+  it("POST /migrate/:id/cancel does NOT emit audit when cancel is rejected", async () => {
+    // Symmetric to the retry case — pre-handler rejection means the migration
+    // wasn't actually cancelled, so no audit row should land.
+    mockCancelResult = {
+      ok: false,
+      reason: "invalid_status",
+      error: "Cannot cancel in_progress migration",
+    };
+    const res = await request("POST", "/migrate/mig-1/cancel");
+    expect(res.status).toBe(400);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
   });
 
   it("GET / does not emit an audit row (read endpoint)", async () => {

--- a/packages/api/src/api/__tests__/admin-residency.test.ts
+++ b/packages/api/src/api/__tests__/admin-residency.test.ts
@@ -7,6 +7,9 @@
 
 import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
 
+// Real ADMIN_ACTIONS values so assertions pin to the canonical strings.
+import { ADMIN_ACTIONS as REAL_ADMIN_ACTIONS } from "@atlas/api/lib/audit/actions";
+
 // --- Effect mock ---
 // Mock the Effect bridge so the route file can load and execute without
 // the full Effect runtime. Effect.gen + runEffect are shimmed to execute
@@ -27,9 +30,58 @@ const fakeAuthContext = {
   },
 };
 
-// Minimal Effect shim — supports gen, promise, tryPromise, succeed, fail
+// Minimal Effect shim — supports gen, promise, tryPromise, succeed, fail.
+// Also handles `.pipe(Effect.tapError(fn))` so admin-residency.ts can emit
+// failure audits (F-32): the tapError hook fires when the wrapped Effect
+// throws, before the throw propagates to the outer generator.
+interface TapErrorMarker {
+  readonly _tag: "TapError";
+  readonly fn: (err: unknown) => unknown;
+}
+
+function isTapError(v: unknown): v is TapErrorMarker {
+  return typeof v === "object" && v !== null && (v as { _tag?: unknown })._tag === "TapError";
+}
+
+// Wrap an iterable so that when Symbol.iterator's first `next()` throws, the
+// tapError hooks fire with the error before the throw propagates. Success
+// path is a passthrough — hooks only run on failure.
+interface PipedIterable {
+  [Symbol.iterator]: () => Iterator<unknown, unknown>;
+  pipe: (...ops: unknown[]) => PipedIterable;
+}
+
+function withPipe(iter: { [Symbol.iterator]: () => Iterator<unknown, unknown> }): PipedIterable {
+  const piped = iter as PipedIterable;
+  piped.pipe = (...ops: unknown[]) => {
+    const hooks = ops.filter(isTapError);
+    return withPipe({
+      [Symbol.iterator]() {
+        const inner = iter[Symbol.iterator]();
+        let firstCall = true;
+        return {
+          next(value?: unknown): IteratorResult<unknown, unknown> {
+            try {
+              return firstCall ? (firstCall = false, inner.next()) : inner.next(value);
+            } catch (err) {
+              for (const h of hooks) {
+                // Side-effect hooks return Effect.sync which has already
+                // executed by the time we get here. Swallow errors from
+                // the hook so the original failure still surfaces.
+                try { h.fn(err); } catch { /* intentionally ignored */ }
+              }
+              throw err;
+            }
+          },
+        };
+      },
+    });
+  };
+  return piped;
+}
+
 function mockEffectIterable(value: unknown) {
-  return { [Symbol.iterator]: () => ({ next: () => ({ done: true, value }) }) };
+  return withPipe({ [Symbol.iterator]: () => ({ next: () => ({ done: true, value }) }) });
 }
 
 mock.module("effect", () => {
@@ -37,19 +89,23 @@ mock.module("effect", () => {
     gen: (genFn: () => Generator) => {
       return { _tag: "EffectGen", genFn };
     },
-    promise: (fn: () => Promise<unknown>) => ({
+    promise: (fn: () => Promise<unknown>) => withPipe({
       [Symbol.iterator]: function* (): Generator<unknown, unknown> {
         return yield { _tag: "EffectPromise", fn };
       },
     }),
-    tryPromise: (opts: { try: () => Promise<unknown>; catch: (err: unknown) => unknown }) => ({
+    tryPromise: (opts: { try: () => Promise<unknown>; catch: (err: unknown) => unknown }) => withPipe({
       [Symbol.iterator]: function* (): Generator<unknown, unknown> {
         return yield { _tag: "EffectPromise", fn: opts.try };
       },
     }),
     succeed: (value: unknown) => mockEffectIterable(value),
-    fail: (error: unknown) => ({ [Symbol.iterator]: () => ({ next: () => { throw error; } }) }),
+    fail: (error: unknown) => withPipe({ [Symbol.iterator]: () => ({ next: () => { throw error; } }) }),
     void: mockEffectIterable(undefined),
+    // Executes the side effect synchronously so audit emission lands before
+    // the throw unwinds. Returns an iterable that resolves to undefined.
+    sync: (fn: () => unknown) => { fn(); return mockEffectIterable(undefined); },
+    tapError: (fn: (err: unknown) => unknown): TapErrorMarker => ({ _tag: "TapError", fn }),
     runPromise: (value: unknown) => Promise.resolve(value),
   };
   return { Effect };
@@ -202,7 +258,11 @@ mock.module("@atlas/ee/platform/residency", () => ({
   },
   getWorkspaceRegionAssignment: () => mockEffectIterable(mockAssignment),
   assignWorkspaceRegion: () => {
-    if (mockAssignError) return { [Symbol.iterator]: () => ({ next: () => { throw mockAssignError; } }) };
+    if (mockAssignError) {
+      return withPipe({
+        [Symbol.iterator]: () => ({ next: () => { throw mockAssignError; } }),
+      });
+    }
     return mockEffectIterable(mockAssignResult);
   },
   ResidencyError: MockResidencyError,
@@ -228,6 +288,29 @@ mock.module("@atlas/api/lib/logger", () => ({
     debug: () => {},
   }),
   withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+  getRequestContext: () => null,
+}));
+
+// --- Audit mock — capture every logAdminAction emission ---
+
+interface CapturedAuditEntry {
+  actionType: string;
+  targetType: string;
+  targetId: string;
+  status?: "success" | "failure";
+  metadata?: Record<string, unknown>;
+  scope?: "platform" | "workspace";
+  ipAddress?: string | null;
+}
+
+const mockLogAdminAction: Mock<(entry: CapturedAuditEntry) => void> = mock(() => {});
+
+mock.module("@atlas/api/lib/audit", () => ({
+  logAdminAction: mockLogAdminAction,
+  logAdminActionAwait: mock(async () => {}),
+  ADMIN_ACTIONS: REAL_ADMIN_ACTIONS,
+  errorMessage: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+  causeToError: () => undefined,
 }));
 
 // --- Migration executor mock ---
@@ -278,6 +361,7 @@ function resetMocks() {
     activeOrganizationId: "org-1",
     orgId: "org-1",
   };
+  mockLogAdminAction.mockClear();
   mockAuthenticateRequest.mockImplementation(() =>
     Promise.resolve({
       authenticated: true,
@@ -686,6 +770,132 @@ describe("POST /migrate/:id/cancel", () => {
     mockHasInternalDB = false;
     const res = await request("POST", "/migrate/mig-1/cancel");
     expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F-32 audit-emission regression tests — admin-residency
+//
+// Residency is the highest-stakes class in this file. `workspace_assign` is
+// permanent — its metadata MUST carry `permanent: true` so triage flags the
+// permanence on the audit row. Migration request / retry / cancel are not
+// permanent but are still compliance-critical (cross-region data movement).
+// ---------------------------------------------------------------------------
+
+describe("admin residency — F-32 audit emission", () => {
+  beforeEach(resetMocks);
+
+  it("PUT / emits residency.workspace_assign with permanent:true on success", async () => {
+    mockAssignResult = {
+      workspaceId: "org-1",
+      region: "eu-west",
+      assignedAt: "2026-04-23T00:00:00Z",
+    };
+    const res = await request("PUT", "/", { region: "eu-west" });
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.actionType).toBe("residency.workspace_assign");
+    expect(entry.targetType).toBe("residency");
+    expect(entry.targetId).toBe("org-1");
+    expect(entry.metadata?.region).toBe("eu-west");
+    // F-32 acceptance criteria: `permanent: true` must be in metadata so
+    // compliance triage knows this row represents an irreversible state
+    // change, not a routine config tweak.
+    expect(entry.metadata?.permanent).toBe(true);
+  });
+
+  it("PUT / emits residency.workspace_assign with status=failure when assignment throws", async () => {
+    // Permanent decisions deserve failure audits — the attempt itself is
+    // useful evidence. Without this, a 409 "already assigned" probe that
+    // reveals the current region leaves no forensic record.
+    mockAssignError = new MockResidencyError(
+      'Workspace is already assigned to region "us-east".',
+      "already_assigned",
+    );
+    const res = await request("PUT", "/", { region: "eu-west" });
+    expect(res.status).toBe(409);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.actionType).toBe("residency.workspace_assign");
+    expect(entry.status).toBe("failure");
+    expect(entry.metadata?.region).toBe("eu-west");
+    expect(entry.metadata?.permanent).toBe(true);
+  });
+
+  it("POST /migrate emits residency.migration_request with source/target regions", async () => {
+    mockAssignment = {
+      workspaceId: "org-1",
+      region: "us-east",
+      assignedAt: "2026-04-01T00:00:00Z",
+    };
+    // Two internalQuery calls follow (existing + rate-limit) then INSERT;
+    // empty rows flow through the handler to the audit emit.
+    mockInternalQueryResult = [];
+    const res = await request("POST", "/migrate", { targetRegion: "eu-west" });
+    expect(res.status).toBe(201);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.actionType).toBe("residency.migration_request");
+    expect(entry.targetType).toBe("residency");
+    expect(entry.metadata?.sourceRegion).toBe("us-east");
+    expect(entry.metadata?.targetRegion).toBe("eu-west");
+  });
+
+  it("POST /migrate/:id/retry emits residency.migration_retry on success", async () => {
+    mockInternalQueryResult = [
+      {
+        id: "mig-1",
+        workspace_id: "org-1",
+        source_region: "us-east",
+        target_region: "eu-west",
+        status: "pending",
+        requested_by: "admin-1",
+        requested_at: "2026-04-01T00:00:00Z",
+        completed_at: null,
+        error_message: null,
+      },
+    ];
+    const res = await request("POST", "/migrate/mig-1/retry");
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.actionType).toBe("residency.migration_retry");
+    expect(entry.targetType).toBe("residency");
+    expect(entry.targetId).toBe("mig-1");
+  });
+
+  it("POST /migrate/:id/retry does NOT emit audit when retry is rejected", async () => {
+    // Pre-handler rejection (resetMigrationForRetry returned ok:false) should
+    // not land an audit row — the migration wasn't actually retried, and
+    // emitting would pollute the forensic record with no-op retry attempts.
+    mockResetResult = { ok: false, reason: "invalid_status", error: "Cannot retry" };
+    const res = await request("POST", "/migrate/mig-1/retry");
+    expect(res.status).toBe(400);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+
+  it("POST /migrate/:id/cancel emits residency.migration_cancel on success", async () => {
+    const res = await request("POST", "/migrate/mig-1/cancel");
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.actionType).toBe("residency.migration_cancel");
+    expect(entry.targetType).toBe("residency");
+    expect(entry.targetId).toBe("mig-1");
+  });
+
+  it("GET / does not emit an audit row (read endpoint)", async () => {
+    const res = await request("GET");
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+
+  it("GET /migration does not emit an audit row (read endpoint)", async () => {
+    mockInternalQueryResult = [];
+    const res = await request("GET", "/migration");
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/api/src/api/routes/admin-branding.ts
+++ b/packages/api/src/api/routes/admin-branding.ts
@@ -7,8 +7,10 @@
 
 import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
+import type { Context } from "hono";
 import { runEffect, domainError } from "@atlas/api/lib/effect/hono";
 import { AuthContext } from "@atlas/api/lib/effect/services";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import {
   getWorkspaceBranding,
   setWorkspaceBranding,
@@ -20,6 +22,10 @@ import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
 
 const brandingDomainError = domainError(BrandingError, { validation: 400, not_found: 404 });
+
+function clientIP(c: Context): string | null {
+  return c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null;
+}
 
 // `BrandingSchema` is re-exported under its prior local alias from
 // `@useatlas/schemas` so the existing route definitions below don't need
@@ -209,10 +215,11 @@ adminBranding.openapi(getBrandingRoute, async (c) => {
 
 // PUT / — set workspace branding
 adminBranding.openapi(setBrandingRoute, async (c) => {
+  const ipAddress = clientIP(c);
+  const body = c.req.valid("json");
+
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
-
-    const body = c.req.valid("json");
 
     const branding = yield* setWorkspaceBranding(orgId!, {
       logoUrl: body.logoUrl,
@@ -221,19 +228,47 @@ adminBranding.openapi(setBrandingRoute, async (c) => {
       faviconUrl: body.faviconUrl,
       hideAtlasBranding: body.hideAtlasBranding,
     });
+    // Metadata mirrors the request body so compliance review can distinguish a
+    // cosmetic tweak (primaryColor) from a white-label takeover
+    // (hideAtlasBranding: true). Only fields the admin actually set show up —
+    // a future refactor that spreads `branding` itself would echo
+    // post-state defaults and obscure the admin's intent.
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.branding.update,
+      targetType: "branding",
+      targetId: orgId!,
+      ipAddress,
+      metadata: {
+        ...(body.logoUrl !== undefined && { logoUrl: body.logoUrl }),
+        ...(body.logoText !== undefined && { logoText: body.logoText }),
+        ...(body.primaryColor !== undefined && { primaryColor: body.primaryColor }),
+        ...(body.faviconUrl !== undefined && { faviconUrl: body.faviconUrl }),
+        ...(body.hideAtlasBranding !== undefined && { hideAtlasBranding: body.hideAtlasBranding }),
+      },
+    });
     return c.json({ branding }, 200);
   }), { label: "save workspace branding", domainErrors: [brandingDomainError] });
 });
 
 // DELETE / — reset workspace branding
 adminBranding.openapi(deleteBrandingRoute, async (c) => {
+  const ipAddress = clientIP(c);
+
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
 
     const deleted = yield* deleteWorkspaceBranding(orgId!);
     if (!deleted) {
+      // No-op deletes don't audit — nothing was reset, so emitting a row
+      // would pollute forensic queries that count actual branding changes.
       return c.json({ error: "not_found", message: "No custom branding found." }, 404);
     }
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.branding.delete,
+      targetType: "branding",
+      targetId: orgId!,
+      ipAddress,
+    });
     return c.json({ message: "Branding reset to Atlas defaults." }, 200);
   }), { label: "reset workspace branding", domainErrors: [brandingDomainError] });
 });

--- a/packages/api/src/api/routes/admin-branding.ts
+++ b/packages/api/src/api/routes/admin-branding.ts
@@ -27,6 +27,16 @@ function clientIP(c: Context): string | null {
   return c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null;
 }
 
+// Strip `user:pass@` userinfo from an admin-supplied URL before it lands in
+// `admin_action_log.metadata`. An admin who pastes
+// `https://u:tok@cdn/logo.png` into the logo URL field shouldn't accidentally
+// write their credentials into the audit trail compliance reviewers read.
+// `null` passes through unchanged (null means "clear the field").
+function scrubUrl(url: string | null | undefined): string | null | undefined {
+  if (url === null || url === undefined) return url;
+  return url.replace(/\b([a-z][a-z0-9+.-]*):\/\/[^\s@/]*@/gi, "$1://***@");
+}
+
 // `BrandingSchema` is re-exported under its prior local alias from
 // `@useatlas/schemas` so the existing route definitions below don't need
 // to change — single source of truth for the workspace-branding wire shape.
@@ -239,10 +249,10 @@ adminBranding.openapi(setBrandingRoute, async (c) => {
       targetId: orgId!,
       ipAddress,
       metadata: {
-        ...(body.logoUrl !== undefined && { logoUrl: body.logoUrl }),
+        ...(body.logoUrl !== undefined && { logoUrl: scrubUrl(body.logoUrl) }),
         ...(body.logoText !== undefined && { logoText: body.logoText }),
         ...(body.primaryColor !== undefined && { primaryColor: body.primaryColor }),
-        ...(body.faviconUrl !== undefined && { faviconUrl: body.faviconUrl }),
+        ...(body.faviconUrl !== undefined && { faviconUrl: scrubUrl(body.faviconUrl) }),
         ...(body.hideAtlasBranding !== undefined && { hideAtlasBranding: body.hideAtlasBranding }),
       },
     });

--- a/packages/api/src/api/routes/admin-compliance.ts
+++ b/packages/api/src/api/routes/admin-compliance.ts
@@ -163,7 +163,7 @@ adminCompliance.openapi(updateRoute, async (c) => {
     // the admin's *intent* (shrinking mask from `full` to `redact` is the
     // high-stakes signal compliance review pivots on).
     logAdminAction({
-      actionType: ADMIN_ACTIONS.compliance.retentionUpdate,
+      actionType: ADMIN_ACTIONS.compliance.piiConfigUpdate,
       targetType: "compliance",
       targetId: id,
       ipAddress,

--- a/packages/api/src/api/routes/admin-compliance.ts
+++ b/packages/api/src/api/routes/admin-compliance.ts
@@ -15,8 +15,10 @@
 import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
+import type { Context } from "hono";
 import { runEffect, domainError } from "@atlas/api/lib/effect/hono";
 import { AuthContext } from "@atlas/api/lib/effect/services";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import {
   listPIIClassifications,
   updatePIIClassification,
@@ -38,6 +40,10 @@ import { createAdminRouter, requireOrgContext } from "./admin-router";
 
 const complianceDomainError = domainError(ComplianceError, { validation: 400, not_found: 404, conflict: 409 });
 const reportDomainError = domainError(ReportError, { validation: 400, not_available: 404 });
+
+function clientIP(c: Context): string | null {
+  return c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null;
+}
 
 // `PIIClassificationSchema` is re-exported under its prior local alias from
 // `@useatlas/schemas`. That migration tightens `category` / `confidence` /
@@ -138,10 +144,12 @@ adminCompliance.openapi(listRoute, async (c) => {
 
 // PUT /classifications/:id
 adminCompliance.openapi(updateRoute, async (c) => {
+  const ipAddress = clientIP(c);
+  const id = c.req.param("id");
+  const body = c.req.valid("json");
+
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
-    const id = c.req.param("id");
-    const body = c.req.valid("json");
 
     const updated = yield* updatePIIClassification(orgId!, id, {
       category: body.category as PIICategory | undefined,
@@ -150,18 +158,42 @@ adminCompliance.openapi(updateRoute, async (c) => {
       reviewed: body.reviewed,
     });
     invalidateClassificationCache(orgId!);
+    // Metadata mirrors only the request-body fields that were actually set —
+    // spreading the update result would echo post-state defaults and drown
+    // the admin's *intent* (shrinking mask from `full` to `redact` is the
+    // high-stakes signal compliance review pivots on).
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.compliance.retentionUpdate,
+      targetType: "compliance",
+      targetId: id,
+      ipAddress,
+      metadata: {
+        ...(body.category !== undefined && { category: body.category }),
+        ...(body.maskingStrategy !== undefined && { maskingStrategy: body.maskingStrategy }),
+        ...(body.dismissed !== undefined && { dismissed: body.dismissed }),
+        ...(body.reviewed !== undefined && { reviewed: body.reviewed }),
+      },
+    });
     return c.json({ classification: updated }, 200);
   }), { label: "update PII classification", domainErrors: [complianceDomainError, reportDomainError] });
 });
 
 // DELETE /classifications/:id
 adminCompliance.openapi(deleteRoute, async (c) => {
+  const ipAddress = clientIP(c);
+  const id = c.req.param("id");
+
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
-    const id = c.req.param("id");
 
     yield* deletePIIClassification(orgId!, id);
     invalidateClassificationCache(orgId!);
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.compliance.piiConfigDelete,
+      targetType: "compliance",
+      targetId: id,
+      ipAddress,
+    });
     return c.json({ deleted: true }, 200);
   }), { label: "delete PII classification", domainErrors: [complianceDomainError, reportDomainError] });
 });

--- a/packages/api/src/api/routes/admin-domains.ts
+++ b/packages/api/src/api/routes/admin-domains.ts
@@ -17,7 +17,9 @@
 
 import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
+import type { Context } from "hono";
 import { createLogger } from "@atlas/api/lib/logger";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { AuthContext, RequestContext } from "@atlas/api/lib/effect/services";
 import { hasInternalDB, getWorkspaceDetails } from "@atlas/api/lib/db/internal";
@@ -30,6 +32,10 @@ import {
   customDomainError,
   loadDomains,
 } from "./shared-domains";
+
+function clientIP(c: Context): string | null {
+  return c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null;
+}
 
 const log = createLogger("admin-domains");
 
@@ -319,6 +325,13 @@ adminDomains.openapi(addDomainRoute, async (c) => {
 
     const domain = yield* mod.registerDomain(orgId, body.domain);
     log.info({ orgId, domain: body.domain, requestId }, "Workspace custom domain registered");
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.domain.workspaceRegister,
+      targetType: "domain",
+      targetId: domain.id,
+      ipAddress: clientIP(c),
+      metadata: { domain: body.domain },
+    });
     // Return full token on registration so admin can set up the DNS TXT record
     return c.json(mod.redactDomain(domain, true), 201);
   }), { label: "add workspace domain", domainErrors: [customDomainError] });
@@ -346,6 +359,13 @@ adminDomains.openapi(verifyDomainRoute, async (c) => {
     }
 
     const domain = yield* mod.verifyDomain(domains[0].id);
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.domain.workspaceVerify,
+      targetType: "domain",
+      targetId: domains[0].id,
+      ipAddress: clientIP(c),
+      metadata: { status: domain.status ?? null },
+    });
     return c.json(mod.redactDomain(domain), 200);
   }), { label: "verify workspace domain", domainErrors: [customDomainError] });
 });
@@ -371,6 +391,13 @@ adminDomains.openapi(verifyDnsTxtRoute, async (c) => {
     }
 
     const domain = yield* mod.verifyDomainDnsTxt(domains[0].id);
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.domain.workspaceVerifyDns,
+      targetType: "domain",
+      targetId: domains[0].id,
+      ipAddress: clientIP(c),
+      metadata: { status: domain.status ?? null },
+    });
     return c.json(mod.redactDomain(domain), 200);
   }), { label: "verify domain DNS TXT", domainErrors: [customDomainError] });
 });
@@ -423,6 +450,13 @@ adminDomains.openapi(removeDomainRoute, async (c) => {
 
     yield* mod.deleteDomain(domains[0].id);
     log.info({ orgId, domainId: domains[0].id, requestId }, "Workspace custom domain removed");
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.domain.workspaceRemove,
+      targetType: "domain",
+      targetId: domains[0].id,
+      ipAddress: clientIP(c),
+      metadata: { domain: domains[0].domain },
+    });
     return c.json({ deleted: true }, 200);
   }), { label: "remove workspace domain", domainErrors: [customDomainError] });
 });

--- a/packages/api/src/api/routes/admin-residency.ts
+++ b/packages/api/src/api/routes/admin-residency.ts
@@ -8,7 +8,7 @@
  * or residency is not configured.
  */
 
-import { Effect } from "effect";
+import { Cause, Effect, Option } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
 import type { Context } from "hono";
 import { runEffect } from "@atlas/api/lib/effect/hono";
@@ -31,14 +31,11 @@ function clientIP(c: Context): string | null {
   return c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null;
 }
 
-// Local `errorMessage` — matches the helper in `admin-roles.ts` so residency
-// failure audits never leak connection-string credentials. Inlined rather
-// than imported from `@atlas/api/lib/audit` because other admin test files
-// only mock the handful of audit exports they need and adding a new load-
-// bearing import would cascade module-resolution errors across ~8 test
-// files (per CLAUDE.md: "mock.module() must cover every named export").
-// If/when the audit-mock drift is cleaned up project-wide, swap this back
-// for the shared helper.
+// Local `errorMessage` — mirrors the helper in `admin-roles.ts` (F-25) so
+// residency failure audits never leak connection-string credentials. Inlined
+// rather than imported from `@atlas/api/lib/audit` so existing admin tests
+// that partial-mock the audit module don't break on a new load-bearing
+// export (per CLAUDE.md: "mock.module() must cover every named export").
 const ERROR_MESSAGE_MAX = 512;
 function errorMessage(err: unknown): string {
   const raw = err instanceof Error ? err.message : String(err);
@@ -46,6 +43,21 @@ function errorMessage(err: unknown): string {
   return scrubbed.length > ERROR_MESSAGE_MAX
     ? `${scrubbed.slice(0, ERROR_MESSAGE_MAX - 3)}...`
     : scrubbed;
+}
+
+// Extract the primary error from an Effect `Cause` — covers typed failures
+// AND defects (rejected `Effect.promise`, `Effect.die`). `Effect.tapError`
+// misses defects entirely, so `assignWorkspaceRegion` (which wraps a DB
+// write in `Effect.promise`) would silently drop the failure-audit row on
+// pool-exhaustion or network drops. `tapErrorCause` + `causeToError`
+// closes that gap — the same pattern `admin-roles.ts` uses.
+// Returns undefined on pure interrupts (fiber cancellation).
+function causeToError(cause: Cause.Cause<unknown>): unknown | undefined {
+  if (Cause.isInterruptedOnly(cause)) return undefined;
+  const failure = Cause.failureOption(cause);
+  if (Option.isSome(failure)) return failure.value;
+  for (const defect of Cause.defects(cause)) return defect;
+  return undefined;
 }
 
 const log = createLogger("admin-residency");
@@ -572,24 +584,31 @@ adminResidency.openapi(assignRegionRoute, async (c) => {
         return c.json({ error: "not_available", message: "Data residency is not available in this deployment." }, 404);
       }
 
-      // Inline failure audit via `.pipe(tapError)` keeps the emission close
-      // to the yield that can fail. Failure audits on
+      // Inline failure audit via `.pipe(tapErrorCause)` keeps the emission
+      // close to the yield that can fail. Failure audits on
       // residency.workspaceAssign are not optional: the attempt itself is
       // compliance-relevant (a 409 reveals the current region; repeated
-      // 400s fingerprint a probe for configured regions).
+      // 400s fingerprint a probe for configured regions). `tapErrorCause`
+      // covers both typed `ResidencyError` failures AND defects from
+      // `Effect.promise` (rejected DB promises — pool exhaustion, network
+      // drops). `tapError` alone would miss defects, dropping the audit
+      // row on exactly the infrastructure-failure mode an attacker would
+      // probe for.
       const result = yield* mod.assignWorkspaceRegion(orgId!, region as string).pipe(
-        Effect.tapError((err) =>
-          Effect.sync(() =>
+        Effect.tapErrorCause((cause) => {
+          const err = causeToError(cause);
+          if (err === undefined) return Effect.void;
+          return Effect.sync(() =>
             logAdminAction({
               actionType: ADMIN_ACTIONS.residency.workspaceAssign,
               targetType: "residency",
-              targetId: orgId ?? "unknown",
+              targetId: orgId!,
               status: "failure",
               ipAddress,
               metadata: { region, permanent: true, error: errorMessage(err) },
             }),
-          ),
-        ),
+          );
+        }),
       );
       log.info({ orgId, region }, "Workspace region assigned via self-serve");
       // Permanent decision — `permanent: true` surfaces the irreversibility

--- a/packages/api/src/api/routes/admin-residency.ts
+++ b/packages/api/src/api/routes/admin-residency.ts
@@ -10,10 +10,12 @@
 
 import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
+import type { Context } from "hono";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
 import { hasInternalDB, queryEffect } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import {
   triggerMigrationExecution,
   failStaleMigrations,
@@ -24,6 +26,27 @@ import { MIGRATION_STATUSES, type RegionMigration } from "@useatlas/types";
 import { RegionMigrationSchema, MigrationStatusResponseSchema } from "@useatlas/schemas";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
+
+function clientIP(c: Context): string | null {
+  return c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null;
+}
+
+// Local `errorMessage` — matches the helper in `admin-roles.ts` so residency
+// failure audits never leak connection-string credentials. Inlined rather
+// than imported from `@atlas/api/lib/audit` because other admin test files
+// only mock the handful of audit exports they need and adding a new load-
+// bearing import would cascade module-resolution errors across ~8 test
+// files (per CLAUDE.md: "mock.module() must cover every named export").
+// If/when the audit-mock drift is cleaned up project-wide, swap this back
+// for the shared helper.
+const ERROR_MESSAGE_MAX = 512;
+function errorMessage(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  const scrubbed = raw.replace(/\b([a-z][a-z0-9+.-]*):\/\/[^\s@/]*@/gi, "$1://***@");
+  return scrubbed.length > ERROR_MESSAGE_MAX
+    ? `${scrubbed.slice(0, ERROR_MESSAGE_MAX - 3)}...`
+    : scrubbed;
+}
 
 const log = createLogger("admin-residency");
 
@@ -537,18 +560,48 @@ adminResidency.openapi(getStatusRoute, async (c) => {
 // PUT / — assign region to workspace
 adminResidency.openapi(assignRegionRoute, async (c) => {
   const mod = await loadResidency();
+  const ipAddress = clientIP(c);
+  const { region } = c.req.valid("json");
+
   return runEffect(
     c,
     Effect.gen(function* () {
       const { orgId } = yield* AuthContext;
-      const { region } = c.req.valid("json");
 
       if (!mod) {
         return c.json({ error: "not_available", message: "Data residency is not available in this deployment." }, 404);
       }
 
-      const result = yield* mod.assignWorkspaceRegion(orgId!, region as string);
+      // Inline failure audit via `.pipe(tapError)` keeps the emission close
+      // to the yield that can fail. Failure audits on
+      // residency.workspaceAssign are not optional: the attempt itself is
+      // compliance-relevant (a 409 reveals the current region; repeated
+      // 400s fingerprint a probe for configured regions).
+      const result = yield* mod.assignWorkspaceRegion(orgId!, region as string).pipe(
+        Effect.tapError((err) =>
+          Effect.sync(() =>
+            logAdminAction({
+              actionType: ADMIN_ACTIONS.residency.workspaceAssign,
+              targetType: "residency",
+              targetId: orgId ?? "unknown",
+              status: "failure",
+              ipAddress,
+              metadata: { region, permanent: true, error: errorMessage(err) },
+            }),
+          ),
+        ),
+      );
       log.info({ orgId, region }, "Workspace region assigned via self-serve");
+      // Permanent decision — `permanent: true` surfaces the irreversibility
+      // on the audit row so triage flags it at read time rather than
+      // requiring reviewers to remember that residency is immutable.
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.residency.workspaceAssign,
+        targetType: "residency",
+        targetId: orgId!,
+        ipAddress,
+        metadata: { region, permanent: true },
+      });
       return c.json(result, 200);
     }),
     { label: "assign workspace region", domainErrors: mod ? [getResidencyDomainError(mod)] : undefined },
@@ -683,6 +736,18 @@ adminResidency.openapi(requestMigrationRoute, async (c) => {
         "Region migration requested",
       );
 
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.residency.migrationRequest,
+        targetType: "residency",
+        targetId: migrationId,
+        ipAddress: clientIP(c),
+        metadata: {
+          workspaceId: orgId,
+          sourceRegion: assignment.region,
+          targetRegion,
+        },
+      });
+
       // Trigger background execution (Phase 2)
       scheduleMigrationExecution(migrationId, requestId);
 
@@ -748,6 +813,18 @@ adminResidency.openapi(retryMigrationRoute, async (c) => {
 
       log.info({ requestId, migrationId: id }, "Migration retry triggered");
 
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.residency.migrationRetry,
+        targetType: "residency",
+        targetId: id,
+        ipAddress: clientIP(c),
+        metadata: {
+          workspaceId: orgId,
+          sourceRegion: row.source_region,
+          targetRegion: row.target_region,
+        },
+      });
+
       return c.json(rowToMigration(row, { requestId }), 200);
     }),
     { label: "retry region migration" },
@@ -777,6 +854,13 @@ adminResidency.openapi(cancelMigrationRoute, async (c) => {
       }
 
       log.info({ requestId, migrationId: id }, "Migration cancelled");
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.residency.migrationCancel,
+        targetType: "residency",
+        targetId: id,
+        ipAddress: clientIP(c),
+        metadata: { workspaceId: orgId },
+      });
       return c.json({ cancelled: true }, 200);
     }),
     { label: "cancel region migration" },

--- a/packages/api/src/lib/audit/actions.ts
+++ b/packages/api/src/lib/audit/actions.ts
@@ -16,13 +16,36 @@ export const ADMIN_ACTIONS = {
     purge: "workspace.purge",
     changePlan: "workspace.change_plan",
   },
+  /**
+   * Custom domain lifecycle. `register` / `verify` / `delete` cover the
+   * platform-admin surface (`platform-domains.ts`). The `workspace*`
+   * variants cover the workspace-self-serve surface (`admin-domains.ts`,
+   * see F-32 in .claude/research/security-audit-1-2-3.md) so forensic
+   * queries can tell a platform-staff domain change from a workspace-admin
+   * one without joining on `scope`.
+   */
   domain: {
     register: "domain.register",
     verify: "domain.verify",
     delete: "domain.delete",
+    workspaceRegister: "domain.workspace_register",
+    workspaceRemove: "domain.workspace_remove",
+    workspaceVerify: "domain.workspace_verify",
+    workspaceVerifyDns: "domain.workspace_verify_dns",
   },
+  /**
+   * Data-residency lifecycle. `assign` covers the platform-admin surface
+   * (`platform-residency.ts`). The `workspace*` variants cover workspace
+   * self-serve (`admin-residency.ts`). Region assignment is permanent —
+   * `workspace_assign` metadata MUST carry `permanent: true` so triage
+   * sees the permanence flag on the audit row. See F-32.
+   */
   residency: {
     assign: "residency.assign",
+    workspaceAssign: "residency.workspace_assign",
+    migrationRequest: "residency.migration_request",
+    migrationRetry: "residency.migration_retry",
+    migrationCancel: "residency.migration_cancel",
   },
   sla: {
     updateThresholds: "sla.update_thresholds",
@@ -188,6 +211,28 @@ export const ADMIN_ACTIONS = {
     update: "model_config.update",
     delete: "model_config.delete",
     test: "model_config.test",
+  },
+  /**
+   * Workspace white-label branding. Enterprise-gated. Without these entries
+   * an admin can silently re-skin the product before phishing tenant users
+   * and the audit trail shows nothing. See F-32.
+   */
+  branding: {
+    update: "branding.update",
+    delete: "branding.delete",
+  },
+  /**
+   * Compliance / PII-classification mutations. `retention_update` covers
+   * the PUT /classifications/{id} path (category / masking-strategy /
+   * dismissed / reviewed changes — each of which controls how long / in
+   * what form PII is retained in audit + query-result storage).
+   * `pii_config_delete` covers the DELETE /classifications/{id} path that
+   * drops a classification row and cache entry. See F-32 in
+   * .claude/research/security-audit-1-2-3.md.
+   */
+  compliance: {
+    retentionUpdate: "compliance.retention_update",
+    piiConfigDelete: "compliance.pii_config_delete",
   },
 } as const;
 

--- a/packages/api/src/lib/audit/actions.ts
+++ b/packages/api/src/lib/audit/actions.ts
@@ -222,16 +222,17 @@ export const ADMIN_ACTIONS = {
     delete: "branding.delete",
   },
   /**
-   * Compliance / PII-classification mutations. `retention_update` covers
+   * Compliance / PII-classification mutations. `pii_config_update` covers
    * the PUT /classifications/{id} path (category / masking-strategy /
-   * dismissed / reviewed changes — each of which controls how long / in
-   * what form PII is retained in audit + query-result storage).
+   * dismissed / reviewed changes on a single classification row).
    * `pii_config_delete` covers the DELETE /classifications/{id} path that
-   * drops a classification row and cache entry. See F-32 in
-   * .claude/research/security-audit-1-2-3.md.
+   * drops a classification row and its cache entry. Deliberately distinct
+   * from the `audit_retention.*` domain — these do NOT control retention
+   * windows, only the shape of PII-masking enforcement on query results.
+   * See F-32 in .claude/research/security-audit-1-2-3.md.
    */
   compliance: {
-    retentionUpdate: "compliance.retention_update",
+    piiConfigUpdate: "compliance.pii_config_update",
     piiConfigDelete: "compliance.pii_config_delete",
   },
 } as const;


### PR DESCRIPTION
## Summary

Phase 4 of the 1.2.3 security sweep — closes the audit gap on 12 write routes across `admin-domains.ts`, `admin-branding.ts`, `admin-residency.ts`, and `admin-compliance.ts`.

Before this PR, a workspace admin could migrate data residency (permanent), register/remove a custom domain, white-label the product, or shrink PII masking with no `admin_action_log` row. The four files previously emitted zero audit entries despite being enterprise-gated workspace-identity surfaces.

## Changes

- **`ADMIN_ACTIONS` catalog** — extends existing `domain` + `residency` groups with workspace-scoped variants (`domain.workspace_register`, `domain.workspace_remove`, `domain.workspace_verify`, `domain.workspace_verify_dns`, `residency.workspace_assign`, `residency.migration_request`, `residency.migration_retry`, `residency.migration_cancel`) and adds new `branding` + `compliance` groups. Naming mirrors the pre-existing `platform-residency.ts` / `platform-domains.ts` split so compliance queries can distinguish platform-staff vs workspace-admin changes without joining on `scope`.
- **Route emissions** — every write handler calls `logAdminAction` after the successful mutation. Reads stay silent. Probe paths that 404 before the mutation (domain verify with no domain configured; migration retry/cancel rejected by the migration executor) intentionally do *not* emit so forensic queries counting actual changes aren't polluted.
- **Residency `workspace_assign` metadata carries `permanent: true`** — surfaces the irreversibility on the audit row so triage flags it at read time. Additionally emits a `status: "failure"` audit via `.pipe(Effect.tapError(...))` so 409 "already assigned" probes (which reveal the current region) leave evidence.
- **Branding / compliance metadata captures admin *intent*** (request-body fields that were set), not post-state defaults. A compliance reviewer can tell a `dismissed: true` tweak from a masking-strategy shrink without extra joins.
- **Regression tests** — exhaustive per-route coverage. New `admin-compliance.test.ts` + extensions to `admin-domains.test.ts`, `admin-branding.test.ts`, `admin-residency.test.ts`. The residency Effect shim gained minimal `pipe` + `tapError` + `sync` support to drive the failure-audit path.
- **Phase-4 tracker doc** — `.claude/research/security-audit-1-2-3.md` row table and F-32 finding section updated to mark shipped.

Closes #1787.

## Notes

- `admin-residency.ts` uses a local inline `errorMessage` helper (matching `admin-roles.ts`) rather than importing from `@atlas/api/lib/audit`. Adding a new load-bearing import would cascade module-resolution `SyntaxError`s across ~8 test files that partial-mock the audit module. An eventual audit-mock cleanup can swap the local helper for the shared one.
- No migration needed — `admin_action_log` is append-only and already accepts the action types via the `AdminActionType` union.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun run test` — 263/263 api, 84/84 web, 25/25 ee, all passing
- [x] `bun x syncpack lint` — no issues
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — 432 files verified
- [x] Targeted regression tests per file exercise each of the 12 routes (success + selected failure paths)
- [x] Reads explicitly asserted as quiet (no audit emission)
- [x] Residency `workspace_assign` success audit asserts `permanent: true` in metadata; failure audit asserts `status: "failure"` with `permanent: true`