### PR TITLE
feat(mcp): #2052 — record path-A decision (hosted-only) in serve error + docs

### DIFF
--- a/apps/docs/content/docs/plugins/interactions/mcp.mdx
+++ b/apps/docs/content/docs/plugins/interactions/mcp.mdx
@@ -19,7 +19,7 @@ For one-command setup against Claude Desktop / Cursor / Continue, prefer `bunx @
 bun add @useatlas/mcp @modelcontextprotocol/sdk
 ```
 
-When loaded inside an Atlas project (monorepo dev or a `create-atlas-agent` scaffold), the `@atlas/mcp` server runtime is resolved via dynamic import — you don't need to depend on it directly. Standalone `bunx @useatlas/mcp serve` outside an Atlas project is tracked in [#2024](https://github.com/AtlasDevHQ/atlas/issues/2024).
+When loaded inside an Atlas project (monorepo dev or a `create-atlas-agent` scaffold), the `@atlas/mcp` server runtime is resolved via dynamic import — you don't need to depend on it directly. Standalone `bunx @useatlas/mcp serve` outside an Atlas project is intentionally not supported; the zero-config path for connecting any MCP client to Atlas is `bunx @useatlas/mcp init --hosted` against Atlas SaaS (see the [hosted endpoint reference](/guides/mcp-hosted)).
 
 ## Configuration
 

