### PR TITLE
fix(api): #1981 — fail SaaS LB probe when internal DB is unreachable

### DIFF
--- a/apps/docs/content/docs/deployment/deploy.mdx
+++ b/apps/docs/content/docs/deployment/deploy.mdx
@@ -271,6 +271,8 @@ GET /api/health
 
 Returns `{"status":"ok"}`, `{"status":"degraded"}`, or `{"status":"error"}` with sub-checks for datasource, provider, semantic layer, internal DB, explore (sandbox backend), auth, and slack. Returns HTTP 200 for `ok`/`degraded`, HTTP 503 for `error`. Always public (no auth required).
 
+In SaaS deploys (`ATLAS_DEPLOY_MODE=saas`), an unreachable internal DB fails the probe with HTTP 503 — auth, org, billing, settings, audit, and the scheduler all live there, so any pod that loses it must be removed from the load balancer rotation. Self-hosted leaves the internal DB optional and continues to report `degraded` (HTTP 200) when it's down.
+
 ---
 
 ## See Also

--- a/packages/api/src/api/__tests__/health.test.ts
+++ b/packages/api/src/api/__tests__/health.test.ts
@@ -146,6 +146,18 @@ mock.module("@atlas/api/lib/auth/middleware", () => ({
   getClientIP: mock(() => null),
 }));
 
+// Internal DB mock — defaults to a successful SELECT 1, individual tests
+// can override by reassigning `internalDBQueryImpl` to reject. We spread the
+// real module so the dozens of route files that statically import other
+// helpers (internalQuery, hasInternalDB, encryptUrl, etc.) keep working.
+const realInternalDBModule = await import("@atlas/api/lib/db/internal");
+let internalDBQueryImpl: () => Promise<unknown> = () =>
+  Promise.resolve({ rows: [{ "?column?": 1 }] });
+mock.module("@atlas/api/lib/db/internal", () => ({
+  ...realInternalDBModule,
+  getInternalDB: () => ({ query: () => internalDBQueryImpl() }),
+}));
+
 // Import after all mocks are registered
 const { app } = await import("../index");
 
