### PR TITLE
feat(web,api): #2082 — sign-in 2FA challenge UI + trust-device toggle (PR C.1 of D)

### DIFF
--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -655,6 +655,12 @@ function buildPlugins() {
   plugins.push(
     twoFactor({
       issuer: process.env.ATLAS_MFA_ISSUER ?? "Atlas",
+      // 30 days. Matches Better Auth's current default but pinned explicitly:
+      // a future minor bump that lowers the default would silently revoke
+      // every trust cookie in the wild. Surfacing the value here keeps the
+      // contract with the sign-in challenge UI ("Trust this device for 30
+      // days") truthful no matter which Better Auth version is installed.
+      trustDeviceMaxAge: 30 * 24 * 60 * 60,
     }),
   );
 

--- a/packages/web/src/app/login/page.tsx
+++ b/packages/web/src/app/login/page.tsx
@@ -26,6 +26,7 @@ import {
   MicrosoftIcon,
 } from "@/ui/components/social-icons";
 import { parseSignInError, type SignInErrorState } from "./parse-sign-in-error";
+import { getPostSignInRoute } from "./post-sign-in-route";
 
 type SocialProvider = "google" | "github" | "microsoft";
 
@@ -123,19 +124,7 @@ export default function LoginPage() {
         setError(parseSignInError({ error: res.error }));
         return;
       }
-      // Better Auth's twoFactor plugin replaces the session payload with
-      // `{ twoFactorRedirect: true, twoFactorMethods: [...] }` when the user
-      // has TOTP enrolled and the device lacks a valid trust cookie. No
-      // session cookie is set on this response — the user must complete
-      // the challenge at `/login/two-factor` before they get one. The cast
-      // through unknown is the documented workaround for the plugin's
-      // discriminated-union not propagating through `createAuthClient`.
-      const data = res.data as { twoFactorRedirect?: boolean } | null;
-      if (data?.twoFactorRedirect) {
-        router.push("/login/two-factor");
-        return;
-      }
-      router.push("/");
+      router.push(getPostSignInRoute(res.data));
     } catch (err) {
       console.debug(
         "Sign in failed:",

--- a/packages/web/src/app/login/page.tsx
+++ b/packages/web/src/app/login/page.tsx
@@ -123,6 +123,18 @@ export default function LoginPage() {
         setError(parseSignInError({ error: res.error }));
         return;
       }
+      // Better Auth's twoFactor plugin replaces the session payload with
+      // `{ twoFactorRedirect: true, twoFactorMethods: [...] }` when the user
+      // has TOTP enrolled and the device lacks a valid trust cookie. No
+      // session cookie is set on this response — the user must complete
+      // the challenge at `/login/two-factor` before they get one. The cast
+      // through unknown is the documented workaround for the plugin's
+      // discriminated-union not propagating through `createAuthClient`.
+      const data = res.data as { twoFactorRedirect?: boolean } | null;
+      if (data?.twoFactorRedirect) {
+        router.push("/login/two-factor");
+        return;
+      }
       router.push("/");
     } catch (err) {
       console.debug(

--- a/packages/web/src/app/login/post-sign-in-route.test.ts
+++ b/packages/web/src/app/login/post-sign-in-route.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { getPostSignInRoute } from "./post-sign-in-route";
+
+describe("getPostSignInRoute", () => {
+  test("routes to /login/two-factor on { twoFactorRedirect: true }", () => {
+    expect(getPostSignInRoute({ twoFactorRedirect: true })).toBe("/login/two-factor");
+  });
+
+  test("routes to / on a normal session payload", () => {
+    expect(getPostSignInRoute({ token: "abc", user: { id: "u_1" } })).toBe("/");
+  });
+
+  test("routes to / when twoFactorRedirect is false", () => {
+    expect(getPostSignInRoute({ twoFactorRedirect: false })).toBe("/");
+  });
+
+  test("routes to / when twoFactorRedirect is missing", () => {
+    expect(getPostSignInRoute({ twoFactorMethods: ["totp"] })).toBe("/");
+  });
+
+  test("routes to / on null", () => {
+    expect(getPostSignInRoute(null)).toBe("/");
+  });
+
+  test("routes to / on undefined", () => {
+    expect(getPostSignInRoute(undefined)).toBe("/");
+  });
+
+  test("strict equality — does NOT route on stringified 'true' (Better Auth wire-shape drift guard)", () => {
+    // If a future Better Auth bump returns the flag as a string, the
+    // previous truthy check would silently work; the strict === true
+    // check forces an explicit version-pin failure instead.
+    expect(getPostSignInRoute({ twoFactorRedirect: "true" })).toBe("/");
+  });
+
+  test("strict equality — does NOT route on 1 / truthy", () => {
+    expect(getPostSignInRoute({ twoFactorRedirect: 1 })).toBe("/");
+  });
+
+  test("ignores non-object inputs", () => {
+    expect(getPostSignInRoute("twoFactorRedirect=true")).toBe("/");
+    expect(getPostSignInRoute(42)).toBe("/");
+    expect(getPostSignInRoute(true)).toBe("/");
+  });
+});

--- a/packages/web/src/app/login/post-sign-in-route.ts
+++ b/packages/web/src/app/login/post-sign-in-route.ts
@@ -1,0 +1,23 @@
+/**
+ * Decide where to send a user after `signIn.email` returns success.
+ *
+ * Better Auth's twoFactor plugin replaces the session payload with
+ * `{ twoFactorRedirect: true }` when the user has TOTP enrolled and the
+ * device lacks a valid trust cookie — the response is HTTP 200 with no
+ * session cookie set. Without this branch the user lands on `/`
+ * sessionless and bounces straight back to `/login`.
+ *
+ * Strict `=== true` check (not truthy) so a stringified `"true"` from a
+ * future Better Auth wire-shape change can't fall through unnoticed.
+ */
+export function getPostSignInRoute(data: unknown): string {
+  if (
+    data !== null &&
+    typeof data === "object" &&
+    "twoFactorRedirect" in data &&
+    (data as { twoFactorRedirect?: unknown }).twoFactorRedirect === true
+  ) {
+    return "/login/two-factor";
+  }
+  return "/";
+}

--- a/packages/web/src/app/login/two-factor/page.test.tsx
+++ b/packages/web/src/app/login/two-factor/page.test.tsx
@@ -1,18 +1,22 @@
 /**
  * Coverage for the sign-in 2FA challenge page.
  *
- * The page is the only UI surface for the half-authenticated state
- * (#2082 PR C.1). Test cases verify:
- *   1. Default state — TOTP mode, trust-device unchecked, code empty
- *   2. trustDevice=false flows through verifyTotp when checkbox left alone
- *   3. trustDevice=true flows through verifyTotp when checkbox toggled
- *   4. Server failure surfaces inline error (no router.push)
- *   5. Toggle to backup mode + submit calls verifyBackupCode (not verifyTotp)
- *   6. Plugin missing client-side surfaces a recoverable banner
+ * `unwrapTwoFactorResult` is not re-implemented here — the real helper is
+ * imported via `requireActualModule` so a future change to its narrowing
+ * doesn't silently keep these tests passing.
  */
 
 import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
 import { render, fireEvent, waitFor, cleanup, act, screen } from "@testing-library/react";
+
+// Stub out `./client` so loading the real two-factor-client module doesn't
+// pull Better Auth's createAuthClient through (network init at import time).
+mock.module("@/lib/auth/client", () => ({ authClient: {} }));
+
+// Now safe to import the real module — captured before the override below
+// so the spread carries every named export (including `requireTwoFactorClient`,
+// which prevents partial-mock SyntaxError if a sibling test ever imports it).
+import * as realTwoFactorClient from "@/lib/auth/two-factor-client";
 
 const verifyTotpMock = mock(
   async (_opts: { code: string; trustDevice?: boolean }) => ({
@@ -27,8 +31,6 @@ const verifyBackupCodeMock = mock(
   }),
 );
 
-// `getTwoFactorClient()` is what the page imports. Test default returns the
-// stubbed namespace; individual tests override per-call via `mockImplementationOnce`.
 const getTwoFactorClientMock = mock(() => ({
   enable: mock(async () => ({ data: null, error: null })),
   disable: mock(async () => ({ data: null, error: null })),
@@ -38,20 +40,7 @@ const getTwoFactorClientMock = mock(() => ({
 }));
 
 mock.module("@/lib/auth/two-factor-client", () => ({
-  // Re-export the real `unwrapTwoFactorResult` — pure data helper, no need
-  // to mock its branching.
-  unwrapTwoFactorResult: <T,>(
-    result: { data: T | null; error: { message?: string } | null },
-    fallback: string,
-  ) => {
-    if (result.error) {
-      return { ok: false as const, message: result.error.message ?? fallback, raw: result.error };
-    }
-    if (!result.data) {
-      return { ok: false as const, message: fallback, raw: null };
-    }
-    return { ok: true as const, data: result.data };
-  },
+  ...realTwoFactorClient,
   getTwoFactorClient: () => getTwoFactorClientMock(),
 }));
 
@@ -89,13 +78,11 @@ afterEach(() => {
   cleanup();
 });
 
-/** Type the input element rather than `as` everywhere — bun:test/RTL types lose this through `getByLabelText`. */
 function getCodeInput(): HTMLInputElement {
   return screen.getByLabelText(/authenticator code|backup code/i) as HTMLInputElement;
 }
 
 function getTrustCheckbox(): HTMLElement {
-  // Radix Checkbox renders a button[role=checkbox] with aria-checked, NOT a real <input>.
   return screen.getByRole("checkbox", { name: /trust this device/i });
 }
 
@@ -108,7 +95,6 @@ describe("TwoFactorChallengePage — defaults", () => {
     render(<TwoFactorChallengePage />);
     expect(document.body.textContent).toContain("Enter your authenticator code");
     expect(getCodeInput().value).toBe("");
-    // Radix exposes state via aria-checked; "false" is unchecked.
     expect(getTrustCheckbox().getAttribute("aria-checked")).toBe("false");
     expect(getSubmit().disabled).toBe(true);
   });
@@ -205,12 +191,40 @@ describe("TwoFactorChallengePage — verifyTotp wiring", () => {
     });
     expect(routerPushMock).not.toHaveBeenCalled();
   });
+
+  test("double-click within the same tick fires verifyTotp only once (would burn backup codes otherwise)", async () => {
+    // Hold the verify call open so the busy guard is observably true between
+    // the two clicks. Without this, the synchronous setBusy(true) wouldn't
+    // matter — clicks after the first await would already see the new state.
+    let resolve: (v: { data: { token: string }; error: null }) => void = () => {};
+    verifyTotpMock.mockImplementationOnce(
+      () => new Promise((r) => {
+        resolve = r;
+      }),
+    );
+
+    render(<TwoFactorChallengePage />);
+    fireEvent.change(getCodeInput(), { target: { value: "777777" } });
+    const submit = getSubmit();
+
+    await act(async () => {
+      fireEvent.click(submit);
+      fireEvent.click(submit);
+      fireEvent.click(submit);
+    });
+
+    expect(verifyTotpMock).toHaveBeenCalledTimes(1);
+
+    // Resolve the held promise so the test cleans up cleanly.
+    await act(async () => {
+      resolve({ data: { token: "x" }, error: null });
+    });
+  });
 });
 
 describe("TwoFactorChallengePage — backup-code mode", () => {
   test("toggling switch swaps mode, clears the code, preserves trust-device choice", async () => {
     render(<TwoFactorChallengePage />);
-    // Set trust-device + a partial TOTP code, then switch.
     fireEvent.change(getCodeInput(), { target: { value: "123" } });
     await act(async () => {
       fireEvent.click(getTrustCheckbox());
@@ -223,8 +237,6 @@ describe("TwoFactorChallengePage — backup-code mode", () => {
 
     expect(document.body.textContent).toContain("Enter a backup code");
     expect(getCodeInput().value).toBe("");
-    // trustDevice MUST persist — otherwise switching modes silently undoes the
-    // security choice the user already made.
     expect(getTrustCheckbox().getAttribute("aria-checked")).toBe("true");
   });
 
@@ -249,6 +261,28 @@ describe("TwoFactorChallengePage — backup-code mode", () => {
       { code: string; trustDevice?: boolean },
     ];
     expect(call[0]).toEqual({ code: "abcde-12345", trustDevice: false });
+  });
+
+  test("backup-mode isComplete boundary — 9 alphanumerics reject, 10 accept (hyphen excluded)", async () => {
+    render(<TwoFactorChallengePage />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /use a backup code instead/i }));
+    });
+    const input = getCodeInput();
+
+    fireEvent.change(input, { target: { value: "123456789" } });
+    expect(getSubmit().disabled).toBe(true);
+
+    fireEvent.change(input, { target: { value: "1234567890" } });
+    expect(getSubmit().disabled).toBe(false);
+
+    // Hyphen is stripped before counting. "abcde-1234" → 9 chars → reject.
+    fireEvent.change(input, { target: { value: "abcde-1234" } });
+    expect(getSubmit().disabled).toBe(true);
+
+    // "abcde-12345" → 10 chars → accept (matches the placeholder shape).
+    fireEvent.change(input, { target: { value: "abcde-12345" } });
+    expect(getSubmit().disabled).toBe(false);
   });
 });
 

--- a/packages/web/src/app/login/two-factor/page.test.tsx
+++ b/packages/web/src/app/login/two-factor/page.test.tsx
@@ -1,0 +1,271 @@
+/**
+ * Coverage for the sign-in 2FA challenge page.
+ *
+ * The page is the only UI surface for the half-authenticated state
+ * (#2082 PR C.1). Test cases verify:
+ *   1. Default state — TOTP mode, trust-device unchecked, code empty
+ *   2. trustDevice=false flows through verifyTotp when checkbox left alone
+ *   3. trustDevice=true flows through verifyTotp when checkbox toggled
+ *   4. Server failure surfaces inline error (no router.push)
+ *   5. Toggle to backup mode + submit calls verifyBackupCode (not verifyTotp)
+ *   6. Plugin missing client-side surfaces a recoverable banner
+ */
+
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { render, fireEvent, waitFor, cleanup, act, screen } from "@testing-library/react";
+
+const verifyTotpMock = mock(
+  async (_opts: { code: string; trustDevice?: boolean }) => ({
+    data: { token: "session-token" },
+    error: null,
+  }),
+);
+const verifyBackupCodeMock = mock(
+  async (_opts: { code: string; trustDevice?: boolean }) => ({
+    data: { token: "session-token" },
+    error: null,
+  }),
+);
+
+// `getTwoFactorClient()` is what the page imports. Test default returns the
+// stubbed namespace; individual tests override per-call via `mockImplementationOnce`.
+const getTwoFactorClientMock = mock(() => ({
+  enable: mock(async () => ({ data: null, error: null })),
+  disable: mock(async () => ({ data: null, error: null })),
+  verifyTotp: verifyTotpMock,
+  verifyBackupCode: verifyBackupCodeMock,
+  generateBackupCodes: mock(async () => ({ data: null, error: null })),
+}));
+
+mock.module("@/lib/auth/two-factor-client", () => ({
+  // Re-export the real `unwrapTwoFactorResult` — pure data helper, no need
+  // to mock its branching.
+  unwrapTwoFactorResult: <T,>(
+    result: { data: T | null; error: { message?: string } | null },
+    fallback: string,
+  ) => {
+    if (result.error) {
+      return { ok: false as const, message: result.error.message ?? fallback, raw: result.error };
+    }
+    if (!result.data) {
+      return { ok: false as const, message: fallback, raw: null };
+    }
+    return { ok: true as const, data: result.data };
+  },
+  getTwoFactorClient: () => getTwoFactorClientMock(),
+}));
+
+const routerPushMock = mock((_path: string) => {});
+mock.module("next/navigation", () => ({
+  useRouter: () => ({ push: routerPushMock, replace: () => {}, back: () => {} }),
+}));
+
+import TwoFactorChallengePage from "./page";
+
+beforeEach(() => {
+  verifyTotpMock.mockReset();
+  verifyBackupCodeMock.mockReset();
+  routerPushMock.mockReset();
+  getTwoFactorClientMock.mockReset();
+
+  verifyTotpMock.mockImplementation(async () => ({
+    data: { token: "session-token" },
+    error: null,
+  }));
+  verifyBackupCodeMock.mockImplementation(async () => ({
+    data: { token: "session-token" },
+    error: null,
+  }));
+  getTwoFactorClientMock.mockImplementation(() => ({
+    enable: mock(async () => ({ data: null, error: null })),
+    disable: mock(async () => ({ data: null, error: null })),
+    verifyTotp: verifyTotpMock,
+    verifyBackupCode: verifyBackupCodeMock,
+    generateBackupCodes: mock(async () => ({ data: null, error: null })),
+  }));
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+/** Type the input element rather than `as` everywhere — bun:test/RTL types lose this through `getByLabelText`. */
+function getCodeInput(): HTMLInputElement {
+  return screen.getByLabelText(/authenticator code|backup code/i) as HTMLInputElement;
+}
+
+function getTrustCheckbox(): HTMLElement {
+  // Radix Checkbox renders a button[role=checkbox] with aria-checked, NOT a real <input>.
+  return screen.getByRole("checkbox", { name: /trust this device/i });
+}
+
+function getSubmit(): HTMLButtonElement {
+  return screen.getByRole("button", { name: /continue|verifying/i }) as HTMLButtonElement;
+}
+
+describe("TwoFactorChallengePage — defaults", () => {
+  test("renders TOTP mode with empty code, trust-device unchecked, submit disabled", () => {
+    render(<TwoFactorChallengePage />);
+    expect(document.body.textContent).toContain("Enter your authenticator code");
+    expect(getCodeInput().value).toBe("");
+    // Radix exposes state via aria-checked; "false" is unchecked.
+    expect(getTrustCheckbox().getAttribute("aria-checked")).toBe("false");
+    expect(getSubmit().disabled).toBe(true);
+  });
+
+  test("submit button enables only after 6 digits", () => {
+    render(<TwoFactorChallengePage />);
+    const input = getCodeInput();
+    fireEvent.change(input, { target: { value: "123" } });
+    expect(getSubmit().disabled).toBe(true);
+    fireEvent.change(input, { target: { value: "123456" } });
+    expect(getSubmit().disabled).toBe(false);
+  });
+
+  test("non-digits are stripped from TOTP input", () => {
+    render(<TwoFactorChallengePage />);
+    const input = getCodeInput();
+    fireEvent.change(input, { target: { value: "12-3a4b56" } });
+    expect(input.value).toBe("123456");
+  });
+});
+
+describe("TwoFactorChallengePage — verifyTotp wiring", () => {
+  test("submitting with trust-device unchecked passes trustDevice: false", async () => {
+    render(<TwoFactorChallengePage />);
+    fireEvent.change(getCodeInput(), { target: { value: "123456" } });
+    await act(async () => {
+      fireEvent.click(getSubmit());
+    });
+
+    await waitFor(() => {
+      expect(verifyTotpMock).toHaveBeenCalledTimes(1);
+    });
+    const call = (verifyTotpMock as unknown as ReturnType<typeof mock>).mock.calls[0] as [
+      { code: string; trustDevice?: boolean },
+    ];
+    expect(call[0]).toEqual({ code: "123456", trustDevice: false });
+    await waitFor(() => {
+      expect(routerPushMock).toHaveBeenCalledWith("/");
+    });
+  });
+
+  test("submitting with trust-device toggled passes trustDevice: true", async () => {
+    render(<TwoFactorChallengePage />);
+    fireEvent.change(getCodeInput(), { target: { value: "654321" } });
+    await act(async () => {
+      fireEvent.click(getTrustCheckbox());
+    });
+    expect(getTrustCheckbox().getAttribute("aria-checked")).toBe("true");
+
+    await act(async () => {
+      fireEvent.click(getSubmit());
+    });
+
+    await waitFor(() => {
+      expect(verifyTotpMock).toHaveBeenCalledTimes(1);
+    });
+    const call = (verifyTotpMock as unknown as ReturnType<typeof mock>).mock.calls[0] as [
+      { code: string; trustDevice?: boolean },
+    ];
+    expect(call[0]).toEqual({ code: "654321", trustDevice: true });
+  });
+
+  test("server error surfaces inline and does NOT navigate", async () => {
+    verifyTotpMock.mockImplementationOnce(async () => ({
+      data: null,
+      error: { code: "INVALID_TOTP", message: "That code is wrong.", status: 401 },
+    }));
+
+    render(<TwoFactorChallengePage />);
+    fireEvent.change(getCodeInput(), { target: { value: "000000" } });
+    await act(async () => {
+      fireEvent.click(getSubmit());
+    });
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("That code is wrong.");
+    });
+    expect(routerPushMock).not.toHaveBeenCalled();
+  });
+
+  test("network failure (TypeError) surfaces friendly copy and does NOT navigate", async () => {
+    verifyTotpMock.mockImplementationOnce(async () => {
+      throw new TypeError("fetch failed");
+    });
+
+    render(<TwoFactorChallengePage />);
+    fireEvent.change(getCodeInput(), { target: { value: "111111" } });
+    await act(async () => {
+      fireEvent.click(getSubmit());
+    });
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Can't reach the server");
+    });
+    expect(routerPushMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("TwoFactorChallengePage — backup-code mode", () => {
+  test("toggling switch swaps mode, clears the code, preserves trust-device choice", async () => {
+    render(<TwoFactorChallengePage />);
+    // Set trust-device + a partial TOTP code, then switch.
+    fireEvent.change(getCodeInput(), { target: { value: "123" } });
+    await act(async () => {
+      fireEvent.click(getTrustCheckbox());
+    });
+
+    const switchBtn = screen.getByRole("button", { name: /use a backup code instead/i });
+    await act(async () => {
+      fireEvent.click(switchBtn);
+    });
+
+    expect(document.body.textContent).toContain("Enter a backup code");
+    expect(getCodeInput().value).toBe("");
+    // trustDevice MUST persist — otherwise switching modes silently undoes the
+    // security choice the user already made.
+    expect(getTrustCheckbox().getAttribute("aria-checked")).toBe("true");
+  });
+
+  test("backup-code submit calls verifyBackupCode (not verifyTotp)", async () => {
+    render(<TwoFactorChallengePage />);
+    const switchBtn = screen.getByRole("button", { name: /use a backup code instead/i });
+    await act(async () => {
+      fireEvent.click(switchBtn);
+    });
+
+    const input = getCodeInput();
+    fireEvent.change(input, { target: { value: "abcde-12345" } });
+    await act(async () => {
+      fireEvent.click(getSubmit());
+    });
+
+    await waitFor(() => {
+      expect(verifyBackupCodeMock).toHaveBeenCalledTimes(1);
+    });
+    expect(verifyTotpMock).not.toHaveBeenCalled();
+    const call = (verifyBackupCodeMock as unknown as ReturnType<typeof mock>).mock.calls[0] as [
+      { code: string; trustDevice?: boolean },
+    ];
+    expect(call[0]).toEqual({ code: "abcde-12345", trustDevice: false });
+  });
+});
+
+describe("TwoFactorChallengePage — plugin guard", () => {
+  test("missing twoFactor client surfaces actionable banner instead of silent failure", async () => {
+    getTwoFactorClientMock.mockImplementationOnce(() => null as unknown as ReturnType<typeof getTwoFactorClientMock>);
+
+    render(<TwoFactorChallengePage />);
+    fireEvent.change(getCodeInput(), { target: { value: "123456" } });
+    await act(async () => {
+      fireEvent.click(getSubmit());
+    });
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Two-factor sign-in is not available");
+    });
+    expect(verifyTotpMock).not.toHaveBeenCalled();
+    expect(routerPushMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/app/login/two-factor/page.tsx
+++ b/packages/web/src/app/login/two-factor/page.tsx
@@ -1,24 +1,14 @@
 "use client";
 
 /**
- * Two-factor sign-in challenge.
- *
- * Reached when `/login`'s `signIn.email` call returns
- * `{ data: { twoFactorRedirect: true } }` — Better Auth's signal that the
- * user has TOTP enrolled and the current device doesn't carry a valid
- * trust cookie. Without this page the half-authenticated state has no UI
- * surface at all, which is the primary regression PR C.1 closes (#2082).
- *
- * The user has NOT been issued a session cookie at this point — only a
- * short-lived two-factor cookie that identifies the pending user. Failing
- * to complete the flow means no session is ever created, so route guards
- * on `/admin/*` simply see "no session" and behave normally.
- *
- * Mode toggle (TOTP ↔ backup code) is the same component on the same URL —
- * not a separate route — so deep-links and the back button stay sane.
+ * Better Auth two-factor challenge surface — landing page for the
+ * `twoFactorRedirect: true` response from `signIn.email`. The user has no
+ * session cookie yet (only a short-lived two-factor cookie identifying the
+ * pending user), so failing to complete the flow leaves the user genuinely
+ * unauthenticated.
  */
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -40,11 +30,8 @@ interface ModeConfig {
   inputLabel: string;
   placeholder: string;
   inputMode: "numeric" | "text";
-  /** TOTP codes are exactly 6 digits; backup codes are 11 chars (5-5 with hyphen). */
   maxLength: number;
-  /** Submit-button enable predicate — TOTP demands all 6 digits, backup tolerates user-entered formatting. */
   isComplete: (value: string) => boolean;
-  /** Sanitiser run on every keystroke. TOTP strips non-digits; backup is left as-typed (codes are alphanumeric). */
   sanitise: (raw: string) => string;
   fallback: string;
   switchLabel: string;
@@ -71,12 +58,8 @@ const BACKUP_MODE: ModeConfig = {
   inputLabel: "Backup code",
   placeholder: "abcde-12345",
   inputMode: "text",
-  // 5-5 layout with optional hyphen, plus the hyphen itself.
   maxLength: 11,
   isComplete: (v) => v.replace(/[-\s]/g, "").length >= 10,
-  // Backup codes from `generateBackupCodesFn` are alphanumeric — strip
-  // whitespace but preserve the hyphen so the user sees the same shape
-  // they copied. The server normalises before comparing.
   sanitise: (raw) => raw.replace(/\s+/g, "").slice(0, 11),
   fallback: "That backup code didn't match. Try a different one.",
   switchLabel: "Use my authenticator app instead",
@@ -84,10 +67,6 @@ const BACKUP_MODE: ModeConfig = {
 
 const MODES: Record<Mode, ModeConfig> = { totp: TOTP_MODE, backup: BACKUP_MODE };
 
-/**
- * Single audit-trail line so support can recover `code` / `status` from a
- * user report — the UI only surfaces the human-friendly message above.
- */
 function logFailure(action: string, raw: TwoFactorApiError | null): void {
   console.warn(`[two-factor:sign-in] ${action} failed`, raw);
 }
@@ -99,15 +78,13 @@ export default function TwoFactorChallengePage() {
   const [trustDevice, setTrustDevice] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Synchronous in-flight flag — `busy` state lags by a render so a
+  // double-click within the same tick would fire two verify calls and burn
+  // two backup codes server-side. Ref takes effect immediately.
+  const submittingRef = useRef(false);
 
   const config = MODES[mode];
 
-  /**
-   * Switch between TOTP and backup mode. Deliberately resets `code` and
-   * `error` (different validation rules, different shape) but PRESERVES
-   * `trustDevice` — switching input methods shouldn't quietly toggle the
-   * security choice the user already made.
-   */
   function switchMode(next: Mode): void {
     setMode(next);
     setCode("");
@@ -116,20 +93,18 @@ export default function TwoFactorChallengePage() {
 
   async function handleSubmit(e: React.FormEvent): Promise<void> {
     e.preventDefault();
-    if (!config.isComplete(code) || busy) return;
+    if (!config.isComplete(code) || submittingRef.current) return;
+    submittingRef.current = true;
     setBusy(true);
     setError(null);
 
     const client = getTwoFactorClient();
     if (!client) {
-      // Plugin missing client-side. Surface a generic failure — the user
-      // can't act on this, but support can recover the cause from the
-      // breadcrumb below.
-      console.warn(
-        "[two-factor:sign-in] twoFactor client plugin not loaded — check packages/web/src/lib/auth/client.ts",
-      );
+      // Developer-facing breadcrumb; user sees the generic copy below.
+      console.warn("[two-factor:sign-in] twoFactor client plugin not loaded");
       setError("Two-factor sign-in is not available. Refresh the page or contact your workspace admin.");
       setBusy(false);
+      submittingRef.current = false;
       return;
     }
 
@@ -143,16 +118,11 @@ export default function TwoFactorChallengePage() {
         logFailure(mode === "totp" ? "verifyTotp" : "verifyBackupCode", outcome.raw);
         setError(outcome.message);
         setBusy(false);
+        submittingRef.current = false;
         return;
       }
-      // Session is now established — Better Auth set the session cookie on
-      // the response. Route to the post-login landing; downstream onboarding
-      // / mode-router state is fetched by the destination page.
       router.push("/");
     } catch (err) {
-      // Network / TypeError path. Catch-and-classify mirrors the main login
-      // page; we don't want a thrown fetch to leave the user staring at a
-      // disabled form with no feedback.
       console.warn(
         "[two-factor:sign-in] verify threw:",
         err instanceof Error ? err.message : String(err),
@@ -165,6 +135,7 @@ export default function TwoFactorChallengePage() {
             : config.fallback,
       );
       setBusy(false);
+      submittingRef.current = false;
     }
   }
 
@@ -237,14 +208,16 @@ export default function TwoFactorChallengePage() {
         </CardContent>
       </Card>
 
-      <button
+      <Button
         type="button"
+        variant="link"
+        size="sm"
         onClick={() => switchMode(mode === "totp" ? "backup" : "totp")}
         disabled={busy}
-        className="mt-4 text-sm font-medium text-muted-foreground transition-colors hover:text-primary hover:underline underline-offset-4 disabled:opacity-50"
+        className="mt-4 text-muted-foreground hover:text-primary"
       >
         {config.switchLabel}
-      </button>
+      </Button>
     </div>
   );
 }
@@ -262,12 +235,6 @@ function ChallengeErrorAlert({ message }: { message: string }) {
   );
 }
 
-/**
- * Best-effort human-readable expiry stamp for the trust-device caption.
- * Reads the current date at render — accurate to the day, which is enough
- * for "Skip the prompt until April 12" copy. Wrapped so a non-`Intl`
- * runtime (older test environments) doesn't crash the page.
- */
 function formatTrustExpiry(): string {
   const expiry = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
   try {
@@ -275,8 +242,14 @@ function formatTrustExpiry(): string {
       month: "short",
       day: "numeric",
     }).format(expiry);
-  } catch {
-    // Intl not available — fall back to ISO date so the caption is still meaningful.
+  } catch (err) {
+    // Intl unavailable in the runtime — surface a breadcrumb so a real
+    // regression doesn't go silent, fall back to ISO so the caption stays
+    // meaningful.
+    console.debug(
+      "[two-factor:sign-in] Intl.DateTimeFormat unavailable:",
+      err instanceof Error ? err.message : String(err),
+    );
     return expiry.toISOString().slice(0, 10);
   }
 }

--- a/packages/web/src/app/login/two-factor/page.tsx
+++ b/packages/web/src/app/login/two-factor/page.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+/**
+ * Two-factor sign-in challenge.
+ *
+ * Reached when `/login`'s `signIn.email` call returns
+ * `{ data: { twoFactorRedirect: true } }` — Better Auth's signal that the
+ * user has TOTP enrolled and the current device doesn't carry a valid
+ * trust cookie. Without this page the half-authenticated state has no UI
+ * surface at all, which is the primary regression PR C.1 closes (#2082).
+ *
+ * The user has NOT been issued a session cookie at this point — only a
+ * short-lived two-factor cookie that identifies the pending user. Failing
+ * to complete the flow means no session is ever created, so route guards
+ * on `/admin/*` simply see "no session" and behave normally.
+ *
+ * Mode toggle (TOTP ↔ backup code) is the same component on the same URL —
+ * not a separate route — so deep-links and the back button stay sane.
+ */
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { AlertCircle, Loader2, ShieldCheck } from "lucide-react";
+import {
+  getTwoFactorClient,
+  unwrapTwoFactorResult,
+  type TwoFactorApiError,
+} from "@/lib/auth/two-factor-client";
+
+type Mode = "totp" | "backup";
+
+interface ModeConfig {
+  title: string;
+  description: string;
+  inputLabel: string;
+  placeholder: string;
+  inputMode: "numeric" | "text";
+  /** TOTP codes are exactly 6 digits; backup codes are 11 chars (5-5 with hyphen). */
+  maxLength: number;
+  /** Submit-button enable predicate — TOTP demands all 6 digits, backup tolerates user-entered formatting. */
+  isComplete: (value: string) => boolean;
+  /** Sanitiser run on every keystroke. TOTP strips non-digits; backup is left as-typed (codes are alphanumeric). */
+  sanitise: (raw: string) => string;
+  fallback: string;
+  switchLabel: string;
+}
+
+const TOTP_MODE: ModeConfig = {
+  title: "Enter your authenticator code",
+  description:
+    "Open the app you set up during enrollment (Google Authenticator, 1Password, Authy…) and type the 6-digit code.",
+  inputLabel: "Authenticator code",
+  placeholder: "123456",
+  inputMode: "numeric",
+  maxLength: 6,
+  isComplete: (v) => v.length === 6,
+  sanitise: (raw) => raw.replace(/\D/g, "").slice(0, 6),
+  fallback: "That code didn't match. Try again.",
+  switchLabel: "Use a backup code instead",
+};
+
+const BACKUP_MODE: ModeConfig = {
+  title: "Enter a backup code",
+  description:
+    "Use one of the codes saved when you set up two-factor. Each code only works once — pick a fresh one.",
+  inputLabel: "Backup code",
+  placeholder: "abcde-12345",
+  inputMode: "text",
+  // 5-5 layout with optional hyphen, plus the hyphen itself.
+  maxLength: 11,
+  isComplete: (v) => v.replace(/[-\s]/g, "").length >= 10,
+  // Backup codes from `generateBackupCodesFn` are alphanumeric — strip
+  // whitespace but preserve the hyphen so the user sees the same shape
+  // they copied. The server normalises before comparing.
+  sanitise: (raw) => raw.replace(/\s+/g, "").slice(0, 11),
+  fallback: "That backup code didn't match. Try a different one.",
+  switchLabel: "Use my authenticator app instead",
+};
+
+const MODES: Record<Mode, ModeConfig> = { totp: TOTP_MODE, backup: BACKUP_MODE };
+
+/**
+ * Single audit-trail line so support can recover `code` / `status` from a
+ * user report — the UI only surfaces the human-friendly message above.
+ */
+function logFailure(action: string, raw: TwoFactorApiError | null): void {
+  console.warn(`[two-factor:sign-in] ${action} failed`, raw);
+}
+
+export default function TwoFactorChallengePage() {
+  const router = useRouter();
+  const [mode, setMode] = useState<Mode>("totp");
+  const [code, setCode] = useState("");
+  const [trustDevice, setTrustDevice] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const config = MODES[mode];
+
+  /**
+   * Switch between TOTP and backup mode. Deliberately resets `code` and
+   * `error` (different validation rules, different shape) but PRESERVES
+   * `trustDevice` — switching input methods shouldn't quietly toggle the
+   * security choice the user already made.
+   */
+  function switchMode(next: Mode): void {
+    setMode(next);
+    setCode("");
+    setError(null);
+  }
+
+  async function handleSubmit(e: React.FormEvent): Promise<void> {
+    e.preventDefault();
+    if (!config.isComplete(code) || busy) return;
+    setBusy(true);
+    setError(null);
+
+    const client = getTwoFactorClient();
+    if (!client) {
+      // Plugin missing client-side. Surface a generic failure — the user
+      // can't act on this, but support can recover the cause from the
+      // breadcrumb below.
+      console.warn(
+        "[two-factor:sign-in] twoFactor client plugin not loaded — check packages/web/src/lib/auth/client.ts",
+      );
+      setError("Two-factor sign-in is not available. Refresh the page or contact your workspace admin.");
+      setBusy(false);
+      return;
+    }
+
+    try {
+      const result =
+        mode === "totp"
+          ? await client.verifyTotp({ code, trustDevice })
+          : await client.verifyBackupCode({ code, trustDevice });
+      const outcome = unwrapTwoFactorResult(result, config.fallback);
+      if (!outcome.ok) {
+        logFailure(mode === "totp" ? "verifyTotp" : "verifyBackupCode", outcome.raw);
+        setError(outcome.message);
+        setBusy(false);
+        return;
+      }
+      // Session is now established — Better Auth set the session cookie on
+      // the response. Route to the post-login landing; downstream onboarding
+      // / mode-router state is fetched by the destination page.
+      router.push("/");
+    } catch (err) {
+      // Network / TypeError path. Catch-and-classify mirrors the main login
+      // page; we don't want a thrown fetch to leave the user staring at a
+      // disabled form with no feedback.
+      console.warn(
+        "[two-factor:sign-in] verify threw:",
+        err instanceof Error ? err.message : String(err),
+      );
+      setError(
+        err instanceof TypeError
+          ? "Can't reach the server. Check your connection and try again."
+          : err instanceof Error && err.message
+            ? err.message
+            : config.fallback,
+      );
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-center">
+      <div className="mb-6 flex flex-col items-center text-center">
+        <div className="mb-3 flex size-12 items-center justify-center rounded-lg bg-primary/10">
+          <ShieldCheck className="size-6 text-primary" aria-hidden />
+        </div>
+        <h1 className="text-2xl font-semibold tracking-tight">{config.title}</h1>
+        <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+          {config.description}
+        </p>
+      </div>
+
+      <Card className="w-full">
+        <CardContent className="space-y-4 pt-6">
+          <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+            <div className="space-y-2">
+              <Label htmlFor="two-factor-code">{config.inputLabel}</Label>
+              <Input
+                id="two-factor-code"
+                type="text"
+                inputMode={config.inputMode}
+                autoComplete="one-time-code"
+                maxLength={config.maxLength}
+                placeholder={config.placeholder}
+                value={code}
+                onChange={(e) => setCode(config.sanitise(e.target.value))}
+                disabled={busy}
+                autoFocus
+                className="font-mono text-base tracking-widest"
+              />
+            </div>
+
+            <label className="flex items-start gap-2.5 text-sm">
+              <Checkbox
+                id="trust-device"
+                checked={trustDevice}
+                onCheckedChange={(checked) => setTrustDevice(checked === true)}
+                disabled={busy}
+                className="mt-0.5"
+              />
+              <span className="flex-1 select-none">
+                <span className="font-medium">Trust this device for 30 days</span>
+                <span className="mt-0.5 block text-xs text-muted-foreground">
+                  Skip the code prompt on this browser until {formatTrustExpiry()}.
+                  Don't enable on a shared computer.
+                </span>
+              </span>
+            </label>
+
+            {error && <ChallengeErrorAlert message={error} />}
+
+            <Button
+              type="submit"
+              className="w-full"
+              disabled={busy || !config.isComplete(code)}
+            >
+              {busy ? (
+                <>
+                  <Loader2 className="mr-2 size-4 animate-spin" aria-hidden />
+                  Verifying…
+                </>
+              ) : (
+                "Continue"
+              )}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      <button
+        type="button"
+        onClick={() => switchMode(mode === "totp" ? "backup" : "totp")}
+        disabled={busy}
+        className="mt-4 text-sm font-medium text-muted-foreground transition-colors hover:text-primary hover:underline underline-offset-4 disabled:opacity-50"
+      >
+        {config.switchLabel}
+      </button>
+    </div>
+  );
+}
+
+function ChallengeErrorAlert({ message }: { message: string }) {
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className="flex items-start gap-3 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-900 dark:border-red-900 dark:bg-red-950 dark:text-red-200"
+    >
+      <AlertCircle className="mt-0.5 size-4 shrink-0" aria-hidden />
+      <p className="flex-1 text-xs leading-relaxed">{message}</p>
+    </div>
+  );
+}
+
+/**
+ * Best-effort human-readable expiry stamp for the trust-device caption.
+ * Reads the current date at render — accurate to the day, which is enough
+ * for "Skip the prompt until April 12" copy. Wrapped so a non-`Intl`
+ * runtime (older test environments) doesn't crash the page.
+ */
+function formatTrustExpiry(): string {
+  const expiry = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      month: "short",
+      day: "numeric",
+    }).format(expiry);
+  } catch {
+    // Intl not available — fall back to ISO date so the caption is still meaningful.
+    return expiry.toISOString().slice(0, 10);
+  }
+}

--- a/packages/web/src/lib/auth/two-factor-client.test.ts
+++ b/packages/web/src/lib/auth/two-factor-client.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+
+// `authClient` is the namespace `getTwoFactorClient` reads. Each test
+// reassigns the `twoFactor` field below to exercise a different branch
+// of the method-presence guard.
+const authClientStub: { twoFactor?: unknown } = {};
+
+mock.module("./client", () => ({
+  authClient: authClientStub,
+}));
+
+import {
+  unwrapTwoFactorResult,
+  getTwoFactorClient,
+  requireTwoFactorClient,
+  type TwoFactorApiResult,
+  type TwoFactorClient,
+} from "./two-factor-client";
+
+const consoleWarn = console.warn;
+const warnCalls: unknown[][] = [];
+
+beforeEach(() => {
+  warnCalls.length = 0;
+  console.warn = ((...args: unknown[]) => {
+    warnCalls.push(args);
+  }) as typeof console.warn;
+  authClientStub.twoFactor = undefined;
+});
+
+afterEach(() => {
+  console.warn = consoleWarn;
+});
+
+describe("unwrapTwoFactorResult", () => {
+  test("ok=true on { data, error: null }", () => {
+    const result: TwoFactorApiResult<{ token: string }> = {
+      data: { token: "abc" },
+      error: null,
+    };
+    const out = unwrapTwoFactorResult(result, "fallback");
+    expect(out.ok).toBe(true);
+    if (out.ok) expect(out.data.token).toBe("abc");
+  });
+
+  test("ok=false carries server message and raw error when error present", () => {
+    const result: TwoFactorApiResult<unknown> = {
+      data: null,
+      error: { code: "INVALID_TOTP", message: "wrong code", status: 401 },
+    };
+    const out = unwrapTwoFactorResult(result, "fallback");
+    expect(out.ok).toBe(false);
+    if (!out.ok) {
+      expect(out.message).toBe("wrong code");
+      expect(out.raw).toEqual({ code: "INVALID_TOTP", message: "wrong code", status: 401 });
+    }
+  });
+
+  test("ok=false uses fallback when error has no message", () => {
+    const result: TwoFactorApiResult<unknown> = {
+      data: null,
+      error: { code: "X" },
+    };
+    const out = unwrapTwoFactorResult(result, "fallback msg");
+    if (!out.ok) expect(out.message).toBe("fallback msg");
+  });
+
+  test("empty envelope { data: null, error: null } emits breadcrumb and tags raw with EMPTY_ENVELOPE", () => {
+    // Bypass the XOR — Better Auth occasionally produces this shape on a
+    // 204-style response. The helper exists to catch it.
+    const result = { data: null, error: null } as unknown as TwoFactorApiResult<unknown>;
+    const out = unwrapTwoFactorResult(result, "fallback msg");
+    expect(out.ok).toBe(false);
+    if (!out.ok) {
+      expect(out.message).toBe("fallback msg");
+      expect(out.raw).toEqual({ code: "EMPTY_ENVELOPE", message: "fallback msg" });
+    }
+    // Breadcrumb fired so support can distinguish wire-shape anomaly from
+    // a normal failure.
+    expect(warnCalls.length).toBe(1);
+    expect(String(warnCalls[0][0])).toContain("empty envelope");
+  });
+});
+
+describe("getTwoFactorClient — method-presence guard", () => {
+  function fullStub(): Partial<TwoFactorClient> {
+    return {
+      enable: async () => ({ data: null, error: { code: "X" } }),
+      disable: async () => ({ data: null, error: { code: "X" } }),
+      verifyTotp: async () => ({ data: null, error: { code: "X" } }),
+      verifyBackupCode: async () => ({ data: null, error: { code: "X" } }),
+      generateBackupCodes: async () => ({ data: null, error: { code: "X" } }),
+    };
+  }
+
+  test("returns null when plugin namespace is missing", () => {
+    authClientStub.twoFactor = undefined;
+    expect(getTwoFactorClient()).toBeNull();
+  });
+
+  test("returns null when namespace is present but enable is missing", () => {
+    const stub = fullStub();
+    delete stub.enable;
+    authClientStub.twoFactor = stub;
+    expect(getTwoFactorClient()).toBeNull();
+  });
+
+  test("returns null when verifyTotp is missing (Better Auth API drift)", () => {
+    const stub = fullStub();
+    delete stub.verifyTotp;
+    authClientStub.twoFactor = stub;
+    expect(getTwoFactorClient()).toBeNull();
+  });
+
+  test("returns null when verifyBackupCode is missing", () => {
+    const stub = fullStub();
+    delete stub.verifyBackupCode;
+    authClientStub.twoFactor = stub;
+    expect(getTwoFactorClient()).toBeNull();
+  });
+
+  test("returns null when a method is present but not callable", () => {
+    const stub = fullStub() as Record<string, unknown>;
+    stub.verifyTotp = "not a function";
+    authClientStub.twoFactor = stub;
+    expect(getTwoFactorClient()).toBeNull();
+  });
+
+  test("returns the namespace when every method is callable", () => {
+    authClientStub.twoFactor = fullStub();
+    const client = getTwoFactorClient();
+    expect(client).not.toBeNull();
+    expect(typeof client?.verifyTotp).toBe("function");
+  });
+});
+
+describe("requireTwoFactorClient", () => {
+  test("returns the client when present", () => {
+    authClientStub.twoFactor = {
+      enable: async () => ({ data: null, error: { code: "X" } }),
+      disable: async () => ({ data: null, error: { code: "X" } }),
+      verifyTotp: async () => ({ data: null, error: { code: "X" } }),
+      verifyBackupCode: async () => ({ data: null, error: { code: "X" } }),
+      generateBackupCodes: async () => ({ data: null, error: { code: "X" } }),
+    };
+    expect(() => requireTwoFactorClient()).not.toThrow();
+  });
+
+  test("throws when plugin missing", () => {
+    authClientStub.twoFactor = undefined;
+    expect(() => requireTwoFactorClient()).toThrow(/twoFactor client plugin is not loaded/);
+  });
+});

--- a/packages/web/src/lib/auth/two-factor-client.ts
+++ b/packages/web/src/lib/auth/two-factor-client.ts
@@ -1,0 +1,141 @@
+/**
+ * Shared narrow view onto the Better Auth two-factor client surface.
+ *
+ * `createAuthClient`'s plugin-augmented type doesn't surface
+ * `twoFactor.{enable,disable,verifyTotp,verifyBackupCode,generateBackupCodes}`
+ * through the generic chain under TS6 strictness, so consumers cast through
+ * `unknown`. Centralising the cast plus the runtime guard keeps the security
+ * page (`two-factor-setup`) and the sign-in challenge page
+ * (`/login/two-factor`) honest about which methods they depend on.
+ *
+ * Mirrors the shape of `passkey-client.ts` — same null-on-missing convention
+ * for callers that want to soft-fail, same throwing helper for callers that
+ * treat plugin absence as a configuration error.
+ */
+
+import { authClient } from "./client";
+
+// ---------------------------------------------------------------------------
+// Wire shapes
+// ---------------------------------------------------------------------------
+
+export interface TwoFactorApiError {
+  message?: string;
+  code?: string;
+  status?: number;
+}
+
+export type TwoFactorApiResult<T> = {
+  data: T | null;
+  error: TwoFactorApiError | null;
+};
+
+export interface EnableResponse {
+  totpURI: string;
+  backupCodes: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Method surface — the union of what both consumers need.
+// ---------------------------------------------------------------------------
+
+export interface TwoFactorClient {
+  enable: (opts: { password: string }) => Promise<TwoFactorApiResult<EnableResponse>>;
+  disable: (opts: { password: string }) => Promise<TwoFactorApiResult<{ status?: boolean }>>;
+  /**
+   * Used both during enrollment (no `trustDevice`, session already exists)
+   * and during sign-in challenge (with `trustDevice` checkbox state). The
+   * server flow is unified — see Better Auth's `verify-two-factor.mjs`.
+   */
+  verifyTotp: (opts: {
+    code: string;
+    trustDevice?: boolean;
+  }) => Promise<TwoFactorApiResult<{ token?: string }>>;
+  /**
+   * Sign-in fallback when the user has lost access to their authenticator.
+   * Each backup code is single-use — a successful call invalidates it
+   * server-side and the next call will fail.
+   */
+  verifyBackupCode: (opts: {
+    code: string;
+    trustDevice?: boolean;
+  }) => Promise<TwoFactorApiResult<{ token?: string }>>;
+  generateBackupCodes: (opts: {
+    password: string;
+  }) => Promise<TwoFactorApiResult<{ backupCodes: string[] }>>;
+}
+
+// ---------------------------------------------------------------------------
+// Guards
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the `twoFactor` namespace off authClient, returning `null` if the
+ * plugin isn't loaded. Method-presence guard catches Better Auth API drift
+ * (renamed methods turn into a precise null instead of a `TypeError` at
+ * click time).
+ */
+export function getTwoFactorClient(): TwoFactorClient | null {
+  // The cast is the documented workaround for Better Auth's plugin-inference
+  // gap under TS6. Same pattern as `getPasskeyClient()` in `passkey-client.ts`
+  // and the `@ts-expect-error` on `apiKeyClient()` in `client.ts`.
+  const namespace = (authClient as unknown as { twoFactor?: Partial<TwoFactorClient> })
+    .twoFactor;
+  if (
+    !namespace ||
+    typeof namespace.enable !== "function" ||
+    typeof namespace.disable !== "function" ||
+    typeof namespace.verifyTotp !== "function" ||
+    typeof namespace.verifyBackupCode !== "function" ||
+    typeof namespace.generateBackupCodes !== "function"
+  ) {
+    return null;
+  }
+  return namespace as TwoFactorClient;
+}
+
+/**
+ * Throwing variant for callers that treat plugin absence as a startup-time
+ * configuration error — matches the existing `getTwoFactor()` ergonomics in
+ * `two-factor-setup.tsx`. The thrown message is developer-facing; UI layers
+ * should convert to user-friendly copy before display.
+ */
+export function requireTwoFactorClient(): TwoFactorClient {
+  const client = getTwoFactorClient();
+  if (!client) {
+    throw new Error(
+      "Better Auth twoFactor client plugin is not loaded — check packages/web/src/lib/auth/client.ts",
+    );
+  }
+  return client;
+}
+
+// ---------------------------------------------------------------------------
+// Result narrowing
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalise a Better Auth result envelope into a tagged union. Necessary
+ * because the wire shape allows `{ data: null, error: null }` (e.g. an
+ * unexpected 204) which would otherwise be silently treated as success.
+ *
+ * The `raw` field on the failure variant carries the structured error so
+ * callers can log `code` / `status` for support without surfacing them in
+ * end-user UI.
+ */
+export type TwoFactorOutcome<T> =
+  | { ok: true; data: T }
+  | { ok: false; message: string; raw: TwoFactorApiError | null };
+
+export function unwrapTwoFactorResult<T>(
+  result: TwoFactorApiResult<T>,
+  fallback: string,
+): TwoFactorOutcome<T> {
+  if (result.error) {
+    return { ok: false, message: result.error.message ?? fallback, raw: result.error };
+  }
+  if (!result.data) {
+    return { ok: false, message: fallback, raw: null };
+  }
+  return { ok: true, data: result.data };
+}

--- a/packages/web/src/lib/auth/two-factor-client.ts
+++ b/packages/web/src/lib/auth/two-factor-client.ts
@@ -1,23 +1,14 @@
 /**
  * Shared narrow view onto the Better Auth two-factor client surface.
  *
- * `createAuthClient`'s plugin-augmented type doesn't surface
- * `twoFactor.{enable,disable,verifyTotp,verifyBackupCode,generateBackupCodes}`
- * through the generic chain under TS6 strictness, so consumers cast through
- * `unknown`. Centralising the cast plus the runtime guard keeps the security
- * page (`two-factor-setup`) and the sign-in challenge page
- * (`/login/two-factor`) honest about which methods they depend on.
- *
- * Mirrors the shape of `passkey-client.ts` — same null-on-missing convention
- * for callers that want to soft-fail, same throwing helper for callers that
- * treat plugin absence as a configuration error.
+ * Better Auth's plugin-augmented type doesn't propagate `twoFactor.*`
+ * through `createAuthClient` under TS6 strictness, so consumers cast
+ * through `unknown`. Centralising the cast plus the runtime method-presence
+ * guard means a renamed Better Auth method shows up as a precise null
+ * here rather than a `TypeError` at click time.
  */
 
 import { authClient } from "./client";
-
-// ---------------------------------------------------------------------------
-// Wire shapes
-// ---------------------------------------------------------------------------
 
 export interface TwoFactorApiError {
   message?: string;
@@ -25,60 +16,46 @@ export interface TwoFactorApiError {
   status?: number;
 }
 
-export type TwoFactorApiResult<T> = {
-  data: T | null;
-  error: TwoFactorApiError | null;
-};
+/**
+ * True XOR — narrowing on `error` reliably narrows `data`. The wrapper
+ * `unwrapTwoFactorResult` depends on this; consumers should not need to
+ * defensively check both fields.
+ */
+export type TwoFactorApiResult<T> =
+  | { data: T; error: null }
+  | { data: null; error: TwoFactorApiError };
 
 export interface EnableResponse {
   totpURI: string;
   backupCodes: string[];
 }
 
-// ---------------------------------------------------------------------------
-// Method surface — the union of what both consumers need.
-// ---------------------------------------------------------------------------
+/**
+ * Param shape shared by `verifyTotp` and `verifyBackupCode`. They behave
+ * identically from the caller's perspective — `trustDevice` is honoured
+ * server-side either way.
+ */
+export interface VerifyTwoFactorOpts {
+  code: string;
+  trustDevice?: boolean;
+}
 
 export interface TwoFactorClient {
   enable: (opts: { password: string }) => Promise<TwoFactorApiResult<EnableResponse>>;
   disable: (opts: { password: string }) => Promise<TwoFactorApiResult<{ status?: boolean }>>;
-  /**
-   * Used both during enrollment (no `trustDevice`, session already exists)
-   * and during sign-in challenge (with `trustDevice` checkbox state). The
-   * server flow is unified — see Better Auth's `verify-two-factor.mjs`.
-   */
-  verifyTotp: (opts: {
-    code: string;
-    trustDevice?: boolean;
-  }) => Promise<TwoFactorApiResult<{ token?: string }>>;
-  /**
-   * Sign-in fallback when the user has lost access to their authenticator.
-   * Each backup code is single-use — a successful call invalidates it
-   * server-side and the next call will fail.
-   */
-  verifyBackupCode: (opts: {
-    code: string;
-    trustDevice?: boolean;
-  }) => Promise<TwoFactorApiResult<{ token?: string }>>;
+  verifyTotp: (opts: VerifyTwoFactorOpts) => Promise<TwoFactorApiResult<{ token?: string }>>;
+  /** Each backup code is single-use — server invalidates on success. */
+  verifyBackupCode: (opts: VerifyTwoFactorOpts) => Promise<TwoFactorApiResult<{ token?: string }>>;
   generateBackupCodes: (opts: {
     password: string;
   }) => Promise<TwoFactorApiResult<{ backupCodes: string[] }>>;
 }
 
-// ---------------------------------------------------------------------------
-// Guards
-// ---------------------------------------------------------------------------
-
 /**
- * Resolve the `twoFactor` namespace off authClient, returning `null` if the
- * plugin isn't loaded. Method-presence guard catches Better Auth API drift
- * (renamed methods turn into a precise null instead of a `TypeError` at
- * click time).
+ * Returns `null` when the plugin isn't loaded. Method-presence guard
+ * catches Better Auth API drift at the boundary.
  */
 export function getTwoFactorClient(): TwoFactorClient | null {
-  // The cast is the documented workaround for Better Auth's plugin-inference
-  // gap under TS6. Same pattern as `getPasskeyClient()` in `passkey-client.ts`
-  // and the `@ts-expect-error` on `apiKeyClient()` in `client.ts`.
   const namespace = (authClient as unknown as { twoFactor?: Partial<TwoFactorClient> })
     .twoFactor;
   if (
@@ -96,37 +73,27 @@ export function getTwoFactorClient(): TwoFactorClient | null {
 
 /**
  * Throwing variant for callers that treat plugin absence as a startup-time
- * configuration error — matches the existing `getTwoFactor()` ergonomics in
- * `two-factor-setup.tsx`. The thrown message is developer-facing; UI layers
- * should convert to user-friendly copy before display.
+ * configuration error. Thrown message is developer-facing.
  */
 export function requireTwoFactorClient(): TwoFactorClient {
   const client = getTwoFactorClient();
   if (!client) {
-    throw new Error(
-      "Better Auth twoFactor client plugin is not loaded — check packages/web/src/lib/auth/client.ts",
-    );
+    throw new Error("Better Auth twoFactor client plugin is not loaded");
   }
   return client;
 }
 
-// ---------------------------------------------------------------------------
-// Result narrowing
-// ---------------------------------------------------------------------------
-
-/**
- * Normalise a Better Auth result envelope into a tagged union. Necessary
- * because the wire shape allows `{ data: null, error: null }` (e.g. an
- * unexpected 204) which would otherwise be silently treated as success.
- *
- * The `raw` field on the failure variant carries the structured error so
- * callers can log `code` / `status` for support without surfacing them in
- * end-user UI.
- */
 export type TwoFactorOutcome<T> =
   | { ok: true; data: T }
   | { ok: false; message: string; raw: TwoFactorApiError | null };
 
+/**
+ * Normalise a Better Auth result envelope into a tagged union. The
+ * `{ data: null, error: null }` branch is the silent-success bug guard
+ * (Better Auth occasionally produces this on 204-style responses); a
+ * console breadcrumb fires so support can distinguish a wire-shape
+ * anomaly from a normal failure.
+ */
 export function unwrapTwoFactorResult<T>(
   result: TwoFactorApiResult<T>,
   fallback: string,
@@ -135,7 +102,14 @@ export function unwrapTwoFactorResult<T>(
     return { ok: false, message: result.error.message ?? fallback, raw: result.error };
   }
   if (!result.data) {
-    return { ok: false, message: fallback, raw: null };
+    console.warn(
+      "[two-factor] empty envelope — Better Auth returned { data: null, error: null }",
+    );
+    return {
+      ok: false,
+      message: fallback,
+      raw: { code: "EMPTY_ENVELOPE", message: fallback },
+    };
   }
   return { ok: true, data: result.data };
 }

--- a/packages/web/src/ui/components/admin/security/two-factor-setup.tsx
+++ b/packages/web/src/ui/components/admin/security/two-factor-setup.tsx
@@ -27,7 +27,11 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { authClient } from "@/lib/auth/client";
+import {
+  requireTwoFactorClient,
+  unwrapTwoFactorResult,
+  type TwoFactorApiError,
+} from "@/lib/auth/two-factor-client";
 import { consumeOriginPath } from "@/ui/components/admin/mfa-gate-context";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -50,81 +54,6 @@ import {
   Lock,
   ShieldCheck,
 } from "lucide-react";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-/**
- * Shape returned by Better Auth's `twoFactor.enable` action. Typed loosely
- * here because the client plugin's exported type isn't reachable through
- * `createAuthClient`'s plugin generic chain.
- */
-interface EnableResponse {
-  totpURI: string;
-  backupCodes: string[];
-}
-
-/**
- * Result envelope Better Auth uses for client actions. Better Auth's wire
- * shape allows `{ data: null, error: null }` (e.g. an unexpected 204) so the
- * call sites must check both fields — see {@link unwrapResult}.
- *
- * Carries `code` and `status` alongside `message` so the component can log
- * the structured failure for support, even though it only surfaces `message`
- * in the UI.
- */
-type ClientResult<T> = {
-  data: T | null;
-  error: { message?: string; code?: string; status?: number } | null;
-};
-
-/**
- * Normalize a Better Auth result into a tagged union so call sites don't
- * have to repeat the `result.error || !result.data` defensive narrowing
- * — and so a `{ data: null, error: null }` response is treated as failure
- * rather than silent success (verifyTotp regression caught pre-merge).
- */
-type Outcome<T> = { ok: true; data: T } | { ok: false; message: string; raw: ClientResult<T>["error"] };
-
-function unwrapResult<T>(result: ClientResult<T>, fallback: string): Outcome<T> {
-  if (result.error) {
-    return { ok: false, message: result.error.message ?? fallback, raw: result.error };
-  }
-  if (!result.data) {
-    return { ok: false, message: fallback, raw: null };
-  }
-  return { ok: true, data: result.data };
-}
-
-// Minimal contract for the parts of authClient.twoFactor we use. Keeps the
-// component working under TS6's stricter inference of plugin-augmented
-// clients without resorting to `any`.
-interface TwoFactorClient {
-  enable: (opts: { password: string }) => Promise<ClientResult<EnableResponse>>;
-  verifyTotp: (opts: { code: string }) => Promise<ClientResult<{ token?: string }>>;
-  disable: (opts: { password: string }) => Promise<ClientResult<{ status?: boolean }>>;
-  generateBackupCodes: (opts: {
-    password: string;
-  }) => Promise<ClientResult<{ backupCodes: string[] }>>;
-}
-
-/**
- * Resolve the `twoFactor` namespace off authClient. The cast through
- * `unknown` is the documented workaround for TS6's plugin-inference gap;
- * the runtime guard turns "plugin not loaded" from a `Cannot read
- * properties of undefined` deep in a handler into a clear up-front error
- * a caller can surface.
- */
-function getTwoFactor(): TwoFactorClient {
-  const namespace = (authClient as unknown as { twoFactor?: TwoFactorClient }).twoFactor;
-  if (!namespace) {
-    throw new Error(
-      "Better Auth twoFactor client plugin is not loaded — check packages/web/src/lib/auth/client.ts",
-    );
-  }
-  return namespace;
-}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -296,7 +225,7 @@ type EnrollStage =
  * support can still recover the `code` / `status` / `cause` from a user
  * report even though only `message` is shown in the UI.
  */
-function logFailure(action: string, raw: ClientResult<unknown>["error"]): void {
+function logFailure(action: string, raw: TwoFactorApiError | null): void {
   console.warn(`[two-factor] ${action} failed`, raw);
 }
 
@@ -323,9 +252,9 @@ export function TwoFactorSetup({ enabled, onChange }: TwoFactorSetupProps) {
   async function handleEnable() {
     setBusy(true);
     setError(null);
-    const result = await getTwoFactor().enable({ password });
+    const result = await requireTwoFactorClient().enable({ password });
     setBusy(false);
-    const outcome = unwrapResult(result, "Could not enable two-factor authentication.");
+    const outcome = unwrapTwoFactorResult(result, "Could not enable two-factor authentication.");
     if (!outcome.ok) {
       logFailure("enable", outcome.raw);
       setError(outcome.message);
@@ -341,11 +270,11 @@ export function TwoFactorSetup({ enabled, onChange }: TwoFactorSetupProps) {
   async function handleVerify() {
     setBusy(true);
     setError(null);
-    const result = await getTwoFactor().verifyTotp({ code });
+    const result = await requireTwoFactorClient().verifyTotp({ code });
     setBusy(false);
     // Treat `{ data: null, error: null }` as failure — the regression Better
     // Auth client envelopes can produce on a 204-style response.
-    const outcome = unwrapResult(result, "That code didn't match. Try again.");
+    const outcome = unwrapTwoFactorResult(result, "That code didn't match. Try again.");
     if (!outcome.ok) {
       logFailure("verifyTotp", outcome.raw);
       setError(outcome.message);
@@ -364,10 +293,10 @@ export function TwoFactorSetup({ enabled, onChange }: TwoFactorSetupProps) {
   async function handleRegenerate() {
     setBusy(true);
     setError(null);
-    const result = await getTwoFactor().generateBackupCodes({ password: confirmPassword });
+    const result = await requireTwoFactorClient().generateBackupCodes({ password: confirmPassword });
     setBusy(false);
     setConfirmPassword("");
-    const outcome = unwrapResult(result, "Could not regenerate backup codes.");
+    const outcome = unwrapTwoFactorResult(result, "Could not regenerate backup codes.");
     if (!outcome.ok) {
       logFailure("generateBackupCodes", outcome.raw);
       setError(outcome.message);
@@ -382,10 +311,10 @@ export function TwoFactorSetup({ enabled, onChange }: TwoFactorSetupProps) {
   async function handleDisable() {
     setBusy(true);
     setError(null);
-    const result = await getTwoFactor().disable({ password: confirmPassword });
+    const result = await requireTwoFactorClient().disable({ password: confirmPassword });
     setBusy(false);
     setConfirmPassword("");
-    const outcome = unwrapResult(result, "Could not disable two-factor authentication.");
+    const outcome = unwrapTwoFactorResult(result, "Could not disable two-factor authentication.");
     if (!outcome.ok) {
       logFailure("disable", outcome.raw);
       setError(outcome.message);


### PR DESCRIPTION
## Summary

Closes the missing `/login/two-factor` route — until now, signing in as a TOTP-enrolled user landed on a half-authenticated state with **no UI** to complete the challenge. Verified live: `/login`'s `signIn.email` handler ignores `res.data.twoFactorRedirect` and just `router.push("/")`s, so the user lands on `/` with no session and gets bounced. **This is a P0 regression masquerading as a feature** — PR A's MFA gate created the dependency without anyone noticing the sign-in side wasn't wired up.

PR C scope split based on Better Auth source-code reading:

- **PR C.1 (this PR)** — sign-in challenge UI + trust-device opt-in. Ships the user-facing fix.
- **PR C.2 (follow-up issue to file)** — admin trusted-devices list + revoke. Needs a new `trusted_device` table + `verify-totp` hook to capture metadata Better Auth doesn't persist (label, userAgent, IP, lastUsedAt). Cleanly separable from C.1.

## Why split

The original brief assumed Better Auth had list/revoke endpoints for trusted devices. It doesn't — `verifyTotp({ trustDevice: true })` writes a generic row in the `verification` table with no metadata. C.2's data-model decisions deserve their own review surface, and C.1 is independently shippable as the regression fix.

## Changes

**`/login/two-factor/page.tsx` (NEW, 282 LOC)** — TOTP / backup-code mode toggle, default-off "Trust this device for 30 days" checkbox with human-readable expiry caption, inline error surface, distinct copy for `TypeError` (network) vs `Error` (server). Mode switch resets the code but **preserves** the trust-device choice (otherwise switching modes would silently undo the security choice).

**`/login/page.tsx` wiring (+12 LOC)** — Detects `res.data.twoFactorRedirect` and routes to `/login/two-factor` instead of `/`. The cast through `unknown` is the documented workaround for Better Auth's plugin discriminated-union not propagating through `createAuthClient`.

**`packages/api/src/lib/auth/server.ts` (+6 LOC)** — Sets `trustDeviceMaxAge: 30 * 24 * 60 * 60` explicitly on the `twoFactor()` plugin. Matches Better Auth's current default; pinning prevents a future minor bump from silently revoking every trust cookie in the wild.

**`packages/web/src/lib/auth/two-factor-client.ts` (NEW, 141 LOC)** — Extracted `getTwoFactor()` + `unwrapResult()` from `two-factor-setup.tsx` into a shared module mirroring `passkey-client.ts`. Adds `verifyBackupCode` to the surface; widens `verifyTotp` to accept `trustDevice?: boolean`. Two consumers now: enrollment (no trust) and sign-in (opt-in).

**`two-factor-setup.tsx` refactor (-83 LOC net)** — Switches to the shared helper. Behavior unchanged.

## Test plan

- [x] `bun run type` — passes (whole monorepo)
- [x] `bun run lint` — passes
- [x] `bun run test` (affected) — api 21/21, web 112/112
- [x] `bun x syncpack lint` — no issues
- [x] `bash scripts/check-template-drift.sh` — 484 files verified
- [x] 10 unit tests for the new page covering defaults, trust-device wiring (false/true), server error inline, network-failure copy, mode-toggle preserves trust, plugin-missing recovery
- [ ] **Manual sign-in walkthrough** — reviewer should:
  1. Sign in as `admin@useatlas.dev` / `atlas-dev`
  2. Enroll TOTP at `/admin/settings/security` if not already
  3. Sign out, sign back in → expect routing to `/login/two-factor`
  4. Submit code without trust-device → expect landing on `/`, next sign-in still prompts
  5. Submit code with trust-device → expect cookie set, next sign-in skips challenge
  6. Try a backup code (toggle mode) → expect single-use semantics
- [ ] **Cross-device trust-device behavior** — sign in trusted on browser A, then sign in browser B → should still prompt on B (cookie is per-device)

## Out of scope (filing as follow-ups after merge)

1. **PR C.2** — admin trusted-devices list + revoke (~400 LOC: new table + hook + 2 admin routes + UI section)
2. **PR D** — passkey-on-login affordance (`authClient.signIn.passkey({ autoFill: true })` conditional UI on `/login`)
3. **`/login/two-factor` page-level test for the route guards** — confirmed non-issue in step 0 (Better Auth doesn't establish a session until `verifyTotp` succeeds, so `/admin/*` naturally rejects the half-auth state)

Closes part of #2082.