### PR TITLE
chore(mcp): #2027 — prep registry manifest (mcpName + server.json), holding submission on #2024

### DIFF
--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -111,8 +111,6 @@ done
 | `@useatlas/react` | `react-v*` | `react-v0.0.2` |
 | `@useatlas/<plugin>` | `<plugin>-v*` | `clickhouse-v0.0.6` |
 
-**Excluded:** `@useatlas/mcp` — private, depends on unpublished `@atlas/mcp` workspace package.
-
 **Publish order:** `types` must be published before `sdk` or `react` (they depend on it).
 
 **Step 5: Verify workflows triggered**
@@ -203,7 +201,6 @@ After initial setup, all subsequent publishes work automatically via tags.
 - Always verify the workflow actually triggered for each tag
 - Don't publish without user confirmation — wrong versions on npm are hard to undo
 - If a publish fails, don't retry blindly — check the error first
-- The `@useatlas/mcp` package is excluded (private, unpublished workspace dep)
 - Tags are always cut from main — never push a tag from a feature branch
 - Core packages (types, sdk, plugin-sdk, react) build before publish; sdk and plugin-sdk also test; plugins ship raw TypeScript
 - npm uses OIDC trusted publisher — no tokens needed, but the GitHub environment must be `npm`

--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -109,7 +109,7 @@ done
 | `@useatlas/sdk` | `sdk-v*` | `sdk-v0.0.7` |
 | `@useatlas/plugin-sdk` | `plugin-sdk-v*` | `plugin-sdk-v0.0.7` |
 | `@useatlas/react` | `react-v*` | `react-v0.0.2` |
-| `@useatlas/<plugin>` | `<plugin>-v*` | `clickhouse-v0.0.6` |
+| `@useatlas/<plugin>` | `<plugin>-v*` | `clickhouse-v0.0.6`, `mcp-v0.0.2` |
 
 **Publish order:** `types` must be published before `sdk` or `react` (they depend on it).
 

--- a/apps/docs/content/docs/plugins/interactions/mcp.mdx
+++ b/apps/docs/content/docs/plugins/interactions/mcp.mdx
@@ -9,18 +9,17 @@ The MCP interaction plugin wraps the `@atlas/mcp` server package as an Atlas plu
 
 Tool bridging and resource registration are handled internally by `@atlas/mcp` -- this plugin is a thin lifecycle wrapper that makes it configurable via `atlas.config.ts`.
 
-<Callout type="warn">
-`@useatlas/mcp` is **not published to npm** — it depends on the internal `@atlas/mcp` workspace package. Use it from the monorepo only. See the [MCP guide](/guides/mcp) for standalone MCP server setup via `atlas mcp`.
+<Callout type="info">
+For one-command setup against Claude Desktop / Cursor / Continue, prefer `bunx @useatlas/mcp init --local` — see the [MCP guide](/guides/mcp). This page documents using `@useatlas/mcp` as an Atlas plugin inside an existing project.
 </Callout>
 
-## Installation (monorepo only)
+## Installation
 
 ```bash
-# Only works inside the Atlas monorepo — not available on npm
 bun add @useatlas/mcp @modelcontextprotocol/sdk
 ```
 
-The `@atlas/mcp` server package is pulled in automatically via dynamic import.
+The `@atlas/mcp` server runtime is pulled in automatically via dynamic import — published as part of the `@useatlas/mcp` package itself, no monorepo dependency.
 
 ## Configuration
 

--- a/apps/docs/content/docs/plugins/interactions/mcp.mdx
+++ b/apps/docs/content/docs/plugins/interactions/mcp.mdx
@@ -19,7 +19,7 @@ For one-command setup against Claude Desktop / Cursor / Continue, prefer `bunx @
 bun add @useatlas/mcp @modelcontextprotocol/sdk
 ```
 
-The `@atlas/mcp` server runtime is pulled in automatically via dynamic import — published as part of the `@useatlas/mcp` package itself, no monorepo dependency.
+When loaded inside an Atlas project (monorepo dev or a `create-atlas-agent` scaffold), the `@atlas/mcp` server runtime is resolved via dynamic import — you don't need to depend on it directly. Standalone `bunx @useatlas/mcp serve` outside an Atlas project is tracked in [#2024](https://github.com/AtlasDevHQ/atlas/issues/2024).
 
 ## Configuration
 

