### PR TITLE
chore(mcp): #2027 — MCP Registry publish workflow (github-oidc)

### DIFF
--- a/.github/workflows/mcp-registry.yml
+++ b/.github/workflows/mcp-registry.yml
@@ -1,0 +1,54 @@
+name: MCP Registry publish
+
+# Publish plugins/mcp/server.json to https://registry.modelcontextprotocol.io
+# whenever a mcp-v* tag ships. Auth is GitHub OIDC — the registry validates that
+# the workflow runs in a repo whose owner matches the io.github.<owner>/<name>
+# namespace declared in server.json.
+on:
+  push:
+    tags:
+      - 'mcp-v*'
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" \
+            | tar xz mcp-publisher
+          sudo mv mcp-publisher /usr/local/bin/
+
+      - name: Wait for npm to surface the new version
+        working-directory: plugins/mcp
+        run: |
+          version=$(node -p "require('./package.json').version")
+          for i in $(seq 1 30); do
+            if npm view "@useatlas/mcp@${version}" version >/dev/null 2>&1; then
+              echo "npm has @useatlas/mcp@${version}"
+              exit 0
+            fi
+            echo "Waiting for npm to surface @useatlas/mcp@${version} (attempt $i/30)..."
+            sleep 10
+          done
+          echo "Timed out waiting for npm" >&2
+          exit 1
+
+      - name: Validate server.json
+        working-directory: plugins/mcp
+        run: mcp-publisher validate
+
+      - name: Login (GitHub OIDC)
+        working-directory: plugins/mcp
+        run: mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        working-directory: plugins/mcp
+        run: mcp-publisher publish


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/mcp-registry.yml` — publishes `plugins/mcp/server.json` to [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io) on every `mcp-v*` tag using GitHub OIDC (no manual auth, namespace-verified via repo owner).
- Includes `workflow_dispatch` so we can retroactively submit `@useatlas/mcp@0.0.2` (just published from `mcp-v0.0.2`) without having to bump the version again.
- Waits for the new package version to appear on the npm registry before validating + publishing — `mcp-publisher` reads `packages[0].version` from `server.json` and the registry rejects manifests whose npm version is not yet visible.

## Why this and not interactive `mcp-publisher login github`

`mcp-publisher 1.7.7` has a polling backoff bug — the device-flow CLI bails on the first `slow_down` response from GitHub instead of backing off, so the human round-trip window is unworkable. `github-oidc` is the registry-recommended auth path for `io.github.<owner>/*` namespaces and pairs with the existing OIDC publish pattern in `.github/workflows/publish.yml`.

## Closes / unblocks

Final remaining gate on #2027 before submission. After merge:

1. `gh workflow run mcp-registry.yml --ref main` — submits `0.0.2` to registry.modelcontextprotocol.io.
2. mcp.so listing form (Matt — account-gated).
3. Claude Desktop catalog (Anthropic-curated interest form — Matt).

## Test plan

- [x] `mcp-publisher validate` passes locally against the prepared `plugins/mcp/server.json` (schema `2025-12-11`).
- [x] E2E: `bun x @useatlas/mcp@0.0.2 init --hosted` from a fresh `/tmp` dir resolves the package, hits `/.well-known/oauth-authorization-server` against `api.useatlas.dev`, performs DCR, binds a 127.0.0.1 loopback listener, and prints a working OAuth 2.1 authorize URL.
- [ ] Post-merge: dispatch the workflow and confirm the registry returns `200` for `GET /v0/servers/io.github.AtlasDevHQ/atlas`.