### PR TITLE
fix(mcp): un-break CI by completing the @atlas/api/lib/config mock

### DIFF
--- a/packages/mcp/src/__tests__/server.test.ts
+++ b/packages/mcp/src/__tests__/server.test.ts
@@ -13,15 +13,28 @@ const TEST_ACTOR = createAtlasUser("u_server", "managed", "server@test", {
   activeOrganizationId: "org_server",
 });
 
-// Mock config initialization to avoid requiring a real database
+// Mock all named exports — partial mocks leak via the in-process Bun
+// runner and break unrelated tests (`Export named 'getConfig' not found`).
+const __mockedConfig = {
+  datasources: {},
+  tools: ["explore", "executeSQL"],
+  auth: "auto",
+  semanticLayer: "./semantic",
+  source: "env",
+};
 mock.module("@atlas/api/lib/config", () => ({
-  initializeConfig: mock(async () => ({
-    datasources: {},
-    tools: ["explore", "executeSQL"],
-    auth: "auto",
-    semanticLayer: "./semantic",
-    source: "env",
-  })),
+  initializeConfig: mock(async () => __mockedConfig),
+  getConfig: mock(() => __mockedConfig),
+  loadConfig: mock(async () => __mockedConfig),
+  configFromEnv: mock(() => __mockedConfig),
+  validateAndResolve: mock(() => __mockedConfig),
+  defineConfig: (c: unknown) => c,
+  applyDatasources: mock(async () => undefined),
+  validateToolConfig: mock(async () => undefined),
+  formatZodErrors: () => "",
+  _resetConfig: mock(() => undefined),
+  _setConfigForTest: mock(() => undefined),
+  _warnPoolDefaultsInSaaS: mock(() => undefined),
 }));
 
 // Mock tool execute functions

--- a/packages/mcp/src/__tests__/smoke.test.ts
+++ b/packages/mcp/src/__tests__/smoke.test.ts
@@ -22,14 +22,28 @@ const SMOKE_ACTOR = createAtlasUser("u_smoke", "managed", "smoke@test", {
 // Module mocks — mock the named exports consumed by the server module
 // ---------------------------------------------------------------------------
 
+// Mock all named exports — partial mocks leak via the in-process Bun
+// runner and break unrelated tests (`Export named 'getConfig' not found`).
+const __mockedConfig = {
+  datasources: {},
+  tools: ["explore", "executeSQL"],
+  auth: "auto",
+  semanticLayer: "./semantic",
+  source: "env",
+};
 mock.module("@atlas/api/lib/config", () => ({
-  initializeConfig: mock(async () => ({
-    datasources: {},
-    tools: ["explore", "executeSQL"],
-    auth: "auto",
-    semanticLayer: "./semantic",
-    source: "env",
-  })),
+  initializeConfig: mock(async () => __mockedConfig),
+  getConfig: mock(() => __mockedConfig),
+  loadConfig: mock(async () => __mockedConfig),
+  configFromEnv: mock(() => __mockedConfig),
+  validateAndResolve: mock(() => __mockedConfig),
+  defineConfig: (c: unknown) => c,
+  applyDatasources: mock(async () => undefined),
+  validateToolConfig: mock(async () => undefined),
+  formatZodErrors: () => "",
+  _resetConfig: mock(() => undefined),
+  _setConfigForTest: mock(() => undefined),
+  _warnPoolDefaultsInSaaS: mock(() => undefined),
 }));
 
 mock.module("@atlas/api/lib/tools/explore", () => ({

--- a/packages/mcp/src/__tests__/sse.test.ts
+++ b/packages/mcp/src/__tests__/sse.test.ts
@@ -9,15 +9,30 @@ const SSE_ACTOR = createAtlasUser("u_sse", "managed", "sse@test", {
   activeOrganizationId: "org_sse",
 });
 
-// Mock config initialization to avoid requiring a real database
+// Mock config initialization to avoid requiring a real database. Per
+// CLAUDE.md, mock.module() must cover every named export downstream
+// callers use — partial mocks leak via the in-process Bun runner and
+// break unrelated tests with `Export named 'X' not found`.
+const __mockedConfig = {
+  datasources: {},
+  tools: ["explore", "executeSQL"],
+  auth: "auto",
+  semanticLayer: "./semantic",
+  source: "env",
+};
 mock.module("@atlas/api/lib/config", () => ({
-  initializeConfig: mock(async () => ({
-    datasources: {},
-    tools: ["explore", "executeSQL"],
-    auth: "auto",
-    semanticLayer: "./semantic",
-    source: "env",
-  })),
+  initializeConfig: mock(async () => __mockedConfig),
+  getConfig: mock(() => __mockedConfig),
+  loadConfig: mock(async () => __mockedConfig),
+  configFromEnv: mock(() => __mockedConfig),
+  validateAndResolve: mock(() => __mockedConfig),
+  defineConfig: (c: unknown) => c,
+  applyDatasources: mock(async () => undefined),
+  validateToolConfig: mock(async () => undefined),
+  formatZodErrors: () => "",
+  _resetConfig: mock(() => undefined),
+  _setConfigForTest: mock(() => undefined),
+  _warnPoolDefaultsInSaaS: mock(() => undefined),
 }));
 
 // Mock tool execute functions


### PR DESCRIPTION
## Summary

CI on main has been red because three @atlas/mcp test files (`sse`, `smoke`, `server`) used `mock.module(\"@atlas/api/lib/config\", ...)` but only declared `initializeConfig`. Bun's in-process runner shares modules across files, so the moment a sibling test (`prompts.test.ts`, `actor.test.ts`) loaded `tools.ts` — which imports `getConfig` — the partial mock served the import and threw:

\`\`\`
SyntaxError: Export named 'getConfig' not found in module '/.../packages/api/src/lib/config.ts'.
\`\`\`

That cascade unhandled-error'd 11 unrelated tests on CI (`prompt library`, `resolveMcpActor`, etc.). Locally the failure was invisible because the test-discovery order differed.

Per CLAUDE.md (\"When using mock.module(), mock ALL named exports — partial mocks break other test files\"), this expands the three config mocks to cover every named export downstream consumers might reach through the same Bun process.

## Test plan

- [x] \`bun run --filter @atlas/mcp test\` — 183 pass, 0 fail across 15 files
- [x] \`bun run test\` (full 26-package suite) — all green
- [x] \`bun run lint\`, \`bun run type\` — green
- [x] syncpack, drift, security-headers, railway-watch — green

## Why this was missed

\`@atlas/mcp\` doesn't have an isolated test runner like \`@atlas/api\` does. The pollution went unnoticed locally because Bun's file-discovery order isn't stable across machines, but CI hit it deterministically. The root fix would be to give \`@atlas/mcp\` its own \`scripts/test-isolated.ts\` (parity with \`@atlas/api\`); this PR is the surgical one-liner-equivalent that gets CI green now. Tracking the larger refactor as a follow-up isn't necessary — the mock-all-exports rule is enforced by CLAUDE.md and code review.