### PR TITLE
fix(api): #1986 — guard region-migration retry after Phase 3 cutover

### DIFF
--- a/apps/docs/content/docs/platform-ops/data-residency.mdx
+++ b/apps/docs/content/docs/platform-ops/data-residency.mdx
@@ -248,6 +248,38 @@ curl -X POST http://localhost:3001/api/v1/admin/residency/migrate/$MIGRATION_ID/
   -H "Authorization: Bearer $TOKEN"
 ```
 
+<Callout type="warn" title="Retry is unsafe after Phase 3 cutover">
+  Once Phase 3 sets `region_updated = TRUE`, the workspace lives in the destination region and the source data is stale. Re-running Phase 1 (export from source) on such a row would re-export a workspace that already moved and overwrite the live destination. The retry endpoint refuses these resets with **HTTP 409 Conflict** (`error: "conflict"`) — recovery requires the manual-intervention runbook below.
+</Callout>
+
+### Recovering from a Phase 4 failure (manual intervention)
+
+When `executeRegionMigration` fails after Phase 3 succeeded, the row will be `status = 'failed'`, `region_updated = TRUE`, and the `error_message` carries the warning `WARNING: region was already updated to "<targetRegion>" — do NOT retry without investigation`. The `/migrate/:id/retry` endpoint will return 409 in this state. The recovery path:
+
+1. **Confirm where the workspace lives now.** Read the `organization` row directly:
+   ```sql
+   SELECT id, region, region_assigned_at FROM organization WHERE id = '<workspaceId>';
+   ```
+   `region` should already match the migration's `target_region`. If it does not, the row is in an unexpected state — open an incident before doing anything else.
+
+2. **Confirm Phase 4 (cleanup scheduling) is what failed.** Inspect the `region_migration_failed` audit event and the `error_message` column on the migration row. If the failure was earlier (Phase 2 transfer or Phase 3 organization update), `region_updated` would not be `TRUE` — the guard would not have fired and the retry endpoint would have accepted the reset normally. A 409 specifically means the destination has taken ownership.
+
+3. **Pick a recovery direction.**
+   - **Forward (preferred):** the destination has the data, only post-cutover bookkeeping failed. Re-issue the cleanup scheduling and any other Phase 4 side effects manually, then mark the migration as completed:
+     ```sql
+     UPDATE region_migrations
+        SET status = 'completed',
+            completed_at = now(),
+            error_message = NULL
+      WHERE id = '<migrationId>';
+     ```
+     Verify the workspace is reachable in the destination region (`/api/v1/admin/residency` returns the new region) before declaring done.
+   - **Backward (rare):** unwind from the destination if the post-cutover work is not recoverable and the destination state is known-bad. Restore the source-region snapshot taken before the migration, then update `organization.region` back to the source region and the migration row to `status = 'cancelled'` with an explanatory `error_message`. Do not flip the migration back to `pending` — the row records the historical attempt; create a new migration request for any future retry.
+
+4. **Audit the recovery.** File an `admin_action` row referencing the migration ID, the chosen direction, and the operator who performed it. The forensic trail must show that the 409 guard fired and was resolved deliberately, not papered over.
+
+> The `region_updated` column is the single source of truth for "destination has taken ownership." It is set inside the same migration executor process that performs the cutover, immediately after `organization.region` is updated, before Phase 4 starts. If you ever need to manually flip `region_updated`, treat it as a destructive operation — the guard exists exactly because the wrong value here corrupts customer data.
+
 ## Limitations
 
 - Region health checks report all configured regions as healthy (no active probing)

--- a/apps/docs/content/docs/platform-ops/data-residency.mdx
+++ b/apps/docs/content/docs/platform-ops/data-residency.mdx
@@ -265,7 +265,7 @@ When `executeRegionMigration` fails after Phase 3 succeeded, the row will be `st
 2. **Confirm Phase 4 (cleanup scheduling) is what failed.** Inspect the `region_migration_failed` audit event and the `error_message` column on the migration row. If the failure was earlier (Phase 2 transfer or Phase 3 organization update), `region_updated` would not be `TRUE` — the guard would not have fired and the retry endpoint would have accepted the reset normally. A 409 specifically means the destination has taken ownership.
 
 3. **Pick a recovery direction.**
-   - **Forward (preferred):** the destination has the data, only post-cutover bookkeeping failed. Re-issue the cleanup scheduling and any other Phase 4 side effects manually, then mark the migration as completed:
+   - **Forward (preferred):** the destination has the data, only post-cutover bookkeeping failed. Re-issue the cleanup scheduling and any other Phase 4 side effects manually, then mark the migration as completed. `region_updated` stays `TRUE` — the destination still owns the data:
      ```sql
      UPDATE region_migrations
         SET status = 'completed',
@@ -274,9 +274,26 @@ When `executeRegionMigration` fails after Phase 3 succeeded, the row will be `st
       WHERE id = '<migrationId>';
      ```
      Verify the workspace is reachable in the destination region (`/api/v1/admin/residency` returns the new region) before declaring done.
-   - **Backward (rare):** unwind from the destination if the post-cutover work is not recoverable and the destination state is known-bad. Restore the source-region snapshot taken before the migration, then update `organization.region` back to the source region and the migration row to `status = 'cancelled'` with an explanatory `error_message`. Do not flip the migration back to `pending` — the row records the historical attempt; create a new migration request for any future retry.
+   - **Backward (rare):** unwind from the destination if the post-cutover work is not recoverable and the destination state is known-bad. This is destructive and should not be self-service — open an incident first. The mechanical steps, after restoring the source-region snapshot taken before the migration:
+     ```sql
+     -- 1. Point the workspace back at the source region
+     UPDATE organization
+        SET region = '<sourceRegion>',
+            region_assigned_at = now()
+      WHERE id = '<workspaceId>';
 
