### PR TITLE
fix(mcp): idle-TTL sweep on hosted session map (closes prod cap-saturation)

### DIFF
--- a/eval/load-tests/mcp/cold-start.js
+++ b/eval/load-tests/mcp/cold-start.js
@@ -91,12 +91,13 @@ export default function () {
   sleep(0.25);
 }
 
-export function handleSummary(data) {
+// `loadtest.sh` passes `--summary-export=results/<scenario>-<UTC>.json`.
+// Don't double-emit `summary.json` to cwd.
+export function handleSummary() {
   return {
     'stdout':
       '\nMCP cold-start load test complete.\n' +
       'Read the per-frame breakdown from `http_req_duration{rpc:initialize}` and `{rpc:tools/list}` in the summary.\n' +
       'Total cold-start cost is the sum of those two — that\'s the user-visible "time to first tool dispatch" on a fresh client.\n',
-    'summary.json': JSON.stringify(data, null, 2),
   };
 }

--- a/eval/load-tests/mcp/concurrent-sessions.js
+++ b/eval/load-tests/mcp/concurrent-sessions.js
@@ -119,10 +119,13 @@ export default function () {
   sleep(1);
 }
 
-export function handleSummary(data) {
+// `loadtest.sh` passes `--summary-export=results/<scenario>-<UTC>.json`,
+// so the per-run summary already lands in the right place. Don't also
+// emit `summary.json` to cwd — that just creates a second copy at the
+// repo root that someone has to remember to clean up.
+export function handleSummary() {
   return {
     'stdout': '\nMCP concurrent-sessions load test complete.\n' +
       'Read the per-stage P50/P95/P99 from the time-series export when running with `--out csv=...` or `--out json=...`.\n',
-    'summary.json': JSON.stringify(data, null, 2),
   };
 }

--- a/eval/load-tests/mcp/tool-call-mix.js
+++ b/eval/load-tests/mcp/tool-call-mix.js
@@ -94,11 +94,12 @@ export default function () {
   // happens via TARGET_RPS / constant-arrival-rate when set.
 }
 
-export function handleSummary(data) {
+// `loadtest.sh` passes `--summary-export=results/<scenario>-<UTC>.json`.
+// Don't double-emit `summary.json` to cwd.
+export function handleSummary() {
   return {
     'stdout':
       '\nMCP tool-call-mix load test complete.\n' +
       'Per-tool latencies are exported as `http_req_duration{tool:<name>}` — slice the summary or the time-series export by that tag.\n',
-    'summary.json': JSON.stringify(data, null, 2),
   };
 }

--- a/packages/mcp/src/__tests__/hosted.test.ts
+++ b/packages/mcp/src/__tests__/hosted.test.ts
@@ -235,7 +235,7 @@ mock.module("@atlas/api/lib/tools/sql", () => ({
 }));
 
 const { Hono } = await import("hono");
-const { createHostedMcpRouter, _resetHostedSessions, _hostedSessionCount } =
+const { createHostedMcpRouter, _resetHostedSessions, _hostedSessionCount, _sweepIdleSessionsForTests, _setIdleTimeoutForTests } =
   await import("../hosted.js");
 
 // ── Test fixtures ─────────────────────────────────────────────────────
@@ -1166,6 +1166,151 @@ describe("hosted MCP — capacity", () => {
 
       await client.close();
     } finally {
+      handle.close();
+    }
+  });
+
+  it("evicts idle sessions on cap-pressure so a new connection can land", async () => {
+    // Reproduces the prod incident: prior runs leaked sessions
+    // (Streamable HTTP has no transport-disconnect event for clients
+    // that vanish), pinning the cap until container restart. With the
+    // sweep, a cap-hit triggers eviction of stale entries first.
+    bindToken(TOKEN_A, {
+      sub: SUB_A,
+      azp: CLIENT_A,
+      scope: "openid mcp:read",
+      [WORKSPACE_CLAIM]: ORG_A,
+    });
+    process.env.ATLAS_MCP_MAX_SESSIONS = "1";
+    process.env.ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS = "60000"; // 1 min — at the floor
+    const handle = await startServer();
+    try {
+      // Open one session — fills the cap.
+      const first = new Client({ name: "client-stale", version: "0.0.1" });
+      const firstTransport = new StreamableHTTPClientTransport(
+        new URL(`${handle.url}/mcp/${ORG_A}/sse`),
+        { requestInit: { headers: { Authorization: `Bearer ${TOKEN_A}` } } },
+      );
+      await first.connect(firstTransport);
+      expect(_hostedSessionCount()).toBe(1);
+
+      // Without the sweep this would 503. The sweep with a clock far
+      // enough in the future evicts the stale entry, freeing a slot.
+      // The test drives the sweep directly (not via cap-hit) so the
+      // assertion is unambiguous: sweep evicts, count drops, cap clears.
+      const farFuture = Date.now() + 24 * 60 * 60 * 1000; // +1 day
+      const evicted = _sweepIdleSessionsForTests(farFuture, 60_000);
+      expect(evicted).toBe(1);
+      expect(_hostedSessionCount()).toBe(0);
+
+      // The originally-leaked client object is now orphaned; the
+      // server-side transport+server were closed by the sweep. A new
+      // connection can land cleanly because the cap is no longer
+      // saturated.
+      const second = new Client({ name: "client-fresh", version: "0.0.1" });
+      const secondTransport = new StreamableHTTPClientTransport(
+        new URL(`${handle.url}/mcp/${ORG_A}/sse`),
+        { requestInit: { headers: { Authorization: `Bearer ${TOKEN_A}` } } },
+      );
+      await second.connect(secondTransport);
+      expect(_hostedSessionCount()).toBe(1);
+
+      await second.close();
+    } finally {
+      delete process.env.ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS;
+      handle.close();
+    }
+  });
+
+  it("preserves recently-active sessions across a sweep", async () => {
+    // The sweep must NOT touch sessions whose lastSeenAt is within
+    // the idle window — a busy region with hundreds of healthy
+    // sessions cannot have one stray sweep wipe legitimate users.
+    bindToken(TOKEN_A, {
+      sub: SUB_A,
+      azp: CLIENT_A,
+      scope: "openid mcp:read",
+      [WORKSPACE_CLAIM]: ORG_A,
+    });
+    process.env.ATLAS_MCP_MAX_SESSIONS = "5";
+    process.env.ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS = "60000";
+    const handle = await startServer();
+    try {
+      const client = new Client({ name: "client-active", version: "0.0.1" });
+      const transport = new StreamableHTTPClientTransport(
+        new URL(`${handle.url}/mcp/${ORG_A}/sse`),
+        { requestInit: { headers: { Authorization: `Bearer ${TOKEN_A}` } } },
+      );
+      await client.connect(transport);
+      expect(_hostedSessionCount()).toBe(1);
+
+      // Sweep with a clock that is JUST under the idle threshold —
+      // session was created moments ago, so lastSeenAt is fresh.
+      // Eviction count must be 0; session must still be usable.
+      const evicted = _sweepIdleSessionsForTests(Date.now(), 60_000);
+      expect(evicted).toBe(0);
+      expect(_hostedSessionCount()).toBe(1);
+
+      // Verify the preserved session still functions — listTools is
+      // the cheapest dispatch that hits the existing-session path.
+      const tools = await client.listTools();
+      expect(tools.tools.length).toBeGreaterThan(0);
+
+      await client.close();
+    } finally {
+      delete process.env.ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS;
+      handle.close();
+    }
+  });
+
+  it("on cap-pressure triggers the sweep automatically (regression for the prod incident)", async () => {
+    // End-to-end check: cap=1, open one session, IMMEDIATELY hand-pin
+    // its lastSeenAt to a past value to simulate a leaked client, then
+    // attempt a new init. The route's lazy sweep should evict the
+    // stale entry and accept the new connection without 503.
+    bindToken(TOKEN_A, {
+      sub: SUB_A,
+      azp: CLIENT_A,
+      scope: "openid mcp:read",
+      [WORKSPACE_CLAIM]: ORG_A,
+    });
+    process.env.ATLAS_MCP_MAX_SESSIONS = "1";
+    // Bypass the production 1-min floor so the test can drive the
+    // age-out path with a sub-second sleep instead of a 60s wait.
+    // _setIdleTimeoutForTests is the documented test seam; the
+    // floor stays in place for production callers.
+    _setIdleTimeoutForTests(50); // 50 ms
+    const handle = await startServer();
+    try {
+      // Step 1 — open the session that occupies the cap.
+      const leaker = new Client({ name: "client-leaker", version: "0.0.1" });
+      const leakerTransport = new StreamableHTTPClientTransport(
+        new URL(`${handle.url}/mcp/${ORG_A}/sse`),
+        { requestInit: { headers: { Authorization: `Bearer ${TOKEN_A}` } } },
+      );
+      await leaker.connect(leakerTransport);
+      expect(_hostedSessionCount()).toBe(1);
+
+      // Step 2 — wait past the idle window so the leaker is sweepable.
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      // Step 3 — a fresh init should now succeed because the route's
+      // cap-check sweep evicts the stale leaker.
+      const fresh = new Client({ name: "client-fresh", version: "0.0.1" });
+      const freshTransport = new StreamableHTTPClientTransport(
+        new URL(`${handle.url}/mcp/${ORG_A}/sse`),
+        { requestInit: { headers: { Authorization: `Bearer ${TOKEN_A}` } } },
+      );
+      await fresh.connect(freshTransport);
+
+      // Final state: only the fresh session remains; the leaker was
+      // swept. The assertion is on count so a future bug that
+      // double-counts during the eviction transition would fail it.
+      expect(_hostedSessionCount()).toBe(1);
+
+      await fresh.close();
+    } finally {
+      _setIdleTimeoutForTests(null);
       handle.close();
     }
   });

--- a/packages/mcp/src/hosted.ts
+++ b/packages/mcp/src/hosted.ts
@@ -80,6 +80,17 @@ const log = createLogger("mcp-hosted");
 interface SessionEntry {
   readonly transport: WebStandardStreamableHTTPServerTransport;
   readonly server: McpServer;
+  /**
+   * Wall-clock ms of the most recent successful frame against this
+   * session. Updated on every dispatch (init AND every subsequent
+   * request). The lazy-sweep at session-creation reads this to evict
+   * idle entries when the cap-check trips — see {@link sweepIdleSessions}.
+   *
+   * Mutable by design: a `Map<string, SessionEntry>` of frozen objects
+   * would force a re-set on every dispatch, defeating the cheap-read
+   * property of the on-hot-path activity refresh.
+   */
+  lastSeenAt: number;
 }
 
 const sessions = new Map<string, SessionEntry>();
@@ -108,6 +119,114 @@ function maxSessions(): number {
   return parsed;
 }
 
+// ── Idle-session sweep ─────────────────────────────────────────────
+//
+// Streamable HTTP is request-response, not a long-lived socket — there
+// is no transport-level disconnect event for a client that closes
+// without sending the explicit `DELETE`. Real-world MCP clients
+// (Claude Desktop, Cursor) routinely vanish (laptop lid closed, app
+// killed, OS update) without a clean handshake. The pre-sweep
+// implementation kept those orphaned sessions in the in-memory map
+// forever — eventually saturating `maxSessions()` and 503-ing every
+// new connection until container restart.
+//
+// The sweep evicts any session whose `lastSeenAt` is older than the
+// idle timeout. Eviction calls `transport.close()` + `server.close()`
+// so resources actually free, not just the map entry.
+//
+// Where the sweep runs:
+//
+//   - **Lazily, only on cap-pressure** (inside `dispatchNewSession`
+//     when `sessions.size + pendingReservations >= cap`). A quiet
+//     region with no traffic doesn't burn CPU on a periodic sweep —
+//     leaked sessions linger but cost only memory until the next
+//     connection attempts to create a new one. The newly-arriving
+//     caller pays the O(n) sweep cost, which is the right shape: the
+//     work is amortized against the request that benefits from it.
+//
+// Not used:
+//
+//   - A `setInterval` background sweep would be slightly more
+//     responsive in extreme idle scenarios, but it adds a fiber to
+//     reason about (unref, shutdown ordering, test-time reset) and
+//     spends CPU on regions that have no traffic. Skipped — the lazy
+//     sweep covers every scenario where the cap actually matters.
+//   - SDK-level idle close hooks. The
+//     `WebStandardStreamableHTTPServerTransport` does not expose one;
+//     `transport.onclose` only fires on internal SDK close events
+//     (which Streamable HTTP rarely produces).
+
+const DEFAULT_SESSION_IDLE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+const MIN_SESSION_IDLE_TIMEOUT_MS = 60 * 1000; // 1 minute floor
+
+/**
+ * Test-only override. Bypasses the production floor so the
+ * cap-pressure sweep can be driven end-to-end with sub-second
+ * timeouts. Production must keep the 1-minute floor so a
+ * misconfigured env var can't degenerate the sweep into a
+ * close-everything-on-every-request loop. Production code paths
+ * never set this.
+ */
+let _idleTimeoutOverrideMs: number | null = null;
+
+/** @internal — test-only. Pin idle timeout below the prod floor. */
+export function _setIdleTimeoutForTests(ms: number | null): void {
+  _idleTimeoutOverrideMs = ms;
+}
+
+function sessionIdleTimeoutMs(): number {
+  if (_idleTimeoutOverrideMs !== null) return _idleTimeoutOverrideMs;
+  const raw = process.env.ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS;
+  if (!raw) return DEFAULT_SESSION_IDLE_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < MIN_SESSION_IDLE_TIMEOUT_MS) {
+    log.warn(
+      { raw, floor: MIN_SESSION_IDLE_TIMEOUT_MS },
+      "ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS missing/below floor — falling back to default",
+    );
+    return DEFAULT_SESSION_IDLE_TIMEOUT_MS;
+  }
+  return parsed;
+}
+
+/**
+ * Evict sessions whose `lastSeenAt` is older than the configured
+ * idle timeout. Returns the count of sessions evicted so the caller
+ * can decide whether the cap-check should be retried (a successful
+ * sweep means a slot opened up).
+ *
+ * Eviction calls `transport.close()` + `server.close()` so the
+ * underlying resources are released, not just the map entry. Both
+ * close paths swallow their own errors via `.catch(() => {})` to
+ * match the existing teardown pattern in `_resetHostedSessions` and
+ * `transport.onclose` — a hanging close on a leaked session must not
+ * block the new caller's init from proceeding.
+ */
+function sweepIdleSessions(now: number, idleTimeoutMs: number): number {
+  let evicted = 0;
+  const cutoff = now - idleTimeoutMs;
+  for (const [id, entry] of sessions) {
+    if (entry.lastSeenAt > cutoff) continue;
+    sessions.delete(id);
+    // intentionally ignored: best-effort teardown of an already-
+    // orphaned session — the client that owned this entry is gone
+    // by definition (no frames in `idleTimeoutMs`), so a close
+    // failure has nowhere to surface. The sweep counter is the
+    // signal that matters; missing one out of N closes does not
+    // affect cap accounting.
+    void entry.transport.close().catch(() => {});
+    void entry.server.close().catch(() => {});
+    evicted++;
+  }
+  if (evicted > 0) {
+    log.info(
+      { evicted, remaining: sessions.size, idleTimeoutMs },
+      "Swept idle MCP sessions",
+    );
+  }
+  return evicted;
+}
+
 export function _hostedSessionCount(): number {
   return sessions.size;
 }
@@ -123,6 +242,14 @@ export async function _resetHostedSessions(): Promise<void> {
     await entry.transport.close().catch(() => {});
     await entry.server.close().catch(() => {});
   }
+}
+
+/** @internal — test-only. Drive the sweep deterministically with a pinned clock. */
+export function _sweepIdleSessionsForTests(now?: number, idleTimeoutMs?: number): number {
+  return sweepIdleSessions(
+    now ?? Date.now(),
+    idleTimeoutMs ?? sessionIdleTimeoutMs(),
+  );
 }
 
 // ── OAuth 2.1 verification ─────────────────────────────────────────
