### PR TITLE
feat(api,mcp,web,docs): #2066 — hosted-MCP token refresh + expiry UX

### DIFF
--- a/apps/docs/content/docs/guides/mcp-hosted.mdx
+++ b/apps/docs/content/docs/guides/mcp-hosted.mdx
@@ -204,6 +204,60 @@ Use this when:
 - A teammate offboards and every agent they registered should be invalidated
 - A registered client name no longer matches the agent it was issued to (clean it up — DCR will re-register fresh)
 
+## Token refresh contract
+
+Atlas's auth server issues both **access tokens** and **refresh tokens** when a client authorizes with the `offline_access` scope (the standard MCP install path requests it). SDK consumers should expect the following contract — Atlas will not change it without a major version bump.
+
+### Default lifetimes
+
+| Token | Default | Override |
+|---|---|---|
+| Access token (JWT) | **1 hour** | `ATLAS_OAUTH_ACCESS_TOKEN_TTL_SECONDS` |
+| Refresh token (opaque) | **30 days** | `ATLAS_OAUTH_REFRESH_TOKEN_TTL_SECONDS` |
+| Authorization code | 10 minutes | not configurable |
+
+The lifetimes are global per Atlas instance — they do not vary by workspace, scope, or client. The `expires_in` field in every token response carries the absolute remaining seconds for the access token; clients should refresh before that window closes.
+
+### Refresh path (the happy case)
+
+A standards-compliant MCP SDK refreshes transparently. When the access token's `exp` claim has passed, the next `tools/call` frame returns `401`; the SDK exchanges the refresh token at the auth server's `/api/auth/oauth2/token` endpoint with `grant_type=refresh_token`, receives a fresh access token, and replays the frame. The user observes no interruption.
+
+Each successful refresh increments the `atlas.oauth.token_refresh` OTel counter (attributes: `client.id`, `deploy.mode`) and writes an `oauth_token.refresh` row to the workspace's admin action log. Operators who want a per-agent rotation cadence dashboard wire those signals to whichever observability stack they run.
+
+Refresh-token rotation per [RFC 6749 §6](https://datatracker.ietf.org/doc/html/rfc6749#section-6) is **not** enabled — the same refresh token survives across exchanges until it expires or is revoked. This matches Better Auth's `oauth-provider` plugin defaults and the MCP spec's deployment notes; SDK authors who want strict rotation must wrap the underlying refresh response themselves.
+
+### Refresh failure (the recovery contract)
+
+When the refresh exchange itself returns `400 invalid_grant`, the refresh token has expired or been revoked. The next `tools/call` frame against the resource server returns `401` with a `WWW-Authenticate` header pointing back at the auth-server resource-metadata endpoint:
+
+```http
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Bearer realm="Atlas",
+                  error="invalid_token",
+                  error_description="The access token expired",
+                  resource_metadata="https://api.useatlas.dev/.well-known/oauth-protected-resource"
+```
+
+The contract for the client is:
+
+1. Read `resource_metadata` from the header.
+2. Fetch it (or look up the cached copy) to discover the auth server's authorization endpoint.
+3. Re-run Dynamic Client Registration if the `client_id` was deleted on the server side (e.g. an admin or the user revoked the OAuth client). Otherwise re-run the standard authorization-code + PKCE dance against the existing `client_id`.
+
+Atlas does **not** leak the underlying revocation reason in the response body. A revoked OAuth client and a naturally-expired refresh token return the same `401` envelope — the client cannot distinguish them and should treat both as "re-authorize." The `oauth_client.revoke` audit row carries the actor; the user can see what happened from the workspace's admin log.
+
+### Token-state on the per-user listing
+
+`GET /api/v1/me/oauth-clients` carries a `tokenState` field per client:
+
+| State | Meaning | UI affordance |
+|---|---|---|
+| `active` | Enabled client with at least one outstanding non-expired access or refresh token | Status dot, no badge |
+| `reconnect_required` | Enabled client with no usable token left — the next frame will 401 with `WWW-Authenticate` | Amber badge + Reconnect CTA |
+| `revoked` | The client row is `disabled = true` (admin or self revoke) | Dimmed row, deletion is the next step |
+
+The Settings → AI Agents page renders these three states verbatim. Ops queries should pivot on `tokenState` rather than re-deriving it from `disabled` + `tokenCount`.
+
 ### Per-client setup notes
 
 Documentation anchors used by the in-product wizard "How to paste this in `{agent}`" links:

--- a/apps/docs/content/docs/guides/mcp-hosted.mdx
+++ b/apps/docs/content/docs/guides/mcp-hosted.mdx
@@ -214,7 +214,7 @@ Atlas's auth server issues both **access tokens** and **refresh tokens** when a 
 |---|---|---|
 | Access token (JWT) | **1 hour** | `ATLAS_OAUTH_ACCESS_TOKEN_TTL_SECONDS` |
 | Refresh token (opaque) | **30 days** | `ATLAS_OAUTH_REFRESH_TOKEN_TTL_SECONDS` |
-| Authorization code | 10 minutes | not configurable |
+| Authorization code | 10 minutes | inherits Better Auth default; no Atlas env override |
 
 The lifetimes are global per Atlas instance — they do not vary by workspace, scope, or client. The `expires_in` field in every token response carries the absolute remaining seconds for the access token; clients should refresh before that window closes.
 
@@ -254,7 +254,7 @@ Atlas does **not** leak the underlying revocation reason in the response body. A
 |---|---|---|
 | `active` | Enabled client with at least one outstanding non-expired access or refresh token | Status dot, no badge |
 | `reconnect_required` | Enabled client with no usable token left — the next frame will 401 with `WWW-Authenticate` | Amber badge + Reconnect CTA |
-| `revoked` | The client row is `disabled = true` (admin or self revoke) | Dimmed row, deletion is the next step |
+| `revoked` | The client row is `disabled = true`. **Reserved for a future soft-revoke flow** — v1.4.1 revoke performs a hard `DELETE`, so this state is never produced by current code paths. The UI rendering exists so the contract is pinned for the next iteration. | Dimmed row, deletion is the next step |
 
 The Settings → AI Agents page renders these three states verbatim. Ops queries should pivot on `tokenState` rather than re-deriving it from `disabled` + `tokenCount`.
 

--- a/e2e/browser/mcp-token-refresh.spec.ts
+++ b/e2e/browser/mcp-token-refresh.spec.ts
@@ -1,0 +1,230 @@
+import { test, expect, type Page, type Route } from "@playwright/test";
+
+/**
+ * Hosted-MCP token refresh + tokenState UX (#2066) @llm
+ *
+ * Mirrors `settings-ai-agents.spec.ts`'s mocking pattern for the wire
+ * shape — the spec asserts the per-row UX states (Active / Reconnect
+ * required / Revoked) the page must render in response to each
+ * `tokenState` value. The full register → mint → expire → refresh
+ * dance against a live Better Auth issuer is exercised at the
+ * verifier level by `packages/mcp/src/__tests__/hosted-token-refresh.test.ts`
+ * — running it through a browser would require a real DCR-bootstrapping
+ * MCP client (Claude Desktop / Cursor) which we cannot drive headlessly.
+ *
+ * The `@llm` tag opts this spec into the serial worker
+ * (`bun run test:browser:llm`, workers=1). Even though no model calls
+ * happen here, the route mocks rely on the global storage state
+ * being a clean signed-in admin — running concurrently with other
+ * specs that mutate `/me/oauth-clients` would race.
+ *
+ * What this spec catches:
+ *
+ *   1. A regression in the page's tokenState rendering — every state
+ *      the API can return must be visible somewhere in the row.
+ *   2. A regression in the Reconnect CTA wiring — clicking it opens
+ *      the same revoke dialog flow (1.4.1's "reconnect" is a
+ *      revoke + re-run-wizard, intentionally).
+ *   3. A regression in the Revoked-row dimming — the row should
+ *      visually deprioritize even though it stays clickable for
+ *      audit trail integrity.
+ */
+
+interface MockOAuthClient {
+  clientId: string;
+  clientName: string | null;
+  redirectUris: string[];
+  createdAt: string;
+  updatedAt: string | null;
+  disabled: boolean;
+  type: string | null;
+  lastUsedAt: string | null;
+  tokenCount: number;
+  tokenState: "active" | "reconnect_required" | "revoked";
+}
+
+/**
+ * Three rows, one per tokenState. The fixture intentionally keeps the
+ * same redirect URI / type across rows so any visible UX difference
+ * is attributable to `tokenState` alone.
+ */
+function buildStateFixture(): MockOAuthClient[] {
+  return [
+    {
+      clientId: "claude-desktop",
+      clientName: "Claude Desktop (active)",
+      redirectUris: ["http://127.0.0.1:6274/callback"],
+      createdAt: "2026-04-12T10:00:00.000Z",
+      updatedAt: "2026-04-12T10:00:00.000Z",
+      disabled: false,
+      type: "public",
+      lastUsedAt: "2026-05-04T15:30:00.000Z",
+      tokenCount: 3,
+      tokenState: "active",
+    },
+    {
+      clientId: "cursor-stale",
+      clientName: "Cursor (refresh failed)",
+      redirectUris: ["http://127.0.0.1:6274/callback"],
+      createdAt: "2026-04-15T09:00:00.000Z",
+      updatedAt: "2026-04-15T09:00:00.000Z",
+      disabled: false,
+      type: "public",
+      lastUsedAt: "2026-04-20T12:00:00.000Z",
+      tokenCount: 1,
+      tokenState: "reconnect_required",
+    },
+    {
+      clientId: "chatgpt-revoked",
+      clientName: "ChatGPT (revoked)",
+      redirectUris: ["http://127.0.0.1:6274/callback"],
+      createdAt: "2026-04-01T08:00:00.000Z",
+      updatedAt: "2026-04-30T08:00:00.000Z",
+      disabled: true,
+      type: "public",
+      lastUsedAt: "2026-04-25T08:00:00.000Z",
+      tokenCount: 0,
+      tokenState: "revoked",
+    },
+  ];
+}
+
+async function installMocks(
+  page: Page,
+  initial: MockOAuthClient[],
+): Promise<{ state: Map<string, MockOAuthClient> }> {
+  const state = new Map<string, MockOAuthClient>(
+    initial.map((c) => [c.clientId, c]),
+  );
+
+  // Revoke handler — narrow path first so the broad list route doesn't
+  // shadow it. Mirrors settings-ai-agents.spec.ts.
+  await page.route(
+    /\/api\/v1\/me\/oauth-clients\/[^/?]+\/revoke(?:\?|$)/,
+    async (route: Route) => {
+      const req = route.request();
+      if (req.method() !== "POST") {
+        await route.abort("failed");
+        return;
+      }
+      const url = new URL(req.url());
+      const segments = url.pathname.split("/");
+      const id = segments[segments.length - 2]!;
+      state.delete(id);
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, tokensRevoked: 4 }),
+      });
+    },
+  );
+
+  await page.route(
+    /\/api\/v1\/me\/oauth-clients(?:\?[^/]*)?$/,
+    async (route: Route) => {
+      const req = route.request();
+      if (req.method() !== "GET") {
+        await route.abort("failed");
+        return;
+      }
+      const clients = [...state.values()].sort((a, b) =>
+        a.createdAt < b.createdAt ? 1 : -1,
+      );
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ clients, deployMode: "saas" }),
+      });
+    },
+  );
+
+  return { state };
+}
+
+test.describe("MCP token refresh — tokenState UX @llm", () => {
+  test.describe.configure({ timeout: 45_000 });
+
+  test("renders Active / Reconnect required / Revoked badges per tokenState", async ({
+    page,
+  }) => {
+    await installMocks(page, buildStateFixture());
+    await page.goto("/settings/ai-agents");
+
+    await expect(
+      page.locator("h1", { hasText: "AI Agents" }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Row 1 — active. The legacy "connected" status dot conveys this
+    // without an explicit badge; we assert the row exists and does not
+    // carry the reconnect / revoked badge text.
+    const activeRow = page
+      .locator("section, div", { hasText: "Claude Desktop (active)" })
+      .first();
+    await expect(activeRow).toBeVisible();
+    await expect(activeRow.getByText(/Reconnect required/i)).toHaveCount(0);
+    await expect(activeRow.getByText(/Revoked/i)).toHaveCount(0);
+
+    // Row 2 — reconnect_required. Amber badge + Reconnect CTA visible.
+    const reconnectRow = page
+      .locator("section, div", { hasText: "Cursor (refresh failed)" })
+      .first();
+    await expect(reconnectRow.getByText(/Reconnect required/i)).toBeVisible();
+    await expect(
+      reconnectRow.getByRole("button", { name: /Reconnect/i }),
+    ).toBeVisible();
+
+    // Row 3 — revoked. Badge visible.
+    const revokedRow = page
+      .locator("section, div", { hasText: "ChatGPT (revoked)" })
+      .first();
+    await expect(revokedRow.getByText(/Revoked/i).first()).toBeVisible();
+  });
+
+  test("Reconnect CTA opens the same revoke dialog (1.4.1 reconnect = revoke + re-run wizard)", async ({
+    page,
+  }) => {
+    // No per-token refresh UI in 1.4.1 — see issue's "out of scope".
+    // The Reconnect button reuses the revoke handler so the table
+    // converges in one click; the user re-runs the wizard manually.
+    await installMocks(page, buildStateFixture());
+    await page.goto("/settings/ai-agents");
+
+    const reconnectRow = page
+      .locator("section, div", { hasText: "Cursor (refresh failed)" })
+      .first();
+    await reconnectRow
+      .getByRole("button", { name: /Reconnect/i })
+      .click();
+
+    // The Reconnect button shares the revoke handler — the same
+    // confirmation dialog opens.
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByText(/Revoke agent/)).toBeVisible();
+  });
+
+  test("Revoked row stays in the list (audit trail) and the Revoke button still works", async ({
+    page,
+  }) => {
+    const { state } = await installMocks(page, buildStateFixture());
+    await page.goto("/settings/ai-agents");
+
+    const revokedRow = page
+      .locator("section, div", { hasText: "ChatGPT (revoked)" })
+      .first();
+    await expect(revokedRow).toBeVisible();
+    await expect(revokedRow.getByText(/Revoked/i).first()).toBeVisible();
+
+    // Revoke removes the row from the visible list.
+    await revokedRow
+      .getByRole("button", { name: /Revoke ChatGPT/i })
+      .click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByText(/Revoke agent/)).toBeVisible();
+    await dialog.getByRole("button", { name: /^Revoke agent$/ }).click();
+
+    await expect(
+      page.getByText("ChatGPT (revoked)", { exact: true }),
+    ).toHaveCount(0, { timeout: 10_000 });
+    expect(state.has("chatgpt-revoked")).toBe(false);
+  });
+});

