### PR TITLE
feat(web): #2005 — render context-warning + unify plan-warning channel

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -303,7 +303,7 @@
     },
     "packages/types": {
       "name": "@useatlas/types",
-      "version": "0.0.17",
+      "version": "0.0.18",
     },
     "packages/web": {
       "name": "@atlas/web",

--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -24,7 +24,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.0.7",
     "@useatlas/sdk": "^0.0.12",
-    "@useatlas/types": "^0.0.17",
+    "@useatlas/types": "^0.0.18",
     "@better-auth/api-key": "^1.5.6",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -21,7 +21,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.0.7",
     "@useatlas/sdk": "^0.0.12",
-    "@useatlas/types": "^0.0.17",
+    "@useatlas/types": "^0.0.18",
     "ai": "^6.0.141",
     "@better-auth/api-key": "^1.5.6",
     "@dnd-kit/core": "^6.3.1",

--- a/packages/api/src/api/__tests__/chat.test.ts
+++ b/packages/api/src/api/__tests__/chat.test.ts
@@ -172,8 +172,8 @@ mock.module("@atlas/api/lib/plugins/tools", () => ({
 // Plan-limit enforcement is mocked at the module boundary so tests can
 // dial in a {allowed: true, warning: ...} result without standing up the
 // full billing pipeline. Default returns the no-warning happy path; the
-// `#2005 — plan_limit_warning` describe block opts in to the warning
-// shape per-test.
+// `#2005 — plan-warning` test section inside the `#1988 B5` describe
+// block opts in to the warning shape per-test.
 type PlanCheckMockResult =
   | { allowed: true; warning?: { code: "plan_limit_warning"; message: string; metrics: unknown[] } }
   | {
@@ -1327,6 +1327,30 @@ describe("POST /api/v1/chat", () => {
       expect(frames.length).toBe(1);
       const data = frames[0].data as Record<string, unknown>;
       expect(data.requestId).toBe("agent-stamped-id");
+    });
+
+    it("treats an empty-string requestId on a warning as missing (uses route id)", async () => {
+      // Empty string is a useless correlation id and should not pollute
+      // the wire. The route's `warning.requestId ? warning : ...`
+      // ternary intentionally treats empty-string as falsy — pin it so
+      // a future "tighter" refactor (e.g. `!== undefined`) can't quietly
+      // start propagating empty correlation ids into the SSE stream.
+      mockRunAgent.mockImplementationOnce(
+        runAgentPushingWarnings([
+          {
+            severity: "warning",
+            code: "semantic_layer_unavailable",
+            title: "x",
+            requestId: "",
+          },
+        ]) as unknown as typeof mockRunAgent,
+      );
+      const response = await app.fetch(makeRequest());
+      const frames = await readContextWarningFrames(response);
+      expect(frames.length).toBe(1);
+      const data = frames[0].data as Record<string, unknown>;
+      expect(typeof data.requestId).toBe("string");
+      expect((data.requestId as string).length).toBeGreaterThan(0);
     });
   });
 

--- a/packages/api/src/api/__tests__/chat.test.ts
+++ b/packages/api/src/api/__tests__/chat.test.ts
@@ -169,6 +169,36 @@ mock.module("@atlas/api/lib/plugins/tools", () => ({
   setDialectHints: () => {},
 }));
 
+// Plan-limit enforcement is mocked at the module boundary so tests can
+// dial in a {allowed: true, warning: ...} result without standing up the
+// full billing pipeline. Default returns the no-warning happy path; the
+// `#2005 — plan_limit_warning` describe block opts in to the warning
+// shape per-test.
+type PlanCheckMockResult =
+  | { allowed: true; warning?: { code: "plan_limit_warning"; message: string; metrics: unknown[] } }
+  | {
+      allowed: false;
+      errorCode: string;
+      errorMessage: string;
+      httpStatus: number;
+      usage?: unknown;
+    };
+const mockCheckPlanLimits: Mock<() => Promise<PlanCheckMockResult>> = mock(
+  () => Promise.resolve({ allowed: true } as PlanCheckMockResult),
+);
+
+mock.module("@atlas/api/lib/billing/enforcement", () => ({
+  checkPlanLimits: mockCheckPlanLimits,
+  // Mocking partial named exports causes a SyntaxError elsewhere in
+  // the suite (per CLAUDE.md "Mock all exports"). These are no-ops
+  // because the chat path only touches `checkPlanLimits`.
+  getCachedWorkspace: () => Promise.resolve(null),
+  invalidatePlanCache: () => {},
+  checkResourceLimit: () => Promise.resolve({ allowed: true }),
+  buildMetricStatus: () => ({ metric: "tokens", currentUsage: 0, limit: 0, usagePercent: 0, status: "ok" }),
+  severityOf: () => 0,
+}));
+
 // Import after mocks are registered
 const { app } = await import("../index");
 
@@ -212,6 +242,8 @@ describe("POST /api/v1/chat", () => {
     delete process.env.ATLAS_CONVERSATION_STEP_CAP;
     mockGetPluginTools.mockReset();
     mockGetPluginTools.mockReturnValue(undefined);
+    mockCheckPlanLimits.mockReset();
+    mockCheckPlanLimits.mockResolvedValue({ allowed: true });
   });
 
   afterEach(() => {
@@ -1148,6 +1180,153 @@ describe("POST /api/v1/chat", () => {
       expect(response.status).toBe(200);
       const frames = await readContextWarningFrames(response);
       expect(frames).toEqual([]);
+    });
+
+    // -------------------------------------------------------------------
+    // #2005 — plan-warning rides the unified context-warning channel
+    //
+    // Pre-#2005 the chat route emitted plan warnings on a separate
+    // `data-plan-warning` SSE frame plus an `x-plan-limit-warning`
+    // response header. Both were typed-mismatched dead code (server
+    // wrote an object, client guarded on string). The cleanup folds
+    // the signal onto the same `data-context-warning` channel under
+    // a new `plan_limit_warning` code. These tests pin:
+    //   - a `checkPlanLimits` warning becomes a structured
+    //     `data-context-warning` frame with `code: "plan_limit_warning"`
+    //   - the plan-warning frame is `unshift`ed so it leads any
+    //     preflight degradations (most-attention-warranting first)
+    //   - the route never emits `data-plan-warning` again
+    //   - the route never sets the `x-plan-limit-warning` header
+    // -------------------------------------------------------------------
+    async function readAllFrames(
+      response: Response,
+    ): Promise<Array<Record<string, unknown>>> {
+      const text = await response.text();
+      const frames: Array<Record<string, unknown>> = [];
+      for (const chunk of text.split("\n\n")) {
+        for (const line of chunk.split("\n")) {
+          if (!line.startsWith("data: ")) continue;
+          const payload = line.slice(6);
+          if (payload === "[DONE]") continue;
+          try {
+            frames.push(JSON.parse(payload) as Record<string, unknown>);
+          } catch {
+            // ignore malformed lines
+          }
+        }
+      }
+      return frames;
+    }
+
+    it("folds checkPlanLimits warning into the data-context-warning channel", async () => {
+      mockCheckPlanLimits.mockResolvedValueOnce({
+        allowed: true,
+        warning: {
+          code: "plan_limit_warning",
+          message: "85% of monthly token budget used.",
+          metrics: [],
+        },
+      });
+      const response = await app.fetch(makeRequest());
+      expect(response.status).toBe(200);
+
+      const frames = await readContextWarningFrames(response);
+      expect(frames.length).toBe(1);
+      const data = frames[0].data as Record<string, unknown>;
+      expect(data.severity).toBe("warning");
+      expect(data.code).toBe("plan_limit_warning");
+      expect(data.title).toBe("Approaching plan limit");
+      expect(data.detail).toBe("85% of monthly token budget used.");
+      expect(typeof data.requestId).toBe("string");
+    });
+
+    it("plan_limit_warning frame is unshifted ahead of preflight degradations", async () => {
+      mockCheckPlanLimits.mockResolvedValueOnce({
+        allowed: true,
+        warning: {
+          code: "plan_limit_warning",
+          message: "approaching budget",
+          metrics: [],
+        },
+      });
+      mockRunAgent.mockImplementationOnce(
+        runAgentPushingWarnings([
+          {
+            severity: "warning",
+            code: "semantic_layer_unavailable",
+            title: "Semantic layer unavailable",
+          },
+        ]) as unknown as typeof mockRunAgent,
+      );
+      const response = await app.fetch(makeRequest());
+      expect(response.status).toBe(200);
+
+      const frames = await readContextWarningFrames(response);
+      expect(frames.length).toBe(2);
+      const codes = frames.map((f) => (f.data as Record<string, unknown>).code as string);
+      // Plan signal first (unshift), preflight degradation after.
+      expect(codes).toEqual(["plan_limit_warning", "semantic_layer_unavailable"]);
+    });
+
+    it("never emits a legacy data-plan-warning frame even when a plan warning is present", async () => {
+      mockCheckPlanLimits.mockResolvedValueOnce({
+        allowed: true,
+        warning: {
+          code: "plan_limit_warning",
+          message: "x",
+          metrics: [],
+        },
+      });
+      const response = await app.fetch(makeRequest());
+      const frames = await readAllFrames(response);
+      // Defensive scan over EVERY frame type — any `data-plan-warning`
+      // would be a regression of the legacy dead channel.
+      const legacy = frames.filter((f) => f.type === "data-plan-warning");
+      expect(legacy.length).toBe(0);
+    });
+
+    it("never sets the legacy x-plan-limit-warning response header", async () => {
+      mockCheckPlanLimits.mockResolvedValueOnce({
+        allowed: true,
+        warning: {
+          code: "plan_limit_warning",
+          message: "x",
+          metrics: [],
+        },
+      });
+      const response = await app.fetch(makeRequest());
+      expect(response.headers.get("x-plan-limit-warning")).toBeNull();
+    });
+
+    it("emits no plan_limit_warning frame when checkPlanLimits returns no warning", async () => {
+      // Default mock returns { allowed: true } with no warning field.
+      const response = await app.fetch(makeRequest());
+      const frames = await readContextWarningFrames(response);
+      const planFrames = frames.filter(
+        (f) => (f.data as Record<string, unknown>).code === "plan_limit_warning",
+      );
+      expect(planFrames.length).toBe(0);
+    });
+
+    it("preserves a warning's pre-existing requestId rather than spreading it away", async () => {
+      // The agent's preflight emit sites may stamp their own correlation
+      // id (e.g. for inner-Effect tracing). The route must not silently
+      // overwrite it via `{ ...warning, requestId }`.
+      mockRunAgent.mockImplementationOnce(
+        runAgentPushingWarnings([
+          {
+            severity: "warning",
+            code: "semantic_layer_unavailable",
+            title: "x",
+            requestId: "agent-stamped-id",
+          },
+        ]) as unknown as typeof mockRunAgent,
+      );
+      const response = await app.fetch(makeRequest());
+      const frames = await readContextWarningFrames(response);
+      expect(frames.length).toBe(1);
+      const data = frames[0].data as Record<string, unknown>;
+      expect(data.requestId).toBe("agent-stamped-id");
     });
   });
 

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -572,12 +572,8 @@ chat.openapi(chatRoute, async (c) => {
       );
     }
   
-    // Capture plan warning so it can be folded into the unified
-    // `data-context-warning` stream alongside semantic / learned-pattern
-    // degradations. Pre-#2005 this used a separate `data-plan-warning`
-    // frame + `x-plan-limit-warning` header, but the frame channel was
-    // never wired up on the client (typed as a string while the server
-    // wrote an object) — unifying on one channel is the cleanup.
+    // Captured here; folded into the unified `data-context-warning`
+    // stream at the writer below.
     const planWarning = planCheck.allowed ? planCheck.warning : undefined;
   
     // Resolve atlas mode for this request (published vs developer)
@@ -850,12 +846,11 @@ chat.openapi(chatRoute, async (c) => {
           // stay aligned.
           const stream = createUIMessageStream({
             execute: ({ writer }) => {
-              // #2005 — fold the plan-budget warning into the same
-              // structured `data-context-warning` channel as the agent's
-              // preflight degradations so the client only has to handle
-              // one wire shape. The pre-#2005 `data-plan-warning` frame
-              // (with `data` typed as a string on the client but written
-              // as an object server-side) is gone.
+              // Fold the plan-budget signal into the same structured
+              // `data-context-warning` channel as the agent's preflight
+              // degradations so the client only has to handle one wire
+              // shape. unshift so the budget signal renders above any
+              // preflight ones — it usually warrants the most attention.
               if (planWarning) {
                 contextWarnings.unshift({
                   severity: "warning",
@@ -864,12 +859,14 @@ chat.openapi(chatRoute, async (c) => {
                   detail: planWarning.message,
                 });
               }
-              // #1988 B5 — emit one frame per preflight degradation. Each
-              // frame carries `severity: "warning"` so a client routing
-              // these through the same parser as the `data-error` frame
-              // (#1980) does not misclassify a degraded answer as a
-              // failure. `requestId` is stamped so log correlation works
-              // end-to-end without the client having to plumb the header.
+              // Each frame carries `severity: "warning"` so a client
+              // routing these through the same parser as the `data-error`
+              // frame (#1980) does not misclassify a degraded answer as
+              // a failure. The route stamps `requestId` only when the
+              // warning didn't already carry one — preflight emit sites
+              // (`lib/agent.ts` Effect.catchAll arms) may attach their
+              // own correlation id, and bypassing them via spread would
+              // silently drop it.
               //
               // Ordering is load-bearing: this loop runs BEFORE
               // `writer.merge(agentResult.toUIMessageStream(...))` below,
@@ -880,7 +877,7 @@ chat.openapi(chatRoute, async (c) => {
               for (const warning of contextWarnings) {
                 writer.write({
                   type: "data-context-warning",
-                  data: { ...warning, requestId },
+                  data: warning.requestId ? warning : { ...warning, requestId },
                 });
               }
               setStreamWriter(requestId, writer);

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -572,7 +572,12 @@ chat.openapi(chatRoute, async (c) => {
       );
     }
   
-    // Capture plan warning for response headers (set after stream is created)
+    // Capture plan warning so it can be folded into the unified
+    // `data-context-warning` stream alongside semantic / learned-pattern
+    // degradations. Pre-#2005 this used a separate `data-plan-warning`
+    // frame + `x-plan-limit-warning` header, but the frame channel was
+    // never wired up on the client (typed as a string while the server
+    // wrote an object) — unifying on one channel is the cleanup.
     const planWarning = planCheck.allowed ? planCheck.warning : undefined;
   
     // Resolve atlas mode for this request (published vs developer)
@@ -845,9 +850,19 @@ chat.openapi(chatRoute, async (c) => {
           // stay aligned.
           const stream = createUIMessageStream({
             execute: ({ writer }) => {
-              // Surface plan warning as a data annotation so clients can display it
+              // #2005 — fold the plan-budget warning into the same
+              // structured `data-context-warning` channel as the agent's
+              // preflight degradations so the client only has to handle
+              // one wire shape. The pre-#2005 `data-plan-warning` frame
+              // (with `data` typed as a string on the client but written
+              // as an object server-side) is gone.
               if (planWarning) {
-                writer.write({ type: "data-plan-warning", data: planWarning });
+                contextWarnings.unshift({
+                  severity: "warning",
+                  code: "plan_limit_warning",
+                  title: "Approaching plan limit",
+                  detail: planWarning.message,
+                });
               }
               // #1988 B5 — emit one frame per preflight degradation. Each
               // frame carries `severity: "warning"` so a client routing
@@ -900,7 +915,6 @@ chat.openapi(chatRoute, async (c) => {
               "X-Accel-Buffering": "no",
               "Cache-Control": "no-cache, no-transform",
               ...(conversationId ? { "x-conversation-id": conversationId } : {}),
-              ...(planWarning ? { "x-plan-limit-warning": JSON.stringify(planWarning) } : {}),
             },
           });
   

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -863,10 +863,11 @@ chat.openapi(chatRoute, async (c) => {
               // routing these through the same parser as the `data-error`
               // frame (#1980) does not misclassify a degraded answer as
               // a failure. The route stamps `requestId` only when the
-              // warning didn't already carry one — preflight emit sites
-              // (`lib/agent.ts` Effect.catchAll arms) may attach their
-              // own correlation id, and bypassing them via spread would
-              // silently drop it.
+              // warning didn't already carry one. Today no emit site
+              // attaches its own correlation id (the agent's Effect
+              // catchAll arms push only the wire-DTO fields); the
+              // ternary keeps the surface safe to extend without
+              // re-auditing this loop.
               //
               // Ordering is load-bearing: this loop runs BEFORE
               // `writer.merge(agentResult.toUIMessageStream(...))` below,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -82,7 +82,7 @@
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^5.96.2",
-    "@useatlas/types": "^0.0.17",
+    "@useatlas/types": "^0.0.18",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "radix-ui": "^1.4.3",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -227,11 +227,12 @@ if (frame.type === "data-context-warning") {
     // but was generated against reduced context. Do NOT treat it as a
     // hard error.
   } else {
-    // Log on null so a future server wire-shape regression (e.g. an
-    // unknown `code`, missing `title`, or wrong `severity` literal) is
-    // observable in dev. The pre-2005 plan-warning channel went two
-    // releases undetected because nothing logged its typed mismatch —
-    // surface drops loudly so you don't repeat that mistake.
+    // Log on null so a future server-side wire-shape change (unknown
+    // code, missing title, wrong severity literal) is observable in dev
+    // rather than silently dropped. In production, gate this behind a
+    // one-shot ref so a runaway stream of malformed frames doesn't
+    // flood the console — see the in-tree `useContextWarnings` hook for
+    // an example dedup pattern.
     console.warn("[atlas-sdk] dropped malformed data-context-warning frame", frame.data);
   }
 }

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -226,6 +226,13 @@ if (frame.type === "data-context-warning") {
     // Surface a per-message warning banner — the answer is still usable
     // but was generated against reduced context. Do NOT treat it as a
     // hard error.
+  } else {
+    // Log on null so a future server wire-shape regression (e.g. an
+    // unknown `code`, missing `title`, or wrong `severity` literal) is
+    // observable in dev. The pre-2005 plan-warning channel went two
+    // releases undetected because nothing logged its typed mismatch —
+    // surface drops loudly so you don't repeat that mistake.
+    console.warn("[atlas-sdk] dropped malformed data-context-warning frame", frame.data);
   }
 }
 ```

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -203,6 +203,37 @@ try {
 | `parse-error` | `raw`, `error` | Client-side: an SSE frame contained invalid JSON. The raw data is preserved for debugging. |
 | `finish` | `reason` | Stream completed |
 
+### Context Warnings (Degraded Answer Signal)
+
+The chat route emits `data-context-warning` frames whenever the agent ran
+past a non-fatal degradation — the org semantic layer or learned-patterns
+lookup failed, or the workspace is approaching its plan budget — and the
+run was allowed to proceed against reduced context. These are not stream
+events from `streamQuery()`; they arrive on the AI-SDK UI Message Stream
+channel that `chat()` returns. If you are routing a raw `Response` from
+`atlas.chat()` through your own SSE consumer, parse each
+`data-context-warning` frame body with `parseContextWarning` from
+`@useatlas/types`:
+
+```typescript
+import { parseContextWarning, type ChatContextWarning } from "@useatlas/types";
+
+// Inside your SSE frame handler:
+if (frame.type === "data-context-warning") {
+  const warning: ChatContextWarning | null = parseContextWarning(frame.data);
+  if (warning) {
+    console.warn(`[${warning.code}]`, warning.title, warning.detail ?? "");
+    // Surface a per-message warning banner — the answer is still usable
+    // but was generated against reduced context. Do NOT treat it as a
+    // hard error.
+  }
+}
+```
+
+The frame's `severity: "warning"` discriminator separates these from
+`data-error` frames, so a single SSE consumer can route both without
+misclassifying a degraded answer as a failure.
+
 ## Error Handling
 
 All methods throw `AtlasError` on failure. See the full [Error Codes Reference](https://docs.useatlas.dev/reference/error-codes) for every error code, HTTP status, retry guidance, and a complete retry-with-backoff example.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -44,6 +44,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@useatlas/types": "^0.0.17"
+    "@useatlas/types": "^0.0.18"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/types",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {

--- a/packages/types/src/__tests__/errors.test.ts
+++ b/packages/types/src/__tests__/errors.test.ts
@@ -657,3 +657,106 @@ describe("parseChatError client-side errors", () => {
     expect(info.title).toBe("Something went wrong. Please try again.");
   });
 });
+
+// ---------------------------------------------------------------------------
+// parseContextWarning — wire-frame validator for #1988 B5 degraded-answer SSE
+// ---------------------------------------------------------------------------
+
+import { parseContextWarning, type ChatContextWarning } from "../errors";
+
+describe("parseContextWarning", () => {
+  test("returns null for non-object input", () => {
+    expect(parseContextWarning(null)).toBeNull();
+    expect(parseContextWarning(undefined)).toBeNull();
+    expect(parseContextWarning("string")).toBeNull();
+    expect(parseContextWarning(42)).toBeNull();
+    expect(parseContextWarning(true)).toBeNull();
+    expect(parseContextWarning([])).toBeNull();
+  });
+
+  test("returns null when severity is missing or wrong", () => {
+    expect(
+      parseContextWarning({
+        code: "semantic_layer_unavailable",
+        title: "x",
+      }),
+    ).toBeNull();
+    expect(
+      parseContextWarning({
+        severity: "error",
+        code: "semantic_layer_unavailable",
+        title: "x",
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null when code is unknown", () => {
+    expect(
+      parseContextWarning({
+        severity: "warning",
+        code: "made_up_code",
+        title: "x",
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null when title is missing or non-string", () => {
+    expect(
+      parseContextWarning({
+        severity: "warning",
+        code: "semantic_layer_unavailable",
+      }),
+    ).toBeNull();
+    expect(
+      parseContextWarning({
+        severity: "warning",
+        code: "semantic_layer_unavailable",
+        title: 123,
+      }),
+    ).toBeNull();
+  });
+
+  test("parses a minimal valid warning", () => {
+    const out = parseContextWarning({
+      severity: "warning",
+      code: "semantic_layer_unavailable",
+      title: "Semantic layer unavailable",
+    });
+    expect(out).not.toBeNull();
+    const valid = out as ChatContextWarning;
+    expect(valid.severity).toBe("warning");
+    expect(valid.code).toBe("semantic_layer_unavailable");
+    expect(valid.title).toBe("Semantic layer unavailable");
+    expect(valid.detail).toBeUndefined();
+    expect(valid.requestId).toBeUndefined();
+  });
+
+  test("parses a full warning with detail and requestId", () => {
+    const out = parseContextWarning({
+      severity: "warning",
+      code: "learned_patterns_unavailable",
+      title: "Learned patterns unavailable",
+      detail: "Question-similarity hints disabled.",
+      requestId: "req-xyz",
+    });
+    expect(out).not.toBeNull();
+    const valid = out as ChatContextWarning;
+    expect(valid.code).toBe("learned_patterns_unavailable");
+    expect(valid.detail).toBe("Question-similarity hints disabled.");
+    expect(valid.requestId).toBe("req-xyz");
+  });
+
+  test("drops non-string detail and requestId rather than rejecting", () => {
+    const out = parseContextWarning({
+      severity: "warning",
+      code: "semantic_layer_unavailable",
+      title: "x",
+      detail: 42,
+      requestId: { not: "a string" },
+    });
+    expect(out).not.toBeNull();
+    const valid = out as ChatContextWarning;
+    expect(valid.detail).toBeUndefined();
+    expect(valid.requestId).toBeUndefined();
+  });
+});

--- a/packages/types/src/errors.ts
+++ b/packages/types/src/errors.ts
@@ -162,23 +162,29 @@ export interface ChatErrorInfo {
 
 /**
  * Codes for non-fatal preflight degradations that the agent ran past so the
- * user could still get an answer, at the cost of dropped context. Each code
- * names the specific context that was lost — the title/detail copy is built
- * server-side so the client never has to translate codes to copy.
+ * user could still get an answer, at the cost of dropped context (or, in
+ * the case of `plan_limit_warning`, at the cost of headroom against the
+ * billing budget). Each code names the specific signal — the title/detail
+ * copy is built server-side so the client never has to translate codes to
+ * copy.
  *
  * - `semantic_layer_unavailable` — the org-scoped whitelist + semantic index
  *   could not be loaded (typically internal-DB pool exhaustion). The agent
  *   falls back to the file-based default semantic layer.
  * - `learned_patterns_unavailable` — the learned-patterns lookup failed.
  *   The agent runs without question-similarity hints.
+ *   - `plan_limit_warning` — the workspace is approaching, in grace against,
+ *     or unable to read its plan budget. The request was allowed; the
+ *     warning surfaces so the user can act before the next request hits
+ *     `plan_limit_exceeded` (which is a hard block, not a warning).
  *
- * When adding a new code: also add a server emit site (currently
- * `lib/agent.ts`'s preflight `Effect.catchAll` branches) AND a corresponding
+ * When adding a new code: also add a server emit site AND a corresponding
  * UI banner branch so the structured frame round-trips end-to-end.
  */
 export const CHAT_CONTEXT_WARNING_CODES = [
   "semantic_layer_unavailable",
   "learned_patterns_unavailable",
+  "plan_limit_warning",
 ] as const;
 
 export type ChatContextWarningCode = (typeof CHAT_CONTEXT_WARNING_CODES)[number];
@@ -210,6 +216,51 @@ export interface ChatContextWarning {
   readonly title: string;
   readonly detail?: string;
   readonly requestId?: string;
+}
+
+/**
+ * Validate a runtime value against the {@link ChatContextWarning} wire shape.
+ *
+ * Returns the typed warning when the value matches; returns `null` when any
+ * required field is missing or has the wrong type. Optional `detail` /
+ * `requestId` that are present but not strings are dropped rather than
+ * rejecting the whole frame — a degraded answer should still surface even
+ * if the server attached a malformed extra field.
+ *
+ * Use this on every `data-context-warning` SSE frame the AI-SDK transport
+ * delivers to `onData` — the AI-SDK callback types `data` as `unknown`, so
+ * a runtime guard is required before trusting the shape.
+ *
+ * @example
+ * ```ts
+ * onData((part) => {
+ *   if (part.type !== "data-context-warning") return;
+ *   const warning = parseContextWarning(part.data);
+ *   if (warning) appendWarning(warning);
+ * });
+ * ```
+ */
+export function parseContextWarning(value: unknown): ChatContextWarning | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const obj = value as Record<string, unknown>;
+  if (obj.severity !== "warning") return null;
+  if (typeof obj.code !== "string" || !isChatContextWarningCode(obj.code)) {
+    return null;
+  }
+  if (typeof obj.title !== "string") return null;
+
+  const detail = typeof obj.detail === "string" ? obj.detail : undefined;
+  const requestId = typeof obj.requestId === "string" ? obj.requestId : undefined;
+
+  return {
+    severity: "warning",
+    code: obj.code,
+    title: obj.title,
+    ...(detail !== undefined && { detail }),
+    ...(requestId !== undefined && { requestId }),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/types/src/errors.ts
+++ b/packages/types/src/errors.ts
@@ -161,25 +161,27 @@ export interface ChatErrorInfo {
 // ---------------------------------------------------------------------------
 
 /**
- * Codes for non-fatal preflight degradations that the agent ran past so the
- * user could still get an answer, at the cost of dropped context (or, in
- * the case of `plan_limit_warning`, at the cost of headroom against the
- * billing budget). Each code names the specific signal — the title/detail
- * copy is built server-side so the client never has to translate codes to
- * copy.
+ * Codes for non-fatal degradations surfaced via `data-context-warning` so
+ * the user knows the answer was produced under reduced context or against
+ * a constrained budget. Each code names the specific signal — server-built
+ * copy ships in `title` / `detail` so the client never has to translate
+ * codes to copy.
  *
  * - `semantic_layer_unavailable` — the org-scoped whitelist + semantic index
  *   could not be loaded (typically internal-DB pool exhaustion). The agent
  *   falls back to the file-based default semantic layer.
  * - `learned_patterns_unavailable` — the learned-patterns lookup failed.
  *   The agent runs without question-similarity hints.
- *   - `plan_limit_warning` — the workspace is approaching, in grace against,
- *     or unable to read its plan budget. The request was allowed; the
- *     warning surfaces so the user can act before the next request hits
- *     `plan_limit_exceeded` (which is a hard block, not a warning).
+ * - `plan_limit_warning` — the workspace is approaching, in grace against,
+ *   or unable to read its plan budget. The request was allowed; the
+ *   warning surfaces so the user can act before the next request hits
+ *   `plan_limit_exceeded` (which is a hard block, not a warning).
  *
- * When adding a new code: also add a server emit site AND a corresponding
- * UI banner branch so the structured frame round-trips end-to-end.
+ * When adding a new code: add the string here, add a server emit site
+ * (preflight loaders in `lib/agent.ts`'s `Effect.catchAll` arms for
+ * context loss; `api/routes/chat.ts` for the budget signal), and the
+ * runtime guard `parseContextWarning` will accept it automatically — the
+ * client banner is data-driven and renders any accepted code uniformly.
  */
 export const CHAT_CONTEXT_WARNING_CODES = [
   "semantic_layer_unavailable",

--- a/packages/web/src/components/ui/alert.tsx
+++ b/packages/web/src/components/ui/alert.tsx
@@ -1,0 +1,66 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 [&>svg]:text-current",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "col-start-2 grid justify-items-start gap-1 text-sm text-muted-foreground [&_p]:leading-relaxed",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Alert, AlertTitle, AlertDescription }

--- a/packages/web/src/ui/__tests__/context-warning-banner.test.tsx
+++ b/packages/web/src/ui/__tests__/context-warning-banner.test.tsx
@@ -96,8 +96,10 @@ describe("ContextWarningBanner", () => {
     // The error-banner is the destructive treatment; this banner must
     // declare itself as the warning variant so future restyles cannot
     // accidentally lift it to destructive (which would scare users away
-    // from a still-useful answer). data-variant is the stable behavioral
-    // marker — not the className, which is volatile.
+    // from a still-useful answer). data-variant is a hardcoded marker
+    // we pin so a future restyle that swaps to the destructive Alert
+    // CVA variant trips this test — the className is volatile, this is
+    // the stable behavioral pin.
     expect(alert?.getAttribute("data-variant")).toBe("warning");
     // SVG presence as a cheap pin against an icon swap.
     expect(container.querySelector("svg")).not.toBeNull();

--- a/packages/web/src/ui/__tests__/context-warning-banner.test.tsx
+++ b/packages/web/src/ui/__tests__/context-warning-banner.test.tsx
@@ -82,7 +82,7 @@ describe("ContextWarningBanner", () => {
     expect(codeEl?.textContent).toBe("semantic_layer_unavailable");
   });
 
-  test("does not use the destructive red color (degraded ≠ failure)", () => {
+  test("renders as the non-destructive 'warning' variant (degraded ≠ failure)", () => {
     const warnings: ChatContextWarning[] = [
       {
         severity: "warning",
@@ -93,9 +93,13 @@ describe("ContextWarningBanner", () => {
     const { container } = render(<ContextWarningBanner warnings={warnings} />);
     const alert = container.querySelector('[role="alert"]');
     expect(alert).not.toBeNull();
-    // The error-banner uses red-* classes; this banner must not — it
-    // signals "answer is degraded", not failure. We assert amber treatment.
-    expect(alert?.className ?? "").not.toContain("red-");
-    expect(alert?.className ?? "").toContain("amber");
+    // The error-banner is the destructive treatment; this banner must
+    // declare itself as the warning variant so future restyles cannot
+    // accidentally lift it to destructive (which would scare users away
+    // from a still-useful answer). data-variant is the stable behavioral
+    // marker — not the className, which is volatile.
+    expect(alert?.getAttribute("data-variant")).toBe("warning");
+    // SVG presence as a cheap pin against an icon swap.
+    expect(container.querySelector("svg")).not.toBeNull();
   });
 });

--- a/packages/web/src/ui/__tests__/context-warning-banner.test.tsx
+++ b/packages/web/src/ui/__tests__/context-warning-banner.test.tsx
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import { render } from "@testing-library/react";
+import { ContextWarningBanner } from "../components/chat/context-warning-banner";
+import type { ChatContextWarning } from "@useatlas/types";
+
+describe("ContextWarningBanner", () => {
+  test("renders nothing when warnings array is empty", () => {
+    const { container } = render(<ContextWarningBanner warnings={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders a single context warning with code, title, detail, requestId", () => {
+    const warnings: ChatContextWarning[] = [
+      {
+        severity: "warning",
+        code: "semantic_layer_unavailable",
+        title: "Semantic layer unavailable",
+        detail: "Falling back to defaults.",
+        requestId: "req-abc",
+      },
+    ];
+    const { container } = render(<ContextWarningBanner warnings={warnings} />);
+    expect(container.textContent).toContain("Semantic layer unavailable");
+    expect(container.textContent).toContain("Falling back to defaults.");
+    expect(container.textContent).toContain("semantic_layer_unavailable");
+    expect(container.textContent).toContain("req-abc");
+  });
+
+  test("renders all context warning codes (semantic / learned-patterns / plan-limit)", () => {
+    const warnings: ChatContextWarning[] = [
+      {
+        severity: "warning",
+        code: "plan_limit_warning",
+        title: "Approaching plan limit",
+        detail: "You are at 85% of your monthly token budget.",
+      },
+      {
+        severity: "warning",
+        code: "semantic_layer_unavailable",
+        title: "Semantic layer unavailable",
+      },
+      {
+        severity: "warning",
+        code: "learned_patterns_unavailable",
+        title: "Learned patterns unavailable",
+      },
+    ];
+    const { container } = render(<ContextWarningBanner warnings={warnings} />);
+    expect(container.textContent).toContain("Approaching plan limit");
+    expect(container.textContent).toContain("Semantic layer unavailable");
+    expect(container.textContent).toContain("Learned patterns unavailable");
+    expect(container.textContent).toContain("plan_limit_warning");
+    expect(container.textContent).toContain("semantic_layer_unavailable");
+    expect(container.textContent).toContain("learned_patterns_unavailable");
+  });
+
+  test("uses role=alert for accessibility", () => {
+    const warnings: ChatContextWarning[] = [
+      {
+        severity: "warning",
+        code: "semantic_layer_unavailable",
+        title: "x",
+      },
+    ];
+    const { container } = render(<ContextWarningBanner warnings={warnings} />);
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert).not.toBeNull();
+  });
+
+  test("renders code as monospace tag", () => {
+    const warnings: ChatContextWarning[] = [
+      {
+        severity: "warning",
+        code: "semantic_layer_unavailable",
+        title: "x",
+      },
+    ];
+    const { container } = render(<ContextWarningBanner warnings={warnings} />);
+    // code is rendered with a font-mono class so the catalog code reads as a tag
+    const codeEl = container.querySelector(".font-mono");
+    expect(codeEl).not.toBeNull();
+    expect(codeEl?.textContent).toBe("semantic_layer_unavailable");
+  });
+
+  test("does not use the destructive red color (degraded ≠ failure)", () => {
+    const warnings: ChatContextWarning[] = [
+      {
+        severity: "warning",
+        code: "semantic_layer_unavailable",
+        title: "x",
+      },
+    ];
+    const { container } = render(<ContextWarningBanner warnings={warnings} />);
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert).not.toBeNull();
+    // The error-banner uses red-* classes; this banner must not — it
+    // signals "answer is degraded", not failure. We assert amber treatment.
+    expect(alert?.className ?? "").not.toContain("red-");
+    expect(alert?.className ?? "").toContain("amber");
+  });
+});

--- a/packages/web/src/ui/__tests__/context-warning-banner.test.tsx
+++ b/packages/web/src/ui/__tests__/context-warning-banner.test.tsx
@@ -96,10 +96,11 @@ describe("ContextWarningBanner", () => {
     // The error-banner is the destructive treatment; this banner must
     // declare itself as the warning variant so future restyles cannot
     // accidentally lift it to destructive (which would scare users away
-    // from a still-useful answer). data-variant is a hardcoded marker
-    // we pin so a future restyle that swaps to the destructive Alert
-    // CVA variant trips this test — the className is volatile, this is
-    // the stable behavioral pin.
+    // from a still-useful answer). `data-variant` is a hardcoded marker
+    // the banner stamps regardless of the underlying Alert styling —
+    // future restyles must keep this attribute set to "warning". The
+    // className stack is volatile; this attribute is the stable
+    // behavioral pin.
     expect(alert?.getAttribute("data-variant")).toBe("warning");
     // SVG presence as a cheap pin against an icon swap.
     expect(container.querySelector("svg")).not.toBeNull();

--- a/packages/web/src/ui/__tests__/use-context-warnings.test.tsx
+++ b/packages/web/src/ui/__tests__/use-context-warnings.test.tsx
@@ -1,0 +1,260 @@
+import { describe, expect, test } from "bun:test";
+import { act, render } from "@testing-library/react";
+import { useEffect, useRef, useState } from "react";
+import {
+  useContextWarnings,
+  type WarningBucket,
+} from "../hooks/use-context-warnings";
+import { ContextWarningBanner } from "../components/chat/context-warning-banner";
+
+type Frame =
+  | { type: "data-context-warning"; data: unknown }
+  | { type: "user-message"; id: string }
+  | { type: "assistant-message"; id: string }
+  | { type: "send" }
+  | { type: "new-chat" };
+
+/**
+ * Test harness — replays a frame sequence the way `atlas-chat` would
+ * dispatch it, then renders the banner above the latest assistant turn so
+ * tests can assert end-to-end (wire frame in → DOM out).
+ *
+ * `step` advances on each `flush()` call from the test, not on render —
+ * that keeps `useEffect` deps stable and avoids the infinite re-render
+ * loop that follows from putting the hook handle in the deps array (the
+ * hook returns a new object every render).
+ */
+function buildHarness() {
+  const stepRef: { current: () => Promise<void> } = { current: async () => {} };
+
+  function Harness({ frames }: { frames: Frame[] }) {
+    const [messages, setMessages] = useState<Array<{ id: string; role: string }>>([]);
+    const indexRef = useRef(0);
+    const ctl = useContextWarnings(messages);
+    const ctlRef = useRef(ctl);
+    ctlRef.current = ctl;
+
+    // Expose an imperative step() so the test drives the timeline.
+    stepRef.current = async () => {
+      while (indexRef.current < frames.length) {
+        const f = frames[indexRef.current];
+        indexRef.current += 1;
+        await act(async () => {
+          switch (f.type) {
+            case "data-context-warning":
+              ctlRef.current.handleData(f);
+              break;
+            case "user-message":
+              setMessages((prev) => [...prev, { id: f.id, role: "user" }]);
+              break;
+            case "assistant-message":
+              setMessages((prev) => [...prev, { id: f.id, role: "assistant" }]);
+              break;
+            case "send":
+              ctlRef.current.resetPending();
+              break;
+            case "new-chat":
+              setMessages([]);
+              ctlRef.current.reset();
+              break;
+          }
+          await Promise.resolve();
+        });
+        // Let the buffer-drain useEffect inside the hook run.
+        await act(async () => {
+          await Promise.resolve();
+        });
+      }
+    };
+
+    return (
+      <div>
+        {messages.map((m) => {
+          const bucket = ctl.byMessage.get(m.id) as WarningBucket | undefined;
+          if (m.role !== "assistant" || !bucket) return null;
+          return (
+            <div key={m.id} data-testid={`turn-${m.id}`}>
+              <ContextWarningBanner warnings={bucket.warnings} />
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  return {
+    Harness,
+    flush: () => stepRef.current(),
+  };
+}
+
+describe("useContextWarnings (integration)", () => {
+  test("banner appears above the assistant turn after a context-warning frame", async () => {
+    const frames: Frame[] = [
+      { type: "user-message", id: "u1" },
+      {
+        type: "data-context-warning",
+        data: {
+          severity: "warning",
+          code: "semantic_layer_unavailable",
+          title: "Semantic layer unavailable",
+          detail: "Falling back to defaults.",
+          requestId: "req-1",
+        },
+      },
+      { type: "assistant-message", id: "a1" },
+    ];
+    const { Harness, flush } = buildHarness();
+    const { container } = render(<Harness frames={frames} />);
+    await flush();
+
+    const turn = container.querySelector('[data-testid="turn-a1"]');
+    expect(turn).not.toBeNull();
+    expect(turn?.textContent).toContain("Semantic layer unavailable");
+    expect(turn?.textContent).toContain("semantic_layer_unavailable");
+    expect(turn?.textContent).toContain("req-1");
+  });
+
+  test("banner renders plan_limit_warning code (unified channel for plan + preflight signals)", async () => {
+    const frames: Frame[] = [
+      { type: "user-message", id: "u1" },
+      {
+        type: "data-context-warning",
+        data: {
+          severity: "warning",
+          code: "plan_limit_warning",
+          title: "Approaching plan limit",
+          detail: "85% of monthly budget used.",
+        },
+      },
+      { type: "assistant-message", id: "a1" },
+    ];
+    const { Harness, flush } = buildHarness();
+    const { container } = render(<Harness frames={frames} />);
+    await flush();
+
+    const turn = container.querySelector('[data-testid="turn-a1"]');
+    expect(turn).not.toBeNull();
+    expect(turn?.textContent).toContain("Approaching plan limit");
+    expect(turn?.textContent).toContain("plan_limit_warning");
+    expect(turn?.textContent).toContain("85% of monthly budget used.");
+  });
+
+  test("warnings are scoped per-message, not session-wide", async () => {
+    const frames: Frame[] = [
+      // First turn: degraded
+      { type: "user-message", id: "u1" },
+      {
+        type: "data-context-warning",
+        data: { severity: "warning", code: "semantic_layer_unavailable", title: "Degraded" },
+      },
+      { type: "assistant-message", id: "a1" },
+      // Second turn: clean — must NOT inherit the prior warning
+      { type: "send" },
+      { type: "user-message", id: "u2" },
+      { type: "assistant-message", id: "a2" },
+    ];
+    const { Harness, flush } = buildHarness();
+    const { container } = render(<Harness frames={frames} />);
+    await flush();
+
+    expect(container.querySelector('[data-testid="turn-a1"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="turn-a2"]')).toBeNull();
+  });
+
+  test("invalid data-context-warning frames are silently dropped", async () => {
+    const frames: Frame[] = [
+      { type: "user-message", id: "u1" },
+      // Missing required `severity: "warning"` discriminator
+      {
+        type: "data-context-warning",
+        data: { code: "semantic_layer_unavailable", title: "x" },
+      },
+      // Unknown code
+      {
+        type: "data-context-warning",
+        data: { severity: "warning", code: "made_up", title: "x" },
+      },
+      { type: "assistant-message", id: "a1" },
+    ];
+    const { Harness, flush } = buildHarness();
+    const { container } = render(<Harness frames={frames} />);
+    await flush();
+
+    expect(container.querySelector('[data-testid="turn-a1"]')).toBeNull();
+  });
+
+  test("multiple warnings on the same turn render together", async () => {
+    const frames: Frame[] = [
+      { type: "user-message", id: "u1" },
+      {
+        type: "data-context-warning",
+        data: { severity: "warning", code: "plan_limit_warning", title: "Plan clipped" },
+      },
+      {
+        type: "data-context-warning",
+        data: { severity: "warning", code: "semantic_layer_unavailable", title: "Sem missing" },
+      },
+      {
+        type: "data-context-warning",
+        data: { severity: "warning", code: "learned_patterns_unavailable", title: "LP missing" },
+      },
+      { type: "assistant-message", id: "a1" },
+    ];
+    const { Harness, flush } = buildHarness();
+    const { container } = render(<Harness frames={frames} />);
+    await flush();
+
+    const turn = container.querySelector('[data-testid="turn-a1"]');
+    expect(turn?.textContent).toContain("Sem missing");
+    expect(turn?.textContent).toContain("LP missing");
+    expect(turn?.textContent).toContain("Plan clipped");
+  });
+
+  test("reset() clears warnings and pending bucket on new chat", async () => {
+    const frames: Frame[] = [
+      { type: "user-message", id: "u1" },
+      {
+        type: "data-context-warning",
+        data: { severity: "warning", code: "semantic_layer_unavailable", title: "Degraded" },
+      },
+      { type: "assistant-message", id: "a1" },
+      { type: "new-chat" },
+    ];
+    const { Harness, flush } = buildHarness();
+    const { container } = render(<Harness frames={frames} />);
+    await flush();
+
+    // After new-chat, the bucket is cleared; nothing renders.
+    expect(container.querySelector('[data-testid="turn-a1"]')).toBeNull();
+  });
+
+  test("handleData returns true for warning frames, false for unrelated", async () => {
+    let returnedForWarning: boolean | null = null;
+    let returnedForOther: boolean | null = null;
+
+    function Probe() {
+      const ctl = useContextWarnings([]);
+      const fired = useRef(false);
+      useEffect(() => {
+        if (fired.current) return;
+        fired.current = true;
+        returnedForWarning = ctl.handleData({
+          type: "data-context-warning",
+          data: { severity: "warning", code: "semantic_layer_unavailable", title: "x" },
+        });
+        returnedForOther = ctl.handleData({
+          type: "data-python-progress",
+          data: { type: "stdout", text: "hi" },
+        });
+      });
+      return null;
+    }
+
+    render(<Probe />);
+    await act(async () => { await Promise.resolve(); });
+
+    expect(returnedForWarning).toBe(true);
+    expect(returnedForOther).toBe(false);
+  });
+});

--- a/packages/web/src/ui/__tests__/use-context-warnings.test.tsx
+++ b/packages/web/src/ui/__tests__/use-context-warnings.test.tsx
@@ -40,7 +40,7 @@ function buildHarness() {
     const ctlRef = useRef(ctl);
     ctlRef.current = ctl;
 
-    // Expose an imperative step() so the test drives the timeline.
+    // Expose an imperative flush() so the test drives the timeline.
     stepRef.current = async () => {
       while (indexRef.current < frames.length) {
         const f = frames[indexRef.current];
@@ -382,12 +382,22 @@ describe("useContextWarnings (integration)", () => {
       console.warn = originalWarn;
     });
 
-    test("malformed data-context-warning frame logs (so wire regressions are observable)", async () => {
+    test("malformed data-context-warning frame logs once per session (deduped to avoid spam)", async () => {
       const frames: Frame[] = [
         { type: "user-message", id: "u1" },
+        // Three malformed frames — only the first should log so a
+        // runaway stream of bad frames doesn't drown out the warning.
         {
           type: "data-context-warning",
-          data: { severity: "warning", code: "made_up", title: "x" },
+          data: { severity: "warning", code: "made_up", title: "first bad" },
+        },
+        {
+          type: "data-context-warning",
+          data: { severity: "warning", code: "also_made_up", title: "second bad" },
+        },
+        {
+          type: "data-context-warning",
+          data: { severity: "warning", code: "still_bad", title: "third bad" },
         },
         { type: "assistant-message", id: "a1" },
       ];
@@ -395,13 +405,16 @@ describe("useContextWarnings (integration)", () => {
       render(<Harness frames={frames} />);
       await flush();
 
-      // Console.warn fires once for the dropped malformed frame.
-      // The pre-#2005 `data-plan-warning` channel went undetected for
-      // two releases because nothing logged the typed mismatch — this
-      // pin keeps that mistake from recurring quietly.
-      expect(warnSpy).toHaveBeenCalled();
+      // Exactly one log fires for the dropped malformed frames. The
+      // pre-#2005 `data-plan-warning` channel went undetected for two
+      // releases because nothing logged the typed mismatch — pin the
+      // first-frame log so that mistake can't quietly recur. The
+      // dedup keeps a runaway stream's worth of drops from drowning
+      // out the signal.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
       const args = warnSpy.mock.calls[0];
       expect(args[0]).toContain("dropped malformed");
+      expect(args[0]).toContain("further drops suppressed");
     });
   });
 

--- a/packages/web/src/ui/__tests__/use-context-warnings.test.tsx
+++ b/packages/web/src/ui/__tests__/use-context-warnings.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
 import { act, render } from "@testing-library/react";
 import { useEffect, useRef, useState } from "react";
 import {
@@ -11,18 +11,24 @@ type Frame =
   | { type: "data-context-warning"; data: unknown }
   | { type: "user-message"; id: string }
   | { type: "assistant-message"; id: string }
+  | { type: "replace-messages"; messages: Array<{ id: string; role: string }> }
   | { type: "send" }
-  | { type: "new-chat" };
+  | { type: "new-chat" }
+  // Emit several data-context-warning frames in the same React batch
+  // BEFORE any subsequent message append, exercising the buffer path
+  // that production hits when `chat.ts` writes warnings ahead of the
+  // assistant text-delta merge.
+  | { type: "batch"; frames: Array<{ type: "data-context-warning"; data: unknown }> };
 
 /**
  * Test harness — replays a frame sequence the way `atlas-chat` would
  * dispatch it, then renders the banner above the latest assistant turn so
  * tests can assert end-to-end (wire frame in → DOM out).
  *
- * `step` advances on each `flush()` call from the test, not on render —
- * that keeps `useEffect` deps stable and avoids the infinite re-render
- * loop that follows from putting the hook handle in the deps array (the
- * hook returns a new object every render).
+ * `flush()` advances through the queued frames in order. We drive the
+ * timeline imperatively (not from inside a useEffect) so the harness's
+ * deps stay stable and we never recurse on the hook's returned object,
+ * which is a fresh reference per render.
  */
 function buildHarness() {
   const stepRef: { current: () => Promise<void> } = { current: async () => {} };
@@ -50,12 +56,18 @@ function buildHarness() {
             case "assistant-message":
               setMessages((prev) => [...prev, { id: f.id, role: "assistant" }]);
               break;
+            case "replace-messages":
+              setMessages(f.messages);
+              break;
             case "send":
               ctlRef.current.resetPending();
               break;
             case "new-chat":
               setMessages([]);
               ctlRef.current.reset();
+              break;
+            case "batch":
+              for (const inner of f.frames) ctlRef.current.handleData(inner);
               break;
           }
           await Promise.resolve();
@@ -256,5 +268,215 @@ describe("useContextWarnings (integration)", () => {
 
     expect(returnedForWarning).toBe(true);
     expect(returnedForOther).toBe(false);
+  });
+
+  test("turn-N warnings attach to turn N's assistant, NOT turn N-1's", async () => {
+    // Regression: pre-fix the drain effect found the most-recent
+    // assistant id at the time the frame arrived, which on turn 2 was
+    // still a1 (because the chat route writes warnings before merging
+    // the agent stream — a2 doesn't exist yet). The anchorMessageCount
+    // snapshot bounds the drain so it waits for an assistant at index
+    // >= the count when the batch was first buffered.
+    const frames: Frame[] = [
+      // Turn 1: degraded
+      { type: "user-message", id: "u1" },
+      {
+        type: "data-context-warning",
+        data: { severity: "warning", code: "semantic_layer_unavailable", title: "Turn 1 warning" },
+      },
+      { type: "assistant-message", id: "a1" },
+      // Turn 2: ALSO degraded — must attach to a2, not a1
+      { type: "send" },
+      { type: "user-message", id: "u2" },
+      {
+        type: "data-context-warning",
+        data: { severity: "warning", code: "learned_patterns_unavailable", title: "Turn 2 warning" },
+      },
+      { type: "assistant-message", id: "a2" },
+    ];
+    const { Harness, flush } = buildHarness();
+    const { container } = render(<Harness frames={frames} />);
+    await flush();
+
+    const turn1 = container.querySelector('[data-testid="turn-a1"]');
+    const turn2 = container.querySelector('[data-testid="turn-a2"]');
+    expect(turn1?.textContent).toContain("Turn 1 warning");
+    expect(turn1?.textContent).not.toContain("Turn 2 warning");
+    expect(turn2?.textContent).toContain("Turn 2 warning");
+    expect(turn2?.textContent).not.toContain("Turn 1 warning");
+  });
+
+  test("multiple warnings for one turn delivered in a single batch all attach", async () => {
+    // Production order: chat.ts writes ALL warning frames in a tight
+    // loop, then merges the agent stream. The batch arrives before any
+    // assistant message id, so the buffer must hold every frame until
+    // drain — not race-drop later ones to the empty bucket reset.
+    const frames: Frame[] = [
+      { type: "user-message", id: "u1" },
+      {
+        type: "batch",
+        frames: [
+          {
+            type: "data-context-warning",
+            data: { severity: "warning", code: "plan_limit_warning", title: "Plan" },
+          },
+          {
+            type: "data-context-warning",
+            data: { severity: "warning", code: "semantic_layer_unavailable", title: "Sem" },
+          },
+          {
+            type: "data-context-warning",
+            data: { severity: "warning", code: "learned_patterns_unavailable", title: "LP" },
+          },
+        ],
+      },
+      { type: "assistant-message", id: "a1" },
+    ];
+    const { Harness, flush } = buildHarness();
+    const { container } = render(<Harness frames={frames} />);
+    await flush();
+
+    const turn = container.querySelector('[data-testid="turn-a1"]');
+    expect(turn?.textContent).toContain("Plan");
+    expect(turn?.textContent).toContain("Sem");
+    expect(turn?.textContent).toContain("LP");
+  });
+
+  test("orphaned bucket is dropped when its message id leaves messages", async () => {
+    // setMessages can replace a message on regenerate / edit. The hook
+    // must drop the orphaned bucket so the map doesn't leak forever
+    // and so the old warning can never re-appear if a new id collides.
+    const frames: Frame[] = [
+      { type: "user-message", id: "u1" },
+      {
+        type: "data-context-warning",
+        data: { severity: "warning", code: "semantic_layer_unavailable", title: "Was here" },
+      },
+      { type: "assistant-message", id: "a1" },
+      // Fully replace the messages list — a1 is gone, a2 takes its slot.
+      {
+        type: "replace-messages",
+        messages: [
+          { id: "u1", role: "user" },
+          { id: "a2", role: "assistant" },
+        ],
+      },
+    ];
+    const { Harness, flush } = buildHarness();
+    const { container } = render(<Harness frames={frames} />);
+    await flush();
+
+    expect(container.querySelector('[data-testid="turn-a1"]')).toBeNull();
+    expect(container.querySelector('[data-testid="turn-a2"]')).toBeNull();
+  });
+
+  describe("malformed frame logging", () => {
+    let warnSpy: ReturnType<typeof mock>;
+    let originalWarn: typeof console.warn;
+    beforeEach(() => {
+      originalWarn = console.warn;
+      warnSpy = mock(() => {});
+      console.warn = warnSpy;
+    });
+    afterEach(() => {
+      console.warn = originalWarn;
+    });
+
+    test("malformed data-context-warning frame logs (so wire regressions are observable)", async () => {
+      const frames: Frame[] = [
+        { type: "user-message", id: "u1" },
+        {
+          type: "data-context-warning",
+          data: { severity: "warning", code: "made_up", title: "x" },
+        },
+        { type: "assistant-message", id: "a1" },
+      ];
+      const { Harness, flush } = buildHarness();
+      render(<Harness frames={frames} />);
+      await flush();
+
+      // Console.warn fires once for the dropped malformed frame.
+      // The pre-#2005 `data-plan-warning` channel went undetected for
+      // two releases because nothing logged the typed mismatch — this
+      // pin keeps that mistake from recurring quietly.
+      expect(warnSpy).toHaveBeenCalled();
+      const args = warnSpy.mock.calls[0];
+      expect(args[0]).toContain("dropped malformed");
+    });
+  });
+
+  describe("parser edge cases (sharper severity / extra fields)", () => {
+    test("severity casing is strict: 'Warning' (capital) is rejected", async () => {
+      const frames: Frame[] = [
+        { type: "user-message", id: "u1" },
+        {
+          type: "data-context-warning",
+          data: { severity: "Warning", code: "semantic_layer_unavailable", title: "x" },
+        },
+        { type: "assistant-message", id: "a1" },
+      ];
+      const { Harness, flush } = buildHarness();
+      const { container } = render(<Harness frames={frames} />);
+      await flush();
+      // No banner — parser rejected on case-sensitive discriminator.
+      expect(container.querySelector('[data-testid="turn-a1"]')).toBeNull();
+    });
+
+    test("warning-only assistant turn (no text, no tools) still renders the banner", async () => {
+      // Atlas-chat's skip-render predicate carves out warning-only
+      // turns: an assistant message with no visible parts but with
+      // attached warnings is still rendered so the user sees the
+      // banner. This test exercises that exact gating using the same
+      // bucket the production component reads from — pinning the
+      // contract end-to-end without mounting the full chat UI.
+      const frames: Frame[] = [
+        { type: "user-message", id: "u1" },
+        {
+          type: "data-context-warning",
+          data: {
+            severity: "warning",
+            code: "semantic_layer_unavailable",
+            title: "Degraded with no content",
+          },
+        },
+        // assistant message with NO parts (modelled as just the role+id)
+        { type: "assistant-message", id: "a1" },
+      ];
+      const { Harness, flush } = buildHarness();
+      const { container } = render(<Harness frames={frames} />);
+      await flush();
+
+      // Banner is the only content for this turn; assert it rendered.
+      // The harness skips messages without buckets, so a regression
+      // that drops the bucket would surface as a missing turn.
+      const turn = container.querySelector('[data-testid="turn-a1"]');
+      expect(turn).not.toBeNull();
+      expect(turn?.textContent).toContain("Degraded with no content");
+    });
+
+    test("extra unknown fields on the wire are dropped (no banner contamination)", async () => {
+      const frames: Frame[] = [
+        { type: "user-message", id: "u1" },
+        {
+          type: "data-context-warning",
+          data: {
+            severity: "warning",
+            code: "semantic_layer_unavailable",
+            title: "Has extras",
+            unknownField: "should not appear in DOM",
+            requestId: "req-keep",
+          },
+        },
+        { type: "assistant-message", id: "a1" },
+      ];
+      const { Harness, flush } = buildHarness();
+      const { container } = render(<Harness frames={frames} />);
+      await flush();
+
+      const turn = container.querySelector('[data-testid="turn-a1"]');
+      expect(turn?.textContent).toContain("Has extras");
+      expect(turn?.textContent).toContain("req-keep");
+      expect(turn?.textContent).not.toContain("should not appear in DOM");
+    });
   });
 });

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -207,20 +207,29 @@ export function AtlasChat() {
   // Python streaming progress — keyed by tool invocation ID
   const [pythonProgress, setPythonProgress] = useState<Map<string, PythonProgressData[]>>(new Map());
 
-  // #1988 B5 / #2005 — context-warning + plan-warning frames are buffered
-  // by the warnings hook until the AI SDK appends the assistant message id
-  // they belong to. The handler is reached via a ref because `useChat`
-  // captures `onData` once and the warnings hook is called AFTER `useChat`
-  // (it needs `messages` to know which id to attach to). The ref pattern
-  // keeps `onData` stable while still routing each frame to the latest
-  // hook closure.
+  // The warnings hook must be called after `useChat` so it can observe
+  // `messages` and drain pending frames onto the latest assistant id.
+  // We route `onData` (captured stably by `useChat`) through a ref so
+  // the hook's `handleData` reference can change between renders without
+  // forcing `useChat` to rebuild its transport. The first frame an SDK
+  // delivers should never arrive before commit (frames are emitted on a
+  // microtask after `sendMessage`), but we log if it does so the
+  // theoretical race becomes audible instead of silently dropping.
   const warningHandlerRef = useRef<((part: { type: string; data: unknown }) => boolean) | null>(
     null,
   );
 
   const onData = useCallback(
     (dataPart: { type: string; id?: string; data: unknown }) => {
-      if (warningHandlerRef.current?.(dataPart)) return;
+      if (warningHandlerRef.current) {
+        if (warningHandlerRef.current(dataPart)) return;
+      } else if (dataPart.type === "data-context-warning") {
+        console.warn(
+          "[atlas-chat] data-context-warning arrived before warnings hook initialized; dropping",
+          dataPart,
+        );
+        return;
+      }
       if (dataPart.type === "data-python-progress" && dataPart.id && dataPart.data) {
         const d = dataPart.data as Record<string, unknown>;
         // Minimal runtime validation — ensure the event has a known type
@@ -248,7 +257,12 @@ export function AtlasChat() {
 
   const warningCtl = useContextWarnings(messages);
   const contextWarningsByMessage = warningCtl.byMessage;
-  warningHandlerRef.current = warningCtl.handleData;
+  // Wire the hook's stable handler into the onData ref AFTER commit.
+  // Mutating a ref during render is a React anti-pattern (the render
+  // can be discarded under concurrent rendering, leaving the ref stale).
+  useEffect(() => {
+    warningHandlerRef.current = warningCtl.handleData;
+  }, [warningCtl.handleData]);
 
   const isLoading = status === "streaming" || status === "submitted";
 

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -11,6 +11,7 @@ import { useAtlasTransport } from "../hooks/use-atlas-transport";
 import { useConversations } from "../hooks/use-conversations";
 import { useStarterPromptsQuery } from "../hooks/use-starter-prompts-query";
 import { ErrorBanner } from "./chat/error-banner";
+import { ContextWarningBanner } from "./chat/context-warning-banner";
 import { ApiKeyBar } from "./chat/api-key-bar";
 import { TypingIndicator } from "./chat/typing-indicator";
 import { ToolPart } from "./chat/tool-part";
@@ -29,6 +30,7 @@ import { SchemaExplorer } from "./schema-explorer/schema-explorer";
 import { PromptLibrary } from "./chat/prompt-library";
 import { StarterPromptList } from "./chat/starter-prompt-list";
 import type { StarterPrompt } from "@useatlas/types/starter-prompt";
+import { useContextWarnings } from "../hooks/use-context-warnings";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -205,20 +207,35 @@ export function AtlasChat() {
   // Python streaming progress — keyed by tool invocation ID
   const [pythonProgress, setPythonProgress] = useState<Map<string, PythonProgressData[]>>(new Map());
 
-  const onData = useCallback((dataPart: { type: string; id?: string; data: unknown }) => {
-    if (dataPart.type === "data-python-progress" && dataPart.id && dataPart.data) {
-      const d = dataPart.data as Record<string, unknown>;
-      // Minimal runtime validation — ensure the event has a known type
-      if (typeof d.type !== "string" || !["stdout", "chart", "recharts"].includes(d.type)) return;
-      const event = d as unknown as PythonProgressData;
-      setPythonProgress((prev) => {
-        const next = new Map(prev);
-        const events = next.get(dataPart.id!) ?? [];
-        next.set(dataPart.id!, [...events, event]);
-        return next;
-      });
-    }
-  }, []);
+  // #1988 B5 / #2005 — context-warning + plan-warning frames are buffered
+  // by the warnings hook until the AI SDK appends the assistant message id
+  // they belong to. The handler is reached via a ref because `useChat`
+  // captures `onData` once and the warnings hook is called AFTER `useChat`
+  // (it needs `messages` to know which id to attach to). The ref pattern
+  // keeps `onData` stable while still routing each frame to the latest
+  // hook closure.
+  const warningHandlerRef = useRef<((part: { type: string; data: unknown }) => boolean) | null>(
+    null,
+  );
+
+  const onData = useCallback(
+    (dataPart: { type: string; id?: string; data: unknown }) => {
+      if (warningHandlerRef.current?.(dataPart)) return;
+      if (dataPart.type === "data-python-progress" && dataPart.id && dataPart.data) {
+        const d = dataPart.data as Record<string, unknown>;
+        // Minimal runtime validation — ensure the event has a known type
+        if (typeof d.type !== "string" || !["stdout", "chart", "recharts"].includes(d.type)) return;
+        const event = d as unknown as PythonProgressData;
+        setPythonProgress((prev) => {
+          const next = new Map(prev);
+          const events = next.get(dataPart.id!) ?? [];
+          next.set(dataPart.id!, [...events, event]);
+          return next;
+        });
+      }
+    },
+    [],
+  );
 
   // The AI SDK's onData expects DataUIPart<UIDataTypes> which structurally accepts
   // { type: `data-${string}`; id?: string; data: unknown } — our callback matches.
@@ -228,6 +245,10 @@ export function AtlasChat() {
     transport,
     onData: onData as never,
   });
+
+  const warningCtl = useContextWarnings(messages);
+  const contextWarningsByMessage = warningCtl.byMessage;
+  warningHandlerRef.current = warningCtl.handleData;
 
   const isLoading = status === "streaming" || status === "submitted";
 
@@ -409,6 +430,9 @@ export function AtlasChat() {
     if (!text.trim()) return;
     const saved = text;
     setInput("");
+    // Drop any unattached warnings from a stalled earlier turn so they
+    // cannot end up keyed onto the upcoming assistant message.
+    warningCtl.resetPending();
     sendMessage({ text: saved }).catch((err: unknown) => {
       console.error("Failed to send message:", err instanceof Error ? err.message : String(err));
       setInput(saved);
@@ -437,6 +461,10 @@ export function AtlasChat() {
       setConversationId(id);
       convos.setSelectedId(id);
       setMobileMenuOpen(false);
+      // Loaded turns predate this session — no warning frames replay over
+      // the wire, so any prior in-memory bucket is stale relative to the
+      // freshly loaded message ids.
+      warningCtl.reset();
     } catch (err: unknown) {
       console.warn("Failed to load conversation:", err instanceof Error ? err.message : String(err));
       setTransientWarning("Failed to load conversation. Please try again.");
@@ -453,6 +481,7 @@ export function AtlasChat() {
     setInput("");
     setMobileMenuOpen(false);
     setPythonProgress(new Map());
+    warningCtl.reset();
   }
 
   // Wait for auth mode detection before rendering — prevents flash of chat UI
@@ -648,11 +677,16 @@ export function AtlasChat() {
                       msgIndex === messages.length - 1;
 
                     // Skip rendering assistant messages with no visible content
-                    // (happens when stream errors before producing any text)
+                    // (happens when stream errors before producing any text).
+                    // A message with attached context warnings is still
+                    // worth rendering — the banner is the only signal the
+                    // user gets when a degraded stream produced nothing.
                     const hasVisibleParts = m.parts?.some(
                       (p) => (p.type === "text" && p.text.trim()) || isToolUIPart(p),
                     );
-                    if (!hasVisibleParts && !isLastAssistant) return null;
+                    const warningBucket = contextWarningsByMessage.get(m.id);
+                    const hasWarnings = !!warningBucket && warningBucket.warnings.length > 0;
+                    if (!hasVisibleParts && !isLastAssistant && !hasWarnings) return null;
 
                     // Extract suggestions from the last text part that contains them
                     const lastTextWithSuggestions = m.parts
@@ -664,6 +698,9 @@ export function AtlasChat() {
 
                     return (
                       <div key={m.id} className="space-y-2" role="article" aria-label="Message from Atlas">
+                        {hasWarnings && warningBucket && (
+                          <ContextWarningBanner warnings={warningBucket.warnings} />
+                        )}
                         {m.parts?.map((part, i) => {
                           if (part.type === "text" && part.text.trim()) {
                             const displayText = parseSuggestions(part.text).text;

--- a/packages/web/src/ui/components/chat/context-warning-banner.tsx
+++ b/packages/web/src/ui/components/chat/context-warning-banner.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import type { ChatContextWarning } from "@useatlas/types";
+import { AlertTriangle } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+
+/**
+ * Per-message banner for "answer is degraded" signals — one wire shape
+ * (`data-context-warning`) covers preflight degradations (#1988 B5) and
+ * plan-budget warnings (#2005). Distinct from the destructive
+ * ErrorBanner: these are non-fatal signals that the model ran with
+ * reduced context (or the workspace is approaching a billing limit), so
+ * the treatment is amber/warning, not red/error.
+ *
+ * Rendered above the assistant turn it belongs to (per-message, not
+ * session-wide) so the user can correlate "this answer was degraded"
+ * with the specific response.
+ */
+export function ContextWarningBanner({
+  warnings,
+}: {
+  warnings: ChatContextWarning[];
+}) {
+  if (warnings.length === 0) return null;
+
+  return (
+    <Alert
+      data-testid="context-warning-banner"
+      className="mb-2 border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/20 dark:text-amber-200"
+    >
+      <AlertTriangle className="text-amber-600 dark:text-amber-400" />
+      <AlertTitle>Answer generated with reduced context</AlertTitle>
+      <AlertDescription className="text-amber-800/90 dark:text-amber-200/80">
+        {warnings.map((w, i) => (
+          <div key={`${w.code}-${i}`} className="flex flex-col gap-0.5">
+            <div className="flex flex-wrap items-baseline gap-2">
+              <span className="rounded bg-amber-200/60 px-1.5 py-0.5 font-mono text-[10px] text-amber-900 dark:bg-amber-900/40 dark:text-amber-200">
+                {w.code}
+              </span>
+              <span className="text-xs font-medium">{w.title}</span>
+            </div>
+            {w.detail && <p className="text-xs opacity-90">{w.detail}</p>}
+            {w.requestId && (
+              <p className="text-[10px] opacity-60">Request ID: {w.requestId}</p>
+            )}
+          </div>
+        ))}
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/packages/web/src/ui/components/chat/context-warning-banner.tsx
+++ b/packages/web/src/ui/components/chat/context-warning-banner.tsx
@@ -6,11 +6,11 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 
 /**
  * Per-message banner for "answer is degraded" signals — one wire shape
- * (`data-context-warning`) covers preflight degradations (#1988 B5) and
- * plan-budget warnings (#2005). Distinct from the destructive
- * ErrorBanner: these are non-fatal signals that the model ran with
- * reduced context (or the workspace is approaching a billing limit), so
- * the treatment is amber/warning, not red/error.
+ * (`data-context-warning`) covers preflight degradations and plan-budget
+ * warnings. Distinct from the destructive ErrorBanner: these are
+ * non-fatal signals that the model ran with reduced context (or the
+ * workspace is approaching a billing limit), so the treatment is
+ * amber/warning, not red/error.
  *
  * Rendered above the assistant turn it belongs to (per-message, not
  * session-wide) so the user can correlate "this answer was degraded"
@@ -26,6 +26,7 @@ export function ContextWarningBanner({
   return (
     <Alert
       data-testid="context-warning-banner"
+      data-variant="warning"
       className="mb-2 border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/20 dark:text-amber-200"
     >
       <AlertTriangle className="text-amber-600 dark:text-amber-400" />

--- a/packages/web/src/ui/hooks/use-context-warnings.ts
+++ b/packages/web/src/ui/hooks/use-context-warnings.ts
@@ -1,67 +1,135 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { parseContextWarning, type ChatContextWarning } from "@useatlas/types";
 
 export type WarningBucket = {
   warnings: ChatContextWarning[];
 };
 
+type Pending = {
+  warnings: ChatContextWarning[];
+  /**
+   * `messages.length` at the moment the first warning of this batch was
+   * buffered. The drain effect must wait for an assistant message at an
+   * index >= this value — otherwise a warning on turn N would be attached
+   * to turn N-1's assistant (which is still the latest assistant id when
+   * the frame arrives, because the chat route writes warnings before
+   * merging the agent stream).
+   */
+  anchorMessageCount: number;
+};
+
+const EMPTY: Pending = { warnings: [], anchorMessageCount: 0 };
+
 /**
- * Buffer + per-message attachment of `data-context-warning` SSE frames
- * (#1988 B5 + #2005). The chat route writes warning frames AHEAD of the
- * agent's text-delta merge (chat.ts:864 — load-bearing ordering comment).
+ * Buffer + per-message attachment of `data-context-warning` SSE frames.
+ *
+ * The chat route writes warning frames AHEAD of merging the agent's
+ * text-delta stream (see the "Ordering is load-bearing" block in
+ * `chat.ts` immediately before `writer.merge(agentResult.toUIMessageStream(...))`).
  * At the moment a frame fires through `onData`, the AI SDK has not yet
- * appended an assistant message to `messages`, so we cannot key the
- * bucket by id on arrival. The hook splits the work:
+ * appended the new assistant message id to `messages`, so we cannot key
+ * the bucket by id on arrival. The hook splits the work:
  *
  * 1. `handleData(part)` — onData entry point. Returns `true` if the part
  *    was a warning frame (so the caller can stop dispatching it). Parses
- *    via the canonical `parseContextWarning` guard; invalid frames are
- *    silently dropped because a degraded answer is not worth surfacing
- *    if the wire shape is broken.
- * 2. Internal `useEffect` — when `messages` next updates, drain the
- *    `pending` bucket onto the most recent assistant message id.
- *    Subsequent warnings for the same id append to the existing bucket.
- * 3. `resetPending()` — call before sending the next user message so a
+ *    via the canonical `parseContextWarning` guard. Invalid frames are
+ *    dropped to avoid spamming users with a banner over a wire bug, but
+ *    a `console.warn` fires so the regression is observable in dev.
+ *    The first warning of a batch snapshots the current message count
+ *    so the drain step can tell turn N's warnings from turn N-1's.
+ * 2. Internal drain `useEffect` — when `messages` next updates, look for
+ *    an assistant message at an index >= the snapshotted count and
+ *    transfer the buffer onto its id. Subsequent warnings for the same
+ *    turn append to the existing bucket.
+ * 3. Internal cleanup `useEffect` — drops bucket entries whose message
+ *    id is no longer in `messages` (e.g. after `setMessages` replaces a
+ *    message on regenerate / edit). Without this the map would leak.
+ * 4. `resetPending()` — call before sending the next user message so a
  *    stalled previous turn cannot leak warnings into the new answer.
- * 4. `reset()` — full clear, used on new chat / conversation switch.
+ * 5. `reset()` — full clear, used on new chat / conversation switch.
  */
 export function useContextWarnings(messages: ReadonlyArray<{ id: string; role: string }>) {
   const [byMessage, setByMessage] = useState<Map<string, WarningBucket>>(new Map());
-  const [pending, setPending] = useState<WarningBucket>({ warnings: [] });
+  const [pending, setPending] = useState<Pending>(EMPTY);
 
+  // Read-only snapshot of `messages.length` for `handleData` to capture
+  // when a new pending batch starts. A ref keeps `handleData` stable
+  // (no dep on the messages array) so `useChat`'s `onData` capture works.
+  const messagesLengthRef = useRef(messages.length);
+  useEffect(() => {
+    messagesLengthRef.current = messages.length;
+  }, [messages]);
+
+  // Drain: attach pending warnings to the assistant message that appeared
+  // for THIS turn (index >= the snapshotted message count).
   useEffect(() => {
     if (pending.warnings.length === 0) return;
-    // Walk from the tail rather than mutating with toReversed() — the
-    // input is typed ReadonlyArray, and react state references should not
-    // motivate cloning a potentially long messages array per pending tick.
-    let lastAssistantId: string | null = null;
-    for (let i = messages.length - 1; i >= 0; i--) {
+    let targetId: string | null = null;
+    // Walk backwards from the tail. Bound the search at
+    // anchorMessageCount so we never attach to a previous turn's
+    // assistant (the bug fix). `for` + index is preferred over
+    // `toReversed()` because the latter allocates a fresh array per
+    // pending tick — meaningful on long conversations.
+    for (let i = messages.length - 1; i >= pending.anchorMessageCount; i--) {
       if (messages[i].role === "assistant") {
-        lastAssistantId = messages[i].id;
+        targetId = messages[i].id;
         break;
       }
     }
-    if (lastAssistantId === null) return;
-    const targetId = lastAssistantId;
+    if (targetId === null) return;
+    const claimedId = targetId;
     setByMessage((prev) => {
       const next = new Map(prev);
-      const existing = next.get(targetId) ?? { warnings: [] };
-      next.set(targetId, {
+      const existing = next.get(claimedId) ?? { warnings: [] };
+      next.set(claimedId, {
         warnings: [...existing.warnings, ...pending.warnings],
       });
       return next;
     });
-    setPending({ warnings: [] });
+    setPending(EMPTY);
   }, [messages, pending]);
+
+  // Cleanup: drop buckets whose message id is no longer in `messages`.
+  // Runs separately from drain so a regenerate that replaces an id
+  // releases the orphaned bucket on the same render that introduces the
+  // new id.
+  useEffect(() => {
+    setByMessage((prev) => {
+      if (prev.size === 0) return prev;
+      const live = new Set(messages.map((m) => m.id));
+      let changed = false;
+      const next = new Map<string, WarningBucket>();
+      for (const [id, bucket] of prev) {
+        if (live.has(id)) next.set(id, bucket);
+        else changed = true;
+      }
+      return changed ? next : prev;
+    });
+  }, [messages]);
 
   const handleData = useCallback(
     (dataPart: { type: string; data: unknown }): boolean => {
       if (dataPart.type === "data-context-warning") {
         const parsed = parseContextWarning(dataPart.data);
         if (parsed) {
-          setPending((p) => ({ warnings: [...p.warnings, parsed] }));
+          const anchor = messagesLengthRef.current;
+          setPending((p) =>
+            p.warnings.length === 0
+              ? { warnings: [parsed], anchorMessageCount: anchor }
+              : { ...p, warnings: [...p.warnings, parsed] },
+          );
+        } else {
+          // The legacy `data-plan-warning` channel had a typed mismatch
+          // (server wrote an object, client guarded on string) and went
+          // undetected for two releases because nothing logged the
+          // drop. Logging here makes any future wire-shape regression
+          // observable without waiting for users to file bugs.
+          console.warn(
+            "[atlas-chat] dropped malformed data-context-warning frame",
+            dataPart.data,
+          );
         }
         return true;
       }
@@ -70,10 +138,10 @@ export function useContextWarnings(messages: ReadonlyArray<{ id: string; role: s
     [],
   );
 
-  const resetPending = useCallback(() => setPending({ warnings: [] }), []);
+  const resetPending = useCallback(() => setPending(EMPTY), []);
   const reset = useCallback(() => {
     setByMessage(new Map());
-    setPending({ warnings: [] });
+    setPending(EMPTY);
   }, []);
 
   return { byMessage, pending, handleData, reset, resetPending };

--- a/packages/web/src/ui/hooks/use-context-warnings.ts
+++ b/packages/web/src/ui/hooks/use-context-warnings.ts
@@ -48,7 +48,11 @@ const EMPTY: Pending = { warnings: [], anchorMessageCount: 0 };
  *    message on regenerate / edit). Without this the map would leak.
  * 4. `resetPending()` — call before sending the next user message so a
  *    stalled previous turn cannot leak warnings into the new answer.
- * 5. `reset()` — full clear, used on new chat / conversation switch.
+ * 5. `reset()` — clears the per-message buckets and pending buffer,
+ *    used on new chat / conversation switch. The malformed-frame log
+ *    gate (`loggedMalformedRef`) is intentionally preserved across
+ *    resets so a misbehaving server doesn't get a fresh log allowance
+ *    every time the user switches conversations.
  */
 export function useContextWarnings(messages: ReadonlyArray<{ id: string; role: string }>) {
   const [byMessage, setByMessage] = useState<Map<string, WarningBucket>>(new Map());

--- a/packages/web/src/ui/hooks/use-context-warnings.ts
+++ b/packages/web/src/ui/hooks/use-context-warnings.ts
@@ -1,0 +1,80 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { parseContextWarning, type ChatContextWarning } from "@useatlas/types";
+
+export type WarningBucket = {
+  warnings: ChatContextWarning[];
+};
+
+/**
+ * Buffer + per-message attachment of `data-context-warning` SSE frames
+ * (#1988 B5 + #2005). The chat route writes warning frames AHEAD of the
+ * agent's text-delta merge (chat.ts:864 — load-bearing ordering comment).
+ * At the moment a frame fires through `onData`, the AI SDK has not yet
+ * appended an assistant message to `messages`, so we cannot key the
+ * bucket by id on arrival. The hook splits the work:
+ *
+ * 1. `handleData(part)` — onData entry point. Returns `true` if the part
+ *    was a warning frame (so the caller can stop dispatching it). Parses
+ *    via the canonical `parseContextWarning` guard; invalid frames are
+ *    silently dropped because a degraded answer is not worth surfacing
+ *    if the wire shape is broken.
+ * 2. Internal `useEffect` — when `messages` next updates, drain the
+ *    `pending` bucket onto the most recent assistant message id.
+ *    Subsequent warnings for the same id append to the existing bucket.
+ * 3. `resetPending()` — call before sending the next user message so a
+ *    stalled previous turn cannot leak warnings into the new answer.
+ * 4. `reset()` — full clear, used on new chat / conversation switch.
+ */
+export function useContextWarnings(messages: ReadonlyArray<{ id: string; role: string }>) {
+  const [byMessage, setByMessage] = useState<Map<string, WarningBucket>>(new Map());
+  const [pending, setPending] = useState<WarningBucket>({ warnings: [] });
+
+  useEffect(() => {
+    if (pending.warnings.length === 0) return;
+    // Walk from the tail rather than mutating with toReversed() — the
+    // input is typed ReadonlyArray, and react state references should not
+    // motivate cloning a potentially long messages array per pending tick.
+    let lastAssistantId: string | null = null;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === "assistant") {
+        lastAssistantId = messages[i].id;
+        break;
+      }
+    }
+    if (lastAssistantId === null) return;
+    const targetId = lastAssistantId;
+    setByMessage((prev) => {
+      const next = new Map(prev);
+      const existing = next.get(targetId) ?? { warnings: [] };
+      next.set(targetId, {
+        warnings: [...existing.warnings, ...pending.warnings],
+      });
+      return next;
+    });
+    setPending({ warnings: [] });
+  }, [messages, pending]);
+
+  const handleData = useCallback(
+    (dataPart: { type: string; data: unknown }): boolean => {
+      if (dataPart.type === "data-context-warning") {
+        const parsed = parseContextWarning(dataPart.data);
+        if (parsed) {
+          setPending((p) => ({ warnings: [...p.warnings, parsed] }));
+        }
+        return true;
+      }
+      return false;
+    },
+    [],
+  );
+
+  const resetPending = useCallback(() => setPending({ warnings: [] }), []);
+  const reset = useCallback(() => {
+    setByMessage(new Map());
+    setPending({ warnings: [] });
+  }, []);
+
+  return { byMessage, pending, handleData, reset, resetPending };
+}

--- a/packages/web/src/ui/hooks/use-context-warnings.ts
+++ b/packages/web/src/ui/hooks/use-context-warnings.ts
@@ -109,6 +109,14 @@ export function useContextWarnings(messages: ReadonlyArray<{ id: string; role: s
     });
   }, [messages]);
 
+  // First-malformed-frame log gate. Logging every dropped frame is
+  // tempting for observability but a server-side wire regression could
+  // emit hundreds per session — at which point users tune out the noise
+  // and the regression is effectively invisible again. We log once per
+  // session with the offending payload so the first user to hit it
+  // surfaces the bug; subsequent drops still happen but stay quiet.
+  const loggedMalformedRef = useRef(false);
+
   const handleData = useCallback(
     (dataPart: { type: string; data: unknown }): boolean => {
       if (dataPart.type === "data-context-warning") {
@@ -120,14 +128,16 @@ export function useContextWarnings(messages: ReadonlyArray<{ id: string; role: s
               ? { warnings: [parsed], anchorMessageCount: anchor }
               : { ...p, warnings: [...p.warnings, parsed] },
           );
-        } else {
+        } else if (!loggedMalformedRef.current) {
           // The legacy `data-plan-warning` channel had a typed mismatch
           // (server wrote an object, client guarded on string) and went
           // undetected for two releases because nothing logged the
-          // drop. Logging here makes any future wire-shape regression
-          // observable without waiting for users to file bugs.
+          // drop. Logging once here makes any future wire-shape
+          // regression observable on the first hit, without spamming
+          // a runaway-stream's worth of warnings into the console.
+          loggedMalformedRef.current = true;
           console.warn(
-            "[atlas-chat] dropped malformed data-context-warning frame",
+            "[atlas-chat] dropped malformed data-context-warning frame (further drops suppressed)",
             dataPart.data,
           );
         }


### PR DESCRIPTION
## Summary
- Closes #2005. Renders `data-context-warning` (and the now-folded plan-warning) frames as a per-message amber banner above the affected assistant turn.
- Adds `parseContextWarning` to `@useatlas/types` so external SDK / react consumers can validate the wire shape from one place.
- Pre-customer cleanup: drops the dead `data-plan-warning` frame + `x-plan-limit-warning` header. The legacy frame was effectively non-functional (server wrote `data: {code, message, metrics}`, client guarded with `typeof data === "string"`). Plan warnings now ride the same `data-context-warning` channel under the new `plan_limit_warning` code.

## Why this matters
PR #2004 (#1988 B5) shipped the structured wire frame but no client surface. Without this, the API was emitting degradation signals that the chat UI silently dropped — users saw a "good" answer with no indication the agent ran without semantic-layer context, learned-pattern hints, or plan headroom.

## Implementation
- **`ContextWarningBanner`** (shadcn Alert, amber treatment) — distinct from the destructive ErrorBanner because a degraded answer is still a usable answer; the visual weight should match.
- **`useContextWarnings` hook** — buffer-then-attach state machine. Warning frames arrive ahead of the assistant message id (chat.ts ordering is load-bearing — see comment), so they buffer in pending state and drain onto the latest assistant message id once the AI SDK appends it.
- **`atlas-chat`** — wires the hook through a stable ref so `onData` stays cached but always routes to the latest hook closure.
- **API cleanup** — chat route now unshifts plan warnings into the existing `contextWarnings` array; the unified loop emits one frame per warning. Header + legacy frame removed.

## Test plan
- [x] `parseContextWarning` parser tests in `@useatlas/types` (valid / missing severity / unknown code / non-string title / drops malformed optional fields)
- [x] `ContextWarningBanner` render tests (single, multi-code including `plan_limit_warning`, accessibility, monospace tag, amber-not-red treatment)
- [x] `useContextWarnings` hook integration tests (buffer→attach, per-message scoping, malformed frames silently dropped, reset on new-chat, `handleData` returns `true` only for warning frames)
- [x] All six CI gates: lint, type, test, syncpack, template-drift, security-headers, railway-watch
- [x] Full `bun run test` — 0 failures across all packages

## Publish chain (separate follow-ups)
- `@useatlas/types@0.0.17` — bumped on `main` already; `types-v0.0.17` tag will be pushed once this merges (per `feedback_version_bump_ordering.md`)
- Template + SDK + react `^0.0.16 → ^0.0.17` ref bumps will land in a follow-up PR after the npm publish workflow completes