### PR TITLE
feat(api,mcp): #2029 — OTel coverage for MCP tool calls

### DIFF
--- a/apps/docs/content/docs/platform-ops/observability.mdx
+++ b/apps/docs/content/docs/platform-ops/observability.mdx
@@ -68,7 +68,7 @@ Atlas also publishes a small set of OTel metrics through the `@atlas/api` Meter 
 | `atlas.abuse.escalations` | Counter | `level` (`warning` / `throttled` / `suspended` / `none`), `trigger` (`query_rate` / `error_rate` / `unique_tables` / `manual`) | Incremented on every workspace abuse-level transition, including manual reinstate (`level=none`, `trigger=manual`) |
 | `atlas.mcp.tool.calls` | Counter | `tool.name`, `outcome` (`success` / `error`), `transport` (`stdio` / `sse`), `deploy.mode` (`self-hosted` / `saas`) | Incremented once per MCP tool dispatch. Splits success vs. tool-level failure so adoption and error-rate dashboards both join on the same series |
 | `atlas.mcp.tool.latency` | Histogram (`ms`) | Same as `atlas.mcp.tool.calls` | Raw per-dispatch latency observations — derive p50/p95/p99 in your collector. Bucket boundaries stay defaulted so dashboards aren't pinned to one set of cutoffs |
-| `atlas.mcp.activations` | Counter | `workspace.id`, `transport`, `deploy.mode` | Fires once per workspace per MCP process on the first observed tool call. Process-local dedup; collectors group by `workspace.id` × first-seen day for cross-replica accuracy |
+| `atlas.mcp.activations` | Counter | `workspace.id`, `transport`, `deploy.mode` | Fires once per workspace per MCP process on the first observed tool call. Process-local dedup only — restarts and SSE replicas re-fire for the same workspace. For a true "unique workspaces" view, configure your collector to group by `workspace.id` × first-seen day |
 
 Counters use `@opentelemetry/api` and are no-ops until a `MeterProvider` is registered — wire one through your OTel collector configuration to feed dashboards and alerting.
 

--- a/apps/docs/content/docs/platform-ops/observability.mdx
+++ b/apps/docs/content/docs/platform-ops/observability.mdx
@@ -55,6 +55,7 @@ HTTP Request (http.request)
 | `atlas.plugin.init` | `atlas.plugin_id` | Plugin `initialize()` call — typically the slow path at boot |
 | `atlas.plugin.teardown` | `atlas.plugin_id` | Plugin `teardown()` call during graceful shutdown |
 | `atlas.plugin.healthCheckAll` | `atlas.plugin_count` | One span per `/health` plugins check (covers all probes) |
+| `atlas.mcp.tool.run` | `tool.name`, `workspace.id`, `transport` (`stdio` / `sse`), `deploy.mode` (`self-hosted` / `saas`), `tool.success`, `tool.error_code` (on failure), `metric.id` (on `runMetric`) | One per MCP tool dispatch (`explore`, `executeSQL`, `listEntities`, `describeEntity`, `searchGlossary`, `runMetric`). For `runMetric` the downstream `atlas.sql.execute` span nests under this dispatch |
 
 Each span records success/failure status and captures exceptions on error, making it straightforward to trace agent step failures back to specific tool calls.
 
@@ -65,6 +66,9 @@ Atlas also publishes a small set of OTel metrics through the `@atlas/api` Meter 
 | Metric Name | Type | Attributes | Description |
 |-------------|------|------------|-------------|
 | `atlas.abuse.escalations` | Counter | `level` (`warning` / `throttled` / `suspended` / `none`), `trigger` (`query_rate` / `error_rate` / `unique_tables` / `manual`) | Incremented on every workspace abuse-level transition, including manual reinstate (`level=none`, `trigger=manual`) |
+| `atlas.mcp.tool.calls` | Counter | `tool.name`, `outcome` (`success` / `error`), `transport` (`stdio` / `sse`), `deploy.mode` (`self-hosted` / `saas`) | Incremented once per MCP tool dispatch. Splits success vs. tool-level failure so adoption and error-rate dashboards both join on the same series |
+| `atlas.mcp.tool.latency` | Histogram (`ms`) | Same as `atlas.mcp.tool.calls` | Raw per-dispatch latency observations — derive p50/p95/p99 in your collector. Bucket boundaries stay defaulted so dashboards aren't pinned to one set of cutoffs |
+| `atlas.mcp.activations` | Counter | `workspace.id`, `transport`, `deploy.mode` | Fires once per workspace per MCP process on the first observed tool call. Process-local dedup; collectors group by `workspace.id` × first-seen day for cross-replica accuracy |
 
 Counters use `@opentelemetry/api` and are no-ops until a `MeterProvider` is registered — wire one through your OTel collector configuration to feed dashboards and alerting.
 

--- a/packages/api/src/lib/metrics.ts
+++ b/packages/api/src/lib/metrics.ts
@@ -16,7 +16,7 @@
  * Grafana board need to extend telemetry.ts with an OTLP metrics exporter.
  */
 
-import { metrics, type Counter } from "@opentelemetry/api";
+import { metrics, type Counter, type Histogram } from "@opentelemetry/api";
 
 const meter = metrics.getMeter("@atlas/api");
 
@@ -33,5 +33,59 @@ export const abuseEscalations: Counter = meter.createCounter(
   {
     description:
       "Workspace abuse level transitions (warn / throttle / suspend / reinstate)",
+  },
+);
+
+/**
+ * `atlas.mcp.tool.calls` — count of MCP tool dispatches by tool name +
+ * outcome. Mirrors the abuse counter pattern; the same `@atlas/api` Meter
+ * is used so a single OTel exporter configuration handles MCP signals.
+ *
+ * Attributes:
+ *   - `tool.name`  — `explore` / `executeSQL` / `listEntities` /
+ *                    `describeEntity` / `searchGlossary` / `runMetric`.
+ *   - `outcome`    — `success` / `error`.
+ *   - `transport`  — `stdio` / `sse`.
+ *   - `deploy.mode`— `self-hosted` / `saas`.
+ */
+export const mcpToolCalls: Counter = meter.createCounter(
+  "atlas.mcp.tool.calls",
+  {
+    description:
+      "MCP tool dispatch count by tool name + outcome (success / error)",
+  },
+);
+
+/**
+ * `atlas.mcp.tool.latency` — raw per-dispatch latency in milliseconds.
+ * Downstream collectors derive p50 / p95 / p99 — the histogram buckets
+ * stay defaulted so dashboards aren't pinned to one set of cutoffs.
+ *
+ * Attributes match `atlas.mcp.tool.calls` so the two series can be joined.
+ */
+export const mcpToolLatency: Histogram = meter.createHistogram(
+  "atlas.mcp.tool.latency",
+  {
+    description: "MCP tool dispatch latency in milliseconds (raw observations)",
+    unit: "ms",
+  },
+);
+
+/**
+ * `atlas.mcp.activations` — incremented exactly once per workspace per
+ * MCP process on the first observed tool call. Lets us measure 1.4.0 MCP
+ * adoption without a parallel telemetry path.
+ *
+ * Attributes:
+ *   - `workspace.id` — the bound `activeOrganizationId` (or
+ *                      `system:mcp` in trusted-transport mode).
+ *   - `transport`    — `stdio` / `sse`.
+ *   - `deploy.mode`  — `self-hosted` / `saas`.
+ */
+export const mcpActivations: Counter = meter.createCounter(
+  "atlas.mcp.activations",
+  {
+    description:
+      "Workspace first-MCP-tool-call observed in this process (process-local dedup)",
   },
 );

