### PR TITLE
fix(api,web,www): #1984 — add HSTS/CSP/frame/nosniff to auth-bearing surfaces

### DIFF
--- a/apps/docs/content/docs/security/meta.json
+++ b/apps/docs/content/docs/security/meta.json
@@ -5,6 +5,7 @@
   "pages": [
     "sql-validation",
     "row-level-security",
+    "security-headers",
     "two-factor-auth"
   ]
 }

--- a/apps/docs/content/docs/security/security-headers.mdx
+++ b/apps/docs/content/docs/security/security-headers.mdx
@@ -13,17 +13,42 @@ Atlas serves the following security headers on every response:
 | `X-Frame-Options`            | `DENY` (skipped on `/widget*`)  | `DENY` (CSP `frame-ancestors *` overrides on `/shared/:token/embed`) | `DENY`                                  |
 | `X-Content-Type-Options`     | `nosniff`                       | `nosniff`                                      | `nosniff`                               |
 | `Referrer-Policy`            | `strict-origin-when-cross-origin` | same                                         | same                                    |
-| `Content-Security-Policy`    | `default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'` | broader policy that allows `'self'` plus inline scripts/styles for Next.js hydration | similar |
+| `Content-Security-Policy`    | `default-src 'none'; style-src 'unsafe-inline'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'` | broader policy that allows `'self'` plus inline scripts/styles for Next.js hydration | similar |
 
 The headers come from three places:
 
-- **`packages/api/src/api/index.ts`** — Hono middleware applied to every request. Skips `X-Frame-Options` and the strict CSP for `/widget*` so customers can iframe-embed the widget from any origin.
+- **`packages/api/src/api/index.ts`** — Hono middleware applied to every request. Skips `X-Frame-Options` and the strict CSP for `/widget`, `/widget/*`, `/widget.js`, and `/widget.d.ts` so customers can iframe-embed the widget from any origin.
 - **`packages/web/next.config.ts`** — `headers()` config for the app. The `/shared/:token/embed` route overrides `frame-ancestors` to `*`; everywhere else inherits `frame-ancestors 'self'`.
 - **`apps/www/serve.ts`** — Bun static-server that fronts the `next export` output. The marketing CSP is intentionally simpler since the site is fully static.
 
-## HSTS preload
+## Verifying the headers
 
