### PR TITLE
docs(security): 1.2.3 phase 6 — rate-limit / timeout / DoS audit

### DIFF
--- a/.claude/research/security-audit-1-2-3.md
+++ b/.claude/research/security-audit-1-2-3.md
@@ -2455,7 +2455,7 @@ Same convention as Phase 4. Legend:
 | `*    /api/v1/discord/*` | admin | g | n | OAuth-only outbound; no inbound webhook |
 | `POST /webhook/:channelId` (plugin) | inline (HMAC / API-key) | n | n | Webhook plugin entrypoint — **no replay protection (F-75), no per-channel rate limit (F-76)** |
 
-Total mounted route prefixes: 36 distinct app-level mounts. The `admin` / `platform` mounts each fan out into ~50 / ~25 inner routes respectively — those inherit the parent's auth + RL posture. `withSourceSlot` rate limit applies to every SQL execution path regardless of which route invoked it, so it's a defense-in-depth layer below the table.
+Total mounted route prefixes: 40 distinct `app.route(...)` mounts in `packages/api/src/api/index.ts`. The `admin` / `platform` mounts each fan out into ~50 / ~25 inner routes respectively — those inherit the parent's auth + RL posture. `withSourceSlot` rate limit applies to every SQL execution path regardless of which route invoked it, so it's a defense-in-depth layer below the table.
 
 ### Unauthenticated route inventory
 
@@ -2704,7 +2704,7 @@ intent.
 `ATLAS_PYTHON_TIMEOUT` for the per-execution timeout but does not
 configure a memory limit. Vercel's runtime applies its own caps; nsjail
 sets `--rlimit_as 512` (default 512MB,
-`packages/api/src/lib/tools/python-nsjail.ts:78`). Operators relying
+`packages/api/src/lib/tools/python-nsjail.ts:117`). Operators relying
 on Vercel get whatever Vercel applies (typically 1024MB default for
 the sandbox runtime; not surfaced in `@vercel/sandbox` API).
 
@@ -2812,7 +2812,7 @@ Verified-clean.
 
 **F-87 — SQL row LIMIT + per-statement timeout enforced at driver layer for both PG and MySQL**
 
