### PR TITLE
feat(web): #1867 — dashboard detail freeform tile grid (1.3.0 Bucket 3b)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -4764,6 +4764,40 @@
                       "string",
                       "null"
                     ]
+                  },
+                  "layout": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "x": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 23
+                      },
+                      "y": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 10000
+                      },
+                      "w": {
+                        "type": "integer",
+                        "minimum": 3,
+                        "maximum": 24
+                      },
+                      "h": {
+                        "type": "integer",
+                        "minimum": 4,
+                        "maximum": 200
+                      }
+                    },
+                    "required": [
+                      "x",
+                      "y",
+                      "w",
+                      "h"
+                    ]
                   }
                 },
                 "required": [
@@ -4992,6 +5026,40 @@
                   "position": {
                     "type": "integer",
                     "minimum": 0
+                  },
+                  "layout": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "x": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 23
+                      },
+                      "y": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 10000
+                      },
+                      "w": {
+                        "type": "integer",
+                        "minimum": 3,
+                        "maximum": 24
+                      },
+                      "h": {
+                        "type": "integer",
+                        "minimum": 4,
+                        "maximum": 200
+                      }
+                    },
+                    "required": [
+                      "x",
+                      "y",
+                      "w",
+                      "h"
+                    ]
                   }
                 }
               }

--- a/bun.lock
+++ b/bun.lock
@@ -343,6 +343,7 @@
         "react": "^19.2.4",
         "react-day-picker": "^9.14.0",
         "react-dom": "^19.2.4",
