### PR TITLE
feat(eval): #2025 — canonical-question harness for the demo dataset

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -146,7 +146,7 @@ Tracker: [milestone #40](https://github.com/AtlasDevHQ/atlas/milestones/40). Lea
 - [x] Structured error envelope for typed MCP tools so agents can recover gracefully (#2030, PR #2034)
 - [ ] List Atlas in MCP registries (mcp.so + others) before close (#2027)
 - [ ] Lead README, docs homepage, and landing with MCP + the YAML-first story (#2026)
-- [ ] Canonical-question eval harness for the demo dataset (#2025)
+- [x] Canonical-question eval harness for the demo dataset (#2025) — 20-question curated set under `eval/canonical-questions/`, deterministic by default (calls typed semantic-layer reads + executes the resolved SQL directly, mirroring the typed MCP `runMetric`), `--llm` mode for the full agent loop. CI gate at `.github/workflows/eval.yml` is informational on PRs and blocking on release tags.
 - [x] Consolidate canonical demo dataset across landing, docs, scaffolder (#2021, PR #2036) — three seeds collapsed to one canonical NovaMart ecommerce seed; multi-seed picker reverted; canonical question set locked for #2025/#2026.
 - [x] Streaming chat CORS fix (PR #2037) — surfaced by the post-#2021 demo smoke; same latent bug existed for cross-origin embedders of `@useatlas/react`.
 - [x] CI un-stuck — partial `mock.module(@atlas/api/lib/config)` in @atlas/mcp tests was breaking `bun test`'s in-process runner across files (PR #2038).

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -1,0 +1,95 @@
+name: Canonical Eval
+
+# Canonical-question eval harness for the consolidated NovaMart demo
+# dataset (#2025). Proves the semantic layer (metrics, query_patterns,
+# glossary disambiguation, virtual dimensions) returns correct answers to
+# a curated set of ~20 questions.
+#
+# Policy:
+#   - Pull requests: informational only. The job is allowed to fail without
+#     blocking the PR; the signal is the `X/N passing` line in the run log.
+#     This matches the `lighthouse.yml` first-month policy.
+#   - Release tags (v*.*.*): blocking. A canonical-question regression
+#     should never ship in a tagged release. Tag pushes drop the
+#     `continue-on-error` and a single fail trips the workflow red.
+#
+# Mode:
+#   Deterministic only (no LLM). The harness calls the typed semantic-layer
+#   reads (`findMetricById`, `searchGlossary`) and executes the resolved SQL
+#   directly against the seeded Postgres. The optional `--llm` mode exists
+#   for local exploration; we don't run it in CI to keep the gate stable.
+#
+# Workflow-injection notes:
+#   - No untrusted PR/issue/commit fields are spliced into `run:` strings.
+#   - Bun + Postgres versions templated into `run:` come from the workflow's
+#     own `env:` block — repo-controlled, not attacker-controlled.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "eval/canonical-questions/**"
+      - "packages/cli/bin/canonical-eval*.ts"
+      - "packages/cli/data/seeds/ecommerce/**"
+      - "packages/api/src/lib/semantic/**"
+      - ".github/workflows/eval.yml"
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+env:
+  BUN_VERSION: "1.3.11"
+
+jobs:
+  canonical-eval:
+    name: canonical-eval
+    runs-on: ubuntu-latest
+    # PR runs are informational; tag pushes are blocking. The release-tag
+    # branch flips this off so a regression actually trips the workflow red.
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: atlas
+          POSTGRES_PASSWORD: atlas
+          POSTGRES_DB: atlas
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U atlas"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=10
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@e3914758a49697077f7bcd190d36582a61667aad # v2 + node24
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build @useatlas/types (resolves api imports)
+        run: bun run --filter '@useatlas/types' build
+
+      # `seedDemoPostgres` expects an existing target database; we provision
+      # `atlas_demo` here so the harness can drop/recreate the seed schema
+      # against a clean DB without polluting `atlas` (the internal DB).
+      - name: Provision atlas_demo database
+        env:
+          PGPASSWORD: atlas
+        run: |
+          bun x wait-on tcp:127.0.0.1:5432 --timeout 60000
+          psql -h 127.0.0.1 -U atlas -d atlas -c "CREATE DATABASE atlas_demo;"
+
+      - name: Run canonical eval (deterministic)
+        env:
+          ATLAS_DATASOURCE_URL: postgres://atlas:atlas@127.0.0.1:5432/atlas_demo
+          DATABASE_URL: postgres://atlas:atlas@127.0.0.1:5432/atlas
+        run: bun packages/cli/bin/atlas.ts canonical-eval

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -30,6 +30,8 @@ on:
     paths:
       - "eval/canonical-questions/**"
       - "packages/cli/bin/canonical-eval*.ts"
+      - "packages/cli/bin/atlas.ts"
+      - "packages/cli/lib/help.ts"
       - "packages/cli/data/seeds/ecommerce/**"
       - "packages/api/src/lib/semantic/**"
       - ".github/workflows/eval.yml"

--- a/apps/docs/content/docs/contributing/eval-harness.mdx
+++ b/apps/docs/content/docs/contributing/eval-harness.mdx
@@ -1,0 +1,90 @@
+---
+title: Canonical-Question Eval Harness
+description: Proves the consolidated NovaMart demo dataset returns correct answers to a curated question set. Locks in semantic-layer correctness for demos, the README, and every change to entity / metric / glossary YAMLs.
+---
+
+> Why this is separate from `atlas eval`: that suite is the LLM SQL-quality benchmark (gold SQL, single shot, LLM nondeterminism). This harness is the *semantic-layer correctness* gate — it calls metric SQL exactly as the typed MCP `runMetric` tool does, asserts ambiguous glossary terms still trigger disambiguation, and proves `query_patterns:` and `virtual:` dimensions compile against the seed.
+
+## What it covers
+
+A curated set of ~20 canonical questions in `eval/canonical-questions/questions.yml`, exercising:
+
+- **Simple metrics** — `total_gmv`, `total_customers`, `aov`, `refund_rate`, `return_rate`
+- **Segmentation** — revenue by category, customers by acquisition source, inventory health, carrier performance
+- **Joins** — DTC vs marketplace revenue (joins `order_items` → `products`), top customers by spend (joins `customers` → `orders`)
+- **Time-series** — monthly GMV trend, new customers by month
+- **Virtual dimensions** — `orders.order_size_bucket`, `products.price_tier`
+- **Glossary disambiguation** — `revenue`, `status`, `price` are `status: ambiguous` and must trigger the disambiguation contract documented in [the typed MCP tools](../platform-ops/mcp-tools), never resolve to a single mapping
+- **Filtered query_patterns** — `orders.orders_with_promotions` (`WHERE status != 'cancelled'`), `products.dtc_vs_marketplace` (`WHERE status = 'active'`)
+
+## Running locally
+
+```bash
+# Spin up Postgres + sandbox sidecar and seed the demo dataset
+bun run db:up
+export ATLAS_DATASOURCE_URL=postgres://atlas:atlas@localhost:5432/atlas_demo
+
+# Deterministic mode (default) — no LLM. Calls semantic-layer reads and
+# executes the resolved SQL directly. Fast, repeatable.
+bun run eval:canonical
+
+# Optional LLM mode — runs the full agent loop and asserts on the SQL
+# pattern of the last executeSQL call. Slower, nondeterministic.
+bun run eval:canonical -- --llm
+```
+
+The output is human-readable, with a `X/N passing` summary line and a per-category breakdown:
+
+```text
+Atlas canonical-question eval
+============================================================
+20/20 passing  (0 warn, 0 fail)
+
+[PASS] cq-001  simple_metric      What is our total GMV?
+[PASS] cq-002  simple_metric      How many customers do we have?
+...
+============================================================
+20/20 passing
+  filtered_pattern     2/2
+  glossary             3/3
+  join                 2/2
+  segmentation         4/4
+  simple_metric        5/5
+  timeseries           2/2
+  virtual_dimension    2/2
+```
+
+## Adding a question
+
+1. Append a new entry to `eval/canonical-questions/questions.yml`. Ids are zero-padded `cq-NNN` and must be unique.
+2. Pick the simplest `mode` that proves the property you care about:
+   - `metric` — pass `metric_id`. The harness calls `findMetricById(id)` and executes the metric's authoritative SQL.
+   - `pattern` — pass `entity` + `pattern`. Resolves a `query_patterns[*].sql` from an entity YAML.
+   - `virtual` — pass `entity`, `dimension`, and an inline `sql`. Used to prove a `virtual: true` dimension compiles against the seed.
+   - `glossary` — pass `term`. The harness asserts the glossary status (`ambiguous` / `defined`) and minimum mapping count.
+3. Choose loose `expect:` assertions — the harness runs against a deterministic seed, but absolute scalar values are brittle. Prefer `sql_pattern` (substrings the resolved SQL must contain), `min_rows` / `max_rows` (row-count bounds), `non_zero` (scalar metric guards), and `column` (single named column).
+4. Run `bun run eval:canonical` locally to confirm.
+5. Update this page if your question category isn't already covered.
+
+## CI policy
+
+`.github/workflows/eval.yml` runs the deterministic mode against a fresh Postgres on every PR that touches:
+
+- `eval/canonical-questions/**`
+- `packages/cli/bin/canonical-eval*.ts`
+- `packages/cli/data/seeds/ecommerce/**`
+- `packages/api/src/lib/semantic/**`
+
+| Trigger | Behavior |
+|---|---|
+| Pull request to `main` | Informational. `continue-on-error: true` — a regression posts the `X/N passing` line in the run log but doesn't block merge. Mirrors the [Lighthouse budget](#lighthouse-budget-advisory) first-month policy. |
+| Tag push (`v*.*.*`) | Blocking. `continue-on-error` flips off. A regression on a release tag trips the workflow red. |
+
+The LLM mode (`--llm`) is **not** run in CI. We keep the gate stable and deterministic; the LLM mode exists for local exploration when debugging an agent regression.
+
+## Out of scope
+
+- Eval coverage beyond the demo dataset (real customer data is separate).
+- LLM-as-judge scoring (we use deterministic SQL substring + value comparison).
+- Latency / throughput benchmarks.
+- Multi-LLM eval — the existing `atlas eval` LLM benchmark covers single-model correctness.

--- a/apps/docs/content/docs/contributing/meta.json
+++ b/apps/docs/content/docs/contributing/meta.json
@@ -2,5 +2,5 @@
   "title": "Contributing",
   "description": "Working on Atlas itself — CI gates, build workflows, and process",
   "icon": "GitPullRequest",
-  "pages": ["ci"]
+  "pages": ["ci", "eval-harness"]
 }

--- a/eval/canonical-questions/questions.yml
+++ b/eval/canonical-questions/questions.yml
@@ -1,0 +1,262 @@
+# Canonical questions — proves the consolidated NovaMart demo dataset (#2021)
+# answers the curated question set correctly.
+#
+# Each question has a `mode` that determines how it's resolved:
+#   - metric:   call findMetricById(id) and execute the metric's authoritative
+#               SQL. Deterministic mode asserts result shape / SQL pattern.
+#   - pattern:  execute a `query_patterns[*].sql` from a specific entity YAML.
+#               Used to exercise WHERE-filtered patterns and joins.
+#   - virtual:  run an inline SELECT that exercises a `virtual: true` dimension
+#               from an entity YAML so the harness proves virtual dims compile.
+#   - glossary: search the glossary for a term; assert `status === 'ambiguous'`
+#               or another expected status.
+#
+# `expect` fields are intentionally loose:
+#   - sql_pattern:  case-insensitive substrings every executed SQL must contain
+#   - min_rows / max_rows: row-count bounds on the result
+#   - non_zero:     scalar metrics must return a non-zero numeric value
+#   - column:       single named column expected on the result
+#
+# Adding a question:
+#   1. Append a new entry below — keep ids zero-padded (cq-001 .. cq-020).
+#   2. Pick the simplest mode that proves the property you care about.
+#   3. Run `bun run eval:canonical` locally to confirm it passes.
+#   4. Update apps/docs/content/docs/contributing/eval-harness.mdx if your
+#      question category isn't already covered.
+
+version: "1.0"
+schema: ecommerce
+questions:
+  # ── Simple metrics (3) ──────────────────────────────────────────────────
+  - id: cq-001
+    category: simple_metric
+    question: What is our total GMV?
+    mode: metric
+    metric_id: total_gmv
+    expect:
+      sql_pattern: ["SUM(total_cents)", "FROM orders"]
+      non_zero: true
+
+  - id: cq-002
+    category: simple_metric
+    question: How many customers do we have?
+    mode: metric
+    metric_id: total_customers
+    expect:
+      sql_pattern: ["COUNT(DISTINCT id)", "FROM customers"]
+      non_zero: true
+
+  - id: cq-003
+    category: simple_metric
+    question: What is our average order value?
+    mode: metric
+    metric_id: aov
+    expect:
+      sql_pattern: ["AVG(total_cents)", "FROM orders"]
+      non_zero: true
+
+  # ── Segmentation (3) ────────────────────────────────────────────────────
+  - id: cq-004
+    category: segmentation
+    question: What is our revenue broken down by category?
+    mode: metric
+    metric_id: revenue_by_category
+    expect:
+      sql_pattern: ["GROUP BY", "categories", "order_items"]
+      min_rows: 1
+
+  - id: cq-005
+    category: segmentation
+    question: How many customers do we have by acquisition source?
+    mode: metric
+    metric_id: customers_by_acquisition_source
+    expect:
+      sql_pattern: ["LOWER(acquisition_source)", "GROUP BY"]
+      min_rows: 1
+      column: channel
+
+  - id: cq-006
+    category: segmentation
+    question: What is our inventory health by stock status?
+    mode: metric
+    metric_id: inventory_health
+    expect:
+      sql_pattern: ["FROM inventory_levels", "GROUP BY"]
+      min_rows: 1
+      column: stock_status
+
+  # ── Joins (2) ────────────────────────────────────────────────────────────
+  - id: cq-007
+    category: join
+    question: What is our revenue split between DTC and marketplace?
+    mode: metric
+    metric_id: revenue_dtc_vs_marketplace
+    expect:
+      sql_pattern: ["JOIN products", "seller_id IS NULL"]
+      min_rows: 1
+      max_rows: 2
+      column: channel
+
+  - id: cq-008
+    category: join
+    question: Who are our top customers by spend?
+    mode: metric
+    metric_id: top_customers_by_spend
+    expect:
+      sql_pattern: ["JOIN orders", "FROM customers"]
+      min_rows: 1
+      max_rows: 20
+
+  # ── Time-series (2) ──────────────────────────────────────────────────────
+  - id: cq-009
+    category: timeseries
+    question: How has our GMV changed by month?
+    mode: metric
+    metric_id: monthly_gmv_trend
+    expect:
+      sql_pattern: ["TO_CHAR(created_at", "GROUP BY"]
+      min_rows: 1
+      column: month
+
+  - id: cq-010
+    category: timeseries
+    question: How many new customers signed up each month?
+    mode: metric
+    metric_id: new_customers_by_month
+    expect:
+      sql_pattern: ["TO_CHAR(created_at", "FROM customers"]
+      min_rows: 1
+      column: month
+
+  # ── Virtual dimensions (2) ───────────────────────────────────────────────
+  - id: cq-011
+    category: virtual_dimension
+    question: How are orders distributed by size bucket?
+    mode: virtual
+    entity: Orders
+    dimension: order_size_bucket
+    sql: |-
+      SELECT
+        CASE
+          WHEN total_cents < 2500 THEN 'Small (<$25)'
+          WHEN total_cents < 7500 THEN 'Medium ($25-$75)'
+          WHEN total_cents < 15000 THEN 'Large ($75-$150)'
+          ELSE 'XL ($150+)'
+        END AS order_size_bucket,
+        COUNT(*) AS order_count
+      FROM orders
+      GROUP BY order_size_bucket
+      ORDER BY order_count DESC
+    expect:
+      min_rows: 1
+      max_rows: 4
+      column: order_size_bucket
+
+  - id: cq-012
+    category: virtual_dimension
+    question: How are active products distributed by price tier?
+    mode: virtual
+    entity: Products
+    dimension: price_tier
+    sql: |-
+      SELECT
+        CASE
+          WHEN price < 25 THEN 'Budget'
+          WHEN price < 75 THEN 'Mid-Range'
+          WHEN price < 200 THEN 'Premium'
+          ELSE 'Luxury'
+        END AS price_tier,
+        COUNT(*) AS product_count
+      FROM products
+      WHERE status = 'active'
+      GROUP BY price_tier
+      ORDER BY product_count DESC
+    expect:
+      min_rows: 1
+      max_rows: 4
+      column: price_tier
+
+  # ── Glossary disambiguation (3) ──────────────────────────────────────────
+  # `status: ambiguous` terms — agent must ASK, never silently pick.
+  # The forthcoming MCP `searchGlossary` (#2020) returns the `ambiguous_term`
+  # envelope code; this harness asserts on the underlying glossary state.
+  - id: cq-013
+    category: glossary
+    question: Show me revenue last quarter
+    mode: glossary
+    term: revenue
+    expect:
+      status: ambiguous
+      mappings_min: 2
+
+  - id: cq-014
+    category: glossary
+    question: Filter by status
+    mode: glossary
+    term: status
+    expect:
+      status: ambiguous
+      mappings_min: 2
+
+  - id: cq-015
+    category: glossary
+    question: What's the price?
+    mode: glossary
+    term: price
+    expect:
+      status: ambiguous
+      mappings_min: 2
+
+  # ── Filtered query_patterns (2) ──────────────────────────────────────────
+  - id: cq-016
+    category: filtered_pattern
+    question: How does promotion usage affect order value?
+    mode: pattern
+    entity: Orders
+    pattern: orders_with_promotions
+    expect:
+      sql_pattern: ["WHERE status != 'cancelled'", "promotion_id IS NOT NULL"]
+      min_rows: 1
+      max_rows: 2
+      column: promo_status
+
+  - id: cq-017
+    category: filtered_pattern
+    question: What is the DTC vs marketplace product mix among active products?
+    mode: pattern
+    entity: Products
+    pattern: dtc_vs_marketplace
+    expect:
+      sql_pattern: ["WHERE status = 'active'", "seller_id IS NULL"]
+      min_rows: 1
+      max_rows: 2
+      column: channel
+
+  # ── Extra coverage (3) ───────────────────────────────────────────────────
+  - id: cq-018
+    category: simple_metric
+    question: What is our refund rate?
+    mode: metric
+    metric_id: refund_rate
+    expect:
+      sql_pattern: ["FROM payments", "FILTER (WHERE status = 'refunded')"]
+      column: refund_rate
+
+  - id: cq-019
+    category: simple_metric
+    question: What is our return rate?
+    mode: metric
+    metric_id: return_rate
+    expect:
+      sql_pattern: ["FROM orders", "LEFT JOIN returns"]
+      column: return_rate
+
+  - id: cq-020
+    category: segmentation
+    question: How are our shipping carriers performing?
+    mode: metric
+    metric_id: carrier_performance
+    expect:
+      sql_pattern: ["FROM shipments", "GROUP BY carrier"]
+      min_rows: 1
+      column: carrier

--- a/eval/canonical-questions/questions.yml
+++ b/eval/canonical-questions/questions.yml
@@ -27,7 +27,7 @@
 version: "1.0"
 schema: ecommerce
 questions:
-  # ── Simple metrics (3) ──────────────────────────────────────────────────
+  # ── Simple metrics (5) ──────────────────────────────────────────────────
   - id: cq-001
     category: simple_metric
     question: What is our total GMV?
@@ -55,7 +55,7 @@ questions:
       sql_pattern: ["AVG(total_cents)", "FROM orders"]
       non_zero: true
 
-  # ── Segmentation (3) ────────────────────────────────────────────────────
+  # ── Segmentation (4) ────────────────────────────────────────────────────
   - id: cq-004
     category: segmentation
     question: What is our revenue broken down by category?
@@ -232,7 +232,7 @@ questions:
       max_rows: 2
       column: channel
 
-  # ── Extra coverage (3) ───────────────────────────────────────────────────
+  # ── Continued: simple_metric + segmentation tail (3) ────────────────────
   - id: cq-018
     category: simple_metric
     question: What is our refund rate?

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:e2e:scaffold": "bash e2e/scripts/run.sh --tier scaffold",
     "test:e2e:all": "bash e2e/scripts/run.sh --all",
     "test:e2e:docker": "bash e2e/scripts/run.sh --tier docker",
+    "eval:canonical": "bun packages/cli/bin/atlas.ts canonical-eval",
     "smoke": "bash scripts/smoke.sh",
     "smoke:scaffold": "bash create-atlas/smoke-test.sh",
     "smoke:remote": "bun run atlas -- smoke",

--- a/packages/cli/bin/__tests__/canonical-eval.test.ts
+++ b/packages/cli/bin/__tests__/canonical-eval.test.ts
@@ -193,6 +193,111 @@ describe("compareMetricResult", () => {
     };
     expect(compareMetricResult(q, bad).status).toBe("fail");
   });
+
+  // ── non_zero edge cases ────────────────────────────────────────────────
+  // The non_zero check coerces via Number(), so null / numeric strings
+  // need to behave the way the canonical questions expect.
+
+  test("non_zero with empty rows fails", () => {
+    const q: Question = {
+      ...baseQuestion,
+      expect: { sql_pattern: [], non_zero: true },
+    };
+    const executed: ExecutedQuery = {
+      sql: "SELECT SUM(total_cents) AS v FROM orders",
+      columns: ["v"],
+      rows: [],
+    };
+    const result = compareMetricResult(q, executed);
+    expect(result.status).toBe("fail");
+    expect(result.detail).toMatch(/empty/);
+  });
+
+  test("non_zero with a null first cell fails", () => {
+    const q: Question = {
+      ...baseQuestion,
+      expect: { sql_pattern: [], non_zero: true },
+    };
+    const executed: ExecutedQuery = {
+      sql: "SELECT SUM(total_cents) AS v FROM orders",
+      columns: ["v"],
+      rows: [{ v: null }],
+    };
+    const result = compareMetricResult(q, executed);
+    expect(result.status).toBe("fail");
+    expect(result.detail).toMatch(/non-zero/);
+  });
+
+  test('non_zero with the string "0" fails (numeric coercion)', () => {
+    const q: Question = {
+      ...baseQuestion,
+      expect: { sql_pattern: [], non_zero: true },
+    };
+    const executed: ExecutedQuery = {
+      sql: "SELECT SUM(total_cents) AS v FROM orders",
+      columns: ["v"],
+      rows: [{ v: "0" }],
+    };
+    const result = compareMetricResult(q, executed);
+    expect(result.status).toBe("fail");
+    expect(result.detail).toMatch(/non-zero/);
+  });
+
+  test('non_zero with the string "42" passes (numeric coercion)', () => {
+    const q: Question = {
+      ...baseQuestion,
+      expect: { sql_pattern: [], non_zero: true },
+    };
+    const executed: ExecutedQuery = {
+      sql: "SELECT SUM(total_cents) AS v FROM orders",
+      columns: ["v"],
+      rows: [{ v: "42" }],
+    };
+    expect(compareMetricResult(q, executed).status).toBe("pass");
+  });
+
+  // ── min_rows / max_rows boundaries ─────────────────────────────────────
+
+  test("max_rows boundary: rowCount === max_rows passes", () => {
+    const q: Question = {
+      ...baseQuestion,
+      expect: { sql_pattern: [], max_rows: 2 },
+    };
+    const executed: ExecutedQuery = {
+      sql: "SELECT 1",
+      columns: ["v"],
+      rows: [{ v: 1 }, { v: 2 }],
+    };
+    expect(compareMetricResult(q, executed).status).toBe("pass");
+  });
+
+  test("max_rows boundary: rowCount > max_rows warns", () => {
+    const q: Question = {
+      ...baseQuestion,
+      expect: { sql_pattern: [], max_rows: 2 },
+    };
+    const executed: ExecutedQuery = {
+      sql: "SELECT 1",
+      columns: ["v"],
+      rows: [{ v: 1 }, { v: 2 }, { v: 3 }],
+    };
+    const result = compareMetricResult(q, executed);
+    expect(result.status).toBe("warn");
+    expect(result.detail).toMatch(/max_rows=2/);
+  });
+
+  test("min_rows: 0 with rowCount === 0 passes", () => {
+    const q: Question = {
+      ...baseQuestion,
+      expect: { sql_pattern: [], min_rows: 0 },
+    };
+    const executed: ExecutedQuery = {
+      sql: "SELECT 1 WHERE FALSE",
+      columns: ["v"],
+      rows: [],
+    };
+    expect(compareMetricResult(q, executed).status).toBe("pass");
+  });
 });
 
 // ── compareGlossaryResult ────────────────────────────────────────────────
@@ -261,6 +366,38 @@ describe("compareGlossaryResult", () => {
     ]);
     expect(result.status).toBe("fail");
     expect(result.detail).toMatch(/mapping/i);
+  });
+
+  test("passes when expected status is `defined` and the match is `defined`", () => {
+    const q: Question = {
+      id: "cq-100",
+      category: "glossary",
+      question: "x",
+      mode: "glossary",
+      term: "customer",
+      expect: { status: "defined" },
+    };
+    const result = compareGlossaryResult(q, [
+      { term: "customer", status: "defined", possible_mappings: [] },
+    ]);
+    expect(result.status).toBe("pass");
+    expect(result.detail).toBe("defined");
+  });
+
+  test("passes when no expected status is set and any match is returned", () => {
+    const q: Question = {
+      id: "cq-101",
+      category: "glossary",
+      question: "x",
+      mode: "glossary",
+      term: "revenue",
+      expect: {},
+    };
+    const result = compareGlossaryResult(q, [
+      { term: "revenue", status: "ambiguous", possible_mappings: ["a"] },
+    ]);
+    expect(result.status).toBe("pass");
+    expect(result.detail).toMatch(/match/);
   });
 });
 
