### PR TITLE
feat(api): #2082 — passkey plugin + MFA gate accepts passkeys (PR A of D)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,11 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 #                                         # overridable via env by design.
 # ATLAS_MFA_ISSUER=Atlas                  # Issuer label shown in TOTP authenticator apps when users
 #                                         # enroll an MFA device. Default: "Atlas".
+# ATLAS_RPID=app.useatlas.dev             # WebAuthn Relying Party ID — the registrable domain that
+#                                         # passkeys are bound to. Self-hosted: set to your auth domain.
+#                                         # Changing this AFTER passkeys are enrolled invalidates them.
+# ATLAS_RPNAME=Atlas                      # Human-readable string the OS shows in the passkey prompt
+#                                         # ("Use your saved passkey for <ATLAS_RPNAME>?"). Default: "Atlas".
 # ATLAS_ABUSE_QUERY_RATE=200              # Max queries per workspace per sliding window (abuse prevention)
 # ATLAS_ABUSE_WINDOW_SECONDS=300          # Sliding window duration in seconds
 # ATLAS_ABUSE_ERROR_RATE=0.5              # Max error rate (0-1) before escalation

--- a/bun.lock
+++ b/bun.lock
@@ -117,6 +117,7 @@
         "@atlas/mcp": "workspace:*",
         "@better-auth/api-key": "^1.6.9",
         "@better-auth/oauth-provider": "^1.6.9",
+        "@better-auth/passkey": "^1.6.9",
         "@better-auth/scim": "^1.6.9",
         "@better-auth/stripe": "^1.6.9",
         "@clickhouse/client": "^1.18.2",
