### PR TITLE
feat(web): #1876 — /demo design pass + widget propApiKey escape hatch (1.3.0 Bucket 6)

### DIFF
--- a/packages/react/src/components/__tests__/atlas-chat.managed-auth-gate.test.tsx
+++ b/packages/react/src/components/__tests__/atlas-chat.managed-auth-gate.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Widget managed-auth gate.
+ *
+ * Embedders that supply their own bearer token (the `/demo` flow signs a
+ * short-lived JWT and passes it as `apiKey`) must NOT see the managed
+ * sign-in card on managed-auth deploys — they've already authenticated
+ * upstream and the bearer is attached to every fetch by `useAtlasTransport`.
+ *
+ * The gate (`packages/react/src/components/atlas-chat.tsx` →
+ * `showManagedSignInCard`) carries a three-clause invariant. A regression
+ * that drops the `!hasEmbedderApiKey` clause silently breaks every embedded
+ * surface — they'd render a Better Auth sign-in form on top of a chat with
+ * a perfectly valid token.
+ */
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { render, waitFor, cleanup } from "@testing-library/react";
+import { AtlasChat } from "../atlas-chat";
+
+interface CapturedRequest {
+  url: string;
+}
+
+const capturedRequests: CapturedRequest[] = [];
+
+function makeFetchMock(authMode: "managed" | "simple-key" | "none") {
+  return function fetchImpl(input: string | URL | Request): Promise<Response> {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    capturedRequests.push({ url });
+
+    if (url.includes("/api/health")) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ checks: { auth: { mode: authMode } } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }
+    if (url.includes("/api/v1/branding")) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ branding: { hideAtlasBranding: false } }), {
+          status: 200,
+        }),
+      );
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify({ error: "not_found" }), { status: 404 }),
+    );
+  };
+}
+
+const fetchMock = mock(makeFetchMock("managed"));
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  capturedRequests.length = 0;
+  fetchMock.mockClear();
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = originalFetch;
+});
+
+describe("AtlasChat managed-auth gate", () => {
+  it("renders ManagedAuthCard on managed-auth without session and without apiKey", async () => {
+    fetchMock.mockImplementation(makeFetchMock("managed"));
+
+    const { findByTestId } = render(<AtlasChat apiUrl="https://api.example.com" />);
+
+    await findByTestId("managed-auth-card", undefined, { timeout: 5_000 });
+  });
+
+  it("does NOT render ManagedAuthCard when the embedder supplies apiKey", async () => {
+    fetchMock.mockImplementation(makeFetchMock("managed"));
+
+    const { queryByTestId } = render(
+      <AtlasChat apiUrl="https://api.example.com" apiKey="demo-jwt" />,
+    );
+
+    // Wait for health to resolve so the gate has actually run.
+    await waitFor(() => {
+      expect(capturedRequests.find((r) => r.url.includes("/api/health"))).toBeDefined();
+    });
+    // ManagedAuthCard must stay suppressed once authMode is known.
+    await waitFor(() => {
+      expect(queryByTestId("managed-auth-card")).toBeNull();
+    });
+  });
+
+  it("does NOT render ManagedAuthCard on simple-key mode regardless of apiKey", async () => {
+    fetchMock.mockImplementation(makeFetchMock("simple-key"));
+
+    const { queryByTestId } = render(
+      <AtlasChat apiUrl="https://api.example.com" apiKey="demo-jwt" />,
+    );
+
+    await waitFor(() => {
+      expect(capturedRequests.find((r) => r.url.includes("/api/health"))).toBeDefined();
+    });
+    expect(queryByTestId("managed-auth-card")).toBeNull();
+  });
+});

