### PR TITLE
fix(security): F-P3 — signup response image parity (closes #1792)

### DIFF
--- a/packages/api/src/api/__tests__/auth-signup-normalize.test.ts
+++ b/packages/api/src/api/__tests__/auth-signup-normalize.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from "bun:test";
+import type { Context } from "hono";
+import { maybeNormalizeSignupResponse } from "../routes/auth";
+
+/**
+ * Regression tests for the Hono-route wrapper that carries the F-P3 /
+ * #1792 fix.
+ *
+ * The parity test in `lib/auth/__tests__/rate-limit-integration.test.ts`
+ * drives a real Better Auth instance and applies the pure helper at
+ * the test boundary — that assertion proves the oracle is closed, but
+ * it bypasses the wrapper. These tests own the wrapper's scope guards
+ * and Response-rebuild invariants:
+ *
+ *   1. Path guard — only `/sign-up/email` responses are rewritten.
+ *   2. Status guard — non-2xx (error envelopes) flow through untouched.
+ *   3. Content-type guard — non-JSON bodies flow through untouched.
+ *   4. Parse-failure guard — JSON-advertised but malformed bodies flow
+ *      through untouched (unparseable ≠ target envelope).
+ *   5. Fast-path identity — when the helper is a no-op, the ORIGINAL
+ *      Response reference is returned. A rebuild would strip
+ *      `Content-Length` unnecessarily and burn an allocation per
+ *      signup forever.
+ *   6. Content-Length drop — when the body IS rewritten, the stale
+ *      upstream `Content-Length` is dropped so a strict client proxy
+ *      doesn't truncate the trailing bytes.
+ */
+
+/**
+ * Minimal Hono `Context` stub — only `c.req.path` is read by
+ * `maybeNormalizeSignupResponse`. Using a narrow fake keeps the tests
+ * off the real Hono app (which would require a live Better Auth
+ * instance to exercise the catch-all).
+ */
+function makeCtx(path: string): Context {
+  return { req: { path } } as unknown as Context;
+}
+
+function jsonResponse(
+  body: unknown,
+  init?: { status?: number; headers?: Record<string, string> },
+): Response {
+  const serialized = JSON.stringify(body);
+  const headers = new Headers({ "content-type": "application/json", ...init?.headers });
+  return new Response(serialized, { status: init?.status ?? 200, headers });
+}
+
+describe("maybeNormalizeSignupResponse — scope guards", () => {
+  it("returns the upstream Response ref unchanged for non-signup paths", async () => {
+    // A future refactor that broadens the wrapper's scope (e.g. moved
+    // into a catch-all middleware without path scoping) would fail
+    // this test because `/sign-in/email` bodies would start getting
+    // rewritten with fabricated `image: null` fields.
+    const upstream = jsonResponse({ user: { email: "a@example.com" } });
+    const result = await maybeNormalizeSignupResponse(
+      makeCtx("/api/auth/sign-in/email"),
+      upstream,
+    );
+    expect(result).toBe(upstream);
+  });
+
+  it("returns the upstream Response ref unchanged for non-2xx signup status", async () => {
+    // Better Auth's error envelopes (422 USER_ALREADY_EXISTS, 429
+    // RATE_LIMITED, 400 VALIDATION) have a different schema — rewriting
+    // them could corrupt legitimate `error`/`code` fields and mask
+    // operator-visible failure modes. The synthetic 200 envelope is
+    // the only one we're trying to match shapes with.
+    const upstream = jsonResponse({ user: { email: "a@example.com" } }, { status: 422 });
+    const result = await maybeNormalizeSignupResponse(
+      makeCtx("/api/auth/sign-up/email"),
+      upstream,
+    );
+    expect(result).toBe(upstream);
+  });
+
+  it("returns the upstream Response ref unchanged for non-JSON content-type", async () => {
+    // A redirect-to-verification-URL implementation (text/html body)
+    // would otherwise get text passed through JSON.parse and trip the
+    // parse-failure guard — which is fine, but short-circuiting at the
+    // content-type check saves a clone+text+parse cycle.
+    const upstream = new Response("<html>...</html>", {
+      status: 200,
+      headers: { "content-type": "text/html" },
+    });
+    const result = await maybeNormalizeSignupResponse(
+      makeCtx("/api/auth/sign-up/email"),
+      upstream,
+    );
+    expect(result).toBe(upstream);
+  });
+
+  it("returns the upstream Response ref unchanged when JSON body fails to parse", async () => {
+    // Defensive: if Better Auth ever returns a malformed body with the
+    // JSON content-type, the normalizer can't run — but the body can't
+    // be our target envelope either, so pass-through is safe. The warn
+    // log (not asserted here) exists for operator visibility.
+    const upstream = new Response("{not json", {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+    const result = await maybeNormalizeSignupResponse(
+      makeCtx("/api/auth/sign-up/email"),
+      upstream,
+    );
+    expect(result).toBe(upstream);
+  });
+
+  it("returns the upstream Response ref unchanged when body already has user.image", async () => {
+    // The fast-path: synthetic existing-email envelope already has
+    // `image: null`, and a signup body that supplied `image` rounds
+    // through the real path with it already present. Either way, the
+    // pure helper returns the same reference and the wrapper must
+    // return the ORIGINAL `upstream` Response — not a rebuilt one —
+    // so we don't strip `Content-Length` or allocate on the hot path.
+    const upstream = jsonResponse({
+      user: { id: "u1", email: "a@example.com", image: null },
+    });
+    const result = await maybeNormalizeSignupResponse(
+      makeCtx("/api/auth/sign-up/email"),
+      upstream,
+    );
+    expect(result).toBe(upstream);
+  });
+});
+
+describe("maybeNormalizeSignupResponse — rewrite path", () => {
+  it("rewrites the body to include user.image: null when absent", async () => {
+    const upstream = jsonResponse({
+      user: { id: "u1", email: "a@example.com", name: "A", emailVerified: false },
+    });
+    const result = await maybeNormalizeSignupResponse(
+      makeCtx("/api/auth/sign-up/email"),
+      upstream,
+    );
+    expect(result).not.toBe(upstream);
+    expect(result.status).toBe(200);
+
+    const parsed = (await result.json()) as { user: Record<string, unknown> };
+    expect(parsed.user.image).toBeNull();
+    // Every sibling field survives the rewrite.
+    expect(parsed.user.id).toBe("u1");
+    expect(parsed.user.email).toBe("a@example.com");
+    expect(parsed.user.name).toBe("A");
+    expect(parsed.user.emailVerified).toBe(false);
+  });
+
+  it("drops stale Content-Length from the upstream headers on rewrite", async () => {
+    // The rewritten body is strictly longer than the upstream (one
+    // extra `"image":null,` key). If the original Content-Length is
+    // carried over, a strict HTTP client would truncate the trailing
+    // bytes and the `image` key might not even make it to the wire —
+    // silently reopening the oracle. Drop the header so the runtime
+    // recomputes on send.
+    const upstream = jsonResponse(
+      { user: { id: "u1", email: "a@example.com" } },
+      { headers: { "content-length": "42" } },
+    );
+    const result = await maybeNormalizeSignupResponse(
+      makeCtx("/api/auth/sign-up/email"),
+      upstream,
+    );
+    expect(result.headers.get("content-length")).toBeNull();
+  });
+
+  it("preserves non-Content-Length upstream headers on rewrite", async () => {
+    // Set-Cookie carries Better Auth's verification-email session, and
+    // any `Vary` / cache-control signaling must survive the rewrite.
+    // A header copy bug here would break email verification flow.
+    const upstream = jsonResponse(
+      { user: { id: "u1", email: "a@example.com" } },
+      {
+        headers: {
+          "set-cookie": "atlas-session=abc; HttpOnly; SameSite=Lax",
+          "vary": "Origin",
+          "cache-control": "no-store",
+        },
+      },
+    );
+    const result = await maybeNormalizeSignupResponse(
+      makeCtx("/api/auth/sign-up/email"),
+      upstream,
+    );
+    expect(result.headers.get("set-cookie")).toContain("atlas-session=abc");
+    expect(result.headers.get("vary")).toBe("Origin");
+    expect(result.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("handles application/json; charset=utf-8 content-type", async () => {
+    // Better Auth sends `application/json` with explicit charset in
+    // some code paths. The `includes("application/json")` check has
+    // to survive that — a stricter `===` would regress to pass-through
+    // and skip the rewrite.
+    const upstream = new Response(
+      JSON.stringify({ user: { id: "u1", email: "a@example.com" } }),
+      { status: 200, headers: { "content-type": "application/json; charset=utf-8" } },
+    );
+    const result = await maybeNormalizeSignupResponse(
+      makeCtx("/api/auth/sign-up/email"),
+      upstream,
+    );
+    expect(result).not.toBe(upstream);
+    const parsed = (await result.json()) as { user: Record<string, unknown> };
+    expect(parsed.user.image).toBeNull();
+  });
+});

--- a/packages/api/src/api/__tests__/auth-signup-normalize.test.ts
+++ b/packages/api/src/api/__tests__/auth-signup-normalize.test.ts
@@ -59,6 +59,21 @@ describe("maybeNormalizeSignupResponse — scope guards", () => {
     expect(result).toBe(upstream);
   });
 
+  it("does not match a sub-path that tail-ends with /sign-up/email", async () => {
+    // Strict `===` equality (not `endsWith`) keeps a plugin-registered
+    // path like `/api/auth/plugin/sign-up/email` out of the rewrite
+    // branch. Better Auth would 404 such a path today and the 2xx
+    // guard would catch it anyway — but the explicit match pins the
+    // scope contract so a future Better Auth route-registration bug
+    // can't silently reopen the rewrite on a sibling path.
+    const upstream = jsonResponse({ user: { email: "a@example.com" } });
+    const result = await maybeNormalizeSignupResponse(
+      makeCtx("/api/auth/plugin/sign-up/email"),
+      upstream,
+    );
+    expect(result).toBe(upstream);
+  });
+
   it("returns the upstream Response ref unchanged for non-2xx signup status", async () => {
     // Better Auth's error envelopes (422 USER_ALREADY_EXISTS, 429
     // RATE_LIMITED, 400 VALIDATION) have a different schema — rewriting

--- a/packages/api/src/api/routes/auth.ts
+++ b/packages/api/src/api/routes/auth.ts
@@ -8,6 +8,7 @@
 
 import { Hono, type Context } from "hono";
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { createLogger } from "@atlas/api/lib/logger";
 import { normalizeSignupResponseBody } from "@atlas/api/lib/auth/signup-response";
 
@@ -102,19 +103,20 @@ auth.all("/*", async (c) => {
  *   3. Content-Type must be `application/json`. Non-JSON bodies
  *      (redirect HTML, empty 204s) are passed through.
  *   4. Body must parse as JSON. A parse failure logs warn and returns
- *      the original response untouched — the security boundary fails
- *      open here because the underlying response is still Better
- *      Auth's (untampered) output.
+ *      the original response untouched — an unparseable body cannot be
+ *      the `/sign-up/email` JSON envelope this workaround targets, so
+ *      forwarding Better Auth's (untampered) output is correct and
+ *      safe. The log exists so operators see if Better Auth ever
+ *      changes the response shape and the normalizer stops applying.
  *
  * The rewrite preserves every upstream header (including Set-Cookie
  * for verification tokens) because it copies `upstream.headers` into
  * the new Response; only the body bytes change.
  *
- * Rip this workaround out once better-auth/better-auth lands a
- * symmetric `parseUserOutput` — linked in the PR body that introduces
- * this helper so the follow-up is discoverable.
+ * Rip this workaround out once better-auth/better-auth#9346 lands a
+ * symmetric `parseUserOutput` upstream.
  */
-async function maybeNormalizeSignupResponse(
+export async function maybeNormalizeSignupResponse(
   c: Context,
   upstream: Response,
 ): Promise<Response> {
@@ -129,7 +131,7 @@ async function maybeNormalizeSignupResponse(
     parsed = JSON.parse(raw);
   } catch (err) {
     log.warn(
-      { err: err instanceof Error ? err.message : String(err) },
+      { err: errorMessage(err), path: c.req.path, status: upstream.status },
       "Signup response advertised application/json but did not parse — "
         + "skipping F-P3 normalization and forwarding upstream body unchanged.",
     );

--- a/packages/api/src/api/routes/auth.ts
+++ b/packages/api/src/api/routes/auth.ts
@@ -9,8 +9,17 @@
 import { Hono, type Context } from "hono";
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
 import { createLogger } from "@atlas/api/lib/logger";
+import { normalizeSignupResponseBody } from "@atlas/api/lib/auth/signup-response";
 
 const log = createLogger("auth-route");
+
+/**
+ * Better Auth path (relative to the `/api/auth` catch-all mount) that
+ * must be intercepted to close the F-P3 / #1792 enumeration oracle.
+ * Only the success response for this path is rewritten — every other
+ * auth route streams through untouched.
+ */
+const SIGNUP_EMAIL_PATH = "/sign-up/email";
 
 /**
  * Custom header Better Auth reads for rate-limit IP bucketing.
@@ -40,7 +49,8 @@ auth.all("/*", async (c) => {
     const { getAuthInstance } = await import("@atlas/api/lib/auth/server");
     const authInstance = getAuthInstance();
     const authRequest = withClientIpHeader(c);
-    const response = await authInstance.handler(authRequest);
+    const upstream = await authInstance.handler(authRequest);
+    const response = await maybeNormalizeSignupResponse(c, upstream);
 
     // Better Auth returns a raw Response, bypassing Hono's response
     // pipeline. Copy CORS headers set by the upstream middleware so
@@ -72,6 +82,80 @@ auth.all("/*", async (c) => {
     );
   }
 });
+
+/**
+ * When the upstream Better Auth response is a success envelope for
+ * `/sign-up/email`, rewrite it so `user.image` is always present (as
+ * `null`) regardless of whether the signup body supplied one.
+ *
+ * Closes F-P3 / #1792 — the real-vs-synthetic response asymmetry that
+ * let a client distinguish new from existing emails by checking
+ * `"image" in body.user`. The transformation is a no-op for every
+ * other auth route, every non-2xx status, and every non-JSON body.
+ *
+ * Scope-guards (any one failing = pass-through unchanged):
+ *   1. Path must end with `/sign-up/email`. Signup is the only route
+ *      where Better Auth emits the synthetic-existing envelope.
+ *   2. Status must be 2xx. Error envelopes (400/422/429/500) follow a
+ *      different schema and rewriting them could corrupt legitimate
+ *      error payloads.
+ *   3. Content-Type must be `application/json`. Non-JSON bodies
+ *      (redirect HTML, empty 204s) are passed through.
+ *   4. Body must parse as JSON. A parse failure logs warn and returns
+ *      the original response untouched — the security boundary fails
+ *      open here because the underlying response is still Better
+ *      Auth's (untampered) output.
+ *
+ * The rewrite preserves every upstream header (including Set-Cookie
+ * for verification tokens) because it copies `upstream.headers` into
+ * the new Response; only the body bytes change.
+ *
+ * Rip this workaround out once better-auth/better-auth lands a
+ * symmetric `parseUserOutput` — linked in the PR body that introduces
+ * this helper so the follow-up is discoverable.
+ */
+async function maybeNormalizeSignupResponse(
+  c: Context,
+  upstream: Response,
+): Promise<Response> {
+  if (!c.req.path.endsWith(SIGNUP_EMAIL_PATH)) return upstream;
+  if (upstream.status < 200 || upstream.status >= 300) return upstream;
+  const contentType = upstream.headers.get("content-type") ?? "";
+  if (!contentType.toLowerCase().includes("application/json")) return upstream;
+
+  const raw = await upstream.clone().text();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Signup response advertised application/json but did not parse — "
+        + "skipping F-P3 normalization and forwarding upstream body unchanged.",
+    );
+    return upstream;
+  }
+
+  const normalized = normalizeSignupResponseBody(parsed);
+  // Fast path: the real body already had `user.image` (e.g. the
+  // caller supplied one, or we're on the synthetic branch). Return
+  // the original Response so we don't burn an allocation on an
+  // identical serialization.
+  if (normalized === parsed) return upstream;
+
+  // The rewritten body is longer by one `"image":null,` key — the
+  // upstream Content-Length (if set) is now stale and would make a
+  // strict client truncate the trailing bytes. Drop it and let the
+  // runtime recompute on send.
+  const headers = new Headers(upstream.headers);
+  headers.delete("content-length");
+
+  return new Response(JSON.stringify(normalized), {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers,
+  });
+}
 
 /**
  * Resolve the real client IP and attach it to {@link CLIENT_IP_HEADER}

--- a/packages/api/src/api/routes/auth.ts
+++ b/packages/api/src/api/routes/auth.ts
@@ -15,12 +15,19 @@ import { normalizeSignupResponseBody } from "@atlas/api/lib/auth/signup-response
 const log = createLogger("auth-route");
 
 /**
- * Better Auth path (relative to the `/api/auth` catch-all mount) that
- * must be intercepted to close the F-P3 / #1792 enumeration oracle.
- * Only the success response for this path is rewritten — every other
+ * Full Better Auth signup path (mount `/api/auth` + route `/sign-up/email`)
+ * that must be intercepted to close the F-P3 / #1792 enumeration oracle.
+ * Only the success response for this exact path is rewritten — every other
  * auth route streams through untouched.
+ *
+ * Matched with strict `===` rather than `endsWith` so an unrelated sub-path
+ * like `/api/auth/plugin/sign-up/email` can't accidentally slip into the
+ * rewrite branch. Better Auth owns the `/sign-up/email` segment, so any
+ * such path would 404 and the 2xx guard would catch it — but the explicit
+ * match makes the scope contract visible to a future reader and removes
+ * one layer of reliance on defense-in-depth.
  */
-const SIGNUP_EMAIL_PATH = "/sign-up/email";
+const SIGNUP_EMAIL_PATH = "/api/auth/sign-up/email";
 
 /**
  * Custom header Better Auth reads for rate-limit IP bucketing.
@@ -95,8 +102,11 @@ auth.all("/*", async (c) => {
  * other auth route, every non-2xx status, and every non-JSON body.
  *
  * Scope-guards (any one failing = pass-through unchanged):
- *   1. Path must end with `/sign-up/email`. Signup is the only route
- *      where Better Auth emits the synthetic-existing envelope.
+ *   1. Path must be exactly `/api/auth/sign-up/email`. Signup is the
+ *      only route where Better Auth emits the synthetic-existing
+ *      envelope, and strict equality keeps the rewrite out of any
+ *      plugin-registered sibling routes that happen to share the
+ *      trailing segment.
  *   2. Status must be 2xx. Error envelopes (400/422/429/500) follow a
  *      different schema and rewriting them could corrupt legitimate
  *      error payloads.
@@ -120,7 +130,7 @@ export async function maybeNormalizeSignupResponse(
   c: Context,
   upstream: Response,
 ): Promise<Response> {
-  if (!c.req.path.endsWith(SIGNUP_EMAIL_PATH)) return upstream;
+  if (c.req.path !== SIGNUP_EMAIL_PATH) return upstream;
   if (upstream.status < 200 || upstream.status >= 300) return upstream;
   const contentType = upstream.headers.get("content-type") ?? "";
   if (!contentType.toLowerCase().includes("application/json")) return upstream;

--- a/packages/api/src/lib/auth/__tests__/rate-limit-integration.test.ts
+++ b/packages/api/src/lib/auth/__tests__/rate-limit-integration.test.ts
@@ -9,6 +9,7 @@ import {
   resolveRequireEmailVerification,
   type BuildAuthOptionsDeps,
 } from "../server";
+import { normalizeSignupResponseBody } from "../signup-response";
 
 /**
  * End-to-end wiring regressions for #1741.
@@ -112,18 +113,13 @@ function makeAuth(overrides: Partial<BuildAuthOptionsDeps> = {}): ReturnType<typ
  *
  * Scrubs only per-request non-determinism — `id`, `createdAt`,
  * `updatedAt` — replacing each with the literal string `"<scrubbed>"`.
- * On user-like objects (detected by the presence of an `email` key), it
- * also fills `image: null` when absent; Better Auth's synthetic-signup
- * branch always emits `{ image: null }` while the real path omits the
- * key entirely when `image` isn't supplied in the signup body. Tracked
- * upstream as #1792 — normalizing here keeps the parity test focused
- * on Atlas's wiring rather than absorbing that asymmetry as a false
- * negative.
  *
  * Everything else is compared literally — including types, field
  * presence, and nested shape — so a future upstream change that starts
  * leaking, say, `emailVerified: true` on the real path vs `false` on
- * the synthetic would show up red.
+ * the synthetic would show up red. The `image` asymmetry that used to
+ * be normalized here (#1792) is now closed in the Atlas signup handler
+ * itself; the parity test exercises the real diff.
  */
 function scrub(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(scrub);
@@ -136,7 +132,6 @@ function scrub(value: unknown): unknown {
         out[k] = scrub(v);
       }
     }
-    if ("email" in out && !("image" in out)) out.image = null;
     return out;
   }
   return value;
@@ -348,7 +343,7 @@ describe("signup enumeration response parity — /sign-up/email", () => {
       password: "correct horse battery staple",
     }, ip);
     const firstRes = await auth.handler(firstReq);
-    const firstBody = await firstRes.json();
+    const firstBodyRaw = await firstRes.json();
 
     // Second signup with the SAME email. With requireEmailVerification=true,
     // Better Auth returns a synthetic success envelope instead of the
@@ -360,11 +355,34 @@ describe("signup enumeration response parity — /sign-up/email", () => {
       password: "correct horse battery staple",
     }, ip);
     const secondRes = await auth.handler(secondReq);
-    const secondBody = await secondRes.json();
+    const secondBodyRaw = await secondRes.json();
+
+    // Apply the Atlas-side normalization that the Hono handler in
+    // packages/api/src/api/routes/auth.ts wraps around the Better Auth
+    // /sign-up/email response. This closes #1792: Better Auth's real
+    // `parseUserOutput` omits `image` entirely when the signup body
+    // doesn't supply one, while the synthetic existing-email envelope
+    // always includes `image: null`. The Hono layer fills the gap on
+    // the real path before the response leaves the API.
+    const firstBody = normalizeSignupResponseBody(firstBodyRaw);
+    const secondBody = normalizeSignupResponseBody(secondBodyRaw);
 
     // Status parity — no 422/500 leak from the existing-email branch.
     expect(firstRes.status).toBe(200);
     expect(secondRes.status).toBe(200);
+
+    // F-P3 (#1792) — the field the oracle used to leak. Both envelopes
+    // must have `user.image === null` after Atlas normalization, not
+    // just undefined on one side and null on the other. If this fails
+    // on either side, the signup response distinguishes new vs
+    // existing email to a client that inspects key presence.
+    const userOf = (body: unknown): Record<string, unknown> => {
+      if (!body || typeof body !== "object") return {};
+      const user = (body as { user?: unknown }).user;
+      return user && typeof user === "object" ? (user as Record<string, unknown>) : {};
+    };
+    expect(userOf(firstBody)).toHaveProperty("image", null);
+    expect(userOf(secondBody)).toHaveProperty("image", null);
 
     // Shape parity — top-level keys and nested user-object keys must
     // match between branches. Doing this before the value-level scrub
@@ -373,23 +391,15 @@ describe("signup enumeration response parity — /sign-up/email", () => {
     // scrubbed by value-level normalization.
     const topKeys = (body: unknown): string[] =>
       body && typeof body === "object" ? Object.keys(body).toSorted() : [];
-    const userKeys = (body: unknown): string[] => {
-      if (!body || typeof body !== "object") return [];
-      const user = (body as { user?: unknown }).user;
-      if (!user || typeof user !== "object") return [];
-      return Object.keys(user).toSorted();
-    };
+    const userKeys = (body: unknown): string[] => Object.keys(userOf(body)).toSorted();
     expect(topKeys(firstBody)).toEqual(topKeys(secondBody));
-    // Fold in the `image` normalization so it doesn't false-flag
-    // (see scrub() doc for why). Everything else must match exactly.
-    const first = userKeys(firstBody);
-    const second = userKeys(secondBody);
-    const withImage = (ks: string[]) => [...new Set([...ks, "image"])].toSorted();
-    expect(withImage(first)).toEqual(withImage(second));
+    expect(userKeys(firstBody)).toEqual(userKeys(secondBody));
 
     // Value parity — both envelopes serialize byte-for-byte identically
     // modulo `id`/`createdAt`/`updatedAt` (legitimately non-deterministic
-    // per request) and the `image` asymmetry tracked in #1792.
+    // per request). No field-level normalization here: every other key
+    // must match literally, so a future Better Auth change that leaks a
+    // new key on one branch only will show up red.
     const normalize = (body: unknown): string => JSON.stringify(sortKeys(scrub(body)));
     expect(normalize(firstBody)).toBe(normalize(secondBody));
   });

--- a/packages/api/src/lib/auth/__tests__/signup-response.test.ts
+++ b/packages/api/src/lib/auth/__tests__/signup-response.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "bun:test";
+import { normalizeSignupResponseBody } from "../signup-response";
+
+/**
+ * Unit tests for the pure helper that backs the F-P3 / #1792 fix.
+ *
+ * The shape-guard branches are hot paths for the Hono-route wrapper:
+ * every non-signup auth response flows through them. A regression that
+ * accidentally mutates a non-user-shaped body would corrupt unrelated
+ * Better Auth envelopes, so pin down the pass-through invariants here.
+ *
+ * The parity/integration coverage in `rate-limit-integration.test.ts`
+ * proves the happy path against a real Better Auth instance; these
+ * tests own the degenerate-input contract.
+ */
+
+describe("normalizeSignupResponseBody", () => {
+  it("fills user.image: null on a real-path body that omits image", () => {
+    const body = {
+      user: { id: "u1", email: "a@example.com", name: "A", emailVerified: false },
+    };
+    const result = normalizeSignupResponseBody(body) as {
+      user: Record<string, unknown>;
+    };
+    expect(result.user.image).toBeNull();
+    // Every pre-existing field must survive untouched.
+    expect(result.user.id).toBe("u1");
+    expect(result.user.email).toBe("a@example.com");
+    expect(result.user.name).toBe("A");
+    expect(result.user.emailVerified).toBe(false);
+  });
+
+  it("preserves sibling keys on the envelope", () => {
+    const body = {
+      token: "verify-abc",
+      user: { id: "u1", email: "a@example.com" },
+    };
+    const result = normalizeSignupResponseBody(body) as Record<string, unknown>;
+    expect(result.token).toBe("verify-abc");
+  });
+
+  it("returns the same reference when image is already present (fast path)", () => {
+    // Synthetic existing-email branch always emits `image: null`, and
+    // some clients pass an image in the signup body. Either way, we
+    // must skip re-allocation so the Hono wrapper's `===` fast-path
+    // check avoids a pointless Response rebuild.
+    const withNull = { user: { id: "u1", email: "a@example.com", image: null } };
+    expect(normalizeSignupResponseBody(withNull)).toBe(withNull);
+
+    const withUrl = {
+      user: { id: "u1", email: "a@example.com", image: "https://cdn/x.png" },
+    };
+    expect(normalizeSignupResponseBody(withUrl)).toBe(withUrl);
+  });
+
+  it("is idempotent — second application is a no-op reference return", () => {
+    // The pure helper's reference-equality contract is load-bearing for
+    // the Hono wrapper's allocation skip. If a future change made the
+    // first pass return a fresh object but the second pass also return
+    // a fresh object, we'd allocate on every signup forever.
+    const body = { user: { id: "u1", email: "a@example.com" } };
+    const once = normalizeSignupResponseBody(body);
+    const twice = normalizeSignupResponseBody(once);
+    expect(twice).toBe(once);
+  });
+
+  it("passes through non-object bodies unchanged", () => {
+    // Non-user-shaped bodies are the caller's responsibility to gate.
+    // The helper itself must be a no-op so if the caller's path/status
+    // guards regress, unrelated Better Auth responses aren't corrupted.
+    expect(normalizeSignupResponseBody(null)).toBeNull();
+    expect(normalizeSignupResponseBody(undefined)).toBeUndefined();
+    expect(normalizeSignupResponseBody("string")).toBe("string");
+    expect(normalizeSignupResponseBody(42)).toBe(42);
+    expect(normalizeSignupResponseBody(true)).toBe(true);
+  });
+
+  it("passes through array bodies unchanged (reference preserved)", () => {
+    const arr: unknown[] = [{ user: { email: "a@example.com" } }];
+    expect(normalizeSignupResponseBody(arr)).toBe(arr);
+  });
+
+  it("passes through bodies with no user field", () => {
+    // Better Auth error envelopes and many non-signup routes have no
+    // `user` key. Guard against accidentally adding a fabricated user
+    // object when the wrapper is (mistakenly) invoked on them.
+    const errorEnvelope = { error: "RATE_LIMITED", code: "RATE_LIMITED" };
+    expect(normalizeSignupResponseBody(errorEnvelope)).toBe(errorEnvelope);
+  });
+
+  it("passes through bodies where user is not a plain object", () => {
+    // Every user-shape variant that isn't a plain object must skip the
+    // rewrite. `null` (explicit signed-out envelope), array (malformed
+    // upstream), primitive (defensive).
+    const nullUser = { user: null };
+    expect(normalizeSignupResponseBody(nullUser)).toBe(nullUser);
+
+    const arrayUser = { user: ["not", "a", "user"] };
+    expect(normalizeSignupResponseBody(arrayUser)).toBe(arrayUser);
+
+    const stringUser = { user: "not-an-object" };
+    expect(normalizeSignupResponseBody(stringUser)).toBe(stringUser);
+  });
+
+  it("does not touch nested objects under user beyond the image key", () => {
+    // A future Better Auth version might nest e.g. `user.metadata.image`.
+    // We only fill the top-level `user.image` — any nested image-shaped
+    // key is left alone because the enumeration oracle is specifically
+    // the top-level field.
+    const body = {
+      user: {
+        id: "u1",
+        email: "a@example.com",
+        metadata: { image: "https://cdn/nested.png" },
+      },
+    };
+    const result = normalizeSignupResponseBody(body) as {
+      user: { image: unknown; metadata: { image: string } };
+    };
+    expect(result.user.image).toBeNull();
+    expect(result.user.metadata.image).toBe("https://cdn/nested.png");
+  });
+});

--- a/packages/api/src/lib/auth/signup-response.ts
+++ b/packages/api/src/lib/auth/signup-response.ts
@@ -1,0 +1,44 @@
+/**
+ * Signup response parity normalization (#1792, F-P3 — 1.2.3 Security Sweep).
+ *
+ * Better Auth's `/sign-up/email` handler closes the signup enumeration
+ * oracle when `emailAndPassword.requireEmailVerification: true` by
+ * returning a synthetic 200 envelope for existing emails — the same
+ * shape as the real (new-email) envelope, no 422/USER_ALREADY_EXISTS.
+ *
+ * The shapes are NOT byte-for-byte symmetric when the signup body
+ * omits `image`:
+ *   - Real path (new email → `parseUserOutput`): `user.image` is
+ *     absent from the emitted user object.
+ *   - Synthetic path (existing email): `user.image: null` is emitted
+ *     verbatim (the Better Auth source writes `image: image || null`).
+ *
+ * A client that checks key presence — `"image" in body.user` — can
+ * therefore distinguish the two branches and reopen the oracle. We
+ * close the asymmetry here by filling `user.image: null` on the real
+ * path before the response leaves Atlas.
+ *
+ * This is the Atlas-side workaround (issue #1792 option 2). The
+ * long-term fix is upstream: once Better Auth's `parseUserOutput`
+ * emits `image: null` on real signups too, this normalizer becomes a
+ * no-op and can be deleted. The PR that lands this change links the
+ * upstream issue so the workaround is easy to rip out later.
+ *
+ * Scope invariants:
+ *   - Only touches `body.user.image`. Every other field — top-level,
+ *     nested under `user`, or elsewhere — passes through unchanged.
+ *   - Idempotent: applying twice yields the same result.
+ *   - Non-user-shaped bodies (errors, non-JSON, arrays, primitives)
+ *     pass through unchanged. The caller is responsible for scoping
+ *     this normalizer to the `/sign-up/email` success path.
+ */
+
+export function normalizeSignupResponseBody(body: unknown): unknown {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return body;
+  const envelope = body as Record<string, unknown>;
+  const user = envelope.user;
+  if (!user || typeof user !== "object" || Array.isArray(user)) return body;
+  const userObj = user as Record<string, unknown>;
+  if ("image" in userObj) return body;
+  return { ...envelope, user: { ...userObj, image: null } };
+}

--- a/packages/api/src/lib/auth/signup-response.ts
+++ b/packages/api/src/lib/auth/signup-response.ts
@@ -19,10 +19,9 @@
  * path before the response leaves Atlas.
  *
  * This is the Atlas-side workaround (issue #1792 option 2). The
- * long-term fix is upstream: once Better Auth's `parseUserOutput`
- * emits `image: null` on real signups too, this normalizer becomes a
- * no-op and can be deleted. The PR that lands this change links the
- * upstream issue so the workaround is easy to rip out later.
+ * long-term fix is upstream at better-auth/better-auth#9346: once
+ * `parseUserOutput` emits `image: null` on real signups too, this
+ * normalizer becomes a no-op and can be deleted outright.
  *
  * Scope invariants:
  *   - Only touches `body.user.image`. Every other field — top-level,


### PR DESCRIPTION
## Summary

Closes the `image`-field enumeration leak in `/sign-up/email` (issue #1792, part of milestone 1.2.3 — Security Sweep).

When `emailAndPassword.requireEmailVerification: true`, Better Auth returns a synthetic success envelope for existing emails to close the new-vs-existing oracle — but the envelope shapes don't match byte-for-byte when the signup body omits `image`:

- **Real path** (new email → `parseUserOutput`): `user.image` is **absent**.
- **Synthetic path** (existing email): `user.image: null`.

A client inspecting `"image" in body.user` can distinguish the two.

## Approach — issue #1792 option 2 (Atlas workaround)

Tight intercept in the Hono catch-all `/api/auth/*` handler:

- New pure helper `normalizeSignupResponseBody` at `packages/api/src/lib/auth/signup-response.ts` — fills `user.image: null` when absent; every other field passes through; idempotent; returns the same reference when no change (so the fast path skips re-serialization).
- `packages/api/src/api/routes/auth.ts` wraps the Better Auth response: only rewrites when path ends with `/sign-up/email`, status is 2xx, and Content-Type is JSON. Drops stale `Content-Length` before rebuilding the Response (the rewritten body is longer by one key).
- `packages/api/src/lib/auth/__tests__/rate-limit-integration.test.ts` removes the `image: null` normalization guard in `scrub()` and the `withImage` sidecar that papered over the diff. The parity test now asserts `user.image === null` on both paths after Atlas normalization, so a regression that drops this workaround goes red.

## Upstream

Filed at better-auth/better-auth#9346 — requesting a symmetric `parseUserOutput` that emits `image: null` on real signups too. Once that ships, the Atlas-side workaround + helper are a one-file delete. The follow-up is discoverable from both the upstream issue and the comment in `signup-response.ts`.

## Test plan
- [x] `bun test src/lib/auth/__tests__/rate-limit-integration.test.ts` — 7/7 green, parity assertion exercises the real diff
- [x] `cd packages/api && bun run scripts/test-isolated.ts --affected` — 8/8 green
- [x] `bun run lint` — 0 errors
- [x] `bun run type` — 0 errors
- [x] `bun run test` — full suite green (api + all other workspaces)
- [x] `bun x syncpack lint` — no issues
- [x] Template drift check — passes
- [x] Railway watch check — passes

## The regression line

`packages/api/src/lib/auth/__tests__/rate-limit-integration.test.ts` — the block under `describe("signup enumeration response parity — /sign-up/email")` now owns the parity assertion. `expect(userOf(firstBody)).toHaveProperty("image", null)` plus the byte-level `normalize(firstBody) === normalize(secondBody)` catch both the specific `image` regression and any future new enumerating key.