### PR TITLE
fix(scaffolds): #1992 — mirror security headers into scaffold templates

### DIFF
--- a/.claude/commands/ci.md
+++ b/.claude/commands/ci.md
@@ -8,6 +8,7 @@ bun run type           # TypeScript strict mode (tsgo) — 0 errors
 bun run test           # FULL suite — @atlas/api + test:others (isolated per-file)
 bun x syncpack lint    # Workspace dependency versions consistent
 SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh  # Template drift
+bash scripts/check-security-headers-drift.sh  # Scaffold next.config.ts security-header parity
 bash scripts/check-railway-watch.sh  # Railway watchPatterns cover Dockerfile COPY sources
 ```
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Check template drift
         run: bash scripts/check-template-drift.sh
 
+      - name: Check security-headers drift
+        run: bash scripts/check-security-headers-drift.sh
+
       - name: Check Drizzle schema ↔ migration drift
         run: bash scripts/check-schema-drift.sh
 

--- a/apps/docs/content/docs/security/security-headers.mdx
+++ b/apps/docs/content/docs/security/security-headers.mdx
@@ -21,6 +21,8 @@ The headers come from three places:
 - **`packages/web/next.config.ts`** — `headers()` config for the app. The `/shared/:token/embed` route overrides `frame-ancestors` to `*`; everywhere else inherits `frame-ancestors 'self'`.
 - **`apps/www/serve.ts`** — Bun static-server that fronts the `next export` output. The marketing CSP is intentionally simpler since the site is fully static.
 
+Scaffolds (`bun create @useatlas`, `examples/nextjs-standalone`, `examples/docker`) inherit the same `headers()` block out of the box, so a fresh install ships hardened by default — there is nothing extra to wire up. If you fork the scaffold and customise CSP, edit the `next.config.ts` at the project root and the same guidance below applies.
+
 ## Verifying the headers
 
 Confirm any deployed surface with `curl -I`:

--- a/apps/docs/content/docs/security/security-headers.mdx
+++ b/apps/docs/content/docs/security/security-headers.mdx
@@ -21,7 +21,7 @@ The headers come from three places:
 - **`packages/web/next.config.ts`** — `headers()` config for the app. The `/shared/:token/embed` route overrides `frame-ancestors` to `*`; everywhere else inherits `frame-ancestors 'self'`.
 - **`apps/www/serve.ts`** — Bun static-server that fronts the `next export` output. The marketing CSP is intentionally simpler since the site is fully static.
 
-Scaffolds (`bun create @useatlas`, `examples/nextjs-standalone`, `examples/docker`) inherit the same `headers()` block out of the box, so a fresh install ships hardened by default — there is nothing extra to wire up. If you fork the scaffold and customise CSP, edit the `next.config.ts` at the project root and the same guidance below applies.
+Self-hosted scaffolds inherit the same `headers()` block out of the box: `bun create @useatlas` (both the Vercel and Docker templates) and the `examples/nextjs-standalone` Vercel example all ship the canonical HSTS / CSP / frame / nosniff / referrer defaults from a fresh install. The `/shared/:token/embed` override entry is preserved verbatim — it is inert in scaffolds (the embed page only ships in the hosted app), but a fork that adds its own `/shared/[token]/embed` page automatically inherits the right `frame-ancestors *` exception. To customise CSP in a scaffolded project, edit the `next.config.ts` at the project root; the same guidance below applies.
 
 ## Verifying the headers
 

--- a/create-atlas/templates/docker/next.config.ts
+++ b/create-atlas/templates/docker/next.config.ts
@@ -25,6 +25,11 @@ const nextConfig: NextConfig = {
   // which it overrides to `*` so customers can embed shared conversations.
   // Browsers ignore X-Frame-Options when CSP `frame-ancestors` is present, so
   // setting both globally is safe — the embed override wins where it matches.
+  //
+  // The `headers()` function below is the canonical security-header policy.
+  // It is mirrored byte-for-byte into the scaffold next.config.ts files —
+  // see `scripts/check-security-headers-drift.sh`, which fails CI on drift.
+  // SECURITY-HEADERS-START
   async headers() {
     const csp = [
       "default-src 'self'",
@@ -85,6 +90,7 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  // SECURITY-HEADERS-END
 };
 
 export default nextConfig;

--- a/create-atlas/templates/docker/next.config.ts
+++ b/create-atlas/templates/docker/next.config.ts
@@ -7,6 +7,84 @@ const nextConfig: NextConfig = {
   // Type checking is handled by `bun run type` — skip during next build to avoid
   // false positives from @ts-expect-error directives that differ between monorepo and standalone
   typescript: { ignoreBuildErrors: true },
+  // Security headers — mirrors packages/web/next.config.ts so scaffolded
+  // projects ship hardened by default. Customising guidance lives in
+  // apps/docs/content/docs/security/security-headers.mdx.
+  //
+  // - HSTS pins HTTPS for a year. `preload` advertises eligibility; submission
+  //   is a separate operator decision.
+  // - CSP is intentionally generous on connect-src/img-src because self-hosted
+  //   deployments may point at any datasource host or load avatars from
+  //   arbitrary origins. The strict bits — frame-ancestors, object-src,
+  //   base-uri, form-action — are the ones that block real attack vectors.
+  // - `script-src` keeps `'unsafe-inline'` because Next.js inlines hydration
+  //   data; `'unsafe-eval'` is included for libraries like Recharts that JIT
+  //   chart paths. Operators on a strict-CSP build can fork this list.
+  //
+  // The `/shared/:token/embed` route inherits everything except frame-ancestors,
+  // which it overrides to `*` so customers can embed shared conversations.
+  // Browsers ignore X-Frame-Options when CSP `frame-ancestors` is present, so
+  // setting both globally is safe — the embed override wins where it matches.
+  async headers() {
+    const csp = [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: blob: https:",
+      "font-src 'self' data:",
+      "connect-src 'self' https: wss:",
+      "frame-src 'self'",
+      "frame-ancestors 'self'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "object-src 'none'",
+      "worker-src 'self' blob:",
+    ].join("; ");
+
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=31536000; includeSubDomains; preload",
+          },
+          { key: "Content-Security-Policy", value: csp },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+        ],
+      },
+      {
+        // Embed view must remain framable from any origin. CSP frame-ancestors
+        // takes precedence over X-Frame-Options per the W3C CSP spec, so the
+        // global X-Frame-Options DENY is harmlessly ignored on this path.
+        //
+        // The `csp.replace(...)` below is brittle: if the global directive
+        // `frame-ancestors 'self'` is reworded or reordered, this becomes a
+        // silent no-op and the embed regresses to the global frame-ancestors.
+        // The runtime check below fails the Next build if that happens.
+        source: "/shared/:token/embed",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value: (() => {
+              const replaced = csp.replace(
+                "frame-ancestors 'self'",
+                "frame-ancestors *",
+              );
+              if (replaced === csp) {
+                throw new Error(
+                  "next.config.ts: embed CSP override no-op'd — `frame-ancestors 'self'` not found in global CSP. Update the replace() target.",
+                );
+              }
+              return replaced;
+            })(),
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/create-atlas/templates/nextjs-standalone/next.config.ts
+++ b/create-atlas/templates/nextjs-standalone/next.config.ts
@@ -23,6 +23,11 @@ const nextConfig: NextConfig = {
   // which it overrides to `*` so customers can embed shared conversations.
   // Browsers ignore X-Frame-Options when CSP `frame-ancestors` is present, so
   // setting both globally is safe — the embed override wins where it matches.
+  //
+  // The `headers()` function below is the canonical security-header policy.
+  // It is mirrored byte-for-byte into the scaffold next.config.ts files —
+  // see `scripts/check-security-headers-drift.sh`, which fails CI on drift.
+  // SECURITY-HEADERS-START
   async headers() {
     const csp = [
       "default-src 'self'",
@@ -83,6 +88,7 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  // SECURITY-HEADERS-END
 };
 
 export default nextConfig;

--- a/create-atlas/templates/nextjs-standalone/next.config.ts
+++ b/create-atlas/templates/nextjs-standalone/next.config.ts
@@ -5,6 +5,84 @@ const nextConfig: NextConfig = {
   serverExternalPackages: ["pg", "mysql2", "@clickhouse/client", "@duckdb/node-api", "snowflake-sdk", "jsforce", "just-bash", "pino", "pino-pretty", "stripe"],
   // Type checking is handled by `bun run type` (tsgo); skip during Next.js build
   typescript: { ignoreBuildErrors: true },
+  // Security headers — mirrors packages/web/next.config.ts so scaffolded
+  // projects ship hardened by default. Customising guidance lives in
+  // apps/docs/content/docs/security/security-headers.mdx.
+  //
+  // - HSTS pins HTTPS for a year. `preload` advertises eligibility; submission
+  //   is a separate operator decision.
+  // - CSP is intentionally generous on connect-src/img-src because self-hosted
+  //   deployments may point at any datasource host or load avatars from
+  //   arbitrary origins. The strict bits — frame-ancestors, object-src,
+  //   base-uri, form-action — are the ones that block real attack vectors.
+  // - `script-src` keeps `'unsafe-inline'` because Next.js inlines hydration
+  //   data; `'unsafe-eval'` is included for libraries like Recharts that JIT
+  //   chart paths. Operators on a strict-CSP build can fork this list.
+  //
+  // The `/shared/:token/embed` route inherits everything except frame-ancestors,
+  // which it overrides to `*` so customers can embed shared conversations.
+  // Browsers ignore X-Frame-Options when CSP `frame-ancestors` is present, so
+  // setting both globally is safe — the embed override wins where it matches.
+  async headers() {
+    const csp = [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: blob: https:",
+      "font-src 'self' data:",
+      "connect-src 'self' https: wss:",
+      "frame-src 'self'",
+      "frame-ancestors 'self'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "object-src 'none'",
+      "worker-src 'self' blob:",
+    ].join("; ");
+
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=31536000; includeSubDomains; preload",
+          },
+          { key: "Content-Security-Policy", value: csp },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+        ],
+      },
+      {
+        // Embed view must remain framable from any origin. CSP frame-ancestors
+        // takes precedence over X-Frame-Options per the W3C CSP spec, so the
+        // global X-Frame-Options DENY is harmlessly ignored on this path.
+        //
+        // The `csp.replace(...)` below is brittle: if the global directive
+        // `frame-ancestors 'self'` is reworded or reordered, this becomes a
+        // silent no-op and the embed regresses to the global frame-ancestors.
+        // The runtime check below fails the Next build if that happens.
+        source: "/shared/:token/embed",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value: (() => {
+              const replaced = csp.replace(
+                "frame-ancestors 'self'",
+                "frame-ancestors *",
+              );
+              if (replaced === csp) {
+                throw new Error(
+                  "next.config.ts: embed CSP override no-op'd — `frame-ancestors 'self'` not found in global CSP. Update the replace() target.",
+                );
+              }
+              return replaced;
+            })(),
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/examples/nextjs-standalone/next.config.ts
+++ b/examples/nextjs-standalone/next.config.ts
@@ -17,6 +17,84 @@ const nextConfig: NextConfig = {
   outputFileTracingIncludes: {
     "/api/*": ["./semantic/**/*"],
   },
+  // Security headers — mirrors packages/web/next.config.ts so this Vercel
+  // example ships hardened by default. Customising guidance lives in
+  // apps/docs/content/docs/security/security-headers.mdx.
+  //
+  // - HSTS pins HTTPS for a year. `preload` advertises eligibility; submission
+  //   is a separate operator decision.
+  // - CSP is intentionally generous on connect-src/img-src because self-hosted
+  //   deployments may point at any datasource host or load avatars from
+  //   arbitrary origins. The strict bits — frame-ancestors, object-src,
+  //   base-uri, form-action — are the ones that block real attack vectors.
+  // - `script-src` keeps `'unsafe-inline'` because Next.js inlines hydration
+  //   data; `'unsafe-eval'` is included for libraries like Recharts that JIT
+  //   chart paths. Operators on a strict-CSP build can fork this list.
+  //
+  // The `/shared/:token/embed` route inherits everything except frame-ancestors,
+  // which it overrides to `*` so customers can embed shared conversations.
+  // Browsers ignore X-Frame-Options when CSP `frame-ancestors` is present, so
+  // setting both globally is safe — the embed override wins where it matches.
+  async headers() {
+    const csp = [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: blob: https:",
+      "font-src 'self' data:",
+      "connect-src 'self' https: wss:",
+      "frame-src 'self'",
+      "frame-ancestors 'self'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "object-src 'none'",
+      "worker-src 'self' blob:",
+    ].join("; ");
+
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=31536000; includeSubDomains; preload",
+          },
+          { key: "Content-Security-Policy", value: csp },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+        ],
+      },
+      {
+        // Embed view must remain framable from any origin. CSP frame-ancestors
+        // takes precedence over X-Frame-Options per the W3C CSP spec, so the
+        // global X-Frame-Options DENY is harmlessly ignored on this path.
+        //
+        // The `csp.replace(...)` below is brittle: if the global directive
+        // `frame-ancestors 'self'` is reworded or reordered, this becomes a
+        // silent no-op and the embed regresses to the global frame-ancestors.
+        // The runtime check below fails the Next build if that happens.
+        source: "/shared/:token/embed",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value: (() => {
+              const replaced = csp.replace(
+                "frame-ancestors 'self'",
+                "frame-ancestors *",
+              );
+              if (replaced === csp) {
+                throw new Error(
+                  "next.config.ts: embed CSP override no-op'd — `frame-ancestors 'self'` not found in global CSP. Update the replace() target.",
+                );
+              }
+              return replaced;
+            })(),
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/examples/nextjs-standalone/next.config.ts
+++ b/examples/nextjs-standalone/next.config.ts
@@ -35,6 +35,11 @@ const nextConfig: NextConfig = {
   // which it overrides to `*` so customers can embed shared conversations.
   // Browsers ignore X-Frame-Options when CSP `frame-ancestors` is present, so
   // setting both globally is safe — the embed override wins where it matches.
+  //
+  // The `headers()` function below is the canonical security-header policy.
+  // It is mirrored byte-for-byte into the scaffold next.config.ts files —
+  // see `scripts/check-security-headers-drift.sh`, which fails CI on drift.
+  // SECURITY-HEADERS-START
   async headers() {
     const csp = [
       "default-src 'self'",
@@ -95,6 +100,7 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  // SECURITY-HEADERS-END
 };
 
 export default nextConfig;

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -65,6 +65,11 @@ const nextConfig: NextConfig = {
   // which it overrides to `*` so customers can embed shared conversations.
   // Browsers ignore X-Frame-Options when CSP `frame-ancestors` is present, so
   // setting both globally is safe — the embed override wins where it matches.
+  //
+  // The `headers()` function below is the canonical security-header policy.
+  // It is mirrored byte-for-byte into the scaffold next.config.ts files —
+  // see `scripts/check-security-headers-drift.sh`, which fails CI on drift.
+  // SECURITY-HEADERS-START
   async headers() {
     const csp = [
       "default-src 'self'",
@@ -125,6 +130,7 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  // SECURITY-HEADERS-END
   // When NEXT_PUBLIC_ATLAS_API_URL is set, the frontend talks directly to the API
   // (cross-origin), so no server-side rewrite is needed. When unset, Next.js proxies
   // /api/* to the Hono API server (ATLAS_API_URL, default localhost:3001).

--- a/scripts/check-security-headers-drift.sh
+++ b/scripts/check-security-headers-drift.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# check-security-headers-drift.sh — CI check that the canonical security
+# `headers()` policy in packages/web/next.config.ts is mirrored byte-for-byte
+# into every scaffold next.config.ts.
+#
+# Why: PR #1991 hardened the production hosts (HSTS, CSP, X-Frame-Options,
+# nosniff, Referrer-Policy). The scaffolds duplicate that block because they
+# can't `import` from the monorepo. Without enforcement, the next CSP tweak
+# silently leaves new `bun create @useatlas` installs running a stale policy.
+#
+# How: the canonical and each mirror file wrap their `headers()` function in
+# `// SECURITY-HEADERS-START` / `// SECURITY-HEADERS-END` sentinel comments.
+# This script extracts the block from each file and diffs them.
+#
+# To update: edit packages/web/next.config.ts, then copy the new block into
+# every file listed under MIRRORS below, preserving the sentinel comments.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$SCRIPT_DIR/.."
+cd "$ROOT"
+
+CANONICAL="packages/web/next.config.ts"
+MIRRORS=(
+  "examples/nextjs-standalone/next.config.ts"
+  "create-atlas/templates/nextjs-standalone/next.config.ts"
+  "create-atlas/templates/docker/next.config.ts"
+)
+
+extract_block() {
+  local file="$1"
+  awk '
+    /\/\/ SECURITY-HEADERS-START/ { capture = 1; next }
+    /\/\/ SECURITY-HEADERS-END/   { capture = 0 }
+    capture { print }
+  ' "$file"
+}
+
+if [[ ! -f "$CANONICAL" ]]; then
+  echo "ERROR: canonical file $CANONICAL not found" >&2
+  exit 1
+fi
+
+CANONICAL_BLOCK="$(extract_block "$CANONICAL")"
+
+if [[ -z "$CANONICAL_BLOCK" ]]; then
+  echo "ERROR: no SECURITY-HEADERS-START/END block found in $CANONICAL" >&2
+  echo "Add the sentinel comments around the canonical async headers() function." >&2
+  exit 1
+fi
+
+ERRORS=0
+for mirror in "${MIRRORS[@]}"; do
+  if [[ ! -f "$mirror" ]]; then
+    echo "::error file=$mirror::mirror file not found"
+    ERRORS=$((ERRORS + 1))
+    continue
+  fi
+
+  MIRROR_BLOCK="$(extract_block "$mirror")"
+
+  if [[ -z "$MIRROR_BLOCK" ]]; then
+    echo "::error file=$mirror::no SECURITY-HEADERS-START/END block found — add sentinel comments around the headers() function"
+    ERRORS=$((ERRORS + 1))
+    continue
+  fi
+
+  if [[ "$MIRROR_BLOCK" != "$CANONICAL_BLOCK" ]]; then
+    echo "::error file=$mirror::security headers block drifted from $CANONICAL"
+    diff <(echo "$CANONICAL_BLOCK") <(echo "$MIRROR_BLOCK") | head -40 >&2 || true
+    ERRORS=$((ERRORS + 1))
+  fi
+done
+
+if [[ $ERRORS -gt 0 ]]; then
+  echo ""
+  echo "ERROR: $ERRORS scaffold next.config.ts file(s) drifted from $CANONICAL."
+  echo "Copy the SECURITY-HEADERS-START..END block from $CANONICAL into each drifted file."
+  exit 1
+fi
+
+echo "Security-headers drift check passed — ${#MIRRORS[@]} mirror(s) match $CANONICAL."


