### PR TITLE
refactor(security): F-44 follow-up — errorMessage() sweep across top-10 callers

### DIFF
--- a/packages/api/src/api/routes/admin-integrations.ts
+++ b/packages/api/src/api/routes/admin-integrations.ts
@@ -9,6 +9,7 @@
 import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { AuthContext } from "@atlas/api/lib/effect/services";
 import { internalQuery, hasInternalDB } from "@atlas/api/lib/db/internal";
@@ -637,14 +638,14 @@ adminIntegrations.openapi(connectSlackByotRoute, async (c) => {
               headers: { Authorization: `Bearer ${botToken}`, "Content-Type": "application/x-www-form-urlencoded" },
             });
           } catch (err) {
-            log.warn({ err: err instanceof Error ? err.message : String(err) }, "Slack auth.test fetch failed");
+            log.warn({ err: errorMessage(err) }, "Slack auth.test fetch failed");
             return { ok: false as const, error: "Could not reach Slack API. Please try again." };
           }
           let data: { ok: boolean; team_id?: string; team?: string; error?: string };
           try {
             data = (await res.json()) as typeof data;
           } catch (err) {
-            log.warn({ err: err instanceof Error ? err.message : String(err) }, "Slack auth.test response parse failed");
+            log.warn({ err: errorMessage(err) }, "Slack auth.test response parse failed");
             return { ok: false as const, error: "Slack API returned an invalid response" };
           }
           if (!data.ok) {
@@ -794,14 +795,14 @@ adminIntegrations.openapi(connectTeamsByotRoute, async (c) => {
               },
             );
           } catch (err) {
-            log.warn({ err: err instanceof Error ? err.message : String(err) }, "Azure AD token fetch failed");
+            log.warn({ err: errorMessage(err) }, "Azure AD token fetch failed");
             return { ok: false as const, error: "Could not reach Azure AD. Please try again." };
           }
           let data: { access_token?: string; error?: string; error_description?: string };
           try {
             data = (await res.json()) as typeof data;
           } catch (err) {
-            log.warn({ err: err instanceof Error ? err.message : String(err) }, "Azure AD token response parse failed");
+            log.warn({ err: errorMessage(err) }, "Azure AD token response parse failed");
             return { ok: false as const, error: "Azure AD returned an invalid response" };
           }
           if (!data.access_token) {
@@ -942,7 +943,7 @@ adminIntegrations.openapi(connectDiscordByotRoute, async (c) => {
               headers: { Authorization: `Bot ${botToken}` },
             });
           } catch (err) {
-            log.warn({ err: err instanceof Error ? err.message : String(err) }, "Discord /users/@me fetch failed");
+            log.warn({ err: errorMessage(err) }, "Discord /users/@me fetch failed");
             return { ok: false as const, error: "Could not reach Discord API. Please try again." };
           }
           if (!res.ok) {
@@ -959,7 +960,7 @@ adminIntegrations.openapi(connectDiscordByotRoute, async (c) => {
           try {
             data = (await res.json()) as typeof data;
           } catch (err) {
-            log.warn({ err: err instanceof Error ? err.message : String(err) }, "Discord /users/@me response parse failed");
+            log.warn({ err: errorMessage(err) }, "Discord /users/@me response parse failed");
             return { ok: false as const, error: "Discord API returned an invalid response" };
           }
           if (!data.id) {
@@ -1334,7 +1335,7 @@ adminIntegrations.openapi(connectGChatRoute, async (c) => {
       try {
         parsed = JSON.parse(credentialsJson) as typeof parsed;
       } catch (err) {
-        log.warn({ err: err instanceof Error ? err.message : String(err) }, "Google Chat credentials JSON parse failed");
+        log.warn({ err: errorMessage(err) }, "Google Chat credentials JSON parse failed");
         return c.json(
           { error: "invalid_credentials", message: "Invalid JSON. Paste the full service account key file contents." },
           400,
@@ -1583,7 +1584,7 @@ adminIntegrations.openapi(connectGitHubRoute, async (c) => {
               },
             });
           } catch (err) {
-            log.warn({ err: err instanceof Error ? err.message : String(err) }, "GitHub /user fetch failed");
+            log.warn({ err: errorMessage(err) }, "GitHub /user fetch failed");
             return { ok: false as const, error: "Could not reach GitHub API. Please try again." };
           }
           if (!res.ok) {
@@ -1600,7 +1601,7 @@ adminIntegrations.openapi(connectGitHubRoute, async (c) => {
           try {
             data = (await res.json()) as typeof data;
           } catch (err) {
-            log.warn({ err: err instanceof Error ? err.message : String(err) }, "GitHub /user response parse failed");
+            log.warn({ err: errorMessage(err) }, "GitHub /user response parse failed");
             return { ok: false as const, error: "GitHub API returned an invalid response" };
           }
           if (!data.id) {
@@ -1837,7 +1838,7 @@ adminIntegrations.openapi(connectLinearRoute, async (c) => {
               signal: AbortSignal.timeout(10_000),
             });
           } catch (err) {
-            log.warn({ err: err instanceof Error ? err.message : String(err) }, "Linear GraphQL fetch failed");
+            log.warn({ err: errorMessage(err) }, "Linear GraphQL fetch failed");
             return { ok: false as const, error: "Could not reach Linear API. Please try again." };
           }
           if (!res.ok) {
@@ -1854,7 +1855,7 @@ adminIntegrations.openapi(connectLinearRoute, async (c) => {
           try {
             data = (await res.json()) as typeof data;
           } catch (err) {
-            log.warn({ err: err instanceof Error ? err.message : String(err) }, "Linear GraphQL response parse failed");
+            log.warn({ err: errorMessage(err) }, "Linear GraphQL response parse failed");
             return { ok: false as const, error: "Linear API returned an invalid response" };
           }
           if (data.errors?.length) {
@@ -2104,7 +2105,7 @@ adminIntegrations.openapi(connectWhatsAppRoute, async (c) => {
               signal: AbortSignal.timeout(10_000),
             });
           } catch (err) {
-            log.warn({ err: err instanceof Error ? err.message : String(err) }, "WhatsApp Graph API fetch failed");
+            log.warn({ err: errorMessage(err) }, "WhatsApp Graph API fetch failed");
             return { ok: false as const, error: "Could not reach Meta API. Please try again." };
           }
           if (!res.ok) {
@@ -2121,7 +2122,7 @@ adminIntegrations.openapi(connectWhatsAppRoute, async (c) => {
           try {
             data = (await res.json()) as typeof data;
           } catch (err) {
-            log.warn({ err: err instanceof Error ? err.message : String(err) }, "WhatsApp Graph API response parse failed");
+            log.warn({ err: errorMessage(err) }, "WhatsApp Graph API response parse failed");
             return { ok: false as const, error: "Meta API returned an invalid response" };
           }
           if (!data.id) {
@@ -2729,7 +2730,7 @@ async function sendSendGridTestEmail(
     }
     return { success: true };
   } catch (err) {
-    return { success: false, error: err instanceof Error ? err.message : String(err) };
+    return { success: false, error: errorMessage(err) };
   }
 }
 
@@ -2762,7 +2763,7 @@ async function sendPostmarkTestEmail(
     }
     return { success: true };
   } catch (err) {
-    return { success: false, error: err instanceof Error ? err.message : String(err) };
+    return { success: false, error: errorMessage(err) };
   }
 }
 
@@ -2799,7 +2800,7 @@ async function sendSmtpTestEmail(
     }
     return { success: true };
   } catch (err) {
-    return { success: false, error: err instanceof Error ? err.message : String(err) };
+    return { success: false, error: errorMessage(err) };
   }
 }
 
@@ -2835,7 +2836,7 @@ async function sendSesTestEmail(
     }
     return { success: true };
   } catch (err) {
-    return { success: false, error: err instanceof Error ? err.message : String(err) };
+    return { success: false, error: errorMessage(err) };
   }
 }
 
@@ -2863,7 +2864,7 @@ async function sendResendTestEmail(
     }
     return { success: true };
   } catch (err) {
-    return { success: false, error: err instanceof Error ? err.message : String(err) };
+    return { success: false, error: errorMessage(err) };
   }
 }
 

--- a/packages/api/src/lib/audit/error-scrub.ts
+++ b/packages/api/src/lib/audit/error-scrub.ts
@@ -11,6 +11,19 @@
  *      and pushes structured fields off the end of log-aggregation size
  *      limits. Truncated to 512 chars with an ellipsis suffix.
  *
+ * When NOT to use `errorMessage` (mark the raw ternary with
+ * `// @atlas-ok-ternary: <reason>` instead):
+ *
+ *   - The string is substring-matched or parsed to branch control flow
+ *     (`msg.includes("does not exist")`, regex extraction) — scrubbing +
+ *     truncation could alter match semantics.
+ *   - The string is concatenated into a thrown `new Error(...)` message —
+ *     per #1829, `throw` constructors are out of scope for the hygiene
+ *     sweep so the original error remains inspectable.
+ *   - It's an `Effect.tryPromise` catch normalizer that returns an
+ *     `Error` instance — the pino `err` serializer handles those with
+ *     full stack preservation.
+ *
  * `causeToError` walks an Effect `Cause` and returns the first underlying
  * error — typed failure, defect, or `undefined` for pure-interrupt causes.
  * Interrupts represent fiber cancellation (client disconnect, request

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -21,6 +21,7 @@ import { stripe as stripePlugin } from "@better-auth/stripe";
 import Stripe from "stripe";
 import { getInternalDB, hasInternalDB, internalQuery, updateWorkspacePlanTier, updateWorkspaceStatus, type InternalPool, type PlanTier } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { isEnterpriseEnabled } from "@atlas/ee/index";
 import { ac, owner as ownerRole, admin as adminRole, member as memberRole } from "@atlas/api/lib/auth/org-permissions";
 import { adminAccessControl, adminRole as adminUserRole, platformAdminRole } from "@atlas/api/lib/auth/admin-permissions";
@@ -393,7 +394,7 @@ export async function _sendVerificationEmail(opts: { to: string; url: string }):
     }
   } catch (err) {
     log.warn(
-      { to: opts.to, err: err instanceof Error ? err.message : String(err) },
+      { to: opts.to, err: errorMessage(err) },
       "Email verification dispatch crashed — signup response is still 200 to preserve enumeration protection; user may need to retry via /send-verification-email",
     );
   }
@@ -454,7 +455,7 @@ function buildPlugins() {
           });
         } catch (err) {
           log.debug(
-            { err: err instanceof Error ? err.message : String(err) },
+            { err: errorMessage(err) },
             "Onboarding hook not available — non-blocking",
           );
         }
@@ -515,7 +516,7 @@ function buildPlugins() {
                     log.info({ orgId, plan: plan.name }, "Subscription activated — plan tier synced");
                   } catch (err) {
                     log.error(
-                      { err: err instanceof Error ? err.message : String(err), orgId, plan: plan.name },
+                      { err: errorMessage(err), orgId, plan: plan.name },
                       "Failed to sync plan tier on subscription activation — Stripe will retry webhook",
                     );
                     throw err;
@@ -531,7 +532,7 @@ function buildPlugins() {
                     log.info({ orgId }, "Subscription canceled — downgraded to free tier");
                   } catch (err) {
                     log.error(
-                      { err: err instanceof Error ? err.message : String(err), orgId },
+                      { err: errorMessage(err), orgId },
                       "Failed to downgrade plan on subscription cancel — Stripe will retry webhook",
                     );
                     throw err;
@@ -571,7 +572,7 @@ function buildPlugins() {
                   );
                 } catch (err) {
                   billingLog.error(
-                    { err: err instanceof Error ? err.message : String(err), orgId, newTier, priceId },
+                    { err: errorMessage(err), orgId, newTier, priceId },
                     "Failed to sync plan tier on subscription update — Stripe will retry webhook",
                   );
                   throw err;
@@ -586,7 +587,7 @@ function buildPlugins() {
                     log.info({ orgId }, "Subscription deleted — downgraded to free tier");
                   } catch (err) {
                     log.error(
-                      { err: err instanceof Error ? err.message : String(err), orgId },
+                      { err: errorMessage(err), orgId },
                       "Failed to downgrade plan on subscription delete — Stripe will retry webhook",
                     );
                     throw err;
@@ -639,7 +640,7 @@ function buildPlugins() {
                     }
                   } catch (err) {
                     billingLog.error(
-                      { err: err instanceof Error ? err.message : String(err), subscriptionId, attemptCount },
+                      { err: errorMessage(err), subscriptionId, attemptCount },
                       "Failed to suspend workspace after repeated payment failures",
                     );
                     // Do not re-throw — the onEvent handler should not cause Stripe to retry
@@ -654,7 +655,7 @@ function buildPlugins() {
         log.info("Stripe billing plugin enabled");
       } catch (err) {
         log.error(
-          { err: err instanceof Error ? err.message : String(err) },
+          { err: errorMessage(err) },
           "Failed to initialize Stripe billing plugin — billing features will be unavailable",
         );
       }
@@ -822,7 +823,7 @@ export async function _autoProvisionSsoMember(user: { id: string; email: string 
       // exceptions from checkResourceLimit. Fail open: blocking SSO login
       // is worse than transient over-provisioning.
       log.warn(
-        { err: err instanceof Error ? err.message : String(err), errName: err instanceof Error ? err.name : "unknown", userId: user.id, orgId },
+        { err: errorMessage(err), errName: err instanceof Error ? err.name : "unknown", userId: user.id, orgId },
         "SSO auto-provisioning: member limit check failed — allowing provisioning",
       );
     }
@@ -840,7 +841,7 @@ export async function _autoProvisionSsoMember(user: { id: string; email: string 
     );
   } catch (err) {
     log.warn(
-      { err: err instanceof Error ? err.message : String(err), userId: user.id, email: user.email },
+      { err: errorMessage(err), userId: user.id, email: user.email },
       "SSO auto-provisioning failed — user created but not auto-joined to org",
     );
   }
@@ -962,7 +963,7 @@ export function buildAuthOptions(deps: BuildAuthOptionsDeps): Parameters<typeof 
         // a 500-vs-200 side channel.
         sendVerification({ to: user.email, url }).catch((err: unknown) => {
           log.warn(
-            { to: user.email, err: err instanceof Error ? err.message : String(err) },
+            { to: user.email, err: errorMessage(err) },
             "Verification email dispatch threw — signup response is still 200 to preserve enumeration protection",
           );
         });
@@ -1019,7 +1020,7 @@ export function buildAuthOptions(deps: BuildAuthOptionsDeps): Parameters<typeof 
               );
             } catch (err) {
               log.warn(
-                { err: err instanceof Error ? err.message : String(err), userId: member.userId },
+                { err: errorMessage(err), userId: member.userId },
                 "Failed to promote org owner to admin — Better Auth admin APIs may return 403",
               );
             }
@@ -1061,7 +1062,7 @@ export function buildAuthOptions(deps: BuildAuthOptionsDeps): Parameters<typeof 
               };
             } catch (err) {
               log.warn(
-                { err: err instanceof Error ? err.message : String(err), userId: session.userId },
+                { err: errorMessage(err), userId: session.userId },
                 "Failed to auto-set active org — user may need to switch manually",
               );
             }
@@ -1097,7 +1098,7 @@ export function buildAuthOptions(deps: BuildAuthOptionsDeps): Parameters<typeof 
             } catch (err) {
               // intentionally best-effort — never block sign-in on metering
               log.debug(
-                { err: err instanceof Error ? err.message : String(err), userId: session.userId },
+                { err: errorMessage(err), userId: session.userId },
                 "Login event emission skipped",
               );
             }
@@ -1140,7 +1141,7 @@ export function buildAuthOptions(deps: BuildAuthOptionsDeps): Parameters<typeof 
               // silently lock out the operator with one opaque log line.
               log.error(
                 {
-                  err: err instanceof Error ? err.message : String(err),
+                  err: errorMessage(err),
                   email: user.email,
                   hasAdminEmail: !!adminEmail,
                   allowFirstSignupAdmin,
@@ -1171,7 +1172,7 @@ export function buildAuthOptions(deps: BuildAuthOptionsDeps): Parameters<typeof 
                   onUserSignup({ userId: user.id, email: userEmail, orgId });
                 } catch (err) {
                   log.warn(
-                    { userId: user.id, err: err instanceof Error ? err.message : String(err) },
+                    { userId: user.id, err: errorMessage(err) },
                     "Failed to trigger welcome email — non-blocking",
                   );
                 }

--- a/packages/api/src/lib/conversations.ts
+++ b/packages/api/src/lib/conversations.ts
@@ -11,6 +11,7 @@
 
 import * as crypto from "crypto";
 import { createLogger } from "@atlas/api/lib/logger";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import {
   hasInternalDB,
   internalQuery,
@@ -163,7 +164,7 @@ export async function createConversation(opts: {
         );
     return rows[0] ?? null;
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "createConversation failed");
+    log.error({ err: errorMessage(err) }, "createConversation failed");
     return null;
   }
 }
@@ -218,7 +219,7 @@ export function persistAssistantSteps(opts: {
     })
     .catch((err: unknown) => {
       log.error(
-        { err: err instanceof Error ? err.message : String(err), conversationId },
+        { err: errorMessage(err), conversationId },
         "[%s] Agent stream failed — assistant response not available",
         label,
       );
@@ -286,7 +287,7 @@ export async function getConversation(
       },
     };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "getConversation failed");
+    log.error({ err: errorMessage(err) }, "getConversation failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -344,7 +345,7 @@ export async function listConversations(opts?: {
       total,
     };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "listConversations failed");
+    log.error({ err: errorMessage(err) }, "listConversations failed");
     return empty;
   }
 }
