### PR TITLE
fix(api): apply CORS headers to streaming chat responses

### DIFF
--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -123,48 +123,18 @@ app.use("/api/*", async (c, next) => {
 // Default "*" is fine for API key / BYOT auth (header-based).
 // Managed auth (cookies) needs explicit origin + credentials — see docs/hono-extraction-design.md.
 //
-// The origin is read per-request from the settings cache so admin changes
-// take effect without a server restart.
-const bootCorsOrigin = process.env.ATLAS_CORS_ORIGIN;
-let corsSettingsWarnLogged = false;
-
-function resolveCorsOrigin(): string {
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports -- lazy import avoids circular dependency at module load
-    const { getSettingAuto } = require("@atlas/api/lib/settings") as {
-      getSettingAuto: (key: string) => string | undefined;
-    };
-    return getSettingAuto("ATLAS_CORS_ORIGIN") ?? bootCorsOrigin ?? "*";
-  } catch (err) {
-    if (!corsSettingsWarnLogged) {
-      log.warn(
-        { err: err instanceof Error ? err.message : String(err) },
-        "CORS: failed to read live setting — falling back to boot-time origin",
-      );
-      corsSettingsWarnLogged = true;
-    }
-    return bootCorsOrigin ?? "*";
-  }
-}
+// The origin is read per-request from the settings cache (via the
+// corsResponseHeaders helper) so admin changes take effect without a server
+// restart. The same helper is reused by streaming-response paths (demo chat,
+// main chat) that bypass this middleware via `throw HTTPException` — see
+// `packages/api/src/lib/cors.ts`.
+import { corsResponseHeaders } from "@atlas/api/lib/cors";
 
 app.use("/api/*", async (c, next) => {
   const requestOrigin = c.req.header("Origin") ?? "";
-  const configuredOrigin = resolveCorsOrigin();
-  const isWildcard = configuredOrigin === "*";
-  const isMatch = isWildcard || configuredOrigin === requestOrigin;
-
-  // Set CORS headers dynamically
-  if (isWildcard) {
-    c.header("Access-Control-Allow-Origin", "*");
-    // credentials must NOT be set with wildcard origin per CORS spec
-  } else if (isMatch) {
-    c.header("Access-Control-Allow-Origin", requestOrigin);
-    c.header("Access-Control-Allow-Credentials", "true");
+  for (const [name, value] of Object.entries(corsResponseHeaders(requestOrigin))) {
+    c.header(name, value);
   }
-  // Non-matching origin: no CORS headers set — browser will reject
-
-  c.header("Access-Control-Allow-Headers", "Content-Type, Authorization");
-  c.header("Access-Control-Expose-Headers", "Retry-After, x-conversation-id");
 
   // Handle preflight
   if (c.req.method === "OPTIONS") {

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -17,6 +17,7 @@ import { type UIMessage, createUIMessageStream, createUIMessageStreamResponse } 
 import { APICallError, LoadAPIKeyError, NoSuchModelError } from "ai";
 import { matchError, isRetryableError, isChatErrorCode, type ChatContextWarning } from "@useatlas/types";
 import { runAgent } from "@atlas/api/lib/agent";
+import { corsResponseHeaders } from "@atlas/api/lib/cors";
 import { validateEnvironment } from "@atlas/api/lib/startup";
 import { GatewayModelNotFoundError } from "@ai-sdk/gateway";
 import { createLogger, withRequestContext } from "@atlas/api/lib/logger";
@@ -907,11 +908,17 @@ chat.openapi(chatRoute, async (c) => {
             },
           });
   
+          // Streaming responses bypass Hono's CORS middleware (we throw a raw
+          // Response via HTTPException so OpenAPIHono's onError returns it
+          // unchanged). Re-apply CORS headers here so cross-origin embedders
+          // (e.g. @useatlas/react widget on a different domain) receive
+          // Access-Control-Allow-Origin. (#2037)
           const streamResponse = createUIMessageStreamResponse({
             stream,
             headers: {
               "X-Accel-Buffering": "no",
               "Cache-Control": "no-cache, no-transform",
+              ...corsResponseHeaders(c.req.header("Origin") ?? ""),
               ...(conversationId ? { "x-conversation-id": conversationId } : {}),
             },
           });

--- a/packages/api/src/api/routes/demo.ts
+++ b/packages/api/src/api/routes/demo.ts
@@ -35,6 +35,7 @@ import {
   persistAssistantSteps,
 } from "@atlas/api/lib/conversations";
 import { setStreamWriter, clearStreamWriter } from "@atlas/api/lib/tools/python-stream";
+import { corsResponseHeaders } from "@atlas/api/lib/cors";
 import {
   signDemoToken,
   verifyDemoToken,
@@ -524,11 +525,16 @@ demo.openapi(demoChatRoute, async (c) => {
           },
         });
 
+        // Streaming responses bypass Hono's CORS middleware (we throw a raw
+        // Response via HTTPException so OpenAPIHono's onError returns it
+        // unchanged). Re-apply the CORS headers here so cross-origin
+        // browser fetches receive Access-Control-Allow-Origin. (#2037)
         const streamResponse = createUIMessageStreamResponse({
           stream,
           headers: {
             "X-Accel-Buffering": "no",
             "Cache-Control": "no-cache, no-transform",
+            ...corsResponseHeaders(c.req.header("Origin") ?? ""),
             ...(conversationId ? { "x-conversation-id": conversationId } : {}),
           },
         });

--- a/packages/api/src/lib/cors.ts
+++ b/packages/api/src/lib/cors.ts
@@ -1,0 +1,68 @@
+/**
+ * CORS header computation shared between the global Hono middleware and the
+ * streaming-response paths (demo chat, main chat) that bypass middleware via
+ * `throw new HTTPException(200, { res: streamResponse })`.
+ *
+ * The streaming response is constructed inside the route handler with its
+ * own headers, then thrown so Hono's onError handler returns it raw — at
+ * which point the CORS middleware's queued headers are NOT applied. Without
+ * this helper, cross-origin streaming requests succeed at the network level
+ * but the browser blocks the response for missing
+ * `Access-Control-Allow-Origin`. (#2037)
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("cors");
+
+const bootCorsOrigin = process.env.ATLAS_CORS_ORIGIN;
+let corsSettingsWarnLogged = false;
+
+/**
+ * Resolve the configured CORS origin. Reads from settings cache (so admin
+ * changes take effect without restart) with a fallback to the boot-time env.
+ * Defaults to `"*"` when unset — fine for API-key/BYOT auth (header-based).
+ */
+export function resolveCorsOrigin(): string {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- lazy import avoids circular dependency at module load
+    const { getSettingAuto } = require("@atlas/api/lib/settings") as {
+      getSettingAuto: (key: string) => string | undefined;
+    };
+    return getSettingAuto("ATLAS_CORS_ORIGIN") ?? bootCorsOrigin ?? "*";
+  } catch (err) {
+    if (!corsSettingsWarnLogged) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "CORS: failed to read live setting — falling back to boot-time origin",
+      );
+      corsSettingsWarnLogged = true;
+    }
+    return bootCorsOrigin ?? "*";
+  }
+}
+
+/**
+ * Compute the CORS response headers for a given request origin. Returns the
+ * exact headers the streaming-response path should attach so cross-origin
+ * fetches receive `Access-Control-Allow-Origin` (the browser blocks any
+ * non-OPTIONS response missing this, even when the preflight succeeded).
+ */
+export function corsResponseHeaders(requestOrigin: string): Record<string, string> {
+  const configured = resolveCorsOrigin();
+  const headers: Record<string, string> = {
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    "Access-Control-Expose-Headers": "Retry-After, x-conversation-id",
+  };
+
+  if (configured === "*") {
+    headers["Access-Control-Allow-Origin"] = "*";
+    // Per CORS spec, credentials must NOT be set with wildcard origin.
+  } else if (configured === requestOrigin) {
+    headers["Access-Control-Allow-Origin"] = requestOrigin;
+    headers["Access-Control-Allow-Credentials"] = "true";
+  }
+  // Non-matching origin: no CORS headers — browser will reject (correct).
+
+  return headers;
+}


### PR DESCRIPTION
## Summary

Streaming responses in `/api/v1/chat` and `/api/v1/demo/chat` bypass Hono's CORS middleware: the route handler builds a raw `Response` via `createUIMessageStreamResponse` and throws `HTTPException(200, { res })`, at which point Hono's `onError` returns the response unchanged — without the CORS headers the middleware would have queued.

**Result:** cross-origin browser fetches to either endpoint succeed at the network level (preflight OK) but the browser blocks the response for missing `Access-Control-Allow-Origin`.

**Discovery:** post-#2036 demo smoke at `app.useatlas.dev/demo` → `api.useatlas.dev/api/v1/demo/chat` blocked by the browser; curl with the same payload returns 200 but **without** the CORS header on the response (preflight had it correctly).

## Fix

- Extract CORS resolution into `packages/api/src/lib/cors.ts`:
  - `resolveCorsOrigin()` — same logic as before, now reusable
  - `corsResponseHeaders(requestOrigin)` — returns the exact headers the streaming-response path should attach
- Refactor `api/index.ts` CORS middleware to use the helper
- Apply `corsResponseHeaders(...)` to the streaming response headers in both `api/routes/demo.ts` and `api/routes/chat.ts`

Main chat had the same latent bug — cross-origin embedders (e.g. the `@useatlas/react` widget loaded on a different domain than the API) would have hit the same issue. The fix covers both paths.

## Test plan

- [x] `bun run lint`, `bun run type` (no new errors — 3 pre-existing `@useatlas/types/mcp` errors on `main` are not introduced by this PR)
- [x] 16 affected tests pass (`packages/api scripts/test-isolated.ts --affected`)
- [x] syncpack, template drift, security-headers, railway-watch all green
- [ ] Post-merge smoke: re-test the demo flow at `app.useatlas.dev/demo` end-to-end (email gate → "Start demo" → ask a canonical question → response streams back). I'll re-drive via Playwright once the merge redeploys.

## Why this wasn't caught earlier

Pre-#2036, the demo deploy didn't surface this because `ATLAS_DEMO_ENABLED` wasn't even set on the api service — the route 404'd before CORS ever became relevant. The combination of (a) enabling demo mode + (b) cross-origin call from `app.useatlas.dev` to `api.useatlas.dev` is what surfaced the streaming-response gap.