### PR TITLE
fix(deploy): #1951 — pre-create semantic/ to avoid root-owned bind mount

### DIFF
--- a/scripts/db-up.sh
+++ b/scripts/db-up.sh
@@ -14,13 +14,25 @@ if ! mkdir -p "$REPO_ROOT/semantic"; then
 fi
 # If the directory was created by a prior root-owned `docker compose up`,
 # `mkdir -p` is a no-op. Probe writability so we surface the real cause
-# now, instead of letting the wizard hit a confusing EACCES later.
-if [ ! -w "$REPO_ROOT/semantic" ] || ! ( probe="$REPO_ROOT/semantic/.atlas-write-probe-$$"; touch "$probe" 2>/dev/null && rm -f "$probe" ); then
-  echo "Error: $REPO_ROOT/semantic exists but is not writable by $(id -un)." >&2
-  echo "This usually means a prior 'docker compose up' created it as root (see #1951)." >&2
-  echo "Fix: sudo chown -R \"\$(id -u):\$(id -g)\" \"$REPO_ROOT/semantic\"" >&2
+# now, instead of letting the wizard hit a confusing EACCES later. `[ -w ]`
+# alone can lie under unusual ACLs / overlayfs / WSL bind mounts, so we
+# also try a real touch and capture its stderr — that way ENOSPC, EROFS,
+# and quota errors get reported as themselves rather than misrouted to
+# the chown remediation below.
+probe="$REPO_ROOT/semantic/.atlas-write-probe-$$"
+touch_err=""
+if [ ! -w "$REPO_ROOT/semantic" ] || ! touch_err="$(touch "$probe" 2>&1)"; then
+  if [ -n "$touch_err" ]; then
+    echo "Error: cannot write to $REPO_ROOT/semantic: $touch_err" >&2
+    echo "This is a filesystem error (e.g. read-only fs, no space, quota), not a permission issue." >&2
+  else
+    echo "Error: $REPO_ROOT/semantic exists but is not writable by $(id -un)." >&2
+    echo "This usually means a prior 'docker compose up' created it as root (see #1951)." >&2
+    echo "Fix (run as your shell, not under sudo): sudo chown -R \"\$(id -u):\$(id -g)\" \"$REPO_ROOT/semantic\"" >&2
+  fi
   exit 1
 fi
+rm -f "$probe"
 
 # Start all services: Postgres + sandbox sidecar
 if ! docker compose up -d; then

--- a/scripts/db-up.sh
+++ b/scripts/db-up.sh
@@ -2,10 +2,12 @@
 set -euo pipefail
 
 # Pre-create bind-mount source directories with host-user ownership.
-# docker-compose mounts ./semantic into the sandbox container; if the host
-# path doesn't exist, the docker daemon creates it as root, which then
-# breaks wizard save (EACCES on mkdir semantic/.orgs/) and `atlas init`.
-# See issue #1951.
+# Any host path bind-mounted into a container must exist before
+# `docker compose up`, otherwise the docker daemon creates it as root.
+# Today this only applies to ./semantic (sandbox sidecar) — when the host
+# path is missing, the resulting root-owned dir breaks wizard save (EACCES
+# on mkdir semantic/.orgs/) and `atlas init`. See issue #1951. Add new
+# bind-mount sources here as compose services are introduced.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 if ! mkdir -p "$REPO_ROOT/semantic"; then

