### PR TITLE
chore: bump @useatlas/types refs to ^0.0.17

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -231,7 +231,7 @@
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^5.96.2",
-        "@useatlas/types": "^0.0.16",
+        "@useatlas/types": "^0.0.17",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "radix-ui": "^1.4.3",
@@ -298,7 +298,7 @@
       "name": "@useatlas/sdk",
       "version": "0.0.12",
       "dependencies": {
-        "@useatlas/types": "^0.0.16",
+        "@useatlas/types": "^0.0.17",
       },
     },
     "packages/types": {
@@ -4250,10 +4250,6 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typespec/ts-http-runtime/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
-    "@useatlas/react/@useatlas/types": ["@useatlas/types@0.0.16", "", {}, "sha512-DZnNmIN+Y3+vEZJ/vPZpxYlOWYKgaEM1+LJ/OGR71Fa26+j6yNwUDeWbAofEjV3rOphnrvQFmEytC4BL9cdgrQ=="],
-
-    "@useatlas/sdk/@useatlas/types": ["@useatlas/types@0.0.16", "", {}, "sha512-DZnNmIN+Y3+vEZJ/vPZpxYlOWYKgaEM1+LJ/OGR71Fa26+j6yNwUDeWbAofEjV3rOphnrvQFmEytC4BL9cdgrQ=="],
 
     "@vercel/sandbox/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 

--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -24,7 +24,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.0.7",
     "@useatlas/sdk": "^0.0.12",
-    "@useatlas/types": "^0.0.16",
+    "@useatlas/types": "^0.0.17",
     "@better-auth/api-key": "^1.5.6",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -21,7 +21,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.0.7",
     "@useatlas/sdk": "^0.0.12",
-    "@useatlas/types": "^0.0.16",
+    "@useatlas/types": "^0.0.17",
     "ai": "^6.0.141",
     "@better-auth/api-key": "^1.5.6",
     "@dnd-kit/core": "^6.3.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -82,7 +82,7 @@
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^5.96.2",
-    "@useatlas/types": "^0.0.16",
+    "@useatlas/types": "^0.0.17",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "radix-ui": "^1.4.3",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -44,6 +44,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@useatlas/types": "^0.0.16"
+    "@useatlas/types": "^0.0.17"
   }
 }


### PR DESCRIPTION
## Summary
- Follow-up to PR #2006 (#2005 UI rendering). `@useatlas/types@0.0.17` is live on npm via the `types-v0.0.17` tag publish workflow.
- Bumps the four consumers that pinned `^0.0.16` so they pick up the new `parseContextWarning` helper and `plan_limit_warning` code:
  - `packages/sdk`
  - `packages/react`
  - `create-atlas/templates/nextjs-standalone`
  - `create-atlas/templates/docker`
- `bun.lock` regenerated.

## Why this is a separate PR
Per `feedback_version_bump_ordering.md`: in `0.0.x` semver, `^0.0.X` resolves exactly to `0.0.X`, so bumping template refs in the same PR as the version bump would race the publish workflow. Deploy Validation scaffold jobs `npm install` from the registry — if templates point at an unpublished version, scaffolds fail. Sequencing the ref bump after publish avoids that.

## Test plan
- [x] `bun x syncpack lint` — `No issues found`
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — passes (466 files verified)
- [x] `bun install` clean