@@ -366,7 +367,7 @@ export async function starConversation(
     );
     return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "starConversation failed");
+    log.error({ err: errorMessage(err) }, "starConversation failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -388,7 +389,7 @@ export async function updateNotebookState(
     );
     return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "updateNotebookState failed");
+    log.error({ err: errorMessage(err) }, "updateNotebookState failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -472,7 +473,7 @@ export async function forkConversation(opts: {
 
     return { ok: true, data: { id: newId, messageCount: copyResult.length } };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err), sourceId: opts.sourceId }, "forkConversation failed");
+    log.error({ err: errorMessage(err), sourceId: opts.sourceId }, "forkConversation failed");
     // Clean up partially-created conversation to avoid orphans
     if (newId) {
       try {
@@ -533,7 +534,7 @@ export async function deleteBranch(opts: {
 
     return { ok: true };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err), rootId: opts.rootId, branchId: opts.branchId }, "deleteBranch failed");
+    log.error({ err: errorMessage(err), rootId: opts.rootId, branchId: opts.branchId }, "deleteBranch failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -575,7 +576,7 @@ export async function renameBranch(opts: {
 
     return { ok: true };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err), rootId: opts.rootId, branchId: opts.branchId }, "renameBranch failed");
+    log.error({ err: errorMessage(err), rootId: opts.rootId, branchId: opts.branchId }, "renameBranch failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -633,7 +634,7 @@ export async function convertToNotebook(opts: {
 
     return { ok: true, data: { id: newId, messageCount: copyResult.length } };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err), sourceId: opts.sourceId }, "convertToNotebook failed");