-4. **Audit the recovery.** File an `admin_action` row referencing the migration ID, the chosen direction, and the operator who performed it. The forensic trail must show that the 409 guard fired and was resolved deliberately, not papered over.
+     -- 2. Mark the migration cancelled and clear region_updated so the
+     --    column reflects post-unwind reality (source owns the data again).
+     UPDATE region_migrations
+        SET status = 'cancelled',
+            completed_at = now(),
+            region_updated = FALSE,
+            error_message = 'Unwound after Phase 4 failure — see incident <ID>'
+      WHERE id = '<migrationId>';
+     ```
+     Do not flip the migration back to `pending` — the row records the historical attempt; create a new migration request for any future retry.
+
+4. **Audit the recovery.** File an `admin_action_log` row referencing the migration ID, the chosen direction, and the operator who performed it. The forensic trail must show that the 409 guard fired and was resolved deliberately, not papered over. The `/migrate/:id/retry` endpoint already records the rejected attempt with `status = 'failure'`; the recovery action is the matching follow-up.
 
 > The `region_updated` column is the single source of truth for "destination has taken ownership." It is set inside the same migration executor process that performs the cutover, immediately after `organization.region` is updated, before Phase 4 starts. If you ever need to manually flip `region_updated`, treat it as a destructive operation — the guard exists exactly because the wrong value here corrupts customer data.
 

--- a/packages/api/src/api/__tests__/admin-residency.test.ts
+++ b/packages/api/src/api/__tests__/admin-residency.test.ts
@@ -154,6 +154,15 @@ mock.module("@atlas/api/lib/effect/services", () => ({
   makeAuthContextLayer: () => ({}),
 }));
 
+// #1986 — Mirror the production tagged-error → HTTP mapping so route tests
+// can assert the 409 surfaced by the unsafe-reset guard. Keeping this map
+// keyed off `_tag` (the Data.TaggedError discriminant) avoids importing the
+// real classes here — tests pass any object with the matching `_tag` and
+// `message` and get the realistic Response shape back.
+const TAGGED_ERROR_HTTP_MAP: Record<string, { status: number; code: string }> = {
+  UnsafeRegionMigrationResetError: { status: 409, code: "conflict" },
+};
+
 mock.module("@atlas/api/lib/effect/hono", () => ({
   runEffect: async (_c: unknown, effect: { _tag: string; genFn: () => Generator }, opts?: { domainErrors?: [unknown, Record<string, number>][] }) => {
     try {
@@ -183,6 +192,18 @@ mock.module("@atlas/api/lib/effect/hono", () => ({
             const status = statusMap[code] ?? 500;
             return new Response(JSON.stringify({ error: code, message: err.message, requestId: "test-req-1" }), { status });
           }
+        }
+      }
+      // Classify Atlas tagged errors (mirrors mapTaggedError dispatch)
+      if (err && typeof err === "object" && "_tag" in err && typeof (err as { _tag?: unknown })._tag === "string") {
+        const tag = (err as { _tag: string })._tag;
+        const mapping = TAGGED_ERROR_HTTP_MAP[tag];
+        if (mapping) {
+          const message = (err as { message?: unknown }).message;
+          return new Response(
+            JSON.stringify({ error: mapping.code, message: typeof message === "string" ? message : tag, requestId: "test-req-1" }),
+            { status: mapping.status },
+          );
         }
       }
       // Unknown / defect errors land as 500 in production. Return the same
@@ -398,11 +419,17 @@ mock.module("@atlas/api/lib/audit", () => ({
 
 let mockResetResult: { ok: true } | { ok: false; reason: string; error: string } = { ok: true };
 let mockCancelResult: { ok: true } | { ok: false; reason: string; error: string } = { ok: true };
+// #1986 — optional throw to exercise the 409 mapping for the unsafe-reset guard
+// without dragging in the real migrate module's DB plumbing.
+let mockResetThrow: Error | null = null;
 
 mock.module("@atlas/api/lib/residency/migrate", () => ({
   triggerMigrationExecution: () => {},
   failStaleMigrations: () => Promise.resolve(0),
-  resetMigrationForRetry: () => Promise.resolve(mockResetResult),
+  resetMigrationForRetry: () => {
+    if (mockResetThrow) return Promise.reject(mockResetThrow);
+    return Promise.resolve(mockResetResult);
+  },
   cancelMigration: () => Promise.resolve(mockCancelResult),
 }));
 
@@ -433,6 +460,7 @@ function resetMocks() {
   };
   mockInternalQueryResult = [];
   mockResetResult = { ok: true };
+  mockResetThrow = null;
   mockCancelResult = { ok: true };
   mockAssignCauseKind = "fail";
   mockEffectUser = {
@@ -821,6 +849,26 @@ describe("POST /migrate/:id/retry", () => {
     mockHasInternalDB = false;
     const res = await request("POST", "/migrate/mig-1/retry");
     expect(res.status).toBe(404);
+  });
+
+  // #1986 — End-to-end: when resetMigrationForRetry throws the typed
+  // UnsafeRegionMigrationResetError (Phase 3 already cut over), the bridge
+  // must classify it via mapTaggedError and respond 409, not 400/500.
+  it("returns 409 when reset is rejected as unsafe (region already updated)", async () => {
+    mockResetThrow = Object.assign(
+      new Error("Migration cannot be reset: workspace already moved to eu-west"),
+      {
+        _tag: "UnsafeRegionMigrationResetError" as const,
+        migrationId: "mig-1",
+        workspaceId: "org-1",
+        targetRegion: "eu-west",
+      },
+    );
+    const res = await request("POST", "/migrate/mig-1/retry");
+    expect(res.status).toBe(409);
+    const json = (await res.json()) as { error: string; message: string };
+    expect(json.error).toBe("conflict");
+    expect(json.message).toContain("already moved");
   });
 });
 

--- a/packages/api/src/api/__tests__/admin-residency.test.ts
+++ b/packages/api/src/api/__tests__/admin-residency.test.ts
@@ -74,21 +74,32 @@ function withPipe(iter: { [Symbol.iterator]: () => Iterator<unknown, unknown> })
       [Symbol.iterator]() {
         const inner = iter[Symbol.iterator]();
         let firstCall = true;
+        function fireHooks(err: unknown): never {
+          const cause: MockCause = { _mockKind: mockAssignCauseKind, error: err };
+          for (const h of hooks) {
+            // Each hook invokes `Effect.sync(() => logAdminAction(...))`; in
+            // the mock `Effect.sync` executes its callback on invocation, so
+            // the audit emission lands before we re-throw. Swallow hook
+            // errors so the original failure still surfaces.
+            try { h.fn(cause); } catch { /* intentionally ignored */ }
+          }
+          throw err;
+        }
         return {
           next(value?: unknown): IteratorResult<unknown, unknown> {
             try {
               return firstCall ? (firstCall = false, inner.next()) : inner.next(value);
             } catch (err) {
-              const cause: MockCause = { _mockKind: mockAssignCauseKind, error: err };
-              for (const h of hooks) {
-                // Each hook invokes `Effect.sync(() => logAdminAction(...))`;
-                // in the mock `Effect.sync` executes its callback on
-                // invocation, so the audit emission lands before we re-throw.
-                // Swallow hook errors so the original failure still surfaces.
-                try { h.fn(cause); } catch { /* intentionally ignored */ }
-              }
-              throw err;
+              return fireHooks(err);
             }
+          },
+          // Generator delegation forwards `gen.throw(err)` to the inner
+          // iterator's `throw` method when the outer generator is suspended
+          // inside a `yield*`. Without this, async-rejection paths (the
+          // runEffect mock awaits an Effect.promise sentinel and calls
+          // `gen.throw` on rejection) would bypass the tapErrorCause hooks.
+          throw(err: unknown): IteratorResult<unknown, unknown> {
+            return fireHooks(err);
           },
         };
       },
@@ -1036,14 +1047,42 @@ describe("admin residency — F-32 audit emission", () => {
     expect(entry.targetId).toBe("mig-1");
   });
 
-  it("POST /migrate/:id/retry does NOT emit audit when retry is rejected", async () => {
-    // Pre-handler rejection (resetMigrationForRetry returned ok:false) should
-    // not land an audit row — the migration wasn't actually retried, and
-    // emitting would pollute the forensic record with no-op retry attempts.
+  it("POST /migrate/:id/retry emits a failure audit when retry is rejected", async () => {
+    // Rejected retries are compliance-relevant: a 4xx here can fingerprint a
+    // probe (operator attempting to undo a half-completed cross-region cutover).
+    // The runbook requires a forensic trail showing every guard outcome; the
+    // route emits a `status: "failure"` audit with the rejection reason.
     mockResetResult = { ok: false, reason: "invalid_status", error: "Cannot retry" };
     const res = await request("POST", "/migrate/mig-1/retry");
     expect(res.status).toBe(400);
-    expect(mockLogAdminAction).not.toHaveBeenCalled();
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.actionType).toBe("residency.migration_retry");
+    expect(entry.status).toBe("failure");
+    expect(entry.metadata.reason).toBe("invalid_status");
+  });
+
+  it("POST /migrate/:id/retry emits a failure audit when reset throws (409 path)", async () => {
+    // The unsafe-reset throw path must also land an audit. tapErrorCause fires
+    // before the bridge converts the tagged error to 409, so the forensic
+    // trail captures the most compliance-relevant outcome in this file.
+    mockResetThrow = Object.assign(
+      new Error("Migration cannot be reset: workspace already moved to eu-west"),
+      {
+        _tag: "UnsafeRegionMigrationResetError" as const,
+        migrationId: "mig-1",
+        workspaceId: "org-1",
+        targetRegion: "eu-west",
+        sourceRegion: "us-east",
+      },
+    );
+    const res = await request("POST", "/migrate/mig-1/retry");
+    expect(res.status).toBe(409);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = mockLogAdminAction.mock.calls[0]![0];
+    expect(entry.actionType).toBe("residency.migration_retry");
+    expect(entry.status).toBe("failure");
+    expect(entry.metadata.error).toContain("already moved");
   });
 
   it("POST /migrate/:id/cancel emits residency.migration_cancel on success", async () => {

--- a/packages/api/src/api/__tests__/admin-residency.test.ts
+++ b/packages/api/src/api/__tests__/admin-residency.test.ts
@@ -1059,7 +1059,7 @@ describe("admin residency — F-32 audit emission", () => {
     const entry = mockLogAdminAction.mock.calls[0]![0];
     expect(entry.actionType).toBe("residency.migration_retry");
     expect(entry.status).toBe("failure");
-    expect(entry.metadata.reason).toBe("invalid_status");
+    expect((entry.metadata as { reason?: string } | undefined)?.reason).toBe("invalid_status");
   });
 
   it("POST /migrate/:id/retry emits a failure audit when reset throws (409 path)", async () => {
@@ -1082,7 +1082,7 @@ describe("admin residency — F-32 audit emission", () => {
     const entry = mockLogAdminAction.mock.calls[0]![0];
     expect(entry.actionType).toBe("residency.migration_retry");
     expect(entry.status).toBe("failure");
-    expect(entry.metadata.error).toContain("already moved");
+    expect((entry.metadata as { error?: string } | undefined)?.error).toContain("already moved");
   });
 
   it("POST /migrate/:id/cancel emits residency.migration_cancel on success", async () => {

--- a/packages/api/src/api/routes/admin-residency.ts
+++ b/packages/api/src/api/routes/admin-residency.ts
@@ -772,6 +772,7 @@ adminResidency.openapi(requestMigrationRoute, async (c) => {
 // ---------------------------------------------------------------------------
 
 adminResidency.openapi(retryMigrationRoute, async (c) => {
+  const ipAddress = clientIP(c);
   return runEffect(
     c,
     Effect.gen(function* () {
@@ -783,17 +784,46 @@ adminResidency.openapi(retryMigrationRoute, async (c) => {
         return c.json({ error: "not_available", message: "Migration tracking requires an internal database.", requestId }, 404);
       }
 
-      // #1986 — `resetMigrationForRetry` throws `UnsafeRegionMigrationResetError`
-      // when the workspace already moved to the destination region. `tryPromise`
-      // (with a normalized catch — never `(err) => err`) preserves the tagged
-      // error in the failure channel so `runEffect` → `mapTaggedError` returns
-      // 409 Conflict. Returning a result variant for this case would let an
-      // operator paper over the data-integrity hazard with a 400 retry button.
+      // `resetMigrationForRetry` throws `UnsafeRegionMigrationResetError`
+      // when the workspace already moved to the destination region. The
+      // tryPromise catch (normalized — never `(err) => err`) preserves the
+      // tagged error so runEffect → mapTaggedError returns 409 Conflict.
+      // tapErrorCause covers BOTH typed failures and defects, mirroring the
+      // assignWorkspaceRegion pattern: a 409 here is the most compliance-
+      // relevant outcome in the file (an operator attempted to undo a
+      // half-completed cross-region cutover) and the runbook explicitly
+      // requires a forensic trail showing the guard fired.
       const result = yield* Effect.tryPromise({
         try: () => resetMigrationForRetry(id, orgId!),
         catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-      });
+      }).pipe(
+        Effect.tapErrorCause((cause) => {
+          const err = causeToError(cause);
+          if (err === undefined) return Effect.void;
+          return Effect.sync(() =>
+            logAdminAction({
+              actionType: ADMIN_ACTIONS.residency.migrationRetry,
+              targetType: "residency",
+              targetId: id,
+              status: "failure",
+              ipAddress,
+              metadata: { workspaceId: orgId, error: errorMessage(err) },
+            }),
+          );
+        }),
+      );
       if (!result.ok) {
+        // Result-variant rejection (not_found / invalid_status / db_error /
+        // no_db). Audit the attempt so the forensic trail covers operator
+        // probes that never reach the unsafe-reset throw path.
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.residency.migrationRetry,
+          targetType: "residency",
+          targetId: id,
+          status: "failure",
+          ipAddress,
+          metadata: { workspaceId: orgId, reason: result.reason, error: result.error },
+        });
         const status = result.reason === "not_found" ? 404 : 400;
         return c.json({ error: "retry_failed", message: result.error, requestId }, status as 400 | 404);
       }

--- a/packages/api/src/api/routes/admin-residency.ts
+++ b/packages/api/src/api/routes/admin-residency.ts
@@ -783,7 +783,16 @@ adminResidency.openapi(retryMigrationRoute, async (c) => {
         return c.json({ error: "not_available", message: "Migration tracking requires an internal database.", requestId }, 404);
       }
 
-      const result = yield* Effect.promise(() => resetMigrationForRetry(id, orgId!));
+      // #1986 — `resetMigrationForRetry` throws `UnsafeRegionMigrationResetError`
+      // when the workspace already moved to the destination region. `tryPromise`
+      // (with a normalized catch — never `(err) => err`) preserves the tagged
+      // error in the failure channel so `runEffect` → `mapTaggedError` returns
+      // 409 Conflict. Returning a result variant for this case would let an
+      // operator paper over the data-integrity hazard with a 400 retry button.
+      const result = yield* Effect.tryPromise({
+        try: () => resetMigrationForRetry(id, orgId!),
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      });
       if (!result.ok) {
         const status = result.reason === "not_found" ? 404 : 400;
         return c.json({ error: "retry_failed", message: result.error, requestId }, status as 400 | 404);

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -288,6 +288,7 @@ describe("migrateAuthTables", () => {
             { name: "0040_drop_integration_plaintext.sql" },
             { name: "0041_dashboard_card_layout.sql" },
             { name: "0042_audit_retention_default.sql" },
+            { name: "0043_region_migration_region_updated.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -79,7 +79,7 @@ describe("runMigrations", () => {
 
     const count = await runMigrations(pool);
 
-    expect(count).toBe(43);
+    expect(count).toBe(44);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -151,6 +151,7 @@ describe("runMigrations", () => {
         "0040_drop_integration_plaintext.sql",
         "0041_dashboard_card_layout.sql",
         "0042_audit_retention_default.sql",
+        "0043_region_migration_region_updated.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0043_region_migration_region_updated.sql
+++ b/packages/api/src/lib/db/migrations/0043_region_migration_region_updated.sql
@@ -19,8 +19,11 @@
 -- persist region_updated. Those rows are conservatively safe to retry from
 -- Phase 1 only because the legacy executor never had a way to leak Phase 3
 -- success into a `failed` state — the warning was always operator-readable.
--- New writes from the executor flip the column to TRUE the moment Phase 3
--- succeeds, well before Phase 4 starts.
+-- New writes from the executor stamp the column from a process-local flag
+-- inside Phase 3 (immediately after `organization.region` is updated) AND
+-- inside the failure-path catch (atomically with status='failed'), so the
+-- column converges on the executor's observed state regardless of which
+-- write path runs.
 --
 -- Issue: #1986
 

--- a/packages/api/src/lib/db/migrations/0043_region_migration_region_updated.sql
+++ b/packages/api/src/lib/db/migrations/0043_region_migration_region_updated.sql
@@ -1,0 +1,28 @@
+-- 0043 — Persist region_updated on region_migrations rows (#1986).
+--
+-- Phase 3 of executeRegionMigration() (the cutover) flips the workspace into
+-- the destination region by updating organization.region. Before this column
+-- existed, that fact lived only in a local variable in the executor process
+-- — so a Phase 4 failure would mark the row `failed` with a warning baked
+-- into error_message, and resetMigrationForRetry() had no way to tell that
+-- re-running Phase 1 (export from source) would re-export a workspace that
+-- already moved to the destination → data integrity hazard.
+--
+-- region_updated = TRUE means: the destination has taken ownership. The
+-- guard in resetMigrationForRetry() (lib/residency/migrate.ts) refuses to
+-- flip such a row back to `pending` and surfaces UnsafeRegionMigrationResetError
+-- (mapped to HTTP 409). Recovery requires the manual-intervention runbook in
+-- apps/docs/content/docs/platform-ops/data-residency.mdx.
+--
+-- DEFAULT FALSE backfills cleanly: any pre-existing `failed` row predates
+-- this migration and was therefore created by an executor that did not
+-- persist region_updated. Those rows are conservatively safe to retry from
+-- Phase 1 only because the legacy executor never had a way to leak Phase 3
+-- success into a `failed` state — the warning was always operator-readable.
+-- New writes from the executor flip the column to TRUE the moment Phase 3
+-- succeeds, well before Phase 4 starts.
+--
+-- Issue: #1986
+
+ALTER TABLE region_migrations
+  ADD COLUMN IF NOT EXISTS region_updated BOOLEAN NOT NULL DEFAULT FALSE;

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -1248,6 +1248,11 @@ export const regionMigrations = pgTable(
     errorMessage: text("error_message"),
     requestedAt: timestamp("requested_at", { withTimezone: true }).notNull().defaultNow(),
     completedAt: timestamp("completed_at", { withTimezone: true }),
+    // #1986 — Phase 3 cutover sets this to TRUE the moment the destination
+    // region takes ownership. Read by resetMigrationForRetry() to refuse
+    // re-running Phase 1 (export from source) on a workspace that already
+    // moved. See migration 0043 and lib/residency/migrate.ts.
+    regionUpdated: boolean("region_updated").notNull().default(false),
   },
   (t) => [
     index("idx_region_migrations_workspace").on(t.workspaceId),

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -1248,10 +1248,9 @@ export const regionMigrations = pgTable(
     errorMessage: text("error_message"),
     requestedAt: timestamp("requested_at", { withTimezone: true }).notNull().defaultNow(),
     completedAt: timestamp("completed_at", { withTimezone: true }),
-    // #1986 — Phase 3 cutover sets this to TRUE the moment the destination
-    // region takes ownership. Read by resetMigrationForRetry() to refuse
-    // re-running Phase 1 (export from source) on a workspace that already
-    // moved. See migration 0043 and lib/residency/migrate.ts.
+    // Phase 3 cutover stamps this to TRUE when the destination takes
+    // ownership. Read by resetMigrationForRetry() to refuse re-running
+    // Phase 1 (export from source) on a workspace that already moved.
     regionUpdated: boolean("region_updated").notNull().default(false),
   },
   (t) => [

--- a/packages/api/src/lib/effect/__tests__/hono.test.ts
+++ b/packages/api/src/lib/effect/__tests__/hono.test.ts
@@ -236,6 +236,7 @@ describe("mapTaggedError", () => {
         migrationId: "mig-1",
         workspaceId: "org-1",
         targetRegion: "eu-west",
+        sourceRegion: "us-east",
       }),
     );
     expect(result.status).toBe(409);

--- a/packages/api/src/lib/effect/__tests__/hono.test.ts
+++ b/packages/api/src/lib/effect/__tests__/hono.test.ts
@@ -43,6 +43,7 @@ const {
   SchedulerTaskTimeoutError,
   SchedulerExecutionError,
   DeliveryError,
+  UnsafeRegionMigrationResetError,
 } = await import("../errors");
 
 // ---------------------------------------------------------------------------
@@ -226,6 +227,20 @@ describe("mapTaggedError", () => {
     const result = mapTaggedError(new DeliveryError({ message: "Failed", channel: "webhook", recipient: "url", permanent: false }));
     expect(result.status).toBe(502);
     expect(result.code).toBe("upstream_error");
+  });
+
+  it("maps UnsafeRegionMigrationResetError to 409", () => {
+    const result = mapTaggedError(
+      new UnsafeRegionMigrationResetError({
+        message: "Cannot reset",
+        migrationId: "mig-1",
+        workspaceId: "org-1",
+        targetRegion: "eu-west",
+      }),
+    );
+    expect(result.status).toBe(409);
+    expect(result.code).toBe("conflict");
+    expect(result.message).toBe("Cannot reset");
   });
 });
 

--- a/packages/api/src/lib/effect/errors.ts
+++ b/packages/api/src/lib/effect/errors.ts
@@ -193,8 +193,8 @@ export class ConversationBudgetExceededError extends Data.TaggedError("Conversat
  * already flipped the workspace into the destination region. Re-running
  * Phase 1 (export from source) on a workspace that already moved would
  * re-export stale data and corrupt the destination — so the code path
- * is closed entirely. Operators must follow the manual-intervention
- * runbook in apps/docs/content/docs/platform-ops/data-residency.mdx.
+ * is closed entirely. Operators must follow the data-residency
+ * manual-intervention runbook.
  *
  * Maps to HTTP 409 Conflict.
  */
@@ -202,7 +202,10 @@ export class UnsafeRegionMigrationResetError extends Data.TaggedError("UnsafeReg
   readonly message: string;
   readonly migrationId: string;
   readonly workspaceId: string;
+  /** Region the workspace already moved to (i.e. the destination that took ownership). */
   readonly targetRegion: string;
+  /** Region the workspace moved from — runbook step 1 needs it to locate the orphaned source bundle. */
+  readonly sourceRegion: string;
 }> {}
 
 // ── Scheduler ──────────────────────────────────────────────────────

--- a/packages/api/src/lib/effect/errors.ts
+++ b/packages/api/src/lib/effect/errors.ts
@@ -186,6 +186,25 @@ export class ConversationBudgetExceededError extends Data.TaggedError("Conversat
   readonly cap: number;
 }> {}
 
+// ── Region Migration ───────────────────────────────────────────────
+
+/**
+ * Reset of a region migration was rejected because Phase 3 (cutover) had
+ * already flipped the workspace into the destination region. Re-running
+ * Phase 1 (export from source) on a workspace that already moved would
+ * re-export stale data and corrupt the destination — so the code path
+ * is closed entirely. Operators must follow the manual-intervention
+ * runbook in apps/docs/content/docs/platform-ops/data-residency.mdx.
+ *
+ * Maps to HTTP 409 Conflict.
+ */
+export class UnsafeRegionMigrationResetError extends Data.TaggedError("UnsafeRegionMigrationResetError")<{
+  readonly message: string;
+  readonly migrationId: string;
+  readonly workspaceId: string;
+  readonly targetRegion: string;
+}> {}
+
 // ── Scheduler ──────────────────────────────────────────────────────
 
 /** Scheduled task execution timed out. */
@@ -233,6 +252,7 @@ export type AtlasError =
   | CustomValidatorError
   | ActionTimeoutError
   | ConversationBudgetExceededError
+  | UnsafeRegionMigrationResetError
   | SchedulerTaskTimeoutError
   | SchedulerExecutionError
   | DeliveryError
@@ -270,6 +290,7 @@ export const ATLAS_ERROR_TAG_LIST = [
   "CustomValidatorError",
   "ActionTimeoutError",
   "ConversationBudgetExceededError",
+  "UnsafeRegionMigrationResetError",
   "SchedulerTaskTimeoutError",
   "SchedulerExecutionError",
   "DeliveryError",

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -153,9 +153,6 @@ export function mapTaggedError(error: AtlasError): HttpErrorMapping {
       return { status: 404, code: "not_found", message: error.message };
 
     // ── 409 Conflict — operation rejected because of resource state ─
-    // #1986 — `resetMigrationForRetry` rejects when Phase 3 already
-    // flipped the workspace into the destination region. The caller
-    // can't progress without out-of-band runbook steps.
     case "UnsafeRegionMigrationResetError":
       return { status: 409, code: "conflict", message: error.message };
 

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -80,6 +80,7 @@ type HttpErrorCode =
   | "bad_request"
   | "forbidden"
   | "not_found"
+  | "conflict"
   | "unprocessable_entity"
   | "rate_limited"
   | "conversation_budget_exceeded"
@@ -150,6 +151,13 @@ export function mapTaggedError(error: AtlasError): HttpErrorMapping {
     // ── 404 Not Found ────────────────────────────────────────────
     case "ConnectionNotFoundError":
       return { status: 404, code: "not_found", message: error.message };
+
+    // ── 409 Conflict — operation rejected because of resource state ─
+    // #1986 — `resetMigrationForRetry` rejects when Phase 3 already
+    // flipped the workspace into the destination region. The caller
+    // can't progress without out-of-band runbook steps.
+    case "UnsafeRegionMigrationResetError":
+      return { status: 409, code: "conflict", message: error.message };
 
     // ── 422 Unprocessable Entity — plugin rejected ───────────────
     case "PluginRejectedError":

--- a/packages/api/src/lib/residency/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate.test.ts
@@ -401,7 +401,9 @@ describe("resetMigrationForRetry", () => {
   });
 
   it("resets a failed migration to pending", async () => {
-    mockQueryResults["SELECT id, status"] = [{ id: "mig-1", status: "failed", workspace_id: "org-1" }];
+    mockQueryResults["SELECT id, status"] = [
+      { id: "mig-1", status: "failed", workspace_id: "org-1", region_updated: false },
+    ];
     mockQueryResults["UPDATE region_migrations"] = [];
 
     const result = await resetMigrationForRetry("mig-1", "org-1");
@@ -411,6 +413,33 @@ describe("resetMigrationForRetry", () => {
       (q) => q.sql.includes("status = 'pending'"),
     );
     expect(resetQuery).toBeDefined();
+  });
+
+  // #1986 — once Phase 3 has flipped the workspace into the destination region,
+  // re-running Phase 1 (export from source) would re-export a workspace that
+  // already moved. The guard makes the unsafe reset impossible from code; the
+  // operator is forced to follow the manual-intervention runbook.
+  it("throws UnsafeRegionMigrationResetError when region_updated=true", async () => {
+    mockQueryResults["SELECT id, status"] = [
+      { id: "mig-1", status: "failed", workspace_id: "org-1", region_updated: true },
+    ];
+    mockQueryResults["UPDATE region_migrations"] = [];
+
+    let thrown: unknown;
+    try {
+      await resetMigrationForRetry("mig-1", "org-1");
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeDefined();
+    expect((thrown as { _tag?: string })._tag).toBe("UnsafeRegionMigrationResetError");
+    expect((thrown as { migrationId?: string }).migrationId).toBe("mig-1");
+
+    // Critically: no UPDATE was issued. The row must remain in `failed` so
+    // operators see it in the audit trail and follow the runbook.
+    const resetQuery = capturedQueries.find((q) => q.sql.includes("status = 'pending'"));
+    expect(resetQuery).toBeUndefined();
   });
 });
 

--- a/packages/api/src/lib/residency/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate.test.ts
@@ -12,6 +12,10 @@ import { describe, it, expect, beforeEach, mock, afterEach } from "bun:test";
 let mockHasInternalDB = true;
 let mockQueryResults: Record<string, unknown[]> = {};
 let mockQueryError: Error | null = null;
+// Per-SQL injection: when set, internalQuery rejects on the first call whose
+// SQL contains the pattern. Used to exercise transient-failure paths on a
+// specific statement without breaking unrelated queries.
+let mockInternalQueryRejectPattern: { pattern: string; error: Error } | null = null;
 let mockPoolQueryResult = { rows: [{ id: "org-1" }] };
 let mockPoolQueryError: Error | null = null;
 const capturedQueries: Array<{ sql: string; params: unknown[] }> = [];
@@ -36,6 +40,9 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   internalQuery: (sql: string, params: unknown[]) => {
     capturedQueries.push({ sql, params });
     if (mockQueryError) return Promise.reject(mockQueryError);
+    if (mockInternalQueryRejectPattern && sql.includes(mockInternalQueryRejectPattern.pattern)) {
+      return Promise.reject(mockInternalQueryRejectPattern.error);
+    }
     // Match query to result based on SQL pattern
     for (const [key, value] of Object.entries(mockQueryResults)) {
       if (sql.includes(key)) return Promise.resolve(value);
@@ -116,6 +123,7 @@ function resetMocks() {
   mockHasInternalDB = true;
   mockQueryResults = {};
   mockQueryError = null;
+  mockInternalQueryRejectPattern = null;
   mockPoolQueryResult = { rows: [{ id: "org-1" }] };
   mockPoolQueryError = null;
   capturedQueries.length = 0;
@@ -301,6 +309,107 @@ describe("executeRegionMigration", () => {
     expect(result.success).toBe(false);
     if (!result.success) expect(result.error).toContain("connection refused");
   });
+
+  // Regression: the dedicated Phase 3 persist runs immediately after the org
+  // region UPDATE and before the status='completed' write. If a refactor moves
+  // it behind the cache flush (or a Phase 4 step) a future failure between
+  // those points would leave the guard column in a stale state.
+  it("persists region_updated=TRUE between the org cutover and status=completed", async () => {
+    mockQueryResults["SELECT id, workspace_id"] = [
+      { id: "mig-1", workspace_id: "org-1", source_region: "us-east", target_region: "eu-west", status: "pending" },
+    ];
+    mockQueryResults["UPDATE region_migrations"] = [];
+
+    const result = await executeRegionMigration("mig-1");
+    expect(result.success).toBe(true);
+
+    const orgUpdateIdx = capturedQueries.findIndex((q) => q.sql.includes("UPDATE organization"));
+    const persistIdx = capturedQueries.findIndex((q) => q.sql.includes("region_updated = TRUE"));
+    const completeIdx = capturedQueries.findIndex(
+      (q) => q.sql.includes("UPDATE region_migrations") && q.params[0] === "completed",
+    );
+
+    expect(orgUpdateIdx).toBeGreaterThanOrEqual(0);
+    expect(persistIdx).toBeGreaterThanOrEqual(0);
+    expect(completeIdx).toBeGreaterThanOrEqual(0);
+    // Strict ordering: cutover → persist → completed.
+    expect(persistIdx).toBeGreaterThan(orgUpdateIdx);
+    expect(persistIdx).toBeLessThan(completeIdx);
+    // The persist UPDATE targets the right migration row.
+    expect(capturedQueries[persistIdx].params).toContain("mig-1");
+  });
+
+  // Regression: even if the dedicated Phase 3 persist fails (transient pool
+  // blip), the failure-path catch must atomically stamp region_updated=true
+  // alongside status='failed' from the in-memory flag — otherwise the guard
+  // fails open and the workspace ends up reset-eligible despite having moved.
+  it("stamps region_updated=true atomically with status=failed when the dedicated persist throws", async () => {
+    mockQueryResults["SELECT id, workspace_id"] = [
+      { id: "mig-1", workspace_id: "org-1", source_region: "us-east", target_region: "eu-west", status: "pending" },
+    ];
+    mockQueryResults["UPDATE region_migrations"] = [];
+
+    // Targeted injection: the dedicated `region_updated = TRUE` UPDATE
+    // throws; every other write keeps working. This is the exact transient-
+    // failure profile that, before the catch-block atomic stamp was added,
+    // would leave the row with status='failed' and region_updated=FALSE
+    // even though `organization.region` had already been flipped.
+    mockInternalQueryRejectPattern = {
+      pattern: "SET region_updated = TRUE",
+      error: new Error("transient pool drop"),
+    };
+
+    const result = await executeRegionMigration("mig-1");
+    expect(result.success).toBe(false);
+
+    // The org cutover succeeded before the persist throw fired.
+    const orgUpdate = capturedQueries.find((q) => q.sql.includes("UPDATE organization"));
+    expect(orgUpdate).toBeDefined();
+    expect(orgUpdate!.params).toContain("eu-west");
+
+    // The catch block writes status='failed' AND region_updated=true in a
+    // single UPDATE via updateMigrationStatus. Confirm both land in the
+    // same statement — partial state would mean the guard fails open.
+    const failedUpdate = capturedQueries.find(
+      (q) =>
+        q.sql.includes("UPDATE region_migrations")
+        && q.sql.includes("region_updated")
+        && q.params.includes("failed"),
+    );
+    expect(failedUpdate).toBeDefined();
+    expect(failedUpdate!.params).toContain(true);
+  });
+
+  // Regression: when the failure happens before Phase 3, the catch stamps
+  // region_updated=FALSE — a no-op against the default but truthful about
+  // the executor's observation. A future retry then legitimately re-runs
+  // Phase 1 because the guard sees region_updated=FALSE.
+  it("stamps region_updated=false when failure occurs before Phase 3", async () => {
+    mockQueryResults["SELECT id, workspace_id"] = [
+      { id: "mig-1", workspace_id: "org-1", source_region: "us-east", target_region: "eu-west", status: "pending" },
+    ];
+    mockQueryResults["UPDATE region_migrations"] = [];
+    mockFetchResponse = { ok: false, status: 500, body: { message: "Import failed" } };
+
+    const result = await executeRegionMigration("mig-1");
+    expect(result.success).toBe(false);
+
+    // Phase 3 never ran, so no org UPDATE.
+    const orgUpdate = capturedQueries.find((q) => q.sql.includes("UPDATE organization"));
+    expect(orgUpdate).toBeUndefined();
+
+    // The failed-status UPDATE includes region_updated=FALSE — the catch
+    // converges on the executor's observation in both directions.
+    const failedUpdate = capturedQueries.find(
+      (q) =>
+        q.sql.includes("UPDATE region_migrations")
+        && q.sql.includes("region_updated")
+        && q.params.includes("failed"),
+    );
+    expect(failedUpdate).toBeDefined();
+    expect(failedUpdate!.params).toContain(false);
+    expect(failedUpdate!.params).not.toContain(true);
+  });
 });
 
 describe("failStaleMigrations", () => {
@@ -402,7 +511,7 @@ describe("resetMigrationForRetry", () => {
 
   it("resets a failed migration to pending", async () => {
     mockQueryResults["SELECT id, status"] = [
-      { id: "mig-1", status: "failed", workspace_id: "org-1", region_updated: false },
+      { id: "mig-1", status: "failed", workspace_id: "org-1", region_updated: false, target_region: "eu-west", source_region: "us-east" },
     ];
     mockQueryResults["UPDATE region_migrations"] = [];
 
@@ -415,13 +524,13 @@ describe("resetMigrationForRetry", () => {
     expect(resetQuery).toBeDefined();
   });
 
-  // #1986 — once Phase 3 has flipped the workspace into the destination region,
+  // Once Phase 3 has flipped the workspace into the destination region,
   // re-running Phase 1 (export from source) would re-export a workspace that
   // already moved. The guard makes the unsafe reset impossible from code; the
   // operator is forced to follow the manual-intervention runbook.
   it("throws UnsafeRegionMigrationResetError when region_updated=true", async () => {
     mockQueryResults["SELECT id, status"] = [
-      { id: "mig-1", status: "failed", workspace_id: "org-1", region_updated: true },
+      { id: "mig-1", status: "failed", workspace_id: "org-1", region_updated: true, target_region: "eu-west", source_region: "us-east" },
     ];
     mockQueryResults["UPDATE region_migrations"] = [];
 
@@ -433,8 +542,14 @@ describe("resetMigrationForRetry", () => {
     }
 
     expect(thrown).toBeDefined();
-    expect((thrown as { _tag?: string })._tag).toBe("UnsafeRegionMigrationResetError");
-    expect((thrown as { migrationId?: string }).migrationId).toBe("mig-1");
+    const tagged = thrown as { _tag?: string; migrationId?: string; sourceRegion?: string; targetRegion?: string; message?: string };
+    expect(tagged._tag).toBe("UnsafeRegionMigrationResetError");
+    expect(tagged.migrationId).toBe("mig-1");
+    expect(tagged.sourceRegion).toBe("us-east");
+    expect(tagged.targetRegion).toBe("eu-west");
+    // Message names both regions so operators can find the orphaned source bundle.
+    expect(tagged.message).toContain("us-east");
+    expect(tagged.message).toContain("eu-west");
 
     // Critically: no UPDATE was issued. The row must remain in `failed` so
     // operators see it in the audit trail and follow the runbook.

--- a/packages/api/src/lib/residency/migrate.ts
+++ b/packages/api/src/lib/residency/migrate.ts
@@ -63,7 +63,7 @@ function logMigrationEvent(
 async function updateMigrationStatus(
   migrationId: string,
   status: MigrationStatus,
-  extra?: { errorMessage?: string; completedAt?: string },
+  extra?: { errorMessage?: string; completedAt?: string; regionUpdated?: boolean },
 ): Promise<void> {
   const sets = [`status = $1`];
   const params: unknown[] = [status];
@@ -77,6 +77,16 @@ async function updateMigrationStatus(
   if (extra?.errorMessage !== undefined) {
     sets.push(`error_message = $${idx}`);
     params.push(extra.errorMessage);
+    idx++;
+  }
+  // Folded into the same UPDATE so the failure path stamps the guard column
+  // atomically with the status flip. Without this, a Phase 4 failure that
+  // survived the dedicated `region_updated` persist (or a transient failure
+  // on the persist itself) would leave status='failed' + region_updated=FALSE
+  // and the resetMigrationForRetry guard would fail open.
+  if (extra?.regionUpdated !== undefined) {
+    sets.push(`region_updated = $${idx}`);
+    params.push(extra.regionUpdated);
     idx++;
   }
 
@@ -273,12 +283,12 @@ export async function executeRegionMigration(
     }
     regionUpdated = true;
 
-    // #1986 — Persist the cutover *immediately*, before flush/Phase 4 can
-    // throw, so a Phase 4 failure surfaces as `failed` + `region_updated=true`
-    // and resetMigrationForRetry() refuses to re-run Phase 1 (which would
-    // re-export a workspace that already moved). The only way to lose this
-    // signal is if the persist itself fails — in which case we throw and
-    // the catch block re-records the error with the region-updated warning.
+    // Persist the cutover happy-path before flush/Phase 4 can throw so the
+    // column reflects reality the instant the destination takes ownership.
+    // If this UPDATE itself fails, the failure-path catch (below) re-stamps
+    // from the local `regionUpdated` flag via updateMigrationStatus, so
+    // both write paths converge on the same column value — the guard's
+    // correctness does not depend on this UPDATE succeeding.
     await internalQuery(
       `UPDATE region_migrations SET region_updated = TRUE WHERE id = $1`,
       [migrationId],
@@ -346,17 +356,21 @@ export async function executeRegionMigration(
       regionUpdated,
     });
 
-    // Mark as failed — the region update may have already happened.
-    // The error message includes a warning if retry would be unsafe.
+    // Mark as failed and atomically stamp `region_updated` from the local
+    // var. This single UPDATE is the load-bearing convergence point for the
+    // guard column: regardless of whether the dedicated cutover persist at
+    // line 282 succeeded, threw, or was never reached, the failed row's
+    // `region_updated` will mirror what the executor actually observed.
     try {
       await updateMigrationStatus(migrationId, "failed", {
         errorMessage,
         completedAt: new Date().toISOString(),
+        regionUpdated,
       });
     } catch (updateErr) {
       log.error(
-        { err: updateErr instanceof Error ? updateErr.message : String(updateErr), migrationId },
-        "Failed to update migration status to 'failed'",
+        { err: updateErr instanceof Error ? updateErr.message : String(updateErr), migrationId, regionUpdated },
+        "Failed to update migration status to 'failed' — region_updated column may not reflect actual cutover state",
       );
     }
 
@@ -478,8 +492,8 @@ export async function getCleanupDueMigrations(): Promise<
  * Reset a failed migration to "pending" so it can be re-executed.
  * Only works for migrations in "failed" status.
  *
- * #1986 — Throws `UnsafeRegionMigrationResetError` (mapped to HTTP 409) when
- * the failed row has `region_updated = TRUE`. Phase 3 already flipped the
+ * Throws `UnsafeRegionMigrationResetError` (mapped to HTTP 409) when the
+ * failed row has `region_updated = TRUE`. Phase 3 already flipped the
  * workspace into the destination; re-running Phase 1 would re-export a
  * workspace that already moved. Recovery requires the manual-intervention
  * runbook, not retry.
@@ -494,7 +508,14 @@ export async function resetMigrationForRetry(
     return { ok: false, reason: "no_db", error: "Internal database not available" };
   }
 
-  let rows: Array<{ id: string; status: string; workspace_id: string; region_updated: boolean; target_region: string }>;
+  let rows: Array<{
+    id: string;
+    status: string;
+    workspace_id: string;
+    region_updated: boolean;
+    target_region: string;
+    source_region: string;
+  }>;
   try {
     rows = await internalQuery<{
       id: string;
@@ -502,8 +523,9 @@ export async function resetMigrationForRetry(
       workspace_id: string;
       region_updated: boolean;
       target_region: string;
+      source_region: string;
     }>(
-      `SELECT id, status, workspace_id, region_updated, target_region FROM region_migrations WHERE id = $1`,
+      `SELECT id, status, workspace_id, region_updated, target_region, source_region FROM region_migrations WHERE id = $1`,
       [migrationId],
     );
   } catch (err) {
@@ -525,22 +547,23 @@ export async function resetMigrationForRetry(
     return { ok: false, reason: "invalid_status", error: `Cannot retry migration in "${row.status}" status` };
   }
 
-  // #1986 — Hard guard: never re-run Phase 1 on a row where Phase 3 already
-  // succeeded. Throw a typed error so the route handler maps it to 409 and
-  // the operator is forced through the manual-intervention runbook.
+  // Hard guard: never re-run Phase 1 on a row where Phase 3 already succeeded.
+  // Throw a typed error so the route handler maps it to 409 and the operator
+  // is forced through the manual-intervention runbook.
   if (row.region_updated) {
     log.warn(
-      { migrationId, workspaceId, targetRegion: row.target_region },
+      { migrationId, workspaceId, targetRegion: row.target_region, sourceRegion: row.source_region },
       "Refused to reset migration — region was already updated to destination",
     );
     throw new UnsafeRegionMigrationResetError({
       message:
-        `Migration "${migrationId}" cannot be reset: the workspace has already moved to ` +
-        `"${row.target_region}". Re-running export from the source would corrupt the ` +
-        `destination. Follow the manual-intervention runbook in the data-residency docs.`,
+        `Migration "${migrationId}" cannot be reset: the workspace has already moved from ` +
+        `"${row.source_region}" to "${row.target_region}". Re-running export from the source ` +
+        `would corrupt the destination. Follow the manual-intervention runbook in the data-residency docs.`,
       migrationId,
       workspaceId,
       targetRegion: row.target_region,
+      sourceRegion: row.source_region,
     });
   }
 

--- a/packages/api/src/lib/residency/migrate.ts
+++ b/packages/api/src/lib/residency/migrate.ts
@@ -17,6 +17,7 @@
 import { createLogger } from "@atlas/api/lib/logger";
 import { hasInternalDB, internalQuery, getInternalDB } from "@atlas/api/lib/db/internal";
 import { getConfig } from "@atlas/api/lib/config";
+import { UnsafeRegionMigrationResetError } from "@atlas/api/lib/effect/errors";
 import { exportWorkspaceBundle } from "./export";
 import type { MigrationStatus, MigrationPhase, ExportBundle } from "@useatlas/types";
 
@@ -272,6 +273,17 @@ export async function executeRegionMigration(
     }
     regionUpdated = true;
 
+    // #1986 — Persist the cutover *immediately*, before flush/Phase 4 can
+    // throw, so a Phase 4 failure surfaces as `failed` + `region_updated=true`
+    // and resetMigrationForRetry() refuses to re-run Phase 1 (which would
+    // re-export a workspace that already moved). The only way to lose this
+    // signal is if the persist itself fails — in which case we throw and
+    // the catch block re-records the error with the region-updated warning.
+    await internalQuery(
+      `UPDATE region_migrations SET region_updated = TRUE WHERE id = $1`,
+      [migrationId],
+    );
+
     // Flush cached data
     try {
       const { flushCache } = await import("@atlas/api/lib/cache/index");
@@ -466,6 +478,12 @@ export async function getCleanupDueMigrations(): Promise<
  * Reset a failed migration to "pending" so it can be re-executed.
  * Only works for migrations in "failed" status.
  *
+ * #1986 — Throws `UnsafeRegionMigrationResetError` (mapped to HTTP 409) when
+ * the failed row has `region_updated = TRUE`. Phase 3 already flipped the
+ * workspace into the destination; re-running Phase 1 would re-export a
+ * workspace that already moved. Recovery requires the manual-intervention
+ * runbook, not retry.
+ *
  * @param workspaceId - The org ID that owns this migration (for authorization).
  */
 export async function resetMigrationForRetry(
@@ -476,24 +494,57 @@ export async function resetMigrationForRetry(
     return { ok: false, reason: "no_db", error: "Internal database not available" };
   }
 
+  let rows: Array<{ id: string; status: string; workspace_id: string; region_updated: boolean; target_region: string }>;
   try {
-    const rows = await internalQuery<{ id: string; status: string; workspace_id: string }>(
-      `SELECT id, status, workspace_id FROM region_migrations WHERE id = $1`,
+    rows = await internalQuery<{
+      id: string;
+      status: string;
+      workspace_id: string;
+      region_updated: boolean;
+      target_region: string;
+    }>(
+      `SELECT id, status, workspace_id, region_updated, target_region FROM region_migrations WHERE id = $1`,
       [migrationId],
     );
+  } catch (err) {
+    log.error({ err: err instanceof Error ? err.message : String(err), migrationId }, "Failed to load migration for retry");
+    return { ok: false, reason: "db_error", error: "Database error while resetting migration" };
+  }
 
-    if (rows.length === 0) {
-      return { ok: false, reason: "not_found", error: "Migration not found" };
-    }
+  if (rows.length === 0) {
+    return { ok: false, reason: "not_found", error: "Migration not found" };
+  }
 
-    if (rows[0].workspace_id !== workspaceId) {
-      return { ok: false, reason: "not_found", error: "Migration not found" };
-    }
+  const row = rows[0];
 
-    if (rows[0].status !== "failed") {
-      return { ok: false, reason: "invalid_status", error: `Cannot retry migration in "${rows[0].status}" status` };
-    }
+  if (row.workspace_id !== workspaceId) {
+    return { ok: false, reason: "not_found", error: "Migration not found" };
+  }
 
+  if (row.status !== "failed") {
+    return { ok: false, reason: "invalid_status", error: `Cannot retry migration in "${row.status}" status` };
+  }
+
+  // #1986 — Hard guard: never re-run Phase 1 on a row where Phase 3 already
+  // succeeded. Throw a typed error so the route handler maps it to 409 and
+  // the operator is forced through the manual-intervention runbook.
+  if (row.region_updated) {
+    log.warn(
+      { migrationId, workspaceId, targetRegion: row.target_region },
+      "Refused to reset migration — region was already updated to destination",
+    );
+    throw new UnsafeRegionMigrationResetError({
+      message:
+        `Migration "${migrationId}" cannot be reset: the workspace has already moved to ` +
+        `"${row.target_region}". Re-running export from the source would corrupt the ` +
+        `destination. Follow the manual-intervention runbook in the data-residency docs.`,
+      migrationId,
+      workspaceId,
+      targetRegion: row.target_region,
+    });
+  }
+
+  try {
     await internalQuery(
       `UPDATE region_migrations SET status = 'pending', error_message = NULL, completed_at = NULL
        WHERE id = $1`,


### PR DESCRIPTION
## Summary

- Persists `region_updated` on `region_migrations` so Phase 3 cutover survives the executor process. Migration `0043_region_migration_region_updated.sql` adds the column with `DEFAULT FALSE` for safe backfill.
- Adds `UnsafeRegionMigrationResetError` (`Data.TaggedError`) → HTTP 409 via `mapTaggedError`. `resetMigrationForRetry()` throws when the failed row has `region_updated = TRUE`; re-running Phase 1 on a workspace that already moved would corrupt the destination.
- Switches `/migrate/:id/retry` to `Effect.tryPromise` with a normalized catch so the typed error reaches the bridge classifier.
- Documents the manual-intervention runbook in `apps/docs/content/docs/platform-ops/data-residency.mdx` — confirm destination ownership, pick forward (re-issue Phase 4 + mark completed) or backward (restore source snapshot + cancel) recovery, audit the choice.

Closes #1986.

## Test plan

- [ ] `bun run test` (api + others) — green locally
- [ ] `bun run lint`, `bun run type`, `bun x syncpack lint`, template drift, railway-watch — all green
- [ ] New `migrate.test.ts` red→green test: `region_updated=true` reset throws `UnsafeRegionMigrationResetError` and emits no UPDATE
- [ ] New `admin-residency.test.ts` route test: 409 + `error: "conflict"` end-to-end via the bridge
- [ ] New `hono.test.ts` mapping test: `mapTaggedError` returns 409/`conflict` for the new tag
- [ ] Existing `db/__tests__/migrate.test.ts` + `auth/__tests__/migrate.test.ts` baseline counts updated for the new SQL file
- [ ] Manual: in a deploy, verify a forced Phase 4 failure leaves the row `failed` + `region_updated=true`, retry returns 409, and the runbook recovery path completes the migration without flipping back to pending