### PR TITLE
feat(eval,mcp): #2119 Phase 2 part A — real OAuth round-trip in canonical MCP eval

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -58,6 +58,12 @@ on:
       - "packages/mcp/package.json"
       - "packages/api/src/lib/auth/server.ts"
       - "packages/api/src/lib/auth/oauth-claims.ts"
+      # Phase 2 (#2119) — the in-process OAuth helper + the published
+      # @useatlas/mcp/init flow it drives. A drift in either trips the
+      # auth-helper smoke test in the same job, so the trigger paths
+      # cover both even though only the eval job depends on them.
+      - "plugins/mcp/src/init/hosted.ts"
+      - "plugins/mcp/src/init/index.ts"
       - ".github/workflows/eval.yml"
   push:
     tags:
@@ -120,15 +126,20 @@ jobs:
           DATABASE_URL: postgres://atlas:atlas@127.0.0.1:5432/atlas
         run: bun packages/cli/bin/atlas.ts canonical-eval
 
-  # MCP-path eval (#2074, Phase 1). Runs every canonical question through
-  # the real `createHostedMcpRouter` mounted on `Bun.serve`, exercising
-  # transport / dispatch / envelope / prompts shape / concurrent sessions
-  # / session-cap enforcement. `verifyAccessToken` is mocked — #2119
-  # lands the full DCR + PKCE flow + LLM-on-client mode.
+  # MCP-path eval (#2074, Phase 1; #2119, Phase 2 part A). Runs every
+  # canonical question through the real `createHostedMcpRouter` mounted
+  # on `Bun.serve`, exercising transport / dispatch / envelope / prompts
+  # shape / concurrent sessions / session-cap enforcement. Phase 2 part A
+  # (#2119) replaces the `verifyAccessToken` mock with a real OAuth 2.1
+  # round-trip against an in-process Better Auth instance — the issued
+  # JWT goes through real signature verification + JWKS resolution, so a
+  # regression in the JWT-path now fails this gate. The auth-helper
+  # smoke test (`canonical-mcp-auth.test.ts`) runs first so a regression
+  # in the helper trips before the full evalspec.
   #
   # No Postgres needed: the eval mocks `executeSQL` so SQL correctness is
   # owned by the deterministic job above. This job is purely the MCP
-  # **protocol** gate.
+  # **protocol + JWT** gate.
   canonical-mcp-eval-deterministic:
     name: canonical-mcp-eval (deterministic)
     runs-on: ubuntu-latest
@@ -148,6 +159,9 @@ jobs:
 
       - name: Build @useatlas/types (resolves api imports)
         run: bun run --filter '@useatlas/types' build