+    log.error({ err: errorMessage(err), sourceId: opts.sourceId }, "convertToNotebook failed");
     // Clean up partially-created conversation to avoid orphans
     if (newId) {
       try {
@@ -661,7 +662,7 @@ export async function deleteConversation(
     );
     return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "deleteConversation failed");
+    log.error({ err: errorMessage(err) }, "deleteConversation failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -741,7 +742,7 @@ export async function shareConversation(
     if (rows.length === 0) return { ok: false, reason: "not_found" };
     return { ok: true, data: { token: rows[0].share_token, expiresAt, shareMode } };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "shareConversation failed");
+    log.error({ err: errorMessage(err) }, "shareConversation failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -762,7 +763,7 @@ export async function unshareConversation(
     );
     return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "unshareConversation failed");
+    log.error({ err: errorMessage(err) }, "unshareConversation failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -795,7 +796,7 @@ export async function getShareStatus(
     }
     return { ok: true, data: { shared: true, token, expiresAt, shareMode } };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "getShareStatus failed");
+    log.error({ err: errorMessage(err) }, "getShareStatus failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -820,7 +821,7 @@ export async function cleanupExpiredShares(): Promise<number> {
     }
     return count;
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "cleanupExpiredShares failed");
+    log.error({ err: errorMessage(err) }, "cleanupExpiredShares failed");
     return -1;
   }
 }
@@ -889,7 +890,7 @@ export async function getSharedConversation(
       },
     };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "getSharedConversation failed");
+    log.error({ err: errorMessage(err) }, "getSharedConversation failed");
     return { ok: false, reason: "error" };
   }
 }

--- a/packages/api/src/lib/dashboards.ts
+++ b/packages/api/src/lib/dashboards.ts
@@ -7,6 +7,7 @@
 
 import * as crypto from "crypto";
 import { createLogger } from "@atlas/api/lib/logger";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import {
   hasInternalDB,
   internalQuery,
@@ -57,7 +58,7 @@ function rowToCard(r: Record<string, unknown>): DashboardCard {
         ? JSON.parse(r.chart_config)
         : (r.chart_config as DashboardChartConfig);
     } catch (err) {
-      log.warn({ cardId: r.id, err: err instanceof Error ? err.message : String(err) }, "Failed to parse chart_config JSONB");
+      log.warn({ cardId: r.id, err: errorMessage(err) }, "Failed to parse chart_config JSONB");
     }
   }
 
@@ -68,7 +69,7 @@ function rowToCard(r: Record<string, unknown>): DashboardCard {
         ? JSON.parse(r.cached_columns)
         : (r.cached_columns as string[]);
     } catch (err) {
-      log.warn({ cardId: r.id, err: err instanceof Error ? err.message : String(err) }, "Failed to parse cached_columns JSONB");
+      log.warn({ cardId: r.id, err: errorMessage(err) }, "Failed to parse cached_columns JSONB");
     }
   }
 
@@ -79,7 +80,7 @@ function rowToCard(r: Record<string, unknown>): DashboardCard {
         ? JSON.parse(r.cached_rows)
         : (r.cached_rows as Record<string, unknown>[]);
     } catch (err) {
-      log.warn({ cardId: r.id, err: err instanceof Error ? err.message : String(err) }, "Failed to parse cached_rows JSONB");
+      log.warn({ cardId: r.id, err: errorMessage(err) }, "Failed to parse cached_rows JSONB");
     }
   }
 
@@ -145,7 +146,7 @@ export async function createDashboard(opts: {
     if (rows.length === 0) return { ok: false, reason: "error" };
     return { ok: true, data: rowToDashboard(rows[0]) };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "createDashboard failed");
+    log.error({ err: errorMessage(err) }, "createDashboard failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -180,7 +181,7 @@ export async function getDashboard(
       data: { ...rest, cards: cardRows.map(rowToCard) },
     };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "getDashboard failed");
+    log.error({ err: errorMessage(err) }, "getDashboard failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -223,7 +224,7 @@ export async function listDashboards(opts?: {
     const total = (countRows[0]?.total as number) ?? 0;
     return { ok: true, data: { dashboards: dataRows.map(rowToDashboard), total } };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "listDashboards failed");
+    log.error({ err: errorMessage(err) }, "listDashboards failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -271,7 +272,7 @@ export async function updateDashboard(
     );
     return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "updateDashboard failed");
+    log.error({ err: errorMessage(err) }, "updateDashboard failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -292,7 +293,7 @@ export async function deleteDashboard(
     );
     return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "deleteDashboard failed");
+    log.error({ err: errorMessage(err) }, "deleteDashboard failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -342,7 +343,7 @@ export async function addCard(opts: {
 
     return { ok: true, data: rowToCard(rows[0]) };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "addCard failed");
+    log.error({ err: errorMessage(err) }, "addCard failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -390,7 +391,7 @@ export async function updateCard(
     internalExecute(`UPDATE dashboards SET updated_at = now() WHERE id = $1`, [dashboardId]);
     return { ok: true };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "updateCard failed");
+    log.error({ err: errorMessage(err) }, "updateCard failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -410,7 +411,7 @@ export async function removeCard(
     internalExecute(`UPDATE dashboards SET updated_at = now() WHERE id = $1`, [dashboardId]);
     return { ok: true };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "removeCard failed");
+    log.error({ err: errorMessage(err) }, "removeCard failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -434,7 +435,7 @@ export async function refreshCard(
     internalExecute(`UPDATE dashboards SET updated_at = now() WHERE id = $1`, [dashboardId]);
     return { ok: true };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "refreshCard failed");
+    log.error({ err: errorMessage(err) }, "refreshCard failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -452,7 +453,7 @@ export async function getCard(
     if (rows.length === 0) return { ok: false, reason: "not_found" };
     return { ok: true, data: rowToCard(rows[0]) };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "getCard failed");
