### PR TITLE
refactor(eval): #2044 — Question discriminated union (drop ?? "" fallbacks)

### DIFF
--- a/apps/docs/content/docs/contributing/eval-harness.mdx
+++ b/apps/docs/content/docs/contributing/eval-harness.mdx
@@ -62,7 +62,11 @@ Atlas canonical-question eval
    - `pattern` — pass `entity` + `pattern`. Resolves a `query_patterns[*].sql` from an entity YAML.
    - `virtual` — pass `entity`, `dimension`, and an inline `sql`. Used to prove a `virtual: true` dimension compiles against the seed.
    - `glossary` — pass `term`. The harness asserts the glossary status (`ambiguous` / `defined`) and minimum mapping count.
-3. Choose loose `expect:` assertions — the harness runs against a deterministic seed, but absolute scalar values are brittle. Prefer `sql_pattern` (substrings the resolved SQL must contain), `min_rows` / `max_rows` (row-count bounds), `non_zero` (scalar metric guards), and `column` (single named column).
+3. Choose loose `expect:` assertions — the harness runs against a deterministic seed, but absolute scalar values are brittle. The accepted fields are per-mode:
+   - `metric` / `pattern` / `virtual` — `sql_pattern` (substrings the resolved SQL must contain), `min_rows` / `max_rows` (row-count bounds), `non_zero` (scalar metric guards), `column` (single named column).
+   - `glossary` — `status` (`defined` / `ambiguous`) and `mappings_min` (minimum number of `possible_mappings`).
+
+   The loader rejects mismatched shapes (e.g. a `glossary` question with `sql_pattern`, or a `metric` question with `status`) — the offending question id is named in the error message.
 4. Run `bun run eval:canonical` locally to confirm.
 5. Update this page if your question category isn't already covered.
 

--- a/apps/docs/content/docs/contributing/eval-harness.mdx
+++ b/apps/docs/content/docs/contributing/eval-harness.mdx
@@ -66,7 +66,7 @@ Atlas canonical-question eval
    - `metric` / `pattern` / `virtual` — `sql_pattern` (substrings the resolved SQL must contain), `min_rows` / `max_rows` (row-count bounds), `non_zero` (scalar metric guards), `column` (single named column).
    - `glossary` — `status` (`defined` / `ambiguous`) and `mappings_min` (minimum number of `possible_mappings`).
 
-   The loader rejects mismatched shapes (e.g. a `glossary` question with `sql_pattern`, or a `metric` question with `status`) — the offending question id is named in the error message.
+   The loader rejects mismatched shapes (e.g. a `glossary` question with `sql_pattern`, or a `metric` question with `status`) — the offending question id and every offending field are named in the error message.
 4. Run `bun run eval:canonical` locally to confirm.
 5. Update this page if your question category isn't already covered.
 

--- a/packages/cli/bin/__tests__/canonical-eval.test.ts
+++ b/packages/cli/bin/__tests__/canonical-eval.test.ts
@@ -107,6 +107,65 @@ describe("loadQuestions", () => {
     expect(() => loadQuestions(tmp)).toThrow(/Duplicate/);
     fs.unlinkSync(tmp);
   });
+
+  // ── Per-mode `expect` mismatch rejection ────────────────────────────────
+  // The discriminated `Question` shape gives metric/pattern/virtual a
+  // SqlExpectations and glossary a GlossaryExpectations. The loader is the
+  // runtime gate that enforces this on operator-authored YAML.
+
+  async function writeTempYaml(
+    body: string,
+  ): Promise<{ path: string; cleanup: () => void }> {
+    const fs = await import("fs");
+    const os = await import("os");
+    const tmp = path.join(os.tmpdir(), `cq-mismatch-${Date.now()}-${Math.random()}.yml`);
+    fs.writeFileSync(tmp, `version: '1.0'\nquestions:\n${body}`);
+    return { path: tmp, cleanup: () => fs.unlinkSync(tmp) };
+  }
+
+  test("rejects glossary question carrying sql-shaped expect.sql_pattern", async () => {
+    const { path: tmp, cleanup } = await writeTempYaml(
+      "  - id: cq-201\n    category: glossary\n    question: x\n    mode: glossary\n    term: revenue\n    expect:\n      sql_pattern: ['FROM orders']\n",
+    );
+    expect(() => loadQuestions(tmp)).toThrow(/cq-201.*"glossary".*sql_pattern/);
+    cleanup();
+  });
+
+  test("rejects glossary question carrying sql-shaped expect.non_zero", async () => {
+    const { path: tmp, cleanup } = await writeTempYaml(
+      "  - id: cq-202\n    category: glossary\n    question: x\n    mode: glossary\n    term: revenue\n    expect:\n      non_zero: true\n",
+    );
+    expect(() => loadQuestions(tmp)).toThrow(/cq-202.*"glossary".*non_zero/);
+    cleanup();
+  });
+
+  test("rejects metric question carrying glossary-shaped expect.status", async () => {
+    const { path: tmp, cleanup } = await writeTempYaml(
+      "  - id: cq-203\n    category: simple_metric\n    question: x\n    mode: metric\n    metric_id: total_gmv\n    expect:\n      status: ambiguous\n",
+    );
+    expect(() => loadQuestions(tmp)).toThrow(/cq-203.*"metric".*status/);
+    cleanup();
+  });
+
+  test("rejects pattern question carrying glossary-shaped expect.mappings_min", async () => {
+    const { path: tmp, cleanup } = await writeTempYaml(
+      "  - id: cq-204\n    category: filtered_pattern\n    question: x\n    mode: pattern\n    entity: Orders\n    pattern: orders_with_promotions\n    expect:\n      mappings_min: 2\n",
+    );
+    expect(() => loadQuestions(tmp)).toThrow(/cq-204.*"pattern".*mappings_min/);
+    cleanup();
+  });
+
+  test("error message names the offending question id and the offending field", async () => {
+    const { path: tmp, cleanup } = await writeTempYaml(
+      "  - id: cq-205\n    category: glossary\n    question: x\n    mode: glossary\n    term: revenue\n    expect:\n      sql_pattern: ['FROM orders']\n      non_zero: true\n",
+    );
+    // Should call out BOTH offenders, not just the first one — operators
+    // editing YAML want to see every problem in one pass.
+    expect(() => loadQuestions(tmp)).toThrow(
+      /cq-205.*sql_pattern.*non_zero/s,
+    );
+    cleanup();
+  });
 });
 
 // ── compareMetricResult ──────────────────────────────────────────────────
