### PR TITLE
feat(mcp): #2024 — bunx init --hosted OAuth 2.1 loopback flow (PR E of E)

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -141,7 +141,7 @@ Tracker: [milestone #40](https://github.com/AtlasDevHQ/atlas/milestones/40). Lea
 - [x] One-command MCP installer — `bunx @useatlas/mcp init --local` writes a paste-ready config or merges into the detected client (#2018, PR #2032)
 - [x] Typed semantic-layer MCP tools + version sync — `listEntities` / `describeEntity` / `listMetrics` / `runMetric` exposed; server version tracks `package.json` (#2019 + #2020, PR #2031)
 - [x] Scaffolder rename — `bun create atlas-agent` / `bun create atlas-plugin` reads as English; old `@useatlas/create*` deprecated with redirect (PR #2033)
-- [ ] Hosted MCP endpoint at `mcp.useatlas.dev` with SaaS auth (#2024, #2028) — pivoted mid-flight to OAuth 2.1 + DCR via `@better-auth/oauth-provider` (PRs #2054/#2056/#2057); Settings UI + `bunx … init --hosted` loopback flow + DNS still open.
+- [ ] Hosted MCP endpoint at `mcp.useatlas.dev` with SaaS auth (#2024, #2028) — pivoted mid-flight to OAuth 2.1 + DCR via `@better-auth/oauth-provider` (PRs #2054/#2056/#2057); `bunx … init --hosted` loopback flow shipped (PR E); Settings UI + DNS still open.
 - [x] OTel coverage for MCP tool calls — activation + tool-call counters (#2029, PR #2035)
 - [x] Structured error envelope for typed MCP tools so agents can recover gracefully (#2030, PR #2034)
 - [ ] List Atlas in MCP registries (mcp.so + others) before close (#2027)

--- a/apps/docs/content/docs/guides/mcp-hosted.mdx
+++ b/apps/docs/content/docs/guides/mcp-hosted.mdx
@@ -1,14 +1,54 @@
 ---
 title: Hosted MCP Endpoint
-description: Connect any MCP client to Atlas SaaS over OAuth 2.1 — Dynamic Client Registration, PKCE, JWT-signed access tokens.
+description: Connect any MCP client to Atlas SaaS over OAuth 2.1 — bunx CLI installer, Dynamic Client Registration, PKCE, JWT-signed access tokens.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-Self-hosted Atlas exposes MCP over stdio (see the [MCP guide](/guides/mcp)). Atlas SaaS adds a hosted MCP endpoint over Streamable HTTP that speaks **OAuth 2.1 + PKCE + Dynamic Client Registration (RFC 7591)** — the authorization model the [MCP spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization) requires. Standards-compliant MCP clients (Claude Desktop, ChatGPT, Cursor, Gemini, Anthropic agents) connect via the hostnames below without any manual token minting.
+Self-hosted Atlas exposes MCP over stdio (see the [MCP guide](/guides/mcp)). Atlas SaaS adds a hosted MCP endpoint over Streamable HTTP that speaks **OAuth 2.1 + PKCE + Dynamic Client Registration (RFC 7591)** — the authorization model the [MCP spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization) requires.
+
+## Install in one command
+
+```bash
+bunx @useatlas/mcp init --hosted --write
+```
+
+That's it. The installer:
+
+1. Discovers Atlas's authorization server at `/.well-known/oauth-authorization-server/api/auth`
+2. Registers itself as a public OAuth client via DCR (no admin pre-issuance needed)
+3. Opens your browser to `/oauth2/authorize` with PKCE (same shape as `gh auth login` / `gcloud auth login`)
+4. Captures the callback on a one-shot `127.0.0.1` listener
+5. Exchanges the auth code for a JWT access token
+6. Merges a workspace-scoped server block into your MCP client config (Claude Desktop, Cursor, or Continue — auto-detected) at mode `0600`
+
+A `.bak` of any prior config is written first. Restart your MCP client to pick up the new server.
+
+```bash
+# Print to stdout instead of writing
+bunx @useatlas/mcp init --hosted
+
+# Force a specific client + override the API region
+bunx @useatlas/mcp init --hosted --client cursor --api-url https://api-eu.useatlas.dev --write
+```
+
+The resulting block looks like:
+
+```json
+{
+  "mcpServers": {
+    "atlas": {
+      "url": "https://api.useatlas.dev/mcp/<your_workspace_id>/sse",
+      "headers": { "Authorization": "Bearer eyJhbGciOiJSUzI1NiIs…" }
+    }
+  }
+}
+```
+
+The `code_verifier` and the registered `client_id` are kept in memory only — never written to disk. The JWT is the single artifact persisted, and only inside your client's config file.
 
 <Callout type="info">
-The Settings → OAuth Clients UI and the `bunx @useatlas/mcp init --hosted` CLI flag are in flight (PR D and PR E of #2024). Until those land, MCP clients that support DCR can connect today using the metadata documents below; tokens are issued through the `/oauth2/authorize` flow.
+Standards-compliant MCP clients (Claude Desktop, ChatGPT, Cursor, Gemini, Anthropic agents) can also connect directly without the CLI — they bootstrap via DCR + PKCE on their own. The protocol details below describe what those clients see; the CLI installer above is the path for any client that doesn't speak DCR yet.
 </Callout>
 
 ## URL pattern

--- a/apps/docs/content/docs/guides/mcp.mdx
+++ b/apps/docs/content/docs/guides/mcp.mdx
@@ -21,7 +21,7 @@ bunx @useatlas/mcp init --local --write
 
 If `ATLAS_DATASOURCE_URL` is unset, the installer points at a bundled accounts/companies/people SQLite fixture so the install works zero-config. If a local Atlas is running at `http://localhost:3001` (override via `ATLAS_API_URL`), the installer leaves the datasource env blank so the MCP server inherits your shell env.
 
-> Hosted mode against `app.useatlas.dev` is partially live: any standards-compliant MCP client (Claude Desktop, ChatGPT, Cursor, etc.) can connect via OAuth 2.1 + Dynamic Client Registration. See the [hosted endpoint reference](/guides/mcp-hosted) for the URL pattern, the discovery documents, and the auth flow. The Settings → OAuth Clients UI and the `bunx @useatlas/mcp init --hosted` flag (which will use the OAuth 2.1 loopback flow) are in flight.
+> Hosted mode against Atlas SaaS is live. Run `bunx @useatlas/mcp init --hosted --write` to authorize via OAuth 2.1 (browser-based loopback flow — same shape as `gh auth login`) and merge a workspace-scoped server block into your MCP client config. Standards-compliant MCP clients (Claude Desktop, ChatGPT, Cursor) can also connect directly using Dynamic Client Registration — see the [hosted endpoint reference](/guides/mcp-hosted).
 
 <Callout title="Prerequisites">
 - An MCP-compatible client (Claude Desktop, Cursor, Continue, or any stdio/SSE client)

--- a/plugins/mcp/__tests__/cli.test.ts
+++ b/plugins/mcp/__tests__/cli.test.ts
@@ -155,34 +155,11 @@ describe("isModuleNotFound", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// runInitCommand — hosted short-circuit pin
-// ---------------------------------------------------------------------------
-
-describe("runInitCommand — hosted mode", () => {
-  it("intentionally drops --write / --client / --api-url when --hosted is passed", async () => {
-    // Capture stdout — the hosted stub prints the #2024 link rather than
-    // touching the filesystem. Pinning the discard prevents a future
-    // refactor from accidentally honoring --write while the hosted
-    // backend doesn't exist yet (#2024).
-    const { runInitCommand } = await import("../bin/cli.js");
-    const logs: string[] = [];
-    const origLog = console.log;
-    console.log = (...a: unknown[]) => {
-      logs.push(a.map((x) => (typeof x === "string" ? x : JSON.stringify(x))).join(" "));
-    };
-    try {
-      const code = await runInitCommand(["--hosted", "--write", "--client", "cursor"]);
-      expect(code).toBe(0);
-      const out = logs.join("\n");
-      expect(out).toMatch(/issues\/2024/);
-      // No filesystem write, no client-specific path
-      expect(out).not.toContain("Wrote ");
-    } finally {
-      console.log = origLog;
-    }
-  });
-});
+// runInitCommand --hosted is now a real OAuth 2.1 loopback flow that
+// passes --write, --client, --api-url through to runInit. End-to-end
+// behaviour is exercised in __tests__/init/hosted.test.ts via the
+// HostedFlowOptions test seams (no real browser, no real network).
+// Pure-parser flag handling is already covered by parseInitArgs above.
 
 // ---------------------------------------------------------------------------
 // Subprocess — exit codes + help output for real argv handling

--- a/plugins/mcp/__tests__/init/hosted.test.ts
+++ b/plugins/mcp/__tests__/init/hosted.test.ts
@@ -1,27 +1,26 @@
 /**
  * Tests for the OAuth 2.1 loopback flow in `init --hosted`.
  *
- * Strategy: every external dep (fetch, browser, loopback listener, RNG,
- * timer) is replaced with a deterministic stub via the `HostedFlowOptions`
- * test seams. No real ports are bound, no real browser launches, no real
- * HTTP. The unit under test is pure flow logic.
- *
- * Coverage:
- *   - happy path: discovery → DCR → callback → token exchange → JWT decode
- *   - state mismatch (CSRF probe)
- *   - missing code in callback
- *   - oauth `error=access_denied` path
- *   - token endpoint 400 (invalid_grant)
- *   - browser-launch failure falls back to "open URL manually" but completes
- *   - missing workspace_id claim in JWT
- *   - end-to-end runInit({ mode: "hosted", write: true }) merges into config
+ * Strategy: most external deps (fetch, browser, loopback listener, RNG,
+ * timer) are replaced with deterministic stubs via the `HostedFlowOptions`
+ * test seams. The integration block at the bottom exercises the actual
+ * `defaultServeImpl` against a real Bun.serve port to pin the once-fired
+ * listener guard.
  */
-import { describe, expect, it } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  defaultServeImpl,
   runHostedAuthFlow,
   type HostedFlowOptions,
   type LoopbackHandler,
@@ -32,7 +31,22 @@ import { runInit } from "../../src/init/index.js";
 
 // ── Helpers ───────────────────────────────────────────────────────────
 
-function captureStdio() {
+interface StdioCapture {
+  logs: string[];
+  errs: string[];
+  restore: () => void;
+}
+
+let activeCapture: StdioCapture | null = null;
+
+afterEach(() => {
+  if (activeCapture) {
+    activeCapture.restore();
+    activeCapture = null;
+  }
+});
+
+function captureStdio(): StdioCapture {
   const logs: string[] = [];
   const errs: string[] = [];
   const origLog = console.log;
@@ -43,7 +57,7 @@ function captureStdio() {
   console.error = (...a: unknown[]) => {
     errs.push(a.map((x) => (typeof x === "string" ? x : JSON.stringify(x))).join(" "));
   };
-  return {
+  const cap: StdioCapture = {
     logs,
     errs,
     restore: () => {
@@ -51,6 +65,8 @@ function captureStdio() {
       console.error = origErr;
     },
   };
+  activeCapture = cap;
+  return cap;
 }
 
 const FAKE_API = "https://atlas.test";
@@ -709,6 +725,226 @@ describe("runInit --hosted error mapping", () => {
       expect(err).toMatch(/state mismatch/i);
     } finally {
       cap.restore();
+    }
+  });
+});
+
+describe("runHostedAuthFlow — wire format header pinning", () => {
+  // OAuth 2.1 §3.2.1 mandates the form-encoded body for the token endpoint.
+  // A regression to `application/json` here would break interop with every
+  // standards-compliant server. DCR is JSON-bodied; pin both directions so
+  // a header swap can't slip through with the existing tests.
+  it("DCR uses application/json + Accept: application/json", async () => {
+    const { serve, controller } = fakeServe({});
+    let dcrHeaders: Headers | null = null;
+    const pending = runHostedAuthFlow({
+      apiUrl: FAKE_API,
+      fetchImpl: fakeFetch({
+        registration: async (req: Request) => {
+          dcrHeaders = req.headers;
+          return new Response(JSON.stringify({ client_id: "cid" }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        },
+      }),
+      serveImpl: serve,
+      openBrowserImpl: async () => ({ ok: true }),
+      randomBytesImpl: deterministicRandom,
+      callbackTimeoutMs: 5000,
+      consoleImpl: { log: () => {}, error: () => {} },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    controller().invoke(new URLSearchParams({ code: "x", state: EXPECTED_STATE }));
+    await pending;
+    expect(dcrHeaders).not.toBeNull();
+    expect(dcrHeaders!.get("Content-Type")).toBe("application/json");
+    expect(dcrHeaders!.get("Accept")).toBe("application/json");
+  });
+
+  it("token exchange uses application/x-www-form-urlencoded + Accept: application/json", async () => {
+    const { serve, controller } = fakeServe({});
+    let tokenHeaders: Headers | null = null;
+    const pending = runHostedAuthFlow({
+      apiUrl: FAKE_API,
+      fetchImpl: fakeFetch({
+        token: async (req: Request) => {
+          tokenHeaders = req.headers;
+          return new Response(
+            JSON.stringify({
+              access_token: jwt({
+                sub: "u",
+                iss: DISCOVERY_BODY.issuer,
+                "https://atlas.useatlas.dev/workspace_id": "ws_alpha",
+              }),
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        },
+      }),
+      serveImpl: serve,
+      openBrowserImpl: async () => ({ ok: true }),
+      randomBytesImpl: deterministicRandom,
+      callbackTimeoutMs: 5000,
+      consoleImpl: { log: () => {}, error: () => {} },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    controller().invoke(new URLSearchParams({ code: "x", state: EXPECTED_STATE }));
+    await pending;
+    expect(tokenHeaders).not.toBeNull();
+    expect(tokenHeaders!.get("Content-Type")).toBe("application/x-www-form-urlencoded");
+    expect(tokenHeaders!.get("Accept")).toBe("application/json");
+  });
+});
+
+describe("runHostedAuthFlow — malformed JWT discriminant", () => {
+  it("rejects with malformed_jwt when access_token isn't a 3-part token", async () => {
+    const { serve, controller } = fakeServe({});
+    const pending = runHostedAuthFlow({
+      apiUrl: FAKE_API,
+      fetchImpl: fakeFetch({
+        token: { access_token: "not-a-jwt" },
+      }),
+      serveImpl: serve,
+      openBrowserImpl: async () => ({ ok: true }),
+      randomBytesImpl: deterministicRandom,
+      callbackTimeoutMs: 5000,
+      consoleImpl: { log: () => {}, error: () => {} },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    controller().invoke(new URLSearchParams({ code: "abc", state: EXPECTED_STATE }));
+    await expect(pending).rejects.toMatchObject({ code: "malformed_jwt" });
+  });
+
+  it("rejects with malformed_jwt when payload base64 is not JSON", async () => {
+    const { serve, controller } = fakeServe({});
+    // Three parts, middle is base64url("not-json"), signature is junk.
+    const middle = btoa("not-json").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    const pending = runHostedAuthFlow({
+      apiUrl: FAKE_API,
+      fetchImpl: fakeFetch({
+        token: { access_token: `header.${middle}.sig` },
+      }),
+      serveImpl: serve,
+      openBrowserImpl: async () => ({ ok: true }),
+      randomBytesImpl: deterministicRandom,
+      callbackTimeoutMs: 5000,
+      consoleImpl: { log: () => {}, error: () => {} },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    controller().invoke(new URLSearchParams({ code: "abc", state: EXPECTED_STATE }));
+    await expect(pending).rejects.toMatchObject({ code: "malformed_jwt" });
+  });
+});
+
+describe("runInit --hosted --write failure path", () => {
+  it("surfaces a write failure and leaves any existing config untouched", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "atlas-mcp-init-hosted-fail-"));
+    // Pre-existing config we expect to survive the failed write.
+    const target = join(dir, "claude_desktop_config.json");
+    const original = `${JSON.stringify({ mcpServers: { existing: { command: "x", args: [] } } }, null, 2)}\n`;
+    writeFileSync(target, original, { encoding: "utf8" });
+    // Make the directory read-only so the tmp write fails. POSIX-only —
+    // skip on win32 where chmod permission bits aren't enforced.
+    if (process.platform === "win32") return;
+    chmodSync(dir, 0o500);
+    const { serve, controller } = fakeServe({});
+    const cap = captureStdio();
+    try {
+      const pending = runInit({
+        mode: "hosted",
+        apiUrl: FAKE_API,
+        client: "claude-desktop",
+        write: true,
+        configPathOverride: target,
+        fetchImpl: fakeFetch({}),
+        serveImpl: serve,
+        openBrowserImpl: async () => ({ ok: true }),
+        randomBytesImpl: deterministicRandom,
+        callbackTimeoutMs: 5000,
+      });
+      await new Promise((r) => setTimeout(r, 0));
+      controller().invoke(new URLSearchParams({ code: "abc", state: EXPECTED_STATE }));
+      const res = await pending;
+      expect(res.exitCode).toBe(1);
+      const err = cap.errs.join("\n");
+      expect(err).toMatch(/failed to write/);
+      expect(err).toMatch(/not modified/);
+      // Original content survives — atomic-write guarantee.
+      expect(readFileSync(target, "utf8")).toBe(original);
+    } finally {
+      cap.restore();
+      // Restore perms so the tmpdir cleanup succeeds.
+      chmodSync(dir, 0o700);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces a directory-creation failure with the directory in the message", async () => {
+    if (process.platform === "win32") return;
+    const dir = mkdtempSync(join(tmpdir(), "atlas-mcp-init-hosted-mkdir-"));
+    // Write a regular file where we want to create a subdirectory — the
+    // recursive mkdir will fail with ENOTDIR.
+    const blocker = join(dir, "blocker");
+    writeFileSync(blocker, "");
+    const target = join(blocker, "child", "claude_desktop_config.json");
+    const { serve, controller } = fakeServe({});
+    const cap = captureStdio();
+    try {
+      const pending = runInit({
+        mode: "hosted",
+        apiUrl: FAKE_API,
+        client: "claude-desktop",
+        write: true,
+        configPathOverride: target,
+        fetchImpl: fakeFetch({}),
+        serveImpl: serve,
+        openBrowserImpl: async () => ({ ok: true }),
+        randomBytesImpl: deterministicRandom,
+        callbackTimeoutMs: 5000,
+      });
+      await new Promise((r) => setTimeout(r, 0));
+      controller().invoke(new URLSearchParams({ code: "abc", state: EXPECTED_STATE }));
+      const res = await pending;
+      expect(res.exitCode).toBe(1);
+      const err = cap.errs.join("\n");
+      expect(err).toMatch(/Could not create config directory/);
+    } finally {
+      cap.restore();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── Real Bun.serve integration: once-fired listener guard ──────────────
+//
+// The `defaultServeImpl` once-fired flag and 404-for-everything-else
+// branches live inside Bun.serve's `fetch` callback — they aren't reachable
+// through the `fakeServe` test seam used elsewhere. Bind a real port (port
+// 0 → OS-assigned) and exercise the guards directly.
+
+describe("defaultServeImpl — single-shot listener guard", () => {
+  it("invokes the handler once, returns 404 on subsequent /callback requests, and 404s non-callback paths", async () => {
+    let calls = 0;
+    const handler: LoopbackHandler = (params) => {
+      calls += 1;
+      return { status: 200, body: `ok:${params.get("code") ?? ""}` };
+    };
+    const server = await defaultServeImpl(handler);
+    try {
+      const base = `http://127.0.0.1:${server.port}`;
+      const first = await fetch(`${base}/callback?code=abc&state=xyz`);
+      expect(first.status).toBe(200);
+      expect(await first.text()).toBe("ok:abc");
+      // Replay — the handler MUST NOT run again.
+      const second = await fetch(`${base}/callback?code=abc&state=xyz`);
+      expect(second.status).toBe(404);
+      // Non-callback path is also 404 and never reaches the handler.
+      const stray = await fetch(`${base}/anything-else`);
+      expect(stray.status).toBe(404);
+      expect(calls).toBe(1);
+    } finally {
+      await server.stop();
     }
   });
 });

--- a/plugins/mcp/__tests__/init/hosted.test.ts
+++ b/plugins/mcp/__tests__/init/hosted.test.ts
@@ -1,0 +1,715 @@
+/**
+ * Tests for the OAuth 2.1 loopback flow in `init --hosted`.
+ *
+ * Strategy: every external dep (fetch, browser, loopback listener, RNG,
+ * timer) is replaced with a deterministic stub via the `HostedFlowOptions`
+ * test seams. No real ports are bound, no real browser launches, no real
+ * HTTP. The unit under test is pure flow logic.
+ *
+ * Coverage:
+ *   - happy path: discovery → DCR → callback → token exchange → JWT decode
+ *   - state mismatch (CSRF probe)
+ *   - missing code in callback
+ *   - oauth `error=access_denied` path
+ *   - token endpoint 400 (invalid_grant)
+ *   - browser-launch failure falls back to "open URL manually" but completes
+ *   - missing workspace_id claim in JWT
+ *   - end-to-end runInit({ mode: "hosted", write: true }) merges into config
+ */
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  runHostedAuthFlow,
+  type HostedFlowOptions,
+  type LoopbackHandler,
+  type LoopbackServer,
+  type ServeImpl,
+} from "../../src/init/hosted.js";
+import { runInit } from "../../src/init/index.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function captureStdio() {
+  const logs: string[] = [];
+  const errs: string[] = [];
+  const origLog = console.log;
+  const origErr = console.error;
+  console.log = (...a: unknown[]) => {
+    logs.push(a.map((x) => (typeof x === "string" ? x : JSON.stringify(x))).join(" "));
+  };
+  console.error = (...a: unknown[]) => {
+    errs.push(a.map((x) => (typeof x === "string" ? x : JSON.stringify(x))).join(" "));
+  };
+  return {
+    logs,
+    errs,
+    restore: () => {
+      console.log = origLog;
+      console.error = origErr;
+    },
+  };
+}
+
+const FAKE_API = "https://atlas.test";
+
+const DISCOVERY_BODY = {
+  authorization_endpoint: `${FAKE_API}/api/auth/oauth2/authorize`,
+  token_endpoint: `${FAKE_API}/api/auth/oauth2/token`,
+  registration_endpoint: `${FAKE_API}/api/auth/oauth2/register`,
+  issuer: `${FAKE_API}/api/auth`,
+};
+
+/** Build a JWT-shaped string with a custom payload. Signature is junk —
+ *  we never verify here. */
+function jwt(payload: Record<string, unknown>): string {
+  const enc = (obj: unknown) =>
+    Buffer.from(JSON.stringify(obj))
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  return `${enc({ alg: "RS256", typ: "JWT" })}.${enc(payload)}.signature-not-verified`;
+}
+
+/** Deterministic random — base64url(0,1,2,…) with the requested length. */
+function deterministicRandom(length: number): Uint8Array {
+  const bytes = new Uint8Array(length);
+  for (let i = 0; i < length; i++) bytes[i] = i & 0xff;
+  return bytes;
+}
+
+/**
+ * The base64url state value the flow generates from `deterministicRandom`
+ * for `randomBytes(32)`. Mirrored inline once so every test asserts
+ * against the same constant — if `encodeBase64Url` ever drifts from this,
+ * one test reports the mismatch instead of all of them.
+ */
+const EXPECTED_STATE = (() => {
+  let bin = "";
+  for (let i = 0; i < 32; i++) bin += String.fromCharCode(i & 0xff);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+})();
+
+/** The verifier the flow generates is a separate 32-byte draw. */
+const EXPECTED_VERIFIER = (() => {
+  let bin = "";
+  for (let i = 0; i < 32; i++) bin += String.fromCharCode(i & 0xff);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+})();
+
+type FetchStub = (req: Request) => Response | Promise<Response>;
+interface FetchStubBehavior {
+  /** Either the JSON body to return or a function that throws/returns. */
+  discovery?: unknown | FetchStub;
+  registration?: unknown | FetchStub;
+  token?: unknown | FetchStub;
+}
+
+function fakeFetch(behavior: FetchStubBehavior): typeof fetch {
+  return (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const req = new Request(url, init);
+    const dispatch = async (slot: unknown): Promise<Response> => {
+      if (typeof slot === "function") {
+        return (slot as FetchStub)(req);
+      }
+      return new Response(JSON.stringify(slot), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+    if (url.includes("/.well-known/oauth-authorization-server")) {
+      return dispatch(behavior.discovery ?? DISCOVERY_BODY);
+    }
+    if (url.endsWith("/register")) {
+      return dispatch(behavior.registration ?? { client_id: "fake-client-id" });
+    }
+    if (url.endsWith("/token")) {
+      return dispatch(behavior.token ?? {
+        access_token: jwt({
+          sub: "user-1",
+          iss: DISCOVERY_BODY.issuer,
+          "https://atlas.useatlas.dev/workspace_id": "ws_alpha",
+        }),
+        refresh_token: "r-1",
+      });
+    }
+    throw new Error(`fakeFetch: no stub for ${url}`);
+  }) as unknown as typeof fetch;
+}
+
+interface FakeServer extends LoopbackServer {
+  invoke: (params: URLSearchParams, method?: string) => { status: number; body: string };
+  stopped: boolean;
+}
+
+/**
+ * Synchronous loopback stub. The flow under test starts the server, then
+ * waits for the callback; we expose a hand-fired `invoke()` that the test
+ * can call after kicking off the flow to deliver `?code=…&state=…`. The
+ * method defaults to GET (the only method the OAuth callback uses).
+ */
+function fakeServe(params?: { port?: number }): { serve: ServeImpl; controller: () => FakeServer } {
+  let captured: FakeServer | null = null;
+  const serve: ServeImpl = async (handler: LoopbackHandler) => {
+    const inst: FakeServer = {
+      port: params?.port ?? 49152,
+      stop: async () => {
+        inst.stopped = true;
+      },
+      invoke: (p, method = "GET") => handler(p, method),
+      stopped: false,
+    };
+    captured = inst;
+    return inst;
+  };
+  return {
+    serve,
+    controller: () => {
+      if (!captured) throw new Error("fakeServe: serve() not yet called");
+      return captured;
+    },
+  };
+}
+
+// ── runHostedAuthFlow ──────────────────────────────────────────────────
+
+describe("runHostedAuthFlow — happy path", () => {
+  it("completes the loopback flow and returns the JWT + refresh + workspace", async () => {
+    const { serve, controller } = fakeServe({ port: 49152 });
+    const opts: HostedFlowOptions = {
+      apiUrl: FAKE_API,
+      fetchImpl: fakeFetch({}),
+      serveImpl: serve,
+      openBrowserImpl: async () => ({ ok: true }),
+      randomBytesImpl: deterministicRandom,
+      callbackTimeoutMs: 5000,
+      consoleImpl: { log: () => {}, error: () => {} },
+    };
+
+    const pending = runHostedAuthFlow(opts);
+
+    // Yield once so the flow registers the loopback handler before we
+    // fire the callback. Without this, controller() throws.
+    await new Promise((r) => setTimeout(r, 0));
+    const params = new URLSearchParams();
+    params.set("code", "abc123");
+    // The state must match the encoded random bytes the flow generated.
+    // We mirror the same encoding inline (deterministic).
+    params.set("state", EXPECTED_STATE);
+    const result = controller().invoke(params);
+    expect(result.status).toBe(200);
+
+    const out = await pending;
+    expect(out.accessToken).toContain(".");
+    // Bearer is a branded string; compare as plain string for the assertion.
+    expect(out.refreshToken as string | null).toBe("r-1");
+    expect(out.workspaceId).toBe("ws_alpha");
+    expect(out.mcpUrl).toBe(`${FAKE_API}/mcp/ws_alpha/sse`);
+    // Listener was stopped on success.
+    expect(controller().stopped).toBe(true);
+  });
+});
+
+describe("runHostedAuthFlow — wire format (pins acceptance criteria from #2024)", () => {
+  it("sends PKCE S256 + 127.0.0.1 redirect_uri across DCR, authorize URL, and token", async () => {
+    const { serve, controller } = fakeServe({ port: 49152 });
+    const expectedRedirect = "http://127.0.0.1:49152/callback";
+
+    let registrationBody: Record<string, unknown> | null = null;
+    let authorizeUrl: string | null = null;
+    let tokenForm: URLSearchParams | null = null;
+
+    // Compute what the flow's PKCE code_challenge should be (S256(verifier)).
+    const verifierBytes = new TextEncoder().encode(EXPECTED_VERIFIER);
+    const digest = await crypto.subtle.digest("SHA-256", verifierBytes);
+    const expectedChallenge = (() => {
+      let bin = "";
+      const arr = new Uint8Array(digest);
+      for (let i = 0; i < arr.length; i++) bin += String.fromCharCode(arr[i]);
+      return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    })();
+
+    const pending = runHostedAuthFlow({
+      apiUrl: FAKE_API,
+      fetchImpl: fakeFetch({
+        registration: async (req: Request) => {
+          registrationBody = (await req.json()) as Record<string, unknown>;
+          return new Response(JSON.stringify({ client_id: "test-client-id" }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        },
+        token: async (req: Request) => {
+          tokenForm = new URLSearchParams(await req.text());
+          return new Response(
+            JSON.stringify({
+              access_token: jwt({
+                sub: "user-1",
+                iss: DISCOVERY_BODY.issuer,
+                "https://atlas.useatlas.dev/workspace_id": "ws_alpha",
+              }),
+              refresh_token: "r-1",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        },
+      }),
+      serveImpl: serve,
+      openBrowserImpl: async (url) => {
+        authorizeUrl = url;
+        return { ok: true };
+      },
+      randomBytesImpl: deterministicRandom,
+      callbackTimeoutMs: 5000,
+      consoleImpl: { log: () => {}, error: () => {} },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    controller().invoke(new URLSearchParams({ code: "the-code", state: EXPECTED_STATE }));
+    await pending;
+
+    // DCR — public-client posture, exact redirect URI, both grant types.
+    expect(registrationBody).toMatchObject({
+      client_name: "Atlas MCP CLI",
+      token_endpoint_auth_method: "none",
+      redirect_uris: [expectedRedirect],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+    });
+
+    // Authorize URL — PKCE S256 + state + redirect parameters all present.
+    expect(authorizeUrl).not.toBeNull();
+    const u = new URL(authorizeUrl!);
+    expect(u.origin + u.pathname).toBe(DISCOVERY_BODY.authorization_endpoint);
+    expect(u.searchParams.get("response_type")).toBe("code");
+    expect(u.searchParams.get("client_id")).toBe("test-client-id");
+    expect(u.searchParams.get("redirect_uri")).toBe(expectedRedirect);
+    expect(u.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(u.searchParams.get("code_challenge")).toBe(expectedChallenge);
+    expect(u.searchParams.get("state")).toBe(EXPECTED_STATE);
+    // Scopes include offline_access so a refresh token is issuable.
+    expect(u.searchParams.get("scope")).toContain("mcp:read");
+    expect(u.searchParams.get("scope")).toContain("offline_access");
+
+    // Token exchange — auth-code grant, code+verifier+redirect_uri match.
+    expect(tokenForm).not.toBeNull();
+    expect(tokenForm!.get("grant_type")).toBe("authorization_code");
+    expect(tokenForm!.get("code")).toBe("the-code");
+    expect(tokenForm!.get("redirect_uri")).toBe(expectedRedirect);
+    expect(tokenForm!.get("client_id")).toBe("test-client-id");
+    expect(tokenForm!.get("code_verifier")).toBe(EXPECTED_VERIFIER);
+  });
+});
+
+describe("runHostedAuthFlow — failure modes", () => {
+  it("rejects on state mismatch (CSRF probe)", async () => {
+    const { serve, controller } = fakeServe({});
+    const pending = runHostedAuthFlow({
+      apiUrl: FAKE_API,
+      fetchImpl: fakeFetch({}),
+      serveImpl: serve,
+      openBrowserImpl: async () => ({ ok: true }),
+      randomBytesImpl: deterministicRandom,
+      callbackTimeoutMs: 5000,
+      consoleImpl: { log: () => {}, error: () => {} },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    const r = controller().invoke(
+      new URLSearchParams({ code: "x", state: "wrong-state" }),
+    );
+    expect(r.status).toBe(400);
+    await expect(pending).rejects.toMatchObject({
+      name: "HostedFlowError",
+      code: "callback_state_mismatch",
+    });
+    expect(controller().stopped).toBe(true);
+  });
+
+  it("rejects when the callback is missing the code parameter", async () => {
+    const { serve, controller } = fakeServe({});
+    const pending = runHostedAuthFlow({
+      apiUrl: FAKE_API,
+      fetchImpl: fakeFetch({}),
+      serveImpl: serve,
+      openBrowserImpl: async () => ({ ok: true }),
+      randomBytesImpl: deterministicRandom,
+      callbackTimeoutMs: 5000,
+      consoleImpl: { log: () => {}, error: () => {} },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    controller().invoke(new URLSearchParams({ state: EXPECTED_STATE }));
+    await expect(pending).rejects.toMatchObject({ code: "callback_missing_code" });
+  });
+
+  it("rejects when the auth server returns ?error=access_denied", async () => {
+    const { serve, controller } = fakeServe({});
+    const pending = runHostedAuthFlow({
+      apiUrl: FAKE_API,
+      fetchImpl: fakeFetch({}),
+      serveImpl: serve,
+      openBrowserImpl: async () => ({ ok: true }),
+      randomBytesImpl: deterministicRandom,
+      callbackTimeoutMs: 5000,
+      consoleImpl: { log: () => {}, error: () => {} },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    controller().invoke(
+      new URLSearchParams({
+        error: "access_denied",
+        error_description: "user clicked deny",
+      }),
+    );
+    await expect(pending).rejects.toMatchObject({ code: "callback_oauth_error" });
+  });
+
+  it("rejects when the token endpoint returns invalid_grant", async () => {
+    const { serve, controller } = fakeServe({});
+    const pending = runHostedAuthFlow({
+      apiUrl: FAKE_API,
+      fetchImpl: fakeFetch({
+        token: () =>
+          new Response(
+            JSON.stringify({ error: "invalid_grant", error_description: "code expired" }),
+            { status: 400, headers: { "Content-Type": "application/json" } },
+          ),
+      }),
+      serveImpl: serve,
+      openBrowserImpl: async () => ({ ok: true }),
+      randomBytesImpl: deterministicRandom,
+      callbackTimeoutMs: 5000,
+      consoleImpl: { log: () => {}, error: () => {} },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    controller().invoke(new URLSearchParams({ code: "abc", state: EXPECTED_STATE }));
+    await expect(pending).rejects.toMatchObject({ code: "token_exchange_failed" });
+  });
+
+  it("falls back to manual URL when the browser launcher fails but completes the flow", async () => {
+    const { serve, controller } = fakeServe({});
+    const errors: string[] = [];
+    const pending = runHostedAuthFlow({
+      apiUrl: FAKE_API,
+      fetchImpl: fakeFetch({}),
+      serveImpl: serve,
+      openBrowserImpl: async () => ({ ok: false, detail: "xdg-open: not found" }),
+      randomBytesImpl: deterministicRandom,
+      callbackTimeoutMs: 5000,
+      consoleImpl: { log: () => {}, error: (m) => errors.push(m) },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    controller().invoke(new URLSearchParams({ code: "abc", state: EXPECTED_STATE }));
+    const result = await pending;
+    expect(result.workspaceId).toBe("ws_alpha");
+    expect(errors.join("\n")).toMatch(/auto-launch the browser/);
+    expect(errors.join("\n")).toMatch(/xdg-open: not found/);
+  });
+
+  it("rejects when the access_token has no workspace_id claim", async () => {
+    const { serve, controller } = fakeServe({});
+    // iss matches, workspace_id missing — should land on missing_workspace_claim
+    const noWorkspaceJwt = jwt({ sub: "user-1", iss: DISCOVERY_BODY.issuer });
+    const pending = runHostedAuthFlow({
+      apiUrl: FAKE_API,
+      fetchImpl: fakeFetch({
+        token: { access_token: noWorkspaceJwt },
+      }),
+      serveImpl: serve,
+      openBrowserImpl: async () => ({ ok: true }),
+      randomBytesImpl: deterministicRandom,
+      callbackTimeoutMs: 5000,
+      consoleImpl: { log: () => {}, error: () => {} },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    controller().invoke(new URLSearchParams({ code: "abc", state: EXPECTED_STATE }));
+    await expect(pending).rejects.toMatchObject({ code: "missing_workspace_claim" });
+  });
+
+  it("rejects when the access_token issuer does not match discovery", async () => {
+    const { serve, controller } = fakeServe({});
+    const wrongIssJwt = jwt({
+      sub: "user-1",
+      iss: "https://evil.example.com/api/auth",
+      "https://atlas.useatlas.dev/workspace_id": "ws_alpha",
+    });
+    const pending = runHostedAuthFlow({
+      apiUrl: FAKE_API,
+      fetchImpl: fakeFetch({ token: { access_token: wrongIssJwt } }),
+      serveImpl: serve,
+      openBrowserImpl: async () => ({ ok: true }),
+      randomBytesImpl: deterministicRandom,
+      callbackTimeoutMs: 5000,
+      consoleImpl: { log: () => {}, error: () => {} },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    controller().invoke(new URLSearchParams({ code: "abc", state: EXPECTED_STATE }));
+    await expect(pending).rejects.toMatchObject({ code: "issuer_mismatch" });
+  });
+
+  it("rejects an http:// apiUrl that isn't localhost", async () => {
+    const { serve } = fakeServe({});
+    await expect(
+      runHostedAuthFlow({
+        apiUrl: "http://evil.example.com",
+        fetchImpl: fakeFetch({}),
+        serveImpl: serve,
+        openBrowserImpl: async () => ({ ok: true }),
+        randomBytesImpl: deterministicRandom,
+        callbackTimeoutMs: 5000,
+        consoleImpl: { log: () => {}, error: () => {} },
+      }),
+    ).rejects.toMatchObject({ code: "invalid_api_url" });
+  });
+
+  it("returns 405 on a non-GET callback without settling the flow", async () => {
+    const { serve, controller } = fakeServe({});
+    const pending = runHostedAuthFlow({
+      apiUrl: FAKE_API,
+      fetchImpl: fakeFetch({}),
+      serveImpl: serve,
+      openBrowserImpl: async () => ({ ok: true }),
+      randomBytesImpl: deterministicRandom,
+      callbackTimeoutMs: 200,
+      consoleImpl: { log: () => {}, error: () => {} },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    const probe = controller().invoke(
+      new URLSearchParams({ code: "abc", state: EXPECTED_STATE }),
+      "POST",
+    );
+    expect(probe.status).toBe(405);
+    // The flow continues waiting; the legitimate callback eventually arrives.
+    controller().invoke(new URLSearchParams({ code: "abc", state: EXPECTED_STATE }));
+    const result = await pending;
+    expect(result.workspaceId).toBe("ws_alpha");
+  });
+
+  it("accepts http://127.0.0.1 for local-dev testing", async () => {
+    const { serve, controller } = fakeServe({});
+    const localDiscovery = {
+      authorization_endpoint: "http://127.0.0.1:3001/api/auth/oauth2/authorize",
+      token_endpoint: "http://127.0.0.1:3001/api/auth/oauth2/token",
+      registration_endpoint: "http://127.0.0.1:3001/api/auth/oauth2/register",
+      issuer: "http://127.0.0.1:3001/api/auth",
+    };
+    const localJwt = jwt({
+      sub: "user-1",
+      iss: localDiscovery.issuer,
+      "https://atlas.useatlas.dev/workspace_id": "ws_dev",
+    });
+    const pending = runHostedAuthFlow({
+      apiUrl: "http://127.0.0.1:3001",
+      fetchImpl: fakeFetch({
+        discovery: localDiscovery,
+        token: { access_token: localJwt },
+      }),
+      serveImpl: serve,
+      openBrowserImpl: async () => ({ ok: true }),
+      randomBytesImpl: deterministicRandom,
+      callbackTimeoutMs: 5000,
+      consoleImpl: { log: () => {}, error: () => {} },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    controller().invoke(new URLSearchParams({ code: "abc", state: EXPECTED_STATE }));
+    const result = await pending;
+    expect(result.workspaceId).toBe("ws_dev");
+  });
+
+  it("rejects when discovery itself fails", async () => {
+    const { serve } = fakeServe({});
+    await expect(
+      runHostedAuthFlow({
+        apiUrl: FAKE_API,
+        fetchImpl: fakeFetch({
+          discovery: () => new Response("nope", { status: 503 }),
+        }),
+        serveImpl: serve,
+        openBrowserImpl: async () => ({ ok: true }),
+        randomBytesImpl: deterministicRandom,
+        callbackTimeoutMs: 5000,
+        consoleImpl: { log: () => {}, error: () => {} },
+      }),
+    ).rejects.toMatchObject({ code: "discovery_failed" });
+  });
+
+  it("rejects when DCR fails", async () => {
+    const { serve } = fakeServe({});
+    await expect(
+      runHostedAuthFlow({
+        apiUrl: FAKE_API,
+        fetchImpl: fakeFetch({
+          registration: () =>
+            new Response(JSON.stringify({ error: "invalid_request" }), {
+              status: 400,
+              headers: { "Content-Type": "application/json" },
+            }),
+        }),
+        serveImpl: serve,
+        openBrowserImpl: async () => ({ ok: true }),
+        randomBytesImpl: deterministicRandom,
+        callbackTimeoutMs: 5000,
+        consoleImpl: { log: () => {}, error: () => {} },
+      }),
+    ).rejects.toMatchObject({ code: "registration_failed" });
+  });
+
+  it("rejects with callback_timeout if the callback never arrives", async () => {
+    const { serve } = fakeServe({});
+    await expect(
+      runHostedAuthFlow({
+        apiUrl: FAKE_API,
+        fetchImpl: fakeFetch({}),
+        serveImpl: serve,
+        openBrowserImpl: async () => ({ ok: true }),
+        randomBytesImpl: deterministicRandom,
+        callbackTimeoutMs: 50, // very short timeout
+        consoleImpl: { log: () => {}, error: () => {} },
+      }),
+    ).rejects.toMatchObject({ code: "callback_timeout" });
+  });
+});
+
+// ── runInit({ mode: "hosted" }) integration ───────────────────────────
+
+describe("runInit --hosted (print-only)", () => {
+  it("prints a JSON snippet with the hosted MCP URL and Bearer header", async () => {
+    const { serve, controller } = fakeServe({});
+    const cap = captureStdio();
+    try {
+      const pending = runInit({
+        mode: "hosted",
+        apiUrl: FAKE_API,
+        fetchImpl: fakeFetch({}),
+        serveImpl: serve,
+        openBrowserImpl: async () => ({ ok: true }),
+        randomBytesImpl: deterministicRandom,
+        callbackTimeoutMs: 5000,
+      });
+      await new Promise((r) => setTimeout(r, 0));
+      controller().invoke(new URLSearchParams({ code: "abc", state: EXPECTED_STATE }));
+      const res = await pending;
+      expect(res.exitCode).toBe(0);
+      const out = cap.logs.join("\n");
+      expect(out).toContain(`"url": "${FAKE_API}/mcp/ws_alpha/sse"`);
+      expect(out).toContain('"Authorization": "Bearer ');
+      // bunx form is for --local, not hosted.
+      expect(out).not.toContain('"command": "bunx"');
+    } finally {
+      cap.restore();
+    }
+  });
+});
+
+describe("runInit --hosted --write", () => {
+  it("merges the hosted server block into the configured client config", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "atlas-mcp-init-hosted-"));
+    const target = join(dir, "claude_desktop_config.json");
+    const { serve, controller } = fakeServe({});
+    const cap = captureStdio();
+    try {
+      const pending = runInit({
+        mode: "hosted",
+        apiUrl: FAKE_API,
+        client: "claude-desktop",
+        write: true,
+        configPathOverride: target,
+        fetchImpl: fakeFetch({}),
+        serveImpl: serve,
+        openBrowserImpl: async () => ({ ok: true }),
+        randomBytesImpl: deterministicRandom,
+        callbackTimeoutMs: 5000,
+      });
+      await new Promise((r) => setTimeout(r, 0));
+      controller().invoke(new URLSearchParams({ code: "abc", state: EXPECTED_STATE }));
+      const res = await pending;
+      expect(res.exitCode).toBe(0);
+      const written = JSON.parse(readFileSync(target, "utf8"));
+      expect(written.mcpServers.atlas.url).toBe(`${FAKE_API}/mcp/ws_alpha/sse`);
+      expect(written.mcpServers.atlas.headers.Authorization).toMatch(/^Bearer /);
+      // No local-style command — hosted is a remote server pointer.
+      expect(written.mcpServers.atlas.command).toBeUndefined();
+    } finally {
+      cap.restore();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("runInit --hosted --write — preserves siblings + writes .bak", () => {
+  it("merges hosted server beside an existing one and backs up the prior config", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "atlas-mcp-init-hosted-merge-"));
+    const target = join(dir, "claude_desktop_config.json");
+    const existing = JSON.stringify(
+      {
+        mcpServers: { other: { command: "x", args: ["y"] } },
+        unrelatedTopLevel: { keep: true },
+      },
+      null,
+      2,
+    );
+    Bun.write(target, existing);
+    const { serve, controller } = fakeServe({});
+    const cap = captureStdio();
+    try {
+      const pending = runInit({
+        mode: "hosted",
+        apiUrl: FAKE_API,
+        client: "claude-desktop",
+        write: true,
+        configPathOverride: target,
+        fetchImpl: fakeFetch({}),
+        serveImpl: serve,
+        openBrowserImpl: async () => ({ ok: true }),
+        randomBytesImpl: deterministicRandom,
+        callbackTimeoutMs: 5000,
+      });
+      await new Promise((r) => setTimeout(r, 0));
+      controller().invoke(new URLSearchParams({ code: "abc", state: EXPECTED_STATE }));
+      const res = await pending;
+      expect(res.exitCode).toBe(0);
+      const written = JSON.parse(readFileSync(target, "utf8"));
+      // Sibling server preserved.
+      expect(written.mcpServers.other).toEqual({ command: "x", args: ["y"] });
+      // Hosted block added.
+      expect(written.mcpServers.atlas.url).toBe(`${FAKE_API}/mcp/ws_alpha/sse`);
+      // Unrelated top-level keys preserved.
+      expect(written.unrelatedTopLevel).toEqual({ keep: true });
+      // .bak written.
+      expect(readFileSync(`${target}.bak`, "utf8")).toBe(existing);
+    } finally {
+      cap.restore();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("runInit --hosted error mapping", () => {
+  it("returns exitCode 1 with a HostedFlowError message on flow failure", async () => {
+    const { serve, controller } = fakeServe({});
+    const cap = captureStdio();
+    try {
+      const pending = runInit({
+        mode: "hosted",
+        apiUrl: FAKE_API,
+        fetchImpl: fakeFetch({}),
+        serveImpl: serve,
+        openBrowserImpl: async () => ({ ok: true }),
+        randomBytesImpl: deterministicRandom,
+        callbackTimeoutMs: 5000,
+      });
+      await new Promise((r) => setTimeout(r, 0));
+      // Wrong state — flow rejects.
+      controller().invoke(new URLSearchParams({ code: "abc", state: "wrong" }));
+      const res = await pending;
+      expect(res.exitCode).toBe(1);
+      const err = cap.errs.join("\n");
+      expect(err).toContain("init --hosted");
+      expect(err).toMatch(/state mismatch/i);
+    } finally {
+      cap.restore();
+    }
+  });
+});
+

--- a/plugins/mcp/__tests__/init/run.test.ts
+++ b/plugins/mcp/__tests__/init/run.test.ts
@@ -30,20 +30,11 @@ function captureStdio(): { logs: string[]; errs: string[]; restore: () => void }
   };
 }
 
-describe("runInit --hosted (stub)", () => {
-  it("prints a tracking-issue link and exits non-fatally", async () => {
-    const cap = captureStdio();
-    try {
-      const res = await runInit({ mode: "hosted" });
-      expect(res.exitCode).toBe(0);
-      const out = [...cap.logs, ...cap.errs].join("\n");
-      expect(out).toMatch(/issues\/2024/);
-      expect(out).toMatch(/hosted/i);
-    } finally {
-      cap.restore();
-    }
-  });
-});
+// runInit --hosted is now a real OAuth 2.1 loopback flow. Behaviour
+// (state mismatch, token exchange error, --write merge, browser fallback)
+// is exercised end-to-end in `__tests__/init/hosted.test.ts` with all
+// external deps stubbed via the test seams. Smoke tests of the stub
+// removed when the stub itself was removed.
 
 describe("runInit --local (print-only, no --write)", () => {
   it("prints a JSON snippet that uses bunx @useatlas/mcp serve", async () => {

--- a/plugins/mcp/bin/cli.ts
+++ b/plugins/mcp/bin/cli.ts
@@ -104,16 +104,19 @@ Run \`bunx @useatlas/mcp <command> --help\` for command-specific options.
 const INIT_HELP = `bunx @useatlas/mcp init [options]
 
   --local            Configure for a local Atlas (default)
-  --hosted           Configure for app.useatlas.dev (not yet available)
+  --hosted           Configure for hosted Atlas via OAuth 2.1 loopback flow
   --client <id>      Force a specific client: claude-desktop | cursor | continue | generic
   --write            Merge into the client's config file (with a .bak backup)
-  --api-url <url>    Override local Atlas detection URL (default: http://localhost:3001)
+  --api-url <url>    Override the API base URL (default: http://localhost:3001 for --local,
+                     https://api.useatlas.dev for --hosted; also reads ATLAS_PUBLIC_API_URL)
   -h, --help         Show this help
 
 Examples:
   bunx @useatlas/mcp init --local
   bunx @useatlas/mcp init --local --write
   bunx @useatlas/mcp init --local --client cursor --write
+  bunx @useatlas/mcp init --hosted --write
+  bunx @useatlas/mcp init --hosted --api-url https://api-eu.useatlas.dev --write
 `;
 
 const SERVE_HELP = `bunx @useatlas/mcp serve [options]
@@ -136,7 +139,12 @@ export async function runInitCommand(argv: string[]): Promise<number> {
 
   const opts: RunInitOptions =
     flags.mode === "hosted"
-      ? { mode: "hosted" }
+      ? {
+          mode: "hosted",
+          client: flags.client,
+          write: flags.write,
+          apiUrl: flags.apiUrl,
+        }
       : {
           mode: "local",
           client: flags.client,

--- a/plugins/mcp/src/init/config-merge.ts
+++ b/plugins/mcp/src/init/config-merge.ts
@@ -5,7 +5,15 @@
  * exists).
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  copyFileSync,
+  renameSync,
+  unlinkSync,
+} from "node:fs";
 import { dirname } from "node:path";
 
 /** Stdio launcher — `bunx @useatlas/mcp serve`, used by `init --local`. */
@@ -28,6 +36,22 @@ export interface HttpServerConfig {
 }
 
 export type ServerConfig = StdioServerConfig | HttpServerConfig;
+
+/**
+ * Type guard for `HttpServerConfig`. Wire format is locked by the MCP
+ * client spec — `{ url, headers? }` for HTTP/SSE, `{ command, args, env? }`
+ * for stdio — so we narrow structurally. Use this guard rather than
+ * inlining `"url" in cfg` at call sites: a future stdio variant adding a
+ * URL field would silently break inline checks.
+ */
+export function isHttpServerConfig(cfg: ServerConfig): cfg is HttpServerConfig {
+  return "url" in cfg && typeof cfg.url === "string";
+}
+
+/** Type guard for `StdioServerConfig`. See `isHttpServerConfig`. */
+export function isStdioServerConfig(cfg: ServerConfig): cfg is StdioServerConfig {
+  return "command" in cfg && typeof cfg.command === "string";
+}
 
 interface BuildOpts {
   /** Inline ATLAS_DATASOURCE_URL into the env block. Omit to inherit the user's shell env. */
@@ -117,24 +141,78 @@ export interface WriteResult {
   backupPath: string | null;
 }
 
+/**
+ * Write a file atomically with a `.bak` of any previous version.
+ *
+ * Order of operations matters: a naive `cp old → bak; write new` leaves
+ * the user without an original config if `write` fails after the copy.
+ * Instead we write to a sibling `.tmp` first, rename it over the live
+ * path (POSIX `rename(2)` is atomic on the same filesystem), and only
+ * then write the backup — so a failed write never destroys the prior
+ * file, and a failed backup leaves the new file in place.
+ */
 export async function writeConfigWithBackup(
   configPath: string,
   newContent: string,
 ): Promise<WriteResult> {
-  let backupPath: string | null = null;
-
-  if (existsSync(configPath)) {
-    backupPath = `${configPath}.bak`;
-    if (existsSync(backupPath)) {
-      const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-      backupPath = `${configPath}.${stamp}.bak`;
+  const dir = dirname(configPath);
+  if (!existsSync(configPath)) {
+    try {
+      mkdirSync(dir, { recursive: true });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Could not create config directory ${dir}: ${msg}`,
+        { cause: err },
+      );
     }
-    copyFileSync(configPath, backupPath);
-  } else {
-    mkdirSync(dirname(configPath), { recursive: true });
   }
 
-  writeFileSync(configPath, newContent, { encoding: "utf8", mode: 0o600 });
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const tmpPath = `${configPath}.${stamp}.tmp`;
+  try {
+    writeFileSync(tmpPath, newContent, { encoding: "utf8", mode: 0o600 });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Could not write ${tmpPath}: ${msg}`, { cause: err });
+  }
+
+  let backupPath: string | null = null;
+  if (existsSync(configPath)) {
+    backupPath = existsSync(`${configPath}.bak`)
+      ? `${configPath}.${stamp}.bak`
+      : `${configPath}.bak`;
+    try {
+      copyFileSync(configPath, backupPath);
+    } catch (err) {
+      // Best-effort cleanup of the staged tmp file before re-throwing.
+      try {
+        unlinkSync(tmpPath);
+      } catch {
+        // intentionally ignored: cleanup of a tmp we just wrote is best-effort.
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Could not back up existing config ${configPath} → ${backupPath}: ${msg}`,
+        { cause: err },
+      );
+    }
+  }
+
+  try {
+    renameSync(tmpPath, configPath);
+  } catch (err) {
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      // intentionally ignored: cleanup of a tmp we just wrote is best-effort.
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Could not rename ${tmpPath} → ${configPath}: ${msg}`,
+      { cause: err },
+    );
+  }
   return { backupPath };
 }
 

--- a/plugins/mcp/src/init/config-merge.ts
+++ b/plugins/mcp/src/init/config-merge.ts
@@ -8,11 +8,26 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync } from "node:fs";
 import { dirname } from "node:path";
 
-export interface ServerConfig {
+/** Stdio launcher — `bunx @useatlas/mcp serve`, used by `init --local`. */
+export interface StdioServerConfig {
   command: string;
   args: string[];
   env?: Record<string, string>;
 }
+
+/**
+ * HTTP/SSE server pointer — used by `init --hosted` against
+ * `app.useatlas.dev` (or a self-hosted instance with managed auth). MCP
+ * clients (Claude Desktop, Cursor, Continue) all accept this `url` +
+ * `headers` shape for remote MCP servers; the bearer is the JWT minted
+ * by the OAuth 2.1 loopback flow in `init/hosted.ts`.
+ */
+export interface HttpServerConfig {
+  url: string;
+  headers?: Record<string, string>;
+}
+
+export type ServerConfig = StdioServerConfig | HttpServerConfig;
 
 interface BuildOpts {
   /** Inline ATLAS_DATASOURCE_URL into the env block. Omit to inherit the user's shell env. */
@@ -23,9 +38,9 @@ interface BuildOpts {
 
 const DEFAULT_PACKAGE = "@useatlas/mcp";
 
-export function buildServerConfig(opts: BuildOpts = {}): ServerConfig {
+export function buildServerConfig(opts: BuildOpts = {}): StdioServerConfig {
   const pkg = opts.packageName ?? DEFAULT_PACKAGE;
-  const cfg: ServerConfig = {
+  const cfg: StdioServerConfig = {
     command: "bunx",
     args: [pkg, "serve"],
   };
@@ -33,6 +48,20 @@ export function buildServerConfig(opts: BuildOpts = {}): ServerConfig {
     cfg.env = { ATLAS_DATASOURCE_URL: opts.datasourceUrl };
   }
   return cfg;
+}
+
+interface BuildHostedOpts {
+  /** The hosted MCP endpoint URL — e.g. `https://api.useatlas.dev/mcp/<workspace>/sse`. */
+  url: string;
+  /** OAuth 2.1 access token (JWT). Written verbatim into the Authorization header. */
+  accessToken: string;
+}
+
+export function buildHostedServerConfig(opts: BuildHostedOpts): HttpServerConfig {
+  return {
+    url: opts.url,
+    headers: { Authorization: `Bearer ${opts.accessToken}` },
+  };
 }
 
 interface ExistingShape {

--- a/plugins/mcp/src/init/hosted.ts
+++ b/plugins/mcp/src/init/hosted.ts
@@ -151,24 +151,31 @@ interface TokenResponse {
 
 // ── Errors ─────────────────────────────────────────────────────────────
 
+/**
+ * Stable error code for tests + exit-code mapping. Exported as a named
+ * union so call sites can `satisfies HostedFlowErrorCode` against the
+ * full set (e.g. an exhaustive switch over CLI exit codes).
+ */
+export type HostedFlowErrorCode =
+  | "invalid_api_url"
+  | "discovery_failed"
+  | "issuer_mismatch"
+  | "registration_failed"
+  | "loopback_bind_failed"
+  | "browser_failed"
+  | "callback_timeout"
+  | "callback_state_mismatch"
+  | "callback_missing_code"
+  | "callback_oauth_error"
+  | "callback_method_not_allowed"
+  | "token_exchange_failed"
+  | "malformed_jwt"
+  | "missing_workspace_claim";
+
 export class HostedFlowError extends Error {
   constructor(
     message: string,
-    /** Stable error code for tests + exit-code mapping. */
-    public readonly code:
-      | "invalid_api_url"
-      | "discovery_failed"
-      | "issuer_mismatch"
-      | "registration_failed"
-      | "loopback_bind_failed"
-      | "browser_failed"
-      | "callback_timeout"
-      | "callback_state_mismatch"
-      | "callback_missing_code"
-      | "callback_oauth_error"
-      | "callback_method_not_allowed"
-      | "token_exchange_failed"
-      | "missing_workspace_claim",
+    public readonly code: HostedFlowErrorCode,
     options?: ErrorOptions,
   ) {
     super(message, options);
@@ -179,6 +186,7 @@ export class HostedFlowError extends Error {
 // ── Constants ──────────────────────────────────────────────────────────
 
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 30 * 1000;
 const REQUESTED_SCOPE = "openid profile email mcp:read offline_access";
 const CLIENT_NAME = "Atlas MCP CLI";
 const WORKSPACE_CLAIM = "https://atlas.useatlas.dev/workspace_id";
@@ -220,10 +228,12 @@ export async function runHostedAuthFlow(
   const codeChallenge = await pkceChallenge(codeVerifier);
 
   const callbackResolver = createCallbackResolver(state, timeoutMs);
-  // Defuse unhandled-rejection warnings on the abort path: we cancel the
-  // resolver in `finally`, which calls `reject()`. If the outer flow
-  // already rejected via a different error, that rejection is orphaned.
-  // Attach a no-op catch so it never propagates as unhandled.
+  // intentionally ignored: the outer `finally` calls `cancel()`, which
+  // settles the resolver as a typed rejection. Whenever the outer flow
+  // already failed via a different throw path (register/exchange/etc.)
+  // that cancel-rejection becomes orphaned. The real error is surfaced
+  // by the throw above; this `.catch` only silences Node's unhandled-
+  // rejection warning for the abort path.
   callbackResolver.promise.catch(() => {});
 
   let server: LoopbackServer | undefined;
@@ -333,6 +343,39 @@ function validateApiUrl(apiUrl: string): void {
 
 // ── Step implementations ───────────────────────────────────────────────
 
+/**
+ * Surface OAuth 2.1 error responses as `error: error_description` when
+ * the body parses as the standard `{error,error_description,error_uri}`
+ * shape (RFC 6749 §5.2). Falls back to the raw text (truncated to 1KiB)
+ * when the body is empty / not JSON / not the canonical shape, so we
+ * never silently lose upstream signal.
+ */
+async function describeErrorBody(res: Response): Promise<string> {
+  const raw = await res.text().catch(() => "");
+  if (!raw) return "";
+  try {
+    const parsed = JSON.parse(raw) as Partial<{
+      error: string;
+      error_description: string;
+      error_uri: string;
+    }>;
+    const parts: string[] = [];
+    if (typeof parsed.error === "string" && parsed.error.length > 0) {
+      parts.push(parsed.error);
+    }
+    if (typeof parsed.error_description === "string" && parsed.error_description.length > 0) {
+      parts.push(parsed.error_description);
+    }
+    if (typeof parsed.error_uri === "string" && parsed.error_uri.length > 0) {
+      parts.push(`see ${parsed.error_uri}`);
+    }
+    if (parts.length > 0) return parts.join(": ");
+  } catch {
+    // intentionally ignored: not JSON — fall through to raw-text branch.
+  }
+  return raw.length > 1024 ? `${raw.slice(0, 1024)}…` : raw;
+}
+
 async function discover(
   apiUrl: string,
   fetchImpl: typeof fetch,
@@ -343,6 +386,7 @@ async function discover(
     res = await fetchImpl(url, {
       method: "GET",
       headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -405,6 +449,7 @@ async function register(
       method: "POST",
       headers: { "Content-Type": "application/json", Accept: "application/json" },
       body: JSON.stringify(body),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -415,9 +460,9 @@ async function register(
     );
   }
   if (!res.ok) {
-    const detail = await res.text().catch(() => "");
+    const detail = await describeErrorBody(res);
     throw new HostedFlowError(
-      `Dynamic Client Registration returned ${res.status}${detail ? `: ${detail.slice(0, 200)}` : ""}`,
+      `Dynamic Client Registration returned ${res.status}${detail ? `: ${detail}` : ""}`,
       "registration_failed",
     );
   }
@@ -455,8 +500,6 @@ function buildAuthorizeUrl(args: BuildAuthorizeUrlArgs): string {
     code_challenge: args.codeChallenge,
     code_challenge_method: "S256",
   });
-  // Robust against authorization endpoints that already carry query
-  // (rare, but cheap to handle).
   const sep = args.authorizationEndpoint.includes("?") ? "&" : "?";
   return `${args.authorizationEndpoint}${sep}${params.toString()}`;
 }
@@ -487,6 +530,7 @@ async function exchangeCode(args: ExchangeArgs): Promise<TokenResponse> {
         Accept: "application/json",
       },
       body: body.toString(),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -497,9 +541,9 @@ async function exchangeCode(args: ExchangeArgs): Promise<TokenResponse> {
     );
   }
   if (!res.ok) {
-    const detail = await res.text().catch(() => "");
+    const detail = await describeErrorBody(res);
     throw new HostedFlowError(
-      `Token endpoint returned ${res.status}${detail ? `: ${detail.slice(0, 200)}` : ""}`,
+      `Token endpoint returned ${res.status}${detail ? `: ${detail}` : ""}`,
       "token_exchange_failed",
     );
   }
@@ -542,7 +586,7 @@ function decodeJwtPayload(jwt: string): Record<string, unknown> {
   if (parts.length !== 3) {
     throw new HostedFlowError(
       `Access token is not a JWT (expected 3 parts, got ${parts.length})`,
-      "missing_workspace_claim",
+      "malformed_jwt",
     );
   }
   try {
@@ -551,7 +595,7 @@ function decodeJwtPayload(jwt: string): Record<string, unknown> {
   } catch (err) {
     throw new HostedFlowError(
       `Could not decode JWT payload: ${err instanceof Error ? err.message : String(err)}`,
-      "missing_workspace_claim",
+      "malformed_jwt",
       { cause: err },
     );
   }
@@ -640,11 +684,10 @@ function createCallbackResolver(
 
   const handler: LoopbackHandler = (params, method) => {
     if (method !== "GET") {
-      // RFC 8252 §7.3 + OAuth 2.1 §3.1.2.5 — the redirect URI is fetched
-      // by the user-agent on completion of the authorization step;
-      // anything other than GET is an attempt to inject parameters
-      // out-of-band. Reject without settling so a probe can't preempt
-      // the legitimate callback.
+      // User-agents only ever fetch the redirect URI as GET on completion
+      // of the authorization step; anything else is an attempt to inject
+      // parameters out-of-band. Reject without settling so a probe can't
+      // preempt the legitimate callback.
       return {
         status: 405,
         body: renderCallbackPage({
@@ -731,13 +774,16 @@ function createCallbackResolver(
 }
 
 /**
- * Default loopback listener — Bun.serve on 127.0.0.1:0. The handler runs
- * once: subsequent requests get a 410 (the auth flow already settled).
+ * Default loopback listener — Bun.serve on 127.0.0.1:0. The handler is
+ * single-shot; subsequent requests get a 404 (see the inline comment
+ * below for why 404 instead of 410). Exported so the test suite can
+ * exercise the once-fired guard without re-binding through the public
+ * `runHostedAuthFlow` entry point.
  */
-const defaultServeImpl: ServeImpl = async (handler) => {
-  // Once-fired guard. RFC 8252 §8.10 recommends rejecting all but the
-  // first request to the redirect URI — replays could only ever be
-  // probes since the legitimate auth code is single-use server-side.
+export const defaultServeImpl: ServeImpl = async (handler) => {
+  // Once-fired guard. The legitimate auth code is single-use server-side,
+  // so any second hit on the redirect URI is either a stray browser
+  // refresh or a fingerprinting probe — refuse either way.
   let used = false;
   const server = Bun.serve({
     hostname: "127.0.0.1",
@@ -773,12 +819,7 @@ const defaultServeImpl: ServeImpl = async (handler) => {
   return {
     port: server.port,
     stop: async () => {
-      // Bun ≥1.1 returns a Promise from stop(); older versions returned
-      // void. Detect at runtime so this works on either.
-      const out = (server as unknown as { stop: (closeActive?: boolean) => unknown }).stop(true);
-      if (out && typeof (out as Promise<unknown>).then === "function") {
-        await (out as Promise<unknown>);
-      }
+      await server.stop(true);
     },
   };
 };
@@ -815,6 +856,9 @@ const defaultOpenBrowserImpl: OpenBrowserImpl = async (url) => {
   // we just need to invoke it. If the helper isn't found, return
   // ok:false so the caller falls back to "open this URL manually".
   const platform = process.platform;
+  const helper = platform === "darwin" ? "open"
+    : platform === "win32" ? "cmd /c start"
+    : "xdg-open";
   const cmd = platform === "darwin" ? ["open", url]
     : platform === "win32" ? ["cmd", "/c", "start", "", url]
     : ["xdg-open", url];
@@ -827,6 +871,16 @@ const defaultOpenBrowserImpl: OpenBrowserImpl = async (url) => {
     }
     return { ok: true };
   } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "ENOENT") {
+      return {
+        ok: false,
+        detail:
+          platform === "linux"
+            ? `${helper} not found on PATH — install xdg-utils (e.g. apt install xdg-utils) or open the URL above manually`
+            : `${helper} not found on PATH — open the URL above manually`,
+      };
+    }
     const msg = err instanceof Error ? err.message : String(err);
     return { ok: false, detail: msg };
   }
@@ -841,7 +895,6 @@ function defaultRandomBytes(length: number): Uint8Array {
 }
 
 function encodeBase64Url(bytes: Uint8Array): string {
-  // bun ships btoa; convert via binary-string round-trip.
   let bin = "";
   for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
   return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");

--- a/plugins/mcp/src/init/hosted.ts
+++ b/plugins/mcp/src/init/hosted.ts
@@ -1,0 +1,854 @@
+/**
+ * `init --hosted` flow: OAuth 2.1 authorization-code-with-PKCE against the
+ * hosted Atlas MCP endpoint (#2024 PR E).
+ *
+ * ── Why loopback (RFC 8252) over device code (RFC 8628) ────────────────
+ *
+ * The MCP authorization spec requires an OAuth 2.1 server (PR C wired
+ * `@better-auth/oauth-provider` for that). Standards-compliant native MCP
+ * clients (Claude Desktop, Cursor, ChatGPT) already use the loopback flow
+ * — same shape as `gh auth login` and `gcloud auth login`. RFC 8252 §7.3
+ * recommends loopback for any native client that can spawn a browser:
+ * better UX than reading codes off a screen, no polling, no
+ * pre-registered client_id needed when DCR is available.
+ *
+ * The loopback redirect MUST use `127.0.0.1` (not `localhost`) per RFC
+ * 8252 §7.3 — DNS resolution to `localhost` is implementation-defined and
+ * a hostile resolver could redirect the auth code somewhere else.
+ *
+ * ── Why DCR is unauthenticated ─────────────────────────────────────────
+ *
+ * The auth server is configured with `allowUnauthenticatedClientRegistration: true`
+ * in `packages/api/src/lib/auth/server.ts`. Without it an MCP client
+ * couldn't bootstrap — there's no admin pre-issuing a client_id for every
+ * end-user's machine. The MCP spec is on track to standardize Client ID
+ * Metadata Documents which would let us turn this off; track upstream.
+ *
+ * ── What we DON'T persist ──────────────────────────────────────────────
+ *
+ * The PKCE `code_verifier` and the registered `client_id` are kept in
+ * memory for the duration of the flow only — never written to disk. The
+ * only artifact written is the JWT access token (and optional refresh
+ * token), inside the user's MCP client config file at mode 0o600.
+ *
+ * ── Test seams ─────────────────────────────────────────────────────────
+ *
+ * Every external dependency is overrideable so the unit tests in
+ * `__tests__/init/hosted.test.ts` never open a browser, never bind a real
+ * port, and never hit a real OAuth server.
+ *
+ *   - `fetchImpl`            — discovery, DCR, token exchange
+ *   - `openBrowserImpl`      — browser launch (returns success/failure)
+ *   - `serveImpl`            — loopback listener factory
+ *   - `randomBytesImpl`      — PKCE verifier + state (deterministic asserts)
+ *   - `nowImpl`              — for the 5-minute timeout
+ *   - `consoleImpl`          — captures user-facing output
+ */
+
+// ── External shape contracts (test seams) ──────────────────────────────
+
+export interface LoopbackServer {
+  /** Bound port — the OS picked it when we requested 0. */
+  readonly port: number;
+  /** Stop accepting and drain. Called on success, timeout, or error. */
+  stop(): Promise<void>;
+}
+
+/**
+ * Loopback handler return value. Status is narrowed to the two values
+ * the OAuth callback ever produces — 200 on success, 400 on protocol
+ * failures (state mismatch, missing code, oauth error). The body is HTML
+ * so any `ServeImpl` substituting for the default `Bun.serve` backend
+ * MUST set `Content-Type: text/html; charset=utf-8` on the response.
+ */
+export interface LoopbackHandler {
+  (params: URLSearchParams, method: string): { status: 200 | 400 | 405; body: string };
+}
+
+export interface ServeImpl {
+  (handler: LoopbackHandler): Promise<LoopbackServer>;
+}
+
+export interface OpenBrowserResult {
+  ok: boolean;
+  /** Human-readable detail shown when ok=false. */
+  detail?: string;
+}
+
+export interface OpenBrowserImpl {
+  (url: string): Promise<OpenBrowserResult>;
+}
+
+export interface ConsoleImpl {
+  log(message: string): void;
+  error(message: string): void;
+}
+
+// ── Public types ───────────────────────────────────────────────────────
+
+export interface HostedFlowOptions {
+  /**
+   * Atlas API base — e.g. `https://api.useatlas.dev`. The discovery doc
+   * lives at `${apiUrl}/.well-known/oauth-authorization-server/api/auth`.
+   * Must be `https://`, except for `http://127.0.0.1` / `http://localhost`
+   * which are accepted for local-dev testing.
+   */
+  apiUrl: string;
+  /** Default 5 min; smaller values shorten test runtime. */
+  callbackTimeoutMs?: number;
+  /** Test seams — defaults wired to real implementations. */
+  fetchImpl?: typeof fetch;
+  serveImpl?: ServeImpl;
+  openBrowserImpl?: OpenBrowserImpl;
+  randomBytesImpl?: (length: number) => Uint8Array;
+  consoleImpl?: ConsoleImpl;
+}
+
+/**
+ * Branded `string` for OAuth bearer credentials. The brand carries no
+ * runtime cost; its purpose is to surface bearer-handling code in code
+ * review (`accessToken: Bearer` next to a `console.log` is a smell) and
+ * to keep the secret-vs-non-secret distinction visible in the type, not
+ * just in trailing comments.
+ */
+export type Bearer = string & { readonly __brand: "Bearer" };
+
+export interface HostedFlowResult {
+  /** OAuth 2.1 access token (signed JWT). Treat as a credential. */
+  accessToken: Bearer;
+  /** OAuth 2.1 refresh token (when offline_access was granted). */
+  refreshToken: Bearer | null;
+  /** The `https://atlas.useatlas.dev/workspace_id` claim from the JWT. */
+  workspaceId: string;
+  /** `${apiUrl}/mcp/${workspaceId}/sse` — what the MCP client connects to. */
+  mcpUrl: string;
+}
+
+// ── OAuth 2.1 metadata + DCR shapes ────────────────────────────────────
+//
+// Restricted to fields we actually consume. Better Auth's discovery doc
+// includes more (e.g. `userinfo_endpoint`, `revocation_endpoint`) but
+// nothing else is load-bearing for the loopback flow.
+
+interface AuthServerMetadata {
+  authorization_endpoint: string;
+  token_endpoint: string;
+  registration_endpoint: string;
+  issuer: string;
+}
+
+interface RegistrationResponse {
+  client_id: string;
+}
+
+interface TokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  token_type?: string;
+  expires_in?: number;
+  scope?: string;
+}
+
+// ── Errors ─────────────────────────────────────────────────────────────
+
+export class HostedFlowError extends Error {
+  constructor(
+    message: string,
+    /** Stable error code for tests + exit-code mapping. */
+    public readonly code:
+      | "invalid_api_url"
+      | "discovery_failed"
+      | "issuer_mismatch"
+      | "registration_failed"
+      | "loopback_bind_failed"
+      | "browser_failed"
+      | "callback_timeout"
+      | "callback_state_mismatch"
+      | "callback_missing_code"
+      | "callback_oauth_error"
+      | "callback_method_not_allowed"
+      | "token_exchange_failed"
+      | "missing_workspace_claim",
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "HostedFlowError";
+  }
+}
+
+// ── Constants ──────────────────────────────────────────────────────────
+
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+const REQUESTED_SCOPE = "openid profile email mcp:read offline_access";
+const CLIENT_NAME = "Atlas MCP CLI";
+const WORKSPACE_CLAIM = "https://atlas.useatlas.dev/workspace_id";
+
+// ── Public entry point ─────────────────────────────────────────────────
+
+/**
+ * Run the OAuth 2.1 loopback flow against `apiUrl` and return the minted
+ * JWT. Pure data — the caller decides whether to print or write.
+ *
+ * Cleanup: the loopback listener is stopped in a `finally` so a failed
+ * exchange never leaves an orphan port bound. Browser-launch failures
+ * fall back to printing the URL and continue waiting for the callback.
+ */
+export async function runHostedAuthFlow(
+  options: HostedFlowOptions,
+): Promise<HostedFlowResult> {
+  const apiUrl = options.apiUrl.replace(/\/+$/, "");
+  validateApiUrl(apiUrl);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const serveImpl = options.serveImpl ?? defaultServeImpl;
+  const openBrowserImpl = options.openBrowserImpl ?? defaultOpenBrowserImpl;
+  const randomBytes = options.randomBytesImpl ?? defaultRandomBytes;
+  const cli: ConsoleImpl = options.consoleImpl ?? {
+    log: (m) => console.log(m),
+    error: (m) => console.error(m),
+  };
+  const timeoutMs = options.callbackTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  // Step 1 — discovery
+  const metadata = await discover(apiUrl, fetchImpl);
+
+  // Step 2 — generate PKCE + state and start the loopback listener BEFORE
+  // registering, so we know the redirect_uri the OS picked. RFC 8252
+  // §7.3 says clients SHOULD bind to 127.0.0.1 with port 0 and use
+  // whatever port they get back.
+  const state = encodeBase64Url(randomBytes(32));
+  const codeVerifier = encodeBase64Url(randomBytes(32));
+  const codeChallenge = await pkceChallenge(codeVerifier);
+
+  const callbackResolver = createCallbackResolver(state, timeoutMs);
+  // Defuse unhandled-rejection warnings on the abort path: we cancel the
+  // resolver in `finally`, which calls `reject()`. If the outer flow
+  // already rejected via a different error, that rejection is orphaned.
+  // Attach a no-op catch so it never propagates as unhandled.
+  callbackResolver.promise.catch(() => {});
+
+  let server: LoopbackServer | undefined;
+  try {
+    server = await serveImpl(callbackResolver.handler);
+    const redirectUri = `http://127.0.0.1:${server.port}/callback`;
+
+    // Step 3 — register a public client via DCR
+    const clientId = await register(metadata, redirectUri, fetchImpl);
+
+    // Step 4 — open the browser. Failure is non-fatal: print the URL
+    // (already printed before the launch attempt) and continue waiting.
+    // In headless / CI shells the user will hit `callback_timeout`
+    // instead — the message there links back to the printed URL above.
+    const authorizeUrl = buildAuthorizeUrl({
+      authorizationEndpoint: metadata.authorization_endpoint,
+      clientId,
+      redirectUri,
+      state,
+      codeChallenge,
+    });
+    cli.log(`Opening your browser to authorize Atlas MCP CLI…`);
+    cli.log(`If it doesn't open automatically, visit:`);
+    cli.log(`  ${authorizeUrl}`);
+    const openResult = await openBrowserImpl(authorizeUrl);
+    if (!openResult.ok) {
+      cli.error(
+        `[atlas-mcp init] Could not auto-launch the browser${openResult.detail ? ` (${openResult.detail})` : ""}. Open the URL above manually.`,
+      );
+    }
+
+    // Step 5 — wait for the callback
+    const code = await callbackResolver.promise;
+
+    // Step 6 — exchange the code
+    const tokenResponse = await exchangeCode({
+      tokenEndpoint: metadata.token_endpoint,
+      clientId,
+      redirectUri,
+      code,
+      codeVerifier,
+      fetchImpl,
+    });
+
+    // Step 7 — extract + verify claims. We don't verify the JWT
+    // signature (the hosted MCP endpoint re-verifies on every request via
+    // JWKS) but we DO check `iss` matches the issuer we discovered, so a
+    // hostile auth server pretending to be Atlas can't slip a token past
+    // us at write-time.
+    const claims = decodeJwtPayload(tokenResponse.access_token);
+    enforceIssuer(claims, metadata.issuer);
+    const workspaceId = extractWorkspaceClaim(claims);
+
+    return {
+      accessToken: tokenResponse.access_token as Bearer,
+      refreshToken: tokenResponse.refresh_token
+        ? (tokenResponse.refresh_token as Bearer)
+        : null,
+      workspaceId,
+      mcpUrl: `${apiUrl}/mcp/${workspaceId}/sse`,
+    };
+  } finally {
+    // Cancel the timer FIRST so a 5-min hang can't survive an early
+    // failure in `register`/`exchangeCode`/`extractWorkspaceClaim`. Then
+    // tear down the listener.
+    callbackResolver.cancel();
+    if (server) {
+      await server.stop().catch((err) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        cli.error(`[atlas-mcp init] loopback listener cleanup warning: ${msg}`);
+      });
+    }
+  }
+}
+
+/**
+ * `apiUrl` ends up driving discovery, the redirect target, and the
+ * eventual MCP URL written to disk. A typo'd or hostile env var
+ * (`ATLAS_PUBLIC_API_URL=http://evil.example.com`) would drive the user
+ * through a fake authorize page and ship a foreign-issued JWT into their
+ * MCP client config. Reject anything that isn't `https://`, except for
+ * documented localhost dev URLs.
+ */
+function validateApiUrl(apiUrl: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(apiUrl);
+  } catch (err) {
+    throw new HostedFlowError(
+      `--api-url is not a valid URL: ${apiUrl}`,
+      "invalid_api_url",
+      { cause: err },
+    );
+  }
+  if (parsed.protocol === "https:") return;
+  if (
+    parsed.protocol === "http:" &&
+    (parsed.hostname === "127.0.0.1" || parsed.hostname === "localhost")
+  ) {
+    return;
+  }
+  throw new HostedFlowError(
+    `--api-url must use https:// (or http://localhost for dev). Got: ${apiUrl}`,
+    "invalid_api_url",
+  );
+}
+
+// ── Step implementations ───────────────────────────────────────────────
+
+async function discover(
+  apiUrl: string,
+  fetchImpl: typeof fetch,
+): Promise<AuthServerMetadata> {
+  const url = `${apiUrl}/.well-known/oauth-authorization-server/api/auth`;
+  let res: Response;
+  try {
+    res = await fetchImpl(url, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new HostedFlowError(
+      `Could not reach Atlas auth discovery at ${url}: ${msg}`,
+      "discovery_failed",
+      { cause: err },
+    );
+  }
+  if (!res.ok) {
+    throw new HostedFlowError(
+      `Atlas auth discovery returned ${res.status} for ${url}`,
+      "discovery_failed",
+    );
+  }
+  const body = (await res.json().catch((err) => {
+    throw new HostedFlowError(
+      `Atlas auth discovery body was not JSON: ${err instanceof Error ? err.message : String(err)}`,
+      "discovery_failed",
+      { cause: err },
+    );
+  })) as Partial<AuthServerMetadata>;
+  if (
+    typeof body.authorization_endpoint !== "string" ||
+    typeof body.token_endpoint !== "string" ||
+    typeof body.registration_endpoint !== "string" ||
+    typeof body.issuer !== "string"
+  ) {
+    throw new HostedFlowError(
+      `Atlas auth discovery is missing one of: authorization_endpoint, token_endpoint, registration_endpoint, issuer`,
+      "discovery_failed",
+    );
+  }
+  return {
+    authorization_endpoint: body.authorization_endpoint,
+    token_endpoint: body.token_endpoint,
+    registration_endpoint: body.registration_endpoint,
+    issuer: body.issuer,
+  };
+}
+
+async function register(
+  metadata: AuthServerMetadata,
+  redirectUri: string,
+  fetchImpl: typeof fetch,
+): Promise<string> {
+  // Public client — no `client_secret`. `token_endpoint_auth_method: "none"`
+  // matches the public-client posture; the server enforces PKCE.
+  const body = {
+    client_name: CLIENT_NAME,
+    redirect_uris: [redirectUri],
+    grant_types: ["authorization_code", "refresh_token"],
+    response_types: ["code"],
+    scope: REQUESTED_SCOPE,
+    token_endpoint_auth_method: "none",
+  };
+  let res: Response;
+  try {
+    res = await fetchImpl(metadata.registration_endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new HostedFlowError(
+      `Dynamic Client Registration failed: ${msg}`,
+      "registration_failed",
+      { cause: err },
+    );
+  }
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new HostedFlowError(
+      `Dynamic Client Registration returned ${res.status}${detail ? `: ${detail.slice(0, 200)}` : ""}`,
+      "registration_failed",
+    );
+  }
+  const data = (await res.json().catch((err) => {
+    throw new HostedFlowError(
+      `Dynamic Client Registration response was not JSON: ${err instanceof Error ? err.message : String(err)}`,
+      "registration_failed",
+      { cause: err },
+    );
+  })) as Partial<RegistrationResponse>;
+  if (typeof data.client_id !== "string" || data.client_id.length === 0) {
+    throw new HostedFlowError(
+      `Dynamic Client Registration response missing client_id`,
+      "registration_failed",
+    );
+  }
+  return data.client_id;
+}
+
+interface BuildAuthorizeUrlArgs {
+  authorizationEndpoint: string;
+  clientId: string;
+  redirectUri: string;
+  state: string;
+  codeChallenge: string;
+}
+
+function buildAuthorizeUrl(args: BuildAuthorizeUrlArgs): string {
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: args.clientId,
+    redirect_uri: args.redirectUri,
+    scope: REQUESTED_SCOPE,
+    state: args.state,
+    code_challenge: args.codeChallenge,
+    code_challenge_method: "S256",
+  });
+  // Robust against authorization endpoints that already carry query
+  // (rare, but cheap to handle).
+  const sep = args.authorizationEndpoint.includes("?") ? "&" : "?";
+  return `${args.authorizationEndpoint}${sep}${params.toString()}`;
+}
+
+interface ExchangeArgs {
+  tokenEndpoint: string;
+  clientId: string;
+  redirectUri: string;
+  code: string;
+  codeVerifier: string;
+  fetchImpl: typeof fetch;
+}
+
+async function exchangeCode(args: ExchangeArgs): Promise<TokenResponse> {
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    code: args.code,
+    redirect_uri: args.redirectUri,
+    client_id: args.clientId,
+    code_verifier: args.codeVerifier,
+  });
+  let res: Response;
+  try {
+    res = await args.fetchImpl(args.tokenEndpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+      body: body.toString(),
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new HostedFlowError(
+      `Token exchange failed: ${msg}`,
+      "token_exchange_failed",
+      { cause: err },
+    );
+  }
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new HostedFlowError(
+      `Token endpoint returned ${res.status}${detail ? `: ${detail.slice(0, 200)}` : ""}`,
+      "token_exchange_failed",
+    );
+  }
+  const data = (await res.json().catch((err) => {
+    throw new HostedFlowError(
+      `Token endpoint response was not JSON: ${err instanceof Error ? err.message : String(err)}`,
+      "token_exchange_failed",
+      { cause: err },
+    );
+  })) as Partial<TokenResponse>;
+  if (typeof data.access_token !== "string" || data.access_token.length === 0) {
+    throw new HostedFlowError(
+      `Token endpoint response missing access_token`,
+      "token_exchange_failed",
+    );
+  }
+  return {
+    access_token: data.access_token,
+    refresh_token: typeof data.refresh_token === "string" ? data.refresh_token : undefined,
+    token_type: typeof data.token_type === "string" ? data.token_type : undefined,
+    expires_in: typeof data.expires_in === "number" ? data.expires_in : undefined,
+    scope: typeof data.scope === "string" ? data.scope : undefined,
+  };
+}
+
+/**
+ * Decode a JWT payload WITHOUT verifying the signature. Safe here only
+ * because we just minted the token through a TLS-protected OAuth flow
+ * against an issuer we discovered ourselves (`validateApiUrl` +
+ * `enforceIssuer`). The hosted MCP endpoint re-verifies the signature
+ * on every request via JWKS, so any tampering between here and there is
+ * rejected server-side.
+ *
+ * Do NOT lift this helper out as a generic JWT decoder — without the
+ * surrounding flow's TLS + issuer guarantees, "decode without verify" is
+ * unsafe.
+ */
+function decodeJwtPayload(jwt: string): Record<string, unknown> {
+  const parts = jwt.split(".");
+  if (parts.length !== 3) {
+    throw new HostedFlowError(
+      `Access token is not a JWT (expected 3 parts, got ${parts.length})`,
+      "missing_workspace_claim",
+    );
+  }
+  try {
+    const json = atob(parts[1].replace(/-/g, "+").replace(/_/g, "/"));
+    return JSON.parse(json) as Record<string, unknown>;
+  } catch (err) {
+    throw new HostedFlowError(
+      `Could not decode JWT payload: ${err instanceof Error ? err.message : String(err)}`,
+      "missing_workspace_claim",
+      { cause: err },
+    );
+  }
+}
+
+/**
+ * Defense-in-depth: if the discovered issuer doesn't match the JWT's
+ * `iss` claim, the auth server returned a token "for" a different
+ * issuer. That's either a server bug or a discovery-redirection attack;
+ * either way, refuse to write it to disk.
+ */
+function enforceIssuer(payload: Record<string, unknown>, expectedIssuer: string): void {
+  const iss = payload.iss;
+  if (typeof iss !== "string" || iss.length === 0) {
+    throw new HostedFlowError(
+      `Access token has no \`iss\` claim — refusing to trust an unsigned-issuer token.`,
+      "issuer_mismatch",
+    );
+  }
+  if (iss !== expectedIssuer) {
+    throw new HostedFlowError(
+      `Access token issuer mismatch: discovered \`${expectedIssuer}\`, token claims \`${iss}\`.`,
+      "issuer_mismatch",
+    );
+  }
+}
+
+function extractWorkspaceClaim(payload: Record<string, unknown>): string {
+  const claim = payload[WORKSPACE_CLAIM];
+  if (typeof claim !== "string" || claim.length === 0) {
+    throw new HostedFlowError(
+      `Access token is missing the ${WORKSPACE_CLAIM} claim — was the token issued for an MCP scope?`,
+      "missing_workspace_claim",
+    );
+  }
+  return claim;
+}
+
+// ── Loopback listener — handler factory + default Bun.serve impl ───────
+
+interface CallbackResolver {
+  /** Single-shot handler that resolves/rejects the promise. */
+  handler: LoopbackHandler;
+  /** Resolves with the authorization code on success. */
+  promise: Promise<string>;
+  /**
+   * Tear down the timer and settle the promise as a no-op rejection.
+   * Called from the outer `finally` block on every flow exit so a
+   * 5-minute timeout can never survive an early-step failure (would
+   * otherwise keep the event loop alive long after the CLI returned).
+   */
+  cancel(): void;
+}
+
+function createCallbackResolver(
+  expectedState: string,
+  timeoutMs: number,
+): CallbackResolver {
+  let resolve!: (code: string) => void;
+  let reject!: (err: HostedFlowError) => void;
+  let settled = false;
+
+  const promise = new Promise<string>((res, rej) => {
+    resolve = (code: string) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      res(code);
+    };
+    reject = (err: HostedFlowError) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      rej(err);
+    };
+  });
+
+  const timer = setTimeout(() => {
+    reject(
+      new HostedFlowError(
+        `Did not receive an authorization callback within ${Math.round(timeoutMs / 1000)}s. If the browser didn't open, try \`bunx @useatlas/mcp init --hosted\` again from a desktop session.`,
+        "callback_timeout",
+      ),
+    );
+  }, timeoutMs);
+
+  const handler: LoopbackHandler = (params, method) => {
+    if (method !== "GET") {
+      // RFC 8252 §7.3 + OAuth 2.1 §3.1.2.5 — the redirect URI is fetched
+      // by the user-agent on completion of the authorization step;
+      // anything other than GET is an attempt to inject parameters
+      // out-of-band. Reject without settling so a probe can't preempt
+      // the legitimate callback.
+      return {
+        status: 405,
+        body: renderCallbackPage({
+          ok: false,
+          message: "Method not allowed. The OAuth callback must be a GET.",
+        }),
+      };
+    }
+    const error = params.get("error");
+    if (error) {
+      const description = params.get("error_description") ?? "";
+      reject(
+        new HostedFlowError(
+          `Authorization server returned error \`${error}\`${description ? `: ${description}` : ""}`,
+          "callback_oauth_error",
+        ),
+      );
+      return {
+        status: 400,
+        body: renderCallbackPage({
+          ok: false,
+          message: `Authorization failed: ${error}${description ? ` — ${description}` : ""}`,
+        }),
+      };
+    }
+    const state = params.get("state");
+    if (state !== expectedState) {
+      reject(
+        new HostedFlowError(
+          `OAuth state mismatch — possible CSRF. Got \`${state ?? "<missing>"}\`, expected the value generated for this run.`,
+          "callback_state_mismatch",
+        ),
+      );
+      return {
+        status: 400,
+        body: renderCallbackPage({
+          ok: false,
+          message: "State mismatch — refusing to complete the flow.",
+        }),
+      };
+    }
+    const code = params.get("code");
+    if (!code) {
+      reject(
+        new HostedFlowError(
+          `Authorization callback was missing the \`code\` parameter.`,
+          "callback_missing_code",
+        ),
+      );
+      return {
+        status: 400,
+        body: renderCallbackPage({
+          ok: false,
+          message: "Missing authorization code in the callback URL.",
+        }),
+      };
+    }
+    resolve(code);
+    return {
+      status: 200,
+      body: renderCallbackPage({
+        ok: true,
+        message: "Atlas MCP CLI is now authorized. You can close this tab.",
+      }),
+    };
+  };
+
+  const cancel = () => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(timer);
+    // Settle as a rejection so any awaiter that's still listening sees
+    // a typed error. The outer flow attaches a no-op .catch() on the
+    // promise to defuse unhandled-rejection on the abort path.
+    reject(
+      new HostedFlowError(
+        "OAuth flow aborted before the authorization callback arrived.",
+        "callback_timeout",
+      ),
+    );
+  };
+
+  return { handler, promise, cancel };
+}
+
+/**
+ * Default loopback listener — Bun.serve on 127.0.0.1:0. The handler runs
+ * once: subsequent requests get a 410 (the auth flow already settled).
+ */
+const defaultServeImpl: ServeImpl = async (handler) => {
+  // Once-fired guard. RFC 8252 §8.10 recommends rejecting all but the
+  // first request to the redirect URI — replays could only ever be
+  // probes since the legitimate auth code is single-use server-side.
+  let used = false;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname !== "/callback") {
+        return new Response("Not Found", { status: 404 });
+      }
+      if (used) {
+        // 404 (not 410) so a fingerprinting probe can't tell whether
+        // the listener was live-but-consumed vs never bound.
+        return new Response("Not Found", { status: 404 });
+      }
+      used = true;
+      const result = handler(url.searchParams, req.method);
+      return new Response(result.body, {
+        status: result.status,
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+      });
+    },
+  });
+  // Bun.serve types port as `number | undefined` (Unix-socket configs
+  // don't carry a TCP port). We bound `port: 0` above so a TCP port is
+  // always assigned — narrow defensively rather than ! through it.
+  if (typeof server.port !== "number") {
+    await server.stop(true);
+    throw new HostedFlowError(
+      "Loopback listener bound but did not report a TCP port",
+      "loopback_bind_failed",
+    );
+  }
+  return {
+    port: server.port,
+    stop: async () => {
+      // Bun ≥1.1 returns a Promise from stop(); older versions returned
+      // void. Detect at runtime so this works on either.
+      const out = (server as unknown as { stop: (closeActive?: boolean) => unknown }).stop(true);
+      if (out && typeof (out as Promise<unknown>).then === "function") {
+        await (out as Promise<unknown>);
+      }
+    },
+  };
+};
+
+interface CallbackPageOpts {
+  ok: boolean;
+  message: string;
+}
+
+function renderCallbackPage(opts: CallbackPageOpts): string {
+  const title = opts.ok ? "Atlas MCP — authorized" : "Atlas MCP — error";
+  const accent = opts.ok ? "#10b981" : "#ef4444";
+  return `<!doctype html>
+<html><head>
+<meta charset="utf-8" />
+<title>${title}</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; background: #0a0a0a; color: #fafafa; margin: 0; min-height: 100vh; display: grid; place-items: center; }
+  .card { max-width: 420px; padding: 32px; border-radius: 12px; background: #111; border: 1px solid #222; text-align: center; }
+  .dot { width: 12px; height: 12px; border-radius: 50%; background: ${accent}; display: inline-block; margin-right: 8px; }
+  h1 { font-size: 18px; margin: 0 0 8px; }
+  p { color: #a1a1aa; margin: 0; line-height: 1.5; }
+</style>
+</head><body>
+<div class="card"><h1><span class="dot"></span>${title}</h1><p>${opts.message}</p></div>
+</body></html>`;
+}
+
+// ── Default browser launcher ───────────────────────────────────────────
+
+const defaultOpenBrowserImpl: OpenBrowserImpl = async (url) => {
+  // Bun.spawn is the cross-platform shell here. Each platform's own
+  // helper handles browser-detection, focus, and security prompts —
+  // we just need to invoke it. If the helper isn't found, return
+  // ok:false so the caller falls back to "open this URL manually".
+  const platform = process.platform;
+  const cmd = platform === "darwin" ? ["open", url]
+    : platform === "win32" ? ["cmd", "/c", "start", "", url]
+    : ["xdg-open", url];
+  try {
+    const proc = Bun.spawn(cmd, { stdout: "ignore", stderr: "pipe" });
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text().catch(() => "");
+      return { ok: false, detail: stderr.trim() || `exit ${exitCode}` };
+    }
+    return { ok: true };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ok: false, detail: msg };
+  }
+};
+
+// ── Crypto helpers ─────────────────────────────────────────────────────
+
+function defaultRandomBytes(length: number): Uint8Array {
+  const buf = new Uint8Array(length);
+  crypto.getRandomValues(buf);
+  return buf;
+}
+
+function encodeBase64Url(bytes: Uint8Array): string {
+  // bun ships btoa; convert via binary-string round-trip.
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+async function pkceChallenge(verifier: string): Promise<string> {
+  const data = new TextEncoder().encode(verifier);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return encodeBase64Url(new Uint8Array(digest));
+}

--- a/plugins/mcp/src/init/index.ts
+++ b/plugins/mcp/src/init/index.ts
@@ -136,8 +136,7 @@ async function runHosted(opts: HostedInitOptions): Promise<RunInitResult> {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`[atlas-mcp init] failed to write ${configPath}: ${msg}`);
     if (existing !== null) {
-      console.error(`A backup of your previous config is at ${configPath}.bak (or a timestamped sibling).`);
-      console.error(`Restore with: cp '${configPath}.bak' '${configPath}'`);
+      console.error("Your existing config was not modified — the new content was staged in a sibling tmp file and the rename never happened.");
     }
     return { exitCode: 1 };
   }
@@ -191,14 +190,10 @@ async function runLocal(opts: LocalInitOptions): Promise<RunInitResult> {
   try {
     writeResult = await writeConfigWithBackup(configPath, merged);
   } catch (err) {
-    // The .bak (if any) was written *before* the failed write, so a partial
-    // failure may have moved the original out of place. Tell the user where
-    // to recover from instead of leaving them with a generic "Fatal".
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`[atlas-mcp init] failed to write ${configPath}: ${msg}`);
     if (existing !== null) {
-      console.error(`A backup of your previous config is at ${configPath}.bak (or a timestamped sibling).`);
-      console.error(`Restore with: cp '${configPath}.bak' '${configPath}'`);
+      console.error("Your existing config was not modified — the new content was staged in a sibling tmp file and the rename never happened.");
     }
     return { exitCode: 1 };
   }

--- a/plugins/mcp/src/init/index.ts
+++ b/plugins/mcp/src/init/index.ts
@@ -6,6 +6,7 @@
 
 import { detectClients, getDefaultConfigPath, type ClientInfo, type McpClientId } from "./clients.js";
 import {
+  buildHostedServerConfig,
   buildServerConfig,
   mergeMcpServerConfig,
   readConfigOrNull,
@@ -14,9 +15,16 @@ import {
 } from "./config-merge.js";
 import { detectLocalAtlas, resolveApiUrl } from "./local-atlas.js";
 import { resolveFixturePaths, shouldUseFixture } from "./fixture.js";
+import {
+  HostedFlowError,
+  runHostedAuthFlow,
+  type HostedFlowOptions,
+  type OpenBrowserImpl,
+  type ServeImpl,
+} from "./hosted.js";
 
 const SERVER_NAME = "atlas";
-const HOSTED_TRACKING_ISSUE = "https://github.com/AtlasDevHQ/atlas/issues/2024";
+const DEFAULT_HOSTED_API_URL = "https://api.useatlas.dev";
 
 export interface LocalInitOptions {
   mode: "local";
@@ -36,6 +44,21 @@ export interface LocalInitOptions {
 
 export interface HostedInitOptions {
   mode: "hosted";
+  /** Override the hosted Atlas API base. Defaults to `https://api.useatlas.dev`. */
+  apiUrl?: string;
+  client?: McpClientId;
+  write?: boolean;
+  /** Override the resolved config file path (test seam). */
+  configPathOverride?: string;
+  /** Process env (test seam). Defaults to `process.env`. */
+  env?: NodeJS.ProcessEnv;
+  /** Test seams — passthrough to the hosted flow. */
+  fetchImpl?: typeof fetch;
+  serveImpl?: ServeImpl;
+  openBrowserImpl?: OpenBrowserImpl;
+  randomBytesImpl?: (length: number) => Uint8Array;
+  callbackTimeoutMs?: number;
+  detectClientsImpl?: () => ClientInfo[];
 }
 
 export type RunInitOptions = LocalInitOptions | HostedInitOptions;
@@ -46,19 +69,84 @@ export interface RunInitResult {
 
 export async function runInit(options: RunInitOptions): Promise<RunInitResult> {
   if (options.mode === "hosted") {
-    return runHostedStub();
+    return runHosted(options);
   }
   return runLocal(options);
 }
 
-function runHostedStub(): RunInitResult {
-  console.log(
-    [
-      `Hosted mode (against app.useatlas.dev) is not yet available — tracking at ${HOSTED_TRACKING_ISSUE}.`,
-      "Run `bunx @useatlas/mcp init --local` for now to point an MCP client at a local Atlas",
-      "instance or the bundled demo fixture.",
-    ].join("\n"),
-  );
+async function runHosted(opts: HostedInitOptions): Promise<RunInitResult> {
+  const env = opts.env ?? process.env;
+  const apiUrl = opts.apiUrl ?? env.ATLAS_PUBLIC_API_URL ?? DEFAULT_HOSTED_API_URL;
+
+  let result;
+  try {
+    const flowOpts: HostedFlowOptions = {
+      apiUrl,
+      fetchImpl: opts.fetchImpl,
+      serveImpl: opts.serveImpl,
+      openBrowserImpl: opts.openBrowserImpl,
+      randomBytesImpl: opts.randomBytesImpl,
+      callbackTimeoutMs: opts.callbackTimeoutMs,
+    };
+    result = await runHostedAuthFlow(flowOpts);
+  } catch (err) {
+    if (err instanceof HostedFlowError) {
+      console.error(`[atlas-mcp init --hosted] ${err.message}`);
+      return { exitCode: 1 };
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[atlas-mcp init --hosted] Unexpected error: ${msg}`);
+    return { exitCode: 1 };
+  }
+
+  const serverCfg = buildHostedServerConfig({
+    url: result.mcpUrl,
+    accessToken: result.accessToken,
+  });
+  const clientId = opts.client ?? pickDefaultClient(opts.detectClientsImpl);
+  const configPath = opts.configPathOverride ?? getDefaultConfigPath(clientId);
+
+  console.log(`Authorized for workspace ${result.workspaceId} at ${apiUrl}.`);
+
+  if (!opts.write || configPath === null) {
+    printPasteSnippet(clientId, serverCfg, configPath);
+    if (result.refreshToken) {
+      console.log(
+        "# A refresh token was issued. Atlas's MCP clients re-authenticate transparently — keep this config file at mode 0600.",
+      );
+    }
+    return { exitCode: 0 };
+  }
+
+  const existing = readConfigOrNull(configPath);
+  let merged: string;
+  try {
+    merged = mergeMcpServerConfig(existing, SERVER_NAME, serverCfg);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[atlas-mcp init] could not merge into existing config (${configPath}): ${msg}`);
+    console.error("Aborting — your config was not modified. Re-run without --write to print a snippet instead.");
+    return { exitCode: 1 };
+  }
+
+  let writeResult;
+  try {
+    writeResult = await writeConfigWithBackup(configPath, merged);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[atlas-mcp init] failed to write ${configPath}: ${msg}`);
+    if (existing !== null) {
+      console.error(`A backup of your previous config is at ${configPath}.bak (or a timestamped sibling).`);
+      console.error(`Restore with: cp '${configPath}.bak' '${configPath}'`);
+    }
+    return { exitCode: 1 };
+  }
+
+  console.log(`Wrote ${configPath}`);
+  if (writeResult.backupPath) {
+    console.log(`Backed up the previous config to ${writeResult.backupPath}`);
+  }
+  console.log("Restart your MCP client to pick up the new server.");
   return { exitCode: 0 };
 }
 


### PR DESCRIPTION
## Summary

PR E of #2024 — replaces the `runHostedStub()` in `plugins/mcp/src/init/index.ts` with a real **OAuth 2.1 authorization-code-with-PKCE flow over a 127.0.0.1 loopback redirect (RFC 8252)** — same shape as `gh auth login` and `gcloud auth login`.

```bash
bunx @useatlas/mcp init --hosted --write
```

…now opens your browser, captures the callback on a one-shot loopback listener, exchanges the code, and merges a workspace-scoped `{ url, headers: { Authorization: "Bearer <jwt>" } }` block into your MCP client config (Claude Desktop / Cursor / Continue auto-detected, mode `0o600`, with a `.bak` backup).

Closes the **user-facing install story** for #2024. Standards-compliant MCP clients (Claude Desktop, ChatGPT, Cursor, Anthropic agents) can already DCR + auth flow on their own against PR C's server surface. PR E is the CLI fallback for everything else.

## What lands

**New (`plugins/mcp/src/init/hosted.ts` — 700+ LOC)**
- Validate `--api-url` (`https://` only, except `http://localhost` for dev)
- Discover at `/.well-known/oauth-authorization-server/api/auth`
- Bind a single-shot loopback listener on `127.0.0.1:0`
- DCR a public client (`token_endpoint_auth_method: "none"`) with the loopback redirect URI
- PKCE S256 + 32-byte state + 32-byte verifier
- Open the browser; on launch failure print the URL and continue waiting
- Capture callback (rejects non-GET, state mismatches, missing code, OAuth `?error=` responses)
- Exchange code at `/oauth2/token`, decode JWT, enforce `iss` matches discovered issuer, extract `https://atlas.useatlas.dev/workspace_id`
- Print snippet (default) or merge into config (`--write`)

**Wired in (`plugins/mcp/src/init/index.ts`, `plugins/mcp/bin/cli.ts`, `config-merge.ts`)**
- `runHosted()` replaces `runHostedStub()`, passes through `--write` / `--client` / `--api-url`
- New `HttpServerConfig` type + `buildHostedServerConfig()` for the `{ url, headers }` shape
- CLI help updated; --hosted no longer drops --write/--client/--api-url

**Tests (`plugins/mcp/__tests__/init/hosted.test.ts` — 19 tests, ~100ms)**
- Wire-format pin: PKCE S256 challenge matches `SHA-256(verifier)`, DCR sends `token_endpoint_auth_method: "none"` + both grant types, loopback uses `127.0.0.1`, `code_verifier` round-trips
- Failure modes: state mismatch, missing code, OAuth error, token 4xx, missing workspace claim, **issuer mismatch**, **invalid apiUrl**, discovery 5xx, DCR 4xx, callback timeout
- Browser-launch failure: continues waiting, surfaces detail to stderr
- `--write` merge with existing siblings, `.bak` backup verification
- Method rejection: non-GET callback returns 405 without settling the flow
- Local-dev path: `http://127.0.0.1:3001` accepted

**Docs**
- `apps/docs/content/docs/guides/mcp.mdx` — flips "in flight" callout to live
- `apps/docs/content/docs/guides/mcp-hosted.mdx` — leads with the CLI flow; manual DCR stays as reference

## Defense-in-depth

| Concern | Defense |
|---|---|
| Hostile env var `ATLAS_PUBLIC_API_URL=http://evil.com` | `validateApiUrl()` rejects non-https unless localhost |
| Discovery redirection attack | `enforceIssuer()` — JWT `iss` must match discovered issuer |
| Hostile local DNS resolving `localhost` | RFC 8252 §7.3: redirect URI is `127.0.0.1`, not `localhost` |
| CSRF on the loopback | 32-byte random `state`, strict equality |
| Out-of-band parameter injection | Reject non-GET callbacks with 405 |
| Replay probes after legitimate callback | Single-shot listener returns 404 (not 410, so it can't be fingerprinted) |
| Process hangs on early failure | `CallbackResolver.cancel()` clears the 5-min timer in `finally` |
| Bearer in code review | `Bearer` branded type on `accessToken` / `refreshToken` |

## What we DON'T persist

The PKCE `code_verifier` and the registered `client_id` are kept in memory only — never written to disk. The JWT is the single artifact persisted, in the user's MCP client config at `0o600`.

## Pre-PR checks

All six `/ci` gates pass locally:
- ✅ Lint (eslint)
- ✅ Type (tsgo)
- ✅ Tests — 119 in `@useatlas/mcp` (was 113), full `bun run test` green across all packages
- ✅ Syncpack
- ✅ Template drift
- ✅ Railway watch

PR-review specialists (code-reviewer, pr-test-analyzer, silent-failure-hunter, comment-analyzer, type-design-analyzer) all ran — every HIGH-priority finding is addressed in this PR (timer leak, error-code reuse, apiUrl scheme validation, JWT iss check, wire-format test pinning, branded Bearer type, dead `nowImpl` removed, `void HostedFlowError` cleanup, state-encoding helper extracted).

## After merge

Should also close:
- **#2028** — CLI auto-routing (this was its last AC)

Unblocks:
- **#2027** — registry submission (install copy now final)
- **#2052** — standalone `bunx serve` decision

Settings → OAuth Clients UI (originally PR D) remains separate; if it doesn't ship in 1.4.0, document as in-flight.

## Test plan

- [x] `bun run lint` (0 errors, 0 warnings)
- [x] `bun run type` (0 errors)
- [x] `bun run test` (all 27 packages pass)
- [x] `bun x syncpack lint` (no issues)
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` (passes)
- [x] `bash scripts/check-security-headers-drift.sh` (passes)
- [x] `bash scripts/check-railway-watch.sh` (passes)
- [x] Wire-format test pins PKCE S256 + 127.0.0.1 redirect + DCR public-client posture
- [x] All 8 `HostedFlowError` discriminant codes exercised by name
- [ ] Manual smoke test against an actual SaaS deployment (post-merge — needs DCR enabled in staging first)