### PR TITLE
fix(auth): promote org owners via organizationHooks.afterCreateOrganization

### DIFF
--- a/packages/api/src/lib/auth/__tests__/org-owner-promotion.test.ts
+++ b/packages/api/src/lib/auth/__tests__/org-owner-promotion.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Regression coverage for the org-owner → user.role="admin" promotion.
+ *
+ * Why this file exists: the previous wiring lived under
+ * `databaseHooks.member.create.after` and silently never fired in
+ * production — Better Auth's organization plugin inserts the initial
+ * owner-member through its own internal context, bypassing user-defined
+ * `databaseHooks`. Every org owner shipped with `user.role="member"` and
+ * the bug went unnoticed until a real user complained, because zero
+ * tests exercised the hook.
+ *
+ * Two layers of coverage here:
+ *
+ *   1. Unit-test the {@link promoteOrgOwnerToAdmin} function in isolation
+ *      with a mock pool injected via `_resetPool`. Catches body-level
+ *      regressions (forgot the platform_admin guard, swallows wrong
+ *      errors, etc.).
+ *
+ *   2. Assert the organization plugin is actually present in
+ *      {@link buildPlugins}'s output. Catches "someone deleted the
+ *      whole plugin" — a coarse but cheap structural guard.
+ *
+ * What this test cannot catch: a refactor that drops only the
+ * `organizationHooks.afterCreateOrganization: promoteOrgOwnerToAdmin`
+ * line while keeping the plugin and the function. Better Auth closes
+ * over its plugin options so the wiring isn't introspectable from
+ * outside the plugin — closing that residual gap requires either a
+ * full integration test against a live `betterAuth()` instance with
+ * mocked DB (substantial setup) or an out-of-band production invariant
+ * check. Filed separately.
+ */
+
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { _resetPool, type InternalPool } from "@atlas/api/lib/db/internal";
+import { promoteOrgOwnerToAdmin, buildPlugins } from "../server";
+
+const USER = { id: "user_test_123" };
+const ORG = { id: "org_test_456" };
+
+const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
+
+interface MockPool {
+  pool: InternalPool;
+  queries: Array<{ sql: string; params?: unknown[] }>;
+}
+
+function makeMockPool(opts: {
+  selectRole?: string | null;
+  selectThrows?: boolean;
+  updateThrows?: boolean;
+}): MockPool {
+  const queries: Array<{ sql: string; params?: unknown[] }> = [];
+  const pool = {
+    query: async (sql: string, params?: unknown[]) => {
+      queries.push({ sql, params });
+      const isSelect = /^\s*SELECT\b/i.test(sql);
+      if (isSelect) {
+        if (opts.selectThrows) throw new Error("connection refused");
+        return {
+          rows: opts.selectRole === undefined
+            ? [{ role: "member" }]
+            : opts.selectRole === null
+              ? []
+              : [{ role: opts.selectRole }],
+          rowCount: 1,
+        };
+      }
+      // UPDATE path
+      if (opts.updateThrows) throw new Error("UPDATE failed");
+      return { rows: [], rowCount: 1 };
+    },
+  } as unknown as InternalPool;
+  return { pool, queries };
+}
+
+describe("promoteOrgOwnerToAdmin — body", () => {
+  beforeEach(() => {
+    // hasInternalDB() reads DATABASE_URL. Default to "available" — tests
+    // that need the unavailable path override below.
+    process.env.DATABASE_URL = "postgresql://test/test";
+  });
+
+  afterAll(() => {
+    _resetPool(null);
+    if (ORIGINAL_DATABASE_URL === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
+    }
+  });
+
+  it("promotes a member-role user to admin", async () => {
+    const { pool, queries } = makeMockPool({ selectRole: "member" });
+    _resetPool(pool);
+
+    await promoteOrgOwnerToAdmin({ user: USER, organization: ORG });
+
+    // Expect SELECT then UPDATE
+    expect(queries).toHaveLength(2);
+    expect(queries[0].sql).toMatch(/SELECT role FROM "user"/);
+    expect(queries[1].sql).toMatch(/UPDATE "user" SET role = 'admin'/);
+    expect(queries[1].params).toEqual([USER.id]);
+  });
+
+  it("skips when internal DB is unavailable", async () => {
+    delete process.env.DATABASE_URL;
+    const { pool, queries } = makeMockPool({ selectRole: "member" });
+    _resetPool(pool);
+
+    await promoteOrgOwnerToAdmin({ user: USER, organization: ORG });
+
+    expect(queries).toHaveLength(0);
+  });
+
+  it("does not downgrade a platform_admin to admin", async () => {
+    const { pool, queries } = makeMockPool({ selectRole: "platform_admin" });
+    _resetPool(pool);
+
+    await promoteOrgOwnerToAdmin({ user: USER, organization: ORG });
+
+    // SELECT runs, but UPDATE must not
+    expect(queries).toHaveLength(1);
+    expect(queries[0].sql).toMatch(/SELECT/);
+  });
+
+  it("is idempotent — skip when user is already admin", async () => {
+    const { pool, queries } = makeMockPool({ selectRole: "admin" });
+    _resetPool(pool);
+
+    await promoteOrgOwnerToAdmin({ user: USER, organization: ORG });
+
+    expect(queries).toHaveLength(1);
+    expect(queries[0].sql).toMatch(/SELECT/);
+  });
+
+  it("does not throw when the SELECT fails — failure is logged, signup continues", async () => {
+    const { pool } = makeMockPool({ selectThrows: true });
+    _resetPool(pool);
+
+    // Throwing here would block org creation — strictly worse than
+    // landing in a recoverable state where user.role stays "member".
+    await expect(
+      promoteOrgOwnerToAdmin({ user: USER, organization: ORG }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not throw when the UPDATE fails", async () => {
+    const { pool } = makeMockPool({ selectRole: "member", updateThrows: true });
+    _resetPool(pool);
+
+    await expect(
+      promoteOrgOwnerToAdmin({ user: USER, organization: ORG }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("promoteOrgOwnerToAdmin — wiring", () => {
+  it("the organization plugin is present in buildPlugins() output", () => {
+    // Coarse but cheap: catches "someone deleted the org plugin entirely",
+    // which would silently break every signup. Does NOT catch
+    // "someone deleted the organizationHooks.afterCreateOrganization line"
+    // — Better Auth closes over its options, so the hook isn't visible
+    // on the returned plugin descriptor. See file-level comment.
+    const plugins = buildPlugins();
+    const ids = plugins.map((p: { id?: string }) => p.id);
+    expect(ids).toContain("organization");
+  });
+});

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -851,6 +851,44 @@ function buildPlugins() {
     organization({
       ac,
       roles: { owner: ownerRole, admin: adminRole, member: memberRole },
+      organizationHooks: {
+        // Promote the org creator's user-level role to "admin" so Better
+        // Auth's admin plugin APIs (list users, manage roles, etc.) work.
+        // Without this, org owners have user.role="member" and Better Auth
+        // blocks admin operations.
+        //
+        // Lives here rather than in `databaseHooks.member.create.after`
+        // because the org plugin inserts the initial owner-member through
+        // its own internal context, which bypasses user-defined
+        // `databaseHooks` — the previous wiring fired zero times in prod.
+        afterCreateOrganization: async ({ user, organization: org }) => {
+          try {
+            if (!hasInternalDB()) return;
+
+            // Don't downgrade platform_admin → admin
+            const rows = await internalQuery<{ role: string | null }>(
+              `SELECT role FROM "user" WHERE id = $1 LIMIT 1`,
+              [user.id],
+            );
+            const currentRole = rows[0]?.role;
+            if (currentRole === "admin" || currentRole === "platform_admin") return;
+
+            await getInternalDB().query(
+              `UPDATE "user" SET role = 'admin' WHERE id = $1`,
+              [user.id],
+            );
+            log.info(
+              { userId: user.id, orgId: org.id },
+              "Promoted org owner to user-level admin",
+            );
+          } catch (err) {
+            log.warn(
+              { err: errorMessage(err), userId: user.id },
+              "Failed to promote org owner to admin — Better Auth admin APIs may return 403",
+            );
+          }
+        },
+      },
       async sendInvitationEmail(data) {
         log.warn(
           { email: data.email, orgName: data.organization.name, inviterId: data.inviter.user.id },
@@ -1571,13 +1609,14 @@ export function buildAuthOptions(deps: BuildAuthOptionsDeps): Parameters<typeof 
   const adminEmail = deps.bootstrapAdmin.mode === "email" ? deps.bootstrapAdmin.email : undefined;
   const allowFirstSignupAdmin = deps.bootstrapAdmin.mode === "first-signup";
 
-  // Cast at the return point: `databaseHooks.member` is contributed by the
-  // organization plugin at runtime and is not part of Better Auth's base
-  // options shape. `Parameters<typeof betterAuth>[0]` resolves to that
-  // base shape because the function is generic over the plugin tuple,
-  // which we intentionally erase from `BuildAuthOptionsDeps`. The cast
-  // pays the cost of that erasure at the single boundary rather than
-  // forcing every caller through plugin generics.
+  // Cast at the return point: `databaseHooks.session` returns a session
+  // shape augmented with the organization plugin's `activeOrganizationId`,
+  // which is not part of Better Auth's base options shape.
+  // `Parameters<typeof betterAuth>[0]` resolves to that base shape because
+  // the function is generic over the plugin tuple, which we intentionally
+  // erase from `BuildAuthOptionsDeps`. The cast pays the cost of that
+  // erasure at the single boundary rather than forcing every caller
+  // through plugin generics.
   const options = {
     // InternalPool is pg.Pool-shaped via a local alias; Better Auth
     // expects its own pool/adapter surface type. The cast is a one-way
@@ -1670,42 +1709,6 @@ export function buildAuthOptions(deps: BuildAuthOptionsDeps): Parameters<typeof 
     // middleware injects. See `buildAdvancedConfig` for the invariant.
     advanced: buildAdvancedConfig(deps.cookieDomain),
     databaseHooks: {
-      member: {
-        create: {
-          after: async (member: { role: string; userId: string; organizationId: string }) => {
-            // When a user becomes org "owner", promote their user-level role
-            // to "admin" so Better Auth's admin plugin APIs (list users,
-            // manage roles, etc.) work. Without this, org owners have
-            // user.role="member" and Better Auth blocks admin operations.
-            try {
-              if (member.role !== "owner") return;
-              if (!hasInternalDB()) return;
-
-              // Don't downgrade platform_admin → admin
-              const rows = await internalQuery<{ role: string | null }>(
-                `SELECT role FROM "user" WHERE id = $1 LIMIT 1`,
-                [member.userId],
-              );
-              const currentRole = rows[0]?.role;
-              if (currentRole === "admin" || currentRole === "platform_admin") return;
-
-              await getInternalDB().query(
-                `UPDATE "user" SET role = 'admin' WHERE id = $1`,
-                [member.userId],
-              );
-              log.info(
-                { userId: member.userId, orgId: member.organizationId },
-                "Promoted org owner to user-level admin",
-              );
-            } catch (err) {
-              log.warn(
-                { err: errorMessage(err), userId: member.userId },
-                "Failed to promote org owner to admin — Better Auth admin APIs may return 403",
-              );
-            }
-          },
-        },
-      },
       session: {
         create: {
           // Better Auth's hook input for `session.create.before/after` is

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -73,6 +73,60 @@ const log = createLogger("auth:server");
 const billingLog = createLogger("billing");
 
 /**
+ * Promote the org creator's user-level role to "admin" so Better Auth's
+ * admin plugin APIs (list users, manage roles, etc.) work. Without this,
+ * org owners have user.role="member" and Better Auth blocks admin
+ * operations.
+ *
+ * Wired into the organization plugin via
+ * `organizationHooks.afterCreateOrganization` in {@link buildPlugins}.
+ *
+ * Exported for direct unit testing — the org plugin closes over its
+ * options, so the only way to assert this hook's contract from outside
+ * the plugin is to test the function in isolation.
+ *
+ * @internal
+ */
+export async function promoteOrgOwnerToAdmin(args: {
+  user: { id: string };
+  organization: { id: string };
+}): Promise<void> {
+  const { user, organization: org } = args;
+  try {
+    if (!hasInternalDB()) return;
+
+    // Don't downgrade platform_admin → admin
+    const rows = await internalQuery<{ role: string | null }>(
+      `SELECT role FROM "user" WHERE id = $1 LIMIT 1`,
+      [user.id],
+    );
+    const currentRole = rows[0]?.role;
+    if (currentRole === "admin" || currentRole === "platform_admin") return;
+
+    await getInternalDB().query(
+      `UPDATE "user" SET role = 'admin' WHERE id = $1`,
+      [user.id],
+    );
+    log.info(
+      { userId: user.id, orgId: org.id },
+      "Promoted org owner to user-level admin",
+    );
+  } catch (err) {
+    // Escalated to log.error so this surfaces in error-rate alarms.
+    // Failure here means the user signed up, owns an org, but
+    // user.role is stuck at "member" — they can't hit Better Auth
+    // admin APIs. Recoverable via manual UPDATE, but a sustained
+    // rate of this fire indicates a regression in the hook contract
+    // (e.g. Better Auth renamed the option and we silently no-op'd
+    // again — exactly the bug class this hook replaced).
+    log.error(
+      { err: errorMessage(err), userId: user.id, orgId: org.id },
+      "Failed to promote org owner to admin — Better Auth admin APIs will return 403",
+    );
+  }
+}
+
+/**
  * Built-in rate-limit ceilings for Better Auth endpoints. Chosen to slow
  * online brute force and email-verification abuse while tolerating
  * legitimate retry patterns (user fat-fingers password 2–3 times, clicks
@@ -835,7 +889,8 @@ export function resolveRefreshTokenTtlSeconds(env: NodeJS.ProcessEnv): number {
  * This keeps all Stripe dependencies out of the module graph for
  * self-hosted deployments that don't use billing.
  */
-function buildPlugins() {
+/** @internal — exported for wiring assertions in tests. */
+export function buildPlugins() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Better Auth plugin types are complex union types that vary by plugin combination
   const plugins: any[] = [
     bearer(),
@@ -852,42 +907,11 @@ function buildPlugins() {
       ac,
       roles: { owner: ownerRole, admin: adminRole, member: memberRole },
       organizationHooks: {
-        // Promote the org creator's user-level role to "admin" so Better
-        // Auth's admin plugin APIs (list users, manage roles, etc.) work.
-        // Without this, org owners have user.role="member" and Better Auth
-        // blocks admin operations.
-        //
         // Lives here rather than in `databaseHooks.member.create.after`
         // because the org plugin inserts the initial owner-member through
         // its own internal context, which bypasses user-defined
         // `databaseHooks` — the previous wiring fired zero times in prod.
-        afterCreateOrganization: async ({ user, organization: org }) => {
-          try {
-            if (!hasInternalDB()) return;
-
-            // Don't downgrade platform_admin → admin
-            const rows = await internalQuery<{ role: string | null }>(
-              `SELECT role FROM "user" WHERE id = $1 LIMIT 1`,
-              [user.id],
-            );
-            const currentRole = rows[0]?.role;
-            if (currentRole === "admin" || currentRole === "platform_admin") return;
-
-            await getInternalDB().query(
-              `UPDATE "user" SET role = 'admin' WHERE id = $1`,
-              [user.id],
-            );
-            log.info(
-              { userId: user.id, orgId: org.id },
-              "Promoted org owner to user-level admin",
-            );
-          } catch (err) {
-            log.warn(
-              { err: errorMessage(err), userId: user.id },
-              "Failed to promote org owner to admin — Better Auth admin APIs may return 403",
-            );
-          }
-        },
+        afterCreateOrganization: promoteOrgOwnerToAdmin,
       },
       async sendInvitationEmail(data) {
         log.warn(


### PR DESCRIPTION
## Summary

Fixes a silent prod bug where org owners were stuck at `user.role = "member"` instead of being promoted to `"admin"` on org creation, locking them out of Better Auth's admin plugin APIs (list users, manage roles, etc.).

The previous wiring lived under `databaseHooks.member.create.after`, which sounds like it would fire when the `organization` plugin inserts the initial owner-member row. It does not — Better Auth's plugins insert through their own internal context, bypassing user-defined `databaseHooks`. The hook had been silently dead since it shipped.

Verified against prod (`api.useatlas.dev`):

```sql
-- Distribution of user.role across all org owners:
--   member         | 1   ← every non-seeded org owner
--   platform_admin | 1   ← only the ATLAS_ADMIN_EMAIL seed user
```

Logs for the most recent signup: `Demo onboarding complete` ✅, `Promoted org owner to user-level admin` ❌, `Failed to promote` ❌. The hook simply never ran.

## Fix

1. Move the promotion logic into `organizationHooks.afterCreateOrganization` — the documented Better Auth API for "run code after an organization is created" ([docs](https://better-auth.com/docs/plugins/organization#configure-organization-creation-and-update-hooks)). It receives `{ organization, member, user }` and fires reliably for every org creation path.

2. Extract the hook body into a named exported function `promoteOrgOwnerToAdmin` so it's directly testable.

3. Escalate the catch-block log from `log.warn` to `log.error`. Failure here means the user signed up, owns an org, but `user.role` is stuck at `"member"` — exactly the failure mode this PR fixes. Without an error-rate alarm, a future regression (e.g. Better Auth renames the option) silently no-ops again.

Same guards as the previous (broken) implementation:
- Skip if internal DB unavailable
- Don't downgrade `platform_admin` → `admin`
- Idempotent: re-runs are no-ops because the `currentRole === "admin"` early-return short-circuits

Drop the dead `databaseHooks.member.create.after` block and update the cast comment at the return point.

## Tests added

`packages/api/src/lib/auth/__tests__/org-owner-promotion.test.ts` — 7 cases:

- **Body coverage** (uses the existing `_resetPool` test seam, no `mock.module` chains):
  - Promotes a `member`-role user to `admin` (asserts SELECT then UPDATE with the right SQL/params)
  - Skips when internal DB unavailable
  - Does not downgrade `platform_admin` → `admin`
  - Idempotent — skips when user is already `admin`
  - SELECT failure does not bubble (throwing would block org creation — strictly worse)
  - UPDATE failure does not bubble
- **Wiring assertion**: the organization plugin is present in `buildPlugins()` output

What the test cannot catch: a refactor that drops the `organizationHooks.afterCreateOrganization: promoteOrgOwnerToAdmin` line while keeping the plugin and the function. Better Auth closes over plugin options so the wiring isn't introspectable from outside the plugin. Closing this residual gap requires either a live `betterAuth()` integration test (substantial setup) or a production invariant check — documented in the test file's header for the next reader.

## Backfill

One affected user in prod (the only non-seeded org owner). Already manually corrected via single-row `UPDATE` scoped by `id + email + role = 'member'`. No migration needed; new signups will be correct from this PR forward.

## Test plan

- [x] `bun run type` — passes
- [x] `bun run lint` — passes
- [x] `cd packages/api && bun run scripts/test-isolated.ts --affected` — 23/23 pass (covers `auth/`, `admin-*`, `sso-provisioning`, `bootstrap`, `migrate`, `sessions`, the new `org-owner-promotion`)
- [ ] After deploy: sign up a new test user → create org → verify `SELECT role FROM "user" WHERE id = ...` returns `'admin'` and the `Promoted org owner to user-level admin` info log appears