### PR TITLE
fix(docs,deploy): #2103 — propagate GITHUB_TOKEN to docs build + add canary

### DIFF
--- a/deploy/docs/Dockerfile
+++ b/deploy/docs/Dockerfile
@@ -3,13 +3,25 @@ FROM oven/bun:1.3.11@sha256:0733e50325078969732ebe3b15ce4c4be5082f18c4ac1a0f0ca4
 # --- Build ---
 FROM base AS builder
 WORKDIR /app
+
+# GITHUB_TOKEN powers the "Last updated on …" timestamp on every docs page
+# via fumadocs' getGithubLastEdit (apps/docs/src/app/(docs)/[[...slug]]/page.tsx).
+# Without it the build hits unauthenticated GitHub API, rate-limits after ~60
+# pages, and the silent catch swallows every failure (issue #2103). Railway
+# auto-passes the service variable as a build arg only when ARG declares it.
+# Self-hosted operators can omit this — the canary below skips when unset.
+ARG GITHUB_TOKEN
+ENV GITHUB_TOKEN=$GITHUB_TOKEN
+
 COPY apps/docs/ ./
 COPY bun.lock* ./
 # globals.css imports ../../brand.css (resolves to project root via symlink in
 # the monorepo). In Docker the symlink target doesn't exist, so copy the real file.
 COPY brand.css ./brand.css
+COPY scripts/check-docs-canary.sh /usr/local/bin/check-docs-canary.sh
+RUN chmod +x /usr/local/bin/check-docs-canary.sh
 RUN bun install
-RUN bun run build
+RUN bun run build && /usr/local/bin/check-docs-canary.sh
 
 # --- Runtime ---
 FROM base AS runner

--- a/deploy/docs/README.md
+++ b/deploy/docs/README.md
@@ -1,0 +1,61 @@
+# `deploy/docs` — Railway docs service
+
+Production deploy config for `docs.useatlas.dev` (Railway service `docs`,
+project `satisfied-creation`).
+
+## `GITHUB_TOKEN` (required for SaaS, optional for self-hosted)
+
+Powers the **Last updated on …** line at the bottom of every docs page via
+Fumadocs' `getGithubLastEdit` (called from
+`apps/docs/src/app/(docs)/[[...slug]]/page.tsx`). Without it, the build hits
+unauthenticated GitHub API, rate-limits after ~60 pages, and the silent
+catch in `getLastUpdate` swallows every error — timestamps disappear from
+the production site with no operator signal. That's the failure mode #2103
+captures.
+
+### How it's wired
+
+1. **Railway service variable** named `GITHUB_TOKEN` on the `docs` service.
+2. **Build-arg propagation** — Railway only forwards service variables to
+   Docker builds when the Dockerfile declares them as `ARG`. `Dockerfile`
+   does this in the builder stage:
+   ```dockerfile
+   ARG GITHUB_TOKEN
+   ENV GITHUB_TOKEN=$GITHUB_TOKEN
+   ```
+3. **Canary** — after `next build` completes, `scripts/check-docs-canary.sh`
+   asserts a few representative prerendered pages contain a "Last updated on"
+   line. Fails the build with an actionable error if not. Skipped when
+   `GITHUB_TOKEN` is unset (self-hosted).
+
+### Token format
+
+Fine-grained PAT scoped to one repo:
+
+- Resource owner: `AtlasDevHQ`
+- Repository access: `atlas` only
+- Repository permissions: **Contents: Read-only**
+- Expiration: 1 year (set a calendar reminder before expiry — the canary
+  will fail the deploy when the token stops working, but a calendar nudge
+  beats finding out via a red CI build)
+
+Generate at <https://github.com/settings/personal-access-tokens>.
+
+### Rotation
+
+1. Generate a new fine-grained PAT with the scope above.
+2. Update the `GITHUB_TOKEN` variable on the Railway docs service.
+3. Trigger a redeploy (`railway redeploy --service docs --yes`, or push any
+   change under `apps/docs/**`).
+4. Verify: `curl -s https://docs.useatlas.dev/guides/mcp | grep -c "Last updated on"`
+   — should be ≥1.
+
+### Self-hosted
+
+The token is **not required** for self-hosted operators. The build will
+print a "skipping last-updated canary" notice and the deployed docs site
+will simply not show "Last updated on" lines. Everything else works.
+
+## Other env vars
+
+None. The docs site is statically built — no runtime DB, no API calls.

--- a/deploy/docs/railway.json
+++ b/deploy/docs/railway.json
@@ -8,7 +8,8 @@
       "bun.lock",
       "brand.css",
       "apps/docs/**",
