### PR TITLE
feat(docs): agent discovery — middleware, robots.txt, .well-known, WebMCP

### DIFF
--- a/apps/docs/middleware.ts
+++ b/apps/docs/middleware.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+// RFC 8288 / 9727 link relations advertised on every docs response.
+// Single line so curl -I shows it cleanly.
+const LINK_HEADER = [
+  '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"',
+  '<https://docs.useatlas.dev/api-reference/openapi.json>; rel="service-desc"; type="application/openapi+json"',
+  '<https://api.useatlas.dev/api/health>; rel="status"; type="application/json"',
+  '</llms.txt>; rel="alternate"; type="text/plain"',
+  '</llms-full.txt>; rel="describedby"; type="text/plain"',
+  '</.well-known/mcp/server-card.json>; rel="mcp-server-card"; type="application/json"',
+  '</.well-known/oauth-protected-resource>; rel="oauth-protected-resource"; type="application/json"',
+  '</.well-known/agent-skills/index.json>; rel="agent-skills"; type="application/json"',
+].join(", ");
+
+function prefersMarkdown(req: NextRequest): boolean {
+  const accept = req.headers.get("accept");
+  if (!accept) return false;
+  return accept
+    .split(",")
+    .some((part) => part.trim().toLowerCase().startsWith("text/markdown"));
+}
+
+/**
+ * Map a docs page path to its markdown twin route. The
+ * /llms.mdx/[[...slug]] route handler already produces a complete
+ * markdown rendering (title + processed MDX) via getLLMText(), so
+ * Accept-based negotiation is just an internal rewrite to that handler.
+ */
+function markdownTwinPath(pathname: string): string | null {
+  // Homepage maps to the index.mdx page; the bare /llms.mdx route returns
+  // 404 because source.getPage([]) doesn't resolve. /llms.mdx/index does.
+  if (pathname === "/" || pathname === "/index") return "/llms.mdx/index";
+  // Skip API surfaces, well-known paths, and Fumadocs internals — they
+  // don't have a markdown twin and rewriting would 404 confusingly.
+  if (
+    pathname.startsWith("/_next/") ||
+    pathname.startsWith("/api/") ||
+    pathname.startsWith("/.well-known/") ||
+    pathname.startsWith("/llms") ||
+    pathname.startsWith("/docs-og/") ||
+    pathname.endsWith(".mdx") ||
+    pathname.endsWith(".txt") ||
+    pathname.endsWith(".json") ||
+    pathname.endsWith(".svg") ||
+    pathname.endsWith(".png") ||
+    pathname.endsWith(".ico")
+  ) {
+    return null;
+  }
+  const trimmed = pathname.replace(/\/+$/, "");
+  return `/llms.mdx${trimmed}`;
+}
+
+export function middleware(req: NextRequest): NextResponse {
+  const { pathname } = req.nextUrl;
+
+  if (prefersMarkdown(req)) {
+    const twin = markdownTwinPath(pathname);
+    if (twin) {
+      const url = req.nextUrl.clone();
+      url.pathname = twin;
+      const res = NextResponse.rewrite(url);
+      res.headers.set("Vary", "Accept");
+      return res;
+    }
+  }
+
+  const res = NextResponse.next();
+  res.headers.set("Link", LINK_HEADER);
+  res.headers.set("Vary", "Accept");
+  return res;
+}
+
+// Skip Next internals, static assets, and the search API. We deliberately
+// run on /.well-known/* so the Link header advertises them on the canonical
+// docs origin.
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|api/search|.*\\.(?:woff2?|png|jpg|jpeg|gif|webp|avif|css|js)).*)",
+  ],
+};

--- a/apps/docs/middleware.ts
+++ b/apps/docs/middleware.ts
@@ -2,7 +2,6 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
 // RFC 8288 / 9727 link relations advertised on every docs response.
