### PR TITLE
fix(mcp): #2042 follow-up — object bin form for npm normalization

### DIFF
--- a/plugins/mcp/package.json
+++ b/plugins/mcp/package.json
@@ -23,7 +23,9 @@
       "default": "./bin/cli.ts"
     }
   },
-  "bin": "./bin/cli.ts",
+  "bin": {
+    "atlas-mcp": "./bin/cli.ts"
+  },
   "files": [
     "bin/",
     "src/",


### PR DESCRIPTION
## Summary

Follow-up to #2048. The `mcp-v0.0.1` publish workflow run failed (https://github.com/AtlasDevHQ/atlas/actions/runs/25297541943) with two issues:

1. **404** — \`@useatlas/mcp\` is a brand-new namespace; OIDC trusted publisher needs a one-time manual setup on the npm web UI before tag-push publishes work. Will be handled out-of-band by the user.
2. **Bin entry mangled** (this PR) — string-form \`"bin": "./bin/cli.ts"\` got dropped during npm publish:
   ```
   "bin" was converted to an object
   "bin[@useatlas/mcp]" was renamed to "bin[mcp]"
   "bin[mcp]" script name bin/cli.ts was invalid and removed
   ```
   The published tarball would have had NO bin entry — \`bunx @useatlas/mcp init\` would resolve the package but find nothing to execute.

Switch to explicit object form \`{ "atlas-mcp": "./bin/cli.ts" }\` matching the pattern already used by \`create-atlas-agent\` and \`create-atlas-plugin\`. \`npm pack --dry-run\` is now warning-free.

## Test plan

- [x] \`bun pm pack\` + \`npm pack --dry-run\` — both clean, bin entry preserved
- [x] \`bun run lint\` / \`bun run type\` clean
- [x] \`bun x @useatlas/mcp init --local\` from a tmp install still produces a valid Claude Desktop config block