--- a/packages/react/src/components/atlas-chat.tsx
+++ b/packages/react/src/components/atlas-chat.tsx
@@ -319,6 +319,12 @@ function AtlasChatInner({
   const authResolved = authMode !== null;
   const isManaged = authMode === "managed";
   const isSignedIn = isManaged && !!managedSession.data?.user;
+  // `propApiKey` is the documented escape hatch for embedded surfaces that
+  // carry their own bearer token (the `/demo` flow signs a short-lived demo
+  // JWT). When supplied, treat the request as authenticated via simple-key
+  // and skip the managed sign-in card / password-change dialog — those gate
+  // off Better Auth sessions which the embedder isn't using.
+  const hasEmbedderApiKey = !!propApiKey;
 
   const getHeaders = useCallback(() => {
     const headers: Record<string, string> = {};
@@ -618,7 +624,7 @@ function AtlasChatInner({
               <p className="mb-2 text-xs text-zinc-400 dark:text-zinc-500">{healthWarning || convos.fetchError}</p>
             )}
 
-            {isManaged && !isSignedIn ? (
+            {isManaged && !isSignedIn && !hasEmbedderApiKey ? (
               <ManagedAuthCard />
             ) : (
               <ActionAuthProvider getHeaders={getHeaders} getCredentials={getCredentials}>

--- a/packages/react/src/components/atlas-chat.tsx
+++ b/packages/react/src/components/atlas-chat.tsx
@@ -319,12 +319,11 @@ function AtlasChatInner({
   const authResolved = authMode !== null;
   const isManaged = authMode === "managed";
   const isSignedIn = isManaged && !!managedSession.data?.user;
-  // `propApiKey` is the documented escape hatch for embedded surfaces that
-  // carry their own bearer token (the `/demo` flow signs a short-lived demo
-  // JWT). When supplied, treat the request as authenticated via simple-key
-  // and skip the managed sign-in card / password-change dialog — those gate
-  // off Better Auth sessions which the embedder isn't using.
+  // When the embedder supplies its own bearer token, skip the managed
+  // sign-in card — that card gates off Better Auth sessions, which a
+  // simple-key bearer caller doesn't have.
   const hasEmbedderApiKey = !!propApiKey;
+  const showManagedSignInCard = isManaged && !isSignedIn && !hasEmbedderApiKey;
 
   const getHeaders = useCallback(() => {
     const headers: Record<string, string> = {};
@@ -624,7 +623,7 @@ function AtlasChatInner({
               <p className="mb-2 text-xs text-zinc-400 dark:text-zinc-500">{healthWarning || convos.fetchError}</p>
             )}
 
-            {isManaged && !isSignedIn && !hasEmbedderApiKey ? (
+            {showManagedSignInCard ? (
               <ManagedAuthCard />
             ) : (
               <ActionAuthProvider getHeaders={getHeaders} getCredentials={getCredentials}>

--- a/packages/react/src/components/chat/managed-auth-card.tsx
+++ b/packages/react/src/components/chat/managed-auth-card.tsx
@@ -43,7 +43,7 @@ export function ManagedAuthCard() {
   }
 
   return (
-    <div className="flex h-full items-center justify-center">
+    <div className="flex h-full items-center justify-center" data-testid="managed-auth-card">
       <div className="w-full max-w-sm space-y-4 rounded-lg border border-zinc-200 bg-zinc-50 p-6 dark:border-zinc-700 dark:bg-zinc-900">
         <div className="text-center">
           <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">

--- a/packages/web/src/app/demo/page.tsx
+++ b/packages/web/src/app/demo/page.tsx
@@ -17,6 +17,7 @@ import {
   Crosshair,
   Database,
   Lock,
+  type LucideIcon,
 } from "lucide-react";
 
 const DEMO_TOKEN_KEY = "atlas-demo-token";
@@ -24,9 +25,9 @@ const DEMO_EMAIL_KEY = "atlas-demo-email";
 const DEMO_EXPIRES_KEY = "atlas-demo-expires";
 
 /**
- * Static curated starter prompts for the demo cohort. Bypasses
- * `/api/v1/starter-prompts` (which the auth pipeline rejects for demo
- * tokens) — `<AtlasChat starterPrompts={...}>` short-circuits the fetch.
+ * Static curated starter prompts for the demo cohort. `/api/v1/starter-prompts`
+ * runs under standardAuth; demo JWTs are only honored under `/api/v1/demo/*`.
+ * Inline the list to avoid a 401 on the public demo.
  */
 const DEMO_STARTER_PROMPTS = [
   "Which alerts had the highest severity in the last 7 days?",
@@ -38,7 +39,7 @@ const DEMO_STARTER_PROMPTS = [
 ] as const;
 
 type DatasetEntry = {
-  icon: typeof ShieldAlert;
+  icon: LucideIcon;
   table: string;
   description: string;
 };
@@ -122,6 +123,10 @@ export default function DemoPage() {
         // intentionally ignored: sessionStorage unavailable — token lives in state only
       }
     } catch (err) {
+      console.warn(
+        "[Atlas] demo start failed:",
+        err instanceof Error ? err.message : String(err),
+      );
       setError(
         err instanceof TypeError
           ? "Unable to reach the server"

--- a/packages/web/src/app/demo/page.tsx
+++ b/packages/web/src/app/demo/page.tsx
@@ -6,18 +6,51 @@ import { getApiUrl } from "@/lib/api-url";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Database, ArrowRight, Sparkles } from "lucide-react";
+  ArrowRight,
+  ShieldAlert,
+  Activity,
+  Users,
+  Network,
+  ShieldOff,
+  Crosshair,
+  Database,
+  Lock,
+} from "lucide-react";
 
 const DEMO_TOKEN_KEY = "atlas-demo-token";
 const DEMO_EMAIL_KEY = "atlas-demo-email";
 const DEMO_EXPIRES_KEY = "atlas-demo-expires";
+
+/**
+ * Static curated starter prompts for the demo cohort. Bypasses
+ * `/api/v1/starter-prompts` (which the auth pipeline rejects for demo
+ * tokens) — `<AtlasChat starterPrompts={...}>` short-circuits the fetch.
+ */
+const DEMO_STARTER_PROMPTS = [
+  "Which alerts had the highest severity in the last 7 days?",
+  "Show me failed login events grouped by user this week.",
+  "What vulnerabilities are unpatched on critical assets?",
+  "Top threat actors by alert count.",
+  "Which assets failed the most scans last month?",
+  "Recent indicators of compromise.",
+] as const;
+
+type DatasetEntry = {
+  icon: typeof ShieldAlert;
+  table: string;
+  description: string;
+};
+
+const DEMO_DATASET: readonly DatasetEntry[] = [
+  { icon: ShieldAlert, table: "alerts", description: "security events with severity, status, and assignee" },
+  { icon: Activity, table: "scan_results", description: "vulnerability scan output across assets" },
+  { icon: Users, table: "login_events", description: "auth attempts, failures, and session metadata" },
+  { icon: Network, table: "assets", description: "hosts, services, and asset groups" },
+  { icon: ShieldOff, table: "vulnerabilities", description: "CVEs with remediation status" },
+  { icon: Crosshair, table: "threat_actors", description: "known IOCs and threat intelligence" },
+];
 
 function getApiBase(): string {
   const url = getApiUrl();
@@ -33,7 +66,6 @@ export default function DemoPage() {
   const [loading, setLoading] = useState(false);
   const [returning, setReturning] = useState(false);
 
-  // Restore token from sessionStorage on mount, checking expiry
   useEffect(() => {
     try {
       const stored = sessionStorage.getItem(DEMO_TOKEN_KEY);
@@ -41,7 +73,6 @@ export default function DemoPage() {
       if (stored && expiresAt && Number(expiresAt) > Date.now()) {
         setToken(stored);
       } else if (stored) {
-        // Token expired — clear stale session
         sessionStorage.removeItem(DEMO_TOKEN_KEY);
         sessionStorage.removeItem(DEMO_EXPIRES_KEY);
       }
@@ -112,89 +143,193 @@ export default function DemoPage() {
     }
   }
 
-  // Email gate
   if (!token) {
     return (
-      <div className="flex flex-1 items-center justify-center p-4">
-        <Card className="w-full max-w-md">
-          <CardHeader className="text-center">
-            <div className="mx-auto mb-2 flex size-12 items-center justify-center rounded-lg bg-primary/10">
-              <Sparkles className="size-6 text-primary" />
+      <div className="flex flex-1 flex-col bg-background">
+        <header className="mx-auto flex w-full max-w-5xl items-center justify-between px-6 py-5">
+          <a href="/" className="flex items-center gap-2 text-sm font-semibold tracking-tight">
+            <svg
+              viewBox="0 0 256 256"
+              className="size-5 text-primary"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M128 24 L232 208 L24 208 Z"
+                stroke="currentColor"
+                strokeWidth="14"
+                fill="none"
+                strokeLinejoin="round"
+              />
+              <circle cx="128" cy="28" r="16" fill="currentColor" />
+            </svg>
+            Atlas
+          </a>
+          <nav className="flex items-center gap-5 text-sm text-muted-foreground">
+            <a href="https://docs.useatlas.dev" className="hover:text-foreground">
+              Docs
+            </a>
+            <a href="/login" className="hover:text-foreground">
+              Sign in
+            </a>
+          </nav>
+        </header>
+
+        <main className="mx-auto grid w-full max-w-5xl flex-1 grid-cols-1 gap-10 px-6 py-8 lg:grid-cols-[1.1fr_0.9fr] lg:gap-16">
+          <section className="flex flex-col gap-6">
+            <Badge variant="outline" className="w-fit gap-1.5 px-2 py-0.5 font-mono text-[11px] uppercase tracking-wider">
+              <span className="size-1.5 rounded-full bg-primary" /> Live demo
+            </Badge>
+            <div className="space-y-3">
+              <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">
+                Try Atlas on a real schema.
+              </h1>
+              <p className="max-w-md text-base text-muted-foreground">
+                Ask a cybersecurity sample dataset in plain English. Atlas
+                writes the SQL, validates it against the semantic layer, and
+                shows the result — no signup, no setup.
+              </p>
             </div>
-            <CardTitle className="text-2xl">Try Atlas</CardTitle>
-            <CardDescription>
-              Ask questions about a sample cybersecurity dataset — no signup or
-              database required.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <form onSubmit={handleStart} className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="demo-email">Email</Label>
-                <Input
-                  id="demo-email"
-                  type="email"
-                  placeholder="you@example.com"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  required
-                  autoFocus
-                />
+
+            <form onSubmit={handleStart} className="flex flex-col gap-3" noValidate>
+              <div className="space-y-1.5">
+                <Label htmlFor="demo-email" className="text-xs uppercase tracking-wider text-muted-foreground">
+                  Email
+                </Label>
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <Input
+                    id="demo-email"
+                    type="email"
+                    placeholder="you@example.com"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    required
+                    autoComplete="email"
+                    autoFocus
+                    className="sm:max-w-xs"
+                  />
+                  <Button type="submit" disabled={loading || !email} className="sm:w-auto">
+                    {loading ? "Starting..." : "Start demo"}
+                    {!loading && <ArrowRight className="ml-1 size-4" />}
+                  </Button>
+                </div>
               </div>
-              {error && <p className="text-sm text-destructive">{error}</p>}
-              <Button
-                type="submit"
-                className="w-full"
-                disabled={loading || !email}
-              >
-                {loading ? "Starting..." : "Start demo"}
-                {!loading && <ArrowRight className="ml-2 size-4" />}
-              </Button>
+              {error && (
+                <p className="text-sm text-destructive" role="alert">
+                  {error}
+                </p>
+              )}
+              <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <Lock className="size-3" aria-hidden="true" />
+                24-hour session. Email only used to send Atlas updates.
+              </p>
             </form>
-            <p className="text-center text-sm text-muted-foreground">
-              Already have an account?{" "}
-              <a href="/signup" className="text-primary hover:underline">
-                Sign in
-              </a>
-            </p>
-          </CardContent>
-        </Card>
+
+            <div className="space-y-2 pt-2">
+              <p className="text-xs uppercase tracking-wider text-muted-foreground">
+                Try asking
+              </p>
+              <ul className="grid grid-cols-1 gap-1.5 sm:grid-cols-2">
+                {DEMO_STARTER_PROMPTS.slice(0, 4).map((prompt) => (
+                  <li key={prompt}>
+                    <span className="block rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-xs leading-snug text-muted-foreground">
+                      {prompt}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </section>
+
+          <aside className="flex flex-col gap-3 self-start rounded-xl border border-border/70 bg-muted/30 p-5 sm:p-6">
+            <div className="flex items-start justify-between gap-2">
+              <div className="space-y-1">
+                <p className="flex items-center gap-1.5 text-xs uppercase tracking-wider text-muted-foreground">
+                  <Database className="size-3" aria-hidden="true" />
+                  Sample workspace
+                </p>
+                <h2 className="text-lg font-semibold tracking-tight">
+                  Sentinel Security
+                </h2>
+                <p className="text-xs text-muted-foreground">
+                  62 tables, ~500K rows. Realistic SaaS schema with audit
+                  log, denormalized reporting tables, and a few legacy
+                  artifacts to keep things honest.
+                </p>
+              </div>
+            </div>
+            <ul className="grid grid-cols-1 gap-1.5">
+              {DEMO_DATASET.map(({ icon: Icon, table, description }) => (
+                <li
+                  key={table}
+                  className="flex items-start gap-3 rounded-md border border-border/60 bg-background/60 px-3 py-2"
+                >
+                  <Icon className="mt-0.5 size-4 shrink-0 text-primary" aria-hidden="true" />
+                  <div className="min-w-0 flex-1">
+                    <p className="font-mono text-xs font-medium">{table}</p>
+                    <p className="text-xs text-muted-foreground">{description}</p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </aside>
+        </main>
+
+        <footer className="mx-auto flex w-full max-w-5xl items-center justify-between px-6 py-5 text-xs text-muted-foreground">
+          <span>
+            <a href="/" className="hover:text-foreground">
+              Powered by Atlas
+            </a>{" "}
+            · open source.
+          </span>
+          <a
+            href="https://github.com/AtlasDevHQ/atlas"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-foreground"
+          >
+            GitHub
+          </a>
+        </footer>
       </div>
     );
   }
 
-  // Chat mode
   return (
     <>
-      {/* CTA banner */}
-      <div className="flex items-center justify-between border-b bg-muted/50 px-4 py-2 text-sm">
-        <div className="flex items-center gap-2 text-muted-foreground">
-          <Database className="size-4" />
-          <span>
-            {returning ? "Welcome back! " : ""}You&apos;re using Atlas in demo
-            mode with sample data.
+      <div className="flex items-center justify-between gap-3 border-b bg-muted/40 px-3 py-2 text-xs sm:px-4 sm:text-sm">
+        <p className="flex min-w-0 items-center gap-2 text-muted-foreground">
+          <Database className="size-3.5 shrink-0 sm:size-4" aria-hidden="true" />
+          <span className="truncate">
+            {returning ? "Welcome back. " : ""}Demo mode — sample dataset.
           </span>
-        </div>
-        <div className="flex items-center gap-3">
+        </p>
+        <div className="flex shrink-0 items-center gap-2 sm:gap-3">
           <a
             href="/signup"
-            className="font-medium text-primary hover:underline"
+            className="hidden font-medium text-primary hover:underline sm:inline"
           >
-            Sign up to connect your own database
+            Sign up to connect your data
+          </a>
+          <a
+            href="/signup"
+            className="font-medium text-primary hover:underline sm:hidden"
+          >
+            Sign up
           </a>
           <Button variant="ghost" size="sm" onClick={handleSignOut}>
-            Exit demo
+            Exit
           </Button>
         </div>
       </div>
 
-      {/* Chat UI */}
       <div className="flex-1 overflow-hidden">
         <AtlasChat
           apiUrl={getApiUrl()}
           apiKey={token}
           chatEndpoint="/api/v1/demo/chat"
           conversationsEndpoint="/api/v1/demo/conversations"
+          starterPrompts={DEMO_STARTER_PROMPTS}
           sidebar
         />
       </div>


### PR DESCRIPTION
Closes #1876.

## Summary

- **Cold state:** centered-card-on-blank-plain → two-column hero with dataset preview + curated sample queries. Marketing hand-off framing now covers what Atlas does, what's in the dataset, and what to ask — *before* the email gate.
- **Active state:** widget ManagedAuthCard previously hijacked the post-gate chat (`isManaged && !isSignedIn` ignored `propApiKey`). Gated on `!hasEmbedderApiKey` — bearer-authenticated embedders skip the sign-in card. Demo cohort now lands on the chat surface with curated cybersecurity starter prompts.
- **Sample queries:** `<AtlasChat starterPrompts={...}>` override short-circuits `/api/v1/starter-prompts` (which rejects demo bearer tokens). Same six prompts are previewed in the cold state, four shown there directly under the form.
- **Mobile:** stacks vertically at 390px, banner copy tightened (`Demo mode — sample dataset.`, `Sign up` / `Exit` instead of `Sign up to connect your own database` / `Exit demo`).

## Critique findings (before)

| Heuristic | Before | After |
|---|---|---|
| Aesthetic & minimalist | 1/4 — empty plain dominates | 3/4 — content fills canvas |
| Recognition not recall | 3/10 — no preview of what Atlas does | 8/10 — schema + sample queries before commitment |
| Help / docs | 2/10 — no schema, no examples | 8/10 — table list + 4 sample queries + footer |
| Marketing hand-off framing | missing | `LIVE DEMO` badge + dataset card + tightened pitch |

P0 fix (widget): `packages/react/src/components/atlas-chat.tsx:621` — see commit body for full reasoning.

## Out of scope (filed implicitly via this PR's wake)

- `/api/v1/starter-prompts` rejects demo bearer tokens with 401 (the demo bearer is signed by `signDemoToken`, not validated by `authenticateRequest`). Worked around with the `starterPrompts` override prop. A follow-up could add a demo-aware path or a public starter-prompts endpoint, but no backend changes here per the design-pass scope.

## Before / after

| State | Before | After |
|---|---|---|
| Cold (1440) | Centered card on blank plain | Two-column hero — pitch left, dataset preview right, sample queries below |
| Active (1440) | "Sign in to Atlas" managed-auth card (broken) | Cybersecurity starter prompts in 2-col grid, chat input ready |
| Cold (390) | Centered card | Stacked: badge → headline → form → sample queries → dataset card |
| Active (390) | "Sign in to Atlas" managed-auth card (broken) | Sample prompts stacked vertically, banner copy fits |

Screenshots are local artifacts (`.playwright-mcp/before-*.png`, `.playwright-mcp/after-*.png`); not committed per `feedback_pr_before_merge.md`.

## /ci

| Gate | Result |
|---|---|
| lint | ✅ |
| type | ✅ |
| test | ✅ (308 api + 19 cli + 97 web + 25 ee + 9 react + all plugin packages) |
| syncpack | ✅ |
| template drift | ✅ (455 files verified) |
| railway-watch | ✅ |

Lighthouse is implicitly improved (no new images, no heavy fonts, no new third-party scripts; cold state ships less DOM than the chat widget the prior surface was running). Not measured against a regression baseline this round.

## Test plan

- [ ] `/demo` cold state on 1440x900 — hero balanced, dataset preview readable, four sample-query chips visible
- [ ] `/demo` cold state on 390x844 — stacks vertically, no overflow, button reaches thumb zone
- [ ] Submit email → demo session starts, chat surface renders the curated cybersecurity starter prompts (six on desktop, six stacked on mobile)
- [ ] Click a starter prompt → message dispatches via `/api/v1/demo/chat` (verifies bearer survives the gate)
- [ ] `Exit` → token cleared from sessionStorage, returns to cold state
- [ ] `Sign up` link → `/signup`, `Sign in` link in cold-state header → `/login`
- [ ] No regression on the embedded widget for non-demo embedders (no `apiKey` prop, managed auth) — ManagedAuthCard still renders