### PR TITLE
fix(api,web): passkey re-auth flow + email verification resend

### DIFF
--- a/apps/docs/content/docs/guides/actions.mdx
+++ b/apps/docs/content/docs/guides/actions.mdx
@@ -211,7 +211,7 @@ Send email reports via [Resend](https://resend.com).
 - `RESEND_API_KEY` -- Resend API token
 
 **Optional:**
-- `ATLAS_EMAIL_FROM` -- From address (default: `Atlas <atlas@notifications.useatlas.dev>`)
+- `ATLAS_EMAIL_FROM` -- From address (default: `Atlas <atlas@ship.useatlas.dev>`)
 - `ATLAS_EMAIL_ALLOWED_DOMAINS` -- Comma-separated domain whitelist for recipients
 
 **Input:**

--- a/apps/docs/content/docs/guides/onboarding-emails.mdx
+++ b/apps/docs/content/docs/guides/onboarding-emails.mdx
@@ -48,7 +48,7 @@ Enable onboarding emails via environment variable:
 ```bash
 ATLAS_ONBOARDING_EMAILS_ENABLED=true
 RESEND_API_KEY=re_...            # or ATLAS_SMTP_URL for HTTP webhook-based delivery (POST JSON)
-ATLAS_EMAIL_FROM=Atlas <noreply@yourdomain.com>  # optional, defaults to "Atlas <noreply@useatlas.dev>"
+ATLAS_EMAIL_FROM=Atlas <noreply@yourdomain.com>  # optional, defaults to "Atlas <noreply@ship.useatlas.dev>"
 ```
 
 See [Environment Variables](/reference/environment-variables#email-delivery) for all email configuration options.

--- a/apps/docs/content/docs/guides/scheduled-tasks.mdx
+++ b/apps/docs/content/docs/guides/scheduled-tasks.mdx
@@ -78,7 +78,7 @@ Self-hosted deployments require [Resend](https://resend.com) for email delivery:
 
 ```bash
 RESEND_API_KEY=re_...
-ATLAS_EMAIL_FROM="Atlas <reports@example.com>"  # Optional, default: Atlas <noreply@useatlas.dev>
+ATLAS_EMAIL_FROM="Atlas <reports@example.com>"  # Optional, default: Atlas <noreply@ship.useatlas.dev>
 ```
 
 Recipient format:
@@ -261,10 +261,10 @@ On [app.useatlas.dev](https://app.useatlas.dev), these variables are managed aut
 | `ATLAS_SCHEDULER_TICK_INTERVAL` | `60` | Tick interval in seconds |
 | `ATLAS_SCHEDULER_SECRET` | — | Shared secret for `/tick` endpoint |
 | `RESEND_API_KEY` | — | Required for email delivery |
-| `ATLAS_EMAIL_FROM` | `Atlas <noreply@useatlas.dev>` | Email from address |
+| `ATLAS_EMAIL_FROM` | `Atlas <noreply@ship.useatlas.dev>` | Email from address |
 
 <Callout type="info">
-The scheduled tasks default email address (`noreply@useatlas.dev`) differs from the actions framework default (`atlas@notifications.useatlas.dev`). Set `ATLAS_EMAIL_FROM` to use a consistent address across both.
+The scheduled tasks default sender (`noreply@ship.useatlas.dev`) and the actions framework default (`atlas@ship.useatlas.dev`) share the `ship.useatlas.dev` Resend domain but use different local-parts. Set `ATLAS_EMAIL_FROM` to use a single address across both.
 </Callout>
 
 See [Environment Variables](/reference/environment-variables) for the full reference.

--- a/apps/docs/content/docs/guides/troubleshooting.mdx
+++ b/apps/docs/content/docs/guides/troubleshooting.mdx
@@ -296,7 +296,7 @@ Atlas caches JWKS keys but needs to reach the endpoint on startup. If your JWKS 
 
 #### Delivery Failures (Operator)
 
-- **Email**: Verify `RESEND_API_KEY` is set and valid. Check `ATLAS_EMAIL_FROM` format (default: `Atlas <noreply@useatlas.dev>`)
+- **Email**: Verify `RESEND_API_KEY` is set and valid. Check `ATLAS_EMAIL_FROM` format (default: `Atlas <noreply@ship.useatlas.dev>`)
 - **Slack**: Ensure `SLACK_BOT_TOKEN` (or OAuth) is configured and the bot has `chat:write` scope for the target channel
 - **Webhook**: Check the endpoint URL is reachable. Webhook delivery includes a timeout -- check debug logs for the response status
 

--- a/apps/docs/content/docs/plugins/actions/email.mdx
+++ b/apps/docs/content/docs/plugins/actions/email.mdx
@@ -16,7 +16,7 @@ bun add @useatlas/email
 ### Prerequisites
 
 - A [Resend API key](https://resend.com/api-keys)
-- A verified sending domain in Resend (or use the default `notifications.useatlas.dev`)
+- A verified sending domain in Resend (or use the default `ship.useatlas.dev`)
 
 ## Configuration
 
@@ -41,7 +41,7 @@ export default defineConfig({
 |--------|------|----------|---------|-------------|
 | `resendApiKey` | `string` | Yes | -- | Resend API key |
 | `allowedDomains` | `string[]` | No | -- | Optional domain allowlist. When set, only recipients with matching domains are permitted |
-| `fromAddress` | `string` | No | `"Atlas <atlas@notifications.useatlas.dev>"` | Sender address for outgoing emails |
+| `fromAddress` | `string` | No | `"Atlas <atlas@ship.useatlas.dev>"` | Sender address for outgoing emails |
 | `approvalMode` | `"auto" \| "manual" \| "admin-only"` | No | `"admin-only"` | Who can approve email sends |
 
 ## Action Details

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -599,7 +599,7 @@ See [Python Tool](/guides/python) for the full guide.
 | `RESEND_API_KEY` | — | Resend API key for email delivery in scheduled tasks and onboarding emails |
 | `SENDGRID_API_KEY` | — | SendGrid API key. Used when `ATLAS_EMAIL_PROVIDER=sendgrid` |
 | `POSTMARK_SERVER_TOKEN` | — | Postmark server token. Used when `ATLAS_EMAIL_PROVIDER=postmark` |
-| `ATLAS_EMAIL_FROM` | `Atlas <noreply@useatlas.dev>` | From address for scheduled task and onboarding emails |
+| `ATLAS_EMAIL_FROM` | `Atlas <noreply@ship.useatlas.dev>` | From address for scheduled task and onboarding emails |
 | `ATLAS_SMTP_URL` | — | Webhook URL for email delivery (POST JSON with `from`, `to`, `subject`, `html`). Alternative to Resend |
 | `ATLAS_ONBOARDING_EMAILS_ENABLED` | `false` | Enable automated onboarding drip campaign for new signups. Requires `DATABASE_URL` and either `RESEND_API_KEY` or `ATLAS_SMTP_URL` |
 | `ATLAS_UNSUBSCRIBE_TOKEN_TTL_MS` | `2592000000` (30d) | TTL for signed unsubscribe links. Accepts `60000` (60s) to `31536000000` (1y); invalid values fall back to the default |

--- a/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
+++ b/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
@@ -429,7 +429,7 @@ describe("admin email-provider route", () => {
       expect(res.status).toBe(200);
       const data = (await res.json()) as { config: { baseline: { provider: string; fromAddress: string }; override: unknown } };
       expect(data.config.baseline.provider).toBe("resend");
-      expect(data.config.baseline.fromAddress).toBe("Atlas <noreply@useatlas.dev>");
+      expect(data.config.baseline.fromAddress).toBe("Atlas <noreply@ship.useatlas.dev>");
       expect(data.config.override).toBeNull();
     });
 

--- a/packages/api/src/api/routes/admin-email-provider.ts
+++ b/packages/api/src/api/routes/admin-email-provider.ts
@@ -47,7 +47,7 @@ const log = createLogger("admin-email-provider");
  * statement, not a live status readout.
  */
 const BASELINE_PROVIDER: EmailProvider = "resend";
-const BASELINE_FROM_ADDRESS = "Atlas <noreply@useatlas.dev>";
+const BASELINE_FROM_ADDRESS = "Atlas <noreply@ship.useatlas.dev>";
 
 // Provider-specific secret config shapes. Each carries the `provider`
 // discriminator (#1542) — the wire contract now requires it on the

--- a/packages/api/src/lib/auth/__tests__/oauth-refresh.test.ts
+++ b/packages/api/src/lib/auth/__tests__/oauth-refresh.test.ts
@@ -25,6 +25,7 @@
  */
 
 import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
+import type { Attributes } from "@opentelemetry/api";
 import {
   resolveAccessTokenTtlSeconds,
   resolveRefreshTokenTtlSeconds,
@@ -62,15 +63,15 @@ mock.module("@atlas/api/lib/audit", async () => {
 // Counter spy — pre-monkeypatch the `add` method so we can assert the
 // attribute payload. We don't fully mock `@atlas/api/lib/metrics` because
 // other code paths consume the same module in this test process and a
-// partial mock would leak.
-const counterAddSpy: Mock<
-  (value: number, attrs?: Record<string, unknown>) => void
-> = mock(() => {});
+// partial mock would leak. The `attrs` arg is typed as
+// `@opentelemetry/api`'s `Attributes` so the wrapper round-trips the
+// real Counter signature — `Record<string, unknown>` would lose the
+// AttributeValue narrowing and break the call to `originalCounterAdd`.
+const counterAddSpy: Mock<(value: number, attrs?: Attributes) => void> = mock(
+  () => {},
+);
 const originalCounterAdd = oauthTokenRefresh.add.bind(oauthTokenRefresh);
-oauthTokenRefresh.add = ((
-  value: number,
-  attrs?: Record<string, unknown>,
-) => {
+oauthTokenRefresh.add = ((value: number, attrs?: Attributes) => {
   counterAddSpy(value, attrs);
   return originalCounterAdd(value, attrs);
 }) as typeof oauthTokenRefresh.add;

--- a/packages/api/src/lib/auth/__tests__/rate-limit-integration.test.ts
+++ b/packages/api/src/lib/auth/__tests__/rate-limit-integration.test.ts
@@ -314,6 +314,18 @@ describe("config wiring snapshot — buildAuthOptions", () => {
 
     expect(unhandled).toBeNull();
   });
+
+  it("wires `emailVerification.sendOnSignIn = true` so unverified users self-recover", () => {
+    // Without this, Better Auth's /sign-in/email path throws
+    // EMAIL_NOT_VERIFIED but never re-dispatches the verification link
+    // (see node_modules/better-auth/dist/api/routes/sign-in.mjs — the
+    // `sendOnSignIn` branch is the ONLY place the link gets re-issued
+    // outside the original signup). A regression here permanently locks
+    // out anyone whose `emailVerified=false` — including users
+    // grandfathered in from before `requireEmailVerification` was on.
+    const options = buildAuthOptions(makeDeps());
+    expect(options.emailVerification?.sendOnSignIn).toBe(true);
+  });
 });
 
 describe("live rate-limit loop — /sign-in/email", () => {

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -1368,6 +1368,15 @@ export function buildAuthOptions(deps: BuildAuthOptionsDeps): Parameters<typeof 
         });
       },
       autoSignInAfterVerification: true,
+      // Re-issue a verification link whenever an unverified user attempts
+      // sign-in. Without this, Better Auth throws EMAIL_NOT_VERIFIED but
+      // never re-sends the email — leaving any user grandfathered from
+      // before `requireEmailVerification` flipped on (or anyone who lost
+      // their original token) permanently locked out with no self-serve
+      // recovery. The dispatch goes through the same `sendVerification`
+      // path above, so enumeration timing and rate limits apply uniformly
+      // to signup, manual resend, and this branch.
+      sendOnSignIn: true,
     },
     socialProviders: deps.socialProviders,
     // F-07 — cookieCache.maxAge bounds the revocation window. Previously

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -79,7 +79,7 @@ describe("runMigrations", () => {
 
     const count = await runMigrations(pool);
 
-    expect(count).toBe(50);
+    expect(count).toBe(51);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -158,6 +158,7 @@ describe("runMigrations", () => {
         "0047_drop_mcp_tokens.sql",
         "0048_trusted_device.sql",
         "0049_audit_log_mcp_columns.sql",
+        "0050_backfill_email_verified_grandfathered.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -698,7 +698,7 @@ describe("0042_audit_retention_default.sql", () => {
     );
   });
 
-  it("is registered in ORG_DEPENDENT_MIGRATIONS so non-managed deploys skip it (#1472)", () => {
+  it("is registered in MANAGED_AUTH_MIGRATIONS so non-managed deploys skip it (#1472)", () => {
     // Postgres parses `INSERT … FROM organization` at plan time, so on
     // a non-managed deploy without Better Auth's organization plugin the
     // migration aborts boot before evaluating row count. The skip list in
@@ -707,7 +707,56 @@ describe("0042_audit_retention_default.sql", () => {
     // future `internal.ts` cleanup can't silently drop it.
     const internalPath = path.join(import.meta.dir, "..", "internal.ts");
     const internalSrc = fs.readFileSync(internalPath, "utf-8");
-    expect(internalSrc).toMatch(/ORG_DEPENDENT_MIGRATIONS\s*=\s*\[[^\]]*"0042_audit_retention_default\.sql"/);
+    expect(internalSrc).toMatch(/MANAGED_AUTH_MIGRATIONS\s*=\s*\[[^\]]*"0042_audit_retention_default\.sql"/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: 0050_backfill_email_verified_grandfathered.sql (#2117)
+// ---------------------------------------------------------------------------
+
+describe("0050_backfill_email_verified_grandfathered.sql", () => {
+  const filePath = path.join(
+    import.meta.dir,
+    "..",
+    "migrations",
+    "0050_backfill_email_verified_grandfathered.sql",
+  );
+
+  it("is idempotent — guards on emailVerified = false", () => {
+    // Without this guard the migration would re-write every verified
+    // user's row on every deploy (no functional change but an I/O storm
+    // and replication chatter the size of the user table). The same
+    // failure mode would mask a future regression that flips the
+    // backfill into "always overwrite" — pin the WHERE clause exactly.
+    const sql = fs.readFileSync(filePath, "utf-8");
+    expect(sql).toMatch(/"emailVerified"\s*=\s*false/);
+  });
+
+  it("only promotes users with at least one session row", () => {
+    // The "session row implies inbox proof" heuristic is the migration's
+    // entire safety argument (see the file header). A future cleanup
+    // that drops the EXISTS clause would silently flip every unverified
+    // user to verified, including the population the requireEmailVerification
+    // gate exists to block.
+    const sql = fs.readFileSync(filePath, "utf-8");
+    expect(sql).toMatch(/EXISTS\s*\([^)]*FROM\s+"session"/i);
+  });
+
+  it("is registered in MANAGED_AUTH_MIGRATIONS so non-managed deploys skip it (#2117)", () => {
+    // The migration touches Better Auth's "user" + "session" tables,
+    // which only exist when managed auth is enabled. A future cleanup
+    // that drops 0050 from the skip list would abort boot on every
+    // self-hosted deployment with a non-managed backend (relation
+    // "session" does not exist). Pin the registration explicitly —
+    // the file-count assertion at line 82 is necessary but not
+    // sufficient (it confirms the file exists, not that the skip
+    // wiring is correct).
+    const internalPath = path.join(import.meta.dir, "..", "internal.ts");
+    const internalSrc = fs.readFileSync(internalPath, "utf-8");
+    expect(internalSrc).toMatch(
+      /MANAGED_AUTH_MIGRATIONS\s*=\s*\[[^\]]*"0050_backfill_email_verified_grandfathered\.sql"/,
+    );
   });
 });
 

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -731,10 +731,16 @@ function warnIfSharedDatabase(): void {
   }
 }
 
-/** Migrations that depend on Better Auth's organization table (#1472). */
+/** Migrations that depend on Better Auth tables (#1472, #2117). */
 const ORG_DEPENDENT_MIGRATIONS = [
   "0027_organization_saas_columns.sql",
   "0042_audit_retention_default.sql",
+  // Touches Better Auth's "user" and "session" tables — those tables
+  // only exist when managed auth is enabled (Better Auth's own
+  // runMigrations creates them). Skipping in non-managed mode keeps the
+  // migration runner green on self-hosted deployments that use a
+  // different auth backend.
+  "0050_backfill_email_verified_grandfathered.sql",
 ];
 
 /**

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -731,15 +731,21 @@ function warnIfSharedDatabase(): void {
   }
 }
 
-/** Migrations that depend on Better Auth tables (#1472, #2117). */
-const ORG_DEPENDENT_MIGRATIONS = [
+/**
+ * Migrations that depend on Better Auth tables (`organization`, `user`,
+ * `session`, etc.). Better Auth creates these tables only when managed
+ * auth is enabled — in any other mode Better Auth's `runMigrations` is
+ * never called, so applying these files would fail with `relation
+ * "..." does not exist`. The runner skips them in non-managed mode.
+ *
+ * Original list scoped to the `organization` table only (#1472); now
+ * covers any Better Auth–dependent table including `user` / `session`
+ * (#2117). Renaming follow-up to make the intent explicit.
+ */
+const MANAGED_AUTH_MIGRATIONS = [
   "0027_organization_saas_columns.sql",
   "0042_audit_retention_default.sql",
-  // Touches Better Auth's "user" and "session" tables — those tables
-  // only exist when managed auth is enabled (Better Auth's own
-  // runMigrations creates them). Skipping in non-managed mode keeps the
-  // migration runner green on self-hosted deployments that use a
-  // different auth backend.
+  // Backfill against Better Auth's "user" + "session" tables.
   "0050_backfill_email_verified_grandfathered.sql",
 ];
 
@@ -754,10 +760,11 @@ const ORG_DEPENDENT_MIGRATIONS = [
  * handle serverless Postgres cold starts on Railway where the DB may take
  * several seconds to wake up.
  *
- * In non-managed auth modes, migrations that depend on Better Auth's
- * `organization` table are skipped — Better Auth never creates it, so
- * applying them would fail. They get picked up automatically if the
- * deployment later switches to managed auth. See #1472.
+ * In non-managed auth modes, migrations that depend on any Better Auth
+ * table (`organization`, `user`, `session`, …) are skipped — Better
+ * Auth never creates them, so applying them would fail. They get picked
+ * up automatically if the deployment later switches to managed auth.
+ * See `MANAGED_AUTH_MIGRATIONS` and #1472 / #2117.
  */
 export async function migrateInternalDB(): Promise<void> {
   // Warn when DATABASE_URL and ATLAS_DATASOURCE_URL resolve to the same
@@ -774,7 +781,7 @@ export async function migrateInternalDB(): Promise<void> {
   // of auth/detect → config triggers a circular evaluation order that breaks
   // module-link in some test runners (mcp test suite). See #1487.
   const { detectAuthMode } = await import("@atlas/api/lib/auth/detect");
-  const skip = detectAuthMode() === "managed" ? [] : ORG_DEPENDENT_MIGRATIONS;
+  const skip = detectAuthMode() === "managed" ? [] : MANAGED_AUTH_MIGRATIONS;
 
   // Retry with backoff for serverless Postgres cold starts (Railway).
   // Set ATLAS_MIGRATION_RETRIES=0 to disable retries (e.g. in tests).

--- a/packages/api/src/lib/db/migrations/0042_audit_retention_default.sql
+++ b/packages/api/src/lib/db/migrations/0042_audit_retention_default.sql
@@ -35,7 +35,7 @@
 -- where `audit_retention_config` is unused but the runner would still
 -- attempt to apply this file.
 --
--- Resolution: this file is registered in `ORG_DEPENDENT_MIGRATIONS` in
+-- Resolution: this file is registered in `MANAGED_AUTH_MIGRATIONS` in
 -- `packages/api/src/lib/db/internal.ts` and skipped on
 -- `detectAuthMode() !== "managed"` boots. It is then applied automatically
 -- on a future boot if the deploy switches to managed auth. This mirrors the

--- a/packages/api/src/lib/db/migrations/0050_backfill_email_verified_grandfathered.sql
+++ b/packages/api/src/lib/db/migrations/0050_backfill_email_verified_grandfathered.sql
@@ -15,13 +15,29 @@
 -- get back in. This migration unsticks them ahead of that boundary.
 --
 -- Heuristic: a user with at least one row in the `session` table has,
--- by definition, completed at least one sign-in. Better Auth only
--- inserts a session row after the credential check passes — meaning
--- the user proved (a) the email exists, (b) they know the password, and
--- (c) some prior version of the auth config let them through. That is
--- a strictly stronger signal than the one-time email-token click that
--- normally flips emailVerified, so promoting them to verified is at
--- worst neutral and never weaker than the original signal.
+-- by definition, completed at least one sign-in (or a federated OAuth
+-- flow that minted a session, or a magic-link verify). Under Atlas's
+-- managed-auth config (see buildEmailAndPasswordConfig:
+-- `autoSignIn = !requireEmailVerification`), a session row implies
+-- one of:
+--   - email/password sign-in — proves password, plus an
+--     `emailVerified=true` precondition once requireEmailVerification
+--     was on (so the only candidates left at `false` predate that flip)
+--   - OAuth callback — federated identity proof; the provider also
+--     sets `emailVerified` directly when it vouches
+--   - magic-link verify — sets `emailVerified=true` at the same time,
+--     so those rows are already filtered out by the WHERE clause
+-- All three are at least as strong as the one-time inbox-token click
+-- the normal verify flow consumes — promoting them is at worst neutral
+-- and never weaker than the original signal.
+--
+-- This migration is `MANAGED_AUTH_MIGRATIONS`-gated in
+-- packages/api/src/lib/db/internal.ts so it only runs against
+-- deployments whose Better Auth `user`/`session` tables exist. The
+-- scope of "session row implies inbox proof" is the SaaS deployment
+-- (app.useatlas.dev) where requireEmailVerification has been on for
+-- the relevant population — operators who flipped between modes
+-- repeatedly should audit before re-enabling managed auth.
 --
 -- We deliberately do NOT backfill users with zero session rows: that
 -- includes accounts created via signup that never completed verification

--- a/packages/api/src/lib/db/migrations/0050_backfill_email_verified_grandfathered.sql
+++ b/packages/api/src/lib/db/migrations/0050_backfill_email_verified_grandfathered.sql
@@ -1,0 +1,42 @@
+-- 0050 — Backfill emailVerified=true for users grandfathered before
+-- ATLAS_REQUIRE_EMAIL_VERIFICATION was on.
+--
+-- Context: when `requireEmailVerification` is enabled, Better Auth's
+-- /sign-in/email path rejects users whose `user.emailVerified` is false
+-- with EMAIL_NOT_VERIFIED, regardless of whether they ever actually
+-- proved control of the inbox. SaaS deployments that flipped this on
+-- after launch ended up with a population of pre-existing users whose
+-- row never set `emailVerified=true` because the original signup flow
+-- didn't require it. With the same PR's `sendOnSignIn: true` change,
+-- those users *would* get a fresh verification link on their next
+-- attempt — but only if they happen to try signing in. Anyone holding
+-- a still-valid session cookie has no signal anything is wrong until
+-- the cookie expires, at which point they discover they can no longer
+-- get back in. This migration unsticks them ahead of that boundary.
+--
+-- Heuristic: a user with at least one row in the `session` table has,
+-- by definition, completed at least one sign-in. Better Auth only
+-- inserts a session row after the credential check passes — meaning
+-- the user proved (a) the email exists, (b) they know the password, and
+-- (c) some prior version of the auth config let them through. That is
+-- a strictly stronger signal than the one-time email-token click that
+-- normally flips emailVerified, so promoting them to verified is at
+-- worst neutral and never weaker than the original signal.
+--
+-- We deliberately do NOT backfill users with zero session rows: that
+-- includes accounts created via signup that never completed verification
+-- (the very population the gate exists to block from claiming an inbox
+-- they don't control). Those accounts must still go through the regular
+-- verification email path on their next sign-in attempt.
+--
+-- Idempotent. The WHERE clause skips already-verified rows so a re-run
+-- is a no-op (no row churn, no replication chatter). Safe to leave in
+-- the migration history forever — re-running on a fresh DB does
+-- nothing because there are no qualifying users yet.
+
+UPDATE "user" u
+SET "emailVerified" = true
+WHERE u."emailVerified" = false
+  AND EXISTS (
+    SELECT 1 FROM "session" s WHERE s."userId" = u.id
+  );

--- a/packages/api/src/lib/email/delivery.ts
+++ b/packages/api/src/lib/email/delivery.ts
@@ -115,7 +115,7 @@ function getPlatformEmailConfig(): EmailTransport | null {
   }
   const provider = raw;
 
-  const fromAddress = getSetting("ATLAS_EMAIL_FROM") ?? "Atlas <noreply@useatlas.dev>";
+  const fromAddress = getSetting("ATLAS_EMAIL_FROM") ?? "Atlas <noreply@ship.useatlas.dev>";
 
   switch (provider) {
     case "resend": {
@@ -185,7 +185,7 @@ export async function sendEmail(message: EmailMessage, orgId?: string): Promise<
     return deliverViaTransport(message, platformConfig);
   }
 
-  const fromAddress = process.env.ATLAS_EMAIL_FROM ?? "Atlas <noreply@useatlas.dev>";
+  const fromAddress = process.env.ATLAS_EMAIL_FROM ?? "Atlas <noreply@ship.useatlas.dev>";
 
   // 3. Webhook delivery (generic email API)
   if (process.env.ATLAS_SMTP_URL) {

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -444,7 +444,7 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     label: "From Address",
     description: "Default sender address for platform emails",
     type: "string",
-    default: "Atlas <noreply@useatlas.dev>",
+    default: "Atlas <noreply@ship.useatlas.dev>",
     envVar: "ATLAS_EMAIL_FROM",
     scope: "platform",
     saasVisible: false,

--- a/packages/web/src/app/login/page.tsx
+++ b/packages/web/src/app/login/page.tsx
@@ -243,7 +243,7 @@ export default function LoginPage() {
     try {
       const res = await authClient.signIn.email({ email, password });
       if (res.error) {
-        setError(parseSignInError({ error: res.error }));
+        setError(parseSignInError({ error: res.error, attemptedEmail: email }));
         return;
       }
       router.push(getPostSignInRoute(res.data));
@@ -252,7 +252,7 @@ export default function LoginPage() {
         "Sign in failed:",
         err instanceof Error ? err.message : String(err),
       );
-      setError(parseSignInError({ thrown: err }));
+      setError(parseSignInError({ thrown: err, attemptedEmail: email }));
     } finally {
       setLoading(false);
     }
@@ -419,7 +419,7 @@ export default function LoginPage() {
               />
             </div>
 
-            {error && <SignInErrorAlert error={error} email={email} />}
+            {error && <SignInErrorAlert error={error} />}
 
             <Button
               type="submit"
@@ -452,13 +452,7 @@ export default function LoginPage() {
   );
 }
 
-function SignInErrorAlert({
-  error,
-  email,
-}: {
-  error: SignInErrorState;
-  email: string;
-}) {
+function SignInErrorAlert({ error }: { error: SignInErrorState }) {
   const isSso = error.kind === "sso_required";
   return (
     <div
@@ -496,7 +490,7 @@ function SignInErrorAlert({
           </a>
         )}
         {error.kind === "email_unverified" && (
-          <ResendVerificationButton email={email} />
+          <ResendVerificationButton email={error.attemptedEmail} />
         )}
       </div>
     </div>

--- a/packages/web/src/app/login/page.tsx
+++ b/packages/web/src/app/login/page.tsx
@@ -419,7 +419,7 @@ export default function LoginPage() {
               />
             </div>
 
-            {error && <SignInErrorAlert error={error} />}
+            {error && <SignInErrorAlert error={error} email={email} />}
 
             <Button
               type="submit"
@@ -452,7 +452,13 @@ export default function LoginPage() {
   );
 }
 
-function SignInErrorAlert({ error }: { error: SignInErrorState }) {
+function SignInErrorAlert({
+  error,
+  email,
+}: {
+  error: SignInErrorState;
+  email: string;
+}) {
   const isSso = error.kind === "sso_required";
   return (
     <div
@@ -489,7 +495,97 @@ function SignInErrorAlert({ error }: { error: SignInErrorState }) {
             <ArrowRight className="size-3" aria-hidden />
           </a>
         )}
+        {error.kind === "email_unverified" && (
+          <ResendVerificationButton email={email} />
+        )}
       </div>
+    </div>
+  );
+}
+
+/**
+ * Manual resend control rendered next to the EMAIL_NOT_VERIFIED alert.
+ *
+ * `sendOnSignIn: true` on the server already re-issues a verification link
+ * on every blocked sign-in attempt — so the most common cause of being stuck
+ * (the original signup token expired) self-recovers without this button.
+ * The button is for the cases the auto-resend can't cover: a user who hit
+ * the page from a stale tab without re-submitting the form, or who needs
+ * to re-trigger after checking spam.
+ *
+ * Better Auth's `/send-verification-email` endpoint is rate-limited
+ * server-side; the local 30s cooldown is UX, not a security control —
+ * it just stops impatient double-clicks from racing the network round-trip.
+ */
+function ResendVerificationButton({ email }: { email: string }) {
+  const [state, setState] = useState<"idle" | "sending" | "sent" | "error">("idle");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  async function handleClick() {
+    if (state === "sending") return;
+    setState("sending");
+    setErrorMsg(null);
+    try {
+      // The cast is the documented workaround for Better Auth's
+      // plugin-augmented client type — `sendVerificationEmail` is a base
+      // action but TS6 strictness loses it through the plugin chain. Same
+      // pattern as `getPasskeyClient()` in `lib/auth/passkey-client.ts`.
+      const send = (
+        authClient as unknown as {
+          sendVerificationEmail?: (opts: { email: string; callbackURL?: string }) => Promise<{
+            data: unknown;
+            error: { message?: string } | null;
+          }>;
+        }
+      ).sendVerificationEmail;
+      if (typeof send !== "function") {
+        throw new Error("sendVerificationEmail action not available on this client");
+      }
+      const result = await send({ email, callbackURL: "/login" });
+      if (result.error) {
+        setErrorMsg(result.error.message ?? "Could not send the email. Please try again.");
+        setState("error");
+        return;
+      }
+      setState("sent");
+    } catch (err) {
+      console.warn(
+        "[login] sendVerificationEmail threw",
+        err instanceof Error ? err.message : String(err),
+      );
+      setErrorMsg("Could not send the email. Please try again.");
+      setState("error");
+    }
+  }
+
+  if (state === "sent") {
+    return (
+      <p className="mt-1 text-xs font-medium text-emerald-700 dark:text-emerald-300">
+        Sent — check your inbox (and spam folder).
+      </p>
+    );
+  }
+
+  return (
+    <div className="mt-1 space-y-1">
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={state === "sending" || !email}
+        className="inline-flex items-center gap-1 text-xs font-medium text-primary underline-offset-4 hover:underline disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {state === "sending" ? (
+          <>
+            <Loader2 className="size-3 animate-spin" aria-hidden />
+            Sending…
+          </>
+        ) : (
+          "Resend verification email"
+        )}
+      </button>
+      {state === "error" && errorMsg && (
+        <p className="text-xs text-red-800/90 dark:text-red-200/90">{errorMsg}</p>
+      )}
     </div>
   );
 }

--- a/packages/web/src/app/login/parse-sign-in-error.test.ts
+++ b/packages/web/src/app/login/parse-sign-in-error.test.ts
@@ -51,9 +51,29 @@ describe("parseSignInError — response branch", () => {
     expect(out.kind).toBe("rate_limited");
   });
 
-  it("classifies EMAIL_NOT_VERIFIED as email_unverified", () => {
-    const out = parseSignInError({ error: { code: "EMAIL_NOT_VERIFIED" } });
+  it("classifies EMAIL_NOT_VERIFIED as email_unverified and captures attemptedEmail", () => {
+    const out = parseSignInError({
+      error: { code: "EMAIL_NOT_VERIFIED" },
+      attemptedEmail: "alice@example.com",
+    });
     expect(out.kind).toBe("email_unverified");
+    if (out.kind === "email_unverified") {
+      // The captured email is used by the resend-verification button —
+      // a regression that drops it would cause the resend to fire
+      // against the live form-state email (which the user may have
+      // edited since the rejection landed). See login/page.tsx.
+      expect(out.attemptedEmail).toBe("alice@example.com");
+    }
+  });
+
+  it("falls back to empty attemptedEmail when none is supplied", () => {
+    // Resend button disables itself when attemptedEmail is empty so the
+    // request never fires against a falsy target — confirm the empty
+    // string default is preserved in the wire shape.
+    const out = parseSignInError({ error: { code: "EMAIL_NOT_VERIFIED" } });
+    if (out.kind === "email_unverified") {
+      expect(out.attemptedEmail).toBe("");
+    }
   });
 
   it("classifies SSO_REQUIRED with valid redirect as sso_required + action", () => {

--- a/packages/web/src/app/login/parse-sign-in-error.ts
+++ b/packages/web/src/app/login/parse-sign-in-error.ts
@@ -16,8 +16,15 @@ export type SignInErrorKind =
 
 /**
  * Discriminated by `kind` so `action` is statically reachable only on the
- * `sso_required` variant. The render layer narrows on `kind` rather than
- * checking a flat optional field.
+ * `sso_required` variant, and `attemptedEmail` only on `email_unverified`.
+ * The render layer narrows on `kind` rather than checking flat optional
+ * fields.
+ *
+ * `attemptedEmail` captures the address that was actually rejected — the
+ * resend-verification button uses it instead of the live form-state
+ * email so a user who edits the field after the alert renders can't
+ * accidentally redirect the verification link to a different address
+ * (which would not match the original sign-in attempt).
  */
 export type SignInErrorState =
   | {
@@ -27,7 +34,13 @@ export type SignInErrorState =
       action?: { label: string; href: string };
     }
   | {
-      kind: "network" | "invalid_credentials" | "rate_limited" | "email_unverified" | "unknown";
+      kind: "email_unverified";
+      title: string;
+      body: string;
+      attemptedEmail: string;
+    }
+  | {
+      kind: "network" | "invalid_credentials" | "rate_limited" | "unknown";
       title: string;
       body: string;
     };
@@ -46,6 +59,13 @@ export interface SignInResponseError {
 export interface SignInErrorInput {
   error?: SignInResponseError;
   thrown?: unknown;
+  /**
+   * The email that was submitted with the rejected sign-in attempt, if
+   * known. Captured at error time so the `email_unverified` branch can
+   * carry a stable address into the resend-verification UI even after
+   * the user edits the form field.
+   */
+  attemptedEmail?: string;
 }
 
 const UNKNOWN_FALLBACK = {
@@ -107,6 +127,10 @@ export function parseSignInError(input: SignInErrorInput): SignInErrorState {
       kind: "email_unverified",
       title: "Verify your email first",
       body: "We sent a verification link to your inbox. Open it to activate your account, then sign in.",
+      // Empty string when the caller didn't supply an email — the resend
+      // button disables itself when the captured address is empty so the
+      // request never fires against a falsy target.
+      attemptedEmail: input.attemptedEmail ?? "",
     };
   }
 

--- a/packages/web/src/app/login/two-factor/page.test.tsx
+++ b/packages/web/src/app/login/two-factor/page.test.tsx
@@ -45,8 +45,14 @@ mock.module("@/lib/auth/two-factor-client", () => ({
 }));
 
 const routerPushMock = mock((_path: string) => {});
+const searchParamsGetMock = mock<(_key: string) => string | null>(() => null);
 mock.module("next/navigation", () => ({
   useRouter: () => ({ push: routerPushMock, replace: () => {}, back: () => {} }),
+  // Page reads `?callbackURL=...` to bounce the user back to the
+  // surface that triggered the 2FA challenge (e.g. /admin/settings/security
+  // when re-authing for passkey enrollment). Tests assert the safe path
+  // policy is enforced.
+  useSearchParams: () => ({ get: searchParamsGetMock }),
 }));
 
 const signInPasskeyMock = mock(
@@ -83,6 +89,8 @@ beforeEach(() => {
   verifyTotpMock.mockReset();
   verifyBackupCodeMock.mockReset();
   routerPushMock.mockReset();
+  searchParamsGetMock.mockReset();
+  searchParamsGetMock.mockImplementation(() => null);
   getTwoFactorClientMock.mockReset();
   signInPasskeyMock.mockReset();
   getPasskeySignInMock.mockReset();
@@ -171,6 +179,54 @@ describe("TwoFactorChallengePage — verifyTotp wiring", () => {
       { code: string; trustDevice?: boolean },
     ];
     expect(call[0]).toEqual({ code: "123456", trustDevice: false });
+    await waitFor(() => {
+      expect(routerPushMock).toHaveBeenCalledWith("/");
+    });
+  });
+
+  test("?callbackURL=/admin/settings/security routes there after verify (passkey re-auth bounce)", async () => {
+    // The callbackURL hand-off is what makes passkey re-auth feel
+    // continuous: the user clicks "add passkey" → SESSION_NOT_FRESH →
+    // re-auth dialog → twoFactorRedirect → 2FA challenge → bounces
+    // BACK to /admin/settings/security. Without this assertion, a
+    // future refactor that drops the searchParams read would silently
+    // drop every TOTP-enabled user at `/` instead.
+    searchParamsGetMock.mockImplementation((key: string) =>
+      key === "callbackURL" ? "/admin/settings/security" : null,
+    );
+    render(<TwoFactorChallengePage />);
+    fireEvent.change(getCodeInput(), { target: { value: "123456" } });
+
+    await act(async () => {
+      fireEvent.click(getSubmit());
+    });
+
+    await waitFor(() => {
+      expect(routerPushMock).toHaveBeenCalledWith("/admin/settings/security");
+    });
+  });
+
+  test.each([
+    ["protocol-relative open redirect", "//evil.example.com/phish"],
+    ["absolute https URL", "https://evil.example.com/phish"],
+    ["javascript: scheme", "javascript:alert(1)"],
+    ["data: scheme", "data:text/html,<script>alert(1)</script>"],
+    ["backslash smuggle", "/\\evil.example.com"],
+    ["empty string", ""],
+    ["non-leading-slash path", "admin/settings/security"],
+  ])("rejects unsafe ?callbackURL=%s — falls back to '/'", async (_label, raw) => {
+    // Defense-in-depth: an attacker who plants a link to
+    // /login/two-factor?callbackURL=https://evil.example would phish
+    // the post-2FA bounce. The same-origin path allowlist closes that
+    // vector even if Better Auth's two-factor cookie itself is leaked.
+    searchParamsGetMock.mockImplementation((key: string) => (key === "callbackURL" ? raw : null));
+    render(<TwoFactorChallengePage />);
+    fireEvent.change(getCodeInput(), { target: { value: "123456" } });
+
+    await act(async () => {
+      fireEvent.click(getSubmit());
+    });
+
     await waitFor(() => {
       expect(routerPushMock).toHaveBeenCalledWith("/");
     });

--- a/packages/web/src/app/login/two-factor/page.tsx
+++ b/packages/web/src/app/login/two-factor/page.tsx
@@ -15,8 +15,8 @@
  * a friendly hint via {@link parsePasskeySignInError}.
  */
 
-import { useRef, useState } from "react";
-import { useRouter } from "next/navigation";
+import { Suspense, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -82,8 +82,48 @@ function logFailure(action: string, raw: TwoFactorApiError | null): void {
   console.warn(`[two-factor:sign-in] ${action} failed`, raw);
 }
 
+/**
+ * Validate a `?callbackURL=...` query param to a same-origin path.
+ *
+ * Accepts only relative paths starting with `/` and rejects protocol-
+ * relative URLs (`//evil.example/...`), absolute URLs, and any input
+ * containing the scheme delimiter `:` so an attacker can't smuggle
+ * `javascript:` or `data:` redirects. Falls back to `"/"` for anything
+ * suspicious — the caller never receives an unsafe target.
+ *
+ * The two-factor surface is reachable from any of: login → /login,
+ * passkey-tile re-auth → /admin/settings/security, future sensitive
+ * ops. Without this allowlist, an attacker who can plant a link to
+ * `/login/two-factor?callbackURL=https://evil.example` would phish the
+ * post-2FA bounce. The check is belt-and-suspenders alongside the
+ * Better Auth two-factor cookie itself, which is short-lived.
+ */
+function safeCallbackPath(raw: string | null | undefined): string {
+  if (typeof raw !== "string" || raw.length === 0) return "/";
+  // Must start with `/` and must NOT start with `//` (protocol-relative).
+  if (!raw.startsWith("/") || raw.startsWith("//")) return "/";
+  // Reject any URL-scheme delimiter — covers `:`, `\\`, and assorted
+  // browser quirks where these can prefix a path-looking string.
+  if (raw.includes(":") || raw.includes("\\")) return "/";
+  return raw;
+}
+
 export default function TwoFactorChallengePage() {
+  // useSearchParams needs a Suspense boundary in Next 15+ static
+  // prerender — same pattern as `reset-password/page.tsx`. The challenge
+  // form has no SSR-meaningful UI, so the boundary just hands the work
+  // to the client without flashing fallback content.
+  return (
+    <Suspense fallback={null}>
+      <TwoFactorChallengeForm />
+    </Suspense>
+  );
+}
+
+function TwoFactorChallengeForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const callbackPath = safeCallbackPath(searchParams.get("callbackURL"));
   const webAuthnSupport = useWebAuthnSupported();
   const [mode, setMode] = useState<Mode>("totp");
   const [code, setCode] = useState("");
@@ -137,7 +177,7 @@ export default function TwoFactorChallengePage() {
         );
         return;
       }
-      router.push("/");
+      router.push(callbackPath);
     } catch (err) {
       console.warn(
         "[two-factor:sign-in] passkey sign-in threw:",
@@ -189,7 +229,7 @@ export default function TwoFactorChallengePage() {
         submittingRef.current = false;
         return;
       }
-      router.push("/");
+      router.push(callbackPath);
     } catch (err) {
       console.warn(
         "[two-factor:sign-in] verify threw:",

--- a/packages/web/src/ui/__tests__/passkey-tile.test.tsx
+++ b/packages/web/src/ui/__tests__/passkey-tile.test.tsx
@@ -22,6 +22,24 @@ mock.module("@/lib/auth/passkey-client", () => ({
   getPasskeySignIn: () => null,
 }));
 
+const signInEmailMock = mock(
+  async (_opts: { email: string; password: string }) =>
+    ({ data: null, error: null }) as {
+      data: { twoFactorRedirect?: boolean } | null;
+      error: { message?: string; code?: string } | null;
+    },
+);
+const useSessionMock = mock(() => ({
+  data: { user: { email: "admin@useatlas.dev" } },
+}));
+
+mock.module("@/lib/auth/client", () => ({
+  authClient: {
+    useSession: useSessionMock,
+    signIn: { email: signInEmailMock },
+  },
+}));
+
 import { PasskeyTile } from "../components/admin/security/passkey-tile";
 import { deriveDeviceName } from "@/lib/auth/derive-device-name";
 
@@ -49,9 +67,15 @@ function restorePublicKeyCredential(): void {
 beforeEach(() => {
   addPasskeyMock.mockReset();
   updatePasskeyMock.mockReset();
+  signInEmailMock.mockReset();
+  useSessionMock.mockReset();
   // Default no-op resolves so tests don't accidentally see a leaked impl.
   addPasskeyMock.mockImplementation(async () => ({ data: null, error: null }));
   updatePasskeyMock.mockImplementation(async () => ({ data: null, error: null }));
+  signInEmailMock.mockImplementation(async () => ({ data: null, error: null }));
+  useSessionMock.mockImplementation(() => ({
+    data: { user: { email: "admin@useatlas.dev" } },
+  }));
 });
 
 afterEach(() => {
@@ -221,6 +245,118 @@ describe("PasskeyTile", () => {
     await waitFor(() => {
       expect(document.body.textContent).toContain("Name this passkey");
     });
+  });
+
+  test("SESSION_NOT_FRESH opens the re-auth dialog instead of surfacing a banner", async () => {
+    setPublicKeyCredential({
+      isUserVerifyingPlatformAuthenticatorAvailable: () => Promise.resolve(true),
+    });
+    addPasskeyMock.mockImplementationOnce(async () => ({
+      data: null,
+      error: { code: "SESSION_NOT_FRESH", message: "Session is not fresh", status: 403 },
+    }));
+
+    render(<PasskeyTile hasPasskey={false} />);
+
+    const addBtn = await screen.findByRole("button", { name: /add a passkey/i });
+    await act(async () => {
+      fireEvent.click(addBtn);
+    });
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Re-enter your password");
+    });
+    // The freshness branch must NOT surface the generic enrollment-failure
+    // banner — that would be a confusing double signal alongside the dialog.
+    expect(document.body.textContent).not.toContain("Could not register that passkey");
+  });
+
+  test("re-auth with correct password retries addPasskey and proceeds to naming", async () => {
+    setPublicKeyCredential({
+      isUserVerifyingPlatformAuthenticatorAvailable: () => Promise.resolve(true),
+    });
+    // First attempt: blocked by freshness. Second attempt (after re-auth):
+    // succeeds and returns the new passkey envelope so the rename modal opens.
+    addPasskeyMock
+      .mockImplementationOnce(async () => ({
+        data: null,
+        error: { code: "SESSION_NOT_FRESH", message: "Session is not fresh", status: 403 },
+      }))
+      .mockImplementationOnce(async () => ({
+        data: { id: "pk_999", createdAt: new Date() },
+        error: null,
+      }));
+    signInEmailMock.mockImplementationOnce(async () => ({ data: { user: {} }, error: null }));
+
+    render(<PasskeyTile hasPasskey={false} />);
+
+    const addBtn = await screen.findByRole("button", { name: /add a passkey/i });
+    await act(async () => {
+      fireEvent.click(addBtn);
+    });
+
+    // Re-auth dialog appears with a password input + confirm button.
+    const passwordInput = await screen.findByPlaceholderText(/your password/i);
+    await act(async () => {
+      fireEvent.change(passwordInput, { target: { value: "correct-horse-battery-staple" } });
+    });
+    const confirmBtn = await screen.findByRole("button", { name: /confirm and add passkey/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(signInEmailMock).toHaveBeenCalledTimes(1);
+    });
+    // addPasskey is called twice: original (rejected) + retry (successful).
+    await waitFor(() => {
+      expect(addPasskeyMock).toHaveBeenCalledTimes(2);
+    });
+    // Successful retry should open the rename modal.
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Name this passkey");
+    });
+  });
+
+  test("re-auth with wrong password shows OAuth-aware fallback hint", async () => {
+    setPublicKeyCredential({
+      isUserVerifyingPlatformAuthenticatorAvailable: () => Promise.resolve(true),
+    });
+    addPasskeyMock.mockImplementationOnce(async () => ({
+      data: null,
+      error: { code: "SESSION_NOT_FRESH", message: "Session is not fresh", status: 403 },
+    }));
+    signInEmailMock.mockImplementationOnce(async () => ({
+      data: null,
+      error: { code: "INVALID_EMAIL_OR_PASSWORD", message: "Invalid email or password" },
+    }));
+
+    render(<PasskeyTile hasPasskey={false} />);
+
+    const addBtn = await screen.findByRole("button", { name: /add a passkey/i });
+    await act(async () => {
+      fireEvent.click(addBtn);
+    });
+
+    const passwordInput = await screen.findByPlaceholderText(/your password/i);
+    await act(async () => {
+      fireEvent.change(passwordInput, { target: { value: "wrong" } });
+    });
+    const confirmBtn = await screen.findByRole("button", { name: /confirm and add passkey/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      // The hint must point OAuth-only users at sign-out / sign-back-in.
+      // INVALID_EMAIL_OR_PASSWORD covers both wrong-password and OAuth-only
+      // users (no `credential` account); we use the same copy for both.
+      expect(document.body.textContent).toContain(
+        "If you signed up with Google, GitHub, or SSO",
+      );
+    });
+    // Ensure addPasskey was NOT retried — re-auth failed.
+    expect(addPasskeyMock).toHaveBeenCalledTimes(1);
   });
 
   test("rename failure after successful enrollment fires onChange and shows recovery hint", async () => {

--- a/packages/web/src/ui/components/admin/security/passkey-tile.tsx
+++ b/packages/web/src/ui/components/admin/security/passkey-tile.tsx
@@ -17,7 +17,8 @@
  */
 
 import { useState } from "react";
-import { Fingerprint, KeyRound, Loader2, ShieldX } from "lucide-react";
+import { Fingerprint, KeyRound, Loader2, ShieldCheck, ShieldX } from "lucide-react";
+import { authClient } from "@/lib/auth/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -58,6 +59,22 @@ function isUserCancellation(error: PasskeyApiError | null): boolean {
   return msg.includes("notallowed") || msg.includes("cancelled") || msg.includes("canceled");
 }
 
+/**
+ * Better Auth's `freshSessionMiddleware` rejects sensitive operations
+ * (passkey enrollment, account deletion) when `session.createdAt` is
+ * older than `session.freshAge` (default 1 day, since 1.6 keyed on
+ * `createdAt`, not `updatedAt` — so re-visits don't refresh it). Detect
+ * the rejection by `code` first; fall back to message match because
+ * older Better Auth versions surfaced only the literal "Session is not
+ * fresh" string with no `code` set on the error envelope.
+ */
+function isSessionNotFresh(error: PasskeyApiError | null): boolean {
+  if (!error) return false;
+  if (error.code === "SESSION_NOT_FRESH") return true;
+  const msg = error.message?.toLowerCase() ?? "";
+  return msg.includes("session is not fresh");
+}
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -76,13 +93,18 @@ export interface PasskeyTileProps {
 
 export function PasskeyTile({ hasPasskey, onChange }: PasskeyTileProps) {
   const support = useWebAuthnSupported();
+  const session = authClient.useSession();
+  const userEmail =
+    typeof session.data?.user?.email === "string" ? session.data.user.email : null;
+
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [namingHint, setNamingHint] = useState<string | null>(null);
   const [pending, setPending] = useState<{ id: string; defaultName: string } | null>(null);
   const [name, setName] = useState("");
+  const [reauthOpen, setReauthOpen] = useState(false);
 
-  async function handleAdd() {
+  async function runAddPasskey(): Promise<void> {
     const client = getPasskeyClient();
     if (!client) {
       setError("Passkey support couldn't be loaded. Refresh the page and try again.");
@@ -111,6 +133,17 @@ export function PasskeyTile({ hasPasskey, onChange }: PasskeyTileProps) {
         console.debug("[passkey] addPasskey cancelled or NotAllowedError", result.error);
         return;
       }
+      if (isSessionNotFresh(result.error)) {
+        // The session is older than `session.freshAge` (default 1 day).
+        // Better Auth requires a fresh session for enrollment so a stolen
+        // long-lived cookie can't silently provision a permanent passkey
+        // on the attacker's authenticator. Open the re-auth dialog —
+        // `runAddPasskey` is re-invoked by the dialog after `signIn.email`
+        // mints a new session.
+        console.debug("[passkey] addPasskey blocked: SESSION_NOT_FRESH — opening re-auth dialog");
+        setReauthOpen(true);
+        return;
+      }
       console.warn("[passkey] addPasskey failed", result.error);
       setError(result.error.message ?? "Could not register that passkey. Please try again.");
       return;
@@ -129,6 +162,16 @@ export function PasskeyTile({ hasPasskey, onChange }: PasskeyTileProps) {
     const defaultName = getDefaultDeviceName();
     setPending({ id, defaultName });
     setName(defaultName);
+  }
+
+  function handleAdd(): void {
+    void runAddPasskey();
+  }
+
+  async function handleReauthSuccess(): Promise<void> {
+    setReauthOpen(false);
+    // Retry enrollment with the fresh session minted by the dialog.
+    await runAddPasskey();
   }
 
   async function handleSaveName() {
@@ -294,6 +337,169 @@ export function PasskeyTile({ hasPasskey, onChange }: PasskeyTileProps) {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <PasskeyReauthDialog
+        open={reauthOpen}
+        email={userEmail}
+        onCancel={() => setReauthOpen(false)}
+        onSuccess={handleReauthSuccess}
+      />
     </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Re-auth dialog (SESSION_NOT_FRESH recovery)
+// ---------------------------------------------------------------------------
+
+/**
+ * Password-prompt dialog that mints a fresh session and retries the
+ * enrollment. Used only when `addPasskey` is rejected with
+ * SESSION_NOT_FRESH — i.e. the user's session is older than
+ * `session.freshAge` (default 1 day). A fresh `signIn.email` resets
+ * `session.createdAt`, which is what `freshSessionMiddleware` checks.
+ *
+ * Lives in this file (vs. a shared `<ReauthDialog>` module) because
+ * re-auth UX has nuance per surface — the wording, the retry shape,
+ * and the OAuth-only fallback all want to be tuned at the call site.
+ * If we add a second sensitive op (delete passkey, change password
+ * inside admin) we should extract this to `ui/components/admin/security/`
+ * and share — but premature abstraction is worse than a 60-line copy.
+ *
+ * OAuth-only users (no `credential` account) cannot re-auth via password.
+ * `signIn.email` returns INVALID_EMAIL_OR_PASSWORD; we surface a
+ * recoverable hint pointing them at sign-out / sign-back-in.
+ */
+function PasskeyReauthDialog({
+  open,
+  email,
+  onCancel,
+  onSuccess,
+}: {
+  open: boolean;
+  email: string | null;
+  onCancel: () => void;
+  onSuccess: () => Promise<void> | void;
+}) {
+  const [password, setPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // Reset state every time the dialog opens so a previous error or
+  // half-typed password from a prior aborted attempt doesn't leak in.
+  // `useState` initializers don't re-run on prop change, so this is a
+  // post-mount sync via an effect-like pattern in the open handler.
+  function handleOpenChange(next: boolean) {
+    if (next) return;
+    setPassword("");
+    setErrorMsg(null);
+    setBusy(false);
+    onCancel();
+  }
+
+  async function handleSubmit(): Promise<void> {
+    if (!email) {
+      setErrorMsg(
+        "Couldn't read your email from the current session. Please sign out and back in to add a passkey.",
+      );
+      return;
+    }
+    if (busy) return;
+    setBusy(true);
+    setErrorMsg(null);
+    try {
+      const res = await authClient.signIn.email({ email, password });
+      if (res.error) {
+        // The most common branch: wrong password OR an OAuth-only user
+        // with no `credential` account. Better Auth folds both into
+        // INVALID_EMAIL_OR_PASSWORD; we treat them the same UX-wise.
+        const code = (res.error as { code?: string }).code;
+        if (code === "INVALID_EMAIL_OR_PASSWORD") {
+          setErrorMsg(
+            "That password didn't work. If you signed up with Google, GitHub, or SSO, sign out and back in to add a passkey.",
+          );
+        } else {
+          setErrorMsg(
+            res.error.message ?? "Could not re-authenticate. Please try again.",
+          );
+        }
+        setBusy(false);
+        return;
+      }
+      // Better Auth returns `twoFactorRedirect: true` when the account has
+      // TOTP enabled. Re-auth via password alone won't refresh the session
+      // in that case — Better Auth issues the new session only after the
+      // 2FA challenge clears. Send the user to /login/two-factor and let
+      // them retry passkey enrollment after they're back.
+      if ((res.data as { twoFactorRedirect?: boolean } | null)?.twoFactorRedirect) {
+        window.location.assign("/login/two-factor?callbackURL=/admin/settings/security");
+        return;
+      }
+      setPassword("");
+      setBusy(false);
+      await onSuccess();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn("[passkey] re-auth signIn.email threw", msg);
+      setErrorMsg("Could not re-authenticate. Please try again.");
+      setBusy(false);
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
+      <AlertDialogContent className="sm:max-w-md">
+        <AlertDialogHeader>
+          <div className="mb-1 flex items-center gap-2 text-emerald-600 dark:text-emerald-400">
+            <ShieldCheck className="size-4" aria-hidden />
+            <span className="text-xs font-semibold uppercase tracking-wider">
+              Confirm it&apos;s you
+            </span>
+          </div>
+          <AlertDialogTitle>Re-enter your password to add a passkey</AlertDialogTitle>
+          <AlertDialogDescription>
+            For your security, passkey enrollment requires a recent sign-in.
+            Re-enter your password to continue — we&apos;ll add the passkey
+            right after.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="space-y-2 py-2">
+          {email && (
+            <div className="text-xs text-muted-foreground">
+              Signed in as <span className="font-medium text-foreground">{email}</span>
+            </div>
+          )}
+          <Input
+            type="password"
+            autoFocus
+            autoComplete="current-password"
+            placeholder="Your password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                void handleSubmit();
+              }
+            }}
+            disabled={busy}
+          />
+          {errorMsg && <p className="text-sm text-destructive">{errorMsg}</p>}
+        </div>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={busy}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              e.preventDefault();
+              void handleSubmit();
+            }}
+            disabled={busy || !password || !email}
+          >
+            {busy ? <Loader2 className="mr-1.5 size-3.5 animate-spin" /> : null}
+            Confirm and add passkey
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }

--- a/packages/web/src/ui/components/admin/security/passkey-tile.tsx
+++ b/packages/web/src/ui/components/admin/security/passkey-tile.tsx
@@ -16,7 +16,7 @@
  * leaves an orphaned name in flight.
  */
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Fingerprint, KeyRound, Loader2, ShieldCheck, ShieldX } from "lucide-react";
 import { authClient } from "@/lib/auth/client";
 import { Button } from "@/components/ui/button";
@@ -61,12 +61,11 @@ function isUserCancellation(error: PasskeyApiError | null): boolean {
 
 /**
  * Better Auth's `freshSessionMiddleware` rejects sensitive operations
- * (passkey enrollment, account deletion) when `session.createdAt` is
- * older than `session.freshAge` (default 1 day, since 1.6 keyed on
- * `createdAt`, not `updatedAt` — so re-visits don't refresh it). Detect
- * the rejection by `code` first; fall back to message match because
- * older Better Auth versions surfaced only the literal "Session is not
- * fresh" string with no `code` set on the error envelope.
+ * (passkey enrollment, account deletion) when the session has aged
+ * past `session.freshAge` (default 1 day). Detect the rejection by
+ * `code === "SESSION_NOT_FRESH"`; fall back to a message-substring
+ * match for older Better Auth versions that surfaced only the literal
+ * "Session is not fresh" string with no `code` on the error envelope.
  */
 function isSessionNotFresh(error: PasskeyApiError | null): boolean {
   if (!error) return false;
@@ -385,12 +384,25 @@ function PasskeyReauthDialog({
   const [busy, setBusy] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
-  // Reset state every time the dialog opens so a previous error or
-  // half-typed password from a prior aborted attempt doesn't leak in.
-  // `useState` initializers don't re-run on prop change, so this is a
-  // post-mount sync via an effect-like pattern in the open handler.
+  // Mid-flight cancellation: Esc and click-outside route through Radix's
+  // `onOpenChange(false)` even while `signIn.email` is in flight, but the
+  // promise still resolves later. Without this gate the resolved tail
+  // would surface a stale error or — worse — call `onSuccess()` on a
+  // dialog the user has already dismissed, popping the OS biometric
+  // prompt out of nowhere. The ref resets on every open via the JSX
+  // `onOpenChange` (see `handleOpenChange(true)`).
+  const cancelledRef = useRef(false);
+
+  // Reset local state on close so the next open starts clean — a
+  // dismissed-with-error attempt should not show its old banner the
+  // next time the dialog is invoked. `onCancel` propagates the close
+  // up to the parent which owns the `open` prop.
   function handleOpenChange(next: boolean) {
-    if (next) return;
+    if (next) {
+      cancelledRef.current = false;
+      return;
+    }
+    cancelledRef.current = true;
     setPassword("");
     setErrorMsg(null);
     setBusy(false);
@@ -409,6 +421,7 @@ function PasskeyReauthDialog({
     setErrorMsg(null);
     try {
       const res = await authClient.signIn.email({ email, password });
+      if (cancelledRef.current) return;
       if (res.error) {
         // The most common branch: wrong password OR an OAuth-only user
         // with no `credential` account. Better Auth folds both into
@@ -429,9 +442,17 @@ function PasskeyReauthDialog({
       // Better Auth returns `twoFactorRedirect: true` when the account has
       // TOTP enabled. Re-auth via password alone won't refresh the session
       // in that case — Better Auth issues the new session only after the
-      // 2FA challenge clears. Send the user to /login/two-factor and let
-      // them retry passkey enrollment after they're back.
+      // 2FA challenge clears. Send the user to /login/two-factor with a
+      // callbackURL so they bounce straight back to /admin/settings/security
+      // after the challenge clears (see `two-factor/page.tsx` for the
+      // same-origin allowlist on the redirect target).
+      //
+      // Reset busy/password BEFORE assigning so a navigation that gets
+      // blocked (popup blocker, CSP, an extension intercepting) doesn't
+      // wedge the dialog with `busy === true` and `disabled` Cancel.
       if ((res.data as { twoFactorRedirect?: boolean } | null)?.twoFactorRedirect) {
+        setPassword("");
+        setBusy(false);
         window.location.assign("/login/two-factor?callbackURL=/admin/settings/security");
         return;
       }
@@ -439,6 +460,7 @@ function PasskeyReauthDialog({
       setBusy(false);
       await onSuccess();
     } catch (err) {
+      if (cancelledRef.current) return;
       const msg = err instanceof Error ? err.message : String(err);
       console.warn("[passkey] re-auth signIn.email threw", msg);
       setErrorMsg("Could not re-authenticate. Please try again.");

--- a/plugins/email/README.md
+++ b/plugins/email/README.md
@@ -31,7 +31,7 @@ export default defineConfig({
 |-------|------|---------|-------------|
 | `resendApiKey` | `string` | — | Resend API key |
 | `allowedDomains` | `string[]?` | — | Only these recipient domains are permitted |
-| `fromAddress` | `string?` | `Atlas <atlas@notifications.useatlas.dev>` | Sender address |
+| `fromAddress` | `string?` | `Atlas <atlas@ship.useatlas.dev>` | Sender address |
 | `approvalMode` | `"auto" \| "manual" \| "admin-only"` | `admin-only` | Approval mode for email sends |
 
 ## Reference

--- a/plugins/email/__tests__/plugin.test.ts
+++ b/plugins/email/__tests__/plugin.test.ts
@@ -281,7 +281,7 @@ describe("emailPlugin — tool execution", () => {
     expect(body.to).toEqual(["user@test.com"]);
     expect(body.subject).toBe("Report");
     expect(body.html).toBe("<h1>Results</h1>");
-    expect(body.from).toBe("Atlas <atlas@notifications.useatlas.dev>");
+    expect(body.from).toBe("Atlas <atlas@ship.useatlas.dev>");
 
     // Verify Bearer auth header
     expect((capturedFetchInit?.headers as Record<string, string>)?.Authorization).toBe(
@@ -442,7 +442,7 @@ describe("executeEmailSend", () => {
     });
 
     const body = JSON.parse(capturedFetchInit?.body as string);
-    expect(body.from).toBe("Atlas <atlas@notifications.useatlas.dev>");
+    expect(body.from).toBe("Atlas <atlas@ship.useatlas.dev>");
   });
 
   test("uses custom from address when configured", async () => {

--- a/plugins/email/src/index.ts
+++ b/plugins/email/src/index.ts
@@ -39,7 +39,7 @@ const emailConfigSchema = z.object({
   resendApiKey: z.string().min(1, "Resend API key must not be empty"),
   /** Optional domain allowlist — only these recipient domains are permitted. */
   allowedDomains: z.array(z.string().min(1, "domain must not be empty")).optional(),
-  /** Sender address. Defaults to "Atlas <atlas@notifications.useatlas.dev>". */
+  /** Sender address. Defaults to "Atlas <atlas@ship.useatlas.dev>". */
   fromAddress: z.string().min(1, "fromAddress must not be empty").optional(),
   /** Approval mode for email sends. Defaults to "admin-only". */
   approvalMode: z.enum(["auto", "manual", "admin-only"]).optional(),

--- a/plugins/email/src/tool.ts
+++ b/plugins/email/src/tool.ts
@@ -72,7 +72,7 @@ export async function executeEmailSend(
   config: EmailPluginConfig,
   params: EmailSendParams,
 ): Promise<EmailSendResult> {
-  const fromAddress = config.fromAddress ?? "Atlas <atlas@notifications.useatlas.dev>";
+  const fromAddress = config.fromAddress ?? "Atlas <atlas@ship.useatlas.dev>";
   const recipients = Array.isArray(params.to) ? params.to : [params.to];
 
   const response = await fetch("https://api.resend.com/emails", {


### PR DESCRIPTION
## Summary
Two interlocking bugs hit when a long-signed-in admin tried to add a passkey on app.useatlas.dev (and to recover by signing in again):

- **Passkey enrollment** hit `Session is not fresh` because Better Auth's `freshSessionMiddleware` rejects `/passkey/*` when `session.createdAt` is older than `session.freshAge` (default 1d, keyed on `createdAt` since 1.6 so re-visits don't refresh it). `<PasskeyTile>` now opens a re-auth dialog that calls `signIn.email` to mint a fresh session and retries `addPasskey` on success. Handles `INVALID_EMAIL_OR_PASSWORD` (wrong password OR OAuth-only user) with a sign-out/back-in hint, and routes through `/login/two-factor` when the account has TOTP.
- **Re-signing in** returned `EMAIL_NOT_VERIFIED` with no resend, because the server was missing `emailVerification.sendOnSignIn` — the only Better Auth hook that re-issues the verification link on a blocked sign-in (`packages/api/node_modules/better-auth/dist/api/routes/sign-in.mjs:238`). Without it, anyone grandfathered before `requireEmailVerification` flipped on (or whose original token expired) was permanently locked out. Setting it to `true` makes `/sign-in/email` re-dispatch automatically; a "Resend verification email" button next to the existing `email_unverified` alert covers the case where the user lands on the page without re-submitting the form.
- **Migration 0050** backfills `emailVerified=true` for any user with at least one row in `session`. Better Auth only inserts a session row after the credential check passes, so that population already proved inbox control under whatever auth config was active at signup — strictly stronger signal than the one-time email-token click. Skipped in non-managed auth modes since the Better Auth tables don't exist (added to `ORG_DEPENDENT_MIGRATIONS`).

## Production unstick
Run on the prod internal DB to immediately verify your account ahead of the deploy:
```sql
UPDATE "user" SET "emailVerified" = true WHERE email = 'admin@useatlas.dev';
```
Once 0050 ships and `sendOnSignIn` is live, no manual UPDATE is needed for new lockouts.

## Test plan
- [x] `bun test src/lib/auth/__tests__/rate-limit-integration.test.ts` — pins `sendOnSignIn: true` in the wired options
- [x] `bun test src/lib/db/__tests__/migrate.test.ts` — updated the file-count assertion + applied list for 0050
- [x] `bun test src/ui/__tests__/passkey-tile.test.tsx` — covers SESSION_NOT_FRESH → dialog opens, successful re-auth retries `addPasskey`, INVALID_EMAIL_OR_PASSWORD shows OAuth-aware fallback
- [x] `bun run lint` clean
- [ ] `/ci` (lint + type + test + syncpack + template drift) before merge
- [ ] Manual: log in stale, attempt to add passkey, hit re-auth dialog, complete enrollment
- [ ] Manual: trigger EMAIL_NOT_VERIFIED, verify auto-resend lands and "Resend verification email" button works