### PR TITLE
ci: cross-check Railway watchPatterns against Dockerfile COPY sources (closes #1761)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Check Dockerfile workspace completeness
         run: bash scripts/check-dockerfile-workspace.sh
 
+      - name: Check Railway watchPatterns coverage
+        run: bash scripts/check-railway-watch.sh
+
       - name: Check template drift
         run: bash scripts/check-template-drift.sh
 

--- a/deploy/api-apac/railway.json
+++ b/deploy/api-apac/railway.json
@@ -13,11 +13,16 @@
       "packages/schemas/**",
       "packages/cli/data/**",
       "packages/plugin-sdk/**",
+      "packages/**/package.json",
+      "apps/**/package.json",
+      "examples/**/package.json",
+      "create-atlas-plugin/package.json",
       "plugins/**",
       "ee/**",
       "semantic/**",
       "deploy/api/**",
-      "deploy/api-apac/**"
+      "deploy/api-apac/**",
+      "examples/docker/scripts/**"
     ]
   },
   "deploy": {

--- a/deploy/api-eu/railway.json
+++ b/deploy/api-eu/railway.json
@@ -13,11 +13,16 @@
       "packages/schemas/**",
       "packages/cli/data/**",
       "packages/plugin-sdk/**",
+      "packages/**/package.json",
+      "apps/**/package.json",
+      "examples/**/package.json",
+      "create-atlas-plugin/package.json",
       "plugins/**",
       "ee/**",
       "semantic/**",
       "deploy/api/**",
-      "deploy/api-eu/**"
+      "deploy/api-eu/**",
+      "examples/docker/scripts/**"
     ]
   },
   "deploy": {

--- a/deploy/api/railway.json
+++ b/deploy/api/railway.json
@@ -13,10 +13,15 @@
       "packages/schemas/**",
       "packages/cli/data/**",
       "packages/plugin-sdk/**",
+      "packages/**/package.json",
+      "apps/**/package.json",
+      "examples/**/package.json",
+      "create-atlas-plugin/package.json",
       "plugins/**",
       "ee/**",
       "semantic/**",
-      "deploy/api/**"
+      "deploy/api/**",
+      "examples/docker/scripts/**"
     ]
   },
   "deploy": {

--- a/deploy/docs/railway.json
+++ b/deploy/docs/railway.json
@@ -3,7 +3,13 @@
   "build": {
     "builder": "DOCKERFILE",
     "dockerfilePath": "deploy/docs/Dockerfile",
-    "dockerfileContext": "../.."
+    "dockerfileContext": "../..",
+    "watchPatterns": [
+      "bun.lock",
+      "brand.css",
+      "apps/docs/**",
+      "deploy/docs/**"
+    ]
   },
   "deploy": {
     "healthcheckPath": "/",

--- a/deploy/web/railway.json
+++ b/deploy/web/railway.json
@@ -12,6 +12,11 @@
       "packages/react/**",
       "packages/types/**",
       "packages/schemas/**",
+      "packages/**/package.json",
+      "apps/**/package.json",
+      "examples/**/package.json",
+      "plugins/**/package.json",
+      "create-atlas-plugin/package.json",
       "ee/**",
       "deploy/web/**"
     ]

--- a/scripts/check-railway-watch.sh
+++ b/scripts/check-railway-watch.sh
@@ -47,8 +47,10 @@ matches_pattern() {
     fi
   fi
 
-  # Build a regex: escape specials, ** → .*, * → [^/]*.
-  # The §§ placeholder prevents collapsing ** into a double [^/]*.
+  # Build a regex: escape specials, then handle glob wildcards.
+  # Sentinels disambiguate pattern classes during substitution so they
+  # don't interact — §§§ for middle /**/ (zero-or-more segments), §§ for
+  # other **, § for single * (single segment).
   local re="$pat"
   re="${re//\\/\\\\}"
   re="${re//./\\.}"
@@ -63,9 +65,15 @@ matches_pattern() {
   re="${re//[/\\[}"
   re="${re//]/\\]}"
   re="${re//|/\\|}"
+  # Middle /**/ must match zero OR more segments between the slashes,
+  # matching micromatch. packages/**/package.json therefore matches
+  # packages/package.json as well as packages/api/package.json.
+  re="${re//\/\*\*\//§§§}"
   re="${re//\*\*/§§}"
-  re="${re//\*/[^/]*}"
+  re="${re//\*/§}"
+  re="${re//§§§/(\/|\/.*\/)}"
   re="${re//§§/.*}"
+  re="${re//§/[^/]*}"
   if [[ "$src" =~ ^${re}$ ]]; then
     return 0
   fi
@@ -117,16 +125,19 @@ extract_sources() {
 extract_watch_patterns() {
   local railway_json="$1"
   # Capture everything between "watchPatterns": [ and the matching ]
-  # then pull out quoted strings.
+  # then pull out every quoted string on each line. Looping on match() —
+  # a single `if (match(...))` only captures the first string per line,
+  # which would silently drop coverage if a formatter collapsed the
+  # array onto one line.
   awk '
     /"watchPatterns"/,/]/ {
-      if (match($0, /"[^"]+"/)) {
-        s = substr($0, RSTART, RLENGTH)
-        # Skip the key itself
-        if (s != "\"watchPatterns\"") {
-          gsub(/"/, "", s)
-          print s
-        }
+      line = $0
+      while (match(line, /"[^"]+"/)) {
+        s = substr(line, RSTART, RLENGTH)
+        line = substr(line, RSTART + RLENGTH)
+        if (s == "\"watchPatterns\"") continue
+        gsub(/"/, "", s)
+        print s
       }
     }
   ' "$railway_json"
@@ -164,6 +175,23 @@ extract_builder() {
   ' "$railway_json"
 }
 
+# Extract dockerfileContext from railway.json. Empty string if absent —
+# callers should default to the railway.json's own directory.
+extract_dockerfile_context() {
+  local railway_json="$1"
+  awk '
+    /"dockerfileContext"/ {
+      if (match($0, /"dockerfileContext"[[:space:]]*:[[:space:]]*"[^"]*"/)) {
+        s = substr($0, RSTART, RLENGTH)
+        sub(/^"dockerfileContext"[[:space:]]*:[[:space:]]*"/, "", s)
+        sub(/"$/, "", s)
+        print s
+        exit
+      }
+    }
+  ' "$railway_json"
+}
+
 # --- main ---
 for railway_json in "$ROOT"/deploy/*/railway.json; do
   [ -f "$railway_json" ] || continue
@@ -183,9 +211,29 @@ for railway_json in "$ROOT"/deploy/*/railway.json; do
     continue
   fi
 
-  dockerfile_abs="$ROOT/$dockerfile_rel"
-  if [ ! -f "$dockerfile_abs" ]; then
-    echo "::error file=$rel_json::dockerfilePath $dockerfile_rel does not exist"
+  # Railway resolves dockerfilePath relative to dockerfileContext. Resolve
+  # the same way: context (default = railway.json's directory) → Dockerfile.
+  # Fall back to repo-root-relative if the context-relative resolution
+  # doesn't exist, because Atlas's historical configs use both shapes
+  # interchangeably (context="../.." + root-relative dockerfilePath works
+  # either way, but a future service may not).
+  svc_dir="$(dirname "$railway_json")"
+  context_raw=$(extract_dockerfile_context "$railway_json")
+  if [ -n "$context_raw" ]; then
+    context_abs="$(cd "$svc_dir" 2>/dev/null && cd "$context_raw" 2>/dev/null && pwd)" || context_abs=""
+  else
+    context_abs="$svc_dir"
+  fi
+
+  dockerfile_abs=""
+  if [ -n "$context_abs" ] && [ -f "$context_abs/$dockerfile_rel" ]; then
+    dockerfile_abs="$context_abs/$dockerfile_rel"
+  elif [ -f "$ROOT/$dockerfile_rel" ]; then
+    dockerfile_abs="$ROOT/$dockerfile_rel"
+  fi
+
+  if [ -z "$dockerfile_abs" ]; then
+    echo "::error file=$rel_json::dockerfilePath '$dockerfile_rel' not found relative to context '${context_raw:-<default>}' or repo root"
     ERRORS=$((ERRORS + 1))
     continue
   fi

--- a/scripts/check-railway-watch.sh
+++ b/scripts/check-railway-watch.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# Verify every repo-relative COPY source in each deploy Dockerfile is
+# covered by its service's railway.json watchPatterns.
+#
+# The F-10 / PR #1758 incident: a bun.lock change went unshipped because
+# api / api-eu / api-apac / web did not list "bun.lock" in watchPatterns,
+# so Railway didn't redeploy on the merge. PR #1760 added the missing
+# entries. This check keeps a future service from drifting the same way.
+#
+# Pass conditions:
+#   - Every `COPY <src> <dst>` source in the Dockerfile is covered by a
+#     watchPatterns entry (exact match, X/** prefix, or X* prefix).
+#   - `COPY --from=<stage>` lines are skipped (intra-image).
+#   - `COPY . .` is skipped (broad-context copy, not useful to match).
+#   - Services without watchPatterns warn (Railway rebuilds on every push —
+#     wasteful but not broken). Services without a Dockerfile builder
+#     (NIXPACKS etc.) are skipped entirely.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ERRORS=0
+WARNINGS=0
+
+# Match a source path against a glob-style watchPattern.
+# Supports:
+#   - Exact match (bun.lock)
+#   - Trailing /** — prefix match (packages/api/**)
+#   - Middle ** — any-depth wildcard (packages/**/package.json)
+#   - Single * — single-segment wildcard (not commonly used but correct)
+#
+# Conversion rules: ** → .*, * → [^/]*. Regex specials are escaped first.
+matches_pattern() {
+  local src="$1"
+  local pat="$2"
+
+  # Fast path: exact match
+  if [ "$src" = "$pat" ]; then
+    return 0
+  fi
+
+  # X/** also matches X itself (bare directory), which the regex wouldn't.
+  if [[ "$pat" == *"/**" ]]; then
+    local prefix="${pat%/**}"
+    if [ "$src" = "$prefix" ]; then
+      return 0
+    fi
+  fi
+
+  # Build a regex: escape specials, ** → .*, * → [^/]*.
+  # The §§ placeholder prevents collapsing ** into a double [^/]*.
+  local re="$pat"
+  re="${re//\\/\\\\}"
+  re="${re//./\\.}"
+  re="${re//+/\\+}"
+  re="${re//\?/\\?}"
+  re="${re//^/\\^}"
+  re="${re//\$/\\\$}"
+  re="${re//(/\\(}"
+  re="${re//)/\\)}"
+  re="${re//\{/\\\{}"
+  re="${re//\}/\\\}}"
+  re="${re//[/\\[}"
+  re="${re//]/\\]}"
+  re="${re//|/\\|}"
+  re="${re//\*\*/§§}"
+  re="${re//\*/[^/]*}"
+  re="${re//§§/.*}"
+  if [[ "$src" =~ ^${re}$ ]]; then
+    return 0
+  fi
+  return 1
+}
+
+# Extract COPY sources from a Dockerfile, one per line.
+# Skips --from= copies (intra-image) and the broad `COPY . .`.
+# Normalizes trailing glob (bun.lock* → bun.lock) since watchPatterns
+# list the base filename.
+extract_sources() {
+  local dockerfile="$1"
+  # Normalize: strip trailing whitespace/CR, drop blank lines, collapse to
+  # lines starting with COPY (case-insensitive would be wrong — Dockerfile
+  # keywords are uppercase by convention).
+  grep -E '^COPY[[:space:]]' "$dockerfile" | while IFS= read -r line; do
+    # Skip --from= (intra-image copy)
+    if [[ "$line" == *"--from="* ]]; then
+      continue
+    fi
+    # Drop the COPY keyword
+    line="${line#COPY}"
+    line="${line# }"
+    # Drop --chown=...:... and any other --flag=value
+    # shellcheck disable=SC2001
+    line=$(echo "$line" | sed -E 's/--[a-zA-Z]+=[^[:space:]]+[[:space:]]+//g')
+    # Last whitespace-separated word is the destination; drop it
+    # shellcheck disable=SC2206
+    words=($line)
+    unset "words[${#words[@]}-1]"
+    for src in "${words[@]}"; do
+      # Skip broad-context copy
+      if [ "$src" = "." ] || [ "$src" = "./" ]; then
+        continue
+      fi
+      # Normalize trailing glob (bun.lock* → bun.lock)
+      src="${src%\*}"
+      # Normalize trailing slash
+      src="${src%/}"
+      if [ -n "$src" ]; then
+        echo "$src"
+      fi
+    done
+  done
+}
+
+# Extract watchPatterns entries from a railway.json, one per line.
+# Uses a simple awk pass since we know the JSON layout — no jq dependency.
+extract_watch_patterns() {
+  local railway_json="$1"
+  # Capture everything between "watchPatterns": [ and the matching ]
+  # then pull out quoted strings.
+  awk '
+    /"watchPatterns"/,/]/ {
+      if (match($0, /"[^"]+"/)) {
+        s = substr($0, RSTART, RLENGTH)
+        # Skip the key itself
+        if (s != "\"watchPatterns\"") {
+          gsub(/"/, "", s)
+          print s
+        }
+      }
+    }
+  ' "$railway_json"
+}
+
+# Extract dockerfilePath from railway.json (awk, no jq)
+extract_dockerfile_path() {
+  local railway_json="$1"
+  awk '
+    /"dockerfilePath"/ {
+      if (match($0, /"dockerfilePath"[[:space:]]*:[[:space:]]*"[^"]+"/)) {
+        s = substr($0, RSTART, RLENGTH)
+        sub(/^"dockerfilePath"[[:space:]]*:[[:space:]]*"/, "", s)
+        sub(/"$/, "", s)
+        print s
+        exit
+      }
+    }
+  ' "$railway_json"
+}
+
+# Extract builder type (DOCKERFILE, NIXPACKS, etc.)
+extract_builder() {
+  local railway_json="$1"
+  awk '
+    /"builder"/ {
+      if (match($0, /"builder"[[:space:]]*:[[:space:]]*"[^"]+"/)) {
+        s = substr($0, RSTART, RLENGTH)
+        sub(/^"builder"[[:space:]]*:[[:space:]]*"/, "", s)
+        sub(/"$/, "", s)
+        print s
+        exit
+      }
+    }
+  ' "$railway_json"
+}
+
+# --- main ---
+for railway_json in "$ROOT"/deploy/*/railway.json; do
+  [ -f "$railway_json" ] || continue
+  svc="$(basename "$(dirname "$railway_json")")"
+  rel_json="${railway_json#"$ROOT"/}"
+
+  builder=$(extract_builder "$railway_json")
+  if [ "$builder" != "DOCKERFILE" ]; then
+    echo "$svc: builder=${builder:-unknown} — skipping (only DOCKERFILE builds are checked)"
+    continue
+  fi
+
+  dockerfile_rel=$(extract_dockerfile_path "$railway_json")
+  if [ -z "$dockerfile_rel" ]; then
+    echo "::error file=$rel_json::dockerfilePath missing for DOCKERFILE builder"
+    ERRORS=$((ERRORS + 1))
+    continue
+  fi
+
+  dockerfile_abs="$ROOT/$dockerfile_rel"
+  if [ ! -f "$dockerfile_abs" ]; then
+    echo "::error file=$rel_json::dockerfilePath $dockerfile_rel does not exist"
+    ERRORS=$((ERRORS + 1))
+    continue
+  fi
+
+  # Read watchPatterns into an array
+  mapfile -t patterns < <(extract_watch_patterns "$railway_json")
+  if [ ${#patterns[@]} -eq 0 ]; then
+    echo "::warning file=$rel_json::$svc has no watchPatterns — Railway rebuilds on every push (wasteful; add narrow patterns to reduce noise)"
+    WARNINGS=$((WARNINGS + 1))
+    continue
+  fi
+
+  # Check each COPY source is covered
+  echo "--- $svc (Dockerfile: $dockerfile_rel, ${#patterns[@]} watchPatterns) ---"
+  missing_for_svc=0
+  mapfile -t sources < <(extract_sources "$dockerfile_abs")
+  for src in "${sources[@]}"; do
+    [ -n "$src" ] || continue
+    covered=0
+    for pat in "${patterns[@]}"; do
+      if matches_pattern "$src" "$pat"; then
+        covered=1
+        break
+      fi
+    done
+    if [ $covered -eq 0 ]; then
+      echo "::error file=$rel_json::COPY source '$src' in $dockerfile_rel is not covered by any watchPattern — a change to this file will not trigger a Railway redeploy"
+      missing_for_svc=$((missing_for_svc + 1))
+      ERRORS=$((ERRORS + 1))
+    fi
+  done
+
+  if [ $missing_for_svc -eq 0 ]; then
+    echo "  All ${#sources[@]} COPY sources covered"
+  fi
+done
+
+echo ""
+if [ $ERRORS -gt 0 ]; then
+  echo "FAIL: $ERRORS COPY source(s) not covered by watchPatterns — see errors above"
+  echo "Fix: add the missing paths to the corresponding deploy/<service>/railway.json watchPatterns array"
+  exit 1
+fi
+
+if [ $WARNINGS -gt 0 ]; then
+  echo "OK (with $WARNINGS warning(s)): all deploy Dockerfile COPY sources are covered where watchPatterns are defined"
+else
+  echo "OK: all deploy Dockerfile COPY sources are covered by their service's watchPatterns"
+fi


### PR DESCRIPTION
## Summary

Adds `scripts/check-railway-watch.sh` — runs in CI and fails if any repo-relative COPY source in a deploy Dockerfile is not covered by its service's `railway.json` watchPatterns. Closes #1761.

## Why

The **F-10 / PR #1758 incident**: a `@useatlas/types` version bump produced a `bun.lock` change that silently did NOT trigger Railway redeploys for api/api-eu/api-apac/web — because `bun.lock` wasn't in those services' `watchPatterns`. The F-10 security fix merged to main but didn't actually ship until PR #1760 re-triggered the build. This check closes the gap for good.

Sibling to `scripts/check-dockerfile-workspace.sh`, which already verifies every workspace member is COPY'd in the Dockerfile. This PR closes the loop in the other direction: every COPY'd source must be in `watchPatterns`.

## What the check surfaced

60 real gaps on the first run — fixed inline:

- **api / api-eu / api-apac** were missing 10 entries each (workspace `package.json` paths from `bun ci --frozen-lockfile` validation, plus `seed-demo.ts`). Added `packages/**/package.json`, `apps/**/package.json`, `examples/**/package.json`, `create-atlas-plugin/package.json`, `examples/docker/scripts/**`.
- **web** was missing 30+ entries (same class — every workspace `package.json`, including `plugins/**/package.json`).
- **docs** had no `watchPatterns` at all — Railway was rebuilding on every push (wasteful but not broken). Added narrow patterns: `bun.lock`, `brand.css`, `apps/docs/**`, `deploy/docs/**`.

## Matcher semantics

Supports:
- Exact match (`bun.lock`)
- Trailing `/**` prefix match (`packages/api/**` covers `packages/api` and anything under it)
- Middle `**` (`packages/**/package.json` matches at any depth)
- Single `*` (`foo*` — rare but correct)

Built on `awk` + bash regex. No `jq` / node dep — the check runs early in CI, before `bun install`.

## Edge cases

- `COPY --from=<stage>` skipped (intra-image)
- `COPY . .` skipped (broad context, not useful to match)
- NIXPACKS builder (www) skipped — only DOCKERFILE builds are checked
- Missing `watchPatterns` is a **warning** not an error (Railway default is rebuild-on-every-push; adding patterns is optional)
- Missing `dockerfilePath` for a DOCKERFILE builder IS an error

## Test plan

- [x] `bash scripts/check-railway-watch.sh` — passes (all 138 COPY sources across 6 services covered)
- [x] `bash scripts/check-dockerfile-workspace.sh` — sibling check still passes
- [x] `bun run lint` — green
- [x] `bun run type` — green
- [x] `bun x syncpack lint` — green
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — green (432 files verified)
- [x] Manually verified: reverting `bun.lock` from one railway.json causes the check to fail with a clear error

## Notes

None of the added watchPatterns trigger NEW rebuilds on unrelated changes — they only catch changes that were previously silently dropped. The api services now also rebuild on workspace `package.json` changes (build-time validation) which was the point of the F-10 fix.