-`packages/api/src/lib/tools/sql.ts:1207-1212` auto-appends `LIMIT
+`packages/api/src/lib/tools/sql.ts:1210-1211` auto-appends `LIMIT
 ${rowLimit}` when not present (`ATLAS_ROW_LIMIT` default 1000).
 `packages/api/src/lib/db/connection.ts:281` runs `SET
 statement_timeout = ${timeoutMs}` per Postgres connection acquisition;
@@ -2932,7 +2932,7 @@ nsjail `-u 65534 -g 65534` runs as nobody. Verified-clean.
 | F-91 | — | Verified-clean | Internal migrate timing-safe compare + 503 on missing secret | — | n/a | verified |
 | F-92 | — | Verified-clean | nsjail Python timeout + memory + nproc + fsize + nofile caps | — | n/a | verified |
 
-**Totals:** P0 = 0, P1 = 1 (F-73), P2 = 4 (F-74 / F-75 / F-76 / F-77), P3 = 4 noted-only (F-78 / F-79 / F-80 / F-81), 11 verified-clean rows (F-82 – F-92). Pool-exhaustion behavior verified by code-read (load testing out of scope per the prompt). Numbering note: Phase 7 (parallel session) claimed F-73–F-80 first via tracker #1718; Phase 6 picked up at F-73 to avoid the clash. Phase 5 P3 notes (F-48–F-52) and Phase 7 (F-73–F-80) sit between.
+**Totals:** P0 = 0, P1 = 1 (F-73), P2 = 4 (F-74 / F-75 / F-76 / F-77), P3 = 4 noted-only (F-78 / F-79 / F-80 / F-81), 11 verified-clean rows (F-82 – F-92). Pool-exhaustion behavior verified by code-read (load testing out of scope per the prompt). Numbering note: Phase 7 (parallel session) claimed F-53–F-60 first via tracker #1718; Phase 6 picked up at F-73 to avoid the clash. Phase 5 P3 notes (F-48–F-52) and Phase 7 (F-53–F-60) sit between.
 
 ### Deliverables this PR
 
@@ -2961,6 +2961,6 @@ nsjail `-u 65534 -g 65534` runs as nobody. Verified-clean.
 | 4 | Audit-log coverage on write routes | complete | 5 / 5 / 5 / 3 | #1777 – #1791 | 15 findings; 9 fixed in-milestone (PR #1797–#1809) |
 | 5 | Secrets + error surfaces + plugin credentials | complete | 0 / 3 / 3 / 4 + 1 verified-clean | 6 P1/P2 issues filed | encryption-at-rest gap is the dominant pattern; no P0 |
 | 6 | Rate limiting + DoS | complete | 0 / 1 / 4 / 4 + 11 verified-clean | #1844 – #1848 | F-73 is the only live finding; webhook plugin cluster (F-75 / F-76) is P2 hardening. Numbering jumps to F-73 because Phase 7 (parallel session) claimed F-53–F-60 first |
-| 7 | Enterprise governance paths | parallel session — see #1718 | — | #1849 – #1853 | Parallel-session audit; F-53–F-60 used by Phase 7 |
+| 7 | Enterprise governance paths | complete (parallel session) | 0 / 2 / 3 / 3 | #1849 – #1853 | Custom-role enforcement + approval-workflow bypasses (F-53 / F-54 P1); SSO / SCIM hardening P2s; F-IDs F-53..F-60 |
 
-**Cross-phase totals (phases 1–6, plus Phase 7 sibling):** P0 = 8, P1 = 13, P2 = 22, P3 = 19 (Phase 6 alone). Phase 7 totals as reported in tracker #1718. No current P0 open; remediation for Phase 5 P1/P2 + Phase 6 P1/P2 clustered into follow-up PRs after each audit lands.
+**Cross-phase totals (phases 1–7):** P0 = 8, P1 = 15, P2 = 25, P3 = 22. No current P0 open; remediation for Phase 5 P1/P2 + Phase 6 P1/P2 + Phase 7 P1/P2 clustered into follow-up PRs after each audit lands.

--- a/.claude/research/security-audit-1-2-3.md
+++ b/.claude/research/security-audit-1-2-3.md
@@ -2951,6 +2951,703 @@ nsjail `-u 65534 -g 65534` runs as nobody. Verified-clean.
 
 ---
 
+
+## Phase 7 — Enterprise governance paths
+
+**Status:** complete (2026-04-24)
+**Scope:** SSO enforcement, SCIM directory sync, IP allowlist, approval
+workflows, custom roles, deploy-mode gating, and the `requireEnterprise()`
+guard contract. Sources walked: `ee/src/auth/{sso,scim,ip-allowlist,roles}.ts`
++ `.test.ts`, `ee/src/governance/approval.ts` + `.test.ts`,
+`ee/src/deploy-mode.ts`, `ee/src/index.ts`,
+`packages/api/src/api/routes/admin-{sso,scim,roles,approval,ip-allowlist,
+action-retention}.ts`, `packages/api/src/api/routes/middleware.ts`,
+`packages/api/src/api/routes/{slack,teams,discord,billing,scheduled-tasks,
+auth,demo,query,chat,validate-sql}.ts`,
+`packages/api/src/lib/auth/{middleware,managed,server}.ts`, and
+`packages/api/src/lib/{tools/sql,scheduler/executor,agent-query}.ts`.
+**Issue:** #1726
+**Phase 6 coordination:** Phase 6 (rate-limit / DoS audit) had not started
+at the time this section was written, so Phase 7 claims the IDs starting at
+F-53. If Phase 6 starts after this lands it picks up at F-61+, per the
+coordination rule in the original prompt.
+
+### Bypass matrix
+
+Governance control × entry point. **yes** = bypass exists (and is a
+finding); **no** = control is enforced; **n/a** = control does not apply
+to this entry point by design (the cell links to the rationale).
+
+| Entry point | SSO enforcement | SCIM-managed identity | IP allowlist | Approval workflows | Custom-role permissions |
+|---|---|---|---|---|---|
+| Web session (cookie / Better Auth bearer) | no | no — admin still mutates SCIM users (F-57) | no | no — chat / query bind user (F-54 covers scheduler) | **yes** — never gated at route layer (F-53) |
+| Better Auth API key (`apiKey()` plugin) | no — `validateManaged` resolves user, SSO check fires | no — same admin path (F-57) | no — `adminAuth`/`standardAuth` middleware fires `checkIPAllowlist` | no — agent path inherits user context | **yes** — never gated at route layer (F-53) |
+| `simple-key` mode (`x-api-key` header, self-hosted) | **yes** — `authenticateRequest` skips SSO check in this branch (F-56) | n/a — no managed users | no — IP allowlist still runs (no orgId → check returns `{ allowed: true }`, by design) | n/a — no orgId → approval check returns `required: false` | n/a — no user role; legacy admin assumed |
+| `byot` mode (third-party JWT) | **yes** — `authenticateRequest` skips SSO check in this branch (F-56) | n/a — IdP owns identity | no — IP allowlist still runs against the BYOT user | inherits user context if user has orgId | inherits user role; **yes** — same route-layer gap as web session (F-53) |
+| Slack / Teams / Discord webhook receivers (`/commands`, `/events`, `/interactions`) | n/a — no Atlas user identity in webhook payload | n/a | **yes** — by design but undocumented (F-58) | **yes** — `executeAgentQuery(text)` runs without user/org context (F-55) | n/a — no user role |
+| Scheduled-task executor (`/tick` + bun in-process loop) | n/a — system-initiated | n/a | n/a — server-internal call, not a request | **yes** — `executeAgentQuery(question, requestId)` drops user (F-54) | n/a — system context |
+| Stripe webhook (`/api/auth/stripe/*`) | n/a — Stripe-originated | n/a | n/a — third-party | n/a | n/a |
+| OAuth install (`/api/v1/{slack,teams,discord}/install`) | n/a — pre-auth handshake; admin gate enforced via `adminAuthPreamble` (F-04 fix) | n/a | no — `adminAuthPreamble` does not invoke `rateLimitAndIPCheck` directly, but admin role is required (gap noted, low risk) | n/a | n/a |
+| MCP server (stdio + SSE) | n/a — local stdio + bearer over SSE | n/a — separate identity model | n/a — outside the Hono app | n/a — runs separately from agent loop | n/a |
+| Embedded widget (`/widget`, `/widget.js`) | n/a — public static asset | n/a | n/a — public static asset | n/a — widget calls back into authenticated API which enforces approval | n/a |
+| Plugin callbacks (Better Auth Stripe plugin, plugin SDK hooks) | n/a — server-internal | n/a | n/a | n/a | n/a |
+
+**Reading the matrix:** every "yes" maps to a finding below. The cells
+that look concerning at first glance (e.g. webhook receivers vs. IP
+allowlist) are documented as "by design" because there is no Atlas-user
+identity to bind to a workspace allowlist — the third-party platform is
+the originating IP. The findings below tighten the cases where bypass is
+exploitable, surfaces undocumented carve-outs, and notes the cases that
+are correct-by-design but undocumented.
+
+### F-53 — Custom-role permission flags defined but never enforced at the route layer ⬆ **P1**
+
+**Where:** `ee/src/auth/roles.ts:42-53` defines `PERMISSIONS` (`query`,
+`query:raw_data`, `admin:users`, `admin:connections`, `admin:settings`,
+`admin:audit`, `admin:roles`, `admin:semantic`).
+`ee/src/auth/roles.ts:256-279` exports a `checkPermission()` middleware
+factory. **Zero call sites** in `packages/api/src/api/routes/**` or
+anywhere outside `roles.ts` itself:
+
+```
+$ grep -rn "checkPermission\|hasPermission\|resolvePermissions\b" \
+    packages/api/src/ --include="*.ts" | grep -v test
+packages/api/src/api/routes/admin-roles.ts:34: } from "@atlas/ee/auth/roles";   # CRUD only
+packages/api/src/api/routes/shared-schemas.ts:38: * custom-role surface (@atlas/ee/auth/roles) ...
+```
+
+The admin routes (`admin.ts`, `admin-{users,connections,audit,settings,
+semantic,roles}.ts`) all gate via `adminAuth` middleware
+(`packages/api/src/api/routes/middleware.ts:244-282`) which checks role
+∈ {admin, owner, platform_admin}. None of them refine by permission flag.
+
+**Repro path:** an admin creates a custom role `data-engineer` with
+permissions `["query", "query:raw_data"]` — explicitly NOT
+`admin:audit`. They `assignRole(userId, "data-engineer")`. The user's
+`member.role` becomes `"data-engineer"`, but every admin route still
+gates on `adminAuth` which doesn't know `data-engineer` from `admin`. The
+user lacks admin role and can't reach `/api/v1/admin/audit` — but that's
+because the role is not in `{admin, owner, platform_admin}`, not because
+the permission flag is missing. Conversely, an admin with a role that
+*does* have `admin` plus a stripped-down permission set still has full
+admin access at the route layer.
+
+The `resolvePermissions()` function in `roles.ts` does correctly compute
+the effective permission set (custom > legacy fallback), but nothing
+calls it on a request boundary. The permission system is currently a
+self-contained UI display feature that has never been wired into
+authorization.
+
+Per the acceptance criteria in #1726: *"Custom roles — permissions
+enforced at the route layer, not just UI. UI-only checks are P1 bypass
+bugs (explicitly called out in acceptance criteria)."* This is a stricter
+shape — there is **no** check (UI or otherwise) of permission flags. P1
+is correct.
+
+**Compliance lens:** SOC 2 CC6.3 (logical access — granular
+authorization). A SOC 2 audit reviewing the admin RBAC matrix would find
+that the role/permission UI promises segregation that the API does not
+deliver.
+
+**Remediation hint:** wire `checkPermission()` into the admin routes
+that map cleanly onto a permission flag. Suggested mapping:
+- `admin:users` → `admin.ts` (`/users`, `/users/{id}/*`,
+  `/users/{id}/membership`, `/users/{id}/role`)
+- `admin:connections` → `admin-connections.ts` (all routes)
+- `admin:audit` → `admin-audit.ts`, `admin-audit-retention.ts`,
+  `admin-action-retention.ts`
+- `admin:roles` → `admin-roles.ts` (all routes)
+- `admin:semantic` → `admin-semantic.ts`, `admin-semantic-improve.ts`
+- `admin:settings` → `admin.ts` settings sub-routes,
+  `admin-{branding,domains,email-provider,sandbox,residency,model-config}.ts`
+- `query`, `query:raw_data` → enforced inside `executeSQL` already via
+  `resolvePermissions`, but route-layer guard on `/api/v1/query` and
+  `/api/v1/chat` would catch users whose role lacks `query`.
+
+This will be a multi-PR remediation — the route-layer changes are wide.
+Suggest doing it in one cluster across the admin surface so the
+permission contract is consistent.
+
+**Status:** P1 — issue to be filed.
+
+---
+
+### F-54 — Approval workflows bypassed for scheduled-task executions ⬆ **P1**
+
+**Where:** `packages/api/src/lib/scheduler/executor.ts:41` calls
+`executeAgentQuery(question, requestId)`. `agent-query.ts:43` then runs
+the agent inside `withRequestContext({ requestId: id }, ...)` — no
+`user` field. Inside `executeSQL` (`packages/api/src/lib/tools/sql.ts:1017`):
+
+```ts
+const checkReqCtx = getRequestContext();
+const checkOrgId = checkReqCtx?.user?.activeOrganizationId;
+approvalMatch = await Effect.runPromise(checkApprovalRequired(
+  checkOrgId, classification.tablesAccessed, classification.columnsAccessed,
+));
+```
+
+`checkOrgId` is `undefined` because no user is bound. The first line of
+`checkApprovalRequired` (`ee/src/governance/approval.ts:412`):
+
+```ts
+if (!orgId || !hasInternalDB()) {
+  return { required: false, matchedRules: [] };
+}
+```
+
+short-circuits to "no approval required". The query executes with no
+audit trail of an approval bypass.
+
+**Repro path:** workspace admin creates an approval rule
+`SELECT FROM customer_pii` requiring approval. They then create a
+scheduled task with the question *"How many records does customer_pii
+have, broken down by acquisition channel?"*. The task runs daily without
+ever hitting the approval queue. Every other route that runs the same
+agent (chat, /query) DOES enforce approval — only the scheduler path
+silently bypasses.
+
+This is the same shape as the F-13 cross-tenant-state-change pattern —
+governance enforcement is per-call-site rather than centralized in the
+agent, so the easy thing (skip context) and the safe thing (block on
+no context) are inverted.
+
+**Partial mitigation worth noting:** `sql.ts:1037-1047` does fail
+closed when `approvalMatch.required === true` AND user identity is
+missing — it returns a clear "approval required but the requester
+identity could not be determined" error. The bug is not that the
+hard-fail is wrong; it is that `approvalMatch.required` never becomes
+true on the scheduler path because the orgId-less call to
+`checkApprovalRequired` short-circuits at `approval.ts:412` before any
+rule lookup runs. Readers should not infer the entire approval
+pipeline is broken — only the orgId-less entry path is.
+
+**Compliance lens:** SOC 2 CC6.1 / SOC 2 CC7.2 — change-management
+controls. The approval workflow is the auditable boundary between
+"user requested data" and "data was returned"; bypassing it via a
+scheduled task removes the human reviewer from the loop.
+
+**Remediation hint:** scheduled tasks are created by a user with
+recorded `created_by`. The task row already carries the actor's user_id
++ org_id. The fix is to:
+
+1. Resolve the task row's `created_by` user before invoking the agent.
+2. Bind that user into `withRequestContext` so `checkOrgId` resolves
+   correctly and approval rules apply.
+3. When approval is required, persist the request to the queue and
+   surface it in the task's run history as `delivery_status =
+   "pending_approval"` rather than silently executing.
+4. Consider whether scheduled tasks created by a user who has since lost
+   permissions should be auto-paused (separate concern, but related).
+
+A defensive secondary fix: in `executeSQL`, treat `orgId === undefined`
+as a hard block when `hasInternalDB()` AND any approval rule exists for
+the workspace. Currently the absence of orgId silently disables the
+gate; the safer default is fail-closed.
+
+**Status:** P1 — issue to be filed.
+
+---
+
+### F-55 — Approval workflows bypassed for Slack / Teams / Discord agent invocations ⬆ **P2**
+
+**Where:**
+- `packages/api/src/api/routes/slack.ts:302` (slash command path) and
+  `slack.ts:458` (events / threaded follow-up path) call
+  `executeAgentQuery(text)` with no user context.
+- `packages/api/src/api/routes/teams.ts` and `discord.ts` follow the
+  same pattern (each forwards to the same agent helper without resolving
+  the bot-platform user back to an Atlas user).
+
+Same root cause as F-54 — the agent runs without `user` bound to
+`RequestContext`, so `checkApprovalRequired(undefined, ...)`
+short-circuits.
+
+**Why this is P2 not P1:** the chat-platform integrations have a known
+identity-mapping gap (Slack user IDs are not Atlas user IDs). Operators
+who deploy Slack / Teams / Discord effectively grant the bot a
+no-approval execution environment. This is a defensible *design* choice
+when documented; it is a *bypass* when not. Today, no admin-facing
+documentation, no admin-toggle, and no audit row records that approval
+was skipped.
+
+**Compliance lens:** same as F-54 — but the impact is mitigated by the
+small surface (only orgs that install the chat integrations are
+exposed).
+
+**Remediation hint:** at minimum, persist a Slack-team-id → Atlas-org-id
+mapping (already done for installation routing; `getBotToken(teamId)`
+implies it) and bind the org as the agent's RequestContext orgId. With
+no Atlas user bound, surface the user identity as `slack:<userId>` and
+reject any approval-required query with a clear "approve via the Atlas
+admin console" message in Slack. This keeps the bot useful for queries
+that don't trip an approval rule and produces an audit trail for the
+ones that do.
+
+A simpler stop-gap: an admin setting `ATLAS_CHAT_PLATFORMS_BYPASS_APPROVAL`
+defaulting to `false`, surfaced in the integrations admin UI, with a
+clear warning that disabling approval for chat platforms reduces the
+governance posture. Logging an `admin_action_log` row when the toggle
+flips closes the audit gap.
+
+**Status:** P2 — issue to be filed.
+
+---
+
+### F-56 — SSO enforcement does not gate `simple-key` or `byot` auth modes ⬆ **P2**
+
+**Where:** `packages/api/src/lib/auth/middleware.ts:227-285`. The switch
+on `mode` has SSO enforcement only in the `case "managed":` branch
+(line 241). The `simple-key` and `byot` branches return immediately
+without any SSO check:
+
+```ts
+case "simple-key":
+  return validateApiKey(req);
+
+case "managed":
+  // ... validateManaged + checkSSOEnforcement ...
+
+case "byot":
+  return await (_byotOverride ?? validateBYOT)(req);
+```
+
+A workspace that has SSO enforcement enabled and is running in
+`simple-key` or `byot` mode will allow API-key/JWT holders to bypass
+Atlas's internal SSO enforcement entirely. The user identity surfaced
+by `simple-key` (`api-key-<sha256-prefix>`) has no email domain, so even
+if SSO checks did run they would no-op via `extractEmailDomain`
+returning null — that path is the documented break-glass. The live gap
+is `byot`.
+
+`byot` mode is gated on `ATLAS_AUTH_JWKS_URL` being set
+(`packages/api/src/lib/auth/detect.ts:76-77`) — a generic IdP signal
+that fits **multi-tenant SaaS deployments using an external IdP**
+(Auth0, Cognito, custom JWKS) just as well as self-hosted. The earlier
+revision of this finding called BYOT "self-hosted only"; that's wrong.
+Any deployment that runs Atlas behind an external IdP and ALSO has an
+SSO enforcement record in `sso_providers` will see the enforcement
+record silently no-op. In one sense the IdP itself is enforcing SSO
+(JWKS validation implies a verified IdP-signed token), so Atlas's
+internal table is somewhat redundant. The gap is the "I clicked the
+'enforce SSO' toggle in the admin UI and assumed it gated my BYOT
+JWTs" mismatch — the operator's mental model and the actual behaviour
+diverge silently.
+
+**Comment in code documents the simple-key carve-out only:**
+
+```ts
+// SSO enforcement: if the user's email domain has SSO enforced,
+// block password/session auth and require SSO login instead.
+// Break-glass bypass: simple-key auth (API key) is not affected.
+```
+
+No comment exists for `byot`. A BYOT JWT does carry the user's email
+(per the BYOT contract), so the domain *would* match an SSO-enforced
+workspace, and the enforcement *should* fire — but it doesn't because
+the switch case skips the check.
+
+**Why this is P2:** the SSO threat model assumes managed-mode
+deployments, which is where the official Atlas SaaS deployment lives and
+is what the SSO admin UI gates on. The `simple-key` carve-out is the
+documented break-glass. The `byot` carve-out is the live gap, but its
+real-world impact is bounded by the fact that a BYOT deployment is by
+definition already delegating identity to an external IdP — the IdP is
+enforcing SSO upstream, just not via Atlas's internal table. Not P1
+because:
+1. The official Atlas SaaS (managed mode) is unaffected.
+2. The break-glass framing is defensible for `simple-key` — the API-key
+   bypass is the intended escape hatch when SSO breaks (e.g. IdP outage
+   during incident response).
+3. BYOT operators who set Atlas's SSO enforcement record alongside an
+   external IdP have a misconfigured stack rather than an exploitable
+   bypass — but the misconfiguration is silent, which is what makes
+   this P2 (admin UI promises something the backend doesn't deliver)
+   rather than P3 (cosmetic).
+
+**Compliance lens:** SOC 2 CC6.6 / ISO A.9.4.2 — system access controls.
+A SOC 2 auditor reviewing the SSO enforcement claim would expect
+documentation of any break-glass paths. Currently undocumented for
+`byot`.
+
+**Remediation hint:** two cleanly-separable changes:
+1. **Documentation:** add an inline comment explaining the `byot`
+   bypass intent and update the SSO admin UI to surface "API key access
+   bypasses SSO enforcement" when an admin enables enforcement.
+2. **Enforcement:** factor `checkSSOEnforcement` out of
+   `case "managed":` into a wrapper that fires for any authenticated
+   path with a resolved email domain. Add a `bypassSSO` flag on
+   per-key / per-token grant if break-glass is needed, gated by an
+   admin-action audit row. Default behaviour: SSO is enforced regardless
+   of auth mode, with an explicit allow-list of bypass-eligible API keys.
+
+**Status:** P2 — issue to be filed. Suggest pairing with F-59 (test
+debt) so the bypass branches grow tests in the same PR.
+
+---
+
+### F-57 — Admin routes mutate SCIM-provisioned users without checking provisioning origin ⬆ **P2**
+
+**Where:** every user-mutation handler in
+`packages/api/src/api/routes/admin.ts` and `admin-roles.ts` operates on
+the `member` / `user` table without consulting the
+`account.providerId` ↔ `scimProvider` join that
+`ee/src/auth/scim.ts:198-205` uses to identify SCIM-managed users:
+
+All line numbers point to the `.openapi(...)` registration site:
+
+| Handler | File | Line |
+|---|---|---|
+| `removeMembershipRoute` | `admin.ts` | 2081 |
+| `deleteUserRoute` | `admin.ts` | 2151 |
+| `changeUserRoleRoute` | `admin.ts` | 1894 |
+| `revokeUserSessionsRoute` | `admin.ts` | 2213 |
+| `banUserRoute` | `admin.ts` | 1986 |
+| `assignRoleRoute` | `admin-roles.ts` | 466 |
+
+The SCIM "source of truth" model is that the IdP (Okta, Azure AD, etc.)
+owns the user lifecycle — when a user is removed from the SCIM group,
+the next sync deactivates the Atlas user. Per the SCIM-with-RBAC
+contract:
+- Admin UI mutations on SCIM-provisioned users **should** be either
+  blocked outright OR explicitly recorded as "manual override" with a
+  warning that the change will be reverted by the next sync.
+- Today, every admin mutation on a SCIM user proceeds silently. The
+  next SCIM sync may revert role changes, may re-create deleted users
+  via a follow-up `User` POST, or may surface the user in an
+  inconsistent state (deleted in Atlas but still in the SCIM provider's
+  user mirror).
+
+**Repro path:** workspace admin demotes an Okta-provisioned admin
+(`PATCH /admin/users/{id}/role` body `{role: "member"}`). The change
+applies immediately to `member.role`. On the next SCIM sync, Okta's
+group mapping promotes the user back to `admin`. The role flip is
+recorded in `admin_action_log` as a successful change, which it was —
+but the operator has no way to predict or learn that the change was
+transient.
+
+More severe variant: admin `DELETE /admin/users/{id}`, the user's
+account row in Better Auth is removed. Next SCIM sync from the IdP
+re-provisions the user with a new userId, orphaning the deleted user's
+audit trail (different primary key) and breaking any per-user RLS that
+references the old id.
+
+**Why this is P2 and not P1:** the F-57 path requires the admin to
+already be authorized to make the mutation. There is no privilege
+escalation. The damage is data-integrity (orphaned references,
+ping-pong with the IdP) and audit clarity (changes that don't stick).
+
+**Remediation cost is non-trivial — flagged here so the issue isn't
+mistaken for a one-line guard.** A grep of `packages/api/src/` and
+`ee/src/` for `scim_provisioned`, `scimProvisioned`, or
+`provisioned_via` returns zero hits — there is no marker column
+distinguishing SCIM-provisioned users from others. The
+`account.providerId` ↔ `scimProvider` join in `scim.ts:198-205` is the
+only mechanism, and it's a runtime query rather than a schema flag.
+Adding the SCIM-provenance check to the 6 user-mutation handlers
+either (a) adds a query per mutation, or (b) requires a schema
+migration to materialize a flag. Either path is doable; flagging it
+here so the implementer doesn't underestimate scope.
+
+**Compliance lens:** ISO A.9.2 — user access management. SCIM is the
+declared source of truth; the API not enforcing it weakens the
+auditable identity contract.
+
+**Remediation hint:** add a helper
+`isSCIMProvisioned(userId): Effect<boolean>` (mirroring the join in
+`scim.ts:getSyncStatus`) and wire it into the user-mutation routes
+above. Two policy modes worth surfacing as a workspace setting:
+- **strict** (default for SCIM-enabled workspaces): block the mutation
+  with a 409 + message explaining that SCIM owns this user.
+- **override** (admin opts in per mutation): mutation proceeds, an
+  `admin_action_log` row is emitted with `metadata.scim_override = true`
+  and a warning is sent to the admin via UI banner.
+
+Phase 4 already established the pattern of recording overrides in
+`admin_action_log` with `status` + structured metadata; reuse the same
+shape.
+
+**Status:** P2 — issue to be filed.
+
+---
+
+### F-58 — Webhook receivers (Slack / Teams / Discord) bypass IP allowlist by design — undocumented (P3 → noted)
+
+**Where:** the Slack `/commands`, `/events`, `/interactions` handlers
+mount via `OpenAPIHono` without `adminAuth`/`standardAuth`/
+`platformAdminAuth` middleware. The only middleware they get is
+`withRequestId` via the parent route. Same for `teams.ts` and
+`discord.ts` chat-platform handlers.
+
+`rateLimitAndIPCheck` (the function that calls `checkIPAllowlist`) only
+runs from `adminAuth` / `standardAuth` / `platformAdminAuth`. Webhook
+receivers therefore never hit the allowlist.
+
+**Why this is correct-by-design:** the webhook receivers verify HMAC
+signatures from the originating platform (Slack:
+`verifySlackSignature`; Teams: bot-framework token; Discord: signature
+header). The originating IP is the third-party platform, not a user IP
+that operators can or should allowlist.
+
+**Why this is still worth documenting:** an operator who configures an
+IP allowlist with the mental model "all access requires an allowlisted
+IP" will be surprised to learn that the chat integrations carve out a
+hole. The carve-out is invisible in admin UI today.
+
+**Remediation hint:** in the integrations admin UI, when a workspace
+has both an active IP allowlist and an active chat integration, surface
+a banner: *"Chat integration messages are validated by signature, not
+IP. Disable the integration to fully scope access to allowlisted IPs."*
+No code change to the receivers themselves.
+
+**Status:** P3 — noted, no separate issue. Roll into the IP allowlist
+admin UI polish cycle (1.3.0 admin revamp final pass).
+
+---
+
+### F-59 — Test coverage gap: SSO enforcement bypass branches not exercised (P3 → noted)
+
+**Where:** `packages/api/src/lib/auth/__tests__/middleware.test.ts`
+covers `mode: managed` SSO enforcement at line 205-247 (block + 500 fail-
+closed). No test covers:
+- `mode: simple-key` skipping SSO enforcement (the F-56 bypass).
+- `mode: byot` skipping SSO enforcement (also F-56).
+- A `managed`-mode session backed by a Better Auth API key (hits SSO
+  check via `auth.api.getSession`'s API-key resolution; is the most
+  common cross-cut and is currently inferred-correct rather than
+  asserted).
+
+Per the prompt's framing — *"if a bypass isn't tested for, that's itself
+a finding"* — these missing tests are the test-debt mirror of F-56.
+Once F-56 is fixed (or its scope is explicitly affirmed), the tests
+should land alongside.
+
+**Remediation hint:** add three test cases mirroring the existing F-56
+shape:
+1. `mode: simple-key — SSO enforcement does NOT block API key auth (documents intentional break-glass)`
+2. `mode: byot — SSO enforcement DOES block when domain matches (target behaviour after F-56)` *or* `mode: byot — SSO enforcement does NOT block (documents current behaviour pending F-56 fix)`
+3. `mode: managed (API-key) — SSO enforcement DOES fire for Better Auth API key auth`
+
+**Status:** P3 — noted. Folded into F-56 remediation PR.
+
+---
+
+### F-60 — `/api/v1/demo/chat` runs agent without `activeOrganizationId` — approval workflows skipped (P3 → noted)
+
+**Where:** `packages/api/src/api/routes/demo.ts:399-435`. The demo chat
+handler binds a demo `user` (synthesized via `createAtlasUser`) into
+`withRequestContext({ requestId, user: demoUser })`, but the demo user
+carries no `activeOrganizationId`. Inside `executeSQL`,
+`getRequestContext()?.user?.activeOrganizationId` resolves to undefined,
+which trips the same `checkApprovalRequired(undefined, ...)`
+short-circuit as F-54 / F-55.
+
+**Why this is P3 and not a real finding:** the demo workspace ships
+fixed sample data (the SaaS demo dataset) and is firewalled from any
+real workspace's data. Approval rules don't apply because there is no
+sensitive data to gate. The demo handler is gated by `isDemoEnabled()`
++ a signed demo token + email rate-limiting (covered by Phase 1 review).
+
+Worth noting for completeness so that future audits don't re-flag the
+same path — and so that any future change that lets the demo handler
+touch real workspace data picks up the explicit "no approval gate"
+constraint as a known precondition.
+
+**Status:** P3 — noted, no issue.
+
+---
+
+### Affirmative verifications
+
+The cells in the bypass matrix marked "no" each correspond to a
+correctly-wired enforcement path. Documenting the verification rationale
+for each so future audits can short-circuit:
+
+- **SSO enforcement on managed-mode auth** — `auth/middleware.ts:191-221`
+  calls `checkSSOEnforcement` after `validateManaged` succeeds. Returns
+  403 + `ssoRedirectUrl` to surface the IdP login URL. Fail-closed on
+  errors (returns 500 not allow). Test coverage:
+  `auth/__tests__/middleware.test.ts:205-247` (block + fail-closed).
+  Verified: no bypass via password, magic link, OAuth (Google / GitHub /
+  Microsoft), or session resume.
+- **SSO enforcement on Better Auth API key** — the `apiKey()` plugin
+  resolves the key to its owning user via `auth.api.getSession`, so the
+  same `validateManaged` → `checkSSOEnforcement` path applies. Inferred
+  from Better Auth docs + plugin source (the plugin populates
+  `session.user` from the key's owner). Test debt: not directly asserted
+  (see F-59).
+- **IP allowlist on `adminAuth` / `platformAdminAuth` / `standardAuth`** —
+  `routes/middleware.ts:117-156` calls `checkIPAllowlist(orgId, ip)`
+  unconditionally inside `rateLimitAndIPCheck`. All three middlewares
+  invoke this helper. Verified by reading the middleware bodies and
+  cross-referencing the inner-app route registrations.
+- **IP allowlist fail-closed on DB error** — `ee/src/auth/ip-allowlist.ts:334-346`
+  uses `Effect.tryPromise` with a typed `catch` that **re-throws** rather
+  than returning `{ allowed: true }` — DB outage blocks rather than
+  permits. Comment explicitly cites CLAUDE.md: *"`catch { return false }`
+  on a security check is a bug"*. Hardened correctly.
+- **Approval enforcement on `/api/v1/chat`** — `chat.ts:309` binds
+  `withRequestContext({ requestId, user: authResult.user, atlasMode })`
+  before the agent runs. `executeSQL` reads the bound user, so
+  `checkApprovalRequired` receives a valid orgId.
+- **Approval enforcement on `/api/v1/query`** — `query.ts:200` follows
+  the same `withRequestContext({ requestId, user: authResult.user })`
+  pattern as chat. Verified.
+- **Approval availability fail-open + creation hard-fail split** —
+  `lib/tools/sql.ts:1009-1090` splits the approval check into two
+  phases. Phase 1 (`checkApprovalRequired`) fails open (logs warn,
+  proceeds without gate) when EE is unavailable. Phase 2
+  (`createApprovalRequest` + `hasApprovedRequest`) fails closed (typed
+  `QueryExecutionError`, blocks the query). Comment explicitly cites
+  *"governance bypass is worse than a failed query"*. Correct posture.
+- **Approval cache-hit cannot bypass approval** — `lib/tools/sql.ts:1094-1110`
+  runs the cache check AFTER the approval check, so a cached result
+  for a query that now requires approval will not short-circuit. The
+  approval phase is upstream of the cache lookup.
+- **Custom-role names cannot shadow built-in Atlas roles (F-10
+  hardening)** — `ee/src/auth/roles.ts:36-38` builds
+  `RESERVED_ATLAS_ROLE_NAMES` from `ATLAS_ROLES`, then checks both at
+  `createRole` (line 364) and at `assignRole` (line 548). Belt-and-
+  suspenders defense. Verified.
+- **`requireEnterprise()` gates every EE CRUD function** — every
+  `Effect.gen` in `ee/src/{auth,governance,audit,branding,platform,
+  compliance,sla}/*.ts` starts with `yield* requireEnterpriseEffect("...")`.
+  The two intentional exceptions (`findProviderByDomain`,
+  `isSSOEnforced{,ForDomain}` in sso.ts; `getWorkspaceBrandingPublic`
+  in branding) carry inline rationale comments. Verified:
+  ```
+  $ grep -nL "requireEnterprise" ee/src/{auth,governance,audit,branding,
+    platform,compliance,sla}/*.ts | xargs grep -nE "^export"
+  # only test files + the documented carve-outs
+  ```
+- **`ATLAS_DEPLOY_MODE=saas` falls back to `self-hosted` without EE** —
+  `ee/src/deploy-mode.ts:31-33` and `deploy-mode.ts:36`. The frontend
+  `deployMode` value comes from `getDeployMode()` which reads the
+  resolved value. Verified by reading the source: no SaaS-only
+  governance route bypasses this gate.
+- **Stripe webhook signature verification** — `/api/auth/stripe/*` is
+  handled by Better Auth's Stripe plugin (`packages/api/src/lib/auth/server.ts:491`
+  conditionally registers when `STRIPE_SECRET_KEY` is present). The
+  plugin uses `stripe.webhooks.constructEvent` with `STRIPE_WEBHOOK_SECRET`.
+  Confirmed via Phase 5 audit (#1724) — no Atlas-side changes.
+- **OAuth state CSRF + orgId binding for chat-platform installs** —
+  `oauth-state.ts` 10-minute TTL + single-use DELETE-RETURNING.
+  `slack.ts:743`, `teams.ts:194`, `discord.ts:202` reject installs that
+  lack `orgId` when `deployMode === "saas"`. Phase 1 / F-04 fix carries
+  forward.
+- **Approval `expireStaleRequests` + `getPendingCount` are org-scoped** —
+  `ee/src/governance/approval.ts:654` and `:687`. The `@security F-13`
+  comment explicitly preserves the cross-tenant guard. Verified.
+- **`reviewApprovalRequest` blocks self-approval** —
+  `approval.ts:606-609`. Requester cannot approve their own request.
+  Verified.
+
+### Considered, not filed
+
+- **Better Auth `/api/auth/sign-in/email` from outside an IP allowlist** —
+  the auth catch-all is mounted without `adminAuth` / `standardAuth`,
+  so a user from outside the allowlist can authenticate. On the next
+  authenticated request, the allowlist fires and blocks them. This is
+  the documented "logged in but can't use the API" state — not a
+  bypass, just an audit-log surface that records a successful login
+  followed by a 403 on the very next request. Worth surfacing in
+  admin UI ("the following users authenticated from outside the
+  allowlist") but not a bypass finding.
+- **MCP server access** — the MCP server (stdio + SSE transport) is a
+  separate runtime from the Hono app. It owns its own auth (bearer over
+  SSE) and tool authorization. Not under Phase 7 scope; will be revisited
+  during the MCP hardening pass.
+- **Better Auth bearer plugin token revocation** — Phase 1 F-11
+  identified that bearer + apiKey co-existence has no documented
+  revocation flow. Re-reading in Phase 7: revocation is delegated to
+  Better Auth's session and apiKey tables (delete the row → next
+  request fails `getSession`). Documented behaviour, not a Phase 7
+  finding. Tracked under #1733 / Phase 1 cleanup.
+- **`getWorkspaceBrandingPublic` skips `requireEnterprise`** — by
+  design (see comment in `ee/src/branding/white-label.ts:130-134`).
+  Reads the public-safe branding fields only (logo, colors, hide-Atlas
+  toggle). No PII or credentials surface here. Phase 5 covered this
+  surface.
+- **`isSSOEnforced` / `isSSOEnforcedForDomain` skip
+  `requireEnterprise`** — by design; these are called during the login
+  flow before the user has a session, and the enterprise gate happens
+  at the admin toggle (`setSSOEnforcement`). Documented in source.
+- **`findProviderByDomain` skips `requireEnterprise`** — same rationale
+  as above; used in the login flow.
+- **`resolvePermissions` skips `requireEnterprise`** — by design; used
+  on every request and gracefully degrades to legacy role mapping when
+  EE is off. (Pairs with F-53; once permissions are wired into routes,
+  the legacy fallback is what protects self-hosted no-EE workspaces.)
+- **`hasInternalDB()` short-circuits** — every EE function checks
+  `if (!hasInternalDB()) return ...` after the enterprise gate. This is
+  the standard pattern for self-hosted-no-DB compatibility. Not a
+  bypass; verified throughout.
+- **`adminAuthPreamble` on chat-platform OAuth install routes does not
+  invoke IP allowlist** — Slack / Teams / Discord `/install` routes
+  use `adminAuthPreamble` directly (which checks role) instead of the
+  `adminAuth` middleware (which also does IP allowlist). An admin from
+  outside the IP allowlist could initiate an OAuth install. Subsequent
+  callbacks save the installation. Low risk because: (1) the install
+  binds to the user's session orgId (F-04 hardening), (2) the
+  callback consumes a single-use OAuth state nonce. But cosmetically
+  inconsistent — worth folding into the admin-router unification when
+  the `/install` flows next get touched. Not a P-finding because no
+  privilege gain.
+
+### Findings summary
+
+| ID | Severity | Type | Surface | Compliance lens | Issue | Status |
+|---|---|---|---|---|---|---|
+| F-53 | P1 | Authorization gap | Custom-role permission flags never enforced at route layer | SOC 2 CC6.3 (granular authorization) | #1849 | open |
+| F-54 | P1 | Governance bypass | Scheduled-task executor runs agent without user context → approval workflows skipped | SOC 2 CC6.1 / CC7.2 (change management) | #1850 | open |
+| F-55 | P2 | Governance bypass | Slack / Teams / Discord agent invocations bypass approval workflows | SOC 2 CC6.1 / CC7.2 | #1851 | open |
+| F-56 | P2 | SSO bypass | `simple-key` and `byot` auth modes skip SSO enforcement | SOC 2 CC6.6 / ISO A.9.4.2 | #1852 | open |
+| F-57 | P2 | Identity-source bypass | Admin routes mutate SCIM-provisioned users without provisioning-origin check | ISO A.9.2 (user access management) | #1853 | open |
+| F-58 | P3 | Doc / UX | Webhook receivers bypass IP allowlist by design — undocumented in admin UI | — | — | noted |
+| F-59 | P3 | Test debt | No tests for `simple-key` / `byot` SSO bypass branches; API-key SSO check inferred-only | — | — | noted (folds into F-56) |
+| F-60 | P3 | Verified by-design | `/api/v1/demo/chat` runs agent without user context — non-sensitive demo data | — | — | noted |
+
+**Totals:** P0 = 0, P1 = 2 (F-53, F-54), P2 = 3 (F-55, F-56, F-57), P3 = 3 (F-58, F-59, F-60). Issue IDs filled in below as filed.
+
+### Deliverables this PR
+
+- **This audit section** — bypass matrix + 5 P1/P2 issue-bearing
+  findings + 3 P3 noted-only findings + an affirmative-verification
+  block listing each correctly-wired enforcement path.
+- **5 GitHub issues filed** (linked in the table above) for every
+  P1/P2 finding (none here are P0). Labels per finding: `security`,
+  `bug` (live flaw) or `chore` (hardening), and `area: api`. Milestone:
+  `1.2.3 — Security Sweep`.
+- **Phase-7 checkbox flipped** in the tracker (#1718). This is the
+  final phase — the audit portion of 1.2.3 closes with this PR.
+- **No production code changes** — fixes ship as follow-up PRs per the
+  phase-1/2/3/4/5 workflow.
+
+**Suggested remediation ordering for the follow-up cluster:**
+
+1. **F-54** first (P1, smallest blast radius). Scheduler executor
+   binds task creator's user; `executeSQL` defends with fail-closed
+   when orgId is undefined and approval rules exist.
+2. **F-53** next (P1, biggest scope). Wire `checkPermission()` into
+   the admin route surface. Multi-PR cluster — one PR per admin
+   sub-router would keep diffs reviewable.
+3. **F-57** (P2). Add `isSCIMProvisioned()` helper and gate the user-
+   mutation routes in `admin.ts` + `admin-roles.ts`. Workspace setting
+   chooses strict / override mode.
+4. **F-55** (P2). Bind chat-platform team-id → org-id mapping into
+   `executeAgentQuery` from Slack / Teams / Discord receivers; reject
+   approval-required queries with a "approve via admin console"
+   message. Or ship the `ATLAS_CHAT_PLATFORMS_BYPASS_APPROVAL`
+   stop-gap.
+5. **F-56 + F-59** (P2 + P3). Document the SSO/`byot` bypass; factor
+   `checkSSOEnforcement` out of the managed-only branch; add the three
+   missing test cases.
+
+P3s (F-58, F-60) roll into 1.3.0 admin polish or stay in this audit
+doc as noted-only.
+
+---
+
 ## 1.2.3 Phase scorecard
 
 | Phase | Title | Audit status | Findings (P0 / P1 / P2 / P3) | Issues filed | Notes |
@@ -2961,6 +3658,6 @@ nsjail `-u 65534 -g 65534` runs as nobody. Verified-clean.
 | 4 | Audit-log coverage on write routes | complete | 5 / 5 / 5 / 3 | #1777 – #1791 | 15 findings; 9 fixed in-milestone (PR #1797–#1809) |
 | 5 | Secrets + error surfaces + plugin credentials | complete | 0 / 3 / 3 / 4 + 1 verified-clean | 6 P1/P2 issues filed | encryption-at-rest gap is the dominant pattern; no P0 |
 | 6 | Rate limiting + DoS | complete | 0 / 1 / 4 / 4 + 11 verified-clean | #1844 – #1848 | F-73 is the only live finding; webhook plugin cluster (F-75 / F-76) is P2 hardening. Numbering jumps to F-73 because Phase 7 (parallel session) claimed F-53–F-60 first |
-| 7 | Enterprise governance paths | complete (parallel session) | 0 / 2 / 3 / 3 | #1849 – #1853 | Custom-role enforcement + approval-workflow bypasses (F-53 / F-54 P1); SSO / SCIM hardening P2s; F-IDs F-53..F-60 |
+| 7 | Enterprise governance paths | complete | 0 / 2 / 3 / 3 | #1849 – #1853 | F-53 (custom-role permissions never enforced) is the dominant gap; F-54 (scheduler approval bypass) is the second |
 
-**Cross-phase totals (phases 1–7):** P0 = 8, P1 = 15, P2 = 25, P3 = 22. No current P0 open; remediation for Phase 5 P1/P2 + Phase 6 P1/P2 + Phase 7 P1/P2 clustered into follow-up PRs after each audit lands.
+**Cross-phase totals (phases 1–7):** P0 = 8, P1 = 15, P2 = 25, P3 = 22. No current P0 open; remediation for Phase 5 P1/P2 + Phase 6 P1/P2 + Phase 7 P1/P2 clustered into follow-up PRs after each audit lands. Finding-ID map: Phase 1 = F-01..F-12, Phase 2 = F-13..F-15, Phase 3 = F-16..F-21, Phase 4 = F-22..F-36, Phase 5 = F-37..F-52, Phase 7 = F-53..F-60 (parallel session), Phase 6 = F-73..F-92.

--- a/.claude/research/security-audit-1-2-3.md
+++ b/.claude/research/security-audit-1-2-3.md
@@ -2325,6 +2325,632 @@ migration).
 
 ---
 
+## Phase 6 — Rate limiting + timeouts + DoS surfaces
+
+**Status:** audit complete (2026-04-24); fixes tracked per-finding.
+**Scope:** every throttle / timeout / pool / queue cap on the public API
+surface — agent loop step + wall-clock caps, SQL validator
+LIMIT/timeout, per-tenant connection pools, per-user/org throttles on
+expensive routes (`/chat`, `/publish`, admin bulk imports, semantic
+sync, plugin install), unauthenticated route inventory, Python sandbox
+execution + memory + queue caps across all backends, and webhook
+signature + replay + rate-limit posture. Matches #1725 scope list
+verbatim.
+**Issue:** #1725
+**Branch:** `security/1-2-3-phase-6-audit`
+
+### Methodology
+
+1. **Route inventory.** Walk every `app.route(...)` registration in
+   `packages/api/src/api/index.ts` and the middleware applied at each
+   mount point (`adminAuth` / `platformAdminAuth` / `standardAuth` /
+   `withRequestId` / unauth). Cross-reference against `routes/*.ts` to
+   confirm `.use(...)` does what the mount comment claims. Same shape
+   Phase 4 used for write routes — three columns this time
+   (auth-required, rate-limited, timeout-bounded) instead of audit
+   coverage.
+2. **Agent + SQL caps.** Trace `runAgent` end-to-end
+   (`packages/api/src/lib/agent.ts`) for the four caps the prompt named
+   — `stepCountIs(getAgentMaxSteps())`, per-tool SQL timeout, total
+   wall-clock budget per request, optional override for demo mode.
+   Confirm `ATLAS_QUERY_TIMEOUT` is applied at the driver layer (not
+   wrapped only in JS) for both PostgreSQL and MySQL paths. Confirm
+   `ATLAS_ROW_LIMIT` is auto-appended by the validator.
+3. **Pool capacity behaviour.** Read `packages/api/src/lib/db/connection.ts`
+   start-to-finish — base + per-org pool config, LRU eviction order,
+   `PoolCapacityExceededError` catch boundary, drain cooldown,
+   consecutive-failure auto-drain threshold. Confirm exhaustion
+   surfaces as a tagged 429 (graceful degrade), not an unhandled
+   exception that kills a fiber.
+4. **Per-route throttles.** Grep every authenticated handler for
+   `checkRateLimit` call sites. Compare per-route weighting (chat = 25
+   LLM steps; admin/audit = 1 DB query) against the single global
+   `ATLAS_RATE_LIMIT_RPM` bucket.
+5. **Unauthenticated route enumeration.** Walk every route file that
+   either has no auth middleware (`new Hono()` constructor) or
+   explicitly registers under `/api/public/*`. For each, confirm
+   whether the handler reaches a paid surface (LLM, sandbox).
+6. **Python + explore sandbox audit.** Read every backend in
+   `packages/api/src/lib/tools/` (`python-nsjail.ts`, `python-sandbox.ts`,
+   `python-sidecar.ts`, `explore-nsjail.ts`, `explore-sandbox.ts`,
+   `explore-sidecar.ts`, `explore.ts` just-bash fallback) for per-call
+   execution timeout, per-call memory cap, sidecar request queue / 429
+   on overflow.
+7. **Webhook signature + replay.** Enumerate every inbound webhook
+   receiver across the codebase. `grep -rn "signature\|webhook\|HMAC"`
+   then walk each — Stripe (Better Auth plugin), Slack
+   (`/api/v1/slack/{commands,events,interactions}`), the webhook
+   plugin (`POST /webhook/:channelId`). Confirm signature verification,
+   timestamp window for replay, and rate limit posture for each.
+   Verify Discord / Teams / Telegram / GChat / GitHub / Linear /
+   WhatsApp don't expose webhook receivers (OAuth-only outbound
+   surfaces).
+
+### Surfaces walked — fingerprint
+
+| Surface | Files inspected | Outcome |
+|---|---|---|
+| Auth-middleware coverage | `routes/middleware.ts`, `routes/admin-router.ts`, every `routes/*.ts` `.use(...)` and module-constructor pattern | every authenticated route runs through `adminAuth` / `platformAdminAuth` / `standardAuth`, all of which call `checkRateLimit` → `IP allowlist` → `misrouting` → `migration write-lock` (write methods only) before the handler. The `withRequestId` middleware is the no-auth context provider used by `/chat` (inline auth), `/query` (inline auth), `/widget*` (no auth needed), `/api/public/*` (no auth) — see route-inventory table |
+| Rate limit | `lib/auth/middleware.ts:80-109` (sliding-window per-key) + `lib/db/source-rate-limit.ts:76-110` (per-source QPM + concurrency) + per-public-route in-memory limiters in `routes/conversations.ts:1191-1252` and `routes/dashboards.ts:124-153` + demo limiter in `lib/demo.ts:46-58` | five distinct limiters in the codebase. The global `ATLAS_RATE_LIMIT_RPM` defaults to 0 (disabled). Per-source DB rate limit defaults 60 QPM / 5 concurrent. Public-share routes default to 60 / 30 per IP / 60s. Demo mode 10 RPM. **No per-route weighting** between chat (25-step) and cheap reads (single query) — F-74 |
+| Agent loop caps | `lib/agent.ts:622-633` | `stepCountIs(maxStepsOverride ?? getAgentMaxSteps())` (default 25, range 1-100, env `ATLAS_AGENT_MAX_STEPS`); `timeout: { totalMs: 180_000, stepMs: 30_000, chunkMs: 5_000 }` — full request budget capped at 180s wall-clock, per step at 30s, per stream chunk at 5s |
+| SQL row LIMIT + timeout | `lib/tools/sql.ts:430-457` (settings reads), `lib/db/connection.ts:281` (PG `SET statement_timeout = ${timeoutMs}`), `lib/db/connection.ts:319-326` (MySQL `SET SESSION TRANSACTION READ ONLY` + `SET SESSION MAX_EXECUTION_TIME`) | `ATLAS_ROW_LIMIT` (default 1000) auto-appended by validator when `LIMIT` not present. `ATLAS_QUERY_TIMEOUT` (default 30000ms) applied at driver layer for both PG and MySQL — defense-in-depth against runaway queries even if the JS wrapper is bypassed |
+| Per-tenant pool caps | `lib/db/connection.ts:399-417` (defaults), `:552-646` (lazy lookup + LRU), `:580-597` (capacity check + `PoolCapacityExceededError`), `:678-710` (close-and-evict path), `:909-931` (consecutive-failure auto-drain), `:1149-1166` (drain cooldown via Effect) | per-org pool: max 5 conns × 50 orgs (default), `maxTotalConnections = 100` global. LRU eviction triggers when capacity hit. `PoolCapacityExceededError` is mapped to `PoolExhaustedError` (`tools/sql.ts:553-559`) → 429 (`lib/effect/hono.ts:169`). Graceful degrade verified |
+| Python sandbox timeouts + memory + queue | `lib/tools/python-nsjail.ts:23-30` (DEFAULT_TIME_LIMIT=30s, MEMORY=512MB, NPROC=16), `lib/tools/python-sandbox.ts:35,265-268` (Vercel: 30s timeout via env, no Atlas-layer memory cap), `lib/tools/python-sidecar.ts:18,46-50` (HTTP timeout = ATLAS_PYTHON_TIMEOUT default 30s + 10s overhead), `packages/sandbox-sidecar/src/server.ts:33-39` (sidecar concurrency cap = 10, MAX_TIMEOUT=120s) | nsjail has explicit time + memory caps; Vercel sandbox delegates memory to platform; sidecar enforces concurrency = 10 with 429 on overflow. Just-bash fallback (dev-only) has no wall-clock cap (F-78 noted) |
+| Explore tool timeouts | `lib/tools/explore.ts:42-81` (just-bash with maxCommandCount=5000, no wall-clock), `lib/tools/explore-nsjail.ts:38-115`, `lib/tools/explore-sidecar.ts:95-141` (DEFAULT_TIMEOUT=10s) | nsjail + sidecar have explicit timeouts; just-bash uses `executionLimits.maxCommandCount = 5000` + `maxLoopIterations = 1000` but no wall-clock guard. Production warning logged when just-bash is the active backend |
+| Stripe webhook signature + replay | `lib/auth/server.ts:498-505` (Better Auth Stripe plugin); upstream `stripe.webhooks.constructEvent` enforces signature + 5-min timestamp tolerance | F-82 verified-clean — replay protection delegated to the official Stripe SDK |
+| Slack webhook signature + replay | `lib/slack/verify.ts:13` (MAX_TIMESTAMP_AGE_SECONDS = 300), `:42-46` (timestamp window check), `:48-67` (HMAC + timing-safe compare) | F-83 verified-clean — 5-min replay window + timing-safe compare |
+| Webhook plugin signature + replay | `plugins/webhook/src/routes.ts:31-60` | HMAC + API-key auth implemented; **no replay protection** (F-75) and **no per-channel rate limit** (F-76). The two together let a captured signed request burn unbounded LLM cost |
+| Other integrations | `routes/discord.ts`, `routes/teams.ts`, `lib/{telegram,gchat,github,linear,whatsapp}/store.ts` | OAuth-only / outbound message senders — no inbound webhook receivers. Verified by listing every `routes/*.ts` constructor and grepping for `webhook` / `signature` |
+| Demo route caps | `lib/demo.ts:24-58` (max steps default 10, RPM default 10), `routes/demo.ts` agent invocation | demo mode enforces a *separate* RPM bucket and a lower `ATLAS_DEMO_MAX_STEPS` (10 vs 25 for the main chat). Token-gated by HMAC-signed email — F-88 verified-clean |
+| Public-share routes | `routes/conversations.ts:1302-1407` (60 / 60s default), `routes/dashboards.ts:1133-1203` (30 / 60s default) | per-IP in-memory limiter exists. **Bypass when `ATLAS_TRUST_PROXY` is unset** because `getClientIP` returns `null` and the fallback `unknown-${requestId}` is per-request (F-73). Org-scoped shares additionally require auth and org-membership match |
+
+### Route inventory
+
+Same convention as Phase 4. Legend:
+
+- **Auth**: `admin` / `plat` (platform_admin) / `std` (any authenticated) / `inline` (handler authenticates explicitly) / `none` (unauthenticated) / `secret` (shared-secret token, e.g. CRON_SECRET)
+- **RL**: `g` (global `ATLAS_RATE_LIMIT_RPM` bucket from `checkRateLimit`), `p` (per-route in-memory limiter), `d` (demo limiter), `s` (per-source DB QPM via `withSourceSlot` for SQL-bearing routes), `n` (none)
+- **Timeout**: `req` (per-request budget), `tool` (per-tool-call SQL timeout / sandbox timeout), `n` (none — handler is a single read or write with no long-running work)
+
+| Mount | Auth | RL | Timeout | Notes |
+|---|---|---|---|---|
+| `POST /api/v1/chat` | inline | g | req + tool | 25-step + 180s + 30s/step + 5s/chunk; SQL via `withSourceSlot` (60 QPM / 5 concurrent default); plan + abuse + workspace status checks; F-74 / F-77 |
+| `GET  /api/health/...` | none | n | n | Static status response; no DB / LLM |
+| `*    /api/auth/*` | inline (Better Auth) | g | n | Catch-all to `getAuthInstance().handler`; signup body rewritten by `normalizeSignupResponseBody` to scrub error messages. Stripe webhook lives at `/api/auth/stripe/webhook` — F-82 verified |
+| `POST /api/v1/query` | inline | g | tool | One-shot SQL through tools/sql.ts; same caps as chat tool path |
+| `*    /api/v1/conversations` | std | g | n | CRUD on conversations (admin-RL bucket) |
+| `GET  /api/public/conversations/:token` | none | p | n | Public share view; **rate limit broken without `ATLAS_TRUST_PROXY` (F-73)** |
+| `*    /api/v1/dashboards` | std | g | n | CRUD on dashboards |
+| `GET  /api/public/dashboards/:token` | none | p | n | Same shape as conversations — F-73 applies |
+| `*    /api/v1/semantic` | std | g | n | Semantic-layer reads + diff |
+| `*    /api/v1/tables` | std | g | n | Table list / metadata |
+| `POST /api/v1/validate-sql` | inline | g | n | Pure validator — no execution |
+| `*    /api/v1/prompts` | std | g | n | Prompt library reads + writes |
+| `GET  /widget` | none | n | n | Static iframe HTML — no DB / LLM |
+| `GET  /widget/atlas-widget.{js,css}` | none | n | n | Static asset bundles loaded once at module init |
+| `GET  /widget.js` | none | n | n | Loader script (templated JS) |
+| `GET  /widget.d.ts` | none | n | n | TypeScript declarations |
+| `GET  /api/v1/branding` | none | n | n | Public branding read; cached + light DB |
+| `GET  /api/v1/onboarding-emails/...` | inline | g | n | Signed-token onboarding email list |
+| `GET  /api/v1/mode` | std | g | n | Returns published vs developer mode + draft counts |
+| `*    /api/v1/starter-prompts` | std | g | n | Adaptive starter prompts surface |
+| `*    /api/v1/onboarding/*` | std (per-route) | g | n | Self-serve signup flow; mixes std + inline |
+| `*    /api/v1/wizard/*` | admin | g | n | Guided semantic-layer setup |
+| `*    /api/v1/suggestions(/)` | std | g | n | Click-through tracking + suggestion list |
+| `*    /api/v1/demo/*` | inline | d | req | Demo mode with separate RPM (10 default) + lower step cap (10) — F-88 |
+| `*    /api/v1/actions/*` | std | g | n | Action approval flow (gated by `ATLAS_ACTIONS_ENABLED`) |
+| `*    /api/v1/scheduled-tasks/*` | admin | g | n | CRUD on scheduled tasks |
+| `POST /api/v1/scheduled-tasks/tick` | secret | n | tool | CRON_SECRET / ATLAS_SCHEDULER_SECRET via Bearer header; runs `runTick()` |
+| `*    /api/v1/sessions/*` | std | g | n | Self session-revoke surface |
+| `*    /api/v1/admin/*` | admin | g | n | Admin console mutations + reads (50+ routes); see Phase 4 audit table for the per-route audit detail. Includes `POST /api/v1/admin/publish` — atomic mode promotion, also `g`-bucketed |
+| `POST /api/v1/internal/migrate/import` | secret | n | n | `ATLAS_INTERNAL_SECRET` via `X-Atlas-Internal-Token`; cross-region import. **No body-size limit / per-call rate limit** (F-80) |
+| `*    /api/v1/platform/*` | plat | g | n | Cross-tenant platform admin |
+| `*    /api/v1/billing/*` | admin | g | n | Subscription status + Stripe portal redirects (Stripe webhook is at `/api/auth/stripe/webhook`) |
+| `POST /api/v1/slack/commands` | inline (Slack signature) | n | n | Acks within 3s, processes async; F-83 verified-clean |
+| `POST /api/v1/slack/events` | inline (Slack signature) | n | n | Same |
+| `POST /api/v1/slack/interactions` | inline (Slack signature) | n | n | Same |
+| `GET  /api/v1/slack/install` | admin | g | n | OAuth install (admin-gated post-Phase-1 F-04) |
+| `GET  /api/v1/slack/callback` | none | n | n | OAuth callback; state nonce single-use via `consumeOAuthState` (Phase 5 verified-clean) |
+| `*    /api/v1/teams/*` | mixed | g | n | OAuth + bot install; admin-gated paths use `adminAuthPreamble` |
+| `*    /api/v1/discord/*` | admin | g | n | OAuth-only outbound; no inbound webhook |
+| `POST /webhook/:channelId` (plugin) | inline (HMAC / API-key) | n | n | Webhook plugin entrypoint — **no replay protection (F-75), no per-channel rate limit (F-76)** |
+
+Total mounted route prefixes: 36 distinct app-level mounts. The `admin` / `platform` mounts each fan out into ~50 / ~25 inner routes respectively — those inherit the parent's auth + RL posture. `withSourceSlot` rate limit applies to every SQL execution path regardless of which route invoked it, so it's a defense-in-depth layer below the table.
+
+### Unauthenticated route inventory
+
+Hitting any of these without credentials:
+
+| Route | Handler | LLM? | Sandbox? | DB? | Risk |
+|---|---|---|---|---|---|
+| `GET /api/health/*` | static / pool stats | no | no | yes (pool counters) | low |
+| `GET /widget` | static HTML | no | no | no | low — static |
+| `GET /widget/atlas-widget.{js,css}` | static asset | no | no | no | low — static |
+| `GET /widget.js` | static loader | no | no | no | low — static |
+| `GET /widget.d.ts` | static .d.ts | no | no | no | low — static |
+| `GET /api/v1/branding` | branding row | no | no | yes | low — single keyed read |
+| `GET /api/public/conversations/:token` | shared conversation | no | no | yes | **F-73 rate-limit bypass** |
+| `GET /api/public/dashboards/:token` | shared dashboard | no | no | yes | **F-73 rate-limit bypass** |
+| `*    /api/auth/*` | Better Auth catch-all | no | no | yes | bounded by Better Auth's own rate limit + signup-email scrubber |
+| `POST /api/v1/onboarding/test-connection` (when ATLAS_AUTH_MODE=none) | DB connectivity test | no | no | yes | gated by managed-auth-or-self-host check inside the handler |
+| `GET /api/v1/slack/callback` | OAuth callback | no | no | yes | state nonce single-use; verified Phase 5 |
+| `POST /api/v1/slack/commands,events,interactions` | Slack signature inline | yes (eventually) | maybe | yes | signature verifies sender; 5-min replay window |
+| `POST /api/v1/scheduled-tasks/tick` | CRON_SECRET | yes (per scheduled task) | maybe | yes | shared-secret guard |
+| `POST /api/v1/internal/migrate/import` | ATLAS_INTERNAL_SECRET | no | no | yes | shared-secret guard; **F-80: no body-size limit** |
+| `POST /webhook/:channelId` (plugin) | HMAC / API-key inline | yes | maybe | yes | **F-75 / F-76** |
+
+**No unauthenticated route hits a paid surface (LLM / sandbox) without an upstream credential check.** The Slack / scheduled-tasks / webhook surfaces all gate on a signature or shared secret. The widget is static. The `*  /api/auth/*` catch-all is signup / login / Stripe webhook — Better Auth owns the cost shape.
+
+The closest call is `POST /webhook/:channelId` — once the channel secret is in the wrong hands, the handler bills the workspace operator for unbounded agent runs (F-75 + F-76). That's a credential-leak follow-on, not a primary unauth vector.
+
+**No P0 from the unauth inventory.**
+
+### Findings
+
+**F-73 — Public-share rate limit silently no-op without `ATLAS_TRUST_PROXY`** — P1
+
+**Location:** `packages/api/src/api/routes/conversations.ts:1329-1337`,
+`packages/api/src/api/routes/dashboards.ts:1140-1148`,
+`packages/api/src/lib/auth/middleware.ts:55-67`.
+
+**Observation:** Both public-share endpoints implement an in-memory
+per-IP rate limit (60 / 60s for conversations, 30 / 60s for
+dashboards). The bucket key is `getClientIP(req) ?? \`unknown-${requestId}\``.
+`getClientIP` only reads `x-forwarded-for` / `x-real-ip` when
+`ATLAS_TRUST_PROXY` is `\"true\"` or `\"1\"`; otherwise it returns
+`null`, and the `unknown-${requestId}` fallback creates a fresh
+`crypto.randomUUID()`-keyed bucket on every request. The bucket count
+starts at 1, never repeats, and the rate limit returns `true`
+indefinitely.
+
+**Attack shape:** Single attacker without `ATLAS_TRUST_PROXY` set runs
+`seq 1 1000 | xargs -P 32 curl ...` against
+`/api/public/conversations/:token` — server processes 32 concurrent
+DB reads / second sustained. Pressure lands directly on the internal
+Postgres (conversation + messages + notebook state for each call).
+The rate limit comment in code says \"rate limited per IP\" but the
+actual behavior depends on a separate operator decision that's easy to
+miss.
+
+**Score:** P1. Live in any deployment without `ATLAS_TRUST_PROXY`.
+Self-hosted operators behind a reverse proxy adding the canonical
+headers are routinely going to miss this env var.
+
+**Suggested fix sketch:** Drop the per-request fallback. Either bucket
+all anonymous traffic into a single `__public_unknown__` key (small
+RPM ceiling, e.g. 10/min, gates the no-IP slow path) or derive a
+stable surrogate from the `x-forwarded-for` header without trusting
+it for IP-allowlist purposes. Option (a) is the smaller diff and
+matches \"safe by default.\"
+
+**Issue:** #1844.
+
+---
+
+**F-74 — Single global RPM bucket conflates chat (25-step LLM) with cheap reads** — P2
+
+**Location:** `packages/api/src/lib/auth/middleware.ts:80-109`. Single
+`windows: Map<string, number[]>` keyed on user ID or IP, single global
+RPM ceiling (`ATLAS_RATE_LIMIT_RPM`).
+
+**Observation:** Every authenticated route increments the same bucket
+regardless of per-call cost. A chat request can fan out to 25 LLM
+calls + same number of tool calls. An audit-log read costs one
+Postgres query. Both subtract 1 from the same allowance. The
+middleware comment at line 76-78 explicitly acknowledges:
+
+> this limits API *requests*, not agent steps. A single chat request
+> may run up to 25 agent steps internally, so effective LLM call
+> volume can be higher than the RPM value implies.
+
+There is no per-route weighting and no per-route override. A SaaS
+deploy targeting cost-per-user budgets has to pick one RPM that
+satisfies both \"fair load on /chat\" and \"don't break /audit/log
+scrolling.\"
+
+**Attack shape:** Compromised user account inside a workspace burns
+the RPM ceiling on `/chat` for the full window, paying full LLM cost.
+Mitigated by per-source DB rate limit (60 QPM / 5 concurrent), agent
+step cap, agent wall-clock cap, plan-limit + abuse-detection — but no
+per-bucket weighting at the chat surface itself.
+
+**Score:** P2 — hardening, not a free-cost exploit. Cost ceiling per
+request is bounded; per-window cost ceiling is not.
+
+**Suggested fix sketch:** Two-tier RPM model — separate
+`ATLAS_RATE_LIMIT_RPM_CHAT` (default `max(5, RPM/4)`) wired into the
+chat handler, leaving the global RPM for cheap reads. Alternative:
+token-bucket weighting where chat counts as N tokens.
+
+**Issue:** #1845.
+
+---
+
+**F-75 — Webhook plugin has no replay-attack protection (no timestamp window)** — P2
+
+**Location:** `plugins/webhook/src/routes.ts:43-60` (`verifyHmac`),
+`:31-41` (`verifyApiKey`).
+
+**Observation:** Atlas's webhook plugin verifies inbound requests via
+HMAC-SHA256 or API-key (timing-safe). Neither verification path
+includes a timestamp / nonce — the signing input is the body alone.
+A captured signed request stays valid forever. Each replay triggers
+`executeQuery(query)` synchronously — full agent loop, full LLM cost,
+full sandbox concurrency consumption.
+
+Compare with Slack (`packages/api/src/lib/slack/verify.ts:42-46`)
+which rejects requests outside `Math.abs(now - ts) > 300` seconds. A
+5-minute timestamp window is the minimum bar for HMAC webhook signing.
+
+**Attack shape:** Attacker captures a signed webhook request from any
+upstream system (log scrape, MITM on a non-TLS internal hop,
+compromised upstream sender). Replays it at line speed — every replay
+invokes the full agent. Cost externality lands on the workspace
+operator.
+
+**Score:** P2. Exploit requires a captured signed request — that's a
+credential-leak follow-on, not a primary vector. But the cost ceiling
+once compromised is unbounded; the protection is the industry
+standard and trivially missing.
+
+**Suggested fix sketch:** Add `X-Webhook-Timestamp` (Unix seconds) to
+the signing input — `${timestamp}:${body}` — and reject when the
+delta is > 300s. Match the Slack pattern. Add a small recent-nonce
+cache for in-window replay.
+
+**Issue:** #1846.
+
+---
+
+**F-76 — Webhook plugin has no per-channel rate limit; one secret leak = unbounded agent invocations** — P2
+
+**Location:** `plugins/webhook/src/routes.ts:115-236`.
+
+**Observation:** Inbound `POST /webhook/:channelId` has no per-channel
+rate limit. After auth (`verifyApiKey` / `verifyHmac`) the handler
+calls `executeQuery(query)` synchronously, or in async mode runs
+`processAsync()` without any in-flight queue cap. A leaked channel
+secret produces unbounded agent runs until the operator notices.
+
+The natural ceiling is `withSourceSlot` (60 QPM / 5 concurrent
+default per datasource) — that bounds DB pressure, but not LLM token
+spend or sandbox concurrency, both of which are paid surfaces.
+
+**Attack shape:** Compromised channel secret → fire `POST
+/webhook/:channelId` at line speed. A small operator monthly LLM
+budget can be drained in minutes.
+
+**Score:** P2. Pairs with F-75; both ship together to make the
+webhook surface safe-by-default.
+
+**Suggested fix sketch:** Per-channel `rateLimitRpm` + `concurrencyLimit`
+on the `WebhookChannel` type. Borrow the `acquireSlot` /
+`withSourceSlot` shape from `lib/db/source-rate-limit.ts` (lift to
+`lib/throttle/` if shared with other plugins). Default to safe values
+(60 RPM, 3 concurrent) so channels configured without overrides still
+get a ceiling.
+
+**Issue:** #1847.
+
+---
+
+**F-77 — No aggregate per-conversation cost ceiling; unbounded agent runs across requests on the same conversationId** — P2
+
+**Location:** `packages/api/src/lib/conversations.ts` (no aggregate
+counter on conversations); `packages/api/src/api/routes/chat.ts:391`
+(`addMessage` appends without bound).
+
+**Observation:** Per-request caps are well-enforced — `stepCountIs(25)`,
+180s wall-clock budget, 30s/step, 5s/chunk. There's no aggregate
+budget across requests on the same conversation. A user can send N
+follow-up messages on the same `conversationId`, each consuming its
+own full budget. The conversation context grows monotonically (each
+follow-up replays the full message history), so per-message LLM cost
+grows roughly linearly with message count.
+
+Mitigations partially in place:
+- `checkAbuseStatus(orgId)` can throttle / suspend a workspace once
+  abuse-detection flags it.
+- `checkPlanLimits(orgId)` enforces SaaS plan ceilings.
+- `getRequestContext().user.id` ties chat to a user for billing.
+
+None of these enforce a per-conversation hard ceiling.
+
+**Attack shape:** Authenticated user with a large open conversation
+runs unbounded marginal cost on each follow-up. A 50-message ×
+25-step × ~3k-tokens conversation = ~3.75M tokens consumed against
+platform budget on one conversation, all within plan / abuse limits if
+the workspace is on a generous tier.
+
+**Score:** P2 — hardening. Not directly exploitable; pattern fragility
+becomes acute when notebook + scheduled-task surfaces lift the
+per-call ceiling further.
+
+**Suggested fix sketch:** Track `total_steps` (or `total_tokens`) on
+the `conversations` row. Reject new messages once the cap is hit; surface a
+`conversation_budget_exceeded` error code so the chat UI renders
+\"start a new conversation.\" Audit the rejection so abuse detection
+gets a signal.
+
+**Issue:** #1848.
+
+---
+
+### P3 noted-only
+
+**F-78 — `just-bash` explore backend has no wall-clock timeout** — P3
+
+`packages/api/src/lib/tools/explore.ts:40-81` builds the just-bash
+backend with `executionLimits: { maxCommandCount: 5000,
+maxLoopIterations: 1000 }`. Both are *count* limits; neither is a
+wall-clock guard. A pathological grep over a huge semantic dir under
+just-bash could run unbounded wall-clock time inside the JS process.
+
+Production warning is logged when just-bash is the active backend
+(\"SECURITY DEGRADATION: Explore tool running without process
+isolation\"). nsjail / sidecar / Vercel sandbox all have explicit
+wall-clock caps. Self-hosted dev fallback only — explicit operator
+intent.
+
+**Severity:** P3. Documented for completeness; no live exploit.
+
+**Status:** No issue filed.
+
+---
+
+**F-79 — Vercel Python sandbox has no Atlas-layer memory cap** — P3
+
+`packages/api/src/lib/tools/python-sandbox.ts:264-268` reads
+`ATLAS_PYTHON_TIMEOUT` for the per-execution timeout but does not
+configure a memory limit. Vercel's runtime applies its own caps; nsjail
+sets `--rlimit_as 512` (default 512MB,
+`packages/api/src/lib/tools/python-nsjail.ts:78`). Operators relying
+on Vercel get whatever Vercel applies (typically 1024MB default for
+the sandbox runtime; not surfaced in `@vercel/sandbox` API).
+
+**Severity:** P3 — platform-managed; documented for parity with the
+nsjail backend.
+
+**Status:** No issue filed.
+
+---
+
+**F-80 — Internal cross-region migrate `/import` has no body-size limit / per-call rate limit** — P3
+
+`packages/api/src/api/routes/admin-migrate.ts:354-410`. The endpoint
+authenticates via `ATLAS_INTERNAL_SECRET` shared secret (timing-safe
+compare). The bundle body has no upstream size limit and the call has
+no rate limit — a large or repeated import floods the internal Postgres.
+
+The shared secret is operator-controlled and never reaches a customer
+surface. A compromised secret would already give the attacker
+unbounded write into the internal DB; the body-size / rate-limit gap
+is a secondary concern after that. P3 hardening.
+
+**Severity:** P3 — hardening for a service-to-service surface.
+
+**Status:** No issue filed.
+
+---
+
+**F-81 — Global `ATLAS_RATE_LIMIT_RPM` defaults to 0 (rate limiting disabled)** — P3
+
+`packages/api/src/lib/auth/middleware.ts:34-46` returns 0 (\"disabled\")
+when the env var is unset. Operator opt-in. SaaS deploys
+(`app.useatlas.dev`) explicitly set this; self-hosted operators
+typically don't. Per-source DB rate limit (60 QPM / 5 concurrent)
+applies regardless and bounds DB pressure even when global RPM is off.
+
+**Severity:** P3 — operator-config gotcha. Documented for visibility.
+The fix lives in F-74 (per-route weighted bucket) — once that lands,
+the default-on conversation can reopen with a sensible ceiling.
+
+**Status:** No issue filed.
+
+---
+
+### Verified-clean rows (no finding)
+
+**F-82 — Stripe webhook signature + replay protection (Better Auth Stripe plugin)**
+
+`packages/api/src/lib/auth/server.ts:498-505` mounts the Better Auth
+Stripe plugin. Inbound `/api/auth/stripe/webhook` verifies signature
++ timestamp tolerance via `stripe.webhooks.constructEvent` —
+upstream Stripe SDK enforces a 5-minute timestamp window by default.
+`STRIPE_WEBHOOK_SECRET` is env-only (Phase 5 F-50 verified). Plugin
+is gated behind `STRIPE_SECRET_KEY` presence; without that the route
+is not mounted. Verified-clean.
+
+---
+
+**F-83 — Slack signature verification + 5-min timestamp window + timing-safe compare**
+
+`packages/api/src/lib/slack/verify.ts:13` (MAX_TIMESTAMP_AGE_SECONDS =
+300), `:42-46` (replay-window check), `:48-67` (HMAC-SHA256 +
+`crypto.timingSafeEqual`). All three Slack receivers
+(`/api/v1/slack/{commands,events,interactions}`) call `verifyRequest`
+before dispatching. Verified-clean.
+
+---
+
+**F-84 — Sandbox sidecar concurrency cap + 429 on overflow**
+
+`packages/sandbox-sidecar/src/server.ts:33-39` — `MAX_CONCURRENT = 10`,
+`activeExecs` counter incremented per request, 429 returned when at
+capacity. Both `/exec` (shell) and `/exec-python` paths share the
+counter. Sidecar request queue is implicit (Bun's HTTP server
+backpressure) but bounded by 10 in-flight × max-timeout (60s shell /
+120s python). Verified-clean.
+
+---
+
+**F-85 — Per-source DB rate limit (60 QPM / 5 concurrent default) on every datasource**
+
+`packages/api/src/lib/db/source-rate-limit.ts:24-27` (`DEFAULT_LIMIT`),
+`:76-110` (`acquireSlot`), `:112-133` (`withSourceSlot` Effect
+helper). Wraps every SQL execution path in
+`packages/api/src/lib/tools/sql.ts`. Failures map to 429 via
+`RateLimitExceededError` / `ConcurrencyLimitError` →
+`hono.ts:159-170`. Defense-in-depth — applies even when the global
+`ATLAS_RATE_LIMIT_RPM` is disabled. Verified-clean.
+
+---
+
+**F-86 — Connection pool LRU + drain cooldown + graceful 429 on capacity exceeded**
+
+`packages/api/src/lib/db/connection.ts:399-417` (defaults: per-org
+maxConnections=5, maxOrgs=50, drainThreshold=5; `maxTotalConnections=100`),
+`:552-646` (lazy create + LRU eviction), `:580-597` (capacity check
+throws `PoolCapacityExceededError`), `:909-931` (consecutive-failure
+auto-drain), `:1149-1166` (drain cooldown via Effect.sleep).
+`PoolCapacityExceededError` is mapped at `tools/sql.ts:553-559` to
+`PoolExhaustedError` → 429 (`hono.ts:169`). Pool exhaustion never
+crashes the process; the worst case is a graceful 429 to the caller.
+Verified-clean.
+
+---
+
+**F-87 — SQL row LIMIT + per-statement timeout enforced at driver layer for both PG and MySQL**
+
+`packages/api/src/lib/tools/sql.ts:1207-1212` auto-appends `LIMIT
+${rowLimit}` when not present (`ATLAS_ROW_LIMIT` default 1000).
+`packages/api/src/lib/db/connection.ts:281` runs `SET
+statement_timeout = ${timeoutMs}` per Postgres connection acquisition;
+`:319-326` runs `SET SESSION TRANSACTION READ ONLY` + `SET SESSION
+MAX_EXECUTION_TIME = ${safeTimeout}` per MySQL connection. Both apply
+the timeout at the *driver* layer — defense-in-depth even if the JS
+wrapper is bypassed. Verified-clean.
+
+---
+
+**F-88 — Demo mode separate rate limit (10 RPM) + lower max steps (10) + signed-token gate**
+
+`packages/api/src/lib/demo.ts:24-58` — `ATLAS_DEMO_RATE_LIMIT_RPM`
+(default 10, separate bucket from main `ATLAS_RATE_LIMIT_RPM`),
+`ATLAS_DEMO_MAX_STEPS` (default 10, range 1-100). Demo route gated
+by HMAC-SHA256-signed email token (`signDemoToken` /
+`verifyDemoToken`) derived from `BETTER_AUTH_SECRET` with `:demo`
+suffix. 24-hour token TTL. Verified-clean — the separate
+limiter + lower step cap are the intentional differential trust
+posture.
+
+---
+
+**F-89 — Agent loop step + wall-clock + per-step + per-chunk caps**
+
+`packages/api/src/lib/agent.ts:622-633` —
+`stopWhen: stepCountIs(maxStepsOverride ?? getAgentMaxSteps())`
+(default 25, env `ATLAS_AGENT_MAX_STEPS`, range 1-100); `timeout:
+{ totalMs: 180_000, stepMs: 30_000, chunkMs: 5_000 }`. The
+`getAgentMaxSteps()` reader (`:59-70`) clamps invalid values to the
+default and warns once per change. Demo override path sets a lower
+cap. Per-tool SQL timeout via `ATLAS_QUERY_TIMEOUT` flows through
+the validator pipeline. Verified-clean.
+
+---
+
+**F-90 — Widget assets unauth but static-only (no LLM, no DB)**
+
+`packages/api/src/api/routes/widget.ts` (3 routes), `widget-loader.ts`
+(2 routes). All four are `GET` with cached static content loaded
+once at module init from `@useatlas/react/dist`. No DB touch, no
+LLM, no per-request work beyond writing the cached body. Phase 5
+F-48 already verified the bundle reads zero env vars. Verified-clean.
+
+---
+
+**F-91 — Internal cross-region migration auth via timing-safe compare**
+
+`packages/api/src/api/routes/admin-migrate.ts:340-369` —
+`timingSafeCompare(token, secret)` over SHA-256 hashes of equal-length
+inputs. Empty token rejected. Missing env var rejected with 503.
+Verified-clean for the *auth* path; the body-size / rate-limit gap
+is tracked as F-80.
+
+---
+
+**F-92 — nsjail Python timeout + memory cap configurable, defaults 30s / 512MB**
+
+`packages/api/src/lib/tools/python-nsjail.ts:23-30` — `DEFAULT_TIME_LIMIT
+= 30`, `DEFAULT_MEMORY_LIMIT = 512MB`, `DEFAULT_NPROC = 16`. Override
+via `ATLAS_NSJAIL_TIME_LIMIT` / `ATLAS_NSJAIL_MEMORY_LIMIT`.
+`--rlimit_fsize 50` (50MB) caps chart output; `--rlimit_nofile 128`.
+nsjail `-u 65534 -g 65534` runs as nobody. Verified-clean.
+
+---
+
+### Considered, not filed
+
+- **Discord / Teams / Telegram / GChat / GitHub / Linear / WhatsApp
+  webhook receivers** — none exist. All seven integrations are
+  outbound-only (Atlas sends messages to those platforms via OAuth
+  bot tokens). No inbound webhook routes mounted in
+  `packages/api/src/api/index.ts`. Verified by listing every
+  `app.route(...)` line and grepping `routes/*.ts` for `webhook` /
+  `signature`.
+- **Public branding read (`GET /api/v1/branding`)** — single keyed
+  read, no per-IP rate limit but also no LLM / sandbox cost. Safe to
+  treat as a static surface.
+- **`POST /api/v1/internal/migrate/import` body-size limit** — see
+  F-80. Rolled into the same finding because the gap is operationally
+  paired (a missing body cap + missing rate limit produces the same
+  attack shape against the same operator-controlled secret).
+- **Better Auth signup rate limit** — Better Auth ships its own
+  rate limit on `/api/auth/sign-up/email`. Phase 1 F-05 already
+  reviewed the signup auth posture. No phase-6 concern.
+- **Plugin tool `runCommand` timeouts** — every datasource plugin
+  inherits the parent SQL pipeline's per-source rate limit + driver
+  timeout (verified F-85 / F-87). No plugin-level escape hatch.
+- **Concurrent agent runs per user** — there's no soft cap on
+  parallel `/chat` calls from the same user. Mitigated by the global
+  RPM bucket (when set), per-source DB limit, and abuse detection.
+  F-74 partially addresses this; revisit if a future incident shows
+  the abuse detector lagging.
+
+### Findings summary
+
+| ID | Severity | Type | Surface | Compliance lens | Issue | Status |
+|---|---|---|---|---|---|---|
+| F-73 | P1 | Live DoS surface | `/api/public/conversations/:token`, `/api/public/dashboards/:token` rate limit broken without `ATLAS_TRUST_PROXY` | SOC 2 CC6.6 / availability | #1844 | open |
+| F-74 | P2 | Hardening | Single global RPM bucket conflates chat (25-step) with cheap reads | — | #1845 | open |
+| F-75 | P2 | Replay protection gap | Webhook plugin has no timestamp-window check | SOC 2 CC6.7 | #1846 | open |
+| F-76 | P2 | Cost ceiling gap | Webhook plugin has no per-channel rate limit | — | #1847 | open |
+| F-77 | P2 | Hardening | No per-conversation aggregate budget cap | — | #1848 | open |
+| F-78 | P3 | Hardening | `just-bash` explore backend has no wall-clock timeout | — | — | noted |
+| F-79 | P3 | Hardening | Vercel python sandbox memory cap delegated to platform | — | — | noted |
+| F-80 | P3 | Hardening | Internal `/migrate/import` no body-size / rate limit | — | — | noted |
+| F-81 | P3 | Operator config | Global `ATLAS_RATE_LIMIT_RPM` defaults to 0 | — | — | noted |
+| F-82 | — | Verified-clean | Stripe webhook signature + replay (Better Auth + stripe SDK) | — | n/a | verified |
+| F-83 | — | Verified-clean | Slack signature + 5-min replay window + timing-safe | — | n/a | verified |
+| F-84 | — | Verified-clean | Sidecar concurrency cap (10) + 429 on overflow | — | n/a | verified |
+| F-85 | — | Verified-clean | Per-source DB rate limit (60 QPM / 5 concurrent) | — | n/a | verified |
+| F-86 | — | Verified-clean | Connection pool LRU + drain cooldown + 429 graceful degrade | — | n/a | verified |
+| F-87 | — | Verified-clean | SQL LIMIT + per-statement timeout at driver layer (PG + MySQL) | — | n/a | verified |
+| F-88 | — | Verified-clean | Demo mode separate RPM + lower max steps + signed-token gate | — | n/a | verified |
+| F-89 | — | Verified-clean | Agent loop step + wall-clock + step + chunk caps | — | n/a | verified |
+| F-90 | — | Verified-clean | Widget assets unauth but static-only | — | n/a | verified |
+| F-91 | — | Verified-clean | Internal migrate timing-safe compare + 503 on missing secret | — | n/a | verified |
+| F-92 | — | Verified-clean | nsjail Python timeout + memory + nproc + fsize + nofile caps | — | n/a | verified |
+
+**Totals:** P0 = 0, P1 = 1 (F-73), P2 = 4 (F-74 / F-75 / F-76 / F-77), P3 = 4 noted-only (F-78 / F-79 / F-80 / F-81), 11 verified-clean rows (F-82 – F-92). Pool-exhaustion behavior verified by code-read (load testing out of scope per the prompt). Numbering note: Phase 7 (parallel session) claimed F-73–F-80 first via tracker #1718; Phase 6 picked up at F-73 to avoid the clash. Phase 5 P3 notes (F-48–F-52) and Phase 7 (F-73–F-80) sit between.
+
+### Deliverables this PR
+
+- **This audit section** — route-inventory table + 5 P1/P2 issue-bearing
+  findings + 4 P3 noted-only + 11 affirmative-verification rows.
+- **5 GitHub issues filed** (#1844 – #1848) for every P0/P1/P2 finding.
+  Labels: `security` + `bug` (live flaw) or `chore` (hardening) + the
+  area label (`area: api` or `area: plugins`). Milestone
+  `1.2.3 — Security Sweep`.
+- **Phase-6 checkbox flipped** in tracker #1718.
+- **No production code changes** — fixes ship as follow-up PRs per the
+  phase-1/2/3/4/5 workflow. Suggested ordering: F-73 first (live DoS),
+  then the F-75 + F-76 webhook-plugin cluster (paired remediation),
+  then F-74 + F-77 (chat-bucket + per-conversation cap, both touch
+  `lib/auth/middleware.ts` + `routes/chat.ts`).
+
+---
+
 ## 1.2.3 Phase scorecard
 
 | Phase | Title | Audit status | Findings (P0 / P1 / P2 / P3) | Issues filed | Notes |
@@ -2334,7 +2960,7 @@ migration).
 | 3 | SQL validator edges + fuzz | complete | 0 / 1 / 2 / 2 | #1742 – #1746 | F-17 RLS header-forward fixed |
 | 4 | Audit-log coverage on write routes | complete | 5 / 5 / 5 / 3 | #1777 – #1791 | 15 findings; 9 fixed in-milestone (PR #1797–#1809) |
 | 5 | Secrets + error surfaces + plugin credentials | complete | 0 / 3 / 3 / 4 + 1 verified-clean | 6 P1/P2 issues filed | encryption-at-rest gap is the dominant pattern; no P0 |
-| 6 | Rate limiting + DoS | not started | — | — | #1725 (pending) |
-| 7 | Enterprise governance paths | not started | — | — | #1726 (pending) |
+| 6 | Rate limiting + DoS | complete | 0 / 1 / 4 / 4 + 11 verified-clean | #1844 – #1848 | F-73 is the only live finding; webhook plugin cluster (F-75 / F-76) is P2 hardening. Numbering jumps to F-73 because Phase 7 (parallel session) claimed F-53–F-60 first |
+| 7 | Enterprise governance paths | parallel session — see #1718 | — | #1849 – #1853 | Parallel-session audit; F-53–F-60 used by Phase 7 |
 
-**Cross-phase totals (phases 1–5):** P0 = 8, P1 = 12, P2 = 18, P3 = 15. No current P0 open; remediation for Phase 5 P1/P2 clustered into follow-up PRs after the audit lands.
+**Cross-phase totals (phases 1–6, plus Phase 7 sibling):** P0 = 8, P1 = 13, P2 = 22, P3 = 19 (Phase 6 alone). Phase 7 totals as reported in tracker #1718. No current P0 open; remediation for Phase 5 P1/P2 + Phase 6 P1/P2 clustered into follow-up PRs after each audit lands.


### PR DESCRIPTION
## Summary

Phase 6 of the 1.2.3 security sweep (tracking #1718). Audit-only — no production code changes. Each P1/P2 finding ships as its own follow-up PR (mirrors phases 1–5).

Closes #1725.

## What was walked

- Agent loop step + wall-clock + per-step + per-chunk caps
- SQL row LIMIT + per-statement timeout enforcement at driver layer (PG + MySQL)
- Connection pool capacity + LRU eviction + drain cooldown + 429 graceful degrade
- Per-user / per-org throttles on every authenticated route
- Unauthenticated route inventory — nothing paid (LLM / sandbox) hit without an upstream credential check
- Python sandbox timeouts + memory caps + queue cap across all backends (sidecar / nsjail / Vercel / plugin / just-bash)
- Webhook signature + replay + rate-limit posture on every receiver (Stripe / Slack / webhook plugin); confirmed Discord / Teams / Telegram / GChat / GitHub / Linear / WhatsApp expose no inbound webhooks

## Findings

| Severity | Count | IDs |
|---|---|---|
| P0 | 0 | — |
| P1 | 1 | F-73 (#1844) — public-share rate limit silently no-op without `ATLAS_TRUST_PROXY` |
| P2 | 4 | F-74 (#1845) chat shares cheap-route RPM bucket; F-75 (#1846) webhook plugin no replay protection; F-76 (#1847) webhook plugin no per-channel rate limit; F-77 (#1848) no per-conversation aggregate budget cap |
| P3 noted-only | 4 | F-78 just-bash no wall-clock; F-79 Vercel python no Atlas-layer memory cap; F-80 internal `/migrate/import` no body-size limit; F-81 `ATLAS_RATE_LIMIT_RPM` defaults to 0 |
| Verified-clean | 11 | F-82..F-92 — Stripe / Slack / sidecar / pool / SQL / demo / agent / widget / internal-migrate / nsjail |

**Numbering note:** A parallel session ran Phase 7 concurrently and claimed F-53..F-60 first via tracker #1718. Phase 6 picks up at F-73 to avoid duplicate finding IDs. F-IDs F-61..F-72 are intentionally unused.

## Suggested remediation order

1. **F-73** first — only live finding; small fix in `routes/conversations.ts` + `routes/dashboards.ts`
2. **F-75 + F-76 cluster** — webhook plugin replay + per-channel rate limit; both touch `plugins/webhook/src/routes.ts`
3. **F-74 + F-77** — chat-bucket split + per-conversation aggregate cap; both touch `lib/auth/middleware.ts` + `routes/chat.ts`

## Tracker

- Phase 6 checkbox flipped in #1718 with finding summary inline
- 5 GH issues filed (#1844–#1848) with `security` + `bug`/`chore` + area labels, milestone `1.2.3 — Security Sweep`

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [ ] `bun run test` — running locally; doc-only change so source graph isn't touched
- [x] `bun x syncpack lint` — `No issues found`
- [x] `bash scripts/check-template-drift.sh` — passed (439 files)
- [x] `bash scripts/check-railway-watch.sh` — `all deploy Dockerfile COPY sources are covered`