--- a/bun.lock
+++ b/bun.lock
@@ -528,8 +528,10 @@
     },
     "plugins/mcp": {
       "name": "@useatlas/mcp",
-      "version": "0.0.1",
-      "bin": "./bin/cli.ts",
+      "version": "0.0.2",
+      "bin": {
+        "atlas-mcp": "./bin/cli.ts",
+      },
       "devDependencies": {
         "@atlas/mcp": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/plugins/mcp/package.json
+++ b/plugins/mcp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@useatlas/mcp",
-  "version": "0.0.1",
+  "version": "0.0.2",
+  "mcpName": "io.github.AtlasDevHQ/atlas",
   "description": "Atlas MCP plugin + bunx installer for Claude Desktop / Cursor / Continue",
   "type": "module",
   "main": "./src/index.ts",
@@ -30,6 +31,7 @@
     "bin/",
     "src/",
     "fixtures/",
+    "server.json",
     "README.md",
     "LICENSE"
   ],

--- a/plugins/mcp/server.json
+++ b/plugins/mcp/server.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.AtlasDevHQ/atlas",
+  "title": "Atlas",
+  "description": "Atlas is a YAML-defined semantic layer for analytics — authored by humans, consumed by AI agents. The MCP server exposes validated SELECT-only SQL execution and typed semantic-layer accessors (listEntities, describeEntity, searchGlossary, runMetric) over your warehouse, plus query-pattern prompts and read-only resources for entities, glossary, and metrics.",
+  "version": "0.0.2",
+  "websiteUrl": "https://docs.useatlas.dev/guides/mcp",
+  "repository": {
+    "url": "https://github.com/AtlasDevHQ/atlas",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@useatlas/mcp",
+      "version": "0.0.2",
+      "runtimeHint": "npx",
+      "transport": { "type": "stdio" },
+      "environmentVariables": [
+        {
+          "name": "ATLAS_DATASOURCE_URL",
+          "description": "Connection URL for your analytics datasource (PostgreSQL, MySQL, ClickHouse, Snowflake, DuckDB, BigQuery, Salesforce). Optional — when unset, the installer points at a bundled NovaMart demo SQLite fixture so the install works zero-config.",
+          "isRequired": false,
+          "isSecret": true,
+          "format": "string"
+        },
+        {
+          "name": "ATLAS_PROVIDER",
+          "description": "LLM provider (anthropic, openai, bedrock, ollama, vercel-ai-gateway). Optional — the MCP server itself does not call an LLM (the client does), so this only matters if you also run Atlas's chat or scheduler surfaces.",
+          "isRequired": false,
+          "format": "string"
+        },
+        {
+          "name": "ATLAS_API_URL",
+          "description": "URL of a running Atlas API. Optional — defaults to http://localhost:3001. When set, the MCP server inherits the API's connections, semantic layer, and governance.",
+          "isRequired": false,
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/mcp/server.json
+++ b/plugins/mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.AtlasDevHQ/atlas",
   "title": "Atlas",
-  "description": "Atlas is a YAML-defined semantic layer for analytics — authored by humans, consumed by AI agents. The MCP server exposes validated SELECT-only SQL execution and typed semantic-layer accessors (listEntities, describeEntity, searchGlossary, runMetric) over your warehouse, plus query-pattern prompts and read-only resources for entities, glossary, and metrics.",
+  "description": "Atlas is a YAML-defined semantic layer for analytics — authored by humans, consumed by AI agents.",
   "version": "0.0.2",
   "websiteUrl": "https://docs.useatlas.dev/guides/mcp",
   "repository": {
@@ -19,22 +19,19 @@
       "environmentVariables": [
         {
           "name": "ATLAS_DATASOURCE_URL",
-          "description": "Connection URL for your analytics datasource (PostgreSQL, MySQL, ClickHouse, Snowflake, DuckDB, BigQuery, Salesforce). Optional — when unset, the installer points at a bundled NovaMart demo SQLite fixture so the install works zero-config.",
+          "description": "Analytics datasource URL (postgres, mysql, clickhouse, snowflake, duckdb, bigquery, salesforce). Optional — falls back to a bundled NovaMart SQLite demo when unset.",
           "isRequired": false,
-          "isSecret": true,
-          "format": "string"
+          "isSecret": true
         },
         {
           "name": "ATLAS_PROVIDER",
-          "description": "LLM provider (anthropic, openai, bedrock, ollama, vercel-ai-gateway). Optional — the MCP server itself does not call an LLM (the client does), so this only matters if you also run Atlas's chat or scheduler surfaces.",
-          "isRequired": false,
-          "format": "string"
+          "description": "LLM provider: anthropic, openai, bedrock, ollama, openai-compatible, gateway. Optional — the MCP server does not call an LLM directly (the client does); set this only if you also run Atlas's chat or scheduler.",
+          "isRequired": false
         },
         {
           "name": "ATLAS_API_URL",
           "description": "URL of a running Atlas API. Optional — defaults to http://localhost:3001. When set, the MCP server inherits the API's connections, semantic layer, and governance.",
-          "isRequired": false,
-          "format": "string"
+          "isRequired": false
         }
       ]
     }


### PR DESCRIPTION
## Summary

Adds the metadata and manifest files MCP registry submission requires, **without** actually submitting to mcp.so or `registry.modelcontextprotocol.io` — those are deliberately deferred until #2024 (hosted MCP) lands, because `bunx @useatlas/mcp serve` is intentionally broken standalone today.

This PR is the prep half of #2027. Issue #2027 stays open with the `blocked` label until #2024 ships.

## Why hold submission

Verified end-to-end: `bunx @useatlas/mcp init --local` writes a paste-ready config, but the config tells the MCP client to run `bunx @useatlas/mcp serve`, which fails outside the monorepo / a `create-atlas-agent` scaffold per `plugins/mcp/bin/cli.ts:250-283`:

> `[atlas-mcp serve] Could not resolve @atlas/mcp from the current project. The serve subcommand currently requires the Atlas API source to be available in the same project ... Standalone bunx @useatlas/mcp serve is tracked in #2024.`

Submitting now would mean: user discovers Atlas via the registry → copies the install snippet → restarts Claude Desktop → watches Atlas die on startup. Registry first impressions don't get a do-over. The standalone-serve product decision (vendored demo runtime vs hosted-only) is tracked separately in #2052.

## Changes

- **`plugins/mcp/package.json`** — bump `0.0.1` → `0.0.2`, add `mcpName: "io.github.AtlasDevHQ/atlas"` (the npm-side ownership marker the official registry verifies at publish time), include `server.json` in the published tarball.
- **`plugins/mcp/server.json`** — full registry manifest. Description leads with the canonical moat one-liner verbatim. Declares the npm package, stdio transport, and optional `ATLAS_DATASOURCE_URL` / `ATLAS_PROVIDER` / `ATLAS_API_URL` env so the registry UI can surface them.
- **`apps/docs/content/docs/plugins/interactions/mcp.mdx`** — drop the stale "`@useatlas/mcp` is not published to npm" callout. Post-#2042 the package is published.
- **`.claude/commands/publish.md`** — drop stale "`@useatlas/mcp` excluded" lines (the package is no longer excluded from the publish workflow).

## Out of scope (and why)

- **Upstream PR to `modelcontextprotocol/servers`** — the third-party list there has been **retired**. The new path is `mcp-publisher publish` against `registry.modelcontextprotocol.io`, no PR involved.
- **mcp.so submission** — held until the install snippet works end-to-end.
- **Claude Desktop "Browse extensions"** — Anthropic-curated, separate "interest form" submission, NOT auto-pulled from the official registry.
- **Republish `@useatlas/mcp@0.0.2`** — happens post-merge via the existing `mcp-v0.0.2` tag workflow (per `feedback_version_bump_ordering.md`: tag pushed from main only, after merge).

## Test plan

- [x] Local `/ci`: lint, type, test (full suite), syncpack, template drift, security-headers drift, railway watch coverage — all pass
- [x] Verified the install-snippet failure mode that motivates the hold (`bunx @useatlas/mcp@0.0.1 serve` → resolution error pointing at #2024)
- [x] Confirmed canonical moat one-liner is consistent across `README.md:4`, `apps/www/src/components/landing/hero.tsx:7`, `apps/docs/content/docs/index.mdx:3,9`, `apps/docs/content/docs/semantic-layer/index.mdx:9`, and the new `server.json` description
- [ ] After merge: tag `mcp-v0.0.2` from main → publish workflow republishes `@useatlas/mcp` to npm with `mcpName` baked in
- [ ] When #2024 closes: `mcp-publisher publish` from `plugins/mcp/` against `registry.modelcontextprotocol.io`, then mcp.so + Claude Desktop interest form

## Related

- #2027 — registry submission (this PR is the prep half; #2027 stays open)
- #2024 — hosted MCP (the blocker)
- #2052 — standalone-serve product decision (filed during the analysis)
- #2042 — publish workflow (which this PR builds on)