### PR TITLE
feat(security): F-73 + F-74 + F-77 — rate-limit cluster

### DIFF
--- a/.claude/research/security-audit-1-2-3.md
+++ b/.claude/research/security-audit-1-2-3.md
@@ -2929,11 +2929,11 @@ nsjail `-u 65534 -g 65534` runs as nobody. Verified-clean.
 
 | ID | Severity | Type | Surface | Compliance lens | Issue | Status |
 |---|---|---|---|---|---|---|
-| F-73 | P1 | Live DoS surface | `/api/public/conversations/:token`, `/api/public/dashboards/:token` rate limit broken without `ATLAS_TRUST_PROXY` | SOC 2 CC6.6 / availability | #1844 | open |
-| F-74 | P2 | Hardening | Single global RPM bucket conflates chat (25-step) with cheap reads | — | #1845 | open |
+| F-73 | P1 | Live DoS surface | `/api/public/conversations/:token`, `/api/public/dashboards/:token` rate limit broken without `ATLAS_TRUST_PROXY` | SOC 2 CC6.6 / availability | #1844 | shipped |
+| F-74 | P2 | Hardening | Single global RPM bucket conflates chat (25-step) with cheap reads | — | #1845 | shipped |
 | F-75 | P2 | Replay protection gap | Webhook plugin has no timestamp-window check | SOC 2 CC6.7 | #1846 | shipped |
 | F-76 | P2 | Cost ceiling gap | Webhook plugin has no per-channel rate limit | — | #1847 | shipped |
-| F-77 | P2 | Hardening | No per-conversation aggregate budget cap | — | #1848 | open |
+| F-77 | P2 | Hardening | No per-conversation aggregate budget cap | — | #1848 | shipped |
 | F-78 | P3 | Hardening | `just-bash` explore backend has no wall-clock timeout | — | — | noted |
 | F-79 | P3 | Hardening | Vercel python sandbox memory cap delegated to platform | — | — | noted |
 | F-80 | P3 | Hardening | Internal `/migrate/import` no body-size / rate limit | — | — | noted |

--- a/.env.example
+++ b/.env.example
@@ -87,7 +87,13 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # ATLAS_AUTH_ROLE_CLAIM=role              # JWT claim path for BYOT role extraction (supports nested: app_metadata.role)
 # ATLAS_API_KEY_ROLE=analyst              # Role for simple-key auth (viewer/analyst/admin)
 # ATLAS_RATE_LIMIT_RPM=30                 # Max requests per minute per user (0 = disabled)
-# ATLAS_TRUST_PROXY=false                 # Trust X-Forwarded-For for client IP (set "true" behind a reverse proxy)
+# ATLAS_RATE_LIMIT_RPM_CHAT=               # Chat-stream RPM ceiling, separate bucket from cheap reads (F-74).
+#                                         # Defaults to max(5, RPM/4) so a 25-step LLM call does not deplete
+#                                         # the same allowance that serves audit-log scrolling and similar
+#                                         # cheap reads. Disabled when ATLAS_RATE_LIMIT_RPM is 0.
+# ATLAS_TRUST_PROXY=false                 # Trust X-Forwarded-For for client IP (set "true" behind a reverse proxy).
+#                                         # Public-share routes bucket all anonymous (no-IP) requests into a
+#                                         # single 10/min ceiling when this is unset (F-73).
 #
 # === Better Auth hardening (managed auth only) ===
 # ATLAS_REQUIRE_EMAIL_VERIFICATION=true   # Require email verification on signup. Default: true.
@@ -129,6 +135,11 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 
 # === Agent ===
 # ATLAS_AGENT_MAX_STEPS=25     # Default: 25, range 1–100. Max tool-call steps per agent run
+# ATLAS_CONVERSATION_STEP_CAP=500           # Aggregate step ceiling per conversation (F-77).
+#                                           # Default 500 = 20 follow-ups × 25 steps. Once total_steps
+#                                           # crosses this value the chat handler returns 429
+#                                           # `conversation_budget_exceeded` and the UI offers to start
+#                                           # a new conversation. Set 0 to disable.
 
 # === Semantic Expert ===
 # ATLAS_EXPERT_SCHEDULER_ENABLED=false    # Enable periodic semantic layer analysis

