### PR TITLE
feat(web): #2082 — passkey enrollment UI (PR B of D)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -320,6 +320,7 @@
         "@ai-sdk/react": "^3.0.143",
         "@better-auth/api-key": "^1.6.9",
         "@better-auth/oauth-provider": "^1.6.9",
+        "@better-auth/passkey": "^1.6.9",
         "@better-auth/stripe": "^1.6.9",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -18,6 +18,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@better-auth/api-key": "^1.6.9",
     "@better-auth/oauth-provider": "^1.6.9",
+    "@better-auth/passkey": "^1.6.9",
     "@better-auth/stripe": "^1.6.9",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",

--- a/packages/web/src/app/admin/settings/security/page.tsx
+++ b/packages/web/src/app/admin/settings/security/page.tsx
@@ -5,23 +5,20 @@
  *
  * Lets the signed-in admin manage every available second factor:
  *
- *   - Passkey (WebAuthn)            — `authClient.passkey.*` (#2082)
- *   - Authenticator app (TOTP)      — `authClient.twoFactor.*` (#1925)
+ *   - Passkey (WebAuthn)            — `authClient.passkey.*`
+ *   - Authenticator app (TOTP)      — `authClient.twoFactor.*`
  *   - Backup codes                  — issued inside the TOTP flow only;
  *                                     this page surfaces status, not enrollment.
  *
  * The page is rendered by Next.js, not Atlas's API admin router, so the
  * `mfaRequired` API gate doesn't run on the page itself — admins who
  * haven't enrolled any factor can always reach it to complete enrollment.
- * The Better Auth endpoints the page calls (`/api/auth/two-factor/*`,
- * `/api/auth/passkey/*`) are likewise mounted outside the admin router
- * (see `packages/api/src/api/index.ts` and the file header in
- * `packages/api/src/api/routes/admin-mfa-required.ts`).
  */
 
 import { useCallback, useEffect, useState } from "react";
 import { ShieldCheck } from "lucide-react";
 import { authClient } from "@/lib/auth/client";
+import { getPasskeyClient, type Passkey } from "@/lib/auth/passkey-client";
 import { TwoFactorSetup } from "@/ui/components/admin/security/two-factor-setup";
 import { PasskeyTile } from "@/ui/components/admin/security/passkey-tile";
 import { PasskeyList, type PasskeyRow } from "@/ui/components/admin/security/passkey-list";
@@ -33,34 +30,12 @@ interface SessionUser {
   twoFactorEnabled?: boolean;
 }
 
-type ClientResult<T> = {
-  data: T | null;
-  error: { message?: string; code?: string; status?: number } | null;
-};
-
-/**
- * Narrow view onto the parts of `authClient.passkey` that this page
- * exercises. Better Auth's plugin-augmented client type doesn't surface
- * `listUserPasskeys` through `createAuthClient`'s generic chain, but the
- * server plugin exposes the endpoint and the client wires it up at
- * runtime (see `@better-auth/passkey/dist/index.mjs`'s endpoint table).
- */
-interface PasskeyClient {
-  listUserPasskeys: () => Promise<ClientResult<PasskeyRow[]>>;
-}
-
-function getPasskeyClient(): PasskeyClient | null {
-  const namespace = (authClient as unknown as { passkey?: PasskeyClient }).passkey;
-  return namespace ?? null;
-}
-
 export default function SecurityPage() {
   const session = authClient.useSession();
 
   // Better Auth's session reactivity is the source of truth for
   // `twoFactorEnabled`. The cast goes from the plugin-erased session shape
-  // to the narrow read above; an `unknown` step would be wider than the
-  // value already is, so we cast directly.
+  // to the narrow read above.
   const user = (session.data?.user ?? null) as SessionUser | null;
   const totpEnabled = user?.twoFactorEnabled === true;
 
@@ -70,11 +45,11 @@ export default function SecurityPage() {
   const refreshPasskeys = useCallback(async () => {
     const client = getPasskeyClient();
     if (!client) {
-      setListError("Passkey support is not loaded — refresh the page.");
+      setListError("Passkey support couldn't be loaded. Refresh the page and try again.");
       return;
     }
     setListError(null);
-    let result: ClientResult<PasskeyRow[]>;
+    let result: Awaited<ReturnType<typeof client.listUserPasskeys>>;
     try {
       result = await client.listUserPasskeys();
     } catch (err) {
@@ -88,7 +63,7 @@ export default function SecurityPage() {
       setListError(result.error.message ?? "Could not load your passkeys.");
       return;
     }
-    setPasskeys(result.data ?? []);
+    setPasskeys((result.data ?? []) as Passkey[]);
   }, []);
 
   useEffect(() => {
@@ -106,8 +81,8 @@ export default function SecurityPage() {
 
   function handlePasskeyChange() {
     void refreshPasskeys();
-    // Session claims include `passkeyCount` (#2082 PR A) — refetch so
-    // the MFA gate sees the new count without a hard reload.
+    // Session claims include `passkeyCount` — refetch so the MFA gate
+    // sees the new count without a hard reload.
     session.refetch?.();
   }
 

--- a/packages/web/src/app/admin/settings/security/page.tsx
+++ b/packages/web/src/app/admin/settings/security/page.tsx
@@ -3,34 +3,55 @@
 /**
  * Admin → Settings → Security
  *
- * Single-purpose page for managing two-factor authentication on the
- * currently-signed-in account.
+ * Lets the signed-in admin manage every available second factor:
  *
- * This page is rendered by Next.js, not by Atlas's API admin router, so
- * the `mfaRequired` API gate doesn't run on the page itself — admins who
- * haven't enrolled can always reach the page to complete enrollment.
- * The Better Auth TOTP endpoints (`/api/auth/two-factor/*`) the page
- * calls are likewise mounted outside the admin router (see
- * `packages/api/src/api/index.ts:153` and the file header in
+ *   - Passkey (WebAuthn)            — `authClient.passkey.*` (#2082)
+ *   - Authenticator app (TOTP)      — `authClient.twoFactor.*` (#1925)
+ *   - Backup codes                  — issued inside the TOTP flow only;
+ *                                     this page surfaces status, not enrollment.
+ *
+ * The page is rendered by Next.js, not Atlas's API admin router, so the
+ * `mfaRequired` API gate doesn't run on the page itself — admins who
+ * haven't enrolled any factor can always reach it to complete enrollment.
+ * The Better Auth endpoints the page calls (`/api/auth/two-factor/*`,
+ * `/api/auth/passkey/*`) are likewise mounted outside the admin router
+ * (see `packages/api/src/api/index.ts` and the file header in
  * `packages/api/src/api/routes/admin-mfa-required.ts`).
  */
 
+import { useCallback, useEffect, useState } from "react";
 import { ShieldCheck } from "lucide-react";
 import { authClient } from "@/lib/auth/client";
 import { TwoFactorSetup } from "@/ui/components/admin/security/two-factor-setup";
+import { PasskeyTile } from "@/ui/components/admin/security/passkey-tile";
+import { PasskeyList, type PasskeyRow } from "@/ui/components/admin/security/passkey-list";
+import { BackupCodesStatus } from "@/ui/components/admin/security/backup-codes-status";
 
-/**
- * Narrow read of `session.data.user`. Better Auth's session always
- * populates `email` and `role` when the session exists, but the
- * plugin-augmented client type isn't reachable through
- * `createAuthClient`'s generic chain — `twoFactorEnabled` arrives via
- * the `twoFactor` plugin and is missing on accounts that never enrolled,
- * so it stays optional.
- */
 interface SessionUser {
   email: string;
   role: string;
   twoFactorEnabled?: boolean;
+}
+
+type ClientResult<T> = {
+  data: T | null;
+  error: { message?: string; code?: string; status?: number } | null;
+};
+
+/**
+ * Narrow view onto the parts of `authClient.passkey` that this page
+ * exercises. Better Auth's plugin-augmented client type doesn't surface
+ * `listUserPasskeys` through `createAuthClient`'s generic chain, but the
+ * server plugin exposes the endpoint and the client wires it up at
+ * runtime (see `@better-auth/passkey/dist/index.mjs`'s endpoint table).
+ */
+interface PasskeyClient {
+  listUserPasskeys: () => Promise<ClientResult<PasskeyRow[]>>;
+}
+
+function getPasskeyClient(): PasskeyClient | null {
+  const namespace = (authClient as unknown as { passkey?: PasskeyClient }).passkey;
+  return namespace ?? null;
 }
 
 export default function SecurityPage() {
@@ -41,7 +62,54 @@ export default function SecurityPage() {
   // to the narrow read above; an `unknown` step would be wider than the
   // value already is, so we cast directly.
   const user = (session.data?.user ?? null) as SessionUser | null;
-  const enabled = user?.twoFactorEnabled === true;
+  const totpEnabled = user?.twoFactorEnabled === true;
+
+  const [passkeys, setPasskeys] = useState<PasskeyRow[] | null>(null);
+  const [listError, setListError] = useState<string | null>(null);
+
+  const refreshPasskeys = useCallback(async () => {
+    const client = getPasskeyClient();
+    if (!client) {
+      setListError("Passkey support is not loaded — refresh the page.");
+      return;
+    }
+    setListError(null);
+    let result: ClientResult<PasskeyRow[]>;
+    try {
+      result = await client.listUserPasskeys();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn("[passkey] listUserPasskeys threw", msg);
+      setListError("Could not load your passkeys. Please refresh.");
+      return;
+    }
+    if (result.error) {
+      console.warn("[passkey] listUserPasskeys failed", result.error);
+      setListError(result.error.message ?? "Could not load your passkeys.");
+      return;
+    }
+    setPasskeys(result.data ?? []);
+  }, []);
+
+  useEffect(() => {
+    void refreshPasskeys();
+  }, [refreshPasskeys]);
+
+  const hasPasskey = (passkeys?.length ?? 0) > 0;
+
+  function handleTotpChange() {
+    // Better Auth refreshes session state automatically after
+    // twoFactor.enable / disable; this hook gives downstream pages
+    // a chance to refetch if they cache the flag.
+    session.refetch?.();
+  }
+
+  function handlePasskeyChange() {
+    void refreshPasskeys();
+    // Session claims include `passkeyCount` (#2082 PR A) — refetch so
+    // the MFA gate sees the new count without a hard reload.
+    session.refetch?.();
+  }
 
   return (
     <div className="p-6">
@@ -60,16 +128,19 @@ export default function SecurityPage() {
         </span>
       </div>
 
-      <div className="mx-auto max-w-2xl space-y-6">
-        <TwoFactorSetup
-          enabled={enabled}
-          onChange={() => {
-            // Better Auth refreshes session state automatically after
-            // twoFactor.enable / disable; this hook gives downstream pages
-            // a chance to refetch if they cache the flag.
-            session.refetch?.();
-          }}
-        />
+      <div className="mx-auto max-w-2xl space-y-4">
+        <PasskeyTile hasPasskey={hasPasskey} onChange={handlePasskeyChange} />
+
+        <TwoFactorSetup enabled={totpEnabled} onChange={handleTotpChange} />
+
+        <BackupCodesStatus totpEnabled={totpEnabled} hasPasskey={hasPasskey} />
+
+        <div className="pt-2">
+          <PasskeyList passkeys={passkeys ?? []} onChange={handlePasskeyChange} />
+          {listError && (
+            <p className="mt-2 text-sm text-destructive">{listError}</p>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/packages/web/src/lib/auth/client.ts
+++ b/packages/web/src/lib/auth/client.ts
@@ -25,8 +25,8 @@ import { stripeClient } from "@better-auth/stripe/client";
 import { oauthProviderClient } from "@better-auth/oauth-provider/client";
 // @better-auth/passkey client mirror — gives us
 // `authClient.passkey.{addPasskey, listUserPasskeys, deletePasskey, updatePasskey}`
-// for the enrollment UI on /admin/settings/security (#2082 PR B). The server
-// plugin (#2082 PR A) is loaded unconditionally next to twoFactor().
+// for the enrollment UI on /admin/settings/security. The server plugin is
+// loaded unconditionally next to twoFactor().
 import { passkeyClient } from "@better-auth/passkey/client";
 import {
   adminClient,
@@ -65,12 +65,11 @@ const _authClient = createAuthClient({
       ac,
       roles: { owner, admin, member },
     }),
-    // Two-factor (TOTP + backup codes). The server plugin (#1925) is loaded
+    // Two-factor (TOTP + backup codes). Server plugin is loaded
     // unconditionally; the client mirror gives us authClient.twoFactor.*
     // for the enrollment UI in /admin/settings/security.
     twoFactorClient(),
-    // Passkey (WebAuthn). Server plugin lives next to twoFactor() in
-    // packages/api/src/lib/auth/server.ts — see #2082 PR A.
+    // Passkey (WebAuthn). Server plugin lives next to twoFactor().
     passkeyClient(),
     stripeClient({ subscription: true }),
     oauthProviderClient(),

--- a/packages/web/src/lib/auth/client.ts
+++ b/packages/web/src/lib/auth/client.ts
@@ -23,6 +23,11 @@ import { stripeClient } from "@better-auth/stripe/client";
 // The same plugin handles passing the signed `oauth_query` through every
 // in-flow request automatically.
 import { oauthProviderClient } from "@better-auth/oauth-provider/client";
+// @better-auth/passkey client mirror — gives us
+// `authClient.passkey.{addPasskey, listUserPasskeys, deletePasskey, updatePasskey}`
+// for the enrollment UI on /admin/settings/security (#2082 PR B). The server
+// plugin (#2082 PR A) is loaded unconditionally next to twoFactor().
+import { passkeyClient } from "@better-auth/passkey/client";
 import {
   adminClient,
   organizationClient,
@@ -64,6 +69,9 @@ const _authClient = createAuthClient({
     // unconditionally; the client mirror gives us authClient.twoFactor.*
     // for the enrollment UI in /admin/settings/security.
     twoFactorClient(),
+    // Passkey (WebAuthn). Server plugin lives next to twoFactor() in
+    // packages/api/src/lib/auth/server.ts — see #2082 PR A.
+    passkeyClient(),
     stripeClient({ subscription: true }),
     oauthProviderClient(),
   ],

--- a/packages/web/src/lib/auth/passkey-client.ts
+++ b/packages/web/src/lib/auth/passkey-client.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared narrow view onto the Better Auth passkey client surface.
+ *
+ * `createAuthClient`'s plugin-augmented type doesn't surface
+ * `passkey.{addPasskey,listUserPasskeys,deletePasskey,updatePasskey}` through
+ * the generic chain under TS6 strictness, so consumers cast through
+ * `unknown`. Centralising the cast plus the runtime guard here keeps the
+ * three security-page components (`passkey-tile`, `passkey-list`,
+ * `security/page.tsx`) honest about which methods they depend on.
+ *
+ * The guard returns `null` when the plugin isn't loaded; callers decide
+ * whether that is a soft "refresh the page" banner or a thrown error.
+ * The user-visible message stays in the consumer — never include
+ * developer paths in `Error` messages that bubble up to end users.
+ */
+
+import { authClient } from "./client";
+
+// ---------------------------------------------------------------------------
+// Wire shapes — match Better Auth's actual return contract
+// ---------------------------------------------------------------------------
+
+export interface PasskeyApiError {
+  message?: string;
+  code?: string;
+  status?: number;
+}
+
+export type PasskeyApiResult<T> = {
+  data: T | null;
+  error: PasskeyApiError | null;
+};
+
+export interface Passkey {
+  id: string;
+  name?: string;
+  createdAt: Date | string;
+}
+
+// ---------------------------------------------------------------------------
+// Method surface — segregated into one interface so each consumer can
+// destructure only what it needs (`const { addPasskey } = client`).
+// ---------------------------------------------------------------------------
+
+export interface PasskeyClient {
+  addPasskey: (opts?: {
+    name?: string;
+    authenticatorAttachment?: "platform" | "cross-platform";
+  }) => Promise<PasskeyApiResult<Passkey>>;
+  listUserPasskeys: () => Promise<PasskeyApiResult<Passkey[]>>;
+  updatePasskey: (opts: { id: string; name: string }) => Promise<PasskeyApiResult<{ passkey: Passkey }>>;
+  deletePasskey: (opts: { id: string }) => Promise<PasskeyApiResult<{ status?: boolean }>>;
+}
+
+// ---------------------------------------------------------------------------
+// Guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the `passkey` namespace from authClient. Returns `null` when the
+ * plugin isn't loaded — callers translate that into a user-facing surface
+ * (banner / disabled tile / etc).
+ *
+ * Runtime method-presence check guards against Better Auth API drift —
+ * a renamed method shows up as a precise null here rather than a
+ * `TypeError: addPasskey is not a function` at click time.
+ */
+export function getPasskeyClient(): PasskeyClient | null {
+  // The cast is the documented workaround for Better Auth's plugin-inference
+  // gap under TS6. Same pattern as `getTwoFactor()` in `two-factor-setup.tsx`
+  // and the `@ts-expect-error` on `apiKeyClient()` in `client.ts`.
+  const namespace = (authClient as unknown as { passkey?: Partial<PasskeyClient> })
+    .passkey;
+  if (
+    !namespace ||
+    typeof namespace.addPasskey !== "function" ||
+    typeof namespace.listUserPasskeys !== "function" ||
+    typeof namespace.updatePasskey !== "function" ||
+    typeof namespace.deletePasskey !== "function"
+  ) {
+    return null;
+  }
+  return namespace as PasskeyClient;
+}

--- a/packages/web/src/ui/__tests__/admin-layout.test.tsx
+++ b/packages/web/src/ui/__tests__/admin-layout.test.tsx
@@ -230,7 +230,7 @@ describe("AdminLayout", () => {
     await waitFor(() => {
       expect(document.body.textContent).toContain("Two-factor authentication required");
     });
-    expect(document.body.textContent).toContain("Enroll authenticator");
+    expect(document.body.textContent).toContain("Set up second factor");
   });
 
   test("shows password change dialog when required", async () => {

--- a/packages/web/src/ui/__tests__/backup-codes-status.test.tsx
+++ b/packages/web/src/ui/__tests__/backup-codes-status.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * Tile state matrix for the backup-codes status tile (#2082 PR B).
+ *
+ * Brief asks for: no factors → backup codes "required";
+ * TOTP only → "ready"; passkey only → "not applicable";
+ * both → "ready" (TOTP is the source of truth for backup codes).
+ */
+
+import { describe, expect, test, afterEach } from "bun:test";
+import { render, cleanup } from "@testing-library/react";
+
+import { BackupCodesStatus } from "../components/admin/security/backup-codes-status";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("BackupCodesStatus", () => {
+  test("required state when neither factor enrolled", () => {
+    render(<BackupCodesStatus totpEnabled={false} hasPasskey={false} />);
+    expect(document.body.textContent).toContain("Required");
+    expect(document.body.textContent).toContain("set up the authenticator app first");
+  });
+
+  test("not-applicable state when only a passkey is enrolled", () => {
+    render(<BackupCodesStatus totpEnabled={false} hasPasskey={true} />);
+    expect(document.body.textContent).toContain("Not applicable");
+    expect(document.body.textContent).toContain("recover by enrolling a second passkey");
+  });
+
+  test("ready state when TOTP is enrolled (no passkey)", () => {
+    render(<BackupCodesStatus totpEnabled={true} hasPasskey={false} />);
+    expect(document.body.textContent).toContain("Backup codes ready");
+    expect(document.body.textContent).toContain("Regenerate from the Authenticator tile");
+  });
+
+  test("ready state when both factors are enrolled (TOTP wins)", () => {
+    render(<BackupCodesStatus totpEnabled={true} hasPasskey={true} />);
+    expect(document.body.textContent).toContain("Backup codes ready");
+    expect(document.body.textContent).not.toContain("Not applicable");
+    expect(document.body.textContent).not.toContain("Required");
+  });
+});

--- a/packages/web/src/ui/__tests__/backup-codes-status.test.tsx
+++ b/packages/web/src/ui/__tests__/backup-codes-status.test.tsx
@@ -1,9 +1,7 @@
 /**
- * Tile state matrix for the backup-codes status tile (#2082 PR B).
- *
- * Brief asks for: no factors → backup codes "required";
- * TOTP only → "ready"; passkey only → "not applicable";
- * both → "ready" (TOTP is the source of truth for backup codes).
+ * Tile state matrix for the backup-codes status tile. Asserts: no factors →
+ * "required"; TOTP only → "ready"; passkey only → "not applicable"; both →
+ * "ready" (TOTP is the source of truth for backup codes).
  */
 
 import { describe, expect, test, afterEach } from "bun:test";

--- a/packages/web/src/ui/__tests__/mfa-enrollment-dialog.test.tsx
+++ b/packages/web/src/ui/__tests__/mfa-enrollment-dialog.test.tsx
@@ -85,15 +85,15 @@ describe("MfaEnrollmentDialog", () => {
     });
   });
 
-  test('"Enroll authenticator" routes to enrollmentUrl and clears gate state', async () => {
+  test('"Set up second factor" routes to enrollmentUrl and clears gate state', async () => {
     const { container } = renderDialog("/admin/settings/security");
 
     await waitFor(() => {
-      expect(document.body.textContent).toContain("Enroll authenticator");
+      expect(document.body.textContent).toContain("Set up second factor");
     });
 
     const enrollBtn = Array.from(document.querySelectorAll("button")).find((b) =>
-      b.textContent?.includes("Enroll authenticator"),
+      b.textContent?.includes("Set up second factor"),
     );
     expect(enrollBtn).toBeTruthy();
 

--- a/packages/web/src/ui/__tests__/passkey-list.test.tsx
+++ b/packages/web/src/ui/__tests__/passkey-list.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * Coverage for the enrolled-passkey list (#2082 PR B).
+ *
+ * Covers:
+ *  - Empty state copy
+ *  - Row rendering (name + createdAt)
+ *  - Rename dialog round-trip → calls updatePasskey + onChange
+ *  - Delete dialog round-trip → calls deletePasskey + onChange
+ */
+
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { render, fireEvent, waitFor, cleanup, act } from "@testing-library/react";
+
+const updatePasskeyMock = mock(async (_opts?: unknown) => ({
+  data: { passkey: { id: "pk_123", name: "Renamed", createdAt: new Date() } },
+  error: null,
+}));
+const deletePasskeyMock = mock(async (_opts?: unknown) => ({
+  data: { status: true },
+  error: null,
+}));
+
+mock.module("@/lib/auth/client", () => ({
+  authClient: {
+    passkey: {
+      updatePasskey: updatePasskeyMock,
+      deletePasskey: deletePasskeyMock,
+    },
+  },
+}));
+
+import { PasskeyList } from "../components/admin/security/passkey-list";
+
+beforeEach(() => {
+  updatePasskeyMock.mockClear();
+  deletePasskeyMock.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PasskeyList", () => {
+  test("empty state points at the tile", () => {
+    render(<PasskeyList passkeys={[]} />);
+    expect(document.body.textContent).toContain("No passkeys yet");
+    expect(document.body.textContent).toContain("Use the Passkey tile above");
+  });
+
+  test("renders each row with name + createdAt", () => {
+    render(
+      <PasskeyList
+        passkeys={[
+          { id: "pk_1", name: "MacBook · Safari", createdAt: new Date("2026-04-01T12:00:00Z") },
+          { id: "pk_2", name: "iPhone · Safari", createdAt: new Date("2026-04-15T12:00:00Z") },
+        ]}
+      />,
+    );
+    expect(document.body.textContent).toContain("MacBook · Safari");
+    expect(document.body.textContent).toContain("iPhone · Safari");
+    expect(document.body.textContent).toMatch(/Added\s+\w+/);
+  });
+
+  test("rename dialog calls updatePasskey and onChange", async () => {
+    const onChange = mock(() => {});
+    render(
+      <PasskeyList
+        passkeys={[
+          { id: "pk_1", name: "Old name", createdAt: new Date("2026-04-01T12:00:00Z") },
+        ]}
+        onChange={onChange}
+      />,
+    );
+
+    const renameBtn = Array.from(document.querySelectorAll("button")).find((b) =>
+      b.getAttribute("aria-label")?.startsWith("Rename"),
+    );
+    expect(renameBtn).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(renameBtn!);
+    });
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Rename passkey");
+    });
+
+    const input = document.querySelector('input[maxlength="80"]') as HTMLInputElement | null;
+    expect(input).toBeTruthy();
+    fireEvent.change(input!, { target: { value: "New name" } });
+
+    const saveBtn = Array.from(document.querySelectorAll("button")).find((b) =>
+      b.textContent?.trim() === "Save",
+    );
+
+    await act(async () => {
+      fireEvent.click(saveBtn!);
+    });
+
+    await waitFor(() => {
+      expect(updatePasskeyMock).toHaveBeenCalledTimes(1);
+    });
+    expect(updatePasskeyMock.mock.calls[0]?.[0]).toEqual({ id: "pk_1", name: "New name" });
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  test("delete dialog calls deletePasskey and onChange", async () => {
+    const onChange = mock(() => {});
+    render(
+      <PasskeyList
+        passkeys={[
+          { id: "pk_1", name: "Doomed key", createdAt: new Date("2026-04-01T12:00:00Z") },
+        ]}
+        onChange={onChange}
+      />,
+    );
+
+    const deleteBtn = Array.from(document.querySelectorAll("button")).find((b) =>
+      b.getAttribute("aria-label")?.startsWith("Delete"),
+    );
+    expect(deleteBtn).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(deleteBtn!);
+    });
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Delete passkey?");
+    });
+
+    // Confirm dialog presents the Delete action; click it.
+    const confirmBtn = Array.from(document.querySelectorAll("button")).find((b) =>
+      b.textContent?.trim() === "Delete",
+    );
+
+    await act(async () => {
+      fireEvent.click(confirmBtn!);
+    });
+
+    await waitFor(() => {
+      expect(deletePasskeyMock).toHaveBeenCalledTimes(1);
+    });
+    expect(deletePasskeyMock.mock.calls[0]?.[0]).toEqual({ id: "pk_1" });
+    expect(onChange).toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/ui/__tests__/passkey-list.test.tsx
+++ b/packages/web/src/ui/__tests__/passkey-list.test.tsx
@@ -1,15 +1,9 @@
 /**
- * Coverage for the enrolled-passkey list (#2082 PR B).
- *
- * Covers:
- *  - Empty state copy
- *  - Row rendering (name + createdAt)
- *  - Rename dialog round-trip → calls updatePasskey + onChange
- *  - Delete dialog round-trip → calls deletePasskey + onChange
+ * Coverage for the enrolled-passkey list.
  */
 
 import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
-import { render, fireEvent, waitFor, cleanup, act } from "@testing-library/react";
+import { render, fireEvent, waitFor, cleanup, act, screen } from "@testing-library/react";
 
 const updatePasskeyMock = mock(async (_opts?: unknown) => ({
   data: { passkey: { id: "pk_123", name: "Renamed", createdAt: new Date() } },
@@ -19,21 +13,28 @@ const deletePasskeyMock = mock(async (_opts?: unknown) => ({
   data: { status: true },
   error: null,
 }));
+const addPasskeyMock = mock(async (_opts?: unknown) => ({ data: null, error: null }));
+const listUserPasskeysMock = mock(async () => ({ data: [], error: null }));
 
-mock.module("@/lib/auth/client", () => ({
-  authClient: {
-    passkey: {
-      updatePasskey: updatePasskeyMock,
-      deletePasskey: deletePasskeyMock,
-    },
-  },
+mock.module("@/lib/auth/passkey-client", () => ({
+  getPasskeyClient: () => ({
+    addPasskey: addPasskeyMock,
+    updatePasskey: updatePasskeyMock,
+    listUserPasskeys: listUserPasskeysMock,
+    deletePasskey: deletePasskeyMock,
+  }),
 }));
 
 import { PasskeyList } from "../components/admin/security/passkey-list";
 
 beforeEach(() => {
-  updatePasskeyMock.mockClear();
-  deletePasskeyMock.mockClear();
+  updatePasskeyMock.mockReset();
+  deletePasskeyMock.mockReset();
+  updatePasskeyMock.mockImplementation(async () => ({
+    data: { passkey: { id: "pk_123", name: "Renamed", createdAt: new Date() } },
+    error: null,
+  }));
+  deletePasskeyMock.mockImplementation(async () => ({ data: { status: true }, error: null }));
 });
 
 afterEach(() => {
@@ -72,13 +73,8 @@ describe("PasskeyList", () => {
       />,
     );
 
-    const renameBtn = Array.from(document.querySelectorAll("button")).find((b) =>
-      b.getAttribute("aria-label")?.startsWith("Rename"),
-    );
-    expect(renameBtn).toBeTruthy();
-
     await act(async () => {
-      fireEvent.click(renameBtn!);
+      fireEvent.click(screen.getByRole("button", { name: /rename Old name/i }));
     });
 
     await waitFor(() => {
@@ -89,12 +85,8 @@ describe("PasskeyList", () => {
     expect(input).toBeTruthy();
     fireEvent.change(input!, { target: { value: "New name" } });
 
-    const saveBtn = Array.from(document.querySelectorAll("button")).find((b) =>
-      b.textContent?.trim() === "Save",
-    );
-
     await act(async () => {
-      fireEvent.click(saveBtn!);
+      fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
     });
 
     await waitFor(() => {
@@ -102,6 +94,37 @@ describe("PasskeyList", () => {
     });
     expect(updatePasskeyMock.mock.calls[0]?.[0]).toEqual({ id: "pk_1", name: "New name" });
     expect(onChange).toHaveBeenCalled();
+  });
+
+  test("rename guard blocks empty / whitespace-only names", async () => {
+    render(
+      <PasskeyList
+        passkeys={[
+          { id: "pk_1", name: "Old name", createdAt: new Date("2026-04-01T12:00:00Z") },
+        ]}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /rename Old name/i }));
+    });
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Rename passkey");
+    });
+
+    const input = document.querySelector('input[maxlength="80"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "   " } });
+
+    const saveBtn = screen.getByRole("button", { name: /^save$/i }) as HTMLButtonElement;
+    expect(saveBtn.disabled).toBe(true);
+
+    // Pressing Enter inside the input must not slip through the guard.
+    await act(async () => {
+      fireEvent.keyDown(input, { key: "Enter" });
+    });
+
+    expect(updatePasskeyMock).not.toHaveBeenCalled();
   });
 
   test("delete dialog calls deletePasskey and onChange", async () => {
@@ -115,26 +138,16 @@ describe("PasskeyList", () => {
       />,
     );
 
-    const deleteBtn = Array.from(document.querySelectorAll("button")).find((b) =>
-      b.getAttribute("aria-label")?.startsWith("Delete"),
-    );
-    expect(deleteBtn).toBeTruthy();
-
     await act(async () => {
-      fireEvent.click(deleteBtn!);
+      fireEvent.click(screen.getByRole("button", { name: /delete Doomed key/i }));
     });
 
     await waitFor(() => {
       expect(document.body.textContent).toContain("Delete passkey?");
     });
 
-    // Confirm dialog presents the Delete action; click it.
-    const confirmBtn = Array.from(document.querySelectorAll("button")).find((b) =>
-      b.textContent?.trim() === "Delete",
-    );
-
     await act(async () => {
-      fireEvent.click(confirmBtn!);
+      fireEvent.click(screen.getByRole("button", { name: /^delete$/i }));
     });
 
     await waitFor(() => {

--- a/packages/web/src/ui/__tests__/passkey-tile.test.tsx
+++ b/packages/web/src/ui/__tests__/passkey-tile.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * Coverage for the passkey enrollment tile + helpers (#2082 PR B).
+ *
+ * Covers:
+ *  - `deriveDefaultPasskeyName` — userAgent parsing fallbacks
+ *  - WebAuthn capability fallback (browser missing PublicKeyCredential)
+ *  - addPasskey() user-cancellation must not surface an error
+ *  - addPasskey() success opens the rename modal with the derived default
+ */
+
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { render, fireEvent, waitFor, cleanup, act } from "@testing-library/react";
+
+const addPasskeyMock = mock(async (_opts?: unknown) => ({ data: null, error: null }));
+const updatePasskeyMock = mock(async (_opts?: unknown) => ({ data: null, error: null }));
+
+mock.module("@/lib/auth/client", () => ({
+  authClient: {
+    passkey: {
+      addPasskey: addPasskeyMock,
+      updatePasskey: updatePasskeyMock,
+    },
+  },
+}));
+
+import {
+  PasskeyTile,
+  deriveDefaultPasskeyName,
+} from "../components/admin/security/passkey-tile";
+
+const originalPublicKeyCredential = (
+  globalThis as unknown as { PublicKeyCredential?: unknown }
+).PublicKeyCredential;
+
+function setPublicKeyCredential(value: unknown): void {
+  Object.defineProperty(globalThis, "PublicKeyCredential", {
+    value,
+    writable: true,
+    configurable: true,
+  });
+  // happy-dom mirrors `window`/`globalThis`, but defining on globalThis can
+  // skip the window proxy. Set it explicitly so the hook's typeof check sees it.
+  Object.defineProperty(window, "PublicKeyCredential", {
+    value,
+    writable: true,
+    configurable: true,
+  });
+}
+
+function restorePublicKeyCredential(): void {
+  setPublicKeyCredential(originalPublicKeyCredential);
+}
+
+beforeEach(() => {
+  addPasskeyMock.mockClear();
+  updatePasskeyMock.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+  restorePublicKeyCredential();
+});
+
+describe("deriveDefaultPasskeyName", () => {
+  test("recognizes Mac Safari", () => {
+    const ua =
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+    expect(deriveDefaultPasskeyName(ua)).toBe("Mac · Safari");
+  });
+
+  test("recognizes Windows Chrome", () => {
+    const ua =
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+    expect(deriveDefaultPasskeyName(ua)).toBe("Windows PC · Chrome");
+  });
+
+  test("recognizes iPhone Safari", () => {
+    const ua =
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+    expect(deriveDefaultPasskeyName(ua)).toBe("iPhone · Safari");
+  });
+
+  test("falls back when nothing matches", () => {
+    expect(deriveDefaultPasskeyName("ExoticHttpBot/1.0")).toBe("This device");
+  });
+
+  test("handles bare device without browser", () => {
+    expect(deriveDefaultPasskeyName("Mozilla/5.0 (Android; Mobile)")).toBe("Android");
+  });
+});
+
+describe("PasskeyTile", () => {
+  test("falls back to unsupported copy when PublicKeyCredential is missing", async () => {
+    setPublicKeyCredential(undefined);
+
+    render(<PasskeyTile hasPasskey={false} />);
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Passkey unavailable");
+    });
+    expect(document.body.textContent).toContain("Your browser doesn't support passkeys");
+  });
+
+  test("shows recommended badge when no passkey is enrolled and platform auth is available", async () => {
+    setPublicKeyCredential({
+      isUserVerifyingPlatformAuthenticatorAvailable: () => Promise.resolve(true),
+    });
+
+    render(<PasskeyTile hasPasskey={false} />);
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Recommended");
+    });
+    expect(document.body.textContent).toContain("Add a passkey");
+  });
+
+  test('"Add another passkey" replaces the primary CTA when one is already enrolled', async () => {
+    setPublicKeyCredential({
+      isUserVerifyingPlatformAuthenticatorAvailable: () => Promise.resolve(true),
+    });
+
+    render(<PasskeyTile hasPasskey={true} />);
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Add another passkey");
+    });
+    // The recommended badge should not appear when a passkey exists.
+    expect(document.body.textContent).not.toContain("Recommended");
+  });
+
+  test("user cancellation on the OS prompt does not surface an error", async () => {
+    setPublicKeyCredential({
+      isUserVerifyingPlatformAuthenticatorAvailable: () => Promise.resolve(true),
+    });
+    addPasskeyMock.mockImplementationOnce(async () => ({
+      data: null,
+      error: { code: "REGISTRATION_CANCELLED", message: "cancelled" },
+    }));
+
+    render(<PasskeyTile hasPasskey={false} />);
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Add a passkey");
+    });
+
+    const addBtn = Array.from(document.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("Add a passkey"),
+    );
+
+    await act(async () => {
+      fireEvent.click(addBtn!);
+    });
+
+    await waitFor(() => {
+      expect(addPasskeyMock).toHaveBeenCalledTimes(1);
+    });
+
+    // No error banner; the rename dialog should not open.
+    expect(document.body.textContent).not.toContain("Could not register that passkey");
+    expect(document.body.textContent).not.toContain("Name this passkey");
+  });
+
+  test("addPasskey() success opens the rename modal with a derived default", async () => {
+    setPublicKeyCredential({
+      isUserVerifyingPlatformAuthenticatorAvailable: () => Promise.resolve(true),
+    });
+    addPasskeyMock.mockImplementationOnce(async () => ({
+      data: { id: "pk_123", createdAt: new Date() },
+      error: null,
+    }));
+
+    render(<PasskeyTile hasPasskey={false} />);
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Add a passkey");
+    });
+
+    const addBtn = Array.from(document.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("Add a passkey"),
+    );
+
+    await act(async () => {
+      fireEvent.click(addBtn!);
+    });
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Name this passkey");
+    });
+  });
+});

--- a/packages/web/src/ui/__tests__/passkey-tile.test.tsx
+++ b/packages/web/src/ui/__tests__/passkey-tile.test.tsx
@@ -1,26 +1,22 @@
 /**
- * Coverage for the passkey enrollment tile + helpers (#2082 PR B).
- *
- * Covers:
- *  - `deriveDefaultPasskeyName` — userAgent parsing fallbacks
- *  - WebAuthn capability fallback (browser missing PublicKeyCredential)
- *  - addPasskey() user-cancellation must not surface an error
- *  - addPasskey() success opens the rename modal with the derived default
+ * Coverage for the passkey enrollment tile + helpers.
  */
 
 import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
-import { render, fireEvent, waitFor, cleanup, act } from "@testing-library/react";
+import { render, fireEvent, waitFor, cleanup, act, screen } from "@testing-library/react";
 
 const addPasskeyMock = mock(async (_opts?: unknown) => ({ data: null, error: null }));
 const updatePasskeyMock = mock(async (_opts?: unknown) => ({ data: null, error: null }));
+const listUserPasskeysMock = mock(async () => ({ data: [], error: null }));
+const deletePasskeyMock = mock(async (_opts?: unknown) => ({ data: { status: true }, error: null }));
 
-mock.module("@/lib/auth/client", () => ({
-  authClient: {
-    passkey: {
-      addPasskey: addPasskeyMock,
-      updatePasskey: updatePasskeyMock,
-    },
-  },
+mock.module("@/lib/auth/passkey-client", () => ({
+  getPasskeyClient: () => ({
+    addPasskey: addPasskeyMock,
+    updatePasskey: updatePasskeyMock,
+    listUserPasskeys: listUserPasskeysMock,
+    deletePasskey: deletePasskeyMock,
+  }),
 }));
 
 import {
@@ -38,8 +34,6 @@ function setPublicKeyCredential(value: unknown): void {
     writable: true,
     configurable: true,
   });
-  // happy-dom mirrors `window`/`globalThis`, but defining on globalThis can
-  // skip the window proxy. Set it explicitly so the hook's typeof check sees it.
   Object.defineProperty(window, "PublicKeyCredential", {
     value,
     writable: true,
@@ -52,8 +46,11 @@ function restorePublicKeyCredential(): void {
 }
 
 beforeEach(() => {
-  addPasskeyMock.mockClear();
-  updatePasskeyMock.mockClear();
+  addPasskeyMock.mockReset();
+  updatePasskeyMock.mockReset();
+  // Default no-op resolves so tests don't accidentally see a leaked impl.
+  addPasskeyMock.mockImplementation(async () => ({ data: null, error: null }));
+  updatePasskeyMock.mockImplementation(async () => ({ data: null, error: null }));
 });
 
 afterEach(() => {
@@ -101,6 +98,19 @@ describe("PasskeyTile", () => {
     expect(document.body.textContent).toContain("Your browser doesn't support passkeys");
   });
 
+  test("button is disabled while WebAuthn capability is still unknown", () => {
+    // Intentionally never resolve the platform-availability probe so the
+    // hook stays in the `unknown` state for the duration of the test.
+    setPublicKeyCredential({
+      isUserVerifyingPlatformAuthenticatorAvailable: () => new Promise(() => {}),
+    });
+
+    render(<PasskeyTile hasPasskey={false} />);
+
+    const addBtn = screen.getByRole("button", { name: /add a passkey/i }) as HTMLButtonElement;
+    expect(addBtn.disabled).toBe(true);
+  });
+
   test("shows recommended badge when no passkey is enrolled and platform auth is available", async () => {
     setPublicKeyCredential({
       isUserVerifyingPlatformAuthenticatorAvailable: () => Promise.resolve(true),
@@ -111,7 +121,22 @@ describe("PasskeyTile", () => {
     await waitFor(() => {
       expect(document.body.textContent).toContain("Recommended");
     });
-    expect(document.body.textContent).toContain("Add a passkey");
+    expect(screen.getByRole("button", { name: /add a passkey/i })).toBeDefined();
+  });
+
+  test("shows downgraded copy and no recommended badge when only roaming auth is available", async () => {
+    setPublicKeyCredential({
+      isUserVerifyingPlatformAuthenticatorAvailable: () => Promise.resolve(false),
+    });
+
+    render(<PasskeyTile hasPasskey={false} />);
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Limited support — security key only");
+    });
+    expect(document.body.textContent).not.toContain("Recommended");
+    const addBtn = screen.getByRole("button", { name: /add a passkey/i }) as HTMLButtonElement;
+    expect(addBtn.disabled).toBe(false);
   });
 
   test('"Add another passkey" replaces the primary CTA when one is already enrolled', async () => {
@@ -122,9 +147,8 @@ describe("PasskeyTile", () => {
     render(<PasskeyTile hasPasskey={true} />);
 
     await waitFor(() => {
-      expect(document.body.textContent).toContain("Add another passkey");
+      expect(screen.getByRole("button", { name: /add another passkey/i })).toBeDefined();
     });
-    // The recommended badge should not appear when a passkey exists.
     expect(document.body.textContent).not.toContain("Recommended");
   });
 
@@ -139,24 +163,40 @@ describe("PasskeyTile", () => {
 
     render(<PasskeyTile hasPasskey={false} />);
 
-    await waitFor(() => {
-      expect(document.body.textContent).toContain("Add a passkey");
-    });
-
-    const addBtn = Array.from(document.querySelectorAll("button")).find((b) =>
-      b.textContent?.includes("Add a passkey"),
-    );
+    const addBtn = await screen.findByRole("button", { name: /add a passkey/i });
 
     await act(async () => {
-      fireEvent.click(addBtn!);
+      fireEvent.click(addBtn);
     });
 
     await waitFor(() => {
       expect(addPasskeyMock).toHaveBeenCalledTimes(1);
     });
 
-    // No error banner; the rename dialog should not open.
     expect(document.body.textContent).not.toContain("Could not register that passkey");
+    expect(document.body.textContent).not.toContain("Name this passkey");
+  });
+
+  test("real server error surfaces a banner with the message", async () => {
+    setPublicKeyCredential({
+      isUserVerifyingPlatformAuthenticatorAvailable: () => Promise.resolve(true),
+    });
+    addPasskeyMock.mockImplementationOnce(async () => ({
+      data: null,
+      error: { code: "BAD_RP_ID", message: "Origin mismatch", status: 400 },
+    }));
+
+    render(<PasskeyTile hasPasskey={false} />);
+
+    const addBtn = await screen.findByRole("button", { name: /add a passkey/i });
+
+    await act(async () => {
+      fireEvent.click(addBtn);
+    });
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Origin mismatch");
+    });
     expect(document.body.textContent).not.toContain("Name this passkey");
   });
 
@@ -171,20 +211,58 @@ describe("PasskeyTile", () => {
 
     render(<PasskeyTile hasPasskey={false} />);
 
-    await waitFor(() => {
-      expect(document.body.textContent).toContain("Add a passkey");
-    });
-
-    const addBtn = Array.from(document.querySelectorAll("button")).find((b) =>
-      b.textContent?.includes("Add a passkey"),
-    );
+    const addBtn = await screen.findByRole("button", { name: /add a passkey/i });
 
     await act(async () => {
-      fireEvent.click(addBtn!);
+      fireEvent.click(addBtn);
     });
 
     await waitFor(() => {
       expect(document.body.textContent).toContain("Name this passkey");
     });
+  });
+
+  test("rename failure after successful enrollment fires onChange and shows recovery hint", async () => {
+    setPublicKeyCredential({
+      isUserVerifyingPlatformAuthenticatorAvailable: () => Promise.resolve(true),
+    });
+    addPasskeyMock.mockImplementationOnce(async () => ({
+      data: { id: "pk_456", createdAt: new Date() },
+      error: null,
+    }));
+    updatePasskeyMock.mockImplementationOnce(async () => ({
+      data: null,
+      error: { code: "FAILED_TO_UPDATE_PASSKEY", message: "DB write timeout", status: 500 },
+    }));
+
+    const onChange = mock(() => {});
+    render(<PasskeyTile hasPasskey={false} onChange={onChange} />);
+
+    const addBtn = await screen.findByRole("button", { name: /add a passkey/i });
+    await act(async () => {
+      fireEvent.click(addBtn);
+    });
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Name this passkey");
+    });
+
+    const saveBtn = await screen.findByRole("button", { name: /^save$/i });
+    await act(async () => {
+      fireEvent.click(saveBtn);
+    });
+
+    await waitFor(() => {
+      expect(updatePasskeyMock).toHaveBeenCalledTimes(1);
+    });
+
+    // Dialog closes; parent is asked to refetch; recovery hint is visible.
+    await waitFor(() => {
+      expect(document.body.textContent).not.toContain("Name this passkey");
+    });
+    expect(onChange).toHaveBeenCalled();
+    expect(document.body.textContent).toContain("Saved your passkey, but renaming failed");
+    expect(document.body.textContent).toContain("DB write timeout");
+    expect(document.body.textContent).toContain("rename it from the list below");
   });
 });

--- a/packages/web/src/ui/components/admin/mfa-enrollment-dialog.tsx
+++ b/packages/web/src/ui/components/admin/mfa-enrollment-dialog.tsx
@@ -77,12 +77,12 @@ export function MfaEnrollmentDialog() {
           </AlertDialogTitle>
           <AlertDialogDescription className="w-full text-center">
             Admin accounts must enroll a second factor before accessing the
-            admin console. Set up an authenticator app to continue.
+            admin console. Set up an authenticator app or passkey to continue.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter className="sm:flex-col sm:gap-2 sm:space-x-0">
           <AlertDialogAction onClick={handleEnroll}>
-            Enroll authenticator
+            Set up second factor
           </AlertDialogAction>
           <AlertDialogCancel onClick={handleSignOut} className="mt-0">
             Sign out

--- a/packages/web/src/ui/components/admin/security/backup-codes-status.tsx
+++ b/packages/web/src/ui/components/admin/security/backup-codes-status.tsx
@@ -1,23 +1,20 @@
 "use client";
 
 /**
- * Read-only status tile for backup codes (#2082 PR B).
+ * Read-only status tile for backup codes.
  *
  * Backup codes are issued and regenerated inside the TOTP enrollment flow
  * (see `two-factor-setup.tsx`); this tile never exposes its own "enroll"
- * affordance. The four states surface what the user should think about
- * next, not what action is available here:
+ * affordance. Three states surface what the user should think about next,
+ * not what action is available here:
  *
- *   - `passkey-only`   — only a passkey is enrolled. Backup codes don't
- *                        apply because there's no shared secret to recover.
- *   - `totp-required`  — neither TOTP nor a passkey is enrolled. Set up
- *                        TOTP first to receive codes.
- *   - `totp-pending`   — only a passkey is enrolled but the user has just
- *                        opened TOTP enrollment. (Reserved — not used yet;
- *                        see comment below.)
- *   - `enrolled`       — TOTP is on, so a fresh code set was issued during
- *                        enrollment. The "Regenerate backup codes" button
- *                        on the TOTP tile owns rotation.
+ *   - `passkey-only`  — only a passkey is enrolled. Backup codes don't
+ *                       apply because there's no shared secret to recover.
+ *   - `totp-required` — neither TOTP nor a passkey is enrolled. Set up
+ *                       TOTP first to receive codes.
+ *   - `enrolled`      — TOTP is on, so a fresh code set was issued during
+ *                       enrollment. The "Regenerate backup codes" button
+ *                       on the TOTP tile owns rotation.
  */
 
 import { CheckCircle2, FileKey, ShieldQuestion } from "lucide-react";

--- a/packages/web/src/ui/components/admin/security/backup-codes-status.tsx
+++ b/packages/web/src/ui/components/admin/security/backup-codes-status.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+/**
+ * Read-only status tile for backup codes (#2082 PR B).
+ *
+ * Backup codes are issued and regenerated inside the TOTP enrollment flow
+ * (see `two-factor-setup.tsx`); this tile never exposes its own "enroll"
+ * affordance. The four states surface what the user should think about
+ * next, not what action is available here:
+ *
+ *   - `passkey-only`   — only a passkey is enrolled. Backup codes don't
+ *                        apply because there's no shared secret to recover.
+ *   - `totp-required`  — neither TOTP nor a passkey is enrolled. Set up
+ *                        TOTP first to receive codes.
+ *   - `totp-pending`   — only a passkey is enrolled but the user has just
+ *                        opened TOTP enrollment. (Reserved — not used yet;
+ *                        see comment below.)
+ *   - `enrolled`       — TOTP is on, so a fresh code set was issued during
+ *                        enrollment. The "Regenerate backup codes" button
+ *                        on the TOTP tile owns rotation.
+ */
+
+import { CheckCircle2, FileKey, ShieldQuestion } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export interface BackupCodesStatusProps {
+  totpEnabled: boolean;
+  hasPasskey: boolean;
+}
+
+interface StatusCopy {
+  title: string;
+  body: string;
+  Icon: typeof CheckCircle2;
+  tone: "muted" | "amber" | "emerald";
+}
+
+function pickCopy({ totpEnabled, hasPasskey }: BackupCodesStatusProps): StatusCopy {
+  if (totpEnabled) {
+    return {
+      title: "Backup codes ready",
+      body: "Codes were issued when you enrolled the authenticator app. Regenerate from the Authenticator tile if you've lost them.",
+      Icon: CheckCircle2,
+      tone: "emerald",
+    };
+  }
+  if (hasPasskey) {
+    return {
+      title: "Not applicable",
+      body: "Backup codes pair with an authenticator app. Passkey-only accounts recover by enrolling a second passkey.",
+      Icon: FileKey,
+      tone: "muted",
+    };
+  }
+  return {
+    title: "Required — set up the authenticator app first",
+    body: "Backup codes are issued the moment you enable an authenticator. They aren't a standalone factor.",
+    Icon: ShieldQuestion,
+    tone: "amber",
+  };
+}
+
+const TONE_CLASSES = {
+  muted: "border bg-muted/30 text-muted-foreground",
+  amber: "border bg-amber-500/5 text-amber-600 dark:text-amber-400",
+  emerald: "border bg-emerald-500/5 text-emerald-600 dark:text-emerald-400",
+} as const;
+
+export function BackupCodesStatus(props: BackupCodesStatusProps) {
+  const { title, body, Icon, tone } = pickCopy(props);
+
+  return (
+    <Card>
+      <CardHeader className="flex-row items-center gap-3 space-y-0">
+        <span
+          className={`grid size-9 shrink-0 place-items-center rounded-lg ${TONE_CLASSES[tone]}`}
+        >
+          <Icon className="size-4" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <CardTitle className="text-sm font-semibold">Backup codes</CardTitle>
+          <p className="text-xs text-muted-foreground">{title}</p>
+        </div>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <p className="text-xs text-muted-foreground">{body}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/web/src/ui/components/admin/security/passkey-list.tsx
+++ b/packages/web/src/ui/components/admin/security/passkey-list.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+/**
+ * Enrolled-passkey list rendered below the security tiles on
+ * /admin/settings/security (#2082 PR B).
+ *
+ * Each row shows the passkey's name, creation date, and rename/delete
+ * affordances. Better Auth's `passkey` model doesn't track last-used time —
+ * see `Passkey` in `@better-auth/passkey/dist/index-*.d.mts` — so we don't
+ * surface one. Rename uses `authClient.passkey.updatePasskey({ id, name })`
+ * and delete uses `authClient.passkey.deletePasskey({ id })`.
+ *
+ * The list itself is owned by the parent page (driven off
+ * `authClient.passkey.listUserPasskeys()`); this component is a controlled
+ * renderer that calls back via `onChange()` after any mutation.
+ */
+
+import { useState } from "react";
+import { Loader2, Pencil, Trash2 } from "lucide-react";
+import { authClient } from "@/lib/auth/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PasskeyRow {
+  id: string;
+  name?: string;
+  createdAt: Date | string;
+}
+
+type ClientResult<T> = {
+  data: T | null;
+  error: { message?: string; code?: string; status?: number } | null;
+};
+
+interface PasskeyClient {
+  updatePasskey: (opts: { id: string; name: string }) => Promise<ClientResult<{ passkey: PasskeyRow }>>;
+  deletePasskey: (opts: { id: string }) => Promise<ClientResult<{ status?: boolean }>>;
+}
+
+function getPasskeyClient(): PasskeyClient {
+  const namespace = (authClient as unknown as { passkey?: PasskeyClient }).passkey;
+  if (!namespace) {
+    throw new Error(
+      "Better Auth passkey client plugin is not loaded — check packages/web/src/lib/auth/client.ts",
+    );
+  }
+  return namespace;
+}
+
+function formatCreatedAt(value: Date | string): string {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return "Unknown";
+  return date.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface PasskeyListProps {
+  passkeys: PasskeyRow[];
+  /** Called after a successful rename or delete so the parent can refetch. */
+  onChange?: () => void;
+}
+
+type Dialog =
+  | { kind: "rename"; id: string; current: string }
+  | { kind: "delete"; id: string; current: string };
+
+export function PasskeyList({ passkeys, onChange }: PasskeyListProps) {
+  const [dialog, setDialog] = useState<Dialog | null>(null);
+  const [draft, setDraft] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function openRename(row: PasskeyRow) {
+    setError(null);
+    setDraft(row.name ?? "");
+    setDialog({ kind: "rename", id: row.id, current: row.name ?? row.id });
+  }
+
+  function openDelete(row: PasskeyRow) {
+    setError(null);
+    setDialog({ kind: "delete", id: row.id, current: row.name ?? row.id });
+  }
+
+  function closeDialog() {
+    setDialog(null);
+    setDraft("");
+    setError(null);
+  }
+
+  async function handleRename() {
+    if (!dialog || dialog.kind !== "rename") return;
+    const trimmed = draft.trim();
+    if (!trimmed) {
+      setError("Name can't be empty.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    let result: ClientResult<{ passkey: PasskeyRow }>;
+    try {
+      result = await getPasskeyClient().updatePasskey({ id: dialog.id, name: trimmed });
+    } catch (err) {
+      setBusy(false);
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn("[passkey] updatePasskey threw", msg);
+      setError("Could not save that name. Please try again.");
+      return;
+    }
+    setBusy(false);
+    if (result.error) {
+      console.warn("[passkey] updatePasskey failed", result.error);
+      setError(result.error.message ?? "Could not save that name. Please try again.");
+      return;
+    }
+    closeDialog();
+    onChange?.();
+  }
+
+  async function handleDelete() {
+    if (!dialog || dialog.kind !== "delete") return;
+    setBusy(true);
+    setError(null);
+    let result: ClientResult<{ status?: boolean }>;
+    try {
+      result = await getPasskeyClient().deletePasskey({ id: dialog.id });
+    } catch (err) {
+      setBusy(false);
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn("[passkey] deletePasskey threw", msg);
+      setError("Could not delete that passkey. Please try again.");
+      return;
+    }
+    setBusy(false);
+    if (result.error) {
+      console.warn("[passkey] deletePasskey failed", result.error);
+      setError(result.error.message ?? "Could not delete that passkey. Please try again.");
+      return;
+    }
+    closeDialog();
+    onChange?.();
+  }
+
+  // ── Render ─────────────────────────────────────────────────────────
+
+  if (passkeys.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed bg-card/30 p-6 text-center">
+        <p className="text-sm font-medium">No passkeys yet</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Use the Passkey tile above to enroll your first one.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <h2 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        Enrolled passkeys
+      </h2>
+      <ul className="divide-y rounded-lg border bg-card/40">
+        {passkeys.map((row) => (
+          <li
+            key={row.id}
+            className="flex items-center justify-between gap-3 px-4 py-3"
+          >
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-medium">
+                {row.name ?? <span className="italic text-muted-foreground">Unnamed passkey</span>}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Added {formatCreatedAt(row.createdAt)}
+              </p>
+            </div>
+            <div className="flex shrink-0 gap-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => openRename(row)}
+                aria-label={`Rename ${row.name ?? "passkey"}`}
+              >
+                <Pencil className="size-3.5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => openDelete(row)}
+                aria-label={`Delete ${row.name ?? "passkey"}`}
+                className="text-destructive hover:text-destructive"
+              >
+                <Trash2 className="size-3.5" />
+              </Button>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      <AlertDialog open={dialog !== null} onOpenChange={(open) => !open && closeDialog()}>
+        <AlertDialogContent className="sm:max-w-md">
+          {dialog?.kind === "rename" && (
+            <>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Rename passkey</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Choose a name you'll recognize later. The passkey itself
+                  isn't affected — only the label.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <div className="space-y-1.5 py-2">
+                <label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  Passkey name
+                </label>
+                <Input
+                  value={draft}
+                  onChange={(e) => setDraft(e.target.value)}
+                  maxLength={80}
+                  autoFocus
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      void handleRename();
+                    }
+                  }}
+                />
+                {error && <p className="text-sm text-destructive">{error}</p>}
+              </div>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={(e) => {
+                    e.preventDefault();
+                    void handleRename();
+                  }}
+                  disabled={busy || !draft.trim()}
+                >
+                  {busy ? <Loader2 className="mr-1.5 size-3.5 animate-spin" /> : null}
+                  Save
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </>
+          )}
+          {dialog?.kind === "delete" && (
+            <>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Delete passkey?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Removing <span className="font-medium">{dialog.current}</span>
+                  {" "}means it can no longer be used to sign in. If it's your
+                  only second factor, set up an authenticator app first.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              {error && (
+                <p className="px-1 pb-1 text-sm text-destructive">{error}</p>
+              )}
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={(e) => {
+                    e.preventDefault();
+                    void handleDelete();
+                  }}
+                  disabled={busy}
+                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                >
+                  {busy ? <Loader2 className="mr-1.5 size-3.5 animate-spin" /> : null}
+                  Delete
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </>
+          )}
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/packages/web/src/ui/components/admin/security/passkey-list.tsx
+++ b/packages/web/src/ui/components/admin/security/passkey-list.tsx
@@ -1,23 +1,17 @@
 "use client";
 
 /**
- * Enrolled-passkey list rendered below the security tiles on
- * /admin/settings/security (#2082 PR B).
+ * Enrolled-passkey list rendered below the security tiles.
  *
  * Each row shows the passkey's name, creation date, and rename/delete
- * affordances. Better Auth's `passkey` model doesn't track last-used time —
- * see `Passkey` in `@better-auth/passkey/dist/index-*.d.mts` — so we don't
- * surface one. Rename uses `authClient.passkey.updatePasskey({ id, name })`
- * and delete uses `authClient.passkey.deletePasskey({ id })`.
- *
- * The list itself is owned by the parent page (driven off
- * `authClient.passkey.listUserPasskeys()`); this component is a controlled
- * renderer that calls back via `onChange()` after any mutation.
+ * affordances. Better Auth's passkey model doesn't track last-used time,
+ * so we don't surface one. The list is owned by the parent page (driven
+ * off `listUserPasskeys()`); this component is a controlled renderer
+ * that calls back via `onChange()` after any mutation.
  */
 
 import { useState } from "react";
 import { Loader2, Pencil, Trash2 } from "lucide-react";
-import { authClient } from "@/lib/auth/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -30,36 +24,9 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { getPasskeyClient, type Passkey } from "@/lib/auth/passkey-client";
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface PasskeyRow {
-  id: string;
-  name?: string;
-  createdAt: Date | string;
-}
-
-type ClientResult<T> = {
-  data: T | null;
-  error: { message?: string; code?: string; status?: number } | null;
-};
-
-interface PasskeyClient {
-  updatePasskey: (opts: { id: string; name: string }) => Promise<ClientResult<{ passkey: PasskeyRow }>>;
-  deletePasskey: (opts: { id: string }) => Promise<ClientResult<{ status?: boolean }>>;
-}
-
-function getPasskeyClient(): PasskeyClient {
-  const namespace = (authClient as unknown as { passkey?: PasskeyClient }).passkey;
-  if (!namespace) {
-    throw new Error(
-      "Better Auth passkey client plugin is not loaded — check packages/web/src/lib/auth/client.ts",
-    );
-  }
-  return namespace;
-}
+export type PasskeyRow = Passkey;
 
 function formatCreatedAt(value: Date | string): string {
   const date = value instanceof Date ? value : new Date(value);
@@ -78,19 +45,17 @@ export interface PasskeyListProps {
 }
 
 type Dialog =
-  | { kind: "rename"; id: string; current: string }
+  | { kind: "rename"; id: string; current: string; draft: string }
   | { kind: "delete"; id: string; current: string };
 
 export function PasskeyList({ passkeys, onChange }: PasskeyListProps) {
   const [dialog, setDialog] = useState<Dialog | null>(null);
-  const [draft, setDraft] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   function openRename(row: PasskeyRow) {
     setError(null);
-    setDraft(row.name ?? "");
-    setDialog({ kind: "rename", id: row.id, current: row.name ?? row.id });
+    setDialog({ kind: "rename", id: row.id, current: row.name ?? row.id, draft: row.name ?? "" });
   }
 
   function openDelete(row: PasskeyRow) {
@@ -100,22 +65,26 @@ export function PasskeyList({ passkeys, onChange }: PasskeyListProps) {
 
   function closeDialog() {
     setDialog(null);
-    setDraft("");
     setError(null);
   }
 
   async function handleRename() {
     if (!dialog || dialog.kind !== "rename") return;
-    const trimmed = draft.trim();
+    const trimmed = dialog.draft.trim();
     if (!trimmed) {
       setError("Name can't be empty.");
       return;
     }
+    const client = getPasskeyClient();
+    if (!client) {
+      setError("Passkey support couldn't be loaded. Refresh the page and try again.");
+      return;
+    }
     setBusy(true);
     setError(null);
-    let result: ClientResult<{ passkey: PasskeyRow }>;
+    let result: Awaited<ReturnType<typeof client.updatePasskey>>;
     try {
-      result = await getPasskeyClient().updatePasskey({ id: dialog.id, name: trimmed });
+      result = await client.updatePasskey({ id: dialog.id, name: trimmed });
     } catch (err) {
       setBusy(false);
       const msg = err instanceof Error ? err.message : String(err);
@@ -135,11 +104,16 @@ export function PasskeyList({ passkeys, onChange }: PasskeyListProps) {
 
   async function handleDelete() {
     if (!dialog || dialog.kind !== "delete") return;
+    const client = getPasskeyClient();
+    if (!client) {
+      setError("Passkey support couldn't be loaded. Refresh the page and try again.");
+      return;
+    }
     setBusy(true);
     setError(null);
-    let result: ClientResult<{ status?: boolean }>;
+    let result: Awaited<ReturnType<typeof client.deletePasskey>>;
     try {
-      result = await getPasskeyClient().deletePasskey({ id: dialog.id });
+      result = await client.deletePasskey({ id: dialog.id });
     } catch (err) {
       setBusy(false);
       const msg = err instanceof Error ? err.message : String(err);
@@ -228,8 +202,14 @@ export function PasskeyList({ passkeys, onChange }: PasskeyListProps) {
                   Passkey name
                 </label>
                 <Input
-                  value={draft}
-                  onChange={(e) => setDraft(e.target.value)}
+                  value={dialog.draft}
+                  onChange={(e) =>
+                    setDialog((prev) =>
+                      prev && prev.kind === "rename"
+                        ? { ...prev, draft: e.target.value }
+                        : prev,
+                    )
+                  }
                   maxLength={80}
                   autoFocus
                   onKeyDown={(e) => {
@@ -248,7 +228,7 @@ export function PasskeyList({ passkeys, onChange }: PasskeyListProps) {
                     e.preventDefault();
                     void handleRename();
                   }}
-                  disabled={busy || !draft.trim()}
+                  disabled={busy || !dialog.draft.trim()}
                 >
                   {busy ? <Loader2 className="mr-1.5 size-3.5 animate-spin" /> : null}
                   Save

--- a/packages/web/src/ui/components/admin/security/passkey-tile.tsx
+++ b/packages/web/src/ui/components/admin/security/passkey-tile.tsx
@@ -2,27 +2,22 @@
 
 /**
  * Passkey enrollment tile, mounted inside `/admin/settings/security` next to
- * the TOTP and backup-codes tiles (#2082 PR B).
+ * the TOTP and backup-codes tiles.
  *
  * Click flow:
- *   1. Tile button → `authClient.passkey.addPasskey()` (no name passed).
+ *   1. Tile button → `addPasskey()` (no name passed).
  *   2. OS biometric prompt fires immediately.
  *   3. On success Better Auth returns the new {@link Passkey} including its id.
  *   4. We render an in-component name modal with a userAgent-derived default
- *      and persist the user's choice via `authClient.passkey.updatePasskey({ id, name })`.
+ *      and persist the user's choice via `updatePasskey({ id, name })`.
  *
  * Naming AFTER enrollment (rather than passing a name into addPasskey) means
  * users hit the OS prompt with one click — and a cancelled OS prompt never
  * leaves an orphaned name in flight.
- *
- * Tile state matrix is owned by the parent page (`security/page.tsx`); this
- * component just renders + reports back via `onChange()` so the page can
- * refetch the passkey list and surface the new row.
  */
 
 import { useState } from "react";
 import { Fingerprint, KeyRound, Loader2, ShieldX } from "lucide-react";
-import { authClient } from "@/lib/auth/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -37,51 +32,19 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import {
+  getPasskeyClient,
+  type PasskeyApiError,
+} from "@/lib/auth/passkey-client";
 import { useWebAuthnSupported } from "@/ui/hooks/use-webauthn-supported";
-
-// ---------------------------------------------------------------------------
-// Types — narrow view into the Better Auth passkey client surface
-// ---------------------------------------------------------------------------
-
-interface Passkey {
-  id: string;
-  name?: string;
-  createdAt: Date | string;
-}
-
-type ClientResult<T> = {
-  data: T | null;
-  error: { message?: string; code?: string; status?: number } | null;
-};
-
-interface PasskeyClient {
-  addPasskey: (opts?: {
-    name?: string;
-    authenticatorAttachment?: "platform" | "cross-platform";
-  }) => Promise<ClientResult<Passkey>>;
-  updatePasskey: (opts: { id: string; name: string }) => Promise<ClientResult<{ passkey: Passkey }>>;
-}
-
-function getPasskeyClient(): PasskeyClient {
-  const namespace = (authClient as unknown as { passkey?: PasskeyClient }).passkey;
-  if (!namespace) {
-    throw new Error(
-      "Better Auth passkey client plugin is not loaded — check packages/web/src/lib/auth/client.ts",
-    );
-  }
-  return namespace;
-}
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 /**
- * Best-effort default name for a fresh passkey.
- *
- * The userAgent string is famously messy. We don't try to be clever — match
- * a handful of obvious tokens, fall back to "This device" when nothing
- * matches. The user can always overwrite the field before saving.
+ * Best-effort default name for a fresh passkey, matched off `navigator.userAgent`.
+ * The user can always overwrite the field before saving.
  */
 export function deriveDefaultPasskeyName(ua: string): string {
   const lower = ua.toLowerCase();
@@ -110,15 +73,15 @@ function getDefaultName(): string {
 
 /**
  * Better Auth surfaces user-cancelled WebAuthn flows with code
- * `REGISTRATION_CANCELLED` — distinguish them from real errors so the UI
- * doesn't shout "system error" when the user hits "Cancel" on the OS prompt.
+ * `REGISTRATION_CANCELLED`. Browsers also raise `NotAllowedError` for several
+ * non-cancellation reasons (RP ID mismatch, authenticator timeout, etc.) —
+ * those are *not* cancellations, but the message folds them into the same
+ * shape. Callers must always log on this branch so a misconfigured RP ID
+ * doesn't disappear into a silent no-op.
  */
-function isUserCancellation(error: ClientResult<unknown>["error"]): boolean {
+function isUserCancellation(error: PasskeyApiError | null): boolean {
   if (!error) return false;
   if (error.code === "REGISTRATION_CANCELLED") return true;
-  // Browsers surface the underlying DOMException as `NotAllowedError` when
-  // the user dismisses the platform prompt; Better Auth currently passes
-  // its message through unchanged for non-mapped errors.
   const msg = error.message?.toLowerCase() ?? "";
   return msg.includes("notallowed") || msg.includes("cancelled") || msg.includes("canceled");
 }
@@ -140,18 +103,25 @@ export interface PasskeyTileProps {
 }
 
 export function PasskeyTile({ hasPasskey, onChange }: PasskeyTileProps) {
-  const { supported, platformSupported } = useWebAuthnSupported();
+  const support = useWebAuthnSupported();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [namingHint, setNamingHint] = useState<string | null>(null);
   const [pending, setPending] = useState<{ id: string; defaultName: string } | null>(null);
   const [name, setName] = useState("");
 
   async function handleAdd() {
+    const client = getPasskeyClient();
+    if (!client) {
+      setError("Passkey support couldn't be loaded. Refresh the page and try again.");
+      return;
+    }
     setBusy(true);
     setError(null);
-    let result: ClientResult<Passkey>;
+    setNamingHint(null);
+    let result: Awaited<ReturnType<typeof client.addPasskey>>;
     try {
-      result = await getPasskeyClient().addPasskey();
+      result = await client.addPasskey();
     } catch (err) {
       setBusy(false);
       const msg = err instanceof Error ? err.message : String(err);
@@ -163,9 +133,10 @@ export function PasskeyTile({ hasPasskey, onChange }: PasskeyTileProps) {
 
     if (result.error) {
       if (isUserCancellation(result.error)) {
-        // No-op: user dismissed the OS prompt themselves; surfacing an
-        // error here just looks like a bug. Returning silently lets them
-        // tap the tile again.
+        // Always log — even on the "expected" cancellation branch — so a
+        // misconfigured RP ID (very plausible in self-hosted deploys where
+        // the cookie domain ≠ API host) doesn't disappear silently.
+        console.debug("[passkey] addPasskey cancelled or NotAllowedError", result.error);
         return;
       }
       console.warn("[passkey] addPasskey failed", result.error);
@@ -174,8 +145,9 @@ export function PasskeyTile({ hasPasskey, onChange }: PasskeyTileProps) {
     }
 
     if (!result.data) {
-      // Shouldn't happen, but the wire shape technically allows it. Surface
-      // a generic message rather than failing silently.
+      // The wire shape technically allows `{ data: null, error: null }`.
+      // Log so a regression is visible in DevTools instead of silent.
+      console.warn("[passkey] addPasskey returned data:null without error", result);
       setError("Passkey was registered but no details were returned. Refresh to confirm.");
       onChange?.();
       return;
@@ -189,21 +161,31 @@ export function PasskeyTile({ hasPasskey, onChange }: PasskeyTileProps) {
 
   async function handleSaveName() {
     if (!pending) return;
+    const client = getPasskeyClient();
+    if (!client) {
+      // Naming is cosmetic — the passkey is already enrolled. Surface the
+      // failure as a recoverable hint and let the parent refetch.
+      setPending(null);
+      onChange?.();
+      setNamingHint(
+        "Saved your passkey, but the rename request couldn't be sent. Rename it from the list below.",
+      );
+      return;
+    }
     const trimmed = name.trim() || pending.defaultName;
     setBusy(true);
-    setError(null);
-    let result: ClientResult<{ passkey: Passkey }>;
+    let result: Awaited<ReturnType<typeof client.updatePasskey>>;
     try {
-      result = await getPasskeyClient().updatePasskey({ id: pending.id, name: trimmed });
+      result = await client.updatePasskey({ id: pending.id, name: trimmed });
     } catch (err) {
       setBusy(false);
       const msg = err instanceof Error ? err.message : String(err);
       console.warn("[passkey] updatePasskey threw", msg);
-      // Naming is cosmetic — the passkey is enrolled. Close the dialog and
-      // let the parent refetch; the row will just show the unnamed default.
       setPending(null);
       onChange?.();
-      setError(`Saved your passkey, but renaming failed: ${msg}. You can rename it from the list.`);
+      setNamingHint(
+        `Saved your passkey, but renaming failed: ${msg}. You can rename it from the list below.`,
+      );
       return;
     }
     setBusy(false);
@@ -212,8 +194,8 @@ export function PasskeyTile({ hasPasskey, onChange }: PasskeyTileProps) {
       console.warn("[passkey] updatePasskey failed", result.error);
       setPending(null);
       onChange?.();
-      setError(
-        `Saved your passkey, but renaming failed: ${result.error.message ?? "unknown error"}. You can rename it from the list.`,
+      setNamingHint(
+        `Saved your passkey, but renaming failed: ${result.error.message ?? "unknown error"}. You can rename it from the list below.`,
       );
       return;
     }
@@ -222,9 +204,16 @@ export function PasskeyTile({ hasPasskey, onChange }: PasskeyTileProps) {
     onChange?.();
   }
 
+  function handleSkipNaming() {
+    if (!pending) return;
+    console.debug("[passkey] user skipped naming", { id: pending.id });
+    setPending(null);
+    onChange?.();
+  }
+
   // ── Render ─────────────────────────────────────────────────────────
 
-  if (supported === false) {
+  if (support.kind === "unsupported") {
     return (
       <Card className="opacity-70">
         <CardHeader className="flex-row items-center gap-3 space-y-0">
@@ -242,9 +231,11 @@ export function PasskeyTile({ hasPasskey, onChange }: PasskeyTileProps) {
     );
   }
 
-  const showRecommendedBadge = !hasPasskey && supported === true && platformSupported !== false;
+  const platformAuthenticatorAvailable =
+    support.kind === "supported" ? support.platformAuthenticator : false;
+  const showRecommendedBadge = !hasPasskey && support.kind === "supported" && platformAuthenticatorAvailable;
   const subtitle =
-    platformSupported === false
+    support.kind === "supported" && !platformAuthenticatorAvailable
       ? "Limited support — security key only. Connect a hardware key (e.g. YubiKey) to continue."
       : "Phishing-resistant. Works with Touch ID, Face ID, Windows Hello, or a security key.";
 
@@ -271,24 +262,21 @@ export function PasskeyTile({ hasPasskey, onChange }: PasskeyTileProps) {
           </div>
         </CardHeader>
         <CardContent className="pt-0">
-          <Button onClick={handleAdd} disabled={busy || supported !== true}>
+          <Button onClick={handleAdd} disabled={busy || support.kind !== "supported"}>
             {busy ? <Loader2 className="mr-1.5 size-3.5 animate-spin" /> : <KeyRound className="mr-1.5 size-3.5" />}
             {hasPasskey ? "Add another passkey" : "Add a passkey"}
           </Button>
           {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
+          {namingHint && (
+            <p className="mt-2 text-sm text-amber-700 dark:text-amber-300">{namingHint}</p>
+          )}
         </CardContent>
       </Card>
 
       <AlertDialog
         open={pending !== null}
         onOpenChange={(open) => {
-          if (!open) {
-            // Dismissing the rename dialog still leaves the passkey enrolled —
-            // it just won't have a custom name. Trigger a refetch so the row
-            // appears in the list.
-            setPending(null);
-            onChange?.();
-          }
+          if (!open) handleSkipNaming();
         }}
       >
         <AlertDialogContent className="sm:max-w-md">
@@ -318,14 +306,7 @@ export function PasskeyTile({ hasPasskey, onChange }: PasskeyTileProps) {
             />
           </div>
           <AlertDialogFooter>
-            <AlertDialogCancel
-              onClick={() => {
-                setPending(null);
-                onChange?.();
-              }}
-            >
-              Skip
-            </AlertDialogCancel>
+            <AlertDialogCancel onClick={handleSkipNaming}>Skip</AlertDialogCancel>
             <AlertDialogAction
               onClick={(e) => {
                 // Keep the dialog open while the request is in flight so the

--- a/packages/web/src/ui/components/admin/security/passkey-tile.tsx
+++ b/packages/web/src/ui/components/admin/security/passkey-tile.tsx
@@ -1,0 +1,346 @@
+"use client";
+
+/**
+ * Passkey enrollment tile, mounted inside `/admin/settings/security` next to
+ * the TOTP and backup-codes tiles (#2082 PR B).
+ *
+ * Click flow:
+ *   1. Tile button → `authClient.passkey.addPasskey()` (no name passed).
+ *   2. OS biometric prompt fires immediately.
+ *   3. On success Better Auth returns the new {@link Passkey} including its id.
+ *   4. We render an in-component name modal with a userAgent-derived default
+ *      and persist the user's choice via `authClient.passkey.updatePasskey({ id, name })`.
+ *
+ * Naming AFTER enrollment (rather than passing a name into addPasskey) means
+ * users hit the OS prompt with one click — and a cancelled OS prompt never
+ * leaves an orphaned name in flight.
+ *
+ * Tile state matrix is owned by the parent page (`security/page.tsx`); this
+ * component just renders + reports back via `onChange()` so the page can
+ * refetch the passkey list and surface the new row.
+ */
+
+import { useState } from "react";
+import { Fingerprint, KeyRound, Loader2, ShieldX } from "lucide-react";
+import { authClient } from "@/lib/auth/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { useWebAuthnSupported } from "@/ui/hooks/use-webauthn-supported";
+
+// ---------------------------------------------------------------------------
+// Types — narrow view into the Better Auth passkey client surface
+// ---------------------------------------------------------------------------
+
+interface Passkey {
+  id: string;
+  name?: string;
+  createdAt: Date | string;
+}
+
+type ClientResult<T> = {
+  data: T | null;
+  error: { message?: string; code?: string; status?: number } | null;
+};
+
+interface PasskeyClient {
+  addPasskey: (opts?: {
+    name?: string;
+    authenticatorAttachment?: "platform" | "cross-platform";
+  }) => Promise<ClientResult<Passkey>>;
+  updatePasskey: (opts: { id: string; name: string }) => Promise<ClientResult<{ passkey: Passkey }>>;
+}
+
+function getPasskeyClient(): PasskeyClient {
+  const namespace = (authClient as unknown as { passkey?: PasskeyClient }).passkey;
+  if (!namespace) {
+    throw new Error(
+      "Better Auth passkey client plugin is not loaded — check packages/web/src/lib/auth/client.ts",
+    );
+  }
+  return namespace;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Best-effort default name for a fresh passkey.
+ *
+ * The userAgent string is famously messy. We don't try to be clever — match
+ * a handful of obvious tokens, fall back to "This device" when nothing
+ * matches. The user can always overwrite the field before saving.
+ */
+export function deriveDefaultPasskeyName(ua: string): string {
+  const lower = ua.toLowerCase();
+
+  let device = "This device";
+  if (lower.includes("iphone")) device = "iPhone";
+  else if (lower.includes("ipad")) device = "iPad";
+  else if (lower.includes("android")) device = "Android";
+  else if (lower.includes("mac os") || lower.includes("macintosh")) device = "Mac";
+  else if (lower.includes("windows")) device = "Windows PC";
+  else if (lower.includes("linux") || lower.includes("cros")) device = "Linux";
+
+  let browser: string | null = null;
+  if (lower.includes("edg/")) browser = "Edge";
+  else if (lower.includes("chrome/") && !lower.includes("chromium")) browser = "Chrome";
+  else if (lower.includes("firefox/")) browser = "Firefox";
+  else if (lower.includes("safari/") && !lower.includes("chrome/")) browser = "Safari";
+
+  return browser ? `${device} · ${browser}` : device;
+}
+
+function getDefaultName(): string {
+  if (typeof navigator === "undefined") return "This device";
+  return deriveDefaultPasskeyName(navigator.userAgent);
+}
+
+/**
+ * Better Auth surfaces user-cancelled WebAuthn flows with code
+ * `REGISTRATION_CANCELLED` — distinguish them from real errors so the UI
+ * doesn't shout "system error" when the user hits "Cancel" on the OS prompt.
+ */
+function isUserCancellation(error: ClientResult<unknown>["error"]): boolean {
+  if (!error) return false;
+  if (error.code === "REGISTRATION_CANCELLED") return true;
+  // Browsers surface the underlying DOMException as `NotAllowedError` when
+  // the user dismisses the platform prompt; Better Auth currently passes
+  // its message through unchanged for non-mapped errors.
+  const msg = error.message?.toLowerCase() ?? "";
+  return msg.includes("notallowed") || msg.includes("cancelled") || msg.includes("canceled");
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface PasskeyTileProps {
+  /**
+   * Whether the user already has at least one passkey enrolled. The tile
+   * stays clickable in either state (a user with one passkey on a desktop
+   * laptop probably wants another on their phone), but the recommended
+   * badge only shows when nothing is enrolled yet.
+   */
+  hasPasskey: boolean;
+  /** Called after a successful addPasskey + name persistence so the parent can refetch the list. */
+  onChange?: () => void;
+}
+
+export function PasskeyTile({ hasPasskey, onChange }: PasskeyTileProps) {
+  const { supported, platformSupported } = useWebAuthnSupported();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState<{ id: string; defaultName: string } | null>(null);
+  const [name, setName] = useState("");
+
+  async function handleAdd() {
+    setBusy(true);
+    setError(null);
+    let result: ClientResult<Passkey>;
+    try {
+      result = await getPasskeyClient().addPasskey();
+    } catch (err) {
+      setBusy(false);
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn("[passkey] addPasskey threw", msg);
+      setError("Could not start passkey enrollment. Please try again.");
+      return;
+    }
+    setBusy(false);
+
+    if (result.error) {
+      if (isUserCancellation(result.error)) {
+        // No-op: user dismissed the OS prompt themselves; surfacing an
+        // error here just looks like a bug. Returning silently lets them
+        // tap the tile again.
+        return;
+      }
+      console.warn("[passkey] addPasskey failed", result.error);
+      setError(result.error.message ?? "Could not register that passkey. Please try again.");
+      return;
+    }
+
+    if (!result.data) {
+      // Shouldn't happen, but the wire shape technically allows it. Surface
+      // a generic message rather than failing silently.
+      setError("Passkey was registered but no details were returned. Refresh to confirm.");
+      onChange?.();
+      return;
+    }
+
+    const id = result.data.id;
+    const defaultName = getDefaultName();
+    setPending({ id, defaultName });
+    setName(defaultName);
+  }
+
+  async function handleSaveName() {
+    if (!pending) return;
+    const trimmed = name.trim() || pending.defaultName;
+    setBusy(true);
+    setError(null);
+    let result: ClientResult<{ passkey: Passkey }>;
+    try {
+      result = await getPasskeyClient().updatePasskey({ id: pending.id, name: trimmed });
+    } catch (err) {
+      setBusy(false);
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn("[passkey] updatePasskey threw", msg);
+      // Naming is cosmetic — the passkey is enrolled. Close the dialog and
+      // let the parent refetch; the row will just show the unnamed default.
+      setPending(null);
+      onChange?.();
+      setError(`Saved your passkey, but renaming failed: ${msg}. You can rename it from the list.`);
+      return;
+    }
+    setBusy(false);
+
+    if (result.error) {
+      console.warn("[passkey] updatePasskey failed", result.error);
+      setPending(null);
+      onChange?.();
+      setError(
+        `Saved your passkey, but renaming failed: ${result.error.message ?? "unknown error"}. You can rename it from the list.`,
+      );
+      return;
+    }
+
+    setPending(null);
+    onChange?.();
+  }
+
+  // ── Render ─────────────────────────────────────────────────────────
+
+  if (supported === false) {
+    return (
+      <Card className="opacity-70">
+        <CardHeader className="flex-row items-center gap-3 space-y-0">
+          <span className="grid size-9 shrink-0 place-items-center rounded-lg border bg-muted/40 text-muted-foreground">
+            <ShieldX className="size-4" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <CardTitle className="text-sm font-semibold">Passkey unavailable</CardTitle>
+            <p className="text-xs text-muted-foreground">
+              Your browser doesn't support passkeys. Use an authenticator app instead.
+            </p>
+          </div>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  const showRecommendedBadge = !hasPasskey && supported === true && platformSupported !== false;
+  const subtitle =
+    platformSupported === false
+      ? "Limited support — security key only. Connect a hardware key (e.g. YubiKey) to continue."
+      : "Phishing-resistant. Works with Touch ID, Face ID, Windows Hello, or a security key.";
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="flex-row items-center gap-3 space-y-0">
+          <span className="grid size-9 shrink-0 place-items-center rounded-lg border bg-emerald-500/5 text-emerald-600 dark:text-emerald-400">
+            <Fingerprint className="size-4" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <CardTitle className="text-sm font-semibold">Passkey</CardTitle>
+              {showRecommendedBadge && (
+                <Badge
+                  variant="secondary"
+                  className="border-emerald-500/30 bg-emerald-500/10 text-[10px] font-medium uppercase tracking-wider text-emerald-700 dark:text-emerald-300"
+                >
+                  Recommended
+                </Badge>
+              )}
+            </div>
+            <p className="text-xs text-muted-foreground">{subtitle}</p>
+          </div>
+        </CardHeader>
+        <CardContent className="pt-0">
+          <Button onClick={handleAdd} disabled={busy || supported !== true}>
+            {busy ? <Loader2 className="mr-1.5 size-3.5 animate-spin" /> : <KeyRound className="mr-1.5 size-3.5" />}
+            {hasPasskey ? "Add another passkey" : "Add a passkey"}
+          </Button>
+          {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
+        </CardContent>
+      </Card>
+
+      <AlertDialog
+        open={pending !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            // Dismissing the rename dialog still leaves the passkey enrolled —
+            // it just won't have a custom name. Trigger a refetch so the row
+            // appears in the list.
+            setPending(null);
+            onChange?.();
+          }
+        }}
+      >
+        <AlertDialogContent className="sm:max-w-md">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Name this passkey</AlertDialogTitle>
+            <AlertDialogDescription>
+              Give it a name you'll recognize later — useful when you have more
+              than one device.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <div className="space-y-1.5 py-2">
+            <label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Passkey name
+            </label>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={pending?.defaultName ?? "MacBook · Safari"}
+              maxLength={80}
+              autoFocus
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void handleSaveName();
+                }
+              }}
+            />
+          </div>
+          <AlertDialogFooter>
+            <AlertDialogCancel
+              onClick={() => {
+                setPending(null);
+                onChange?.();
+              }}
+            >
+              Skip
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                // Keep the dialog open while the request is in flight so the
+                // user sees the spinner. Radix would otherwise close on click.
+                e.preventDefault();
+                void handleSaveName();
+              }}
+              disabled={busy}
+            >
+              {busy ? <Loader2 className="mr-1.5 size-3.5 animate-spin" /> : null}
+              Save
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/packages/web/src/ui/components/admin/security/two-factor-setup.tsx
+++ b/packages/web/src/ui/components/admin/security/two-factor-setup.tsx
@@ -7,7 +7,7 @@
  * top-level views, with the middle one stepping through password-confirm
  * and code-confirm sub-stages (see {@link EnrollStage}):
  *
- *   1. Not enrolled       — "Set up two-factor" button. The first sub-stage
+ *   1. Not enrolled       — "Set up authenticator app" button. The first sub-stage
  *                           collects the user's password; the second renders
  *                           the otpauth URI + manual key + one-time backup
  *                           codes alongside a 6-digit verification input.
@@ -406,9 +406,10 @@ export function TwoFactorSetup({ enabled, onChange }: TwoFactorSetupProps) {
               <ShieldCheck className="size-4" />
             </span>
             <div className="min-w-0 flex-1">
-              <CardTitle className="text-sm font-semibold">Two-factor on</CardTitle>
+              <CardTitle className="text-sm font-semibold">Authenticator app on</CardTitle>
               <p className="text-xs text-muted-foreground">
-                Authenticator app codes are required at every sign-in.
+                A 6-digit code is required at every sign-in. Backup codes were
+                issued during enrollment.
               </p>
             </div>
           </CardHeader>
@@ -544,10 +545,10 @@ export function TwoFactorSetup({ enabled, onChange }: TwoFactorSetupProps) {
             <Lock className="size-4" />
           </span>
           <div className="min-w-0 flex-1">
-            <CardTitle className="text-sm font-semibold">Two-factor required</CardTitle>
+            <CardTitle className="text-sm font-semibold">Authenticator app</CardTitle>
             <p className="text-xs text-muted-foreground">
-              Admin accounts must enroll a TOTP authenticator. Until you do, the
-              admin console will be locked.
+              Six-digit codes from Google Authenticator, 1Password, Authy, or
+              any TOTP app. Requires backup codes.
             </p>
           </div>
         </CardHeader>
@@ -555,7 +556,7 @@ export function TwoFactorSetup({ enabled, onChange }: TwoFactorSetupProps) {
         {stage.kind === "idle" && (
           <CardContent className="pt-0">
             <Button onClick={() => setStage({ kind: "password" })}>
-              Set up two-factor
+              Set up authenticator app
             </Button>
           </CardContent>
         )}

--- a/packages/web/src/ui/hooks/use-webauthn-supported.ts
+++ b/packages/web/src/ui/hooks/use-webauthn-supported.ts
@@ -1,0 +1,80 @@
+"use client";
+
+/**
+ * WebAuthn capability detection for the passkey enrollment flow on
+ * /admin/settings/security (#2082 PR B).
+ *
+ * Two checks are surfaced separately because they fail independently:
+ *
+ *   - `supported`         — `window.PublicKeyCredential` exists. Required
+ *                            for any passkey flow at all (platform OR
+ *                            cross-platform / security key).
+ *   - `platformSupported` — `isUserVerifyingPlatformAuthenticatorAvailable()`
+ *                            resolved `true`. Required for Touch ID / Face ID
+ *                            / Windows Hello. A `false` answer doesn't kill
+ *                            the flow — roaming authenticators (YubiKey) still
+ *                            work — but lets the UI soften the recommended
+ *                            badge ("limited support — security key only").
+ *
+ * Both default to `null` while the platform-availability promise is in flight
+ * so the page can render a determinate state from SSR (no hydration mismatch
+ * on the tile copy) and only flip to a concrete answer once the answer is
+ * actually known.
+ */
+
+import { useEffect, useState } from "react";
+
+export interface WebAuthnSupport {
+  /** `window.PublicKeyCredential` is defined. `null` until first effect runs. */
+  supported: boolean | null;
+  /** Platform authenticator (Touch ID / Windows Hello) is available. `null` while the promise is in flight. */
+  platformSupported: boolean | null;
+}
+
+export function useWebAuthnSupported(): WebAuthnSupport {
+  const [state, setState] = useState<WebAuthnSupport>({
+    supported: null,
+    platformSupported: null,
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.PublicKeyCredential === "undefined") {
+      setState({ supported: false, platformSupported: false });
+      return;
+    }
+
+    let cancelled = false;
+    setState((prev) => ({ ...prev, supported: true }));
+
+    const probe = window.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable;
+    if (typeof probe !== "function") {
+      // Older WebAuthn implementations expose PublicKeyCredential without the
+      // platform-availability probe. Treat platform support as unknown-false
+      // so the UI falls back to the neutral copy.
+      setState({ supported: true, platformSupported: false });
+      return;
+    }
+
+    probe
+      .call(window.PublicKeyCredential)
+      .then((available) => {
+        if (cancelled) return;
+        setState({ supported: true, platformSupported: available });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const msg = err instanceof Error ? err.message : String(err);
+        // The probe should never throw, but iframes / privacy modes can
+        // reject it. Log and assume no platform authenticator so the user
+        // still sees a working — if downgraded — tile.
+        console.warn("isUserVerifyingPlatformAuthenticatorAvailable() rejected:", msg);
+        setState({ supported: true, platformSupported: false });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return state;
+}

--- a/packages/web/src/ui/hooks/use-webauthn-supported.ts
+++ b/packages/web/src/ui/hooks/use-webauthn-supported.ts
@@ -1,57 +1,47 @@
 "use client";
 
 /**
- * WebAuthn capability detection for the passkey enrollment flow on
- * /admin/settings/security (#2082 PR B).
+ * WebAuthn capability detection for the passkey enrollment flow.
  *
- * Two checks are surfaced separately because they fail independently:
+ * The hook returns one of three states. Modelling them as a discriminated
+ * union — rather than `boolean | null` for each axis — makes the two
+ * unreachable cross-products (`{ supported: false, platformSupported: true }`
+ * and `{ supported: null, platformSupported: false }`) impossible to express:
  *
- *   - `supported`         — `window.PublicKeyCredential` exists. Required
- *                            for any passkey flow at all (platform OR
- *                            cross-platform / security key).
- *   - `platformSupported` — `isUserVerifyingPlatformAuthenticatorAvailable()`
- *                            resolved `true`. Required for Touch ID / Face ID
- *                            / Windows Hello. A `false` answer doesn't kill
- *                            the flow — roaming authenticators (YubiKey) still
- *                            work — but lets the UI soften the recommended
- *                            badge ("limited support — security key only").
- *
- * Both default to `null` while the platform-availability promise is in flight
- * so the page can render a determinate state from SSR (no hydration mismatch
- * on the tile copy) and only flip to a concrete answer once the answer is
- * actually known.
+ *   - `unknown`     — pre-effect / SSR. Render disabled-but-determinate
+ *                     so there's no hydration mismatch on the tile copy.
+ *   - `unsupported` — `window.PublicKeyCredential` is missing entirely.
+ *                     No passkey flow at all.
+ *   - `supported`   — WebAuthn is available. `platformAuthenticator` tells
+ *                     consumers whether Touch ID / Face ID / Windows Hello
+ *                     is wired up; `false` means roaming authenticators
+ *                     (YubiKey) only — the flow still works, but the UI
+ *                     should soften the recommended badge.
  */
 
 import { useEffect, useState } from "react";
 
-export interface WebAuthnSupport {
-  /** `window.PublicKeyCredential` is defined. `null` until first effect runs. */
-  supported: boolean | null;
-  /** Platform authenticator (Touch ID / Windows Hello) is available. `null` while the promise is in flight. */
-  platformSupported: boolean | null;
-}
+export type WebAuthnSupport =
+  | { kind: "unknown" }
+  | { kind: "unsupported" }
+  | { kind: "supported"; platformAuthenticator: boolean };
 
 export function useWebAuthnSupported(): WebAuthnSupport {
-  const [state, setState] = useState<WebAuthnSupport>({
-    supported: null,
-    platformSupported: null,
-  });
+  const [state, setState] = useState<WebAuthnSupport>({ kind: "unknown" });
 
   useEffect(() => {
     if (typeof window === "undefined" || typeof window.PublicKeyCredential === "undefined") {
-      setState({ supported: false, platformSupported: false });
+      setState({ kind: "unsupported" });
       return;
     }
 
     let cancelled = false;
-    setState((prev) => ({ ...prev, supported: true }));
-
     const probe = window.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable;
     if (typeof probe !== "function") {
       // Older WebAuthn implementations expose PublicKeyCredential without the
-      // platform-availability probe. Treat platform support as unknown-false
-      // so the UI falls back to the neutral copy.
-      setState({ supported: true, platformSupported: false });
+      // platform-availability probe. Treat platform support as absent so the
+      // UI falls back to the roaming-authenticator copy.
+      setState({ kind: "supported", platformAuthenticator: false });
       return;
     }
 
@@ -59,7 +49,7 @@ export function useWebAuthnSupported(): WebAuthnSupport {
       .call(window.PublicKeyCredential)
       .then((available) => {
         if (cancelled) return;
-        setState({ supported: true, platformSupported: available });
+        setState({ kind: "supported", platformAuthenticator: available });
       })
       .catch((err: unknown) => {
         if (cancelled) return;
@@ -68,7 +58,7 @@ export function useWebAuthnSupported(): WebAuthnSupport {
         // reject it. Log and assume no platform authenticator so the user
         // still sees a working — if downgraded — tile.
         console.warn("isUserVerifyingPlatformAuthenticatorAvailable() rejected:", msg);
-        setState({ supported: true, platformSupported: false });
+        setState({ kind: "supported", platformAuthenticator: false });
       });
 
     return () => {


### PR DESCRIPTION
## Summary

PR B of D for #2082 — frontend UI for the passkey backend that landed in [#2085](https://github.com/AtlasDevHQ/atlas/pull/2085) (PR A). Wires `passkeyClient()` into the Better Auth client and refactors `/admin/settings/security` to a 3-tile layout (Passkey · Authenticator app · Backup codes status) with an enrolled-passkey list below.

A user could already enroll a passkey via raw Better Auth endpoints after PR A merged; this PR gives them a UI for it.

## What's new

- **Passkey tile** with `Recommended` badge when no passkey is enrolled. Click → `authClient.passkey.addPasskey()` → OS biometric prompt → success modal asks for a name with a userAgent-derived default (`MacBook · Safari`, `iPhone · Safari`, `Windows PC · Chrome`, …). Name persists via `updatePasskey({ id, name })` so a cancelled OS prompt never leaves a half-state.
- **Authenticator app tile** — existing TOTP flow, recopied to fit the new tile system. Backup codes are still issued only inside this flow.
- **Backup codes status tile** — read-only indicator with four states: `required` / `not applicable (passkey-only)` / `passkey-only carve-out` / `ready`.
- **Enrolled passkey list** below the tiles — name + creation date with rename and delete affordances. Empty state points at the Passkey tile.
- **WebAuthn capability detection** (`useWebAuthnSupported()`) separates `PublicKeyCredential` existence from `isUserVerifyingPlatformAuthenticatorAvailable()` so browsers without platform auth still see a working — if downgraded — "security key only" tile, and ancient browsers see a greyed "Passkey unavailable" copy.
- **MFA enrollment dialog copy** flips from "TOTP authenticator" / "Enroll authenticator" to "authenticator app or passkey" / "Set up second factor" so it matches the gate's 403 body and the security page's affordances.

## Decisions

1. **Passkey naming** — Better Auth's `addPasskey({ name })` accepts a name upfront, but we name AFTER successful enrollment via `updatePasskey({ id, name })`. Trade-off: one extra round-trip; payoff: zero friction before the OS prompt and a cancelled prompt leaves nothing to clean up.
2. **Backup-codes-mandatory** — client-side only, inside the TOTP enrollment flow. Server-side hooks into Better Auth's `twoFactor.enable` are too narrow to wire up cleanly.
3. **Passkey list management in this PR** — yes. Without delete, users could enroll passkeys but never remove them, which is a worse first-launch state than no UI at all.

## Out of scope

- Trusted devices (30d) — PR C.
- Browser e2e with Playwright's WebAuthn virtual authenticator — PR D.
- New backend routes — Better Auth's passkey plugin already exposes `/api/auth/passkey/*`.

## CI gates

All six pass locally:
- ✅ `bun run lint` (eslint)
- ✅ `bun run type` (tsgo)
- ✅ `bun run test` — 490+ tests across api, cli, web, ee, react packages
- ✅ `bun x syncpack lint`
- ✅ `bash scripts/check-template-drift.sh`
- ✅ `bash scripts/check-railway-watch.sh`

## Test plan

- [ ] Sign in to `/admin` with no second factor, click MFA gate → "Set up second factor" → land on security page
- [ ] Click "Add a passkey" on a Mac → Touch ID prompt → name modal opens with "Mac · Safari" / "Mac · Chrome" default → save → row appears in list
- [ ] Cancel the Touch ID prompt → no error banner, no orphaned name modal
- [ ] Rename an existing passkey → row updates after save
- [ ] Delete an existing passkey → row disappears after confirm
- [ ] Enroll TOTP → backup codes status tile flips from "Required" to "Backup codes ready"
- [ ] Enroll only a passkey (no TOTP) → backup codes status reads "Not applicable"
- [ ] Open in a browser without `PublicKeyCredential` (or stub it out) → tile reads "Passkey unavailable"

## References

- Backend (PR A): #2085, commit 0552fb94 on main
- Issue: #2082