### PR TITLE
feat(api,web,docs): #2091 — passkey-first sign-in (Wave 2A)

### DIFF
--- a/apps/docs/content/docs/security/passkeys.mdx
+++ b/apps/docs/content/docs/security/passkeys.mdx
@@ -17,11 +17,13 @@ For TOTP authenticator-app enrollment, see
 
 A passkey is a hardware-bound WebAuthn credential — Touch ID, Face ID,
 Windows Hello, a YubiKey, or a passkey synced through iCloud Keychain
-or Google Password Manager. Atlas accepts a passkey as a complete
-second factor: an admin who has enrolled at least one passkey
-satisfies the same gate that TOTP satisfies, with no backup codes
-required. The phishing-resistance, hardware binding, and zero-prompt
-sign-in flow make this the recommended path.
+or Google Password Manager. Atlas accepts a passkey as both a
+**first-factor sign-in** (replacing the email + password form) and a
+**second-factor alternative** (replacing the TOTP challenge). An
+admin who has enrolled at least one passkey can sign in without typing
+a password, and satisfies the same MFA gate that TOTP satisfies with
+no backup codes required. The phishing-resistance, hardware binding,
+and zero-prompt sign-in flow make this the recommended path.
 
 <Callout type="warn">
 Passkeys are bound to the **Relying Party ID** (`rpID`) the credential
@@ -69,14 +71,77 @@ unenrolled — the next admin request returns
 `403 mfa_enrollment_required`. The UI warns you before deletion if
 the row in question is your only second factor.
 
+## Signing In With a Passkey
+
+Once you have a passkey enrolled on a device, the sign-in flow on
+that device drops the password step entirely.
+
+### From the login page
+
+The `/login` page renders a **Sign in with a passkey** button above
+the email/password form whenever the browser supports WebAuthn. Click
+it, complete the OS prompt (Touch ID, Face ID, Windows Hello, or your
+security key), and the page navigates straight to your workspace —
+no password typed.
+
+The same page also opts into **conditional UI autofill**: as soon as
+you focus the email field, the OS surfaces saved passkeys in the same
+dropdown that normally shows saved emails. Picking one completes the
+WebAuthn ceremony silently — there's no separate button click. The
+mechanism is `autocomplete="username webauthn"` on the email input,
+plus a `signIn.passkey({ autoFill: true })` call mounted on page
+load. Browsers that don't support conditional UI ignore the token and
+fall back to the explicit button path.
+
+If WebAuthn isn't supported (very old browsers, locked-down kiosks),
+the passkey button is hidden entirely and the email/password form
+remains. There's no banner — the page stays clean for legacy clients.
+
+### On the 2FA challenge page
+
+A user who already has both a TOTP authenticator and a passkey lands
+on `/login/two-factor` after entering email + password (the legacy
+flow). The challenge page renders a **Use a passkey** button above
+the TOTP code input — clicking it bypasses the code entry entirely
+and completes sign-in via the WebAuthn assertion. The trust-device
+toggle stays visible on either path; choose whichever method is
+convenient on the device you're using.
+
+A user who is passkey-only (no TOTP enrolled) skips the challenge
+page altogether — `signIn.passkey()` from `/login` creates a session
+directly.
+
+### What if the passkey button does nothing?
+
+The most common cause is a misconfigured **Relying Party ID** on a
+self-hosted deployment. The browser raises `NotAllowedError` from
+`navigator.credentials.get`; Better Auth re-surfaces it as a
+`result.error` with code `AUTH_CANCELLED` (which our UI silently
+treats as a user cancellation, since they look identical at the
+WebAuthn layer). The login page logs the failure to the browser
+DevTools console as a `[passkey]` debug breadcrumb so the cause is
+visible without a banner. Open DevTools → Console and look for the
+`autoFill returned error` or `sign-in failed` line; an `rpID`
+mismatch is the leading suspect. See
+[Self-Hosted Configuration](#self-hosted-configuration) below.
+
+Cross-device QR sign-in (the WebAuthn `hybrid` transport) is
+intentionally out of scope — OS-bound passkeys cover the vast
+majority of value at a fraction of the implementation surface. If a
+deployment requires it, file an enhancement request.
+
 ## Trust Device (30 days)
 
 The "Trust this device for 30 days" opt-in is collected on the TOTP
 sign-in challenge page (see
-[Two-Factor Authentication](./two-factor-auth)). There is no
-equivalent checkbox on the passkey sign-in path today — passkeys
-already complete in one OS prompt, so the friction the trust-device
-toggle is meant to relieve doesn't really exist on that path.
+[Two-Factor Authentication](./two-factor-auth)). The toggle stays
+visible alongside the **Use a passkey** alternative button on that
+page — pick whichever flow works on the device — but its effect
+only applies to the TOTP path. Passkeys already complete in one OS
+prompt, so the friction the trust-device toggle is meant to relieve
+doesn't really exist on that path; we render the checkbox there for
+consistency rather than because it does anything if the user chooses
+the passkey button.
 
 Where the trust-device flow does intersect passkeys is the **Trusted
 browsers** list at **Admin → Settings → Security**: any browser the
@@ -177,12 +242,15 @@ gate and works on any browser.
 
 ## Limitations
 
-- Passwordless sign-in (using a passkey as both factors at once) is
-  not yet wired through Atlas's sign-in challenge — the current flow
-  always prompts for a password before the second factor. Tracked
-  separately.
+- Cross-device QR sign-in (WebAuthn `hybrid` transport) is not
+  surfaced. OS-bound passkeys plus iCloud / Google Password Manager
+  cloud sync cover the vast majority of value; a hybrid path adds
+  significant UI surface (the QR rendering, the BLE proximity
+  pairing, the connection-state banner) and is gated on an explicit
+  enterprise contract before we wire it.
 - Recovery for a user with no remaining passkey and no backup codes
-  requires an out-of-band reset by a `platform_admin`.
+  requires an out-of-band reset by a `platform_admin`. A user-
+  triggered recovery flow is tracked in the Wave 2B parallel issue.
 - A single global `rpID` is used for all hosted regions
   (`app.useatlas.dev`). WebAuthn binds credentials to a single
   registrable suffix; per-region frontends would each need a

--- a/apps/docs/content/docs/security/two-factor-auth.mdx
+++ b/apps/docs/content/docs/security/two-factor-auth.mdx
@@ -96,6 +96,30 @@ set:
 so disabling two-factor locks you out of the admin console on the next
 request. Disabling is only useful before changing your account role.
 