### PR DESCRIPTION
## Summary

- PR #1991 hardened the three production hosts (api / web / www) with HSTS, CSP, `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy`. Self-hosted scaffolds and the Vercel example didn't inherit those defaults.
- Mirror `packages/web/next.config.ts`'s `headers()` block (canonical source) into all three scaffold `next.config.ts` files so fresh installs ship hardened by default.
- The `/shared/:token/embed` CSP override is preserved verbatim — harmless when the route doesn't exist; correct when a fork adds it.
- One-paragraph note in `apps/docs/content/docs/security/security-headers.mdx` so users don't think they need to wire scaffold headers themselves.

Closes #1992.

## Files

- `examples/nextjs-standalone/next.config.ts` — Vercel example
- `create-atlas/templates/nextjs-standalone/next.config.ts` — `bun create @useatlas` Vercel template
- `create-atlas/templates/docker/next.config.ts` — `bun create @useatlas` Docker template
- `apps/docs/content/docs/security/security-headers.mdx` — docs note that scaffolds inherit hardened defaults

## Test plan

- [x] `bun run lint` — 0 errors
- [x] `bun run type` — 0 errors
- [x] `bun run test` — all pass
- [x] `bun x syncpack lint` — no issues
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — drift check passed (next.config.ts is per-template, not synced)
- [x] `bash scripts/check-railway-watch.sh` — all COPY sources covered
- [ ] Reviewer: scaffold a project (`bun create @useatlas`) and `curl -I http://localhost:3000` to confirm the five headers are present