+    log.error({ err: errorMessage(err) }, "getCard failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -532,7 +533,7 @@ export async function shareDashboard(
     if (rows.length === 0) return { ok: false, reason: "not_found" };
     return { ok: true, data: { token: rows[0].share_token, expiresAt, shareMode } };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "shareDashboard failed");
+    log.error({ err: errorMessage(err) }, "shareDashboard failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -553,7 +554,7 @@ export async function unshareDashboard(
     );
     return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "unshareDashboard failed");
+    log.error({ err: errorMessage(err) }, "unshareDashboard failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -584,7 +585,7 @@ export async function getShareStatus(
       },
     };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "getShareStatus failed");
+    log.error({ err: errorMessage(err) }, "getShareStatus failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -635,7 +636,7 @@ export async function getSharedDashboard(
       },
     };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "getSharedDashboard failed");
+    log.error({ err: errorMessage(err) }, "getSharedDashboard failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -660,7 +661,7 @@ export async function getDashboardsDueForRefresh(): Promise<Dashboard[]> {
     );
     return rows.map(rowToDashboard);
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "getDashboardsDueForRefresh failed");
+    log.error({ err: errorMessage(err) }, "getDashboardsDueForRefresh failed");
     return [];
   }
 }
@@ -703,7 +704,7 @@ export async function lockDashboardForRefresh(
     );
     return rows.length > 0;
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err), dashboardId }, "lockDashboardForRefresh failed");
+    log.error({ err: errorMessage(err), dashboardId }, "lockDashboardForRefresh failed");
     return false;
   }
 }
@@ -751,7 +752,7 @@ export async function refreshDashboardCards(dashboardId: string): Promise<{
       if (result.ok) refreshed++;
       else failed++;
     } catch (err) {
-      log.warn({ err: err instanceof Error ? err.message : String(err), cardId: card.id }, "Auto-refresh: card query failed");
+      log.warn({ err: errorMessage(err), cardId: card.id }, "Auto-refresh: card query failed");
       failed++;
     }
   }
@@ -787,7 +788,7 @@ async function getDashboardUnscoped(
       data: { ...rest, cards: cardRows.map(rowToCard) },
     };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "getDashboardUnscoped failed");
+    log.error({ err: errorMessage(err) }, "getDashboardUnscoped failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -824,7 +825,7 @@ export async function setRefreshSchedule(
     );
     return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "setRefreshSchedule failed");
+    log.error({ err: errorMessage(err) }, "setRefreshSchedule failed");
     return { ok: false, reason: "error" };
   }
 }

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -608,7 +608,7 @@ export class ConnectionRegistry {
       newConn = createConnection(baseEntry.dbType, orgConfig);
     } catch (err) {
       log.error(
-        { orgId, connectionId, err: err instanceof Error ? err.message : String(err) },
+        { orgId, connectionId, err: errorMessage(err) },
         "Failed to create org-scoped pool after LRU eviction",
       );
       throw err;
@@ -699,7 +699,7 @@ export class ConnectionRegistry {
       if (key.startsWith(prefix)) {
         keysToDelete.push(key);
         entry.conn.close().catch((err) => {
-          log.error({ key, err: err instanceof Error ? err.message : String(err) }, "Failed to close org pool — connections may be leaked");
+          log.error({ key, err: errorMessage(err) }, "Failed to close org pool — connections may be leaked");
         });
       }
     }
@@ -717,7 +717,7 @@ export class ConnectionRegistry {
         await entry.conn.query("SELECT 1", 5000);
       } catch (err) {
         failures++;
-        log.warn({ probe: i + 1, total: count, err: err instanceof Error ? err.message : String(err), ...context }, "Warmup probe failed");
+        log.warn({ probe: i + 1, total: count, err: errorMessage(err), ...context }, "Warmup probe failed");
       }
     }
     if (failures === count && count > 0) {
@@ -751,7 +751,7 @@ export class ConnectionRegistry {
       const oldestId = oldest.id;
       log.info({ connectionId: oldestId }, "Evicting LRU connection to free pool capacity");
       oldest.entry.conn.close().catch((err) => {
-        log.warn({ err: err instanceof Error ? err.message : String(err), connectionId: oldestId }, "Failed to close evicted connection");
+        log.warn({ err: errorMessage(err), connectionId: oldestId }, "Failed to close evicted connection");
       });
       this.entries.delete(oldestId);
     }
@@ -790,7 +790,7 @@ export class ConnectionRegistry {
 
     if (existing) {
       existing.conn.close().catch((err) => {
-        log.warn({ err: err instanceof Error ? err.message : String(err), connectionId: id }, "Failed to close previous connection during re-registration");
+        log.warn({ err: errorMessage(err), connectionId: id }, "Failed to close previous connection during re-registration");
       });
     }
   }
@@ -824,7 +824,7 @@ export class ConnectionRegistry {
     });
     if (existing) {
       existing.conn.close().catch((err) => {
-        log.warn({ err: err instanceof Error ? err.message : String(err), connectionId: id }, "Failed to close previous connection during re-registration");
+        log.warn({ err: errorMessage(err), connectionId: id }, "Failed to close previous connection during re-registration");
       });
     }
   }
@@ -838,7 +838,7 @@ export class ConnectionRegistry {
     const entry = this.entries.get(id);
     if (!entry) return false;
     entry.conn.close().catch((err) => {
-      log.warn({ err: err instanceof Error ? err.message : String(err), connectionId: id }, "Failed to close connection during unregister");
+      log.warn({ err: errorMessage(err), connectionId: id }, "Failed to close connection during unregister");
     });
     this.entries.delete(id);
     _resetWhitelists();
@@ -1125,7 +1125,7 @@ export class ConnectionRegistry {
           await entry.conn.query("SELECT 1", 5000);
           ready++;
         } catch (err) {
-          log.warn({ connectionId: id, probe: i + 1, err: err instanceof Error ? err.message : String(err) }, "Pool warmup probe failed");
+          log.warn({ connectionId: id, probe: i + 1, err: errorMessage(err) }, "Pool warmup probe failed");
         }
       }
     }));
@@ -1192,7 +1192,7 @@ export class ConnectionRegistry {
     entry.lastDrainAt = Date.now();
 
     oldConn.close().catch((err) => {
-      log.warn({ err: err instanceof Error ? err.message : String(err), connectionId: id }, "Failed to close drained pool");
+      log.warn({ err: errorMessage(err), connectionId: id }, "Failed to close drained pool");
     });
   }
 
