### PR TITLE
fix(web,api): #2081 — friendlyError passthrough + MFA enrollment overlay

### DIFF
--- a/packages/api/src/api/routes/admin-mfa-required.ts
+++ b/packages/api/src/api/routes/admin-mfa-required.ts
@@ -47,7 +47,7 @@
  *    independent of this middleware.
  *
  * Member-role users are NEVER gated. The enrollment surface is available
- * to them voluntarily; the policy in this milestone is admin-only.
+ * to them voluntarily; the policy is admin-only.
  */
 
 import type { Context } from "hono";

--- a/packages/api/src/api/routes/admin-mfa-required.ts
+++ b/packages/api/src/api/routes/admin-mfa-required.ts
@@ -19,16 +19,32 @@
  *
  * ### What is NOT gated by this middleware
  *
- * The middleware is mounted on `/api/v1/admin/*` and `/api/v1/platform/*`
- * via `createAdminRouter()` / `createPlatformRouter()`. Better Auth's
- * own routes — `/api/auth/two-factor/*` (enrollment) and `/api/auth/sign-out`
- * — are mounted on a separate sub-app at `/api/auth` (`api/index.ts`)
- * and therefore never traverse this middleware. Admins without an
- * enrolled second factor reach those endpoints regardless of role: the
- * gate sits in front of admin-data routes, not in front of Better Auth.
+ * The middleware is mounted on routers built via `createAdminRouter()` /
+ * `createPlatformRouter()` (see `admin-router.ts`). It is therefore in
+ * front of every admin sub-router that uses those factories: connections,
+ * audit, sandbox, integrations, plugins, etc.
  *
- * The Next.js page at `/admin/settings/security` is rendered by the
- * frontend, not the API admin router, so it is also not gated here.
+ * **Three deliberate carve-outs:**
+ *
+ * 1. **Better Auth (`/api/auth/*`).** Mounted on a separate sub-app at
+ *    `/api/auth` in `api/index.ts`, so the two-factor enrollment endpoints
+ *    (`/api/auth/two-factor/enable`, `/api/auth/two-factor/verify-totp`,
+ *    `/api/auth/two-factor/generate-backup-codes`) and `/api/auth/sign-out`
+ *    never traverse this middleware. Admins without an enrolled second
+ *    factor reach those endpoints regardless of role.
+ *
+ * 2. **The parent admin router itself (`admin.ts`).** That router is built
+ *    as a raw `OpenAPIHono` instance with its own per-handler auth via
+ *    `adminAuthAndContext()`, NOT through `createAdminRouter()`. So the
+ *    self-service routes registered directly on it — `/me/password-status`,
+ *    `/me/password`, `/settings`, semantic editor routes — are NOT gated
+ *    by `mfaRequired`. The web's `usePasswordStatus` hook depends on this
+ *    carve-out: AdminLayout must be able to check password status before
+ *    the user has enrolled a second factor.
+ *
+ * 3. **The Next.js security page (`/admin/settings/security`).** Rendered
+ *    by the frontend, not by the API admin router, so it is reachable
+ *    independent of this middleware.
  *
  * Member-role users are NEVER gated. The enrollment surface is available
  * to them voluntarily; the policy in this milestone is admin-only.

--- a/packages/web/src/ui/__tests__/admin-layout.test.tsx
+++ b/packages/web/src/ui/__tests__/admin-layout.test.tsx
@@ -106,6 +106,22 @@ function mockDeniedFetch() {
   ) as unknown as typeof fetch;
 }
 
