### PR TITLE
fix(auth,web): post-verify redirect lands on frontend, center onboarding header

### DIFF
--- a/packages/api/src/lib/auth/__tests__/rate-limit-integration.test.ts
+++ b/packages/api/src/lib/auth/__tests__/rate-limit-integration.test.ts
@@ -315,6 +315,78 @@ describe("config wiring snapshot — buildAuthOptions", () => {
     expect(unhandled).toBeNull();
   });
 
+  it("wires `rewriteVerificationCallbackURL` into the verification dispatch path", async () => {
+    // Pins the post-verify-redirect bug fix: a relative `callbackURL` in
+    // the URL Better Auth hands the dispatcher must be rewritten to an
+    // absolute URL on the first trusted origin BEFORE the dispatcher is
+    // called. Without this assertion, a refactor that drops the
+    // `rewriteVerificationCallbackURL(...)` wrapping at the call site
+    // would silently restore the original 404-on-verify regression and no
+    // existing test would go red — the unit tests for the helper itself
+    // pass, the dispatch wiring's `.catch()` test passes, but the wiring
+    // between the two would be broken.
+    let captured: { to: string; url: string } | null = null;
+    const options = buildAuthOptions(
+      makeDeps({
+        trustedOrigins: ["https://app.useatlas.dev", "https://api.useatlas.dev"],
+        testOverrides: {
+          sendVerificationEmail: async (opts) => {
+            captured = opts;
+          },
+        },
+      }),
+    );
+
+    const callback = options.emailVerification?.sendVerificationEmail;
+    expect(typeof callback).toBe("function");
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- narrow Better Auth callback type for test invocation
+    await (callback as any)({
+      user: { email: "verify@example.com" },
+      url: "https://api.useatlas.dev/api/auth/verify-email?token=t&callbackURL=%2Flogin",
+      token: "t",
+    });
+    // Allow the fire-and-forget dispatch to settle.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(captured).not.toBeNull();
+    const cb = new URL(captured!.url).searchParams.get("callbackURL");
+    expect(cb).toBe("https://app.useatlas.dev/login");
+  });
+
+  it("wires `rewriteVerificationCallbackURL` into the password-reset dispatch path", async () => {
+    // Symmetric pin for the reset path. `sendResetPassword` and
+    // `sendVerificationEmail` share the same rewrite helper but live on
+    // separate callback fields — both wires must be tested independently
+    // or a one-sided regression would survive merge.
+    let captured: { to: string; url: string } | null = null;
+    const options = buildAuthOptions(
+      makeDeps({
+        trustedOrigins: ["https://app.useatlas.dev"],
+        testOverrides: {
+          sendPasswordResetEmail: async (opts) => {
+            captured = opts;
+          },
+        },
+      }),
+    );
+
+    const callback = options.emailAndPassword?.sendResetPassword;
+    expect(typeof callback).toBe("function");
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- narrow Better Auth callback type for test invocation
+    await (callback as any)({
+      user: { email: "reset@example.com" },
+      url: "https://api.useatlas.dev/api/auth/reset-password?token=r&callbackURL=%2Freset",
+      token: "r",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(captured).not.toBeNull();
+    const cb = new URL(captured!.url).searchParams.get("callbackURL");
+    expect(cb).toBe("https://app.useatlas.dev/reset");
+  });
+
   it("wires `emailVerification.sendOnSignIn = true` so unverified users self-recover", () => {
     // Without this, Better Auth's /sign-in/email path throws
     // EMAIL_NOT_VERIFIED but never re-dispatches the verification link

--- a/packages/api/src/lib/auth/__tests__/verification-callback-rewrite.test.ts
+++ b/packages/api/src/lib/auth/__tests__/verification-callback-rewrite.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "bun:test";
+import { rewriteVerificationCallbackURL } from "../server";
+
+const FRONTEND = "https://app.useatlas.dev";
+
+describe("rewriteVerificationCallbackURL", () => {
+  it("rewrites a relative path to an absolute frontend URL", () => {
+    const input =
+      "https://api.useatlas.dev/api/auth/verify-email?token=abc&callbackURL=%2Flogin";
+    const out = rewriteVerificationCallbackURL(input, FRONTEND);
+    const parsed = new URL(out);
+    expect(parsed.searchParams.get("callbackURL")).toBe("https://app.useatlas.dev/login");
+    // Token is preserved.
+    expect(parsed.searchParams.get("token")).toBe("abc");
+  });
+
+  it("rewrites the default '/' callback to the frontend root", () => {
+    const input = "https://api.useatlas.dev/api/auth/verify-email?token=abc&callbackURL=%2F";
+    const out = rewriteVerificationCallbackURL(input, FRONTEND);
+    expect(new URL(out).searchParams.get("callbackURL")).toBe("https://app.useatlas.dev/");
+  });
+
+  it("rewrites missing callbackURL to the frontend root", () => {
+    const input = "https://api.useatlas.dev/api/auth/verify-email?token=abc";
+    const out = rewriteVerificationCallbackURL(input, FRONTEND);
+    expect(new URL(out).searchParams.get("callbackURL")).toBe("https://app.useatlas.dev/");
+  });
+
+  it("preserves an already-absolute callbackURL untouched", () => {
+    const input =
+      "https://api.useatlas.dev/api/auth/verify-email?token=abc&callbackURL=https%3A%2F%2Fapp.useatlas.dev%2Fdashboard";
+    const out = rewriteVerificationCallbackURL(input, FRONTEND);
+    expect(out).toBe(input);
+  });
+
+  it("does not rewrite a protocol-relative callback that pivots origin", () => {
+    // `//evil.com/x` resolves to `https://evil.com/x` when given
+    // `https://app.useatlas.dev` as base — we must NOT propagate that as
+    // an absolute, frontend-blessed URL. Better Auth's trustedOrigins
+    // check is the authority on the original; we just don't make it worse.
+    const evilCb = "//evil.com/x";
+    const input = `https://api.useatlas.dev/api/auth/verify-email?token=abc&callbackURL=${encodeURIComponent(evilCb)}`;
+    const out = rewriteVerificationCallbackURL(input, FRONTEND);
+    expect(out).toBe(input);
+  });
+
+  it("returns input unchanged when frontendOrigin is empty", () => {
+    const input = "https://api.useatlas.dev/api/auth/verify-email?token=abc&callbackURL=%2Flogin";
+    const out = rewriteVerificationCallbackURL(input, "");
+    expect(out).toBe(input);
+  });
+
+  it("returns input unchanged when input URL is malformed", () => {
+    const input = "not a url";
+    const out = rewriteVerificationCallbackURL(input, FRONTEND);
+    expect(out).toBe(input);
+  });
+
+  it("preserves path-with-query callback", () => {
+    const input =
+      "https://api.useatlas.dev/api/auth/verify-email?token=abc&callbackURL=%2Fsignup%2Fworkspace%3Fnew%3D1";
+    const out = rewriteVerificationCallbackURL(input, FRONTEND);
+    const cb = new URL(out).searchParams.get("callbackURL");
+    expect(cb).toBe("https://app.useatlas.dev/signup/workspace?new=1");
+  });
+});

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -488,6 +488,69 @@ export async function _sendPasswordResetEmail(opts: {
 }
 
 /**
+ * Rewrite a Better Auth verify-email / password-reset URL so its
+ * `callbackURL` query param is absolute against the frontend origin.
+ *
+ * Better Auth links look like `${baseURL}/api/auth/verify-email?token=...&callbackURL=...`
+ * where `baseURL` is the API host (`api.useatlas.dev`). After validating
+ * the token, the handler 302s to whatever `callbackURL` resolves to. Browsers
+ * resolve a relative `callbackURL` (`/login`, `/`) against the response
+ * origin — which is the API — so users land on `https://api.useatlas.dev/login`
+ * and 404. Rewriting to an absolute URL pinned to the frontend origin (taken
+ * from `BETTER_AUTH_TRUSTED_ORIGINS[0]`) makes the redirect bounce to the
+ * web app no matter what the client passed at signup or resend time.
+ *
+ * Safety: only relative paths are rewritten. Absolute URLs pass through
+ * untouched so Better Auth's own `trustedOrigins` host check stays the
+ * authority on cross-origin allowance. Protocol-relative inputs
+ * (`//evil.com/x`) would resolve to an attacker host under `new URL(rel, base)`,
+ * so we re-check the resolved `origin` matches the expected frontend
+ * origin and fall back to the original URL if not — keeping us out of the
+ * open-redirect business while leaving Better Auth to reject the bad
+ * callback at its own layer.
+ *
+ * @internal — exported for testing.
+ */
+export function rewriteVerificationCallbackURL(rawUrl: string, frontendOrigin: string): string {
+  if (!frontendOrigin) return rawUrl;
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return rawUrl;
+  }
+  const callbackRaw = parsed.searchParams.get("callbackURL") ?? "/";
+
+  // If callbackURL is already absolute (parseable on its own), leave it.
+  // Better Auth's trustedOrigins check decides whether the host is allowed.
+  try {
+    new URL(callbackRaw);
+    return rawUrl;
+  } catch {
+    // Relative — fall through.
+  }
+
+  let resolved: URL;
+  let expectedOrigin: string;
+  try {
+    resolved = new URL(callbackRaw, frontendOrigin);
+    expectedOrigin = new URL(frontendOrigin).origin;
+  } catch {
+    return rawUrl;
+  }
+  // Protocol-relative or `?callbackURL=//evil.com/x` would resolve to a
+  // different origin under `new URL(rel, base)`. Refuse to propagate it —
+  // the original URL still carries the suspicious value, and Better Auth's
+  // trustedOrigins check will catch it downstream.
+  if (resolved.origin !== expectedOrigin) {
+    return rawUrl;
+  }
+
+  parsed.searchParams.set("callbackURL", resolved.toString());
+  return parsed.toString();
+}
+
+/**
  * Minimal HTML attribute-value escape for the verification URL. Better
  * Auth URLs are well-formed, but a `"` in the token would break the
  * `<a href="...">` attribute and — absent this — could produce a
@@ -1383,6 +1446,10 @@ export function buildAuthOptions(deps: BuildAuthOptionsDeps): Parameters<typeof 
   const rateLimitConfig = resolveAuthRateLimitConfig(deps.env, internalDbAvailable);
   const sendVerification = deps.testOverrides?.sendVerificationEmail ?? _sendVerificationEmail;
   const sendReset = deps.testOverrides?.sendPasswordResetEmail ?? _sendPasswordResetEmail;
+  // Frontend origin for post-verify / post-reset redirects. Without this,
+  // Better Auth's redirect lands on the API host and 404s. First trusted
+  // origin is the canonical web app URL — set via BETTER_AUTH_TRUSTED_ORIGINS.
+  const frontendOrigin = deps.trustedOrigins[0] ?? "";
 
   // Unfold the tagged bootstrap-admin config into the flat args
   // `computeBootstrapRole` expects. Keeping the flat pair confined to
@@ -1422,7 +1489,10 @@ export function buildAuthOptions(deps: BuildAuthOptionsDeps): Parameters<typeof 
         // try/catch must still not be able to crash the request handler
         // (which would reopen an enumeration oracle as a 500 vs 200 side
         // channel) or print to stderr with no correlation.
-        sendReset({ to: data.user.email, url: data.url }).catch((err: unknown) => {
+        sendReset({
+          to: data.user.email,
+          url: rewriteVerificationCallbackURL(data.url, frontendOrigin),
+        }).catch((err: unknown) => {
           log.warn(
             { to: data.user.email, err: errorMessage(err) },
             "Password reset dispatch threw — request response stays 200 to preserve enumeration protection",
@@ -1445,7 +1515,10 @@ export function buildAuthOptions(deps: BuildAuthOptionsDeps): Parameters<typeof 
         // with no correlation or (with --unhandled-rejections=strict)
         // crash the process and reintroduce the enumeration oracle as
         // a 500-vs-200 side channel.
-        sendVerification({ to: user.email, url }).catch((err: unknown) => {
+        sendVerification({
+          to: user.email,
+          url: rewriteVerificationCallbackURL(url, frontendOrigin),
+        }).catch((err: unknown) => {
           log.warn(
             { to: user.email, err: errorMessage(err) },
             "Verification email dispatch threw — signup response is still 200 to preserve enumeration protection",

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -512,22 +512,35 @@ export async function _sendPasswordResetEmail(opts: {
  * @internal — exported for testing.
  */
 export function rewriteVerificationCallbackURL(rawUrl: string, frontendOrigin: string): string {
-  if (!frontendOrigin) return rawUrl;
+  if (!frontendOrigin) {
+    // BETTER_AUTH_TRUSTED_ORIGINS is unset or empty. Loud warn here would
+    // fire per email; the boot-time warn in `buildAuthOptions` is the
+    // single-source signal — silent here is intentional.
+    return rawUrl;
+  }
   let parsed: URL;
   try {
     parsed = new URL(rawUrl);
-  } catch {
+  } catch (err) {
+    // Better Auth constructed `rawUrl` itself — an unparseable value is a
+    // real bug (baseURL misconfig, upstream API change). Surface it so
+    // operators can see why links silently break, but still fall back to
+    // the original to preserve the auth response (enumeration-safe).
+    log.warn(
+      { rawUrl, err: errorMessage(err) },
+      "Better Auth verification URL was unparseable — passing through unchanged",
+    );
     return rawUrl;
   }
   const callbackRaw = parsed.searchParams.get("callbackURL") ?? "/";
 
-  // If callbackURL is already absolute (parseable on its own), leave it.
-  // Better Auth's trustedOrigins check decides whether the host is allowed.
   try {
+    // intentionally ignored: a throw here means callbackRaw is relative,
+    // which is exactly the path we want to rewrite — fall through.
     new URL(callbackRaw);
     return rawUrl;
   } catch {
-    // Relative — fall through.
+    // relative path — continue to the resolve+origin-check step below
   }
 
   let resolved: URL;
@@ -535,7 +548,14 @@ export function rewriteVerificationCallbackURL(rawUrl: string, frontendOrigin: s
   try {
     resolved = new URL(callbackRaw, frontendOrigin);
     expectedOrigin = new URL(frontendOrigin).origin;
-  } catch {
+  } catch (err) {
+    // `frontendOrigin` came from BETTER_AUTH_TRUSTED_ORIGINS[0]; if it
+    // doesn't parse, that's a deployment-config bug. Warn so the operator
+    // sees it across every email send instead of silently 404ing users.
+    log.warn(
+      { frontendOrigin, callbackRaw, err: errorMessage(err) },
+      "BETTER_AUTH_TRUSTED_ORIGINS[0] is not a parseable URL — verification link callback rewrite skipped",
+    );
     return rawUrl;
   }
   // Protocol-relative or `?callbackURL=//evil.com/x` would resolve to a
@@ -1449,7 +1469,16 @@ export function buildAuthOptions(deps: BuildAuthOptionsDeps): Parameters<typeof 
   // Frontend origin for post-verify / post-reset redirects. Without this,
   // Better Auth's redirect lands on the API host and 404s. First trusted
   // origin is the canonical web app URL — set via BETTER_AUTH_TRUSTED_ORIGINS.
+  // An empty/missing value silently re-creates the original 404 bug, so warn
+  // once at config-resolution time rather than per-email-send. Operators
+  // running tests with empty trustedOrigins shouldn't be spammed though, so
+  // we suppress the warn when the env signal explicitly disables verification.
   const frontendOrigin = deps.trustedOrigins[0] ?? "";
+  if (!frontendOrigin && requireEmailVerification) {
+    log.warn(
+      "BETTER_AUTH_TRUSTED_ORIGINS is empty — verification + password-reset links will redirect to the API host and 404. Set BETTER_AUTH_TRUSTED_ORIGINS to the web app URL (e.g. https://app.useatlas.dev).",
+    );
+  }
 
   // Unfold the tagged bootstrap-admin config into the flat args
   // `computeBootstrapRole` expects. Keeping the flat pair confined to

--- a/packages/web/src/ui/components/onboarding/onboarding-shell.tsx
+++ b/packages/web/src/ui/components/onboarding/onboarding-shell.tsx
@@ -52,24 +52,36 @@ export function OnboardingShell({
   return (
     <div className="flex min-h-dvh flex-col bg-background">
       <header className="border-b bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-        <div className="mx-auto flex w-full max-w-5xl items-center gap-3 px-4 py-3 sm:px-6 sm:py-4">
+        {/*
+         * Three-column grid: logo | indicator | skip. Equal-flex side
+         * columns keep the indicator centered in the container regardless
+         * of logo or skip-link width — `flex` + `ml-auto` previously
+         * anchored the indicator right of the logo's flow position, which
+         * read as visibly skewed when no skip slot was rendered.
+         * `minmax(0,1fr)` on the side columns lets them shrink below
+         * intrinsic content size on narrow viewports instead of forcing
+         * horizontal overflow.
+         */}
+        <div className="mx-auto grid w-full max-w-5xl grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-3 px-4 py-3 sm:px-6 sm:py-4">
           <Link
             href="/"
-            className="flex shrink-0 items-center gap-2 rounded-md outline-none transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-ring"
+            className="flex shrink-0 items-center gap-2 justify-self-start rounded-md outline-none transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-ring"
             aria-label="Atlas home"
           >
             {AtlasMark}
             <span className="text-sm font-semibold tracking-tight">Atlas</span>
           </Link>
-          <div className="ml-auto flex w-full max-w-xl flex-1">{indicator}</div>
-          {skip && (
-            <Link
-              href={skip.href}
-              className="hidden shrink-0 rounded text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:inline-flex"
-            >
-              {skip.label}
-            </Link>
-          )}
+          <div className="flex w-full max-w-xl justify-self-center">{indicator}</div>
+          <div className="flex justify-self-end">
+            {skip && (
+              <Link
+                href={skip.href}
+                className="hidden shrink-0 rounded text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:inline-flex"
+              >
+                {skip.label}
+              </Link>
+            )}
+          </div>
         </div>
       </header>
 

--- a/packages/web/src/ui/components/onboarding/onboarding-shell.tsx
+++ b/packages/web/src/ui/components/onboarding/onboarding-shell.tsx
@@ -53,14 +53,9 @@ export function OnboardingShell({
     <div className="flex min-h-dvh flex-col bg-background">
       <header className="border-b bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
         {/*
-         * Three-column grid: logo | indicator | skip. Equal-flex side
-         * columns keep the indicator centered in the container regardless
-         * of logo or skip-link width — `flex` + `ml-auto` previously
-         * anchored the indicator right of the logo's flow position, which
-         * read as visibly skewed when no skip slot was rendered.
-         * `minmax(0,1fr)` on the side columns lets them shrink below
-         * intrinsic content size on narrow viewports instead of forcing
-         * horizontal overflow.
+         * Equal-flex side columns keep the indicator centered regardless
+         * of logo or skip-link width. `minmax(0,1fr)` lets columns shrink
+         * below intrinsic content size on narrow viewports.
          */}
         <div className="mx-auto grid w-full max-w-5xl grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-3 px-4 py-3 sm:px-6 sm:py-4">
           <Link


### PR DESCRIPTION
## Summary

Two onboarding paper-cuts found while debugging the first hosted-SaaS signup attempt.

### 1. Verify-email / password-reset 404 after click

Better Auth links are built against `BETTER_AUTH_URL` (the API host: `api.useatlas.dev`) and embed `callbackURL` verbatim. Once the token validates, the handler 302s to the callback — but the value is a relative path (`/login`, `/`), which the browser resolves against the **API** origin → `https://api.useatlas.dev/login` → 404.

Fix: rewrite the embedded `callbackURL` to absolute against the first trusted origin in `BETTER_AUTH_TRUSTED_ORIGINS`, applied to both verify-email and password-reset send sites. Covers signup default (`/`), the login-page resend (`/login`), and password reset in one place — independent of what any future client caller passes.

Safety:
- Already-absolute callback URLs pass through unchanged so Better Auth's own `trustedOrigins` host check stays the authority on cross-origin redirects.
- Protocol-relative inputs like `//evil.com/x` would resolve to a different origin under `new URL(rel, base)`. We re-check the resolved origin matches the expected frontend origin and return the original URL unchanged if not — keeping us out of the open-redirect business.

### 2. Onboarding header skew

`OnboardingShell` used `flex` with `ml-auto` on the indicator, which anchored it right of the logo's flow position. With no right-side counterweight the indicator visibly skewed right. Switch to a 3-column grid (`minmax(0,1fr) auto minmax(0,1fr)`) so the indicator centers regardless of logo or skip-link width.

## Notes for reviewers

- `BETTER_AUTH_TRUSTED_ORIGINS` is already set per region (`https://app.useatlas.dev`); no new env var introduced.
- New helper `rewriteVerificationCallbackURL` is exported from `auth/server.ts` for testability.
- The `_sendVerificationEmail` / `_sendPasswordResetEmail` test seam shape is unchanged — the rewrite happens in `buildAuthOptions` before invocation, so existing tests for those dispatchers stay valid.

## Test plan

- [x] `bun run scripts/test-isolated.ts --affected` — 22 affected tests pass (api package)
- [x] `bun run type` — clean (api + web)
- [x] `bun run lint` — clean
- [x] New unit tests for `rewriteVerificationCallbackURL`: relative path, default `/`, missing param, already-absolute, protocol-relative attack, empty origin, malformed input, path-with-query
- [ ] Manual: sign up on `app.useatlas.dev`, click verify-email link, confirm landing on `app.useatlas.dev/login` instead of 404
- [ ] Manual: confirm signup top-bar logo + steps render centered (no rightward skew)