### PR TITLE
fix(api): prod-audit — add requestId to onboarding 500

### DIFF
--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -688,7 +688,7 @@ onboarding.openapi(
         dbType = detectDBType(url);
       } catch (err) {
         log.error({ err: errorMessage(err), requestId }, "Demo datasource URL has unsupported scheme");
-        return c.json({ error: "invalid_datasource", message: "Demo datasource URL has an unsupported scheme." }, 500);
+        return c.json({ error: "invalid_datasource", message: "Demo datasource URL has an unsupported scheme.", requestId }, 500);
       }
 
       // Encrypt and persist with status='published'


### PR DESCRIPTION
Single-line fix from /prod-audit Part A (Observability).

`onboarding.ts:691` was the only 500-with-no-requestId across `packages/api/src/` (52 of 53 already correct). requestId was already in scope — just needed to be included in the JSON body so log correlation works for the user seeing the error.

Closes the only Part A HIGH that was a one-line fix. Other Part A findings (scheduler OTel spans, plugin lifecycle spans, abuse counter metric export) are filed as separate issues.