+/** Mock fetch that returns 403 with `mfa_enrollment_required` body. */
+function mockMfaRequiredFetch() {
+  globalThis.fetch = mock(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          error: "mfa_enrollment_required",
+          message: "Two-factor authentication is required for admin accounts.",
+          enrollmentUrl: "/admin/settings/security",
+        }),
+        { status: 403 },
+      ),
+    ),
+  ) as unknown as typeof fetch;
+}
+
 describe("AdminLayout", () => {
   beforeEach(() => {
     testQueryClient = new QueryClient({
@@ -190,6 +206,31 @@ describe("AdminLayout", () => {
     await waitFor(() => {
       expect(container.textContent).toContain("Admin Console");
     });
+  });
+
+  test("does NOT show 'Access denied' Card on mfa_enrollment_required", async () => {
+    // Regression guard for #2081 — the broken behavior was that any 403
+    // routed to the "Access denied. Admin role required." Card. The
+    // discriminated `usePasswordStatus` result keeps the Card in front of
+    // genuine role failures only; missing-second-factor 403s fall through
+    // to the normal layout where the dialog can render.
+    mockMfaRequiredFetch();
+    mockSession = { data: { user: { email: "admin@test.com", role: "admin" } } };
+    const { container } = renderLayout();
+    await waitFor(() => {
+      expect(container.textContent).toContain("Admin Console");
+    });
+    expect(container.textContent).not.toContain("admin console requires the admin role");
+  });
+
+  test("opens MFA enrollment dialog on mfa_enrollment_required", async () => {
+    mockMfaRequiredFetch();
+    mockSession = { data: { user: { email: "admin@test.com", role: "admin" } } };
+    renderLayout();
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Two-factor authentication required");
+    });
+    expect(document.body.textContent).toContain("Enroll authenticator");
   });
 
   test("shows password change dialog when required", async () => {

--- a/packages/web/src/ui/__tests__/fetch-error.test.ts
+++ b/packages/web/src/ui/__tests__/fetch-error.test.ts
@@ -87,26 +87,63 @@ describe("extractFetchError", () => {
 });
 
 describe("friendlyError", () => {
-  test("maps 401 to sign-in message", () => {
-    expect(friendlyError({ message: "Unauthorized", status: 401 })).toBe(
+  test("server message wins on 401 (typed body)", () => {
+    // After the #2081 precedence flip, a server-authored body message reaches
+    // the user verbatim — masking it with the canned "sign in" copy is what
+    // produced the "Admin role required" lie for unenrolled admins.
+    expect(friendlyError({ message: "Session expired.", status: 401 })).toBe(
+      "Session expired.",
+    );
+  });
+
+  test("server message wins on 403 (typed body)", () => {
+    // The motivating bug: an unenrolled admin saw "Admin role required" when
+    // the real cause was `mfa_enrollment_required`. The server-authored
+    // message must reach the user.
+    expect(
+      friendlyError({
+        message: "Two-factor authentication is required for admin accounts.",
+        status: 403,
+        code: "mfa_enrollment_required",
+      }),
+    ).toBe("Two-factor authentication is required for admin accounts.");
+  });
+
+  test("server message wins on 404 (typed body)", () => {
+    expect(friendlyError({ message: "Workspace not found.", status: 404 })).toBe(
+      "Workspace not found.",
+    );
+  });
+
+  test("server message wins on 503 (typed body)", () => {
+    expect(
+      friendlyError({ message: "Datasource pool draining.", status: 503 }),
+    ).toBe("Datasource pool draining.");
+  });
+
+  test("falls back to canned 401 copy when body is empty (HTTP status placeholder)", () => {
+    // `extractFetchError` substitutes `HTTP ${status}` when the body had no
+    // usable message field. `friendlyError` recognizes that placeholder and
+    // swaps in the canned copy — otherwise the user would see "HTTP 401".
+    expect(friendlyError({ message: "HTTP 401", status: 401 })).toBe(
       "Not authenticated. Please sign in.",
     );
   });
 
-  test("maps 403 to access denied", () => {
-    expect(friendlyError({ message: "Forbidden", status: 403 })).toBe(
-      "Access denied. Admin role required to view this page.",
+  test("falls back to canned 403 copy when body is empty", () => {
+    expect(friendlyError({ message: "HTTP 403", status: 403 })).toBe(
+      "Access denied. You may need additional permissions to view this page.",
     );
   });
 
-  test("maps 404 to feature not enabled", () => {
-    expect(friendlyError({ message: "Not Found", status: 404 })).toBe(
+  test("falls back to canned 404 copy when body is empty", () => {
+    expect(friendlyError({ message: "HTTP 404", status: 404 })).toBe(
       "This feature is not enabled on this server.",
     );
   });
 
-  test("maps 503 to service unavailable", () => {
-    expect(friendlyError({ message: "Service Unavailable", status: 503 })).toBe(
+  test("falls back to canned 503 copy when body is empty", () => {
+    expect(friendlyError({ message: "HTTP 503", status: 503 })).toBe(
       "A required service is unavailable. Check server configuration.",
     );
   });
@@ -125,10 +162,21 @@ describe("friendlyError", () => {
     );
   });
 
-  test("appends requestId to friendly-mapped messages", () => {
-    expect(friendlyError({ message: "x", status: 401, requestId: "req-abc" })).toBe(
-      "Not authenticated. Please sign in. (Request ID: req-abc)",
-    );
+  test("appends requestId to canned fallback copy", () => {
+    expect(
+      friendlyError({ message: "HTTP 401", status: 401, requestId: "req-abc" }),
+    ).toBe("Not authenticated. Please sign in. (Request ID: req-abc)");
+  });
+
+  test("appends requestId to server-authored message", () => {
+    expect(
+      friendlyError({
+        message: "Two-factor required.",
+        status: 403,
+        code: "mfa_enrollment_required",
+        requestId: "req-mfa",
+      }),
+    ).toBe("Two-factor required. (Request ID: req-mfa)");
   });
 
   test("routes schema_mismatch to a version-drift specific message", () => {
@@ -139,16 +187,24 @@ describe("friendlyError", () => {
     );
   });
 
-  test("HTTP status mapping wins over schema_mismatch when status is set", () => {
+  test("server message wins over schema_mismatch when status is set", () => {
     // Defensive: if a server response body ever sets `error: "schema_mismatch"`
-    // on a 401/403/404/503, the auth/role/feature copy must still reach the
-    // user — masking it with "out of sync" would break the sign-in loop.
+    // on an HTTP error, the server message reaches the user — masking it with
+    // "out of sync" would override the real auth/role/feature signal.
     expect(
-      friendlyError({ message: "x", status: 401, code: "schema_mismatch" }),
+      friendlyError({ message: "Bad token.", status: 401, code: "schema_mismatch" }),
+    ).toBe("Bad token.");
+    expect(
+      friendlyError({ message: "Forbidden by policy.", status: 403, code: "schema_mismatch" }),
+    ).toBe("Forbidden by policy.");
+  });
+
+  test("schema_mismatch with status + empty body falls through to canned copy", () => {
+    // The `HTTP 401` placeholder triggers the canned fallback, not the
+    // schema-mismatch copy — schema_mismatch only wins on the no-status path.
+    expect(
+      friendlyError({ message: "HTTP 401", status: 401, code: "schema_mismatch" }),
     ).toBe("Not authenticated. Please sign in.");
-    expect(
-      friendlyError({ message: "x", status: 403, code: "schema_mismatch" }),
-    ).toContain("Access denied");
   });
 
   test("schema_mismatch falls through to raw message when status is set without a friendly mapping", () => {
@@ -306,10 +362,21 @@ describe("friendlyErrorOrNull", () => {
     expect(friendlyErrorOrNull(err)).toBe(friendlyError(err));
   });
 
-  test("preserves EE 403 translation on non-null path", () => {
-    // Routes through friendlyError, so the 403 admin-role copy still fires.
-    expect(friendlyErrorOrNull({ message: "Forbidden", status: 403 })).toBe(
-      "Access denied. Admin role required to view this page.",
+  test("preserves server message on non-null 403 path", () => {
+    // Routes through friendlyError — server-authored messages reach the user
+    // verbatim (post-#2081 precedence flip).
+    expect(
+      friendlyErrorOrNull({
+        message: "Two-factor required.",
+        status: 403,
+        code: "mfa_enrollment_required",
+      }),
+    ).toBe("Two-factor required.");
+  });
+
+  test("falls back to canned 403 copy on empty-body 403", () => {
+    expect(friendlyErrorOrNull({ message: "HTTP 403", status: 403 })).toBe(
+      "Access denied. You may need additional permissions to view this page.",
     );
   });
 });

--- a/packages/web/src/ui/__tests__/fetch-error.test.ts
+++ b/packages/web/src/ui/__tests__/fetch-error.test.ts
@@ -84,6 +84,41 @@ describe("extractFetchError", () => {
     const err = await extractFetchError(res);
     expect(err).toEqual({ message: "HTTP 500", status: 500, requestId: "req-456" });
   });
+
+  test("extracts enrollmentUrl alongside mfa_enrollment_required code", async () => {
+    const res = mockResponse(403, {
+      error: "mfa_enrollment_required",
+      message: "Two-factor required.",
+      enrollmentUrl: "/admin/settings/security",
+    });
+    const err = await extractFetchError(res);
+    expect(err).toEqual({
+      message: "Two-factor required.",
+      status: 403,
+      code: "mfa_enrollment_required",
+      enrollmentUrl: "/admin/settings/security",
+    });
+  });
+
+  test("ignores empty-string enrollmentUrl", async () => {
+    const res = mockResponse(403, {
+      error: "mfa_enrollment_required",
+      message: "x",
+      enrollmentUrl: "",
+    });
+    const err = await extractFetchError(res);
+    expect(err.enrollmentUrl).toBeUndefined();
+  });
+
+  test("ignores non-string enrollmentUrl", async () => {
+    const res = mockResponse(403, {
+      error: "mfa_enrollment_required",
+      message: "x",
+      enrollmentUrl: 42,
+    });
+    const err = await extractFetchError(res);
+    expect(err.enrollmentUrl).toBeUndefined();
+  });
 });
 
 describe("friendlyError", () => {

--- a/packages/web/src/ui/__tests__/mfa-enrollment-dialog.test.tsx
+++ b/packages/web/src/ui/__tests__/mfa-enrollment-dialog.test.tsx
@@ -1,0 +1,176 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { render, fireEvent, waitFor, cleanup, act } from "@testing-library/react";
+import React, { useEffect } from "react";
+import { MfaGateProvider, useMfaGate } from "../components/admin/mfa-gate-context";
+import { MfaEnrollmentDialog } from "../components/admin/mfa-enrollment-dialog";
+import { AtlasProvider, type AtlasAuthClient } from "../context";
+
+const routerPush = mock((_path: string) => {});
+const routerReplace = mock(() => {});
+const mockSignOut = mock(() => Promise.resolve());
+
+mock.module("next/navigation", () => ({
+  usePathname: () => "/admin/users",
+  useRouter: () => ({ push: routerPush, replace: routerReplace, back: () => {} }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+function makeAuthClient(overrides: Partial<AtlasAuthClient> = {}): AtlasAuthClient {
+  return {
+    signIn: { email: async () => ({}) },
+    signUp: { email: async () => ({}) },
+    signOut: mockSignOut,
+    useSession: () => ({ data: null }),
+    ...overrides,
+  };
+}
+
+/**
+ * Helper component — triggers the gate immediately on mount so the dialog
+ * has state to render. Lets us exercise the dialog without spinning up the
+ * full hook + fetch path.
+ */
+function GateTrigger({ enrollmentUrl }: { enrollmentUrl: string }) {
+  const { trigger } = useMfaGate();
+  useEffect(() => {
+    trigger(enrollmentUrl);
+  }, [trigger, enrollmentUrl]);
+  return null;
+}
+
+function renderDialog(enrollmentUrl = "/admin/settings/security") {
+  return render(
+    <AtlasProvider
+      config={{
+        apiUrl: "http://localhost:3001",
+        isCrossOrigin: false,
+        authClient: makeAuthClient(),
+      }}
+    >
+      <MfaGateProvider>
+        <GateTrigger enrollmentUrl={enrollmentUrl} />
+        <MfaEnrollmentDialog />
+      </MfaGateProvider>
+    </AtlasProvider>,
+  );
+}
+
+const originalAssign = window.location.assign;
+
+beforeEach(() => {
+  routerPush.mockClear();
+  routerReplace.mockClear();
+  mockSignOut.mockClear();
+  Object.defineProperty(window, "location", {
+    value: { ...window.location, assign: mock(() => {}) },
+    writable: true,
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  Object.defineProperty(window, "location", {
+    value: { ...window.location, assign: originalAssign },
+    writable: true,
+    configurable: true,
+  });
+});
+
+describe("MfaEnrollmentDialog", () => {
+  test("opens with the gate state", async () => {
+    renderDialog();
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Two-factor authentication required");
+    });
+  });
+
+  test('"Enroll authenticator" routes to enrollmentUrl and clears gate state', async () => {
+    const { container } = renderDialog("/admin/settings/security");
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Enroll authenticator");
+    });
+
+    const enrollBtn = Array.from(document.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("Enroll authenticator"),
+    );
+    expect(enrollBtn).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(enrollBtn!);
+    });
+
+    expect(routerPush).toHaveBeenCalledWith("/admin/settings/security");
+
+    // After click, dialog should close (gate.state cleared).
+    await waitFor(() => {
+      expect(container.textContent).not.toContain("Two-factor authentication required");
+    });
+  });
+
+  test('"Sign out" calls authClient.signOut and navigates to /login', async () => {
+    renderDialog();
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Sign out");
+    });
+
+    const signOutBtn = Array.from(document.querySelectorAll("button")).find((b) =>
+      b.textContent?.trim() === "Sign out",
+    );
+    expect(signOutBtn).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(signOutBtn!);
+    });
+
+    await waitFor(() => {
+      expect(mockSignOut).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(window.location.assign).toHaveBeenCalledWith("/login");
+    });
+  });
+
+  test("Sign-out failure still navigates to /login (recovery)", async () => {
+    const failingSignOut = mock(() => Promise.reject(new Error("network down")));
+    const originalWarn = console.warn;
+    console.warn = mock(() => {}) as typeof console.warn;
+
+    try {
+      render(
+        <AtlasProvider
+          config={{
+            apiUrl: "http://localhost:3001",
+            isCrossOrigin: false,
+            authClient: makeAuthClient({ signOut: failingSignOut }),
+          }}
+        >
+          <MfaGateProvider>
+            <GateTrigger enrollmentUrl="/admin/settings/security" />
+            <MfaEnrollmentDialog />
+          </MfaGateProvider>
+        </AtlasProvider>,
+      );
+
+      await waitFor(() => {
+        expect(document.body.textContent).toContain("Sign out");
+      });
+      const signOutBtn = Array.from(document.querySelectorAll("button")).find((b) =>
+        b.textContent?.trim() === "Sign out",
+      );
+
+      await act(async () => {
+        fireEvent.click(signOutBtn!);
+      });
+
+      await waitFor(() => {
+        expect(window.location.assign).toHaveBeenCalledWith("/login");
+      });
+      expect(console.warn).toHaveBeenCalled();
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});

--- a/packages/web/src/ui/__tests__/mfa-gate-context.test.tsx
+++ b/packages/web/src/ui/__tests__/mfa-gate-context.test.tsx
@@ -1,0 +1,174 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { renderHook, cleanup, act } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import {
+  MfaGateProvider,
+  useMfaGate,
+  useMfaGateOptional,
+  consumeOriginPath,
+} from "../components/admin/mfa-gate-context";
+
+let mockPathname = "/admin/users";
+
+mock.module("next/navigation", () => ({
+  usePathname: () => mockPathname,
+  useRouter: () => ({ push: () => {}, replace: () => {}, back: () => {} }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const ORIGIN_PATH_KEY = "atlas:mfa-origin-path";
+
+function providerWrapper({ children }: { children: ReactNode }) {
+  return createElement(MfaGateProvider, null, children);
+}
+
+beforeEach(() => {
+  mockPathname = "/admin/users";
+  window.sessionStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  window.sessionStorage.clear();
+});
+
+describe("MfaGateProvider.trigger", () => {
+  test("opens the gate and stashes the current pathname", () => {
+    mockPathname = "/admin/sandbox";
+    const { result } = renderHook(() => useMfaGate(), { wrapper: providerWrapper });
+
+    act(() => {
+      result.current.trigger("/admin/settings/security");
+    });
+
+    expect(result.current.state).not.toBeNull();
+    expect(result.current.state!.enrollmentUrl).toBe("/admin/settings/security");
+    expect(window.sessionStorage.getItem(ORIGIN_PATH_KEY)).toBe("/admin/sandbox");
+  });
+
+  test("no-op when on the enrollment page", () => {
+    mockPathname = "/admin/settings/security";
+    const { result } = renderHook(() => useMfaGate(), { wrapper: providerWrapper });
+
+    act(() => {
+      result.current.trigger("/admin/settings/security");
+    });
+
+    expect(result.current.state).toBeNull();
+    expect(window.sessionStorage.getItem(ORIGIN_PATH_KEY)).toBeNull();
+  });
+
+  test("no-op on nested security page paths", () => {
+    mockPathname = "/admin/settings/security/audit-log";
+    const { result } = renderHook(() => useMfaGate(), { wrapper: providerWrapper });
+
+    act(() => {
+      result.current.trigger("/admin/settings/security");
+    });
+
+    expect(result.current.state).toBeNull();
+  });
+
+  test("idempotent — first call wins, second is dropped", () => {
+    // Concurrent fan-out (parallel admin queries on a fresh page load) must
+    // not stomp the first failure's stashed origin path.
+    mockPathname = "/admin/users";
+    const { result } = renderHook(() => useMfaGate(), { wrapper: providerWrapper });
+
+    act(() => {
+      result.current.trigger("/admin/settings/security");
+    });
+
+    const firstState = result.current.state;
+    expect(firstState).not.toBeNull();
+    expect(window.sessionStorage.getItem(ORIGIN_PATH_KEY)).toBe("/admin/users");
+
+    // Simulate a different pathname for the second call (impossible in
+    // practice with a stable usePathname, but proves the sessionStorage
+    // write is gated by the prev=null branch).
+    act(() => {
+      result.current.trigger("/admin/different-target");
+    });
+
+    expect(result.current.state!.enrollmentUrl).toBe("/admin/settings/security");
+    expect(window.sessionStorage.getItem(ORIGIN_PATH_KEY)).toBe("/admin/users");
+  });
+
+  test("clear() resets state", () => {
+    const { result } = renderHook(() => useMfaGate(), { wrapper: providerWrapper });
+
+    act(() => {
+      result.current.trigger("/admin/settings/security");
+    });
+    expect(result.current.state).not.toBeNull();
+
+    act(() => {
+      result.current.clear();
+    });
+    expect(result.current.state).toBeNull();
+  });
+});
+
+describe("consumeOriginPath", () => {
+  test("reads + clears the stashed origin atomically", () => {
+    window.sessionStorage.setItem(ORIGIN_PATH_KEY, "/admin/sandbox");
+
+    expect(consumeOriginPath()).toBe("/admin/sandbox");
+    expect(window.sessionStorage.getItem(ORIGIN_PATH_KEY)).toBeNull();
+    expect(consumeOriginPath()).toBeNull();
+  });
+
+  test("returns null when no origin was stashed", () => {
+    expect(consumeOriginPath()).toBeNull();
+  });
+
+  test("fails open when sessionStorage throws", () => {
+    const originalGetItem = window.sessionStorage.getItem;
+    window.sessionStorage.getItem = mock(() => {
+      throw new Error("private mode");
+    }) as typeof window.sessionStorage.getItem;
+
+    try {
+      expect(consumeOriginPath()).toBeNull();
+    } finally {
+      window.sessionStorage.getItem = originalGetItem;
+    }
+  });
+});
+
+describe("useMfaGate without provider", () => {
+  test("throws — admin surfaces must mount the provider", () => {
+    // Suppress React's error-boundary console output during the throw.
+    const originalError = console.error;
+    console.error = mock(() => {}) as typeof console.error;
+    try {
+      expect(() => renderHook(() => useMfaGate())).toThrow(
+        /must be used inside.*MfaGateProvider/,
+      );
+    } finally {
+      console.error = originalError;
+    }
+  });
+});
+
+describe("useMfaGateOptional without provider", () => {
+  test("returns a no-op gate that does not throw", () => {
+    const originalWarn = console.warn;
+    const warnSpy = mock(() => {}) as typeof console.warn;
+    console.warn = warnSpy;
+
+    try {
+      const { result } = renderHook(() => useMfaGateOptional());
+      expect(result.current.state).toBeNull();
+
+      act(() => {
+        result.current.trigger("/admin/settings/security");
+      });
+
+      expect(result.current.state).toBeNull();
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});

--- a/packages/web/src/ui/__tests__/use-admin-fetch.test.ts
+++ b/packages/web/src/ui/__tests__/use-admin-fetch.test.ts
@@ -16,10 +16,25 @@ describe("friendlyError", () => {
     expect(friendlyError(err)).toContain("Not authenticated");
   });
 
-  test("returns access denied for 403", () => {
+  test("returns access denied for 403 with empty body", () => {
+    // Post-#2081 the canned 403 copy fires only when the body has no
+    // usable message (`extractFetchError` substitutes `HTTP ${status}`).
+    // Server-typed messages reach the user verbatim; this case is the
+    // empty-body fallback path.
     const err: FetchError = { message: "HTTP 403", status: 403 };
     expect(friendlyError(err)).toContain("Access denied");
-    expect(friendlyError(err)).toContain("Admin role");
+  });
+
+  test("server-typed 403 message wins over canned copy", () => {
+    // The motivating regression: an unenrolled admin saw "Admin role required"
+    // on a `mfa_enrollment_required` 403. The server-authored message must
+    // reach the user.
+    const err: FetchError = {
+      message: "Two-factor required.",
+      status: 403,
+      code: "mfa_enrollment_required",
+    };
+    expect(friendlyError(err)).toBe("Two-factor required.");
   });
 
   test("returns feature not enabled for 404", () => {

--- a/packages/web/src/ui/__tests__/use-admin-fetch.test.ts
+++ b/packages/web/src/ui/__tests__/use-admin-fetch.test.ts
@@ -5,6 +5,16 @@ import { z } from "zod";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { friendlyError, useAdminFetch, type FetchError } from "../hooks/use-admin-fetch";
 import { AtlasProvider } from "../context";
+import {
+  MfaGateProvider,
+  useMfaGate,
+} from "../components/admin/mfa-gate-context";
+
+mock.module("next/navigation", () => ({
+  usePathname: () => "/admin/users",
+  useRouter: () => ({ push: () => {}, replace: () => {}, back: () => {} }),
+  useSearchParams: () => new URLSearchParams(),
+}));
 
 /* ------------------------------------------------------------------ */
 /*  friendlyError (pure function)                                      */
@@ -595,5 +605,135 @@ describe("useAdminFetch", () => {
     expect(result.current.error!.message).toContain("transform boom");
 
     console.warn = originalWarn;
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  useAdminFetch → MfaGate dispatch                                   */
+/* ------------------------------------------------------------------ */
+
+function gatedWrapper({ children }: { children: ReactNode }) {
+  return createElement(
+    QueryClientProvider,
+    { client: testQueryClient },
+    createElement(
+      AtlasProvider,
+      { config: { apiUrl: "http://localhost:3001", isCrossOrigin: false as const, authClient: stubAuthClient } },
+      createElement(MfaGateProvider, null, children),
+    ),
+  );
+}
+
+function useFetchAndGate(path: string) {
+  const fetched = useAdminFetch(path);
+  const gate = useMfaGate();
+  return { fetched, gate };
+}
+
+describe("useAdminFetch → MfaGate dispatch", () => {
+  beforeEach(() => {
+    testQueryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+  });
+
+  afterEach(() => {
+    testQueryClient.clear();
+    cleanup();
+    globalThis.fetch = originalFetch;
+  });
+
+  test("opens the gate on mfa_enrollment_required 403", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            error: "mfa_enrollment_required",
+            message: "Two-factor required.",
+            enrollmentUrl: "/admin/settings/security",
+          }),
+          { status: 403, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    ) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useFetchAndGate("/api/test"), { wrapper: gatedWrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetched.loading).toBe(false);
+    });
+
+    expect(result.current.gate.state).not.toBeNull();
+    expect(result.current.gate.state!.enrollmentUrl).toBe("/admin/settings/security");
+    expect(result.current.fetched.error?.code).toBe("mfa_enrollment_required");
+  });
+
+  test("falls back to default enrollmentUrl when server omits it", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            error: "mfa_enrollment_required",
+            message: "Two-factor required.",
+          }),
+          { status: 403, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    ) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useFetchAndGate("/api/test"), { wrapper: gatedWrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetched.loading).toBe(false);
+    });
+
+    expect(result.current.gate.state!.enrollmentUrl).toBe("/admin/settings/security");
+  });
+
+  test("does NOT open the gate on non-MFA 403 (forbidden_role)", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({ error: "forbidden_role", message: "Admin role required." }),
+          { status: 403, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    ) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useFetchAndGate("/api/test"), { wrapper: gatedWrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetched.loading).toBe(false);
+    });
+
+    expect(result.current.gate.state).toBeNull();
+    expect(result.current.fetched.error?.code).toBe("forbidden_role");
+  });
+
+  test("hook does not throw when used outside MfaGateProvider", async () => {
+    // useMfaGateOptional fallback path — admin hooks must remain safe on
+    // non-admin surfaces (chat, embedded widget) without a provider mount.
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({ error: "mfa_enrollment_required", message: "x" }),
+          { status: 403, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    ) as unknown as typeof fetch;
+
+    // Suppress the dev-warn the NOOP_GATE.trigger emits.
+    const originalWarn = console.warn;
+    console.warn = mock(() => {}) as typeof console.warn;
+
+    try {
+      const { result } = renderHook(() => useAdminFetch("/api/test"), { wrapper });
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+      expect(result.current.error?.code).toBe("mfa_enrollment_required");
+    } finally {
+      console.warn = originalWarn;
+    }
   });
 });

--- a/packages/web/src/ui/__tests__/use-password-status.test.ts
+++ b/packages/web/src/ui/__tests__/use-password-status.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { renderHook, waitFor, cleanup } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { usePasswordStatus } from "../hooks/use-password-status";
+import { AtlasProvider } from "../context";
+
+const stubAuthClient = {
+  signIn: { email: async () => ({}) },
+  signUp: { email: async () => ({}) },
+  signOut: async () => {},
+  useSession: () => ({ data: null }),
+};
+
+let testQueryClient: QueryClient;
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(
+    QueryClientProvider,
+    { client: testQueryClient },
+    createElement(
+      AtlasProvider,
+      {
+        config: {
+          apiUrl: "http://localhost:3001",
+          isCrossOrigin: false as const,
+          authClient: stubAuthClient,
+        },
+      },
+      children,
+    ),
+  );
+}
+
+const originalFetch = globalThis.fetch;
+
+function mockResp(status: number, body?: unknown): typeof fetch {
+  return mock(() =>
+    Promise.resolve(
+      body === undefined
+        ? new Response(null, { status })
+        : new Response(JSON.stringify(body), {
+            status,
+            headers: { "Content-Type": "application/json" },
+          }),
+    ),
+  ) as unknown as typeof fetch;
+}
+
+describe("usePasswordStatus discriminated result", () => {
+  beforeEach(() => {
+    testQueryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+  });
+
+  afterEach(() => {
+    testQueryClient.clear();
+    cleanup();
+    globalThis.fetch = originalFetch;
+  });
+
+  test('200 → kind: "allowed" with passwordChangeRequired', async () => {
+    globalThis.fetch = mockResp(200, { passwordChangeRequired: true });
+
+    const { result } = renderHook(() => usePasswordStatus(true), { wrapper });
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(result.current.data).toEqual({
+      kind: "allowed",
+      passwordChangeRequired: true,
+    });
+  });
+
+  test('403 forbidden_role → kind: "denied"', async () => {
+    globalThis.fetch = mockResp(403, { error: "forbidden_role", message: "x" });
+
+    const { result } = renderHook(() => usePasswordStatus(true), { wrapper });
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(result.current.data).toEqual({ kind: "denied" });
+  });
+
+  test('403 mfa_enrollment_required → kind: "mfa-required" with enrollmentUrl', async () => {
+    globalThis.fetch = mockResp(403, {
+      error: "mfa_enrollment_required",
+      enrollmentUrl: "/admin/settings/security",
+    });
+
+    const { result } = renderHook(() => usePasswordStatus(true), { wrapper });
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(result.current.data).toEqual({
+      kind: "mfa-required",
+      enrollmentUrl: "/admin/settings/security",
+    });
+  });
+
+  test('403 with non-JSON body → kind: "denied" (safer default)', async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response("Forbidden", { status: 403 })),
+    ) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => usePasswordStatus(true), { wrapper });
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(result.current.data).toEqual({ kind: "denied" });
+  });
+
+  test('403 mfa_enrollment_required without enrollmentUrl → uses default URL', async () => {
+    globalThis.fetch = mockResp(403, { error: "mfa_enrollment_required" });
+
+    const { result } = renderHook(() => usePasswordStatus(true), { wrapper });
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(result.current.data).toEqual({
+      kind: "mfa-required",
+      enrollmentUrl: "/admin/settings/security",
+    });
+  });
+
+  test("500 throws → isError, no data", async () => {
+    // The hook configures `retry: 1` so a 500 retries once before erroring.
+    // Bump waitFor's timeout above the default 1s to cover the retry window.
+    const originalWarn = console.warn;
+    console.warn = mock(() => {}) as typeof console.warn;
+
+    try {
+      globalThis.fetch = mockResp(500);
+
+      const { result } = renderHook(() => usePasswordStatus(true), { wrapper });
+      await waitFor(() => expect(result.current.isError).toBe(true), { timeout: 5000 });
+
+      expect(result.current.data).toBeUndefined();
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  test("disabled when enabled=false — never fetches", () => {
+    globalThis.fetch = mock(() =>
+      Promise.reject(new Error("should not be called")),
+    ) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => usePasswordStatus(false), { wrapper });
+
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/packages/web/src/ui/components/admin/admin-layout.tsx
+++ b/packages/web/src/ui/components/admin/admin-layout.tsx
@@ -37,11 +37,9 @@ function AdminLayoutInner({ children }: { children: ReactNode }) {
   // Shared with AtlasChat — TanStack deduplicates to a single request.
   const { data, isPending, isError } = usePasswordStatus(!!session.data?.user);
 
-  // Defensive: dispatch the MFA gate when password-status comes back as
-  // `mfa-required`. The route isn't gated today (admin.ts parent router has
-  // no `mfaRequired` middleware), so this branch only fires if someone moves
-  // the route or extends the gate later — without this hook, those changes
-  // would silently re-introduce the #2081 "Access denied" misrender.
+  // The password-status endpoint is not behind `mfaRequired` today — the
+  // dispatch is defensive so the gate fires correctly if that ever changes,
+  // instead of falling through to the denied Card below.
   useEffect(() => {
     if (data?.kind === "mfa-required") {
       trigger(data.enrollmentUrl);
@@ -73,9 +71,7 @@ function AdminLayoutInner({ children }: { children: ReactNode }) {
   }
 
   // Signed in but not admin — inline forbidden UI using shadcn.
-  // The `mfa-required` branch falls through to the normal layout so the
-  // dialog (mounted below) is the one that gates access; rendering this
-  // Card on top would be the same misleading "Access denied" UX #2081 fixed.
+  // mfa-required falls through — the dialog below is the gating UI, not this Card.
   if (adminCheck === "denied") {
     return (
       <main id="main" tabIndex={-1} className="flex h-full items-center justify-center bg-background p-4">

--- a/packages/web/src/ui/components/admin/admin-layout.tsx
+++ b/packages/web/src/ui/components/admin/admin-layout.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
+import { useEffect } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { SidebarProvider, SidebarInset, SidebarTrigger } from "@/components/ui/sidebar";
 import { Separator } from "@/components/ui/separator";
@@ -18,23 +19,47 @@ import { AdminSidebar } from "./admin-sidebar";
 import { useAtlasConfig } from "@/ui/context";
 import { LoadingState } from "./loading-state";
 import { ChangePasswordDialog } from "./change-password-dialog";
+import { MfaGateProvider, useMfaGate } from "./mfa-gate-context";
+import { MfaEnrollmentDialog } from "./mfa-enrollment-dialog";
 import { usePasswordStatus } from "@/ui/hooks/use-password-status";
 
-export function AdminLayout({ children }: { children: ReactNode }) {
+/**
+ * Inner layout — runs inside `MfaGateProvider` so it can dispatch the
+ * gate when password-status returns `mfa-required`. Splitting the provider
+ * out from the layout content keeps the trigger effect colocated with the
+ * data fetch instead of fanning out to every page.
+ */
+function AdminLayoutInner({ children }: { children: ReactNode }) {
   const { authClient } = useAtlasConfig();
   const session = authClient.useSession();
+  const { trigger } = useMfaGate();
 
   // Shared with AtlasChat — TanStack deduplicates to a single request.
   const { data, isPending, isError } = usePasswordStatus(!!session.data?.user);
 
-  // Derive admin check state
-  let adminCheck: "pending" | "allowed" | "denied";
+  // Defensive: dispatch the MFA gate when password-status comes back as
+  // `mfa-required`. The route isn't gated today (admin.ts parent router has
+  // no `mfaRequired` middleware), so this branch only fires if someone moves
+  // the route or extends the gate later — without this hook, those changes
+  // would silently re-introduce the #2081 "Access denied" misrender.
+  useEffect(() => {
+    if (data?.kind === "mfa-required") {
+      trigger(data.enrollmentUrl);
+    }
+  }, [data, trigger]);
+
+  // Derive admin check state from the discriminated result.
+  let adminCheck: "pending" | "allowed" | "denied" | "mfa-required";
   if (!session.data?.user || isPending) {
     adminCheck = "pending";
   } else if (isError || !data) {
     adminCheck = "denied";
+  } else if (data.kind === "denied") {
+    adminCheck = "denied";
+  } else if (data.kind === "mfa-required") {
+    adminCheck = "mfa-required";
   } else {
-    adminCheck = data.allowed ? "allowed" : "denied";
+    adminCheck = "allowed";
   }
 
   // Loading session — only show loading on hard navigation (no cached session).
@@ -47,7 +72,10 @@ export function AdminLayout({ children }: { children: ReactNode }) {
     );
   }
 
-  // Signed in but not admin — inline forbidden UI using shadcn
+  // Signed in but not admin — inline forbidden UI using shadcn.
+  // The `mfa-required` branch falls through to the normal layout so the
+  // dialog (mounted below) is the one that gates access; rendering this
+  // Card on top would be the same misleading "Access denied" UX #2081 fixed.
   if (adminCheck === "denied") {
     return (
       <main id="main" tabIndex={-1} className="flex h-full items-center justify-center bg-background p-4">
@@ -93,9 +121,18 @@ export function AdminLayout({ children }: { children: ReactNode }) {
       </SidebarInset>
 
       <ChangePasswordDialog
-        open={data?.passwordChangeRequired ?? false}
+        open={data?.kind === "allowed" && data.passwordChangeRequired}
         onComplete={() => { /* Dialog handles its own state */ }}
       />
+      <MfaEnrollmentDialog />
     </SidebarProvider>
+  );
+}
+
+export function AdminLayout({ children }: { children: ReactNode }) {
+  return (
+    <MfaGateProvider>
+      <AdminLayoutInner>{children}</AdminLayoutInner>
+    </MfaGateProvider>
   );
 }

--- a/packages/web/src/ui/components/admin/mfa-enrollment-dialog.tsx
+++ b/packages/web/src/ui/components/admin/mfa-enrollment-dialog.tsx
@@ -1,16 +1,14 @@
 "use client";
 
 /**
- * Modal that fires when an admin/owner/platform_admin session hits an
- * `mfa_enrollment_required` 403 anywhere on `/admin/*` or
- * `/admin/platform/*`. State lives in {@link MfaGateContext} — the
- * `useAdminFetch` / `useAdminMutation` hooks dispatch the trigger; this
+ * Modal that fires when an admin session hits an `mfa_enrollment_required`
+ * 403 anywhere on `/admin/*` or `/admin/platform/*`. State lives in
+ * {@link MfaGateContext}; the admin hooks dispatch the trigger and this
  * component renders the modal off the same context.
  *
  * Non-dismissable by design (matches `ChangePasswordDialog`): the user
- * either enrolls or signs out. Closing via Escape / outside-click is
- * suppressed, and there is no close X. Re-mounting on every page keep is
- * deliberate — the modal is the single intended exit from the gate state.
+ * either enrolls or signs out. Escape / outside-click are suppressed, no
+ * close X.
  */
 
 import { ShieldAlert } from "lucide-react";
@@ -37,10 +35,8 @@ export function MfaEnrollmentDialog() {
 
   function handleEnroll() {
     if (!state) return;
-    // Clear gate state before navigating so the destination page renders
-    // without the dialog stacked on top — the security page is its own
-    // surface and the skip-on-security-page rule in the provider keeps
-    // the gate from re-arming there.
+    // Clear before navigating — destination's own fetches must not re-arm
+    // the dialog (the provider's skip-on-security-page rule covers that).
     clear();
     router.push(state.enrollmentUrl);
   }
@@ -48,8 +44,14 @@ export function MfaEnrollmentDialog() {
   function handleSignOut() {
     void authClient
       .signOut()
-      .then(() => window.location.assign("/login"))
-      .catch(() => window.location.assign("/login"));
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        // Recovery is the same either way (navigate to /login), but log the
+        // failure so an underlying issue (auth proxy 5xx, broken plugin
+        // chain, network error) doesn't disappear into a silent redirect.
+        console.warn("MFA dialog sign-out failed; navigating to /login anyway:", msg);
+      })
+      .finally(() => window.location.assign("/login"));
   }
 
   return (

--- a/packages/web/src/ui/components/admin/mfa-enrollment-dialog.tsx
+++ b/packages/web/src/ui/components/admin/mfa-enrollment-dialog.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+/**
+ * Modal that fires when an admin/owner/platform_admin session hits an
+ * `mfa_enrollment_required` 403 anywhere on `/admin/*` or
+ * `/admin/platform/*`. State lives in {@link MfaGateContext} — the
+ * `useAdminFetch` / `useAdminMutation` hooks dispatch the trigger; this
+ * component renders the modal off the same context.
+ *
+ * Non-dismissable by design (matches `ChangePasswordDialog`): the user
+ * either enrolls or signs out. Closing via Escape / outside-click is
+ * suppressed, and there is no close X. Re-mounting on every page keep is
+ * deliberate — the modal is the single intended exit from the gate state.
+ */
+
+import { ShieldAlert } from "lucide-react";
+import { useRouter } from "next/navigation";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { useAtlasConfig } from "@/ui/context";
+import { useMfaGate } from "./mfa-gate-context";
+
+export function MfaEnrollmentDialog() {
+  const { state, clear } = useMfaGate();
+  const { authClient } = useAtlasConfig();
+  const router = useRouter();
+
+  const open = state !== null;
+
+  function handleEnroll() {
+    if (!state) return;
+    // Clear gate state before navigating so the destination page renders
+    // without the dialog stacked on top — the security page is its own
+    // surface and the skip-on-security-page rule in the provider keeps
+    // the gate from re-arming there.
+    clear();
+    router.push(state.enrollmentUrl);
+  }
+
+  function handleSignOut() {
+    void authClient
+      .signOut()
+      .then(() => window.location.assign("/login"))
+      .catch(() => window.location.assign("/login"));
+  }
+
+  return (
+    <AlertDialog open={open}>
+      <AlertDialogContent
+        className="sm:max-w-md"
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
+        <AlertDialogHeader>
+          <div className="mx-auto mb-2 flex size-12 items-center justify-center rounded-lg bg-amber-500/10">
+            <ShieldAlert className="size-6 text-amber-600 dark:text-amber-400" />
+          </div>
+          <AlertDialogTitle className="text-center">
+            Two-factor authentication required
+          </AlertDialogTitle>
+          <AlertDialogDescription className="text-center">
+            Admin accounts must enroll a second factor before accessing the
+            admin console. Set up an authenticator app to continue.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="sm:flex-col sm:gap-2 sm:space-x-0">
+          <AlertDialogAction onClick={handleEnroll}>
+            Enroll authenticator
+          </AlertDialogAction>
+          <AlertDialogCancel onClick={handleSignOut} className="mt-0">
+            Sign out
+          </AlertDialogCancel>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/packages/web/src/ui/components/admin/mfa-gate-context.tsx
+++ b/packages/web/src/ui/components/admin/mfa-gate-context.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+/**
+ * MFA enrollment gate state — shared across `useAdminFetch` /
+ * `useAdminMutation` (which detect `mfa_enrollment_required` 403s) and the
+ * dialog mounted in `AdminLayout` (which renders the modal). Keeps the
+ * dispatch path React-idiomatic and testable: hooks call
+ * `useMfaGate().trigger(...)`, the dialog reads from the same context, no
+ * `window` events flying around. See #2081.
+ *
+ * The provider also handles two policies that don't belong in either the
+ * hook layer or the dialog:
+ *
+ * 1. **Skip on the enrollment page.** When pathname starts with
+ *    `/admin/settings/security`, `trigger` is a no-op. Otherwise the
+ *    page's own pre-enroll fetches (which may transitively go through
+ *    `useAdminFetch` someday) would re-arm the dialog and trap the user
+ *    on the page they are already on.
+ * 2. **Capture origin path for redirect-back.** Stash the URL that fired
+ *    the gate into `sessionStorage` so the security page can bounce the
+ *    user back after enrollment completes. `consumeOriginPath()` reads +
+ *    clears the slot atomically.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { usePathname } from "next/navigation";
+
+const ENROLLMENT_PATH_PREFIX = "/admin/settings/security";
+
+/** sessionStorage key for the redirect-back URL captured at gate time. */
+const ORIGIN_PATH_KEY = "atlas:mfa-origin-path";
+
+interface MfaGateState {
+  /** Where the API told us to send the user. Always `/admin/settings/security` today. */
+  enrollmentUrl: string;
+}
+
+export interface MfaGateContextValue {
+  /** Non-null while the dialog should be open. */
+  state: MfaGateState | null;
+  /**
+   * Open the dialog. No-op when:
+   * - The user is already on the enrollment page (pathname prefix match).
+   * - The dialog is already open (idempotent — concurrent failed fetches
+   *   shouldn't re-stash origin paths or flicker the dialog).
+   */
+  trigger: (enrollmentUrl: string) => void;
+  /** Close the dialog. Used by the dialog itself + reset hooks in tests. */
+  clear: () => void;
+}
+
+const MfaGateContext = createContext<MfaGateContextValue | null>(null);
+
+/**
+ * Read + clear the origin path captured when the gate fired. Called by the
+ * security page after enrollment so the user lands back where they were.
+ * Returns `null` when no origin was stashed (e.g. the user navigated to
+ * `/admin/settings/security` directly).
+ */
+export function consumeOriginPath(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const value = window.sessionStorage.getItem(ORIGIN_PATH_KEY);
+    if (value) {
+      window.sessionStorage.removeItem(ORIGIN_PATH_KEY);
+    }
+    return value;
+  } catch {
+    // sessionStorage can throw in private browsing on some browsers.
+    // The redirect-back is a UX nicety — fail open.
+    return null;
+  }
+}
+
+export function MfaGateProvider({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const [state, setState] = useState<MfaGateState | null>(null);
+
+  const trigger = useCallback(
+    (enrollmentUrl: string) => {
+      // Skip when already on the enrollment page so the page's own fetches
+      // can't re-arm the dialog and trap the user on the destination.
+      if (pathname?.startsWith(ENROLLMENT_PATH_PREFIX)) return;
+
+      // Idempotent: the first failed fetch wins. Concurrent fan-out
+      // (parallel admin queries on a fresh page load) shouldn't stomp the
+      // origin path that the first failure captured.
+      setState((prev) => {
+        if (prev) return prev;
+        if (typeof window !== "undefined") {
+          try {
+            const origin = pathname ?? window.location.pathname;
+            window.sessionStorage.setItem(ORIGIN_PATH_KEY, origin);
+          } catch {
+            // sessionStorage write can throw in private mode — the dialog
+            // still opens, the user just doesn't get the redirect-back nicety.
+          }
+        }
+        return { enrollmentUrl };
+      });
+    },
+    [pathname],
+  );
+
+  const clear = useCallback(() => {
+    setState(null);
+  }, []);
+
+  const value = useMemo<MfaGateContextValue>(
+    () => ({ state, trigger, clear }),
+    [state, trigger, clear],
+  );
+
+  return <MfaGateContext.Provider value={value}>{children}</MfaGateContext.Provider>;
+}
+
+/**
+ * Read the MFA gate. Throws if used outside `MfaGateProvider` — every admin
+ * surface mounts the provider, so a missing one is a wiring bug worth
+ * surfacing loudly rather than silently no-op-ing the dialog.
+ *
+ * Public-page consumers that don't have the provider mounted (e.g. shared
+ * conversation views) should use {@link useMfaGateOptional} instead.
+ */
+export function useMfaGate(): MfaGateContextValue {
+  const ctx = useContext(MfaGateContext);
+  if (!ctx) {
+    throw new Error(
+      "useMfaGate must be used inside <MfaGateProvider>. Mount it in the admin layout.",
+    );
+  }
+  return ctx;
+}
+
+/**
+ * Optional variant for hook call sites that may run on either an admin or
+ * non-admin surface. Returns a no-op gate when the provider is missing so
+ * `useAdminFetch` / `useAdminMutation` can be used outside the admin tree
+ * (e.g. embedded in the chat) without throwing on every fetch.
+ */
+export function useMfaGateOptional(): MfaGateContextValue {
+  const ctx = useContext(MfaGateContext);
+  return ctx ?? NOOP_GATE;
+}
+
+const NOOP_GATE: MfaGateContextValue = {
+  state: null,
+  trigger: () => {},
+  clear: () => {},
+};

--- a/packages/web/src/ui/components/admin/mfa-gate-context.tsx
+++ b/packages/web/src/ui/components/admin/mfa-gate-context.tsx
@@ -1,23 +1,18 @@
 "use client";
 
 /**
- * MFA enrollment gate state — shared across `useAdminFetch` /
- * `useAdminMutation` (which detect `mfa_enrollment_required` 403s) and the
- * dialog mounted in `AdminLayout` (which renders the modal). Keeps the
- * dispatch path React-idiomatic and testable: hooks call
- * `useMfaGate().trigger(...)`, the dialog reads from the same context, no
- * `window` events flying around. See #2081.
+ * Shared state for the MFA enrollment gate. Hook layer dispatches via
+ * `trigger()`; `MfaEnrollmentDialog` reads the same state and renders the
+ * modal.
  *
- * The provider also handles two policies that don't belong in either the
- * hook layer or the dialog:
+ * Two policies that don't belong in either the hook layer or the dialog:
  *
  * 1. **Skip on the enrollment page.** When pathname starts with
- *    `/admin/settings/security`, `trigger` is a no-op. Otherwise the
- *    page's own pre-enroll fetches (which may transitively go through
- *    `useAdminFetch` someday) would re-arm the dialog and trap the user
- *    on the page they are already on.
+ *    `/admin/settings/security`, `trigger` is a no-op. Otherwise a
+ *    pre-enroll fetch on that page could re-arm the dialog and trap the
+ *    user on the page they need to complete enrollment on.
  * 2. **Capture origin path for redirect-back.** Stash the URL that fired
- *    the gate into `sessionStorage` so the security page can bounce the
+ *    the gate in `sessionStorage` so the security page can bounce the
  *    user back after enrollment completes. `consumeOriginPath()` reads +
  *    clears the slot atomically.
  */
@@ -58,12 +53,7 @@ export interface MfaGateContextValue {
 
 const MfaGateContext = createContext<MfaGateContextValue | null>(null);
 
-/**
- * Read + clear the origin path captured when the gate fired. Called by the
- * security page after enrollment so the user lands back where they were.
- * Returns `null` when no origin was stashed (e.g. the user navigated to
- * `/admin/settings/security` directly).
- */
+/** Read + clear the origin path. Null when no origin was captured (direct nav). */
 export function consumeOriginPath(): string | null {
   if (typeof window === "undefined") return null;
   try {
@@ -73,8 +63,8 @@ export function consumeOriginPath(): string | null {
     }
     return value;
   } catch {
-    // sessionStorage can throw in private browsing on some browsers.
-    // The redirect-back is a UX nicety — fail open.
+    // intentionally ignored: sessionStorage throws in private browsing on
+    // some browsers; the redirect-back is a UX nicety, fail open.
     return null;
   }
 }
@@ -99,8 +89,9 @@ export function MfaGateProvider({ children }: { children: ReactNode }) {
             const origin = pathname ?? window.location.pathname;
             window.sessionStorage.setItem(ORIGIN_PATH_KEY, origin);
           } catch {
-            // sessionStorage write can throw in private mode — the dialog
-            // still opens, the user just doesn't get the redirect-back nicety.
+            // intentionally ignored: sessionStorage write can throw in
+            // private mode; the dialog still opens, the user just doesn't
+            // get the redirect-back nicety.
           }
         }
         return { enrollmentUrl };
@@ -152,6 +143,19 @@ export function useMfaGateOptional(): MfaGateContextValue {
 
 const NOOP_GATE: MfaGateContextValue = {
   state: null,
-  trigger: () => {},
+  trigger: (enrollmentUrl: string) => {
+    // The optional variant exists so non-admin surfaces (chat, embedded
+    // widget) can use the admin hooks without a provider. But an admin
+    // page that forgot to mount the provider would also land here and
+    // silently never open the dialog — surface that wiring bug in dev
+    // builds without changing runtime behavior. Production stays silent
+    // so the no-op stays cheap on the embedded path.
+    if (process.env.NODE_ENV !== "production") {
+      console.warn(
+        `[mfa-gate] trigger called outside MfaGateProvider — dialog won't open. ` +
+          `enrollmentUrl=${enrollmentUrl}. Mount <MfaGateProvider> in this tree if the dialog UX is desired.`,
+      );
+    }
+  },
   clear: () => {},
 };

--- a/packages/web/src/ui/components/admin/queue/__tests__/reason-dialog.test.tsx
+++ b/packages/web/src/ui/components/admin/queue/__tests__/reason-dialog.test.tsx
@@ -284,17 +284,35 @@ describe("ReasonDialog mutationError without feature (#1652, #1716)", () => {
     expect(text).not.toContain("enterprise");
   });
 
-  test("friendlyError's 403 mapping still applies in the feature-less fallback", () => {
-    // A 403 arriving without a feature still gets `friendlyError`'s
-    // admin-role translation — proof the structured status survives the
-    // fallback path even though we lose the EnterpriseUpsell routing.
+  test("server-typed 403 message reaches the user in the feature-less fallback", () => {
+    // Post-#2081 the server message wins over canned 403 copy — proof
+    // the structured FetchError survives the fallback path even though
+    // we lose the EnterpriseUpsell routing. The canned "Access denied"
+    // text now only appears for empty-body 403s.
     render(
       <ReasonDialog
         open
         onOpenChange={() => {}}
         title="Deny"
         onConfirm={async () => {}}
-        mutationError={{ message: "Forbidden", status: 403 }}
+        mutationError={{ message: "Forbidden by policy.", status: 403 }}
+      />,
+    );
+    const text = errorText() ?? "";
+    expect(text).toContain("Forbidden by policy.");
+  });
+
+  test("canned 403 copy still fires when 403 body is empty", () => {
+    // `extractFetchError` substitutes `HTTP 403` when the response body
+    // had no usable message — `friendlyError` swaps in the canned copy
+    // so the user doesn't see the placeholder.
+    render(
+      <ReasonDialog
+        open
+        onOpenChange={() => {}}
+        title="Deny"
+        onConfirm={async () => {}}
+        mutationError={{ message: "HTTP 403", status: 403 }}
       />,
     );
     const text = errorText() ?? "";

--- a/packages/web/src/ui/components/admin/security/two-factor-setup.tsx
+++ b/packages/web/src/ui/components/admin/security/two-factor-setup.tsx
@@ -353,10 +353,6 @@ export function TwoFactorSetup({ enabled, onChange }: TwoFactorSetupProps) {
     }
     reset();
     onChange?.();
-    // If the user landed here via the MFA gate, send them back to where
-    // they were trying to go. `consumeOriginPath` reads + clears the
-    // sessionStorage slot atomically; a null return means they navigated
-    // here directly (settings menu) and stays on the security page.
     // Skip self-redirects so a fresh enrollment from /admin/settings/security
     // doesn't no-op into a router.push to the same path.
     const origin = consumeOriginPath();

--- a/packages/web/src/ui/components/admin/security/two-factor-setup.tsx
+++ b/packages/web/src/ui/components/admin/security/two-factor-setup.tsx
@@ -26,7 +26,9 @@
  */
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { authClient } from "@/lib/auth/client";
+import { consumeOriginPath } from "@/ui/components/admin/mfa-gate-context";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -299,6 +301,7 @@ function logFailure(action: string, raw: ClientResult<unknown>["error"]): void {
 }
 
 export function TwoFactorSetup({ enabled, onChange }: TwoFactorSetupProps) {
+  const router = useRouter();
   const [stage, setStage] = useState<EnrollStage>({ kind: "idle" });
   const [password, setPassword] = useState("");
   const [code, setCode] = useState("");
@@ -350,6 +353,16 @@ export function TwoFactorSetup({ enabled, onChange }: TwoFactorSetupProps) {
     }
     reset();
     onChange?.();
+    // If the user landed here via the MFA gate, send them back to where
+    // they were trying to go. `consumeOriginPath` reads + clears the
+    // sessionStorage slot atomically; a null return means they navigated
+    // here directly (settings menu) and stays on the security page.
+    // Skip self-redirects so a fresh enrollment from /admin/settings/security
+    // doesn't no-op into a router.push to the same path.
+    const origin = consumeOriginPath();
+    if (origin && !origin.startsWith("/admin/settings/security")) {
+      router.push(origin);
+    }
   }
 
   async function handleRegenerate() {

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -849,7 +849,11 @@ export function AtlasChat() {
         getCredentials={getCredentials}
       />
       <ChangePasswordDialog
-        open={!passwordDialogDismissed && (passwordData?.passwordChangeRequired ?? false)}
+        open={
+          !passwordDialogDismissed &&
+          passwordData?.kind === "allowed" &&
+          passwordData.passwordChangeRequired
+        }
         onComplete={() => setPasswordDialogDismissed(true)}
       />
     </>

--- a/packages/web/src/ui/hooks/use-admin-fetch.ts
+++ b/packages/web/src/ui/hooks/use-admin-fetch.ts
@@ -6,10 +6,20 @@ import type { z } from "zod";
 import { useAtlasConfig } from "@/ui/context";
 import { buildFetchError, extractFetchError, type FetchError } from "@/ui/lib/fetch-error";
 import { ADMIN_FETCH_QUERY_KEY } from "@/ui/hooks/admin-query-keys";
+import { useMfaGateOptional } from "@/ui/components/admin/mfa-gate-context";
 
 // Re-export from @/ui/lib/fetch-error (canonical location) for backward
 // compatibility. New code should import directly from @/ui/lib/fetch-error.
 export { type FetchError, friendlyError } from "@/ui/lib/fetch-error";
+
+/**
+ * Default redirect target when the server didn't include `enrollmentUrl`
+ * on the `mfa_enrollment_required` body. Mirrors `ENROLLMENT_URL` in
+ * `packages/api/src/api/routes/admin-mfa-required.ts` — drift between the
+ * two is a one-line fix when the server-side path moves, so a shared
+ * source of truth isn't worth the cross-package import.
+ */
+const DEFAULT_ENROLLMENT_URL = "/admin/settings/security";
 
 /**
  * Shared fetch hook for admin pages.
@@ -36,6 +46,14 @@ export function useAdminFetch<T>(
   // Ref to avoid stale closure if isCrossOrigin changes at runtime.
   const credentialsRef = useRef(credentials);
   credentialsRef.current = credentials;
+
+  // MFA gate dispatcher — `useMfaGateOptional` returns a no-op gate when
+  // the provider isn't mounted (e.g. embedded chat surfaces), so this hook
+  // remains safe outside the admin tree. Capture in a ref so the queryFn
+  // can dispatch without being torn apart by render churn.
+  const mfaGate = useMfaGateOptional();
+  const mfaGateRef = useRef(mfaGate);
+  mfaGateRef.current = mfaGate;
 
   // Manual error override — exposed via setError for backward compatibility.
   const [errorOverride, setErrorOverride] = useState<FetchError | null>(null);
@@ -67,7 +85,17 @@ export function useAdminFetch<T>(
       }
 
       if (!res.ok) {
-        throw await extractFetchError(res);
+        const fetchError = await extractFetchError(res);
+        // Dispatch the MFA gate before throwing so the dialog opens even
+        // for in-flight queries — the thrown error still surfaces in the
+        // page's `error` state, but with the dialog mounted on top the
+        // friendly message becomes informational rather than the only UI.
+        if (fetchError.code === "mfa_enrollment_required") {
+          mfaGateRef.current.trigger(
+            fetchError.enrollmentUrl ?? DEFAULT_ENROLLMENT_URL,
+          );
+        }
+        throw fetchError;
       }
       const json: unknown = await res.json();
 

--- a/packages/web/src/ui/hooks/use-admin-fetch.ts
+++ b/packages/web/src/ui/hooks/use-admin-fetch.ts
@@ -12,13 +12,9 @@ import { useMfaGateOptional } from "@/ui/components/admin/mfa-gate-context";
 // compatibility. New code should import directly from @/ui/lib/fetch-error.
 export { type FetchError, friendlyError } from "@/ui/lib/fetch-error";
 
-/**
- * Default redirect target when the server didn't include `enrollmentUrl`
- * on the `mfa_enrollment_required` body. Mirrors `ENROLLMENT_URL` in
- * `packages/api/src/api/routes/admin-mfa-required.ts` — drift between the
- * two is a one-line fix when the server-side path moves, so a shared
- * source of truth isn't worth the cross-package import.
- */
+// Mirrors ENROLLMENT_URL in admin-mfa-required.ts; cross-package import
+// not worth it for one path. Used only when the server response body
+// lacks `enrollmentUrl`.
 const DEFAULT_ENROLLMENT_URL = "/admin/settings/security";
 
 /**
@@ -47,10 +43,8 @@ export function useAdminFetch<T>(
   const credentialsRef = useRef(credentials);
   credentialsRef.current = credentials;
 
-  // MFA gate dispatcher — `useMfaGateOptional` returns a no-op gate when
-  // the provider isn't mounted (e.g. embedded chat surfaces), so this hook
-  // remains safe outside the admin tree. Capture in a ref so the queryFn
-  // can dispatch without being torn apart by render churn.
+  // Optional gate: returns a no-op when the provider isn't mounted (chat
+  // surfaces). Ref keeps the queryFn stable.
   const mfaGate = useMfaGateOptional();
   const mfaGateRef = useRef(mfaGate);
   mfaGateRef.current = mfaGate;
@@ -86,10 +80,8 @@ export function useAdminFetch<T>(
 
       if (!res.ok) {
         const fetchError = await extractFetchError(res);
-        // Dispatch the MFA gate before throwing so the dialog opens even
-        // for in-flight queries — the thrown error still surfaces in the
-        // page's `error` state, but with the dialog mounted on top the
-        // friendly message becomes informational rather than the only UI.
+        // Open the dialog before throwing; the thrown error still surfaces
+        // in the page's error state.
         if (fetchError.code === "mfa_enrollment_required") {
           mfaGateRef.current.trigger(
             fetchError.enrollmentUrl ?? DEFAULT_ENROLLMENT_URL,

--- a/packages/web/src/ui/hooks/use-admin-mutation.ts
+++ b/packages/web/src/ui/hooks/use-admin-mutation.ts
@@ -5,6 +5,15 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAtlasConfig } from "@/ui/context";
 import { buildFetchError, extractFetchError, type FetchError } from "@/ui/lib/fetch-error";
 import { ADMIN_FETCH_QUERY_KEY } from "@/ui/hooks/admin-query-keys";
+import { useMfaGateOptional } from "@/ui/components/admin/mfa-gate-context";
+
+/**
+ * Default redirect target when the server didn't include `enrollmentUrl`
+ * on the `mfa_enrollment_required` body. Mirrors the constant in
+ * `use-admin-fetch.ts` and `ENROLLMENT_URL` in
+ * `packages/api/src/api/routes/admin-mfa-required.ts`.
+ */
+const DEFAULT_ENROLLMENT_URL = "/admin/settings/security";
 
 /** HTTP methods supported by admin mutations. */
 type MutationMethod = "POST" | "PUT" | "PATCH" | "DELETE";
@@ -120,6 +129,14 @@ export function useAdminMutation<TResponse = unknown>(
   const { apiUrl, isCrossOrigin } = useAtlasConfig();
   const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
   const queryClient = useQueryClient();
+
+  // MFA gate dispatcher — `useMfaGateOptional` returns a no-op gate when
+  // the provider isn't mounted, so this hook stays safe outside the admin
+  // tree. Captured in a ref so the mutationFn can dispatch through render
+  // churn without recreating the mutation.
+  const mfaGate = useMfaGateOptional();
+  const mfaGateRef = useRef(mfaGate);
+  mfaGateRef.current = mfaGate;
 
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<FetchError | null>(null);
@@ -262,6 +279,15 @@ export function useAdminMutation<TResponse = unknown>(
 
       if (!res.ok) {
         const fetchError = await extractFetchError(res);
+        // Dispatch the MFA gate alongside the throw so write-path callers
+        // surface the dialog the same way read-path callers do. Without
+        // this, an admin-mutation 403 would set hook-level `error` and
+        // render a banner instead of opening the modal.
+        if (fetchError.code === "mfa_enrollment_required") {
+          mfaGateRef.current.trigger(
+            fetchError.enrollmentUrl ?? DEFAULT_ENROLLMENT_URL,
+          );
+        }
         // Preserve the structured FetchError across the throw boundary so the
         // catch in `mutate()` can return it as `MutateResult.error`. The bare
         // `Error.message` is kept human-readable as a fallback for anything

--- a/packages/web/src/ui/hooks/use-admin-mutation.ts
+++ b/packages/web/src/ui/hooks/use-admin-mutation.ts
@@ -7,12 +7,7 @@ import { buildFetchError, extractFetchError, type FetchError } from "@/ui/lib/fe
 import { ADMIN_FETCH_QUERY_KEY } from "@/ui/hooks/admin-query-keys";
 import { useMfaGateOptional } from "@/ui/components/admin/mfa-gate-context";
 
-/**
- * Default redirect target when the server didn't include `enrollmentUrl`
- * on the `mfa_enrollment_required` body. Mirrors the constant in
- * `use-admin-fetch.ts` and `ENROLLMENT_URL` in
- * `packages/api/src/api/routes/admin-mfa-required.ts`.
- */
+// See use-admin-fetch.ts for rationale.
 const DEFAULT_ENROLLMENT_URL = "/admin/settings/security";
 
 /** HTTP methods supported by admin mutations. */
@@ -130,10 +125,8 @@ export function useAdminMutation<TResponse = unknown>(
   const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
   const queryClient = useQueryClient();
 
-  // MFA gate dispatcher — `useMfaGateOptional` returns a no-op gate when
-  // the provider isn't mounted, so this hook stays safe outside the admin
-  // tree. Captured in a ref so the mutationFn can dispatch through render
-  // churn without recreating the mutation.
+  // Optional gate: returns a no-op when the provider isn't mounted (chat
+  // surfaces). Ref keeps the mutationFn stable.
   const mfaGate = useMfaGateOptional();
   const mfaGateRef = useRef(mfaGate);
   mfaGateRef.current = mfaGate;
@@ -279,10 +272,7 @@ export function useAdminMutation<TResponse = unknown>(
 
       if (!res.ok) {
         const fetchError = await extractFetchError(res);
-        // Dispatch the MFA gate alongside the throw so write-path callers
-        // surface the dialog the same way read-path callers do. Without
-        // this, an admin-mutation 403 would set hook-level `error` and
-        // render a banner instead of opening the modal.
+        // Open the dialog so the write path opens it too, not just the read path.
         if (fetchError.code === "mfa_enrollment_required") {
           mfaGateRef.current.trigger(
             fetchError.enrollmentUrl ?? DEFAULT_ENROLLMENT_URL,

--- a/packages/web/src/ui/hooks/use-password-status.ts
+++ b/packages/web/src/ui/hooks/use-password-status.ts
@@ -3,22 +3,36 @@
 import { useQuery } from "@tanstack/react-query";
 import { useAtlasConfig } from "@/ui/context";
 
-interface PasswordStatusResult {
-  /** Whether the user has admin access (password-status endpoint returned 200). */
-  allowed: boolean;
-  /** Whether the user needs to change their default password. */
-  passwordChangeRequired: boolean;
+/**
+ * Discriminated result so consumers can distinguish a "not admin" 403 from
+ * an "MFA enrollment required" 403 — same status code, different UX.
+ *
+ * Today `/api/v1/admin/me/password-status` is mounted on the parent admin
+ * router (admin.ts) which is NOT gated by `mfaRequired`, so the
+ * `mfa-required` branch is defensive: if the route ever moves or the gate
+ * extends, AdminLayout would otherwise render the bad "Access denied"
+ * Card on a missing-second-factor admin (the symptom #2081 fixed).
+ */
+export type PasswordStatusResult =
+  | { kind: "allowed"; passwordChangeRequired: boolean }
+  | { kind: "denied" }
+  | { kind: "mfa-required"; enrollmentUrl: string };
+
+interface MfaErrorBody {
+  error?: string;
+  enrollmentUrl?: string;
 }
 
 /**
  * Checks admin access and password-change status via the password-status endpoint.
  *
- * Shared between AdminLayout (uses `allowed` for access gating) and AtlasChat
+ * Shared between AdminLayout (uses `kind` for access gating) and AtlasChat
  * (uses `passwordChangeRequired` for the change-password dialog). TanStack Query
  * deduplicates to a single request when both are mounted.
  *
  * Returns `isPending: true` until the check completes, `isError: true` on
- * transient failures (network, 500). Only 403 is treated as a definitive "denied".
+ * transient failures (network, 500). 403 resolves to either `denied` or
+ * `mfa-required` based on the body's typed error code.
  */
 export function usePasswordStatus(enabled: boolean) {
   const { apiUrl, isCrossOrigin } = useAtlasConfig();
@@ -39,9 +53,23 @@ export function usePasswordStatus(enabled: boolean) {
         throw new Error(msg || "Network error", { cause: err });
       }
 
-      // 403 = definitive denial (not admin). Don't throw — this is a valid result.
       if (res.status === 403) {
-        return { allowed: false, passwordChangeRequired: false };
+        // Inspect the typed error code so missing-second-factor 403s don't
+        // get classified the same as missing-role 403s. Body parse failures
+        // fall through to `denied` — the safer default for an unknown 403.
+        let body: MfaErrorBody = {};
+        try {
+          body = (await res.json()) as MfaErrorBody;
+        } catch {
+          // Non-JSON body — fall through to denied.
+        }
+        if (body.error === "mfa_enrollment_required") {
+          return {
+            kind: "mfa-required",
+            enrollmentUrl: body.enrollmentUrl ?? "/admin/settings/security",
+          };
+        }
+        return { kind: "denied" };
       }
 
       // Other non-ok = transient failure. Throw so TanStack retries.
@@ -52,7 +80,7 @@ export function usePasswordStatus(enabled: boolean) {
 
       const data: { passwordChangeRequired?: boolean } = await res.json();
       return {
-        allowed: true,
+        kind: "allowed",
         passwordChangeRequired: !!data.passwordChangeRequired,
       };
     },

--- a/packages/web/src/ui/hooks/use-password-status.ts
+++ b/packages/web/src/ui/hooks/use-password-status.ts
@@ -5,13 +5,9 @@ import { useAtlasConfig } from "@/ui/context";
 
 /**
  * Discriminated result so consumers can distinguish a "not admin" 403 from
- * an "MFA enrollment required" 403 — same status code, different UX.
- *
- * Today `/api/v1/admin/me/password-status` is mounted on the parent admin
- * router (admin.ts) which is NOT gated by `mfaRequired`, so the
- * `mfa-required` branch is defensive: if the route ever moves or the gate
- * extends, AdminLayout would otherwise render the bad "Access denied"
- * Card on a missing-second-factor admin (the symptom #2081 fixed).
+ * an "MFA enrollment required" 403. The `mfa-required` branch is defensive
+ * — the password-status endpoint is not currently behind `mfaRequired`,
+ * but classifying the typed body keeps AdminLayout correct if that changes.
  */
 export type PasswordStatusResult =
   | { kind: "allowed"; passwordChangeRequired: boolean }
@@ -61,7 +57,8 @@ export function usePasswordStatus(enabled: boolean) {
         try {
           body = (await res.json()) as MfaErrorBody;
         } catch {
-          // Non-JSON body — fall through to denied.
+          // intentionally ignored: non-JSON 403 body falls through to
+          // `denied`, the safer default for an unparseable forbidden response.
         }
         if (body.error === "mfa_enrollment_required") {
           return {

--- a/packages/web/src/ui/lib/fetch-error.ts
+++ b/packages/web/src/ui/lib/fetch-error.ts
@@ -6,12 +6,18 @@
  * `code` captures the machine-readable `error` field from the API's JSON body
  * (e.g. `"enterprise_required"`). Prefer branching on this over string-matching
  * the human-facing `message`.
+ *
+ * `enrollmentUrl` carries the server-provided redirect target for typed
+ * gate codes that ask the client to send the user somewhere (today only
+ * `mfa_enrollment_required`). Generic enough that a future
+ * `payment_required` 402 can reuse the same field for an upgrade URL.
  */
 export interface FetchError {
   message: string;
   status?: number;
   requestId?: string;
   code?: string;
+  enrollmentUrl?: string;
 }
 
 /**
@@ -34,6 +40,7 @@ export function buildFetchError(input: {
   status?: number;
   code?: string;
   requestId?: string;
+  enrollmentUrl?: string;
 }): FetchError {
   const message = input.message?.trim();
   if (!message) {
@@ -52,6 +59,7 @@ export function buildFetchError(input: {
       ...(input.status !== undefined && { status: input.status }),
       ...(input.code && { code: input.code }),
       ...(input.requestId && { requestId: input.requestId }),
+      ...(input.enrollmentUrl && { enrollmentUrl: input.enrollmentUrl }),
     };
   }
   return {
@@ -59,6 +67,7 @@ export function buildFetchError(input: {
     ...(input.status !== undefined && { status: input.status }),
     ...(input.code && { code: input.code }),
     ...(input.requestId && { requestId: input.requestId }),
+    ...(input.enrollmentUrl && { enrollmentUrl: input.enrollmentUrl }),
   };
 }
 
@@ -71,6 +80,7 @@ export async function extractFetchError(res: Response): Promise<FetchError> {
   let message: string | undefined;
   let requestId: string | undefined;
   let code: string | undefined;
+  let enrollmentUrl: string | undefined;
   try {
     const body: unknown = await res.json();
     if (typeof body === "object" && body !== null) {
@@ -85,6 +95,9 @@ export async function extractFetchError(res: Response): Promise<FetchError> {
       }
       if (typeof obj.requestId === "string") requestId = obj.requestId;
       if (typeof obj.error === "string") code = obj.error;
+      if (typeof obj.enrollmentUrl === "string" && obj.enrollmentUrl.length > 0) {
+        enrollmentUrl = obj.enrollmentUrl;
+      }
     }
   } catch (err) {
     // Non-JSON body is expected (SyntaxError, swallowed silently). Unexpected
@@ -107,6 +120,7 @@ export async function extractFetchError(res: Response): Promise<FetchError> {
     status: res.status,
     code,
     requestId,
+    enrollmentUrl,
   });
 }
 
@@ -128,28 +142,66 @@ export function friendlyErrorOrNull(err: FetchError | null | undefined): string 
 
 /**
  * Convert a FetchError into a user-friendly message.
- * Replaces known HTTP status codes (401, 403, 404, 503) with admin-specific
- * guidance; falls back to the raw error message for other codes or non-HTTP
- * errors. Appends request ID for log correlation when available.
+ *
+ * **Precedence — server message wins.** When the API returns a non-empty
+ * body message (paired with a typed `code`, e.g. `mfa_enrollment_required`,
+ * `enterprise_required`, `forbidden_role`), that text reaches the user
+ * verbatim — the alternative was the false "Admin role required" lie that
+ * #2081 fixed (an unenrolled admin saw a role-failure message even though
+ * the actual cause was a missing second factor).
+ *
+ * Canned 401/403/404/503 copy is the fallback for HTTP errors whose body
+ * is empty or non-JSON (`extractFetchError` substitutes `HTTP {status}` in
+ * that case — short-circuit the substitute back to the friendly text).
+ *
+ * Status-code mappings stay status-only (not code-only) so unknown 4xx/5xx
+ * with empty bodies still get reasonable copy; a dedicated `code` branch
+ * for one error would force every future code to opt in or get the canned
+ * fallback. Server-authored typed messages are the right shape — keep the
+ * API surface focused there, not in this file.
  */
 export function friendlyError(err: FetchError): string {
-  let msg: string;
   // Schema mismatch only wins for client-side parse failures (status undefined),
   // because the body parses as 200 OK but fails Zod — HTTP status alone can't
   // distinguish this case. Gating on `status === undefined` prevents an HTTP
   // error whose body happens to set `error: "schema_mismatch"` from masking
-  // the 401/403/404/503 mappings below — the 401 "sign in" message has to
-  // reach the user even if a misconfigured server tags the body that way.
-  if (err.code === "schema_mismatch" && err.status === undefined)
-    msg = "The server returned data this version of the app can't read. This usually means the server and app are out of sync — contact your administrator or try again later.";
-  else if (err.status === 401) msg = "Not authenticated. Please sign in.";
+  // the friendly mappings — the typed mismatch copy is for the no-status path.
+  if (err.code === "schema_mismatch" && err.status === undefined) {
+    return appendRequestId(
+      "The server returned data this version of the app can't read. This usually means the server and app are out of sync — contact your administrator or try again later.",
+      err.requestId,
+    );
+  }
+
+  // Server-authored message wins on HTTP errors. `extractFetchError` only
+  // populates `message` from a non-empty body field, so any string here is a
+  // real server-typed message — render it. Canned text below covers the
+  // empty-body path where the message was substituted to `HTTP {status}`.
+  if (err.status !== undefined && !isHttpStatusFallback(err.message, err.status)) {
+    return appendRequestId(err.message, err.requestId);
+  }
+
+  let msg: string;
+  if (err.status === 401) msg = "Not authenticated. Please sign in.";
   else if (err.status === 403)
-    msg = "Access denied. Admin role required to view this page.";
+    msg = "Access denied. You may need additional permissions to view this page.";
   else if (err.status === 404)
     msg = "This feature is not enabled on this server.";
   else if (err.status === 503)
     msg = "A required service is unavailable. Check server configuration.";
   else msg = err.message;
-  if (err.requestId) msg += ` (Request ID: ${err.requestId})`;
-  return msg;
+  return appendRequestId(msg, err.requestId);
+}
+
+/**
+ * Detect the `HTTP {status}` substitute that {@link extractFetchError}
+ * produces when the response body has no usable message field. Anything
+ * else is real server text and should reach the user verbatim.
+ */
+function isHttpStatusFallback(message: string, status: number): boolean {
+  return message === `HTTP ${status}`;
+}
+
+function appendRequestId(message: string, requestId: string | undefined): string {
+  return requestId ? `${message} (Request ID: ${requestId})` : message;
 }

--- a/packages/web/src/ui/lib/fetch-error.ts
+++ b/packages/web/src/ui/lib/fetch-error.ts
@@ -7,10 +7,12 @@
  * (e.g. `"enterprise_required"`). Prefer branching on this over string-matching
  * the human-facing `message`.
  *
- * `enrollmentUrl` carries the server-provided redirect target for typed
- * gate codes that ask the client to send the user somewhere (today only
- * `mfa_enrollment_required`). Generic enough that a future
- * `payment_required` 402 can reuse the same field for an upgrade URL.
+ * `enrollmentUrl` is enrollment-specific — populated only when `code` is
+ * `mfa_enrollment_required`. A future typed code that needs its own
+ * redirect target (e.g. `payment_required` → upgrade URL) should add a
+ * dedicated field rather than reuse this one. Reusing the field for a
+ * non-enrollment redirect would mislead readers and shadow the existing
+ * one when both codes coexist on the wire.
  */
 export interface FetchError {
   message: string;
@@ -143,22 +145,12 @@ export function friendlyErrorOrNull(err: FetchError | null | undefined): string 
 /**
  * Convert a FetchError into a user-friendly message.
  *
- * **Precedence — server message wins.** When the API returns a non-empty
- * body message (paired with a typed `code`, e.g. `mfa_enrollment_required`,
- * `enterprise_required`, `forbidden_role`), that text reaches the user
- * verbatim — the alternative was the false "Admin role required" lie that
- * #2081 fixed (an unenrolled admin saw a role-failure message even though
- * the actual cause was a missing second factor).
- *
- * Canned 401/403/404/503 copy is the fallback for HTTP errors whose body
- * is empty or non-JSON (`extractFetchError` substitutes `HTTP {status}` in
- * that case — short-circuit the substitute back to the friendly text).
- *
- * Status-code mappings stay status-only (not code-only) so unknown 4xx/5xx
- * with empty bodies still get reasonable copy; a dedicated `code` branch
- * for one error would force every future code to opt in or get the canned
- * fallback. Server-authored typed messages are the right shape — keep the
- * API surface focused there, not in this file.
+ * Precedence: a non-empty server-typed message wins over the canned
+ * status copy. `extractFetchError` only populates `message` from a real
+ * body field, so any string here is server-authored — render it verbatim.
+ * The status-code branches are the empty-body fallback;
+ * `extractFetchError` substitutes `HTTP {status}` there, which
+ * `isHttpStatusFallback` round-trips back to the friendly text.
  */
 export function friendlyError(err: FetchError): string {
   // Schema mismatch only wins for client-side parse failures (status undefined),
@@ -193,11 +185,6 @@ export function friendlyError(err: FetchError): string {
   return appendRequestId(msg, err.requestId);
 }
 
-/**
- * Detect the `HTTP {status}` substitute that {@link extractFetchError}
- * produces when the response body has no usable message field. Anything
- * else is real server text and should reach the user verbatim.
- */
 function isHttpStatusFallback(message: string, status: number): boolean {
   return message === `HTTP ${status}`;
 }


### PR DESCRIPTION
## Summary

- **friendlyError precedence flip.** Server-authored body messages now reach the user verbatim on 401/403/404/503 (`mfa_enrollment_required`, `enterprise_required`, `forbidden_role`, etc.). The canned "Admin role required" lie that misrendered every MFA gate fired only because the helper masked typed messages — now it fires only on empty bodies (`HTTP {status}` placeholder).
- **Global MFA enrollment dialog.** New `MfaGateContext` provider mounted in `AdminLayout` collects `mfa_enrollment_required` dispatches from `useAdminFetch` / `useAdminMutation` and renders a non-dismissable `MfaEnrollmentDialog`. Origin path stashed in sessionStorage so the security page bounces the user back after enrollment.
- **Drive-bys:** `usePasswordStatus` returns a discriminated `kind` (`allowed` / `denied` / `mfa-required`) so a future regression that gates the route can't silently re-introduce the broken "Access denied" Card. `admin-mfa-required.ts` docstring spells out the three deliberate carve-outs (Better Auth `/api/auth/*`, parent admin router with per-handler auth, Next.js security page).

## Files of note

- `packages/web/src/ui/lib/fetch-error.ts` — precedence flip + new `enrollmentUrl` field on `FetchError`.
- `packages/web/src/ui/components/admin/mfa-gate-context.tsx` (new) — `MfaGateProvider`, `useMfaGate` / `useMfaGateOptional`, `consumeOriginPath`.
- `packages/web/src/ui/components/admin/mfa-enrollment-dialog.tsx` (new) — non-dismissable `AlertDialog`, "Enroll authenticator" / "Sign out".
- `packages/web/src/ui/components/admin/admin-layout.tsx` — wraps tree in provider, mounts dialog, new `mfa-required` admin-check branch.
- `packages/web/src/ui/hooks/use-admin-fetch.ts` / `use-admin-mutation.ts` — dispatch the gate when the typed code lands.
- `packages/web/src/ui/hooks/use-password-status.ts` — discriminated result.
- `packages/web/src/ui/components/admin/security/two-factor-setup.tsx` — `consumeOriginPath()` on enroll success → `router.push` back.

## Test plan

- [x] `bun run lint` — passes
- [x] `bun run type` — passes
- [x] `bun run test` — passes (all packages)
- [x] `bun x syncpack lint` — passes
- [x] Template drift, security headers drift, railway-watch — pass
- [x] `fetch-error.test.ts` — 12 new/updated cases (precedence flip, empty-body fallback, requestId append on both paths, schema_mismatch interaction)
- [x] `admin-layout.test.tsx` — 2 new cases: regression guard against the bad Card on `mfa_enrollment_required`, dialog opens on the same response
- [x] `use-admin-fetch.test.ts` + `reason-dialog.test.tsx` — old "Admin role required" assertions replaced with explicit empty-body fallback + server-typed message wins tests
- [x] API: `admin-mfa-required.test.ts` unchanged, still green (gate's wire shape unchanged)
- [ ] Manual: log into `app.useatlas.dev` as an unenrolled admin → expect MFA dialog with "Enroll authenticator" / "Sign out" instead of "Admin role required" Card
- [ ] Manual: click "Enroll authenticator" → land on security page → complete TOTP → land back on the originating page

Closes #2081