### PR TITLE
docs: #1956 + #1959 — backfill auth/rate-limit/encryption env vars + document nsjail per-backend defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,6 +105,8 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # ATLAS_AUTH_RATE_LIMIT_MAX=100           # Global rate-limit ceiling. Per-endpoint rules are tighter
 #                                         # (signin ≤10/min, signup/forget ≤5/min) — those are not
 #                                         # overridable via env by design.
+# ATLAS_MFA_ISSUER=Atlas                  # Issuer label shown in TOTP authenticator apps when users
+#                                         # enroll an MFA device. Default: "Atlas".
 # ATLAS_ABUSE_QUERY_RATE=200              # Max queries per workspace per sliding window (abuse prevention)
 # ATLAS_ABUSE_WINDOW_SECONDS=300          # Sliding window duration in seconds
 # ATLAS_ABUSE_ERROR_RATE=0.5              # Max error rate (0-1) before escalation
@@ -281,8 +283,14 @@ ATLAS_SANDBOX_URL=http://localhost:8080
 # ATLAS_SANDBOX_BACKEND=                         # SaaS admin-facing selector: vercel-sandbox | sidecar | e2b-sandbox | daytona-sandbox | <plugin-id>. Self-hosted operators typically use ATLAS_SANDBOX_PRIORITY instead
 # SIDECAR_AUTH_TOKEN=                            # Optional shared secret for sidecar auth (set on both API and sidecar)
 # ATLAS_NSJAIL_PATH=      # Explicit path to nsjail binary (auto-detected on PATH otherwise)
-# ATLAS_NSJAIL_TIME_LIMIT=10     # nsjail per-command time limit in seconds
-# ATLAS_NSJAIL_MEMORY_LIMIT=256  # nsjail per-command memory limit in MB
+# ATLAS_NSJAIL_TIME_LIMIT and ATLAS_NSJAIL_MEMORY_LIMIT are read by BOTH the explore
+# tool (semantic FS sandbox) and the executePython tool, with different built-in defaults:
+#   explore:        time_limit=10s,   memory_limit=256 MB
+#   executePython:  time_limit=30s,   memory_limit=512 MB  (data-science workloads need more headroom)
+# Setting either env var overrides BOTH backends with the same value. See
+# docs/reference/environment-variables (Sandbox & Isolation) for the full split.
+# ATLAS_NSJAIL_TIME_LIMIT=10     # nsjail per-command time limit in seconds (overrides both backends)
+# ATLAS_NSJAIL_MEMORY_LIMIT=256  # nsjail per-command memory limit in MB (overrides both backends)
 
 # === Action Framework (optional) ===
 # ATLAS_ACTIONS_ENABLED=true                  # Enable action framework (requires auth)
@@ -302,6 +310,8 @@ ATLAS_SANDBOX_URL=http://localhost:8080
 
 # === Teams Integration (optional) ===
 # TEAMS_APP_ID=                       # Microsoft Teams app ID — enables Teams routes when set
+# TEAMS_APP_PASSWORD=                 # Microsoft Teams app password (client secret) — required alongside
+                                      # TEAMS_APP_ID for the platform OAuth token exchange.
 
 # === JIRA Integration (optional) ===
 # Requires ATLAS_ACTIONS_ENABLED=true
@@ -334,6 +344,10 @@ ATLAS_SANDBOX_URL=http://localhost:8080
 # ATLAS_ENTERPRISE_ENABLED=false      # Enable enterprise features (SSO, SCIM, PII detection, custom roles)
 # ATLAS_ENTERPRISE_LICENSE_KEY=       # License key for enterprise features (https://www.useatlas.dev/enterprise)
 # ATLAS_APPROVAL_EXPIRY_HOURS=24     # Hours before pending approval requests auto-expire
+# ATLAS_SCIM_OVERRIDE_POLICY=strict  # F-57 SCIM provenance gate. "strict" blocks admin mutations on
+#                                    # SCIM-provisioned users (409 SCIM_MANAGED). "override" allows the
+#                                    # mutation but stamps the audit row with metadata.scim_override = true.
+#                                    # No-op for workspaces with no SCIM provider configured. Default: strict.
 
 # === Enterprise — SLA Monitoring ===
 # ATLAS_SLA_LATENCY_P99_MS=          # P99 latency threshold in ms (fires SLA alerts when exceeded)