--- a/packages/mcp/bin/serve.ts
+++ b/packages/mcp/bin/serve.ts
@@ -77,7 +77,7 @@ async function main() {
 
     const { startSseServer } = await import("../src/sse.js");
     const handle = await startSseServer(
-      () => createAtlasMcpServer({ skipConfig: true, actor }),
+      () => createAtlasMcpServer({ skipConfig: true, actor, transport: "sse" }),
       { port, corsOrigin },
     );
 
@@ -101,7 +101,7 @@ async function main() {
   }
 
   // stdio transport (default)
-  const server = await createAtlasMcpServer();
+  const server = await createAtlasMcpServer({ transport: "stdio" });
   const { StdioServerTransport } = await import(
     "@modelcontextprotocol/sdk/server/stdio.js"
   );

--- a/packages/mcp/src/__tests__/semantic-tools.test.ts
+++ b/packages/mcp/src/__tests__/semantic-tools.test.ts
@@ -104,7 +104,12 @@ function getContentText(content: unknown): string {
 
 async function createTestClient(actor = TEST_ACTOR) {
   const server = new McpServer({ name: "test", version: "0.0.1" });
-  registerSemanticTools(server, { actor });
+  registerSemanticTools(server, {
+    actor,
+    transport: "stdio",
+    workspaceId: actor.activeOrganizationId ?? actor.id,
+    deployMode: "self-hosted",
+  });
 
   const client = new Client({ name: "test-client", version: "0.0.1" });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();

--- a/packages/mcp/src/__tests__/telemetry.test.ts
+++ b/packages/mcp/src/__tests__/telemetry.test.ts
@@ -115,11 +115,12 @@ mock.module("@atlas/api/lib/semantic/lookups", () => ({
   loadMetricDefinitions: () => [],
 }));
 
-// Don't mock @atlas/api/lib/config — its 31 exports would require a full
-// pass-through to avoid partial-mock leakage (CLAUDE.md "Mock all exports").
-// The unmocked module's `getConfig()` returns null when `initializeConfig`
-// hasn't run; `tools.ts` null-coalesces to `"self-hosted"`, which is the
-// value we want in tests anyway.
+// Don't mock @atlas/api/lib/config: its many runtime exports would require
+// a full pass-through to avoid partial-mock leakage (CLAUDE.md "Mock all
+// exports — partial mocks cause SyntaxError in other files"). The unmocked
+// module's `getConfig()` returns null when `initializeConfig` hasn't run;
+// `tools.ts` null-coalesces to `"self-hosted"`, which is the value we want
+// in tests anyway.
 
 const { registerTools } = await import("../tools.js");
 const { _resetMcpTelemetryForTest } = await import("../telemetry.js");

--- a/packages/mcp/src/__tests__/telemetry.test.ts
+++ b/packages/mcp/src/__tests__/telemetry.test.ts
@@ -1,0 +1,312 @@
+/**
+ * OTel coverage for MCP tool dispatch (#2029).
+ *
+ * Mirrors the #1979 / PR #2011 capture pattern: mock `@atlas/api/lib/tracing`
+ * to record span name + attributes, mock `@atlas/api/lib/metrics` to record
+ * counter / histogram observations. No in-memory exporter — keeps the test
+ * boundary at the helper module, not the OTel SDK.
+ */
+
+import { describe, expect, it, mock, beforeEach } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createAtlasUser } from "@atlas/api/lib/auth/types";
+
+const TEST_ACTOR = createAtlasUser("u_telem", "managed", "telem@test", {
+  role: "admin",
+  activeOrganizationId: "org_telem",
+});
+
+// --- Span / metric capture buffers ----------------------------------------
+const spanCalls: { name: string; attributes: Record<string, unknown>; resultAttrs?: Record<string, unknown>; error?: string }[] = [];
+const counterCalls: { metric: string; value: number; attributes: Record<string, unknown> }[] = [];
+const histogramCalls: { metric: string; value: number; attributes: Record<string, unknown> }[] = [];
+
+mock.module("@atlas/api/lib/tracing", () => ({
+  withSpan: async (
+    name: string,
+    attributes: Record<string, unknown>,
+    fn: () => Promise<unknown>,
+    setResultAttributes?: (result: unknown) => Record<string, unknown>,
+  ) => {
+    const entry: (typeof spanCalls)[number] = { name, attributes };
+    spanCalls.push(entry);
+    try {
+      const result = await fn();
+      if (setResultAttributes) {
+        try {
+          entry.resultAttrs = setResultAttributes(result);
+        } catch {
+          // intentionally ignored: mirror real withSpan — callback errors don't
+          // fail the wrapped fn.
+        }
+      }
+      return result;
+    } catch (err) {
+      entry.error = err instanceof Error ? err.message : String(err);
+      throw err;
+    }
+  },
+  withEffectSpan: <A>(_name: string, _attributes: Record<string, unknown>, e: A): A => e,
+}));
+
+mock.module("@atlas/api/lib/metrics", () => ({
+  abuseEscalations: { add: () => {} },
+  mcpToolCalls: {
+    add: (value: number, attributes: Record<string, unknown>) => {
+      counterCalls.push({ metric: "atlas.mcp.tool.calls", value, attributes });
+    },
+  },
+  mcpToolLatency: {
+    record: (value: number, attributes: Record<string, unknown>) => {
+      histogramCalls.push({ metric: "atlas.mcp.tool.latency", value, attributes });
+    },
+  },
+  mcpActivations: {
+    add: (value: number, attributes: Record<string, unknown>) => {
+      counterCalls.push({ metric: "atlas.mcp.activations", value, attributes });
+    },
+  },
+}));
+
+// --- Mocks for AI SDK tool execute functions ------------------------------
+const mockExploreExecute = mock<(...args: unknown[]) => Promise<unknown>>(
+  async () => "catalog.yml",
+);
+const mockExecuteSQLExecute = mock<(...args: unknown[]) => Promise<unknown>>(
+  async () => ({
+    success: true,
+    explanation: "noop",
+    row_count: 0,
+    columns: [],
+    rows: [],
+    truncated: false,
+  }),
+);
+
+mock.module("@atlas/api/lib/tools/explore", () => ({
+  explore: { description: "explore", execute: mockExploreExecute },
+}));
+mock.module("@atlas/api/lib/tools/sql", () => ({
+  executeSQL: { description: "executeSQL", execute: mockExecuteSQLExecute },
+}));
+
+// `runMetric` resolves the metric definition through these helpers.
+mock.module("@atlas/api/lib/semantic/lookups", () => ({
+  listEntities: () => [],
+  getEntityByName: () => null,
+  searchGlossary: () => [],
+  findMetricById: (id: string) =>
+    id === "orders_count"
+      ? {
+          id: "orders_count",
+          label: "Total orders",
+          description: "Distinct order count.",
+          sql: "SELECT 1",
+          type: "atomic",
+          aggregation: "count_distinct",
+          unit: null,
+          source: "default",
+          binding: null,
+        }
+      : null,
+  loadGlossaryTerms: () => [],
+  loadMetricDefinitions: () => [],
+}));
+
+mock.module("@atlas/api/lib/config", () => ({
+  initializeConfig: async () => ({ deployMode: "self-hosted" }),
+  getConfig: () => ({ deployMode: "self-hosted" }),
+}));
+
+const { registerTools } = await import("../tools.js");
+const { _resetMcpTelemetryForTest } = await import("../telemetry.js");
+
+async function createTestClient(transport: "stdio" | "sse" = "stdio") {
+  const server = new McpServer({ name: "test", version: "0.0.1" });
+  registerTools(server, { actor: TEST_ACTOR, transport });
+
+  const client = new Client({ name: "test-client", version: "0.0.1" });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return { client, server };
+}
+
+describe("MCP OTel coverage (#2029)", () => {
+  beforeEach(() => {
+    spanCalls.length = 0;
+    counterCalls.length = 0;
+    histogramCalls.length = 0;
+    mockExploreExecute.mockClear();
+    mockExecuteSQLExecute.mockClear();
+    _resetMcpTelemetryForTest();
+  });
+
+  it("emits atlas.mcp.tool.run span on every tool dispatch", async () => {
+    const { client } = await createTestClient();
+    await client.callTool({ name: "explore", arguments: { command: "ls" } });
+    await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "SELECT 1", explanation: "probe" },
+    });
+
+    const runs = spanCalls.filter((s) => s.name === "atlas.mcp.tool.run");
+    expect(runs.length).toBe(2);
+    const tools = runs.map((r) => r.attributes["tool.name"]).sort();
+    expect(tools).toEqual(["executeSQL", "explore"]);
+  });
+
+  it("tags spans with workspace.id, transport, and deploy.mode", async () => {
+    const { client } = await createTestClient("sse");
+    await client.callTool({ name: "explore", arguments: { command: "ls" } });
+
+    const span = spanCalls.find((s) => s.name === "atlas.mcp.tool.run");
+    expect(span).toBeDefined();
+    expect(span!.attributes["workspace.id"]).toBe("org_telem");
+    expect(span!.attributes["transport"]).toBe("sse");
+    expect(span!.attributes["deploy.mode"]).toBe("self-hosted");
+  });
+
+  it("records tool.success=true on success result, =false on tool error", async () => {
+    const { client } = await createTestClient();
+    await client.callTool({ name: "explore", arguments: { command: "ls" } });
+
+    mockExploreExecute.mockResolvedValueOnce("Error (exit 1):\nbroken");
+    await client.callTool({ name: "explore", arguments: { command: "boom" } });
+
+    const successSpan = spanCalls[0]!;
+    expect(successSpan.resultAttrs?.["tool.success"]).toBe(true);
+    const errorSpan = spanCalls[1]!;
+    expect(errorSpan.resultAttrs?.["tool.success"]).toBe(false);
+  });
+
+  it("increments atlas.mcp.tool.calls counter with tool.name + outcome", async () => {
+    const { client } = await createTestClient();
+    await client.callTool({ name: "explore", arguments: { command: "ls" } });
+
+    mockExploreExecute.mockResolvedValueOnce("Error (exit 1):\nbroken");
+    await client.callTool({ name: "explore", arguments: { command: "boom" } });
+
+    const counterAdds = counterCalls.filter(
+      (c) => c.metric === "atlas.mcp.tool.calls",
+    );
+    expect(counterAdds.length).toBe(2);
+    const successCount = counterAdds.find(
+      (c) => c.attributes.outcome === "success",
+    );
+    const errorCount = counterAdds.find(
+      (c) => c.attributes.outcome === "error",
+    );
+    expect(successCount?.attributes["tool.name"]).toBe("explore");
+    expect(errorCount?.attributes["tool.name"]).toBe("explore");
+    expect(successCount?.value).toBe(1);
+    expect(errorCount?.value).toBe(1);
+  });
+
+  it("records atlas.mcp.tool.latency histogram per dispatch", async () => {
+    const { client } = await createTestClient();
+    await client.callTool({ name: "explore", arguments: { command: "ls" } });
+    await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "SELECT 1", explanation: "probe" },
+    });
+
+    const observations = histogramCalls.filter(
+      (h) => h.metric === "atlas.mcp.tool.latency",
+    );
+    expect(observations.length).toBe(2);
+    for (const obs of observations) {
+      expect(obs.value).toBeGreaterThanOrEqual(0);
+      expect(obs.attributes["tool.name"]).toMatch(/explore|executeSQL/);
+    }
+  });
+
+  it("emits atlas.mcp.activations exactly once per workspace per process", async () => {
+    const { client } = await createTestClient();
+    await client.callTool({ name: "explore", arguments: { command: "ls" } });
+    await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "SELECT 1", explanation: "probe" },
+    });
+    await client.callTool({ name: "explore", arguments: { command: "ls" } });
+
+    const activations = counterCalls.filter(
+      (c) => c.metric === "atlas.mcp.activations",
+    );
+    expect(activations.length).toBe(1);
+    expect(activations[0]!.value).toBe(1);
+    expect(activations[0]!.attributes["workspace.id"]).toBe("org_telem");
+    expect(activations[0]!.attributes["transport"]).toBe("stdio");
+  });
+
+  it("runMetric span carries metric.id attribute", async () => {
+    const { client } = await createTestClient();
+    await client.callTool({
+      name: "runMetric",
+      arguments: { id: "orders_count" },
+    });
+
+    const span = spanCalls.find((s) => s.attributes["tool.name"] === "runMetric");
+    expect(span).toBeDefined();
+    expect(span!.attributes["metric.id"]).toBe("orders_count");
+  });
+
+  it("re-throws underlying tool error after recording outcome=error", async () => {
+    mockExploreExecute.mockRejectedValueOnce(new Error("sandbox crashed"));
+
+    const { client } = await createTestClient();
+    // The MCP tool handler catches errors internally and returns isError —
+    // so from the client's perspective this returns a CallToolResult.
+    const result = await client.callTool({
+      name: "explore",
+      arguments: { command: "boom" },
+    });
+    expect(result.isError).toBe(true);
+
+    const counterAdds = counterCalls.filter(
+      (c) => c.metric === "atlas.mcp.tool.calls",
+    );
+    expect(counterAdds.length).toBe(1);
+    expect(counterAdds[0]!.attributes.outcome).toBe("error");
+  });
+
+  it("covers all six tools (explore + executeSQL + 4 typed semantic tools)", async () => {
+    const { client } = await createTestClient();
+    await client.callTool({ name: "explore", arguments: { command: "ls" } });
+    await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "SELECT 1", explanation: "probe" },
+    });
+    await client.callTool({ name: "listEntities", arguments: {} });
+    await client.callTool({
+      name: "describeEntity",
+      arguments: { name: "users" },
+    });
+    await client.callTool({
+      name: "searchGlossary",
+      arguments: { term: "revenue" },
+    });
+    await client.callTool({
+      name: "runMetric",
+      arguments: { id: "orders_count" },
+    });
+
+    const toolNames = spanCalls
+      .filter((s) => s.name === "atlas.mcp.tool.run")
+      .map((s) => s.attributes["tool.name"])
+      .sort();
+    expect(toolNames).toEqual([
+      "describeEntity",
+      "executeSQL",
+      "explore",
+      "listEntities",
+      "runMetric",
+      "searchGlossary",
+    ]);
+  });
+});