--- a/scripts/db-up.sh
+++ b/scripts/db-up.sh
@@ -1,6 +1,27 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Pre-create bind-mount source directories with host-user ownership.
+# docker-compose mounts ./semantic into the sandbox container; if the host
+# path doesn't exist, the docker daemon creates it as root, which then
+# breaks wizard save (EACCES on mkdir semantic/.orgs/) and `atlas init`.
+# See issue #1951.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+if ! mkdir -p "$REPO_ROOT/semantic"; then
+  echo "Error: cannot create $REPO_ROOT/semantic (needed for sandbox bind-mount, see #1951)." >&2
+  exit 1
+fi
+# If the directory was created by a prior root-owned `docker compose up`,
+# `mkdir -p` is a no-op. Probe writability so we surface the real cause
+# now, instead of letting the wizard hit a confusing EACCES later.
+if [ ! -w "$REPO_ROOT/semantic" ] || ! ( probe="$REPO_ROOT/semantic/.atlas-write-probe-$$"; touch "$probe" 2>/dev/null && rm -f "$probe" ); then
+  echo "Error: $REPO_ROOT/semantic exists but is not writable by $(id -un)." >&2
+  echo "This usually means a prior 'docker compose up' created it as root (see #1951)." >&2
+  echo "Fix: sudo chown -R \"\$(id -u):\$(id -g)\" \"$REPO_ROOT/semantic\"" >&2
+  exit 1
+fi
+
 # Start all services: Postgres + sandbox sidecar
 if ! docker compose up -d; then
   echo "Error: Failed to start containers." >&2


### PR DESCRIPTION
## Summary

Closes #1951.

- On a fresh clone, `semantic/` is gitignored, so it doesn't exist when `bun run db:up` runs `docker compose up`. The sandbox service has a `./semantic:/semantic:ro` bind mount, and the docker daemon creates missing host paths as **root** — which then trips the wizard save endpoint (`EACCES: permission denied, mkdir 'semantic/.orgs/'`) and `atlas init`.
- `scripts/db-up.sh` now `mkdir -p`s `semantic/` (resolved from `BASH_SOURCE`, so cwd doesn't matter) before `docker compose up`. The daemon adopts the existing host-owned directory instead of creating a root-owned one.
- After `mkdir -p`, the script probes writability with a touch-and-remove check. Users with an **already-broken** checkout (root-owned `semantic/` from a prior failed run) now get a clear remediation message pointing at #1951 — instead of seeing "Sandbox sidecar is ready" and then hitting a confusing EACCES later in the wizard.

## Acceptance

- [x] On a clean checkout: `bun install && bun run db:up && bun run dev` → wizard save works without manual chown. Verified locally: deleted `semantic/`, ran `bash scripts/db-up.sh`, dir is owned by `msywu` (host user), wizard's `mkdir semantic/.orgs/{orgId}` succeeds.
- [x] No filesystem path leaks in user-facing copy — `scrubPaths()` / `userMessageFor()` from PR #1949 still in place at `packages/web/src/app/wizard/wizard-helpers.ts`.

## Reproduction (before fix)

```sh
docker compose down
sudo rm -rf semantic/   # or: docker run --rm -v "$PWD":/work alpine rm -rf /work/semantic
docker compose up -d sandbox
ls -la semantic/        # → drwxr-xr-x  2 root root
# wizard save → EACCES on mkdir semantic/.orgs/{orgId}
```

## After fix

| State | Behavior |
| --- | --- |
| `semantic/` missing | Created host-owned, `db-up` succeeds |
| `semantic/` writable | No-op, `db-up` succeeds |
| `semantic/` root-owned (pre-broken) | `db-up` fails fast with explicit `sudo chown` remediation referencing #1951 |

## Why pre-create rather than uid-passthrough on the container?

The sandbox bind mount is `:ro` — the container never writes to `semantic/`. The bug is purely about the docker daemon creating the host-side path. `mkdir -p` is simpler and more portable across macOS / Linux / WSL2 than uid-passthrough on the container would be.

## Test plan

- [x] `bun run lint` passes
- [x] `bun run type` passes
- [x] `bun run test` passes (full suite, monorepo)
- [x] `bun run deps:lint` (syncpack) passes
- [x] `scripts/check-template-drift.sh` passes
- [x] `scripts/check-railway-watch.sh` passes
- [x] `bash -n scripts/db-up.sh` syntax check passes
- [x] Manual verification on three states (missing / writable / root-owned)