-      "deploy/docs/**"
+      "deploy/docs/**",
+      "scripts/check-docs-canary.sh"
     ]
   },
   "deploy": {

--- a/scripts/check-docs-canary.sh
+++ b/scripts/check-docs-canary.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# check-docs-canary.sh — verifies Fumadocs' getGithubLastEdit succeeded during
+# `next build`. Without this canary, a missing/expired GITHUB_TOKEN degrades
+# silently: every page hits the unauthenticated GitHub API, gets rate-limited
+# after ~60 calls, the catch in getLastUpdate swallows the error, and timestamps
+# vanish from production with no operator signal (issue #2103).
+#
+# Runs as the last step of the docs Dockerfile builder stage (deploy/docs/Dockerfile).
+# Expects to be executed from the docs build root (where `.next/server/app/` lives).
+#
+# Behavior:
+#   - GITHUB_TOKEN unset → skip canary, print notice. Self-hosted operators
+#     don't need the token; their unauthenticated builds will degrade silently
+#     for the last-updated timestamp, which is the documented trade-off.
+#   - GITHUB_TOKEN set → assert representative pages contain a <time> tag.
+#     If not, fail loudly so Railway marks the deploy failed instead of
+#     shipping a docs site without timestamps.
+
+set -euo pipefail
+
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+  echo "[docs-canary] GITHUB_TOKEN unset — skipping last-updated canary"
+  echo "[docs-canary] (self-hosted builds without a token will not show 'Last updated on …' timestamps)"
+  exit 0
+fi
+
+# Pick a handful of stable, high-traffic pages. If Fumadocs ever changes its
+# output structure these probes will need updating; that's intentional — the
+# canary should fail visibly when its assumptions break.
+PROBES=(
+  ".next/server/app/index.html"
+  ".next/server/app/guides/mcp.html"
+  ".next/server/app/semantic-layer.html"
+)
+
+missing_files=()
+no_time_tag=()
+
+for probe in "${PROBES[@]}"; do
+  if [ ! -f "$probe" ]; then
+    missing_files+=("$probe")
+    continue
+  fi
+  # Fumadocs renders the timestamp as <p>Last updated on {date}</p>
+  # (apps/docs/node_modules/fumadocs-ui/dist/layouts/docs/page/index.js:PageLastUpdate).
+  # If lastUpdate prop is undefined the <p> never renders, so this string is
+  # the canonical signal that getGithubLastEdit returned a Date.
+  if ! grep -q "Last updated on" "$probe"; then
+    no_time_tag+=("$probe")
+  fi
+done
+
+if [ "${#missing_files[@]}" -gt 0 ]; then
+  echo "[docs-canary] FAIL: prerender output missing expected files:"
+  printf '  %s\n' "${missing_files[@]}"
+  echo "[docs-canary] Fumadocs output structure may have changed — update PROBES in scripts/check-docs-canary.sh."
+  exit 1
+fi
+
+if [ "${#no_time_tag[@]}" -gt 0 ]; then
+  echo "[docs-canary] FAIL: GITHUB_TOKEN is set but these prerendered pages have no 'Last updated on' line:"
+  printf '  %s\n' "${no_time_tag[@]}"
+  echo
+  echo "[docs-canary] Likely causes:"
+  echo "  1. Token is expired or revoked — rotate at https://github.com/settings/personal-access-tokens"
+  echo "  2. Token is missing 'Contents: Read-only' permission on AtlasDevHQ/atlas"
+  echo "  3. GitHub API outage — re-run the deploy in a few minutes"
+  exit 1
+fi
+
+echo "[docs-canary] PASS: ${#PROBES[@]} probed pages have last-updated timestamps"


### PR DESCRIPTION
## Summary

Closes acceptance criteria 1 + 2 of #2103. Self-hosted operators are unaffected (token remains optional).

The real bug behind the missing **Last updated on …** timestamps on docs.useatlas.dev wasn't an expired token — it was that **the Dockerfile builder stage never received the token in the first place**. Railway only forwards service variables to docker builds when the Dockerfile declares `ARG`, and `deploy/docs/Dockerfile` didn't. So `getGithubLastEdit` always ran unauthenticated, hit GitHub's 60-req/hr rate limit ~12% of the way through the prerender (verified: 76/521 pages got timestamps in the local unauthenticated build — exactly the rate-limit cliff), and the silent catch swallowed every failure for the remaining 445 pages.

## Changes
- **`deploy/docs/Dockerfile`** — `ARG GITHUB_TOKEN` + `ENV GITHUB_TOKEN=\$GITHUB_TOKEN` in the builder stage so `next build` sees `process.env.GITHUB_TOKEN`.
- **`scripts/check-docs-canary.sh`** (new) — post-build canary asserting representative prerendered pages contain a "Last updated on" line. Fails the build with an actionable error if the token was set but the API rejected it (expired, wrong scope, outage). Skips when `GITHUB_TOKEN` unset (self-hosted).
- **`deploy/docs/railway.json`** — adds `scripts/check-docs-canary.sh` to `watchPatterns` per `check-railway-watch.sh` invariant.
- **`deploy/docs/README.md`** (new) — documents the env var, format, rotation steps, and self-hosted opt-out.

## Test plan
- [x] `bash scripts/check-railway-watch.sh` — passes (canary script is now a watched path)
- [x] Canary correctly identifies the broken build (76/521 pages have timestamps; canary flags `guides/mcp.html` which is past the 60th-page rate-limit threshold)
- [x] Canary skips cleanly when `GITHUB_TOKEN` unset (self-hosted ergonomics preserved)
- [ ] **After merge**: rotate `GITHUB_TOKEN` on Railway docs service (the prior value may have been partially leaked to a conversation log). Verify build canary passes during the redeploy. `curl -s docs.useatlas.dev/guides/mcp | grep -c "Last updated on"` should be ≥1.

## Out of scope
- The fumadocs silent catch in `getLastUpdate` is left as-is. The canary now provides the operator signal that was missing; the per-page `console.warn` continues for cases where a single page fails (e.g. transient 5xx) but doesn't fail the build wholesale. Aligns with the issue's preference for Option A (build-time canary) over Option B (warning escalation).