-// Single line so curl -I shows it cleanly.
 const LINK_HEADER = [
   '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"',
   '<https://docs.useatlas.dev/api-reference/openapi.json>; rel="service-desc"; type="application/openapi+json"',
@@ -28,27 +27,21 @@ function prefersMarkdown(req: NextRequest): boolean {
  * markdown rendering (title + processed MDX) via getLLMText(), so
  * Accept-based negotiation is just an internal rewrite to that handler.
  */
+// Paths that don't have a markdown twin. Most static-asset extensions
+// are already filtered by the matcher regex below; this list covers the
+// remaining route prefixes (Fumadocs internals, our own llms* + .well-
+// known surfaces) plus the document-format extensions matcher doesn't
+// strip. Keep both layers — the matcher is a perf gate, this is a
+// correctness gate against a future matcher refactor.
+const MARKDOWN_TWIN_SKIP_PREFIXES = ["/_next/", "/api/", "/.well-known/", "/llms", "/docs-og/"];
+const MARKDOWN_TWIN_SKIP_SUFFIXES = [".mdx", ".txt", ".json", ".xml"];
+
 function markdownTwinPath(pathname: string): string | null {
   // Homepage maps to the index.mdx page; the bare /llms.mdx route returns
   // 404 because source.getPage([]) doesn't resolve. /llms.mdx/index does.
   if (pathname === "/" || pathname === "/index") return "/llms.mdx/index";
-  // Skip API surfaces, well-known paths, and Fumadocs internals — they
-  // don't have a markdown twin and rewriting would 404 confusingly.
-  if (
-    pathname.startsWith("/_next/") ||
-    pathname.startsWith("/api/") ||
-    pathname.startsWith("/.well-known/") ||
-    pathname.startsWith("/llms") ||
-    pathname.startsWith("/docs-og/") ||
-    pathname.endsWith(".mdx") ||
-    pathname.endsWith(".txt") ||
-    pathname.endsWith(".json") ||
-    pathname.endsWith(".svg") ||
-    pathname.endsWith(".png") ||
-    pathname.endsWith(".ico")
-  ) {
-    return null;
-  }
+  if (MARKDOWN_TWIN_SKIP_PREFIXES.some((p) => pathname.startsWith(p))) return null;
+  if (MARKDOWN_TWIN_SKIP_SUFFIXES.some((s) => pathname.endsWith(s))) return null;
   const trimmed = pathname.replace(/\/+$/, "");
   return `/llms.mdx${trimmed}`;
 }
@@ -73,9 +66,8 @@ export function middleware(req: NextRequest): NextResponse {
   return res;
 }
 
-// Skip Next internals, static assets, and the search API. We deliberately
-// run on /.well-known/* so the Link header advertises them on the canonical
-// docs origin.
+// Run on /.well-known/* so the Link header advertises them on the
+// canonical docs origin.
 export const config = {
   matcher: [
     "/((?!_next/static|_next/image|favicon.ico|api/search|.*\\.(?:woff2?|png|jpg|jpeg|gif|webp|avif|css|js)).*)",

--- a/apps/docs/public/robots.txt
+++ b/apps/docs/public/robots.txt
@@ -2,9 +2,6 @@
 # RFC 9309 (Robots Exclusion Protocol)
 # Content-Signal: https://contentsignals.org/
 
-# General crawlers — full access. Docs are public + intentionally
-# discoverable. Search indexing yes, training no, agent input yes (we
-# want agents to recommend Atlas based on these docs).
 User-agent: *
 Content-Signal: ai-train=no, search=yes, ai-input=yes
 Allow: /

--- a/apps/docs/public/robots.txt
+++ b/apps/docs/public/robots.txt
@@ -1,0 +1,88 @@
+# Atlas Docs — robots.txt
+# RFC 9309 (Robots Exclusion Protocol)
+# Content-Signal: https://contentsignals.org/
+
+# General crawlers — full access. Docs are public + intentionally
+# discoverable. Search indexing yes, training no, agent input yes (we
+# want agents to recommend Atlas based on these docs).
+User-agent: *
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+Allow: /
+Disallow: /api/search
+Disallow: /docs-og/
+
+# Search-specialized crawlers — full search indexing.
+User-agent: Googlebot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: DuckDuckBot
+Allow: /
+
+# AI training crawlers — opt out. We publish docs to help users build
+# with Atlas, not to train competing models. Refer to llms.txt for an
+# explicit agent-friendly summary if a model is permitted to read here
+# at agent-input time.
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: OAI-SearchBot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: Claude-Web
+Disallow: /
+
+User-agent: PerplexityBot
+Disallow: /
+
+User-agent: Perplexity-User
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: Meta-ExternalAgent
+Disallow: /
+
+User-agent: Meta-ExternalFetcher
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: cohere-ai
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: ImagesiftBot
+Disallow: /
+
+User-agent: Omgili
+Disallow: /
+
+User-agent: Timpibot
+Disallow: /
+
+Sitemap: https://docs.useatlas.dev/sitemap.xml

--- a/apps/docs/src/app/.well-known/agent-skills/index.json/route.ts
+++ b/apps/docs/src/app/.well-known/agent-skills/index.json/route.ts
@@ -1,0 +1,50 @@
+// Agent Skills Discovery RFC v0.2.0. The skills surface for the docs
+// origin: machine-readable summary, full corpus, OpenAPI spec, and the
+// MCP server card. Sha256 digests are computed at build time over the
+// referenced URL contents (llms.txt, llms-full.txt are dynamic so we
+// omit the digest there — agents that need it can recompute on fetch).
+export const dynamic = "force-static";
+
+const BODY = {
+  version: "0.2.0",
+  publisher: { name: "Atlas", url: "https://www.useatlas.dev" },
+  skills: [
+    {
+      name: "atlas-docs-summary",
+      type: "documentation",
+      description:
+        "Dynamic summary of the Atlas docs corpus (titles + descriptions of every page) — built from the Fumadocs source tree at request time.",
+      url: "https://docs.useatlas.dev/llms.txt",
+    },
+    {
+      name: "atlas-docs-full",
+      type: "documentation",
+      description:
+        "Full markdown rendering of every Atlas docs page concatenated into a single document. Use when you need the entire corpus inline.",
+      url: "https://docs.useatlas.dev/llms-full.txt",
+    },
+    {
+      name: "atlas-api-spec",
+      type: "tool",
+      description:
+        "OpenAPI 3.1 specification for the Atlas API. Use to generate clients or reason about request shapes.",
+      url: "https://docs.useatlas.dev/api-reference/openapi.json",
+    },
+    {
+      name: "atlas-mcp-server",
+      type: "tool",
+      description:
+        "MCP server card — connect an MCP-compatible client to your data warehouse via Atlas's validated text-to-SQL agent.",
+      url: "https://docs.useatlas.dev/.well-known/mcp/server-card.json",
+    },
+  ],
+};
+
+export function GET(): Response {
+  return new Response(JSON.stringify(BODY, null, 2), {
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "Cache-Control": "public, max-age=300",
+    },
+  });
+}

--- a/apps/docs/src/app/.well-known/agent-skills/index.json/route.ts
+++ b/apps/docs/src/app/.well-known/agent-skills/index.json/route.ts
@@ -1,8 +1,6 @@
 // Agent Skills Discovery RFC v0.2.0. The skills surface for the docs
 // origin: machine-readable summary, full corpus, OpenAPI spec, and the
-// MCP server card. Sha256 digests are computed at build time over the
-// referenced URL contents (llms.txt, llms-full.txt are dynamic so we
-// omit the digest there — agents that need it can recompute on fetch).
+// MCP server card.
 export const dynamic = "force-static";
 
 const BODY = {
@@ -38,7 +36,7 @@ const BODY = {
       url: "https://docs.useatlas.dev/.well-known/mcp/server-card.json",
     },
   ],
-};
+} as const;
 
 export function GET(): Response {
   return new Response(JSON.stringify(BODY, null, 2), {

--- a/apps/docs/src/app/.well-known/api-catalog/route.ts
+++ b/apps/docs/src/app/.well-known/api-catalog/route.ts
@@ -36,7 +36,7 @@ const BODY = {
       ],
     },
   ],
-};
+} as const;
 
 export function GET(): Response {
   return new Response(JSON.stringify(BODY, null, 2), {

--- a/apps/docs/src/app/.well-known/api-catalog/route.ts
+++ b/apps/docs/src/app/.well-known/api-catalog/route.ts
@@ -1,0 +1,48 @@
+// RFC 9727 — API catalog. application/linkset+json (RFC 9264).
+export const dynamic = "force-static";
+
+const BODY = {
+  linkset: [
+    {
+      anchor: "https://api.useatlas.dev/",
+      "service-desc": [
+        {
+          href: "https://docs.useatlas.dev/api-reference/openapi.json",
+          type: "application/openapi+json",
+        },
+      ],
+      "service-doc": [
+        { href: "https://docs.useatlas.dev/api-reference", type: "text/html" },
+        {
+          href: "https://docs.useatlas.dev/api-reference.mdx",
+          type: "text/markdown",
+        },
+      ],
+      status: [
+        { href: "https://api.useatlas.dev/api/health", type: "application/json" },
+      ],
+      "service-meta": [
+        {
+          href: "https://docs.useatlas.dev/.well-known/oauth-protected-resource",
+          type: "application/json",
+        },
+      ],
+    },
+    {
+      anchor: "https://docs.useatlas.dev/",
+      "service-doc": [
+        { href: "https://docs.useatlas.dev/llms.txt", type: "text/plain" },
+        { href: "https://docs.useatlas.dev/llms-full.txt", type: "text/plain" },
+      ],
+    },
+  ],
+};
+
+export function GET(): Response {
+  return new Response(JSON.stringify(BODY, null, 2), {
+    headers: {
+      "Content-Type": "application/linkset+json; charset=utf-8",
+      "Cache-Control": "public, max-age=300",
+    },
+  });
+}

--- a/apps/docs/src/app/.well-known/mcp/server-card.json/route.ts
+++ b/apps/docs/src/app/.well-known/mcp/server-card.json/route.ts
@@ -1,0 +1,65 @@
+// MCP Server Card (SEP-1649). Mirrors www's card so an agent that
+// discovers via either origin reaches the same metadata.
+export const dynamic = "force-static";
+
+const BODY = {
+  serverInfo: {
+    name: "atlas",
+    title: "Atlas — Text-to-SQL Data Analyst",
+    version: "0.1.0",
+    description:
+      "Atlas MCP server. Connects an MCP-compatible client (Claude Desktop, Cursor, Windsurf, Zed) to your data warehouse via Atlas's text-to-SQL agent. Read-only by default; every query is AST-validated against a YAML semantic layer and table whitelist.",
+    websiteUrl: "https://www.useatlas.dev",
+    documentationUrl: "https://docs.useatlas.dev/integrations/mcp",
+    license: "AGPL-3.0-or-later",
+    vendor: { name: "Atlas", url: "https://www.useatlas.dev" },
+  },
+  transports: [
+    {
+      type: "http",
+      endpoint: "https://api.useatlas.dev/api/v1/mcp/sse",
+      authentication: {
+        scheme: "bearer",
+        tokenSource: "https://app.useatlas.dev/admin/api-keys",
+      },
+    },
+  ],
+  capabilities: {
+    tools: { listChanged: true },
+    resources: { subscribe: false, listChanged: true },
+    prompts: { listChanged: true },
+    logging: {},
+  },
+  tools: [
+    {
+      name: "executeSQL",
+      description:
+        "Run a read-only SELECT against a connected datasource. Validates against the semantic-layer whitelist.",
+    },
+    {
+      name: "explore",
+      description:
+        "Read-only filesystem access (ls / cat / grep / find) over the semantic layer YAML.",
+    },
+    {
+      name: "executePython",
+      description:
+        "Run sandboxed Python (nsjail / Vercel sandbox / sidecar) for chart rendering and analysis.",
+    },
+  ],
+  links: {
+    agentSkills:
+      "https://docs.useatlas.dev/.well-known/agent-skills/index.json",
+    apiCatalog: "https://docs.useatlas.dev/.well-known/api-catalog",
+    openapi: "https://docs.useatlas.dev/api-reference/openapi.json",
+  },
+};
+
+export function GET(): Response {
+  return new Response(JSON.stringify(BODY, null, 2), {
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "Cache-Control": "public, max-age=300",
+    },
+  });
+}

--- a/apps/docs/src/app/.well-known/mcp/server-card.json/route.ts
+++ b/apps/docs/src/app/.well-known/mcp/server-card.json/route.ts
@@ -53,7 +53,7 @@ const BODY = {
     apiCatalog: "https://docs.useatlas.dev/.well-known/api-catalog",
     openapi: "https://docs.useatlas.dev/api-reference/openapi.json",
   },
-};
+} as const;
 
 export function GET(): Response {
   return new Response(JSON.stringify(BODY, null, 2), {

--- a/apps/docs/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/apps/docs/src/app/.well-known/oauth-protected-resource/route.ts
@@ -11,7 +11,7 @@ const BODY = {
   resource_name: "Atlas API",
   resource_policy_uri: "https://www.useatlas.dev/privacy",
   resource_tos_uri: "https://www.useatlas.dev/terms",
-};
+} as const;
 
 export function GET(): Response {
   return new Response(JSON.stringify(BODY, null, 2), {

--- a/apps/docs/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/apps/docs/src/app/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,23 @@
+// RFC 9728 — OAuth Protected Resource Metadata. Atlas API uses bearer
+// API keys (issued at app.useatlas.dev/admin/api-keys) plus Better Auth
+// sessions; the resource server is api.useatlas.dev.
+export const dynamic = "force-static";
+
+const BODY = {
+  resource: "https://api.useatlas.dev",
+  authorization_servers: ["https://api.useatlas.dev"],
+  bearer_methods_supported: ["header"],
+  resource_documentation: "https://docs.useatlas.dev/api-reference",
+  resource_name: "Atlas API",
+  resource_policy_uri: "https://www.useatlas.dev/privacy",
+  resource_tos_uri: "https://www.useatlas.dev/terms",
+};
+
+export function GET(): Response {
+  return new Response(JSON.stringify(BODY, null, 2), {
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "Cache-Control": "public, max-age=300",
+    },
+  });
+}

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { RootProvider } from "fumadocs-ui/provider/next";
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import "./globals.css";
+import WebMCP from "@/components/webmcp";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://docs.useatlas.dev"),
@@ -18,6 +19,7 @@ export default function Layout({ children }: { children: ReactNode }) {
     <html lang="en" suppressHydrationWarning>
       <body className="flex min-h-screen flex-col">
         <RootProvider>{children}</RootProvider>
+        <WebMCP />
       </body>
     </html>
   );

--- a/apps/docs/src/app/llms.mdx/[[...slug]]/route.ts
+++ b/apps/docs/src/app/llms.mdx/[[...slug]]/route.ts
@@ -13,9 +13,7 @@ export async function GET(
   if (!page) notFound();
 
   const content = await getLLMText(page);
-  // Rough token estimate — most tokenizers land around 3.5–4 chars/token
-  // for English markdown. Surfaced so agents can budget context windows
-  // without re-tokenizing the body.
+  // Rough char/4 token estimate so agents can budget context without re-tokenizing.
   const tokenEstimate = Math.ceil(content.length / 4);
   return new Response(content, {
     headers: {

--- a/apps/docs/src/app/llms.mdx/[[...slug]]/route.ts
+++ b/apps/docs/src/app/llms.mdx/[[...slug]]/route.ts
@@ -13,8 +13,16 @@ export async function GET(
   if (!page) notFound();
 
   const content = await getLLMText(page);
+  // Rough token estimate — most tokenizers land around 3.5–4 chars/token
+  // for English markdown. Surfaced so agents can budget context windows
+  // without re-tokenizing the body.
+  const tokenEstimate = Math.ceil(content.length / 4);
   return new Response(content, {
-    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "X-Markdown-Tokens": String(tokenEstimate),
+      "X-Markdown-Source": page.url,
+    },
   });
 }
 

--- a/apps/docs/src/components/webmcp.tsx
+++ b/apps/docs/src/components/webmcp.tsx
@@ -2,10 +2,9 @@
 
 import { useEffect } from "react";
 
-// Provides tools to in-browser agents via Chrome's experimental webmcp
-// proposal (navigator.modelContext). No-op elsewhere. Response envelope
-// mirrors MCP server tools/call since the WebMCP draft hasn't finalized
-// its own shape — track at https://webmachinelearning.github.io/webmcp/.
+// Chrome's experimental webmcp proposal (navigator.modelContext).
+// Response envelope mirrors MCP tools/call until the WebMCP draft
+// finalizes its shape: https://webmachinelearning.github.io/webmcp/.
 type ModelContextTool = {
   name: string;
   description: string;
@@ -85,21 +84,41 @@ const TOOLS: ModelContextTool[] = [
       if (typeof input.slug !== "string") {
         return { content: [{ type: "text", text: "slug must be a string." }] };
       }
-      const slug = input.slug.trim().replace(/^\/+/, "").replace(/\.mdx?$/, "");
-      if (!slug) {
+      const normalized = input.slug.trim().replace(/^\/+/, "").replace(/\.mdx?$/, "");
+      if (!normalized) {
         return { content: [{ type: "text", text: "No slug provided." }] };
       }
-      const url = `https://docs.useatlas.dev/${slug}.mdx`;
+      // Defense-in-depth: same-origin URL parsing already keeps fetches
+      // within docs.useatlas.dev, but reject obvious garbage early so the
+      // agent gets a clear error before a wasted round-trip.
+      if (!/^[a-z0-9][a-z0-9/_-]*$/i.test(normalized)) {
+        return {
+          content: [{ type: "text", text: `Invalid slug: ${input.slug}. Use lowercase letters, digits, '/', '_', or '-'.` }],
+        };
+      }
+      const url = `https://docs.useatlas.dev/${normalized}.mdx`;
       try {
         const res = await fetch(url, { headers: { Accept: "text/markdown,text/plain" } });
         if (!res.ok) {
-          return {
-            content: [{ type: "text", text: `Page not found: ${url} (HTTP ${res.status}).` }],
-          };
+          console.warn(
+            "[webmcp] atlas_get_doc_markdown non-OK status:",
+            url,
+            res.status,
+          );
+          const transient = res.status >= 500 || res.status === 429;
+          const message = transient
+            ? `Upstream error fetching ${url} (HTTP ${res.status}). Retry shortly.`
+            : `Page not found: ${url} (HTTP ${res.status}).`;
+          return { content: [{ type: "text", text: message }] };
         }
         const md = await res.text();
         return { content: [{ type: "text", text: md }] };
       } catch (err) {
+        console.warn(
+          "[webmcp] atlas_get_doc_markdown fetch failed:",
+          url,
+          err instanceof Error ? err.message : String(err),
+        );
         return {
           content: [
             {
@@ -128,6 +147,9 @@ export default function WebMCP() {
     const mc = (navigator as WebMcpNavigator).modelContext;
     if (!mc?.provideContext) return;
     Promise.resolve(mc.provideContext({ tools: TOOLS })).catch((err: unknown) => {
+      // console.warn so the failure is visible at the default devtools
+      // level — silent breakage of the whole webmcp surface is exactly
+      // what we don't want to ship.
       console.warn(
         "[webmcp] provideContext failed:",
         err instanceof Error ? err.message : String(err),

--- a/apps/docs/src/components/webmcp.tsx
+++ b/apps/docs/src/components/webmcp.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect } from "react";
+
+// Provides tools to in-browser agents via Chrome's experimental webmcp
+// proposal (navigator.modelContext). No-op elsewhere. Response envelope
+// mirrors MCP server tools/call since the WebMCP draft hasn't finalized
+// its own shape — track at https://webmachinelearning.github.io/webmcp/.
+type ModelContextTool = {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  execute: (input: Record<string, unknown>) => Promise<{
+    content: Array<{ type: "text"; text: string }>;
+  }>;
+};
+
+type ModelContext = {
+  provideContext: (ctx: { tools: ModelContextTool[] }) => Promise<void> | void;
+};
+
+type WebMcpNavigator = Navigator & { modelContext?: ModelContext };
+
+function openAndReport(
+  url: string,
+  openedText: string,
+): { content: Array<{ type: "text"; text: string }> } {
+  if (typeof window === "undefined") {
+    return { content: [{ type: "text", text: `${url} (server context — cannot open)` }] };
+  }
+  const win = window.open(url, "_blank", "noopener");
+  const text =
+    win === null
+      ? `Couldn't open a new tab — popup blocker likely. Visit ${url} directly.`
+      : openedText;
+  return { content: [{ type: "text", text }] };
+}
+
+const TOOLS: ModelContextTool[] = [
+  {
+    name: "atlas_search_docs",
+    description:
+      "Search the Atlas documentation. Use to find setup guides, API reference, plugin docs, or integration walkthroughs.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "What to search for (e.g. 'BigQuery setup', 'MCP server', 'rate limits').",
+        },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+    async execute(input) {
+      if (typeof input.query !== "string") {
+        return { content: [{ type: "text", text: "query must be a string." }] };
+      }
+      const query = input.query.trim();
+      if (!query) {
+        return {
+          content: [{ type: "text", text: "No query provided. Try 'BigQuery setup' or 'MCP server'." }],
+        };
+      }
+      const url = `https://docs.useatlas.dev/?q=${encodeURIComponent(query)}`;
+      return openAndReport(url, `Opened Atlas docs search for "${query}": ${url}`);
+    },
+  },
+  {
+    name: "atlas_get_doc_markdown",
+    description:
+      "Fetch the markdown source of an Atlas docs page by slug (e.g. 'getting-started', 'integrations/mcp'). Returns the full markdown inline so the agent can read it without a separate browser fetch. Use this when you need to ground an answer in the docs.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        slug: {
+          type: "string",
+          description: "Docs page slug, with or without leading slash (e.g. 'getting-started').",
+        },
+      },
+      required: ["slug"],
+      additionalProperties: false,
+    },
+    async execute(input) {
+      if (typeof input.slug !== "string") {
+        return { content: [{ type: "text", text: "slug must be a string." }] };
+      }
+      const slug = input.slug.trim().replace(/^\/+/, "").replace(/\.mdx?$/, "");
+      if (!slug) {
+        return { content: [{ type: "text", text: "No slug provided." }] };
+      }
+      const url = `https://docs.useatlas.dev/${slug}.mdx`;
+      try {
+        const res = await fetch(url, { headers: { Accept: "text/markdown,text/plain" } });
+        if (!res.ok) {
+          return {
+            content: [{ type: "text", text: `Page not found: ${url} (HTTP ${res.status}).` }],
+          };
+        }
+        const md = await res.text();
+        return { content: [{ type: "text", text: md }] };
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Fetch failed for ${url}: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+        };
+      }
+    },
+  },
+  {
+    name: "atlas_view_repo",
+    description:
+      "Open the Atlas source repository on GitHub (AtlasDevHQ/atlas). Useful when the agent needs to reference issues, PRs, or source code.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    async execute() {
+      const url = "https://github.com/AtlasDevHQ/atlas";
+      return openAndReport(url, `Opened Atlas repository: ${url}`);
+    },
+  },
+];
+
+export default function WebMCP() {
+  useEffect(() => {
+    const mc = (navigator as WebMcpNavigator).modelContext;
+    if (!mc?.provideContext) return;
+    Promise.resolve(mc.provideContext({ tools: TOOLS })).catch((err: unknown) => {
+      console.warn(
+        "[webmcp] provideContext failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+    });
+  }, []);
+  return null;
+}


### PR DESCRIPTION
## Summary

Mirrors the www agent-discovery surface (#1857) on docs.useatlas.dev, adapted to the Next.js standalone runtime. Where www needed a custom Bun server, docs uses middleware + route handlers — much cleaner.

The win: docs already had `getLLMText(page)` producing markdown for every MDX file via the `/llms.mdx/[[...slug]]` handler. Markdown content negotiation is just a middleware rewrite that points at this existing infrastructure.

## Endpoints lit up

| # | Goal | Where |
|---|---|---|
| 1 | robots.txt with crawl rules | `public/robots.txt` |
| 2 | RFC 8288 Link header | `middleware.ts` (every response) |
| 3 | Markdown for Agents | `middleware.ts` rewrites `Accept: text/markdown` → `/llms.mdx/<slug>` |
| 4 | AI-crawler User-agent rules | `public/robots.txt` (GPTBot, ClaudeBot, Google-Extended, +15 more) |
| 5 | Content-Signal | `public/robots.txt` — \`ai-train=no, search=yes, ai-input=yes\` |
| 6 | API catalog (RFC 9727) | `src/app/.well-known/api-catalog/route.ts` (linkset+json) |
| 7 | OAuth protected resource (RFC 9728) | `src/app/.well-known/oauth-protected-resource/route.ts` |
| 8 | MCP server card | `src/app/.well-known/mcp/server-card.json/route.ts` |
| 9 | Agent skills index v0.2.0 | `src/app/.well-known/agent-skills/index.json/route.ts` |
| 10 | WebMCP | `src/components/webmcp.tsx` — search docs, get-doc-markdown, view-repo |

## What's deliberately skipped

- **openid-configuration** + **oauth-authorization-server** — same reasoning as #1857. Atlas runs cookie sessions + API keys, no JWT plugin, no OIDC issuer. Publishing aspirational metadata would break spec-compliant agents that try to follow it.

## Behavior notes

- Markdown content negotiation: homepage rewrites to `/llms.mdx/index` (`source.getPage([])` doesn't resolve in Fumadocs; the explicit `index` slug does). Section landings (e.g. `/getting-started`) correctly 404 for markdown — they have no MDX file of their own; agents should request a specific child page.
- `llms.mdx` route handler now emits `X-Markdown-Tokens` (chars/4 estimate) and `X-Markdown-Source` headers so agents can budget context windows.
- WebMCP `atlas_get_doc_markdown` fetches `/<slug>.mdx` server-side and returns the markdown inline — saves a browser fetch when the agent wants to ground an answer in docs content.

## Smoke tests (local on port 3003)

\`\`\`
$ curl -sI -H 'Accept: text/markdown' http://localhost:3003/
HTTP/1.1 200 OK
content-type: text/markdown; charset=utf-8
x-middleware-rewrite: /llms.mdx/index

$ curl -sI -H 'Accept: text/markdown' http://localhost:3003/changelog
content-type: text/markdown; charset=utf-8
x-markdown-source: /changelog
x-markdown-tokens: 13

$ curl -sI http://localhost:3003/.well-known/api-catalog
content-type: application/linkset+json; charset=utf-8

$ curl -sI http://localhost:3003/.well-known/oauth-protected-resource
content-type: application/json; charset=utf-8

$ curl -s http://localhost:3003/robots.txt | grep -E 'Content-Signal|GPTBot|ClaudeBot'
Content-Signal: ai-train=no, search=yes, ai-input=yes
User-agent: GPTBot
User-agent: ClaudeBot
\`\`\`

## Test plan

- [x] \`bun run --filter '@atlas/docs' build\` — clean, 1490 static pages + 4 well-known route handlers + middleware
- [x] \`bun run type\` — clean
- [x] \`bun x syncpack lint\` — \`No issues found\`
- [x] \`SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh\` — passed
- [x] \`bash scripts/check-railway-watch.sh\` — passed
- [x] Manual smoke against local docs server (commands above)
- [ ] Post-deploy: verify isitagentready.com lights up the 10 checks against \`docs.useatlas.dev\`