### PR TITLE
docs(mcp): #2042 — drop "in final review" callouts now that @useatlas/mcp is live

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ bunx @useatlas/mcp init --local            # print paste-ready config
 bunx @useatlas/mcp init --local --write    # merge into the detected client config (with a .bak)
 ```
 
-> **Note:** The `@useatlas/mcp` npm package is in final review for publishing — see [#2042](https://github.com/AtlasDevHQ/atlas/issues/2042). Until then, the installer runs from the monorepo via `bun packages/mcp/bin/init.ts --local`.
-
 Restart Claude Desktop / Cursor and ask one of the canonical questions:
 
 - *"What's our GMV this quarter?"*

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -19,10 +19,6 @@ bunx @useatlas/mcp init --local            # print paste-ready config
 bunx @useatlas/mcp init --local --write    # merge into the detected client config (with a .bak)
 ```
 
-<Callout type="info" title="`@useatlas/mcp` is in final review for npm publishing">
-Tracked in [#2042](https://github.com/AtlasDevHQ/atlas/issues/2042). Until the package lands on npm, run the installer from the monorepo with `bun packages/mcp/bin/init.ts --local`.
-</Callout>
-
 Restart your client and try one of the canonical NovaMart demo questions:
 
 - "What's our GMV this quarter?"


### PR DESCRIPTION
## Summary

`@useatlas/mcp@0.0.1` shipped to npm via #2048 + #2049 — https://www.npmjs.com/package/@useatlas/mcp. The README hero + docs index hero still pointed at the monorepo-only workaround (`bun packages/mcp/bin/init.ts --local`) and at the now-closed-by-this-work tracking issue. Trivial cleanup.

## Test plan

- [x] `grep -rn "in final review\|packages/mcp/bin/init.ts --local"` returns nothing in apps/, docs/, README.md
- [x] No other links to #2042 remain in user-visible copy