### PR TITLE
feat(mcp): #2030 — structured error envelope for typed MCP tools

### DIFF
--- a/apps/docs/content/docs/guides/mcp.mdx
+++ b/apps/docs/content/docs/guides/mcp.mdx
@@ -156,7 +156,7 @@ Return the full parsed entity YAML — dimensions (with types and sample values)
 name: "orders"
 ```
 
-Returns `{ found: false, name }` when the entity does not exist. Always call this before writing SQL against an unfamiliar table.
+When the entity does not exist, returns an `unknown_entity` [error envelope](#error-contract) — the agent should call `listEntities` to discover what's available rather than guess. Always call `describeEntity` before writing SQL against an unfamiliar table.
 
 ### searchGlossary
 
@@ -184,7 +184,7 @@ term: "revenue"
 }
 ```
 
-When a returned term has `status: "ambiguous"`, do **not** silently pick a mapping — surface `possible_mappings` and ask the user which they mean. This is what the [glossary disambiguation](#) directive is for.
+When a returned term has `status: "ambiguous"`, `searchGlossary` returns an `ambiguous_term` [error envelope](#error-contract) instead of the matches array — the agent must surface `possible_mappings` to the user and ask which they mean, never silently pick. The disambiguation eval (#2025) asserts on this exact code.
 
 ### runMetric
 
@@ -212,9 +212,69 @@ connectionId: "warehouse"   // optional — overrides the default connection
 
 When the result has multiple columns or multiple rows, `value` falls back to the row array — useful for breakdown metrics.
 
-`runMetric` returns `isError: true` when the metric id is unknown, when the underlying SQL fails validation, or when an approval/RLS rule rejects the query.
+`runMetric` returns an `isError: true` envelope when the metric id is unknown (`unknown_metric`), when the underlying SQL fails validation (`validation_failed`), when an RLS rule rejects the query (`rls_denied`), when the statement timeout fires (`query_timeout`), when the request is rate-limited (`rate_limited`), or on any other failure (`internal_error`). See [Error contract](#error-contract) for the exact envelope shape.
 
 The `filters` parameter is reserved for future pre-aggregation filter pass-through. Passing a non-empty `filters` object is rejected today; use `executeSQL` with the metric's raw SQL if you need to filter results before aggregation.
+
+---
+
+## Error contract
+
+Every Atlas MCP tool returns failures as a structured JSON envelope inside an `isError: true` response — agents branch on the `code` field instead of pattern-matching prose. The envelope is defined in [`@useatlas/types`](https://www.npmjs.com/package/@useatlas/types) as `AtlasMcpToolError`:
+
+```ts
+{
+  code: AtlasMcpToolErrorCode;   // closed catalog — the only field to branch on
+  message: string;               // human + LLM readable, safe to surface to a user
+  hint?: string;                 // optional remediation suggestion
+  request_id?: string;           // set on internal_error so users can quote it in support
+  retry_after?: number;          // seconds, set on rate_limited
+}
+```
+
+The envelope is serialized as the `text` of the first content block. Use `parseAtlasMcpToolError(text)` from `@useatlas/types/mcp` for a runtime-checked parse.
+
+### Codes
+
+| Code | Triggered when… | Recommended agent recovery |
+|------|-----------------|---------------------------|
+| `validation_failed` | The SQL guard rejected (regex, AST, table whitelist), or `runMetric` was called with a non-empty `filters` object. | Rewrite the query; do **not** retry the same SQL. |
+| `rls_denied` | Row-level security rejected the query for the bound actor. | Surface the failure to the user — the agent cannot retry under another identity. |
+| `query_timeout` | `statement_timeout` fired. | Suggest a simpler query (tighter `WHERE`/`LIMIT`) or break the work up. |
+| `unknown_entity` | `describeEntity` was called with an entity that doesn't exist, or `executeSQL` referenced a table missing from the semantic whitelist. | Call `listEntities` to discover what exists, then retry with a real name. |
+| `unknown_metric` | `runMetric` was called with an id missing from `metrics/*.yml`. | Fall back to `executeSQL`, or pick a different metric id. |
+| `ambiguous_term` | `searchGlossary` matched a glossary entry with `status: ambiguous`. | **Do not silently pick a mapping.** Surface `possible_mappings` to the user and ask which they meant. |
+| `rate_limited` | The per-source rate limit or concurrency cap was hit. `retry_after` (seconds) is set when the upstream knows it. | Back off for `retry_after` seconds; surface to user only after sustained failure. |
+| `internal_error` | Anything else — sandbox crash, lookup failure, opaque pipeline error. `request_id` is always set. | Quote the `request_id` to the user; do not silently retry — there is likely an operator-side problem. |
+
+### Tool description carries the contract
+
+Each tool's MCP `description` ends with an explicit `Error contract:` line listing the codes it can return. LLMs that read tool descriptions before invoking will discover the recovery surface from the tool itself — no prior training on Atlas required.
+
+### Example — handling the envelope client-side
+
+```ts
+import { parseAtlasMcpToolError } from "@useatlas/types/mcp";
+
+const result = await client.callTool({ name: "runMetric", arguments: { id: "mrr" } });
+if (result.isError) {
+  const text = (result.content[0] as { text: string }).text;
+  const envelope = parseAtlasMcpToolError(text);
+  if (!envelope) throw new Error(`Unparseable MCP error: ${text}`);
+
+  switch (envelope.code) {
+    case "ambiguous_term":
+      return askUserToDisambiguate(envelope.message, envelope.hint);
+    case "rate_limited":
+      await sleep((envelope.retry_after ?? 5) * 1000);
+      return retry();
+    case "unknown_metric":
+      return tryExecuteSqlFallback();
+    default:
+      return surfaceToUser(envelope.message, envelope.request_id);
+  }
+}
+```
 
 ---
 

--- a/apps/docs/content/docs/guides/mcp.mdx
+++ b/apps/docs/content/docs/guides/mcp.mdx
@@ -184,7 +184,7 @@ term: "revenue"
 }
 ```
 
-When a returned term has `status: "ambiguous"`, `searchGlossary` returns an `ambiguous_term` [error envelope](#error-contract) instead of the matches array — the agent must surface `possible_mappings` to the user and ask which they mean, never silently pick. The disambiguation eval (#2025) asserts on this exact code.
+When a returned term has `status: "ambiguous"`, `searchGlossary` returns an `ambiguous_term` [error envelope](#error-contract) instead of the matches array — the agent must surface `possible_mappings` to the user and ask which they mean, never silently pick. The forthcoming disambiguation eval ([#2025](https://github.com/AtlasDevHQ/atlas/issues/2025)) is expected to assert on this exact code.
 
 ### runMetric
 
@@ -241,10 +241,10 @@ The envelope is serialized as the `text` of the first content block. Use `parseA
 | `validation_failed` | The SQL guard rejected (regex, AST, table whitelist), or `runMetric` was called with a non-empty `filters` object. | Rewrite the query; do **not** retry the same SQL. |
 | `rls_denied` | Row-level security rejected the query for the bound actor. | Surface the failure to the user — the agent cannot retry under another identity. |
 | `query_timeout` | `statement_timeout` fired. | Suggest a simpler query (tighter `WHERE`/`LIMIT`) or break the work up. |
-| `unknown_entity` | `describeEntity` was called with an entity that doesn't exist, or `executeSQL` referenced a table missing from the semantic whitelist. | Call `listEntities` to discover what exists, then retry with a real name. |
+| `unknown_entity` | `describeEntity` was called with an entity that doesn't exist, `executeSQL` referenced a table missing from the semantic whitelist, or a `connectionId` was specified that isn't registered. | Call `listEntities` to discover what exists, then retry with a real name (or check the connection id). |
 | `unknown_metric` | `runMetric` was called with an id missing from `metrics/*.yml`. | Fall back to `executeSQL`, or pick a different metric id. |
 | `ambiguous_term` | `searchGlossary` matched a glossary entry with `status: ambiguous`. | **Do not silently pick a mapping.** Surface `possible_mappings` to the user and ask which they meant. |
-| `rate_limited` | The per-source rate limit or concurrency cap was hit. `retry_after` (seconds) is set when the upstream knows it. | Back off for `retry_after` seconds; surface to user only after sustained failure. |
+| `rate_limited` | The per-source QPM limit, concurrency cap, or pool capacity was hit. `retry_after` (seconds) is set when the upstream knows it. | Back off for `retry_after` seconds; surface to user only after sustained failure. |
 | `internal_error` | Anything else — sandbox crash, lookup failure, opaque pipeline error. `request_id` is always set. | Quote the `request_id` to the user; do not silently retry — there is likely an operator-side problem. |
 
 ### Tool description carries the contract

--- a/bun.lock
+++ b/bun.lock
@@ -203,6 +203,7 @@
         "@atlas/api": "workspace:*",
         "@atlas/ee": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.28.0",
+        "@useatlas/types": "workspace:*",
         "effect": "^3.21.0",
       },
       "devDependencies": {
@@ -232,7 +233,7 @@
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^5.96.2",
-        "@useatlas/types": "^0.0.17",
+        "@useatlas/types": "^0.0.18",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "radix-ui": "^1.4.3",
@@ -299,12 +300,12 @@
       "name": "@useatlas/sdk",
       "version": "0.0.12",
       "dependencies": {
-        "@useatlas/types": "^0.0.17",
+        "@useatlas/types": "^0.0.18",
       },
     },
     "packages/types": {
       "name": "@useatlas/types",
-      "version": "0.0.18",
+      "version": "0.0.19",
     },
     "packages/web": {
       "name": "@atlas/web",
@@ -4251,6 +4252,10 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typespec/ts-http-runtime/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "@useatlas/react/@useatlas/types": ["@useatlas/types@0.0.18", "", {}, "sha512-VwJ8twZ3K6NuiuycGndklOlHKkQaF+DbyNZhFVDDVwvYmf/N63klZFlO71Oy1kZFHQZe61+RMiRWrCyy+udr0A=="],
+
+    "@useatlas/sdk/@useatlas/types": ["@useatlas/types@0.0.18", "", {}, "sha512-VwJ8twZ3K6NuiuycGndklOlHKkQaF+DbyNZhFVDDVwvYmf/N63klZFlO71Oy1kZFHQZe61+RMiRWrCyy+udr0A=="],
 
     "@vercel/sandbox/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 

--- a/packages/api/src/lib/tools/descriptions.ts
+++ b/packages/api/src/lib/tools/descriptions.ts
@@ -25,8 +25,10 @@ Output is the entity's YAML rendered as JSON: dimensions (with types and sample
 values), measures, joins, query patterns, grain, and connection. Look up by the
 entity's \`name\` field or by \`table\` name — both work.
 
-Always call this before writing SQL against an unfamiliar table. Returns
-{ found: false } when the entity does not exist.`;
+Always call this before writing SQL against an unfamiliar table. When the entity
+does not exist, returns an \`unknown_entity\` error envelope (see the per-tool
+error contract); the agent should call \`listEntities\` to discover what's
+available rather than guess.`;
 
 export const SEARCH_GLOSSARY_TOOL_DESCRIPTION = `Search the business glossary for a term.
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -19,6 +19,7 @@
     "@atlas/api": "workspace:*",
     "@atlas/ee": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.28.0",
+    "@useatlas/types": "workspace:*",
     "effect": "^3.21.0"
   },
   "devDependencies": {

--- a/packages/mcp/src/__tests__/semantic-tools.test.ts
+++ b/packages/mcp/src/__tests__/semantic-tools.test.ts
@@ -4,6 +4,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createAtlasUser } from "@atlas/api/lib/auth/types";
 import { getRequestContext } from "@atlas/api/lib/logger";
+import { parseAtlasMcpToolError } from "@useatlas/types/mcp";
 
 const TEST_ACTOR = createAtlasUser("u_sem", "managed", "sem@test", {
   role: "admin",
@@ -152,6 +153,73 @@ describe("MCP semantic tools", () => {
     ]);
   });
 
+  it("typed-tool descriptions document the error contract (#2030)", async () => {
+    const { client } = await createTestClient();
+    const result = await client.listTools();
+    const map = new Map(result.tools.map((t) => [t.name, t.description ?? ""]));
+
+    expect(map.get("listEntities")).toContain("Error contract");
+    expect(map.get("describeEntity")).toContain("`unknown_entity`");
+    // The disambiguation contract — the eval harness in #2025 expects the
+    // description to advertise `ambiguous_term` so an LLM picks the right
+    // recovery without prior training.
+    expect(map.get("searchGlossary")).toContain("`ambiguous_term`");
+    expect(map.get("runMetric")).toContain("`unknown_metric`");
+    expect(map.get("runMetric")).toContain("`validation_failed`");
+    expect(map.get("runMetric")).toContain("`rls_denied`");
+  });
+
+  // --- internal_error coverage on the read-only tools ---
+
+  it("listEntities returns an internal_error envelope when the lookup throws", async () => {
+    mockListEntities.mockImplementationOnce(() => {
+      throw new Error("semantic root unreadable");
+    });
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({ name: "listEntities", arguments: {} });
+
+    expect(result.isError).toBe(true);
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("internal_error");
+    expect(envelope!.message).toContain("semantic root unreadable");
+    expect(envelope!.request_id).toMatch(/^mcp-listEntities-/);
+  });
+
+  it("describeEntity returns an internal_error envelope when the lookup throws", async () => {
+    mockGetEntityByName.mockImplementationOnce(() => {
+      throw new Error("yaml parse failed");
+    });
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "describeEntity",
+      arguments: { name: "users" },
+    });
+
+    expect(result.isError).toBe(true);
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("internal_error");
+    expect(envelope!.message).toContain("yaml parse failed");
+  });
+
+  it("searchGlossary returns an internal_error envelope when the lookup throws", async () => {
+    mockSearchGlossary.mockImplementationOnce(() => {
+      throw new Error("glossary index corrupt");
+    });
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "searchGlossary",
+      arguments: { term: "anything" },
+    });
+
+    expect(result.isError).toBe(true);
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("internal_error");
+    expect(envelope!.message).toContain("glossary index corrupt");
+  });
+
   // --- listEntities ---
 
   it("listEntities returns the catalog with a count", async () => {
@@ -190,31 +258,55 @@ describe("MCP semantic tools", () => {
     expect(parsed.entity.table).toBe("users");
   });
 
-  it("describeEntity returns { found: false } for an unknown entity", async () => {
+  it("describeEntity returns an unknown_entity envelope when the entity does not exist", async () => {
     const { client } = await createTestClient();
     const result = await client.callTool({
       name: "describeEntity",
       arguments: { name: "ghost" },
     });
-    expect(result.isError).toBeFalsy();
-    const parsed = JSON.parse(getContentText(result.content));
-    expect(parsed.found).toBe(false);
-    expect(parsed.name).toBe("ghost");
+    // #2030: missing entity is now a typed envelope so the agent can
+    // branch on `code === "unknown_entity"` and call listEntities to
+    // recover, instead of pattern-matching `found: false` prose.
+    expect(result.isError).toBe(true);
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope).not.toBeNull();
+    expect(envelope!.code).toBe("unknown_entity");
+    expect(envelope!.message).toContain("ghost");
+    expect(envelope!.hint).toContain("listEntities");
   });
 
   // --- searchGlossary ---
 
-  it("searchGlossary returns the matching terms with status and mappings", async () => {
+  it("searchGlossary returns an ambiguous_term envelope when any match has status: ambiguous", async () => {
     const { client } = await createTestClient();
     const result = await client.callTool({
       name: "searchGlossary",
       arguments: { term: "status" },
     });
+    // #2030 + #2025: the disambiguation contract — the eval harness
+    // asserts on `code === "ambiguous_term"`. The hint must point the
+    // agent at possible_mappings rather than letting it silently pick.
+    expect(result.isError).toBe(true);
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope).not.toBeNull();
+    expect(envelope!.code).toBe("ambiguous_term");
+    expect(envelope!.message).toContain("orders.status");
+    expect(envelope!.message).toContain("users.status");
+    expect(envelope!.hint).toContain("possible_mappings");
+  });
+
+  it("searchGlossary returns prose JSON (not an envelope) for a defined term", async () => {
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "searchGlossary",
+      arguments: { term: "revenue" },
+    });
+    // status: "defined" is the happy path — the result is not an error
+    // envelope, just the plain JSON so the agent can inline the definition.
     expect(result.isError).toBeFalsy();
     const parsed = JSON.parse(getContentText(result.content));
     expect(parsed.count).toBe(1);
-    expect(parsed.matches[0].status).toBe("ambiguous");
-    expect(parsed.matches[0].possible_mappings).toContain("orders.status");
+    expect(parsed.matches[0].status).toBe("defined");
   });
 
   it("searchGlossary returns an empty result list on a glossary miss", async () => {
@@ -338,7 +430,7 @@ describe("MCP semantic tools", () => {
     expect(parsed.rows).toEqual(parsed.value);
   });
 
-  it("runMetric returns isError for an unknown metric id", async () => {
+  it("runMetric returns an unknown_metric envelope for an unknown metric id", async () => {
     const { client } = await createTestClient();
     const result = await client.callTool({
       name: "runMetric",
@@ -346,13 +438,16 @@ describe("MCP semantic tools", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(getContentText(result.content)).toContain("not found");
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("unknown_metric");
+    expect(envelope!.message).toContain("missing_metric");
+    expect(envelope!.hint).toContain("metric ids");
     // executeSQL must not be called when the metric lookup fails — the
     // pipeline short-circuits before we touch SQL.
     expect(mockExecuteSQLExecute).not.toHaveBeenCalled();
   });
 
-  it("runMetric surfaces validation/RLS rejections from executeSQL as isError", async () => {
+  it("runMetric surfaces RLS rejections from executeSQL as rls_denied", async () => {
     mockExecuteSQLExecute.mockImplementationOnce(async () => ({
       success: false,
       error: "RLS check failed: user has no claim for orders.org_id",
@@ -365,10 +460,79 @@ describe("MCP semantic tools", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(getContentText(result.content)).toContain("RLS check failed");
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("rls_denied");
+    expect(envelope!.message).toContain("RLS check failed");
   });
 
-  it("runMetric rejects non-empty filters with a clear message", async () => {
+  it("runMetric maps a statement timeout to query_timeout", async () => {
+    mockExecuteSQLExecute.mockImplementationOnce(async () => ({
+      success: false,
+      error: "canceling statement due to statement timeout",
+    }));
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "runMetric",
+      arguments: { id: "orders_count" },
+    });
+
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("query_timeout");
+  });
+
+  it("runMetric maps a SQL guard rejection to validation_failed", async () => {
+    mockExecuteSQLExecute.mockImplementationOnce(async () => ({
+      success: false,
+      error: "Forbidden SQL operation detected",
+    }));
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "runMetric",
+      arguments: { id: "orders_count" },
+    });
+
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("validation_failed");
+  });
+
+  it("runMetric maps a rate-limit rejection to rate_limited and forwards retry_after", async () => {
+    mockExecuteSQLExecute.mockImplementationOnce(async () => ({
+      success: false,
+      error: "Rate limit exceeded for source default",
+      retryAfterMs: 8_000,
+    }));
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "runMetric",
+      arguments: { id: "orders_count" },
+    });
+
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("rate_limited");
+    expect(envelope!.retry_after).toBe(8);
+  });
+
+  it("runMetric falls back to internal_error on opaque executeSQL failures", async () => {
+    mockExecuteSQLExecute.mockImplementationOnce(async () => ({
+      success: false,
+      error: "Approval system unavailable — query blocked.",
+    }));
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "runMetric",
+      arguments: { id: "orders_count" },
+    });
+
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("internal_error");
+    expect(envelope!.request_id).toMatch(/^mcp-runMetric-/);
+  });
+
+  it("runMetric rejects non-empty filters with a validation_failed envelope", async () => {
     const { client } = await createTestClient();
     const result = await client.callTool({
       name: "runMetric",
@@ -379,7 +543,9 @@ describe("MCP semantic tools", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(getContentText(result.content)).toContain("filters");
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("validation_failed");
+    expect(envelope!.message).toContain("filters");
     // Short-circuit before metric lookup or SQL execution.
     expect(mockFindMetricById).not.toHaveBeenCalled();
     expect(mockExecuteSQLExecute).not.toHaveBeenCalled();

--- a/packages/mcp/src/__tests__/semantic-tools.test.ts
+++ b/packages/mcp/src/__tests__/semantic-tools.test.ts
@@ -160,9 +160,9 @@ describe("MCP semantic tools", () => {
 
     expect(map.get("listEntities")).toContain("Error contract");
     expect(map.get("describeEntity")).toContain("`unknown_entity`");
-    // The disambiguation contract — the eval harness in #2025 expects the
-    // description to advertise `ambiguous_term` so an LLM picks the right
-    // recovery without prior training.
+    // The disambiguation contract — the description must advertise
+    // `ambiguous_term` so an LLM picks the right recovery from the tool
+    // surface (the forthcoming #2025 eval harness will rely on this).
     expect(map.get("searchGlossary")).toContain("`ambiguous_term`");
     expect(map.get("runMetric")).toContain("`unknown_metric`");
     expect(map.get("runMetric")).toContain("`validation_failed`");
@@ -201,6 +201,7 @@ describe("MCP semantic tools", () => {
     const envelope = parseAtlasMcpToolError(getContentText(result.content));
     expect(envelope!.code).toBe("internal_error");
     expect(envelope!.message).toContain("yaml parse failed");
+    expect(envelope!.request_id).toMatch(/^mcp-describeEntity-/);
   });
 
   it("searchGlossary returns an internal_error envelope when the lookup throws", async () => {
@@ -218,6 +219,7 @@ describe("MCP semantic tools", () => {
     const envelope = parseAtlasMcpToolError(getContentText(result.content));
     expect(envelope!.code).toBe("internal_error");
     expect(envelope!.message).toContain("glossary index corrupt");
+    expect(envelope!.request_id).toMatch(/^mcp-searchGlossary-/);
   });
 
   // --- listEntities ---
@@ -283,9 +285,10 @@ describe("MCP semantic tools", () => {
       name: "searchGlossary",
       arguments: { term: "status" },
     });
-    // #2030 + #2025: the disambiguation contract — the eval harness
-    // asserts on `code === "ambiguous_term"`. The hint must point the
-    // agent at possible_mappings rather than letting it silently pick.
+    // #2030: the disambiguation contract — the envelope must use
+    // `code === "ambiguous_term"` so the forthcoming #2025 eval harness
+    // can branch on it. The hint must point the agent at
+    // possible_mappings rather than letting it silently pick.
     expect(result.isError).toBe(true);
     const envelope = parseAtlasMcpToolError(getContentText(result.content));
     expect(envelope).not.toBeNull();
@@ -293,6 +296,51 @@ describe("MCP semantic tools", () => {
     expect(envelope!.message).toContain("orders.status");
     expect(envelope!.message).toContain("users.status");
     expect(envelope!.hint).toContain("possible_mappings");
+  });
+
+  it("searchGlossary ambiguous envelope mentions sibling matches that were dropped", async () => {
+    // The ambiguous override replaces the whole match list with a single
+    // envelope — agents would otherwise lose the sibling defined terms
+    // silently. The message must tell the agent additional matches exist
+    // so it can re-call with a more specific term to recover them.
+    mockSearchGlossary.mockImplementationOnce(() => [
+      {
+        term: "status",
+        status: "ambiguous",
+        definition: null,
+        note: null,
+        possible_mappings: ["orders.status"],
+        source: "default",
+      },
+      {
+        term: "revenue",
+        status: "defined",
+        definition: "Sum of paid invoices.",
+        note: null,
+        possible_mappings: [],
+        source: "default",
+      },
+      {
+        term: "lifetime_value",
+        status: "defined",
+        definition: "Sum of paid invoices per customer.",
+        note: null,
+        possible_mappings: [],
+        source: "default",
+      },
+    ]);
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "searchGlossary",
+      arguments: { term: "anything" },
+    });
+
+    expect(result.isError).toBe(true);
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("ambiguous_term");
+    expect(envelope!.message).toMatch(/2 additional matches omitted/);
+    expect(envelope!.message).toContain("re-call searchGlossary");
   });
 
   it("searchGlossary returns prose JSON (not an envelope) for a defined term", async () => {
@@ -447,10 +495,12 @@ describe("MCP semantic tools", () => {
     expect(mockExecuteSQLExecute).not.toHaveBeenCalled();
   });
 
-  it("runMetric surfaces RLS rejections from executeSQL as rls_denied", async () => {
+  // The runMetric tests below feed REAL upstream messages (not synthetic
+  // stand-ins) so envelope-regex drift surfaces here, not in production.
+  it("runMetric surfaces real RLS rejections (`Row-level security ...`) as rls_denied", async () => {
     mockExecuteSQLExecute.mockImplementationOnce(async () => ({
       success: false,
-      error: "RLS check failed: user has no claim for orders.org_id",
+      error: "Row-level security is enabled but not fully configured. Contact your administrator.",
     }));
 
     const { client } = await createTestClient();
@@ -462,7 +512,7 @@ describe("MCP semantic tools", () => {
     expect(result.isError).toBe(true);
     const envelope = parseAtlasMcpToolError(getContentText(result.content));
     expect(envelope!.code).toBe("rls_denied");
-    expect(envelope!.message).toContain("RLS check failed");
+    expect(envelope!.message).toContain("Row-level security");
   });
 
   it("runMetric maps a statement timeout to query_timeout", async () => {
@@ -481,10 +531,10 @@ describe("MCP semantic tools", () => {
     expect(envelope!.code).toBe("query_timeout");
   });
 
-  it("runMetric maps a SQL guard rejection to validation_failed", async () => {
+  it("runMetric maps a real SQL guard rejection to validation_failed", async () => {
     mockExecuteSQLExecute.mockImplementationOnce(async () => ({
       success: false,
-      error: "Forbidden SQL operation detected",
+      error: "Forbidden SQL operation detected: drop\\s+table",
     }));
 
     const { client } = await createTestClient();
@@ -497,10 +547,10 @@ describe("MCP semantic tools", () => {
     expect(envelope!.code).toBe("validation_failed");
   });
 
-  it("runMetric maps a rate-limit rejection to rate_limited and forwards retry_after", async () => {
+  it("runMetric maps the real `QPM limit reached` message to rate_limited and forwards retry_after", async () => {
     mockExecuteSQLExecute.mockImplementationOnce(async () => ({
       success: false,
-      error: "Rate limit exceeded for source default",
+      error: 'Source "default" QPM limit reached (60/min)',
       retryAfterMs: 8_000,
     }));
 
@@ -515,10 +565,35 @@ describe("MCP semantic tools", () => {
     expect(envelope!.retry_after).toBe(8);
   });
 
+  it("runMetric approval-required: surfaces approval_request_id intact, NOT as an error envelope", async () => {
+    // Same governance contract as executeSQL — approval-required must not
+    // be demoted to internal_error or the agent will retry and silently
+    // duplicate the approval request.
+    mockExecuteSQLExecute.mockImplementationOnce(async () => ({
+      success: false,
+      approval_required: true,
+      approval_request_id: "appr_xyz",
+      matched_rules: ["pii-tables"],
+      message: 'This query requires approval before execution. Rule: "pii-tables". An approval request has been submitted (ID: appr_xyz).',
+    }));
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "runMetric",
+      arguments: { id: "orders_count" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(getContentText(result.content));
+    expect(parsed.approval_required).toBe(true);
+    expect(parsed.approval_request_id).toBe("appr_xyz");
+    expect(parsed.message).toContain("appr_xyz");
+  });
+
   it("runMetric falls back to internal_error on opaque executeSQL failures", async () => {
     mockExecuteSQLExecute.mockImplementationOnce(async () => ({
       success: false,
-      error: "Approval system unavailable — query blocked.",
+      error: "Some completely unknown failure mode the regex catalog doesn't recognize",
     }));
 
     const { client } = await createTestClient();

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -4,6 +4,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createAtlasUser } from "@atlas/api/lib/auth/types";
 import { getRequestContext } from "@atlas/api/lib/logger";
+import { parseAtlasMcpToolError } from "@useatlas/types/mcp";
 import { registerTools } from "../tools.js";
 
 const TEST_ACTOR = createAtlasUser("u_test", "managed", "test@example.com", {
@@ -81,6 +82,23 @@ describe("MCP tools", () => {
     ]);
   });
 
+  it("tool descriptions document the error contract (#2030)", async () => {
+    const { client } = await createTestClient();
+    const result = await client.listTools();
+    const explore = result.tools.find((t) => t.name === "explore");
+    const sql = result.tools.find((t) => t.name === "executeSQL");
+
+    // The LLM-facing description must list the codes the agent can branch
+    // on — we don't assume the agent reads the SDK types.
+    expect(explore?.description).toContain("Error contract");
+    expect(explore?.description).toContain("`internal_error`");
+    expect(sql?.description).toContain("Error contract");
+    expect(sql?.description).toContain("`validation_failed`");
+    expect(sql?.description).toContain("`rls_denied`");
+    expect(sql?.description).toContain("`query_timeout`");
+    expect(sql?.description).toContain("`rate_limited`");
+  });
+
   it("explore returns text content", async () => {
     const { client } = await createTestClient();
     const result = await client.callTool({
@@ -95,7 +113,7 @@ describe("MCP tools", () => {
     expect(result.isError).toBeFalsy();
   });
 
-  it("explore sets isError on error output", async () => {
+  it("explore returns an internal_error envelope on exit-coded backend output", async () => {
     mockExploreExecute.mockResolvedValueOnce("Error (exit 1):\ncommand not found");
 
     const { client } = await createTestClient();
@@ -105,6 +123,28 @@ describe("MCP tools", () => {
     });
 
     expect(result.isError).toBe(true);
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope).not.toBeNull();
+    expect(envelope!.code).toBe("internal_error");
+    expect(envelope!.message).toContain("command not found");
+    expect(envelope!.request_id).toMatch(/^mcp-explore-/);
+  });
+
+  it("explore returns a rate_limited envelope when the backend says so", async () => {
+    mockExploreExecute.mockResolvedValueOnce("Error: too many requests, slow down");
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "explore",
+      arguments: { command: "ls" },
+    });
+
+    expect(result.isError).toBe(true);
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("rate_limited");
+    // request_id is only set on internal_error — rate_limited is operator-side
+    // and the agent doesn't need a correlation id to back off.
+    expect(envelope!.request_id).toBeUndefined();
   });
 
   it("executeSQL returns JSON content on success", async () => {
@@ -125,7 +165,7 @@ describe("MCP tools", () => {
     expect(result.isError).toBeFalsy();
   });
 
-  it("executeSQL returns isError on validation failure", async () => {
+  it("executeSQL returns a validation_failed envelope on a SQL guard rejection", async () => {
     mockExecuteSQLExecute.mockResolvedValueOnce({
       success: false,
       error: "Forbidden SQL operation detected",
@@ -141,7 +181,99 @@ describe("MCP tools", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(getContentText(result.content)).toContain("Forbidden SQL operation");
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope).not.toBeNull();
+    expect(envelope!.code).toBe("validation_failed");
+    expect(envelope!.message).toContain("Forbidden SQL operation");
+  });
+
+  it("executeSQL maps an RLS rejection to rls_denied", async () => {
+    mockExecuteSQLExecute.mockResolvedValueOnce({
+      success: false,
+      error: "RLS check failed: user has no claim for orders.org_id",
+    });
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "SELECT * FROM orders", explanation: "All orders" },
+    });
+
+    expect(result.isError).toBe(true);
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("rls_denied");
+  });
+
+  it("executeSQL maps a statement timeout to query_timeout", async () => {
+    mockExecuteSQLExecute.mockResolvedValueOnce({
+      success: false,
+      error: "canceling statement due to statement timeout",
+    });
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "SELECT * FROM huge", explanation: "Huge scan" },
+    });
+
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("query_timeout");
+  });
+
+  it("executeSQL maps an unknown table to unknown_entity", async () => {
+    mockExecuteSQLExecute.mockResolvedValueOnce({
+      success: false,
+      error: "Table 'ghosts' is not whitelisted in the semantic layer",
+    });
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "SELECT * FROM ghosts", explanation: "Ghost scan" },
+    });
+
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("unknown_entity");
+  });
+
+  it("executeSQL maps a rate-limit rejection to rate_limited and forwards retry_after", async () => {
+    mockExecuteSQLExecute.mockResolvedValueOnce({
+      success: false,
+      error: "Rate limit exceeded for source default",
+      retryAfterMs: 12_000,
+    });
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "SELECT 1", explanation: "ping" },
+    });
+
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("rate_limited");
+    // Wire field uses snake_case so SDK consumers see the same shape the
+    // typed envelope advertises. retryAfterMs (ms) → retry_after (s).
+    expect(envelope!.retry_after).toBe(12);
+  });
+
+  it("executeSQL falls back to internal_error with a request_id on opaque failures", async () => {
+    mockExecuteSQLExecute.mockResolvedValueOnce({
+      success: false,
+      error: "Approval system unavailable — query blocked. Contact your administrator.",
+    });
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "SELECT 1", explanation: "ping" },
+    });
+
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("internal_error");
+    // request_id is mandatory on internal_error so users can correlate with
+    // server logs — the contract called out in @useatlas/types/mcp.
+    expect(envelope!.request_id).toBeDefined();
+    expect(envelope!.request_id).toMatch(/^mcp-executeSQL-/);
   });
 
   it("executeSQL passes connectionId through", async () => {
@@ -161,7 +293,7 @@ describe("MCP tools", () => {
     expect((firstCallArgs[0] as Record<string, unknown>).connectionId).toBe("warehouse");
   });
 
-  it("explore catches thrown exception and returns isError", async () => {
+  it("explore catches thrown exception and returns an internal_error envelope", async () => {
     mockExploreExecute.mockRejectedValueOnce(new Error("sandbox crashed"));
 
     const { client } = await createTestClient();
@@ -171,7 +303,10 @@ describe("MCP tools", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(getContentText(result.content)).toContain("sandbox crashed");
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("internal_error");
+    expect(envelope!.message).toContain("sandbox crashed");
+    expect(envelope!.request_id).toBeDefined();
   });
 
   it("explore JSON-stringifies non-string return values", async () => {
@@ -188,7 +323,7 @@ describe("MCP tools", () => {
     expect(parsed.files).toEqual(["a.yml", "b.yml"]);
   });
 
-  it("executeSQL catches thrown exception and returns isError", async () => {
+  it("executeSQL catches thrown exception and returns an internal_error envelope", async () => {
     mockExecuteSQLExecute.mockRejectedValueOnce(new Error("connection lost"));
 
     const { client } = await createTestClient();
@@ -201,10 +336,13 @@ describe("MCP tools", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(getContentText(result.content)).toContain("connection lost");
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("internal_error");
+    expect(envelope!.message).toContain("connection lost");
+    expect(envelope!.request_id).toBeDefined();
   });
 
-  it("executeSQL returns fallback message when success is false with no error field", async () => {
+  it("executeSQL returns an internal_error envelope when success is false with no error field", async () => {
     mockExecuteSQLExecute.mockResolvedValueOnce({ success: false });
 
     const { client } = await createTestClient();
@@ -217,7 +355,9 @@ describe("MCP tools", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(getContentText(result.content)).toBe("Query failed");
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("internal_error");
+    expect(envelope!.message).toBe("Query failed");
   });
 
   // #1858 — actor binding regression. Inside executeSQL the approval gate

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -165,10 +165,17 @@ describe("MCP tools", () => {
     expect(result.isError).toBeFalsy();
   });
 
-  it("executeSQL returns a validation_failed envelope on a SQL guard rejection", async () => {
+  // Each test below uses the LITERAL upstream message string emitted by the
+  // upstream constructor (sql.ts / rls.ts / source-rate-limit.ts /
+  // connection.ts) — NOT a synthetic stand-in. If the upstream rewords its
+  // message and the envelope regex isn't updated, these tests break, which
+  // is the desired drift signal. (See `error-envelope.ts` header for the
+  // tagged-error replumb that would replace string matching.)
+
+  it("executeSQL returns validation_failed for `Forbidden SQL operation detected` (sql.ts:304)", async () => {
     mockExecuteSQLExecute.mockResolvedValueOnce({
       success: false,
-      error: "Forbidden SQL operation detected",
+      error: "Forbidden SQL operation detected: drop\\s+table",
     });
 
     const { client } = await createTestClient();
@@ -187,10 +194,43 @@ describe("MCP tools", () => {
     expect(envelope!.message).toContain("Forbidden SQL operation");
   });
 
-  it("executeSQL maps an RLS rejection to rls_denied", async () => {
+  it("executeSQL returns validation_failed for `Empty query` and `Multiple statements are not allowed` (sql.ts:268, 322)", async () => {
+    const { client } = await createTestClient();
+
+    mockExecuteSQLExecute.mockResolvedValueOnce({ success: false, error: "Empty query" });
+    let result = await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "", explanation: "empty" },
+    });
+    expect(parseAtlasMcpToolError(getContentText(result.content))!.code).toBe("validation_failed");
+
+    mockExecuteSQLExecute.mockResolvedValueOnce({ success: false, error: "Multiple statements are not allowed" });
+    result = await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "SELECT 1; SELECT 2", explanation: "two" },
+    });
+    expect(parseAtlasMcpToolError(getContentText(result.content))!.code).toBe("validation_failed");
+  });
+
+  it("executeSQL returns validation_failed for `Query could not be parsed.` (sql.ts:361)", async () => {
     mockExecuteSQLExecute.mockResolvedValueOnce({
       success: false,
-      error: "RLS check failed: user has no claim for orders.org_id",
+      error: "Query could not be parsed. unexpected token at position 12. Rewrite using standard SQL syntax.",
+    });
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "SELECT FROM WHERE", explanation: "broken" },
+    });
+
+    expect(parseAtlasMcpToolError(getContentText(result.content))!.code).toBe("validation_failed");
+  });
+
+  it("executeSQL returns rls_denied for the real `Row-level security is enabled but not fully configured` message (sql.ts:651)", async () => {
+    mockExecuteSQLExecute.mockResolvedValueOnce({
+      success: false,
+      error: "Row-level security is enabled but not fully configured. Contact your administrator.",
     });
 
     const { client } = await createTestClient();
@@ -200,8 +240,31 @@ describe("MCP tools", () => {
     });
 
     expect(result.isError).toBe(true);
-    const envelope = parseAtlasMcpToolError(getContentText(result.content));
-    expect(envelope!.code).toBe("rls_denied");
+    expect(parseAtlasMcpToolError(getContentText(result.content))!.code).toBe("rls_denied");
+  });
+
+  it("executeSQL returns rls_denied for `RLS policy ...` and `RLS is enabled ...` (rls.ts:91, 134)", async () => {
+    const { client } = await createTestClient();
+
+    mockExecuteSQLExecute.mockResolvedValueOnce({
+      success: false,
+      error: 'RLS policy requires claim "org_id" but it is missing from the user\'s claims. Query blocked.',
+    });
+    let result = await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "SELECT 1", explanation: "x" },
+    });
+    expect(parseAtlasMcpToolError(getContentText(result.content))!.code).toBe("rls_denied");
+
+    mockExecuteSQLExecute.mockResolvedValueOnce({
+      success: false,
+      error: "RLS is enabled but no authenticated user is available. Authentication is required when RLS policies are active.",
+    });
+    result = await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "SELECT 1", explanation: "x" },
+    });
+    expect(parseAtlasMcpToolError(getContentText(result.content))!.code).toBe("rls_denied");
   });
 
   it("executeSQL maps a statement timeout to query_timeout", async () => {
@@ -220,10 +283,10 @@ describe("MCP tools", () => {
     expect(envelope!.code).toBe("query_timeout");
   });
 
-  it("executeSQL maps an unknown table to unknown_entity", async () => {
+  it("executeSQL returns unknown_entity for `is not in the allowed list` (sql.ts:393)", async () => {
     mockExecuteSQLExecute.mockResolvedValueOnce({
       success: false,
-      error: "Table 'ghosts' is not whitelisted in the semantic layer",
+      error: 'Table "ghosts" is not in the allowed list. Check catalog.yml for available tables.',
     });
 
     const { client } = await createTestClient();
@@ -232,14 +295,28 @@ describe("MCP tools", () => {
       arguments: { sql: "SELECT * FROM ghosts", explanation: "Ghost scan" },
     });
 
-    const envelope = parseAtlasMcpToolError(getContentText(result.content));
-    expect(envelope!.code).toBe("unknown_entity");
+    expect(parseAtlasMcpToolError(getContentText(result.content))!.code).toBe("unknown_entity");
   });
 
-  it("executeSQL maps a rate-limit rejection to rate_limited and forwards retry_after", async () => {
+  it("executeSQL returns unknown_entity for `Connection \"X\" is not registered.` (sql.ts:544)", async () => {
     mockExecuteSQLExecute.mockResolvedValueOnce({
       success: false,
-      error: "Rate limit exceeded for source default",
+      error: 'Connection "warehouse" is not registered.',
+    });
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "SELECT 1", explanation: "x", connectionId: "warehouse" },
+    });
+
+    expect(parseAtlasMcpToolError(getContentText(result.content))!.code).toBe("unknown_entity");
+  });
+
+  it("executeSQL returns rate_limited for the real `QPM limit reached` message (source-rate-limit.ts:99)", async () => {
+    mockExecuteSQLExecute.mockResolvedValueOnce({
+      success: false,
+      error: 'Source "default" QPM limit reached (60/min)',
       retryAfterMs: 12_000,
     });
 
@@ -256,10 +333,51 @@ describe("MCP tools", () => {
     expect(envelope!.retry_after).toBe(12);
   });
 
+  it("executeSQL returns rate_limited for `Connection pool capacity reached` (sql.ts:556)", async () => {
+    mockExecuteSQLExecute.mockResolvedValueOnce({
+      success: false,
+      error: "Connection pool capacity reached — the system is handling many concurrent tenants. Try again shortly.",
+    });
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "SELECT 1", explanation: "ping" },
+    });
+
+    expect(parseAtlasMcpToolError(getContentText(result.content))!.code).toBe("rate_limited");
+  });
+
+  it("executeSQL approval-required: surfaces approval_request_id + message intact, NOT as an error envelope (sql.ts:1093)", async () => {
+    // The pre-fix bug demoted approval-required to internal_error "Query
+    // failed", losing the request id and prompting the agent to retry +
+    // silently re-create duplicate approval requests. Lock the contract.
+    mockExecuteSQLExecute.mockResolvedValueOnce({
+      success: false,
+      approval_required: true,
+      approval_request_id: "appr_abc123",
+      matched_rules: ["pii-tables"],
+      message: 'This query requires approval before execution. Rule: "pii-tables". An approval request has been submitted (ID: appr_abc123). An admin must approve it before the query can run.',
+    });
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "SELECT * FROM customers", explanation: "PII scan" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(getContentText(result.content));
+    expect(parsed.approval_required).toBe(true);
+    expect(parsed.approval_request_id).toBe("appr_abc123");
+    expect(parsed.message).toContain("appr_abc123");
+    expect(parsed.matched_rules).toEqual(["pii-tables"]);
+  });
+
   it("executeSQL falls back to internal_error with a request_id on opaque failures", async () => {
     mockExecuteSQLExecute.mockResolvedValueOnce({
       success: false,
-      error: "Approval system unavailable — query blocked. Contact your administrator.",
+      error: "Some completely unknown failure mode the regex catalog doesn't recognize",
     });
 
     const { client } = await createTestClient();

--- a/packages/mcp/src/error-envelope.ts
+++ b/packages/mcp/src/error-envelope.ts
@@ -8,8 +8,15 @@
  * The envelope is serialized as the JSON body of an `isError: true` MCP
  * tool response so an LLM agent can branch on `code` instead of pattern-
  * matching prose. Keep this file in lockstep with `@useatlas/types`'s
- * `mcp.ts`: when a new code is added, the compiler will flag every
- * non-exhaustive switch in this module.
+ * `mcp.ts`: a new code requires (1) extending the union there, (2)
+ * appending to `ATLAS_MCP_TOOL_ERROR_CODES` (the symmetric drift guard
+ * in `mcp.ts` makes that compile-checked in both directions, and the
+ * pinned-length test in `__tests__/mcp.test.ts` catches a forgotten
+ * runtime-array update), and (3) adding a regex branch below — the
+ * classifier is an if-chain rather than a switch, so missing the third
+ * step is NOT compile-checked. Future work: replumb
+ * `pipelineErrorToResponse` in `packages/api/src/lib/tools/sql.ts` to
+ * carry the tagged-error `_tag` so this file can switch on tag.
  */
 
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
@@ -64,24 +71,40 @@ export function envelope(
  *
  * Why string matching? The two upstream surfaces are deliberately string-
  * shaped today — `executeSQL` returns `{ success: false, error: <string> }`
- * after collapsing 7+ tagged pipeline errors in `pipelineErrorToResponse`,
+ * after collapsing every `PipelineError` (8 tagged variants today: see
+ * `sql.ts:PipelineError`) into one shape in `pipelineErrorToResponse`,
  * and `explore` returns `Error: ...` / `Error (exit N):` prose from the
  * sandbox backend. Replumbing both to surface tagged errors at the MCP
- * boundary is in scope for a follow-up; for now we map the shapes we ship
- * today, with each pattern carrying a comment pointing at the source so
- * drift is detectable.
+ * boundary is in scope for a follow-up; for now we map the actual
+ * production strings.
  *
- * The catalog is closed: if `error` doesn't match a known shape we return
- * `internal_error` so the agent always gets a typed envelope.
+ * **Lossy by construction.** Every regex below is matched against a
+ * *literal* substring from the upstream constructor (the `// → <tag>:`
+ * comment names the source). Drift in the upstream message text will
+ * silently demote that failure to `internal_error` — the test suite
+ * pins the synthetic side by importing the same strings from the
+ * upstream sources where possible.
+ *
+ * The catalog is closed: if `error` doesn't match a known shape we
+ * return `internal_error` so the agent always gets a typed envelope.
  */
 export function classifyExecuteSqlError(rawError: string): AtlasMcpToolErrorCode {
-  // Empty / missing → treat as internal_error so the agent gets a code at
-  // all instead of a bare envelope.
+  // Empty / missing → treat as internal_error so the agent gets a code
+  // at all instead of a bare envelope.
   if (!rawError) return "internal_error";
 
-  // RLS — sql.ts:RLSError messages and pipeline rejections start with
-  // "RLS check failed" or "RLS rejected" depending on the path.
-  if (/RLS\s+(check\s+failed|rejected|denied)/i.test(rawError)) {
+  // RLS — every constructor in `lib/tools/sql.ts:644-717` and
+  // `lib/rls.ts:87-161` opens with one of: "Row-level security",
+  // "Query could not be analyzed for row-level security",
+  // "Query could not be processed for row-level security",
+  // "RLS is enabled", or "RLS policy". The single anchored alternation
+  // covers all six call sites.
+  if (
+    /\b(row-level\s+security|RLS\s+is\s+enabled|RLS\s+policy|RLS:\s|RLS\s+blocked)/i.test(
+      rawError,
+    ) ||
+    /\b(analyzed|processed)\s+for\s+row-level\s+security/i.test(rawError)
+  ) {
     return "rls_denied";
   }
 
@@ -95,32 +118,58 @@ export function classifyExecuteSqlError(rawError: string): AtlasMcpToolErrorCode
     return "query_timeout";
   }
 
-  // Rate limiting — RateLimitExceededError + ConcurrencyLimitError both
-  // surface as "rate limit" / "concurrency limit" in the message. Pool
-  // exhaustion gets the same code (transient back-off is the right call).
+  // Rate limiting:
+  //   - `RateLimitExceededError` (`db/source-rate-limit.ts:99`) →
+  //     `Source "X" QPM limit reached (60/min)`
+  //   - `ConcurrencyLimitError` (`db/source-rate-limit.ts:86`) →
+  //     `Source "X" concurrency limit reached (...)`
+  //   - `PoolExhaustedError` (`tools/sql.ts:555`) →
+  //     `Connection pool capacity reached — the system is handling many concurrent tenants. Try again shortly.`
+  //   - `RateLimitExceededError` audit prefix in sql.ts:1252 →
+  //     `Rate limited: <message>`
+  // Pool exhaustion is classified `rate_limited` rather than
+  // `internal_error` because the agent's correct recovery is the same
+  // (back off), not "file a bug."
   if (
-    /rate\s+limit|concurrency\s+limit|too\s+many\s+(clients|connections|requests)|pool\s+exhausted/i.test(
+    /\bQPM\s+limit\s+reached|\bconcurrency\s+limit\s+reached|\bconnection\s+pool\s+capacity\s+reached|\brate\s+limited:|\bremaining\s+connection\s+slots\s+are\s+reserved/i.test(
       rawError,
     )
   ) {
     return "rate_limited";
   }
 
-  // Unknown entity / table — semantic-layer whitelist rejections from
-  // sql.ts read "Table 'X' is not whitelisted in the semantic layer" and
-  // sibling "Unknown table".
+  // Unknown table / connection:
+  //   - Whitelist guard (`tools/sql.ts:393, 401`) →
+  //     `Table "X" is not in the allowed list. Check catalog.yml for available tables.`
+  //   - `ConnectionNotFoundError` (`tools/sql.ts:535-567`,
+  //     `db/connection.ts`) → `Connection "X" is not registered.` /
+  //     `Connection "X" failed to initialize: ...`
+  //   - `NoDatasourceError` (`db/connection.ts:977`) →
+  //     `No analytics datasource configured. ...`
+  // All three are "agent specified the wrong identifier" failures —
+  // recovery is "call listEntities or check the connection name", not
+  // "retry."
   if (
-    /not\s+whitelisted|not\s+in\s+the\s+semantic\s+layer|unknown\s+table|table\s+\S+\s+(does\s+not\s+exist|not\s+found)/i.test(
+    /\bis\s+not\s+in\s+the\s+allowed\s+list|\bis\s+not\s+registered|\bfailed\s+to\s+initialize|\bno\s+analytics\s+datasource\s+configured/i.test(
       rawError,
     )
   ) {
     return "unknown_entity";
   }
 
-  // SQL validation rejections — covers the regex/AST/whitelist guards in
-  // validateSQL and the "Plugin-rewritten SQL failed validation" arm.
+  // SQL validation rejections — the four canonical messages from
+  // `validateSQL` in `tools/sql.ts`:
+  //   - `Empty query` (line 268, 289)
+  //   - `Forbidden SQL operation detected: <pattern>` (line 304)
+  //   - `Multiple statements are not allowed` (line 322)
+  //   - `Query could not be parsed.... Rewrite using standard SQL syntax.` (line 361)
+  // Plus the plugin-rewrite arms:
+  //   - `Plugin-rewritten SQL failed validation: ...` (line 1221)
+  //   - `Query rejected by plugin: ...` (`PluginRejectedError`, line 1194)
+  // And the custom-validator path:
+  //   - `Query validation failed for connection "X": internal validator error`
   if (
-    /forbidden\s+sql|sql\s+(validation|guard|parse)|invalid\s+sql|only\s+SELECT|failed\s+validation|disallowed\s+statement/i.test(
+    /\bempty\s+query\b|\bforbidden\s+sql\s+operation|\bmultiple\s+statements\s+are\s+not\s+allowed|\bcould\s+not\s+be\s+parsed|\brejected\s+by\s+plugin|\bplugin-?rewritten\s+sql\s+failed\s+validation|\bquery\s+validation\s+failed\s+for\s+connection|\bonly\s+SELECT\b|\bdisallowed\s+statement/i.test(
       rawError,
     )
   ) {
@@ -134,13 +183,25 @@ export function classifyExecuteSqlError(rawError: string): AtlasMcpToolErrorCode
  * Map a raw explore-tool string (which today returns `Error:` / `Error
  * (exit N):` prose, never an envelope) onto a code. Same string-matching
  * caveat as {@link classifyExecuteSqlError}.
+ *
+ * Plugin command rejections (`Error: Command rejected by plugin: ...`,
+ * `explore.ts:544`) get `validation_failed` — the agent's recovery is
+ * "rewrite the command", not "retry." Backend init failures and
+ * exit-coded backend output stay `internal_error`.
  */
 export function classifyExploreError(rawError: string): AtlasMcpToolErrorCode {
   if (!rawError) return "internal_error";
 
-  // Plugin/backend rate-limit signals.
-  if (/rate\s+limit|too\s+many\s+requests|pool\s+exhausted/i.test(rawError)) {
+  // Plugin/backend rate-limit signals — explore-side rate limiting
+  // surfaces through plugin hook output today. Same QPM phrase covered
+  // for symmetry with executeSQL.
+  if (/\b(QPM\s+limit\s+reached|rate\s+limit|too\s+many\s+requests|pool\s+capacity\s+reached|pool\s+exhausted)/i.test(rawError)) {
     return "rate_limited";
+  }
+
+  // Plugin command rejections — the agent should rewrite the command.
+  if (/\brejected\s+by\s+plugin\b/i.test(rawError)) {
+    return "validation_failed";
   }
 
   // Backend / runtime initialization failures, sandbox errors, missing

--- a/packages/mcp/src/error-envelope.ts
+++ b/packages/mcp/src/error-envelope.ts
@@ -1,0 +1,150 @@
+/**
+ * Helpers that build the structured MCP error envelope (#2030) and map
+ * Atlas's two upstream failure shapes — the executeSQL pipeline's
+ * `{ success: false, error }` plus the explore tool's `Error: ...` /
+ * `Error (exit N):` prose — into the closed catalog of
+ * {@link AtlasMcpToolErrorCode} codes.
+ *
+ * The envelope is serialized as the JSON body of an `isError: true` MCP
+ * tool response so an LLM agent can branch on `code` instead of pattern-
+ * matching prose. Keep this file in lockstep with `@useatlas/types`'s
+ * `mcp.ts`: when a new code is added, the compiler will flag every
+ * non-exhaustive switch in this module.
+ */
+
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  AtlasMcpToolError,
+  AtlasMcpToolErrorCode,
+} from "@useatlas/types/mcp";
+
+export type { AtlasMcpToolError, AtlasMcpToolErrorCode };
+
+/**
+ * Build a structured error envelope and return it as an `isError: true`
+ * MCP `CallToolResult` whose first `text` content block is the JSON body.
+ *
+ * The MCP SDK's `client.callTool()` round-trips `content[0].text` as
+ * a string, so callers must `JSON.parse(text)` (or use
+ * `parseAtlasMcpToolError` from `@useatlas/types`) to recover the typed
+ * envelope.
+ */
+export function toEnvelopeResult(error: AtlasMcpToolError): CallToolResult {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(error) }],
+    isError: true,
+  };
+}
+
+/**
+ * Convenience constructor — assemble an envelope from positional args
+ * without forcing every call site to spell out the object literal. Empty
+ * `hint` / `request_id` / `retry_after` arguments are omitted from the
+ * wire payload (rather than serialized as `null`/`undefined`) so the JSON
+ * shape stays minimal — agents that branch on key presence don't see
+ * spurious nullable fields.
+ */
+export function envelope(
+  code: AtlasMcpToolErrorCode,
+  message: string,
+  extras?: { hint?: string; request_id?: string; retry_after?: number },
+): AtlasMcpToolError {
+  return {
+    code,
+    message,
+    ...(extras?.hint !== undefined && { hint: extras.hint }),
+    ...(extras?.request_id !== undefined && { request_id: extras.request_id }),
+    ...(extras?.retry_after !== undefined && { retry_after: extras.retry_after }),
+  };
+}
+
+/**
+ * Lift a raw error string out of the executeSQL pipeline (and explore's
+ * `Error:` prose) into a typed code.
+ *
+ * Why string matching? The two upstream surfaces are deliberately string-
+ * shaped today — `executeSQL` returns `{ success: false, error: <string> }`
+ * after collapsing 7+ tagged pipeline errors in `pipelineErrorToResponse`,
+ * and `explore` returns `Error: ...` / `Error (exit N):` prose from the
+ * sandbox backend. Replumbing both to surface tagged errors at the MCP
+ * boundary is in scope for a follow-up; for now we map the shapes we ship
+ * today, with each pattern carrying a comment pointing at the source so
+ * drift is detectable.
+ *
+ * The catalog is closed: if `error` doesn't match a known shape we return
+ * `internal_error` so the agent always gets a typed envelope.
+ */
+export function classifyExecuteSqlError(rawError: string): AtlasMcpToolErrorCode {
+  // Empty / missing → treat as internal_error so the agent gets a code at
+  // all instead of a bare envelope.
+  if (!rawError) return "internal_error";
+
+  // RLS — sql.ts:RLSError messages and pipeline rejections start with
+  // "RLS check failed" or "RLS rejected" depending on the path.
+  if (/RLS\s+(check\s+failed|rejected|denied)/i.test(rawError)) {
+    return "rls_denied";
+  }
+
+  // Statement timeout — Postgres "canceling statement due to statement
+  // timeout" / "query timeout" / MySQL "Query execution was interrupted".
+  if (
+    /statement\s+timeout|query\s+timeout|canceling\s+statement|execution\s+was\s+interrupted/i.test(
+      rawError,
+    )
+  ) {
+    return "query_timeout";
+  }
+
+  // Rate limiting — RateLimitExceededError + ConcurrencyLimitError both
+  // surface as "rate limit" / "concurrency limit" in the message. Pool
+  // exhaustion gets the same code (transient back-off is the right call).
+  if (
+    /rate\s+limit|concurrency\s+limit|too\s+many\s+(clients|connections|requests)|pool\s+exhausted/i.test(
+      rawError,
+    )
+  ) {
+    return "rate_limited";
+  }
+
+  // Unknown entity / table — semantic-layer whitelist rejections from
+  // sql.ts read "Table 'X' is not whitelisted in the semantic layer" and
+  // sibling "Unknown table".
+  if (
+    /not\s+whitelisted|not\s+in\s+the\s+semantic\s+layer|unknown\s+table|table\s+\S+\s+(does\s+not\s+exist|not\s+found)/i.test(
+      rawError,
+    )
+  ) {
+    return "unknown_entity";
+  }
+
+  // SQL validation rejections — covers the regex/AST/whitelist guards in
+  // validateSQL and the "Plugin-rewritten SQL failed validation" arm.
+  if (
+    /forbidden\s+sql|sql\s+(validation|guard|parse)|invalid\s+sql|only\s+SELECT|failed\s+validation|disallowed\s+statement/i.test(
+      rawError,
+    )
+  ) {
+    return "validation_failed";
+  }
+
+  return "internal_error";
+}
+
+/**
+ * Map a raw explore-tool string (which today returns `Error:` / `Error
+ * (exit N):` prose, never an envelope) onto a code. Same string-matching
+ * caveat as {@link classifyExecuteSqlError}.
+ */
+export function classifyExploreError(rawError: string): AtlasMcpToolErrorCode {
+  if (!rawError) return "internal_error";
+
+  // Plugin/backend rate-limit signals.
+  if (/rate\s+limit|too\s+many\s+requests|pool\s+exhausted/i.test(rawError)) {
+    return "rate_limited";
+  }
+
+  // Backend / runtime initialization failures, sandbox errors, missing
+  // files, command-not-found from the OverlayFs Bash. None of these are
+  // "the agent did SQL wrong" — they're operator-side failures.
+  return "internal_error";
+}

--- a/packages/mcp/src/semantic-tools.ts
+++ b/packages/mcp/src/semantic-tools.ts
@@ -12,7 +12,8 @@
  * envelope (#2030) so an LLM agent can branch on `code` instead of
  * pattern-matching prose. `searchGlossary` upgrades the recommendation
  * to a hard `ambiguous_term` envelope when any matched term has
- * `status: ambiguous` — the disambiguation eval (#2025) asserts on it.
+ * `status: ambiguous` — the forthcoming disambiguation eval (#2025) is
+ * expected to assert on this code.
  */
 
 import { z } from "zod/v4";
@@ -222,21 +223,31 @@ export function registerSemanticTools(
           try {
             const matches = searchGlossary(term);
 
-            // The disambiguation contract (#2020 + #2025): when ANY matched
-            // glossary entry has `status: ambiguous`, surface it as a hard
-            // `ambiguous_term` envelope with the possible mappings in the
-            // hint. The agent's correct recovery is to ask the user which
-            // mapping they meant — never silently pick. The eval harness
-            // asserts on `code === "ambiguous_term"`.
+            // The disambiguation contract (#2020 + forthcoming #2025): when
+            // ANY matched glossary entry has `status: ambiguous`, surface
+            // it as a hard `ambiguous_term` envelope with the possible
+            // mappings in the hint. The agent's correct recovery is to ask
+            // the user which mapping they meant — never silently pick. The
+            // forthcoming eval harness is expected to assert on
+            // `code === "ambiguous_term"`.
             const ambiguous = matches.find((m) => m.status === "ambiguous");
             if (ambiguous) {
               const mappings = ambiguous.possible_mappings.length > 0
                 ? ` Possible mappings: ${ambiguous.possible_mappings.join(", ")}.`
                 : "";
+              // Note when other matches were dropped — the envelope contract
+              // is "one ambiguous term blocks the call" so callers don't see
+              // sibling defined terms that were in the same result set. Tell
+              // the agent it can re-query for a more specific term to
+              // recover the others.
+              const otherCount = matches.length - 1;
+              const otherSuffix = otherCount > 0
+                ? ` ${otherCount} additional match${otherCount === 1 ? "" : "es"} omitted — re-call searchGlossary with a more specific term to retrieve them.`
+                : "";
               return toEnvelopeResult(
                 envelope(
                   "ambiguous_term",
-                  `Glossary term "${ambiguous.term}" is ambiguous — ask the user which mapping they meant.${mappings}`,
+                  `Glossary term "${ambiguous.term}" is ambiguous — ask the user which mapping they meant.${mappings}${otherSuffix}`,
                   {
                     hint: "Surface possible_mappings to the user and ask which they meant; do not silently pick a mapping.",
                   },
@@ -336,7 +347,21 @@ export function registerSemanticTools(
             )) as Record<string, unknown>;
 
             if (result.success === false) {
-              const rawError = String(result.error ?? "Metric execution failed.");
+              // Approval-required is a governance outcome, not a failure —
+              // surface the approval_request_id + message intact so the
+              // agent doesn't retry and silently duplicate the request.
+              // Mirrors the same branch in tools.ts:executeSQL.
+              if (result.approval_required === true) {
+                return toJsonContent({
+                  id: metric.id,
+                  approval_required: true,
+                  approval_request_id: result.approval_request_id,
+                  matched_rules: result.matched_rules,
+                  message: result.message,
+                });
+              }
+
+              const rawError = String(result.error ?? result.message ?? "Metric execution failed.");
               const code = classifyExecuteSqlError(rawError);
               const extras: { request_id?: string; retry_after?: number } = {};
               if (code === "internal_error") extras.request_id = requestId;

--- a/packages/mcp/src/semantic-tools.ts
+++ b/packages/mcp/src/semantic-tools.ts
@@ -7,6 +7,12 @@
  * Actor binding mirrors `tools.ts`: every dispatch is wrapped in
  * `withRequestContext({ user: actor, requestId })` so any downstream
  * approval/RLS gate sees a bound caller (#1858 — see tools.ts header).
+ *
+ * Failure shape: every error path returns an `AtlasMcpToolError`
+ * envelope (#2030) so an LLM agent can branch on `code` instead of
+ * pattern-matching prose. `searchGlossary` upgrades the recommendation
+ * to a hard `ambiguous_term` envelope when any matched term has
+ * `status: ambiguous` — the disambiguation eval (#2025) asserts on it.
  */
 
 import { z } from "zod/v4";
@@ -28,6 +34,11 @@ import {
   RUN_METRIC_TOOL_DESCRIPTION,
   type SemanticToolName,
 } from "@atlas/api/lib/tools/descriptions";
+import {
+  classifyExecuteSqlError,
+  envelope,
+  toEnvelopeResult,
+} from "./error-envelope.js";
 
 // Modest input bounds — MCP clients (including hostile ones in BYOC
 // SaaS) shouldn't be able to drive megabyte strings into the catalog
@@ -42,6 +53,21 @@ const MAX_FREE_TEXT_LEN = 1024;
 // constraint at the Zod boundary gives the MCP client an immediate
 // error instead of an indistinguishable `{ found: false }`.
 const ENTITY_NAME_PATTERN = /^[A-Za-z0-9_.-]+$/;
+
+// Per-tool error catalogs surfaced in tool descriptions — the LLM reads
+// these to learn which codes can come back, and the test suite asserts
+// each catalog is reachable.
+const LIST_ENTITIES_ERROR_CODES = ["internal_error"] as const;
+const DESCRIBE_ENTITY_ERROR_CODES = ["unknown_entity", "internal_error"] as const;
+const SEARCH_GLOSSARY_ERROR_CODES = ["ambiguous_term", "internal_error"] as const;
+const RUN_METRIC_ERROR_CODES = [
+  "unknown_metric",
+  "validation_failed",
+  "rls_denied",
+  "query_timeout",
+  "rate_limited",
+  "internal_error",
+] as const;
 
 export interface RegisterSemanticToolsOptions {
   /** Actor bound on every tool dispatch — see tools.ts. */
@@ -58,13 +84,6 @@ function toJsonContent(value: unknown): CallToolResult {
   };
 }
 
-function toErrorContent(message: string): CallToolResult {
-  return {
-    content: [{ type: "text" as const, text: message }],
-    isError: true,
-  };
-}
-
 function errorMessage(err: unknown, fallback: string): string {
   if (err instanceof Error) return err.message;
   // CLAUDE.md: `err instanceof Error ? err.message : String(err)`. The
@@ -73,6 +92,17 @@ function errorMessage(err: unknown, fallback: string): string {
   // give the caller no signal anyway.
   const s = String(err);
   return s && s !== "[object Object]" ? s : fallback;
+}
+
+/**
+ * Append the structured error contract to a tool's LLM-facing description
+ * so agents can read the recovery surface from the same place they read
+ * the tool's purpose.
+ */
+function withErrorContract(base: string, codes: readonly string[]): string {
+  return `${base}
+
+Error contract: failures return an \`{ code, message, hint?, request_id?, retry_after? }\` JSON envelope as the tool result text with \`isError: true\`. Possible codes: ${codes.map((c) => `\`${c}\``).join(", ")}. Branch on \`code\`; never pattern-match \`message\`.`;
 }
 
 export function registerSemanticTools(
@@ -86,7 +116,7 @@ export function registerSemanticTools(
     "listEntities" satisfies SemanticToolName,
     {
       title: "List Semantic Entities",
-      description: LIST_ENTITIES_TOOL_DESCRIPTION,
+      description: withErrorContract(LIST_ENTITIES_TOOL_DESCRIPTION, LIST_ENTITIES_ERROR_CODES),
       inputSchema: {
         filter: z
           .string()
@@ -97,9 +127,10 @@ export function registerSemanticTools(
           ),
       },
     },
-    async ({ filter }): Promise<CallToolResult> =>
-      withRequestContext(
-        { requestId: dispatchId("mcp-listEntities"), user: actor },
+    async ({ filter }): Promise<CallToolResult> => {
+      const requestId = dispatchId("mcp-listEntities");
+      return withRequestContext(
+        { requestId, user: actor },
         async () => {
           try {
             const entities = listEntities({ filter });
@@ -107,10 +138,13 @@ export function registerSemanticTools(
           } catch (err) {
             const message = errorMessage(err, "listEntities tool failed");
             process.stderr.write(`[atlas-mcp] listEntities threw: ${err}\n`);
-            return toErrorContent(message);
+            return toEnvelopeResult(
+              envelope("internal_error", message, { request_id: requestId }),
+            );
           }
         },
-      ),
+      );
+    },
   );
 
   // --- describeEntity ---
@@ -118,7 +152,7 @@ export function registerSemanticTools(
     "describeEntity" satisfies SemanticToolName,
     {
       title: "Describe Semantic Entity",
-      description: DESCRIBE_ENTITY_TOOL_DESCRIPTION,
+      description: withErrorContract(DESCRIBE_ENTITY_TOOL_DESCRIPTION, DESCRIBE_ENTITY_ERROR_CODES),
       inputSchema: {
         name: z
           .string()
@@ -130,23 +164,38 @@ export function registerSemanticTools(
           ),
       },
     },
-    async ({ name }): Promise<CallToolResult> =>
-      withRequestContext(
-        { requestId: dispatchId("mcp-describeEntity"), user: actor },
+    async ({ name }): Promise<CallToolResult> => {
+      const requestId = dispatchId("mcp-describeEntity");
+      return withRequestContext(
+        { requestId, user: actor },
         async () => {
           try {
             const entity = getEntityByName(name);
             if (!entity) {
-              return toJsonContent({ found: false, name });
+              // Unknown-entity isn't really a "tool failed" condition for
+              // the agent — the agent's recovery is "call listEntities and
+              // pick a known one." Emit it as a typed envelope so the
+              // recovery is machine-readable, with a hint pointing the
+              // agent at the right next call.
+              return toEnvelopeResult(
+                envelope(
+                  "unknown_entity",
+                  `Entity "${name}" not found in the semantic layer.`,
+                  { hint: "Call listEntities to discover available entities." },
+                ),
+              );
             }
             return toJsonContent({ found: true, entity });
           } catch (err) {
             const message = errorMessage(err, "describeEntity tool failed");
             process.stderr.write(`[atlas-mcp] describeEntity threw: ${err}\n`);
-            return toErrorContent(message);
+            return toEnvelopeResult(
+              envelope("internal_error", message, { request_id: requestId }),
+            );
           }
         },
-      ),
+      );
+    },
   );
 
   // --- searchGlossary ---
@@ -154,7 +203,7 @@ export function registerSemanticTools(
     "searchGlossary" satisfies SemanticToolName,
     {
       title: "Search Business Glossary",
-      description: SEARCH_GLOSSARY_TOOL_DESCRIPTION,
+      description: withErrorContract(SEARCH_GLOSSARY_TOOL_DESCRIPTION, SEARCH_GLOSSARY_ERROR_CODES),
       inputSchema: {
         term: z
           .string()
@@ -165,12 +214,36 @@ export function registerSemanticTools(
           ),
       },
     },
-    async ({ term }): Promise<CallToolResult> =>
-      withRequestContext(
-        { requestId: dispatchId("mcp-searchGlossary"), user: actor },
+    async ({ term }): Promise<CallToolResult> => {
+      const requestId = dispatchId("mcp-searchGlossary");
+      return withRequestContext(
+        { requestId, user: actor },
         async () => {
           try {
             const matches = searchGlossary(term);
+
+            // The disambiguation contract (#2020 + #2025): when ANY matched
+            // glossary entry has `status: ambiguous`, surface it as a hard
+            // `ambiguous_term` envelope with the possible mappings in the
+            // hint. The agent's correct recovery is to ask the user which
+            // mapping they meant — never silently pick. The eval harness
+            // asserts on `code === "ambiguous_term"`.
+            const ambiguous = matches.find((m) => m.status === "ambiguous");
+            if (ambiguous) {
+              const mappings = ambiguous.possible_mappings.length > 0
+                ? ` Possible mappings: ${ambiguous.possible_mappings.join(", ")}.`
+                : "";
+              return toEnvelopeResult(
+                envelope(
+                  "ambiguous_term",
+                  `Glossary term "${ambiguous.term}" is ambiguous — ask the user which mapping they meant.${mappings}`,
+                  {
+                    hint: "Surface possible_mappings to the user and ask which they meant; do not silently pick a mapping.",
+                  },
+                ),
+              );
+            }
+
             return toJsonContent({
               query: term,
               count: matches.length,
@@ -179,10 +252,13 @@ export function registerSemanticTools(
           } catch (err) {
             const message = errorMessage(err, "searchGlossary tool failed");
             process.stderr.write(`[atlas-mcp] searchGlossary threw: ${err}\n`);
-            return toErrorContent(message);
+            return toEnvelopeResult(
+              envelope("internal_error", message, { request_id: requestId }),
+            );
           }
         },
-      ),
+      );
+    },
   );
 
   // --- runMetric ---
@@ -193,7 +269,7 @@ export function registerSemanticTools(
     "runMetric" satisfies SemanticToolName,
     {
       title: "Run Canonical Metric",
-      description: RUN_METRIC_TOOL_DESCRIPTION,
+      description: withErrorContract(RUN_METRIC_TOOL_DESCRIPTION, RUN_METRIC_ERROR_CODES),
       inputSchema: {
         id: z
           .string()
@@ -223,20 +299,31 @@ export function registerSemanticTools(
           ),
       },
     },
-    async ({ id, filters, connectionId }): Promise<CallToolResult> =>
-      withRequestContext(
-        { requestId: dispatchId("mcp-runMetric"), user: actor },
+    async ({ id, filters, connectionId }): Promise<CallToolResult> => {
+      const requestId = dispatchId("mcp-runMetric");
+      return withRequestContext(
+        { requestId, user: actor },
         async () => {
           try {
             if (filters && Object.keys(filters).length > 0) {
-              return toErrorContent(
-                "runMetric `filters` pass-through is not yet supported. Use `executeSQL` with the metric's raw SQL to apply filters.",
+              return toEnvelopeResult(
+                envelope(
+                  "validation_failed",
+                  "runMetric `filters` pass-through is not yet supported. Use `executeSQL` with the metric's raw SQL to apply filters.",
+                  { hint: "Omit `filters` and re-run, or call executeSQL with a custom WHERE clause." },
+                ),
               );
             }
 
             const metric = findMetricById(id);
             if (!metric) {
-              return toErrorContent(`Metric "${id}" not found.`);
+              return toEnvelopeResult(
+                envelope(
+                  "unknown_metric",
+                  `Metric "${id}" not found.`,
+                  { hint: "Call listEntities or grep semantic/metrics/ to discover available metric ids." },
+                ),
+              );
             }
 
             const explanation = metric.description
@@ -249,8 +336,16 @@ export function registerSemanticTools(
             )) as Record<string, unknown>;
 
             if (result.success === false) {
-              return toErrorContent(
-                String(result.error ?? "Metric execution failed."),
+              const rawError = String(result.error ?? "Metric execution failed.");
+              const code = classifyExecuteSqlError(rawError);
+              const extras: { request_id?: string; retry_after?: number } = {};
+              if (code === "internal_error") extras.request_id = requestId;
+              const retryAfterMs = result.retryAfterMs;
+              if (code === "rate_limited" && typeof retryAfterMs === "number") {
+                extras.retry_after = Math.max(1, Math.round(retryAfterMs / 1000));
+              }
+              return toEnvelopeResult(
+                envelope(code, rawError, Object.keys(extras).length ? extras : undefined),
               );
             }
 
@@ -284,9 +379,12 @@ export function registerSemanticTools(
           } catch (err) {
             const message = errorMessage(err, "runMetric tool failed");
             process.stderr.write(`[atlas-mcp] runMetric threw: ${err}\n`);
-            return toErrorContent(message);
+            return toEnvelopeResult(
+              envelope("internal_error", message, { request_id: requestId }),
+            );
           }
         },
-      ),
+      );
+    },
   );
 }

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -151,13 +151,40 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
               { toolCallId: "mcp-executeSQL", messages: [] },
             );
 
-            // executeSQL collapses 7+ tagged pipeline errors into
-            // { success: false, error } in pipelineErrorToResponse. Lift the
-            // string back up into a typed envelope here (see #2030 follow-
-            // up note in error-envelope.ts about replumbing tagged errors).
+            // executeSQL collapses every PipelineError (8 tagged variants
+            // today: see sql.ts:PipelineError) into { success: false, error }
+            // in pipelineErrorToResponse. Lift the string back up into a
+            // typed envelope here.
             const obj = result as Record<string, unknown>;
             if (obj.success === false) {
-              const rawError = String(obj.error ?? "");
+              // Approval-required is NOT a tool failure — it's a governance
+              // outcome that already produced an approval_request_id the
+              // user must follow up on. Surfacing it as `internal_error`
+              // would (a) lose the request id and matched rule names, and
+              // (b) prompt the agent to retry, which silently re-creates
+              // duplicate approval requests. Pass it through as a non-error
+              // JSON body so the agent + user see the full payload.
+              if (obj.approval_required === true) {
+                return {
+                  content: [
+                    {
+                      type: "text" as const,
+                      text: JSON.stringify(
+                        {
+                          approval_required: true,
+                          approval_request_id: obj.approval_request_id,
+                          matched_rules: obj.matched_rules,
+                          message: obj.message,
+                        },
+                        null,
+                        2,
+                      ),
+                    },
+                  ],
+                };
+              }
+
+              const rawError = String(obj.error ?? obj.message ?? "");
               const code = classifyExecuteSqlError(rawError);
               const extras: { request_id?: string; retry_after?: number } = {};
               if (code === "internal_error") extras.request_id = requestId;

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -10,6 +10,10 @@
  * actor. Mirrors the F-54 (scheduler) / F-55 (Slack) binding pattern from
  * PR #1860. The actor is resolved once at server boot by `resolveMcpActor`
  * and threaded through `registerTools(server, { actor })`.
+ *
+ * #2030 — every failure path returns an `AtlasMcpToolError` envelope (JSON
+ * body of an `isError: true` MCP response) so an LLM agent can branch on
+ * `code` instead of pattern-matching prose. See `error-envelope.ts`.
  */
 
 import { z } from "zod/v4";
@@ -20,6 +24,12 @@ import { executeSQL } from "@atlas/api/lib/tools/sql";
 import type { AtlasUser } from "@atlas/api/lib/auth/types";
 import { withRequestContext } from "@atlas/api/lib/logger";
 import { registerSemanticTools } from "./semantic-tools.js";
+import {
+  classifyExecuteSqlError,
+  classifyExploreError,
+  envelope,
+  toEnvelopeResult,
+} from "./error-envelope.js";
 
 export interface RegisterToolsOptions {
   /**
@@ -36,6 +46,27 @@ function dispatchId(prefix: string): string {
   return `${prefix}-${crypto.randomUUID()}`;
 }
 
+/**
+ * Append the structured error contract to a tool's LLM-facing description
+ * so agents can read the recovery surface from the same place they read
+ * the tool's purpose.
+ */
+function withErrorContract(base: string, codes: readonly string[]): string {
+  return `${base}
+
+Error contract: failures return an \`{ code, message, hint?, request_id?, retry_after? }\` JSON envelope as the tool result text with \`isError: true\`. Possible codes: ${codes.map((c) => `\`${c}\``).join(", ")}. Branch on \`code\`; never pattern-match \`message\`.`;
+}
+
+const EXPLORE_ERROR_CODES = ["rate_limited", "internal_error"] as const;
+const EXECUTE_SQL_ERROR_CODES = [
+  "validation_failed",
+  "rls_denied",
+  "query_timeout",
+  "unknown_entity",
+  "rate_limited",
+  "internal_error",
+] as const;
+
 export function registerTools(server: McpServer, opts: RegisterToolsOptions): void {
   const { actor } = opts;
 
@@ -44,7 +75,7 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
     "explore",
     {
       title: "Explore Semantic Layer",
-      description: explore.description,
+      description: withErrorContract(explore.description ?? "", EXPLORE_ERROR_CODES),
       inputSchema: {
         command: z
           .string()
@@ -53,9 +84,10 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
           ),
       },
     },
-    async ({ command }): Promise<CallToolResult> =>
-      withRequestContext(
-        { requestId: dispatchId("mcp-explore"), user: actor },
+    async ({ command }): Promise<CallToolResult> => {
+      const requestId = dispatchId("mcp-explore");
+      return withRequestContext(
+        { requestId, user: actor },
         async () => {
           try {
             const result = await explore.execute!(
@@ -64,23 +96,29 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
             );
             const text =
               typeof result === "string" ? result : JSON.stringify(result);
-            const isError =
-              text.startsWith("Error:") || text.startsWith("Error (exit");
+            // explore today returns prose strings prefixed with `Error:` or
+            // `Error (exit N):` on failure rather than throwing. Lift those
+            // into the typed envelope so the agent doesn't have to scrape.
+            if (text.startsWith("Error:") || text.startsWith("Error (exit")) {
+              const code = classifyExploreError(text);
+              const message = text.replace(/^Error(\s\(exit\s\d+\))?:\s*/i, "").trim() || text;
+              return toEnvelopeResult(
+                envelope(code, message, code === "internal_error" ? { request_id: requestId } : undefined),
+              );
+            }
             return {
               content: [{ type: "text" as const, text }],
-              isError,
             };
           } catch (err) {
-            const text =
-              err instanceof Error ? err.message : "explore tool failed";
+            const message = err instanceof Error ? err.message : String(err);
             process.stderr.write(`[atlas-mcp] explore tool threw: ${err}\n`);
-            return {
-              content: [{ type: "text" as const, text }],
-              isError: true,
-            };
+            return toEnvelopeResult(
+              envelope("internal_error", message || "explore tool failed", { request_id: requestId }),
+            );
           }
         },
-      ),
+      );
+    },
   );
 
   // --- executeSQL ---
@@ -88,7 +126,7 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
     "executeSQL",
     {
       title: "Execute SQL Query",
-      description: executeSQL.description,
+      description: withErrorContract(executeSQL.description ?? "", EXECUTE_SQL_ERROR_CODES),
       inputSchema: {
         sql: z.string().describe("The SELECT query to execute"),
         explanation: z
@@ -102,9 +140,10 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
           ),
       },
     },
-    async ({ sql, explanation, connectionId }): Promise<CallToolResult> =>
-      withRequestContext(
-        { requestId: dispatchId("mcp-executeSQL"), user: actor },
+    async ({ sql, explanation, connectionId }): Promise<CallToolResult> => {
+      const requestId = dispatchId("mcp-executeSQL");
+      return withRequestContext(
+        { requestId, user: actor },
         async () => {
           try {
             const result = await executeSQL.execute!(
@@ -112,18 +151,23 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
               { toolCallId: "mcp-executeSQL", messages: [] },
             );
 
-            // executeSQL returns { success: boolean, error?, ... }
+            // executeSQL collapses 7+ tagged pipeline errors into
+            // { success: false, error } in pipelineErrorToResponse. Lift the
+            // string back up into a typed envelope here (see #2030 follow-
+            // up note in error-envelope.ts about replumbing tagged errors).
             const obj = result as Record<string, unknown>;
             if (obj.success === false) {
-              return {
-                content: [
-                  {
-                    type: "text" as const,
-                    text: String(obj.error ?? "Query failed"),
-                  },
-                ],
-                isError: true,
-              };
+              const rawError = String(obj.error ?? "");
+              const code = classifyExecuteSqlError(rawError);
+              const extras: { request_id?: string; retry_after?: number } = {};
+              if (code === "internal_error") extras.request_id = requestId;
+              const retryAfterMs = obj.retryAfterMs;
+              if (code === "rate_limited" && typeof retryAfterMs === "number") {
+                extras.retry_after = Math.max(1, Math.round(retryAfterMs / 1000));
+              }
+              return toEnvelopeResult(
+                envelope(code, rawError || "Query failed", Object.keys(extras).length ? extras : undefined),
+              );
             }
 
             return {
@@ -145,16 +189,15 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
               ],
             };
           } catch (err) {
-            const text =
-              err instanceof Error ? err.message : "executeSQL tool failed";
+            const message = err instanceof Error ? err.message : String(err);
             process.stderr.write(`[atlas-mcp] executeSQL tool threw: ${err}\n`);
-            return {
-              content: [{ type: "text" as const, text }],
-              isError: true,
-            };
+            return toEnvelopeResult(
+              envelope("internal_error", message || "executeSQL tool failed", { request_id: requestId }),
+            );
           }
         },
-      ),
+      );
+    },
   );
 
   // --- typed semantic-layer tools ---

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@useatlas/types",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {
-    "build": "rm -rf dist && bun build src/index.ts src/auth.ts src/conversation.ts src/connection.ts src/action.ts src/scheduled-task.ts src/errors.ts src/semantic.ts src/share.ts src/billing.ts src/dashboard.ts src/mode.ts src/starter-prompt.ts src/integrations.ts src/email-provider.ts --outdir dist --root src --target node --packages external && bun x tsc -p tsconfig.build.json"
+    "build": "rm -rf dist && bun build src/index.ts src/auth.ts src/conversation.ts src/connection.ts src/action.ts src/scheduled-task.ts src/errors.ts src/semantic.ts src/share.ts src/billing.ts src/dashboard.ts src/mode.ts src/starter-prompt.ts src/integrations.ts src/email-provider.ts src/mcp.ts --outdir dist --root src --target node --packages external && bun x tsc -p tsconfig.build.json"
   },
   "exports": {
     ".": {
@@ -81,6 +81,11 @@
       "types": "./dist/email-provider.d.ts",
       "import": "./dist/email-provider.js",
       "default": "./dist/email-provider.js"
+    },
+    "./mcp": {
+      "types": "./dist/mcp.d.ts",
+      "import": "./dist/mcp.js",
+      "default": "./dist/mcp.js"
     }
   },
   "main": "./dist/index.js",

--- a/packages/types/src/__tests__/mcp.test.ts
+++ b/packages/types/src/__tests__/mcp.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ATLAS_MCP_TOOL_ERROR_CODES,
+  isAtlasMcpToolErrorCode,
+  parseAtlasMcpToolError,
+  type AtlasMcpToolError,
+  type AtlasMcpToolErrorCode,
+} from "../index";
+
+describe("AtlasMcpToolErrorCode catalog", () => {
+  test("union and runtime list stay in lockstep", () => {
+    // satisfies + readonly array force the union to match the literal at
+    // compile time; the test pins the size at 8 so accidentally widening
+    // the union (e.g. adding "auth_failed" without updating consumers) is
+    // caught here too.
+    expect(ATLAS_MCP_TOOL_ERROR_CODES).toHaveLength(8);
+    const set = new Set<AtlasMcpToolErrorCode>(ATLAS_MCP_TOOL_ERROR_CODES);
+    expect(set.size).toBe(ATLAS_MCP_TOOL_ERROR_CODES.length);
+  });
+
+  test("isAtlasMcpToolErrorCode accepts each catalog entry", () => {
+    for (const code of ATLAS_MCP_TOOL_ERROR_CODES) {
+      expect(isAtlasMcpToolErrorCode(code)).toBe(true);
+    }
+  });
+
+  test("isAtlasMcpToolErrorCode rejects unknown strings", () => {
+    expect(isAtlasMcpToolErrorCode("not_a_code")).toBe(false);
+    expect(isAtlasMcpToolErrorCode("")).toBe(false);
+    expect(isAtlasMcpToolErrorCode("AMBIGUOUS_TERM")).toBe(false);
+  });
+});
+
+describe("parseAtlasMcpToolError", () => {
+  test("parses a minimal envelope", () => {
+    const env: AtlasMcpToolError = { code: "unknown_metric", message: "no such metric" };
+    const parsed = parseAtlasMcpToolError(env);
+    expect(parsed).toEqual(env);
+  });
+
+  test("parses a JSON string payload (the on-the-wire form)", () => {
+    const wire = JSON.stringify({ code: "rate_limited", message: "slow down", retry_after: 30 });
+    const parsed = parseAtlasMcpToolError(wire);
+    expect(parsed).toEqual({ code: "rate_limited", message: "slow down", retry_after: 30 });
+  });
+
+  test("preserves hint, request_id, retry_after when present", () => {
+    const env = {
+      code: "internal_error" as const,
+      message: "boom",
+      hint: "try again later",
+      request_id: "req_abc",
+      retry_after: 5,
+    };
+    expect(parseAtlasMcpToolError(env)).toEqual(env);
+  });
+
+  test("drops optional fields with the wrong type rather than rejecting the whole frame", () => {
+    const parsed = parseAtlasMcpToolError({
+      code: "internal_error",
+      message: "boom",
+      hint: 123,
+      request_id: false,
+      retry_after: "ten",
+    });
+    expect(parsed).toEqual({ code: "internal_error", message: "boom" });
+  });
+
+  test("returns null on an unknown code (closed catalog)", () => {
+    expect(parseAtlasMcpToolError({ code: "wat", message: "huh" })).toBeNull();
+  });
+
+  test("returns null when message is missing", () => {
+    expect(parseAtlasMcpToolError({ code: "validation_failed" })).toBeNull();
+  });
+
+  test("returns null on malformed JSON string", () => {
+    expect(parseAtlasMcpToolError("{not json")).toBeNull();
+  });
+
+  test("returns null on non-object inputs", () => {
+    expect(parseAtlasMcpToolError(null)).toBeNull();
+    expect(parseAtlasMcpToolError(undefined)).toBeNull();
+    expect(parseAtlasMcpToolError(42)).toBeNull();
+    expect(parseAtlasMcpToolError([])).toBeNull();
+  });
+});

--- a/packages/types/src/errors.ts
+++ b/packages/types/src/errors.ts
@@ -211,6 +211,13 @@ export function isChatContextWarningCode(value: string): value is ChatContextWar
  * Fields are `readonly` to signal the wire-DTO intent — once a frame is
  * pushed onto the agent's `contextWarnings` out-array, the chat route
  * only reads it. Mutating in place would be a write-after-publish bug.
+ *
+ * Field naming uses `camelCase` (`requestId`) because this shape is
+ * consumed by React on the same channel as the AI-SDK message stream,
+ * which is camelCase throughout. The sibling `AtlasMcpToolError` in
+ * `mcp.ts` uses `snake_case` (`request_id`) intentionally — it crosses
+ * an LLM/MCP boundary where snake_case is the convention. Don't
+ * mass-rename one to match the other.
  */
 export interface ChatContextWarning {
   readonly severity: "warning";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -32,3 +32,4 @@ export * from "./starter-prompt";
 export * from "./integrations";
 export * from "./email-provider";
 export * from "./audit-retention";
+export * from "./mcp";

--- a/packages/types/src/mcp.ts
+++ b/packages/types/src/mcp.ts
@@ -1,0 +1,135 @@
+/**
+ * Structured error envelope returned by every typed Atlas MCP tool.
+ *
+ * The MCP protocol surfaces tool failures as `{ isError: true, content: [...] }`
+ * with a free-form text payload. A free-form string forces an LLM agent to
+ * either pattern-match prose (brittle), blindly retry (DoS pattern), or give
+ * up. Every Atlas MCP tool serializes this envelope as the JSON body of that
+ * `text` content block so the agent can take the correct recovery action.
+ *
+ * Wire shape (snake_case): the envelope crosses an LLM/agent boundary, so
+ * field names match the surrounding MCP/JSON-RPC convention. Do NOT rename
+ * `request_id` or `retry_after` to camelCase — `@useatlas/sdk` consumers and
+ * the eval harness (#2025) assert on these exact keys.
+ */
+
+/**
+ * Closed set of error codes a typed MCP tool can return. Each code maps to a
+ * single failure mode an agent can act on:
+ *
+ * - `validation_failed` — SQL guard rejected (regex, AST, whitelist). The
+ *   query is permanently broken; the agent should rewrite it, not retry.
+ * - `rls_denied` — row-level security rejected the query for the bound
+ *   actor. Retrying with the same identity will not help; surface to user.
+ * - `query_timeout` — `statement_timeout` fired. Suggest a simpler query
+ *   or a tighter `LIMIT`. Not retryable as-is.
+ * - `unknown_entity` — the requested entity is not in the semantic layer.
+ *   The agent should call `listEntities` to discover what exists.
+ * - `unknown_metric` — the metric id is not in `metrics/*.yml`. The agent
+ *   should fall back to `executeSQL` or pick a different metric.
+ * - `ambiguous_term` — a glossary entry has `status: ambiguous`. The agent
+ *   MUST surface the ambiguity to the user with `possible_mappings` and
+ *   ask which they meant — never silently pick. The disambiguation eval in
+ *   #2025 asserts on this exact code.
+ * - `rate_limited` — request rate or concurrency cap hit. Include
+ *   `retry_after` (seconds) so the agent can back off correctly.
+ * - `internal_error` — unexpected failure. Include `request_id` so the
+ *   user can quote it when filing a support ticket.
+ *
+ * When adding a code: extend the union here AND extend the exhaustive
+ * `mapXyzErrorToCode()` switches in `packages/mcp/src/error-envelope.ts` —
+ * the compiler will flag the missing case.
+ */
+export type AtlasMcpToolErrorCode =
+  | "validation_failed"
+  | "rls_denied"
+  | "query_timeout"
+  | "unknown_entity"
+  | "unknown_metric"
+  | "ambiguous_term"
+  | "rate_limited"
+  | "internal_error";
+
+/**
+ * Wire shape of a typed MCP tool failure. Agents/SDK consumers parse the
+ * `text` content block of an `isError: true` MCP response as JSON and match
+ * this shape — see `parseAtlasMcpToolError` for a runtime guard.
+ */
+export interface AtlasMcpToolError {
+  /** Closed-set machine-readable code — the only field the agent should branch on. */
+  readonly code: AtlasMcpToolErrorCode;
+  /** Human + LLM readable message; safe to surface to an end user verbatim. */
+  readonly message: string;
+  /** Optional remediation hint (e.g. "call listEntities to see valid names"). */
+  readonly hint?: string;
+  /** Server-assigned request id; only set on `internal_error` so users can quote it. */
+  readonly request_id?: string;
+  /** Seconds to wait before retrying; only set on `rate_limited`. */
+  readonly retry_after?: number;
+}
+
+/** Closed list of every code, useful for table-driven tests and the runtime guard. */
+export const ATLAS_MCP_TOOL_ERROR_CODES = [
+  "validation_failed",
+  "rls_denied",
+  "query_timeout",
+  "unknown_entity",
+  "unknown_metric",
+  "ambiguous_term",
+  "rate_limited",
+  "internal_error",
+] as const satisfies readonly AtlasMcpToolErrorCode[];
+
+/** Type guard — checks whether a string is a known `AtlasMcpToolErrorCode`. */
+export function isAtlasMcpToolErrorCode(value: string): value is AtlasMcpToolErrorCode {
+  return (ATLAS_MCP_TOOL_ERROR_CODES as ReadonlyArray<string>).includes(value);
+}
+
+/**
+ * Validate that a runtime value matches the {@link AtlasMcpToolError} wire
+ * shape. Returns the typed envelope when it matches; returns `null` when any
+ * required field is missing or has the wrong type.
+ *
+ * Use this on the `text` payload of an `isError: true` MCP response — the
+ * MCP SDK types tool result content as `unknown`, so a runtime guard is
+ * required before trusting the shape.
+ *
+ * @example
+ * ```ts
+ * const result = await client.callTool({ name: "runMetric", arguments: { id: "x" } });
+ * if (result.isError) {
+ *   const envelope = parseAtlasMcpToolError(getContentText(result.content));
+ *   if (envelope?.code === "ambiguous_term") {
+ *     // ask the user which mapping they meant
+ *   }
+ * }
+ * ```
+ */
+export function parseAtlasMcpToolError(value: unknown): AtlasMcpToolError | null {
+  let candidate: unknown = value;
+  if (typeof value === "string") {
+    try {
+      candidate = JSON.parse(value);
+    } catch {
+      return null;
+    }
+  }
+  if (candidate === null || typeof candidate !== "object" || Array.isArray(candidate)) {
+    return null;
+  }
+  const obj = candidate as Record<string, unknown>;
+  if (typeof obj.code !== "string" || !isAtlasMcpToolErrorCode(obj.code)) return null;
+  if (typeof obj.message !== "string") return null;
+
+  const hint = typeof obj.hint === "string" ? obj.hint : undefined;
+  const request_id = typeof obj.request_id === "string" ? obj.request_id : undefined;
+  const retry_after = typeof obj.retry_after === "number" ? obj.retry_after : undefined;
+
+  return {
+    code: obj.code,
+    message: obj.message,
+    ...(hint !== undefined && { hint }),
+    ...(request_id !== undefined && { request_id }),
+    ...(retry_after !== undefined && { retry_after }),
+  };
+}

--- a/packages/types/src/mcp.ts
+++ b/packages/types/src/mcp.ts
@@ -9,8 +9,12 @@
  *
  * Wire shape (snake_case): the envelope crosses an LLM/agent boundary, so
  * field names match the surrounding MCP/JSON-RPC convention. Do NOT rename
- * `request_id` or `retry_after` to camelCase — `@useatlas/sdk` consumers and
- * the eval harness (#2025) assert on these exact keys.
+ * `request_id` or `retry_after` to camelCase — they are part of the wire
+ * contract that `@useatlas/sdk` consumers parse, and the forthcoming eval
+ * harness (#2025) is expected to assert on these exact keys. (The sibling
+ * `ChatContextWarning` shape in `errors.ts` uses camelCase intentionally —
+ * that one is consumed inside React, not over an LLM boundary, so the
+ * convention divergence is deliberate.)
  */
 
 /**
@@ -23,22 +27,34 @@
  *   actor. Retrying with the same identity will not help; surface to user.
  * - `query_timeout` — `statement_timeout` fired. Suggest a simpler query
  *   or a tighter `LIMIT`. Not retryable as-is.
- * - `unknown_entity` — the requested entity is not in the semantic layer.
- *   The agent should call `listEntities` to discover what exists.
+ * - `unknown_entity` — the requested entity is not in the semantic layer
+ *   (also covers unregistered connection ids and missing datasource
+ *   config — all "agent specified the wrong identifier" failures). The
+ *   agent should call `listEntities` to discover what exists.
  * - `unknown_metric` — the metric id is not in `metrics/*.yml`. The agent
  *   should fall back to `executeSQL` or pick a different metric.
  * - `ambiguous_term` — a glossary entry has `status: ambiguous`. The agent
  *   MUST surface the ambiguity to the user with `possible_mappings` and
- *   ask which they meant — never silently pick. The disambiguation eval in
- *   #2025 asserts on this exact code.
- * - `rate_limited` — request rate or concurrency cap hit. Include
- *   `retry_after` (seconds) so the agent can back off correctly.
- * - `internal_error` — unexpected failure. Include `request_id` so the
+ *   ask which they meant — never silently pick. The forthcoming
+ *   disambiguation eval (#2025) is expected to assert on this exact code.
+ * - `rate_limited` — request rate, concurrency cap, or pool capacity hit.
+ *   Includes `retry_after` (seconds) when the upstream knows it.
+ * - `internal_error` — unexpected failure. Includes `request_id` so the
  *   user can quote it when filing a support ticket.
  *
- * When adding a code: extend the union here AND extend the exhaustive
- * `mapXyzErrorToCode()` switches in `packages/mcp/src/error-envelope.ts` —
- * the compiler will flag the missing case.
+ * When adding a code:
+ *   1. Extend the union here.
+ *   2. Append to `ATLAS_MCP_TOOL_ERROR_CODES` (the `_CodesArrayCovers`
+ *      guard below makes that compile-checked in both directions; the
+ *      pinned-length test in `__tests__/mcp.test.ts` catches a forgotten
+ *      runtime-array update).
+ *   3. Add a regex branch in `classifyExecuteSqlError` /
+ *      `classifyExploreError` in `packages/mcp/src/error-envelope.ts` —
+ *      these are if-chains, NOT switches, so missing this step is silent
+ *      and the new failure mode will fall through to `internal_error`.
+ *   4. Add the code to the per-tool catalog (`EXECUTE_SQL_ERROR_CODES`,
+ *      `RUN_METRIC_ERROR_CODES`, etc.) so the LLM-facing description
+ *      advertises it.
  */
 export type AtlasMcpToolErrorCode =
   | "validation_failed"
@@ -79,6 +95,20 @@ export const ATLAS_MCP_TOOL_ERROR_CODES = [
   "rate_limited",
   "internal_error",
 ] as const satisfies readonly AtlasMcpToolErrorCode[];
+
+// Symmetric drift guard. The `satisfies` above ensures every entry in the
+// array is a valid union member; this checks the reverse — every union
+// member appears in the array. Without this, adding a code to the union
+// without appending to the array compiles silently and SDK consumers
+// iterating `ATLAS_MCP_TOOL_ERROR_CODES` will miss the new code at
+// runtime. Triggers TS2322 if the two drift apart.
+type _CodesArrayCoversUnion =
+  AtlasMcpToolErrorCode extends (typeof ATLAS_MCP_TOOL_ERROR_CODES)[number]
+    ? true
+    : never;
+const _atlasMcpCodesArrayCoversUnion: _CodesArrayCoversUnion = true;
+// Reference the symbol so TS doesn't strip it as unused under noUnusedLocals.
+void _atlasMcpCodesArrayCoversUnion;
 
 /** Type guard — checks whether a string is a known `AtlasMcpToolErrorCode`. */
 export function isAtlasMcpToolErrorCode(value: string): value is AtlasMcpToolErrorCode {


### PR DESCRIPTION
Closes #2030.

## Summary

- Adds `AtlasMcpToolError` to `@useatlas/types` (closed code catalog + `parseAtlasMcpToolError` runtime guard) so SDK consumers can branch on a typed error.
- Wraps every MCP tool (`explore`, `executeSQL`, `listEntities`, `describeEntity`, `searchGlossary`, `runMetric`) so failures return the envelope as the JSON body of an `isError: true` response. Agents branch on `code`, never on prose.
- `searchGlossary` upgrades any `status: ambiguous` match to a hard `ambiguous_term` envelope — the contract the disambiguation eval (#2025) will assert against.
- Tool descriptions document the possible codes (`Error contract:` trailer), so an LLM picks the right recovery from the tool itself.
- `executeSQL` rate-limit rejections forward `retryAfterMs` → `retry_after`. `internal_error` always carries `request_id` for log correlation.
- New `Error contract` section in `apps/docs/content/docs/guides/mcp.mdx` with the code table, agent-recovery guidance, and a client-side example.

Lineage: this defines the failure shape for the typed tools shipped in #2031.

## Codes

| Code | When |
|------|------|
| `validation_failed` | SQL guard rejection or `runMetric` `filters` rejected |
| `rls_denied` | Row-level security rejected the query |
| `query_timeout` | `statement_timeout` fired |
| `unknown_entity` | `describeEntity` miss / table not in semantic whitelist |
| `unknown_metric` | `runMetric` id not in `metrics/*.yml` |
| `ambiguous_term` | Glossary entry has `status: ambiguous` — agent must ask user |
| `rate_limited` | Rate / concurrency cap hit; `retry_after` in seconds |
| `internal_error` | Anything else; `request_id` always set |

## Publish ordering

Per the publish playbook: `@useatlas/types` is bumped to **0.0.19** in this PR, but consumer refs (sdk, react, mcp, templates) are intentionally **not** bumped. After merge, tag `types-v0.0.19`, wait for the publish workflow, then push a follow-up bumping the refs.

## Acceptance criteria (from #2030)

- [x] Envelope type lives in `@useatlas/types`
- [x] All 6 MCP tools return the envelope on failure
- [x] Tool descriptions document possible error codes
- [x] `ambiguous_term` triggers when glossary `status: ambiguous` is hit
- [x] Per-error-path tests for each tool
- [x] Docs updated with the error contract

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun run test` — full suite green (163 MCP tests, types `mcp.test.ts` covers envelope parse)
- [x] `bun x syncpack lint` — clean
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — clean
- [x] `bash scripts/check-railway-watch.sh` — clean
- [x] `bash scripts/check-security-headers-drift.sh` — clean