### PR TITLE
chore(deps): bump @useatlas/types ^0.0.15 → ^0.0.16 in template + sdk + react

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -227,7 +227,7 @@
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^5.96.2",
-        "@useatlas/types": "^0.0.15",
+        "@useatlas/types": "^0.0.16",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "radix-ui": "^1.4.3",
@@ -294,7 +294,7 @@
       "name": "@useatlas/sdk",
       "version": "0.0.11",
       "dependencies": {
-        "@useatlas/types": "^0.0.15",
+        "@useatlas/types": "^0.0.16",
       },
     },
     "packages/types": {
@@ -4227,10 +4227,6 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typespec/ts-http-runtime/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
-    "@useatlas/react/@useatlas/types": ["@useatlas/types@0.0.15", "", {}, "sha512-golL7ZJAfSF5lBRFZKh+o2b8WzUWyDjdXVTPrBzS+kUcNg1W4Wa/SfUcpBdlI/e6aDUQn2IToODy+PizFDDTGQ=="],
-
-    "@useatlas/sdk/@useatlas/types": ["@useatlas/types@0.0.15", "", {}, "sha512-golL7ZJAfSF5lBRFZKh+o2b8WzUWyDjdXVTPrBzS+kUcNg1W4Wa/SfUcpBdlI/e6aDUQn2IToODy+PizFDDTGQ=="],
 
     "@vercel/sandbox/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 

--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -24,7 +24,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.0.7",
     "@useatlas/sdk": "^0.0.11",
-    "@useatlas/types": "^0.0.15",
+    "@useatlas/types": "^0.0.16",
     "@better-auth/api-key": "^1.5.6",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -21,7 +21,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.0.7",
     "@useatlas/sdk": "^0.0.11",
-    "@useatlas/types": "^0.0.15",
+    "@useatlas/types": "^0.0.16",
     "ai": "^6.0.141",
     "@better-auth/api-key": "^1.5.6",
     "@dnd-kit/core": "^6.3.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -82,7 +82,7 @@
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^5.96.2",
-    "@useatlas/types": "^0.0.15",
+    "@useatlas/types": "^0.0.16",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "radix-ui": "^1.4.3",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -44,6 +44,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@useatlas/types": "^0.0.15"
+    "@useatlas/types": "^0.0.16"
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1842. \`types-v0.0.16\` is live on npm — the template can now consume the F-36 Phase 2 exports (\`AUDIT_ANONYMIZE_INITIATED_BY\`, \`AnonymizeInitiatedBy\`, \`AuditRetentionPolicy\`).

- \`create-atlas/templates/nextjs-standalone/package.json\`: \`^0.0.15\` → \`^0.0.16\`
- \`packages/sdk/package.json\`: \`^0.0.15\` → \`^0.0.16\`
- \`packages/react/package.json\`: \`^0.0.15\` → \`^0.0.16\`
- \`bun.lock\` refresh

## Why a separate PR

Per \`feedback_version_bump_ordering.md\`: for 0.0.x semver, \`^0.0.15\` pins exactly to 0.0.15. Template refs must flip AFTER the publish workflow completes, otherwise scaffold jobs race against an unpublished tag.

## Test plan

- [ ] Deploy Validation Scaffold (docker) passes — previously failed with "Export AUDIT_ANONYMIZE_INITIATED_BY doesn't exist in target module".
- [ ] Deploy Validation Scaffold (vercel) passes.
- [ ] Standalone Example Build passes.