### PR TITLE
docs: tidy — flip 1.4.1 Theme A1/A3 + Wave 2A passkey sign-in shipped

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -141,9 +141,9 @@ Tracker: [milestone #41](https://github.com/AtlasDevHQ/atlas/milestones/41). Rou
 
 ### Theme A — Workspace-native UX
 
-- [ ] Settings → AI Agents — per-user MCP connect + manage flow ([#2065](https://github.com/AtlasDevHQ/atlas/issues/2065)) — `/settings/ai-agents` page + 3-step connect wizard + per-user OAuth-client endpoints. Closes the install-path gap for non-CLI users.
+- [x] Settings → AI Agents — per-user MCP connect + manage flow ([#2065](https://github.com/AtlasDevHQ/atlas/issues/2065), [#2100](https://github.com/AtlasDevHQ/atlas/pull/2100)) — `/settings/ai-agents` page + 3-step connect wizard + per-user OAuth-client endpoints. Closes the install-path gap for non-CLI users.
 - [ ] Hosted-MCP token refresh + expiry UX, end-to-end tested ([#2066](https://github.com/AtlasDevHQ/atlas/issues/2066)) — refresh-token lifecycle untested; first user across expiry surfaces silently. Adds e2e coverage + UI states for expired/revoked clients.
-- [ ] Admin audit-log filter view for MCP tool calls ([#2067](https://github.com/AtlasDevHQ/atlas/issues/2067)) — audit rows exist; admin UI doesn't have the MCP-shaped filter (`actorKind=mcp`, by `clientId`, by `tool`).
+- [x] Admin audit-log filter view for MCP tool calls ([#2067](https://github.com/AtlasDevHQ/atlas/issues/2067), [#2101](https://github.com/AtlasDevHQ/atlas/pull/2101)) — `actorKind=mcp` / `clientId` / `tool` query filters with nuqs URL-state UI; new `0049_audit_log_mcp_columns` migration.
 
 ### Theme B — Brand + production hygiene
 
@@ -183,8 +183,8 @@ Post-1.3.x TOTP MFA. WebAuthn passkeys + TOTP + trusted-device 30d shipped via [
 - [x] Closeout — passkey browser e2e + docs ([#2090](https://github.com/AtlasDevHQ/atlas/issues/2090), [#2095](https://github.com/AtlasDevHQ/atlas/pull/2095)) — `@llm`-tagged virtual-authenticator e2e + new `security/passkeys.mdx`; drops the stale "passkeys out of scope" line.
 - [x] Platform-admin force-revoke ([#2093](https://github.com/AtlasDevHQ/atlas/issues/2093), [#2097](https://github.com/AtlasDevHQ/atlas/pull/2097)) — atomic `POST /admin/users/{id}/revoke-auth` revokes sessions + trust-devices + passkeys + OAuth tokens in one transaction.
 - [x] Adoption telemetry ([#2094](https://github.com/AtlasDevHQ/atlas/issues/2094), [#2096](https://github.com/AtlasDevHQ/atlas/pull/2096)) — per-workspace + cross-workspace security metrics endpoints with admin / platform-admin posture panels.
-- [ ] Passkey-first sign-in ([#2091](https://github.com/AtlasDevHQ/atlas/issues/2091)) — `signIn.passkey({ autoFill: true })` conditional UI on `/login` + "Use a passkey" alternative on the 2FA challenge screen. Cross-device QR explicitly out of scope.
-- [ ] Passkey-only recovery ([#2092](https://github.com/AtlasDevHQ/atlas/issues/2092)) — recovery codes (Option B, decoupled from TOTP) + recovery login path + admin-mediated MFA reset. Confirm Better Auth `twoFactor.generateBackupCodes` works without an active TOTP factor before coding.
+- [x] Passkey-first sign-in ([#2091](https://github.com/AtlasDevHQ/atlas/issues/2091), [#2099](https://github.com/AtlasDevHQ/atlas/pull/2099)) — `signIn.passkey({ autoFill: true })` conditional UI on `/login` + "Use a passkey" alternative on the 2FA challenge screen. Cross-device QR explicitly out of scope.
+- [ ] Passkey-only recovery ([#2092](https://github.com/AtlasDevHQ/atlas/issues/2092)) — second-passkey nudge + admin-mediated MFA reset. Recovery codes dropped: Better Auth's `twoFactor` plugin bundles backup codes with TOTP and they can't be cleanly decoupled (Context7-verified). A single passkey is already multi-factor by WebAuthn UV.
 
 ---
 


### PR DESCRIPTION
## Summary

Three ROADMAP checkboxes flip after this morning's burst:

- **1.4.1 Theme A1** — Settings → AI Agents (#2065 / #2100)
- **1.4.1 Theme A3** — admin audit-log MCP filter (#2067 / #2101)
- **Parallel MFA Wave 2A** — passkey-first sign-in (#2091 / #2099)

#2092 (passkey-only recovery) bullet rewritten to reflect the revised scope: recovery codes dropped (Better Auth's \`twoFactor\` plugin won't decouple them from TOTP — Context7-verified), second-passkey nudge + admin-mediated reset is now the design.

## Test plan
- [x] Renders correctly in markdown
- [x] All issue + PR links resolve