### PR TITLE
fix(docs): escape MDX {agent} placeholder breaking docs prerender

### DIFF
--- a/apps/docs/content/docs/guides/mcp-hosted.mdx
+++ b/apps/docs/content/docs/guides/mcp-hosted.mdx
@@ -206,7 +206,7 @@ Use this when:
 
 ### Per-client setup notes
 
-Documentation anchors used by the in-product wizard "How to paste this in {agent}" links:
+Documentation anchors used by the in-product wizard "How to paste this in `{agent}`" links:
 
 #### Claude Desktop
 


### PR DESCRIPTION
## Summary

PR #2100 added \`\"How to paste this in {agent}\"\` to \`apps/docs/content/docs/guides/mcp-hosted.mdx\` as plain prose. MDX parses curly braces as JSX expressions, so \`{agent}\` resolved against an undefined identifier at prerender time and the docs Railway deploy started crashing:

\`\`\`
Error occurred prerendering page \"/guides/mcp-hosted\"
ReferenceError: agent is not defined
\`\`\`

Every other surface (api, web, www) was green — only \`satisfied-creation - docs\` failed. Wrapping the placeholder in backticks renders it as inline code and tells MDX to treat the braces as literal text.

Verified locally: \`bun run --filter '@atlas/docs' build\` exits 0 with the fix; the build crashed at \`/guides/mcp-hosted\` without it.

## Test plan
- [x] Local docs build passes (\`bun run --filter '@atlas/docs' build\`)
- [ ] Railway \`docs\` service redeploys green on merge