### PR TITLE
docs: #2026 — lead README, docs homepage, and landing with MCP + YAML moat

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -145,7 +145,7 @@ Tracker: [milestone #40](https://github.com/AtlasDevHQ/atlas/milestones/40). Lea
 - [x] OTel coverage for MCP tool calls — activation + tool-call counters (#2029, PR #2035)
 - [x] Structured error envelope for typed MCP tools so agents can recover gracefully (#2030, PR #2034)
 - [ ] List Atlas in MCP registries (mcp.so + others) before close (#2027)
-- [ ] Lead README, docs homepage, and landing with MCP + the YAML-first story (#2026)
+- [x] Lead README, docs homepage, and landing with MCP + the YAML-first story (#2026)
 - [ ] Canonical-question eval harness for the demo dataset (#2025)
 - [x] Consolidate canonical demo dataset across landing, docs, scaffolder (#2021, PR #2036) — three seeds collapsed to one canonical NovaMart ecommerce seed; multi-seed picker reverted; canonical question set locked for #2025/#2026.
 - [x] Streaming chat CORS fix (PR #2037) — surfaced by the post-#2021 demo smoke; same latent bug existed for cross-origin embedders of `@useatlas/react`.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  <a href="https://docs.useatlas.dev">Documentation</a> · <a href="https://app.useatlas.dev">Live Demo</a> · <a href="https://docs.useatlas.dev/getting-started/semantic-layer">The Semantic Layer</a> · <a href="https://docs.useatlas.dev/guides/mcp">MCP Guide</a> · <a href="https://github.com/AtlasDevHQ/atlas/issues">Issues</a>
+  <a href="https://docs.useatlas.dev">Documentation</a> · <a href="https://app.useatlas.dev">Live Demo</a> · <a href="https://docs.useatlas.dev/semantic-layer">The Semantic Layer</a> · <a href="https://docs.useatlas.dev/guides/mcp">MCP Guide</a> · <a href="https://github.com/AtlasDevHQ/atlas/issues">Issues</a>
 </p>
 
 <p align="center">
@@ -37,6 +37,8 @@ bunx @useatlas/mcp init --local            # print paste-ready config
 bunx @useatlas/mcp init --local --write    # merge into the detected client config (with a .bak)
 ```
 
+> **Note:** The `@useatlas/mcp` npm package is in final review for publishing — see [#2042](https://github.com/AtlasDevHQ/atlas/issues/2042). Until then, the installer runs from the monorepo via `bun packages/mcp/bin/init.ts --local`.
+
 Restart Claude Desktop / Cursor and ask one of the canonical questions:
 
 - *"What's our GMV this quarter?"*
@@ -45,7 +47,7 @@ Restart Claude Desktop / Cursor and ask one of the canonical questions:
 - *"Show me revenue last quarter."* — Atlas asks which definition you mean (GMV vs. net revenue vs. seller revenue) because `revenue` is `status: ambiguous` in the glossary
 - *"What are our most common return reasons?"*
 
-The agent reads your YAML semantic layer first, picks the right entities, writes SQL, runs it through the validation pipeline, and returns answers with the underlying SQL on display. See the [MCP guide](https://docs.useatlas.dev/guides/mcp) for the full flow including hosted MCP at `mcp.useatlas.dev` (#2024).
+The agent reads your YAML semantic layer first, picks the right entities, writes SQL, runs it through the validation pipeline, and returns answers with the underlying SQL on display. See the [MCP guide](https://docs.useatlas.dev/guides/mcp) for the full flow. Hosted MCP at `mcp.useatlas.dev` is in development — tracked in [#2024](https://github.com/AtlasDevHQ/atlas/issues/2024).
 
 ## What's in the YAML?
 
@@ -90,7 +92,7 @@ cd my-app && bun run dev
 # Open http://localhost:3000
 ```
 
-The `--demo` flag seeds the canonical NovaMart e-commerce dataset (52 tables, ~480K rows) with the same canonical questions baked in as starter prompts.
+The `--demo` flag seeds the canonical NovaMart e-commerce dataset (52 tables, ~480K rows) — twelve generic e-commerce KPIs ship as starter prompts inside the chat UI; the canonical 5 above drive the eval harness ([#2025](https://github.com/AtlasDevHQ/atlas/issues/2025)) and the docs/landing copy.
 
 ## Embed in your app
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">Atlas</h1>
 
 <p align="center">
-  Open-source text-to-SQL agent you can embed anywhere.
+  Atlas is a YAML-defined semantic layer for analytics — authored by humans, consumed by AI agents.
 </p>
 
 <p align="center">
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  <a href="https://docs.useatlas.dev">Documentation</a> · <a href="https://app.useatlas.dev">Live Demo</a> · <a href="https://docs.useatlas.dev/deployment/deploy">Deploy Guide</a> · <a href="https://github.com/AtlasDevHQ/atlas/issues">Issues</a>
+  <a href="https://docs.useatlas.dev">Documentation</a> · <a href="https://app.useatlas.dev">Live Demo</a> · <a href="https://docs.useatlas.dev/getting-started/semantic-layer">The Semantic Layer</a> · <a href="https://docs.useatlas.dev/guides/mcp">MCP Guide</a> · <a href="https://github.com/AtlasDevHQ/atlas/issues">Issues</a>
 </p>
 
 <p align="center">
@@ -22,11 +22,67 @@
 
 ## What is Atlas?
 
-Atlas is a deploy-anywhere text-to-SQL agent. Connect any database, auto-generate a semantic layer, and let your users ask questions in plain English. Every query is validated through a multi-layer security pipeline — only read-only SQL against whitelisted tables is allowed.
+Atlas turns a directory of YAML files into a complete semantic layer for analytics — entities, dimensions, measures, joins, virtual dimensions, query patterns, glossary terms, and authoritative metrics. Humans author the YAML. AI agents consume it through the **Model Context Protocol (MCP)** to answer business questions in natural language, with deterministic, validated, read-only SQL.
+
+Every YAML field exists because an LLM needs it to write correct SQL: `sample_values` ground the agent in real data, `glossary.status: ambiguous` forces clarifying questions, `metrics.objective` picks `MAX` vs `MIN`, `query_patterns` teach the canonical join shapes for your domain.
 
 Built with Hono, Vercel AI SDK, and bun. Supports Anthropic, OpenAI, Bedrock, Ollama, and Vercel AI Gateway. Works with PostgreSQL, MySQL, ClickHouse, Snowflake, DuckDB, BigQuery, and Salesforce.
 
-## Try it in 60 seconds
+## Install Atlas as an MCP server (the lead path)
+
+Add Atlas to Claude Desktop, Cursor, or Continue with one command. Auto-detects the client and falls back to a bundled demo fixture when no datasource is configured:
+
+```bash
+bunx @useatlas/mcp init --local            # print paste-ready config
+bunx @useatlas/mcp init --local --write    # merge into the detected client config (with a .bak)
+```
+
+Restart Claude Desktop / Cursor and ask one of the canonical questions:
+
+- *"What's our GMV this quarter?"*
+- *"What's our top-performing category by GMV this month?"*
+- *"Monthly GMV trend over the past 6 months."*
+- *"Show me revenue last quarter."* — Atlas asks which definition you mean (GMV vs. net revenue vs. seller revenue) because `revenue` is `status: ambiguous` in the glossary
+- *"What are our most common return reasons?"*
+
+The agent reads your YAML semantic layer first, picks the right entities, writes SQL, runs it through the validation pipeline, and returns answers with the underlying SQL on display. See the [MCP guide](https://docs.useatlas.dev/guides/mcp) for the full flow including hosted MCP at `mcp.useatlas.dev` (#2024).
+
+## What's in the YAML?
+
+A 20-line slice of `semantic/entities/orders.yml` from the bundled NovaMart e-commerce demo (#2021):
+
+```yaml
+name: Orders
+type: fact_table
+table: orders
+grain: one row per order
+description: |
+  Customer orders — the primary fact table for revenue analysis.
+  shipping_cost uses MIXED UNITS (some rows in dollars, some in cents).
+dimensions:
+  - name: status
+    sql: status
+    type: string
+    sample_values: [pending, processing, shipped, delivered, cancelled]
+  - name: order_month
+    sql: TO_CHAR(created_at, 'YYYY-MM')
+    type: string
+    virtual: true
+measures:
+  - name: total_gmv_cents
+    sql: total_cents
+    type: sum
+joins:
+  - target_entity: Customers
+    relationship: many_to_one
+    join_columns: { from: customer_id, to: id }
+```
+
+That YAML is the contract between your team and the agent — version-controlled, code-reviewed, diffable. Sibling files (`glossary.yml`, `metrics/*.yml`, `catalog.yml`) round it out: glossary terms with `status: ambiguous` force the agent to clarify, metrics with `objective: maximize` / `minimize` make optimization direction explicit, and the catalog routes the agent to the right entity for a given question.
+
+See the full [Semantic Layer reference](https://docs.useatlas.dev/getting-started/semantic-layer) for the complete schema.
+
+## Try the demo locally
 
 ```bash
 bun create atlas-agent my-app --demo
@@ -34,11 +90,11 @@ cd my-app && bun run dev
 # Open http://localhost:3000
 ```
 
-The `--demo` flag seeds the canonical NovaMart e-commerce dataset (52 tables, ~480K rows) so you can start asking questions immediately.
+The `--demo` flag seeds the canonical NovaMart e-commerce dataset (52 tables, ~480K rows) with the same canonical questions baked in as starter prompts.
 
 ## Embed in your app
 
-Drop a single `<script>` tag into any page to add a floating chat widget:
+Atlas also ships an embeddable chat widget for any frontend:
 
 ```html
 <script
@@ -60,24 +116,14 @@ export default function App() {
 
 The widget supports programmatic control (`Atlas.open()`, `Atlas.ask("...")`, `Atlas.destroy()`), event callbacks, and theming. See the [widget docs](https://docs.useatlas.dev/guides/embedding-widget).
 
-## Use as an MCP server
-
-Add Atlas to Claude Desktop, Cursor, or Continue with a single command — auto-detects the client, falls back to a bundled demo fixture if no datasource is configured:
-
-```bash
-bunx @useatlas/mcp init --local            # print paste-ready config
-bunx @useatlas/mcp init --local --write    # merge into the detected client config (with a .bak)
-```
-
-See the [MCP guide](https://docs.useatlas.dev/guides/mcp) for the full flow.
-
 ## Why Atlas?
 
 | | Atlas | Traditional BI | Other text-to-SQL |
 |---|---|---|---|
-| **Embeddable** | Script tag, React component, or headless API | Standalone app | Standalone app |
+| **Semantic layer** | YAML on disk — `query_patterns`, `virtual_dimensions`, `glossary.status: ambiguous`, `metrics.objective` are all first-class | Proprietary metadata, GUI-authored | None or limited |
+| **Agent-native** | MCP server first — Claude Desktop, Cursor, Continue with `bunx @useatlas/mcp init` | Bolted-on AI feature | Standalone chat UI |
+| **Embeddable** | Script tag, React component, headless API, MCP, Slack, Teams | Standalone app | Standalone app |
 | **Deploy anywhere** | Docker, Railway, Vercel, or your own infra | Vendor-hosted | Vendor-hosted |
-| **Semantic layer** | YAML on disk, version-controlled, LLM-enriched | Proprietary metadata | None or limited |
 | **Plugin ecosystem** | 21 plugins across 5 types — extend anything | Closed | Limited |
 | **Open source** | AGPL-3.0 core, MIT client libs | Proprietary | Varies |
 | **Multi-database** | PostgreSQL, MySQL, ClickHouse, Snowflake, DuckDB, BigQuery, Salesforce | Usually one | Usually one |
@@ -103,13 +149,13 @@ docker compose up
 
 ## How It Works
 
-1. User asks a natural language question
-2. Agent explores the **semantic layer** (YAML files describing your schema)
+1. User (or agent) asks a natural language question — over MCP, the chat widget, the API, Slack, or Teams
+2. Agent explores the **YAML semantic layer** — entities, glossary, metrics, query patterns
 3. Agent writes SQL, validated through a multi-layer security pipeline (regex guard, AST parse, table whitelist, auto-LIMIT, statement timeout)
-4. Results are returned with charts and interpreted narrative
+4. Results are returned with charts and an interpreted narrative
 
 ```
-User question → Semantic layer exploration → SQL generation → Multi-layer validation → Query execution → Charts + narrative
+Question → YAML semantic layer → SQL generation → Multi-layer validation → Query execution → Charts + narrative
 ```
 
 ### Generate the semantic layer
@@ -117,7 +163,7 @@ User question → Semantic layer exploration → SQL generation → Multi-layer 
 ```bash
 bun run atlas -- init                 # Profile DB and generate YAMLs
 bun run atlas -- init --enrich        # Profile + LLM enrichment
-bun run atlas -- init --demo          # Load demo data + profile
+bun run atlas -- init --demo          # Load NovaMart demo data + profile
 ```
 
 ## Architecture
@@ -175,7 +221,10 @@ See [`.env.example`](.env.example) for all options.
 
 ## Documentation
 
+- [The Semantic Layer](https://docs.useatlas.dev/getting-started/semantic-layer) — Entities, dimensions, measures, joins, glossary, metrics — the YAML format reference
+- [MCP Server](https://docs.useatlas.dev/guides/mcp) — Use Atlas from Claude Desktop, Cursor, Continue
 - [Quick Start](https://docs.useatlas.dev/getting-started/quick-start) — Local dev from zero to asking questions
+- [Demo Dataset](https://docs.useatlas.dev/getting-started/demo-datasets) — NovaMart e-commerce dataset and canonical questions
 - [Deploy Options](https://docs.useatlas.dev/deployment/deploy) — Docker, Railway, Vercel, and more
 - [Connect Your Data](https://docs.useatlas.dev/getting-started/connect-your-data) — Connect to an existing database safely
 - [Widget Embedding](https://docs.useatlas.dev/guides/embedding-widget) — Script tag and React component

--- a/apps/docs/content/docs/getting-started/quick-start.mdx
+++ b/apps/docs/content/docs/getting-started/quick-start.mdx
@@ -192,9 +192,11 @@ Another dev server is using the port. Find it with `lsof -i :3000` (or `:3001`),
 
 The chat UI shows suggested questions based on the demo dataset. Try one:
 
-- "How many companies are there by industry?"
-- "What are the top 5 companies by revenue?"
-- "Which department has the most people?"
+- "What's our GMV this quarter?"
+- "What's our top-performing category by GMV this month?"
+- "Monthly GMV trend over the past 6 months."
+- "Show me revenue last quarter." — `revenue` is `status: ambiguous` in the glossary, so the agent will ask which definition you mean (GMV vs net revenue vs seller revenue)
+- "What are our most common return reasons?"
 
 <Callout type="info" title="You should see">
 The agent will:

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -19,6 +19,10 @@ bunx @useatlas/mcp init --local            # print paste-ready config
 bunx @useatlas/mcp init --local --write    # merge into the detected client config (with a .bak)
 ```
 
+<Callout type="info" title="`@useatlas/mcp` is in final review for npm publishing">
+Tracked in [#2042](https://github.com/AtlasDevHQ/atlas/issues/2042). Until the package lands on npm, run the installer from the monorepo with `bun packages/mcp/bin/init.ts --local`.
+</Callout>
+
 Restart your client and try one of the canonical NovaMart demo questions:
 
 - "What's our GMV this quarter?"

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -1,21 +1,59 @@
 ---
 title: Introduction to Atlas
-description: Atlas is a deploy-anywhere text-to-SQL data analyst agent.
+description: Atlas is a YAML-defined semantic layer for analytics — authored by humans, consumed by AI agents.
 ---
 
-Atlas lets you connect your database, auto-generate a semantic layer, and query your data in plain English. Every query is validated, read-only access is enforced, and it deploys anywhere.
+import { Callout } from "fumadocs-ui/components/callout";
+import { Cards, Card } from "fumadocs-ui/components/card";
+
+> Atlas is a YAML-defined semantic layer for analytics — authored by humans, consumed by AI agents.
+
+The semantic layer is the product. Everything else — the agent loop, the MCP server, the chat widget, the SQL validation pipeline — exists to make the YAML you write the source of truth for how questions become answers. Every field in the format exists because an LLM needs it: `sample_values` to ground the agent, `glossary.status: ambiguous` to force clarifying questions, `metrics.objective` to pick `MAX` vs `MIN`, `query_patterns` to teach canonical join shapes.
+
+## Get started
+
+The lead path is **MCP**. Install Atlas as a Model Context Protocol server and start asking questions from Claude Desktop, Cursor, or Continue:
+
+```bash
+bunx @useatlas/mcp init --local            # print paste-ready config
+bunx @useatlas/mcp init --local --write    # merge into the detected client config (with a .bak)
+```
+
+Restart your client and try one of the canonical NovaMart demo questions:
+
+- "What's our GMV this quarter?"
+- "What's our top-performing category by GMV this month?"
+- "Monthly GMV trend over the past 6 months."
+- "Show me revenue last quarter." — the agent asks which definition (GMV vs net revenue vs seller revenue) because `revenue` is `status: ambiguous` in the glossary
+- "What are our most common return reasons?"
+
+<Cards>
+  <Card title="MCP Server" href="/guides/mcp" description="Connect Claude Desktop, Cursor, or Continue with bunx @useatlas/mcp init" />
+  <Card title="The Semantic Layer" href="/semantic-layer" description="The YAML format that powers Atlas — entities, dimensions, measures, joins, glossary, metrics" />
+  <Card title="Hosted Quick Start" href="/getting-started/hosted" description="Sign up at app.useatlas.dev and start querying in minutes" />
+  <Card title="Self-Hosted Quick Start" href="/getting-started/quick-start" description="Local dev with Docker, Bun, and the NovaMart demo dataset" />
+</Cards>
 
 ## Getting Started
 
 - [Hosted Quick Start](/getting-started/hosted) -- Sign up at app.useatlas.dev and start querying in minutes
 - [Self-Hosted Quick Start](/getting-started/quick-start) -- Deploy Atlas on your own infrastructure
 - [Connect Your Data](/getting-started/connect-your-data) -- Connect to PostgreSQL, MySQL, or plugin-based sources (ClickHouse, Snowflake, DuckDB, Salesforce)
-- [Semantic Layer](/getting-started/semantic-layer) -- Define your data schema in YAML so the agent understands your database
-- [Demo Datasets](/getting-started/demo-datasets) -- Try Atlas with pre-built demo data
+- [Semantic Layer Reference](/getting-started/semantic-layer) -- The full YAML format reference (entities, dimensions, measures, joins, virtual dimensions, query patterns)
+- [Demo Dataset](/getting-started/demo-datasets) -- The NovaMart e-commerce dataset and its canonical questions
+
+## The Semantic Layer
+
+The YAML format is a first-class concept — read these before authoring anything in `semantic/`:
+
+- [Overview](/semantic-layer) -- The moat sentence, the canonical questions, and a 20-line YAML excerpt
+- [YAML Format](/semantic-layer/yaml-format) -- Pointer to the full field-level reference
+- [Glossary & Metrics](/semantic-layer/glossary-and-metrics) -- How glossary terms force clarifying questions and how metrics give the agent authoritative SQL
+- [Why YAML?](/semantic-layer/why-yaml) -- Why the semantic layer is files on disk, versioned and reviewable
 
 ## Guides
 
-- [MCP Server](/guides/mcp) -- Use Atlas in Claude Desktop, Cursor, and other MCP clients
+- [MCP Server](/guides/mcp) -- Use Atlas in Claude Desktop, Cursor, and other MCP clients (the lead install path)
 - [Slack Integration](/guides/slack) -- Query your data from Slack with slash commands and threaded follow-ups
 - [Python Data Analysis](/guides/python) -- Sandboxed Python execution for charts and statistical analysis
 - [Scheduled Tasks](/guides/scheduled-tasks) -- Run recurring queries and deliver results via email, Slack, or webhook

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -4,6 +4,7 @@
   "icon": "Book",
   "pages": [
     "getting-started",
+    "semantic-layer",
     "guides",
     "reference",
     "sdk",

--- a/apps/docs/content/docs/semantic-layer/glossary-and-metrics.mdx
+++ b/apps/docs/content/docs/semantic-layer/glossary-and-metrics.mdx
@@ -1,0 +1,61 @@
+---
+title: Glossary & Metrics
+description: Two YAML files that turn a schema description into a domain model — glossary terms force clarifying questions, metrics give the agent authoritative SQL.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+Beyond entities, two files in `semantic/` raise the YAML format from a schema description to a complete domain model.
+
+## `glossary.yml` — definitions and disambiguation
+
+The glossary defines the business vocabulary your team uses *and* tags ambiguous terms. When a term is `status: ambiguous`, the agent **asks a clarifying question** instead of guessing. This is how Atlas avoids the most common text-to-SQL failure mode: the model picks one plausible meaning and silently runs with it.
+
+```yaml
+terms:
+  GMV:
+    status: defined
+    definition: |
+      Gross Merchandise Value. SUM(orders.total_cents) / 100 for dollars.
+      Filter status != 'cancelled' for net GMV.
+    tables: [orders]
+
+  revenue:
+    status: ambiguous
+    note: |
+      Could mean GMV (orders.total_cents), net revenue (GMV minus refunds),
+      or seller revenue (after commission). ASK the user which definition.
+    possible_mappings:
+      - orders.total_cents
+      - payments.amount_cents
+      - refunds (subtracted)
+```
+
+When a user asks "show me revenue last quarter", the agent reads the glossary, sees `revenue` is ambiguous, and clarifies before writing SQL. This is one of the [canonical questions](/getting-started/demo-datasets) and the most visible part of the moat in action.
+
+## `metrics/*.yml` — authoritative SQL
+
+Metric files give the agent SQL it must use *exactly as written* for a given KPI. Three metric types — `atomic`, `derived`, `breakdown` — cover the spectrum from "single number" to "metric split by dimensions". The `objective` field (`maximize` / `minimize` / `maintain`) tells the agent which direction is "good".
+
+```yaml
+metrics:
+  - id: total_gmv
+    label: Total GMV
+    description: Gross merchandise value, in dollars, excluding cancelled orders.
+    type: atomic
+    unit: USD
+    sql: |
+      SELECT SUM(total_cents) / 100.0 AS total_gmv
+      FROM orders
+      WHERE status != 'cancelled'
+    aggregation: sum
+    objective: maximize
+```
+
+When a user asks "what's our GMV this quarter?", the agent finds the `total_gmv` metric, parameterizes the date filter, and runs the SQL exactly as defined. No invention, no drift.
+
+<Callout type="info" title="Why this matters for an agent">
+  Glossary disambiguation and authoritative metric SQL are the two YAML constructs that most directly shape agent correctness. Without them, "show me revenue" silently runs against whichever column the model finds first; "what's our top month?" picks `MAX` or `MIN` based on a coin flip. With them, the agent's behavior is grounded in artifacts your team owns and reviews.
+</Callout>
+
+For the complete metric and glossary schemas, see the [Semantic Layer reference](/getting-started/semantic-layer#metrics).

--- a/apps/docs/content/docs/semantic-layer/glossary-and-metrics.mdx
+++ b/apps/docs/content/docs/semantic-layer/glossary-and-metrics.mdx
@@ -52,7 +52,7 @@ metrics:
     objective: maximize
 ```
 
-When a user asks "what's our GMV this quarter?", the agent finds the `total_gmv` metric, parameterizes the date filter, and runs the SQL exactly as defined. No invention, no drift.
+When a user asks "what's our GMV this quarter?", the agent finds the `total_gmv` metric, runs its `WHERE` clause as defined (`status != 'cancelled'`), and adds the date filter the question requires. The aggregation, columns, and table semantics come from the metric file — the agent doesn't invent them.
 
 <Callout type="info" title="Why this matters for an agent">
   Glossary disambiguation and authoritative metric SQL are the two YAML constructs that most directly shape agent correctness. Without them, "show me revenue" silently runs against whichever column the model finds first; "what's our top month?" picks `MAX` or `MIN` based on a coin flip. With them, the agent's behavior is grounded in artifacts your team owns and reviews.

--- a/apps/docs/content/docs/semantic-layer/index.mdx
+++ b/apps/docs/content/docs/semantic-layer/index.mdx
@@ -1,0 +1,71 @@
+---
+title: The Semantic Layer
+description: The YAML format that powers Atlas — entities, dimensions, measures, joins, glossary, and metrics. Authored by humans, consumed by AI agents.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+import { Cards, Card } from "fumadocs-ui/components/card";
+
+> Atlas is a YAML-defined semantic layer for analytics — authored by humans, consumed by AI agents.
+
+The semantic layer is the **product**. Everything else in Atlas — the agent loop, the MCP server, the chat widget, the SQL validation pipeline — exists to make the YAML you write the source of truth for how questions become answers.
+
+Every field in the Atlas YAML format exists because an LLM needs it to write correct SQL. `sample_values` ground the agent in real data. `glossary.status: ambiguous` forces the agent to ask a clarifying question instead of guessing. `metrics.objective` tells it whether `MAX` or `MIN` is the right answer to "what's our best month?". `query_patterns` teach the canonical join shapes for your domain.
+
+## What's in the YAML?
+
+A 20-line slice of `semantic/entities/orders.yml` from the bundled NovaMart e-commerce demo:
+
+```yaml
+name: Orders
+type: fact_table
+table: orders
+grain: one row per order
+description: |
+  Customer orders — the primary fact table for revenue analysis.
+  shipping_cost uses MIXED UNITS (some rows in dollars, some in cents).
+dimensions:
+  - name: status
+    sql: status
+    type: string
+    sample_values: [pending, processing, shipped, delivered, cancelled]
+  - name: order_month
+    sql: TO_CHAR(created_at, 'YYYY-MM')
+    type: string
+    virtual: true
+measures:
+  - name: total_gmv_cents
+    sql: total_cents
+    type: sum
+joins:
+  - target_entity: Customers
+    relationship: many_to_one
+    join_columns: { from: customer_id, to: id }
+```
+
+That YAML is the contract between your team and the agent. It's version-controlled, code-reviewed, and diffable. Sibling files round it out: `glossary.yml` for term definitions, `metrics/*.yml` for authoritative SQL, and `catalog.yml` for the agent's index across entities.
+
+## The canonical questions
+
+These five questions — drawn from the [NovaMart demo dataset](/getting-started/demo-datasets) — exercise the full surface of the YAML format. They're the same questions the README, the landing page, and the eval harness all reference.
+
+| Question | What in the YAML answers it |
+|---|---|
+| What's our GMV this quarter? | `measures.total_gmv_cents` on `orders.yml`, plus the `GMV` glossary term |
+| What's our top-performing category by GMV this month? | A join chain through `order_items` → `products` → `categories`, plus the `monthly_gmv` query pattern |
+| Monthly GMV trend over the past 6 months. | The `order_month` virtual dimension, plus the `monthly_gmv` query pattern |
+| Show me revenue last quarter. | The agent **asks a clarifying question** — `revenue` is `status: ambiguous` in the glossary (GMV vs. net revenue vs. seller revenue) |
+| What are our most common return reasons? | `LOWER()` normalization called out on the `return_reason` glossary term, applied across the `returns` entity |
+
+## Read next
+
+<Cards>
+  <Card title="YAML Format Reference" href="/getting-started/semantic-layer" description="Full schema for entities, dimensions, measures, joins, virtual dimensions, query patterns, and use cases" />
+  <Card title="Glossary & Metrics" href="/semantic-layer/glossary-and-metrics" description="How glossary terms force clarifying questions and how metrics give the agent authoritative SQL" />
+  <Card title="Why YAML?" href="/semantic-layer/why-yaml" description="Why the semantic layer is files on disk — versioned, diffable, reviewable — instead of a GUI or DB table" />
+  <Card title="MCP Server" href="/guides/mcp" description="Connect Claude Desktop, Cursor, or Continue to your YAML semantic layer with bunx @useatlas/mcp init" />
+</Cards>
+
+<Callout type="info" title="Generating the YAML">
+  Run `bun run atlas -- init` against any PostgreSQL or MySQL database to auto-generate entity files, glossary, metrics, and catalog from the schema. The profiler picks up types, samples real values, infers joins from foreign keys, and flags data-quality issues. See the [CLI reference](/reference/cli#init) for all flags.
+</Callout>

--- a/apps/docs/content/docs/semantic-layer/meta.json
+++ b/apps/docs/content/docs/semantic-layer/meta.json
@@ -1,0 +1,12 @@
+{
+  "title": "The Semantic Layer",
+  "description": "The YAML format that powers Atlas — entities, dimensions, measures, joins, glossary, metrics",
+  "icon": "Layers",
+  "defaultOpen": true,
+  "pages": [
+    "index",
+    "yaml-format",
+    "glossary-and-metrics",
+    "why-yaml"
+  ]
+}

--- a/apps/docs/content/docs/semantic-layer/why-yaml.mdx
+++ b/apps/docs/content/docs/semantic-layer/why-yaml.mdx
@@ -34,7 +34,7 @@ The traditional semantic-layer-as-code pattern was designed for BI tools and SQL
 
 The format converges on the same nouns because the underlying problem is the same: turn a database into a queryable domain model. The difference is who's at the other end of the contract.
 
-For a side-by-side feature matrix that names specific products (LookML, dbt, Cube, Metabase, ThoughtSpot, WrenAI, Vanna), see the [Comparisons](/comparisons) page.
+For side-by-side feature matrices that name specific products (Cube, Metabase, ThoughtSpot, WrenAI, Vanna, raw MCP), see the [Comparisons](/comparisons) page.
 
 <Callout title="What you can do with files on disk that you can't do with a GUI">
 - **Code review the data model.** Every change to `revenue` ships through a PR with reviewers.
@@ -50,4 +50,4 @@ For a side-by-side feature matrix that names specific products (LookML, dbt, Cub
 - [YAML format reference](/getting-started/semantic-layer) — every field, every type
 - [Glossary & Metrics](/semantic-layer/glossary-and-metrics) — the two files that turn a schema into a domain model
 - [MCP Server](/guides/mcp) — how agents consume the YAML through the Model Context Protocol
-- [Comparisons](/comparisons) — feature matrix vs LookML, dbt, Cube, Metabase, ThoughtSpot, WrenAI, Vanna
+- [Comparisons](/comparisons) — feature matrices vs Cube, Metabase, ThoughtSpot, WrenAI, Vanna, raw MCP

--- a/apps/docs/content/docs/semantic-layer/why-yaml.mdx
+++ b/apps/docs/content/docs/semantic-layer/why-yaml.mdx
@@ -1,0 +1,53 @@
+---
+title: Why YAML?
+description: Why the semantic layer is files on disk — versioned, diffable, and reviewable — instead of a GUI or a database table.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+The semantic layer is a directory of YAML files in your repo. Not rows in a metadata database. Not nodes in a GUI tree. Files. On disk. In `semantic/`.
+
+That choice is deliberate.
+
+## Versioned, diffable, reviewable
+
+Your data model evolves the same way the rest of your code does. Someone proposes a change in a pull request. Reviewers see the diff. CI runs `bun run atlas -- validate` to catch broken joins or unknown column references. The change merges, the agent picks it up on the next request, and there's a complete audit trail in `git log`.
+
+You can't get that with a GUI-edited model. You can't get it from a metadata DB without building the diff/review/CI loop yourself.
+
+## Authored by humans, consumed by agents
+
+The YAML is the contract. A human (or an agent assisted by a human) decides what `revenue` means, which terms are ambiguous, what the canonical join shape is for "top products by category". The model doesn't get to decide.
+
+Compare this to schema-only approaches where the agent reads `information_schema` and reasons from raw column names. With Atlas, the agent reads the YAML *first*, before generating SQL. Field names like `total_cents` come with `description: "Order total in cents (subtotal + shipping + tax). Primary revenue field."` and `sample_values: [1299, 2499, 4999]`. Ambiguous terms are flagged. Authoritative metrics override speculation.
+
+## Designed for an LLM consumer, not a BI compiler
+
+The traditional semantic-layer-as-code pattern was designed for BI tools and SQL authors. Atlas takes the same nouns — entities, dimensions, measures, joins, metrics — and shapes every field for an LLM consumer.
+
+| Traditional semantic-layer-as-code | Atlas |
+|---|---|
+| Designed for BI tools and SQL authors | Designed for AI agents (and humans who read YAML) |
+| Fields are types and aggregations | Fields are types, aggregations, **plus** `sample_values`, `glossary.status: ambiguous`, `metrics.objective`, `query_patterns` |
+| Compiled by a server | Read at request time by the agent, exposed over MCP |
+| Output is SQL fragments | Output is a complete answer — interpretation, SQL, validation, results |
+
+The format converges on the same nouns because the underlying problem is the same: turn a database into a queryable domain model. The difference is who's at the other end of the contract.
+
+For a side-by-side feature matrix that names specific products (LookML, dbt, Cube, Metabase, ThoughtSpot, WrenAI, Vanna), see the [Comparisons](/comparisons) page.
+
+<Callout title="What you can do with files on disk that you can't do with a GUI">
+- **Code review the data model.** Every change to `revenue` ships through a PR with reviewers.
+- **CI checks.** `bun run atlas -- validate` catches typos, missing FKs, and orphaned references before they hit production.
+- **Diff schema drift.** `bun run atlas -- diff` compares the live DB to the YAML and tells you what changed.
+- **Roll back.** A bad metric definition is `git revert`, not a frantic GUI edit.
+- **AI-assisted authoring.** The Semantic Editor and `init --enrich` use the same YAML the agent consumes — closing the loop.
+</Callout>
+
+## See also
+
+- [The Semantic Layer overview](/semantic-layer) — the canonical questions and a 20-line YAML excerpt
+- [YAML format reference](/getting-started/semantic-layer) — every field, every type
+- [Glossary & Metrics](/semantic-layer/glossary-and-metrics) — the two files that turn a schema into a domain model
+- [MCP Server](/guides/mcp) — how agents consume the YAML through the Model Context Protocol
+- [Comparisons](/comparisons) — feature matrix vs LookML, dbt, Cube, Metabase, ThoughtSpot, WrenAI, Vanna

--- a/apps/docs/content/docs/semantic-layer/yaml-format.mdx
+++ b/apps/docs/content/docs/semantic-layer/yaml-format.mdx
@@ -1,0 +1,21 @@
+---
+title: YAML Format
+description: Pointer to the full entity-YAML reference — dimensions, measures, joins, virtual dimensions, query patterns.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+The complete YAML format reference — entity types, dimension fields, measure fields, join fields, virtual dimensions, and query patterns — lives on the [Semantic Layer reference page](/getting-started/semantic-layer) under Getting Started.
+
+That page is the canonical reference for authoring the YAML. This top-level **The Semantic Layer** section frames the moat — *why* the YAML format is the product. Once you've read that, the format reference is the day-to-day book you'll keep open while editing files in `semantic/entities/`.
+
+<Callout title="Where each field lives">
+- **Entity-level fields** (`name`, `type`, `table`, `grain`, `description`, `use_cases`, `cross_source_joins`) — top of every entity YAML
+- **`dimensions[]`** — every column the agent is allowed to reference, plus virtual computed columns
+- **`measures[]`** — pre-defined aggregations the agent can pick up by name
+- **`joins[]`** — same-source relationships, with `relationship` cardinality
+- **`query_patterns[]`** — canonical SQL the agent should prefer for common questions
+- **`virtual_dimensions[]`** — separate from `dimensions` with `virtual: true`; useful for grouping logic that lives outside the column list
+</Callout>
+
+See [Semantic Layer reference](/getting-started/semantic-layer) for the full schema and field tables.

--- a/apps/www/src/app/page.tsx
+++ b/apps/www/src/app/page.tsx
@@ -1,9 +1,11 @@
 import { BigStat } from "../components/landing/big-stat";
+import { Comparison } from "../components/landing/comparison";
 import { Deploy } from "../components/landing/deploy";
 import { EndCta } from "../components/landing/end-cta";
 import { Hero } from "../components/landing/hero";
 import { Primitives } from "../components/landing/primitives";
 import { TraceSection } from "../components/landing/trace-section";
+import { YamlSection } from "../components/landing/yaml-section";
 import { Footer } from "../components/footer";
 import { Nav } from "../components/nav";
 import { StickyNav } from "../components/sticky-nav";
@@ -23,9 +25,11 @@ export default function Home() {
 
       <main id="main" tabIndex={-1} className="focus:outline-none">
         <Hero />
+        <YamlSection />
         <BigStat />
         <TraceSection />
         <Primitives />
+        <Comparison />
         <Deploy />
         <EndCta />
       </main>

--- a/apps/www/src/components/landing/comparison.tsx
+++ b/apps/www/src/components/landing/comparison.tsx
@@ -1,0 +1,121 @@
+type Row = {
+  feature: string;
+  atlas: string;
+  bi: string;
+  textToSql: string;
+};
+
+const ROWS: ReadonlyArray<Row> = [
+  {
+    feature: "Semantic layer",
+    atlas:
+      "YAML on disk — query_patterns, virtual_dimensions, glossary.status: ambiguous, metrics.objective are all first-class",
+    bi: "Proprietary metadata, GUI-authored",
+    textToSql: "None or limited",
+  },
+  {
+    feature: "Agent-native",
+    atlas:
+      "MCP server first — Claude Desktop, Cursor, Continue with bunx @useatlas/mcp init",
+    bi: "Bolted-on AI feature",
+    textToSql: "Standalone chat UI",
+  },
+  {
+    feature: "Embeddable",
+    atlas: "Script tag, React component, headless API, MCP, Slack, Teams",
+    bi: "Standalone app",
+    textToSql: "Standalone app",
+  },
+  {
+    feature: "Deploy anywhere",
+    atlas: "Docker, Railway, Vercel, or your own infra",
+    bi: "Vendor-hosted",
+    textToSql: "Vendor-hosted",
+  },
+  {
+    feature: "Plugin ecosystem",
+    atlas: "21 plugins across 5 types",
+    bi: "Closed",
+    textToSql: "Limited",
+  },
+  {
+    feature: "Open source",
+    atlas: "AGPL-3.0 core, MIT client libs",
+    bi: "Proprietary",
+    textToSql: "Varies",
+  },
+];
+
+export function Comparison() {
+  return (
+    <section
+      id="why-atlas"
+      className="scroll-mt-20 border-b border-white/5 px-6 pt-20 pb-16 md:px-16 md:pt-[88px] md:pb-[72px]"
+    >
+      <header className="mb-10 max-w-[720px]">
+        <p className="mb-4 font-mono text-[11.5px] uppercase tracking-[0.16em] text-brand">
+          // why atlas
+        </p>
+        <h2 className="m-0 mb-4 text-[36px] md:text-[46px] font-semibold leading-[1.05] tracking-[-0.03em] text-zinc-50">
+          Three columns. One choice.
+        </h2>
+        <p className="m-0 text-base leading-[1.65] text-zinc-400">
+          The same comparison from the README — same words, same scoring, no claim drift across surfaces.
+        </p>
+      </header>
+
+      <div
+        className="overflow-hidden rounded-xl border border-white/10"
+        style={{ background: "oklch(0.16 0 0)" }}
+      >
+        {/* Mobile-first: stack rows. Desktop: 4-col grid. */}
+        <div className="hidden grid-cols-[200px_1fr_1fr_1fr] border-b border-white/5 md:grid">
+          <div className="px-4 py-3 font-mono text-[11px] uppercase tracking-[0.06em] text-zinc-400">
+            feature
+          </div>
+          <div className="px-4 py-3 font-mono text-[11px] uppercase tracking-[0.06em] text-brand">
+            atlas
+          </div>
+          <div className="px-4 py-3 font-mono text-[11px] uppercase tracking-[0.06em] text-zinc-400">
+            traditional bi
+          </div>
+          <div className="px-4 py-3 font-mono text-[11px] uppercase tracking-[0.06em] text-zinc-400">
+            other text-to-sql
+          </div>
+        </div>
+
+        {ROWS.map((row, i) => (
+          <div
+            key={row.feature}
+            className="grid grid-cols-1 border-b border-white/5 last:border-b-0 md:grid-cols-[200px_1fr_1fr_1fr]"
+            style={{
+              background: i % 2 ? "oklch(0.14 0 0)" : "transparent",
+            }}
+          >
+            <div className="px-4 py-3 font-mono text-[12.5px] font-medium text-zinc-50">
+              {row.feature}
+            </div>
+            <div className="px-4 py-3 text-[13px] leading-[1.55] text-zinc-200">
+              <span className="md:hidden font-mono text-[10.5px] uppercase tracking-[0.06em] text-brand">
+                Atlas:{" "}
+              </span>
+              {row.atlas}
+            </div>
+            <div className="px-4 py-3 text-[13px] leading-[1.55] text-zinc-400">
+              <span className="md:hidden font-mono text-[10.5px] uppercase tracking-[0.06em] text-zinc-500">
+                Traditional BI:{" "}
+              </span>
+              {row.bi}
+            </div>
+            <div className="px-4 py-3 text-[13px] leading-[1.55] text-zinc-400">
+              <span className="md:hidden font-mono text-[10.5px] uppercase tracking-[0.06em] text-zinc-500">
+                Other text-to-SQL:{" "}
+              </span>
+              {row.textToSql}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/www/src/components/landing/comparison.tsx
+++ b/apps/www/src/components/landing/comparison.tsx
@@ -34,7 +34,7 @@ const ROWS: ReadonlyArray<Row> = [
   },
   {
     feature: "Plugin ecosystem",
-    atlas: "21 plugins across 5 types",
+    atlas: "21 plugins across 5 types — extend anything",
     bi: "Closed",
     textToSql: "Limited",
   },
@@ -43,6 +43,13 @@ const ROWS: ReadonlyArray<Row> = [
     atlas: "AGPL-3.0 core, MIT client libs",
     bi: "Proprietary",
     textToSql: "Varies",
+  },
+  {
+    feature: "Multi-database",
+    atlas:
+      "PostgreSQL, MySQL, ClickHouse, Snowflake, DuckDB, BigQuery, Salesforce",
+    bi: "Usually one",
+    textToSql: "Usually one",
   },
 ];
 

--- a/apps/www/src/components/landing/comparison.tsx
+++ b/apps/www/src/components/landing/comparison.tsx
@@ -1,9 +1,12 @@
-type Row = {
-  feature: string;
-  atlas: string;
-  bi: string;
-  textToSql: string;
-};
+const COLUMNS = [
+  { id: "atlas", label: "atlas", mobileLabel: "Atlas", tone: "brand" },
+  { id: "bi", label: "traditional bi", mobileLabel: "Traditional BI", tone: "muted" },
+  { id: "textToSql", label: "other text-to-sql", mobileLabel: "Other text-to-SQL", tone: "muted" },
+] as const;
+
+type ColumnId = (typeof COLUMNS)[number]["id"];
+
+type Row = { readonly feature: string } & Readonly<Record<ColumnId, string>>;
 
 const ROWS: ReadonlyArray<Row> = [
   {
@@ -80,15 +83,16 @@ export function Comparison() {
           <div className="px-4 py-3 font-mono text-[11px] uppercase tracking-[0.06em] text-zinc-400">
             feature
           </div>
-          <div className="px-4 py-3 font-mono text-[11px] uppercase tracking-[0.06em] text-brand">
-            atlas
-          </div>
-          <div className="px-4 py-3 font-mono text-[11px] uppercase tracking-[0.06em] text-zinc-400">
-            traditional bi
-          </div>
-          <div className="px-4 py-3 font-mono text-[11px] uppercase tracking-[0.06em] text-zinc-400">
-            other text-to-sql
-          </div>
+          {COLUMNS.map((col) => (
+            <div
+              key={col.id}
+              className={`px-4 py-3 font-mono text-[11px] uppercase tracking-[0.06em] ${
+                col.tone === "brand" ? "text-brand" : "text-zinc-400"
+              }`}
+            >
+              {col.label}
+            </div>
+          ))}
         </div>
 
         {ROWS.map((row, i) => (
@@ -102,24 +106,23 @@ export function Comparison() {
             <div className="px-4 py-3 font-mono text-[12.5px] font-medium text-zinc-50">
               {row.feature}
             </div>
-            <div className="px-4 py-3 text-[13px] leading-[1.55] text-zinc-200">
-              <span className="md:hidden font-mono text-[10.5px] uppercase tracking-[0.06em] text-brand">
-                Atlas:{" "}
-              </span>
-              {row.atlas}
-            </div>
-            <div className="px-4 py-3 text-[13px] leading-[1.55] text-zinc-400">
-              <span className="md:hidden font-mono text-[10.5px] uppercase tracking-[0.06em] text-zinc-500">
-                Traditional BI:{" "}
-              </span>
-              {row.bi}
-            </div>
-            <div className="px-4 py-3 text-[13px] leading-[1.55] text-zinc-400">
-              <span className="md:hidden font-mono text-[10.5px] uppercase tracking-[0.06em] text-zinc-500">
-                Other text-to-SQL:{" "}
-              </span>
-              {row.textToSql}
-            </div>
+            {COLUMNS.map((col) => (
+              <div
+                key={col.id}
+                className={`px-4 py-3 text-[13px] leading-[1.55] ${
+                  col.tone === "brand" ? "text-zinc-200" : "text-zinc-400"
+                }`}
+              >
+                <span
+                  className={`md:hidden font-mono text-[10.5px] uppercase tracking-[0.06em] ${
+                    col.tone === "brand" ? "text-brand" : "text-zinc-500"
+                  }`}
+                >
+                  {col.mobileLabel}:{" "}
+                </span>
+                {row[col.id]}
+              </div>
+            ))}
           </div>
         ))}
       </div>

--- a/apps/www/src/components/landing/data.ts
+++ b/apps/www/src/components/landing/data.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared sample data used across landing-page components.
+ *
+ * Hoisted here so the YAML section, the Trace component, and any future
+ * surface that quotes the same NovaMart "top categories by GMV" answer all
+ * read from a single source — no copy/paste drift between the result table
+ * in {@link ./yaml-section.tsx} and the result strip in {@link ./trace.tsx}.
+ */
+export type CategoryRow = {
+  readonly category: string;
+  readonly gmv: string;
+  readonly orders: string;
+};
+
+export const CATEGORY_ROWS: ReadonlyArray<CategoryRow> = [
+  { category: "Bedding",     gmv: "$184,219", orders: "2,041" },
+  { category: "Kitchen",     gmv: "$142,718", orders: "1,587" },
+  { category: "Bath",        gmv: "$98,402",  orders: "1,103" },
+  { category: "Outdoor",     gmv: "$71,288",  orders: "812"   },
+  { category: "Accessories", gmv: "$54,011",  orders: "693"   },
+];

--- a/apps/www/src/components/landing/end-cta.tsx
+++ b/apps/www/src/components/landing/end-cta.tsx
@@ -14,27 +14,27 @@ export function EndCta() {
           // ship it
         </p>
         <h2 className="m-0 mb-8 text-[40px] md:text-[56px] font-semibold leading-[1.05] tracking-[-0.035em] text-zinc-50">
-          <span className="block">Stop reviewing AI-written SQL.</span>
+          <span className="block">YAML in.</span>
           <em className="block font-semibold text-brand">
-            Start running it.
+            Validated answers out.
           </em>
         </h2>
         <div className="flex flex-wrap justify-center gap-2.5">
           <a
-            href="https://app.useatlas.dev"
+            href="https://docs.useatlas.dev/guides/mcp"
             className="inline-flex items-center rounded-lg bg-brand px-[18px] py-[11px] text-[13.5px] font-semibold text-zinc-950 transition-colors hover:bg-brand-hover"
           >
-            Start 14-day trial →
+            Install the MCP server →
           </a>
           <a
             href="https://app.useatlas.dev/demo"
             className="inline-flex items-center rounded-lg border border-white/10 bg-zinc-900 px-3.5 py-2.5 text-[13.5px] text-zinc-50 transition-colors hover:border-white/20"
           >
-            book 15-min demo
+            try the NovaMart demo
           </a>
         </div>
         <p className="mt-3.5 font-mono text-[11px] tracking-[0.04em] text-zinc-400">
-          14-day trial · no card · cancel any time
+          works in claude desktop, cursor, continue · self-host is free
         </p>
       </div>
     </section>

--- a/apps/www/src/components/landing/hero.tsx
+++ b/apps/www/src/components/landing/hero.tsx
@@ -4,7 +4,7 @@ const HEADLINE_LINES = ["A semantic layer", "for analytics,", "agent-native."] a
 const ITALIC_LINE_INDEX = 2;
 
 const SUBHEAD =
-  "Atlas is a YAML-defined semantic layer for analytics — authored by humans, consumed by AI agents. Entities, glossary, and metrics live in your repo; the agent reads them, writes deterministic SQL, and runs it through 7 validators before it ever touches your warehouse.";
+  "Atlas is a YAML-defined semantic layer for analytics — authored by humans, consumed by AI agents. Entities, glossary, and metrics live in your repo; the agent reads them, writes deterministic SQL, and runs it through a 7-stage validation pipeline — read-only, table-whitelisted, statement-timed.";
 
 type NodeKind =
   | "input"

--- a/apps/www/src/components/landing/hero.tsx
+++ b/apps/www/src/components/landing/hero.tsx
@@ -17,16 +17,16 @@ type NodeKind =
   | "widget";
 
 type SchemaNode = {
-  id: string;
-  x: number;
-  y: number;
-  w: number;
-  label: string;
-  value: string;
-  kind: NodeKind;
+  readonly id: string;
+  readonly x: number;
+  readonly y: number;
+  readonly w: number;
+  readonly label: string;
+  readonly value: string;
+  readonly kind: NodeKind;
 };
 
-const NODES: SchemaNode[] = [
+const NODES = [
   { id: "prompt",     x: 600,  y: 560, w: 220, label: "prompt",                value: '"top categories by gmv…"',   kind: "input"   },
   { id: "semantic",   x: 620,  y: 100, w: 240, label: "semantic_layer.yaml",   value: "entities · metrics · glossary", kind: "yaml"  },
   { id: "compiler",   x: 640,  y: 320, w: 200, label: "compiler",              value: "AST → SQL",                    kind: "process" },
@@ -35,15 +35,17 @@ const NODES: SchemaNode[] = [
   { id: "result",     x: 1190, y: 460, w: 220, label: "result",                value: "rows · read-only",             kind: "result"  },
   { id: "audit",      x: 900,  y: 560, w: 240, label: "audit_log",             value: "every query · every op",       kind: "audit"   },
   { id: "widget",     x: 640,  y: 460, w: 200, label: "<AtlasChat />",         value: "react widget",                 kind: "widget"  },
-];
+] as const satisfies ReadonlyArray<SchemaNode>;
 
-const NODE_BY_ID: Record<string, SchemaNode> = Object.fromEntries(
+type NodeId = (typeof NODES)[number]["id"];
+
+const NODE_BY_ID: Record<NodeId, SchemaNode> = Object.fromEntries(
   NODES.map((n) => [n.id, n]),
-);
+) as Record<NodeId, SchemaNode>;
 
-type Edge = { from: string; to: string; label: string };
+type Edge = { readonly from: NodeId; readonly to: NodeId; readonly label: string };
 
-const EDGES: Edge[] = [
+const EDGES: ReadonlyArray<Edge> = [
   { from: "prompt",     to: "compiler",   label: "01"  },
   { from: "semantic",   to: "compiler",   label: "02"  },
   { from: "compiler",   to: "validators", label: "03"  },
@@ -54,8 +56,8 @@ const EDGES: Edge[] = [
   { from: "result",     to: "audit",      label: "log" },
 ];
 
-const EDGE_DELAY_MS = [0, 300, 600, 900, 1200, 1500, 1800, 2100];
-const NODE_DELAY_MS: Record<string, number> = {
+const EDGE_DELAY_MS: ReadonlyArray<number> = [0, 300, 600, 900, 1200, 1500, 1800, 2100];
+const NODE_DELAY_MS: Record<NodeId, number> = {
   prompt: 0,
   semantic: 0,
   compiler: 300,
@@ -117,8 +119,8 @@ function SchemaMap() {
       <ellipse cx="980" cy="380" rx="420" ry="300" fill="url(#hero-halo)" />
 
       {EDGES.map((e, i) => {
-        const a = NODE_BY_ID[e.from]!;
-        const b = NODE_BY_ID[e.to]!;
+        const a = NODE_BY_ID[e.from];
+        const b = NODE_BY_ID[e.to];
         const ax = a.x + a.w / 2;
         const ay = a.y + 32;
         const bx = b.x + b.w / 2;

--- a/apps/www/src/components/landing/hero.tsx
+++ b/apps/www/src/components/landing/hero.tsx
@@ -1,10 +1,10 @@
 import { type CSSProperties } from "react";
 
-const HEADLINE_LINES = ["Text-to-SQL,", "that actually", "ships."] as const;
-const ITALIC_LINE_INDEX = 1;
+const HEADLINE_LINES = ["A semantic layer", "for analytics,", "agent-native."] as const;
+const ITALIC_LINE_INDEX = 2;
 
 const SUBHEAD =
-  "Your data has structure — schemas, joins, metrics, glossaries. Atlas reads them, writes deterministic SQL, and runs it through 7 validators before it ever touches your warehouse.";
+  "Atlas is a YAML-defined semantic layer for analytics — authored by humans, consumed by AI agents. Entities, glossary, and metrics live in your repo; the agent reads them, writes deterministic SQL, and runs it through 7 validators before it ever touches your warehouse.";
 
 type NodeKind =
   | "input"
@@ -27,7 +27,7 @@ type SchemaNode = {
 };
 
 const NODES: SchemaNode[] = [
-  { id: "prompt",     x: 600,  y: 560, w: 220, label: "prompt",                value: '"top 5 accounts by arr…"',   kind: "input"   },
+  { id: "prompt",     x: 600,  y: 560, w: 220, label: "prompt",                value: '"top categories by gmv…"',   kind: "input"   },
   { id: "semantic",   x: 620,  y: 100, w: 240, label: "semantic_layer.yaml",   value: "entities · metrics · glossary", kind: "yaml"  },
   { id: "compiler",   x: 640,  y: 320, w: 200, label: "compiler",              value: "AST → SQL",                    kind: "process" },
   { id: "validators", x: 900,  y: 320, w: 240, label: "7 validators",          value: "ast · perms · row_limit · …",  kind: "gate"    },
@@ -262,22 +262,22 @@ export function Hero() {
         </p>
         <div className="mt-7 flex flex-wrap gap-2.5">
           <a
-            href="https://app.useatlas.dev"
+            href="https://docs.useatlas.dev/guides/mcp"
             className="inline-flex items-center gap-2 rounded-lg bg-brand px-[18px] py-[11px] text-[13.5px] font-semibold text-zinc-950 transition-colors hover:bg-brand-hover"
           >
-            Start 14-day trial →
+            Install the MCP server →
           </a>
           <a
-            href="https://docs.useatlas.dev/getting-started"
+            href="https://docs.useatlas.dev/guides/mcp"
             className="inline-flex items-center rounded-lg border border-white/10 bg-zinc-900 px-3.5 py-2.5 text-zinc-50 transition-colors hover:border-white/20"
           >
             <code className="font-mono text-[12.5px]">
-              $ bun create atlas-agent
+              $ bunx @useatlas/mcp init
             </code>
           </a>
         </div>
         <p className="mt-3.5 font-mono text-[11px] tracking-[0.04em] text-zinc-400">
-          no card · self-host is free, every feature
+          works in claude desktop, cursor, continue · self-host is free
         </p>
       </div>
 

--- a/apps/www/src/components/landing/primitives.tsx
+++ b/apps/www/src/components/landing/primitives.tsx
@@ -89,8 +89,8 @@ export function Primitives() {
           kind="entity"
           name="semantic_layer"
           title="Semantic layer"
-          blurb="Entities, metrics, glossary in YAML. Versioned beside your code. Atlas reads them on every prompt."
-          ports={["accounts", "metrics", "glossary"]}
+          blurb="Entities, glossary, metrics in YAML. Versioned beside your code. Atlas reads them on every prompt."
+          ports={["entities", "glossary", "metrics"]}
         />
         <PrimitiveCard
           kind="gate"

--- a/apps/www/src/components/landing/trace.tsx
+++ b/apps/www/src/components/landing/trace.tsx
@@ -16,19 +16,19 @@ type TraceStep = {
 };
 
 const TRACE_STEPS: TraceStep[] = [
-  { t: 0.0, k: "prompt", v: "Top 5 accounts by ARR this quarter, with QoQ growth.", kind: "input" },
+  { t: 0.0, k: "prompt", v: "Top-performing category by GMV this month.", kind: "input" },
   {
     t: 0.041,
     k: "resolve",
-    v: "accounts, arr, quarter, qoq_growth",
+    v: "orders, order_items, products, categories, gmv",
     kind: "info",
     detail:
-      "Maps prompt terms → entities + metrics defined in semantic_layer.yaml. No invented columns.",
+      "Maps prompt terms → entities + metrics defined in the YAML semantic layer. No invented columns.",
   },
   {
     t: 0.124,
     k: "compile",
-    v: "78 lines · 1 join · 5 columns",
+    v: "78 lines · 3 joins · 3 columns",
     kind: "info",
     detail:
       "AST → SQL. Atlas writes deterministic SQL from the entity graph; no LLM-generated joins.",
@@ -54,7 +54,7 @@ const TRACE_STEPS: TraceStep[] = [
   {
     t: 0.168,
     k: "permissions",
-    v: "ok · select on accounts, snapshots",
+    v: "ok · select on orders, order_items, products, categories",
     kind: "gate",
     n: 3,
     detail:
@@ -76,12 +76,12 @@ const TRACE_STEPS: TraceStep[] = [
     kind: "gate",
     n: 5,
     detail:
-      "Joins must use keys declared in semantic_layer.yaml. No cartesian products, no fuzzy joins, no surprises.",
+      "Joins must use keys declared in the YAML semantic layer. No cartesian products, no fuzzy joins, no surprises.",
   },
   {
     t: 0.217,
     k: "metric_whitelist",
-    v: "ok · arr, qoq_growth",
+    v: "ok · total_gmv",
     kind: "gate",
     n: 6,
     detail:
@@ -116,27 +116,49 @@ const SQL_TOKENS: SqlToken[] = [
   { k: "cm", v: "-- session.4f8e · 7 validations passed\n" },
   { k: "cm", v: "-- read-only · scoped to analytics.public\n\n" },
   { k: "kw", v: "SELECT" },
-  { k: "t", v: " a.name,\n       a.arr,\n       " },
-  { k: "fn", v: "ROUND" },
-  { k: "t", v: "(\n         (a.arr - p.arr) / p.arr * " },
-  { k: "num", v: "100" },
-  { k: "t", v: ",\n         " },
-  { k: "num", v: "1" },
-  { k: "t", v: "\n       ) " },
+  { k: "t", v: " c.name,\n       " },
+  { k: "fn", v: "SUM" },
+  { k: "t", v: "(o.total_cents) / " },
+  { k: "num", v: "100.0" },
+  { k: "t", v: " " },
   { k: "kw", v: "AS" },
-  { k: "t", v: " qoq_pct\n  " },
+  { k: "t", v: " gmv,\n       " },
+  { k: "fn", v: "COUNT" },
+  { k: "t", v: "(" },
+  { k: "kw", v: "DISTINCT" },
+  { k: "t", v: " o.id) " },
+  { k: "kw", v: "AS" },
+  { k: "t", v: " orders\n  " },
   { k: "kw", v: "FROM" },
-  { k: "t", v: " accounts a\n  " },
+  { k: "t", v: " orders o\n  " },
   { k: "kw", v: "JOIN" },
-  { k: "t", v: " account_snapshots p\n    " },
+  { k: "t", v: " order_items oi " },
   { k: "kw", v: "ON" },
-  { k: "t", v: " p.account_id = a.id\n   " },
+  { k: "t", v: " oi.order_id = o.id\n  " },
+  { k: "kw", v: "JOIN" },
+  { k: "t", v: " products p " },
+  { k: "kw", v: "ON" },
+  { k: "t", v: " p.id = oi.product_id\n  " },
+  { k: "kw", v: "JOIN" },
+  { k: "t", v: " categories c " },
+  { k: "kw", v: "ON" },
+  { k: "t", v: " c.id = p.category_id\n " },
+  { k: "kw", v: "WHERE" },
+  { k: "t", v: " o.status != " },
+  { k: "str", v: "'cancelled'" },
+  { k: "t", v: "\n   " },
   { k: "kw", v: "AND" },
-  { k: "t", v: " p.quarter = " },
-  { k: "str", v: "'2026-Q1'" },
-  { k: "t", v: "\n " },
+  { k: "t", v: " o.created_at >= " },
+  { k: "fn", v: "DATE_TRUNC" },
+  { k: "t", v: "(" },
+  { k: "str", v: "'month'" },
+  { k: "t", v: ", " },
+  { k: "fn", v: "NOW" },
+  { k: "t", v: "())\n " },
+  { k: "kw", v: "GROUP BY" },
+  { k: "t", v: " c.name\n " },
   { k: "kw", v: "ORDER BY" },
-  { k: "t", v: " a.arr " },
+  { k: "t", v: " gmv " },
   { k: "kw", v: "DESC LIMIT" },
   { k: "t", v: " " },
   { k: "num", v: "5" },
@@ -146,11 +168,11 @@ const SQL_TOKENS: SqlToken[] = [
 const SQL_TOTAL = SQL_TOKENS.reduce((sum, tok) => sum + tok.v.length, 0);
 
 const RESULT_ROWS: ReadonlyArray<readonly [string, string, string]> = [
-  ["Northwind Trading",  "$2.40M", "+18.4%"],
-  ["Gemini Robotics",    "$1.92M", "+9.1%"],
-  ["Helios Aerospace",   "$1.71M", "+5.8%"],
-  ["Kite & Key Capital", "$1.55M", "+22.7%"],
-  ["Orca Logistics",     "$1.41M", "−2.3%"],
+  ["Bedding",     "$184,219", "2,041"],
+  ["Kitchen",     "$142,718", "1,587"],
+  ["Bath",        "$98,402",  "1,103"],
+  ["Outdoor",     "$71,288",  "812"],
+  ["Accessories", "$54,011",  "693"],
 ];
 
 const SQL_KIND_STYLE: Record<SqlTokenKind, CSSProperties> = {
@@ -403,16 +425,16 @@ export function Trace() {
               className="grid border-b border-white/5 py-2 font-mono text-[10px] tracking-[0.1em] uppercase text-zinc-400"
               style={{ gridTemplateColumns: "2fr 1fr 1fr" }}
             >
-              <span>account</span>
-              <span>arr</span>
-              <span>qoq</span>
+              <span>category</span>
+              <span>gmv</span>
+              <span>orders</span>
             </div>
             {resultsVisible === 0 ? (
               <div className="px-0 py-4 font-mono text-[11px] text-zinc-400">
                 {idx >= LAST_INDEX - 1 ? "// executing…" : "// awaiting validation"}
               </div>
             ) : (
-              RESULT_ROWS.slice(0, resultsVisible).map(([name, arr, qoq]) => (
+              RESULT_ROWS.slice(0, resultsVisible).map(([name, gmv, orders]) => (
                 <div
                   key={name}
                   className="grid py-2 font-mono text-[12px] text-zinc-200"
@@ -422,10 +444,8 @@ export function Trace() {
                   }}
                 >
                   <span>{name}</span>
-                  <span className="text-zinc-50">{arr}</span>
-                  <span style={{ color: qoq.startsWith("−") ? "oklch(0.7 0.16 22)" : "var(--atlas-brand)" }}>
-                    {qoq}
-                  </span>
+                  <span className="text-brand">{gmv}</span>
+                  <span className="text-zinc-400">{orders}</span>
                 </div>
               ))
             )}

--- a/apps/www/src/components/landing/trace.tsx
+++ b/apps/www/src/components/landing/trace.tsx
@@ -28,7 +28,7 @@ const TRACE_STEPS: TraceStep[] = [
   {
     t: 0.124,
     k: "compile",
-    v: "78 lines · 3 joins · 3 columns",
+    v: "14 lines · 3 joins · 3 columns",
     kind: "info",
     detail:
       "AST → SQL. Atlas writes deterministic SQL from the entity graph; no LLM-generated joins.",
@@ -138,7 +138,7 @@ const SQL_TOKENS: SqlToken[] = [
   { k: "kw", v: "JOIN" },
   { k: "t", v: " products p " },
   { k: "kw", v: "ON" },
-  { k: "t", v: " p.id = oi.product_id\n  " },
+  { k: "t", v: " p.name = oi.product_name\n  " },
   { k: "kw", v: "JOIN" },
   { k: "t", v: " categories c " },
   { k: "kw", v: "ON" },

--- a/apps/www/src/components/landing/trace.tsx
+++ b/apps/www/src/components/landing/trace.tsx
@@ -2,20 +2,32 @@
 
 import { type CSSProperties, useEffect, useRef, useState } from "react";
 
+import { CATEGORY_ROWS } from "./data";
+
 type TraceKind = "input" | "info" | "gate" | "result";
 
-type TraceStep = {
-  t: number;
-  k: string;
-  v: string;
-  kind: TraceKind;
-  /** Gate index (1..7). Only set when `kind === "gate"`. */
-  n?: number;
+type GateIndex = 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+type BaseStep = {
+  readonly t: number;
+  readonly k: string;
+  readonly v: string;
   /** Long-form copy shown in the viewer's detail strip when this step is active. */
-  detail?: string;
+  readonly detail?: string;
 };
 
-const TRACE_STEPS: TraceStep[] = [
+type GateStep = BaseStep & {
+  readonly kind: "gate";
+  readonly n: GateIndex;
+};
+
+type OtherStep = BaseStep & {
+  readonly kind: Exclude<TraceKind, "gate">;
+};
+
+type TraceStep = GateStep | OtherStep;
+
+const TRACE_STEPS: ReadonlyArray<TraceStep> = [
   { t: 0.0, k: "prompt", v: "Top-performing category by GMV this month.", kind: "input" },
   {
     t: 0.041,
@@ -167,14 +179,6 @@ const SQL_TOKENS: SqlToken[] = [
 
 const SQL_TOTAL = SQL_TOKENS.reduce((sum, tok) => sum + tok.v.length, 0);
 
-const RESULT_ROWS: ReadonlyArray<readonly [string, string, string]> = [
-  ["Bedding",     "$184,219", "2,041"],
-  ["Kitchen",     "$142,718", "1,587"],
-  ["Bath",        "$98,402",  "1,103"],
-  ["Outdoor",     "$71,288",  "812"],
-  ["Accessories", "$54,011",  "693"],
-];
-
 const SQL_KIND_STYLE: Record<SqlTokenKind, CSSProperties> = {
   cm:  { color: "oklch(0.65 0 0)" },
   kw:  { color: "var(--atlas-brand)" },
@@ -272,7 +276,7 @@ export function Trace() {
     used += slice.length;
   }
 
-  const resultsVisible = idx >= LAST_INDEX ? RESULT_ROWS.length : 0;
+  const resultsVisible = idx >= LAST_INDEX ? CATEGORY_ROWS.length : 0;
   const gatesPassed = Math.min(7, Math.max(0, idx - 2));
   const isDone = idx >= LAST_INDEX;
 
@@ -354,7 +358,7 @@ export function Trace() {
                         : "oklch(0.65 0 0)",
                   }}
                 >
-                  {step.kind === "gate" && step.n != null && (
+                  {step.kind === "gate" && (
                     <span
                       className="inline-flex h-3.5 w-3.5 items-center justify-center rounded-sm text-[9px] font-semibold text-brand"
                       style={{
@@ -386,7 +390,7 @@ export function Trace() {
             <span className="tracking-[0.06em] text-zinc-400">result</span>
             <span className="tracking-[0.06em] text-zinc-400">raw</span>
             <span className="ml-auto text-[10.5px] tracking-[0.06em] text-brand">
-              {cur.kind === "gate" && cur.n != null ? `gate ${cur.n} of 7` : cur.kind}
+              {cur.kind === "gate" ? `gate ${cur.n} of 7` : cur.kind}
             </span>
           </div>
 
@@ -430,16 +434,16 @@ export function Trace() {
                 {idx >= LAST_INDEX - 1 ? "// executing…" : "// awaiting validation"}
               </div>
             ) : (
-              RESULT_ROWS.slice(0, resultsVisible).map(([name, gmv, orders]) => (
+              CATEGORY_ROWS.slice(0, resultsVisible).map(({ category, gmv, orders }) => (
                 <div
-                  key={name}
+                  key={category}
                   className="grid py-2 font-mono text-[12px] text-zinc-200"
                   style={{
                     gridTemplateColumns: "2fr 1fr 1fr",
                     borderBottom: "1px solid oklch(1 0 0 / 0.04)",
                   }}
                 >
-                  <span>{name}</span>
+                  <span>{category}</span>
                   <span className="text-brand">{gmv}</span>
                   <span className="text-zinc-400">{orders}</span>
                 </div>

--- a/apps/www/src/components/landing/trace.tsx
+++ b/apps/www/src/components/landing/trace.tsx
@@ -205,7 +205,6 @@ export function Trace() {
   const [playing, setPlaying] = useState(false);
   const [hasAutoPlayed, setHasAutoPlayed] = useState(false);
   const rootRef = useRef<HTMLDivElement | null>(null);
-  const playTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Auto-play when scrolled into view, but only once and only if the user
   // hasn't asked us to stop moving things.
@@ -244,10 +243,7 @@ export function Trace() {
     const cur = TRACE_STEPS[idx]!.t;
     const nxt = TRACE_STEPS[idx + 1]!.t;
     const dwell = Math.max(120, Math.min(900, (nxt - cur) * 800));
-    // Capture the local id so cleanup clears *this* run's timer, not whichever
-    // one happens to be in `playTimer.current` when cleanup runs.
     const id = setTimeout(() => setIdx((i) => i + 1), dwell);
-    playTimer.current = id;
     return () => clearTimeout(id);
   }, [playing, idx]);
 

--- a/apps/www/src/components/landing/yaml-section.tsx
+++ b/apps/www/src/components/landing/yaml-section.tsx
@@ -81,7 +81,10 @@ function YamlPane() {
           semantic/entities/orders.yml
         </span>
       </div>
-      <pre className="m-0 overflow-auto p-4 font-mono text-[12px] leading-[1.7] text-zinc-300">
+      <pre
+        className="m-0 overflow-auto p-4 font-mono text-[12px] leading-[1.7] text-zinc-300"
+        aria-label="YAML excerpt from semantic/entities/orders.yml"
+      >
         {YAML_LINES.map((line, i) => (
           <span key={i} className="block">
             {tokenize(line.raw).map((tok, j) => (
@@ -140,6 +143,7 @@ function AnswerPane() {
           <pre
             className="m-0 overflow-auto rounded-md border border-white/10 px-3 py-2 font-mono text-[11.5px] leading-[1.6] text-zinc-300"
             style={{ background: "oklch(0.10 0 0)" }}
+            aria-label="Generated SQL for: top-performing category by GMV this month"
           >
             <span className="text-purple-300/90">SELECT</span> c.name,{"\n"}       <span className="text-purple-300/90">SUM</span>(o.total_cents) /{" "}
             <span className="text-amber-200/80">100.0</span> <span className="text-purple-300/90">AS</span> gmv,{"\n"}       <span className="text-purple-300/90">COUNT</span>(<span className="text-purple-300/90">DISTINCT</span> o.id){" "}
@@ -148,7 +152,7 @@ function AnswerPane() {
             <span className="text-purple-300/90">JOIN</span> order_items oi{" "}
             <span className="text-purple-300/90">ON</span> oi.order_id = o.id{"\n"}
             <span className="text-purple-300/90">JOIN</span> products p{" "}
-            <span className="text-purple-300/90">ON</span> p.id = oi.product_id{"\n"}
+            <span className="text-purple-300/90">ON</span> p.name = oi.product_name{"\n"}
             <span className="text-purple-300/90">JOIN</span> categories c{" "}
             <span className="text-purple-300/90">ON</span> c.id = p.category_id{"\n"}
             <span className="text-purple-300/90">WHERE</span> o.status !={" "}

--- a/apps/www/src/components/landing/yaml-section.tsx
+++ b/apps/www/src/components/landing/yaml-section.tsx
@@ -1,58 +1,53 @@
-import { type CSSProperties } from "react";
-
-const YAML_LINES: ReadonlyArray<{ raw: string }> = [
-  { raw: "name: Orders" },
-  { raw: "type: fact_table" },
-  { raw: "table: orders" },
-  { raw: "grain: one row per order" },
-  { raw: "" },
-  { raw: "dimensions:" },
-  { raw: "  - name: status" },
-  { raw: "    sql: status" },
-  { raw: "    type: string" },
-  { raw: "    sample_values: [pending, shipped, delivered, cancelled]" },
-  { raw: "" },
-  { raw: "  - name: order_month" },
-  { raw: "    sql: TO_CHAR(created_at, 'YYYY-MM')" },
-  { raw: "    type: string" },
-  { raw: "    virtual: true" },
-  { raw: "" },
-  { raw: "measures:" },
-  { raw: "  - name: total_gmv_cents" },
-  { raw: "    sql: total_cents" },
-  { raw: "    type: sum" },
-  { raw: "" },
-  { raw: "joins:" },
-  { raw: "  - target_entity: Customers" },
-  { raw: "    relationship: many_to_one" },
-  { raw: "    join_columns: { from: customer_id, to: id }" },
+const YAML_LINES: ReadonlyArray<string> = [
+  "name: Orders",
+  "type: fact_table",
+  "table: orders",
+  "grain: one row per order",
+  "",
+  "dimensions:",
+  "  - name: status",
+  "    sql: status",
+  "    type: string",
+  "    sample_values: [pending, shipped, delivered, cancelled]",
+  "",
+  "  - name: order_month",
+  "    sql: TO_CHAR(created_at, 'YYYY-MM')",
+  "    type: string",
+  "    virtual: true",
+  "",
+  "measures:",
+  "  - name: total_gmv_cents",
+  "    sql: total_cents",
+  "    type: sum",
+  "",
+  "joins:",
+  "  - target_entity: Customers",
+  "    relationship: many_to_one",
+  "    join_columns: { from: customer_id, to: id }",
 ];
 
 type Token = { text: string; cls?: string };
 
+function valueClass(rest: string): string {
+  if (/^\[.*\]$/.test(rest) || /^\{.*\}$/.test(rest)) return "text-amber-300/90";
+  if (rest === "true" || rest === "false") return "text-purple-300/90";
+  return "text-amber-200/80";
+}
+
 function tokenize(line: string): Token[] {
-  if (line.trim().startsWith("- ") || line.trim().startsWith("name:") || line.includes(":")) {
-    const match = line.match(/^(\s*)(-?\s*)?([\w\-_]+)(:\s*)(.*)$/);
-    if (match) {
-      const [, indent, dash, key, colon, rest] = match;
-      const tokens: Token[] = [];
-      if (indent) tokens.push({ text: indent });
-      if (dash) tokens.push({ text: dash, cls: "text-brand" });
-      tokens.push({ text: key ?? "", cls: "text-zinc-50 font-medium" });
-      tokens.push({ text: colon ?? "" });
-      if (rest) {
-        if (/^\[.*\]$/.test(rest) || /^\{.*\}$/.test(rest)) {
-          tokens.push({ text: rest, cls: "text-amber-300/90" });
-        } else if (rest === "true" || rest === "false") {
-          tokens.push({ text: rest, cls: "text-purple-300/90" });
-        } else {
-          tokens.push({ text: rest, cls: "text-amber-200/80" });
-        }
-      }
-      return tokens;
-    }
-  }
-  return [{ text: line }];
+  if (!line.includes(":")) return [{ text: line }];
+
+  const match = line.match(/^(\s*)(-?\s*)?([\w\-_]+)(:\s*)(.*)$/);
+  if (!match) return [{ text: line }];
+
+  const [, indent, dash, key, colon, rest] = match;
+  const tokens: Token[] = [];
+  if (indent) tokens.push({ text: indent });
+  if (dash) tokens.push({ text: dash, cls: "text-brand" });
+  tokens.push({ text: key, cls: "text-zinc-50 font-medium" });
+  tokens.push({ text: colon });
+  if (rest) tokens.push({ text: rest, cls: valueClass(rest) });
+  return tokens;
 }
 
 function YamlPane() {
@@ -87,7 +82,7 @@ function YamlPane() {
       >
         {YAML_LINES.map((line, i) => (
           <span key={i} className="block">
-            {tokenize(line.raw).map((tok, j) => (
+            {tokenize(line).map((tok, j) => (
               <span key={j} className={tok.cls}>
                 {tok.text || " "}
               </span>
@@ -211,12 +206,11 @@ const QUESTIONS: ReadonlyArray<string> = [
 ];
 
 export function YamlSection() {
-  const cardStyle: CSSProperties = { background: "oklch(0.16 0 0)" };
   return (
     <section
       id="yaml"
       className="scroll-mt-20 border-b border-white/5 px-6 pt-20 pb-16 md:px-16 md:pt-[100px] md:pb-20"
-      style={cardStyle}
+      style={{ background: "oklch(0.16 0 0)" }}
     >
       <header className="mb-10 max-w-[760px]">
         <p className="mb-4 font-mono text-[11.5px] uppercase tracking-[0.16em] text-brand">

--- a/apps/www/src/components/landing/yaml-section.tsx
+++ b/apps/www/src/components/landing/yaml-section.tsx
@@ -1,0 +1,270 @@
+import { type CSSProperties } from "react";
+
+const YAML_LINES: ReadonlyArray<{ raw: string }> = [
+  { raw: "name: Orders" },
+  { raw: "type: fact_table" },
+  { raw: "table: orders" },
+  { raw: "grain: one row per order" },
+  { raw: "" },
+  { raw: "dimensions:" },
+  { raw: "  - name: status" },
+  { raw: "    sql: status" },
+  { raw: "    type: string" },
+  { raw: "    sample_values: [pending, shipped, delivered, cancelled]" },
+  { raw: "" },
+  { raw: "  - name: order_month" },
+  { raw: "    sql: TO_CHAR(created_at, 'YYYY-MM')" },
+  { raw: "    type: string" },
+  { raw: "    virtual: true" },
+  { raw: "" },
+  { raw: "measures:" },
+  { raw: "  - name: total_gmv_cents" },
+  { raw: "    sql: total_cents" },
+  { raw: "    type: sum" },
+  { raw: "" },
+  { raw: "joins:" },
+  { raw: "  - target_entity: Customers" },
+  { raw: "    relationship: many_to_one" },
+  { raw: "    join_columns: { from: customer_id, to: id }" },
+];
+
+type Token = { text: string; cls?: string };
+
+function tokenize(line: string): Token[] {
+  if (line.trim().startsWith("- ") || line.trim().startsWith("name:") || line.includes(":")) {
+    const match = line.match(/^(\s*)(-?\s*)?([\w\-_]+)(:\s*)(.*)$/);
+    if (match) {
+      const [, indent, dash, key, colon, rest] = match;
+      const tokens: Token[] = [];
+      if (indent) tokens.push({ text: indent });
+      if (dash) tokens.push({ text: dash, cls: "text-brand" });
+      tokens.push({ text: key ?? "", cls: "text-zinc-50 font-medium" });
+      tokens.push({ text: colon ?? "" });
+      if (rest) {
+        if (/^\[.*\]$/.test(rest) || /^\{.*\}$/.test(rest)) {
+          tokens.push({ text: rest, cls: "text-amber-300/90" });
+        } else if (rest === "true" || rest === "false") {
+          tokens.push({ text: rest, cls: "text-purple-300/90" });
+        } else {
+          tokens.push({ text: rest, cls: "text-amber-200/80" });
+        }
+      }
+      return tokens;
+    }
+  }
+  return [{ text: line }];
+}
+
+function YamlPane() {
+  return (
+    <div
+      className="overflow-hidden rounded-xl border border-white/10"
+      style={{ background: "oklch(0.12 0 0)" }}
+    >
+      <div
+        className="flex items-center gap-2 border-b border-white/5 px-3.5 py-2"
+        style={{ background: "oklch(0.16 0 0)" }}
+      >
+        <span
+          className="h-2.5 w-2.5 rounded-full"
+          style={{ background: "oklch(0.65 0.18 22)" }}
+        />
+        <span
+          className="h-2.5 w-2.5 rounded-full"
+          style={{ background: "oklch(0.78 0.16 70)" }}
+        />
+        <span
+          className="h-2.5 w-2.5 rounded-full"
+          style={{ background: "oklch(0.7 0.16 140)" }}
+        />
+        <span className="ml-2 font-mono text-[11px] text-zinc-400">
+          semantic/entities/orders.yml
+        </span>
+      </div>
+      <pre className="m-0 overflow-auto p-4 font-mono text-[12px] leading-[1.7] text-zinc-300">
+        {YAML_LINES.map((line, i) => (
+          <span key={i} className="block">
+            {tokenize(line.raw).map((tok, j) => (
+              <span key={j} className={tok.cls}>
+                {tok.text || " "}
+              </span>
+            ))}
+          </span>
+        ))}
+      </pre>
+    </div>
+  );
+}
+
+const QUESTION = "What's our top-performing category by GMV this month?";
+
+const ANSWER_ROWS: ReadonlyArray<{ category: string; gmv: string; orders: string }> = [
+  { category: "Bedding", gmv: "$184,219", orders: "2,041" },
+  { category: "Kitchen", gmv: "$142,718", orders: "1,587" },
+  { category: "Bath", gmv: "$98,402", orders: "1,103" },
+  { category: "Outdoor", gmv: "$71,288", orders: "812" },
+  { category: "Accessories", gmv: "$54,011", orders: "693" },
+];
+
+function AnswerPane() {
+  return (
+    <div
+      className="flex h-full flex-col overflow-hidden rounded-xl border border-white/10"
+      style={{ background: "oklch(0.14 0 0)" }}
+    >
+      <div
+        className="flex items-center gap-2 border-b border-white/5 px-3.5 py-2"
+        style={{ background: "oklch(0.16 0 0)" }}
+      >
+        <span
+          className="h-2 w-2 rounded-full"
+          style={{ background: "var(--atlas-brand)" }}
+        />
+        <span className="font-mono text-[11px] text-zinc-400">atlas · agent reply</span>
+        <span className="ml-auto rounded border border-white/10 px-2 py-[2px] font-mono text-[10px] text-zinc-400">
+          via MCP
+        </span>
+      </div>
+      <div className="flex flex-col gap-4 px-4 py-5">
+        <div>
+          <p className="mb-1 font-mono text-[11px] tracking-[0.06em] text-brand">
+            // user
+          </p>
+          <p className="m-0 text-[14px] text-zinc-100">{QUESTION}</p>
+        </div>
+
+        <div>
+          <p className="mb-2 font-mono text-[11px] tracking-[0.06em] text-zinc-400">
+            // agent reads orders.yml + categories.yml + glossary.yml, then writes SQL
+          </p>
+          <pre
+            className="m-0 overflow-auto rounded-md border border-white/10 px-3 py-2 font-mono text-[11.5px] leading-[1.6] text-zinc-300"
+            style={{ background: "oklch(0.10 0 0)" }}
+          >
+            <span className="text-purple-300/90">SELECT</span> c.name,{"\n"}       <span className="text-purple-300/90">SUM</span>(o.total_cents) /{" "}
+            <span className="text-amber-200/80">100.0</span> <span className="text-purple-300/90">AS</span> gmv,{"\n"}       <span className="text-purple-300/90">COUNT</span>(<span className="text-purple-300/90">DISTINCT</span> o.id){" "}
+            <span className="text-purple-300/90">AS</span> orders{"\n"}
+            <span className="text-purple-300/90">FROM</span> orders o{"\n"}
+            <span className="text-purple-300/90">JOIN</span> order_items oi{" "}
+            <span className="text-purple-300/90">ON</span> oi.order_id = o.id{"\n"}
+            <span className="text-purple-300/90">JOIN</span> products p{" "}
+            <span className="text-purple-300/90">ON</span> p.id = oi.product_id{"\n"}
+            <span className="text-purple-300/90">JOIN</span> categories c{" "}
+            <span className="text-purple-300/90">ON</span> c.id = p.category_id{"\n"}
+            <span className="text-purple-300/90">WHERE</span> o.status !={" "}
+            <span className="text-amber-200/80">'cancelled'</span>{"\n"}
+              <span className="text-purple-300/90">AND</span> o.created_at &gt;={" "}
+            <span className="text-purple-300/90">DATE_TRUNC</span>(<span className="text-amber-200/80">'month'</span>,{" "}
+            <span className="text-purple-300/90">NOW</span>()){"\n"}
+            <span className="text-purple-300/90">GROUP BY</span> c.name{"\n"}
+            <span className="text-purple-300/90">ORDER BY</span> gmv{" "}
+            <span className="text-purple-300/90">DESC</span>{"\n"}
+            <span className="text-purple-300/90">LIMIT</span> <span className="text-amber-200/80">5</span>;
+          </pre>
+        </div>
+
+        <div>
+          <p className="mb-2 font-mono text-[11px] tracking-[0.06em] text-zinc-400">
+            // result · 5 rows · 7 validators passed
+          </p>
+          <div
+            className="overflow-hidden rounded-md border border-white/10"
+            style={{ background: "oklch(0.10 0 0)" }}
+          >
+            <div
+              className="grid grid-cols-[1fr_auto_auto] gap-4 border-b border-white/5 px-3 py-2 font-mono text-[11px] uppercase tracking-[0.06em] text-zinc-400"
+            >
+              <span>category</span>
+              <span className="text-right">gmv</span>
+              <span className="text-right">orders</span>
+            </div>
+            {ANSWER_ROWS.map((row, i) => (
+              <div
+                key={row.category}
+                className="grid grid-cols-[1fr_auto_auto] gap-4 px-3 py-1.5 font-mono text-[12px] text-zinc-200"
+                style={{
+                  background: i % 2 ? "oklch(0.12 0 0)" : "transparent",
+                }}
+              >
+                <span>{row.category}</span>
+                <span className="text-right text-brand">{row.gmv}</span>
+                <span className="text-right text-zinc-400">{row.orders}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const QUESTIONS: ReadonlyArray<string> = [
+  "What's our GMV this quarter?",
+  "What's our top-performing category by GMV this month?",
+  "Monthly GMV trend over the past 6 months.",
+  "Show me revenue last quarter.",
+  "What are our most common return reasons?",
+];
+
+export function YamlSection() {
+  const cardStyle: CSSProperties = { background: "oklch(0.16 0 0)" };
+  return (
+    <section
+      id="yaml"
+      className="scroll-mt-20 border-b border-white/5 px-6 pt-20 pb-16 md:px-16 md:pt-[100px] md:pb-20"
+      style={cardStyle}
+    >
+      <header className="mb-10 max-w-[760px]">
+        <p className="mb-4 font-mono text-[11.5px] uppercase tracking-[0.16em] text-brand">
+          // the schema is the product
+        </p>
+        <h2 className="m-0 mb-4 text-[36px] md:text-[46px] font-semibold leading-[1.05] tracking-[-0.03em] text-zinc-50">
+          The YAML format is the moat.
+        </h2>
+        <p className="m-0 text-base leading-[1.65] text-zinc-400">
+          Entities, dimensions, measures, joins, virtual dimensions, query patterns, glossary terms, and authoritative metrics — all in YAML, in your repo, code-reviewed in pull requests. Every field exists because an LLM needs it: <code className="font-mono text-zinc-300">sample_values</code> ground the agent in real data, <code className="font-mono text-zinc-300">glossary.status: ambiguous</code> forces clarifying questions, <code className="font-mono text-zinc-300">metrics.objective</code> picks <code className="font-mono text-zinc-300">MAX</code> vs <code className="font-mono text-zinc-300">MIN</code>.
+        </p>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-2 md:items-stretch">
+        <YamlPane />
+        <AnswerPane />
+      </div>
+
+      <div className="mt-10">
+        <p className="mb-3 font-mono text-[11px] tracking-[0.06em] text-brand">
+          // canonical questions
+        </p>
+        <div className="grid gap-2 md:grid-cols-2 lg:grid-cols-5">
+          {QUESTIONS.map((q) => (
+            <div
+              key={q}
+              className="rounded-md border border-white/10 px-3 py-2.5 font-mono text-[12px] leading-[1.5] text-zinc-300"
+              style={{ background: "oklch(0.14 0 0)" }}
+            >
+              {q}
+            </div>
+          ))}
+        </div>
+        <p className="mt-3 font-mono text-[11px] tracking-[0.04em] text-zinc-400">
+          // same questions on the readme, the docs homepage, and the eval harness · against the bundled NovaMart e-commerce demo
+        </p>
+      </div>
+
+      <div className="mt-10 flex flex-wrap gap-2.5">
+        <a
+          href="https://docs.useatlas.dev/semantic-layer"
+          className="inline-flex items-center rounded-lg bg-brand px-[18px] py-[11px] text-[13.5px] font-semibold text-zinc-950 transition-colors hover:bg-brand-hover"
+        >
+          Read the YAML format →
+        </a>
+        <a
+          href="https://app.useatlas.dev/demo"
+          className="inline-flex items-center rounded-lg border border-white/10 bg-zinc-900 px-3.5 py-2.5 text-[13.5px] text-zinc-50 transition-colors hover:border-white/20"
+        >
+          try the NovaMart demo
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/apps/www/src/components/landing/yaml-section.tsx
+++ b/apps/www/src/components/landing/yaml-section.tsx
@@ -1,3 +1,5 @@
+import { CATEGORY_ROWS } from "./data";
+
 const YAML_LINES: ReadonlyArray<string> = [
   "name: Orders",
   "type: fact_table",
@@ -96,14 +98,6 @@ function YamlPane() {
 
 const QUESTION = "What's our top-performing category by GMV this month?";
 
-const ANSWER_ROWS: ReadonlyArray<{ category: string; gmv: string; orders: string }> = [
-  { category: "Bedding", gmv: "$184,219", orders: "2,041" },
-  { category: "Kitchen", gmv: "$142,718", orders: "1,587" },
-  { category: "Bath", gmv: "$98,402", orders: "1,103" },
-  { category: "Outdoor", gmv: "$71,288", orders: "812" },
-  { category: "Accessories", gmv: "$54,011", orders: "693" },
-];
-
 function AnswerPane() {
   return (
     <div
@@ -177,7 +171,7 @@ function AnswerPane() {
               <span className="text-right">gmv</span>
               <span className="text-right">orders</span>
             </div>
-            {ANSWER_ROWS.map((row, i) => (
+            {CATEGORY_ROWS.map((row, i) => (
               <div
                 key={row.category}
                 className="grid grid-cols-[1fr_auto_auto] gap-4 px-3 py-1.5 font-mono text-[12px] text-zinc-200"

--- a/apps/www/src/components/sticky-nav.tsx
+++ b/apps/www/src/components/sticky-nav.tsx
@@ -28,8 +28,10 @@ export function StickyNav() {
             <span className="font-mono text-sm font-semibold text-zinc-100">atlas</span>
           </a>
           <div className="hidden items-center gap-4 sm:flex">
+            <a href="#yaml" className="text-xs text-zinc-400 transition-colors hover:text-zinc-300">YAML</a>
             <a href="#trace" className="text-xs text-zinc-400 transition-colors hover:text-zinc-300">Trace</a>
             <a href="#primitives" className="text-xs text-zinc-400 transition-colors hover:text-zinc-300">Primitives</a>
+            <a href="#why-atlas" className="text-xs text-zinc-400 transition-colors hover:text-zinc-300">Why Atlas</a>
             <a href="#deploy" className="text-xs text-zinc-400 transition-colors hover:text-zinc-300">Deploy</a>
             <a href="/pricing" className="text-xs text-zinc-400 transition-colors hover:text-zinc-300">Pricing</a>
           </div>


### PR DESCRIPTION
## Summary

Closes #2026. Rewrites Atlas's three public surfaces — README, docs homepage, www landing — to lead with **MCP + the YAML semantic-layer moat** instead of the embed widget. Post-1.4.0, MCP is the strongest install path and the YAML format is the strongest differentiator, so the public copy should match.

**Moat sentence — verbatim across all three surfaces:**

> Atlas is a YAML-defined semantic layer for analytics — authored by humans, consumed by AI agents.

(Per coordinator update mid-task, the headline lost the "1:1 alternative to LookML — but agent-native" tail. Hero prose now stands on Atlas's strengths; the deeper Why-YAML doc page is the only place LookML / dbt / Cube get named, and it links to ``/comparisons``.)

## What changed

### `README.md`
- Hero opens with the moat sentence verbatim.
- ``bunx @useatlas/mcp init`` is now the lead install snippet (replaces ``bun create atlas-agent``).
- New **What's in the YAML?** section with a 20-line excerpt from the bundled NovaMart ``semantic/entities/orders.yml``.
- Embed (script tag, ``@useatlas/react``) demoted below MCP, still discoverable.
- **Why Atlas?** comparison table: semantic-layer row now calls out ``query_patterns``, ``virtual_dimensions``, ``glossary.status: ambiguous``, ``metrics.objective``; new agent-native row leads with MCP.

### `apps/docs/`
- ``index.mdx`` hero rewritten; MCP-first Get Started CTA; canonical NovaMart questions inline.
- New top-level **The Semantic Layer** section (``apps/docs/content/docs/semantic-layer/``) with four pages — overview + 20-line YAML excerpt, yaml-format pointer, glossary-and-metrics, why-yaml. Separate from Setup / Configuration as the issue requested.
- ``meta.json`` updated to surface ``semantic-layer`` as a top-level entry between ``getting-started`` and ``guides``.
- ``quick-start.mdx`` canonical questions swapped from old cybersec/simple seed (``companies by industry``) to NovaMart questions.

### `apps/www/`
- Hero headline + subhead rewritten to the moat sentence; CTA flipped from "Start 14-day trial" to **Install the MCP server** with ``bunx @useatlas/mcp init``.
- New ``YamlSection`` component: split-pane visual (``orders.yml`` on the left, agent SQL + result table on the right) plus the 5-question canonical strip.
- New ``Comparison`` component mirroring the README "Why Atlas?" table — same rows, same words, no claim drift.
- ``Trace`` component retargeted from the old accounts/ARR demo to the NovaMart top-category-by-GMV canonical question.
- ``EndCta`` updated; demo CTA points to the NovaMart demo.
- ``StickyNav`` adds **YAML** and **Why Atlas** anchors.

### Same canonical 5 questions on all three surfaces
1. What's our GMV this quarter? (simple metric)
2. What's our top-performing category by GMV this month? (segmentation)
3. Monthly GMV trend over the past 6 months. (time-series)
4. Show me revenue last quarter. (**glossary disambiguation** — ``revenue`` is ``status: ambiguous``)
5. What are our most common return reasons? (normalized enum aggregation)

### `.claude/research/ROADMAP.md`
- 1.4.0 active section: ``[x]`` for [#2026].

## Acceptance criteria

- [x] Moat sentence verbatim across README hero, docs homepage hero, www landing hero
- [x] MCP install is the lead path on all three; embed still discoverable
- [x] 20-line YAML excerpt visible above-the-fold in README
- [x] New "Semantic Layer" docs section
- [x] Same 5 canonical example questions on all three surfaces
- [x] Demo links point to NovaMart (no removed ``cybersec``/``simple`` seeds reintroduced)
- [x] ROADMAP.md updated
- [x] All six ``/ci`` gates pass (lint, type, test, syncpack, template drift, railway-watch)

## Test plan

- [ ] Render the docs homepage and confirm the moat sentence + Cards block render correctly.
- [ ] Render the new ``/semantic-layer`` section and click through to overview, yaml-format, glossary-and-metrics, why-yaml.
- [ ] Render the www landing and confirm: hero copy, YAML split-pane visual, canonical questions strip, comparison table, sticky-nav anchors all render and scroll.
- [ ] Verify the trace section animation still autoplays correctly with the new NovaMart copy + SQL tokens.
- [ ] Confirm ``bunx @useatlas/mcp init`` snippet still copies cleanly from the README.
- [ ] Spot-check that no internal links 404 (e.g. ``/semantic-layer/glossary-and-metrics``, ``/comparisons``).