### PR TITLE
fix(security): F-35 prompt/semantic-improve/starter-prompt audit emission (closes #1790)

### DIFF
--- a/.claude/research/security-audit-1-2-3.md
+++ b/.claude/research/security-audit-1-2-3.md
@@ -1087,17 +1087,17 @@ Totals at the file level; individual uncovered writes are enumerated under the f
 | `admin-model-config.ts` | 3 | 3 | ✅ | F-30 fixed (PR #1805) — `model_config.update` / `delete` / `test` emitted with success + failure paths; metadata carries `hasSecret` marker and never the apiKey value; test route audits success + failure to close the credential-oracle gap |
 | `admin-orgs.ts` | 4 | 4 | ✅ | F-31 fixed (PR #1804) — `workspace.suspend` / `workspace.unsuspend` / `workspace.change_plan` / `workspace.delete` emitted with `scope: "platform"`, matching `platform-admin.ts` canonical fields exactly. Regression test compares entries directly across both surfaces |
 | `admin-plugins.ts` | 4 | 3 | ✅ | `plugin.enable` / `plugin.disable` / `plugin.config_update` audited; read-only health check stays silent — F-22 fixed |
-| `admin-prompts.ts` | 7 | 0 | ❌ | Content governance — collection + prompt CRUD (F-35) |
+| `admin-prompts.ts` | 7 | 7 | ✅ | F-35 fixed — `prompt.collection_create` / `collection_update` / `collection_delete` + `prompt.create` / `update` / `delete` / `reorder` emitted. Delete handlers pre-fetch the row so metadata carries the name after deletion. Reorder carries the full `newOrder: string[]` for drag-and-drop forensics |
 | `admin-publish.ts` | 1 | 1 | ✅ | `mode.publish` |
 | `admin-residency.ts` | 4 | 4 | ✅ | F-32 fixed (PR #1806) — `residency.workspace_assign` / `migration_request` / `migration_retry` / `migration_cancel` emitted. `workspace_assign` metadata carries explicit `permanent: true` so triage flags the irreversibility, and emits failure-status audits on validation / conflict errors so 409 probes for the current region leave a trail |
 | `admin-roles.ts` | 4 | 4 | ✅ | F-25 fixed (PR #1800) — `role.create` / `role.update` / `role.delete` / `role.assign` emitted with success + failure paths; update captures previousPermissions, delete pre-fetches so metadata retains the deleted role, assign captures previousRole |
 | `admin-sandbox.ts` | 2 | 0 | ❌ | Connect/disconnect BYOC sandbox (F-37) |
 | `admin-scim.ts` | 3 | 3 | ✅ | `scim.connection_delete` / `scim.group_mapping_create` / `scim.group_mapping_delete` — F-23 fixed |
-| `admin-semantic-improve.ts` | 4 | 0 | ❌ | AI-assisted semantic layer edits (F-35) |
+| `admin-semantic-improve.ts` | 4 | 4 | ✅ | F-35 fixed — `semantic.improve_draft` on `/chat`, `semantic.improve_accept` / `improve_reject` on `/proposals/{id}/approve+reject`, `semantic.improve_apply` (approved) / `improve_reject` (rejected) on `/amendments/{id}/review`. Rejection branches on the DB-backed route collapse to `improve_reject` so forensic queries catch both surfaces |
 | `admin-semantic.ts` | 3 | 3 | ✅ | `semantic.update_entity` / `semantic.delete_entity` |
 | `admin-sessions.ts` | 2 | 2 | ✅ | F-28 fixed (PR for #1783) — `user.session_revoke` / `user.session_revoke_all` emitted with success + failure paths; single-session path pre-fetches target userId and records `wasCurrentUser` |
 | `admin-sso.ts` | 6 | 4 | 🟡 | Configure / update / delete / test audited; **`POST /providers/{id}/verify` + `PUT /enforcement` unaudited** (F-29) |
-| `admin-starter-prompts.ts` | 4 | 0 | ❌ | Queue moderation — approve/hide/unhide/author (F-36) |
+| `admin-starter-prompts.ts` | 4 | 4 | ✅ | F-35 fixed — `starter_prompt.approve` / `hide` / `unhide` emit on successful moderation outcomes (gated on `outcome.status === "ok"` so 403/404 paths do not produce audit rows); `starter_prompt.author_update` emits on the admin-authored seed path with the new suggestion id + text |
 | `admin-suggestions.ts` | 1 | 0 | ❌ | DELETE suggestion (F-37) |
 | `admin.ts` | 12 | 10 | 🟡 | User role / ban / unban / remove-membership / delete-user / revoke-sessions / settings update + delete + semantic put/delete audited; **`POST /me/password`, `POST /semantic/org/import` unaudited** — tracked in F-29. `POST /users/{id}/revoke-sessions` now emits `user.session_revoke_all` (F-28 fixed, PR #1801) |
 | `billing.ts` | 2 | 0 | ✳︎ | Stripe portal redirects — Stripe event log is the authoritative trail; both routes are admin-gated |
@@ -1437,7 +1437,7 @@ POST /api/v1/admin/connections/pool/orgs/{orgId}/drain → drain org pools, no a
 
 ---
 
-**F-35 — Prompt library + semantic-improve + starter-prompt moderation writes unaudited** — P2
+**F-35 — Prompt library + semantic-improve + starter-prompt moderation writes unaudited** — P2 — **FIXED**
 
 Bundled class — content-governance admin writes:
 
@@ -1447,7 +1447,16 @@ Bundled class — content-governance admin writes:
 
 **Impact:** Content-governance actions that affect every user of the workspace (starter prompts surfaced on first-run, prompts in the library, semantic drafts that reshape agent SQL). No trail of who approved / hid / applied. Same shape as the learned-patterns surface that IS audited (`pattern.approve` / `pattern.reject` / `pattern.delete` in `admin-learned-patterns.ts`).
 
-**Fix sketch:** Model on `admin-learned-patterns.ts`. Add `prompt.create` / `prompt.update` / `prompt.delete` / `prompt_collection.*`, `semantic.improve_draft` / `semantic.improve_apply`, `starter_prompt.approve` / `starter_prompt.hide` / `starter_prompt.unhide` / `starter_prompt.author_update`.
+**Resolution:** 15 new action types added to `ADMIN_ACTIONS` — `prompt.{collection_create, collection_update, collection_delete, create, update, delete, reorder}`, `semantic.{improve_draft, improve_apply, improve_accept, improve_reject}`, `starter_prompt.{approve, hide, unhide, author_update}`. Each of the 15 write routes emits `logAdminAction` on success. Metadata contracts:
+
+- Content items: `{ id, name }` (collection create additionally carries `industry` + `status`; prompt items carry `collectionId`).
+- Moderation decisions: `{ id, name }` for starter-prompt approve/hide/unhide/author; `{ id, decision }` for amendment review.
+- Reorder: `{ collectionId, newOrder: string[] }` — the full ordered id list so drag-and-drop forensics can replay the admin's intent.
+- `semantic.improve_*` carries `{ sessionId, proposalIndex, entityName, amendmentType }` where available; the `/chat` draft row additionally marks `resumed: boolean` so a resumed session is distinguishable from a fresh one.
+
+Rejection paths on `POST /amendments/{id}/review` collapse to `semantic.improve_reject` (rather than keeping the route-anchored `improve_apply`) so forensic queries can filter on a single action_type regardless of which surface — in-memory session or DB-backed amendment — rejected a proposal. Delete handlers pre-fetch `{ id, name }` so the audit row survives the row's removal (matches the F-25 role-delete pattern).
+
+Starter-prompt moderation emits are gated on `outcome.status === "ok"`: 403/404 outcomes do not emit, keeping the trail clean of probe attempts (the 403 boundary is already covered by the `adminAuth` middleware and the test suite pins the non-emission on the forbidden/not-found branches).
 
 **Severity:** P2 — content-governance trail gap. Less privileged than F-22/F-25 but same class of "admin mutations visible to end users, invisible in audit."
 
@@ -1567,7 +1576,7 @@ Grep every `metadata: { ... }` literal on the admin-audit call sites. Sampled pa
 | F-32 | P1 | Audit gap | Workspace enterprise config (`admin-domains.ts`, `admin-branding.ts`, `admin-residency.ts`, `admin-compliance.ts`) | #1787 | fixed (PR #1806) |
 | F-33 | P2 | Split trail | Abuse reinstate writes to `abuse_events`, not `admin_action_log` | #1788 | open |
 | F-34 | P2 | Audit gap | Wizard connection path bypasses `connection.create` (`wizard.ts`, plus connection test/drain in `admin-connections.ts`) | #1789 | open |
-| F-35 | P2 | Audit gap | Prompt / semantic-improve / starter-prompt moderation | #1790 | open |
+| F-35 | P2 | Audit gap | Prompt / semantic-improve / starter-prompt moderation | #1790 | fixed |
 | F-36 | P2 | Retention | `admin_action_log` unbounded, no purge, no GDPR erasure path | #1791 | open |
 | F-37 | P3 | Audit gap | Low-signal admin writes (cache / migrate / suggestions / sandbox / onboarding) | — (stays in doc) | deferred |
 | F-38 | P3 | Audit gap | OAuth-callback install path not mirrored in `admin_action_log` | — (stays in doc) | deferred |

--- a/packages/api/src/api/__tests__/admin-prompts-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-prompts-audit.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Audit regression suite for `admin-prompts.ts` — F-35 (#1790).
+ *
+ * Pins every write route to the canonical `ADMIN_ACTIONS.prompt.*` string
+ * and the metadata shape that forensic queries expect. A drift on any
+ * route (renamed action type, missing `id` / `name`, stripped `scope`)
+ * trips the suite before it reaches production.
+ *
+ * Test pattern modeled on `admin-orgs-audit.test.ts` (F-31) and
+ * `admin-model-config.test.ts` (F-30).
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterAll,
+  mock,
+  type Mock,
+} from "bun:test";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+
+// ---------------------------------------------------------------------------
+// Mocks — set up before app import
+// ---------------------------------------------------------------------------
+
+const mocks = createApiTestMocks({
+  authUser: {
+    id: "admin-1",
+    mode: "managed",
+    label: "admin@test.com",
+    role: "admin",
+    activeOrganizationId: "org-alpha",
+  },
+  authMode: "managed",
+});
+
+interface AuditEntry {
+  actionType: string;
+  targetType: string;
+  targetId: string;
+  status?: "success" | "failure";
+  scope?: "platform" | "workspace";
+  ipAddress?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+const mockLogAdminAction: Mock<(entry: AuditEntry) => void> = mock(() => {});
+
+mock.module("@atlas/api/lib/audit", async () => {
+  const actual = await import("@atlas/api/lib/audit/actions");
+  return {
+    logAdminAction: mockLogAdminAction,
+    logAdminActionAwait: mock(async () => {}),
+    ADMIN_ACTIONS: actual.ADMIN_ACTIONS,
+  };
+});
+
+const { app } = await import("../index");
+
+afterAll(() => mocks.cleanup());
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function adminRequest(method: string, path: string, body?: unknown): Request {
+  const opts: RequestInit = {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer test-key",
+    },
+  };
+  if (body !== undefined) opts.body = JSON.stringify(body);
+  return new Request(`http://localhost${path}`, opts);
+}
+
+function lastAuditCall(): AuditEntry {
+  const calls = mockLogAdminAction.mock.calls;
+  if (calls.length === 0) throw new Error("logAdminAction was not called");
+  return calls[calls.length - 1]![0]!;
+}
+
+function collectionRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "col-1",
+    org_id: "org-alpha",
+    name: "My Collection",
+    industry: "saas",
+    description: "Test collection",
+    is_builtin: false,
+    sort_order: 0,
+    status: "published",
+    created_at: "2026-04-24T00:00:00Z",
+    updated_at: "2026-04-24T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function itemRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "item-1",
+    collection_id: "col-1",
+    question: "What does this metric measure?",
+    description: null,
+    category: null,
+    sort_order: 0,
+    created_at: "2026-04-24T00:00:00Z",
+    updated_at: "2026-04-24T00:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mocks.hasInternalDB = true;
+  mockLogAdminAction.mockClear();
+  mocks.mockInternalQuery.mockReset();
+  mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/admin/prompts — collection create
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/admin/prompts — audit emission", () => {
+  it("emits prompt.collection_create with id + name + industry metadata", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.startsWith("INSERT INTO prompt_collections")) {
+        return [collectionRow({ id: "col-new", name: "New Collection", industry: "saas" })];
+      }
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/prompts/", {
+        name: "New Collection",
+        industry: "saas",
+        description: "From a unit test",
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("prompt.collection_create");
+    expect(entry.targetType).toBe("prompt");
+    expect(entry.targetId).toBe("col-new");
+    expect(entry.metadata).toMatchObject({
+      id: "col-new",
+      name: "New Collection",
+      industry: "saas",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /api/v1/admin/prompts/:id — collection update
+// ---------------------------------------------------------------------------
+
+describe("PATCH /api/v1/admin/prompts/:id — audit emission", () => {
+  it("emits prompt.collection_update with id + name metadata", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.startsWith("SELECT * FROM prompt_collections")) {
+        return [collectionRow({ id: "col-1", name: "Old Name" })];
+      }
+      if (sql.startsWith("UPDATE prompt_collections")) {
+        return [collectionRow({ id: "col-1", name: "Renamed" })];
+      }
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("PATCH", "/api/v1/admin/prompts/col-1", { name: "Renamed" }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("prompt.collection_update");
+    expect(entry.targetType).toBe("prompt");
+    expect(entry.targetId).toBe("col-1");
+    expect(entry.metadata).toMatchObject({ id: "col-1", name: "Renamed" });
+  });
+
+  it("does not emit when the collection is built-in (403)", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.startsWith("SELECT * FROM prompt_collections")) {
+        return [collectionRow({ id: "col-builtin", is_builtin: true })];
+      }
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("PATCH", "/api/v1/admin/prompts/col-builtin", { name: "Try" }),
+    );
+    expect(res.status).toBe(403);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/v1/admin/prompts/:id — collection delete
+// ---------------------------------------------------------------------------
+
+describe("DELETE /api/v1/admin/prompts/:id — audit emission", () => {
+  it("emits prompt.collection_delete with id + name metadata", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.startsWith("SELECT * FROM prompt_collections")) {
+        return [collectionRow({ id: "col-1", name: "Doomed" })];
+      }
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("DELETE", "/api/v1/admin/prompts/col-1"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("prompt.collection_delete");
+    expect(entry.targetType).toBe("prompt");
+    expect(entry.targetId).toBe("col-1");
+    expect(entry.metadata).toMatchObject({ id: "col-1", name: "Doomed" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/admin/prompts/:id/items — item create
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/admin/prompts/:id/items — audit emission", () => {
+  it("emits prompt.create with id + name (question) + collectionId metadata", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.startsWith("SELECT * FROM prompt_collections")) {
+        return [collectionRow({ id: "col-1" })];
+      }
+      if (sql.includes("MAX(sort_order)")) return [{ max: 0 }];
+      if (sql.startsWith("INSERT INTO prompt_items")) {
+        return [itemRow({ id: "item-new", collection_id: "col-1", question: "New question" })];
+      }
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/prompts/col-1/items", {
+        question: "New question",
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("prompt.create");
+    expect(entry.targetType).toBe("prompt");
+    expect(entry.targetId).toBe("item-new");
+    expect(entry.metadata).toMatchObject({
+      id: "item-new",
+      name: "New question",
+      collectionId: "col-1",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /api/v1/admin/prompts/:collectionId/items/:itemId — item update
+// ---------------------------------------------------------------------------
+
+describe("PATCH /api/v1/admin/prompts/:collectionId/items/:itemId — audit emission", () => {
+  it("emits prompt.update with id + name (question) + collectionId metadata", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.startsWith("SELECT * FROM prompt_collections")) {
+        return [collectionRow({ id: "col-1" })];
+      }
+      if (sql.startsWith("SELECT * FROM prompt_items")) {
+        return [itemRow({ id: "item-1" })];
+      }
+      if (sql.startsWith("UPDATE prompt_items")) {
+        return [itemRow({ id: "item-1", question: "Updated question" })];
+      }
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("PATCH", "/api/v1/admin/prompts/col-1/items/item-1", {
+        question: "Updated question",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("prompt.update");
+    expect(entry.targetType).toBe("prompt");
+    expect(entry.targetId).toBe("item-1");
+    expect(entry.metadata).toMatchObject({
+      id: "item-1",
+      name: "Updated question",
+      collectionId: "col-1",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/v1/admin/prompts/:collectionId/items/:itemId — item delete
+// ---------------------------------------------------------------------------
+
+describe("DELETE /api/v1/admin/prompts/:collectionId/items/:itemId — audit emission", () => {
+  it("emits prompt.delete with id + name (question) + collectionId metadata", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.startsWith("SELECT * FROM prompt_collections")) {
+        return [collectionRow({ id: "col-1" })];
+      }
+      if (sql.includes("FROM prompt_items WHERE id")) {
+        return [{ id: "item-1", question: "Doomed prompt" }];
+      }
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("DELETE", "/api/v1/admin/prompts/col-1/items/item-1"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("prompt.delete");
+    expect(entry.targetType).toBe("prompt");
+    expect(entry.targetId).toBe("item-1");
+    expect(entry.metadata).toMatchObject({
+      id: "item-1",
+      name: "Doomed prompt",
+      collectionId: "col-1",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PUT /api/v1/admin/prompts/:id/reorder — item reorder
+// ---------------------------------------------------------------------------
+
+describe("PUT /api/v1/admin/prompts/:id/reorder — audit emission", () => {
+  it("emits prompt.reorder with collectionId + newOrder metadata", async () => {
+    const newOrder = ["item-a", "item-b", "item-c"];
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.startsWith("SELECT * FROM prompt_collections")) {
+        return [collectionRow({ id: "col-1" })];
+      }
+      if (sql.includes("SELECT id FROM prompt_items WHERE collection_id")) {
+        return newOrder.map((id) => ({ id }));
+      }
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("PUT", "/api/v1/admin/prompts/col-1/reorder", {
+        itemIds: newOrder,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("prompt.reorder");
+    expect(entry.targetType).toBe("prompt");
+    expect(entry.targetId).toBe("col-1");
+    expect(entry.metadata).toMatchObject({
+      collectionId: "col-1",
+      newOrder,
+    });
+  });
+});

--- a/packages/api/src/api/__tests__/admin-semantic-improve-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-semantic-improve-audit.test.ts
@@ -1,0 +1,375 @@
+/**
+ * Audit regression suite for `admin-semantic-improve.ts` — F-35 (#1790).
+ *
+ * Pins the four write surfaces to the canonical
+ * `ADMIN_ACTIONS.semantic.improve*` action types:
+ *
+ *   - POST /chat                     → `semantic.improve_draft`
+ *   - POST /proposals/{id}/approve   → `semantic.improve_accept`
+ *   - POST /proposals/{id}/reject    → `semantic.improve_reject`
+ *   - POST /amendments/{id}/review   → `semantic.improve_apply` (approved)
+ *                                      / `semantic.improve_reject` (rejected)
+ *
+ * The DB-backed `/amendments/{id}/review` route is exercised end-to-end
+ * through the Hono app. The in-memory proposal surface (`/chat` +
+ * `/proposals/{id}/(approve|reject)`) is driven by mounting the router
+ * into a minimal Hono host so the streaming SSE round-trip in `/chat`
+ * does not block the test runner — the audit wire-up is identical.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterAll,
+  mock,
+  type Mock,
+} from "bun:test";
+import { Hono } from "hono";
+import type { OrgContextEnv } from "../routes/admin-router";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+
+const mockGetPendingAmendments: Mock<(orgId: string) => Promise<unknown[]>> =
+  mock(async () => []);
+const mockReviewSemanticAmendment: Mock<
+  (id: string, orgId: string, decision: string, reviewer: string) => Promise<boolean>
+> = mock(async () => true);
+
+const mocks = createApiTestMocks({
+  authUser: {
+    id: "admin-1",
+    mode: "managed",
+    label: "admin@test.com",
+    role: "admin",
+    activeOrganizationId: "org-alpha",
+  },
+  authMode: "managed",
+  internal: {
+    getPendingAmendments: mockGetPendingAmendments,
+    reviewSemanticAmendment: mockReviewSemanticAmendment,
+  },
+});
+
+interface AuditEntry {
+  actionType: string;
+  targetType: string;
+  targetId: string;
+  status?: "success" | "failure";
+  scope?: "platform" | "workspace";
+  ipAddress?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+const mockLogAdminAction: Mock<(entry: AuditEntry) => void> = mock(() => {});
+
+mock.module("@atlas/api/lib/audit", async () => {
+  const actual = await import("@atlas/api/lib/audit/actions");
+  return {
+    logAdminAction: mockLogAdminAction,
+    logAdminActionAwait: mock(async () => {}),
+    ADMIN_ACTIONS: actual.ADMIN_ACTIONS,
+  };
+});
+
+// Stub YAML apply so the approved branch does not touch the filesystem.
+mock.module("@atlas/api/lib/semantic/expert/apply", () => ({
+  applyAmendmentToEntity: mock(async () => undefined),
+}));
+
+// Seed `createSession` to return one proposal so /proposals/0/(approve|reject)
+// resolve. `recordDecision` / `getSessionSummary` / `buildSessionContext`
+// match the real shape enough for the routes under test.
+interface MinimalProposal {
+  readonly entityName: string;
+  readonly category: string;
+  readonly amendmentType: string;
+  readonly amendment: Record<string, unknown>;
+  readonly rationale: string;
+  readonly confidence: number;
+  readonly impact: number;
+  readonly score: number;
+  readonly testQuery?: string;
+}
+
+const SEEDED_PROPOSAL: MinimalProposal = {
+  entityName: "events",
+  category: "coverage_gaps",
+  amendmentType: "update_description",
+  amendment: { description: "Updated" },
+  rationale: "Sample proposal",
+  confidence: 0.9,
+  impact: 0.5,
+  score: 0.7,
+};
+
+mock.module("@atlas/api/lib/semantic/expert", () => ({
+  createSession: () => ({
+    proposals: [SEEDED_PROPOSAL],
+    currentIndex: 0,
+    reviewed: [] as { result: MinimalProposal; decision: string; decidedAt: Date }[],
+    messages: [],
+    rejectedKeys: new Set<string>(),
+    startedAt: new Date(),
+  }),
+  recordDecision: (
+    session: {
+      currentIndex: number;
+      proposals: readonly MinimalProposal[];
+      reviewed: { result: MinimalProposal; decision: string; decidedAt: Date }[];
+    },
+    decision: "accepted" | "rejected" | "skipped",
+  ) => {
+    const current = session.proposals[session.currentIndex];
+    if (current) session.reviewed.push({ result: current, decision, decidedAt: new Date() });
+    session.currentIndex += 1;
+  },
+  getSessionSummary: () => ({ total: 1, accepted: 0, rejected: 0, skipped: 0, remaining: 1 }),
+  buildSessionContext: () => "",
+}));
+
+// Stub the agent runner — /chat awaits runAgent and then emits the audit row.
+mock.module("@atlas/api/lib/agent", () => ({
+  runAgent: mock(async () => ({
+    toUIMessageStream: () =>
+      new ReadableStream<Uint8Array>({ start: (ctl) => ctl.close() }),
+    text: Promise.resolve("ok"),
+  })),
+}));
+
+mock.module("@atlas/api/lib/tools/expert-registry", () => ({
+  buildExpertRegistry: () => ({ tools: {}, freeze: () => {} }),
+}));
+
+const { app } = await import("../index");
+const { adminSemanticImprove } = await import(
+  "../routes/admin-semantic-improve"
+);
+
+afterAll(() => mocks.cleanup());
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function adminRequest(method: string, path: string, body?: unknown): Request {
+  const opts: RequestInit = {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer test-key",
+    },
+  };
+  if (body !== undefined) opts.body = JSON.stringify(body);
+  return new Request(`http://localhost${path}`, opts);
+}
+
+function findAuditCall(actionType: string): AuditEntry | undefined {
+  return mockLogAdminAction.mock.calls
+    .map(([entry]) => entry)
+    .find((entry) => entry.actionType === actionType);
+}
+
+/**
+ * Mount the router into a minimal Hono host that pre-populates the
+ * request context (requestId + atlasMode + authResult + orgContext). This
+ * avoids bringing the full app's streaming pipeline online for the
+ * `/chat` and `/proposals/{id}/*` routes while still exercising the
+ * router's real audit emissions.
+ */
+function makeRouterHost() {
+  const host = new Hono<OrgContextEnv>();
+  host.use("*", async (c, next) => {
+    c.set("requestId", "req-test-1");
+    c.set("atlasMode", "published");
+    c.set("authResult", {
+      authenticated: true,
+      mode: "managed",
+      user: {
+        id: "admin-1",
+        mode: "managed",
+        label: "admin@test.com",
+        role: "admin",
+        activeOrganizationId: "org-alpha",
+      },
+    });
+    c.set("orgContext", {
+      requestId: "req-test-1",
+      orgId: "org-alpha",
+    });
+    await next();
+  });
+  host.route("/", adminSemanticImprove);
+  return host;
+}
+
+function hostRequest(
+  host: ReturnType<typeof makeRouterHost>,
+  method: string,
+  path: string,
+  body?: unknown,
+) {
+  const init: RequestInit = {
+    method,
+    headers: { "Content-Type": "application/json" },
+  };
+  if (body !== undefined) init.body = JSON.stringify(body);
+  return host.request(path, init);
+}
+
+beforeEach(() => {
+  mocks.hasInternalDB = true;
+  mockLogAdminAction.mockClear();
+  mockGetPendingAmendments.mockReset();
+  mockGetPendingAmendments.mockImplementation(async () => []);
+  mockReviewSemanticAmendment.mockReset();
+  mockReviewSemanticAmendment.mockImplementation(async () => true);
+});
+
+// ---------------------------------------------------------------------------
+// POST /chat — improve_draft
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/admin/semantic-improve/chat — audit emission", () => {
+  it("emits semantic.improve_draft on new chat session", async () => {
+    const host = makeRouterHost();
+    const res = await hostRequest(host, "POST", "/chat", {
+      messages: [
+        { role: "user", parts: [{ type: "text", text: "analyze" }], id: "m1" },
+      ],
+    });
+    expect(res.status).toBe(200);
+
+    const entry = findAuditCall("semantic.improve_draft");
+    expect(entry).toBeDefined();
+    expect(entry!.targetType).toBe("semantic");
+    expect(entry!.metadata).toMatchObject({ resumed: false });
+    expect(typeof entry!.metadata?.sessionId).toBe("string");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /proposals/{id}/approve — improve_accept
+// POST /proposals/{id}/reject  — improve_reject
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/admin/semantic-improve/proposals/{id}/approve — audit", () => {
+  it("emits semantic.improve_accept with proposalIndex + entityName + amendmentType", async () => {
+    const host = makeRouterHost();
+    // First create a session via /chat
+    const chatRes = await hostRequest(host, "POST", "/chat", {
+      messages: [
+        { role: "user", parts: [{ type: "text", text: "seed" }], id: "m1" },
+      ],
+    });
+    expect(chatRes.status).toBe(200);
+    mockLogAdminAction.mockClear();
+
+    const res = await hostRequest(host, "POST", "/proposals/0/approve");
+    expect(res.status).toBe(200);
+
+    const entry = findAuditCall("semantic.improve_accept");
+    expect(entry).toBeDefined();
+    expect(entry!.targetType).toBe("semantic");
+    expect(entry!.metadata).toMatchObject({
+      proposalIndex: 0,
+      entityName: "events",
+      amendmentType: "update_description",
+    });
+  });
+});
+
+describe("POST /api/v1/admin/semantic-improve/proposals/{id}/reject — audit", () => {
+  it("emits semantic.improve_reject with proposalIndex + entityName", async () => {
+    const host = makeRouterHost();
+    const chatRes = await hostRequest(host, "POST", "/chat", {
+      messages: [
+        { role: "user", parts: [{ type: "text", text: "seed" }], id: "m1" },
+      ],
+    });
+    expect(chatRes.status).toBe(200);
+    mockLogAdminAction.mockClear();
+
+    const res = await hostRequest(host, "POST", "/proposals/0/reject");
+    expect(res.status).toBe(200);
+
+    const entry = findAuditCall("semantic.improve_reject");
+    expect(entry).toBeDefined();
+    expect(entry!.targetType).toBe("semantic");
+    expect(entry!.metadata).toMatchObject({
+      proposalIndex: 0,
+      entityName: "events",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /amendments/{id}/review — improve_apply (approved) / improve_reject (rejected)
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/admin/semantic-improve/amendments/:id/review — audit emission", () => {
+  it("approved decision emits semantic.improve_apply with id + decision", async () => {
+    mockGetPendingAmendments.mockImplementation(async () => [
+      {
+        id: "amd-1",
+        source_entity: "events",
+        description: "Update",
+        confidence: 0.8,
+        amendment_payload: {
+          category: "coverage_gaps",
+          amendmentType: "update_description",
+          rationale: "text",
+        },
+        created_at: "2026-04-24T00:00:00Z",
+      },
+    ]);
+
+    const res = await app.fetch(
+      adminRequest(
+        "POST",
+        "/api/v1/admin/semantic-improve/amendments/amd-1/review",
+        { decision: "approved" },
+      ),
+    );
+    expect(res.status).toBe(200);
+
+    const entry = findAuditCall("semantic.improve_apply");
+    expect(entry).toBeDefined();
+    expect(entry!.targetType).toBe("semantic");
+    expect(entry!.targetId).toBe("amd-1");
+    expect(entry!.metadata).toMatchObject({ id: "amd-1", decision: "approved" });
+    expect(findAuditCall("semantic.improve_reject")).toBeUndefined();
+  });
+
+  it("rejected decision emits semantic.improve_reject with id + decision", async () => {
+    const res = await app.fetch(
+      adminRequest(
+        "POST",
+        "/api/v1/admin/semantic-improve/amendments/amd-2/review",
+        { decision: "rejected" },
+      ),
+    );
+    expect(res.status).toBe(200);
+
+    const entry = findAuditCall("semantic.improve_reject");
+    expect(entry).toBeDefined();
+    expect(entry!.targetType).toBe("semantic");
+    expect(entry!.targetId).toBe("amd-2");
+    expect(entry!.metadata).toMatchObject({ id: "amd-2", decision: "rejected" });
+    expect(findAuditCall("semantic.improve_apply")).toBeUndefined();
+  });
+
+  it("does not emit when the amendment is missing (404)", async () => {
+    mockReviewSemanticAmendment.mockImplementation(async () => false);
+
+    const res = await app.fetch(
+      adminRequest(
+        "POST",
+        "/api/v1/admin/semantic-improve/amendments/amd-missing/review",
+        { decision: "rejected" },
+      ),
+    );
+    expect(res.status).toBe(404);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/api/__tests__/admin-starter-prompts-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-starter-prompts-audit.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Audit regression suite for `admin-starter-prompts.ts` — F-35 (#1790).
+ *
+ * Pins each moderation mutation (approve / hide / unhide / author) to the
+ * canonical `ADMIN_ACTIONS.starter_prompt.*` action type and metadata
+ * shape. Starter prompts are surfaced on first-run / empty-state
+ * surfaces, so a workspace admin can reshape the landing experience for
+ * every tenant user — this suite makes sure that never happens silently
+ * again.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterAll,
+  mock,
+  type Mock,
+} from "bun:test";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+
+const mocks = createApiTestMocks({
+  authUser: {
+    id: "admin-1",
+    mode: "managed",
+    label: "admin@test.com",
+    role: "admin",
+    activeOrganizationId: "org-alpha",
+  },
+  authMode: "managed",
+});
+
+interface AuditEntry {
+  actionType: string;
+  targetType: string;
+  targetId: string;
+  status?: "success" | "failure";
+  scope?: "platform" | "workspace";
+  ipAddress?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+const mockLogAdminAction: Mock<(entry: AuditEntry) => void> = mock(() => {});
+
+mock.module("@atlas/api/lib/audit", async () => {
+  const actual = await import("@atlas/api/lib/audit/actions");
+  return {
+    logAdminAction: mockLogAdminAction,
+    logAdminActionAwait: mock(async () => {}),
+    ADMIN_ACTIONS: actual.ADMIN_ACTIONS,
+  };
+});
+
+const { app } = await import("../index");
+
+afterAll(() => mocks.cleanup());
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function adminRequest(method: string, path: string, body?: unknown): Request {
+  const opts: RequestInit = {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer test-key",
+    },
+  };
+  if (body !== undefined) opts.body = JSON.stringify(body);
+  return new Request(`http://localhost${path}`, opts);
+}
+
+function lastAuditCall(): AuditEntry {
+  const calls = mockLogAdminAction.mock.calls;
+  if (calls.length === 0) throw new Error("logAdminAction was not called");
+  return calls[calls.length - 1]![0]!;
+}
+
+function suggestionRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "sug-1",
+    org_id: "org-alpha",
+    description: "How many users signed up last week?",
+    pattern_sql: "SELECT 1",
+    normalized_hash: "abc",
+    tables_involved: "[]",
+    primary_table: null,
+    frequency: 5,
+    clicked_count: 5,
+    distinct_user_clicks: 5,
+    score: 1.2,
+    approval_status: "pending",
+    status: "draft",
+    approved_by: null,
+    approved_at: null,
+    last_seen_at: "2026-04-15T00:00:00.000Z",
+    created_at: "2026-04-01T00:00:00.000Z",
+    updated_at: "2026-04-15T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mocks.hasInternalDB = true;
+  mockLogAdminAction.mockClear();
+  mocks.mockInternalQuery.mockReset();
+  mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/admin/starter-prompts/:id/approve
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/admin/starter-prompts/:id/approve — audit emission", () => {
+  it("emits starter_prompt.approve with id + name metadata on success", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT org_id")) return [{ org_id: "org-alpha" }];
+      if (sql.includes("UPDATE")) {
+        return [suggestionRow({ id: "sug-1", approval_status: "approved" })];
+      }
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/starter-prompts/sug-1/approve"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("starter_prompt.approve");
+    expect(entry.targetType).toBe("starter_prompt");
+    expect(entry.targetId).toBe("sug-1");
+    expect(entry.metadata).toMatchObject({
+      id: "sug-1",
+      name: "How many users signed up last week?",
+    });
+  });
+
+  it("does not emit when the suggestion belongs to a different org (403)", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT org_id")) return [{ org_id: "org-other" }];
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/starter-prompts/sug-1/approve"),
+    );
+    expect(res.status).toBe(403);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+
+  it("does not emit when the suggestion does not exist (404)", async () => {
+    mocks.mockInternalQuery.mockImplementation(async () => []);
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/starter-prompts/missing/approve"),
+    );
+    expect(res.status).toBe(404);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/admin/starter-prompts/:id/hide
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/admin/starter-prompts/:id/hide — audit emission", () => {
+  it("emits starter_prompt.hide with id + name metadata", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT org_id")) return [{ org_id: "org-alpha" }];
+      if (sql.includes("UPDATE")) {
+        return [suggestionRow({ id: "sug-1", approval_status: "hidden" })];
+      }
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/starter-prompts/sug-1/hide"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("starter_prompt.hide");
+    expect(entry.targetType).toBe("starter_prompt");
+    expect(entry.targetId).toBe("sug-1");
+    expect(entry.metadata).toMatchObject({
+      id: "sug-1",
+      name: "How many users signed up last week?",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/admin/starter-prompts/:id/unhide
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/admin/starter-prompts/:id/unhide — audit emission", () => {
+  it("emits starter_prompt.unhide with id + name metadata", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT org_id")) return [{ org_id: "org-alpha" }];
+      if (sql.includes("UPDATE")) {
+        return [suggestionRow({ id: "sug-1", approval_status: "pending" })];
+      }
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/starter-prompts/sug-1/unhide"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("starter_prompt.unhide");
+    expect(entry.targetType).toBe("starter_prompt");
+    expect(entry.targetId).toBe("sug-1");
+    expect(entry.metadata).toMatchObject({
+      id: "sug-1",
+      name: "How many users signed up last week?",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/admin/starter-prompts/author
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/admin/starter-prompts/author — audit emission", () => {
+  it("emits starter_prompt.author_update with id + name metadata", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("INSERT INTO query_suggestions")) {
+        return [
+          suggestionRow({
+            id: "authored-1",
+            description: "What tables exist?",
+            approval_status: "approved",
+            status: "published",
+            approved_by: "admin-1",
+          }),
+        ];
+      }
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/starter-prompts/author", {
+        text: "What tables exist?",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("starter_prompt.author_update");
+    expect(entry.targetType).toBe("starter_prompt");
+    expect(entry.targetId).toBe("authored-1");
+    expect(entry.metadata).toMatchObject({
+      id: "authored-1",
+      name: "What tables exist?",
+    });
+  });
+
+  it("does not emit on duplicate (409)", async () => {
+    mocks.mockInternalQuery.mockImplementation(async () => {
+      const err = new Error(
+        "duplicate key value violates unique constraint",
+      ) as Error & { code?: string };
+      err.code = "23505";
+      throw err;
+    });
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/starter-prompts/author", {
+        text: "Dup",
+      }),
+    );
+    expect(res.status).toBe(409);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/api/routes/admin-prompts.ts
+++ b/packages/api/src/api/routes/admin-prompts.ts
@@ -7,8 +7,10 @@
  */
 
 import { Effect } from "effect";
+import type { Context as HonoContext } from "hono";
 import { createRoute, z } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
 import { internalQuery, queryEffect } from "@atlas/api/lib/db/internal";
@@ -476,6 +478,10 @@ export const adminPrompts = createAdminRouter();
 
 adminPrompts.use(requireOrgContext());
 
+function clientIpFor(c: HonoContext): string | null {
+  return c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null;
+}
+
 // Helper to look up collection with org scoping
 async function findCollection(orgId: string | undefined, collectionId: string) {
   if (orgId) {
@@ -526,7 +532,15 @@ adminPrompts.openapi(createCollectionRoute, async (c) => {
     const status = atlasMode === "developer" ? "draft" : "published";
 
     const rows = yield* queryEffect<Record<string, unknown>>(`INSERT INTO prompt_collections (org_id, name, industry, description, is_builtin, status) VALUES ($1, $2, $3, $4, false, $5) RETURNING *`, [orgId ?? null, name, industry, description, status]);
-    return c.json(toPromptCollection(rows[0]), 201);
+    const created = toPromptCollection(rows[0]);
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.prompt.collectionCreate,
+      targetType: "prompt",
+      targetId: created.id,
+      ipAddress: clientIpFor(c),
+      metadata: { id: created.id, name: created.name, industry: created.industry, status },
+    });
+    return c.json(created, 201);
   }), { label: "create prompt collection" });
 });
 
@@ -564,7 +578,15 @@ adminPrompts.openapi(updateCollectionRoute, async (c) => {
 
     const updated = yield* queryEffect<Record<string, unknown>>(`UPDATE prompt_collections SET ${setClauses.join(", ")} WHERE id = $${idIdx} RETURNING *`, updateParams);
     if (updated.length === 0) return c.json({ error: "not_found", message: "Collection was deleted before update completed." }, 404);
-    return c.json(toPromptCollection(updated[0]), 200);
+    const collection = toPromptCollection(updated[0]);
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.prompt.collectionUpdate,
+      targetType: "prompt",
+      targetId: collection.id,
+      ipAddress: clientIpFor(c),
+      metadata: { id: collection.id, name: collection.name },
+    });
+    return c.json(collection, 200);
   }), { label: "update prompt collection" });
 });
 
@@ -580,6 +602,13 @@ adminPrompts.openapi(deleteCollectionRoute, async (c) => {
     if (existing[0].is_builtin === true) return c.json({ error: "forbidden", message: "Built-in collections cannot be modified.", requestId }, 403);
 
     yield* queryEffect(`DELETE FROM prompt_collections WHERE id = $1`, [id]);
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.prompt.collectionDelete,
+      targetType: "prompt",
+      targetId: id,
+      ipAddress: clientIpFor(c),
+      metadata: { id, name: existing[0].name as string },
+    });
     return c.json({ deleted: true }, 200);
   }), { label: "delete prompt collection" });
 });
@@ -614,7 +643,15 @@ adminPrompts.openapi(createItemRoute, async (c) => {
     }
 
     const rows = yield* queryEffect<Record<string, unknown>>(`INSERT INTO prompt_items (collection_id, question, description, category, sort_order) VALUES ($1, $2, $3, $4, $5) RETURNING *`, [collectionId, question, description, category, sortOrder]);
-    return c.json(toPromptItem(rows[0]), 201);
+    const item = toPromptItem(rows[0]);
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.prompt.create,
+      targetType: "prompt",
+      targetId: item.id,
+      ipAddress: clientIpFor(c),
+      metadata: { id: item.id, name: item.question, collectionId },
+    });
+    return c.json(item, 201);
   }), { label: "create prompt item" });
 });
 
@@ -655,7 +692,15 @@ adminPrompts.openapi(updateItemRoute, async (c) => {
 
     const updated = yield* queryEffect<Record<string, unknown>>(`UPDATE prompt_items SET ${setClauses.join(", ")} WHERE id = $${idIdx} RETURNING *`, updateParams);
     if (updated.length === 0) return c.json({ error: "not_found", message: "Item was deleted before update completed." }, 404);
-    return c.json(toPromptItem(updated[0]), 200);
+    const item = toPromptItem(updated[0]);
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.prompt.update,
+      targetType: "prompt",
+      targetId: item.id,
+      ipAddress: clientIpFor(c),
+      metadata: { id: item.id, name: item.question, collectionId },
+    });
+    return c.json(item, 200);
   }), { label: "update prompt item" });
 });
 
@@ -670,10 +715,20 @@ adminPrompts.openapi(deleteItemRoute, async (c) => {
     if (collection.length === 0) return c.json({ error: "not_found", message: "Prompt collection not found." }, 404);
     if (collection[0].is_builtin === true) return c.json({ error: "forbidden", message: "Built-in collections cannot be modified.", requestId }, 403);
 
-    const existingItem = yield* queryEffect<Record<string, unknown>>(`SELECT id FROM prompt_items WHERE id = $1 AND collection_id = $2`, [itemId, collectionId]);
+    // Pre-fetch `question` (not just `id`) so the audit row retains the
+    // item name after the row is gone — matches the pattern F-25
+    // established for role-delete in admin-roles.ts.
+    const existingItem = yield* queryEffect<Record<string, unknown>>(`SELECT id, question FROM prompt_items WHERE id = $1 AND collection_id = $2`, [itemId, collectionId]);
     if (existingItem.length === 0) return c.json({ error: "not_found", message: "Prompt item not found." }, 404);
 
     yield* queryEffect(`DELETE FROM prompt_items WHERE id = $1`, [itemId]);
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.prompt.delete,
+      targetType: "prompt",
+      targetId: itemId,
+      ipAddress: clientIpFor(c),
+      metadata: { id: itemId, name: existingItem[0].question as string, collectionId },
+    });
     return c.json({ deleted: true }, 200);
   }), { label: "delete prompt item" });
 });
@@ -706,9 +761,31 @@ adminPrompts.openapi(reorderItemsRoute, async (c) => {
     if (existingIds.size !== providedIds.size) return c.json({ error: "bad_request", message: `itemIds count (${providedIds.size}) does not match existing items count (${existingIds.size}). All items must be included.` }, 400);
     for (const id of itemIds) { if (!existingIds.has(id)) return c.json({ error: "bad_request", message: `Item ID "${id}" does not belong to this collection.` }, 400); }
 
+    // One UPDATE per row was non-atomic — a mid-loop failure left the
+    // collection in a partial reorder state with no audit row. Collapse to
+    // a single statement via a VALUES clause so the reorder either lands
+    // whole or not at all.
+    const valuesClause = itemIds
+      .map((_id, i) => `($${i * 2 + 2}::text, $${i * 2 + 3}::int)`)
+      .join(", ");
+    const reorderParams: unknown[] = [collectionId];
     for (let i = 0; i < itemIds.length; i++) {
-      yield* queryEffect(`UPDATE prompt_items SET sort_order = $1, updated_at = now() WHERE id = $2`, [i, itemIds[i]]);
+      reorderParams.push(itemIds[i], i);
     }
+    yield* queryEffect(
+      `UPDATE prompt_items pi
+       SET sort_order = v.ord, updated_at = now()
+       FROM (VALUES ${valuesClause}) AS v(id, ord)
+       WHERE pi.collection_id = $1 AND pi.id = v.id`,
+      reorderParams,
+    );
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.prompt.reorder,
+      targetType: "prompt",
+      targetId: collectionId,
+      ipAddress: clientIpFor(c),
+      metadata: { collectionId, newOrder: itemIds },
+    });
     return c.json({ reordered: true }, 200);
   }), { label: "reorder prompt items" });
 });

--- a/packages/api/src/api/routes/admin-semantic-improve.ts
+++ b/packages/api/src/api/routes/admin-semantic-improve.ts
@@ -13,7 +13,9 @@ import {
   type UIMessage,
 } from "ai";
 import { createLogger } from "@atlas/api/lib/logger";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runHandler } from "@atlas/api/lib/effect/hono";
+import type { Context as HonoContext } from "hono";
 import { runAgent } from "@atlas/api/lib/agent";
 import { buildExpertRegistry } from "@atlas/api/lib/tools/expert-registry";
 import {
@@ -45,6 +47,10 @@ const sessions = new Map<string, StoredSession>();
 
 function generateId(): string {
   return crypto.randomUUID();
+}
+
+function clientIpFor(c: HonoContext): string | null {
+  return c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null;
 }
 
 // ---------------------------------------------------------------------------
@@ -411,6 +417,7 @@ Analyze the semantic layer and propose improvements. For each finding:
       });
 
       // Create session if not existing
+      const wasNewSession = !stored;
       if (!stored) {
         sessionId = generateId();
         stored = {
@@ -423,6 +430,19 @@ Analyze the semantic layer and propose improvements. For each finding:
         sessions.set(sessionId, stored);
       }
       stored.updatedAt = new Date();
+
+      // Audit the draft surface: starting or continuing an expert-agent
+      // session that can propose amendments via `proposeAmendment`. The
+      // tool may persist a pending `semantic_amendments` row mid-stream,
+      // so the audit row is the single anchor for "admin opened the
+      // improve chat at time T" even if the stream errors later.
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.semantic.improveDraft,
+        targetType: "semantic",
+        targetId: stored.id,
+        ipAddress: clientIpFor(c),
+        metadata: { sessionId: stored.id, resumed: !wasNewSession },
+      });
 
       const stream = createUIMessageStream({
         execute: ({ writer }) => {
@@ -545,6 +565,20 @@ adminSemanticImprove.openapi(approveProposalRoute, async (c) =>
     // Record decision in session state (separate from YAML apply)
     advanceAndRecord(stored, proposalIndex, "accepted");
 
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.semantic.improveAccept,
+      targetType: "semantic",
+      targetId: stored.id,
+      ipAddress: clientIpFor(c),
+      metadata: {
+        id: stored.id,
+        sessionId: stored.id,
+        proposalIndex,
+        entityName: proposal.entityName,
+        amendmentType: proposal.amendmentType,
+      },
+    });
+
     log.info({ requestId, orgId, proposalIndex, entity: proposal.entityName }, "Proposal approved");
     return c.json({ ok: true, proposalIndex, decision: "accepted" }, 200);
   }),
@@ -571,6 +605,19 @@ adminSemanticImprove.openapi(rejectProposalRoute, async (c) =>
     }
 
     advanceAndRecord(match.stored, proposalIndex, "rejected");
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.semantic.improveReject,
+      targetType: "semantic",
+      targetId: match.stored.id,
+      ipAddress: clientIpFor(c),
+      metadata: {
+        id: match.stored.id,
+        sessionId: match.stored.id,
+        proposalIndex,
+        entityName: match.proposal.entityName,
+      },
+    });
 
     log.info({ requestId, orgId, proposalIndex }, "Proposal rejected");
     return c.json({ ok: true, proposalIndex, decision: "rejected" }, 200);
