### PR TITLE
refactor(web): #1888 — extract <AssistantTurn> primitive for gutter rail

### DIFF
--- a/.claude/research/architecture-wins.md
+++ b/.claude/research/architecture-wins.md
@@ -1158,3 +1158,23 @@ Second, a hand-constructed `FetchError { message: "" }` would render blank `Erro
 - **Line count:** registry is 72 lines (50 tuple entries + JSDoc + type alias), helper is ~45 lines inclusive of JSDoc + prod-substitute path, call-site edits are one-line-each across ~4 pages (the rest were already canonical). Net positive line count, but every type-level guarantee is now load-bearing.
 
 **Category:** Branded-literal registry + system-boundary invariant helper. The registry deepens the 50+ admin page call surface by constraining what would otherwise be an open `string` slot to a canonical enumeration — future typos become compile errors instead of user-visible copy bugs. The helper codifies an invariant that was previously scattered across three fallback paths with matching-but-drifting `|| "Request failed"` suffixes. Closes the remaining type-design gap from the 1.2.2 arc.
+
+---
+
+## 44. Extract `<AssistantTurn>` primitive — gutter rail consolidated
+
+**Date:** 2026-05-02
+**Issue:** #1888
+**Branch:** 1888-assistant-turn-primitive
+
+**Problem:** The `border-l-2 border-primary/<N> pl-4` gutter rail — the visual anchor that ties an assistant response to its prompting question — was hand-inlined at two call sites with a small but real opacity drift between them: the chat surface (`packages/web/src/app/page.tsx:451`) used `border-primary/30`, while the notebook query cell output (`packages/web/src/ui/components/notebook/notebook-cell-output.tsx:50`) used `border-primary/40`. Same visual element, two slightly different styles, no shared source of truth. The rule of three was being relaxed because the drift between `/30` and `/40` was itself the bug worth fixing — extraction forced a single decision instead of letting a third adopter (the pending tool-call grouping fold-down from #1864) inherit the inconsistency.
+
+**Solution:** New `packages/web/src/ui/components/chat/assistant-turn.tsx` — a 14-line `AssistantTurn` component that wraps the gutter style behind `cn("border-l-2 border-primary/40 pl-4", className)`. Typed as `React.ComponentProps<"div">` per the local shadcn convention (`Card`, `CardHeader`, `Table`, etc.) so callers can spread native div props — needed at the chat call site to preserve `role="article"` and `aria-label="Message from Atlas"` on the same DOM node without wrapping in a second element. Both call sites migrated; the chat surface picks up the `/30` → `/40` opacity bump as part of consolidation.
+
+**Impact:**
+- **Net +6 lines, but a single source of truth.** The component is 14 lines (JSDoc + 7 line body), the two call sites each lose 1 line of inlined classes. Future adopters (tool-call grouping fold-down, any third surface) inherit the consolidated style automatically.
+- **Opacity drift resolved.** One `primary/40` across both surfaces. A future reviewer who tweaks gutter saturation only has to find one place.
+- **Accessibility preserved.** Spreading `React.ComponentProps<"div">` lets the chat surface keep `role="article"` and `aria-label="Message from Atlas"` on the gutter element where they belong semantically, instead of forcing a wrapper div.
+- **Pure refactor.** No behavior change, no new tests, no public API surface added.
+
+**Category:** Tightly-coupled style fragment consolidated into a deep module with a small interface. Same shape as #1 (`useAdminMutation`) but minimal in line count — the value isn't line reduction, it's that the visual primitive now has one definition instead of two slightly-drifting copies.

--- a/.claude/research/architecture-wins.md
+++ b/.claude/research/architecture-wins.md
@@ -1172,7 +1172,7 @@ Second, a hand-constructed `FetchError { message: "" }` would render blank `Erro
 **Solution:** New `packages/web/src/ui/components/chat/assistant-turn.tsx` — a 14-line `AssistantTurn` component that wraps the gutter style behind `cn("border-l-2 border-primary/40 pl-4", className)`. Typed as `React.ComponentProps<"div">` per the local shadcn convention (`Card`, `CardHeader`, `Table`, etc.) so callers can spread native div props — needed at the chat call site to preserve `role="article"` and `aria-label="Message from Atlas"` on the same DOM node without wrapping in a second element. Both call sites migrated; the chat surface picks up the `/30` → `/40` opacity bump as part of consolidation.
 
 **Impact:**
-- **Net +6 lines, but a single source of truth.** The component is 14 lines (JSDoc + 7 line body), the two call sites each lose 1 line of inlined classes. Future adopters (tool-call grouping fold-down, any third surface) inherit the consolidated style automatically.
+- **Net positive line count, but a single source of truth.** The component is 14 lines, each call site loses its inlined gutter classes but gains an import. Future adopters (tool-call grouping fold-down, any third surface) inherit the consolidated style automatically.
 - **Opacity drift resolved.** One `primary/40` across both surfaces. A future reviewer who tweaks gutter saturation only has to find one place.
 - **Accessibility preserved.** Spreading `React.ComponentProps<"div">` lets the chat surface keep `role="article"` and `aria-label="Message from Atlas"` on the gutter element where they belong semantically, instead of forcing a wrapper div.
 - **Pure refactor.** No behavior change, no new tests, no public API surface added.

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -15,6 +15,7 @@ import { useAtlasTransport } from "@/ui/hooks/use-atlas-transport";
 import { authClient } from "@/lib/auth/client";
 import { NavBar } from "@/ui/components/tour/nav-bar";
 import { IncidentBanner } from "@/ui/components/incident-banner";
