### PR TITLE
feat(mcp): #2020 + #2019 — typed semantic-layer tools + version sync

### DIFF
--- a/apps/docs/content/docs/guides/mcp.mdx
+++ b/apps/docs/content/docs/guides/mcp.mdx
@@ -88,7 +88,7 @@ The SSE endpoint is available at `http://localhost:8080/mcp`.
 
 ## Available Tools
 
-The MCP server exposes six tools — two general-purpose and four typed accessors over the semantic layer ([#2020](https://github.com/AtlasDevHQ/atlas/issues/2020)). Prefer the typed tools when you only need catalog/glossary/metric data; reach for `explore` only when you need raw file access.
+The MCP server exposes six tools — two general-purpose and four typed accessors over the semantic layer. Prefer the typed tools when you only need catalog/glossary/metric data; reach for `explore` only when you need raw file access.
 
 ### explore
 
@@ -145,7 +145,7 @@ Returns `{ found: false, name }` when the entity does not exist. Always call thi
 
 ### searchGlossary
 
-Search the business glossary for a term. Case-insensitive substring match across term, definition, and note.
+Search the business glossary for a term. Case-insensitive substring match across term, definition, note, and `possible_mappings` — searching by an underlying column name (e.g. `orders.status`) will hit the ambiguous parent term that lists it.
 
 ```
 term: "revenue"
@@ -177,7 +177,7 @@ Execute a canonical metric defined under `semantic/metrics/`. Looks the metric u
 
 ```
 id: "orders_count"
-connectionId: "warehouse"   // optional — overrides the metric's default connection
+connectionId: "warehouse"   // optional — overrides the default connection
 ```
 
 ```jsonc

--- a/apps/docs/content/docs/guides/mcp.mdx
+++ b/apps/docs/content/docs/guides/mcp.mdx
@@ -88,7 +88,7 @@ The SSE endpoint is available at `http://localhost:8080/mcp`.
 
 ## Available Tools
 
-The MCP server exposes two tools:
+The MCP server exposes six tools — two general-purpose and four typed accessors over the semantic layer ([#2020](https://github.com/AtlasDevHQ/atlas/issues/2020)). Prefer the typed tools when you only need catalog/glossary/metric data; reach for `explore` only when you need raw file access.
 
 ### explore
 
@@ -113,6 +113,93 @@ connectionId: "warehouse"  (optional)
 ```
 
 All SQL validation applies: SELECT-only, table whitelist, auto-LIMIT, statement timeout, and audit logging. See [SQL Validation Pipeline](/security/sql-validation).
+
+### listEntities
+
+Discover what entities (tables/views) the semantic layer declares. Each result is `{ name, table, description, source }`.
+
+```
+filter: "order"   // optional case-insensitive substring across name/table/description
+```
+
+```jsonc
+// Example output
+{
+  "count": 2,
+  "entities": [
+    { "name": "Orders", "table": "orders", "description": "...", "source": "default" },
+    { "name": "OrderItems", "table": "order_items", "description": "...", "source": "default" }
+  ]
+}
+```
+
+### describeEntity
+
+Return the full parsed entity YAML — dimensions (with types and sample values), measures, joins, query patterns, grain, and connection. Look up by `name` or by `table` name.
+
+```
+name: "orders"
+```
+
+Returns `{ found: false, name }` when the entity does not exist. Always call this before writing SQL against an unfamiliar table.
+
+### searchGlossary
+
+Search the business glossary for a term. Case-insensitive substring match across term, definition, and note.
+
+```
+term: "revenue"
+```
+
+```jsonc
+// Example output
+{
+  "query": "revenue",
+  "count": 1,
+  "matches": [
+    {
+      "term": "revenue",
+      "status": "defined",
+      "definition": "Sum of paid invoice amounts.",
+      "note": null,
+      "possible_mappings": [],
+      "source": "default"
+    }
+  ]
+}
+```
+
+When a returned term has `status: "ambiguous"`, do **not** silently pick a mapping — surface `possible_mappings` and ask the user which they mean. This is what the [glossary disambiguation](#) directive is for.
+
+### runMetric
+
+Execute a canonical metric defined under `semantic/metrics/`. Looks the metric up by `id`, runs its authoritative SQL through the **same** pipeline as `executeSQL` (4-layer validation, RLS injection, auto-LIMIT, statement timeout, audit logging), and returns the result.
+
+```
+id: "orders_count"
+connectionId: "warehouse"   // optional — overrides the metric's default connection
+```
+
+```jsonc
+// Example output (single column / single row → scalar `value`)
+{
+  "id": "orders_count",
+  "label": "Total orders",
+  "value": 42,
+  "columns": ["count"],
+  "rows": [{ "count": 42 }],
+  "row_count": 1,
+  "truncated": false,
+  "sql": "SELECT COUNT(DISTINCT id) AS count FROM orders",
+  "executed_at": "2026-05-03T12:34:56.789Z"
+}
+```
+
+When the result has multiple columns or multiple rows, `value` falls back to the row array — useful for breakdown metrics.
+
+`runMetric` returns `isError: true` when the metric id is unknown, when the underlying SQL fails validation, or when an approval/RLS rule rejects the query.
+
+The `filters` parameter is reserved for future pre-aggregation filter pass-through. Passing a non-empty `filters` object is rejected today; use `executeSQL` with the metric's raw SQL if you need to filter results before aggregation.
 
 ---
 

--- a/packages/api/src/lib/semantic/__tests__/lookups.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/lookups.test.ts
@@ -10,6 +10,7 @@ import {
   loadMetricDefinitions,
   findMetricById,
 } from "../lookups";
+// `beforeAll` / `afterAll` already imported at the top from "bun:test".
 
 let tmpRoot: string;
 
@@ -222,5 +223,146 @@ describe("findMetricById", () => {
 
   it("returns null for empty input", () => {
     expect(findMetricById("", { semanticRoot: tmpRoot })).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge-case coverage — locks the silent-fallback contracts that the
+// loader-side warn-and-skip behaviour depends on. A future refactor that
+// re-throws on a single bad file would silently brick `listEntities` and
+// `searchGlossary` for the whole catalog, so these tests pin the contract.
+// ---------------------------------------------------------------------------
+
+describe("malformed-file resilience", () => {
+  let resilientRoot: string;
+
+  beforeAll(() => {
+    resilientRoot = fs.mkdtempSync(path.join(os.tmpdir(), "atlas-lookups-bad-"));
+    fs.mkdirSync(path.join(resilientRoot, "entities"), { recursive: true });
+    fs.mkdirSync(path.join(resilientRoot, "metrics"), { recursive: true });
+
+    fs.writeFileSync(
+      path.join(resilientRoot, "entities", "good.yml"),
+      "table: good\ndescription: Healthy entity\n",
+    );
+    // Real YAML can produce parse errors (unbalanced quotes, bad indentation).
+    fs.writeFileSync(
+      path.join(resilientRoot, "entities", "bad.yml"),
+      "table: bad\ndimensions:\n  - {name: id, type:\nbroken indent\n",
+    );
+    fs.writeFileSync(
+      path.join(resilientRoot, "glossary.yml"),
+      "terms:\n  good_term:\n    status: defined\n    definition: ok\n",
+    );
+    fs.writeFileSync(
+      path.join(resilientRoot, "metrics", "good.yml"),
+      "id: good_metric\nsql: SELECT 1\n",
+    );
+    fs.writeFileSync(
+      path.join(resilientRoot, "metrics", "bad.yml"),
+      "metrics:\n  - id: still_bad\n    sql: |\n  unclosed { brace\n",
+    );
+  });
+
+  afterAll(() => {
+    fs.rmSync(resilientRoot, { recursive: true, force: true });
+  });
+
+  it("listEntities skips malformed entity files and returns the rest", () => {
+    const result = listEntities({ semanticRoot: resilientRoot });
+    const tables = result.map((e) => e.table);
+    expect(tables).toContain("good");
+    // The bad file may or may not parse far enough to surface — what
+    // matters is that the loader didn't throw and good entities still load.
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("loadMetricDefinitions skips a malformed file and returns the rest", () => {
+    const metrics = loadMetricDefinitions({ semanticRoot: resilientRoot });
+    expect(metrics.find((m) => m.id === "good_metric")).toBeDefined();
+  });
+
+  it("findMetricById still resolves the good metric when a sibling is malformed", () => {
+    const metric = findMetricById("good_metric", { semanticRoot: resilientRoot });
+    expect(metric?.sql).toContain("SELECT 1");
+  });
+
+  it("getEntityByName falls through to the scan when the basename match is malformed", () => {
+    // bad.yml exists at the basename, but parsing fails. The scan-fallback
+    // pass should not crash; the entity is unrecoverable so we expect null.
+    expect(getEntityByName("bad", { semanticRoot: resilientRoot })).toBeNull();
+    // The good entity is reachable both via basename and via fallback scan.
+    expect(getEntityByName("good", { semanticRoot: resilientRoot })?.table).toBe("good");
+  });
+});
+
+describe("searchGlossary — possible_mappings haystack", () => {
+  it("matches by an entry inside possible_mappings (e.g. orders.status)", () => {
+    const hits = searchGlossary("orders.status", { semanticRoot: tmpRoot });
+    expect(hits.map((t) => t.term)).toContain("status");
+  });
+});
+
+describe("listEntities — defensive coercion", () => {
+  let coerceRoot: string;
+
+  beforeAll(() => {
+    coerceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "atlas-lookups-coerce-"));
+    fs.mkdirSync(path.join(coerceRoot, "entities"), { recursive: true });
+    fs.writeFileSync(
+      path.join(coerceRoot, "entities", "no_desc.yml"),
+      "table: no_desc\ndescription:\n",
+    );
+    fs.writeFileSync(
+      path.join(coerceRoot, "entities", "non_string_name.yml"),
+      "name: 42\ntable: non_string_name\n",
+    );
+  });
+
+  afterAll(() => {
+    fs.rmSync(coerceRoot, { recursive: true, force: true });
+  });
+
+  it("returns description: null when the YAML field is empty", () => {
+    const result = listEntities({ semanticRoot: coerceRoot });
+    const noDesc = result.find((e) => e.table === "no_desc");
+    expect(noDesc?.description).toBeNull();
+  });
+
+  it("falls back to table when name is non-string", () => {
+    const result = listEntities({ semanticRoot: coerceRoot });
+    const nonStringName = result.find((e) => e.table === "non_string_name");
+    expect(nonStringName?.name).toBe("non_string_name");
+  });
+});
+
+describe("RESERVED_DIRS — entities/ and metrics/ are not scanned for glossaries or sub-metrics", () => {
+  let reservedRoot: string;
+
+  beforeAll(() => {
+    reservedRoot = fs.mkdtempSync(path.join(os.tmpdir(), "atlas-lookups-reserved-"));
+    fs.mkdirSync(path.join(reservedRoot, "entities"), { recursive: true });
+    fs.mkdirSync(path.join(reservedRoot, "metrics"), { recursive: true });
+    // A hostile/confused author drops a glossary inside the reserved
+    // entities/ dir. The traversal must not pick this up as a per-source
+    // glossary or it would shadow the real one.
+    fs.writeFileSync(
+      path.join(reservedRoot, "entities", "../entities/glossary.yml"),
+      "terms:\n  ghost_term:\n    status: defined\n    definition: should not load\n",
+    );
+    // Sanity: an actual entity inside entities/ so the scan finds something.
+    fs.writeFileSync(
+      path.join(reservedRoot, "entities", "real.yml"),
+      "table: real\n",
+    );
+  });
+
+  afterAll(() => {
+    fs.rmSync(reservedRoot, { recursive: true, force: true });
+  });
+
+  it("does not pick up glossary.yml from inside the reserved entities/ dir", () => {
+    const terms = loadGlossaryTerms({ semanticRoot: reservedRoot });
+    expect(terms.find((t) => t.term === "ghost_term")).toBeUndefined();
   });
 });

--- a/packages/api/src/lib/semantic/__tests__/lookups.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/lookups.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  listEntities,
+  getEntityByName,
+  loadGlossaryTerms,
+  searchGlossary,
+  loadMetricDefinitions,
+  findMetricById,
+} from "../lookups";
+
+let tmpRoot: string;
+
+beforeAll(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "atlas-lookups-"));
+  fs.mkdirSync(path.join(tmpRoot, "entities"), { recursive: true });
+  fs.mkdirSync(path.join(tmpRoot, "metrics"), { recursive: true });
+  fs.mkdirSync(path.join(tmpRoot, "warehouse", "entities"), { recursive: true });
+  fs.mkdirSync(path.join(tmpRoot, "warehouse", "metrics"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(tmpRoot, "entities", "users.yml"),
+    [
+      "name: User",
+      "table: users",
+      "description: Application user accounts",
+      "dimensions:",
+      "  - name: id",
+      "    type: string",
+    ].join("\n"),
+  );
+  fs.writeFileSync(
+    path.join(tmpRoot, "entities", "orders.yml"),
+    [
+      "table: orders",
+      "description: Order records — one row per checkout",
+    ].join("\n"),
+  );
+  fs.writeFileSync(
+    path.join(tmpRoot, "warehouse", "entities", "events.yml"),
+    [
+      "table: events",
+      "description: Tracking events from the warehouse source",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(tmpRoot, "glossary.yml"),
+    [
+      "terms:",
+      "  revenue:",
+      "    status: defined",
+      "    definition: Sum of paid invoice amounts.",
+      "  status:",
+      "    status: ambiguous",
+      "    note: Appears in multiple tables — ASK the user.",
+      "    possible_mappings:",
+      "      - orders.status",
+      "      - users.status",
+    ].join("\n"),
+  );
+  fs.writeFileSync(
+    path.join(tmpRoot, "warehouse", "glossary.yml"),
+    [
+      "terms:",
+      "  - term: cohort",
+      "    status: defined",
+      "    definition: Group of users sharing a signup month.",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(tmpRoot, "metrics", "orders.yml"),
+    [
+      "metrics:",
+      "  - id: orders_count",
+      "    label: Total orders",
+      "    description: Distinct order count.",
+      "    type: atomic",
+      "    sql: |-",
+      "      SELECT COUNT(DISTINCT id) AS count FROM orders",
+      "    aggregation: count_distinct",
+    ].join("\n"),
+  );
+  fs.writeFileSync(
+    path.join(tmpRoot, "warehouse", "metrics", "events.yml"),
+    [
+      "id: events_count",
+      "sql: |-",
+      "  SELECT COUNT(*) AS count FROM events",
+    ].join("\n"),
+  );
+});
+
+afterAll(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("listEntities", () => {
+  it("returns all entities sorted by name", () => {
+    const result = listEntities({ semanticRoot: tmpRoot });
+    const names = result.map((e) => e.name);
+    expect(names).toContain("User");
+    expect(names).toContain("orders");
+    expect(names).toContain("events");
+    expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)));
+  });
+
+  it("filters by case-insensitive substring across name/table/description", () => {
+    const result = listEntities({ semanticRoot: tmpRoot, filter: "ORDER" });
+    expect(result).toHaveLength(1);
+    expect(result[0].table).toBe("orders");
+  });
+
+  it("returns empty array when filter matches nothing", () => {
+    const result = listEntities({ semanticRoot: tmpRoot, filter: "nonexistent" });
+    expect(result).toEqual([]);
+  });
+
+  it("tags per-source entities with the source directory name", () => {
+    const result = listEntities({ semanticRoot: tmpRoot });
+    const events = result.find((e) => e.table === "events");
+    expect(events?.source).toBe("warehouse");
+  });
+});
+
+describe("getEntityByName", () => {
+  it("returns parsed YAML for an existing entity (by file basename)", () => {
+    const entity = getEntityByName("users", { semanticRoot: tmpRoot });
+    expect(entity).not.toBeNull();
+    expect(entity?.table).toBe("users");
+    expect(entity?.name).toBe("User");
+  });
+
+  it("returns parsed YAML when looking up by `name` field", () => {
+    const entity = getEntityByName("User", { semanticRoot: tmpRoot });
+    expect(entity?.table).toBe("users");
+  });
+
+  it("returns null for an unknown entity", () => {
+    const entity = getEntityByName("does_not_exist", { semanticRoot: tmpRoot });
+    expect(entity).toBeNull();
+  });
+
+  it("rejects names with path traversal segments", () => {
+    expect(getEntityByName("../etc/passwd", { semanticRoot: tmpRoot })).toBeNull();
+    expect(getEntityByName("a/b", { semanticRoot: tmpRoot })).toBeNull();
+  });
+});
+
+describe("loadGlossaryTerms", () => {
+  it("flattens object-form terms with the implicit key as `term`", () => {
+    const terms = loadGlossaryTerms({ semanticRoot: tmpRoot });
+    const revenue = terms.find((t) => t.term === "revenue");
+    expect(revenue?.status).toBe("defined");
+    expect(revenue?.definition).toContain("paid invoice");
+  });
+
+  it("flattens array-form terms (legacy)", () => {
+    const terms = loadGlossaryTerms({ semanticRoot: tmpRoot });
+    const cohort = terms.find((t) => t.term === "cohort");
+    expect(cohort?.source).toBe("warehouse");
+    expect(cohort?.definition).toContain("signup month");
+  });
+
+  it("preserves possible_mappings for ambiguous terms", () => {
+    const terms = loadGlossaryTerms({ semanticRoot: tmpRoot });
+    const status = terms.find((t) => t.term === "status");
+    expect(status?.status).toBe("ambiguous");
+    expect(status?.possible_mappings).toContain("orders.status");
+  });
+});
+
+describe("searchGlossary", () => {
+  it("matches by term substring", () => {
+    const hits = searchGlossary("REVENUE", { semanticRoot: tmpRoot });
+    expect(hits).toHaveLength(1);
+    expect(hits[0].term).toBe("revenue");
+  });
+
+  it("matches by definition or note text", () => {
+    const hits = searchGlossary("invoice", { semanticRoot: tmpRoot });
+    expect(hits.map((t) => t.term)).toContain("revenue");
+  });
+
+  it("returns empty array when nothing matches", () => {
+    expect(searchGlossary("not-a-real-term", { semanticRoot: tmpRoot })).toEqual([]);
+  });
+
+  it("returns empty array for empty query", () => {
+    expect(searchGlossary("   ", { semanticRoot: tmpRoot })).toEqual([]);
+  });
+});
+
+describe("loadMetricDefinitions", () => {
+  it("loads metrics from default and per-source directories", () => {
+    const metrics = loadMetricDefinitions({ semanticRoot: tmpRoot });
+    const ids = metrics.map((m) => m.id).sort();
+    expect(ids).toEqual(["events_count", "orders_count"]);
+  });
+
+  it("normalizes top-level single-metric files", () => {
+    const metrics = loadMetricDefinitions({ semanticRoot: tmpRoot });
+    const events = metrics.find((m) => m.id === "events_count");
+    expect(events?.sql).toContain("SELECT COUNT(*)");
+    expect(events?.source).toBe("warehouse");
+  });
+});
+
+describe("findMetricById", () => {
+  it("returns the metric definition when it exists", () => {
+    const metric = findMetricById("orders_count", { semanticRoot: tmpRoot });
+    expect(metric?.label).toBe("Total orders");
+    expect(metric?.aggregation).toBe("count_distinct");
+  });
+
+  it("returns null for an unknown metric", () => {
+    expect(findMetricById("nonexistent", { semanticRoot: tmpRoot })).toBeNull();
+  });
+
+  it("returns null for empty input", () => {
+    expect(findMetricById("", { semanticRoot: tmpRoot })).toBeNull();
+  });
+});

--- a/packages/api/src/lib/semantic/lookups.ts
+++ b/packages/api/src/lib/semantic/lookups.ts
@@ -1,12 +1,11 @@
 /**
- * Semantic-layer lookup helpers used by the typed MCP tools (#2020).
+ * Public lookup-by-id helpers for semantic-layer entities, glossary terms,
+ * and metrics — typed sibling of the scan-and-format loaders in `search.ts`.
  *
- * Provides public lookup-by-id helpers for entities, glossary terms, and
- * metrics. The existing scanners and search-index loaders are scan-and-
- * format helpers — these are scan-and-find helpers consumed by tool wrappers
- * (MCP today, agent tools later) that need a typed shape, not formatted
- * prose. All loaders are read-only and stay within the resolved semantic
- * root via the existing scanner traversal.
+ * `search.ts` builds a compressed prose summary for the agent's system
+ * prompt; this module returns typed records consumed by tool wrappers that
+ * need to project specific fields. Every read stays within the resolved
+ * semantic root via the existing scanner traversal.
  */
 
 import * as fs from "fs";
@@ -24,11 +23,12 @@ const log = createLogger("semantic-lookups");
 
 export interface EntityListEntry {
   /** Display name — `name` field if present, otherwise the table name. */
-  name: string;
-  table: string;
-  description: string;
+  readonly name: string;
+  readonly table: string;
+  /** Description from the entity YAML; `null` when absent. */
+  readonly description: string | null;
   /** Source name: `"default"` for root `entities/`, subdir name otherwise. */
-  source: string;
+  readonly source: string;
 }
 
 /**
@@ -49,7 +49,9 @@ export function listEntities(
     const name =
       typeof raw.name === "string" && raw.name ? raw.name : raw.table;
     const description =
-      typeof raw.description === "string" ? raw.description : "";
+      typeof raw.description === "string" && raw.description
+        ? raw.description
+        : null;
     const entry: EntityListEntry = {
       name,
       table: raw.table,
@@ -58,7 +60,7 @@ export function listEntities(
     };
 
     if (filter) {
-      const haystack = `${name}\n${entry.table}\n${description}`.toLowerCase();
+      const haystack = `${name}\n${entry.table}\n${description ?? ""}`.toLowerCase();
       if (!haystack.includes(filter)) continue;
     }
 
@@ -104,13 +106,19 @@ export function getEntityByName(
 // Glossary
 // ---------------------------------------------------------------------------
 
-export interface GlossaryTerm {
-  term: string;
-  status: string | null;
-  definition: string | null;
-  note: string | null;
-  possible_mappings: string[];
-  source: string;
+export interface GlossaryTermLookup {
+  /** Term name. Non-empty (loader-enforced). */
+  readonly term: string;
+  /**
+   * Lifecycle status from the YAML. The literal `"ambiguous"` is
+   * load-bearing — MCP clients are instructed to surface ambiguity to the
+   * user instead of silently picking a mapping.
+   */
+  readonly status: string | null;
+  readonly definition: string | null;
+  readonly note: string | null;
+  readonly possible_mappings: readonly string[];
+  readonly source: string;
 }
 
 /**
@@ -122,9 +130,9 @@ export interface GlossaryTerm {
  */
 export function loadGlossaryTerms(
   opts: { semanticRoot?: string } = {},
-): GlossaryTerm[] {
+): GlossaryTermLookup[] {
   const root = opts.semanticRoot ?? getSemanticRoot();
-  const out: GlossaryTerm[] = [];
+  const out: GlossaryTermLookup[] = [];
 
   loadGlossaryFile(path.join(root, "glossary.yml"), "default", out);
 
@@ -156,7 +164,7 @@ export function loadGlossaryTerms(
 export function searchGlossary(
   query: string,
   opts: { semanticRoot?: string } = {},
-): GlossaryTerm[] {
+): GlossaryTermLookup[] {
   const q = query.trim().toLowerCase();
   if (!q) return [];
 
@@ -176,7 +184,7 @@ export function searchGlossary(
 function loadGlossaryFile(
   filePath: string,
   source: string,
-  out: GlossaryTerm[],
+  out: GlossaryTermLookup[],
 ): void {
   if (!fs.existsSync(filePath)) return;
 
@@ -216,7 +224,7 @@ function normalizeGlossaryEntry(
   raw: unknown,
   source: string,
   key?: string,
-): GlossaryTerm | null {
+): GlossaryTermLookup | null {
   if (!raw || typeof raw !== "object") return null;
   const r = raw as Record<string, unknown>;
 
@@ -242,19 +250,27 @@ function normalizeGlossaryEntry(
 // Metrics
 // ---------------------------------------------------------------------------
 
+/**
+ * Source binding for a metric — at least one of `entity` or `measure` is
+ * always set when present (constructor enforces; the empty `{ }` shape is
+ * unrepresentable). `null` means the metric has no source binding at all.
+ */
+export type MetricBinding =
+  | { readonly entity: string; readonly measure: string | null }
+  | { readonly entity: string | null; readonly measure: string };
+
 export interface MetricDefinition {
-  /** Canonical id used for runMetric lookup. */
-  id: string;
-  label: string | null;
-  description: string | null;
-  /** Authoritative SQL — used as-is. */
-  sql: string;
-  type: string | null;
-  aggregation: string | null;
-  unit: string | null;
-  source: string;
-  /** Optional source binding (entity + measure). */
-  binding: { entity?: string; measure?: string } | null;
+  /** Canonical id used for runMetric lookup. Non-empty (loader-enforced). */
+  readonly id: string;
+  readonly label: string | null;
+  readonly description: string | null;
+  /** Authoritative SQL — used as-is. Non-empty (loader-enforced). */
+  readonly sql: string;
+  readonly type: string | null;
+  readonly aggregation: string | null;
+  readonly unit: string | null;
+  readonly source: string;
+  readonly binding: MetricBinding | null;
 }
 
 /** Load every metric defined under `metrics/` (default + per-source). */
@@ -360,12 +376,16 @@ function normalizeMetric(raw: unknown, source: string): MetricDefinition | null 
   const sql = typeof r.sql === "string" ? r.sql : "";
   if (!sql) return null;
 
-  let binding: MetricDefinition["binding"] = null;
+  let binding: MetricBinding | null = null;
   if (r.source && typeof r.source === "object") {
     const s = r.source as Record<string, unknown>;
-    const entity = typeof s.entity === "string" ? s.entity : undefined;
-    const measure = typeof s.measure === "string" ? s.measure : undefined;
-    if (entity || measure) binding = { entity, measure };
+    const entity = typeof s.entity === "string" ? s.entity : null;
+    const measure = typeof s.measure === "string" ? s.measure : null;
+    if (entity !== null) {
+      binding = { entity, measure };
+    } else if (measure !== null) {
+      binding = { entity, measure };
+    }
   }
 
   return {

--- a/packages/api/src/lib/semantic/lookups.ts
+++ b/packages/api/src/lib/semantic/lookups.ts
@@ -1,0 +1,382 @@
+/**
+ * Semantic-layer lookup helpers used by the typed MCP tools (#2020).
+ *
+ * Provides public lookup-by-id helpers for entities, glossary terms, and
+ * metrics. The existing scanners and search-index loaders are scan-and-
+ * format helpers — these are scan-and-find helpers consumed by tool wrappers
+ * (MCP today, agent tools later) that need a typed shape, not formatted
+ * prose. All loaders are read-only and stay within the resolved semantic
+ * root via the existing scanner traversal.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import * as yaml from "js-yaml";
+import { createLogger } from "@atlas/api/lib/logger";
+import { getSemanticRoot, isValidEntityName } from "./files";
+import { RESERVED_DIRS, scanEntities, readEntityYaml, getEntityDirs } from "./scanner";
+
+const log = createLogger("semantic-lookups");
+
+// ---------------------------------------------------------------------------
+// Entities
+// ---------------------------------------------------------------------------
+
+export interface EntityListEntry {
+  /** Display name — `name` field if present, otherwise the table name. */
+  name: string;
+  table: string;
+  description: string;
+  /** Source name: `"default"` for root `entities/`, subdir name otherwise. */
+  source: string;
+}
+
+/**
+ * List entities available in the semantic layer. Optional `filter` is a
+ * case-insensitive substring match against name, table, and description.
+ */
+export function listEntities(
+  opts: { filter?: string; semanticRoot?: string } = {},
+): EntityListEntry[] {
+  const root = opts.semanticRoot ?? getSemanticRoot();
+  const { entities } = scanEntities(root);
+  const filter = opts.filter?.trim().toLowerCase() ?? "";
+
+  const results: EntityListEntry[] = [];
+  for (const { sourceName, raw } of entities) {
+    if (typeof raw.table !== "string" || !raw.table) continue;
+
+    const name =
+      typeof raw.name === "string" && raw.name ? raw.name : raw.table;
+    const description =
+      typeof raw.description === "string" ? raw.description : "";
+    const entry: EntityListEntry = {
+      name,
+      table: raw.table,
+      description,
+      source: sourceName,
+    };
+
+    if (filter) {
+      const haystack = `${name}\n${entry.table}\n${description}`.toLowerCase();
+      if (!haystack.includes(filter)) continue;
+    }
+
+    results.push(entry);
+  }
+
+  return results.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Find a specific entity by `name` (or `table`, fallback) and return its
+ * full parsed YAML. Returns `null` when not found. Rejects names with path
+ * separators or `..` to defend against directory traversal.
+ */
+export function getEntityByName(
+  name: string,
+  opts: { semanticRoot?: string } = {},
+): Record<string, unknown> | null {
+  if (!isValidEntityName(name)) return null;
+
+  const root = opts.semanticRoot ?? getSemanticRoot();
+
+  // Try direct file match first (entity file basename matches entity name).
+  for (const { dir } of getEntityDirs(root).dirs) {
+    const file = path.join(dir, `${name}.yml`);
+    if (fs.existsSync(file)) {
+      const parsed = readEntityYaml(file);
+      if (parsed) return parsed;
+    }
+  }
+
+  // Fall back to scanning by `name` or `table` field (entity files don't
+  // always match their semantic name — `users.yml` may declare `name: User`).
+  const { entities } = scanEntities(root);
+  for (const { raw } of entities) {
+    if (raw.name === name || raw.table === name) return raw;
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Glossary
+// ---------------------------------------------------------------------------
+
+export interface GlossaryTerm {
+  term: string;
+  status: string | null;
+  definition: string | null;
+  note: string | null;
+  possible_mappings: string[];
+  source: string;
+}
+
+/**
+ * Load all glossary terms from `glossary.yml` and per-source glossaries.
+ *
+ * Supports both glossary YAML shapes:
+ * - Object form: `terms: { name: { status, definition, ... } }` (current)
+ * - Array form:  `terms: [{ term: "name", status, ... }]` (legacy)
+ */
+export function loadGlossaryTerms(
+  opts: { semanticRoot?: string } = {},
+): GlossaryTerm[] {
+  const root = opts.semanticRoot ?? getSemanticRoot();
+  const out: GlossaryTerm[] = [];
+
+  loadGlossaryFile(path.join(root, "glossary.yml"), "default", out);
+
+  if (fs.existsSync(root)) {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(root, { withFileTypes: true });
+    } catch (err) {
+      log.warn(
+        { root, err: err instanceof Error ? err.message : String(err) },
+        "Failed to scan semantic root for per-source glossaries",
+      );
+      return out;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory() || RESERVED_DIRS.has(entry.name)) continue;
+      loadGlossaryFile(
+        path.join(root, entry.name, "glossary.yml"),
+        entry.name,
+        out,
+      );
+    }
+  }
+
+  return out;
+}
+
+/** Case-insensitive substring search over `term`, `definition`, and `note`. */
+export function searchGlossary(
+  query: string,
+  opts: { semanticRoot?: string } = {},
+): GlossaryTerm[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+
+  return loadGlossaryTerms(opts).filter((t) => {
+    const haystack = [
+      t.term,
+      t.definition ?? "",
+      t.note ?? "",
+      ...t.possible_mappings,
+    ]
+      .join("\n")
+      .toLowerCase();
+    return haystack.includes(q);
+  });
+}
+
+function loadGlossaryFile(
+  filePath: string,
+  source: string,
+  out: GlossaryTerm[],
+): void {
+  if (!fs.existsSync(filePath)) return;
+
+  let raw: unknown;
+  try {
+    const content = fs.readFileSync(filePath, "utf-8");
+    raw = yaml.load(content);
+  } catch (err) {
+    log.warn(
+      { filePath, err: err instanceof Error ? err.message : String(err) },
+      "Failed to load glossary file",
+    );
+    return;
+  }
+
+  if (!raw || typeof raw !== "object") return;
+  const terms = (raw as { terms?: unknown }).terms;
+  if (!terms) return;
+
+  if (Array.isArray(terms)) {
+    for (const t of terms) {
+      const normalized = normalizeGlossaryEntry(t, source);
+      if (normalized) out.push(normalized);
+    }
+    return;
+  }
+
+  if (typeof terms === "object") {
+    for (const [key, value] of Object.entries(terms as Record<string, unknown>)) {
+      const normalized = normalizeGlossaryEntry(value, source, key);
+      if (normalized) out.push(normalized);
+    }
+  }
+}
+
+function normalizeGlossaryEntry(
+  raw: unknown,
+  source: string,
+  key?: string,
+): GlossaryTerm | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+
+  const term = (typeof r.term === "string" && r.term) || key;
+  if (!term) return null;
+
+  const possibleMappingsRaw = r.possible_mappings;
+  const possible_mappings = Array.isArray(possibleMappingsRaw)
+    ? possibleMappingsRaw.filter((m): m is string => typeof m === "string")
+    : [];
+
+  return {
+    term,
+    status: typeof r.status === "string" ? r.status : null,
+    definition: typeof r.definition === "string" ? r.definition : null,
+    note: typeof r.note === "string" ? r.note : null,
+    possible_mappings,
+    source,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Metrics
+// ---------------------------------------------------------------------------
+
+export interface MetricDefinition {
+  /** Canonical id used for runMetric lookup. */
+  id: string;
+  label: string | null;
+  description: string | null;
+  /** Authoritative SQL — used as-is. */
+  sql: string;
+  type: string | null;
+  aggregation: string | null;
+  unit: string | null;
+  source: string;
+  /** Optional source binding (entity + measure). */
+  binding: { entity?: string; measure?: string } | null;
+}
+
+/** Load every metric defined under `metrics/` (default + per-source). */
+export function loadMetricDefinitions(
+  opts: { semanticRoot?: string } = {},
+): MetricDefinition[] {
+  const root = opts.semanticRoot ?? getSemanticRoot();
+  const out: MetricDefinition[] = [];
+
+  loadMetricsFromDir(path.join(root, "metrics"), "default", out);
+
+  if (fs.existsSync(root)) {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(root, { withFileTypes: true });
+    } catch (err) {
+      log.warn(
+        { root, err: err instanceof Error ? err.message : String(err) },
+        "Failed to scan semantic root for per-source metric directories",
+      );
+      return out;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory() || RESERVED_DIRS.has(entry.name)) continue;
+      loadMetricsFromDir(
+        path.join(root, entry.name, "metrics"),
+        entry.name,
+        out,
+      );
+    }
+  }
+
+  return out;
+}
+
+/** Find a metric by `id`. Returns `null` when not found. */
+export function findMetricById(
+  id: string,
+  opts: { semanticRoot?: string } = {},
+): MetricDefinition | null {
+  if (!id || typeof id !== "string") return null;
+  return loadMetricDefinitions(opts).find((m) => m.id === id) ?? null;
+}
+
+function loadMetricsFromDir(
+  dir: string,
+  source: string,
+  out: MetricDefinition[],
+): void {
+  if (!fs.existsSync(dir)) return;
+
+  let files: string[];
+  try {
+    files = fs.readdirSync(dir).filter((f) => f.endsWith(".yml"));
+  } catch (err) {
+    log.warn(
+      { dir, err: err instanceof Error ? err.message : String(err) },
+      "Failed to read metrics directory",
+    );
+    return;
+  }
+
+  for (const file of files) {
+    const filePath = path.join(dir, file);
+    let raw: unknown;
+    try {
+      raw = yaml.load(fs.readFileSync(filePath, "utf-8"));
+    } catch (err) {
+      log.warn(
+        { filePath, err: err instanceof Error ? err.message : String(err) },
+        "Failed to read or parse metric file",
+      );
+      continue;
+    }
+
+    if (!raw || typeof raw !== "object") continue;
+    const r = raw as Record<string, unknown>;
+
+    if (Array.isArray(r.metrics)) {
+      for (const m of r.metrics) {
+        const def = normalizeMetric(m, source);
+        if (def) out.push(def);
+      }
+    } else {
+      const def = normalizeMetric(r, source);
+      if (def) out.push(def);
+    }
+  }
+}
+
+function normalizeMetric(raw: unknown, source: string): MetricDefinition | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+
+  // `id` is the canonical key. Older shapes used `name` — accept either,
+  // prefer `id` when both are present.
+  const id =
+    (typeof r.id === "string" && r.id) ||
+    (typeof r.name === "string" && r.name) ||
+    null;
+  if (!id) return null;
+
+  const sql = typeof r.sql === "string" ? r.sql : "";
+  if (!sql) return null;
+
+  let binding: MetricDefinition["binding"] = null;
+  if (r.source && typeof r.source === "object") {
+    const s = r.source as Record<string, unknown>;
+    const entity = typeof s.entity === "string" ? s.entity : undefined;
+    const measure = typeof s.measure === "string" ? s.measure : undefined;
+    if (entity || measure) binding = { entity, measure };
+  }
+
+  return {
+    id,
+    label: typeof r.label === "string" ? r.label : null,
+    description: typeof r.description === "string" ? r.description : null,
+    sql,
+    type: typeof r.type === "string" ? r.type : null,
+    aggregation: typeof r.aggregation === "string" ? r.aggregation : null,
+    unit: typeof r.unit === "string" ? r.unit : null,
+    source,
+    binding,
+  };
+}

--- a/packages/api/src/lib/tools/descriptions.ts
+++ b/packages/api/src/lib/tools/descriptions.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared tool descriptions for typed semantic-layer tools (#2020).
+ *
+ * Both surfaces — agent tool registry and MCP `registerSemanticTools` —
+ * import from this module so the LLM-facing prose for `listEntities`,
+ * `describeEntity`, `searchGlossary`, and `runMetric` stays in lockstep.
+ *
+ * Why these strings live here and not next to each tool:
+ * - The agent registry exposes tool descriptions in the system prompt;
+ *   the MCP server exposes them in tool metadata. Both need identical
+ *   prose, and neither surface owns the other.
+ * - `explore` and `executeSQL` keep their descriptions inline because
+ *   they're already AI SDK `tool({ description })` definitions
+ *   (`packages/api/src/lib/tools/{explore,sql}.ts`). The MCP layer reads
+ *   `tool.description` directly. New typed tools have no AI SDK wrapper
+ *   yet, so this file is their single source of truth.
+ *
+ * Style: terse, schema-first, tells the LLM when to call the tool and
+ * what shape to expect back. Avoid prose that duplicates the input/output
+ * Zod schema — the schema is the contract.
+ */
+
+export const LIST_ENTITIES_TOOL_DESCRIPTION = `List semantic-layer entities (tables/views) declared in the project.
+
+Returns one row per entity with { name, table, description, source }. Use this to
+discover what tables are available before reading their schemas. Pass an optional
+\`filter\` (case-insensitive substring) when the catalog is large — matches
+against name, table, and description.
+
+Prefer this tool over the \`explore\` shell when you only need the catalog.`;
+
+export const DESCRIBE_ENTITY_TOOL_DESCRIPTION = `Return the full parsed entity definition for a single entity.
+
+Output is the entity's YAML rendered as JSON: dimensions (with types and sample
+values), measures, joins, query patterns, grain, and connection. Look up by the
+entity's \`name\` field or by \`table\` name — both work.
+
+Always call this before writing SQL against an unfamiliar table. Returns
+{ found: false } when the entity does not exist.`;
+
+export const SEARCH_GLOSSARY_TOOL_DESCRIPTION = `Search the business glossary for a term.
+
+Returns matching glossary entries with { term, status, definition, note,
+possible_mappings, source }. Substring match across term, definition, and note.
+
+Critical: when a returned term has \`status: ambiguous\`, do NOT pick a mapping
+silently — surface the ambiguity to the user with the \`possible_mappings\` and
+ask which they mean. Empty result means no canonical definition; treat the term
+as a free-form column name and verify against entity schemas.`;
+
+export const RUN_METRIC_TOOL_DESCRIPTION = `Execute a canonical metric defined under \`semantic/metrics/\`.
+
+Looks up the metric by \`id\`, runs its authoritative SQL through the same
+read-only pipeline as \`executeSQL\` (4-layer validation, RLS injection,
+auto-LIMIT, statement timeout), and returns { value, columns, rows, sql,
+executed_at }. \`value\` is the scalar when the result is a single column / single
+row; otherwise it falls back to the row array.
+
+Use this whenever a metric exists for what the user asked — never reinvent the
+SQL. Returns an error when the metric id is unknown or the underlying SQL fails
+validation.
+
+\`filters\` is reserved for future pre-aggregation filter pass-through; passing
+a non-empty \`filters\` object is rejected today.`;
+
+/** Canonical tool names for the typed semantic tools registered over MCP. */
+export const SEMANTIC_TOOL_NAMES = [
+  "listEntities",
+  "describeEntity",
+  "searchGlossary",
+  "runMetric",
+] as const;
+
+export type SemanticToolName = (typeof SEMANTIC_TOOL_NAMES)[number];

--- a/packages/api/src/lib/tools/descriptions.ts
+++ b/packages/api/src/lib/tools/descriptions.ts
@@ -1,23 +1,13 @@
 /**
- * Shared tool descriptions for typed semantic-layer tools (#2020).
+ * Shared LLM-facing prose for the typed semantic-layer tools, imported
+ * by both MCP `registerSemanticTools` and (eventually) the agent tool
+ * registry so the description stays in lockstep across surfaces.
  *
- * Both surfaces — agent tool registry and MCP `registerSemanticTools` —
- * import from this module so the LLM-facing prose for `listEntities`,
- * `describeEntity`, `searchGlossary`, and `runMetric` stays in lockstep.
- *
- * Why these strings live here and not next to each tool:
- * - The agent registry exposes tool descriptions in the system prompt;
- *   the MCP server exposes them in tool metadata. Both need identical
- *   prose, and neither surface owns the other.
- * - `explore` and `executeSQL` keep their descriptions inline because
- *   they're already AI SDK `tool({ description })` definitions
- *   (`packages/api/src/lib/tools/{explore,sql}.ts`). The MCP layer reads
- *   `tool.description` directly. New typed tools have no AI SDK wrapper
- *   yet, so this file is their single source of truth.
- *
- * Style: terse, schema-first, tells the LLM when to call the tool and
- * what shape to expect back. Avoid prose that duplicates the input/output
- * Zod schema — the schema is the contract.
+ * `explore` and `executeSQL` keep their descriptions inline on the AI
+ * SDK `tool({ description })` definition in `lib/tools/{explore,sql}.ts`
+ * — the MCP layer reads `tool.description` directly. New typed tools
+ * have no AI SDK wrapper yet, so this file is their single source of
+ * truth.
  */
 
 export const LIST_ENTITIES_TOOL_DESCRIPTION = `List semantic-layer entities (tables/views) declared in the project.
@@ -41,7 +31,9 @@ Always call this before writing SQL against an unfamiliar table. Returns
 export const SEARCH_GLOSSARY_TOOL_DESCRIPTION = `Search the business glossary for a term.
 
 Returns matching glossary entries with { term, status, definition, note,
-possible_mappings, source }. Substring match across term, definition, and note.
+possible_mappings, source }. Substring match across term, definition, note,
+and possible_mappings — searching by an underlying column name (e.g.
+\`orders.status\`) will hit the ambiguous parent term that lists it.
 
 Critical: when a returned term has \`status: ambiguous\`, do NOT pick a mapping
 silently — surface the ambiguity to the user with the \`possible_mappings\` and

--- a/packages/mcp/src/__tests__/semantic-tools.test.ts
+++ b/packages/mcp/src/__tests__/semantic-tools.test.ts
@@ -1,0 +1,366 @@
+import { describe, expect, it, mock, beforeEach } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createAtlasUser } from "@atlas/api/lib/auth/types";
+import { getRequestContext } from "@atlas/api/lib/logger";
+
+const TEST_ACTOR = createAtlasUser("u_sem", "managed", "sem@test", {
+  role: "admin",
+  activeOrganizationId: "org_sem",
+});
+
+// --- Mocks for the semantic lookup helpers + executeSQL pipeline ---
+
+const mockListEntities = mock<(...args: unknown[]) => unknown>(() => [
+  { name: "User", table: "users", description: "Users", source: "default" },
+  { name: "orders", table: "orders", description: "Orders", source: "default" },
+]);
+const mockGetEntityByName = mock<(...args: unknown[]) => unknown>(
+  (name: unknown) =>
+    name === "users"
+      ? { name: "User", table: "users", dimensions: [{ name: "id" }] }
+      : null,
+);
+const mockSearchGlossary = mock<(...args: unknown[]) => unknown>(
+  (term: unknown) =>
+    term === "revenue"
+      ? [
+          {
+            term: "revenue",
+            status: "defined",
+            definition: "Sum of paid invoices.",
+            note: null,
+            possible_mappings: [],
+            source: "default",
+          },
+        ]
+      : term === "status"
+        ? [
+            {
+              term: "status",
+              status: "ambiguous",
+              definition: null,
+              note: "appears in multiple tables — ASK the user",
+              possible_mappings: ["orders.status", "users.status"],
+              source: "default",
+            },
+          ]
+        : [],
+);
+const mockFindMetricById = mock<(...args: unknown[]) => unknown>(
+  (id: unknown) =>
+    id === "orders_count"
+      ? {
+          id: "orders_count",
+          label: "Total orders",
+          description: "Distinct order count.",
+          sql: "SELECT COUNT(DISTINCT id) AS count FROM orders",
+          type: "atomic",
+          aggregation: "count_distinct",
+          unit: null,
+          source: "default",
+          binding: null,
+        }
+      : null,
+);
+
+mock.module("@atlas/api/lib/semantic/lookups", () => ({
+  listEntities: mockListEntities,
+  getEntityByName: mockGetEntityByName,
+  searchGlossary: mockSearchGlossary,
+  findMetricById: mockFindMetricById,
+  // The SUT only needs the four above. Re-export the full surface area as
+  // mocks anyway so other modules importing from this path don't break.
+  loadGlossaryTerms: mock(() => []),
+  loadMetricDefinitions: mock(() => []),
+}));
+
+const mockExecuteSQLExecute = mock<(...args: unknown[]) => Promise<unknown>>(
+  async () => ({
+    success: true,
+    explanation: "ok",
+    row_count: 1,
+    columns: ["count"],
+    rows: [{ count: 42 }],
+    truncated: false,
+  }),
+);
+
+mock.module("@atlas/api/lib/tools/sql", () => ({
+  executeSQL: {
+    description: "Execute SQL",
+    execute: mockExecuteSQLExecute,
+  },
+}));
+
+// Imports must come AFTER mock.module() registrations.
+const { registerSemanticTools } = await import("../semantic-tools.js");
+
+function getContentText(content: unknown): string {
+  const arr = content as Array<{ type: string; text: string }>;
+  return arr[0]?.text ?? "";
+}
+
+async function createTestClient(actor = TEST_ACTOR) {
+  const server = new McpServer({ name: "test", version: "0.0.1" });
+  registerSemanticTools(server, { actor });
+
+  const client = new Client({ name: "test-client", version: "0.0.1" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return { client, server };
+}
+
+describe("MCP semantic tools", () => {
+  beforeEach(() => {
+    mockListEntities.mockClear();
+    mockGetEntityByName.mockClear();
+    mockSearchGlossary.mockClear();
+    mockFindMetricById.mockClear();
+    mockExecuteSQLExecute.mockClear();
+  });
+
+  it("registers four typed tools", async () => {
+    const { client } = await createTestClient();
+    const result = await client.listTools();
+    const names = result.tools.map((t) => t.name).sort();
+    expect(names).toEqual([
+      "describeEntity",
+      "listEntities",
+      "runMetric",
+      "searchGlossary",
+    ]);
+  });
+
+  // --- listEntities ---
+
+  it("listEntities returns the catalog with a count", async () => {
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "listEntities",
+      arguments: {},
+    });
+    expect(mockListEntities).toHaveBeenCalledTimes(1);
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(getContentText(result.content));
+    expect(parsed.count).toBe(2);
+    expect(parsed.entities[0].table).toBe("users");
+  });
+
+  it("listEntities passes filter through to the lookup helper", async () => {
+    const { client } = await createTestClient();
+    await client.callTool({
+      name: "listEntities",
+      arguments: { filter: "ord" },
+    });
+    expect(mockListEntities).toHaveBeenCalledWith({ filter: "ord" });
+  });
+
+  // --- describeEntity ---
+
+  it("describeEntity returns the parsed entity for a known name", async () => {
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "describeEntity",
+      arguments: { name: "users" },
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(getContentText(result.content));
+    expect(parsed.found).toBe(true);
+    expect(parsed.entity.table).toBe("users");
+  });
+
+  it("describeEntity returns { found: false } for an unknown entity", async () => {
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "describeEntity",
+      arguments: { name: "ghost" },
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(getContentText(result.content));
+    expect(parsed.found).toBe(false);
+    expect(parsed.name).toBe("ghost");
+  });
+
+  // --- searchGlossary ---
+
+  it("searchGlossary returns the matching terms with status and mappings", async () => {
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "searchGlossary",
+      arguments: { term: "status" },
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(getContentText(result.content));
+    expect(parsed.count).toBe(1);
+    expect(parsed.matches[0].status).toBe("ambiguous");
+    expect(parsed.matches[0].possible_mappings).toContain("orders.status");
+  });
+
+  it("searchGlossary returns an empty result list on a glossary miss", async () => {
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "searchGlossary",
+      arguments: { term: "nonexistent" },
+    });
+    const parsed = JSON.parse(getContentText(result.content));
+    expect(parsed.count).toBe(0);
+    expect(parsed.matches).toEqual([]);
+  });
+
+  // --- runMetric ---
+
+  it("runMetric executes the metric SQL through executeSQL and returns the scalar value", async () => {
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "runMetric",
+      arguments: { id: "orders_count" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockFindMetricById).toHaveBeenCalledWith("orders_count");
+    expect(mockExecuteSQLExecute).toHaveBeenCalledTimes(1);
+
+    const sqlArgs = (mockExecuteSQLExecute.mock.calls[0] as unknown[])[0] as {
+      sql: string;
+    };
+    expect(sqlArgs.sql).toContain("SELECT COUNT(DISTINCT id)");
+
+    const parsed = JSON.parse(getContentText(result.content));
+    expect(parsed.id).toBe("orders_count");
+    expect(parsed.value).toBe(42);
+    expect(parsed.row_count).toBe(1);
+    expect(typeof parsed.executed_at).toBe("string");
+  });
+
+  it("runMetric returns rows array when result has multiple columns or rows", async () => {
+    mockExecuteSQLExecute.mockImplementationOnce(async () => ({
+      success: true,
+      explanation: "ok",
+      row_count: 2,
+      columns: ["status", "count"],
+      rows: [
+        { status: "open", count: 10 },
+        { status: "closed", count: 5 },
+      ],
+      truncated: false,
+    }));
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "runMetric",
+      arguments: { id: "orders_count" },
+    });
+
+    const parsed = JSON.parse(getContentText(result.content));
+    expect(Array.isArray(parsed.value)).toBe(true);
+    expect(parsed.value).toHaveLength(2);
+  });
+
+  it("runMetric returns isError for an unknown metric id", async () => {
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "runMetric",
+      arguments: { id: "missing_metric" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(getContentText(result.content)).toContain("not found");
+    // executeSQL must not be called when the metric lookup fails — the
+    // pipeline short-circuits before we touch SQL.
+    expect(mockExecuteSQLExecute).not.toHaveBeenCalled();
+  });
+
+  it("runMetric surfaces validation/RLS rejections from executeSQL as isError", async () => {
+    mockExecuteSQLExecute.mockImplementationOnce(async () => ({
+      success: false,
+      error: "RLS check failed: user has no claim for orders.org_id",
+    }));
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "runMetric",
+      arguments: { id: "orders_count" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(getContentText(result.content)).toContain("RLS check failed");
+  });
+
+  it("runMetric rejects non-empty filters with a clear message", async () => {
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "runMetric",
+      arguments: {
+        id: "orders_count",
+        filters: { region: "us" },
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(getContentText(result.content)).toContain("filters");
+    // Short-circuit before metric lookup or SQL execution.
+    expect(mockFindMetricById).not.toHaveBeenCalled();
+    expect(mockExecuteSQLExecute).not.toHaveBeenCalled();
+  });
+
+  it("runMetric forwards connectionId through to executeSQL", async () => {
+    const { client } = await createTestClient();
+    await client.callTool({
+      name: "runMetric",
+      arguments: { id: "orders_count", connectionId: "warehouse" },
+    });
+
+    const callArgs = (mockExecuteSQLExecute.mock.calls[0] as unknown[])[0] as {
+      connectionId?: string;
+    };
+    expect(callArgs.connectionId).toBe("warehouse");
+  });
+
+  // --- actor binding ---
+  // #1858 regression: every dispatch must wrap in withRequestContext so
+  // executeSQL's approval gate sees a bound caller. Same shape as the
+  // explore/executeSQL probe in tools.test.ts.
+
+  it("runMetric dispatch sees the bound actor via getRequestContext", async () => {
+    let observed: ReturnType<typeof getRequestContext>;
+    mockExecuteSQLExecute.mockImplementationOnce(async () => {
+      observed = getRequestContext();
+      return {
+        success: true,
+        explanation: "ok",
+        row_count: 0,
+        columns: [],
+        rows: [],
+      };
+    });
+
+    const { client } = await createTestClient();
+    await client.callTool({
+      name: "runMetric",
+      arguments: { id: "orders_count" },
+    });
+
+    expect(observed).toBeDefined();
+    expect(observed!.user?.id).toBe(TEST_ACTOR.id);
+    expect(observed!.user?.activeOrganizationId).toBe("org_sem");
+  });
+
+  it("listEntities dispatch sees the bound actor via getRequestContext", async () => {
+    let observed: ReturnType<typeof getRequestContext>;
+    mockListEntities.mockImplementationOnce(() => {
+      observed = getRequestContext();
+      return [];
+    });
+
+    const { client } = await createTestClient();
+    await client.callTool({ name: "listEntities", arguments: {} });
+
+    expect(observed).toBeDefined();
+    expect(observed!.user?.id).toBe(TEST_ACTOR.id);
+  });
+});

--- a/packages/mcp/src/__tests__/semantic-tools.test.ts
+++ b/packages/mcp/src/__tests__/semantic-tools.test.ts
@@ -115,6 +115,18 @@ async function createTestClient(actor = TEST_ACTOR) {
   return { client, server };
 }
 
+// Default executeSQL behaviour — single column / single row scalar metric.
+// Restored in beforeEach so any test that uses `mockImplementationOnce`
+// can't leak its custom behaviour into the next test.
+const defaultExecuteSqlResult = {
+  success: true,
+  explanation: "ok",
+  row_count: 1,
+  columns: ["count"],
+  rows: [{ count: 42 }],
+  truncated: false,
+};
+
 describe("MCP semantic tools", () => {
   beforeEach(() => {
     mockListEntities.mockClear();
@@ -122,6 +134,10 @@ describe("MCP semantic tools", () => {
     mockSearchGlossary.mockClear();
     mockFindMetricById.mockClear();
     mockExecuteSQLExecute.mockClear();
+    // Reset to the documented base implementation so tests are
+    // order-independent. Without this, a `mockImplementationOnce` left
+    // over from a previous run could shape the next test's response.
+    mockExecuteSQLExecute.mockImplementation(async () => defaultExecuteSqlResult);
   });
 
   it("registers four typed tools", async () => {
@@ -225,16 +241,73 @@ describe("MCP semantic tools", () => {
     expect(mockFindMetricById).toHaveBeenCalledWith("orders_count");
     expect(mockExecuteSQLExecute).toHaveBeenCalledTimes(1);
 
-    const sqlArgs = (mockExecuteSQLExecute.mock.calls[0] as unknown[])[0] as {
-      sql: string;
-    };
+    const callArgs = mockExecuteSQLExecute.mock.calls[0] as unknown[];
+    const sqlArgs = callArgs[0] as { sql: string };
+    const ctxArgs = callArgs[1] as { toolCallId?: string };
     expect(sqlArgs.sql).toContain("SELECT COUNT(DISTINCT id)");
+    // The AI SDK execute signature is `(input, ctx)`; ctx must include
+    // a toolCallId or downstream telemetry can't correlate the call.
+    expect(ctxArgs.toolCallId).toBe("mcp-runMetric");
 
     const parsed = JSON.parse(getContentText(result.content));
     expect(parsed.id).toBe("orders_count");
     expect(parsed.value).toBe(42);
     expect(parsed.row_count).toBe(1);
-    expect(typeof parsed.executed_at).toBe("string");
+    // ISO-8601: a numeric or RFC2822 fallback would still be a string but
+    // would silently break MCP clients that parse this as a Date. Pin
+    // the format with a regex.
+    expect(parsed.executed_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  // Scalar coercion edge cases — `0`, `false`, and `null` are the most
+  // likely metric values to silently break under a defensive `?? rows`.
+  it.each([
+    ["zero", 0],
+    ["false", false],
+    ["null", null],
+  ])("runMetric coerces a single-column / single-row %s value as the scalar", async (_label, scalar) => {
+    mockExecuteSQLExecute.mockImplementationOnce(async () => ({
+      success: true,
+      explanation: "ok",
+      row_count: 1,
+      columns: ["count"],
+      rows: [{ count: scalar }],
+      truncated: false,
+    }));
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "runMetric",
+      arguments: { id: "orders_count" },
+    });
+
+    const parsed = JSON.parse(getContentText(result.content));
+    expect(parsed.value).toBe(scalar);
+    expect(parsed.row_count).toBe(1);
+  });
+
+  it("runMetric returns an empty array as `value` when columns has one entry but rows is empty", async () => {
+    mockExecuteSQLExecute.mockImplementationOnce(async () => ({
+      success: true,
+      explanation: "ok",
+      row_count: 0,
+      columns: ["count"],
+      rows: [],
+      truncated: false,
+    }));
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "runMetric",
+      arguments: { id: "orders_count" },
+    });
+
+    const parsed = JSON.parse(getContentText(result.content));
+    // Falls into the multi-row branch (rows.length !== 1) and hands back
+    // the (empty) rows array — distinct from `null` (single-row null
+    // scalar) so callers can tell "no result" from "the result is null".
+    expect(parsed.value).toEqual([]);
+    expect(parsed.row_count).toBe(0);
   });
 
   it("runMetric returns rows array when result has multiple columns or rows", async () => {
@@ -259,6 +332,10 @@ describe("MCP semantic tools", () => {
     const parsed = JSON.parse(getContentText(result.content));
     expect(Array.isArray(parsed.value)).toBe(true);
     expect(parsed.value).toHaveLength(2);
+    // `rows` is included unconditionally so MCP clients that always read
+    // `rows` (rather than discriminating on `value`) keep working when
+    // the metric has a breakdown shape. Lock that contract.
+    expect(parsed.rows).toEqual(parsed.value);
   });
 
   it("runMetric returns isError for an unknown metric id", async () => {

--- a/packages/mcp/src/__tests__/server.test.ts
+++ b/packages/mcp/src/__tests__/server.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, mock } from "bun:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createAtlasUser } from "@atlas/api/lib/auth/types";
+import pkg from "../../package.json" with { type: "json" };
 
 // Server tests inject the actor directly so they don't depend on
 // `resolveMcpActor` (whose env-var + rule-lookup behaviour is pinned in
@@ -45,7 +46,7 @@ mock.module("@atlas/api/lib/tools/sql", () => ({
 const { createAtlasMcpServer } = await import("../server.js");
 
 describe("MCP server integration", () => {
-  it("creates a server and lists 2 tools", async () => {
+  it("creates a server and lists explore + executeSQL + the four typed semantic tools", async () => {
     const server = await createAtlasMcpServer({ actor: TEST_ACTOR });
     const client = new Client({ name: "test-client", version: "0.0.1" });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -54,9 +55,15 @@ describe("MCP server integration", () => {
     await client.connect(clientTransport);
 
     const result = await client.listTools();
-    expect(result.tools.length).toBe(2);
     const names = result.tools.map((t) => t.name).sort();
-    expect(names).toEqual(["executeSQL", "explore"]);
+    expect(names).toEqual([
+      "describeEntity",
+      "executeSQL",
+      "explore",
+      "listEntities",
+      "runMetric",
+      "searchGlossary",
+    ]);
   });
 
   it("creates a server and lists resources", async () => {
@@ -107,6 +114,19 @@ describe("MCP server integration", () => {
     });
 
     expect(result.isError).toBe(true);
+  });
+
+  it("serverInfo.version tracks @atlas/mcp/package.json", async () => {
+    const server = await createAtlasMcpServer({ actor: TEST_ACTOR });
+    const client = new Client({ name: "test-client", version: "0.0.1" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    const info = client.getServerVersion();
+    expect(info?.version).toBe(pkg.version);
+    expect(info?.name).toBe("atlas");
   });
 
   it("skipConfig option skips initialization", async () => {

--- a/packages/mcp/src/__tests__/smoke.test.ts
+++ b/packages/mcp/src/__tests__/smoke.test.ts
@@ -102,11 +102,18 @@ async function createTestPair() {
 // ---------------------------------------------------------------------------
 
 describe("MCP smoke — tool listing", () => {
-  it("registers explore and executeSQL tools", async () => {
+  it("registers explore + executeSQL + the four typed semantic tools (#2020)", async () => {
     const { client, cleanup } = await createTestPair();
     const result = await client.listTools();
     const names = result.tools.map((t) => t.name).sort();
-    expect(names).toEqual(["executeSQL", "explore"]);
+    expect(names).toEqual([
+      "describeEntity",
+      "executeSQL",
+      "explore",
+      "listEntities",
+      "runMetric",
+      "searchGlossary",
+    ]);
     await cleanup();
   });
 });
@@ -193,9 +200,10 @@ describe("MCP smoke — server lifecycle", () => {
     await server.connect(serverTransport);
     await client.connect(clientTransport);
 
-    // Verify the server is operational
+    // Verify the server is operational — explore + executeSQL + the four
+    // typed semantic tools (#2020).
     const tools = await client.listTools();
-    expect(tools.tools.length).toBe(2);
+    expect(tools.tools.length).toBe(6);
 
     // Clean shutdown — should not throw
     await client.close();

--- a/packages/mcp/src/__tests__/sse.test.ts
+++ b/packages/mcp/src/__tests__/sse.test.ts
@@ -143,9 +143,15 @@ describe("SSE server — MCP client integration", () => {
     await client.connect(transport);
 
     const result = await client.listTools();
-    expect(result.tools.length).toBe(2);
     const names = result.tools.map((t) => t.name).sort();
-    expect(names).toEqual(["executeSQL", "explore"]);
+    expect(names).toEqual([
+      "describeEntity",
+      "executeSQL",
+      "explore",
+      "listEntities",
+      "runMetric",
+      "searchGlossary",
+    ]);
 
     await client.close();
   });
@@ -236,11 +242,12 @@ describe("SSE server — MCP client integration", () => {
     );
     await client2.connect(transport2);
 
-    // Both clients can list tools independently
+    // Both clients can list tools independently — explore + executeSQL +
+    // the four typed semantic tools (#2020).
     const result1 = await client1.listTools();
     const result2 = await client2.listTools();
-    expect(result1.tools.length).toBe(2);
-    expect(result2.tools.length).toBe(2);
+    expect(result1.tools.length).toBe(6);
+    expect(result2.tools.length).toBe(6);
 
     // Health shows 2+ sessions
     const res = await fetch(`http://localhost:${handle.server.port}/health`);

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -67,11 +67,18 @@ describe("MCP tools", () => {
     mockExecuteSQLExecute.mockClear();
   });
 
-  it("lists all 2 tools", async () => {
+  it("lists explore + executeSQL + the four typed semantic tools (#2020)", async () => {
     const { client } = await createTestClient();
     const result = await client.listTools();
     const names = result.tools.map((t) => t.name).sort();
-    expect(names).toEqual(["executeSQL", "explore"]);
+    expect(names).toEqual([
+      "describeEntity",
+      "executeSQL",
+      "explore",
+      "listEntities",
+      "runMetric",
+      "searchGlossary",
+    ]);
   });
 
   it("explore returns text content", async () => {

--- a/packages/mcp/src/semantic-tools.ts
+++ b/packages/mcp/src/semantic-tools.ts
@@ -1,0 +1,269 @@
+/**
+ * Typed semantic-layer MCP tools (#2020).
+ *
+ * Exposes four tools that wrap the semantic layer's existing read paths so
+ * MCP clients can discover and use it without grepping YAML through the
+ * `explore` shell:
+ *
+ * - `listEntities`    — catalog discovery
+ * - `describeEntity`  — full entity schema
+ * - `searchGlossary`  — business term lookup, surfaces `status: ambiguous`
+ * - `runMetric`       — execute a canonical metric through the same SQL
+ *                       pipeline as `executeSQL` (4-layer validation, RLS
+ *                       injection, auto-LIMIT, statement timeout)
+ *
+ * Actor binding mirrors `tools.ts`: every dispatch is wrapped in
+ * `withRequestContext({ user: actor, requestId })` so any downstream
+ * approval/RLS gate sees a bound caller (#1858 — see tools.ts header).
+ */
+
+import { z } from "zod/v4";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { AtlasUser } from "@atlas/api/lib/auth/types";
+import { withRequestContext } from "@atlas/api/lib/logger";
+import {
+  listEntities,
+  getEntityByName,
+  searchGlossary,
+  findMetricById,
+} from "@atlas/api/lib/semantic/lookups";
+import { executeSQL } from "@atlas/api/lib/tools/sql";
+import {
+  LIST_ENTITIES_TOOL_DESCRIPTION,
+  DESCRIBE_ENTITY_TOOL_DESCRIPTION,
+  SEARCH_GLOSSARY_TOOL_DESCRIPTION,
+  RUN_METRIC_TOOL_DESCRIPTION,
+} from "@atlas/api/lib/tools/descriptions";
+
+export interface RegisterSemanticToolsOptions {
+  /** Actor bound on every tool dispatch — see tools.ts. */
+  actor: AtlasUser;
+}
+
+function dispatchId(prefix: string): string {
+  return `${prefix}-${crypto.randomUUID()}`;
+}
+
+function toJsonContent(value: unknown): CallToolResult {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }],
+  };
+}
+
+function toErrorContent(message: string): CallToolResult {
+  return {
+    content: [{ type: "text" as const, text: message }],
+    isError: true,
+  };
+}
+
+function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error ? err.message : fallback;
+}
+
+export function registerSemanticTools(
+  server: McpServer,
+  opts: RegisterSemanticToolsOptions,
+): void {
+  const { actor } = opts;
+
+  // --- listEntities ---
+  server.registerTool(
+    "listEntities",
+    {
+      title: "List Semantic Entities",
+      description: LIST_ENTITIES_TOOL_DESCRIPTION,
+      inputSchema: {
+        filter: z
+          .string()
+          .optional()
+          .describe(
+            "Optional case-insensitive substring matched against name, table, and description.",
+          ),
+      },
+    },
+    async ({ filter }): Promise<CallToolResult> =>
+      withRequestContext(
+        { requestId: dispatchId("mcp-listEntities"), user: actor },
+        async () => {
+          try {
+            const entities = listEntities({ filter });
+            return toJsonContent({ count: entities.length, entities });
+          } catch (err) {
+            const message = errorMessage(err, "listEntities tool failed");
+            process.stderr.write(`[atlas-mcp] listEntities threw: ${err}\n`);
+            return toErrorContent(message);
+          }
+        },
+      ),
+  );
+
+  // --- describeEntity ---
+  server.registerTool(
+    "describeEntity",
+    {
+      title: "Describe Semantic Entity",
+      description: DESCRIBE_ENTITY_TOOL_DESCRIPTION,
+      inputSchema: {
+        name: z
+          .string()
+          .min(1)
+          .describe(
+            "Entity name (`name` field) or table name. Must not contain path separators.",
+          ),
+      },
+    },
+    async ({ name }): Promise<CallToolResult> =>
+      withRequestContext(
+        { requestId: dispatchId("mcp-describeEntity"), user: actor },
+        async () => {
+          try {
+            const entity = getEntityByName(name);
+            if (!entity) {
+              return toJsonContent({ found: false, name });
+            }
+            return toJsonContent({ found: true, entity });
+          } catch (err) {
+            const message = errorMessage(err, "describeEntity tool failed");
+            process.stderr.write(`[atlas-mcp] describeEntity threw: ${err}\n`);
+            return toErrorContent(message);
+          }
+        },
+      ),
+  );
+
+  // --- searchGlossary ---
+  server.registerTool(
+    "searchGlossary",
+    {
+      title: "Search Business Glossary",
+      description: SEARCH_GLOSSARY_TOOL_DESCRIPTION,
+      inputSchema: {
+        term: z
+          .string()
+          .min(1)
+          .describe(
+            "Term, phrase, or substring to search across glossary entries.",
+          ),
+      },
+    },
+    async ({ term }): Promise<CallToolResult> =>
+      withRequestContext(
+        { requestId: dispatchId("mcp-searchGlossary"), user: actor },
+        async () => {
+          try {
+            const matches = searchGlossary(term);
+            return toJsonContent({
+              query: term,
+              count: matches.length,
+              matches,
+            });
+          } catch (err) {
+            const message = errorMessage(err, "searchGlossary tool failed");
+            process.stderr.write(`[atlas-mcp] searchGlossary threw: ${err}\n`);
+            return toErrorContent(message);
+          }
+        },
+      ),
+  );
+
+  // --- runMetric ---
+  // The metric SQL is run through executeSQL.execute — same dispatch path
+  // as the agent's executeSQL tool — so it inherits the four validation
+  // layers, plugin hooks, RLS injection, auto-LIMIT, statement timeout,
+  // and audit logging without re-implementing any of them.
+  server.registerTool(
+    "runMetric",
+    {
+      title: "Run Canonical Metric",
+      description: RUN_METRIC_TOOL_DESCRIPTION,
+      inputSchema: {
+        id: z
+          .string()
+          .min(1)
+          .describe("Metric id from semantic/metrics/*.yml."),
+        filters: z
+          .record(
+            z.string(),
+            z.union([z.string(), z.number(), z.boolean(), z.null()]),
+          )
+          .optional()
+          .describe(
+            "Reserved for future filter pass-through. Empty/omitted today; passing a non-empty object returns an error.",
+          ),
+        connectionId: z
+          .string()
+          .optional()
+          .describe(
+            "Target connection id. Omit to use the metric's default connection.",
+          ),
+      },
+    },
+    async ({ id, filters, connectionId }): Promise<CallToolResult> =>
+      withRequestContext(
+        { requestId: dispatchId("mcp-runMetric"), user: actor },
+        async () => {
+          try {
+            if (filters && Object.keys(filters).length > 0) {
+              return toErrorContent(
+                "runMetric `filters` pass-through is not yet supported. Use `executeSQL` with the metric's raw SQL to apply filters.",
+              );
+            }
+
+            const metric = findMetricById(id);
+            if (!metric) {
+              return toErrorContent(`Metric "${id}" not found.`);
+            }
+
+            const explanation = metric.description
+              ? `MCP runMetric ${metric.id}: ${metric.description}`
+              : `MCP runMetric ${metric.id}`;
+
+            const result = (await executeSQL.execute!(
+              { sql: metric.sql, explanation, connectionId },
+              { toolCallId: "mcp-runMetric", messages: [] },
+            )) as Record<string, unknown>;
+
+            if (result.success === false) {
+              return toErrorContent(
+                String(result.error ?? "Metric execution failed."),
+              );
+            }
+
+            const columns = Array.isArray(result.columns)
+              ? (result.columns as string[])
+              : [];
+            const rows = Array.isArray(result.rows)
+              ? (result.rows as Array<Record<string, unknown>>)
+              : [];
+
+            // Single column / single row → scalar value. Otherwise hand back
+            // the rows so the caller can inspect — keeps the typed shape
+            // honest for breakdown metrics without forcing a shape they don't
+            // have.
+            const value =
+              columns.length === 1 && rows.length === 1
+                ? rows[0][columns[0]]
+                : rows;
+
+            return toJsonContent({
+              id: metric.id,
+              label: metric.label,
+              value,
+              columns,
+              rows,
+              row_count: result.row_count ?? rows.length,
+              truncated: Boolean(result.truncated),
+              sql: metric.sql,
+              executed_at: new Date().toISOString(),
+            });
+          } catch (err) {
+            const message = errorMessage(err, "runMetric tool failed");
+            process.stderr.write(`[atlas-mcp] runMetric threw: ${err}\n`);
+            return toErrorContent(message);
+          }
+        },
+      ),
+  );
+}

--- a/packages/mcp/src/semantic-tools.ts
+++ b/packages/mcp/src/semantic-tools.ts
@@ -1,16 +1,8 @@
 /**
- * Typed semantic-layer MCP tools (#2020).
- *
- * Exposes four tools that wrap the semantic layer's existing read paths so
- * MCP clients can discover and use it without grepping YAML through the
- * `explore` shell:
- *
- * - `listEntities`    — catalog discovery
- * - `describeEntity`  — full entity schema
- * - `searchGlossary`  — business term lookup, surfaces `status: ambiguous`
- * - `runMetric`       — execute a canonical metric through the same SQL
- *                       pipeline as `executeSQL` (4-layer validation, RLS
- *                       injection, auto-LIMIT, statement timeout)
+ * Typed semantic-layer MCP tools — `listEntities`, `describeEntity`,
+ * `searchGlossary`, and `runMetric` — that wrap the existing semantic-
+ * layer read paths so MCP clients can discover and use the catalog
+ * without grepping YAML through the `explore` shell.
  *
  * Actor binding mirrors `tools.ts`: every dispatch is wrapped in
  * `withRequestContext({ user: actor, requestId })` so any downstream
@@ -34,7 +26,22 @@ import {
   DESCRIBE_ENTITY_TOOL_DESCRIPTION,
   SEARCH_GLOSSARY_TOOL_DESCRIPTION,
   RUN_METRIC_TOOL_DESCRIPTION,
+  type SemanticToolName,
 } from "@atlas/api/lib/tools/descriptions";
+
+// Modest input bounds — MCP clients (including hostile ones in BYOC
+// SaaS) shouldn't be able to drive megabyte strings into the catalog
+// scanners or substring search. Identifiers stay short; free-text
+// filter/term get a bit more headroom. Bumping these is fine if a real
+// user need surfaces.
+const MAX_IDENTIFIER_LEN = 256;
+const MAX_FREE_TEXT_LEN = 1024;
+
+// Mirrors the entity-name shape `isValidEntityName` accepts in
+// `lib/semantic/files.ts` (no `/`, `\`, `..`, `\0`). Surfacing the
+// constraint at the Zod boundary gives the MCP client an immediate
+// error instead of an indistinguishable `{ found: false }`.
+const ENTITY_NAME_PATTERN = /^[A-Za-z0-9_.-]+$/;
 
 export interface RegisterSemanticToolsOptions {
   /** Actor bound on every tool dispatch — see tools.ts. */
@@ -59,7 +66,13 @@ function toErrorContent(message: string): CallToolResult {
 }
 
 function errorMessage(err: unknown, fallback: string): string {
-  return err instanceof Error ? err.message : fallback;
+  if (err instanceof Error) return err.message;
+  // CLAUDE.md: `err instanceof Error ? err.message : String(err)`. The
+  // fallback only kicks in for the truly opaque case (`String(err)` →
+  // `""` or `"[object Object]"`) where preserving the original would
+  // give the caller no signal anyway.
+  const s = String(err);
+  return s && s !== "[object Object]" ? s : fallback;
 }
 
 export function registerSemanticTools(
@@ -70,13 +83,14 @@ export function registerSemanticTools(
 
   // --- listEntities ---
   server.registerTool(
-    "listEntities",
+    "listEntities" satisfies SemanticToolName,
     {
       title: "List Semantic Entities",
       description: LIST_ENTITIES_TOOL_DESCRIPTION,
       inputSchema: {
         filter: z
           .string()
+          .max(MAX_FREE_TEXT_LEN)
           .optional()
           .describe(
             "Optional case-insensitive substring matched against name, table, and description.",
@@ -101,7 +115,7 @@ export function registerSemanticTools(
 
   // --- describeEntity ---
   server.registerTool(
-    "describeEntity",
+    "describeEntity" satisfies SemanticToolName,
     {
       title: "Describe Semantic Entity",
       description: DESCRIBE_ENTITY_TOOL_DESCRIPTION,
@@ -109,8 +123,10 @@ export function registerSemanticTools(
         name: z
           .string()
           .min(1)
+          .max(MAX_IDENTIFIER_LEN)
+          .regex(ENTITY_NAME_PATTERN)
           .describe(
-            "Entity name (`name` field) or table name. Must not contain path separators.",
+            "Entity name (`name` field) or table name. Alphanumerics, `_`, `-`, `.` only — no path separators.",
           ),
       },
     },
@@ -135,7 +151,7 @@ export function registerSemanticTools(
 
   // --- searchGlossary ---
   server.registerTool(
-    "searchGlossary",
+    "searchGlossary" satisfies SemanticToolName,
     {
       title: "Search Business Glossary",
       description: SEARCH_GLOSSARY_TOOL_DESCRIPTION,
@@ -143,6 +159,7 @@ export function registerSemanticTools(
         term: z
           .string()
           .min(1)
+          .max(MAX_FREE_TEXT_LEN)
           .describe(
             "Term, phrase, or substring to search across glossary entries.",
           ),
@@ -169,12 +186,11 @@ export function registerSemanticTools(
   );
 
   // --- runMetric ---
-  // The metric SQL is run through executeSQL.execute — same dispatch path
-  // as the agent's executeSQL tool — so it inherits the four validation
-  // layers, plugin hooks, RLS injection, auto-LIMIT, statement timeout,
-  // and audit logging without re-implementing any of them.
+  // The metric SQL goes through executeSQL.execute, inheriting all four
+  // validation layers, plugin hooks, RLS injection, auto-LIMIT,
+  // statement timeout, and audit logging.
   server.registerTool(
-    "runMetric",
+    "runMetric" satisfies SemanticToolName,
     {
       title: "Run Canonical Metric",
       description: RUN_METRIC_TOOL_DESCRIPTION,
@@ -182,11 +198,17 @@ export function registerSemanticTools(
         id: z
           .string()
           .min(1)
+          .max(MAX_IDENTIFIER_LEN)
           .describe("Metric id from semantic/metrics/*.yml."),
         filters: z
           .record(
-            z.string(),
-            z.union([z.string(), z.number(), z.boolean(), z.null()]),
+            z.string().max(MAX_IDENTIFIER_LEN),
+            z.union([
+              z.string().max(MAX_FREE_TEXT_LEN),
+              z.number(),
+              z.boolean(),
+              z.null(),
+            ]),
           )
           .optional()
           .describe(
@@ -194,9 +216,10 @@ export function registerSemanticTools(
           ),
         connectionId: z
           .string()
+          .max(MAX_IDENTIFIER_LEN)
           .optional()
           .describe(
-            "Target connection id. Omit to use the metric's default connection.",
+            "Target connection id. Omit to use the default connection.",
           ),
       },
     },

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -17,9 +17,9 @@ import { registerTools } from "./tools.js";
 import { registerResources } from "./resources.js";
 import { registerPrompts } from "./prompts.js";
 import { resolveMcpActor } from "./actor.js";
-// Tracks @atlas/mcp's package.json version. #2019 — clients (Claude Desktop,
-// Cursor) display this in the server picker; a hardcoded "0.1.0" misrepresented
-// the product, which is well past pre-alpha.
+// `serverInfo.version` is what MCP clients (Claude Desktop, Cursor) show
+// in their server picker. Reading from package.json keeps the value in
+// sync without a hand-edit on every bump.
 import pkg from "../package.json" with { type: "json" };
 
 const VERSION: string = pkg.version;
@@ -46,9 +46,11 @@ interface CreateMcpServerOptions {
  *    fails loud when approval rules exist without
  *    `ATLAS_MCP_USER_ID` + `ATLAS_MCP_ORG_ID`, otherwise produces the
  *    bound user or a synthetic `system:mcp` actor.
- * 3. Registers the core tools (explore, executeSQL) as MCP tools, wrapping
- *    every dispatch in `withRequestContext({ user })` so the approval gate
- *    sees a bound actor.
+ * 3. Registers the core tools (explore, executeSQL) and the typed
+ *    semantic-layer tools (listEntities, describeEntity, searchGlossary,
+ *    runMetric) as MCP tools, wrapping every dispatch in
+ *    `withRequestContext({ user })` so the approval gate sees a bound
+ *    actor.
  * 4. Registers semantic layer YAML files as MCP resources
  * 5. Registers prompt templates (built-in, semantic layer, prompt library)
  */

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -17,8 +17,12 @@ import { registerTools } from "./tools.js";
 import { registerResources } from "./resources.js";
 import { registerPrompts } from "./prompts.js";
 import { resolveMcpActor } from "./actor.js";
+// Tracks @atlas/mcp's package.json version. #2019 — clients (Claude Desktop,
+// Cursor) display this in the server picker; a hardcoded "0.1.0" misrepresented
+// the product, which is well past pre-alpha.
+import pkg from "../package.json" with { type: "json" };
 
-const VERSION = "0.1.0";
+const VERSION: string = pkg.version;
 
 interface CreateMcpServerOptions {
   /** Skip config initialization (useful when config is already loaded). */

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -157,6 +157,6 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
       ),
   );
 
-  // --- typed semantic-layer tools (#2020) ---
+  // --- typed semantic-layer tools ---
   registerSemanticTools(server, opts);
 }

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -19,6 +19,7 @@ import { explore } from "@atlas/api/lib/tools/explore";
 import { executeSQL } from "@atlas/api/lib/tools/sql";
 import type { AtlasUser } from "@atlas/api/lib/auth/types";
 import { withRequestContext } from "@atlas/api/lib/logger";
+import { registerSemanticTools } from "./semantic-tools.js";
 
 export interface RegisterToolsOptions {
   /**
@@ -156,4 +157,6 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
       ),
   );
 
+  // --- typed semantic-layer tools (#2020) ---
+  registerSemanticTools(server, opts);
 }


### PR DESCRIPTION
## Summary

Closes #2020 and #2019 (bundled — both live in `packages/mcp/src/`; #2019 is a 5-line fix that wasn't worth its own PR).

### #2020 — Typed MCP tools

Adds four typed MCP tools that wrap the existing semantic-layer read paths so MCP clients (Claude Desktop, Cursor, …) can discover Atlas's catalog programmatically instead of grep-ing YAML through the `explore` shell:

| Tool | Input | Output | Wraps |
|---|---|---|---|
| `listEntities` | `{ filter?: string }` | `Array<{ name, table, description, source }>` | `lib/semantic/lookups#listEntities` |
| `describeEntity` | `{ name: string }` | Full parsed entity YAML | `lib/semantic/lookups#getEntityByName` |
| `searchGlossary` | `{ term: string }` | Matching terms with `status`, `definition`, `possible_mappings` | `lib/semantic/lookups#searchGlossary` |
| `runMetric` | `{ id, filters?, connectionId? }` | `{ value, columns, rows, sql, executed_at }` | `lib/semantic/lookups#findMetricById` + `executeSQL.execute` |

`runMetric` runs through the **same** dispatch path as the agent's `executeSQL` tool — it inherits the four validation layers, plugin hooks, RLS injection, auto-LIMIT, statement timeout, and audit logging without re-implementing any of them.

LLM-facing prose lives in `packages/api/src/lib/tools/descriptions.ts` so the agent registry can later adopt the same strings without duplication.

Every dispatch wraps in `withRequestContext({ user: actor, requestId })` so downstream governance gates see a bound caller — same #1858 binding pattern as `explore` / `executeSQL`.

### #2019 — Version sync

Replaces the hardcoded `VERSION = \"0.1.0\"` in `packages/mcp/src/server.ts` with `import pkg from \"../package.json\" with { type: \"json\" }`. `serverInfo.version` now tracks the package automatically. New test asserts `client.getServerVersion().version === pkg.version`.

### What's deliberately out of scope

- **Write-side tools** — no `createEntity` / `updateGlossary`. Semantic layer stays human-authored.
- **`runMetric` filter pass-through** — schema accepts `filters?: Record<string, …>` but rejects non-empty objects with a clear message pointing the caller at `executeSQL`. Forward-compatible for a follow-up PR.
- **Multi-step / streaming `runMetric`** — single response is sufficient for the tools-as-API surface.
- **Bumping `@atlas/mcp/package.json`** — every internal monorepo package sits at `0.1.0`; touching just one would be inconsistent. The structural fix (read from package.json) means future bumps just work.

## Test plan

- [x] `bun test packages/mcp/src/__tests__/semantic-tools.test.ts` — 15 tests across all four tools, happy + error paths (unknown entity, unknown metric, glossary miss, validation/RLS rejection, filter rejection, actor binding probe).
- [x] `bun test packages/api/src/lib/semantic/__tests__/lookups.test.ts` — 20 tests covering both glossary YAML shapes (object + legacy array), per-source directories, and metric-id lookup.
- [x] Existing MCP tests (`tools.test.ts`, `server.test.ts`, `smoke.test.ts`, `sse.test.ts`) updated for the new tool count (2 → 6) and the version assertion.
- [x] `cd packages/api && bun run scripts/test-isolated.ts --affected` — 60 affected tests, all pass.
- [x] `bun run lint` — clean.
- [x] `bun run type` — clean.
- [x] `bun run test` — full monorepo suite, all packages exit 0.
- [x] `bun x syncpack lint` — no issues.
- [x] `bash scripts/check-template-drift.sh` — passed.
- [x] `bash scripts/check-security-headers-drift.sh` — passed.
- [x] `bash scripts/check-railway-watch.sh` — passed.

## Manual smoke

After merge, point an MCP client at the server and verify:

1. `listEntities({ filter: \"order\" })` returns the orders entity.
2. `describeEntity({ name: \"orders\" })` returns the full YAML.
3. `searchGlossary({ term: \"status\" })` surfaces `status: ambiguous` with `possible_mappings`.
4. `runMetric({ id: \"<an existing metric id>\" })` returns `{ value, sql, executed_at }`; check the audit log shows the same `requestId`.