@@ -834,6 +881,22 @@ adminSemanticImprove.openapi(reviewAmendmentRoute, async (c) =>
     if (!reviewed) {
       return c.json({ error: "not_found", message: "Amendment not found or already reviewed.", requestId }, 404);
     }
+
+    // Action type reflects the intent, not the route path — an approved
+    // review fires `improve_apply` (YAML was written); a rejected review
+    // fires `improve_reject` so compliance queries filtering on a single
+    // action_type catch both in-memory (proposals) and DB-backed
+    // (amendments) rejections.
+    logAdminAction({
+      actionType:
+        decision === "approved"
+          ? ADMIN_ACTIONS.semantic.improveApply
+          : ADMIN_ACTIONS.semantic.improveReject,
+      targetType: "semantic",
+      targetId: id,
+      ipAddress: clientIpFor(c),
+      metadata: { id, decision },
+    });
 
     log.info({ requestId, orgId, id, decision }, "Amendment reviewed");
     return c.json({ ok: true, id, decision }, 200);

--- a/packages/api/src/api/routes/admin-starter-prompts.ts
+++ b/packages/api/src/api/routes/admin-starter-prompts.ts
@@ -31,10 +31,16 @@ import {
   SUGGESTION_TEXT_MAX_LENGTH,
 } from "@atlas/api/lib/suggestions/approval-store";
 import { createLogger } from "@atlas/api/lib/logger";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
+import type { Context as HonoContext } from "hono";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
 
 const log = createLogger("admin-starter-prompts");
+
+function clientIpFor(c: HonoContext): string | null {
+  return c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null;
+}
 
 // ---------------------------------------------------------------------------
 // Schemas
@@ -393,6 +399,15 @@ adminStarterPrompts.openapi(approveRoute, async (c) =>
 
     try {
       const outcome = await approveSuggestion({ id, orgId, userId, mode: atlasMode });
+      if (outcome.status === "ok") {
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.starter_prompt.approve,
+          targetType: "starter_prompt",
+          targetId: id,
+          ipAddress: clientIpFor(c),
+          metadata: { id, name: outcome.suggestion.description },
+        });
+      }
       return respondApprovalResult(c, outcome, requestId, "approve");
     } catch (err) {
       log.error(
@@ -417,6 +432,15 @@ adminStarterPrompts.openapi(hideRoute, async (c) =>
 
     try {
       const outcome = await hideSuggestion({ id, orgId, mode: atlasMode });
+      if (outcome.status === "ok") {
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.starter_prompt.hide,
+          targetType: "starter_prompt",
+          targetId: id,
+          ipAddress: clientIpFor(c),
+          metadata: { id, name: outcome.suggestion.description },
+        });
+      }
       return respondApprovalResult(c, outcome, requestId, "hide");
     } catch (err) {
       log.error(
@@ -441,6 +465,15 @@ adminStarterPrompts.openapi(unhideRoute, async (c) =>
 
     try {
       const outcome = await unhideSuggestion({ id, orgId, mode: atlasMode });
+      if (outcome.status === "ok") {
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.starter_prompt.unhide,
+          targetType: "starter_prompt",
+          targetId: id,
+          ipAddress: clientIpFor(c),
+          metadata: { id, name: outcome.suggestion.description },
+        });
+      }
       return respondApprovalResult(c, outcome, requestId, "unhide");
     } catch (err) {
       log.error(
@@ -467,6 +500,13 @@ adminStarterPrompts.openapi(authorRoute, async (c) =>
 
     try {
       const suggestion = await createApprovedSuggestion({ orgId, userId, text, mode: atlasMode });
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.starter_prompt.authorUpdate,
+        targetType: "starter_prompt",
+        targetId: suggestion.id,
+        ipAddress: clientIpFor(c),
+        metadata: { id: suggestion.id, name: suggestion.description },
+      });
       return c.json({ suggestion }, 200);
     } catch (err) {
       if (err instanceof InvalidSuggestionTextError) {

--- a/packages/api/src/lib/audit/actions.ts
+++ b/packages/api/src/lib/audit/actions.ts
@@ -88,12 +88,30 @@ export const ADMIN_ACTIONS = {
     delete: "sso.delete",
     test: "sso.test",
   },
+  /**
+   * Semantic-layer mutations. `createEntity` / `updateEntity` /
+   * `deleteEntity` / `updateMetric` / `updateGlossary` cover direct
+   * entity CRUD (`admin-semantic.ts` and the admin bulk import). The
+   * `improve*` variants cover the AI-assisted expert-agent surface
+   * (`admin-semantic-improve.ts`): `improveDraft` marks a new
+   * chat-driven draft session, `improveApply` fires when a DB-backed
+   * amendment review flips a pending row to applied (YAML written to
+   * disk), `improveAccept` / `improveReject` cover the in-memory
+   * session proposal decisions. Note: the DB-backed review route
+   * branches on `decision` — rejection emits `improve_reject` so
+   * forensic queries can filter on a single action_type regardless of
+   * which surface rejected it. See F-35.
+   */
   semantic: {
     createEntity: "semantic.create_entity",
     updateEntity: "semantic.update_entity",
     deleteEntity: "semantic.delete_entity",
     updateMetric: "semantic.update_metric",
     updateGlossary: "semantic.update_glossary",
+    improveDraft: "semantic.improve_draft",
+    improveApply: "semantic.improve_apply",
+    improveAccept: "semantic.improve_accept",
+    improveReject: "semantic.improve_reject",
   },
   pattern: {
     approve: "pattern.approve",
@@ -234,6 +252,39 @@ export const ADMIN_ACTIONS = {
   compliance: {
     piiConfigUpdate: "compliance.pii_config_update",
     piiConfigDelete: "compliance.pii_config_delete",
+  },
+  /**
+   * Prompt library CRUD — collections + prompt items. Content-governance
+   * trail: these writes reshape the prompts end-users see in the workspace
+   * library. Without these entries a workspace admin can edit / delete /
+   * reorder prompts (or the collections they live in) with zero forensic
+   * record. `collection_*` actions target the collection; `create` /
+   * `update` / `delete` / `reorder` target individual prompt items.
+   * See F-35.
+   */
+  prompt: {
+    collectionCreate: "prompt.collection_create",
+    collectionUpdate: "prompt.collection_update",
+    collectionDelete: "prompt.collection_delete",
+    create: "prompt.create",
+    update: "prompt.update",
+    delete: "prompt.delete",
+    reorder: "prompt.reorder",
+  },
+  /**
+   * Starter-prompt moderation queue. Approve / hide / unhide flip
+   * `approval_status` on a `query_suggestions` row; `author_update`
+   * covers the admin-authored seed path that skips the pending queue.
+   * Starter prompts are surfaced on the first-run / empty-state
+   * surfaces, so a workspace admin can reshape the landing experience
+   * for every tenant user — unaudited, nobody knows who authored what.
+   * See F-35.
+   */
+  starter_prompt: {
+    approve: "starter_prompt.approve",
+    hide: "starter_prompt.hide",
+    unhide: "starter_prompt.unhide",
+    authorUpdate: "starter_prompt.author_update",
   },
 } as const;
 


### PR DESCRIPTION
## Summary

Closes the **F-35** audit gap (#1790) from the 1.2.3 Security Sweep phase 4 (tracker #1718). Adds `logAdminAction` emission on 15 content-governance admin write routes across three files, plus 15 matching action types in the canonical `ADMIN_ACTIONS` catalog.

Before this PR, seven prompt-library CRUD routes, four AI-assisted semantic-improve routes, and four starter-prompt moderation routes all produced zero audit rows. A workspace admin could reshape the landing-page starter prompts, rewrite the prompt library, or apply semantic-layer amendments for every tenant user with no forensic trail. The `admin-learned-patterns.ts` surface has been audited since 0.8.x (`pattern.approve` / `reject` / `delete`) — F-35 brings the three sister surfaces in line with that precedent.

## Changes

- **`packages/api/src/lib/audit/actions.ts`** — added 7 `prompt.*` actions, 4 `semantic.improve_*` actions merged into the existing `semantic` domain, and 4 `starter_prompt.*` actions under a new top-level domain.
- **`packages/api/src/api/routes/admin-prompts.ts`** — 7 write routes audited. DELETE-item pre-fetches `id, question` so the row's name survives deletion (F-25 pattern). The reorder route additionally collapses the per-row UPDATE loop into a single atomic `UPDATE ... FROM (VALUES ...)` statement — the previous loop was non-atomic and would leave collections in a partial reorder state on mid-loop failure, with no audit row.
- **`packages/api/src/api/routes/admin-semantic-improve.ts`** — `/chat` emits `improve_draft` after `runAgent` resolves but before the SSE stream starts (so the audit row captures intent even if the stream errors later); `/proposals/{id}/(approve|reject)` emit `improve_accept` / `improve_reject`; `/amendments/{id}/review` branches on `decision` so rejection collapses to `improve_reject` (compliance queries on a single action_type catch both in-memory and DB-backed rejections).
- **`packages/api/src/api/routes/admin-starter-prompts.ts`** — approve / hide / unhide emit only when `outcome.status === "ok"` so forbidden/not-found probes leave no audit row; author emits `starter_prompt.author_update` on the seed path.

### Metadata conventions

- Content items: `{ id, name }` (+ `industry` / `collectionId` where the route carries them).
- Reorder: `{ collectionId, newOrder: string[] }` — full ordered id list so drag-and-drop forensics can replay intent.
- Moderation decisions: `{ id, name }` for starter-prompt mutations; `{ id, decision }` for amendment review.
- Semantic improve: `{ sessionId, proposalIndex, entityName, amendmentType }` where available; `/chat` additionally marks `resumed: boolean`.

No credential material in any metadata payload. Naming and shape follow the F-22 / F-25 / F-28 / F-31 precedent.

### Regression tests

- `admin-prompts-audit.test.ts` — 8 tests
- `admin-starter-prompts-audit.test.ts` — 7 tests
- `admin-semantic-improve-audit.test.ts` — 6 tests

Each pins the canonical action-type string and metadata shape. Forbidden / not-found / duplicate paths are pinned to non-emission.

### Docs

- `.claude/research/security-audit-1-2-3.md` — three table rows flipped to ✅ with per-surface resolution notes; F-35 finding rewritten as FIXED with full resolution detail.

## Test plan

- [x] `bun run lint` — 0 errors, 0 warnings
- [x] `bun run type` — 0 errors
- [x] `bun run test` — all packages green
- [x] `bun x syncpack lint` — no issues
- [x] `bash scripts/check-template-drift.sh` — no drift (432 files verified)
- [x] 21 new audit regression tests green locally
- [x] code-reviewer agent review — no merge-blockers; reorder-loop concern fixed inline

Closes #1790.