@@ -948,6 +949,8 @@
 
     "@better-auth/oauth-provider": ["@better-auth/oauth-provider@1.6.9", "", { "dependencies": { "jose": "^6.1.3", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.6.9", "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21", "better-auth": "^1.6.9", "better-call": "1.3.5" } }, "sha512-GJCRDLu7xOc/HcAuQXaFZ9xZo8l3yLuc+1/vKYB5gh0O+owub+vLH88+AfNm/jMHZ084MSHpgkyxmEnmBXe4iQ=="],
 
+    "@better-auth/passkey": ["@better-auth/passkey@1.6.9", "", { "dependencies": { "@simplewebauthn/browser": "^13.2.2", "@simplewebauthn/server": "^13.2.3", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.6.9", "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21", "better-auth": "^1.6.9", "better-call": "1.3.5", "nanostores": "^1.0.1" } }, "sha512-MFpi+2G/pG2wVcTuL/PcnWxP2ddFL4jmFByTCbgvr61tp7u96d5liBptxpTqfS5IuCi2o8bBRmjiQnDZAvxmHg=="],
+
     "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.6.9", "", { "peerDependencies": { "@better-auth/core": "^1.6.9", "@better-auth/utils": "0.4.0", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-XHks01ntK20orqK/jICq8wmEbJ/zT6dct49Fk8zTQKN9QNGDc+Ix5+7z/Kvui0DXGFf790GfvRozquzaLtXa8Q=="],
 
     "@better-auth/scim": ["@better-auth/scim@1.6.9", "", { "dependencies": { "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.6.9", "@better-auth/utils": "0.4.0", "better-auth": "^1.6.9", "better-call": "1.3.5" } }, "sha512-RgrZMQ9xKT9o7hBDWdbPHUHjBJb8BndSvLj9b+yTTe2HPNFNkS+vmMzXc7Ntaxk49Nhd1gScaHUPKFJgNJVOog=="],
@@ -1184,6 +1187,8 @@
 
     "@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
 
+    "@hexagon/base64": ["@hexagon/base64@1.1.28", "", {}, "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw=="],
+
     "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
 
     "@hono/zod-openapi": ["@hono/zod-openapi@1.2.4", "", { "dependencies": { "@asteasolutions/zod-to-openapi": "^8.5.0", "@hono/zod-validator": "^0.7.6", "openapi3-ts": "^4.5.0" }, "peerDependencies": { "hono": ">=4.3.6", "zod": "^4.0.0" } }, "sha512-cZu71bpODTbtIDoUsIIYPrs58wJ565Tbg6FE+JshU0irBAd6KxrP+k62Amm/mjA7tTOQ3+ingODHKGFOnv+Ibw=="],
@@ -1285,6 +1290,8 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
+
+    "@levischuck/tiny-cbor": ["@levischuck/tiny-cbor@0.2.11", "", {}, "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow=="],
 
     "@linear/sdk": ["@linear/sdk@76.0.0", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.2.0" } }, "sha512-Xt0x5Kl6qBoWhGFypb8ykyP+c5kT7scmRPs1uJidSPOaRgkMJ/4y41QpmZCWCBUMmZtf/O0VktgQio6rLXT94w=="],
 
@@ -1475,6 +1482,32 @@
     "@parcel/watcher-win32-ia32": ["@parcel/watcher-win32-ia32@2.5.6", "", { "os": "win32", "cpu": "ia32" }, "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g=="],
 
     "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw=="],
+
+    "@peculiar/asn1-android": ["@peculiar/asn1-android@2.7.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-iD3VskhVQnM4nE3PN9cBdPTR7JrqZy3FYk+uD2CeG6DUqKoANqaEfx0f7izPmW+Qm5JBM35ek+viLCmjy18ByQ=="],
+
+    "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.7.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/asn1-x509": "^2.7.0", "@peculiar/asn1-x509-attr": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ=="],
+
+    "@peculiar/asn1-csr": ["@peculiar/asn1-csr@2.7.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/asn1-x509": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA=="],
+
+    "@peculiar/asn1-ecc": ["@peculiar/asn1-ecc@2.7.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/asn1-x509": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw=="],
+
+    "@peculiar/asn1-pfx": ["@peculiar/asn1-pfx@2.7.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.7.0", "@peculiar/asn1-pkcs8": "^2.7.0", "@peculiar/asn1-rsa": "^2.7.0", "@peculiar/asn1-schema": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA=="],
+
+    "@peculiar/asn1-pkcs8": ["@peculiar/asn1-pkcs8@2.7.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/asn1-x509": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw=="],
+
+    "@peculiar/asn1-pkcs9": ["@peculiar/asn1-pkcs9@2.7.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.7.0", "@peculiar/asn1-pfx": "^2.7.0", "@peculiar/asn1-pkcs8": "^2.7.0", "@peculiar/asn1-schema": "^2.7.0", "@peculiar/asn1-x509": "^2.7.0", "@peculiar/asn1-x509-attr": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew=="],
+
+    "@peculiar/asn1-rsa": ["@peculiar/asn1-rsa@2.7.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/asn1-x509": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ=="],
+
+    "@peculiar/asn1-schema": ["@peculiar/asn1-schema@2.7.0", "", { "dependencies": { "@peculiar/utils": "^2.0.2", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg=="],
+
+    "@peculiar/asn1-x509": ["@peculiar/asn1-x509@2.7.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/utils": "^2.0.2", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g=="],
+
+    "@peculiar/asn1-x509-attr": ["@peculiar/asn1-x509-attr@2.7.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/asn1-x509": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w=="],
+
+    "@peculiar/utils": ["@peculiar/utils@2.0.3", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ=="],
+
+    "@peculiar/x509": ["@peculiar/x509@1.14.3", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.0", "@peculiar/asn1-csr": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.0", "@peculiar/asn1-pkcs9": "^2.6.0", "@peculiar/asn1-rsa": "^2.6.0", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.0", "pvtsutils": "^1.3.6", "reflect-metadata": "^0.2.2", "tslib": "^2.8.1", "tsyringe": "^4.10.0" } }, "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA=="],
 
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
@@ -1735,6 +1768,10 @@
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
     "@shuding/opentype.js": ["@shuding/opentype.js@1.4.0-beta.0", "", { "dependencies": { "fflate": "^0.7.3", "string.prototype.codepointat": "^0.2.1" }, "bin": { "ot": "bin/ot" } }, "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA=="],
+
+    "@simplewebauthn/browser": ["@simplewebauthn/browser@13.3.0", "", {}, "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ=="],
+
+    "@simplewebauthn/server": ["@simplewebauthn/server@13.3.0", "", { "dependencies": { "@hexagon/base64": "^1.1.27", "@levischuck/tiny-cbor": "^0.2.2", "@peculiar/asn1-android": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.1", "@peculiar/asn1-rsa": "^2.6.1", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "@peculiar/x509": "^1.14.3" } }, "sha512-MLHYFrYG8/wK2i+86XMhiecK72nMaHKKt4bo+7Q1TbuG9iGjlSdfkPWKO5ZFE/BX+ygCJ7pr8H/AJeyAj1EaTQ=="],
 
     "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
@@ -2149,6 +2186,8 @@
     "asn1.js-rfc2560": ["asn1.js-rfc2560@5.0.1", "", { "dependencies": { "asn1.js-rfc5280": "^3.0.0" }, "peerDependencies": { "asn1.js": "^5.0.0" } }, "sha512-1PrVg6kuBziDN3PGFmRk3QrjpKvP9h/Hv5yMrFZvC1kpzP6dQRzf5BpKstANqHBkaOUmTpakJWhicTATOA/SbA=="],
 
     "asn1.js-rfc5280": ["asn1.js-rfc5280@3.0.0", "", { "dependencies": { "asn1.js": "^5.0.0" } }, "sha512-Y2LZPOWeZ6qehv698ZgOGGCZXBQShObWnGthTrIFlIQjuV1gg2B8QOhWFRExq/MR1VnPpIIe7P9vX2vElxv+Pg=="],
+
+    "asn1js": ["asn1js@3.0.10", "", { "dependencies": { "pvtsutils": "^1.3.6", "pvutils": "^1.1.5", "tslib": "^2.8.1" } }, "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg=="],
 
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
 
@@ -3554,6 +3593,10 @@
 
     "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
+    "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
+
+    "pvutils": ["pvutils@1.1.5", "", {}, "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="],
+
     "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
@@ -3635,6 +3678,8 @@
     "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
 
     "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
+
+    "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
 
     "refractor": ["refractor@5.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/prismjs": "^1.0.0", "hastscript": "^9.0.0", "parse-entities": "^4.0.0" } }, "sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw=="],
 
@@ -3955,6 +4000,8 @@
     "tsup": ["tsup@8.5.1", "", { "dependencies": { "bundle-require": "^5.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "consola": "^3.4.0", "debug": "^4.4.0", "esbuild": "^0.27.0", "fix-dts-default-cjs-exports": "^1.0.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.34.8", "source-map": "^0.7.6", "sucrase": "^3.35.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.11", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing=="],
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
+
+    "tsyringe": ["tsyringe@4.10.0", "", { "dependencies": { "tslib": "^1.9.3" } }, "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw=="],
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
@@ -4509,6 +4556,8 @@
     "tsx/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
     "tsx/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
     "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -35,6 +35,7 @@
     "@atlas/mcp": "workspace:*",
     "@better-auth/api-key": "^1.6.9",
     "@better-auth/oauth-provider": "^1.6.9",
+    "@better-auth/passkey": "^1.6.9",
     "@better-auth/scim": "^1.6.9",
     "@better-auth/stripe": "^1.6.9",
     "@clickhouse/client": "^1.18.2",

--- a/packages/api/src/api/routes/__tests__/admin-mfa-required.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-mfa-required.test.ts
@@ -3,7 +3,9 @@
  *
  * Covers the role × mode × enrollment-state matrix:
  *   - managed admin without MFA → 403 with mfa_enrollment_required
- *   - managed admin with MFA → pass-through
+ *   - managed admin with TOTP → pass-through
+ *   - managed admin with passkey only → pass-through (#2082)
+ *   - managed admin with both factors → pass-through
  *   - managed platform_admin without MFA → 403
  *   - managed owner without MFA → 403 (mirrors adminAuth's role admit-list)
  *   - managed member without MFA → pass-through (not enforced for members)
@@ -47,6 +49,7 @@ import type { AuthEnv } from "../middleware";
 interface FakeUserOpts {
   role?: "admin" | "platform_admin" | "member" | "owner";
   twoFactorEnabled?: boolean;
+  passkeyCount?: number;
 }
 
 function fakeAuthResult(opts: FakeUserOpts = {}): AuthResult & { authenticated: true } {
@@ -60,7 +63,10 @@ function fakeAuthResult(opts: FakeUserOpts = {}): AuthResult & { authenticated: 
       label: "test@atlas.dev",
       role,
       activeOrganizationId: "org-1",
-      claims: Object.freeze({ twoFactorEnabled: opts.twoFactorEnabled === true }),
+      claims: Object.freeze({
+        twoFactorEnabled: opts.twoFactorEnabled === true,
+        passkeyCount: opts.passkeyCount ?? 0,
+      }),
     },
   };
 }
@@ -161,6 +167,44 @@ describe("mfaRequired middleware", () => {
 
     const res = await app.request("/admin/anything");
     expect(res.status).toBe(200);
+  });
+
+  it("passes through when an admin user has only a passkey enrolled (no TOTP)", async () => {
+    // #2082 — passkey-only admins must be admitted. The gate accepts any
+    // strong second factor; before this issue the only acceptable factor
+    // was TOTP, which would have rejected this user with a 403.
+    const app = new OpenAPIHono<AuthEnv>();
+    injectAuth(app, fakeAuthResult({ role: "admin", twoFactorEnabled: false, passkeyCount: 1 }));
+    app.use(mfaRequired);
+    app.openapi(okRoute, (c) => c.json({ ok: true }, 200));
+
+    const res = await app.request("/admin/anything");
+    expect(res.status).toBe(200);
+  });
+
+  it("passes through when an admin user has both TOTP and passkeys enrolled", async () => {
+    const app = new OpenAPIHono<AuthEnv>();
+    injectAuth(app, fakeAuthResult({ role: "admin", twoFactorEnabled: true, passkeyCount: 2 }));
+    app.use(mfaRequired);
+    app.openapi(okRoute, (c) => c.json({ ok: true }, 200));
+
+    const res = await app.request("/admin/anything");
+    expect(res.status).toBe(200);
+  });
+
+  it("blocks when both factors are absent (twoFactorEnabled=false, passkeyCount=0)", async () => {
+    // The both-zero case is the canonical reject — admin with no second
+    // factor of any kind. Asserted explicitly so a regression where
+    // passkeyCount=0 accidentally short-circuits admit can't slip past.
+    const app = new OpenAPIHono<AuthEnv>();
+    injectAuth(app, fakeAuthResult({ role: "admin", twoFactorEnabled: false, passkeyCount: 0 }));
+    app.use(mfaRequired);
+    app.openapi(okRoute, (c) => c.json({ ok: true }, 200));
+
+    const res = await app.request("/admin/anything");
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("mfa_enrollment_required");
   });
 
   it("passes through when an owner user has MFA enrolled", async () => {
@@ -307,6 +351,48 @@ describe("mfaRequired middleware", () => {
 
     const res = await app.request("/admin/anything");
     expect(res.status).toBe(403);
+  });
+
+  it("treats passkeyCount values that aren't real positive numbers as not-enrolled", async () => {
+    // Symmetric to the twoFactorEnabled-as-string case. A future internal-DB
+    // shape change that surfaces COUNT(*) as a string ("1") instead of an
+    // integer must NOT silently admit users — the resolver in managed.ts
+    // already coerces, but the gate fail-closes as a second line of defense.
+    const cases: Array<{ name: string; value: unknown }> = [
+      { name: "string '1'", value: "1" as unknown as number },
+      { name: "string 'true'", value: "true" as unknown as number },
+      { name: "boolean true", value: true as unknown as number },
+      { name: "NaN", value: Number.NaN },
+      { name: "negative", value: -1 },
+      { name: "zero", value: 0 },
+    ];
+    for (const { value } of cases) {
+      const app = new OpenAPIHono<AuthEnv>();
+      app.use(
+        createMiddleware<AuthEnv>(async (c, next) => {
+          c.set("requestId", "test-req-id");
+          c.set("authResult", {
+            authenticated: true,
+            mode: "managed",
+            user: {
+              id: "user-1",
+              mode: "managed",
+              label: "test@atlas.dev",
+              role: "admin",
+              activeOrganizationId: "org-1",
+              claims: Object.freeze({ twoFactorEnabled: false, passkeyCount: value }),
+            },
+          });
+          c.set("atlasMode", "published");
+          await next();
+        }),
+      );
+      app.use(mfaRequired);
+      app.openapi(okRoute, (c) => c.json({ ok: true }, 200));
+
+      const res = await app.request("/admin/anything");
+      expect(res.status).toBe(403);
+    }
   });
 
   it("returns 500 auth_misconfigured when authResult is missing (middleware-order contract)", async () => {

--- a/packages/api/src/api/routes/__tests__/admin-mfa-required.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-mfa-required.test.ts
@@ -4,7 +4,7 @@
  * Covers the role × mode × enrollment-state matrix:
  *   - managed admin without MFA → 403 with mfa_enrollment_required
  *   - managed admin with TOTP → pass-through
- *   - managed admin with passkey only → pass-through (#2082)
+ *   - managed admin with passkey only → pass-through
  *   - managed admin with both factors → pass-through
  *   - managed platform_admin without MFA → 403
  *   - managed owner without MFA → 403 (mirrors adminAuth's role admit-list)
@@ -123,6 +123,8 @@ describe("mfaRequired middleware", () => {
     expect(body.requestId).toBe("test-req-id");
     expect(typeof body.message).toBe("string");
     expect((body.message as string).toLowerCase()).toContain("two-factor");
+    // Copy must mention both options so passkey-only users aren't told to set up TOTP.
+    expect((body.message as string).toLowerCase()).toMatch(/passkey/);
     // Lock the body shape — no leakage of internal fields like userId/role/claims.
     expect(Object.keys(body).toSorted()).toEqual(
       ["enrollmentUrl", "error", "message", "requestId"].toSorted(),
@@ -170,9 +172,6 @@ describe("mfaRequired middleware", () => {
   });
 
   it("passes through when an admin user has only a passkey enrolled (no TOTP)", async () => {
-    // #2082 — passkey-only admins must be admitted. The gate accepts any
-    // strong second factor; before this issue the only acceptable factor
-    // was TOTP, which would have rejected this user with a 403.
     const app = new OpenAPIHono<AuthEnv>();
     injectAuth(app, fakeAuthResult({ role: "admin", twoFactorEnabled: false, passkeyCount: 1 }));
     app.use(mfaRequired);
@@ -354,10 +353,8 @@ describe("mfaRequired middleware", () => {
   });
 
   it("treats passkeyCount values that aren't real positive numbers as not-enrolled", async () => {
-    // Symmetric to the twoFactorEnabled-as-string case. A future internal-DB
-    // shape change that surfaces COUNT(*) as a string ("1") instead of an
-    // integer must NOT silently admit users — the resolver in managed.ts
-    // already coerces, but the gate fail-closes as a second line of defense.
+    // Symmetric to the twoFactorEnabled-as-string case. The gate's strict
+    // narrowing is the load-bearing defense against shape drift.
     const cases: Array<{ name: string; value: unknown }> = [
       { name: "string '1'", value: "1" as unknown as number },
       { name: "string 'true'", value: "true" as unknown as number },
@@ -366,7 +363,7 @@ describe("mfaRequired middleware", () => {
       { name: "negative", value: -1 },
       { name: "zero", value: 0 },
     ];
-    for (const { value } of cases) {
+    for (const { name, value } of cases) {
       const app = new OpenAPIHono<AuthEnv>();
       app.use(
         createMiddleware<AuthEnv>(async (c, next) => {
@@ -391,8 +388,39 @@ describe("mfaRequired middleware", () => {
       app.openapi(okRoute, (c) => c.json({ ok: true }, 200));
 
       const res = await app.request("/admin/anything");
-      expect(res.status).toBe(403);
+      expect(res.status, `passkeyCount=${name} should reject`).toBe(403);
     }
+  });
+
+  it("treats claims with twoFactorEnabled=false and no passkeyCount field as not-enrolled", async () => {
+    // The gate must fail closed when `passkeyCount` is absent from claims —
+    // not just when its value is the wrong shape. Catches a future managed.ts
+    // refactor that stops writing the field under some code path.
+    const app = new OpenAPIHono<AuthEnv>();
+    app.use(
+      createMiddleware<AuthEnv>(async (c, next) => {
+        c.set("requestId", "test-req-id");
+        c.set("authResult", {
+          authenticated: true,
+          mode: "managed",
+          user: {
+            id: "user-1",
+            mode: "managed",
+            label: "test@atlas.dev",
+            role: "admin",
+            activeOrganizationId: "org-1",
+            claims: Object.freeze({ twoFactorEnabled: false }), // no passkeyCount key
+          },
+        });
+        c.set("atlasMode", "published");
+        await next();
+      }),
+    );
+    app.use(mfaRequired);
+    app.openapi(okRoute, (c) => c.json({ ok: true }, 200));
+
+    const res = await app.request("/admin/anything");
+    expect(res.status).toBe(403);
   });
 
   it("returns 500 auth_misconfigured when authResult is missing (middleware-order contract)", async () => {

--- a/packages/api/src/api/routes/admin-mfa-required.ts
+++ b/packages/api/src/api/routes/admin-mfa-required.ts
@@ -6,7 +6,7 @@
  * authenticates against an admin router, this middleware refuses to
  * serve any route until they have enrolled at least one strong second
  * factor — either TOTP via Better Auth's `twoFactor` plugin, or a WebAuthn
- * passkey via `@better-auth/passkey` (#2082).
+ * passkey via `@better-auth/passkey`.
  *
  * Apply downstream of {@link adminAuth} or {@link platformAdminAuth}: this
  * middleware reads `c.get("authResult")` and never re-authenticates.
@@ -177,7 +177,7 @@ export const mfaRequired = createMiddleware<AuthEnv>(async (c, next) => {
     {
       error: MFA_ENROLLMENT_REQUIRED,
       message:
-        "Two-factor authentication is required for admin accounts. Enroll a TOTP authenticator to continue.",
+        "Two-factor authentication is required for admin accounts. Enroll an authenticator app or passkey to continue.",
       enrollmentUrl: ENROLLMENT_URL,
       requestId,
     },

--- a/packages/api/src/api/routes/admin-mfa-required.ts
+++ b/packages/api/src/api/routes/admin-mfa-required.ts
@@ -4,7 +4,9 @@
  * Delivers the admin-MFA promise from `/privacy` §9 + `/dpa` Annex II
  * (#1925). When a user with role `admin`, `owner`, or `platform_admin`
  * authenticates against an admin router, this middleware refuses to
- * serve any route until they have enrolled a TOTP second factor.
+ * serve any route until they have enrolled at least one strong second
+ * factor — either TOTP via Better Auth's `twoFactor` plugin, or a WebAuthn
+ * passkey via `@better-auth/passkey` (#2082).
  *
  * Apply downstream of {@link adminAuth} or {@link platformAdminAuth}: this
  * middleware reads `c.get("authResult")` and never re-authenticates.
@@ -80,20 +82,26 @@ export const ENROLLMENT_URL = "/admin/settings/security";
 export const MFA_ENROLLMENT_REQUIRED = "mfa_enrollment_required";
 
 /**
- * Read `twoFactorEnabled` off the auth result. Better Auth's two-factor
- * plugin adds the field to the `user` table; `managed.ts` spreads the
- * session user object into `claims` (see `claims = { ...sessionUser, sub }`),
- * so the field lands here without any extra wiring.
+ * Decide whether the session has any acceptable second factor enrolled.
  *
- * Treat anything other than the strict boolean `true` as not-enabled —
- * the safer default. A `1` / `"true"` / wrapped object from a future
- * Better Auth shape change must continue to fail closed.
+ * Two sources, both injected into `claims` by `managed.ts`:
+ *   - `twoFactorEnabled: boolean` — TOTP (Better Auth `twoFactor` plugin).
+ *     Rides on the `user` table, lands in claims via `...sessionUser` spread.
+ *   - `passkeyCount: number` — count of WebAuthn credentials, looked up
+ *     from the `passkey` table by `resolvePasskeyCount` (managed.ts).
+ *
+ * Defensive narrowing on both fields: only the strict boolean `true` opens
+ * the TOTP path, only a positive `number` opens the passkey path. A future
+ * Better Auth shape change that returns `"true"` / `"1"` / wrapped objects
+ * must continue to fail closed — admitting an unenrolled admin is a worse
+ * outcome than gating one extra retry.
  */
-function isTwoFactorEnabled(c: Context<AuthEnv>): boolean {
-  const authResult = c.get("authResult");
-  const claims = authResult?.user?.claims;
+function isMfaEnrolled(c: Context<AuthEnv>): boolean {
+  const claims = c.get("authResult")?.user?.claims;
   if (!claims) return false;
-  return claims.twoFactorEnabled === true;
+  if (claims.twoFactorEnabled === true) return true;
+  const count = claims.passkeyCount;
+  return typeof count === "number" && count > 0;
 }
 
 /**
@@ -152,7 +160,7 @@ export const mfaRequired = createMiddleware<AuthEnv>(async (c, next) => {
     return;
   }
 
-  if (isTwoFactorEnabled(c)) {
+  if (isMfaEnrolled(c)) {
     await next();
     return;
   }

--- a/packages/api/src/lib/auth/__tests__/managed.test.ts
+++ b/packages/api/src/lib/auth/__tests__/managed.test.ts
@@ -1,4 +1,19 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+
+// Module mock for the internal-DB adapter must be installed BEFORE
+// `validateManaged` is imported so its transitive `hasInternalDB` /
+// `internalQuery` references resolve to these stubs. Tests flip the
+// closures (mockHasInternalDB / mockInternalQuery) to cover the
+// resolvePasskeyCount branches that aren't reachable via env-only setup.
+let mockHasInternalDB = false;
+let mockInternalQuery: (sql: string, params: unknown[]) => Promise<unknown[]> =
+  () => Promise.resolve([]);
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => mockHasInternalDB,
+  internalQuery: (sql: string, params: unknown[]) => mockInternalQuery(sql, params),
+}));
+
 import { validateManaged } from "../managed";
 import { _setAuthInstance } from "../server";
 
@@ -13,14 +28,17 @@ describe("validateManaged()", () => {
     // Inject a fake auth instance whose api.getSession is our mock
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- injecting partial auth mock for testing
     _setAuthInstance({ api: { getSession: mockGetSession } } as any);
-    // Defensive: validateManaged doesn't itself touch the internal DB, but
-    // unsetting DATABASE_URL keeps these tests immune to any future
-    // internal-DB hooks added to managed validation (mirrors middleware.test.ts).
+    // Internal-DB mock defaults: no DB available, no rows. Individual tests
+    // override these closures to exercise the positive / failure paths.
+    mockHasInternalDB = false;
+    mockInternalQuery = () => Promise.resolve([]);
     delete process.env.DATABASE_URL;
   });
 
   afterEach(() => {
     _setAuthInstance(null);
+    mockHasInternalDB = false;
+    mockInternalQuery = () => Promise.resolve([]);
     if (origDatabaseUrl !== undefined) process.env.DATABASE_URL = origDatabaseUrl;
     else delete process.env.DATABASE_URL;
   });
@@ -341,20 +359,12 @@ describe("validateManaged()", () => {
     });
   });
 
-  // -------------------------------------------------------------------------
-  // passkeyCount claims propagation (#2082)
-  //
-  // Read by the `mfaRequired` middleware to admit passkey-only admins. The
-  // claim must always be present — gating logic relies on the strict
-  // `typeof === "number"` check to reject undefined / string drift, so a
-  // missing field would silently lock out every passkey-enrolled admin.
-  // -------------------------------------------------------------------------
-
+  // passkeyCount is read by `mfaRequired` to admit passkey-only admins.
+  // The claim must always be present and authoritative — a missing field
+  // silently locks out passkey users; a spread-overridable field lets a
+  // hostile session-user payload inflate the count.
   describe("passkeyCount claim", () => {
     it("populates passkeyCount: 0 in claims when internal DB is unavailable", async () => {
-      // beforeEach() unsets DATABASE_URL → hasInternalDB() returns false →
-      // resolvePasskeyCount short-circuits to 0. That 0 must still land in
-      // claims so the gate can read it instead of getting undefined.
       mockGetSession.mockResolvedValueOnce({
         user: { id: "usr_123", email: "alice@example.com" },
         session: { id: "sess_abc", userId: "usr_123" },
@@ -369,17 +379,68 @@ describe("validateManaged()", () => {
       }
     });
 
-    it("passkeyCount survives the spread-then-overwrite contract in claims", async () => {
-      // managed.ts spreads `sessionUser` first, then writes computed fields
-      // (sub, passkeyCount, org_id) on top — so a future Better Auth shape
-      // change that puts a stray `passkeyCount` on the user object can't
-      // overwrite the resolver's authoritative value.
+    it("populates passkeyCount with the value from the passkey table when DB is up", async () => {
+      mockHasInternalDB = true;
+      mockInternalQuery = () => Promise.resolve([{ count: 2 }]);
+      mockGetSession.mockResolvedValueOnce({
+        user: { id: "usr_123", email: "alice@example.com" },
+        session: { id: "sess_abc", userId: "usr_123" },
+      });
+
+      const result = await validateManaged(makeRequest());
+
+      expect(result.authenticated).toBe(true);
+      if (result.authenticated && result.user) {
+        expect(result.user.claims?.passkeyCount).toBe(2);
+      }
+    });
+
+    it("returns 0 when the count row is missing entirely", async () => {
+      // pg returns no rows — should land 0, not NaN/undefined, so the gate's
+      // `typeof === "number"` narrow continues to read a valid number.
+      mockHasInternalDB = true;
+      mockInternalQuery = () => Promise.resolve([]);
+      mockGetSession.mockResolvedValueOnce({
+        user: { id: "usr_123", email: "alice@example.com" },
+        session: { id: "sess_abc", userId: "usr_123" },
+      });
+
+      const result = await validateManaged(makeRequest());
+
+      expect(result.authenticated).toBe(true);
+      if (result.authenticated && result.user) {
+        expect(result.user.claims?.passkeyCount).toBe(0);
+        expect(Number.isFinite(result.user.claims?.passkeyCount as number)).toBe(true);
+      }
+    });
+
+    it("falls back to 0 when internalQuery throws (transient infra error)", async () => {
+      // Auth must still succeed — failing the whole login because of a
+      // passkey-count read would be a much worse outcome than gating the user.
+      mockHasInternalDB = true;
+      mockInternalQuery = () => Promise.reject(new Error("connection refused"));
+      mockGetSession.mockResolvedValueOnce({
+        user: { id: "usr_123", email: "alice@example.com" },
+        session: { id: "sess_abc", userId: "usr_123" },
+      });
+
+      const result = await validateManaged(makeRequest());
+
+      expect(result.authenticated).toBe(true);
+      if (result.authenticated && result.user) {
+        expect(result.user.claims?.passkeyCount).toBe(0);
+      }
+    });
+
+    it("attacker-controlled passkeyCount on the session user cannot bypass the gate", async () => {
+      // Computed fields land AFTER the spread (managed.ts), so a hostile
+      // session-user payload that already carries `passkeyCount: "9999"`
+      // gets shadowed by the resolver's authoritative 0.
+      mockHasInternalDB = false; // resolver returns 0
       mockGetSession.mockResolvedValueOnce({
         user: {
           id: "usr_123",
           email: "alice@example.com",
-          // hostile drift: a Better Auth user object that already carries a
-          // passkeyCount claim with the wrong shape.
           passkeyCount: "9999" as unknown as number,
         },
         session: { id: "sess_abc", userId: "usr_123" },
@@ -389,7 +450,6 @@ describe("validateManaged()", () => {
 
       expect(result.authenticated).toBe(true);
       if (result.authenticated && result.user) {
-        // Computed value (0) wins, not the spread "9999".
         expect(result.user.claims?.passkeyCount).toBe(0);
       }
     });

--- a/packages/api/src/lib/auth/__tests__/managed.test.ts
+++ b/packages/api/src/lib/auth/__tests__/managed.test.ts
@@ -340,4 +340,58 @@ describe("validateManaged()", () => {
       }
     });
   });
+
+  // -------------------------------------------------------------------------
+  // passkeyCount claims propagation (#2082)
+  //
+  // Read by the `mfaRequired` middleware to admit passkey-only admins. The
+  // claim must always be present — gating logic relies on the strict
+  // `typeof === "number"` check to reject undefined / string drift, so a
+  // missing field would silently lock out every passkey-enrolled admin.
+  // -------------------------------------------------------------------------
+
+  describe("passkeyCount claim", () => {
+    it("populates passkeyCount: 0 in claims when internal DB is unavailable", async () => {
+      // beforeEach() unsets DATABASE_URL → hasInternalDB() returns false →
+      // resolvePasskeyCount short-circuits to 0. That 0 must still land in
+      // claims so the gate can read it instead of getting undefined.
+      mockGetSession.mockResolvedValueOnce({
+        user: { id: "usr_123", email: "alice@example.com" },
+        session: { id: "sess_abc", userId: "usr_123" },
+      });
+
+      const result = await validateManaged(makeRequest());
+
+      expect(result.authenticated).toBe(true);
+      if (result.authenticated && result.user) {
+        expect(result.user.claims?.passkeyCount).toBe(0);
+        expect(typeof result.user.claims?.passkeyCount).toBe("number");
+      }
+    });
+
+    it("passkeyCount survives the spread-then-overwrite contract in claims", async () => {
+      // managed.ts spreads `sessionUser` first, then writes computed fields
+      // (sub, passkeyCount, org_id) on top — so a future Better Auth shape
+      // change that puts a stray `passkeyCount` on the user object can't
+      // overwrite the resolver's authoritative value.
+      mockGetSession.mockResolvedValueOnce({
+        user: {
+          id: "usr_123",
+          email: "alice@example.com",
+          // hostile drift: a Better Auth user object that already carries a
+          // passkeyCount claim with the wrong shape.
+          passkeyCount: "9999" as unknown as number,
+        },
+        session: { id: "sess_abc", userId: "usr_123" },
+      });
+
+      const result = await validateManaged(makeRequest());
+
+      expect(result.authenticated).toBe(true);
+      if (result.authenticated && result.user) {
+        // Computed value (0) wins, not the spread "9999".
+        expect(result.user.claims?.passkeyCount).toBe(0);
+      }
+    });
+  });
 });

--- a/packages/api/src/lib/auth/managed.ts
+++ b/packages/api/src/lib/auth/managed.ts
@@ -93,28 +93,15 @@ export async function validateManaged(req: Request): Promise<AuthResult> {
   // via POST /organization/set-active.
   const activeOrganizationId = (sessionData?.activeOrganizationId as string) ?? undefined;
 
-  // Resolve effective role + passkey count in parallel — both hit the
-  // internal DB but are otherwise independent. Sequencing them would add a
-  // round-trip to every authenticated request that has an active workspace.
-  //
-  // Effective role: the user-level role (from admin plugin) may be "member"
-  // even when the user is "owner" of their active org (org plugin stores
-  // membership roles in the `member` table, not the `user` table). Use the
-  // higher of the two so org owners/admins can access the admin console.
-  //
-  // Passkey count: number of WebAuthn credentials enrolled against this
-  // user. Read by `mfaRequired` (admin-mfa-required.ts) which accepts
-  // either `twoFactorEnabled === true` or `passkeyCount > 0` as proof of a
-  // strong second factor — see #2082.
+  // Both queries hit the internal DB but are independent — parallelize so
+  // every authenticated request doesn't pay two sequential round-trips.
   const [effectiveRole, passkeyCount] = await Promise.all([
     resolveEffectiveRole(role, userId, activeOrganizationId),
     resolvePasskeyCount(userId),
   ]);
 
-  // Carry session user fields as claims for RLS policy evaluation. The
-  // explicit fields land AFTER the spread so a future Better Auth shape
-  // change can't accidentally overwrite our computed values with raw user
-  // columns of the same name.
+  // Computed fields land AFTER the spread so a session-user field can't
+  // shadow our authoritative claims (asserted in managed.test.ts).
   const claims: Record<string, unknown> = { ...sessionUser, sub: userId, passkeyCount };
   if (activeOrganizationId) {
     claims.org_id = activeOrganizationId;
@@ -177,28 +164,10 @@ async function resolveEffectiveRole(
   }
 }
 
-// ---------------------------------------------------------------------------
-// Passkey count resolution (WebAuthn second factor)
-// ---------------------------------------------------------------------------
-
-/**
- * Count WebAuthn credentials enrolled against this user. Stored in Better
- * Auth's `passkey` table (managed by `@better-auth/passkey`'s migration —
- * see `lib/auth/server.ts:buildPlugins`).
- *
- * Read by the `mfaRequired` middleware to admit users whose second factor
- * is a passkey instead of TOTP. Returns 0 when:
- *   - The internal DB is not configured (self-hosted minimal install).
- *   - The query fails (transient infra error). Failing closed here is
- *     deliberate: a stale `passkeyCount > 0` would let an unenrolled user
- *     bypass the admin gate. Falling back to 0 means a passkey-only user
- *     hits a 403 during DB blips and can recover by retrying — strictly
- *     safer than admitting them on a broken read.
- *
- * The `::int` cast is required because PostgreSQL's `COUNT(*)` returns
- * `bigint`, which `pg` surfaces as a string in JS. Casting to `int` keeps
- * the return type a JS number and avoids dual-typed handling.
- */
+// `::int` cast keeps PG's bigint COUNT(*) as a JS number — pg surfaces
+// bigint as a string by default. Returns 0 on missing DB / read failure:
+// fail-closed gates passkey-only users on infra blips, which is strictly
+// safer than admitting them on a stale read.
 async function resolvePasskeyCount(userId: string): Promise<number> {
   if (!hasInternalDB()) return 0;
   try {
@@ -206,13 +175,11 @@ async function resolvePasskeyCount(userId: string): Promise<number> {
       `SELECT COUNT(*)::int AS count FROM passkey WHERE "userId" = $1`,
       [userId],
     );
-    const raw = rows[0]?.count;
-    const count = typeof raw === "number" ? raw : Number(raw);
-    return Number.isFinite(count) && count >= 0 ? count : 0;
+    return rows[0]?.count ?? 0;
   } catch (err) {
     log.warn(
       { err: err instanceof Error ? err.message : String(err), userId },
-      "Failed to look up passkey count — treating as 0; passkey-only users will be gated until the read recovers",
+      "Failed to look up passkey count — treating as 0",
     );
     return 0;
   }

--- a/packages/api/src/lib/auth/managed.ts
+++ b/packages/api/src/lib/auth/managed.ts
@@ -93,14 +93,29 @@ export async function validateManaged(req: Request): Promise<AuthResult> {
   // via POST /organization/set-active.
   const activeOrganizationId = (sessionData?.activeOrganizationId as string) ?? undefined;
 
-  // Resolve effective role: the user-level role (from admin plugin) may be
-  // "member" even when the user is "owner" of their active org (org plugin
-  // stores membership roles in the `member` table, not the `user` table).
-  // Use the higher of the two so org owners/admins can access the admin console.
-  const effectiveRole = await resolveEffectiveRole(role, userId, activeOrganizationId);
+  // Resolve effective role + passkey count in parallel — both hit the
+  // internal DB but are otherwise independent. Sequencing them would add a
+  // round-trip to every authenticated request that has an active workspace.
+  //
+  // Effective role: the user-level role (from admin plugin) may be "member"
+  // even when the user is "owner" of their active org (org plugin stores
+  // membership roles in the `member` table, not the `user` table). Use the
+  // higher of the two so org owners/admins can access the admin console.
+  //
+  // Passkey count: number of WebAuthn credentials enrolled against this
+  // user. Read by `mfaRequired` (admin-mfa-required.ts) which accepts
+  // either `twoFactorEnabled === true` or `passkeyCount > 0` as proof of a
+  // strong second factor — see #2082.
+  const [effectiveRole, passkeyCount] = await Promise.all([
+    resolveEffectiveRole(role, userId, activeOrganizationId),
+    resolvePasskeyCount(userId),
+  ]);
 
-  // Carry session user fields as claims for RLS policy evaluation
-  const claims: Record<string, unknown> = { ...sessionUser, sub: userId };
+  // Carry session user fields as claims for RLS policy evaluation. The
+  // explicit fields land AFTER the spread so a future Better Auth shape
+  // change can't accidentally overwrite our computed values with raw user
+  // columns of the same name.
+  const claims: Record<string, unknown> = { ...sessionUser, sub: userId, passkeyCount };
   if (activeOrganizationId) {
     claims.org_id = activeOrganizationId;
   }
@@ -159,5 +174,46 @@ async function resolveEffectiveRole(
       "Failed to look up org member role — falling back to user-level role",
     );
     return userRole;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Passkey count resolution (WebAuthn second factor)
+// ---------------------------------------------------------------------------
+
+/**
+ * Count WebAuthn credentials enrolled against this user. Stored in Better
+ * Auth's `passkey` table (managed by `@better-auth/passkey`'s migration —
+ * see `lib/auth/server.ts:buildPlugins`).
+ *
+ * Read by the `mfaRequired` middleware to admit users whose second factor
+ * is a passkey instead of TOTP. Returns 0 when:
+ *   - The internal DB is not configured (self-hosted minimal install).
+ *   - The query fails (transient infra error). Failing closed here is
+ *     deliberate: a stale `passkeyCount > 0` would let an unenrolled user
+ *     bypass the admin gate. Falling back to 0 means a passkey-only user
+ *     hits a 403 during DB blips and can recover by retrying — strictly
+ *     safer than admitting them on a broken read.
+ *
+ * The `::int` cast is required because PostgreSQL's `COUNT(*)` returns
+ * `bigint`, which `pg` surfaces as a string in JS. Casting to `int` keeps
+ * the return type a JS number and avoids dual-typed handling.
+ */
+async function resolvePasskeyCount(userId: string): Promise<number> {
+  if (!hasInternalDB()) return 0;
+  try {
+    const rows = await internalQuery<{ count: number }>(
+      `SELECT COUNT(*)::int AS count FROM passkey WHERE "userId" = $1`,
+      [userId],
+    );
+    const raw = rows[0]?.count;
+    const count = typeof raw === "number" ? raw : Number(raw);
+    return Number.isFinite(count) && count >= 0 ? count : 0;
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), userId },
+      "Failed to look up passkey count — treating as 0; passkey-only users will be gated until the read recovers",
+    );
+    return 0;
   }
 }

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -658,25 +658,10 @@ function buildPlugins() {
     }),
   );
 
-  // Passkeys (WebAuthn) — second supported MFA factor alongside TOTP.
-  // The `mfaRequired` middleware accepts either `twoFactorEnabled === true`
-  // or `passkeyCount > 0` once any user has enrolled at least one passkey
-  // (see `managed.ts:resolveSessionClaims`).
-  //
-  // `rpID` is the WebAuthn Relying Party ID — the registrable domain that
-  // credentials are bound to. Passkeys created against rpID `app.useatlas.dev`
-  // cannot be used against any other origin, which is the phishing-resistance
-  // guarantee. Self-hosted deployments override via `ATLAS_RPID`. White-label
-  // / multi-region SaaS deployments would force re-enrollment if rpID changes
-  // — captured in `2082` for posterity but not a forcing function today.
-  //
-  // `rpName` is the human-readable string the OS surfaces in the passkey
-  // prompt ("Use your saved passkey for <rpName>?"). Default matches the
-  // TOTP issuer string for visual consistency in authenticator apps + OS UI.
-  //
-  // Loaded unconditionally for the same reason as `twoFactor()`: the
-  // backing `passkey` table must always be present so the schema does not
-  // disappear under feet of users who have already enrolled.
+  // Passkeys — loaded unconditionally (see `twoFactor()` above for rationale:
+  // schema must persist for already-enrolled users). Changing `rpID` after
+  // enrollment invalidates every existing passkey, so the default is fixed
+  // and self-hosted overrides go through `ATLAS_RPID` / `ATLAS_RPNAME`.
   plugins.push(
     passkey({
       rpID: process.env.ATLAS_RPID ?? "app.useatlas.dev",

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -18,6 +18,7 @@ import { twoFactor } from "better-auth/plugins/two-factor";
 // All pinned to ^1.6.x in package.json — update together (the peer-dep
 // constraint is exact-version per minor on the @better-auth/* side).
 import { apiKey } from "@better-auth/api-key";
+import { passkey } from "@better-auth/passkey";
 import { scim } from "@better-auth/scim";
 import { stripe as stripePlugin } from "@better-auth/stripe";
 import { oauthProvider } from "@better-auth/oauth-provider";
@@ -654,6 +655,32 @@ function buildPlugins() {
   plugins.push(
     twoFactor({
       issuer: process.env.ATLAS_MFA_ISSUER ?? "Atlas",
+    }),
+  );
+
+  // Passkeys (WebAuthn) — second supported MFA factor alongside TOTP.
+  // The `mfaRequired` middleware accepts either `twoFactorEnabled === true`
+  // or `passkeyCount > 0` once any user has enrolled at least one passkey
+  // (see `managed.ts:resolveSessionClaims`).
+  //
+  // `rpID` is the WebAuthn Relying Party ID — the registrable domain that
+  // credentials are bound to. Passkeys created against rpID `app.useatlas.dev`
+  // cannot be used against any other origin, which is the phishing-resistance
+  // guarantee. Self-hosted deployments override via `ATLAS_RPID`. White-label
+  // / multi-region SaaS deployments would force re-enrollment if rpID changes
+  // — captured in `2082` for posterity but not a forcing function today.
+  //
+  // `rpName` is the human-readable string the OS surfaces in the passkey
+  // prompt ("Use your saved passkey for <rpName>?"). Default matches the
+  // TOTP issuer string for visual consistency in authenticator apps + OS UI.
+  //
+  // Loaded unconditionally for the same reason as `twoFactor()`: the
+  // backing `passkey` table must always be present so the schema does not
+  // disappear under feet of users who have already enrolled.
+  plugins.push(
+    passkey({
+      rpID: process.env.ATLAS_RPID ?? "app.useatlas.dev",
+      rpName: process.env.ATLAS_RPNAME ?? "Atlas",
     }),
   );
 


### PR DESCRIPTION
## Summary

Backend foundation for #2082's multi-method MFA work. Wires up `@better-auth/passkey` next to the existing `twoFactor` plugin and broadens the admin gate from "TOTP enrolled" to "any strong second factor enrolled". Existing TOTP-enrolled admins are unaffected.

- `@better-auth/passkey ^1.6.9` added — `rpID` / `rpName` env-overridable (`ATLAS_RPID`, `ATLAS_RPNAME`); default `app.useatlas.dev` / `Atlas`.
- `managed.ts` injects `passkeyCount` into session claims via parallel internal-DB lookup (no waterfall vs the existing org-member role query).
- `admin-mfa-required` gate accepts `twoFactorEnabled === true || passkeyCount > 0`, with strict type narrowing on both fields so a future Better Auth shape change can't silently admit unenrolled users.

## What's NOT in this PR

- `/admin/settings/security` 3-tile UI (passkey + TOTP + backup-codes-on-TOTP) — **PR B**
- Trusted-device 30d (verify-time checkbox + revoke list) — **PR C**
- Browser e2e with Playwright `webAuthn` virtual authenticator — **PR D**
- Gate body message flip (`"Enroll an authenticator app or passkey…"`) — held for PR B so we don't direct users to a passkey-enrollment UI that doesn't exist yet. The current message still works because TOTP enrollment is available today.

## Files

- `packages/api/package.json` + `bun.lock` — add `@better-auth/passkey ^1.6.9`
- `packages/api/src/lib/auth/server.ts` — push `passkey()` plugin alongside `twoFactor()`
- `packages/api/src/lib/auth/managed.ts` — `resolvePasskeyCount()` + parallel resolution + `passkeyCount` in claims
- `packages/api/src/api/routes/admin-mfa-required.ts` — `isTwoFactorEnabled` → `isMfaEnrolled`; accept either factor
- Tests for both — passkey-only accept, both-zero reject, combined accept, defensive value narrowing

## Test plan

- [x] Unit: `admin-mfa-required.test.ts` — passkey-only accept, both-zero reject, both-true accept, defensive narrowing on `passkeyCount` (string / boolean / NaN / negative / zero all reject)
- [x] Unit: `managed.test.ts` — `passkeyCount: 0` lands when internal DB unavailable; spread-then-overwrite contract holds against hostile drift
- [x] Local `/ci` — lint, type, full test suite, syncpack, template drift, security-headers drift, railway-watch — all pass
- [ ] Smoke (post-deploy): existing TOTP-enrolled admin still passes the gate; new user with no factor still 403's; manual passkey enroll via raw Better Auth endpoints (no UI yet) admits the gate

Closes part of #2082 (PR A of D).