--- a/.env.example
+++ b/.env.example
@@ -310,8 +310,8 @@ ATLAS_SANDBOX_URL=http://localhost:8080
 
 # === Teams Integration (optional) ===
 # TEAMS_APP_ID=                       # Microsoft Teams app ID — enables Teams routes when set
-# TEAMS_APP_PASSWORD=                 # Microsoft Teams app password (client secret) — required alongside
-                                      # TEAMS_APP_ID for the platform OAuth token exchange.
+# Note: per-org Teams app passwords are stored encrypted in the internal DB,
+# configured via the admin integrations UI — not from a platform env var.
 
 # === JIRA Integration (optional) ===
 # Requires ATLAS_ACTIONS_ENABLED=true

--- a/apps/docs/content/docs/architecture/sandbox.mdx
+++ b/apps/docs/content/docs/architecture/sandbox.mdx
@@ -188,8 +188,8 @@ The health endpoint (`GET /api/health`) reports which backend is active in the `
 | `ATLAS_SANDBOX_URL` | -- | Sidecar service URL (enables sidecar backend) |
 | `SIDECAR_AUTH_TOKEN` | -- | Shared secret for sidecar auth |
 | `ATLAS_NSJAIL_PATH` | -- | Explicit path to nsjail binary |
-| `ATLAS_NSJAIL_TIME_LIMIT` | `10` | nsjail per-command time limit in seconds |
-| `ATLAS_NSJAIL_MEMORY_LIMIT` | `256` | nsjail per-command memory limit in MB (`rlimit_as`) |
+| `ATLAS_NSJAIL_TIME_LIMIT` | explore: `10`, python: `30` | nsjail per-command time limit in seconds. Defaults differ per backend (explore vs `executePython`); setting this env var overrides both |
+| `ATLAS_NSJAIL_MEMORY_LIMIT` | explore: `256`, python: `512` | nsjail per-command memory limit in MB (`rlimit_as`). Defaults differ per backend (`executePython` needs more headroom for data-science workloads); setting this env var overrides both |
 
 ### nsjail Resource Limits
 
@@ -197,7 +197,7 @@ In addition to the configurable time and memory limits above, nsjail enforces th
 
 | Limit | Value | Description |
 |-------|-------|-------------|
-| `rlimit_as` | `ATLAS_NSJAIL_MEMORY_LIMIT` (default 256 MB) | Virtual memory limit |
+| `rlimit_as` | `ATLAS_NSJAIL_MEMORY_LIMIT` (default 256 MB explore, 512 MB python) | Virtual memory limit |
 | `rlimit_fsize` | 10 MB | Max file size a process can create |
 | `rlimit_nproc` | 5 | Max number of processes |
 | `rlimit_nofile` | 64 | Max open file descriptors |

--- a/apps/docs/content/docs/guides/python.mdx
+++ b/apps/docs/content/docs/guides/python.mdx
@@ -99,6 +99,10 @@ Python execution is isolated at multiple layers:
 
 The sandbox itself is configured via the standard sandbox variables. See [Environment Variables](/reference/environment-variables) and [Sandbox Architecture](/architecture/sandbox).
 
+<Callout type="info" title="nsjail defaults differ per backend">
+When using nsjail for `executePython`, the default time and memory limits are **30 seconds** and **512 MB** — higher than the explore tool's defaults (10s / 256 MB). Setting `ATLAS_NSJAIL_TIME_LIMIT` or `ATLAS_NSJAIL_MEMORY_LIMIT` overrides both backends with the same value. See [`ATLAS_NSJAIL_TIME_LIMIT`](/reference/environment-variables#sandbox--isolation).
+</Callout>
+
 ---
 
 ## How It Works

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -629,13 +629,13 @@ DISCORD_CLIENT_SECRET=your-discord-client-secret
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `TEAMS_APP_ID` | — | Microsoft Teams app ID. Enables Teams integration routes. Required for Teams connect flow |
-| `TEAMS_APP_PASSWORD` | — | Microsoft Teams app password (client secret) for the platform OAuth flow. Required alongside `TEAMS_APP_ID` for token exchange |
 
 ```bash
 # Teams integration via Azure AD admin consent
 TEAMS_APP_ID=your-teams-app-id
