### PR TITLE
feat(api,web,docs): #2092 — passkey-only user recovery (Wave 2B closeout)

### DIFF
--- a/apps/docs/content/docs/security/passkeys.mdx
+++ b/apps/docs/content/docs/security/passkeys.mdx
@@ -201,6 +201,108 @@ for the rationale on always logging this branch (silent in the UI,
 but visible in DevTools, so a misconfigured RP doesn't disappear
 without trace).
 
+## Recovery
+
+Atlas treats account recovery as an **explicit, audited admin
+action** rather than a self-service primitive. The recovery model
+has two halves: a recommended posture that keeps any single user
+out of lockout territory, and a documented escape hatch for the
+narrow case where someone still ends up locked out.
+
+### Recommended posture
+
+Pick **one** of the following — any of them keeps you out of the
+lockout edge case:
+
+- **Two passkeys on different devices.** A laptop passkey plus a
+  phone passkey is the most resilient setup: each device has its own
+  hardware-bound credential, and losing one doesn't take the other
+  out.
+- **A password kept on the account, paired with a passkey.** A
+  password is itself a separate factor and an automatic recovery
+  path — the sign-in page will still accept it, and an admin who
+  signed up via email/password can always fall back to it.
+- **TOTP enrolled alongside the passkey.** TOTP plus a passkey
+  satisfies the MFA gate from either side; losing one still leaves
+  the other.
+
+The security page nudges users toward the first option. Whenever a
+user matches the **lockout-risk profile** — exactly one passkey, no
+password set, no TOTP — a yellow banner appears at the top of
+**Admin → Settings → Security** asking them to enroll a second
+passkey or add a password. The banner is dismissable for the current
+session but re-renders on the next sign-in until the predicate
+clears (≥2 passkeys, OR a password, OR TOTP). The same predicate is
+visible in the workspace **Security posture** panel: passkey-only
+admins fall in the *passkey-only* bucket, distinct from *both
+factors*.
+
+### What happens if you're locked out
+
+If a passkey-only user loses their only authenticator (lost device,
+no cloud sync, no second passkey, no password), an admin **resets
+their MFA** from the user detail page:
+
+1. Workspace admin (or platform admin, cross-org) opens
+   **Admin → Users → \<user\>**.
+2. In the **Danger zone** card, click **Reset MFA enrollment**.
+3. A reason dialog records what triggered the reset (e.g. *"User
+   reports stolen laptop, cross-checked with HR ticket TKT-1234"*).
+   The reason is recorded in the audit log alongside the action.
+4. On confirm, the API atomically clears the user's passkey
+   enrollments, TOTP secret, and bundled backup-code batch in a
+   single transaction. Sessions and OAuth grants are deliberately
+   **left in place** — this is recovery, not off-boarding (off-
+   boarding is the separate **Revoke all authentication** path).
+5. The user is forced to re-enroll a second factor on the next
+   admin-router request via the existing
+   `mfa_enrollment_required` 403 — see
+   [Two-Factor Authentication](./two-factor-auth#how-the-gate-works).
+
+The audit row carries per-artifact counts (passkeys, TOTP secrets,
+backup-code batches), the actor, the target, and the reason — so
+forensic queries can answer "who was reset, by whom, when, and why"
+without joining other tables. The action type is `user.mfa_reset`,
+distinct from `user.auth_revoke` (the off-boarding sibling) so
+compliance queries can split recovery from off-boarding.
+
+Workspace admins can only reset users in their own org. Cross-org
+resets require a platform admin and emit the same audit row.
+
+### What we don't ship — and why
+
+Atlas deliberately does **not** offer the following recovery
+mechanisms:
+
+- **Recovery codes decoupled from TOTP.** Better Auth's `twoFactor`
+  plugin bundles backup codes with TOTP enrollment as a single
+  primitive — `POST /two-factor/enable` issues the secret and the
+  codes together; `POST /two-factor/generate-backup-codes` is a
+  regenerate endpoint that assumes TOTP is already enabled. Shipping
+  passkey-only users a *separate* recovery-code primitive would mean
+  either hacking the plugin contract (fragile, breaks on every
+  Better Auth update) or building a parallel recovery-codes table
+  outside the plugin (duplicates a primitive, requires our own
+  verification + invalidation). Both bad. The principled answer is
+  to widen the lockout bottleneck (the recommended posture above)
+  rather than add a parallel recovery primitive.
+- **Email-based recovery / OTP.** Email is not a strong enough
+  factor for an admin role: an attacker who compromises the inbox
+  compromises the recovery channel. Worse, it leaks who has Atlas
+  access to anyone who can read the inbox (a privacy regression for
+  shared accounts). Admin-mediated reset by another human is a
+  stronger trust anchor for the same recovery scenario.
+- **Forcing TOTP as the recovery factor.** The whole point of
+  passkey-first sign-in is treating passkeys as a first-class
+  factor, not a TOTP UX layer. Mandating TOTP for "recovery" would
+  undo that.
+
+If you have a deployment that needs one of the above, file an
+enhancement request — but expect the bar to be high: the recovery
+model above is the result of [Wave 2B's
+discussion](https://github.com/AtlasDevHQ/atlas/issues/2092),
+not an oversight.
+
 ## Operator Reference
 
 ### What's stored
@@ -248,9 +350,11 @@ gate and works on any browser.
   significant UI surface (the QR rendering, the BLE proximity
   pairing, the connection-state banner) and is gated on an explicit
   enterprise contract before we wire it.
-- Recovery for a user with no remaining passkey and no backup codes
-  requires an out-of-band reset by a `platform_admin`. A user-
-  triggered recovery flow is tracked in the Wave 2B parallel issue.
+- Recovery for a user with no remaining passkey and no other factor
+  requires an admin-mediated MFA reset (Wave 2B closeout — see
+  [Recovery](#recovery) above). A user-triggered self-service
+  recovery flow is intentionally not provided; the rationale is
+  documented in the same section.
 - A single global `rpID` is used for all hosted regions
   (`app.useatlas.dev`). WebAuthn binds credentials to a single
   registrable suffix; per-region frontends would each need a

--- a/apps/docs/content/docs/security/passkeys.mdx
+++ b/apps/docs/content/docs/security/passkeys.mdx
@@ -299,9 +299,7 @@ mechanisms:
 
 If you have a deployment that needs one of the above, file an
 enhancement request — but expect the bar to be high: the recovery
-model above is the result of [Wave 2B's
-discussion](https://github.com/AtlasDevHQ/atlas/issues/2092),
-not an oversight.
+model above is a deliberate design decision, not an oversight.
 
 ## Operator Reference
 

--- a/packages/api/src/api/__tests__/admin-mfa-reset.test.ts
+++ b/packages/api/src/api/__tests__/admin-mfa-reset.test.ts
@@ -38,6 +38,16 @@ const mocks = createApiTestMocks({
   },
 });
 
+// Mutable detectAuthMode override — the factory captures a frozen mode
+// at construction; we need a runtime knob so the simple-key guard test
+// can flip without rebuilding the whole mock graph. Later mock.module
+// wins, so this overrides the factory's detect stub.
+let currentAuthMode = "managed";
+mock.module("@atlas/api/lib/auth/detect", () => ({
+  detectAuthMode: () => currentAuthMode,
+  resetAuthModeCache: () => {},
+}));
+
 interface AuditEntry {
   actionType: string;
   targetType: string;
@@ -129,6 +139,7 @@ function resetTxClient(): void {
 
 beforeEach(() => {
   mocks.hasInternalDB = true;
+  currentAuthMode = "managed";
   mocks.setOrgAdmin("org-alpha");
   mocks.mockInternalQuery.mockReset();
   mocks.mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
@@ -205,22 +216,23 @@ describe("admin reset-mfa — POST /users/:id/reset-mfa", () => {
     expect(clientReleased).toBe(true);
     expect(clientReleaseArg).toBeUndefined();
 
-    // The narrower-scope guard: this route MUST NOT touch sessions /
-    // trust-devices / OAuth tokens. A regression that imported the
-    // wrong DELETE block from admin-revoke.ts would land here.
+    // Positive whitelist: this route MUST mutate exactly { passkey,
+    // twoFactor, user } and nothing else. A copy-paste regression from
+    // admin-revoke.ts that added a DELETE on session/trust-device/OAuth
+    // would surface as an extra entry. Stronger than a negative
+    // blacklist — it catches additions to a fourth table we haven't
+    // thought to forbid.
     const tablesTouched = clientQueries
       .filter((q) => /^\s*(DELETE|UPDATE)\b/i.test(q.sql))
       .map((q) => {
         const m = q.sql.match(/(?:DELETE\s+FROM|UPDATE)\s+"?(\w+)"?/i);
         return m ? m[1] : null;
       });
-    expect(tablesTouched).toContain("passkey");
-    expect(tablesTouched).toContain("twoFactor");
-    expect(tablesTouched).toContain("user");
-    expect(tablesTouched).not.toContain("session");
-    expect(tablesTouched).not.toContain("trusted_device");
-    expect(tablesTouched).not.toContain("oauthAccessToken");
-    expect(tablesTouched).not.toContain("oauthRefreshToken");
+    expect([...new Set(tablesTouched)].sort()).toEqual([
+      "passkey",
+      "twoFactor",
+      "user",
+    ]);
 
     expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
     const entry = lastAuditCall();
@@ -495,6 +507,21 @@ describe("admin reset-mfa — POST /users/:id/reset-mfa", () => {
       adminRequest("POST", "/api/v1/admin/users/user-target/reset-mfa", {}),
     );
     expect(res.status).toBe(404);
+  });
+
+  it("returns 404 in simple-key mode even with an internal DB attached", async () => {
+    // The right arm of `!hasInternalDB() || detectAuthMode() !== "managed"`.
+    // A regression that flipped the OR to AND, or dropped the auth-mode
+    // check, would let a self-hosted simple-key admin clear another
+    // user's MFA against the managed Better Auth schema.
+    mocks.hasInternalDB = true;
+    currentAuthMode = "simple-key";
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/users/user-target/reset-mfa", {}),
+    );
+    expect(res.status).toBe(404);
+    // Fast-path guard — no transaction should have been opened.
+    expect(clientQueries.map((q) => q.sql.trim().toUpperCase()).includes("BEGIN")).toBe(false);
   });
 
   it("rejects an oversized reason rather than landing it in audit metadata", async () => {

--- a/packages/api/src/api/__tests__/admin-mfa-reset.test.ts
+++ b/packages/api/src/api/__tests__/admin-mfa-reset.test.ts
@@ -1,0 +1,597 @@
+/**
+ * Admin MFA-reset route tests (#2092).
+ *
+ * Sibling to `admin-revoke.test.ts`: same MockClient transactional capture,
+ * same workspace-vs-platform authz split, same scrub-the-pg-userinfo audit
+ * contract. The narrower deletion scope (passkeys + twoFactor only) is the
+ * load-bearing distinction — a regression that started deleting sessions
+ * or OAuth tokens here would erase the boundary between #2093 and #2092
+ * and is exactly what these tests pin.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterAll,
+  mock,
+  type Mock,
+} from "bun:test";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+
+const mockGetInternalDB = mock(() => ({
+  connect: async () => makeMockClient(),
+}));
+
+const mocks = createApiTestMocks({
+  authUser: {
+    id: "admin-1",
+    mode: "managed",
+    label: "admin@test.com",
+    role: "admin",
+    activeOrganizationId: "org-alpha",
+  },
+  authMode: "managed",
+  internal: {
+    getInternalDB: mockGetInternalDB,
+  },
+});
+
+interface AuditEntry {
+  actionType: string;
+  targetType: string;
+  targetId: string;
+  status?: "success" | "failure";
+  ipAddress?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+const mockLogAdminAction: Mock<(entry: AuditEntry) => void> = mock(() => {});
+
+mock.module("@atlas/api/lib/audit", async () => {
+  const actual = await import("@atlas/api/lib/audit/actions");
+  return {
+    logAdminAction: mockLogAdminAction,
+    logAdminActionAwait: mock(async () => {}),
+    ADMIN_ACTIONS: actual.ADMIN_ACTIONS,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Transactional client mock
+// ---------------------------------------------------------------------------
+
+interface ClientQuery {
+  sql: string;
+  params?: unknown[];
+}
+
+interface MockClient {
+  query: (sql: string, params?: unknown[]) => Promise<{ rows: Record<string, unknown>[] }>;
+  release: (err?: unknown) => void;
+}
+
+let clientQueries: ClientQuery[] = [];
+let clientReleased = false;
+let clientReleaseArg: unknown = undefined;
+let queryHandler: (sql: string, params?: unknown[]) => Promise<{ rows: Record<string, unknown>[] }> = async () => ({ rows: [] });
+
+function makeMockClient(): MockClient {
+  return {
+    query: async (sql: string, params?: unknown[]) => {
+      clientQueries.push({ sql, params });
+      return queryHandler(sql, params);
+    },
+    release: (err?: unknown) => {
+      clientReleased = true;
+      clientReleaseArg = err;
+    },
+  };
+}
+
+const { app } = await import("../index");
+
+afterAll(() => mocks.cleanup());
+
+function adminRequest(
+  method: string,
+  path: string,
+  body?: unknown,
+  extraHeaders: Record<string, string> = {},
+): Request {
+  const init: RequestInit = {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer test-token",
+      ...extraHeaders,
+    },
+  };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+  }
+  return new Request(`http://localhost${path}`, init);
+}
+
+function lastAuditCall(): AuditEntry {
+  const calls = mockLogAdminAction.mock.calls;
+  if (calls.length === 0) throw new Error("logAdminAction was not called");
+  return calls[calls.length - 1]![0]!;
+}
+
+function resetTxClient(): void {
+  clientQueries = [];
+  clientReleased = false;
+  clientReleaseArg = undefined;
+  queryHandler = async () => ({ rows: [] });
+}
+
+beforeEach(() => {
+  mocks.hasInternalDB = true;
+  mocks.setOrgAdmin("org-alpha");
+  mocks.mockInternalQuery.mockReset();
+  mocks.mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+    if (sql.includes(`FROM member`) && sql.includes(`"organizationId"`)) {
+      return [{ userId: params?.[0] ?? "unknown" }];
+    }
+    if (sql.includes(`FROM "user"`) && sql.includes(`WHERE id = $1`)) {
+      return [{ id: params?.[0] ?? "user-target", email: "target@test.com" }];
+    }
+    return [];
+  });
+  mockLogAdminAction.mockClear();
+  resetTxClient();
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/admin/users/:id/reset-mfa
+// ---------------------------------------------------------------------------
+
+describe("admin reset-mfa — POST /users/:id/reset-mfa", () => {
+  it("atomically clears passkeys + TOTP and emits success audit with per-artifact counts", async () => {
+    queryHandler = async (sql) => {
+      if (sql.includes("DELETE FROM passkey")) {
+        return { rows: [{ id: "pk1" }, { id: "pk2" }] };
+      }
+      if (sql.includes(`DELETE FROM "twoFactor"`)) {
+        // Two rows returned: one carries backup-code material, the other doesn't.
+        // The route emits both `totpSecretsRevoked` and `backupCodeBatchesRevoked`
+        // so triage can tell "this user had 1 batch of codes" from "no codes were
+        // ever issued".
+        return {
+          rows: [
+            { id: "tf1", had_backup_codes: true },
+            { id: "tf2", had_backup_codes: false },
+          ],
+        };
+      }
+      if (/UPDATE\s+"user"/i.test(sql)) {
+        return { rows: [{ id: "user-target" }] };
+      }
+      return { rows: [] };
+    };
+
+    const res = await app.fetch(
+      adminRequest(
+        "POST",
+        "/api/v1/admin/users/user-target/reset-mfa",
+        { reason: "Lost all devices 2026-05-05" },
+        { "x-forwarded-for": "203.0.113.42" },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success: boolean;
+      targetUserId: string;
+      passkeysRevoked: number;
+      totpSecretsRevoked: number;
+      backupCodeBatchesRevoked: number;
+    };
+    expect(body.success).toBe(true);
+    expect(body.targetUserId).toBe("user-target");
+    expect(body.passkeysRevoked).toBe(2);
+    expect(body.totpSecretsRevoked).toBe(2);
+    expect(body.backupCodeBatchesRevoked).toBe(1);
+
+    // Transaction lifecycle: BEGIN first, COMMIT must be the LAST query
+    // (a stray DELETE after COMMIT would land outside the transaction
+    // and leak across-user state), ROLLBACK must not run.
+    const sqls = clientQueries.map((q) => q.sql.trim().toUpperCase());
+    expect(sqls[0]).toBe("BEGIN");
+    expect(sqls[sqls.length - 1]).toBe("COMMIT");
+    expect(sqls.includes("ROLLBACK")).toBe(false);
+    expect(clientReleased).toBe(true);
+    expect(clientReleaseArg).toBeUndefined();
+
+    // The narrower-scope guard: this route MUST NOT touch sessions /
+    // trust-devices / OAuth tokens. A regression that imported the
+    // wrong DELETE block from admin-revoke.ts would land here.
+    const tablesTouched = clientQueries
+      .filter((q) => /^\s*(DELETE|UPDATE)\b/i.test(q.sql))
+      .map((q) => {
+        const m = q.sql.match(/(?:DELETE\s+FROM|UPDATE)\s+"?(\w+)"?/i);
+        return m ? m[1] : null;
+      });
+    expect(tablesTouched).toContain("passkey");
+    expect(tablesTouched).toContain("twoFactor");
+    expect(tablesTouched).toContain("user");
+    expect(tablesTouched).not.toContain("session");
+    expect(tablesTouched).not.toContain("trusted_device");
+    expect(tablesTouched).not.toContain("oauthAccessToken");
+    expect(tablesTouched).not.toContain("oauthRefreshToken");
+
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("user.mfa_reset");
+    expect(entry.targetType).toBe("user");
+    expect(entry.targetId).toBe("user-target");
+    expect(entry.status ?? "success").toBe("success");
+    expect(entry.metadata).toMatchObject({
+      targetUserId: "user-target",
+      targetUserEmail: "target@test.com",
+      passkeysRevoked: 2,
+      totpSecretsRevoked: 2,
+      backupCodeBatchesRevoked: 1,
+      reason: "Lost all devices 2026-05-05",
+    });
+    expect(entry.ipAddress).toBe("203.0.113.42");
+  });
+
+  it("succeeds with zero counts when the user has no enrolled MFA artifacts", async () => {
+    queryHandler = async () => ({ rows: [] });
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/users/user-target/reset-mfa", {}),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean; passkeysRevoked: number };
+    expect(body.success).toBe(true);
+    expect(body.passkeysRevoked).toBe(0);
+
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("user.mfa_reset");
+    expect(entry.metadata).toMatchObject({
+      targetUserId: "user-target",
+      passkeysRevoked: 0,
+      totpSecretsRevoked: 0,
+      backupCodeBatchesRevoked: 0,
+    });
+  });
+
+  it("scopes by userId on every transactional DELETE / UPDATE", async () => {
+    queryHandler = async () => ({ rows: [] });
+
+    await app.fetch(
+      adminRequest("POST", "/api/v1/admin/users/user-target/reset-mfa", {}),
+    );
+
+    // Every mutating query inside the transaction must carry $1 = userId.
+    // A regression that scopes a DELETE on something other than the
+    // target user is exactly the cross-user reset this surface forbids.
+    const muts = clientQueries.filter((q) => /^\s*(DELETE\s+FROM|UPDATE)\b/i.test(q.sql));
+    expect(muts.length).toBeGreaterThanOrEqual(3);
+    for (const m of muts) {
+      expect(m.params?.[0]).toBe("user-target");
+    }
+  });
+
+  it("clears user.twoFactorEnabled so the mfaRequired middleware re-blocks on next sign-in", async () => {
+    queryHandler = async () => ({ rows: [] });
+
+    await app.fetch(
+      adminRequest("POST", "/api/v1/admin/users/user-target/reset-mfa", {}),
+    );
+
+    // The "force re-enrollment" contract: clearing both DELETE targets
+    // AND `user.twoFactorEnabled` is what trips the mfaRequired 403 on
+    // the next admin-router request. Dropping the UPDATE would leave a
+    // stale-true `twoFactorEnabled` for an admin who has no actual
+    // backing twoFactor row — the gate would admit them silently.
+    const userUpdate = clientQueries.find(
+      (q) => /UPDATE\s+"user"/i.test(q.sql) && /twoFactorEnabled/i.test(q.sql),
+    );
+    expect(userUpdate).toBeDefined();
+    expect(userUpdate?.params?.[0]).toBe("user-target");
+  });
+
+  it("workspace admin cannot reset a foreign-org user — 404 + audit attempt", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes(`FROM member`)) return [];
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/users/foreign-user/reset-mfa", {}),
+    );
+
+    expect(res.status).toBe(404);
+
+    const sqls = clientQueries.map((q) => q.sql.trim().toUpperCase());
+    expect(sqls.includes("BEGIN")).toBe(false);
+
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("user.mfa_reset");
+    expect(entry.metadata).toMatchObject({
+      targetUserId: "foreign-user",
+      found: false,
+    });
+  });
+
+  it("platform admin can reset across orgs", async () => {
+    mocks.mockAuthenticateRequest.mockImplementation(() =>
+      Promise.resolve({
+        authenticated: true,
+        mode: "managed",
+        user: {
+          id: "platform-admin-1",
+          mode: "managed",
+          label: "platform@test.com",
+          role: "platform_admin",
+          activeOrganizationId: "org-alpha",
+          claims: { twoFactorEnabled: true },
+        },
+      }),
+    );
+    mocks.mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes(`FROM member`)) return []; // platform admin doesn't need this
+      if (sql.includes(`FROM "user"`)) {
+        return [{ id: params?.[0], email: "in-other-org@test.com" }];
+      }
+      return [];
+    });
+    queryHandler = async (sql) => {
+      if (sql.includes("DELETE FROM passkey")) return { rows: [{ id: "pk1" }] };
+      return { rows: [] };
+    };
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/users/cross-org-user/reset-mfa", {}),
+    );
+
+    expect(res.status).toBe(200);
+
+    const sqls = clientQueries.map((q) => q.sql.trim().toUpperCase());
+    expect(sqls[0]).toBe("BEGIN");
+    expect(sqls.includes("COMMIT")).toBe(true);
+
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.metadata).toMatchObject({
+      targetUserId: "cross-org-user",
+      targetUserEmail: "in-other-org@test.com",
+      passkeysRevoked: 1,
+    });
+  });
+
+  it("rolls back and emits failure audit with phase + scrubbed error when a DELETE throws mid-sequence", async () => {
+    queryHandler = async (sql) => {
+      if (sql.includes("DELETE FROM passkey")) {
+        return { rows: [{ id: "pk1" }] };
+      }
+      if (sql.includes(`DELETE FROM "twoFactor"`)) {
+        throw new Error(
+          "connection refused: postgres://atlas_user:supersecret@db.internal:5432/atlas",
+        );
+      }
+      return { rows: [] };
+    };
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/users/user-target/reset-mfa", {}),
+    );
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { requestId?: string };
+    expect(body.requestId).toBeDefined();
+
+    const sqls = clientQueries.map((q) => q.sql.trim().toUpperCase());
+    expect(sqls[0]).toBe("BEGIN");
+    expect(sqls.includes("ROLLBACK")).toBe(true);
+    expect(sqls.includes("COMMIT")).toBe(false);
+
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("user.mfa_reset");
+    expect(entry.status).toBe("failure");
+    expect(entry.metadata).toMatchObject({
+      targetUserId: "user-target",
+      phase: "two_factor",
+    });
+    const err = String(entry.metadata?.error ?? "");
+    expect(err).toContain("postgres://***@db.internal");
+    expect(err).not.toContain("atlas_user");
+    expect(err).not.toContain("supersecret");
+  });
+
+  it("destroys the client when ROLLBACK itself fails — pool-poison defence", async () => {
+    queryHandler = async (sql) => {
+      if (sql.includes("DELETE FROM passkey")) {
+        throw new Error("primary delete failed");
+      }
+      if (sql.trim().toUpperCase() === "ROLLBACK") {
+        throw new Error("rollback also failed: TCP reset");
+      }
+      return { rows: [] };
+    };
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/users/user-target/reset-mfa", {}),
+    );
+
+    expect(res.status).toBe(500);
+
+    const sqls = clientQueries.map((q) => q.sql.trim().toUpperCase());
+    expect(sqls[0]).toBe("BEGIN");
+    expect(sqls.includes("ROLLBACK")).toBe(true);
+    expect(sqls.includes("COMMIT")).toBe(false);
+
+    expect(clientReleased).toBe(true);
+    expect(clientReleaseArg).toBeInstanceOf(Error);
+    expect(String((clientReleaseArg as Error).message)).toContain("rollback also failed");
+
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.status).toBe("failure");
+    expect(entry.metadata).toMatchObject({
+      targetUserId: "user-target",
+      phase: "passkey",
+    });
+    expect(String(entry.metadata?.error ?? "")).toContain("primary delete failed");
+  });
+
+  it("returns 404 when the target user does not exist before any DELETE runs", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes(`FROM member`)) return [{ userId: params?.[0] }];
+      if (sql.includes(`FROM "user"`)) return [];
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/users/missing-user/reset-mfa", {}),
+    );
+
+    expect(res.status).toBe(404);
+
+    const sqls = clientQueries.map((q) => q.sql.trim().toUpperCase());
+    expect(sqls.includes("BEGIN")).toBe(false);
+
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    expect(lastAuditCall().metadata).toMatchObject({
+      targetUserId: "missing-user",
+      found: false,
+    });
+  });
+
+  it("returns 403 for non-admin members", async () => {
+    mocks.mockAuthenticateRequest.mockImplementation(() =>
+      Promise.resolve({
+        authenticated: true,
+        mode: "managed",
+        user: {
+          id: "user-1",
+          mode: "managed",
+          label: "user@test.com",
+          role: "member",
+          activeOrganizationId: "org-alpha",
+        },
+      }),
+    );
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/users/user-target/reset-mfa", {}),
+    );
+    expect(res.status).toBe(403);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when no internal DB is configured", async () => {
+    mocks.hasInternalDB = false;
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/users/user-target/reset-mfa", {}),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects an oversized reason rather than landing it in audit metadata", async () => {
+    const huge = "x".repeat(501);
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/users/user-target/reset-mfa", {
+        reason: huge,
+      }),
+    );
+    expect(res.status).toBe(422);
+    const sqls = clientQueries.map((q) => q.sql.trim().toUpperCase());
+    expect(sqls.includes("BEGIN")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/admin/me/mfa-factors
+// ---------------------------------------------------------------------------
+
+describe("admin mfa-factors — GET /me/mfa-factors", () => {
+  it("returns the per-user factor snapshot for the BackupMethodBanner predicate", async () => {
+    mocks.mockInternalQuery.mockImplementation(async () => [
+      { has_password: false, has_totp: false, passkey_count: 1 },
+    ]);
+
+    const res = await app.fetch(
+      adminRequest("GET", "/api/v1/admin/me/mfa-factors"),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      hasPassword: boolean;
+      hasTotp: boolean;
+      passkeyCount: number;
+    };
+    // The lockout-risk predicate the banner pins on: one passkey, no
+    // password, no TOTP. A regression that swapped boolean polarity in
+    // the SQL → JSON map would surface here.
+    expect(body).toEqual({ hasPassword: false, hasTotp: false, passkeyCount: 1 });
+  });
+
+  it("normalizes a non-managed session to a no-risk snapshot (banner stays silent)", async () => {
+    mocks.mockAuthenticateRequest.mockImplementation(() =>
+      Promise.resolve({
+        authenticated: true,
+        mode: "simple-key",
+        user: {
+          id: "admin-1",
+          mode: "simple-key",
+          label: "Admin",
+          role: "admin",
+        },
+      }),
+    );
+
+    const res = await app.fetch(
+      adminRequest("GET", "/api/v1/admin/me/mfa-factors"),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      hasPassword: boolean;
+      hasTotp: boolean;
+      passkeyCount: number;
+    };
+    // simple-key mode has no Better Auth user record. Returning all-zero
+    // keeps the banner inert for self-hosted simple-key admins instead
+    // of 500-ing on a pointless SQL lookup.
+    expect(body).toEqual({ hasPassword: false, hasTotp: false, passkeyCount: 0 });
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mocks.mockAuthenticateRequest.mockImplementation(() =>
+      Promise.resolve({
+        authenticated: false,
+        mode: "managed",
+        status: 401,
+        error: "No session found",
+      }),
+    );
+
+    const res = await app.fetch(
+      adminRequest("GET", "/api/v1/admin/me/mfa-factors"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 on DB error rather than silently leaking a false 'no-risk' snapshot", async () => {
+    mocks.mockInternalQuery.mockImplementation(async () => {
+      throw new Error("connection refused");
+    });
+
+    const res = await app.fetch(
+      adminRequest("GET", "/api/v1/admin/me/mfa-factors"),
+    );
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string; requestId?: string };
+    expect(body.error).toBe("internal_error");
+    expect(body.requestId).toBeDefined();
+  });
+});
+

--- a/packages/api/src/api/routes/admin-mfa-reset.ts
+++ b/packages/api/src/api/routes/admin-mfa-reset.ts
@@ -1,0 +1,474 @@
+/**
+ * Wave 2B passkey-recovery surface (#2092):
+ *
+ *   - `POST /api/v1/admin/users/{id}/reset-mfa` — admin-mediated reset
+ *     for a locked-out user (the load-bearing primitive of this file).
+ *   - `GET  /api/v1/admin/me/mfa-factors`       — per-user factor snapshot
+ *     consumed by the `BackupMethodBanner` on `/admin/settings/security`
+ *     to compute the lockout-risk predicate (one passkey, no password,
+ *     no TOTP). Light auth, no `mfaRequired` gate — by definition the
+ *     banner has to render before the user has a backup method.
+ *
+ * Atomic primitive for "this user lost their only authenticator and is
+ * locked out". Sibling to #2093's `admin-revoke.ts`: same transactional
+ * shape, same workspace-vs-platform authz split, same `<ReasonDialog>` UI
+ * contract — narrower scope. The reset surface only clears second-factor
+ * artifacts so the user can re-enroll on next sign-in. Sessions, OAuth
+ * grants, and trust-device cookies are deliberately left in place: the
+ * goal is recovery, not off-boarding.
+ *
+ * Re-enrollment is forced by removing every credential the
+ * `mfaRequired` middleware accepts:
+ *   1. Every passkey row for the user
+ *   2. Every `twoFactor` row (TOTP secret + backup-code batch are bundled
+ *      together in Better Auth's plugin schema — one row per enrollment)
+ *   3. `user.twoFactorEnabled = false` so the gate doesn't see a stale
+ *      `claims.twoFactorEnabled = true` for an admin who has no actual
+ *      backing twoFactor row
+ *
+ * No new column is needed. The existing `mfaRequired` middleware in
+ * `admin-mfa-required.ts` already returns `mfa_enrollment_required` to
+ * any admin/owner/platform_admin session whose claims show neither TOTP
+ * nor a passkey — emptying both rows trips that gate on the next
+ * admin-router request.
+ *
+ * Workspace admins are scoped to org members via `verifyOrgMembership`;
+ * platform admins cross-org. The non-member branch returns 404 (not 403)
+ * so probing a foreign-workspace user surfaces the same response as a
+ * missing user.
+ */
+
+import { createRoute, z } from "@hono/zod-openapi";
+import type { OpenAPIHono } from "@hono/zod-openapi";
+import { createLogger } from "@atlas/api/lib/logger";
+import { runHandler } from "@atlas/api/lib/effect/hono";
+import { getInternalDB, hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { detectAuthMode } from "@atlas/api/lib/auth/detect";
+import { authenticateRequest } from "@atlas/api/lib/auth/middleware";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
+import type { AuthenticatedResult } from "@atlas/api/lib/auth/types";
+import { authErrorCode } from "./admin-auth";
+import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
+
+const log = createLogger("admin-mfa-reset");
+
+// Cap on the `id` route param. Better Auth user ids are 32-char nanoid-ish;
+// 255 is well clear of the upper bound and prevents adversarial inputs
+// from bloating `admin_action_log.metadata` on the not-found audit branch.
+const ID_MAX_LEN = 255;
+
+// Cap on the operator-supplied audit reason. Long enough for a real
+// recovery rationale ("user reports stolen laptop, cross-checked with
+// HR ticket TKT-1234"); short enough that a malicious paste can't
+// balloon `admin_action_log.metadata`'s JSONB column.
+const REASON_MAX_LEN = 500;
+
+/**
+ * SQL phase the rolled-back transaction tripped on. Surfaced in the
+ * failure-audit metadata so triage can answer "did anything actually
+ * delete?" without grep-ing pino. Phases are listed in execution order
+ * so a `phase: "two_factor"` reads as "passkeys deleted, then bail".
+ */
+type ResetPhase = "passkey" | "two_factor" | "user_flag" | "commit";
+
+interface ResetCounts {
+  passkeysRevoked: number;
+  totpSecretsRevoked: number;
+  backupCodeBatchesRevoked: number;
+}
+
+type ResetOutcome =
+  | { status: "ok"; counts: ResetCounts }
+  | { status: "rolled_back"; phase: ResetPhase; error: Error };
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+const ResetRequestSchema = z.object({
+  reason: z.string().max(REASON_MAX_LEN).optional(),
+});
+
+const ResetResponseSchema = z.object({
+  success: z.boolean(),
+  targetUserId: z.string(),
+  passkeysRevoked: z.number().int().nonnegative(),
+  totpSecretsRevoked: z.number().int().nonnegative(),
+  backupCodeBatchesRevoked: z.number().int().nonnegative(),
+});
+
+const MyMfaFactorsResponseSchema = z.object({
+  hasPassword: z.boolean(),
+  hasTotp: z.boolean(),
+  passkeyCount: z.number().int().nonnegative(),
+});
+
+// ---------------------------------------------------------------------------
+// Route definition
+// ---------------------------------------------------------------------------
+
+const myMfaFactorsRoute = createRoute({
+  method: "get",
+  path: "/me/mfa-factors",
+  tags: ["Admin — Security"],
+  summary: "Per-user MFA factor snapshot",
+  description:
+    "Returns the calling user's password / TOTP / passkey-count snapshot " +
+    "used by the BackupMethodBanner on /admin/settings/security to detect " +
+    "the lockout-risk profile (one passkey, no password, no TOTP). Light " +
+    "auth — by definition the banner has to render before the user has a " +
+    "second factor enrolled.",
+  responses: {
+    200: { description: "Factor snapshot", content: { "application/json": { schema: MyMfaFactorsResponseSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
+    403: { description: "Forbidden — SSO enforcement active", content: { "application/json": { schema: AuthErrorSchema } } },
+    500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
+const resetMfaRoute = createRoute({
+  method: "post",
+  path: "/users/{id}/reset-mfa",
+  tags: ["Admin — Users"],
+  summary: "Reset MFA enrollment for a user",
+  description:
+    "Atomically clears every second-factor artifact (passkey enrollments, " +
+    "TOTP secrets, bundled backup-code batches) for the target user inside " +
+    "a single transaction so a locked-out passkey-only user can re-enroll " +
+    "on next sign-in. Sessions, OAuth grants, and trust-device cookies are " +
+    "left untouched — this is recovery, not off-boarding (#2093 covers " +
+    "off-boarding). Workspace admins are scoped to their org members; " +
+    "platform admins cross-org.",
+  request: {
+    params: z.object({
+      id: z.string().min(1).max(ID_MAX_LEN).openapi({ param: { name: "id", in: "path" }, example: "user_abc123" }),
+    }),
+    body: {
+      content: {
+        "application/json": {
+          schema: ResetRequestSchema,
+        },
+      },
+      required: false,
+    },
+  },
+  responses: {
+    200: { description: "MFA artifacts reset", content: { "application/json": { schema: ResetResponseSchema } } },
+    400: { description: "Invalid request body", content: { "application/json": { schema: ErrorSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
+    403: { description: "Forbidden — admin role required", content: { "application/json": { schema: AuthErrorSchema } } },
+    404: { description: "User not found or not in workspace", content: { "application/json": { schema: ErrorSchema } } },
+    429: { description: "Rate limit exceeded", content: { "application/json": { schema: AuthErrorSchema } } },
+    500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Transactional reset helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Atomically clear every second-factor artifact for `userId`. All three
+ * mutating queries run inside a single transaction; partial-state failures
+ * roll back so the user never ends up with passkeys deleted but
+ * `twoFactorEnabled = true` lingering on the user row (the gate would
+ * admit them silently).
+ *
+ * Returns a discriminated outcome so the caller can branch on success /
+ * rolled-back without exception handling. Mirrors `admin-revoke.ts`'s
+ * BEGIN/COMMIT/ROLLBACK + `release(rollbackErr)` destroy-on-poison
+ * pattern verbatim — pg destroys the socket when `release(err)` is called
+ * with a truthy arg, so a poisoned client doesn't return to the pool to
+ * corrupt the next borrower's transaction.
+ */
+async function resetAtomically(userId: string): Promise<ResetOutcome> {
+  const pool = getInternalDB();
+  const client = await pool.connect();
+  let phase: ResetPhase = "passkey";
+  let rollbackErr: Error | null = null;
+
+  try {
+    await client.query("BEGIN");
+
+    const passkey = await client.query(
+      `DELETE FROM passkey
+        WHERE "userId" = $1
+        RETURNING id`,
+      [userId],
+    );
+    phase = "two_factor";
+
+    // Better Auth's twoFactor plugin stores the TOTP secret and the
+    // backup-code batch in the same row — `secret` and `backupCodes`
+    // are sibling columns. Counting `had_backup_codes` separately lets
+    // the audit row distinguish "this user had codes" (a meaningful
+    // recovery fact) from "TOTP secret only" — without a per-row
+    // RETURNING the audit log would conflate the two.
+    const twoFactor = await client.query(
+      `DELETE FROM "twoFactor"
+        WHERE "userId" = $1
+        RETURNING id, ("backupCodes" IS NOT NULL AND "backupCodes" <> '') AS had_backup_codes`,
+      [userId],
+    );
+    phase = "user_flag";
+
+    // Even with no twoFactor row to delete, `user.twoFactorEnabled`
+    // can still be `true` for accounts that enrolled and then dropped
+    // their TOTP via Better Auth's disable path on a non-Atlas client
+    // (rare, but possible). Clearing it unconditionally is cheap and
+    // closes the silent-admit gap described in the file header.
+    await client.query(
+      `UPDATE "user"
+          SET "twoFactorEnabled" = false
+        WHERE id = $1`,
+      [userId],
+    );
+
+    phase = "commit";
+    await client.query("COMMIT");
+
+    const backupCodeBatchesRevoked = twoFactor.rows.filter(
+      (r) => (r as { had_backup_codes?: boolean }).had_backup_codes === true,
+    ).length;
+
+    return {
+      status: "ok",
+      counts: {
+        passkeysRevoked: passkey.rows.length,
+        totpSecretsRevoked: twoFactor.rows.length,
+        backupCodeBatchesRevoked,
+      },
+    };
+  } catch (err) {
+    await client.query("ROLLBACK").catch((rbErr: unknown) => {
+      rollbackErr = rbErr instanceof Error ? rbErr : new Error(String(rbErr));
+      log.warn(
+        { err: rollbackErr.message, userId, phase },
+        "ROLLBACK failed after MFA reset error — client will be destroyed",
+      );
+    });
+    return {
+      status: "rolled_back",
+      phase,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  } finally {
+    client.release(rollbackErr ?? undefined);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Registration function
+// ---------------------------------------------------------------------------
+
+/**
+ * Register the MFA-reset route directly on the admin router.
+ * Same dependency-injection pattern as `registerRevokeRoutes` —
+ * `adminAuthAndContext` and `verifyOrgMembership` live inside
+ * admin.ts' module closure, so we accept them as params instead of
+ * cyclically importing.
+ */
+export function registerMfaResetRoutes(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- generic admin router type
+  admin: OpenAPIHono<any>,
+  adminAuthAndContext: (
+    c: { req: { raw: Request }; get(key: string): unknown; set?: (key: string, value: unknown) => void },
+    permission?: import("@atlas/ee/auth/roles").Permission,
+  ) => Promise<{ authResult: AuthenticatedResult; requestId: string }>,
+  verifyOrgMembership: (authResult: AuthenticatedResult, targetUserId: string) => Promise<boolean>,
+  reqId: (c: { get(key: string): unknown }) => string,
+) {
+  // GET /me/mfa-factors — per-user factor snapshot for the BackupMethodBanner.
+  // Light auth path: same carve-out rationale as /me/password-status — the
+  // banner is the surface that NUDGES the user toward a second factor, so it
+  // has to be reachable before any factor is enrolled. mfaRequired stays off.
+  admin.openapi(myMfaFactorsRoute, async (c) => {
+    const req = c.req.raw;
+    const requestId = reqId(c);
+
+    let authResult: Awaited<ReturnType<typeof authenticateRequest>>;
+    try {
+      authResult = await authenticateRequest(req);
+    } catch (err) {
+      log.error(
+        { err: err instanceof Error ? err.message : String(err), requestId },
+        "Authentication system error in mfa-factors check",
+      );
+      return c.json({ error: "auth_error", message: "Authentication system error", requestId }, 500);
+    }
+    if (!authResult.authenticated) {
+      const code = authErrorCode(authResult.error);
+      return c.json({ error: code, message: authResult.error, requestId }, authResult.status);
+    }
+    const user = authResult.user;
+    // Non-managed sessions don't have a Better Auth-backed user record to
+    // bucket — return a "no-risk" snapshot so the banner renders nothing
+    // rather than 500-ing a self-hosted simple-key admin.
+    if (authResult.mode !== "managed" || !user || !hasInternalDB()) {
+      return c.json({ hasPassword: false, hasTotp: false, passkeyCount: 0 }, 200);
+    }
+
+    try {
+      // Single round-trip: three EXISTS / scalar reads. The `account` JOIN
+      // matches the credential-presence check in lib/auth/migrate.ts —
+      // `providerId = 'credential'` is Better Auth's marker for a
+      // password-backed account. SSO / OAuth-only accounts will land
+      // `hasPassword = false`, which is the signal the banner needs.
+      const rows = await internalQuery<{
+        has_password: boolean;
+        has_totp: boolean;
+        passkey_count: number;
+      }>(
+        `SELECT
+           EXISTS (
+             SELECT 1 FROM "account"
+              WHERE "userId" = $1 AND "providerId" = 'credential'
+           ) AS has_password,
+           COALESCE((SELECT "twoFactorEnabled" FROM "user" WHERE id = $1), false) AS has_totp,
+           (SELECT COUNT(*)::int FROM passkey WHERE "userId" = $1) AS passkey_count`,
+        [user.id],
+      );
+      const row = rows[0];
+      return c.json(
+        {
+          hasPassword: row?.has_password === true,
+          hasTotp: row?.has_totp === true,
+          passkeyCount: typeof row?.passkey_count === "number" ? row.passkey_count : 0,
+        },
+        200,
+      );
+    } catch (err) {
+      log.error(
+        {
+          err: err instanceof Error ? err.message : String(err),
+          userId: user.id,
+          requestId,
+        },
+        "Failed to load /me/mfa-factors snapshot",
+      );
+      return c.json(
+        {
+          error: "internal_error",
+          message: "Could not load your MFA status. Please refresh and try again.",
+          requestId,
+        },
+        500,
+      );
+    }
+  });
+
+  admin.openapi(resetMfaRoute, async (c) => runHandler(c, "reset user mfa", async () => {
+    const { id: userId } = c.req.valid("param");
+    const ipAddress = c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null;
+    const { authResult, requestId } = await adminAuthAndContext(c, "admin:users");
+
+    if (!hasInternalDB() || detectAuthMode() !== "managed") {
+      return c.json(
+        { error: "not_available", message: "MFA reset requires managed auth mode.", requestId },
+        404,
+      );
+    }
+
+    if (!(await verifyOrgMembership(authResult, userId))) {
+      // Probing a foreign-workspace user is a forensic signal — record
+      // the attempt with `found: false` so the audit trail can show
+      // which admin tried to reach across orgs.
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.user.mfaReset,
+        targetType: "user",
+        targetId: userId,
+        ipAddress,
+        metadata: { targetUserId: userId, found: false },
+      });
+      return c.json({ error: "not_found", message: "User not found.", requestId }, 404);
+    }
+
+    // Body schema is optional — operators using ReasonDialog with
+    // `required: false` may submit no JSON body. Parse manually with a
+    // safe default; safeParse rejects malformed shapes with 400.
+    const rawBody = await c.req.json().catch(() => {
+      // intentionally ignored: optional body — safeParse below validates the shape.
+      return {};
+    });
+    const parsed = ResetRequestSchema.safeParse(rawBody ?? {});
+    if (!parsed.success) {
+      return c.json({ error: "invalid_request", message: "Invalid request body.", requestId }, 400);
+    }
+    const reason = parsed.data.reason?.trim() || undefined;
+
+    // Pre-fetch the email for the audit row before the DELETEs strip
+    // every artifact pointer. We want the audit row to record who was
+    // reset even if the user later gets erased.
+    const userRows = await internalQuery<{ id: string; email: string | null }>(
+      `SELECT id, email FROM "user" WHERE id = $1 LIMIT 1`,
+      [userId],
+    );
+    if (userRows.length === 0) {
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.user.mfaReset,
+        targetType: "user",
+        targetId: userId,
+        ipAddress,
+        metadata: { targetUserId: userId, found: false },
+      });
+      return c.json({ error: "not_found", message: "User not found.", requestId }, 404);
+    }
+    const targetUserEmail = userRows[0]?.email ?? null;
+
+    const outcome = await resetAtomically(userId);
+
+    if (outcome.status === "rolled_back") {
+      // Transaction rolled back. Audit with the phase that tripped + the
+      // scrubbed error message (errorMessage strips pg userinfo and caps
+      // length), then re-fail through runHandler so the response surfaces
+      // a 500 with requestId.
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.user.mfaReset,
+        targetType: "user",
+        targetId: userId,
+        status: "failure",
+        ipAddress,
+        metadata: {
+          targetUserId: userId,
+          targetUserEmail,
+          phase: outcome.phase,
+          error: errorMessage(outcome.error),
+          ...(reason !== undefined && { reason }),
+        },
+      });
+      throw outcome.error;
+    }
+
+    log.info(
+      {
+        requestId,
+        targetUserId: userId,
+        actorId: authResult.user?.id,
+        ...outcome.counts,
+      },
+      "User MFA reset",
+    );
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.user.mfaReset,
+      targetType: "user",
+      targetId: userId,
+      ipAddress,
+      metadata: {
+        targetUserId: userId,
+        targetUserEmail,
+        ...outcome.counts,
+        ...(reason !== undefined && { reason }),
+      },
+    });
+
+    return c.json(
+      {
+        success: true,
+        targetUserId: userId,
+        ...outcome.counts,
+      },
+      200,
+    );
+  }));
+}

--- a/packages/api/src/api/routes/admin-mfa-reset.ts
+++ b/packages/api/src/api/routes/admin-mfa-reset.ts
@@ -1,36 +1,20 @@
 /**
- * Wave 2B passkey-recovery surface (#2092):
+ * Admin-mediated MFA reset for a locked-out user.
  *
- *   - `POST /api/v1/admin/users/{id}/reset-mfa` — admin-mediated reset
- *     for a locked-out user (the load-bearing primitive of this file).
- *   - `GET  /api/v1/admin/me/mfa-factors`       — per-user factor snapshot
- *     consumed by the `BackupMethodBanner` on `/admin/settings/security`
- *     to compute the lockout-risk predicate (one passkey, no password,
- *     no TOTP). Light auth, no `mfaRequired` gate — by definition the
- *     banner has to render before the user has a backup method.
+ *   - `POST /api/v1/admin/users/{id}/reset-mfa` — atomically clears every
+ *     passkey, twoFactor row (TOTP secret + bundled backup-code batch),
+ *     and the `user.twoFactorEnabled` flag. Sessions, OAuth grants, and
+ *     trust-device cookies are deliberately spared — this is recovery,
+ *     not off-boarding.
+ *   - `GET  /api/v1/admin/me/mfa-factors` — per-user `{hasPassword,
+ *     hasTotp, passkeyCount}` snapshot. Light auth (no `mfaRequired`
+ *     gate) so the banner that renders this signal is reachable before
+ *     a second factor is enrolled. Same carve-out as `/me/password-status`.
  *
- * Atomic primitive for "this user lost their only authenticator and is
- * locked out". Sibling to #2093's `admin-revoke.ts`: same transactional
- * shape, same workspace-vs-platform authz split, same `<ReasonDialog>` UI
- * contract — narrower scope. The reset surface only clears second-factor
- * artifacts so the user can re-enroll on next sign-in. Sessions, OAuth
- * grants, and trust-device cookies are deliberately left in place: the
- * goal is recovery, not off-boarding.
- *
- * Re-enrollment is forced by removing every credential the
- * `mfaRequired` middleware accepts:
- *   1. Every passkey row for the user
- *   2. Every `twoFactor` row (TOTP secret + backup-code batch are bundled
- *      together in Better Auth's plugin schema — one row per enrollment)
- *   3. `user.twoFactorEnabled = false` so the gate doesn't see a stale
- *      `claims.twoFactorEnabled = true` for an admin who has no actual
- *      backing twoFactor row
- *
- * No new column is needed. The existing `mfaRequired` middleware in
- * `admin-mfa-required.ts` already returns `mfa_enrollment_required` to
- * any admin/owner/platform_admin session whose claims show neither TOTP
- * nor a passkey — emptying both rows trips that gate on the next
- * admin-router request.
+ * Re-enrollment is forced by emptying every credential `mfaRequired`
+ * accepts; no new column needed. Clearing `twoFactorEnabled` separately
+ * closes a silent-admit gap where the flag could remain `true` for an
+ * account whose backing `twoFactor` row was deleted out-of-band.
  *
  * Workspace admins are scoped to org members via `verifyOrgMembership`;
  * platform admins cross-org. The non-member branch returns 404 (not 403)
@@ -199,12 +183,9 @@ async function resetAtomically(userId: string): Promise<ResetOutcome> {
     );
     phase = "two_factor";
 
-    // Better Auth's twoFactor plugin stores the TOTP secret and the
-    // backup-code batch in the same row — `secret` and `backupCodes`
-    // are sibling columns. Counting `had_backup_codes` separately lets
-    // the audit row distinguish "this user had codes" (a meaningful
-    // recovery fact) from "TOTP secret only" — without a per-row
-    // RETURNING the audit log would conflate the two.
+    // Better Auth bundles TOTP secret + backup codes in the same row.
+    // `had_backup_codes` lets the audit distinguish "had codes" from
+    // "TOTP secret only".
     const twoFactor = await client.query(
       `DELETE FROM "twoFactor"
         WHERE "userId" = $1
@@ -213,11 +194,8 @@ async function resetAtomically(userId: string): Promise<ResetOutcome> {
     );
     phase = "user_flag";
 
-    // Even with no twoFactor row to delete, `user.twoFactorEnabled`
-    // can still be `true` for accounts that enrolled and then dropped
-    // their TOTP via Better Auth's disable path on a non-Atlas client
-    // (rare, but possible). Clearing it unconditionally is cheap and
-    // closes the silent-admit gap described in the file header.
+    // Clear unconditionally — `twoFactorEnabled` can linger as true even
+    // with no twoFactor row (Better Auth disable path on non-Atlas client).
     await client.query(
       `UPDATE "user"
           SET "twoFactorEnabled" = false
@@ -279,10 +257,8 @@ export function registerMfaResetRoutes(
   verifyOrgMembership: (authResult: AuthenticatedResult, targetUserId: string) => Promise<boolean>,
   reqId: (c: { get(key: string): unknown }) => string,
 ) {
-  // GET /me/mfa-factors — per-user factor snapshot for the BackupMethodBanner.
-  // Light auth path: same carve-out rationale as /me/password-status — the
-  // banner is the surface that NUDGES the user toward a second factor, so it
-  // has to be reachable before any factor is enrolled. mfaRequired stays off.
+  // GET /me/mfa-factors — light-auth snapshot for the BackupMethodBanner.
+  // mfaRequired stays off: the banner has to render before any factor is enrolled.
   admin.openapi(myMfaFactorsRoute, async (c) => {
     const req = c.req.raw;
     const requestId = reqId(c);
@@ -302,19 +278,15 @@ export function registerMfaResetRoutes(
       return c.json({ error: code, message: authResult.error, requestId }, authResult.status);
     }
     const user = authResult.user;
-    // Non-managed sessions don't have a Better Auth-backed user record to
-    // bucket — return a "no-risk" snapshot so the banner renders nothing
-    // rather than 500-ing a self-hosted simple-key admin.
+    // Non-managed sessions return a no-risk snapshot so the banner renders
+    // nothing rather than 500-ing a self-hosted simple-key admin.
     if (authResult.mode !== "managed" || !user || !hasInternalDB()) {
       return c.json({ hasPassword: false, hasTotp: false, passkeyCount: 0 }, 200);
     }
 
     try {
-      // Single round-trip: three EXISTS / scalar reads. The `account` JOIN
-      // matches the credential-presence check in lib/auth/migrate.ts —
-      // `providerId = 'credential'` is Better Auth's marker for a
-      // password-backed account. SSO / OAuth-only accounts will land
-      // `hasPassword = false`, which is the signal the banner needs.
+      // `providerId = 'credential'` is Better Auth's password-backed marker
+      // (matches lib/auth/migrate.ts). SSO / OAuth-only accounts land hasPassword=false.
       const rows = await internalQuery<{
         has_password: boolean;
         has_totp: boolean;
@@ -371,9 +343,7 @@ export function registerMfaResetRoutes(
     }
 
     if (!(await verifyOrgMembership(authResult, userId))) {
-      // Probing a foreign-workspace user is a forensic signal — record
-      // the attempt with `found: false` so the audit trail can show
-      // which admin tried to reach across orgs.
+      // Audit the cross-org probe so the trail shows which admin tried.
       logAdminAction({
         actionType: ADMIN_ACTIONS.user.mfaReset,
         targetType: "user",
@@ -384,9 +354,8 @@ export function registerMfaResetRoutes(
       return c.json({ error: "not_found", message: "User not found.", requestId }, 404);
     }
 
-    // Body schema is optional — operators using ReasonDialog with
-    // `required: false` may submit no JSON body. Parse manually with a
-    // safe default; safeParse rejects malformed shapes with 400.
+    // Body is optional (ReasonDialog allows empty submission); safeParse
+    // rejects malformed shapes with 400.
     const rawBody = await c.req.json().catch(() => {
       // intentionally ignored: optional body — safeParse below validates the shape.
       return {};
@@ -397,9 +366,7 @@ export function registerMfaResetRoutes(
     }
     const reason = parsed.data.reason?.trim() || undefined;
 
-    // Pre-fetch the email for the audit row before the DELETEs strip
-    // every artifact pointer. We want the audit row to record who was
-    // reset even if the user later gets erased.
+    // Pre-fetch the email so the audit row survives the user being erased later.
     const userRows = await internalQuery<{ id: string; email: string | null }>(
       `SELECT id, email FROM "user" WHERE id = $1 LIMIT 1`,
       [userId],
@@ -419,10 +386,8 @@ export function registerMfaResetRoutes(
     const outcome = await resetAtomically(userId);
 
     if (outcome.status === "rolled_back") {
-      // Transaction rolled back. Audit with the phase that tripped + the
-      // scrubbed error message (errorMessage strips pg userinfo and caps
-      // length), then re-fail through runHandler so the response surfaces
-      // a 500 with requestId.
+      // Audit the phase + scrubbed error, then re-throw so runHandler
+      // returns a 500 with requestId.
       logAdminAction({
         actionType: ADMIN_ACTIONS.user.mfaReset,
         targetType: "user",

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -289,6 +289,12 @@ registerTrustedDeviceRoutes(admin, reqId);
 // directly so the existing /users/* routes share the same middleware chain.
 import { registerRevokeRoutes } from "./admin-revoke";
 registerRevokeRoutes(admin, adminAuthAndContext, verifyOrgMembership);
+// Admin-mediated MFA reset for a locked-out user (#2092 — Wave 2B closeout).
+// Sibling to admin-revoke; registered the same way for the same reason.
+// `reqId` is also passed through for the per-user /me/mfa-factors route in
+// the same module — that route uses light auth (no adminAuthAndContext gate).
+import { registerMfaResetRoutes } from "./admin-mfa-reset";
+registerMfaResetRoutes(admin, adminAuthAndContext, verifyOrgMembership, reqId);
 admin.route("/connections", adminConnections);
 admin.route("/connections/", adminConnections);
 admin.route("/publish", adminPublish);

--- a/packages/api/src/lib/audit/actions.ts
+++ b/packages/api/src/lib/audit/actions.ts
@@ -140,6 +140,27 @@ export const ADMIN_ACTIONS = {
      */
     authRevoke: "user.auth_revoke",
     /**
+     * Admin-mediated MFA reset for a target user (#2092). Sibling to
+     * `auth_revoke` — narrower scope: clears only the second-factor
+     * artifacts (passkey enrollments, TOTP secrets, backup-code batches)
+     * so a locked-out passkey-only user can re-enroll on next sign-in.
+     * Sessions, OAuth grants, and trust-device cookies are deliberately
+     * left in place; the goal is "let them recover their MFA", not "kick
+     * them out of every surface".
+     *
+     * Re-enrollment is forced by removing every credential the
+     * `mfaRequired` middleware accepts (passkey + `user.twoFactorEnabled`).
+     * No new column is needed — emptying both rows trips the existing
+     * `mfa_enrollment_required` 403 on the next admin-router request.
+     *
+     * Success metadata: `{ targetUserId, targetUserEmail, passkeysRevoked,
+     * totpSecretsRevoked, backupCodeBatchesRevoked, reason? }`.
+     * Failure metadata adds `{ phase, error }`. The phase enum is listed
+     * in execution order in `admin-mfa-reset.ts` so a `phase: "two_factor"`
+     * reads as "passkeys deleted, then bail".
+     */
+    mfaReset: "user.mfa_reset",
+    /**
      * Self-service password change via `POST /me/password`. The actor IS
      * the target — audit row carries `targetType: "user"` and
      * `targetId: actorId` so forensic queries can distinguish a user

--- a/packages/api/src/lib/audit/actions.ts
+++ b/packages/api/src/lib/audit/actions.ts
@@ -140,7 +140,7 @@ export const ADMIN_ACTIONS = {
      */
     authRevoke: "user.auth_revoke",
     /**
-     * Admin-mediated MFA reset for a target user (#2092). Sibling to
+     * Admin-mediated MFA reset for a target user. Sibling to
      * `auth_revoke` — narrower scope: clears only the second-factor
      * artifacts (passkey enrollments, TOTP secrets, backup-code batches)
      * so a locked-out passkey-only user can re-enroll on next sign-in.
@@ -154,10 +154,10 @@ export const ADMIN_ACTIONS = {
      * `mfa_enrollment_required` 403 on the next admin-router request.
      *
      * Success metadata: `{ targetUserId, targetUserEmail, passkeysRevoked,
-     * totpSecretsRevoked, backupCodeBatchesRevoked, reason? }`.
-     * Failure metadata adds `{ phase, error }`. The phase enum is listed
-     * in execution order in `admin-mfa-reset.ts` so a `phase: "two_factor"`
-     * reads as "passkeys deleted, then bail".
+     * totpSecretsRevoked, backupCodeBatchesRevoked, reason? }`. Failure
+     * metadata adds `{ phase, error }` where `phase` names the rolled-back
+     * step so triage can answer "did anything actually delete?" without
+     * grep-ing pino.
      */
     mfaReset: "user.mfa_reset",
     /**

--- a/packages/web/src/app/admin/settings/security/page.tsx
+++ b/packages/web/src/app/admin/settings/security/page.tsx
@@ -15,7 +15,7 @@
  * haven't enrolled any factor can always reach it to complete enrollment.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ShieldCheck } from "lucide-react";
 import { authClient } from "@/lib/auth/client";
 import { getPasskeyClient, type Passkey } from "@/lib/auth/passkey-client";
@@ -25,6 +25,7 @@ import { PasskeyList, type PasskeyRow } from "@/ui/components/admin/security/pas
 import { BackupCodesStatus } from "@/ui/components/admin/security/backup-codes-status";
 import { TrustedDevicesList } from "@/ui/components/admin/security/trusted-devices-list";
 import { SecurityPosturePanel } from "@/ui/components/admin/security/security-posture-panel";
+import { BackupMethodBanner } from "@/ui/components/admin/security/backup-method-banner";
 
 interface SessionUser {
   email: string;
@@ -43,6 +44,16 @@ export default function SecurityPage() {
 
   const [passkeys, setPasskeys] = useState<PasskeyRow[] | null>(null);
   const [listError, setListError] = useState<string | null>(null);
+  // Hop the banner's "Enroll a second passkey" CTA down to the existing
+  // `PasskeyTile` enrollment flow. Scrolling — instead of programmatically
+  // clicking the tile's button — keeps the WebAuthn ceremony scoped to a
+  // single source of truth (the tile owns the OS prompt, naming dialog,
+  // and post-enroll refetch). The banner's job is to nudge, the tile's
+  // job is to enroll.
+  const passkeyTileRef = useRef<HTMLDivElement | null>(null);
+  const handleEnrollSecondPasskey = useCallback(() => {
+    passkeyTileRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+  }, []);
 
   const refreshPasskeys = useCallback(async () => {
     const client = getPasskeyClient();
@@ -106,9 +117,13 @@ export default function SecurityPage() {
       </div>
 
       <div className="mx-auto max-w-2xl space-y-4">
+        <BackupMethodBanner onAddPasskey={handleEnrollSecondPasskey} />
+
         <SecurityPosturePanel />
 
-        <PasskeyTile hasPasskey={hasPasskey} onChange={handlePasskeyChange} />
+        <div ref={passkeyTileRef}>
+          <PasskeyTile hasPasskey={hasPasskey} onChange={handlePasskeyChange} />
+        </div>
 
         <TwoFactorSetup enabled={totpEnabled} onChange={handleTotpChange} />
 

--- a/packages/web/src/app/admin/settings/security/page.tsx
+++ b/packages/web/src/app/admin/settings/security/page.tsx
@@ -44,16 +44,13 @@ export default function SecurityPage() {
 
   const [passkeys, setPasskeys] = useState<PasskeyRow[] | null>(null);
   const [listError, setListError] = useState<string | null>(null);
-  // Hop the banner's "Enroll a second passkey" CTA down to the existing
-  // `PasskeyTile` enrollment flow. Scrolling — instead of programmatically
-  // clicking the tile's button — keeps the WebAuthn ceremony scoped to a
-  // single source of truth (the tile owns the OS prompt, naming dialog,
-  // and post-enroll refetch). The banner's job is to nudge, the tile's
-  // job is to enroll.
+  // The banner nudges; the tile owns the WebAuthn ceremony. Scrolling
+  // (vs. programmatic click) keeps enrollment scoped to a single source
+  // of truth.
   const passkeyTileRef = useRef<HTMLDivElement | null>(null);
-  const handleEnrollSecondPasskey = useCallback(() => {
+  function handleEnrollSecondPasskey() {
     passkeyTileRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
-  }, []);
+  }
 
   const refreshPasskeys = useCallback(async () => {
     const client = getPasskeyClient();

--- a/packages/web/src/app/admin/users/[id]/page.tsx
+++ b/packages/web/src/app/admin/users/[id]/page.tsx
@@ -45,10 +45,8 @@ export default function UserDetailPage() {
     invalidates: refetch,
   });
 
-  // Sibling primitive (#2092 — Wave 2B). Narrower scope than revoke-auth:
-  // clears passkeys + TOTP only, leaves sessions and OAuth grants alone.
-  // The same `refetch` invalidates the preview counts so the passkey
-  // count tile updates after a successful reset.
+  // Narrower than revoke-auth: passkeys + TOTP only, leaves sessions and
+  // OAuth grants alone. Same refetch updates the passkey-count tile.
   const resetMfa = useAdminMutation({
     path: `/api/v1/admin/users/${userId}/reset-mfa`,
     method: "POST",
@@ -189,12 +187,7 @@ export default function UserDetailPage() {
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
-                {/*
-                  MFA reset (#2092 — Wave 2B). Narrower scope than full revoke:
-                  clears passkeys + TOTP + bundled backup codes only. Sessions
-                  and OAuth grants stay live so a recovery reset doesn't
-                  double as an unintended sign-out.
-                */}
+                {/* MFA reset — passkeys + TOTP + backup codes only; sessions and OAuth grants stay live. */}
                 <div className="rounded-md border border-amber-500/40 bg-amber-500/5 p-4">
                   <h3 className="text-sm font-semibold">Reset MFA enrollment</h3>
                   <p className="mt-1 text-xs text-muted-foreground">
@@ -205,12 +198,7 @@ export default function UserDetailPage() {
                     lost their only authenticator and is locked out.
                   </p>
                   <div className="mt-3 flex flex-wrap items-center gap-3">
-                    {/*
-                      Stays clickable even at zero-passkey preview — the
-                      preview endpoint doesn't expose TOTP enrollment, and
-                      a zero-MFA reset still emits a forensic audit row
-                      (same "audit on zero" pattern as revoke-auth).
-                    */}
+                    {/* Always clickable: preview hides TOTP, and zero-MFA reset still emits a forensic audit row. */}
                     <Button
                       variant="outline"
                       size="sm"

--- a/packages/web/src/app/admin/users/[id]/page.tsx
+++ b/packages/web/src/app/admin/users/[id]/page.tsx
@@ -5,7 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { ArrowLeft, ShieldAlert, KeyRound, Smartphone, MonitorSmartphone, Database, UserX } from "lucide-react";
+import { ArrowLeft, Fingerprint, ShieldAlert, KeyRound, Smartphone, MonitorSmartphone, Database, UserX } from "lucide-react";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { ReasonDialog } from "@/ui/components/admin/queue";
@@ -32,6 +32,7 @@ export default function UserDetailPage() {
   const userId = params.id;
 
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [mfaResetOpen, setMfaResetOpen] = useState(false);
 
   const { data: preview, loading, error, refetch } = useAdminFetch<Preview>(
     `/api/v1/admin/users/${userId}/revoke-auth/preview`,
@@ -40,6 +41,16 @@ export default function UserDetailPage() {
 
   const revokeAuth = useAdminMutation({
     path: `/api/v1/admin/users/${userId}/revoke-auth`,
+    method: "POST",
+    invalidates: refetch,
+  });
+
+  // Sibling primitive (#2092 — Wave 2B). Narrower scope than revoke-auth:
+  // clears passkeys + TOTP only, leaves sessions and OAuth grants alone.
+  // The same `refetch` invalidates the preview counts so the passkey
+  // count tile updates after a successful reset.
+  const resetMfa = useAdminMutation({
+    path: `/api/v1/admin/users/${userId}/reset-mfa`,
     method: "POST",
     invalidates: refetch,
   });
@@ -56,6 +67,13 @@ export default function UserDetailPage() {
     await revokeAuth.mutate({
       body: reason ? { reason } : {},
       onSuccess: () => setConfirmOpen(false),
+    });
+  }
+
+  async function handleMfaReset(reason: string) {
+    await resetMfa.mutate({
+      body: reason ? { reason } : {},
+      onSuccess: () => setMfaResetOpen(false),
     });
   }
 
@@ -165,12 +183,51 @@ export default function UserDetailPage() {
                   Danger zone
                 </CardTitle>
                 <CardDescription>
-                  Force-revoke every authentication artifact for this user. The user can re-enroll
-                  if they&apos;re re-hired; the contractor / compromised-account scenario is the
-                  load-bearing case.
+                  Recovery and off-boarding controls. Reset MFA recovers a locked-out user;
+                  full revoke handles the contractor / compromised-account case. Both write
+                  audit rows.
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
+                {/*
+                  MFA reset (#2092 — Wave 2B). Narrower scope than full revoke:
+                  clears passkeys + TOTP + bundled backup codes only. Sessions
+                  and OAuth grants stay live so a recovery reset doesn't
+                  double as an unintended sign-out.
+                */}
+                <div className="rounded-md border border-amber-500/40 bg-amber-500/5 p-4">
+                  <h3 className="text-sm font-semibold">Reset MFA enrollment</h3>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Atomically clears every passkey, TOTP secret, and bundled backup-code
+                    batch for this user inside a single transaction. Sessions and OAuth
+                    grants are left in place. The user is forced to re-enroll a second
+                    factor on the next admin-router request. Use this when a user has
+                    lost their only authenticator and is locked out.
+                  </p>
+                  <div className="mt-3 flex flex-wrap items-center gap-3">
+                    {/*
+                      Stays clickable even at zero-passkey preview — the
+                      preview endpoint doesn't expose TOTP enrollment, and
+                      a zero-MFA reset still emits a forensic audit row
+                      (same "audit on zero" pattern as revoke-auth).
+                    */}
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="border-amber-500/40 text-amber-700 hover:bg-amber-500/10 dark:text-amber-300"
+                      onClick={() => setMfaResetOpen(true)}
+                    >
+                      <Fingerprint className="mr-1.5 size-3.5" />
+                      Reset MFA enrollment
+                    </Button>
+                    <span className="text-xs text-muted-foreground">
+                      {preview.passkeys === 0
+                        ? "No passkeys on file. Any TOTP secret will still be cleared."
+                        : `${preview.passkeys} passkey${preview.passkeys === 1 ? "" : "s"} and any TOTP secret will be cleared.`}
+                    </span>
+                  </div>
+                </div>
+
                 <div className="rounded-md border border-destructive/40 bg-destructive/5 p-4">
                   <h3 className="text-sm font-semibold">Revoke all authentication</h3>
                   <p className="mt-1 text-xs text-muted-foreground">
@@ -236,6 +293,37 @@ export default function UserDetailPage() {
         onConfirm={handleRevoke}
         loading={revokeAuth.saving}
         mutationError={revokeAuth.error}
+      />
+
+      <ReasonDialog
+        open={mfaResetOpen}
+        onOpenChange={(open) => {
+          if (!resetMfa.saving) {
+            setMfaResetOpen(open);
+            if (!open) resetMfa.clearError();
+          }
+        }}
+        title="Reset MFA enrollment"
+        description="Recorded in the audit log with per-artifact counts (passkeys, TOTP secrets, backup-code batches). Sessions and OAuth grants stay live."
+        confirmLabel="Reset MFA"
+        placeholder="e.g., User reports stolen laptop, cross-checked with HR ticket TKT-1234"
+        feature="User MFA Reset"
+        context={
+          preview ? (
+            <div className="space-y-1.5">
+              <div className="font-medium text-foreground">
+                {preview.targetUserEmail ?? preview.targetUserId}
+              </div>
+              <div className="text-muted-foreground">
+                {preview.passkeys} passkey{preview.passkeys === 1 ? "" : "s"} on file. Any TOTP
+                secret + bundled backup codes will also be cleared.
+              </div>
+            </div>
+          ) : null
+        }
+        onConfirm={handleMfaReset}
+        loading={resetMfa.saving}
+        mutationError={resetMfa.error}
       />
     </div>
   );

--- a/packages/web/src/ui/__tests__/backup-method-banner.test.tsx
+++ b/packages/web/src/ui/__tests__/backup-method-banner.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * Smoke tests for the lockout-risk backup-method banner.
+ *
+ * Pins the predicate (`passkeyCount === 1 && !hasPassword && !hasTotp`),
+ * the per-session dismissal contract, and the dismissal-clears-once-the-
+ * predicate-clears recovery transition. Mirrors the mocking pattern from
+ * `security-posture-panel.test.tsx` (mocked `useAdminFetch`, query client
+ * wrapper, `cleanup()` between tests).
+ */
+
+import { describe, expect, test, mock, afterEach, beforeEach } from "bun:test";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+interface MfaFactors {
+  hasPassword: boolean;
+  hasTotp: boolean;
+  passkeyCount: number;
+}
+
+let mockData: MfaFactors | null = null;
+let mockLoading = false;
+let mockError: { message: string; status?: number } | null = null;
+
+mock.module("next/navigation", () => ({
+  usePathname: () => "/admin/settings/security",
+  useRouter: () => ({ push: () => {}, replace: () => {}, back: () => {} }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+mock.module("@/ui/hooks/use-admin-fetch", () => ({
+  useAdminFetch: () => ({
+    data: mockError ? null : mockData,
+    loading: mockLoading,
+    error: mockError,
+    setError: () => {},
+    refetch: () => Promise.resolve(),
+  }),
+  friendlyError: (err: { message?: string }) => err?.message ?? "error",
+}));
+
+const { BackupMethodBanner } = await import(
+  "../components/admin/security/backup-method-banner"
+);
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return createElement(QueryClientProvider, { client }, children);
+}
+
+const STORAGE_KEY = "atlas:backup-method-banner:dismissed";
+
+beforeEach(() => {
+  window.sessionStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  mockData = null;
+  mockLoading = false;
+  mockError = null;
+  window.sessionStorage.clear();
+});
+
+describe("BackupMethodBanner — predicate", () => {
+  test("renders when passkeyCount === 1 AND no password AND no TOTP", () => {
+    mockData = { passkeyCount: 1, hasPassword: false, hasTotp: false };
+    render(<BackupMethodBanner onAddPasskey={() => {}} />, { wrapper });
+    expect(document.body.textContent).toContain("Add a backup method");
+  });
+
+  test("stays silent when passkeyCount === 0 (no factors yet — different surface)", () => {
+    mockData = { passkeyCount: 0, hasPassword: false, hasTotp: false };
+    render(<BackupMethodBanner onAddPasskey={() => {}} />, { wrapper });
+    expect(document.body.textContent).not.toContain("Add a backup method");
+  });
+
+  test("stays silent when passkeyCount >= 2 (the count === 1 not >= 1 guard)", () => {
+    mockData = { passkeyCount: 2, hasPassword: false, hasTotp: false };
+    render(<BackupMethodBanner onAddPasskey={() => {}} />, { wrapper });
+    expect(document.body.textContent).not.toContain("Add a backup method");
+  });
+
+  test("stays silent when a password is set", () => {
+    mockData = { passkeyCount: 1, hasPassword: true, hasTotp: false };
+    render(<BackupMethodBanner onAddPasskey={() => {}} />, { wrapper });
+    expect(document.body.textContent).not.toContain("Add a backup method");
+  });
+
+  test("stays silent when TOTP is enrolled", () => {
+    mockData = { passkeyCount: 1, hasPassword: false, hasTotp: true };
+    render(<BackupMethodBanner onAddPasskey={() => {}} />, { wrapper });
+    expect(document.body.textContent).not.toContain("Add a backup method");
+  });
+
+  test("stays silent during the loading flash (avoids a banner that disappears as the snapshot resolves)", () => {
+    mockLoading = true;
+    render(<BackupMethodBanner onAddPasskey={() => {}} />, { wrapper });
+    expect(document.body.textContent).not.toContain("Add a backup method");
+  });
+
+  test("stays silent on fetch error", () => {
+    mockError = { message: "boom", status: 500 };
+    render(<BackupMethodBanner onAddPasskey={() => {}} />, { wrapper });
+    expect(document.body.textContent).not.toContain("Add a backup method");
+  });
+});
+
+describe("BackupMethodBanner — secondary CTA", () => {
+  test("'Add a password' is suppressed when no handler is supplied", () => {
+    mockData = { passkeyCount: 1, hasPassword: false, hasTotp: false };
+    render(<BackupMethodBanner onAddPasskey={() => {}} />, { wrapper });
+    expect(document.body.textContent).not.toContain("Add a password");
+  });
+
+  test("'Add a password' renders when the parent supplies a handler", () => {
+    mockData = { passkeyCount: 1, hasPassword: false, hasTotp: false };
+    render(
+      <BackupMethodBanner onAddPasskey={() => {}} onAddPassword={() => {}} />,
+      { wrapper },
+    );
+    expect(document.body.textContent).toContain("Add a password");
+  });
+
+  test("'Enroll a second passkey' fires the primary callback", () => {
+    let calls = 0;
+    mockData = { passkeyCount: 1, hasPassword: false, hasTotp: false };
+    const { getByRole } = render(
+      <BackupMethodBanner onAddPasskey={() => calls++} />,
+      { wrapper },
+    );
+    fireEvent.click(getByRole("button", { name: /Enroll a second passkey/ }));
+    expect(calls).toBe(1);
+  });
+});
+
+describe("BackupMethodBanner — dismissal", () => {
+  test("dismiss persists for the session via sessionStorage", () => {
+    mockData = { passkeyCount: 1, hasPassword: false, hasTotp: false };
+    const { getByLabelText, queryByText, rerender } = render(
+      <BackupMethodBanner onAddPasskey={() => {}} />,
+      { wrapper },
+    );
+    expect(queryByText("Add a backup method")).not.toBeNull();
+    fireEvent.click(getByLabelText("Dismiss for this session"));
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBe("1");
+    // Subsequent renders honor the dismissed flag.
+    rerender(<BackupMethodBanner onAddPasskey={() => {}} />);
+    expect(queryByText("Add a backup method")).toBeNull();
+  });
+
+  test("dismissal honored on remount when the predicate is still at-risk", () => {
+    window.sessionStorage.setItem(STORAGE_KEY, "1");
+    mockData = { passkeyCount: 1, hasPassword: false, hasTotp: false };
+    render(<BackupMethodBanner onAddPasskey={() => {}} />, { wrapper });
+    expect(document.body.textContent).not.toContain("Add a backup method");
+  });
+
+  test("dismissal clears once the predicate clears (next at-risk session sees the banner cleanly)", () => {
+    window.sessionStorage.setItem(STORAGE_KEY, "1");
+    // Recovered profile — second passkey enrolled.
+    mockData = { passkeyCount: 2, hasPassword: false, hasTotp: false };
+    render(<BackupMethodBanner onAddPasskey={() => {}} />, { wrapper });
+    // The useEffect cleanup runs synchronously after render via React 19 effects.
+    // sessionStorage should be empty so a future at-risk transition surfaces the banner.
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});

--- a/packages/web/src/ui/components/admin/feature-registry.ts
+++ b/packages/web/src/ui/components/admin/feature-registry.ts
@@ -70,6 +70,7 @@ export const FEATURE_NAMES = [
   "Usage Dashboard",
   "User Auth Revoke",
   "User Erasure",
+  "User MFA Reset",
   "Users",
 ] as const;
 

--- a/packages/web/src/ui/components/admin/security/backup-method-banner.tsx
+++ b/packages/web/src/ui/components/admin/security/backup-method-banner.tsx
@@ -1,29 +1,20 @@
 "use client";
 
 /**
- * Backup-method banner — top of `/admin/settings/security` (#2092).
+ * Backup-method banner — top of `/admin/settings/security`.
  *
- * Wave 2B passkey-recovery surface. Renders when the calling user matches
- * the lockout-risk profile:
+ * Renders when the calling user matches the lockout-risk profile:
+ * exactly one passkey, no password, no TOTP. Losing the only
+ * authenticator in that state requires admin-mediated MFA reset to
+ * recover; the banner widens the bottleneck by nudging the user toward
+ * a second passkey (preferred) or a password fallback.
  *
- *   exactly one passkey AND no password AND no TOTP
- *
- * That predicate maps to the `passkeyOnly` bucket from the #2094
- * adoption telemetry, narrowed to "single passkey" — a passkey is
- * already multi-factor by WebAuthn UV, but losing the only authenticator
- * is the lockout case admin-mediated reset (#2092 Section 2) exists to
- * recover from. The banner widens that bottleneck by nudging users to
- * either enroll a second passkey (preferred) or keep a password set.
- *
- * Dismissal is per-session (`sessionStorage`) so re-rendering on the
- * next sign-in is automatic — the persistence guarantee from the
- * acceptance criteria. Once the predicate clears (≥2 passkeys, OR a
- * password, OR TOTP), the banner stays away regardless of dismissal
- * state. A user who dismisses then enrolls a second passkey will not
- * see the banner again, even before sessionStorage rotates.
+ * Dismissal is per-session (`sessionStorage`); the dismissal flag is
+ * cleared once the predicate clears so a future at-risk session
+ * surfaces the banner cleanly.
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { KeyRound, ShieldAlert, X } from "lucide-react";
 import { z } from "zod";
 import { Button } from "@/components/ui/button";
@@ -32,8 +23,7 @@ import { cn } from "@/lib/utils";
 
 // Hand-mirrored from `MyMfaFactorsResponseSchema` in
 // `packages/api/src/api/routes/admin-mfa-reset.ts`. Update both when the
-// response shape changes — keeping the mirror local to the consumer
-// avoids pulling the API package into the web bundle.
+// response shape changes.
 const MfaFactorsSchema = z.object({
   hasPassword: z.boolean(),
   hasTotp: z.boolean(),
@@ -42,16 +32,7 @@ const MfaFactorsSchema = z.object({
 
 type MfaFactors = z.infer<typeof MfaFactorsSchema>;
 
-/**
- * Single source of truth for the lockout-risk predicate. Lifted out of
- * the component so a future change (e.g. relax to `passkeyCount <= 1`
- * once the SaaS auth schema enforces a min-2 invariant) only mutates one
- * location.
- *
- * The acceptance criteria pin BOTH halves of the rule:
- *   - exactly one passkey (count === 1, not "≥1")
- *   - no other factor (no password, no TOTP)
- */
+// Lockout-risk: exactly one passkey, no password, no TOTP.
 function isAtLockoutRisk(f: MfaFactors): boolean {
   return f.passkeyCount === 1 && !f.hasPassword && !f.hasTotp;
 }
@@ -80,18 +61,14 @@ export function BackupMethodBanner({ onAddPasskey, onAddPassword }: BackupMethod
     { schema: MfaFactorsSchema },
   );
 
-  // sessionStorage is read once on mount — re-renders during this
-  // session honor the same value. Per-session dismissal is the
-  // acceptance-criteria requirement: dismiss persists "until the
-  // predicate clears", and predicate clearing is checked below.
+  // Per-session dismissal — read once on mount, cleared below when the
+  // predicate clears.
   const [dismissed, setDismissed] = useState<boolean>(() => {
     if (typeof window === "undefined") return false;
     try {
       return window.sessionStorage.getItem(DISMISS_STORAGE_KEY) === "1";
     } catch (err) {
-      // intentionally ignored: storage access can throw in private-mode
-      // browsers — falling through to "not dismissed" is the safer
-      // default; the banner re-renders once they reach a normal session.
+      // intentionally ignored: storage access throws in private-mode browsers.
       console.debug("[backup-method-banner] sessionStorage unavailable", err);
       return false;
     }
@@ -102,17 +79,13 @@ export function BackupMethodBanner({ onAddPasskey, onAddPassword }: BackupMethod
     try {
       window.sessionStorage.setItem(DISMISS_STORAGE_KEY, "1");
     } catch (err) {
-      // intentionally ignored: storage write can throw in private-mode
-      // browsers — keep the in-memory dismissal so the user sees the
-      // banner disappear; it'll re-render on the next sign-in regardless.
+      // intentionally ignored: storage write throws in private-mode browsers.
       console.debug("[backup-method-banner] sessionStorage write failed", err);
     }
   }
 
-  // If the predicate cleared since the last dismissal (user just
-  // enrolled a second passkey, then refetch fired), drop the
-  // dismissal flag so the next at-risk session — possibly weeks
-  // later — surfaces the banner cleanly.
+  // Drop the dismissal once the predicate clears so a future at-risk
+  // session surfaces the banner cleanly.
   useEffect(() => {
     if (!data) return;
     if (dismissed && !isAtLockoutRisk(data)) {
@@ -125,18 +98,7 @@ export function BackupMethodBanner({ onAddPasskey, onAddPassword }: BackupMethod
     }
   }, [data, dismissed]);
 
-  // Memoize the at-risk decision so a render where `data` is referentially
-  // stable but TanStack returns a new wrapper doesn't re-evaluate the
-  // predicate every paint.
-  const atRisk = useMemo(() => (data ? isAtLockoutRisk(data) : false), [data]);
-
-  // Render-gating waterfall: don't render anything while the snapshot is
-  // loading (avoids a flash of the banner that disappears once the
-  // session check resolves), don't render on error (the panel below
-  // will surface a separate error if it matters), don't render when
-  // dismissed for the session, don't render when the user is not at
-  // risk. All four branches collapse to the same null return.
-  if (loading || error || !data || dismissed || !atRisk) {
+  if (loading || error || !data || dismissed || !isAtLockoutRisk(data)) {
     return null;
   }
 
@@ -169,13 +131,7 @@ export function BackupMethodBanner({ onAddPasskey, onAddPassword }: BackupMethod
             <KeyRound className="mr-1.5 size-3.5" />
             Enroll a second passkey
           </Button>
-          {/*
-            Secondary CTA is "Add a password" — only rendered when the
-            parent supplies a handler (predicate already required
-            hasPassword=false, so suppressing on missing handler is the
-            "deploy doesn't expose self-service password setup" carve-out
-            documented on the prop).
-          */}
+          {/* Secondary CTA only renders when the parent supplies a handler — see prop doc. */}
           {onAddPassword && (
             <Button size="sm" variant="outline" onClick={onAddPassword}>
               Add a password

--- a/packages/web/src/ui/components/admin/security/backup-method-banner.tsx
+++ b/packages/web/src/ui/components/admin/security/backup-method-banner.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+/**
+ * Backup-method banner — top of `/admin/settings/security` (#2092).
+ *
+ * Wave 2B passkey-recovery surface. Renders when the calling user matches
+ * the lockout-risk profile:
+ *
+ *   exactly one passkey AND no password AND no TOTP
+ *
+ * That predicate maps to the `passkeyOnly` bucket from the #2094
+ * adoption telemetry, narrowed to "single passkey" — a passkey is
+ * already multi-factor by WebAuthn UV, but losing the only authenticator
+ * is the lockout case admin-mediated reset (#2092 Section 2) exists to
+ * recover from. The banner widens that bottleneck by nudging users to
+ * either enroll a second passkey (preferred) or keep a password set.
+ *
+ * Dismissal is per-session (`sessionStorage`) so re-rendering on the
+ * next sign-in is automatic — the persistence guarantee from the
+ * acceptance criteria. Once the predicate clears (≥2 passkeys, OR a
+ * password, OR TOTP), the banner stays away regardless of dismissal
+ * state. A user who dismisses then enrolls a second passkey will not
+ * see the banner again, even before sessionStorage rotates.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { KeyRound, ShieldAlert, X } from "lucide-react";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
+import { cn } from "@/lib/utils";
+
+// Hand-mirrored from `MyMfaFactorsResponseSchema` in
+// `packages/api/src/api/routes/admin-mfa-reset.ts`. Update both when the
+// response shape changes — keeping the mirror local to the consumer
+// avoids pulling the API package into the web bundle.
+const MfaFactorsSchema = z.object({
+  hasPassword: z.boolean(),
+  hasTotp: z.boolean(),
+  passkeyCount: z.number().int().nonnegative(),
+});
+
+type MfaFactors = z.infer<typeof MfaFactorsSchema>;
+
+/**
+ * Single source of truth for the lockout-risk predicate. Lifted out of
+ * the component so a future change (e.g. relax to `passkeyCount <= 1`
+ * once the SaaS auth schema enforces a min-2 invariant) only mutates one
+ * location.
+ *
+ * The acceptance criteria pin BOTH halves of the rule:
+ *   - exactly one passkey (count === 1, not "≥1")
+ *   - no other factor (no password, no TOTP)
+ */
+function isAtLockoutRisk(f: MfaFactors): boolean {
+  return f.passkeyCount === 1 && !f.hasPassword && !f.hasTotp;
+}
+
+const DISMISS_STORAGE_KEY = "atlas:backup-method-banner:dismissed";
+
+export interface BackupMethodBannerProps {
+  /**
+   * Click handler for the primary "Enroll a second passkey" CTA. Wired
+   * by the parent so the same passkey-add flow as the enrollment tile
+   * fires (consistent OS prompt, naming dialog, post-enroll refetch).
+   */
+  onAddPasskey: () => void;
+  /**
+   * Click handler for the secondary "Add a password" CTA. Optional —
+   * when omitted (e.g. SaaS deploys that don't expose self-service
+   * password setup outside the email flow), the secondary button is
+   * suppressed and only the passkey CTA renders.
+   */
+  onAddPassword?: () => void;
+}
+
+export function BackupMethodBanner({ onAddPasskey, onAddPassword }: BackupMethodBannerProps) {
+  const { data, loading, error } = useAdminFetch<MfaFactors>(
+    "/api/v1/admin/me/mfa-factors",
+    { schema: MfaFactorsSchema },
+  );
+
+  // sessionStorage is read once on mount — re-renders during this
+  // session honor the same value. Per-session dismissal is the
+  // acceptance-criteria requirement: dismiss persists "until the
+  // predicate clears", and predicate clearing is checked below.
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    try {
+      return window.sessionStorage.getItem(DISMISS_STORAGE_KEY) === "1";
+    } catch (err) {
+      // intentionally ignored: storage access can throw in private-mode
+      // browsers — falling through to "not dismissed" is the safer
+      // default; the banner re-renders once they reach a normal session.
+      console.debug("[backup-method-banner] sessionStorage unavailable", err);
+      return false;
+    }
+  });
+
+  function handleDismiss() {
+    setDismissed(true);
+    try {
+      window.sessionStorage.setItem(DISMISS_STORAGE_KEY, "1");
+    } catch (err) {
+      // intentionally ignored: storage write can throw in private-mode
+      // browsers — keep the in-memory dismissal so the user sees the
+      // banner disappear; it'll re-render on the next sign-in regardless.
+      console.debug("[backup-method-banner] sessionStorage write failed", err);
+    }
+  }
+
+  // If the predicate cleared since the last dismissal (user just
+  // enrolled a second passkey, then refetch fired), drop the
+  // dismissal flag so the next at-risk session — possibly weeks
+  // later — surfaces the banner cleanly.
+  useEffect(() => {
+    if (!data) return;
+    if (dismissed && !isAtLockoutRisk(data)) {
+      try {
+        window.sessionStorage.removeItem(DISMISS_STORAGE_KEY);
+      } catch (err) {
+        console.debug("[backup-method-banner] sessionStorage removeItem failed", err);
+      }
+      setDismissed(false);
+    }
+  }, [data, dismissed]);
+
+  // Memoize the at-risk decision so a render where `data` is referentially
+  // stable but TanStack returns a new wrapper doesn't re-evaluate the
+  // predicate every paint.
+  const atRisk = useMemo(() => (data ? isAtLockoutRisk(data) : false), [data]);
+
+  // Render-gating waterfall: don't render anything while the snapshot is
+  // loading (avoids a flash of the banner that disappears once the
+  // session check resolves), don't render on error (the panel below
+  // will surface a separate error if it matters), don't render when
+  // dismissed for the session, don't render when the user is not at
+  // risk. All four branches collapse to the same null return.
+  if (loading || error || !data || dismissed || !atRisk) {
+    return null;
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "rounded-lg ring-1 ring-amber-500/30 bg-amber-500/5 p-4",
+        "flex items-start gap-3",
+      )}
+    >
+      <span
+        className="mt-0.5 grid size-9 shrink-0 place-items-center rounded-md bg-amber-500/10 text-amber-700 dark:text-amber-300"
+        aria-hidden
+      >
+        <ShieldAlert className="size-4" />
+      </span>
+      <div className="min-w-0 flex-1">
+        <h2 className="text-sm font-semibold">Add a backup method</h2>
+        <p className="mt-1 text-xs text-muted-foreground">
+          You have one passkey and no other way to sign in. If you lose access
+          to that authenticator, an admin will need to manually reset your
+          MFA before you can recover the account. Enrolling a second
+          passkey&mdash;ideally on a different device&mdash;is the simplest
+          way to widen the recovery path.
+        </p>
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <Button size="sm" onClick={onAddPasskey}>
+            <KeyRound className="mr-1.5 size-3.5" />
+            Enroll a second passkey
+          </Button>
+          {/*
+            Secondary CTA is "Add a password" — only rendered when the
+            parent supplies a handler (predicate already required
+            hasPassword=false, so suppressing on missing handler is the
+            "deploy doesn't expose self-service password setup" carve-out
+            documented on the prop).
+          */}
+          {onAddPassword && (
+            <Button size="sm" variant="outline" onClick={onAddPassword}>
+              Add a password
+            </Button>
+          )}
+        </div>
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="shrink-0 text-muted-foreground hover:text-foreground"
+        onClick={handleDismiss}
+        aria-label="Dismiss for this session"
+      >
+        <X className="size-4" />
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Closes Wave 2B and the parallel MFA hardening track. Two narrow primitives widen the lockout bottleneck for passkey-only users without introducing a parallel recovery primitive.
- Backup-method banner on `/admin/settings/security` nudges users matching the lockout-risk profile (exactly one passkey, no password, no TOTP) toward a second passkey or keeping a password set. Dismissable per session; re-renders on the next sign-in until the predicate clears (≥2 passkeys OR a password OR TOTP).
- New admin-mediated `POST /api/v1/admin/users/{id}/reset-mfa` endpoint. Atomically clears every passkey + TOTP secret + bundled backup-code batch inside a single transaction; sessions and OAuth grants stay live. Workspace admins scoped to org members; platform admins cross-org. Mirrors #2093's `admin-revoke.ts` shape (BEGIN/COMMIT/ROLLBACK + `release(rollbackErr)` destroy-on-poison + `errorMessage()` audit scrub).
- New `user.mfa_reset` audit action with per-artifact metadata: `{ targetUserId, targetUserEmail, passkeysRevoked, totpSecretsRevoked, backupCodeBatchesRevoked, reason? }`. Failure rows add `{ phase, error }` so triage can answer 'did anything actually delete?' from the audit log alone.
- New `User MFA Reset` entry in `FEATURE_NAMES` so the danger-zone tile's `<ReasonDialog feature="user-mfa-reset">` (and any future `<MutationErrorSurface>` / `<EnterpriseUpsell>` consumers) get TS-enforced banner copy.
- Docs: new **Recovery** section in `apps/docs/content/docs/security/passkeys.mdx` covering recommended setup, the admin-mediated reset path, and the explicit absence of recovery codes / email OTP — the privacy + security tradeoff is documented inline.

## Why this shape

The Wave 2B issue resolved on three options: (A) mandatory second-passkey nudge + admin-mediated reset, (B) recovery codes decoupled from TOTP, (C) force TOTP as the recovery factor. **A** is what shipped here. **B** is dead because Better Auth's `twoFactor` plugin bundles backup codes with TOTP as a single primitive (Context7-verified) — extracting them cleanly would mean either hacking the plugin contract (fragile) or building a parallel recovery-codes table (duplicates a primitive). **C** undoes #2082's whole point. A passkey is already multi-factor by WebAuthn UV; the right move is widening the single-passkey bottleneck.

## Test plan

- [x] /ci passes locally — lint, type, test (335/335 api, 120/120 web, 25/25 ee, 20/20 cli, 10/10 react), syncpack, template drift, security-headers drift, railway-watch
- [ ] Banner renders on `/admin/settings/security` only when `passkeyCount === 1 && !hasPassword && !hasTotp`
- [ ] Banner dismissal (X button) hides for the session via `sessionStorage`; cleared automatically once the predicate stops matching
- [ ] Primary CTA ('Enroll a second passkey') scrolls to the existing passkey tile so the WebAuthn ceremony stays in one place
- [ ] Danger-zone 'Reset MFA enrollment' tile on `/admin/users/{id}` opens `<ReasonDialog feature="user-mfa-reset">` and posts to `/api/v1/admin/users/{id}/reset-mfa`
- [ ] Audit row carries actor, target, reason, and per-artifact counts after reset
- [ ] User who is reset trips `mfa_enrollment_required` 403 on the next admin-router request and re-enrolls cleanly

## Closes

Closes #2092.