### PR TITLE
docs: thread new local workflow through CLAUDE.md + slash commands

### DIFF
--- a/.claude/commands/ci.md
+++ b/.claude/commands/ci.md
@@ -5,10 +5,13 @@ Run the same checks CI runs. This must pass before opening a PR.
 ```bash
 bun run lint           # ESLint — 0 errors, 0 warnings
 bun run type           # TypeScript strict mode (tsgo) — 0 errors
-bun run test           # All tests (isolated per-file runner)
+bun run test           # FULL suite — @atlas/api + test:others (isolated per-file)
 bun x syncpack lint    # Workspace dependency versions consistent
 SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh  # Template drift
+bash scripts/check-railway-watch.sh  # Railway watchPatterns cover Dockerfile COPY sources
 ```
+
+Use the full `bun run test` here — `/ci` is the pre-PR check, not an iteration loop. For iteration, use `cd packages/api && bun run scripts/test-isolated.ts --affected` (only tests whose source graph your branch touched — typical 10–60s vs 225s full).
 
 **Evaluate results:**
 
@@ -19,6 +22,7 @@ SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh  # Template drift
 | Test | All packages pass, 0 failures |
 | Syncpack | `No issues found` |
 | Template drift | `Template drift check passed` |
+| Railway watch | `all deploy Dockerfile COPY sources are covered` |
 
 **If any gate fails:**
 
@@ -33,7 +37,7 @@ SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh  # Template drift
 
 **If all gates pass:**
 
-Report: `CI gates: lint, type, test, syncpack, drift — all pass.`
+Report: `CI gates: lint, type, test, syncpack, drift, railway-watch — all pass.`
 
 ---
 
@@ -68,7 +72,7 @@ gh api repos/AtlasDevHQ/atlas/commits/main/statuses --jq '[.[] | {context, state
 
 **If all checks pass:**
 
-Report: `CI gates: lint, type, test, syncpack, drift — all pass. Remote: CI, Sync Starters, Railway (api/web/docs) — all green.`
+Report: `CI gates: lint, type, test, syncpack, drift, railway-watch — all pass. Remote: CI, Sync Starters, Railway (api/web/docs) — all green.`
 
 ---
 

--- a/.claude/commands/health-check.md
+++ b/.claude/commands/health-check.md
@@ -30,13 +30,14 @@ gh run view <run_id> -R AtlasDevHQ/atlas --log-failed 2>&1 | tail -30
 
 ### A1. Lint, Type Check, Tests & Dependency Sync
 
-Run all four CI gates locally. If any fail, stop and report — the codebase is broken.
+Run all CI gates locally. If any fail, stop and report — the codebase is broken.
 
 ```bash
 bun run lint           # ESLint (flat config) — 0 warnings
 bun run type           # TypeScript strict mode via tsgo — 0 errors
-bun run test           # bun test across @atlas/api + @atlas/cli + @atlas/mcp
+bun run test           # Full suite — @atlas/api + all other workspace packages (isolated per-file)
 bun x syncpack lint    # Workspace dependency versions consistent
+bash scripts/check-railway-watch.sh  # Railway watchPatterns vs Dockerfile COPY sources
 ```
 
 | Check | What to Look For |

--- a/.claude/commands/next.md
+++ b/.claude/commands/next.md
@@ -60,15 +60,20 @@ The user runs up to 3 Claude Code sessions in parallel (separate checkouts).
 Reference the GH issue number. Include acceptance criteria.
 
 IMPORTANT — CI gates (mandatory before PR):
-- Before creating a PR, run `/ci` which checks: lint, type, test, syncpack, template drift
-- All five gates must pass. If any fail, fix them before pushing.
-- You can also run gates individually during development:
+- Before creating a PR, run `/ci` — checks lint, type, test, syncpack, template drift, railway-watch. All six must pass.
+- Individual gates during development:
   - `bun run lint` — ESLint
   - `bun run type` — TypeScript (tsgo)
