### PR TITLE
fix(web,signup): show 'check your inbox' interstitial after signup

### DIFF
--- a/packages/web/src/app/login/page.tsx
+++ b/packages/web/src/app/login/page.tsx
@@ -31,6 +31,7 @@ import { getPostSignInRoute } from "./post-sign-in-route";
 import { getPasskeySignIn } from "@/lib/auth/passkey-client";
 import { parsePasskeySignInError } from "@/lib/auth/parse-passkey-sign-in-error";
 import { useWebAuthnSupported } from "@/ui/hooks/use-webauthn-supported";
+import { ResendVerificationButton } from "@/ui/components/auth/resend-verification-button";
 
 type SocialProvider = "google" | "github" | "microsoft";
 
@@ -490,96 +491,10 @@ function SignInErrorAlert({ error }: { error: SignInErrorState }) {
           </a>
         )}
         {error.kind === "email_unverified" && (
-          <ResendVerificationButton email={error.attemptedEmail} />
+          <ResendVerificationButton email={error.attemptedEmail} callbackURL="/login" />
         )}
       </div>
     </div>
   );
 }
 
-/**
- * Manual resend control rendered next to the EMAIL_NOT_VERIFIED alert.
- *
- * `sendOnSignIn: true` on the server already re-issues a verification link
- * on every blocked sign-in attempt — so the most common cause of being stuck
- * (the original signup token expired) self-recovers without this button.
- * The button is for the cases the auto-resend can't cover: a user who hit
- * the page from a stale tab without re-submitting the form, or who needs
- * to re-trigger after checking spam.
- *
- * Better Auth's `/send-verification-email` endpoint is rate-limited
- * server-side; the local 30s cooldown is UX, not a security control —
- * it just stops impatient double-clicks from racing the network round-trip.
- */
-function ResendVerificationButton({ email }: { email: string }) {
-  const [state, setState] = useState<"idle" | "sending" | "sent" | "error">("idle");
-  const [errorMsg, setErrorMsg] = useState<string | null>(null);
-
-  async function handleClick() {
-    if (state === "sending") return;
-    setState("sending");
-    setErrorMsg(null);
-    try {
-      // The cast is the documented workaround for Better Auth's
-      // plugin-augmented client type — `sendVerificationEmail` is a base
-      // action but TS6 strictness loses it through the plugin chain. Same
-      // pattern as `getPasskeyClient()` in `lib/auth/passkey-client.ts`.
-      const send = (
-        authClient as unknown as {
-          sendVerificationEmail?: (opts: { email: string; callbackURL?: string }) => Promise<{
-            data: unknown;
-            error: { message?: string } | null;
-          }>;
-        }
-      ).sendVerificationEmail;
-      if (typeof send !== "function") {
-        throw new Error("sendVerificationEmail action not available on this client");
-      }
-      const result = await send({ email, callbackURL: "/login" });
-      if (result.error) {
-        setErrorMsg(result.error.message ?? "Could not send the email. Please try again.");
-        setState("error");
-        return;
-      }
-      setState("sent");
-    } catch (err) {
-      console.warn(
-        "[login] sendVerificationEmail threw",
-        err instanceof Error ? err.message : String(err),
-      );
-      setErrorMsg("Could not send the email. Please try again.");
-      setState("error");
-    }
-  }
-
-  if (state === "sent") {
-    return (
-      <p className="mt-1 text-xs font-medium text-emerald-700 dark:text-emerald-300">
-        Sent — check your inbox (and spam folder).
-      </p>
-    );
-  }
-
-  return (
-    <div className="mt-1 space-y-1">
-      <button
-        type="button"
-        onClick={handleClick}
-        disabled={state === "sending" || !email}
-        className="inline-flex items-center gap-1 text-xs font-medium text-primary underline-offset-4 hover:underline disabled:cursor-not-allowed disabled:opacity-60"
-      >
-        {state === "sending" ? (
-          <>
-            <Loader2 className="size-3 animate-spin" aria-hidden />
-            Sending…
-          </>
-        ) : (
-          "Resend verification email"
-        )}
-      </button>
-      {state === "error" && errorMsg && (
-        <p className="text-xs text-red-800/90 dark:text-red-200/90">{errorMsg}</p>
-      )}
-    </div>
-  );
-}

