### PR TITLE
fix(web): center MFA enrollment dialog title

### DIFF
--- a/packages/web/src/ui/components/admin/mfa-enrollment-dialog.tsx
+++ b/packages/web/src/ui/components/admin/mfa-enrollment-dialog.tsx
@@ -60,14 +60,22 @@ export function MfaEnrollmentDialog() {
         className="sm:max-w-md"
         onEscapeKeyDown={(e) => e.preventDefault()}
       >
+        {/*
+         * shadcn's AlertDialogHeader switches to `sm:place-items-start
+         * sm:text-left` at the `sm:` breakpoint when the content size is
+         * `default`. The title's grid cell shrink-wraps and pins to the
+         * left, so a bare `text-center` on the title doesn't visually
+         * center it. `w-full` on Title + Description makes each fill its
+         * grid cell so the inline `text-center` lands.
+         */}
         <AlertDialogHeader>
           <div className="mx-auto mb-2 flex size-12 items-center justify-center rounded-lg bg-amber-500/10">
             <ShieldAlert className="size-6 text-amber-600 dark:text-amber-400" />
           </div>
-          <AlertDialogTitle className="text-center">
+          <AlertDialogTitle className="w-full text-center">
             Two-factor authentication required
           </AlertDialogTitle>
-          <AlertDialogDescription className="text-center">
+          <AlertDialogDescription className="w-full text-center">
             Admin accounts must enroll a second factor before accessing the
             admin console. Set up an authenticator app to continue.
           </AlertDialogDescription>


### PR DESCRIPTION
## Summary

The title in `MfaEnrollmentDialog` rendered left-aligned at the `sm:` breakpoint while the description and icon were centered. shadcn's `AlertDialogHeader` switches to `sm:place-items-start sm:text-left` for default-size content, which shrink-wraps the title's grid cell and pins it to the start — so `text-center` on the title centers inline text within an already-shrunk left-pinned box, producing no visual change.

Adding `w-full` to Title + Description makes each fill its grid cell, so the existing `text-center` lands and the icon / title / description column reads as one centered stack.

Followup to #2081 — surfaced after merge during a manual UI check.

## Test plan

- [x] `bun run lint` — passes
- [x] `bun run type` — passes
- [x] `mfa-enrollment-dialog.test.tsx` — 4/4 pass (DOM-text assertions unaffected by alignment change)
- [ ] Manual: open the modal, confirm title and description are both center-aligned beneath the icon