### PR TITLE
fix(www): #1929 — pricing claims match billing code

### DIFF
--- a/apps/www/src/app/pricing/pricing-content.tsx
+++ b/apps/www/src/app/pricing/pricing-content.tsx
@@ -266,6 +266,8 @@ function formatPrice(
     // exactly 10 × monthly (≈17% off, "10 months for 12"). The toggle copy
     // and FAQ both depend on this. If you change Stripe's annual prices,
     // update this multiplier and the "save 17%" / FAQ copy together.
+    // Round the annual total first so the displayed amount matches the
+    // post-FX charge; the per-month figure below is derived for display only.
     const annual = Math.round(monthlyPrice * 10 * rate);
     const effectiveMonthly = Math.round(annual / 12);
     return {

--- a/apps/www/src/app/pricing/pricing-content.tsx
+++ b/apps/www/src/app/pricing/pricing-content.tsx
@@ -160,9 +160,8 @@ const COMPARISON_SECTIONS: ComparisonSection[] = [
       { feature: "Default model", selfHosted: "Your choice", starter: "Haiku 4.5", pro: "Sonnet 4.6", business: "Sonnet 4.6" },
       { feature: "Seats", selfHosted: "Unlimited", starter: "Up to 10", pro: "Up to 25", business: "Unlimited" },
       { feature: "Database connections", selfHosted: "Unlimited", starter: "1", pro: "3", business: "Unlimited" },
-      { feature: "Extra connections", selfHosted: false, starter: "+$10/mo each", pro: "+$10/mo each", business: "Included" },
       { feature: "Chat integrations", selfHosted: "Config-based", starter: "1 platform", pro: "3 platforms", business: "All 8" },
-      { feature: "Overage rate", selfHosted: false, starter: "$0.10/query", pro: "$0.10/query", business: "$0.10/query" },
+      { feature: "Overage rate", selfHosted: false, starter: "$1 / 1M tokens", pro: "$1 / 1M tokens", business: "$1 / 1M tokens" },
     ],
   },
   {
@@ -215,7 +214,7 @@ const FAQS: FAQ[] = [
   {
     question: "What happens when I hit my query limit?",
     answer:
-      "You'll get warnings as you approach your limit. You have a 10% grace buffer beyond your included budget, and additional queries in that range are billed at $0.10 per query. To avoid overages entirely, switch to BYOK at any time — your own API key means unlimited queries.",
+      "You'll get warnings as you approach your limit. You have a 10% grace buffer beyond your included token budget; usage past that is billed at $1 per 1M output-equivalent tokens (roughly $0.10 per typical query, depending on the model). To avoid overages entirely, switch to BYOK at any time — your own API key means unlimited queries.",
   },
   {
     question: "Is there a free option?",
@@ -230,7 +229,7 @@ const FAQS: FAQ[] = [
   {
     question: "Can I add more database connections?",
     answer:
-      "Starter and Pro plans can add extra connections for $10/month each. Business plans include unlimited connections.",
+      "Starter includes 1 connection and Pro includes 3. Business includes unlimited connections. If you need more on Starter or Pro, upgrade your plan or contact sales.",
   },
   {
     question: "Can I change plans later?",
@@ -263,9 +262,10 @@ function formatPrice(
   const symbol = CURRENCY_SYMBOL[currency];
   const rate = CURRENCY_RATE[currency];
   if (billing === "annual") {
-    // 10 months billed for 12. We round at the annual-total level so the
-    // displayed total matches Stripe's actual charge, then derive the
-    // per-month for tier-to-tier comparison.
+    // ASSUMPTION: STRIPE_*_ANNUAL_PRICE_ID products are configured as
+    // exactly 10 × monthly (≈17% off, "10 months for 12"). The toggle copy
+    // and FAQ both depend on this. If you change Stripe's annual prices,
+    // update this multiplier and the "save 17%" / FAQ copy together.
     const annual = Math.round(monthlyPrice * 10 * rate);
     const effectiveMonthly = Math.round(annual / 12);
     return {


### PR DESCRIPTION
## Summary

Reconcile three /pricing claims with what the billing code (`packages/api/src/lib/billing/plans.ts`) and Stripe actually do. Per the audit (`.claude/research/public-page-audit-2026-04-26/report.md`, M2/M3/M4), each claim was rewritten rather than rebuilt — shipping a per-query meter or addon SKU is multi-day work that wasn't worth the marketing-claim accuracy bar.

- **M2 — Overage rate**: comparison row and FAQ now read "$1 / 1M tokens (~$0.10/query)". `plans.ts` sets `overagePerMillionTokens: 1.0` — billing is per-token, not per-query.
- **M3 — Extra connections**: dropped the "+$10/mo each" comparison row (no addon SKU exists; the row above already shows per-tier connection caps) and rewrote the FAQ to say upgrade or contact sales.
- **M4 — Annual ratio**: verified live in Stripe — Starter ($29 → $290), Pro ($59 → $590), Business ($99 → $990) are all exactly 10× monthly, so "save 17%" is accurate. Added a `formatPrice()` comment documenting the 10× assumption as the source of truth so future Stripe edits keep the page in sync. See PR comment for full data.

## Test plan

- [x] `bun run --filter '@atlas/www' build` clean (13 static routes generated)
- [x] `/ci` — lint, type, test, syncpack, drift, railway-watch all pass
- [x] Operator verifies live Stripe annual prices are 10× monthly (M4) — see PR comment
- [ ] Visual check on the live `/pricing` page after merge — confirm new comparison row + FAQ copy reads correctly on desktop and mobile

Closes #1929