### PR TITLE
fix(seeds): #2039 — add product_id FK to order_items

### DIFF
--- a/eval/canonical-questions/questions.yml
+++ b/eval/canonical-questions/questions.yml
@@ -62,7 +62,7 @@ questions:
     mode: metric
     metric_id: revenue_by_category
     expect:
-      sql_pattern: ["GROUP BY", "categories", "order_items"]
+      sql_pattern: ["GROUP BY", "categories", "order_items", "product_id = p.id"]
       min_rows: 1
 
   - id: cq-005
@@ -92,8 +92,8 @@ questions:
     mode: metric
     metric_id: revenue_dtc_vs_marketplace
     expect:
-      sql_pattern: ["JOIN products", "seller_id IS NULL"]
-      min_rows: 1
+      sql_pattern: ["JOIN products", "product_id = p.id", "seller_id IS NULL"]
+      min_rows: 2
       max_rows: 2
       column: channel
 

--- a/packages/cli/bin/__tests__/canonical-eval.test.ts
+++ b/packages/cli/bin/__tests__/canonical-eval.test.ts
@@ -904,13 +904,13 @@ describe("runHarness", () => {
     total_customers: "SELECT COUNT(DISTINCT id) AS v FROM customers",
     aov: "SELECT AVG(total_cents) AS v FROM orders",
     revenue_by_category:
-      "SELECT 1 AS v FROM order_items JOIN categories GROUP BY 1",
+      "SELECT 1 AS v FROM order_items oi JOIN products p ON oi.product_id = p.id JOIN categories GROUP BY 1",
     customers_by_acquisition_source:
       "SELECT LOWER(acquisition_source) AS channel, 1 FROM customers GROUP BY 1",
     inventory_health:
       "SELECT 'Adequate' AS stock_status, 1 AS v FROM inventory_levels GROUP BY 1",
     revenue_dtc_vs_marketplace:
-      "SELECT 'DTC' AS channel, 1 AS v FROM orders JOIN products ON p WHERE seller_id IS NULL GROUP BY 1",
+      "SELECT channel, 1 AS v FROM order_items oi JOIN products p ON oi.product_id = p.id WHERE seller_id IS NULL GROUP BY 1",
     top_customers_by_spend: "SELECT 1 AS v FROM customers JOIN orders ON o",
     monthly_gmv_trend:
       "SELECT TO_CHAR(created_at, 'YYYY-MM') AS month, 1 AS v FROM orders GROUP BY 1",
@@ -955,7 +955,13 @@ describe("runHarness", () => {
           };
         }
         if (lower.includes("seller_id is null") && lower.includes("products")) {
-          return { columns: ["channel"], rows: [{ channel: "DTC" }] };
+          // cq-007 (revenue_dtc_vs_marketplace) requires both channels via min_rows: 2.
+          // cq-017 (Products/dtc_vs_marketplace pattern) only checks the column,
+          // so an extra row is harmless there.
+          return {
+            columns: ["channel"],
+            rows: [{ channel: "DTC" }, { channel: "Marketplace" }],
+          };
         }
         if (lower.includes("promotion_id is not null")) {
           return {

--- a/packages/cli/data/seeds/ecommerce/seed.sql
+++ b/packages/cli/data/seeds/ecommerce/seed.sql
@@ -276,7 +276,7 @@ CREATE TABLE order_items (
     order_id           INTEGER NOT NULL REFERENCES orders(id),
     product_id         INTEGER NOT NULL REFERENCES products(id),
     product_variant_id INTEGER,        -- TECH DEBT: NO FK to product_variants
-    product_name       TEXT NOT NULL,  -- TECH DEBT: denormalized snapshot of products.name at purchase time; can drift from current name
+    product_name       TEXT NOT NULL,  -- denormalized snapshot of products.name at purchase time; can drift from current name
     quantity           INTEGER NOT NULL DEFAULT 1,
     unit_price_cents   INTEGER NOT NULL,
     total_cents        INTEGER NOT NULL,
@@ -1043,21 +1043,19 @@ FROM (
 ) AS src;
 
 -- ---------- Order Items (55,000) ----------
--- product_id is a real FK into products.id (1..800). product_name is a
--- denormalized snapshot of products.name at purchase time — kept for the
--- "denormalized convenience column" demo pattern, but joins should always
--- go through product_id (see semantic/entities/order_items.yml).
+-- Always join order_items → products via product_id. product_name is a
+-- denormalized snapshot of products.name at purchase time and can drift.
 INSERT INTO order_items (order_id, product_id, product_variant_id, product_name, quantity, unit_price_cents, total_cents, created_at)
 SELECT
-    order_id,
-    product_id,
+    src.order_id,
+    src.product_id,
     -- TECH DEBT: no FK to product_variants
     1 + floor(random() * 3200)::int,
-    (SELECT name FROM products WHERE id = product_id),
-    qty,
-    unit_price,
-    unit_price * qty,
-    '2020-03-01'::timestamptz + (power(g::float / 55000, 1.0) * interval '1795 days')
+    p.name,
+    src.qty,
+    src.unit_price,
+    src.unit_price * src.qty,
+    '2020-03-01'::timestamptz + (power(src.g::float / 55000, 1.0) * interval '1795 days')
 FROM (
     SELECT
         g,
@@ -1066,7 +1064,8 @@ FROM (
         (ARRAY[1,1,1,1,1,1,2,2,3])[1 + floor(random() * 9)::int] AS qty,
         (1999 + floor(random() * 15000))::int AS unit_price
     FROM generate_series(1, 55000) AS g
-) AS src;
+) AS src
+JOIN products p ON p.id = src.product_id;
 
 -- ---------- Order Events (60,000) ----------
 INSERT INTO order_events (order_id, event_type, description, created_at)

--- a/packages/cli/data/seeds/ecommerce/seed.sql
+++ b/packages/cli/data/seeds/ecommerce/seed.sql
@@ -274,8 +274,9 @@ CREATE TABLE orders (
 CREATE TABLE order_items (
     id                 SERIAL PRIMARY KEY,
     order_id           INTEGER NOT NULL REFERENCES orders(id),
+    product_id         INTEGER NOT NULL REFERENCES products(id),
     product_variant_id INTEGER,        -- TECH DEBT: NO FK to product_variants
-    product_name       TEXT NOT NULL,
+    product_name       TEXT NOT NULL,  -- TECH DEBT: denormalized snapshot of products.name at purchase time; can drift from current name
     quantity           INTEGER NOT NULL DEFAULT 1,
     unit_price_cents   INTEGER NOT NULL,
     total_cents        INTEGER NOT NULL,
@@ -652,6 +653,7 @@ CREATE INDEX idx_orders_customer ON orders(customer_id);
 CREATE INDEX idx_orders_created ON orders(created_at);
 CREATE INDEX idx_orders_status ON orders(status);
 CREATE INDEX idx_order_items_order ON order_items(order_id);
+CREATE INDEX idx_order_items_product ON order_items(product_id);
 CREATE INDEX idx_order_events_order ON order_events(order_id);
 CREATE INDEX idx_order_events_created ON order_events(created_at);
 CREATE INDEX idx_payments_order ON payments(order_id);
@@ -1041,16 +1043,17 @@ FROM (
 ) AS src;
 
 -- ---------- Order Items (55,000) ----------
-INSERT INTO order_items (order_id, product_variant_id, product_name, quantity, unit_price_cents, total_cents, created_at)
+-- product_id is a real FK into products.id (1..800). product_name is a
+-- denormalized snapshot of products.name at purchase time — kept for the
+-- "denormalized convenience column" demo pattern, but joins should always
+-- go through product_id (see semantic/entities/order_items.yml).
+INSERT INTO order_items (order_id, product_id, product_variant_id, product_name, quantity, unit_price_cents, total_cents, created_at)
 SELECT
     order_id,
+    product_id,
     -- TECH DEBT: no FK to product_variants
     1 + floor(random() * 3200)::int,
-    (ARRAY['Egyptian Cotton Sheet Set','Bamboo Pillowcase','Memory Foam Pillow','Linen Duvet Cover',
-           'Cast Iron Skillet','Nonstick Pan Set','Turkish Bath Towel','Waffle Bath Robe',
-           'Patio Lounge Chair','Soy Candle Set','Area Rug','Throw Pillow',
-           'Weighted Blanket','Mattress Topper','Chef Knife','Cutting Board Set',
-           'Solar String Lights','Ceramic Vase','Wall Print','Hand Towel Set'])[1 + floor(random() * 20)::int],
+    (SELECT name FROM products WHERE id = product_id),
     qty,
     unit_price,
     unit_price * qty,
@@ -1059,6 +1062,7 @@ FROM (
     SELECT
         g,
         1 + floor(random() * 25000)::int AS order_id,
+        1 + floor(random() * 800)::int AS product_id,
         (ARRAY[1,1,1,1,1,1,2,2,3])[1 + floor(random() * 9)::int] AS qty,
         (1999 + floor(random() * 15000))::int AS unit_price
     FROM generate_series(1, 55000) AS g
@@ -1499,8 +1503,8 @@ SELECT
     p.id,
     p.name,
     cat.name,
-    COALESCE((SELECT sum(oi.quantity) FROM order_items oi WHERE oi.product_name = p.name), 0)::int,
-    COALESCE((SELECT sum(oi.total_cents) FROM order_items oi WHERE oi.product_name = p.name), 0)::int,
+    COALESCE((SELECT sum(oi.quantity) FROM order_items oi WHERE oi.product_id = p.id), 0)::int,
+    COALESCE((SELECT sum(oi.total_cents) FROM order_items oi WHERE oi.product_id = p.id), 0)::int,
     COALESCE((SELECT round(avg(pr.rating)::numeric, 2) FROM product_reviews pr WHERE pr.product_id = p.id), NULL),
     COALESCE((SELECT count(*) FROM product_reviews pr WHERE pr.product_id = p.id), 0)::int,
     round((random() * 8)::numeric, 2),

--- a/packages/cli/data/seeds/ecommerce/semantic/entities/order_items.yml
+++ b/packages/cli/data/seeds/ecommerce/semantic/entities/order_items.yml
@@ -4,9 +4,14 @@ table: order_items
 grain: one row per line item in an order
 description: |
   Individual line items within orders. Each row represents a specific product purchased
-  at a quantity and price. product_name is denormalized for convenience.
+  at a quantity and price.
 
   Data quality notes:
+  - product_id is the real foreign key to products.id — use this for any join
+    against products.
+  - product_name is a denormalized snapshot of products.name at purchase time
+    and may drift from the current name. Do NOT join to products via
+    product_name; use product_id.
   - product_variant_id has no foreign key constraint — not all values may match
     product_variants.id.
   - All monetary values (unit_price_cents, total_cents) are in cents.
@@ -24,6 +29,11 @@ dimensions:
     type: number
     description: Foreign key to orders — which order this item belongs to
 
+  - name: product_id
+    sql: product_id
+    type: number
+    description: Foreign key to products — the canonical join key for product attribution
+
   - name: product_variant_id
     sql: product_variant_id
     type: number
@@ -34,7 +44,9 @@ dimensions:
   - name: product_name
     sql: product_name
     type: string
-    description: Denormalized product name (copied at time of purchase)
+    description: |
+      Denormalized snapshot of products.name at purchase time. May drift from
+      the current product name — for joins to products, use product_id.
 
   - name: quantity
     sql: quantity
@@ -114,6 +126,13 @@ joins:
       from: order_id
       to: id
     description: Each line item belongs to one order
+
+  - target_entity: Products
+    relationship: many_to_one
+    join_columns:
+      from: product_id
+      to: id
+    description: Each line item references one product (use product_id, not product_name)
 
 use_cases:
   - Product-level revenue attribution — which products drive the most revenue

--- a/packages/cli/data/seeds/ecommerce/semantic/entities/order_items.yml
+++ b/packages/cli/data/seeds/ecommerce/semantic/entities/order_items.yml
@@ -44,9 +44,7 @@ dimensions:
   - name: product_name
     sql: product_name
     type: string
-    description: |
-      Denormalized snapshot of products.name at purchase time. May drift from
-      the current product name — for joins to products, use product_id.
+    description: Denormalized snapshot of products.name at purchase time (may drift; join via product_id).
 
   - name: quantity
     sql: quantity
@@ -145,12 +143,14 @@ query_patterns:
   - name: top_products_by_revenue
     description: Highest-revenue products
     sql: |-
-      SELECT product_name,
-             SUM(total_cents) / 100.0 AS total_revenue,
-             SUM(quantity) AS total_units,
-             COUNT(DISTINCT order_id) AS order_count
-      FROM order_items
-      GROUP BY product_name
+      SELECT p.id AS product_id,
+             p.name AS product_name,
+             SUM(oi.total_cents) / 100.0 AS total_revenue,
+             SUM(oi.quantity) AS total_units,
+             COUNT(DISTINCT oi.order_id) AS order_count
+      FROM order_items oi
+      JOIN products p ON oi.product_id = p.id
+      GROUP BY p.id, p.name
       ORDER BY total_revenue DESC
       LIMIT 20
 
@@ -170,9 +170,11 @@ query_patterns:
   - name: revenue_by_product_and_month
     description: Monthly revenue trend by top products
     sql: |-
-      SELECT product_name,
+      SELECT p.id AS product_id,
+             p.name AS product_name,
              TO_CHAR(oi.created_at, 'YYYY-MM') AS month,
              SUM(oi.total_cents) / 100.0 AS revenue
       FROM order_items oi
-      GROUP BY product_name, TO_CHAR(oi.created_at, 'YYYY-MM')
+      JOIN products p ON oi.product_id = p.id
+      GROUP BY p.id, p.name, TO_CHAR(oi.created_at, 'YYYY-MM')
       ORDER BY month, revenue DESC

--- a/packages/cli/data/seeds/ecommerce/semantic/metrics/revenue.yml
+++ b/packages/cli/data/seeds/ecommerce/semantic/metrics/revenue.yml
@@ -58,7 +58,7 @@ metrics:
              COUNT(DISTINCT oi.order_id) AS order_count,
              SUM(oi.quantity) AS units_sold
       FROM order_items oi
-      JOIN products p ON oi.product_name = p.name
+      JOIN products p ON oi.product_id = p.id
       JOIN categories c ON p.category_id = c.id
       GROUP BY c.name
       ORDER BY revenue DESC
@@ -76,7 +76,7 @@ metrics:
              COUNT(DISTINCT oi.order_id) AS order_count,
              AVG(oi.unit_price_cents) / 100.0 AS avg_unit_price
       FROM order_items oi
-      JOIN products p ON oi.product_name = p.name
+      JOIN products p ON oi.product_id = p.id
       GROUP BY CASE WHEN p.seller_id IS NULL THEN 'DTC' ELSE 'Marketplace' END
 
   - id: refund_rate


### PR DESCRIPTION
## Summary

- The NovaMart seed generated `order_items.product_name` from a 20-item ARRAY of base names while `products.name` used a 32×8 base+suffix combination — zero overlap, so the two metric YAMLs that joined `order_items` → `products` on that string column (`revenue_by_category`, `revenue_dtc_vs_marketplace`) returned 0 rows. Surfaced by the canonical-question eval harness from #2025 as `[WARN]` lines.
- Applies option 1 from the issue — denormalize properly. Adds `product_id INTEGER NOT NULL REFERENCES products(id)` to `order_items`, snapshots `product_name` from `products.name` at insert time, and switches both affected metrics + the `product_performance_cache` seed population to join via `product_id`.
- `order_items.yml` gains a `product_id` dimension and a `to_products` join. Description steers the agent away from string-joining via `product_name`.

## Test plan

- [x] `bun run atlas -- canonical-eval` → 20/20 passing (was 18/20 with the two segmentation/join WARNs)
- [x] `SELECT COUNT(*) FROM order_items oi JOIN products p ON oi.product_id = p.id;` → 55000
- [x] DTC vs Marketplace split returns real rows: 43,364 / 11,636 line items (matches the ~20% marketplace seller_id rate in `products`)
- [x] Local /ci: lint, type, full `bun run test`, syncpack, template-drift, security-headers-drift, railway-watch — all pass

Closes #2039