@@ -469,35 +606,118 @@ describe("resolveQuestion", () => {
 });
 
 describe("runHarness", () => {
+  // Build SQL that satisfies every metric question's `sql_pattern` substrings
+  // by id, sourced directly from the curated questions. This makes the test
+  // a real regression gate — if a comparator stops matching, the count of
+  // passes drops and the assertion below catches it.
+  const metricSqlForId: Record<string, string> = {
+    total_gmv: "SELECT SUM(total_cents) AS v FROM orders",
+    total_customers: "SELECT COUNT(DISTINCT id) AS v FROM customers",
+    aov: "SELECT AVG(total_cents) AS v FROM orders",
+    revenue_by_category:
+      "SELECT 1 AS v FROM order_items JOIN categories GROUP BY 1",
+    customers_by_acquisition_source:
+      "SELECT LOWER(acquisition_source) AS channel, 1 FROM customers GROUP BY 1",
+    inventory_health:
+      "SELECT 'Adequate' AS stock_status, 1 AS v FROM inventory_levels GROUP BY 1",
+    revenue_dtc_vs_marketplace:
+      "SELECT 'DTC' AS channel, 1 AS v FROM orders JOIN products ON p WHERE seller_id IS NULL GROUP BY 1",
+    top_customers_by_spend: "SELECT 1 AS v FROM customers JOIN orders ON o",
+    monthly_gmv_trend:
+      "SELECT TO_CHAR(created_at, 'YYYY-MM') AS month, 1 AS v FROM orders GROUP BY 1",
+    new_customers_by_month:
+      "SELECT TO_CHAR(created_at, 'YYYY-MM') AS month, 1 AS v FROM customers GROUP BY 1",
+    refund_rate:
+      "SELECT 1.0 AS refund_rate FROM payments WHERE COUNT(*) FILTER (WHERE status = 'refunded') > 0",
+    return_rate: "SELECT 1.0 AS return_rate FROM orders LEFT JOIN returns r ON r.id = id",
+    carrier_performance:
+      "SELECT 'UPS' AS carrier, 1 AS v FROM shipments GROUP BY carrier",
+  };
+
+  const patternSqlFor: Record<string, string> = {
+    "Orders/orders_with_promotions":
+      "SELECT 'Promoted' AS promo_status FROM orders WHERE status != 'cancelled' AND promotion_id IS NOT NULL",
+    "Products/dtc_vs_marketplace":
+      "SELECT 'DTC' AS channel FROM products WHERE status = 'active' AND seller_id IS NULL",
+  };
+
   test("runs every question through resolveQuestion with the same opts", async () => {
-    const sqlFor: Record<string, string> = {
-      total_gmv: "SELECT 1 AS v FROM orders",
-      total_customers: "SELECT 1 AS v FROM customers",
-      aov: "SELECT 1 AS v FROM orders",
-    };
     let calls = 0;
     const results = await runHarness({
       findMetricSql: (id) => {
         calls++;
-        return sqlFor[id] ?? "SELECT 1 AS v";
+        return metricSqlForId[id] ?? "SELECT 1 AS v";
       },
-      findPatternSql: (entity, pattern) => `SELECT 1 AS v -- ${entity}/${pattern}`,
+      findPatternSql: (entity, pattern) =>
+        patternSqlFor[`${entity}/${pattern}`] ?? null,
+      // All three glossary questions assert `status: "ambiguous"` with
+      // `mappings_min: 2`, so this stub satisfies them.
       searchGlossary: (term) => [
         { term, status: "ambiguous", possible_mappings: ["a.b", "c.d"] },
       ],
+      // Synthetic executor — returns shape sufficient for every column /
+      // row-bounds check on the curated set.
       executeSql: async (sql) => {
-        // Every test SQL returns one synthetic row that satisfies the loose
-        // expectations on the curated set. We mirror columns from the SQL.
-        if (sql.toLowerCase().includes("from inventory_levels")) {
-          return { columns: ["stock_status"], rows: [{ stock_status: "Adequate" }] };
+        const lower = sql.toLowerCase();
+        if (lower.includes("from inventory_levels")) {
+          return {
+            columns: ["stock_status"],
+            rows: [{ stock_status: "Adequate" }],
+          };
         }
-        if (sql.toLowerCase().includes("seller_id is null")) {
+        if (lower.includes("seller_id is null") && lower.includes("products")) {
           return { columns: ["channel"], rows: [{ channel: "DTC" }] };
         }
-        return { columns: ["v", "month", "channel", "carrier", "promo_status", "refund_rate", "return_rate", "order_size_bucket", "price_tier", "stock_status"], rows: [{ v: 42, month: "2024-01", channel: "DTC", carrier: "UPS", promo_status: "Promoted", refund_rate: 1, return_rate: 1, order_size_bucket: "Small", price_tier: "Budget", stock_status: "Adequate" }] };
+        if (lower.includes("promotion_id is not null")) {
+          return {
+            columns: ["promo_status"],
+            rows: [{ promo_status: "Promoted" }],
+          };
+        }
+        return {
+          columns: [
+            "v",
+            "month",
+            "channel",
+            "carrier",
+            "promo_status",
+            "refund_rate",
+            "return_rate",
+            "order_size_bucket",
+            "price_tier",
+            "stock_status",
+          ],
+          rows: [
+            {
+              v: 42,
+              month: "2024-01",
+              channel: "DTC",
+              carrier: "UPS",
+              promo_status: "Promoted",
+              refund_rate: 1,
+              return_rate: 1,
+              order_size_bucket: "Small",
+              price_tier: "Budget",
+              stock_status: "Adequate",
+            },
+          ],
+        };
       },
     });
-    expect(results.length).toBeGreaterThanOrEqual(20);
+
+    // Assert specific counts so the test is a real regression gate. If a
+    // comparator silently stops matching, the pass count drops and the
+    // assertion fires.
+    const passCount = results.filter((r) => r.status === "pass").length;
+    const failCount = results.filter((r) => r.status === "fail").length;
+    const warnCount = results.filter((r) => r.status === "warn").length;
+    expect(results.length).toBe(20);
+    expect(passCount + failCount + warnCount).toBe(results.length);
+    // With the wired-in stubs, every question should pass — the stubs
+    // are crafted to satisfy each curated `expect:` block.
+    expect(passCount).toBe(20);
+    expect(failCount).toBe(0);
+    expect(warnCount).toBe(0);
     expect(calls).toBeGreaterThan(0);
   });
 });

--- a/packages/cli/bin/__tests__/canonical-eval.test.ts
+++ b/packages/cli/bin/__tests__/canonical-eval.test.ts
@@ -1,0 +1,503 @@
+/**
+ * Tests for the canonical-question eval runner core.
+ *
+ * The runner is split so the loader, the per-mode comparators, the formatter,
+ * and the resolveQuestion dispatcher are all pure (DB-free) and testable.
+ * The CLI driver in `canonical-eval-run.ts` provides the real DB / semantic
+ * wiring; these tests inject stubs.
+ */
+
+import { describe, expect, test } from "bun:test";
+import * as path from "path";
+import {
+  loadQuestions,
+  compareMetricResult,
+  compareGlossaryResult,
+  compareVirtualResult,
+  comparePatternResult,
+  formatSummary,
+  resolveQuestion,
+  runHarness,
+  type Question,
+  type ExecutedQuery,
+  type RunHarnessOptions,
+  type GlossaryMatch,
+} from "../canonical-eval";
+
+const QUESTIONS_PATH = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "..",
+  "eval",
+  "canonical-questions",
+  "questions.yml",
+);
+
+describe("loadQuestions", () => {
+  test("loads the curated set without throwing", () => {
+    const questions = loadQuestions(QUESTIONS_PATH);
+    expect(questions.length).toBeGreaterThanOrEqual(20);
+  });
+
+  test("every question has a unique id", () => {
+    const questions = loadQuestions(QUESTIONS_PATH);
+    const ids = new Set(questions.map((q) => q.id));
+    expect(ids.size).toBe(questions.length);
+  });
+
+  test("ids follow the cq-NNN convention", () => {
+    const questions = loadQuestions(QUESTIONS_PATH);
+    for (const q of questions) {
+      expect(q.id).toMatch(/^cq-\d{3}$/);
+    }
+  });
+
+  test("every metric/pattern/virtual question carries the fields its mode needs", () => {
+    const questions = loadQuestions(QUESTIONS_PATH);
+    for (const q of questions) {
+      switch (q.mode) {
+        case "metric":
+          expect(q.metric_id).toBeTruthy();
+          break;
+        case "pattern":
+          expect(q.entity).toBeTruthy();
+          expect(q.pattern).toBeTruthy();
+          break;
+        case "virtual":
+          expect(q.entity).toBeTruthy();
+          expect(q.dimension).toBeTruthy();
+          expect(q.sql).toBeTruthy();
+          break;
+        case "glossary":
+          expect(q.term).toBeTruthy();
+          break;
+      }
+    }
+  });
+
+  test("covers every required category from the issue", () => {
+    const questions = loadQuestions(QUESTIONS_PATH);
+    const categories: Set<string> = new Set(questions.map((q) => q.category));
+    for (const required of [
+      "simple_metric",
+      "segmentation",
+      "join",
+      "timeseries",
+      "virtual_dimension",
+      "glossary",
+      "filtered_pattern",
+    ]) {
+      expect(categories.has(required)).toBe(true);
+    }
+  });
+
+  test("rejects a duplicate id", async () => {
+    // Use a temporary file with a forced duplicate.
+    const fs = await import("fs");
+    const os = await import("os");
+    const tmp = path.join(os.tmpdir(), `dup-${Date.now()}.yml`);
+    fs.writeFileSync(
+      tmp,
+      "version: '1.0'\nquestions:\n" +
+        "  - id: cq-001\n    category: simple_metric\n    question: a\n    mode: metric\n    metric_id: x\n    expect: {}\n" +
+        "  - id: cq-001\n    category: simple_metric\n    question: b\n    mode: metric\n    metric_id: y\n    expect: {}\n",
+    );
+    expect(() => loadQuestions(tmp)).toThrow(/Duplicate/);
+    fs.unlinkSync(tmp);
+  });
+});
+
+// ── compareMetricResult ──────────────────────────────────────────────────
+
+describe("compareMetricResult", () => {
+  const baseQuestion: Question = {
+    id: "cq-001",
+    category: "simple_metric",
+    question: "Test",
+    mode: "metric",
+    metric_id: "total_gmv",
+    expect: {
+      sql_pattern: ["SUM(total_cents)", "FROM orders"],
+      non_zero: true,
+    },
+  };
+
+  test("passes when SQL contains every required substring and value is non-zero", () => {
+    const executed: ExecutedQuery = {
+      sql: "SELECT SUM(total_cents) / 100.0 AS total_gmv FROM orders WHERE status != 'cancelled'",
+      columns: ["total_gmv"],
+      rows: [{ total_gmv: 12345.67 }],
+    };
+    expect(compareMetricResult(baseQuestion, executed).status).toBe("pass");
+  });
+
+  test("fails when an expected SQL substring is missing", () => {
+    const executed: ExecutedQuery = {
+      sql: "SELECT 42 AS total_gmv",
+      columns: ["total_gmv"],
+      rows: [{ total_gmv: 42 }],
+    };
+    const result = compareMetricResult(baseQuestion, executed);
+    expect(result.status).toBe("fail");
+    expect(result.detail).toMatch(/SUM\(total_cents\)/);
+  });
+
+  test("fails when non_zero is required and result is 0", () => {
+    const executed: ExecutedQuery = {
+      sql: "SELECT SUM(total_cents) / 100.0 AS total_gmv FROM orders",
+      columns: ["total_gmv"],
+      rows: [{ total_gmv: 0 }],
+    };
+    const result = compareMetricResult(baseQuestion, executed);
+    expect(result.status).toBe("fail");
+    expect(result.detail).toMatch(/non-zero/);
+  });
+
+  test("warns when SQL pattern matches but row count violates a soft bound", () => {
+    const segQ: Question = {
+      ...baseQuestion,
+      id: "cq-005",
+      expect: {
+        sql_pattern: ["GROUP BY"],
+        min_rows: 2,
+      },
+    };
+    const executed: ExecutedQuery = {
+      sql: "SELECT a, COUNT(*) FROM t GROUP BY a",
+      columns: ["a", "count"],
+      rows: [{ a: "x", count: 1 }],
+    };
+    const result = compareMetricResult(segQ, executed);
+    expect(result.status).toBe("warn");
+    expect(result.detail).toMatch(/min_rows/);
+  });
+
+  test("checks expected column is present", () => {
+    const q: Question = {
+      ...baseQuestion,
+      expect: { sql_pattern: ["SELECT"], column: "total_gmv" },
+    };
+    const ok: ExecutedQuery = {
+      sql: "SELECT 1 AS total_gmv",
+      columns: ["total_gmv"],
+      rows: [{ total_gmv: 1 }],
+    };
+    expect(compareMetricResult(q, ok).status).toBe("pass");
+
+    const bad: ExecutedQuery = {
+      sql: "SELECT 1 AS revenue",
+      columns: ["revenue"],
+      rows: [{ revenue: 1 }],
+    };
+    expect(compareMetricResult(q, bad).status).toBe("fail");
+  });
+});
+
+// ── compareGlossaryResult ────────────────────────────────────────────────
+
+describe("compareGlossaryResult", () => {
+  test("passes when ambiguous status with enough mappings", () => {
+    const q: Question = {
+      id: "cq-013",
+      category: "glossary",
+      question: "x",
+      mode: "glossary",
+      term: "revenue",
+      expect: { status: "ambiguous", mappings_min: 2 },
+    };
+    const result = compareGlossaryResult(q, [
+      {
+        term: "revenue",
+        status: "ambiguous",
+        possible_mappings: ["a", "b", "c"],
+      },
+    ]);
+    expect(result.status).toBe("pass");
+  });
+
+  test("fails when expected ambiguous but term is defined", () => {
+    const q: Question = {
+      id: "cq-013",
+      category: "glossary",
+      question: "x",
+      mode: "glossary",
+      term: "revenue",
+      expect: { status: "ambiguous" },
+    };
+    const result = compareGlossaryResult(q, [
+      { term: "revenue", status: "defined", possible_mappings: [] },
+    ]);
+    expect(result.status).toBe("fail");
+    expect(result.detail).toMatch(/expected.*ambiguous/i);
+  });
+
+  test("fails when no glossary term matches", () => {
+    const q: Question = {
+      id: "cq-013",
+      category: "glossary",
+      question: "x",
+      mode: "glossary",
+      term: "totally_unknown_term",
+      expect: { status: "ambiguous" },
+    };
+    const result = compareGlossaryResult(q, []);
+    expect(result.status).toBe("fail");
+    expect(result.detail).toMatch(/no glossary match/i);
+  });
+
+  test("fails when ambiguous but mappings count is too low", () => {
+    const q: Question = {
+      id: "cq-013",
+      category: "glossary",
+      question: "x",
+      mode: "glossary",
+      term: "revenue",
+      expect: { status: "ambiguous", mappings_min: 3 },
+    };
+    const result = compareGlossaryResult(q, [
+      { term: "revenue", status: "ambiguous", possible_mappings: ["a", "b"] },
+    ]);
+    expect(result.status).toBe("fail");
+    expect(result.detail).toMatch(/mapping/i);
+  });
+});
+
+// ── compareVirtualResult / comparePatternResult ──────────────────────────
+
+describe("compareVirtualResult / comparePatternResult", () => {
+  test("virtual mode passes when SQL executes and column is present", () => {
+    const q: Question = {
+      id: "cq-011",
+      category: "virtual_dimension",
+      question: "x",
+      mode: "virtual",
+      entity: "Orders",
+      dimension: "order_size_bucket",
+      sql: "SELECT 'Small' AS order_size_bucket, 10 AS c",
+      expect: { min_rows: 1, column: "order_size_bucket" },
+    };
+    const executed: ExecutedQuery = {
+      sql: "SELECT 'Small' AS order_size_bucket, 10 AS c",
+      columns: ["order_size_bucket", "c"],
+      rows: [{ order_size_bucket: "Small", c: 10 }],
+    };
+    expect(compareVirtualResult(q, executed).status).toBe("pass");
+  });
+
+  test("pattern mode requires every sql_pattern substring", () => {
+    const q: Question = {
+      id: "cq-016",
+      category: "filtered_pattern",
+      question: "x",
+      mode: "pattern",
+      entity: "Orders",
+      pattern: "orders_with_promotions",
+      expect: {
+        sql_pattern: ["WHERE status != 'cancelled'", "promotion_id IS NOT NULL"],
+      },
+    };
+    const ok: ExecutedQuery = {
+      sql: "SELECT promotion_id IS NOT NULL FROM orders WHERE status != 'cancelled'",
+      columns: ["promo_status"],
+      rows: [{ promo_status: "Promoted" }],
+    };
+    expect(comparePatternResult(q, ok).status).toBe("pass");
+    const missing: ExecutedQuery = {
+      sql: "SELECT 1 FROM orders",
+      columns: [],
+      rows: [],
+    };
+    expect(comparePatternResult(q, missing).status).toBe("fail");
+  });
+});
+
+// ── formatSummary ────────────────────────────────────────────────────────
+
+describe("formatSummary", () => {
+  test("renders X/N passing with category breakdown", () => {
+    const out = formatSummary([
+      {
+        question: { id: "cq-001", category: "simple_metric", mode: "metric" } as Question,
+        status: "pass",
+        detail: "ok",
+        sql: "SELECT 1",
+      },
+      {
+        question: { id: "cq-002", category: "simple_metric", mode: "metric" } as Question,
+        status: "fail",
+        detail: "boom",
+        sql: null,
+      },
+      {
+        question: { id: "cq-013", category: "glossary", mode: "glossary" } as Question,
+        status: "warn",
+        detail: "soft",
+        sql: null,
+      },
+    ]);
+    expect(out).toMatch(/1\/3 passing/);
+    expect(out).toMatch(/cq-001/);
+    expect(out).toMatch(/cq-002/);
+    expect(out).toMatch(/cq-013/);
+  });
+});
+
+// ── resolveQuestion / runHarness ─────────────────────────────────────────
+
+describe("resolveQuestion", () => {
+  function makeOpts(overrides: Partial<RunHarnessOptions>): RunHarnessOptions {
+    return {
+      findMetricSql: () => null,
+      findPatternSql: () => null,
+      searchGlossary: () => [],
+      executeSql: async () => ({ columns: [], rows: [] }),
+      ...overrides,
+    };
+  }
+
+  test("metric mode returns fail when metric is unknown", async () => {
+    const q: Question = {
+      id: "cq-099",
+      category: "simple_metric",
+      question: "x",
+      mode: "metric",
+      metric_id: "missing",
+      expect: { sql_pattern: ["FROM orders"] },
+    };
+    const r = await resolveQuestion(q, makeOpts({ findMetricSql: () => null }));
+    expect(r.status).toBe("fail");
+    expect(r.detail).toMatch(/unknown metric/);
+  });
+
+  test("metric mode dispatches sql + asserts patterns + non-zero", async () => {
+    const q: Question = {
+      id: "cq-001",
+      category: "simple_metric",
+      question: "x",
+      mode: "metric",
+      metric_id: "total_gmv",
+      expect: { sql_pattern: ["FROM orders"], non_zero: true, column: "v" },
+    };
+    const r = await resolveQuestion(
+      q,
+      makeOpts({
+        findMetricSql: () => "SELECT 42 AS v FROM orders",
+        executeSql: async () => ({ columns: ["v"], rows: [{ v: 42 }] }),
+      }),
+    );
+    expect(r.status).toBe("pass");
+    expect(r.sql).toContain("FROM orders");
+  });
+
+  test("pattern mode fails when entity/pattern unknown", async () => {
+    const q: Question = {
+      id: "cq-016",
+      category: "filtered_pattern",
+      question: "x",
+      mode: "pattern",
+      entity: "Orders",
+      pattern: "missing",
+      expect: { sql_pattern: [] },
+    };
+    const r = await resolveQuestion(q, makeOpts({ findPatternSql: () => null }));
+    expect(r.status).toBe("fail");
+    expect(r.detail).toMatch(/unknown query_pattern/);
+  });
+
+  test("virtual mode runs the inline SQL straight from the question", async () => {
+    const q: Question = {
+      id: "cq-011",
+      category: "virtual_dimension",
+      question: "x",
+      mode: "virtual",
+      entity: "Orders",
+      dimension: "order_size_bucket",
+      sql: "SELECT 'Small' AS order_size_bucket",
+      expect: { column: "order_size_bucket" },
+    };
+    const r = await resolveQuestion(
+      q,
+      makeOpts({
+        executeSql: async () => ({
+          columns: ["order_size_bucket"],
+          rows: [{ order_size_bucket: "Small" }],
+        }),
+      }),
+    );
+    expect(r.status).toBe("pass");
+  });
+
+  test("glossary mode hits the disambiguation contract", async () => {
+    const q: Question = {
+      id: "cq-013",
+      category: "glossary",
+      question: "x",
+      mode: "glossary",
+      term: "revenue",
+      expect: { status: "ambiguous", mappings_min: 2 },
+    };
+    const matches: GlossaryMatch[] = [
+      { term: "revenue", status: "ambiguous", possible_mappings: ["a", "b"] },
+    ];
+    const r = await resolveQuestion(q, makeOpts({ searchGlossary: () => matches }));
+    expect(r.status).toBe("pass");
+  });
+
+  test("execute errors are surfaced as fail (not thrown)", async () => {
+    const q: Question = {
+      id: "cq-001",
+      category: "simple_metric",
+      question: "x",
+      mode: "metric",
+      metric_id: "total_gmv",
+      expect: { sql_pattern: [] },
+    };
+    const r = await resolveQuestion(
+      q,
+      makeOpts({
+        findMetricSql: () => "SELECT 1",
+        executeSql: async () => {
+          throw new Error("connection refused");
+        },
+      }),
+    );
+    expect(r.status).toBe("fail");
+    expect(r.detail).toMatch(/connection refused/);
+  });
+});
+
+describe("runHarness", () => {
+  test("runs every question through resolveQuestion with the same opts", async () => {
+    const sqlFor: Record<string, string> = {
+      total_gmv: "SELECT 1 AS v FROM orders",
+      total_customers: "SELECT 1 AS v FROM customers",
+      aov: "SELECT 1 AS v FROM orders",
+    };
+    let calls = 0;
+    const results = await runHarness({
+      findMetricSql: (id) => {
+        calls++;
+        return sqlFor[id] ?? "SELECT 1 AS v";
+      },
+      findPatternSql: (entity, pattern) => `SELECT 1 AS v -- ${entity}/${pattern}`,
+      searchGlossary: (term) => [
+        { term, status: "ambiguous", possible_mappings: ["a.b", "c.d"] },
+      ],
+      executeSql: async (sql) => {
+        // Every test SQL returns one synthetic row that satisfies the loose
+        // expectations on the curated set. We mirror columns from the SQL.
+        if (sql.toLowerCase().includes("from inventory_levels")) {
+          return { columns: ["stock_status"], rows: [{ stock_status: "Adequate" }] };
+        }
+        if (sql.toLowerCase().includes("seller_id is null")) {
+          return { columns: ["channel"], rows: [{ channel: "DTC" }] };
+        }
+        return { columns: ["v", "month", "channel", "carrier", "promo_status", "refund_rate", "return_rate", "order_size_bucket", "price_tier", "stock_status"], rows: [{ v: 42, month: "2024-01", channel: "DTC", carrier: "UPS", promo_status: "Promoted", refund_rate: 1, return_rate: 1, order_size_bucket: "Small", price_tier: "Budget", stock_status: "Adequate" }] };
+      },
+    });
+    expect(results.length).toBeGreaterThanOrEqual(20);
+    expect(calls).toBeGreaterThan(0);
+  });
+});

--- a/packages/cli/bin/atlas.ts
+++ b/packages/cli/bin/atlas.ts
@@ -199,6 +199,11 @@ async function main() {
     return handleEval(args);
   }
 
+  if (command === "canonical-eval") {
+    const { handleCanonicalEval } = await import("./canonical-eval-run");
+    return handleCanonicalEval(args);
+  }
+
   if (command === "benchmark") {
     const { handleBenchmark } = await import("./benchmark");
     return handleBenchmark(args);

--- a/packages/cli/bin/canonical-eval-run.ts
+++ b/packages/cli/bin/canonical-eval-run.ts
@@ -257,6 +257,8 @@ async function runWithAgent(
           case "virtual":
             result = compareVirtualResult(q, executed);
             break;
+          default:
+            throw new Error(`unreachable mode: ${q.mode satisfies never}`);
         }
       }
     } catch (err) {
@@ -301,7 +303,6 @@ export async function handleCanonicalEval(args: string[]): Promise<void> {
     // — same hook used by bin/eval.ts. seedDemoPostgres takes a connection
     // string, not a schema; only `ecommerce` ships today (#2021).
     await seedDemoPostgres(connStr);
-    process.env.ATLAS_DATASOURCE_URL = connStr;
 
     // Reset cached connection / whitelist / explore-backend state so the
     // freshly installed semantic layer is re-resolved.

--- a/packages/cli/bin/canonical-eval-run.ts
+++ b/packages/cli/bin/canonical-eval-run.ts
@@ -1,0 +1,353 @@
+/**
+ * CLI driver for the canonical-question eval harness.
+ *
+ * Usage:
+ *   bun run atlas -- canonical-eval                 # deterministic mode (default)
+ *   bun run atlas -- canonical-eval --llm           # full agent loop, snapshot SQL
+ *   bun run atlas -- canonical-eval --schema ecommerce
+ *
+ * Wires the pure runner core (`canonical-eval.ts`) up to:
+ *   - Real semantic-layer reads via `@atlas/api/lib/semantic/lookups`
+ *   - Real Postgres execution via `@atlas/api/lib/db/connection`
+ *
+ * The deterministic path mirrors what the typed MCP `runMetric` tool does:
+ *   findMetricById(id) → executeSQL(sql). No LLM. No nondeterminism.
+ *
+ * The optional `--llm` path runs the full agent loop and asserts on the
+ * SQL pattern of the last `executeSQL` call. This is the "snapshot" path
+ * called out in the issue acceptance.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import * as yaml from "js-yaml";
+import { getFlag, seedDemoPostgres } from "./atlas";
+import {
+  loadQuestions,
+  formatSummary,
+  resolveQuestion,
+  compareMetricResult,
+  comparePatternResult,
+  compareVirtualResult,
+  compareGlossaryResult,
+  DEFAULT_QUESTIONS_PATH,
+  type GlossaryMatch,
+  type QuestionResult,
+  type RunHarnessOptions,
+} from "./canonical-eval";
+
+const VALID_SCHEMAS = ["ecommerce"] as const;
+type ValidSchema = (typeof VALID_SCHEMAS)[number];
+
+const SEMANTIC_DIR = path.resolve("semantic");
+// The canonical NovaMart semantic layer ships with the demo seed at
+// packages/cli/data/seeds/<schema>/semantic. The auto-generated catalog
+// at eval/schemas/<schema> is for the LLM benchmark (`atlas eval`); it
+// uses different metric ids and is not the right ground truth here.
+const SCHEMAS_DIR = path.resolve(
+  "packages",
+  "cli",
+  "data",
+  "seeds",
+);
+const BACKUP_DIR = path.resolve(".semantic-backup-canonical-eval");
+
+interface CanonicalEvalOptions {
+  schema: ValidSchema;
+  questionsPath: string;
+  llm: boolean;
+  json: boolean;
+}
+
+function parseOptions(args: string[]): CanonicalEvalOptions {
+  const schemaArg = getFlag(args, "--schema") ?? "ecommerce";
+  if (!(VALID_SCHEMAS as readonly string[]).includes(schemaArg)) {
+    throw new Error(
+      `Invalid --schema "${schemaArg}". Valid: ${VALID_SCHEMAS.join(", ")}`,
+    );
+  }
+  const questionsPath = getFlag(args, "--questions") ?? DEFAULT_QUESTIONS_PATH;
+  const llm = args.includes("--llm");
+  const json = args.includes("--json");
+  return {
+    schema: schemaArg as ValidSchema,
+    questionsPath,
+    llm,
+    json,
+  };
+}
+
+// ── Semantic-layer install/restore ──────────────────────────────────────
+
+function backupSemanticLayer(): void {
+  if (fs.existsSync(BACKUP_DIR)) {
+    fs.rmSync(BACKUP_DIR, { recursive: true });
+  }
+  if (fs.existsSync(SEMANTIC_DIR)) {
+    try {
+      fs.cpSync(SEMANTIC_DIR, BACKUP_DIR, { recursive: true });
+    } catch (err) {
+      throw new Error(
+        `Failed to backup semantic layer before canonical eval: ${err instanceof Error ? err.message : String(err)}. ` +
+          `Refusing to proceed — your semantic/ directory would be at risk.`,
+        { cause: err },
+      );
+    }
+  }
+}
+
+function restoreSemanticLayer(): void {
+  if (!fs.existsSync(BACKUP_DIR)) return;
+  try {
+    if (fs.existsSync(SEMANTIC_DIR)) {
+      fs.rmSync(SEMANTIC_DIR, { recursive: true });
+    }
+    fs.cpSync(BACKUP_DIR, SEMANTIC_DIR, { recursive: true });
+    fs.rmSync(BACKUP_DIR, { recursive: true });
+  } catch (err) {
+    process.stderr.write(
+      `\nCRITICAL: Failed to restore semantic layer: ${err instanceof Error ? err.message : String(err)}\n` +
+        `Your original semantic layer was backed up to: ${BACKUP_DIR}\n` +
+        `To restore manually: rm -rf ${SEMANTIC_DIR} && cp -r ${BACKUP_DIR} ${SEMANTIC_DIR}\n`,
+    );
+  }
+}
+
+function installSchemaSemanticLayer(schema: ValidSchema): void {
+  const srcDir = path.join(SCHEMAS_DIR, schema, "semantic");
+  if (!fs.existsSync(srcDir)) {
+    throw new Error(
+      `Canonical semantic layer not found for schema "${schema}" at ${srcDir}. ` +
+        `Expected packages/cli/data/seeds/<schema>/semantic to ship with the demo seed.`,
+    );
+  }
+  if (fs.existsSync(SEMANTIC_DIR)) {
+    fs.rmSync(SEMANTIC_DIR, { recursive: true });
+  }
+  fs.cpSync(srcDir, SEMANTIC_DIR, { recursive: true });
+}
+
+// ── Pattern / entity lookup ─────────────────────────────────────────────
+
+interface QueryPattern {
+  name: string;
+  sql: string;
+}
+
+/**
+ * Find a `query_patterns[*].sql` by entity name + pattern name. Walks the
+ * semantic root directly so it doesn't depend on the in-process scanner —
+ * the deterministic harness is meant to behave like a fresh load every
+ * time.
+ */
+function findPatternSqlFromDisk(
+  entity: string,
+  patternName: string,
+  semanticRoot: string,
+): string | null {
+  const entitiesDir = path.join(semanticRoot, "entities");
+  if (!fs.existsSync(entitiesDir)) return null;
+  for (const file of fs.readdirSync(entitiesDir)) {
+    if (!file.endsWith(".yml") && !file.endsWith(".yaml")) continue;
+    const filePath = path.join(entitiesDir, file);
+    const raw = yaml.load(fs.readFileSync(filePath, "utf-8"));
+    if (!raw || typeof raw !== "object") continue;
+    const r = raw as Record<string, unknown>;
+    const matchesEntity =
+      (typeof r.name === "string" && r.name === entity) ||
+      (typeof r.table === "string" && r.table === entity);
+    if (!matchesEntity) continue;
+    const patterns = r.query_patterns;
+    if (!Array.isArray(patterns)) return null;
+    for (const p of patterns as QueryPattern[]) {
+      if (p && typeof p === "object" && p.name === patternName) {
+        return typeof p.sql === "string" ? p.sql : null;
+      }
+    }
+    return null;
+  }
+  return null;
+}
+
+// ── Wiring (deterministic mode) ──────────────────────────────────────────
+
+async function runDeterministic(
+  options: CanonicalEvalOptions,
+): Promise<QuestionResult[]> {
+  // Lazy imports so that --llm / --help paths don't pull the full API runtime.
+  const lookups = await import("@atlas/api/lib/semantic/lookups");
+  const { connections } = await import("@atlas/api/lib/db/connection");
+
+  const harnessOpts: RunHarnessOptions = {
+    questionsPath: options.questionsPath,
+    findMetricSql: (id) => {
+      const m = lookups.findMetricById(id);
+      return m ? m.sql : null;
+    },
+    findPatternSql: (entity, pattern) =>
+      findPatternSqlFromDisk(entity, pattern, SEMANTIC_DIR),
+    searchGlossary: (term): readonly GlossaryMatch[] => {
+      const matches = lookups.searchGlossary(term);
+      return matches.map((m) => ({
+        term: m.term,
+        status: m.status,
+        possible_mappings: m.possible_mappings,
+      }));
+    },
+    executeSql: async (sql) => {
+      const db = connections.getDefault();
+      const result = await db.query(sql, 60_000);
+      return { columns: result.columns, rows: result.rows };
+    },
+  };
+
+  const questions = loadQuestions(options.questionsPath);
+  const results: QuestionResult[] = [];
+  for (const q of questions) {
+    process.stdout.write(`  ${q.id} ${q.category} ... `);
+    const r = await resolveQuestion(q, harnessOpts);
+    process.stdout.write(`${r.status}\n`);
+    results.push(r);
+  }
+  return results;
+}
+
+// ── Wiring (LLM mode) ────────────────────────────────────────────────────
+
+async function runWithAgent(
+  options: CanonicalEvalOptions,
+): Promise<QuestionResult[]> {
+  const { executeAgentQuery } = await import("@atlas/api/lib/agent-query");
+  const lookups = await import("@atlas/api/lib/semantic/lookups");
+
+  const questions = loadQuestions(options.questionsPath);
+  const results: QuestionResult[] = [];
+
+  for (const q of questions) {
+    process.stdout.write(`  ${q.id} ${q.category} (--llm) ... `);
+    let result: QuestionResult;
+    try {
+      if (q.mode === "glossary") {
+        // For glossary, the agent should refuse / disambiguate. We assert
+        // that the disambiguation contract is honored by checking the
+        // semantic-layer state directly — same as deterministic.
+        const matches = lookups.searchGlossary(q.term ?? "").map((m) => ({
+          term: m.term,
+          status: m.status,
+          possible_mappings: m.possible_mappings,
+        }));
+        result = compareGlossaryResult(q, matches);
+      } else {
+        const agent = await executeAgentQuery(q.question);
+        const lastSql = agent.sql.length > 0 ? agent.sql[agent.sql.length - 1] : "";
+        const lastData =
+          agent.data.length > 0 ? agent.data[agent.data.length - 1] : null;
+        const executed = {
+          sql: lastSql,
+          columns: lastData?.columns ?? [],
+          rows: lastData?.rows ?? [],
+        };
+        switch (q.mode) {
+          case "metric":
+            result = compareMetricResult(q, executed);
+            break;
+          case "pattern":
+            result = comparePatternResult(q, executed);
+            break;
+          case "virtual":
+            result = compareVirtualResult(q, executed);
+            break;
+        }
+      }
+    } catch (err) {
+      result = {
+        question: q,
+        status: "fail",
+        detail: `agent error: ${err instanceof Error ? err.message : String(err)}`,
+        sql: null,
+      };
+    }
+    process.stdout.write(`${result.status}\n`);
+    results.push(result);
+  }
+  return results;
+}
+
+// ── Entrypoint ───────────────────────────────────────────────────────────
+
+export async function handleCanonicalEval(args: string[]): Promise<void> {
+  const options = parseOptions(args);
+
+  const connStr = process.env.ATLAS_DATASOURCE_URL;
+  if (!connStr) {
+    process.stderr.write(
+      "Error: ATLAS_DATASOURCE_URL is required for canonical-eval.\n" +
+        "Tip: bun run db:up && export ATLAS_DATASOURCE_URL=postgres://atlas:atlas@localhost:5433/atlas_demo\n",
+    );
+    process.exit(1);
+  }
+
+  process.stdout.write(
+    `Atlas canonical-question eval — schema=${options.schema} mode=${options.llm ? "llm" : "deterministic"}\n`,
+  );
+
+  // Stage the semantic layer for the chosen schema, identical to bin/eval.ts.
+  backupSemanticLayer();
+  let exitCode = 0;
+  try {
+    installSchemaSemanticLayer(options.schema);
+
+    // Seed the demo Postgres before running so the harness is self-contained
+    // — same hook used by bin/eval.ts. seedDemoPostgres takes a connection
+    // string, not a schema; only `ecommerce` ships today (#2021).
+    await seedDemoPostgres(connStr);
+    process.env.ATLAS_DATASOURCE_URL = connStr;
+
+    // Reset cached connection / whitelist / explore-backend state so the
+    // freshly installed semantic layer is re-resolved.
+    const { connections } = await import("@atlas/api/lib/db/connection");
+    const { _resetWhitelists } = await import("@atlas/api/lib/semantic");
+    const { invalidateExploreBackend } = await import(
+      "@atlas/api/lib/tools/explore"
+    );
+    connections._reset();
+    _resetWhitelists();
+    invalidateExploreBackend();
+
+    const results = options.llm
+      ? await runWithAgent(options)
+      : await runDeterministic(options);
+
+    if (options.json) {
+      process.stdout.write(
+        `${JSON.stringify(
+          {
+            schema: options.schema,
+            mode: options.llm ? "llm" : "deterministic",
+            total: results.length,
+            passing: results.filter((r) => r.status === "pass").length,
+            warning: results.filter((r) => r.status === "warn").length,
+            failing: results.filter((r) => r.status === "fail").length,
+            results: results.map((r) => ({
+              id: r.question.id,
+              category: r.question.category,
+              question: r.question.question,
+              status: r.status,
+              detail: r.detail,
+              sql: r.sql,
+            })),
+          },
+          null,
+          2,
+        )}\n`,
+      );
+    } else {
+      process.stdout.write(`\n${formatSummary(results)}\n`);
+    }
+
+    if (results.some((r) => r.status === "fail")) exitCode = 1;
+  } finally {
+    restoreSemanticLayer();
+  }
+  process.exit(exitCode);
+}

--- a/packages/cli/bin/canonical-eval-run.ts
+++ b/packages/cli/bin/canonical-eval-run.ts
@@ -32,6 +32,7 @@ import {
   compareGlossaryResult,
   DEFAULT_QUESTIONS_PATH,
   type GlossaryMatch,
+  type Question,
   type QuestionResult,
   type RunHarnessOptions,
 } from "./canonical-eval";
@@ -169,6 +170,39 @@ function findPatternSqlFromDisk(
   return null;
 }
 
+// Map a `lookups.searchGlossary` result to the wire shape the harness
+// comparator expects. Shared by deterministic + LLM paths.
+type LookupsModule = typeof import("@atlas/api/lib/semantic/lookups");
+
+function toGlossaryMatches(
+  lookups: LookupsModule,
+  term: string,
+): readonly GlossaryMatch[] {
+  return lookups.searchGlossary(term).map((m) => ({
+    term: m.term,
+    status: m.status,
+    possible_mappings: m.possible_mappings,
+  }));
+}
+
+// Iterate questions printing a per-question progress line. The resolver
+// closure isolates the deterministic-vs-LLM behavioral difference; this
+// helper just owns the I/O and the result accumulator.
+async function evalEachQuestion(
+  questions: readonly Question[],
+  label: string,
+  resolve: (q: Question) => Promise<QuestionResult>,
+): Promise<QuestionResult[]> {
+  const results: QuestionResult[] = [];
+  for (const q of questions) {
+    process.stdout.write(`  ${q.id} ${q.category}${label} ... `);
+    const r = await resolve(q);
+    process.stdout.write(`${r.status}\n`);
+    results.push(r);
+  }
+  return results;
+}
+
 // ── Wiring (deterministic mode) ──────────────────────────────────────────
 
 async function runDeterministic(
@@ -180,36 +214,19 @@ async function runDeterministic(
 
   const harnessOpts: RunHarnessOptions = {
     questionsPath: options.questionsPath,
-    findMetricSql: (id) => {
-      const m = lookups.findMetricById(id);
-      return m ? m.sql : null;
-    },
+    findMetricSql: (id) => lookups.findMetricById(id)?.sql ?? null,
     findPatternSql: (entity, pattern) =>
       findPatternSqlFromDisk(entity, pattern, SEMANTIC_DIR),
-    searchGlossary: (term): readonly GlossaryMatch[] => {
-      const matches = lookups.searchGlossary(term);
-      return matches.map((m) => ({
-        term: m.term,
-        status: m.status,
-        possible_mappings: m.possible_mappings,
-      }));
-    },
+    searchGlossary: (term) => toGlossaryMatches(lookups, term),
     executeSql: async (sql) => {
       const db = connections.getDefault();
-      const result = await db.query(sql, 60_000);
-      return { columns: result.columns, rows: result.rows };
+      const { columns, rows } = await db.query(sql, 60_000);
+      return { columns, rows };
     },
   };
 
   const questions = loadQuestions(options.questionsPath);
-  const results: QuestionResult[] = [];
-  for (const q of questions) {
-    process.stdout.write(`  ${q.id} ${q.category} ... `);
-    const r = await resolveQuestion(q, harnessOpts);
-    process.stdout.write(`${r.status}\n`);
-    results.push(r);
-  }
-  return results;
+  return evalEachQuestion(questions, "", (q) => resolveQuestion(q, harnessOpts));
 }
 
 // ── Wiring (LLM mode) ────────────────────────────────────────────────────
@@ -221,58 +238,42 @@ async function runWithAgent(
   const lookups = await import("@atlas/api/lib/semantic/lookups");
 
   const questions = loadQuestions(options.questionsPath);
-  const results: QuestionResult[] = [];
-
-  for (const q of questions) {
-    process.stdout.write(`  ${q.id} ${q.category} (--llm) ... `);
-    let result: QuestionResult;
+  return evalEachQuestion(questions, " (--llm)", async (q) => {
     try {
+      // For glossary, the agent should refuse / disambiguate. We assert
+      // that the disambiguation contract is honored by checking the
+      // semantic-layer state directly — same as deterministic.
       if (q.mode === "glossary") {
-        // For glossary, the agent should refuse / disambiguate. We assert
-        // that the disambiguation contract is honored by checking the
-        // semantic-layer state directly — same as deterministic.
-        const matches = lookups.searchGlossary(q.term ?? "").map((m) => ({
-          term: m.term,
-          status: m.status,
-          possible_mappings: m.possible_mappings,
-        }));
-        result = compareGlossaryResult(q, matches);
-      } else {
-        const agent = await executeAgentQuery(q.question);
-        const lastSql = agent.sql.length > 0 ? agent.sql[agent.sql.length - 1] : "";
-        const lastData =
-          agent.data.length > 0 ? agent.data[agent.data.length - 1] : null;
-        const executed = {
-          sql: lastSql,
-          columns: lastData?.columns ?? [],
-          rows: lastData?.rows ?? [],
-        };
-        switch (q.mode) {
-          case "metric":
-            result = compareMetricResult(q, executed);
-            break;
-          case "pattern":
-            result = comparePatternResult(q, executed);
-            break;
-          case "virtual":
-            result = compareVirtualResult(q, executed);
-            break;
-          default:
-            throw new Error(`unreachable mode: ${q.mode satisfies never}`);
-        }
+        return compareGlossaryResult(q, toGlossaryMatches(lookups, q.term ?? ""));
+      }
+
+      const agent = await executeAgentQuery(q.question);
+      const lastSql = agent.sql[agent.sql.length - 1] ?? "";
+      const lastData = agent.data[agent.data.length - 1] ?? null;
+      const executed = {
+        sql: lastSql,
+        columns: lastData?.columns ?? [],
+        rows: lastData?.rows ?? [],
+      };
+      switch (q.mode) {
+        case "metric":
+          return compareMetricResult(q, executed);
+        case "pattern":
+          return comparePatternResult(q, executed);
+        case "virtual":
+          return compareVirtualResult(q, executed);
+        default:
+          throw new Error(`unreachable mode: ${q.mode satisfies never}`);
       }
     } catch (err) {
-      result = {
+      return {
         question: q,
         status: "fail",
         detail: `agent error: ${err instanceof Error ? err.message : String(err)}`,
         sql: null,
       };
     }
-    process.stdout.write(`${result.status}\n`);
-    results.push(result);
-  }
-  return results;
+  });
 }
 
 // ── Entrypoint ───────────────────────────────────────────────────────────

--- a/packages/cli/bin/canonical-eval-run.ts
+++ b/packages/cli/bin/canonical-eval-run.ts
@@ -32,6 +32,7 @@ import {
   compareGlossaryResult,
   DEFAULT_QUESTIONS_PATH,
   type GlossaryMatch,
+  type GlossaryStatus,
   type Question,
   type QuestionResult,
   type RunHarnessOptions,
@@ -68,6 +69,12 @@ function parseOptions(args: string[]): CanonicalEvalOptions {
     );
   }
   const questionsPath = getFlag(args, "--questions") ?? DEFAULT_QUESTIONS_PATH;
+  // Validate up front, before any destructive setup (semantic-layer backup,
+  // demo seed). A typo in --questions used to surface as a confusing error
+  // partway through a partially-staged run.
+  if (!fs.existsSync(questionsPath)) {
+    throw new Error(`--questions file not found: ${questionsPath}`);
+  }
   const llm = args.includes("--llm");
   const json = args.includes("--json");
   return {
@@ -97,20 +104,29 @@ function backupSemanticLayer(): void {
   }
 }
 
-function restoreSemanticLayer(): void {
-  if (!fs.existsSync(BACKUP_DIR)) return;
+/**
+ * Restore the user's original semantic layer from the backup made by
+ * `backupSemanticLayer`. Returns `true` on success, `false` on failure —
+ * the caller MUST surface a non-zero exit code on failure so a user
+ * doesn't see "all green" output while their `semantic/` directory is
+ * gone.
+ */
+function restoreSemanticLayer(): boolean {
+  if (!fs.existsSync(BACKUP_DIR)) return true;
   try {
     if (fs.existsSync(SEMANTIC_DIR)) {
       fs.rmSync(SEMANTIC_DIR, { recursive: true });
     }
     fs.cpSync(BACKUP_DIR, SEMANTIC_DIR, { recursive: true });
     fs.rmSync(BACKUP_DIR, { recursive: true });
+    return true;
   } catch (err) {
     process.stderr.write(
       `\nCRITICAL: Failed to restore semantic layer: ${err instanceof Error ? err.message : String(err)}\n` +
         `Your original semantic layer was backed up to: ${BACKUP_DIR}\n` +
         `To restore manually: rm -rf ${SEMANTIC_DIR} && cp -r ${BACKUP_DIR} ${SEMANTIC_DIR}\n`,
     );
+    return false;
   }
 }
 
@@ -130,11 +146,6 @@ function installSchemaSemanticLayer(schema: ValidSchema): void {
 
 // ── Pattern / entity lookup ─────────────────────────────────────────────
 
-interface QueryPattern {
-  name: string;
-  sql: string;
-}
-
 /**
  * Find a `query_patterns[*].sql` by entity name + pattern name. Walks the
  * semantic root directly so it doesn't depend on the in-process scanner —
@@ -151,8 +162,24 @@ function findPatternSqlFromDisk(
   for (const file of fs.readdirSync(entitiesDir)) {
     if (!file.endsWith(".yml") && !file.endsWith(".yaml")) continue;
     const filePath = path.join(entitiesDir, file);
-    const raw = yaml.load(fs.readFileSync(filePath, "utf-8"));
-    if (!raw || typeof raw !== "object") continue;
+    let raw: unknown;
+    try {
+      raw = yaml.load(fs.readFileSync(filePath, "utf-8"));
+    } catch (err) {
+      // Re-throw with file context so a malformed entity YAML is debuggable
+      // — yaml.load's default error references neither the file nor the
+      // calling harness.
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to parse semantic entity ${filePath}: ${msg}`, {
+        cause: err,
+      });
+    }
+    if (!raw || typeof raw !== "object") {
+      process.stderr.write(
+        `[canonical-eval] WARN: skipping ${filePath} — top-level value is not an object\n`,
+      );
+      continue;
+    }
     const r = raw as Record<string, unknown>;
     const matchesEntity =
       (typeof r.name === "string" && r.name === entity) ||
@@ -160,9 +187,14 @@ function findPatternSqlFromDisk(
     if (!matchesEntity) continue;
     const patterns = r.query_patterns;
     if (!Array.isArray(patterns)) return null;
-    for (const p of patterns as QueryPattern[]) {
-      if (p && typeof p === "object" && p.name === patternName) {
-        return typeof p.sql === "string" ? p.sql : null;
+    // Duck-type each pattern entry — the YAML is operator-authored, so
+    // never trust the shape. The previous `as QueryPattern[]` cast was a
+    // lie that hid malformed entries.
+    for (const p of patterns) {
+      if (!p || typeof p !== "object") continue;
+      const pp = p as { name?: unknown; sql?: unknown };
+      if (typeof pp.name === "string" && pp.name === patternName) {
+        return typeof pp.sql === "string" ? pp.sql : null;
       }
     }
     return null;
@@ -171,8 +203,17 @@ function findPatternSqlFromDisk(
 }
 
 // Map a `lookups.searchGlossary` result to the wire shape the harness
-// comparator expects. Shared by deterministic + LLM paths.
+// comparator expects. Shared by deterministic + LLM paths. Upstream
+// `status` is typed `string | null` (the YAML is operator-authored) — we
+// narrow at the boundary to the harness's `GlossaryStatus | null`, mapping
+// any unrecognised value to `null` so the comparator never asserts on a
+// status it doesn't understand.
 type LookupsModule = typeof import("@atlas/api/lib/semantic/lookups");
+
+function narrowGlossaryStatus(value: string | null): GlossaryStatus | null {
+  if (value === "defined" || value === "ambiguous") return value;
+  return null;
+}
 
 function toGlossaryMatches(
   lookups: LookupsModule,
@@ -180,7 +221,7 @@ function toGlossaryMatches(
 ): readonly GlossaryMatch[] {
   return lookups.searchGlossary(term).map((m) => ({
     term: m.term,
-    status: m.status,
+    status: narrowGlossaryStatus(m.status),
     possible_mappings: m.possible_mappings,
   }));
 }
@@ -239,39 +280,66 @@ async function runWithAgent(
 
   const questions = loadQuestions(options.questionsPath);
   return evalEachQuestion(questions, " (--llm)", async (q) => {
-    try {
-      // For glossary, the agent should refuse / disambiguate. We assert
-      // that the disambiguation contract is honored by checking the
-      // semantic-layer state directly — same as deterministic.
-      if (q.mode === "glossary") {
-        return compareGlossaryResult(q, toGlossaryMatches(lookups, q.term ?? ""));
-      }
+    // Glossary mode never invokes the agent — we assert the
+    // disambiguation contract by checking semantic-layer state directly.
+    if (q.mode === "glossary") {
+      return compareGlossaryResult(q, toGlossaryMatches(lookups, q.term ?? ""));
+    }
 
-      const agent = await executeAgentQuery(q.question);
-      const lastSql = agent.sql[agent.sql.length - 1] ?? "";
-      const lastData = agent.data[agent.data.length - 1] ?? null;
-      const executed = {
-        sql: lastSql,
-        columns: lastData?.columns ?? [],
-        rows: lastData?.rows ?? [],
-      };
-      switch (q.mode) {
-        case "metric":
-          return compareMetricResult(q, executed);
-        case "pattern":
-          return comparePatternResult(q, executed);
-        case "virtual":
-          return compareVirtualResult(q, executed);
-        default:
-          throw new Error(`unreachable mode: ${q.mode satisfies never}`);
-      }
+    // Narrow the try/catch to ONLY the agent invocation. Comparator
+    // throws + the unreachable-mode default below are harness bugs (not
+    // eval failures) and should propagate so they're visible.
+    let agent;
+    try {
+      agent = await executeAgentQuery(q.question);
     } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
       return {
         question: q,
         status: "fail",
-        detail: `agent error: ${err instanceof Error ? err.message : String(err)}`,
+        detail:
+          `agent error: ${msg}. ` +
+          `Tip: verify ATLAS_DATASOURCE_URL is reachable and the configured model provider is responsive.`,
         sql: null,
       };
+    }
+
+    const lastSql = agent.sql[agent.sql.length - 1] ?? "";
+    const lastData = agent.data[agent.data.length - 1] ?? null;
+
+    // Hard-fail when the agent never executed SQL or returned no rows.
+    // Without this guard the executed shape `{ sql: "", columns: [], rows: [] }`
+    // falls through to the comparators which return pass/warn depending
+    // on whether `min_rows` is set — masking a legitimate LLM failure as
+    // a green run.
+    if (agent.sql.length === 0 || agent.data.length === 0) {
+      return {
+        question: q,
+        status: "fail",
+        detail:
+          agent.sql.length === 0
+            ? "agent did not execute any SQL"
+            : "agent executed SQL but returned no result rows",
+        sql: lastSql || null,
+      };
+    }
+
+    const executed = {
+      sql: lastSql,
+      columns: lastData?.columns ?? [],
+      rows: lastData?.rows ?? [],
+    };
+    switch (q.mode) {
+      case "metric":
+        return compareMetricResult(q, executed);
+      case "pattern":
+        return comparePatternResult(q, executed);
+      case "virtual":
+        return compareVirtualResult(q, executed);
+      default: {
+        const _exhaustive: never = q.mode;
+        throw new Error(`unreachable mode: ${String(_exhaustive)}`);
+      }
     }
   });
 }
@@ -303,10 +371,22 @@ export async function handleCanonicalEval(args: string[]): Promise<void> {
     // Seed the demo Postgres before running so the harness is self-contained
     // — same hook used by bin/eval.ts. seedDemoPostgres takes a connection
     // string, not a schema; only `ecommerce` ships today (#2021).
-    await seedDemoPostgres(connStr);
+    try {
+      await seedDemoPostgres(connStr);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `\nError: failed to seed demo Postgres: ${msg}\n` +
+          `Tip: bun run db:up && export ATLAS_DATASOURCE_URL=postgres://atlas:atlas@localhost:5433/atlas_demo\n`,
+      );
+      exitCode = 1;
+      return;
+    }
 
     // Reset cached connection / whitelist / explore-backend state so the
-    // freshly installed semantic layer is re-resolved.
+    // freshly installed semantic layer is re-resolved. `connections._reset()`
+    // is intentionally synchronous — it queues async pool closes via
+    // `.catch()` handlers (verified in lib/db/connection.ts).
     const { connections } = await import("@atlas/api/lib/db/connection");
     const { _resetWhitelists } = await import("@atlas/api/lib/semantic");
     const { invalidateExploreBackend } = await import(
@@ -349,7 +429,12 @@ export async function handleCanonicalEval(args: string[]): Promise<void> {
 
     if (results.some((r) => r.status === "fail")) exitCode = 1;
   } finally {
-    restoreSemanticLayer();
+    // Surface restore failure via the exit code — silently swallowing it
+    // would let a developer see an "all green" run while their original
+    // semantic/ directory is gone. Use exit 2 so it's distinguishable from
+    // a normal eval failure (exit 1).
+    const restored = restoreSemanticLayer();
+    if (!restored) exitCode = Math.max(exitCode, 2);
   }
   process.exit(exitCode);
 }

--- a/packages/cli/bin/canonical-eval.ts
+++ b/packages/cli/bin/canonical-eval.ts
@@ -249,151 +249,87 @@ function checkNonZero(
   return null;
 }
 
-/** Generic comparator used by metric / pattern / virtual modes. */
+/**
+ * Generic comparator used by metric / pattern / virtual modes. The three
+ * exported `compare*Result` functions below are aliases — the per-mode
+ * dispatch happens in `resolveQuestion`, but distinct names document intent
+ * at the call sites in `canonical-eval-run.ts`.
+ */
 function compareSqlResult(
   question: Question,
   executed: ExecutedQuery,
 ): QuestionResult {
-  const sqlMismatch = checkSqlPattern(question.expect, executed.sql);
-  if (sqlMismatch) {
-    return {
-      question,
-      status: "fail",
-      detail: sqlMismatch,
-      sql: executed.sql,
-    };
-  }
-
-  const columnMismatch = checkColumn(question.expect, executed.columns);
-  if (columnMismatch) {
-    return {
-      question,
-      status: "fail",
-      detail: columnMismatch,
-      sql: executed.sql,
-    };
-  }
-
-  const nonZeroMismatch = checkNonZero(
-    question.expect,
-    executed.rows,
-    executed.columns,
-  );
-  if (nonZeroMismatch) {
-    return {
-      question,
-      status: "fail",
-      detail: nonZeroMismatch,
-      sql: executed.sql,
-    };
+  const { sql } = executed;
+  const failOn =
+    checkSqlPattern(question.expect, sql) ??
+    checkColumn(question.expect, executed.columns) ??
+    checkNonZero(question.expect, executed.rows, executed.columns);
+  if (failOn) {
+    return { question, status: "fail", detail: failOn, sql };
   }
 
   const rowBounds = checkRowBounds(question.expect, executed.rows.length);
   if (rowBounds.kind === "warn") {
-    return {
-      question,
-      status: "warn",
-      detail: rowBounds.detail,
-      sql: executed.sql,
-    };
+    return { question, status: "warn", detail: rowBounds.detail, sql };
   }
 
+  const n = executed.rows.length;
   return {
     question,
     status: "pass",
-    detail: `${executed.rows.length} row${executed.rows.length === 1 ? "" : "s"}`,
-    sql: executed.sql,
+    detail: `${n} row${n === 1 ? "" : "s"}`,
+    sql,
   };
 }
 
-export function compareMetricResult(
-  question: Question,
-  executed: ExecutedQuery,
-): QuestionResult {
-  return compareSqlResult(question, executed);
-}
-
-export function comparePatternResult(
-  question: Question,
-  executed: ExecutedQuery,
-): QuestionResult {
-  return compareSqlResult(question, executed);
-}
-
-export function compareVirtualResult(
-  question: Question,
-  executed: ExecutedQuery,
-): QuestionResult {
-  return compareSqlResult(question, executed);
-}
+export const compareMetricResult = compareSqlResult;
+export const comparePatternResult = compareSqlResult;
+export const compareVirtualResult = compareSqlResult;
 
 export function compareGlossaryResult(
   question: Question,
   matches: readonly GlossaryMatch[],
 ): QuestionResult {
+  const fail = (detail: string): QuestionResult => ({
+    question,
+    status: "fail",
+    detail,
+    sql: null,
+  });
+  const pass = (detail: string): QuestionResult => ({
+    question,
+    status: "pass",
+    detail,
+    sql: null,
+  });
+
   if (matches.length === 0) {
-    return {
-      question,
-      status: "fail",
-      detail: `no glossary match for term "${question.term ?? ""}"`,
-      sql: null,
-    };
+    return fail(`no glossary match for term "${question.term ?? ""}"`);
   }
 
   const expectedStatus = question.expect.status ?? null;
+  if (expectedStatus === null) {
+    return pass(`${matches.length} match${matches.length === 1 ? "" : "es"}`);
+  }
+
+  const match = matches.find((m) => m.status === expectedStatus);
+  if (!match) {
+    const got = matches.map((m) => `${m.term}=${m.status}`).join(", ");
+    return fail(`expected ${expectedStatus} status but got [${got}]`);
+  }
+
   if (expectedStatus === "ambiguous") {
-    const ambiguous = matches.find((m) => m.status === "ambiguous");
-    if (!ambiguous) {
-      return {
-        question,
-        status: "fail",
-        detail: `expected ambiguous status but got [${matches.map((m) => `${m.term}=${m.status}`).join(", ")}]`,
-        sql: null,
-      };
+    const { mappings_min } = question.expect;
+    const count = match.possible_mappings.length;
+    if (typeof mappings_min === "number" && count < mappings_min) {
+      return fail(
+        `expected at least ${mappings_min} possible_mappings, got ${count}`,
+      );
     }
-    if (
-      typeof question.expect.mappings_min === "number" &&
-      ambiguous.possible_mappings.length < question.expect.mappings_min
-    ) {
-      return {
-        question,
-        status: "fail",
-        detail: `expected at least ${question.expect.mappings_min} possible_mappings, got ${ambiguous.possible_mappings.length}`,
-        sql: null,
-      };
-    }
-    return {
-      question,
-      status: "pass",
-      detail: `ambiguous (${ambiguous.possible_mappings.length} mappings)`,
-      sql: null,
-    };
+    return pass(`ambiguous (${count} mappings)`);
   }
 
-  if (expectedStatus === "defined") {
-    const defined = matches.find((m) => m.status === "defined");
-    if (!defined) {
-      return {
-        question,
-        status: "fail",
-        detail: `expected defined status but got [${matches.map((m) => `${m.term}=${m.status}`).join(", ")}]`,
-        sql: null,
-      };
-    }
-    return {
-      question,
-      status: "pass",
-      detail: "defined",
-      sql: null,
-    };
-  }
-
-  return {
-    question,
-    status: "pass",
-    detail: `${matches.length} match${matches.length === 1 ? "" : "es"}`,
-    sql: null,
-  };
+  return pass("defined");
 }
 
 // ── Formatter ───────────────────────────────────────────────────────────
@@ -503,67 +439,56 @@ export async function resolveQuestion(
   question: Question,
   opts: RunHarnessOptions,
 ): Promise<QuestionResult> {
+  const failNoSql = (detail: string): QuestionResult => ({
+    question,
+    status: "fail",
+    detail,
+    sql: null,
+  });
+
   try {
+    // Resolve SQL up-front so the execute + compare tail is shared across
+    // the three SQL-bearing modes. Glossary mode skips SQL entirely.
+    let sql: string;
     switch (question.mode) {
       case "metric": {
-        const sql = opts.findMetricSql(question.metric_id ?? "");
-        if (!sql) {
-          return {
-            question,
-            status: "fail",
-            detail: `unknown metric ${JSON.stringify(question.metric_id)}`,
-            sql: null,
-          };
+        const m = opts.findMetricSql(question.metric_id ?? "");
+        if (!m) {
+          return failNoSql(
+            `unknown metric ${JSON.stringify(question.metric_id)}`,
+          );
         }
-        const result = await opts.executeSql(sql);
-        return compareMetricResult(question, {
-          sql,
-          columns: result.columns,
-          rows: result.rows,
-        });
+        sql = m;
+        break;
       }
       case "pattern": {
-        const sql = opts.findPatternSql(
+        const p = opts.findPatternSql(
           question.entity ?? "",
           question.pattern ?? "",
         );
-        if (!sql) {
-          return {
-            question,
-            status: "fail",
-            detail: `unknown query_pattern ${JSON.stringify(question.entity)}.${JSON.stringify(question.pattern)}`,
-            sql: null,
-          };
+        if (!p) {
+          return failNoSql(
+            `unknown query_pattern ${JSON.stringify(question.entity)}.${JSON.stringify(question.pattern)}`,
+          );
         }
-        const result = await opts.executeSql(sql);
-        return comparePatternResult(question, {
-          sql,
-          columns: result.columns,
-          rows: result.rows,
-        });
+        sql = p;
+        break;
       }
-      case "virtual": {
-        const sql = question.sql ?? "";
-        const result = await opts.executeSql(sql);
-        return compareVirtualResult(question, {
-          sql,
-          columns: result.columns,
-          rows: result.rows,
-        });
-      }
-      case "glossary": {
-        const matches = opts.searchGlossary(question.term ?? "");
-        return compareGlossaryResult(question, matches);
-      }
+      case "virtual":
+        sql = question.sql ?? "";
+        break;
+      case "glossary":
+        return compareGlossaryResult(
+          question,
+          opts.searchGlossary(question.term ?? ""),
+        );
     }
+
+    const { columns, rows } = await opts.executeSql(sql);
+    return compareSqlResult(question, { sql, columns, rows });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    return {
-      question,
-      status: "fail",
-      detail: `error: ${message}`,
-      sql: null,
-    };
+    return failNoSql(`error: ${message}`);
   }
 }
 

--- a/packages/cli/bin/canonical-eval.ts
+++ b/packages/cli/bin/canonical-eval.ts
@@ -1,0 +1,586 @@
+/**
+ * Canonical-question eval harness — pure runner core.
+ *
+ * Proves the consolidated NovaMart demo dataset (#2021) returns correct
+ * answers to a curated question set (`eval/canonical-questions/questions.yml`).
+ *
+ * Why a separate harness from the LLM eval (`bin/eval.ts`):
+ *   - `bin/eval.ts` is the SQL-quality LLM benchmark (gold SQL, single shot,
+ *     LLM nondeterminism) and is run with `bun run atlas -- eval`.
+ *   - This harness is the *semantic-layer correctness* gate. It calls metric
+ *     SQL exactly as the typed MCP `runMetric` tool would, asserts ambiguous
+ *     glossary terms still trigger disambiguation, and proves
+ *     `query_patterns:` / `virtual:` dimensions compile against the seed.
+ *
+ * The runner is split so the loader and per-mode comparators stay pure
+ * (DB-free, no semantic-root resolution) and unit-testable. The CLI driver
+ * in `canonical-eval-run.ts` injects the real SQL executor / semantic
+ * lookup; tests inject stubs.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import * as yaml from "js-yaml";
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+export type QuestionMode = "metric" | "pattern" | "virtual" | "glossary";
+
+export type QuestionCategory =
+  | "simple_metric"
+  | "segmentation"
+  | "join"
+  | "timeseries"
+  | "virtual_dimension"
+  | "glossary"
+  | "filtered_pattern";
+
+export interface QuestionExpectations {
+  /** Case-insensitive substrings that must appear in the executed SQL. */
+  readonly sql_pattern?: readonly string[];
+  /** Lower bound on row count. */
+  readonly min_rows?: number;
+  /** Upper bound on row count. */
+  readonly max_rows?: number;
+  /** Scalar metric must return a non-zero numeric value. */
+  readonly non_zero?: boolean;
+  /** Named column must appear in the result columns. */
+  readonly column?: string;
+  /** Glossary status (`defined` / `ambiguous`). */
+  readonly status?: "defined" | "ambiguous";
+  /** Minimum number of `possible_mappings` on an ambiguous glossary term. */
+  readonly mappings_min?: number;
+}
+
+export interface Question {
+  readonly id: string;
+  readonly category: QuestionCategory;
+  readonly question: string;
+  readonly mode: QuestionMode;
+  readonly metric_id?: string;
+  readonly entity?: string;
+  readonly pattern?: string;
+  readonly dimension?: string;
+  readonly sql?: string;
+  readonly term?: string;
+  readonly expect: QuestionExpectations;
+}
+
+export interface ExecutedQuery {
+  readonly sql: string;
+  readonly columns: readonly string[];
+  readonly rows: readonly Record<string, unknown>[];
+}
+
+export interface GlossaryMatch {
+  readonly term: string;
+  readonly status: string | null;
+  readonly possible_mappings: readonly string[];
+}
+
+export type ResultStatus = "pass" | "warn" | "fail";
+
+export interface QuestionResult {
+  readonly question: Question;
+  readonly status: ResultStatus;
+  readonly detail: string;
+  readonly sql: string | null;
+}
+
+interface QuestionsFile {
+  version?: string;
+  schema?: string;
+  questions: Question[];
+}
+
+const VALID_MODES: ReadonlySet<QuestionMode> = new Set([
+  "metric",
+  "pattern",
+  "virtual",
+  "glossary",
+]);
+
+const VALID_CATEGORIES: ReadonlySet<QuestionCategory> = new Set([
+  "simple_metric",
+  "segmentation",
+  "join",
+  "timeseries",
+  "virtual_dimension",
+  "glossary",
+  "filtered_pattern",
+]);
+
+// ── Loader ───────────────────────────────────────────────────────────────
+
+export function loadQuestions(filePath: string): Question[] {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Canonical questions file not found: ${filePath}`);
+  }
+
+  const raw = yaml.load(fs.readFileSync(filePath, "utf-8"));
+  if (!raw || typeof raw !== "object") {
+    throw new Error(`Invalid questions file (not an object): ${filePath}`);
+  }
+
+  const file = raw as QuestionsFile;
+  if (!Array.isArray(file.questions)) {
+    throw new Error(`questions: array missing in ${filePath}`);
+  }
+
+  const seen = new Set<string>();
+  const out: Question[] = [];
+
+  for (let i = 0; i < file.questions.length; i++) {
+    const q = file.questions[i] as Partial<Question> | undefined;
+    if (!q || typeof q !== "object") {
+      throw new Error(`questions[${i}] is not an object in ${filePath}`);
+    }
+
+    if (typeof q.id !== "string" || !/^cq-\d{3}$/.test(q.id)) {
+      throw new Error(
+        `questions[${i}].id must match /^cq-\\d{3}$/ in ${filePath} (got ${String(q.id)})`,
+      );
+    }
+    if (seen.has(q.id)) {
+      throw new Error(`Duplicate question id "${q.id}" in ${filePath}`);
+    }
+    seen.add(q.id);
+
+    if (typeof q.question !== "string" || !q.question.trim()) {
+      throw new Error(`${q.id}: question must be a non-empty string`);
+    }
+    if (typeof q.mode !== "string" || !VALID_MODES.has(q.mode as QuestionMode)) {
+      throw new Error(
+        `${q.id}: mode must be one of ${[...VALID_MODES].join(", ")} (got ${String(q.mode)})`,
+      );
+    }
+    if (
+      typeof q.category !== "string" ||
+      !VALID_CATEGORIES.has(q.category as QuestionCategory)
+    ) {
+      throw new Error(
+        `${q.id}: category must be one of ${[...VALID_CATEGORIES].join(", ")} (got ${String(q.category)})`,
+      );
+    }
+    if (!q.expect || typeof q.expect !== "object") {
+      throw new Error(`${q.id}: expect must be an object`);
+    }
+
+    const mode = q.mode as QuestionMode;
+    if (mode === "metric" && !q.metric_id) {
+      throw new Error(`${q.id}: metric mode requires metric_id`);
+    }
+    if (mode === "pattern" && (!q.entity || !q.pattern)) {
+      throw new Error(`${q.id}: pattern mode requires entity + pattern`);
+    }
+    if (mode === "virtual" && (!q.entity || !q.dimension || !q.sql)) {
+      throw new Error(`${q.id}: virtual mode requires entity + dimension + sql`);
+    }
+    if (mode === "glossary" && !q.term) {
+      throw new Error(`${q.id}: glossary mode requires term`);
+    }
+
+    out.push(q as Question);
+  }
+
+  return out;
+}
+
+// ── Per-mode comparators ────────────────────────────────────────────────
+
+function checkSqlPattern(
+  expectations: QuestionExpectations,
+  sql: string,
+): string | null {
+  const patterns = expectations.sql_pattern ?? [];
+  const haystack = sql.toLowerCase();
+  for (const needle of patterns) {
+    if (!haystack.includes(needle.toLowerCase())) {
+      return `expected SQL to include ${JSON.stringify(needle)}`;
+    }
+  }
+  return null;
+}
+
+function checkRowBounds(
+  expectations: QuestionExpectations,
+  rowCount: number,
+): { kind: "pass" } | { kind: "warn"; detail: string } {
+  if (typeof expectations.min_rows === "number" && rowCount < expectations.min_rows) {
+    return {
+      kind: "warn",
+      detail: `min_rows=${expectations.min_rows}, got ${rowCount}`,
+    };
+  }
+  if (typeof expectations.max_rows === "number" && rowCount > expectations.max_rows) {
+    return {
+      kind: "warn",
+      detail: `max_rows=${expectations.max_rows}, got ${rowCount}`,
+    };
+  }
+  return { kind: "pass" };
+}
+
+function checkColumn(
+  expectations: QuestionExpectations,
+  columns: readonly string[],
+): string | null {
+  if (!expectations.column) return null;
+  if (!columns.includes(expectations.column)) {
+    return `expected column ${JSON.stringify(expectations.column)} not in result (got [${columns.join(", ")}])`;
+  }
+  return null;
+}
+
+function checkNonZero(
+  expectations: QuestionExpectations,
+  rows: readonly Record<string, unknown>[],
+  columns: readonly string[],
+): string | null {
+  if (!expectations.non_zero) return null;
+  if (rows.length === 0 || columns.length === 0) {
+    return "non-zero scalar expected, but result was empty";
+  }
+  const first = rows[0]?.[columns[0]];
+  const num = typeof first === "number" ? first : Number(first);
+  if (!Number.isFinite(num) || num === 0) {
+    return `expected non-zero scalar, got ${JSON.stringify(first)}`;
+  }
+  return null;
+}
+
+/** Generic comparator used by metric / pattern / virtual modes. */
+function compareSqlResult(
+  question: Question,
+  executed: ExecutedQuery,
+): QuestionResult {
+  const sqlMismatch = checkSqlPattern(question.expect, executed.sql);
+  if (sqlMismatch) {
+    return {
+      question,
+      status: "fail",
+      detail: sqlMismatch,
+      sql: executed.sql,
+    };
+  }
+
+  const columnMismatch = checkColumn(question.expect, executed.columns);
+  if (columnMismatch) {
+    return {
+      question,
+      status: "fail",
+      detail: columnMismatch,
+      sql: executed.sql,
+    };
+  }
+
+  const nonZeroMismatch = checkNonZero(
+    question.expect,
+    executed.rows,
+    executed.columns,
+  );
+  if (nonZeroMismatch) {
+    return {
+      question,
+      status: "fail",
+      detail: nonZeroMismatch,
+      sql: executed.sql,
+    };
+  }
+
+  const rowBounds = checkRowBounds(question.expect, executed.rows.length);
+  if (rowBounds.kind === "warn") {
+    return {
+      question,
+      status: "warn",
+      detail: rowBounds.detail,
+      sql: executed.sql,
+    };
+  }
+
+  return {
+    question,
+    status: "pass",
+    detail: `${executed.rows.length} row${executed.rows.length === 1 ? "" : "s"}`,
+    sql: executed.sql,
+  };
+}
+
+export function compareMetricResult(
+  question: Question,
+  executed: ExecutedQuery,
+): QuestionResult {
+  return compareSqlResult(question, executed);
+}
+
+export function comparePatternResult(
+  question: Question,
+  executed: ExecutedQuery,
+): QuestionResult {
+  return compareSqlResult(question, executed);
+}
+
+export function compareVirtualResult(
+  question: Question,
+  executed: ExecutedQuery,
+): QuestionResult {
+  return compareSqlResult(question, executed);
+}
+
+export function compareGlossaryResult(
+  question: Question,
+  matches: readonly GlossaryMatch[],
+): QuestionResult {
+  if (matches.length === 0) {
+    return {
+      question,
+      status: "fail",
+      detail: `no glossary match for term "${question.term ?? ""}"`,
+      sql: null,
+    };
+  }
+
+  const expectedStatus = question.expect.status ?? null;
+  if (expectedStatus === "ambiguous") {
+    const ambiguous = matches.find((m) => m.status === "ambiguous");
+    if (!ambiguous) {
+      return {
+        question,
+        status: "fail",
+        detail: `expected ambiguous status but got [${matches.map((m) => `${m.term}=${m.status}`).join(", ")}]`,
+        sql: null,
+      };
+    }
+    if (
+      typeof question.expect.mappings_min === "number" &&
+      ambiguous.possible_mappings.length < question.expect.mappings_min
+    ) {
+      return {
+        question,
+        status: "fail",
+        detail: `expected at least ${question.expect.mappings_min} possible_mappings, got ${ambiguous.possible_mappings.length}`,
+        sql: null,
+      };
+    }
+    return {
+      question,
+      status: "pass",
+      detail: `ambiguous (${ambiguous.possible_mappings.length} mappings)`,
+      sql: null,
+    };
+  }
+
+  if (expectedStatus === "defined") {
+    const defined = matches.find((m) => m.status === "defined");
+    if (!defined) {
+      return {
+        question,
+        status: "fail",
+        detail: `expected defined status but got [${matches.map((m) => `${m.term}=${m.status}`).join(", ")}]`,
+        sql: null,
+      };
+    }
+    return {
+      question,
+      status: "pass",
+      detail: "defined",
+      sql: null,
+    };
+  }
+
+  return {
+    question,
+    status: "pass",
+    detail: `${matches.length} match${matches.length === 1 ? "" : "es"}`,
+    sql: null,
+  };
+}
+
+// ── Formatter ───────────────────────────────────────────────────────────
+
+const STATUS_GLYPH: Record<ResultStatus, string> = {
+  pass: "[PASS]",
+  warn: "[WARN]",
+  fail: "[FAIL]",
+};
+
+export function formatSummary(results: readonly QuestionResult[]): string {
+  const lines: string[] = [];
+  lines.push("Atlas canonical-question eval");
+  lines.push("=".repeat(60));
+
+  const passing = results.filter((r) => r.status === "pass").length;
+  const warning = results.filter((r) => r.status === "warn").length;
+  const failing = results.filter((r) => r.status === "fail").length;
+
+  lines.push(`${passing}/${results.length} passing  (${warning} warn, ${failing} fail)`);
+  lines.push("");
+
+  for (const r of results) {
+    const id = r.question.id.padEnd(7);
+    const cat = r.question.category.padEnd(18);
+    const head = `${STATUS_GLYPH[r.status]} ${id} ${cat} ${r.question.question}`;
+    lines.push(head);
+    if (r.status !== "pass") {
+      lines.push(`         -> ${r.detail}`);
+    }
+  }
+
+  lines.push("");
+  lines.push("=".repeat(60));
+  lines.push(`${passing}/${results.length} passing`);
+
+  // Per-category summary — useful for spotting an entire category regressing.
+  const byCat = new Map<string, { total: number; pass: number }>();
+  for (const r of results) {
+    const entry = byCat.get(r.question.category) ?? { total: 0, pass: 0 };
+    entry.total++;
+    if (r.status === "pass") entry.pass++;
+    byCat.set(r.question.category, entry);
+  }
+  const sortedCats = [...byCat.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  for (const [cat, stats] of sortedCats) {
+    lines.push(`  ${cat.padEnd(20)} ${stats.pass}/${stats.total}`);
+  }
+
+  return lines.join("\n");
+}
+
+// ── Default questions path ───────────────────────────────────────────────
+
+/**
+ * Default location of the curated question set, relative to the repo root.
+ * Resolved at runtime by walking up from this file.
+ */
+export const DEFAULT_QUESTIONS_PATH = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "eval",
+  "canonical-questions",
+  "questions.yml",
+);
+
+// ── Driver ───────────────────────────────────────────────────────────────
+
+export interface RunHarnessOptions {
+  /** Override the questions file path (defaults to `DEFAULT_QUESTIONS_PATH`). */
+  readonly questionsPath?: string;
+  /**
+   * Resolve a metric's authoritative SQL by id. Returns `null` when the
+   * metric is unknown. The CLI driver wires this to `findMetricById` from
+   * `@atlas/api/lib/semantic/lookups`; tests inject stubs.
+   */
+  readonly findMetricSql: (id: string) => string | null;
+  /**
+   * Resolve an entity's `query_patterns[*].sql` by entity name + pattern
+   * name. Returns `null` when either is unknown.
+   */
+  readonly findPatternSql: (entity: string, pattern: string) => string | null;
+  /**
+   * Search the glossary for a term. Returns the matching entries (zero or
+   * more). The CLI driver wires this to `searchGlossary`; tests inject
+   * stubs.
+   */
+  readonly searchGlossary: (term: string) => readonly GlossaryMatch[];
+  /**
+   * Execute a SQL string and return the result. The CLI driver wires this
+   * to the configured Postgres datasource; tests inject stubs.
+   */
+  readonly executeSql: (sql: string) => Promise<{
+    columns: readonly string[];
+    rows: readonly Record<string, unknown>[];
+  }>;
+}
+
+/**
+ * Resolve a single question to a `QuestionResult`. Pure given its
+ * dependencies — the actual DB / semantic-layer reads come in via
+ * `RunHarnessOptions`.
+ */
+export async function resolveQuestion(
+  question: Question,
+  opts: RunHarnessOptions,
+): Promise<QuestionResult> {
+  try {
+    switch (question.mode) {
+      case "metric": {
+        const sql = opts.findMetricSql(question.metric_id ?? "");
+        if (!sql) {
+          return {
+            question,
+            status: "fail",
+            detail: `unknown metric ${JSON.stringify(question.metric_id)}`,
+            sql: null,
+          };
+        }
+        const result = await opts.executeSql(sql);
+        return compareMetricResult(question, {
+          sql,
+          columns: result.columns,
+          rows: result.rows,
+        });
+      }
+      case "pattern": {
+        const sql = opts.findPatternSql(
+          question.entity ?? "",
+          question.pattern ?? "",
+        );
+        if (!sql) {
+          return {
+            question,
+            status: "fail",
+            detail: `unknown query_pattern ${JSON.stringify(question.entity)}.${JSON.stringify(question.pattern)}`,
+            sql: null,
+          };
+        }
+        const result = await opts.executeSql(sql);
+        return comparePatternResult(question, {
+          sql,
+          columns: result.columns,
+          rows: result.rows,
+        });
+      }
+      case "virtual": {
+        const sql = question.sql ?? "";
+        const result = await opts.executeSql(sql);
+        return compareVirtualResult(question, {
+          sql,
+          columns: result.columns,
+          rows: result.rows,
+        });
+      }
+      case "glossary": {
+        const matches = opts.searchGlossary(question.term ?? "");
+        return compareGlossaryResult(question, matches);
+      }
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      question,
+      status: "fail",
+      detail: `error: ${message}`,
+      sql: null,
+    };
+  }
+}
+
+/**
+ * Run every question in the curated set against the wired-in dependencies,
+ * returning the per-question results. Caller is responsible for printing
+ * via `formatSummary` and exiting with a non-zero code when desired.
+ */
+export async function runHarness(
+  opts: RunHarnessOptions,
+): Promise<QuestionResult[]> {
+  const questions = loadQuestions(
+    opts.questionsPath ?? DEFAULT_QUESTIONS_PATH,
+  );
+  const results: QuestionResult[] = [];
+  for (const q of questions) {
+    results.push(await resolveQuestion(q, opts));
+  }
+  return results;
+}

--- a/packages/cli/bin/canonical-eval.ts
+++ b/packages/cli/bin/canonical-eval.ts
@@ -66,15 +66,32 @@ export interface Question {
   readonly expect: QuestionExpectations;
 }
 
-export interface ExecutedQuery {
-  readonly sql: string;
+/**
+ * Wire shape returned by an executed SQL query — used by both the metric /
+ * pattern / virtual comparators and the `RunHarnessOptions.executeSql`
+ * dependency. Extracted so the CLI driver and tests share a single source
+ * of truth for what `executeSql` returns.
+ */
+export interface SqlQueryResult {
   readonly columns: readonly string[];
   readonly rows: readonly Record<string, unknown>[];
 }
 
+export interface ExecutedQuery extends SqlQueryResult {
+  readonly sql: string;
+}
+
+/**
+ * Glossary status values recognised by the harness. The literal
+ * `"ambiguous"` is load-bearing — agent clients are instructed to surface
+ * ambiguity to the user instead of silently picking a mapping. `null`
+ * means the underlying YAML omitted a status.
+ */
+export type GlossaryStatus = "defined" | "ambiguous";
+
 export interface GlossaryMatch {
   readonly term: string;
-  readonly status: string | null;
+  readonly status: GlossaryStatus | null;
   readonly possible_mappings: readonly string[];
 }
 
@@ -88,9 +105,9 @@ export interface QuestionResult {
 }
 
 interface QuestionsFile {
-  version?: string;
-  schema?: string;
-  questions: Question[];
+  readonly version?: string;
+  readonly schema?: string;
+  readonly questions: readonly unknown[];
 }
 
 const VALID_MODES: ReadonlySet<QuestionMode> = new Set([
@@ -131,10 +148,11 @@ export function loadQuestions(filePath: string): Question[] {
   const out: Question[] = [];
 
   for (let i = 0; i < file.questions.length; i++) {
-    const q = file.questions[i] as Partial<Question> | undefined;
-    if (!q || typeof q !== "object") {
+    const rawQ = file.questions[i];
+    if (!rawQ || typeof rawQ !== "object") {
       throw new Error(`questions[${i}] is not an object in ${filePath}`);
     }
+    const q = rawQ as Partial<Question>;
 
     if (typeof q.id !== "string" || !/^cq-\d{3}$/.test(q.id)) {
       throw new Error(
@@ -424,10 +442,7 @@ export interface RunHarnessOptions {
    * Execute a SQL string and return the result. The CLI driver wires this
    * to the configured Postgres datasource; tests inject stubs.
    */
-  readonly executeSql: (sql: string) => Promise<{
-    columns: readonly string[];
-    rows: readonly Record<string, unknown>[];
-  }>;
+  readonly executeSql: (sql: string) => Promise<SqlQueryResult>;
 }
 
 /**
@@ -482,6 +497,12 @@ export async function resolveQuestion(
           question,
           opts.searchGlossary(question.term ?? ""),
         );
+      default: {
+        // Compile-time exhaustiveness — adding a new mode here forces TS to
+        // flag this branch. Mirrors the dispatcher in `runWithAgent`.
+        const _exhaustive: never = question.mode;
+        throw new Error(`unreachable mode: ${String(_exhaustive)}`);
+      }
     }
 
     const { columns, rows } = await opts.executeSql(sql);

--- a/packages/cli/lib/help.ts
+++ b/packages/cli/lib/help.ts
@@ -541,6 +541,33 @@ export const SUBCOMMAND_HELP: Record<string, SubcommandHelp> = {
       "atlas eval --baseline",
     ],
   },
+  "canonical-eval": {
+    description:
+      "Run the canonical-question harness against the consolidated NovaMart demo dataset. Proves the semantic layer (metrics, query_patterns, glossary) returns correct answers to a curated question set without involving an LLM by default.",
+    usage: "canonical-eval [options]",
+    flags: [
+      {
+        flag: "--schema <name>",
+        description:
+          "Demo dataset to seed (only `ecommerce` ships today; flag stays open for future seeds)",
+      },
+      {
+        flag: "--questions <path>",
+        description:
+          "Override the questions.yml path (default: eval/canonical-questions/questions.yml)",
+      },
+      {
+        flag: "--llm",
+        description:
+          "Run the full agent loop (slower, nondeterministic) instead of calling typed semantic-layer reads directly",
+      },
+      { flag: "--json", description: "JSON summary output" },
+    ],
+    examples: [
+      "atlas canonical-eval",
+      "atlas canonical-eval --llm",
+    ],
+  },
   smoke: {
     description:
       "Run end-to-end smoke tests against a running Atlas deployment.",

--- a/packages/cli/lib/help.ts
+++ b/packages/cli/lib/help.ts
@@ -661,6 +661,7 @@ export function printOverviewHelp(): void {
       "  validate         Validate config, semantic layer, and connectivity\n" +
       "  doctor           Alias for validate\n" +
       "  eval             Run eval pipeline against demo schemas\n" +
+      "  canonical-eval   Run canonical-question harness against the demo dataset (no LLM by default)\n" +
       "  smoke            Run E2E smoke tests against a running Atlas deployment\n" +
       "  migrate          Semantic layer versioning (snapshot, diff, rollback)\n" +
       "  plugin           Manage plugins (list, create, add)\n" +


### PR DESCRIPTION
## Summary

Closes #2025. Builds the semantic-layer correctness gate the issue asked for — distinct from the existing `atlas eval` LLM benchmark (that's the SQL-quality shoot-out; this is the moat-proof).

The deterministic mode calls metric SQL exactly as the typed MCP `runMetric` tool does (`findMetricById(id)` -> `executeSQL(sql)`), asserts the glossary disambiguation contract on `revenue` / `status` / `price`, and proves `query_patterns:` / `virtual:` dimensions compile against the consolidated NovaMart seed.

- 20 curated questions in `eval/canonical-questions/questions.yml` covering simple metrics (5), segmentation (4), joins (2), time-series (2), virtual dimensions (2), glossary disambiguation (3), and filtered query_patterns (2).
- Pure runner core in `packages/cli/bin/canonical-eval.ts` (loader, comparators, formatter, dispatcher) — DB-free, unit-testable.
- CLI driver in `packages/cli/bin/canonical-eval-run.ts` that wires real semantic-layer reads + Postgres execution; `--llm` flag opts into the full agent loop.
- `bun run eval:canonical` shortcut, plus a `bun run atlas -- canonical-eval` subcommand with full help.
- `.github/workflows/eval.yml` — informational on PRs (mirrors the Lighthouse first-month policy), blocking on release tags.
- `apps/docs/content/docs/contributing/eval-harness.mdx` — running and extending guide.

## Deterministic baseline

```
18/20 passing  (2 warn, 0 fail)
  filtered_pattern     2/2
  glossary             3/3
  join                 1/2
  segmentation         3/4
  simple_metric        5/5
  timeseries           2/2
  virtual_dimension    2/2
```

The two warnings are `revenue_by_category` and `revenue_dtc_vs_marketplace` — both join `order_items.product_name = products.name`, which the seed populates with disjoint value sets. Filed as #2039 (`fix(seeds)`) so the metric SQL stays as-is and the seed catches up. The harness flagging this is exactly the value the issue called out.

## Tests

- 25 new in `packages/cli/bin/__tests__/canonical-eval.test.ts` covering the loader, per-mode comparators, formatter, and dispatcher with stubbed dependencies.
- Full `bun run test` green: 321 api / 20 cli / 104 web / 25 ee / 10 react files.
- `lint`, `type`, `syncpack lint`, `check-template-drift`, `check-railway-watch` all green locally.

## Test plan

- [ ] CI workflow run — confirm `Canonical Eval` job posts `18/20 passing` (or better) on this PR
- [ ] Deterministic mode locally: `bun run db:up && export ATLAS_DATASOURCE_URL=postgres://atlas:atlas@localhost:5432/atlas_demo && bun run eval:canonical`
- [ ] LLM mode locally with a real provider: `bun run eval:canonical -- --llm`
- [ ] Open the docs page (`apps/docs`) and confirm the new contributing -> eval-harness link renders
- [ ] Verify `.claude/research/ROADMAP.md` 1.4.0 active section now shows `[x]` for #2025