--- a/plugins/mcp/__tests__/cli.test.ts
+++ b/plugins/mcp/__tests__/cli.test.ts
@@ -231,7 +231,7 @@ describe("cli — top-level dispatch", () => {
 // ---------------------------------------------------------------------------
 
 describe("cli — serve fails cleanly when @atlas/mcp can't be resolved", () => {
-  it("prints the #2024 link and exits 1", async () => {
+  it("points users at `init --hosted` and exits 1", async () => {
     // Build an isolated package tree at /tmp/atlas-mcp-isolated-XXX/pkg
     // that contains JUST cli.ts + its local imports. Crucially nothing
     // upward has `@atlas/mcp`, so resolution will throw.
@@ -271,9 +271,10 @@ describe("cli — serve fails cleanly when @atlas/mcp can't be resolved", () => 
       const r = await runCli(["serve"], pkg, join(pkg, "bin", "cli.ts"));
       expect(r.exitCode).toBe(1);
       expect(r.stderr).toContain("Could not resolve `@atlas/mcp`");
-      expect(r.stderr).toContain(
-        "https://github.com/AtlasDevHQ/atlas/issues/2024",
-      );
+      // Path-A decision (#2052): standalone serve is not supported. The
+      // error must point users at the hosted installer rather than at a
+      // tracking issue.
+      expect(r.stderr).toContain("bunx @useatlas/mcp init --hosted");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/plugins/mcp/bin/cli.ts
+++ b/plugins/mcp/bin/cli.ts
@@ -10,8 +10,9 @@
  * dependency, so it works in a transient `bunx` install. `serve` is a thin
  * pass-through that dynamic-imports `@atlas/mcp/server`; if that resolves
  * (monorepo dev or a create-atlas-agent project that bundles the API code)
- * it boots the server, otherwise it prints a clear "not yet supported"
- * message pointing at #2024 (hosted MCP).
+ * it boots the server, otherwise it prints a clear "not supported" message
+ * pointing users at `bunx @useatlas/mcp init --hosted` (decision recorded
+ * in #2052; the standalone "serve" path is intentionally not vendored).
  */
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 
@@ -127,7 +128,8 @@ const SERVE_HELP = `bunx @useatlas/mcp serve [options]
 The serve command requires \`@atlas/mcp\` to be resolvable from the current
 working directory — i.e. you're running it inside a project that includes the
 Atlas API source (the create-atlas-agent template, the monorepo, or a custom
-deployment). Standalone \`bunx\`-only invocations are tracked in #2024.
+deployment). For zero-config use, run \`bunx @useatlas/mcp init --hosted\` to
+connect to Atlas SaaS instead.
 `;
 
 export async function runInitCommand(argv: string[]): Promise<number> {
@@ -201,7 +203,7 @@ export function parseServeArgs(argv: string[]): ServeFlags {
  * the catch on `@atlas/mcp/server` to ONLY these so a config bug or
  * downstream module-evaluation error inside `@atlas/api` (e.g. missing
  * `DATABASE_URL`, an Effect Layer construction failure) doesn't get
- * misreported as "package missing — see #2024."
+ * misreported as "package missing — install via `init --hosted`."
  *
  * Detection strategy: Node sets `err.code === "ERR_MODULE_NOT_FOUND"` /
  * `"MODULE_NOT_FOUND"`. Bun raises a `ResolveMessage` class with a
@@ -258,8 +260,10 @@ export async function runServeCommand(argv: string[]): Promise<number> {
   // Dynamic imports — resolve only when the consumer's project includes
   // `@atlas/mcp` (currently the monorepo + create-atlas-agent scaffolds that
   // path-alias the Atlas API source). A transient `bunx` install does NOT
-  // include `@atlas/mcp`, so this path intentionally fails with a pointer to
-  // #2024 (hosted MCP) rather than pretending to start a broken server.
+  // include `@atlas/mcp`, so this path intentionally fails and points the
+  // user at the hosted installer rather than pretending to start a broken
+  // server. Vendoring a demo runtime (#2052 path B) was considered and
+  // rejected — the supported zero-friction path is `init --hosted`.
   let serverMod: ServerModule;
   try {
     // The cast threads the dynamic-import payload through our local
@@ -280,9 +284,13 @@ export async function runServeCommand(argv: string[]): Promise<number> {
       [
         "[atlas-mcp serve] Could not resolve `@atlas/mcp` from the current project.",
         "",
-        "The serve subcommand currently requires the Atlas API source to be available",
-        "in the same project (monorepo dev or a create-atlas-agent scaffold). Standalone",
-        "`bunx @useatlas/mcp serve` is tracked in https://github.com/AtlasDevHQ/atlas/issues/2024.",
+        "Standalone `bunx @useatlas/mcp serve` is not supported. To connect any MCP",
+        "client to Atlas SaaS in one command, run:",
+        "",
+        "    bunx @useatlas/mcp init --hosted --write",
+        "",
+        "Self-hosted: scaffold a project with `bun create atlas-agent` and run",
+        "`bun run mcp` from inside it. See https://docs.useatlas.dev/guides/mcp.",
         "",
         `Details: ${detail}`,
       ].join("\n"),


### PR DESCRIPTION
Closes #2052.

## Decision: path A (hosted-only)

`bunx @useatlas/mcp serve` outside an Atlas project remains intentionally unsupported. Vendoring a demo runtime (path B in the issue body) was considered and rejected. The supported zero-friction path is the hosted endpoint:

- **Spec-compliant MCP clients** (Claude Desktop, ChatGPT, Cursor) bootstrap via Dynamic Client Registration + PKCE against `mcp.useatlas.dev` — no CLI required.
- **Other clients** run `bunx @useatlas/mcp init --hosted --write`, which opens a browser, runs the OAuth 2.1 loopback flow (#2059), and merges a workspace-scoped server block into the client config.
- **Self-hosters** scaffold a project with `bun create atlas-agent` and run `bun run mcp`.

### Why not path B (vendored demo runtime)?

Bundling `@atlas/api` + a NovaMart SQLite seed into `@useatlas/mcp` would give an unauthenticated zero-account demo, but:

- The hosted SaaS path is the revenue surface — a vendored demo competes with it for first impressions.
- Bundle size, version drift between snapshot and live API, and an `/ee` gating decision would all need separate scoping.
- Spec-compliant MCP clients already get zero-friction onboarding via DCR; the gap path B addresses is narrow.

If we later want a true \"try Atlas in 30 seconds without an account\" surface, that's its own feature with its own scope — not a slipped-in extension of #2024 or #2027.

### #2024 acceptance check

- PR A — bearer-token store (#2054) ✅ merged
- PR B — hosted endpoint mount + residency 421 (#2056) ✅ merged
- PR C — OAuth 2.1 provider + drop mcp_tokens (#2057) ✅ merged
- PR E — `init --hosted` loopback (#2059) ✅ merged

## Summary

- `plugins/mcp/bin/cli.ts` — rewrote the serve error message: drops the now-stale \"tracked in #2024\" pointer and points users at `bunx @useatlas/mcp init --hosted --write` (hosted) or `bun create atlas-agent` (self-hosted). Help text + module-doc + dynamic-import comment updated to match.
- `plugins/mcp/__tests__/cli.test.ts` — pinned assertion to the new pointer (`bunx @useatlas/mcp init --hosted`) instead of the tracking-issue URL.
- `apps/docs/content/docs/plugins/interactions/mcp.mdx` — replaced the \"tracked in #2024\" callout with a plain statement that standalone `serve` is intentionally not supported, pointing readers at the hosted-endpoint reference.

The next step (after this merges) is closing #2052 with the decision recorded in the issue itself.

## Test plan

- [x] `bun test plugins/mcp/__tests__/cli.test.ts` — 24 pass / 0 fail
- [x] Local `/ci`: lint, type, full `bun run test`, syncpack, template drift, security-headers drift, railway-watch — all pass
- [x] Manual read of `mcp.mdx` + `mcp-hosted.mdx` to confirm unscaffolded users land on the hosted path