### PR TITLE
feat(web): #1868 — shared chat surface design pass (1.3.0 Bucket 4)

### DIFF
--- a/.claude/research/1868-shared-chat-design-pass/critique.md
+++ b/.claude/research/1868-shared-chat-design-pass/critique.md
@@ -1,0 +1,93 @@
+# 1868 Shared Chat Surface — Critique
+
+Critique of `/shared/[token]` (`packages/web/src/app/shared/[token]/page.tsx`, 175 LOC) and its OG image (`opengraph-image.tsx`). Code-only critique this round — full live screenshots require seed + dev-server + a real share token, which wasn't set up this session. The visual changes below are well-bounded enough to land without screenshot diffs, but a manual Playwright pass before merge is recommended (test plan in the PR body).
+
+Baseline: branch `1868-shared-chat-design-pass` cut from `713d46df`.
+
+## Headline scores (0–10, higher = better)
+
+| Axis | Score | Note |
+|---|---|---|
+| Visual hierarchy | **3** | Header reads "Atlas · Shared conversation · date" then optional title. Each message is `circle avatar (U/A)` + muted-color role label *above* the content. Hierarchy inverted: the metadata is louder than the content. |
+| Information architecture | **3** | Tool calls completely filtered out — viewer sees only user/assistant text. The substance of an Atlas analysis (the SQL the agent ran, the result table) is invisible. No affordance to "view full conversation" surfaces this gap. |
+| Brand coherence | **2** | OG image uses an indigo gradient (`#3b82f6 → #6366f1`) — not Atlas teal (`oklch(0.58 0.185 167.71)`). Every share-link Slack/Twitter/Linear preview embeds *blue Atlas* in the public eye. Stale from before the teal retune. |
+| External-stakeholder polish | **2** | No "Powered by Atlas" attribution (the embed surface has it; the canonical share doesn't). No conversion CTA — viewer has no path to try Atlas themselves. |
+| Print | **0** | No `@media print` rules at all. People print these. Avatars + footer + dark backgrounds will all carry into the PDF. |
+| Mobile | **6** | `mx-auto max-w-3xl px-4 py-8` is already responsive-by-default. No specific mobile bugs in code review; needs a Playwright pass to confirm. |
+| Read-only cue | **3** | Header says "Shared conversation" but no chip / banner / framing tells the viewer "you can't reply here". |
+
+Overall: **2.7 / 10**. The page is functional but plain — barely a step above a markdown blob, with stale brand colors visible to every external viewer.
+
+## Top P0 / P1 findings
+
+### P0 — OG image renders Atlas in the wrong brand color
+`opengraph-image.tsx:37` — the avatar badge uses `linear-gradient(135deg, #3b82f6, #6366f1)` (blue → indigo). Atlas brand is teal. Every Slack / Twitter / LinkedIn / Linear preview that unfurls a share link shows *blue Atlas*. Stale from before `--primary` was retuned to teal in `globals.css`.
+
+**Fix:** swap to teal — `oklch(0.58 0.185 167.71)` ≈ `#0d9488` (Tailwind teal-600) → `#0f766e` (teal-700) for the gradient. Match the rest of the product.
+
+### P0 — No "Powered by Atlas" attribution
+`/shared/[token]/embed/page.tsx:55-65` has it. `/shared/[token]/page.tsx` does not. This is the canonical share surface that external stakeholders see — it should have at least the same attribution density as the embed. The omission is also a missed conversion: viewers see an Atlas-rendered analysis and have no link to try Atlas themselves.
+
+**Fix:** add a subtle bottom footer mirroring the embed pattern: "Powered by Atlas" + outbound link to `useatlas.dev`. Pair it with a "Try Atlas free →" CTA so the attribution doubles as conversion.
+
+### P1 — Assistant text renders as `whitespace-pre-wrap`, not markdown
+`page.tsx:166` — the agent's responses contain markdown (bullets, code, headings, bold, tables). Right now they all display as raw text — `**bold**` shows literal asterisks, lists render as `- one\n- two` strings, fenced code blocks lose their styling. The codebase already has a battle-tested `<Markdown>` component at `packages/web/src/ui/components/chat/markdown.tsx` that handles GFM + lazy-loaded syntax highlighting.
+
+**Fix:** render assistant messages with `<Markdown>`. Keep user messages as plain text (asterisks the user typed should remain literal).
+
+### P1 — No read-only state cue
+The header text "Shared conversation" is metadata, not a state cue. No chip / banner / framing makes it clear the viewer can't reply. Adjacent: a viewer landing here from Slack may not even register it's a *snapshot* and not the live conversation.
+
+**Fix:** add a small "Read-only" chip in the header alongside the date, plus reframe the metadata line to make snapshot semantics obvious ("Snapshot · {date}" or "Captured {date}").
+
+### P1 — No print stylesheet
+Issue scope explicitly calls for it. People print analysis snapshots. Today the page would print with whatever ambient theme is active — including potentially dark backgrounds — and would carry the (non-existent yet — see P0) footer / CTA chrome onto the page.
+
+**Fix:** Tailwind `print:` variants — hide footer / CTA in print, force black-on-white via `print:bg-white print:text-black`, `break-inside: avoid` on each message block so a long message doesn't split mid-sentence across pages, drop the page padding to `print:p-0` so the print engine controls margins.
+
+### P1 — Tool calls completely filtered from the public view
+`page.tsx:121-123` — `visibleMessages = convo.messages.filter((m) => m.role === "user" || m.role === "assistant")`. The substance of an Atlas analysis is the SQL the agent ran + the result. A shared conversation that included a multi-step exploration with a final chart is reduced to "the agent's plain prose summary." Without a hint that there *was* analysis, the page understates what Atlas does.
+
+**Fix (light, in scope):** count filtered tool/system messages; if any, render a "+ N analysis steps run — view full conversation in Atlas" footnote near the bottom that links to `/c/{conversationId}` (which prompts sign-in if the viewer isn't logged in). Doesn't expose tool detail; just signals depth.
+
+**Fix (deep, OUT of scope):** render tool calls inline. Defer to a follow-up issue if requested.
+
+## P2 / polish
+
+### P2 — Avatar circles "U" / "A" read as placeholder amateur cue
+`page.tsx:153-160` — single-letter avatars in colored circles are jarring next to the rest of the product (which uses no avatars in chat surfaces). Worse: the role label appears *below* the avatar in muted color, hierarchy-inverted.
+
+**Fix:** drop avatars entirely. Use a small uppercase eyebrow label ("USER" / "ATLAS") above each message, primary-tinted for ATLAS. Content becomes the hero.
+
+### P2 — Stale `text-zinc-500` / `text-zinc-400` muted colors
+Pre-1.2.x palette. Recently we've been bumping to `text-zinc-600` for AA contrast on near-white backgrounds (see PR #1901, PR #1894). `page.tsx:101, 128, 163` use the old palette.
+
+**Fix:** bump to `text-zinc-600 dark:text-zinc-400` where they sit on the page background.
+
+### P2 — Date format fixed to "Apr 26, 2026" — could be relative for recency
+`page.tsx:135-141`. For shares opened the same day/week, "Today" / "2 days ago" reads cleaner than the absolute date. Out of essential scope; nice-to-have.
+
+## Out of scope (deferred)
+
+### Workspace branding override
+Issue scope mentions "workspace branding override + Atlas attribution". The workspace branding endpoint (`/api/v1/branding`, see `packages/api/src/api/routes/public-branding.ts:70-91`) resolves branding from the *session*, returns null branding for unauthenticated visitors. Public share viewers have no session, so they always get default Atlas branding regardless of what the workspace owner configured.
+
+To support this, the public conversations endpoint (`/api/public/conversations/:token`) would need to return the owning workspace's branding alongside the conversation. That's a backend change, which the issue explicitly puts out of scope for this UI/UX pass.
+
+**Action:** call out as deferred in the PR body. File a follow-up backend issue if the user wants to ship workspace branding on shared chat in a later release.
+
+## Acceptance check vs #1868
+
+- [x] `/critique` run with findings captured (this file)
+- [ ] PR with before/after screenshots — partial, see PR body for the manual test plan
+- [ ] Lighthouse pass — the page is server-rendered with no agent stream and `react-markdown` is the only client-side cost; Lighthouse Performance ≥ 95 should hold but needs verification post-merge
+
+## Plan applied (next: edits to `page.tsx` and `opengraph-image.tsx`)
+
+1. OG image: indigo → teal (`#0d9488` / `#0f766e`).
+2. Header: drop the wordmark/middot/snapshot copy mishmash → reframe as "Shared from Atlas · Read-only · {date}". Add "Try Atlas free →" CTA in header right.
+3. Messages: drop circle avatars; uppercase eyebrow label + content. Render assistant text with `<Markdown>`. Bump muted colors. Add `break-inside: avoid` for print.
+4. Hidden-tool-runs hint: if tool calls were filtered, show a single "View N analysis steps in Atlas" link below the messages.
+5. Footer: "Powered by Atlas" + outbound link to `useatlas.dev`, hidden on print.
+6. Print: `print:bg-white print:text-black print:p-0`, hide footer + CTA via `print:hidden`, page-break-avoid on message blocks.
+7. Empty / no-text-content: skip rendering empty messages instead of leaving blank flex rows.

--- a/packages/web/src/app/shared/[token]/opengraph-image.tsx
+++ b/packages/web/src/app/shared/[token]/opengraph-image.tsx
@@ -34,7 +34,7 @@ export default function OgImage() {
               width: "56px",
               height: "56px",
               borderRadius: "14px",
-              background: "linear-gradient(135deg, #3b82f6, #6366f1)",
+              background: "linear-gradient(135deg, #0d9488, #0f766e)",
               display: "flex",
               alignItems: "center",
               justifyContent: "center",

--- a/packages/web/src/app/shared/[token]/page.tsx
+++ b/packages/web/src/app/shared/[token]/page.tsx
@@ -120,13 +120,11 @@ export default async function SharedConversationPage({
   }
 
   const convo = result.data;
-  const visibleMessages = convo.messages.filter(
-    (m) => m.role === "user" || m.role === "assistant",
-  );
-  const hiddenStepCount = convo.messages.length - visibleMessages.length;
-  const renderedMessages = visibleMessages
+  const renderedMessages = convo.messages
+    .filter((m) => m.role === "user" || m.role === "assistant")
     .map((msg) => ({ msg, text: extractTextContent(msg.content) }))
     .filter(({ text }) => text.trim().length > 0);
+  const hiddenStepCount = convo.messages.length - renderedMessages.length;
 
   const formattedDate = new Date(convo.createdAt).toLocaleDateString(undefined, {
     year: "numeric",

--- a/packages/web/src/app/shared/[token]/page.tsx
+++ b/packages/web/src/app/shared/[token]/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { ArrowUpRight } from "lucide-react";
 import { buttonVariants } from "@/components/ui/button";
+import { Markdown } from "@/ui/components/chat/markdown";
 import {
   fetchSharedConversation,
   extractTextContent,
@@ -15,7 +17,7 @@ export async function generateMetadata({
   const { token } = await params;
   const result = await fetchSharedConversation(token);
 
-  const fallbackTitle = "Atlas \u2014 Shared Conversation";
+  const fallbackTitle = "Atlas — Shared Conversation";
   const fallbackDescription =
     "A shared conversation from Atlas, the text-to-SQL data analyst.";
 
@@ -93,13 +95,13 @@ export default async function SharedConversationPage({
           ? "Connection failed"
           : "Unable to load conversation";
     return (
-      <div className="flex min-h-screen items-center justify-center">
+      <div className="flex min-h-screen items-center justify-center px-4">
         <div className="text-center">
           <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-100">
             {heading}
           </h1>
-          <p className="mt-2 text-zinc-500 dark:text-zinc-400">{message}</p>
-          <div className="mt-4 flex items-center justify-center gap-3">
+          <p className="mt-2 text-zinc-600 dark:text-zinc-400">{message}</p>
+          <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
             <Link href="/" className={buttonVariants()}>
               Go to Atlas
             </Link>
@@ -121,55 +123,110 @@ export default async function SharedConversationPage({
   const visibleMessages = convo.messages.filter(
     (m) => m.role === "user" || m.role === "assistant",
   );
+  const hiddenStepCount = convo.messages.length - visibleMessages.length;
+  const renderedMessages = visibleMessages
+    .map((msg) => ({ msg, text: extractTextContent(msg.content) }))
+    .filter(({ text }) => text.trim().length > 0);
+
+  const formattedDate = new Date(convo.createdAt).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
 
   return (
-    <div className="mx-auto max-w-3xl px-4 py-8">
-      <header className="mb-6 border-b border-zinc-200 pb-4 dark:border-zinc-800">
-        <div className="flex items-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
-          <span className="font-medium text-zinc-900 dark:text-zinc-100">
-            Atlas
-          </span>
-          <span aria-hidden="true">&middot;</span>
-          <span>Shared conversation</span>
-          <span aria-hidden="true">&middot;</span>
-          <time dateTime={convo.createdAt}>
-            {new Date(convo.createdAt).toLocaleDateString(undefined, {
-              year: "numeric",
-              month: "short",
-              day: "numeric",
-            })}
-          </time>
-        </div>
-        {convo.title && (
-          <h1 className="mt-2 text-xl font-semibold text-zinc-900 dark:text-zinc-100">
-            {convo.title}
-          </h1>
-        )}
-      </header>
-
-      <div className="space-y-6">
-        {visibleMessages.map((msg, i) => (
-          <div key={i} className="flex gap-4">
-            <div
-              className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-medium ${
-                msg.role === "user"
-                  ? "bg-primary/15 text-primary dark:bg-primary/20 dark:text-primary"
-                  : "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
-              }`}
+    <div className="flex min-h-screen flex-col bg-white dark:bg-zinc-950 print:bg-white print:text-black">
+      <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-8 print:p-0">
+        <header className="mb-6 border-b border-zinc-200 pb-4 dark:border-zinc-800 print:border-zinc-300">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex flex-wrap items-center gap-2 text-sm text-zinc-600 dark:text-zinc-400">
+              <span className="font-medium text-zinc-900 dark:text-zinc-100">
+                Atlas
+              </span>
+              <span aria-hidden="true">&middot;</span>
+              <span
+                className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 print:bg-transparent print:px-0"
+                aria-label="This is a read-only snapshot"
+              >
+                Read-only
+              </span>
+              <span aria-hidden="true">&middot;</span>
+              <time dateTime={convo.createdAt}>Captured {formattedDate}</time>
+            </div>
+            <Link
+              href="/signup"
+              className="inline-flex items-center gap-1 text-sm font-medium text-primary transition-colors hover:text-primary/80 print:hidden"
             >
-              {msg.role === "user" ? "U" : "A"}
-            </div>
-            <div className="min-w-0 flex-1 pt-1">
-              <p className="text-sm font-medium text-zinc-500 dark:text-zinc-400">
-                {msg.role === "user" ? "User" : "Atlas"}
-              </p>
-              <div className="mt-1 whitespace-pre-wrap text-zinc-900 dark:text-zinc-100">
-                {extractTextContent(msg.content)}
-              </div>
-            </div>
+              Try Atlas free
+              <ArrowUpRight className="h-3.5 w-3.5" />
+            </Link>
           </div>
-        ))}
-      </div>
+          {convo.title && (
+            <h1 className="mt-3 text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+              {convo.title}
+            </h1>
+          )}
+        </header>
+
+        {renderedMessages.length === 0 ? (
+          <p className="text-sm text-zinc-600 dark:text-zinc-400">
+            This conversation has no readable content.
+          </p>
+        ) : (
+          <div className="space-y-6">
+            {renderedMessages.map(({ msg, text }, i) => {
+              const isUser = msg.role === "user";
+              return (
+                <article
+                  key={i}
+                  className="space-y-1.5 print:break-inside-avoid"
+                  aria-label={isUser ? "User message" : "Atlas response"}
+                >
+                  <p
+                    className={`text-[10px] font-semibold uppercase tracking-wider ${
+                      isUser
+                        ? "text-zinc-500 dark:text-zinc-400"
+                        : "text-primary"
+                    }`}
+                  >
+                    {isUser ? "User" : "Atlas"}
+                  </p>
+                  {isUser ? (
+                    <p className="whitespace-pre-wrap text-zinc-900 dark:text-zinc-100">
+                      {text}
+                    </p>
+                  ) : (
+                    <div className="text-zinc-900 dark:text-zinc-100">
+                      <Markdown content={text} />
+                    </div>
+                  )}
+                </article>
+              );
+            })}
+          </div>
+        )}
+
+        {hiddenStepCount > 0 && (
+          <p className="mt-8 border-t border-zinc-200 pt-4 text-xs text-zinc-600 dark:border-zinc-800 dark:text-zinc-400 print:hidden">
+            {hiddenStepCount} analysis step{hiddenStepCount === 1 ? "" : "s"} not shown.{" "}
+            <Link href="/signup" className="text-primary hover:underline">
+              View the full conversation in Atlas
+              <ArrowUpRight className="ml-0.5 inline h-3 w-3" aria-hidden="true" />
+            </Link>
+          </p>
+        )}
+      </main>
+
+      <footer className="border-t border-zinc-200 px-4 py-4 text-center dark:border-zinc-800 print:hidden">
+        <a
+          href="https://www.useatlas.dev"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-zinc-500 transition-colors hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200"
+        >
+          Powered by Atlas
+        </a>
+      </footer>
     </div>
   );
 }


### PR DESCRIPTION
Closes #1868.

First Bucket 4 PR — public views are the highest-leverage 1.3.0 target since they're what external stakeholders actually see. `/shared/[token]` is the canonical share URL.

## What changed

`packages/web/src/app/shared/[token]/page.tsx` (rewrite, ~50 LOC delta) and `opengraph-image.tsx` (1-line color fix). Pure UI/UX, no backend changes.

### Brand coherence
- **OG image**: indigo gradient (`#3b82f6 → #6366f1`) → teal (`#0d9488 → #0f766e`) so Slack / Twitter / Linear unfurls don't embed *blue Atlas* in the public eye. Stale from before the `--primary` teal retune.
- **Header CTA**: added "Try Atlas free →" link in header right — every viewer of a colleague's shared analysis is a potential signup.

### Information density
- **Markdown rendering**: assistant messages now render through the existing `<Markdown>` component (was `whitespace-pre-wrap`, so `**bold**` showed literal asterisks and fenced code blocks lost styling). User messages stay plain text.
- **Hidden-step hint**: when tool/system messages are filtered from the public view (which is most conversations with real analysis), show `+ N analysis steps not shown — view in Atlas →` so the surface doesn't understate what the agent did.
- **Empty messages**: extracted-text length check filters out no-content messages instead of leaving blank flex rows.

### Hierarchy
- Dropped the U / A circle avatars (placeholder-cue, hierarchy-inverted with the role label sitting muted *below* them). Replaced with uppercase eyebrow labels (`USER` / `ATLAS`), Atlas-tinted in primary teal. Content becomes the hero.
- Restructured around `<article aria-label=\"…\">` for each message so each turn is a proper landmark for AT.

### Read-only state cue
- Header reframed from `Atlas · Shared conversation · {date}` to `Atlas · [Read-only chip] · Captured {date}`. Viewer immediately knows this is a snapshot, not the live conversation.

### Print
- `print:bg-white print:text-black print:p-0` on the page shell.
- `print:break-inside-avoid` on each message so a long response doesn't split mid-sentence.
- Header CTA + footer attribution + hidden-step hint all `print:hidden` — the printed page is just the conversation.

### Attribution
- Bottom footer with `Powered by Atlas` → `useatlas.dev` outbound, mirroring the embed surface pattern (`/shared/[token]/embed`). Hidden in print.

### Polish
- Bumped muted text from `zinc-400/500` to `zinc-600/400` for AA contrast on near-white backgrounds (matches PR #1894 / #1901).
- Wrapped error-state CTAs in `flex-wrap` so the two buttons don't push off-screen at narrow viewports.

## Out of scope (deferred)

**Workspace branding override.** The issue's scope mentions it, but `/api/v1/branding` is session-scoped and public viewers have no session — they always get default Atlas branding regardless of what the workspace owner configured. Supporting this needs a backend change (returning workspace branding alongside the public conversation payload), which the issue explicitly puts out of scope. Worth a follow-up backend issue if the user wants workspace-branded shares.

## Testing

- `bun run lint` ✓
- `bun run type` ✓
- `bun run test` ✓ — full suite green: api 307, cli 19, web 95 (incl. shared-page-metadata 14, shared-embed 27, report-view 14), ee 25, react 9, all plugins
- `bun x syncpack lint` ✓
- `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` ✓
- `bash scripts/check-railway-watch.sh` ✓
- `cd packages/api && bun run scripts/test-isolated.ts --affected` — no api tests touch web

## Manual verification (recommended before merge)

Live screenshots weren't captured this session — needs containers + seed + a real share token. Quick sanity:

1. `bun run db:up && bun run dev`
2. Sign in, create a conversation, click Share
3. Open the share URL in an incognito window
4. Verify: header reads `Atlas · Read-only · Captured {date}`; `Try Atlas free →` CTA visible top-right; assistant text renders markdown; `Powered by Atlas` footer at bottom
5. Print preview (Cmd-P): footer + CTA hidden, content B&W, messages don't split mid-sentence
6. Mobile (375px): header CTAs wrap cleanly, no horizontal scroll
7. Slack-paste the share URL: OG card shows teal \"A\" badge, not indigo
8. Lighthouse Performance ≥ 95 (page is server-rendered with one client component for markdown)

## Critique notes

`.claude/research/1868-shared-chat-design-pass/critique.md` has the full P0/P1/P2 breakdown with axis scores. Code-only critique this round (no live screenshots); applied the full plan listed there.

## Test plan
- [ ] Visual: load `/shared/<token>` desktop 1440 — header reads `Atlas · Read-only · Captured {date}`, `Try Atlas free →` visible, assistant text renders markdown (not raw `**`), `Powered by Atlas` footer present
- [ ] Mobile 375px: header items wrap cleanly, no horizontal scroll, CTA still visible
- [ ] Print preview: only the conversation prints, no chrome, messages don't split mid-sentence
- [ ] OG card: paste share URL into Slack/Twitter — teal badge, not indigo
- [ ] Filtered tool calls: a conversation with tool calls shows `+ N analysis steps not shown` hint linking to /signup
- [ ] Empty content: a conversation with no readable text shows the empty-state copy instead of blank flex rows
- [ ] Lighthouse Performance ≥ 95