@@ -1279,7 +1279,7 @@ export class ConnectionRegistry {
       if (key.startsWith(prefix)) {
         closing.push(
           entry.conn.close().catch((err) => {
-            log.warn({ key, err: err instanceof Error ? err.message : String(err) }, "Failed to close org pool during drain");
+            log.warn({ key, err: errorMessage(err) }, "Failed to close org pool during drain");
           }),
         );
         this.orgEntries.delete(key);
@@ -1306,14 +1306,14 @@ export class ConnectionRegistry {
     for (const [id, entry] of this.entries.entries()) {
       closing.push(
         entry.conn.close().catch((err) => {
-          log.warn({ err: err instanceof Error ? err.message : String(err), connectionId: id }, "Failed to close connection during shutdown");
+          log.warn({ err: errorMessage(err), connectionId: id }, "Failed to close connection during shutdown");
         }),
       );
     }
     for (const [key, entry] of this.orgEntries.entries()) {
       closing.push(
         entry.conn.close().catch((err) => {
-          log.warn({ err: err instanceof Error ? err.message : String(err), orgPoolKey: key }, "Failed to close org pool during shutdown");
+          log.warn({ err: errorMessage(err), orgPoolKey: key }, "Failed to close org pool during shutdown");
         }),
       );
     }
@@ -1331,12 +1331,12 @@ export class ConnectionRegistry {
     this.drainCooldownExpiry.clear();
     for (const [id, entry] of this.entries.entries()) {
       entry.conn.close().catch((err) => {
-        log.warn({ err: err instanceof Error ? err.message : String(err), connectionId: id }, "Failed to close connection during registry reset");
+        log.warn({ err: errorMessage(err), connectionId: id }, "Failed to close connection during registry reset");
       });
     }
     for (const [key, entry] of this.orgEntries.entries()) {
       entry.conn.close().catch((err) => {
-        log.warn({ err: err instanceof Error ? err.message : String(err), orgPoolKey: key }, "Failed to close org pool during registry reset");
+        log.warn({ err: errorMessage(err), orgPoolKey: key }, "Failed to close org pool during registry reset");
       });
     }
     this.entries.clear();
@@ -1390,7 +1390,7 @@ export async function isConnectionVisibleInMode(
     return rows.length > 0;
   } catch (err) {
     log.error(
-      { err: err instanceof Error ? err.message : String(err), orgId, connectionId, mode },
+      { err: errorMessage(err), orgId, connectionId, mode },
       "Connection visibility check failed — denying access (fail closed)",
     );
     return false;
@@ -1430,7 +1430,7 @@ export async function getRegionAwareConnection(
     }
     // EE module exists but failed to load — this is a real error.
     // Data residency cannot be guaranteed; refuse to silently downgrade.
-    log.error({ err: err instanceof Error ? err.message : String(err), orgId }, "Residency module failed to load — cannot guarantee data residency");
+    log.error({ err: errorMessage(err), orgId }, "Residency module failed to load — cannot guarantee data residency");
     throw err instanceof Error ? err : new Error(String(err));
   }
 
@@ -1440,7 +1440,7 @@ export async function getRegionAwareConnection(
     regionInfo = await Effect.runPromise(resolveRegionDatabaseUrlFn(orgId));
   } catch (err) {
     log.warn(
-      { err: err instanceof Error ? err.message : String(err), orgId },
+      { err: errorMessage(err), orgId },
       "Region resolution failed — falling back to default datasource",
     );
     return { db: connections.getForOrg(orgId, connectionId), resolvedConnId: connectionId };

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -34,6 +34,7 @@
 
 import { Context, Duration, Effect, Fiber, Layer, Schedule } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { InternalDB, makeInternalDBLive, hasInternalDB } from "@atlas/api/lib/db/internal";
 
 const log = createLogger("effect:layers");
@@ -299,7 +300,7 @@ export const SettingsLive: Layer.Layer<Settings> = Layer.scoped(
         return getConfig()?.deployMode === "saas";
       },
       catch: (err) => {
-        log.debug({ err: err instanceof Error ? err.message : String(err) }, "Config not available for SaaS detection — defaulting to self-hosted");
+        log.debug({ err: errorMessage(err) }, "Config not available for SaaS detection — defaulting to self-hosted");
         return false;
       },
     }).pipe(Effect.catchAll(() => Effect.succeed(false)));
@@ -316,7 +317,7 @@ export const SettingsLive: Layer.Layer<Settings> = Layer.scoped(
         Effect.catchAll((err) =>
           Effect.sync(() => {
             log.warn(
-              { err: err instanceof Error ? err.message : String(err) },
+              { err: errorMessage(err) },
               "Periodic settings refresh failed — will retry next interval",
             );
           }),
@@ -407,7 +408,7 @@ export function makeSchedulerLive(
           return isEmailSchedulerEnabled();
         },
         catch: (err) => {
-          log.debug({ err: err instanceof Error ? err.message : String(err) }, "Email scheduler module not available — skipping");
+          log.debug({ err: errorMessage(err) }, "Email scheduler module not available — skipping");
           return false;
         },
       }).pipe(Effect.catchAll(() => Effect.succeed(false)));
@@ -426,7 +427,7 @@ export function makeSchedulerLive(
         }).pipe(
           Effect.catchAll((err) =>
             Effect.sync(() => {
-              log.warn({ err: err instanceof Error ? err.message : String(err) }, "Onboarding email tick failed");
+              log.warn({ err: errorMessage(err) }, "Onboarding email tick failed");
             }),
           ),
         );
@@ -448,7 +449,7 @@ export function makeSchedulerLive(
           return isExpertSchedulerEnabled();
         },
         catch: (err) => {
-          log.debug({ err: err instanceof Error ? err.message : String(err) }, "Expert scheduler module not available — skipping");
+          log.debug({ err: errorMessage(err) }, "Expert scheduler module not available — skipping");
           return false;
         },
       }).pipe(Effect.catchAll(() => Effect.succeed(false)));
@@ -467,7 +468,7 @@ export function makeSchedulerLive(
         }).pipe(
           Effect.catchAll((err) =>
             Effect.sync(() => {
-              log.warn({ err: err instanceof Error ? err.message : String(err) }, "Expert scheduler tick failed");
+              log.warn({ err: errorMessage(err) }, "Expert scheduler tick failed");
             }),
           ),
         );
@@ -513,7 +514,7 @@ export function makeSchedulerLive(
         Effect.catchAll((err) =>
           Effect.sync(() => {
             log.warn(
-              { err: err instanceof Error ? err.message : String(err) },
+              { err: errorMessage(err) },
               "OAuth state cleanup tick failed",
             );
           }),
@@ -539,7 +540,7 @@ export function makeSchedulerLive(
         Effect.catchAll((err) =>
           Effect.sync(() => {
             log.warn(
-              { err: err instanceof Error ? err.message : String(err) },
+              { err: errorMessage(err) },
               "Rate limit cleanup tick failed",
             );
           }),
@@ -564,7 +565,7 @@ export function makeSchedulerLive(
         Effect.catchAll((err) =>
           Effect.sync(() => {
             log.error(
-              { err: err instanceof Error ? err.message : String(err) },
+              { err: errorMessage(err) },
               "Demo rate-limit cleanup tick failed",
             );
           }),
@@ -593,7 +594,7 @@ export function makeSchedulerLive(
         Effect.catchAll((err) =>
           Effect.sync(() => {
             log.warn(
-              { err: err instanceof Error ? err.message : String(err) },
+              { err: errorMessage(err) },
               "Abuse cleanup tick failed",
             );
           }),
@@ -622,7 +623,7 @@ export function makeSchedulerLive(
         Effect.catchAll((err) =>
           Effect.sync(() => {
             log.warn(
-              { err: err instanceof Error ? err.message : String(err) },
+              { err: errorMessage(err) },
               "Dashboard rate-limit cleanup tick failed",
             );
           }),
@@ -657,7 +658,7 @@ export function makeSchedulerLive(
         Effect.catchAll((err) =>
           Effect.sync(() => {
             log.warn(
-              { err: err instanceof Error ? err.message : String(err) },
+              { err: errorMessage(err) },
               "Conversation rate sweep tick failed",
             );
           }),
@@ -687,7 +688,7 @@ export function makeSchedulerLive(
         Effect.catchAll((err) =>
           Effect.sync(() => {
             log.error(
-              { err: err instanceof Error ? err.message : String(err) },
+              { err: errorMessage(err) },
               "Unexpected error in share cleanup tick",
             );
           }),

--- a/packages/api/src/lib/scheduled-tasks.ts
+++ b/packages/api/src/lib/scheduled-tasks.ts
@@ -11,6 +11,7 @@
 
 import { Cron } from "croner";
 import { createLogger } from "@atlas/api/lib/logger";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import {
   hasInternalDB,
   internalQuery,
@@ -60,7 +61,7 @@ function rowToScheduledTask(r: Record<string, unknown>): ScheduledTask {
     }
   } catch (err) {
     log.error(
-      { taskId: r.id, err: err instanceof Error ? err.message : String(err) },
+      { taskId: r.id, err: errorMessage(err) },
       "Failed to parse recipients JSONB — task will have no delivery targets",
     );
   }
@@ -118,7 +119,7 @@ export function validateCronExpression(expr: string): { valid: boolean; error?: 
     job.stop();
     return { valid: true };
   } catch (err) {
-    return { valid: false, error: err instanceof Error ? err.message : String(err) };
+    return { valid: false, error: errorMessage(err) };
   }
 }
 
@@ -131,7 +132,7 @@ export function computeNextRun(expr: string, after?: Date): Date | null {
     return next;
   } catch (err) {
     log.warn(
-      { cronExpression: expr, err: err instanceof Error ? err.message : String(err) },
+      { cronExpression: expr, err: errorMessage(err) },
       "Failed to compute next run time — task will not be scheduled",
     );
     return null;
@@ -203,7 +204,7 @@ export async function createScheduledTask(opts: {
     if (rows.length === 0) return { ok: false, reason: "error" };
     return { ok: true, data: rowToScheduledTask(rows[0]) };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "createScheduledTask failed");
+    log.error({ err: errorMessage(err) }, "createScheduledTask failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -240,7 +241,7 @@ export async function getScheduledTask(
     if (rows.length === 0) return { ok: false, reason: "not_found" };
     return { ok: true, data: rowToScheduledTask(rows[0]) };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "getScheduledTask failed");
+    log.error({ err: errorMessage(err) }, "getScheduledTask failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -287,7 +288,7 @@ export async function listScheduledTasks(opts?: {
     const total = (countRows[0]?.total as number) ?? 0;
     return { tasks: dataRows.map(rowToScheduledTask), total };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "listScheduledTasks failed");
+    log.error({ err: errorMessage(err) }, "listScheduledTasks failed");
     return empty;
   }
 }
@@ -369,7 +370,7 @@ export async function updateScheduledTask(
     );
     return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "updateScheduledTask failed");
+    log.error({ err: errorMessage(err) }, "updateScheduledTask failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -390,7 +391,7 @@ export async function deleteScheduledTask(
     );
     return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "deleteScheduledTask failed");
+    log.error({ err: errorMessage(err) }, "deleteScheduledTask failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -409,7 +410,7 @@ export async function createTaskRun(taskId: string): Promise<string | null> {
     );
     return rows[0]?.id ?? null;
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err), taskId }, "createTaskRun failed");
+    log.error({ err: errorMessage(err), taskId }, "createTaskRun failed");
     return null;
   }
 }
@@ -517,7 +518,7 @@ export async function listAllRuns(opts?: {
     }));
     return { runs, total };
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "listAllRuns failed");
+    log.error({ err: errorMessage(err) }, "listAllRuns failed");
     return empty;
   }
 }
@@ -536,7 +537,7 @@ export async function listTaskRuns(
     );
     return rows.map(rowToScheduledTaskRun);
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err), taskId }, "listTaskRuns failed");
+    log.error({ err: errorMessage(err), taskId }, "listTaskRuns failed");
     return [];
   }
 }
