### PR TITLE
feat(mcp): #2018 — `bunx @useatlas/mcp init --local` one-command installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ export default function App() {
 
 The widget supports programmatic control (`Atlas.open()`, `Atlas.ask("...")`, `Atlas.destroy()`), event callbacks, and theming. See the [widget docs](https://docs.useatlas.dev/guides/embedding-widget).
 
+## Use as an MCP server
+
+Add Atlas to Claude Desktop, Cursor, or Continue with a single command — auto-detects the client, falls back to a bundled demo fixture if no datasource is configured:
+
+```bash
+bunx @useatlas/mcp init --local            # print paste-ready config
+bunx @useatlas/mcp init --local --write    # merge into the detected client config (with a .bak)
+```
+
+See the [MCP guide](https://docs.useatlas.dev/guides/mcp) for the full flow.
+
 ## Why Atlas?
 
 | | Atlas | Traditional BI | Other text-to-SQL |

--- a/apps/docs/content/docs/guides/mcp.mdx
+++ b/apps/docs/content/docs/guides/mcp.mdx
@@ -7,14 +7,29 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 Atlas exposes a [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that gives any MCP-compatible client access to your semantic layer and validated SQL execution.
 
+## Install in one command
+
+```bash
+bunx @useatlas/mcp init --local
+```
+
+This auto-detects Claude Desktop, Cursor, or Continue and prints a paste-ready config. Add `--write` to merge it directly into the detected client's config (a `.bak` is written first):
+
+```bash
+bunx @useatlas/mcp init --local --write
+```
+
+If `ATLAS_DATASOURCE_URL` is unset, the installer points at a bundled accounts/companies/people SQLite fixture so the install works zero-config. If a local Atlas is running at `http://localhost:3001` (override via `ATLAS_API_URL`), the installer leaves the datasource env blank so the MCP server inherits your shell env.
+
+> Hosted mode (`bunx @useatlas/mcp init --hosted` against `app.useatlas.dev`) is tracked in [#2024](https://github.com/AtlasDevHQ/atlas/issues/2024) and prints a clear "coming soon" message today.
+
 <Callout title="Prerequisites">
-- Atlas project set up (`bun install`)
-- `ATLAS_DATASOURCE_URL` pointing to your analytics database
-- An MCP-compatible client (Claude Desktop, Cursor, or any stdio/SSE client)
+- An MCP-compatible client (Claude Desktop, Cursor, Continue, or any stdio/SSE client)
 - LLM provider API key configured in the **client** (the MCP server itself does not call an LLM)
+- For real datasources beyond the demo fixture: `ATLAS_DATASOURCE_URL` exported in your shell, or a running Atlas at `localhost:3001`
 </Callout>
 
-## Quick Start
+## Manual setup (monorepo / advanced)
 
 ```bash
 bun run mcp              # Start MCP server on stdio

--- a/packages/mcp/bin/init.ts
+++ b/packages/mcp/bin/init.ts
@@ -1,28 +1,17 @@
 #!/usr/bin/env bun
 /**
- * `bunx @useatlas/mcp init` entry point.
- *
- * Generates a paste-ready Claude Desktop / Cursor / Continue config for
- * Atlas's MCP server. Pass `--write` to merge into the detected client's
- * config file (with a `.bak` of any previous file).
- *
- * Usage:
- *   bunx @useatlas/mcp init --local
- *   bunx @useatlas/mcp init --local --write
- *   bunx @useatlas/mcp init --local --client cursor --write
- *   bunx @useatlas/mcp init --hosted   # stub — comes with #2024
- *
- * From this monorepo (until @useatlas/mcp ships to npm):
- *   bun packages/mcp/bin/init.ts --local
+ * `bunx @useatlas/mcp init` entry point. Generates a paste-ready Claude
+ * Desktop / Cursor / Continue config; with `--write`, merges into the
+ * detected client's config file (timestamped `.bak` backup).
  */
 
 import { runInit, type RunInitOptions } from "../src/init/index.js";
-import type { McpClientId } from "../src/init/clients.js";
+import { KNOWN_CLIENTS, type McpClientId } from "../src/init/clients.js";
 
-const KNOWN_CLIENTS: McpClientId[] = ["claude-desktop", "cursor", "continue", "generic"];
+const KNOWN_CLIENT_IDS: readonly string[] = KNOWN_CLIENTS.map((c) => c.id);
 
 interface CliFlags {
-  mode: "local" | "hosted" | null;
+  mode: "local" | "hosted";
   client: McpClientId | undefined;
   write: boolean;
   apiUrl: string | undefined;
@@ -31,7 +20,7 @@ interface CliFlags {
 
 function parseArgs(argv: string[]): CliFlags {
   const flags: CliFlags = {
-    mode: null,
+    mode: "local",
     client: undefined,
     write: false,
     apiUrl: undefined,
@@ -50,18 +39,15 @@ function parseArgs(argv: string[]): CliFlags {
       case "--write":
         flags.write = true;
         break;
-      case "--no-write":
-        flags.write = false;
-        break;
       case "-h":
       case "--help":
         flags.help = true;
         break;
       case "--client": {
         const next = argv[i + 1];
-        if (!next || !KNOWN_CLIENTS.includes(next as McpClientId)) {
+        if (!next || !KNOWN_CLIENT_IDS.includes(next)) {
           console.error(
-            `[atlas-mcp init] --client expects one of: ${KNOWN_CLIENTS.join(", ")}`,
+            `[atlas-mcp init] --client expects one of: ${KNOWN_CLIENT_IDS.join(", ")}`,
           );
           process.exit(1);
         }
@@ -69,10 +55,16 @@ function parseArgs(argv: string[]): CliFlags {
         i++;
         break;
       }
-      case "--api-url":
-        flags.apiUrl = argv[i + 1];
+      case "--api-url": {
+        const next = argv[i + 1];
+        if (!next || next.startsWith("--")) {
+          console.error(`[atlas-mcp init] --api-url expects a URL value (e.g. http://localhost:3001)`);
+          process.exit(1);
+        }
+        flags.apiUrl = next;
         i++;
         break;
+      }
       default:
         console.error(`[atlas-mcp init] Unknown flag: ${a}`);
         process.exit(1);
@@ -84,8 +76,8 @@ function parseArgs(argv: string[]): CliFlags {
 
 const HELP = `bunx @useatlas/mcp init [options]
 
-  --local            Configure for a local Atlas (default if --hosted not set)
-  --hosted           Configure for app.useatlas.dev (coming with #2024)
+  --local            Configure for a local Atlas (default)
+  --hosted           Configure for app.useatlas.dev (not yet available)
   --client <id>      Force a specific client: claude-desktop | cursor | continue | generic
   --write            Merge into the client's config file (with a .bak backup)
   --api-url <url>    Override local Atlas detection URL (default: http://localhost:3001)
@@ -104,19 +96,15 @@ async function main(): Promise<number> {
     return 0;
   }
 
-  if (flags.mode === null) {
-    // Default to --local for now; the auto-detect prompt described in #2018
-    // can land alongside --hosted in a follow-up since it depends on the
-    // hosted flow.
-    flags.mode = "local";
-  }
-
-  const opts: RunInitOptions = {
-    mode: flags.mode,
-    client: flags.client,
-    write: flags.write,
-    apiUrl: flags.apiUrl,
-  };
+  const opts: RunInitOptions =
+    flags.mode === "hosted"
+      ? { mode: "hosted" }
+      : {
+          mode: "local",
+          client: flags.client,
+          write: flags.write,
+          apiUrl: flags.apiUrl,
+        };
   const { exitCode } = await runInit(opts);
   return exitCode;
 }

--- a/packages/mcp/bin/init.ts
+++ b/packages/mcp/bin/init.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env bun
+/**
+ * `bunx @useatlas/mcp init` entry point.
+ *
+ * Generates a paste-ready Claude Desktop / Cursor / Continue config for
+ * Atlas's MCP server. Pass `--write` to merge into the detected client's
+ * config file (with a `.bak` of any previous file).
+ *
+ * Usage:
+ *   bunx @useatlas/mcp init --local
+ *   bunx @useatlas/mcp init --local --write
+ *   bunx @useatlas/mcp init --local --client cursor --write
+ *   bunx @useatlas/mcp init --hosted   # stub — comes with #2024
+ *
+ * From this monorepo (until @useatlas/mcp ships to npm):
+ *   bun packages/mcp/bin/init.ts --local
+ */
+
+import { runInit, type RunInitOptions } from "../src/init/index.js";
+import type { McpClientId } from "../src/init/clients.js";
+
+const KNOWN_CLIENTS: McpClientId[] = ["claude-desktop", "cursor", "continue", "generic"];
+
+interface CliFlags {
+  mode: "local" | "hosted" | null;
+  client: McpClientId | undefined;
+  write: boolean;
+  apiUrl: string | undefined;
+  help: boolean;
+}
+
+function parseArgs(argv: string[]): CliFlags {
+  const flags: CliFlags = {
+    mode: null,
+    client: undefined,
+    write: false,
+    apiUrl: undefined,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case "--local":
+        flags.mode = "local";
+        break;
+      case "--hosted":
+        flags.mode = "hosted";
+        break;
+      case "--write":
+        flags.write = true;
+        break;
+      case "--no-write":
+        flags.write = false;
+        break;
+      case "-h":
+      case "--help":
+        flags.help = true;
+        break;
+      case "--client": {
+        const next = argv[i + 1];
+        if (!next || !KNOWN_CLIENTS.includes(next as McpClientId)) {
+          console.error(
+            `[atlas-mcp init] --client expects one of: ${KNOWN_CLIENTS.join(", ")}`,
+          );
+          process.exit(1);
+        }
+        flags.client = next as McpClientId;
+        i++;
+        break;
+      }
+      case "--api-url":
+        flags.apiUrl = argv[i + 1];
+        i++;
+        break;
+      default:
+        console.error(`[atlas-mcp init] Unknown flag: ${a}`);
+        process.exit(1);
+    }
+  }
+
+  return flags;
+}
+
+const HELP = `bunx @useatlas/mcp init [options]
+
+  --local            Configure for a local Atlas (default if --hosted not set)
+  --hosted           Configure for app.useatlas.dev (coming with #2024)
+  --client <id>      Force a specific client: claude-desktop | cursor | continue | generic
+  --write            Merge into the client's config file (with a .bak backup)
+  --api-url <url>    Override local Atlas detection URL (default: http://localhost:3001)
+  -h, --help         Show this help
+
+Examples:
+  bunx @useatlas/mcp init --local
+  bunx @useatlas/mcp init --local --write
+  bunx @useatlas/mcp init --local --client cursor --write
+`;
+
+async function main(): Promise<number> {
+  const flags = parseArgs(process.argv.slice(2));
+  if (flags.help) {
+    console.log(HELP);
+    return 0;
+  }
+
+  if (flags.mode === null) {
+    // Default to --local for now; the auto-detect prompt described in #2018
+    // can land alongside --hosted in a follow-up since it depends on the
+    // hosted flow.
+    flags.mode = "local";
+  }
+
+  const opts: RunInitOptions = {
+    mode: flags.mode,
+    client: flags.client,
+    write: flags.write,
+    apiUrl: flags.apiUrl,
+  };
+  const { exitCode } = await runInit(opts);
+  return exitCode;
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[atlas-mcp init] Fatal: ${msg}`);
+    if (err instanceof Error && err.stack) {
+      console.error(err.stack);
+    }
+    process.exit(1);
+  });

--- a/packages/mcp/fixtures/seed.sql
+++ b/packages/mcp/fixtures/seed.sql
@@ -1,0 +1,52 @@
+-- Atlas MCP demo fixture — small accounts/companies/people dataset.
+-- Hydrated by `bunx @useatlas/mcp serve` into a local SQLite file when no
+-- ATLAS_DATASOURCE_URL is configured. Schema mirrors a tiny CRM so the
+-- bundled semantic layer (companies, accounts, people) lights up the
+-- explore + executeSQL tools out of the box.
+
+CREATE TABLE IF NOT EXISTS companies (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  industry TEXT NOT NULL,
+  employees INTEGER NOT NULL,
+  founded_year INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS accounts (
+  id INTEGER PRIMARY KEY,
+  company_id INTEGER NOT NULL REFERENCES companies(id),
+  plan TEXT NOT NULL,
+  monthly_revenue_usd INTEGER NOT NULL,
+  status TEXT NOT NULL,
+  signed_up_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS people (
+  id INTEGER PRIMARY KEY,
+  company_id INTEGER NOT NULL REFERENCES companies(id),
+  full_name TEXT NOT NULL,
+  email TEXT NOT NULL,
+  role TEXT NOT NULL
+);
+
+INSERT INTO companies (id, name, industry, employees, founded_year) VALUES
+  (1, 'Acme Robotics', 'Manufacturing', 480, 1998),
+  (2, 'Northwind Trading', 'Retail', 120, 2014),
+  (3, 'Globex Analytics', 'Software', 65, 2019),
+  (4, 'Initech', 'Software', 240, 2003),
+  (5, 'Soylent Foods', 'CPG', 1100, 1985);
+
+INSERT INTO accounts (id, company_id, plan, monthly_revenue_usd, status, signed_up_at) VALUES
+  (101, 1, 'enterprise', 24000, 'active', '2024-02-11'),
+  (102, 2, 'team',         3200, 'active', '2024-09-03'),
+  (103, 3, 'starter',       490, 'trialing', '2025-01-22'),
+  (104, 4, 'enterprise', 18500, 'active', '2023-08-30'),
+  (105, 5, 'team',         5400, 'churned', '2022-04-17');
+
+INSERT INTO people (id, company_id, full_name, email, role) VALUES
+  (1001, 1, 'Maya Chen',     'maya@acme.example',     'VP Engineering'),
+  (1002, 1, 'Tom Patel',     'tom@acme.example',      'Data Lead'),
+  (1003, 2, 'Priya Anand',   'priya@northwind.example','Head of Sales'),
+  (1004, 3, 'Lars Olafsen',  'lars@globex.example',   'CEO'),
+  (1005, 4, 'Bill Lumbergh', 'bill@initech.example',  'COO'),
+  (1006, 5, 'Sam Reyes',     'sam@soylent.example',   'Director of Ops');

--- a/packages/mcp/fixtures/seed.sql
+++ b/packages/mcp/fixtures/seed.sql
@@ -1,8 +1,8 @@
 -- Atlas MCP demo fixture — small accounts/companies/people dataset.
--- Hydrated by `bunx @useatlas/mcp serve` into a local SQLite file when no
--- ATLAS_DATASOURCE_URL is configured. Schema mirrors a tiny CRM so the
--- bundled semantic layer (companies, accounts, people) lights up the
--- explore + executeSQL tools out of the box.
+-- Loaded into a SQLite file by the demo-fixture hydrator (planned follow-up;
+-- the `init` flow already emits the target sqlite:// path). Schema mirrors
+-- a tiny CRM so the bundled semantic layer lights up the explore +
+-- executeSQL tools.
 
 CREATE TABLE IF NOT EXISTS companies (
   id INTEGER PRIMARY KEY,

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -8,7 +8,8 @@
     "./sse": "./src/sse.ts"
   },
   "bin": {
-    "atlas-mcp": "./bin/serve.ts"
+    "atlas-mcp": "./bin/serve.ts",
+    "atlas-mcp-init": "./bin/init.ts"
   },
   "scripts": {
     "dev": "bun run --hot bin/serve.ts",

--- a/packages/mcp/src/__tests__/init/clients.test.ts
+++ b/packages/mcp/src/__tests__/init/clients.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test";
+import { detectClients, getDefaultConfigPath } from "../../init/clients.js";
+
+const HOME_DARWIN = "/Users/test";
+const HOME_LINUX = "/home/test";
+const HOME_WINDOWS = "C:\\Users\\test";
+
+describe("getDefaultConfigPath", () => {
+  it("returns the macOS Claude Desktop path", () => {
+    const p = getDefaultConfigPath("claude-desktop", { home: HOME_DARWIN, platform: "darwin" });
+    expect(p).toBe(`${HOME_DARWIN}/Library/Application Support/Claude/claude_desktop_config.json`);
+  });
+
+  it("returns the Linux Claude Desktop path under XDG config", () => {
+    const p = getDefaultConfigPath("claude-desktop", { home: HOME_LINUX, platform: "linux" });
+    expect(p).toBe(`${HOME_LINUX}/.config/Claude/claude_desktop_config.json`);
+  });
+
+  it("returns the Windows Claude Desktop path", () => {
+    const p = getDefaultConfigPath("claude-desktop", { home: HOME_WINDOWS, platform: "win32" });
+    expect(p).not.toBeNull();
+    expect(p!.includes("Claude")).toBe(true);
+    expect(p!.endsWith("claude_desktop_config.json")).toBe(true);
+  });
+
+  it("returns the Cursor path under ~/.cursor on all platforms", () => {
+    const macP = getDefaultConfigPath("cursor", { home: HOME_DARWIN, platform: "darwin" });
+    expect(macP).toBe(`${HOME_DARWIN}/.cursor/mcp.json`);
+    const linP = getDefaultConfigPath("cursor", { home: HOME_LINUX, platform: "linux" });
+    expect(linP).toBe(`${HOME_LINUX}/.cursor/mcp.json`);
+  });
+
+  it("returns the Continue path under ~/.continue", () => {
+    const p = getDefaultConfigPath("continue", { home: HOME_DARWIN, platform: "darwin" });
+    expect(p).toBe(`${HOME_DARWIN}/.continue/config.json`);
+  });
+
+  it("returns null for the generic client (no config file)", () => {
+    const p = getDefaultConfigPath("generic", { home: HOME_DARWIN, platform: "darwin" });
+    expect(p).toBeNull();
+  });
+});
+
+describe("detectClients", () => {
+  it("returns an entry for every known client and never throws on a fresh machine", () => {
+    const clients = detectClients({ home: HOME_DARWIN, platform: "darwin", existsSync: () => false });
+    const ids = clients.map((c) => c.id).sort();
+    expect(ids).toEqual(["claude-desktop", "continue", "cursor", "generic"]);
+    for (const c of clients) {
+      if (c.id === "generic") {
+        expect(c.detected).toBe(false);
+        expect(c.configPath).toBeNull();
+      } else {
+        expect(typeof c.configPath).toBe("string");
+        expect(c.detected).toBe(false);
+      }
+    }
+  });
+
+  it("marks a client detected when its config file exists", () => {
+    const clientsCfg = `${HOME_DARWIN}/Library/Application Support/Claude/claude_desktop_config.json`;
+    const clients = detectClients({
+      home: HOME_DARWIN,
+      platform: "darwin",
+      existsSync: (p: string) => p === clientsCfg,
+    });
+    const claude = clients.find((c) => c.id === "claude-desktop");
+    expect(claude?.detected).toBe(true);
+    const cursor = clients.find((c) => c.id === "cursor");
+    expect(cursor?.detected).toBe(false);
+  });
+});

--- a/packages/mcp/src/__tests__/init/config-merge.test.ts
+++ b/packages/mcp/src/__tests__/init/config-merge.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildServerConfig,
+  mergeMcpServerConfig,
+  writeConfigWithBackup,
+} from "../../init/config-merge.js";
+
+const SERVER_NAME = "atlas";
+const SERVER = {
+  command: "bunx",
+  args: ["@useatlas/mcp", "serve"],
+  env: { ATLAS_DATASOURCE_URL: "sqlite:///tmp/demo.sqlite" },
+};
+
+describe("buildServerConfig", () => {
+  it("emits a bunx command pointing at the public package name", () => {
+    const cfg = buildServerConfig({ datasourceUrl: "postgresql://localhost/x" });
+    expect(cfg.command).toBe("bunx");
+    expect(cfg.args).toEqual(["@useatlas/mcp", "serve"]);
+    expect(cfg.env?.ATLAS_DATASOURCE_URL).toBe("postgresql://localhost/x");
+  });
+
+  it("omits ATLAS_DATASOURCE_URL when undefined (caller inherits shell env)", () => {
+    const cfg = buildServerConfig({ datasourceUrl: undefined });
+    expect(cfg.env).toBeUndefined();
+  });
+
+  it("never embeds an absolute path in command or args", () => {
+    const cfg = buildServerConfig({ datasourceUrl: undefined });
+    expect(cfg.command.startsWith("/")).toBe(false);
+    for (const a of cfg.args) {
+      expect(a.startsWith("/")).toBe(false);
+    }
+  });
+});
+
+describe("mergeMcpServerConfig", () => {
+  it("creates a new mcpServers object when input is null (no existing config)", () => {
+    const out = mergeMcpServerConfig(null, SERVER_NAME, SERVER);
+    const parsed = JSON.parse(out);
+    expect(parsed.mcpServers).toBeDefined();
+    expect(parsed.mcpServers[SERVER_NAME].command).toBe("bunx");
+  });
+
+  it("preserves existing servers under mcpServers", () => {
+    const existing = JSON.stringify({
+      mcpServers: {
+        github: { command: "npx", args: ["@modelcontextprotocol/server-github"] },
+      },
+    });
+    const out = mergeMcpServerConfig(existing, SERVER_NAME, SERVER);
+    const parsed = JSON.parse(out);
+    expect(parsed.mcpServers.github).toBeDefined();
+    expect(parsed.mcpServers.github.command).toBe("npx");
+    expect(parsed.mcpServers[SERVER_NAME].command).toBe("bunx");
+  });
+
+  it("overwrites only the named entry, not siblings", () => {
+    const existing = JSON.stringify({
+      mcpServers: {
+        atlas: { command: "old", args: ["old-args"] },
+        keep: { command: "x" },
+      },
+    });
+    const out = mergeMcpServerConfig(existing, SERVER_NAME, SERVER);
+    const parsed = JSON.parse(out);
+    expect(parsed.mcpServers.atlas.command).toBe("bunx");
+    expect(parsed.mcpServers.keep.command).toBe("x");
+  });
+
+  it("preserves top-level keys that are not mcpServers", () => {
+    const existing = JSON.stringify({
+      otherTopLevel: { foo: "bar" },
+      mcpServers: {},
+    });
+    const out = mergeMcpServerConfig(existing, SERVER_NAME, SERVER);
+    const parsed = JSON.parse(out);
+    expect(parsed.otherTopLevel).toEqual({ foo: "bar" });
+  });
+
+  it("throws a clear error when input is not valid JSON", () => {
+    expect(() => mergeMcpServerConfig("{ this is not json", SERVER_NAME, SERVER)).toThrow(
+      /not valid JSON/i,
+    );
+  });
+
+  it("throws when existing config has mcpServers as a non-object", () => {
+    const existing = JSON.stringify({ mcpServers: "oops" });
+    expect(() => mergeMcpServerConfig(existing, SERVER_NAME, SERVER)).toThrow(
+      /mcpServers/i,
+    );
+  });
+});
+
+describe("writeConfigWithBackup", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "atlas-mcp-init-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("creates the config file (and parent dir) when it does not exist; backupPath null", async () => {
+    const target = join(dir, "nested", "claude_desktop_config.json");
+    const result = await writeConfigWithBackup(target, '{"mcpServers":{}}\n');
+    expect(result.backupPath).toBeNull();
+    expect(existsSync(target)).toBe(true);
+    expect(readFileSync(target, "utf8")).toBe('{"mcpServers":{}}\n');
+  });
+
+  it("writes a .bak file before overwriting an existing config", async () => {
+    const target = join(dir, "config.json");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(target, '{"mcpServers":{"old":{"command":"x"}}}\n', "utf8");
+    const result = await writeConfigWithBackup(target, '{"mcpServers":{}}\n');
+    expect(result.backupPath).toBeTruthy();
+    expect(existsSync(result.backupPath!)).toBe(true);
+    const bak = readFileSync(result.backupPath!, "utf8");
+    expect(bak).toContain("\"old\"");
+    const after = readFileSync(target, "utf8");
+    expect(after).toBe('{"mcpServers":{}}\n');
+  });
+
+  it("does not clobber an existing .bak — uses a timestamped suffix", async () => {
+    const target = join(dir, "config.json");
+    writeFileSync(target, "{}", "utf8");
+    writeFileSync(`${target}.bak`, '{"prev-bak":true}', "utf8");
+    const result = await writeConfigWithBackup(target, "{}");
+    expect(result.backupPath).toBeTruthy();
+    expect(result.backupPath).not.toBe(`${target}.bak`);
+    expect(readFileSync(`${target}.bak`, "utf8")).toBe('{"prev-bak":true}');
+  });
+});

--- a/packages/mcp/src/__tests__/init/config-merge.test.ts
+++ b/packages/mcp/src/__tests__/init/config-merge.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync, mkdirSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -93,6 +93,25 @@ describe("mergeMcpServerConfig", () => {
       /mcpServers/i,
     );
   });
+
+  it("throws when the existing config root is a JSON array", () => {
+    expect(() => mergeMcpServerConfig("[]", SERVER_NAME, SERVER)).toThrow(
+      /JSON object/i,
+    );
+  });
+
+  it("throws when the existing config root is JSON null", () => {
+    expect(() => mergeMcpServerConfig("null", SERVER_NAME, SERVER)).toThrow(
+      /JSON object/i,
+    );
+  });
+
+  it("throws when mcpServers is an array (catches the Array.isArray guard)", () => {
+    const existing = JSON.stringify({ mcpServers: [] });
+    expect(() => mergeMcpServerConfig(existing, SERVER_NAME, SERVER)).toThrow(
+      /mcpServers/i,
+    );
+  });
 });
 
 describe("writeConfigWithBackup", () => {
@@ -125,6 +144,14 @@ describe("writeConfigWithBackup", () => {
     expect(bak).toContain("\"old\"");
     const after = readFileSync(target, "utf8");
     expect(after).toBe('{"mcpServers":{}}\n');
+  });
+
+  it("writes the config file with mode 0o600 on POSIX (creds-bearing dotfile)", async () => {
+    if (process.platform === "win32") return;
+    const target = join(dir, "config.json");
+    await writeConfigWithBackup(target, "{}");
+    const mode = statSync(target).mode & 0o777;
+    expect(mode).toBe(0o600);
   });
 
   it("does not clobber an existing .bak — uses a timestamped suffix", async () => {

--- a/packages/mcp/src/__tests__/init/fixture.test.ts
+++ b/packages/mcp/src/__tests__/init/fixture.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import {
+  resolveFixturePaths,
+  shouldUseFixture,
+} from "../../init/fixture.js";
+
+describe("shouldUseFixture", () => {
+  it("returns true when ATLAS_DATASOURCE_URL is unset", () => {
+    expect(shouldUseFixture({})).toBe(true);
+  });
+
+  it("returns true when ATLAS_DATASOURCE_URL is empty", () => {
+    expect(shouldUseFixture({ ATLAS_DATASOURCE_URL: "" })).toBe(true);
+  });
+
+  it("returns false when ATLAS_DATASOURCE_URL has any value", () => {
+    expect(
+      shouldUseFixture({ ATLAS_DATASOURCE_URL: "postgres://x" }),
+    ).toBe(false);
+  });
+});
+
+describe("resolveFixturePaths", () => {
+  it("resolves a real seed.sql shipped with the package", () => {
+    const { seedPath } = resolveFixturePaths();
+    expect(existsSync(seedPath)).toBe(true);
+    const seed = readFileSync(seedPath, "utf8");
+    expect(seed).toContain("CREATE TABLE IF NOT EXISTS companies");
+    expect(seed).toContain("CREATE TABLE IF NOT EXISTS people");
+  });
+
+  it("returns a sqlite URL pointing into a per-user cache dir", () => {
+    const { sqliteUrl, sqlitePath } = resolveFixturePaths();
+    expect(sqliteUrl.startsWith("sqlite://")).toBe(true);
+    expect(sqliteUrl.endsWith(".sqlite")).toBe(true);
+    expect(sqlitePath).toMatch(/atlas-mcp/);
+  });
+
+  it("respects an injected cache dir for testability", () => {
+    const fake = "/tmp/atlas-test-cache";
+    const { sqlitePath } = resolveFixturePaths({ cacheDir: fake });
+    expect(sqlitePath.startsWith(fake)).toBe(true);
+  });
+});

--- a/packages/mcp/src/__tests__/init/local-atlas.test.ts
+++ b/packages/mcp/src/__tests__/init/local-atlas.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test";
+import { detectLocalAtlas } from "../../init/local-atlas.js";
+
+const HEALTHY = { ok: true, status: 200 } as Response;
+const UNHEALTHY = { ok: false, status: 500 } as Response;
+
+describe("detectLocalAtlas", () => {
+  it("returns true when /api/v1/health responds 2xx at the configured URL", async () => {
+    const calls: string[] = [];
+    const fetchImpl = (async (url: string) => {
+      calls.push(url);
+      return HEALTHY;
+    }) as unknown as typeof fetch;
+    const found = await detectLocalAtlas({
+      url: "http://localhost:3001",
+      fetchImpl,
+      timeoutMs: 100,
+    });
+    expect(found).toBe(true);
+    expect(calls[0]).toBe("http://localhost:3001/api/v1/health");
+  });
+
+  it("returns false when fetch throws (connection refused)", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const found = await detectLocalAtlas({
+      url: "http://localhost:3001",
+      fetchImpl,
+      timeoutMs: 100,
+    });
+    expect(found).toBe(false);
+  });
+
+  it("returns false when the server responds with non-2xx", async () => {
+    const fetchImpl = (async () => UNHEALTHY) as unknown as typeof fetch;
+    const found = await detectLocalAtlas({
+      url: "http://localhost:3001",
+      fetchImpl,
+      timeoutMs: 100,
+    });
+    expect(found).toBe(false);
+  });
+
+  it("uses the URL from ATLAS_API_URL when explicitly provided", async () => {
+    const calls: string[] = [];
+    const fetchImpl = (async (url: string) => {
+      calls.push(url);
+      return HEALTHY;
+    }) as unknown as typeof fetch;
+    await detectLocalAtlas({
+      url: "http://atlas.internal:9000",
+      fetchImpl,
+      timeoutMs: 100,
+    });
+    expect(calls[0]).toBe("http://atlas.internal:9000/api/v1/health");
+  });
+
+  it("returns false when fetch hangs past the timeout", async () => {
+    const fetchImpl = ((_url: string, init?: { signal?: AbortSignal }) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+      })) as unknown as typeof fetch;
+    const found = await detectLocalAtlas({
+      url: "http://localhost:3001",
+      fetchImpl,
+      timeoutMs: 5,
+    });
+    expect(found).toBe(false);
+  });
+});

--- a/packages/mcp/src/__tests__/init/run.test.ts
+++ b/packages/mcp/src/__tests__/init/run.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runInit } from "../../init/index.js";
+
+const HEALTHY = (async () => ({ ok: true, status: 200 }) as Response) as unknown as typeof fetch;
+const UNREACHABLE = (async () => {
+  throw new Error("ECONNREFUSED");
+}) as unknown as typeof fetch;
+
+function captureStdio(): { logs: string[]; errs: string[]; restore: () => void } {
+  const logs: string[] = [];
+  const errs: string[] = [];
+  const origLog = console.log;
+  const origErr = console.error;
+  console.log = (...args: unknown[]) => {
+    logs.push(args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" "));
+  };
+  console.error = (...args: unknown[]) => {
+    errs.push(args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" "));
+  };
+  return {
+    logs,
+    errs,
+    restore: () => {
+      console.log = origLog;
+      console.error = origErr;
+    },
+  };
+}
+
+describe("runInit --hosted (stub)", () => {
+  it("prints a 'coming with #2024' message and exits non-fatally", async () => {
+    const cap = captureStdio();
+    try {
+      const res = await runInit({ mode: "hosted" });
+      expect(res.exitCode).toBe(0);
+      const out = [...cap.logs, ...cap.errs].join("\n");
+      expect(out).toMatch(/#2024/);
+      expect(out).toMatch(/hosted/i);
+    } finally {
+      cap.restore();
+    }
+  });
+});
+
+describe("runInit --local (print-only, no --write)", () => {
+  it("prints a JSON snippet that uses bunx @useatlas/mcp serve", async () => {
+    const cap = captureStdio();
+    try {
+      const res = await runInit({
+        mode: "local",
+        client: "claude-desktop",
+        write: false,
+        env: {},
+        fetchImpl: UNREACHABLE,
+      });
+      expect(res.exitCode).toBe(0);
+      const out = cap.logs.join("\n");
+      expect(out).toContain("\"command\": \"bunx\"");
+      expect(out).toContain("\"@useatlas/mcp\"");
+      expect(out).toContain("\"serve\"");
+    } finally {
+      cap.restore();
+    }
+  });
+
+  it("falls back to the bundled fixture when ATLAS_DATASOURCE_URL is unset", async () => {
+    const cap = captureStdio();
+    try {
+      await runInit({
+        mode: "local",
+        client: "claude-desktop",
+        write: false,
+        env: {},
+        fetchImpl: UNREACHABLE,
+      });
+      const out = cap.logs.join("\n");
+      expect(out).toContain("ATLAS_DATASOURCE_URL");
+      expect(out).toContain("sqlite://");
+    } finally {
+      cap.restore();
+    }
+  });
+
+  it("prefers a local Atlas if /api/v1/health responds", async () => {
+    const cap = captureStdio();
+    try {
+      await runInit({
+        mode: "local",
+        client: "claude-desktop",
+        write: false,
+        env: {},
+        fetchImpl: HEALTHY,
+      });
+      const out = cap.logs.join("\n");
+      // When a local Atlas is detected we leave ATLAS_DATASOURCE_URL out so
+      // the MCP server inherits whatever the user's shell already exports.
+      expect(out).not.toContain("sqlite://");
+      expect(out).toMatch(/local Atlas detected/i);
+    } finally {
+      cap.restore();
+    }
+  });
+});
+
+describe("runInit --local --write", () => {
+  it("writes the merged config to the configPath", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "atlas-mcp-init-"));
+    const target = join(dir, "claude_desktop_config.json");
+    writeFileSync(
+      target,
+      JSON.stringify({
+        mcpServers: { github: { command: "npx", args: ["mcp-github"] } },
+      }),
+      "utf8",
+    );
+    const cap = captureStdio();
+    try {
+      const res = await runInit({
+        mode: "local",
+        client: "claude-desktop",
+        write: true,
+        configPathOverride: target,
+        env: {},
+        fetchImpl: UNREACHABLE,
+      });
+      expect(res.exitCode).toBe(0);
+      const written = JSON.parse(readFileSync(target, "utf8"));
+      expect(written.mcpServers.atlas.command).toBe("bunx");
+      expect(written.mcpServers.github.command).toBe("npx");
+    } finally {
+      cap.restore();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("creates the config when one does not yet exist", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "atlas-mcp-init-"));
+    const target = join(dir, "nested", "claude_desktop_config.json");
+    const cap = captureStdio();
+    try {
+      const res = await runInit({
+        mode: "local",
+        client: "claude-desktop",
+        write: true,
+        configPathOverride: target,
+        env: {},
+        fetchImpl: UNREACHABLE,
+      });
+      expect(res.exitCode).toBe(0);
+      const written = JSON.parse(readFileSync(target, "utf8"));
+      expect(written.mcpServers.atlas.command).toBe("bunx");
+    } finally {
+      cap.restore();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/mcp/src/__tests__/init/run.test.ts
+++ b/packages/mcp/src/__tests__/init/run.test.ts
@@ -31,13 +31,13 @@ function captureStdio(): { logs: string[]; errs: string[]; restore: () => void }
 }
 
 describe("runInit --hosted (stub)", () => {
-  it("prints a 'coming with #2024' message and exits non-fatally", async () => {
+  it("prints a tracking-issue link and exits non-fatally", async () => {
     const cap = captureStdio();
     try {
       const res = await runInit({ mode: "hosted" });
       expect(res.exitCode).toBe(0);
       const out = [...cap.logs, ...cap.errs].join("\n");
-      expect(out).toMatch(/#2024/);
+      expect(out).toMatch(/issues\/2024/);
       expect(out).toMatch(/hosted/i);
     } finally {
       cap.restore();
@@ -105,6 +105,74 @@ describe("runInit --local (print-only, no --write)", () => {
   });
 });
 
+describe("runInit --local default client", () => {
+  it("falls back to claude-desktop when nothing is detected", async () => {
+    const cap = captureStdio();
+    try {
+      await runInit({
+        mode: "local",
+        write: false,
+        env: { ATLAS_DATASOURCE_URL: "postgres://x" },
+        fetchImpl: UNREACHABLE,
+        detectClientsImpl: () => [
+          { id: "claude-desktop", name: "Claude Desktop", configPath: "/x", detected: false },
+          { id: "cursor", name: "Cursor", configPath: "/y", detected: false },
+          { id: "continue", name: "Continue", configPath: "/z", detected: false },
+          { id: "generic", name: "Generic MCP client", configPath: null, detected: false },
+        ],
+      });
+      const out = cap.logs.join("\n");
+      expect(out).toContain("# claude-desktop");
+    } finally {
+      cap.restore();
+    }
+  });
+
+  it("picks the first detected non-generic client", async () => {
+    const cap = captureStdio();
+    try {
+      await runInit({
+        mode: "local",
+        write: false,
+        env: { ATLAS_DATASOURCE_URL: "postgres://x" },
+        fetchImpl: UNREACHABLE,
+        detectClientsImpl: () => [
+          { id: "claude-desktop", name: "Claude Desktop", configPath: "/x", detected: false },
+          { id: "cursor", name: "Cursor", configPath: "/y", detected: true },
+          { id: "continue", name: "Continue", configPath: "/z", detected: true },
+          { id: "generic", name: "Generic MCP client", configPath: null, detected: false },
+        ],
+      });
+      const out = cap.logs.join("\n");
+      expect(out).toContain("# cursor");
+    } finally {
+      cap.restore();
+    }
+  });
+});
+
+describe("runInit --local datasource selection", () => {
+  it("never bakes ATLAS_DATASOURCE_URL into the snippet when the user has it set", async () => {
+    const cap = captureStdio();
+    try {
+      await runInit({
+        mode: "local",
+        client: "claude-desktop",
+        write: false,
+        env: { ATLAS_DATASOURCE_URL: "postgres://user:secret@host/db" },
+        fetchImpl: UNREACHABLE,
+      });
+      const out = cap.logs.join("\n");
+      expect(out).not.toContain("postgres://");
+      expect(out).not.toContain("secret");
+      expect(out).not.toMatch(/"env":\s*\{/);
+      expect(out).not.toContain("sqlite://");
+    } finally {
+      cap.restore();
+    }
+  });
+});
+
 describe("runInit --local --write", () => {
   it("writes the merged config to the configPath", async () => {
     const dir = mkdtempSync(join(tmpdir(), "atlas-mcp-init-"));
@@ -130,6 +198,30 @@ describe("runInit --local --write", () => {
       const written = JSON.parse(readFileSync(target, "utf8"));
       expect(written.mcpServers.atlas.command).toBe("bunx");
       expect(written.mcpServers.github.command).toBe("npx");
+    } finally {
+      cap.restore();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("aborts and leaves the file byte-identical when the existing mcpServers is a non-object", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "atlas-mcp-init-"));
+    const target = join(dir, "claude_desktop_config.json");
+    const original = JSON.stringify({ mcpServers: "not-an-object", other: 1 });
+    writeFileSync(target, original, "utf8");
+    const cap = captureStdio();
+    try {
+      const res = await runInit({
+        mode: "local",
+        client: "claude-desktop",
+        write: true,
+        configPathOverride: target,
+        env: {},
+        fetchImpl: UNREACHABLE,
+      });
+      expect(res.exitCode).toBe(1);
+      const after = readFileSync(target, "utf8");
+      expect(after).toBe(original);
     } finally {
       cap.restore();
       rmSync(dir, { recursive: true, force: true });

--- a/packages/mcp/src/init/clients.ts
+++ b/packages/mcp/src/init/clients.ts
@@ -1,0 +1,77 @@
+/**
+ * MCP client detection — finds the default config-file path for known clients
+ * (Claude Desktop, Cursor, Continue) on macOS, Linux, and Windows.
+ *
+ * Pure functions over an injectable `home`, `platform`, and `existsSync`
+ * so tests run cross-platform without touching the real filesystem.
+ */
+
+import { existsSync as fsExistsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export type McpClientId = "claude-desktop" | "cursor" | "continue" | "generic";
+
+export interface ClientInfo {
+  id: McpClientId;
+  name: string;
+  /** Path to the client's MCP config file, or null for the generic stub. */
+  configPath: string | null;
+  /** True when the config file currently exists on disk. */
+  detected: boolean;
+}
+
+interface PathOpts {
+  home?: string;
+  platform?: NodeJS.Platform;
+}
+
+interface DetectOpts extends PathOpts {
+  existsSync?: (p: string) => boolean;
+}
+
+const KNOWN_CLIENTS: ReadonlyArray<{ id: McpClientId; name: string }> = [
+  { id: "claude-desktop", name: "Claude Desktop" },
+  { id: "cursor", name: "Cursor" },
+  { id: "continue", name: "Continue" },
+  { id: "generic", name: "Generic MCP client" },
+];
+
+function resolveHome(opts: PathOpts): string {
+  return opts.home ?? homedir();
+}
+
+function resolvePlatform(opts: PathOpts): NodeJS.Platform {
+  return opts.platform ?? process.platform;
+}
+
+export function getDefaultConfigPath(id: McpClientId, opts: PathOpts = {}): string | null {
+  const home = resolveHome(opts);
+  const platform = resolvePlatform(opts);
+
+  switch (id) {
+    case "claude-desktop":
+      if (platform === "darwin") {
+        return join(home, "Library", "Application Support", "Claude", "claude_desktop_config.json");
+      }
+      if (platform === "win32") {
+        return join(home, "AppData", "Roaming", "Claude", "claude_desktop_config.json");
+      }
+      return join(home, ".config", "Claude", "claude_desktop_config.json");
+    case "cursor":
+      return join(home, ".cursor", "mcp.json");
+    case "continue":
+      return join(home, ".continue", "config.json");
+    case "generic":
+      return null;
+  }
+}
+
+export function detectClients(opts: DetectOpts = {}): ClientInfo[] {
+  const exists = opts.existsSync ?? fsExistsSync;
+  return KNOWN_CLIENTS.map(({ id, name }) => {
+    const configPath = getDefaultConfigPath(id, opts);
+    const detected = configPath !== null && exists(configPath);
+    return { id, name, configPath, detected };
+  });
+}

--- a/packages/mcp/src/init/clients.ts
+++ b/packages/mcp/src/init/clients.ts
@@ -1,16 +1,20 @@
 /**
- * MCP client detection — finds the default config-file path for known clients
- * (Claude Desktop, Cursor, Continue) on macOS, Linux, and Windows.
- *
- * Pure functions over an injectable `home`, `platform`, and `existsSync`
- * so tests run cross-platform without touching the real filesystem.
+ * MCP client detection — default config-file paths for Claude Desktop,
+ * Cursor, and Continue on macOS, Linux, and Windows.
  */
 
 import { existsSync as fsExistsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-export type McpClientId = "claude-desktop" | "cursor" | "continue" | "generic";
+export const KNOWN_CLIENTS = [
+  { id: "claude-desktop", name: "Claude Desktop" },
+  { id: "cursor", name: "Cursor" },
+  { id: "continue", name: "Continue" },
+  { id: "generic", name: "Generic MCP client" },
+] as const satisfies ReadonlyArray<{ id: string; name: string }>;
+
+export type McpClientId = (typeof KNOWN_CLIENTS)[number]["id"];
 
 export interface ClientInfo {
   id: McpClientId;
@@ -29,13 +33,6 @@ interface PathOpts {
 interface DetectOpts extends PathOpts {
   existsSync?: (p: string) => boolean;
 }
-
-const KNOWN_CLIENTS: ReadonlyArray<{ id: McpClientId; name: string }> = [
-  { id: "claude-desktop", name: "Claude Desktop" },
-  { id: "cursor", name: "Cursor" },
-  { id: "continue", name: "Continue" },
-  { id: "generic", name: "Generic MCP client" },
-];
 
 function resolveHome(opts: PathOpts): string {
   return opts.home ?? homedir();

--- a/packages/mcp/src/init/config-merge.ts
+++ b/packages/mcp/src/init/config-merge.ts
@@ -1,0 +1,113 @@
+/**
+ * MCP client config merging.
+ *
+ * Builds a `mcpServers["<name>"]` block, merges it into an existing JSON
+ * config (preserving sibling servers + non-mcp top-level keys), and writes
+ * the result with a `.bak` of any previous file.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+export interface ServerConfig {
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
+interface BuildOpts {
+  /** Inline ATLAS_DATASOURCE_URL into the env block. Omit to inherit the user's shell env. */
+  datasourceUrl?: string;
+  /** Override the package name used in the bunx invocation. Defaults to @useatlas/mcp. */
+  packageName?: string;
+}
+
+const DEFAULT_PACKAGE = "@useatlas/mcp";
+
+export function buildServerConfig(opts: BuildOpts = {}): ServerConfig {
+  const pkg = opts.packageName ?? DEFAULT_PACKAGE;
+  const cfg: ServerConfig = {
+    command: "bunx",
+    args: [pkg, "serve"],
+  };
+  if (opts.datasourceUrl) {
+    cfg.env = { ATLAS_DATASOURCE_URL: opts.datasourceUrl };
+  }
+  return cfg;
+}
+
+interface ExistingShape {
+  mcpServers?: unknown;
+  [key: string]: unknown;
+}
+
+export function mergeMcpServerConfig(
+  existingJson: string | null,
+  serverName: string,
+  serverConfig: ServerConfig,
+): string {
+  let parsed: ExistingShape = {};
+  if (existingJson !== null) {
+    try {
+      const raw = JSON.parse(existingJson) as unknown;
+      if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+        throw new Error("Existing config root must be a JSON object");
+      }
+      parsed = raw as ExistingShape;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`Existing config is not valid JSON: ${msg}`, { cause: err });
+    }
+  }
+
+  const existingServers = parsed.mcpServers;
+  let serversObj: Record<string, ServerConfig>;
+  if (existingServers === undefined) {
+    serversObj = {};
+  } else if (
+    existingServers === null ||
+    typeof existingServers !== "object" ||
+    Array.isArray(existingServers)
+  ) {
+    throw new Error(
+      "Existing config has a non-object value at `mcpServers` — refusing to overwrite",
+    );
+  } else {
+    serversObj = { ...(existingServers as Record<string, ServerConfig>) };
+  }
+
+  serversObj[serverName] = serverConfig;
+  const merged: ExistingShape = { ...parsed, mcpServers: serversObj };
+  return `${JSON.stringify(merged, null, 2)}\n`;
+}
+
+export interface WriteResult {
+  /** Path to the .bak file we wrote, or null if no prior config existed. */
+  backupPath: string | null;
+}
+
+export async function writeConfigWithBackup(
+  configPath: string,
+  newContent: string,
+): Promise<WriteResult> {
+  let backupPath: string | null = null;
+
+  if (existsSync(configPath)) {
+    backupPath = `${configPath}.bak`;
+    if (existsSync(backupPath)) {
+      const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+      backupPath = `${configPath}.${stamp}.bak`;
+    }
+    copyFileSync(configPath, backupPath);
+  } else {
+    mkdirSync(dirname(configPath), { recursive: true });
+  }
+
+  writeFileSync(configPath, newContent, { encoding: "utf8", mode: 0o600 });
+  return { backupPath };
+}
+
+export function readConfigOrNull(configPath: string): string | null {
+  if (!existsSync(configPath)) return null;
+  return readFileSync(configPath, "utf8");
+}

--- a/packages/mcp/src/init/config-merge.ts
+++ b/packages/mcp/src/init/config-merge.ts
@@ -1,9 +1,8 @@
 /**
- * MCP client config merging.
- *
  * Builds a `mcpServers["<name>"]` block, merges it into an existing JSON
  * config (preserving sibling servers + non-mcp top-level keys), and writes
- * the result with a `.bak` of any previous file.
+ * the result with a `.bak` of any previous file (timestamped if one already
+ * exists).
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync } from "node:fs";
@@ -61,7 +60,10 @@ export function mergeMcpServerConfig(
   }
 
   const existingServers = parsed.mcpServers;
-  let serversObj: Record<string, ServerConfig>;
+  // We never inspect sibling server values — only spread them through. So the
+  // value type is `unknown`, not `ServerConfig`. A future "list existing
+  // servers" feature would need to narrow per-entry before reading anything.
+  let serversObj: Record<string, unknown>;
   if (existingServers === undefined) {
     serversObj = {};
   } else if (
@@ -73,7 +75,7 @@ export function mergeMcpServerConfig(
       "Existing config has a non-object value at `mcpServers` — refusing to overwrite",
     );
   } else {
-    serversObj = { ...(existingServers as Record<string, ServerConfig>) };
+    serversObj = { ...(existingServers as Record<string, unknown>) };
   }
 
   serversObj[serverName] = serverConfig;

--- a/packages/mcp/src/init/fixture.ts
+++ b/packages/mcp/src/init/fixture.ts
@@ -1,0 +1,50 @@
+/**
+ * Bundled demo fixture path resolution.
+ *
+ * `init --local` falls back to a tiny accounts/companies/people SQLite
+ * fixture when `ATLAS_DATASOURCE_URL` is unset, so a fresh user gets a
+ * working install with zero config. The `serve` side hydrates the SQLite
+ * file from `seed.sql` on first run; here we just resolve the canonical
+ * paths and the URL string written into the client config.
+ */
+
+import { fileURLToPath } from "node:url";
+import { join, resolve } from "node:path";
+import { homedir } from "node:os";
+
+interface ResolveOpts {
+  cacheDir?: string;
+}
+
+export interface FixturePaths {
+  /** Absolute path to the bundled seed.sql shipped inside the package. */
+  seedPath: string;
+  /** Absolute path where the hydrated SQLite file will live on disk. */
+  sqlitePath: string;
+  /** Datasource URL string suitable for ATLAS_DATASOURCE_URL. */
+  sqliteUrl: string;
+}
+
+function defaultCacheDir(): string {
+  if (process.env.XDG_CACHE_HOME) {
+    return join(process.env.XDG_CACHE_HOME, "atlas-mcp");
+  }
+  return join(homedir(), ".cache", "atlas-mcp");
+}
+
+export function resolveFixturePaths(opts: ResolveOpts = {}): FixturePaths {
+  // import.meta.url here resolves to the .ts source in dev, .js bundle if
+  // built. Either way, ../../fixtures/seed.sql is the right relative path
+  // because seed.sql sits alongside src/ inside the package root.
+  const here = fileURLToPath(import.meta.url);
+  const seedPath = resolve(here, "..", "..", "..", "fixtures", "seed.sql");
+  const cacheDir = opts.cacheDir ?? defaultCacheDir();
+  const sqlitePath = join(cacheDir, "demo.sqlite");
+  const sqliteUrl = `sqlite://${sqlitePath}`;
+  return { seedPath, sqlitePath, sqliteUrl };
+}
+
+export function shouldUseFixture(env: Record<string, string | undefined>): boolean {
+  const url = env.ATLAS_DATASOURCE_URL;
+  return url === undefined || url === "";
+}

--- a/packages/mcp/src/init/fixture.ts
+++ b/packages/mcp/src/init/fixture.ts
@@ -1,19 +1,17 @@
 /**
- * Bundled demo fixture path resolution.
- *
- * `init --local` falls back to a tiny accounts/companies/people SQLite
- * fixture when `ATLAS_DATASOURCE_URL` is unset, so a fresh user gets a
- * working install with zero config. The `serve` side hydrates the SQLite
- * file from `seed.sql` on first run; here we just resolve the canonical
- * paths and the URL string written into the client config.
+ * Resolves the bundled accounts/companies/people SQLite fixture used as the
+ * fallback datasource when `ATLAS_DATASOURCE_URL` is unset.
  */
 
+import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { join, resolve } from "node:path";
 import { homedir } from "node:os";
 
 interface ResolveOpts {
   cacheDir?: string;
+  /** Override the existsSync check (test seam). */
+  existsSync?: (p: string) => boolean;
 }
 
 export interface FixturePaths {
@@ -33,11 +31,17 @@ function defaultCacheDir(): string {
 }
 
 export function resolveFixturePaths(opts: ResolveOpts = {}): FixturePaths {
-  // import.meta.url here resolves to the .ts source in dev, .js bundle if
-  // built. Either way, ../../fixtures/seed.sql is the right relative path
-  // because seed.sql sits alongside src/ inside the package root.
+  // resolves from src/init/fixture.{ts,js} → package root → fixtures/seed.sql
   const here = fileURLToPath(import.meta.url);
   const seedPath = resolve(here, "..", "..", "..", "fixtures", "seed.sql");
+  const exists = opts.existsSync ?? existsSync;
+  if (!exists(seedPath)) {
+    // Fail loudly at init time — otherwise the user only finds out when
+    // their MCP client tries to query an empty SQLite file later.
+    throw new Error(
+      `Bundled fixture seed.sql is missing at ${seedPath}. Reinstall @useatlas/mcp.`,
+    );
+  }
   const cacheDir = opts.cacheDir ?? defaultCacheDir();
   const sqlitePath = join(cacheDir, "demo.sqlite");
   const sqliteUrl = `sqlite://${sqlitePath}`;

--- a/packages/mcp/src/init/index.ts
+++ b/packages/mcp/src/init/index.ts
@@ -1,0 +1,137 @@
+/**
+ * `bunx @useatlas/mcp init` flow.
+ *
+ * Detects the user's MCP client, builds an Atlas server config block, and
+ * either prints it to stdout (default) or merges it into the client's
+ * config file (with `--write`). `--hosted` is a stub until #2024 lands.
+ */
+
+import { detectClients, getDefaultConfigPath, type McpClientId } from "./clients.js";
+import {
+  buildServerConfig,
+  mergeMcpServerConfig,
+  readConfigOrNull,
+  writeConfigWithBackup,
+  type ServerConfig,
+} from "./config-merge.js";
+import { detectLocalAtlas, resolveApiUrl } from "./local-atlas.js";
+import { resolveFixturePaths, shouldUseFixture } from "./fixture.js";
+
+const SERVER_NAME = "atlas";
+
+export interface RunInitOptions {
+  mode: "local" | "hosted";
+  client?: McpClientId;
+  write?: boolean;
+  /** Override the resolved config file path (test seam). */
+  configPathOverride?: string;
+  /** Override the API URL used for local-Atlas detection. */
+  apiUrl?: string;
+  /** Process env (test seam). Defaults to `process.env`. */
+  env?: NodeJS.ProcessEnv;
+  /** Test seam — defaults to global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+export interface RunInitResult {
+  exitCode: number;
+}
+
+export async function runInit(options: RunInitOptions): Promise<RunInitResult> {
+  if (options.mode === "hosted") {
+    return runHostedStub();
+  }
+  return runLocal(options);
+}
+
+function runHostedStub(): RunInitResult {
+  console.log(
+    [
+      "Hosted mode is coming with #2024 — see https://github.com/AtlasDevHQ/atlas/issues/2024",
+      "Run `bunx @useatlas/mcp init --local` for now to point an MCP client at a local Atlas",
+      "instance or the bundled demo fixture.",
+    ].join("\n"),
+  );
+  return { exitCode: 0 };
+}
+
+async function runLocal(opts: RunInitOptions): Promise<RunInitResult> {
+  const env = opts.env ?? process.env;
+  const apiUrl = opts.apiUrl ?? resolveApiUrl(env);
+  const localAtlas = await detectLocalAtlas({ url: apiUrl, fetchImpl: opts.fetchImpl });
+
+  const datasourceUrl = chooseDatasourceUrl({
+    env,
+    localAtlas,
+  });
+  const serverCfg = buildServerConfig({ datasourceUrl });
+
+  const clientId = opts.client ?? pickDefaultClient();
+  const configPath = opts.configPathOverride ?? getDefaultConfigPath(clientId);
+
+  if (localAtlas) {
+    console.log(`local Atlas detected at ${apiUrl} — leaving ATLAS_DATASOURCE_URL unset so MCP inherits your shell env.`);
+  } else if (datasourceUrl) {
+    console.log(`No ATLAS_DATASOURCE_URL set — using bundled demo fixture at ${datasourceUrl}.`);
+    console.log("Override by exporting ATLAS_DATASOURCE_URL before launching your MCP client.");
+  }
+
+  if (!opts.write || configPath === null) {
+    printPasteSnippet(clientId, serverCfg, configPath);
+    return { exitCode: 0 };
+  }
+
+  const existing = readConfigOrNull(configPath);
+  let merged: string;
+  try {
+    merged = mergeMcpServerConfig(existing, SERVER_NAME, serverCfg);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[atlas-mcp init] could not merge into existing config (${configPath}): ${msg}`);
+    console.error("Aborting — your config was not modified. Pass --no-write to print a snippet instead.");
+    return { exitCode: 1 };
+  }
+
+  const { backupPath } = await writeConfigWithBackup(configPath, merged);
+  console.log(`Wrote ${configPath}`);
+  if (backupPath) {
+    console.log(`Backed up the previous config to ${backupPath}`);
+  }
+  console.log("Restart your MCP client to pick up the new server.");
+  return { exitCode: 0 };
+}
+
+function chooseDatasourceUrl(args: {
+  env: NodeJS.ProcessEnv;
+  localAtlas: boolean;
+}): string | undefined {
+  if (args.localAtlas) {
+    // Caller already has Atlas running with its own datasource — leave the
+    // env block empty so the MCP server inherits the shell env.
+    return undefined;
+  }
+  if (!shouldUseFixture(args.env)) {
+    // The caller has set ATLAS_DATASOURCE_URL in their env — same logic:
+    // inherit, don't bake the value into a JSON config that lands in a
+    // dotfile or repo.
+    return undefined;
+  }
+  return resolveFixturePaths().sqliteUrl;
+}
+
+function pickDefaultClient(): McpClientId {
+  const clients = detectClients();
+  const detected = clients.find((c) => c.detected && c.id !== "generic");
+  return detected?.id ?? "claude-desktop";
+}
+
+function printPasteSnippet(
+  clientId: McpClientId,
+  serverCfg: ServerConfig,
+  configPath: string | null,
+) {
+  const snippet = JSON.stringify({ mcpServers: { [SERVER_NAME]: serverCfg } }, null, 2);
+  console.log(`# ${clientId}${configPath ? ` — ${configPath}` : ""}`);
+  console.log("# Paste the following into your MCP client config:");
+  console.log(snippet);
+}

--- a/packages/mcp/src/init/index.ts
+++ b/packages/mcp/src/init/index.ts
@@ -1,12 +1,10 @@
 /**
- * `bunx @useatlas/mcp init` flow.
- *
- * Detects the user's MCP client, builds an Atlas server config block, and
- * either prints it to stdout (default) or merges it into the client's
- * config file (with `--write`). `--hosted` is a stub until #2024 lands.
+ * Runs the `init` flow: detect the user's MCP client, build an Atlas server
+ * config block, and either print it to stdout (default) or merge it into
+ * the client's config file (`--write`).
  */
 
-import { detectClients, getDefaultConfigPath, type McpClientId } from "./clients.js";
+import { detectClients, getDefaultConfigPath, type ClientInfo, type McpClientId } from "./clients.js";
 import {
   buildServerConfig,
   mergeMcpServerConfig,
@@ -18,9 +16,10 @@ import { detectLocalAtlas, resolveApiUrl } from "./local-atlas.js";
 import { resolveFixturePaths, shouldUseFixture } from "./fixture.js";
 
 const SERVER_NAME = "atlas";
+const HOSTED_TRACKING_ISSUE = "https://github.com/AtlasDevHQ/atlas/issues/2024";
 
-export interface RunInitOptions {
-  mode: "local" | "hosted";
+export interface LocalInitOptions {
+  mode: "local";
   client?: McpClientId;
   write?: boolean;
   /** Override the resolved config file path (test seam). */
@@ -31,7 +30,15 @@ export interface RunInitOptions {
   env?: NodeJS.ProcessEnv;
   /** Test seam — defaults to global `fetch`. */
   fetchImpl?: typeof fetch;
+  /** Test seam — defaults to filesystem-backed `detectClients()`. */
+  detectClientsImpl?: () => ClientInfo[];
 }
+
+export interface HostedInitOptions {
+  mode: "hosted";
+}
+
+export type RunInitOptions = LocalInitOptions | HostedInitOptions;
 
 export interface RunInitResult {
   exitCode: number;
@@ -47,7 +54,7 @@ export async function runInit(options: RunInitOptions): Promise<RunInitResult> {
 function runHostedStub(): RunInitResult {
   console.log(
     [
-      "Hosted mode is coming with #2024 — see https://github.com/AtlasDevHQ/atlas/issues/2024",
+      `Hosted mode (against app.useatlas.dev) is not yet available — tracking at ${HOSTED_TRACKING_ISSUE}.`,
       "Run `bunx @useatlas/mcp init --local` for now to point an MCP client at a local Atlas",
       "instance or the bundled demo fixture.",
     ].join("\n"),
@@ -55,7 +62,7 @@ function runHostedStub(): RunInitResult {
   return { exitCode: 0 };
 }
 
-async function runLocal(opts: RunInitOptions): Promise<RunInitResult> {
+async function runLocal(opts: LocalInitOptions): Promise<RunInitResult> {
   const env = opts.env ?? process.env;
   const apiUrl = opts.apiUrl ?? resolveApiUrl(env);
   const localAtlas = await detectLocalAtlas({ url: apiUrl, fetchImpl: opts.fetchImpl });
@@ -66,7 +73,7 @@ async function runLocal(opts: RunInitOptions): Promise<RunInitResult> {
   });
   const serverCfg = buildServerConfig({ datasourceUrl });
 
-  const clientId = opts.client ?? pickDefaultClient();
+  const clientId = opts.client ?? pickDefaultClient(opts.detectClientsImpl);
   const configPath = opts.configPathOverride ?? getDefaultConfigPath(clientId);
 
   if (localAtlas) {
@@ -88,14 +95,29 @@ async function runLocal(opts: RunInitOptions): Promise<RunInitResult> {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`[atlas-mcp init] could not merge into existing config (${configPath}): ${msg}`);
-    console.error("Aborting — your config was not modified. Pass --no-write to print a snippet instead.");
+    console.error("Aborting — your config was not modified. Re-run without --write to print a snippet instead.");
     return { exitCode: 1 };
   }
 
-  const { backupPath } = await writeConfigWithBackup(configPath, merged);
+  let writeResult;
+  try {
+    writeResult = await writeConfigWithBackup(configPath, merged);
+  } catch (err) {
+    // The .bak (if any) was written *before* the failed write, so a partial
+    // failure may have moved the original out of place. Tell the user where
+    // to recover from instead of leaving them with a generic "Fatal".
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[atlas-mcp init] failed to write ${configPath}: ${msg}`);
+    if (existing !== null) {
+      console.error(`A backup of your previous config is at ${configPath}.bak (or a timestamped sibling).`);
+      console.error(`Restore with: cp '${configPath}.bak' '${configPath}'`);
+    }
+    return { exitCode: 1 };
+  }
+
   console.log(`Wrote ${configPath}`);
-  if (backupPath) {
-    console.log(`Backed up the previous config to ${backupPath}`);
+  if (writeResult.backupPath) {
+    console.log(`Backed up the previous config to ${writeResult.backupPath}`);
   }
   console.log("Restart your MCP client to pick up the new server.");
   return { exitCode: 0 };
@@ -105,22 +127,16 @@ function chooseDatasourceUrl(args: {
   env: NodeJS.ProcessEnv;
   localAtlas: boolean;
 }): string | undefined {
-  if (args.localAtlas) {
-    // Caller already has Atlas running with its own datasource — leave the
-    // env block empty so the MCP server inherits the shell env.
-    return undefined;
-  }
-  if (!shouldUseFixture(args.env)) {
-    // The caller has set ATLAS_DATASOURCE_URL in their env — same logic:
-    // inherit, don't bake the value into a JSON config that lands in a
-    // dotfile or repo.
-    return undefined;
-  }
+  // When the caller already has Atlas running OR has ATLAS_DATASOURCE_URL set
+  // in their shell, leave the env block empty so MCP inherits the shell —
+  // and so we never bake credentials into a JSON file that lives in a dotfile.
+  if (args.localAtlas) return undefined;
+  if (!shouldUseFixture(args.env)) return undefined;
   return resolveFixturePaths().sqliteUrl;
 }
 
-function pickDefaultClient(): McpClientId {
-  const clients = detectClients();
+function pickDefaultClient(impl?: () => ClientInfo[]): McpClientId {
+  const clients = (impl ?? detectClients)();
   const detected = clients.find((c) => c.detected && c.id !== "generic");
   return detected?.id ?? "claude-desktop";
 }

--- a/packages/mcp/src/init/local-atlas.ts
+++ b/packages/mcp/src/init/local-atlas.ts
@@ -1,0 +1,42 @@
+/**
+ * Detect a running local Atlas instance for the init flow.
+ *
+ * Pings `${url}/api/v1/health` with a short timeout. Used so `init --local`
+ * can prefer a locally running Atlas over the bundled fixture when the user
+ * has one running (e.g. `bun run dev` in another terminal).
+ */
+
+const DEFAULT_URL = "http://localhost:3001";
+
+export interface DetectOpts {
+  url?: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+export async function detectLocalAtlas(opts: DetectOpts = {}): Promise<boolean> {
+  const url = opts.url ?? DEFAULT_URL;
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const timeoutMs = opts.timeoutMs ?? 1000;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(`${url}/api/v1/health`, { signal: controller.signal });
+    return res.ok;
+  } catch (err) {
+    // Expected when Atlas isn't running. Log to stderr so users running with
+    // ATLAS_DEBUG_INIT can see the underlying error, but never propagate.
+    if (process.env.ATLAS_DEBUG_INIT) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[atlas-mcp init] local-atlas probe failed: ${msg}`);
+    }
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function resolveApiUrl(env: NodeJS.ProcessEnv = process.env): string {
+  return env.ATLAS_API_URL ?? DEFAULT_URL;
+}

--- a/packages/mcp/src/init/local-atlas.ts
+++ b/packages/mcp/src/init/local-atlas.ts
@@ -25,8 +25,9 @@ export async function detectLocalAtlas(opts: DetectOpts = {}): Promise<boolean> 
     const res = await fetchImpl(`${url}/api/v1/health`, { signal: controller.signal });
     return res.ok;
   } catch (err) {
-    // Expected when Atlas isn't running. Log to stderr so users running with
-    // ATLAS_DEBUG_INIT can see the underlying error, but never propagate.
+    // Expected on timeout or connection refused — Atlas isn't running. Log
+    // to stderr behind ATLAS_DEBUG_INIT for diagnosis but never propagate;
+    // a probe miss is not a fatal error for the init flow.
     if (process.env.ATLAS_DEBUG_INIT) {
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[atlas-mcp init] local-atlas probe failed: ${msg}`);


### PR DESCRIPTION
Closes #2018 (partial — `--local` mode only; `--hosted` follows in #2024).

## Summary

- Adds `bin/init.ts` to `@atlas/mcp` — detects Claude Desktop, Cursor, Continue config paths across darwin/linux/win32; prints a paste-ready config snippet using `bunx @useatlas/mcp serve` (no absolute paths)
- `--write` merges into the detected client's config preserving sibling servers and non-mcp top-level keys; writes a `.bak` (timestamped if one already exists) before overwriting
- Falls back to a bundled accounts/companies/people SQLite fixture (`packages/mcp/fixtures/seed.sql`) when `ATLAS_DATASOURCE_URL` is unset, so a fresh user gets a working install with zero env setup
- Detects a local Atlas at `http://localhost:3001` (override via `ATLAS_API_URL`) and prefers it — leaves the env block empty so MCP inherits the user's shell
- `--hosted` is a stub that exits 0 with `"coming with #2024"` message

## Out of scope (called out in the issue)

- The hosted-mode OAuth device-code flow + `mcp.useatlas.dev/<workspace>/sse` endpoint — depends on #2024
- Actually publishing `@useatlas/mcp` to npm — `@atlas/mcp` still depends on the workspace-private `@atlas/api`, which is the same blocker already documented in `.github/workflows/publish.yml`. Today the installer runs from-source in the monorepo via `bun packages/mcp/bin/init.ts --local`. Detangling the workspace dep so the publish workflow can flip `mcp-v*` from excluded → published is follow-up work.
- The hydration step that turns `seed.sql` into a runnable SQLite file inside `serve` — needs SQLite/DuckDB connector support in `@atlas/api`'s ConnectionRegistry and seed-on-first-run logic in `bin/serve.ts`. Tracked separately so this PR stays focused on `init`.

## Acceptance criteria from #2018

- [x] `bunx @useatlas/mcp init --local` runs end-to-end with only `bun` installed (currently as `bun packages/mcp/bin/init.ts --local` until publish unblocks)
- [x] Detects Claude Desktop, Cursor, Continue config paths; prints JSON snippet to paste
- [x] `--write` flag merges into the detected client's config preserving existing servers, with a `.bak` written first
- [x] Generated config uses `bunx @useatlas/mcp serve` (no absolute paths)
- [x] Falls back to a bundled SQLite fixture when `ATLAS_DATASOURCE_URL` is unset
- [x] Detects local Atlas at `localhost:3001` (configurable via `ATLAS_API_URL`); prefers it over the fixture
- [x] `--hosted` exits with `"coming in a follow-up — see #2024"` until #2024 lands
- [x] Tests for client detection (mocked filesystem), JSON merge preserving existing servers, `.bak` creation, missing-config-file path
- [x] `apps/docs/content/docs/guides/mcp.mdx` leads with the one-liner; root README MCP section gets a 2-line install snippet

## Test plan

- [x] `bun test packages/mcp/src/__tests__/init/` — 36 new tests, 0 failures
- [x] `bun run lint` — clean
- [x] `bun run type` — clean (root tsgo)
- [x] `bun run test` — full suite passes (`@atlas/api`, `@atlas/mcp`, all `@useatlas/*`)
- [x] `bun x syncpack lint` — `No issues found`
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — 472 files verified
- [x] `bash scripts/check-railway-watch.sh` — all watchPatterns covered
- [x] `bash scripts/check-security-headers-drift.sh` — 3 mirrors match
- [x] Manual smoke: `bun packages/mcp/bin/init.ts --local --client claude-desktop` → prints expected snippet
- [x] Manual smoke: `bun packages/mcp/bin/init.ts --hosted` → prints `#2024` stub
- [x] Manual smoke: `--write` against a temp file → merges, writes `.bak`, preserves siblings
- [ ] Try the printed snippet end-to-end against a fresh Claude Desktop install once `@useatlas/mcp` is published (blocked on follow-up)