### PR TITLE
chore: bump @useatlas/sdk template refs to ^0.0.12

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -296,7 +296,7 @@
     },
     "packages/sdk": {
       "name": "@useatlas/sdk",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "dependencies": {
         "@useatlas/types": "^0.0.16",
       },

--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -23,7 +23,7 @@
     "@ai-sdk/provider": "^3.0.8",
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.0.7",
-    "@useatlas/sdk": "^0.0.11",
+    "@useatlas/sdk": "^0.0.12",
     "@useatlas/types": "^0.0.16",
     "@better-auth/api-key": "^1.5.6",
     "@dnd-kit/core": "^6.3.1",

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -20,7 +20,7 @@
     "@ai-sdk/provider": "^3.0.8",
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.0.7",
-    "@useatlas/sdk": "^0.0.11",
+    "@useatlas/sdk": "^0.0.12",
     "@useatlas/types": "^0.0.16",
     "ai": "^6.0.141",
     "@better-auth/api-key": "^1.5.6",


### PR DESCRIPTION
## Summary

- Bump `@useatlas/sdk` from `^0.0.11` to `^0.0.12` in `create-atlas/templates/{docker,nextjs-standalone}/package.json`
- Follow-up to #1996 (which bumped the SDK package version for #1980 chat error surfacing) — the `sdk-v0.0.12` tag has been pushed and 0.0.12 is now live on npm, so template refs can safely catch up

## Why this is its own PR

Per the version-bump-ordering rule: bump dep refs **after** publish completes. Doing it in the same PR as the version bump would race the publish workflow and break Deploy Validation scaffold jobs that run `npm install` from the registry.

## Test plan
- [x] `bun x syncpack lint` — clean
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — passed (463 files verified)
- [x] `npm view @useatlas/sdk version` returns `0.0.12`