### PR TITLE
docs: trivial fixes from /docs-audit pass (2026-05-02)

### DIFF
--- a/apps/docs/content/docs/guides/mcp.mdx
+++ b/apps/docs/content/docs/guides/mcp.mdx
@@ -245,6 +245,8 @@ const server = await createAtlasMcpServer();
 // Connect to any transport: server.connect(stdioTransport) or server.connect(sseTransport)
 ```
 
+> `@atlas/mcp` is an internal monorepo package — this snippet only resolves from inside the Atlas repo (or via the `@useatlas/mcp` plugin, which wraps it). Use the [stdio entry point](#installation) for external integrations.
+
 The server factory initializes configuration, registers tools, resources, and prompt templates, and returns a ready-to-use `McpServer` instance. Connect it to any transport (stdio, SSE, or custom).
 
 ---

--- a/apps/docs/content/docs/guides/mcp.mdx
+++ b/apps/docs/content/docs/guides/mcp.mdx
@@ -245,7 +245,7 @@ const server = await createAtlasMcpServer();
 // Connect to any transport: server.connect(stdioTransport) or server.connect(sseTransport)
 ```
 
-> `@atlas/mcp` is an internal monorepo package — this snippet only resolves from inside the Atlas repo (or via the `@useatlas/mcp` plugin, which wraps it). Use the [stdio entry point](#installation) for external integrations.
+> `@atlas/mcp` is an internal monorepo package — this snippet only resolves from inside the Atlas repo (or via the `@useatlas/mcp` plugin, which wraps it). Use the [stdio entry point](#quick-start) for external integrations.
 
 The server factory initializes configuration, registers tools, resources, and prompt templates, and returns a ready-to-use `McpServer` instance. Connect it to any transport (stdio, SSE, or custom).
 

--- a/apps/docs/content/docs/reference/error-codes.mdx
+++ b/apps/docs/content/docs/reference/error-codes.mdx
@@ -46,6 +46,7 @@ Retrying these will not help — the request or configuration must be changed.
 | `invalid_request` | 400 | Invalid request | Malformed JSON body or missing required fields | Check the request body format. See [API Reference](/reference/api) |
 | `validation_error` | 422 | Request validation failed | Request body doesn't match the expected schema (wrong types, missing fields) | Check the `details` field for specific field errors |
 | `not_found` | 404 | Resource not found | Conversation, entity, or other resource doesn't exist or isn't owned by the caller | Verify the resource ID. The resource may have been deleted |
+| `conversation_budget_exceeded` | 429 | Conversation has reached its step ceiling | Conversation hit the per-conversation step cap (`ATLAS_CONVERSATION_STEP_CAP`, default 500) — F-77 atomic budget | Start a new conversation. The current thread cannot be continued |
 | `plan_limit_exceeded` | 429 | Plan limit exceeded | Workspace has exceeded its plan's query or token limit (including the 10% grace buffer) | Upgrade your plan or wait until the next billing period |
 | `provider_model_not_found` | 400 | AI model not found | The model specified in `ATLAS_MODEL` doesn't exist at the configured provider | Check `ATLAS_MODEL` and `ATLAS_PROVIDER` values. See [Environment Variables](/reference/environment-variables) |
 | `provider_auth_error` | 503 | AI provider authentication failed | Invalid or expired LLM provider API key (e.g., `ANTHROPIC_API_KEY`) | Verify your provider API key. Regenerate it if expired |

--- a/apps/docs/content/docs/reference/sdk.mdx
+++ b/apps/docs/content/docs/reference/sdk.mdx
@@ -746,6 +746,7 @@ try {
 | `validation_error` | 422 | No | Request validation failed (see `details` for field errors) |
 | `not_found` | 404 | No | Resource not found |
 | `not_available` | 404 | No | Feature not available (e.g., no internal DB) |
+| `conversation_budget_exceeded` | 429 | No | Conversation hit the per-thread step ceiling — start a new one |
 | `provider_model_not_found` | 400 | No | Configured AI model does not exist |
 | `provider_auth_error` | 503 | No | LLM provider auth failed |
 | `provider_rate_limit` | 503 | Yes | LLM provider rate limited |


### PR DESCRIPTION
## Summary

Trivial fixes surfaced by the `/docs-audit` pass on 2026-05-02. All under 5 lines each. Larger gaps from the same audit are tracked separately:

- #1956 — backfill auth + rate-limit + encryption env vars in `environment-variables.mdx`
- #1957 — add `/create-org` standalone route doc page
- #1958 — add 'Enterprise (`/ee`) boundary' page covering `isEnterpriseEnabled`, `requireEnterprise`, and AGPL-vs-commercial split
- #1959 — nsjail defaults split between explore + python sandbox — document both or align in code

## Changes

- **`apps/docs/content/docs/reference/error-codes.mdx`** — add `conversation_budget_exceeded` to the Permanent Errors table. The F-77 per-conversation step ceiling code (`packages/types/src/errors.ts:28,102`) shipped during 1.2.3 but was never documented.
- **`apps/docs/content/docs/reference/sdk.mdx`** — same code added to the SDK Error Codes table.
- **`apps/docs/content/docs/guides/mcp.mdx`** — inline blockquote noting that the `@atlas/mcp` programmatic import is monorepo-only. The parallel `plugins/interactions/mcp.mdx` page already documents this constraint; the guide page didn't, so a non-monorepo reader running the snippet would get an unresolved import.

## Test plan

- [x] Diff is 4 inserted lines across 3 files
- [ ] Pre-PR `/ci` not run for docs-only changes — docs site build is its own pipeline; manual scan of MDX preserved
- [ ] Manual MDX render not done locally — content is plain markdown (table row + blockquote), no Fumadocs components added