### PR TITLE
docs: #2043 — retarget concepts.mdx examples to NovaMart

### DIFF
--- a/apps/docs/content/docs/getting-started/concepts.mdx
+++ b/apps/docs/content/docs/getting-started/concepts.mdx
@@ -33,7 +33,7 @@ Entities have a **type** that reflects their role in the semantic layer:
 A short phrase on an entity that describes what one row represents. Grain helps the agent avoid double-counting and understand cardinality.
 
 ```yaml
-grain: one row per subscription account
+grain: one row per order
 ```
 
 If the grain is "one row per order line item" and a user asks "how many orders?", the agent knows it needs `COUNT(DISTINCT order_id)`, not `COUNT(*)`.
@@ -44,11 +44,11 @@ A column or expression on an entity that users can filter, group, or select. Dim
 
 ```yaml
 dimensions:
-  - name: plan
-    sql: plan
+  - name: acquisition_source
+    sql: acquisition_source
     type: string
-    description: Subscription tier (Free, Starter, Pro, Enterprise)
-    sample_values: [Enterprise, Pro, Starter, Free]
+    description: How this customer was acquired
+    sample_values: [organic, paid_search, social, referral, email, direct]
 ```
 
 A dimension marked `primary_key: true` identifies the unique row. A dimension marked `virtual: true` is computed from an expression, not a raw database column (see [Virtual dimension](#virtual-dimension)).
@@ -61,18 +61,18 @@ A computed dimension defined by a SQL expression — typically a `CASE` statemen
 
 ```yaml
 dimensions:
-  - name: monthly_value_bucket
+  - name: order_size_bucket
     sql: |-
       CASE
-        WHEN monthly_value = 0 THEN 'Free'
-        WHEN monthly_value < 100 THEN 'Low'
-        WHEN monthly_value < 1000 THEN 'Mid'
-        ELSE 'High'
+        WHEN total_cents < 2500 THEN 'Small (<$25)'
+        WHEN total_cents < 7500 THEN 'Medium ($25-$75)'
+        WHEN total_cents < 15000 THEN 'Large ($75-$150)'
+        ELSE 'XL ($150+)'
       END
     type: string
-    description: MRR tier bucket — Free / Low / Mid / High
+    description: Order size bucket based on total value
     virtual: true
-    sample_values: [Free, Low, Mid, High]
+    sample_values: ["Small (<$25)", "Medium ($25-$75)", "Large ($75-$150)", "XL ($150+)"]
 ```
 
 Use virtual dimensions for common groupings (revenue tiers, date buckets, status categories) that users ask about frequently but don't exist as raw columns.
@@ -87,10 +87,10 @@ A pre-defined aggregation on an entity. Measures tell the agent how to summarize
 
 ```yaml
 measures:
-  - name: total_mrr
-    sql: monthly_value
+  - name: total_gmv_cents
+    sql: total_cents
     type: sum
-    description: Total Monthly Recurring Revenue
+    description: Total GMV in cents (sum of all order totals)
 ```
 
 **Aggregation types:** `count_distinct`, `sum`, `avg`, `min`, `max`
@@ -103,17 +103,17 @@ A relationship between two entities, defined by foreign key columns and cardinal
 
 ```yaml
 joins:
-  - target_entity: Companies
+  - target_entity: Customers
     relationship: many_to_one
     join_columns:
-      from: company_id
+      from: customer_id
       to: id
-    description: Each account belongs to one company (customer)
+    description: Each order belongs to one customer
 ```
 
 **Relationship types:** `many_to_one`, `one_to_many`, `one_to_one`, `many_to_many`
 
-When a question spans multiple entities (e.g., "MRR by industry" requires joining accounts to companies), the agent uses these definitions to generate the correct `JOIN` clause.
+When a question spans multiple entities (e.g., "GMV by acquisition source" requires joining orders to customers), the agent uses these definitions to generate the correct `JOIN` clause.
 
 ### Cross-source join
 
@@ -136,16 +136,17 @@ A pre-written SQL query for a common question. When a user asks something that m
 
 ```yaml
 query_patterns:
-  - name: churn_rate_by_plan
-    description: Churn rate by plan type
+  - name: monthly_gmv
+    description: Monthly GMV trend
     sql: |-
-      SELECT plan,
-             COUNT(*) FILTER (WHERE status = 'Churned') AS churned,
-             COUNT(*) AS total,
-             ROUND(100.0 * COUNT(*) FILTER (WHERE status = 'Churned') / COUNT(*), 1) AS churn_pct
-      FROM accounts
-      GROUP BY plan
-      ORDER BY churn_pct DESC
+      SELECT TO_CHAR(created_at, 'YYYY-MM') AS order_month,
+             COUNT(*) AS order_count,
+             SUM(total_cents) / 100.0 AS gmv_dollars,
+             AVG(total_cents) / 100.0 AS aov_dollars
+      FROM orders
+      WHERE status != 'cancelled'
+      GROUP BY TO_CHAR(created_at, 'YYYY-MM')
+      ORDER BY order_month
 ```
 
 Query patterns are especially valuable for complex queries involving window functions, CTEs, or non-obvious filter conditions that the agent might get wrong.
@@ -158,11 +159,11 @@ An array of example values on a dimension. Sample values help the agent understa
 - name: status
   sql: status
   type: string
-  description: Current billing status
-  sample_values: [Active, Churned, Inactive, Suspended]
+  description: Order fulfillment status
+  sample_values: [pending, processing, shipped, delivered, cancelled]
 ```
 
-Without sample values, the agent might filter on `WHERE status = 'active'` (lowercase) when the actual data uses `'Active'` (title case). Sample values eliminate this class of error.
+Without sample values, the agent might filter on `WHERE status = 'Pending'` (title case) when the actual data uses `'pending'` (lowercase). Sample values eliminate this class of error.
 
 ### Metric
 
@@ -170,25 +171,31 @@ An authoritative, named business KPI defined in `semantic/metrics/*.yml`. Unlike
 
 ```yaml
 metrics:
-  - id: churn_rate
-    label: Churn Rate
-    description: Percentage of all accounts that have churned
-    type: derived
-    unit: percent
+  - id: total_gmv
+    label: Total GMV
+    description: >
+      Gross Merchandise Value — total value of all non-cancelled orders.
+      Calculated from orders.total_cents / 100.
+    type: atomic
+    unit: USD
+    source:
+      entity: Orders
+      measure: total_gmv_cents
     sql: |-
-      SELECT ROUND(100.0 * COUNT(*) FILTER (WHERE status = 'Churned') / COUNT(*), 1) AS churn_rate
-      FROM accounts
-    aggregation: ratio
-    objective: minimize
+      SELECT SUM(total_cents) / 100.0 AS total_gmv
+      FROM orders
+      WHERE status != 'cancelled'
+    aggregation: sum
+    objective: maximize
 ```
 
 **Metric types:**
 
 | Type | Description | Example |
 |------|-------------|---------|
-| `atomic` | Base metric directly from data | Total MRR, Active Accounts |
-| `derived` | Calculated from an expression or ratio | Churn Rate, ARPA |
-| `breakdown` | A metric split by one or more dimensions | MRR by Plan, Churn by Region |
+| `atomic` | Base metric directly from data | Total GMV, Active Customers |
+| `derived` | Calculated from an expression or ratio | AOV, Refund Rate |
+| `breakdown` | A metric split by one or more dimensions | Revenue by Category, Monthly GMV Trend |
 
 <Callout type="warn">
 Metric SQL is authoritative — the agent executes it verbatim. If a metric's SQL is wrong, the agent will produce wrong results. Treat metric files as source code.
@@ -202,24 +209,28 @@ Each term is marked `defined` (unambiguous) or `ambiguous` (needs clarification)
 
 ```yaml
 terms:
-  MRR:
+  GMV:
     status: defined
     definition: >
-      Monthly Recurring Revenue. The sum of monthly_value across all active accounts.
+      Gross Merchandise Value. Total value of all orders before refunds and returns.
+      Use SUM(orders.total_cents) / 100 for dollar amount. Filter by status != 'cancelled'
+      for net GMV.
     tables:
-      - accounts
+      - orders
 
   revenue:
     status: ambiguous
     note: >
-      Could mean company revenue (companies.revenue — annual total revenue)
-      or account revenue (accounts.monthly_value — our MRR). Clarify which.
+      Could mean GMV (total order value from orders.total_cents), net revenue
+      (GMV minus refunds), or seller revenue (after commission). ASK the user
+      which definition they mean.
     possible_mappings:
-      - companies.revenue
-      - accounts.monthly_value
+      - orders.total_cents
+      - payments.amount_cents
+      - refunds (subtracted)
 ```
 
-When a user asks about "revenue" and the glossary marks it as ambiguous, the agent asks "Do you mean company revenue or account MRR?" rather than guessing.
+When a user asks about "revenue" and the glossary marks it as ambiguous, the agent asks "Do you mean GMV, net revenue (GMV minus refunds), or seller revenue (after commission)?" rather than guessing.
 
 ### Catalog
 

--- a/apps/docs/content/docs/getting-started/concepts.mdx
+++ b/apps/docs/content/docs/getting-started/concepts.mdx
@@ -75,7 +75,7 @@ dimensions:
     sample_values: ["Small (<$25)", "Medium ($25-$75)", "Large ($75-$150)", "XL ($150+)"]
 ```
 
-Use virtual dimensions for common groupings (revenue tiers, date buckets, status categories) that users ask about frequently but don't exist as raw columns.
+Use virtual dimensions for common groupings (order-size buckets, date buckets, status categories) that users ask about frequently but don't exist as raw columns.
 
 <Callout type="info">
 Virtual dimensions can also be defined in a separate `virtual_dimensions` section of the entity YAML. Both approaches are functionally identical — the agent reads the raw YAML either way. The demo dataset and `atlas init` both use the inline `virtual: true` style.

--- a/apps/docs/content/docs/getting-started/concepts.mdx
+++ b/apps/docs/content/docs/getting-started/concepts.mdx
@@ -221,16 +221,16 @@ terms:
   revenue:
     status: ambiguous
     note: >
-      Could mean GMV (total order value from orders.total_cents), net revenue
-      (GMV minus refunds), or seller revenue (after commission). ASK the user
+      Could mean gross revenue (GMV before refunds), net revenue (GMV minus
+      refunds), or seller revenue (gross minus commission). ASK the user
       which definition they mean.
     possible_mappings:
       - orders.total_cents
       - payments.amount_cents
-      - refunds (subtracted)
+      - refunds.amount_cents
 ```
 
-When a user asks about "revenue" and the glossary marks it as ambiguous, the agent asks "Do you mean GMV, net revenue (GMV minus refunds), or seller revenue (after commission)?" rather than guessing.
+When a user asks about "revenue" and the glossary marks it as ambiguous, the agent asks "Do you mean gross revenue, net revenue, or seller revenue?" rather than guessing.
 
 ### Catalog
 


### PR DESCRIPTION
Closes #2043.

## Summary

- Final stale-reference cleanup from #2021's demo-seed consolidation. `apps/docs/content/docs/getting-started/concepts.mdx` was the largest remaining straggler (#2040 handled the README + landing + new `/semantic-layer` section).
- All 30+ stale example bodies retargeted: every snippet now lifts directly from `packages/cli/data/seeds/ecommerce/semantic/` so readers who copy code find tables/columns that actually exist in the demo dataset they just installed.
- Page structure unchanged — only example bodies and supporting prose touched. All cross-links preserved.

## Retargeting map (per #2043 inventory)

| Concept | Before | After (lifted from) |
|---|---|---|
| Grain | `one row per subscription account` | `one row per order` |
| Dimension | `plan` / Free, Starter, Pro, Enterprise | `acquisition_source` from `customers.yml` |
| Virtual dimension | `monthly_value_bucket` (MRR tier) | `order_size_bucket` from `orders.yml` |
| Measure | `total_mrr` (sum of monthly_value) | `total_gmv_cents` from `orders.yml` |
| Join | `accounts → companies` (company_id) | `orders → customers` (customer_id) from `orders.yml` |
| Query pattern | `churn_rate_by_plan` | `monthly_gmv` from `orders.yml` |
| Sample values | `[Active, Churned, Inactive, Suspended]` | `[pending, processing, shipped, delivered, cancelled]` |
| Metric | `churn_rate` (derived) | `total_gmv` (atomic) from `metrics/revenue.yml` |
| Metric type table | Total MRR / Active Accounts / Churn Rate / ARPA / MRR by Plan / Churn by Region | Total GMV / Active Customers / AOV / Refund Rate / Revenue by Category / Monthly GMV Trend |
| Glossary defined term | `MRR` (account MRR) | `GMV` from `glossary.yml` |
| Glossary ambiguous term | `revenue` (companies.revenue vs accounts.monthly_value) | `revenue` (GMV vs net revenue vs seller revenue) — verbatim from `glossary.yml` |

## Verification

- `grep -i 'account\|companies\|company\|subscription\|mrr\|churn\|monthly_value' apps/docs/content/docs/getting-started/concepts.mdx` — empty
- `cd apps/docs && bun run build` — 1532 static pages generated
- Cross-links to `/getting-started/semantic-layer`, `/security/sql-validation`, `/deployment/schema-evolution`, `/reference/cli` all preserved

## Test plan

- [ ] Skim the rendered page to confirm prose flows naturally with the retargeted examples
- [ ] Verify the page is internally consistent with the existing `/semantic-layer/index.mdx` (which already used NovaMart shapes)

## Out of scope

- Restructuring the page (just retargeting, per #2043)
- Other docs pages (caught in #2040; this was the one straggler)