-The header advertises eligibility for the [HSTS preload list](https://hstspreload.org). Submission is a separate operator action — adding the header alone does not enrol your domain. Self-hosted operators on a custom domain should drop the `preload` token until they are ready to commit, since preload is effectively irreversible.
+Confirm any deployed surface with `curl -I`:
+
+```bash
+curl -sI https://api.useatlas.dev/api/health \
+  | grep -iE 'strict-transport|content-security-policy|x-frame|x-content-type|referrer-policy'
+```
+
+If the headers are missing, the request is most likely terminating at a reverse proxy or CDN that strips them — check the proxy config before assuming Atlas is broken.
+
+## HSTS
+
+<Callout type="warn">
+  HSTS preload is **effectively irreversible**. Once your domain is in the [browser preload list](https://hstspreload.org), every Chrome/Firefox/Safari install pins HTTPS for that domain until it ships an updated list — typically 12+ weeks per browser, and removal requires submitting to the [removal form](https://hstspreload.org/removal/) and waiting out the same cycle.
+
+  **Self-hosted operators on a custom domain** should drop the `preload` token from `Strict-Transport-Security` until they are sure they will never need to serve HTTP from that domain again. Edit the constant in `packages/api/src/api/index.ts`, `packages/web/next.config.ts`, and `apps/www/serve.ts`. Submission to hstspreload.org is a separate manual step — adding the header alone does not enrol your domain.
+</Callout>
+
+HSTS is silently ignored on `http://` connections — browsers only honour the header when it arrives over a valid TLS connection. If you are testing locally over HTTP and "the header isn't doing anything," that is expected; deploy behind TLS to verify.
+
+### Rolling back HSTS
+
+If you set `max-age=31536000` and need to back out (e.g. an internal subdomain that needs to fall back to HTTP):
+
+1. Change `max-age` to `0` (and remove `includeSubDomains` if the issue is on a subdomain). This tells browsers to forget the pin on next visit.
+2. Wait out the cached TTL on every client. There is no way to push the reset; clients update only when they next hit the host.
+3. If the domain is in the preload list, also submit the [hstspreload.org removal form](https://hstspreload.org/removal/) and expect a months-long cycle before all browsers ship an updated list.
 
 ## Customising CSP for self-hosted deployments
 

--- a/apps/docs/content/docs/security/security-headers.mdx
+++ b/apps/docs/content/docs/security/security-headers.mdx
@@ -1,0 +1,46 @@
+---
+title: Security Headers
+description: HSTS, CSP, and frame protection on the Atlas API and web surfaces.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+Atlas serves the following security headers on every response:
+
+| Header                       | API (`api.useatlas.dev`)        | App (`app.useatlas.dev`)                       | www (`www.useatlas.dev`)                |
+| ---------------------------- | ------------------------------- | ---------------------------------------------- | --------------------------------------- |
+| `Strict-Transport-Security`  | `max-age=31536000; includeSubDomains; preload` | same                                          | same                                    |
+| `X-Frame-Options`            | `DENY` (skipped on `/widget*`)  | `DENY` (CSP `frame-ancestors *` overrides on `/shared/:token/embed`) | `DENY`                                  |
+| `X-Content-Type-Options`     | `nosniff`                       | `nosniff`                                      | `nosniff`                               |
+| `Referrer-Policy`            | `strict-origin-when-cross-origin` | same                                         | same                                    |
+| `Content-Security-Policy`    | `default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'` | broader policy that allows `'self'` plus inline scripts/styles for Next.js hydration | similar |
+
+The headers come from three places:
+
+- **`packages/api/src/api/index.ts`** — Hono middleware applied to every request. Skips `X-Frame-Options` and the strict CSP for `/widget*` so customers can iframe-embed the widget from any origin.
+- **`packages/web/next.config.ts`** — `headers()` config for the app. The `/shared/:token/embed` route overrides `frame-ancestors` to `*`; everywhere else inherits `frame-ancestors 'self'`.
+- **`apps/www/serve.ts`** — Bun static-server that fronts the `next export` output. The marketing CSP is intentionally simpler since the site is fully static.
+
+## HSTS preload
+
+The header advertises eligibility for the [HSTS preload list](https://hstspreload.org). Submission is a separate operator action — adding the header alone does not enrol your domain. Self-hosted operators on a custom domain should drop the `preload` token until they are ready to commit, since preload is effectively irreversible.
+
+## Customising CSP for self-hosted deployments
+
+If you add a third-party script to the marketing site or the app (analytics, error reporting, customer chat), you must extend the CSP `script-src` and `connect-src` directives so the browser does not block it. Edit:
+
+- `packages/web/next.config.ts` — the `csp` constant inside `headers()`
+- `apps/www/serve.ts` — the `WWW_CSP` constant
+- `packages/api/src/api/index.ts` — only if you serve HTML from the API (rare)
+
+After changing CSP, hit your deployed surface and watch the browser devtools "Console" tab for `Refused to load … because it violates the following Content Security Policy directive` warnings — those are the hosts you need to allowlist.
+
+<Callout type="warn">
+  Two `Content-Security-Policy` headers on a single response are intersected by the browser (strictest wins). The Next.js `/shared/:token/embed` override emits a *single* combined CSP — do not add a second route entry that also sets CSP, or your override will collapse to the global value.
+</Callout>
+
+## Embedding the widget under CSP
+
+The widget host route (`/widget`) on the API explicitly emits `Content-Security-Policy: frame-ancestors *`. The global API middleware skips its X-Frame-Options + strict CSP for any path under `/widget`, so embedded iframes continue to load from any origin.
+
+If you self-host behind a reverse proxy that adds its own headers, make sure the proxy does **not** force `X-Frame-Options: DENY` on `/widget*` — that would silently break customer embeds. CSP `frame-ancestors *` takes precedence over `X-Frame-Options` per the [W3C CSP spec](https://www.w3.org/TR/CSP3/#frame-ancestors-and-frame-options), but only when the widget's CSP actually reaches the browser.

--- a/apps/www/serve.ts
+++ b/apps/www/serve.ts
@@ -3,7 +3,30 @@ import { join } from "path";
 const OUT_DIR = join(import.meta.dir, "out");
 const port = parseInt(process.env.PORT || "8080");
 
+// Marketing site is fully static — no inline event handlers, but Next.js
+// still emits inline `__NEXT_DATA__` and a runtime hydration script, so
+// `script-src` keeps `'unsafe-inline'`. Tailwind's preflight + utility
+// classes inline a few `<style>` tags during hydration, so `style-src`
+// keeps `'unsafe-inline'` too. Operators who add analytics or third-party
+// scripts will need to extend this in their own deploy.
+const WWW_CSP = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: https:",
+  "font-src 'self' data:",
+  "connect-src 'self' https:",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "object-src 'none'",
+].join("; ");
+
 const SECURITY_HEADERS: Record<string, string> = {
+  // HSTS — pin HTTPS for a year. `preload` advertises eligibility for the
+  // browser preload list; submission is a separate operator decision.
+  "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+  "Content-Security-Policy": WWW_CSP,
   "X-Frame-Options": "DENY",
   "X-Content-Type-Options": "nosniff",
   "Referrer-Policy": "strict-origin-when-cross-origin",

--- a/apps/www/serve.ts
+++ b/apps/www/serve.ts
@@ -3,12 +3,10 @@ import { join } from "path";
 const OUT_DIR = join(import.meta.dir, "out");
 const port = parseInt(process.env.PORT || "8080");
 
-// Marketing site is fully static — no inline event handlers, but Next.js
-// still emits inline `__NEXT_DATA__` and a runtime hydration script, so
-// `script-src` keeps `'unsafe-inline'`. Tailwind's preflight + utility
-// classes inline a few `<style>` tags during hydration, so `style-src`
-// keeps `'unsafe-inline'` too. Operators who add analytics or third-party
-// scripts will need to extend this in their own deploy.
+// `script-src 'unsafe-inline'` is required by Next.js's `__NEXT_DATA__` and
+// hydration runtime. `style-src 'unsafe-inline'` is required by Next.js's
+// inlined critical CSS. Operators who add analytics or third-party scripts
+// will need to extend this in their own deploy.
 const WWW_CSP = [
   "default-src 'self'",
   "script-src 'self' 'unsafe-inline'",
@@ -23,8 +21,6 @@ const WWW_CSP = [
 ].join("; ");
 
 const SECURITY_HEADERS: Record<string, string> = {
-  // HSTS — pin HTTPS for a year. `preload` advertises eligibility for the
-  // browser preload list; submission is a separate operator decision.
   "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
   "Content-Security-Policy": WWW_CSP,
   "X-Frame-Options": "DENY",
@@ -159,7 +155,9 @@ Bun.serve({
     const { pathname } = url;
 
     if (pathname === "/health") {
-      return new Response("ok", { headers: { "Content-Type": "text/plain" } });
+      return new Response("ok", {
+        headers: { ...SECURITY_HEADERS, "Content-Type": "text/plain" },
+      });
     }
 
     if (pathname === "/api/health") {

--- a/packages/api/src/api/__tests__/security-headers.test.ts
+++ b/packages/api/src/api/__tests__/security-headers.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Unit tests for the security-headers middleware on the Hono API app.
+ *
+ * Per issue #1984 — auth-bearing surfaces (api.useatlas.dev) need HSTS,
+ * CSP, X-Frame-Options, X-Content-Type-Options. Widget routes (/widget*)
+ * are intentionally framable, so they MUST NOT receive X-Frame-Options
+ * DENY and they retain their per-route `frame-ancestors *` CSP.
+ */
+
+import { describe, it, expect, mock } from "bun:test";
+import { createConnectionMock } from "../../__mocks__/connection";
+
+// --- Mocks (matching cors.test.ts shape) ---
+
+mock.module("@atlas/api/lib/auth/middleware", () => ({
+  authenticateRequest: () =>
+    Promise.resolve({ authenticated: true, mode: "none", user: undefined }),
+  checkRateLimit: () => ({ allowed: true }),
+  getClientIP: () => null,
+}));
+
+mock.module("@atlas/api/lib/agent", () => ({
+  runAgent: () =>
+    Promise.resolve({
+      toUIMessageStream: () => new ReadableStream({ start(c) { c.close(); } }),
+      text: Promise.resolve(""),
+    }),
+}));
+
+mock.module("@atlas/api/lib/startup", () => ({
+  validateEnvironment: () => Promise.resolve([]),
+  getStartupWarnings: () => [],
+}));
+
+mock.module("@atlas/api/lib/semantic", () => ({
+  getOrgWhitelistedTables: () => new Set(),
+  loadOrgWhitelist: async () => new Map(),
+  invalidateOrgWhitelist: () => {},
+  getOrgSemanticIndex: async () => "",
+  invalidateOrgSemanticIndex: () => {},
+  _resetOrgWhitelists: () => {},
+  _resetOrgSemanticIndexes: () => {},
+  getWhitelistedTables: () => new Set(),
+  _resetWhitelists: () => {},
+}));
+
+mock.module("@atlas/api/lib/db/connection", () =>
+  createConnectionMock({ resolveDatasourceUrl: () => "postgresql://mock:5432/test" }),
+);
+
+mock.module("@atlas/api/lib/tools/explore", () => ({
+  getExploreBackendType: () => "just-bash",
+  getActiveSandboxPluginId: () => null,
+  explore: { type: "function" },
+  invalidateExploreBackend: mock(() => {}),
+  markNsjailFailed: mock(() => {}),
+  markSidecarFailed: mock(() => {}),
+}));
+
+mock.module("@atlas/api/lib/auth/detect", () => ({
+  detectAuthMode: () => "none",
+  resetAuthModeCache: () => {},
+}));
+
+mock.module("@atlas/api/lib/settings", () => ({
+  getSetting: () => undefined,
+  getSettingAuto: () => undefined,
+  getSettingLive: async () => undefined,
+  setSetting: async () => {},
+  deleteSetting: async () => {},
+  getAllSettingOverrides: async () => [],
+  loadSettings: async () => 0,
+  getSettingsForAdmin: () => [],
+  getSettingsRegistry: () => [],
+  getSettingDefinition: () => undefined,
+  _resetSettingsCache: () => {},
+}));
+
+const { app } = await import("../index");
+
+describe("security-headers middleware", () => {
+  it("/api/health response carries HSTS, CSP, X-Frame-Options DENY, nosniff", async () => {
+    const res = await app.fetch(
+      new Request("http://localhost/api/health", { method: "GET" }),
+    );
+
+    const hsts = res.headers.get("Strict-Transport-Security") ?? "";
+    expect(hsts).toContain("max-age=");
+    expect(hsts).toContain("includeSubDomains");
+
+    const csp = res.headers.get("Content-Security-Policy") ?? "";
+    expect(csp.length).toBeGreaterThan(0);
+    expect(csp).toContain("frame-ancestors 'none'");
+
+    expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("Referrer-Policy")).toBeTruthy();
+  });
+
+  it("OPTIONS preflight to /api/v1/chat carries security headers", async () => {
+    // CORS middleware short-circuits OPTIONS via c.body(null, 204). Security
+    // headers must run BEFORE CORS so preflight responses are also hardened.
+    const res = await app.fetch(
+      new Request("http://localhost/api/v1/chat", {
+        method: "OPTIONS",
+        headers: {
+          Origin: "http://example.com",
+          "Access-Control-Request-Method": "POST",
+        },
+      }),
+    );
+
+    expect(res.headers.get("Strict-Transport-Security")).toBeTruthy();
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+  });
+
+  it("/widget/atlas-widget.js retains permissive framing — no X-Frame-Options DENY, no global CSP", async () => {
+    // Widget routes set their own CSP (frame-ancestors *) for cross-origin
+    // iframe embedding. Global X-Frame-Options DENY would break embeds.
+    const res = await app.fetch(
+      new Request("http://localhost/widget/atlas-widget.js", { method: "GET" }),
+    );
+
+    expect(res.headers.get("X-Frame-Options")).toBeNull();
+
+    // Widget JS asset itself does not set CSP (only the HTML page does).
+    // The important invariant is X-Frame-Options absent so embeds work.
+    // HSTS + nosniff still apply — they're safe everywhere.
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("Strict-Transport-Security")).toBeTruthy();
+  });
+
+  it("/widget HTML keeps frame-ancestors * CSP (route-level override)", async () => {
+    // The widget HTML page sets Content-Security-Policy: frame-ancestors *
+    // explicitly. Global middleware MUST NOT replace it with the strict CSP.
+    const res = await app.fetch(
+      new Request("http://localhost/widget", { method: "GET" }),
+    );
+
+    const csp = res.headers.get("Content-Security-Policy") ?? "";
+    expect(csp).toContain("frame-ancestors *");
+    expect(res.headers.get("X-Frame-Options")).toBeNull();
+  });
+});

--- a/packages/api/src/api/__tests__/security-headers.test.ts
+++ b/packages/api/src/api/__tests__/security-headers.test.ts
@@ -91,15 +91,19 @@ describe("security-headers middleware", () => {
     const csp = res.headers.get("Content-Security-Policy") ?? "";
     expect(csp.length).toBeGreaterThan(0);
     expect(csp).toContain("frame-ancestors 'none'");
+    // style-src 'unsafe-inline' is required by routes/onboarding-emails.ts
+    // (inline `style="..."` on the unsubscribe page). Regression guard.
+    expect(csp).toContain("style-src 'unsafe-inline'");
 
     expect(res.headers.get("X-Frame-Options")).toBe("DENY");
     expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
     expect(res.headers.get("Referrer-Policy")).toBeTruthy();
   });
 
-  it("OPTIONS preflight to /api/v1/chat carries security headers", async () => {
+  it("OPTIONS preflight short-circuits with 204 AND carries every security header", async () => {
     // CORS middleware short-circuits OPTIONS via c.body(null, 204). Security
     // headers must run BEFORE CORS so preflight responses are also hardened.
+    // Asserting status=204 proves CORS short-circuit fired (not a route handler).
     const res = await app.fetch(
       new Request("http://localhost/api/v1/chat", {
         method: "OPTIONS",
@@ -110,35 +114,83 @@ describe("security-headers middleware", () => {
       }),
     );
 
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBeTruthy();
     expect(res.headers.get("Strict-Transport-Security")).toBeTruthy();
     expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+    expect(res.headers.get("Content-Security-Policy")).toBeTruthy();
   });
 
-  it("/widget/atlas-widget.js retains permissive framing — no X-Frame-Options DENY, no global CSP", async () => {
-    // Widget routes set their own CSP (frame-ancestors *) for cross-origin
-    // iframe embedding. Global X-Frame-Options DENY would break embeds.
+  it("/api/v1/openapi.json carries the strict API CSP", async () => {
+    // Spec endpoint returns JSON. Confirms the comment claim that all JSON
+    // surfaces carry the strict CSP.
+    const res = await app.fetch(
+      new Request("http://localhost/api/v1/openapi.json", { method: "GET" }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Security-Policy")).toContain(
+      "default-src 'none'",
+    );
+    expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+  });
+
+  it("/widget/atlas-widget.js retains permissive framing — no X-Frame-Options, no strict CSP, but nosniff/HSTS still apply", async () => {
     const res = await app.fetch(
       new Request("http://localhost/widget/atlas-widget.js", { method: "GET" }),
     );
 
     expect(res.headers.get("X-Frame-Options")).toBeNull();
-
-    // Widget JS asset itself does not set CSP (only the HTML page does).
-    // The important invariant is X-Frame-Options absent so embeds work.
-    // HSTS + nosniff still apply — they're safe everywhere.
+    // Negative assertion: the strict global CSP must NOT leak onto widget
+    // assets or the iframe parent will block them.
+    expect(res.headers.get("Content-Security-Policy")).toBeNull();
+    // Header-poisoning defenses still apply on the asset.
     expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
     expect(res.headers.get("Strict-Transport-Security")).toBeTruthy();
   });
 
-  it("/widget HTML keeps frame-ancestors * CSP (route-level override)", async () => {
-    // The widget HTML page sets Content-Security-Policy: frame-ancestors *
-    // explicitly. Global middleware MUST NOT replace it with the strict CSP.
+  it("/widget HTML route returns 200 and keeps frame-ancestors * CSP", async () => {
     const res = await app.fetch(
       new Request("http://localhost/widget", { method: "GET" }),
     );
 
+    // Status assertion proves the route actually matched (not a 404 fallthrough).
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("html");
     const csp = res.headers.get("Content-Security-Policy") ?? "";
     expect(csp).toContain("frame-ancestors *");
     expect(res.headers.get("X-Frame-Options")).toBeNull();
+  });
+
+  it("/widgetfoo (non-widget path that shares the prefix) DOES get X-Frame-Options + strict CSP", async () => {
+    // Regression guard against `startsWith("/widget")` over-matching. The
+    // precise matcher (path === "/widget" || "/widget/..." || "/widget....")
+    // must reject sibling prefixes — otherwise a future careless route name
+    // silently becomes framable.
+    const res = await app.fetch(
+      new Request("http://localhost/widgetfoo", { method: "GET" }),
+    );
+
+    expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+    expect(res.headers.get("Content-Security-Policy")).toContain(
+      "frame-ancestors 'none'",
+    );
+  });
+
+  it("HTTPException 404 response carries security headers", async () => {
+    // Hono returns a 404 HTTPException for unmatched routes. The onError
+    // handler builds a fresh Response from err.getResponse() which bypasses
+    // c.res — confirms the explicit header-copy in onError is wired.
+    const res = await app.fetch(
+      new Request("http://localhost/api/this-route-does-not-exist", {
+        method: "GET",
+      }),
+    );
+
+    expect(res.status).toBe(404);
+    expect(res.headers.get("Strict-Transport-Security")).toBeTruthy();
+    expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
   });
 });

--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -41,15 +41,33 @@ const log = createLogger("api");
 const tracer = trace.getTracer("atlas");
 const app = new OpenAPIHono({ defaultHook: validationHook });
 
-// Security headers (issue #1984) — applied to every response, including
-// OPTIONS preflights and error responses. Must run BEFORE the CORS
-// middleware because CORS short-circuits OPTIONS via `c.body(null, 204)`
-// and we want preflight responses hardened too.
+// Security headers (issue #1984). Must run BEFORE the CORS middleware
+// because CORS short-circuits OPTIONS preflights via `c.body(null, 204)`
+// and we want those hardened too.
 //
-// Widget routes (`/widget*`) intentionally opt out of X-Frame-Options and
-// the strict CSP so they can be iframe-embedded from any origin. The
-// widget HTML route sets its own `Content-Security-Policy: frame-ancestors *`.
-// HSTS, nosniff, and Referrer-Policy are safe to apply everywhere.
+// Widget routes opt out of X-Frame-Options and the strict CSP so they can
+// be iframe-embedded from any origin — the widget HTML route sets its own
+// `frame-ancestors *`. The match is precise (covers /widget, /widget/...,
+// /widget.js, /widget.d.ts) — a bare `startsWith("/widget")` would also
+// match a future /widgetfoo route and silently make it framable.
+//
+// `style-src 'unsafe-inline'` is required by the email unsubscribe pages
+// in routes/onboarding-emails.ts, which use inline `style="..."` for
+// styling. The rest of the policy stays at `default-src 'none'` so JSON
+// endpoints can't be turned into resource loaders by an XSS in a rendered
+// field. The set of paths that emit this CSP is the union of every
+// `c.html(...)` call across the api package — keep that list small.
+function isWidgetPath(path: string): boolean {
+  return (
+    path === "/widget" ||
+    path.startsWith("/widget/") ||
+    path.startsWith("/widget.")
+  );
+}
+
+const API_SECURITY_CSP =
+  "default-src 'none'; style-src 'unsafe-inline'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'";
+
 app.use("*", async (c, next) => {
   c.header(
     "Strict-Transport-Security",
@@ -58,17 +76,9 @@ app.use("*", async (c, next) => {
   c.header("X-Content-Type-Options", "nosniff");
   c.header("Referrer-Policy", "strict-origin-when-cross-origin");
 
-  if (!c.req.path.startsWith("/widget")) {
+  if (!isWidgetPath(c.req.path)) {
     c.header("X-Frame-Options", "DENY");
-    // API serves JSON (and a few HTML pages like the OpenAPI viewer). A
-    // JSON-only API doesn't need to load any sub-resources, so the strict
-    // `default-src 'none'` is safe and blocks every exfiltration vector
-    // an XSS in a rendered field could open. Self-hosted operators who
-    // expose extra HTML can override `ATLAS_API_CSP` (see docs).
-    c.header(
-      "Content-Security-Policy",
-      "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'",
-    );
+    c.header("Content-Security-Policy", API_SECURITY_CSP);
   }
 
   await next();
@@ -441,25 +451,27 @@ if (process.env.DISCORD_CLIENT_ID) {
 app.onError((err, c) => {
   // Framework HTTP exceptions (e.g., malformed JSON from @hono/zod-openapi) carry
   // their own status code and response — forward them instead of converting to 500.
-  // CORS headers must be copied from the middleware context because the raw Response
-  // from HTTPException(200, { res }) bypasses Hono's header pipeline.
+  // CORS + security headers must be copied from the middleware context because the
+  // raw Response from HTTPException(200, { res }) bypasses Hono's header pipeline.
   if (err instanceof HTTPException) {
     const res = err.getResponse();
-    const corsOrigin = c.res.headers.get("Access-Control-Allow-Origin");
-    if (corsOrigin && !res.headers.has("Access-Control-Allow-Origin")) {
-      const patched = new Response(res.body, res);
-      for (const h of [
-        "Access-Control-Allow-Origin",
-        "Access-Control-Allow-Credentials",
-        "Access-Control-Allow-Headers",
-        "Access-Control-Expose-Headers",
-      ]) {
-        const v = c.res.headers.get(h);
-        if (v) patched.headers.set(h, v);
-      }
-      return patched;
+    const patched = new Response(res.body, res);
+    for (const h of [
+      "Access-Control-Allow-Origin",
+      "Access-Control-Allow-Credentials",
+      "Access-Control-Allow-Headers",
+      "Access-Control-Expose-Headers",
+      "Strict-Transport-Security",
+      "Content-Security-Policy",
+      "X-Frame-Options",
+      "X-Content-Type-Options",
+      "Referrer-Policy",
+    ]) {
+      if (patched.headers.has(h)) continue;
+      const v = c.res.headers.get(h);
+      if (v) patched.headers.set(h, v);
     }
-    return res;
+    return patched;
   }
   const requestId = crypto.randomUUID();
   log.error({ err, path: c.req.path, requestId }, "Unhandled error");

--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -41,6 +41,39 @@ const log = createLogger("api");
 const tracer = trace.getTracer("atlas");
 const app = new OpenAPIHono({ defaultHook: validationHook });
 
+// Security headers (issue #1984) — applied to every response, including
+// OPTIONS preflights and error responses. Must run BEFORE the CORS
+// middleware because CORS short-circuits OPTIONS via `c.body(null, 204)`
+// and we want preflight responses hardened too.
+//
+// Widget routes (`/widget*`) intentionally opt out of X-Frame-Options and
+// the strict CSP so they can be iframe-embedded from any origin. The
+// widget HTML route sets its own `Content-Security-Policy: frame-ancestors *`.
+// HSTS, nosniff, and Referrer-Policy are safe to apply everywhere.
+app.use("*", async (c, next) => {
+  c.header(
+    "Strict-Transport-Security",
+    "max-age=31536000; includeSubDomains; preload",
+  );
+  c.header("X-Content-Type-Options", "nosniff");
+  c.header("Referrer-Policy", "strict-origin-when-cross-origin");
+
+  if (!c.req.path.startsWith("/widget")) {
+    c.header("X-Frame-Options", "DENY");
+    // API serves JSON (and a few HTML pages like the OpenAPI viewer). A
+    // JSON-only API doesn't need to load any sub-resources, so the strict
+    // `default-src 'none'` is safe and blocks every exfiltration vector
+    // an XSS in a rendered field could open. Self-hosted operators who
+    // expose extra HTML can override `ATLAS_API_CSP` (see docs).
+    c.header(
+      "Content-Security-Policy",
+      "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'",
+    );
+  }
+
+  await next();
+});
+
 // OTel tracing — root span per HTTP request. No-op when SDK is not initialized.
 // Must be the first middleware so all downstream operations are children.
 app.use("/api/*", async (c, next) => {

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -99,11 +99,27 @@ const nextConfig: NextConfig = {
         // Embed view must remain framable from any origin. CSP frame-ancestors
         // takes precedence over X-Frame-Options per the W3C CSP spec, so the
         // global X-Frame-Options DENY is harmlessly ignored on this path.
+        //
+        // The `csp.replace(...)` below is brittle: if the global directive
+        // `frame-ancestors 'self'` is reworded or reordered, this becomes a
+        // silent no-op and the embed regresses to the global frame-ancestors.
+        // The runtime check below fails the Next build if that happens.
         source: "/shared/:token/embed",
         headers: [
           {
             key: "Content-Security-Policy",
-            value: csp.replace("frame-ancestors 'self'", "frame-ancestors *"),
+            value: (() => {
+              const replaced = csp.replace(
+                "frame-ancestors 'self'",
+                "frame-ancestors *",
+              );
+              if (replaced === csp) {
+                throw new Error(
+                  "next.config.ts: embed CSP override no-op'd — `frame-ancestors 'self'` not found in global CSP. Update the replace() target.",
+                );
+              }
+              return replaced;
+            })(),
           },
         ],
       },

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -49,16 +49,61 @@ const nextConfig: NextConfig = {
   typescript: { ignoreBuildErrors: true },
   transpilePackages: ["@useatlas/react"],
   turbopack: {},
-  // Allow embedding shared conversations in iframes. The /embed route removes
-  // chrome for a minimal read-only view; frame-ancestors * permits any origin.
+  // Security headers (issue #1984) — applied to all responses.
+  //
+  // - HSTS pins HTTPS for a year. `preload` advertises eligibility; submission
+  //   is a separate operator decision.
+  // - CSP is intentionally generous on connect-src/img-src because self-hosted
+  //   deployments may point at any datasource host or load avatars from
+  //   arbitrary origins. The strict bits — frame-ancestors, object-src,
+  //   base-uri, form-action — are the ones that block real attack vectors.
+  // - `script-src` keeps `'unsafe-inline'` because Next.js inlines hydration
+  //   data; `'unsafe-eval'` is included for libraries like Recharts that JIT
+  //   chart paths. Operators on a strict-CSP build can fork this list.
+  //
+  // The `/shared/:token/embed` route inherits everything except frame-ancestors,
+  // which it overrides to `*` so customers can embed shared conversations.
+  // Browsers ignore X-Frame-Options when CSP `frame-ancestors` is present, so
+  // setting both globally is safe — the embed override wins where it matches.
   async headers() {
+    const csp = [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: blob: https:",
+      "font-src 'self' data:",
+      "connect-src 'self' https: wss:",
+      "frame-src 'self'",
+      "frame-ancestors 'self'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "object-src 'none'",
+      "worker-src 'self' blob:",
+    ].join("; ");
+
     return [
       {
+        source: "/:path*",
+        headers: [
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=31536000; includeSubDomains; preload",
+          },
+          { key: "Content-Security-Policy", value: csp },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+        ],
+      },
+      {
+        // Embed view must remain framable from any origin. CSP frame-ancestors
+        // takes precedence over X-Frame-Options per the W3C CSP spec, so the
+        // global X-Frame-Options DENY is harmlessly ignored on this path.
         source: "/shared/:token/embed",
         headers: [
           {
             key: "Content-Security-Policy",
-            value: "frame-ancestors *",
+            value: csp.replace("frame-ancestors 'self'", "frame-ancestors *"),
           },
         ],
       },


### PR DESCRIPTION
Closes #1984.

## Summary

`/prod-audit` on 2026-05-02 found that `api.useatlas.dev` and `app.useatlas.dev` (auth-bearing surfaces) were missing **HSTS, CSP, X-Frame-Options, X-Content-Type-Options**. `www.useatlas.dev` was missing **HSTS + CSP**. Chat renders Markdown from user-influenced content, so an XSS escape today could exfiltrate session cookies / API keys without CSP — this is a real exposure, not theoretical.

This PR adds defaulted security headers across all three production hosts.

| Host | HSTS | CSP | X-Frame-Options | X-Content-Type-Options |
|---|---|---|---|---|
| `www.useatlas.dev` | ✅ now | ✅ now | ✅ already | ✅ already |
| `app.useatlas.dev` | ✅ now | ✅ now | ✅ now | ✅ now |
| `api.useatlas.dev` | ✅ now | ✅ now | ✅ now | ✅ now |

## Approach

- **`packages/api/src/api/index.ts`** — Hono middleware mounted as the *first* `app.use("*", ...)`, before OTel and CORS. Runs ahead of the CORS short-circuit on `OPTIONS` so preflight responses are hardened too. Skips `X-Frame-Options` and the strict CSP for `/widget*` paths so the widget HTML route's own `frame-ancestors *` keeps working.
- **`packages/web/next.config.ts`** — `headers()` config sets HSTS + strict CSP + `X-Frame-Options DENY` + nosniff + Referrer-Policy on every path. `/shared/:token/embed` overrides CSP to use `frame-ancestors *`; `X-Frame-Options DENY` is set globally but is harmlessly ignored on that route per the [W3C CSP spec](https://www.w3.org/TR/CSP3/#frame-ancestors-and-frame-options) (CSP `frame-ancestors` overrides `X-Frame-Options` when both are present).
- **`apps/www/serve.ts`** — extends `SECURITY_HEADERS` with HSTS + CSP. The marketing site is fully static; `WWW_CSP` is a tighter policy than the app's because there are no third-party scripts.
- **`apps/docs/content/docs/security/security-headers.mdx`** — new docs page covering the header rationale and how self-hosted operators extend CSP for analytics or error-reporting scripts.

## Tests

`packages/api/src/api/__tests__/security-headers.test.ts` (new file, 4 tests):

- `/api/health` carries HSTS, strict CSP, `X-Frame-Options DENY`, nosniff
- `OPTIONS` preflight to `/api/v1/chat` carries security headers (proves middleware ordering — runs before CORS short-circuit)
- `/widget/atlas-widget.js` does **not** receive `X-Frame-Options DENY` (would break embeds) but does keep nosniff + HSTS
- `/widget` HTML keeps its route-level `frame-ancestors *` CSP

Existing CORS, widget, chat, and 310-file `@atlas/api` isolated suite — all green.

## Out of scope

- `examples/nextjs-standalone/`, `create-atlas/templates/nextjs-standalone/`, `create-atlas/templates/docker/` next.config.ts files — file as a follow-up so self-hosted scaffolds inherit the same defaults.
- HSTS preload-list submission — operator decision; the header advertises eligibility but submission is a separate, manual step (and effectively irreversible).

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun run test` — full suite green
- [x] `bun x syncpack lint` — clean
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — clean
- [x] `bash scripts/check-railway-watch.sh` — clean
- [ ] After merge: curl `https://api.useatlas.dev`, `https://app.useatlas.dev`, `https://www.useatlas.dev` and confirm headers
- [ ] After merge: load the embeddable widget on a third-party page and confirm it still mounts (frame-ancestors carve-out)
- [ ] After merge: load `/shared/:token/embed` from a different origin and confirm it still iframes