### PR TITLE
polish(web): tooltip the dashboard switcher chevron for discoverability

### DIFF
--- a/packages/web/src/ui/components/dashboards/dashboard-switcher.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-switcher.tsx
@@ -11,6 +11,12 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { friendlyError } from "@/ui/lib/fetch-error";
 import { cn } from "@/lib/utils";
@@ -37,15 +43,24 @@ export function DashboardSwitcher({ currentId }: DashboardSwitcherProps) {
   return (
     <>
       <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button
-            type="button"
-            aria-label="Switch dashboard"
-            className="-ml-1 inline-flex size-7 items-center justify-center rounded-md text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
-          >
-            <ChevronDown className="size-4" aria-hidden="true" />
-          </button>
-        </DropdownMenuTrigger>
+        <TooltipProvider delayDuration={400}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="Switch dashboard"
+                  className="-ml-1 inline-flex size-7 items-center justify-center rounded-md text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+                >
+                  <ChevronDown className="size-4" aria-hidden="true" />
+                </button>
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" sideOffset={4}>
+              Switch dashboard
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
         <DropdownMenuContent
           align="start"
           className="w-72 max-w-[90vw] p-1"


### PR DESCRIPTION
Easy follow-up to #1896. The dashboard switcher's only sighted affordance is the chevron icon next to the title — first-time users have no signal that it's interactive (the title click enters edit mode, not the switcher). Wrap the trigger in a shadcn Tooltip so a 400ms hover surfaces "Switch dashboard". Screen-reader users were already covered by the existing \`aria-label\`.

\`\`\`diff
+<TooltipProvider delayDuration={400}>
+  <Tooltip>
+    <TooltipTrigger asChild>
       <DropdownMenuTrigger asChild>
         <button aria-label="Switch dashboard" ...><ChevronDown /></button>
       </DropdownMenuTrigger>
+    </TooltipTrigger>
+    <TooltipContent>Switch dashboard</TooltipContent>
+  </Tooltip>
+</TooltipProvider>
\`\`\`

## CI
- 17 switcher + topbar tests pass.
- Lint clean.