@@ -731,6 +858,11 @@ async function dispatchExistingSession(
       },
     );
   }
+  // Refresh the activity timestamp so the lazy sweep at the cap-check
+  // doesn't evict an actively-used session. Updated PRE-dispatch so
+  // a long-running tool call (executeSQL on a large query) doesn't
+  // race with a concurrent sweep observing a stale `lastSeenAt`.
+  entry.lastSeenAt = Date.now();
   return entry.transport.handleRequest(req);
 }
 
@@ -739,14 +871,26 @@ async function dispatchNewSession(
   ctx: InitialFactoryContext,
 ): Promise<Response> {
   const cap = maxSessions();
+
+  // Lazy sweep: when the cap appears full, evict idle sessions FIRST
+  // and re-check. Without this, a region that has accumulated leaked
+  // sessions (Streamable HTTP has no transport disconnect event for
+  // a client that vanishes without sending DELETE — laptop closed,
+  // app killed, OS update) will permanently 503 every new connection
+  // until container restart. The sweep cost is paid only on
+  // cap-pressure, so quiet regions don't burn CPU evicting nothing.
   if (sessions.size + pendingReservations >= cap) {
-    return new Response(
-      JSON.stringify({
-        error: "too_many_sessions",
-        message: "Too many active MCP sessions on this region. Try again later.",
-      }),
-      { status: 503, headers: { "Content-Type": "application/json" } },
-    );
+    sweepIdleSessions(Date.now(), sessionIdleTimeoutMs());
+    if (sessions.size + pendingReservations >= cap) {
+      return new Response(
+        JSON.stringify({
+          error: "too_many_sessions",
+          message:
+            "Too many active MCP sessions on this region. Try again later.",
+        }),
+        { status: 503, headers: { "Content-Type": "application/json" } },
+      );
+    }
   }
 
   pendingReservations++;
@@ -759,7 +903,10 @@ async function dispatchNewSession(
     const transport = new WebStandardStreamableHTTPServerTransport({
       sessionIdGenerator: () => crypto.randomUUID(),
       onsessioninitialized: (id) => {
-        sessions.set(id, { transport, server: mcpServer });
+        // Stamp `lastSeenAt: Date.now()` at registration so the sweep
+        // doesn't immediately evict a freshly-created session that
+        // hasn't yet received a follow-up frame.
+        sessions.set(id, { transport, server: mcpServer, lastSeenAt: Date.now() });
         registered = true;
         emitSessionStartAudit(
           {


### PR DESCRIPTION
## Summary

Hosted MCP sessions never expired. Streamable HTTP is request-response — there's no transport disconnect event for clients that vanish without the explicit `DELETE` (laptop closed, app killed, OS update). Each ghost session occupied a slot in the in-memory `sessions` Map forever. A region accumulating leaks would eventually hit `ATLAS_MCP_MAX_SESSIONS` (default 100) and 503 every new connection until container restart.

## How this surfaced

A load-test ladder run opened 99 sessions; the runtime didn't fully tear them down on graceful-stop. The next load-test invocation hit `503 too_many_sessions` 14,413 times in a row. A direct probe with a fresh JWT also got 503. The cap was saturated by leaked entries from a prior run with no recovery path short of `railway redeploy`.

Real customer impact: a dozen Claude Desktop users force-quitting over a week would lock the region out of new MCP connections.

## Fix

- `lastSeenAt: number` on every `SessionEntry`, refreshed on every dispatch (init + every subsequent frame).
- **Lazy sweep at the cap-check** inside `dispatchNewSession` — when the cap appears full, evict idle entries first and re-check. Quiet regions don't burn CPU on a periodic timer; the work is paid only on cap-pressure, amortized against the request that benefits.
- Eviction calls `transport.close()` + `server.close()` so resources actually free, not just the map entry.
- Default idle timeout 30 min, env-configurable via `ATLAS_MCP_SESSION_IDLE_TIMEOUT_MS`, **floor 1 min** (a misconfigured low value would degenerate into a close-everything loop).
- Test seam `_setIdleTimeoutForTests(ms)` lets the e2e regression test drive the cap-pressure path in <1s without waiting on the production floor.

**Applies to every MCP session, not just load-test bearers.** The sweep doesn't differentiate by bearer source — the leak was caused by real OAuth-flow clients, so the fix has to cover them too.

## Tests

3 new cases in `hosted.test.ts`:
- Sweep evicts a stale entry, freeing the cap (direct sweep).
- Sweep preserves a recently-active session (no false eviction).
- E2E regression: cap=1, leaker session ages out, next init succeeds via the route's automatic sweep on cap-pressure.

185/185 mcp tests pass.

## Operational follow-up (not in this PR — env-var change only)

After this lands, bump the cap on Railway:
```
railway variables --set ATLAS_MCP_MAX_SESSIONS=300
```
Run 1's perf data showed 100 sessions sustained at p95 58ms with plenty of CPU headroom. 300 is conservative for the current per-session memory footprint.

## Bonus cleanup

Each `eval/load-tests/mcp/*.js` script's `handleSummary` was writing `summary.json` to cwd in addition to the `--summary-export` flag the runbook passes. That's why a stray `summary.json` kept landing at the repo root. Removed the duplicate emit.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun test src/__tests__/hosted.test.ts` from `packages/mcp` — 28/28 pass
- [x] Full mcp suite — 185/185 pass
- [ ] After deploy: set `ATLAS_MCP_MAX_SESSIONS=300` on Railway, restart the API container, verify probe hits 401 (not 503) on a fresh init.
- [ ] Re-run the load-test profile (concurrent-sessions + tool-call-mix + cold-start) end-to-end.