@@ -454,25 +513,34 @@ describe("compareVirtualResult / comparePatternResult", () => {
 
 describe("formatSummary", () => {
   test("renders X/N passing with category breakdown", () => {
+    const passQ: Question = {
+      id: "cq-001",
+      category: "simple_metric",
+      question: "Total GMV?",
+      mode: "metric",
+      metric_id: "total_gmv",
+      expect: { sql_pattern: ["FROM orders"] },
+    };
+    const failQ: Question = {
+      id: "cq-002",
+      category: "simple_metric",
+      question: "Total customers?",
+      mode: "metric",
+      metric_id: "total_customers",
+      expect: { sql_pattern: ["FROM customers"] },
+    };
+    const warnQ: Question = {
+      id: "cq-013",
+      category: "glossary",
+      question: "What is revenue?",
+      mode: "glossary",
+      term: "revenue",
+      expect: { status: "ambiguous" },
+    };
     const out = formatSummary([
-      {
-        question: { id: "cq-001", category: "simple_metric", mode: "metric" } as Question,
-        status: "pass",
-        detail: "ok",
-        sql: "SELECT 1",
-      },
-      {
-        question: { id: "cq-002", category: "simple_metric", mode: "metric" } as Question,
-        status: "fail",
-        detail: "boom",
-        sql: null,
-      },
-      {
-        question: { id: "cq-013", category: "glossary", mode: "glossary" } as Question,
-        status: "warn",
-        detail: "soft",
-        sql: null,
-      },
+      { question: passQ, status: "pass", detail: "ok", sql: "SELECT 1" },
+      { question: failQ, status: "fail", detail: "boom", sql: null },
+      { question: warnQ, status: "warn", detail: "soft", sql: null },
     ]);
     expect(out).toMatch(/1\/3 passing/);
     expect(out).toMatch(/cq-001/);
@@ -602,6 +670,151 @@ describe("resolveQuestion", () => {
     );
     expect(r.status).toBe("fail");
     expect(r.detail).toMatch(/connection refused/);
+  });
+});
+
+// ── Dispatcher routing ──────────────────────────────────────────────────
+// The deferred test-C2: per mode, prove resolveQuestion calls the correct
+// dependency on RunHarnessOptions and does NOT touch the others. Bug class
+// caught: a future refactor of the dispatcher accidentally hits
+// `searchGlossary` for a metric question (returns empty, falls through to
+// "fail: no glossary match" — confusing failure mode).
+
+describe("resolveQuestion dispatcher routing", () => {
+  function spy<T extends (...args: never[]) => unknown>(impl: T) {
+    const calls: Parameters<T>[] = [];
+    const fn = ((...args: Parameters<T>) => {
+      calls.push(args);
+      return impl(...args);
+    }) as T;
+    return { fn, calls };
+  }
+
+  test("metric mode hits findMetricSql + executeSql, skips findPatternSql/searchGlossary", async () => {
+    const findMetric = spy((_id: string) => "SELECT 1 AS v FROM orders");
+    const findPattern = spy((_e: string, _p: string) => null as string | null);
+    const search = spy((_t: string) => [] as readonly GlossaryMatch[]);
+    const exec = spy(async (_sql: string) => ({
+      columns: ["v"] as readonly string[],
+      rows: [{ v: 1 }] as readonly Record<string, unknown>[],
+    }));
+
+    const q: Question = {
+      id: "cq-301",
+      category: "simple_metric",
+      question: "x",
+      mode: "metric",
+      metric_id: "total_gmv",
+      expect: { sql_pattern: ["FROM orders"] },
+    };
+    await resolveQuestion(q, {
+      findMetricSql: findMetric.fn,
+      findPatternSql: findPattern.fn,
+      searchGlossary: search.fn,
+      executeSql: exec.fn,
+    });
+
+    expect(findMetric.calls).toEqual([["total_gmv"]]);
+    expect(exec.calls.length).toBe(1);
+    expect(findPattern.calls.length).toBe(0);
+    expect(search.calls.length).toBe(0);
+  });
+
+  test("pattern mode hits findPatternSql + executeSql, skips findMetricSql/searchGlossary", async () => {
+    const findMetric = spy((_id: string) => null as string | null);
+    const findPattern = spy(
+      (_e: string, _p: string) => "SELECT 1 FROM orders WHERE 1=1",
+    );
+    const search = spy((_t: string) => [] as readonly GlossaryMatch[]);
+    const exec = spy(async (_sql: string) => ({
+      columns: [] as readonly string[],
+      rows: [] as readonly Record<string, unknown>[],
+    }));
+
+    const q: Question = {
+      id: "cq-302",
+      category: "filtered_pattern",
+      question: "x",
+      mode: "pattern",
+      entity: "Orders",
+      pattern: "orders_with_promotions",
+      expect: {},
+    };
+    await resolveQuestion(q, {
+      findMetricSql: findMetric.fn,
+      findPatternSql: findPattern.fn,
+      searchGlossary: search.fn,
+      executeSql: exec.fn,
+    });
+
+    expect(findPattern.calls).toEqual([["Orders", "orders_with_promotions"]]);
+    expect(exec.calls.length).toBe(1);
+    expect(findMetric.calls.length).toBe(0);
+    expect(search.calls.length).toBe(0);
+  });
+
+  test("virtual mode hits executeSql with inline question.sql, skips lookup deps", async () => {
+    const findMetric = spy((_id: string) => null as string | null);
+    const findPattern = spy((_e: string, _p: string) => null as string | null);
+    const search = spy((_t: string) => [] as readonly GlossaryMatch[]);
+    const exec = spy(async (_sql: string) => ({
+      columns: ["bucket"] as readonly string[],
+      rows: [{ bucket: "Small" }] as readonly Record<string, unknown>[],
+    }));
+
+    const q: Question = {
+      id: "cq-303",
+      category: "virtual_dimension",
+      question: "x",
+      mode: "virtual",
+      entity: "Orders",
+      dimension: "order_size_bucket",
+      sql: "SELECT 'Small' AS bucket",
+      expect: { column: "bucket" },
+    };
+    await resolveQuestion(q, {
+      findMetricSql: findMetric.fn,
+      findPatternSql: findPattern.fn,
+      searchGlossary: search.fn,
+      executeSql: exec.fn,
+    });
+
+    expect(exec.calls).toEqual([["SELECT 'Small' AS bucket"]]);
+    expect(findMetric.calls.length).toBe(0);
+    expect(findPattern.calls.length).toBe(0);
+    expect(search.calls.length).toBe(0);
+  });
+
+  test("glossary mode hits searchGlossary only — never executeSql or SQL lookups", async () => {
+    const findMetric = spy((_id: string) => null as string | null);
+    const findPattern = spy((_e: string, _p: string) => null as string | null);
+    const search = spy((term: string) => [
+      { term, status: "ambiguous", possible_mappings: ["a", "b"] },
+    ] as readonly GlossaryMatch[]);
+    const exec = spy(async (_sql: string) => ({
+      columns: [] as readonly string[],
+      rows: [] as readonly Record<string, unknown>[],
+    }));
+
+    const q: Question = {
+      id: "cq-304",
+      category: "glossary",
+      question: "x",
+      mode: "glossary",
+      term: "revenue",
+      expect: { status: "ambiguous", mappings_min: 2 },
+    };
+    await resolveQuestion(q, {
+      findMetricSql: findMetric.fn,
+      findPatternSql: findPattern.fn,
+      searchGlossary: search.fn,
+      executeSql: exec.fn,
+    });
+
+    expect(search.calls).toEqual([["revenue"]]);
+    expect(exec.calls.length).toBe(0);
+    expect(findMetric.calls.length).toBe(0);
+    expect(findPattern.calls.length).toBe(0);
   });
 });
 

--- a/packages/cli/bin/__tests__/canonical-eval.test.ts
+++ b/packages/cli/bin/__tests__/canonical-eval.test.ts
@@ -7,7 +7,7 @@
  * wiring; these tests inject stubs.
  */
 
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import * as path from "path";
 import {
   loadQuestions,
@@ -164,6 +164,71 @@ describe("loadQuestions", () => {
     expect(() => loadQuestions(tmp)).toThrow(
       /cq-205.*sql_pattern.*non_zero/s,
     );
+    cleanup();
+  });
+
+  test("rejects forbidden expect key set to YAML null (~ counts as set)", async () => {
+    // `key: ~` and `key: null` parse to JS `null`. The loader treats null
+    // as "operator typed it, surface the cross-mode mismatch" — not as
+    // "absent". Pin this so a future refactor can't silently flip to
+    // `expect[k] != null` (which would tolerate explicit null).
+    const { path: tmp, cleanup } = await writeTempYaml(
+      "  - id: cq-206\n    category: glossary\n    question: x\n    mode: glossary\n    term: revenue\n    expect:\n      sql_pattern: ~\n      status: ambiguous\n",
+    );
+    expect(() => loadQuestions(tmp)).toThrow(/cq-206.*"glossary".*sql_pattern/);
+    cleanup();
+  });
+
+  // ── Per-arm required-field rejection ────────────────────────────────────
+  // `requireString` enforces non-empty discriminator-adjacent fields per
+  // mode. Previously untested — a future no-op refactor of the helper or
+  // its call sites would silently pass without these gates.
+
+  test("rejects metric question without metric_id", async () => {
+    const { path: tmp, cleanup } = await writeTempYaml(
+      "  - id: cq-301\n    category: simple_metric\n    question: x\n    mode: metric\n    expect: {}\n",
+    );
+    expect(() => loadQuestions(tmp)).toThrow(/cq-301.*metric_id.*non-empty/);
+    cleanup();
+  });
+
+  test("rejects pattern question missing entity", async () => {
+    const { path: tmp, cleanup } = await writeTempYaml(
+      "  - id: cq-302\n    category: filtered_pattern\n    question: x\n    mode: pattern\n    pattern: orders_with_promotions\n    expect: {}\n",
+    );
+    expect(() => loadQuestions(tmp)).toThrow(/cq-302.*entity.*non-empty/);
+    cleanup();
+  });
+
+  test("rejects virtual question missing inline sql", async () => {
+    const { path: tmp, cleanup } = await writeTempYaml(
+      "  - id: cq-303\n    category: virtual_dimension\n    question: x\n    mode: virtual\n    entity: Orders\n    dimension: order_size_bucket\n    expect: {}\n",
+    );
+    expect(() => loadQuestions(tmp)).toThrow(/cq-303.*sql.*non-empty/);
+    cleanup();
+  });
+
+  test("rejects glossary question without term", async () => {
+    const { path: tmp, cleanup } = await writeTempYaml(
+      "  - id: cq-304\n    category: glossary\n    question: x\n    mode: glossary\n    expect: {}\n",
+    );
+    expect(() => loadQuestions(tmp)).toThrow(/cq-304.*term.*non-empty/);
+    cleanup();
+  });
+
+  test("rejects metric_id with the wrong type (numeric YAML literal)", async () => {
+    const { path: tmp, cleanup } = await writeTempYaml(
+      "  - id: cq-305\n    category: simple_metric\n    question: x\n    mode: metric\n    metric_id: 42\n    expect: {}\n",
+    );
+    expect(() => loadQuestions(tmp)).toThrow(/cq-305.*metric_id.*non-empty/);
+    cleanup();
+  });
+
+  test("rejects an unknown mode value", async () => {
+    const { path: tmp, cleanup } = await writeTempYaml(
+      "  - id: cq-306\n    category: simple_metric\n    question: x\n    mode: sqlite\n    metric_id: total_gmv\n    expect: {}\n",
+    );
+    expect(() => loadQuestions(tmp)).toThrow(/cq-306.*mode must be one of/);
     cleanup();
   });
 });
@@ -547,6 +612,26 @@ describe("formatSummary", () => {
     expect(out).toMatch(/cq-002/);
     expect(out).toMatch(/cq-013/);
   });
+
+  test("pass result with omitted detail does not render 'undefined'", () => {
+    // `QuestionResult` makes `detail` optional on pass-arm results. The
+    // formatter only prints `detail` for warn|fail, but an explicit
+    // regression test pins that — guards against a refactor that
+    // accidentally re-adds an unconditional `${r.detail}` line.
+    const passQ: Question = {
+      id: "cq-401",
+      category: "simple_metric",
+      question: "Probe?",
+      mode: "metric",
+      metric_id: "total_gmv",
+      expect: {},
+    };
+    const out = formatSummary([
+      { question: passQ, status: "pass", sql: "SELECT 1" },
+    ]);
+    expect(out).not.toMatch(/undefined/);
+    expect(out).toMatch(/1\/1 passing/);
+  });
 });
 
 // ── resolveQuestion / runHarness ─────────────────────────────────────────