@@ -556,7 +557,7 @@ export async function getTasksDueForExecution(): Promise<ScheduledTask[]> {
     );
     return rows.map(rowToScheduledTask);
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err) }, "getTasksDueForExecution failed");
+    log.error({ err: errorMessage(err) }, "getTasksDueForExecution failed");
     return [];
   }
 }
@@ -599,7 +600,7 @@ export async function lockTaskForExecution(taskId: string): Promise<boolean> {
     if (rows.length === 0) return false;
     return true;
   } catch (err) {
-    log.error({ err: err instanceof Error ? err.message : String(err), taskId }, "lockTaskForExecution failed");
+    log.error({ err: errorMessage(err), taskId }, "lockTaskForExecution failed");
     return false;
   }
 }

--- a/packages/api/src/lib/semantic/sync.ts
+++ b/packages/api/src/lib/semantic/sync.ts
@@ -17,6 +17,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { createLogger } from "@atlas/api/lib/logger";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { getSemanticRoot as getBaseSemanticRoot } from "./files";
 
 const log = createLogger("semantic-sync");
@@ -131,7 +132,7 @@ export async function syncEntityToDisk(
     log.debug({ orgId, name, type, filePath }, "Synced entity to disk");
   } catch (err) {
     log.error(
-      { orgId, name, type, filePath, err: err instanceof Error ? err.message : String(err) },
+      { orgId, name, type, filePath, err: errorMessage(err) },
       "Failed to sync entity to disk — DB is authoritative, disk may be stale",
     );
     // Don't re-throw — DB write already succeeded, disk sync failure is
@@ -158,7 +159,7 @@ export async function syncEntityDeleteFromDisk(
       return;
     }
     log.error(
-      { orgId, name, type, filePath, err: err instanceof Error ? err.message : String(err) },
+      { orgId, name, type, filePath, err: errorMessage(err) },
       "Failed to delete entity from disk",
     );
   }
@@ -188,7 +189,7 @@ export async function syncAllEntitiesToDisk(orgId: string): Promise<number> {
   if (existing) {
     await existing.catch((err) => {
       log.debug(
-        { orgId, err: err instanceof Error ? err.message : String(err) },
+        { orgId, err: errorMessage(err) },
         "Prior rebuild for org failed — proceeding with fresh rebuild attempt",
       );
     });
@@ -230,7 +231,7 @@ async function _doSyncAllEntitiesToDisk(orgId: string): Promise<number> {
       synced++;
     } catch (err) {
       log.error(
-        { orgId, name: row.name, type: row.entity_type, err: err instanceof Error ? err.message : String(err) },
+        { orgId, name: row.name, type: row.entity_type, err: errorMessage(err) },
         "Failed to write entity during full sync",
       );
     }
@@ -273,14 +274,14 @@ async function _cleanStaleFiles(root: string, expectedFiles: Set<string>): Promi
             log.debug({ path: fullPath }, "Removed stale entity file");
           } catch (err) {
             if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-              log.warn({ path: fullPath, err: err instanceof Error ? err.message : String(err) }, "Failed to remove stale file");
+              log.warn({ path: fullPath, err: errorMessage(err) }, "Failed to remove stale file");
             }
           }
         }
       }
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-        log.warn({ dir, err: err instanceof Error ? err.message : String(err) }, "Failed to scan directory for stale files");
+        log.warn({ dir, err: errorMessage(err) }, "Failed to scan directory for stale files");
       }
     }
   }
@@ -301,7 +302,7 @@ export async function cleanupOrgDirectory(orgId: string): Promise<void> {
     log.info({ orgId, path: root }, "Cleaned up org semantic directory");
   } catch (err) {
     log.error(
-      { orgId, path: root, err: err instanceof Error ? err.message : String(err) },
+      { orgId, path: root, err: errorMessage(err) },
       "Failed to clean up org directory",
     );
   }
@@ -440,7 +441,7 @@ async function _buildOrgModeRoot(
     } catch (err) {
       failed++;
       log.error(
-        { orgId, mode, name: row.name, type: row.entity_type, err: err instanceof Error ? err.message : String(err) },
+        { orgId, mode, name: row.name, type: row.entity_type, err: errorMessage(err) },
         "Failed to write mode-specific entity file",
       );
     }
@@ -523,11 +524,11 @@ export async function importFromDisk(
         connectionId: options?.connectionId,
       });
     } catch (err) {
-      errors.push({ file: "glossary.yml", reason: `Invalid YAML: ${err instanceof Error ? err.message : String(err)}` });
+      errors.push({ file: "glossary.yml", reason: `Invalid YAML: ${errorMessage(err)}` });
     }
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-      errors.push({ file: "glossary.yml", reason: err instanceof Error ? err.message : String(err) });
+      errors.push({ file: "glossary.yml", reason: errorMessage(err) });
     }
     // ENOENT is fine — glossary is optional
   }
@@ -581,7 +582,7 @@ async function _scanYamlDir(
     files = (await fs.promises.readdir(dir)).filter((f) => f.endsWith(".yml"));
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return; // dir doesn't exist — fine
-    errors.push({ file: dir, reason: err instanceof Error ? err.message : String(err) });
+    errors.push({ file: dir, reason: errorMessage(err) });
     return;
   }
 
@@ -602,7 +603,7 @@ async function _scanYamlDir(
 
       out.push({ entityType, name, yamlContent: content, connectionId });
     } catch (err) {
-      errors.push({ file, reason: err instanceof Error ? err.message : String(err) });
+      errors.push({ file, reason: errorMessage(err) });
     }
   }
 }
@@ -629,6 +630,8 @@ export async function reconcileAllOrgs(): Promise<void> {
         "SELECT DISTINCT org_id FROM semantic_entities",
       );
     } catch (err) {
+      // @atlas-ok-ternary: msg is substring-matched on "does not exist" / "no such table"
+      // — errorMessage() would scrub+truncate, altering match semantics.
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes("does not exist") || msg.includes("no such table")) {
         log.info("semantic_entities table not found — first boot before migration, skipping reconciliation");
@@ -661,7 +664,7 @@ export async function reconcileAllOrgs(): Promise<void> {
           needsRebuild = true;
         } else {
           log.warn(
-            { orgId, err: err instanceof Error ? err.message : String(err) },
+            { orgId, err: errorMessage(err) },
             "Unexpected error reading org entities directory — attempting rebuild",
           );
           needsRebuild = true;
@@ -674,7 +677,7 @@ export async function reconcileAllOrgs(): Promise<void> {
           log.info({ orgId, synced }, "Boot reconciliation: rebuilt org directory");
         } catch (err) {
           log.error(
-            { orgId, err: err instanceof Error ? err.message : String(err) },
+            { orgId, err: errorMessage(err) },
             "Boot reconciliation failed for org — explore may not work for this org until next restart",
           );
         }
@@ -684,7 +687,7 @@ export async function reconcileAllOrgs(): Promise<void> {
     }
   } catch (err) {
     log.error(
-      { err: err instanceof Error ? err.message : String(err) },
+      { err: errorMessage(err) },
       "Boot reconciliation failed — org semantic layers may be incomplete",
     );
   }
@@ -707,7 +710,7 @@ async function _autoImportOrgsFromDisk(): Promise<void> {
       .map((d) => d.name);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return; // no .orgs/ dir — nothing to import
-    log.warn({ err: err instanceof Error ? err.message : String(err) }, "Could not scan .orgs/ for auto-import — skipping");
+    log.warn({ err: errorMessage(err) }, "Could not scan .orgs/ for auto-import — skipping");
     return;
   }
 
@@ -721,7 +724,7 @@ async function _autoImportOrgsFromDisk(): Promise<void> {
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
         log.warn(
-          { orgId, err: err instanceof Error ? err.message : String(err) },
+          { orgId, err: errorMessage(err) },
           "Cannot read entities dir for auto-import — skipping org",
         );
       }
@@ -740,7 +743,7 @@ async function _autoImportOrgsFromDisk(): Promise<void> {
       );
     } catch (err) {
       log.error(
-        { orgId, err: err instanceof Error ? err.message : String(err) },
+        { orgId, err: errorMessage(err) },
         "Auto-import from disk failed for org",
       );
     }

