### PR TITLE
fix(api,deploy): ship packages/mcp in API container; surface mount failures at error level

### DIFF
--- a/deploy/api/Dockerfile
+++ b/deploy/api/Dockerfile
@@ -100,6 +100,16 @@ COPY --from=builder --chown=atlas:atlas /app/packages/schemas ./packages/schemas
 COPY --from=builder --chown=atlas:atlas /app/packages/react/dist ./packages/react/dist
 # Hono API server source + dependencies
 COPY --from=builder --chown=atlas:atlas /app/packages/api ./packages/api
+# packages/mcp is the hosted-MCP edge — `api/index.ts` does
+# `import("@atlas/mcp/hosted")` at boot, and the workspace symlink
+# in node_modules/@atlas/mcp resolves to /app/packages/mcp at
+# runtime. Without this COPY, the dynamic import ENOENTs and every
+# request to /mcp/{workspace_id}/sse 404s with the Hono default
+# (no route registered). The pre-fix catch logged at debug level,
+# which prod Pino filters — so the breakage was invisible. See
+# packages/api/src/api/index.ts:482 for the mount + the (now
+# error-level) catch.
+COPY --from=builder --chown=atlas:atlas /app/packages/mcp ./packages/mcp
 COPY --from=builder --chown=atlas:atlas /app/node_modules ./node_modules
 COPY --from=builder --chown=atlas:atlas /app/semantic ./semantic
 COPY --from=builder --chown=atlas:atlas /app/package.json ./package.json

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -83,6 +83,11 @@ COPY --from=nsjail-builder /nsjail-out/ /usr/local/bin/
 COPY --from=builder --chown=atlas:atlas /app/packages/react/dist ./packages/react/dist
 # Hono API server source + dependencies
 COPY --from=builder --chown=atlas:atlas /app/packages/api ./packages/api
+# packages/mcp is the hosted-MCP edge — see deploy/api/Dockerfile
+# for the full rationale. Without this COPY, every request to
+# /mcp/{workspace_id}/sse 404s because the workspace symlink
+# `node_modules/@atlas/mcp` resolves to a missing path.
+COPY --from=builder --chown=atlas:atlas /app/packages/mcp ./packages/mcp
 COPY --from=builder --chown=atlas:atlas /app/node_modules ./node_modules
 COPY --from=builder --chown=atlas:atlas /app/semantic ./semantic
 COPY --from=builder --chown=atlas:atlas /app/package.json ./package.json

--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -486,9 +486,20 @@ try {
   app.route("/mcp", createHostedMcpRouter());
   log.info("Hosted MCP endpoint mounted at /mcp/{workspace_id}/sse");
 } catch (err) {
-  log.debug(
+  // Promoted from log.debug — debug-level messages are filtered by
+  // production Pino, which silently hid a P1 service-unavailable
+  // (every /mcp/{workspace_id}/sse request 404'd). The catch was
+  // originally written for the standalone Vercel template
+  // (`examples/nextjs-standalone`) where the heavy `@atlas/mcp` graph
+  // is intentionally not bundled — but in any deploy that DOES intend
+  // to serve hosted MCP (Railway / Docker), an ENOENT here means the
+  // build pipeline didn't ship `packages/mcp` and operators need to
+  // page on it. Logging at error makes the breakage visible without
+  // changing behaviour for the no-MCP-build case (the message text
+  // still says "agent connections will be unavailable").
+  log.error(
     { err: err instanceof Error ? err.message : String(err) },
-    "Hosted MCP endpoint not available in this build — agent connections via mcp.useatlas.dev will be unavailable",
+    "Hosted MCP endpoint not available in this build — agent connections via mcp.useatlas.dev will be unavailable. If you intended to serve hosted MCP, verify packages/mcp is shipped in the runtime container.",
   );
 }
 


### PR DESCRIPTION
## Summary

Two compounding bugs that were silently 404-ing every hosted MCP request on `mcp.useatlas.dev`:

1. **`packages/mcp` was not being copied into the API runtime container** — both `deploy/api/Dockerfile` (Railway, prod) and `examples/docker/Dockerfile` (template) copy `packages/api`, `packages/types`, `packages/schemas`, etc. into the runner stage, but not `packages/mcp`. The workspace symlink at `node_modules/@atlas/mcp` resolves to a missing path, so the dynamic `import(\"@atlas/mcp/hosted\")` in `api/index.ts:482` ENOENTs and no route is registered at `/mcp/*`.
2. **The mount-failure catch logged at `debug` level** — production Pino filters debug, so the breakage was invisible (no Sentry, no Railway logs, no alert). Promoted to `log.error`.

Result of the gap: real MCP clients (Claude Desktop, Cursor) were silently failing to connect; the load-test runbook in `eval/load-tests/mcp/` was getting 100% failure on `initialize` with no actionable signal. Probing `POST /mcp/{ws}/sse` with a junk bearer returned Hono's default plaintext \"404 Not Found\" instead of the route's JSON 401 — the diagnostic signature of \"no route registered.\"

## How this was found

Smoke-testing the new `/me/load-test/mcp-token` self-mint endpoint (PR #2137). The mint succeeded and the bearer was valid (audit row written, claims correct), but every k6 iteration 404'd on the MCP edge. Probe → no `Hosted MCP endpoint mounted` log line in any recent Railway deploy.

## Not a regression from recent PRs

Verified by checking earlier deploy logs across multiple deploys (PR #2136 era and earlier) — the \"Hosted MCP endpoint mounted\" log line has been absent throughout. The hosted MCP edge has been quietly broken for some time; the load-test runbook is what surfaced it.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun test` smoke on health + me-load-test routes — 37/37 pass, app boots clean
- [ ] Deploy to Railway, verify `Hosted MCP endpoint mounted` log line appears at boot
- [ ] After deploy, probe `POST /mcp/{ws}/sse` with a junk bearer and confirm JSON 401 response (not plaintext 404)
- [ ] Re-run `./eval/load-tests/mcp/loadtest.sh concurrent-sessions -- -e STAGES=1 -e STAGE_SECONDS=10` and confirm the run actually exercises tools