### PR TITLE
feat(api): #1969 — guard SaaS-region platform email to Resend at boot

### DIFF
--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -13,10 +13,13 @@ import {
   Scheduler,
   makeSchedulerLive,
   buildAppLayer,
+  DpaGuardLive,
   type ConfigShape,
   type MigrationShape,
+  type SettingsShape,
 } from "../layers";
 import { createInternalDBTestLayer } from "@atlas/api/lib/db/internal";
+import { DpaInconsistencyError } from "@atlas/api/lib/email/dpa-guard";
 
 // ── Test helpers ────────────────────────────────────────────────────
 
@@ -208,6 +211,105 @@ describe("makeSchedulerLive", () => {
 
     // Disposing should not throw
     await rt.dispose();
+  });
+});
+
+// ── DpaGuardLive (#1969) ───────────────────────────────────────────
+
+const DPA_ENV_KEYS = ["ATLAS_EMAIL_PROVIDER", "ATLAS_SMTP_URL", "RESEND_API_KEY"] as const;
+
+function withCleanDpaEnv<T>(run: () => Promise<T>): Promise<T> {
+  const saved: Record<string, string | undefined> = {};
+  for (const key of DPA_ENV_KEYS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+  return run().finally(() => {
+    for (const key of DPA_ENV_KEYS) {
+      if (saved[key] !== undefined) process.env[key] = saved[key];
+      else delete process.env[key];
+    }
+  });
+}
+
+function settingsTestLayer(): Layer.Layer<Settings> {
+  return Layer.succeed(Settings, { loaded: 0 } satisfies SettingsShape);
+}
+
+describe("DpaGuardLive", () => {
+  test("fails the Layer with DpaInconsistencyError when SaaS + nothing configured", async () => {
+    await withCleanDpaEnv(async () => {
+      const exit = await Effect.runPromiseExit(
+        Effect.void.pipe(
+          Effect.provide(
+            DpaGuardLive.pipe(
+              Layer.provide(Layer.merge(makeTestConfigLayer({ deployMode: "saas" }), settingsTestLayer())),
+            ),
+          ),
+        ),
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+      const cause = Exit.isFailure(exit) ? exit.cause : null;
+      const text = String(cause);
+      expect(text).toContain("DpaInconsistencyError");
+      expect(text).toContain("#1969");
+    });
+  });
+
+  test("succeeds when SaaS + RESEND_API_KEY present", async () => {
+    await withCleanDpaEnv(async () => {
+      process.env.RESEND_API_KEY = "re_test";
+      const exit = await Effect.runPromiseExit(
+        Effect.void.pipe(
+          Effect.provide(
+            DpaGuardLive.pipe(
+              Layer.provide(Layer.merge(makeTestConfigLayer({ deployMode: "saas" }), settingsTestLayer())),
+            ),
+          ),
+        ),
+      );
+      expect(Exit.isSuccess(exit)).toBe(true);
+    });
+  });
+
+  test("succeeds on self-hosted regardless of transport", async () => {
+    await withCleanDpaEnv(async () => {
+      process.env.ATLAS_SMTP_URL = "http://example.com";
+      const exit = await Effect.runPromiseExit(
+        Effect.void.pipe(
+          Effect.provide(
+            DpaGuardLive.pipe(
+              Layer.provide(Layer.merge(makeTestConfigLayer({ deployMode: "self-hosted" }), settingsTestLayer())),
+            ),
+          ),
+        ),
+      );
+      expect(Exit.isSuccess(exit)).toBe(true);
+    });
+  });
+
+  // Regression: DpaInconsistencyError must reach the boot Layer's error
+  // channel (not a tagged channel) so that server.ts's plain `.catch()`
+  // logs and exits — verifies the Effect.try `instanceof Error` mapping
+  // doesn't demote `_tag`.
+  test("preserves _tag through the error channel", async () => {
+    await withCleanDpaEnv(async () => {
+      const exit = await Effect.runPromiseExit(
+        Effect.void.pipe(
+          Effect.provide(
+            DpaGuardLive.pipe(
+              Layer.provide(Layer.merge(makeTestConfigLayer({ deployMode: "saas" }), settingsTestLayer())),
+            ),
+          ),
+        ),
+      );
+      if (!Exit.isFailure(exit)) {
+        throw new Error("expected failure");
+      }
+      const failure = exit.cause._tag === "Fail" ? exit.cause.error : null;
+      expect(failure).toBeInstanceOf(DpaInconsistencyError);
+      expect((failure as DpaInconsistencyError)?._tag).toBe("DpaInconsistencyError");
+    });
   });
 });
 

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -36,6 +36,7 @@ import { Context, Duration, Effect, Fiber, Layer, Schedule } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { InternalDB, makeInternalDBLive, hasInternalDB } from "@atlas/api/lib/db/internal";
+import { assertSaasPlatformEmailIsResend } from "@atlas/api/lib/email/dpa-guard";
 
 const log = createLogger("effect:layers");
 
@@ -733,51 +734,33 @@ export function makeSchedulerLive(
 // ██  DPA Guard Layer (#1969)
 // ══════════════════════════════════════════════════════════════════════
 
-export interface DpaGuardShape {
-  /** No-op marker — guard either passes or fails the boot Layer. */
-  readonly checked: true;
-}
-
-export class DpaGuard extends Context.Tag("DpaGuard")<
-  DpaGuard,
-  DpaGuardShape
->() {}
-
 /**
  * SaaS-region platform email DPA guard (#1969). Enforces that, in SaaS
  * deploy mode, the platform email transport is Resend (the vendor listed
  * on /dpa). Self-hosted is unaffected.
  *
- * Depends on `Config` (for deployMode) and `Settings` (so the in-process
- * settings cache is warm before `getPlatformEmailConfig()` reads it). On
- * violation the Layer fails with `DpaInconsistencyError`, which propagates
- * out of `runtime.runtimeEffect` in server.ts and exits the process — the
- * intended behavior for a DPA misconfig.
+ * Depends on `Config` (for `deployMode`) and `Settings` (so the in-process
+ * settings cache is warm before `getSetting("ATLAS_EMAIL_PROVIDER")` is
+ * read). On violation the Layer fails with `DpaInconsistencyError`, which
+ * propagates out of `runtime.runtimeEffect` in server.ts and exits the
+ * process — the intended behavior for a DPA misconfig.
  *
- * The guard intentionally skips per-org `email_installations` (BYOC) — see
- * the file comment in `lib/email/dpa-guard.ts` for the load-bearing reason.
+ * `Layer.effectDiscard` is correct here over `Layer.effect`: the guard
+ * has no service to expose; it runs once at boot and either passes or
+ * fails the Layer. No phantom Tag, no shape, no consumers.
  */
-export const DpaGuardLive: Layer.Layer<DpaGuard, Error, Config | Settings> = Layer.effect(
-  DpaGuard,
+export const DpaGuardLive: Layer.Layer<never, Error, Config | Settings> = Layer.effectDiscard(
   Effect.gen(function* () {
     const { config } = yield* Config;
     yield* Settings; // sequence after settings cache is loaded
 
     yield* Effect.try({
-      try: () => {
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        const { assertSaasPlatformEmailIsResend } = require("@atlas/api/lib/email/dpa-guard") as {
-          assertSaasPlatformEmailIsResend: (deps?: { isSaas?: () => boolean }) => void;
-        };
+      try: () =>
         assertSaasPlatformEmailIsResend({
           isSaas: () => config.deployMode === "saas",
-        });
-      },
-      catch: (err) =>
-        err instanceof Error ? err : new Error(String(err)),
+        }),
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
     });
-
-    return { checked: true } satisfies DpaGuardShape;
   }),
 );
 
@@ -798,7 +781,7 @@ export const DpaGuardLive: Layer.Layer<DpaGuard, Error, Config | Settings> = Lay
  * Connection and plugin shutdown is handled imperatively in server.ts.
  */
 export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
-  Telemetry | Config | InternalDB | Migration | SemanticSync | Settings | Scheduler | DpaGuard,
+  Telemetry | Config | InternalDB | Migration | SemanticSync | Settings | Scheduler,
   Error
 > {
   const configLayer = Layer.succeed(Config, { config });

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -730,6 +730,58 @@ export function makeSchedulerLive(
 }
 
 // ══════════════════════════════════════════════════════════════════════
+// ██  DPA Guard Layer (#1969)
+// ══════════════════════════════════════════════════════════════════════
+
+export interface DpaGuardShape {
+  /** No-op marker — guard either passes or fails the boot Layer. */
+  readonly checked: true;
+}
+
+export class DpaGuard extends Context.Tag("DpaGuard")<
+  DpaGuard,
+  DpaGuardShape
+>() {}
+
+/**
+ * SaaS-region platform email DPA guard (#1969). Enforces that, in SaaS
+ * deploy mode, the platform email transport is Resend (the vendor listed
+ * on /dpa). Self-hosted is unaffected.
+ *
+ * Depends on `Config` (for deployMode) and `Settings` (so the in-process
+ * settings cache is warm before `getPlatformEmailConfig()` reads it). On
+ * violation the Layer fails with `DpaInconsistencyError`, which propagates
+ * out of `runtime.runtimeEffect` in server.ts and exits the process — the
+ * intended behavior for a DPA misconfig.
+ *
+ * The guard intentionally skips per-org `email_installations` (BYOC) — see
+ * the file comment in `lib/email/dpa-guard.ts` for the load-bearing reason.
+ */
+export const DpaGuardLive: Layer.Layer<DpaGuard, Error, Config | Settings> = Layer.effect(
+  DpaGuard,
+  Effect.gen(function* () {
+    const { config } = yield* Config;
+    yield* Settings; // sequence after settings cache is loaded
+
+    yield* Effect.try({
+      try: () => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { assertSaasPlatformEmailIsResend } = require("@atlas/api/lib/email/dpa-guard") as {
+          assertSaasPlatformEmailIsResend: (deps?: { isSaas?: () => boolean }) => void;
+        };
+        assertSaasPlatformEmailIsResend({
+          isSaas: () => config.deployMode === "saas",
+        });
+      },
+      catch: (err) =>
+        err instanceof Error ? err : new Error(String(err)),
+    });
+
+    return { checked: true } satisfies DpaGuardShape;
+  }),
+);
+
+// ══════════════════════════════════════════════════════════════════════
 // ██  AppLayer — compose the full startup DAG
 // ══════════════════════════════════════════════════════════════════════
 
@@ -746,7 +798,8 @@ export function makeSchedulerLive(
  * Connection and plugin shutdown is handled imperatively in server.ts.
  */
 export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
-  Telemetry | Config | InternalDB | Migration | SemanticSync | Settings | Scheduler
+  Telemetry | Config | InternalDB | Migration | SemanticSync | Settings | Scheduler | DpaGuard,
+  Error
 > {
   const configLayer = Layer.succeed(Config, { config });
   const internalDBLayer = makeInternalDBLive();
@@ -759,6 +812,12 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
   const settingsLayer = SettingsLive;
   const schedulerLayer = makeSchedulerLive(config);
 
+  // DpaGuardLive depends on Config + Settings — provide them so the boot
+  // Layer fails on any SaaS DPA misconfig (#1969) before HTTP starts.
+  const dpaGuardLayer = DpaGuardLive.pipe(
+    Layer.provide(Layer.merge(configLayer, settingsLayer)),
+  );
+
   // Merge all layers. InternalDB is included both directly and as a
   // dependency of migrationLayer — Effect memoizes same-reference Layers.
   return Layer.mergeAll(
@@ -769,5 +828,6 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
     semanticSyncLayer,
     settingsLayer,
     schedulerLayer,
+    dpaGuardLayer,
   );
 }

--- a/packages/api/src/lib/email/__tests__/dpa-guard.test.ts
+++ b/packages/api/src/lib/email/__tests__/dpa-guard.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for the SaaS-region platform email DPA guard (#1969).
+ *
+ * The guard locks SaaS regions to Resend at the **platform** level so the
+ * /dpa sub-processor table stays accurate. Per-org `email_installations`
+ * (BYOC) are deliberately NOT considered — those are the customer's own
+ * vendor relationship, not Atlas's sub-processor. The two "per-org"
+ * cases below are the load-bearing assertions of that distinction.
+ *
+ * Tests use dependency-injection rather than mock.module so the assertion
+ * surface is the function's own contract (no module-graph coupling).
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  assertSaasPlatformEmailIsResend,
+  DpaInconsistencyError,
+  type DpaGuardDeps,
+} from "../dpa-guard";
+
+/** Build a deps stub. Defaults to the safe SaaS+nothing-configured shape (which throws). */
+function deps(overrides: Partial<DpaGuardDeps> = {}): DpaGuardDeps {
+  return {
+    isSaas: () => true,
+    getPlatformProvider: () => null,
+    hasSmtpUrl: () => false,
+    hasResendKey: () => false,
+    ...overrides,
+  };
+}
+
+describe("assertSaasPlatformEmailIsResend", () => {
+  // ── SaaS + platform Resend → ok ────────────────────────────────────
+  it("does not throw when SaaS + platform provider is resend", () => {
+    expect(() =>
+      assertSaasPlatformEmailIsResend(deps({ getPlatformProvider: () => "resend" })),
+    ).not.toThrow();
+  });
+
+  // ── SaaS + platform SendGrid → throws ──────────────────────────────
+  it("throws DpaInconsistencyError when SaaS + platform provider is sendgrid", () => {
+    let captured: unknown;
+    try {
+      assertSaasPlatformEmailIsResend(deps({ getPlatformProvider: () => "sendgrid" }));
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(DpaInconsistencyError);
+    const err = captured as DpaInconsistencyError;
+    expect(err.resolvedProvider).toBe("sendgrid");
+    expect(err.message).toContain("DPA");
+    expect(err.message).toContain("#1969");
+  });
+
+  it("throws when SaaS + platform provider is postmark", () => {
+    expect(() =>
+      assertSaasPlatformEmailIsResend(deps({ getPlatformProvider: () => "postmark" })),
+    ).toThrow(DpaInconsistencyError);
+  });
+
+  // ── SaaS + ATLAS_SMTP_URL → throws ────────────────────────────────
+  it("throws when SaaS + no platform provider but ATLAS_SMTP_URL is set", () => {
+    let captured: unknown;
+    try {
+      assertSaasPlatformEmailIsResend(deps({ hasSmtpUrl: () => true }));
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(DpaInconsistencyError);
+    const err = captured as DpaInconsistencyError;
+    expect(err.resolvedProvider).toBe("smtp-bridge");
+    expect(err.message).toContain("ATLAS_SMTP_URL");
+    expect(err.message).toContain("#1969");
+  });
+
+  // ── SaaS + only RESEND_API_KEY → ok ────────────────────────────────
+  it("does not throw when SaaS + only RESEND_API_KEY env-var is set", () => {
+    expect(() =>
+      assertSaasPlatformEmailIsResend(deps({ hasResendKey: () => true })),
+    ).not.toThrow();
+  });
+
+  // ── SaaS + nothing → throws ────────────────────────────────────────
+  it("throws when SaaS + no platform config and no env transports", () => {
+    let captured: unknown;
+    try {
+      assertSaasPlatformEmailIsResend(deps());
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(DpaInconsistencyError);
+    const err = captured as DpaInconsistencyError;
+    expect(err.resolvedProvider).toBe("none");
+    expect(err.message).toContain("#1969");
+  });
+
+  // ── BYOC distinction (load-bearing) ────────────────────────────────
+  // These two cases codify that per-org `email_installations` are NEVER
+  // considered by the guard. The function does not even take an orgId
+  // and never queries the email-installation store, so the only thing
+  // we can assert here is that platform-level resolution alone decides
+  // the outcome — which is exactly the point.
+
+  it("does not throw when SaaS + per-org config exists AND platform is resend", () => {
+    // Per-org installation existence is irrelevant — the guard never queries it.
+    // Resolution stays at the platform layer (resend), so this passes.
+    expect(() =>
+      assertSaasPlatformEmailIsResend(deps({ getPlatformProvider: () => "resend" })),
+    ).not.toThrow();
+  });
+
+  it("throws when SaaS + per-org config exists but no platform transport", () => {
+    // Even if a customer has BYOC sendgrid wired into their org, the SaaS
+    // platform itself has no sub-processor configured — that's a DPA bug
+    // because Atlas-originated mail (e.g. password reset for unauthenticated
+    // /forgot-password requests) has nowhere to go that's covered by the DPA.
+    let captured: unknown;
+    try {
+      assertSaasPlatformEmailIsResend(deps());
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(DpaInconsistencyError);
+  });
+
+  // ── Self-hosted → never throws ─────────────────────────────────────
+  it("does not throw on self-hosted regardless of provider", () => {
+    expect(() =>
+      assertSaasPlatformEmailIsResend(
+        deps({ isSaas: () => false, getPlatformProvider: () => "sendgrid" }),
+      ),
+    ).not.toThrow();
+
+    expect(() =>
+      assertSaasPlatformEmailIsResend(
+        deps({ isSaas: () => false, hasSmtpUrl: () => true }),
+      ),
+    ).not.toThrow();
+
+    expect(() =>
+      assertSaasPlatformEmailIsResend(deps({ isSaas: () => false })),
+    ).not.toThrow();
+  });
+});

--- a/packages/api/src/lib/email/__tests__/dpa-guard.test.ts
+++ b/packages/api/src/lib/email/__tests__/dpa-guard.test.ts
@@ -1,14 +1,18 @@
 /**
  * Tests for the SaaS-region platform email DPA guard (#1969).
  *
- * The guard locks SaaS regions to Resend at the **platform** level so the
- * /dpa sub-processor table stays accurate. Per-org `email_installations`
- * (BYOC) are deliberately NOT considered — those are the customer's own
- * vendor relationship, not Atlas's sub-processor. The two "per-org"
- * cases below are the load-bearing assertions of that distinction.
+ * Covers two checks performed by `assertSaasPlatformEmailIsResend`:
+ *   1. Stated intent (`ATLAS_EMAIL_PROVIDER` setting) must be "resend" or
+ *      the registry default. Explicit non-Resend → throw.
+ *   2. A Resend key must exist; otherwise an `ATLAS_SMTP_URL` bridge would
+ *      become the actual transport (DPA-violating) or no mail would send.
  *
- * Tests use dependency-injection rather than mock.module so the assertion
- * surface is the function's own contract (no module-graph coupling).
+ * Per-org `email_installations` (BYOC) are deliberately NOT considered —
+ * those are the customer's own vendor relationship, not Atlas's
+ * sub-processor. The two BYOC cases below codify that distinction.
+ *
+ * Tests use dependency injection rather than module mocking so the assertion
+ * surface is the function's own contract.
  */
 
 import { describe, it, expect } from "bun:test";
@@ -18,11 +22,16 @@ import {
   type DpaGuardDeps,
 } from "../dpa-guard";
 
-/** Build a deps stub. Defaults to the safe SaaS+nothing-configured shape (which throws). */
+/**
+ * Build a deps stub. Defaults model a SaaS region whose registry default
+ * `ATLAS_EMAIL_PROVIDER=resend` is in effect but no Resend key has been
+ * pasted yet — i.e. the "fail at boot" baseline. Tests opt in to the
+ * passing shape by setting `hasResendKey: () => true`.
+ */
 function deps(overrides: Partial<DpaGuardDeps> = {}): DpaGuardDeps {
   return {
     isSaas: () => true,
-    getPlatformProvider: () => null,
+    getPlatformProvider: () => "resend",
     hasSmtpUrl: () => false,
     hasResendKey: () => false,
     ...overrides,
@@ -30,15 +39,15 @@ function deps(overrides: Partial<DpaGuardDeps> = {}): DpaGuardDeps {
 }
 
 describe("assertSaasPlatformEmailIsResend", () => {
-  // ── SaaS + platform Resend → ok ────────────────────────────────────
-  it("does not throw when SaaS + platform provider is resend", () => {
+  // ── SaaS + platform Resend with key → ok ───────────────────────────
+  it("does not throw when SaaS + platform=resend AND RESEND_API_KEY set", () => {
     expect(() =>
-      assertSaasPlatformEmailIsResend(deps({ getPlatformProvider: () => "resend" })),
+      assertSaasPlatformEmailIsResend(deps({ hasResendKey: () => true })),
     ).not.toThrow();
   });
 
-  // ── SaaS + platform SendGrid → throws ──────────────────────────────
-  it("throws DpaInconsistencyError when SaaS + platform provider is sendgrid", () => {
+  // ── SaaS + platform SendGrid → throws (intent check) ───────────────
+  it("throws DpaInconsistencyError when SaaS + ATLAS_EMAIL_PROVIDER=sendgrid", () => {
     let captured: unknown;
     try {
       assertSaasPlatformEmailIsResend(deps({ getPlatformProvider: () => "sendgrid" }));
@@ -52,14 +61,26 @@ describe("assertSaasPlatformEmailIsResend", () => {
     expect(err.message).toContain("#1969");
   });
 
-  it("throws when SaaS + platform provider is postmark", () => {
+  it("throws when SaaS + ATLAS_EMAIL_PROVIDER=postmark", () => {
     expect(() =>
       assertSaasPlatformEmailIsResend(deps({ getPlatformProvider: () => "postmark" })),
     ).toThrow(DpaInconsistencyError);
   });
 
-  // ── SaaS + ATLAS_SMTP_URL → throws ────────────────────────────────
-  it("throws when SaaS + no platform provider but ATLAS_SMTP_URL is set", () => {
+  // The silent-failure-hunter scenario: operator stamps non-Resend intent,
+  // forgets the key, but happens to have RESEND_API_KEY in env. The actual
+  // transport is currently Resend, but a future "key paste" flips traffic to
+  // an unlisted vendor. Guard catches the intent at boot.
+  it("throws on non-Resend intent even when RESEND_API_KEY is also set", () => {
+    expect(() =>
+      assertSaasPlatformEmailIsResend(
+        deps({ getPlatformProvider: () => "sendgrid", hasResendKey: () => true }),
+      ),
+    ).toThrow(DpaInconsistencyError);
+  });
+
+  // ── SaaS + ATLAS_SMTP_URL only → throws (transport check) ──────────
+  it("throws when SaaS + intent=resend but no key + ATLAS_SMTP_URL set", () => {
     let captured: unknown;
     try {
       assertSaasPlatformEmailIsResend(deps({ hasSmtpUrl: () => true }));
@@ -73,15 +94,17 @@ describe("assertSaasPlatformEmailIsResend", () => {
     expect(err.message).toContain("#1969");
   });
 
-  // ── SaaS + only RESEND_API_KEY → ok ────────────────────────────────
+  // ── SaaS + RESEND_API_KEY only → ok ────────────────────────────────
+  // This is the env-var fallback path #4 in `sendEmail`. Intent defaults
+  // to "resend" via the settings registry default.
   it("does not throw when SaaS + only RESEND_API_KEY env-var is set", () => {
     expect(() =>
       assertSaasPlatformEmailIsResend(deps({ hasResendKey: () => true })),
     ).not.toThrow();
   });
 
-  // ── SaaS + nothing → throws ────────────────────────────────────────
-  it("throws when SaaS + no platform config and no env transports", () => {
+  // ── SaaS + nothing (default intent, no transport) → throws ─────────
+  it("throws when SaaS + intent=resend but no key and no SMTP_URL", () => {
     let captured: unknown;
     try {
       assertSaasPlatformEmailIsResend(deps());
@@ -95,36 +118,34 @@ describe("assertSaasPlatformEmailIsResend", () => {
   });
 
   // ── BYOC distinction (load-bearing) ────────────────────────────────
-  // These two cases codify that per-org `email_installations` are NEVER
-  // considered by the guard. The function does not even take an orgId
-  // and never queries the email-installation store, so the only thing
-  // we can assert here is that platform-level resolution alone decides
-  // the outcome — which is exactly the point.
+  // Codifies that per-org `email_installations` are NEVER considered.
+  // Structurally enforced: the function takes no `orgId` and never imports
+  // the email-installation store.
 
-  it("does not throw when SaaS + per-org config exists AND platform is resend", () => {
-    // Per-org installation existence is irrelevant — the guard never queries it.
-    // Resolution stays at the platform layer (resend), so this passes.
+  it("does not throw when SaaS + per-org config exists AND platform Resend works", () => {
     expect(() =>
-      assertSaasPlatformEmailIsResend(deps({ getPlatformProvider: () => "resend" })),
+      assertSaasPlatformEmailIsResend(deps({ hasResendKey: () => true })),
     ).not.toThrow();
   });
 
   it("throws when SaaS + per-org config exists but no platform transport", () => {
-    // Even if a customer has BYOC sendgrid wired into their org, the SaaS
-    // platform itself has no sub-processor configured — that's a DPA bug
-    // because Atlas-originated mail (e.g. password reset for unauthenticated
-    // /forgot-password requests) has nowhere to go that's covered by the DPA.
-    let captured: unknown;
-    try {
-      assertSaasPlatformEmailIsResend(deps());
-    } catch (err) {
-      captured = err;
-    }
-    expect(captured).toBeInstanceOf(DpaInconsistencyError);
+    expect(() => assertSaasPlatformEmailIsResend(deps())).toThrow(DpaInconsistencyError);
+  });
+
+  // ── Precedence ─────────────────────────────────────────────────────
+  it("does not throw when SaaS + platform Resend + key + ATLAS_SMTP_URL also set", () => {
+    // Platform Resend wins over the SMTP bridge in `sendEmail`. A future
+    // refactor that reorders the checks (e.g. SMTP-first to "fail fast")
+    // would silently start failing this valid SaaS shape.
+    expect(() =>
+      assertSaasPlatformEmailIsResend(
+        deps({ hasResendKey: () => true, hasSmtpUrl: () => true }),
+      ),
+    ).not.toThrow();
   });
 
   // ── Self-hosted → never throws ─────────────────────────────────────
-  it("does not throw on self-hosted regardless of provider", () => {
+  it("does not throw on self-hosted regardless of provider or transport", () => {
     expect(() =>
       assertSaasPlatformEmailIsResend(
         deps({ isSaas: () => false, getPlatformProvider: () => "sendgrid" }),

--- a/packages/api/src/lib/email/delivery.ts
+++ b/packages/api/src/lib/email/delivery.ts
@@ -105,8 +105,14 @@ export async function getEmailTransport(
 /**
  * Resolve the platform-level email provider from the settings registry.
  * Returns a transport-compatible object or null when no API key is available.
+ *
+ * #1969 — exported so the SaaS DPA guard (`lib/email/dpa-guard.ts`) can read
+ * the platform-level resolution. The guard skips per-org `email_installations`
+ * because BYOC is the customer's own vendor relationship, not Atlas's
+ * sub-processor — only platform-level transports (paths #2–#4 in `sendEmail`)
+ * count toward the DPA sub-processor table on /dpa.
  */
-function getPlatformEmailConfig(): EmailTransport | null {
+export function getPlatformEmailConfig(): EmailTransport | null {
   const raw = getSetting("ATLAS_EMAIL_PROVIDER");
   if (!raw) return null;
   if (!isEmailProvider(raw)) {

--- a/packages/api/src/lib/email/delivery.ts
+++ b/packages/api/src/lib/email/delivery.ts
@@ -105,14 +105,8 @@ export async function getEmailTransport(
 /**
  * Resolve the platform-level email provider from the settings registry.
  * Returns a transport-compatible object or null when no API key is available.
- *
- * #1969 — exported so the SaaS DPA guard (`lib/email/dpa-guard.ts`) can read
- * the platform-level resolution. The guard skips per-org `email_installations`
- * because BYOC is the customer's own vendor relationship, not Atlas's
- * sub-processor — only platform-level transports (paths #2–#4 in `sendEmail`)
- * count toward the DPA sub-processor table on /dpa.
  */
-export function getPlatformEmailConfig(): EmailTransport | null {
+function getPlatformEmailConfig(): EmailTransport | null {
   const raw = getSetting("ATLAS_EMAIL_PROVIDER");
   if (!raw) return null;
   if (!isEmailProvider(raw)) {

--- a/packages/api/src/lib/email/dpa-guard.ts
+++ b/packages/api/src/lib/email/dpa-guard.ts
@@ -15,19 +15,39 @@
  * list, so the guard intentionally never reads `getEmailTransport(orgId)` or
  * any per-org row.
  *
- * Resolution order (mirrors `sendEmail` paths #2–#4 only):
- *   1. Platform settings registry — must resolve to "resend".
- *   2. `ATLAS_SMTP_URL` env webhook — FAIL (could route anywhere).
- *   3. `RESEND_API_KEY` env-var fallback — OK (Resend by name).
- *   4. None of the above — FAIL (SaaS region with no transport is its own bug).
+ * Two checks, in order — both must pass for SaaS to boot:
  *
- * The guard is wired into `buildAppLayer` via `DpaGuardLive`; throwing here
- * fails the boot Layer and exits the process, surfacing the misconfig before
- * any customer email is sent.
+ *   1. **Stated intent** (`ATLAS_EMAIL_PROVIDER` setting). Read via
+ *      `getSetting()` so that DB-cache overrides from the admin UI count
+ *      alongside env vars. Compared against the literal `"resend"` —
+ *      anything else (including the legitimate registry default `"resend"`)
+ *      is fine. Reading the raw setting (rather than `getPlatformEmailConfig`)
+ *      is deliberate: an operator who flips `ATLAS_EMAIL_PROVIDER=sendgrid`
+ *      without yet pasting `SENDGRID_API_KEY` still has *stated intent* that
+ *      violates the DPA. Catching that at boot prevents a later "key paste"
+ *      from silently flipping traffic to a vendor not on /dpa.
+ *
+ *   2. **Resolved transport**. `sendEmail`'s fallback order is platform-config
+ *      → `ATLAS_SMTP_URL` → `RESEND_API_KEY` → log. The DPA-safe outcomes are
+ *      "platform-resend with key" and "RESEND_API_KEY fallback" — both are
+ *      recognised by `hasResendKey()` (the platform Resend config reads its
+ *      key via `getSetting("RESEND_API_KEY")`, which itself falls through to
+ *      env). If no Resend key exists, `ATLAS_SMTP_URL` would route through
+ *      an arbitrary bridge → FAIL. If nothing is configured at all, mail is
+ *      silently dropped → FAIL.
+ *
+ * The guard is wired into `buildAppLayer` via the `Layer.effectDiscard`
+ * built from `assertSaasPlatformEmailIsResendEffect`; throwing here fails
+ * the boot Layer and exits the process, surfacing the misconfig before any
+ * customer email is sent.
  */
 
 import { Data } from "effect";
-import { getPlatformEmailConfig } from "./delivery";
+import { getSetting } from "@atlas/api/lib/settings";
+import { EMAIL_PROVIDERS, type EmailProvider } from "@atlas/api/lib/integrations/types";
+
+/** Resolved-transport discriminator carried by `DpaInconsistencyError`. */
+export type ResolvedProvider = EmailProvider | "smtp-bridge" | "none";
 
 /**
  * Thrown when a SaaS region's platform email transport doesn't match the
@@ -35,21 +55,33 @@ import { getPlatformEmailConfig } from "./delivery";
  */
 export class DpaInconsistencyError extends Data.TaggedError("DpaInconsistencyError")<{
   readonly message: string;
-  readonly resolvedProvider: string;
+  readonly resolvedProvider: ResolvedProvider;
 }> {}
 
-/** Injectable dependencies — defaults read from process.env + the settings registry. */
+/**
+ * Injectable dependencies. `isSaas` has no default — callers must pass it
+ * matching the **resolved config's** `deployMode`, not the env var. The
+ * env var and the resolved value can diverge (config-file overrides, deploy
+ * mode `auto`, etc.) and this guard is too important to silently no-op on
+ * that mismatch.
+ */
 export interface DpaGuardDeps {
   isSaas: () => boolean;
-  /** Resolved platform email provider name, or null if no platform config is active. */
-  getPlatformProvider: () => string | null;
+  /** Stated platform provider intent — raw `ATLAS_EMAIL_PROVIDER` setting, validated against `EMAIL_PROVIDERS`. */
+  getPlatformProvider: () => EmailProvider | null;
   hasSmtpUrl: () => boolean;
   hasResendKey: () => boolean;
 }
 
-const defaultDeps: DpaGuardDeps = {
-  isSaas: () => process.env.ATLAS_DEPLOY_MODE === "saas",
-  getPlatformProvider: () => getPlatformEmailConfig()?.provider ?? null,
+const PROVIDER_SET: ReadonlySet<string> = new Set(EMAIL_PROVIDERS);
+
+const productionDeps: Omit<DpaGuardDeps, "isSaas"> = {
+  getPlatformProvider: () => {
+    const raw = getSetting("ATLAS_EMAIL_PROVIDER");
+    if (!raw) return null;
+    if (!PROVIDER_SET.has(raw)) return null;
+    return raw as EmailProvider;
+  },
   hasSmtpUrl: () => Boolean(process.env.ATLAS_SMTP_URL),
   hasResendKey: () => Boolean(process.env.RESEND_API_KEY),
 };
@@ -62,46 +94,55 @@ const ISSUE_REF = "#1969";
  *
  * Throws `DpaInconsistencyError` on violation. Pure / synchronous so the
  * boot Layer can short-circuit before any plugin or HTTP listener starts.
+ *
+ * `isSaas` is required (no default). All other deps fall back to production
+ * implementations that read from the settings registry and `process.env`.
  */
 export function assertSaasPlatformEmailIsResend(
-  overrides: Partial<DpaGuardDeps> = {},
+  deps: { isSaas: () => boolean } & Partial<Omit<DpaGuardDeps, "isSaas">>,
 ): void {
-  const d: DpaGuardDeps = { ...defaultDeps, ...overrides };
+  const d: DpaGuardDeps = { ...productionDeps, ...deps };
 
   if (!d.isSaas()) return;
 
-  const platformProvider = d.getPlatformProvider();
-  if (platformProvider) {
-    if (platformProvider !== "resend") {
-      throw new DpaInconsistencyError({
-        message:
-          `SaaS DPA constraint violated: platform email provider resolved to "${platformProvider}", ` +
-          `but the /dpa sub-processor table lists only Resend. ` +
-          `Either revert ATLAS_EMAIL_PROVIDER to "resend" (preferred) or amend the DPA before changing vendors. ` +
-          `See ${ISSUE_REF}.`,
-        resolvedProvider: platformProvider,
-      });
-    }
-    return;
+  // 1. Intent check — operator-explicit non-Resend is a DPA violation
+  //    even when the corresponding API key isn't pasted yet.
+  const intent = d.getPlatformProvider();
+  if (intent && intent !== "resend") {
+    throw new DpaInconsistencyError({
+      message:
+        `SaaS DPA constraint violated: ATLAS_EMAIL_PROVIDER is "${intent}", ` +
+        `but the /dpa sub-processor table lists only Resend. ` +
+        `Either revert ATLAS_EMAIL_PROVIDER to "resend" (preferred) or amend the DPA before changing vendors. ` +
+        `See ${ISSUE_REF}.`,
+      resolvedProvider: intent,
+    });
   }
 
+  // 2. Transport check — having a Resend key (env or settings) means the
+  //    actual sender is Resend regardless of `ATLAS_SMTP_URL` (the platform
+  //    config wins over the SMTP bridge in `sendEmail`).
+  if (d.hasResendKey()) return;
+
+  // No Resend key — SMTP bridge would be the actual transport. Anything
+  // could be on the other end, so the DPA can't speak to it.
   if (d.hasSmtpUrl()) {
     throw new DpaInconsistencyError({
       message:
         `SaaS DPA constraint violated: ATLAS_SMTP_URL routes to an arbitrary webhook bridge ` +
         `whose downstream vendor cannot be assumed to be Resend. ` +
-        `Remove ATLAS_SMTP_URL in SaaS regions, or amend the DPA to list the bridge's vendor. ` +
+        `Set RESEND_API_KEY in addition (so platform config takes precedence) or remove ATLAS_SMTP_URL. ` +
         `See ${ISSUE_REF}.`,
       resolvedProvider: "smtp-bridge",
     });
   }
 
-  if (d.hasResendKey()) return;
-
+  // No transport at all — Atlas-originated mail (password reset, etc.)
+  // would silently drop. Fail boot to surface the misconfig.
   throw new DpaInconsistencyError({
     message:
       `SaaS region has no platform email transport configured. ` +
-      `Set RESEND_API_KEY (matches the /dpa sub-processor table) or configure ATLAS_EMAIL_PROVIDER=resend. ` +
+      `Set RESEND_API_KEY (matches the /dpa sub-processor table). ` +
       `Per-org BYOC email installations don't satisfy this requirement — Atlas-originated mail ` +
       `(e.g. /forgot-password before a session exists) needs a platform-level transport. ` +
       `See ${ISSUE_REF}.`,

--- a/packages/api/src/lib/email/dpa-guard.ts
+++ b/packages/api/src/lib/email/dpa-guard.ts
@@ -1,0 +1,110 @@
+/**
+ * SaaS-region platform email DPA guard (#1969).
+ *
+ * The DPA sub-processor table on /dpa lists Resend as Atlas's email vendor.
+ * That's accurate for Atlas Cloud today because the platform falls back to
+ * Resend via `RESEND_API_KEY`. The risk this guard locks down is a future
+ * SaaS operator flipping `ATLAS_EMAIL_PROVIDER` (or `ATLAS_SMTP_URL`) at
+ * the **platform** level without amending the DPA — the customer-facing
+ * sub-processor list would then be silently inaccurate.
+ *
+ * IMPORTANT — what this guard does NOT consider: per-org `email_installations`
+ * (BYOC). When a customer brings their own SendGrid / Postmark / SMTP creds
+ * for their own org, Atlas isn't a party to that vendor relationship — the
+ * customer is. The DPA correctly omits BYOC vendors from Atlas's sub-processor
+ * list, so the guard intentionally never reads `getEmailTransport(orgId)` or
+ * any per-org row.
+ *
+ * Resolution order (mirrors `sendEmail` paths #2–#4 only):
+ *   1. Platform settings registry — must resolve to "resend".
+ *   2. `ATLAS_SMTP_URL` env webhook — FAIL (could route anywhere).
+ *   3. `RESEND_API_KEY` env-var fallback — OK (Resend by name).
+ *   4. None of the above — FAIL (SaaS region with no transport is its own bug).
+ *
+ * The guard is wired into `buildAppLayer` via `DpaGuardLive`; throwing here
+ * fails the boot Layer and exits the process, surfacing the misconfig before
+ * any customer email is sent.
+ */
+
+import { Data } from "effect";
+import { getPlatformEmailConfig } from "./delivery";
+
+/**
+ * Thrown when a SaaS region's platform email transport doesn't match the
+ * DPA sub-processor table. Carries the resolved provider for diagnostics.
+ */
+export class DpaInconsistencyError extends Data.TaggedError("DpaInconsistencyError")<{
+  readonly message: string;
+  readonly resolvedProvider: string;
+}> {}
+
+/** Injectable dependencies — defaults read from process.env + the settings registry. */
+export interface DpaGuardDeps {
+  isSaas: () => boolean;
+  /** Resolved platform email provider name, or null if no platform config is active. */
+  getPlatformProvider: () => string | null;
+  hasSmtpUrl: () => boolean;
+  hasResendKey: () => boolean;
+}
+
+const defaultDeps: DpaGuardDeps = {
+  isSaas: () => process.env.ATLAS_DEPLOY_MODE === "saas",
+  getPlatformProvider: () => getPlatformEmailConfig()?.provider ?? null,
+  hasSmtpUrl: () => Boolean(process.env.ATLAS_SMTP_URL),
+  hasResendKey: () => Boolean(process.env.RESEND_API_KEY),
+};
+
+const ISSUE_REF = "#1969";
+
+/**
+ * Enforce: in SaaS deploy mode, the platform email transport must be Resend.
+ * Self-hosted is unaffected — operators retain full provider freedom.
+ *
+ * Throws `DpaInconsistencyError` on violation. Pure / synchronous so the
+ * boot Layer can short-circuit before any plugin or HTTP listener starts.
+ */
+export function assertSaasPlatformEmailIsResend(
+  overrides: Partial<DpaGuardDeps> = {},
+): void {
+  const d: DpaGuardDeps = { ...defaultDeps, ...overrides };
+
+  if (!d.isSaas()) return;
+
+  const platformProvider = d.getPlatformProvider();
+  if (platformProvider) {
+    if (platformProvider !== "resend") {
+      throw new DpaInconsistencyError({
+        message:
+          `SaaS DPA constraint violated: platform email provider resolved to "${platformProvider}", ` +
+          `but the /dpa sub-processor table lists only Resend. ` +
+          `Either revert ATLAS_EMAIL_PROVIDER to "resend" (preferred) or amend the DPA before changing vendors. ` +
+          `See ${ISSUE_REF}.`,
+        resolvedProvider: platformProvider,
+      });
+    }
+    return;
+  }
+
+  if (d.hasSmtpUrl()) {
+    throw new DpaInconsistencyError({
+      message:
+        `SaaS DPA constraint violated: ATLAS_SMTP_URL routes to an arbitrary webhook bridge ` +
+        `whose downstream vendor cannot be assumed to be Resend. ` +
+        `Remove ATLAS_SMTP_URL in SaaS regions, or amend the DPA to list the bridge's vendor. ` +
+        `See ${ISSUE_REF}.`,
+      resolvedProvider: "smtp-bridge",
+    });
+  }
+
+  if (d.hasResendKey()) return;
+
+  throw new DpaInconsistencyError({
+    message:
+      `SaaS region has no platform email transport configured. ` +
+      `Set RESEND_API_KEY (matches the /dpa sub-processor table) or configure ATLAS_EMAIL_PROVIDER=resend. ` +
+      `Per-org BYOC email installations don't satisfy this requirement — Atlas-originated mail ` +
+      `(e.g. /forgot-password before a session exists) needs a platform-level transport. ` +
+      `See ${ISSUE_REF}.`,
+    resolvedProvider: "none",
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `assertSaasPlatformEmailIsResend()` in `packages/api/src/lib/email/dpa-guard.ts`, wired into `buildAppLayer` via a new `DpaGuardLive` layer. In SaaS deploy mode, the platform email transport must resolve to Resend (the vendor named in the DPA sub-processor table on `/dpa`); SendGrid/Postmark, an `ATLAS_SMTP_URL` webhook bridge, or no transport at all fail the boot Layer with `DpaInconsistencyError` (a `Data.TaggedError`) so the process exits before mail is sent.
- The guard intentionally skips per-org `email_installations` (BYOC). Per-org credentials are the customer's own vendor relationship, not Atlas's sub-processor — the DPA correctly omits them. The load-bearing test pair (`SaaS + per-org + platform Resend → ok`, `SaaS + per-org + no platform → throws`) codifies that distinction; the file header in `dpa-guard.ts` and a comment on the now-exported `getPlatformEmailConfig()` document the reasoning so future maintainers don't accidentally extend the guard to BYOC.
- Self-hosted operators are unaffected — the guard returns early when `config.deployMode !== "saas"`.

Closes #1969.

## Test plan

- [x] TDD red → green: `bun test src/lib/email/__tests__/dpa-guard.test.ts` (9 cases — SaaS+Resend ok, SaaS+SendGrid throws with assertion on error message + `resolvedProvider`, SaaS+SMTP_URL throws, SaaS+only RESEND_API_KEY ok, SaaS+nothing throws, two per-org BYOC cases, self-hosted+anything ok)
- [x] `--affected` 11 files all pass (dpa-guard, delivery, layers, admin-email-provider-route, scheduler, etc.)
- [x] Full `bun run test` exit 0
- [x] `bun run lint` clean
- [x] `bun x tsgo --noEmit` clean
- [x] `bun x syncpack lint` — no issues
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — 463 files verified
- [x] `bash scripts/check-railway-watch.sh` — all COPY sources covered

## Out of scope (per #1969 narrowing note)

- Per-org `email_installations` (BYOC) — see file header for reasoning.
- DPA copy edits on `/dpa` or `/privacy` — DPA is correct today; this PR is purely runtime enforcement.
- `apps/docs/content/docs/deployment/email.mdx` doesn't exist; no docs edit.