### PR TITLE
chore(api): declare bun + node types so IDE LSP resolves bun:test

### DIFF
--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "types": ["bun", "node"],
     "paths": {
       "@atlas/api/*": ["./src/*"],
       "@atlas/ee/*": ["../../ee/src/*"]


### PR DESCRIPTION
## Summary

Every test file in \`packages/api/src/**/__tests__/\` imports from \`bun:test\`. CI is green because the root \`bun run type\` script runs \`tsgo\` from the workspace root — default \`@types/*\` discovery picks up the hoisted \`node_modules/@types/bun\` from there. But the IDE LSP (and \`bun x tsgo\` from \`packages/api/\`) initializes against \`packages/api/tsconfig.json\` directly, and tsgo's auto-discovery doesn't walk up to the hoisted \`@types\` root. Result: every test file lights up red in the editor with \`Cannot find module 'bun:test'\`, even though \`bun run type\` and \`bun run test\` both pass.

Declaring \`types: [\"bun\", \"node\"]\` in the api tsconfig makes resolution explicit. Cheap one-line DX fix.

## Test plan
- [x] \`bun x tsgo --noEmit\` from \`packages/api/\` — \`bun:test\` errors gone (verified, was 200+ before, 0 after)
- [x] \`bun run type\` from root still passes