### PR TITLE
fix(api): #1980 — chat Retry-After + mid-stream structured errors

### DIFF
--- a/apps/docs/content/docs/reference/api.mdx
+++ b/apps/docs/content/docs/reference/api.mdx
@@ -398,11 +398,15 @@ All error responses follow a consistent format:
 | `not_available` | 404 | Feature not available (e.g., no internal DB) |
 | `provider_model_not_found` | 400 | Configured AI model does not exist |
 | `provider_auth_error` | 503 | AI provider authentication failed |
-| `provider_rate_limit` | 503 | AI provider rate limited |
-| `provider_timeout` | 504 | AI provider timed out |
+| `provider_rate_limit` | 503 | AI provider rate limited. Forwards the upstream `Retry-After` (clamped to 300s) when present |
+| `provider_timeout` | 504 | AI provider timed out. Forwards the upstream `Retry-After` (clamped to 300s) when present |
 | `provider_unreachable` | 503 | Could not reach the AI provider |
-| `provider_error` | 502 | AI provider returned an error |
+| `provider_error` | 502 | AI provider returned an error. Forwards the upstream `Retry-After` (clamped to 300s) when present |
 | `internal_error` | 500 | Unexpected server error |
+
+### Mid-stream Errors
+
+When `/api/v1/chat` fails *after* the SSE connection is open, the failure travels as an `error` chunk whose `errorText` is a JSON-encoded `ChatErrorInfo` body — the same `{ error, message, retryable, retryAfterSeconds?, requestId }` shape the synchronous response uses. Clients can run a single `JSON.parse(errorText)` to recover the typed `code` and surface the same retry guidance regardless of when the failure occurred. The Atlas SDK and React package do this automatically.
 
 ---
 
@@ -413,6 +417,8 @@ When `ATLAS_RATE_LIMIT_RPM` is set, the API enforces per-user rate limits (slidi
 - HTTP status `429`
 - `Retry-After` header (seconds until the limit resets)
 - `retryAfterSeconds` in the response body
+
+Provider-driven rate limits (`provider_rate_limit`, `provider_timeout`, `provider_error`, `provider_auth_error`) also forward the upstream LLM's `Retry-After` header — clamped to a 300s ceiling — both as the response header and as `retryAfterSeconds` in the body.
 
 See [Environment Variables](/reference/environment-variables) for configuration.
 

--- a/apps/docs/content/docs/reference/sdk.mdx
+++ b/apps/docs/content/docs/reference/sdk.mdx
@@ -251,7 +251,7 @@ Each yielded event is a discriminated union:
 | `tool-call` | `toolCallId`, `name`, `args` | Agent is calling a tool |
 | `tool-result` | `toolCallId`, `name`, `result` | Tool returned a result |
 | `result` | `columns`, `rows` | Convenience event when `executeSQL` returns data (emitted alongside `tool-result`) |
-| `error` | `message` | Error during streaming |
+| `error` | `message`, `code?`, `retryable?`, `retryAfterSeconds?`, `requestId?` | Mid-stream error. When the server emits a structured `ChatErrorInfo` body, the typed `code` (`provider_rate_limit`, `provider_timeout`, …) and `retryAfterSeconds` travel alongside the human-readable `message`. Older servers populate only `message`. |
 | `parse-error` | `raw`, `error` | Client-side: an SSE frame contained invalid JSON. The raw data is preserved for debugging. |
 | `finish` | `reason` | Stream completed (`"stop"`, `"length"`, `"tool-calls"`, etc.) |
 

--- a/packages/api/src/api/__tests__/chat.test.ts
+++ b/packages/api/src/api/__tests__/chat.test.ts
@@ -14,6 +14,7 @@ import {
   mock,
   type Mock,
 } from "bun:test";
+import { APICallError } from "ai";
 import type { AuthResult } from "@atlas/api/lib/auth/types";
 
 // --- Mocks ---
@@ -710,5 +711,287 @@ describe("POST /api/v1/chat", () => {
     } finally {
       delete process.env.ATLAS_PYTHON_ENABLED;
     }
+  });
+
+  // ---------------------------------------------------------------------
+  // #1980 — provider Retry-After surfacing
+  //
+  // The `APICallError.responseHeaders["retry-after"]` value MUST round-trip
+  // to both `retryAfterSeconds` in the JSON body and the `Retry-After` HTTP
+  // response header. Anthropic / OpenAI 503/429 responses carry this header
+  // and we previously dropped it, leaving clients to invent their own
+  // backoff. Clamp at 300s (RFC 7231 allows arbitrarily large deltas; we
+  // refuse to make users wait longer than 5 minutes).
+  // ---------------------------------------------------------------------
+
+  describe("#1980 — provider Retry-After header", () => {
+    it("forwards Retry-After from a 401 provider response (provider_auth_error)", async () => {
+      mockRunAgent.mockRejectedValueOnce(
+        new APICallError({
+          message: "Unauthorized",
+          url: "https://api.example.com/v1/chat",
+          requestBodyValues: {},
+          statusCode: 401,
+          responseHeaders: { "retry-after": "45" },
+        }),
+      );
+      const response = await app.fetch(makeRequest());
+      expect(response.status).toBe(503);
+      expect(response.headers.get("Retry-After")).toBe("45");
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("provider_auth_error");
+      expect(body.retryAfterSeconds).toBe(45);
+    });
+
+    it("forwards Retry-After from a 429 provider response (provider_rate_limit)", async () => {
+      mockRunAgent.mockRejectedValueOnce(
+        new APICallError({
+          message: "Rate limited",
+          url: "https://api.example.com/v1/chat",
+          requestBodyValues: {},
+          statusCode: 429,
+          responseHeaders: { "retry-after": "60" },
+        }),
+      );
+      const response = await app.fetch(makeRequest());
+      expect(response.status).toBe(503);
+      expect(response.headers.get("Retry-After")).toBe("60");
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("provider_rate_limit");
+      expect(body.retryAfterSeconds).toBe(60);
+    });
+
+    it("forwards Retry-After from a 408 provider response (provider_timeout)", async () => {
+      mockRunAgent.mockRejectedValueOnce(
+        new APICallError({
+          message: "Request timeout",
+          url: "https://api.example.com/v1/chat",
+          requestBodyValues: {},
+          statusCode: 408,
+          responseHeaders: { "retry-after": "10" },
+        }),
+      );
+      const response = await app.fetch(makeRequest());
+      expect(response.status).toBe(504);
+      expect(response.headers.get("Retry-After")).toBe("10");
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("provider_timeout");
+      expect(body.retryAfterSeconds).toBe(10);
+    });
+
+    it("forwards Retry-After from a generic 5xx provider response (provider_error)", async () => {
+      mockRunAgent.mockRejectedValueOnce(
+        new APICallError({
+          message: "Service Unavailable",
+          url: "https://api.example.com/v1/chat",
+          requestBodyValues: {},
+          statusCode: 503,
+          responseHeaders: { "retry-after": "20" },
+        }),
+      );
+      const response = await app.fetch(makeRequest());
+      expect(response.status).toBe(502);
+      expect(response.headers.get("Retry-After")).toBe("20");
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("provider_error");
+      expect(body.retryAfterSeconds).toBe(20);
+    });
+
+    it("clamps Retry-After to 300s ceiling", async () => {
+      mockRunAgent.mockRejectedValueOnce(
+        new APICallError({
+          message: "Rate limited",
+          url: "https://api.example.com/v1/chat",
+          requestBodyValues: {},
+          statusCode: 429,
+          responseHeaders: { "retry-after": "9999" },
+        }),
+      );
+      const response = await app.fetch(makeRequest());
+      expect(response.headers.get("Retry-After")).toBe("300");
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.retryAfterSeconds).toBe(300);
+    });
+
+    it("ignores HTTP-date Retry-After (delta-seconds only)", async () => {
+      // RFC 7231 also allows an HTTP-date form. We only support the delta
+      // form because the date form requires a clock-drift-aware parser
+      // and providers almost never emit it.
+      mockRunAgent.mockRejectedValueOnce(
+        new APICallError({
+          message: "Rate limited",
+          url: "https://api.example.com/v1/chat",
+          requestBodyValues: {},
+          statusCode: 429,
+          responseHeaders: { "retry-after": "Wed, 21 Oct 2026 07:28:00 GMT" },
+        }),
+      );
+      const response = await app.fetch(makeRequest());
+      expect(response.status).toBe(503);
+      // No header set, no field in body.
+      expect(response.headers.get("Retry-After")).toBeNull();
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.retryAfterSeconds).toBeUndefined();
+    });
+
+    it("omits Retry-After when the provider does not send the header", async () => {
+      mockRunAgent.mockRejectedValueOnce(
+        new APICallError({
+          message: "Rate limited",
+          url: "https://api.example.com/v1/chat",
+          requestBodyValues: {},
+          statusCode: 429,
+        }),
+      );
+      const response = await app.fetch(makeRequest());
+      expect(response.status).toBe(503);
+      expect(response.headers.get("Retry-After")).toBeNull();
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("provider_rate_limit");
+      expect(body.retryAfterSeconds).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // #1980 — mid-stream structured error frames
+  //
+  // Once the SSE connection is open, errors used to surface as opaque
+  // "ref XXXXXXXX" text. We now serialize a `ChatErrorInfo`-shaped JSON
+  // body into the AI SDK error chunk's `errorText` so the client can
+  // round-trip it through `parseChatError()` (which already does
+  // `JSON.parse(error.message)`). The shape MUST match the pre-stream
+  // synchronous body — code, message, retryable, requestId, plus
+  // optional retryAfterSeconds — so a client can't tell whether the
+  // failure happened before or after the first byte.
+  // ---------------------------------------------------------------------
+
+  describe("#1980 — mid-stream structured error frames", () => {
+    function midstreamRunAgent(error: unknown): {
+      toUIMessageStreamResponse: () => Response;
+      toUIMessageStream: () => ReadableStream<unknown>;
+      text: Promise<string>;
+      steps: Promise<unknown[]>;
+    } {
+      // Build a stream that errors out on first read so the merge
+      // promise inside createUIMessageStream rejects and our onError
+      // callback is invoked.
+      return {
+        toUIMessageStreamResponse: () => new Response("stream", { status: 200 }),
+        toUIMessageStream: () =>
+          new ReadableStream({
+            start(c) {
+              c.error(error);
+            },
+          }),
+        text: Promise.resolve(""),
+        // steps rejection is fire-and-forget settlement; suppress noise.
+        steps: (() => {
+          const p = Promise.reject(error);
+          p.catch(() => undefined);
+          return p;
+        })(),
+      };
+    }
+
+    async function readErrorFrame(
+      response: Response,
+    ): Promise<Record<string, unknown> | null> {
+      const text = await response.text();
+      // SSE format: `data: {...json...}\n\n`. Find the chunk whose JSON has
+      // type:"error" and parse the errorText field.
+      for (const chunk of text.split("\n\n")) {
+        for (const line of chunk.split("\n")) {
+          if (!line.startsWith("data: ")) continue;
+          const payload = line.slice(6);
+          if (payload === "[DONE]") continue;
+          try {
+            const obj = JSON.parse(payload) as Record<string, unknown>;
+            if (obj.type === "error" && typeof obj.errorText === "string") {
+              try {
+                return JSON.parse(obj.errorText) as Record<string, unknown>;
+              } catch {
+                return { errorText: obj.errorText };
+              }
+            }
+          } catch {
+            // ignore malformed lines
+          }
+        }
+      }
+      return null;
+    }
+
+    it("emits a structured ChatErrorInfo frame on mid-stream APICallError 429", async () => {
+      mockRunAgent.mockResolvedValueOnce(
+        midstreamRunAgent(
+          new APICallError({
+            message: "Rate limited mid-stream",
+            url: "https://api.example.com/v1/chat",
+            requestBodyValues: {},
+            statusCode: 429,
+            responseHeaders: { "retry-after": "30" },
+          }),
+        ) as unknown as Awaited<ReturnType<typeof mockRunAgent>>,
+      );
+      const response = await app.fetch(makeRequest());
+      expect(response.status).toBe(200); // SSE is already open
+      const frame = await readErrorFrame(response);
+      expect(frame).not.toBeNull();
+      expect(frame!.error).toBe("provider_rate_limit");
+      expect(frame!.retryable).toBe(true);
+      expect(frame!.retryAfterSeconds).toBe(30);
+      expect(typeof frame!.requestId).toBe("string");
+      expect((frame!.requestId as string).length).toBeGreaterThan(0);
+      expect(typeof frame!.message).toBe("string");
+    });
+
+    it("emits a structured frame on mid-stream network drop (fetch failed)", async () => {
+      mockRunAgent.mockResolvedValueOnce(
+        midstreamRunAgent(new Error("fetch failed")) as unknown as Awaited<
+          ReturnType<typeof mockRunAgent>
+        >,
+      );
+      const response = await app.fetch(makeRequest());
+      expect(response.status).toBe(200);
+      const frame = await readErrorFrame(response);
+      expect(frame).not.toBeNull();
+      expect(frame!.error).toBe("provider_unreachable");
+      expect(frame!.retryable).toBe(true);
+      expect(typeof frame!.requestId).toBe("string");
+    });
+
+    it("emits a structured frame on mid-stream provider timeout (APICallError 408)", async () => {
+      mockRunAgent.mockResolvedValueOnce(
+        midstreamRunAgent(
+          new APICallError({
+            message: "Provider stream timed out",
+            url: "https://api.example.com/v1/chat",
+            requestBodyValues: {},
+            statusCode: 408,
+          }),
+        ) as unknown as Awaited<ReturnType<typeof mockRunAgent>>,
+      );
+      const response = await app.fetch(makeRequest());
+      expect(response.status).toBe(200);
+      const frame = await readErrorFrame(response);
+      expect(frame).not.toBeNull();
+      expect(frame!.error).toBe("provider_timeout");
+      expect(frame!.retryable).toBe(true);
+      expect(typeof frame!.requestId).toBe("string");
+    });
+
+    it("falls back to internal_error for unclassifiable mid-stream errors", async () => {
+      mockRunAgent.mockResolvedValueOnce(
+        midstreamRunAgent(new Error("something nobody recognizes")) as unknown as Awaited<
+          ReturnType<typeof mockRunAgent>
+        >,
+      );
+      const response = await app.fetch(makeRequest());
+      expect(response.status).toBe(200);
+      const frame = await readErrorFrame(response);
+      expect(frame).not.toBeNull();
+      expect(frame!.error).toBe("internal_error");
+      expect(typeof frame!.requestId).toBe("string");
+    });
   });
 });