+        "react-grid-layout": "^2.2.3",
         "react-hook-form": "^7.72.0",
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^4",
@@ -2620,6 +2621,8 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
+    "fast-equals": ["fast-equals@4.0.3", "", {}, "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg=="],
+
     "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
 
     "fast-glob": ["fast-glob@3.3.1", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.4" } }, "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg=="],
@@ -3086,6 +3089,8 @@
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
+    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
+
     "lowlight": ["lowlight@1.20.0", "", { "dependencies": { "fault": "^1.0.0", "highlight.js": "~10.7.0" } }, "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw=="],
 
     "lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
@@ -3514,6 +3519,8 @@
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
+    "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
+
     "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
@@ -3562,6 +3569,10 @@
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
+    "react-draggable": ["react-draggable@4.5.0", "", { "dependencies": { "clsx": "^2.1.1", "prop-types": "^15.8.1" }, "peerDependencies": { "react": ">= 16.3.0", "react-dom": ">= 16.3.0" } }, "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw=="],
+
+    "react-grid-layout": ["react-grid-layout@2.2.3", "", { "dependencies": { "clsx": "^2.1.1", "fast-equals": "^4.0.3", "prop-types": "^15.8.1", "react-draggable": "^4.4.6", "react-resizable": "^3.1.3", "resize-observer-polyfill": "^1.5.1" }, "peerDependencies": { "react": ">= 16.3.0", "react-dom": ">= 16.3.0" } }, "sha512-OAEJHBxmfuxQfVtZwRzmsokijGlBgzYIJ7MUlLk/VSa43SaGzu15w5D0P2RDrfX5EvP9POMbL6bFrai/huDzbQ=="],
+
     "react-hook-form": ["react-hook-form@7.72.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-V4v6jubaf6JAurEaVnT9aUPKFbNtDgohj5CIgVGyPHvT9wRx5OZHVjz31GsxnPNI278XMu+ruFz+wGOscHaLKw=="],
 
     "react-is": ["react-is@19.2.4", "", {}, "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA=="],
@@ -3575,6 +3586,8 @@
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
+
+    "react-resizable": ["react-resizable@3.1.3", "", { "dependencies": { "prop-types": "15.x", "react-draggable": "^4.5.0" }, "peerDependencies": { "react": ">= 16.3", "react-dom": ">= 16.3" } }, "sha512-liJBNayhX7qA4tBJiBD321FDhJxgGTJ07uzH5zSORXoE8h7PyEZ8mLqmosST7ppf6C4zUsbd2gzDMmBCfFp9Lw=="],
 
     "react-resizable-panels": ["react-resizable-panels@4.9.0", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-sEl+hA6y9/kxa0aPlrUC+G1lcShAf/PiIjoeC8kWXxa53RfAVplVCIxEl01Nwa4L2iRa5JXBXq1/mI8ch6qOZQ=="],
 
@@ -3643,6 +3656,8 @@
     "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 
     "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
+
+    "resize-observer-polyfill": ["resize-observer-polyfill@1.5.1", "", {}, "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="],
 
     "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
@@ -4415,6 +4430,8 @@
     "prisma/mysql2": ["mysql2@3.15.3", "", { "dependencies": { "aws-ssl-profiles": "^1.1.1", "denque": "^2.1.0", "generate-function": "^2.3.1", "iconv-lite": "^0.7.0", "long": "^5.2.1", "lru.min": "^1.0.0", "named-placeholders": "^1.1.3", "seq-queue": "^0.0.5", "sqlstring": "^2.3.2" } }, "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "proper-lockfile/retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 

--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -173,6 +173,10 @@ const mockGetSharedDashboard = mock((): Promise<unknown> =>
   Promise.resolve({ ok: false, reason: "not_found" }),
 );
 
+// Re-import the real CardLayoutSchema + rowToCard so the mock is otherwise complete
+// per CLAUDE.md ("Mock all exports — partial mocks cause SyntaxError").
+const realDashboards = await import("@atlas/api/lib/dashboards");
+
 mock.module("@atlas/api/lib/dashboards", () => ({
   createDashboard: mockCreateDashboard,
   getDashboard: mockGetDashboard,
@@ -192,6 +196,8 @@ mock.module("@atlas/api/lib/dashboards", () => ({
   getDashboardsDueForRefresh: mock(() => Promise.resolve([])),
   lockDashboardForRefresh: mock(() => Promise.resolve(false)),
   refreshDashboardCards: mock(() => Promise.resolve({ refreshed: 0, failed: 0, total: 0 })),
+  CardLayoutSchema: realDashboards.CardLayoutSchema,
+  rowToCard: realDashboards.rowToCard,
 }));
 
 // --- Other mocks required by app index.ts ---

--- a/packages/api/src/api/routes/dashboards.ts
+++ b/packages/api/src/api/routes/dashboards.ts
@@ -28,6 +28,7 @@ import {
   getShareStatus,
   getSharedDashboard,
   setRefreshSchedule,
+  CardLayoutSchema,
   type CrudFailReason,
   type SharedDashboardFailReason,
 } from "@atlas/api/lib/dashboards";
@@ -56,14 +57,6 @@ const ChartConfigSchema = z.object({
   type: z.enum(CHART_TYPES),
   categoryColumn: z.string(),
   valueColumns: z.array(z.string()).min(1),
-});
-
-// 24-col freeform grid layout. Bounds match the client's grid math (#1867).
-const CardLayoutSchema = z.object({
-  x: z.number().int().min(0).max(23),
-  y: z.number().int().min(0).max(10_000),
-  w: z.number().int().min(3).max(24),
-  h: z.number().int().min(4).max(200),
 });
 
 const CreateDashboardSchema = z.object({

--- a/packages/api/src/api/routes/dashboards.ts
+++ b/packages/api/src/api/routes/dashboards.ts
@@ -58,6 +58,14 @@ const ChartConfigSchema = z.object({
   valueColumns: z.array(z.string()).min(1),
 });
 
+// 24-col freeform grid layout. Bounds match the client's grid math (#1867).
+const CardLayoutSchema = z.object({
+  x: z.number().int().min(0).max(23),
+  y: z.number().int().min(0).max(10_000),
+  w: z.number().int().min(3).max(24),
+  h: z.number().int().min(4).max(200),
+});
+
 const CreateDashboardSchema = z.object({
   title: z.string().min(1).max(200),
   description: z.string().max(2000).nullable().optional(),
@@ -76,12 +84,14 @@ const AddCardSchema = z.object({
   cachedColumns: z.array(z.string()).nullable().optional(),
   cachedRows: z.array(z.record(z.string(), z.unknown())).nullable().optional(),
   connectionId: z.string().nullable().optional(),
+  layout: CardLayoutSchema.nullable().optional(),
 });
 
 const UpdateCardSchema = z.object({
   title: z.string().min(1).max(200).optional(),
   chartConfig: ChartConfigSchema.nullable().optional(),
   position: z.number().int().min(0).optional(),
+  layout: CardLayoutSchema.nullable().optional(),
 });
 
 const ShareSchema = z.object({
@@ -656,6 +666,7 @@ authed.openapi(
         cachedColumns: parsed.cachedColumns ?? null,
         cachedRows: parsed.cachedRows ?? null,
         connectionId: parsed.connectionId ?? null,
+        layout: parsed.layout ?? null,
       }));
 
       if (!result.ok) {

--- a/packages/api/src/lib/__tests__/dashboards-row-to-card.test.ts
+++ b/packages/api/src/lib/__tests__/dashboards-row-to-card.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect } from "bun:test";
+import { rowToCard, CardLayoutSchema } from "@atlas/api/lib/dashboards";
+
+const baseRow = {
+  id: "card-1",
+  dashboard_id: "dash-1",
+  position: 0,
+  title: "Untitled",
+  sql: "SELECT 1",
+  chart_config: null,
+  cached_columns: null,
+  cached_rows: null,
+  cached_at: null,
+  connection_id: null,
+  created_at: "2026-04-25T00:00:00Z",
+  updated_at: "2026-04-25T00:00:00Z",
+};
+
+describe("rowToCard layout parsing", () => {
+  test("accepts a valid layout object", () => {
+    const card = rowToCard({ ...baseRow, layout: { x: 1, y: 2, w: 12, h: 6 } });
+    expect(card.layout).toEqual({ x: 1, y: 2, w: 12, h: 6 });
+  });
+
+  test("accepts a JSON-string layout (driver may surface JSONB as text)", () => {
+    const card = rowToCard({ ...baseRow, layout: '{"x":3,"y":0,"w":10,"h":5}' });
+    expect(card.layout).toEqual({ x: 3, y: 0, w: 10, h: 5 });
+  });
+
+  test("discards a layout missing required fields", () => {
+    const card = rowToCard({ ...baseRow, layout: { x: 1, y: 2, w: 12 } });
+    expect(card.layout).toBeNull();
+  });
+
+  test("discards malformed JSON string", () => {
+    const card = rowToCard({ ...baseRow, layout: "not json" });
+    expect(card.layout).toBeNull();
+  });
+
+  test("discards out-of-bounds values that the route schema would reject", () => {
+    const card = rowToCard({ ...baseRow, layout: { x: -5, y: 0, w: 12, h: 6 } });
+    expect(card.layout).toBeNull();
+  });
+
+  test("discards layouts overflowing the 24-col grid via x + w", () => {
+    const card = rowToCard({ ...baseRow, layout: { x: 23, y: 0, w: 24, h: 6 } });
+    expect(card.layout).toBeNull();
+  });
+
+  test("discards NaN/Infinity numbers", () => {
+    expect(rowToCard({ ...baseRow, layout: { x: Number.NaN, y: 0, w: 12, h: 6 } }).layout).toBeNull();
+    expect(rowToCard({ ...baseRow, layout: { x: 1, y: Number.POSITIVE_INFINITY, w: 12, h: 6 } }).layout).toBeNull();
+  });
+
+  test("treats null layout as not-yet-placed", () => {
+    expect(rowToCard({ ...baseRow, layout: null }).layout).toBeNull();
+    expect(rowToCard({ ...baseRow }).layout).toBeNull();
+  });
+});
+
+describe("CardLayoutSchema bounds", () => {
+  test("accepts a typical layout", () => {
+    expect(CardLayoutSchema.safeParse({ x: 0, y: 0, w: 12, h: 10 }).success).toBe(true);
+  });
+
+  test("rejects x at the right edge that overflows", () => {
+    expect(CardLayoutSchema.safeParse({ x: 23, y: 0, w: 12, h: 10 }).success).toBe(false);
+  });
+
+  test("rejects w below minimum", () => {
+    expect(CardLayoutSchema.safeParse({ x: 0, y: 0, w: 2, h: 10 }).success).toBe(false);
+  });
+
+  test("rejects h below minimum", () => {
+    expect(CardLayoutSchema.safeParse({ x: 0, y: 0, w: 12, h: 3 }).success).toBe(false);
+  });
+
+  test("rejects fractional values", () => {
+    expect(CardLayoutSchema.safeParse({ x: 0.5, y: 0, w: 12, h: 10 }).success).toBe(false);
+  });
+
+  test("rejects negative coordinates", () => {
+    expect(CardLayoutSchema.safeParse({ x: -1, y: 0, w: 12, h: 10 }).success).toBe(false);
+    expect(CardLayoutSchema.safeParse({ x: 0, y: -1, w: 12, h: 10 }).success).toBe(false);
+  });
+});

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -286,6 +286,7 @@ describe("migrateAuthTables", () => {
             { name: "0038_encryption_key_versioning.sql" },
             { name: "0039_conversation_step_cap.sql" },
             { name: "0040_drop_integration_plaintext.sql" },
+            { name: "0041_dashboard_card_layout.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/dashboard-types.ts
+++ b/packages/api/src/lib/dashboard-types.ts
@@ -14,4 +14,4 @@ export type {
   DashboardSuggestion,
 } from "@useatlas/types";
 
-export { CHART_TYPES } from "@useatlas/types";
+export { CHART_TYPES, DASHBOARD_GRID } from "@useatlas/types";

--- a/packages/api/src/lib/dashboard-types.ts
+++ b/packages/api/src/lib/dashboard-types.ts
@@ -7,6 +7,7 @@
 export type {
   ChartType,
   DashboardChartConfig,
+  DashboardCardLayout,
   Dashboard,
   DashboardCard,
   DashboardWithCards,

--- a/packages/api/src/lib/dashboard-types.ts
+++ b/packages/api/src/lib/dashboard-types.ts
@@ -14,4 +14,19 @@ export type {
   DashboardSuggestion,
 } from "@useatlas/types";
 
-export { CHART_TYPES, DASHBOARD_GRID } from "@useatlas/types";
+export { CHART_TYPES } from "@useatlas/types";
+
+/**
+ * Bounds of the dashboard tile grid (#1867). Lives in the api package — not
+ * `@useatlas/types` — so a bump doesn't require an npm publish + template
+ * version bump. Must mirror the constants in
+ * `packages/web/src/ui/components/dashboards/grid-constants.ts`.
+ */
+export const DASHBOARD_GRID = {
+  COLS: 24,
+  MIN_W: 3,
+  MAX_W: 24,
+  MIN_H: 4,
+  MAX_H: 200,
+  MAX_Y: 10_000,
+} as const;

--- a/packages/api/src/lib/dashboards.ts
+++ b/packages/api/src/lib/dashboards.ts
@@ -16,6 +16,7 @@ import {
 import type {
   Dashboard,
   DashboardCard,
+  DashboardCardLayout,
   DashboardWithCards,
   DashboardChartConfig,
 } from "@atlas/api/lib/dashboard-types";
@@ -84,6 +85,26 @@ function rowToCard(r: Record<string, unknown>): DashboardCard {
     }
   }
 
+  let layout: DashboardCardLayout | null = null;
+  if (r.layout) {
+    try {
+      const raw = typeof r.layout === "string" ? JSON.parse(r.layout) : r.layout;
+      if (
+        raw && typeof raw === "object"
+        && typeof (raw as { x: unknown }).x === "number"
+        && typeof (raw as { y: unknown }).y === "number"
+        && typeof (raw as { w: unknown }).w === "number"
+        && typeof (raw as { h: unknown }).h === "number"
+      ) {
+        layout = raw as DashboardCardLayout;
+      } else {
+        log.warn({ cardId: r.id }, "Discarding malformed dashboard_card.layout JSONB");
+      }
+    } catch (err) {
+      log.warn({ cardId: r.id, err: errorMessage(err) }, "Failed to parse layout JSONB");
+    }
+  }
+
   return {
     id: r.id as string,
     dashboardId: r.dashboard_id as string,
@@ -95,6 +116,7 @@ function rowToCard(r: Record<string, unknown>): DashboardCard {
     cachedRows,
     cachedAt: r.cached_at ? String(r.cached_at) : null,
     connectionId: (r.connection_id as string) ?? null,
+    layout,
     createdAt: String(r.created_at),
     updatedAt: String(r.updated_at),
   };
@@ -310,6 +332,7 @@ export async function addCard(opts: {
   cachedColumns?: string[] | null;
   cachedRows?: Record<string, unknown>[] | null;
   connectionId?: string | null;
+  layout?: DashboardCardLayout | null;
 }): Promise<CrudDataResult<DashboardCard>> {
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
   try {
@@ -321,8 +344,8 @@ export async function addCard(opts: {
     const nextPos = (posRows[0]?.next_pos as number) ?? 0;
 
     const rows = await internalQuery<Record<string, unknown>>(
-      `INSERT INTO dashboard_cards (dashboard_id, position, title, sql, chart_config, cached_columns, cached_rows, cached_at, connection_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      `INSERT INTO dashboard_cards (dashboard_id, position, title, sql, chart_config, cached_columns, cached_rows, cached_at, connection_id, layout)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
        RETURNING *`,
       [
         opts.dashboardId,
@@ -334,6 +357,7 @@ export async function addCard(opts: {
         opts.cachedRows ? JSON.stringify(opts.cachedRows) : null,
         opts.cachedRows ? new Date().toISOString() : null,
         opts.connectionId ?? null,
+        opts.layout ? JSON.stringify(opts.layout) : null,
       ],
     );
     if (rows.length === 0) return { ok: false, reason: "error" };
@@ -355,6 +379,7 @@ export async function updateCard(
     title?: string;
     chartConfig?: DashboardChartConfig | null;
     position?: number;
+    layout?: DashboardCardLayout | null;
   },
 ): Promise<CrudResult> {
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
@@ -374,6 +399,10 @@ export async function updateCard(
   if (updates.position !== undefined) {
     setClauses.push(`position = $${paramIdx++}`);
     params.push(updates.position);
+  }
+  if (updates.layout !== undefined) {
+    setClauses.push(`layout = $${paramIdx++}`);
+    params.push(updates.layout ? JSON.stringify(updates.layout) : null);
   }
 
   if (setClauses.length === 0) return { ok: true };

--- a/packages/api/src/lib/dashboards.ts
+++ b/packages/api/src/lib/dashboards.ts
@@ -6,6 +6,7 @@
  */
 
 import * as crypto from "crypto";
+import { z } from "zod";
 import { createLogger } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import {
@@ -20,6 +21,7 @@ import type {
   DashboardWithCards,
   DashboardChartConfig,
 } from "@atlas/api/lib/dashboard-types";
+import { DASHBOARD_GRID } from "@atlas/api/lib/dashboard-types";
 import type { ShareMode, ShareExpiryKey } from "@useatlas/types/share";
 import { SHARE_EXPIRY_OPTIONS } from "@useatlas/types/share";
 import type { CrudResult, CrudDataResult, CrudFailReason } from "@atlas/api/lib/conversations";
@@ -27,6 +29,19 @@ import type { CrudResult, CrudDataResult, CrudFailReason } from "@atlas/api/lib/
 export type { CrudResult, CrudDataResult, CrudFailReason };
 
 const log = createLogger("dashboards");
+
+/**
+ * Tile layout in the 24-col freeform grid. Single source for both write-time
+ * Zod validation (route) and read-time DB-row validation (`rowToCard`).
+ */
+export const CardLayoutSchema = z.object({
+  x: z.number().int().min(0).max(DASHBOARD_GRID.COLS - 1),
+  y: z.number().int().min(0).max(DASHBOARD_GRID.MAX_Y),
+  w: z.number().int().min(DASHBOARD_GRID.MIN_W).max(DASHBOARD_GRID.MAX_W),
+  h: z.number().int().min(DASHBOARD_GRID.MIN_H).max(DASHBOARD_GRID.MAX_H),
+}).refine((l) => l.x + l.w <= DASHBOARD_GRID.COLS, {
+  message: `Tile extends past column ${DASHBOARD_GRID.COLS}`,
+});
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -51,7 +66,7 @@ function rowToDashboard(r: Record<string, unknown>): Dashboard {
   };
 }
 
-function rowToCard(r: Record<string, unknown>): DashboardCard {
+export function rowToCard(r: Record<string, unknown>): DashboardCard {
   let chartConfig: DashboardChartConfig | null = null;
   if (r.chart_config) {
     try {
@@ -89,16 +104,11 @@ function rowToCard(r: Record<string, unknown>): DashboardCard {
   if (r.layout) {
     try {
       const raw = typeof r.layout === "string" ? JSON.parse(r.layout) : r.layout;
-      if (
-        raw && typeof raw === "object"
-        && typeof (raw as { x: unknown }).x === "number"
-        && typeof (raw as { y: unknown }).y === "number"
-        && typeof (raw as { w: unknown }).w === "number"
-        && typeof (raw as { h: unknown }).h === "number"
-      ) {
-        layout = raw as DashboardCardLayout;
+      const parsed = CardLayoutSchema.safeParse(raw);
+      if (parsed.success) {
+        layout = parsed.data;
       } else {
-        log.warn({ cardId: r.id }, "Discarding malformed dashboard_card.layout JSONB");
+        log.warn({ cardId: r.id, issues: parsed.error.issues }, "Discarding malformed dashboard_card.layout JSONB");
       }
     } catch (err) {
       log.warn({ cardId: r.id, err: errorMessage(err) }, "Failed to parse layout JSONB");

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -79,7 +79,7 @@ describe("runMigrations", () => {
 
     const count = await runMigrations(pool);
 
-    expect(count).toBe(41);
+    expect(count).toBe(42);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -149,6 +149,7 @@ describe("runMigrations", () => {
         "0038_encryption_key_versioning.sql",
         "0039_conversation_step_cap.sql",
         "0040_drop_integration_plaintext.sql",
+        "0041_dashboard_card_layout.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0041_dashboard_card_layout.sql
+++ b/packages/api/src/lib/db/migrations/0041_dashboard_card_layout.sql
@@ -1,0 +1,11 @@
+-- 0041 — Dashboard card grid layout: per-card position in a 24-col freeform grid.
+-- Replaces the single-column `position` index for the new tile-grid surface (#1867).
+-- `position` is preserved for ordering on share/list views and for cards that have
+-- not yet been laid out (layout IS NULL → fall back to auto-place by position).
+ALTER TABLE dashboard_cards ADD COLUMN IF NOT EXISTS layout JSONB;
+
+-- Layout shape: { x: int, y: int, w: int, h: int }
+--   x: 0..23 grid columns
+--   y: row index (ROW_H = 40px on the client)
+--   w: 3..24 columns, h: 4+ rows
+-- A NULL layout signals "not yet positioned" and gets auto-placed client-side.

--- a/packages/api/src/lib/db/migrations/0041_dashboard_card_layout.sql
+++ b/packages/api/src/lib/db/migrations/0041_dashboard_card_layout.sql
@@ -1,11 +1,4 @@
--- 0041 — Dashboard card grid layout: per-card position in a 24-col freeform grid.
--- Replaces the single-column `position` index for the new tile-grid surface (#1867).
--- `position` is preserved for ordering on share/list views and for cards that have
--- not yet been laid out (layout IS NULL → fall back to auto-place by position).
+-- 0041 — Dashboard tile grid layout (#1867).
+-- Bounds + shape live in CardLayoutSchema (lib/dashboards.ts). NULL = not yet
+-- placed; the client auto-lays out from `position`.
 ALTER TABLE dashboard_cards ADD COLUMN IF NOT EXISTS layout JSONB;
-
--- Layout shape: { x: int, y: int, w: int, h: int }
---   x: 0..23 grid columns
---   y: row index (ROW_H = 40px on the client)
---   w: 3..24 columns, h: 4+ rows
--- A NULL layout signals "not yet positioned" and gets auto-placed client-side.

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -1354,6 +1354,10 @@ export const dashboardCards = pgTable(
     cachedRows: jsonb("cached_rows"),
     cachedAt: timestamp("cached_at", { withTimezone: true }),
     connectionId: text("connection_id"),
+    // `layout` (0041) carries `{ x, y, w, h }` for the freeform 24-col tile
+    // grid on the detail page. NULL means not yet placed → auto-laid-out
+    // client-side from the legacy `position` index.
+    layout: jsonb("layout"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -1354,9 +1354,7 @@ export const dashboardCards = pgTable(
     cachedRows: jsonb("cached_rows"),
     cachedAt: timestamp("cached_at", { withTimezone: true }),
     connectionId: text("connection_id"),
-    // `layout` (0041) carries `{ x, y, w, h }` for the freeform 24-col tile
-    // grid on the detail page. NULL means not yet placed → auto-laid-out
-    // client-side from the legacy `position` index.
+    // NULL = not yet placed; client auto-lays out by `position`.
     layout: jsonb("layout"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/types/src/dashboard.ts
+++ b/packages/types/src/dashboard.ts
@@ -13,20 +13,26 @@ export interface DashboardChartConfig {
   valueColumns: string[];
 }
 
-/**
- * Tile placement inside the 24-column freeform dashboard grid (#1867).
- *
- * x: column origin (0..23). w: span in columns (min 3).
- * y: row origin (rows are ROW_H=40px on the client). h: span in rows (min 4).
- *
- * NULL on a card means "not yet placed" — the client auto-lays out by `position`.
- */
+/** NULL on a card means not yet placed — client auto-lays out by `position`. */
 export interface DashboardCardLayout {
   x: number;
   y: number;
   w: number;
   h: number;
 }
+
+/**
+ * Bounds of the dashboard tile grid. Single source of truth shared by the API
+ * Zod schema and the web grid math.
+ */
+export const DASHBOARD_GRID = {
+  COLS: 24,
+  MIN_W: 3,
+  MAX_W: 24,
+  MIN_H: 4,
+  MAX_H: 200,
+  MAX_Y: 10_000,
+} as const;
 
 // ---------------------------------------------------------------------------
 // API shapes (camelCase)

--- a/packages/types/src/dashboard.ts
+++ b/packages/types/src/dashboard.ts
@@ -21,19 +21,6 @@ export interface DashboardCardLayout {
   h: number;
 }
 
-/**
- * Bounds of the dashboard tile grid. Single source of truth shared by the API
- * Zod schema and the web grid math.
- */
-export const DASHBOARD_GRID = {
-  COLS: 24,
-  MIN_W: 3,
-  MAX_W: 24,
-  MIN_H: 4,
-  MAX_H: 200,
-  MAX_Y: 10_000,
-} as const;
-
 // ---------------------------------------------------------------------------
 // API shapes (camelCase)
 // ---------------------------------------------------------------------------

--- a/packages/types/src/dashboard.ts
+++ b/packages/types/src/dashboard.ts
@@ -13,6 +13,21 @@ export interface DashboardChartConfig {
   valueColumns: string[];
 }
 
+/**
+ * Tile placement inside the 24-column freeform dashboard grid (#1867).
+ *
+ * x: column origin (0..23). w: span in columns (min 3).
+ * y: row origin (rows are ROW_H=40px on the client). h: span in rows (min 4).
+ *
+ * NULL on a card means "not yet placed" — the client auto-lays out by `position`.
+ */
+export interface DashboardCardLayout {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
 // ---------------------------------------------------------------------------
 // API shapes (camelCase)
 // ---------------------------------------------------------------------------
@@ -45,6 +60,7 @@ export interface DashboardCard {
   cachedRows: Record<string, unknown>[] | null;
   cachedAt: string | null;
   connectionId: string | null;
+  layout: DashboardCardLayout | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -51,6 +51,7 @@
     "react": "^19.2.4",
     "react-day-picker": "^9.14.0",
     "react-dom": "^19.2.4",
+    "react-grid-layout": "^2.2.3",
     "react-hook-form": "^7.72.0",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4",

--- a/packages/web/src/app/dashboards/[id]/page.tsx
+++ b/packages/web/src/app/dashboards/[id]/page.tsx
@@ -1,27 +1,16 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
-import dynamic from "next/dynamic";
 import {
-  ArrowLeft,
-  RefreshCw,
-  Trash2,
-  Pencil,
-  GripVertical,
-  Clock,
-  Timer,
   LayoutDashboard,
-  Check,
-  X,
-  Sparkles,
   Plus,
+  Sparkles,
   XCircle,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   AlertDialog,
@@ -33,221 +22,111 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import {
-  Sortable,
-  SortableContent,
-  SortableItem,
-  SortableItemHandle,
-  SortableOverlay,
-} from "@/components/ui/sortable";
+import { Badge } from "@/components/ui/badge";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { friendlyError } from "@/ui/lib/fetch-error";
 import { NavBar } from "@/ui/components/tour/nav-bar";
-import { DataTable } from "@/ui/components/chat/data-table";
-import { useDarkMode } from "@/ui/hooks/use-dark-mode";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { authClient } from "@/lib/auth/client";
-import { Badge } from "@/components/ui/badge";
 import { DashboardShareDialog } from "./share-dialog";
-import type { DashboardWithCards, DashboardCard, DashboardSuggestion } from "@/ui/lib/types";
+import { DashboardGrid } from "@/ui/components/dashboards/dashboard-grid";
+import { DashboardTopBar } from "@/ui/components/dashboards/dashboard-topbar";
+import { nextTileLayout, withAutoLayout } from "@/ui/components/dashboards/auto-layout";
+import type {
+  DashboardCard,
+  DashboardCardLayout,
+  DashboardSuggestion,
+  DashboardWithCards,
+} from "@/ui/lib/types";
 
-const ResultChart = dynamic(
-  () => import("@/ui/components/chart/result-chart").then((m) => ({ default: m.ResultChart })),
-  { ssr: false, loading: () => <div className="h-48 animate-pulse rounded-lg bg-zinc-100 dark:bg-zinc-800" /> },
-);
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function timeAgo(iso: string | null): string {
-  if (!iso) return "never";
-  const diff = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(diff / 60_000);
-  if (mins < 1) return "just now";
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  const days = Math.floor(hrs / 24);
-  if (days < 30) return `${days}d ago`;
-  return new Date(iso).toLocaleDateString();
-}
-
-/** Convert Record rows to string[][] for ResultChart. */
-function toStringRows(columns: string[], rows: Record<string, unknown>[]): string[][] {
-  return rows.map((row) => columns.map((col) => (row[col] == null ? "" : String(row[col]))));
-}
-
-// ---------------------------------------------------------------------------
-// Card Component
-// ---------------------------------------------------------------------------
-
-function DashboardCardView({
-  card,
-  onRefresh,
-  onDelete,
-  onUpdate,
-  refreshingId,
-}: {
-  card: DashboardCard;
-  onRefresh: (cardId: string) => void;
-  onDelete: (card: DashboardCard) => void;
-  onUpdate: (cardId: string, title: string) => void;
-  refreshingId: string | null;
-}) {
-  const dark = useDarkMode();
-  const [editing, setEditing] = useState(false);
-  const [editTitle, setEditTitle] = useState(card.title);
-  const isRefreshing = refreshingId === card.id;
-
-  const columns = card.cachedColumns ?? [];
-  const rows = (card.cachedRows ?? []) as Record<string, unknown>[];
-  const hasData = columns.length > 0 && rows.length > 0;
-  const stringRows = hasData ? toStringRows(columns, rows) : [];
-
-  function handleSaveTitle() {
-    if (editTitle.trim() && editTitle.trim() !== card.title) {
-      onUpdate(card.id, editTitle.trim());
-    }
-    setEditing(false);
-  }
-
-  return (
-    <Card className="overflow-hidden">
-      {/* Card header */}
-      <div className="flex items-center gap-2 border-b border-zinc-100 px-4 py-3 dark:border-zinc-800">
-        <SortableItemHandle className="cursor-grab text-zinc-400 hover:text-zinc-600 dark:text-zinc-500 dark:hover:text-zinc-300">
-          <GripVertical className="size-4" />
-        </SortableItemHandle>
-
-        {editing ? (
-          <div className="flex flex-1 items-center gap-1.5">
-            <Input
-              value={editTitle}
-              onChange={(e) => setEditTitle(e.target.value)}
-              onKeyDown={(e) => { if (e.key === "Enter") handleSaveTitle(); if (e.key === "Escape") setEditing(false); }}
-              className="h-7 text-sm"
-              autoFocus
-            />
-            <Button variant="ghost" size="icon" className="size-7" onClick={handleSaveTitle}>
-              <Check className="size-3.5" />
-            </Button>
-            <Button variant="ghost" size="icon" className="size-7" onClick={() => setEditing(false)}>
-              <X className="size-3.5" />
-            </Button>
-          </div>
-        ) : (
-          <h3 className="flex-1 text-sm font-medium text-zinc-900 dark:text-zinc-100 line-clamp-1">
-            {card.title}
-          </h3>
-        )}
-
-        <div className="flex items-center gap-1">
-          <span className="mr-1 text-xs text-zinc-400 dark:text-zinc-500">
-            <Clock className="mr-0.5 inline size-3" />
-            {timeAgo(card.cachedAt)}
-          </span>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-7"
-            onClick={() => onRefresh(card.id)}
-            disabled={isRefreshing}
-            title="Refresh data"
-          >
-            <RefreshCw className={`size-3.5 ${isRefreshing ? "animate-spin" : ""}`} />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-7"
-            onClick={() => { setEditTitle(card.title); setEditing(true); }}
-            title="Edit title"
-          >
-            <Pencil className="size-3.5" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-7 text-zinc-400 hover:text-red-500 dark:hover:text-red-400"
-            onClick={() => onDelete(card)}
-            title="Remove card"
-          >
-            <Trash2 className="size-3.5" />
-          </Button>
-        </div>
-      </div>
-
-      {/* Card body — chart + table */}
-      {hasData ? (
-        <div>
-          {card.chartConfig && card.chartConfig.type !== "table" && (
-            <div className="px-4 py-3">
-              <ResultChart headers={columns} rows={stringRows} dark={dark} />
-            </div>
-          )}
-          <DataTable columns={columns} rows={rows} />
-        </div>
-      ) : (
-        <div className="px-4 py-8 text-center text-xs text-zinc-500 dark:text-zinc-400">
-          No cached data. Click refresh to load results.
-        </div>
-      )}
-    </Card>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Page
-// ---------------------------------------------------------------------------
+type Density = "compact" | "comfortable" | "spacious";
 
 export default function DashboardViewPage() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const session = authClient.useSession();
-  const user = session.data?.user as
-    | { email?: string; role?: string }
-    | undefined;
-  const isAdmin = user?.role === "admin" || user?.role === "owner" || user?.role === "platform_admin";
+  const user = session.data?.user as { email?: string; role?: string } | undefined;
+  const isAdmin =
+    user?.role === "admin" || user?.role === "owner" || user?.role === "platform_admin";
 
   const { data: dashboard, loading, error, refetch } = useAdminFetch<DashboardWithCards>(
     `/api/v1/dashboards/${id}`,
   );
 
   const { mutate, error: mutationError } = useAdminMutation({ invalidates: refetch });
+  const { mutate: layoutMutate } = useAdminMutation({});
+
   const [refreshingCardId, setRefreshingCardId] = useState<string | null>(null);
   const [refreshingAll, setRefreshingAll] = useState(false);
   const [deleteCardTarget, setDeleteCardTarget] = useState<DashboardCard | null>(null);
   const [deleteDashboard, setDeleteDashboard] = useState(false);
   const [editingTitle, setEditingTitle] = useState(false);
-  const [titleValue, setTitleValue] = useState("");
+  const [titleDraft, setTitleDraft] = useState("");
   const [suggestions, setSuggestions] = useState<DashboardSuggestion[]>([]);
   const [suggestingCards, setSuggestingCards] = useState(false);
   const [suggestError, setSuggestError] = useState<string | null>(null);
   const [addingSuggestion, setAddingSuggestion] = useState<number | null>(null);
 
+  const [editing, setEditing] = useState(false);
+  const [density, setDensity] = useState<Density>("comfortable");
+
+  // Optimistic layout — applied immediately on drag/resize end so the UI doesn't
+  // wait for the PATCH round-trip. Cleared once `dashboard` reflects the change.
+  const [optimisticLayouts, setOptimisticLayouts] = useState<Record<string, DashboardCardLayout>>({});
+  const lastSettledLayouts = useRef<Record<string, DashboardCardLayout>>({});
+
+  useEffect(() => {
+    if (!dashboard) return;
+    const next: Record<string, DashboardCardLayout> = {};
+    for (const card of dashboard.cards) {
+      if (card.layout) next[card.id] = card.layout;
+    }
+    lastSettledLayouts.current = next;
+    setOptimisticLayouts((prev) => {
+      // Drop optimistic entries that match the server-confirmed layout.
+      const remaining: Record<string, DashboardCardLayout> = {};
+      for (const [cardId, optimistic] of Object.entries(prev)) {
+        const settled = next[cardId];
+        if (
+          !settled
+          || settled.x !== optimistic.x
+          || settled.y !== optimistic.y
+          || settled.w !== optimistic.w
+          || settled.h !== optimistic.h
+        ) {
+          remaining[cardId] = optimistic;
+        }
+      }
+      return remaining;
+    });
+  }, [dashboard]);
+
+  // Keyboard: E toggles edit mode (when not focused in an input). Esc exits edit.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName?.toLowerCase();
+      if (tag === "input" || tag === "textarea" || target?.isContentEditable) return;
+      if (e.key === "e" || e.key === "E") {
+        e.preventDefault();
+        setEditing((prev) => !prev);
+      } else if (e.key === "Escape") {
+        setEditing(false);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
   async function handleRefreshCard(cardId: string) {
     setRefreshingCardId(cardId);
-    await mutate({
-      path: `/api/v1/dashboards/${id}/cards/${cardId}/refresh`,
-      method: "POST",
-    });
+    await mutate({ path: `/api/v1/dashboards/${id}/cards/${cardId}/refresh`, method: "POST" });
     setRefreshingCardId(null);
   }
 
   async function handleRefreshAll() {
     setRefreshingAll(true);
-    await mutate({
-      path: `/api/v1/dashboards/${id}/refresh`,
-      method: "POST",
-    });
+    await mutate({ path: `/api/v1/dashboards/${id}/refresh`, method: "POST" });
     setRefreshingAll(false);
   }
 
@@ -261,10 +140,7 @@ export default function DashboardViewPage() {
   }
 
   async function handleDeleteDashboard() {
-    await mutate({
-      path: `/api/v1/dashboards/${id}`,
-      method: "DELETE",
-    });
+    await mutate({ path: `/api/v1/dashboards/${id}`, method: "DELETE" });
     router.push("/dashboards");
   }
 
@@ -276,17 +152,42 @@ export default function DashboardViewPage() {
     });
   }
 
-  async function handleReorder(activeId: string, overId: string) {
-    if (!dashboard) return;
-    const cards = dashboard.cards;
-    const oldIdx = cards.findIndex((c) => c.id === activeId);
-    const newIdx = cards.findIndex((c) => c.id === overId);
-    if (oldIdx === -1 || newIdx === -1 || oldIdx === newIdx) return;
-
-    await mutate({
-      path: `/api/v1/dashboards/${id}/cards/${activeId}`,
+  async function handleLayoutChange(cardId: string, layout: DashboardCardLayout) {
+    setOptimisticLayouts((prev) => ({ ...prev, [cardId]: layout }));
+    const result = await layoutMutate({
+      path: `/api/v1/dashboards/${id}/cards/${cardId}`,
       method: "PATCH",
-      body: { position: newIdx },
+      body: { layout },
+    });
+    if (!result.ok) {
+      // Revert: drop the optimistic entry; UI falls back to the server's layout.
+      setOptimisticLayouts((prev) => {
+        const { [cardId]: _, ...rest } = prev;
+        return rest;
+      });
+    }
+    // Trigger a fresh fetch to pull the canonical server state.
+    refetch();
+  }
+
+  async function handleDuplicate(cardId: string) {
+    if (!dashboard) return;
+    const card = dashboard.cards.find((c) => c.id === cardId);
+    if (!card) return;
+    const placed = withAutoLayout(dashboard.cards).map((c) => c.resolvedLayout);
+    const newLayout = nextTileLayout(placed);
+    await mutate({
+      path: `/api/v1/dashboards/${id}/cards`,
+      method: "POST",
+      body: {
+        title: `${card.title} (copy)`,
+        sql: card.sql,
+        chartConfig: card.chartConfig,
+        cachedColumns: card.cachedColumns,
+        cachedRows: card.cachedRows,
+        connectionId: card.connectionId,
+        layout: newLayout,
+      },
     });
   }
 
@@ -295,10 +196,7 @@ export default function DashboardViewPage() {
     setSuggestions([]);
     setSuggestError(null);
     try {
-      const result = await mutate({
-        path: `/api/v1/dashboards/${id}/suggest`,
-        method: "POST",
-      });
+      const result = await mutate({ path: `/api/v1/dashboards/${id}/suggest`, method: "POST" });
       if (result.ok && result.data) {
         const data = result.data as { suggestions?: DashboardSuggestion[] };
         setSuggestions(data.suggestions ?? []);
@@ -309,7 +207,6 @@ export default function DashboardViewPage() {
       const message = err instanceof Error ? err.message : String(err);
       console.debug("[dashboard] Failed to fetch AI suggestions:", message);
       setSuggestError(message || "Failed to generate suggestions. Please try again.");
-      setSuggestions([]);
     } finally {
       setSuggestingCards(false);
     }
@@ -317,9 +214,10 @@ export default function DashboardViewPage() {
 
   async function handleAcceptSuggestion(index: number) {
     const suggestion = suggestions[index];
-    if (!suggestion) return;
+    if (!suggestion || !dashboard) return;
     setAddingSuggestion(index);
     try {
+      const placed = withAutoLayout(dashboard.cards).map((c) => c.resolvedLayout);
       const result = await mutate({
         path: `/api/v1/dashboards/${id}/cards`,
         method: "POST",
@@ -327,11 +225,10 @@ export default function DashboardViewPage() {
           title: suggestion.title,
           sql: suggestion.sql,
           chartConfig: suggestion.chartConfig,
+          layout: nextTileLayout(placed),
         },
       });
-      if (result.ok) {
-        setSuggestions((prev) => prev.filter((_, i) => i !== index));
-      }
+      if (result.ok) setSuggestions((prev) => prev.filter((_, i) => i !== index));
     } finally {
       setAddingSuggestion(null);
     }
@@ -342,29 +239,46 @@ export default function DashboardViewPage() {
   }
 
   async function handleSaveDashboardTitle() {
-    if (titleValue.trim() && titleValue.trim() !== dashboard?.title) {
+    if (!dashboard) return;
+    if (titleDraft.trim() && titleDraft.trim() !== dashboard.title) {
       await mutate({
         path: `/api/v1/dashboards/${id}`,
         method: "PATCH",
-        body: { title: titleValue.trim() },
+        body: { title: titleDraft.trim() },
       });
     }
     setEditingTitle(false);
   }
 
-  const cards = dashboard?.cards ?? [];
+  async function handleScheduleChange(value: string) {
+    const schedule = value === "off" ? null : value;
+    await mutate({
+      path: `/api/v1/dashboards/${id}`,
+      method: "PATCH",
+      body: { refreshSchedule: schedule },
+    });
+  }
+
+  // Merge optimistic layouts into the cards we hand to the grid.
+  const cardsForGrid: DashboardCard[] = dashboard
+    ? dashboard.cards.map((c) =>
+        optimisticLayouts[c.id] ? { ...c, layout: optimisticLayouts[c.id] } : c,
+      )
+    : [];
 
   return (
     <div className="flex min-h-screen flex-col bg-white dark:bg-zinc-950">
       <NavBar isAdmin={isAdmin} />
 
-      <main className="mx-auto w-full max-w-4xl flex-1 px-4 py-8">
+      <main className="flex flex-1 flex-col">
         {/* Loading */}
         {loading && (
-          <div className="space-y-4">
+          <div className="space-y-4 px-4 py-6 sm:px-6">
             <Skeleton className="h-8 w-1/3" />
             <Skeleton className="h-4 w-1/4" />
-            <div className="mt-8 space-y-4">
+            <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-2">
+              <Skeleton className="h-64 w-full" />
+              <Skeleton className="h-64 w-full" />
               <Skeleton className="h-64 w-full" />
               <Skeleton className="h-64 w-full" />
             </div>
@@ -373,7 +287,7 @@ export default function DashboardViewPage() {
 
         {/* Error */}
         {!loading && error && (
-          <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/20 dark:text-red-400">
+          <div className="m-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/20 dark:text-red-400">
             {error.message ?? "Failed to load dashboard."}
             <Button variant="ghost" size="sm" className="ml-2" onClick={() => refetch()}>
               Retry
@@ -384,113 +298,41 @@ export default function DashboardViewPage() {
         {/* Dashboard content */}
         {!loading && !error && dashboard && (
           <>
-            {/* Header */}
-            <div className="mb-8">
-              <Link
-                href="/dashboards"
-                className="mb-4 inline-flex items-center gap-1 text-xs text-zinc-500 transition-colors hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300"
-              >
-                <ArrowLeft className="size-3" />
-                All Dashboards
-              </Link>
+            <DashboardTopBar
+              title={dashboard.title}
+              cardCount={dashboard.cards.length}
+              description={dashboard.description}
+              editingTitle={editingTitle}
+              titleDraft={titleDraft}
+              onTitleClick={() => {
+                setTitleDraft(dashboard.title);
+                setEditingTitle(true);
+              }}
+              onTitleDraftChange={setTitleDraft}
+              onTitleSave={handleSaveDashboardTitle}
+              onTitleCancel={() => setEditingTitle(false)}
+              refreshing={refreshingAll}
+              refreshSchedule={dashboard.refreshSchedule}
+              onScheduleChange={handleScheduleChange}
+              onRefreshAll={handleRefreshAll}
+              onSuggest={handleSuggestCards}
+              suggesting={suggestingCards}
+              onDelete={() => setDeleteDashboard(true)}
+              shareSlot={<DashboardShareDialog dashboardId={id} />}
+              editing={editing}
+              onEditingChange={setEditing}
+              density={density}
+              onDensityChange={setDensity}
+            />
 
-              <div className="flex items-start justify-between">
-                <div className="flex-1">
-                  {editingTitle ? (
-                    <div className="flex items-center gap-2">
-                      <Input
-                        value={titleValue}
-                        onChange={(e) => setTitleValue(e.target.value)}
-                        onKeyDown={(e) => { if (e.key === "Enter") handleSaveDashboardTitle(); if (e.key === "Escape") setEditingTitle(false); }}
-                        className="text-xl font-semibold"
-                        autoFocus
-                      />
-                      <Button variant="ghost" size="icon" onClick={handleSaveDashboardTitle}>
-                        <Check className="size-4" />
-                      </Button>
-                      <Button variant="ghost" size="icon" onClick={() => setEditingTitle(false)}>
-                        <X className="size-4" />
-                      </Button>
-                    </div>
-                  ) : (
-                    <h1
-                      className="cursor-pointer text-xl font-semibold tracking-tight text-zinc-900 hover:text-zinc-700 dark:text-zinc-100 dark:hover:text-zinc-300"
-                      onClick={() => { setTitleValue(dashboard.title); setEditingTitle(true); }}
-                      title="Click to edit title"
-                    >
-                      {dashboard.title}
-                    </h1>
-                  )}
-                  {mutationError && (
-                    <p className="mt-1 text-xs text-red-500 dark:text-red-400">{friendlyError(mutationError)}</p>
-                  )}
-                  {dashboard.description && (
-                    <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
-                      {dashboard.description}
-                    </p>
-                  )}
-                </div>
-
-                <div className="flex items-center gap-2">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleSuggestCards}
-                    disabled={suggestingCards || cards.length === 0}
-                  >
-                    <Sparkles className={`mr-1.5 size-3.5 ${suggestingCards ? "animate-pulse" : ""}`} />
-                    {suggestingCards ? "Thinking..." : "Suggest Cards"}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleRefreshAll}
-                    disabled={refreshingAll || cards.length === 0}
-                  >
-                    <RefreshCw className={`mr-1.5 size-3.5 ${refreshingAll ? "animate-spin" : ""}`} />
-                    Refresh All
-                  </Button>
-                  <Select
-                    value={dashboard.refreshSchedule ?? "off"}
-                    onValueChange={async (v) => {
-                      const schedule = v === "off" ? null : v;
-                      await mutate({
-                        path: `/api/v1/dashboards/${id}`,
-                        method: "PATCH",
-                        body: { refreshSchedule: schedule },
-                      });
-                    }}
-                  >
-                    <SelectTrigger className="h-8 w-auto gap-1.5 text-xs">
-                      <Timer className="size-3.5 text-zinc-500" />
-                      <SelectValue placeholder="Auto-refresh" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="off">Off</SelectItem>
-                      <SelectItem value="*/15 * * * *">Every 15 min</SelectItem>
-                      <SelectItem value="0 * * * *">Every hour</SelectItem>
-                      <SelectItem value="0 */6 * * *">Every 6 hours</SelectItem>
-                      <SelectItem value="0 0 * * *">Daily</SelectItem>
-                      <SelectItem value="0 9 * * 1">Weekly (Mon 9am)</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <DashboardShareDialog dashboardId={id} />
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setDeleteDashboard(true)}
-                    className="text-red-500 hover:text-red-600 dark:text-red-400"
-                  >
-                    <Trash2 className="mr-1.5 size-3.5" />
-                    Delete
-                  </Button>
-                </div>
+            {mutationError && (
+              <div className="mx-4 mt-3 rounded-md border border-red-200 bg-red-50/60 px-3 py-2 text-xs text-red-700 dark:border-red-900/50 dark:bg-red-950/20 dark:text-red-400 sm:mx-6">
+                {friendlyError(mutationError)}
               </div>
-            </div>
+            )}
 
-            {/* Suggest error */}
             {suggestError && (
-              <div className="mb-4 rounded-lg border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm text-amber-800 dark:border-amber-900/50 dark:bg-amber-950/20 dark:text-amber-300">
+              <div className="mx-4 mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-900/50 dark:bg-amber-950/20 dark:text-amber-300 sm:mx-6">
                 {suggestError}
                 <Button variant="ghost" size="sm" className="ml-2 h-6 text-xs" onClick={() => setSuggestError(null)}>
                   Dismiss
@@ -498,18 +340,15 @@ export default function DashboardViewPage() {
               </div>
             )}
 
-            {/* AI Suggestions */}
             {suggestions.length > 0 && (
-              <div className="mb-6 space-y-3">
+              <div className="mx-4 mt-4 space-y-2 sm:mx-6">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
-                    <Sparkles className="size-4 text-teal-500" />
-                    <h2 className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                      Suggested Cards
+                    <Sparkles className="size-4 text-primary" />
+                    <h2 className="text-sm font-medium tracking-tight text-zinc-900 dark:text-zinc-100">
+                      Suggested tiles
                     </h2>
-                    <Badge variant="secondary" className="text-xs">
-                      {suggestions.length}
-                    </Badge>
+                    <Badge variant="secondary" className="text-xs">{suggestions.length}</Badge>
                   </div>
                   <Button
                     variant="ghost"
@@ -517,37 +356,38 @@ export default function DashboardViewPage() {
                     onClick={() => setSuggestions([])}
                     className="text-xs text-zinc-500"
                   >
-                    Dismiss All
+                    Dismiss all
                   </Button>
                 </div>
-
                 <div className="space-y-2">
                   {suggestions.map((suggestion, idx) => (
-                    <Card key={`suggestion-${idx}`} className="border-dashed border-teal-200 bg-teal-50/30 dark:border-teal-900/50 dark:bg-teal-950/10">
+                    <Card
+                      key={`suggestion-${idx}`}
+                      className="border-dashed border-primary/40 bg-primary/5 dark:border-primary/30 dark:bg-primary/5"
+                    >
                       <div className="flex items-start gap-3 px-4 py-3">
-                        <div className="flex-1 min-w-0">
-                          <h3 className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                            {suggestion.title}
-                          </h3>
-                          <p className="mt-0.5 text-xs text-zinc-500 dark:text-zinc-400 line-clamp-2">
+                        <div className="min-w-0 flex-1">
+                          <h3 className="text-sm font-medium tracking-tight">{suggestion.title}</h3>
+                          <p className="mt-0.5 line-clamp-2 text-xs text-zinc-500 dark:text-zinc-400">
                             {suggestion.reason}
                           </p>
                           <div className="mt-1.5 flex items-center gap-2">
-                            <Badge variant="outline" className="text-[10px] px-1.5 py-0">
+                            <Badge variant="outline" className="px-1.5 py-0 text-[10px]">
                               {suggestion.chartConfig.type}
                             </Badge>
-                            <span className="text-[10px] font-mono text-zinc-400 dark:text-zinc-500 truncate max-w-[300px]">
-                              {suggestion.sql.slice(0, 80)}{suggestion.sql.length > 80 ? "..." : ""}
+                            <span className="max-w-[40ch] truncate font-mono text-[10px] text-zinc-400 dark:text-zinc-500">
+                              {suggestion.sql.slice(0, 80)}
+                              {suggestion.sql.length > 80 ? "..." : ""}
                             </span>
                           </div>
                         </div>
-                        <div className="flex items-center gap-1 shrink-0">
+                        <div className="flex shrink-0 items-center gap-1">
                           <Button
                             variant="outline"
                             size="sm"
                             onClick={() => handleAcceptSuggestion(idx)}
                             disabled={addingSuggestion === idx}
-                            className="h-7 border-teal-300 text-teal-700 hover:bg-teal-100 dark:border-teal-800 dark:text-teal-400 dark:hover:bg-teal-900/30"
+                            className="h-7 border-primary/40 text-primary hover:bg-primary/10"
                           >
                             <Plus className="mr-1 size-3" />
                             {addingSuggestion === idx ? "Adding..." : "Add"}
@@ -569,76 +409,57 @@ export default function DashboardViewPage() {
               </div>
             )}
 
-            {/* Empty state */}
-            {cards.length === 0 && (
-              <div className="flex flex-col items-center justify-center py-24 text-center">
+            {dashboard.cards.length === 0 ? (
+              <div className="flex flex-1 flex-col items-center justify-center px-6 py-16 text-center">
                 <div className="mb-4 rounded-xl border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-800 dark:bg-zinc-900">
                   <LayoutDashboard className="size-8 text-zinc-400 dark:text-zinc-500" />
                 </div>
-                <h2 className="mb-1 text-base font-medium text-zinc-900 dark:text-zinc-100">
-                  No cards yet
-                </h2>
+                <h2 className="mb-1 text-2xl font-semibold tracking-tight">An empty canvas</h2>
                 <p className="mb-6 max-w-sm text-sm text-zinc-500 dark:text-zinc-400">
-                  Run a query in chat and click the Dashboard button on the result to add it here.
+                  Run a query in chat and click <span className="font-medium">Add to Dashboard</span> on the result to drop your first tile here.
                 </p>
-                <Button variant="outline" size="sm" asChild>
-                  <Link href="/">Go to Chat</Link>
+                <Button asChild size="sm">
+                  <Link href="/">Go to chat</Link>
                 </Button>
               </div>
-            )}
-
-            {/* Sortable cards */}
-            {cards.length > 0 && (
-              <Sortable
-                value={cards.map((c) => c.id)}
-                onValueChange={(ids) => {
-                  // Find which item moved
-                  const oldOrder = cards.map((c) => c.id);
-                  for (let i = 0; i < ids.length; i++) {
-                    if (ids[i] !== oldOrder[i]) {
-                      // First changed index — this is the moved item's new position
-                      const movedId = ids[i];
-                      handleReorder(movedId, oldOrder[i]);
-                      break;
-                    }
-                  }
-                }}
-                orientation="vertical"
-              >
-                <SortableContent className="space-y-4">
-                  {cards.map((card) => (
-                    <SortableItem key={card.id} value={card.id} asChild>
-                      <div>
-                        <DashboardCardView
-                          card={card}
-                          onRefresh={handleRefreshCard}
-                          onDelete={setDeleteCardTarget}
-                          onUpdate={handleUpdateCardTitle}
-                          refreshingId={refreshingCardId}
-                        />
-                      </div>
-                    </SortableItem>
-                  ))}
-                </SortableContent>
-                <SortableOverlay />
-              </Sortable>
+            ) : (
+              <div className="flex-1 overflow-auto px-3 py-4 sm:px-5">
+                <DashboardGrid
+                  cards={cardsForGrid}
+                  editing={editing}
+                  density={density}
+                  refreshingId={refreshingCardId}
+                  onLayoutChange={handleLayoutChange}
+                  onRefresh={handleRefreshCard}
+                  onDuplicate={handleDuplicate}
+                  onDelete={setDeleteCardTarget}
+                  onUpdateTitle={handleUpdateCardTitle}
+                />
+              </div>
             )}
           </>
         )}
       </main>
 
       {/* Delete card confirmation */}
-      <AlertDialog open={!!deleteCardTarget} onOpenChange={(open) => { if (!open) setDeleteCardTarget(null); }}>
+      <AlertDialog
+        open={!!deleteCardTarget}
+        onOpenChange={(open) => { if (!open) setDeleteCardTarget(null); }}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Remove card?</AlertDialogTitle>
+            <AlertDialogTitle>Remove tile?</AlertDialogTitle>
             <AlertDialogDescription>
-              This will remove &ldquo;{deleteCardTarget?.title}&rdquo; from this dashboard. The underlying query is not affected.
+              This will remove &ldquo;{deleteCardTarget?.title}&rdquo; from this dashboard. The
+              underlying query is not affected.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={handleDeleteCard} className="bg-red-600 text-white hover:bg-red-700">
+            <AlertDialogAction
+              onClick={handleDeleteCard}
+              className="bg-red-600 text-white hover:bg-red-700"
+            >
               Remove
             </AlertDialogAction>
           </AlertDialogFooter>
@@ -651,12 +472,16 @@ export default function DashboardViewPage() {
           <AlertDialogHeader>
             <AlertDialogTitle>Delete dashboard?</AlertDialogTitle>
             <AlertDialogDescription>
-              This will permanently delete &ldquo;{dashboard?.title}&rdquo; and all its cards. This action cannot be undone.
+              This will permanently delete &ldquo;{dashboard?.title}&rdquo; and all its tiles.
+              This action cannot be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={handleDeleteDashboard} className="bg-red-600 text-white hover:bg-red-700">
+            <AlertDialogAction
+              onClick={handleDeleteDashboard}
+              className="bg-red-600 text-white hover:bg-red-700"
+            >
               Delete
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/packages/web/src/app/dashboards/[id]/page.tsx
+++ b/packages/web/src/app/dashboards/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import {
@@ -32,14 +32,13 @@ import { DashboardShareDialog } from "./share-dialog";
 import { DashboardGrid } from "@/ui/components/dashboards/dashboard-grid";
 import { DashboardTopBar } from "@/ui/components/dashboards/dashboard-topbar";
 import { nextTileLayout, withAutoLayout } from "@/ui/components/dashboards/auto-layout";
+import type { Density } from "@/ui/components/dashboards/grid-constants";
 import type {
   DashboardCard,
   DashboardCardLayout,
   DashboardSuggestion,
   DashboardWithCards,
 } from "@/ui/lib/types";
-
-type Density = "compact" | "comfortable" | "spacious";
 
 export default function DashboardViewPage() {
   const { id } = useParams<{ id: string }>();
@@ -54,14 +53,11 @@ export default function DashboardViewPage() {
   );
 
   const { mutate, error: mutationError } = useAdminMutation({ invalidates: refetch });
-  const { mutate: layoutMutate } = useAdminMutation({});
 
   const [refreshingCardId, setRefreshingCardId] = useState<string | null>(null);
   const [refreshingAll, setRefreshingAll] = useState(false);
   const [deleteCardTarget, setDeleteCardTarget] = useState<DashboardCard | null>(null);
   const [deleteDashboard, setDeleteDashboard] = useState(false);
-  const [editingTitle, setEditingTitle] = useState(false);
-  const [titleDraft, setTitleDraft] = useState("");
   const [suggestions, setSuggestions] = useState<DashboardSuggestion[]>([]);
   const [suggestingCards, setSuggestingCards] = useState(false);
   const [suggestError, setSuggestError] = useState<string | null>(null);
@@ -70,29 +66,27 @@ export default function DashboardViewPage() {
   const [editing, setEditing] = useState(false);
   const [density, setDensity] = useState<Density>("comfortable");
 
-  // Optimistic layout — applied immediately on drag/resize end so the UI doesn't
-  // wait for the PATCH round-trip. Cleared once `dashboard` reflects the change.
+  // Optimistic layout — applied on drop/resize end so the UI doesn't wait for
+  // the PATCH round-trip. Cleared once `dashboard` reflects the change. On
+  // failure the entry is dropped and `mutationError` surfaces in the banner.
   const [optimisticLayouts, setOptimisticLayouts] = useState<Record<string, DashboardCardLayout>>({});
-  const lastSettledLayouts = useRef<Record<string, DashboardCardLayout>>({});
 
   useEffect(() => {
     if (!dashboard) return;
-    const next: Record<string, DashboardCardLayout> = {};
+    const settled: Record<string, DashboardCardLayout> = {};
     for (const card of dashboard.cards) {
-      if (card.layout) next[card.id] = card.layout;
+      if (card.layout) settled[card.id] = card.layout;
     }
-    lastSettledLayouts.current = next;
     setOptimisticLayouts((prev) => {
-      // Drop optimistic entries that match the server-confirmed layout.
       const remaining: Record<string, DashboardCardLayout> = {};
       for (const [cardId, optimistic] of Object.entries(prev)) {
-        const settled = next[cardId];
+        const next = settled[cardId];
         if (
-          !settled
-          || settled.x !== optimistic.x
-          || settled.y !== optimistic.y
-          || settled.w !== optimistic.w
-          || settled.h !== optimistic.h
+          !next
+          || next.x !== optimistic.x
+          || next.y !== optimistic.y
+          || next.w !== optimistic.w
+          || next.h !== optimistic.h
         ) {
           remaining[cardId] = optimistic;
         }
@@ -101,7 +95,7 @@ export default function DashboardViewPage() {
     });
   }, [dashboard]);
 
-  // Keyboard: E toggles edit mode (when not focused in an input). Esc exits edit.
+  // Skip when typing in inputs.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement | null;
@@ -154,20 +148,19 @@ export default function DashboardViewPage() {
 
   async function handleLayoutChange(cardId: string, layout: DashboardCardLayout) {
     setOptimisticLayouts((prev) => ({ ...prev, [cardId]: layout }));
-    const result = await layoutMutate({
+    const result = await mutate({
       path: `/api/v1/dashboards/${id}/cards/${cardId}`,
       method: "PATCH",
       body: { layout },
     });
     if (!result.ok) {
-      // Revert: drop the optimistic entry; UI falls back to the server's layout.
+      // Revert optimistic; UI falls back to the server's layout. Error banner
+      // surfaces via `mutationError`.
       setOptimisticLayouts((prev) => {
         const { [cardId]: _, ...rest } = prev;
         return rest;
       });
     }
-    // Trigger a fresh fetch to pull the canonical server state.
-    refetch();
   }
 
   async function handleDuplicate(cardId: string) {
@@ -175,7 +168,6 @@ export default function DashboardViewPage() {
     const card = dashboard.cards.find((c) => c.id === cardId);
     if (!card) return;
     const placed = withAutoLayout(dashboard.cards).map((c) => c.resolvedLayout);
-    const newLayout = nextTileLayout(placed);
     await mutate({
       path: `/api/v1/dashboards/${id}/cards`,
       method: "POST",
@@ -186,7 +178,7 @@ export default function DashboardViewPage() {
         cachedColumns: card.cachedColumns,
         cachedRows: card.cachedRows,
         connectionId: card.connectionId,
-        layout: newLayout,
+        layout: nextTileLayout(placed),
       },
     });
   }
@@ -238,16 +230,12 @@ export default function DashboardViewPage() {
     setSuggestions((prev) => prev.filter((_, i) => i !== index));
   }
 
-  async function handleSaveDashboardTitle() {
-    if (!dashboard) return;
-    if (titleDraft.trim() && titleDraft.trim() !== dashboard.title) {
-      await mutate({
-        path: `/api/v1/dashboards/${id}`,
-        method: "PATCH",
-        body: { title: titleDraft.trim() },
-      });
-    }
-    setEditingTitle(false);
+  async function handleTitleChange(next: string) {
+    await mutate({
+      path: `/api/v1/dashboards/${id}`,
+      method: "PATCH",
+      body: { title: next },
+    });
   }
 
   async function handleScheduleChange(value: string) {
@@ -259,7 +247,6 @@ export default function DashboardViewPage() {
     });
   }
 
-  // Merge optimistic layouts into the cards we hand to the grid.
   const cardsForGrid: DashboardCard[] = dashboard
     ? dashboard.cards.map((c) =>
         optimisticLayouts[c.id] ? { ...c, layout: optimisticLayouts[c.id] } : c,
@@ -271,7 +258,6 @@ export default function DashboardViewPage() {
       <NavBar isAdmin={isAdmin} />
 
       <main className="flex flex-1 flex-col">
-        {/* Loading */}
         {loading && (
           <div className="space-y-4 px-4 py-6 sm:px-6">
             <Skeleton className="h-8 w-1/3" />
@@ -285,7 +271,6 @@ export default function DashboardViewPage() {
           </div>
         )}
 
-        {/* Error */}
         {!loading && error && (
           <div className="m-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/20 dark:text-red-400">
             {error.message ?? "Failed to load dashboard."}
@@ -295,22 +280,13 @@ export default function DashboardViewPage() {
           </div>
         )}
 
-        {/* Dashboard content */}
         {!loading && !error && dashboard && (
           <>
             <DashboardTopBar
               title={dashboard.title}
               cardCount={dashboard.cards.length}
               description={dashboard.description}
-              editingTitle={editingTitle}
-              titleDraft={titleDraft}
-              onTitleClick={() => {
-                setTitleDraft(dashboard.title);
-                setEditingTitle(true);
-              }}
-              onTitleDraftChange={setTitleDraft}
-              onTitleSave={handleSaveDashboardTitle}
-              onTitleCancel={() => setEditingTitle(false)}
+              onTitleChange={handleTitleChange}
               refreshing={refreshingAll}
               refreshSchedule={dashboard.refreshSchedule}
               onScheduleChange={handleScheduleChange}
@@ -423,11 +399,10 @@ export default function DashboardViewPage() {
                 </Button>
               </div>
             ) : (
-              <div className="flex-1 overflow-auto px-3 py-4 sm:px-5">
+              <div className={`dash-density-${density} flex-1 overflow-auto px-3 py-4 sm:px-5`}>
                 <DashboardGrid
                   cards={cardsForGrid}
                   editing={editing}
-                  density={density}
                   refreshingId={refreshingCardId}
                   onLayoutChange={handleLayoutChange}
                   onRefresh={handleRefreshCard}
@@ -441,7 +416,6 @@ export default function DashboardViewPage() {
         )}
       </main>
 
-      {/* Delete card confirmation */}
       <AlertDialog
         open={!!deleteCardTarget}
         onOpenChange={(open) => { if (!open) setDeleteCardTarget(null); }}
@@ -466,7 +440,6 @@ export default function DashboardViewPage() {
         </AlertDialogContent>
       </AlertDialog>
 
-      {/* Delete dashboard confirmation */}
       <AlertDialog open={deleteDashboard} onOpenChange={setDeleteDashboard}>
         <AlertDialogContent>
           <AlertDialogHeader>

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -148,61 +148,22 @@
   }
 }
 
-/* ============================================================
- * Dashboards detail — freeform 24-col tile grid (#1867)
- * Tailwind handles tile chrome; this section owns the bits that
- * are awkward in utilities: faint editing grid, drop ghost,
- * absolute-positioned resize handles, drag/resize cursor lock.
- * ============================================================ */
-
-.dash-canvas {
-  position: relative;
-  width: 100%;
-}
-
-.dash-canvas.editing {
-  background-image: linear-gradient(to right, oklch(0 0 0 / 0.04) 1px, transparent 1px);
-  background-size: calc(100% / 24) 100%;
-  border-radius: 4px;
-}
-
-.dark .dash-canvas.editing {
-  background-image: linear-gradient(to right, oklch(1 0 0 / 0.035) 1px, transparent 1px);
-}
-
-.dash-canvas.editing .dash-row-guides {
-  position: absolute; inset: 0; pointer-events: none;
-  background-image: linear-gradient(to bottom, oklch(0 0 0 / 0.04) 1px, transparent 1px);
-  background-size: 100% var(--dash-row-h, 40px);
-}
-
-.dark .dash-canvas.editing .dash-row-guides {
-  background-image: linear-gradient(to bottom, oklch(1 0 0 / 0.035) 1px, transparent 1px);
-}
-
-.dash-drag-ghost {
-  position: absolute; pointer-events: none; z-index: 2;
+/* Dashboards detail — react-grid-layout overrides (#1867). */
+.react-grid-item.react-grid-placeholder {
+  background: color-mix(in oklch, var(--primary) 10%, transparent);
   border: 1.5px dashed color-mix(in oklch, var(--primary) 60%, transparent);
-  background: color-mix(in oklch, var(--primary) 8%, transparent);
   border-radius: 12px;
+  opacity: 1;
+}
+.react-grid-item.react-draggable-dragging {
+  box-shadow: 0 20px 40px oklch(0 0 0 / 0.4);
+}
+.react-grid-item > .react-resizable-handle::after {
+  border-right-color: var(--muted-foreground);
+  border-bottom-color: var(--muted-foreground);
 }
 
-.dash-tile {
-  position: absolute;
-  display: flex; flex-direction: column;
-  overflow: hidden;
-  transition: box-shadow 120ms ease-out, border-color 120ms ease-out, transform 120ms ease-out;
-}
-.dash-tile.is-dragging {
-  z-index: 30;
-  box-shadow: 0 20px 40px oklch(0 0 0 / 0.4);
-  border-color: color-mix(in oklch, var(--primary) 50%, var(--border)) !important;
-}
-.dash-tile.is-resizing {
-  z-index: 30;
-  border-color: color-mix(in oklch, var(--primary) 40%, var(--border)) !important;
-}
-.dash-tile.is-fullscreen {
+.dash-tile-wrapper.is-fullscreen {
   position: fixed !important;
   inset: 14px !important;
   width: auto !important;
@@ -212,25 +173,6 @@
   box-shadow: 0 30px 60px oklch(0 0 0 / 0.6);
 }
 
-/* Resize handles only render in edit mode and never on fullscreen tiles. */
-.dash-rh { position: absolute; z-index: 2; }
-.dash-rh.e  { right: -3px; top: 20%; bottom: 20%; width: 8px; cursor: ew-resize; }
-.dash-rh.s  { bottom: -3px; left: 20%; right: 20%; height: 8px; cursor: ns-resize; }
-.dash-rh.se { right: -2px; bottom: -2px; width: 16px; height: 16px; cursor: nwse-resize; }
-.dash-rh.se::after {
-  content: ''; position: absolute; right: 3px; bottom: 3px;
-  width: 8px; height: 8px;
-  background:
-    linear-gradient(135deg, transparent 0 45%, var(--muted-foreground) 45% 55%, transparent 55% 70%, var(--muted-foreground) 70% 80%, transparent 80%);
-}
-
-.dashboard-app.is-dragging,
-.dashboard-app.is-resizing {
-  user-select: none;
-  cursor: grabbing;
-}
-
-/* Density variants — only affect tile internals; grid math is unchanged. */
 .dash-density-compact .dash-tile-head { padding: 7px 10px 6px; }
 .dash-density-compact .dash-tile-body { padding: 6px 10px 8px; }
 .dash-density-spacious .dash-tile-head { padding: 14px 16px 11px; }

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -147,3 +147,91 @@
     transform: translateY(-2px);
   }
 }
+
+/* ============================================================
+ * Dashboards detail — freeform 24-col tile grid (#1867)
+ * Tailwind handles tile chrome; this section owns the bits that
+ * are awkward in utilities: faint editing grid, drop ghost,
+ * absolute-positioned resize handles, drag/resize cursor lock.
+ * ============================================================ */
+
+.dash-canvas {
+  position: relative;
+  width: 100%;
+}
+
+.dash-canvas.editing {
+  background-image: linear-gradient(to right, oklch(0 0 0 / 0.04) 1px, transparent 1px);
+  background-size: calc(100% / 24) 100%;
+  border-radius: 4px;
+}
+
+.dark .dash-canvas.editing {
+  background-image: linear-gradient(to right, oklch(1 0 0 / 0.035) 1px, transparent 1px);
+}
+
+.dash-canvas.editing .dash-row-guides {
+  position: absolute; inset: 0; pointer-events: none;
+  background-image: linear-gradient(to bottom, oklch(0 0 0 / 0.04) 1px, transparent 1px);
+  background-size: 100% var(--dash-row-h, 40px);
+}
+
+.dark .dash-canvas.editing .dash-row-guides {
+  background-image: linear-gradient(to bottom, oklch(1 0 0 / 0.035) 1px, transparent 1px);
+}
+
+.dash-drag-ghost {
+  position: absolute; pointer-events: none; z-index: 2;
+  border: 1.5px dashed color-mix(in oklch, var(--primary) 60%, transparent);
+  background: color-mix(in oklch, var(--primary) 8%, transparent);
+  border-radius: 12px;
+}
+
+.dash-tile {
+  position: absolute;
+  display: flex; flex-direction: column;
+  overflow: hidden;
+  transition: box-shadow 120ms ease-out, border-color 120ms ease-out, transform 120ms ease-out;
+}
+.dash-tile.is-dragging {
+  z-index: 30;
+  box-shadow: 0 20px 40px oklch(0 0 0 / 0.4);
+  border-color: color-mix(in oklch, var(--primary) 50%, var(--border)) !important;
+}
+.dash-tile.is-resizing {
+  z-index: 30;
+  border-color: color-mix(in oklch, var(--primary) 40%, var(--border)) !important;
+}
+.dash-tile.is-fullscreen {
+  position: fixed !important;
+  inset: 14px !important;
+  width: auto !important;
+  height: auto !important;
+  transform: none !important;
+  z-index: 100;
+  box-shadow: 0 30px 60px oklch(0 0 0 / 0.6);
+}
+
+/* Resize handles only render in edit mode and never on fullscreen tiles. */
+.dash-rh { position: absolute; z-index: 2; }
+.dash-rh.e  { right: -3px; top: 20%; bottom: 20%; width: 8px; cursor: ew-resize; }
+.dash-rh.s  { bottom: -3px; left: 20%; right: 20%; height: 8px; cursor: ns-resize; }
+.dash-rh.se { right: -2px; bottom: -2px; width: 16px; height: 16px; cursor: nwse-resize; }
+.dash-rh.se::after {
+  content: ''; position: absolute; right: 3px; bottom: 3px;
+  width: 8px; height: 8px;
+  background:
+    linear-gradient(135deg, transparent 0 45%, var(--muted-foreground) 45% 55%, transparent 55% 70%, var(--muted-foreground) 70% 80%, transparent 80%);
+}
+
+.dashboard-app.is-dragging,
+.dashboard-app.is-resizing {
+  user-select: none;
+  cursor: grabbing;
+}
+
+/* Density variants — only affect tile internals; grid math is unchanged. */
+.dash-density-compact .dash-tile-head { padding: 7px 10px 6px; }
+.dash-density-compact .dash-tile-body { padding: 6px 10px 8px; }
+.dash-density-spacious .dash-tile-head { padding: 14px 16px 11px; }
+.dash-density-spacious .dash-tile-body { padding: 12px 16px 14px; }

--- a/packages/web/src/ui/components/dashboards/__tests__/auto-layout.test.ts
+++ b/packages/web/src/ui/components/dashboards/__tests__/auto-layout.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import type { DashboardCard } from "@/ui/lib/types";
+import { nextTileLayout, withAutoLayout } from "../auto-layout";
+
+const DEFAULT_CARD: Omit<DashboardCard, "id" | "position" | "layout"> = {
+  dashboardId: "d1",
+  title: "Untitled",
+  sql: "SELECT 1",
+  chartConfig: null,
+  cachedColumns: null,
+  cachedRows: null,
+  cachedAt: null,
+  connectionId: null,
+  createdAt: "2026-04-25T00:00:00Z",
+  updatedAt: "2026-04-25T00:00:00Z",
+};
+
+function card(overrides: Partial<DashboardCard> & { id: string; position: number }): DashboardCard {
+  return { ...DEFAULT_CARD, layout: null, ...overrides };
+}
+
+describe("withAutoLayout", () => {
+  test("preserves existing layouts verbatim", () => {
+    const result = withAutoLayout([
+      card({ id: "a", position: 0, layout: { x: 5, y: 7, w: 8, h: 9 } }),
+    ]);
+    expect(result[0].resolvedLayout).toEqual({ x: 5, y: 7, w: 8, h: 9 });
+  });
+
+  test("places never-positioned cards into a 2-col waterfall", () => {
+    const result = withAutoLayout([
+      card({ id: "a", position: 0 }),
+      card({ id: "b", position: 1 }),
+      card({ id: "c", position: 2 }),
+    ]);
+    expect(result.map((r) => r.resolvedLayout)).toEqual([
+      { x: 0, y: 0, w: 12, h: 10 },
+      { x: 12, y: 0, w: 12, h: 10 },
+      { x: 0, y: 10, w: 12, h: 10 },
+    ]);
+  });
+
+  test("auto-placed cards never collide with stored layouts", () => {
+    const result = withAutoLayout([
+      card({ id: "stored", position: 0, layout: { x: 0, y: 0, w: 24, h: 12 } }),
+      card({ id: "new", position: 1 }),
+    ]);
+    // Stored tile reserves rows 0..11 → newcomer must start at y >= 12.
+    expect(result[1].resolvedLayout.y).toBeGreaterThanOrEqual(12);
+  });
+
+  test("respects position order regardless of input order", () => {
+    const result = withAutoLayout([
+      card({ id: "second", position: 5 }),
+      card({ id: "first", position: 1 }),
+    ]);
+    expect(result.map((r) => r.id)).toEqual(["first", "second"]);
+  });
+});
+
+describe("nextTileLayout", () => {
+  test("places the very first tile at the origin at default size", () => {
+    expect(nextTileLayout([])).toEqual({ x: 0, y: 0, w: 12, h: 10 });
+  });
+
+  test("appends below the lowest existing tile", () => {
+    const next = nextTileLayout([
+      { x: 0, y: 0, w: 12, h: 10 },
+      { x: 12, y: 0, w: 12, h: 14 },
+    ]);
+    expect(next.y).toBe(14);
+    expect(next.x).toBe(0);
+  });
+});

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-topbar.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-topbar.test.tsx
@@ -1,29 +1,29 @@
 import { describe, expect, test, afterEach } from "bun:test";
 import { render, cleanup, fireEvent, screen } from "@testing-library/react";
 import { DashboardTopBar } from "../dashboard-topbar";
+import type { Density } from "../grid-constants";
+
+const unexpected = (label: string) => () => {
+  throw new Error(`unexpected ${label} call`);
+};
 
 const baseProps = {
   title: "Revenue overview",
   cardCount: 3,
   description: null,
-  editingTitle: false,
-  titleDraft: "",
-  onTitleClick: () => {},
-  onTitleDraftChange: () => {},
-  onTitleSave: () => {},
-  onTitleCancel: () => {},
+  onTitleChange: unexpected("onTitleChange") as (next: string) => void,
   refreshing: false,
   refreshSchedule: null,
-  onScheduleChange: () => {},
-  onRefreshAll: () => {},
-  onSuggest: () => {},
+  onScheduleChange: unexpected("onScheduleChange") as (v: string) => void,
+  onRefreshAll: unexpected("onRefreshAll"),
+  onSuggest: unexpected("onSuggest"),
   suggesting: false,
-  onDelete: () => {},
+  onDelete: unexpected("onDelete"),
   shareSlot: <button type="button">Share</button>,
   editing: false,
-  onEditingChange: (_next: boolean) => {},
-  density: "comfortable" as const,
-  onDensityChange: (_next: "compact" | "comfortable" | "spacious") => {},
+  onEditingChange: unexpected("onEditingChange") as (next: boolean) => void,
+  density: "comfortable" as Density,
+  onDensityChange: unexpected("onDensityChange") as (next: Density) => void,
 };
 
 describe("DashboardTopBar", () => {
@@ -51,11 +51,6 @@ describe("DashboardTopBar", () => {
     expect(captured).toBe(true);
   });
 
-  test("Delete button is rendered", () => {
-    render(<DashboardTopBar {...baseProps} />);
-    expect(screen.getByRole("button", { name: /Delete/ })).toBeTruthy();
-  });
-
   test("Suggest button disabled when no cards", () => {
     render(<DashboardTopBar {...baseProps} cardCount={0} />);
     const suggestBtn = screen.getByRole("button", { name: /Suggest/ });
@@ -74,5 +69,39 @@ describe("DashboardTopBar", () => {
     expect(screen.getByText("1 tile")).toBeTruthy();
     rerender(<DashboardTopBar {...baseProps} cardCount={5} />);
     expect(screen.getByText("5 tiles")).toBeTruthy();
+  });
+
+  test("title is internally editable — committing fires onTitleChange with the trimmed draft", () => {
+    let saved: string | null = null;
+    render(
+      <DashboardTopBar
+        {...baseProps}
+        onTitleChange={(next) => { saved = next; }}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Revenue overview"));
+    const input = screen.getByDisplayValue("Revenue overview") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "  New title  " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(saved).toBe("New title");
+  });
+
+  test("Escape cancels the title edit without firing onTitleChange", () => {
+    render(<DashboardTopBar {...baseProps} />);
+    fireEvent.click(screen.getByText("Revenue overview"));
+    const input = screen.getByDisplayValue("Revenue overview") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Different" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(screen.queryByDisplayValue("Different")).toBeNull();
+    expect(screen.getByText("Revenue overview")).toBeTruthy();
+  });
+
+  test("Delete button calls onDelete on click", () => {
+    let called = false;
+    render(<DashboardTopBar {...baseProps} onDelete={() => { called = true; }} />);
+    fireEvent.click(screen.getByRole("button", { name: /Delete/ }));
+    expect(called).toBe(true);
   });
 });

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-topbar.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-topbar.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { render, cleanup, fireEvent, screen } from "@testing-library/react";
+import { DashboardTopBar } from "../dashboard-topbar";
+
+const baseProps = {
+  title: "Revenue overview",
+  cardCount: 3,
+  description: null,
+  editingTitle: false,
+  titleDraft: "",
+  onTitleClick: () => {},
+  onTitleDraftChange: () => {},
+  onTitleSave: () => {},
+  onTitleCancel: () => {},
+  refreshing: false,
+  refreshSchedule: null,
+  onScheduleChange: () => {},
+  onRefreshAll: () => {},
+  onSuggest: () => {},
+  suggesting: false,
+  onDelete: () => {},
+  shareSlot: <button type="button">Share</button>,
+  editing: false,
+  onEditingChange: (_next: boolean) => {},
+  density: "comfortable" as const,
+  onDensityChange: (_next: "compact" | "comfortable" | "spacious") => {},
+};
+
+describe("DashboardTopBar", () => {
+  afterEach(cleanup);
+
+  test("renders title, breadcrumb, and tile chip", () => {
+    render(<DashboardTopBar {...baseProps} />);
+    expect(screen.getByText("Revenue overview")).toBeTruthy();
+    expect(screen.getByText("All dashboards")).toBeTruthy();
+    expect(screen.getByText(/3 tiles/)).toBeTruthy();
+  });
+
+  test("View/Edit toggle reflects current mode and fires onEditingChange", () => {
+    let captured: boolean | null = null;
+    render(
+      <DashboardTopBar
+        {...baseProps}
+        editing={false}
+        onEditingChange={(v) => { captured = v; }}
+      />,
+    );
+    const editBtn = screen.getByRole("button", { name: /Edit/ });
+    expect(editBtn.getAttribute("aria-pressed")).toBe("false");
+    fireEvent.click(editBtn);
+    expect(captured).toBe(true);
+  });
+
+  test("Delete button is rendered", () => {
+    render(<DashboardTopBar {...baseProps} />);
+    expect(screen.getByRole("button", { name: /Delete/ })).toBeTruthy();
+  });
+
+  test("Suggest button disabled when no cards", () => {
+    render(<DashboardTopBar {...baseProps} cardCount={0} />);
+    const suggestBtn = screen.getByRole("button", { name: /Suggest/ });
+    expect((suggestBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test("Add tile only renders in edit mode", () => {
+    const { rerender } = render(<DashboardTopBar {...baseProps} editing={false} />);
+    expect(screen.queryByText("Add tile")).toBeNull();
+    rerender(<DashboardTopBar {...baseProps} editing={true} />);
+    expect(screen.getByText("Add tile")).toBeTruthy();
+  });
+
+  test("singular vs plural tile chip", () => {
+    const { rerender } = render(<DashboardTopBar {...baseProps} cardCount={1} />);
+    expect(screen.getByText("1 tile")).toBeTruthy();
+    rerender(<DashboardTopBar {...baseProps} cardCount={5} />);
+    expect(screen.getByText("5 tiles")).toBeTruthy();
+  });
+});

--- a/packages/web/src/ui/components/dashboards/auto-layout.ts
+++ b/packages/web/src/ui/components/dashboards/auto-layout.ts
@@ -1,0 +1,51 @@
+import type { DashboardCard, DashboardCardLayout } from "@/ui/lib/types";
+import { COLS, DEFAULT_TILE_H, DEFAULT_TILE_W } from "./grid-constants";
+
+/**
+ * Auto-layout cards that have not yet been positioned in the freeform grid.
+ *
+ * Cards with a stored layout keep it. Cards without one waterfall into a
+ * 2-column grid (12+12=24) below every already-placed tile, never overlapping
+ * with stored layouts. Pairs share a row (left/right halves), and a new pair
+ * starts below whatever is currently the lowest placed tile.
+ */
+export function withAutoLayout(cards: DashboardCard[]): Array<DashboardCard & { resolvedLayout: DashboardCardLayout }> {
+  const sorted = cards.toSorted((a, b) => a.position - b.position);
+  const placed: Array<DashboardCard & { resolvedLayout: DashboardCardLayout }> = [];
+  const half = Math.floor(COLS / 2);
+  let pairStartY = 0;
+  let unplacedInRun = 0;
+
+  for (const card of sorted) {
+    if (card.layout) {
+      placed.push({ ...card, resolvedLayout: card.layout });
+      unplacedInRun = 0;
+      continue;
+    }
+
+    let resolvedLayout: DashboardCardLayout;
+    if (unplacedInRun % 2 === 0) {
+      // Start a new row below every tile placed so far, including stored ones.
+      const taken = placed.map((p) => p.resolvedLayout);
+      pairStartY = taken.length === 0 ? 0 : Math.max(...taken.map((l) => l.y + l.h));
+      resolvedLayout = { x: 0, y: pairStartY, w: half, h: DEFAULT_TILE_H };
+    } else {
+      resolvedLayout = { x: half, y: pairStartY, w: half, h: DEFAULT_TILE_H };
+    }
+    unplacedInRun++;
+    placed.push({ ...card, resolvedLayout });
+  }
+
+  return placed;
+}
+
+/**
+ * Given the current layout, find a y for a brand-new tile that doesn't
+ * collide with anything. Default to placing at the bottom-left at width
+ * `DEFAULT_TILE_W`.
+ */
+export function nextTileLayout(existing: DashboardCardLayout[]): DashboardCardLayout {
+  if (existing.length === 0) return { x: 0, y: 0, w: DEFAULT_TILE_W, h: DEFAULT_TILE_H };
+  const maxY = Math.max(...existing.map((l) => l.y + l.h));
+  return { x: 0, y: maxY, w: DEFAULT_TILE_W, h: DEFAULT_TILE_H };
+}

--- a/packages/web/src/ui/components/dashboards/auto-layout.ts
+++ b/packages/web/src/ui/components/dashboards/auto-layout.ts
@@ -2,12 +2,9 @@ import type { DashboardCard, DashboardCardLayout } from "@/ui/lib/types";
 import { COLS, DEFAULT_TILE_H, DEFAULT_TILE_W } from "./grid-constants";
 
 /**
- * Auto-layout cards that have not yet been positioned in the freeform grid.
- *
- * Cards with a stored layout keep it. Cards without one waterfall into a
- * 2-column grid (12+12=24) below every already-placed tile, never overlapping
- * with stored layouts. Pairs share a row (left/right halves), and a new pair
- * starts below whatever is currently the lowest placed tile.
+ * Cards with a stored layout keep it. The rest waterfall into a 2-col grid
+ * below every already-placed tile (left/right halves share a row), never
+ * overlapping a stored layout.
  */
 export function withAutoLayout(cards: DashboardCard[]): Array<DashboardCard & { resolvedLayout: DashboardCardLayout }> {
   const sorted = cards.toSorted((a, b) => a.position - b.position);
@@ -25,7 +22,6 @@ export function withAutoLayout(cards: DashboardCard[]): Array<DashboardCard & { 
 
     let resolvedLayout: DashboardCardLayout;
     if (unplacedInRun % 2 === 0) {
-      // Start a new row below every tile placed so far, including stored ones.
       const taken = placed.map((p) => p.resolvedLayout);
       pairStartY = taken.length === 0 ? 0 : Math.max(...taken.map((l) => l.y + l.h));
       resolvedLayout = { x: 0, y: pairStartY, w: half, h: DEFAULT_TILE_H };
@@ -39,11 +35,6 @@ export function withAutoLayout(cards: DashboardCard[]): Array<DashboardCard & { 
   return placed;
 }
 
-/**
- * Given the current layout, find a y for a brand-new tile that doesn't
- * collide with anything. Default to placing at the bottom-left at width
- * `DEFAULT_TILE_W`.
- */
 export function nextTileLayout(existing: DashboardCardLayout[]): DashboardCardLayout {
   if (existing.length === 0) return { x: 0, y: 0, w: DEFAULT_TILE_W, h: DEFAULT_TILE_H };
   const maxY = Math.max(...existing.map((l) => l.y + l.h));

--- a/packages/web/src/ui/components/dashboards/dashboard-grid.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-grid.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Keyboard } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { DashboardCard, DashboardCardLayout } from "@/ui/lib/types";
+import { COLS, ROW_H, GAP, MIN_W, MIN_H } from "./grid-constants";
+import { withAutoLayout } from "./auto-layout";
+import { DashboardTile } from "./dashboard-tile";
+
+type Density = "compact" | "comfortable" | "spacious";
+
+interface DashboardGridProps {
+  cards: DashboardCard[];
+  editing: boolean;
+  density: Density;
+  refreshingId: string | null;
+  onLayoutChange: (cardId: string, layout: DashboardCardLayout) => void;
+  onRefresh: (cardId: string) => void;
+  onDuplicate: (cardId: string) => void;
+  onDelete: (card: DashboardCard) => void;
+  onUpdateTitle: (cardId: string, title: string) => void;
+}
+
+interface PxRect { x: number; y: number; w: number; h: number }
+
+interface DragState {
+  cardId: string;
+  startMouse: { x: number; y: number };
+  startPx: PxRect;
+}
+
+interface ResizeState {
+  cardId: string;
+  dir: "e" | "s" | "se";
+  startMouse: { x: number; y: number };
+  startPx: PxRect;
+}
+
+function useGridMetrics(canvasRef: React.RefObject<HTMLDivElement | null>) {
+  const [metrics, setMetrics] = useState({ colW: 60, width: 1200 });
+  useEffect(() => {
+    const node = canvasRef.current;
+    if (!node) return;
+    const update = () => {
+      const w = node.getBoundingClientRect().width;
+      setMetrics({ colW: w / COLS, width: w });
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(node);
+    return () => ro.disconnect();
+  }, [canvasRef]);
+  return metrics;
+}
+
+function toPx(layout: DashboardCardLayout, colW: number): PxRect {
+  return {
+    x: layout.x * colW + GAP / 2,
+    y: layout.y * ROW_H + GAP / 2,
+    w: layout.w * colW - GAP,
+    h: layout.h * ROW_H - GAP,
+  };
+}
+
+export function DashboardGrid({
+  cards,
+  editing,
+  density,
+  refreshingId,
+  onLayoutChange,
+  onRefresh,
+  onDuplicate,
+  onDelete,
+  onUpdateTitle,
+}: DashboardGridProps) {
+  const canvasRef = useRef<HTMLDivElement | null>(null);
+  const metrics = useGridMetrics(canvasRef);
+
+  const [drag, setDrag] = useState<DragState | null>(null);
+  const [resize, setResize] = useState<ResizeState | null>(null);
+  const [livePx, setLivePx] = useState<Record<string, PxRect>>({});
+  const [fullscreenId, setFullscreenId] = useState<string | null>(null);
+
+  const placed = useMemo(() => withAutoLayout(cards), [cards]);
+
+  // Mouse-move + mouse-up handlers — only mounted while a drag/resize is active.
+  useEffect(() => {
+    if (!drag && !resize) return;
+
+    const onMove = (e: MouseEvent) => {
+      if (drag) {
+        const dx = e.clientX - drag.startMouse.x;
+        const dy = e.clientY - drag.startMouse.y;
+        const nx = Math.max(GAP / 2, drag.startPx.x + dx);
+        const ny = Math.max(GAP / 2, drag.startPx.y + dy);
+        setLivePx((prev) => ({ ...prev, [drag.cardId]: { ...drag.startPx, x: nx, y: ny } }));
+      }
+      if (resize) {
+        const dx = e.clientX - resize.startMouse.x;
+        const dy = e.clientY - resize.startMouse.y;
+        const { x, y } = resize.startPx;
+        let { w, h } = resize.startPx;
+        if (resize.dir.includes("e")) w = Math.max(metrics.colW * MIN_W - GAP, w + dx);
+        if (resize.dir.includes("s")) h = Math.max(ROW_H * MIN_H - GAP, h + dy);
+        setLivePx((prev) => ({ ...prev, [resize.cardId]: { x, y, w, h } }));
+      }
+    };
+
+    const onUp = () => {
+      if (drag) {
+        const cur = livePx[drag.cardId] || drag.startPx;
+        const card = placed.find((p) => p.id === drag.cardId);
+        if (card) {
+          const gx = Math.max(0, Math.min(COLS - 1, Math.round(cur.x / metrics.colW)));
+          const gy = Math.max(0, Math.round(cur.y / ROW_H));
+          const next: DashboardCardLayout = {
+            ...card.resolvedLayout,
+            x: Math.min(gx, COLS - card.resolvedLayout.w),
+            y: gy,
+          };
+          if (next.x !== card.resolvedLayout.x || next.y !== card.resolvedLayout.y) {
+            onLayoutChange(drag.cardId, next);
+          }
+        }
+        setDrag(null);
+      }
+      if (resize) {
+        const cur = livePx[resize.cardId] || resize.startPx;
+        const card = placed.find((p) => p.id === resize.cardId);
+        if (card) {
+          const gw = Math.max(MIN_W, Math.round((cur.w + GAP) / metrics.colW));
+          const gh = Math.max(MIN_H, Math.round((cur.h + GAP) / ROW_H));
+          const next: DashboardCardLayout = {
+            ...card.resolvedLayout,
+            w: Math.min(gw, COLS - card.resolvedLayout.x),
+            h: gh,
+          };
+          if (next.w !== card.resolvedLayout.w || next.h !== card.resolvedLayout.h) {
+            onLayoutChange(resize.cardId, next);
+          }
+        }
+        setResize(null);
+      }
+      setLivePx({});
+    };
+
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+    return () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+  }, [drag, resize, metrics, placed, livePx, onLayoutChange]);
+
+  const onDragStart = (e: React.MouseEvent, cardId: string) => {
+    e.preventDefault();
+    const card = placed.find((p) => p.id === cardId);
+    if (!card) return;
+    const px = toPx(card.resolvedLayout, metrics.colW);
+    setDrag({ cardId, startMouse: { x: e.clientX, y: e.clientY }, startPx: px });
+  };
+
+  const onResizeStart = (e: React.MouseEvent, cardId: string, dir: "e" | "s" | "se") => {
+    e.preventDefault();
+    e.stopPropagation();
+    const card = placed.find((p) => p.id === cardId);
+    if (!card) return;
+    const px = toPx(card.resolvedLayout, metrics.colW);
+    setResize({ cardId, dir, startMouse: { x: e.clientX, y: e.clientY }, startPx: px });
+  };
+
+  const onFullscreen = (cardId: string) =>
+    setFullscreenId((prev) => (prev === cardId ? null : cardId));
+
+  const totalRows = Math.max(18, ...placed.map((p) => p.resolvedLayout.y + p.resolvedLayout.h)) + 2;
+  const canvasStyle = {
+    height: totalRows * ROW_H,
+    "--dash-row-h": `${ROW_H}px`,
+  } as React.CSSProperties;
+
+  return (
+    <div
+      className={cn(
+        "dashboard-app relative flex-1",
+        `dash-density-${density}`,
+        drag && "is-dragging",
+        resize && "is-resizing",
+      )}
+    >
+      <div ref={canvasRef} className={cn("dash-canvas", editing && "editing")} style={canvasStyle}>
+        {editing && <div className="dash-row-guides" />}
+
+        {placed.map((card) => {
+          const px = toPx(card.resolvedLayout, metrics.colW);
+          const live = livePx[card.id];
+          const rect = live ?? px;
+          const isDragging = drag?.cardId === card.id;
+          const isResizing = resize?.cardId === card.id;
+
+          let ghost: { left: number; top: number; width: number; height: number } | null = null;
+          if (isDragging) {
+            const gx = Math.max(0, Math.min(COLS - 1, Math.round(rect.x / metrics.colW)));
+            const gy = Math.max(0, Math.round(rect.y / ROW_H));
+            const gw = Math.min(card.resolvedLayout.w, COLS - gx);
+            ghost = {
+              left: gx * metrics.colW + GAP / 2,
+              top: gy * ROW_H + GAP / 2,
+              width: gw * metrics.colW - GAP,
+              height: card.resolvedLayout.h * ROW_H - GAP,
+            };
+          } else if (isResizing) {
+            const gw = Math.max(MIN_W, Math.min(COLS - card.resolvedLayout.x, Math.round((rect.w + GAP) / metrics.colW)));
+            const gh = Math.max(MIN_H, Math.round((rect.h + GAP) / ROW_H));
+            ghost = {
+              left: card.resolvedLayout.x * metrics.colW + GAP / 2,
+              top: card.resolvedLayout.y * ROW_H + GAP / 2,
+              width: gw * metrics.colW - GAP,
+              height: gh * ROW_H - GAP,
+            };
+          }
+
+          return (
+            <div key={card.id}>
+              {ghost && (
+                <div
+                  className="dash-drag-ghost"
+                  style={{ left: ghost.left, top: ghost.top, width: ghost.width, height: ghost.height }}
+                />
+              )}
+              <DashboardTile
+                card={card}
+                pxRect={rect}
+                editing={editing}
+                dragging={isDragging}
+                resizing={isResizing}
+                fullscreen={fullscreenId === card.id}
+                isRefreshing={refreshingId === card.id}
+                onDragStart={onDragStart}
+                onResizeStart={onResizeStart}
+                onFullscreen={onFullscreen}
+                onRefresh={onRefresh}
+                onDuplicate={onDuplicate}
+                onDelete={onDelete}
+                onUpdateTitle={onUpdateTitle}
+              />
+            </div>
+          );
+        })}
+
+        {placed.length === 0 && (
+          <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-2 px-6 text-center">
+            <div className="text-2xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">
+              An empty canvas
+            </div>
+            <p className="max-w-md text-sm text-zinc-500 dark:text-zinc-400">
+              Run a query in chat and click <span className="font-medium">Add to Dashboard</span> to drop your first tile here.
+            </p>
+            {editing && (
+              <p className="mt-1 inline-flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-wider text-zinc-500 dark:text-zinc-500">
+                <Keyboard className="size-3" />
+                Press <kbd className="rounded border border-zinc-300 bg-zinc-100 px-1.5 py-0.5 text-[10px] dark:border-zinc-700 dark:bg-zinc-900">E</kbd> to exit edit mode
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/ui/components/dashboards/dashboard-grid.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-grid.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
+import {
+  GridLayout,
+  useContainerWidth,
+  noCompactor,
+  type Layout,
+} from "react-grid-layout";
+import "react-grid-layout/css/styles.css";
 import { Keyboard } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { DashboardCard, DashboardCardLayout } from "@/ui/lib/types";
@@ -8,12 +15,9 @@ import { COLS, ROW_H, GAP, MIN_W, MIN_H } from "./grid-constants";
 import { withAutoLayout } from "./auto-layout";
 import { DashboardTile } from "./dashboard-tile";
 
-type Density = "compact" | "comfortable" | "spacious";
-
 interface DashboardGridProps {
   cards: DashboardCard[];
   editing: boolean;
-  density: Density;
   refreshingId: string | null;
   onLayoutChange: (cardId: string, layout: DashboardCardLayout) => void;
   onRefresh: (cardId: string) => void;
@@ -22,51 +26,9 @@ interface DashboardGridProps {
   onUpdateTitle: (cardId: string, title: string) => void;
 }
 
-interface PxRect { x: number; y: number; w: number; h: number }
-
-interface DragState {
-  cardId: string;
-  startMouse: { x: number; y: number };
-  startPx: PxRect;
-}
-
-interface ResizeState {
-  cardId: string;
-  dir: "e" | "s" | "se";
-  startMouse: { x: number; y: number };
-  startPx: PxRect;
-}
-
-function useGridMetrics(canvasRef: React.RefObject<HTMLDivElement | null>) {
-  const [metrics, setMetrics] = useState({ colW: 60, width: 1200 });
-  useEffect(() => {
-    const node = canvasRef.current;
-    if (!node) return;
-    const update = () => {
-      const w = node.getBoundingClientRect().width;
-      setMetrics({ colW: w / COLS, width: w });
-    };
-    update();
-    const ro = new ResizeObserver(update);
-    ro.observe(node);
-    return () => ro.disconnect();
-  }, [canvasRef]);
-  return metrics;
-}
-
-function toPx(layout: DashboardCardLayout, colW: number): PxRect {
-  return {
-    x: layout.x * colW + GAP / 2,
-    y: layout.y * ROW_H + GAP / 2,
-    w: layout.w * colW - GAP,
-    h: layout.h * ROW_H - GAP,
-  };
-}
-
 export function DashboardGrid({
   cards,
   editing,
-  density,
   refreshingId,
   onLayoutChange,
   onRefresh,
@@ -74,197 +36,99 @@ export function DashboardGrid({
   onDelete,
   onUpdateTitle,
 }: DashboardGridProps) {
-  const canvasRef = useRef<HTMLDivElement | null>(null);
-  const metrics = useGridMetrics(canvasRef);
-
-  const [drag, setDrag] = useState<DragState | null>(null);
-  const [resize, setResize] = useState<ResizeState | null>(null);
-  const [livePx, setLivePx] = useState<Record<string, PxRect>>({});
+  const { width, containerRef, mounted } = useContainerWidth();
   const [fullscreenId, setFullscreenId] = useState<string | null>(null);
-
   const placed = useMemo(() => withAutoLayout(cards), [cards]);
 
-  // Mouse-move + mouse-up handlers — only mounted while a drag/resize is active.
-  useEffect(() => {
-    if (!drag && !resize) return;
+  const layout: Layout = placed.map((p) => ({
+    i: p.id,
+    x: p.resolvedLayout.x,
+    y: p.resolvedLayout.y,
+    w: p.resolvedLayout.w,
+    h: p.resolvedLayout.h,
+    minW: MIN_W,
+    minH: MIN_H,
+    maxW: COLS,
+  }));
 
-    const onMove = (e: MouseEvent) => {
-      if (drag) {
-        const dx = e.clientX - drag.startMouse.x;
-        const dy = e.clientY - drag.startMouse.y;
-        const nx = Math.max(GAP / 2, drag.startPx.x + dx);
-        const ny = Math.max(GAP / 2, drag.startPx.y + dy);
-        setLivePx((prev) => ({ ...prev, [drag.cardId]: { ...drag.startPx, x: nx, y: ny } }));
+  function handleRGLLayoutChange(next: Layout) {
+    for (const item of next) {
+      const before = placed.find((p) => p.id === item.i);
+      if (!before) continue;
+      const cur = before.resolvedLayout;
+      if (item.x !== cur.x || item.y !== cur.y || item.w !== cur.w || item.h !== cur.h) {
+        onLayoutChange(item.i, { x: item.x, y: item.y, w: item.w, h: item.h });
       }
-      if (resize) {
-        const dx = e.clientX - resize.startMouse.x;
-        const dy = e.clientY - resize.startMouse.y;
-        const { x, y } = resize.startPx;
-        let { w, h } = resize.startPx;
-        if (resize.dir.includes("e")) w = Math.max(metrics.colW * MIN_W - GAP, w + dx);
-        if (resize.dir.includes("s")) h = Math.max(ROW_H * MIN_H - GAP, h + dy);
-        setLivePx((prev) => ({ ...prev, [resize.cardId]: { x, y, w, h } }));
-      }
-    };
-
-    const onUp = () => {
-      if (drag) {
-        const cur = livePx[drag.cardId] || drag.startPx;
-        const card = placed.find((p) => p.id === drag.cardId);
-        if (card) {
-          const gx = Math.max(0, Math.min(COLS - 1, Math.round(cur.x / metrics.colW)));
-          const gy = Math.max(0, Math.round(cur.y / ROW_H));
-          const next: DashboardCardLayout = {
-            ...card.resolvedLayout,
-            x: Math.min(gx, COLS - card.resolvedLayout.w),
-            y: gy,
-          };
-          if (next.x !== card.resolvedLayout.x || next.y !== card.resolvedLayout.y) {
-            onLayoutChange(drag.cardId, next);
-          }
-        }
-        setDrag(null);
-      }
-      if (resize) {
-        const cur = livePx[resize.cardId] || resize.startPx;
-        const card = placed.find((p) => p.id === resize.cardId);
-        if (card) {
-          const gw = Math.max(MIN_W, Math.round((cur.w + GAP) / metrics.colW));
-          const gh = Math.max(MIN_H, Math.round((cur.h + GAP) / ROW_H));
-          const next: DashboardCardLayout = {
-            ...card.resolvedLayout,
-            w: Math.min(gw, COLS - card.resolvedLayout.x),
-            h: gh,
-          };
-          if (next.w !== card.resolvedLayout.w || next.h !== card.resolvedLayout.h) {
-            onLayoutChange(resize.cardId, next);
-          }
-        }
-        setResize(null);
-      }
-      setLivePx({});
-    };
-
-    window.addEventListener("mousemove", onMove);
-    window.addEventListener("mouseup", onUp);
-    return () => {
-      window.removeEventListener("mousemove", onMove);
-      window.removeEventListener("mouseup", onUp);
-    };
-  }, [drag, resize, metrics, placed, livePx, onLayoutChange]);
-
-  const onDragStart = (e: React.MouseEvent, cardId: string) => {
-    e.preventDefault();
-    const card = placed.find((p) => p.id === cardId);
-    if (!card) return;
-    const px = toPx(card.resolvedLayout, metrics.colW);
-    setDrag({ cardId, startMouse: { x: e.clientX, y: e.clientY }, startPx: px });
-  };
-
-  const onResizeStart = (e: React.MouseEvent, cardId: string, dir: "e" | "s" | "se") => {
-    e.preventDefault();
-    e.stopPropagation();
-    const card = placed.find((p) => p.id === cardId);
-    if (!card) return;
-    const px = toPx(card.resolvedLayout, metrics.colW);
-    setResize({ cardId, dir, startMouse: { x: e.clientX, y: e.clientY }, startPx: px });
-  };
-
-  const onFullscreen = (cardId: string) =>
-    setFullscreenId((prev) => (prev === cardId ? null : cardId));
-
-  const totalRows = Math.max(18, ...placed.map((p) => p.resolvedLayout.y + p.resolvedLayout.h)) + 2;
-  const canvasStyle = {
-    height: totalRows * ROW_H,
-    "--dash-row-h": `${ROW_H}px`,
-  } as React.CSSProperties;
+    }
+  }
 
   return (
-    <div
-      className={cn(
-        "dashboard-app relative flex-1",
-        `dash-density-${density}`,
-        drag && "is-dragging",
-        resize && "is-resizing",
-      )}
-    >
-      <div ref={canvasRef} className={cn("dash-canvas", editing && "editing")} style={canvasStyle}>
-        {editing && <div className="dash-row-guides" />}
-
-        {placed.map((card) => {
-          const px = toPx(card.resolvedLayout, metrics.colW);
-          const live = livePx[card.id];
-          const rect = live ?? px;
-          const isDragging = drag?.cardId === card.id;
-          const isResizing = resize?.cardId === card.id;
-
-          let ghost: { left: number; top: number; width: number; height: number } | null = null;
-          if (isDragging) {
-            const gx = Math.max(0, Math.min(COLS - 1, Math.round(rect.x / metrics.colW)));
-            const gy = Math.max(0, Math.round(rect.y / ROW_H));
-            const gw = Math.min(card.resolvedLayout.w, COLS - gx);
-            ghost = {
-              left: gx * metrics.colW + GAP / 2,
-              top: gy * ROW_H + GAP / 2,
-              width: gw * metrics.colW - GAP,
-              height: card.resolvedLayout.h * ROW_H - GAP,
-            };
-          } else if (isResizing) {
-            const gw = Math.max(MIN_W, Math.min(COLS - card.resolvedLayout.x, Math.round((rect.w + GAP) / metrics.colW)));
-            const gh = Math.max(MIN_H, Math.round((rect.h + GAP) / ROW_H));
-            ghost = {
-              left: card.resolvedLayout.x * metrics.colW + GAP / 2,
-              top: card.resolvedLayout.y * ROW_H + GAP / 2,
-              width: gw * metrics.colW - GAP,
-              height: gh * ROW_H - GAP,
-            };
-          }
-
-          return (
-            <div key={card.id}>
-              {ghost && (
-                <div
-                  className="dash-drag-ghost"
-                  style={{ left: ghost.left, top: ghost.top, width: ghost.width, height: ghost.height }}
-                />
+    <div ref={containerRef} className="dashboard-app relative flex-1">
+      {placed.length === 0 ? (
+        <EmptyCanvas editing={editing} />
+      ) : mounted && width > 0 ? (
+        <GridLayout
+          layout={layout}
+          width={width}
+          gridConfig={{
+            cols: COLS,
+            rowHeight: ROW_H,
+            margin: [GAP, GAP],
+            containerPadding: [GAP / 2, GAP / 2],
+            maxRows: Number.POSITIVE_INFINITY,
+          }}
+          dragConfig={{
+            enabled: editing,
+            bounded: false,
+            handle: ".dash-drag-handle",
+            cancel: "button, input, [role='button']",
+          }}
+          resizeConfig={{ enabled: editing, handles: ["e", "s", "se"] }}
+          compactor={noCompactor}
+          onLayoutChange={handleRGLLayoutChange}
+        >
+          {placed.map((card) => (
+            <div
+              key={card.id}
+              className={cn(
+                "dash-tile-wrapper",
+                fullscreenId === card.id && "is-fullscreen",
               )}
+            >
               <DashboardTile
                 card={card}
-                pxRect={rect}
                 editing={editing}
-                dragging={isDragging}
-                resizing={isResizing}
                 fullscreen={fullscreenId === card.id}
                 isRefreshing={refreshingId === card.id}
-                onDragStart={onDragStart}
-                onResizeStart={onResizeStart}
-                onFullscreen={onFullscreen}
+                onFullscreen={(id) => setFullscreenId((prev) => (prev === id ? null : id))}
                 onRefresh={onRefresh}
                 onDuplicate={onDuplicate}
                 onDelete={onDelete}
                 onUpdateTitle={onUpdateTitle}
               />
             </div>
-          );
-        })}
+          ))}
+        </GridLayout>
+      ) : null}
+    </div>
+  );
+}
 
-        {placed.length === 0 && (
-          <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-2 px-6 text-center">
-            <div className="text-2xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">
-              An empty canvas
-            </div>
-            <p className="max-w-md text-sm text-zinc-500 dark:text-zinc-400">
-              Run a query in chat and click <span className="font-medium">Add to Dashboard</span> to drop your first tile here.
-            </p>
-            {editing && (
-              <p className="mt-1 inline-flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-wider text-zinc-500 dark:text-zinc-500">
-                <Keyboard className="size-3" />
-                Press <kbd className="rounded border border-zinc-300 bg-zinc-100 px-1.5 py-0.5 text-[10px] dark:border-zinc-700 dark:bg-zinc-900">E</kbd> to exit edit mode
-              </p>
-            )}
-          </div>
-        )}
+function EmptyCanvas({ editing }: { editing: boolean }) {
+  return (
+    <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 px-6 text-center">
+      <div className="text-2xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">
+        An empty canvas
       </div>
+      <p className="max-w-md text-sm text-zinc-500 dark:text-zinc-400">
+        Run a query in chat and click <span className="font-medium">Add to Dashboard</span> to drop your first tile here.
+      </p>
+      {editing && (
+        <p className="mt-1 inline-flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-wider text-zinc-500 dark:text-zinc-500">
+          <Keyboard className="size-3" />
+          Press <kbd className="rounded border border-zinc-300 bg-zinc-100 px-1.5 py-0.5 text-[10px] dark:border-zinc-700 dark:bg-zinc-900">E</kbd> to exit edit mode
+        </p>
+      )}
     </div>
   );
 }

--- a/packages/web/src/ui/components/dashboards/dashboard-tile.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-tile.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type CSSProperties } from "react";
+import { useState } from "react";
 import dynamic from "next/dynamic";
 import {
   GripVertical,
@@ -55,14 +55,9 @@ type ViewMode = "chart" | "table";
 
 interface DashboardTileProps {
   card: DashboardCard;
-  pxRect: { x: number; y: number; w: number; h: number };
   editing: boolean;
-  dragging: boolean;
-  resizing: boolean;
   fullscreen: boolean;
   isRefreshing: boolean;
-  onDragStart: (e: React.MouseEvent, cardId: string) => void;
-  onResizeStart: (e: React.MouseEvent, cardId: string, dir: "e" | "s" | "se") => void;
   onFullscreen: (cardId: string) => void;
   onRefresh: (cardId: string) => void;
   onDuplicate: (cardId: string) => void;
@@ -72,14 +67,9 @@ interface DashboardTileProps {
 
 export function DashboardTile({
   card,
-  pxRect,
   editing,
-  dragging,
-  resizing,
   fullscreen,
   isRefreshing,
-  onDragStart,
-  onResizeStart,
   onFullscreen,
   onRefresh,
   onDuplicate,
@@ -98,14 +88,6 @@ export function DashboardTile({
   const hasData = columns.length > 0 && rows.length > 0;
   const stringRows = hasData ? toStringRows(columns, rows) : [];
 
-  const style: CSSProperties = fullscreen
-    ? {}
-    : {
-        transform: `translate(${pxRect.x}px, ${pxRect.y}px)`,
-        width: pxRect.w,
-        height: pxRect.h,
-      };
-
   function commitTitle() {
     const next = titleDraft.trim();
     if (next && next !== card.title) onUpdateTitle(card.id, next);
@@ -115,21 +97,15 @@ export function DashboardTile({
   return (
     <div
       className={cn(
-        "dash-tile rounded-xl border border-zinc-200 bg-white text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-100",
+        "dash-tile flex h-full w-full flex-col rounded-xl border border-zinc-200 bg-white text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-100",
         "hover:border-zinc-300 dark:hover:border-zinc-700",
-        dragging && "is-dragging",
-        resizing && "is-resizing",
-        fullscreen && "is-fullscreen",
       )}
-      style={style}
     >
-      {/* Tile head — drag handle, title, hover actions */}
       <div
         className={cn(
           "dash-tile-head group/head flex shrink-0 items-center gap-2 border-b border-zinc-100 px-3 py-2 dark:border-zinc-800/80",
-          editing ? "cursor-grab active:cursor-grabbing" : "cursor-default",
+          editing && "dash-drag-handle cursor-grab active:cursor-grabbing",
         )}
-        onMouseDown={editing ? (e) => onDragStart(e, card.id) : undefined}
       >
         <span
           aria-hidden
@@ -142,7 +118,7 @@ export function DashboardTile({
         </span>
 
         {titleEditing ? (
-          <div className="flex flex-1 items-center gap-1.5" onMouseDown={(e) => e.stopPropagation()}>
+          <div className="flex flex-1 items-center gap-1.5">
             <Input
               value={titleDraft}
               onChange={(e) => setTitleDraft(e.target.value)}
@@ -171,12 +147,8 @@ export function DashboardTile({
           </h3>
         )}
 
-        {/* Chart/Table switcher — only when we actually have a chart-eligible config */}
         {hasChartConfig && hasData && !titleEditing && (
-          <div
-            className="flex shrink-0 items-center gap-0 rounded-md p-0.5"
-            onMouseDown={(e) => e.stopPropagation()}
-          >
+          <div className="flex shrink-0 items-center gap-0 rounded-md p-0.5">
             <button
               type="button"
               className={cn(
@@ -204,14 +176,8 @@ export function DashboardTile({
           </div>
         )}
 
-        {/* Actions — refresh / fullscreen always visible (50% opacity → 100% on hover);
-            copy / delete / more collapsed into kebab to keep the head readable on
-            narrow tiles. */}
         {!titleEditing && (
-          <div
-            className="flex shrink-0 items-center gap-0.5 opacity-60 transition-opacity group-hover/head:opacity-100"
-            onMouseDown={(e) => e.stopPropagation()}
-          >
+          <div className="flex shrink-0 items-center gap-0.5 opacity-60 transition-opacity group-hover/head:opacity-100">
             <Button
               variant="ghost"
               size="icon"
@@ -260,11 +226,10 @@ export function DashboardTile({
         )}
       </div>
 
-      {/* Tile body */}
       <div className="dash-tile-body flex min-h-0 flex-1 flex-col gap-2 overflow-hidden px-3 py-2.5">
         {hasData ? (
           viewMode === "chart" && hasChartConfig ? (
-            <div className="min-h-0 flex-1 [&>div]:!aspect-auto [&>div]:!h-full">
+            <div className="min-h-0 flex-1 [&>div]:aspect-auto! [&>div]:h-full!">
               <ResultChart headers={columns} rows={stringRows} dark={dark} />
             </div>
           ) : (
@@ -279,7 +244,6 @@ export function DashboardTile({
         )}
       </div>
 
-      {/* Footer caption — last refresh */}
       <div className="flex shrink-0 items-center justify-between border-t border-zinc-100 px-3 py-1.5 font-mono text-[10px] text-zinc-500 dark:border-zinc-800/80 dark:text-zinc-500">
         <span className="inline-flex items-center gap-1">
           <Clock className="size-2.5" />
@@ -287,15 +251,6 @@ export function DashboardTile({
         </span>
         {hasData && <span>{rows.length} rows</span>}
       </div>
-
-      {/* Resize handles — only in edit mode, never on fullscreen tiles */}
-      {editing && !fullscreen && (
-        <>
-          <div className="dash-rh e" onMouseDown={(e) => onResizeStart(e, card.id, "e")} />
-          <div className="dash-rh s" onMouseDown={(e) => onResizeStart(e, card.id, "s")} />
-          <div className="dash-rh se" onMouseDown={(e) => onResizeStart(e, card.id, "se")} />
-        </>
-      )}
     </div>
   );
 }

--- a/packages/web/src/ui/components/dashboards/dashboard-tile.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-tile.tsx
@@ -1,0 +1,301 @@
+"use client";
+
+import { useState, type CSSProperties } from "react";
+import dynamic from "next/dynamic";
+import {
+  GripVertical,
+  RefreshCw,
+  Maximize2,
+  Minimize2,
+  Copy,
+  Trash2,
+  MoreHorizontal,
+  Pencil,
+  Check,
+  X,
+  Clock,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
+import { DataTable } from "@/ui/components/chat/data-table";
+import { useDarkMode } from "@/ui/hooks/use-dark-mode";
+import { cn } from "@/lib/utils";
+import type { DashboardCard } from "@/ui/lib/types";
+
+const ResultChart = dynamic(
+  () => import("@/ui/components/chart/result-chart").then((m) => ({ default: m.ResultChart })),
+  { ssr: false, loading: () => <div className="h-full w-full animate-pulse rounded-md bg-zinc-100 dark:bg-zinc-800/50" /> },
+);
+
+function timeAgo(iso: string | null): string {
+  if (!iso) return "never";
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+function toStringRows(columns: string[], rows: Record<string, unknown>[]): string[][] {
+  return rows.map((row) => columns.map((col) => (row[col] == null ? "" : String(row[col]))));
+}
+
+type ViewMode = "chart" | "table";
+
+interface DashboardTileProps {
+  card: DashboardCard;
+  pxRect: { x: number; y: number; w: number; h: number };
+  editing: boolean;
+  dragging: boolean;
+  resizing: boolean;
+  fullscreen: boolean;
+  isRefreshing: boolean;
+  onDragStart: (e: React.MouseEvent, cardId: string) => void;
+  onResizeStart: (e: React.MouseEvent, cardId: string, dir: "e" | "s" | "se") => void;
+  onFullscreen: (cardId: string) => void;
+  onRefresh: (cardId: string) => void;
+  onDuplicate: (cardId: string) => void;
+  onDelete: (card: DashboardCard) => void;
+  onUpdateTitle: (cardId: string, title: string) => void;
+}
+
+export function DashboardTile({
+  card,
+  pxRect,
+  editing,
+  dragging,
+  resizing,
+  fullscreen,
+  isRefreshing,
+  onDragStart,
+  onResizeStart,
+  onFullscreen,
+  onRefresh,
+  onDuplicate,
+  onDelete,
+  onUpdateTitle,
+}: DashboardTileProps) {
+  const dark = useDarkMode();
+  const [titleEditing, setTitleEditing] = useState(false);
+  const [titleDraft, setTitleDraft] = useState(card.title);
+
+  const hasChartConfig = !!card.chartConfig && card.chartConfig.type !== "table";
+  const [viewMode, setViewMode] = useState<ViewMode>(hasChartConfig ? "chart" : "table");
+
+  const columns = card.cachedColumns ?? [];
+  const rows = (card.cachedRows ?? []) as Record<string, unknown>[];
+  const hasData = columns.length > 0 && rows.length > 0;
+  const stringRows = hasData ? toStringRows(columns, rows) : [];
+
+  const style: CSSProperties = fullscreen
+    ? {}
+    : {
+        transform: `translate(${pxRect.x}px, ${pxRect.y}px)`,
+        width: pxRect.w,
+        height: pxRect.h,
+      };
+
+  function commitTitle() {
+    const next = titleDraft.trim();
+    if (next && next !== card.title) onUpdateTitle(card.id, next);
+    setTitleEditing(false);
+  }
+
+  return (
+    <div
+      className={cn(
+        "dash-tile rounded-xl border border-zinc-200 bg-white text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-100",
+        "hover:border-zinc-300 dark:hover:border-zinc-700",
+        dragging && "is-dragging",
+        resizing && "is-resizing",
+        fullscreen && "is-fullscreen",
+      )}
+      style={style}
+    >
+      {/* Tile head — drag handle, title, hover actions */}
+      <div
+        className={cn(
+          "dash-tile-head group/head flex shrink-0 items-center gap-2 border-b border-zinc-100 px-3 py-2 dark:border-zinc-800/80",
+          editing ? "cursor-grab active:cursor-grabbing" : "cursor-default",
+        )}
+        onMouseDown={editing ? (e) => onDragStart(e, card.id) : undefined}
+      >
+        <span
+          aria-hidden
+          className={cn(
+            "flex shrink-0 items-center text-zinc-400 transition-opacity dark:text-zinc-500",
+            editing ? "opacity-60 group-hover/head:opacity-100" : "opacity-0 pointer-events-none",
+          )}
+        >
+          <GripVertical className="size-3.5" />
+        </span>
+
+        {titleEditing ? (
+          <div className="flex flex-1 items-center gap-1.5" onMouseDown={(e) => e.stopPropagation()}>
+            <Input
+              value={titleDraft}
+              onChange={(e) => setTitleDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") commitTitle();
+                if (e.key === "Escape") setTitleEditing(false);
+              }}
+              className="h-7 text-sm"
+              autoFocus
+            />
+            <Button variant="ghost" size="icon" className="size-7" onClick={commitTitle}>
+              <Check className="size-3.5" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-7"
+              onClick={() => setTitleEditing(false)}
+            >
+              <X className="size-3.5" />
+            </Button>
+          </div>
+        ) : (
+          <h3 className="line-clamp-1 flex-1 text-sm font-medium tracking-tight" title={card.title}>
+            {card.title}
+          </h3>
+        )}
+
+        {/* Chart/Table switcher — only when we actually have a chart-eligible config */}
+        {hasChartConfig && hasData && !titleEditing && (
+          <div
+            className="flex shrink-0 items-center gap-0 rounded-md p-0.5"
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            <button
+              type="button"
+              className={cn(
+                "rounded px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider transition-colors",
+                viewMode === "chart"
+                  ? "bg-primary/12 text-primary"
+                  : "text-zinc-500 hover:text-zinc-800 dark:text-zinc-500 dark:hover:text-zinc-200",
+              )}
+              onClick={() => setViewMode("chart")}
+            >
+              Chart
+            </button>
+            <button
+              type="button"
+              className={cn(
+                "rounded px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider transition-colors",
+                viewMode === "table"
+                  ? "bg-primary/12 text-primary"
+                  : "text-zinc-500 hover:text-zinc-800 dark:text-zinc-500 dark:hover:text-zinc-200",
+              )}
+              onClick={() => setViewMode("table")}
+            >
+              Table
+            </button>
+          </div>
+        )}
+
+        {/* Actions — refresh / fullscreen always visible (50% opacity → 100% on hover);
+            copy / delete / more collapsed into kebab to keep the head readable on
+            narrow tiles. */}
+        {!titleEditing && (
+          <div
+            className="flex shrink-0 items-center gap-0.5 opacity-60 transition-opacity group-hover/head:opacity-100"
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-7"
+              onClick={() => onRefresh(card.id)}
+              disabled={isRefreshing}
+              title="Refresh data"
+            >
+              <RefreshCw className={cn("size-3.5", isRefreshing && "animate-spin")} />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-7"
+              onClick={() => onFullscreen(card.id)}
+              title={fullscreen ? "Exit fullscreen" : "Fullscreen"}
+            >
+              {fullscreen ? <Minimize2 className="size-3.5" /> : <Maximize2 className="size-3.5" />}
+            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" className="size-7" title="More">
+                  <MoreHorizontal className="size-3.5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="text-xs">
+                <DropdownMenuItem onSelect={() => { setTitleDraft(card.title); setTitleEditing(true); }}>
+                  <Pencil className="mr-2 size-3.5" />
+                  Rename
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => onDuplicate(card.id)}>
+                  <Copy className="mr-2 size-3.5" />
+                  Duplicate
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onSelect={() => onDelete(card)}
+                  className="text-red-600 focus:text-red-600 dark:text-red-400 dark:focus:text-red-400"
+                >
+                  <Trash2 className="mr-2 size-3.5" />
+                  Remove
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        )}
+      </div>
+
+      {/* Tile body */}
+      <div className="dash-tile-body flex min-h-0 flex-1 flex-col gap-2 overflow-hidden px-3 py-2.5">
+        {hasData ? (
+          viewMode === "chart" && hasChartConfig ? (
+            <div className="min-h-0 flex-1 [&>div]:!aspect-auto [&>div]:!h-full">
+              <ResultChart headers={columns} rows={stringRows} dark={dark} />
+            </div>
+          ) : (
+            <div className="min-h-0 flex-1 overflow-auto">
+              <DataTable columns={columns} rows={rows} />
+            </div>
+          )
+        ) : (
+          <div className="flex flex-1 items-center justify-center px-2 text-center text-xs text-zinc-500 dark:text-zinc-400">
+            No cached data. Click <RefreshCw className="mx-1 inline size-3" /> to load results.
+          </div>
+        )}
+      </div>
+
+      {/* Footer caption — last refresh */}
+      <div className="flex shrink-0 items-center justify-between border-t border-zinc-100 px-3 py-1.5 font-mono text-[10px] text-zinc-500 dark:border-zinc-800/80 dark:text-zinc-500">
+        <span className="inline-flex items-center gap-1">
+          <Clock className="size-2.5" />
+          {timeAgo(card.cachedAt)}
+        </span>
+        {hasData && <span>{rows.length} rows</span>}
+      </div>
+
+      {/* Resize handles — only in edit mode, never on fullscreen tiles */}
+      {editing && !fullscreen && (
+        <>
+          <div className="dash-rh e" onMouseDown={(e) => onResizeStart(e, card.id, "e")} />
+          <div className="dash-rh s" onMouseDown={(e) => onResizeStart(e, card.id, "s")} />
+          <div className="dash-rh se" onMouseDown={(e) => onResizeStart(e, card.id, "se")} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/ui/components/dashboards/dashboard-topbar.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-topbar.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import Link from "next/link";
+import {
+  ArrowLeft,
+  RefreshCw,
+  Eye,
+  Pencil,
+  Sparkles,
+  Plus,
+  Trash2,
+  Check,
+  X,
+  Timer,
+  Rows3,
+  Rows,
+  StretchHorizontal,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+type Density = "compact" | "comfortable" | "spacious";
+
+interface DashboardTopBarProps {
+  title: string;
+  cardCount: number;
+  description: string | null;
+  editingTitle: boolean;
+  titleDraft: string;
+  onTitleClick: () => void;
+  onTitleDraftChange: (v: string) => void;
+  onTitleSave: () => void;
+  onTitleCancel: () => void;
+  refreshing: boolean;
+  refreshSchedule: string | null;
+  onScheduleChange: (v: string) => void;
+  onRefreshAll: () => void;
+  onSuggest: () => void;
+  suggesting: boolean;
+  onDelete: () => void;
+  shareSlot: React.ReactNode;
+  editing: boolean;
+  onEditingChange: (next: boolean) => void;
+  density: Density;
+  onDensityChange: (next: Density) => void;
+}
+
+export function DashboardTopBar({
+  title,
+  cardCount,
+  description,
+  editingTitle,
+  titleDraft,
+  onTitleClick,
+  onTitleDraftChange,
+  onTitleSave,
+  onTitleCancel,
+  refreshing,
+  refreshSchedule,
+  onScheduleChange,
+  onRefreshAll,
+  onSuggest,
+  suggesting,
+  onDelete,
+  shareSlot,
+  editing,
+  onEditingChange,
+  density,
+  onDensityChange,
+}: DashboardTopBarProps) {
+  return (
+    <div className="sticky top-0 z-10 flex flex-wrap items-center justify-between gap-3 border-b border-zinc-200 bg-background/95 px-4 py-3 backdrop-blur dark:border-zinc-800 sm:px-6">
+      {/* Left: breadcrumb + title + chip */}
+      <div className="flex min-w-0 flex-col gap-1">
+        <Link
+          href="/dashboards"
+          className="inline-flex items-center gap-1 font-mono text-[11px] uppercase tracking-wider text-zinc-500 transition-colors hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300"
+        >
+          <ArrowLeft className="size-3" />
+          All dashboards
+        </Link>
+        <div className="flex items-center gap-2 min-w-0">
+          {editingTitle ? (
+            <div className="flex items-center gap-1.5 min-w-0">
+              <Input
+                value={titleDraft}
+                onChange={(e) => onTitleDraftChange(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") onTitleSave();
+                  if (e.key === "Escape") onTitleCancel();
+                }}
+                className="h-8 min-w-[16ch] text-base font-semibold tracking-tight"
+                autoFocus
+              />
+              <Button variant="ghost" size="icon" className="size-7" onClick={onTitleSave}>
+                <Check className="size-4" />
+              </Button>
+              <Button variant="ghost" size="icon" className="size-7" onClick={onTitleCancel}>
+                <X className="size-4" />
+              </Button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={onTitleClick}
+              className="cursor-pointer truncate text-left text-lg font-semibold tracking-tight text-zinc-900 hover:text-zinc-700 dark:text-zinc-100 dark:hover:text-zinc-300"
+              title="Click to edit title"
+            >
+              {title}
+            </button>
+          )}
+          <span className="hidden shrink-0 rounded border border-primary/30 bg-primary/12 px-1.5 py-px font-mono text-[10px] uppercase tracking-widest text-primary sm:inline">
+            {cardCount} {cardCount === 1 ? "tile" : "tiles"}
+          </span>
+        </div>
+        {description && !editingTitle && (
+          <p className="line-clamp-1 max-w-[60ch] text-xs text-zinc-500 dark:text-zinc-400">
+            {description}
+          </p>
+        )}
+      </div>
+
+      {/* Right: action group */}
+      <div className="flex flex-wrap items-center gap-2">
+        {/* View / Edit segmented control */}
+        <div
+          role="group"
+          aria-label="Mode"
+          className="inline-flex items-center rounded-md border border-zinc-200 bg-zinc-100/60 p-0.5 dark:border-zinc-800 dark:bg-zinc-900"
+        >
+          <button
+            type="button"
+            className={cn(
+              "inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium transition-colors",
+              !editing
+                ? "bg-background text-foreground shadow-sm"
+                : "text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-100",
+            )}
+            onClick={() => onEditingChange(false)}
+            aria-pressed={!editing}
+          >
+            <Eye className="size-3.5" />
+            View
+          </button>
+          <button
+            type="button"
+            className={cn(
+              "inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium transition-colors",
+              editing
+                ? "bg-background text-foreground shadow-sm"
+                : "text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-100",
+            )}
+            onClick={() => onEditingChange(true)}
+            aria-pressed={editing}
+          >
+            <Pencil className="size-3.5" />
+            Edit
+          </button>
+        </div>
+
+        {/* Density */}
+        <div
+          role="group"
+          aria-label="Density"
+          className="hidden items-center rounded-md border border-zinc-200 bg-zinc-100/60 p-0.5 dark:border-zinc-800 dark:bg-zinc-900 md:inline-flex"
+        >
+          <DensityButton current={density} value="compact" label="Compact" onChange={onDensityChange}>
+            <Rows3 className="size-3.5" />
+          </DensityButton>
+          <DensityButton current={density} value="comfortable" label="Comfortable" onChange={onDensityChange}>
+            <Rows className="size-3.5" />
+          </DensityButton>
+          <DensityButton current={density} value="spacious" label="Spacious" onChange={onDensityChange}>
+            <StretchHorizontal className="size-3.5" />
+          </DensityButton>
+        </div>
+
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onSuggest}
+          disabled={suggesting || cardCount === 0}
+          className="hidden sm:inline-flex"
+        >
+          <Sparkles className={cn("mr-1.5 size-3.5", suggesting && "animate-pulse")} />
+          {suggesting ? "Thinking..." : "Suggest"}
+        </Button>
+
+        <Button variant="outline" size="sm" onClick={onRefreshAll} disabled={refreshing || cardCount === 0}>
+          <RefreshCw className={cn("mr-1.5 size-3.5", refreshing && "animate-spin")} />
+          Refresh
+        </Button>
+
+        <Select value={refreshSchedule ?? "off"} onValueChange={onScheduleChange}>
+          <SelectTrigger className="hidden h-8 w-auto gap-1.5 text-xs lg:inline-flex">
+            <Timer className="size-3.5 text-zinc-500" />
+            <SelectValue placeholder="Auto-refresh" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="off">Auto-refresh: Off</SelectItem>
+            <SelectItem value="*/15 * * * *">Every 15 min</SelectItem>
+            <SelectItem value="0 * * * *">Every hour</SelectItem>
+            <SelectItem value="0 */6 * * *">Every 6 hours</SelectItem>
+            <SelectItem value="0 0 * * *">Daily</SelectItem>
+            <SelectItem value="0 9 * * 1">Weekly (Mon 9am)</SelectItem>
+          </SelectContent>
+        </Select>
+
+        {shareSlot}
+
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onDelete}
+          className="text-red-500 hover:text-red-600 dark:text-red-400"
+        >
+          <Trash2 className="mr-1.5 size-3.5" />
+          Delete
+        </Button>
+
+        {editing && (
+          <Button size="sm" asChild>
+            <Link href="/">
+              <Plus className="mr-1.5 size-3.5" />
+              Add tile
+            </Link>
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DensityButton({
+  current,
+  value,
+  label,
+  onChange,
+  children,
+}: {
+  current: Density;
+  value: Density;
+  label: string;
+  onChange: (v: Density) => void;
+  children: React.ReactNode;
+}) {
+  const active = current === value;
+  return (
+    <button
+      type="button"
+      title={label}
+      aria-label={label}
+      aria-pressed={active}
+      onClick={() => onChange(value)}
+      className={cn(
+        "inline-flex items-center rounded px-2 py-1 transition-colors",
+        active
+          ? "bg-background text-foreground shadow-sm"
+          : "text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-100",
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/web/src/ui/components/dashboards/dashboard-topbar.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-topbar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import {
   ArrowLeft,
@@ -26,19 +27,13 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
-
-type Density = "compact" | "comfortable" | "spacious";
+import type { Density } from "./grid-constants";
 
 interface DashboardTopBarProps {
   title: string;
   cardCount: number;
   description: string | null;
-  editingTitle: boolean;
-  titleDraft: string;
-  onTitleClick: () => void;
-  onTitleDraftChange: (v: string) => void;
-  onTitleSave: () => void;
-  onTitleCancel: () => void;
+  onTitleChange: (next: string) => void;
   refreshing: boolean;
   refreshSchedule: string | null;
   onScheduleChange: (v: string) => void;
@@ -57,12 +52,7 @@ export function DashboardTopBar({
   title,
   cardCount,
   description,
-  editingTitle,
-  titleDraft,
-  onTitleClick,
-  onTitleDraftChange,
-  onTitleSave,
-  onTitleCancel,
+  onTitleChange,
   refreshing,
   refreshSchedule,
   onScheduleChange,
@@ -76,9 +66,28 @@ export function DashboardTopBar({
   density,
   onDensityChange,
 }: DashboardTopBarProps) {
+  const [titleEditing, setTitleEditing] = useState(false);
+  const [draft, setDraft] = useState(title);
+
+  // Resync the draft when the canonical title changes (e.g. after a server save
+  // resolves) so a subsequent edit starts from the up-to-date value.
+  useEffect(() => {
+    if (!titleEditing) setDraft(title);
+  }, [title, titleEditing]);
+
+  function commitTitle() {
+    const next = draft.trim();
+    if (next && next !== title) onTitleChange(next);
+    setTitleEditing(false);
+  }
+
+  function cancelTitle() {
+    setDraft(title);
+    setTitleEditing(false);
+  }
+
   return (
     <div className="sticky top-0 z-10 flex flex-wrap items-center justify-between gap-3 border-b border-zinc-200 bg-background/95 px-4 py-3 backdrop-blur dark:border-zinc-800 sm:px-6">
-      {/* Left: breadcrumb + title + chip */}
       <div className="flex min-w-0 flex-col gap-1">
         <Link
           href="/dashboards"
@@ -87,30 +96,30 @@ export function DashboardTopBar({
           <ArrowLeft className="size-3" />
           All dashboards
         </Link>
-        <div className="flex items-center gap-2 min-w-0">
-          {editingTitle ? (
-            <div className="flex items-center gap-1.5 min-w-0">
+        <div className="flex min-w-0 items-center gap-2">
+          {titleEditing ? (
+            <div className="flex min-w-0 items-center gap-1.5">
               <Input
-                value={titleDraft}
-                onChange={(e) => onTitleDraftChange(e.target.value)}
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter") onTitleSave();
-                  if (e.key === "Escape") onTitleCancel();
+                  if (e.key === "Enter") commitTitle();
+                  if (e.key === "Escape") cancelTitle();
                 }}
                 className="h-8 min-w-[16ch] text-base font-semibold tracking-tight"
                 autoFocus
               />
-              <Button variant="ghost" size="icon" className="size-7" onClick={onTitleSave}>
+              <Button variant="ghost" size="icon" className="size-7" onClick={commitTitle}>
                 <Check className="size-4" />
               </Button>
-              <Button variant="ghost" size="icon" className="size-7" onClick={onTitleCancel}>
+              <Button variant="ghost" size="icon" className="size-7" onClick={cancelTitle}>
                 <X className="size-4" />
               </Button>
             </div>
           ) : (
             <button
               type="button"
-              onClick={onTitleClick}
+              onClick={() => { setDraft(title); setTitleEditing(true); }}
               className="cursor-pointer truncate text-left text-lg font-semibold tracking-tight text-zinc-900 hover:text-zinc-700 dark:text-zinc-100 dark:hover:text-zinc-300"
               title="Click to edit title"
             >
@@ -121,16 +130,14 @@ export function DashboardTopBar({
             {cardCount} {cardCount === 1 ? "tile" : "tiles"}
           </span>
         </div>
-        {description && !editingTitle && (
+        {description && !titleEditing && (
           <p className="line-clamp-1 max-w-[60ch] text-xs text-zinc-500 dark:text-zinc-400">
             {description}
           </p>
         )}
       </div>
 
-      {/* Right: action group */}
       <div className="flex flex-wrap items-center gap-2">
-        {/* View / Edit segmented control */}
         <div
           role="group"
           aria-label="Mode"
@@ -166,7 +173,6 @@ export function DashboardTopBar({
           </button>
         </div>
 
-        {/* Density */}
         <div
           role="group"
           aria-label="Density"
@@ -264,7 +270,7 @@ function DensityButton({
         "inline-flex items-center rounded px-2 py-1 transition-colors",
         active
           ? "bg-background text-foreground shadow-sm"
-          : "text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-100",
+          : "text-zinc-500 hover:text-zinc-400 dark:text-zinc-400 dark:hover:text-zinc-100",
       )}
     >
       {children}

--- a/packages/web/src/ui/components/dashboards/grid-constants.ts
+++ b/packages/web/src/ui/components/dashboards/grid-constants.ts
@@ -1,0 +1,18 @@
+/**
+ * Dashboard tile-grid constants. Mirrors the Anthropic design exactly so
+ * stored layout coordinates round-trip between sessions and devices.
+ */
+
+export const COLS = 24;
+/** Row height in CSS pixels — also fed into `--dash-row-h` for the editing guides. */
+export const ROW_H = 40;
+/** Inner gap between tiles in pixels (applied as half-gap padding on each side). */
+export const GAP = 10;
+
+/** Minimum tile dimensions in grid units. Below this, charts compress to nothing. */
+export const MIN_W = 3;
+export const MIN_H = 4;
+
+/** Default placement for a freshly added tile in an empty area. */
+export const DEFAULT_TILE_W = 12;
+export const DEFAULT_TILE_H = 10;

--- a/packages/web/src/ui/components/dashboards/grid-constants.ts
+++ b/packages/web/src/ui/components/dashboards/grid-constants.ts
@@ -1,8 +1,13 @@
-import { DASHBOARD_GRID } from "@/ui/lib/types";
+/**
+ * Web-side grid constants. Must mirror `DASHBOARD_GRID` in
+ * `packages/api/src/lib/dashboard-types.ts` (the Zod schema there gates persisted
+ * layouts). They aren't in `@useatlas/types` because that would require an npm
+ * publish + template ref bump for every change.
+ */
 
-export const COLS = DASHBOARD_GRID.COLS;
-export const MIN_W = DASHBOARD_GRID.MIN_W;
-export const MIN_H = DASHBOARD_GRID.MIN_H;
+export const COLS = 24;
+export const MIN_W = 3;
+export const MIN_H = 4;
 
 export const ROW_H = 40;
 export const GAP = 10;

--- a/packages/web/src/ui/components/dashboards/grid-constants.ts
+++ b/packages/web/src/ui/components/dashboards/grid-constants.ts
@@ -1,18 +1,13 @@
-/**
- * Dashboard tile-grid constants. Mirrors the Anthropic design exactly so
- * stored layout coordinates round-trip between sessions and devices.
- */
+import { DASHBOARD_GRID } from "@/ui/lib/types";
 
-export const COLS = 24;
-/** Row height in CSS pixels — also fed into `--dash-row-h` for the editing guides. */
+export const COLS = DASHBOARD_GRID.COLS;
+export const MIN_W = DASHBOARD_GRID.MIN_W;
+export const MIN_H = DASHBOARD_GRID.MIN_H;
+
 export const ROW_H = 40;
-/** Inner gap between tiles in pixels (applied as half-gap padding on each side). */
 export const GAP = 10;
 
-/** Minimum tile dimensions in grid units. Below this, charts compress to nothing. */
-export const MIN_W = 3;
-export const MIN_H = 4;
-
-/** Default placement for a freshly added tile in an empty area. */
 export const DEFAULT_TILE_W = 12;
 export const DEFAULT_TILE_H = 10;
+
+export type Density = "compact" | "comfortable" | "spacious";

--- a/packages/web/src/ui/lib/types.ts
+++ b/packages/web/src/ui/lib/types.ts
@@ -152,6 +152,7 @@ export type {
 export type {
   Dashboard,
   DashboardCard,
+  DashboardCardLayout,
   DashboardWithCards,
   DashboardChartConfig,
   DashboardSuggestion,

--- a/packages/web/src/ui/lib/types.ts
+++ b/packages/web/src/ui/lib/types.ts
@@ -158,6 +158,7 @@ export type {
   DashboardSuggestion,
   ChartType,
 } from "@useatlas/types";
+export { DASHBOARD_GRID } from "@useatlas/types";
 export { CHART_TYPES } from "@useatlas/types";
 export { DOMAIN_STATUSES, CERTIFICATE_STATUSES } from "@useatlas/types";
 export { BACKUP_STATUSES } from "@useatlas/types";

--- a/packages/web/src/ui/lib/types.ts
+++ b/packages/web/src/ui/lib/types.ts
@@ -158,7 +158,6 @@ export type {
   DashboardSuggestion,
   ChartType,
 } from "@useatlas/types";
-export { DASHBOARD_GRID } from "@useatlas/types";
 export { CHART_TYPES } from "@useatlas/types";
 export { DOMAIN_STATUSES, CERTIFICATE_STATUSES } from "@useatlas/types";
 export { BACKUP_STATUSES } from "@useatlas/types";


### PR DESCRIPTION
Closes #1867. Pivot from list-page critique to building the new dashboard detail surface from the Claude Design handoff (`Dashboard.html`). Critique passes on this and the list (#1866) come in a follow-up session.

## Summary

- Replaces the single-column `Sortable` on `/dashboards/[id]` with a **freeform 24-col tile grid** (drag, resize, fullscreen, view/edit modes).
- Persists per-tile layout `{x, y, w, h}` in a new `layout` JSONB column on `dashboard_cards` (#0041 migration).
- Cards predating the migration auto-place in a 2-col waterfall on first render — the moment a tile is dragged or resized, the layout commits.
- Sticky topbar wraps Atlas's existing actions (Refresh, Suggest cards, Share, Delete, refresh schedule) into one row with View/Edit + density toggles.
- AI Suggest cards keeps working unchanged — accepted suggestions land at the bottom of the canvas with a default layout.
- Keyboard: `E` toggles edit mode, `Esc` exits.

## Scope notes

Out of scope (ported from the design but not implemented):
- **Left sidebar** with Pinned / Recent / brand. Atlas uses a single `NavBar`; bolting a sidebar onto only the detail page would create chrome inconsistency. Defer.
- **Cross-dashboard `DashTabs`**. Conflicts with the current `/dashboards` list ↔ `/dashboards/[id]` model. Defer.
- **Tile library drawer**. Atlas's add-card flow is "from chat result" — wiring a saved-queries drawer is a separate feature. Defer.
- **Date range picker / Tweaks panel**. Range picker doesn't apply to Atlas's per-card SQL model; Tweaks panel UX is a power-user perm. Defer.
- **List-page critique (#1866)** and **detail critique pass**. Per the user's pivot — build first, critique afterwards.

## Surface area

- `packages/api/src/lib/db/migrations/0041_dashboard_card_layout.sql` — `ALTER TABLE dashboard_cards ADD COLUMN IF NOT EXISTS layout JSONB`.
- `packages/api/src/lib/db/schema.ts`, `lib/dashboards.ts`, `lib/dashboard-types.ts` — read/write `layout`, with malformed-JSON guard logged via `log.warn`.
- `packages/api/src/api/routes/dashboards.ts` — `CardLayoutSchema` (Zod bounds: `x ∈ [0,23]`, `w ∈ [3,24]`, `h ∈ [4,200]`); `AddCardSchema` and `UpdateCardSchema` accept it.
- `packages/types/src/dashboard.ts` — new `DashboardCardLayout` type, added to `DashboardCard`.
- `packages/web/src/ui/components/dashboards/` — new component group: `DashboardGrid` (drag/resize math, drop ghost, faint edit-mode grid lines), `DashboardTile` (head + chart/table switcher + resize handles), `DashboardTopBar`, plus `auto-layout.ts` (waterfall + collision-aware) and `grid-constants.ts`.
- `packages/web/src/app/globals.css` — scoped grid styles (faint edit-mode lines, drag-ghost, resize handles, density variants).
- `packages/web/src/app/dashboards/[id]/page.tsx` — rewritten around `DashboardGrid`, with optimistic-layout state and `E`/`Esc` keybinds.

## Test plan

- [ ] Boot `bun run dev`, visit `/dashboards/[id]` for an existing dashboard — pre-existing cards should auto-place in a 2-col waterfall, and pressing `E` should reveal grid lines + drag handles.
- [ ] Drag a tile → release → confirm layout persists across page reload (fetch from `/api/v1/dashboards/[id]` returns the new `layout`).
- [ ] Resize a tile from the SE corner → release → confirm `w`/`h` persist.
- [ ] Fullscreen a tile → confirm it expands to viewport, exits cleanly.
- [ ] Empty dashboard → "An empty canvas" state with a CTA back to chat.
- [ ] Suggest cards → accept one → verify the new tile lands below existing rows.
- [ ] `bun run --cwd /home/msywu/oss/atlas/ide type` (passes locally — full `lint + type + test + syncpack + template + openapi` clean).
- [ ] `bun run --filter '@atlas/web' test` (90 files, 0 failures).
- [ ] `cd packages/api && bun run scripts/test-isolated.ts --affected` (44 files, 0 failures).