### PR TITLE
fix(www): point /sla to atlas.openstatus.dev — status.useatlas.dev has no TLS

### DIFF
--- a/apps/www/src/app/sla/page.tsx
+++ b/apps/www/src/app/sla/page.tsx
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
   },
 };
 
-const STATUS_PAGE_URL = "https://status.useatlas.dev";
+const STATUS_PAGE_URL = "https://atlas.openstatus.dev";
 
 interface UptimeCard {
   tier: string;
@@ -92,7 +92,7 @@ const SECTIONS: LegalSectionData[] = [
     id: "exclusions",
     title: "Exclusions",
     legal: [
-      "Downtime does not include unavailability caused by: (a) scheduled maintenance announced ≥7 days in advance via status.useatlas.dev; (b) Customer-caused issues, including misconfiguration, exceeding rate limits, or use of unsupported model endpoints; (c) failures of Customer’s data warehouse, identity provider, or model provider; (d) force majeure events; (e) suspension of the account for non-payment or violation of the Acceptable Use Policy.",
+      "Downtime does not include unavailability caused by: (a) scheduled maintenance announced ≥7 days in advance via atlas.openstatus.dev; (b) Customer-caused issues, including misconfiguration, exceeding rate limits, or use of unsupported model endpoints; (c) failures of Customer’s data warehouse, identity provider, or model provider; (d) force majeure events; (e) suspension of the account for non-payment or violation of the Acceptable Use Policy.",
       "Maintenance windows are limited to 2 hours per month and are scheduled outside 09:00–18:00 in Customer’s primary business timezone where reasonably possible.",
     ],
     plain:
@@ -113,7 +113,7 @@ const SECTIONS: LegalSectionData[] = [
     id: "status",
     title: "Status, Incidents & Postmortems",
     legal: [
-      "Atlas maintains a public status page at status.useatlas.dev showing current Service health, ongoing incidents, and historical uptime by region.",
+      "Atlas maintains a public status page at atlas.openstatus.dev showing current Service health, ongoing incidents, and historical uptime.",
       "For any Severity 1 incident, Atlas will publish a written postmortem within 5 business days of resolution. Postmortems include timeline, root cause, remediation steps, and a list of preventive measures.",
       "Customers may subscribe to status updates via email, RSS, Slack, or webhook.",
     ],

--- a/apps/www/src/app/status/page.tsx
+++ b/apps/www/src/app/status/page.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from "react";
 // External status page redirect
 // ---------------------------------------------------------------------------
 // When NEXT_PUBLIC_STATUS_URL is set (SaaS deployment), redirect to the
-// external status page (e.g. OpenStatus at status.useatlas.dev). The external
+// external status page (e.g. OpenStatus at atlas.openstatus.dev). The external
 // page runs on independent infrastructure so it's reachable during outages.
 // Self-hosted deployments leave this unset and get the built-in health checks.
 const EXTERNAL_STATUS_URL = process.env.NEXT_PUBLIC_STATUS_URL;


### PR DESCRIPTION
## Summary

Regression from #1933 + closes #1930.

The "View live status" button on /sla currently 404s with an SSL handshake error. Custom domain (`status.useatlas.dev`) is an OpenStatus paid-tier feature; Atlas is on the free tier (1 monitor cap, no custom domain). The audit aligned the prose and the const in the wrong direction — this re-aligns to the working URL.

Also softens "historical uptime by region" → "historical uptime" since the free tier only allows 1 monitor (verified live: `atlas.openstatus.dev` has exactly 1 monitor today, hitting `api.useatlas.dev`). Closes the M6 audit item.

## Investigation

- DNS check: `getent hosts status.useatlas.dev` → resolves to OpenStatus IPs (216.150.1.129, 216.150.16.129) — CNAME is set
- TLS check: `curl -sI https://status.useatlas.dev/` → `SSL_ERROR_SYSCALL` — no cert issued
- OpenStatus pricing: Free tier = 1 monitor, no custom domain. Custom domain requires Starter ($X/mo)
- Live board: `curl https://atlas.openstatus.dev/feed/json` → 1 monitor (id 9230, "API"), 3 decorative components with `monitorId: null`

## Changes

`apps/www/src/app/sla/page.tsx` — 3 string changes:
- `STATUS_PAGE_URL` const → `https://atlas.openstatus.dev` (fixes the broken button)
- §4 (Exclusions): "via status.useatlas.dev" → "via atlas.openstatus.dev"
- §6 (Status): "status.useatlas.dev … historical uptime by region" → "atlas.openstatus.dev … historical uptime"

## Out of scope (parked)

When enterprise pipeline justifies the spend (~$30-40/mo for OpenStatus Starter), revisit:
- Custom domain at `status.useatlas.dev` (better branding, matches the rest of \*.useatlas.dev)
- 1m check interval (down from 10m)
- Per-region monitors (api-eu, api-apac) so /sla §6 can revert to "uptime by region"
- Wire monitorIds for the 3 decorative components on the existing OpenStatus page (Web App, Documentation, Landing) — those currently have `monitorId: null` and don't actually probe anything

I'll file a separate park-it issue for the upgrade decision so it's tracked.

## Test plan

- [x] `bun run build` — clean
- [ ] After merge + deploy: visit https://www.useatlas.dev/sla and click "View live status" — should land on atlas.openstatus.dev with valid TLS
- [ ] §4 + §6 prose reads "atlas.openstatus.dev"
- [ ] §6 plain summary still makes sense (it didn't reference the URL or "by region", so unchanged)