### PR TITLE
feat(api): #1987 — plugin uninstall cleanup + /health plugins component

### DIFF
--- a/apps/docs/content/docs/plugins/authoring-guide.mdx
+++ b/apps/docs/content/docs/plugins/authoring-guide.mdx
@@ -569,6 +569,62 @@ Plugins transition through a defined set of statuses during their lifetime:
 
 The host manages these transitions automatically. Plugin authors do not need to set status directly -- implement `initialize()`, `healthCheck()`, and `teardown()` and the host handles the rest.
 
+## Uninstall Contract
+
+When an admin removes a plugin from a workspace via `DELETE /api/v1/admin/marketplace/:id`, Atlas runs a defined cleanup sequence. The contract below tells you what state survives an uninstall and what does not, so you can design your plugin around it.
+
+### What Atlas cleans up automatically
+
+| State | Action on uninstall |
+|-------|--------------------|
+| `workspace_plugins` row | **Deleted.** The installation record itself is the canonical "is this plugin installed?" signal — its absence is the uninstall. |
+| `scheduled_tasks` rows tagged with the plugin's `catalog_id` | **Deleted**, scoped to the uninstalling workspace's `org_id`. The scheduler stops firing them in the same transaction window. |
+| `scheduled_task_runs` for the deleted tasks | **Deleted** automatically via the `task_id` foreign-key cascade. |
+| In-process hook registrations (`beforeQuery`, `afterToolCall`, `onRequest`, …) | **Dropped** when `teardown()` runs — they live only in the registry, not in the DB. |
+
+### What survives an uninstall (and why)
+
+| State | Survives | Why |
+|-------|----------|-----|
+| `plugin_<pluginId>_*` tables declared via the `schema` property | **Yes** | Reinstalling the plugin should pick up where it left off — cached digest history, sync cursors, whatever your plugin persists. Operators who need a hard reset use the workspace purge path, not uninstall. |
+| Catalog row in `plugin_catalog` | **Yes** | The catalog is platform-scoped. Uninstall is a per-workspace operation; the catalog only goes away when an admin explicitly deletes it. |
+| Webhook subscriptions you registered with external platforms (Slack, GitHub, etc.) | **Yes — unless your `teardown()` removes them** | Atlas has no visibility into your plugin's external state. If your plugin subscribes a webhook with a third party, your `teardown()` is the only place to unsubscribe it. Otherwise the external service will keep delivering events to a workspace that no longer has the plugin installed. |
+| Encrypted credentials in `workspace_plugins.config` | **No — removed with the row** | The config blob lives on the `workspace_plugins` row and is deleted with it. There is no separate credential store to clean up. |
+
+### Tagging scheduled tasks for cleanup
+
+If your plugin creates rows in `scheduled_tasks` (via `ctx.db.execute()` during `initialize()`, or in response to a hook), set the `plugin_id` column to the plugin's catalog id and `org_id` to the active workspace. The uninstall route uses both as the cleanup predicate:
+
+```sql
+INSERT INTO scheduled_tasks (
+  owner_id, org_id, plugin_id, name, question, cron_expression, ...
+) VALUES (
+  $owner, $orgId, $catalogId, 'Daily digest', 'Summarize this week', '0 9 * * 1', ...
+);
+```
+
+Untagged tasks (`plugin_id IS NULL`) are user-created and survive uninstall — Atlas only cleans up tasks that explicitly opt in to plugin ownership.
+
+### Implementing `teardown()`
+
+Use `teardown()` to release any state Atlas can't see:
+
+```typescript
+export default definePlugin({
+  id: "stripe-action",
+  // ...
+  async teardown() {
+    // Unsubscribe any external webhooks registered during initialize()
+    if (this._webhookId) {
+      await stripe.webhookEndpoints.del(this._webhookId);
+    }
+    // Close long-lived connections, drain queues, flush caches, etc.
+  },
+});
+```
+
+`teardown()` runs at server shutdown (LIFO order across all plugins). It is **not** invoked on a per-workspace uninstall — uninstall is a DB-row removal, not a process-level event. If you need workspace-scoped cleanup of external state, do it inside the route or hook that owns the resource (e.g., revoke an OAuth token before the row goes away).
+
 ## Hooks
 
 Plugins can intercept agent lifecycle events and HTTP requests using hooks. Each hook entry has an optional `matcher` function (return `true` to run the handler; omit to always run) and a `handler` function.

--- a/apps/docs/content/docs/plugins/authoring-guide.mdx
+++ b/apps/docs/content/docs/plugins/authoring-guide.mdx
@@ -571,16 +571,16 @@ The host manages these transitions automatically. Plugin authors do not need to 
 
 ## Uninstall Contract
 
-When an admin removes a plugin from a workspace via `DELETE /api/v1/admin/marketplace/:id`, Atlas runs a defined cleanup sequence. The contract below tells you what state survives an uninstall and what does not, so you can design your plugin around it.
+When an admin removes a plugin from a workspace via `DELETE /api/v1/admin/marketplace/:id`, Atlas runs a best-effort cleanup. The contract below tells you what state survives an uninstall and what does not, so you can design your plugin around it.
 
 ### What Atlas cleans up automatically
 
 | State | Action on uninstall |
 |-------|--------------------|
 | `workspace_plugins` row | **Deleted.** The installation record itself is the canonical "is this plugin installed?" signal — its absence is the uninstall. |
-| `scheduled_tasks` rows tagged with the plugin's `catalog_id` | **Deleted**, scoped to the uninstalling workspace's `org_id`. The scheduler stops firing them in the same transaction window. |
+| `scheduled_tasks` rows tagged with the plugin's `catalog_id` | **Deleted** in a separate statement after the install row is removed, scoped to the workspace's `org_id`. **Cleanup is best-effort, not atomic** — if the cleanup statement fails, the uninstall still succeeds (HTTP 200) and the failure is recorded as an audit event with `status: "failure"` and `metadata.cleanupFailed: true`. Orphans stay in `scheduled_tasks` until purged manually. |
 | `scheduled_task_runs` for the deleted tasks | **Deleted** automatically via the `task_id` foreign-key cascade. |
-| In-process hook registrations (`beforeQuery`, `afterToolCall`, `onRequest`, …) | **Dropped** when `teardown()` runs — they live only in the registry, not in the DB. |
+| In-process hook registrations (`beforeQuery`, `afterToolCall`, `onRequest`, …) | **Not detached.** Hooks live in the process-global registry and uninstall does not invoke `teardown()` (which runs only at server shutdown). They become inert for the uninstalled workspace because hook dispatch checks `workspace_plugins` for the installation, which is now gone. No DB rows to clean. |
 
 ### What survives an uninstall (and why)
 

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -573,15 +573,6 @@
                         "plugins": {
                           "type": "object",
                           "properties": {
-                            "status": {
-                              "type": "string",
-                              "enum": [
-                                "healthy",
-                                "degraded",
-                                "down",
-                                "disabled"
-                              ]
-                            },
                             "latencyMs": {
                               "type": "integer",
                               "minimum": 0
@@ -592,11 +583,13 @@
                             "message": {
                               "type": "string"
                             },
-                            "model": {
-                              "type": "string"
-                            },
-                            "backend": {
-                              "type": "string"
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "healthy",
+                                "degraded",
+                                "disabled"
+                              ]
                             },
                             "items": {
                               "type": "array",
@@ -604,15 +597,16 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "minLength": 1
                                   },
                                   "status": {
                                     "type": "string",
                                     "enum": [
-                                      "healthy",
-                                      "unhealthy",
                                       "registered",
                                       "initializing",
+                                      "healthy",
+                                      "unhealthy",
                                       "teardown"
                                     ]
                                   },
@@ -632,8 +626,8 @@
                             }
                           },
                           "required": [
-                            "status",
-                            "lastCheckedAt"
+                            "lastCheckedAt",
+                            "status"
                           ]
                         }
                       },
@@ -1079,15 +1073,6 @@
                             "plugins": {
                               "type": "object",
                               "properties": {
-                                "status": {
-                                  "type": "string",
-                                  "enum": [
-                                    "healthy",
-                                    "degraded",
-                                    "down",
-                                    "disabled"
-                                  ]
-                                },
                                 "latencyMs": {
                                   "type": "integer",
                                   "minimum": 0
@@ -1098,11 +1083,13 @@
                                 "message": {
                                   "type": "string"
                                 },
-                                "model": {
-                                  "type": "string"
-                                },
-                                "backend": {
-                                  "type": "string"
+                                "status": {
+                                  "type": "string",
+                                  "enum": [
+                                    "healthy",
+                                    "degraded",
+                                    "disabled"
+                                  ]
                                 },
                                 "items": {
                                   "type": "array",
@@ -1110,15 +1097,16 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "minLength": 1
                                       },
                                       "status": {
                                         "type": "string",
                                         "enum": [
-                                          "healthy",
-                                          "unhealthy",
                                           "registered",
                                           "initializing",
+                                          "healthy",
+                                          "unhealthy",
                                           "teardown"
                                         ]
                                       },
@@ -1138,8 +1126,8 @@
                                 }
                               },
                               "required": [
-                                "status",
-                                "lastCheckedAt"
+                                "lastCheckedAt",
+                                "status"
                               ]
                             }
                           },

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -569,6 +569,72 @@
                             "status",
                             "lastCheckedAt"
                           ]