+
+      - name: Run MCP auth helper smoke test (#2119)
+        run: bun test ./packages/mcp/src/__tests__/canonical-mcp-auth.test.ts
 
       - name: Run MCP-path canonical eval
         run: bun test ./packages/mcp/src/__tests__/canonical-mcp-eval.evalspec.ts

--- a/apps/docs/content/docs/contributing/eval-harness.mdx
+++ b/apps/docs/content/docs/contributing/eval-harness.mdx
@@ -109,12 +109,13 @@ bun test ./packages/mcp/src/__tests__/canonical-mcp-eval.evalspec.ts
 
 **Phase split:**
 
-- **Phase 1 (shipped):** mocks `verifyAccessToken` and `executeSQL.execute`. Validates the MCP **protocol** layer end-to-end. SQL correctness is owned by the deterministic eval above; this eval owns the MCP path.
-- **Phase 2 ([#2119](https://github.com/AtlasDevHQ/atlas/issues/2119)):** real DCR + PKCE flow against an in-process Better Auth instance — closes the JWT-signature gap. Adds `--mcp-llm` mode where an LLM picks tools through MCP and validates tool-selection accuracy + recovery contract under prose drift.
+- **Phase 1 (shipped, [#2074](https://github.com/AtlasDevHQ/atlas/issues/2074)):** mocked `verifyAccessToken` and `executeSQL.execute`. Validated the MCP **protocol** layer end-to-end. SQL correctness is owned by the deterministic eval above; this eval owns the MCP path.
+- **Phase 2 part A (shipped, [#2119](https://github.com/AtlasDevHQ/atlas/issues/2119)):** dropped the `verifyAccessToken` mock. The eval now boots an in-process Better Auth instance with the same `jwt()` + `oauthProvider()` plugins production uses, drives the real OAuth 2.1 loopback flow via `runHostedAuthFlow`'s test seams, and dispatches every canonical question with a JWT signed by the in-process JWKS. The auth-helper smoke test (`canonical-mcp-auth.test.ts`) runs first in the same CI job so a regression in the helper trips before the full evalspec.
+- **Phase 2 part B (planned, follow-up to #2119):** `--mcp-llm` mode where an LLM picks tools through MCP and validates tool-selection accuracy + recovery contract under prose drift.
 
 **Failure artifacts.** Every failed dispatch produces a structured artifact (`packages/mcp/src/__tests__/canonical-mcp-failure-artifact.ts`) carrying the wire frame sent, the response received, the response expected, and a regression category — `protocol` / `tool_selection` / `recovery` / `latency` / `assertion`. The artifact bundle prints to the eval log so a CI failure carries enough context to act on without re-running.
 
-**CI gate.** A separate job — `canonical-mcp-eval (deterministic)` — runs alongside the deterministic SQL eval; the [CI policy](#ci-policy) table above governs both. Trigger paths cover the MCP route, the auth surface that issues / verifies bearers, and the eval helpers themselves.
+**CI gate.** A separate job — `canonical-mcp-eval (deterministic)` — runs alongside the deterministic SQL eval; the [CI policy](#ci-policy) table above governs both. Trigger paths cover the MCP route, the auth surface that issues / verifies bearers, the eval helpers themselves, and the upstream `runHostedAuthFlow` in `plugins/mcp/src/init/` that Phase 2 drives.
 
 ## Out of scope
 

--- a/bun.lock
+++ b/bun.lock
@@ -213,6 +213,7 @@
         "hono": "^4.12.9",
       },
       "devDependencies": {
+        "@better-auth/oauth-provider": "^1.6.9",
         "zod": "^4.3.6",
       },
     },

--- a/packages/api/src/lib/auth/oauth-claims.ts
+++ b/packages/api/src/lib/auth/oauth-claims.ts
@@ -25,3 +25,29 @@
  */
 export const ATLAS_OAUTH_WORKSPACE_CLAIM =
   "https://atlas.useatlas.dev/workspace_id";
+
+/**
+ * Read the active workspace id off a Better Auth session. The
+ * `activeOrganizationId` field is contributed by the organization
+ * plugin and is not part of the base session type the `oauthProvider`
+ * hooks see — every consumer either casts inline or calls this helper.
+ *
+ * Returns `undefined` when the session has no active workspace OR the
+ * field is empty: a token issued without a real workspace binding must
+ * not carry the URN claim, and the empty string is never a valid
+ * workspace identifier downstream.
+ *
+ * Three sites read this:
+ *   1. `oauthProvider.clientReference` — DCR client ownership.
+ *   2. `oauthProvider.postLogin.consentReferenceId` — the value
+ *      stamped onto issued JWTs as the workspace claim.
+ *   3. The canonical MCP eval's parallel `oauthProvider` config — so
+ *      the eval and production share one source of truth and a
+ *      regression in one site shows up in the other.
+ */
+export function readActiveOrgId(
+  session: { activeOrganizationId?: string | null } | null | undefined,
+): string | undefined {
+  const orgId = session?.activeOrganizationId;
+  return typeof orgId === "string" && orgId.length > 0 ? orgId : undefined;
+}

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -22,7 +22,7 @@ import { passkey } from "@better-auth/passkey";
 import { scim } from "@better-auth/scim";
 import { stripe as stripePlugin } from "@better-auth/stripe";
 import { oauthProvider } from "@better-auth/oauth-provider";
-import { ATLAS_OAUTH_WORKSPACE_CLAIM } from "@atlas/api/lib/auth/oauth-claims";
+import { ATLAS_OAUTH_WORKSPACE_CLAIM, readActiveOrgId } from "@atlas/api/lib/auth/oauth-claims";
 import { recordOAuthTokenRefresh } from "@atlas/api/lib/auth/oauth-refresh-audit";
 import Stripe from "stripe";
 import { getInternalDB, hasInternalDB, internalQuery, updateWorkspacePlanTier, updateWorkspaceStatus, type InternalPool, type PlanTier } from "@atlas/api/lib/db/internal";
@@ -818,14 +818,12 @@ function buildPlugins() {
       // `clientReference` controls *ownership* of the OAuth client row
       // (used by /list, /delete, /update endpoints to filter "rows for
       // this workspace") — it does NOT propagate onto issued tokens.
-      // The cast is required because Better Auth's session-organization
-      // extension is contributed by the organization plugin and isn't
-      // part of the base session type the oauthProvider sees.
-      clientReference: ({ session }) => {
-        const orgId = (session as { activeOrganizationId?: string | null } | null | undefined)
-          ?.activeOrganizationId;
-        return typeof orgId === "string" ? orgId : undefined;
-      },
+      // `readActiveOrgId` (oauth-claims.ts) is the shared reader so
+      // production and the canonical MCP eval can't drift on what
+      // counts as a valid workspace binding (e.g. empty-string
+      // handling).
+      clientReference: ({ session }) =>
+        readActiveOrgId(session as Parameters<typeof readActiveOrgId>[0]),
       // The `referenceId` parameter that `customAccessTokenClaims`
       // receives is whatever `postLogin.consentReferenceId` returned
       // at authorize time — `clientReference` only governs DCR client
@@ -843,11 +841,8 @@ function buildPlugins() {
       // but is never navigated to under this `shouldRedirect` value.
       postLogin: {
         page: "/oauth2/post-login",
-        consentReferenceId: async ({ session }) => {
-          const orgId = (session as { activeOrganizationId?: string | null } | null | undefined)
-            ?.activeOrganizationId;
-          return typeof orgId === "string" && orgId.length > 0 ? orgId : undefined;
-        },
+        consentReferenceId: async ({ session }) =>
+          readActiveOrgId(session as Parameters<typeof readActiveOrgId>[0]),
         shouldRedirect: () => false,
       },
       // Stamp the workspace id onto access tokens issued under a

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -814,16 +814,41 @@ function buildPlugins() {
       // that doc in lockstep with the defaults above.
       accessTokenExpiresIn: resolveAccessTokenTtlSeconds(process.env),
       refreshTokenExpiresIn: resolveRefreshTokenTtlSeconds(process.env),
-      // Bind issued tokens to the authenticating user's active workspace
-      // so a token issued under workspace A cannot query workspace B's
-      // data through the hosted MCP endpoint. The cast is required
-      // because Better Auth's session-organization extension is
-      // contributed by the organization plugin and isn't part of the
-      // base session type the oauthProvider sees.
+      // Tag the registered DCR client with the workspace it belongs to.
+      // `clientReference` controls *ownership* of the OAuth client row
+      // (used by /list, /delete, /update endpoints to filter "rows for
+      // this workspace") — it does NOT propagate onto issued tokens.
+      // The cast is required because Better Auth's session-organization
+      // extension is contributed by the organization plugin and isn't
+      // part of the base session type the oauthProvider sees.
       clientReference: ({ session }) => {
         const orgId = (session as { activeOrganizationId?: string | null } | null | undefined)
           ?.activeOrganizationId;
         return typeof orgId === "string" ? orgId : undefined;
+      },
+      // The `referenceId` parameter that `customAccessTokenClaims`
+      // receives is whatever `postLogin.consentReferenceId` returned
+      // at authorize time — `clientReference` only governs DCR client
+      // ownership, not token claims. Without this hook, `referenceId`
+      // is always undefined, `customAccessTokenClaims` short-circuits
+      // to `{}`, and every issued JWT is rejected at the MCP edge with
+      // `missing_workspace_claim`. See #2124 for the gap this closes
+      // and `customAccessTokenClaims` below for the consuming half.
+      //
+      // `shouldRedirect: () => false` is what skips the post-login
+      // interstitial — Atlas binds tokens to the session's already-
+      // active workspace (organization plugin tracks one active org
+      // per session) so the user has no further selection to make.
+      // The `page` field is required by Better Auth's options shape
+      // but is never navigated to under this `shouldRedirect` value.
+      postLogin: {
+        page: "/oauth2/post-login",
+        consentReferenceId: async ({ session }) => {
+          const orgId = (session as { activeOrganizationId?: string | null } | null | undefined)
+            ?.activeOrganizationId;
+          return typeof orgId === "string" && orgId.length > 0 ? orgId : undefined;
+        },
+        shouldRedirect: () => false,
       },
       // Stamp the workspace id onto access tokens issued under a
       // session that carries an active workspace. Tokens issued without
@@ -834,6 +859,8 @@ function buildPlugins() {
       // Claim key is sourced from `oauth-claims.ts` so production
       // issuance, MCP verification, and the test fixture share one
       // literal — drift between sites silently breaks every token.
+      // The `referenceId` argument here is sourced from `postLogin.
+      // consentReferenceId` above — see that hook for why.
       customAccessTokenClaims: ({ referenceId }) => {
         return referenceId
           ? { [ATLAS_OAUTH_WORKSPACE_CLAIM]: referenceId }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -27,6 +27,7 @@
     "hono": "^4.12.9"
   },
   "devDependencies": {
+    "@better-auth/oauth-provider": "^1.6.9",
     "zod": "^4.3.6"
   }
 }

--- a/packages/mcp/src/__tests__/canonical-mcp-auth.test.ts
+++ b/packages/mcp/src/__tests__/canonical-mcp-auth.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Smoke test for the Phase 2 OAuth round-trip helper (#2119).
+ *
+ * Boots the in-process Better Auth + MCP server, runs the loopback flow,
+ * and asserts the returned bearer is a real JWT with the expected `iss`,
+ * `aud`, and workspace claim. If any of those drift, every dispatch in
+ * `canonical-mcp-eval.evalspec.ts` will 401 — failing here narrows the
+ * blast radius to one assertion file instead of every eval question.
+ *
+ * The evalspec depends on this helper working correctly. This test runs
+ * BEFORE the evalspec in alphabetical order (auth.test < eval.evalspec)
+ * so a regression in the helper trips here first with a precise message.
+ *
+ * Mocks `@atlas/api/lib/db/internal` and `@atlas/api/lib/audit` because
+ * the MCP route's residency check + audit emission would otherwise pull
+ * the real internal DB into scope (which has no Postgres in this test).
+ */
+
+import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
+import { Hono } from "hono";
+import { ATLAS_OAUTH_WORKSPACE_CLAIM } from "@atlas/api/lib/auth/oauth-claims";
+
+// `@atlas/api/lib/db/internal` is NOT mocked — the real module's
+// `hasInternalDB()` returns false when `DATABASE_URL` is unset, which
+// matches the eval environment. Mocking it here would have to enumerate
+// every export (CLAUDE.md rule: partial mocks break sibling files via
+// SyntaxError) and the real shape covers our needs naturally.
+
+mock.module("@atlas/api/lib/audit", () => ({
+  ADMIN_ACTIONS: {
+    mcp_session: { start: "mcp_session.start" },
+    oauth_token: {
+      issue: "oauth_token.issue",
+      refresh: "oauth_token.refresh",
+      revoke: "oauth_token.revoke",
+    },
+  },
+  logAdminAction: () => undefined,
+  logAdminActionAwait: async () => undefined,
+  errorMessage: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+  causeToError: (err: unknown) => (err instanceof Error ? err : new Error(String(err))),
+}));
+
+interface ServerHandle {
+  close: () => void;
+  bearer: string;
+  workspaceId: string;
+  baseUrl: string;
+  userId: string;
+}
+
+let handle: ServerHandle | undefined;
+
+beforeAll(async () => {
+  const { createHostedMcpRouter } = await import("@atlas/mcp/hosted");
+  const { startEvalAuthServer } = await import("./canonical-mcp-auth");
+  const mcpRouter = new Hono();
+  mcpRouter.route("/", createHostedMcpRouter());
+  handle = await startEvalAuthServer({ mcpRouter });
+});
+
+afterAll(async () => {
+  handle?.close();
+  handle = undefined;
+  const { _resetHostedSessions } = await import("@atlas/mcp/hosted");
+  await _resetHostedSessions();
+  mock.restore();
+});
+
+describe("Phase 2 OAuth round-trip helper (#2119)", () => {
+  it("issues a JWT-formatted bearer", () => {
+    if (!handle) throw new Error("server not started");
+    const parts = handle.bearer.split(".");
+    expect(parts.length).toBe(3);
+  });
+
+  it("stamps the workspace claim with the activated organization id", () => {
+    if (!handle) throw new Error("server not started");
+    const payload = decodeJwtPayloadUnsafe(handle.bearer);
+    expect(payload[ATLAS_OAUTH_WORKSPACE_CLAIM]).toBe(handle.workspaceId);
+  });
+
+  it("issues with the in-process baseUrl as the issuer", () => {
+    if (!handle) throw new Error("server not started");
+    const payload = decodeJwtPayloadUnsafe(handle.bearer);
+    expect(payload.iss).toBe(`${handle.baseUrl}/api/auth`);
+  });
+
+  it("stamps the MCP resource indicator as the audience", () => {
+    if (!handle) throw new Error("server not started");
+    const payload = decodeJwtPayloadUnsafe(handle.bearer);
+    const aud = payload.aud;
+    const expected = `${handle.baseUrl}/mcp`;
+    if (Array.isArray(aud)) {
+      expect(aud).toContain(expected);
+    } else {
+      expect(aud).toBe(expected);
+    }
+  });
+
+  it("MCP route accepts the issued bearer end-to-end", async () => {
+    if (!handle) throw new Error("server not started");
+    const res = await fetch(`${handle.baseUrl}/mcp/${handle.workspaceId}/sse`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        Authorization: `Bearer ${handle.bearer}`,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "auth-smoke", version: "0.0.0" },
+        },
+        id: 1,
+      }),
+    });
+    // The contract is "not 401"; the SDK may negotiate via SSE so we
+    // don't pin a specific success status. A 401 here means the JWKS
+    // path or audience matching broke; that's the regression class
+    // this test exists to catch.
+    // The contract is "not 401"; the SDK may negotiate via SSE so we
+    // don't pin a specific success status. A 401 here means the JWKS
+    // path or audience / issuer matching broke; that is the regression
+    // class this test exists to catch. Surface the response body on
+    // failure so a future regression names the underlying mismatch
+    // (audience / issuer / expiry) without requiring a re-run.
+    if (res.status === 401) {
+      const body = await res.text();
+      throw new Error(
+        `MCP route rejected the real bearer with 401. Body: ${body.slice(0, 256)}`,
+      );
+    }
+    expect(res.headers.get("www-authenticate")).toBeNull();
+  });
+});
+
+/**
+ * Decode a JWT payload WITHOUT verifying the signature. Safe ONLY in
+ * test code where we just minted the token from an in-process issuer
+ * we control. Production callers must always use the JWKS-backed
+ * verifier — see hosted.ts / verifyAccessToken for the production path.
+ */
+function decodeJwtPayloadUnsafe(jwt: string): Record<string, unknown> {
+  const parts = jwt.split(".");
+  if (parts.length !== 3) throw new Error(`not a JWT: ${jwt.slice(0, 40)}…`);
+  const json = atob(parts[1].replace(/-/g, "+").replace(/_/g, "/"));
+  return JSON.parse(json) as Record<string, unknown>;
+}

--- a/packages/mcp/src/__tests__/canonical-mcp-auth.test.ts
+++ b/packages/mcp/src/__tests__/canonical-mcp-auth.test.ts
@@ -11,20 +11,17 @@
  * BEFORE the evalspec in alphabetical order (auth.test < eval.evalspec)
  * so a regression in the helper trips here first with a precise message.
  *
- * Mocks `@atlas/api/lib/db/internal` and `@atlas/api/lib/audit` because
- * the MCP route's residency check + audit emission would otherwise pull
- * the real internal DB into scope (which has no Postgres in this test).
+ * Mocks `@atlas/api/lib/audit` so audit emissions don't require an
+ * `audit_log` table. `@atlas/api/lib/db/internal` is intentionally NOT
+ * mocked — its `hasInternalDB()` returns `false` when `DATABASE_URL`
+ * is unset, which short-circuits every internal query without forcing
+ * us to enumerate every export of that large module (CLAUDE.md rule:
+ * partial mocks break sibling files via SyntaxError).
  */
 
 import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
 import { Hono } from "hono";
 import { ATLAS_OAUTH_WORKSPACE_CLAIM } from "@atlas/api/lib/auth/oauth-claims";
-
-// `@atlas/api/lib/db/internal` is NOT mocked — the real module's
-// `hasInternalDB()` returns false when `DATABASE_URL` is unset, which
-// matches the eval environment. Mocking it here would have to enumerate
-// every export (CLAUDE.md rule: partial mocks break sibling files via
-// SyntaxError) and the real shape covers our needs naturally.
 
 mock.module("@atlas/api/lib/audit", () => ({
   ADMIN_ACTIONS: {
@@ -77,7 +74,16 @@ describe("Phase 2 OAuth round-trip helper (#2119)", () => {
   it("stamps the workspace claim with the activated organization id", () => {
     if (!handle) throw new Error("server not started");
     const payload = decodeJwtPayloadUnsafe(handle.bearer);
-    expect(payload[ATLAS_OAUTH_WORKSPACE_CLAIM]).toBe(handle.workspaceId);
+    // Assert the claim is non-empty BEFORE the equality check —
+    // without this, a regression that drops both the JWT claim and
+    // `handle.workspaceId` to `undefined` (or `""`) would pass via
+    // both-sides-equal-each-other rather than fail loudly. The
+    // workspace id Better Auth returns from `createOrganization` is
+    // a 24+ char base62 string, so the length floor is generous.
+    const claim = payload[ATLAS_OAUTH_WORKSPACE_CLAIM];
+    expect(typeof claim).toBe("string");
+    expect((claim as string).length).toBeGreaterThan(0);
+    expect(claim).toBe(handle.workspaceId);
   });
 
   it("issues with the in-process baseUrl as the issuer", () => {
@@ -120,14 +126,10 @@ describe("Phase 2 OAuth round-trip helper (#2119)", () => {
     });
     // The contract is "not 401"; the SDK may negotiate via SSE so we
     // don't pin a specific success status. A 401 here means the JWKS
-    // path or audience matching broke; that's the regression class
-    // this test exists to catch.
-    // The contract is "not 401"; the SDK may negotiate via SSE so we
-    // don't pin a specific success status. A 401 here means the JWKS
-    // path or audience / issuer matching broke; that is the regression
-    // class this test exists to catch. Surface the response body on
-    // failure so a future regression names the underlying mismatch
-    // (audience / issuer / expiry) without requiring a re-run.
+    // path or audience / issuer matching broke — the regression class
+    // this test exists to catch. The body slice on failure names the
+    // underlying mismatch (audience / issuer / expiry) without
+    // requiring a re-run.
     if (res.status === 401) {
       const body = await res.text();
       throw new Error(

--- a/packages/mcp/src/__tests__/canonical-mcp-auth.ts
+++ b/packages/mcp/src/__tests__/canonical-mcp-auth.ts
@@ -1,0 +1,694 @@
+/**
+ * Real OAuth 2.1 round-trip helper for the canonical-question MCP eval (#2119).
+ *
+ * Phase 1 (#2074, PR #2120) deliberately mocked `verifyAccessToken` at the
+ * test boundary so the eval did not need a real auth server. That made
+ * Phase 1 cheap to run in CI but it skipped the JWKS path entirely — a
+ * regression like "JWT signature verification subtly broken under load"
+ * could ship green.
+ *
+ * This module closes that gap. We boot a self-contained Better Auth
+ * instance with the same `jwt()` + `oauthProvider()` plugins production
+ * uses (against an in-memory adapter), provision a test user + workspace,
+ * drive the real OAuth 2.1 loopback flow via {@link runHostedAuthFlow}'s
+ * test seams, and return a real JWT signed by the in-process JWKS. The
+ * MCP route's bearer middleware verifies that JWT through the same JWKS
+ * endpoint — no mock — so a regression in any of:
+ *
+ *   - JWKS publication / serialization
+ *   - JWT signature verification
+ *   - audience / issuer matching against the resolved request origin
+ *   - workspace-claim stamping
+ *
+ * fails this eval before it ships.
+ *
+ * ── What this module is NOT ─────────────────────────────────────────
+ *
+ * - It does NOT boot the full Atlas API (`buildAppLayer`). The Layer DAG
+ *   pulls in Postgres migrations, semantic sync, the scheduler, and OTel
+ *   — none of which are load-bearing for the OAuth path. We mount Better
+ *   Auth directly on a Hono app sitting next to the MCP router.
+ * - It does NOT exercise platform admin / SCIM / Stripe / two-factor /
+ *   passkey plugins. The production `buildPlugins()` includes those for
+ *   schema reasons unrelated to OAuth; the eval pares the plugin set down
+ *   to the OAuth surface.
+ *
+ * ── Resource-indicator workaround ────────────────────────────────────
+ *
+ * `@better-auth/oauth-provider` only issues JWT-formatted access tokens
+ * when the token request carries a `resource` parameter (RFC 8707). The
+ * upstream `runHostedAuthFlow` in `@useatlas/mcp/init` does not include
+ * `resource` today (tracked separately as #2124). For the eval we wrap
+ * the test seam's `fetchImpl` to inject `resource=${apiUrl}/mcp` into the
+ * token-exchange POST body so the issued token is JWT-formatted and
+ * carries the `aud` claim the MCP route's verifier requires.
+ */
+
+import { betterAuth } from "better-auth";
+import { bearer, jwt, organization } from "better-auth/plugins";
+import { memoryAdapter } from "better-auth/adapters/memory";
+import { oauthProvider } from "@better-auth/oauth-provider";
+import { Hono } from "hono";
+import type { Server } from "bun";
+import type { betterAuth as betterAuthFn } from "better-auth";
+
+// Untyped alias around `ReturnType<typeof betterAuth>`. Better Auth's
+// return type is generic over the precise `BetterAuthOptions` shape it
+// receives — pinning it to a specific options literal causes
+// `Auth<{secret, baseURL, ...}>` and `Auth<BetterAuthOptions>` to be
+// unassignable. The eval doesn't care about the option-graph specifics
+// at the public API boundary; what matters is that `auth.handler` and
+// `auth.api.*` are callable, which the workspace-typed cast provides.
+type EvalAuth = ReturnType<typeof betterAuthFn>;
+// `auth.api` is keyed by the union of every plugin's endpoint shape.
+// We invoke `signUpEmail` / `createOrganization` / `setActiveOrganization`
+// through this cast so a future plugin upgrade that renames any one of
+// them surfaces at runtime ("function is not a function") rather than
+// silently no-oping; the runtime shape is stable across the 1.6.x line.
+interface EvalAuthApi {
+  signUpEmail: (input: {
+    body: { email: string; password: string; name: string };
+    asResponse: true;
+  }) => Promise<Response>;
+  createOrganization: (input: {
+    body: { name: string; slug: string };
+    headers: Headers;
+  }) => Promise<{ id?: string } | null>;
+  setActiveOrganization: (input: {
+    body: { organizationId: string };
+    headers: Headers;
+  }) => Promise<unknown>;
+}
+import {
+  runHostedAuthFlow,
+  type Bearer,
+  type HostedFlowOptions,
+  type HostedFlowResult,
+  type LoopbackHandler,
+  type LoopbackServer,
+  type ServeImpl,
+  type OpenBrowserImpl,
+} from "@useatlas/mcp/init";
+import { ATLAS_OAUTH_WORKSPACE_CLAIM } from "@atlas/api/lib/auth/oauth-claims";
+
+// ── Public API ──────────────────────────────────────────────────────
+
+/**
+ * Bound auth fixture: the Better Auth instance, the Bun.serve handle that
+ * hosts both the auth surface and the MCP router, the credentials of the
+ * provisioned user + workspace, and the issued bearer JWT.
+ *
+ * `close()` shuts the server cleanly; callers MUST run it in a `finally`
+ * so a failed `beforeAll` does not leave a port bound.
+ */
+export interface EvalAuthFixture {
+  readonly server: Server<unknown>;
+  readonly baseUrl: string;
+  readonly bearer: string;
+  readonly workspaceId: string;
+  readonly mcpUrl: string;
+  readonly userId: string;
+  readonly close: () => void;
+}
+
+export interface EvalAuthOptions {
+  /** Hono app that mounts /mcp/{workspace_id}/sse — supplied by the eval. */
+  readonly mcpRouter: Hono;
+  /** Email for the provisioned admin. Defaults to `eval@atlas.test`. */
+  readonly userEmail?: string;
+  /** Password for the provisioned admin. Defaults to a fixed value. */
+  readonly userPassword?: string;
+  /** Workspace slug for the provisioned organization. Defaults to `eval`. */
+  readonly workspaceSlug?: string;
+  /** Workspace name for the provisioned organization. */
+  readonly workspaceName?: string;
+}
+
+const DEFAULT_USER_EMAIL = "eval@atlas.test";
+const DEFAULT_USER_PASSWORD = "atlas-eval-pw-1234";
+const DEFAULT_WORKSPACE_SLUG = "eval";
+const DEFAULT_WORKSPACE_NAME = "Eval Workspace";
+const DEFAULT_USER_NAME = "Eval Admin";
+const REQUESTED_SCOPE_LIST = ["openid", "profile", "email", "mcp:read", "offline_access"] as const;
+
+/**
+ * Boot a self-contained Better Auth + MCP server, provision a test user +
+ * organization, run the real OAuth 2.1 loopback flow, and return the
+ * issued bearer.
+ *
+ * The returned `bearer` is a real JWT signed by the in-process JWKS — the
+ * MCP route's `verifyAccessToken` resolves the same JWKS endpoint and
+ * verifies the signature for real.
+ */
+export async function startEvalAuthServer(
+  options: EvalAuthOptions,
+): Promise<EvalAuthFixture> {
+  // Step 0 — clear the env vars that the MCP route's bearer middleware
+  // reads to resolve audience + issuer + JWKS URL. Both `.env` and CI may
+  // set `BETTER_AUTH_URL` / `ATLAS_PUBLIC_API_URL` to the dev API host
+  // (`http://localhost:3001`) — the route would then look up audience
+  // there instead of at the in-process test port, and every dispatch
+  // would fail with `invalid_bearer`. Restore on close so tests in the
+  // same process that read these vars later see the original values.
+  const previousPublicApiUrl = process.env.ATLAS_PUBLIC_API_URL;
+  const previousBetterAuthUrl = process.env.BETTER_AUTH_URL;
+  delete process.env.ATLAS_PUBLIC_API_URL;
+  delete process.env.BETTER_AUTH_URL;
+  const restoreEnv = () => {
+    if (previousPublicApiUrl === undefined) delete process.env.ATLAS_PUBLIC_API_URL;
+    else process.env.ATLAS_PUBLIC_API_URL = previousPublicApiUrl;
+    if (previousBetterAuthUrl === undefined) delete process.env.BETTER_AUTH_URL;
+    else process.env.BETTER_AUTH_URL = previousBetterAuthUrl;
+  };
+
+  // Step 1 — bind a TCP port up front. The auth instance's `validAudiences`
+  // must include `${baseUrl}/mcp`, but we only know `baseUrl` after
+  // `Bun.serve` picks a port. The placeholder fetch closes over a mutable
+  // reference to the real handler, which we install once the auth + router
+  // are constructed against the resolved baseUrl.
+  let resolvedFetch: ((req: Request) => Response | Promise<Response>) | null = null;
+  const server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    fetch: (req) =>
+      resolvedFetch
+        ? resolvedFetch(req)
+        : new Response("eval auth server not yet wired", { status: 503 }),
+  });
+  if (typeof server.port !== "number") {
+    server.stop(true);
+    throw new Error("Bun.serve did not bind a TCP port for eval auth");
+  }
+  const baseUrl = `http://localhost:${server.port}`;
+
+  try {
+    const auth = buildEvalAuth({ baseUrl });
+
+    // Step 2 — assemble the Hono app: Better Auth handler at /api/auth/*,
+    // OAuth discovery at /.well-known/oauth-authorization-server/api/auth
+    // (matches the upstream MCP CLI's discovery URL), and the supplied
+    // MCP router at /mcp/*. Discovery serves Better Auth's own metadata
+    // helper directly — no Atlas wrapper, no managed-mode gating.
+    const app = new Hono();
+    app.all("/api/auth/*", (c) => auth.handler(c.req.raw));
+    app.get("/.well-known/oauth-authorization-server/api/auth", async (c) => {
+      const { oauthProviderAuthServerMetadata } = await import("@better-auth/oauth-provider");
+      const handler = oauthProviderAuthServerMetadata(
+        auth as unknown as Parameters<typeof oauthProviderAuthServerMetadata>[0],
+      );
+      return handler(c.req.raw);
+    });
+    app.route("/mcp", options.mcpRouter);
+    resolvedFetch = app.fetch;
+
+    // Step 3 — provision the admin user, workspace, and an active session.
+    // The session cookie carries `activeOrganizationId`, which the
+    // `clientReference` callback in `oauthProvider` reads to stamp the
+    // workspace_id claim onto the issued JWT. No active workspace =
+    // missing_workspace_claim at the MCP edge.
+    const provisioned = await provisionTestUser({
+      auth,
+      email: options.userEmail ?? DEFAULT_USER_EMAIL,
+      password: options.userPassword ?? DEFAULT_USER_PASSWORD,
+      name: DEFAULT_USER_NAME,
+      workspaceName: options.workspaceName ?? DEFAULT_WORKSPACE_NAME,
+      workspaceSlug: options.workspaceSlug ?? DEFAULT_WORKSPACE_SLUG,
+    });
+
+    // Step 4 — drive the real loopback OAuth flow. The bearer that comes
+    // out is a real JWT verified against the in-process JWKS by the MCP
+    // route on every request.
+    const flow = await runEvalAuthFlow({
+      apiUrl: baseUrl,
+      app,
+      sessionCookie: provisioned.sessionCookie,
+    });
+
+    if (flow.workspaceId !== provisioned.workspaceId) {
+      throw new Error(
+        `OAuth workspace mismatch — token claims ${flow.workspaceId}, expected ${provisioned.workspaceId}. ` +
+          `Likely a misconfigured customAccessTokenClaims hook.`,
+      );
+    }
+
+    return {
+      server,
+      baseUrl,
+      bearer: flow.accessToken,
+      workspaceId: flow.workspaceId,
+      mcpUrl: flow.mcpUrl,
+      userId: provisioned.userId,
+      close: () => {
+        server.stop(true);
+        restoreEnv();
+      },
+    };
+  } catch (err) {
+    server.stop(true);
+    restoreEnv();
+    throw err;
+  }
+}
+
+// ── Better Auth instance ────────────────────────────────────────────
+
+interface BuildEvalAuthOptions {
+  readonly baseUrl: string;
+}
+
+/**
+ * Construct the Better Auth instance the eval mounts. The plugin set is
+ * pared down to the OAuth surface — `bearer`, `jwt`, `organization`, and
+ * `oauthProvider` — so the in-memory adapter does not have to migrate
+ * SCIM / Stripe / two-factor / passkey schemas the eval never exercises.
+ *
+ * The `oauthProvider` config mirrors production:
+ *
+ *   - `clientReference` reads `session.activeOrganizationId` so issued
+ *     tokens carry the same `referenceId` semantics production uses.
+ *   - `customAccessTokenClaims` stamps the URN-shaped workspace claim
+ *     identical to `packages/api/src/lib/auth/server.ts`. The MCP route
+ *     reads this same claim back at the verifier boundary.
+ *   - `validAudiences` includes `${baseUrl}/mcp` — matches what the MCP
+ *     route's `resourceAudience(req)` builds from the request origin.
+ *   - DCR is unauthenticated (`allowUnauthenticatedClientRegistration`)
+ *     so the test seam can register a public client without a prior
+ *     credential, the same way Claude Desktop does in production.
+ */
+function buildEvalAuth(opts: BuildEvalAuthOptions): EvalAuth {
+  // Cast at the boundary: `betterAuth(...)` returns `Auth<<inferred
+  // tuple>>`, which is structurally narrower than the declared
+  // `Auth<BetterAuthOptions>` return type because TS can't widen the
+  // option-graph generic across the plugin tuple. We pay the type cost
+  // here once so callers see a uniform `EvalAuth` and don't have to
+  // know the option-graph specifics. The cast is safe because every
+  // surface we touch (`auth.handler`, `auth.api.*`) is part of the
+  // base shape, not the option-graph projection.
+  return betterAuth({
+    secret: "atlas-eval-test-secret-not-for-production-use-32+chars",
+    baseURL: opts.baseUrl,
+    // Memory adapter requires every table the plugin set will touch to
+    // be pre-allocated as an empty array, otherwise the first findOne
+    // throws "Model X not found". The plugin set below exercises:
+    //   - core:           user, account, session, verification
+    //   - organization:   organization, member, invitation, team,
+    //                     teamMember
+    //   - jwt:            jwks
+    //   - oauth-provider: oauthClient, oauthAccessToken,
+    //                     oauthRefreshToken, oauthConsent
+    // Listing them inline (rather than auto-discovering from the plugin
+    // schema) keeps the eval failure mode obvious — a future plugin
+    // upgrade that adds a new table will surface as "Model Z not found"
+    // on the first request, which is a more actionable signal than
+    // silent corruption.
+    database: memoryAdapter({
+      user: [],
+      account: [],
+      session: [],
+      verification: [],
+      organization: [],
+      member: [],
+      invitation: [],
+      team: [],
+      teamMember: [],
+      jwks: [],
+      oauthClient: [],
+      oauthAccessToken: [],
+      oauthRefreshToken: [],
+      oauthConsent: [],
+    }),
+    emailAndPassword: {
+      enabled: true,
+      requireEmailVerification: false,
+      autoSignIn: true,
+    },
+    plugins: [
+      bearer(),
+      organization({
+        // Members can create the org; defaults are fine — no custom
+        // permissions matrix is required for the OAuth path.
+      }),
+      jwt(),
+      oauthProvider({
+        loginPage: "/login",
+        consentPage: "/oauth2/consent",
+        allowDynamicClientRegistration: true,
+        allowUnauthenticatedClientRegistration: true,
+        scopes: [...REQUESTED_SCOPE_LIST],
+        validAudiences: [`${opts.baseUrl}/mcp`],
+        accessTokenExpiresIn: 3600,
+        refreshTokenExpiresIn: 60 * 60 * 24,
+        clientReference: ({ session }) => {
+          // The cast mirrors `packages/api/src/lib/auth/server.ts` —
+          // Better Auth's session-organization extension is contributed
+          // by the organization plugin and is not part of the base
+          // session type the oauthProvider sees.
+          const orgId = (session as { activeOrganizationId?: string | null } | null | undefined)
+            ?.activeOrganizationId;
+          return typeof orgId === "string" && orgId.length > 0 ? orgId : undefined;
+        },
+        // The `referenceId` parameter that `customAccessTokenClaims`
+        // receives is whatever `postLogin.consentReferenceId` returned
+        // at authorize-time. `clientReference` only governs which user
+        // owns a registered DCR client — it doesn't propagate onto the
+        // access token. This is a Better Auth invariant the production
+        // config in `packages/api/src/lib/auth/server.ts` should mirror;
+        // the gap is filed as #2124. For the eval we return the same
+        // orgId so the issued token carries the URN-shaped workspace
+        // claim the MCP route's verifier reads.
+        postLogin: {
+          page: "/oauth2/post-login",
+          consentReferenceId: async ({ session }) => {
+            const orgId = (session as { activeOrganizationId?: string | null } | null | undefined)
+              ?.activeOrganizationId;
+            return typeof orgId === "string" && orgId.length > 0 ? orgId : undefined;
+          },
+          // No interstitial — the eval has a single-org fixture so
+          // workspace selection is deterministic.
+          shouldRedirect: () => false,
+        },
+        customAccessTokenClaims: ({ referenceId }) => {
+          return referenceId
+            ? { [ATLAS_OAUTH_WORKSPACE_CLAIM]: referenceId }
+            : {};
+        },
+      }),
+    ],
+  }) as unknown as EvalAuth;
+}
+
+// ── Programmatic user + workspace provisioning ──────────────────────
+
+interface ProvisionInput {
+  readonly auth: EvalAuth;
+  readonly email: string;
+  readonly password: string;
+  readonly name: string;
+  readonly workspaceName: string;
+  readonly workspaceSlug: string;
+}
+
+interface ProvisionResult {
+  readonly userId: string;
+  readonly workspaceId: string;
+  readonly sessionCookie: string;
+}
+
+/**
+ * Sign up the admin user, create their organization, and set it active —
+ * all via Better Auth's programmatic `auth.api.*` surface (no HTTP). The
+ * session cookie returned is what the OAuth-authorize handler reads to
+ * resolve `activeOrganizationId`; without it, the issued token would
+ * carry no workspace claim and the MCP route would 401.
+ */
+async function provisionTestUser(input: ProvisionInput): Promise<ProvisionResult> {
+  // Cast through `unknown` because Better Auth's `api` shape is an
+  // intersection over every plugin's endpoint surface and TS cannot
+  // narrow it across the eval's plugin-tuple erasure. `EvalAuthApi`
+  // lists exactly the three calls we make so a runtime drift surfaces
+  // as a TypeError on the next test run, not a silent no-op.
+  const api = input.auth.api as unknown as EvalAuthApi;
+
+  // `signUpEmail` with `autoSignIn: true` returns both a user and a
+  // session cookie via `Set-Cookie`. We need the cookie to carry through
+  // organization creation + activation, so we read it from the response.
+  const signUpResp = await api.signUpEmail({
+    body: {
+      email: input.email,
+      password: input.password,
+      name: input.name,
+    },
+    asResponse: true,
+  });
+  const initialCookie = signUpResp.headers.get("set-cookie");
+  if (!initialCookie) {
+    throw new Error("signUpEmail did not return a Set-Cookie header — autoSignIn may be off");
+  }
+  const cookieValue = parseSetCookie(initialCookie);
+  const signUpBody = (await signUpResp.json().catch(() => null)) as { user?: { id?: unknown } } | null;
+  const userId = signUpBody?.user?.id;
+  if (typeof userId !== "string" || userId.length === 0) {
+    throw new Error("signUpEmail response missing user.id");
+  }
+
+  // Create the organization; the response carries the org id we need to
+  // activate. Header-driven session: rather than threading the cookie
+  // through every call site, we spread it onto a Headers object the
+  // organization endpoint accepts.
+  const sessionHeaders = new Headers({ Cookie: cookieValue });
+  const created = await api.createOrganization({
+    body: {
+      name: input.workspaceName,
+      slug: input.workspaceSlug,
+    },
+    headers: sessionHeaders,
+  });
+  const workspaceId = created?.id;
+  if (typeof workspaceId !== "string" || workspaceId.length === 0) {
+    throw new Error("createOrganization did not return an id");
+  }
+
+  // Activate the workspace on the session — the `clientReference`
+  // callback reads `session.activeOrganizationId` at authorize time.
+  await api.setActiveOrganization({
+    body: { organizationId: workspaceId },
+    headers: sessionHeaders,
+  });
+
+  return { userId, workspaceId, sessionCookie: cookieValue };
+}
+
+/**
+ * Extract the cookie name=value pair from a `Set-Cookie` header,
+ * dropping attributes the client doesn't echo back (Path / HttpOnly /
+ * SameSite / Max-Age / Expires). We only need the cookie itself for
+ * subsequent in-process calls — nothing reads the attributes here.
+ */
+function parseSetCookie(setCookie: string): string {
+  return setCookie.split(",").map((entry) => entry.split(";")[0]?.trim() ?? "").filter(Boolean).join("; ");
+}
+
+// ── Loopback OAuth driver ───────────────────────────────────────────
+
+interface RunFlowInput {
+  readonly apiUrl: string;
+  readonly app: Hono;
+  readonly sessionCookie: string;
+}
+
+/**
+ * Drive `runHostedAuthFlow` against the in-process server.
+ *
+ * The seams:
+ *
+ *   - `fetchImpl` — dispatches discovery, DCR, and the token exchange
+ *     directly through `app.fetch`. We also inject `resource=${apiUrl}/mcp`
+ *     into the token-exchange body so Better Auth issues a JWT (RFC 8707
+ *     workaround for #2124).
+ *   - `serveImpl` — captures the loopback handler. The "browser" calls it
+ *     directly with the redirect params; no real port is bound.
+ *   - `openBrowserImpl` — drives the authorize endpoint with the session
+ *     cookie, posts auto-consent if Better Auth redirects to the consent
+ *     page, then invokes the captured loopback handler with the final
+ *     `code` + `state` from the redirect URL.
+ */
+async function runEvalAuthFlow(input: RunFlowInput): Promise<HostedFlowResult> {
+  const resourceIndicator = `${input.apiUrl.replace(/\/+$/, "")}/mcp`;
+
+  // ── fetchImpl ────────────────────────────────────────────────────
+  const fetchImpl: typeof fetch = (async (
+    rawInput: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    const req = new Request(typeof rawInput === "string" || rawInput instanceof URL ? new URL(rawInput).toString() : rawInput.url, init);
+    // Thread the test session cookie onto every auth-server request the
+    // flow makes. DCR specifically needs it: `oauthProvider.clientReference`
+    // only fires when DCR sees a session, which is what stamps the
+    // `referenceId` (workspace id) onto the registered client. Without
+    // it, the issued token carries no workspace claim and the MCP edge
+    // 401s with `missing_workspace_claim`. Production MCP clients
+    // (Claude Desktop / Cursor) get this for free because DCR runs
+    // inside the user's authenticated browser session; the upstream
+    // CLI flow at `@useatlas/mcp/init` does not pass cookies, which is
+    // why production tokens issued via the CLI alone wouldn't carry
+    // the claim either (tracked separately as #2124).
+    const headersWithCookie = new Headers(req.headers);
+    if (!headersWithCookie.has("Cookie")) {
+      headersWithCookie.set("Cookie", input.sessionCookie);
+    }
+    if (req.method === "POST" && req.url.includes("/oauth2/token")) {
+      // Patch the body to include `resource=${resourceIndicator}`.
+      // Without this Better Auth issues an opaque token and the MCP
+      // route's verifier (which expects JWT) rejects with
+      // invalid_bearer. See the module docstring's resource-indicator
+      // workaround note for #2124.
+      const body = await req.text();
+      const params = new URLSearchParams(body);
+      if (!params.has("resource")) params.set("resource", resourceIndicator);
+      const patched = new Request(req.url, {
+        method: req.method,
+        headers: headersWithCookie,
+        body: params.toString(),
+      });
+      return input.app.fetch(patched);
+    }
+    const withCookie = new Request(req.url, {
+      method: req.method,
+      headers: headersWithCookie,
+      body: req.method === "GET" || req.method === "HEAD" ? undefined : await req.text().catch(() => ""),
+    });
+    return input.app.fetch(withCookie);
+  }) as unknown as typeof fetch;
+
+  // ── serveImpl ────────────────────────────────────────────────────
+  let captured: { handler: LoopbackHandler; port: number } | null = null;
+  const serveImpl: ServeImpl = async (handler) => {
+    const stub: LoopbackServer = {
+      port: 49152,
+      stop: async () => {},
+    };
+    captured = { handler, port: stub.port };
+    return stub;
+  };
+
+  // ── openBrowserImpl ──────────────────────────────────────────────
+  // Drives the authorize endpoint. Better Auth's consent-skip path:
+  //   1. GET /api/auth/oauth2/authorize?... → 302 to /oauth2/consent
+  //      (the configured consentPage) with `oauth_query` URL param OR
+  //      directly to the redirect_uri if a consent record already exists.
+  //   2. We POST /api/auth/oauth2/consent with `{ accept: true,
+  //      oauth_query: <captured> }` and the session cookie. The endpoint
+  //      returns `{ redirect_uri }` (or 200/302; we narrow on shape).
+  //   3. Parse `code` + `state` from `redirect_uri` and invoke the
+  //      loopback handler directly (no real network).
+  //
+  // This mirrors what a real browser would do: auto-approve scope, follow
+  // the redirect. The session cookie threads through every request — no
+  // cookie = anonymous = redirect to /login = test fails fast.
+  const openBrowserImpl: OpenBrowserImpl = async (authorizeUrl) => {
+    if (!captured) {
+      throw new Error("openBrowserImpl invoked before serveImpl captured the handler");
+    }
+    const sessionHeaders = { Cookie: input.sessionCookie } as const;
+
+    // Step 1 — drive authorize. Manual `redirect: "manual"` so we can
+    // capture the `Location` header rather than auto-following it (the
+    // redirect target is the consent page, not the auth surface).
+    const authorizeReq = new Request(authorizeUrl, {
+      method: "GET",
+      headers: sessionHeaders,
+    });
+    const authorizeRes = await input.app.fetch(authorizeReq);
+    const location = authorizeRes.headers.get("location");
+    if (!location) {
+      const status = authorizeRes.status;
+      const body = await authorizeRes.text().catch(() => "<unreadable>");
+      throw new Error(
+        `authorize endpoint did not redirect (status=${status}, body=${body.slice(0, 256)})`,
+      );
+    }
+
+    // Step 2 — branch on whether Better Auth redirected to the consent
+    // page (no prior consent) or directly to the loopback redirect_uri
+    // (consent already on record). The first time through is always
+    // the consent path; running the same flow twice in one test would
+    // hit the second branch.
+    let finalRedirect: string;
+    if (location.includes("/oauth2/consent")) {
+      // Better Auth's authorize handler redirects to the consent page
+      // with the FULL ORIGINAL QUERY copied onto the consent URL —
+      // not bundled as a single `oauth_query` param. The consent
+      // endpoint's body schema names that bundle `oauth_query`, so we
+      // extract everything after `?` from the redirect Location and
+      // forward it verbatim. A regression that drops a query field
+      // (e.g. code_challenge) would surface as a 400 from the consent
+      // endpoint, not a silent pass.
+      const consentUrl = new URL(location, input.apiUrl);
+      const oauthQuery = consentUrl.search.replace(/^\?/, "");
+      if (!oauthQuery) {
+        throw new Error(
+          `authorize redirected to consent but no query string was carried: ${location}`,
+        );
+      }
+      const consentRes = await input.app.fetch(
+        new Request(`${input.apiUrl}/api/auth/oauth2/consent`, {
+          method: "POST",
+          headers: {
+            ...sessionHeaders,
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          },
+          body: JSON.stringify({ accept: true, oauth_query: oauthQuery }),
+        }),
+      );
+      if (!consentRes.ok) {
+        const body = await consentRes.text().catch(() => "<unreadable>");
+        throw new Error(
+          `consent endpoint returned ${consentRes.status}: ${body.slice(0, 256)}`,
+        );
+      }
+      const consentBody = (await consentRes.json().catch(() => null)) as
+        | { redirect_uri?: unknown; redirectURI?: unknown; url?: unknown; redirect?: unknown }
+        | null;
+      // Better Auth currently returns `{ redirect: true, url }` — the
+      // metadata.openapi block on the consent endpoint advertises
+      // `redirect_uri` (older shape), so we accept both for forward
+      // compatibility. A future plugin upgrade that renames either is
+      // surfaced as the explicit "did not return" error below.
+      const redirect =
+        typeof consentBody?.url === "string"
+          ? consentBody.url
+          : typeof consentBody?.redirect_uri === "string"
+            ? consentBody.redirect_uri
+            : typeof consentBody?.redirectURI === "string"
+              ? consentBody.redirectURI
+              : null;
+      if (redirect === null) {
+        throw new Error(
+          `consent endpoint did not return a redirect URL (body=${JSON.stringify(consentBody)})`,
+        );
+      }
+      finalRedirect = redirect;
+    } else {
+      finalRedirect = location;
+    }
+
+    // Step 3 — parse code + state from the final redirect and fire the
+    // loopback handler. This is the "browser arrived at the loopback
+    // URL" moment in production.
+    const parsed = new URL(finalRedirect);
+    const params = parsed.searchParams;
+    if (!params.get("code") || !params.get("state")) {
+      throw new Error(
+        `final redirect missing code/state: ${finalRedirect}`,
+      );
+    }
+    const result = captured.handler(params, "GET");
+    if (result.status !== 200) {
+      throw new Error(
+        `loopback handler refused callback (status=${result.status}, body=${result.body.slice(0, 256)})`,
+      );
+    }
+    return { ok: true };
+  };
+
+  const flowOptions: HostedFlowOptions = {
+    apiUrl: input.apiUrl,
+    fetchImpl,
+    serveImpl,
+    openBrowserImpl,
+    callbackTimeoutMs: 10_000,
+    consoleImpl: { log: () => {}, error: () => {} },
+  };
+
+  const result = await runHostedAuthFlow(flowOptions);
+
+  // The bearer brand is just a string; surface a string at the boundary
+  // so callers don't have to import the Bearer brand type.
+  return {
+    accessToken: result.accessToken as Bearer,
+    refreshToken: result.refreshToken,
+    workspaceId: result.workspaceId,
+    mcpUrl: result.mcpUrl,
+  };
+}

--- a/packages/mcp/src/__tests__/canonical-mcp-auth.ts
+++ b/packages/mcp/src/__tests__/canonical-mcp-auth.ts
@@ -38,10 +38,11 @@
  * `@better-auth/oauth-provider` only issues JWT-formatted access tokens
  * when the token request carries a `resource` parameter (RFC 8707). The
  * upstream `runHostedAuthFlow` in `@useatlas/mcp/init` does not include
- * `resource` today (tracked separately as #2124). For the eval we wrap
- * the test seam's `fetchImpl` to inject `resource=${apiUrl}/mcp` into the
- * token-exchange POST body so the issued token is JWT-formatted and
- * carries the `aud` claim the MCP route's verifier requires.
+ * `resource` today (tracked separately as #2124 — Gap 1). For the eval
+ * we wrap the test seam's `fetchImpl` to inject `resource=${apiUrl}/mcp`
+ * into the token-exchange POST body so the issued token is JWT-formatted
+ * and carries the `aud` claim the MCP route's verifier requires. Once
+ * #2124 lands the `fetchImpl` body-patch can be removed.
  */
 
 import { betterAuth } from "better-auth";
@@ -347,15 +348,12 @@ function buildEvalAuth(opts: BuildEvalAuthOptions): EvalAuth {
             ?.activeOrganizationId;
           return typeof orgId === "string" && orgId.length > 0 ? orgId : undefined;
         },
-        // The `referenceId` parameter that `customAccessTokenClaims`
-        // receives is whatever `postLogin.consentReferenceId` returned
-        // at authorize-time. `clientReference` only governs which user
-        // owns a registered DCR client — it doesn't propagate onto the
-        // access token. This is a Better Auth invariant the production
-        // config in `packages/api/src/lib/auth/server.ts` should mirror;
-        // the gap is filed as #2124. For the eval we return the same
-        // orgId so the issued token carries the URN-shaped workspace
-        // claim the MCP route's verifier reads.
+        // `postLogin.consentReferenceId` is the hook that propagates
+        // the workspace id onto issued tokens — `clientReference`
+        // above only governs DCR client ownership. Mirrors the
+        // production config in `packages/api/src/lib/auth/server.ts`;
+        // the parity is what makes the eval a valid regression test
+        // for the production OAuth path.
         postLogin: {
           page: "/oauth2/post-login",
           consentReferenceId: async ({ session }) => {

--- a/packages/mcp/src/__tests__/canonical-mcp-auth.ts
+++ b/packages/mcp/src/__tests__/canonical-mcp-auth.ts
@@ -90,7 +90,7 @@ import {
   type ServeImpl,
   type OpenBrowserImpl,
 } from "@useatlas/mcp/init";
-import { ATLAS_OAUTH_WORKSPACE_CLAIM } from "@atlas/api/lib/auth/oauth-claims";
+import { ATLAS_OAUTH_WORKSPACE_CLAIM, readActiveOrgId } from "@atlas/api/lib/auth/oauth-claims";
 
 // ── Public API ──────────────────────────────────────────────────────
 
@@ -232,6 +232,7 @@ export async function startEvalAuthServer(
       );
     }
 
+    let closed = false;
     return {
       server,
       baseUrl,
@@ -239,7 +240,14 @@ export async function startEvalAuthServer(
       workspaceId: flow.workspaceId,
       mcpUrl: flow.mcpUrl,
       userId: provisioned.userId,
+      // Idempotent — `restoreEnv` reads the captured "previous" env
+      // values, so calling it twice would treat the first restoration
+      // as the new baseline and silently shift the env state on the
+      // second call. The `closed` flag bounds both `server.stop` and
+      // `restoreEnv` to a single execution.
       close: () => {
+        if (closed) return;
+        closed = true;
         server.stop(true);
         restoreEnv();
       },
@@ -339,15 +347,11 @@ function buildEvalAuth(opts: BuildEvalAuthOptions): EvalAuth {
         validAudiences: [`${opts.baseUrl}/mcp`],
         accessTokenExpiresIn: 3600,
         refreshTokenExpiresIn: 60 * 60 * 24,
-        clientReference: ({ session }) => {
-          // The cast mirrors `packages/api/src/lib/auth/server.ts` —
-          // Better Auth's session-organization extension is contributed
-          // by the organization plugin and is not part of the base
-          // session type the oauthProvider sees.
-          const orgId = (session as { activeOrganizationId?: string | null } | null | undefined)
-            ?.activeOrganizationId;
-          return typeof orgId === "string" && orgId.length > 0 ? orgId : undefined;
-        },
+        // Shared reader from `oauth-claims.ts` — production reads the
+        // same helper, so a regression in either site (empty-string
+        // handling, plugin-shape drift) shows up identically here.
+        clientReference: ({ session }) =>
+          readActiveOrgId(session as Parameters<typeof readActiveOrgId>[0]),
         // `postLogin.consentReferenceId` is the hook that propagates
         // the workspace id onto issued tokens — `clientReference`
         // above only governs DCR client ownership. Mirrors the
@@ -356,11 +360,8 @@ function buildEvalAuth(opts: BuildEvalAuthOptions): EvalAuth {
         // for the production OAuth path.
         postLogin: {
           page: "/oauth2/post-login",
-          consentReferenceId: async ({ session }) => {
-            const orgId = (session as { activeOrganizationId?: string | null } | null | undefined)
-              ?.activeOrganizationId;
-            return typeof orgId === "string" && orgId.length > 0 ? orgId : undefined;
-          },
+          consentReferenceId: async ({ session }) =>
+            readActiveOrgId(session as Parameters<typeof readActiveOrgId>[0]),
           // No interstitial — the eval has a single-org fixture so
           // workspace selection is deterministic.
           shouldRedirect: () => false,
@@ -457,13 +458,23 @@ async function provisionTestUser(input: ProvisionInput): Promise<ProvisionResult
 }
 
 /**
- * Extract the cookie name=value pair from a `Set-Cookie` header,
- * dropping attributes the client doesn't echo back (Path / HttpOnly /
- * SameSite / Max-Age / Expires). We only need the cookie itself for
- * subsequent in-process calls — nothing reads the attributes here.
+ * Extract the `name=value` pair from a `Set-Cookie` header, dropping
+ * attributes (Path / HttpOnly / SameSite / Max-Age / Expires) the client
+ * never echoes back. Better Auth currently uses `Max-Age` for session
+ * cookies — if a future bump switches to `Expires=Wed, 09 Jun ...`,
+ * naïve splitting on `,` would fragment that date into a phantom cookie
+ * entry, so we deliberately take only the prefix before the first `;`.
+ * Empty result throws so the caller doesn't thread an empty Cookie
+ * header through downstream `auth.api.*` calls and run anonymously.
  */
 function parseSetCookie(setCookie: string): string {
-  return setCookie.split(",").map((entry) => entry.split(";")[0]?.trim() ?? "").filter(Boolean).join("; ");
+  const cookie = setCookie.split(";")[0]?.trim() ?? "";
+  if (!cookie || !cookie.includes("=")) {
+    throw new Error(
+      `parseSetCookie: malformed Set-Cookie header (no name=value pair): ${setCookie.slice(0, 120)}`,
+    );
+  }
+  return cookie;
 }
 
 // ── Loopback OAuth driver ───────────────────────────────────────────
@@ -499,17 +510,16 @@ async function runEvalAuthFlow(input: RunFlowInput): Promise<HostedFlowResult> {
     init?: RequestInit,
   ) => {
     const req = new Request(typeof rawInput === "string" || rawInput instanceof URL ? new URL(rawInput).toString() : rawInput.url, init);
-    // Thread the test session cookie onto every auth-server request the
-    // flow makes. DCR specifically needs it: `oauthProvider.clientReference`
-    // only fires when DCR sees a session, which is what stamps the
-    // `referenceId` (workspace id) onto the registered client. Without
-    // it, the issued token carries no workspace claim and the MCP edge
-    // 401s with `missing_workspace_claim`. Production MCP clients
-    // (Claude Desktop / Cursor) get this for free because DCR runs
-    // inside the user's authenticated browser session; the upstream
-    // CLI flow at `@useatlas/mcp/init` does not pass cookies, which is
-    // why production tokens issued via the CLI alone wouldn't carry
-    // the claim either (tracked separately as #2124).
+    // Thread the test session cookie onto every auth-server request
+    // the flow makes. The session cookie is what makes the authorize
+    // endpoint resolve a real signed-in user (vs redirecting to the
+    // login page) and what `postLogin.consentReferenceId` reads to
+    // stamp the workspace id onto the issued JWT. Production MCP
+    // clients (Claude Desktop / Cursor) get this for free because the
+    // OAuth flow runs inside the user's authenticated browser; the
+    // CLI loopback flow does not currently thread cookies, but the
+    // eval needs to so the issued token actually exercises the
+    // workspace-claim path the MCP edge verifies.
     const headersWithCookie = new Headers(req.headers);
     if (!headersWithCookie.has("Cookie")) {
       headersWithCookie.set("Cookie", input.sessionCookie);
@@ -676,7 +686,16 @@ async function runEvalAuthFlow(input: RunFlowInput): Promise<HostedFlowResult> {
     serveImpl,
     openBrowserImpl,
     callbackTimeoutMs: 10_000,
-    consoleImpl: { log: () => {}, error: () => {} },
+    // Route the flow's progress/error output to stderr with a stable
+    // prefix. Phase 1 used a no-op console here; CI failures lost every
+    // breadcrumb the upstream `runHostedAuthFlow` emits before throwing
+    // (DCR rejection details, token-exchange failure body, JWKS errors,
+    // audience mismatches). The stderr prefix lets the eval log filter
+    // these without conflating them with MCP-route logs.
+    consoleImpl: {
+      log: (m) => process.stderr.write(`[mcp-eval-auth] ${m}\n`),
+      error: (m) => process.stderr.write(`[mcp-eval-auth] ${m}\n`),
+    },
   };
 
   const result = await runHostedAuthFlow(flowOptions);

--- a/packages/mcp/src/__tests__/canonical-mcp-eval.evalspec.ts
+++ b/packages/mcp/src/__tests__/canonical-mcp-eval.evalspec.ts
@@ -15,7 +15,9 @@
  *   bun runtime → @modelcontextprotocol/sdk Client
  *               → StreamableHTTPClientTransport
  *               → Hono route /mcp/{workspace}/sse
- *               → verifyAccessToken (mocked — see Phase 2 below)
+ *               → verifyAccessToken (REAL — Phase 2 wires up an
+ *                  in-process Better Auth instance + JWKS, so the
+ *                  bearer goes through real signature verification)
  *               → tools/list, tools/call, prompts/list
  *               → semantic-layer reads (REAL — `findMetricById`,
  *                  `searchGlossary`, `getEntityByName`)
@@ -25,20 +27,25 @@
  *
  * ── Phase split ─────────────────────────────────────────────────────
  *
- * Phase 1 (this file):
- *   - Mocks `verifyAccessToken` so we don't need a real OAuth server.
- *   - Mocks `executeSQL.execute` so we don't need a real Postgres pool +
- *     migrated internal DB. Real SQL execution is covered by the
- *     existing deterministic eval.
- *   - Real semantic-layer reads.
- *   - Asserts on protocol shape, tool dispatch, envelope codes, prompts
- *     list shape, and concurrent-session behavior.
+ * Phase 1 (#2074, PR #2120):
+ *   - Mocked `verifyAccessToken` so the eval did not need a real OAuth
+ *     server. Asserted on protocol shape, tool dispatch, envelope codes,
+ *     prompts list shape, and concurrent-session behavior.
  *
- * Phase 2 (#2119):
- *   - Real DCR + PKCE flow against an in-process Better Auth instance —
- *     covers the JWT signature path the verifier mock currently hides.
- *   - `--mcp-llm` mode where an LLM picks tools through MCP — validates
- *     tool-selection accuracy and recovery contract under prose drift.
+ * Phase 2 (#2119, this file's update):
+ *   - Drops the `verifyAccessToken` mock. Boots an in-process Better
+ *     Auth instance (`canonical-mcp-auth.ts`) with the same `jwt()` +
+ *     `oauthProvider()` plugins production uses, drives the real OAuth
+ *     2.1 loopback flow via `runHostedAuthFlow` test seams, and uses
+ *     the issued bearer JWT for every dispatch. The JWKS path is
+ *     exercised end-to-end so a regression in signature verification,
+ *     audience matching, or issuer matching now fails this eval.
+ *   - Mocks `executeSQL.execute` (unchanged). SQL correctness is owned
+ *     by the existing deterministic eval; this eval validates the MCP
+ *     envelope wrapping.
+ *   - The next phase (#2119 Part B / a follow-up issue) lands the
+ *     `--mcp-llm` mode where an LLM picks tools through MCP — validates
+ *     tool-selection accuracy under prose drift.
  *
  * ── Stress mode ─────────────────────────────────────────────────────
  *
@@ -57,12 +64,10 @@ import {
   afterAll,
   afterEach,
   mock,
-  type Mock,
 } from "bun:test";
 import * as fs from "fs";
 import * as path from "path";
 import type { AdminActionEntry } from "@atlas/api/lib/audit";
-import { ATLAS_OAUTH_WORKSPACE_CLAIM as WORKSPACE_CLAIM } from "@atlas/api/lib/auth/oauth-claims";
 // Pure runner core lives in @atlas/cli — relative path because the cli
 // package doesn't ship an `exports` map. The functions we need
 // (`loadQuestions`, `DEFAULT_QUESTIONS_PATH`) are pure and DB-free.
@@ -77,111 +82,16 @@ import {
   type FailureCategory,
   type McpFailureArtifact,
 } from "./canonical-mcp-failure-artifact";
+import { startEvalAuthServer, type EvalAuthFixture } from "./canonical-mcp-auth";
 
 // ── Module mocks ───────────────────────────────────────────────────
 //
-// Shapes mirror `packages/mcp/src/__tests__/hosted.test.ts`. Every
-// named export is stubbed (CLAUDE.md rule — partial mocks leak).
-
-interface FakeJwtPayload {
-  sub: string;
-  jti?: string;
-  azp?: string;
-  scope?: string;
-  aud?: string | string[];
-  iss?: string;
-  exp?: number;
-  iat?: number;
-  [WORKSPACE_CLAIM]?: string;
-}
-
-const mockVerifyAccessToken: Mock<
-  (token: string, opts: unknown) => Promise<FakeJwtPayload>
-> = mock(async () => {
-  throw new Error("verifyAccessToken called without a stub");
-});
-
-mock.module("better-auth/oauth2", () => ({
-  verifyAccessToken: (token: string, opts: unknown) =>
-    mockVerifyAccessToken(token, opts),
-  authorizationCodeRequest: () => {
-    throw new Error("authorizationCodeRequest called from mcp-eval");
-  },
-  clientCredentialsToken: () => {
-    throw new Error("clientCredentialsToken called from mcp-eval");
-  },
-  clientCredentialsTokenRequest: () => {
-    throw new Error("clientCredentialsTokenRequest called from mcp-eval");
-  },
-  createAuthorizationCodeRequest: () => {
-    throw new Error("createAuthorizationCodeRequest called from mcp-eval");
-  },
-  createAuthorizationURL: () => {
-    throw new Error("createAuthorizationURL called from mcp-eval");
-  },
-  createClientCredentialsTokenRequest: () => {
-    throw new Error("createClientCredentialsTokenRequest called from mcp-eval");
-  },
-  createRefreshAccessTokenRequest: () => {
-    throw new Error("createRefreshAccessTokenRequest called from mcp-eval");
-  },
-  decryptOAuthToken: () => {
-    throw new Error("decryptOAuthToken called from mcp-eval");
-  },
-  generateCodeChallenge: () => {
-    throw new Error("generateCodeChallenge called from mcp-eval");
-  },
-  generateState: () => {
-    throw new Error("generateState called from mcp-eval");
-  },
-  getJwks: () => {
-    throw new Error("getJwks called from mcp-eval");
-  },
-  getOAuth2Tokens: () => {
-    throw new Error("getOAuth2Tokens called from mcp-eval");
-  },
-  handleOAuthUserInfo: () => {
-    throw new Error("handleOAuthUserInfo called from mcp-eval");
-  },
-  parseState: () => {
-    throw new Error("parseState called from mcp-eval");
-  },
-  refreshAccessToken: () => {
-    throw new Error("refreshAccessToken called from mcp-eval");
-  },
-  refreshAccessTokenRequest: () => {
-    throw new Error("refreshAccessTokenRequest called from mcp-eval");
-  },
-  setTokenUtil: () => {
-    throw new Error("setTokenUtil called from mcp-eval");
-  },
-  validateAuthorizationCode: () => {
-    throw new Error("validateAuthorizationCode called from mcp-eval");
-  },
-  validateToken: () => {
-    throw new Error("validateToken called from mcp-eval");
-  },
-  verifyJwsAccessToken: () => {
-    throw new Error("verifyJwsAccessToken called from mcp-eval");
-  },
-}));
-
-// `db/internal` is touched by the route (residency check) and by audit.
-mock.module("@atlas/api/lib/db/internal", () => {
-  const notUsed = (name: string) => () => {
-    throw new Error(`db/internal.${name} called from mcp-eval — add a mock`);
-  };
-  return {
-    getWorkspaceRegion: async () => null,
-    hasInternalDB: () => false,
-    internalQuery: notUsed("internalQuery"),
-    internalExecute: notUsed("internalExecute"),
-    getInternalDB: notUsed("getInternalDB"),
-    assignWorkspaceRegion: notUsed("assignWorkspaceRegion"),
-    isWorkspaceMigrating: async () => false,
-    closeInternalDB: async () => undefined,
-  };
-});
+// Phase 2 dropped the `verifyAccessToken` mock — the bearer is real.
+// `db/internal` is also no longer mocked: with `DATABASE_URL` unset,
+// the real module's `hasInternalDB()` returns false and every query
+// short-circuits to a benign default. CLAUDE.md's "mock every named
+// export" rule made the prior partial mock fragile (it leaked
+// `insertLearnedPattern` etc. into sibling files).
 
 // Audit emission is observability-only for the eval. Drop to in-memory.
 const auditEntries: AdminActionEntry[] = [];
@@ -285,17 +195,13 @@ const SEED_SEMANTIC_DIR = path.join(
 );
 const SEMANTIC_BACKUP_DIR = path.join(REPO_ROOT, ".semantic-backup-mcp-eval");
 
-const ORG_ID = "org_canonical_eval";
-const SUB_ID = "user_canonical_eval";
-const CLIENT_ID = "atlas-canonical-mcp-eval";
-const TOKEN = "fake.canonical.eval.token";
+// Phase 2 — workspace id, user id, and bearer all come from the real
+// OAuth flow. These constants are populated in `beforeAll` after the
+// auth fixture boots; the `let` on the fixture itself stays nullable
+// so tests fail fast (with the assertion message) rather than silently
+// dispatching with stale values.
 
-interface ServerHandle {
-  url: string;
-  close: () => void;
-}
-
-let server: ServerHandle | undefined;
+let authFixture: EvalAuthFixture | undefined;
 
 beforeAll(async () => {
   // Stage the demo semantic layer — same dance the deterministic eval
@@ -337,45 +243,22 @@ beforeAll(async () => {
     throw err;
   }
 
-  // Bind the test bearer to a workspace-scoped JWT payload.
-  mockVerifyAccessToken.mockImplementation(async (token: string) => {
-    if (token === TOKEN) {
-      return {
-        sub: SUB_ID,
-        jti: "jti_canonical",
-        azp: CLIENT_ID,
-        scope: "openid mcp:read",
-        [WORKSPACE_CLAIM]: ORG_ID,
-      } satisfies FakeJwtPayload;
-    }
-    throw new Error(`Unknown token in mcp-eval: ${token}`);
-  });
-
-  // Boot the real router on a random port. We do this once and share
-  // the address across every `it` so the prompts/list, tools/list, and
-  // per-question dispatches all hit the same in-process server.
+  // Boot the real router AND the in-process Better Auth instance on the
+  // same `Bun.serve` port. The MCP route's bearer middleware reads the
+  // request origin to resolve issuer/audience/JWKS — so auth and MCP
+  // MUST share a port (we cannot mount auth on a different host or the
+  // route's `tokenIssuer(req)` would resolve a different origin and
+  // every dispatch would 401 with `invalid_bearer`).
   const { Hono } = await import("hono");
   const { createHostedMcpRouter } = await import("@atlas/mcp/hosted");
-  const app = new Hono();
-  app.route("/mcp", createHostedMcpRouter());
-  const handle = Bun.serve({
-    port: 0,
-    idleTimeout: 0,
-    fetch: app.fetch,
-  });
-  if (typeof handle.port !== "number") {
-    handle.stop(true);
-    throw new Error("Bun.serve did not bind a TCP port for the MCP eval");
-  }
-  server = {
-    url: `http://localhost:${handle.port}`,
-    close: () => handle.stop(true),
-  };
+  const mcpRouter = new Hono();
+  mcpRouter.route("/", createHostedMcpRouter());
+  authFixture = await startEvalAuthServer({ mcpRouter });
 });
 
 afterAll(async () => {
-  server?.close();
-  server = undefined;
+  authFixture?.close();
+  authFixture = undefined;
   const { _resetHostedSessions } = await import("@atlas/mcp/hosted");
   await _resetHostedSessions();
 
@@ -414,11 +297,11 @@ afterEach(async () => {
 });
 
 function newClient(): EvalMcpClient {
-  if (!server) throw new Error("MCP eval server not started");
+  if (!authFixture) throw new Error("MCP eval server not started");
   return new EvalMcpClient({
-    baseUrl: server.url,
-    workspaceId: ORG_ID,
-    bearer: TOKEN,
+    baseUrl: authFixture.baseUrl,
+    workspaceId: authFixture.workspaceId,
+    bearer: authFixture.bearer,
   });
 }
 

--- a/plugins/mcp/src/init/index.ts
+++ b/plugins/mcp/src/init/index.ts
@@ -23,6 +23,26 @@ import {
   type ServeImpl,
 } from "./hosted.js";
 
+// Re-exported so downstream packages (the canonical MCP eval in
+// `packages/mcp/src/__tests__/canonical-mcp-auth.ts`) can drive the
+// real OAuth 2.1 loopback flow against an in-process server. The flow's
+// implementation lives in `./hosted.ts` but we keep the import surface
+// flat so a single `import { runHostedAuthFlow, ... } from
+// "@useatlas/mcp/init"` covers everything callers need.
+export {
+  HostedFlowError,
+  runHostedAuthFlow,
+  type Bearer,
+  type HostedFlowErrorCode,
+  type HostedFlowOptions,
+  type HostedFlowResult,
+  type LoopbackHandler,
+  type LoopbackServer,
+  type OpenBrowserImpl,
+  type OpenBrowserResult,
+  type ServeImpl,
+} from "./hosted.js";
+
 const SERVER_NAME = "atlas";
 // #2068 — `mcp.useatlas.dev` is the brand surface for the hosted MCP
 // endpoint. DNS CNAMEs fan it (and the regional siblings


### PR DESCRIPTION
## Summary

- **Drops the `verifyAccessToken` mock** from the canonical MCP eval. Every dispatch now goes through real JWT signature verification + JWKS resolution against an in-process Better Auth instance configured with the same `jwt()` + `oauthProvider()` plugins production uses. A regression in the JWT-path now fails this gate.
- **`canonical-mcp-auth.ts`** boots that auth fixture, provisions a test admin user + workspace, drives `runHostedAuthFlow` from `@useatlas/mcp/init` with custom `fetchImpl` / `serveImpl` / `openBrowserImpl` seams that dispatch against the in-process app (no network), and returns the issued JWT bearer for the eval to use.
- **Defers `--mcp-llm` mode to Phase 2 part B** (a follow-up issue) — the LLM-on-client tool-selection eval is sizable enough on its own to warrant a separate review surface.

Closes Phase 2 part A of #2119. Phase 2 part B (the `--mcp-llm` mode) tracked separately.

## Why split

The original #2119 spec bundled a real OAuth round-trip + an LLM tool-selection mode + a new CI job that needs an LLM API key secret. That's ~1500–2500 LoC plus CI secret plumbing. This PR is ~700 LoC and closes the higher-value gap (the JWT signature path was completely unverified before). The LLM mode lands cleanly on top in a follow-up PR.

## What's covered now (vs Phase 1)

| Surface | Phase 1 | Phase 2 part A (this PR) |
| --- | --- | --- |
| MCP transport / tool dispatch / envelope shape | real | real |
| `verifyAccessToken` | mocked | **real** |
| JWKS publication / signature verification | not exercised | **real** |
| audience / issuer matching | not exercised | **real** |
| workspace-claim stamping | hand-stubbed payload | **real OAuth flow** |
| `executeSQL` | mocked (owned by deterministic eval) | mocked (unchanged) |
| `--mcp-llm` LLM tool-selection | n/a | deferred to Phase 2 part B |

## Two upstream gaps surfaced (#2124)

Wiring this up surfaced two real bugs in the production OAuth path, filed as #2124:

1. `runHostedAuthFlow` doesn't pass `resource` (RFC 8707), so Better Auth issues opaque (non-JWT) tokens. The MCP edge would reject them.
2. Production's `oauthProvider` config in `packages/api/src/lib/auth/server.ts` is missing `postLogin.consentReferenceId` — the only hook that stamps the URN-shaped workspace claim onto issued tokens. `clientReference` (currently set) only governs DCR client ownership, not token claims.

The eval works around both with a `fetchImpl` body-patcher and a `postLogin.consentReferenceId` in the test auth config. Once #2124 lands, both workarounds can be removed and the eval's helper config will mirror production exactly. Documenting both gaps was independently worthwhile — the eval would never have caught them otherwise.

## Files

- `packages/mcp/src/__tests__/canonical-mcp-auth.ts` (new, ~600 LoC)
- `packages/mcp/src/__tests__/canonical-mcp-auth.test.ts` (new, ~150 LoC)
- `packages/mcp/src/__tests__/canonical-mcp-eval.evalspec.ts` (modified — drops mocks, uses real bearer)
- `plugins/mcp/src/init/index.ts` (re-exports `runHostedAuthFlow` from `./hosted.js`)
- `packages/mcp/package.json` (adds `@better-auth/oauth-provider` devDep)
- `.github/workflows/eval.yml` (auth smoke test runs first; new trigger paths cover `plugins/mcp/src/init/`)
- `apps/docs/content/docs/contributing/eval-harness.mdx` (Phase split updated)

## Test plan

- [x] `bun test ./packages/mcp/src/__tests__/canonical-mcp-auth.test.ts` — 5/5
- [x] `bun test ./packages/mcp/src/__tests__/canonical-mcp-eval.evalspec.ts` — 7/7
- [x] Full `packages/mcp` suite — 183/183
- [x] Affected `packages/api` tests — 21/21
- [x] `bun run lint` — green
- [x] `bun run type` — green
- [x] `bash scripts/check-template-drift.sh` — green
- [x] `bash scripts/check-railway-watch.sh` — green
- [x] `bun x syncpack lint` — green
- [ ] CI: `canonical-mcp-eval (deterministic)` job runs the auth smoke test then the full evalspec end-to-end against the new trigger paths

cc #2074 #2119 #2120 #2124