### PR TITLE
fix: add admin_action_retention_config to schema.ts (Drizzle drift)

### DIFF
--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -1385,3 +1385,27 @@ export const adminActionLog = pgTable(
     check("chk_admin_action_status", sql`status IN ('success', 'failure')`),
   ],
 );
+
+// ---------------------------------------------------------------------------
+// Admin action retention config
+// ---------------------------------------------------------------------------
+// Parallel to `auditRetentionConfig` — retention policy for `adminActionLog`.
+// Key is `org_id` with the reserved literal 'platform' for the platform-scoped
+// policy row. See migration 0035 and `.claude/research/design/admin-action-log-retention.md`.
+
+export const adminActionRetentionConfig = pgTable(
+  "admin_action_retention_config",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    orgId: text("org_id").notNull().unique(),
+    retentionDays: integer("retention_days"),
+    hardDeleteDelayDays: integer("hard_delete_delay_days").notNull().default(30),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedBy: text("updated_by"),
+    lastPurgeAt: timestamp("last_purge_at", { withTimezone: true }),
+    lastPurgeCount: integer("last_purge_count"),
+  },
+  (t) => [
+    index("idx_admin_action_retention_config_org").on(t.orgId),
+  ],
+);


### PR DESCRIPTION
## Summary
- Migration `0035_admin_action_retention.sql` (from #1821, F-36 phase 1) added the `admin_action_retention_config` table to SQL but not to the Drizzle schema.
- `scripts/check-schema-drift.sh` fails in CI on `main` with "Table 'admin_action_retention_config' exists in migration SQL but not in schema.ts".
- Without the schema entry, a future `drizzle-kit generate` would emit a `DROP TABLE` migration.

Mirrors `auditRetentionConfig` at line 718 — same column shape + `idx_admin_action_retention_config_org` index.

Together with #1826 this unblocks the two failing checks on `main`.

## Test plan
- [x] `bash scripts/check-schema-drift.sh` → "Schema drift check passed — all 61 migration tables found in schema.ts"
- [ ] CI passes