@@ -681,26 +766,17 @@ describe("resolveQuestion", () => {
 // "fail: no glossary match" — confusing failure mode).
 
 describe("resolveQuestion dispatcher routing", () => {
-  function spy<T extends (...args: never[]) => unknown>(impl: T) {
-    const calls: Parameters<T>[] = [];
-    const fn = ((...args: Parameters<T>) => {
-      calls.push(args);
-      return impl(...args);
-    }) as T;
-    return { fn, calls };
-  }
-
   test("metric mode hits findMetricSql + executeSql, skips findPatternSql/searchGlossary", async () => {
-    const findMetric = spy((_id: string) => "SELECT 1 AS v FROM orders");
-    const findPattern = spy((_e: string, _p: string) => null as string | null);
-    const search = spy((_t: string) => [] as readonly GlossaryMatch[]);
-    const exec = spy(async (_sql: string) => ({
+    const findMetric = mock((_id: string) => "SELECT 1 AS v FROM orders");
+    const findPattern = mock((_e: string, _p: string) => null as string | null);
+    const search = mock((_t: string) => [] as readonly GlossaryMatch[]);
+    const exec = mock(async (_sql: string) => ({
       columns: ["v"] as readonly string[],
       rows: [{ v: 1 }] as readonly Record<string, unknown>[],
     }));
 
     const q: Question = {
-      id: "cq-301",
+      id: "cq-401",
       category: "simple_metric",
       question: "x",
       mode: "metric",
@@ -708,31 +784,31 @@ describe("resolveQuestion dispatcher routing", () => {
       expect: { sql_pattern: ["FROM orders"] },
     };
     await resolveQuestion(q, {
-      findMetricSql: findMetric.fn,
-      findPatternSql: findPattern.fn,
-      searchGlossary: search.fn,
-      executeSql: exec.fn,
+      findMetricSql: findMetric,
+      findPatternSql: findPattern,
+      searchGlossary: search,
+      executeSql: exec,
     });
 
-    expect(findMetric.calls).toEqual([["total_gmv"]]);
-    expect(exec.calls.length).toBe(1);
-    expect(findPattern.calls.length).toBe(0);
-    expect(search.calls.length).toBe(0);
+    expect(findMetric.mock.calls).toEqual([["total_gmv"]]);
+    expect(exec.mock.calls.length).toBe(1);
+    expect(findPattern.mock.calls.length).toBe(0);
+    expect(search.mock.calls.length).toBe(0);
   });
 
   test("pattern mode hits findPatternSql + executeSql, skips findMetricSql/searchGlossary", async () => {
-    const findMetric = spy((_id: string) => null as string | null);
-    const findPattern = spy(
+    const findMetric = mock((_id: string) => null as string | null);
+    const findPattern = mock(
       (_e: string, _p: string) => "SELECT 1 FROM orders WHERE 1=1",
     );
-    const search = spy((_t: string) => [] as readonly GlossaryMatch[]);
-    const exec = spy(async (_sql: string) => ({
+    const search = mock((_t: string) => [] as readonly GlossaryMatch[]);
+    const exec = mock(async (_sql: string) => ({
       columns: [] as readonly string[],
       rows: [] as readonly Record<string, unknown>[],
     }));
 
     const q: Question = {
-      id: "cq-302",
+      id: "cq-402",
       category: "filtered_pattern",
       question: "x",
       mode: "pattern",
@@ -741,29 +817,29 @@ describe("resolveQuestion dispatcher routing", () => {
       expect: {},
     };
     await resolveQuestion(q, {
-      findMetricSql: findMetric.fn,
-      findPatternSql: findPattern.fn,
-      searchGlossary: search.fn,
-      executeSql: exec.fn,
+      findMetricSql: findMetric,
+      findPatternSql: findPattern,
+      searchGlossary: search,
+      executeSql: exec,
     });
 
-    expect(findPattern.calls).toEqual([["Orders", "orders_with_promotions"]]);
-    expect(exec.calls.length).toBe(1);
-    expect(findMetric.calls.length).toBe(0);
-    expect(search.calls.length).toBe(0);
+    expect(findPattern.mock.calls).toEqual([["Orders", "orders_with_promotions"]]);
+    expect(exec.mock.calls.length).toBe(1);
+    expect(findMetric.mock.calls.length).toBe(0);
+    expect(search.mock.calls.length).toBe(0);
   });
 
   test("virtual mode hits executeSql with inline question.sql, skips lookup deps", async () => {
-    const findMetric = spy((_id: string) => null as string | null);
-    const findPattern = spy((_e: string, _p: string) => null as string | null);
-    const search = spy((_t: string) => [] as readonly GlossaryMatch[]);
-    const exec = spy(async (_sql: string) => ({
+    const findMetric = mock((_id: string) => null as string | null);
+    const findPattern = mock((_e: string, _p: string) => null as string | null);
+    const search = mock((_t: string) => [] as readonly GlossaryMatch[]);
+    const exec = mock(async (_sql: string) => ({
       columns: ["bucket"] as readonly string[],
       rows: [{ bucket: "Small" }] as readonly Record<string, unknown>[],
     }));
 
     const q: Question = {
-      id: "cq-303",
+      id: "cq-403",
       category: "virtual_dimension",
       question: "x",
       mode: "virtual",
@@ -773,31 +849,31 @@ describe("resolveQuestion dispatcher routing", () => {
       expect: { column: "bucket" },
     };
     await resolveQuestion(q, {
-      findMetricSql: findMetric.fn,
-      findPatternSql: findPattern.fn,
-      searchGlossary: search.fn,
-      executeSql: exec.fn,
+      findMetricSql: findMetric,
+      findPatternSql: findPattern,
+      searchGlossary: search,
+      executeSql: exec,
     });
 
-    expect(exec.calls).toEqual([["SELECT 'Small' AS bucket"]]);
-    expect(findMetric.calls.length).toBe(0);
-    expect(findPattern.calls.length).toBe(0);
-    expect(search.calls.length).toBe(0);
+    expect(exec.mock.calls).toEqual([["SELECT 'Small' AS bucket"]]);
+    expect(findMetric.mock.calls.length).toBe(0);
+    expect(findPattern.mock.calls.length).toBe(0);
+    expect(search.mock.calls.length).toBe(0);
   });
 
   test("glossary mode hits searchGlossary only — never executeSql or SQL lookups", async () => {
-    const findMetric = spy((_id: string) => null as string | null);
-    const findPattern = spy((_e: string, _p: string) => null as string | null);
-    const search = spy((term: string) => [
+    const findMetric = mock((_id: string) => null as string | null);
+    const findPattern = mock((_e: string, _p: string) => null as string | null);
+    const search = mock((term: string) => [
       { term, status: "ambiguous", possible_mappings: ["a", "b"] },
     ] as readonly GlossaryMatch[]);
-    const exec = spy(async (_sql: string) => ({
+    const exec = mock(async (_sql: string) => ({
       columns: [] as readonly string[],
       rows: [] as readonly Record<string, unknown>[],
     }));
 
     const q: Question = {
-      id: "cq-304",
+      id: "cq-404",
       category: "glossary",
       question: "x",
       mode: "glossary",
@@ -805,16 +881,16 @@ describe("resolveQuestion dispatcher routing", () => {
       expect: { status: "ambiguous", mappings_min: 2 },
     };
     await resolveQuestion(q, {
-      findMetricSql: findMetric.fn,
-      findPatternSql: findPattern.fn,
-      searchGlossary: search.fn,
-      executeSql: exec.fn,
+      findMetricSql: findMetric,
+      findPatternSql: findPattern,
+      searchGlossary: search,
+      executeSql: exec,
     });
 
-    expect(search.calls).toEqual([["revenue"]]);
-    expect(exec.calls.length).toBe(0);
-    expect(findMetric.calls.length).toBe(0);
-    expect(findPattern.calls.length).toBe(0);
+    expect(search.mock.calls).toEqual([["revenue"]]);
+    expect(exec.mock.calls.length).toBe(0);
+    expect(findMetric.mock.calls.length).toBe(0);
+    expect(findPattern.mock.calls.length).toBe(0);
   });
 });
 

--- a/packages/cli/bin/canonical-eval-run.ts
+++ b/packages/cli/bin/canonical-eval-run.ts
@@ -304,6 +304,11 @@ async function runWithAgent(
       };
     }
 
+    // The `?? ""` / `?? null` are required under TS strict
+    // `noUncheckedIndexedAccess` — array index access is `T | undefined`.
+    // The empty-array hard-fail below at `agent.sql.length === 0` is the
+    // load-bearing guard for the empty case; these defaults only feed the
+    // early-return branch's `sql: lastSql || null` mapping.
     const lastSql = agent.sql[agent.sql.length - 1] ?? "";
     const lastData = agent.data[agent.data.length - 1] ?? null;
 

--- a/packages/cli/bin/canonical-eval-run.ts
+++ b/packages/cli/bin/canonical-eval-run.ts
@@ -283,7 +283,7 @@ async function runWithAgent(
     // Glossary mode never invokes the agent — we assert the
     // disambiguation contract by checking semantic-layer state directly.
     if (q.mode === "glossary") {
-      return compareGlossaryResult(q, toGlossaryMatches(lookups, q.term ?? ""));
+      return compareGlossaryResult(q, toGlossaryMatches(lookups, q.term));
     }
 
     // Narrow the try/catch to ONLY the agent invocation. Comparator
@@ -337,7 +337,7 @@ async function runWithAgent(
       case "virtual":
         return compareVirtualResult(q, executed);
       default: {
-        const _exhaustive: never = q.mode;
+        const _exhaustive: never = q;
         throw new Error(`unreachable mode: ${String(_exhaustive)}`);
       }
     }

--- a/packages/cli/bin/canonical-eval.ts
+++ b/packages/cli/bin/canonical-eval.ts
@@ -44,12 +44,21 @@ interface BaseExpectations {
   readonly column?: string;
 }
 
-/** Expectations for SQL-bearing modes (metric / pattern / virtual). */
+/**
+ * Expectations for SQL-bearing modes (metric / pattern / virtual).
+ *
+ * The `?: never` slots make the discriminated `Question` union exclusive at
+ * the type level — a literal that mixes SQL-shaped and glossary-shaped
+ * fields fails at compile time, so `rejectKeys` in `loadQuestions` is a
+ * runtime echo of a TS guarantee, not the only line of defence.
+ */
 export interface SqlExpectations extends BaseExpectations {
   /** Case-insensitive substrings that must appear in the executed SQL. */
   readonly sql_pattern?: readonly string[];
   /** Scalar metric must return a non-zero numeric value. */
   readonly non_zero?: boolean;
+  readonly status?: never;
+  readonly mappings_min?: never;
 }
 
 /** Expectations for glossary disambiguation lookups. */
@@ -58,6 +67,11 @@ export interface GlossaryExpectations {
   readonly status?: "defined" | "ambiguous";
   /** Minimum number of `possible_mappings` on an ambiguous glossary term. */
   readonly mappings_min?: number;
+  readonly sql_pattern?: never;
+  readonly non_zero?: never;
+  readonly min_rows?: never;
+  readonly max_rows?: never;
+  readonly column?: never;
 }
 
 interface QuestionBase {
@@ -186,6 +200,12 @@ function requireString(id: string, field: string, value: unknown): string {
   return value;
 }
 
+/**
+ * Reject any forbidden keys present on an `expect:` block. An explicit YAML
+ * `null` (e.g. `expect: { sql_pattern: ~ }`) counts as set and is rejected
+ * — a contributor who typed the key intended it; the right response is to
+ * surface the cross-mode mismatch, not silently treat null as absent.
+ */
 function rejectKeys(
   id: string,
   mode: QuestionMode,
@@ -385,8 +405,10 @@ function checkNonZero(
 /**
  * Generic comparator used by metric / pattern / virtual modes. The three
  * exported `compare*Result` functions below are aliases — the per-mode
- * dispatch happens in `resolveQuestion`, but distinct names document intent
- * at the call sites in `canonical-eval-run.ts`.
+ * dispatch happens in `resolveQuestion`, and the `SqlQuestion` parameter
+ * type now type-enforces that callers can't pass a glossary question. The
+ * named aliases document intent at the LLM-mode call sites in
+ * `canonical-eval-run.ts`.
  */
 function compareSqlResult(
   question: SqlQuestion,

--- a/packages/cli/bin/canonical-eval.ts
+++ b/packages/cli/bin/canonical-eval.ts
@@ -35,36 +35,64 @@ export type QuestionCategory =
   | "glossary"
   | "filtered_pattern";
 
-export interface QuestionExpectations {
-  /** Case-insensitive substrings that must appear in the executed SQL. */
-  readonly sql_pattern?: readonly string[];
+interface BaseExpectations {
   /** Lower bound on row count. */
   readonly min_rows?: number;
   /** Upper bound on row count. */
   readonly max_rows?: number;
-  /** Scalar metric must return a non-zero numeric value. */
-  readonly non_zero?: boolean;
   /** Named column must appear in the result columns. */
   readonly column?: string;
+}
+
+/** Expectations for SQL-bearing modes (metric / pattern / virtual). */
+export interface SqlExpectations extends BaseExpectations {
+  /** Case-insensitive substrings that must appear in the executed SQL. */
+  readonly sql_pattern?: readonly string[];
+  /** Scalar metric must return a non-zero numeric value. */
+  readonly non_zero?: boolean;
+}
+
+/** Expectations for glossary disambiguation lookups. */
+export interface GlossaryExpectations {
   /** Glossary status (`defined` / `ambiguous`). */
   readonly status?: "defined" | "ambiguous";
   /** Minimum number of `possible_mappings` on an ambiguous glossary term. */
   readonly mappings_min?: number;
 }
 
-export interface Question {
+interface QuestionBase {
   readonly id: string;
   readonly category: QuestionCategory;
   readonly question: string;
-  readonly mode: QuestionMode;
-  readonly metric_id?: string;
-  readonly entity?: string;
-  readonly pattern?: string;
-  readonly dimension?: string;
-  readonly sql?: string;
-  readonly term?: string;
-  readonly expect: QuestionExpectations;
 }
+
+export type Question =
+  | (QuestionBase & {
+      readonly mode: "metric";
+      readonly metric_id: string;
+      readonly expect: SqlExpectations;
+    })
+  | (QuestionBase & {
+      readonly mode: "pattern";
+      readonly entity: string;
+      readonly pattern: string;
+      readonly expect: SqlExpectations;
+    })
+  | (QuestionBase & {
+      readonly mode: "virtual";
+      readonly entity: string;
+      readonly dimension: string;
+      readonly sql: string;
+      readonly expect: SqlExpectations;
+    })
+  | (QuestionBase & {
+      readonly mode: "glossary";
+      readonly term: string;
+      readonly expect: GlossaryExpectations;
+    });
+
+export type SqlQuestion = Extract<Question, { mode: "metric" | "pattern" | "virtual" }>;
+export type GlossaryQuestion = Extract<Question, { mode: "glossary" }>;
 
 /**
  * Wire shape returned by an executed SQL query — used by both the metric /
@@ -97,12 +125,23 @@ export interface GlossaryMatch {
 
 export type ResultStatus = "pass" | "warn" | "fail";
 
-export interface QuestionResult {
+interface QuestionResultBase {
   readonly question: Question;
-  readonly status: ResultStatus;
-  readonly detail: string;
   readonly sql: string | null;
 }
+
+/**
+ * Discriminated by `status`:
+ *   - `pass` — `detail` is an optional summary ("12 rows").
+ *   - `warn` / `fail` — `detail` is required and explains why.
+ *
+ * Splitting the shape lets formatters and downstream consumers ask "is there
+ * a reason to print" without falling back on truthiness of an always-present
+ * string.
+ */
+export type QuestionResult =
+  | (QuestionResultBase & { readonly status: "pass"; readonly detail?: string })
+  | (QuestionResultBase & { readonly status: "warn" | "fail"; readonly detail: string });
 
 interface QuestionsFile {
   readonly version?: string;
@@ -129,6 +168,41 @@ const VALID_CATEGORIES: ReadonlySet<QuestionCategory> = new Set([
 
 // ── Loader ───────────────────────────────────────────────────────────────
 
+/** Fields only valid on glossary-mode `expect`. Rejected on SQL-bearing modes. */
+const GLOSSARY_ONLY_EXPECT_KEYS = ["status", "mappings_min"] as const;
+/** Fields only valid on SQL-bearing-mode `expect`. Rejected on glossary mode. */
+const SQL_ONLY_EXPECT_KEYS = [
+  "sql_pattern",
+  "non_zero",
+  "min_rows",
+  "max_rows",
+  "column",
+] as const;
+
+function requireString(id: string, field: string, value: unknown): string {
+  if (typeof value !== "string" || !value) {
+    throw new Error(`${id}: ${field} must be a non-empty string`);
+  }
+  return value;
+}
+
+function rejectKeys(
+  id: string,
+  mode: QuestionMode,
+  expect: Record<string, unknown>,
+  forbidden: readonly string[],
+): void {
+  const offenders = forbidden.filter((k) => expect[k] !== undefined);
+  if (offenders.length > 0) {
+    throw new Error(
+      `${id}: mode "${mode}" rejects expect.${offenders.join(", expect.")} ` +
+        `— those fields are only valid on ${
+          mode === "glossary" ? "metric/pattern/virtual" : "glossary"
+        } questions`,
+    );
+  }
+}
+
 export function loadQuestions(filePath: string): Question[] {
   if (!fs.existsSync(filePath)) {
     throw new Error(`Canonical questions file not found: ${filePath}`);
@@ -152,24 +226,25 @@ export function loadQuestions(filePath: string): Question[] {
     if (!rawQ || typeof rawQ !== "object") {
       throw new Error(`questions[${i}] is not an object in ${filePath}`);
     }
-    const q = rawQ as Partial<Question>;
+    const q = rawQ as Record<string, unknown>;
 
     if (typeof q.id !== "string" || !/^cq-\d{3}$/.test(q.id)) {
       throw new Error(
         `questions[${i}].id must match /^cq-\\d{3}$/ in ${filePath} (got ${String(q.id)})`,
       );
     }
-    if (seen.has(q.id)) {
-      throw new Error(`Duplicate question id "${q.id}" in ${filePath}`);
+    const id = q.id;
+    if (seen.has(id)) {
+      throw new Error(`Duplicate question id "${id}" in ${filePath}`);
     }
-    seen.add(q.id);
+    seen.add(id);
 
     if (typeof q.question !== "string" || !q.question.trim()) {
-      throw new Error(`${q.id}: question must be a non-empty string`);
+      throw new Error(`${id}: question must be a non-empty string`);
     }
     if (typeof q.mode !== "string" || !VALID_MODES.has(q.mode as QuestionMode)) {
       throw new Error(
-        `${q.id}: mode must be one of ${[...VALID_MODES].join(", ")} (got ${String(q.mode)})`,
+        `${id}: mode must be one of ${[...VALID_MODES].join(", ")} (got ${String(q.mode)})`,
       );
     }
     if (
@@ -177,28 +252,68 @@ export function loadQuestions(filePath: string): Question[] {
       !VALID_CATEGORIES.has(q.category as QuestionCategory)
     ) {
       throw new Error(
-        `${q.id}: category must be one of ${[...VALID_CATEGORIES].join(", ")} (got ${String(q.category)})`,
+        `${id}: category must be one of ${[...VALID_CATEGORIES].join(", ")} (got ${String(q.category)})`,
       );
     }
     if (!q.expect || typeof q.expect !== "object") {
-      throw new Error(`${q.id}: expect must be an object`);
+      throw new Error(`${id}: expect must be an object`);
     }
 
     const mode = q.mode as QuestionMode;
-    if (mode === "metric" && !q.metric_id) {
-      throw new Error(`${q.id}: metric mode requires metric_id`);
-    }
-    if (mode === "pattern" && (!q.entity || !q.pattern)) {
-      throw new Error(`${q.id}: pattern mode requires entity + pattern`);
-    }
-    if (mode === "virtual" && (!q.entity || !q.dimension || !q.sql)) {
-      throw new Error(`${q.id}: virtual mode requires entity + dimension + sql`);
-    }
-    if (mode === "glossary" && !q.term) {
-      throw new Error(`${q.id}: glossary mode requires term`);
-    }
+    const category = q.category as QuestionCategory;
+    const question = q.question;
+    const expect = q.expect as Record<string, unknown>;
+    const base = { id, category, question } as const;
 
-    out.push(q as Question);
+    switch (mode) {
+      case "metric": {
+        rejectKeys(id, mode, expect, GLOSSARY_ONLY_EXPECT_KEYS);
+        out.push({
+          ...base,
+          mode,
+          metric_id: requireString(id, "metric_id", q.metric_id),
+          expect: expect as SqlExpectations,
+        });
+        break;
+      }
+      case "pattern": {
+        rejectKeys(id, mode, expect, GLOSSARY_ONLY_EXPECT_KEYS);
+        out.push({
+          ...base,
+          mode,
+          entity: requireString(id, "entity", q.entity),
+          pattern: requireString(id, "pattern", q.pattern),
+          expect: expect as SqlExpectations,
+        });
+        break;
+      }
+      case "virtual": {
+        rejectKeys(id, mode, expect, GLOSSARY_ONLY_EXPECT_KEYS);
+        out.push({
+          ...base,
+          mode,
+          entity: requireString(id, "entity", q.entity),
+          dimension: requireString(id, "dimension", q.dimension),
+          sql: requireString(id, "sql", q.sql),
+          expect: expect as SqlExpectations,
+        });
+        break;
+      }
+      case "glossary": {
+        rejectKeys(id, mode, expect, SQL_ONLY_EXPECT_KEYS);
+        out.push({
+          ...base,
+          mode,
+          term: requireString(id, "term", q.term),
+          expect: expect as GlossaryExpectations,
+        });
+        break;
+      }
+      default: {
+        const _exhaustive: never = mode;
+        throw new Error(`unreachable mode: ${String(_exhaustive)}`);
+      }
+    }
   }
 
   return out;
@@ -207,7 +322,7 @@ export function loadQuestions(filePath: string): Question[] {
 // ── Per-mode comparators ────────────────────────────────────────────────
 
 function checkSqlPattern(
-  expectations: QuestionExpectations,
+  expectations: SqlExpectations,
   sql: string,
 ): string | null {
   const patterns = expectations.sql_pattern ?? [];
@@ -221,7 +336,7 @@ function checkSqlPattern(
 }
 
 function checkRowBounds(
-  expectations: QuestionExpectations,
+  expectations: SqlExpectations,
   rowCount: number,
 ): { kind: "pass" } | { kind: "warn"; detail: string } {
   if (typeof expectations.min_rows === "number" && rowCount < expectations.min_rows) {
@@ -240,7 +355,7 @@ function checkRowBounds(
 }
 
 function checkColumn(
-  expectations: QuestionExpectations,
+  expectations: SqlExpectations,
   columns: readonly string[],
 ): string | null {
   if (!expectations.column) return null;
@@ -251,7 +366,7 @@ function checkColumn(
 }
 
 function checkNonZero(
-  expectations: QuestionExpectations,
+  expectations: SqlExpectations,
   rows: readonly Record<string, unknown>[],
   columns: readonly string[],
 ): string | null {
@@ -274,7 +389,7 @@ function checkNonZero(
  * at the call sites in `canonical-eval-run.ts`.
  */
 function compareSqlResult(
-  question: Question,
+  question: SqlQuestion,
   executed: ExecutedQuery,
 ): QuestionResult {
   const { sql } = executed;
@@ -305,7 +420,7 @@ export const comparePatternResult = compareSqlResult;
 export const compareVirtualResult = compareSqlResult;
 
 export function compareGlossaryResult(
-  question: Question,
+  question: GlossaryQuestion,
   matches: readonly GlossaryMatch[],
 ): QuestionResult {
   const fail = (detail: string): QuestionResult => ({
@@ -322,7 +437,7 @@ export function compareGlossaryResult(
   });
 
   if (matches.length === 0) {
-    return fail(`no glossary match for term "${question.term ?? ""}"`);
+    return fail(`no glossary match for term "${question.term}"`);
   }
 
   const expectedStatus = question.expect.status ?? null;
@@ -462,12 +577,20 @@ export async function resolveQuestion(
   });
 
   try {
-    // Resolve SQL up-front so the execute + compare tail is shared across
-    // the three SQL-bearing modes. Glossary mode skips SQL entirely.
+    // Glossary mode skips SQL entirely — branch out of the dispatcher
+    // before resolving SQL so TS narrows `question` to `SqlQuestion` for
+    // the shared execute + compare tail below.
+    if (question.mode === "glossary") {
+      return compareGlossaryResult(
+        question,
+        opts.searchGlossary(question.term),
+      );
+    }
+
     let sql: string;
     switch (question.mode) {
       case "metric": {
-        const m = opts.findMetricSql(question.metric_id ?? "");
+        const m = opts.findMetricSql(question.metric_id);
         if (!m) {
           return failNoSql(
             `unknown metric ${JSON.stringify(question.metric_id)}`,
@@ -477,10 +600,7 @@ export async function resolveQuestion(
         break;
       }
       case "pattern": {
-        const p = opts.findPatternSql(
-          question.entity ?? "",
-          question.pattern ?? "",
-        );
+        const p = opts.findPatternSql(question.entity, question.pattern);
         if (!p) {
           return failNoSql(
             `unknown query_pattern ${JSON.stringify(question.entity)}.${JSON.stringify(question.pattern)}`,
@@ -490,17 +610,12 @@ export async function resolveQuestion(
         break;
       }
       case "virtual":
-        sql = question.sql ?? "";
+        sql = question.sql;
         break;
-      case "glossary":
-        return compareGlossaryResult(
-          question,
-          opts.searchGlossary(question.term ?? ""),
-        );
       default: {
         // Compile-time exhaustiveness — adding a new mode here forces TS to
         // flag this branch. Mirrors the dispatcher in `runWithAgent`.
-        const _exhaustive: never = question.mode;
+        const _exhaustive: never = question;
         throw new Error(`unreachable mode: ${String(_exhaustive)}`);
       }
     }


### PR DESCRIPTION
Closes #2044.

## Summary

Tightens `Question` in `packages/cli/bin/canonical-eval.ts` into a real tagged discriminated union — `mode` now drives both the per-arm fields (`metric_id` / `entity` / `pattern` / `dimension` / `sql` / `term`) and the `expect` shape (`SqlExpectations` for metric/pattern/virtual, `GlossaryExpectations` for glossary). TS proves per-mode invariants, so every consumer drops its `?? ""` fallback.

## Changes

- **Type tightening** — `Question` is a 4-arm tagged union; `expect` per-mode (`SqlExpectations` vs `GlossaryExpectations`); `QuestionBase` extracted; `SqlQuestion` / `GlossaryQuestion` exported for comparator signatures.
- **Loader is a real parser** — `loadQuestions` produces a fully-narrowed `Question[]`, with explicit per-arm validation. Rejects metric/pattern/virtual carrying glossary-shaped `expect` (`status`, `mappings_min`) and glossary carrying SQL-shaped `expect` (`sql_pattern`, `non_zero`, `min_rows`, `max_rows`, `column`). Error messages name the offending question id and every offending field.
- **`?? ""` removed** — 6 sites in `resolveQuestion` (`metric_id`, `entity`, `pattern`, `term`, `sql`) + 1 in `runWithAgent` (`q.term ?? ""`). The exhaustiveness `never` checks now narrow on the question itself, not just `q.mode`.
- **`QuestionResult` tightened (review I1)** — split into pass arm (optional `detail` summary) + warn|fail arm (required `detail`).
- **Comparators narrowed** — `compareSqlResult` takes `SqlQuestion`; `compareGlossaryResult` takes `GlossaryQuestion`. The `compare*Result` aliases keep the documented per-mode call sites in `canonical-eval-run.ts`.
- **Test fixtures realistic** — every fixture constructs a real per-mode shape; zero `as Question` casts (was 3 in `formatSummary`).
- **Deferred PR #2041 tests landed**:
  - **Dispatcher routing (test-C2)** — 4 tests, one per mode. Each asserts the correct `RunHarnessOptions` dependency is called and the wrong ones are NOT (catches a future refactor accidentally hitting `searchGlossary` for a metric question).
  - **Loader mismatch rejection (test-C4)** — 5 tests covering glossary-with-`sql_pattern`, glossary-with-`non_zero`, metric-with-`status`, pattern-with-`mappings_min`, and a multi-offender message test.
- **Docs touch** — `apps/docs/content/docs/contributing/eval-harness.mdx` step 3 now lists the `expect:` shape per-mode and notes that the loader rejects mismatches.

## Test plan

- [x] Existing 34 canonical-eval tests still pass
- [x] Test count: 34 → **43** (+5 loader mismatch, +4 dispatcher routing)
- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun run test` — full suite passes (api + cli + web + plugins + ee)
- [x] `bun x syncpack lint` — no issues
- [x] Template drift, security headers, railway-watch — all pass

## Out of scope

- Behavioral changes to comparator semantics
- New question modes
- Anything outside the three target files (+ surgical docs touch)