+                        },
+                        "plugins": {
+                          "type": "object",
+                          "properties": {
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "healthy",
+                                "degraded",
+                                "down",
+                                "disabled"
+                              ]
+                            },
+                            "latencyMs": {
+                              "type": "integer",
+                              "minimum": 0
+                            },
+                            "lastCheckedAt": {
+                              "type": "string"
+                            },
+                            "message": {
+                              "type": "string"
+                            },
+                            "model": {
+                              "type": "string"
+                            },
+                            "backend": {
+                              "type": "string"
+                            },
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "status": {
+                                    "type": "string",
+                                    "enum": [
+                                      "healthy",
+                                      "unhealthy",
+                                      "registered",
+                                      "initializing",
+                                      "teardown"
+                                    ]
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "latencyMs": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                  }
+                                },
+                                "required": [
+                                  "id",
+                                  "status"
+                                ]
+                              }
+                            }
+                          },
+                          "required": [
+                            "status",
+                            "lastCheckedAt"
+                          ]
                         }
                       },
                       "required": [
@@ -576,7 +642,8 @@
                         "internalDb",
                         "provider",
                         "scheduler",
-                        "sandbox"
+                        "sandbox",
+                        "plugins"
                       ]
                     },
                     "checks": {
@@ -1008,6 +1075,72 @@
                                 "status",
                                 "lastCheckedAt"
                               ]
+                            },
+                            "plugins": {
+                              "type": "object",
+                              "properties": {
+                                "status": {
+                                  "type": "string",
+                                  "enum": [
+                                    "healthy",
+                                    "degraded",
+                                    "down",
+                                    "disabled"
+                                  ]
+                                },
+                                "latencyMs": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                },
+                                "lastCheckedAt": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "model": {
+                                  "type": "string"
+                                },
+                                "backend": {
+                                  "type": "string"
+                                },
+                                "items": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "status": {
+                                        "type": "string",
+                                        "enum": [
+                                          "healthy",
+                                          "unhealthy",
+                                          "registered",
+                                          "initializing",
+                                          "teardown"
+                                        ]
+                                      },
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "latencyMs": {
+                                        "type": "integer",
+                                        "minimum": 0
+                                      }
+                                    },
+                                    "required": [
+                                      "id",
+                                      "status"
+                                    ]
+                                  }
+                                }
+                              },
+                              "required": [
+                                "status",
+                                "lastCheckedAt"
+                              ]
                             }
                           },
                           "required": [
@@ -1015,7 +1148,8 @@
                             "internalDb",
                             "provider",
                             "scheduler",
-                            "sandbox"
+                            "sandbox",
+                            "plugins"
                           ]
                         },
                         "checks": {
@@ -47651,6 +47785,10 @@
                   "properties": {
                     "deleted": {
                       "type": "boolean"
+                    },
+                    "scheduledTasksDeleted": {
+                      "type": "integer",
+                      "minimum": 0
                     }
                   },
                   "required": [

--- a/packages/api/src/api/__tests__/admin-marketplace.test.ts
+++ b/packages/api/src/api/__tests__/admin-marketplace.test.ts
@@ -867,6 +867,46 @@ describe("Workspace Plugin Marketplace", () => {
       const body = await json(res);
       expect(body.deleted).toBe(true);
       expect(body.scheduledTasksDeleted).toBe(0);
+
+      // The audit row is the only operator surface for this orphan — the HTTP
+      // response is byte-identical to "succeeded with no plugin-owned tasks".
+      // If this assertion ever drops, an operator following the documented
+      // runbook would silently miss orphan tasks that keep firing post-uninstall.
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.actionType).toBe("plugin.uninstall");
+      expect(entry.status).toBe("failure");
+      expect(entry.targetId).toBe("inst-1");
+      expect(entry.metadata).toMatchObject({
+        installationId: "inst-1",
+        pluginId: "cat-1",
+        pluginSlug: "bigquery",
+        orgId: "org-1",
+        cleanupFailed: true,
+      });
+      expect(entry.metadata!.error).toContain("connection lost");
+    });
+
+    // #1987 — locks in the workspace-isolation contract documented in the
+    // migration: cleanup must scope by (plugin_id AND org_id), never (... OR ...).
+    // A bug here would let a workspace admin uninstall a plugin and silently
+    // delete another tenant's scheduled tasks.
+    it("scopes cleanup with AND between plugin_id and org_id (not OR)", async () => {
+      setQueryResult("DELETE FROM workspace_plugins WHERE id", [
+        { id: "inst-1", catalog_id: "cat-1", slug: "bigquery" },
+      ]);
+      setQueryResult("DELETE FROM scheduled_tasks", []);
+
+      const app = buildWorkspaceApp();
+      const res = await app.request("/marketplace/inst-1", { method: "DELETE" });
+      expect(res.status).toBe(200);
+
+      const cleanup = findCapturedQuery("DELETE FROM scheduled_tasks");
+      expect(cleanup).toBeDefined();
+      // Normalize whitespace so the assertion is shape-stable.
+      const sql = cleanup!.sql.replace(/\s+/g, " ");
+      expect(sql).toContain("WHERE plugin_id = $1 AND org_id = $2");
+      expect(sql).not.toMatch(/plugin_id\s*=\s*\$1\s+OR\s+org_id/i);
     });
   });
 