+import { AssistantTurn } from "@/ui/components/chat/assistant-turn";
 import { ErrorBanner } from "@/ui/components/chat/error-banner";
 import { FollowUpChips } from "@/ui/components/chat/follow-up-chips";
 import { ToolPart } from "@/ui/components/chat/tool-part";
@@ -446,9 +447,8 @@ function ChatPage() {
                     const { failureRuns, skipFailureIndex } = computeSqlFailureDedup(m.parts);
 
                     return (
-                      <div
+                      <AssistantTurn
                         key={m.id}
-                        className="border-l-2 border-primary/30 pl-4"
                         role="article"
                         aria-label="Message from Atlas"
                       >
@@ -500,7 +500,7 @@ function ChatPage() {
                             onSelect={handleSend}
                           />
                         )}
-                      </div>
+                      </AssistantTurn>
                     );
                   })}
 

--- a/packages/web/src/ui/components/chat/assistant-turn.tsx
+++ b/packages/web/src/ui/components/chat/assistant-turn.tsx
@@ -2,11 +2,11 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-/** Visual gutter anchoring an assistant's response to its prompting question.
- *  Used by the chat surface and notebook query cells. */
+/** Visual gutter anchoring an assistant's response to its prompting question. */
 export function AssistantTurn({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
+      data-slot="assistant-turn"
       className={cn("border-l-2 border-primary/40 pl-4", className)}
       {...props}
     />

--- a/packages/web/src/ui/components/chat/assistant-turn.tsx
+++ b/packages/web/src/ui/components/chat/assistant-turn.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+/** Visual gutter anchoring an assistant's response to its prompting question.
+ *  Used by the chat surface and notebook query cells. */
+export function AssistantTurn({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("border-l-2 border-primary/40 pl-4", className)}
+      {...props}
+    />
+  );
+}

--- a/packages/web/src/ui/components/notebook/notebook-cell-output.tsx
+++ b/packages/web/src/ui/components/notebook/notebook-cell-output.tsx
@@ -3,6 +3,7 @@
 import type { UIMessage } from "@ai-sdk/react";
 import { isToolUIPart } from "ai";
 import type { CellStatus, PreviousExecution } from "./types";
+import { AssistantTurn } from "@/ui/components/chat/assistant-turn";
 import { ToolPart } from "@/ui/components/chat/tool-part";
 import { Markdown } from "@/ui/components/chat/markdown";
 import { TypingIndicator } from "@/ui/components/chat/typing-indicator";
@@ -47,7 +48,7 @@ export function NotebookCellOutput({ assistantMessage, status, collapsed, previo
   const { failureRuns, skipFailureIndex } = computeSqlFailureDedup(assistantMessage.parts);
 
   return (
-    <div className="space-y-2 border-l-2 border-primary/40 pl-4 text-sm">
+    <AssistantTurn className="space-y-2 text-sm">
       {assistantMessage.parts.map((part, i) => {
         if (skipFailureIndex.has(i)) return null;
         if (part.type === "text") {
@@ -66,6 +67,6 @@ export function NotebookCellOutput({ assistantMessage, status, collapsed, previo
         }
         return null;
       })}
-    </div>
+    </AssistantTurn>
   );
 }


### PR DESCRIPTION
## Summary

- Extracted `<AssistantTurn>` to `packages/web/src/ui/components/chat/assistant-turn.tsx` — wraps the `border-l-2 border-primary/40 pl-4` gutter rail that anchors an assistant response to its prompting question.
- Migrated both call sites: chat surface (`page.tsx:451`) and notebook cell output (`notebook-cell-output.tsx:50`). Chat surface picks up the `/30` → `/40` opacity bump as part of consolidating the drift between the two surfaces.
- Component types as `React.ComponentProps<"div">` per the local shadcn convention (`Card`, `CardHeader`, `Table`, etc.) — this is a slight extension of the issue's two-prop signature, but it lets the chat call site preserve `role="article"` and `aria-label="Message from Atlas"` on the same DOM node without wrapping in another element. Wanted to flag this explicitly — happy to revert to the strict `{ children, className }` signature if you'd rather see the a11y attrs migrate to a wrapper div.
- Architecture-wins entry #44 added.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun run test` — full suite passes
- [x] `bun x syncpack lint` — no issues
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — passes
- [x] `bash scripts/check-railway-watch.sh` — passes
- [ ] Browser verify chat surface (`/`) — confirm gutter rail renders with the slight `/30` → `/40` saturation bump and isn't jarring
- [ ] Browser verify notebook (`/notebook`) — confirm gutter rail unchanged (was already at `/40`)
- [ ] Mobile viewport (390×844) for both surfaces

If the chat-surface `/40` saturation feels too strong in review, drift was the bug we were fixing — flag it here and we can pick the canonical opacity together rather than silently retreat to `/30`.

Closes #1888