--- a/packages/web/src/app/signup/page.tsx
+++ b/packages/web/src/app/signup/page.tsx
@@ -17,6 +17,8 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { GoogleIcon, GitHubIcon, MicrosoftIcon } from "@/ui/components/social-icons";
 import { SignupShell } from "@/ui/components/signup/signup-shell";
+import { ResendVerificationButton } from "@/ui/components/auth/resend-verification-button";
+import { MailCheck } from "lucide-react";
 
 function getApiBase(): string {
   const url = getApiUrl();
@@ -34,6 +36,13 @@ export default function SignupPage() {
   const [loading, setLoading] = useState(false);
   const [socialLoading, setSocialLoading] = useState<string | null>(null);
   const [socialProviders, setSocialProviders] = useState<string[]>([]);
+  // When email verification is required server-side, signup does not create
+  // a session — we can't push to /signup/workspace because the proxy will
+  // bounce the unauthenticated user to /login. Hold the email here to
+  // render the "check your inbox" interstitial instead. The verification
+  // link's callbackURL bounces the user back to /signup/workspace post-verify
+  // (Better Auth auto-signs them in via `autoSignInAfterVerification`).
+  const [pendingEmail, setPendingEmail] = useState<string | null>(null);
 
   useEffect(() => {
     const base = getApiBase();
@@ -63,12 +72,27 @@ export default function SignupPage() {
         email,
         password,
         name: name || email.split("@")[0],
+        // After verification, Better Auth's `autoSignInAfterVerification`
+        // sets the session and 302s here — landing the user on the next
+        // step of the wizard with auth in place.
+        callbackURL: "/signup/workspace",
       });
       if (res.error) {
         setError(res.error.message ?? "Sign up failed");
         return;
       }
-      router.push("/signup/workspace");
+      // If verification is required server-side (`requireEmailVerification:
+      // true`), Better Auth omits the session token from the signup
+      // response. Detect that via `data.token` rather than environment
+      // probes — the response is the source of truth and works in both
+      // managed-SaaS (verification on) and self-hosted-dev (verification
+      // off, autoSignIn on) deployments without a config branch.
+      const token = (res.data as { token?: string | null } | undefined)?.token;
+      if (token) {
+        router.push("/signup/workspace");
+      } else {
+        setPendingEmail(email);
+      }
     } catch (err) {
       console.warn("Signup failed:", err instanceof Error ? err.message : String(err));
       setError(
@@ -97,6 +121,46 @@ export default function SignupPage() {
     } finally {
       setSocialLoading(null);
     }
+  }
+
+  if (pendingEmail) {
+    return (
+      <SignupShell step="account">
+        <Card>
+          <CardHeader className="space-y-3 text-center">
+            <div className="mx-auto flex size-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <MailCheck className="size-6" aria-hidden="true" />
+            </div>
+            <CardTitle className="text-2xl tracking-tight">Check your inbox</CardTitle>
+            <CardDescription>
+              We sent a verification link to{" "}
+              <span className="font-medium text-foreground">{pendingEmail}</span>.
+              Open it to activate your account — we&apos;ll bring you straight to the next step.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3 text-center">
+            <p className="text-xs text-muted-foreground">
+              Wrong email or didn&apos;t see it?
+            </p>
+            <div className="flex items-center justify-center">
+              <ResendVerificationButton
+                email={pendingEmail}
+                callbackURL="/signup/workspace"
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              <button
+                type="button"
+                onClick={() => setPendingEmail(null)}
+                className="font-medium text-primary hover:underline"
+              >
+                Use a different email
+              </button>
+            </p>
+          </CardContent>
+        </Card>
+      </SignupShell>
+    );
   }
 
   return (

--- a/packages/web/src/ui/components/auth/resend-verification-button.tsx
+++ b/packages/web/src/ui/components/auth/resend-verification-button.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+import { authClient } from "@/lib/auth/client";
+
+/**
+ * Resend the verification email for a given address.
+ *
+ * Used by both the login-page EMAIL_NOT_VERIFIED alert (callback `/login`)
+ * and the signup-page "check your email" interstitial (callback
+ * `/signup/workspace`). The 30s local cooldown is UX, not a security
+ * control — the `/send-verification-email` endpoint is rate-limited
+ * server-side.
+ */
+export function ResendVerificationButton({
+  email,
+  callbackURL,
+}: {
+  email: string;
+  callbackURL: string;
+}) {
+  const [state, setState] = useState<"idle" | "sending" | "sent" | "error">("idle");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  async function handleClick() {
+    if (state === "sending") return;
+    setState("sending");
+    setErrorMsg(null);
+    try {
+      // The cast is the documented workaround for Better Auth's
+      // plugin-augmented client type — `sendVerificationEmail` is a base
+      // action but TS6 strictness loses it through the plugin chain.
+      const send = (
+        authClient as unknown as {
+          sendVerificationEmail?: (opts: { email: string; callbackURL?: string }) => Promise<{
+            data: unknown;
+            error: { message?: string } | null;
+          }>;
+        }
+      ).sendVerificationEmail;
+      if (typeof send !== "function") {
+        throw new Error("sendVerificationEmail action not available on this client");
+      }
+      const result = await send({ email, callbackURL });
+      if (result.error) {
+        setErrorMsg(result.error.message ?? "Could not send the email. Please try again.");
+        setState("error");
+        return;
+      }
+      setState("sent");
+    } catch (err) {
+      console.warn(
+        "[auth] sendVerificationEmail threw",
+        err instanceof Error ? err.message : String(err),
+      );
+      setErrorMsg("Could not send the email. Please try again.");
+      setState("error");
+    }
+  }
+
+  if (state === "sent") {
+    return (
+      <p className="mt-1 text-xs font-medium text-emerald-700 dark:text-emerald-300">
+        Sent — check your inbox (and spam folder).
+      </p>
+    );
+  }
+
+  return (
+    <div className="mt-1 space-y-1">
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={state === "sending" || !email}
+        className="inline-flex items-center gap-1 text-xs font-medium text-primary underline-offset-4 hover:underline disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {state === "sending" ? (
+          <>
+            <Loader2 className="size-3 animate-spin" aria-hidden />
+            Sending…
+          </>
+        ) : (
+          "Resend verification email"
+        )}
+      </button>
+      {state === "error" && errorMsg && (
+        <p className="text-xs text-red-800/90 dark:text-red-200/90">{errorMsg}</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Third onboarding paper-cut from the same first-hosted-signup walkthrough. With email verification required server-side, signup does NOT create a session — but `signup/page.tsx` was unconditionally calling `router.push("/signup/workspace")` immediately after a successful response. The proxy treated the unauthenticated visit to `/signup/workspace` as a non-auth route and redirected to `/login`. From the user's perspective the "Create account" button silently restarted the flow.

## Fix

Branch on the signup response's session token:

- `data.token` present → push to `/signup/workspace` (self-hosted dev with `autoSignIn: true`, SSO post-provision, etc.)
- `data.token` absent → render a "check your inbox" interstitial; verification link's `callbackURL` is `/signup/workspace` so `autoSignInAfterVerification` (already configured server-side) lands the user back at the next wizard step with auth in place. Cookie domain is `.useatlas.dev`, so the session cookie set via `api.useatlas.dev` is readable on `app.useatlas.dev`.

`ResendVerificationButton` is extracted from `login/page.tsx` into a shared `ui/components/auth/` component so the new interstitial can reuse it. The login page passes `callbackURL="/login"` (existing behavior preserved); the signup interstitial passes `/signup/workspace`.

## Test plan

- [x] `bun run type` clean
- [x] `bun run lint` clean
- [ ] Manual: sign up at `app.useatlas.dev/signup`, confirm "Check your inbox" view appears with the entered email shown
- [ ] Manual: click verification link in inbox, confirm landing on `app.useatlas.dev/signup/workspace` (with session) instead of `/login`
- [ ] Manual: "Use a different email" link returns to the signup form
- [ ] Manual: "Resend verification email" produces a new email