### PR TITLE
fix(ci): unblock main — api-tests build, Drizzle drift, OpenAPI drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,11 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # @useatlas/types resolves to packages/types/dist via its "exports" field,
+      # so api tests can't import it until the package has been built.
+      - name: Build @useatlas/types
+        run: bun run --filter '@useatlas/types' build
+
       - name: Test @atlas/api (shard ${{ matrix.shard }}/4)
         working-directory: packages/api
         run: bun run scripts/test-isolated.ts --shard ${{ matrix.shard }}/4

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -45804,10 +45804,16 @@
                             "type": "string"
                           },
                           "actorId": {
-                            "type": "string"
+                            "type": [
+                              "string",
+                              "null"
+                            ]
                           },
                           "actorEmail": {
-                            "type": "string"
+                            "type": [
+                              "string",
+                              "null"
+                            ]
                           },
                           "scope": {
                             "type": "string",
@@ -45853,6 +45859,12 @@
                           },
                           "requestId": {
                             "type": "string"
+                          },
+                          "anonymizedAt": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
                           }
                         },
                         "required": [
@@ -45868,7 +45880,8 @@
                           "status",
                           "metadata",
                           "ipAddress",
-                          "requestId"
+                          "requestId",
+                          "anonymizedAt"
                         ]
                       }
                     },
@@ -54583,10 +54596,16 @@
                             "type": "string"
                           },
                           "actorId": {
-                            "type": "string"
+                            "type": [
+                              "string",
+                              "null"
+                            ]
                           },
                           "actorEmail": {
-                            "type": "string"
+                            "type": [
+                              "string",
+                              "null"
+                            ]
                           },
                           "scope": {
                             "type": "string",
@@ -54632,6 +54651,12 @@
                           },
                           "requestId": {
                             "type": "string"
+                          },
+                          "anonymizedAt": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
                           }
                         },
                         "required": [
@@ -54647,7 +54672,8 @@
                           "status",
                           "metadata",
                           "ipAddress",
-                          "requestId"
+                          "requestId",
+                          "anonymizedAt"
                         ]
                       }
                     },

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -1385,3 +1385,27 @@ export const adminActionLog = pgTable(
     check("chk_admin_action_status", sql`status IN ('success', 'failure')`),
   ],
 );
+
+// ---------------------------------------------------------------------------
+// Admin action retention config
+// ---------------------------------------------------------------------------
+// Parallel to `auditRetentionConfig` — retention policy for `adminActionLog`.
+// Key is `org_id` with the reserved literal 'platform' for the platform-scoped
+// policy row. See migration 0035 and `.claude/research/design/admin-action-log-retention.md`.
+
+export const adminActionRetentionConfig = pgTable(
+  "admin_action_retention_config",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    orgId: text("org_id").notNull().unique(),
+    retentionDays: integer("retention_days"),
+    hardDeleteDelayDays: integer("hard_delete_delay_days").notNull().default(30),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedBy: text("updated_by"),
+    lastPurgeAt: timestamp("last_purge_at", { withTimezone: true }),
+    lastPurgeCount: integer("last_purge_count"),
+  },
+  (t) => [
+    index("idx_admin_action_retention_config_org").on(t.orgId),
+  ],
+);


### PR DESCRIPTION
## Summary
Three independent CI regressions on `main` — all from PRs merged in the last ~20 min. Consolidated here.

**1. api-tests shards 1–4 — `Cannot find module '@useatlas/types'`**
- PR #1824 added the sharded `api-tests` matrix but skipped the `@useatlas/types` build step. Its `exports` field points at `./dist/`, which the new job never builds.
- Fix: add `bun run --filter '@useatlas/types' build` before `test-isolated`.

**2. `ci` job — Drizzle schema drift**
- PR #1821 (F-36 phase 1) added migration `0035_admin_action_retention.sql` but not the matching Drizzle entry, so `scripts/check-schema-drift.sh` flags `admin_action_retention_config`.
- Fix: add `adminActionRetentionConfig` to `schema.ts`, mirroring `auditRetentionConfig`.

**3. `ci` job — OpenAPI drift**
- A recent merge modified a route-schema without regenerating `apps/docs/openapi.json`.
- Fix: run `openapi:extract` + `generate:api`, commit the spec (MDX was already in sync).

Closes #1827 (folded in).

## Test plan
- [x] `bash scripts/check-schema-drift.sh` → passes locally
- [x] `bash scripts/check-openapi-drift.sh` → passes locally
- [x] api-tests 1/4–4/4 already green on this PR's first push
- [ ] Full CI green after this push