-  - `bun run test` — all tests (isolated per-file runner), NEVER bare `bun test`
+  - `bun run test` — FULL suite across all packages (isolated per-file runner). NEVER bare `bun test`.
   - `bun x syncpack lint` — dependency version consistency
   - `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — template drift
-- To run a single test file: `bun test path/to/file.test.ts`
+  - `bash scripts/check-railway-watch.sh` — Railway watchPatterns vs Dockerfile COPY sources
+- **Fast local feedback loop** — during the edit/test cycle, DON'T run the full suite. Use:
+  - `cd packages/api && bun run scripts/test-isolated.ts --affected` — only tests whose source graph your branch touched vs `origin/main` (typical: 10–60s vs 225s full)
+  - `cd packages/api && bun run scripts/test-isolated.ts --since HEAD~3` — last-3-commit window
+  - `bun test path/to/file.test.ts` — single test file
+- Run full `bun run test` once before opening a PR, even if `--affected` has been passing.
+- The isolated runner throws loudly if its git detector can't resolve the base ref — don't ignore it, you've likely got a shallow clone or unfetched ref.
 - When using mock.module(), mock ALL named exports — partial mocks break other test files
 - Use `createConnectionMock()` from `packages/api/src/__mocks__/connection.ts` for connection mocks
 
@@ -90,6 +95,7 @@ IMPORTANT — Incidental findings:
 IMPORTANT — Testing approach:
 - For features and bug fixes, use `/tdd` to drive development with red-green-refactor
 - Write tests alongside code, not after — one test → one implementation → repeat
+- Use `--affected` mode to keep the red→green loop under a minute; reserve the full suite for the pre-PR gate
 - Skip `/tdd` for docs-only, chore, or trivial config changes
 
 IMPORTANT — Docs impact:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,9 @@ Guidance for Claude Code when working in this repository.
 - [ ] **satisfies on service returns** — Always use `satisfies FooShape` on returned service objects for compile-time verification
 
 ### Testing
-- [ ] **`bun run test`, never `bun test`** — Project uses isolated test runner (each file in its own subprocess). Always `bun run test` or `bun test <single-file>`. Never bare `bun test` against a directory
+- [ ] **`bun run test`, never `bun test`** — Project uses isolated test runner (each file in its own subprocess). Always `bun run test` (or `test:api` / `test:others` / `test-isolated.ts --affected`). Single file is OK: `bun test path/to/file.test.ts`. Never bare `bun test` against a directory
+- [ ] **Use `--affected` for local feedback loops** — `cd packages/api && bun run scripts/test-isolated.ts --affected` runs only tests whose source graph your branch touched vs `origin/main`. Use `--since HEAD~3` for last-N-commit windows. Typical PRs drop from 225s to 10–60s. Run the full `bun run test` before opening a PR. The runner throws loudly if the git detector can't resolve the base ref — don't ignore it
+- [ ] **Pre-PR gates via `/ci`** — `/ci` runs lint + type + test + syncpack + template drift + railway-watch. All five must pass before opening a PR. In CI the api suite is sharded 4-way; locally it runs serial
 - [ ] **Mock all exports** — When using `mock.module()`, mock every named export. Partial mocks cause `SyntaxError` in other files
 - [ ] **Use shared mock factory** — Connection mocks use `createConnectionMock()` from `packages/api/src/__mocks__/connection.ts`. Don't create inline connection mocks
 - [ ] **Effect test layers preferred** — For new tests, prefer `createConnectionTestLayer()` / `TestAppLayer` / `buildTestLayer()` from `packages/api/src/__test-utils__/layers.ts` over `mock.module()`. Composable Layers are type-safe and don't leak state between tests
@@ -107,7 +109,12 @@ bun run dev:web          # Standalone Next.js
 bun run build            # Production build
 bun run lint             # ESLint
 bun run type             # TypeScript type-check (tsgo --noEmit)
-bun run test             # Tests (isolated per-file)
+bun run test             # Full suite — @atlas/api then all other packages (isolated per-file)
+bun run test:api         # Just @atlas/api tests (serial, full)
+bun run test:others      # All other workspace test suites
+# Fast local feedback loop — only tests whose source graph your branch touched:
+cd packages/api && bun run scripts/test-isolated.ts --affected
+cd packages/api && bun run scripts/test-isolated.ts --since HEAD~3     # last 3 commits
 bun run db:up            # Start Postgres + sandbox sidecar
 bun run db:down          # Stop containers
 bun run db:reset         # Nuke volume + restart


### PR DESCRIPTION
Follow-up to PR #1824 (#1811). Propagates the new test commands (`test:api` / `test:others` / `--affected` / `--since`) and the new `railway-watch` CI gate through the workflow guidance so future sessions reach for the fast loop by default.

## CLAUDE.md
- **Testing checklist** — `bun run test` rule now explicitly mentions the valid forms (`test:api`, `test:others`, `test-isolated.ts --affected`, `bun test <single-file>`). Added a checklist item specifically for `--affected` as the local feedback loop (225s → 10–60s), plus guidance to run full `bun run test` before opening a PR. Added a pre-PR gates item pointing to `/ci`.
- **Commands section** — expanded the `bun run test` one-liner into the full `test:api` / `test:others` surface plus the affected-mode one-liner with `--since HEAD~3` example.

## .claude/commands/next.md (the prompts emitted to fresh sessions)
- CI gates list now includes `railway-watch` (6th gate).
- New explicit **Fast local feedback loop** subsection telling sessions to use `--affected` during edit/test cycles, full suite only pre-PR.
- Called out the loud-fail behavior when git can't resolve the base — "don't ignore it, you've likely got a shallow clone or unfetched ref."
- Testing-approach section notes `--affected` keeps the red→green loop under a minute.

## .claude/commands/ci.md
- Added `bash scripts/check-railway-watch.sh` as the 6th gate.
- Explicit note: `--affected` is for iteration, not `/ci` (which is the pre-PR check).
- Updated the two success-report strings to include `railway-watch`.

## .claude/commands/health-check.md
- Fixed a stale claim: the test line said "across `@atlas/api + @atlas/cli + @atlas/mcp`". Updated to reflect the current 26-package surface.
- Added `railway-watch` to the gate list.

## Test plan

- [x] No code changes — docs only
- [x] Verified each updated reference points to a real script / command that exists on main post-#1824

## Why only these four files

Grep for `bun run test` / `bun test` / `test-isolated` across `CLAUDE.md` + `.claude/commands/*.md` returned exactly these four files. `revamp.md` mentions `bun:test` noise (a type-check filter, not a test command) and `test-browser.md` is about Playwright — neither needed updating.