-TEAMS_APP_PASSWORD=your-teams-app-password
 ```
+
+> The Teams app password (client secret) is **not** read from a platform env var. Per-org Teams credentials are stored encrypted in the internal database and configured via the admin integrations UI — see [Teams integration](/guides/integrations#microsoft-teams).
 
 ---
 

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -181,7 +181,9 @@ Query safety and SQL validation settings. See [SQL Validation Pipeline](/securit
 | `ATLAS_QUERY_TIMEOUT` | `30000` | Query timeout in milliseconds |
 | `ATLAS_TABLE_WHITELIST` | `true` | Only allow queries against tables defined in the semantic layer |
 | `ATLAS_SCHEMA` | — | PostgreSQL schema name. When set to a non-`public` value, the API sets `search_path` to `"<schema>", public` on each connection. When unset, no `search_path` is set and PostgreSQL uses its server default (typically `public`). Also used by `atlas doctor` to verify the schema exists |
-| `ATLAS_ENCRYPTION_KEY` | — | Dedicated encryption key for connection URLs stored at rest. Takes precedence over `BETTER_AUTH_SECRET`. Recommended for production when managing datasource connections via the admin UI |
+| `ATLAS_ENCRYPTION_KEYS` | — | F-47 versioned at-rest encryption keyset. Comma-separated `version:key` pairs (e.g. `v2:NEW-KEY,v1:OLD-KEY`). The first entry is the active write key; later entries are legacy read-only keys kept available during a rotation soak. **Preferred form for production** — see the [encryption key rotation guide](/platform-ops/encryption-key-rotation) |
+| `ATLAS_ENCRYPTION_KEY` | — | Legacy single-key form, treated as an implicit `v1` when `ATLAS_ENCRYPTION_KEYS` is unset. Takes precedence over `BETTER_AUTH_SECRET`. Kept for back-compat — new deployments should set `ATLAS_ENCRYPTION_KEYS` instead. Key derivation order: `ATLAS_ENCRYPTION_KEYS` → `ATLAS_ENCRYPTION_KEY` → `BETTER_AUTH_SECRET` (the last is deprecated under SaaS — startup warns) |
+| `ATLAS_STRICT_PLUGIN_SECRETS` | `false` | F-42 / #1835: when `true`, plugin admin write paths reject PUTs whose catalog schema is corrupt or carries per-key secret/passthrough drift. SaaS regions opt in; self-hosted defaults to off. Tolerant idempotent passthrough is the baseline |
 | `ATLAS_POOL_WARMUP` | `2` | Number of warmup probes per connection at startup. Set to `0` to disable warmup |
 | `ATLAS_POOL_DRAIN_THRESHOLD` | `5` | Consecutive query errors before the pool is automatically drained and recreated |
 | `ATLAS_CACHE_ENABLED` | `true` | Enable query result caching. Set to `false` to disable |
@@ -234,11 +236,15 @@ ATLAS_API_KEY_ROLE=analyst
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `BETTER_AUTH_SECRET` | — | Session signing secret. Min 32 chars, cryptographically random. Requires `DATABASE_URL`. Also used to encrypt connection URLs at rest (unless `ATLAS_ENCRYPTION_KEY` is set) |
-| `ATLAS_ENCRYPTION_KEY` | — | Dedicated encryption key for connection URLs at rest. Takes precedence over `BETTER_AUTH_SECRET` |
+| `BETTER_AUTH_SECRET` | — | Session signing secret. Min 32 chars, cryptographically random. Requires `DATABASE_URL`. Also used to encrypt connection URLs at rest as a last-resort fallback (deprecated under SaaS — set `ATLAS_ENCRYPTION_KEYS` instead) |
+| `ATLAS_ENCRYPTION_KEYS` | — | F-47 versioned at-rest encryption keyset (preferred). See [Security](#security) for rotation details |
+| `ATLAS_ENCRYPTION_KEY` | — | Legacy single-key form; treated as implicit `v1` when `ATLAS_ENCRYPTION_KEYS` is unset. Takes precedence over `BETTER_AUTH_SECRET` |
 | `BETTER_AUTH_URL` | Auto-detected | Base URL for auth endpoints. Auto-detected on Vercel; set explicitly for Railway/Docker |
 | `BETTER_AUTH_TRUSTED_ORIGINS` | — | Comma-separated CSRF-allowed origins |
-| `ATLAS_ADMIN_EMAIL` | — | User matching this email gets `admin` role on signup. If unset, first signup gets admin |
+| `ATLAS_ADMIN_EMAIL` | — | User matching this email gets `admin` role on signup. If unset, first signup gets admin only when `ATLAS_ALLOW_FIRST_SIGNUP_ADMIN=true` |
+| `ATLAS_ALLOW_FIRST_SIGNUP_ADMIN` | `false` | Opt-in fallback: when `ATLAS_ADMIN_EMAIL` is unset and no admin user exists, the first signup is promoted to `platform_admin`. Accepts `true`/`1`/`yes`/`on` (case-insensitive). **Do not enable in production** — any unauthenticated visitor could race the operator and claim admin with a single signup |
+| `ATLAS_REQUIRE_EMAIL_VERIFICATION` | `true` | Require email verification on signup. Setting `false` re-enables Better Auth's `USER_ALREADY_EXISTS` signup error (an email-enumeration oracle) and is only acceptable for self-hosted single-tenant deployments without an email provider |
+| `ATLAS_MFA_ISSUER` | `Atlas` | Issuer label shown in TOTP authenticator apps (Google Authenticator, 1Password, etc.) when users enroll an MFA device |
 
 <Callout type="warn">
 Never use the default dev secret in production. Generate a cryptographically random secret: `openssl rand -base64 32`
@@ -298,7 +304,12 @@ ATLAS_AUTH_ROLE_CLAIM=app_metadata.atlas_role
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ATLAS_RATE_LIMIT_RPM` | `0` (disabled) | Max requests per minute per user. `0` or unset = unlimited |
+| `ATLAS_RATE_LIMIT_RPM_CHAT` | `max(5, ATLAS_RATE_LIMIT_RPM/4)` | F-74 separate-bucket ceiling for `/api/v1/chat`. Defaults to a quarter of `ATLAS_RATE_LIMIT_RPM` (minimum 5) so a 25-step LLM call cannot deplete the same allowance that serves cheap reads like audit-log scrolling. Disabled when `ATLAS_RATE_LIMIT_RPM` is `0` |
 | `ATLAS_TRUST_PROXY` | `false` | Trust `X-Forwarded-For` / `X-Real-IP` headers. Set `true` behind a reverse proxy |
