### PR TITLE
fix(web): prevent React #185 (infinite render loop) on dashboard drag

### DIFF
--- a/packages/web/src/app/dashboards/[id]/page.tsx
+++ b/packages/web/src/app/dashboards/[id]/page.tsx
@@ -76,20 +76,26 @@ export default function DashboardViewPage() {
       if (card.layout) settled[card.id] = card.layout;
     }
     setOptimisticLayouts((prev) => {
-      const remaining: Record<string, DashboardCardLayout> = {};
+      // Walk `prev` and decide which optimistic entries are still ahead of the
+      // server. Crucially: if nothing changed, return `prev` by reference so
+      // React's Object.is short-circuits the state update — without this guard
+      // every refetch produces a new `{}` ref and during a multi-drag session
+      // the effect → setState → refetch → effect chain can cascade into
+      // "Maximum update depth exceeded" (#185).
+      let changed = false;
+      const next: Record<string, DashboardCardLayout> = {};
       for (const [cardId, optimistic] of Object.entries(prev)) {
-        const next = settled[cardId];
-        if (
-          !next
-          || next.x !== optimistic.x
-          || next.y !== optimistic.y
-          || next.w !== optimistic.w
-          || next.h !== optimistic.h
-        ) {
-          remaining[cardId] = optimistic;
-        }
+        const server = settled[cardId];
+        const stillAhead =
+          !server
+          || server.x !== optimistic.x
+          || server.y !== optimistic.y
+          || server.w !== optimistic.w
+          || server.h !== optimistic.h;
+        if (stillAhead) next[cardId] = optimistic;
+        else changed = true;
       }
-      return remaining;
+      return changed ? next : prev;
     });
   }, [dashboard]);
 


### PR DESCRIPTION
**Closes:** prod regression observed after #1896 merged — visiting any dashboard, hitting Edit, and starting to drag a tile throws \`Minified React error #185\` (Maximum update depth exceeded).

## Root cause

\`/dashboards/[id]/page.tsx\` keeps an \`optimisticLayouts\` map for in-flight drag/resize updates and trims settled entries in a \`useEffect\` keyed on \`[dashboard]\`. The updater always returned a freshly-allocated \`{}\` even when nothing had actually settled — so React's \`Object.is\` check on the new state always reported a change, and the cascade became:

\`\`\`
drag → setOptimisticLayouts → PATCH → refetch (new dashboard ref) →
  effect runs → setOptimisticLayouts({}) → re-render →
  effect runs again (new dashboard ref still in flight) → … → React #185
\`\`\`

In dev with one slow drag the chain settles after a round trip. In production with multiple rapid drags + concurrent PATCH refetches it cascades past React's safety threshold.

## Fix

Return \`prev\` by reference when nothing settled. React's state-update bail-out then short-circuits the cascade. No behavior change on the happy path; the optimistic entry still drops the moment the server reflects it.

\`\`\`diff
 setOptimisticLayouts((prev) => {
-  const remaining = {};
+  let changed = false;
+  const next = {};
   for (...) {
-    if (!server || !equal) remaining[id] = optimistic;
+    if (!server || !equal) next[id] = optimistic;
+    else changed = true;
   }
-  return remaining;
+  return changed ? next : prev;
 });
\`\`\`

## CI

- \`bun test src/ui/components/dashboards/__tests__/ src/app/dashboards/__tests__/\` — 48/48 pass
- \`bun x eslint\` on the changed file — 0 issues