### PR TITLE
feat(api): #2082 — record trust-device identifier on admin audit log (PR C.3 of D)

### DIFF
--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -27,6 +27,7 @@
     "@useatlas/types": "^0.0.18",
     "@better-auth/api-key": "^1.6.9",
     "@better-auth/oauth-provider": "^1.6.9",
+    "@better-auth/passkey": "^1.6.9",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -25,6 +25,7 @@
     "ai": "^6.0.141",
     "@better-auth/api-key": "^1.6.9",
     "@better-auth/oauth-provider": "^1.6.9",
+    "@better-auth/passkey": "^1.6.9",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",

--- a/packages/api/src/api/routes/__tests__/middleware-trust-device.test.ts
+++ b/packages/api/src/api/routes/__tests__/middleware-trust-device.test.ts
@@ -1,0 +1,242 @@
+/**
+ * #2082 PR C.3 — verify the trust-device cookie threads through the auth
+ * middlewares onto the Hono context (`c.get("trustDeviceIdentifier")`)
+ * AND through `withRequestContext` so `logAdminAction` can pick it up
+ * via `getRequestContext()`.
+ *
+ * Tests the orchestration in `setTrustDeviceIdentifier()` indirectly —
+ * the helper is private so we drive each public middleware (`adminAuth`,
+ * `platformAdminAuth`, `standardAuth`) with a fake request and assert the
+ * downstream context state. Auth itself is mocked because the cookie
+ * extraction runs after auth succeeds.
+ */
+
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before importing the middleware module
+// ---------------------------------------------------------------------------
+
+const adminUser = {
+  id: "admin-1",
+  mode: "managed" as const,
+  label: "admin@test.com",
+  role: "admin" as const,
+  activeOrganizationId: "org-1",
+};
+
+const platformUser = {
+  ...adminUser,
+  id: "platform-1",
+  role: "platform_admin" as const,
+};
+
+let authUser: typeof adminUser | typeof platformUser = adminUser;
+
+mock.module("@atlas/api/lib/auth/middleware", () => ({
+  authenticateRequest: () =>
+    Promise.resolve({ authenticated: true, mode: "managed", user: authUser }),
+  checkRateLimit: () => ({ allowed: true }),
+  getClientIP: () => "10.0.0.1",
+  resetRateLimits: () => {},
+  rateLimitCleanupTick: () => {},
+}));
+
+let withRequestContextCalls: Array<Record<string, unknown>> = [];
+
+mock.module("@atlas/api/lib/logger", () => {
+  const noop = () => {};
+  const logger = {
+    info: noop,
+    warn: noop,
+    error: noop,
+    debug: noop,
+    child: () => logger,
+  };
+  return {
+    createLogger: () => logger,
+    getLogger: () => logger,
+    withRequestContext: (ctx: Record<string, unknown>, fn: () => unknown) => {
+      withRequestContextCalls.push(ctx);
+      return fn();
+    },
+    getRequestContext: () => undefined,
+    redactPaths: [],
+  };
+});
+
+mock.module("@atlas/api/lib/residency/misrouting", () => ({
+  detectMisrouting: async () => null,
+  isStrictRoutingEnabled: () => false,
+}));
+
+mock.module("@atlas/api/lib/residency/readonly", () => ({
+  isWorkspaceMigrating: async () => false,
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+const {
+  adminAuth,
+  platformAdminAuth,
+  standardAuth,
+  requestContext,
+} = await import("../middleware");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface FakeContext {
+  req: { raw: Request; method: string; header: (name: string) => string | undefined };
+  set: (key: string, value: unknown) => void;
+  get: (key: string) => unknown;
+  json: (
+    body: Record<string, unknown>,
+    status?: number,
+    headers?: Record<string, string>,
+  ) => Response;
+  var: Record<string, unknown>;
+}
+
+function fakeContext(req: Request): FakeContext {
+  const vars: Record<string, unknown> = {};
+  return {
+    req: {
+      raw: req,
+      method: req.method,
+      header: (name: string) => req.headers.get(name) ?? undefined,
+    },
+    set: (key, value) => {
+      vars[key] = value;
+    },
+    get: (key) => vars[key],
+    json: (body, status = 200, _headers) =>
+      new Response(JSON.stringify(body), { status }),
+    var: vars,
+  };
+}
+
+function buildRequest(cookieHeader: string | null): Request {
+  const headers: Record<string, string> = {};
+  if (cookieHeader) headers.cookie = cookieHeader;
+  return new Request("http://test.local/admin/orgs", {
+    method: "POST",
+    headers,
+  });
+}
+
+beforeEach(() => {
+  authUser = adminUser;
+  withRequestContextCalls = [];
+});
+
+// ---------------------------------------------------------------------------
+// adminAuth
+// ---------------------------------------------------------------------------
+
+describe("adminAuth — trust-device cookie surfacing", () => {
+  it("populates c.get('trustDeviceIdentifier') from a signed cookie", async () => {
+    const c = fakeContext(
+      buildRequest("better-auth.trust_device=hmac!trust-device-abc123"),
+    );
+
+    await adminAuth(c as never, async () => {});
+
+    expect(c.get("trustDeviceIdentifier")).toBe("trust-device-abc123");
+  });
+
+  it("populates undefined when no cookie is present", async () => {
+    const c = fakeContext(buildRequest(null));
+
+    await adminAuth(c as never, async () => {});
+
+    // Strictly undefined — never the empty string or null. Downstream
+    // consumers (`requestContext`, the Effect bridge) test for undefined
+    // and skip writing the field when absent.
+    expect(c.get("trustDeviceIdentifier")).toBeUndefined();
+  });
+
+  it("populates undefined when the cookie is malformed", async () => {
+    // Cookie with no '!' separator — extractor returns null, surfaces as undefined.
+    const c = fakeContext(
+      buildRequest("better-auth.trust_device=missing-bang-marker"),
+    );
+
+    await adminAuth(c as never, async () => {});
+
+    expect(c.get("trustDeviceIdentifier")).toBeUndefined();
+  });
+
+  it("ignores cookies with a non-trust-device prefix on the value", async () => {
+    const c = fakeContext(
+      buildRequest("better-auth.trust_device=hmac!session-token-abc"),
+    );
+
+    await adminAuth(c as never, async () => {});
+
+    expect(c.get("trustDeviceIdentifier")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// platformAdminAuth + standardAuth — same surfacing path
+// ---------------------------------------------------------------------------
+
+describe("platformAdminAuth — trust-device cookie surfacing", () => {
+  it("populates c.get('trustDeviceIdentifier') from a signed cookie", async () => {
+    authUser = platformUser;
+    const c = fakeContext(
+      buildRequest("better-auth.trust_device=hmac!trust-device-platform"),
+    );
+
+    await platformAdminAuth(c as never, async () => {});
+
+    expect(c.get("trustDeviceIdentifier")).toBe("trust-device-platform");
+  });
+});
+
+describe("standardAuth — trust-device cookie surfacing", () => {
+  it("populates c.get('trustDeviceIdentifier') from a signed cookie", async () => {
+    const c = fakeContext(
+      buildRequest("better-auth.trust_device=hmac!trust-device-user"),
+    );
+
+    await standardAuth(c as never, async () => {});
+
+    expect(c.get("trustDeviceIdentifier")).toBe("trust-device-user");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requestContext — threads trustDeviceIdentifier through withRequestContext
+// ---------------------------------------------------------------------------
+
+describe("requestContext — propagates trustDeviceIdentifier into AsyncLocalStorage", () => {
+  it("includes trustDeviceIdentifier in withRequestContext call when cookie is present", async () => {
+    const c = fakeContext(
+      buildRequest("better-auth.trust_device=hmac!trust-device-abc123"),
+    );
+    // Pre-populate auth state since requestContext expects auth middleware to have run
+    await adminAuth(c as never, async () => {
+      await requestContext(c as never, async () => {});
+    });
+
+    expect(withRequestContextCalls.length).toBeGreaterThanOrEqual(1);
+    const lastCall = withRequestContextCalls[withRequestContextCalls.length - 1];
+    expect(lastCall.trustDeviceIdentifier).toBe("trust-device-abc123");
+  });
+
+  it("passes undefined when the cookie is absent", async () => {
+    const c = fakeContext(buildRequest(null));
+
+    await adminAuth(c as never, async () => {
+      await requestContext(c as never, async () => {});
+    });
+
+    const lastCall = withRequestContextCalls[withRequestContextCalls.length - 1];
+    expect(lastCall.trustDeviceIdentifier).toBeUndefined();
+  });
+});

--- a/packages/api/src/api/routes/__tests__/middleware-trust-device.test.ts
+++ b/packages/api/src/api/routes/__tests__/middleware-trust-device.test.ts
@@ -1,14 +1,10 @@
 /**
- * #2082 PR C.3 — verify the trust-device cookie threads through the auth
- * middlewares onto the Hono context (`c.get("trustDeviceIdentifier")`)
- * AND through `withRequestContext` so `logAdminAction` can pick it up
- * via `getRequestContext()`.
- *
  * Tests the orchestration in `setTrustDeviceIdentifier()` indirectly —
  * the helper is private so we drive each public middleware (`adminAuth`,
  * `platformAdminAuth`, `standardAuth`) with a fake request and assert the
- * downstream context state. Auth itself is mocked because the cookie
- * extraction runs after auth succeeds.
+ * downstream context state, plus the thread-through to `withRequestContext`
+ * via the `requestContext` middleware. Auth itself is mocked because the
+ * cookie extraction runs after auth succeeds.
  */
 
 import { describe, it, expect, mock, beforeEach } from "bun:test";
@@ -83,6 +79,7 @@ const {
   platformAdminAuth,
   standardAuth,
   requestContext,
+  withRequestId,
 } = await import("../middleware");
 
 // ---------------------------------------------------------------------------
@@ -237,6 +234,47 @@ describe("requestContext — propagates trustDeviceIdentifier into AsyncLocalSto
     });
 
     const lastCall = withRequestContextCalls[withRequestContextCalls.length - 1];
+    expect(lastCall.trustDeviceIdentifier).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withRequestId — covers the admin.ts path (auth runs inline per-handler,
+// so the cookie has to be parsed by this lightweight middleware before the
+// route preamble has access to authResult)
+// ---------------------------------------------------------------------------
+
+describe("withRequestId — populates trustDeviceIdentifier on Hono context + ALS", () => {
+  it("sets c.get('trustDeviceIdentifier') from a signed cookie", async () => {
+    const c = fakeContext(
+      buildRequest("better-auth.trust_device=hmac!trust-device-via-witness"),
+    );
+
+    await withRequestId(c as never, async () => {});
+
+    expect(c.get("trustDeviceIdentifier")).toBe("trust-device-via-witness");
+  });
+
+  it("threads trustDeviceIdentifier into withRequestContext", async () => {
+    const c = fakeContext(
+      buildRequest("better-auth.trust_device=hmac!trust-device-witness-2"),
+    );
+
+    await withRequestId(c as never, async () => {});
+
+    const lastCall =
+      withRequestContextCalls[withRequestContextCalls.length - 1];
+    expect(lastCall.trustDeviceIdentifier).toBe("trust-device-witness-2");
+  });
+
+  it("passes undefined when no cookie is present", async () => {
+    const c = fakeContext(buildRequest(null));
+
+    await withRequestId(c as never, async () => {});
+
+    expect(c.get("trustDeviceIdentifier")).toBeUndefined();
+    const lastCall =
+      withRequestContextCalls[withRequestContextCalls.length - 1];
     expect(lastCall.trustDeviceIdentifier).toBeUndefined();
   });
 });

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -15,6 +15,7 @@ import type { Context } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { createLogger, withRequestContext, getRequestContext } from "@atlas/api/lib/logger";
 import { withRequestId, resolveMode, parseModeFromCookie } from "./middleware";
+import { extractTrustDeviceIdentifier } from "@atlas/api/lib/auth/trust-device-cookie";
 import type { AuthResult } from "@atlas/api/lib/auth/types";
 import { authenticateRequest } from "@atlas/api/lib/auth/middleware";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
@@ -147,10 +148,21 @@ async function adminAuthAndContext(
   // Bind user identity into the existing AsyncLocalStorage context so
   // downstream log lines include userId. The context was created by
   // withRequestId middleware with { requestId } only — mutating is safe
-  // because each request has its own context object.
+  // because each request has its own context object. Same path also
+  // surfaces the trust-device identifier so `logAdminAction` can record
+  // which trusted browser an admin used (parity with the
+  // adminAuth/standardAuth middleware paths in `./middleware.ts` —
+  // admin.ts uses `withRequestId` which doesn't run auth, so neither
+  // value is set until the per-handler preamble resolves).
   const ctx = getRequestContext();
   if (ctx) {
-    (ctx as unknown as Record<string, unknown>).user = authResult.user;
+    const ctxRecord = ctx as unknown as Record<string, unknown>;
+    ctxRecord.user = authResult.user;
+    const cookieHeader = c.req.raw.headers.get("cookie");
+    const trustDeviceIdentifier = extractTrustDeviceIdentifier(cookieHeader);
+    if (trustDeviceIdentifier) {
+      ctxRecord.trustDeviceIdentifier = trustDeviceIdentifier;
+    }
   }
 
   // Resolve and publish atlas mode for downstream handlers. getAtlasMode(c)

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -15,7 +15,6 @@ import type { Context } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { createLogger, withRequestContext, getRequestContext } from "@atlas/api/lib/logger";
 import { withRequestId, resolveMode, parseModeFromCookie } from "./middleware";
-import { extractTrustDeviceIdentifier } from "@atlas/api/lib/auth/trust-device-cookie";
 import type { AuthResult } from "@atlas/api/lib/auth/types";
 import { authenticateRequest } from "@atlas/api/lib/auth/middleware";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
@@ -147,22 +146,11 @@ async function adminAuthAndContext(
   }
   // Bind user identity into the existing AsyncLocalStorage context so
   // downstream log lines include userId. The context was created by
-  // withRequestId middleware with { requestId } only — mutating is safe
-  // because each request has its own context object. Same path also
-  // surfaces the trust-device identifier so `logAdminAction` can record
-  // which trusted browser an admin used (parity with the
-  // adminAuth/standardAuth middleware paths in `./middleware.ts` —
-  // admin.ts uses `withRequestId` which doesn't run auth, so neither
-  // value is set until the per-handler preamble resolves).
+  // withRequestId middleware with { requestId, trustDeviceIdentifier }
+  // — mutating is safe because each request has its own context object.
   const ctx = getRequestContext();
   if (ctx) {
-    const ctxRecord = ctx as unknown as Record<string, unknown>;
-    ctxRecord.user = authResult.user;
-    const cookieHeader = c.req.raw.headers.get("cookie");
-    const trustDeviceIdentifier = extractTrustDeviceIdentifier(cookieHeader);
-    if (trustDeviceIdentifier) {
-      ctxRecord.trustDeviceIdentifier = trustDeviceIdentifier;
-    }
+    (ctx as unknown as Record<string, unknown>).user = authResult.user;
   }
 
   // Resolve and publish atlas mode for downstream handlers. getAtlasMode(c)

--- a/packages/api/src/api/routes/me-trusted-devices.ts
+++ b/packages/api/src/api/routes/me-trusted-devices.ts
@@ -23,6 +23,7 @@ import type { OpenAPIHono } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { authenticateRequest } from "@atlas/api/lib/auth/middleware";
+import { extractTrustDeviceIdentifier } from "@atlas/api/lib/auth/trust-device-cookie";
 import {
   getInternalDB,
   hasInternalDB,
@@ -30,6 +31,11 @@ import {
 } from "@atlas/api/lib/db/internal";
 import { authErrorCode } from "./admin-auth";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
+
+// Re-exported for the audit route's existing callers (tests, the C.2
+// admin route module). New consumers should import directly from
+// `@atlas/api/lib/auth/trust-device-cookie`.
+export { extractTrustDeviceIdentifier };
 
 const log = createLogger("me-trusted-devices");
 
@@ -115,54 +121,6 @@ const deleteRoute = createRoute({
     500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
-
-// ---------------------------------------------------------------------------
-// Cookie helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Extract the trust-device identifier from the request's cookie header, if any.
- *
- * Better Auth sets a signed cookie named `<prefix>.trust_device` (default
- * `better-auth.trust_device`) with optional `__Secure-` prefix in production,
- * plus an env-overridable `cookiePrefix`. The cookie value format is
- * `${hmac}!${identifier}`.
- *
- * We do NOT verify the HMAC here — `isCurrent` is a UX hint (drives the
- * "This browser" badge), not a security gate. The user can only see their
- * own rows from the GET, so a forged identifier would just light up the
- * badge on a row they already control. Skipping the verify avoids hauling
- * Better Auth's secret + crypto path into the read.
- *
- * Strategy: scan all cookie names ending in `.trust_device` (we don't know
- * the operator's `cookiePrefix` at read time, and it's cheap to scan).
- */
-export function extractTrustDeviceIdentifier(cookieHeader: string | null): string | null {
-  if (!cookieHeader) return null;
-  for (const part of cookieHeader.split(";")) {
-    const eq = part.indexOf("=");
-    if (eq === -1) continue;
-    const rawName = part.slice(0, eq).trim();
-    // Strip __Secure- / __Host- prefix so a prod and dev request match the
-    // same suffix logic. Better Auth's createCookieGetter applies the prefix
-    // dynamically based on protocol — we don't know which one is in flight.
-    const name = rawName.replace(/^__(?:Secure|Host)-/, "");
-    if (!name.endsWith(".trust_device")) continue;
-    const rawValue = part.slice(eq + 1).trim();
-    // Cookie values are URL-encoded by setSignedCookie; decode best-effort.
-    let value = rawValue;
-    try {
-      value = decodeURIComponent(rawValue);
-    } catch {
-      // intentionally ignored: malformed encoding falls through with raw value
-    }
-    const bang = value.indexOf("!");
-    if (bang === -1) continue;
-    const identifier = value.slice(bang + 1);
-    if (identifier.startsWith("trust-device-")) return identifier;
-  }
-  return null;
-}
 
 // ---------------------------------------------------------------------------
 // Registration

--- a/packages/api/src/api/routes/middleware.ts
+++ b/packages/api/src/api/routes/middleware.ts
@@ -74,13 +74,7 @@ export type AuthEnv = Env & {
     authResult: AuthResult & { authenticated: true };
     requestId: string;
     atlasMode: import("@useatlas/types/auth").AtlasMode;
-    /**
-     * Trust-device identifier from the `<prefix>.trust_device` cookie on the
-     * incoming request, or undefined when the cookie is absent / malformed.
-     * Set once by `adminAuth` / `platformAdminAuth` / `standardAuth` so route
-     * handlers and the audit logger don't re-parse the cookie on every call.
-     * Forensic-only — never used as an authorization input.
-     */
+    /** See `lib/auth/trust-device-cookie.ts`. Set once by the auth middlewares; reads are uniform. */
     trustDeviceIdentifier: string | undefined;
   };
 };
@@ -450,18 +444,9 @@ export function resolveMode(
 }
 
 /**
- * Read the trust-device cookie once per request and surface it on the Hono
- * context. Downstream consumers:
- *
- * - `requestContext` middleware threads it into `withRequestContext` so
- *   `logAdminAction` can include it in `admin_action_log` metadata without
- *   the 269 call sites needing to know it exists.
- * - The Effect bridge (`buildContextLayer` in `lib/effect/hono.ts`) mirrors
- *   it onto `AuthContext` for Effect-based handlers.
- *
- * Cookie absence is the dominant case (BYOT, simple-key, fresh sign-in
- * without opt-in) — `extractTrustDeviceIdentifier` returns null and we
- * write `undefined`, never a sentinel string.
+ * Surface the parsed cookie identifier on Hono context once, so the audit
+ * logger and Effect bridge don't re-parse per call. Always sets the key —
+ * `undefined` when absent — so reads are uniform.
  */
 function setTrustDeviceIdentifier(c: {
   req: { raw: Request };
@@ -524,9 +509,19 @@ export const requestContext = createMiddleware<AuthEnv>(async (c, next) => {
  * Generates a requestId and wraps downstream in withRequestContext.
  * Does NOT run auth — use when auth is handled inline in the handler
  * (e.g. admin.ts which mixes admin and non-admin routes).
+ *
+ * The trust-device cookie is parsed here too — it's available pre-auth and
+ * having it on the AsyncLocalStorage context from the start means
+ * `logAdminAction` picks it up without per-handler ALS mutation. The
+ * `adminAuth` family does the same via `setTrustDeviceIdentifier`; this
+ * keeps both paths symmetric.
  */
 export const withRequestId = createMiddleware<AuthEnv>(async (c, next) => {
   const requestId = crypto.randomUUID();
   c.set("requestId", requestId);
-  await withRequestContext({ requestId }, () => next());
+  const cookieHeader = c.req.raw.headers.get("cookie");
+  const trustDeviceIdentifier =
+    extractTrustDeviceIdentifier(cookieHeader) ?? undefined;
+  c.set("trustDeviceIdentifier", trustDeviceIdentifier);
+  await withRequestContext({ requestId, trustDeviceIdentifier }, () => next());
 });

--- a/packages/api/src/api/routes/middleware.ts
+++ b/packages/api/src/api/routes/middleware.ts
@@ -23,6 +23,7 @@ import {
   checkRateLimit,
   getClientIP,
 } from "@atlas/api/lib/auth/middleware";
+import { extractTrustDeviceIdentifier } from "@atlas/api/lib/auth/trust-device-cookie";
 import {
   detectMisrouting,
   isStrictRoutingEnabled,
@@ -73,6 +74,14 @@ export type AuthEnv = Env & {
     authResult: AuthResult & { authenticated: true };
     requestId: string;
     atlasMode: import("@useatlas/types/auth").AtlasMode;
+    /**
+     * Trust-device identifier from the `<prefix>.trust_device` cookie on the
+     * incoming request, or undefined when the cookie is absent / malformed.
+     * Set once by `adminAuth` / `platformAdminAuth` / `standardAuth` so route
+     * handlers and the audit logger don't re-parse the cookie on every call.
+     * Forensic-only — never used as an authorization input.
+     */
+    trustDeviceIdentifier: string | undefined;
   };
 };
 
@@ -278,6 +287,7 @@ export const adminAuth = createMiddleware<AuthEnv>(async (c, next) => {
 
   c.set("authResult", authResult);
   resolveModeForRequest(c, authResult, requestId);
+  setTrustDeviceIdentifier(c);
   await next();
 });
 
@@ -325,6 +335,7 @@ export const platformAdminAuth = createMiddleware<AuthEnv>(async (c, next) => {
 
   c.set("authResult", authResult);
   resolveModeForRequest(c, authResult, requestId);
+  setTrustDeviceIdentifier(c);
   await next();
 });
 
@@ -354,6 +365,7 @@ export const standardAuth = createMiddleware<AuthEnv>(async (c, next) => {
 
   c.set("authResult", authResult);
   resolveModeForRequest(c, authResult, requestId);
+  setTrustDeviceIdentifier(c);
   await next();
 });
 
@@ -438,6 +450,29 @@ export function resolveMode(
 }
 
 /**
+ * Read the trust-device cookie once per request and surface it on the Hono
+ * context. Downstream consumers:
+ *
+ * - `requestContext` middleware threads it into `withRequestContext` so
+ *   `logAdminAction` can include it in `admin_action_log` metadata without
+ *   the 269 call sites needing to know it exists.
+ * - The Effect bridge (`buildContextLayer` in `lib/effect/hono.ts`) mirrors
+ *   it onto `AuthContext` for Effect-based handlers.
+ *
+ * Cookie absence is the dominant case (BYOT, simple-key, fresh sign-in
+ * without opt-in) — `extractTrustDeviceIdentifier` returns null and we
+ * write `undefined`, never a sentinel string.
+ */
+function setTrustDeviceIdentifier(c: {
+  req: { raw: Request };
+  set: (key: string, value: unknown) => void;
+}): void {
+  const cookieHeader = c.req.raw.headers.get("cookie");
+  const identifier = extractTrustDeviceIdentifier(cookieHeader);
+  c.set("trustDeviceIdentifier", identifier ?? undefined);
+}
+
+/**
  * Resolve mode and log when a developer request is downgraded due to
  * insufficient role. Used by the auth middlewares to centralize the
  * resolve + set + log pattern.
@@ -474,7 +509,11 @@ export const requestContext = createMiddleware<AuthEnv>(async (c, next) => {
   const requestId = c.get("requestId");
   const authResult = c.get("authResult");
   const atlasMode = c.get("atlasMode");
-  await withRequestContext({ requestId, user: authResult.user, atlasMode }, () => next());
+  const trustDeviceIdentifier = c.get("trustDeviceIdentifier");
+  await withRequestContext(
+    { requestId, user: authResult.user, atlasMode, trustDeviceIdentifier },
+    () => next(),
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/audit/__tests__/admin.test.ts
+++ b/packages/api/src/lib/audit/__tests__/admin.test.ts
@@ -442,3 +442,241 @@ describe("logAdminAction() — system actor (F-27)", () => {
     expect(PINNED).toMatch(/^system:[a-z0-9][a-z0-9_-]*$/);
   });
 });
+
+/**
+ * #2082 PR C.3 — trust-device identifier on the admin audit row.
+ *
+ * `extractTrustDeviceIdentifier` runs once in middleware and surfaces the
+ * cookie payload via the AsyncLocalStorage RequestContext. Auto-resolution
+ * here means every existing `logAdminAction` call site forensically records
+ * which trusted browser an admin used — no per-call wiring across the 269
+ * existing emissions.
+ *
+ * Tested separately from `ipAddress` because the resolution path is
+ * different: ipAddress is always caller-supplied (per-handler header
+ * choice), trustDeviceIdentifier flows through context.
+ */
+describe("logAdminAction() — trust-device identifier (#2082 C.3)", () => {
+  const origDbUrl = process.env.DATABASE_URL;
+
+  beforeEach(() => {
+    queryCalls = [];
+    queryThrow = null;
+  });
+
+  afterEach(() => {
+    if (origDbUrl) {
+      process.env.DATABASE_URL = origDbUrl;
+    } else {
+      delete process.env.DATABASE_URL;
+    }
+    _resetPool(null);
+  });
+
+  function enableInternalDB() {
+    process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+    _resetPool(mockPool);
+  }
+
+  const user: AtlasUser = {
+    id: "admin-1",
+    label: "admin@example.com",
+    mode: "managed",
+    role: "admin",
+    activeOrganizationId: "org-123",
+  };
+
+  it("auto-resolves trustDeviceIdentifier from request context into metadata JSONB", () => {
+    enableInternalDB();
+
+    withRequestContext(
+      {
+        requestId: "req-1",
+        user,
+        trustDeviceIdentifier: "trust-device-abc123",
+      },
+      () => {
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.workspace.delete,
+          targetType: "workspace",
+          targetId: "ws-1",
+        });
+      },
+    );
+
+    expect(queryCalls).toHaveLength(1);
+    const metadataParam = queryCalls[0].params![8] as string;
+    expect(metadataParam).not.toBeNull();
+    expect(JSON.parse(metadataParam)).toEqual({
+      trustDeviceIdentifier: "trust-device-abc123",
+    });
+  });
+
+  it("merges trustDeviceIdentifier alongside caller-supplied metadata fields", () => {
+    enableInternalDB();
+
+    withRequestContext(
+      {
+        requestId: "req-1",
+        user,
+        trustDeviceIdentifier: "trust-device-abc123",
+      },
+      () => {
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.user.ban,
+          targetType: "user",
+          targetId: "user-2",
+          metadata: { reason: "abuse", durationDays: 30 },
+        });
+      },
+    );
+
+    expect(queryCalls).toHaveLength(1);
+    const metadata = JSON.parse(queryCalls[0].params![8] as string);
+    expect(metadata).toEqual({
+      trustDeviceIdentifier: "trust-device-abc123",
+      reason: "abuse",
+      durationDays: 30,
+    });
+  });
+
+  it("caller-supplied metadata.trustDeviceIdentifier wins over context value", () => {
+    // Defensive — the auto-resolved value spreads BEFORE caller metadata,
+    // so an explicit caller key wins. Pinned so a future refactor can't
+    // silently invert the precedence.
+    enableInternalDB();
+
+    withRequestContext(
+      {
+        requestId: "req-1",
+        user,
+        trustDeviceIdentifier: "trust-device-from-context",
+      },
+      () => {
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.user.ban,
+          targetType: "user",
+          targetId: "user-2",
+          metadata: { trustDeviceIdentifier: "trust-device-explicit" },
+        });
+      },
+    );
+
+    expect(queryCalls).toHaveLength(1);
+    const metadata = JSON.parse(queryCalls[0].params![8] as string);
+    expect(metadata.trustDeviceIdentifier).toBe("trust-device-explicit");
+  });
+
+  it("entry.trustDeviceIdentifier wins over context — explicit pass is the override", () => {
+    enableInternalDB();
+
+    withRequestContext(
+      {
+        requestId: "req-1",
+        user,
+        trustDeviceIdentifier: "trust-device-from-context",
+      },
+      () => {
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.user.ban,
+          targetType: "user",
+          targetId: "user-2",
+          trustDeviceIdentifier: "trust-device-typed-override",
+        });
+      },
+    );
+
+    expect(queryCalls).toHaveLength(1);
+    const metadata = JSON.parse(queryCalls[0].params![8] as string);
+    expect(metadata.trustDeviceIdentifier).toBe("trust-device-typed-override");
+  });
+
+  it("leaves metadata null when no cookie is present and no caller metadata", () => {
+    // Backwards compat: pre-C.3 audit rows had `metadata = null` when the
+    // caller didn't pass any. Adding C.3 must not flip every cookie-less
+    // request to `metadata = "{}"` — that would churn forensic queries
+    // that distinguish "no metadata" from "empty metadata".
+    enableInternalDB();
+
+    withRequestContext({ requestId: "req-1", user }, () => {
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.settings.update,
+        targetType: "settings",
+        targetId: "ATLAS_MODEL",
+      });
+    });
+
+    expect(queryCalls).toHaveLength(1);
+    expect(queryCalls[0].params![8]).toBeNull();
+  });
+
+  it("preserves caller metadata as-is when cookie is absent", () => {
+    enableInternalDB();
+
+    withRequestContext({ requestId: "req-1", user }, () => {
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.connection.create,
+        targetType: "connection",
+        targetId: "conn-1",
+        metadata: { name: "prod-db", dbType: "postgres" },
+      });
+    });
+
+    expect(queryCalls).toHaveLength(1);
+    const metadata = JSON.parse(queryCalls[0].params![8] as string);
+    expect(metadata).toEqual({ name: "prod-db", dbType: "postgres" });
+    expect(metadata.trustDeviceIdentifier).toBeUndefined();
+  });
+
+  it("systemActor writes never carry a context-derived trust-device identifier", () => {
+    // Schedulers run inside withRequestContext in tests but have no
+    // browser-bound cookie — the trust-device field must never bleed
+    // from an outer request into a system-emitted row, otherwise the
+    // forensic queries pivoting on trustDeviceIdentifier would
+    // mis-attribute scheduler activity to the user whose request
+    // happened to be in flight when the tick fired.
+    enableInternalDB();
+
+    withRequestContext(
+      {
+        requestId: "req-1",
+        user,
+        trustDeviceIdentifier: "trust-device-outer-request",
+      },
+      () => {
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.audit_log.purgeCycle,
+          targetType: "audit_log",
+          targetId: "scheduler",
+          systemActor: "system:audit-purge-scheduler",
+          metadata: { softDeleted: 0 },
+        });
+      },
+    );
+
+    expect(queryCalls).toHaveLength(1);
+    const metadata = JSON.parse(queryCalls[0].params![8] as string);
+    expect(metadata).toEqual({ softDeleted: 0 });
+    expect(metadata.trustDeviceIdentifier).toBeUndefined();
+  });
+
+  it("systemActor writes still record an explicit trustDeviceIdentifier when one is passed", () => {
+    // Edge case: a future code path could legitimately attribute a
+    // system-emitted row to a specific browser (e.g. a delayed-job
+    // dispatcher recording the originating request). Explicit values pass
+    // through; only context-bleed is suppressed.
+    enableInternalDB();
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.audit_log.purgeCycle,
+      targetType: "audit_log",
+      targetId: "scheduler",
+      systemActor: "system:audit-purge-scheduler",
+      trustDeviceIdentifier: "trust-device-explicit",
+    });
+
+    expect(queryCalls).toHaveLength(1);
+    const metadata = JSON.parse(queryCalls[0].params![8] as string);
+    expect(metadata.trustDeviceIdentifier).toBe("trust-device-explicit");
+  });
+});

--- a/packages/api/src/lib/audit/__tests__/admin.test.ts
+++ b/packages/api/src/lib/audit/__tests__/admin.test.ts
@@ -444,19 +444,14 @@ describe("logAdminAction() — system actor (F-27)", () => {
 });
 
 /**
- * #2082 PR C.3 — trust-device identifier on the admin audit row.
- *
- * `extractTrustDeviceIdentifier` runs once in middleware and surfaces the
- * cookie payload via the AsyncLocalStorage RequestContext. Auto-resolution
- * here means every existing `logAdminAction` call site forensically records
- * which trusted browser an admin used — no per-call wiring across the 269
- * existing emissions.
+ * Trust-device identifier on the admin audit row.
  *
  * Tested separately from `ipAddress` because the resolution path is
  * different: ipAddress is always caller-supplied (per-handler header
- * choice), trustDeviceIdentifier flows through context.
+ * choice), trustDeviceIdentifier flows through the AsyncLocalStorage
+ * RequestContext populated once in middleware.
  */
-describe("logAdminAction() — trust-device identifier (#2082 C.3)", () => {
+describe("logAdminAction() — trust-device identifier", () => {
   const origDbUrl = process.env.DATABASE_URL;
 
   beforeEach(() => {
@@ -592,9 +587,8 @@ describe("logAdminAction() — trust-device identifier (#2082 C.3)", () => {
   });
 
   it("leaves metadata null when no cookie is present and no caller metadata", () => {
-    // Backwards compat: pre-C.3 audit rows had `metadata = null` when the
-    // caller didn't pass any. Adding C.3 must not flip every cookie-less
-    // request to `metadata = "{}"` — that would churn forensic queries
+    // Backwards compat: a cookie-less request must keep `metadata = null`,
+    // not flip to `metadata = "{}"` — that would churn forensic queries
     // that distinguish "no metadata" from "empty metadata".
     enableInternalDB();
 

--- a/packages/api/src/lib/audit/admin.ts
+++ b/packages/api/src/lib/audit/admin.ts
@@ -39,17 +39,11 @@ export interface AdminActionEntry {
   /** Client IP address (extracted from request headers by caller). */
   ipAddress?: string | null;
   /**
-   * Trust-device identifier from the `<prefix>.trust_device` cookie on the
-   * incoming request. Surfaced into `admin_action_log.metadata.trustDeviceIdentifier`
-   * (and the pino line as a top-level field) so audit reviewers can pivot on
-   * which trusted browser an admin used.
-   *
    * Auto-resolved from the AsyncLocalStorage request context populated by
    * the auth middlewares — callers don't need to pass it explicitly.
-   * Explicit values still win, mirroring the `metadata` precedence rule
-   * (caller-supplied keys are not overwritten).
-   *
-   * Forensic-only — never used as an authorization input.
+   * Explicit values still win, mirroring the `metadata` precedence rule.
+   * Surfaced into `admin_action_log.metadata.trustDeviceIdentifier` and
+   * the pino line as a top-level field. See `lib/auth/trust-device-cookie.ts`.
    */
   trustDeviceIdentifier?: string;
   /**

--- a/packages/api/src/lib/audit/admin.ts
+++ b/packages/api/src/lib/audit/admin.ts
@@ -39,6 +39,20 @@ export interface AdminActionEntry {
   /** Client IP address (extracted from request headers by caller). */
   ipAddress?: string | null;
   /**
+   * Trust-device identifier from the `<prefix>.trust_device` cookie on the
+   * incoming request. Surfaced into `admin_action_log.metadata.trustDeviceIdentifier`
+   * (and the pino line as a top-level field) so audit reviewers can pivot on
+   * which trusted browser an admin used.
+   *
+   * Auto-resolved from the AsyncLocalStorage request context populated by
+   * the auth middlewares — callers don't need to pass it explicitly.
+   * Explicit values still win, mirroring the `metadata` precedence rule
+   * (caller-supplied keys are not overwritten).
+   *
+   * Forensic-only — never used as an authorization input.
+   */
+  trustDeviceIdentifier?: string;
+  /**
    * Reserved actor for system-initiated writes with no HTTP request context
    * (schedulers, background jobs). Must match `SYSTEM_ACTOR_PATTERN`
    * (`^system:[a-z0-9][a-z0-9_-]*$`, where the leading char must be
@@ -141,6 +155,8 @@ interface ResolvedEntry {
   readonly requestId: string;
   readonly scope: "platform" | "workspace";
   readonly status: "success" | "failure";
+  readonly trustDeviceIdentifier: string | undefined;
+  readonly metadata: Record<string, unknown> | null;
   readonly params: unknown[];
 }
 
@@ -158,6 +174,25 @@ function resolveEntry(entry: AdminActionEntry): ResolvedEntry {
   const requestId = ctx?.requestId ?? (useSystemActor ? entry.systemActor! : "unknown");
   const scope = entry.scope ?? (useSystemActor ? "platform" : "workspace");
   const status = entry.status ?? "success";
+
+  // Trust-device identifier: explicit caller value wins over the
+  // request-context value so unit tests / future explicit pass paths can
+  // override. systemActor writes have no HTTP request and stay undefined.
+  const trustDeviceIdentifier = useSystemActor
+    ? entry.trustDeviceIdentifier
+    : (entry.trustDeviceIdentifier ?? ctx?.trustDeviceIdentifier);
+
+  // Merge trustDeviceIdentifier into metadata under the same key so
+  // forensic queries can pivot via `metadata->>'trustDeviceIdentifier'`.
+  // Caller-supplied metadata wins on key collision — no surprise
+  // overwrites of an explicit metadata field with the auto-resolved
+  // identifier. `null` (not "{}") when there's nothing to record so the
+  // existing zero-metadata audit rows look identical to before.
+  const metadata: Record<string, unknown> | null =
+    trustDeviceIdentifier !== undefined
+      ? { trustDeviceIdentifier, ...(entry.metadata ?? {}) }
+      : (entry.metadata ?? null);
+
   const params: unknown[] = [
     actorId,
     actorEmail,
@@ -167,11 +202,22 @@ function resolveEntry(entry: AdminActionEntry): ResolvedEntry {
     entry.targetType,
     entry.targetId,
     status,
-    entry.metadata ? JSON.stringify(entry.metadata) : null,
+    metadata ? JSON.stringify(metadata) : null,
     entry.ipAddress ?? null,
     requestId,
   ];
-  return { entry, actorId, actorEmail, orgId, requestId, scope, status, params };
+  return {
+    entry,
+    actorId,
+    actorEmail,
+    orgId,
+    requestId,
+    scope,
+    status,
+    trustDeviceIdentifier,
+    metadata,
+    params,
+  };
 }
 
 function emitPino(resolved: ResolvedEntry): void {
@@ -187,8 +233,15 @@ function emitPino(resolved: ResolvedEntry): void {
       actorEmail: resolved.actorEmail,
       orgId: resolved.orgId,
       requestId: resolved.requestId,
-      ...(resolved.entry.metadata && { metadata: resolved.entry.metadata }),
+      // Log the merged metadata (caller-provided + auto-resolved
+      // trustDeviceIdentifier) so the pino line matches the DB row 1:1.
+      // Top-level `trustDeviceIdentifier` mirrors the `ipAddress` pattern
+      // for grep-friendly forensic queries against the log stream.
+      ...(resolved.metadata && { metadata: resolved.metadata }),
       ...(resolved.entry.ipAddress && { ipAddress: resolved.entry.ipAddress }),
+      ...(resolved.trustDeviceIdentifier && {
+        trustDeviceIdentifier: resolved.trustDeviceIdentifier,
+      }),
     },
     `admin_action: ${resolved.entry.actionType}`,
   );

--- a/packages/api/src/lib/auth/trust-device-cookie.ts
+++ b/packages/api/src/lib/auth/trust-device-cookie.ts
@@ -1,0 +1,65 @@
+/**
+ * Trust-device cookie parser.
+ *
+ * Better Auth sets a signed cookie named `<prefix>.trust_device` (default
+ * `better-auth.trust_device`) with optional `__Secure-` prefix in production,
+ * plus an env-overridable `cookiePrefix`. The cookie value format is
+ * `${hmac}!${identifier}` where `identifier` is `trust-device-<random>` —
+ * the same value Better Auth wrote to the `verification` table.
+ *
+ * We do NOT verify the HMAC here — the identifier is consumed by two read
+ * paths and one audit path, none of which use it as an authorization input:
+ *
+ * - `/me/trusted-devices` GET: drives the "This browser" badge. The user
+ *   only sees their own rows, so a forged identifier would just light up the
+ *   badge on a row they already control.
+ * - admin audit log: forensic metadata. A forged value would corrupt the
+ *   audit row for the requesting user only — not an authorization decision.
+ *
+ * If a future caller wants to use this identifier as an authorization input
+ * (e.g. step-up auth: "this browser cleared 2FA recently, skip the re-verify"),
+ * that caller MUST verify the HMAC. Use Better Auth's
+ * `getSignedCookie(c, secret, name)` directly — do not extend this helper.
+ */
+
+const TRUST_DEVICE_PREFIX = "trust-device-";
+const COOKIE_SUFFIX = ".trust_device";
+const SECURE_PREFIX_RE = /^__(?:Secure|Host)-/;
+
+/**
+ * Extract the trust-device identifier from a request's `Cookie` header.
+ *
+ * Returns null when:
+ * - no cookie header is present
+ * - no cookie name ends in `.trust_device`
+ * - the value is malformed (no `!` separator, identifier missing the
+ *   `trust-device-` prefix)
+ *
+ * Strategy: scan every cookie name ending in `.trust_device` (we don't know
+ * the operator's `cookiePrefix` at read time and it's cheap to scan). The
+ * `__Secure-` / `__Host-` prefix is stripped so prod and dev requests share
+ * the same suffix logic — Better Auth's `createCookieGetter` toggles the
+ * prefix dynamically based on protocol.
+ */
+export function extractTrustDeviceIdentifier(cookieHeader: string | null): string | null {
+  if (!cookieHeader) return null;
+  for (const part of cookieHeader.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    const rawName = part.slice(0, eq).trim();
+    const name = rawName.replace(SECURE_PREFIX_RE, "");
+    if (!name.endsWith(COOKIE_SUFFIX)) continue;
+    const rawValue = part.slice(eq + 1).trim();
+    let value = rawValue;
+    try {
+      value = decodeURIComponent(rawValue);
+    } catch {
+      // intentionally ignored: malformed encoding falls through with raw value
+    }
+    const bang = value.indexOf("!");
+    if (bang === -1) continue;
+    const identifier = value.slice(bang + 1);
+    if (identifier.startsWith(TRUST_DEVICE_PREFIX)) return identifier;
+  }
+  return null;
+}

--- a/packages/api/src/lib/effect/__tests__/hono.test.ts
+++ b/packages/api/src/lib/effect/__tests__/hono.test.ts
@@ -21,6 +21,7 @@ mock.module("@atlas/api/lib/logger", () => ({
 }));
 
 const { runEffect, runHandler, mapTaggedError, domainError } = await import("../hono");
+const { AuthContext } = await import("../services");
 const { EnterpriseError } = await import("@atlas/ee/index");
 const {
   EmptyQueryError,
@@ -788,6 +789,102 @@ describe("runHandler", () => {
     expect(res.status).toBe(500);
     const body = (await res.json()) as ErrorBody;
     expect(body.error).toBe("internal_error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Trust-device identifier propagation via the Hono → Effect context bridge
+// ---------------------------------------------------------------------------
+
+describe("buildContextLayer — trustDeviceIdentifier on AuthContext", () => {
+  type AuthBridgeEnv = {
+    Variables: {
+      requestId: string;
+      authResult?: {
+        authenticated: true;
+        mode: string;
+        user?: { id: string; activeOrganizationId?: string };
+      };
+      trustDeviceIdentifier?: string;
+    };
+  };
+
+  function appWithAuth() {
+    const app = new Hono<AuthBridgeEnv>();
+    app.use(async (c, next) => {
+      c.set("requestId", "test-req-123");
+      await next();
+    });
+    return app;
+  }
+
+  it("propagates trustDeviceIdentifier to AuthContext when authResult is present", async () => {
+    const app = appWithAuth();
+    app.get("/test", async (c) => {
+      c.set("authResult", {
+        authenticated: true,
+        mode: "managed",
+        user: { id: "admin-1", activeOrganizationId: "org-1" },
+      });
+      c.set("trustDeviceIdentifier", "trust-device-bridge-test");
+      return runEffect(
+        c,
+        Effect.gen(function* () {
+          const auth = yield* AuthContext;
+          return c.json({ identifier: auth.trustDeviceIdentifier ?? null }, 200);
+        }),
+      );
+    });
+
+    const res = await app.request("/test");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { identifier: string | null };
+    expect(body.identifier).toBe("trust-device-bridge-test");
+  });
+
+  it("propagates trustDeviceIdentifier on the no-auth fallback AuthContext", async () => {
+    const app = appWithAuth();
+    app.get("/test", async (c) => {
+      // No authResult — exercises the noAuthLayer branch in buildContextLayer
+      c.set("trustDeviceIdentifier", "trust-device-no-auth");
+      return runEffect(
+        c,
+        Effect.gen(function* () {
+          const auth = yield* AuthContext;
+          return c.json({ identifier: auth.trustDeviceIdentifier ?? null, mode: auth.mode }, 200);
+        }),
+      );
+    });
+
+    const res = await app.request("/test");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { identifier: string | null; mode: string };
+    expect(body.identifier).toBe("trust-device-no-auth");
+    expect(body.mode).toBe("none");
+  });
+
+  it("AuthContext.trustDeviceIdentifier is undefined when no cookie was set", async () => {
+    const app = appWithAuth();
+    app.get("/test", async (c) => {
+      c.set("authResult", {
+        authenticated: true,
+        mode: "managed",
+        user: { id: "admin-1", activeOrganizationId: "org-1" },
+      });
+      // Deliberately do NOT set trustDeviceIdentifier
+      return runEffect(
+        c,
+        Effect.gen(function* () {
+          const auth = yield* AuthContext;
+          return c.json({ identifier: auth.trustDeviceIdentifier ?? null }, 200);
+        }),
+      );
+    });
+
+    const res = await app.request("/test");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { identifier: string | null };
+    expect(body.identifier).toBeNull();
   });
 });
 

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -474,6 +474,11 @@ function buildContextLayer(
 
   const requestLayer = makeRequestContextLayer(requestId, undefined, atlasMode);
 
+  // Trust-device identifier is set by auth middleware from the request cookie.
+  // Forensic-only — surfaced via AuthContext for parity with the AsyncLocalStorage
+  // RequestContext path consumed by `logAdminAction`. Undefined when no cookie.
+  const trustDeviceIdentifier = c.get("trustDeviceIdentifier") as string | undefined;
+
   // authResult may not be set (e.g. public routes, before auth middleware)
   const authResult = c.get("authResult") as
     | { authenticated: true; mode: string; user?: { activeOrganizationId?: string } & Record<string, unknown> }
@@ -483,6 +488,7 @@ function buildContextLayer(
     const authLayer = makeAuthContextLayer(
       authResult.mode as import("@useatlas/types/auth").AuthMode,
       authResult.user as import("@useatlas/types/auth").AtlasUser | undefined,
+      trustDeviceIdentifier,
     );
     return Layer.merge(requestLayer, authLayer);
   }
@@ -490,7 +496,7 @@ function buildContextLayer(
   // No auth — provide RequestContext with a fallback AuthContext (mode: "none",
   // no user) so programs that yield* AuthContext always get a valid service
   // rather than a cryptic "service not found" at runtime.
-  const noAuthLayer = makeAuthContextLayer("none", undefined);
+  const noAuthLayer = makeAuthContextLayer("none", undefined, trustDeviceIdentifier);
   return Layer.merge(requestLayer, noAuthLayer);
 }
 

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -749,6 +749,12 @@ export interface AuthContextShape {
   readonly user: AtlasUser | undefined;
   /** Convenience: active org ID from user, or undefined. */
   readonly orgId: string | undefined;
+  /**
+   * Trust-device identifier from the `<prefix>.trust_device` cookie, if any.
+   * Forensic-only — never read as an authorization input. See
+   * `lib/auth/trust-device-cookie.ts` for the parsing contract.
+   */
+  readonly trustDeviceIdentifier: string | undefined;
 }
 
 export class AuthContext extends Context.Tag("AuthContext")<
@@ -763,11 +769,13 @@ export class AuthContext extends Context.Tag("AuthContext")<
 export function makeAuthContextLayer(
   mode: AuthMode,
   user: AtlasUser | undefined,
+  trustDeviceIdentifier?: string,
 ): Layer.Layer<AuthContext> {
   return Layer.succeed(AuthContext, {
     mode,
     user,
     orgId: user?.activeOrganizationId,
+    trustDeviceIdentifier,
   });
 }
 
@@ -779,5 +787,6 @@ export function createAuthContextTestLayer(
     mode: partial.mode ?? "none",
     user: partial.user,
     orgId: partial.orgId ?? partial.user?.activeOrganizationId,
+    trustDeviceIdentifier: partial.trustDeviceIdentifier,
   });
 }

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -749,11 +749,7 @@ export interface AuthContextShape {
   readonly user: AtlasUser | undefined;
   /** Convenience: active org ID from user, or undefined. */
   readonly orgId: string | undefined;
-  /**
-   * Trust-device identifier from the `<prefix>.trust_device` cookie, if any.
-   * Forensic-only — never read as an authorization input. See
-   * `lib/auth/trust-device-cookie.ts` for the parsing contract.
-   */
+  /** See `lib/auth/trust-device-cookie.ts`. */
   readonly trustDeviceIdentifier: string | undefined;
 }
 

--- a/packages/api/src/lib/logger.ts
+++ b/packages/api/src/lib/logger.ts
@@ -20,12 +20,7 @@ interface RequestContext {
   user?: AtlasUser;
   /** Resolved atlas mode for this request. When "published", tools should restrict to published entities only. */
   atlasMode?: import("@useatlas/types/auth").AtlasMode;
-  /**
-   * Trust-device identifier from the `<prefix>.trust_device` cookie, if any.
-   * Forensic-only: surfaced via `logAdminAction` into `admin_action_log`
-   * metadata so audit reviewers can pivot on a specific browser. Never used
-   * as an authorization input — see `lib/auth/trust-device-cookie.ts`.
-   */
+  /** See `lib/auth/trust-device-cookie.ts`. Surfaced into `admin_action_log` metadata via `logAdminAction`. */
   trustDeviceIdentifier?: string;
 }
 

--- a/packages/api/src/lib/logger.ts
+++ b/packages/api/src/lib/logger.ts
@@ -20,6 +20,13 @@ interface RequestContext {
   user?: AtlasUser;
   /** Resolved atlas mode for this request. When "published", tools should restrict to published entities only. */
   atlasMode?: import("@useatlas/types/auth").AtlasMode;
+  /**
+   * Trust-device identifier from the `<prefix>.trust_device` cookie, if any.
+   * Forensic-only: surfaced via `logAdminAction` into `admin_action_log`
+   * metadata so audit reviewers can pivot on a specific browser. Never used
+   * as an authorization input — see `lib/auth/trust-device-cookie.ts`.
+   */
+  trustDeviceIdentifier?: string;
 }
 
 const requestStore = new AsyncLocalStorage<RequestContext>();


### PR DESCRIPTION
Closes #2082.

## Summary

Final PR of the #2082 trust-device chain. Closes the data-flow loop:
**capture** (PR C.1, sign-in toggle + Better Auth verification row) →
**list + revoke** (PR C.2, `/me/trusted-devices`) → **audit** (this PR).

`logAdminAction` now records the calling browser's trust-device identifier
into `admin_action_log.metadata.trustDeviceIdentifier`. Audit reviewers can
pivot on a specific trusted browser to answer "what did this browser do?"
across the workspace lifecycle.

## Step 0 decision — OPTION A

The C.2 list/revoke flow leaves the trust-device cookie unused after sign-in:
the cookie skips the next 2FA challenge (Better Auth's responsibility) but
nothing else reads it. Three plausible C.3 scopes:

- **A.** Audit observability — surface the identifier into the audit log. Forensic value, no enforcement.
- **B.** Step-up auth on destructive admin writes — gated by trust-cookie OR recent re-verify.
- **C.** Close #2082 as-is — list/revoke is functionally complete.

**Picked A.** B deserves its own issue with explicit threat-model review
(which endpoints, what TTL, BYOT/SSO flows, API-key callers — bundling it
into "the final PR" forces those decisions under time pressure). C is
defensible but the trust-device identifier is meaningful forensic data and
there's no reason not to log it.

## Architecture refinement — auto-resolve via RequestContext

The original sketch called for wiring `trustDeviceIdentifier` into 1–2
destructive route handlers. Instead I auto-resolve it through
`getRequestContext()` (AsyncLocalStorage) — the same path that auto-pulls
`actorId`, `orgId`, `requestId`. Result: **all 269 existing
`logAdminAction` call sites pick up the identifier with zero per-call
changes.**

The cookie has exactly one source (no per-route header decision like
`x-forwarded-for` vs `x-real-ip` for IP), so auto-pull is the right
pattern. Explicit per-call wiring would mean a typo on any one of 269
sites silently drops the field — exactly the failure mode the actor_id
auto-pull was designed to prevent.

## Schema decision — JSONB, not a new column

Stored inside the existing `admin_action_log.metadata` blob — no migration,
no `schema.ts` churn, no audit-retention SELECT updates. If forensic
queries by trust-device get hot later, a GIN index on `metadata` is one
migration away.

## Files

- `lib/auth/trust-device-cookie.ts` — extracted `extractTrustDeviceIdentifier` from `me-trusted-devices.ts` so middleware + the route both consume it as peer modules. Behavior unchanged; the route still re-exports the symbol for existing test imports
- `lib/logger.ts` — adds optional `trustDeviceIdentifier` to the AsyncLocalStorage `RequestContext`
- `lib/effect/services.ts` + `lib/effect/hono.ts` — mirrors the field on `AuthContextShape` for Effect-based handlers (`makeAuthContextLayer` accepts it as an optional 3rd arg; `buildContextLayer` reads `c.get("trustDeviceIdentifier")` and threads it through)
- `api/routes/middleware.ts` — `setTrustDeviceIdentifier()` runs after auth in `adminAuth` / `platformAdminAuth` / `standardAuth`. `requestContext` middleware threads the value into `withRequestContext`
- `api/routes/admin.ts` — mirrors the same population path in `adminAuthAndContext()` for the `withRequestId` middleware family (admin.ts handlers don't go through `adminAuth`)
- `lib/audit/admin.ts` — typed `trustDeviceIdentifier?: string` on `AdminActionEntry`. `resolveEntry()` auto-resolves from request context (entry override wins for explicit pass), merges into the metadata JSONB, emits as a top-level pino field for grep-friendly forensic queries
- Tests: 8 round-trip cases on the audit logger; 8 cookie-flow cases on the middleware

## Security

- **Forensic-only.** No code path uses `trustDeviceIdentifier` as an authorization input. The helper module's docblock explicitly redirects future callers who want step-up auth to `getSignedCookie()` directly — they MUST verify the HMAC, this helper does NOT
- **System-actor isolation.** Schedulers / background jobs that run inside an outer request context never inherit the outer user's trust-device identifier — pinned by `systemActor writes never carry a context-derived trust-device identifier` test
- **Cookie absence is normal.** Field is `string | undefined` end-to-end; never throws, never logs an empty value
- **No HMAC half logged.** Only the `trust-device-<random>` identifier suffix flows through (the same value the C.2 helper extracts)

## Out of scope — filed as follow-ups on #2082

- **Step-up auth on destructive admin writes** (OPTION B) — needs its own issue with explicit security review
- **Cookie-rotation merge logic** — preserve original `created_at` across Better Auth's silent rotation. Known follow-up from C.2
- **Cross-user platform-admin revoke** — fired-contractor cleanup. Known follow-up from C.2
- **Geo-derived location** ("San Francisco, CA") — needs IP geo lookup, EE-gated, separate PR

## Test plan

- [x] `bun test src/lib/audit/__tests__/admin.test.ts` — 30 pass, 0 fail
- [x] `bun test src/api/routes/__tests__/middleware-trust-device.test.ts` — 8 pass, 0 fail
- [x] `bun test src/api/routes/__tests__/me-trusted-devices.test.ts` — 20 pass, 0 fail (cookie helper re-export still works)
- [x] `bun test src/lib/effect/__tests__/context.test.ts` — 11 pass, 0 fail
- [x] `bun run scripts/test-isolated.ts --affected` — 181 pass, 0 fail
- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun x syncpack lint` — no issues
- [x] template drift, security-headers drift, railway-watch — pass
- [x] schema drift — pass (no new tables/columns)
- [x] OpenAPI drift — pass (no new endpoints)
- [ ] `/pr-review-toolkit:review-pr` after PR opens (per project convention)