### PR TITLE
fix(web): add /forgot-password + /reset-password to proxy authRoutes (prod-active bug)

### DIFF
--- a/packages/web/src/proxy.ts
+++ b/packages/web/src/proxy.ts
@@ -22,7 +22,7 @@ const authMode = process.env.NEXT_PUBLIC_ATLAS_AUTH_MODE ?? "";
 const VALID_MODES = new Set<string>(ATLAS_MODES);
 
 /** Routes that only unauthenticated users should see (exact match). */
-const authRoutes = ["/signup", "/login"];
+const authRoutes = ["/signup", "/login", "/forgot-password", "/reset-password"];
 
 /** Routes that are always accessible regardless of auth state. */
 const publicPrefixes = ["/demo", "/shared", "/report", "/api", "/_next"];


### PR DESCRIPTION
## Critical — password reset flow broken in prod

`/prod-audit` live-curl verification caught this:

```
$ curl -sI https://app.useatlas.dev/forgot-password
HTTP/2 307
location: /login
```

Anyone who clicks 'Forgot password?' on /login right now is redirected back to /login. The password reset flow we shipped in #1955 is non-functional in production.

## Root cause

`packages/web/src/proxy.ts:25` lists only `/signup` and `/login` as exact-match auth routes that unauthenticated users can reach. The default-deny logic at line 76 (`if (!sessionToken && !isAuthRoute(pathname)) → redirect to /login`) catches `/forgot-password` and `/reset-password` — both deliberate unauthenticated entry points (one for the form, one for the email-issued token).

Two callers link to `/forgot-password`:
- `packages/web/src/app/login/page.tsx:240` (the conditional 'Forgot password?' link)
- `packages/web/src/app/reset-password/page.tsx:214` ('Request a new reset link' fallback)

Both work after this fix.

## Fix

One-line addition to `authRoutes`. Both routes already exist as pages and contain server-side logic that handles unauthenticated access correctly (the proxy was the only thing rejecting them).

## Test plan

- [x] Verify the bug live: `curl -sI https://app.useatlas.dev/forgot-password` → 307 to /login (confirmed before fix)
- [ ] After merge + deploy: re-curl, expect 200
- [ ] Manual: visit /login → click 'Forgot password?' → see the form (not a redirect loop)

## Why this matters / how it was missed

The /www-audit + /docs-audit + /prod-audit chain:
- /www-audit: said docs need this page (filed #1957, shipped #1955)
- /docs-audit: verified page exists and docs are accurate
- /prod-audit Part E (live-curl): caught the actual production redirect loop

Without the live-curl check, this would have stayed broken until a customer forgot their password and reported it. Vindicates the /prod-audit live-surface-cross-check pattern.

## Closes

No issue tracked yet — emergency direct-to-PR. The /www-audit follow-up #1985 (api-apac availability) was the closest precedent for 'live-surface verification surfaces something the static audit missed.'