### PR TITLE
docs(seed): align ecommerce glossary `revenue` term with concepts.mdx

### DIFF
--- a/create-atlas/templates/docker/semantic/glossary.yml
+++ b/create-atlas/templates/docker/semantic/glossary.yml
@@ -86,13 +86,13 @@ terms:
   revenue:
     status: ambiguous
     note: >
-      Could mean GMV (total order value from orders.total_cents), net revenue
-      (GMV minus refunds), or seller revenue (after commission). ASK the user
+      Could mean gross revenue (GMV before refunds), net revenue (GMV minus
+      refunds), or seller revenue (gross minus commission). ASK the user
       which definition they mean.
     possible_mappings:
       - orders.total_cents
       - payments.amount_cents
-      - refunds (subtracted)
+      - refunds.amount_cents
 
   price:
     status: ambiguous

--- a/create-atlas/templates/nextjs-standalone/semantic/glossary.yml
+++ b/create-atlas/templates/nextjs-standalone/semantic/glossary.yml
@@ -86,13 +86,13 @@ terms:
   revenue:
     status: ambiguous
     note: >
-      Could mean GMV (total order value from orders.total_cents), net revenue
-      (GMV minus refunds), or seller revenue (after commission). ASK the user
+      Could mean gross revenue (GMV before refunds), net revenue (GMV minus
+      refunds), or seller revenue (gross minus commission). ASK the user
       which definition they mean.
     possible_mappings:
       - orders.total_cents
       - payments.amount_cents
-      - refunds (subtracted)
+      - refunds.amount_cents
 
   price:
     status: ambiguous

--- a/packages/cli/data/seeds/ecommerce/semantic/glossary.yml
+++ b/packages/cli/data/seeds/ecommerce/semantic/glossary.yml
@@ -86,13 +86,13 @@ terms:
   revenue:
     status: ambiguous
     note: >
-      Could mean GMV (total order value from orders.total_cents), net revenue
-      (GMV minus refunds), or seller revenue (after commission). ASK the user
+      Could mean gross revenue (GMV before refunds), net revenue (GMV minus
+      refunds), or seller revenue (gross minus commission). ASK the user
       which definition they mean.
     possible_mappings:
       - orders.total_cents
       - payments.amount_cents
-      - refunds (subtracted)
+      - refunds.amount_cents
 
   price:
     status: ambiguous


### PR DESCRIPTION
Follow-up to #2045.

## Summary

The docs page `concepts.mdx` was retargeted to NovaMart in #2045 and the glossary example was tightened during PR review:
- `revenue` ambiguity reframed as **gross / net / seller** (the previous "GMV / net / seller" listed `GMV` as one option, which collapses one branch into the already-defined GMV term).
- Third `possible_mapping` switched from the parenthetical `refunds (subtracted)` to `refunds.amount_cents` so all three mappings use the consistent `table.column` shape.

This PR mirrors the same wording back to the source seed (`packages/cli/data/seeds/ecommerce/semantic/glossary.yml`) so the docs and the demo dataset's glossary stay in lockstep — that lockstep is what #2043 cared about. Templates regenerated via `prepare-templates.sh`.

## Files

- `packages/cli/data/seeds/ecommerce/semantic/glossary.yml` — source change
- `create-atlas/templates/docker/semantic/glossary.yml` — regenerated
- `create-atlas/templates/nextjs-standalone/semantic/glossary.yml` — regenerated

3 files, +9 / -9.

## Verification

- All 7 local /ci gates pass: lint, type, full test suite, syncpack, template drift, security headers, railway watch
- `refunds.amount_cents` confirmed real (`packages/cli/data/seeds/ecommerce/seed.sql` defines `refunds(payment_id, amount_cents, reason, status, created_at)`)

## Test plan

- [ ] CI green
- [ ] No further drift between docs page and seed glossary