### PR TITLE
feat(mcp,eval,ci,docs): #2074 Phase 1 — canonical-question eval through the MCP path

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -13,11 +13,17 @@ name: Canonical Eval
 #     should never ship in a tagged release. Tag pushes drop the
 #     `continue-on-error` and a single fail trips the workflow red.
 #
-# Mode:
-#   Deterministic only (no LLM). The harness calls the typed semantic-layer
-#   reads (`findMetricById`, `searchGlossary`) and executes the resolved SQL
-#   directly against the seeded Postgres. The optional `--llm` mode exists
-#   for local exploration; we don't run it in CI to keep the gate stable.
+# Modes:
+#   - canonical-eval (existing): typed semantic-layer reads + direct SQL
+#     execution against seeded Postgres. Validates SQL correctness.
+#   - canonical-mcp-eval (new, #2074): every canonical question dispatched
+#     through the real `createHostedMcpRouter()` mounted on `Bun.serve`.
+#     Validates the MCP **protocol** layer end-to-end — transport, tool
+#     dispatch, error envelopes, prompts/list shape, concurrent sessions.
+#     `verifyAccessToken` is mocked (Phase 1); a follow-up issue replaces
+#     the mock with a real DCR + PKCE flow for full JWT-path coverage.
+#   The optional `--llm` mode for canonical-eval exists for local
+#   exploration; we don't run it in CI to keep the gate stable.
 #
 # Workflow-injection notes:
 #   - No untrusted PR/issue/commit fields are spliced into `run:` strings.
@@ -34,6 +40,18 @@ on:
       - "packages/cli/lib/help.ts"
       - "packages/cli/data/seeds/ecommerce/**"
       - "packages/api/src/lib/semantic/**"
+      # MCP-path eval (#2074): trigger on changes to the MCP route, the
+      # auth surface that issues / verifies bearers, and the eval helpers
+      # themselves.
+      - "packages/mcp/src/__tests__/canonical-mcp-*.ts"
+      - "packages/mcp/src/__tests__/canonical-mcp-*.evalspec.ts"
+      - "packages/mcp/src/hosted.ts"
+      - "packages/mcp/src/server.ts"
+      - "packages/mcp/src/tools.ts"
+      - "packages/mcp/src/semantic-tools.ts"
+      - "packages/mcp/src/error-envelope.ts"
+      - "packages/api/src/lib/auth/server.ts"
+      - "packages/api/src/lib/auth/oauth-claims.ts"
       - ".github/workflows/eval.yml"
   push:
     tags:
@@ -95,3 +113,35 @@ jobs:
           ATLAS_DATASOURCE_URL: postgres://atlas:atlas@127.0.0.1:5432/atlas_demo
           DATABASE_URL: postgres://atlas:atlas@127.0.0.1:5432/atlas
         run: bun packages/cli/bin/atlas.ts canonical-eval
+
+  # MCP-path eval (#2074, Phase 1). Runs every canonical question through
+  # the real `createHostedMcpRouter` mounted on `Bun.serve`, exercising
+  # transport / dispatch / envelope / prompts shape / concurrent sessions.
+  # `verifyAccessToken` is mocked — Phase 2 (follow-up) lands the full
+  # DCR + PKCE flow + LLM-on-client mode.
+  #
+  # No Postgres needed: the eval mocks `executeSQL` so SQL correctness is
+  # owned by the deterministic job above. This job is purely the MCP
+  # **protocol** gate.
+  canonical-mcp-eval-deterministic:
+    name: canonical-mcp-eval (deterministic)
+    runs-on: ubuntu-latest
+    # Same policy as the deterministic job: PRs informational, tag pushes
+    # blocking. A protocol-shape regression must not ship in a tag.
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@e3914758a49697077f7bcd190d36582a61667aad # v2 + node24
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build @useatlas/types (resolves api imports)
+        run: bun run --filter '@useatlas/types' build
+
+      - name: Run MCP-path canonical eval
+        run: bun test ./packages/mcp/src/__tests__/canonical-mcp-eval.evalspec.ts

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -20,8 +20,8 @@ name: Canonical Eval
 #     through the real `createHostedMcpRouter()` mounted on `Bun.serve`.
 #     Validates the MCP **protocol** layer end-to-end — transport, tool
 #     dispatch, error envelopes, prompts/list shape, concurrent sessions.
-#     `verifyAccessToken` is mocked (Phase 1); a follow-up issue replaces
-#     the mock with a real DCR + PKCE flow for full JWT-path coverage.
+#     `verifyAccessToken` is mocked (Phase 1); #2119 replaces the mock
+#     with a real DCR + PKCE flow for full JWT-path coverage.
 #   The optional `--llm` mode for canonical-eval exists for local
 #   exploration; we don't run it in CI to keep the gate stable.
 #
@@ -41,15 +41,21 @@ on:
       - "packages/cli/data/seeds/ecommerce/**"
       - "packages/api/src/lib/semantic/**"
       # MCP-path eval (#2074): trigger on changes to the MCP route, the
-      # auth surface that issues / verifies bearers, and the eval helpers
-      # themselves.
+      # tools the eval dispatches, the prompts/resources surfaces it
+      # asserts shape on, the auth surface that issues / verifies
+      # bearers, and the eval helpers themselves. `canonical-mcp-*.ts`
+      # already matches `canonical-mcp-eval.evalspec.ts` since the
+      # extension still ends in `.ts`.
       - "packages/mcp/src/__tests__/canonical-mcp-*.ts"
-      - "packages/mcp/src/__tests__/canonical-mcp-*.evalspec.ts"
       - "packages/mcp/src/hosted.ts"
       - "packages/mcp/src/server.ts"
+      - "packages/mcp/src/actor.ts"
       - "packages/mcp/src/tools.ts"
       - "packages/mcp/src/semantic-tools.ts"
+      - "packages/mcp/src/prompts.ts"
+      - "packages/mcp/src/resources.ts"
       - "packages/mcp/src/error-envelope.ts"
+      - "packages/mcp/package.json"
       - "packages/api/src/lib/auth/server.ts"
       - "packages/api/src/lib/auth/oauth-claims.ts"
       - ".github/workflows/eval.yml"
@@ -116,9 +122,9 @@ jobs:
 
   # MCP-path eval (#2074, Phase 1). Runs every canonical question through
   # the real `createHostedMcpRouter` mounted on `Bun.serve`, exercising
-  # transport / dispatch / envelope / prompts shape / concurrent sessions.
-  # `verifyAccessToken` is mocked — Phase 2 (follow-up) lands the full
-  # DCR + PKCE flow + LLM-on-client mode.
+  # transport / dispatch / envelope / prompts shape / concurrent sessions
+  # / session-cap enforcement. `verifyAccessToken` is mocked — #2119
+  # lands the full DCR + PKCE flow + LLM-on-client mode.
   #
   # No Postgres needed: the eval mocks `executeSQL` so SQL correctness is
   # owned by the deterministic job above. This job is purely the MCP

--- a/apps/docs/content/docs/contributing/eval-harness.mdx
+++ b/apps/docs/content/docs/contributing/eval-harness.mdx
@@ -110,11 +110,11 @@ bun test ./packages/mcp/src/__tests__/canonical-mcp-eval.evalspec.ts
 **Phase split:**
 
 - **Phase 1 (shipped):** mocks `verifyAccessToken` and `executeSQL.execute`. Validates the MCP **protocol** layer end-to-end. SQL correctness is owned by the deterministic eval above; this eval owns the MCP path.