+## At Sign-In: TOTP or Passkey
+
+A user with both TOTP and a passkey enrolled lands on the
+`/login/two-factor` challenge page after entering email + password.
+The page renders two paths side by side:
+
+- **Use a passkey** — a button above the code input that calls
+  `signIn.passkey()`. The OS prompt fires; on success the page
+  navigates to the workspace. No code is entered.
+- **Authenticator code** — the existing 6-digit input (with the
+  *Use a backup code instead* fallback link below the form).
+
+Either path completes the second factor. The **Trust this device for
+30 days** checkbox stays visible alongside both, but only takes effect
+on the TOTP path — passkey assertions create a fresh session directly
+and don't need a trust cookie. The button is hidden on browsers that
+don't support WebAuthn, with no banner.
+
+If a user is **passkey-only** (no TOTP enrolled), they don't reach
+this page at all — `signIn.passkey()` from `/login` creates a session
+in one step and routes straight to the workspace. See
+[Passkeys → Signing In With a Passkey](./passkeys#signing-in-with-a-passkey)
+for the login-page surface.
+
 ## Operator Reference
 
 ### What's stored

--- a/e2e/browser/passkey-signin.spec.ts
+++ b/e2e/browser/passkey-signin.spec.ts
@@ -76,6 +76,24 @@ test.describe("Passkey-only sign-in (no password) @llm", () => {
         timeout: 15_000,
       });
 
+      // Pre-flight — fail fast if a previous run leaked an `e2e-signin-*`
+      // row. A leaked credential silently bypasses the password
+      // requirement on the shared admin and would mask exactly the
+      // regression this spec catches; the actionable error here is far
+      // better than a confusingly-passing run.
+      const leakedRow = page
+        .getByRole("listitem")
+        .filter({ hasText: /^e2e-signin-/ });
+      const leakedCount = await leakedRow.count();
+      if (leakedCount > 0) {
+        const leakedNames = await leakedRow.allTextContents();
+        throw new Error(
+          `Previous run leaked ${leakedCount} passkey(s) onto the shared admin: ` +
+          `${leakedNames.join(", ")}. Delete them via /admin/settings/security or ` +
+          `via the Better Auth API before re-running this spec.`,
+        );
+      }
+
       const addButton = page.getByRole("button", {
         name: /^Add (a|another) passkey$/,
       });
@@ -137,7 +155,24 @@ test.describe("Passkey-only sign-in (no password) @llm", () => {
         timeout: 10_000,
       });
 
-      // ── 4. Sign in via the passkey button (no password) ─────────────
+      // ── 4. Capture the password input state BEFORE the passkey click ─
+      // Reading the input AFTER a successful passkey sign-in is vacuous
+      // because we navigate away from /login — the field no longer exists
+      // in the DOM. Reading here, while the form is still mounted, catches
+      // the failure mode the test is designed to surface: a regression
+      // where browser autofill (or a prefill from a previous session)
+      // leaked a saved password into the input even though we intend to
+      // bypass it entirely.
+      const passwordBeforeClick = await page
+        .locator('input[type="password"]')
+        .inputValue();
+      expect(
+        passwordBeforeClick,
+        "Password input was prefilled before the passkey click — the assertion " +
+          "that signIn.passkey() bypasses the password depends on the field being empty.",
+      ).toBe("");
+
+      // ── 5. Sign in via the passkey button (no password) ─────────────
       // The button only renders when WebAuthn is supported — the virtual
       // authenticator above ensures this is true. If the button is
       // missing, the gating regression itself is the primary signal.
@@ -148,36 +183,31 @@ test.describe("Passkey-only sign-in (no password) @llm", () => {
       await expect(passkeyButton).toBeEnabled();
       await passkeyButton.click();
 
-      // ── 5. Assert a session was issued without typing a password ────
+      // ── 6. Assert a session was issued without typing a password ────
       // After a successful signIn.passkey(), the page navigates to "/".
       // Reaching the chat UI proves an authenticated session exists.
       await expect(
         page.locator('input[placeholder="Ask a question about your data..."]'),
       ).toBeVisible({ timeout: 15_000 });
 
-      // Belt-and-suspenders: the password input should NEVER have received
-      // input during this flow. A regression where the passkey button
-      // silently falls through to the password form would have failed the
-      // assertion above; this assertion catches a more pernicious failure
-      // mode where some upstream code prefilled a saved password.
-      const passwordValue = await page
-        .locator('input[type="password"]')
-        .inputValue()
-        .catch(() => "");
-      expect(passwordValue).toBe("");
-
-      // Sanity: the session-bearing /api/v1/health endpoint authenticates
-      // (returns 200 — auth.spec.ts uses the same surface).
-      const healthRes = await page.request.get("/api/v1/admin/audit?limit=1");
+      // Sanity: an authenticated route is reachable. /api/v1/admin/audit
+      // goes through the same admin-auth + MFA-required pipeline as the
+      // rest of the admin console, so a non-5xx here proves the session
+      // cookie is set and trusted. We accept any 4xx/2xx — a 403 still
+      // means "session present, MFA gate decided" rather than "session
+      // missing", which is what this assertion is guarding against.
+      const auditRes = await page.request.get("/api/v1/admin/audit?limit=1");
       expect(
-        healthRes.status(),
-        `Expected /api/v1/admin/audit to be reachable after passkey-only sign-in, got ${healthRes.status()}`,
+        auditRes.status(),
+        `Expected /api/v1/admin/audit to be reachable after passkey-only sign-in, got ${auditRes.status()}`,
       ).toBeLessThan(500);
     } finally {
-      // ── 6. Clean up — delete the credential and tear down the authn ─
-      // Best-effort, but failures here MUST be visible: a leaked passkey
-      // bypasses the password requirement on the shared admin and would
-      // silently mask exactly the regressions this test catches.
+      // ── 7. Clean up — delete the credential and tear down the authn ─
+      // Best-effort. The cleanup helper warns + continues on inner failures
+      // (page closed, row never rendered) — a hard fail in the finally
+      // block would mask the underlying assertion failure that brought us
+      // here. The pre-flight detection below at the start of subsequent
+      // runs is what catches a genuinely leaked credential.
       if (enrolledPasskeyName) {
         await cleanupEnrolledPasskey(page, enrolledPasskeyName);
       }

--- a/e2e/browser/passkey-signin.spec.ts
+++ b/e2e/browser/passkey-signin.spec.ts
@@ -1,0 +1,248 @@
+import { test, expect, type CDPSession, type Page } from "@playwright/test";
+
+/**
+ * Wave 2A of the MFA hardening track (#2091): proves a user enrolled with a
+ * passkey can complete sign-in without typing a password. The unit-level
+ * coverage in `packages/web/src/app/login/page.test.tsx` verifies the
+ * button wires `signIn.passkey()` correctly; this spec is the only barrier
+ * that catches a regression in the full flow:
+ *
+ *   1. The browser registers a credential.
+ *   2. Better Auth persists it under the user's id.
+ *   3. The login page invokes `signIn.passkey()` against the virtual
+ *      authenticator and the assertion verifies server-side.
+ *   4. A real session cookie is issued — *without the password being typed*.
+ *
+ * If any one of those steps regresses (e.g. `signIn.passkey()` is renamed,
+ * the rpID mismatches, the conditional-UI autofill ceremony bricks the
+ * explicit-button flow), this test fails red.
+ *
+ * Why CDP, not `page.context().addVirtualAuthenticator()`:
+ * Same rationale as `passkey-mfa-gate.spec.ts` — Playwright 1.58 exposes
+ * the CDP path only. Tagged `@llm` so the spec runs on the serial worker
+ * (`bun run test:browser:llm`, workers=1) — concurrent specs would race
+ * on the shared `admin@useatlas.dev` user's `passkey` rows.
+ *
+ * Self-cleaning: every exit path deletes the credential. A leaked passkey
+ * bypasses subsequent `signIn.passkey()` flows on the shared admin and
+ * masks exactly the regressions this test exists to catch.
+ *
+ * Required env: `ATLAS_RPID=localhost` on the dev server. The default
+ * (`app.useatlas.dev`) does not match `localhost:3000` and the WebAuthn
+ * ceremony will reject every assertion with `NotAllowedError`.
+ */
+
+test.describe("Passkey-only sign-in (no password) @llm", () => {
+  // The flow does enrollment + sign-out + passkey sign-in back-to-back;
+  // 90s leaves room for a cold dev server while still failing fast on a
+  // genuine hang in the WebAuthn ceremony. Higher than passkey-mfa-gate
+  // because the sign-out + re-sign-in adds two full-page navigations.
+  test.describe.configure({ timeout: 90_000, mode: "serial" });
+
+  // The signed-in storage state from global-setup gives us a logged-in
+  // session for the enrollment phase. We sign out mid-test to exercise
+  // the actual passkey sign-in.
+  test("enrolls a passkey, signs out, signs back in via passkey only", async ({ page }) => {
+    let cdp: CDPSession | null = null;
+    let authenticatorId: string | null = null;
+    let enrolledPasskeyName: string | null = null;
+
+    try {
+      // ── 1. Install a virtual authenticator via CDP ──────────────────
+      // `transport: "internal"` + UV pre-confirmed produces a platform
+      // authenticator that auto-completes both `create()` and `get()`
+      // without an OS prompt — matching the conditions Better Auth's
+      // sign-in passkey flow expects from a real Touch ID / Face ID device.
+      cdp = await page.context().newCDPSession(page);
+      await cdp.send("WebAuthn.enable", { enableUI: false });
+      const { authenticatorId: id } = await cdp.send(
+        "WebAuthn.addVirtualAuthenticator",
+        {
+          options: {
+            protocol: "ctap2",
+            transport: "internal",
+            hasResidentKey: true,
+            hasUserVerification: true,
+            isUserVerified: true,
+            automaticPresenceSimulation: true,
+          },
+        },
+      );
+      authenticatorId = id;
+
+      // ── 2. Enroll a passkey from the security page ──────────────────
+      await page.goto("/admin/settings/security");
+      await expect(page.locator("h1", { hasText: "Security" })).toBeVisible({
+        timeout: 15_000,
+      });
+
+      const addButton = page.getByRole("button", {
+        name: /^Add (a|another) passkey$/,
+      });
+      await expect(addButton).toBeEnabled({ timeout: 10_000 });
+      await addButton.click();
+
+      // Race the success dialog against the destructive-error paragraph.
+      // Without this, a misconfigured rpID surfaces as an opaque 15s
+      // "naming dialog never visible" timeout that says nothing actionable.
+      enrolledPasskeyName = `e2e-signin-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+      const nameDialog = page.getByRole("alertdialog").filter({
+        hasText: "Name this passkey",
+      });
+      const errorParagraph = page.locator("p.text-destructive").first();
+      const winner = await Promise.race([
+        nameDialog
+          .waitFor({ state: "visible", timeout: 15_000 })
+          .then(() => "dialog" as const),
+        errorParagraph
+          .waitFor({ state: "visible", timeout: 15_000 })
+          .then(() => "error" as const),
+      ]).catch(() => "timeout" as const);
+
+      if (winner === "error") {
+        const text = (await errorParagraph.textContent())?.trim() ?? "(no text)";
+        throw new Error(
+          `Passkey enrollment failed before the naming dialog opened. UI surfaced: ` +
+          `"${text}". Common cause: ATLAS_RPID does not match the page origin ` +
+          `(default app.useatlas.dev vs localhost:3000 — set ATLAS_RPID=localhost ` +
+          `on the dev server).`,
+        );
+      }
+      if (winner === "timeout") {
+        throw new Error(
+          "Neither the naming dialog nor an error paragraph appeared within 15s " +
+          "after clicking 'Add a passkey'. The WebAuthn ceremony is hung.",
+        );
+      }
+
+      const nameInput = nameDialog.getByRole("textbox");
+      await nameInput.fill(enrolledPasskeyName);
+      await nameDialog.getByRole("button", { name: "Save" }).click();
+
+      // The list refetches after `onChange()` fires — wait for the row to
+      // appear so we know the credential is durable in the DB before we
+      // sign out.
+      await expect(
+        page.getByRole("listitem").filter({ hasText: enrolledPasskeyName }),
+      ).toBeVisible({ timeout: 10_000 });
+
+      // ── 3. Sign out — must clear the session cookie completely ──────
+      // The passkey assertion below has to create a session from scratch
+      // to prove the password isn't being typed. We sign out via the UI
+      // (not the API) so any cleanup the UI does (clearing in-memory
+      // state, redirecting) runs as in production.
+      await page.goto("/");
+      await page.locator('button:has-text("Sign out")').click();
+      await expect(page.locator('input[type="email"]')).toBeVisible({
+        timeout: 10_000,
+      });
+
+      // ── 4. Sign in via the passkey button (no password) ─────────────
+      // The button only renders when WebAuthn is supported — the virtual
+      // authenticator above ensures this is true. If the button is
+      // missing, the gating regression itself is the primary signal.
+      const passkeyButton = page.getByRole("button", {
+        name: /sign in with a passkey/i,
+      });
+      await expect(passkeyButton).toBeVisible({ timeout: 10_000 });
+      await expect(passkeyButton).toBeEnabled();
+      await passkeyButton.click();
+
+      // ── 5. Assert a session was issued without typing a password ────
+      // After a successful signIn.passkey(), the page navigates to "/".
+      // Reaching the chat UI proves an authenticated session exists.
+      await expect(
+        page.locator('input[placeholder="Ask a question about your data..."]'),
+      ).toBeVisible({ timeout: 15_000 });
+
+      // Belt-and-suspenders: the password input should NEVER have received
+      // input during this flow. A regression where the passkey button
+      // silently falls through to the password form would have failed the
+      // assertion above; this assertion catches a more pernicious failure
+      // mode where some upstream code prefilled a saved password.
+      const passwordValue = await page
+        .locator('input[type="password"]')
+        .inputValue()
+        .catch(() => "");
+      expect(passwordValue).toBe("");
+
+      // Sanity: the session-bearing /api/v1/health endpoint authenticates
+      // (returns 200 — auth.spec.ts uses the same surface).
+      const healthRes = await page.request.get("/api/v1/admin/audit?limit=1");
+      expect(
+        healthRes.status(),
+        `Expected /api/v1/admin/audit to be reachable after passkey-only sign-in, got ${healthRes.status()}`,
+      ).toBeLessThan(500);
+    } finally {
+      // ── 6. Clean up — delete the credential and tear down the authn ─
+      // Best-effort, but failures here MUST be visible: a leaked passkey
+      // bypasses the password requirement on the shared admin and would
+      // silently mask exactly the regressions this test catches.
+      if (enrolledPasskeyName) {
+        await cleanupEnrolledPasskey(page, enrolledPasskeyName);
+      }
+
+      if (cdp && authenticatorId) {
+        try {
+          await cdp.send("WebAuthn.removeVirtualAuthenticator", {
+            authenticatorId,
+          });
+        } catch (err) {
+          console.warn(
+            "[passkey-signin] removeVirtualAuthenticator failed:",
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+      }
+      if (cdp) {
+        try {
+          await cdp.send("WebAuthn.disable");
+        } catch (err) {
+          console.warn(
+            "[passkey-signin] WebAuthn.disable failed:",
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+        try {
+          await cdp.detach();
+        } catch (err) {
+          console.warn(
+            "[passkey-signin] CDP detach failed:",
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+      }
+    }
+  });
+});
+
+/**
+ * Delete the named passkey via the security-page UI. We're already signed
+ * back in (via passkey) at this point, so the same admin route works.
+ * Best-effort — failures are warned but don't fail the test.
+ */
+async function cleanupEnrolledPasskey(page: Page, name: string): Promise<void> {
+  try {
+    await page.goto("/admin/settings/security");
+    const row = page.getByRole("listitem").filter({ hasText: name });
+    const visible = await row
+      .waitFor({ state: "visible", timeout: 5_000 })
+      .then(() => true)
+      // intentionally ignored: page closed mid-cleanup or row legitimately
+      // never rendered (test failed before sign-back-in completed).
+      .catch(() => false);
+    if (!visible) return;
+
+    await row.getByRole("button", { name: `Delete ${name}` }).click();
+    const confirm = page.getByRole("alertdialog").filter({
+      hasText: "Delete passkey?",
+    });
+    await confirm.getByRole("button", { name: "Delete" }).click();
+    await expect(row).toHaveCount(0, { timeout: 10_000 });
+  } catch (err) {
+    console.warn(
+      "[passkey-signin] cleanup of enrolled passkey row failed:",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}

--- a/packages/api/src/lib/auth/__tests__/passkey-routes.test.ts
+++ b/packages/api/src/lib/auth/__tests__/passkey-routes.test.ts
@@ -62,7 +62,7 @@ function makeAuth(): ReturnType<typeof betterAuth> {
 }
 
 describe("Passkey plugin — route surface", () => {
-  it("mounts /api/auth/passkey/generate-authenticate-options (the sign-in entry path)", async () => {
+  it("mounts /api/auth/passkey/generate-authenticate-options with a challenge envelope", async () => {
     const auth = makeAuth();
     const req = new Request(
       "http://localhost:3000/api/auth/passkey/generate-authenticate-options",
@@ -70,11 +70,14 @@ describe("Passkey plugin — route surface", () => {
     );
     const res = await auth.handler(req);
 
-    // The exact body shape is Better Auth's contract; we only assert the
-    // route is RECOGNIZED (anything that isn't 404 means the path was
-    // matched by the plugin). A 200 with a JSON challenge envelope is the
-    // happy path; any 4xx other than 404 still proves wiring.
-    expect(res.status).not.toBe(404);
+    // 200 with a JSON challenge is Better Auth's documented contract for
+    // an unauthenticated GET on this path. A loose `not.toBe(404)` would
+    // pass on a 500 or 503; pin the happy path so a contract drift (or a
+    // boot-time crash that returns 5xx) trips this test.
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(typeof body.challenge).toBe("string");
+    expect((body.challenge as string).length).toBeGreaterThan(0);
   });
 
   it("registers `passkey` in the auth options.plugins list", () => {

--- a/packages/api/src/lib/auth/__tests__/passkey-routes.test.ts
+++ b/packages/api/src/lib/auth/__tests__/passkey-routes.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Smoke regression for the passkey plugin's HTTP surface.
+ *
+ * The passkey plugin auto-mounts `/passkey/*` under `/api/auth/*` when
+ * `passkey()` is in the options.plugins list. Two failure modes this test
+ * catches that the unit-level `passkey-tile.test.tsx` cannot:
+ *
+ *   1. A future refactor that drops `passkey()` from `buildPlugins()` (or
+ *      conditionally skips it). The web client's `signIn.passkey()` call
+ *      would still typecheck — the plugin's client mirror is loaded
+ *      unconditionally — but every WebAuthn ceremony would 404 at runtime.
+ *
+ *   2. A Better Auth version bump that renames the authentication endpoint
+ *      from `/passkey/generate-authenticate-options` to anything else. We
+ *      route the entire passkey-first sign-in flow off that path; a rename
+ *      would silently break #2091's UX.
+ *
+ * The test does NOT exercise the full WebAuthn ceremony — virtual
+ * authenticator coverage lives in `e2e/browser/passkey-signin.spec.ts`.
+ * Here we just probe the route is reachable and produces the documented
+ * 200 challenge envelope (or a 4xx that is NOT 404).
+ */
+
+import { describe, it, expect } from "bun:test";
+import { betterAuth } from "better-auth";
+import { passkey } from "@better-auth/passkey";
+import {
+  buildAuthOptions,
+  parseAuthSecret,
+  type BuildAuthOptionsDeps,
+} from "../server";
+
+const SECRET = parseAuthSecret("0123456789abcdef0123456789abcdef");
+
+function makeDeps(overrides: Partial<BuildAuthOptionsDeps> = {}): BuildAuthOptionsDeps {
+  return {
+    env: {} as NodeJS.ProcessEnv,
+    secret: SECRET,
+    baseURL: "http://localhost:3000",
+    database: undefined,
+    cookieDomain: undefined,
+    socialProviders: undefined,
+    // Mirror the production wiring in `buildPlugins()` — passkey is loaded
+    // unconditionally next to twoFactor. The rpID fallback matches the
+    // server.ts default so a regression that flips it (which would
+    // invalidate every existing passkey) is also visible.
+    plugins: [
+      passkey({
+        rpID: "localhost",
+        rpName: "Atlas",
+      }),
+    ],
+    trustedOrigins: ["http://localhost:3000"],
+    bootstrapAdmin: { mode: "none" },
+    ...overrides,
+  };
+}
+
+function makeAuth(): ReturnType<typeof betterAuth> {
+  const options = buildAuthOptions(makeDeps());
+  return betterAuth(options as Parameters<typeof betterAuth>[0]);
+}
+
+describe("Passkey plugin — route surface", () => {
+  it("mounts /api/auth/passkey/generate-authenticate-options (the sign-in entry path)", async () => {
+    const auth = makeAuth();
+    const req = new Request(
+      "http://localhost:3000/api/auth/passkey/generate-authenticate-options",
+      { method: "GET", headers: { "x-atlas-client-ip": "10.0.0.1", origin: "http://localhost:3000" } },
+    );
+    const res = await auth.handler(req);
+
+    // The exact body shape is Better Auth's contract; we only assert the
+    // route is RECOGNIZED (anything that isn't 404 means the path was
+    // matched by the plugin). A 200 with a JSON challenge envelope is the
+    // happy path; any 4xx other than 404 still proves wiring.
+    expect(res.status).not.toBe(404);
+  });
+
+  it("registers `passkey` in the auth options.plugins list", () => {
+    const options = buildAuthOptions(makeDeps());
+    // `id: "passkey"` is the plugin's stable identifier — tested instead of
+    // a structural shape check so a future Better Auth version that adds
+    // new fields to plugin objects doesn't false-positive this assertion.
+    const ids = (options.plugins ?? []).map((p) => (p as { id?: string }).id);
+    expect(ids).toContain("passkey");
+  });
+
+  it("the sign-in passkey route is GET (Better Auth contract — required for conditional UI autofill)", async () => {
+    const auth = makeAuth();
+    const wrongMethod = new Request(
+      "http://localhost:3000/api/auth/passkey/generate-authenticate-options",
+      { method: "DELETE", headers: { origin: "http://localhost:3000" } },
+    );
+    const res = await auth.handler(wrongMethod);
+    // 404 vs 405 is fuzzy across Better Auth versions; either proves the
+    // GET-only contract — what we MUST NOT see is a 200 (which would mean
+    // the route accepts arbitrary methods and the conditional-UI assumption
+    // about idempotent challenge issuance is broken).
+    expect([404, 405]).toContain(res.status);
+  });
+});

--- a/packages/web/src/app/login/page.test.tsx
+++ b/packages/web/src/app/login/page.test.tsx
@@ -1,0 +1,258 @@
+/**
+ * Coverage for the login page — passkey-first paths.
+ *
+ * The existing email/password + social-provider behavior is exercised end-
+ * to-end by `e2e/browser/auth.spec.ts`; this file pins the unit-level
+ * passkey wiring so a refactor of `useWebAuthnSupported` or
+ * `getPasskeySignIn` can't silently turn the new sign-in path into a
+ * no-op.
+ *
+ * `mock.module(...)` covers every named export of the modules it stubs
+ * (per repo rule) so a sibling test file that imports a different export
+ * doesn't trip a partial-mock SyntaxError.
+ */
+
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { render, fireEvent, waitFor, cleanup, act, screen } from "@testing-library/react";
+
+// ── Mocks ───────────────────────────────────────────────────────────────
+
+mock.module("@/lib/auth/client", () => ({ authClient: {} }));
+
+const signInPasskeyMock = mock(
+  async (_opts?: { autoFill?: boolean }): Promise<{
+    data: unknown;
+    error: { code?: string; message?: string; status?: number } | null;
+  }> => ({ data: { session: {}, user: {} }, error: null }),
+);
+
+mock.module("@/lib/auth/passkey-client", () => ({
+  // PasskeyTile + PasskeyList consume getPasskeyClient — the login page only
+  // needs the sign-in shim. Both are mocked so a sibling test that imports
+  // either module-export still resolves something callable.
+  getPasskeyClient: () => null,
+  getPasskeySignIn: () => signInPasskeyMock,
+}));
+
+const webAuthnSupportMock = mock<() => { kind: "supported" | "unsupported" | "unknown"; platformAuthenticator?: boolean }>(() => ({
+  kind: "supported",
+  platformAuthenticator: true,
+}));
+
+mock.module("@/ui/hooks/use-webauthn-supported", () => ({
+  useWebAuthnSupported: () => webAuthnSupportMock(),
+}));
+
+const routerPushMock = mock((_path: string) => {});
+mock.module("next/navigation", () => ({
+  useRouter: () => ({ push: routerPushMock, replace: () => {}, back: () => {} }),
+}));
+
+// `LoginPage` fetches the social-provider list + password-reset status
+// from the API on mount. Stub `globalThis.fetch` so the network never
+// fires from the test runner.
+const fetchMock = mock(async (input: RequestInfo | URL): Promise<Response> => {
+  const url = typeof input === "string" ? input : input.toString();
+  if (url.includes("/api/v1/onboarding/social-providers")) {
+    return new Response(JSON.stringify({ providers: [] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }
+  if (url.includes("/api/v1/onboarding/password-reset-status")) {
+    return new Response(JSON.stringify({ enabled: false }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }
+  return new Response("not found", { status: 404 });
+});
+const originalFetch = globalThis.fetch;
+globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+import LoginPage from "./page";
+
+beforeEach(() => {
+  signInPasskeyMock.mockReset();
+  routerPushMock.mockReset();
+  webAuthnSupportMock.mockReset();
+  fetchMock.mockClear();
+  signInPasskeyMock.mockImplementation(async () => ({
+    data: { session: {}, user: {} },
+    error: null,
+  }));
+  webAuthnSupportMock.mockImplementation(() => ({
+    kind: "supported",
+    platformAuthenticator: true,
+  }));
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// Run after the suite — restore the real fetch so unrelated test files
+// in the same bun subprocess (under the project's isolated runner each
+// file is its own process, but defensive cleanup is cheap) aren't left
+// with our mock.
+import { afterAll } from "bun:test";
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe("LoginPage — passkey button visibility", () => {
+  test("hidden on unsupported browsers (no banner — keeps the page clean)", async () => {
+    webAuthnSupportMock.mockImplementation(() => ({ kind: "unsupported" }));
+    render(<LoginPage />);
+    // Wait for the on-mount fetches to settle so the first paint isn't
+    // racing the assertion.
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: /sign in with a passkey/i })).toBeNull();
+    });
+    expect(document.body.textContent).not.toContain("Passkey unavailable");
+  });
+
+  test("hidden during the pre-effect 'unknown' window to avoid hydration mismatch", async () => {
+    webAuthnSupportMock.mockImplementation(() => ({ kind: "unknown" }));
+    render(<LoginPage />);
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: /sign in with a passkey/i })).toBeNull();
+    });
+  });
+
+  test("rendered when WebAuthn is supported", async () => {
+    render(<LoginPage />);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /sign in with a passkey/i })).toBeDefined();
+    });
+  });
+});
+
+describe("LoginPage — email input autocomplete", () => {
+  test("opts into 'username webauthn' for conditional UI when supported", async () => {
+    render(<LoginPage />);
+    const email = (await screen.findByLabelText(/^email$/i)) as HTMLInputElement;
+    expect(email.getAttribute("autocomplete")).toBe("username webauthn");
+  });
+
+  test("falls back to plain 'email' when WebAuthn is unsupported", async () => {
+    webAuthnSupportMock.mockImplementation(() => ({ kind: "unsupported" }));
+    render(<LoginPage />);
+    const email = (await screen.findByLabelText(/^email$/i)) as HTMLInputElement;
+    expect(email.getAttribute("autocomplete")).toBe("email");
+  });
+});
+
+describe("LoginPage — passkey button click", () => {
+  test("success calls signIn.passkey() and navigates to '/'", async () => {
+    render(<LoginPage />);
+    const btn = await screen.findByRole("button", { name: /sign in with a passkey/i });
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    await waitFor(() => {
+      // First call is the auto-fill effect on mount; the click adds another.
+      expect(signInPasskeyMock).toHaveBeenCalledTimes(2);
+    });
+    // The explicit click does NOT pass autoFill: true.
+    const explicitCall = (signInPasskeyMock as unknown as ReturnType<typeof mock>).mock.calls[1] as [
+      ({ autoFill?: boolean } | undefined)?,
+    ];
+    expect(explicitCall[0]).toBeUndefined();
+
+    await waitFor(() => {
+      expect(routerPushMock).toHaveBeenCalledWith("/");
+    });
+  });
+
+  test("user cancellation (AUTH_CANCELLED) is silent — no banner, no navigation", async () => {
+    signInPasskeyMock.mockImplementation(async () => ({
+      data: null,
+      error: { code: "AUTH_CANCELLED", message: "cancelled", status: 400 },
+    }));
+    render(<LoginPage />);
+    const btn = await screen.findByRole("button", { name: /sign in with a passkey/i });
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    await waitFor(() => {
+      expect(signInPasskeyMock).toHaveBeenCalledTimes(2);
+    });
+    expect(routerPushMock).not.toHaveBeenCalled();
+    // Crucial: no NotAllowedError leak. The renderer must NOT show the
+    // raw cancellation message.
+    expect(document.body.textContent).not.toContain("NotAllowedError");
+    expect(document.body.textContent).not.toContain("cancelled");
+  });
+
+  test("server error surfaces friendly copy, never the raw NotAllowedError shape", async () => {
+    signInPasskeyMock.mockImplementation(async () => ({
+      data: null,
+      error: {
+        code: "AUTHENTICATION_FAILED",
+        message: "raw NotAllowedError verbose blob",
+        status: 400,
+      },
+    }));
+    render(<LoginPage />);
+    const btn = await screen.findByRole("button", { name: /sign in with a passkey/i });
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    await waitFor(() => {
+      // Friendly copy from `parsePasskeySignInError` for AUTHENTICATION_FAILED.
+      expect(document.body.textContent).toContain("couldn't verify that passkey");
+    });
+    expect(document.body.textContent).not.toContain("raw NotAllowedError verbose blob");
+    expect(routerPushMock).not.toHaveBeenCalled();
+  });
+
+  test("network failure (TypeError) surfaces 'can't reach the server' copy", async () => {
+    signInPasskeyMock.mockImplementation(async () => {
+      throw new TypeError("fetch failed");
+    });
+    render(<LoginPage />);
+    const btn = await screen.findByRole("button", { name: /sign in with a passkey/i });
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Can't reach the server");
+    });
+    expect(routerPushMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("LoginPage — conditional UI autofill on mount", () => {
+  test("supported browser fires signIn.passkey({ autoFill: true }) once on mount", async () => {
+    render(<LoginPage />);
+    await waitFor(() => {
+      expect(signInPasskeyMock).toHaveBeenCalledTimes(1);
+    });
+    const call = (signInPasskeyMock as unknown as ReturnType<typeof mock>).mock.calls[0] as [
+      { autoFill?: boolean } | undefined,
+    ];
+    expect(call[0]).toEqual({ autoFill: true });
+  });
+
+  test("autofill success navigates the user — no need for a button click", async () => {
+    render(<LoginPage />);
+    await waitFor(() => {
+      expect(routerPushMock).toHaveBeenCalledWith("/");
+    });
+  });
+
+  test("does NOT fire on unsupported browsers", async () => {
+    webAuthnSupportMock.mockImplementation(() => ({ kind: "unsupported" }));
+    render(<LoginPage />);
+    // Give the effect a chance to run if it were going to.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(signInPasskeyMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/app/login/page.test.tsx
+++ b/packages/web/src/app/login/page.test.tsx
@@ -251,8 +251,60 @@ describe("LoginPage — conditional UI autofill on mount", () => {
   test("does NOT fire on unsupported browsers", async () => {
     webAuthnSupportMock.mockImplementation(() => ({ kind: "unsupported" }));
     render(<LoginPage />);
-    // Give the effect a chance to run if it were going to.
-    await new Promise((r) => setTimeout(r, 20));
+    // Drain microtasks deterministically — if the gating regressed the
+    // signIn would already be queued by the time the awaited tick resolves.
+    await Promise.resolve();
+    await Promise.resolve();
     expect(signInPasskeyMock).not.toHaveBeenCalled();
+  });
+
+  test("ref guard prevents duplicate ceremonies under re-render churn", async () => {
+    // Hold the autofill promise open so the ref is observably gating
+    // re-renders before the first invocation has settled.
+    let resolveSignIn: (v: { data: unknown; error: null }) => void = () => {};
+    signInPasskeyMock.mockImplementationOnce(
+      () => new Promise((r) => { resolveSignIn = r; }),
+    );
+
+    const { rerender } = render(<LoginPage />);
+    await waitFor(() => {
+      expect(signInPasskeyMock).toHaveBeenCalledTimes(1);
+    });
+
+    // Force several re-renders by re-issuing the same element. Without the
+    // useRef guard the unstable router reference would re-fire the effect
+    // (regression caught by the original review pass — call count went to 5).
+    for (let i = 0; i < 4; i++) {
+      rerender(<LoginPage />);
+      await Promise.resolve();
+    }
+
+    expect(signInPasskeyMock).toHaveBeenCalledTimes(1);
+
+    // Resolve so cleanup is clean.
+    await act(async () => {
+      resolveSignIn({ data: { session: {}, user: {} }, error: null });
+    });
+  });
+});
+
+describe("LoginPage — empty envelope on click", () => {
+  test("data:null + error:null surfaces the 'refresh the page' banner — does not navigate", async () => {
+    signInPasskeyMock.mockImplementation(async () => ({
+      data: null,
+      error: null,
+    }));
+    render(<LoginPage />);
+    const btn = await screen.findByRole("button", { name: /sign in with a passkey/i });
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain(
+        "Passkey signed in but the server didn't return a session",
+      );
+    });
+    expect(routerPushMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/app/login/page.tsx
+++ b/packages/web/src/app/login/page.tsx
@@ -147,19 +147,29 @@ export default function LoginPage() {
         const res = await signIn({ autoFill: true });
         if (cancelled) return;
         if (res.error) {
-          // The autofill flow surfaces cancellations + "no passkeys for this
-          // origin" as the same shape — debug-log so a misconfigured rpID
-          // doesn't disappear silently, but never block the password form.
+          // Debug level (not warn) is intentional: the autofill flow is
+          // expected to fall through silently for users without a saved
+          // passkey, and warn would spam DevTools on every visit. A real
+          // misconfiguration (rpID mismatch) still leaves a breadcrumb.
           console.debug(
             "[passkey] autoFill returned error:",
             res.error.code ?? res.error.message ?? "unknown",
           );
           return;
         }
-        if (res.data) router.push("/");
+        if (res.data) {
+          router.push("/");
+          return;
+        }
+        // Better Auth's wire shape technically allows `{ data: null, error: null }`.
+        // It shouldn't happen in practice; warn so a contract drift is visible.
+        console.warn("[passkey] autoFill returned data:null without error", res);
       } catch (err) {
         if (cancelled) return;
-        console.debug(
+        // A throw out of `signIn()` is genuinely unexpected — Better Auth
+        // catches the user-cancellation NotAllowedError internally — so
+        // warn rather than debug.
+        console.warn(
           "[passkey] autoFill threw:",
           err instanceof Error ? err.message : String(err),
         );
@@ -187,18 +197,15 @@ export default function LoginPage() {
     try {
       const res = await signIn();
       if (res.error) {
-        const message = parsePasskeySignInError({ error: res.error });
-        if (message === null) {
+        const outcome = parsePasskeySignInError({ kind: "wire", error: res.error });
+        if (outcome.kind === "silent") {
           // User cancellation — log so a misconfigured rpID is visible in
           // DevTools, but don't render a banner. Same discipline as the
           // enrollment tile in passkey-tile.tsx.
-          console.debug(
-            "[passkey] sign-in cancelled or NotAllowedError:",
-            res.error,
-          );
+          console.debug("[passkey] sign-in cancelled or NotAllowedError:", res.error);
         } else {
           console.warn("[passkey] sign-in failed", res.error);
-          setPasskeyError(message);
+          setPasskeyError(outcome.message);
         }
         return;
       }
@@ -217,7 +224,10 @@ export default function LoginPage() {
         "[passkey] sign-in threw:",
         err instanceof Error ? err.message : String(err),
       );
-      setPasskeyError(parsePasskeySignInError({ thrown: err }) ?? "Passkey sign-in didn't complete.");
+      const outcome = parsePasskeySignInError({ kind: "thrown", value: err });
+      // Thrown branch never returns `silent` — only the wire-error path
+      // does — but the discriminated outcome forces explicit handling.
+      if (outcome.kind === "user") setPasskeyError(outcome.message);
     } finally {
       setPasskeyLoading(false);
     }

--- a/packages/web/src/app/login/page.tsx
+++ b/packages/web/src/app/login/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { authClient } from "@/lib/auth/client";
 import { getApiUrl } from "@/lib/api-url";
@@ -16,6 +16,7 @@ import { cn } from "@/lib/utils";
 import {
   Database,
   AlertCircle,
+  Fingerprint,
   Loader2,
   ShieldCheck,
   ArrowRight,
@@ -27,6 +28,9 @@ import {
 } from "@/ui/components/social-icons";
 import { parseSignInError, type SignInErrorState } from "./parse-sign-in-error";
 import { getPostSignInRoute } from "./post-sign-in-route";
+import { getPasskeySignIn } from "@/lib/auth/passkey-client";
+import { parsePasskeySignInError } from "@/lib/auth/parse-passkey-sign-in-error";
+import { useWebAuthnSupported } from "@/ui/hooks/use-webauthn-supported";
 
 type SocialProvider = "google" | "github" | "microsoft";
 
@@ -51,13 +55,21 @@ function getApiBase(): string {
 
 export default function LoginPage() {
   const router = useRouter();
+  const webAuthnSupport = useWebAuthnSupported();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<SignInErrorState | null>(null);
+  const [passkeyError, setPasskeyError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [passkeyLoading, setPasskeyLoading] = useState(false);
   const [socialLoading, setSocialLoading] = useState<SocialProvider | null>(null);
   const [socialProviders, setSocialProviders] = useState<readonly SocialProvider[]>([]);
   const [passwordResetEnabled, setPasswordResetEnabled] = useState(false);
+  // The passkey button is hidden entirely on unsupported browsers (no banner —
+  // see issue #2091). `webAuthnSupport.kind === "supported"` is the load-bearing
+  // gate; `unknown` (pre-effect / SSR) hides the button to avoid hydration
+  // mismatch and a no-op click before capability detection settles.
+  const passkeyAvailable = webAuthnSupport.kind === "supported";
 
   useEffect(() => {
     const controller = new AbortController();
@@ -111,6 +123,106 @@ export default function LoginPage() {
     return () => controller.abort();
   }, []);
 
+  // Conditional UI autofill — pairs with `autocomplete="username webauthn"`
+  // on the email input below to surface saved passkeys in the OS autofill
+  // picker without the user clicking the dedicated button. Fires exactly
+  // once after capability detection settles; the ref guard prevents a
+  // re-render from firing duplicate ceremonies (each ceremony allocates a
+  // server-side challenge, so duplicates are wasteful and produce confusing
+  // double prompts on slow autofill hardware).
+  //
+  // Better Auth's wrapper traps `NotAllowedError` from the conditional-UI
+  // ceremony and folds it into `error.code === "AUTH_CANCELLED"`. We treat
+  // that branch as silent — the autofill picker is allowed to be ignored.
+  const autoFillFiredRef = useRef(false);
+  useEffect(() => {
+    if (webAuthnSupport.kind !== "supported") return;
+    if (autoFillFiredRef.current) return;
+    const signIn = getPasskeySignIn();
+    if (!signIn) return;
+    autoFillFiredRef.current = true;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await signIn({ autoFill: true });
+        if (cancelled) return;
+        if (res.error) {
+          // The autofill flow surfaces cancellations + "no passkeys for this
+          // origin" as the same shape — debug-log so a misconfigured rpID
+          // doesn't disappear silently, but never block the password form.
+          console.debug(
+            "[passkey] autoFill returned error:",
+            res.error.code ?? res.error.message ?? "unknown",
+          );
+          return;
+        }
+        if (res.data) router.push("/");
+      } catch (err) {
+        if (cancelled) return;
+        console.debug(
+          "[passkey] autoFill threw:",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [webAuthnSupport.kind, router]);
+
+  async function handlePasskeySignIn() {
+    setError(null);
+    setPasskeyError(null);
+    const signIn = getPasskeySignIn();
+    if (!signIn) {
+      // Plugin unavailable — surface a soft message rather than a silent
+      // no-op so a misconfigured client (e.g. passkeyClient() not
+      // registered) is visible to the user rather than baked-in disabled.
+      setPasskeyError(
+        "Passkey sign-in is not available right now. Use email and password instead.",
+      );
+      return;
+    }
+    setPasskeyLoading(true);
+    try {
+      const res = await signIn();
+      if (res.error) {
+        const message = parsePasskeySignInError({ error: res.error });
+        if (message === null) {
+          // User cancellation — log so a misconfigured rpID is visible in
+          // DevTools, but don't render a banner. Same discipline as the
+          // enrollment tile in passkey-tile.tsx.
+          console.debug(
+            "[passkey] sign-in cancelled or NotAllowedError:",
+            res.error,
+          );
+        } else {
+          console.warn("[passkey] sign-in failed", res.error);
+          setPasskeyError(message);
+        }
+        return;
+      }
+      if (!res.data) {
+        // Wire shape technically allows `{ data: null, error: null }`.
+        // Treat as a "refresh the page" hint rather than a silent success.
+        console.warn("[passkey] sign-in returned data:null without error", res);
+        setPasskeyError(
+          "Passkey signed in but the server didn't return a session. Refresh the page.",
+        );
+        return;
+      }
+      router.push("/");
+    } catch (err) {
+      console.warn(
+        "[passkey] sign-in threw:",
+        err instanceof Error ? err.message : String(err),
+      );
+      setPasskeyError(parsePasskeySignInError({ thrown: err }) ?? "Passkey sign-in didn't complete.");
+    } finally {
+      setPasskeyLoading(false);
+    }
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!email || !password) return;
@@ -152,7 +264,7 @@ export default function LoginPage() {
     }
   }
 
-  const anyLoading = loading || socialLoading !== null;
+  const anyLoading = loading || socialLoading !== null || passkeyLoading;
   const visibleProviders = SOCIAL_PROVIDERS.filter((p) =>
     socialProviders.includes(p.id),
   );
@@ -174,6 +286,42 @@ export default function LoginPage() {
 
       <Card className="w-full">
         <CardContent className="space-y-4 pt-6">
+          {passkeyAvailable && (
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full"
+                disabled={anyLoading}
+                onClick={handlePasskeySignIn}
+                aria-label="Sign in with a passkey"
+              >
+                {passkeyLoading ? (
+                  <Loader2 className="size-4 animate-spin" aria-hidden />
+                ) : (
+                  <Fingerprint className="size-4" aria-hidden />
+                )}
+                {passkeyLoading ? "Waiting for passkey…" : "Sign in with a passkey"}
+              </Button>
+              {passkeyError && (
+                <div
+                  role="alert"
+                  aria-live="polite"
+                  className="flex items-start gap-3 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-900 dark:border-red-900 dark:bg-red-950 dark:text-red-200"
+                >
+                  <AlertCircle className="mt-0.5 size-4 shrink-0" aria-hidden />
+                  <p className="flex-1 text-xs leading-relaxed">{passkeyError}</p>
+                </div>
+              )}
+              <div className="relative">
+                <Separator />
+                <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-card px-2 text-xs text-muted-foreground">
+                  or
+                </span>
+              </div>
+            </>
+          )}
+
           {visibleProviders.length > 0 && (
             <>
               <div className="grid gap-2">
@@ -219,7 +367,11 @@ export default function LoginPage() {
                 onChange={(e) => setEmail(e.target.value)}
                 required
                 autoFocus
-                autoComplete="email"
+                // `username webauthn` opts the field into the OS conditional-UI
+                // picker driven by `signIn.passkey({ autoFill: true })` above.
+                // Falls back to plain `username` (browsers ignore the unknown
+                // token) when WebAuthn is unsupported.
+                autoComplete={passkeyAvailable ? "username webauthn" : "email"}
                 disabled={anyLoading}
               />
               <p className="flex items-start gap-1.5 text-xs text-muted-foreground">

--- a/packages/web/src/app/login/two-factor/page.test.tsx
+++ b/packages/web/src/app/login/two-factor/page.test.tsx
@@ -449,4 +449,24 @@ describe("TwoFactorChallengePage — passkey alternative", () => {
     expect(getPasskeyButton()).toBeDefined();
     expect(screen.getByRole("checkbox", { name: /trust this device/i })).toBeDefined();
   });
+
+  test("data:null + error:null surfaces the 'refresh the page' banner — does not navigate", async () => {
+    signInPasskeyMock.mockImplementation(async () => ({
+      data: null,
+      error: null,
+    }));
+    render(<TwoFactorChallengePage />);
+    await act(async () => {
+      fireEvent.click(getPasskeyButton());
+    });
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain(
+        "Passkey signed in but the server didn't return a session",
+      );
+    });
+    expect(routerPushMock).not.toHaveBeenCalled();
+    // The TOTP path remains usable after the failed passkey attempt.
+    expect(getCodeInput().disabled).toBe(false);
+  });
 });

--- a/packages/web/src/app/login/two-factor/page.test.tsx
+++ b/packages/web/src/app/login/two-factor/page.test.tsx
@@ -49,6 +49,34 @@ mock.module("next/navigation", () => ({
   useRouter: () => ({ push: routerPushMock, replace: () => {}, back: () => {} }),
 }));
 
+const signInPasskeyMock = mock(
+  async (_opts?: { autoFill?: boolean }): Promise<{
+    data: unknown;
+    error: { code?: string; message?: string; status?: number } | null;
+  }> => ({ data: { session: {}, user: {} }, error: null }),
+);
+
+const getPasskeySignInMock = mock<() => typeof signInPasskeyMock | null>(
+  () => signInPasskeyMock,
+);
+
+mock.module("@/lib/auth/passkey-client", () => ({
+  // PasskeyTile + PasskeyList consume getPasskeyClient — the 2FA page only
+  // touches the sign-in shim. Keeping both exports stubbed prevents a
+  // partial-mock SyntaxError if a sibling test imports the other.
+  getPasskeyClient: () => null,
+  getPasskeySignIn: () => getPasskeySignInMock(),
+}));
+
+const webAuthnSupportMock = mock<() => { kind: "supported" | "unsupported" | "unknown"; platformAuthenticator?: boolean }>(() => ({
+  kind: "supported",
+  platformAuthenticator: true,
+}));
+
+mock.module("@/ui/hooks/use-webauthn-supported", () => ({
+  useWebAuthnSupported: () => webAuthnSupportMock(),
+}));
+
 import TwoFactorChallengePage from "./page";
 
 beforeEach(() => {
@@ -56,6 +84,9 @@ beforeEach(() => {
   verifyBackupCodeMock.mockReset();
   routerPushMock.mockReset();
   getTwoFactorClientMock.mockReset();
+  signInPasskeyMock.mockReset();
+  getPasskeySignInMock.mockReset();
+  webAuthnSupportMock.mockReset();
 
   verifyTotpMock.mockImplementation(async () => ({
     data: { token: "session-token" },
@@ -71,6 +102,15 @@ beforeEach(() => {
     verifyTotp: verifyTotpMock,
     verifyBackupCode: verifyBackupCodeMock,
     generateBackupCodes: mock(async () => ({ data: null, error: null })),
+  }));
+  signInPasskeyMock.mockImplementation(async () => ({
+    data: { session: {}, user: {} },
+    error: null,
+  }));
+  getPasskeySignInMock.mockImplementation(() => signInPasskeyMock);
+  webAuthnSupportMock.mockImplementation(() => ({
+    kind: "supported",
+    platformAuthenticator: true,
   }));
 });
 
@@ -301,5 +341,112 @@ describe("TwoFactorChallengePage — plugin guard", () => {
     });
     expect(verifyTotpMock).not.toHaveBeenCalled();
     expect(routerPushMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("TwoFactorChallengePage — passkey alternative", () => {
+  function getPasskeyButton(): HTMLButtonElement {
+    return screen.getByRole("button", { name: /use a passkey/i }) as HTMLButtonElement;
+  }
+
+  test("rendered when WebAuthn is supported", () => {
+    render(<TwoFactorChallengePage />);
+    expect(getPasskeyButton()).toBeDefined();
+  });
+
+  test("hidden when WebAuthn is unsupported (no banner — keeps the page clean)", () => {
+    webAuthnSupportMock.mockImplementation(() => ({ kind: "unsupported" }));
+    render(<TwoFactorChallengePage />);
+    expect(screen.queryByRole("button", { name: /use a passkey/i })).toBeNull();
+  });
+
+  test("hidden during the pre-effect 'unknown' window to avoid hydration mismatch", () => {
+    webAuthnSupportMock.mockImplementation(() => ({ kind: "unknown" }));
+    render(<TwoFactorChallengePage />);
+    expect(screen.queryByRole("button", { name: /use a passkey/i })).toBeNull();
+  });
+
+  test("success calls signIn.passkey() and navigates to '/'", async () => {
+    render(<TwoFactorChallengePage />);
+    await act(async () => {
+      fireEvent.click(getPasskeyButton());
+    });
+
+    await waitFor(() => {
+      expect(signInPasskeyMock).toHaveBeenCalledTimes(1);
+    });
+    // No autoFill — explicit click fires the modal authenticator prompt.
+    const call = (signInPasskeyMock as unknown as ReturnType<typeof mock>).mock.calls[0] as [
+      ({ autoFill?: boolean } | undefined)?,
+    ];
+    expect(call[0]).toBeUndefined();
+
+    await waitFor(() => {
+      expect(routerPushMock).toHaveBeenCalledWith("/");
+    });
+    // The TOTP path must NOT have fired — passkey is the alternative, not
+    // a parallel verification.
+    expect(verifyTotpMock).not.toHaveBeenCalled();
+  });
+
+  test("user cancellation is silent — no banner, no navigation, TOTP form still usable", async () => {
+    signInPasskeyMock.mockImplementationOnce(async () => ({
+      data: null,
+      error: { code: "AUTH_CANCELLED", message: "cancelled", status: 400 },
+    }));
+
+    render(<TwoFactorChallengePage />);
+    await act(async () => {
+      fireEvent.click(getPasskeyButton());
+    });
+
+    await waitFor(() => {
+      expect(signInPasskeyMock).toHaveBeenCalledTimes(1);
+    });
+    expect(routerPushMock).not.toHaveBeenCalled();
+    expect(document.body.textContent).not.toContain("NotAllowedError");
+    // The TOTP input should remain usable after a cancelled passkey attempt.
+    expect(getCodeInput().disabled).toBe(false);
+  });
+
+  test("PASSKEY_NOT_FOUND surfaces the friendly 'no passkey for this device' hint", async () => {
+    signInPasskeyMock.mockImplementationOnce(async () => ({
+      data: null,
+      error: { code: "PASSKEY_NOT_FOUND", message: "no passkey", status: 404 },
+    }));
+
+    render(<TwoFactorChallengePage />);
+    await act(async () => {
+      fireEvent.click(getPasskeyButton());
+    });
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain(
+        "No passkey is registered for this device",
+      );
+    });
+    expect(routerPushMock).not.toHaveBeenCalled();
+  });
+
+  test("missing passkey plugin surfaces actionable banner instead of silent no-op", async () => {
+    getPasskeySignInMock.mockImplementation(() => null);
+
+    render(<TwoFactorChallengePage />);
+    await act(async () => {
+      fireEvent.click(getPasskeyButton());
+    });
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain(
+        "Passkey sign-in is not available right now",
+      );
+    });
+    expect(signInPasskeyMock).not.toHaveBeenCalled();
+  });
+
+  test("trust-device toggle stays visible alongside the passkey button", () => {
+    render(<TwoFactorChallengePage />);
+    expect(getPasskeyButton()).toBeDefined();
+    expect(screen.getByRole("checkbox", { name: /trust this device/i })).toBeDefined();
   });
 });

--- a/packages/web/src/app/login/two-factor/page.tsx
+++ b/packages/web/src/app/login/two-factor/page.tsx
@@ -6,6 +6,13 @@
  * session cookie yet (only a short-lived two-factor cookie identifying the
  * pending user), so failing to complete the flow leaves the user genuinely
  * unauthenticated.
+ *
+ * A user with a passkey enrolled can also complete the second factor by
+ * calling `signIn.passkey()` — the passkey is itself a possession factor,
+ * so a successful WebAuthn assertion creates a fresh session that supersedes
+ * the partial-auth two-factor cookie. The button is rendered whenever the
+ * browser supports WebAuthn; the "no passkey for this user" path surfaces
+ * a friendly hint via {@link parsePasskeySignInError}.
  */
 
 import { useRef, useState } from "react";
@@ -15,12 +22,16 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
-import { AlertCircle, Loader2, ShieldCheck } from "lucide-react";
+import { Separator } from "@/components/ui/separator";
+import { AlertCircle, Fingerprint, Loader2, ShieldCheck } from "lucide-react";
 import {
   getTwoFactorClient,
   unwrapTwoFactorResult,
   type TwoFactorApiError,
 } from "@/lib/auth/two-factor-client";
+import { getPasskeySignIn } from "@/lib/auth/passkey-client";
+import { parsePasskeySignInError } from "@/lib/auth/parse-passkey-sign-in-error";
+import { useWebAuthnSupported } from "@/ui/hooks/use-webauthn-supported";
 
 type Mode = "totp" | "backup";
 
@@ -73,17 +84,74 @@ function logFailure(action: string, raw: TwoFactorApiError | null): void {
 
 export default function TwoFactorChallengePage() {
   const router = useRouter();
+  const webAuthnSupport = useWebAuthnSupported();
   const [mode, setMode] = useState<Mode>("totp");
   const [code, setCode] = useState("");
   const [trustDevice, setTrustDevice] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [passkeyBusy, setPasskeyBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [passkeyError, setPasskeyError] = useState<string | null>(null);
   // Synchronous in-flight flag — `busy` state lags by a render so a
   // double-click within the same tick would fire two verify calls and burn
   // two backup codes server-side. Ref takes effect immediately.
   const submittingRef = useRef(false);
+  const passkeySubmittingRef = useRef(false);
 
   const config = MODES[mode];
+  const passkeyAvailable = webAuthnSupport.kind === "supported";
+
+  async function handlePasskey(): Promise<void> {
+    if (passkeySubmittingRef.current) return;
+    setPasskeyError(null);
+    const signIn = getPasskeySignIn();
+    if (!signIn) {
+      setPasskeyError(
+        "Passkey sign-in is not available right now. Use your authenticator app instead.",
+      );
+      return;
+    }
+    passkeySubmittingRef.current = true;
+    setPasskeyBusy(true);
+    try {
+      const res = await signIn();
+      if (res.error) {
+        const message = parsePasskeySignInError({ error: res.error });
+        if (message === null) {
+          // Cancellation — log so a misconfigured rpID still leaves a
+          // breadcrumb; never render a banner for an Esc on the OS prompt.
+          console.debug("[two-factor:sign-in] passkey cancelled", res.error);
+        } else {
+          console.warn("[two-factor:sign-in] passkey sign-in failed", res.error);
+          setPasskeyError(message);
+        }
+        return;
+      }
+      if (!res.data) {
+        console.warn(
+          "[two-factor:sign-in] passkey sign-in returned data:null without error",
+          res,
+        );
+        setPasskeyError(
+          "Passkey signed in but the server didn't return a session. Refresh the page.",
+        );
+        return;
+      }
+      router.push("/");
+    } catch (err) {
+      console.warn(
+        "[two-factor:sign-in] passkey sign-in threw:",
+        err instanceof Error ? err.message : String(err),
+      );
+      setPasskeyError(
+        parsePasskeySignInError({ thrown: err }) ??
+          "Passkey sign-in didn't complete. Try your authenticator app.",
+      );
+    } finally {
+      passkeySubmittingRef.current = false;
+      setPasskeyBusy(false);
+    }
+  }
 
   function switchMode(next: Mode): void {
     setMode(next);
@@ -153,6 +221,44 @@ export default function TwoFactorChallengePage() {
 
       <Card className="w-full">
         <CardContent className="space-y-4 pt-6">
+          {passkeyAvailable && (
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full"
+                disabled={busy || passkeyBusy}
+                onClick={() => {
+                  void handlePasskey();
+                }}
+                aria-label="Use a passkey instead"
+              >
+                {passkeyBusy ? (
+                  <Loader2 className="size-4 animate-spin" aria-hidden />
+                ) : (
+                  <Fingerprint className="size-4" aria-hidden />
+                )}
+                {passkeyBusy ? "Waiting for passkey…" : "Use a passkey"}
+              </Button>
+              {passkeyError && (
+                <div
+                  role="alert"
+                  aria-live="polite"
+                  className="flex items-start gap-3 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-900 dark:border-red-900 dark:bg-red-950 dark:text-red-200"
+                >
+                  <AlertCircle className="mt-0.5 size-4 shrink-0" aria-hidden />
+                  <p className="flex-1 text-xs leading-relaxed">{passkeyError}</p>
+                </div>
+              )}
+              <div className="relative">
+                <Separator />
+                <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-card px-2 text-xs text-muted-foreground">
+                  or
+                </span>
+              </div>
+            </>
+          )}
+
           <form onSubmit={handleSubmit} className="space-y-4" noValidate>
             <div className="space-y-2">
               <Label htmlFor="two-factor-code">{config.inputLabel}</Label>
@@ -165,7 +271,7 @@ export default function TwoFactorChallengePage() {
                 placeholder={config.placeholder}
                 value={code}
                 onChange={(e) => setCode(config.sanitise(e.target.value))}
-                disabled={busy}
+                disabled={busy || passkeyBusy}
                 autoFocus
                 className="font-mono text-base tracking-widest"
               />
@@ -176,7 +282,7 @@ export default function TwoFactorChallengePage() {
                 id="trust-device"
                 checked={trustDevice}
                 onCheckedChange={(checked) => setTrustDevice(checked === true)}
-                disabled={busy}
+                disabled={busy || passkeyBusy}
                 className="mt-0.5"
               />
               <span className="flex-1 select-none">
@@ -193,7 +299,7 @@ export default function TwoFactorChallengePage() {
             <Button
               type="submit"
               className="w-full"
-              disabled={busy || !config.isComplete(code)}
+              disabled={busy || passkeyBusy || !config.isComplete(code)}
             >
               {busy ? (
                 <>
@@ -213,7 +319,7 @@ export default function TwoFactorChallengePage() {
         variant="link"
         size="sm"
         onClick={() => switchMode(mode === "totp" ? "backup" : "totp")}
-        disabled={busy}
+        disabled={busy || passkeyBusy}
         className="mt-4 text-muted-foreground hover:text-primary"
       >
         {config.switchLabel}

--- a/packages/web/src/app/login/two-factor/page.tsx
+++ b/packages/web/src/app/login/two-factor/page.tsx
@@ -116,14 +116,14 @@ export default function TwoFactorChallengePage() {
     try {
       const res = await signIn();
       if (res.error) {
-        const message = parsePasskeySignInError({ error: res.error });
-        if (message === null) {
+        const outcome = parsePasskeySignInError({ kind: "wire", error: res.error });
+        if (outcome.kind === "silent") {
           // Cancellation — log so a misconfigured rpID still leaves a
           // breadcrumb; never render a banner for an Esc on the OS prompt.
           console.debug("[two-factor:sign-in] passkey cancelled", res.error);
         } else {
           console.warn("[two-factor:sign-in] passkey sign-in failed", res.error);
-          setPasskeyError(message);
+          setPasskeyError(outcome.message);
         }
         return;
       }
@@ -143,10 +143,10 @@ export default function TwoFactorChallengePage() {
         "[two-factor:sign-in] passkey sign-in threw:",
         err instanceof Error ? err.message : String(err),
       );
-      setPasskeyError(
-        parsePasskeySignInError({ thrown: err }) ??
-          "Passkey sign-in didn't complete. Try your authenticator app.",
-      );
+      const outcome = parsePasskeySignInError({ kind: "thrown", value: err });
+      // Thrown branch never produces `silent` — only the wire-error path
+      // does — but the discriminated outcome makes that contract explicit.
+      if (outcome.kind === "user") setPasskeyError(outcome.message);
     } finally {
       passkeySubmittingRef.current = false;
       setPasskeyBusy(false);

--- a/packages/web/src/lib/auth/parse-passkey-sign-in-error.test.ts
+++ b/packages/web/src/lib/auth/parse-passkey-sign-in-error.test.ts
@@ -1,93 +1,111 @@
 /**
  * Branch coverage for the passkey sign-in error parser.
  *
- * Pins the canonical "Esc on the OS prompt" path to `null` (no banner)
- * and the explicit Better Auth error codes to friendly copy. The login
- * + 2FA pages route their full UI behavior off these branches — a
- * regression that flips a cancellation into a banner is exactly what
- * this file is designed to catch.
+ * Pins the canonical "Esc on the OS prompt" path to `kind: "silent"` and
+ * the explicit Better Auth error codes to friendly copy. The login + 2FA
+ * pages route their full UI behavior off these branches — a regression
+ * that flips a cancellation into a banner is exactly what this file is
+ * designed to catch.
  */
 
 import { describe, expect, test } from "bun:test";
 import { parsePasskeySignInError } from "./parse-passkey-sign-in-error";
 
-describe("parsePasskeySignInError — cancellation (returns null)", () => {
+describe("parsePasskeySignInError — cancellation (kind: 'silent')", () => {
   test("AUTH_CANCELLED code → silent", () => {
     expect(
       parsePasskeySignInError({
+        kind: "wire",
         error: { code: "AUTH_CANCELLED", message: "cancelled", status: 400 },
       }),
-    ).toBeNull();
+    ).toEqual({ kind: "silent" });
   });
 
   test("REGISTRATION_CANCELLED code → silent", () => {
     expect(
       parsePasskeySignInError({
+        kind: "wire",
         error: { code: "REGISTRATION_CANCELLED", message: "cancelled", status: 400 },
       }),
-    ).toBeNull();
+    ).toEqual({ kind: "silent" });
   });
 
   test("NotAllowedError fragment in message → silent", () => {
     expect(
       parsePasskeySignInError({
+        kind: "wire",
         error: { message: "DOMException: NotAllowedError on get()", status: 0 },
       }),
-    ).toBeNull();
+    ).toEqual({ kind: "silent" });
   });
 });
 
 describe("parsePasskeySignInError — error codes route to friendly copy", () => {
   test("AUTHENTICATION_FAILED → 'couldn't verify' copy", () => {
-    expect(
-      parsePasskeySignInError({
-        error: { code: "AUTHENTICATION_FAILED", message: "raw blob", status: 400 },
-      }),
-    ).toContain("couldn't verify");
+    const result = parsePasskeySignInError({
+      kind: "wire",
+      error: { code: "AUTHENTICATION_FAILED", message: "raw blob", status: 400 },
+    });
+    expect(result.kind).toBe("user");
+    if (result.kind === "user") {
+      expect(result.message).toContain("couldn't verify");
+    }
   });
 
   test("PASSKEY_NOT_FOUND → 'no passkey for this device' copy", () => {
-    expect(
-      parsePasskeySignInError({
-        error: { code: "PASSKEY_NOT_FOUND", message: "raw", status: 404 },
-      }),
-    ).toContain("No passkey is registered");
+    const result = parsePasskeySignInError({
+      kind: "wire",
+      error: { code: "PASSKEY_NOT_FOUND", message: "raw", status: 404 },
+    });
+    expect(result.kind).toBe("user");
+    if (result.kind === "user") {
+      expect(result.message).toContain("No passkey is registered");
+    }
   });
 
   test("CHALLENGE_NOT_FOUND → 'expired challenge' copy", () => {
-    expect(
-      parsePasskeySignInError({
-        error: { code: "CHALLENGE_NOT_FOUND", message: "raw", status: 400 },
-      }),
-    ).toContain("challenge expired");
+    const result = parsePasskeySignInError({
+      kind: "wire",
+      error: { code: "CHALLENGE_NOT_FOUND", message: "raw", status: 400 },
+    });
+    expect(result.kind).toBe("user");
+    if (result.kind === "user") {
+      expect(result.message).toContain("challenge expired");
+    }
   });
 
   test("status 429 → rate-limit copy regardless of message wording", () => {
-    expect(
-      parsePasskeySignInError({
-        error: { status: 429, message: "anything" },
-      }),
-    ).toContain("Too many attempts");
+    const result = parsePasskeySignInError({
+      kind: "wire",
+      error: { status: 429, message: "anything" },
+    });
+    expect(result.kind).toBe("user");
+    if (result.kind === "user") {
+      expect(result.message).toContain("Too many attempts");
+    }
   });
 });
 
 describe("parsePasskeySignInError — thrown branch", () => {
   test("TypeError → 'can't reach the server' copy", () => {
-    expect(
-      parsePasskeySignInError({ thrown: new TypeError("fetch failed") }),
-    ).toContain("Can't reach the server");
+    const result = parsePasskeySignInError({ kind: "thrown", value: new TypeError("fetch failed") });
+    expect(result.kind).toBe("user");
+    if (result.kind === "user") {
+      expect(result.message).toContain("Can't reach the server");
+    }
   });
 
   test("plain Error with message → exact message bubbles", () => {
-    expect(
-      parsePasskeySignInError({ thrown: new Error("custom failure") }),
-    ).toBe("custom failure");
+    const result = parsePasskeySignInError({ kind: "thrown", value: new Error("custom failure") });
+    expect(result).toEqual({ kind: "user", message: "custom failure" });
   });
 
   test("non-Error throw → fallback copy", () => {
-    expect(parsePasskeySignInError({ thrown: "weird string" })).toContain(
-      "didn't complete",
-    );
+    const result = parsePasskeySignInError({ kind: "thrown", value: "weird string" });
+    expect(result.kind).toBe("user");
+    if (result.kind === "user") {
+      expect(result.message).toContain("didn't complete");
+    }
   });
 });
 
@@ -96,18 +114,22 @@ describe("parsePasskeySignInError — branch ordering invariant", () => {
     // A 429 response that happens to mention 'cancelled' must NOT fall
     // through the cancellation branch. Order of checks in the parser is
     // load-bearing: code/status leads, fuzzy substring match runs after.
-    expect(
-      parsePasskeySignInError({
-        error: { status: 429, message: "Too many requests; previous request cancelled" },
-      }),
-    ).toContain("Too many attempts");
+    const result = parsePasskeySignInError({
+      kind: "wire",
+      error: { status: 429, message: "Too many requests; previous request cancelled" },
+    });
+    expect(result.kind).toBe("user");
+    if (result.kind === "user") {
+      expect(result.message).toContain("Too many attempts");
+    }
   });
 
   test("AUTH_CANCELLED with status 401 still routes to silent (cancellation wins)", () => {
     expect(
       parsePasskeySignInError({
+        kind: "wire",
         error: { code: "AUTH_CANCELLED", status: 401, message: "anything" },
       }),
-    ).toBeNull();
+    ).toEqual({ kind: "silent" });
   });
 });

--- a/packages/web/src/lib/auth/parse-passkey-sign-in-error.test.ts
+++ b/packages/web/src/lib/auth/parse-passkey-sign-in-error.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Branch coverage for the passkey sign-in error parser.
+ *
+ * Pins the canonical "Esc on the OS prompt" path to `null` (no banner)
+ * and the explicit Better Auth error codes to friendly copy. The login
+ * + 2FA pages route their full UI behavior off these branches — a
+ * regression that flips a cancellation into a banner is exactly what
+ * this file is designed to catch.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { parsePasskeySignInError } from "./parse-passkey-sign-in-error";
+
+describe("parsePasskeySignInError — cancellation (returns null)", () => {
+  test("AUTH_CANCELLED code → silent", () => {
+    expect(
+      parsePasskeySignInError({
+        error: { code: "AUTH_CANCELLED", message: "cancelled", status: 400 },
+      }),
+    ).toBeNull();
+  });
+
+  test("REGISTRATION_CANCELLED code → silent", () => {
+    expect(
+      parsePasskeySignInError({
+        error: { code: "REGISTRATION_CANCELLED", message: "cancelled", status: 400 },
+      }),
+    ).toBeNull();
+  });
+
+  test("NotAllowedError fragment in message → silent", () => {
+    expect(
+      parsePasskeySignInError({
+        error: { message: "DOMException: NotAllowedError on get()", status: 0 },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("parsePasskeySignInError — error codes route to friendly copy", () => {
+  test("AUTHENTICATION_FAILED → 'couldn't verify' copy", () => {
+    expect(
+      parsePasskeySignInError({
+        error: { code: "AUTHENTICATION_FAILED", message: "raw blob", status: 400 },
+      }),
+    ).toContain("couldn't verify");
+  });
+
+  test("PASSKEY_NOT_FOUND → 'no passkey for this device' copy", () => {
+    expect(
+      parsePasskeySignInError({
+        error: { code: "PASSKEY_NOT_FOUND", message: "raw", status: 404 },
+      }),
+    ).toContain("No passkey is registered");
+  });
+
+  test("CHALLENGE_NOT_FOUND → 'expired challenge' copy", () => {
+    expect(
+      parsePasskeySignInError({
+        error: { code: "CHALLENGE_NOT_FOUND", message: "raw", status: 400 },
+      }),
+    ).toContain("challenge expired");
+  });
+
+  test("status 429 → rate-limit copy regardless of message wording", () => {
+    expect(
+      parsePasskeySignInError({
+        error: { status: 429, message: "anything" },
+      }),
+    ).toContain("Too many attempts");
+  });
+});
+
+describe("parsePasskeySignInError — thrown branch", () => {
+  test("TypeError → 'can't reach the server' copy", () => {
+    expect(
+      parsePasskeySignInError({ thrown: new TypeError("fetch failed") }),
+    ).toContain("Can't reach the server");
+  });
+
+  test("plain Error with message → exact message bubbles", () => {
+    expect(
+      parsePasskeySignInError({ thrown: new Error("custom failure") }),
+    ).toBe("custom failure");
+  });
+
+  test("non-Error throw → fallback copy", () => {
+    expect(parsePasskeySignInError({ thrown: "weird string" })).toContain(
+      "didn't complete",
+    );
+  });
+});
+
+describe("parsePasskeySignInError — branch ordering invariant", () => {
+  test("status 429 with 'cancelled' in body still routes to rate-limited (not silent)", () => {
+    // A 429 response that happens to mention 'cancelled' must NOT fall
+    // through the cancellation branch. Order of checks in the parser is
+    // load-bearing: code/status leads, fuzzy substring match runs after.
+    expect(
+      parsePasskeySignInError({
+        error: { status: 429, message: "Too many requests; previous request cancelled" },
+      }),
+    ).toContain("Too many attempts");
+  });
+
+  test("AUTH_CANCELLED with status 401 still routes to silent (cancellation wins)", () => {
+    expect(
+      parsePasskeySignInError({
+        error: { code: "AUTH_CANCELLED", status: 401, message: "anything" },
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/web/src/lib/auth/parse-passkey-sign-in-error.ts
+++ b/packages/web/src/lib/auth/parse-passkey-sign-in-error.ts
@@ -1,0 +1,88 @@
+/**
+ * Categorize a Better Auth `signIn.passkey()` failure into a user-facing
+ * message. Distinguishes user cancellation (silent — return `null`) from
+ * real failures so the login surface stays quiet on the canonical "user
+ * pressed Esc on the OS prompt" path while still surfacing real problems.
+ *
+ * Branch order is load-bearing: code/status checks lead because a 429 with
+ * a body that mentions "passkey" still routes to rate-limited copy, not
+ * unknown-fallback. Mirrors the structure of `parse-sign-in-error.ts`.
+ */
+
+import type { PasskeyApiError } from "./passkey-client";
+
+export interface PasskeySignInErrorInput {
+  /**
+   * Result envelope returned by `signIn.passkey()`. Better Auth's client
+   * wrapper traps `NotAllowedError` from the WebAuthn ceremony and folds
+   * it into `error.code === "AUTH_CANCELLED"` — that branch is silent.
+   */
+  error?: PasskeyApiError | null;
+  /** Caught from a `try/catch` around the call — usually a network failure. */
+  thrown?: unknown;
+}
+
+const FALLBACK = "Passkey sign-in didn't complete. Try again, or use email and password.";
+
+/**
+ * Returns `null` when the failure is a user cancellation (Esc on the OS
+ * prompt, dismissed authenticator picker) — the caller should NOT show a
+ * banner, just stop the spinner. Returns a string for everything else.
+ *
+ * Always log on the cancellation branch from the caller — a misconfigured
+ * `rpID` surfaces with the same `NotAllowedError` shape and would
+ * otherwise disappear silently.
+ */
+export function parsePasskeySignInError(input: PasskeySignInErrorInput): string | null {
+  if (input.thrown !== undefined) {
+    if (input.thrown instanceof TypeError) {
+      return "Can't reach the server. Check your connection and try again.";
+    }
+    if (input.thrown instanceof Error && input.thrown.message) {
+      return input.thrown.message;
+    }
+    return FALLBACK;
+  }
+
+  const err = input.error ?? {};
+  const code = (err.code ?? "").toUpperCase();
+  const message = err.message ?? "";
+  const status = err.status ?? 0;
+
+  // Code-based cancellation wins unconditionally — Better Auth surfaces
+  // user-cancelled WebAuthn ceremonies as `AUTH_CANCELLED` regardless of
+  // the HTTP status (some browsers report 401 here, others 400).
+  if (code === "AUTH_CANCELLED" || code === "REGISTRATION_CANCELLED") return null;
+
+  // Authoritative status / code branches run BEFORE the fuzzy-message
+  // cancellation match so a 429 body that incidentally mentions
+  // "cancelled" still routes to rate-limited copy. Same ordering
+  // invariant as `parse-sign-in-error.ts`.
+  if (status === 429 || code === "RATE_LIMITED" || /too many|rate limit/i.test(message)) {
+    return "Too many attempts. Wait a minute and try again.";
+  }
+
+  if (code === "AUTHENTICATION_FAILED" || /authentication failed/i.test(message)) {
+    return "We couldn't verify that passkey. Try again, or use email and password.";
+  }
+
+  if (code === "PASSKEY_NOT_FOUND" || /passkey not found|no passkey/i.test(message)) {
+    return "No passkey is registered for this device. Sign in with your password to add one from Settings → Security.";
+  }
+
+  if (code === "CHALLENGE_NOT_FOUND" || /challenge/i.test(message)) {
+    return "The sign-in challenge expired. Tap the passkey button again.";
+  }
+
+  // Fuzzy-message cancellation — older browsers / pre-`@simplewebauthn/
+  // browser` v9 wiring surface NotAllowedError in the message field
+  // without a stable code. Treat as silent.
+  if (isFuzzyCancellation(message)) return null;
+
+  return message || FALLBACK;
+}
+
+function isFuzzyCancellation(message: string): boolean {
+  const m = message.toLowerCase();
+  return m.includes("notallowed") || m.includes("cancelled") || m.includes("canceled");
+}

--- a/packages/web/src/lib/auth/parse-passkey-sign-in-error.ts
+++ b/packages/web/src/lib/auth/parse-passkey-sign-in-error.ts
@@ -1,47 +1,68 @@
 /**
  * Categorize a Better Auth `signIn.passkey()` failure into a user-facing
- * message. Distinguishes user cancellation (silent — return `null`) from
- * real failures so the login surface stays quiet on the canonical "user
- * pressed Esc on the OS prompt" path while still surfacing real problems.
+ * outcome. The discriminated return type forces every caller to handle
+ * the silent-cancellation path explicitly: `kind: "silent"` means the
+ * user pressed Esc on the OS prompt and the UI must NOT show a banner;
+ * `kind: "user"` carries copy to render.
  *
- * Branch order is load-bearing: code/status checks lead because a 429 with
- * a body that mentions "passkey" still routes to rate-limited copy, not
- * unknown-fallback. Mirrors the structure of `parse-sign-in-error.ts`.
+ * Branch order is load-bearing: code/status checks lead because a 429
+ * with a body that mentions "passkey" still routes to rate-limited copy,
+ * not unknown-fallback. Mirrors the structure of `parse-sign-in-error.ts`.
  */
 
 import type { PasskeyApiError } from "./passkey-client";
 
-export interface PasskeySignInErrorInput {
-  /**
-   * Result envelope returned by `signIn.passkey()`. Better Auth's client
-   * wrapper traps `NotAllowedError` from the WebAuthn ceremony and folds
-   * it into `error.code === "AUTH_CANCELLED"` — that branch is silent.
-   */
-  error?: PasskeyApiError | null;
-  /** Caught from a `try/catch` around the call — usually a network failure. */
-  thrown?: unknown;
-}
-
-const FALLBACK = "Passkey sign-in didn't complete. Try again, or use email and password.";
+/**
+ * Discriminated input. Forces callers to commit to one of two failure
+ * surfaces — the `signIn.passkey()` wire envelope (`{ data, error }`) or
+ * a caught throw — instead of passing both fields and hoping the parser
+ * picks the right one. The implicit-XOR shape this replaces was easy to
+ * misuse: `{}` typechecked but always returned the unknown fallback.
+ */
+export type PasskeySignInErrorInput =
+  | {
+      kind: "wire";
+      /**
+       * Result envelope. Better Auth's client wrapper traps
+       * `NotAllowedError` from the user-cancelled ceremony and folds it
+       * into `error.code === "AUTH_CANCELLED"` — that branch is silent.
+       */
+      error: PasskeyApiError | null;
+    }
+  | {
+      kind: "thrown";
+      /** Caught from a `try/catch` around the call — usually a network failure. */
+      value: unknown;
+    };
 
 /**
- * Returns `null` when the failure is a user cancellation (Esc on the OS
- * prompt, dismissed authenticator picker) — the caller should NOT show a
- * banner, just stop the spinner. Returns a string for everything else.
+ * Discriminated outcome. `silent` fires when the failure is a user
+ * cancellation (Esc on the OS prompt, dismissed authenticator picker) —
+ * the caller stops the spinner without rendering a banner. `user`
+ * carries the message to display.
  *
- * Always log on the cancellation branch from the caller — a misconfigured
- * `rpID` surfaces with the same `NotAllowedError` shape and would
- * otherwise disappear silently.
+ * Callers MUST log on the silent branch — a misconfigured `rpID`
+ * surfaces with the same `NotAllowedError` shape and would otherwise
+ * disappear without a DevTools breadcrumb.
  */
-export function parsePasskeySignInError(input: PasskeySignInErrorInput): string | null {
-  if (input.thrown !== undefined) {
-    if (input.thrown instanceof TypeError) {
-      return "Can't reach the server. Check your connection and try again.";
+export type PasskeySignInOutcome =
+  | { kind: "silent" }
+  | { kind: "user"; message: string };
+
+const FALLBACK_MESSAGE = "Passkey sign-in didn't complete. Try again, or use email and password.";
+
+export function parsePasskeySignInError(input: PasskeySignInErrorInput): PasskeySignInOutcome {
+  if (input.kind === "thrown") {
+    if (input.value instanceof TypeError) {
+      return {
+        kind: "user",
+        message: "Can't reach the server. Check your connection and try again.",
+      };
     }
-    if (input.thrown instanceof Error && input.thrown.message) {
-      return input.thrown.message;
+    if (input.value instanceof Error && input.value.message) {
+      return { kind: "user", message: input.value.message };
     }
-    return FALLBACK;
+    return { kind: "user", message: FALLBACK_MESSAGE };
   }
 
   const err = input.error ?? {};
@@ -50,36 +71,45 @@ export function parsePasskeySignInError(input: PasskeySignInErrorInput): string 
   const status = err.status ?? 0;
 
   // Code-based cancellation wins unconditionally — Better Auth surfaces
-  // user-cancelled WebAuthn ceremonies as `AUTH_CANCELLED` regardless of
+  // user-cancelled WebAuthn assertions as `AUTH_CANCELLED` regardless of
   // the HTTP status (some browsers report 401 here, others 400).
-  if (code === "AUTH_CANCELLED" || code === "REGISTRATION_CANCELLED") return null;
+  if (code === "AUTH_CANCELLED" || code === "REGISTRATION_CANCELLED") {
+    return { kind: "silent" };
+  }
 
   // Authoritative status / code branches run BEFORE the fuzzy-message
   // cancellation match so a 429 body that incidentally mentions
   // "cancelled" still routes to rate-limited copy. Same ordering
   // invariant as `parse-sign-in-error.ts`.
   if (status === 429 || code === "RATE_LIMITED" || /too many|rate limit/i.test(message)) {
-    return "Too many attempts. Wait a minute and try again.";
+    return { kind: "user", message: "Too many attempts. Wait a minute and try again." };
   }
 
   if (code === "AUTHENTICATION_FAILED" || /authentication failed/i.test(message)) {
-    return "We couldn't verify that passkey. Try again, or use email and password.";
+    return {
+      kind: "user",
+      message: "We couldn't verify that passkey. Try again, or use email and password.",
+    };
   }
 
   if (code === "PASSKEY_NOT_FOUND" || /passkey not found|no passkey/i.test(message)) {
-    return "No passkey is registered for this device. Sign in with your password to add one from Settings → Security.";
+    return {
+      kind: "user",
+      message:
+        "No passkey is registered for this device. Sign in with your password to add one from Settings → Security.",
+    };
   }
 
   if (code === "CHALLENGE_NOT_FOUND" || /challenge/i.test(message)) {
-    return "The sign-in challenge expired. Tap the passkey button again.";
+    return { kind: "user", message: "The sign-in challenge expired. Tap the passkey button again." };
   }
 
   // Fuzzy-message cancellation — older browsers / pre-`@simplewebauthn/
   // browser` v9 wiring surface NotAllowedError in the message field
   // without a stable code. Treat as silent.
-  if (isFuzzyCancellation(message)) return null;
+  if (isFuzzyCancellation(message)) return { kind: "silent" };
 
-  return message || FALLBACK;
+  return { kind: "user", message: message || FALLBACK_MESSAGE };
 }
 
 function isFuzzyCancellation(message: string): boolean {

--- a/packages/web/src/lib/auth/passkey-client.ts
+++ b/packages/web/src/lib/auth/passkey-client.ts
@@ -8,10 +8,15 @@
  * guard here keeps the security-page components and the login flow honest
  * about which methods they depend on.
  *
- * The guard returns `null` when the plugin isn't loaded; callers decide
+ * The guards return `null` when the plugin isn't loaded; callers decide
  * whether that is a soft "refresh the page" banner or a thrown error.
  * The user-visible message stays in the consumer — never include
  * developer paths in `Error` messages that bubble up to end users.
+ *
+ * `PasskeyClient` and `PasskeySignIn` are intentionally split: Better Auth
+ * mounts enrollment endpoints under `passkey.*` and sign-in under
+ * `signIn.passkey`, and a future namespace shuffle on either side must
+ * not dark-mode the other surface.
  */
 
 import { authClient } from "./client";
@@ -48,11 +53,6 @@ export interface PasskeySignInData {
   user: Record<string, unknown>;
 }
 
-// ---------------------------------------------------------------------------
-// Method surface — segregated into one interface so each consumer can
-// destructure only what it needs (`const { addPasskey } = client`).
-// ---------------------------------------------------------------------------
-
 export interface PasskeyClient {
   addPasskey: (opts?: {
     name?: string;
@@ -61,62 +61,46 @@ export interface PasskeyClient {
   listUserPasskeys: () => Promise<PasskeyApiResult<Passkey[]>>;
   updatePasskey: (opts: { id: string; name: string }) => Promise<PasskeyApiResult<{ passkey: Passkey }>>;
   deletePasskey: (opts: { id: string }) => Promise<PasskeyApiResult<{ status?: boolean }>>;
-  /**
-   * Initiates a passkey-first sign-in. With `autoFill: true` the call
-   * subscribes the page to the OS conditional-UI picker rather than
-   * triggering a modal prompt — pair it with an email input that has
-   * `autocomplete="username webauthn"` so saved passkeys appear in the
-   * autofill dropdown. Without `autoFill`, Better Auth fires the modal
-   * authenticator prompt immediately (the "Sign in with passkey" CTA path).
-   */
-  signInPasskey: (opts?: {
-    autoFill?: boolean;
-  }) => Promise<PasskeyApiResult<PasskeySignInData>>;
 }
 
-// ---------------------------------------------------------------------------
-// Guards
-// ---------------------------------------------------------------------------
+/**
+ * Initiates a passkey-first sign-in. With `autoFill: true` the call
+ * subscribes the page to the OS conditional-UI picker rather than
+ * triggering a modal prompt — pair it with an email input that has
+ * `autocomplete="username webauthn"` so saved passkeys appear in the
+ * autofill dropdown. Without `autoFill`, Better Auth fires the modal
+ * authenticator prompt immediately (the "Sign in with passkey" CTA path).
+ */
+export type PasskeySignIn = (opts?: {
+  autoFill?: boolean;
+}) => Promise<PasskeyApiResult<PasskeySignInData>>;
 
 /**
- * Resolve the `passkey` namespace from authClient. Returns `null` when the
- * plugin isn't loaded — callers translate that into a user-facing surface
- * (banner / disabled tile / etc).
+ * Resolve the `passkey` namespace from authClient. Returns `null` when
+ * enrollment endpoints aren't loaded — the security page translates that
+ * into a "refresh the page" banner. Independent of `getPasskeySignIn` so
+ * a renamed `signIn.passkey` doesn't dark-mode admin enrollment.
  *
- * Runtime method-presence check guards against Better Auth API drift —
- * a renamed method shows up as a precise null here rather than a
+ * The runtime method-presence check catches Better Auth API drift — a
+ * renamed method surfaces as a precise null rather than a
  * `TypeError: addPasskey is not a function` at click time.
- *
- * `signInPasskey` is resolved separately by {@link getPasskeySignIn} because
- * Better Auth mounts it under the top-level `signIn.passkey` namespace, not
- * under `passkey.*` — keeping the two guards apart prevents a renamed
- * `signIn.passkey` from disabling the security-page tile (or vice versa).
  */
 export function getPasskeyClient(): PasskeyClient | null {
   // The cast is the documented workaround for Better Auth's plugin-inference
-  // gap under TS6. Same pattern as `getTwoFactor()` in `two-factor-setup.tsx`
-  // and the `@ts-expect-error` on `apiKeyClient()` in `client.ts`.
-  const passkeyNamespace = (
-    authClient as unknown as { passkey?: Partial<Omit<PasskeyClient, "signInPasskey">> }
-  ).passkey;
-  const signIn = getPasskeySignIn();
+  // gap under TS6. Same pattern as `getTwoFactorClient()` in
+  // `lib/auth/two-factor-client.ts` and the `@ts-expect-error` on
+  // `apiKeyClient()` in `client.ts`.
+  const namespace = (authClient as unknown as { passkey?: Partial<PasskeyClient> }).passkey;
   if (
-    !passkeyNamespace ||
-    typeof passkeyNamespace.addPasskey !== "function" ||
-    typeof passkeyNamespace.listUserPasskeys !== "function" ||
-    typeof passkeyNamespace.updatePasskey !== "function" ||
-    typeof passkeyNamespace.deletePasskey !== "function" ||
-    !signIn
+    !namespace ||
+    typeof namespace.addPasskey !== "function" ||
+    typeof namespace.listUserPasskeys !== "function" ||
+    typeof namespace.updatePasskey !== "function" ||
+    typeof namespace.deletePasskey !== "function"
   ) {
     return null;
   }
-  return {
-    addPasskey: passkeyNamespace.addPasskey,
-    listUserPasskeys: passkeyNamespace.listUserPasskeys,
-    updatePasskey: passkeyNamespace.updatePasskey,
-    deletePasskey: passkeyNamespace.deletePasskey,
-    signInPasskey: signIn,
-  };
+  return namespace as PasskeyClient;
 }
 
 /**
@@ -125,11 +109,9 @@ export function getPasskeyClient(): PasskeyClient | null {
  * into "passkey button hidden" rather than a hard error: a user without
  * the plugin still has email + password.
  */
-export function getPasskeySignIn(): PasskeyClient["signInPasskey"] | null {
+export function getPasskeySignIn(): PasskeySignIn | null {
   const signInNamespace = (
-    authClient as unknown as {
-      signIn?: { passkey?: PasskeyClient["signInPasskey"] };
-    }
+    authClient as unknown as { signIn?: { passkey?: PasskeySignIn } }
   ).signIn;
   if (!signInNamespace || typeof signInNamespace.passkey !== "function") {
     return null;

--- a/packages/web/src/lib/auth/passkey-client.ts
+++ b/packages/web/src/lib/auth/passkey-client.ts
@@ -2,11 +2,11 @@
  * Shared narrow view onto the Better Auth passkey client surface.
  *
  * `createAuthClient`'s plugin-augmented type doesn't surface
- * `passkey.{addPasskey,listUserPasskeys,deletePasskey,updatePasskey}` through
- * the generic chain under TS6 strictness, so consumers cast through
- * `unknown`. Centralising the cast plus the runtime guard here keeps the
- * three security-page components (`passkey-tile`, `passkey-list`,
- * `security/page.tsx`) honest about which methods they depend on.
+ * `passkey.{addPasskey,listUserPasskeys,deletePasskey,updatePasskey}` or
+ * `signIn.passkey()` through the generic chain under TS6 strictness, so
+ * consumers cast through `unknown`. Centralising the cast plus the runtime
+ * guard here keeps the security-page components and the login flow honest
+ * about which methods they depend on.
  *
  * The guard returns `null` when the plugin isn't loaded; callers decide
  * whether that is a soft "refresh the page" banner or a thrown error.
@@ -37,6 +37,17 @@ export interface Passkey {
   createdAt: Date | string;
 }
 
+/**
+ * The `signIn.passkey()` success envelope. Better Auth populates `data` with
+ * `{ session, user }` once the WebAuthn assertion verifies; we narrow to
+ * `Record<string, unknown>` because the page only needs to know the call
+ * succeeded — routing decisions stay in the page itself.
+ */
+export interface PasskeySignInData {
+  session: Record<string, unknown>;
+  user: Record<string, unknown>;
+}
+
 // ---------------------------------------------------------------------------
 // Method surface — segregated into one interface so each consumer can
 // destructure only what it needs (`const { addPasskey } = client`).
@@ -50,10 +61,21 @@ export interface PasskeyClient {
   listUserPasskeys: () => Promise<PasskeyApiResult<Passkey[]>>;
   updatePasskey: (opts: { id: string; name: string }) => Promise<PasskeyApiResult<{ passkey: Passkey }>>;
   deletePasskey: (opts: { id: string }) => Promise<PasskeyApiResult<{ status?: boolean }>>;
+  /**
+   * Initiates a passkey-first sign-in. With `autoFill: true` the call
+   * subscribes the page to the OS conditional-UI picker rather than
+   * triggering a modal prompt — pair it with an email input that has
+   * `autocomplete="username webauthn"` so saved passkeys appear in the
+   * autofill dropdown. Without `autoFill`, Better Auth fires the modal
+   * authenticator prompt immediately (the "Sign in with passkey" CTA path).
+   */
+  signInPasskey: (opts?: {
+    autoFill?: boolean;
+  }) => Promise<PasskeyApiResult<PasskeySignInData>>;
 }
 
 // ---------------------------------------------------------------------------
-// Guard
+// Guards
 // ---------------------------------------------------------------------------
 
 /**
@@ -64,21 +86,53 @@ export interface PasskeyClient {
  * Runtime method-presence check guards against Better Auth API drift —
  * a renamed method shows up as a precise null here rather than a
  * `TypeError: addPasskey is not a function` at click time.
+ *
+ * `signInPasskey` is resolved separately by {@link getPasskeySignIn} because
+ * Better Auth mounts it under the top-level `signIn.passkey` namespace, not
+ * under `passkey.*` — keeping the two guards apart prevents a renamed
+ * `signIn.passkey` from disabling the security-page tile (or vice versa).
  */
 export function getPasskeyClient(): PasskeyClient | null {
   // The cast is the documented workaround for Better Auth's plugin-inference
   // gap under TS6. Same pattern as `getTwoFactor()` in `two-factor-setup.tsx`
   // and the `@ts-expect-error` on `apiKeyClient()` in `client.ts`.
-  const namespace = (authClient as unknown as { passkey?: Partial<PasskeyClient> })
-    .passkey;
+  const passkeyNamespace = (
+    authClient as unknown as { passkey?: Partial<Omit<PasskeyClient, "signInPasskey">> }
+  ).passkey;
+  const signIn = getPasskeySignIn();
   if (
-    !namespace ||
-    typeof namespace.addPasskey !== "function" ||
-    typeof namespace.listUserPasskeys !== "function" ||
-    typeof namespace.updatePasskey !== "function" ||
-    typeof namespace.deletePasskey !== "function"
+    !passkeyNamespace ||
+    typeof passkeyNamespace.addPasskey !== "function" ||
+    typeof passkeyNamespace.listUserPasskeys !== "function" ||
+    typeof passkeyNamespace.updatePasskey !== "function" ||
+    typeof passkeyNamespace.deletePasskey !== "function" ||
+    !signIn
   ) {
     return null;
   }
-  return namespace as PasskeyClient;
+  return {
+    addPasskey: passkeyNamespace.addPasskey,
+    listUserPasskeys: passkeyNamespace.listUserPasskeys,
+    updatePasskey: passkeyNamespace.updatePasskey,
+    deletePasskey: passkeyNamespace.deletePasskey,
+    signInPasskey: signIn,
+  };
+}
+
+/**
+ * Resolve the `signIn.passkey()` action. Returns `null` when the plugin
+ * isn't loaded — callers (login page, 2FA challenge page) translate that
+ * into "passkey button hidden" rather than a hard error: a user without
+ * the plugin still has email + password.
+ */
+export function getPasskeySignIn(): PasskeyClient["signInPasskey"] | null {
+  const signInNamespace = (
+    authClient as unknown as {
+      signIn?: { passkey?: PasskeyClient["signInPasskey"] };
+    }
+  ).signIn;
+  if (!signInNamespace || typeof signInNamespace.passkey !== "function") {
+    return null;
+  }
+  return signInNamespace.passkey;
 }

--- a/packages/web/src/ui/__tests__/passkey-list.test.tsx
+++ b/packages/web/src/ui/__tests__/passkey-list.test.tsx
@@ -23,6 +23,9 @@ mock.module("@/lib/auth/passkey-client", () => ({
     listUserPasskeys: listUserPasskeysMock,
     deletePasskey: deletePasskeyMock,
   }),
+  // Stubbed to satisfy the `mock.module() must mock every named export`
+  // rule — the list view never calls signIn.passkey() itself.
+  getPasskeySignIn: () => null,
 }));
 
 import { PasskeyList } from "../components/admin/security/passkey-list";

--- a/packages/web/src/ui/__tests__/passkey-tile.test.tsx
+++ b/packages/web/src/ui/__tests__/passkey-tile.test.tsx
@@ -17,6 +17,9 @@ mock.module("@/lib/auth/passkey-client", () => ({
     listUserPasskeys: listUserPasskeysMock,
     deletePasskey: deletePasskeyMock,
   }),
+  // Stubbed to satisfy the `mock.module() must mock every named export`
+  // rule — the enrollment tile never calls signIn.passkey() itself.
+  getPasskeySignIn: () => null,
 }));
 
 import { PasskeyTile } from "../components/admin/security/passkey-tile";


### PR DESCRIPTION
## Summary

Wave 2A of the parallel **MFA hardening track** (issue #2091). #2082 shipped passkey *enrollment*; this PR makes the credential actually usable for sign-in:

- **`/login`** renders a **Sign in with a passkey** button above the email/password form whenever WebAuthn is supported. Calls `authClient.signIn.passkey()`. Hidden entirely on unsupported browsers — no banner.
- **`/login`** opts the email input into **conditional UI autofill** (`autocomplete="username webauthn"` + `signIn.passkey({ autoFill: true })` on mount). A ref guard ensures the ceremony fires exactly once even if the router reference is unstable in tests.
- **`/login/two-factor`** renders a **Use a passkey** alternative above the TOTP code input. Trust-device toggle stays visible for consistency on either path.
- **`PasskeyClient` interface** in `lib/auth/passkey-client.ts` gains a typed `signInPasskey`, exposed via `getPasskeySignIn()`.
- **`parsePasskeySignInError`** centralises the user-facing copy. Code-based cancellation (`AUTH_CANCELLED` / `REGISTRATION_CANCELLED`) and fuzzy `NotAllowedError` messages return `null` (silent — no banner). Friendly copy for `AUTHENTICATION_FAILED`, `PASSKEY_NOT_FOUND`, `CHALLENGE_NOT_FOUND`, 429.
- **API route-listing test** (`passkey-routes.test.ts`) builds a real Better Auth instance and proves `/api/auth/passkey/generate-authenticate-options` is mounted (no new server routes — Better Auth's `passkey()` plugin auto-registers).
- **Browser e2e** (`e2e/browser/passkey-signin.spec.ts`, `@llm`-tagged): CDP virtual authenticator → enrol on `/admin/settings/security` → sign out → click **Sign in with a passkey** → assert no password input, session active. Self-cleaning.
- **Docs**: `security/passkeys.mdx` gains a *Signing In With a Passkey* section (login + 2FA paths, autofill, troubleshooting). `security/two-factor-auth.mdx` describes the passkey alternative on the 2FA challenge.

Cross-device QR sign-in (`hybrid` transport) is explicitly out of scope; recovery flows are queued for **Wave 2B (#2092)** behind this PR.

Closes #2091.

## Test plan

- [x] `bun run lint` — 0 errors, 0 warnings
- [x] `bun run type` — 0 errors
- [x] `bun run test` — full suite, 119 web files + 332 api files + every other workspace package — 0 failures
- [x] `bun x syncpack lint` — no issues
- [x] `bash scripts/check-template-drift.sh` — 493 files verified
- [x] `bash scripts/check-security-headers-drift.sh` — 3 mirrors match
- [x] `bash scripts/check-railway-watch.sh` — all COPY sources covered
- [ ] Manual: load `/login` in a browser with a saved passkey → confirm autofill picker surfaces the credential (browser-specific; verified in the `@llm` e2e under CDP)
- [ ] Manual: enrol passkey + TOTP, sign in, land on `/login/two-factor`, confirm both paths render and either completes sign-in