### PR TITLE
feat(api,web,mcp): #2067 — admin audit-log MCP filter view

### DIFF
--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -1269,10 +1269,12 @@ describe("GET /api/v1/admin/audit", () => {
     // Org-scoped predicate must remain $1 — a malicious caller adding
     // ?actorKind=mcp must not be able to see another org's MCP rows.
     setOrgAdmin("org-other");
+    let capturedSql = "";
     let capturedParams: unknown[] = [];
     mockInternalQuery.mockImplementation((sql: string, params?: unknown[]) => {
       if (sql.includes("ip_allowlist")) return Promise.resolve([]);
-      if (!capturedParams.length && sql.includes("audit_log")) {
+      if (!capturedSql && sql.includes("audit_log") && sql.includes("actor_kind")) {
+        capturedSql = sql;
         capturedParams = params ?? [];
       }
       if (sql.includes("COUNT(*)")) return Promise.resolve([{ count: "0" }]);
@@ -1283,6 +1285,18 @@ describe("GET /api/v1/admin/audit", () => {
 
     expect(capturedParams[0]).toBe("org-other");
     expect(capturedParams).toContain("mcp");
+    // Pin the AND-junction between org_id and the MCP filter so a
+    // future regression that uses OR (or drops the AND entirely) is
+    // caught at compile-of-SQL time, not at "why is data leaking?"
+    expect(capturedSql).toMatch(/a\.org_id = \$1\s+AND\s+/);
+  });
+
+  it("returns 400 for an actorKind value outside the canonical set", async () => {
+    const res = await app.fetch(adminRequest("/api/v1/admin/audit?actorKind=robot"));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("invalid_request");
+    expect(body.message).toContain("actorKind");
   });
 
   it("returns 500 when internalQuery throws", async () => {

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -1180,6 +1180,111 @@ describe("GET /api/v1/admin/audit", () => {
     expect(body.error).toBe("invalid_request");
   });
 
+  // #2067 — MCP filter shape
+  it("supports actorKind=mcp filter", async () => {
+    let capturedSql = "";
+    let capturedParams: unknown[] = [];
+    mockInternalQuery.mockImplementation((sql: string, params?: unknown[]) => {
+      if (sql.includes("ip_allowlist")) return Promise.resolve([]);
+      if (!capturedSql && sql.includes("audit_log")) {
+        capturedSql = sql;
+        capturedParams = params ?? [];
+      }
+      if (sql.includes("COUNT(*)")) return Promise.resolve([{ count: "0" }]);
+      return Promise.resolve([]);
+    });
+
+    await app.fetch(adminRequest("/api/v1/admin/audit?actorKind=mcp"));
+
+    expect(capturedSql).toContain("a.actor_kind = $2");
+    expect(capturedParams).toEqual(["org-test", "mcp"]);
+  });
+
+  it("supports clientId filter", async () => {
+    let capturedSql = "";
+    let capturedParams: unknown[] = [];
+    mockInternalQuery.mockImplementation((sql: string, params?: unknown[]) => {
+      if (sql.includes("ip_allowlist")) return Promise.resolve([]);
+      if (!capturedSql && sql.includes("audit_log")) {
+        capturedSql = sql;
+        capturedParams = params ?? [];
+      }
+      if (sql.includes("COUNT(*)")) return Promise.resolve([{ count: "0" }]);
+      return Promise.resolve([]);
+    });
+
+    await app.fetch(adminRequest("/api/v1/admin/audit?clientId=claude-desktop"));
+
+    expect(capturedSql).toContain("a.client_id = $2");
+    expect(capturedParams).toEqual(["org-test", "claude-desktop"]);
+  });
+
+  it("supports tool filter", async () => {
+    let capturedSql = "";
+    let capturedParams: unknown[] = [];
+    mockInternalQuery.mockImplementation((sql: string, params?: unknown[]) => {
+      if (sql.includes("ip_allowlist")) return Promise.resolve([]);
+      if (!capturedSql && sql.includes("audit_log")) {
+        capturedSql = sql;
+        capturedParams = params ?? [];
+      }
+      if (sql.includes("COUNT(*)")) return Promise.resolve([{ count: "0" }]);
+      return Promise.resolve([]);
+    });
+
+    await app.fetch(adminRequest("/api/v1/admin/audit?tool=runMetric"));
+
+    expect(capturedSql).toContain("a.tool_name = $2");
+    expect(capturedParams).toEqual(["org-test", "runMetric"]);
+  });
+
+  it("AND-combines actorKind + clientId + tool with existing filters", async () => {
+    let capturedSql = "";
+    let capturedParams: unknown[] = [];
+    mockInternalQuery.mockImplementation((sql: string, params?: unknown[]) => {
+      if (sql.includes("ip_allowlist")) return Promise.resolve([]);
+      if (!capturedSql && sql.includes("audit_log")) {
+        capturedSql = sql;
+        capturedParams = params ?? [];
+      }
+      if (sql.includes("COUNT(*)")) return Promise.resolve([{ count: "0" }]);
+      return Promise.resolve([]);
+    });
+
+    await app.fetch(adminRequest(
+      "/api/v1/admin/audit?actorKind=mcp&clientId=claude-desktop&tool=runMetric&success=true",
+    ));
+
+    // Org always $1; success applied first (existing param), then the
+    // three #2067 filters in declaration order (actorKind → clientId → tool).
+    expect(capturedSql).toContain("a.org_id = $1");
+    expect(capturedSql).toContain("a.success = $2");
+    expect(capturedSql).toContain("a.actor_kind = $3");
+    expect(capturedSql).toContain("a.client_id = $4");
+    expect(capturedSql).toContain("a.tool_name = $5");
+    expect(capturedParams).toEqual(["org-test", true, "mcp", "claude-desktop", "runMetric"]);
+  });
+
+  it("preserves cross-workspace isolation when MCP filters are present", async () => {
+    // Org-scoped predicate must remain $1 — a malicious caller adding
+    // ?actorKind=mcp must not be able to see another org's MCP rows.
+    setOrgAdmin("org-other");
+    let capturedParams: unknown[] = [];
+    mockInternalQuery.mockImplementation((sql: string, params?: unknown[]) => {
+      if (sql.includes("ip_allowlist")) return Promise.resolve([]);
+      if (!capturedParams.length && sql.includes("audit_log")) {
+        capturedParams = params ?? [];
+      }
+      if (sql.includes("COUNT(*)")) return Promise.resolve([{ count: "0" }]);
+      return Promise.resolve([]);
+    });
+
+    await app.fetch(adminRequest("/api/v1/admin/audit?actorKind=mcp"));
+
+    expect(capturedParams[0]).toBe("org-other");
+    expect(capturedParams).toContain("mcp");
+  });
+
   it("returns 500 when internalQuery throws", async () => {
     mockInternalQuery.mockRejectedValue(new Error("DB connection lost"));
 

--- a/packages/api/src/api/routes/admin-audit.ts
+++ b/packages/api/src/api/routes/admin-audit.ts
@@ -14,7 +14,8 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { AuthContext } from "@atlas/api/lib/effect/services";
 import { internalQuery, queryEffect } from "@atlas/api/lib/db/internal";
-import { ErrorSchema, AuthErrorSchema, parsePagination, escapeIlike } from "./shared-schemas";
+import { buildAuditFilters } from "@atlas/api/lib/audit/query";
+import { ErrorSchema, AuthErrorSchema, parsePagination } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext, requirePermission } from "./admin-router";
 
 const log = createLogger("admin-audit");
@@ -30,81 +31,6 @@ function csvField(val: string | null | undefined): string {
     return `"${s.replace(/"/g, '""')}"`;
   }
   return s;
-}
-
-type AuditFilterResult =
-  | { ok: true; conditions: string[]; params: unknown[]; paramIdx: number }
-  | { ok: false; error: string; message: string; status: 400 };
-
-/**
- * Build WHERE conditions for audit list + export endpoints.
- * The orgId condition is always first ($1).
- */
-function buildAuditFilters(
-  orgId: string,
-  query: (key: string) => string | undefined,
-): AuditFilterResult {
-  const conditions: string[] = ["a.deleted_at IS NULL", "a.org_id = $1"];
-  const params: unknown[] = [orgId];
-  let paramIdx = 2;
-
-  const user = query("user");
-  if (user) {
-    conditions.push(`a.user_id = $${paramIdx++}`);
-    params.push(user);
-  }
-
-  const success = query("success");
-  if (success === "true" || success === "false") {
-    conditions.push(`a.success = $${paramIdx++}`);
-    params.push(success === "true");
-  }
-
-  const from = query("from");
-  if (from) {
-    if (isNaN(Date.parse(from))) {
-      return { ok: false, error: "invalid_request", message: `Invalid 'from' date format: "${from}". Use ISO 8601 (e.g. 2026-01-01).`, status: 400 };
-    }
-    conditions.push(`a.timestamp >= $${paramIdx++}`);
-    params.push(from);
-  }
-
-  const to = query("to");
-  if (to) {
-    if (isNaN(Date.parse(to))) {
-      return { ok: false, error: "invalid_request", message: `Invalid 'to' date format: "${to}". Use ISO 8601 (e.g. 2026-03-03).`, status: 400 };
-    }
-    conditions.push(`a.timestamp <= $${paramIdx++}`);
-    params.push(to);
-  }
-
-  const connection = query("connection");
-  if (connection) {
-    conditions.push(`a.source_id = $${paramIdx++}`);
-    params.push(connection);
-  }
-
-  const table = query("table");
-  if (table) {
-    conditions.push(`a.tables_accessed ? $${paramIdx++}`);
-    params.push(table.toLowerCase());
-  }
-
-  const column = query("column");
-  if (column) {
-    conditions.push(`a.columns_accessed ? $${paramIdx++}`);
-    params.push(column.toLowerCase());
-  }
-
-  const search = query("search");
-  if (search) {
-    const term = `%${escapeIlike(search)}%`;
-    conditions.push(`(a.sql ILIKE $${paramIdx} OR u.email ILIKE $${paramIdx} OR a.error ILIKE $${paramIdx})`);
-    params.push(term);
-    paramIdx++;
-  }
-
-  return { ok: true, conditions, params, paramIdx };
 }
 
 /** Build org-scoped WHERE clause from optional date range query params. */

--- a/packages/api/src/lib/audit/__tests__/query.test.ts
+++ b/packages/api/src/lib/audit/__tests__/query.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Unit tests for the audit-log filter builder (#2067).
+ *
+ * The route-level tests in `admin.test.ts` exercise the full HTTP path;
+ * these tests pin the SQL shape the builder emits so a future
+ * refactor (e.g. moving to Drizzle's QueryBuilder) can't silently drop
+ * a filter or shuffle the placeholder ordering.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { buildAuditFilters } from "../query";
+
+function reader(map: Record<string, string>): (k: string) => string | undefined {
+  return (k) => map[k];
+}
+
+describe("buildAuditFilters", () => {
+  it("returns the orgId + soft-delete predicates with no caller filters", () => {
+    const result = buildAuditFilters("org-1", reader({}));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.conditions).toEqual([
+      "a.deleted_at IS NULL",
+      "a.org_id = $1",
+    ]);
+    expect(result.params).toEqual(["org-1"]);
+    expect(result.paramIdx).toBe(2);
+  });
+
+  it("applies actorKind filter (#2067)", () => {
+    const result = buildAuditFilters("org-1", reader({ actorKind: "mcp" }));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.conditions).toContain("a.actor_kind = $2");
+    expect(result.params).toEqual(["org-1", "mcp"]);
+  });
+
+  it("applies clientId filter (#2067)", () => {
+    const result = buildAuditFilters("org-1", reader({ clientId: "claude-desktop" }));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.conditions).toContain("a.client_id = $2");
+    expect(result.params).toEqual(["org-1", "claude-desktop"]);
+  });
+
+  it("applies tool filter (#2067)", () => {
+    const result = buildAuditFilters("org-1", reader({ tool: "runMetric" }));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.conditions).toContain("a.tool_name = $2");
+    expect(result.params).toEqual(["org-1", "runMetric"]);
+  });
+
+  it("AND-combines all three #2067 filters with stable ordering", () => {
+    const result = buildAuditFilters(
+      "org-1",
+      reader({ actorKind: "mcp", clientId: "claude-desktop", tool: "executeSQL" }),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Declaration order: actorKind ($2) → clientId ($3) → tool ($4)
+    expect(result.conditions.slice(2)).toEqual([
+      "a.actor_kind = $2",
+      "a.client_id = $3",
+      "a.tool_name = $4",
+    ]);
+    expect(result.params).toEqual(["org-1", "mcp", "claude-desktop", "executeSQL"]);
+    expect(result.paramIdx).toBe(5);
+  });
+
+  it("ignores empty-string actorKind / clientId / tool", () => {
+    // The frontend sends `?actorKind=` when the user picks "All actors";
+    // the builder must treat empty strings as absent so the SQL doesn't
+    // become `WHERE actor_kind = ''` and silently match no rows.
+    const result = buildAuditFilters(
+      "org-1",
+      reader({ actorKind: "", clientId: "", tool: "" }),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.conditions).toEqual([
+      "a.deleted_at IS NULL",
+      "a.org_id = $1",
+    ]);
+    expect(result.params).toEqual(["org-1"]);
+  });
+
+  it("preserves placeholder ordering when interleaved with existing filters", () => {
+    const result = buildAuditFilters(
+      "org-1",
+      reader({
+        user: "u-9",
+        success: "true",
+        actorKind: "mcp",
+        clientId: "claude-desktop",
+        tool: "runMetric",
+        search: "orders",
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // user $2 → success $3 → actorKind $4 → clientId $5 → tool $6 → search $7
+    expect(result.params).toEqual([
+      "org-1",
+      "u-9",
+      true,
+      "mcp",
+      "claude-desktop",
+      "runMetric",
+      "%orders%",
+    ]);
+    expect(result.conditions).toContain("a.user_id = $2");
+    expect(result.conditions).toContain("a.success = $3");
+    expect(result.conditions).toContain("a.actor_kind = $4");
+    expect(result.conditions).toContain("a.client_id = $5");
+    expect(result.conditions).toContain("a.tool_name = $6");
+    expect(
+      result.conditions.some((c) => c.includes("a.sql ILIKE $7")),
+    ).toBe(true);
+  });
+
+  it("propagates invalid date errors as 400 results", () => {
+    const result = buildAuditFilters("org-1", reader({ from: "not-a-date" }));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.status).toBe(400);
+    expect(result.error).toBe("invalid_request");
+  });
+});

--- a/packages/api/src/lib/audit/__tests__/query.test.ts
+++ b/packages/api/src/lib/audit/__tests__/query.test.ts
@@ -126,4 +126,24 @@ describe("buildAuditFilters", () => {
     expect(result.status).toBe(400);
     expect(result.error).toBe("invalid_request");
   });
+
+  it("rejects actorKind values outside the canonical set with a 400", () => {
+    // Whitelist enforcement — typo'd values like 'mpc' must not silently
+    // produce a `WHERE actor_kind = 'mpc'` zero-row match.
+    const result = buildAuditFilters("org-1", reader({ actorKind: "robot" }));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.status).toBe(400);
+    expect(result.error).toBe("invalid_request");
+    expect(result.message).toContain("actorKind");
+  });
+
+  it("accepts every canonical actorKind value", () => {
+    for (const kind of ["human", "agent", "mcp", "scheduler"] as const) {
+      const result = buildAuditFilters("org-1", reader({ actorKind: kind }));
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.params).toContain(kind);
+    }
+  });
 });

--- a/packages/api/src/lib/audit/query.ts
+++ b/packages/api/src/lib/audit/query.ts
@@ -1,0 +1,183 @@
+/**
+ * Audit-log filter builder shared by `/api/v1/admin/audit` list +
+ * export endpoints. Lives here (not in the route file) so #2067's
+ * filter shape — `actorKind`, `clientId`, `tool` — is testable in
+ * isolation and reusable by any future surface that pivots on the
+ * same audit dimensions (CSV export, OTel-driven dashboards, etc).
+ *
+ * Builds parameterized WHERE conditions. Every filter is optional and
+ * AND-combined. The result is a single read-only SELECT — no DML, no
+ * statement chaining — and the table-allowlist guard at the API
+ * boundary ensures the only table reachable here is `audit_log` (plus
+ * its `LEFT JOIN "user"` for the search filter). `org_id` is always
+ * `$1` so callers can rely on a stable index.
+ */
+
+/**
+ * Escape ILIKE special characters so they are matched literally. Inline
+ * here (rather than importing from `api/routes/shared-schemas`) because
+ * CLAUDE.md forbids `lib/*` from importing the route layer.
+ */
+function escapeIlike(s: string): string {
+  return s.replace(/[%_\\]/g, "\\$&");
+}
+
+/**
+ * Successful build result. `params` has `paramIdx - 1` entries when
+ * `paramIdx` is the next $-placeholder the caller can use for any
+ * trailing arguments (LIMIT/OFFSET on the list endpoint, LIMIT on
+ * export). `conditions` always includes the `org_id` and soft-delete
+ * predicates as the first two entries.
+ */
+export type AuditFilterOk = {
+  ok: true;
+  conditions: string[];
+  params: unknown[];
+  paramIdx: number;
+};
+
+/**
+ * Failed build — invalid filter input from the caller. The route
+ * propagates `error` / `message` / `status` straight into the JSON
+ * response so every 400 carries actionable copy without a second
+ * round-trip through the error mapper.
+ */
+export type AuditFilterErr = {
+  ok: false;
+  error: string;
+  message: string;
+  status: 400;
+};
+
+export type AuditFilterResult = AuditFilterOk | AuditFilterErr;
+
+/**
+ * Reader for query-string params. Routes pass `(k) => c.req.query(k)`;
+ * tests can pass a plain Map adapter. Decoupling from Hono keeps this
+ * module mock-free in unit tests.
+ */
+export type QueryReader = (key: string) => string | undefined;
+
+/**
+ * Build WHERE conditions for audit list + export endpoints. Returns
+ * `ok: false` on the first invalid input so the caller can short-
+ * circuit with a 400 — no partial filtering, no silent drops.
+ *
+ * Keep the order: `org_id` → soft-delete → caller-supplied filters.
+ * The two leading predicates pin every row to the active workspace
+ * and exclude retention-purged rows; reordering breaks the index hit
+ * on `idx_audit_log_org`.
+ */
+export function buildAuditFilters(
+  orgId: string,
+  query: QueryReader,
+): AuditFilterResult {
+  const conditions: string[] = ["a.deleted_at IS NULL", "a.org_id = $1"];
+  const params: unknown[] = [orgId];
+  let paramIdx = 2;
+
+  const user = query("user");
+  if (user) {
+    conditions.push(`a.user_id = $${paramIdx++}`);
+    params.push(user);
+  }
+
+  const success = query("success");
+  if (success === "true" || success === "false") {
+    conditions.push(`a.success = $${paramIdx++}`);
+    params.push(success === "true");
+  }
+
+  const from = query("from");
+  if (from) {
+    if (isNaN(Date.parse(from))) {
+      return {
+        ok: false,
+        error: "invalid_request",
+        message: `Invalid 'from' date format: "${from}". Use ISO 8601 (e.g. 2026-01-01).`,
+        status: 400,
+      };
+    }
+    conditions.push(`a.timestamp >= $${paramIdx++}`);
+    params.push(from);
+  }
+
+  const to = query("to");
+  if (to) {
+    if (isNaN(Date.parse(to))) {
+      return {
+        ok: false,
+        error: "invalid_request",
+        message: `Invalid 'to' date format: "${to}". Use ISO 8601 (e.g. 2026-03-03).`,
+        status: 400,
+      };
+    }
+    conditions.push(`a.timestamp <= $${paramIdx++}`);
+    params.push(to);
+  }
+
+  const connection = query("connection");
+  if (connection) {
+    conditions.push(`a.source_id = $${paramIdx++}`);
+    params.push(connection);
+  }
+
+  const table = query("table");
+  if (table) {
+    conditions.push(`a.tables_accessed ? $${paramIdx++}`);
+    params.push(table.toLowerCase());
+  }
+
+  const column = query("column");
+  if (column) {
+    conditions.push(`a.columns_accessed ? $${paramIdx++}`);
+    params.push(column.toLowerCase());
+  }
+
+  // ── #2067 — MCP filter shape ────────────────────────────────────
+  // `actorKind` is an open-ended discriminator (today: `mcp` is the
+  // only writer; `human` / `agent` / `scheduler` are reserved). We
+  // accept any non-empty string so future writers can opt in without
+  // a route-level whitelist. The frontend renders the canonical four
+  // options in the dropdown.
+  const actorKind = query("actorKind");
+  if (actorKind) {
+    conditions.push(`a.actor_kind = $${paramIdx++}`);
+    params.push(actorKind);
+  }
+
+  // `clientId` scopes to a specific OAuth client (e.g. `claude-desktop`
+  // or a DCR UUID). Only meaningful when actorKind is `mcp`, but we
+  // don't enforce the cross-field constraint server-side — pairing
+  // them is a UI affordance.
+  const clientId = query("clientId");
+  if (clientId) {
+    conditions.push(`a.client_id = $${paramIdx++}`);
+    params.push(clientId);
+  }
+
+  // `tool` filters by the dispatched tool name (`executeSQL`,
+  // `runMetric`, etc). `tool_name` was populated by the MCP path in
+  // `tools.ts` / `semantic-tools.ts`; non-MCP rows have NULL and
+  // won't match — that's the right semantics for a "scope to a tool"
+  // filter.
+  const tool = query("tool");
+  if (tool) {
+    conditions.push(`a.tool_name = $${paramIdx++}`);
+    params.push(tool);
+  }
+
+  // ── End #2067 filters ───────────────────────────────────────────
+
+  const search = query("search");
+  if (search) {
+    const term = `%${escapeIlike(search)}%`;
+    conditions.push(
+      `(a.sql ILIKE $${paramIdx} OR u.email ILIKE $${paramIdx} OR a.error ILIKE $${paramIdx})`,
+    );
+    params.push(term);
+    paramIdx++;
+  }
+
+  return { ok: true, conditions, params, paramIdx };
+}

--- a/packages/api/src/lib/audit/query.ts
+++ b/packages/api/src/lib/audit/query.ts
@@ -1,47 +1,36 @@
 /**
- * Audit-log filter builder shared by `/api/v1/admin/audit` list +
- * export endpoints. Lives here (not in the route file) so #2067's
- * filter shape — `actorKind`, `clientId`, `tool` — is testable in
- * isolation and reusable by any future surface that pivots on the
- * same audit dimensions (CSV export, OTel-driven dashboards, etc).
+ * Audit-log WHERE-clause builder. Pure function over a `QueryReader`;
+ * emits parameterized predicates and tracks the next free `$N` so
+ * callers can append LIMIT/OFFSET. Lives outside the route layer
+ * because `lib/*` cannot import from `api/routes/*` (CLAUDE.md).
  *
- * Builds parameterized WHERE conditions. Every filter is optional and
- * AND-combined. The result is a single read-only SELECT — no DML, no
- * statement chaining — and the table-allowlist guard at the API
- * boundary ensures the only table reachable here is `audit_log` (plus
- * its `LEFT JOIN "user"` for the search filter). `org_id` is always
- * `$1` so callers can rely on a stable index.
+ * Every value is parameterized; the function never emits identifiers,
+ * so a single SELECT is safe to construct from the returned conditions.
+ * The `u.*` references in the search predicate assume the caller's
+ * outer SQL has already joined `LEFT JOIN "user" u ON a.user_id = u.id`.
  */
 
-/**
- * Escape ILIKE special characters so they are matched literally. Inline
- * here (rather than importing from `api/routes/shared-schemas`) because
- * CLAUDE.md forbids `lib/*` from importing the route layer.
- */
+import { ACTOR_KINDS, type ActorKind } from "@atlas/api/lib/logger";
+
+/** Inlined; `lib/` cannot import the route layer. */
 function escapeIlike(s: string): string {
   return s.replace(/[%_\\]/g, "\\$&");
 }
 
-/**
- * Successful build result. `params` has `paramIdx - 1` entries when
- * `paramIdx` is the next $-placeholder the caller can use for any
- * trailing arguments (LIMIT/OFFSET on the list endpoint, LIMIT on
- * export). `conditions` always includes the `org_id` and soft-delete
- * predicates as the first two entries.
- */
+const ACTOR_KIND_SET = new Set<string>(ACTOR_KINDS);
+
+function isActorKind(value: string): value is ActorKind {
+  return ACTOR_KIND_SET.has(value);
+}
+
 export type AuditFilterOk = {
   ok: true;
   conditions: string[];
   params: unknown[];
+  /** Next free `$N` placeholder — caller appends LIMIT/OFFSET starting here. */
   paramIdx: number;
 };
 
-/**
- * Failed build — invalid filter input from the caller. The route
- * propagates `error` / `message` / `status` straight into the JSON
- * response so every 400 carries actionable copy without a second
- * round-trip through the error mapper.
- */
 export type AuditFilterErr = {
   ok: false;
   error: string;
@@ -51,11 +40,6 @@ export type AuditFilterErr = {
 
 export type AuditFilterResult = AuditFilterOk | AuditFilterErr;
 
-/**
- * Reader for query-string params. Routes pass `(k) => c.req.query(k)`;
- * tests can pass a plain Map adapter. Decoupling from Hono keeps this
- * module mock-free in unit tests.
- */
 export type QueryReader = (key: string) => string | undefined;
 
 /**
@@ -63,10 +47,10 @@ export type QueryReader = (key: string) => string | undefined;
  * `ok: false` on the first invalid input so the caller can short-
  * circuit with a 400 — no partial filtering, no silent drops.
  *
- * Keep the order: `org_id` → soft-delete → caller-supplied filters.
- * The two leading predicates pin every row to the active workspace
- * and exclude retention-purged rows; reordering breaks the index hit
- * on `idx_audit_log_org`.
+ * `org_id` is always `$1` so callers + tests can rely on a stable
+ * parameter index. The soft-delete predicate goes second so the first
+ * two conditions are always present (callers slicing or asserting on
+ * shape don't need length checks).
  */
 export function buildAuditFilters(
   orgId: string,
@@ -134,40 +118,41 @@ export function buildAuditFilters(
     params.push(column.toLowerCase());
   }
 
-  // ── #2067 — MCP filter shape ────────────────────────────────────
-  // `actorKind` is an open-ended discriminator (today: `mcp` is the
-  // only writer; `human` / `agent` / `scheduler` are reserved). We
-  // accept any non-empty string so future writers can opt in without
-  // a route-level whitelist. The frontend renders the canonical four
-  // options in the dropdown.
+  // `actorKind` is whitelisted against the canonical ActorKind set.
+  // An invalid value is a 400 rather than a silent zero-row match —
+  // mirrors the date validation contract above so callers see drift
+  // immediately instead of suspecting a permissions bug.
   const actorKind = query("actorKind");
   if (actorKind) {
+    if (!isActorKind(actorKind)) {
+      return {
+        ok: false,
+        error: "invalid_request",
+        message: `Invalid 'actorKind' value: "${actorKind}". Allowed: ${ACTOR_KINDS.join(", ")}.`,
+        status: 400,
+      };
+    }
     conditions.push(`a.actor_kind = $${paramIdx++}`);
     params.push(actorKind);
   }
 
-  // `clientId` scopes to a specific OAuth client (e.g. `claude-desktop`
-  // or a DCR UUID). Only meaningful when actorKind is `mcp`, but we
-  // don't enforce the cross-field constraint server-side — pairing
-  // them is a UI affordance.
+  // `clientId` scopes to a specific OAuth client. Only meaningful when
+  // actorKind is `mcp`, but we don't enforce that cross-field constraint
+  // server-side — pairing them is a UI affordance.
   const clientId = query("clientId");
   if (clientId) {
     conditions.push(`a.client_id = $${paramIdx++}`);
     params.push(clientId);
   }
 
-  // `tool` filters by the dispatched tool name (`executeSQL`,
-  // `runMetric`, etc). `tool_name` was populated by the MCP path in
-  // `tools.ts` / `semantic-tools.ts`; non-MCP rows have NULL and
-  // won't match — that's the right semantics for a "scope to a tool"
+  // `tool` scopes to a dispatched tool name. Non-MCP rows have NULL
+  // `tool_name` and won't match — intentional for a "scope to a tool"
   // filter.
   const tool = query("tool");
   if (tool) {
     conditions.push(`a.tool_name = $${paramIdx++}`);
     params.push(tool);
   }
-
-  // ── End #2067 filters ───────────────────────────────────────────
 
   const search = query("search");
   if (search) {

--- a/packages/api/src/lib/auth/__tests__/audit.test.ts
+++ b/packages/api/src/lib/auth/__tests__/audit.test.ts
@@ -81,6 +81,9 @@ describe("logQueryAudit()", () => {
       null, // tables_accessed
       null, // columns_accessed
       null, // org_id
+      null, // actor_kind (#2067)
+      null, // client_id (#2067)
+      null, // tool_name (#2067)
     ]);
   });
 
@@ -102,6 +105,33 @@ describe("logQueryAudit()", () => {
     expect(params[8]).toBe("warehouse");   // source_id
     expect(params[9]).toBe("postgres");    // source_type
     expect(params[10]).toBe("db.example.com"); // target_host
+  });
+
+  it("persists actor_kind / client_id / tool_name from RequestContext (#2067)", () => {
+    enableInternalDB();
+    const user: AtlasUser = { id: "u-mcp", label: "mcp@test.com", mode: "managed" };
+
+    withRequestContext(
+      {
+        requestId: "req-mcp",
+        user,
+        actor: { kind: "mcp", clientId: "claude-desktop", toolName: "executeSQL" },
+      },
+      () => {
+        logQueryAudit({
+          sql: "SELECT 1",
+          durationMs: 12,
+          rowCount: 1,
+          success: true,
+        });
+      },
+    );
+
+    expect(queryCalls).toHaveLength(1);
+    const params = queryCalls[0].params!;
+    expect(params[14]).toBe("mcp");            // actor_kind
+    expect(params[15]).toBe("claude-desktop"); // client_id
+    expect(params[16]).toBe("executeSQL");     // tool_name
   });
 
   it("does not insert when internal DB is not available", () => {

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -294,6 +294,7 @@ describe("migrateAuthTables", () => {
             { name: "0046_mcp_tokens.sql" },
             { name: "0047_drop_mcp_tokens.sql" },
             { name: "0048_trusted_device.sql" },
+            { name: "0049_audit_log_mcp_columns.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/auth/audit.ts
+++ b/packages/api/src/lib/auth/audit.ts
@@ -42,9 +42,13 @@ export function logQueryAudit(entry: AuditEntry): void {
   const userId = ctx?.user?.id ?? null;
   const userLabel = ctx?.user?.label ?? null;
   const authMode = ctx?.user?.mode ?? "none";
-  const actorKind = ctx?.actor?.kind ?? null;
-  const clientId = ctx?.actor?.clientId ?? null;
-  const toolName = ctx?.actor?.toolName ?? null;
+  const actor = ctx?.actor;
+  const actorKind = actor?.kind ?? null;
+  // The mcp branch is the only one carrying clientId / toolName — the
+  // discriminated union in `lib/logger.ts` makes this guard a type
+  // narrow rather than an ad-hoc truthy check.
+  const clientId = actor?.kind === "mcp" ? actor.clientId ?? null : null;
+  const toolName = actor?.kind === "mcp" ? actor.toolName : null;
   const scrubbedError = scrubError(entry.success ? undefined : entry.error);
 
   // Always log to pino (SQL truncated to 500 chars)

--- a/packages/api/src/lib/auth/audit.ts
+++ b/packages/api/src/lib/auth/audit.ts
@@ -42,6 +42,9 @@ export function logQueryAudit(entry: AuditEntry): void {
   const userId = ctx?.user?.id ?? null;
   const userLabel = ctx?.user?.label ?? null;
   const authMode = ctx?.user?.mode ?? "none";
+  const actorKind = ctx?.actor?.kind ?? null;
+  const clientId = ctx?.actor?.clientId ?? null;
+  const toolName = ctx?.actor?.toolName ?? null;
   const scrubbedError = scrubError(entry.success ? undefined : entry.error);
 
   // Always log to pino (SQL truncated to 500 chars)
@@ -56,6 +59,9 @@ export function logQueryAudit(entry: AuditEntry): void {
       userId,
       userLabel,
       authMode,
+      ...(actorKind && { actorKind }),
+      ...(clientId && { clientId }),
+      ...(toolName && { toolName }),
       ...(entry.sourceId && { sourceId: entry.sourceId }),
       ...(entry.sourceType && { sourceType: entry.sourceType }),
       ...(entry.targetHost && { targetHost: entry.targetHost }),
@@ -78,8 +84,8 @@ export function logQueryAudit(entry: AuditEntry): void {
   if (hasInternalDB()) {
     try {
       internalExecute(
-        `INSERT INTO audit_log (user_id, user_label, auth_mode, sql, duration_ms, row_count, success, error, source_id, source_type, target_host, tables_accessed, columns_accessed, org_id)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
+        `INSERT INTO audit_log (user_id, user_label, auth_mode, sql, duration_ms, row_count, success, error, source_id, source_type, target_host, tables_accessed, columns_accessed, org_id, actor_kind, client_id, tool_name)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
         [
           userId,
           userLabel,
@@ -95,6 +101,9 @@ export function logQueryAudit(entry: AuditEntry): void {
           entry.tablesAccessed?.length ? JSON.stringify(entry.tablesAccessed) : null,
           entry.columnsAccessed?.length ? JSON.stringify(entry.columnsAccessed) : null,
           ctx?.user?.activeOrganizationId ?? null,
+          actorKind,
+          clientId,
+          toolName,
         ],
       );
     } catch (err) {

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -79,7 +79,7 @@ describe("runMigrations", () => {
 
     const count = await runMigrations(pool);
 
-    expect(count).toBe(49);
+    expect(count).toBe(50);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -157,6 +157,7 @@ describe("runMigrations", () => {
         "0046_mcp_tokens.sql",
         "0047_drop_mcp_tokens.sql",
         "0048_trusted_device.sql",
+        "0049_audit_log_mcp_columns.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0049_audit_log_mcp_columns.sql
+++ b/packages/api/src/lib/db/migrations/0049_audit_log_mcp_columns.sql
@@ -28,15 +28,22 @@
 -- without bloating writes for the NULL-actor_kind majority. Partial
 -- WHERE clause keeps the index from indexing every legacy row.
 --
--- We deliberately do NOT add a CHECK constraint on actor_kind. The
--- value set evolves (Slack/Teams writers landing in later milestones
--- will append more discriminators); a CHECK constraint would force
--- a migration on every addition with no governance benefit.
+-- CHECK constraint pins actor_kind to the canonical four values (plus
+-- NULL for legacy / non-attributed rows). When a future writer needs a
+-- new kind, the migration is a one-line ALTER — the cost of a CHECK
+-- here (catching typos like 'mpc' before they pollute the table) beats
+-- silent-zero-rows in the admin filter when nobody notices.
 
 ALTER TABLE audit_log
   ADD COLUMN IF NOT EXISTS actor_kind TEXT,
   ADD COLUMN IF NOT EXISTS client_id  TEXT,
   ADD COLUMN IF NOT EXISTS tool_name  TEXT;
+
+DO $$ BEGIN
+  ALTER TABLE audit_log
+    ADD CONSTRAINT chk_audit_log_actor_kind
+    CHECK (actor_kind IS NULL OR actor_kind IN ('human', 'agent', 'mcp', 'scheduler'));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
 
 CREATE INDEX IF NOT EXISTS idx_audit_log_org_actor_ts
   ON audit_log (org_id, actor_kind, timestamp DESC)

--- a/packages/api/src/lib/db/migrations/0049_audit_log_mcp_columns.sql
+++ b/packages/api/src/lib/db/migrations/0049_audit_log_mcp_columns.sql
@@ -1,0 +1,47 @@
+-- 0049 — Audit-log MCP filter columns (#2067).
+--
+-- Adds three nullable columns so the admin audit surface can answer
+-- governance questions shaped around the MCP transport — "what did
+-- Claude Desktop do in my workspace last week?" — without a JSONB
+-- scan or join. Each column is independently nullable: legacy rows
+-- (and any non-MCP write path that hasn't been threaded yet) keep
+-- behaving exactly as they did pre-#2067.
+--
+-- Columns:
+--   actor_kind  — discriminator on who initiated the query. Today
+--                 only `'mcp'` is populated; `'human'` / `'agent'` /
+--                 `'scheduler'` are reserved for future writers and
+--                 left NULL until those paths thread the field. The
+--                 UI surfaces all four in the filter dropdown so the
+--                 schema doesn't drift when later writers come online.
+--   client_id   — OAuth client_id (e.g. `claude-desktop`, a DCR UUID)
+--                 for hosted-MCP rows. NULL for stdio MCP and every
+--                 non-MCP row.
+--   tool_name   — MCP tool dispatched (`executeSQL` / `runMetric` /
+--                 etc). NULL for non-MCP rows.
+--
+-- All three are nullable with no default so existing rows stay
+-- untouched — no rewrite, no I/O storm on the migration.
+--
+-- Index choice: btree on (org_id, actor_kind, timestamp DESC) covers
+-- the hot filter path — "MCP rows in this workspace, newest first" —
+-- without bloating writes for the NULL-actor_kind majority. Partial
+-- WHERE clause keeps the index from indexing every legacy row.
+--
+-- We deliberately do NOT add a CHECK constraint on actor_kind. The
+-- value set evolves (Slack/Teams writers landing in later milestones
+-- will append more discriminators); a CHECK constraint would force
+-- a migration on every addition with no governance benefit.
+
+ALTER TABLE audit_log
+  ADD COLUMN IF NOT EXISTS actor_kind TEXT,
+  ADD COLUMN IF NOT EXISTS client_id  TEXT,
+  ADD COLUMN IF NOT EXISTS tool_name  TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_org_actor_ts
+  ON audit_log (org_id, actor_kind, timestamp DESC)
+  WHERE actor_kind IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_client_id
+  ON audit_log (client_id)
+  WHERE client_id IS NOT NULL;

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -73,6 +73,7 @@ export const auditLog = pgTable(
     index("idx_audit_log_org_actor_ts").on(t.orgId, t.actorKind, t.timestamp.desc())
       .where(sql`actor_kind IS NOT NULL`),
     index("idx_audit_log_client_id").on(t.clientId).where(sql`client_id IS NOT NULL`),
+    check("chk_audit_log_actor_kind", sql`actor_kind IS NULL OR actor_kind IN ('human', 'agent', 'mcp', 'scheduler')`),
   ],
 );
 

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -56,6 +56,11 @@ export const auditLog = pgTable(
     orgId: text("org_id"),
     // Soft-delete (retention purge)
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
+    // #2067 — MCP filter discriminators. NULL for non-MCP rows; today
+    // only the MCP transport populates these. See migration 0049.
+    actorKind: text("actor_kind"),
+    clientId: text("client_id"),
+    toolName: text("tool_name"),
   },
   (t) => [
     index("idx_audit_log_timestamp").on(t.timestamp),
@@ -65,6 +70,9 @@ export const auditLog = pgTable(
     index("idx_audit_log_columns_accessed").using("gin", t.columnsAccessed),
     index("idx_audit_log_org").on(t.orgId),
     index("idx_audit_log_deleted_at").on(t.deletedAt).where(sql`deleted_at IS NOT NULL`),
+    index("idx_audit_log_org_actor_ts").on(t.orgId, t.actorKind, t.timestamp.desc())
+      .where(sql`actor_kind IS NOT NULL`),
+    index("idx_audit_log_client_id").on(t.clientId).where(sql`client_id IS NOT NULL`),
   ],
 );
 

--- a/packages/api/src/lib/logger.ts
+++ b/packages/api/src/lib/logger.ts
@@ -15,6 +15,23 @@ import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 
 // --- Request context ---
 
+/**
+ * Discriminator on who initiated the request, threaded through audit_log
+ * via #2067. Only `mcp` is wired today — `human` / `agent` / `scheduler`
+ * are reserved values that future writer paths can opt into without a
+ * schema change. The audit-log filter UI surfaces all four; rows that
+ * never set `actor` write NULL and stay invisible to actor-scoped filters.
+ */
+export type ActorKind = "human" | "agent" | "mcp" | "scheduler";
+
+export interface RequestActor {
+  kind: ActorKind;
+  /** Hosted-MCP OAuth client_id (e.g. `claude-desktop`, a DCR UUID). Stdio MCP leaves this undefined. */
+  clientId?: string;
+  /** MCP tool dispatched (`executeSQL`, `runMetric`, etc). Only meaningful when `kind === "mcp"`. */
+  toolName?: string;
+}
+
 interface RequestContext {
   requestId: string;
   user?: AtlasUser;
@@ -22,6 +39,8 @@ interface RequestContext {
   atlasMode?: import("@useatlas/types/auth").AtlasMode;
   /** See `lib/auth/trust-device-cookie.ts`. Surfaced into `admin_action_log` metadata via `logAdminAction`. */
   trustDeviceIdentifier?: string;
+  /** #2067 — request-shape discriminator persisted to `audit_log.{actor_kind, client_id, tool_name}`. */
+  actor?: RequestActor;
 }
 
 const requestStore = new AsyncLocalStorage<RequestContext>();

--- a/packages/api/src/lib/logger.ts
+++ b/packages/api/src/lib/logger.ts
@@ -17,20 +17,29 @@ import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 
 /**
  * Discriminator on who initiated the request, threaded through audit_log
- * via #2067. Only `mcp` is wired today — `human` / `agent` / `scheduler`
- * are reserved values that future writer paths can opt into without a
- * schema change. The audit-log filter UI surfaces all four; rows that
- * never set `actor` write NULL and stay invisible to actor-scoped filters.
+ * via #2067. Only `mcp` is wired today; `human` / `agent` / `scheduler`
+ * are reserved for future writer paths to opt into without a schema
+ * change. Rows that never set `actor` write NULL and stay invisible to
+ * actor-scoped filters.
+ *
+ * Modeled as a discriminated union so `clientId` / `toolName` are only
+ * reachable on the `mcp` branch — the type system enforces the
+ * "client_id only for mcp" invariant the migration's column shape
+ * implies, and `audit.ts` can stamp the columns without per-field
+ * truthy guards.
  */
-export type ActorKind = "human" | "agent" | "mcp" | "scheduler";
+export const ACTOR_KINDS = ["human", "agent", "mcp", "scheduler"] as const;
+export type ActorKind = (typeof ACTOR_KINDS)[number];
 
-export interface RequestActor {
-  kind: ActorKind;
-  /** Hosted-MCP OAuth client_id (e.g. `claude-desktop`, a DCR UUID). Stdio MCP leaves this undefined. */
-  clientId?: string;
-  /** MCP tool dispatched (`executeSQL`, `runMetric`, etc). Only meaningful when `kind === "mcp"`. */
-  toolName?: string;
-}
+export type RequestActor =
+  | { kind: "human" | "agent" | "scheduler" }
+  | {
+      kind: "mcp";
+      /** Hosted-MCP OAuth client_id (e.g. `claude-desktop`, a DCR UUID). Stdio MCP leaves this undefined. */
+      clientId?: string;
+      /** MCP tool dispatched (`executeSQL`, `runMetric`, etc). Required because every dispatch site is named. */
+      toolName: string;
+    };
 
 interface RequestContext {
   requestId: string;

--- a/packages/mcp/src/__tests__/semantic-tools.test.ts
+++ b/packages/mcp/src/__tests__/semantic-tools.test.ts
@@ -103,13 +103,14 @@ function getContentText(content: unknown): string {
   return arr[0]?.text ?? "";
 }
 
-async function createTestClient(actor = TEST_ACTOR) {
+async function createTestClient(actor = TEST_ACTOR, clientId?: string) {
   const server = new McpServer({ name: "test", version: "0.0.1" });
   registerSemanticTools(server, {
     actor,
     transport: "stdio",
     workspaceId: actor.activeOrganizationId ?? actor.id,
     deployMode: "self-hosted",
+    ...(clientId ? { clientId } : {}),
   });
 
   const client = new Client({ name: "test-client", version: "0.0.1" });
@@ -685,5 +686,78 @@ describe("MCP semantic tools", () => {
 
     expect(observed).toBeDefined();
     expect(observed!.user?.id).toBe(TEST_ACTOR.id);
+  });
+
+  // #2067 — every semantic-tool dispatch must stamp `actor: { kind: "mcp",
+  // toolName }` so audit_log.{actor_kind, tool_name} populates regardless of
+  // which tool the caller picks. Pinning each tool individually catches a
+  // regression where one dispatch loses the wrap during a refactor.
+  it("runMetric stamps actor: mcp + toolName", async () => {
+    let observed: ReturnType<typeof getRequestContext>;
+    mockExecuteSQLExecute.mockImplementationOnce(async () => {
+      observed = getRequestContext();
+      return { success: true, explanation: "ok", row_count: 0, columns: [], rows: [] };
+    });
+
+    const { client } = await createTestClient();
+    await client.callTool({ name: "runMetric", arguments: { id: "orders_count" } });
+
+    expect(observed!.actor).toEqual({ kind: "mcp", toolName: "runMetric" });
+  });
+
+  it("listEntities stamps actor: mcp + toolName", async () => {
+    let observed: ReturnType<typeof getRequestContext>;
+    mockListEntities.mockImplementationOnce(() => {
+      observed = getRequestContext();
+      return [];
+    });
+
+    const { client } = await createTestClient();
+    await client.callTool({ name: "listEntities", arguments: {} });
+
+    expect(observed!.actor).toEqual({ kind: "mcp", toolName: "listEntities" });
+  });
+
+  it("describeEntity stamps actor: mcp + toolName", async () => {
+    let observed: ReturnType<typeof getRequestContext>;
+    mockGetEntityByName.mockImplementationOnce(() => {
+      observed = getRequestContext();
+      return null;
+    });
+
+    const { client } = await createTestClient();
+    await client.callTool({ name: "describeEntity", arguments: { name: "orders" } });
+
+    expect(observed!.actor).toEqual({ kind: "mcp", toolName: "describeEntity" });
+  });
+
+  it("searchGlossary stamps actor: mcp + toolName", async () => {
+    let observed: ReturnType<typeof getRequestContext>;
+    mockSearchGlossary.mockImplementationOnce(() => {
+      observed = getRequestContext();
+      return [];
+    });
+
+    const { client } = await createTestClient();
+    await client.callTool({ name: "searchGlossary", arguments: { term: "ARR" } });
+
+    expect(observed!.actor).toEqual({ kind: "mcp", toolName: "searchGlossary" });
+  });
+
+  it("threads clientId through registerSemanticTools into RequestContext.actor", async () => {
+    let observed: ReturnType<typeof getRequestContext>;
+    mockExecuteSQLExecute.mockImplementationOnce(async () => {
+      observed = getRequestContext();
+      return { success: true, explanation: "ok", row_count: 0, columns: [], rows: [] };
+    });
+
+    const { client } = await createTestClient(TEST_ACTOR, "claude-desktop");
+    await client.callTool({ name: "runMetric", arguments: { id: "orders_count" } });
+
+    expect(observed!.actor).toEqual({
+      kind: "mcp",
+      clientId: "claude-desktop",
+      toolName: "runMetric",
+    });
   });
 });

--- a/packages/mcp/src/__tests__/server.test.ts
+++ b/packages/mcp/src/__tests__/server.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, mock } from "bun:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createAtlasUser } from "@atlas/api/lib/auth/types";
+import { getRequestContext } from "@atlas/api/lib/logger";
 import pkg from "../../package.json" with { type: "json" };
 
 // Server tests inject the actor directly so they don't depend on
@@ -149,5 +150,39 @@ describe("MCP server integration", () => {
 
     await createAtlasMcpServer({ skipConfig: true, actor: TEST_ACTOR });
     expect(mockFn).not.toHaveBeenCalled();
+  });
+
+  // #2067 — hosted MCP threads `bindFactoryContext.clientId` →
+  // `createAtlasMcpServer({ clientId })` → `RequestContext.actor.clientId`
+  // → `audit_log.client_id`. The hosted-route plumbing is exercised in
+  // hosted.test.ts; this test pins the server-factory leg so a regression
+  // that drops the `clientId` field on `CreateMcpServerOptions` is caught
+  // even if hosted.ts continues to set `mcp_session.start.metadata.clientId`.
+  it("threads clientId from createAtlasMcpServer into RequestContext.actor", async () => {
+    let observed: ReturnType<typeof getRequestContext>;
+    const { explore } = await import("@atlas/api/lib/tools/explore");
+    const exploreExecuteMock = explore.execute as ReturnType<typeof mock>;
+    exploreExecuteMock.mockImplementationOnce(async () => {
+      observed = getRequestContext();
+      return "ok";
+    });
+
+    const server = await createAtlasMcpServer({
+      actor: TEST_ACTOR,
+      skipConfig: true,
+      clientId: "claude-desktop",
+    });
+    const client = new Client({ name: "test-client", version: "0.0.1" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    await client.callTool({ name: "explore", arguments: { command: "ls" } });
+
+    expect(observed!.actor).toEqual({
+      kind: "mcp",
+      clientId: "claude-desktop",
+      toolName: "explore",
+    });
   });
 });

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -49,9 +49,9 @@ function getContentText(content: unknown): string {
   return arr[0]?.text ?? "";
 }
 
-async function createTestClient(actor = TEST_ACTOR) {
+async function createTestClient(actor = TEST_ACTOR, clientId?: string) {
   const server = new McpServer({ name: "test", version: "0.0.1" });
-  registerTools(server, { actor });
+  registerTools(server, { actor, ...(clientId ? { clientId } : {}) });
 
   const client = new Client({ name: "test-client", version: "0.0.1" });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -514,6 +514,60 @@ describe("MCP tools", () => {
 
     expect(observed).toBeDefined();
     expect(observed!.user?.id).toBe(TEST_ACTOR.id);
+  });
+
+  // #2067 — every tool dispatch must stamp `actor: { kind: "mcp", toolName }`
+  // on the request context so `audit_log.{actor_kind, tool_name}` is populated.
+  // A regression that drops the third arg from any single `withRequestContext`
+  // call would invisibly NULL out those columns for that tool — these tests
+  // pin the wrap shape per dispatch site.
+  it("executeSQL stamps actor: mcp + toolName on RequestContext", async () => {
+    let observed: ReturnType<typeof getRequestContext>;
+    mockExecuteSQLExecute.mockImplementationOnce(async () => {
+      observed = getRequestContext();
+      return { success: true, explanation: "noop", row_count: 0, columns: [], rows: [] };
+    });
+
+    const { client } = await createTestClient();
+    await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "SELECT 1", explanation: "actor probe" },
+    });
+
+    expect(observed!.actor).toEqual({ kind: "mcp", toolName: "executeSQL" });
+  });
+
+  it("explore stamps actor: mcp + toolName on RequestContext", async () => {
+    let observed: ReturnType<typeof getRequestContext>;
+    mockExploreExecute.mockImplementationOnce(async () => {
+      observed = getRequestContext();
+      return "ls output";
+    });
+
+    const { client } = await createTestClient();
+    await client.callTool({ name: "explore", arguments: { command: "ls" } });
+
+    expect(observed!.actor).toEqual({ kind: "mcp", toolName: "explore" });
+  });
+
+  it("threads clientId through registerTools into RequestContext.actor", async () => {
+    let observed: ReturnType<typeof getRequestContext>;
+    mockExecuteSQLExecute.mockImplementationOnce(async () => {
+      observed = getRequestContext();
+      return { success: true, explanation: "noop", row_count: 0, columns: [], rows: [] };
+    });
+
+    const { client } = await createTestClient(TEST_ACTOR, "claude-desktop");
+    await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "SELECT 1", explanation: "clientId probe" },
+    });
+
+    expect(observed!.actor).toEqual({
+      kind: "mcp",
+      clientId: "claude-desktop",
+      toolName: "executeSQL",
+    });
   });
 
 });

--- a/packages/mcp/src/hosted.ts
+++ b/packages/mcp/src/hosted.ts
@@ -619,6 +619,10 @@ async function createBoundMcpServer(
     actor: ctx.user,
     transport: "sse",
     skipConfig: true,
+    // #2067 — surface the registered OAuth client_id into
+    // `audit_log.client_id` so the admin filter can scope to "rows from
+    // claude-desktop" without joining on token tables.
+    clientId: ctx.clientId,
   });
 }
 

--- a/packages/mcp/src/semantic-tools.ts
+++ b/packages/mcp/src/semantic-tools.ts
@@ -91,6 +91,8 @@ export interface RegisterSemanticToolsOptions {
   workspaceId: string;
   /** Resolved `deployMode` for OTel attribution (`self-hosted` / `saas`). */
   deployMode: McpDeployMode;
+  /** Hosted-MCP OAuth client_id, surfaced into `audit_log.client_id` (#2067). */
+  clientId?: string;
 }
 
 function dispatchId(prefix: string): string {
@@ -128,7 +130,15 @@ export function registerSemanticTools(
   server: McpServer,
   opts: RegisterSemanticToolsOptions,
 ): void {
-  const { actor, transport, workspaceId, deployMode } = opts;
+  const { actor, transport, workspaceId, deployMode, clientId } = opts;
+  // #2067 — wrap each dispatch with the same actor shape as tools.ts. The
+  // `mcp` actor_kind / clientId / toolName trail through `logQueryAudit`
+  // so admins can scope `audit_log` rows to a specific MCP tool/client.
+  const mcpActor = (toolName: string) => ({
+    kind: "mcp" as const,
+    ...(clientId ? { clientId } : {}),
+    toolName,
+  });
 
   // --- listEntities ---
   server.registerTool(
@@ -151,7 +161,7 @@ export function registerSemanticTools(
         { toolName: "listEntities", workspaceId, transport, deployMode },
         () => {
           const requestId = dispatchId("mcp-listEntities");
-          return withRequestContext({ requestId, user: actor }, async () => {
+          return withRequestContext({ requestId, user: actor, actor: mcpActor("listEntities") }, async () => {
             try {
               const entities = listEntities({ filter });
               return toJsonContent({ count: entities.length, entities });
@@ -189,7 +199,7 @@ export function registerSemanticTools(
         { toolName: "describeEntity", workspaceId, transport, deployMode },
         () => {
           const requestId = dispatchId("mcp-describeEntity");
-          return withRequestContext({ requestId, user: actor }, async () => {
+          return withRequestContext({ requestId, user: actor, actor: mcpActor("describeEntity") }, async () => {
             try {
               const entity = getEntityByName(name);
               if (!entity) {
@@ -240,7 +250,7 @@ export function registerSemanticTools(
         { toolName: "searchGlossary", workspaceId, transport, deployMode },
         () => {
           const requestId = dispatchId("mcp-searchGlossary");
-          return withRequestContext({ requestId, user: actor }, async () => {
+          return withRequestContext({ requestId, user: actor, actor: mcpActor("searchGlossary") }, async () => {
             try {
               const matches = searchGlossary(term);
 
@@ -346,7 +356,7 @@ export function registerSemanticTools(
         },
         () => {
           const requestId = dispatchId("mcp-runMetric");
-          return withRequestContext({ requestId, user: actor }, async () => {
+          return withRequestContext({ requestId, user: actor, actor: mcpActor("runMetric") }, async () => {
             try {
               if (filters && Object.keys(filters).length > 0) {
                 return toEnvelopeResult(

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -40,6 +40,11 @@ interface CreateMcpServerOptions {
    * dispatch. Defaults to `stdio`.
    */
   transport?: McpTransport;
+  /**
+   * Hosted-MCP OAuth client_id, threaded into `audit_log.client_id` via
+   * `RequestContext.actor.clientId` (#2067). Stdio MCP leaves this unset.
+   */
+  clientId?: string;
 }
 
 /**
@@ -71,13 +76,14 @@ export async function createAtlasMcpServer(
 
   const actor = opts?.actor ?? (await resolveMcpActor());
   const transport: McpTransport = opts?.transport ?? "stdio";
+  const clientId = opts?.clientId;
 
   const server = new McpServer({
     name: "atlas",
     version: VERSION,
   });
 
-  registerTools(server, { actor, transport });
+  registerTools(server, { actor, transport, clientId });
   registerResources(server);
   await registerPrompts(server);
 

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -60,6 +60,12 @@ export interface RegisterToolsOptions {
    * to `stdio`. See #2029.
    */
   transport?: McpTransport;
+  /**
+   * Hosted-MCP OAuth client_id, surfaced into `audit_log.client_id` via
+   * `RequestContext.actor.clientId` so the admin audit filter can scope
+   * by registered OAuth client (#2067). Stdio MCP leaves this undefined.
+   */
+  clientId?: string;
 }
 
 function dispatchId(prefix: string): string {
@@ -103,9 +109,17 @@ const EXECUTE_SQL_ERROR_CODES = [
 ] as const;
 
 export function registerTools(server: McpServer, opts: RegisterToolsOptions): void {
-  const { actor, transport = "stdio" } = opts;
+  const { actor, transport = "stdio", clientId } = opts;
   const workspaceId = workspaceIdOf(actor);
   const deployMode = deployModeOf();
+  // #2067 — every MCP tool dispatch wraps in the same `actor` shape so
+  // `audit_log.{actor_kind, client_id, tool_name}` is populated regardless
+  // of which tool the caller picks. `clientId` stays undefined for stdio.
+  const mcpActor = (toolName: string) => ({
+    kind: "mcp" as const,
+    ...(clientId ? { clientId } : {}),
+    toolName,
+  });
 
   // --- explore ---
   server.registerTool(
@@ -126,7 +140,7 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
         { toolName: "explore", workspaceId, transport, deployMode },
         () => {
           const requestId = dispatchId("mcp-explore");
-          return withRequestContext({ requestId, user: actor }, async () => {
+          return withRequestContext({ requestId, user: actor, actor: mcpActor("explore") }, async () => {
             try {
               const result = await explore.execute!(
                 { command },
@@ -190,7 +204,7 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
         { toolName: "executeSQL", workspaceId, transport, deployMode },
         () => {
           const requestId = dispatchId("mcp-executeSQL");
-          return withRequestContext({ requestId, user: actor }, async () => {
+          return withRequestContext({ requestId, user: actor, actor: mcpActor("executeSQL") }, async () => {
             try {
               const result = await executeSQL.execute!(
                 { sql, explanation, connectionId },
@@ -280,5 +294,5 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
   );
 
   // --- typed semantic-layer tools ---
-  registerSemanticTools(server, { actor, transport, workspaceId, deployMode });
+  registerSemanticTools(server, { actor, transport, workspaceId, deployMode, clientId });
 }

--- a/packages/web/src/app/admin/audit/page.tsx
+++ b/packages/web/src/app/admin/audit/page.tsx
@@ -29,7 +29,13 @@ import { AdminActionRetentionPanel } from "./admin-action-retention-panel";
 import { Separator } from "@/components/ui/separator";
 import { useAdminFetch, type FetchError } from "@/ui/hooks/use-admin-fetch";
 import { extractFetchError } from "@/ui/lib/fetch-error";
-import { AuditStatsSchema, AuditFacetsSchema, AuditConnectionMetaSchema } from "@/ui/lib/admin-schemas";
+import {
+  AuditStatsSchema,
+  AuditFacetsSchema,
+  AuditConnectionMetaSchema,
+  AuditOAuthClientsSchema,
+} from "@/ui/lib/admin-schemas";
+import { AuditFilterBar, type ActorKindFilter } from "@/ui/components/admin/audit/filter-bar";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
@@ -45,6 +51,9 @@ interface AuditQueryParams {
   status: string;
   from: string;
   to: string;
+  actorKind: string;
+  clientId: string;
+  tool: string;
   sortId?: string;
   sortDesc?: boolean;
 }
@@ -63,6 +72,9 @@ function buildQueryString(p: AuditQueryParams, opts?: { noPagination?: boolean }
   if (p.status === "error") qs.set("success", "false");
   if (p.from) qs.set("from", p.from);
   if (p.to) qs.set("to", p.to);
+  if (p.actorKind) qs.set("actorKind", p.actorKind);
+  if (p.clientId) qs.set("clientId", p.clientId);
+  if (p.tool) qs.set("tool", p.tool);
   if (p.sortId) {
     qs.set("sort", p.sortId);
     qs.set("order", p.sortDesc ? "desc" : "asc");
@@ -82,7 +94,19 @@ export default function AuditPage() {
   const [exporting, setExporting] = useState(false);
 
   const [params, setParams] = useQueryStates(auditSearchParams);
-  const { tab, search, connection, table: tableFilter, column: columnFilter, status, from, to } = params;
+  const {
+    tab,
+    search,
+    connection,
+    table: tableFilter,
+    column: columnFilter,
+    status,
+    from,
+    to,
+    actorKind,
+    clientId,
+    tool,
+  } = params;
 
   // Analytics date range (separate from log tab filters)
   const [analyticsFrom, setAnalyticsFrom] = useState("");
@@ -100,6 +124,16 @@ export default function AuditPage() {
     "/api/v1/admin/audit/facets",
     { schema: AuditFacetsSchema },
   );
+
+  // OAuth clients for the MCP actor's clientId dropdown (#2067).
+  // Fetched lazily — useAdminFetch streams in parallel with the audit
+  // list. If this fails the filter bar falls back to a free-text input
+  // so an admin pasting a known client_id is never blocked.
+  const { data: oauthClientsData } = useAdminFetch(
+    "/api/v1/admin/oauth-clients",
+    { schema: AuditOAuthClientsSchema },
+  );
+  const oauthClients = oauthClientsData?.clients ?? [];
   if (facetsError && !facetsError.status) {
     // Log client-side so devs can diagnose why dropdowns fell back to text inputs
     console.warn("Audit facets fetch failed:", facetsError.message);
@@ -145,7 +179,7 @@ export default function AuditPage() {
   const sortDesc = sorting[0]?.desc;
 
   const queryParams: AuditQueryParams = {
-    pageSize, offset, search, connection, tableFilter, columnFilter, status, from, to, sortId, sortDesc,
+    pageSize, offset, search, connection, tableFilter, columnFilter, status, from, to, actorKind, clientId, tool, sortId, sortDesc,
   };
 
   // Fetch rows on mount and when table state changes (only for log tab)
@@ -181,7 +215,7 @@ export default function AuditPage() {
     }
     fetchRows();
     return () => { cancelled = true; };
-  }, [apiUrl, offset, pageSize, search, connection, tableFilter, columnFilter, status, from, to, sortId, sortDesc, tab, credentials]);
+  }, [apiUrl, offset, pageSize, search, connection, tableFilter, columnFilter, status, from, to, actorKind, clientId, tool, sortId, sortDesc, tab, credentials]);
 
   async function handleExport() {
     setExporting(true);
@@ -220,10 +254,24 @@ export default function AuditPage() {
     }
   }
 
-  const hasFilters = !!(search || connection || tableFilter || columnFilter || status || from || to);
+  const hasFilters = !!(
+    search || connection || tableFilter || columnFilter || status || from || to ||
+    actorKind || clientId || tool
+  );
 
   function clearFilters() {
-    setParams({ search: "", connection: "", table: "", column: "", status: "", from: "", to: "" });
+    setParams({
+      search: "",
+      connection: "",
+      table: "",
+      column: "",
+      status: "",
+      from: "",
+      to: "",
+      actorKind: "",
+      clientId: "",
+      tool: "",
+    });
   }
 
   return (
@@ -438,6 +486,14 @@ export default function AuditPage() {
                 <SelectItem value="error">Error</SelectItem>
               </SelectContent>
             </Select>
+
+            <AuditFilterBar
+              actorKind={actorKind as ActorKindFilter}
+              clientId={clientId}
+              tool={tool}
+              clientOptions={oauthClients}
+              onChange={(next) => setParams(next)}
+            />
 
             <div className="space-y-0">
               <Input

--- a/packages/web/src/app/admin/audit/page.tsx
+++ b/packages/web/src/app/admin/audit/page.tsx
@@ -125,14 +125,17 @@ export default function AuditPage() {
     { schema: AuditFacetsSchema },
   );
 
-  // OAuth clients for the MCP actor's clientId dropdown (#2067).
-  // Fetched lazily — useAdminFetch streams in parallel with the audit
-  // list. If this fails the filter bar falls back to a free-text input
-  // so an admin pasting a known client_id is never blocked.
-  const { data: oauthClientsData } = useAdminFetch(
+  // OAuth clients for the MCP `clientId` dropdown; the filter bar
+  // falls back to free text if the fetch fails.
+  const { data: oauthClientsData, error: oauthClientsError } = useAdminFetch(
     "/api/v1/admin/oauth-clients",
     { schema: AuditOAuthClientsSchema },
   );
+  if (oauthClientsError && !oauthClientsError.status) {
+    // Mirror the facetsError pattern: log transient failures so devs
+    // can diagnose why the dropdown collapsed to a text input.
+    console.warn("Audit OAuth-clients fetch failed:", oauthClientsError.message);
+  }
   const oauthClients = oauthClientsData?.clients ?? [];
   if (facetsError && !facetsError.status) {
     // Log client-side so devs can diagnose why dropdowns fell back to text inputs

--- a/packages/web/src/app/admin/audit/search-params.ts
+++ b/packages/web/src/app/admin/audit/search-params.ts
@@ -2,12 +2,10 @@ import { parseAsString, parseAsStringLiteral } from "nuqs"
 
 const auditTabs = ["log", "analytics", "retention"] as const
 
-// #2067 — `actorKind` matches the audit_log column shape. The empty
-// literal `""` represents the "All actors" default and is not a stored
-// row value. Keeping the parser as a string-literal union (rather than
-// a free `parseAsString`) keeps the URL bookmarkable + drift-safe: an
-// invalid `?actorKind=robot` reverts to "" instead of poisoning a SQL
-// `WHERE actor_kind = 'robot'` that would silently return 0 rows.
+// `actorKind` is parsed as a string-literal union so an invalid
+// `?actorKind=robot` reverts to "" — the route also rejects invalid
+// values with a 400, but the parser keeps a stale URL from issuing a
+// pointless round-trip. The empty literal represents "All actors".
 const actorKinds = ["", "human", "agent", "mcp", "scheduler"] as const
 
 export const auditSearchParams = {

--- a/packages/web/src/app/admin/audit/search-params.ts
+++ b/packages/web/src/app/admin/audit/search-params.ts
@@ -2,6 +2,14 @@ import { parseAsString, parseAsStringLiteral } from "nuqs"
 
 const auditTabs = ["log", "analytics", "retention"] as const
 
+// #2067 — `actorKind` matches the audit_log column shape. The empty
+// literal `""` represents the "All actors" default and is not a stored
+// row value. Keeping the parser as a string-literal union (rather than
+// a free `parseAsString`) keeps the URL bookmarkable + drift-safe: an
+// invalid `?actorKind=robot` reverts to "" instead of poisoning a SQL
+// `WHERE actor_kind = 'robot'` that would silently return 0 rows.
+const actorKinds = ["", "human", "agent", "mcp", "scheduler"] as const
+
 export const auditSearchParams = {
   tab: parseAsStringLiteral(auditTabs).withDefault("log"),
   search: parseAsString.withDefault(""),
@@ -11,4 +19,7 @@ export const auditSearchParams = {
   status: parseAsStringLiteral(["success", "error", ""] as const).withDefault(""),
   from: parseAsString.withDefault(""),
   to: parseAsString.withDefault(""),
+  actorKind: parseAsStringLiteral(actorKinds).withDefault(""),
+  clientId: parseAsString.withDefault(""),
+  tool: parseAsString.withDefault(""),
 }

--- a/packages/web/src/ui/__tests__/audit-filter-bar.test.tsx
+++ b/packages/web/src/ui/__tests__/audit-filter-bar.test.tsx
@@ -15,7 +15,7 @@
 
 import { describe, expect, test, mock } from "bun:test";
 import { render, fireEvent } from "@testing-library/react";
-import { AuditFilterBar } from "../components/admin/audit/filter-bar";
+import { AuditFilterBar, actorKindUpdate } from "../components/admin/audit/filter-bar";
 
 function noop() {}
 
@@ -118,5 +118,38 @@ describe("AuditFilterBar", () => {
     fireEvent.change(input, { target: { value: "custom-dcr-uuid" } });
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange.mock.calls[0]![0]).toEqual({ clientId: "custom-dcr-uuid" });
+  });
+});
+
+// `actorKindUpdate` is the pure decision function the Select trigger calls.
+// Driving Radix Select through jsdom is fragile, so the load-bearing
+// "switch away from MCP clears the follow-ups" branch is exercised via
+// the helper directly. A regression that flattens the branch (e.g.
+// always emitting `{ actorKind: next }`) fails these tests.
+describe("actorKindUpdate", () => {
+  test("clears clientId + tool when switching away from MCP with stale follow-ups", () => {
+    expect(actorKindUpdate("human", "claude-desktop", "runMetric")).toEqual({
+      actorKind: "human",
+      clientId: "",
+      tool: "",
+    });
+  });
+
+  test("emits only actorKind when follow-ups are already empty", () => {
+    expect(actorKindUpdate("human", "", "")).toEqual({ actorKind: "human" });
+  });
+
+  test("does NOT clear when staying on MCP (e.g. MCP→MCP no-op)", () => {
+    expect(actorKindUpdate("mcp", "claude-desktop", "runMetric")).toEqual({
+      actorKind: "mcp",
+    });
+  });
+
+  test("clears when switching to the empty 'All actors' value", () => {
+    expect(actorKindUpdate("", "claude-desktop", "")).toEqual({
+      actorKind: "",
+      clientId: "",
+      tool: "",
+    });
   });
 });

--- a/packages/web/src/ui/__tests__/audit-filter-bar.test.tsx
+++ b/packages/web/src/ui/__tests__/audit-filter-bar.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Filter-bar component tests for the audit-log MCP filter (#2067).
+ *
+ * Pinned behaviors:
+ *   1. The MCP follow-up fields (clientId / tool) are hidden when
+ *      actorKind is anything other than "mcp" — the discriminated-
+ *      union UI must not leak invalid state into the URL.
+ *   2. Selecting actorKind=mcp reveals exactly two extra fields.
+ *   3. The clientId input gracefully falls back to free-text when
+ *      the OAuth-clients fetch returned an empty list — admins
+ *      pasting a known DCR UUID must not be blocked.
+ *   4. Typing in the tool / clientId text inputs propagates a
+ *      partial-update via onChange.
+ */
+
+import { describe, expect, test, mock } from "bun:test";
+import { render, fireEvent } from "@testing-library/react";
+import { AuditFilterBar } from "../components/admin/audit/filter-bar";
+
+function noop() {}
+
+describe("AuditFilterBar", () => {
+  test("does NOT render clientId or tool fields when actorKind is empty", () => {
+    const { container } = render(
+      <AuditFilterBar
+        actorKind=""
+        clientId=""
+        tool=""
+        clientOptions={[]}
+        onChange={noop}
+      />,
+    );
+    expect(container.querySelector('[aria-label="Filter by OAuth client"]')).toBeNull();
+    expect(container.querySelector('[aria-label="Filter by MCP tool"]')).toBeNull();
+  });
+
+  test("does NOT render MCP follow-ups for non-MCP actor kinds", () => {
+    const { container } = render(
+      <AuditFilterBar
+        actorKind="human"
+        clientId=""
+        tool=""
+        clientOptions={[]}
+        onChange={noop}
+      />,
+    );
+    expect(container.querySelector('[aria-label="Filter by OAuth client"]')).toBeNull();
+    expect(container.querySelector('[aria-label="Filter by MCP tool"]')).toBeNull();
+  });
+
+  test("reveals clientId + tool fields when actorKind=mcp", () => {
+    const { container } = render(
+      <AuditFilterBar
+        actorKind="mcp"
+        clientId=""
+        tool=""
+        clientOptions={[
+          { clientId: "claude-desktop", clientName: "Claude Desktop" },
+        ]}
+        onChange={noop}
+      />,
+    );
+    expect(container.querySelector('[aria-label="Filter by OAuth client"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label="Filter by MCP tool"]')).not.toBeNull();
+  });
+
+  test("falls back to a free-text clientId input when no OAuth clients exist", () => {
+    const { container } = render(
+      <AuditFilterBar
+        actorKind="mcp"
+        clientId=""
+        tool=""
+        clientOptions={[]}
+        onChange={noop}
+      />,
+    );
+    const clientField = container.querySelector('[aria-label="Filter by OAuth client"]');
+    expect(clientField).not.toBeNull();
+    // The fallback is an `<input>`; the populated dropdown renders a
+    // Radix Select trigger (`<button role="combobox">`). Asserting the
+    // tag name pins the right branch was rendered.
+    expect(clientField?.tagName).toBe("INPUT");
+  });
+
+  test("typing in the tool text input propagates a partial onChange", () => {
+    const onChange = mock((_args: Record<string, unknown>) => {});
+    const { container } = render(
+      <AuditFilterBar
+        actorKind="mcp"
+        clientId=""
+        tool=""
+        clientOptions={[]}
+        onChange={onChange}
+      />,
+    );
+    const input = container.querySelector(
+      '[aria-label="Filter by MCP tool"]',
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "runMetric" } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0]![0]).toEqual({ tool: "runMetric" });
+  });
+
+  test("typing in the clientId fallback input propagates a partial onChange", () => {
+    const onChange = mock((_args: Record<string, unknown>) => {});
+    const { container } = render(
+      <AuditFilterBar
+        actorKind="mcp"
+        clientId=""
+        tool=""
+        clientOptions={[]}
+        onChange={onChange}
+      />,
+    );
+    const input = container.querySelector(
+      '[aria-label="Filter by OAuth client"]',
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "custom-dcr-uuid" } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0]![0]).toEqual({ clientId: "custom-dcr-uuid" });
+  });
+});

--- a/packages/web/src/ui/components/admin/audit/filter-bar.tsx
+++ b/packages/web/src/ui/components/admin/audit/filter-bar.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+/**
+ * Audit-log filter bar (#2067).
+ *
+ * Renders the `actorKind` discriminator dropdown + the MCP-only
+ * `clientId` and `tool` follow-up fields. Lifted out of `audit/page.tsx`
+ * so the discriminated-union UI is independently testable — the page
+ * is too dense (600 LOC of stat cards, tabs, retention panel) to mount
+ * end-to-end just to verify "Actor=MCP reveals two extra fields".
+ *
+ * Contract:
+ *   - Pure controlled component. URL state lives in the parent's
+ *     `useQueryStates(auditSearchParams)`; we never read or write
+ *     `nuqs` directly so the filter bar can be reused under a
+ *     different state container if the audit page ever splits.
+ *   - The MCP follow-ups (`clientId`, `tool`) are revealed only when
+ *     `actorKind === "mcp"`. Switching away clears both fields so the
+ *     URL doesn't carry stale `?clientId=` after the user picks
+ *     "Human" — that drift was the source of #2067's "filter says
+ *     MCP-only but rows look like web traffic" confusion.
+ *   - `clientOptions` may be empty (no DCR clients yet, or fetch
+ *     failed). When empty we fall back to a free-text input so an
+ *     admin can paste a known client_id manually rather than be
+ *     blocked.
+ */
+
+import type { ReactElement } from "react";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+/**
+ * Canonical actor-kind values surfaced in the dropdown. Only `"mcp"`
+ * is currently populated by a writer (see `audit_log.actor_kind`);
+ * the others are reserved for future writer paths (chat, scheduler)
+ * to opt into without a UI change.
+ */
+export const ACTOR_KIND_OPTIONS = [
+  { value: "human", label: "Human" },
+  { value: "agent", label: "Agent" },
+  { value: "mcp", label: "MCP" },
+  { value: "scheduler", label: "Scheduler" },
+] as const;
+
+export type ActorKindFilter = (typeof ACTOR_KIND_OPTIONS)[number]["value"] | "";
+
+export interface AuditFilterBarProps {
+  /** Current actor-kind filter ("" = all). */
+  actorKind: ActorKindFilter;
+  /** OAuth client_id filter ("" = all). Only meaningful when actorKind === "mcp". */
+  clientId: string;
+  /** Tool-name filter ("" = all). Only meaningful when actorKind === "mcp". */
+  tool: string;
+  /**
+   * Registered OAuth clients in the active workspace. Populates the
+   * `clientId` dropdown. Empty array → free-text input fallback.
+   */
+  clientOptions: ReadonlyArray<{ clientId: string; clientName: string | null }>;
+  /**
+   * Single setter — the parent batches the URL update so switching
+   * Actor away from MCP can clear the follow-ups in one history
+   * entry (otherwise the back button would step through three
+   * intermediate states).
+   */
+  onChange: (next: { actorKind?: ActorKindFilter; clientId?: string; tool?: string }) => void;
+}
+
+const ALL_SENTINEL = "__all__";
+
+export function AuditFilterBar({
+  actorKind,
+  clientId,
+  tool,
+  clientOptions,
+  onChange,
+}: AuditFilterBarProps): ReactElement {
+  return (
+    <>
+      <Select
+        value={actorKind || ALL_SENTINEL}
+        onValueChange={(v) => {
+          const next = v === ALL_SENTINEL ? "" : (v as ActorKindFilter);
+          // Switching away from MCP clears the follow-ups so a stale
+          // `?clientId=claude-desktop` doesn't keep filtering when the
+          // dropdown reads "Human". Mirrors the audit page's existing
+          // clearFilters affordance — surgical, not a full reset.
+          if (next !== "mcp" && (clientId || tool)) {
+            onChange({ actorKind: next, clientId: "", tool: "" });
+          } else {
+            onChange({ actorKind: next });
+          }
+        }}
+      >
+        <SelectTrigger className="h-9 w-32" aria-label="Filter by actor">
+          <SelectValue placeholder="All actors" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL_SENTINEL}>All actors</SelectItem>
+          {ACTOR_KIND_OPTIONS.map((opt) => (
+            <SelectItem key={opt.value} value={opt.value}>
+              {opt.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {actorKind === "mcp" && (
+        <>
+          {clientOptions.length > 0 ? (
+            <Select
+              value={clientId || ALL_SENTINEL}
+              onValueChange={(v) =>
+                onChange({ clientId: v === ALL_SENTINEL ? "" : v })
+              }
+            >
+              <SelectTrigger className="h-9 w-44" aria-label="Filter by OAuth client">
+                <SelectValue placeholder="All clients" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={ALL_SENTINEL}>All clients</SelectItem>
+                {clientOptions.map((c) => (
+                  <SelectItem key={c.clientId} value={c.clientId}>
+                    {c.clientName ? `${c.clientName} (${c.clientId})` : c.clientId}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : (
+            <Input
+              placeholder="Filter by OAuth client_id..."
+              value={clientId}
+              onChange={(e) => onChange({ clientId: e.target.value })}
+              className="h-9 w-44"
+              aria-label="Filter by OAuth client"
+            />
+          )}
+
+          <Input
+            placeholder="Filter by tool (e.g. runMetric)..."
+            value={tool}
+            onChange={(e) => onChange({ tool: e.target.value })}
+            className="h-9 w-52"
+            aria-label="Filter by MCP tool"
+          />
+        </>
+      )}
+    </>
+  );
+}

--- a/packages/web/src/ui/components/admin/audit/filter-bar.tsx
+++ b/packages/web/src/ui/components/admin/audit/filter-bar.tsx
@@ -1,28 +1,18 @@
 "use client";
 
 /**
- * Audit-log filter bar (#2067).
+ * Audit-log filter bar — actor discriminator + MCP-only follow-ups.
  *
- * Renders the `actorKind` discriminator dropdown + the MCP-only
- * `clientId` and `tool` follow-up fields. Lifted out of `audit/page.tsx`
- * so the discriminated-union UI is independently testable — the page
- * is too dense (600 LOC of stat cards, tabs, retention panel) to mount
- * end-to-end just to verify "Actor=MCP reveals two extra fields".
+ * Pure controlled component. URL state lives in the parent's
+ * `useQueryStates(auditSearchParams)`; we never read or write `nuqs`
+ * directly so the filter bar can be reused under a different state
+ * container if the audit page ever splits.
  *
- * Contract:
- *   - Pure controlled component. URL state lives in the parent's
- *     `useQueryStates(auditSearchParams)`; we never read or write
- *     `nuqs` directly so the filter bar can be reused under a
- *     different state container if the audit page ever splits.
- *   - The MCP follow-ups (`clientId`, `tool`) are revealed only when
- *     `actorKind === "mcp"`. Switching away clears both fields so the
- *     URL doesn't carry stale `?clientId=` after the user picks
- *     "Human" — that drift was the source of #2067's "filter says
- *     MCP-only but rows look like web traffic" confusion.
- *   - `clientOptions` may be empty (no DCR clients yet, or fetch
- *     failed). When empty we fall back to a free-text input so an
- *     admin can paste a known client_id manually rather than be
- *     blocked.
+ * Switching `actorKind` away from `mcp` clears the follow-ups so a
+ * stale `?clientId=` doesn't keep filtering after the dropdown shows
+ * a non-MCP actor. `clientOptions` may be empty (no DCR clients yet,
+ * or fetch failed) — the component falls back to a free-text input
+ * so an admin pasting a known client_id is never blocked.
  */
 
 import type { ReactElement } from "react";
@@ -73,6 +63,23 @@ export interface AuditFilterBarProps {
 
 const ALL_SENTINEL = "__all__";
 
+/**
+ * Compute the next URL-state patch when the actor dropdown changes.
+ * Pulled out as a pure function so the load-bearing "switch away from
+ * MCP clears the follow-ups" branch is unit-testable without driving
+ * Radix Select internals through jsdom.
+ */
+export function actorKindUpdate(
+  next: ActorKindFilter,
+  currentClientId: string,
+  currentTool: string,
+): { actorKind?: ActorKindFilter; clientId?: string; tool?: string } {
+  if (next !== "mcp" && (currentClientId || currentTool)) {
+    return { actorKind: next, clientId: "", tool: "" };
+  }
+  return { actorKind: next };
+}
+
 export function AuditFilterBar({
   actorKind,
   clientId,
@@ -86,15 +93,7 @@ export function AuditFilterBar({
         value={actorKind || ALL_SENTINEL}
         onValueChange={(v) => {
           const next = v === ALL_SENTINEL ? "" : (v as ActorKindFilter);
-          // Switching away from MCP clears the follow-ups so a stale
-          // `?clientId=claude-desktop` doesn't keep filtering when the
-          // dropdown reads "Human". Mirrors the audit page's existing
-          // clearFilters affordance — surgical, not a full reset.
-          if (next !== "mcp" && (clientId || tool)) {
-            onChange({ actorKind: next, clientId: "", tool: "" });
-          } else {
-            onChange({ actorKind: next });
-          }
+          onChange(actorKindUpdate(next, clientId, tool));
         }}
       >
         <SelectTrigger className="h-9 w-32" aria-label="Filter by actor">

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -135,6 +135,21 @@ export const AuditConnectionMetaSchema = z.object({
   })),
 });
 
+/**
+ * Subset of `/api/v1/admin/oauth-clients` consumed by the audit-log
+ * filter bar (#2067). The dropdown only needs `clientId` + the
+ * display label; pulling the full row would force the schema to
+ * track every column the OAuth Clients admin page surfaces.
+ */
+export const AuditOAuthClientsSchema = z.object({
+  clients: z.array(
+    z.object({
+      clientId: z.string(),
+      clientName: z.string().nullable(),
+    }),
+  ),
+});
+
 // ── Sessions ─────────────────────────────────────────────────────
 
 export const SessionStatsSchema = z.object({


### PR DESCRIPTION
## Summary

- Adds three nullable columns to `audit_log` (`actor_kind`, `client_id`, `tool_name`) so the admin filter can scope to MCP rows without JSONB scans. Migration 0049, partial btree on `(org_id, actor_kind, timestamp DESC)`.
- Threads MCP context through `RequestContext.actor` → `logQueryAudit` so every dispatch via `tools.ts` / `semantic-tools.ts` (executeSQL / explore / runMetric / listEntities / describeEntity / searchGlossary) stamps `actor_kind=mcp` + tool name + (hosted) OAuth client_id.
- New `lib/audit/query.ts` builder accepts `actorKind` / `clientId` / `tool` query params; `GET /api/v1/admin/audit` route consumes it. Single-statement SELECT, AND-combined, org_id stays `$1` so cross-workspace isolation holds.
- New `AuditFilterBar` component: Actor dropdown (Human / Agent / MCP / Scheduler). When MCP, reveals a clientId selector (sourced from `/api/v1/admin/oauth-clients`, free-text fallback) and a tool name input. URL state via existing `nuqs` `auditSearchParams`; switching away from MCP clears the follow-ups in one history entry.

Closes #2067.

## Test plan

- [x] `lib/audit/query.test.ts` — pins SQL shape + placeholder ordering for the new filters in isolation.
- [x] `api/__tests__/admin.test.ts` — actorKind / clientId / tool individually, AND-combined with existing filters, cross-org isolation.
- [x] `lib/auth/__tests__/audit.test.ts` — pins the 17-column INSERT and verifies `RequestContext.actor` round-trips into `audit_log`.
- [x] `ui/__tests__/audit-filter-bar.test.tsx` — discriminated-union UI hides MCP fields outside the MCP branch + free-text fallback when no DCR clients.
- [x] `lib/db/__tests__/migrate.test.ts` + `lib/auth/__tests__/migrate.test.ts` updated for the new migration.
- [x] `/ci`: lint, type, full test, syncpack, template drift, security headers drift, railway-watch — all pass.
- [ ] Manual: open `/admin/audit`, pick Actor=MCP, verify clientId + tool inputs appear; trigger an MCP tool call (Claude Desktop) and confirm the row carries `actor_kind=mcp` + `tool_name=executeSQL`.