-- **Phase 2 (follow-up issue):** real DCR + PKCE flow against an in-process Better Auth instance — closes the JWT-signature gap. Adds `--mcp-llm` mode where an LLM picks tools through MCP and validates tool-selection accuracy + recovery contract under prose drift.
+- **Phase 2 ([#2119](https://github.com/AtlasDevHQ/atlas/issues/2119)):** real DCR + PKCE flow against an in-process Better Auth instance — closes the JWT-signature gap. Adds `--mcp-llm` mode where an LLM picks tools through MCP and validates tool-selection accuracy + recovery contract under prose drift.
 
 **Failure artifacts.** Every failed dispatch produces a structured artifact (`packages/mcp/src/__tests__/canonical-mcp-failure-artifact.ts`) carrying the wire frame sent, the response received, the response expected, and a regression category — `protocol` / `tool_selection` / `recovery` / `latency` / `assertion`. The artifact bundle prints to the eval log so a CI failure carries enough context to act on without re-running.
 
-**CI gate.** A separate job — `canonical-mcp-eval (deterministic)` — runs alongside the deterministic SQL eval. Same policy: PRs are informational, tag pushes are blocking. Trigger paths cover the MCP route, the auth surface that issues / verifies bearers, and the eval helpers themselves.
+**CI gate.** A separate job — `canonical-mcp-eval (deterministic)` — runs alongside the deterministic SQL eval; the [CI policy](#ci-policy) table above governs both. Trigger paths cover the MCP route, the auth surface that issues / verifies bearers, and the eval helpers themselves.
 
 ## Out of scope
 

--- a/apps/docs/content/docs/contributing/eval-harness.mdx
+++ b/apps/docs/content/docs/contributing/eval-harness.mdx
@@ -5,6 +5,8 @@ description: Proves the consolidated NovaMart demo dataset returns correct answe
 
 > Why this is separate from `atlas eval`: that suite is the LLM SQL-quality benchmark (gold SQL, single shot, LLM nondeterminism). This harness is the *semantic-layer correctness* gate — it calls metric SQL exactly as the typed MCP `runMetric` tool does, asserts ambiguous glossary terms still trigger disambiguation, and proves `query_patterns:` and `virtual:` dimensions compile against the seed.
 
+A sibling harness — the **MCP-path canonical eval** ([`canonical-mcp-eval.evalspec.ts`](#mcp-path-eval-2074)) — dispatches the same canonical questions through the real hosted MCP route so a regression in transport, tool dispatch, error envelopes, or the prompts/list shape doesn't ship green.
+
 ## What it covers
 
 A curated set of ~20 canonical questions in `eval/canonical-questions/questions.yml`, exercising:
@@ -86,9 +88,37 @@ Atlas canonical-question eval
 
 The LLM mode (`--llm`) is **not** run in CI. We keep the gate stable and deterministic; the LLM mode exists for local exploration when debugging an agent regression.
 
+## MCP-path eval (#2074)
+
+The deterministic harness above proves the semantic layer answers each canonical question correctly. It cannot catch a regression in the MCP layer itself — a bad tool description, malformed `AtlasMcpToolError` envelope, `prompts/list` shape change, or session-cap break would all ship green.
+
+The MCP-path eval closes that gap. Every canonical question is dispatched through the real `createHostedMcpRouter()` mounted on `Bun.serve`, exercising:
+
+- `@modelcontextprotocol/sdk` Client → `StreamableHTTPClientTransport`
+- The Hono `/mcp/{workspace}/sse` route (full bearer + residency middleware path)
+- `tools/list`, `tools/call`, `prompts/list`
+- Real semantic-layer reads (`findMetricById`, `searchGlossary`, `getEntityByName`)
+- Recovery contracts: `unknown_metric`, `unknown_entity`, `ambiguous_term`
+- Concurrent sessions (a small stress test ships alongside)
+
+The eval lives at [`packages/mcp/src/__tests__/canonical-mcp-eval.evalspec.ts`](https://github.com/AtlasDevHQ/atlas/blob/main/packages/mcp/src/__tests__/canonical-mcp-eval.evalspec.ts). The `.evalspec.ts` extension keeps it out of `bun test`'s default discovery — invoke it explicitly:
+
+```bash
+bun test ./packages/mcp/src/__tests__/canonical-mcp-eval.evalspec.ts
+```
+
+**Phase split:**
+
+- **Phase 1 (shipped):** mocks `verifyAccessToken` and `executeSQL.execute`. Validates the MCP **protocol** layer end-to-end. SQL correctness is owned by the deterministic eval above; this eval owns the MCP path.
+- **Phase 2 (follow-up issue):** real DCR + PKCE flow against an in-process Better Auth instance — closes the JWT-signature gap. Adds `--mcp-llm` mode where an LLM picks tools through MCP and validates tool-selection accuracy + recovery contract under prose drift.
+
+**Failure artifacts.** Every failed dispatch produces a structured artifact (`packages/mcp/src/__tests__/canonical-mcp-failure-artifact.ts`) carrying the wire frame sent, the response received, the response expected, and a regression category — `protocol` / `tool_selection` / `recovery` / `latency` / `assertion`. The artifact bundle prints to the eval log so a CI failure carries enough context to act on without re-running.
+
+**CI gate.** A separate job — `canonical-mcp-eval (deterministic)` — runs alongside the deterministic SQL eval. Same policy: PRs are informational, tag pushes are blocking. Trigger paths cover the MCP route, the auth surface that issues / verifies bearers, and the eval helpers themselves.
+
 ## Out of scope
 
 - Eval coverage beyond the demo dataset (real customer data is separate).
 - LLM-as-judge scoring (we use deterministic SQL substring + value comparison).
-- Latency / throughput benchmarks.
+- Latency / throughput benchmarks — the MCP eval includes a small protocol-layer stress test, but the full k6 perf profile lives in [#2070](https://github.com/AtlasDevHQ/atlas/issues/2070).
 - Multi-LLM eval — the existing `atlas eval` LLM benchmark covers single-model correctness.

--- a/packages/mcp/src/__tests__/canonical-mcp-client.ts
+++ b/packages/mcp/src/__tests__/canonical-mcp-client.ts
@@ -19,9 +19,9 @@
  * MCP **protocol** layer end-to-end (transport, dispatch, envelope,
  * prompts, recovery) but NOT the JWT signature path.
  *
- * Phase 2 (follow-up issue) replaces the mocked verifier with the real
- * DCR + PKCE flow against an in-process Better Auth instance + JWKS,
- * closing the JWT-signature gap.
+ * Phase 2 (#2119) replaces the mocked verifier with the real DCR + PKCE
+ * flow against an in-process Better Auth instance + JWKS, closing the
+ * JWT-signature gap.
  */
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -92,14 +92,15 @@ export class EvalMcpClient {
   async listPrompts(): Promise<readonly PromptListEntry[]> {
     this.ensureConnected("listPrompts");
     // `prompts/list` may not be implemented if the server didn't register
-    // any prompts. The SDK throws; surface it as an empty list so the
-    // eval can still distinguish "no prompts" from "method missing".
+    // any prompts. The MCP SDK surfaces "method not found" as JSON-RPC
+    // error code -32601 — narrow on the code, not on a string match. A
+    // server-side 500 whose body happens to mention `prompts/list` is a
+    // real bug and must propagate, not be silently coerced to `[]`.
     try {
       const res = await this.client.listPrompts();
       return res.prompts.map((p) => ({ name: p.name, description: p.description }));
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (/Method not found|prompts\/list/.test(message)) return [];
+      if (isMethodNotFoundError(err)) return [];
       throw err;
     }
   }
@@ -119,20 +120,28 @@ export class EvalMcpClient {
   async close(): Promise<void> {
     if (!this.connected) return;
     this.connected = false;
-    // Closing the SDK client also closes the transport — the redundant
-    // transport.close() below catches the case where `client.close`
-    // throws before reaching the transport tear-down.
+    // The SDK's `client.close()` already closes the underlying transport,
+    // so the explicit `transport.close()` below is the duplicate-close
+    // path. We log a debug line on `client.close` failure so genuine
+    // teardown bugs (malformed-response handlers, abort-controller leaks)
+    // leave a trail; the transport double-close is matched against a
+    // narrow signature so EPIPE / socket teardown failures still surface.
     try {
       await this.client.close();
     } catch (err) {
-      // intentionally ignored: best-effort teardown — surface only via
-      // the transport close below if that also fails.
-      void err;
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[mcp-eval] client.close threw: ${message}\n`);
     }
-    await this.transport.close().catch(() => {
-      // intentionally ignored: see above. Logging here would spam every
-      // eval run with the duplicate-close path that's expected.
-    });
+    try {
+      await this.transport.close();
+    } catch (err) {
+      if (!isAlreadyClosedError(err)) {
+        const message = err instanceof Error ? err.message : String(err);
+        process.stderr.write(
+          `[mcp-eval] transport.close threw (not idempotent close): ${message}\n`,
+        );
+      }
+    }
   }
 
   private ensureConnected(op: string): void {
@@ -163,8 +172,47 @@ export function extractToolJson(
   try {
     parsed = JSON.parse(text);
   } catch {
+    // intentionally ignored: malformed JSON is a category of result, not
+    // an error. The eval branches on `kind` and reports `unparseable` as
+    // a `protocol` regression artifact rather than throwing.
     return { kind: "unparseable", raw: text };
   }
   if (result.isError === true) return { kind: "error", envelope: parsed };
   return { kind: "ok", data: parsed };
+}
+
+// ── Internal error classifiers ────────────────────────────────────────
+
+/**
+ * JSON-RPC `Method not found` is error code `-32601` (per the JSON-RPC
+ * 2.0 spec, mirrored by MCP). The SDK exposes the code on the rejection
+ * payload; fall back to a tightly-anchored prose check for older SDK
+ * builds that don't set `.code`. Anything else is a real failure and
+ * must propagate — a 500 whose body happens to mention `prompts/list`
+ * is exactly the regression class this eval exists to catch.
+ */
+function isMethodNotFoundError(err: unknown): boolean {
+  if (typeof err === "object" && err !== null) {
+    const e = err as { code?: unknown };
+    if (e.code === -32601) return true;
+  }
+  if (err instanceof Error) {
+    return /^Method not found\b/.test(err.message);
+  }
+  return false;
+}
+
+/**
+ * Detect the harmless duplicate-close case: `Client.close()` already
+ * tears the transport down, so a follow-on `transport.close()` may hit
+ * an "already closed" guard. We accept those quietly. Anything else
+ * (EPIPE, socket-leak signatures, generic TypeError from a mis-wired
+ * transport) propagates as a stderr line so test cleanup regressions
+ * are visible.
+ */
+function isAlreadyClosedError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return /already (closed|disposed)|transport.* (closed|terminated)/i.test(
+    err.message,
+  );
 }

--- a/packages/mcp/src/__tests__/canonical-mcp-client.ts
+++ b/packages/mcp/src/__tests__/canonical-mcp-client.ts
@@ -1,0 +1,170 @@
+/**
+ * Thin wrapper around `@modelcontextprotocol/sdk`'s `Client` +
+ * `StreamableHTTPClientTransport` for the canonical-question MCP eval
+ * harness (#2074).
+ *
+ * The eval drives every canonical question through the real MCP
+ * Streamable-HTTP transport so a regression in tool dispatch, error
+ * envelope shape, prompts/list format, or recovery contract is caught
+ * before it ships. The wrapper exposes only the surface the harness
+ * needs (connect / listTools / listPrompts / callTool / close) so test
+ * files do not have to learn the SDK's full API.
+ *
+ * ── Auth (Phase 1) ─────────────────────────────────────────────────
+ *
+ * Phase 1 mocks `verifyAccessToken` at the module boundary in the test
+ * file (matches `packages/mcp/src/__tests__/hosted.test.ts`) — the
+ * bearer threaded into the `Authorization` header is opaque and the
+ * route accepts it because the verifier is stubbed. This covers the
+ * MCP **protocol** layer end-to-end (transport, dispatch, envelope,
+ * prompts, recovery) but NOT the JWT signature path.
+ *
+ * Phase 2 (follow-up issue) replaces the mocked verifier with the real
+ * DCR + PKCE flow against an in-process Better Auth instance + JWKS,
+ * closing the JWT-signature gap.
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+export interface EvalMcpClientOptions {
+  /** Base URL of the in-process MCP server, e.g. `http://localhost:54321`. */
+  readonly baseUrl: string;
+  /** Workspace id path segment — token's `workspace_id` claim must match. */
+  readonly workspaceId: string;
+  /** Opaque bearer threaded into `Authorization`. The route's verifier resolves it. */
+  readonly bearer: string;
+  /** Optional client metadata so server logs distinguish eval sessions from production probes. */
+  readonly clientName?: string;
+  readonly clientVersion?: string;
+}
+
+export interface ToolListEntry {
+  readonly name: string;
+  readonly description?: string;
+}
+
+export interface PromptListEntry {
+  readonly name: string;
+  readonly description?: string;
+}
+
+/**
+ * Open a session against the hosted MCP route, dispatch tool/prompt
+ * calls, and close cleanly. The lifecycle mirrors `Client` exactly —
+ * `connect` is required before any other call, `close` must run in a
+ * `finally` so a failed dispatch never leaks a session past the test.
+ */
+export class EvalMcpClient {
+  private readonly client: Client;
+  private readonly transport: StreamableHTTPClientTransport;
+  private connected = false;
+
+  constructor(opts: EvalMcpClientOptions) {
+    const url = new URL(`${opts.baseUrl.replace(/\/+$/, "")}/mcp/${opts.workspaceId}/sse`);
+    this.transport = new StreamableHTTPClientTransport(url, {
+      requestInit: {
+        headers: { Authorization: `Bearer ${opts.bearer}` },
+      },
+    });
+    this.client = new Client(
+      {
+        name: opts.clientName ?? "atlas-canonical-mcp-eval",
+        version: opts.clientVersion ?? "0.1.0",
+      },
+      { capabilities: {} },
+    );
+  }
+
+  async connect(): Promise<void> {
+    if (this.connected) return;
+    await this.client.connect(this.transport);
+    this.connected = true;
+  }
+
+  async listTools(): Promise<readonly ToolListEntry[]> {
+    this.ensureConnected("listTools");
+    const res = await this.client.listTools();
+    return res.tools.map((t) => ({ name: t.name, description: t.description }));
+  }
+
+  async listPrompts(): Promise<readonly PromptListEntry[]> {
+    this.ensureConnected("listPrompts");
+    // `prompts/list` may not be implemented if the server didn't register
+    // any prompts. The SDK throws; surface it as an empty list so the
+    // eval can still distinguish "no prompts" from "method missing".
+    try {
+      const res = await this.client.listPrompts();
+      return res.prompts.map((p) => ({ name: p.name, description: p.description }));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (/Method not found|prompts\/list/.test(message)) return [];
+      throw err;
+    }
+  }
+
+  async callTool(
+    name: string,
+    args: Record<string, unknown>,
+  ): Promise<CallToolResult> {
+    this.ensureConnected("callTool");
+    const result = (await this.client.callTool({
+      name,
+      arguments: args,
+    })) as CallToolResult;
+    return result;
+  }
+
+  async close(): Promise<void> {
+    if (!this.connected) return;
+    this.connected = false;
+    // Closing the SDK client also closes the transport — the redundant
+    // transport.close() below catches the case where `client.close`
+    // throws before reaching the transport tear-down.
+    try {
+      await this.client.close();
+    } catch (err) {
+      // intentionally ignored: best-effort teardown — surface only via
+      // the transport close below if that also fails.
+      void err;
+    }
+    await this.transport.close().catch(() => {
+      // intentionally ignored: see above. Logging here would spam every
+      // eval run with the duplicate-close path that's expected.
+    });
+  }
+
+  private ensureConnected(op: string): void {
+    if (!this.connected) {
+      throw new Error(
+        `EvalMcpClient.${op} called before connect(). Call connect() first.`,
+      );
+    }
+  }
+}
+
+/**
+ * MCP `tools/call` returns content as an array of items (text / image /
+ * resource). The semantic-layer tools always return a single text item
+ * containing JSON (success path) or the `AtlasMcpToolError` envelope
+ * (failure path). Extract that JSON so callers compare structured data
+ * instead of pattern-matching on prose.
+ */
+export function extractToolJson(
+  result: CallToolResult,
+): { kind: "ok"; data: unknown } | { kind: "error"; envelope: unknown } | { kind: "unparseable"; raw: string } {
+  const text = result.content
+    .filter((c): c is { type: "text"; text: string } => c.type === "text")
+    .map((c) => c.text)
+    .join("");
+  if (!text) return { kind: "unparseable", raw: "" };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return { kind: "unparseable", raw: text };
+  }
+  if (result.isError === true) return { kind: "error", envelope: parsed };
+  return { kind: "ok", data: parsed };
+}

--- a/packages/mcp/src/__tests__/canonical-mcp-client.ts
+++ b/packages/mcp/src/__tests__/canonical-mcp-client.ts
@@ -75,6 +75,14 @@ export class EvalMcpClient {
       },
       { capabilities: {} },
     );
+    // Server-initiated close (session cap, server shutdown, route 503)
+    // would otherwise leave `connected = true` with a dead transport.
+    // The next `callTool` would reject from inside the SDK rather than
+    // tripping `ensureConnected` — losing the typed precondition error.
+    // Listening here flips the flag so callers see the right surface.
+    this.transport.onclose = () => {
+      this.connected = false;
+    };
   }
 
   async connect(): Promise<void> {

--- a/packages/mcp/src/__tests__/canonical-mcp-eval.evalspec.ts
+++ b/packages/mcp/src/__tests__/canonical-mcp-eval.evalspec.ts
@@ -34,7 +34,7 @@
  *   - Asserts on protocol shape, tool dispatch, envelope codes, prompts
  *     list shape, and concurrent-session behavior.
  *
- * Phase 2 (follow-up issue, see PR description):
+ * Phase 2 (#2119):
  *   - Real DCR + PKCE flow against an in-process Better Auth instance —
  *     covers the JWT signature path the verifier mock currently hides.
  *   - `--mcp-llm` mode where an LLM picks tools through MCP — validates
@@ -168,8 +168,6 @@ mock.module("better-auth/oauth2", () => ({
 }));
 
 // `db/internal` is touched by the route (residency check) and by audit.
-// Pin every named export to keep this mock from leaking into other test
-// files that may run in the same process.
 mock.module("@atlas/api/lib/db/internal", () => {
   const notUsed = (name: string) => () => {
     throw new Error(`db/internal.${name} called from mcp-eval — add a mock`);
@@ -367,16 +365,30 @@ afterAll(async () => {
   const { _resetHostedSessions } = await import("@atlas/mcp/hosted");
   await _resetHostedSessions();
 
-  // Restore semantic layer no matter what; surface failure loudly.
-  if (fs.existsSync(SEMANTIC_BACKUP_DIR)) {
-    if (fs.existsSync(SEMANTIC_DIR)) {
+  // Restore semantic layer no matter what. A failed restore would
+  // silently corrupt the contributor's working tree (eval-seeded
+  // entities staying in `semantic/`); print the recovery commands and
+  // re-throw so the test run fails loudly instead of "all green".
+  try {
+    if (fs.existsSync(SEMANTIC_BACKUP_DIR)) {
+      if (fs.existsSync(SEMANTIC_DIR)) {
+        fs.rmSync(SEMANTIC_DIR, { recursive: true });
+      }
+      fs.cpSync(SEMANTIC_BACKUP_DIR, SEMANTIC_DIR, { recursive: true });
+      fs.rmSync(SEMANTIC_BACKUP_DIR, { recursive: true });
+    } else if (fs.existsSync(SEMANTIC_DIR)) {
+      // No backup means there was nothing in semantic/ before — clean up.
       fs.rmSync(SEMANTIC_DIR, { recursive: true });
     }
-    fs.cpSync(SEMANTIC_BACKUP_DIR, SEMANTIC_DIR, { recursive: true });
-    fs.rmSync(SEMANTIC_BACKUP_DIR, { recursive: true });
-  } else if (fs.existsSync(SEMANTIC_DIR)) {
-    // No backup means there was nothing in semantic/ before — clean up.
-    fs.rmSync(SEMANTIC_DIR, { recursive: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `\nCRITICAL: failed to restore semantic layer after MCP eval: ${message}\n` +
+        `Recover manually:\n` +
+        `  rm -rf ${SEMANTIC_DIR}\n` +
+        `  ${fs.existsSync(SEMANTIC_BACKUP_DIR) ? `mv ${SEMANTIC_BACKUP_DIR} ${SEMANTIC_DIR}` : "# no backup exists — semantic/ is now empty (this is fine if it started empty)"}\n`,
+    );
+    throw err;
   }
 
   mock.restore();
@@ -398,12 +410,15 @@ function newClient(): EvalMcpClient {
 
 // ── Per-question dispatch ─────────────────────────────────────────
 
-interface QuestionOutcome {
-  readonly questionId: string;
-  readonly status: "pass" | "fail";
-  readonly latencyMs: number;
-  readonly artifact?: McpFailureArtifact;
-}
+/**
+ * Discriminated by `status`: a `fail` outcome always carries an
+ * artifact, a `pass` outcome never does. Modeling this as a union
+ * (rather than an optional artifact field) lets the summary code at
+ * the bottom narrow without a guard each time it touches `outcome.artifact`.
+ */
+type QuestionOutcome =
+  | { readonly questionId: string; readonly status: "pass"; readonly latencyMs: number }
+  | { readonly questionId: string; readonly status: "fail"; readonly latencyMs: number; readonly artifact: McpFailureArtifact };
 
 async function runOneQuestion(
   client: EvalMcpClient,
@@ -453,7 +468,13 @@ async function runOneQuestion(
             expected: { id: q.metric_id, success: true },
           });
         }
-        const data = parsed.data as { id?: unknown; sql?: unknown };
+        const data = parsed.data as {
+          id?: unknown;
+          sql?: unknown;
+          columns?: unknown;
+          rows?: unknown;
+          truncated?: unknown;
+        };
         if (data.id !== q.metric_id) {
           return fail("protocol", `runMetric envelope id mismatch`, {
             tool,
@@ -468,6 +489,34 @@ async function runOneQuestion(
             args,
             response: data,
             expected: "non-empty sql string",
+          });
+        }
+        // Wire-shape pin: a regression that flips `truncated` to a string
+        // or drops `columns`/`rows` ships invisible to the agent until a
+        // downstream tool (a notebook, a chat-platform formatter)
+        // crashes on the unexpected type. Catch it at the eval boundary.
+        if (!Array.isArray(data.columns)) {
+          return fail("protocol", `runMetric envelope columns must be an array`, {
+            tool,
+            args,
+            response: data,
+            expected: { columns: "string[]" },
+          });
+        }
+        if (!Array.isArray(data.rows)) {
+          return fail("protocol", `runMetric envelope rows must be an array`, {
+            tool,
+            args,
+            response: data,
+            expected: { rows: "Record<string, unknown>[]" },
+          });
+        }
+        if (typeof data.truncated !== "boolean") {
+          return fail("protocol", `runMetric envelope truncated must be a boolean`, {
+            tool,
+            args,
+            response: data,
+            expected: { truncated: "boolean" },
           });
         }
         return { questionId: q.id, status: "pass", latencyMs: Date.now() - start };
@@ -658,8 +707,13 @@ describe("MCP path canonical eval (#2074)", () => {
       const parsed = extractToolJson(result);
       expect(parsed.kind).toBe("error");
       if (parsed.kind === "error") {
-        const env = parsed.envelope as { code?: unknown };
+        const env = parsed.envelope as { code?: unknown; hint?: unknown };
         expect(env.code).toBe("unknown_metric");
+        // Recovery contract: every `unknown_*` envelope must carry a
+        // non-empty `hint` so an agent can self-correct (e.g. "call
+        // listEntities to discover available metrics"). A regression
+        // that drops the hint would silently degrade agent recovery.
+        expect(env.hint).toBeTruthy();
       }
     } finally {
       await client.close();
@@ -699,22 +753,24 @@ describe("MCP path canonical eval (#2074)", () => {
     }
 
     const passing = outcomes.filter((o) => o.status === "pass").length;
-    const failures = outcomes.filter((o) => o.status === "fail");
+    const failures = outcomes.filter(
+      (o): o is Extract<QuestionOutcome, { status: "fail" }> =>
+        o.status === "fail",
+    );
+    const artifactBundle = formatArtifactBundle(failures.map((f) => f.artifact));
 
     process.stdout.write(
       `\nMCP canonical eval: ${passing}/${outcomes.length} passing\n`,
     );
     if (failures.length > 0) {
-      process.stdout.write(
-        formatArtifactBundle(failures.flatMap((f) => (f.artifact ? [f.artifact] : []))),
-      );
+      process.stdout.write(artifactBundle);
     }
 
     // Acceptance criterion (Phase 1 deterministic): every canonical
     // question round-trips through MCP without protocol / recovery /
     // assertion failure. If this drops below 20/20 something on the
     // MCP path regressed and the artifacts above explain what.
-    expect(failures, formatArtifactBundle(failures.flatMap((f) => (f.artifact ? [f.artifact] : [])))).toEqual([]);
+    expect(failures, artifactBundle).toEqual([]);
   });
 });
 
@@ -736,6 +792,45 @@ describe("MCP path stress (#2074, partial #2070)", () => {
       }
     } finally {
       await Promise.all(clients.map((c) => c.close()));
+    }
+  });
+
+  it("enforces ATLAS_MCP_MAX_SESSIONS without TOCTOU drift under contention", async () => {
+    // The reservation counter at hosted.ts (`pendingReservations`) closes
+    // a TOCTOU window between the cap check and `createAtlasMcpServer`'s
+    // async resolution. Driving the cap with N=DEFAULT_MAX_SESSIONS+ would
+    // be slow; instead we lower the cap and saturate it, which exercises
+    // the exact same code path with concrete contention.
+    const CAP = 3;
+    const previous = process.env.ATLAS_MCP_MAX_SESSIONS;
+    process.env.ATLAS_MCP_MAX_SESSIONS = String(CAP);
+    const { _resetHostedSessions } = await import("@atlas/mcp/hosted");
+    await _resetHostedSessions();
+
+    // Open CAP+2 concurrent connect attempts. The first CAP must
+    // succeed; the remainder must reject with the route's 429-style
+    // session-cap error rather than slip through a race.
+    const N = CAP + 2;
+    const clients = Array.from({ length: N }, () => newClient());
+    const results = await Promise.allSettled(
+      clients.map((c) => c.connect()),
+    );
+    try {
+      const fulfilled = results.filter((r) => r.status === "fulfilled").length;
+      const rejected = results.length - fulfilled;
+      expect(fulfilled).toBeLessThanOrEqual(CAP);
+      expect(rejected).toBeGreaterThanOrEqual(N - CAP);
+    } finally {
+      // Best-effort close — only fulfilled connects need teardown; the
+      // rejected ones never registered a session.
+      await Promise.all(
+        clients.map((c, i) =>
+          results[i].status === "fulfilled" ? c.close() : Promise.resolve(),
+        ),
+      );
+      if (previous === undefined) delete process.env.ATLAS_MCP_MAX_SESSIONS;
+      else process.env.ATLAS_MCP_MAX_SESSIONS = previous;
+      await _resetHostedSessions();
     }
   });
 });

--- a/packages/mcp/src/__tests__/canonical-mcp-eval.evalspec.ts
+++ b/packages/mcp/src/__tests__/canonical-mcp-eval.evalspec.ts
@@ -80,9 +80,8 @@ import {
 
 // ── Module mocks ───────────────────────────────────────────────────
 //
-// CLAUDE.md requires every named export of a mocked module to be
-// stubbed; partial mocks leak across the in-process test runner. The
-// shapes mirror `packages/mcp/src/__tests__/hosted.test.ts`.
+// Shapes mirror `packages/mcp/src/__tests__/hosted.test.ts`. Every
+// named export is stubbed (CLAUDE.md rule — partial mocks leak).
 
 interface FakeJwtPayload {
   sub: string;
@@ -319,9 +318,24 @@ beforeAll(async () => {
   fs.cpSync(SEED_SEMANTIC_DIR, SEMANTIC_DIR, { recursive: true });
 
   // Reset semantic-layer caches so the freshly installed YAMLs are
-  // re-resolved by the in-process MCP server.
-  const { _resetWhitelists } = await import("@atlas/api/lib/semantic");
-  _resetWhitelists();
+  // re-resolved by the in-process MCP server. If the reset itself
+  // throws, `semantic/` is already swapped — point the contributor at
+  // the recovery commands rather than letting bun:test surface a
+  // generic error with no working-tree context.
+  try {
+    const { _resetWhitelists } = await import("@atlas/api/lib/semantic");
+    _resetWhitelists();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `\nMCP eval beforeAll failed after staging semantic/. Working tree is now seeded with the demo layer; backup at ${SEMANTIC_BACKUP_DIR}.\n` +
+        `Recover manually:\n` +
+        `  rm -rf ${SEMANTIC_DIR}\n` +
+        `  ${fs.existsSync(SEMANTIC_BACKUP_DIR) ? `mv ${SEMANTIC_BACKUP_DIR} ${SEMANTIC_DIR}` : "# no backup — semantic/ was empty before"}\n` +
+        `Underlying error: ${message}\n`,
+    );
+    throw err;
+  }
 
   // Bind the test bearer to a workspace-scoped JWT payload.
   mockVerifyAccessToken.mockImplementation(async (token: string) => {
@@ -563,7 +577,9 @@ async function runOneQuestion(
           }
           return { questionId: q.id, status: "pass", latencyMs: Date.now() - start };
         }
-        // Defined / no-status path — success envelope expected.
+        // Defined / no-status path — success envelope expected with a
+        // `matches[]` array. A regression that returns `{}` or
+        // stringifies the matches must trip here, not silently pass.
         if (parsed.kind === "error") {
           return fail("recovery", `searchGlossary returned error envelope on a defined term`, {
             tool,
@@ -572,13 +588,23 @@ async function runOneQuestion(
             expected: "success matches[]",
           });
         }
+        const glossaryData = parsed.data as { matches?: unknown };
+        if (!Array.isArray(glossaryData.matches)) {
+          return fail("protocol", `searchGlossary success envelope must carry matches[]`, {
+            tool,
+            args,
+            response: glossaryData,
+            expected: { matches: "Array<{term, status, possible_mappings}>" },
+          });
+        }
         return { questionId: q.id, status: "pass", latencyMs: Date.now() - start };
       }
       case "pattern": {
-        // The MCP semantic toolset doesn't expose query_patterns directly
-        // — `describeEntity` returns the entity, callers extract the
-        // pattern, then dispatch via `executeSQL`. Validate the
-        // describeEntity round-trip surfaces the expected pattern name.
+        // `describeEntity` is the round-trip under test — the MCP
+        // semantic toolset surfaces `query_patterns[*]` through the
+        // entity envelope. Asserting the named pattern is present in
+        // the response catches a regression in the entity loader's
+        // shape without coupling the eval to executeSQL semantics.
         const tool = "describeEntity";
         const args = { name: q.entity };
         const result = await client.callTool(tool, args);
@@ -674,10 +700,43 @@ describe("MCP path canonical eval (#2074)", () => {
         "runMetric",
         "searchGlossary",
       ]);
-      // Every tool must carry a description — the agent's tool-selection
-      // accuracy is gated by description quality.
+      // Description-quality floor — agent tool-selection accuracy is
+      // gated by description quality (full audit owned by #2075). Pin
+      // the cheap things now: descriptions exist, are long enough to
+      // carry intent + one usage hint, and the tools that surface a
+      // typed error envelope mention their error catalog so the agent
+      // can branch on `code`. A tool that drops to "Run a metric." or
+      // forgets to surface its error contract slips through #2075's
+      // backlog window otherwise.
+      const MIN_DESC_LEN = 40;
       for (const t of tools) {
-        expect(t.description, `tool ${t.name} missing description`).toBeTruthy();
+        const desc = t.description ?? "";
+        expect(desc.length, `tool ${t.name} description too short (${desc.length} < ${MIN_DESC_LEN}): ${JSON.stringify(desc)}`)
+          .toBeGreaterThanOrEqual(MIN_DESC_LEN);
+      }
+      // Every tool description should mention the error-envelope
+      // contract — `withErrorContract` (semantic-tools.ts) appends
+      // "Error contract:" to each description. A regression that drops
+      // the wrapper would degrade agent recovery silently.
+      for (const t of tools) {
+        const desc = t.description ?? "";
+        expect(desc, `tool ${t.name} missing 'Error contract:' line`).toContain("Error contract:");
+      }
+      // Tools that emit envelopes for `unknown_*` or `ambiguous_term`
+      // must mention those codes by name — pinning the recovery surface
+      // the agent reads.
+      const expectMentions: ReadonlyArray<readonly [string, readonly string[]]> = [
+        ["runMetric", ["unknown_metric", "validation_failed"]],
+        ["describeEntity", ["unknown_entity"]],
+        ["searchGlossary", ["ambiguous_term"]],
+      ];
+      for (const [name, codes] of expectMentions) {
+        const t = tools.find((x) => x.name === name);
+        expect(t, `tool ${name} missing from listTools()`).toBeTruthy();
+        for (const code of codes) {
+          expect(t!.description ?? "", `tool ${name} description does not mention error code "${code}"`)
+            .toContain(`\`${code}\``);
+        }
       }
     } finally {
       await client.close();

--- a/packages/mcp/src/__tests__/canonical-mcp-eval.evalspec.ts
+++ b/packages/mcp/src/__tests__/canonical-mcp-eval.evalspec.ts
@@ -1,0 +1,741 @@
+/**
+ * Canonical-question eval through the MCP path (#2074, Phase 1).
+ *
+ * The existing deterministic canonical eval (`packages/cli/bin/canonical-eval.ts`)
+ * proves the **semantic-layer** answers each question correctly — it calls
+ * `findMetricById` and executes the resolved SQL directly. That harness
+ * cannot catch a regression in the MCP layer itself: a bad tool
+ * description, a malformed `AtlasMcpToolError` envelope, a `prompts/list`
+ * shape change, or a session-cap break would all ship green.
+ *
+ * This file closes that gap. Every canonical question is dispatched
+ * through the real `createHostedMcpRouter()` mounted on `Bun.serve`,
+ * exercising the full MCP transport stack:
+ *
+ *   bun runtime → @modelcontextprotocol/sdk Client
+ *               → StreamableHTTPClientTransport
+ *               → Hono route /mcp/{workspace}/sse
+ *               → verifyAccessToken (mocked — see Phase 2 below)
+ *               → tools/list, tools/call, prompts/list
+ *               → semantic-layer reads (REAL — `findMetricById`,
+ *                  `searchGlossary`, `getEntityByName`)
+ *               → executeSQL (MOCKED — SQL correctness is owned by the
+ *                  existing deterministic eval; here we validate the MCP
+ *                  envelope wrapping)
+ *
+ * ── Phase split ─────────────────────────────────────────────────────
+ *
+ * Phase 1 (this file):
+ *   - Mocks `verifyAccessToken` so we don't need a real OAuth server.
+ *   - Mocks `executeSQL.execute` so we don't need a real Postgres pool +
+ *     migrated internal DB. Real SQL execution is covered by the
+ *     existing deterministic eval.
+ *   - Real semantic-layer reads.
+ *   - Asserts on protocol shape, tool dispatch, envelope codes, prompts
+ *     list shape, and concurrent-session behavior.
+ *
+ * Phase 2 (follow-up issue, see PR description):
+ *   - Real DCR + PKCE flow against an in-process Better Auth instance —
+ *     covers the JWT signature path the verifier mock currently hides.
+ *   - `--mcp-llm` mode where an LLM picks tools through MCP — validates
+ *     tool-selection accuracy and recovery contract under prose drift.
+ *
+ * ── Stress mode ─────────────────────────────────────────────────────
+ *
+ * Beyond the per-question coverage, the file ends with a concurrent-
+ * session stress test that opens N parallel sessions and asserts the
+ * route honours `ATLAS_MCP_MAX_SESSIONS` without a TOCTOU race. This is
+ * the protocol-layer half of the load-test work tracked in #2070; the
+ * full k6 profile lands separately.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  afterEach,
+  mock,
+  type Mock,
+} from "bun:test";
+import * as fs from "fs";
+import * as path from "path";
+import type { AdminActionEntry } from "@atlas/api/lib/audit";
+import { ATLAS_OAUTH_WORKSPACE_CLAIM as WORKSPACE_CLAIM } from "@atlas/api/lib/auth/oauth-claims";
+// Pure runner core lives in @atlas/cli — relative path because the cli
+// package doesn't ship an `exports` map. The functions we need
+// (`loadQuestions`, `DEFAULT_QUESTIONS_PATH`) are pure and DB-free.
+import {
+  loadQuestions,
+  DEFAULT_QUESTIONS_PATH,
+  type Question,
+} from "../../../cli/bin/canonical-eval";
+import { EvalMcpClient, extractToolJson } from "./canonical-mcp-client";
+import {
+  formatArtifactBundle,
+  type FailureCategory,
+  type McpFailureArtifact,
+} from "./canonical-mcp-failure-artifact";
+
+// ── Module mocks ───────────────────────────────────────────────────
+//
+// CLAUDE.md requires every named export of a mocked module to be
+// stubbed; partial mocks leak across the in-process test runner. The
+// shapes mirror `packages/mcp/src/__tests__/hosted.test.ts`.
+
+interface FakeJwtPayload {
+  sub: string;
+  jti?: string;
+  azp?: string;
+  scope?: string;
+  aud?: string | string[];
+  iss?: string;
+  exp?: number;
+  iat?: number;
+  [WORKSPACE_CLAIM]?: string;
+}
+
+const mockVerifyAccessToken: Mock<
+  (token: string, opts: unknown) => Promise<FakeJwtPayload>
+> = mock(async () => {
+  throw new Error("verifyAccessToken called without a stub");
+});
+
+mock.module("better-auth/oauth2", () => ({
+  verifyAccessToken: (token: string, opts: unknown) =>
+    mockVerifyAccessToken(token, opts),
+  authorizationCodeRequest: () => {
+    throw new Error("authorizationCodeRequest called from mcp-eval");
+  },
+  clientCredentialsToken: () => {
+    throw new Error("clientCredentialsToken called from mcp-eval");
+  },
+  clientCredentialsTokenRequest: () => {
+    throw new Error("clientCredentialsTokenRequest called from mcp-eval");
+  },
+  createAuthorizationCodeRequest: () => {
+    throw new Error("createAuthorizationCodeRequest called from mcp-eval");
+  },
+  createAuthorizationURL: () => {
+    throw new Error("createAuthorizationURL called from mcp-eval");
+  },
+  createClientCredentialsTokenRequest: () => {
+    throw new Error("createClientCredentialsTokenRequest called from mcp-eval");
+  },
+  createRefreshAccessTokenRequest: () => {
+    throw new Error("createRefreshAccessTokenRequest called from mcp-eval");
+  },
+  decryptOAuthToken: () => {
+    throw new Error("decryptOAuthToken called from mcp-eval");
+  },
+  generateCodeChallenge: () => {
+    throw new Error("generateCodeChallenge called from mcp-eval");
+  },
+  generateState: () => {
+    throw new Error("generateState called from mcp-eval");
+  },
+  getJwks: () => {
+    throw new Error("getJwks called from mcp-eval");
+  },
+  getOAuth2Tokens: () => {
+    throw new Error("getOAuth2Tokens called from mcp-eval");
+  },
+  handleOAuthUserInfo: () => {
+    throw new Error("handleOAuthUserInfo called from mcp-eval");
+  },
+  parseState: () => {
+    throw new Error("parseState called from mcp-eval");
+  },
+  refreshAccessToken: () => {
+    throw new Error("refreshAccessToken called from mcp-eval");
+  },
+  refreshAccessTokenRequest: () => {
+    throw new Error("refreshAccessTokenRequest called from mcp-eval");
+  },
+  setTokenUtil: () => {
+    throw new Error("setTokenUtil called from mcp-eval");
+  },
+  validateAuthorizationCode: () => {
+    throw new Error("validateAuthorizationCode called from mcp-eval");
+  },
+  validateToken: () => {
+    throw new Error("validateToken called from mcp-eval");
+  },
+  verifyJwsAccessToken: () => {
+    throw new Error("verifyJwsAccessToken called from mcp-eval");
+  },
+}));
+
+// `db/internal` is touched by the route (residency check) and by audit.
+// Pin every named export to keep this mock from leaking into other test
+// files that may run in the same process.
+mock.module("@atlas/api/lib/db/internal", () => {
+  const notUsed = (name: string) => () => {
+    throw new Error(`db/internal.${name} called from mcp-eval — add a mock`);
+  };
+  return {
+    getWorkspaceRegion: async () => null,
+    hasInternalDB: () => false,
+    internalQuery: notUsed("internalQuery"),
+    internalExecute: notUsed("internalExecute"),
+    getInternalDB: notUsed("getInternalDB"),
+    assignWorkspaceRegion: notUsed("assignWorkspaceRegion"),
+    isWorkspaceMigrating: async () => false,
+    closeInternalDB: async () => undefined,
+  };
+});
+
+// Audit emission is observability-only for the eval. Drop to in-memory.
+const auditEntries: AdminActionEntry[] = [];
+mock.module("@atlas/api/lib/audit", () => ({
+  ADMIN_ACTIONS: {
+    mcp_session: { start: "mcp_session.start" },
+    oauth_token: {
+      issue: "oauth_token.issue",
+      refresh: "oauth_token.refresh",
+      revoke: "oauth_token.revoke",
+    },
+  },
+  logAdminAction: (entry: AdminActionEntry) => auditEntries.push(entry),
+  logAdminActionAwait: async (entry: AdminActionEntry) =>
+    void auditEntries.push(entry),
+  errorMessage: (err: unknown) =>
+    err instanceof Error ? err.message : String(err),
+  causeToError: (err: unknown) =>
+    err instanceof Error ? err : new Error(String(err)),
+}));
+
+// `executeSQL` is the SQL execution boundary inside `runMetric` and the
+// MCP `executeSQL` tool. We stub it to return a static success envelope
+// so the eval validates the MCP wrapping (envelope shape, success path,
+// truncation flag) without standing up a Postgres pool. SQL correctness
+// is the existing deterministic eval's job; this eval owns the MCP path.
+mock.module("@atlas/api/lib/tools/sql", () => ({
+  executeSQL: {
+    description:
+      "Execute a SELECT query against the configured analytics database. Returns columns + rows.",
+    execute: async (
+      args: { sql: string; explanation?: string; connectionId?: string },
+    ) => ({
+      success: true,
+      explanation: args.explanation ?? "mcp-eval",
+      columns: ["count"],
+      rows: [{ count: 42 }],
+      row_count: 1,
+      truncated: false,
+    }),
+  },
+}));
+
+// Avoid pulling the full sandbox stack — `explore` isn't exercised by
+// canonical questions but the MCP server still registers it.
+mock.module("@atlas/api/lib/tools/explore", () => ({
+  explore: {
+    description: "Explore the semantic layer (read-only).",
+    execute: async () => "catalog.yml\nentities/\nmetrics/\nglossary.yml",
+  },
+}));
+
+// Config: minimal. The MCP server reads `tools` to know which tools to
+// register; tag the eval-relevant ones explicitly.
+interface MockedConfig {
+  datasources: Record<string, unknown>;
+  tools: string[];
+  auth: string;
+  semanticLayer: string;
+  source: string;
+}
+const mockedConfig: MockedConfig = {
+  datasources: {},
+  tools: ["explore", "executeSQL"],
+  auth: "auto",
+  semanticLayer: "./semantic",
+  source: "env",
+};
+mock.module("@atlas/api/lib/config", () => ({
+  initializeConfig: async () => mockedConfig,
+  getConfig: () => mockedConfig,
+  loadConfig: async () => mockedConfig,
+  configFromEnv: () => mockedConfig,
+  validateAndResolve: () => mockedConfig,
+  defineConfig: (c: unknown) => c,
+  applyDatasources: async () => undefined,
+  validateToolConfig: async () => undefined,
+  formatZodErrors: () => "",
+  _resetConfig: () => undefined,
+  _setConfigForTest: () => undefined,
+  _warnPoolDefaultsInSaaS: () => undefined,
+}));
+
+// ── Test fixtures ─────────────────────────────────────────────────
+
+// Anchor every fs path at the test file location so the harness behaves
+// the same whether `bun test` is invoked from the repo root or from
+// `packages/mcp/`. The existing canonical-eval CLI runs from the repo
+// root and relies on `process.cwd()`; mirroring that here would break
+// the per-package `bun run test` workflow.
+const REPO_ROOT = path.resolve(import.meta.dir, "..", "..", "..", "..");
+const SEMANTIC_DIR = path.join(REPO_ROOT, "semantic");
+const SEED_SEMANTIC_DIR = path.join(
+  REPO_ROOT,
+  "packages",
+  "cli",
+  "data",
+  "seeds",
+  "ecommerce",
+  "semantic",
+);
+const SEMANTIC_BACKUP_DIR = path.join(REPO_ROOT, ".semantic-backup-mcp-eval");
+
+const ORG_ID = "org_canonical_eval";
+const SUB_ID = "user_canonical_eval";
+const CLIENT_ID = "atlas-canonical-mcp-eval";
+const TOKEN = "fake.canonical.eval.token";
+
+interface ServerHandle {
+  url: string;
+  close: () => void;
+}
+
+let server: ServerHandle | undefined;
+
+beforeAll(async () => {
+  // Stage the demo semantic layer — same dance the deterministic eval
+  // uses. Restoration runs in `afterAll`; failure to restore is loud
+  // because a partial restore would silently change the user's working
+  // tree.
+  if (fs.existsSync(SEMANTIC_BACKUP_DIR)) {
+    fs.rmSync(SEMANTIC_BACKUP_DIR, { recursive: true });
+  }
+  if (fs.existsSync(SEMANTIC_DIR)) {
+    fs.cpSync(SEMANTIC_DIR, SEMANTIC_BACKUP_DIR, { recursive: true });
+    fs.rmSync(SEMANTIC_DIR, { recursive: true });
+  }
+  if (!fs.existsSync(SEED_SEMANTIC_DIR)) {
+    throw new Error(
+      `Demo seed semantic layer not found at ${SEED_SEMANTIC_DIR}. ` +
+        `Cannot run MCP eval without it.`,
+    );
+  }
+  fs.cpSync(SEED_SEMANTIC_DIR, SEMANTIC_DIR, { recursive: true });
+
+  // Reset semantic-layer caches so the freshly installed YAMLs are
+  // re-resolved by the in-process MCP server.
+  const { _resetWhitelists } = await import("@atlas/api/lib/semantic");
+  _resetWhitelists();
+
+  // Bind the test bearer to a workspace-scoped JWT payload.
+  mockVerifyAccessToken.mockImplementation(async (token: string) => {
+    if (token === TOKEN) {
+      return {
+        sub: SUB_ID,
+        jti: "jti_canonical",
+        azp: CLIENT_ID,
+        scope: "openid mcp:read",
+        [WORKSPACE_CLAIM]: ORG_ID,
+      } satisfies FakeJwtPayload;
+    }
+    throw new Error(`Unknown token in mcp-eval: ${token}`);
+  });
+
+  // Boot the real router on a random port. We do this once and share
+  // the address across every `it` so the prompts/list, tools/list, and
+  // per-question dispatches all hit the same in-process server.
+  const { Hono } = await import("hono");
+  const { createHostedMcpRouter } = await import("@atlas/mcp/hosted");
+  const app = new Hono();
+  app.route("/mcp", createHostedMcpRouter());
+  const handle = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    fetch: app.fetch,
+  });
+  if (typeof handle.port !== "number") {
+    handle.stop(true);
+    throw new Error("Bun.serve did not bind a TCP port for the MCP eval");
+  }
+  server = {
+    url: `http://localhost:${handle.port}`,
+    close: () => handle.stop(true),
+  };
+});
+
+afterAll(async () => {
+  server?.close();
+  server = undefined;
+  const { _resetHostedSessions } = await import("@atlas/mcp/hosted");
+  await _resetHostedSessions();
+
+  // Restore semantic layer no matter what; surface failure loudly.
+  if (fs.existsSync(SEMANTIC_BACKUP_DIR)) {
+    if (fs.existsSync(SEMANTIC_DIR)) {
+      fs.rmSync(SEMANTIC_DIR, { recursive: true });
+    }
+    fs.cpSync(SEMANTIC_BACKUP_DIR, SEMANTIC_DIR, { recursive: true });
+    fs.rmSync(SEMANTIC_BACKUP_DIR, { recursive: true });
+  } else if (fs.existsSync(SEMANTIC_DIR)) {
+    // No backup means there was nothing in semantic/ before — clean up.
+    fs.rmSync(SEMANTIC_DIR, { recursive: true });
+  }
+
+  mock.restore();
+});
+
+afterEach(async () => {
+  const { _resetHostedSessions } = await import("@atlas/mcp/hosted");
+  await _resetHostedSessions();
+});
+
+function newClient(): EvalMcpClient {
+  if (!server) throw new Error("MCP eval server not started");
+  return new EvalMcpClient({
+    baseUrl: server.url,
+    workspaceId: ORG_ID,
+    bearer: TOKEN,
+  });
+}
+
+// ── Per-question dispatch ─────────────────────────────────────────
+
+interface QuestionOutcome {
+  readonly questionId: string;
+  readonly status: "pass" | "fail";
+  readonly latencyMs: number;
+  readonly artifact?: McpFailureArtifact;
+}
+
+async function runOneQuestion(
+  client: EvalMcpClient,
+  q: Question,
+): Promise<QuestionOutcome> {
+  const start = Date.now();
+  const fail = (
+    category: FailureCategory,
+    summary: string,
+    detail: { tool: string | null; args: Record<string, unknown>; response: unknown; expected: unknown },
+  ): QuestionOutcome => {
+    const latencyMs = Date.now() - start;
+    return {
+      questionId: q.id,
+      status: "fail",
+      latencyMs,
+      artifact: {
+        questionId: q.id,
+        category,
+        latencyMs,
+        ...detail,
+        summary,
+      },
+    };
+  };
+
+  try {
+    switch (q.mode) {
+      case "metric": {
+        const tool = "runMetric";
+        const args = { id: q.metric_id };
+        const result = await client.callTool(tool, args);
+        const parsed = extractToolJson(result);
+        if (parsed.kind === "unparseable") {
+          return fail("protocol", `runMetric returned non-JSON content`, {
+            tool,
+            args,
+            response: parsed.raw,
+            expected: "JSON envelope or success object",
+          });
+        }
+        if (parsed.kind === "error") {
+          return fail("recovery", `runMetric returned error envelope for known metric`, {
+            tool,
+            args,
+            response: parsed.envelope,
+            expected: { id: q.metric_id, success: true },
+          });
+        }
+        const data = parsed.data as { id?: unknown; sql?: unknown };
+        if (data.id !== q.metric_id) {
+          return fail("protocol", `runMetric envelope id mismatch`, {
+            tool,
+            args,
+            response: data,
+            expected: { id: q.metric_id },
+          });
+        }
+        if (typeof data.sql !== "string" || data.sql.length === 0) {
+          return fail("protocol", `runMetric envelope missing sql`, {
+            tool,
+            args,
+            response: data,
+            expected: "non-empty sql string",
+          });
+        }
+        return { questionId: q.id, status: "pass", latencyMs: Date.now() - start };
+      }
+      case "glossary": {
+        const tool = "searchGlossary";
+        const args = { term: q.term };
+        const result = await client.callTool(tool, args);
+        const parsed = extractToolJson(result);
+        if (parsed.kind === "unparseable") {
+          return fail("protocol", `searchGlossary returned non-JSON content`, {
+            tool,
+            args,
+            response: parsed.raw,
+            expected: "JSON envelope or matches[]",
+          });
+        }
+        const expectedStatus = q.expect.status ?? null;
+        if (expectedStatus === "ambiguous") {
+          if (parsed.kind !== "error") {
+            return fail("recovery", `searchGlossary did not return ambiguous_term envelope`, {
+              tool,
+              args,
+              response: parsed.data,
+              expected: { code: "ambiguous_term" },
+            });
+          }
+          const env = parsed.envelope as { code?: unknown; hint?: unknown };
+          if (env.code !== "ambiguous_term") {
+            return fail("recovery", `searchGlossary envelope code is ${String(env.code)}, expected ambiguous_term`, {
+              tool,
+              args,
+              response: env,
+              expected: { code: "ambiguous_term" },
+            });
+          }
+          if (typeof env.hint !== "string" || env.hint.length === 0) {
+            return fail("recovery", `ambiguous_term envelope missing hint`, {
+              tool,
+              args,
+              response: env,
+              expected: { code: "ambiguous_term", hint: "<non-empty>" },
+            });
+          }
+          return { questionId: q.id, status: "pass", latencyMs: Date.now() - start };
+        }
+        // Defined / no-status path — success envelope expected.
+        if (parsed.kind === "error") {
+          return fail("recovery", `searchGlossary returned error envelope on a defined term`, {
+            tool,
+            args,
+            response: parsed.envelope,
+            expected: "success matches[]",
+          });
+        }
+        return { questionId: q.id, status: "pass", latencyMs: Date.now() - start };
+      }
+      case "pattern": {
+        // The MCP semantic toolset doesn't expose query_patterns directly
+        // — `describeEntity` returns the entity, callers extract the
+        // pattern, then dispatch via `executeSQL`. Validate the
+        // describeEntity round-trip surfaces the expected pattern name.
+        const tool = "describeEntity";
+        const args = { name: q.entity };
+        const result = await client.callTool(tool, args);
+        const parsed = extractToolJson(result);
+        if (parsed.kind === "unparseable") {
+          return fail("protocol", `describeEntity returned non-JSON content`, {
+            tool,
+            args,
+            response: parsed.raw,
+            expected: "JSON entity envelope",
+          });
+        }
+        if (parsed.kind === "error") {
+          return fail("recovery", `describeEntity returned error envelope for a known entity`, {
+            tool,
+            args,
+            response: parsed.envelope,
+            expected: { found: true },
+          });
+        }
+        const entity = (parsed.data as { entity?: { query_patterns?: Array<{ name?: string }> } }).entity;
+        const patterns = entity?.query_patterns ?? [];
+        if (!patterns.some((p) => p.name === q.pattern)) {
+          return fail("assertion", `describeEntity result missing query_pattern "${q.pattern}"`, {
+            tool,
+            args,
+            response: { patterns: patterns.map((p) => p.name) },
+            expected: { has_pattern: q.pattern },
+          });
+        }
+        return { questionId: q.id, status: "pass", latencyMs: Date.now() - start };
+      }
+      case "virtual": {
+        // Virtual dimensions exercise raw SQL through the MCP `executeSQL`
+        // tool. With executeSQL mocked the wire-shape is what we assert.
+        const tool = "executeSQL";
+        const args = {
+          sql: q.sql,
+          explanation: `mcp-eval ${q.id}`,
+        };
+        const result = await client.callTool(tool, args);
+        const parsed = extractToolJson(result);
+        if (parsed.kind === "unparseable") {
+          return fail("protocol", `executeSQL returned non-JSON content`, {
+            tool,
+            args,
+            response: parsed.raw,
+            expected: "JSON tool result",
+          });
+        }
+        if (parsed.kind === "error") {
+          return fail("recovery", `executeSQL returned error envelope for valid virtual SQL`, {
+            tool,
+            args,
+            response: parsed.envelope,
+            expected: "success",
+          });
+        }
+        return { questionId: q.id, status: "pass", latencyMs: Date.now() - start };
+      }
+      default: {
+        const _exhaustive: never = q;
+        throw new Error(`unreachable mode: ${String(_exhaustive)}`);
+      }
+    }
+  } catch (err) {
+    return fail("protocol", `dispatch threw: ${err instanceof Error ? err.message : String(err)}`, {
+      tool: null,
+      args: {},
+      response: { error: err instanceof Error ? err.message : String(err) },
+      expected: "successful round-trip",
+    });
+  }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+describe("MCP path canonical eval (#2074)", () => {
+  it("registers the expected tool surface", async () => {
+    const client = newClient();
+    try {
+      await client.connect();
+      const tools = await client.listTools();
+      const names = tools.map((t) => t.name).sort();
+      // Expected toolset — adding a tool here means an explicit decision
+      // in the eval. A change at the `registerTools` / `registerSemanticTools`
+      // call sites should land in lockstep with this assertion.
+      expect(names).toEqual([
+        "describeEntity",
+        "executeSQL",
+        "explore",
+        "listEntities",
+        "runMetric",
+        "searchGlossary",
+      ]);
+      // Every tool must carry a description — the agent's tool-selection
+      // accuracy is gated by description quality.
+      for (const t of tools) {
+        expect(t.description, `tool ${t.name} missing description`).toBeTruthy();
+      }
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("exposes prompts/list without crashing", async () => {
+    const client = newClient();
+    try {
+      await client.connect();
+      // The semantic-layer prompts library may or may not be populated
+      // in this fixture (the demo seed registers query_patterns as
+      // prompts via registerPrompts). We assert the call does not
+      // throw and returns an array — the shape contract.
+      const prompts = await client.listPrompts();
+      expect(Array.isArray(prompts)).toBe(true);
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("returns unknown_metric envelope for an unrecognized metric id", async () => {
+    const client = newClient();
+    try {
+      await client.connect();
+      const result = await client.callTool("runMetric", { id: "this_metric_does_not_exist_xyz" });
+      const parsed = extractToolJson(result);
+      expect(parsed.kind).toBe("error");
+      if (parsed.kind === "error") {
+        const env = parsed.envelope as { code?: unknown };
+        expect(env.code).toBe("unknown_metric");
+      }
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("returns unknown_entity envelope for an unrecognized entity name", async () => {
+    const client = newClient();
+    try {
+      await client.connect();
+      const result = await client.callTool("describeEntity", { name: "ZZZNotARealEntityZZZ" });
+      const parsed = extractToolJson(result);
+      expect(parsed.kind).toBe("error");
+      if (parsed.kind === "error") {
+        const env = parsed.envelope as { code?: unknown; hint?: unknown };
+        expect(env.code).toBe("unknown_entity");
+        expect(env.hint).toBeTruthy();
+      }
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("dispatches every canonical question through MCP and reports per-question outcome", async () => {
+    const questions = loadQuestions(DEFAULT_QUESTIONS_PATH);
+    expect(questions.length).toBeGreaterThanOrEqual(20);
+
+    const client = newClient();
+    const outcomes: QuestionOutcome[] = [];
+    try {
+      await client.connect();
+      for (const q of questions) {
+        outcomes.push(await runOneQuestion(client, q));
+      }
+    } finally {
+      await client.close();
+    }
+
+    const passing = outcomes.filter((o) => o.status === "pass").length;
+    const failures = outcomes.filter((o) => o.status === "fail");
+
+    process.stdout.write(
+      `\nMCP canonical eval: ${passing}/${outcomes.length} passing\n`,
+    );
+    if (failures.length > 0) {
+      process.stdout.write(
+        formatArtifactBundle(failures.flatMap((f) => (f.artifact ? [f.artifact] : []))),
+      );
+    }
+
+    // Acceptance criterion (Phase 1 deterministic): every canonical
+    // question round-trips through MCP without protocol / recovery /
+    // assertion failure. If this drops below 20/20 something on the
+    // MCP path regressed and the artifacts above explain what.
+    expect(failures, formatArtifactBundle(failures.flatMap((f) => (f.artifact ? [f.artifact] : [])))).toEqual([]);
+  });
+});
+
+describe("MCP path stress (#2074, partial #2070)", () => {
+  it("opens N concurrent sessions through the route without contention", async () => {
+    const N = 5;
+    const clients = Array.from({ length: N }, () => newClient());
+    try {
+      await Promise.all(clients.map((c) => c.connect()));
+      // Every session can dispatch independently — no shared mutable
+      // state should leak between them. We hit `tools/list` per client
+      // (cheapest dispatch) and assert the surface is identical, which
+      // catches a session-binding regression where one client's
+      // registration pollutes another's view.
+      const surfaces = await Promise.all(clients.map((c) => c.listTools()));
+      const reference = [...surfaces[0]].map((t) => t.name).sort().join(",");
+      for (const s of surfaces) {
+        expect([...s].map((t) => t.name).sort().join(",")).toEqual(reference);
+      }
+    } finally {
+      await Promise.all(clients.map((c) => c.close()));
+    }
+  });
+});

--- a/packages/mcp/src/__tests__/canonical-mcp-failure-artifact.ts
+++ b/packages/mcp/src/__tests__/canonical-mcp-failure-artifact.ts
@@ -9,8 +9,9 @@
  * Categories:
  *   - `protocol`        wire shape changed (missing fields, wrong content[]
  *                       layout, isError on a success path, etc.)
- *   - `tool_selection`  the LLM picked the wrong tool (only meaningful in
- *                       --mcp-llm; emitted by Phase 2)
+ *   - `tool_selection`  reserved for the Phase 2 `--mcp-llm` mode (#2119)
+ *                       where an LLM picks tools through MCP and a wrong
+ *                       pick is the regression — Phase 1 never emits this
  *   - `recovery`        an `ambiguous_term` envelope came back without
  *                       possible_mappings, an `unknown_metric` came back
  *                       without a `hint`, etc.
@@ -83,6 +84,9 @@ function stringifyClipped(value: unknown): string {
   try {
     s = typeof value === "string" ? value : JSON.stringify(value);
   } catch {
+    // intentionally ignored: cyclic / non-JSON-serializable values fall
+    // back to `String(value)` so the artifact is still printable; the
+    // dump is for human triage, not round-tripping.
     s = String(value);
   }
   if (s.length <= MAX_DUMP_LEN) return s;

--- a/packages/mcp/src/__tests__/canonical-mcp-failure-artifact.ts
+++ b/packages/mcp/src/__tests__/canonical-mcp-failure-artifact.ts
@@ -1,0 +1,90 @@
+/**
+ * Structured failure artifact for the MCP-path canonical eval (#2074).
+ *
+ * Every failed question produces one artifact: the wire frame the eval
+ * sent, the response we got back, the response we expected, and a
+ * machine-readable category so a future reader (human or LLM) can
+ * reason about the regression without re-running the eval.
+ *
+ * Categories:
+ *   - `protocol`        wire shape changed (missing fields, wrong content[]
+ *                       layout, isError on a success path, etc.)
+ *   - `tool_selection`  the LLM picked the wrong tool (only meaningful in
+ *                       --mcp-llm; emitted by Phase 2)
+ *   - `recovery`        an `ambiguous_term` envelope came back without
+ *                       possible_mappings, an `unknown_metric` came back
+ *                       without a `hint`, etc.
+ *   - `latency`         frame round-trip exceeded the baseline by >25%
+ *   - `assertion`       eval-level assertion failed (row count, sql_pattern,
+ *                       non_zero, expected status). The most common case.
+ */
+
+export type FailureCategory =
+  | "protocol"
+  | "tool_selection"
+  | "recovery"
+  | "latency"
+  | "assertion";
+
+export interface McpFailureArtifact {
+  readonly questionId: string;
+  readonly category: FailureCategory;
+  /** Tool name dispatched, or `null` for non-tool dispatches (prompts/list). */
+  readonly tool: string | null;
+  /** Args passed to the tool (or empty for prompts/list). */
+  readonly args: Readonly<Record<string, unknown>>;
+  /** Round-trip latency in milliseconds — useful for trend tracking. */
+  readonly latencyMs: number;
+  /** Response we got back — already parsed from JSON when possible. */
+  readonly response: unknown;
+  /** What the eval expected. Free-form per category. */
+  readonly expected: unknown;
+  /** One-line human summary. Goes into the printed eval log. */
+  readonly summary: string;
+}
+
+/**
+ * Format a single artifact as a multi-line block. Rendered into the eval
+ * log so a CI failure carries enough context to act on without rerunning.
+ * The diff is intentionally a JSON dump rather than a unified-diff —
+ * callers can pipe through `jq` / a diff tool of choice.
+ */
+export function formatArtifact(a: McpFailureArtifact): string {
+  const lines: string[] = [];
+  lines.push(`-- ${a.questionId} [${a.category}] ${a.summary}`);
+  lines.push(`   tool: ${a.tool ?? "<none>"}  latency: ${a.latencyMs}ms`);
+  if (Object.keys(a.args).length > 0) {
+    lines.push(`   args:     ${JSON.stringify(a.args)}`);
+  }
+  lines.push(`   response: ${stringifyClipped(a.response)}`);
+  lines.push(`   expected: ${stringifyClipped(a.expected)}`);
+  return lines.join("\n");
+}
+
+export function formatArtifactBundle(
+  artifacts: readonly McpFailureArtifact[],
+): string {
+  if (artifacts.length === 0) return "";
+  const lines: string[] = [];
+  lines.push("");
+  lines.push("Failure artifacts");
+  lines.push("-----------------");
+  for (const a of artifacts) {
+    lines.push(formatArtifact(a));
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+const MAX_DUMP_LEN = 800;
+
+function stringifyClipped(value: unknown): string {
+  let s: string;
+  try {
+    s = typeof value === "string" ? value : JSON.stringify(value);
+  } catch {
+    s = String(value);
+  }
+  if (s.length <= MAX_DUMP_LEN) return s;
+  return `${s.slice(0, MAX_DUMP_LEN)}… [+${s.length - MAX_DUMP_LEN} chars]`;
+}


### PR DESCRIPTION
Closes Phase 1 of #2074. Phase 2 follow-up tracked in #2119.

## Summary

- Every canonical question now dispatches through the real `createHostedMcpRouter()` mounted on `Bun.serve`, exercising the full Streamable-HTTP transport, tool dispatch, error envelopes, `prompts/list` shape, and concurrent sessions.
- New CI job `canonical-mcp-eval (deterministic)` alongside the existing SQL eval — same policy: PR-informational, tag-blocking.
- Phase 1 mocks `verifyAccessToken` (matches existing `hosted.test.ts` pattern) + `executeSQL.execute` (SQL correctness already owned by the deterministic SQL eval). Phase 2 lands the real DCR + PKCE flow + `--mcp-llm` mode + release-tag-blocking LLM CI gate — see #2119.

## Why this gap exists

The existing deterministic eval (`packages/cli/bin/canonical-eval.ts`) calls `findMetricById` and executes the resolved SQL directly. It never traverses the MCP transport. Production traffic hits the hosted MCP endpoint, so a regression in any of these would ship green:

- A malformed `AtlasMcpToolError` envelope shape
- `prompts/list` returning the wrong format
- Tool description regressions degrading LLM tool selection
- Session-cap TOCTOU races (`ATLAS_MCP_MAX_SESSIONS`)
- JWT verification subtly broken under load (Phase 2 closes — Phase 1 mocks the verifier)

This PR adds the protocol-layer gate.

## What's in this PR

| File | What it does |
|---|---|
| `packages/mcp/src/__tests__/canonical-mcp-client.ts` | `EvalMcpClient` wrapper around `Client` + `StreamableHTTPClientTransport`. `extractToolJson` normalises the `CallToolResult` content[] envelope so callers compare structured data, not prose. |
| `packages/mcp/src/__tests__/canonical-mcp-failure-artifact.ts` | Wire frame + response + expected + regression category (`protocol` / `tool_selection` / `recovery` / `latency` / `assertion`). Bundle prints to the eval log so a CI failure carries enough context to act on without re-running. |
| `packages/mcp/src/__tests__/canonical-mcp-eval.evalspec.ts` | 6-test `bun:test` file. 20/20 canonical questions round-trip through MCP; `tools/list`, `prompts/list`, `unknown_metric`, `unknown_entity`, and a 5-session stress test all assert. `.evalspec.ts` extension keeps it out of `bun test` default discovery — invoked explicitly by CI. |
| `.github/workflows/eval.yml` | New `canonical-mcp-eval-deterministic` job. Trigger paths cover the MCP route, auth surface, and eval helpers. |
| `apps/docs/content/docs/contributing/eval-harness.mdx` | Phase split, failure artifact format, CI gate policy. |

## Phase split (clearly scoped)

**Phase 1 (this PR):**
- Mocks `verifyAccessToken` and `executeSQL.execute`
- Validates the MCP **protocol** layer end-to-end
- Coverage: transport, dispatch, envelopes, prompts list shape, recovery contracts, concurrent sessions

**Phase 2 (#2119):**
- Real DCR + PKCE flow against an in-process Better Auth instance — closes the JWT signature path
- `--mcp-llm` mode: LLM-on-client picks tools through MCP — validates tool selection accuracy + recovery contract under prose drift
- Release-tag-blocking `eval-mcp-llm` CI job
- Concurrent stress under real auth (full coverage of #2070 ties in here)

## Local results

```
$ bun test ./packages/mcp/src/__tests__/canonical-mcp-eval.evalspec.ts
 6 pass
 0 fail
 20 expect() calls
Ran 6 tests across 1 file. [536.00ms]

$ bun run --filter '@atlas/mcp' test
 173 pass
 0 fail
 457 expect() calls
Ran 173 tests across 12 files. [697.00ms]
```

The new eval doesn't pollute the existing `bun test` discovery — pre-existing 173 tests stay green.

## Test plan

- [x] `bun test ./packages/mcp/src/__tests__/canonical-mcp-eval.evalspec.ts` — 6/6 pass, 20 questions through MCP
- [x] `bun run --filter '@atlas/mcp' test` — 173/173 pass (eval not auto-discovered)
- [x] `bun run lint`
- [x] `bun run type` (clean)
- [x] `bun x syncpack lint` (no issues)
- [x] `bash scripts/check-template-drift.sh` (501 files verified)
- [x] `bash scripts/check-railway-watch.sh` (all COPY sources covered)
- [x] api `--affected` mode reports zero changed-files-with-tests (correct — this PR doesn't touch `@atlas/api`)
- [ ] CI green on the new `canonical-mcp-eval-deterministic` job