### PR TITLE
docs: #1958 — add Enterprise (/ee) boundary page covering isEnterpriseEnabled, requireEnterprise, and gated features

### DIFF
--- a/apps/docs/content/docs/architecture/enterprise.mdx
+++ b/apps/docs/content/docs/architecture/enterprise.mdx
@@ -1,0 +1,298 @@
+---
+title: Enterprise (/ee) Boundary
+description: The AGPL-vs-commercial split, the isEnterpriseEnabled / requireEnterprise API, and the inventory of features gated behind @atlas/ee.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+> Single source of truth on the Atlas enterprise gate. Plugin authors and self-hosted operators land here when they want to know what `/ee` is, what's inside it, and how to interact with it from code.
+
+## Why this page exists
+
+Atlas ships as two layers that share one repository:
+
+- **`@atlas/api`, `@atlas/web`, `@atlas/cli`, `@useatlas/*`** — the **AGPL** core. Self-hosted users get the entire product: agent loop, semantic layer, tools, admin console, plugins, multi-datasource support, the works.
+- **`@atlas/ee`** (the `ee/` directory) — **source-available, commercial license**. Adds the governance, compliance, scale, and polished SaaS surfaces that make Atlas viable as a hosted product.
+
+The boundary between them is enforced by two functions exported from `@atlas/ee/index`:
+
+- [`isEnterpriseEnabled()`](#isenterpriseenabled) — boolean check, safe for conditional logic.
+- [`requireEnterprise(name?)`](#requireenterprise-and-requireenterpriseeffect) — guard that throws [`EnterpriseError`](#enterpriseerror).
+
+Everything else flows from those two. If you've grepped for `requireEnterprise(` and built a mental model from the call sites, this page formalizes it.
+
+---
+
+## License split
+
+### AGPL core — what self-hosted gets for free
+
+The core product is **AGPL-3.0**. Run it standalone, embed it via the SDK, ship it on Docker, Railway, or Vercel — no license key, no feature flags. Self-hosted deployments get:
+
+- The agent loop, tools (`executeSQL`, `explore`, plugin actions), and Vercel AI SDK integration
+- The semantic layer, `atlas init` / `atlas diff` / `atlas learn` CLI
+- Multi-tenant primitives (Better Auth org plugin, tenant-scoped pools, query result cache)
+- The admin console, audit log, role assignment via the built-in `admin`/`member`/`owner` triad
+- The full plugin ecosystem and Chat SDK adapters
+- Notebooks, dashboards, sharing, embedding widget
+
+Atlas is fully usable for any internal-tool or single-team deployment **without ever enabling enterprise**.
+
+### Commercial `/ee` — what the gate adds
+
+Anything that exists specifically to make Atlas work as a **hosted SaaS product** lives under `ee/src/` and runs under the [`ee/LICENSE`](https://github.com/AtlasDevHQ/atlas/blob/main/ee/LICENSE). That covers:
+
+- Multi-tenant governance (custom roles, SSO, SCIM, IP allowlists, approval workflows, custom domains)
+- Compliance (PII detection, compliance reports, long-tail audit retention)
+- Platform operations (automated backups, SLA monitoring, abuse prevention, data residency, model routing, white-labeling)
+- The deploy-mode flag that branches admin UX between self-hosted and SaaS
+
+### The "no competing SaaS" clause
+
+The commercial license is the business model — self-hosted is free, the hosted SaaS and enterprise features are how Atlas funds development. From [`ee/LICENSE`](https://github.com/AtlasDevHQ/atlas/blob/main/ee/LICENSE):
+
+> RESTRICTIONS. You may not: (a) redistribute, sublicense, or transfer the Software to any third party; (b) modify the Software for the purpose of circumventing license verification or feature gating; **(c) use the Software in a competing product or service**; (d) remove or alter any license notices or proprietary markings.
+
+Source is published for transparency, security auditing, and to enable self-hosted deployments by licensed customers — not to be cloned into a competing offering. If you want to use enterprise features, contact `enterprise@useatlas.dev` for a license.
+
+---
+
+## The API
+
+Two exports — `isEnterpriseEnabled` and `requireEnterprise` — back every gated surface in the codebase. There's also an Effect-flavored variant for code in the Effect.ts service graph.
+
+### `isEnterpriseEnabled()`
+
+```typescript
+import { isEnterpriseEnabled } from "@atlas/ee/index";
+
+export function isEnterpriseEnabled(): boolean;
+```
+
+Returns `true` when the gate is open. Resolution order:
+
+1. `enterprise.enabled` in `atlas.config.ts` (if the `enterprise` section is configured)
+2. The `ATLAS_ENTERPRISE_ENABLED` env var (`"true"` → `true`, anything else → `false`)
+
+Use this for **conditional logic** — UI branching, optional feature wiring, defensive defaults — anywhere throwing would be wrong. For example, the SCIM provenance helper short-circuits when the gate is closed:
+
+```typescript
+import { isEnterpriseEnabled } from "@atlas/ee/index";
+
+export function isScimManaged(user: User): boolean {
+  if (!isEnterpriseEnabled()) return false;
+  return user.metadata?.scimProvenance === "scim";
+}
+```
+
+The IP-allowlist admin route uses it the same way to decide whether to render the live blocklist count:
+
+```typescript
+const showCount =
+  enterpriseGate.isEnterpriseEnabled() && hasInternalDB() && list.length > 0;
+```
+
+### `requireEnterprise()` and `requireEnterpriseEffect()`
+
+```typescript
+import { requireEnterprise, requireEnterpriseEffect } from "@atlas/ee/index";
+
+export function requireEnterprise(feature?: string): void;
+export const requireEnterpriseEffect: (
+  feature?: string,
+) => Effect.Effect<void, EnterpriseError>;
+```
+
+Use these as **guards** at the top of any function that should refuse to run when the gate is closed. The optional `feature` label lands in the error message — pass a stable identifier (`"sso"`, `"scim"`, `"approval-workflows"`) so audit logs and UI surfaces can route on it.
+
+Sync guard inside an `Effect.try`:
+
+```typescript
+// ee/src/backups/scheduler.ts
+import { requireEnterprise } from "../index";
+
+export const scheduleBackup = (orgId: string) =>
+  Effect.gen(function* () {
+    yield* Effect.try({
+      try: () => requireEnterprise("backups"),
+      catch: (err) => err instanceof Error ? err : new Error(String(err)),
+    });
+    // ...rest of the scheduling logic
+  });
+```
+
+Effect-native guard for handlers in the service graph:
+
+```typescript
+// ee/src/auth/sso.ts
+import { requireEnterpriseEffect, EnterpriseError } from "../index";
+
+export const listProviders = (
+  orgId: string,
+): Effect.Effect<SSOProvider[], EnterpriseError> =>
+  Effect.gen(function* () {
+    yield* requireEnterpriseEffect("sso");
+    // ...query the providers table
+  });
+```
+
+The Effect variant fails with `EnterpriseError` in the error channel — pipeline `catchTag("EnterpriseError", ...)` handlers compose cleanly.
+
+<Callout type="info" title="License key vs gate">
+The license key check is **separate** from `requireEnterprise`. Self-hosted customers validate their key at startup; the SaaS platform and local dev don't require one. The key check was deliberately removed from this guard so platform admins can use features they control. Set `ATLAS_ENTERPRISE_LICENSE_KEY` in production self-hosted deployments — see [`reference/config`](/reference/config#enterprise) for the full schema.
+</Callout>
+
+### `EnterpriseError`
+
+```typescript
+import { EnterpriseError } from "@atlas/ee/index";
+
+export class EnterpriseError extends Data.TaggedError("EnterpriseError")<{
+  message: string;
+  code: "enterprise_required";
+}> {}
+```
+
+Tagged error built on `Data.TaggedError` — supports `instanceof`, `Effect.catchTag("EnterpriseError", ...)`, and structural equality. **Always check via `instanceof`, never by string-matching the message.**
+
+```typescript
+// good
+if (err instanceof EnterpriseError) { /* ... */ }
+
+// bad — message is hand-authored at the throw site and varies
+if (err.message.includes("enterprise")) { /* ... */ }
+```
+
+Route handlers in the AGPL core never have to map this error themselves. The shared Effect-to-Hono bridge in `packages/api/src/lib/effect/hono.ts` recognizes it via duck-typed coupling (`error.name === "EnterpriseError"` + string `code`) and emits **HTTP 403** with a `requestId`. The duck type stays decoupled from the `@atlas/ee` import so the AGPL core can compile without the enterprise package.
+
+```text
+runHandler(c, "label", () => program)
+  ↓ classifyError(err)
+  ↓ err.name === "EnterpriseError" && typeof err.code === "string"
+  ↓
+HTTP 403 { code: "enterprise_required", message, requestId }
+```
+
+---
+
+## Gated feature inventory
+
+Every feature in the table below calls `requireEnterprise(...)` or `requireEnterpriseEffect(...)` somewhere in its write path. The `Feature label` column is the literal string passed to the guard — search the codebase for `requireEnterprise("<label>"` to find every call site.
+
+| Category | Feature label | What's gated | Guide |
+|---|---|---|---|
+| **Identity** | `sso` | SAML 2.0 / OIDC providers, domain verification, IdP test connection, auto-provisioning toggles | [Enterprise SSO](/guides/enterprise-sso) |
+| **Identity** | `scim` | SCIM 2.0 connections, group mapping, sync-status endpoints | [SCIM Directory Sync](/guides/scim) |
+| **Identity** | `roles` | Custom role definitions, permission flag CRUD, role assignment beyond the built-in admin/analyst/viewer triad | [Custom Roles](/guides/custom-roles) |
+| **Network** | `ip-allowlist` | CIDR allowlist CRUD, request-time allowlist enforcement | [IP Allowlisting](/guides/ip-allowlisting) |
+| **Governance** | `approval-workflows` | Approval rules, request lifecycle, expiration sweeps, pending-count queries | [Approval Workflows](/guides/approval-workflows) |
+| **Compliance** | `pii-detection` | Column classification CRUD, masking config, PII scan triggers | [PII Masking](/guides/pii-masking) |
+| **Compliance** | `compliance` | SOC 2 / ISO / GDPR report generation, evidence aggregation | [Compliance Reporting](/guides/compliance-reporting) |
+| **Audit** | `audit-retention` | Long-tail retention policies, archive/export, retention policy CRUD | [Audit Retention](/guides/audit-retention) |
+| **Platform** | `backups` | Scheduled backups, restore, integrity verification | [Backups](/platform-ops/backups) |
+| **Platform** | `model-routing` | Per-workspace model overrides, routing rules, BYOT model config beyond defaults | [Model Routing](/guides/model-routing) |
+| **Platform** | `branding` | White-label branding, custom logo / colors / favicon, hosted-product theming | [White Labeling](/guides/white-labeling) |
+| **Platform** | (admin-domains route) | Custom domains for SaaS workspaces — gated inline via `Effect.fail(new EnterpriseError(...))` in `admin-domains.ts` rather than a `requireEnterprise` label | [Custom Domains](/platform-ops/custom-domains) |
+| **Platform ops** | (resolveDeployMode) | Abuse prevention surfaces, data residency routing, SLA monitoring — gated indirectly via `isEnterpriseEnabled()` checks at the service-init layer rather than per-call `requireEnterprise` | [Abuse Prevention](/platform-ops/abuse-prevention), [Data Residency](/platform-ops/data-residency) |
+
+The labels are stable identifiers — once a feature ships with a label, audit log entries and admin UI surfaces lock onto it. Don't rename a label without a migration plan.
+
+<Callout title="Adding a new gated feature">
+1. Implement under `ee/src/<category>/<feature>.ts`.
+2. Call `requireEnterpriseEffect("<feature-label>")` (or `requireEnterprise(...)` inside `Effect.try`) at the top of every public Effect.
+3. Re-export the public surface — do **not** import `@atlas/ee` from the AGPL core; the core relies on the duck-typed `EnterpriseError` mapping.
+4. Add the feature label to the [feature inventory](#gated-feature-inventory) above.
+5. If the feature surfaces in the admin UI, add its canonical name to the `FeatureName` registry in `packages/web/src/ui/components/admin/feature-registry.ts` so `<EnterpriseUpsell>` / `<FeatureGate>` typecheck.
+</Callout>
+
+---
+
+## Deploy mode and the gate
+
+`ATLAS_DEPLOY_MODE` controls whether the admin UX renders the SaaS variant (billing, plugin marketplace, residency picker, custom domains) or the self-hosted variant. The setting is enterprise-gated:
+
+```typescript
+// ee/src/deploy-mode.ts
+export function resolveDeployMode(raw?: DeployModeSetting): DeployMode {
+  const setting = raw ?? process.env.ATLAS_DEPLOY_MODE ?? "auto";
+
+  if (setting === "self-hosted") return "self-hosted";
+
+  if (setting === "saas") {
+    return isEnterpriseEnabled() ? "saas" : "self-hosted";
+  }
+
+  // "auto" — both enterprise enabled AND an internal database configured
+  return isEnterpriseEnabled() && hasInternalDB() ? "saas" : "self-hosted";
+}
+```
+
+Three settings, one rule: **`saas` requires enterprise**. Without it, deploy mode always resolves to `self-hosted` regardless of what the env var says. The frontend reads `deployMode` from `GET /api/v1/mode` and branches accordingly — there's no way for an unlicensed deployment to render SaaS-only admin UX, even by accident.
+
+| Setting | With enterprise | Without enterprise |
+|---|---|---|
+| `self-hosted` (explicit) | `self-hosted` | `self-hosted` |
+| `saas` (explicit) | `saas` | `self-hosted` (silent fallback) |
+| `auto` (default) | `saas` if `DATABASE_URL` set, else `self-hosted` | `self-hosted` |
+
+See [Environment Variables](/reference/environment-variables#deploy-mode) for the full env-var schema.
+
+---
+
+## Patterns
+
+### From a plugin
+
+Plugins live in the AGPL core but can opt into enterprise gating for premium features. **Don't** import `@atlas/ee` directly — your plugin should be installable in unlicensed deployments. Instead, accept a config flag and let the host decide:
+
+```typescript
+// plugins/my-plugin/src/index.ts
+import { definePlugin } from "@useatlas/plugin-sdk";
+
+export default definePlugin({
+  name: "my-plugin",
+  // ... rest of plugin shape
+  initialize: async (ctx) => {
+    if (ctx.config.premiumFeatures) {
+      // Host has confirmed enterprise context — wire the premium path.
+    } else {
+      // Free path — works in every deployment.
+    }
+  },
+});
+```
+
+If your plugin **must** check the gate at runtime (e.g., to refuse a write for compliance reasons), the host can forward the resolved boolean through the plugin context. Avoid hard-coupling plugin code to `@atlas/ee` — it complicates packaging and breaks self-hosted users who don't have the package on disk.
+
+### From a route handler
+
+Route handlers in `packages/api/src/api/routes/` either guard via `requireEnterpriseEffect` inside an `Effect.gen` body or fail directly with `EnterpriseError` at conditional points (see `admin-domains.ts` for the pattern). The shared bridge maps it to 403 — you don't need to write your own try/catch.
+
+```typescript
+// packages/api/src/api/routes/admin-domains.ts
+import { EnterpriseError } from "@atlas/ee/index";
+
+const program = Effect.gen(function* () {
+  if (!isEnterpriseEnabled()) {
+    return yield* Effect.fail(new EnterpriseError(EE_REQUIRED_MESSAGE));
+  }
+  // ... rest of the handler
+});
+```
+
+### From the frontend
+
+The web package never imports `@atlas/ee`. UI gating lives in two places:
+
+1. `GET /api/v1/mode` returns the resolved `deployMode` — branch SaaS vs self-hosted UX on that.
+2. The `FeatureName` registry at `packages/web/src/ui/components/admin/feature-registry.ts` is the source of truth for `<EnterpriseUpsell>`, `<FeatureGate>`, and `<MutationErrorSurface>` `feature` props. Add a feature there, then the UI components are typechecked against it.
+
+---
+
+## See also
+
+- [Reference: Config](/reference/config#enterprise) — `enterprise.enabled` / `enterprise.licenseKey` schema
+- [Reference: Environment Variables](/reference/environment-variables) — `ATLAS_ENTERPRISE_ENABLED`, `ATLAS_ENTERPRISE_LICENSE_KEY`, `ATLAS_DEPLOY_MODE`
+- [Architecture: Sandbox](/architecture/sandbox) — companion design doc on the runtime sandbox boundary
+- [Comparisons: Metabase](/comparisons/metabase#license) — split-license positioning vs other AGPL BI tools
+- [`ee/LICENSE`](https://github.com/AtlasDevHQ/atlas/blob/main/ee/LICENSE) — the commercial license verbatim

--- a/apps/docs/content/docs/architecture/enterprise.mdx
+++ b/apps/docs/content/docs/architecture/enterprise.mdx
@@ -14,7 +14,7 @@ Atlas ships as two layers that share one repository:
 - **`@atlas/api`, `@atlas/web`, `@atlas/cli`, `@useatlas/*`** — the **AGPL** core. Self-hosted users get the entire product: agent loop, semantic layer, tools, admin console, plugins, multi-datasource support, the works.
 - **`@atlas/ee`** (the `ee/` directory) — **source-available, commercial license**. Adds the governance, compliance, scale, and polished SaaS surfaces that make Atlas viable as a hosted product.
 
-The boundary between them is enforced by two functions exported from `@atlas/ee/index`:
+The boundary between them is enforced by two functions exported from `@atlas/ee`:
 
 - [`isEnterpriseEnabled()`](#isenterpriseenabled) — boolean check, safe for conditional logic.
 - [`requireEnterprise(name?)`](#requireenterprise-and-requireenterpriseeffect) — guard that throws [`EnterpriseError`](#enterpriseerror).
@@ -64,7 +64,7 @@ Two exports — `isEnterpriseEnabled` and `requireEnterprise` — back every gat
 ### `isEnterpriseEnabled()`
 
 ```typescript
-import { isEnterpriseEnabled } from "@atlas/ee/index";
+import { isEnterpriseEnabled } from "@atlas/ee";
 
 export function isEnterpriseEnabled(): boolean;
 ```
@@ -77,7 +77,7 @@ Returns `true` when the gate is open. Resolution order:
 Use this for **conditional logic** — UI branching, optional feature wiring, defensive defaults — anywhere throwing would be wrong. For example, the SCIM provenance helper short-circuits when the gate is closed:
 
 ```typescript
-import { isEnterpriseEnabled } from "@atlas/ee/index";
+import { isEnterpriseEnabled } from "@atlas/ee";
 
 export function isScimManaged(user: User): boolean {
   if (!isEnterpriseEnabled()) return false;
@@ -95,7 +95,7 @@ const showCount =
 ### `requireEnterprise()` and `requireEnterpriseEffect()`
 
 ```typescript
-import { requireEnterprise, requireEnterpriseEffect } from "@atlas/ee/index";
+import { requireEnterprise, requireEnterpriseEffect } from "@atlas/ee";
 
 export function requireEnterprise(feature?: string): void;
 export const requireEnterpriseEffect: (
@@ -145,7 +145,7 @@ The license key check is **separate** from `requireEnterprise`. Self-hosted cust
 ### `EnterpriseError`
 
 ```typescript
-import { EnterpriseError } from "@atlas/ee/index";
+import { EnterpriseError } from "@atlas/ee";
 
 export class EnterpriseError extends Data.TaggedError("EnterpriseError")<{
   message: string;
@@ -183,10 +183,10 @@ Every feature in the table below calls `requireEnterprise(...)` or `requireEnter
 |---|---|---|---|
 | **Identity** | `sso` | SAML 2.0 / OIDC providers, domain verification, IdP test connection, auto-provisioning toggles | [Enterprise SSO](/guides/enterprise-sso) |
 | **Identity** | `scim` | SCIM 2.0 connections, group mapping, sync-status endpoints | [SCIM Directory Sync](/guides/scim) |
-| **Identity** | `roles` | Custom role definitions, permission flag CRUD, role assignment beyond the built-in admin/analyst/viewer triad | [Custom Roles](/guides/custom-roles) |
+| **Identity** | `roles` | Custom role definitions, permission flag CRUD, role assignment beyond the built-in admin/member/owner triad | [Custom Roles](/guides/custom-roles) |
 | **Network** | `ip-allowlist` | CIDR allowlist CRUD, request-time allowlist enforcement | [IP Allowlisting](/guides/ip-allowlisting) |
 | **Governance** | `approval-workflows` | Approval rules, request lifecycle, expiration sweeps, pending-count queries | [Approval Workflows](/guides/approval-workflows) |
-| **Compliance** | `pii-detection` | Column classification CRUD, masking config, PII scan triggers | [PII Masking](/guides/pii-masking) |
+| **Compliance** | `pii-detection` | Column classification CRUD, masking config, PII scan triggers (write paths via `requireEnterpriseEffect`); query-time row masking gated inline via `isEnterpriseEnabled()` in `masking.ts` so AGPL deployments simply skip masking instead of failing the query | [PII Masking](/guides/pii-masking) |
 | **Compliance** | `compliance` | SOC 2 / ISO / GDPR report generation, evidence aggregation | [Compliance Reporting](/guides/compliance-reporting) |
 | **Audit** | `audit-retention` | Long-tail retention policies, archive/export, retention policy CRUD | [Audit Retention](/guides/audit-retention) |
 | **Platform** | `backups` | Scheduled backups, restore, integrity verification | [Backups](/platform-ops/backups) |
@@ -270,7 +270,7 @@ Route handlers in `packages/api/src/api/routes/` either guard via `requireEnterp
 
 ```typescript
 // packages/api/src/api/routes/admin-domains.ts
-import { EnterpriseError } from "@atlas/ee/index";
+import { EnterpriseError } from "@atlas/ee";
 
 const program = Effect.gen(function* () {
   if (!isEnterpriseEnabled()) {

--- a/apps/docs/content/docs/architecture/meta.json
+++ b/apps/docs/content/docs/architecture/meta.json
@@ -4,6 +4,7 @@
   "icon": "Layers",
   "pages": [
     "sandbox",
-    "content-mode"
+    "content-mode",
+    "enterprise"
   ]
 }

--- a/apps/docs/content/docs/guides/approval-workflows.mdx
+++ b/apps/docs/content/docs/guides/approval-workflows.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 Atlas supports approval workflows for sensitive queries. Admins define rules that intercept queries before execution, requiring sign-off from designated approvers. This adds a governance layer for compliance-sensitive environments.
 
 <Callout type="info" title="SaaS Feature">
-  Approval workflows are available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments do not include enterprise features.
+  Approval workflows are available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments do not include enterprise features. This feature is part of the Atlas commercial offering — see the [Enterprise (`/ee`) boundary](/architecture/enterprise) for details on the gate, license split, and `requireEnterprise("approval-workflows")` call sites.
 </Callout>
 
 <Callout title="Prerequisites">

--- a/apps/docs/content/docs/guides/audit-retention.mdx
+++ b/apps/docs/content/docs/guides/audit-retention.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 Atlas includes configurable audit log retention with automatic purging and compliance-ready export formats. Workspace admins can set retention periods, configure soft-delete with delayed hard-delete, and export audit data in CSV or JSON for SOC2 compliance.
 
 <Callout type="info" title="SaaS Feature">
-  Audit log retention policies are available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments manage retention directly via their own database.
+  Audit log retention policies are available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments manage retention directly via their own database. This feature is part of the Atlas commercial offering — see the [Enterprise (`/ee`) boundary](/architecture/enterprise) for details on the gate, license split, and `requireEnterprise("audit-retention")` call sites.
 </Callout>
 
 <Callout title="Prerequisites">

--- a/apps/docs/content/docs/guides/compliance-reporting.mdx
+++ b/apps/docs/content/docs/guides/compliance-reporting.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 Atlas provides compliance reports built on top of audit log data, PII classifications, and user session history. Reports help answer audit questions like "who accessed what data, when, and how often" — a requirement for SOC2, HIPAA, and similar frameworks.
 
 <Callout type="info" title="SaaS Feature">
-  Compliance reporting is available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments do not include enterprise features.
+  Compliance reporting is available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments do not include enterprise features. This feature is part of the Atlas commercial offering — see the [Enterprise (`/ee`) boundary](/architecture/enterprise) for details on the gate, license split, and `requireEnterprise("compliance")` call sites.
 </Callout>
 
 <Callout title="Prerequisites">

--- a/apps/docs/content/docs/guides/custom-roles.mdx
+++ b/apps/docs/content/docs/guides/custom-roles.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 Atlas supports custom role definitions with granular permission flags. Move beyond the default admin/member/owner hierarchy by creating named roles with specific permission sets.
 
 <Callout type="info" title="SaaS Feature">
-  Custom roles are available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments use the built-in admin/member roles.
+  Custom roles are available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments use the built-in admin/member roles. This feature is part of the Atlas commercial offering — see the [Enterprise (`/ee`) boundary](/architecture/enterprise) for details on the gate, license split, and `requireEnterprise("roles")` call sites.
 </Callout>
 
 <Callout title="Prerequisites">

--- a/apps/docs/content/docs/guides/enterprise-sso.mdx
+++ b/apps/docs/content/docs/guides/enterprise-sso.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 Atlas supports enterprise SSO via SAML 2.0 and OpenID Connect (OIDC). Admins register identity providers through the admin API, verify domain ownership via DNS, test the connection, and enable the provider. Users with matching email domains are auto-provisioned on first login.
 
 <Callout type="info" title="SaaS Feature">
-  Enterprise SSO is available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments do not include enterprise features.
+  Enterprise SSO is available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments do not include enterprise features. This feature is part of the Atlas commercial offering — see the [Enterprise (`/ee`) boundary](/architecture/enterprise) for details on the gate, license split, and `requireEnterprise("sso")` call sites.
 </Callout>
 
 <Callout title="Prerequisites">

--- a/apps/docs/content/docs/guides/ip-allowlisting.mdx
+++ b/apps/docs/content/docs/guides/ip-allowlisting.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 Atlas supports per-workspace IP allowlisting. When configured, only requests originating from allowed CIDR ranges can access the workspace — all other requests are rejected with a `403` response. This applies to both API and UI access.
 
 <Callout type="info" title="SaaS Feature">
-  IP allowlisting is available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments do not include enterprise features.
+  IP allowlisting is available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments do not include enterprise features. This feature is part of the Atlas commercial offering — see the [Enterprise (`/ee`) boundary](/architecture/enterprise) for details on the gate, license split, and `requireEnterprise("ip-allowlist")` call sites.
 </Callout>
 
 <Callout title="Prerequisites">

--- a/apps/docs/content/docs/guides/model-routing.mdx
+++ b/apps/docs/content/docs/guides/model-routing.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 Atlas supports workspace-level model routing. Each workspace can configure its own LLM provider and API key, overriding the platform default. This enables enterprise customers to use their own Anthropic, OpenAI, Azure OpenAI, or custom OpenAI-compatible endpoints.
 
 <Callout type="info" title="SaaS Feature">
-  Model routing is available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments configure the model provider globally via environment variables.
+  Model routing is available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments configure the model provider globally via environment variables. This feature is part of the Atlas commercial offering — see the [Enterprise (`/ee`) boundary](/architecture/enterprise) for details on the gate, license split, and `requireEnterprise("model-routing")` call sites.
 </Callout>
 
 <Callout title="Prerequisites">

--- a/apps/docs/content/docs/guides/pii-masking.mdx
+++ b/apps/docs/content/docs/guides/pii-masking.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 Atlas can auto-detect personally identifiable information (PII) in your database columns and mask sensitive values in query results. Detection runs during profiling, and masking is applied at query time based on user role.
 
 <Callout type="info" title="SaaS Feature">
-  PII detection and masking is available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments do not include enterprise features.
+  PII detection and masking is available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments do not include enterprise features. This feature is part of the Atlas commercial offering — see the [Enterprise (`/ee`) boundary](/architecture/enterprise) for details on the gate, license split, and `requireEnterprise("pii-detection")` call sites.
 </Callout>
 
 <Callout title="Prerequisites">

--- a/apps/docs/content/docs/guides/scim.mdx
+++ b/apps/docs/content/docs/guides/scim.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 Atlas supports SCIM 2.0 (RFC 7643/7644) for automated user provisioning from enterprise identity providers like Okta, Azure AD (Entra ID), and OneLogin. When users are added, updated, or deactivated in your corporate directory, changes are automatically synced to Atlas.
 
 <Callout type="info" title="SaaS Feature">
-  SCIM directory sync is available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments do not include enterprise features.
+  SCIM directory sync is available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments do not include enterprise features. This feature is part of the Atlas commercial offering — see the [Enterprise (`/ee`) boundary](/architecture/enterprise) for details on the gate, license split, and `requireEnterprise("scim")` call sites.
 </Callout>
 
 <Callout title="Prerequisites">

--- a/apps/docs/content/docs/guides/white-labeling.mdx
+++ b/apps/docs/content/docs/guides/white-labeling.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 White-labeling lets customers remove Atlas branding and replace it with their own identity — custom logo, colors, favicon, and text — in the admin console.
 
 <Callout type="info" title="SaaS Feature">
-  White-labeling is available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments do not include enterprise features.
+  White-labeling is available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments do not include enterprise features. This feature is part of the Atlas commercial offering — see the [Enterprise (`/ee`) boundary](/architecture/enterprise) for details on the gate, license split, and `requireEnterprise("branding")` call sites.
 </Callout>
 
 <Callout title="Prerequisites">

--- a/apps/docs/content/docs/platform-ops/abuse-prevention.mdx
+++ b/apps/docs/content/docs/platform-ops/abuse-prevention.mdx
@@ -7,6 +7,10 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 Atlas includes built-in abuse prevention that detects anomalous query patterns per workspace and applies a graduated response: **warn**, **throttle**, then **suspend**. This protects your analytics datasource from runaway queries, credential stuffing, and resource exhaustion.
 
+<Callout type="info" title="SaaS Feature">
+  Cross-workspace abuse prevention surfaces are part of the Atlas commercial offering. Self-hosted deployments get the per-workspace counters via the AGPL core. See the [Enterprise (`/ee`) boundary](/architecture/enterprise) for details on the gate and license split.
+</Callout>
+
 <Callout title="Prerequisites">
 - Atlas server running with `DATABASE_URL` configured (internal DB required for persistence)
 - Admin access for the admin console abuse management page

--- a/apps/docs/content/docs/platform-ops/backups.mdx
+++ b/apps/docs/content/docs/platform-ops/backups.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 Atlas provides automated backup and disaster recovery for the internal PostgreSQL database (`DATABASE_URL`). This database stores auth, audit logs, semantic layer metadata, billing, SLA metrics, learned patterns, and chat state — protecting it is critical.
 
 <Callout type="info" title="SaaS Feature">
-  Managed backups are available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments should use their own backup strategy (e.g. managed database backups from your cloud provider).
+  Managed backups are available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments should use their own backup strategy (e.g. managed database backups from your cloud provider). This feature is part of the Atlas commercial offering — see the [Enterprise (`/ee`) boundary](/architecture/enterprise) for details on the gate, license split, and `requireEnterprise("backups")` call sites.
 </Callout>
 
 <Callout title="Prerequisites">

--- a/apps/docs/content/docs/platform-ops/custom-domains.mdx
+++ b/apps/docs/content/docs/platform-ops/custom-domains.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 Custom domains let workspaces use their own URL (e.g. `data.acme.com`) instead of the default `app.useatlas.dev`. Atlas integrates with Railway's custom domain API for provisioning and automatic TLS certificate management via Let's Encrypt.
 
 <Callout type="info" title="SaaS Feature">
-  Custom domains are available on [app.useatlas.dev](https://app.useatlas.dev) Pro and Business plans. Self-hosted deployments configure domains directly in their hosting provider. Workspace admins can self-serve via **Admin Console → Configuration → Custom Domain**. Platform admins retain cross-workspace management at **Admin Console → Platform → Custom Domains**.
+  Custom domains are available on [app.useatlas.dev](https://app.useatlas.dev) Pro and Business plans. Self-hosted deployments configure domains directly in their hosting provider. Workspace admins can self-serve via **Admin Console → Configuration → Custom Domain**. Platform admins retain cross-workspace management at **Admin Console → Platform → Custom Domains**. This feature is part of the Atlas commercial offering — see the [Enterprise (`/ee`) boundary](/architecture/enterprise) for details on the gate and license split.
 </Callout>
 
 <Callout title="Prerequisites">

--- a/apps/docs/content/docs/platform-ops/data-residency.mdx
+++ b/apps/docs/content/docs/platform-ops/data-residency.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 Atlas data residency controls let operators assign workspaces to geographic regions (e.g. `eu-west`, `us-east`). Each region maps to a dedicated database, ensuring tenant data stays in the correct jurisdiction.
 
 <Callout type="info" title="SaaS Feature">
-  Data residency is available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments manage database routing directly.
+  Data residency is available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments manage database routing directly. This feature is part of the Atlas commercial offering — see the [Enterprise (`/ee`) boundary](/architecture/enterprise) for details on the gate and license split.
 </Callout>
 
 <Callout title="Prerequisites">

--- a/apps/docs/content/docs/plugins/authoring-guide.mdx
+++ b/apps/docs/content/docs/plugins/authoring-guide.mdx
@@ -993,3 +993,4 @@ myPlugin({ apiKey: process.env.MY_API_KEY! })
 - [Plugin Composition](/plugins/composition) — How multiple plugins interact (ordering, priority, constraints)
 - [Configuration](/reference/config#plugins) — Registering plugins in `atlas.config.ts`
 - [SQL Validation Pipeline](/security/sql-validation) — How plugin hooks and custom validators fit into validation
+- [Enterprise (`/ee`) boundary](/architecture/enterprise) — License split, the `isEnterpriseEnabled` / `requireEnterprise` API, and how plugins should (and shouldn't) interact with the gate


### PR DESCRIPTION
Closes #1958.

Adds a top-level Enterprise (/ee) boundary doc so plugin authors and self-hosted operators have one place to learn about the AGPL-vs-commercial split, the gate API, and what's actually gated. Today the answer is "read CLAUDE.md, then grep for `requireEnterprise`" — this consolidates that into a real reference page.

## Changes

**New page:** `apps/docs/content/docs/architecture/enterprise.mdx` (added to `architecture/meta.json` after `sandbox` and `content-mode`).

Sections covered:

- **License split** — AGPL core inventory, commercial `/ee` inventory, the "no competing SaaS" clause from `ee/LICENSE` quoted verbatim
- **The API** — `isEnterpriseEnabled()`, `requireEnterprise()` / `requireEnterpriseEffect()`, `EnterpriseError`. Each with a real call site pulled from the codebase (SCIM provenance, IP-allowlist count, backups scheduler, SSO list providers)
- **`EnterpriseError` → HTTP 403** — diagram of how the duck-typed bridge in `lib/effect/hono.ts` maps it without coupling the AGPL core to `@atlas/ee`
- **Gated feature inventory** — table of every literal `requireEnterprise(...)` label in the codebase, grouped by category, each linked to its existing guide
- **Deploy mode and the gate** — full table of `ATLAS_DEPLOY_MODE` × enterprise-enabled outcomes, with the actual `resolveDeployMode` source quoted
- **Patterns** — plugin / route handler / frontend integration
- **See also** — config reference, env vars reference, sandbox companion doc, Metabase comparison, `ee/LICENSE`

## Gated features documented (12)

`sso`, `scim`, `roles`, `ip-allowlist`, `approval-workflows`, `pii-detection`, `compliance`, `audit-retention`, `backups`, `model-routing`, `branding`, plus the inline `EnterpriseError` gate in `admin-domains.ts` (custom domains) and the `isEnterpriseEnabled()`-gated platform ops surfaces (abuse prevention, data residency).

## Cross-linked back to the boundary page (15 guides)

- `guides/enterprise-sso.mdx`
- `guides/scim.mdx`
- `guides/custom-roles.mdx`
- `guides/approval-workflows.mdx`
- `guides/audit-retention.mdx`
- `guides/ip-allowlisting.mdx`
- `guides/pii-masking.mdx`
- `guides/white-labeling.mdx`
- `guides/model-routing.mdx`
- `guides/compliance-reporting.mdx`
- `platform-ops/abuse-prevention.mdx` (added a SaaS Feature callout — none existed before)
- `platform-ops/data-residency.mdx`
- `platform-ops/backups.mdx`
- `platform-ops/custom-domains.mdx`
- `plugins/authoring-guide.mdx` (See Also entry)

Each cross-link is a one-liner inside the existing "SaaS Feature" callout — no structural changes to the host pages, just an appended sentence.

## Test plan

- [x] `bun run lint` — clean
- [x] `bash scripts/check-openapi-drift.sh` — passes
- [x] Verified all `requireEnterprise(...)` labels in the inventory table match real call sites in `ee/src/`
- [x] Verified all 15 cross-links resolve to `/architecture/enterprise`
- [ ] Render the page locally / in preview (will eyeball before merge)