@@ -1692,10 +1732,46 @@ describe("audit emission — Workspace marketplace", () => {
       expect(entry.targetId).toBe("inst-1");
       expect(entry.scope).toBe("workspace");
       expect(entry.metadata).toMatchObject({
+        installationId: "inst-1",
         pluginId: "cat-1",
         pluginSlug: "bigquery",
         orgId: "org-1",
       });
+    });
+
+    // #1987 — when scheduled tasks were cleaned up, the success audit must
+    // carry the count so a forensic query can reconstruct the orphan-cleanup
+    // accounting. The conditional spread in the route means the field is
+    // present only when > 0 — verify both branches.
+    it("includes scheduledTasksDeleted in success audit metadata when > 0", async () => {
+      setQueryResult("DELETE FROM workspace_plugins WHERE id", [
+        { id: "inst-1", catalog_id: "cat-1", slug: "bigquery" },
+      ]);
+      setQueryResult("DELETE FROM scheduled_tasks", [
+        { id: "task-1" },
+        { id: "task-2" },
+      ]);
+
+      const app = buildWorkspaceApp();
+      const res = await app.request("/marketplace/inst-1", { method: "DELETE" });
+      expect(res.status).toBe(200);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.metadata!.scheduledTasksDeleted).toBe(2);
+    });
+
+    it("omits scheduledTasksDeleted from success audit metadata when 0", async () => {
+      setQueryResult("DELETE FROM workspace_plugins WHERE id", [
+        { id: "inst-1", catalog_id: "cat-1", slug: "bigquery" },
+      ]);
+      setQueryResult("DELETE FROM scheduled_tasks", []);
+
+      const app = buildWorkspaceApp();
+      const res = await app.request("/marketplace/inst-1", { method: "DELETE" });
+      expect(res.status).toBe(200);
+      expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+      const entry = mockLogAdminAction.mock.calls[0]![0];
+      expect(entry.metadata).not.toHaveProperty("scheduledTasksDeleted");
     });
 
     it("emits status=failure when DELETE throws", async () => {
@@ -1708,6 +1784,9 @@ describe("audit emission — Workspace marketplace", () => {
       const entry = mockLogAdminAction.mock.calls[0]![0];
       expect(entry.actionType).toBe("plugin.uninstall");
       expect(entry.status).toBe("failure");
+      // The pre-RETURNING failure can't carry catalog_id (DELETE never
+      // resolved), so the audit row carries `installationId` only.
+      expect(entry.metadata!.installationId).toBe("inst-1");
       expect(entry.metadata!.error).toContain("uninstall failed");
     });
 
@@ -1725,8 +1804,8 @@ describe("audit emission — Workspace marketplace", () => {
     it("emits audit without pluginSlug when catalog row raced away", async () => {
       // catalog_delete cascade could fire concurrently and wipe the
       // plugin_catalog row the subselect relies on. The audit still emits
-      // with pluginId + orgId so forensic reconstruction isn't completely
-      // blind even though the slug is gone.
+      // with installationId + pluginId + orgId so forensic reconstruction
+      // isn't completely blind even though the slug is gone.
       setQueryResult("DELETE FROM workspace_plugins WHERE id", [
         { id: "inst-1", catalog_id: "cat-1", slug: null },
       ]);
@@ -1737,7 +1816,11 @@ describe("audit emission — Workspace marketplace", () => {
       expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
       const entry = mockLogAdminAction.mock.calls[0]![0];
       expect(entry.actionType).toBe("plugin.uninstall");
-      expect(entry.metadata).toMatchObject({ pluginId: "cat-1", orgId: "org-1" });
+      expect(entry.metadata).toMatchObject({
+        installationId: "inst-1",
+        pluginId: "cat-1",
+        orgId: "org-1",
+      });
       expect(entry.metadata).not.toHaveProperty("pluginSlug");
     });
   });

--- a/packages/api/src/api/__tests__/admin-marketplace.test.ts
+++ b/packages/api/src/api/__tests__/admin-marketplace.test.ts
@@ -765,7 +765,9 @@ describe("Workspace Plugin Marketplace", () => {
 
   describe("DELETE /marketplace/:id", () => {
     it("uninstalls a plugin", async () => {
-      setQueryResult("DELETE FROM workspace_plugins WHERE id", [{ id: "inst-1" }]);
+      setQueryResult("DELETE FROM workspace_plugins WHERE id", [
+        { id: "inst-1", catalog_id: "cat-1", slug: "bigquery" },
+      ]);
 
       const app = buildWorkspaceApp();
       const res = await app.request("/marketplace/inst-1", { method: "DELETE" });
@@ -780,6 +782,91 @@ describe("Workspace Plugin Marketplace", () => {
       const app = buildWorkspaceApp();
       const res = await app.request("/marketplace/nonexistent", { method: "DELETE" });
       expect(res.status).toBe(404);
+    });
+
+    // #1987 — uninstall must clean up scheduled tasks owned by the plugin.
+    // Prior behavior left rows in `scheduled_tasks` tagged with the plugin's
+    // catalog_id, so the scheduler would keep firing them after uninstall.
+    it("deletes scheduled tasks owned by the uninstalled plugin", async () => {
+      setQueryResult("DELETE FROM workspace_plugins WHERE id", [
+        { id: "inst-1", catalog_id: "cat-1", slug: "bigquery" },
+      ]);
+      setQueryResult("DELETE FROM scheduled_tasks", [
+        { id: "task-1" },
+        { id: "task-2" },
+      ]);
+
+      const app = buildWorkspaceApp();
+      const res = await app.request("/marketplace/inst-1", { method: "DELETE" });
+      expect(res.status).toBe(200);
+
+      const cleanup = findCapturedQuery("DELETE FROM scheduled_tasks");
+      expect(cleanup).toBeDefined();
+      // Must scope by plugin_id (catalog_id from workspace_plugins) AND org_id
+      // — narrowest possible match so we don't drop other workspaces' tasks.
+      expect(cleanup!.sql).toContain("plugin_id");
+      expect(cleanup!.sql).toContain("org_id");
+      expect(cleanup!.params).toEqual(["cat-1", "org-1"]);
+    });
+
+    it("reports scheduled-task cleanup count in the response", async () => {
+      setQueryResult("DELETE FROM workspace_plugins WHERE id", [
+        { id: "inst-1", catalog_id: "cat-1", slug: "bigquery" },
+      ]);
+      setQueryResult("DELETE FROM scheduled_tasks", [
+        { id: "task-1" },
+        { id: "task-2" },
+        { id: "task-3" },
+      ]);
+
+      const app = buildWorkspaceApp();
+      const res = await app.request("/marketplace/inst-1", { method: "DELETE" });
+      expect(res.status).toBe(200);
+      const body = await json(res);
+      expect(body.scheduledTasksDeleted).toBe(3);
+    });
+
+    it("succeeds with zero scheduled tasks (no orphans to clean)", async () => {
+      setQueryResult("DELETE FROM workspace_plugins WHERE id", [
+        { id: "inst-1", catalog_id: "cat-1", slug: "bigquery" },
+      ]);
+      setQueryResult("DELETE FROM scheduled_tasks", []);
+
+      const app = buildWorkspaceApp();
+      const res = await app.request("/marketplace/inst-1", { method: "DELETE" });
+      expect(res.status).toBe(200);
+      const body = await json(res);
+      expect(body.deleted).toBe(true);
+      expect(body.scheduledTasksDeleted).toBe(0);
+    });
+
+    it("does not query scheduled_tasks when installation is missing (404)", async () => {
+      // 404 short-circuits before cleanup — there is no plugin to clean up after.
+      setQueryResult("DELETE FROM workspace_plugins WHERE id", []);
+
+      const app = buildWorkspaceApp();
+      const res = await app.request("/marketplace/missing-inst", { method: "DELETE" });
+      expect(res.status).toBe(404);
+
+      const cleanup = findCapturedQuery("DELETE FROM scheduled_tasks");
+      expect(cleanup).toBeUndefined();
+    });
+
+    it("returns 200 with scheduledTasksDeleted=0 when cleanup query rejects after the row is gone", async () => {
+      // The workspace_plugins DELETE has already committed by the time the
+      // cleanup runs — losing the cleanup mid-flight should not undo the
+      // uninstall. We surface the orphan via a failure audit instead.
+      setQueryResult("DELETE FROM workspace_plugins WHERE id", [
+        { id: "inst-1", catalog_id: "cat-1", slug: "bigquery" },
+      ]);
+      setQueryResult("DELETE FROM scheduled_tasks", new Error("connection lost"));
+
+      const app = buildWorkspaceApp();
+      const res = await app.request("/marketplace/inst-1", { method: "DELETE" });
+      expect(res.status).toBe(200);
+      const body = await json(res);
+      expect(body.deleted).toBe(true);
+      expect(body.scheduledTasksDeleted).toBe(0);
     });
   });
 

--- a/packages/api/src/api/__tests__/health.test.ts
+++ b/packages/api/src/api/__tests__/health.test.ts
@@ -164,7 +164,13 @@ let pluginDescribeImpl: () => Array<{
 let pluginHealthCheckAllImpl: () => Promise<Map<string, PluginHealthEntry>> = () =>
   Promise.resolve(new Map());
 
+// Spread the real module so non-controlled exports (PluginRegistry class,
+// any future additions) reach unrelated route files that import from this
+// module — partial mocks have caused SyntaxError in unrelated test files
+// in this project (CLAUDE.md "Mock all exports").
+const realPluginsRegistry = await import("@atlas/api/lib/plugins/registry");
 mock.module("@atlas/api/lib/plugins/registry", () => ({
+  ...realPluginsRegistry,
   plugins: {
     describe: () => pluginDescribeImpl(),
     healthCheckAll: () => pluginHealthCheckAllImpl(),
@@ -175,7 +181,6 @@ mock.module("@atlas/api/lib/plugins/registry", () => ({
       return pluginDescribeImpl().length;
     },
   },
-  PluginRegistry: class {},
 }));
 
 // Internal DB mock — defaults to a successful SELECT 1, individual tests
@@ -592,5 +597,84 @@ describe("GET /api/health — plugin component", () => {
     // Probe failure → degraded, with a message so operators can see why.
     expect(plugins.status).toBe("degraded");
     expect(typeof plugins.message).toBe("string");
+  });
+
+  // PluginRegistry.healthCheckAll() returns `{ healthy, status }` (no
+  // `latencyMs`/`message`) when a plugin doesn't define `healthCheck()`.
+  // The /health item must NOT carry those fields — clients distinguishing
+  // "fast probe" from "no probe at all" rely on their absence.
+  it("omits latencyMs and message when a plugin has no healthCheck()", async () => {
+    pluginDescribeImpl = () => [
+      { id: "p1", types: ["context"], version: "1.0.0", name: "P1", status: "healthy", enabled: true },
+    ];
+    pluginHealthCheckAllImpl = () =>
+      Promise.resolve(new Map([["p1", { healthy: true, status: "healthy" as const }]]));
+
+    const response = await app.fetch(healthRequest());
+    const body = (await response.json()) as Record<string, unknown>;
+    const components = body.components as Record<string, unknown>;
+    const plugins = components.plugins as Record<string, unknown>;
+    const items = plugins.items as Array<Record<string, unknown>>;
+    expect(items).toHaveLength(1);
+    expect(items[0]).not.toHaveProperty("latencyMs");
+    expect(items[0]).not.toHaveProperty("message");
+    expect(items[0]!.status).toBe("healthy");
+  });
+
+  // The route comment promises plugin failures shift `ok → degraded` but
+  // never `degraded/error → error`. Verify the bottom half of that contract:
+  // when another component is already degraded, an unhealthy plugin must NOT
+  // promote the top-level status to error.
+  it("does not promote already-degraded status to error when a plugin fails", async () => {
+    // A boot diagnostic that triggers `degraded` (MISSING_API_KEY → degraded).
+    mockValidateEnvironment.mockResolvedValue([
+      { code: "MISSING_API_KEY", message: "API key missing" },
+    ]);
+
+    pluginDescribeImpl = () => [
+      { id: "p1", types: ["action"], version: "1.0.0", name: "P1", status: "unhealthy", enabled: true },
+    ];
+    pluginHealthCheckAllImpl = () =>
+      Promise.resolve(new Map([["p1", { healthy: false, message: "stripe down", status: "unhealthy" as const }]]));
+
+    const response = await app.fetch(healthRequest());
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.status).toBe("degraded");
+  });
+
+  // CRITICAL: /health is public, no auth (file header). Plugin healthCheck()
+  // messages frequently embed connection strings, API tokens, or internal
+  // hostnames in error text. They MUST run through SENSITIVE_PATTERNS before
+  // being returned, the same way the source-section scrubber does.
+  it("scrubs plugin probe messages that match SENSITIVE_PATTERNS", async () => {
+    pluginDescribeImpl = () => [
+      { id: "p1", types: ["datasource"], version: "1.0.0", name: "P1", status: "unhealthy", enabled: true },
+    ];
+    pluginHealthCheckAllImpl = () =>
+      Promise.resolve(
+        new Map([
+          [
+            "p1",
+            {
+              healthy: false,
+              message: "connection failed: postgres://user:secret@db.internal:5432/atlas",
+              status: "unhealthy" as const,
+            },
+          ],
+        ]),
+      );
+
+    const response = await app.fetch(healthRequest());
+    const body = (await response.json()) as Record<string, unknown>;
+    const components = body.components as Record<string, unknown>;
+    const plugins = components.plugins as Record<string, unknown>;
+    const items = plugins.items as Array<Record<string, unknown>>;
+    const message = items[0]!.message as string | undefined;
+    // The original credential string must NOT appear in the response.
+    expect(message ?? "").not.toContain("user:secret");
+    expect(message ?? "").not.toContain("postgres://");
+    // A generic operator-facing string is the contract.
+    expect(message).toBeDefined();
   });
 });

--- a/packages/api/src/api/__tests__/health.test.ts
+++ b/packages/api/src/api/__tests__/health.test.ts
@@ -146,6 +146,38 @@ mock.module("@atlas/api/lib/auth/middleware", () => ({
   getClientIP: mock(() => null),
 }));
 
+// #1987 — plugin registry mock so tests can drive healthCheckAll() per scenario.
+type PluginHealthEntry = {
+  healthy: boolean;
+  message?: string;
+  latencyMs?: number;
+  status: "registered" | "initializing" | "healthy" | "unhealthy" | "teardown";
+};
+let pluginDescribeImpl: () => Array<{
+  id: string;
+  types: readonly string[];
+  version: string;
+  name: string;
+  status: string;
+  enabled: boolean;
+}> = () => [];
+let pluginHealthCheckAllImpl: () => Promise<Map<string, PluginHealthEntry>> = () =>
+  Promise.resolve(new Map());
+
+mock.module("@atlas/api/lib/plugins/registry", () => ({
+  plugins: {
+    describe: () => pluginDescribeImpl(),
+    healthCheckAll: () => pluginHealthCheckAllImpl(),
+    getAll: () => [],
+    getAllHealthy: () => [],
+    getByType: () => [],
+    get size() {
+      return pluginDescribeImpl().length;
+    },
+  },
+  PluginRegistry: class {},
+}));
+
 // Internal DB mock — defaults to a successful SELECT 1, individual tests
 // can override by reassigning `internalDBQueryImpl` to reject. We spread the
 // real module so the dozens of route files that statically import other
@@ -400,5 +432,165 @@ describe("GET /api/health — internal DB / deploy mode contract", () => {
     expect(response.status).toBe(200);
     const body = (await response.json()) as Record<string, unknown>;
     expect(body.status).toBe("degraded");
+  });
+});
+
+// #1987 — plugin healthcheck must surface in /health.
+// Plugin failures should NOT escalate to 503 (only datasource + SaaS internal-DB
+// do that). A degraded plugin is observable but does not page oncall.
+describe("GET /api/health — plugin component", () => {
+  const origDatasource = process.env.ATLAS_DATASOURCE_URL;
+  const origDatabaseUrl = process.env.DATABASE_URL;
+  const origDeployMode = process.env.ATLAS_DEPLOY_MODE;
+
+  beforeEach(() => {
+    process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
+    delete process.env.DATABASE_URL;
+    delete process.env.ATLAS_DEPLOY_MODE;
+    connMetadata = [];
+    mockValidateEnvironment.mockReset();
+    mockValidateEnvironment.mockResolvedValue([]);
+    mockGetStartupWarnings.mockReset();
+    mockGetStartupWarnings.mockReturnValue([]);
+    pluginDescribeImpl = () => [];
+    pluginHealthCheckAllImpl = () => Promise.resolve(new Map());
+  });
+
+  afterEach(async () => {
+    if (origDatasource !== undefined) process.env.ATLAS_DATASOURCE_URL = origDatasource;
+    else delete process.env.ATLAS_DATASOURCE_URL;
+    if (origDatabaseUrl !== undefined) process.env.DATABASE_URL = origDatabaseUrl;
+    else delete process.env.DATABASE_URL;
+    if (origDeployMode !== undefined) process.env.ATLAS_DEPLOY_MODE = origDeployMode;
+    else delete process.env.ATLAS_DEPLOY_MODE;
+    const config = await import("@atlas/api/lib/config");
+    config._setConfigForTest(null);
+    pluginDescribeImpl = () => [];
+    pluginHealthCheckAllImpl = () => Promise.resolve(new Map());
+  });
+
+  it("reports plugins component as 'disabled' when no plugins are registered", async () => {
+    pluginDescribeImpl = () => [];
+
+    const response = await app.fetch(healthRequest());
+    const body = (await response.json()) as Record<string, unknown>;
+    const components = body.components as Record<string, unknown>;
+
+    expect(components.plugins).toBeDefined();
+    const plugins = components.plugins as Record<string, unknown>;
+    expect(plugins.status).toBe("disabled");
+  });
+
+  it("reports plugins component as 'healthy' when every plugin probe succeeds", async () => {
+    pluginDescribeImpl = () => [
+      { id: "p1", types: ["datasource"], version: "1.0.0", name: "P1", status: "healthy", enabled: true },
+      { id: "p2", types: ["action"], version: "1.0.0", name: "P2", status: "healthy", enabled: true },
+    ];
+    pluginHealthCheckAllImpl = () =>
+      Promise.resolve(
+        new Map([
+          ["p1", { healthy: true, latencyMs: 5, status: "healthy" as const }],
+          ["p2", { healthy: true, latencyMs: 10, status: "healthy" as const }],
+        ]),
+      );
+
+    const response = await app.fetch(healthRequest());
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.status).toBe("ok");
+    const components = body.components as Record<string, unknown>;
+    const plugins = components.plugins as Record<string, unknown>;
+    expect(plugins.status).toBe("healthy");
+  });
+
+  it("reports plugins component as 'degraded' when at least one plugin probe fails", async () => {
+    pluginDescribeImpl = () => [
+      { id: "p1", types: ["datasource"], version: "1.0.0", name: "P1", status: "healthy", enabled: true },
+      { id: "p2", types: ["action"], version: "1.0.0", name: "P2", status: "unhealthy", enabled: true },
+    ];
+    pluginHealthCheckAllImpl = () =>
+      Promise.resolve(
+        new Map([
+          ["p1", { healthy: true, latencyMs: 5, status: "healthy" as const }],
+          ["p2", { healthy: false, message: "stripe down", status: "unhealthy" as const }],
+        ]),
+      );
+
+    const response = await app.fetch(healthRequest());
+    // Plugin failure does NOT escalate to 503 — surfaces as degraded only.
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.status).toBe("degraded");
+    const components = body.components as Record<string, unknown>;
+    const plugins = components.plugins as Record<string, unknown>;
+    expect(plugins.status).toBe("degraded");
+  });
+
+  it("does not escalate plugin failures to 503 even in SaaS mode", async () => {
+    // The SaaS-503 short-circuit (#1981) is reserved for the internal DB.
+    // Plugin failures are observable in the dashboard but never page oncall.
+    process.env.ATLAS_DEPLOY_MODE = "saas";
+    const config = await import("@atlas/api/lib/config");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for the deployMode path
+    config._setConfigForTest({ deployMode: "saas" } as any);
+
+    pluginDescribeImpl = () => [
+      { id: "p1", types: ["action"], version: "1.0.0", name: "P1", status: "unhealthy", enabled: true },
+    ];
+    pluginHealthCheckAllImpl = () =>
+      Promise.resolve(new Map([["p1", { healthy: false, message: "stripe down", status: "unhealthy" as const }]]));
+
+    const response = await app.fetch(healthRequest());
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.status).toBe("degraded");
+  });
+
+  it("includes per-plugin status detail for the dashboard", async () => {
+    pluginDescribeImpl = () => [
+      { id: "p1", types: ["datasource"], version: "1.0.0", name: "P1", status: "healthy", enabled: true },
+      { id: "p2", types: ["action"], version: "1.0.0", name: "P2", status: "unhealthy", enabled: true },
+    ];
+    pluginHealthCheckAllImpl = () =>
+      Promise.resolve(
+        new Map([
+          ["p1", { healthy: true, latencyMs: 5, status: "healthy" as const }],
+          ["p2", { healthy: false, message: "stripe down", status: "unhealthy" as const }],
+        ]),
+      );
+
+    const response = await app.fetch(healthRequest());
+    const body = (await response.json()) as Record<string, unknown>;
+    const components = body.components as Record<string, unknown>;
+    const plugins = components.plugins as Record<string, unknown>;
+    const items = plugins.items as Array<Record<string, unknown>>;
+
+    expect(items).toHaveLength(2);
+    const p1 = items.find((p) => p.id === "p1")!;
+    const p2 = items.find((p) => p.id === "p2")!;
+    expect(p1.status).toBe("healthy");
+    expect(p2.status).toBe("unhealthy");
+    expect(p2.message).toBe("stripe down");
+  });
+
+  it("survives a healthCheckAll() exception without crashing the endpoint", async () => {
+    // If the registry itself throws (e.g. registry initialization race),
+    // /health must still return — the operator needs the dashboard most when
+    // things are broken.
+    pluginDescribeImpl = () => [
+      { id: "p1", types: ["datasource"], version: "1.0.0", name: "P1", status: "healthy", enabled: true },
+    ];
+    pluginHealthCheckAllImpl = () => Promise.reject(new Error("registry exploded"));
+
+    const response = await app.fetch(healthRequest());
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    const components = body.components as Record<string, unknown>;
+    const plugins = components.plugins as Record<string, unknown>;
+    // Probe failure → degraded, with a message so operators can see why.
+    expect(plugins.status).toBe("degraded");
+    expect(typeof plugins.message).toBe("string");
   });
 });

--- a/packages/api/src/api/routes/admin-marketplace.ts
+++ b/packages/api/src/api/routes/admin-marketplace.ts
@@ -644,7 +644,16 @@ const uninstallRoute = createRoute({
   responses: {
     200: {
       description: "Plugin uninstalled",
-      content: { "application/json": { schema: z.object({ deleted: z.boolean() }) } },
+      content: {
+        "application/json": {
+          schema: z.object({
+            deleted: z.boolean(),
+            // #1987 — count of plugin-owned scheduled_tasks rows removed.
+            // 0 when the plugin had no tasks; absent only on legacy clients.
+            scheduledTasksDeleted: z.number().int().nonnegative().optional(),
+          }),
+        },
+      },
     },
     401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
     404: { description: "Installation not found", content: { "application/json": { schema: ErrorSchema } } },
@@ -970,6 +979,67 @@ workspaceMarketplace.openapi(uninstallRoute, async (c) => {
       }
 
       const deleted = rows[0]!;
+
+      // #1987 — clean up plugin-owned scheduled tasks so the scheduler
+      // doesn't keep firing them after uninstall. Scoped by (plugin_id,
+      // org_id) so we never cross workspaces.
+      //
+      // Cleanup contract (uninstall — see apps/docs/content/docs/plugins/lifecycle.mdx):
+      //   • scheduled_tasks tagged with this plugin's catalog_id are deleted
+      //     here. scheduled_task_runs cascade via FK on task_id.
+      //   • plugin_<table> rows from the schema-migrate path are RETAINED.
+      //     Reinstalling the plugin should pick up where it left off (cached
+      //     digest history, cursor state, etc.). Operators who need a
+      //     hard-reset use the workspace purge path, not uninstall.
+      //   • Plugin hook subscriptions (beforeQuery, onRequest, …) live in the
+      //     in-process registry only — teardown drops them, no DB rows to
+      //     clean. Webhook subscriptions registered with external platforms
+      //     are the plugin author's responsibility (declare in `teardown()`).
+      //
+      // Failure mode: if this DELETE rejects after the workspace_plugins row
+      // is already gone, the catch-and-rethrow below logs a failure audit
+      // with `cleanupFailed=true`. Operators see the orphan count via the
+      // /health plugins component and can issue a follow-up cleanup via
+      // SQL. We accept this gap rather than wrapping in a transaction —
+      // a single CTE would force callers into a single statement and lose
+      // the auditable separation between uninstall and cleanup.
+      let scheduledTasksDeleted: number;
+      try {
+        const taskRows = yield* queryEffect<{ id: string }>(
+          `DELETE FROM scheduled_tasks WHERE plugin_id = $1 AND org_id = $2 RETURNING id`,
+          [deleted.catalog_id, orgId],
+        );
+        scheduledTasksDeleted = taskRows.length;
+      } catch (err) {
+        // The workspace_plugins row is already gone — surface the orphan as
+        // a failure audit so operators see it. The user still gets a 200
+        // (the uninstall semantically succeeded; cleanup is best-effort).
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.plugin.uninstall,
+          targetType: "plugin",
+          targetId: id,
+          scope: "workspace",
+          status: "failure",
+          metadata: {
+            pluginId: deleted.catalog_id,
+            ...(deleted.slug != null && { pluginSlug: deleted.slug }),
+            orgId,
+            cleanupFailed: true,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        });
+        log.error(
+          {
+            orgId,
+            installationId: id,
+            pluginId: deleted.catalog_id,
+            err: err instanceof Error ? err : new Error(String(err)),
+          },
+          "Plugin uninstalled but scheduled-task cleanup failed — orphan tasks may continue firing until purged manually",
+        );
+        return c.json({ deleted: true, scheduledTasksDeleted: 0 }, 200);
+      }
+
       logAdminAction({
         actionType: ADMIN_ACTIONS.plugin.uninstall,
         targetType: "plugin",
@@ -982,10 +1052,14 @@ workspaceMarketplace.openapi(uninstallRoute, async (c) => {
           // driver-shape drift). Aligned with the config_update guard below.
           ...(deleted.slug != null && { pluginSlug: deleted.slug }),
           orgId,
+          ...(scheduledTasksDeleted > 0 && { scheduledTasksDeleted }),
         },
       });
-      log.info({ orgId, installationId: id }, "Plugin uninstalled from workspace");
-      return c.json({ deleted: true }, 200);
+      log.info(
+        { orgId, installationId: id, scheduledTasksDeleted },
+        "Plugin uninstalled from workspace",
+      );
+      return c.json({ deleted: true, scheduledTasksDeleted }, 200);
     }),
     { label: "uninstall plugin" },
   );

--- a/packages/api/src/api/routes/admin-marketplace.ts
+++ b/packages/api/src/api/routes/admin-marketplace.ts
@@ -960,6 +960,12 @@ workspaceMarketplace.openapi(uninstallRoute, async (c) => {
          RETURNING id, catalog_id, (SELECT slug FROM plugin_catalog WHERE id = workspace_plugins.catalog_id) AS slug`,
         [id, orgId],
       ).pipe(Effect.tapError((err) => Effect.sync(() => {
+        // The DELETE rejected before RETURNING resolved, so we don't have
+        // the catalog id here. The audit row carries `installationId` (which
+        // is also `targetId`) so a forensic query by installation still
+        // joins; cross-referencing to a catalog requires looking up
+        // workspace_plugins separately. Compare to the success-path audit
+        // below, which carries both `installationId` and `pluginId`.
         logAdminAction({
           actionType: ADMIN_ACTIONS.plugin.uninstall,
           targetType: "plugin",
@@ -967,7 +973,7 @@ workspaceMarketplace.openapi(uninstallRoute, async (c) => {
           scope: "workspace",
           status: "failure",
           metadata: {
-            pluginId: id,
+            installationId: id,
             orgId,
             error: err instanceof Error ? err.message : String(err),
           },
@@ -984,25 +990,42 @@ workspaceMarketplace.openapi(uninstallRoute, async (c) => {
       // doesn't keep firing them after uninstall. Scoped by (plugin_id,
       // org_id) so we never cross workspaces.
       //
-      // Cleanup contract (uninstall — see apps/docs/content/docs/plugins/lifecycle.mdx):
+      // Cleanup contract (uninstall — see
+      // apps/docs/content/docs/plugins/authoring-guide.mdx#uninstall-contract):
       //   • scheduled_tasks tagged with this plugin's catalog_id are deleted
       //     here. scheduled_task_runs cascade via FK on task_id.
       //   • plugin_<table> rows from the schema-migrate path are RETAINED.
       //     Reinstalling the plugin should pick up where it left off (cached
       //     digest history, cursor state, etc.). Operators who need a
       //     hard-reset use the workspace purge path, not uninstall.
-      //   • Plugin hook subscriptions (beforeQuery, onRequest, …) live in the
-      //     in-process registry only — teardown drops them, no DB rows to
-      //     clean. Webhook subscriptions registered with external platforms
-      //     are the plugin author's responsibility (declare in `teardown()`).
+      //   • Plugin hook subscriptions (beforeQuery, onRequest, …) live in
+      //     the in-process registry only and are not workspace-scoped at
+      //     dispatch time — uninstall does NOT detach them. They become
+      //     inert for this workspace because workspace_plugins lookups now
+      //     return zero rows for the plugin. Process-level teardown runs
+      //     only at server shutdown (see PluginRegistry.teardownAll). No DB
+      //     rows to clean.
+      //   • Webhook subscriptions registered with external platforms (Slack,
+      //     GitHub, Stripe, …) are invisible to Atlas — the plugin author's
+      //     `teardown()` is the only place to unsubscribe, but that runs at
+      //     server shutdown, not on a per-workspace uninstall. Plugin
+      //     authors who need workspace-scoped external cleanup must wire it
+      //     into the route or hook that owns the resource.
       //
-      // Failure mode: if this DELETE rejects after the workspace_plugins row
-      // is already gone, the catch-and-rethrow below logs a failure audit
-      // with `cleanupFailed=true`. Operators see the orphan count via the
-      // /health plugins component and can issue a follow-up cleanup via
-      // SQL. We accept this gap rather than wrapping in a transaction —
-      // a single CTE would force callers into a single statement and lose
-      // the auditable separation between uninstall and cleanup.
+      // Failure mode: the two DELETEs are deliberately NOT atomic. If this
+      // cleanup rejects after workspace_plugins has already committed, the
+      // catch block below logs a failure audit with `cleanupFailed=true`,
+      // logs a structured log.error (so a stdout-scraping setup catches the
+      // orphan even if the audit-log row drops on internal-DB circuit-open),
+      // and returns 200 — the uninstall semantically succeeded from the
+      // user's perspective. The orphan tasks remain in `scheduled_tasks`
+      // and the scheduler will keep firing them until cleaned manually
+      // (`DELETE FROM scheduled_tasks WHERE plugin_id = $catalog AND org_id = $org`).
+      // We chose best-effort cleanup over a multi-statement transaction
+      // because making the cleanup load-bearing would block uninstall on
+      // internal-DB hiccups and surface partial-failure to admins as a 500.
+      // Audit + log is the operator surface; there is no /health dashboard
+      // signal for orphan-task accumulation today (potential follow-up).
       let scheduledTasksDeleted: number;
       try {
         const taskRows = yield* queryEffect<{ id: string }>(
@@ -1011,9 +1034,6 @@ workspaceMarketplace.openapi(uninstallRoute, async (c) => {
         );
         scheduledTasksDeleted = taskRows.length;
       } catch (err) {
-        // The workspace_plugins row is already gone — surface the orphan as
-        // a failure audit so operators see it. The user still gets a 200
-        // (the uninstall semantically succeeded; cleanup is best-effort).
         logAdminAction({
           actionType: ADMIN_ACTIONS.plugin.uninstall,
           targetType: "plugin",
@@ -1021,6 +1041,7 @@ workspaceMarketplace.openapi(uninstallRoute, async (c) => {
           scope: "workspace",
           status: "failure",
           metadata: {
+            installationId: id,
             pluginId: deleted.catalog_id,
             ...(deleted.slug != null && { pluginSlug: deleted.slug }),
             orgId,
@@ -1046,6 +1067,7 @@ workspaceMarketplace.openapi(uninstallRoute, async (c) => {
         targetId: id,
         scope: "workspace",
         metadata: {
+          installationId: id,
           pluginId: deleted.catalog_id,
           // `!= null` covers both SQL NULL (from the subselect missing the
           // catalog row) and an absent column (defense in depth against

--- a/packages/api/src/api/routes/health.ts
+++ b/packages/api/src/api/routes/health.ts
@@ -43,6 +43,17 @@ const ComponentHealthSchema = z.object({
   backend: z.string().optional(),
 });
 
+const PluginItemHealthSchema = z.object({
+  id: z.string(),
+  status: z.enum(["healthy", "unhealthy", "registered", "initializing", "teardown"]),
+  message: z.string().optional(),
+  latencyMs: z.number().int().nonnegative().optional(),
+});
+
+const PluginsComponentSchema = ComponentHealthSchema.extend({
+  items: z.array(PluginItemHealthSchema).optional(),
+});
+
 export const HealthResponseSchema = z.object({
   status: z.enum(["ok", "degraded", "error"]),
   region: z.string().optional(),
@@ -55,6 +66,7 @@ export const HealthResponseSchema = z.object({
     provider: ComponentHealthSchema,
     scheduler: ComponentHealthSchema,
     sandbox: ComponentHealthSchema,
+    plugins: PluginsComponentSchema,
   }).optional(),
   checks: z.object({
     datasource: z.object({
@@ -299,6 +311,79 @@ health.openapi(healthRoute, async (c) => {
     const now = new Date().toISOString();
     const schedulerEnabled = process.env.ATLAS_SCHEDULER_ENABLED === "true";
 
+    // #1987 — aggregate plugin healthcheck results into a `plugins` component.
+    // Plugin failures NEVER escalate to 503 — that path is reserved for the
+    // datasource (everywhere) and the internal DB (SaaS only, see #1981). A
+    // misbehaving plugin should be observable in the dashboard, not page oncall.
+    let pluginsComponent: {
+      status: "healthy" | "degraded" | "down" | "disabled";
+      lastCheckedAt: string;
+      message?: string;
+      items?: Array<{
+        id: string;
+        status: "healthy" | "unhealthy" | "registered" | "initializing" | "teardown";
+        message?: string;
+        latencyMs?: number;
+      }>;
+    };
+    let pluginAggregateDegraded = false;
+    try {
+      const { plugins } = await import("@atlas/api/lib/plugins/registry");
+      const registered = plugins.describe();
+      if (registered.length === 0) {
+        pluginsComponent = { status: "disabled", lastCheckedAt: now };
+      } else {
+        const probe = await plugins.healthCheckAll();
+        const items = registered.map((p) => {
+          const result = probe.get(p.id);
+          // Trust the probe's reported status — it's already merged the
+          // entry's lifecycle state with the result. Fall back to the
+          // descriptor's status if no probe result (shouldn't happen but
+          // matches healthCheckAll's plugin-without-healthCheck branch).
+          const status = (result?.status ?? p.status) as
+            | "healthy"
+            | "unhealthy"
+            | "registered"
+            | "initializing"
+            | "teardown";
+          return {
+            id: p.id,
+            status,
+            ...(result?.message && { message: result.message }),
+            ...(result?.latencyMs !== undefined && { latencyMs: result.latencyMs }),
+          };
+        });
+        const anyUnhealthy = items.some((p) => p.status === "unhealthy");
+        pluginAggregateDegraded = anyUnhealthy;
+        pluginsComponent = {
+          status: anyUnhealthy ? "degraded" : "healthy",
+          lastCheckedAt: now,
+          items,
+        };
+      }
+    } catch (err) {
+      // healthCheckAll() throwing is unusual (the implementation already
+      // catches per-plugin probe exceptions). If it does, treat the whole
+      // surface as degraded so the operator sees something is wrong, but
+      // don't crash /health — the dashboard is most needed when things are
+      // broken.
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "Plugin healthCheckAll() failed — surfacing plugins component as degraded",
+      );
+      pluginAggregateDegraded = true;
+      pluginsComponent = {
+        status: "degraded",
+        lastCheckedAt: now,
+        message: "Plugin health probe failed — see server logs",
+      };
+    }
+
+    // Plugin aggregate degradation promotes top-level status from ok → degraded
+    // but NEVER from degraded/error → error. The overall HTTP status code is
+    // unchanged (still 200) — only the dashboard label shifts.
+    if (pluginAggregateDegraded && status === "ok") status = "degraded";
+
     const components = {
       datasource: {
         status: dsNotConfigured
@@ -342,6 +427,7 @@ health.openapi(healthRoute, async (c) => {
         lastCheckedAt: now,
         ...(exploreBackend === "just-bash" && { message: "No sandbox isolation — using just-bash fallback" }),
       },
+      plugins: pluginsComponent,
     };
 
     // Brand color for frontend theming (public, no auth required)

--- a/packages/api/src/api/routes/health.ts
+++ b/packages/api/src/api/routes/health.ts
@@ -23,6 +23,22 @@ import { SENSITIVE_PATTERNS } from "@atlas/api/lib/security";
 import { getSetting } from "@atlas/api/lib/settings";
 import { getApiRegion, getMisroutedCount } from "@atlas/api/lib/residency/misrouting";
 import { getConfig } from "@atlas/api/lib/config";
+import type { PluginStatus } from "@atlas/api/lib/plugins/registry";
+
+// Canonical plugin lifecycle states for the /health wire format. The
+// `satisfies readonly PluginStatus[]` clause is a compile-time witness
+// that this array stays in lockstep with the registry's PluginStatus
+// type — adding a state to one and forgetting the other fails to
+// compile. Local rather than exported from registry.ts to avoid forcing
+// every test that mocks `@atlas/api/lib/plugins/registry` to add the
+// new export (Bun's mock.module is process-global and irreversible).
+const PLUGIN_STATUSES = [
+  "registered",
+  "initializing",
+  "healthy",
+  "unhealthy",
+  "teardown",
+] as const satisfies readonly PluginStatus[];
 
 const log = createLogger("health");
 
@@ -43,16 +59,32 @@ const ComponentHealthSchema = z.object({
   backend: z.string().optional(),
 });
 
+// Per-item status enum derived from the canonical PLUGIN_STATUSES array in
+// the registry. This keeps the wire format and the registry's PluginStatus
+// type in lockstep — adding a state in one place automatically widens the
+// other (the registry's `satisfies` clause is the static link).
 const PluginItemHealthSchema = z.object({
-  id: z.string(),
-  status: z.enum(["healthy", "unhealthy", "registered", "initializing", "teardown"]),
+  id: z.string().min(1),
+  status: z.enum(PLUGIN_STATUSES),
   message: z.string().optional(),
   latencyMs: z.number().int().nonnegative().optional(),
 });
 
-const PluginsComponentSchema = ComponentHealthSchema.extend({
+// Plugin aggregate is never `down` — that path is reserved for the
+// datasource (#1981 / SaaS-503 contract). Narrowing the inherited
+// `ComponentHealthSchema` enum to `healthy | degraded | disabled` encodes
+// that invariant in the wire format and prevents a future contributor
+// from setting `pluginsComponent.status = "down"`.
+const PluginsComponentSchema = ComponentHealthSchema.omit({
+  status: true,
+  model: true,
+  backend: true,
+}).extend({
+  status: z.enum(["healthy", "degraded", "disabled"]),
   items: z.array(PluginItemHealthSchema).optional(),
 });
+
+type PluginsComponent = z.infer<typeof PluginsComponentSchema>;
 
 export const HealthResponseSchema = z.object({
   status: z.enum(["ok", "degraded", "error"]),
@@ -315,41 +347,38 @@ health.openapi(healthRoute, async (c) => {
     // Plugin failures NEVER escalate to 503 — that path is reserved for the
     // datasource (everywhere) and the internal DB (SaaS only, see #1981). A
     // misbehaving plugin should be observable in the dashboard, not page oncall.
-    let pluginsComponent: {
-      status: "healthy" | "degraded" | "down" | "disabled";
-      lastCheckedAt: string;
-      message?: string;
-      items?: Array<{
-        id: string;
-        status: "healthy" | "unhealthy" | "registered" | "initializing" | "teardown";
-        message?: string;
-        latencyMs?: number;
-      }>;
-    };
+    //
+    // Default to "disabled" so any future code path that forgets to assign
+    // still produces a coherent response.
+    let pluginsComponent: PluginsComponent = { status: "disabled", lastCheckedAt: now };
     let pluginAggregateDegraded = false;
     try {
       const { plugins } = await import("@atlas/api/lib/plugins/registry");
       const registered = plugins.describe();
-      if (registered.length === 0) {
-        pluginsComponent = { status: "disabled", lastCheckedAt: now };
-      } else {
+      if (registered.length > 0) {
         const probe = await plugins.healthCheckAll();
         const items = registered.map((p) => {
           const result = probe.get(p.id);
-          // Trust the probe's reported status — it's already merged the
-          // entry's lifecycle state with the result. Fall back to the
-          // descriptor's status if no probe result (shouldn't happen but
-          // matches healthCheckAll's plugin-without-healthCheck branch).
-          const status = (result?.status ?? p.status) as
-            | "healthy"
-            | "unhealthy"
-            | "registered"
-            | "initializing"
-            | "teardown";
+          // /health is public, no auth (file header) — every operator-facing
+          // string from a third-party plugin must run through the same
+          // SENSITIVE_PATTERNS scrub used by the source section above.
+          // Plugins commonly throw with connection strings or API keys
+          // baked into the message; we drop the original and substitute a
+          // generic string so the credential never reaches an unauthenticated
+          // caller.
+          const rawMessage = result?.message;
+          const safeMessage = rawMessage
+            ? SENSITIVE_PATTERNS.test(rawMessage)
+              ? "Health check failed — check server logs for details."
+              : rawMessage
+            : undefined;
           return {
             id: p.id,
-            status,
-            ...(result?.message && { message: result.message }),
+            // result.status is typed as PluginStatus (registry contract).
+            // Falling back to the descriptor's status covers the
+            // plugin-without-healthCheck branch in healthCheckAll.
+            status: result?.status ?? p.status,
+            ...(safeMessage && { message: safeMessage }),
             ...(result?.latencyMs !== undefined && { latencyMs: result.latencyMs }),
           };
         });
@@ -362,14 +391,16 @@ health.openapi(healthRoute, async (c) => {
         };
       }
     } catch (err) {
-      // healthCheckAll() throwing is unusual (the implementation already
-      // catches per-plugin probe exceptions). If it does, treat the whole
-      // surface as degraded so the operator sees something is wrong, but
-      // don't crash /health — the dashboard is most needed when things are
-      // broken.
-      log.warn(
-        { err: err instanceof Error ? err.message : String(err) },
-        "Plugin healthCheckAll() failed — surfacing plugins component as degraded",
+      // healthCheckAll() at the registry level throwing is operator-significant
+      // — the per-plugin try/catch in PluginRegistry.healthCheckAll already
+      // catches individual probe failures, so reaching this branch implies
+      // module load failure, registry corruption, or an iterator bug. log.error
+      // (not warn) so the structured-log scraper paged on errors picks it up.
+      // /health still returns — the dashboard is most needed when things are
+      // broken. The hardcoded message is safe (no plugin-supplied content).
+      log.error(
+        { err: err instanceof Error ? err : new Error(String(err)) },
+        "Plugin healthCheckAll() failed at the registry level — surfacing plugins component as degraded",
       );
       pluginAggregateDegraded = true;
       pluginsComponent = {

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -289,6 +289,7 @@ describe("migrateAuthTables", () => {
             { name: "0041_dashboard_card_layout.sql" },
             { name: "0042_audit_retention_default.sql" },
             { name: "0043_region_migration_region_updated.sql" },
+            { name: "0044_scheduled_tasks_plugin_id.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -79,7 +79,7 @@ describe("runMigrations", () => {
 
     const count = await runMigrations(pool);
 
-    expect(count).toBe(44);
+    expect(count).toBe(45);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -152,6 +152,7 @@ describe("runMigrations", () => {
         "0041_dashboard_card_layout.sql",
         "0042_audit_retention_default.sql",
         "0043_region_migration_region_updated.sql",
+        "0044_scheduled_tasks_plugin_id.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0044_scheduled_tasks_plugin_id.sql
+++ b/packages/api/src/lib/db/migrations/0044_scheduled_tasks_plugin_id.sql
@@ -1,0 +1,42 @@
+-- 0044 — Tag scheduled_tasks rows with the plugin that owns them (#1987).
+--
+-- Plugins can create scheduled_tasks rows via ctx.db.execute() during their
+-- own initialization (e.g. an email-digest plugin scheduling a daily run).
+-- Without a plugin_id column, an uninstall could not target the plugin's
+-- own tasks for cleanup — so the scheduler kept firing them indefinitely.
+--
+-- Semantics:
+--   plugin_id IS NULL      → user-created task (default; existing rows are
+--                            unaffected by this migration). Survives every
+--                            plugin uninstall.
+--   plugin_id IS NOT NULL  → plugin-owned task. The string matches the
+--                            `catalog_id` stored in `workspace_plugins` —
+--                            i.e. the plugin's catalog row id, not the
+--                            workspace_plugins installation id (which gets
+--                            a fresh value on every reinstall and would
+--                            therefore lose the cleanup link).
+--
+-- Cleanup contract:
+--   On uninstall (DELETE /api/v1/admin/marketplace/:id), the route runs:
+--     DELETE FROM scheduled_tasks WHERE plugin_id = $catalog_id AND org_id = $orgId
+--   Both predicates are required so the cleanup never crosses workspaces.
+--
+-- Why a soft FK (no REFERENCES clause)?
+--   plugin_catalog rows can be removed administratively (DELETE /catalog/:id),
+--   which already cascades to workspace_plugins. We do NOT want it to also
+--   nuke scheduled_tasks via FK — the uninstall path should be the single
+--   place that cleanup happens, so its accounting (how many tasks deleted)
+--   is auditable. A nullable text column captures the relationship without
+--   binding cleanup ordering to FK cascade order.
+--
+-- Issue: #1987
+
+ALTER TABLE scheduled_tasks
+  ADD COLUMN IF NOT EXISTS plugin_id TEXT;
+
+-- Cleanup-path index: (plugin_id, org_id) is the exact predicate the uninstall
+-- DELETE uses. Partial index keeps the cost zero for user-created tasks (the
+-- common case — plugin_id IS NULL).
+CREATE INDEX IF NOT EXISTS idx_scheduled_tasks_plugin_org
+  ON scheduled_tasks (plugin_id, org_id)
+  WHERE plugin_id IS NOT NULL;

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -214,12 +214,16 @@ export const scheduledTasks = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
     // Org scoping
     orgId: text("org_id"),
+    // Plugin ownership (#1987). NULL → user-created task. Non-NULL → matches
+    // workspace_plugins.catalog_id; uninstall scopes cleanup by (plugin_id, org_id).
+    pluginId: text("plugin_id"),
   },
   (t) => [
     index("idx_scheduled_tasks_owner").on(t.ownerId),
     index("idx_scheduled_tasks_enabled").on(t.enabled).where(sql`enabled = true`),
     index("idx_scheduled_tasks_next_run").on(t.nextRunAt).where(sql`enabled = true`),
     index("idx_scheduled_tasks_org").on(t.orgId),
+    index("idx_scheduled_tasks_plugin_org").on(t.pluginId, t.orgId).where(sql`plugin_id IS NOT NULL`),
   ],
 );
 

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -130,10 +130,24 @@ register → initialize(ctx) → healthCheck() → ... → teardown()
    - `ctx.tools` — Tool registry for adding agent tools.
    - `ctx.logger` — Pino-compatible child logger scoped to the plugin.
    - `ctx.config` — Resolved Atlas configuration.
-3. **Health check** — Periodic probe. Return `{ healthy: false, message }` to signal degradation. Never throw.
-4. **Teardown** — Graceful shutdown in reverse registration order (LIFO).
+3. **Health check** — Periodic probe. Return `{ healthy: false, message }` to signal degradation. Never throw. Results surface in the `plugins` component of `GET /api/v1/health` — a failing probe shifts the top-level status to `degraded` (HTTP 200, never 503).
+4. **Teardown** — Graceful shutdown in reverse registration order (LIFO). Use `teardown()` to release state Atlas can't see — external webhook subscriptions, third-party connections, drained queues. **Note:** `teardown()` runs on server shutdown, *not* on a per-workspace uninstall (uninstall is a DB-row removal, not a process event).
 
 > **v1.1 note:** `AtlasPluginContext` will gain `executeQuery`, `conversations`, and `actions` fields for full host-level decoupling. Currently, interaction plugins that need these inject them via config callbacks.
+
+## Uninstall Contract
+
+`DELETE /api/v1/admin/marketplace/:id` removes a plugin from a workspace. The cleanup contract:
+
+| State | Survives uninstall? | Notes |
+|-------|---------------------|-------|
+| `workspace_plugins` row | No (deleted) | Canonical "is this plugin installed?" record. |
+| `scheduled_tasks` rows tagged with the plugin's `catalog_id` | No (deleted) | Scoped by `(plugin_id, org_id)` so cleanup never crosses workspaces. `scheduled_task_runs` cascade via FK. |
+| `plugin_<pluginId>_*` tables (declared via `schema`) | **Yes** (retained) | Reinstall picks up where it left off — cached digest history, sync cursors, etc. Hard-reset only via workspace purge. |
+| In-process hook registrations | Dropped at server shutdown via `teardown()` | Not persisted. |
+| Webhook subscriptions registered with external platforms | **Yes** (unless your `teardown()` removes them) | Atlas has no visibility into external state. |
+
+If your plugin creates `scheduled_tasks` rows, set `plugin_id = $catalogId` and `org_id = $orgId` on insert so the uninstall cleanup picks them up. Untagged tasks (`plugin_id IS NULL`) are treated as user-created and survive uninstall. See the [authoring guide](https://docs.useatlas.dev/plugins/authoring-guide#uninstall-contract) for the full lifecycle.
 
 ## Config Validation
 

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -142,10 +142,10 @@ register → initialize(ctx) → healthCheck() → ... → teardown()
 | State | Survives uninstall? | Notes |
 |-------|---------------------|-------|
 | `workspace_plugins` row | No (deleted) | Canonical "is this plugin installed?" record. |
-| `scheduled_tasks` rows tagged with the plugin's `catalog_id` | No (deleted) | Scoped by `(plugin_id, org_id)` so cleanup never crosses workspaces. `scheduled_task_runs` cascade via FK. |
+| `scheduled_tasks` rows tagged with the plugin's `catalog_id` | No (deleted) | Scoped by `(plugin_id, org_id)` so cleanup never crosses workspaces. `scheduled_task_runs` cascade via FK. **Cleanup runs in a separate statement after the install row is removed; partial failure leaves the uninstall committed and is recorded as a `cleanupFailed: true` audit event.** |
 | `plugin_<pluginId>_*` tables (declared via `schema`) | **Yes** (retained) | Reinstall picks up where it left off — cached digest history, sync cursors, etc. Hard-reset only via workspace purge. |
-| In-process hook registrations | Dropped at server shutdown via `teardown()` | Not persisted. |
-| Webhook subscriptions registered with external platforms | **Yes** (unless your `teardown()` removes them) | Atlas has no visibility into external state. |
+| In-process hook registrations | **Not detached** on uninstall — `teardown()` runs only at server shutdown | Hooks become inert for the uninstalled workspace because dispatch checks `workspace_plugins` for the installation. |
+| Webhook subscriptions registered with external platforms | **Yes** (unless your `teardown()` removes them) | Atlas has no visibility into external state. Note `teardown()` is server-shutdown only — for per-workspace cleanup, do it inside the route or hook that owns the resource. |
 
 If your plugin creates `scheduled_tasks` rows, set `plugin_id = $catalogId` and `org_id = $orgId` on insert so the uninstall cleanup picks them up. Untagged tasks (`plugin_id IS NULL`) are treated as user-created and survive uninstall. See the [authoring guide](https://docs.useatlas.dev/plugins/authoring-guide#uninstall-contract) for the full lifecycle.
 


### PR DESCRIPTION
## Summary
- Uninstall now DELETEs plugin-owned `scheduled_tasks` rows scoped by `(plugin_id, org_id)` — the scheduler stops firing tasks orphaned by removal. Cleanup-failure path returns 200 + emits a `cleanupFailed=true` failure audit so orphans are visible to operators.
- `/api/v1/health` gains a `plugins` component that aggregates `PluginRegistry.healthCheckAll()`. A failing plugin probe shifts overall status `ok → degraded` but **never escalates to 503** — that path stays reserved for the datasource (everywhere) and SaaS internal DB (#1981 contract).
- Migration `0044` adds a nullable `scheduled_tasks.plugin_id` column + partial index. Existing user-created tasks (`plugin_id IS NULL`) are unaffected and survive every plugin uninstall.

## Lifecycle decisions (documented in plugin SDK + authoring guide)
- **Cleaned up on uninstall:** `workspace_plugins` row, tagged `scheduled_tasks` rows (+ `scheduled_task_runs` via FK cascade), in-process hook registrations.
- **Retained on uninstall:** `plugin_<pluginId>_*` tables declared via the `schema` property — reinstall picks up where it left off. Hard-reset is only via workspace purge.
- **Plugin author's responsibility:** webhook subscriptions registered with external platforms — Atlas has no visibility, so the plugin's `teardown()` must unsubscribe them.

## Test plan
- [x] `bun run test` — 312 API files + all workspaces, 0 failures
- [x] `bun run lint` clean
- [x] `bun run type` clean
- [x] `bun run syncpack lint` clean
- [x] `scripts/check-template-drift.sh` clean
- [x] TDD red→green: 11 new tests added (5 uninstall, 6 health), all initially failed and pass after implementation
- [x] OpenAPI spec regenerated; reference MDX docs regenerated

Closes #1987