### PR TITLE
fix(api): #1991 — widget HTML test accepts 200 or 503 (CI build-order skew)

### DIFF
--- a/packages/api/src/api/__tests__/security-headers.test.ts
+++ b/packages/api/src/api/__tests__/security-headers.test.ts
@@ -150,13 +150,18 @@ describe("security-headers middleware", () => {
     expect(res.headers.get("Strict-Transport-Security")).toBeTruthy();
   });
 
-  it("/widget HTML route returns 200 and keeps frame-ancestors * CSP", async () => {
+  it("/widget HTML route is reached and keeps frame-ancestors * CSP", async () => {
     const res = await app.fetch(
       new Request("http://localhost/widget", { method: "GET" }),
     );
 
-    // Status assertion proves the route actually matched (not a 404 fallthrough).
-    expect(res.status).toBe(200);
+    // Status proves the route handler ran (not a 404 fallthrough). Two valid
+    // outcomes: 200 when packages/react/dist/widget.js is built, 503 when the
+    // bundle is missing (CI shards run before `bun run --filter @useatlas/react
+    // build`). Both paths set the route-level `frame-ancestors *` CSP, which
+    // is the load-bearing invariant for this test — the global strict CSP
+    // must NOT replace it on either branch.
+    expect([200, 503]).toContain(res.status);
     expect(res.headers.get("Content-Type")).toContain("html");
     const csp = res.headers.get("Content-Security-Policy") ?? "";
     expect(csp).toContain("frame-ancestors *");


### PR DESCRIPTION
Follow-up to PR #1991. CI failed on main after the security-headers PR landed because the new \`/widget HTML route returns 200\` test asserts \`status === 200\`, but CI runs the api test shards **before** \`bun run --filter @useatlas/react build\`. Without \`packages/react/dist/widget.js\` the widget HTML route correctly returns 503 (with the same \`frame-ancestors *\` CSP).

Locally the test passes because \`bun run type\` builds \`@useatlas/react\` ahead of any tests, so the bundle is present and the route returns 200.

The load-bearing invariant for the test is "the route handler ran AND set its own \`frame-ancestors *\` CSP, not the strict global one." Both 200 and 503 paths satisfy that. Accept either.

## Test plan

- [x] \`bun test packages/api/src/api/__tests__/security-headers.test.ts\` — green locally (7 pass)
- [ ] CI green on this branch (sharded, no react build first)