### PR TITLE
fix(www): public-page audit cleanup — license, regions, retention, AUP, certifications

### DIFF
--- a/apps/www/src/app/aup/page.tsx
+++ b/apps/www/src/app/aup/page.tsx
@@ -1,0 +1,257 @@
+import type { Metadata } from "next";
+
+import { Footer } from "../../components/footer";
+import { LegalSection, LegalTOC, type LegalSectionData } from "../../components/legal";
+import { Nav } from "../../components/nav";
+import { TopGlow } from "../../components/shared";
+import { StickyNav } from "../../components/sticky-nav";
+
+export const metadata: Metadata = {
+  title: "Acceptable Use Policy — Atlas",
+  description:
+    "What you can't do with Atlas Cloud. Five prohibited categories up top, eight sections below — short, specific, and enforceable.",
+  openGraph: {
+    title: "Acceptable Use Policy — Atlas",
+    description:
+      "Atlas Cloud Acceptable Use Policy: prohibited uses, security-research carve-outs, customer-data responsibilities, and how violations are handled.",
+    url: "https://www.useatlas.dev/aup",
+    siteName: "Atlas",
+    type: "website",
+  },
+};
+
+interface ProhibitionCard {
+  mono: string;
+  label: string;
+  sub: string;
+}
+
+const PROHIBITIONS: ProhibitionCard[] = [
+  {
+    mono: "no_illegal",
+    label: "Don’t use Atlas to break the law",
+    sub: "Or to violate someone else’s rights. That includes IP, privacy, and export-control rules.",
+  },
+  {
+    mono: "no_abuse",
+    label: "Don’t abuse shared infrastructure",
+    sub: "No DDoS, no scraping the product, no rate-limit evasion, no degrading performance for other customers.",
+  },
+  {
+    mono: "no_unauth_probe",
+    label: "Don’t probe without permission",
+    sub: "Security testing is welcome — email security@useatlas.dev first. Unannounced probing is not.",
+  },
+  {
+    mono: "no_compete_on_ee",
+    label: "Don’t build a competing hosted product on /ee",
+    sub: "The commercial /ee directory is licensed for your use — not for relaunching as your own SaaS.",
+  },
+];
+
+const SECTIONS: LegalSectionData[] = [
+  {
+    id: "scope",
+    title: "Scope",
+    legal: [
+      'This Acceptable Use Policy ("AUP") sets out the activities prohibited on Atlas Cloud ("the Service") and on the public Atlas websites at useatlas.dev. It is part of the Terms of Service at useatlas.dev/terms and is incorporated by reference; capitalized terms not defined here have the meaning given in those Terms.',
+      "This AUP does not apply to the open-source Atlas distribution that you self-host. When you run Atlas in your own infrastructure under AGPL-3.0, your acceptable use is governed by the license, your own internal policies, and applicable law — Atlas DevHQ has no enforcement role.",
+      "If you discover a violation by another user, please report it to security@useatlas.dev with as much detail as you can share. We treat reports confidentially.",
+    ],
+    plain:
+      "Applies to Atlas Cloud and useatlas.dev. Doesn’t apply to self-hosted Atlas (your infra, your rules). Report violations to security@useatlas.dev.",
+  },
+  {
+    id: "prohibited",
+    title: "Prohibited Uses",
+    legal: [
+      "You agree not to use the Service to: (a) violate any applicable law, regulation, or court order, or any third party’s intellectual-property, privacy, publicity, or contract rights; (b) transmit, store, or generate malware, viruses, ransomware, exploits, command-and-control payloads, or any code intended to disable, surveil, or damage another system; (c) generate or distribute child sexual abuse material, content depicting non-consensual sexual conduct, or content that incites violence against a protected class; (d) conduct fraud, phishing, identity theft, or social-engineering campaigns against third parties; (e) circumvent export controls or sanctions, including by routing prompts on behalf of sanctioned persons or jurisdictions; (f) misrepresent the source of a query, prompt, or generated artifact in a way intended to deceive the recipient about its origin.",
+      "Atlas does not pre-screen Customer Data, prompts, or query results. Compliance with this Section is the Customer’s responsibility.",
+    ],
+    plain:
+      "No illegal activity. No malware. No CSAM or non-consensual sexual content. No fraud or phishing. No sanctions evasion. No misrepresenting AI-generated content as human-authored when it would deceive the recipient.",
+  },
+  {
+    id: "customer-data",
+    title: "Customer-Data Responsibilities",
+    legal: [
+      "You are responsible for ensuring you have the legal right to submit any Customer Data (including warehouse contents that surface in query results) to the Service. This includes obtaining any required consents, providing required notices, and honoring any applicable contractual restrictions.",
+      "Special categories of personal data under GDPR Art. 9 (e.g. health, biometric, sexual-orientation, political-opinion data) and protected health information under HIPAA may not be submitted to the Service unless Customer has notified Atlas in writing in advance and the parties have signed appropriate supplementary terms.",
+      "You may not submit data that is, to your knowledge, unlawful for you to disclose — for example, data covered by an active legal hold belonging to a third party, or trade secrets that you do not have authorization to share with a processor.",
+    ],
+    plain:
+      "You can only submit data you have the right to submit. No GDPR special-category data or HIPAA-protected health information without prior written agreement. No third-party data you’re not authorized to share.",
+  },
+  {
+    id: "security-research",
+    title: "Security Research & Testing",
+    legal: [
+      "Unauthorized security testing, vulnerability scanning, fuzzing, and probing of the Service is prohibited. This includes automated tooling pointed at app.useatlas.dev, api.useatlas.dev, the regional API endpoints, and any sub-domain of useatlas.dev.",
+      "Atlas welcomes coordinated security research. Email security@useatlas.dev with the scope of testing you want to conduct, the source IP ranges you’ll test from, and a window. We respond within five business days. Our published disclosure policy is at useatlas.dev/.well-known/security.txt (RFC 9116).",
+      "Findings reported in good faith under this Section, and within an authorized scope, will not be the basis of any legal action by Atlas. Atlas does not currently operate a paid bug-bounty program.",
+    ],
+    plain:
+      "Don’t probe us without asking first. Email security@useatlas.dev to coordinate testing — we’ll respond within 5 business days. Good-faith research within scope is safe-harbored. No paid bounty (yet).",
+  },
+  {
+    id: "competitive",
+    title: "Competitive Use of /ee",
+    legal: [
+      "Atlas’s open-source distribution is licensed under AGPL-3.0; the source-available commercial features in the `/ee` directory are licensed under the separate Atlas Commercial License at github.com/AtlasDevHQ/atlas/blob/main/ee/LICENSE.",
+      "You may not use the Service, or any code in the `/ee` directory of the Atlas repository, to develop, market, or operate a hosted product that substitutes for Atlas Cloud. Internal use, customer use, embedding via the SDK, and contribution back to upstream are not affected.",
+    ],
+    plain:
+      "You can use the Service for anything except building a competing hosted version of Atlas on top of our /ee features. Self-host all you want; just don’t resell it.",
+  },
+  {
+    id: "infrastructure",
+    title: "Infrastructure Abuse",
+    legal: [
+      "You may not: (a) intentionally or negligently exceed published rate limits in a way that degrades performance for other customers; (b) submit prompts or queries designed to consume resources without producing useful output (e.g. infinite-loop prompts, prompts crafted to maximize token usage without legitimate purpose); (c) operate the Service in a way that materially increases Atlas’s upstream model-provider costs without commensurate Customer use; (d) automate signups or trial accounts to evade plan limits.",
+      "Atlas applies rate limits and quotas to protect Service availability. Where automated enforcement is not sufficient, Atlas may contact Customer to discuss usage, and may suspend access in extreme cases as set out in Section 8.",
+    ],
+    plain:
+      "Don’t intentionally hammer the rate limits, run prompts designed to burn tokens, or chain free trials. Use it like the product it is.",
+  },
+  {
+    id: "responsibility",
+    title: "Responsibility for Users & Affiliates",
+    legal: [
+      "Customer is responsible for the actions of any user accessing the Service through Customer’s account, including employees, contractors, and any end users to whom Customer makes the Service available (for example, via the embeddable widget).",
+      "Customer must ensure that its users have agreed to terms at least as protective as these (the Terms of Service, this AUP, and the Privacy Policy) before granting them access.",
+    ],
+    plain:
+      "Anything done under your account is your responsibility, including by your end users if you embed Atlas in your own product.",
+  },
+  {
+    id: "enforcement",
+    title: "Enforcement",
+    legal: [
+      "If Atlas reasonably believes Customer has violated this AUP, Atlas may, in proportion to the violation: (a) issue a written warning and request remediation within a stated period; (b) restrict the affected feature or rate-limit the affected account; (c) suspend the account, in whole or in part, with notice where reasonably possible; (d) terminate the Agreement for cause under the Terms.",
+      "For violations that materially threaten the security or availability of the Service for other customers, or that involve illegal content, Atlas may suspend access immediately and without prior notice, and will provide notice as soon as practicable.",
+      "Suspension or termination for AUP violation is not subject to the SLA credit obligations at useatlas.dev/sla.",
+    ],
+    plain:
+      "Minor issues: warning + chance to fix. Serious issues (security, illegal content): immediate suspension. Repeat or material violations: termination for cause. SLA credits don’t apply when we suspend you for AUP violations.",
+  },
+  {
+    id: "changes",
+    title: "Changes",
+    legal: [
+      "Atlas may update this AUP. Material changes will be announced by email to account admins at least 30 days before taking effect, with the prior version archived and linked from this page.",
+    ],
+    plain:
+      "Material changes are announced to account admins by email at least 30 days before they take effect.",
+  },
+];
+
+export default function AupPage() {
+  return (
+    <div className="relative min-h-screen">
+      <a
+        href="#main"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-60 focus:rounded-md focus:bg-zinc-900 focus:px-3 focus:py-2 focus:font-mono focus:text-sm focus:text-zinc-100 focus:ring-2 focus:ring-brand"
+      >
+        Skip to content
+      </a>
+
+      <StickyNav />
+      <TopGlow />
+      <Nav currentPage="/aup" />
+
+      <main id="main" tabIndex={-1} className="focus:outline-none">
+        {/* Hero */}
+        <section className="mx-auto max-w-4xl px-6 pt-16 pb-10 text-center md:pt-24 md:pb-14">
+          <p className="animate-fade-in-up delay-100 mb-4 font-mono text-xs tracking-widest text-brand/80 uppercase">
+            // legal · aup
+          </p>
+          <h1 className="animate-fade-in-up delay-200 text-3xl font-semibold tracking-tight text-zinc-100 md:text-5xl">
+            Acceptable Use Policy.
+          </h1>
+          <p className="animate-fade-in-up delay-300 mx-auto mt-4 max-w-xl text-lg text-zinc-400">
+            What you can&rsquo;t do with Atlas Cloud. Specific, enforceable, and
+            short enough to read in one sitting.
+          </p>
+          <div className="animate-fade-in-up delay-400 mt-5 flex flex-wrap items-center justify-center gap-x-5 gap-y-1 font-mono text-[11px] tracking-wider text-zinc-400 uppercase">
+            <span>effective 2026-04-26</span>
+            <span aria-hidden="true">·</span>
+            <span>v1.0</span>
+            <span aria-hidden="true">·</span>
+            <span>questions: legal@useatlas.dev</span>
+          </div>
+        </section>
+
+        {/* Four prohibited categories */}
+        <section
+          aria-labelledby="four-prohibitions-heading"
+          className="mx-auto max-w-5xl px-6 pt-6 pb-4 md:pt-8"
+        >
+          <p
+            id="four-prohibitions-heading"
+            className="mb-3 font-mono text-xs tracking-widest text-brand/80 uppercase"
+          >
+            // four things to avoid
+          </p>
+          <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {PROHIBITIONS.map((p) => (
+              <li
+                key={p.mono}
+                className="rounded-xl border border-brand/30 bg-brand/4 p-5 md:p-6"
+              >
+                <p className="mb-3 font-mono text-[12px] tracking-wider text-brand">
+                  {p.mono}
+                </p>
+                <p className="mb-2 text-[15px] leading-snug font-semibold text-zinc-100">
+                  {p.label}
+                </p>
+                <p className="text-[12.5px] leading-relaxed text-zinc-400">
+                  {p.sub}
+                </p>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* Legal sections — TOC + dual-column body */}
+        <section className="mx-auto max-w-7xl px-6 py-12 md:py-16">
+          <div className="grid gap-12 lg:grid-cols-[220px_1fr] lg:gap-16">
+            <LegalTOC sections={SECTIONS} />
+            <article className="flex flex-col gap-12 md:gap-16">
+              {SECTIONS.map((section, i) => (
+                <LegalSection key={section.id} section={section} index={i} />
+              ))}
+            </article>
+          </div>
+        </section>
+
+        {/* Closing CTA */}
+        <section className="mx-auto max-w-4xl px-6 py-16 text-center md:py-24">
+          <h2 className="mb-3 text-2xl font-semibold tracking-tight text-zinc-100 md:text-3xl">
+            Questions or reports?
+          </h2>
+          <p className="mx-auto mb-6 max-w-xl text-zinc-400">
+            Email security for suspected violations or coordinated testing
+            requests, or legal for clarifications and negotiated terms on
+            enterprise contracts.
+          </p>
+          <div className="flex flex-wrap items-center justify-center gap-4">
+            <a
+              href="mailto:security@useatlas.dev"
+              className="group inline-flex items-center gap-2 rounded-lg bg-zinc-100 px-5 py-2.5 text-sm font-medium text-zinc-950 transition-all hover:bg-white"
+            >
+              Email security
+            </a>
+            <a
+              href="mailto:legal@useatlas.dev"
+              className="group inline-flex items-center gap-2 rounded-lg border border-zinc-800 px-5 py-2.5 text-sm font-medium text-zinc-300 transition-all hover:border-zinc-700 hover:text-zinc-100"
+            >
+              Email legal
+            </a>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/apps/www/src/app/aup/page.tsx
+++ b/apps/www/src/app/aup/page.tsx
@@ -9,7 +9,7 @@ import { StickyNav } from "../../components/sticky-nav";
 export const metadata: Metadata = {
   title: "Acceptable Use Policy — Atlas",
   description:
-    "What you can't do with Atlas Cloud. Five prohibited categories up top, eight sections below — short, specific, and enforceable.",
+    "What you can't do with Atlas Cloud. Four prohibited categories up top, nine sections below — short, specific, and enforceable.",
   openGraph: {
     title: "Acceptable Use Policy — Atlas",
     description:

--- a/apps/www/src/app/dpa/page.tsx
+++ b/apps/www/src/app/dpa/page.tsx
@@ -31,7 +31,7 @@ const SUBPROCESSORS: SubProcessor[] = [
   {
     name: "Railway",
     purpose: "Cloud infrastructure (compute, storage, Postgres)",
-    region: "Customer’s selected region (US East, EU West, APAC SE)",
+    region: "Customer’s selected region — United States (Virginia), Europe (Netherlands), or Asia Pacific (Singapore)",
     since: "2026-01",
   },
   {
@@ -145,11 +145,11 @@ const SECTIONS: LegalSectionData[] = [
     id: "audit",
     title: "Audits",
     legal: [
-      "Atlas makes available to Customer all information necessary to demonstrate compliance with Art. 28 GDPR, including its current SOC 2 Type II report and ISO 27001 certificate where applicable. Reports are available on request under appropriate confidentiality terms.",
+      "Atlas makes available to Customer all information reasonably necessary to demonstrate compliance with Art. 28 GDPR. Atlas operates a security program aligned with SOC 2 Type II and ISO 27001 controls; formal certification is on the roadmap and the certification status, including any third-party report or attestation, is available on request under appropriate confidentiality terms.",
       "Once per twelve-month period, on at least 30 days’ notice and during normal business hours, Customer may conduct, or have a third party conduct under appropriate confidentiality, an audit of Atlas’s processing activities, limited to information reasonably necessary to verify compliance and conducted in a manner that does not unreasonably interfere with Atlas’s operations.",
     ],
     plain:
-      "We share our SOC 2 Type II report and ISO 27001 certificate on request. You may audit our processing once per year with 30 days’ notice and confidentiality protections.",
+      "We share our current security-program documentation and any completed third-party report on request. You may audit our processing once per year with 30 days’ notice and confidentiality protections.",
   },
   {
     id: "deletion",
@@ -166,7 +166,7 @@ const SECTIONS: LegalSectionData[] = [
     title: "Annexes",
     legal: [
       "Annex I — List of Sub-processors. The current list is rendered as a table at the bottom of this page and is the source of truth.",
-      "Annex II — Technical and Organizational Measures: encryption (TLS 1.2+ in transit, AES-256 at rest), customer-managed KMS keys negotiable on enterprise contracts, MFA-required admin access, least-privilege IAM, audit logging of administrative operations, automated vulnerability scanning, annual third-party penetration testing, ISO 27001-aligned ISMS, SOC 2 Type II reported annually, secure SDLC with mandatory code review, segregated production access, documented incident-response runbook with quarterly drills.",
+      "Annex II — Technical and Organizational Measures: encryption (TLS 1.2+ in transit, AES-256-GCM at rest with versioned key rotation; integration credentials and connection strings encrypted in the internal database), customer-managed KMS keys negotiable on enterprise contracts, least-privilege IAM, audit logging of administrative operations, automated vulnerability scanning of container images and dependencies, ISO 27001-aligned ISMS, security program aligned with SOC 2 Type II controls (formal certification on the roadmap), secure SDLC with mandatory code review, segregated production access, documented incident-response runbook. Two-factor authentication for admin accounts and a third-party penetration-testing program are on the public roadmap.",
       "Annex III — Standard Contractual Clauses, Module Two (controller-to-processor) selected by default. Optional Clause 7 (Docking Clause) is included. Clause 9 sub-processor option (b) — general written authorization with 30-day notice — applies. Clause 11 dispute-resolution option (a) is selected. Clause 17 governing law: Ireland. Clause 18 forum: Ireland.",
     ],
     plain:
@@ -378,9 +378,9 @@ export default function DPAPage() {
             Procurement questions?
           </h2>
           <p className="mx-auto mb-6 max-w-xl text-zinc-400">
-            For DPA negotiation, custom enterprise terms, or audit-package
-            requests (SOC 2, ISO 27001, pen-test summary), reach out to legal
-            or sales.
+            For DPA negotiation, custom enterprise terms, or to ask about our
+            security-program documentation and certification roadmap, reach
+            out to legal or sales.
           </p>
           <div className="flex flex-wrap items-center justify-center gap-4">
             <a

--- a/apps/www/src/app/privacy/page.tsx
+++ b/apps/www/src/app/privacy/page.tsx
@@ -45,7 +45,7 @@ const PROMISES: PromiseCard[] = [
   {
     mono: "encrypted",
     label: "Encrypted in transit + at rest",
-    sub: "TLS 1.2+ in flight. AES-256 on disk. Per-customer KMS keys negotiable on enterprise contracts.",
+    sub: "TLS 1.2+ in flight. AES-256-GCM on disk with versioned key rotation. Per-customer KMS keys negotiable on enterprise contracts.",
   },
 ];
 
@@ -127,33 +127,33 @@ const SECTIONS: LegalSectionData[] = [
     id: "transfers",
     title: "International transfers",
     legal: [
-      "Atlas Cloud is hosted in three Customer-selectable regions on the Business plan: us-east-1 (Virginia), eu-west-1 (Ireland), and ap-southeast-2 (Sydney). Customer Data does not leave the selected region except for transactional services (auth, billing, status email) which are processed in the United States.",
+      "Atlas Cloud is hosted in three Customer-selectable regions on the Business plan: United States (Ashburn, Virginia), Europe (Eemshaven, Netherlands), and Asia Pacific (Singapore). Customer Data does not leave the selected region except for transactional services (billing, status email) which are processed in the United States.",
       "Where personal data is transferred from the EEA, UK, or Switzerland to the US, we rely on Standard Contractual Clauses and the EU-US Data Privacy Framework where available. Custom enterprise contracts can negotiate additional regions.",
     ],
     plain:
-      "Customer Data stays in the region you select (US East, EU West, or APAC Southeast on Business). Auth and billing are processed in the US under Standard Contractual Clauses where applicable.",
+      "Customer Data stays in the region you select (United States, Europe, or Asia Pacific on Business). Billing and outbound email are processed in the US under Standard Contractual Clauses where applicable.",
   },
   {
     id: "retention",
     title: "Retention",
     legal: [
       "Account data: retained for the duration of the account plus 90 days after closure.",
-      "Audit logs: retained for the period configured by the Customer admin (default 365 days on Business; configurable per-workspace).",
+      "Audit logs: retained indefinitely until the Customer admin configures a retention policy. Once configured, retention is at least 7 days, with soft-delete plus a hard-delete delay for compliance export.",
       "Telemetry: 30 days, then aggregated and de-identified.",
       "Backups: production data is retained in encrypted backups for up to 90 days.",
     ],
     plain:
-      "Account data: term + 90 days. Audit logs: 365 days by default, configurable. Telemetry: 30 days then aggregated. Encrypted backups: up to 90 days.",
+      "Account data: term + 90 days. Audit logs: kept until you configure a retention policy (minimum 7 days). Telemetry: 30 days then aggregated. Encrypted backups: up to 90 days.",
   },
   {
     id: "security",
     title: "Security",
     legal: [
-      "Atlas maintains a security program based on ISO 27001 and SOC 2 Type II controls. Highlights: TLS 1.2+ in transit, AES-256 at rest, MFA-required admin access, least-privilege IAM, automated vulnerability scanning, and external penetration tests at least annually. Per-customer KMS keys are negotiable on enterprise contracts.",
+      "Atlas maintains a security program aligned with ISO 27001 and SOC 2 Type II controls. Highlights: TLS 1.2+ in transit, AES-256-GCM at rest with versioned key rotation, least-privilege IAM, encrypted internal-database storage of all integration credentials and connection strings, and automated vulnerability scanning of container images and dependencies. Two-factor authentication for admin accounts and per-customer KMS keys are on the public roadmap and negotiable on enterprise contracts.",
       "Suspected security incidents may be reported to security@useatlas.dev. Our disclosure policy is published at useatlas.dev/.well-known/security.txt (RFC 9116). A PGP key is available on request.",
     ],
     plain:
-      "TLS 1.2+ in transit, AES-256 at rest, MFA-required admin access, annual third-party pen tests. Report suspected issues to security@useatlas.dev (PGP key on request).",
+      "TLS 1.2+ in transit, AES-256-GCM at rest with versioned key rotation, least-privilege IAM. Working toward formal SOC 2 Type II + ISO 27001 certifications and admin MFA. Report suspected issues to security@useatlas.dev (PGP key on request).",
   },
   {
     id: "cookies",

--- a/apps/www/src/app/sla/page.tsx
+++ b/apps/www/src/app/sla/page.tsx
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
   },
 };
 
-const STATUS_PAGE_URL = "https://atlas.openstatus.dev";
+const STATUS_PAGE_URL = "https://status.useatlas.dev";
 
 interface UptimeCard {
   tier: string;

--- a/apps/www/src/components/footer.tsx
+++ b/apps/www/src/components/footer.tsx
@@ -42,6 +42,9 @@ export function Footer() {
           <a href="/privacy" className="text-xs text-zinc-400 transition-colors hover:text-zinc-200">
             Privacy
           </a>
+          <a href="/aup" className="text-xs text-zinc-400 transition-colors hover:text-zinc-200">
+            AUP
+          </a>
           <a href="/dpa" className="text-xs text-zinc-400 transition-colors hover:text-zinc-200">
             DPA
           </a>

--- a/apps/www/src/components/landing/deploy.tsx
+++ b/apps/www/src/components/landing/deploy.tsx
@@ -36,7 +36,7 @@ function SelfHostCard() {
       </header>
 
       <p className="m-0 mb-5 text-sm leading-[1.6] text-zinc-400">
-        One command. Bun, Docker, or k8s. MIT-licensed.
+        One command. Bun, Docker, or k8s. AGPL-3.0.
         <br />
         Every feature, no limits.
       </p>


### PR DESCRIPTION
## Summary

Public-page audit (2026-04-26) flagged drift between the legal/marketing surfaces and what the codebase + production infra actually do. This PR fixes every text-level item in one pass; deeper changes are tracked separately as #1925, #1926, #1927, #1928, #1929, #1930.

The same failure mode that produced the Plausible / Vercel-AI-Gateway misses in #1921 produced most of these — copy-paste from the prototype handoff that was never reconciled against ground truth.

## Changes

| Audit ID | File | Fix |
|---|---|---|
| H1 | `landing/deploy.tsx` | "MIT-licensed" → "AGPL-3.0" |
| H2 | `/privacy` §7 | Region IDs replaced with actual production regions — verified via Railway CLI against `satisfied-creation` env `multiRegionConfig` |
| H3 | `/dpa` Annex I Railway row | Same region naming fix |
| H5 | `/privacy` §8 | Audit-log retention reworded to match schema (NULL = unlimited, 7-day floor when admin opts in). Stronger 365-day default is tracked in #1927. |
| H6 | new `/aup` route + `footer.tsx` | Created Acceptable Use Policy (10 sections, dual-column legal/plain). Footer link added between Privacy and DPA so the URL referenced in /terms §3 resolves. |
| H9 | `/dpa` §7 + Annex II + closing CTA, `/privacy` §9 + encryption promise card | Softened SOC 2 Type II / ISO 27001 / annual pen-test / quarterly drill claims from "current" to "aligned with… on the roadmap." Pursuing real certifications tracked in #1928. Filled in the security details that *do* exist: `AES-256-GCM` with versioned key rotation, encrypted integration credentials in the internal DB, container-image scanning. |
| M5 | `/sla` page | `STATUS_PAGE_URL` const switched from `https://atlas.openstatus.dev` to `https://status.useatlas.dev` so the button matches §4 + §6 prose. (Per-region uptime claim tracked in #1930.) |
| M8 | `/privacy` §7 | Dropped "auth" from the US-processed list — better-auth runs in-region, not centrally. |

## Region naming — verified ground truth

| Customer label (`atlas.config.ts`) | GCP region (Railway `multiRegionConfig`) | Physical location |
|---|---|---|
| `us` | `us-east4-eqdc4a` | Ashburn, Virginia, USA |
| `eu` | `europe-west4-drams3a` | Eemshaven, Netherlands |
| `apac` | `asia-southeast1-eqsg3a` | Singapore |

The pages previously claimed Ireland and Sydney — both wrong.

## Out of scope (filed as issues)

- #1925 — Enable two-factor auth (TOTP) so the "MFA-required admin access" claim is backed (was H8)
- #1926 — Decide AWS / Bedrock posture so /dpa Annex I is complete (was H4)
- #1927 — Ship 365-day default for `audit_retention_config` so /privacy can revert to the stronger claim (was H5 code-side)
- #1928 — Compliance program: SOC 2 Type II + ISO 27001 + annual pen test + IR drills (was H9)
- #1929 — Pricing claims need code/Stripe backing: `$0.10/query` overage, `+$10/mo` extra connection, 10:12 annual ratio (was M2/M3/M4)
- #1930 — Confirm OpenStatus board shows uptime by region or soften /sla prose (was M6)

Plus #1924 (`/sub-processors` route) was already on the books — covers H7.

## Test plan

- [x] `bun run build` from `apps/www` — Next.js compiles, all 12 routes prerender (incl. new `/aup`).
- [ ] Visit `/aup` locally and verify TOC scrolls, legal/plain dual-column renders, footer link reaches it.
- [ ] Visit `/privacy`, `/dpa`, `/terms`, `/sla` and verify all the reworded sections still render cleanly with no broken markup.
- [ ] Click the SLA "View live status" button and confirm `status.useatlas.dev` is reachable.
- [ ] Spot-check the landing page self-host card now reads "AGPL-3.0".
- [ ] No code-path changes outside `apps/www/src/`; no API or DB changes; no env-var changes; no migration. Self-hosted users unaffected.