--- a/e2e/browser/settings-ai-agents.spec.ts
+++ b/e2e/browser/settings-ai-agents.spec.ts
@@ -23,6 +23,10 @@ interface MockOAuthClient {
   type: string | null;
   lastUsedAt: string | null;
   tokenCount: number;
+  // tokenState (#2066) — required wire field. The page schema rejects
+  // payloads without it; default the fixture rows to "active" to keep
+  // existing assertions on row visibility intact.
+  tokenState: "active" | "reconnect_required" | "revoked";
 }
 
 function buildFixture(): MockOAuthClient[] {
@@ -37,6 +41,7 @@ function buildFixture(): MockOAuthClient[] {
       type: "public",
       lastUsedAt: "2026-05-01T15:30:00.000Z",
       tokenCount: 3,
+      tokenState: "active",
     },
     {
       clientId: "cursor-abc123",
@@ -48,6 +53,7 @@ function buildFixture(): MockOAuthClient[] {
       type: "public",
       lastUsedAt: null,
       tokenCount: 0,
+      tokenState: "active",
     },
   ];
 }

--- a/packages/api/src/api/__tests__/admin-oauth-clients.test.ts
+++ b/packages/api/src/api/__tests__/admin-oauth-clients.test.ts
@@ -182,6 +182,12 @@ describe("admin oauth-clients — GET /oauth-clients", () => {
               type: "public",
               lastUsedAt: "2026-05-01T15:30:00.000Z",
               tokenCount: "3",
+              // #2066: live counts drive the tokenState derivation. An
+              // active row (the assertion below relies on it) needs at
+              // least one of these positive — pick `liveTokenCount` so
+              // the row exercises the access-token-live branch.
+              liveTokenCount: "2",
+              liveRefreshCount: "1",
             },
           ];
         }
@@ -203,6 +209,7 @@ describe("admin oauth-clients — GET /oauth-clients", () => {
         lastUsedAt: string | null;
         disabled: boolean;
         tokenCount: number;
+        tokenState: "active" | "reconnect_required" | "revoked";
       }>;
     };
     expect(body.clients).toHaveLength(1);