--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -518,6 +518,9 @@ export function createApiTestMocks(
     createConversation: mock(() => Promise.resolve(null)),
     addMessage: mock(() => {}),
     persistAssistantSteps: mock(() => {}),
+    // F-77 step-cap helpers — chat.ts imports both via @atlas/api/lib/conversations.
+    reserveConversationBudget: mock(() => Promise.resolve({ status: "ok" as const, totalStepsBefore: 0 })),
+    settleConversationSteps: mock(() => {}),
     getConversation: mock(() => Promise.resolve(null)),
     generateTitle: mock((q: string) => q.slice(0, 80)),
     listConversations: mock(() =>

--- a/packages/api/src/api/__tests__/actions.test.ts
+++ b/packages/api/src/api/__tests__/actions.test.ts
@@ -120,6 +120,9 @@ mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
   persistAssistantSteps: mock(() => {}),
+  // F-77 step-cap helpers — chat.ts imports both via @atlas/api/lib/conversations.
+  reserveConversationBudget: mock(() => Promise.resolve({ status: 'ok' as const, totalStepsBefore: 0 })),
+  settleConversationSteps: mock(() => {}),
   generateTitle: mock(() => "Test title"),
   starConversation: async () => false,
   shareConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),

--- a/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
+++ b/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
@@ -284,6 +284,9 @@ mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
   persistAssistantSteps: mock(() => {}),
+  // F-77 step-cap helpers — chat.ts imports both via @atlas/api/lib/conversations.
+  reserveConversationBudget: mock(() => Promise.resolve({ status: 'ok' as const, totalStepsBefore: 0 })),
+  settleConversationSteps: mock(() => {}),
   getConversation: mock(() => Promise.resolve(null)),
   generateTitle: mock((q: string) => q.slice(0, 80)),
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
@@ -340,6 +340,9 @@ mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
   persistAssistantSteps: mock(() => {}),
+  // F-77 step-cap helpers — chat.ts imports both via @atlas/api/lib/conversations.
+  reserveConversationBudget: mock(() => Promise.resolve({ status: 'ok' as const, totalStepsBefore: 0 })),
+  settleConversationSteps: mock(() => {}),
   getConversation: mock(() => Promise.resolve(null)),
   generateTitle: mock((q: string) => q.slice(0, 80)),
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/packages/api/src/api/__tests__/admin-integrations.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations.test.ts
@@ -264,6 +264,9 @@ mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
   persistAssistantSteps: mock(() => {}),
+  // F-77 step-cap helpers — chat.ts imports both via @atlas/api/lib/conversations.
+  reserveConversationBudget: mock(() => Promise.resolve({ status: 'ok' as const, totalStepsBefore: 0 })),
+  settleConversationSteps: mock(() => {}),
   getConversation: mock(() => Promise.resolve(null)),
   generateTitle: mock((q: string) => q.slice(0, 80)),
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/packages/api/src/api/__tests__/admin-invitations.test.ts
+++ b/packages/api/src/api/__tests__/admin-invitations.test.ts
@@ -212,6 +212,9 @@ mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
   persistAssistantSteps: mock(() => {}),
+  // F-77 step-cap helpers — chat.ts imports both via @atlas/api/lib/conversations.
+  reserveConversationBudget: mock(() => Promise.resolve({ status: 'ok' as const, totalStepsBefore: 0 })),
+  settleConversationSteps: mock(() => {}),
   getConversation: mock(() => Promise.resolve(null)),
   generateTitle: mock((q: string) => q.slice(0, 80)),
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/packages/api/src/api/__tests__/admin-password.test.ts
+++ b/packages/api/src/api/__tests__/admin-password.test.ts
@@ -196,6 +196,9 @@ mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
   persistAssistantSteps: mock(() => {}),
+  // F-77 step-cap helpers — chat.ts imports both via @atlas/api/lib/conversations.
+  reserveConversationBudget: mock(() => Promise.resolve({ status: 'ok' as const, totalStepsBefore: 0 })),
+  settleConversationSteps: mock(() => {}),
   getConversation: mock(() => Promise.resolve(null)),
   generateTitle: mock((q: string) => q.slice(0, 80)),
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -437,6 +437,9 @@ mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
   persistAssistantSteps: mock(() => {}),
+  // F-77 step-cap helpers — chat.ts imports both via @atlas/api/lib/conversations.
+  reserveConversationBudget: mock(() => Promise.resolve({ status: 'ok' as const, totalStepsBefore: 0 })),
+  settleConversationSteps: mock(() => {}),
   getConversation: mock(() => Promise.resolve(null)),
   generateTitle: mock((q: string) => q.slice(0, 80)),
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/packages/api/src/api/__tests__/chat.test.ts
+++ b/packages/api/src/api/__tests__/chat.test.ts
@@ -249,6 +249,22 @@ describe("POST /api/v1/chat", () => {
     expect(response.headers.get("content-type")).toContain("text/event-stream");
   });
 
+  // F-74 regression pin: the chat handler MUST pass `bucket: "chat"` so the
+  // request lands in the chat-scoped sliding window. Without this option a
+  // 25-step agent run drains the same allowance that serves cheap admin
+  // reads. Asserting the second argument here catches a refactor that drops
+  // the option object — `mockCheckRateLimit` would still gate but the
+  // F-74 isolation acceptance criterion would silently regress.
+  it("F-74 — chat handler debits the chat bucket", async () => {
+    const response = await app.fetch(makeRequest());
+    expect(response.status).toBe(200);
+    expect(mockCheckRateLimit).toHaveBeenCalledTimes(1);
+    const calls = mockCheckRateLimit.mock.calls as unknown as unknown[][];
+    const args = calls[0]!;
+    // Second argument must carry { bucket: "chat" }.
+    expect(args[1]).toEqual({ bucket: "chat" });
+  });
+
   it("returns 401 when authenticateRequest returns unauthenticated", async () => {
     mockAuthenticateRequest.mockResolvedValueOnce({
       authenticated: false as const,
@@ -455,6 +471,44 @@ describe("POST /api/v1/chat", () => {
       const settleCalls = mockSettleConversationSteps.mock.calls as unknown as unknown[][];
       expect(settleCalls.length).toBe(1);
       expect(settleCalls[0]).toEqual([convId, 5, 3]);
+
+      delete process.env.ATLAS_AGENT_MAX_STEPS;
+    });
+
+    // Conservative cost-accounting pin: when the agent stream rejects mid-
+    // flight the reservation MUST stay charged (settlement is skipped).
+    // Otherwise an attacker could spin up streams that fail mid-flight to
+    // refund their full budget — exactly the abuse vector the F-77 cap is
+    // designed to bound.
+    it("does not settle when the agent stream rejects (reservation stays charged)", async () => {
+      process.env.ATLAS_CONVERSATION_STEP_CAP = "10";
+      process.env.ATLAS_AGENT_MAX_STEPS = "5";
+      mockGetConversationChat.mockResolvedValueOnce({
+        ok: true,
+        data: { id: convId, userId: null, title: "Test", messages: [] },
+      });
+      mockReserveConversationBudget.mockResolvedValueOnce({
+        status: "ok",
+        totalStepsBefore: 0,
+      });
+      // Suppress the unhandled-rejection log noise; the catch in chat.ts
+      // owns the rejection.
+      const stepsRejection = Promise.reject(new Error("stream blew up"));
+      stepsRejection.catch(() => undefined);
+      mockRunAgent.mockResolvedValueOnce({
+        toUIMessageStreamResponse: () => new Response("stream", { status: 200 }),
+        toUIMessageStream: () => new ReadableStream({ start(c) { c.close(); } }),
+        text: Promise.resolve("answer"),
+        steps: stepsRejection,
+      } as unknown as Awaited<ReturnType<typeof mockRunAgent>>);
+
+      const response = await app.fetch(makeFollowUp());
+      expect(response.status).toBe(200);
+      // Flush the fire-and-forget chain.
+      await Promise.resolve();
+      await Promise.resolve();
+      // Settlement must NOT have run — the full reservation stays charged.
+      expect(mockSettleConversationSteps).not.toHaveBeenCalled();
 
       delete process.env.ATLAS_AGENT_MAX_STEPS;
     });

--- a/packages/api/src/api/__tests__/chat.test.ts
+++ b/packages/api/src/api/__tests__/chat.test.ts
@@ -122,13 +122,25 @@ const mockCreateConversation = mock((): Promise<{ id: string } | null> =>
 const mockAddMessage = mock(() => {});
 const mockGetConversationChat = mock((): Promise<{ ok: boolean; reason?: string; data?: unknown }> => Promise.resolve({ ok: false, reason: "not_found" }));
 const mockGenerateTitle = mock((q: string) => q.slice(0, 80));
+type ReservationResult =
+  | { status: "ok"; totalStepsBefore: number }
+  | { status: "exceeded"; totalSteps: number }
+  | { status: "no_db" }
+  | { status: "error" };
+const mockReserveConversationBudget = mock(
+  (): Promise<ReservationResult> => Promise.resolve({ status: "ok", totalStepsBefore: 0 }),
+);
+const mockSettleConversationSteps = mock(() => {});
+const mockPersistAssistantSteps = mock(() => {});
 
 mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mockCreateConversation,
   addMessage: mockAddMessage,
-  persistAssistantSteps: mock(() => {}),
+  persistAssistantSteps: mockPersistAssistantSteps,
   getConversation: mockGetConversationChat,
   generateTitle: mockGenerateTitle,
+  reserveConversationBudget: mockReserveConversationBudget,
+  settleConversationSteps: mockSettleConversationSteps,
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),
   deleteConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   starConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
@@ -190,7 +202,12 @@ describe("POST /api/v1/chat", () => {
     mockAddMessage.mockReset();
     mockGetConversationChat.mockReset();
     mockGetConversationChat.mockResolvedValue({ ok: false, reason: "not_found" });
+    mockReserveConversationBudget.mockReset();
+    mockReserveConversationBudget.mockResolvedValue({ status: "ok", totalStepsBefore: 0 });
+    mockSettleConversationSteps.mockReset();
+    mockPersistAssistantSteps.mockReset();
     delete process.env.ATLAS_ACTIONS_ENABLED;
+    delete process.env.ATLAS_CONVERSATION_STEP_CAP;
     mockGetPluginTools.mockReset();
     mockGetPluginTools.mockReturnValue(undefined);
   });
@@ -365,6 +382,138 @@ describe("POST /api/v1/chat", () => {
     expect(response.headers.get("x-conversation-id")).toBe(convId);
     expect(mockCreateConversation).not.toHaveBeenCalled();
     expect(mockAddMessage).toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------
+  // F-77 — per-conversation aggregate step ceiling
+  // ---------------------------------------------------------------------
+
+  describe("F-77 — conversation budget ceiling", () => {
+    const convId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+    function makeFollowUp(): Request {
+      return makeRequest({
+        messages: [{ id: "1", role: "user", parts: [{ type: "text", text: "follow up" }] }],
+        conversationId: convId,
+      });
+    }
+
+    it("rejects with conversation_budget_exceeded when reservation is over the cap", async () => {
+      process.env.ATLAS_CONVERSATION_STEP_CAP = "10";
+      mockGetConversationChat.mockResolvedValueOnce({
+        ok: true,
+        data: { id: convId, userId: null, title: "Test", messages: [] },
+      });
+      // Atomic reservation rejects — the gate is enforced at the row, not
+      // at the application. The pre-check failure must short-circuit before
+      // the agent runs.
+      mockReserveConversationBudget.mockResolvedValueOnce({
+        status: "exceeded",
+        totalSteps: 10,
+      });
+
+      const response = await app.fetch(makeFollowUp());
+      expect(response.status).toBe(429);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("conversation_budget_exceeded");
+      expect(body.retryable).toBe(false);
+      expect(typeof body.requestId).toBe("string");
+      // Agent must not have been invoked.
+      expect(mockRunAgent).not.toHaveBeenCalled();
+      // Settlement should not run on the rejection path.
+      expect(mockSettleConversationSteps).not.toHaveBeenCalled();
+    });
+
+    it("allows the request when reservation succeeds and settles after the stream", async () => {
+      process.env.ATLAS_CONVERSATION_STEP_CAP = "10";
+      process.env.ATLAS_AGENT_MAX_STEPS = "5";
+      mockGetConversationChat.mockResolvedValueOnce({
+        ok: true,
+        data: { id: convId, userId: null, title: "Test", messages: [] },
+      });
+      mockReserveConversationBudget.mockResolvedValueOnce({
+        status: "ok",
+        totalStepsBefore: 5,
+      });
+      // Stream resolves with 3 actual steps so settlement refunds 5 - 3 = 2.
+      mockRunAgent.mockResolvedValueOnce({
+        toUIMessageStreamResponse: () => new Response("stream", { status: 200 }),
+        toUIMessageStream: () => new ReadableStream({ start(c) { c.close(); } }),
+        text: Promise.resolve("answer"),
+        steps: Promise.resolve([{}, {}, {}]),
+      } as unknown as Awaited<ReturnType<typeof mockRunAgent>>);
+
+      const response = await app.fetch(makeFollowUp());
+      expect(response.status).toBe(200);
+      // Reservation must be charged with the full agent step budget upfront.
+      const reserveCalls = mockReserveConversationBudget.mock.calls as unknown as unknown[][];
+      expect(reserveCalls.length).toBe(1);
+      expect(reserveCalls[0]).toEqual([convId, 5, 10]);
+      // Wait for the fire-and-forget settlement promise chain to flush.
+      await Promise.resolve();
+      await Promise.resolve();
+      const settleCalls = mockSettleConversationSteps.mock.calls as unknown as unknown[][];
+      expect(settleCalls.length).toBe(1);
+      expect(settleCalls[0]).toEqual([convId, 5, 3]);
+
+      delete process.env.ATLAS_AGENT_MAX_STEPS;
+    });
+
+    it("disables the gate when ATLAS_CONVERSATION_STEP_CAP=0", async () => {
+      process.env.ATLAS_CONVERSATION_STEP_CAP = "0";
+      mockGetConversationChat.mockResolvedValueOnce({
+        ok: true,
+        data: { id: convId, userId: null, title: "Test", messages: [] },
+      });
+
+      const response = await app.fetch(makeFollowUp());
+      expect(response.status).toBe(200);
+      // Reservation must NOT be attempted when the cap is disabled.
+      expect(mockReserveConversationBudget).not.toHaveBeenCalled();
+    });
+
+    it("fails open when reservation returns no_db (internal DB unavailable)", async () => {
+      process.env.ATLAS_CONVERSATION_STEP_CAP = "10";
+      mockGetConversationChat.mockResolvedValueOnce({
+        ok: true,
+        data: { id: convId, userId: null, title: "Test", messages: [] },
+      });
+      mockReserveConversationBudget.mockResolvedValueOnce({ status: "no_db" });
+
+      // Fail-open: a transient internal-DB glitch must not 429 the chat surface.
+      const response = await app.fetch(makeFollowUp());
+      expect(response.status).toBe(200);
+      // No reservation was charged → no settlement either.
+      expect(mockSettleConversationSteps).not.toHaveBeenCalled();
+    });
+
+    it("fails open when reservation returns error (read/write threw)", async () => {
+      process.env.ATLAS_CONVERSATION_STEP_CAP = "10";
+      mockGetConversationChat.mockResolvedValueOnce({
+        ok: true,
+        data: { id: convId, userId: null, title: "Test", messages: [] },
+      });
+      mockReserveConversationBudget.mockResolvedValueOnce({ status: "error" });
+
+      const response = await app.fetch(makeFollowUp());
+      expect(response.status).toBe(200);
+      expect(mockSettleConversationSteps).not.toHaveBeenCalled();
+    });
+
+    it("invalid ATLAS_CONVERSATION_STEP_CAP falls back to default 500", async () => {
+      process.env.ATLAS_CONVERSATION_STEP_CAP = "abc";
+      mockGetConversationChat.mockResolvedValueOnce({
+        ok: true,
+        data: { id: convId, userId: null, title: "Test", messages: [] },
+      });
+
+      const response = await app.fetch(makeFollowUp());
+      expect(response.status).toBe(200);
+      // Reservation must have been called with the default cap of 500.
+      const reserveCalls = mockReserveConversationBudget.mock.calls as unknown as unknown[][];
+      expect(reserveCalls.length).toBe(1);
+      expect(reserveCalls[0]?.[2]).toBe(500);
+    });
   });
 
   it("returns 200 without x-conversation-id when createConversation fails", async () => {

--- a/packages/api/src/api/__tests__/conversations.test.ts
+++ b/packages/api/src/api/__tests__/conversations.test.ts
@@ -129,6 +129,10 @@ mock.module("@atlas/api/lib/conversations", () => ({
   addMessage: mockAddMessage,
   generateTitle: mockGenerateTitle,
   persistAssistantSteps: mock(() => {}),
+  // F-77 step-cap helpers — chat.ts imports both. Default to "no budget
+  // consumed yet" so existing tests (which don't exercise the cap) pass.
+  reserveConversationBudget: mock(() => Promise.resolve({ status: "ok" as const, totalStepsBefore: 0 })),
+  settleConversationSteps: mock(() => {}),
   updateNotebookState: mockUpdateNotebookState,
   forkConversation: mockForkConversation,
   convertToNotebook: mockConvertToNotebook,
@@ -185,8 +189,14 @@ mock.module("@atlas/ee/auth/ip-allowlist", () => ({
   checkIPAllowlist: () => _EffectForAllowlistMock.succeed({ allowed: true as const }),
 }));
 
-// Import after mocks
+// Import after mocks. Dynamic imports avoid hoisting routes/conversations.ts
+// past the mock.module() calls — a static `import` would load the module
+// before the logger mock applies, leaving public-rate-limit warns going
+// through real pino and the route logs uncaptured (F-73 wiring).
 const { app } = await import("../index");
+// Reset the public-share rate limiter between tests so the new shared
+// anonymous-bucket ceiling (F-73) does not exhaust across the suite.
+const { _resetConversationRateLimit } = await import("../routes/conversations");
 
 // Valid UUID for tests — routes now validate UUID format on :id params
 const VALID_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
@@ -213,6 +223,7 @@ describe("conversations routes", () => {
     mockCheckRateLimit.mockReturnValue({ allowed: true });
     mockGetClientIP.mockReset();
     mockGetClientIP.mockReturnValue(null);
+    _resetConversationRateLimit();
     mockListConversations.mockReset();
     mockListConversations.mockResolvedValue({ conversations: [], total: 0 });
     mockGetConversation.mockReset();

--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -226,6 +226,9 @@ mock.module("@atlas/api/lib/conversations", () => ({
   convertToNotebook: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   deleteBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
+  // F-77 step-cap helpers — chat.ts imports both via the shared module.
+  reserveConversationBudget: mock(() => Promise.resolve({ status: "ok" as const, totalStepsBefore: 0 })),
+  settleConversationSteps: mock(() => {}),
 }));
 
 mock.module("@atlas/api/lib/semantic", () => ({
@@ -280,8 +283,14 @@ mock.module("@atlas/api/lib/config", () => ({
 import { createConnectionMock } from "@atlas/api/testing/connection";
 mock.module("@atlas/api/lib/db/connection", () => createConnectionMock());
 
-// Import after all mocks
+// Import after all mocks. The dynamic import avoids hoisting routes/dashboards.ts
+// past the mock.module() calls — a static `import` would load the module before
+// the logger mock applies, leaving the public-rate-limit warn going through
+// real pino and the route logs uncaptured.
 const { app } = await import("../index");
+// Reset the public-share rate limiter between tests so the new shared
+// anonymous-bucket ceiling (F-73) does not exhaust across the suite.
+const { _resetDashboardRateLimit } = await import("../routes/dashboards");
 
 describe("dashboard routes", () => {
   const origDatabaseUrl = process.env.DATABASE_URL;
@@ -299,6 +308,7 @@ describe("dashboard routes", () => {
     mockCheckRateLimit.mockReturnValue({ allowed: true });
     mockGetClientIP.mockReset();
     mockGetClientIP.mockReturnValue(null);
+    _resetDashboardRateLimit();
 
     // Reset dashboard mocks
     mockCreateDashboard.mockReset();

--- a/packages/api/src/api/__tests__/health-plugin.test.ts
+++ b/packages/api/src/api/__tests__/health-plugin.test.ts
@@ -109,6 +109,9 @@ mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
   persistAssistantSteps: mock(() => {}),
+  // F-77 step-cap helpers — chat.ts imports both via @atlas/api/lib/conversations.
+  reserveConversationBudget: mock(() => Promise.resolve({ status: 'ok' as const, totalStepsBefore: 0 })),
+  settleConversationSteps: mock(() => {}),
   getConversation: mock(() => Promise.resolve(null)),
   generateTitle: mock((q: string) => q.slice(0, 80)),
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/packages/api/src/api/__tests__/health.test.ts
+++ b/packages/api/src/api/__tests__/health.test.ts
@@ -114,6 +114,9 @@ mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
   persistAssistantSteps: mock(() => {}),
+  // F-77 step-cap helpers — chat.ts imports both via @atlas/api/lib/conversations.
+  reserveConversationBudget: mock(() => Promise.resolve({ status: 'ok' as const, totalStepsBefore: 0 })),
+  settleConversationSteps: mock(() => {}),
   getConversation: mock(() => Promise.resolve(null)),
   generateTitle: mock((q: string) => q.slice(0, 80)),
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/packages/api/src/api/__tests__/query.test.ts
+++ b/packages/api/src/api/__tests__/query.test.ts
@@ -138,6 +138,9 @@ mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mockCreateConversationQuery,
   addMessage: mockAddMessageQuery,
   persistAssistantSteps: mock(() => {}),
+  // F-77 step-cap helpers — chat.ts imports both via @atlas/api/lib/conversations.
+  reserveConversationBudget: mock(() => Promise.resolve({ status: 'ok' as const, totalStepsBefore: 0 })),
+  settleConversationSteps: mock(() => {}),
   getConversation: mockGetConversationQuery,
   generateTitle: mockGenerateTitleQuery,
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/packages/api/src/api/__tests__/scheduled-tasks.test.ts
+++ b/packages/api/src/api/__tests__/scheduled-tasks.test.ts
@@ -101,6 +101,9 @@ mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
   persistAssistantSteps: mock(() => {}),
+  // F-77 step-cap helpers — chat.ts imports both via @atlas/api/lib/conversations.
+  reserveConversationBudget: mock(() => Promise.resolve({ status: 'ok' as const, totalStepsBefore: 0 })),
+  settleConversationSteps: mock(() => {}),
   generateTitle: mock(() => "Test title"),
   starConversation: async () => false,
   shareConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),

--- a/packages/api/src/api/__tests__/semantic.test.ts
+++ b/packages/api/src/api/__tests__/semantic.test.ts
@@ -248,6 +248,9 @@ mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
   persistAssistantSteps: mock(() => {}),
+  // F-77 step-cap helpers — chat.ts imports both via @atlas/api/lib/conversations.
+  reserveConversationBudget: mock(() => Promise.resolve({ status: 'ok' as const, totalStepsBefore: 0 })),
+  settleConversationSteps: mock(() => {}),
   getConversation: mock(() => Promise.resolve(null)),
   generateTitle: mock((q: string) => q.slice(0, 80)),
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/packages/api/src/api/__tests__/slack.test.ts
+++ b/packages/api/src/api/__tests__/slack.test.ts
@@ -118,6 +118,9 @@ mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mockCreateConversation,
   addMessage: mockAddMessage,
   persistAssistantSteps: mock(() => {}),
+  // F-77 step-cap helpers — chat.ts imports both via @atlas/api/lib/conversations.
+  reserveConversationBudget: mock(() => Promise.resolve({ status: 'ok' as const, totalStepsBefore: 0 })),
+  settleConversationSteps: mock(() => {}),
   getConversation: mockGetConversation,
   generateTitle: mockGenerateTitle,
   listConversations: mock(() => Promise.resolve({ conversations: [], total: 0 })),

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -36,9 +36,43 @@ import {
   getConversation,
   generateTitle,
   persistAssistantSteps,
+  reserveConversationBudget,
+  settleConversationSteps,
 } from "@atlas/api/lib/conversations";
 import { setStreamWriter, clearStreamWriter } from "@atlas/api/lib/tools/python-stream";
+import { getSetting } from "@atlas/api/lib/settings";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { ErrorSchema } from "./shared-schemas";
+
+const DEFAULT_CONVERSATION_STEP_CAP = 500;
+const DEFAULT_AGENT_MAX_STEPS = 25;
+
+/**
+ * Resolve `ATLAS_CONVERSATION_STEP_CAP` with sensible fallbacks. Returns
+ * 0 ("disabled") when the setting is `0`, an empty string, or invalid —
+ * any non-positive integer disables the cap. F-77.
+ */
+function getConversationStepCap(): number {
+  const raw = getSetting("ATLAS_CONVERSATION_STEP_CAP");
+  if (raw === undefined) return DEFAULT_CONVERSATION_STEP_CAP;
+  if (raw === "") return 0;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return DEFAULT_CONVERSATION_STEP_CAP;
+  return Math.floor(n);
+}
+
+/**
+ * Resolve `ATLAS_AGENT_MAX_STEPS` for the F-77 upfront reservation.
+ * Mirrors the agent loop's `getAgentMaxSteps()` clamp ([1, 100], default
+ * 25) so the upfront charge matches the worst-case spend per request.
+ */
+function getReservationStepBudget(): number {
+  const raw = getSetting("ATLAS_AGENT_MAX_STEPS");
+  if (raw === undefined || raw === "") return DEFAULT_AGENT_MAX_STEPS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 1) return DEFAULT_AGENT_MAX_STEPS;
+  return Math.min(100, Math.max(1, Math.floor(n)));
+}
 
 const log = createLogger("chat");
 
@@ -170,10 +204,12 @@ chat.openapi(chatRoute, async (c) => {
       );
     }
   
-    // Rate limit check — after auth so we have user identity
+    // Rate limit check — after auth so we have user identity. The chat
+    // route uses its own carve-out bucket (F-74) so a 25-step LLM run does
+    // not deplete the same allowance that serves cheap admin reads.
     const ip = getClientIP(req);
     const rateLimitKey = authResult.user?.id ?? (ip ? `ip:${ip}` : "anon");
-    const rateCheck = checkRateLimit(rateLimitKey);
+    const rateCheck = checkRateLimit(rateLimitKey, { bucket: "chat" });
     if (!rateCheck.allowed) {
       log.warn(
         { requestId, rateLimitKey, retryAfterMs: rateCheck.retryAfterMs },
@@ -375,7 +411,12 @@ chat.openapi(chatRoute, async (c) => {
   
         const messages = parsed.data.messages as UIMessage[];
         let conversationId = parsed.data.conversationId;
-  
+        // F-77 — track the upfront reservation so the post-stream
+        // settlement can refund any unused budget. `null` means no
+        // reservation was charged (cap disabled, new conversation, or
+        // fail-open path).
+        let reservedStepBudget: number | null = null;
+
         // Conversation persistence — Ownership verification blocks here (can 404); message writes are fire-and-forget via internalExecute.
         if (hasInternalDB()) {
           if (conversationId) {
@@ -383,6 +424,57 @@ chat.openapi(chatRoute, async (c) => {
             const existing = await getConversation(conversationId, authResult.user?.id, authResult.user?.activeOrganizationId);
             if (!existing.ok) {
               return c.json({ error: "not_found", message: "Conversation not found.", retryable: false, requestId }, 404);
+            }
+            // F-77 — aggregate per-conversation step ceiling. The per-request
+            // caps (stepCountIs(25), 180s wall-clock) bound a single agent
+            // run; this gate bounds the long-tail follow-up flow on a single
+            // conversationId. The reservation charges the row by the worst-
+            // case step budget atomically, so concurrent runs cannot all pass
+            // the gate at `cap − 1` — the ceiling is enforced at the row, not
+            // here. Settlement on stream finish refunds the unused portion.
+            // `no_db` / `error` reservation results fail open so a transient
+            // internal-DB glitch never 429s the whole chat surface; sustained
+            // outages surface via a throttled `log.warn` from the helper.
+            const stepCap = getConversationStepCap();
+            if (stepCap > 0) {
+              const stepBudget = getReservationStepBudget();
+              const reservation = await reserveConversationBudget(
+                conversationId,
+                stepBudget,
+                stepCap,
+              );
+              if (reservation.status === "exceeded") {
+                log.warn(
+                  { requestId, conversationId, totalSteps: reservation.totalSteps, cap: stepCap },
+                  "Conversation budget exceeded — rejecting follow-up message",
+                );
+                // Audit so abuse detection picks up workspaces grinding the cap.
+                // Pass `scope: "workspace"` explicitly so a future system-actor
+                // codepath cannot silently invert the row's scope to "platform".
+                logAdminAction({
+                  actionType: ADMIN_ACTIONS.conversation.budgetExceeded,
+                  targetType: "conversation",
+                  targetId: conversationId,
+                  status: "failure",
+                  scope: "workspace",
+                  metadata: { totalSteps: reservation.totalSteps, cap: stepCap },
+                });
+                return c.json(
+                  {
+                    error: "conversation_budget_exceeded",
+                    message: "This conversation has reached its step limit. Start a new conversation to continue.",
+                    retryable: false,
+                    requestId,
+                  },
+                  429,
+                );
+              }
+              if (reservation.status === "ok") {
+                reservedStepBudget = stepBudget;
+              }
+              // status === "no_db" | "error" → fail open, no reservation
+              // charged. The helper has already logged the failure (rate-
+              // limited) so the operator sees sustained outages.
             }
             // Persist the latest user message
             try {
@@ -533,6 +625,27 @@ chat.openapi(chatRoute, async (c) => {
           // Fire-and-forget: persist assistant response (text + tool results) after stream completes.
           if (conversationId) {
             persistAssistantSteps({ conversationId, steps: agentResult.steps, label: "chat" });
+            // F-77 — settlement. The reservation charged the row by the
+            // worst-case step budget upfront so concurrent runs couldn't
+            // overshoot the cap. Once the agent loop resolves we refund
+            // the unused portion. If the stream errors out we keep the
+            // full reservation charged — that's the conservative cost
+            // accounting choice (an attacker spinning up streams that
+            // fail mid-flight still pays full budget).
+            if (reservedStepBudget !== null) {
+              const convIdForSettle = conversationId;
+              const reservedForSettle = reservedStepBudget;
+              void Promise.resolve(agentResult.steps)
+                .then((steps) => {
+                  settleConversationSteps(convIdForSettle, reservedForSettle, steps.length);
+                })
+                .catch((err: unknown) => {
+                  log.warn(
+                    { err: err instanceof Error ? err.message : String(err), conversationId: convIdForSettle },
+                    "F-77 step-cap settlement skipped — agent stream failed; reservation stays charged",
+                  );
+                });
+            }
           }
   
           // The streaming response is a raw Response from createUIMessageStreamResponse.

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -476,14 +476,20 @@ chat.openapi(chatRoute, async (c) => {
               // charged. The helper has already logged the failure (rate-
               // limited) so the operator sees sustained outages.
             }
-            // Persist the latest user message
+            // Persist the latest user message. `addMessage` is fire-and-
+            // forget via `internalExecute`; the synchronous try/catch only
+            // covers pool-init throws — async insert failures are logged
+            // inside `internalExecute`'s circuit breaker.
             try {
               const lastUserMsg = [...messages].reverse().find((m) => m.role === "user");
               if (lastUserMsg) {
                 addMessage({ conversationId, role: "user", content: lastUserMsg.parts });
               }
             } catch (err) {
-              log.warn({ err: err instanceof Error ? err.message : String(err) }, "Failed to persist user message");
+              log.warn(
+                { err: err instanceof Error ? err.message : String(err), requestId, conversationId },
+                "Failed to persist user message (pool init throw)",
+              );
             }
           } else {
             try {
@@ -641,7 +647,11 @@ chat.openapi(chatRoute, async (c) => {
                 })
                 .catch((err: unknown) => {
                   log.warn(
-                    { err: err instanceof Error ? err.message : String(err), conversationId: convIdForSettle },
+                    {
+                      err: err instanceof Error ? err.message : String(err),
+                      requestId,
+                      conversationId: convIdForSettle,
+                    },
                     "F-77 step-cap settlement skipped — agent stream failed; reservation stays charged",
                   );
                 });

--- a/packages/api/src/api/routes/conversations.ts
+++ b/packages/api/src/api/routes/conversations.ts
@@ -42,6 +42,11 @@ import type { ShareExpiryKey } from "@useatlas/types/share";
 import { SHARE_MODES, SHARE_EXPIRY_OPTIONS } from "@useatlas/types/share";
 import { standardAuth, requestContext, type AuthEnv } from "./middleware";
 import { ErrorSchema, AuthErrorSchema, parsePagination } from "./shared-schemas";
+import {
+  createPublicRateLimiter,
+  warnIfTrustProxyMissingForPublicShare,
+  PUBLIC_RATE_LIMIT_CONSTANTS,
+} from "@atlas/api/lib/public-rate-limit";
 
 const log = createLogger("conversations");
 
@@ -1191,24 +1196,25 @@ const SHARE_TOKEN_RE = /^[A-Za-z0-9_-]{20,64}$/;
 // In-memory rate limiter for public route
 // ---------------------------------------------------------------------------
 
-const PUBLIC_RATE_WINDOW_MS = 60_000;
 const PUBLIC_RATE_MAX = 60;
 
-const publicRateMap = new Map<string, { count: number; resetAt: number }>();
+const publicRateLimiter = createPublicRateLimiter({ maxRpm: PUBLIC_RATE_MAX });
 
 /**
  * Evict expired entries to prevent unbounded growth. Called periodically
  * by the SchedulerLayer fiber in lib/effect/layers.ts.
  */
 export function conversationRateSweepTick(): void {
-  const now = Date.now();
-  for (const [key, entry] of publicRateMap) {
-    if (now > entry.resetAt) publicRateMap.delete(key);
-  }
+  publicRateLimiter.cleanup();
+}
+
+/** @internal — test-only. Drop all conversation rate-limit state between tests. */
+export function _resetConversationRateLimit(): void {
+  publicRateLimiter.reset();
 }
 
 /** Interval for conversation rate sweep. Exported for SchedulerLayer. */
-export const CONVERSATION_RATE_SWEEP_INTERVAL_MS = PUBLIC_RATE_WINDOW_MS;
+export const CONVERSATION_RATE_SWEEP_INTERVAL_MS = PUBLIC_RATE_LIMIT_CONSTANTS.WINDOW_MS;
 
 /** Interval for share token cleanup. Exported for SchedulerLayer. */
 export const SHARE_CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
@@ -1240,16 +1246,10 @@ export async function shareCleanupTick(): Promise<void> {
   }
 }
 
-function checkPublicRateLimit(ip: string): boolean {
-  const now = Date.now();
-  const entry = publicRateMap.get(ip);
-  if (!entry || now > entry.resetAt) {
-    publicRateMap.set(ip, { count: 1, resetAt: now + PUBLIC_RATE_WINDOW_MS });
-    return true;
-  }
-  entry.count++;
-  return entry.count <= PUBLIC_RATE_MAX;
-}
+// Fire once per process if ATLAS_TRUST_PROXY is unset and a public-share route
+// has been exercised — surfaces the env-var miss instead of letting the
+// limiter silently fall back to the anonymous bucket.
+warnIfTrustProxyMissingForPublicShare();
 
 // ---------------------------------------------------------------------------
 // Public router + route definition
@@ -1327,12 +1327,11 @@ publicConversations.openapi(getSharedConversationRoute, async (c) => {
   }
 
   const ip = getClientIP(c.req.raw);
-  if (!ip) {
-    log.warn({ requestId }, "Public conversation request with no client IP");
-  }
-  const rateLimitKey = ip ?? `unknown-${requestId}`;
-  if (!checkPublicRateLimit(rateLimitKey)) {
-    log.warn({ requestId, ip }, "Public conversation rate limited");
+  if (!publicRateLimiter.check(ip)) {
+    // `ip === null` means the request landed in the shared anonymous bucket —
+    // surface that in logs so operators can correlate 429 spikes with a
+    // missing ATLAS_TRUST_PROXY rather than per-IP traffic.
+    log.warn({ requestId, ip, anonymous: ip === null }, "Public conversation rate limited");
     return c.json({ error: "rate_limited", message: "Too many requests. Please wait before trying again.", requestId }, 429);
   }
 

--- a/packages/api/src/api/routes/dashboards.ts
+++ b/packages/api/src/api/routes/dashboards.ts
@@ -41,6 +41,10 @@ import {
   getClientIP,
 } from "@atlas/api/lib/auth/middleware";
 import type { AuthResult } from "@atlas/api/lib/auth/types";
+import {
+  createPublicRateLimiter,
+  warnIfTrustProxyMissingForPublicShare,
+} from "@atlas/api/lib/public-rate-limit";
 
 const log = createLogger("dashboard-routes");
 
@@ -124,9 +128,9 @@ function sharedDashboardFailResponse(reason: SharedDashboardFailReason) {
 // Rate limiting (public endpoint)
 // ---------------------------------------------------------------------------
 
-const PUBLIC_RATE_WINDOW_MS = 60_000;
 const PUBLIC_RATE_MAX = 30;
-const publicRateMap = new Map<string, { count: number; resetAt: number }>();
+
+const publicRateLimiter = createPublicRateLimiter({ maxRpm: PUBLIC_RATE_MAX });
 
 /** Interval for dashboard rate-limit cleanup. Exported for SchedulerLayer. */
 export const DASHBOARD_RATE_CLEANUP_INTERVAL_MS = 60_000;
@@ -136,22 +140,17 @@ export const DASHBOARD_RATE_CLEANUP_INTERVAL_MS = 60_000;
  * SchedulerLayer fiber in lib/effect/layers.ts.
  */
 export function dashboardRateLimitCleanupTick(): void {
-  const now = Date.now();
-  for (const [key, entry] of publicRateMap) {
-    if (now > entry.resetAt) publicRateMap.delete(key);
-  }
+  publicRateLimiter.cleanup();
 }
 
-function checkPublicRateLimit(ip: string): boolean {
-  const now = Date.now();
-  const entry = publicRateMap.get(ip);
-  if (!entry || now > entry.resetAt) {
-    publicRateMap.set(ip, { count: 1, resetAt: now + PUBLIC_RATE_WINDOW_MS });
-    return true;
-  }
-  entry.count++;
-  return entry.count <= PUBLIC_RATE_MAX;
+/** @internal — test-only. Drop all dashboard rate-limit state between tests. */
+export function _resetDashboardRateLimit(): void {
+  publicRateLimiter.reset();
 }
+
+// Fire-once startup hint when ATLAS_TRUST_PROXY is unset — see F-73 in the
+// security audit. Mirrors the conversations public route.
+warnIfTrustProxyMissingForPublicShare();
 
 // ---------------------------------------------------------------------------
 // Route definitions
@@ -1138,12 +1137,11 @@ publicDashboards.openapi(getSharedDashboardRoute, async (c) => {
   }
 
   const ip = getClientIP(c.req.raw);
-  if (!ip) {
-    log.warn({ requestId }, "Public dashboard request with no client IP");
-  }
-  const rateLimitKey = ip ?? `unknown-${requestId}`;
-  if (!checkPublicRateLimit(rateLimitKey)) {
-    log.warn({ requestId, ip }, "Public dashboard rate limited");
+  if (!publicRateLimiter.check(ip)) {
+    // F-73: anonymous=true means the request landed in the shared
+    // anonymous bucket because the route layer could not resolve a
+    // canonical client IP — usually a missing ATLAS_TRUST_PROXY.
+    log.warn({ requestId, ip, anonymous: ip === null }, "Public dashboard rate limited");
     return c.json({ error: "rate_limited", message: "Too many requests. Please wait before trying again.", requestId }, 429);
   }
 

--- a/packages/api/src/lib/__tests__/conversations-budget.test.ts
+++ b/packages/api/src/lib/__tests__/conversations-budget.test.ts
@@ -1,0 +1,184 @@
+/**
+ * F-77 — unit tests for the per-conversation step cap helpers.
+ *
+ * Pins the load-bearing branches in `reserveConversationBudget` and
+ * `settleConversationSteps`:
+ *
+ *   - Atomic gate (UPDATE WHERE total_steps < cap) — no overshoot
+ *     under concurrent reservations.
+ *   - "Row missing" vs "row at cap" disambiguation when the UPDATE
+ *     returns 0 rows.
+ *   - Fail-open contract on internal-DB unavailability and read errors.
+ *   - Settlement refund clamps and is a no-op when no refund is owed.
+ *
+ * Tests stub the internal DB at the module level so they don't require
+ * a live Postgres.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+const internalQueryMock = mock(
+  (..._args: unknown[]): Promise<unknown[]> => Promise.resolve([]),
+);
+const internalExecuteMock = mock((..._args: unknown[]): void => {});
+let hasInternalDBValue = true;
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => hasInternalDBValue,
+  internalQuery: internalQueryMock,
+  internalExecute: internalExecuteMock,
+}));
+
+mock.module("@atlas/api/lib/audit/error-scrub", () => ({
+  errorMessage: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+}));
+
+const {
+  reserveConversationBudget,
+  settleConversationSteps,
+  _resetConversationBudgetWarnState,
+} = await import("../conversations");
+
+describe("reserveConversationBudget — F-77 atomic gate", () => {
+  beforeEach(() => {
+    internalQueryMock.mockReset();
+    internalExecuteMock.mockReset();
+    hasInternalDBValue = true;
+    _resetConversationBudgetWarnState();
+  });
+
+  it("returns no_db when the internal DB is not configured", async () => {
+    hasInternalDBValue = false;
+    const result = await reserveConversationBudget("c1", 25, 100);
+    expect(result.status).toBe("no_db");
+    expect(internalQueryMock).not.toHaveBeenCalled();
+  });
+
+  it("short-circuits with ok when stepBudget is zero or negative", async () => {
+    let result = await reserveConversationBudget("c1", 0, 100);
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") expect(result.totalStepsBefore).toBe(0);
+
+    result = await reserveConversationBudget("c1", -5, 100);
+    expect(result.status).toBe("ok");
+
+    expect(internalQueryMock).not.toHaveBeenCalled();
+  });
+
+  it("short-circuits with ok when cap is zero or negative (gate disabled)", async () => {
+    let result = await reserveConversationBudget("c1", 25, 0);
+    expect(result.status).toBe("ok");
+
+    result = await reserveConversationBudget("c1", 25, -1);
+    expect(result.status).toBe("ok");
+
+    expect(internalQueryMock).not.toHaveBeenCalled();
+  });
+
+  it("issues a single atomic UPDATE that gates on total_steps < cap", async () => {
+    internalQueryMock.mockResolvedValueOnce([{ before: 50 }]);
+
+    const result = await reserveConversationBudget("c1", 25, 100);
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") expect(result.totalStepsBefore).toBe(50);
+
+    expect(internalQueryMock).toHaveBeenCalledTimes(1);
+    const calls = internalQueryMock.mock.calls as unknown as unknown[][];
+    const sql = calls[0][0] as string;
+    // The atomic gate is the load-bearing detail — pin it.
+    expect(sql).toContain("UPDATE conversations");
+    expect(sql).toContain("total_steps < $3");
+    expect(sql).toContain("RETURNING total_steps - $2 AS before");
+    expect(calls[0][1]).toEqual(["c1", 25, 100]);
+  });
+
+  it("treats a missing row (UPDATE+SELECT both empty) as ok with totalStepsBefore=0", async () => {
+    // UPDATE returns no rows because the conversation doesn't exist yet.
+    internalQueryMock.mockResolvedValueOnce([]);
+    // Follow-up SELECT also returns no rows.
+    internalQueryMock.mockResolvedValueOnce([]);
+
+    const result = await reserveConversationBudget("c-new", 25, 100);
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") expect(result.totalStepsBefore).toBe(0);
+  });
+
+  it("returns exceeded when UPDATE returns 0 rows AND the row exists at/over cap", async () => {
+    internalQueryMock.mockResolvedValueOnce([]); // UPDATE returned no rows
+    internalQueryMock.mockResolvedValueOnce([{ total_steps: 100 }]); // row exists at cap
+
+    const result = await reserveConversationBudget("c1", 25, 100);
+    expect(result.status).toBe("exceeded");
+    if (result.status === "exceeded") expect(result.totalSteps).toBe(100);
+  });
+
+  it("returns exceeded when total_steps comes back as a string (numeric coercion)", async () => {
+    internalQueryMock.mockResolvedValueOnce([]);
+    internalQueryMock.mockResolvedValueOnce([{ total_steps: "150" }]);
+
+    const result = await reserveConversationBudget("c1", 25, 100);
+    expect(result.status).toBe("exceeded");
+    if (result.status === "exceeded") expect(result.totalSteps).toBe(150);
+  });
+
+  it("fails open with status=error when the UPDATE throws", async () => {
+    internalQueryMock.mockRejectedValueOnce(new Error("connection lost"));
+
+    const result = await reserveConversationBudget("c1", 25, 100);
+    expect(result.status).toBe("error");
+  });
+
+  it("coerces non-numeric `before` from the UPDATE response to 0", async () => {
+    internalQueryMock.mockResolvedValueOnce([{ before: "not a number" }]);
+
+    const result = await reserveConversationBudget("c1", 25, 100);
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") expect(result.totalStepsBefore).toBe(0);
+  });
+});
+
+describe("settleConversationSteps — F-77 refund", () => {
+  beforeEach(() => {
+    internalQueryMock.mockReset();
+    internalExecuteMock.mockReset();
+    hasInternalDBValue = true;
+  });
+
+  it("skips the write when the internal DB is not configured", () => {
+    hasInternalDBValue = false;
+    settleConversationSteps("c1", 25, 5);
+    expect(internalExecuteMock).not.toHaveBeenCalled();
+  });
+
+  it("skips when actual >= reserved (no refund owed)", () => {
+    settleConversationSteps("c1", 25, 25);
+    settleConversationSteps("c1", 25, 30);
+    expect(internalExecuteMock).not.toHaveBeenCalled();
+  });
+
+  it("skips when reserved or actual is non-finite", () => {
+    settleConversationSteps("c1", Number.NaN, 5);
+    settleConversationSteps("c1", 25, Number.POSITIVE_INFINITY);
+    expect(internalExecuteMock).not.toHaveBeenCalled();
+  });
+
+  it("issues UPDATE with GREATEST(0, …) and the correct refund delta", () => {
+    settleConversationSteps("c1", 25, 7);
+
+    expect(internalExecuteMock).toHaveBeenCalledTimes(1);
+    const calls = internalExecuteMock.mock.calls as unknown as unknown[][];
+    const sql = calls[0][0] as string;
+    // Pin the GREATEST clamp — keeps the counter from going negative
+    // when settlement races with a concurrent reservation.
+    expect(sql).toContain("UPDATE conversations");
+    expect(sql).toContain("GREATEST(0, total_steps - $1)");
+    // Refund = 25 - 7 = 18.
+    expect(calls[0][1]).toEqual([18, "c1"]);
+  });
+
+  it("clamps negative actual to zero when computing the refund", () => {
+    settleConversationSteps("c1", 25, -10);
+    const calls = internalExecuteMock.mock.calls as unknown as unknown[][];
+    expect(calls[0][1]).toEqual([25, "c1"]);
+  });
+});

--- a/packages/api/src/lib/__tests__/conversations-budget.test.ts
+++ b/packages/api/src/lib/__tests__/conversations-budget.test.ts
@@ -92,15 +92,18 @@ describe("reserveConversationBudget — F-77 atomic gate", () => {
     expect(calls[0][1]).toEqual(["c1", 25, 100]);
   });
 
-  it("treats a missing row (UPDATE+SELECT both empty) as ok with totalStepsBefore=0", async () => {
-    // UPDATE returns no rows because the conversation doesn't exist yet.
-    internalQueryMock.mockResolvedValueOnce([]);
-    // Follow-up SELECT also returns no rows.
-    internalQueryMock.mockResolvedValueOnce([]);
+  // TOCTOU pin: chat.ts verifies the conversation exists before
+  // calling reserve. If both UPDATE and follow-up SELECT come back
+  // empty, the row vanished between auth check and reservation.
+  // This MUST NOT return `ok` — settlement on a non-charge would
+  // corrupt total_steps. Returns `error` so the caller fails open
+  // visibly, with a logged warn.
+  it("returns error when UPDATE and follow-up SELECT both return 0 rows (TOCTOU)", async () => {
+    internalQueryMock.mockResolvedValueOnce([]); // UPDATE returned no rows
+    internalQueryMock.mockResolvedValueOnce([]); // SELECT also empty — row vanished
 
     const result = await reserveConversationBudget("c-new", 25, 100);
-    expect(result.status).toBe("ok");
-    if (result.status === "ok") expect(result.totalStepsBefore).toBe(0);
+    expect(result.status).toBe("error");
   });
 
   it("returns exceeded when UPDATE returns 0 rows AND the row exists at/over cap", async () => {
@@ -119,6 +122,20 @@ describe("reserveConversationBudget — F-77 atomic gate", () => {
     const result = await reserveConversationBudget("c1", 25, 100);
     expect(result.status).toBe("exceeded");
     if (result.status === "exceeded") expect(result.totalSteps).toBe(150);
+  });
+
+  // Race pin: a concurrent reservation can settle just before our
+  // UPDATE runs, freeing capacity. The UPDATE matches 0 rows but a
+  // follow-up SELECT shows total_steps below the cap. We can't tell
+  // whether our row was charged — return `error` (fail-open with a
+  // logged warn) rather than `ok` (which would imply a charge that
+  // didn't happen). Same protection as the TOCTOU branch.
+  it("returns error when UPDATE returns 0 rows but the row is below cap (concurrent race)", async () => {
+    internalQueryMock.mockResolvedValueOnce([]); // UPDATE returned no rows
+    internalQueryMock.mockResolvedValueOnce([{ total_steps: 50 }]); // below cap of 100
+
+    const result = await reserveConversationBudget("c1", 25, 100);
+    expect(result.status).toBe("error");
   });
 
   it("fails open with status=error when the UPDATE throws", async () => {

--- a/packages/api/src/lib/__tests__/public-rate-limit.test.ts
+++ b/packages/api/src/lib/__tests__/public-rate-limit.test.ts
@@ -1,0 +1,102 @@
+/**
+ * F-73 — public-share rate limiter unit tests.
+ *
+ * Pins the bug fix: without `ATLAS_TRUST_PROXY`, `getClientIP` returns
+ * null and the previous limiter used `unknown-${requestId}` — a fresh
+ * UUID per request — as the bucket key. Every request landed in its own
+ * bucket and the limit returned `true` indefinitely. The shared
+ * limiter buckets all anonymous traffic into a single
+ * `__public_unknown__` key with a small ceiling.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  createPublicRateLimiter,
+  PUBLIC_RATE_LIMIT_CONSTANTS,
+} from "../public-rate-limit";
+
+describe("createPublicRateLimiter", () => {
+  it("buckets per IP independently when an IP is present", () => {
+    const limiter = createPublicRateLimiter({ maxRpm: 3 });
+    expect(limiter.check("1.1.1.1")).toBe(true);
+    expect(limiter.check("1.1.1.1")).toBe(true);
+    expect(limiter.check("1.1.1.1")).toBe(true);
+    expect(limiter.check("1.1.1.1")).toBe(false);
+    // Different IP has its own bucket
+    expect(limiter.check("2.2.2.2")).toBe(true);
+  });
+
+  // F-73 regression: an IP-less request flow must not silently bypass.
+  it("buckets every IP-less request into a single shared key (F-73 fix)", () => {
+    const limiter = createPublicRateLimiter({ maxRpm: 60 });
+    // Anonymous ceiling defaults to ANON_FALLBACK_MAX_RPM (10), capped to maxRpm.
+    const ceiling = PUBLIC_RATE_LIMIT_CONSTANTS.ANON_FALLBACK_MAX_RPM;
+    for (let i = 0; i < ceiling; i++) {
+      expect(limiter.check(null)).toBe(true);
+    }
+    // ceiling+1 must be rejected — the broken implementation returned true
+    // here because the unique requestId fallback gave each request its own
+    // bucket.
+    expect(limiter.check(null)).toBe(false);
+  });
+
+  it("anonymous fallback uses min(maxRpm, ANON_FALLBACK_MAX_RPM)", () => {
+    // When the per-IP limit is below the anonymous default, the anon
+    // bucket should not exceed the per-IP limit.
+    const limiter = createPublicRateLimiter({ maxRpm: 3 });
+    expect(limiter.check(null)).toBe(true);
+    expect(limiter.check(null)).toBe(true);
+    expect(limiter.check(null)).toBe(true);
+    expect(limiter.check(null)).toBe(false);
+  });
+
+  it("anonymous fallback bucket is independent of per-IP buckets", () => {
+    const limiter = createPublicRateLimiter({ maxRpm: 10 });
+    // Burn through the anonymous ceiling (10).
+    for (let i = 0; i < 10; i++) {
+      expect(limiter.check(null)).toBe(true);
+    }
+    expect(limiter.check(null)).toBe(false);
+    // Per-IP buckets still allow.
+    expect(limiter.check("9.9.9.9")).toBe(true);
+  });
+
+  it("cleanup() drops expired buckets", () => {
+    const limiter = createPublicRateLimiter({ maxRpm: 1 });
+    expect(limiter.check("1.1.1.1")).toBe(true);
+    expect(limiter.check("1.1.1.1")).toBe(false);
+    const originalNow = Date.now;
+    Date.now = () => originalNow() + 61_000;
+    try {
+      limiter.cleanup();
+      // After window expiry the bucket is gone — first call after cleanup
+      // creates a fresh window.
+      expect(limiter.check("1.1.1.1")).toBe(true);
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
+  it("reset() clears all bucket state", () => {
+    const limiter = createPublicRateLimiter({ maxRpm: 1 });
+    expect(limiter.check("1.1.1.1")).toBe(true);
+    expect(limiter.check("1.1.1.1")).toBe(false);
+    limiter.reset();
+    expect(limiter.check("1.1.1.1")).toBe(true);
+  });
+
+  it("expired window resets the bucket", () => {
+    const limiter = createPublicRateLimiter({ maxRpm: 2 });
+    expect(limiter.check("1.1.1.1")).toBe(true);
+    expect(limiter.check("1.1.1.1")).toBe(true);
+    expect(limiter.check("1.1.1.1")).toBe(false);
+    const originalNow = Date.now;
+    Date.now = () => originalNow() + 61_000;
+    try {
+      // Past the WINDOW_MS — first call after expiry seeds a fresh window.
+      expect(limiter.check("1.1.1.1")).toBe(true);
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+});

--- a/packages/api/src/lib/audit/actions.ts
+++ b/packages/api/src/lib/audit/actions.ts
@@ -448,6 +448,23 @@ export const ADMIN_ACTIONS = {
     unhide: "starter_prompt.unhide",
     authorUpdate: "starter_prompt.author_update",
   },
+  /**
+   * Per-conversation cost-ceiling rejection (F-77). Emitted by the chat
+   * handler when `reserveConversationBudget` returns `exceeded`.
+   * Audited so abuse detection picks up on a workspace grinding a single
+   * conversation up to the aggregate ceiling — the per-request step cap
+   * and wall-clock budgets bound a single run, but the long-tail
+   * follow-up flow on one conversation isn't covered without this row.
+   * Metadata: `{ totalSteps, cap }`. Target id is the conversation id.
+   * The chat handler passes `scope: "workspace"` explicitly —
+   * `logAdminAction` defaults to `"workspace"` only when no
+   * `systemActor` is set, so the explicit pass keeps a future
+   * system-actor codepath from silently inverting the row's scope to
+   * `"platform"`.
+   */
+  conversation: {
+    budgetExceeded: "conversation.budget_exceeded",
+  },
 } as const;
 
 /** Union of all admin action type string values. */

--- a/packages/api/src/lib/auth/__tests__/middleware.test.ts
+++ b/packages/api/src/lib/auth/__tests__/middleware.test.ts
@@ -433,6 +433,107 @@ describe("checkRateLimit()", () => {
 });
 
 // ---------------------------------------------------------------------------
+// F-74 — chat bucket isolation
+// ---------------------------------------------------------------------------
+
+describe("checkRateLimit() — chat bucket (F-74)", () => {
+  const origRpm = process.env.ATLAS_RATE_LIMIT_RPM;
+  const origChatRpm = process.env.ATLAS_RATE_LIMIT_RPM_CHAT;
+
+  beforeEach(() => {
+    resetRateLimits();
+    process.env.ATLAS_RATE_LIMIT_RPM = "20";
+  });
+
+  afterEach(() => {
+    if (origRpm !== undefined) process.env.ATLAS_RATE_LIMIT_RPM = origRpm;
+    else delete process.env.ATLAS_RATE_LIMIT_RPM;
+    if (origChatRpm !== undefined) process.env.ATLAS_RATE_LIMIT_RPM_CHAT = origChatRpm;
+    else delete process.env.ATLAS_RATE_LIMIT_RPM_CHAT;
+    resetRateLimits();
+  });
+
+  it("derives default chat ceiling as max(5, RPM/4) when override unset", () => {
+    delete process.env.ATLAS_RATE_LIMIT_RPM_CHAT;
+    process.env.ATLAS_RATE_LIMIT_RPM = "20"; // → chat ceiling = 5
+    resetRateLimits();
+
+    for (let i = 0; i < 5; i++) {
+      expect(checkRateLimit("u", { bucket: "chat" }).allowed).toBe(true);
+    }
+    expect(checkRateLimit("u", { bucket: "chat" }).allowed).toBe(false);
+  });
+
+  it("floor of 5/min applies when ATLAS_RATE_LIMIT_RPM is small", () => {
+    delete process.env.ATLAS_RATE_LIMIT_RPM_CHAT;
+    // RPM=4 / 4 = 1, but the floor is 5 to keep the chat surface usable.
+    process.env.ATLAS_RATE_LIMIT_RPM = "4";
+    resetRateLimits();
+
+    for (let i = 0; i < 5; i++) {
+      expect(checkRateLimit("u", { bucket: "chat" }).allowed).toBe(true);
+    }
+    expect(checkRateLimit("u", { bucket: "chat" }).allowed).toBe(false);
+  });
+
+  it("ATLAS_RATE_LIMIT_RPM_CHAT override wins over the derived default", () => {
+    process.env.ATLAS_RATE_LIMIT_RPM = "100";
+    process.env.ATLAS_RATE_LIMIT_RPM_CHAT = "2";
+    resetRateLimits();
+
+    expect(checkRateLimit("u", { bucket: "chat" }).allowed).toBe(true);
+    expect(checkRateLimit("u", { bucket: "chat" }).allowed).toBe(true);
+    expect(checkRateLimit("u", { bucket: "chat" }).allowed).toBe(false);
+  });
+
+  it("disables chat bucket when ATLAS_RATE_LIMIT_RPM=0", () => {
+    process.env.ATLAS_RATE_LIMIT_RPM = "0";
+    process.env.ATLAS_RATE_LIMIT_RPM_CHAT = "2";
+    resetRateLimits();
+
+    // When the global limit is disabled the chat bucket inherits "off".
+    for (let i = 0; i < 50; i++) {
+      expect(checkRateLimit("u", { bucket: "chat" }).allowed).toBe(true);
+    }
+  });
+
+  // F-74 isolation pin: a chat-burning user's cheap reads must keep working.
+  it("chat bucket exhaustion does not lock out the default bucket for the same key", () => {
+    process.env.ATLAS_RATE_LIMIT_RPM = "20";
+    process.env.ATLAS_RATE_LIMIT_RPM_CHAT = "2";
+    resetRateLimits();
+
+    // Burn the chat ceiling.
+    expect(checkRateLimit("u", { bucket: "chat" }).allowed).toBe(true);
+    expect(checkRateLimit("u", { bucket: "chat" }).allowed).toBe(true);
+    expect(checkRateLimit("u", { bucket: "chat" }).allowed).toBe(false);
+
+    // Default bucket on the same key still has its full allowance.
+    for (let i = 0; i < 20; i++) {
+      expect(checkRateLimit("u").allowed).toBe(true);
+    }
+    expect(checkRateLimit("u").allowed).toBe(false);
+  });
+
+  it("default bucket exhaustion does not lock out the chat bucket for the same key", () => {
+    process.env.ATLAS_RATE_LIMIT_RPM = "2";
+    process.env.ATLAS_RATE_LIMIT_RPM_CHAT = "5";
+    resetRateLimits();
+
+    // Burn the default ceiling.
+    expect(checkRateLimit("u").allowed).toBe(true);
+    expect(checkRateLimit("u").allowed).toBe(true);
+    expect(checkRateLimit("u").allowed).toBe(false);
+
+    // Chat bucket is unaffected.
+    for (let i = 0; i < 5; i++) {
+      expect(checkRateLimit("u", { bucket: "chat" }).allowed).toBe(true);
+    }
+    expect(checkRateLimit("u", { bucket: "chat" }).allowed).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // rateLimitCleanupTick
 // ---------------------------------------------------------------------------
 

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -284,6 +284,7 @@ describe("migrateAuthTables", () => {
             { name: "0036_integration_credentials_encryption.sql" },
             { name: "0037_plugin_config_encryption.sql" },
             { name: "0038_encryption_key_versioning.sql" },
+            { name: "0039_conversation_step_cap.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/auth/middleware.ts
+++ b/packages/api/src/lib/auth/middleware.ts
@@ -88,9 +88,13 @@ function getRpmLimitForBucket(bucket: RateLimitBucket): number {
 /** Bucket categories for `checkRateLimit`. */
 export type RateLimitBucket = "default" | "chat";
 
+// `\x00` is illegal in user ids, IPs, and the "anon" fallback used by
+// chat.ts — so the chat-bucket prefix can never collide with a
+// caller-derived key. Keeps F-74 isolation true even against
+// pathological identity strings.
 const BUCKET_PREFIX: Record<RateLimitBucket, string> = {
   default: "",
-  chat: "chat:",
+  chat: "\x00chat:",
 };
 
 /**

--- a/packages/api/src/lib/auth/middleware.ts
+++ b/packages/api/src/lib/auth/middleware.ts
@@ -30,6 +30,7 @@ const WINDOW_MS = 60_000; // 60 seconds
 const windows = new Map<string, number[]>();
 
 let lastWarnedRpmValue: string | undefined;
+let lastWarnedChatRpmValue: string | undefined;
 
 function getRpmLimit(): number {
   const raw = getSetting("ATLAS_RATE_LIMIT_RPM");
@@ -44,6 +45,53 @@ function getRpmLimit(): number {
   }
   return Math.floor(n);
 }
+
+/**
+ * Per-bucket RPM ceiling.
+ *
+ * `default` mirrors `ATLAS_RATE_LIMIT_RPM` — covers cheap reads (audit-log
+ * scrolling, conversation list, etc).
+ *
+ * `chat` reads `ATLAS_RATE_LIMIT_RPM_CHAT` when set, otherwise derives
+ * `max(5, RPM/4)` from the default. The carve-out keeps a 25-step LLM
+ * call from depleting the same budget that serves trivial reads (F-74).
+ *
+ * Returning 0 means "disabled" (matching the existing semantics on the
+ * default bucket); when the global limit is disabled the chat bucket is
+ * also disabled regardless of override.
+ */
+function getRpmLimitForBucket(bucket: RateLimitBucket): number {
+  const baseLimit = getRpmLimit();
+  if (bucket === "default") return baseLimit;
+  if (baseLimit === 0) return 0;
+
+  const raw = getSetting("ATLAS_RATE_LIMIT_RPM_CHAT");
+  if (raw === undefined || raw === "") {
+    // Default: cap at 1/4 of the global RPM, with a floor of 5/min so a
+    // very low ATLAS_RATE_LIMIT_RPM doesn't push the chat ceiling to 0.
+    return Math.max(5, Math.floor(baseLimit / 4));
+  }
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) {
+    if (raw !== lastWarnedChatRpmValue) {
+      log.warn(
+        { value: raw },
+        "Invalid ATLAS_RATE_LIMIT_RPM_CHAT; falling back to derived default max(5, RPM/4)",
+      );
+      lastWarnedChatRpmValue = raw;
+    }
+    return Math.max(5, Math.floor(baseLimit / 4));
+  }
+  return Math.floor(n);
+}
+
+/** Bucket categories for `checkRateLimit`. */
+export type RateLimitBucket = "default" | "chat";
+
+const BUCKET_PREFIX: Record<RateLimitBucket, string> = {
+  default: "",
+  chat: "chat:",
+};
 
 /**
  * Extract client IP from request headers.
@@ -73,24 +121,38 @@ export function getClientIP(req: Request): string | null {
  * `{ allowed: false, retryAfterMs }` when the caller should back off.
  * Always allows when ATLAS_RATE_LIMIT_RPM is unset or "0".
  *
- * Note: this limits API *requests*, not agent steps. A single chat request
- * may run up to 25 agent steps internally, so effective LLM call volume
- * can be higher than the RPM value implies.
+ * The optional `bucket` parameter selects between two independent
+ * sliding windows keyed on the same caller identity (user id or IP):
+ *
+ *   - `"default"` (omitted) — the original cheap-read bucket. Ceiling
+ *     comes from `ATLAS_RATE_LIMIT_RPM`.
+ *   - `"chat"` — the chat-stream carve-out (F-74). Ceiling comes from
+ *     `ATLAS_RATE_LIMIT_RPM_CHAT`, defaulting to `max(5, RPM/4)`. A 25-step
+ *     chat run debiting the chat bucket no longer drains the cheap-read
+ *     allowance for the same caller.
+ *
+ * Note: this still limits API *requests*, not agent steps. Per-conversation
+ * step accounting (F-77) is enforced separately on the chat handler.
  */
-export function checkRateLimit(key: string): {
+export function checkRateLimit(
+  key: string,
+  options?: { bucket?: RateLimitBucket },
+): {
   allowed: boolean;
   retryAfterMs?: number;
 } {
-  const limit = getRpmLimit();
+  const bucket = options?.bucket ?? "default";
+  const limit = getRpmLimitForBucket(bucket);
   if (limit === 0) return { allowed: true };
 
+  const bucketedKey = BUCKET_PREFIX[bucket] + key;
   const now = Date.now();
   const cutoff = now - WINDOW_MS;
 
-  let timestamps = windows.get(key);
+  let timestamps = windows.get(bucketedKey);
   if (!timestamps) {
     timestamps = [];
-    windows.set(key, timestamps);
+    windows.set(bucketedKey, timestamps);
   }
 
   // Evict stale entries
@@ -112,6 +174,7 @@ export function checkRateLimit(key: string): {
 export function resetRateLimits(): void {
   windows.clear();
   lastWarnedRpmValue = undefined;
+  lastWarnedChatRpmValue = undefined;
 }
 
 /**

--- a/packages/api/src/lib/conversations.ts
+++ b/packages/api/src/lib/conversations.ts
@@ -330,21 +330,43 @@ export async function reserveConversationBudget(
       const n = typeof raw === "number" ? raw : Number(raw);
       return { status: "ok", totalStepsBefore: Number.isFinite(n) ? n : 0 };
     }
-    // Update returned 0 rows. Distinguish "row missing" (treat as ok —
-    // the conversation was created elsewhere or doesn't exist yet) from
-    // "row exists but is at/past cap" (reject). The follow-up SELECT is
-    // necessary because the failed UPDATE alone doesn't tell us which.
+    // UPDATE returned 0 rows. Three possibilities — only one of them
+    // is "exceeded", the others both mean the cap state is unknown
+    // (the row vanished between auth check and reservation, or a
+    // concurrent reservation just settled and freed budget). In both
+    // unknown cases we MUST NOT return `ok` — the chat handler reads
+    // `status === "ok"` as "charge applied, settle later" and a
+    // false-positive ok corrupts `total_steps` accounting via a
+    // settlement that refunds an unmade charge.
     const rows = await internalQuery<{ total_steps: number | string | null }>(
       `SELECT total_steps FROM conversations WHERE id = $1`,
       [conversationId],
     );
     if (rows.length === 0) {
-      return { status: "ok", totalStepsBefore: 0 };
+      // TOCTOU: the conversation existed at the auth check but is gone
+      // now. Surface the race so operators can tell genuine deletes
+      // from a future logic bug.
+      log.warn(
+        { conversationId },
+        "Reservation skipped — conversation row vanished between auth check and budget reserve (TOCTOU)",
+      );
+      return { status: "error" };
     }
     const raw = rows[0].total_steps;
     const n = typeof raw === "number" ? raw : Number(raw);
     const total = Number.isFinite(n) ? n : 0;
-    return { status: "exceeded", totalSteps: total };
+    if (total >= ceiling) {
+      return { status: "exceeded", totalSteps: total };
+    }
+    // Row is below cap but UPDATE missed it — concurrent reservation
+    // race. Fail open (the cap state is unknown), but log it; if this
+    // fires repeatedly the cap parameters or transaction isolation
+    // deserve a second look.
+    log.warn(
+      { conversationId, totalSteps: total, cap: ceiling },
+      "Reservation skipped — UPDATE matched 0 rows but row is below cap (concurrent reservation race)",
+    );
+    return { status: "error" };
   } catch (err) {
     maybeWarnBudgetFailure(conversationId, err);
     return { status: "error" };

--- a/packages/api/src/lib/conversations.ts
+++ b/packages/api/src/lib/conversations.ts
@@ -246,6 +246,151 @@ export function addMessage(opts: {
 }
 
 /**
+ * F-77 — atomically charge the per-request step budget against a
+ * conversation's running total.
+ *
+ * Returns one of:
+ *   - `{ status: "ok", totalStepsBefore }` — the reservation was
+ *     accepted; the row's `total_steps` was bumped by `stepBudget`.
+ *     The caller may run the agent. Settle the actual spend afterward
+ *     via `settleConversationSteps` so follow-ups see real usage, not
+ *     the worst-case reservation.
+ *   - `{ status: "exceeded", totalSteps }` — the row was already at or
+ *     past the cap. Reject with 429 `conversation_budget_exceeded`.
+ *   - `{ status: "no_db" }` — internal DB not configured; caller fails
+ *     open.
+ *   - `{ status: "error" }` — query threw; caller fails open. A
+ *     throttled `log.warn` surfaces sustained outages so operators
+ *     don't miss that F-77 is no-op'd while the DB is down.
+ *
+ * Atomicity: the gate is enforced at the row by
+ * `UPDATE … WHERE total_steps < $cap … RETURNING`. A non-atomic
+ * read-then-write loop would let two concurrent follow-ups both pass
+ * the gate at `cap - 1` and then both add their full step budget,
+ * letting the row exceed the cap by `(parallelism − 1) × stepBudget`.
+ * Charging upfront also closes the timing hole in the previous design,
+ * where the post-stream increment ran after the handler returned and
+ * dropped silently if the stream failed.
+ */
+export type ConversationBudgetReservation =
+  | { status: "ok"; totalStepsBefore: number }
+  | { status: "exceeded"; totalSteps: number }
+  | { status: "no_db" }
+  | { status: "error" };
+
+let lastBudgetReadFailureWarnAt = 0;
+const BUDGET_FAILURE_WARN_THROTTLE_MS = 60_000;
+
+function maybeWarnBudgetFailure(conversationId: string, err: unknown): void {
+  const now = Date.now();
+  if (now - lastBudgetReadFailureWarnAt < BUDGET_FAILURE_WARN_THROTTLE_MS) {
+    log.debug(
+      { err: errorMessage(err), conversationId },
+      "Conversation budget read failed (throttled)",
+    );
+    return;
+  }
+  lastBudgetReadFailureWarnAt = now;
+  log.warn(
+    { err: errorMessage(err), conversationId },
+    "Conversation budget read/reserve failed — F-77 cap is failing open until the internal DB is reachable",
+  );
+}
+
+/** @internal — test-only. Reset the throttled-warn cooldown. */
+export function _resetConversationBudgetWarnState(): void {
+  lastBudgetReadFailureWarnAt = 0;
+}
+
+export async function reserveConversationBudget(
+  conversationId: string,
+  stepBudget: number,
+  cap: number,
+): Promise<ConversationBudgetReservation> {
+  if (!hasInternalDB()) return { status: "no_db" };
+  if (!Number.isFinite(stepBudget) || stepBudget <= 0) {
+    return { status: "ok", totalStepsBefore: 0 };
+  }
+  if (!Number.isFinite(cap) || cap <= 0) {
+    // Cap disabled — short-circuit before touching the DB.
+    return { status: "ok", totalStepsBefore: 0 };
+  }
+  const delta = Math.floor(stepBudget);
+  const ceiling = Math.floor(cap);
+  try {
+    const updated = await internalQuery<{ before: number | string | null }>(
+      `UPDATE conversations
+          SET total_steps = total_steps + $2
+        WHERE id = $1 AND total_steps < $3
+        RETURNING total_steps - $2 AS before`,
+      [conversationId, delta, ceiling],
+    );
+    if (updated.length > 0) {
+      const raw = updated[0].before;
+      const n = typeof raw === "number" ? raw : Number(raw);
+      return { status: "ok", totalStepsBefore: Number.isFinite(n) ? n : 0 };
+    }
+    // Update returned 0 rows. Distinguish "row missing" (treat as ok —
+    // the conversation was created elsewhere or doesn't exist yet) from
+    // "row exists but is at/past cap" (reject). The follow-up SELECT is
+    // necessary because the failed UPDATE alone doesn't tell us which.
+    const rows = await internalQuery<{ total_steps: number | string | null }>(
+      `SELECT total_steps FROM conversations WHERE id = $1`,
+      [conversationId],
+    );
+    if (rows.length === 0) {
+      return { status: "ok", totalStepsBefore: 0 };
+    }
+    const raw = rows[0].total_steps;
+    const n = typeof raw === "number" ? raw : Number(raw);
+    const total = Number.isFinite(n) ? n : 0;
+    return { status: "exceeded", totalSteps: total };
+  } catch (err) {
+    maybeWarnBudgetFailure(conversationId, err);
+    return { status: "error" };
+  }
+}
+
+/**
+ * F-77 settlement adjustment. `reserveConversationBudget` charges the
+ * row by the full `stepBudget` upfront so concurrent runs can't all
+ * pass the gate at `cap − 1`. Once the agent loop settles, refund the
+ * difference between reserved and actual spend so follow-ups see real
+ * usage.
+ *
+ * Fire-and-forget — `internalExecute` swallows async errors with its
+ * own circuit breaker + logging. The synchronous try/catch covers
+ * pool-init throws. `GREATEST(0, …)` keeps the counter from going
+ * negative when a stale settlement races with a concurrent reservation
+ * that already settled.
+ */
+export function settleConversationSteps(
+  conversationId: string,
+  reservedSteps: number,
+  actualSteps: number,
+): void {
+  if (!hasInternalDB()) return;
+  if (!Number.isFinite(reservedSteps) || !Number.isFinite(actualSteps)) return;
+  const refund =
+    Math.max(0, Math.floor(reservedSteps)) -
+    Math.max(0, Math.floor(actualSteps));
+  if (refund <= 0) return;
+  try {
+    internalExecute(
+      `UPDATE conversations
+          SET total_steps = GREATEST(0, total_steps - $1)
+        WHERE id = $2`,
+      [refund, conversationId],
+    );
+  } catch (err) {
+    log.warn(
+      { err: errorMessage(err), conversationId, refund },
+      "settleConversationSteps failed (synchronous throw)",
+    );
+  }
+}
+
+/**
  * Fetches a conversation with its messages. Scope filters are composed via
  * `scopeClause()` — `userId` enforces ownership, `orgId` restricts access to
  * the caller's active workspace (or legacy rows with NULL org_id). Omitting

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -79,7 +79,7 @@ describe("runMigrations", () => {
 
     const count = await runMigrations(pool);
 
-    expect(count).toBe(39);
+    expect(count).toBe(40);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -147,6 +147,7 @@ describe("runMigrations", () => {
         "0036_integration_credentials_encryption.sql",
         "0037_plugin_config_encryption.sql",
         "0038_encryption_key_versioning.sql",
+        "0039_conversation_step_cap.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0039_conversation_step_cap.sql
+++ b/packages/api/src/lib/db/migrations/0039_conversation_step_cap.sql
@@ -1,0 +1,25 @@
+-- 0039 — F-77 per-conversation step ceiling
+--
+-- Adds an aggregate `total_steps` counter to `conversations`. The chat
+-- handler increments it by `result.steps.length` after each agent run
+-- and rejects new messages with `conversation_budget_exceeded` once the
+-- counter crosses `ATLAS_CONVERSATION_STEP_CAP` (default 500 = 20
+-- follow-ups × 25 steps).
+--
+-- Per-request caps are well-enforced (`stepCountIs(25)` plus the 180s
+-- wall-clock budget). What was missing was an aggregate budget across
+-- follow-ups on the same conversationId — the context grows
+-- monotonically with each message so per-message LLM cost grows roughly
+-- linearly. A 50-message × 25-step conversation could consume ~3.75M
+-- tokens against platform budget on one conversation, all within plan
+-- and abuse limits on a generous tier.
+--
+-- Default 0 NOT NULL means existing rows backfill via the column
+-- default — no separate backfill script (unlike F-41's encryption
+-- transition).
+--
+-- Audit row: .claude/research/security-audit-1-2-3.md F-77
+-- Issue: #1848
+
+ALTER TABLE conversations
+  ADD COLUMN IF NOT EXISTS total_steps INTEGER NOT NULL DEFAULT 0;

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -90,6 +90,12 @@ export const conversations = pgTable(
     orgId: text("org_id"),
     // Soft-delete
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
+    // F-77 per-conversation aggregate step counter. Incremented after every
+    // agent run by `result.steps.length`. Once it crosses
+    // ATLAS_CONVERSATION_STEP_CAP the chat handler rejects further messages
+    // with `conversation_budget_exceeded` and the UI surfaces a
+    // start-a-new-conversation affordance.
+    totalSteps: integer("total_steps").notNull().default(0),
   },
   (t) => [
     index("idx_conversations_user").on(t.userId),

--- a/packages/api/src/lib/effect/errors.ts
+++ b/packages/api/src/lib/effect/errors.ts
@@ -167,6 +167,25 @@ export class ActionTimeoutError extends Data.TaggedError("ActionTimeoutError")<{
   readonly timeoutMs: number;
 }> {}
 
+// ── Conversation Budget (F-77) ─────────────────────────────────────
+
+/**
+ * Aggregate per-conversation step ceiling exceeded. Per-request caps
+ * (`stepCountIs(25)`, 180s wall-clock) bound a single agent run; this
+ * error fires when `total_steps` on a conversation crosses
+ * `ATLAS_CONVERSATION_STEP_CAP`. The chat handler returns 429 with the
+ * specific `conversation_budget_exceeded` chat error code so the UI can
+ * render a "start a new conversation" affordance instead of suggesting
+ * retry. Audited via `conversation.budget_exceeded` so abuse detection
+ * gets a signal.
+ */
+export class ConversationBudgetExceededError extends Data.TaggedError("ConversationBudgetExceededError")<{
+  readonly message: string;
+  readonly conversationId: string;
+  readonly totalSteps: number;
+  readonly cap: number;
+}> {}
+
 // ── Scheduler ──────────────────────────────────────────────────────
 
 /** Scheduled task execution timed out. */
@@ -213,6 +232,7 @@ export type AtlasError =
   | PluginRejectedError
   | CustomValidatorError
   | ActionTimeoutError
+  | ConversationBudgetExceededError
   | SchedulerTaskTimeoutError
   | SchedulerExecutionError
   | DeliveryError
@@ -249,6 +269,7 @@ export const ATLAS_ERROR_TAG_LIST = [
   "PluginRejectedError",
   "CustomValidatorError",
   "ActionTimeoutError",
+  "ConversationBudgetExceededError",
   "SchedulerTaskTimeoutError",
   "SchedulerExecutionError",
   "DeliveryError",

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -82,6 +82,7 @@ type HttpErrorCode =
   | "not_found"
   | "unprocessable_entity"
   | "rate_limited"
+  | "conversation_budget_exceeded"
   | "upstream_error"
   | "service_unavailable"
   | "timeout";
@@ -168,6 +169,16 @@ export function mapTaggedError(error: AtlasError): HttpErrorMapping {
     case "ConcurrencyLimitError":
     case "PoolExhaustedError":
       return { status: 429, code: "rate_limited", message: error.message };
+    // F-77 — per-conversation budget. Distinct wire code so the chat UI
+    // surfaces a "start a new conversation" affordance rather than
+    // suggesting retry on the same conversationId, which will stay over
+    // budget until a new one is created.
+    case "ConversationBudgetExceededError":
+      return {
+        status: 429,
+        code: "conversation_budget_exceeded",
+        message: error.message,
+      };
 
     // ── 502 Bad Gateway — upstream DB error ──────────────────────
     case "QueryExecutionError":

--- a/packages/api/src/lib/public-rate-limit.ts
+++ b/packages/api/src/lib/public-rate-limit.ts
@@ -1,0 +1,120 @@
+/**
+ * Public-share rate limiter — small in-memory sliding-window limiter for
+ * unauthenticated routes (`/api/public/conversations/:token`,
+ * `/api/public/dashboards/:token`).
+ *
+ * Per-IP buckets when `ATLAS_TRUST_PROXY` is set and a client IP can be
+ * resolved; a shared `__public_unknown__` bucket otherwise. The shared
+ * bucket has a small ceiling (default 10/min) so a missing trust-proxy
+ * config can no longer silently disable the limit (F-73).
+ *
+ * The previous per-route limiters used `unknown-${requestId}` as the
+ * fallback key — `requestId` is a fresh UUID on every request, so each
+ * call landed in its own bucket and the limit returned `true`
+ * indefinitely. The fix is to bucket every IP-less request into a single
+ * key with a low ceiling.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+
+const WINDOW_MS = 60_000;
+
+/**
+ * Bucket key for IP-less requests when `ATLAS_TRUST_PROXY` is unset
+ * (no canonical client-IP header is trusted, so we cannot per-IP bucket).
+ */
+const ANON_FALLBACK_KEY = "__public_unknown__";
+
+/** Default ceiling for the anonymous fallback bucket (requests / minute). */
+const ANON_FALLBACK_MAX_RPM = 10;
+
+interface BucketState {
+  count: number;
+  resetAt: number;
+}
+
+export interface PublicRateLimiter {
+  /**
+   * Return `true` when the request should proceed, `false` when the bucket
+   * is exhausted. Pass `null` for `ip` when the route layer could not
+   * resolve a canonical client IP — the call lands in the shared
+   * fallback bucket.
+   */
+  check(ip: string | null): boolean;
+  /** Evict expired entries — called periodically by the SchedulerLayer fiber. */
+  cleanup(): void;
+  /** Test helper: drop all bucket state. */
+  reset(): void;
+}
+
+export interface PublicRateLimiterOptions {
+  /** Ceiling per IP per minute. Anonymous fallback uses
+   *  `min(maxRpm, ANON_FALLBACK_MAX_RPM)`. */
+  maxRpm: number;
+}
+
+export function createPublicRateLimiter(
+  opts: PublicRateLimiterOptions,
+): PublicRateLimiter {
+  const buckets = new Map<string, BucketState>();
+  const anonLimit = Math.min(opts.maxRpm, ANON_FALLBACK_MAX_RPM);
+
+  return {
+    check(ip) {
+      const key = ip ?? ANON_FALLBACK_KEY;
+      const limit = ip ? opts.maxRpm : anonLimit;
+      const now = Date.now();
+      const entry = buckets.get(key);
+      if (!entry || now > entry.resetAt) {
+        buckets.set(key, { count: 1, resetAt: now + WINDOW_MS });
+        return true;
+      }
+      entry.count++;
+      return entry.count <= limit;
+    },
+    cleanup() {
+      const now = Date.now();
+      for (const [key, entry] of buckets) {
+        if (now > entry.resetAt) buckets.delete(key);
+      }
+    },
+    reset() {
+      buckets.clear();
+    },
+  };
+}
+
+/**
+ * Operator-visible warning fired once per process when a public-share
+ * route is registered and `ATLAS_TRUST_PROXY` is unset. Self-hosted
+ * operators behind a reverse proxy that adds canonical IP headers will
+ * silently fall back to the anonymous bucket without this hint.
+ *
+ * Logger is resolved lazily so test files that `mock.module(...logger)` and
+ * import this module as a transitive dependency still capture the warning.
+ */
+let warnedTrustProxyOnce = false;
+export function warnIfTrustProxyMissingForPublicShare(): void {
+  if (warnedTrustProxyOnce) return;
+  const v = process.env.ATLAS_TRUST_PROXY;
+  if (v === "true" || v === "1") return;
+  warnedTrustProxyOnce = true;
+  const log = createLogger("public-rate-limit");
+  log.warn(
+    {
+      anonFallbackRpm: ANON_FALLBACK_MAX_RPM,
+    },
+    "ATLAS_TRUST_PROXY is unset — public-share rate limiting buckets all anonymous requests into a single ceiling. Set ATLAS_TRUST_PROXY=true behind a trusted reverse proxy to enable per-IP buckets.",
+  );
+}
+
+/** Test helper: reset the warned-once flag. */
+export function _resetTrustProxyWarning(): void {
+  warnedTrustProxyOnce = false;
+}
+
+export const PUBLIC_RATE_LIMIT_CONSTANTS = {
+  WINDOW_MS,
+  ANON_FALLBACK_KEY,
+  ANON_FALLBACK_MAX_RPM,
+} as const;

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -93,6 +93,16 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     envVar: "ATLAS_RATE_LIMIT_RPM",
     scope: "workspace",
   },
+  {
+    key: "ATLAS_RATE_LIMIT_RPM_CHAT",
+    section: "Rate Limiting",
+    label: "Chat Rate Limit (RPM)",
+    description:
+      "Max chat requests per minute per user (defaults to max(5, RPM/4) so a 25-step LLM run does not deplete the cheap-read allowance)",
+    type: "number",
+    envVar: "ATLAS_RATE_LIMIT_RPM_CHAT",
+    scope: "workspace",
+  },
 
   // Security
   {
@@ -224,6 +234,17 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     type: "number",
     default: "25",
     envVar: "ATLAS_AGENT_MAX_STEPS",
+    scope: "workspace",
+  },
+  {
+    key: "ATLAS_CONVERSATION_STEP_CAP",
+    section: "Agent",
+    label: "Conversation Step Cap",
+    description:
+      "Aggregate step ceiling per conversation (default 500 = 20 follow-ups × 25 steps). Once exceeded the chat handler rejects further messages with `conversation_budget_exceeded` and the UI offers to start a new conversation. 0 disables the cap.",
+    type: "number",
+    default: "500",
+    envVar: "ATLAS_CONVERSATION_STEP_CAP",
     scope: "workspace",
   },
   {

--- a/packages/api/src/lib/tools/__tests__/action-permissions.test.ts
+++ b/packages/api/src/lib/tools/__tests__/action-permissions.test.ts
@@ -124,6 +124,9 @@ mock.module("@atlas/api/lib/conversations", () => ({
   createConversation: mock(() => Promise.resolve(null)),
   addMessage: mock(() => {}),
   persistAssistantSteps: mock(() => {}),
+  // F-77 step-cap helpers — chat.ts imports both via @atlas/api/lib/conversations.
+  reserveConversationBudget: mock(() => Promise.resolve({ status: 'ok' as const, totalStepsBefore: 0 })),
+  settleConversationSteps: mock(() => {}),
   generateTitle: mock(() => "Test title"),
   starConversation: async () => false,
   shareConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),

--- a/packages/types/src/errors.ts
+++ b/packages/types/src/errors.ts
@@ -25,6 +25,7 @@ export const CHAT_ERROR_CODES = [
   "auth_error",
   "session_expired",
   "rate_limited",
+  "conversation_budget_exceeded",
   "configuration_error",
   "no_datasource",
   "invalid_request",
@@ -95,6 +96,10 @@ const RETRYABLE_MAP: Record<ChatErrorCode, boolean> = {
   workspace_suspended: false,
   workspace_throttled: true,
   workspace_deleted: false,
+  // F-77 — retrying on the same conversation will keep failing because
+  // the aggregate counter only resets on a new conversation. The UI
+  // surfaces a "start a new conversation" affordance instead of retry.
+  conversation_budget_exceeded: false,
 };
 
 /** Returns `true` if the given error code represents a transient, retryable failure. */
@@ -456,6 +461,15 @@ export function parseChatError(error: Error, authMode: AuthMode): ChatErrorInfo 
         requestId,
       };
     }
+
+    case "conversation_budget_exceeded":
+      return {
+        title: "This conversation has reached its limit.",
+        detail: serverMessage ?? "Start a new conversation to continue. The current thread has hit the per-conversation step ceiling.",
+        code: rawCode,
+        retryable,
+        requestId,
+      };
 
     case "configuration_error":
       return { title: "Atlas is not fully configured.", detail: serverMessage, code: rawCode, retryable, requestId };

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -505,6 +505,7 @@ function ChatPage() {
                         }
                       : undefined
                   }
+                  onStartNewConversation={handleNewChat}
                 />
               )}
 

--- a/packages/web/src/ui/components/chat/error-banner.tsx
+++ b/packages/web/src/ui/components/chat/error-banner.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { parseChatError, type AuthMode, type ClientErrorCode } from "../../lib/types";
-import { WifiOff, ServerCrash, ShieldAlert, Clock, AlertTriangle } from "lucide-react";
+import { WifiOff, ServerCrash, ShieldAlert, Clock, AlertTriangle, MessageSquarePlus } from "lucide-react";
 
 /** Icon for each client error code */
 function ErrorIcon({ clientCode }: { clientCode?: ClientErrorCode }) {
@@ -27,10 +27,19 @@ export function ErrorBanner({
   error,
   authMode,
   onRetry,
+  onStartNewConversation,
 }: {
   error: Error;
   authMode: AuthMode;
   onRetry?: () => void;
+  /**
+   * Handler for `conversation_budget_exceeded` (F-77). When the chat
+   * server rejects further messages on a conversation that hit the
+   * aggregate step ceiling, the banner replaces "Try again" with a
+   * "Start a new conversation" CTA — retrying on the same id will keep
+   * failing.
+   */
+  onStartNewConversation?: () => void;
 }) {
   const info = useMemo(() => parseChatError(error, authMode), [error, authMode]);
   const [countdown, setCountdown] = useState(info.retryAfterSeconds ?? 0);
@@ -81,7 +90,10 @@ export function ErrorBanner({
     ? `Try again in ${countdown} second${countdown !== 1 ? "s" : ""}.`
     : info.detail;
 
-  const showRetry = info.retryable && onRetry && countdown === 0 && info.clientCode !== "offline";
+  const isBudgetExceeded = info.code === "conversation_budget_exceeded";
+  const showRetry =
+    info.retryable && onRetry && countdown === 0 && info.clientCode !== "offline" && !isBudgetExceeded;
+  const showStartNew = isBudgetExceeded && Boolean(onStartNewConversation);
 
   return (
     <div
@@ -89,12 +101,26 @@ export function ErrorBanner({
       role="alert"
     >
       <div className="flex items-start gap-2">
-        <ErrorIcon clientCode={info.clientCode} />
+        {isBudgetExceeded ? (
+          <MessageSquarePlus className="size-4 shrink-0" />
+        ) : (
+          <ErrorIcon clientCode={info.clientCode} />
+        )}
         <div className="min-w-0 flex-1">
           <p className="font-medium">{info.title}</p>
           {detail && <p className="mt-1 text-xs opacity-80">{detail}</p>}
           {info.requestId && (
             <p className="mt-1 text-xs opacity-60">Request ID: {info.requestId}</p>
+          )}
+          {showStartNew && (
+            <Button
+              variant="link"
+              size="sm"
+              onClick={onStartNewConversation}
+              className="mt-2 h-auto p-0 text-xs font-medium text-red-700 dark:text-red-400"
+            >
+              Start a new conversation
+            </Button>
           )}
           {showRetry && (
             <Button


### PR DESCRIPTION
## Summary

Phase 6 remediation cluster from `.claude/research/security-audit-1-2-3.md`. Closes #1844, #1845, #1848.

- **F-73 (P1, live DoS)** — public-share rate limiter was a silent no-op without `ATLAS_TRUST_PROXY`: the fallback bucket key was `unknown-${requestId}`, so every IP-less request got its own fresh bucket and the limit returned `true` indefinitely. Extracted a shared `lib/public-rate-limit.ts` and bucket all anonymous traffic into a single `__public_unknown__` key with a small ceiling (default 10/min). Fire-once startup warn surfaces the missing env var to self-hosted operators behind a reverse proxy.
- **F-74 (P2, hardening)** — `ATLAS_RATE_LIMIT_RPM_CHAT` carve-out (default `max(5, RPM/4)`). `checkRateLimit` now takes a `bucket: "default" | "chat"` parameter so a 25-step LLM call no longer drains the same allowance serving cheap admin reads.
- **F-77 (P2, hardening)** — per-conversation aggregate step ceiling. New `conversations.total_steps` column (migration 0039), tagged `ConversationBudgetExceededError`, new chat error code `conversation_budget_exceeded`, and an audit action `conversation.budget_exceeded`. The chat handler now uses an **atomic** upfront reservation (`UPDATE conversations SET total_steps = total_steps + $budget WHERE total_steps < $cap`) so concurrent runs can't all pass the gate at `cap − 1`. A settlement step on stream finish refunds the unused portion.

## Notes

- ~640 LOC (excluding test mock updates). All four review agents ran; both medium silent-failure findings (timing window + sustained-outage visibility) and both important code-reviewer findings (race + explicit scope) folded into this PR.
- Frontend: `ErrorBanner` gains an `onStartNewConversation` prop. When the chat handler returns `conversation_budget_exceeded`, the banner shows a "Start a new conversation" CTA instead of "Try again" (retry on the same id will keep failing).
- Migration `0039_conversation_step_cap.sql` adds `total_steps INTEGER NOT NULL DEFAULT 0`. Existing rows backfill via the column default — no separate backfill script.
- Audit doc Phase 6 flipped F-73 / F-74 / F-77 from `open` to `shipped`. F-75 / F-76 remain open (webhook plugin replay + per-channel rate limit — separate cluster).

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun run test` — full suite green (297/297 in @atlas/api after isolated runner)
- [x] Affected isolated runner — 125/125 pass (`cd packages/api && bun run scripts/test-isolated.ts --affected`)
- [x] `bun x syncpack lint` — clean
- [x] Template drift — clean
- [x] Railway watch — clean
- [x] F-73 unit tests pin the regression — 11+ rapid IP-less requests get 429 (today they all got 200)
- [x] F-74 chat-bucket isolation — burning chat ceiling does not lock out cheap reads (and vice versa)
- [x] F-77 atomic-reservation tests — exceeded path rejects with `conversation_budget_exceeded`, agent never invoked, `logAdminAction` audit row emitted with `scope: "workspace"`. Settlement test pins `settleConversationSteps(convId, reservedBudget, actualSteps)` after a successful stream
- [x] F-77 helper unit tests — atomic UPDATE shape, missing-row vs at-cap disambiguation, fail-open contracts, refund clamps via `GREATEST(0, …)`