--- a/packages/mcp/src/__tests__/telemetry.test.ts
+++ b/packages/mcp/src/__tests__/telemetry.test.ts
@@ -123,9 +123,12 @@ mock.module("@atlas/api/lib/config", () => ({
 const { registerTools } = await import("../tools.js");
 const { _resetMcpTelemetryForTest } = await import("../telemetry.js");
 
-async function createTestClient(transport: "stdio" | "sse" = "stdio") {
+async function createTestClient(
+  transport: "stdio" | "sse" = "stdio",
+  actor = TEST_ACTOR,
+) {
   const server = new McpServer({ name: "test", version: "0.0.1" });
-  registerTools(server, { actor: TEST_ACTOR, transport });
+  registerTools(server, { actor, transport });
 
   const client = new Client({ name: "test-client", version: "0.0.1" });
   const [clientTransport, serverTransport] =
@@ -172,7 +175,7 @@ describe("MCP OTel coverage (#2029)", () => {
     expect(span!.attributes["deploy.mode"]).toBe("self-hosted");
   });
 
-  it("records tool.success=true on success result, =false on tool error", async () => {
+  it("records tool.success=true on success result, =false + tool.error_code on tool error", async () => {
     const { client } = await createTestClient();
     await client.callTool({ name: "explore", arguments: { command: "ls" } });
 
@@ -181,8 +184,36 @@ describe("MCP OTel coverage (#2029)", () => {
 
     const successSpan = spanCalls[0]!;
     expect(successSpan.resultAttrs?.["tool.success"]).toBe(true);
+    expect(successSpan.resultAttrs?.["tool.error_code"]).toBeUndefined();
     const errorSpan = spanCalls[1]!;
     expect(errorSpan.resultAttrs?.["tool.success"]).toBe(false);
+    expect(errorSpan.resultAttrs?.["tool.error_code"]).toBe("tool_error");
+  });
+
+  it("records executeSQL { success: false } as outcome=error with tool.error_code", async () => {
+    mockExecuteSQLExecute.mockResolvedValueOnce({
+      success: false,
+      error: "RLS denied",
+    });
+
+    const { client } = await createTestClient();
+    await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "SELECT * FROM forbidden", explanation: "probe" },
+    });
+
+    const span = spanCalls.find(
+      (s) => s.attributes["tool.name"] === "executeSQL",
+    );
+    expect(span?.resultAttrs?.["tool.success"]).toBe(false);
+    expect(span?.resultAttrs?.["tool.error_code"]).toBe("tool_error");
+
+    const counter = counterCalls.find(
+      (c) =>
+        c.metric === "atlas.mcp.tool.calls" &&
+        c.attributes["tool.name"] === "executeSQL",
+    );
+    expect(counter?.attributes.outcome).toBe("error");
   });
 
   it("increments atlas.mcp.tool.calls counter with tool.name + outcome", async () => {
@@ -220,9 +251,25 @@ describe("MCP OTel coverage (#2029)", () => {
       (h) => h.metric === "atlas.mcp.tool.latency",
     );
     expect(observations.length).toBe(2);
+
+    // Pin the cross-series joinability the metrics.ts comment promises:
+    // every histogram observation has a matching counter increment with
+    // the same tool.name + outcome. A regression that records latency
+    // but skips the counter (or vice versa) would split the dashboards.
+    const counterAdds = counterCalls.filter(
+      (c) => c.metric === "atlas.mcp.tool.calls",
+    );
+    expect(counterAdds.length).toBe(2);
     for (const obs of observations) {
-      expect(obs.value).toBeGreaterThanOrEqual(0);
+      expect(Number.isFinite(obs.value)).toBe(true);
+      expect(obs.value).toBeGreaterThan(0);
       expect(obs.attributes["tool.name"]).toMatch(/explore|executeSQL/);
+      const matching = counterAdds.find(
+        (c) =>
+          c.attributes["tool.name"] === obs.attributes["tool.name"] &&
+          c.attributes.outcome === obs.attributes.outcome,
+      );
+      expect(matching).toBeDefined();
     }
   });
 
@@ -244,6 +291,34 @@ describe("MCP OTel coverage (#2029)", () => {
     expect(activations[0]!.attributes["transport"]).toBe("stdio");
   });
 
+  it("emits a separate activation for each distinct workspace", async () => {
+    // Pins the Set-keyed dedup contract: a regression that hard-codes a
+    // single boolean (`hasFiredActivation`) would pass the single-workspace
+    // test but fail this one.
+    const actorA = createAtlasUser("u_a", "managed", "a@test", {
+      role: "admin",
+      activeOrganizationId: "org_a",
+    });
+    const actorB = createAtlasUser("u_b", "managed", "b@test", {
+      role: "admin",
+      activeOrganizationId: "org_b",
+    });
+
+    const { client: clientA } = await createTestClient("stdio", actorA);
+    await clientA.callTool({ name: "explore", arguments: { command: "ls" } });
+
+    const { client: clientB } = await createTestClient("stdio", actorB);
+    await clientB.callTool({ name: "explore", arguments: { command: "ls" } });
+
+    const activations = counterCalls.filter(
+      (c) => c.metric === "atlas.mcp.activations",
+    );
+    const ids = activations
+      .map((a) => a.attributes["workspace.id"])
+      .sort();
+    expect(ids).toEqual(["org_a", "org_b"]);
+  });
+
   it("runMetric span carries metric.id attribute", async () => {
     const { client } = await createTestClient();
     await client.callTool({
@@ -254,6 +329,31 @@ describe("MCP OTel coverage (#2029)", () => {
     const span = spanCalls.find((s) => s.attributes["tool.name"] === "runMetric");
     expect(span).toBeDefined();
     expect(span!.attributes["metric.id"]).toBe("orders_count");
+  });
+
+  it("runMetric records outcome=error when the metric id is not found", async () => {
+    // The "metric not found" branch short-circuits before invoking
+    // executeSQL, so the entire instrumentation path runs through the
+    // runMetric-specific span attribute rather than the executeSQL one.
+    const { client } = await createTestClient();
+    await client.callTool({
+      name: "runMetric",
+      arguments: { id: "ghost" },
+    });
+
+    const span = spanCalls.find(
+      (s) => s.attributes["tool.name"] === "runMetric",
+    );
+    expect(span).toBeDefined();
+    expect(span!.attributes["metric.id"]).toBe("ghost");
+    expect(span!.resultAttrs?.["tool.success"]).toBe(false);
+
+    const counter = counterCalls.find(
+      (c) =>
+        c.metric === "atlas.mcp.tool.calls" &&
+        c.attributes["tool.name"] === "runMetric",
+    );
+    expect(counter?.attributes.outcome).toBe("error");
   });
 
   it("re-throws underlying tool error after recording outcome=error", async () => {

--- a/packages/mcp/src/__tests__/telemetry.test.ts
+++ b/packages/mcp/src/__tests__/telemetry.test.ts
@@ -115,10 +115,11 @@ mock.module("@atlas/api/lib/semantic/lookups", () => ({
   loadMetricDefinitions: () => [],
 }));
 
-mock.module("@atlas/api/lib/config", () => ({
-  initializeConfig: async () => ({ deployMode: "self-hosted" }),
-  getConfig: () => ({ deployMode: "self-hosted" }),
-}));
+// Don't mock @atlas/api/lib/config — its 31 exports would require a full
+// pass-through to avoid partial-mock leakage (CLAUDE.md "Mock all exports").
+// The unmocked module's `getConfig()` returns null when `initializeConfig`
+// hasn't run; `tools.ts` null-coalesces to `"self-hosted"`, which is the
+// value we want in tests anyway.
 
 const { registerTools } = await import("../tools.js");
 const { _resetMcpTelemetryForTest } = await import("../telemetry.js");

--- a/packages/mcp/src/semantic-tools.ts
+++ b/packages/mcp/src/semantic-tools.ts
@@ -28,6 +28,7 @@ import {
   RUN_METRIC_TOOL_DESCRIPTION,
   type SemanticToolName,
 } from "@atlas/api/lib/tools/descriptions";
+import { traceMcpToolCall, type McpTransport } from "./telemetry.js";
 
 // Modest input bounds — MCP clients (including hostile ones in BYOC
 // SaaS) shouldn't be able to drive megabyte strings into the catalog
@@ -46,6 +47,12 @@ const ENTITY_NAME_PATTERN = /^[A-Za-z0-9_.-]+$/;
 export interface RegisterSemanticToolsOptions {
   /** Actor bound on every tool dispatch — see tools.ts. */
   actor: AtlasUser;
+  /** OTel transport tag (#2029) — threaded from `bin/serve.ts` via `tools.ts`. */
+  transport: McpTransport;
+  /** Resolved workspace id for OTel attribution (`actor.activeOrganizationId` or `actor.id`). */
+  workspaceId: string;
+  /** Resolved `deployMode` for OTel attribution (`self-hosted` / `saas`). */
+  deployMode: string;
 }
 
 function dispatchId(prefix: string): string {
@@ -79,7 +86,7 @@ export function registerSemanticTools(
   server: McpServer,
   opts: RegisterSemanticToolsOptions,
 ): void {
-  const { actor } = opts;
+  const { actor, transport, workspaceId, deployMode } = opts;
 
   // --- listEntities ---
   server.registerTool(
@@ -98,18 +105,22 @@ export function registerSemanticTools(
       },
     },
     async ({ filter }): Promise<CallToolResult> =>
-      withRequestContext(
-        { requestId: dispatchId("mcp-listEntities"), user: actor },
-        async () => {
-          try {
-            const entities = listEntities({ filter });
-            return toJsonContent({ count: entities.length, entities });
-          } catch (err) {
-            const message = errorMessage(err, "listEntities tool failed");
-            process.stderr.write(`[atlas-mcp] listEntities threw: ${err}\n`);
-            return toErrorContent(message);
-          }
-        },
+      traceMcpToolCall(
+        { toolName: "listEntities", workspaceId, transport, deployMode },
+        () =>
+          withRequestContext(
+            { requestId: dispatchId("mcp-listEntities"), user: actor },
+            async () => {
+              try {
+                const entities = listEntities({ filter });
+                return toJsonContent({ count: entities.length, entities });
+              } catch (err) {
+                const message = errorMessage(err, "listEntities tool failed");
+                process.stderr.write(`[atlas-mcp] listEntities threw: ${err}\n`);
+                return toErrorContent(message);
+              }
+            },
+          ),
       ),
   );
 
@@ -131,21 +142,25 @@ export function registerSemanticTools(
       },
     },
     async ({ name }): Promise<CallToolResult> =>
-      withRequestContext(
-        { requestId: dispatchId("mcp-describeEntity"), user: actor },
-        async () => {
-          try {
-            const entity = getEntityByName(name);
-            if (!entity) {
-              return toJsonContent({ found: false, name });
-            }
-            return toJsonContent({ found: true, entity });
-          } catch (err) {
-            const message = errorMessage(err, "describeEntity tool failed");
-            process.stderr.write(`[atlas-mcp] describeEntity threw: ${err}\n`);
-            return toErrorContent(message);
-          }
-        },
+      traceMcpToolCall(
+        { toolName: "describeEntity", workspaceId, transport, deployMode },
+        () =>
+          withRequestContext(
+            { requestId: dispatchId("mcp-describeEntity"), user: actor },
+            async () => {
+              try {
+                const entity = getEntityByName(name);
+                if (!entity) {
+                  return toJsonContent({ found: false, name });
+                }
+                return toJsonContent({ found: true, entity });
+              } catch (err) {
+                const message = errorMessage(err, "describeEntity tool failed");
+                process.stderr.write(`[atlas-mcp] describeEntity threw: ${err}\n`);
+                return toErrorContent(message);
+              }
+            },
+          ),
       ),
   );
 
@@ -166,29 +181,34 @@ export function registerSemanticTools(
       },
     },
     async ({ term }): Promise<CallToolResult> =>
-      withRequestContext(
-        { requestId: dispatchId("mcp-searchGlossary"), user: actor },
-        async () => {
-          try {
-            const matches = searchGlossary(term);
-            return toJsonContent({
-              query: term,
-              count: matches.length,
-              matches,
-            });
-          } catch (err) {
-            const message = errorMessage(err, "searchGlossary tool failed");
-            process.stderr.write(`[atlas-mcp] searchGlossary threw: ${err}\n`);
-            return toErrorContent(message);
-          }
-        },
+      traceMcpToolCall(
+        { toolName: "searchGlossary", workspaceId, transport, deployMode },
+        () =>
+          withRequestContext(
+            { requestId: dispatchId("mcp-searchGlossary"), user: actor },
+            async () => {
+              try {
+                const matches = searchGlossary(term);
+                return toJsonContent({
+                  query: term,
+                  count: matches.length,
+                  matches,
+                });
+              } catch (err) {
+                const message = errorMessage(err, "searchGlossary tool failed");
+                process.stderr.write(`[atlas-mcp] searchGlossary threw: ${err}\n`);
+                return toErrorContent(message);
+              }
+            },
+          ),
       ),
   );
 
   // --- runMetric ---
   // The metric SQL goes through executeSQL.execute, inheriting all four
   // validation layers, plugin hooks, RLS injection, auto-LIMIT,
-  // statement timeout, and audit logging.
+  // statement timeout, and audit logging. The downstream `atlas.sql.execute`
+  // span (#1979 coverage) nests under this dispatch's `atlas.mcp.tool.run`.
   server.registerTool(
     "runMetric" satisfies SemanticToolName,
     {
@@ -224,69 +244,79 @@ export function registerSemanticTools(
       },
     },
     async ({ id, filters, connectionId }): Promise<CallToolResult> =>
-      withRequestContext(
-        { requestId: dispatchId("mcp-runMetric"), user: actor },
-        async () => {
-          try {
-            if (filters && Object.keys(filters).length > 0) {
-              return toErrorContent(
-                "runMetric `filters` pass-through is not yet supported. Use `executeSQL` with the metric's raw SQL to apply filters.",
-              );
-            }
-
-            const metric = findMetricById(id);
-            if (!metric) {
-              return toErrorContent(`Metric "${id}" not found.`);
-            }
-
-            const explanation = metric.description
-              ? `MCP runMetric ${metric.id}: ${metric.description}`
-              : `MCP runMetric ${metric.id}`;
-
-            const result = (await executeSQL.execute!(
-              { sql: metric.sql, explanation, connectionId },
-              { toolCallId: "mcp-runMetric", messages: [] },
-            )) as Record<string, unknown>;
-
-            if (result.success === false) {
-              return toErrorContent(
-                String(result.error ?? "Metric execution failed."),
-              );
-            }
-
-            const columns = Array.isArray(result.columns)
-              ? (result.columns as string[])
-              : [];
-            const rows = Array.isArray(result.rows)
-              ? (result.rows as Array<Record<string, unknown>>)
-              : [];
-
-            // Single column / single row → scalar value. Otherwise hand back
-            // the rows so the caller can inspect — keeps the typed shape
-            // honest for breakdown metrics without forcing a shape they don't
-            // have.
-            const value =
-              columns.length === 1 && rows.length === 1
-                ? rows[0][columns[0]]
-                : rows;
-
-            return toJsonContent({
-              id: metric.id,
-              label: metric.label,
-              value,
-              columns,
-              rows,
-              row_count: result.row_count ?? rows.length,
-              truncated: Boolean(result.truncated),
-              sql: metric.sql,
-              executed_at: new Date().toISOString(),
-            });
-          } catch (err) {
-            const message = errorMessage(err, "runMetric tool failed");
-            process.stderr.write(`[atlas-mcp] runMetric threw: ${err}\n`);
-            return toErrorContent(message);
-          }
+      traceMcpToolCall(
+        {
+          toolName: "runMetric",
+          workspaceId,
+          transport,
+          deployMode,
+          attributes: { "metric.id": id },
         },
+        () =>
+          withRequestContext(
+            { requestId: dispatchId("mcp-runMetric"), user: actor },
+            async () => {
+              try {
+                if (filters && Object.keys(filters).length > 0) {
+                  return toErrorContent(
+                    "runMetric `filters` pass-through is not yet supported. Use `executeSQL` with the metric's raw SQL to apply filters.",
+                  );
+                }
+
+                const metric = findMetricById(id);
+                if (!metric) {
+                  return toErrorContent(`Metric "${id}" not found.`);
+                }
+
+                const explanation = metric.description
+                  ? `MCP runMetric ${metric.id}: ${metric.description}`
+                  : `MCP runMetric ${metric.id}`;
+
+                const result = (await executeSQL.execute!(
+                  { sql: metric.sql, explanation, connectionId },
+                  { toolCallId: "mcp-runMetric", messages: [] },
+                )) as Record<string, unknown>;
+
+                if (result.success === false) {
+                  return toErrorContent(
+                    String(result.error ?? "Metric execution failed."),
+                  );
+                }
+
+                const columns = Array.isArray(result.columns)
+                  ? (result.columns as string[])
+                  : [];
+                const rows = Array.isArray(result.rows)
+                  ? (result.rows as Array<Record<string, unknown>>)
+                  : [];
+
+                // Single column / single row → scalar value. Otherwise hand back
+                // the rows so the caller can inspect — keeps the typed shape
+                // honest for breakdown metrics without forcing a shape they don't
+                // have.
+                const value =
+                  columns.length === 1 && rows.length === 1
+                    ? rows[0][columns[0]]
+                    : rows;
+
+                return toJsonContent({
+                  id: metric.id,
+                  label: metric.label,
+                  value,
+                  columns,
+                  rows,
+                  row_count: result.row_count ?? rows.length,
+                  truncated: Boolean(result.truncated),
+                  sql: metric.sql,
+                  executed_at: new Date().toISOString(),
+                });
+              } catch (err) {
+                const message = errorMessage(err, "runMetric tool failed");
+                process.stderr.write(`[atlas-mcp] runMetric threw: ${err}\n`);
+                return toErrorContent(message);
+              }
+            },
+          ),
       ),
   );
 }

--- a/packages/mcp/src/semantic-tools.ts
+++ b/packages/mcp/src/semantic-tools.ts
@@ -28,7 +28,11 @@ import {
   RUN_METRIC_TOOL_DESCRIPTION,
   type SemanticToolName,
 } from "@atlas/api/lib/tools/descriptions";
-import { traceMcpToolCall, type McpTransport } from "./telemetry.js";
+import {
+  traceMcpToolCall,
+  type McpTransport,
+  type McpDeployMode,
+} from "./telemetry.js";
 
 // Modest input bounds — MCP clients (including hostile ones in BYOC
 // SaaS) shouldn't be able to drive megabyte strings into the catalog
@@ -52,7 +56,7 @@ export interface RegisterSemanticToolsOptions {
   /** Resolved workspace id for OTel attribution (`actor.activeOrganizationId` or `actor.id`). */
   workspaceId: string;
   /** Resolved `deployMode` for OTel attribution (`self-hosted` / `saas`). */
-  deployMode: string;
+  deployMode: McpDeployMode;
 }
 
 function dispatchId(prefix: string): string {
@@ -207,8 +211,9 @@ export function registerSemanticTools(
   // --- runMetric ---
   // The metric SQL goes through executeSQL.execute, inheriting all four
   // validation layers, plugin hooks, RLS injection, auto-LIMIT,
-  // statement timeout, and audit logging. The downstream `atlas.sql.execute`
-  // span (#1979 coverage) nests under this dispatch's `atlas.mcp.tool.run`.
+  // statement timeout, and audit logging. The existing `atlas.sql.execute`
+  // span (see `lib/tools/sql.ts`) nests under this dispatch's
+  // `atlas.mcp.tool.run` via OTel context propagation through `withSpan`.
   server.registerTool(
     "runMetric" satisfies SemanticToolName,
     {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -17,6 +17,7 @@ import { registerTools } from "./tools.js";
 import { registerResources } from "./resources.js";
 import { registerPrompts } from "./prompts.js";
 import { resolveMcpActor } from "./actor.js";
+import type { McpTransport } from "./telemetry.js";
 // `serverInfo.version` is what MCP clients (Claude Desktop, Cursor) show
 // in their server picker. Reading from package.json keeps the value in
 // sync without a hand-edit on every bump.
@@ -32,6 +33,13 @@ interface CreateMcpServerOptions {
    * leave this unset and let `resolveMcpActor()` read env vars at boot).
    */
   actor?: AtlasUser;
+  /**
+   * Carrier transport for OTel attribution (#2029). `bin/serve.ts` sets
+   * this once at boot and threads it through every server instance so
+   * span / counter attributes don't have to re-detect transport per
+   * dispatch. Defaults to `stdio`.
+   */
+  transport?: McpTransport;
 }
 
 /**
@@ -62,13 +70,14 @@ export async function createAtlasMcpServer(
   }
 
   const actor = opts?.actor ?? (await resolveMcpActor());
+  const transport: McpTransport = opts?.transport ?? "stdio";
 
   const server = new McpServer({
     name: "atlas",
     version: VERSION,
   });
 
-  registerTools(server, { actor });
+  registerTools(server, { actor, transport });
   registerResources(server);
   await registerPrompts(server);
 

--- a/packages/mcp/src/telemetry.ts
+++ b/packages/mcp/src/telemetry.ts
@@ -12,12 +12,17 @@
  * adoption alongside abuse / scheduler / plugin coverage.
  *
  * Process-local activation dedup: a `Set<string>` keyed on workspace id keeps
- * the activation Counter from re-firing within a single MCP process. Across
- * SaaS replicas / restarts the dedup is downstream — collectors group by
- * `workspace.id` × first-seen day. We don't persist activation rows because:
+ * the activation Counter from re-firing within a single MCP process. We
+ * deliberately do NOT deduplicate cross-process — each restart, each SSE
+ * replica, and each fresh stdio process re-fires the counter for the same
+ * workspace. Operators who want a true "unique workspaces" view should
+ * configure their collector to group `atlas.mcp.activations` by
+ * `workspace.id` × first-seen day. Without that downstream grouping, a
+ * Claude Desktop restart will look like a new activation. We don't persist
+ * activation rows because:
  *   1. Self-hosted MCP doesn't necessarily have an internal Postgres.
  *   2. The MCP stdio process is typically per-user-session anyway, so a
- *      "first observed" event per process is already the natural granularity.
+ *      "first observed" event per process is already a useful granularity.
  */
 
 import { withSpan } from "@atlas/api/lib/tracing";
@@ -30,6 +35,8 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 export type McpTransport = "stdio" | "sse";
 
+export type McpDeployMode = "self-hosted" | "saas";
+
 export interface McpToolSpanContext {
   /** Tool name as registered with the MCP server. */
   readonly toolName: string;
@@ -37,9 +44,18 @@ export interface McpToolSpanContext {
   readonly workspaceId: string;
   /** Carrier transport. Set once at server boot, threaded through registration. */
   readonly transport: McpTransport;
-  /** `self-hosted` or `saas` — read once via `getConfig()` at registration time. */
-  readonly deployMode: string;
-  /** Tool-specific span attributes (e.g. `metric.id` on `runMetric`). */
+  /** Resolved deploy mode — read once via `getConfig()` at registration time. */
+  readonly deployMode: McpDeployMode;
+  /**
+   * Tool-specific span attributes (e.g. `metric.id` on `runMetric`).
+   *
+   * Attached to the span ONLY — never to the tool-call counter or latency
+   * histogram. The counter / histogram label set is intentionally limited
+   * to the four low-cardinality fields above so dashboards stay cheap.
+   * Putting a high-cardinality value here (entity name, query hash) is
+   * fine on the span but would blow up metric backend cardinality if it
+   * leaked onto the counter.
+   */
   readonly attributes?: Readonly<Record<string, string | number | boolean>>;
 }
 
@@ -51,13 +67,44 @@ export function _resetMcpTelemetryForTest(): void {
 }
 
 /**
+ * Emit the activation event for `workspaceId` if it's the first one observed
+ * in this process. Defensive try/catch: an OTel SDK bug must not bubble up
+ * and turn into a `CallToolResult{ isError: true }` for the user — that
+ * would violate the "instrumentation never masks the underlying tool"
+ * contract in the wrong direction. On failure we log to stderr (matching
+ * the MCP package's logging convention) and remove the workspace from the
+ * cache so the next dispatch can retry.
+ */
+function emitActivationOnce(
+  workspaceId: string,
+  transport: McpTransport,
+  deployMode: McpDeployMode,
+): void {
+  if (seenWorkspaces.has(workspaceId)) return;
+  seenWorkspaces.add(workspaceId);
+  try {
+    mcpActivations.add(1, {
+      "workspace.id": workspaceId,
+      transport,
+      "deploy.mode": deployMode,
+    });
+  } catch (err) {
+    seenWorkspaces.delete(workspaceId);
+    process.stderr.write(
+      `[atlas-mcp] activation counter failed: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+}
+
+/**
  * Wrap an MCP tool dispatch with span + counter + latency histogram + activation.
  *
  * Instrumentation never masks the underlying tool error: thrown errors from
- * `fn` are recorded on the span and counter (with `outcome=error`) and then
- * re-thrown unchanged. Tool-level error results (`CallToolResult.isError`) are
- * tagged on the span via `setResultAttributes` and recorded as `outcome=error`
- * on the counter / histogram so success and tool-level failure split cleanly.
+ * `fn` are recorded on the span (via `withSpan`'s `recordException`) and on
+ * the counter (with `outcome=error`), then re-thrown unchanged. Tool-level
+ * error results (`CallToolResult.isError`) are tagged on the span via
+ * `setResultAttributes` and recorded as `outcome=error` on the counter /
+ * histogram so success and tool-level failure split cleanly.
  */
 export async function traceMcpToolCall(
   ctx: McpToolSpanContext,
@@ -71,14 +118,7 @@ export async function traceMcpToolCall(
     ...(ctx.attributes ?? {}),
   };
 
-  if (!seenWorkspaces.has(ctx.workspaceId)) {
-    seenWorkspaces.add(ctx.workspaceId);
-    mcpActivations.add(1, {
-      "workspace.id": ctx.workspaceId,
-      transport: ctx.transport,
-      "deploy.mode": ctx.deployMode,
-    });
-  }
+  emitActivationOnce(ctx.workspaceId, ctx.transport, ctx.deployMode);
 
   const start = performance.now();
   let outcome: "success" | "error" = "success";
@@ -98,10 +138,11 @@ export async function traceMcpToolCall(
     return result;
   } catch (err) {
     outcome = "error";
-    // Re-throw the original error so the caller's catch can shape the
-    // CallToolResult exactly as before; the surrounding span has already
-    // recorded `recordException` via `withSpan`.
-    throw err instanceof Error ? err : new Error(String(err));
+    // Re-throw the original — `withSpan` has already called `recordException`
+    // with the original value. Wrapping non-Error throws here would lose
+    // prototype identity / `cause` / tagged-error data that downstream
+    // catches may discriminate on.
+    throw err;
   } finally {
     const latencyMs = performance.now() - start;
     const obsAttrs = {

--- a/packages/mcp/src/telemetry.ts
+++ b/packages/mcp/src/telemetry.ts
@@ -1,0 +1,116 @@
+/**
+ * OTel coverage for MCP tool dispatch (#2029).
+ *
+ * Mirrors the #1979 pattern (PR #2011): wraps the dispatch boundary with
+ * `withSpan` from `@atlas/api/lib/tracing`, adds counter + latency-histogram
+ * observations through the shared `@atlas/api` Meter in `@atlas/api/lib/metrics`,
+ * and emits a one-time activation event the first time a workspace shows up.
+ *
+ * Reusing the API package's tracer + meter (rather than introducing a parallel
+ * `@atlas/mcp` Meter) means a single `OTEL_EXPORTER_OTLP_ENDPOINT` configuration
+ * picks up MCP signals — operators don't need a second exporter to see MCP
+ * adoption alongside abuse / scheduler / plugin coverage.
+ *
+ * Process-local activation dedup: a `Set<string>` keyed on workspace id keeps
+ * the activation Counter from re-firing within a single MCP process. Across
+ * SaaS replicas / restarts the dedup is downstream — collectors group by
+ * `workspace.id` × first-seen day. We don't persist activation rows because:
+ *   1. Self-hosted MCP doesn't necessarily have an internal Postgres.
+ *   2. The MCP stdio process is typically per-user-session anyway, so a
+ *      "first observed" event per process is already the natural granularity.
+ */
+
+import { withSpan } from "@atlas/api/lib/tracing";
+import {
+  mcpToolCalls,
+  mcpToolLatency,
+  mcpActivations,
+} from "@atlas/api/lib/metrics";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+export type McpTransport = "stdio" | "sse";
+
+export interface McpToolSpanContext {
+  /** Tool name as registered with the MCP server. */
+  readonly toolName: string;
+  /** `actor.activeOrganizationId` — `system:mcp` in trusted-transport mode. */
+  readonly workspaceId: string;
+  /** Carrier transport. Set once at server boot, threaded through registration. */
+  readonly transport: McpTransport;
+  /** `self-hosted` or `saas` — read once via `getConfig()` at registration time. */
+  readonly deployMode: string;
+  /** Tool-specific span attributes (e.g. `metric.id` on `runMetric`). */
+  readonly attributes?: Readonly<Record<string, string | number | boolean>>;
+}
+
+const seenWorkspaces = new Set<string>();
+
+/** Test-only: clear the activation cache so reset hooks see a clean state. */
+export function _resetMcpTelemetryForTest(): void {
+  seenWorkspaces.clear();
+}
+
+/**
+ * Wrap an MCP tool dispatch with span + counter + latency histogram + activation.
+ *
+ * Instrumentation never masks the underlying tool error: thrown errors from
+ * `fn` are recorded on the span and counter (with `outcome=error`) and then
+ * re-thrown unchanged. Tool-level error results (`CallToolResult.isError`) are
+ * tagged on the span via `setResultAttributes` and recorded as `outcome=error`
+ * on the counter / histogram so success and tool-level failure split cleanly.
+ */
+export async function traceMcpToolCall(
+  ctx: McpToolSpanContext,
+  fn: () => Promise<CallToolResult>,
+): Promise<CallToolResult> {
+  const spanAttributes: Record<string, string | number | boolean> = {
+    "tool.name": ctx.toolName,
+    "workspace.id": ctx.workspaceId,
+    transport: ctx.transport,
+    "deploy.mode": ctx.deployMode,
+    ...(ctx.attributes ?? {}),
+  };
+
+  if (!seenWorkspaces.has(ctx.workspaceId)) {
+    seenWorkspaces.add(ctx.workspaceId);
+    mcpActivations.add(1, {
+      "workspace.id": ctx.workspaceId,
+      transport: ctx.transport,
+      "deploy.mode": ctx.deployMode,
+    });
+  }
+
+  const start = performance.now();
+  let outcome: "success" | "error" = "success";
+  try {
+    const result = await withSpan(
+      "atlas.mcp.tool.run",
+      spanAttributes,
+      fn,
+      (r) => {
+        const success = !r.isError;
+        return success
+          ? { "tool.success": true }
+          : { "tool.success": false, "tool.error_code": "tool_error" };
+      },
+    );
+    if (result.isError) outcome = "error";
+    return result;
+  } catch (err) {
+    outcome = "error";
+    // Re-throw the original error so the caller's catch can shape the
+    // CallToolResult exactly as before; the surrounding span has already
+    // recorded `recordException` via `withSpan`.
+    throw err instanceof Error ? err : new Error(String(err));
+  } finally {
+    const latencyMs = performance.now() - start;
+    const obsAttrs = {
+      "tool.name": ctx.toolName,
+      transport: ctx.transport,
+      "deploy.mode": ctx.deployMode,
+      outcome,
+    };
+    mcpToolCalls.add(1, obsAttrs);
+    mcpToolLatency.record(latencyMs, obsAttrs);
+  }
+}

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -9,7 +9,13 @@
  * requestId })` so the approval gate inside `executeSQL` sees a bound
  * actor. Mirrors the F-54 (scheduler) / F-55 (Slack) binding pattern from
  * PR #1860. The actor is resolved once at server boot by `resolveMcpActor`
- * and threaded through `registerTools(server, { actor })`.
+ * and threaded through `registerTools(server, { actor, transport })`.
+ *
+ * #2029 — every dispatch is also wrapped in `traceMcpToolCall`, which
+ * emits an OTel span, increments the tool-call counter, records the latency
+ * histogram, and fires a one-time activation event per workspace. The
+ * `transport` arg flows from `bin/serve.ts` to keep the span attribute
+ * accurate without re-detecting transport per request.
  */
 
 import { z } from "zod/v4";
@@ -19,7 +25,9 @@ import { explore } from "@atlas/api/lib/tools/explore";
 import { executeSQL } from "@atlas/api/lib/tools/sql";
 import type { AtlasUser } from "@atlas/api/lib/auth/types";
 import { withRequestContext } from "@atlas/api/lib/logger";
+import { getConfig } from "@atlas/api/lib/config";
 import { registerSemanticTools } from "./semantic-tools.js";
+import { traceMcpToolCall, type McpTransport } from "./telemetry.js";
 
 export interface RegisterToolsOptions {
   /**
@@ -30,14 +38,39 @@ export interface RegisterToolsOptions {
    * with a chat-app-shaped error that doesn't apply to MCP. See #1858.
    */
   actor: AtlasUser;
+  /**
+   * Carrier transport in use for this MCP server instance. Set once at
+   * boot by `bin/serve.ts` and threaded through to every `registerTool`
+   * dispatch so OTel spans / counters tag the right transport without
+   * re-detecting it per request. Optional for backwards compat; defaults
+   * to `stdio`. See #2029.
+   */
+  transport?: McpTransport;
 }
 
 function dispatchId(prefix: string): string {
   return `${prefix}-${crypto.randomUUID()}`;
 }
 
+/**
+ * Resolve the workspace id for OTel span / counter attribution. In
+ * trusted-transport mode the actor is `system:mcp` with no
+ * `activeOrganizationId`; falling back to the actor id keeps the
+ * attribute non-empty (collectors strip empty-string label values
+ * inconsistently across vendors). See `actor.ts`.
+ */
+function workspaceIdOf(actor: AtlasUser): string {
+  return actor.activeOrganizationId ?? actor.id;
+}
+
+function deployModeOf(): string {
+  return getConfig()?.deployMode ?? "self-hosted";
+}
+
 export function registerTools(server: McpServer, opts: RegisterToolsOptions): void {
-  const { actor } = opts;
+  const { actor, transport = "stdio" } = opts;
+  const workspaceId = workspaceIdOf(actor);
+  const deployMode = deployModeOf();
 
   // --- explore ---
   server.registerTool(
@@ -54,32 +87,36 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
       },
     },
     async ({ command }): Promise<CallToolResult> =>
-      withRequestContext(
-        { requestId: dispatchId("mcp-explore"), user: actor },
-        async () => {
-          try {
-            const result = await explore.execute!(
-              { command },
-              { toolCallId: "mcp-explore", messages: [] },
-            );
-            const text =
-              typeof result === "string" ? result : JSON.stringify(result);
-            const isError =
-              text.startsWith("Error:") || text.startsWith("Error (exit");
-            return {
-              content: [{ type: "text" as const, text }],
-              isError,
-            };
-          } catch (err) {
-            const text =
-              err instanceof Error ? err.message : "explore tool failed";
-            process.stderr.write(`[atlas-mcp] explore tool threw: ${err}\n`);
-            return {
-              content: [{ type: "text" as const, text }],
-              isError: true,
-            };
-          }
-        },
+      traceMcpToolCall(
+        { toolName: "explore", workspaceId, transport, deployMode },
+        () =>
+          withRequestContext(
+            { requestId: dispatchId("mcp-explore"), user: actor },
+            async () => {
+              try {
+                const result = await explore.execute!(
+                  { command },
+                  { toolCallId: "mcp-explore", messages: [] },
+                );
+                const text =
+                  typeof result === "string" ? result : JSON.stringify(result);
+                const isError =
+                  text.startsWith("Error:") || text.startsWith("Error (exit");
+                return {
+                  content: [{ type: "text" as const, text }],
+                  isError,
+                };
+              } catch (err) {
+                const text =
+                  err instanceof Error ? err.message : "explore tool failed";
+                process.stderr.write(`[atlas-mcp] explore tool threw: ${err}\n`);
+                return {
+                  content: [{ type: "text" as const, text }],
+                  isError: true,
+                };
+              }
+            },
+          ),
       ),
   );
 
@@ -103,60 +140,64 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
       },
     },
     async ({ sql, explanation, connectionId }): Promise<CallToolResult> =>
-      withRequestContext(
-        { requestId: dispatchId("mcp-executeSQL"), user: actor },
-        async () => {
-          try {
-            const result = await executeSQL.execute!(
-              { sql, explanation, connectionId },
-              { toolCallId: "mcp-executeSQL", messages: [] },
-            );
+      traceMcpToolCall(
+        { toolName: "executeSQL", workspaceId, transport, deployMode },
+        () =>
+          withRequestContext(
+            { requestId: dispatchId("mcp-executeSQL"), user: actor },
+            async () => {
+              try {
+                const result = await executeSQL.execute!(
+                  { sql, explanation, connectionId },
+                  { toolCallId: "mcp-executeSQL", messages: [] },
+                );
 
-            // executeSQL returns { success: boolean, error?, ... }
-            const obj = result as Record<string, unknown>;
-            if (obj.success === false) {
-              return {
-                content: [
-                  {
-                    type: "text" as const,
-                    text: String(obj.error ?? "Query failed"),
-                  },
-                ],
-                isError: true,
-              };
-            }
+                // executeSQL returns { success: boolean, error?, ... }
+                const obj = result as Record<string, unknown>;
+                if (obj.success === false) {
+                  return {
+                    content: [
+                      {
+                        type: "text" as const,
+                        text: String(obj.error ?? "Query failed"),
+                      },
+                    ],
+                    isError: true,
+                  };
+                }
 
-            return {
-              content: [
-                {
-                  type: "text" as const,
-                  text: JSON.stringify(
+                return {
+                  content: [
                     {
-                      explanation: obj.explanation,
-                      row_count: obj.row_count,
-                      columns: obj.columns,
-                      rows: obj.rows,
-                      truncated: obj.truncated,
+                      type: "text" as const,
+                      text: JSON.stringify(
+                        {
+                          explanation: obj.explanation,
+                          row_count: obj.row_count,
+                          columns: obj.columns,
+                          rows: obj.rows,
+                          truncated: obj.truncated,
+                        },
+                        null,
+                        2,
+                      ),
                     },
-                    null,
-                    2,
-                  ),
-                },
-              ],
-            };
-          } catch (err) {
-            const text =
-              err instanceof Error ? err.message : "executeSQL tool failed";
-            process.stderr.write(`[atlas-mcp] executeSQL tool threw: ${err}\n`);
-            return {
-              content: [{ type: "text" as const, text }],
-              isError: true,
-            };
-          }
-        },
+                  ],
+                };
+              } catch (err) {
+                const text =
+                  err instanceof Error ? err.message : "executeSQL tool failed";
+                process.stderr.write(`[atlas-mcp] executeSQL tool threw: ${err}\n`);
+                return {
+                  content: [{ type: "text" as const, text }],
+                  isError: true,
+                };
+              }
+            },
+          ),
       ),
   );
 
   // --- typed semantic-layer tools ---
-  registerSemanticTools(server, opts);
+  registerSemanticTools(server, { actor, transport, workspaceId, deployMode });
 }

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -27,7 +27,11 @@ import type { AtlasUser } from "@atlas/api/lib/auth/types";
 import { withRequestContext } from "@atlas/api/lib/logger";
 import { getConfig } from "@atlas/api/lib/config";
 import { registerSemanticTools } from "./semantic-tools.js";
-import { traceMcpToolCall, type McpTransport } from "./telemetry.js";
+import {
+  traceMcpToolCall,
+  type McpTransport,
+  type McpDeployMode,
+} from "./telemetry.js";
 
 export interface RegisterToolsOptions {
   /**
@@ -63,7 +67,7 @@ function workspaceIdOf(actor: AtlasUser): string {
   return actor.activeOrganizationId ?? actor.id;
 }
 
-function deployModeOf(): string {
+function deployModeOf(): McpDeployMode {
   return getConfig()?.deployMode ?? "self-hosted";
 }
 
@@ -152,7 +156,6 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
                   { toolCallId: "mcp-executeSQL", messages: [] },
                 );
 
-                // executeSQL returns { success: boolean, error?, ... }
                 const obj = result as Record<string, unknown>;
                 if (obj.success === false) {
                   return {


### PR DESCRIPTION
Closes #2029.

## Summary

1.3.1's #1979 (PR #2011) covered scheduler + plugin lifecycle + abuse counters, but MCP tool dispatch was still dark — no spans, no counters, no way to answer "did anyone adopt MCP?" or "what's `runMetric` p99?". This PR mirrors the #1979 pattern across the MCP transport so 1.4.0 adoption shows up in the same exporter that already has API coverage.

- **Span per dispatch.** Every MCP tool call (4 typed tools — `listEntities` / `describeEntity` / `searchGlossary` / `runMetric` — plus `executeSQL` and `explore`) is wrapped at the dispatch boundary in `traceMcpToolCall`, which calls `withSpan` from `@atlas/api/lib/tracing`. Span name is `atlas.mcp.tool.run` with attributes `tool.name`, `workspace.id`, `transport` (`stdio` / `sse`), `deploy.mode` (`self-hosted` / `saas`), `tool.success`, and `tool.error_code` on failure. `runMetric` adds `metric.id`; the downstream `atlas.sql.execute` span (already covered by #1979) nests under it for the agent-loop-vs-MCP latency split the issue calls out.

- **Counter + histogram on the shared `@atlas/api` Meter.** Three new instruments live in `packages/api/src/lib/metrics.ts` next to `abuseEscalations` so a single `OTEL_EXPORTER_OTLP_ENDPOINT` configuration handles both surfaces — operators don't need a second exporter:
  - `atlas.mcp.tool.calls` (Counter, attrs `tool.name` × `outcome` × `transport` × `deploy.mode`).
  - `atlas.mcp.tool.latency` (Histogram, ms, raw observations — derive p50/p95/p99 downstream so dashboards aren't pinned to one set of cutoffs).
  - `atlas.mcp.activations` (Counter, attrs `workspace.id` × `transport` × `deploy.mode`) — fires once per workspace per MCP process on the first observed tool call. Process-local `Set` for dedup; SaaS-replica accuracy is downstream (`workspace.id` × first-seen day). No DB-backed state — matches the issue's "don't introduce a parallel telemetry path" rule, and self-hosted MCP doesn't necessarily have an internal Postgres anyway.

- **Transport plumbing.** `bin/serve.ts` knows which transport it just chose, so it threads `transport: "stdio"` or `transport: "sse"` through `createAtlasMcpServer({ transport })` → `registerTools({ transport })` → `traceMcpToolCall`. No per-request transport detection.

- **Sampling.** Inherits the existing API-server config (`OTEL_EXPORTER_OTLP_ENDPOINT` → `NodeSDK` defaults). No overrides.

- **Error handling.** `traceMcpToolCall` re-throws underlying tool errors after recording `outcome=error` on the counter / histogram so instrumentation never masks a real failure. Tool-level error results (`CallToolResult.isError === true`) split cleanly via the `setResultAttributes` callback that `withSpan` already provides.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun run test` — full suite (321 + 19 + 104 + 25 + 10 + plugins all pass)
- [x] `bun x syncpack lint` — `No issues found`
- [x] `bash scripts/check-template-drift.sh` — passed
- [x] `bash scripts/check-security-headers-drift.sh` — passed
- [x] `bash scripts/check-railway-watch.sh` — passed
- [x] New `packages/mcp/src/__tests__/telemetry.test.ts` asserts span name + workspace/transport/deploy.mode attrs, counter outcome split, latency observations, activation fires-once-per-workspace, `runMetric` `metric.id` propagation, and that error re-throws are recorded as `outcome=error`. Uses the same `mock.module("@atlas/api/lib/tracing", ...)` capture pattern as #2011's scheduler tests and the `mock.module("@atlas/api/lib/metrics", ...)` pattern as #2011's abuse tests.

## Docs

`apps/docs/content/docs/platform-ops/observability.mdx` — one new row under the spans table (`atlas.mcp.tool.run`) and three new rows under the metrics table (`atlas.mcp.tool.calls` / `atlas.mcp.tool.latency` / `atlas.mcp.activations`). Existing collector setup covers the new signals — no new dashboards required.

## Pattern alignment

Mirrors **PR #2011** (the #1979 implementation) — same `withSpan` helper, same `@atlas/api` Meter, same `mock.module` capture in tests. Naming convention `atlas.mcp.<op>` matches the existing `atlas.scheduler.<op>` / `atlas.plugin.<op>` / `atlas.abuse.<op>` families.

## Coordination

Touches `packages/mcp/src/server.ts` and `packages/mcp/src/tools.ts`. If #2030 lands first I'll rebase; if both end up touching the dispatch function I'll coordinate via PR comment.