+| `ATLAS_AUTH_RATE_LIMIT_ENABLED` | `true` | Toggle rate limiting on `/api/auth/*` endpoints. Setting `false` is logged as a security warning at boot — only acceptable for self-hosted single-tenant deployments |
+| `ATLAS_AUTH_RATE_LIMIT_WINDOW` | `60` | Global `/api/auth/*` rate-limit window in seconds |
+| `ATLAS_AUTH_RATE_LIMIT_MAX` | `100` | Global `/api/auth/*` rate-limit ceiling per window. Per-endpoint rules are tighter (signin ≤10/min, signup/forget ≤5/min) and are not env-overridable by design |
+| `ATLAS_CONVERSATION_STEP_CAP` | `500` | F-77 atomic per-conversation step budget (default 500 = 20 follow-ups × 25 steps). Once `total_steps` crosses this value, `/api/v1/chat` returns `429 conversation_budget_exceeded` and the UI offers to start a new conversation. Set `0` to disable |
 
 ```bash
 # Production rate limiting behind a reverse proxy
@@ -356,6 +367,17 @@ Idle and absolute timeouts can also be configured via [`atlas.config.ts`](/refer
 
 ---
 
+## MCP Transport
+
+Actor binding for the [MCP server](/guides/mcp). The transport runs in one of two modes — bound (governed) or unbound (trusted).
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ATLAS_MCP_USER_ID` | — | MCP actor binding (#1858) — Atlas user ID the MCP transport should act as. Set **both** `ATLAS_MCP_USER_ID` and `ATLAS_MCP_ORG_ID` for governed transport (approval rules + audit apply to MCP queries). Leaving both unset selects trusted transport with a synthetic `system:mcp` actor — only safe when no approval rules exist |
+| `ATLAS_MCP_ORG_ID` | — | MCP actor binding — org ID the bound user acts under. The MCP server fails to boot when approval rules exist and the binding is missing, or when only one of the two vars is set |
+
+---
+
 ## Semantic Layer
 
 | Variable | Default | Description |
@@ -404,7 +426,7 @@ ATLAS_RLS_CLAIMS='{"tenant_id": "acme-corp"}'
 
 ## Sandbox & Isolation
 
-Explore tool isolation backends. See [Sandbox Architecture](/architecture/sandbox#backend-selection-priority) for the full selection priority.
+Explore tool isolation backends (also used by `executePython` when nsjail is active — see the per-backend default split on `ATLAS_NSJAIL_TIME_LIMIT` / `ATLAS_NSJAIL_MEMORY_LIMIT` below). See [Sandbox Architecture](/architecture/sandbox#backend-selection-priority) for the full selection priority.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -414,8 +436,8 @@ Explore tool isolation backends. See [Sandbox Architecture](/architecture/sandbo
 | `SIDECAR_AUTH_TOKEN` | — | Shared secret for sidecar auth (set on both API and sidecar) |
 | `SEMANTIC_DIR` | `/semantic` | Sidecar only: directory where the sidecar serves semantic layer files. Defaults to `/semantic` via the sidecar Dockerfile, but can be overridden at container runtime. Not used by the main API |
 | `ATLAS_NSJAIL_PATH` | Auto-detected | Explicit path to nsjail binary |
-| `ATLAS_NSJAIL_TIME_LIMIT` | `10` | nsjail per-command time limit in seconds |
-| `ATLAS_NSJAIL_MEMORY_LIMIT` | `256` | nsjail per-command memory limit in MB |
+| `ATLAS_NSJAIL_TIME_LIMIT` | explore: `10`, python: `30` | nsjail per-command time limit in seconds. **Defaults differ per backend**: the explore tool (semantic FS sandbox) uses 10s, the Python tool (`executePython`) uses 30s. Setting this env var overrides both backends with the same value |
+| `ATLAS_NSJAIL_MEMORY_LIMIT` | explore: `256`, python: `512` | nsjail per-command memory limit in MB. **Defaults differ per backend**: explore uses 256 MB, Python uses 512 MB (data-science workloads need more headroom). Setting this env var overrides both backends with the same value |
 | `ATLAS_SANDBOX_PRIORITY` | — | Comma-separated backend priority order (e.g. `sidecar,nsjail,just-bash`). Valid values: `vercel-sandbox`, `nsjail`, `sidecar`, `just-bash`. Plugin backends always take highest priority. See [Configuration](/reference/config#sandbox) |
 | `ATLAS_SANDBOX_BACKEND` | — | SaaS admin-facing selector for the workspace's sandbox backend: `vercel-sandbox`, `sidecar`, `e2b-sandbox`, `daytona-sandbox`, or a plugin ID. Set via the Settings UI in the hosted product; self-hosted operators typically use `ATLAS_SANDBOX_PRIORITY` instead |
 
@@ -607,10 +629,12 @@ DISCORD_CLIENT_SECRET=your-discord-client-secret
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `TEAMS_APP_ID` | — | Microsoft Teams app ID. Enables Teams integration routes. Required for Teams connect flow |
+| `TEAMS_APP_PASSWORD` | — | Microsoft Teams app password (client secret) for the platform OAuth flow. Required alongside `TEAMS_APP_ID` for token exchange |
 
 ```bash
 # Teams integration via Azure AD admin consent
 TEAMS_APP_ID=your-teams-app-id
+TEAMS_APP_PASSWORD=your-teams-app-password
 ```
 
 ---
@@ -669,6 +693,7 @@ stripe listen --forward-to localhost:3001/api/auth/stripe/webhook
 | `ATLAS_ENTERPRISE_ENABLED` | `false` | Set `true` to enable enterprise features (SSO, SCIM, PII detection, custom roles). Requires a valid license key for production use |
 | `ATLAS_ENTERPRISE_LICENSE_KEY` | — | License key for enterprise features. Obtain from [useatlas.dev/enterprise](https://www.useatlas.dev/enterprise) |
 | `ATLAS_APPROVAL_EXPIRY_HOURS` | `24` | Hours before pending approval requests auto-expire. See [Approval Workflows](/guides/approval-workflows) |
+| `ATLAS_SCIM_OVERRIDE_POLICY` | `strict` | F-57 SCIM provenance gate. Controls admin mutations on SCIM-provisioned users: `strict` blocks the mutation with `409 SCIM_MANAGED` so the IdP stays canonical; `override` allows the mutation but stamps the audit row with `metadata.scim_override = true`. No-op for workspaces with no SCIM provider configured |
 
 These can also be configured via [`atlas.config.ts`](/reference/config#enterprise).
 


### PR DESCRIPTION
Closes #1956
Closes #1959

## Summary

Two related docs-only fixes surfaced by the 2026-05-02 `/docs-audit` pass, batched together because they touch the same files (`apps/docs/content/docs/reference/environment-variables.mdx` + `.env.example`).

## #1956 — backfill 14 env vars in the docs reference

Added to `apps/docs/content/docs/reference/environment-variables.mdx` (counted as 13 in the issue — MCP_USER_ID and MCP_ORG_ID were grouped into one row there):

| Var | Section | One-line description |
|---|---|---|
| `ATLAS_REQUIRE_EMAIL_VERIFICATION` | Auth → Managed | Default `true`; controls email-enumeration-oracle behavior |
| `ATLAS_ALLOW_FIRST_SIGNUP_ADMIN` | Auth → Managed | First-signup-becomes-admin opt-in fallback |
| `ATLAS_MFA_ISSUER` | Auth → Managed | TOTP issuer label (default `Atlas`) |
| `ATLAS_AUTH_RATE_LIMIT_ENABLED` | Auth → Rate Limiting | Toggles `/api/auth/*` rate limiting |
| `ATLAS_AUTH_RATE_LIMIT_WINDOW` | Auth → Rate Limiting | Default 60s |
| `ATLAS_AUTH_RATE_LIMIT_MAX` | Auth → Rate Limiting | Default 100 |
| `ATLAS_RATE_LIMIT_RPM_CHAT` | Auth → Rate Limiting | F-74 separate-bucket chat ceiling |
| `ATLAS_CONVERSATION_STEP_CAP` | Auth → Rate Limiting | F-77 atomic per-conversation step budget (default 500) |
| `ATLAS_MCP_USER_ID` | MCP Transport (new section) | MCP actor binding — Atlas user ID |
| `ATLAS_MCP_ORG_ID` | MCP Transport (new section) | MCP actor binding — org ID |
| `ATLAS_SCIM_OVERRIDE_POLICY` | Enterprise | F-57 SCIM provenance gate (default `strict`) |
| `ATLAS_STRICT_PLUGIN_SECRETS` | Security | F-42 plugin admin write strictness |
| `ATLAS_ENCRYPTION_KEYS` | Security (+ Auth → Managed cross-ref) | F-47 versioned at-rest encryption keyset (preferred form) |
| `TEAMS_APP_PASSWORD` | Teams Integration | Teams platform OAuth client secret |

`ATLAS_ENCRYPTION_KEY` rows updated to mark the legacy single-key form as the implicit `v1` fallback and to spell out the derivation order from `CLAUDE.md`: `ATLAS_ENCRYPTION_KEYS` → `ATLAS_ENCRYPTION_KEY` → `BETTER_AUTH_SECRET` (the last is deprecated under SaaS).

Added to `.env.example` per the issue's acceptance criteria: `ATLAS_MFA_ISSUER`, `ATLAS_SCIM_OVERRIDE_POLICY`, `TEAMS_APP_PASSWORD`.

All 14 vars verified with `grep -rl` against `packages/api/src`, `ee/src`, `packages/mcp/src` — every var resolves to at least one source file. Issue's source-of-truth citations were accurate; no corrections needed.

## #1959 — nsjail per-backend default split (option 1, docs only)

The two backends share env vars but use different built-in defaults:

> | Backend | File | Time default | Memory default |
> |---|---|---|---|
> | Explore (semantic FS sandbox) | `packages/api/src/lib/tools/backends/nsjail.ts:75-86` | 10s | 256 MB |
> | Python (executePython tool) | `packages/api/src/lib/tools/python-nsjail.ts:24,27` | 30s | 512 MB |

Took **option 1** (docs only — no code defaults touched). Rewrote the two rows in:

- `apps/docs/content/docs/reference/environment-variables.mdx` — both rows now show `explore: 10, python: 30` / `explore: 256, python: 512` and explain the env var overrides both backends with the same value
- `apps/docs/content/docs/architecture/sandbox.mdx` — the Configuration table and the `rlimit_as` row in nsjail Resource Limits both reflect the split
- `.env.example` — comment block above the two `ATLAS_NSJAIL_*` lines documents the per-backend defaults
- `apps/docs/content/docs/guides/python.mdx` — added a `<Callout type="info">` cross-link pointing back at the env-vars reference

## Test plan

- [x] `bun run lint` passes
- [x] `bash scripts/check-openapi-drift.sh` passes (no route changes)
- [x] All 14 added vars `grep`-verified against `packages/api/src`, `ee/src`, `packages/mcp/src`
- [x] Markdown table integrity preserved (4 pipes per row across all touched tables)
- [x] Internal cross-links (`/platform-ops/encryption-key-rotation`, `/guides/mcp`) point at existing pages