### PR TITLE
fix(api,docs): #2066 follow-up — regenerate OpenAPI spec + fix me-oauth-clients fixture

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -14540,6 +14540,14 @@
                           "tokenCount": {
                             "type": "integer",
                             "minimum": 0
+                          },
+                          "tokenState": {
+                            "type": "string",
+                            "enum": [
+                              "active",
+                              "reconnect_required",
+                              "revoked"
+                            ]
                           }
                         },
                         "required": [
@@ -14551,7 +14559,8 @@
                           "disabled",
                           "type",
                           "lastUsedAt",
-                          "tokenCount"
+                          "tokenCount",
+                          "tokenState"
                         ]
                       }
                     },
@@ -44026,6 +44035,14 @@
                           "tokenCount": {
                             "type": "integer",
                             "minimum": 0
+                          },
+                          "tokenState": {
+                            "type": "string",
+                            "enum": [
+                              "active",
+                              "reconnect_required",
+                              "revoked"
+                            ]
                           }
                         },
                         "required": [
@@ -44037,7 +44054,8 @@
                           "disabled",
                           "type",
                           "lastUsedAt",
-                          "tokenCount"
+                          "tokenCount",
+                          "tokenState"
                         ]
                       }
                     }

--- a/packages/api/src/api/__tests__/me-oauth-clients.test.ts
+++ b/packages/api/src/api/__tests__/me-oauth-clients.test.ts
@@ -190,6 +190,8 @@ describe("me oauth-clients — GET /me/oauth-clients", () => {
               type: "public",
               lastUsedAt: "2026-05-01T15:30:00.000Z",
               tokenCount: "3",
+              liveTokenCount: "3",
+              liveRefreshCount: "1",
             },
           ];
         }


### PR DESCRIPTION
## Summary

Two pre-existing failures on `main`, both introduced by the merge of [#2106](https://github.com/AtlasDevHQ/atlas/pull/2106) (hosted-MCP token refresh + `tokenState`):

1. **`ci` job** — `apps/docs/openapi.json` drifted from `packages/api` routes. The `/me/oauth-clients` and `/admin/oauth-clients` responses gained a `tokenState` enum in #2066 but the spec wasn't regenerated. Fix: ran `bun run --filter '@atlas/api' openapi:extract` and committed the diff. (The api-reference MDX didn't need updates — the new field is encoded in the JSON spec only.)

2. **`api-tests (1/4)`** — `src/api/__tests__/me-oauth-clients.test.ts :: "lists clients filtered by userId AND referenceId"` was missing `liveTokenCount` and `liveRefreshCount` in its mock fixture. The GROUP BY regression fix in #2066 made `oauth-clients.ts:223` throw when those aggregates are undefined (the right call — silently classifying healthy clients as `reconnect_required` would be the false-negative-fallback CLAUDE.md prohibits). The 19 newer tests in the same file already carry the live-count fields; only the very first test was missed in the fixture migration. Set live counts to 3/1 to match the existing `tokenCount` assertion.

## Test plan

- [x] `bun test packages/api/src/api/__tests__/me-oauth-clients.test.ts` → 20 pass / 0 fail
- [x] `bash scripts/check-openapi-drift.sh` → green
- [ ] CI on PR — `ci` and all four `api-tests` shards green