@@ -305,14 +317,17 @@ describe("GET /api/health — sources section", () => {
 describe("GET /api/health — internal DB / deploy mode contract", () => {
   const origDatasource = process.env.ATLAS_DATASOURCE_URL;
   const origDatabaseUrl = process.env.DATABASE_URL;
+  const origDeployMode = process.env.ATLAS_DEPLOY_MODE;
 
   beforeEach(() => {
     process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
     delete process.env.DATABASE_URL;
+    delete process.env.ATLAS_DEPLOY_MODE;
     connMetadata = [];
     mockValidateEnvironment.mockReset();
     mockGetStartupWarnings.mockReset();
     mockGetStartupWarnings.mockReturnValue([]);
+    internalDBQueryImpl = () => Promise.resolve({ rows: [{ "?column?": 1 }] });
   });
 
   afterEach(async () => {
@@ -320,17 +335,52 @@ describe("GET /api/health — internal DB / deploy mode contract", () => {
     else delete process.env.ATLAS_DATASOURCE_URL;
     if (origDatabaseUrl !== undefined) process.env.DATABASE_URL = origDatabaseUrl;
     else delete process.env.DATABASE_URL;
+    if (origDeployMode !== undefined) process.env.ATLAS_DEPLOY_MODE = origDeployMode;
+    else delete process.env.ATLAS_DEPLOY_MODE;
     const config = await import("@atlas/api/lib/config");
     config._setConfigForTest(null);
+    internalDBQueryImpl = () => Promise.resolve({ rows: [{ "?column?": 1 }] });
   });
 
-  it("returns 503 in SaaS when internal DB is unreachable", async () => {
+  it("returns 503 in SaaS when internal DB diagnostic flags it unreachable", async () => {
     mockValidateEnvironment.mockResolvedValue([
       { code: "INTERNAL_DB_UNREACHABLE", message: "internal db down" },
     ]);
     const config = await import("@atlas/api/lib/config");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for the deployMode path
     config._setConfigForTest({ deployMode: "saas" } as any);
+
+    const response = await app.fetch(healthRequest());
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.status).toBe("error");
+  });
+
+  it("returns 503 in SaaS when the live internal DB probe rejects", async () => {
+    // Realistic mid-life failure: pod was connected, internal DB just died.
+    // Surfaces via internalProbeError (live SELECT 1), not the boot diagnostic.
+    process.env.DATABASE_URL = "postgresql://internal:internal@localhost:5432/atlas";
+    internalDBQueryImpl = () => Promise.reject(new Error("connection refused"));
+    mockValidateEnvironment.mockResolvedValue([]);
+    const config = await import("@atlas/api/lib/config");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for the deployMode path
+    config._setConfigForTest({ deployMode: "saas" } as any);
+
+    const response = await app.fetch(healthRequest());
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.status).toBe("error");
+  });
+
+  it("returns 503 when ATLAS_DEPLOY_MODE=saas even if config is not yet loaded", async () => {
+    // Boot-window safety net: a probe hitting a SaaS pod before loadConfig()
+    // resolves must still fail closed. getConfig() returns null here.
+    mockValidateEnvironment.mockResolvedValue([
+      { code: "INTERNAL_DB_UNREACHABLE", message: "internal db down" },
+    ]);
+    process.env.ATLAS_DEPLOY_MODE = "saas";
+    const config = await import("@atlas/api/lib/config");
+    config._setConfigForTest(null);
 
     const response = await app.fetch(healthRequest());
     expect(response.status).toBe(503);

--- a/packages/api/src/api/__tests__/health.test.ts
+++ b/packages/api/src/api/__tests__/health.test.ts
@@ -299,3 +299,56 @@ describe("GET /api/health — sources section", () => {
     expect(defaultSource.status).toBe("healthy");
   });
 });
+
+// #1981 — internal DB unreachable must fail the SaaS load-balancer probe.
+// Self-hosted treats the internal DB as optional, so degraded → 200 must hold.
+describe("GET /api/health — internal DB / deploy mode contract", () => {
+  const origDatasource = process.env.ATLAS_DATASOURCE_URL;
+  const origDatabaseUrl = process.env.DATABASE_URL;
+
+  beforeEach(() => {
+    process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
+    delete process.env.DATABASE_URL;
+    connMetadata = [];
+    mockValidateEnvironment.mockReset();
+    mockGetStartupWarnings.mockReset();
+    mockGetStartupWarnings.mockReturnValue([]);
+  });
+
+  afterEach(async () => {
+    if (origDatasource !== undefined) process.env.ATLAS_DATASOURCE_URL = origDatasource;
+    else delete process.env.ATLAS_DATASOURCE_URL;
+    if (origDatabaseUrl !== undefined) process.env.DATABASE_URL = origDatabaseUrl;
+    else delete process.env.DATABASE_URL;
+    const config = await import("@atlas/api/lib/config");
+    config._setConfigForTest(null);
+  });
+
+  it("returns 503 in SaaS when internal DB is unreachable", async () => {
+    mockValidateEnvironment.mockResolvedValue([
+      { code: "INTERNAL_DB_UNREACHABLE", message: "internal db down" },
+    ]);
+    const config = await import("@atlas/api/lib/config");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for the deployMode path
+    config._setConfigForTest({ deployMode: "saas" } as any);
+
+    const response = await app.fetch(healthRequest());
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.status).toBe("error");
+  });
+
+  it("returns 200 degraded in self-hosted when internal DB is unreachable", async () => {
+    mockValidateEnvironment.mockResolvedValue([
+      { code: "INTERNAL_DB_UNREACHABLE", message: "internal db down" },
+    ]);
+    const config = await import("@atlas/api/lib/config");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for the deployMode path
+    config._setConfigForTest({ deployMode: "self-hosted" } as any);
+
+    const response = await app.fetch(healthRequest());
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.status).toBe("degraded");
+  });
+});

--- a/packages/api/src/api/routes/health.ts
+++ b/packages/api/src/api/routes/health.ts
@@ -22,6 +22,7 @@ import { detectAuthMode } from "@atlas/api/lib/auth/detect";
 import { SENSITIVE_PATTERNS } from "@atlas/api/lib/security";
 import { getSetting } from "@atlas/api/lib/settings";
 import { getApiRegion, getMisroutedCount } from "@atlas/api/lib/residency/misrouting";
+import { getConfig } from "@atlas/api/lib/config";
 
 const log = createLogger("health");
 
@@ -222,8 +223,14 @@ health.openapi(healthRoute, async (c) => {
     );
     const hasAuthError = !!authDiagnostic;
 
+    // SaaS treats the internal DB as critical infrastructure (auth, org,
+    // billing, settings, audit, scheduler all live there). A pod that can't
+    // reach it must fail the LB probe (#1981). Self-hosted leaves it optional.
+    const isSaas = getConfig()?.deployMode === "saas";
+    const internalDbBlocksProbe = hasInternalDbError && isSaas;
+
     let status: "ok" | "degraded" | "error";
-    if (hasDsError && !dsNotConfigured) status = "error";
+    if ((hasDsError && !dsNotConfigured) || internalDbBlocksProbe) status = "error";
     else if (
       dsNotConfigured ||
       hasKeyError ||

--- a/packages/api/src/api/routes/health.ts
+++ b/packages/api/src/api/routes/health.ts
@@ -226,7 +226,11 @@ health.openapi(healthRoute, async (c) => {
     // SaaS treats the internal DB as critical infrastructure (auth, org,
     // billing, settings, audit, scheduler all live there). A pod that can't
     // reach it must fail the LB probe (#1981). Self-hosted leaves it optional.
-    const isSaas = getConfig()?.deployMode === "saas";
+    // Fall back to the env var so a probe hitting a SaaS pod before
+    // `loadConfig()` resolves still fails closed instead of returning 200.
+    const isSaas =
+      getConfig()?.deployMode === "saas" ||
+      process.env.ATLAS_DEPLOY_MODE === "saas";
     const internalDbBlocksProbe = hasInternalDbError && isSaas;
 
     let status: "ok" | "degraded" | "error";


### PR DESCRIPTION
## Summary
- In SaaS, internal DB hosts auth/org/billing/settings/audit/scheduler. Today a pod that loses it still returns `degraded` / 200, so the load balancer keeps sending traffic that piles up at the auth layer (#1981).
- `/api/health` now returns `error` / **HTTP 503** when `getConfig().deployMode === "saas"` AND the internal DB probe (or `INTERNAL_DB_UNREACHABLE` diagnostic) flags it as unreachable — so the LB removes the pod from rotation.
- Self-hosted is unchanged: internal DB stays optional and an outage still reports `degraded` / 200.

## Test plan
- [x] TDD red→green: new SaaS test asserts 503 + `status: "error"`; new self-hosted test pins the existing `degraded` / 200 contract
- [x] `bun test packages/api/src/api/__tests__/health.test.ts` — 9/9 pass
- [x] `bun run scripts/test-isolated.ts --affected` (8 affected files) — all pass
- [x] Full `bun run scripts/test-isolated.ts` — 310/310 pass
- [x] `bun run lint`, `bun run type`, `bun x syncpack lint`, template drift, railway-watch — all green
- [x] Docs: one-line note added to `apps/docs/content/docs/deployment/deploy.mdx#health-check`

Closes #1981