### PR TITLE
docs(www): #1970 — bump legal effective dates to 2026-05-02

### DIFF
--- a/apps/www/src/app/dpa/page.tsx
+++ b/apps/www/src/app/dpa/page.tsx
@@ -203,9 +203,9 @@ export default function DPAPage() {
             no negotiation needed.
           </p>
           <div className="animate-fade-in-up delay-400 mt-5 flex flex-wrap items-center justify-center gap-x-5 gap-y-1 font-mono text-[11px] tracking-wider text-zinc-400 uppercase">
-            <span>effective 2026-01-15</span>
+            <span>effective 2026-05-02</span>
             <span aria-hidden="true">·</span>
-            <span>v2.4</span>
+            <span>v2.5</span>
             <span aria-hidden="true">·</span>
             <span>incorporates: SCCs (2021/914), UK IDTA</span>
           </div>
@@ -226,10 +226,10 @@ export default function DPAPage() {
             <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between md:gap-6">
               <div>
                 <p className="mb-1 font-mono text-[15px] font-semibold text-zinc-100 md:text-base">
-                  DPA-v2.4-pre-signed.pdf
+                  DPA-v2.5-pre-signed.pdf
                 </p>
                 <p className="font-mono text-[11px] tracking-wider text-zinc-400">
-                  Countersigned by Atlas · valid through 2027-01-15 ·
+                  Countersigned by Atlas · valid through 2027-05-02 ·
                   available on request
                 </p>
               </div>

--- a/apps/www/src/app/privacy/page.tsx
+++ b/apps/www/src/app/privacy/page.tsx
@@ -213,9 +213,9 @@ export default function PrivacyPage() {
             it. Aggressively boring on purpose.
           </p>
           <div className="animate-fade-in-up delay-400 mt-5 flex flex-wrap items-center justify-center gap-x-5 gap-y-1 font-mono text-[11px] tracking-wider text-zinc-400 uppercase">
-            <span>effective 2026-01-15</span>
+            <span>effective 2026-05-02</span>
             <span aria-hidden="true">·</span>
-            <span>v3.0</span>
+            <span>v3.1</span>
             <span aria-hidden="true">·</span>
             <span>questions: privacy@useatlas.dev</span>
           </div>

--- a/apps/www/src/app/sla/page.tsx
+++ b/apps/www/src/app/sla/page.tsx
@@ -169,9 +169,9 @@ export default function SLAPage() {
             times, and what happens if we miss.
           </p>
           <div className="animate-fade-in-up delay-400 mt-5 flex flex-wrap items-center justify-center gap-x-5 gap-y-1 font-mono text-[11px] tracking-wider text-zinc-400 uppercase">
-            <span>effective 2026-01-15</span>
+            <span>effective 2026-05-02</span>
             <span aria-hidden="true">·</span>
-            <span>v3.2</span>
+            <span>v3.3</span>
             <span aria-hidden="true">·</span>
             <span>applies to: atlas cloud</span>
           </div>

--- a/apps/www/src/app/terms/page.tsx
+++ b/apps/www/src/app/terms/page.tsx
@@ -194,11 +194,11 @@ export default function TermsPage() {
             right.
           </p>
           <div className="animate-fade-in-up delay-400 mt-5 flex flex-wrap items-center justify-center gap-x-5 gap-y-1 font-mono text-[11px] tracking-wider text-zinc-400 uppercase">
-            <span>effective 2026-01-15</span>
+            <span>effective 2026-05-02</span>
             <span aria-hidden="true">·</span>
-            <span>v4.1</span>
+            <span>v4.2</span>
             <span aria-hidden="true">·</span>
-            <span>last updated 2026-04-02</span>
+            <span>last updated 2026-05-02</span>
           </div>
         </section>
 


### PR DESCRIPTION
## Summary

Bumps effective dates and minor versions on the four legal pages whose prose was reworked across PR #1933, the 1.3.0 Bucket 8 design pass, and PR #1966 — without anyone touching the version stamps. AUP (v1.0 · 2026-04-26) is already fresh and untouched.

| Page | Before | After |
|---|---|---|
| /privacy | v3.0 · 2026-01-15 | **v3.1 · 2026-05-02** |
| /terms   | v4.1 · 2026-01-15 | **v4.2 · 2026-05-02** (also \`last updated\` → 2026-05-02) |
| /dpa     | v2.4 · 2026-01-15 | **v2.5 · 2026-05-02** |
| /sla     | v3.2 · 2026-01-15 | **v3.3 · 2026-05-02** |

This is **option 1** from the issue body — simplest, signals attention without a major bump or per-page changelog.

## Notes

- **DPA pre-signed PDF.** The page surfaces \`DPA-v2.4-pre-signed.pdf · valid through 2027-01-15\` in the request card. Bumped both to \`DPA-v2.5-pre-signed.pdf · valid through 2027-05-02\` to keep the filename in lockstep with the version stamp and preserve the 1-year validity window. If Legal wants a different validity window for the v2.5 cycle, that's a one-line follow-up.
- **No shared primitive.** The version-stamp markup is hardcoded inline in each of the four pages (slightly different secondary metadata in each — questions email on /privacy, last-updated on /terms, SCC reference on /dpa, scope on /sla). Could be a future architecture refactor — a \`<LegalStamp>\` primitive in \`apps/www/src/components/\` would make the next bump a one-line change. Not in scope here.
- **\`last updated\` field.** Only /terms currently has a distinct \`last updated\` field. Adding it to the other three is the optional refinement called out in the prompt — also a candidate for the same future refactor PR.

## Test plan

- [x] \`bun run lint\` passes
- [x] \`bun run type\` passes
- [x] No remaining \`2026-01-15\`, \`v3.0\`, \`v4.1\`, \`v2.4\`, \`v3.2\`, or \`DPA-v2.4\` references in \`apps/www/\`
- [ ] Reviewer eyeballs each of the four pages in dev (\`bun run dev:www\`) to confirm the stamp renders as intended

Closes #1970.