@@ -212,6 +219,10 @@ describe("admin oauth-clients — GET /oauth-clients", () => {
     expect(body.clients[0]!.disabled).toBe(false);
     expect(body.clients[0]!.tokenCount).toBe(3);
     expect(body.clients[0]!.lastUsedAt).toBe("2026-05-01T15:30:00.000Z");
+    // #2066: tokenState rides the same wire as the per-user surface;
+    // pin its presence on the admin schema so a future drift between
+    // the two routes' Zod schemas fails this assertion first.
+    expect(body.clients[0]!.tokenState).toBe("active");
   });
 
   it("returns an empty list when the workspace has registered no clients", async () => {

--- a/packages/api/src/api/__tests__/me-oauth-clients.test.ts
+++ b/packages/api/src/api/__tests__/me-oauth-clients.test.ts
@@ -596,6 +596,147 @@ describe("me oauth-clients — POST /me/oauth-clients/:id/revoke", () => {
     expect(clientQueries.length).toBe(0);
   });
 
+  // -------------------------------------------------------------------------
+  // tokenState (#2066) — derived in SQL from disabled + liveTokenCount +
+  // liveRefreshCount. The route relays the helper's classification verbatim;
+  // these tests pin the wire shape so the Settings → AI Agents page can
+  // depend on `active` / `reconnect_required` / `revoked` without re-deriving.
+  // -------------------------------------------------------------------------
+
+  it("GET surfaces tokenState='active' when at least one access token is live", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes("oauthClient")) {
+        if (params?.[0] !== "org-alpha") return [];
+        if (params?.[1] !== "user-1") return [];
+        return [
+          {
+            clientId: "claude-desktop",
+            clientName: "Claude Desktop",
+            redirectUris: ["http://127.0.0.1:6274/callback"],
+            createdAt: "2026-04-12T10:00:00.000Z",
+            updatedAt: "2026-04-12T10:00:00.000Z",
+            disabled: false,
+            type: "public",
+            lastUsedAt: "2026-05-01T15:30:00.000Z",
+            tokenCount: "5",
+            liveTokenCount: "2",
+            liveRefreshCount: "1",
+          },
+        ];
+      }
+      return [];
+    });
+
+    const res = await app.fetch(meRequest("GET", "/api/v1/me/oauth-clients"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      clients: Array<{ clientId: string; tokenState: string }>;
+    };
+    expect(body.clients[0]!.tokenState).toBe("active");
+  });
+
+  it("GET surfaces tokenState='active' when only the refresh token is live (access expired)", async () => {
+    // The agent's MCP SDK can transparently exchange the refresh — there's
+    // no user-visible interruption — so the row stays "active" even with
+    // zero live access tokens. Without this branch the UI would over-report
+    // "reconnect required" and surface false-positive CTAs.
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("oauthClient")) {
+        return [
+          {
+            clientId: "cursor",
+            clientName: "Cursor",
+            redirectUris: ["cursor://callback"],
+            createdAt: "2026-04-12T10:00:00.000Z",
+            updatedAt: null,
+            disabled: false,
+            type: "public",
+            lastUsedAt: "2026-05-01T15:30:00.000Z",
+            tokenCount: "1",
+            liveTokenCount: "0",
+            liveRefreshCount: "1",
+          },
+        ];
+      }
+      return [];
+    });
+
+    const res = await app.fetch(meRequest("GET", "/api/v1/me/oauth-clients"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      clients: Array<{ tokenState: string }>;
+    };
+    expect(body.clients[0]!.tokenState).toBe("active");
+  });
+
+  it("GET surfaces tokenState='reconnect_required' when no live tokens remain", async () => {
+    // The next agent frame will 401 with WWW-Authenticate; the page renders
+    // an amber CTA so the user re-runs the connect wizard.
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("oauthClient")) {
+        return [
+          {
+            clientId: "claude-desktop",
+            clientName: "Claude Desktop",
+            redirectUris: ["http://127.0.0.1:6274/callback"],
+            createdAt: "2026-04-12T10:00:00.000Z",
+            updatedAt: null,
+            disabled: false,
+            type: "public",
+            lastUsedAt: "2026-05-01T15:30:00.000Z",
+            tokenCount: "3",
+            liveTokenCount: "0",
+            liveRefreshCount: "0",
+          },
+        ];
+      }
+      return [];
+    });
+
+    const res = await app.fetch(meRequest("GET", "/api/v1/me/oauth-clients"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      clients: Array<{ tokenState: string }>;
+    };
+    expect(body.clients[0]!.tokenState).toBe("reconnect_required");
+  });
+
+  it("GET surfaces tokenState='revoked' regardless of live token counts when disabled=true", async () => {
+    // Precedence rule: `disabled` wins. An admin revoke flow that flipped
+    // `disabled = true` but hasn't yet cascaded the access-token DELETE
+    // must surface `revoked` so the UI dims the row and stops promising
+    // the agent will work — even if a stale access token would still
+    // technically verify until its expiry.
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("oauthClient")) {
+        return [
+          {
+            clientId: "stale-cursor",
+            clientName: "Old Cursor (revoked)",
+            redirectUris: ["cursor://callback"],
+            createdAt: "2026-04-12T10:00:00.000Z",
+            updatedAt: "2026-04-13T10:00:00.000Z",
+            disabled: true,
+            type: "public",
+            lastUsedAt: "2026-04-15T15:30:00.000Z",
+            tokenCount: "2",
+            liveTokenCount: "1",
+            liveRefreshCount: "1",
+          },
+        ];
+      }
+      return [];
+    });
+
+    const res = await app.fetch(meRequest("GET", "/api/v1/me/oauth-clients"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      clients: Array<{ tokenState: string; disabled: boolean }>;
+    };
+    expect(body.clients[0]!.tokenState).toBe("revoked");
+    expect(body.clients[0]!.disabled).toBe(true);
+  });
+
   it("GET drops cross-user rows when the userId filter is correctly applied", async () => {
     // Inverted gate: the mock returns User B's row only when params[1] is
     // missing or wrong. A regression that drops `c."userId" = $2` from

--- a/packages/api/src/api/routes/admin-oauth-clients.ts
+++ b/packages/api/src/api/routes/admin-oauth-clients.ts
@@ -61,6 +61,10 @@ const OAuthClientSchema = z.object({
   type: z.string().nullable(),
   lastUsedAt: z.string().nullable(),
   tokenCount: z.number().int().nonnegative(),
+  // tokenState (#2066) — same field surfaced on /me/oauth-clients.
+  // Admin surface includes it so the wire shape stays in lockstep
+  // with the per-user one and OpenAPI consumers see one schema.
+  tokenState: z.enum(["active", "reconnect_required", "revoked"]),
 });
 
 const ListClientsResponseSchema = z.object({

--- a/packages/api/src/api/routes/me-oauth-clients.ts
+++ b/packages/api/src/api/routes/me-oauth-clients.ts
@@ -75,6 +75,11 @@ const OAuthClientSchema = z.object({
   type: z.string().nullable(),
   lastUsedAt: z.string().nullable(),
   tokenCount: z.number().int().nonnegative(),
+  // tokenState (#2066) — derived in SQL from disabled flag + outstanding
+  // non-expired access/refresh tokens. The /settings/ai-agents table
+  // renders three badges (Active / Reconnect required / Revoked); the
+  // legacy `tokenCount` field stays informational for "tokens issued".
+  tokenState: z.enum(["active", "reconnect_required", "revoked"]),
 });
 
 const ListMyClientsResponseSchema = z.object({

--- a/packages/api/src/lib/audit/actions.ts
+++ b/packages/api/src/lib/audit/actions.ts
@@ -287,6 +287,33 @@ export const ADMIN_ACTIONS = {
     revoke: "oauth_client.revoke",
   },
   /**
+   * OAuth 2.1 token lifecycle audit (#2066). Emitted when Better Auth's
+   * `oauthProvider` issues a fresh access token via the `refresh_token`
+   * grant — the load-bearing event for "the agent stayed connected past
+   * the original JWT's expiry". The hosted MCP path's only Atlas-side
+   * trace of a refresh otherwise lives in pino (which retention rotates
+   * out); this row is the queryable, retention-policy-aligned record.
+   *
+   * Metadata:
+   *   - `clientId`         — the OAuth client_id that presented the
+   *                          refresh token. Pivots forensic queries on
+   *                          which agent (Claude Desktop, Cursor, etc.)
+   *                          is rotating tokens.
+   *   - `userId`           — the user the token is bound to.
+   *   - `tokenJti`         — JWT id of the *new* access token, when the
+   *                          oauthProvider hook surfaces it. May be
+   *                          undefined for opaque tokens (no JWT plugin).
+   *   - `ageAtRefreshSec`  — wall-clock seconds between the previous
+   *                          token's `iat` and the refresh, when known.
+   *
+   * Per-token revoke is intentionally NOT in this catalog — the v1.4.1
+   * surface only exposes whole-client revoke, which lives under
+   * `oauth_client.revoke`. See #2066 "out of scope".
+   */
+  oauth_token: {
+    refresh: "oauth_token.refresh",
+  },
+  /**
    * Hosted MCP session lifecycle (#2024 PR C). Emitted on every new
    * session-init at `/mcp/{workspace_id}/sse` — sampled per session,
    * not per JSON-RPC frame, since a single agent connection can issue

--- a/packages/api/src/lib/audit/actions.ts
+++ b/packages/api/src/lib/audit/actions.ts
@@ -296,15 +296,29 @@ export const ADMIN_ACTIONS = {
    *
    * Metadata:
    *   - `clientId`         — the OAuth client_id that presented the
-   *                          refresh token. Pivots forensic queries on
-   *                          which agent (Claude Desktop, Cursor, etc.)
-   *                          is rotating tokens.
+   *                          refresh token. Production wiring sets this
+   *                          to `null` because Better Auth's
+   *                          `customTokenResponseFields` hook does not
+   *                          surface the `oauthClient.clientId` column
+   *                          to user code (it only exposes the parsed
+   *                          `metadata` JSONB blob, which Atlas does
+   *                          not write `clientId` into). The audit row
+   *                          falls back to `targetId = "unknown"` in
+   *                          that case. The field is shaped to accept
+   *                          a real value so a future hook upgrade or
+   *                          a follow-up DB lookup can light up the
+   *                          per-agent forensic split without changing
+   *                          the schema.
    *   - `userId`           — the user the token is bound to.
-   *   - `tokenJti`         — JWT id of the *new* access token, when the
-   *                          oauthProvider hook surfaces it. May be
-   *                          undefined for opaque tokens (no JWT plugin).
+   *   - `tokenJti`         — JWT id of the *new* access token. NOT
+   *                          populated by the production hook in
+   *                          v1.4.1; reserved for direct integration
+   *                          callers and a future hook upgrade that
+   *                          surfaces the issued JWT.
    *   - `ageAtRefreshSec`  — wall-clock seconds between the previous
-   *                          token's `iat` and the refresh, when known.
+   *                          token's `iat` and the refresh. Same caveat
+   *                          as `tokenJti` — not populated by the
+   *                          production hook today.
    *
    * Per-token revoke is intentionally NOT in this catalog — the v1.4.1
    * surface only exposes whole-client revoke, which lives under

--- a/packages/api/src/lib/auth/__tests__/oauth-refresh.test.ts
+++ b/packages/api/src/lib/auth/__tests__/oauth-refresh.test.ts
@@ -24,14 +24,62 @@
  * itself (the audit logger has its own dedicated tests).
  */
 
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
 import {
   resolveAccessTokenTtlSeconds,
   resolveRefreshTokenTtlSeconds,
 } from "../server";
 import { recordOAuthTokenRefresh } from "../oauth-refresh-audit";
-import { ADMIN_ACTIONS } from "@atlas/api/lib/audit";
+import { ADMIN_ACTIONS, type AdminActionEntry } from "@atlas/api/lib/audit";
 import { oauthTokenRefresh } from "@atlas/api/lib/metrics";
+
+// Capture audit emissions through a partial-mock of the audit module.
+// CLAUDE.md requires every named export to be present — we re-export the
+// real `ADMIN_ACTIONS` constant so the catalog assertions below see the
+// load-bearing string literal.
+const auditedEntries: AdminActionEntry[] = [];
+const mockLogAdminAction: Mock<(entry: AdminActionEntry) => void> = mock(
+  (entry) => {
+    auditedEntries.push(entry);
+  },
+);
+
+mock.module("@atlas/api/lib/audit", async () => {
+  const actual = await import("@atlas/api/lib/audit/actions");
+  return {
+    ADMIN_ACTIONS: actual.ADMIN_ACTIONS,
+    logAdminAction: (entry: AdminActionEntry) => mockLogAdminAction(entry),
+    logAdminActionAwait: async (entry: AdminActionEntry) => {
+      mockLogAdminAction(entry);
+    },
+    errorMessage: (err: unknown) =>
+      err instanceof Error ? err.message : String(err),
+    causeToError: (err: unknown) =>
+      err instanceof Error ? err : new Error(String(err)),
+  };
+});
+
+// Counter spy — pre-monkeypatch the `add` method so we can assert the
+// attribute payload. We don't fully mock `@atlas/api/lib/metrics` because
+// other code paths consume the same module in this test process and a
+// partial mock would leak.
+const counterAddSpy: Mock<
+  (value: number, attrs?: Record<string, unknown>) => void
+> = mock(() => {});
+const originalCounterAdd = oauthTokenRefresh.add.bind(oauthTokenRefresh);
+oauthTokenRefresh.add = ((
+  value: number,
+  attrs?: Record<string, unknown>,
+) => {
+  counterAddSpy(value, attrs);
+  return originalCounterAdd(value, attrs);
+}) as typeof oauthTokenRefresh.add;
+
+beforeEach(() => {
+  auditedEntries.length = 0;
+  mockLogAdminAction.mockClear();
+  counterAddSpy.mockClear();
+});
 
 describe("resolveAccessTokenTtlSeconds", () => {
   it("returns the 1-hour default when the env var is unset", () => {
@@ -120,33 +168,96 @@ describe("oauthTokenRefresh counter", () => {
 });
 
 describe("recordOAuthTokenRefresh", () => {
-  it("does not throw on a fully-populated info object", () => {
-    expect(() =>
-      recordOAuthTokenRefresh({
-        clientId: "claude-desktop",
-        userId: "user_abc",
-        tokenJti: "jti_xyz",
-        ageAtRefreshSec: 3600,
-        scopes: ["openid", "profile", "offline_access", "mcp:read"],
-      }),
-    ).not.toThrow();
+  it("emits a single audit row pinning the canonical wire shape", () => {
+    // Forensic queries pivot on `action_type = 'oauth_token.refresh'`,
+    // `target_type = 'oauth_token'`, and the metadata field set. Pin
+    // every load-bearing field — a regression on any one of these
+    // breaks dashboard joins or retention policy.
+    recordOAuthTokenRefresh({
+      clientId: "claude-desktop",
+      userId: "user_abc",
+      tokenJti: "jti_xyz",
+      ageAtRefreshSec: 3600,
+      scopes: ["openid", "profile", "offline_access", "mcp:read"],
+    });
+
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = auditedEntries[0]!;
+    expect(entry.actionType).toBe("oauth_token.refresh");
+    expect(entry.targetType).toBe("oauth_token");
+    expect(entry.targetId).toBe("claude-desktop");
+    expect(entry.metadata).toMatchObject({
+      clientId: "claude-desktop",
+      userId: "user_abc",
+      tokenJti: "jti_xyz",
+      ageAtRefreshSec: 3600,
+      scopes: ["openid", "profile", "offline_access", "mcp:read"],
+    });
   });
 
-  it("does not throw when clientId is null (production hook fallback)", () => {
-    // The production hook can't always pull clientId from
-    // `customTokenResponseFields`'s `metadata` arg — record with
-    // `null` and let the audit row carry whatever we have rather
-    // than dropping the event.
-    expect(() =>
-      recordOAuthTokenRefresh({
-        clientId: null,
-        userId: "user_abc",
-        scopes: ["mcp:read"],
-      }),
-    ).not.toThrow();
+  it("falls back targetId to 'unknown' when clientId is null (production hook reality)", () => {
+    // The production hook is essentially always called with
+    // `clientId: null` because `customTokenResponseFields` does not
+    // surface the `oauthClient.clientId` column to user code. The
+    // audit row's `target_id` must NOT be NULL — forensic queries
+    // pivoting on `target_id IS NULL` would otherwise sweep these
+    // rows up by accident.
+    recordOAuthTokenRefresh({
+      clientId: null,
+      userId: "user_abc",
+      scopes: ["mcp:read"],
+    });
+
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = auditedEntries[0]!;
+    expect(entry.targetId).toBe("unknown");
+    expect(entry.metadata).toMatchObject({
+      clientId: null,
+      userId: "user_abc",
+      scopes: ["mcp:read"],
+    });
+    // tokenJti / ageAtRefreshSec are conditionally spread — must NOT
+    // appear when caller didn't supply them. A regression that always
+    // emits `tokenJti: undefined` would corrupt JSON aggregations.
+    expect(entry.metadata?.tokenJti).toBeUndefined();
+    expect(entry.metadata?.ageAtRefreshSec).toBeUndefined();
   });
 
-  it("does not throw when userId is null", () => {
+  it("emits the OTel counter with client.id + deploy.mode attributes", () => {
+    // The counter's whole reason for existing is the per-agent split.
+    // A regression dropping `client.id` collapses the dashboard view
+    // into a single bucket; a regression on `deploy.mode` mis-attributes
+    // every self-hosted refresh as SaaS or vice versa.
+    recordOAuthTokenRefresh({
+      clientId: "claude-desktop",
+      userId: "user_abc",
+      scopes: ["mcp:read"],
+    });
+
+    expect(counterAddSpy).toHaveBeenCalledTimes(1);
+    const [value, attrs] = counterAddSpy.mock.calls[0]!;
+    expect(value).toBe(1);
+    expect(attrs).toMatchObject({
+      "client.id": "claude-desktop",
+      // getConfig() is null in unit-test default — resolveDeployMode
+      // safe-defaults to self-hosted.
+      "deploy.mode": "self-hosted",
+    });
+  });
+
+  it("counter falls back client.id='unknown' when clientId is null", () => {
+    recordOAuthTokenRefresh({
+      clientId: null,
+      userId: "user_abc",
+      scopes: ["mcp:read"],
+    });
+
+    expect(counterAddSpy).toHaveBeenCalledTimes(1);
+    const [, attrs] = counterAddSpy.mock.calls[0]!;
+    expect(attrs).toMatchObject({ "client.id": "unknown" });
+  });
+
+  it("does not throw when userId is null (defense in depth)", () => {
     // M2M flows have `user?` undefined — but this hook only fires on
     // `refresh_token` grant (always user-bound per Better Auth's
     // own contract). The null path exists as a defense in depth.
@@ -157,5 +268,7 @@ describe("recordOAuthTokenRefresh", () => {
         scopes: ["openid"],
       }),
     ).not.toThrow();
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    expect(auditedEntries[0]!.metadata).toMatchObject({ userId: null });
   });
 });

--- a/packages/api/src/lib/auth/__tests__/oauth-refresh.test.ts
+++ b/packages/api/src/lib/auth/__tests__/oauth-refresh.test.ts
@@ -1,0 +1,161 @@
+/**
+ * OAuth refresh-token TTL resolvers + audit hook (#2066).
+ *
+ * Three concerns pinned here:
+ *
+ *   1. `resolveAccessTokenTtlSeconds` / `resolveRefreshTokenTtlSeconds`
+ *      — env-driven config that backs the e2e test's "mint a 30-second
+ *      JWT" override. Bad parsing here silently ships a 0-second token
+ *      or falls back to a default the e2e setup didn't expect.
+ *
+ *   2. `recordOAuthTokenRefresh` — the helper wired into Better Auth's
+ *      `customTokenResponseFields` hook. Side-effects (audit + counter)
+ *      must fire even when fields are partial; production calls have
+ *      `clientId: null` because the hook signature doesn't expose it.
+ *
+ *   3. The actions catalog and metrics counter exist and are wired in.
+ *      Compile-time + light runtime checks: `ADMIN_ACTIONS.oauth_token`
+ *      must be the string the audit row writes; `oauthTokenRefresh`
+ *      must implement the OTel Counter shape.
+ *
+ * No `mock.module()` here — the helpers under test are pure functions
+ * + side-effect emitters. The audit emit is fire-and-forget under the
+ * hood, so we exercise the call path rather than asserting on the row
+ * itself (the audit logger has its own dedicated tests).
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  resolveAccessTokenTtlSeconds,
+  resolveRefreshTokenTtlSeconds,
+} from "../server";
+import { recordOAuthTokenRefresh } from "../oauth-refresh-audit";
+import { ADMIN_ACTIONS } from "@atlas/api/lib/audit";
+import { oauthTokenRefresh } from "@atlas/api/lib/metrics";
+
+describe("resolveAccessTokenTtlSeconds", () => {
+  it("returns the 1-hour default when the env var is unset", () => {
+    expect(resolveAccessTokenTtlSeconds({} as NodeJS.ProcessEnv)).toBe(3600);
+  });
+
+  it("returns the 1-hour default when the env var is empty", () => {
+    expect(
+      resolveAccessTokenTtlSeconds({
+        ATLAS_OAUTH_ACCESS_TOKEN_TTL_SECONDS: "",
+      } as NodeJS.ProcessEnv),
+    ).toBe(3600);
+  });
+
+  it("parses a positive integer override", () => {
+    // 30 seconds is the e2e test's canonical short-TTL value — keep
+    // this assertion in sync with the spec or the test's premise breaks.
+    expect(
+      resolveAccessTokenTtlSeconds({
+        ATLAS_OAUTH_ACCESS_TOKEN_TTL_SECONDS: "30",
+      } as NodeJS.ProcessEnv),
+    ).toBe(30);
+  });
+
+  it("falls back to default on a non-numeric value (no silent 0-second token)", () => {
+    // A typo ('thirty') must not ship a zero-TTL token — that would mean
+    // every token is born expired and refresh would loop forever.
+    expect(
+      resolveAccessTokenTtlSeconds({
+        ATLAS_OAUTH_ACCESS_TOKEN_TTL_SECONDS: "thirty",
+      } as NodeJS.ProcessEnv),
+    ).toBe(3600);
+  });
+
+  it("falls back to default on zero / negative values", () => {
+    for (const raw of ["0", "-1", "  -42 "]) {
+      expect(
+        resolveAccessTokenTtlSeconds({
+          ATLAS_OAUTH_ACCESS_TOKEN_TTL_SECONDS: raw,
+        } as NodeJS.ProcessEnv),
+      ).toBe(3600);
+    }
+  });
+});
+
+describe("resolveRefreshTokenTtlSeconds", () => {
+  it("returns the 30-day default when the env var is unset", () => {
+    expect(resolveRefreshTokenTtlSeconds({} as NodeJS.ProcessEnv)).toBe(
+      60 * 60 * 24 * 30,
+    );
+  });
+
+  it("parses a positive integer override", () => {
+    expect(
+      resolveRefreshTokenTtlSeconds({
+        ATLAS_OAUTH_REFRESH_TOKEN_TTL_SECONDS: "120",
+      } as NodeJS.ProcessEnv),
+    ).toBe(120);
+  });
+
+  it("falls back to default on garbage input", () => {
+    expect(
+      resolveRefreshTokenTtlSeconds({
+        ATLAS_OAUTH_REFRESH_TOKEN_TTL_SECONDS: "forever",
+      } as NodeJS.ProcessEnv),
+    ).toBe(60 * 60 * 24 * 30);
+  });
+});
+
+describe("ADMIN_ACTIONS.oauth_token catalog", () => {
+  it("declares the canonical refresh action string", () => {
+    // The literal is the wire shape — forensic queries pivot on
+    // `action_type = 'oauth_token.refresh'`. Don't drift it.
+    expect(ADMIN_ACTIONS.oauth_token.refresh).toBe("oauth_token.refresh");
+  });
+});
+
+describe("oauthTokenRefresh counter", () => {
+  it("implements the OTel Counter `add` method", () => {
+    // We're not asserting against an exporter — there is none in unit
+    // tests. The check is structural: the metric exists and the SDK
+    // returns a real counter (not the no-op stub the type system
+    // would happily accept).
+    expect(typeof oauthTokenRefresh.add).toBe("function");
+  });
+});
+
+describe("recordOAuthTokenRefresh", () => {
+  it("does not throw on a fully-populated info object", () => {
+    expect(() =>
+      recordOAuthTokenRefresh({
+        clientId: "claude-desktop",
+        userId: "user_abc",
+        tokenJti: "jti_xyz",
+        ageAtRefreshSec: 3600,
+        scopes: ["openid", "profile", "offline_access", "mcp:read"],
+      }),
+    ).not.toThrow();
+  });
+
+  it("does not throw when clientId is null (production hook fallback)", () => {
+    // The production hook can't always pull clientId from
+    // `customTokenResponseFields`'s `metadata` arg — record with
+    // `null` and let the audit row carry whatever we have rather
+    // than dropping the event.
+    expect(() =>
+      recordOAuthTokenRefresh({
+        clientId: null,
+        userId: "user_abc",
+        scopes: ["mcp:read"],
+      }),
+    ).not.toThrow();
+  });
+
+  it("does not throw when userId is null", () => {
+    // M2M flows have `user?` undefined — but this hook only fires on
+    // `refresh_token` grant (always user-bound per Better Auth's
+    // own contract). The null path exists as a defense in depth.
+    expect(() =>
+      recordOAuthTokenRefresh({
+        clientId: "cursor",
+        userId: null,
+        scopes: ["openid"],
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/api/src/lib/auth/oauth-clients.ts
+++ b/packages/api/src/lib/auth/oauth-clients.ts
@@ -37,23 +37,30 @@ const log = createLogger("oauth-clients-helper");
  * Token-state classification surfaced to the per-user UI (#2066).
  *
  * - `active`              — the client is enabled and has at least one
- *                           outstanding non-expired access token. The
- *                           agent should be able to make a tools/call
- *                           without re-auth.
+ *                           outstanding non-expired access OR refresh
+ *                           token. The agent should be able to make a
+ *                           tools/call without user-visible re-auth.
  * - `reconnect_required`  — the client is enabled but every access
  *                           token has expired *and* no usable refresh
  *                           token remains (refresh exhausted or never
  *                           issued). The UI surfaces a re-run-wizard CTA.
- * - `revoked`             — the client row is `disabled = true`. Either
- *                           an admin or the user revoked it; the row
- *                           stays for audit retention but the agent will
- *                           always 401 from this point.
+ * - `revoked`             — the client row is `disabled = true`.
+ *                           **As of v1.4.1, no production code path
+ *                           produces this state**: `revokeOAuthClient`
+ *                           performs a hard `DELETE FROM "oauthClient"`,
+ *                           so a revoked client disappears from the
+ *                           list query entirely. The state is reserved
+ *                           for a future soft-revoke flow that flips
+ *                           `disabled` without removing the row (so the
+ *                           audit trail stays intact under whole-row
+ *                           retention policy). The UI rendering and
+ *                           tests exist now to keep the contract
+ *                           pinned for that future flow.
  *
- * The `disabled` flag is authoritative for `revoked` even when tokens
- * are still in the table — admin revoke doesn't necessarily delete
- * children inside the same transaction (Better Auth's revoke endpoint
- * cascades, but a future flow that flips `disabled` without a DELETE
- * needs the UI state to stay correct).
+ * The `disabled` flag is authoritative for `revoked` regardless of
+ * outstanding token counts — when the soft-revoke flow lands, tokens
+ * may not yet be cascaded by the time the list query reads, and the
+ * UI must already say "Revoked" rather than "Active."
  */
 export type OAuthTokenState = "active" | "reconnect_required" | "revoked";
 
@@ -197,20 +204,36 @@ export async function listOAuthClients(scope: OAuthClientScope): Promise<OAuthCl
         ${tokenUserClause}
        WHERE c."referenceId" = $1
          ${userClause}
-       GROUP BY c."clientId", c."name", c."redirectUris", c."createdAt",
-                c."updatedAt", c."disabled", c."type"
+       GROUP BY c."id", c."clientId", c."name", c."redirectUris", c."createdAt",
+                c."updatedAt", c."disabled", c."type", c."referenceId"
        ORDER BY c."createdAt" DESC`,
     params,
   );
 
   return rows.map((r): OAuthClientRow => {
     const disabled = Boolean(r.disabled);
-    const liveAccess = parseInt(r.liveTokenCount, 10);
-    const liveRefresh = parseInt(r.liveRefreshCount, 10);
+    // pg returns COUNT(*) as a string. NaN from a NULL aggregate would
+    // silently classify a healthy active client as "reconnect_required"
+    // (NaN > 0 → false → falls through to the default branch) — exactly
+    // the false-negative-fallback CLAUDE.md prohibits. A NULL here means
+    // the SQL or the schema drifted; surface a 500 with a `requestId`
+    // rather than render a wrong status badge.
+    const liveAccess = Number.parseInt(r.liveTokenCount ?? "", 10);
+    const liveRefresh = Number.parseInt(r.liveRefreshCount ?? "", 10);
+    if (!Number.isFinite(liveAccess) || !Number.isFinite(liveRefresh)) {
+      throw new Error(
+        `oauth-clients aggregate parse failed for clientId=${r.clientId} `
+        + `(liveTokenCount=${String(r.liveTokenCount)}, `
+        + `liveRefreshCount=${String(r.liveRefreshCount)})`,
+      );
+    }
     // Three-state collapse, in precedence order:
     //   1. disabled  → "revoked" wins regardless of outstanding tokens
-    //                  (admin / self-revoke flips this; tokens may not
-    //                  yet be DELETEd by the cascading endpoint).
+    //                  (reserved for a future soft-revoke flow that
+    //                  flips `disabled` without DELETEing the row;
+    //                  current `revokeOAuthClient` does a hard DELETE
+    //                  so disabled-with-rows never actually surfaces
+    //                  in v1.4.1).
     //   2. liveAccess > 0 → "active": at least one token will verify
     //                  on the next agent frame.
     //   3. liveRefresh > 0 → "active": no live access token, but the

--- a/packages/api/src/lib/auth/oauth-clients.ts
+++ b/packages/api/src/lib/auth/oauth-clients.ts
@@ -34,11 +34,42 @@ const log = createLogger("oauth-clients-helper");
 // ---------------------------------------------------------------------------
 
 /**
+ * Token-state classification surfaced to the per-user UI (#2066).
+ *
+ * - `active`              — the client is enabled and has at least one
+ *                           outstanding non-expired access token. The
+ *                           agent should be able to make a tools/call
+ *                           without re-auth.
+ * - `reconnect_required`  — the client is enabled but every access
+ *                           token has expired *and* no usable refresh
+ *                           token remains (refresh exhausted or never
+ *                           issued). The UI surfaces a re-run-wizard CTA.
+ * - `revoked`             — the client row is `disabled = true`. Either
+ *                           an admin or the user revoked it; the row
+ *                           stays for audit retention but the agent will
+ *                           always 401 from this point.
+ *
+ * The `disabled` flag is authoritative for `revoked` even when tokens
+ * are still in the table — admin revoke doesn't necessarily delete
+ * children inside the same transaction (Better Auth's revoke endpoint
+ * cascades, but a future flow that flips `disabled` without a DELETE
+ * needs the UI state to stay correct).
+ */
+export type OAuthTokenState = "active" | "reconnect_required" | "revoked";
+
+/**
  * One row of the per-client list query. Wire shape — kept aligned with the
  * Zod `OAuthClientSchema` in `me-schemas.ts` so the API edge and the web
  * page agree without a third translation layer. `tokenCount` is normalised
  * to `number` here (Postgres `COUNT(*)` returns string) so callers receive
  * a consistent shape.
+ *
+ * `tokenState` is derived in SQL (see `listOAuthClients`) so the UI
+ * can render Active / Reconnect required / Revoked without needing a
+ * second roundtrip per client. `tokenCount` continues to count *all*
+ * outstanding rows including expired ones — the legacy "active tokens"
+ * UI string is informational; the new state badge is the load-bearing
+ * health signal.
  */
 export interface OAuthClientRow {
   clientId: string;
@@ -50,6 +81,7 @@ export interface OAuthClientRow {
   type: string | null;
   lastUsedAt: string | null;
   tokenCount: number;
+  tokenState: OAuthTokenState;
 }
 
 export type RevokePhase =
@@ -118,6 +150,14 @@ export async function listOAuthClients(scope: OAuthClientScope): Promise<OAuthCl
     tokenUserClause = `AND t."userId" = $2`;
   }
 
+  // The `liveTokenCount` and `liveRefreshCount` aggregates feed the
+  // tokenState derivation below. We intentionally count "live" (non-
+  // expired) rows separately from the legacy `tokenCount` (every row,
+  // expired or not) so the UI can keep displaying "tokens issued" while
+  // gaining a precise health signal. NOW() is preferred over a JS-side
+  // Date.now() so the read is consistent with whatever transaction
+  // isolation the connection runs at — and so unit tests against a
+  // fixed-clock fixture don't drift.
   const rows = await internalQuery<{
     clientId: string;
     clientName: string | null;
@@ -128,6 +168,8 @@ export async function listOAuthClients(scope: OAuthClientScope): Promise<OAuthCl
     type: string | null;
     lastUsedAt: string | null;
     tokenCount: string;
+    liveTokenCount: string;
+    liveRefreshCount: string;
   }>(
     `SELECT c."clientId" AS "clientId",
             c."name" AS "clientName",
@@ -137,7 +179,17 @@ export async function listOAuthClients(scope: OAuthClientScope): Promise<OAuthCl
             c."disabled" AS "disabled",
             c."type" AS "type",
             MAX(t."createdAt") AS "lastUsedAt",
-            COUNT(t."id") AS "tokenCount"
+            COUNT(t."id") AS "tokenCount",
+            COUNT(t."id") FILTER (WHERE t."expiresAt" > NOW()) AS "liveTokenCount",
+            (
+              SELECT COUNT(*)
+                FROM "oauthRefreshToken" r
+               WHERE r."clientId" = c."clientId"
+                 AND r."referenceId" = c."referenceId"
+                 ${scope.kind === "user" ? `AND r."userId" = $2` : ""}
+                 AND (r."revoked" IS NULL)
+                 AND (r."expiresAt" IS NULL OR r."expiresAt" > NOW())
+            ) AS "liveRefreshCount"
        FROM "oauthClient" c
        LEFT JOIN "oauthAccessToken" t
          ON t."clientId" = c."clientId"
@@ -151,17 +203,39 @@ export async function listOAuthClients(scope: OAuthClientScope): Promise<OAuthCl
     params,
   );
 
-  return rows.map((r) => ({
-    clientId: r.clientId,
-    clientName: r.clientName,
-    redirectUris: r.redirectUris ?? [],
-    createdAt: r.createdAt,
-    updatedAt: r.updatedAt,
-    disabled: Boolean(r.disabled),
-    type: r.type,
-    lastUsedAt: r.lastUsedAt,
-    tokenCount: parseInt(r.tokenCount, 10),
-  }));
+  return rows.map((r): OAuthClientRow => {
+    const disabled = Boolean(r.disabled);
+    const liveAccess = parseInt(r.liveTokenCount, 10);
+    const liveRefresh = parseInt(r.liveRefreshCount, 10);
+    // Three-state collapse, in precedence order:
+    //   1. disabled  → "revoked" wins regardless of outstanding tokens
+    //                  (admin / self-revoke flips this; tokens may not
+    //                  yet be DELETEd by the cascading endpoint).
+    //   2. liveAccess > 0 → "active": at least one token will verify
+    //                  on the next agent frame.
+    //   3. liveRefresh > 0 → "active": no live access token, but the
+    //                  refresh path will mint one transparently.
+    //   4. otherwise → "reconnect_required": agent's MCP SDK will 401
+    //                  on next frame and cannot recover without re-DCR.
+    const tokenState: OAuthTokenState = disabled
+      ? "revoked"
+      : liveAccess > 0 || liveRefresh > 0
+        ? "active"
+        : "reconnect_required";
+
+    return {
+      clientId: r.clientId,
+      clientName: r.clientName,
+      redirectUris: r.redirectUris ?? [],
+      createdAt: r.createdAt,
+      updatedAt: r.updatedAt,
+      disabled,
+      type: r.type,
+      lastUsedAt: r.lastUsedAt,
+      tokenCount: parseInt(r.tokenCount, 10),
+      tokenState,
+    };
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/auth/oauth-refresh-audit.ts
+++ b/packages/api/src/lib/auth/oauth-refresh-audit.ts
@@ -1,0 +1,99 @@
+/**
+ * OAuth refresh-token audit + telemetry hook (#2066).
+ *
+ * Better Auth's `oauthProvider` plugin issues a fresh access token on the
+ * `refresh_token` grant — that path is the load-bearing piece of the
+ * "agent stays connected past the original JWT's expiry" contract. Without
+ * this hook the only Atlas-side record of a refresh is the underlying
+ * pino access log, which retention rotates out and which forensic queries
+ * cannot pivot on.
+ *
+ * The helper is intentionally fire-and-forget — both `logAdminAction`
+ * (under the hood) and the OTel counter swallow their own write errors,
+ * so the refresh path never fails because audit/telemetry is misconfigured.
+ *
+ * Wired from `server.ts` via `customTokenResponseFields` — that's the
+ * only oauthProvider hook that surfaces `grantType`, so the side-effect
+ * is gated on `grantType === "refresh_token"`. The hook contract gives
+ * us userId + scopes + (best-effort) clientId from the OAuth client
+ * metadata blob. `tokenJti` and `ageAtRefreshSec` are recorded when the
+ * caller can supply them — they're surfaced to bun:test integration
+ * callers but are best-effort under the production hook.
+ */
+
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
+import { oauthTokenRefresh } from "@atlas/api/lib/metrics";
+import { createLogger } from "@atlas/api/lib/logger";
+import { getConfig } from "@atlas/api/lib/config";
+
+const log = createLogger("oauth-refresh-audit");
+
+export interface OAuthTokenRefreshAuditInfo {
+  /**
+   * The OAuth client_id presenting the refresh token. Pivots forensic
+   * queries on which agent (Claude Desktop, Cursor, …) is rotating.
+   * Best-effort under the production hook — pulled from the client
+   * metadata blob when available, falls back to `"unknown"` otherwise.
+   */
+  clientId: string | null;
+  /** The user the refreshed token is bound to. */
+  userId: string | null;
+  /** JTI of the *new* access token, if the JWT plugin is active. */
+  tokenJti?: string;
+  /**
+   * Wall-clock seconds between the previous token's `iat` and the
+   * refresh, when known. Surfaces "rotation cadence" for dashboards.
+   */
+  ageAtRefreshSec?: number;
+  /** Scopes carried on the refreshed token. */
+  scopes: readonly string[];
+}
+
+function resolveDeployMode(): "self-hosted" | "saas" {
+  return getConfig()?.deployMode === "saas" ? "saas" : "self-hosted";
+}
+
+/**
+ * Emits a single `oauth_token.refresh` audit row + atlas.oauth.token_refresh
+ * counter increment. Returns `void` — the hook layer doesn't block on
+ * audit / telemetry writes.
+ *
+ * Never throws. A misconfigured audit or metrics pipeline must not
+ * abort the user-facing refresh response.
+ */
+export function recordOAuthTokenRefresh(info: OAuthTokenRefreshAuditInfo): void {
+  try {
+    oauthTokenRefresh.add(1, {
+      "client.id": info.clientId ?? "unknown",
+      "deploy.mode": resolveDeployMode(),
+    });
+  } catch (err: unknown) {
+    // Counter increments shouldn't throw, but the OTel SDK can panic if
+    // the SDK is initialized in a degraded state. Don't let a metric
+    // failure surface as a 500 on the refresh response.
+    log.debug(
+      { err: err instanceof Error ? err.message : String(err) },
+      "oauthTokenRefresh counter increment failed (non-fatal)",
+    );
+  }
+
+  // Audit row — `logAdminAction` is fire-and-forget under the hood, so
+  // we don't need a try/catch around it. `targetId` is the clientId
+  // (the entity whose token rotated); when the hook can't surface it,
+  // we fall back to `"unknown"` so forensic queries pivoting on
+  // `target_id IS NULL` don't see this row by accident.
+  logAdminAction({
+    actionType: ADMIN_ACTIONS.oauth_token.refresh,
+    targetType: "oauth_token",
+    targetId: info.clientId ?? "unknown",
+    metadata: {
+      clientId: info.clientId,
+      userId: info.userId,
+      ...(info.tokenJti ? { tokenJti: info.tokenJti } : {}),
+      ...(typeof info.ageAtRefreshSec === "number"
+        ? { ageAtRefreshSec: info.ageAtRefreshSec }
+        : {}),
+      scopes: info.scopes,
+    },
+  });
+}

--- a/packages/api/src/lib/auth/oauth-refresh-audit.ts
+++ b/packages/api/src/lib/auth/oauth-refresh-audit.ts
@@ -30,19 +30,35 @@ const log = createLogger("oauth-refresh-audit");
 
 export interface OAuthTokenRefreshAuditInfo {
   /**
-   * The OAuth client_id presenting the refresh token. Pivots forensic
-   * queries on which agent (Claude Desktop, Cursor, …) is rotating.
-   * Best-effort under the production hook — pulled from the client
-   * metadata blob when available, falls back to `"unknown"` otherwise.
+   * The OAuth client_id presenting the refresh token. Under the v1.4.1
+   * production hook this is essentially always `null` because Better
+   * Auth's `customTokenResponseFields` does not surface the
+   * `oauthClient.clientId` column to user code (only the parsed
+   * `metadata` JSONB blob, which Atlas does not write `clientId` into).
+   * The audit row + counter both fall back to `"unknown"` in that case.
+   * The field accepts a real value so a hook upgrade or a follow-up
+   * lookup that joins the issued `oauthAccessToken` row can light up
+   * the per-agent forensic split without changing call sites.
+   *
+   * Convention: `null` means "the hook could not determine it" rather
+   * than "definitely none." There is no M2M path through this helper
+   * (refresh-token grants are always user-bound), so the "definitely
+   * none" semantic does not arise.
    */
   clientId: string | null;
-  /** The user the refreshed token is bound to. */
+  /** The user the refreshed token is bound to. `null` only as defense-in-depth. */
   userId: string | null;
-  /** JTI of the *new* access token, if the JWT plugin is active. */
+  /**
+   * JTI of the *new* access token. NOT populated by the production
+   * hook in v1.4.1 — Better Auth's `customTokenResponseFields` runs
+   * before the JWT is minted. Reserved for direct integration callers
+   * and a future hook that fires post-issuance.
+   */
   tokenJti?: string;
   /**
    * Wall-clock seconds between the previous token's `iat` and the
-   * refresh, when known. Surfaces "rotation cadence" for dashboards.
+   * refresh. Same caveat as `tokenJti` — not populated by the
+   * production hook today; reserved for future upgrade.
    */
   ageAtRefreshSec?: number;
   /** Scopes carried on the refreshed token. */

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -23,6 +23,7 @@ import { scim } from "@better-auth/scim";
 import { stripe as stripePlugin } from "@better-auth/stripe";
 import { oauthProvider } from "@better-auth/oauth-provider";
 import { ATLAS_OAUTH_WORKSPACE_CLAIM } from "@atlas/api/lib/auth/oauth-claims";
+import { recordOAuthTokenRefresh } from "@atlas/api/lib/auth/oauth-refresh-audit";
 import Stripe from "stripe";
 import { getInternalDB, hasInternalDB, internalQuery, updateWorkspacePlanTier, updateWorkspaceStatus, type InternalPool, type PlanTier } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
@@ -596,6 +597,43 @@ export function resolveAllowUnauthDcr(env: NodeJS.ProcessEnv): boolean {
 }
 
 /**
+ * Default access-token TTL — 1 hour (Better Auth's default, OAuth 2.1
+ * "industry standard"). Refresh-token default — 30 days. Documented in
+ * `docs/guides/mcp-hosted.mdx` so SDK consumers have one source of truth
+ * for the contract; the literals here are the implementation half.
+ *
+ * Surfacing both as env vars (#2066) lets the e2e test override them to
+ * run a full register → expire → refresh cycle in seconds. Production
+ * operators rarely need to change these — the override exists so a
+ * Playwright spec can mint a 30-second JWT instead of waiting an hour.
+ */
+const DEFAULT_ACCESS_TOKEN_TTL_SECONDS = 3600;
+const DEFAULT_REFRESH_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 30;
+
+/**
+ * Parse an integer env var of seconds, with a positive lower bound.
+ * Empty string or a non-numeric / non-positive value falls back to the
+ * default — avoids a typo like `ATLAS_OAUTH_ACCESS_TOKEN_TTL_SECONDS=`
+ * silently shipping a 0-second token.
+ */
+function resolveTtlSeconds(raw: string | undefined, fallback: number): number {
+  if (raw === undefined) return fallback;
+  const trimmed = raw.trim();
+  if (!trimmed) return fallback;
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+export function resolveAccessTokenTtlSeconds(env: NodeJS.ProcessEnv): number {
+  return resolveTtlSeconds(env.ATLAS_OAUTH_ACCESS_TOKEN_TTL_SECONDS, DEFAULT_ACCESS_TOKEN_TTL_SECONDS);
+}
+
+export function resolveRefreshTokenTtlSeconds(env: NodeJS.ProcessEnv): number {
+  return resolveTtlSeconds(env.ATLAS_OAUTH_REFRESH_TOKEN_TTL_SECONDS, DEFAULT_REFRESH_TOKEN_TTL_SECONDS);
+}
+
+/**
  * Build the Better Auth plugins array.
  *
  * Stripe plugin is conditionally included when STRIPE_SECRET_KEY is set.
@@ -706,6 +744,13 @@ function buildPlugins() {
       allowUnauthenticatedClientRegistration: resolveAllowUnauthDcr(process.env),
       scopes: [...ATLAS_OAUTH_SCOPES],
       validAudiences: resolveOAuthValidAudiences(process.env),
+      // Token TTLs (#2066). Defaults match Better Auth's own defaults
+      // (1h access / 30d refresh) but surfaced explicitly so the e2e
+      // test can drop access TTL to ~30s without rebuilding the auth
+      // server. The values are documented in mcp-hosted.mdx — keep
+      // that doc in lockstep with the defaults above.
+      accessTokenExpiresIn: resolveAccessTokenTtlSeconds(process.env),
+      refreshTokenExpiresIn: resolveRefreshTokenTtlSeconds(process.env),
       // Bind issued tokens to the authenticating user's active workspace
       // so a token issued under workspace A cannot query workspace B's
       // data through the hosted MCP endpoint. The cast is required
@@ -730,6 +775,30 @@ function buildPlugins() {
         return referenceId
           ? { [ATLAS_OAUTH_WORKSPACE_CLAIM]: referenceId }
           : {};
+      },
+      // Refresh-token audit + telemetry hook (#2066). `customTokenResponseFields`
+      // is the only oauthProvider hook that surfaces `grantType`; we gate
+      // the side-effect on `refresh_token` so initial code-grant issuance
+      // doesn't double-count as a refresh. Returns `{}` — the hook is
+      // observability-only and never reshapes the wire response.
+      //
+      // The `metadata` arg is the parsed `oauthClient.metadata` JSONB
+      // (NOT the clientId column). We surface `clientId` as a best-effort
+      // pull from that blob when present; the bun:test integration calls
+      // `recordOAuthTokenRefresh` directly to validate audit + counter
+      // emit when clientId is known.
+      customTokenResponseFields: ({ grantType, user, scopes, metadata }) => {
+        if (grantType !== "refresh_token") return {};
+        const clientId =
+          metadata && typeof metadata.clientId === "string"
+            ? metadata.clientId
+            : null;
+        recordOAuthTokenRefresh({
+          clientId,
+          userId: user?.id ?? null,
+          scopes,
+        });
+        return {};
       },
     }),
   );

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -783,21 +783,50 @@ function buildPlugins() {
       // observability-only and never reshapes the wire response.
       //
       // The `metadata` arg is the parsed `oauthClient.metadata` JSONB
-      // (NOT the clientId column). We surface `clientId` as a best-effort
-      // pull from that blob when present; the bun:test integration calls
-      // `recordOAuthTokenRefresh` directly to validate audit + counter
-      // emit when clientId is known.
+      // (NOT the `oauthClient.clientId` column — Better Auth's hook does
+      // not surface that column). Atlas does not write `clientId` into
+      // the JSONB blob today, so under the production wiring this lookup
+      // is essentially always `null` and the audit row + counter
+      // attribute fall back to `"unknown"`. The hook still records the
+      // userId and scopes — useful even without per-client splits — and
+      // the helper signature accepts a populated clientId so a future
+      // upstream Better Auth hook upgrade (or a wrapper that joins
+      // `oauthAccessToken` post-issuance) can light up the per-agent
+      // dashboard split without changing call sites.
+      //
+      // The whole callback body is wrapped in try/catch because Better
+      // Auth `await`s this hook in the token-response code path with no
+      // try/catch on its side — a synchronous throw here would 500 the
+      // user's `/oauth/token` refresh request, breaking the very
+      // contract this telemetry exists to verify. `recordOAuthTokenRefresh`
+      // is documented "never throws" but its guarantee depends on
+      // `logAdminAction`'s fire-and-forget contract holding indefinitely,
+      // and on the `ADMIN_ACTIONS.oauth_token` constant being importable
+      // — both fragile in the face of future refactors. The defensive
+      // catch enforces the contract at the call site rather than relying
+      // on the helper's discipline.
       customTokenResponseFields: ({ grantType, user, scopes, metadata }) => {
         if (grantType !== "refresh_token") return {};
-        const clientId =
-          metadata && typeof metadata.clientId === "string"
-            ? metadata.clientId
-            : null;
-        recordOAuthTokenRefresh({
-          clientId,
-          userId: user?.id ?? null,
-          scopes,
-        });
+        try {
+          const clientId =
+            metadata && typeof metadata.clientId === "string"
+              ? metadata.clientId
+              : null;
+          recordOAuthTokenRefresh({
+            clientId,
+            userId: user?.id ?? null,
+            scopes,
+          });
+        } catch (err: unknown) {
+          // Telemetry must never break user-visible refresh. Log loud
+          // enough that operators can correlate dashboards going flat
+          // with this branch firing; pino warn (not error) reflects
+          // "non-fatal but worth investigating".
+          log.warn(
+            { err: err instanceof Error ? err.message : String(err) },
+            "oauth refresh telemetry hook threw — refresh response unaffected",
+          );
+        }
         return {};
       },
     }),

--- a/packages/api/src/lib/metrics.ts
+++ b/packages/api/src/lib/metrics.ts
@@ -98,9 +98,14 @@ export const mcpActivations: Counter = meter.createCounter(
  * separate from the noisier `atlas.mcp.tool.calls` series.
  *
  * Attributes:
- *   - `client.id`   — the OAuth client_id presenting the refresh.
- *                     Lets dashboards split refresh volume by agent
- *                     (Claude Desktop vs Cursor vs DCR-issued UUID).
+ *   - `client.id`   — the OAuth client_id presenting the refresh, when
+ *                     the hook can surface it. In v1.4.1 the production
+ *                     hook collapses to `"unknown"` because Better
+ *                     Auth's `customTokenResponseFields` does not pass
+ *                     the `oauthClient.clientId` column to user code.
+ *                     The attribute is in place so a future hook
+ *                     upgrade lights up the per-agent split without
+ *                     a metric-rename migration.
  *   - `deploy.mode` — `self-hosted` / `saas`. SaaS-only growth in this
  *                     series with self-hosted flat is the expected
  *                     shape (hosted MCP is SaaS-only).

--- a/packages/api/src/lib/metrics.ts
+++ b/packages/api/src/lib/metrics.ts
@@ -89,3 +89,26 @@ export const mcpActivations: Counter = meter.createCounter(
       "Workspace first-MCP-tool-call observed in this process (process-local dedup)",
   },
 );
+
+/**
+ * `atlas.oauth.token_refresh` — incremented every time Better Auth's
+ * `oauthProvider` issues a fresh access token via the `refresh_token`
+ * grant (#2066). Sibling to `atlas.abuse.escalations`: gives operators a
+ * dashboard signal for "agents are quietly rotating their JWTs"
+ * separate from the noisier `atlas.mcp.tool.calls` series.
+ *
+ * Attributes:
+ *   - `client.id`   — the OAuth client_id presenting the refresh.
+ *                     Lets dashboards split refresh volume by agent
+ *                     (Claude Desktop vs Cursor vs DCR-issued UUID).
+ *   - `deploy.mode` — `self-hosted` / `saas`. SaaS-only growth in this
+ *                     series with self-hosted flat is the expected
+ *                     shape (hosted MCP is SaaS-only).
+ */
+export const oauthTokenRefresh: Counter = meter.createCounter(
+  "atlas.oauth.token_refresh",
+  {
+    description:
+      "OAuth 2.1 refresh_token grants completed (Better Auth oauthProvider)",
+  },
+);

--- a/packages/mcp/src/__tests__/hosted-token-refresh.test.ts
+++ b/packages/mcp/src/__tests__/hosted-token-refresh.test.ts
@@ -1,0 +1,478 @@
+/**
+ * Hosted-MCP token refresh + expiry verifier-level tests (#2066).
+ *
+ * The browser e2e (`e2e/browser/mcp-token-refresh.spec.ts`) covers the
+ * full register → expire → refresh dance against a live Better Auth
+ * issuer. This file mirrors the failure-mode branches at the verifier
+ * level — no browser, no real OAuth server — so a regression in the
+ * 401 + WWW-Authenticate shape fails fast on every PR.
+ *
+ * Three branches the production hosted route must handle correctly:
+ *
+ *   1. Stale JWT (post-expiry, pre-refresh) — verify the route 401s
+ *      with `WWW-Authenticate: Bearer ... resource_metadata=...`. The
+ *      MCP SDK reads that header to bootstrap the refresh exchange.
+ *      A regression that drops the header silently breaks every
+ *      compliant client in production.
+ *
+ *   2. Refresh-token-expired path (post-refresh-failure, post-resource-
+ *      server retry) — same 401 shape as expired-access. The contract
+ *      is "client treats both the same"; the auth server is the only
+ *      site that knows the difference.
+ *
+ *   3. Client-revoked-mid-session — when an admin or the user revokes
+ *      the OAuth client between two frames, the next bearer-bearing
+ *      frame must 401 with the same envelope. No leakage of *why*
+ *      (user-revoke vs admin-revoke vs natural expiry) in the body.
+ *
+ * verifyAccessToken is mocked to fold each underlying failure mode
+ * (signature / audience / expired / revoked) into the single
+ * `throws` path the production verifier collapses them to.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  afterAll,
+  mock,
+  type Mock,
+} from "bun:test";
+import type { AdminActionEntry } from "@atlas/api/lib/audit";
+import { ATLAS_OAUTH_WORKSPACE_CLAIM as WORKSPACE_CLAIM } from "@atlas/api/lib/auth/oauth-claims";
+
+// ── Module-scope mocks (mirrors hosted.test.ts) ──────────────────────
+
+interface FakeJwtPayload {
+  sub: string;
+  jti?: string;
+  azp?: string;
+  scope?: string;
+  aud?: string | string[];
+  iss?: string;
+  exp?: number;
+  iat?: number;
+  [WORKSPACE_CLAIM]?: string;
+}
+
+const mockVerifyAccessToken: Mock<
+  (token: string, opts: unknown) => Promise<FakeJwtPayload>
+> = mock(async () => {
+  throw new Error("verifyAccessToken called without a stub");
+});
+
+mock.module("better-auth/oauth2", () => ({
+  verifyAccessToken: (token: string, opts: unknown) =>
+    mockVerifyAccessToken(token, opts),
+  authorizationCodeRequest: () => {
+    throw new Error("authorizationCodeRequest called from refresh test");
+  },
+  clientCredentialsToken: () => {
+    throw new Error("clientCredentialsToken called from refresh test");
+  },
+  clientCredentialsTokenRequest: () => {
+    throw new Error("clientCredentialsTokenRequest called from refresh test");
+  },
+  createAuthorizationCodeRequest: () => {
+    throw new Error("createAuthorizationCodeRequest called from refresh test");
+  },
+  createAuthorizationURL: () => {
+    throw new Error("createAuthorizationURL called from refresh test");
+  },
+  createClientCredentialsTokenRequest: () => {
+    throw new Error("createClientCredentialsTokenRequest called from refresh test");
+  },
+  createRefreshAccessTokenRequest: () => {
+    throw new Error("createRefreshAccessTokenRequest called from refresh test");
+  },
+  decryptOAuthToken: () => {
+    throw new Error("decryptOAuthToken called from refresh test");
+  },
+  generateCodeChallenge: () => {
+    throw new Error("generateCodeChallenge called from refresh test");
+  },
+  generateState: () => {
+    throw new Error("generateState called from refresh test");
+  },
+  getJwks: () => {
+    throw new Error("getJwks called from refresh test");
+  },
+  getOAuth2Tokens: () => {
+    throw new Error("getOAuth2Tokens called from refresh test");
+  },
+  handleOAuthUserInfo: () => {
+    throw new Error("handleOAuthUserInfo called from refresh test");
+  },
+  parseState: () => {
+    throw new Error("parseState called from refresh test");
+  },
+  refreshAccessToken: () => {
+    throw new Error("refreshAccessToken called from refresh test");
+  },
+  refreshAccessTokenRequest: () => {
+    throw new Error("refreshAccessTokenRequest called from refresh test");
+  },
+  setTokenUtil: () => {
+    throw new Error("setTokenUtil called from refresh test");
+  },
+  validateAuthorizationCode: () => {
+    throw new Error("validateAuthorizationCode called from refresh test");
+  },
+  validateToken: () => {
+    throw new Error("validateToken called from refresh test");
+  },
+  verifyJwsAccessToken: () => {
+    throw new Error("verifyJwsAccessToken called from refresh test");
+  },
+}));
+
+mock.module("@atlas/api/lib/residency/misrouting", () => ({
+  detectMisrouting: async () => null,
+  getApiRegion: () => null,
+  isStrictRoutingEnabled: () => false,
+  getMisroutedCount: () => 0,
+  _resetMisroutedCount: () => undefined,
+  _resetRegionCache: () => undefined,
+}));
+
+mock.module("@atlas/api/lib/db/internal", () => {
+  const notUsed = (name: string) => () => {
+    throw new Error(`db/internal.${name} called from refresh test — add a mock`);
+  };
+  return {
+    getWorkspaceRegion: async () => null,
+    hasInternalDB: () => true,
+    internalQuery: notUsed("internalQuery"),
+    internalExecute: notUsed("internalExecute"),
+    getInternalDB: notUsed("getInternalDB"),
+    assignWorkspaceRegion: notUsed("assignWorkspaceRegion"),
+    isWorkspaceMigrating: async () => false,
+    closeInternalDB: async () => undefined,
+  };
+});
+
+const auditedEntries: AdminActionEntry[] = [];
+const mockLogAdminAction: Mock<(entry: AdminActionEntry) => void> = mock(
+  (entry) => {
+    auditedEntries.push(entry);
+  },
+);
+
+mock.module("@atlas/api/lib/audit", () => ({
+  ADMIN_ACTIONS: {
+    mcp_session: { start: "mcp_session.start" },
+    oauth_token: { refresh: "oauth_token.refresh" },
+  },
+  logAdminAction: (entry: AdminActionEntry) => mockLogAdminAction(entry),
+  logAdminActionAwait: async (entry: AdminActionEntry) => {
+    mockLogAdminAction(entry);
+  },
+  errorMessage: (err: unknown) =>
+    err instanceof Error ? err.message : String(err),
+  causeToError: (err: unknown) =>
+    err instanceof Error ? err : new Error(String(err)),
+}));
+
+interface MockedConfig {
+  datasources: Record<string, unknown>;
+  tools: string[];
+  auth: string;
+  semanticLayer: string;
+  source: string;
+}
+
+const __mockedConfig: MockedConfig = {
+  datasources: {},
+  tools: ["explore", "executeSQL"],
+  auth: "auto",
+  semanticLayer: "./semantic",
+  source: "env",
+};
+
+mock.module("@atlas/api/lib/config", () => ({
+  initializeConfig: mock(async () => __mockedConfig),
+  getConfig: mock(() => __mockedConfig),
+  loadConfig: mock(async () => __mockedConfig),
+  configFromEnv: mock(() => __mockedConfig),
+  validateAndResolve: mock(() => __mockedConfig),
+  defineConfig: (c: unknown) => c,
+  applyDatasources: mock(async () => undefined),
+  validateToolConfig: mock(async () => undefined),
+  formatZodErrors: () => "",
+  _resetConfig: mock(() => undefined),
+  _setConfigForTest: mock(() => undefined),
+  _warnPoolDefaultsInSaaS: mock(() => undefined),
+}));
+
+mock.module("@atlas/api/lib/tools/explore", () => ({
+  explore: {
+    description: "Explore the semantic layer",
+    execute: mock(async () => "catalog.yml"),
+  },
+}));
+
+mock.module("@atlas/api/lib/tools/sql", () => ({
+  executeSQL: {
+    description: "Execute SQL",
+    execute: mock(async () => ({
+      success: true,
+      explanation: "ok",
+      row_count: 0,
+      columns: [],
+      rows: [],
+      truncated: false,
+    })),
+  },
+}));
+
+const { Hono } = await import("hono");
+const { createHostedMcpRouter, _resetHostedSessions } = await import("../hosted.js");
+
+// ── Test fixtures ─────────────────────────────────────────────────────
+
+const ORG = "org_a";
+const CLIENT_ID = "claude-desktop";
+const SUB = "user_a";
+const STALE_TOKEN = "fake.jwt.stale";
+
+beforeEach(() => {
+  mockVerifyAccessToken.mockReset();
+  mockLogAdminAction.mockReset();
+  mockLogAdminAction.mockImplementation((entry) => {
+    auditedEntries.push(entry);
+  });
+  auditedEntries.length = 0;
+  delete process.env.ATLAS_MCP_MAX_SESSIONS;
+});
+
+afterEach(async () => {
+  await _resetHostedSessions();
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+async function startServer() {
+  const app = new Hono();
+  app.route("/mcp", createHostedMcpRouter());
+  const server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    fetch: app.fetch,
+  });
+  return {
+    url: `http://localhost:${server.port}`,
+    close: () => server.stop(true),
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("hosted MCP — refresh contract", () => {
+  it("rejects a stale (expired) JWT with 401 + WWW-Authenticate pointing at resource metadata", async () => {
+    // Production verifier collapses signature / audience / expired into
+    // a single throw. We mimic the expired-token shape jose emits — the
+    // route's behavior is identical regardless of underlying cause, but
+    // the assertion comment names the intent.
+    mockVerifyAccessToken.mockImplementation(async () => {
+      throw new Error('"exp" claim timestamp check failed');
+    });
+
+    const handle = await startServer();
+    try {
+      const res = await fetch(`${handle.url}/mcp/${ORG}/sse`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${STALE_TOKEN}`,
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", method: "ping", id: 1 }),
+      });
+
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { error: string; requestId: string };
+      expect(body.error).toBe("invalid_bearer");
+      expect(body.requestId).toBeTruthy();
+
+      const wwwAuth = res.headers.get("www-authenticate");
+      expect(wwwAuth).toBeTruthy();
+      // RFC 9728 + MCP spec: the resource_metadata pointer is the
+      // contract that lets the SDK bootstrap a refresh exchange (or
+      // re-DCR) without out-of-band config.
+      expect(wwwAuth).toContain("Bearer");
+      expect(wwwAuth).toContain("resource_metadata=");
+      expect(wwwAuth).toContain(`/mcp/${ORG}`);
+    } finally {
+      handle.close();
+    }
+  });
+
+  it("returns the same 401 envelope when the OAuth client is revoked mid-session", async () => {
+    // Better Auth's verifyAccessToken throws on a token whose underlying
+    // oauth client was deleted (the JWKS still verifies the signature,
+    // but the introspect/lookup paths fail). The route's contract: same
+    // envelope as expired — clients cannot distinguish revoke from
+    // expiry from the response body.
+    mockVerifyAccessToken.mockImplementation(async () => {
+      throw new Error("client not found");
+    });
+
+    const handle = await startServer();
+    try {
+      const res = await fetch(`${handle.url}/mcp/${ORG}/sse`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${STALE_TOKEN}`,
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list", id: 1 }),
+      });
+
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as Record<string, unknown>;
+      // Body must NOT carry the underlying revocation reason — that
+      // would let an adversary distinguish "user revoked" from "admin
+      // revoked" from "natural expiry" via timing or copy.
+      expect(body.error).toBe("invalid_bearer");
+      const bodyText = JSON.stringify(body);
+      expect(bodyText).not.toContain("revoked");
+      expect(bodyText).not.toContain("client not found");
+
+      const wwwAuth = res.headers.get("www-authenticate");
+      expect(wwwAuth).toContain("resource_metadata=");
+    } finally {
+      handle.close();
+    }
+  });
+
+  it("returns 401 + WWW-Authenticate when the refresh attempt itself failed (refresh-token expired)", async () => {
+    // The MCP SDK contract: if the refresh exchange returns
+    // 400 invalid_grant, the SDK retries the original frame against
+    // the resource server with the still-stale access token. The
+    // resource server's response must again be 401 with the
+    // resource_metadata pointer so the SDK then triggers re-DCR.
+    mockVerifyAccessToken.mockImplementation(async () => {
+      throw new Error("invalid_grant");
+    });
+
+    const handle = await startServer();
+    try {
+      const res = await fetch(`${handle.url}/mcp/${ORG}/sse`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${STALE_TOKEN}`,
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "tools/call",
+          params: { name: "explore", arguments: { path: "" } },
+          id: 1,
+        }),
+      });
+
+      expect(res.status).toBe(401);
+      expect(res.headers.get("www-authenticate")).toContain(
+        "resource_metadata=",
+      );
+
+      // Audit invariant: the resource server's 401 path does NOT emit
+      // an `oauth_token.refresh` row — that's the auth server's job
+      // (and only fires when refresh succeeded). A regression that
+      // emits it here would inflate the success counter.
+      expect(
+        auditedEntries.some((e) => e.actionType === "oauth_token.refresh"),
+      ).toBe(false);
+    } finally {
+      handle.close();
+    }
+  });
+
+  it("WWW-Authenticate's resource_metadata URL is workspace-specific", async () => {
+    // Each workspace has its own resource. Cross-workspace collisions
+    // (same metadata URL for org_a and org_b) would let a token issued
+    // for one workspace be replayed against another by following the
+    // metadata pointer to the same auth server. The metadata path
+    // includes the workspace id explicitly — pin it so a future
+    // refactor of `wwwAuthenticateHeader` can't drop the segment.
+    mockVerifyAccessToken.mockImplementation(async () => {
+      throw new Error("expired");
+    });
+
+    const handle = await startServer();
+    try {
+      const resA = await fetch(`${handle.url}/mcp/org_alpha/sse`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${STALE_TOKEN}`,
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", method: "ping", id: 1 }),
+      });
+      const resB = await fetch(`${handle.url}/mcp/org_beta/sse`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${STALE_TOKEN}`,
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", method: "ping", id: 1 }),
+      });
+
+      const wwwAlpha = resA.headers.get("www-authenticate") ?? "";
+      const wwwBeta = resB.headers.get("www-authenticate") ?? "";
+      expect(wwwAlpha).toContain("/mcp/org_alpha");
+      expect(wwwBeta).toContain("/mcp/org_beta");
+      expect(wwwAlpha).not.toBe(wwwBeta);
+    } finally {
+      handle.close();
+    }
+  });
+
+  it("happy-path verify keeps a fresh token unchallenged (regression guard)", async () => {
+    // Negative control: the refresh contract is only loadbearing on the
+    // 401 path. A regression that caused every verified token to also
+    // emit WWW-Authenticate would silently force every working session
+    // through the recovery flow. This pins the negative invariant.
+    mockVerifyAccessToken.mockImplementation(async () => ({
+      sub: SUB,
+      jti: "jti_fresh",
+      azp: CLIENT_ID,
+      scope: "openid mcp:read",
+      [WORKSPACE_CLAIM]: ORG,
+    }));
+
+    const handle = await startServer();
+    try {
+      const res = await fetch(`${handle.url}/mcp/${ORG}/sse`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          Authorization: `Bearer fresh.jwt.token`,
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-03-26",
+            capabilities: {},
+            clientInfo: { name: "test", version: "0.0.0" },
+          },
+          id: 1,
+        }),
+      });
+
+      // The MCP SDK transport may negotiate via SSE; we only assert
+      // *not 401* and *no WWW-Authenticate* — the contract for fresh
+      // tokens, regardless of whether the response is 200 / 202 /
+      // streamed.
+      expect(res.status).not.toBe(401);
+      expect(res.headers.get("www-authenticate")).toBeNull();
+    } finally {
+      handle.close();
+    }
+  });
+});

--- a/packages/web/src/app/admin/oauth-clients/__tests__/oauth-clients-schema.test.ts
+++ b/packages/web/src/app/admin/oauth-clients/__tests__/oauth-clients-schema.test.ts
@@ -20,6 +20,9 @@ describe("ListOAuthClientsResponseSchema round-trip", () => {
         type: "public",
         lastUsedAt: "2026-05-01T15:30:00.000Z",
         tokenCount: 3,
+        // tokenState (#2066) — required wire field. Active row has at
+        // least one outstanding non-expired access or refresh token.
+        tokenState: "active" as const,
       },
       {
         clientId: "dcr-uuid-abc",
@@ -31,6 +34,10 @@ describe("ListOAuthClientsResponseSchema round-trip", () => {
         type: null,
         lastUsedAt: null,
         tokenCount: 0,
+        // Registered but never used — no live tokens yet, but the row
+        // is fresh; UI presents the same "registered, awaiting first
+        // use" affordance whichever leg of the enum lands here.
+        tokenState: "reconnect_required" as const,
       },
     ],
   };

--- a/packages/web/src/app/settings/ai-agents/page.tsx
+++ b/packages/web/src/app/settings/ai-agents/page.tsx
@@ -51,7 +51,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { formatDate, formatDateTime } from "@/lib/format";
-import { Bot, Loader2, Plus, Trash2 } from "lucide-react";
+import { AlertTriangle, Bot, Loader2, Plus, RefreshCw, Trash2 } from "lucide-react";
 
 // Wizard is heavier than the list view (carries client-config templates +
 // clipboard glue) and only opens on user action. Dynamic import keeps the
@@ -167,11 +167,20 @@ export default function AIAgentsPage() {
             />
             <div className="space-y-2">
               {clients.map((client) => (
-                <AIAgentShell
+                <div
                   key={client.clientId}
-                  client={client}
-                  onRevoke={requestRevoke}
-                />
+                  // Revoked rows dim slightly so the audit trail is visible
+                  // but the row reads as "no longer active". Active and
+                  // reconnect_required render at full opacity.
+                  className={cn(
+                    client.tokenState === "revoked" && "opacity-60",
+                  )}
+                >
+                  <AIAgentShell
+                    client={client}
+                    onRevoke={requestRevoke}
+                  />
+                </div>
               ))}
             </div>
           </section>
@@ -253,6 +262,46 @@ export default function AIAgentsPage() {
   );
 }
 
+/**
+ * Map the wire-level `tokenState` to the page's three-state UI surface.
+ * The function is a pure switch so the badge / status / description /
+ * row dim treatment all derive from one decision and stay in lockstep.
+ *
+ * The legacy `disabled` flag remains the source of truth for `revoked`
+ * — admin-revoke flips it before the cascading DELETE finishes — and
+ * `tokenState` collapses three signals (disabled, live access, live
+ * refresh) into one render-time enum so the renderer doesn't have to
+ * re-derive the precedence.
+ */
+function presentTokenState(tokenState: OAuthClient["tokenState"]): {
+  status: StatusKind;
+  badge: { label: string; tone: "muted" | "warn" | "danger" } | null;
+  description: string | null;
+} {
+  switch (tokenState) {
+    case "active":
+      return {
+        status: "connected",
+        // No badge for the healthy state — the row stays uncluttered;
+        // the connected status dot already conveys "Active".
+        badge: null,
+        description: null,
+      };
+    case "reconnect_required":
+      return {
+        status: "ready",
+        badge: { label: "Reconnect required", tone: "warn" },
+        description: "Last token expired and refresh failed — re-run the connect wizard to restore this agent.",
+      };
+    case "revoked":
+      return {
+        status: "unavailable",
+        badge: { label: "Revoked", tone: "danger" },
+        description: "Revoked — remove from the list to clean up.",
+      };
+  }
+}
+
 function AIAgentShell({
   client,
   onRevoke,
@@ -260,47 +309,70 @@ function AIAgentShell({
   client: OAuthClient;
   onRevoke: (client: OAuthClient) => void;
 }) {
-  const status: StatusKind = client.disabled
-    ? "unavailable"
-    : client.lastUsedAt
-      ? "connected"
-      : "ready";
+  const presentation = presentTokenState(client.tokenState);
   const displayName = client.clientName ?? client.clientId;
+  const description =
+    presentation.description ??
+    (client.lastUsedAt
+      ? `Last used ${formatDateTime(client.lastUsedAt)}`
+      : "Registered but never used");
+
+  const badge = presentation.badge ? (
+    <Badge
+      variant="outline"
+      className={cn(
+        "shrink-0 text-[10px]",
+        presentation.badge.tone === "danger" && "border-destructive/30 text-destructive",
+        presentation.badge.tone === "warn" && "border-amber-500/40 text-amber-700 dark:text-amber-400",
+      )}
+    >
+      {presentation.badge.tone === "warn" && (
+        <AlertTriangle className="mr-1 size-3" aria-hidden="true" />
+      )}
+      {presentation.badge.label}
+    </Badge>
+  ) : client.type === "public" ? (
+    <Badge variant="outline" className="shrink-0 text-[10px]">
+      Public
+    </Badge>
+  ) : undefined;
 
   return (
     <Shell
       icon={Bot}
       title={displayName}
-      description={
-        client.disabled
-          ? "Disabled — revoke to remove from the list"
-          : client.lastUsedAt
-            ? `Last used ${formatDateTime(client.lastUsedAt)}`
-            : "Registered but never used"
-      }
-      status={status}
-      titleBadge={
-        client.disabled ? (
-          <Badge variant="outline" className="shrink-0 border-destructive/30 text-[10px] text-destructive">
-            Disabled
-          </Badge>
-        ) : client.type === "public" ? (
-          <Badge variant="outline" className="shrink-0 text-[10px]">
-            Public
-          </Badge>
-        ) : undefined
-      }
+      description={description}
+      status={presentation.status}
+      titleBadge={badge}
       actions={
-        <Button
-          variant="outline"
-          size="xs"
-          onClick={() => onRevoke(client)}
-          className="text-destructive hover:text-destructive"
-          aria-label={`Revoke ${displayName}`}
-        >
-          <Trash2 className="mr-1.5 size-3" />
-          Revoke
-        </Button>
+        <div className="flex items-center gap-2">
+          {client.tokenState === "reconnect_required" && (
+            <Button
+              variant="outline"
+              size="xs"
+              onClick={() => onRevoke(client)}
+              aria-label={`Reconnect ${displayName}`}
+              // The reconnect path is "revoke + re-run the wizard" today
+              // (no per-token refresh UI in 1.4.1). The CTA shares the
+              // revoke handler so the table state converges immediately
+              // — Out of scope: a one-click "refresh now" that doesn't
+              // tear down the client.
+            >
+              <RefreshCw className="mr-1.5 size-3" />
+              Reconnect
+            </Button>
+          )}
+          <Button
+            variant="outline"
+            size="xs"
+            onClick={() => onRevoke(client)}
+            className="text-destructive hover:text-destructive"
+            aria-label={`Revoke ${displayName}`}
+          >
+            <Trash2 className="mr-1.5 size-3" />
+            Revoke
+          </Button>
+        </div>
       }
     >
       <DetailList>

--- a/packages/web/src/app/settings/ai-agents/page.tsx
+++ b/packages/web/src/app/settings/ai-agents/page.tsx
@@ -299,6 +299,24 @@ function presentTokenState(tokenState: OAuthClient["tokenState"]): {
         badge: { label: "Revoked", tone: "danger" },
         description: "Revoked — remove from the list to clean up.",
       };
+    default: {
+      // Defense in depth: if the API ever ships a fourth state before
+      // this page is updated, the Zod schema in `me-schemas.ts` will
+      // normally reject the response at the parse boundary. But during
+      // a multi-PR rollout the schema can land first; without this
+      // branch, an unknown enum value crashes the entire page render
+      // with `TypeError: Cannot read properties of undefined`. Fall
+      // back to a neutral status badge + soft warning so the rest of
+      // the table stays usable. `satisfies never` keeps compile-time
+      // exhaustiveness.
+      const _exhaustive: never = tokenState;
+      console.error(`Unknown tokenState received from API: ${String(_exhaustive)}`);
+      return {
+        status: "ready",
+        badge: { label: "Unknown state", tone: "warn" },
+        description: "Status temporarily unavailable — please refresh.",
+      };
+    }
   }
 }
 

--- a/packages/web/src/ui/lib/me-schemas.ts
+++ b/packages/web/src/ui/lib/me-schemas.ts
@@ -39,6 +39,17 @@ export const OAuthClientSchema = z.object({
   // the route. `int().nonnegative()` rejects NaN (parseInt of garbage),
   // negatives, and fractions — defense-in-depth for the route's coercion.
   tokenCount: z.number().int().nonnegative(),
+  // tokenState (#2066) — derived in SQL from disabled flag + outstanding
+  // non-expired access/refresh tokens. The Settings → AI Agents table
+  // renders this as a status badge:
+  //   - "active"             → green "Active"
+  //   - "reconnect_required" → amber CTA prompting the user to re-run
+  //                            the connect wizard
+  //   - "revoked"            → dimmed row, deletion is the only sensible
+  //                            next step
+  // Legacy `tokenCount` stays as the informational "tokens issued"
+  // signal; `tokenState` is the load-bearing health field.
+  tokenState: z.enum(["active", "reconnect_required", "revoked"]),
 });
 
 export const ListOAuthClientsResponseSchema = z.object({


### PR DESCRIPTION
## Summary

Wires end-to-end coverage of the OAuth 2.1 refresh path that #2024 issued tokens for, surfaces a queryable `tokenState` on `/me/oauth-clients`, and adds the audit + OTel signals needed to answer "how often are tokens rotating?" without grepping pino.

- **TTL knobs** (`packages/api/src/lib/auth/server.ts`) — surfaces `ATLAS_OAUTH_ACCESS_TOKEN_TTL_SECONDS` (default 1h) and `ATLAS_OAUTH_REFRESH_TOKEN_TTL_SECONDS` (default 30d) and pipes them into Better Auth's `oauthProvider`. The 30-second access TTL the e2e test relies on now ships behind a single env var.
- **Refresh hook** (`packages/api/src/lib/auth/oauth-refresh-audit.ts`) — fire-and-forget helper wired into `customTokenResponseFields`. Emits an `oauth_token.refresh` audit row + `atlas.oauth.token_refresh` OTel counter on every `refresh_token` grant. Side-effects only; the response shape is unchanged.
- **`tokenState`** (`packages/api/src/lib/auth/oauth-clients.ts`) — the list query now derives `active | reconnect_required | revoked` in SQL from `disabled` + outstanding non-expired access/refresh counts. The same field flows through `/me/oauth-clients`, `/admin/oauth-clients`, and `me-schemas.ts`.
- **UX** (`packages/web/src/app/settings/ai-agents/page.tsx`) — three-state badge + a Reconnect CTA that re-uses the revoke handler (1.4.1's "reconnect" is intentionally revoke + re-run-wizard). Revoked rows dim but stay visible.
- **Tests** —
  - `packages/api/src/lib/auth/__tests__/oauth-refresh.test.ts` (TTL parsing + recordOAuthTokenRefresh contract)
  - `packages/api/src/api/__tests__/me-oauth-clients.test.ts` (tokenState cases — active via access, active via refresh-only, reconnect_required, revoked precedence)
  - `packages/mcp/src/__tests__/hosted-token-refresh.test.ts` (verifier-level 401 + WWW-Authenticate for stale JWT, revoked client, refresh-token-expired, workspace-specific resource_metadata, fresh-token negative control)
  - `e2e/browser/mcp-token-refresh.spec.ts` (`@llm`) — page renders all three tokenState UX flavors, Reconnect CTA wires to revoke dialog
- **Docs** (`apps/docs/content/docs/guides/mcp-hosted.mdx`) — new "Token refresh contract" section documents access/refresh TTLs, the happy-path flow, the 401 + `WWW-Authenticate` recovery contract, and the `tokenState` wire field. Stays out of the sticky-routing section near line 163 (#2069's territory).

## Out of scope (per issue)

- Per-token revocation UI (current surface is whole-client revoke).
- RFC 6749 §6 strict refresh-token rotation (Better Auth's default behavior is documented as-is).

## Test plan

- [x] `bun run scripts/test-isolated.ts --affected` from `packages/api/` — 73/73
- [x] `bun test` in `packages/mcp/` — 173/173
- [x] `bun run test` (full) — all packages green; no flakes
- [x] `bun run lint` — 0 errors, 0 warnings
- [x] `bun run type` — 0 errors
- [x] `bun x syncpack lint` — no issues
- [x] Template drift — passed
- [x] Security-headers drift — passed
- [x] Railway watch — 42 COPY sources covered

Closes #2066