--- a/packages/api/src/lib/startup.ts
+++ b/packages/api/src/lib/startup.ts
@@ -13,6 +13,7 @@ import { maskConnectionUrl } from "./security";
 import { getDefaultProvider } from "./providers";
 import { detectAuthMode, getAuthModeSource } from "./auth/detect";
 import { createLogger } from "./logger";
+import { errorMessage } from "./audit/error-scrub";
 import { getSemanticRoot as getDefaultSemanticRoot } from "./semantic/files";
 
 const log = createLogger("startup");
@@ -196,7 +197,7 @@ function checkSemanticLayerPresence(errors: DiagnosticError[]): void {
     if (code !== "ENOENT") {
       errors.push({
         code: "MISSING_SEMANTIC_LAYER",
-        message: `Could not read semantic layer directory: ${err instanceof Error ? err.message : String(err)}. Check file permissions.`,
+        message: `Could not read semantic layer directory: ${errorMessage(err)}. Check file permissions.`,
       });
       hasEntities = true; // prevent duplicate "no semantic layer" error below
     }
@@ -218,7 +219,7 @@ async function checkDatasourceConnectivity(
   try {
     dbType = detectDBType(resolvedDatasourceUrl);
   } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
+    const detail = errorMessage(err);
     log.error({ err: detail }, "Unsupported datasource URL");
     errors.push({ code: "DB_UNREACHABLE", message: detail });
   }
@@ -309,7 +310,7 @@ async function checkMysqlConnectivity(
   } finally {
     if (pool) {
       await pool.end().catch((err: unknown) => {
-        log.warn({ err: err instanceof Error ? err.message : String(err) }, "Pool cleanup warning");
+        log.warn({ err: errorMessage(err) }, "Pool cleanup warning");
       });
     }
   }
@@ -406,7 +407,7 @@ async function checkPostgresConnectivity(
     errors.push({ code: "DB_UNREACHABLE", message });
   } finally {
     await pool.end().catch((err: unknown) => {
-      log.warn({ err: err instanceof Error ? err.message : String(err) }, "Pool cleanup warning");
+      log.warn({ err: errorMessage(err) }, "Pool cleanup warning");
     });
   }
 }
@@ -447,7 +448,7 @@ async function checkInternalDbConnectivity(errors: DiagnosticError[]): Promise<v
         errors.push({ code: "INTERNAL_DB_UNREACHABLE", message });
       } finally {
         await pool.end().catch((err: unknown) => {
-          log.warn({ err: err instanceof Error ? err.message : String(err) }, "Internal DB pool cleanup warning");
+          log.warn({ err: errorMessage(err) }, "Internal DB pool cleanup warning");
         });
       }
     }
@@ -467,7 +468,7 @@ async function checkConfigFile(errors: DiagnosticError[]): Promise<void> {
       await configMod.loadConfig();
     }
   } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
+    const detail = errorMessage(err);
     log.error({ err: detail }, "Config validation failed");
     errors.push({ code: "INVALID_CONFIG", message: detail });
   }
@@ -610,7 +611,7 @@ async function checkByotAuthMode(errors: DiagnosticError[]): Promise<void> {
         if (!_startupWarnings.includes(msg)) _startupWarnings.push(msg);
       }
     } catch (err) {
-      log.warn({ err: err instanceof Error ? err.message : String(err), jwksUrl }, "JWKS endpoint unreachable during startup check");
+      log.warn({ err: errorMessage(err), jwksUrl }, "JWKS endpoint unreachable during startup check");
     }
   }
 
@@ -680,7 +681,7 @@ async function checkActionFramework(errors: DiagnosticError[], authMode: string)
     }
   } catch (err) {
     log.warn(
-      { err: err instanceof Error ? err.message : String(err) },
+      { err: errorMessage(err) },
       "Could not validate action credentials at startup",
     );
   }
@@ -712,7 +713,7 @@ async function checkActionFramework(errors: DiagnosticError[], authMode: string)
     }
   } catch (err) {
     log.warn(
-      { err: err instanceof Error ? err.message : String(err) },
+      { err: errorMessage(err) },
       "Could not validate action config at startup",
     );
   }
@@ -737,7 +738,7 @@ async function logSandboxPlugins(): Promise<void> {
       }
     } catch (err) {
       log.warn(
-        { err: err instanceof Error ? err.message : String(err) },
+        { err: errorMessage(err) },
         "Failed to enumerate sandbox plugins",
       );
     }
@@ -762,7 +763,7 @@ async function checkSandboxPreFlight(): Promise<void> {
       && (err as NodeJS.ErrnoException).code === "MODULE_NOT_FOUND";
     if (!isModuleErr) {
       log.warn(
-        { err: err instanceof Error ? err.message : String(err) },
+        { err: errorMessage(err) },
         "Failed to read sandbox priority from config",
       );
     }
@@ -811,7 +812,7 @@ async function checkExplicitNsjail(): Promise<void> {
       if (!_startupWarnings.includes(msg)) _startupWarnings.push(msg);
     }
   } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
+    const detail = errorMessage(err);
     log.warn({ err: detail }, "Sandbox pre-flight check skipped");
   }
 }
@@ -837,7 +838,7 @@ async function checkSidecarHealth(): Promise<void> {
     }
   } catch (err) {
     markSidecarFailed();
-    const detail = err instanceof Error ? err.message : String(err);
+    const detail = errorMessage(err);
     const msg =
       `Sidecar unreachable at ${sidecarUrl}: ${detail}. ` +
       "The sidecar may not be running yet — explore will retry on first use.";
@@ -872,7 +873,7 @@ async function autoDetectNsjail(): Promise<void> {
       }
     }
   } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
+    const detail = errorMessage(err);
     log.warn({ err: detail }, "Sandbox pre-flight check skipped");
   }
 

--- a/packages/api/src/lib/tools/explore.ts
+++ b/packages/api/src/lib/tools/explore.ts
@@ -23,6 +23,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { withSpan } from "@atlas/api/lib/tracing";
 import { getConfig, type SandboxBackendName } from "@atlas/api/lib/config";
 import { getSemanticRoot, ensureOrgModeSemanticRoot } from "@atlas/api/lib/semantic/sync";
