### PR TITLE
fix(api,web): #1944 — accept demo bearer on /api/v1/starter-prompts

### DIFF
--- a/packages/api/src/api/__tests__/starter-prompts.test.ts
+++ b/packages/api/src/api/__tests__/starter-prompts.test.ts
@@ -24,6 +24,12 @@ import {
   type UpdatePositionResult,
   type FavoritePromptRow,
 } from "@atlas/api/lib/starter-prompts/favorite-store";
+// Demo helpers read BETTER_AUTH_SECRET live on every call (not at import time),
+// so a static import is safe even though the secret is only assigned in beforeAll.
+import {
+  signDemoToken,
+  resetDemoRateLimits,
+} from "@atlas/api/lib/demo";
 
 const DEMO_TEST_SECRET = "test-secret-that-is-at-least-32-chars-long";
 const ORIGINAL_BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET;
@@ -148,6 +154,9 @@ afterAll(() => {
 });
 
 beforeEach(() => {
+  // Clear call history so per-test "was/wasn't called" assertions are
+  // honest (the mock accumulates across the whole file otherwise).
+  mocks.mockAuthenticateRequest.mockClear();
   mocks.mockAuthenticateRequest.mockImplementation(() =>
     Promise.resolve({
       authenticated: true,
@@ -165,6 +174,9 @@ beforeEach(() => {
   mocks.mockInternalQuery.mockReset();
   mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([]));
   mocks.mockCheckRateLimit.mockImplementation(() => ({ allowed: true }));
+  // Demo rate limiter is keyed by demoUserId(email) and persists across
+  // tests in module-level state — clear it so per-test budgets are reset.
+  resetDemoRateLimits();
   demoIndustryFixture = undefined;
   mockListFavorites.mockReset();
   mockListFavorites.mockImplementation(async () => []);
@@ -294,18 +306,15 @@ describe("GET /api/v1/starter-prompts", () => {
 // scoped to the global `__demo__` cohort prompts. Standard session / API-key
 // paths must be unaffected.
 describe("GET /api/v1/starter-prompts — demo bearer auth", () => {
-  // Loaded after BETTER_AUTH_SECRET is set so the HMAC key derives correctly.
-  let signDemoToken: typeof import("@atlas/api/lib/demo").signDemoToken;
-
-  beforeAll(async () => {
-    ({ signDemoToken } = await import("@atlas/api/lib/demo"));
-  });
-
-  function demoReq(token: string) {
+  function demoReq(
+    token: string,
+    extraHeaders: Record<string, string> = {},
+    path = "/api/v1/starter-prompts",
+  ) {
     return app.fetch(
-      new Request("http://localhost/api/v1/starter-prompts", {
+      new Request(`http://localhost${path}`, {
         method: "GET",
-        headers: { Authorization: `Bearer ${token}` },
+        headers: { Authorization: `Bearer ${token}`, ...extraHeaders },
       }),
     );
   }
@@ -322,9 +331,13 @@ describe("GET /api/v1/starter-prompts — demo bearer auth", () => {
       { id: "demo-2", question: "Show me failed login events grouped by user this week." },
     ]);
 
-    const signed = signDemoToken("demo@example.com");
+    const signed = signDemoToken("demo-200@example.com");
     expect(signed).not.toBeNull();
-    const res = await demoReq(signed!.token);
+
+    // The `x-atlas-mode: developer` header would normally let an admin opt
+    // into the draft overlay. Demo callers must NOT — assert the SQL still
+    // filters to `published` only.
+    const res = await demoReq(signed!.token, { "x-atlas-mode": "developer" });
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -337,12 +350,20 @@ describe("GET /api/v1/starter-prompts — demo bearer auth", () => {
       { id: "library:demo-2", text: "Show me failed login events grouped by user this week.", provenance: "library" },
     ]);
 
+    // Bright-line guard: the demo path must NOT silently delegate to
+    // standardAuth. If a future regression flips the order, this assertion
+    // catches it before the wire contract changes.
+    expect(mocks.mockAuthenticateRequest).not.toHaveBeenCalled();
+
     // Demo bearer queries scope library to global builtin prompts —
-    // pc.org_id IS NULL OR pc.org_id = NULL collapses to the IS NULL branch.
+    // pc.org_id IS NULL OR pc.org_id = NULL collapses to the IS NULL branch —
+    // and stay in published mode regardless of the developer header.
     const sqlCalls = mocks.mockInternalQuery.mock.calls;
     expect(sqlCalls.length).toBeGreaterThan(0);
-    const [, params] = sqlCalls[0]!;
+    const [sql, params] = sqlCalls[0]!;
     expect(params![1]).toBeNull();
+    expect(sql).toContain("pc.status = 'published'");
+    expect(sql).not.toContain("'draft'");
   });
 
   it("returns 401 when the demo bearer is malformed and standard auth also fails", async () => {
@@ -360,13 +381,107 @@ describe("GET /api/v1/starter-prompts — demo bearer auth", () => {
       Promise.resolve({ authenticated: false, error: "Invalid token", status: 401 }),
     );
 
-    const signed = signDemoToken("demo@example.com");
+    const signed = signDemoToken("demo-tampered@example.com");
     expect(signed).not.toBeNull();
     const tampered = signed!.token.slice(0, -4) + "AAAA";
 
     const res = await demoReq(tampered);
 
     expect(res.status).toBe(401);
+  });
+
+  it("returns 429 with Retry-After when the demo per-email rate limit is exceeded", async () => {
+    // Saturate the limiter — default RPM is 10 (ATLAS_DEMO_RATE_LIMIT_RPM).
+    // Use a unique email so this test can't see budget consumed elsewhere.
+    const email = "demo-ratelimit@example.com";
+    const signed = signDemoToken(email);
+    expect(signed).not.toBeNull();
+
+    const limit = 10;
+    for (let i = 0; i < limit; i++) {
+      const ok = await demoReq(signed!.token);
+      expect(ok.status).toBe(200);
+    }
+
+    const blocked = await demoReq(signed!.token);
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get("retry-after")).toBeTruthy();
+    const body = (await blocked.json()) as { error: string; requestId: string };
+    expect(body.error).toBe("rate_limited");
+    expect(typeof body.requestId).toBe("string");
+  });
+
+  it("falls through to standardAuth when BETTER_AUTH_SECRET is unset (no 500)", async () => {
+    // Misconfigured self-hosted deploys: verifyDemoToken returns null, the
+    // middleware must NOT throw. Standard auth (mocked here as success) takes
+    // the request the rest of the way.
+    delete process.env.BETTER_AUTH_SECRET;
+    try {
+      // Any bearer string — verification fails before any HMAC check.
+      const res = await demoReq("anything-since-no-secret");
+      expect(res.status).toBe(200);
+      // Standard auth ran — exact opposite of the happy-path 200 test.
+      expect(mocks.mockAuthenticateRequest).toHaveBeenCalled();
+    } finally {
+      process.env.BETTER_AUTH_SECRET = DEMO_TEST_SECRET;
+    }
+  });
+
+  // Favorites endpoints stay on standardAuth — a demo bearer must not let a
+  // demo caller pin into a non-existent workspace. Three small guard tests
+  // so that mounting `demoOrStandardAuth` at `*` in a future refactor would
+  // turn red here before shipping.
+  describe("favorites endpoints reject demo bearers", () => {
+    function demoFavReq(
+      method: "POST" | "DELETE" | "PATCH",
+      path: string,
+      token: string,
+      body?: unknown,
+    ) {
+      const init: RequestInit = {
+        method,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+      };
+      if (body !== undefined) init.body = JSON.stringify(body);
+      return app.fetch(new Request(`http://localhost${path}`, init));
+    }
+
+    it("rejects POST /favorites with 401", async () => {
+      mocks.mockAuthenticateRequest.mockImplementation(() =>
+        Promise.resolve({ authenticated: false, error: "Invalid token", status: 401 }),
+      );
+      const signed = signDemoToken("demo-fav-post@example.com");
+      const res = await demoFavReq("POST", "/api/v1/starter-prompts/favorites", signed!.token, {
+        text: "should be rejected",
+      });
+      expect(res.status).toBe(401);
+      expect(mockCreateFavorite).not.toHaveBeenCalled();
+    });
+
+    it("rejects DELETE /favorites/:id with 401", async () => {
+      mocks.mockAuthenticateRequest.mockImplementation(() =>
+        Promise.resolve({ authenticated: false, error: "Invalid token", status: 401 }),
+      );
+      const signed = signDemoToken("demo-fav-delete@example.com");
+      const res = await demoFavReq("DELETE", "/api/v1/starter-prompts/favorites/fav-x", signed!.token);
+      expect(res.status).toBe(401);
+      expect(mockDeleteFavorite).not.toHaveBeenCalled();
+    });
+
+    it("rejects PATCH /favorites/:id with 401", async () => {
+      mocks.mockAuthenticateRequest.mockImplementation(() =>
+        Promise.resolve({ authenticated: false, error: "Invalid token", status: 401 }),
+      );
+      const signed = signDemoToken("demo-fav-patch@example.com");
+      const res = await demoFavReq("PATCH", "/api/v1/starter-prompts/favorites/fav-x", signed!.token, {
+        position: 2,
+      });
+      expect(res.status).toBe(401);
+      expect(mockUpdateFavoritePosition).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/packages/api/src/api/__tests__/starter-prompts.test.ts
+++ b/packages/api/src/api/__tests__/starter-prompts.test.ts
@@ -10,6 +10,7 @@ import {
   describe,
   it,
   expect,
+  beforeAll,
   beforeEach,
   afterAll,
   mock,
@@ -23,6 +24,13 @@ import {
   type UpdatePositionResult,
   type FavoritePromptRow,
 } from "@atlas/api/lib/starter-prompts/favorite-store";
+
+const DEMO_TEST_SECRET = "test-secret-that-is-at-least-32-chars-long";
+const ORIGINAL_BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET;
+
+beforeAll(() => {
+  process.env.BETTER_AUTH_SECRET = DEMO_TEST_SECRET;
+});
 
 // ── Module mocks (must run before importing the app) ────────────────────
 
@@ -132,6 +140,11 @@ function jsonReq(
 
 afterAll(() => {
   mocks.cleanup();
+  if (ORIGINAL_BETTER_AUTH_SECRET !== undefined) {
+    process.env.BETTER_AUTH_SECRET = ORIGINAL_BETTER_AUTH_SECRET;
+  } else {
+    delete process.env.BETTER_AUTH_SECRET;
+  }
 });
 
 beforeEach(() => {
@@ -270,6 +283,90 @@ describe("GET /api/v1/starter-prompts", () => {
     expect(sqlCalls.length).toBeGreaterThan(0);
     const [, params] = sqlCalls[0]!;
     expect(params![2]).toBe("90");
+  });
+});
+
+// ── Demo bearer auth (#1944) ─────────────────────────────────────────────
+//
+// `/api/v1/starter-prompts` accepts the same demo bearer that `/api/v1/demo/*`
+// uses. With a valid demo bearer, the resolver runs with `orgId = null`, mode
+// `published`, and the SQL `pc.org_id IS NULL OR pc.org_id = $2` keeps reads
+// scoped to the global `__demo__` cohort prompts. Standard session / API-key
+// paths must be unaffected.
+describe("GET /api/v1/starter-prompts — demo bearer auth", () => {
+  // Loaded after BETTER_AUTH_SECRET is set so the HMAC key derives correctly.
+  let signDemoToken: typeof import("@atlas/api/lib/demo").signDemoToken;
+
+  beforeAll(async () => {
+    ({ signDemoToken } = await import("@atlas/api/lib/demo"));
+  });
+
+  function demoReq(token: string) {
+    return app.fetch(
+      new Request("http://localhost/api/v1/starter-prompts", {
+        method: "GET",
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+    );
+  }
+
+  it("returns 200 with the __demo__ cohort's published prompts for a valid demo bearer", async () => {
+    // Standard auth path is broken in this test — only demo bearer should let us in.
+    mocks.mockAuthenticateRequest.mockImplementation(() =>
+      Promise.resolve({ authenticated: false, error: "Invalid token", status: 401 }),
+    );
+
+    demoIndustryFixture = "cybersecurity";
+    mocks.mockInternalQuery.mockImplementation(async () => [
+      { id: "demo-1", question: "Which alerts had the highest severity in the last 7 days?" },
+      { id: "demo-2", question: "Show me failed login events grouped by user this week." },
+    ]);
+
+    const signed = signDemoToken("demo@example.com");
+    expect(signed).not.toBeNull();
+    const res = await demoReq(signed!.token);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      prompts: Array<{ id: string; text: string; provenance: string }>;
+      total: number;
+    };
+    expect(body.total).toBe(2);
+    expect(body.prompts).toEqual([
+      { id: "library:demo-1", text: "Which alerts had the highest severity in the last 7 days?", provenance: "library" },
+      { id: "library:demo-2", text: "Show me failed login events grouped by user this week.", provenance: "library" },
+    ]);
+
+    // Demo bearer queries scope library to global builtin prompts —
+    // pc.org_id IS NULL OR pc.org_id = NULL collapses to the IS NULL branch.
+    const sqlCalls = mocks.mockInternalQuery.mock.calls;
+    expect(sqlCalls.length).toBeGreaterThan(0);
+    const [, params] = sqlCalls[0]!;
+    expect(params![1]).toBeNull();
+  });
+
+  it("returns 401 when the demo bearer is malformed and standard auth also fails", async () => {
+    mocks.mockAuthenticateRequest.mockImplementation(() =>
+      Promise.resolve({ authenticated: false, error: "Invalid token", status: 401 }),
+    );
+
+    const res = await demoReq("not-a-real-token");
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when the demo bearer is signature-tampered and standard auth also fails", async () => {
+    mocks.mockAuthenticateRequest.mockImplementation(() =>
+      Promise.resolve({ authenticated: false, error: "Invalid token", status: 401 }),
+    );
+
+    const signed = signDemoToken("demo@example.com");
+    expect(signed).not.toBeNull();
+    const tampered = signed!.token.slice(0, -4) + "AAAA";
+
+    const res = await demoReq(tampered);
+
+    expect(res.status).toBe(401);
   });
 });
 

--- a/packages/api/src/api/routes/starter-prompts.ts
+++ b/packages/api/src/api/routes/starter-prompts.ts
@@ -24,7 +24,7 @@ import {
 import { getConfig } from "@atlas/api/lib/config";
 import { createLogger, withRequestContext } from "@atlas/api/lib/logger";
 import { resolveStarterPrompts } from "@atlas/api/lib/starter-prompts/resolver";
-import { verifyDemoToken, demoUserId } from "@atlas/api/lib/demo";
+import { verifyDemoToken, demoUserId, checkDemoRateLimit } from "@atlas/api/lib/demo";
 import { createAtlasUser, type AuthResult } from "@atlas/api/lib/auth/types";
 import {
   createFavorite,
@@ -246,8 +246,9 @@ const log = createLogger("starter-prompts-route");
  * Auth middleware for the list endpoint that accepts EITHER a valid demo
  * bearer token (signed via `signDemoToken` in `/api/v1/demo/start`) or a
  * standard session / API-key auth. With a valid demo bearer the request
- * runs against the global `__demo__` cohort: no orgId, mode `published`.
- * Demo bearers are scoped to the read-only list endpoint — favorites
+ * runs against the global `__demo__` cohort: no orgId, mode `published`,
+ * and gated by the same per-email demo rate limiter `/api/v1/demo/chat`
+ * uses so a leaked token can't pound the internal DB. Favorites
  * (POST/DELETE/PATCH) keep the standard auth gate so demo callers can't
  * pin into a non-existent workspace.
  *
@@ -261,6 +262,25 @@ const demoOrStandardAuth = createMiddleware<AuthEnv>(async (c, next) => {
 
   if (demoEmail) {
     const requestId = crypto.randomUUID();
+
+    // Same per-email throttle the rest of the demo surface uses. Returning
+    // 429 with Retry-After mirrors `/api/v1/demo/chat` so the widget can
+    // back off without bespoke handling.
+    const rateCheck = checkDemoRateLimit(demoEmail);
+    if (!rateCheck.allowed) {
+      const retryAfterSeconds = Math.ceil((rateCheck.retryAfterMs ?? 60_000) / 1000);
+      return c.json(
+        {
+          error: "rate_limited",
+          message: "Demo rate limit reached. Please wait before trying again.",
+          retryAfterSeconds,
+          requestId,
+        },
+        429,
+        { "Retry-After": String(retryAfterSeconds) },
+      );
+    }
+
     const userId = demoUserId(demoEmail);
     const demoUser = createAtlasUser(userId, "simple-key", `demo:${demoEmail}`, {
       role: "member",
@@ -272,8 +292,8 @@ const demoOrStandardAuth = createMiddleware<AuthEnv>(async (c, next) => {
     };
     c.set("requestId", requestId);
     c.set("authResult", authResult);
-    // Demo callers always run in published mode — no developer overlay.
     c.set("atlasMode", "published");
+    log.info({ requestId, demoUserId: userId }, "Demo bearer accepted on starter-prompts");
     return withRequestContext(
       { requestId, user: demoUser, atlasMode: "published" },
       () => next(),
@@ -282,10 +302,7 @@ const demoOrStandardAuth = createMiddleware<AuthEnv>(async (c, next) => {
 
   // Not a demo bearer — fall through to the standard auth + requestContext
   // pipeline. `requestContext` is run inline so the order matches the
-  // standardAuth + requestContext mount used by other routes. The inner
-  // closure is async-void to match Hono's `Next` (`() => Promise<void>`)
-  // signature even though both middlewares can short-circuit with a
-  // `Response`; standardAuth already handles that path itself.
+  // standardAuth + requestContext mount used by other routes.
   return standardAuth(c, async () => {
     await requestContext(c, next);
   });
@@ -293,7 +310,6 @@ const demoOrStandardAuth = createMiddleware<AuthEnv>(async (c, next) => {
 
 const starterPrompts = new OpenAPIHono<AuthEnv>();
 
-// List endpoint accepts demo bearers; favorites stay on standardAuth.
 starterPrompts.use("/", demoOrStandardAuth);
 starterPrompts.use("/favorites/*", standardAuth);
 starterPrompts.use("/favorites/*", requestContext);

--- a/packages/api/src/api/routes/starter-prompts.ts
+++ b/packages/api/src/api/routes/starter-prompts.ts
@@ -9,6 +9,7 @@
 
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { Effect } from "effect";
+import { createMiddleware } from "hono/factory";
 import type {
   StarterPromptsResponse,
   CreateFavoriteResponse,
@@ -21,8 +22,10 @@ import {
   AuthContext,
 } from "@atlas/api/lib/effect/services";
 import { getConfig } from "@atlas/api/lib/config";
-import { createLogger } from "@atlas/api/lib/logger";
+import { createLogger, withRequestContext } from "@atlas/api/lib/logger";
 import { resolveStarterPrompts } from "@atlas/api/lib/starter-prompts/resolver";
+import { verifyDemoToken, demoUserId } from "@atlas/api/lib/demo";
+import { createAtlasUser, type AuthResult } from "@atlas/api/lib/auth/types";
 import {
   createFavorite,
   deleteFavorite,
@@ -239,10 +242,61 @@ const patchFavoriteRoute = createRoute({
 
 const log = createLogger("starter-prompts-route");
 
+/**
+ * Auth middleware for the list endpoint that accepts EITHER a valid demo
+ * bearer token (signed via `signDemoToken` in `/api/v1/demo/start`) or a
+ * standard session / API-key auth. With a valid demo bearer the request
+ * runs against the global `__demo__` cohort: no orgId, mode `published`.
+ * Demo bearers are scoped to the read-only list endpoint — favorites
+ * (POST/DELETE/PATCH) keep the standard auth gate so demo callers can't
+ * pin into a non-existent workspace.
+ *
+ * #1944 — replaces a hard-coded `starterPrompts={...}` override on the
+ * /demo page with an end-to-end fetch through the adaptive resolver.
+ */
+const demoOrStandardAuth = createMiddleware<AuthEnv>(async (c, next) => {
+  const authHeader = c.req.raw.headers.get("authorization");
+  const match = authHeader?.match(/^Bearer\s+(.+)$/i);
+  const demoEmail = match ? verifyDemoToken(match[1]) : null;
+
+  if (demoEmail) {
+    const requestId = crypto.randomUUID();
+    const userId = demoUserId(demoEmail);
+    const demoUser = createAtlasUser(userId, "simple-key", `demo:${demoEmail}`, {
+      role: "member",
+    });
+    const authResult: AuthResult & { authenticated: true } = {
+      authenticated: true,
+      mode: "simple-key",
+      user: demoUser,
+    };
+    c.set("requestId", requestId);
+    c.set("authResult", authResult);
+    // Demo callers always run in published mode — no developer overlay.
+    c.set("atlasMode", "published");
+    return withRequestContext(
+      { requestId, user: demoUser, atlasMode: "published" },
+      () => next(),
+    );
+  }
+
+  // Not a demo bearer — fall through to the standard auth + requestContext
+  // pipeline. `requestContext` is run inline so the order matches the
+  // standardAuth + requestContext mount used by other routes. The inner
+  // closure is async-void to match Hono's `Next` (`() => Promise<void>`)
+  // signature even though both middlewares can short-circuit with a
+  // `Response`; standardAuth already handles that path itself.
+  return standardAuth(c, async () => {
+    await requestContext(c, next);
+  });
+});
+
 const starterPrompts = new OpenAPIHono<AuthEnv>();
 
-starterPrompts.use("/*", standardAuth);
-starterPrompts.use("/*", requestContext);
+// List endpoint accepts demo bearers; favorites stay on standardAuth.
+starterPrompts.use("/", demoOrStandardAuth);
+starterPrompts.use("/favorites/*", standardAuth);
+starterPrompts.use("/favorites/*", requestContext);
 
 function serializeFavorite(row: FavoritePromptRow): FavoriteStarterPrompt {
   return {

--- a/packages/api/src/lib/demo-industry.ts
+++ b/packages/api/src/lib/demo-industry.ts
@@ -40,13 +40,17 @@ export type ReadDemoIndustryResult =
  * because `getSettingAuto` is a cache read. The try/catch is defensive —
  * if `getSettingAuto` ever starts throwing, callers get the failure
  * surfaced instead of a silent `null`.
+ *
+ * `orgId: null` is the demo-bearer path — there is no workspace context,
+ * so the read falls back through the platform-level cache and env var via
+ * the same tiered resolution `getSettingAuto` already implements.
  */
 export function readDemoIndustry(
-  orgId: string,
+  orgId: string | null,
   requestId: string,
 ): ReadDemoIndustryResult {
   try {
-    const value = getSettingAuto(DEMO_INDUSTRY_SETTING, orgId) ?? null;
+    const value = getSettingAuto(DEMO_INDUSTRY_SETTING, orgId ?? undefined) ?? null;
     return { ok: true, value };
   } catch (err) {
     const normalized = err instanceof Error ? err : new Error(String(err));

--- a/packages/api/src/lib/demo.ts
+++ b/packages/api/src/lib/demo.ts
@@ -121,7 +121,12 @@ export function verifyDemoToken(token: string): string | null {
   }
 
   const parts = token.split(".");
-  if (parts.length !== 2) return null;
+  if (parts.length !== 2) {
+    // Active-attack signal: a non-empty Bearer header that doesn't even
+    // match the demo-token shape. Probe traffic is worth seeing in logs.
+    log.warn({ partsCount: parts.length }, "Demo token rejected — malformed structure");
+    return null;
+  }
 
   const [payloadStr, signatureStr] = parts;
 
@@ -136,7 +141,13 @@ export function verifyDemoToken(token: string): string | null {
   }
 
   if (expectedSig.length !== actualSig.length) return null;
-  if (!crypto.timingSafeEqual(expectedSig, actualSig)) return null;
+  if (!crypto.timingSafeEqual(expectedSig, actualSig)) {
+    // Active-attack signal: token structure is valid but signature does
+    // not match the server's HMAC key. This is the bright-line "tampered"
+    // event security ops should be able to see.
+    log.warn("Demo token rejected — signature mismatch");
+    return null;
+  }
 
   // Parse payload
   let payload: DemoTokenPayload;

--- a/packages/api/src/lib/starter-prompts/__tests__/resolver.test.ts
+++ b/packages/api/src/lib/starter-prompts/__tests__/resolver.test.ts
@@ -142,13 +142,20 @@ describe("resolveStarterPrompts — cold-start", () => {
     expect(mockInternalQuery).not.toHaveBeenCalled();
   });
 
-  it("returns empty when orgId is null (single-tenant / unauth)", async () => {
+  it("runs the library tier with orgId=null and scopes to global builtin prompts (#1944)", async () => {
+    // With no workspace context (e.g. demo bearer, single-tenant unauth), the
+    // library tier still runs but the SQL `pc.org_id = $2` collapses to NULL,
+    // leaving only `pc.org_id IS NULL` rows visible — the global `__demo__`
+    // cohort prompts. The default mock returns no rows, so this test asserts
+    // empty output AND that the SQL ran with `params[1] = null`.
     demoIndustryFixture = "cybersecurity";
 
     const result = await resolveStarterPrompts(baseCtx({ orgId: null }));
 
     expect(result).toEqual([]);
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
+    const [, params] = mockInternalQuery.mock.calls[0]!;
+    expect(params![1]).toBeNull();
   });
 
   it("returns empty when library tier finds no matching collections", async () => {

--- a/packages/api/src/lib/starter-prompts/resolver.ts
+++ b/packages/api/src/lib/starter-prompts/resolver.ts
@@ -203,7 +203,12 @@ export async function resolveStarterPrompts(
   }
 
   // Tier 3 — library (demo-industry curated collections).
-  if (out.length < limit && ctx.orgId) {
+  //
+  // Runs whether or not we have a workspace context. With `ctx.orgId = null`
+  // (demo-bearer callers, see #1944) the SQL `pc.org_id IS NULL OR pc.org_id = $2`
+  // collapses to the IS NULL branch — only globally-scoped builtin demo
+  // prompts surface, which is exactly the `__demo__` cohort.
+  if (out.length < limit) {
     const industryResult = readDemoIndustry(ctx.orgId, ctx.requestId);
     if (!industryResult.ok) {
       // Propagate: callers map to 500. A transient settings read failure

--- a/packages/web/src/app/demo/page.tsx
+++ b/packages/web/src/app/demo/page.tsx
@@ -25,17 +25,15 @@ const DEMO_EMAIL_KEY = "atlas-demo-email";
 const DEMO_EXPIRES_KEY = "atlas-demo-expires";
 
 /**
- * Static curated starter prompts for the demo cohort. `/api/v1/starter-prompts`
- * runs under standardAuth; demo JWTs are only honored under `/api/v1/demo/*`.
- * Inline the list to avoid a 401 on the public demo.
+ * Marketing teaser shown on the pre-auth email gate — NOT the chat surface's
+ * starter prompts. The chat fetches the live adaptive list from
+ * `/api/v1/starter-prompts` once a demo bearer is signed; see #1944.
  */
-const DEMO_STARTER_PROMPTS = [
+const DEMO_TEASER_PROMPTS = [
   "Which alerts had the highest severity in the last 7 days?",
   "Show me failed login events grouped by user this week.",
   "What vulnerabilities are unpatched on critical assets?",
   "Top threat actors by alert count.",
-  "Which assets failed the most scans last month?",
-  "Recent indicators of compromise.",
 ] as const;
 
 type DatasetEntry = {
@@ -235,7 +233,7 @@ export default function DemoPage() {
                 Try asking
               </p>
               <ul className="grid grid-cols-1 gap-1.5 sm:grid-cols-2">
-                {DEMO_STARTER_PROMPTS.slice(0, 4).map((prompt) => (
+                {DEMO_TEASER_PROMPTS.map((prompt) => (
                   <li key={prompt}>
                     <span className="block rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-xs leading-snug text-muted-foreground">
                       {prompt}
@@ -334,7 +332,6 @@ export default function DemoPage() {
           apiKey={token}
           chatEndpoint="/api/v1/demo/chat"
           conversationsEndpoint="/api/v1/demo/conversations"
-          starterPrompts={DEMO_STARTER_PROMPTS}
           sidebar
         />
       </div>


### PR DESCRIPTION
## Summary

- `/api/v1/starter-prompts` now recognizes demo JWTs from `signDemoToken` in addition to standard session/API-key auth. Demo callers run as `orgId=null`, mode `published`; the resolver's library tier reads only globally-scoped builtin prompts (`pc.org_id IS NULL`) — the `__demo__` cohort.
- Drops the hard-coded `<AtlasChat starterPrompts={...}>` override on `/demo` so the public demo flows through the same adaptive resolver as every other surface (#1474, PR #1492). The pre-auth gate teaser is kept and renamed `DEMO_TEASER_PROMPTS` to make clear it's marketing copy, not the live list.
- Favorites endpoints keep `standardAuth` — pinning a starter prompt still requires a real workspace.

## Behavior matrix

| Auth                     | List endpoint   | Favorites endpoints |
|--------------------------|-----------------|---------------------|
| Valid demo bearer        | 200 (`__demo__`)| 401                 |
| Valid session / API key  | 200 (cohort)    | 200                 |
| Invalid / no auth        | 401             | 401                 |

## Test plan

- [x] `bun test packages/api/src/api/__tests__/starter-prompts.test.ts` — 28/28 pass (3 new demo-bearer cases: valid → 200 + library, malformed → 401, tampered → 401)
- [x] `bun test packages/api/src/lib/starter-prompts/__tests__/resolver.test.ts` — 29/29 pass (one existing case updated to assert library tier now runs with `orgId=null`)
- [x] `bun run lint`
- [x] `bun run type`
- [x] `bun run test` — full suite green (308 api, 19 cli, 98 web, 25 ee, 10 react)
- [x] `bun x syncpack lint`
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh`
- [x] `bash scripts/check-railway-watch.sh`
- [ ] Manual: navigate to `/demo`, sign in with email, confirm starter prompts render and DevTools shows `/api/v1/starter-prompts` returning 200

Closes #1944