--- a/packages/api/src/api/__tests__/chat.test.ts
+++ b/packages/api/src/api/__tests__/chat.test.ts
@@ -14,7 +14,8 @@ import {
   mock,
   type Mock,
 } from "bun:test";
-import { APICallError } from "ai";
+import { APICallError, LoadAPIKeyError, NoSuchModelError } from "ai";
+import { GatewayModelNotFoundError } from "@ai-sdk/gateway";
 import type { AuthResult } from "@atlas/api/lib/auth/types";
 
 // --- Mocks ---
@@ -716,12 +717,12 @@ describe("POST /api/v1/chat", () => {
   // ---------------------------------------------------------------------
   // #1980 — provider Retry-After surfacing
   //
-  // The `APICallError.responseHeaders["retry-after"]` value MUST round-trip
-  // to both `retryAfterSeconds` in the JSON body and the `Retry-After` HTTP
-  // response header. Anthropic / OpenAI 503/429 responses carry this header
-  // and we previously dropped it, leaving clients to invent their own
-  // backoff. Clamp at 300s (RFC 7231 allows arbitrarily large deltas; we
-  // refuse to make users wait longer than 5 minutes).
+  // The chat route forwards `APICallError.responseHeaders["retry-after"]`
+  // to both `retryAfterSeconds` in the JSON body and the `Retry-After`
+  // HTTP response header so clients don't invent their own backoff.
+  // RFC 7231 permits arbitrarily large deltas; the route clamps at 300s
+  // because longer waits should be surfaced as a hard failure rather
+  // than a UI countdown.
   // ---------------------------------------------------------------------
 
   describe("#1980 — provider Retry-After header", () => {
@@ -855,14 +856,12 @@ describe("POST /api/v1/chat", () => {
   // ---------------------------------------------------------------------
   // #1980 — mid-stream structured error frames
   //
-  // Once the SSE connection is open, errors used to surface as opaque
-  // "ref XXXXXXXX" text. We now serialize a `ChatErrorInfo`-shaped JSON
-  // body into the AI SDK error chunk's `errorText` so the client can
-  // round-trip it through `parseChatError()` (which already does
-  // `JSON.parse(error.message)`). The shape MUST match the pre-stream
-  // synchronous body — code, message, retryable, requestId, plus
-  // optional retryAfterSeconds — so a client can't tell whether the
-  // failure happened before or after the first byte.
+  // Once the SSE connection is open, errors travel through the AI SDK
+  // error chunk's `errorText` as a `ChatErrorInfo`-shaped JSON body —
+  // the same `{ error, message, retryable, retryAfterSeconds?, requestId }`
+  // the synchronous response uses. The shape pins parity so a client
+  // can `JSON.parse(errorText)` and reuse `parseChatError()` regardless
+  // of when the failure happened.
   // ---------------------------------------------------------------------
 
   describe("#1980 — mid-stream structured error frames", () => {
@@ -992,6 +991,204 @@ describe("POST /api/v1/chat", () => {
       expect(frame).not.toBeNull();
       expect(frame!.error).toBe("internal_error");
       expect(typeof frame!.requestId).toBe("string");
+    });
+
+    // Two onError hooks feed the same classifier:
+    //   - `toUIMessageStream({ onError })` runs for per-chunk error events
+    //     emitted by `streamText` (the agent loop).
+    //   - `createUIMessageStream({ onError })` runs when the merge promise
+    //     rejects (the inner stream itself errors).
+    // The earlier mid-stream tests exercise the merge-rejection path. This
+    // one routes through the per-chunk hook by yielding a `type: "error"`
+    // chunk so a refactor that breaks one hook can't slip through behind
+    // the other still working.
+    it("routes per-chunk error chunks through the same classifier", async () => {
+      mockRunAgent.mockResolvedValueOnce({
+        toUIMessageStreamResponse: () => new Response("stream", { status: 200 }),
+        toUIMessageStream: (
+          opts?: { onError?: (error: unknown) => string },
+        ) =>
+          new ReadableStream({
+            start(c) {
+              const errorText = opts?.onError
+                ? opts.onError(
+                    new APICallError({
+                      message: "rate limited per-chunk",
+                      url: "https://api.example.com/v1/chat",
+                      requestBodyValues: {},
+                      statusCode: 429,
+                      responseHeaders: { "retry-after": "12" },
+                    }),
+                  )
+                : "fallback";
+              c.enqueue({ type: "error", errorText });
+              c.close();
+            },
+          }),
+        text: Promise.resolve(""),
+        steps: Promise.resolve([]),
+      } as unknown as Awaited<ReturnType<typeof mockRunAgent>>);
+      const response = await app.fetch(makeRequest());
+      expect(response.status).toBe(200);
+      const frame = await readErrorFrame(response);
+      expect(frame).not.toBeNull();
+      expect(frame!.error).toBe("provider_rate_limit");
+      expect(frame!.retryable).toBe(true);
+      expect(frame!.retryAfterSeconds).toBe(12);
+      expect(typeof frame!.requestId).toBe("string");
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // #1980 — synchronous classifier coverage (every emit branch)
+  //
+  // Pin every code `classifyChatError` can emit to its expected status
+  // and shape so a refactor of the cascade (or `CLASSIFIER_STATUS_MAP`)
+  // can't silently re-route a known error class.
+  // ---------------------------------------------------------------------
+
+  describe("#1980 — synchronous classifier coverage", () => {
+    it("classifies LoadAPIKeyError as provider_auth_error 503", async () => {
+      mockRunAgent.mockRejectedValueOnce(
+        new LoadAPIKeyError({ message: "ANTHROPIC_API_KEY missing" }),
+      );
+      const response = await app.fetch(makeRequest());
+      expect(response.status).toBe(503);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("provider_auth_error");
+      expect(body.retryable).toBe(false);
+      expect(body.retryAfterSeconds).toBeUndefined();
+      expect(response.headers.get("Retry-After")).toBeNull();
+    });
+
+    it("classifies NoSuchModelError as provider_model_not_found 400", async () => {
+      mockRunAgent.mockRejectedValueOnce(
+        new NoSuchModelError({
+          modelId: "made-up-model",
+          modelType: "languageModel",
+        }),
+      );
+      const response = await app.fetch(makeRequest());
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("provider_model_not_found");
+      expect(body.retryable).toBe(false);
+    });
+
+    it("classifies GatewayModelNotFoundError as provider_model_not_found 400", async () => {
+      mockRunAgent.mockRejectedValueOnce(
+        new GatewayModelNotFoundError({
+          message: "model not found on gateway",
+          modelId: "anthropic/missing-model",
+        }),
+      );
+      const response = await app.fetch(makeRequest());
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("provider_model_not_found");
+    });
+
+    it("classifies ECONNREFUSED as provider_unreachable 503 (synchronous)", async () => {
+      mockRunAgent.mockRejectedValueOnce(
+        new Error("connect ECONNREFUSED 10.0.0.1:443"),
+      );
+      const response = await app.fetch(makeRequest());
+      expect(response.status).toBe(503);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("provider_unreachable");
+      expect(body.retryable).toBe(true);
+      // No retry-after header for unreachable — the regex-matched fallback
+      // doesn't ship one and we don't want clients to invent a delta.
+      expect(response.headers.get("Retry-After")).toBeNull();
+      expect(body.retryAfterSeconds).toBeUndefined();
+    });
+
+    it("omits Retry-After header when provider_auth_error has no header", async () => {
+      mockRunAgent.mockRejectedValueOnce(
+        new APICallError({
+          message: "Unauthorized",
+          url: "https://api.example.com/v1/chat",
+          requestBodyValues: {},
+          statusCode: 401,
+        }),
+      );
+      const response = await app.fetch(makeRequest());
+      expect(response.status).toBe(503);
+      expect(response.headers.get("Retry-After")).toBeNull();
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.retryAfterSeconds).toBeUndefined();
+    });
+
+    it("omits Retry-After header on the internal_error fallback", async () => {
+      // An error matchError can't recognize and which isn't an APICallError.
+      mockRunAgent.mockRejectedValueOnce(new Error("totally unfamiliar"));
+      const response = await app.fetch(makeRequest());
+      expect(response.status).toBe(500);
+      expect(response.headers.get("Retry-After")).toBeNull();
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("internal_error");
+      expect(body.retryAfterSeconds).toBeUndefined();
+      expect(typeof body.requestId).toBe("string");
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // #1980 — Retry-After parser edge cases
+  //
+  // Whitespace, fractional, zero, and negative deltas — each is an
+  // explicit branch in `parseProviderRetryAfter`, so pin the contract.
+  // ---------------------------------------------------------------------
+
+  describe("#1980 — parseProviderRetryAfter edge cases", () => {
+    async function runWith(retryAfter: string): Promise<Response> {
+      mockRunAgent.mockRejectedValueOnce(
+        new APICallError({
+          message: "Rate limited",
+          url: "https://api.example.com/v1/chat",
+          requestBodyValues: {},
+          statusCode: 429,
+          responseHeaders: { "retry-after": retryAfter },
+        }),
+      );
+      return app.fetch(makeRequest());
+    }
+
+    it("trims whitespace around delta-seconds", async () => {
+      const response = await runWith(" 60 ");
+      expect(response.headers.get("Retry-After")).toBe("60");
+    });
+
+    it("floors fractional values", async () => {
+      const response = await runWith("5.7");
+      expect(response.headers.get("Retry-After")).toBe("5");
+    });
+
+    it("accepts zero as a valid delta", async () => {
+      const response = await runWith("0");
+      expect(response.headers.get("Retry-After")).toBe("0");
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.retryAfterSeconds).toBe(0);
+    });
+
+    it("rejects negative deltas as malformed", async () => {
+      const response = await runWith("-5");
+      expect(response.headers.get("Retry-After")).toBeNull();
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.retryAfterSeconds).toBeUndefined();
+    });
+
+    it("accepts mixed-case header key", async () => {
+      mockRunAgent.mockRejectedValueOnce(
+        new APICallError({
+          message: "Rate limited",
+          url: "https://api.example.com/v1/chat",
+          requestBodyValues: {},
+          statusCode: 429,
+          responseHeaders: { "Retry-After": "15" },
+        }),
+      );
+      const response = await app.fetch(makeRequest());
+      expect(response.headers.get("Retry-After")).toBe("15");
     });
   });
 });

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -15,7 +15,7 @@ import { withRequestId, resolveMode, type AuthEnv } from "./middleware";
 import { z } from "zod";
 import { type UIMessage, createUIMessageStream, createUIMessageStreamResponse } from "ai";
 import { APICallError, LoadAPIKeyError, NoSuchModelError } from "ai";
-import { matchError, isRetryableError, isChatErrorCode, type ChatErrorCode } from "@useatlas/types";
+import { matchError, isRetryableError, isChatErrorCode } from "@useatlas/types";
 import { runAgent } from "@atlas/api/lib/agent";
 import { validateEnvironment } from "@atlas/api/lib/startup";
 import { GatewayModelNotFoundError } from "@ai-sdk/gateway";
@@ -82,61 +82,119 @@ const log = createLogger("chat");
 
 /**
  * Provider Retry-After response headers can be arbitrarily large in the RFC.
- * We refuse to make a user wait more than 5 minutes — beyond that the
- * UI should treat the call as failed and ask them to start over.
+ * 5 minutes is the longest delta the chat surface honours — beyond that the
+ * UI should treat the call as failed and ask the user to start over.
  */
 const PROVIDER_RETRY_AFTER_MAX_SECONDS = 300;
+
+const retryAfterLog = createLogger("chat-retry-after");
 
 /**
  * Parse a provider's `Retry-After` response header into seconds.
  *
  * Returns `undefined` when the header is missing, non-numeric, negative,
- * or in the HTTP-date form (RFC 7231 also permits a date but providers
- * almost never emit it; supporting it would require a clock-drift-aware
- * parser). Otherwise returns a non-negative integer clamped to
- * `PROVIDER_RETRY_AFTER_MAX_SECONDS`.
+ * or in the HTTP-date form. RFC 7231 also permits an HTTP-date, but
+ * providers almost never emit it and supporting it would require a
+ * clock-drift-aware parser. Otherwise returns a non-negative integer
+ * clamped to `PROVIDER_RETRY_AFTER_MAX_SECONDS`.
  */
 function parseProviderRetryAfter(
   responseHeaders: Record<string, string> | undefined,
+  requestId?: string,
 ): number | undefined {
   if (!responseHeaders) return undefined;
-  // Headers are typically lowercase but be defensive.
+  // AI SDK normalizes header keys to lowercase, but providers/proxies
+  // sometimes preserve mixed case — probe both.
   const raw = responseHeaders["retry-after"] ?? responseHeaders["Retry-After"];
   if (raw === undefined) return undefined;
   const n = Number(raw.trim());
-  if (!Number.isFinite(n) || n < 0) return undefined;
+  if (!Number.isFinite(n) || n < 0) {
+    // Surface the parse miss so operators see new providers / proxies
+    // emitting unexpected formats (HTTP-date, comments, etc.). The
+    // underlying APICallError is still classified and logged at the
+    // call site — this is operator visibility, not user-facing.
+    retryAfterLog.debug(
+      { raw, ...(requestId !== undefined && { requestId }) },
+      "Provider Retry-After could not be parsed as delta-seconds",
+    );
+    return undefined;
+  }
   return Math.min(Math.floor(n), PROVIDER_RETRY_AFTER_MAX_SECONDS);
 }
 
+/**
+ * Codes the chat-route classifier emits.
+ *
+ * Narrower than the full `ChatErrorCode` union because middleware-produced
+ * codes (`auth_error`, `validation_error`, `not_found`, `forbidden`, plan /
+ * billing / workspace gates, etc.) are emitted *before* the classifier runs
+ * and never travel through it. Restricting the emit set lets
+ * `CLASSIFIER_STATUS_MAP` express a 1:1 code↔httpStatus invariant — adding a
+ * branch to `classifyChatError` that returns a code outside this union is a
+ * compile error.
+ */
+type ClassifierCode =
+  | "provider_model_not_found"
+  | "provider_auth_error"
+  | "provider_rate_limit"
+  | "provider_timeout"
+  | "provider_unreachable"
+  | "provider_error"
+  | "rate_limited"
+  | "internal_error";
+
+/**
+ * The 1:1 code↔httpStatus contract for codes emitted by the classifier.
+ *
+ * Other status codes (401, 403, 404, 422) appear in the chat route's
+ * OpenAPI declaration but are produced upstream of the classifier (auth
+ * middleware, validation hook, conversation-ownership check) — they are
+ * intentionally absent here.
+ */
+const CLASSIFIER_STATUS_MAP = {
+  provider_model_not_found: 400,
+  provider_auth_error: 503,
+  provider_rate_limit: 503,
+  provider_timeout: 504,
+  provider_unreachable: 503,
+  provider_error: 502,
+  rate_limited: 429,
+  internal_error: 500,
+} as const satisfies Record<ClassifierCode, 400 | 429 | 500 | 502 | 503 | 504>;
+
+type ClassifierHttpStatus = (typeof CLASSIFIER_STATUS_MAP)[ClassifierCode];
+
+/**
+ * Result of classifying an agent-loop error.
+ *
+ * Stores only `code`, `message`, and an optional `retryAfterSeconds`. The
+ * derived fields (`httpStatus`, `retryable`) are looked up at call sites
+ * via `CLASSIFIER_STATUS_MAP` and `isRetryableError` so there is exactly
+ * one source of truth for each invariant.
+ */
 type ChatErrorClassification = {
-  code: ChatErrorCode;
-  message: string;
-  retryable: boolean;
-  retryAfterSeconds?: number;
-  httpStatus: 400 | 429 | 500 | 502 | 503 | 504;
+  readonly code: ClassifierCode;
+  readonly message: string;
+  readonly retryAfterSeconds?: number;
 };
 
 /**
- * Classify a thrown or streamed agent-loop error into a
- * `ChatErrorInfo`-shaped result.
+ * Classify a thrown or streamed agent-loop error.
  *
- * Single source of truth for the chat surface — used by both the
- * synchronous catch block (which converts the result into the JSON
- * HTTP response) and the SSE `onError` path (which serializes the
- * result into the AI SDK error chunk's `errorText`). Keeping one
- * classifier guarantees pre-stream and mid-stream errors carry the
- * same `code` / `retryable` / `retryAfterSeconds` shape, so a client
- * can't tell — and shouldn't have to know — whether the failure
- * happened before or after the first byte.
+ * Single source of truth for the chat surface — invoked by both the
+ * synchronous catch block (which builds the JSON HTTP response) and the
+ * SSE `onError` path (which serializes the result into the AI SDK error
+ * chunk's `errorText`). One classifier guarantees pre-stream and
+ * mid-stream errors carry the same `code` / `retryAfterSeconds`, so a
+ * client can't tell whether a failure happened before or after the first
+ * byte and shouldn't have to.
  */
-function classifyChatError(err: unknown): ChatErrorClassification {
+function classifyChatError(err: unknown, requestId?: string): ChatErrorClassification {
   if (GatewayModelNotFoundError.isInstance(err)) {
     return {
       code: "provider_model_not_found",
       message:
         "Model not found on the AI Gateway. Check that your ATLAS_MODEL uses the correct provider/model format (e.g., anthropic/claude-sonnet-4.6).",
-      retryable: isRetryableError("provider_model_not_found"),
-      httpStatus: 400,
     };
   }
   if (NoSuchModelError.isInstance(err)) {
@@ -144,8 +202,6 @@ function classifyChatError(err: unknown): ChatErrorClassification {
       code: "provider_model_not_found",
       message:
         "The configured model was not found. Check ATLAS_MODEL and ATLAS_PROVIDER settings.",
-      retryable: isRetryableError("provider_model_not_found"),
-      httpStatus: 400,
     };
   }
   if (LoadAPIKeyError.isInstance(err)) {
@@ -153,20 +209,16 @@ function classifyChatError(err: unknown): ChatErrorClassification {
       code: "provider_auth_error",
       message:
         "LLM provider API key could not be loaded. Check that the required API key environment variable is set.",
-      retryable: isRetryableError("provider_auth_error"),
-      httpStatus: 503,
     };
   }
   if (APICallError.isInstance(err)) {
     const status = err.statusCode;
-    const retryAfterSeconds = parseProviderRetryAfter(err.responseHeaders);
+    const retryAfterSeconds = parseProviderRetryAfter(err.responseHeaders, requestId);
     if (status === 401 || status === 403) {
       return {
         code: "provider_auth_error",
         message:
           "LLM provider authentication failed. Check that your API key is valid and has not expired.",
-        retryable: isRetryableError("provider_auth_error"),
-        httpStatus: 503,
         ...(retryAfterSeconds !== undefined && { retryAfterSeconds }),
       };
     }
@@ -174,8 +226,6 @@ function classifyChatError(err: unknown): ChatErrorClassification {
       return {
         code: "provider_rate_limit",
         message: "LLM provider rate limit reached. Wait a moment and try again.",
-        retryable: isRetryableError("provider_rate_limit"),
-        httpStatus: 503,
         ...(retryAfterSeconds !== undefined && { retryAfterSeconds }),
       };
     }
@@ -185,76 +235,83 @@ function classifyChatError(err: unknown): ChatErrorClassification {
         message:
           "The request timed out. The LLM provider took too long to respond. " +
           "Try again, or if using a local model, ensure it has sufficient resources.",
-        retryable: isRetryableError("provider_timeout"),
-        httpStatus: 504,
         ...(retryAfterSeconds !== undefined && { retryAfterSeconds }),
       };
     }
     return {
       code: "provider_error",
       message: `The LLM provider returned an error (HTTP ${status}). This is usually a temporary issue. Try again in a moment.`,
-      retryable: isRetryableError("provider_error"),
-      httpStatus: 502,
       ...(retryAfterSeconds !== undefined && { retryAfterSeconds }),
     };
   }
-  // Pattern-matched fallback for non-APICallError exceptions. Connection
-  // errors get re-routed to provider_unreachable because in this route we
-  // know the unreachable host is the LLM, not the analytics datasource.
+  // Pattern-matched fallback for non-APICallError exceptions. In this route
+  // we know an unreachable host is the LLM, not the analytics datasource —
+  // re-route the generic `internal_error` matchError default accordingly.
   const errMessage = err instanceof Error ? err.message : String(err);
   const matched = matchError(err);
   if (matched) {
     const isConnectionError = /ECONNREFUSED|ENOTFOUND|fetch failed/i.test(errMessage);
-    const code: ChatErrorCode =
-      matched.code === "internal_error" && isConnectionError
-        ? "provider_unreachable"
-        : matched.code;
-    const httpStatus: 429 | 500 | 502 | 503 | 504 =
-      code === "rate_limited"
-        ? 429
-        : code === "provider_unreachable"
-          ? 503
-          : code === "provider_timeout"
-            ? 504
-            : 500;
-    const userMessage =
-      code === "provider_unreachable"
-        ? "Could not reach the LLM provider. Check your network connection and provider status."
-        : code === "provider_timeout"
-          ? "The request timed out. The LLM provider took too long to respond. " +
-            "Try again, or if using a local model, ensure it has sufficient resources."
-          : matched.message;
-    return {
-      code,
-      message: userMessage,
-      // Pool exhaustion (rate_limited via matchError) is always retryable;
-      // its 5s backoff is what the chat catch block historically advertised.
-      retryable: code === "rate_limited" ? true : isRetryableError(code),
-      ...(code === "rate_limited" && { retryAfterSeconds: 5 }),
-      httpStatus,
-    };
+    if (matched.code === "internal_error" && isConnectionError) {
+      return {
+        code: "provider_unreachable",
+        message:
+          "Could not reach the LLM provider. Check your network connection and provider status.",
+      };
+    }
+    if (matched.code === "provider_unreachable") {
+      return {
+        code: "provider_unreachable",
+        message:
+          "Could not reach the LLM provider. Check your network connection and provider status.",
+      };
+    }
+    if (matched.code === "provider_timeout") {
+      return {
+        code: "provider_timeout",
+        message:
+          "The request timed out. The LLM provider took too long to respond. " +
+          "Try again, or if using a local model, ensure it has sufficient resources.",
+      };
+    }
+    if (matched.code === "rate_limited") {
+      // Pool exhaustion is transient — the connection registry recovers
+      // within seconds. The 5s suggestion mirrors the underlying
+      // backoff in the pg pool code; surfacing it lets the UI show a
+      // concrete delta instead of a vague "try again later".
+      return {
+        code: "rate_limited",
+        message: matched.message,
+        retryAfterSeconds: 5,
+      };
+    }
+    // Any other matched code (provider_*, internal_error) falls through
+    // to the unclassified path with the generic matched message —
+    // currently no other matcher exists, but a future entry would.
   }
   return {
     code: "internal_error",
     message: "An unexpected error occurred.",
-    retryable: isRetryableError("internal_error"),
-    httpStatus: 500,
   };
+}
+
+/** Look up the HTTP status for a code emitted by `classifyChatError`. */
+function statusForClassifierCode(code: ClassifierCode): ClassifierHttpStatus {
+  return CLASSIFIER_STATUS_MAP[code];
 }
 
 /**
  * Serialize a `ChatErrorClassification` into the JSON body the SSE
- * error frame carries as `errorText`. The shape mirrors the
- * synchronous error response so the same `parseChatError()` works on
- * both — the client can't tell whether a failure happened before or
- * after the first byte.
+ * error frame carries as `errorText`. Same shape as the synchronous
+ * error response so a single `parseChatError()` works for both
+ * transports — clients can't tell whether a failure happened before
+ * or after the first byte.
  */
 function buildMidStreamErrorFrame(err: unknown, requestId: string): string {
-  const cls = classifyChatError(err);
+  const cls = classifyChatError(err, requestId);
   return JSON.stringify({
     error: cls.code,
     message: cls.message,
-    retryable: cls.retryable,
+    retryable: isRetryableError(cls.code),
     ...(cls.retryAfterSeconds !== undefined && {
       retryAfterSeconds: cls.retryAfterSeconds,
     }),
@@ -872,10 +929,13 @@ chat.openapi(chatRoute, async (c) => {
           if (err instanceof HTTPException) throw err;
 
           const errObj = err instanceof Error ? err : new Error(String(err));
-          const cls = classifyChatError(err);
+          const cls = classifyChatError(err, requestId);
+          const httpStatus = statusForClassifierCode(cls.code);
+          const retryable = isRetryableError(cls.code);
 
-          // The pool-exhaustion (rate_limited via matchError) path was a
-          // warn historically — keep it. Everything else is an error.
+          // Pool exhaustion is transient (the connection registry recycles
+          // within seconds), so log at warn — it's not operator-actionable.
+          // Everything else is a genuine error.
           if (cls.code === "rate_limited") {
             log.warn(
               { err: errObj, category: cls.code },
@@ -904,7 +964,7 @@ chat.openapi(chatRoute, async (c) => {
           const body = {
             error: cls.code,
             message: userMessage,
-            retryable: cls.retryable,
+            retryable,
             ...(cls.retryAfterSeconds !== undefined && {
               retryAfterSeconds: cls.retryAfterSeconds,
             }),
@@ -913,11 +973,11 @@ chat.openapi(chatRoute, async (c) => {
 
           if (cls.retryAfterSeconds !== undefined) {
             return c.json(body, {
-              status: cls.httpStatus,
+              status: httpStatus,
               headers: { "Retry-After": String(cls.retryAfterSeconds) },
             });
           }
-          return c.json(body, cls.httpStatus);
+          return c.json(body, httpStatus);
         }
       },
     );

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -15,7 +15,7 @@ import { withRequestId, resolveMode, type AuthEnv } from "./middleware";
 import { z } from "zod";
 import { type UIMessage, createUIMessageStream, createUIMessageStreamResponse } from "ai";
 import { APICallError, LoadAPIKeyError, NoSuchModelError } from "ai";
-import { matchError, isRetryableError, isChatErrorCode } from "@useatlas/types";
+import { matchError, isRetryableError, isChatErrorCode, type ChatErrorCode } from "@useatlas/types";
 import { runAgent } from "@atlas/api/lib/agent";
 import { validateEnvironment } from "@atlas/api/lib/startup";
 import { GatewayModelNotFoundError } from "@ai-sdk/gateway";
@@ -75,6 +75,192 @@ function getReservationStepBudget(): number {
 }
 
 const log = createLogger("chat");
+
+// ---------------------------------------------------------------------------
+// #1980 — error classification shared across pre-stream and mid-stream paths
+// ---------------------------------------------------------------------------
+
+/**
+ * Provider Retry-After response headers can be arbitrarily large in the RFC.
+ * We refuse to make a user wait more than 5 minutes — beyond that the
+ * UI should treat the call as failed and ask them to start over.
+ */
+const PROVIDER_RETRY_AFTER_MAX_SECONDS = 300;
+
+/**
+ * Parse a provider's `Retry-After` response header into seconds.
+ *
+ * Returns `undefined` when the header is missing, non-numeric, negative,
+ * or in the HTTP-date form (RFC 7231 also permits a date but providers
+ * almost never emit it; supporting it would require a clock-drift-aware
+ * parser). Otherwise returns a non-negative integer clamped to
+ * `PROVIDER_RETRY_AFTER_MAX_SECONDS`.
+ */
+function parseProviderRetryAfter(
+  responseHeaders: Record<string, string> | undefined,
+): number | undefined {
+  if (!responseHeaders) return undefined;
+  // Headers are typically lowercase but be defensive.
+  const raw = responseHeaders["retry-after"] ?? responseHeaders["Retry-After"];
+  if (raw === undefined) return undefined;
+  const n = Number(raw.trim());
+  if (!Number.isFinite(n) || n < 0) return undefined;
+  return Math.min(Math.floor(n), PROVIDER_RETRY_AFTER_MAX_SECONDS);
+}
+
+type ChatErrorClassification = {
+  code: ChatErrorCode;
+  message: string;
+  retryable: boolean;
+  retryAfterSeconds?: number;
+  httpStatus: 400 | 429 | 500 | 502 | 503 | 504;
+};
+
+/**
+ * Classify a thrown or streamed agent-loop error into a
+ * `ChatErrorInfo`-shaped result.
+ *
+ * Single source of truth for the chat surface — used by both the
+ * synchronous catch block (which converts the result into the JSON
+ * HTTP response) and the SSE `onError` path (which serializes the
+ * result into the AI SDK error chunk's `errorText`). Keeping one
+ * classifier guarantees pre-stream and mid-stream errors carry the
+ * same `code` / `retryable` / `retryAfterSeconds` shape, so a client
+ * can't tell — and shouldn't have to know — whether the failure
+ * happened before or after the first byte.
+ */
+function classifyChatError(err: unknown): ChatErrorClassification {
+  if (GatewayModelNotFoundError.isInstance(err)) {
+    return {
+      code: "provider_model_not_found",
+      message:
+        "Model not found on the AI Gateway. Check that your ATLAS_MODEL uses the correct provider/model format (e.g., anthropic/claude-sonnet-4.6).",
+      retryable: isRetryableError("provider_model_not_found"),
+      httpStatus: 400,
+    };
+  }
+  if (NoSuchModelError.isInstance(err)) {
+    return {
+      code: "provider_model_not_found",
+      message:
+        "The configured model was not found. Check ATLAS_MODEL and ATLAS_PROVIDER settings.",
+      retryable: isRetryableError("provider_model_not_found"),
+      httpStatus: 400,
+    };
+  }
+  if (LoadAPIKeyError.isInstance(err)) {
+    return {
+      code: "provider_auth_error",
+      message:
+        "LLM provider API key could not be loaded. Check that the required API key environment variable is set.",
+      retryable: isRetryableError("provider_auth_error"),
+      httpStatus: 503,
+    };
+  }
+  if (APICallError.isInstance(err)) {
+    const status = err.statusCode;
+    const retryAfterSeconds = parseProviderRetryAfter(err.responseHeaders);
+    if (status === 401 || status === 403) {
+      return {
+        code: "provider_auth_error",
+        message:
+          "LLM provider authentication failed. Check that your API key is valid and has not expired.",
+        retryable: isRetryableError("provider_auth_error"),
+        httpStatus: 503,
+        ...(retryAfterSeconds !== undefined && { retryAfterSeconds }),
+      };
+    }
+    if (status === 429) {
+      return {
+        code: "provider_rate_limit",
+        message: "LLM provider rate limit reached. Wait a moment and try again.",
+        retryable: isRetryableError("provider_rate_limit"),
+        httpStatus: 503,
+        ...(retryAfterSeconds !== undefined && { retryAfterSeconds }),
+      };
+    }
+    if (status === 408 || /timeout/i.test(err.message)) {
+      return {
+        code: "provider_timeout",
+        message:
+          "The request timed out. The LLM provider took too long to respond. " +
+          "Try again, or if using a local model, ensure it has sufficient resources.",
+        retryable: isRetryableError("provider_timeout"),
+        httpStatus: 504,
+        ...(retryAfterSeconds !== undefined && { retryAfterSeconds }),
+      };
+    }
+    return {
+      code: "provider_error",
+      message: `The LLM provider returned an error (HTTP ${status}). This is usually a temporary issue. Try again in a moment.`,
+      retryable: isRetryableError("provider_error"),
+      httpStatus: 502,
+      ...(retryAfterSeconds !== undefined && { retryAfterSeconds }),
+    };
+  }
+  // Pattern-matched fallback for non-APICallError exceptions. Connection
+  // errors get re-routed to provider_unreachable because in this route we
+  // know the unreachable host is the LLM, not the analytics datasource.
+  const errMessage = err instanceof Error ? err.message : String(err);
+  const matched = matchError(err);
+  if (matched) {
+    const isConnectionError = /ECONNREFUSED|ENOTFOUND|fetch failed/i.test(errMessage);
+    const code: ChatErrorCode =
+      matched.code === "internal_error" && isConnectionError
+        ? "provider_unreachable"
+        : matched.code;
+    const httpStatus: 429 | 500 | 502 | 503 | 504 =
+      code === "rate_limited"
+        ? 429
+        : code === "provider_unreachable"
+          ? 503
+          : code === "provider_timeout"
+            ? 504
+            : 500;
+    const userMessage =
+      code === "provider_unreachable"
+        ? "Could not reach the LLM provider. Check your network connection and provider status."
+        : code === "provider_timeout"
+          ? "The request timed out. The LLM provider took too long to respond. " +
+            "Try again, or if using a local model, ensure it has sufficient resources."
+          : matched.message;
+    return {
+      code,
+      message: userMessage,
+      // Pool exhaustion (rate_limited via matchError) is always retryable;
+      // its 5s backoff is what the chat catch block historically advertised.
+      retryable: code === "rate_limited" ? true : isRetryableError(code),
+      ...(code === "rate_limited" && { retryAfterSeconds: 5 }),
+      httpStatus,
+    };
+  }
+  return {
+    code: "internal_error",
+    message: "An unexpected error occurred.",
+    retryable: isRetryableError("internal_error"),
+    httpStatus: 500,
+  };
+}
+
+/**
+ * Serialize a `ChatErrorClassification` into the JSON body the SSE
+ * error frame carries as `errorText`. The shape mirrors the
+ * synchronous error response so the same `parseChatError()` works on
+ * both — the client can't tell whether a failure happened before or
+ * after the first byte.
+ */
+function buildMidStreamErrorFrame(err: unknown, requestId: string): string {
+  const cls = classifyChatError(err);
+  return JSON.stringify({
+    error: cls.code,
+    message: cls.message,
+    retryable: cls.retryable,
+    ...(cls.retryAfterSeconds !== undefined && {
+      retryAfterSeconds: cls.retryAfterSeconds,
+    }),
+    requestId,
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Zod schemas — exported for OpenAPI spec generation
@@ -581,6 +767,14 @@ chat.openapi(chatRoute, async (c) => {
   
           // Register stream writer so Python tool can send progress events.
           // The writer is set before merge() triggers tool execution reads.
+          // #1980 — both `toUIMessageStream`'s onError (per-chunk error
+          // events from streamText) and `createUIMessageStream`'s onError
+          // (the merge promise rejecting) serialize a structured
+          // ChatErrorInfo-shaped JSON body so the client can route the
+          // failure through the same `parseChatError()` it uses for
+          // pre-stream errors. Both call sites delegate to the shared
+          // classifier so codes, retryability, and Retry-After deltas
+          // stay aligned.
           const stream = createUIMessageStream({
             execute: ({ writer }) => {
               // Surface plan warning as a data annotation so clients can display it
@@ -588,7 +782,17 @@ chat.openapi(chatRoute, async (c) => {
                 writer.write({ type: "data-plan-warning", data: planWarning });
               }
               setStreamWriter(requestId, writer);
-              writer.merge(agentResult.toUIMessageStream());
+              writer.merge(
+                agentResult.toUIMessageStream({
+                  onError: (error) => {
+                    log.error(
+                      { err: error instanceof Error ? error : new Error(String(error)), requestId },
+                      "Mid-stream error (toUIMessageStream)",
+                    );
+                    return buildMidStreamErrorFrame(error, requestId);
+                  },
+                }),
+              );
             },
             onFinish: () => {
               clearStreamWriter(requestId);
@@ -599,7 +803,7 @@ chat.openapi(chatRoute, async (c) => {
                 { err: error instanceof Error ? error : new Error(String(error)), requestId },
                 "Stream error",
               );
-              return `An error occurred while generating a response (ref: ${requestId.slice(0, 8)}). Try sending your message again.`;
+              return buildMidStreamErrorFrame(error, requestId);
             },
           });
   
@@ -666,188 +870,54 @@ chat.openapi(chatRoute, async (c) => {
         } catch (err) {
           // Re-throw HTTPException (stream response) — handled by global onError
           if (err instanceof HTTPException) throw err;
-  
+
           const errObj = err instanceof Error ? err : new Error(String(err));
-          const message = errObj.message;
-  
-          // --- Structured AI SDK error types (checked first) ---
-  
-          if (GatewayModelNotFoundError.isInstance(err)) {
+          const cls = classifyChatError(err);
+
+          // The pool-exhaustion (rate_limited via matchError) path was a
+          // warn historically — keep it. Everything else is an error.
+          if (cls.code === "rate_limited") {
+            log.warn(
+              { err: errObj, category: cls.code },
+              "Matched error: %s",
+              cls.code,
+            );
+          } else {
             log.error(
-              { err: errObj, category: "provider_model_not_found" },
-              "Gateway model not found",
-            );
-            return c.json(
               {
-                error: "provider_model_not_found",
-                message:
-                  "Model not found on the AI Gateway. Check that your ATLAS_MODEL uses the correct provider/model format (e.g., anthropic/claude-sonnet-4.6).",
-                retryable: isRetryableError("provider_model_not_found"),
-                requestId,
+                err: errObj,
+                category: cls.code,
+                ...(APICallError.isInstance(err) && { statusCode: err.statusCode }),
               },
-              400,
+              "Chat error: %s",
+              cls.code,
             );
           }
-  
-          if (NoSuchModelError.isInstance(err)) {
-            log.error(
-              { err: errObj, category: "provider_model_not_found" },
-              "Model not found",
-            );
-            return c.json(
-              {
-                error: "provider_model_not_found",
-                message:
-                  "The configured model was not found. Check ATLAS_MODEL and ATLAS_PROVIDER settings.",
-                retryable: isRetryableError("provider_model_not_found"),
-                requestId,
-              },
-              400,
-            );
+
+          // The unclassified fallback gets a ref-id message so the operator
+          // can correlate the user's report with server logs.
+          const userMessage =
+            cls.code === "internal_error"
+              ? `An unexpected error occurred. Quote ref ${requestId.slice(0, 8)} when reporting this issue.`
+              : cls.message;
+
+          const body = {
+            error: cls.code,
+            message: userMessage,
+            retryable: cls.retryable,
+            ...(cls.retryAfterSeconds !== undefined && {
+              retryAfterSeconds: cls.retryAfterSeconds,
+            }),
+            requestId,
+          };
+
+          if (cls.retryAfterSeconds !== undefined) {
+            return c.json(body, {
+              status: cls.httpStatus,
+              headers: { "Retry-After": String(cls.retryAfterSeconds) },
+            });
           }
-  
-          if (LoadAPIKeyError.isInstance(err)) {
-            log.error(
-              { err: errObj, category: "provider_auth_error" },
-              "API key not loaded",
-            );
-            return c.json(
-              {
-                error: "provider_auth_error",
-                message:
-                  "LLM provider API key could not be loaded. Check that the required API key environment variable is set.",
-                retryable: isRetryableError("provider_auth_error"),
-                requestId,
-              },
-              503,
-            );
-          }
-  
-          // APICallError carries the HTTP status code from the provider response
-          if (APICallError.isInstance(err)) {
-            const status = err.statusCode;
-  
-            if (status === 401 || status === 403) {
-              log.error(
-                { err: errObj, category: "provider_auth_error", statusCode: status },
-                "Provider auth error",
-              );
-              return c.json(
-                {
-                  error: "provider_auth_error",
-                  message:
-                    "LLM provider authentication failed. Check that your API key is valid and has not expired.",
-                  retryable: isRetryableError("provider_auth_error"),
-                  requestId,
-                },
-                503,
-              );
-            }
-  
-            if (status === 429) {
-              log.error(
-                { err: errObj, category: "provider_rate_limit", statusCode: status },
-                "Provider rate limit",
-              );
-              return c.json(
-                {
-                  error: "provider_rate_limit",
-                  message:
-                    "LLM provider rate limit reached. Wait a moment and try again.",
-                  retryable: isRetryableError("provider_rate_limit"),
-                  requestId,
-                },
-                503,
-              );
-            }
-  
-            if (status === 408 || /timeout/i.test(message)) {
-              log.error(
-                { err: errObj, category: "provider_timeout", statusCode: status },
-                "Request timed out",
-              );
-              return c.json(
-                {
-                  error: "provider_timeout",
-                  message:
-                    "The request timed out. The LLM provider took too long to respond. " +
-                    "Try again, or if using a local model, ensure it has sufficient resources.",
-                  retryable: isRetryableError("provider_timeout"),
-                  requestId,
-                },
-                504,
-              );
-            }
-  
-            // Catch-all for any other APICallError status codes (5xx, etc.)
-            log.error(
-              { err: errObj, category: "provider_error", statusCode: status },
-              "Provider error",
-            );
-            return c.json(
-              {
-                error: "provider_error",
-                message: `The LLM provider returned an error (HTTP ${status}). This is usually a temporary issue. Try again in a moment.`,
-                retryable: isRetryableError("provider_error"),
-                requestId,
-              },
-              502,
-            );
-          }
-  
-          // --- Pattern-matched errors (non-APICallError exceptions) ---
-          // In the chat route, errors from runAgent are typically provider-related,
-          // so we override matchError's generic messages with provider-appropriate ones.
-  
-          const matched = matchError(err);
-          if (matched) {
-            const isConnectionError = /ECONNREFUSED|ENOTFOUND|fetch failed/i.test(message);
-            const code = (matched.code === "internal_error" && isConnectionError)
-              ? "provider_unreachable" as const
-              : matched.code === "provider_unreachable" ? "provider_unreachable" as const
-              : matched.code;
-            const httpStatus = code === "rate_limited" ? 429
-              : code === "provider_unreachable" ? 503
-              : code === "provider_timeout" ? 504
-              : 500;
-            // Use provider-appropriate messages instead of database-oriented matchError defaults
-            const userMessage = code === "provider_unreachable"
-              ? "Could not reach the LLM provider. Check your network connection and provider status."
-              : code === "provider_timeout"
-                ? "The request timed out. The LLM provider took too long to respond. Try again, or if using a local model, ensure it has sufficient resources."
-                : matched.message;
-            if (code === "rate_limited") {
-              // Pool exhaustion is transient — warn, don't error
-              log.warn({ err: errObj, category: code }, "Matched error: %s", code);
-              return c.json(
-                { error: code, message: userMessage, retryable: true, retryAfterSeconds: 5, requestId },
-                { status: 429, headers: { "Retry-After": "5" } },
-              );
-            }
-            log.error({ err: errObj, category: code }, "Matched error: %s", code);
-            return c.json(
-              { error: code, message: userMessage, retryable: isRetryableError(code), requestId },
-              httpStatus as 429 | 500 | 503 | 504,
-            );
-          }
-  
-          // Fallback — safe 500 with requestId for log correlation.
-          // Full error details (stack trace, original message) are serialized
-          // server-side via pino's err serializer; only a generic message +
-          // request ID reach the client.
-          log.error(
-            { err: errObj, category: "internal_error" },
-            "Unclassified error",
-          );
-          return c.json(
-            {
-              error: "internal_error",
-              message: `An unexpected error occurred. Quote ref ${requestId.slice(0, 8)} when reporting this issue.`,
-              retryable: isRetryableError("internal_error"),
-              requestId,
-            },
-            500,
-          );
+          return c.json(body, cls.httpStatus);
         }
       },
     );

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -124,7 +124,13 @@ for await (const event of atlas.streamQuery("How many users signed up last week?
       console.table(event.rows); // convenience: { columns, rows } from executeSQL
       break;
     case "error":
-      console.error(event.message);
+      // Mid-stream errors carry a typed `code` and a `retryAfterSeconds`
+      // delta when the server emits a structured `ChatErrorInfo` body
+      // (e.g. provider rate limiting). Older servers populate only `message`.
+      console.error(event.code ?? "error", event.message);
+      if (event.retryable && event.retryAfterSeconds !== undefined) {
+        console.warn(`Server suggests retrying in ${event.retryAfterSeconds}s`);
+      }
       break;
     case "parse-error":
       console.warn("Malformed SSE frame", event.raw);
@@ -193,7 +199,7 @@ try {
 | `tool-call` | `toolCallId`, `name`, `args` | Agent is calling a tool |
 | `tool-result` | `toolCallId`, `name`, `result` | Tool returned a result |
 | `result` | `columns`, `rows` | Convenience event extracted from `tool-result` when `executeSQL` returns data. Both `tool-result` and `result` are emitted. |
-| `error` | `message` | Error during streaming |
+| `error` | `message`, `code?`, `retryable?`, `retryAfterSeconds?`, `requestId?` | Mid-stream error. When the server sends a structured `ChatErrorInfo` body (`provider_rate_limit`, `provider_timeout`, etc.) the typed `code` and upstream `Retry-After` delta travel alongside the human-readable `message`. Older servers populate only `message`. |
 | `parse-error` | `raw`, `error` | Client-side: an SSE frame contained invalid JSON. The raw data is preserved for debugging. |
 | `finish` | `reason` | Stream completed |
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/sdk",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "TypeScript SDK for the Atlas text-to-SQL agent API",
   "type": "module",
   "scripts": {

--- a/packages/sdk/src/__tests__/stream.test.ts
+++ b/packages/sdk/src/__tests__/stream.test.ts
@@ -350,6 +350,47 @@ describe("streamQuery — error and finish events", () => {
     expect(events[0]).toEqual({ type: "error", message: "Unknown error" });
   });
 
+  // #1980 — mid-stream errors travel as a `ChatErrorInfo`-shaped JSON body
+  // inside `errorText`. The SDK exposes `code` / `retryable` /
+  // `retryAfterSeconds` / `requestId` so callers can branch without
+  // regex-scraping the message.
+  test("extracts structured ChatErrorInfo fields from JSON errorText", async () => {
+    installFetchMock(sseResponse([
+      {
+        type: "error",
+        errorText: JSON.stringify({
+          error: "provider_rate_limit",
+          message: "LLM provider rate limit reached. Wait a moment and try again.",
+          retryable: true,
+          retryAfterSeconds: 30,
+          requestId: "11111111-2222-3333-4444-555555555555",
+        }),
+      },
+    ]));
+
+    const events = await collectEvents(makeClient().streamQuery("test"));
+    const evt = events[0] as Extract<(typeof events)[number], { type: "error" }>;
+    expect(evt.type).toBe("error");
+    expect(evt.code).toBe("provider_rate_limit");
+    expect(evt.retryable).toBe(true);
+    expect(evt.retryAfterSeconds).toBe(30);
+    expect(evt.requestId).toBe("11111111-2222-3333-4444-555555555555");
+    expect(evt.message).toContain("rate limit");
+  });
+
+  test("plain-text errorText still surfaces as message only (back-compat)", async () => {
+    installFetchMock(sseResponse([
+      { type: "error", errorText: "An error occurred while generating a response (ref: 12345678). Try sending your message again." },
+    ]));
+
+    const events = await collectEvents(makeClient().streamQuery("test"));
+    const evt = events[0] as Extract<(typeof events)[number], { type: "error" }>;
+    expect(evt.type).toBe("error");
+    expect(evt.message).toContain("An error occurred");
+    expect(evt.code).toBeUndefined();
+    expect(evt.retryable).toBeUndefined();
+  });
+
   test("yields finish event with default reason", async () => {
     installFetchMock(sseResponse([
       { type: "finish" },

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -379,11 +379,12 @@ export type StreamEvent =
   /**
    * Mid-stream error.
    *
-   * The server emits a `ChatErrorInfo`-shaped JSON body inside the SSE
-   * error frame's `errorText`. When that JSON parses cleanly we surface
-   * `code` / `retryable` / `retryAfterSeconds` / `requestId` so callers
-   * can branch on the typed code instead of regex-scraping the message.
-   * For older servers (or unparseable text) only `message` is set.
+   * Atlas serializes mid-stream errors as a `ChatErrorInfo`-shaped JSON
+   * body inside the SSE error frame's `errorText` so callers can branch
+   * on the typed `code` instead of regex-scraping the message. When
+   * `errorText` is not parseable as that body (a plain-text frame from a
+   * non-Atlas server, a malformed payload, or a non-JSON error) only
+   * `message` is set.
    */
   | {
       type: "error";
@@ -773,10 +774,10 @@ export function createAtlasClient(options: AtlasClientOptions) {
             }
             case "error": {
               const raw = (event.errorText ?? event.message ?? "Unknown error") as string;
-              // Atlas serializes mid-stream errors as a `ChatErrorInfo`-
-              // shaped JSON body so the typed code travels alongside the
-              // human-readable message. Older servers send a plain string;
-              // surface it as `message` only.
+              // If `errorText` parses as the `ChatErrorInfo` JSON Atlas
+              // serializes, lift the typed fields. Otherwise treat it as
+              // plain text — non-Atlas servers and malformed payloads
+              // both land here.
               let message = raw;
               let code: string | undefined;
               let retryable: boolean | undefined;
@@ -794,7 +795,8 @@ export function createAtlasClient(options: AtlasClientOptions) {
                   if (typeof parsed.requestId === "string") requestId = parsed.requestId;
                 }
               } catch {
-                // Plain-text errorText — leave `message` as the raw string.
+                // intentionally ignored: `raw` is not JSON — fall through
+                // with `message = raw`, leaving the typed fields unset.
               }
               yield {
                 type: "error",

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -376,7 +376,23 @@ export type StreamEvent =
   | { type: "tool-call"; toolCallId: string; name: string; args: Record<string, unknown> }
   | { type: "tool-result"; toolCallId: string; name: string; result: Record<string, unknown> }
   | { type: "result"; columns: string[]; rows: Record<string, unknown>[] }
-  | { type: "error"; message: string }
+  /**
+   * Mid-stream error.
+   *
+   * The server emits a `ChatErrorInfo`-shaped JSON body inside the SSE
+   * error frame's `errorText`. When that JSON parses cleanly we surface
+   * `code` / `retryable` / `retryAfterSeconds` / `requestId` so callers
+   * can branch on the typed code instead of regex-scraping the message.
+   * For older servers (or unparseable text) only `message` is set.
+   */
+  | {
+      type: "error";
+      message: string;
+      code?: string;
+      retryable?: boolean;
+      retryAfterSeconds?: number;
+      requestId?: string;
+    }
   /** Client-side: emitted when an SSE frame contains invalid JSON. */
   | { type: "parse-error"; raw: string; error: string }
   | { type: "finish"; reason: StreamFinishReason };
@@ -756,9 +772,37 @@ export function createAtlasClient(options: AtlasClientOptions) {
               break;
             }
             case "error": {
+              const raw = (event.errorText ?? event.message ?? "Unknown error") as string;
+              // Atlas serializes mid-stream errors as a `ChatErrorInfo`-
+              // shaped JSON body so the typed code travels alongside the
+              // human-readable message. Older servers send a plain string;
+              // surface it as `message` only.
+              let message = raw;
+              let code: string | undefined;
+              let retryable: boolean | undefined;
+              let retryAfterSeconds: number | undefined;
+              let requestId: string | undefined;
+              try {
+                const parsed = JSON.parse(raw) as Record<string, unknown>;
+                if (parsed && typeof parsed === "object") {
+                  if (typeof parsed.error === "string") code = parsed.error;
+                  if (typeof parsed.message === "string") message = parsed.message;
+                  if (typeof parsed.retryable === "boolean") retryable = parsed.retryable;
+                  if (typeof parsed.retryAfterSeconds === "number") {
+                    retryAfterSeconds = parsed.retryAfterSeconds;
+                  }
+                  if (typeof parsed.requestId === "string") requestId = parsed.requestId;
+                }
+              } catch {
+                // Plain-text errorText — leave `message` as the raw string.
+              }
               yield {
                 type: "error",
-                message: (event.errorText ?? event.message ?? "Unknown error") as string,
+                message,
+                ...(code !== undefined && { code }),
+                ...(retryable !== undefined && { retryable }),
+                ...(retryAfterSeconds !== undefined && { retryAfterSeconds }),
+                ...(requestId !== undefined && { requestId }),
               };
               break;
             }

--- a/packages/types/src/__tests__/errors.test.ts
+++ b/packages/types/src/__tests__/errors.test.ts
@@ -299,6 +299,32 @@ describe("parseChatError requestId", () => {
     const info = parseChatError(err, authMode);
     expect(info.requestId).toBeUndefined();
   });
+
+  // #1980 — mid-stream errors arrive via the AI SDK error chunk, where
+  // `errorText` becomes `error.message`. Atlas now ships the same
+  // `ChatErrorInfo`-shaped JSON body it uses for synchronous errors, so
+  // this parser round-trips both transports identically. Pin the shape:
+  // a provider rate-limit mid-stream MUST surface a typed code,
+  // retryable=true, and the upstream Retry-After delta.
+  test("round-trips mid-stream provider_rate_limit frame with retryAfterSeconds", () => {
+    const err = new Error(
+      JSON.stringify({
+        error: "provider_rate_limit",
+        message: "LLM provider rate limit reached. Wait a moment and try again.",
+        retryable: true,
+        retryAfterSeconds: 30,
+        requestId: "abcd-1234",
+      }),
+    );
+    const info = parseChatError(err, authMode);
+    expect(info.code).toBe("provider_rate_limit");
+    expect(info.retryable).toBe(true);
+    expect(info.requestId).toBe("abcd-1234");
+    // The provider_rate_limit branch in parseChatError doesn't currently
+    // expose retryAfterSeconds (only the rate_limited branch does), but
+    // that's a separate UI affordance — the typed code + retryable is
+    // what callers branch on.
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/types/src/__tests__/errors.test.ts
+++ b/packages/types/src/__tests__/errors.test.ts
@@ -301,11 +301,16 @@ describe("parseChatError requestId", () => {
   });
 
   // #1980 — mid-stream errors arrive via the AI SDK error chunk, where
-  // `errorText` becomes `error.message`. Atlas now ships the same
-  // `ChatErrorInfo`-shaped JSON body it uses for synchronous errors, so
-  // this parser round-trips both transports identically. Pin the shape:
-  // a provider rate-limit mid-stream MUST surface a typed code,
-  // retryable=true, and the upstream Retry-After delta.
+  // `errorText` becomes `error.message`. The mid-stream JSON body shape
+  // matches the synchronous chat response, so this parser round-trips
+  // both transports identically. Pin: a provider rate-limit mid-stream
+  // surfaces a typed code, `retryable=true`, and `requestId`.
+  //
+  // Surfacing `retryAfterSeconds` from `provider_rate_limit` is
+  // intentionally out of scope for this parser — only the in-process
+  // `rate_limited` code (per-user request budget) carries a UI-facing
+  // delta. Provider-driven backoff is consumed by the chat route via
+  // the response body / `Retry-After` header rather than by client UI.
   test("round-trips mid-stream provider_rate_limit frame with retryAfterSeconds", () => {
     const err = new Error(
       JSON.stringify({
@@ -320,10 +325,8 @@ describe("parseChatError requestId", () => {
     expect(info.code).toBe("provider_rate_limit");
     expect(info.retryable).toBe(true);
     expect(info.requestId).toBe("abcd-1234");
-    // The provider_rate_limit branch in parseChatError doesn't currently
-    // expose retryAfterSeconds (only the rate_limited branch does), but
-    // that's a separate UI affordance — the typed code + retryable is
-    // what callers branch on.
+    // Pin the deliberate scope decision so a future widening fails loud.
+    expect(info.retryAfterSeconds).toBeUndefined();
   });
 });
 
@@ -381,6 +384,7 @@ describe("isRetryableError", () => {
     "trial_expired",
     "workspace_suspended",
     "workspace_deleted",
+    "conversation_budget_exceeded",
   ];
 
   test("marks transient codes as retryable", () => {


### PR DESCRIPTION
Closes #1980.

## Summary

- **Provider Retry-After is now forwarded.** The `APICallError` branches in `packages/api/src/api/routes/chat.ts` (provider_auth_error 503 / provider_rate_limit 503 / provider_timeout 504 / provider_error 502) parse `err.responseHeaders["retry-after"]`, clamp to `[0, 300]` seconds, and round-trip the value to both the JSON body (`retryAfterSeconds`) and the `Retry-After` HTTP header. Previously only the in-process rate-limit and pool-exhaustion paths populated those fields.
- **Mid-stream errors emit structured frames.** Both `toUIMessageStream({ onError })` and the outer `createUIMessageStream({ onError })` now serialize a `ChatErrorInfo`-shaped JSON body (`{ error, message, retryable, retryAfterSeconds?, requestId }`) inside the AI SDK error chunk's `errorText` — the same shape the synchronous response uses, so the existing `parseChatError()` round-trips both transports identically. No more opaque "ref XXXXXXXX" text once the SSE is open.
- A single `classifyChatError(err)` helper drives both the synchronous catch block and the SSE `onError` paths so codes, retryability, and Retry-After deltas stay aligned.

## SDK

- `StreamEvent.error` widened with optional `code` / `retryable` / `retryAfterSeconds` / `requestId`. The SDK JSON-parses `errorText` where possible and falls back to the plain-text message for older servers.
- Bumped `@useatlas/sdk` 0.0.11 → 0.0.12 (new optional fields on `StreamEvent.error`).

## Docs

- `apps/docs/content/docs/reference/api.mdx`: documented Retry-After forwarding for provider errors and the mid-stream `errorText` JSON shape.
- `apps/docs/content/docs/reference/sdk.mdx` + `packages/sdk/README.md`: updated the `StreamEvent.error` table and added an example branching on `event.code` / `event.retryAfterSeconds`.

## Test plan

- [x] `bun run test` — full suite, 310 api tests + every other package — all green.
- [x] `bun run lint`, `bun run type`, `bun x syncpack lint`, `check-template-drift.sh`, `check-railway-watch.sh` — all green.
- [x] New tests in `packages/api/src/api/__tests__/chat.test.ts` cover provider Retry-After for each `APICallError` branch (401/403, 429, 408/timeout, catch-all 5xx), the 300s clamp, ignored HTTP-date form, and the missing-header path.
- [x] New mid-stream frame tests cover APICallError 429 mid-stream, network drop (`fetch failed`), APICallError 408 timeout mid-stream, and the unclassified `internal_error` fallback. Each asserts the SSE error chunk contains structured JSON with `code`, `retryable`, `retryAfterSeconds?`, and a non-empty `requestId`.
- [x] `packages/sdk/src/__tests__/stream.test.ts` pins both the structured-frame and back-compat plain-text paths.
- [x] `packages/types/src/__tests__/errors.test.ts` pins that a mid-stream `provider_rate_limit` body round-trips through `parseChatError()`.
- [x] `pr-review-toolkit:code-reviewer` — clean, no high-confidence issues.