@@ -45,7 +46,7 @@ async function createBashBackend(
   try {
     ({ Bash, OverlayFs } = await import("just-bash"));
   } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
+    const detail = errorMessage(err);
     log.error({ err: detail }, "Failed to import just-bash");
     throw new Error(
       "Failed to load the just-bash runtime for the explore tool. " +
@@ -101,7 +102,7 @@ function useNsjail(): boolean {
       _nsjailAvailable = false;
     } else {
       log.error(
-        { error: err instanceof Error ? err.message : String(err) },
+        { error: errorMessage(err) },
         "Unexpected error loading nsjail module",
       );
       _nsjailAvailable = false;
@@ -188,7 +189,7 @@ async function tryCreateBackend(name: SandboxBackendName, semanticRoot: string, 
         const { createSandboxBackend } = await import("./explore-sandbox");
         return createSandboxBackend(semanticRoot);
       } catch (err) {
-        const detail = err instanceof Error ? err.message : String(err);
+        const detail = errorMessage(err);
         log.warn(
           { error: detail },
           "vercel-sandbox backend failed to initialize — trying next in priority",
@@ -209,7 +210,7 @@ async function tryCreateBackend(name: SandboxBackendName, semanticRoot: string, 
         });
       } catch (err) {
         _nsjailFailed = true;
-        const detail = err instanceof Error ? err.message : String(err);
+        const detail = errorMessage(err);
         log.warn(
           { error: detail },
           "nsjail backend failed to initialize — trying next in priority",
@@ -229,7 +230,7 @@ async function tryCreateBackend(name: SandboxBackendName, semanticRoot: string, 
         return createSidecarBackend(sidecarUrl, { semanticRoot });
       } catch (err) {
         _sidecarFailed = true;
-        const detail = err instanceof Error ? err.message : String(err);
+        const detail = errorMessage(err);
         log.warn(
           { error: detail },
           "sidecar backend failed to initialize — trying next in priority",
@@ -318,7 +319,7 @@ function getExploreBackend(semanticRoot: string, orgId?: string): Promise<Explor
               return result.backend as ExploreBackend;
             }
           } catch (err) {
-            const detail = err instanceof Error ? err.message : String(err);
+            const detail = errorMessage(err);
             log.warn(
               { backend: wsOverride, orgId, err: detail },
               "Workspace sandbox plugin override %s failed — falling through to default",
@@ -347,7 +348,7 @@ function getExploreBackend(semanticRoot: string, orgId?: string): Promise<Explor
             return result.backend as ExploreBackend;
           }
         } catch (err) {
-          const detail = err instanceof Error ? err.message : String(err);
+          const detail = errorMessage(err);
           const isModuleError = err != null && typeof err === "object" && "code" in err
             && (err as NodeJS.ErrnoException).code === "MODULE_NOT_FOUND";
           if (isModuleError) {
@@ -412,6 +413,8 @@ function getExploreBackend(semanticRoot: string, orgId?: string): Promise<Explor
             onNsjailFailed: markNsjailFailed,
           });
         } catch (err) {
+          // @atlas-ok-ternary: detail is concatenated into a thrown Error message
+          // — per #1829 non-goal, don't modify throw new Error(...) constructors.
           const detail = err instanceof Error ? err.message : String(err);
           throw new Error(
             "nsjail was explicitly requested (ATLAS_SANDBOX=nsjail) but failed to initialize: " +
@@ -438,7 +441,7 @@ function getExploreBackend(semanticRoot: string, orgId?: string): Promise<Explor
             onNsjailFailed: markNsjailFailed,
           });
         } catch (err) {
-          const detail = err instanceof Error ? err.message : String(err);
+          const detail = errorMessage(err);
           _nsjailFailed = true;
           log.error(
             { error: detail, fallback: "just-bash" },
@@ -511,7 +514,7 @@ Always start by listing the root directory to see what sources are available.`,
         ? await ensureOrgModeSemanticRoot(orgId, atlasMode)
         : getSemanticRoot();
     } catch (err) {
-      const detail = err instanceof Error ? err.message : String(err);
+      const detail = errorMessage(err);
       log.error({ err: detail, orgId, atlasMode }, "Failed to prepare org semantic root for explore");
       return `Error: Explore tool is unavailable — ${detail}`;
     }
@@ -520,7 +523,7 @@ Always start by listing the root directory to see what sources are available.`,
     try {
       backend = await getExploreBackend(semanticRoot, orgId);
     } catch (err) {
-      const detail = err instanceof Error ? err.message : String(err);
+      const detail = errorMessage(err);
       log.error({ err: detail, orgId }, "Explore backend initialization failed");
       return `Error: Explore tool is unavailable — ${detail}`;
     }
@@ -536,7 +539,7 @@ Always start by listing the root directory to see what sources are available.`,
           "command",
         );
       } catch (err) {
-        const detail = err instanceof Error ? err.message : String(err);
+        const detail = errorMessage(err);
         log.warn({ err: detail, command }, "Explore command rejected by plugin");
         return `Error: Command rejected by plugin: ${detail}`;
       }
@@ -573,7 +576,7 @@ Always start by listing the root directory to see what sources are available.`,
 
       return output;
     } catch (err) {
-      const detail = err instanceof Error ? err.message : String(err);
+      const detail = errorMessage(err);
       log.error({ err: detail, command }, "Explore command failed");
       return `Error: ${detail}`;
     }


### PR DESCRIPTION
## Summary

Mechanical sweep replacing the raw `err instanceof Error ? err.message : String(err)` ternary with `errorMessage()` from `@atlas/api/lib/audit/error-scrub` across the 10 worst offenders identified in #1829. Hygiene + log-size cleanup — the pino `serializers.err` in #1818 (F-44) already catches the security exposure.

**Why:** `errorMessage()` applies uniform 512-char truncation + DSN userinfo scrub. Raw ternaries can dump 50KB stack traces that push structured context off Loki/Datadog aggregation limits and bloat `admin_action_log.metadata`. Single audit surface for Phase 6/7 tightening.

## Per-file before → after

| File | Before | After | Notes |
|------|--------|-------|-------|
| `packages/api/src/lib/dashboards.ts` | 22 | 0 | clean swap |
| `packages/api/src/lib/effect/layers.ts` | 20 | 7 | Effect.tryPromise catch normalizers + 1 `new Error(\`Config...\`)` constructor (non-goals per #1829) |
| `packages/api/src/lib/semantic/sync.ts` | 19 | 1 | `@atlas-ok-ternary`: substring-matched on `"does not exist"` / `"no such table"` — scrub+truncate could alter match |
| `packages/api/src/lib/db/connection.ts` | 18 | 1 | Effect.tryPromise catch normalizer (non-goal) |
| `packages/api/src/api/routes/admin-integrations.ts` | 18 | 0 | includes 5 `TestEmailResult` error-field swaps (user-visible admin UI strings) |
| `packages/api/src/lib/conversations.ts` | 16 | 0 | clean swap |
| `packages/api/src/lib/auth/server.ts` | 16 | 0 | clean swap |
| `packages/api/src/lib/startup.ts` | 14 | 0 | clean swap — `detail` const form consolidated |
| `packages/api/src/lib/tools/explore.ts` | 13 | 1 | `@atlas-ok-ternary`: detail concatenated into a thrown Error message |
| `packages/api/src/lib/scheduled-tasks.ts` | 13 | 0 | includes cron-validation result-object error field |

**Totals:** 169 → 10 across the top-10 files. 10 remaining are all legitimate non-goals or explicitly marked `@atlas-ok-ternary` with justification.

## Non-goals preserved (per #1829)

- **Effect.tryPromise catch normalizers** (both `(err) => err instanceof Error ? err : new Error(String(err))` and `(err) => err instanceof Error ? err.message : String(err)`) — these produce the Effect typed error channel value; the Error-instance form is handled correctly by the pino serializer, and rewriting to `errorMessage` would lose the stack trace.
- **`throw new Error(...)` constructors** — not touched.
- **Import path** — `errorMessage` imported from the direct module (`@atlas/api/lib/audit/error-scrub`), not the barrel, to avoid breaking partial-mock tests that depend on the barrel's narrow shape.

## `@atlas-ok-ternary` markers left

1. **`packages/api/src/lib/semantic/sync.ts:635`** — `const msg = err...` is substring-matched on `"does not exist"` / `"no such table"` for first-boot detection. `errorMessage()` would scrub+truncate, altering match semantics.
2. **`packages/api/src/lib/tools/explore.ts:418`** — `detail` is concatenated into a thrown `Error` message. Per #1829 non-goal "No change to `throw new Error(...)` constructors."

Convention is now documented at the top of `packages/api/src/lib/audit/error-scrub.ts` so future contributors don't need to trace back through this PR.

## Review pass (multi-agent, run before merge)

- **code-reviewer**: approve. All remaining raw ternaries verified as legitimate non-goals; import path correct; `admin-integrations.ts` `TestEmailResult.error` swaps are net-positive (DSN scrubbing on an admin surface that could leak SMTP creds).
- **silent-failure-hunter**: clean. Enumerated every `.message.includes / .match / .test` across the 10 files and cross-checked swap sites — no control-flow paths inadvertently broken by truncation.
- **comment-analyzer**: both `@atlas-ok-ternary` markers accurate and load-bearing.

## Test plan
- [x] `/ci` — lint + type + test + syncpack + drift + railway-watch all green
- [x] `--affected` after each file — no regressions across 108 affected test files
- [x] Full `bun run test` passes
- [x] Remote CI + Railway deploy checks green
- [x] 3-agent review pass (code/errors/comments) all approve

Closes #1829