### PR TITLE
fix(api,sql): lazy-load org whitelist in validateSQL — unblocks MCP executeSQL

### DIFF
--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -255,7 +255,7 @@ mock.module("@atlas/api/lib/tools/explore", () => ({
 }));
 
 mock.module("@atlas/api/lib/tools/sql", () => ({
-  validateSQL: mock(() => ({ valid: true, classification: { type: "select" } })),
+  validateSQL: mock(async () => ({ valid: true, classification: { type: "select" } })),
   extractClassification: mock(() => ({ type: "select" })),
   parserDatabase: mock(() => "PostgreSQL"),
   executeSQL: {},

--- a/packages/api/src/api/routes/dashboards.ts
+++ b/packages/api/src/api/routes/dashboards.ts
@@ -772,7 +772,7 @@ authed.openapi(refreshCardRoute, async (c) => {
 
     // Validate SQL before execution — card SQL could have been stored before whitelist changes
     const { validateSQL } = yield* Effect.promise(() => import("@atlas/api/lib/tools/sql"));
-    const validation = validateSQL(cardResult.data.sql, cardResult.data.connectionId ?? undefined);
+    const validation = yield* Effect.promise(() => validateSQL(cardResult.data.sql, cardResult.data.connectionId ?? undefined));
     if (!validation.valid) {
       return c.json({ error: "invalid_sql", message: `Card SQL failed validation: ${validation.error}`, requestId }, 400);
     }
@@ -848,7 +848,7 @@ authed.openapi(refreshAllCardsRoute, async (c) => {
       yield* Effect.tryPromise({
         try: async () => {
           // Validate SQL before execution
-          const validation = validateSQL(card.sql, card.connectionId ?? undefined);
+          const validation = await validateSQL(card.sql, card.connectionId ?? undefined);
           if (!validation.valid) {
             log.warn({ cardId: card.id, error: validation.error }, "Bulk refresh: card SQL failed validation");
             failed++;
@@ -1104,9 +1104,12 @@ authed.openapi(suggestCardsRoute, async (c) => {
     const { validateSQL } = yield* Effect.promise(() => import("@atlas/api/lib/tools/sql"));
     const validChartTypes = new Set(CHART_TYPES);
 
-    const suggestions = rawSuggestions
-      .map((s) => {
-        const validation = validateSQL(s.sql, undefined);
+    // validateSQL is now async (lazy-loads the per-org whitelist).
+    // Run validations concurrently — map → Promise.all → filter, same
+    // shape as the prior sync map, with the per-call await contained.
+    const suggestionsResolved = yield* Effect.promise(() =>
+      Promise.all(rawSuggestions.map(async (s) => {
+        const validation = await validateSQL(s.sql, undefined);
         if (!validation.valid) return null;
         const chartType = validChartTypes.has(s.chartType as typeof CHART_TYPES[number]) ? s.chartType : "table";
         return {
@@ -1119,7 +1122,9 @@ authed.openapi(suggestCardsRoute, async (c) => {
           },
           reason: s.reason.slice(0, 500),
         };
-      })
+      }))
+    );
+    const suggestions = suggestionsResolved
       .filter((s): s is NonNullable<typeof s> => s !== null);
 
     return c.json({ suggestions }, 200);

--- a/packages/api/src/api/routes/validate-sql.ts
+++ b/packages/api/src/api/routes/validate-sql.ts
@@ -129,7 +129,7 @@ validateSqlRoute.openapi(
   async (c) => {
     const { sql, connectionId } = c.req.valid("json");
 
-    const result = validateSQL(sql, connectionId);
+    const result = await validateSQL(sql, connectionId);
 
     if (!result.valid) {
       return c.json({

--- a/packages/api/src/lib/__tests__/plugin-aware-validation.test.ts
+++ b/packages/api/src/lib/__tests__/plugin-aware-validation.test.ts
@@ -166,7 +166,7 @@ describe("validateSQL with plugin forbidden patterns", () => {
     });
 
     // UNION is not forbidden for regular postgres, but our plugin says it is
-    const result = validateSQL("SELECT 1 UNION SELECT 2", "strict-ds");
+    const result = await validateSQL("SELECT 1 UNION SELECT 2", "strict-ds");
     expect(result.valid).toBe(false);
     expect(result.error).toContain("UNION");
   });
@@ -182,12 +182,12 @@ describe("validateSQL with plugin forbidden patterns", () => {
     connections.registerDirect("plain", mockConn(), "postgres");
 
     // Blocked on strict
-    expect(validateSQL("SELECT 1 UNION SELECT 2", "strict").valid).toBe(false);
+    expect((await validateSQL("SELECT 1 UNION SELECT 2", "strict")).valid).toBe(false);
 
     // Allowed on plain (postgres has no UNION restriction)
     // Note: this requires the semantic layer whitelist to be off
     process.env.ATLAS_TABLE_WHITELIST = "false";
-    expect(validateSQL("SELECT 1 UNION SELECT 2", "plain").valid).toBe(true);
+    expect((await validateSQL("SELECT 1 UNION SELECT 2", "plain")).valid).toBe(true);
     delete process.env.ATLAS_TABLE_WHITELIST;
   });
 });

--- a/packages/api/src/lib/__tests__/sql-validator-fuzz.test.ts
+++ b/packages/api/src/lib/__tests__/sql-validator-fuzz.test.ts
@@ -73,8 +73,8 @@ const { validateSQL } = await import("@atlas/api/lib/tools/sql");
 // Shared helpers
 // ---------------------------------------------------------------------------
 
-function expectInvalid(sql: string, reasonFragment?: string): void {
-  const r = validateSQL(sql);
+async function expectInvalid(sql: string, reasonFragment?: string): Promise<void> {
+  const r = await validateSQL(sql);
   if (r.valid) {
     throw new Error(`Expected validateSQL to reject but it accepted: ${sql}`);
   }
@@ -85,8 +85,8 @@ function expectInvalid(sql: string, reasonFragment?: string): void {
   }
 }
 
-function expectValid(sql: string): void {
-  const r = validateSQL(sql);
+async function expectValid(sql: string): Promise<void> {
+  const r = await validateSQL(sql);
   if (!r.valid) {
     throw new Error(`Expected validateSQL to accept but it rejected: ${sql} (error: ${r.error})`);
   }
@@ -141,31 +141,31 @@ describe("fuzz: mutation keyword obfuscation", () => {
     });
   }
 
-  it("rejects DML after block comment (stripped before regex)", () => {
+  it("rejects DML after block comment (stripped before regex)", async () => {
     expectInvalid("/* pretend */ DROP TABLE companies", "forbidden");
   });
 
-  it("rejects DML after line comment (stripped before regex)", () => {
+  it("rejects DML after line comment (stripped before regex)", async () => {
     expectInvalid("-- harmless\nDROP TABLE companies", "forbidden");
   });
 
-  it("rejects DML after hash comment (stripped before regex)", () => {
+  it("rejects DML after hash comment (stripped before regex)", async () => {
     expectInvalid("# harmless\nDELETE FROM companies", "forbidden");
   });
 
-  it("rejects DML separated by block comment inside the keyword region", () => {
+  it("rejects DML separated by block comment inside the keyword region", async () => {
     expectInvalid("DROP /* split */ TABLE companies", "forbidden");
   });
 
-  it("rejects DML with internal whitespace variants", () => {
+  it("rejects DML with internal whitespace variants", async () => {
     expectInvalid("DROP\t\nTABLE\tcompanies", "forbidden");
   });
 
-  it("rejects forbidden keyword even with unusual whitespace before it", () => {
+  it("rejects forbidden keyword even with unusual whitespace before it", async () => {
     expectInvalid("\r\n\t  DROP TABLE companies", "forbidden");
   });
 
-  it("does NOT treat Unicode homoglyphs as keywords (both validator and DB reject)", () => {
+  it("does NOT treat Unicode homoglyphs as keywords (both validator and DB reject)", async () => {
     // Cyrillic Е is U+0415, Latin E is U+0045. Neither MySQL nor PG recognize
     // Cyrillic keywords, so no bypass — but the validator should also reject
     // (AST parser fails), giving a uniform reject verdict.
@@ -180,79 +180,79 @@ describe("fuzz: mutation keyword obfuscation", () => {
 describe("fuzz: CTE + real-table collisions", () => {
   useDialect(PG_URL);
 
-  it("accepts CTE that shadows a whitelisted table (no DB-table access)", () => {
+  it("accepts CTE that shadows a whitelisted table (no DB-table access)", async () => {
     expectValid("WITH orders AS (SELECT 42 AS id) SELECT * FROM orders");
   });
 
-  it("rejects CTE that reads from a non-whitelisted real table", () => {
+  it("rejects CTE that reads from a non-whitelisted real table", async () => {
     expectInvalid(
       "WITH x AS (SELECT name FROM secret_data) SELECT * FROM x",
       "not in the allowed list",
     );
   });
 
-  it("rejects outer reference to non-whitelisted table even with valid CTE", () => {
+  it("rejects outer reference to non-whitelisted table even with valid CTE", async () => {
     expectInvalid(
       "WITH x AS (SELECT 1 AS id) SELECT * FROM x JOIN secret_data ON x.id = secret_data.id",
       "not in the allowed list",
     );
   });
 
-  it("rejects CTE that only lives in the WITH block but is never selected", () => {
+  it("rejects CTE that only lives in the WITH block but is never selected", async () => {
     expectInvalid(
       "WITH x AS (SELECT name FROM secret_data) SELECT 1",
       "not in the allowed list",
     );
   });
 
-  it("accepts nested CTEs that only reference whitelisted tables", () => {
+  it("accepts nested CTEs that only reference whitelisted tables", async () => {
     expectValid(
       "WITH a AS (SELECT id FROM companies), b AS (SELECT id FROM a) SELECT * FROM b",
     );
   });
 
-  it("rejects nested CTE where the inner CTE reads a non-whitelisted table", () => {
+  it("rejects nested CTE where the inner CTE reads a non-whitelisted table", async () => {
     expectInvalid(
       "WITH a AS (SELECT id FROM secret_data), b AS (SELECT id FROM a) SELECT * FROM b",
       "not in the allowed list",
     );
   });
 
-  it("accepts WITH RECURSIVE over whitelisted tables", () => {
+  it("accepts WITH RECURSIVE over whitelisted tables", async () => {
     expectValid(
       "WITH RECURSIVE t(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM t WHERE n < 5) SELECT * FROM t",
     );
   });
 
-  it("rejects WITH RECURSIVE with a non-whitelisted anchor", () => {
+  it("rejects WITH RECURSIVE with a non-whitelisted anchor", async () => {
     expectInvalid(
       "WITH RECURSIVE t(n) AS (SELECT id FROM secret_data UNION ALL SELECT n+1 FROM t WHERE n<5) SELECT * FROM t",
       "not in the allowed list",
     );
   });
 
-  it("rejects CTE that UNIONs with a non-whitelisted table", () => {
+  it("rejects CTE that UNIONs with a non-whitelisted table", async () => {
     expectInvalid(
       "WITH x AS (SELECT id FROM companies UNION SELECT id FROM secret_data) SELECT * FROM x",
       "not in the allowed list",
     );
   });
 
-  it("rejects cross-CTE reference to non-whitelisted table", () => {
+  it("rejects cross-CTE reference to non-whitelisted table", async () => {
     expectInvalid(
       "WITH a AS (SELECT id FROM companies), b AS (SELECT id FROM secret_data) SELECT * FROM a, b",
       "not in the allowed list",
     );
   });
 
-  it("accepts CTE named the same as a whitelisted table without leaking real access", () => {
+  it("accepts CTE named the same as a whitelisted table without leaking real access", async () => {
     // The CTE named `companies` shadows the real table. Since the outer query
     // only refers to the CTE name, no real table is accessed. This is valid
     // and expected behavior.
     expectValid("WITH companies AS (SELECT 1 AS id) SELECT * FROM companies");
   });
 
-  it("rejects query that uses same name as both CTE and real non-whitelisted table", () => {
+  it("rejects query that uses same name as both CTE and real non-whitelisted table", async () => {
     // CTE `secret_data` shadows a real table. But the outer SELECT references
     // `other_secret`, which is not whitelisted. Reject.
     expectInvalid(
@@ -269,77 +269,77 @@ describe("fuzz: CTE + real-table collisions", () => {
 describe("fuzz: UNION + subquery + lateral + array-subquery", () => {
   useDialect(PG_URL);
 
-  it("rejects UNION against non-whitelisted table", () => {
+  it("rejects UNION against non-whitelisted table", async () => {
     expectInvalid(
       "SELECT id FROM companies UNION SELECT id FROM secret_data",
       "not in the allowed list",
     );
   });
 
-  it("rejects UNION ALL against non-whitelisted table", () => {
+  it("rejects UNION ALL against non-whitelisted table", async () => {
     expectInvalid(
       "SELECT id FROM companies UNION ALL SELECT id FROM secret_data",
       "not in the allowed list",
     );
   });
 
-  it("rejects INTERSECT against non-whitelisted table", () => {
+  it("rejects INTERSECT against non-whitelisted table", async () => {
     expectInvalid(
       "SELECT id FROM companies INTERSECT SELECT id FROM secret_data",
       "not in the allowed list",
     );
   });
 
-  it("rejects EXCEPT against non-whitelisted table", () => {
+  it("rejects EXCEPT against non-whitelisted table", async () => {
     expectInvalid(
       "SELECT id FROM companies EXCEPT SELECT id FROM secret_data",
       "not in the allowed list",
     );
   });
 
-  it("rejects scalar subquery reading non-whitelisted table", () => {
+  it("rejects scalar subquery reading non-whitelisted table", async () => {
     expectInvalid(
       "SELECT * FROM companies WHERE id = (SELECT max(id) FROM secret_data)",
       "not in the allowed list",
     );
   });
 
-  it("rejects IN-subquery reading non-whitelisted table", () => {
+  it("rejects IN-subquery reading non-whitelisted table", async () => {
     expectInvalid(
       "SELECT * FROM companies WHERE id IN (SELECT id FROM secret_data)",
       "not in the allowed list",
     );
   });
 
-  it("rejects EXISTS-subquery reading non-whitelisted table", () => {
+  it("rejects EXISTS-subquery reading non-whitelisted table", async () => {
     expectInvalid(
       "SELECT * FROM companies c WHERE EXISTS (SELECT 1 FROM secret_data s WHERE s.id = c.id)",
       "not in the allowed list",
     );
   });
 
-  it("rejects FROM-subquery over non-whitelisted table", () => {
+  it("rejects FROM-subquery over non-whitelisted table", async () => {
     expectInvalid(
       "SELECT * FROM (SELECT id FROM secret_data) s",
       "not in the allowed list",
     );
   });
 
-  it("rejects LATERAL join against non-whitelisted table", () => {
+  it("rejects LATERAL join against non-whitelisted table", async () => {
     expectInvalid(
       "SELECT * FROM companies c, LATERAL (SELECT id FROM secret_data WHERE id = c.id) s",
       "not in the allowed list",
     );
   });
 
-  it("rejects CROSS JOIN LATERAL over non-whitelisted table", () => {
+  it("rejects CROSS JOIN LATERAL over non-whitelisted table", async () => {
     expectInvalid(
       "SELECT * FROM companies c CROSS JOIN LATERAL (SELECT id FROM secret_data WHERE id = c.id) s",
       "not in the allowed list",
     );
   });
 
-  it("rejects ARRAY(subquery) over non-whitelisted table", () => {
+  it("rejects ARRAY(subquery) over non-whitelisted table", async () => {
     expectInvalid(
       "SELECT ARRAY(SELECT id FROM secret_data) FROM companies",
       "not in the allowed list",
@@ -355,13 +355,13 @@ describe("fuzz: UNION + subquery + lateral + array-subquery", () => {
     );
   });
 
-  it("accepts deeply nested subqueries over whitelisted tables", () => {
+  it("accepts deeply nested subqueries over whitelisted tables", async () => {
     expectValid(
       "SELECT id FROM companies WHERE id IN (SELECT id FROM people WHERE id IN (SELECT id FROM accounts))",
     );
   });
 
-  it("rejects one non-whitelisted table deep inside otherwise valid nesting", () => {
+  it("rejects one non-whitelisted table deep inside otherwise valid nesting", async () => {
     expectInvalid(
       "SELECT id FROM companies WHERE id IN (SELECT id FROM people WHERE id IN (SELECT id FROM secret_data))",
       "not in the allowed list",
@@ -376,26 +376,26 @@ describe("fuzz: UNION + subquery + lateral + array-subquery", () => {
 describe("fuzz: schema-qualified + quoted identifier whitelist", () => {
   useDialect(PG_URL);
 
-  it("accepts whitelisted table in the default schema", () => {
+  it("accepts whitelisted table in the default schema", async () => {
     expectValid("SELECT * FROM companies");
   });
 
-  it("accepts schema-qualified whitelisted variant", () => {
+  it("accepts schema-qualified whitelisted variant", async () => {
     expectValid("SELECT * FROM public.companies");
   });
 
-  it("accepts non-default schema-qualified variant when whitelisted", () => {
+  it("accepts non-default schema-qualified variant when whitelisted", async () => {
     expectValid("SELECT * FROM analytics.companies");
   });
 
-  it("rejects schema-qualified name whose qualified form is NOT in whitelist", () => {
+  it("rejects schema-qualified name whose qualified form is NOT in whitelist", async () => {
     expectInvalid(
       "SELECT * FROM other_schema.companies",
       "not in the allowed list",
     );
   });
 
-  it("rejects schema-qualified target where only unqualified is whitelisted (cross-schema)", () => {
+  it("rejects schema-qualified target where only unqualified is whitelisted (cross-schema)", async () => {
     // `orders` is whitelisted unqualified but `wicked.orders` is not — reject.
     expectInvalid(
       "SELECT * FROM wicked.orders",
@@ -403,29 +403,29 @@ describe("fuzz: schema-qualified + quoted identifier whitelist", () => {
     );
   });
 
-  it("rejects information_schema.tables (catalog probe)", () => {
+  it("rejects information_schema.tables (catalog probe)", async () => {
     expectInvalid(
       "SELECT table_name FROM information_schema.tables",
       "not in the allowed list",
     );
   });
 
-  it("rejects pg_catalog.pg_tables (catalog probe)", () => {
+  it("rejects pg_catalog.pg_tables (catalog probe)", async () => {
     expectInvalid(
       "SELECT tablename FROM pg_catalog.pg_tables",
       "not in the allowed list",
     );
   });
 
-  it("rejects unqualified pg_tables even though pg_catalog is on search_path", () => {
+  it("rejects unqualified pg_tables even though pg_catalog is on search_path", async () => {
     expectInvalid("SELECT tablename FROM pg_tables", "not in the allowed list");
   });
 
-  it("accepts quoted whitelisted identifier", () => {
+  it("accepts quoted whitelisted identifier", async () => {
     expectValid('SELECT * FROM "companies"');
   });
 
-  it("accepts uppercase quoted identifier that normalizes to whitelist", () => {
+  it("accepts uppercase quoted identifier that normalizes to whitelist", async () => {
     // See F-20 (case-fold collision) in the phase-3 audit. Current validator
     // treats `"COMPANIES"` and `companies` as equivalent, which is the
     // expected current behavior for self-hosted deployments that use
@@ -435,15 +435,15 @@ describe("fuzz: schema-qualified + quoted identifier whitelist", () => {
     expectValid('SELECT * FROM "COMPANIES"');
   });
 
-  it("rejects quoted identifier that is not in the whitelist", () => {
+  it("rejects quoted identifier that is not in the whitelist", async () => {
     expectInvalid('SELECT * FROM "secret_data"', "not in the allowed list");
   });
 
-  it("accepts quoted schema-qualified whitelisted", () => {
+  it("accepts quoted schema-qualified whitelisted", async () => {
     expectValid('SELECT * FROM "public"."companies"');
   });
 
-  it("rejects quoted cross-schema variant", () => {
+  it("rejects quoted cross-schema variant", async () => {
     expectInvalid(
       'SELECT * FROM "other_schema"."companies"',
       "not in the allowed list",
@@ -463,19 +463,19 @@ describe("fuzz: schema-qualified + quoted identifier whitelist", () => {
 describe("fuzz: LIMIT handling at the validator layer", () => {
   useDialect(PG_URL);
 
-  it("accepts a bare SELECT with no LIMIT (auto-appended downstream)", () => {
+  it("accepts a bare SELECT with no LIMIT (auto-appended downstream)", async () => {
     expectValid("SELECT * FROM companies");
   });
 
-  it("accepts SELECT with an explicit LIMIT", () => {
+  it("accepts SELECT with an explicit LIMIT", async () => {
     expectValid("SELECT * FROM companies LIMIT 10");
   });
 
-  it("accepts SELECT with LIMIT and OFFSET", () => {
+  it("accepts SELECT with LIMIT and OFFSET", async () => {
     expectValid("SELECT * FROM companies LIMIT 10 OFFSET 100");
   });
 
-  it("rejects SQL:2008 FETCH FIRST form (node-sql-parser PG grammar gap, documented)", () => {
+  it("rejects SQL:2008 FETCH FIRST form (node-sql-parser PG grammar gap, documented)", async () => {
     // node-sql-parser 5.4 does not recognise the SQL:2008 `FETCH FIRST n ROWS
     // ONLY` construct in PostgreSQL mode. Since the validator rejects on
     // parse failure (by design), queries using this form must be rewritten
@@ -487,13 +487,13 @@ describe("fuzz: LIMIT handling at the validator layer", () => {
     );
   });
 
-  it("accepts UNION with LIMIT on each side", () => {
+  it("accepts UNION with LIMIT on each side", async () => {
     expectValid(
       "(SELECT id FROM companies LIMIT 10) UNION (SELECT id FROM people LIMIT 10)",
     );
   });
 
-  it("accepts nested subquery with inner LIMIT 0 (does not bypass outer count)", () => {
+  it("accepts nested subquery with inner LIMIT 0 (does not bypass outer count)", async () => {
     // A subquery with LIMIT 0 still must pass validation; the outer query has
     // no rows to return from the subquery, but the query is well-formed.
     expectValid(
@@ -501,11 +501,11 @@ describe("fuzz: LIMIT handling at the validator layer", () => {
     );
   });
 
-  it("accepts LIMIT 1 with ORDER BY", () => {
+  it("accepts LIMIT 1 with ORDER BY", async () => {
     expectValid("SELECT * FROM companies ORDER BY id DESC LIMIT 1");
   });
 
-  it("accepts CTE with LIMIT inside the WITH clause", () => {
+  it("accepts CTE with LIMIT inside the WITH clause", async () => {
     expectValid(
       "WITH top AS (SELECT id FROM companies LIMIT 10) SELECT * FROM top",
     );
@@ -519,123 +519,123 @@ describe("fuzz: LIMIT handling at the validator layer", () => {
 describe("fuzz: PostgreSQL dialect escape hatches", () => {
   useDialect(PG_URL);
 
-  it("rejects LOCK TABLE (non-select AST)", () => {
+  it("rejects LOCK TABLE (non-select AST)", async () => {
     expectInvalid("LOCK TABLE companies IN ACCESS SHARE MODE");
   });
 
-  it("rejects SET session var", () => {
+  it("rejects SET session var", async () => {
     expectInvalid("SET search_path TO public");
   });
 
-  it("rejects BEGIN transaction control", () => {
+  it("rejects BEGIN transaction control", async () => {
     // Regex guard passes (no DML); AST parser rejects as non-select type
     expectInvalid("BEGIN");
   });
 
-  it("rejects COMMIT transaction control", () => {
+  it("rejects COMMIT transaction control", async () => {
     expectInvalid("COMMIT");
   });
 
-  it("rejects ROLLBACK transaction control", () => {
+  it("rejects ROLLBACK transaction control", async () => {
     expectInvalid("ROLLBACK");
   });
 
-  it("rejects NOTIFY", () => {
+  it("rejects NOTIFY", async () => {
     expectInvalid("NOTIFY foo, 'payload'");
   });
 
-  it("rejects LISTEN", () => {
+  it("rejects LISTEN", async () => {
     expectInvalid("LISTEN foo");
   });
 
-  it("rejects UNLISTEN", () => {
+  it("rejects UNLISTEN", async () => {
     expectInvalid("UNLISTEN foo");
   });
 
-  it("rejects DEALLOCATE", () => {
+  it("rejects DEALLOCATE", async () => {
     expectInvalid("DEALLOCATE plan1");
   });
 
-  it("rejects DO anonymous block", () => {
+  it("rejects DO anonymous block", async () => {
     expectInvalid("DO $$BEGIN PERFORM 1; END$$");
   });
 
-  it("rejects RAISE plpgsql", () => {
+  it("rejects RAISE plpgsql", async () => {
     expectInvalid("RAISE NOTICE 'hi'");
   });
 
-  it("rejects PREPARE statement", () => {
+  it("rejects PREPARE statement", async () => {
     expectInvalid("PREPARE plan1 AS SELECT 1");
   });
 
-  it("rejects CLUSTER (table maintenance)", () => {
+  it("rejects CLUSTER (table maintenance)", async () => {
     expectInvalid("CLUSTER companies");
   });
 
-  it("rejects DISCARD ALL (session reset)", () => {
+  it("rejects DISCARD ALL (session reset)", async () => {
     expectInvalid("DISCARD ALL");
   });
 
-  it("rejects DECLARE CURSOR", () => {
+  it("rejects DECLARE CURSOR", async () => {
     expectInvalid("DECLARE cur1 CURSOR FOR SELECT * FROM companies");
   });
 
-  it("rejects FETCH from cursor", () => {
+  it("rejects FETCH from cursor", async () => {
     expectInvalid("FETCH NEXT FROM cur1");
   });
 
-  it("rejects CLOSE cursor", () => {
+  it("rejects CLOSE cursor", async () => {
     expectInvalid("CLOSE cur1");
   });
 
-  it("rejects COMMENT ON statement (DDL)", () => {
+  it("rejects COMMENT ON statement (DDL)", async () => {
     expectInvalid("COMMENT ON TABLE companies IS 'annotated'");
   });
 
-  it("rejects dollar-quoted string that contains a forbidden keyword (conservative)", () => {
+  it("rejects dollar-quoted string that contains a forbidden keyword (conservative)", async () => {
     // `$$DROP TABLE$$` is a STRING LITERAL in PG; it does not execute DROP.
     // The regex guard is conservative and rejects — this is a deliberate
     // known false-positive, documented in the main sql.test.ts as well.
     expectInvalid("SELECT $$DROP TABLE$$ FROM companies", "forbidden");
   });
 
-  it("accepts dollar-quoted string with benign content", () => {
+  it("accepts dollar-quoted string with benign content", async () => {
     expectValid("SELECT $$hello$$ AS x FROM companies");
   });
 
-  it("accepts dollar-tagged string with benign content", () => {
+  it("accepts dollar-tagged string with benign content", async () => {
     expectValid("SELECT $tag$ hi $tag$ AS x FROM companies");
   });
 
-  it("does not block pg_read_file (known limitation — DB perms mitigate)", () => {
+  it("does not block pg_read_file (known limitation — DB perms mitigate)", async () => {
     // See F-21. Relies on the DB user lacking superuser privileges.
     expectValid("SELECT pg_read_file('/etc/passwd')");
   });
 
-  it("does not block pg_sleep (mitigated by statement_timeout)", () => {
+  it("does not block pg_sleep (mitigated by statement_timeout)", async () => {
     expectValid("SELECT pg_sleep(29)");
   });
 
-  it("does not block pg_terminate_backend (known limitation)", () => {
+  it("does not block pg_terminate_backend (known limitation)", async () => {
     expectValid("SELECT pg_terminate_backend(12345)");
   });
 
-  it("does not block generate_series set-returning function", () => {
+  it("does not block generate_series set-returning function", async () => {
     expectValid("SELECT * FROM generate_series(1,10)");
   });
 
-  it("does not block current_setting(session var reader)", () => {
+  it("does not block current_setting(session var reader)", async () => {
     expectValid("SELECT * FROM current_setting('search_path')");
   });
 
-  it("rejects CREATE MATERIALIZED VIEW (DDL)", () => {
+  it("rejects CREATE MATERIALIZED VIEW (DDL)", async () => {
     expectInvalid(
       "CREATE MATERIALIZED VIEW foo AS SELECT * FROM companies",
       "forbidden",
     );
   });
 
-  it("rejects REFRESH MATERIALIZED VIEW (DDL-ish)", () => {
+  it("rejects REFRESH MATERIALIZED VIEW (DDL-ish)", async () => {
     expectInvalid("REFRESH MATERIALIZED VIEW foo");
   });
 });
@@ -647,89 +647,89 @@ describe("fuzz: PostgreSQL dialect escape hatches", () => {
 describe("fuzz: MySQL dialect escape hatches", () => {
   useDialect(MYSQL_URL);
 
-  it("rejects SHOW TABLES", () => {
+  it("rejects SHOW TABLES", async () => {
     expectInvalid("SHOW TABLES", "forbidden");
   });
 
-  it("rejects SHOW DATABASES", () => {
+  it("rejects SHOW DATABASES", async () => {
     expectInvalid("SHOW DATABASES", "forbidden");
   });
 
-  it("rejects SHOW GRANTS", () => {
+  it("rejects SHOW GRANTS", async () => {
     expectInvalid("SHOW GRANTS FOR 'root'@'%'", "forbidden");
   });
 
-  it("rejects DESCRIBE", () => {
+  it("rejects DESCRIBE", async () => {
     expectInvalid("DESCRIBE companies", "forbidden");
   });
 
-  it("rejects EXPLAIN SELECT", () => {
+  it("rejects EXPLAIN SELECT", async () => {
     expectInvalid("EXPLAIN SELECT * FROM companies", "forbidden");
   });
 
-  it("rejects USE database", () => {
+  it("rejects USE database", async () => {
     expectInvalid("USE other_database", "forbidden");
   });
 
-  it("rejects HANDLER open", () => {
+  it("rejects HANDLER open", async () => {
     expectInvalid("HANDLER companies OPEN", "forbidden");
   });
 
-  it("rejects LOAD DATA", () => {
+  it("rejects LOAD DATA", async () => {
     expectInvalid(
       "LOAD DATA INFILE '/tmp/x.csv' INTO TABLE companies",
       "forbidden",
     );
   });
 
-  it("rejects LOAD XML", () => {
+  it("rejects LOAD XML", async () => {
     expectInvalid(
       "LOAD XML INFILE '/tmp/x.xml' INTO TABLE companies",
       "forbidden",
     );
   });
 
-  it("rejects SELECT INTO OUTFILE", () => {
+  it("rejects SELECT INTO OUTFILE", async () => {
     expectInvalid(
       "SELECT * FROM companies INTO OUTFILE '/tmp/x'",
       "forbidden",
     );
   });
 
-  it("accepts backtick-quoted whitelisted identifier", () => {
+  it("accepts backtick-quoted whitelisted identifier", async () => {
     expectValid("SELECT `id` FROM `companies`");
   });
 
-  it("rejects backtick-quoted non-whitelisted table", () => {
+  it("rejects backtick-quoted non-whitelisted table", async () => {
     expectInvalid("SELECT `id` FROM `secret_data`", "not in the allowed list");
   });
 
-  it("rejects UNION reaching into mysql.user (schema-qualified)", () => {
+  it("rejects UNION reaching into mysql.user (schema-qualified)", async () => {
     expectInvalid(
       "SELECT id FROM companies UNION SELECT user FROM mysql.user",
       "not in the allowed list",
     );
   });
 
-  it("does not block BENCHMARK (DoS, mitigated by statement_timeout)", () => {
+  it("does not block BENCHMARK (DoS, mitigated by statement_timeout)", async () => {
     expectValid("SELECT BENCHMARK(1000000, MD5('a'))");
   });
 
-  it("does not block SLEEP (mitigated by statement_timeout)", () => {
+  it("does not block SLEEP (mitigated by statement_timeout)", async () => {
     expectValid("SELECT SLEEP(29)");
   });
 
-  it("does not block GET_LOCK (known limitation — mitigated by connection lifecycle)", () => {
+  it("does not block GET_LOCK (known limitation — mitigated by connection lifecycle)", async () => {
     expectValid("SELECT GET_LOCK('x', 30)");
   });
 
-  it("does not block LOAD_FILE (known limitation — FILE privilege required)", () => {
+  it("does not block LOAD_FILE (known limitation — FILE privilege required)", async () => {
     // Blocked at the DB permission layer; file reads need FILE priv which
     // should not be granted to the Atlas user.
     expectValid("SELECT LOAD_FILE('/etc/passwd')");
   });
 
-  it("accepts SELECT INTO @user_variable (session-local, no persistence)", () => {
+  it("accepts SELECT INTO @user_variable (session-local, no persistence)", async () => {
     // MySQL variable assignment. Session-only, not a write to a durable
     // location. Documented as accepted behavior.
     expectValid("SELECT id INTO @my_var FROM companies LIMIT 1");
@@ -743,44 +743,44 @@ describe("fuzz: MySQL dialect escape hatches", () => {
 describe("fuzz: comment smuggling + multi-statement", () => {
   useDialect(PG_URL);
 
-  it("rejects `SELECT 1; DROP TABLE` via regex guard before AST", () => {
+  it("rejects `SELECT 1; DROP TABLE` via regex guard before AST", async () => {
     expectInvalid("SELECT 1; DROP TABLE companies", "forbidden");
   });
 
-  it("rejects two SELECTs separated by semicolon", () => {
+  it("rejects two SELECTs separated by semicolon", async () => {
     expectInvalid("SELECT 1; SELECT 2", "multiple statements");
   });
 
-  it("rejects two SELECTs separated by newline + semicolon", () => {
+  it("rejects two SELECTs separated by newline + semicolon", async () => {
     expectInvalid("SELECT 1\n;SELECT 2", "multiple statements");
   });
 
-  it("rejects multi-statement with leading whitespace", () => {
+  it("rejects multi-statement with leading whitespace", async () => {
     expectInvalid("   SELECT 1;   SELECT 2   ", "multiple statements");
   });
 
-  it("strips block comment and then evaluates stripped content", () => {
+  it("strips block comment and then evaluates stripped content", async () => {
     expectValid("/* banner */ SELECT * FROM companies");
   });
 
-  it("strips line comment and then evaluates stripped content", () => {
+  it("strips line comment and then evaluates stripped content", async () => {
     expectValid("-- banner\nSELECT * FROM companies");
   });
 
-  it("rejects `#` in PostgreSQL mode — AST parser does not accept it", () => {
+  it("rejects `#` in PostgreSQL mode — AST parser does not accept it", async () => {
     // Property: if stripSqlComments normalises something away for regex
     // purposes, the AST parser must still see the original; if it fails
     // there, the query is safely rejected. No bypass.
     expectInvalid("SELECT 1 # trailing comment\nFROM companies", "could not be parsed");
   });
 
-  it("preserves keywords inside string literals (known conservative false positive)", () => {
+  it("preserves keywords inside string literals (known conservative false positive)", async () => {
     // The regex guard rejects even if the keyword is strictly inside a quoted
     // string. This is documented in sql.test.ts and we pin it here too.
     expectInvalid("SELECT 'DELETE' FROM companies", "forbidden");
   });
 
-  it("allows literal semicolon inside a string", () => {
+  it("allows literal semicolon inside a string", async () => {
     expectValid("SELECT ';' FROM companies");
   });
 });
@@ -792,7 +792,7 @@ describe("fuzz: comment smuggling — MySQL dialect slice", () => {
   // per-test `beforeEach` reset but fragile for future tests added between.
   useDialect(MYSQL_URL);
 
-  it("strips hash comment from regex guard (MySQL dialect where # is a valid comment)", () => {
+  it("strips hash comment from regex guard (MySQL dialect where # is a valid comment)", async () => {
     // `#` is a MySQL comment, not PG. stripSqlComments uses a single regex
     // that removes `#` lines unconditionally — safe because the AST parser
     // then sees the original SQL and will reject in PG mode (parser does
@@ -890,8 +890,8 @@ describe("fuzz: generator — whitelisted table × shape must pass", () => {
   for (const table of WHITELISTED_TABLES) {
     for (const shape of SHAPES) {
       const sql = shape(table).replace(/\bsecret_data\b|\bpasswords\b|\bmysql\.user\b|\bpg_catalog\.pg_authid\b|\bother\.companies\b/g, table);
-      it(`accepts ${table} via shape — ${sql.slice(0, 60)}…`, () => {
-        const r = validateSQL(sql);
+      it(`accepts ${table} via shape — ${sql.slice(0, 60)}…`, async () => {
+        const r = await validateSQL(sql);
         expect(r.valid).toBe(true);
       });
     }
@@ -920,7 +920,7 @@ describe("fuzz: regression pins — phase-3 validator bypass fixes", () => {
       process.env.ATLAS_DATASOURCE_URL = MYSQL_URL;
     });
 
-    it("F-17.a: bare /*!50000 UNION ... */ against mysql.user is rejected", () => {
+    it("F-17.a: bare /*!50000 UNION ... */ against mysql.user is rejected", async () => {
       // Unwrap (Option A): `/*!50000 ... */` becomes live SQL so the
       // whitelist sees the mysql.user reference and rejects it.
       expectInvalid(
@@ -929,14 +929,14 @@ describe("fuzz: regression pins — phase-3 validator bypass fixes", () => {
       );
     });
 
-    it("F-17.b: boundary version /*!00000 */ is rejected", () => {
+    it("F-17.b: boundary version /*!00000 */ is rejected", async () => {
       expectInvalid(
         "SELECT 1 /*!00000 UNION SELECT id FROM secret_data */",
         "not in the allowed list",
       );
     });
 
-    it("F-17.c: high-version /*!99999 */ is rejected", () => {
+    it("F-17.c: high-version /*!99999 */ is rejected", async () => {
       // Defense in depth: the validator must not rely on the server version
       // check to decline execution — the unwrap normalizes digits away.
       expectInvalid(
@@ -945,7 +945,7 @@ describe("fuzz: regression pins — phase-3 validator bypass fixes", () => {
       );
     });
 
-    it("F-17.d: /*! (no digits) is rejected", () => {
+    it("F-17.d: /*! (no digits) is rejected", async () => {
       // MariaDB-style conditional comment with no version gate. Regex
       // tolerates `\d{0,5}` so the unwrap still fires.
       expectInvalid(
@@ -954,21 +954,21 @@ describe("fuzz: regression pins — phase-3 validator bypass fixes", () => {
       );
     });
 
-    it("F-17.e: /*! inside a CTE body is rejected", () => {
+    it("F-17.e: /*! inside a CTE body is rejected", async () => {
       expectInvalid(
         "WITH x AS (SELECT 1 /*!50000 UNION SELECT id FROM secret_data */) SELECT * FROM x",
         "not in the allowed list",
       );
     });
 
-    it("F-17.f: /*! smuggling a column into the SELECT list is rejected", () => {
+    it("F-17.f: /*! smuggling a column into the SELECT list is rejected", async () => {
       expectInvalid(
         "SELECT 1 /*!50000 , (SELECT id FROM secret_data LIMIT 1) AS leaked */ FROM companies",
         "not in the allowed list",
       );
     });
 
-    it("F-17.g: nested /*!50000 /*!80000 ... */ */ unwrap exposes the DML keyword", () => {
+    it("F-17.g: nested /*!50000 /*!80000 ... */ */ unwrap exposes the DML keyword", async () => {
       // Loop-until-stable unwrap peels both levels. Inner content `DROP`
       // reaches the regex guard as live SQL and fires a mutation match.
       expectInvalid(
@@ -977,14 +977,14 @@ describe("fuzz: regression pins — phase-3 validator bypass fixes", () => {
       );
     });
 
-    it("F-17.h: unclosed /*!NNNNN ... (EOF, no closing */) still rejected", () => {
+    it("F-17.h: unclosed /*!NNNNN ... (EOF, no closing */) still rejected", async () => {
       // No `*/` means the unwrap regex doesn't fire. The unclosed comment
       // stays intact so the regex guard sees the literal `DROP` inside the
       // prefix and rejects it as a mutation keyword.
       expectInvalid("SELECT 1 /*!50000 DROP", "forbidden");
     });
 
-    it("F-17.i: /*! with whitespace before digits still rejects (MariaDB zero-digit form)", () => {
+    it("F-17.i: /*! with whitespace before digits still rejects (MariaDB zero-digit form)", async () => {
       // Pin the `\d{0,5}` tolerance. MySQL's grammar requires digits to
       // immediately follow `/*!` — a space means this is the MariaDB no-digit
       // form with body ` 50000 UNION ...`, which unwraps to live SQL whose
@@ -997,7 +997,7 @@ describe("fuzz: regression pins — phase-3 validator bypass fixes", () => {
       );
     });
 
-    it("F-17.j: /*!NNNNNN (over-spec six digits) still rejects", () => {
+    it("F-17.j: /*!NNNNNN (over-spec six digits) still rejects", async () => {
       // `\d{0,5}` consumes five digits and leaves the trailing `0` in the
       // body, producing `SELECT 1 0 UNION SELECT ...` which fails parse.
       // If the regex were relaxed to `\d+`, MySQL would simply treat this
@@ -1009,7 +1009,7 @@ describe("fuzz: regression pins — phase-3 validator bypass fixes", () => {
       );
     });
 
-    it("F-17.k: nested /*! /*! ... */ */ (no digits at either level) still rejects", () => {
+    it("F-17.k: nested /*! /*! ... */ */ (no digits at either level) still rejects", async () => {
       // Stacked MariaDB-form wrappers — separate branch through the regex's
       // `\d{0,5}` alternation from the digits+digits nest covered by F-17.g.
       expectInvalid(
@@ -1018,13 +1018,13 @@ describe("fuzz: regression pins — phase-3 validator bypass fixes", () => {
       );
     });
 
-    it("F-17 positive regression: unwrapped /*! against a whitelisted table is accepted", () => {
+    it("F-17 positive regression: unwrapped /*! against a whitelisted table is accepted", async () => {
       // Option A must not over-reject — a `/*!` wrapper around a UNION that
       // only references whitelisted tables unwraps to valid SQL and passes.
       expectValid("SELECT 1 /*!50000 UNION SELECT id FROM companies */");
     });
 
-    it("F-17 string-literal protection: /*! inside a string must not be unwrapped", () => {
+    it("F-17 string-literal protection: /*! inside a string must not be unwrapped", async () => {
       // The unwrap regex alternates with a string-literal arm so a literal
       // `'/*!50000 ...'` stays as a plain string and the query validates
       // against the outer whitelisted table.
@@ -1037,7 +1037,7 @@ describe("fuzz: regression pins — phase-3 validator bypass fixes", () => {
       process.env.ATLAS_DATASOURCE_URL = PG_URL;
     });
 
-    it("PG treats /*!...*/ as a plain comment — payload that WOULD reject if unwrapped stays valid", () => {
+    it("PG treats /*!...*/ as a plain comment — payload that WOULD reject if unwrapped stays valid", async () => {
       // Strong property: the comment body references `mysql.user` (not in the
       // whitelist). If unwrap fired in PG mode, the whitelist would see
       // `mysql.user` and reject. It stays valid because PG skips the unwrap
@@ -1048,7 +1048,7 @@ describe("fuzz: regression pins — phase-3 validator bypass fixes", () => {
     });
   });
 
-  it("F-18 (P2, PostgreSQL, #1773): SELECT INTO new_table is blocked", () => {
+  it("F-18 (P2, PostgreSQL, #1773): SELECT INTO new_table is blocked", async () => {
     process.env.ATLAS_DATASOURCE_URL = PG_URL;
     // PG's `SELECT ... INTO new_table FROM source` creates a table (DDL
     // equivalent). AST-layer guard rejects on `stmt.into.type === "into"`
@@ -1056,26 +1056,26 @@ describe("fuzz: regression pins — phase-3 validator bypass fixes", () => {
     expectInvalid("SELECT * INTO new_table FROM companies", "forbidden");
   });
 
-  it("F-18 regression: plain SELECT still accepted", () => {
+  it("F-18 regression: plain SELECT still accepted", async () => {
     process.env.ATLAS_DATASOURCE_URL = PG_URL;
     expectValid("SELECT * FROM companies");
   });
 
-  it("F-18 regression: MySQL SELECT INTO @var (session variable) still accepted", () => {
+  it("F-18 regression: MySQL SELECT INTO @var (session variable) still accepted", async () => {
     // `INTO @var` is session-local variable assignment — not a table write.
     // AST keyword is "var" so the guard skips it.
     process.env.ATLAS_DATASOURCE_URL = MYSQL_URL;
     expectValid("SELECT id INTO @my_var FROM companies LIMIT 1");
   });
 
-  it("F-18 regression: MySQL multi-variable INTO @a, @b still accepted", () => {
+  it("F-18 regression: MySQL multi-variable INTO @a, @b still accepted", async () => {
     // Multiple variable targets share the same `keyword === "var"` shape.
     // Pin exercises the `var`-carve-out against a richer AST payload.
     process.env.ATLAS_DATASOURCE_URL = MYSQL_URL;
     expectValid("SELECT id, id INTO @a, @b FROM companies LIMIT 1");
   });
 
-  it("F-18 regression: PG SELECT INTO TEMP ... is rejected (parser-layer today, AST-guard if parser adds support)", () => {
+  it("F-18 regression: PG SELECT INTO TEMP ... is rejected (parser-layer today, AST-guard if parser adds support)", async () => {
     // node-sql-parser 5.4 does not recognise PG's `SELECT INTO TEMP t` form,
     // so today this rejects at parse layer. If a future parser release adds
     // support, the AST guard would catch it via `keyword === "temp"` (not
@@ -1084,7 +1084,7 @@ describe("fuzz: regression pins — phase-3 validator bypass fixes", () => {
     expectInvalid("SELECT * INTO TEMP t FROM companies", "could not be parsed");
   });
 
-  it("F-19 (P2, MySQL, #1774): INTO DUMPFILE is blocked", () => {
+  it("F-19 (P2, MySQL, #1774): INTO DUMPFILE is blocked", async () => {
     process.env.ATLAS_DATASOURCE_URL = MYSQL_URL;
     // Regex `INTO\s+(?:OUTFILE|DUMPFILE)` now enumerates both filesystem
     // writing variants. Requires FILE privilege at runtime but the
@@ -1092,7 +1092,7 @@ describe("fuzz: regression pins — phase-3 validator bypass fixes", () => {
     expectInvalid("SELECT * FROM companies INTO DUMPFILE '/tmp/x'", "forbidden");
   });
 
-  it("F-19 regression: INTO OUTFILE still rejected after DUMPFILE extension", () => {
+  it("F-19 regression: INTO OUTFILE still rejected after DUMPFILE extension", async () => {
     process.env.ATLAS_DATASOURCE_URL = MYSQL_URL;
     expectInvalid("SELECT * FROM companies INTO OUTFILE '/tmp/x'", "forbidden");
   });
@@ -1105,17 +1105,17 @@ describe("fuzz: regression pins — phase-3 validator bypass fixes", () => {
     expectValid("SELECT dumpfile FROM companies");
   });
 
-  it("F-19 regression: INTO<TAB>DUMPFILE still rejected (whitespace class, not literal space)", () => {
+  it("F-19 regression: INTO<TAB>DUMPFILE still rejected (whitespace class, not literal space)", async () => {
     process.env.ATLAS_DATASOURCE_URL = MYSQL_URL;
     expectInvalid("SELECT * FROM companies INTO\tDUMPFILE '/tmp/x'", "forbidden");
   });
 
-  it("F-19 regression: INTO<NEWLINE>DUMPFILE still rejected", () => {
+  it("F-19 regression: INTO<NEWLINE>DUMPFILE still rejected", async () => {
     process.env.ATLAS_DATASOURCE_URL = MYSQL_URL;
     expectInvalid("SELECT * FROM companies INTO\nDUMPFILE '/tmp/x'", "forbidden");
   });
 
-  it("F-19 regression: backtick-quoted `DUMPFILE` still rejected by parse layer", () => {
+  it("F-19 regression: backtick-quoted `DUMPFILE` still rejected by parse layer", async () => {
     // MySQL does not accept `` INTO `DUMPFILE` `` as filesystem-write syntax
     // (the keyword must be a bare identifier), so node-sql-parser rejects.
     // Pin documents the layered defence — regex deliberately does NOT match

--- a/packages/api/src/lib/dashboards.ts
+++ b/packages/api/src/lib/dashboards.ts
@@ -774,7 +774,7 @@ export async function refreshDashboardCards(dashboardId: string): Promise<{
 
   for (const card of cards) {
     try {
-      const validation = validateSQL(card.sql, card.connectionId ?? undefined);
+      const validation = await validateSQL(card.sql, card.connectionId ?? undefined);
       if (!validation.valid) {
         log.warn({ cardId: card.id, error: validation.error }, "Auto-refresh: card SQL failed validation");
         failed++;

--- a/packages/api/src/lib/tools/__tests__/sql-connection-whitelist.test.ts
+++ b/packages/api/src/lib/tools/__tests__/sql-connection-whitelist.test.ts
@@ -51,42 +51,42 @@ mock.module("@atlas/api/lib/db/connection", () =>
 const { validateSQL } = await import("../sql");
 
 describe("per-connection whitelist enforcement", () => {
-  it("allows table in default connection whitelist", () => {
-    const result = validateSQL("SELECT * FROM orders");
+  it("allows table in default connection whitelist", async () => {
+    const result = await validateSQL("SELECT * FROM orders");
     expect(result.valid).toBe(true);
   });
 
-  it("allows table in warehouse connection whitelist", () => {
-    const result = validateSQL("SELECT * FROM events", "warehouse");
+  it("allows table in warehouse connection whitelist", async () => {
+    const result = await validateSQL("SELECT * FROM events", "warehouse");
     expect(result.valid).toBe(true);
   });
 
-  it("rejects table not in target connection whitelist", () => {
-    const result = validateSQL("SELECT * FROM orders", "warehouse");
+  it("rejects table not in target connection whitelist", async () => {
+    const result = await validateSQL("SELECT * FROM orders", "warehouse");
     expect(result.valid).toBe(false);
     expect(result.error).toContain("not in the allowed list");
   });
 
-  it("rejects all tables for unknown connection", () => {
+  it("rejects all tables for unknown connection", async () => {
     // getDBType throws for "nonexistent", so validateSQL returns an error
-    const result = validateSQL("SELECT * FROM orders", "nonexistent");
+    const result = await validateSQL("SELECT * FROM orders", "nonexistent");
     expect(result.valid).toBe(false);
     expect(result.error).toContain("not registered");
   });
 
-  it("default connection cannot access warehouse-only tables", () => {
-    const result = validateSQL("SELECT * FROM events");
+  it("default connection cannot access warehouse-only tables", async () => {
+    const result = await validateSQL("SELECT * FROM events");
     expect(result.valid).toBe(false);
     expect(result.error).toContain("not in the allowed list");
   });
 
-  it("allows schema-qualified table in warehouse whitelist", () => {
-    const result = validateSQL("SELECT * FROM analytics.events", "warehouse");
+  it("allows schema-qualified table in warehouse whitelist", async () => {
+    const result = await validateSQL("SELECT * FROM analytics.events", "warehouse");
     expect(result.valid).toBe(true);
   });
 
-  it("rejects schema-qualified table not in warehouse whitelist", () => {
-    const result = validateSQL("SELECT * FROM public.orders", "warehouse");
+  it("rejects schema-qualified table not in warehouse whitelist", async () => {
+    const result = await validateSQL("SELECT * FROM public.orders", "warehouse");
     expect(result.valid).toBe(false);
     expect(result.error).toContain("not in the allowed list");
   });

--- a/packages/api/src/lib/tools/__tests__/sql-org-whitelist.test.ts
+++ b/packages/api/src/lib/tools/__tests__/sql-org-whitelist.test.ts
@@ -45,10 +45,21 @@ mock.module("@atlas/api/lib/logger", () => ({
 const orgTables = new Set(["org_orders", "org_users"]);
 const fileTables = new Set(["file_orders", "file_users", "file_companies"]);
 
+// Track loadOrgWhitelist invocations so the regression test can
+// assert validateSQL preloads the cache. Pre-fix, the MCP edge skipped
+// this preload and getOrgWhitelistedTables returned an empty Set,
+// rejecting every table with `unknown_entity`.
+let loadOrgWhitelistCallCount = 0;
+const loadOrgWhitelistCalls: Array<{ orgId: string; mode: string | undefined }> = [];
+
 mock.module("@atlas/api/lib/semantic", () => ({
   getWhitelistedTables: () => fileTables,
   getOrgWhitelistedTables: (_orgId: string) => orgTables,
-  loadOrgWhitelist: async () => new Map(),
+  loadOrgWhitelist: async (orgId: string, mode: string | undefined) => {
+    loadOrgWhitelistCallCount++;
+    loadOrgWhitelistCalls.push({ orgId, mode });
+    return new Map();
+  },
   invalidateOrgWhitelist: () => {},
   getOrgSemanticIndex: async () => "",
   invalidateOrgSemanticIndex: () => {},
@@ -108,52 +119,77 @@ const { validateSQL } = await import("../sql");
 describe("org-scoped SQL whitelist enforcement", () => {
   beforeEach(() => {
     mockOrgId = undefined;
+    loadOrgWhitelistCallCount = 0;
+    loadOrgWhitelistCalls.length = 0;
   });
 
-  it("uses org whitelist when activeOrganizationId is present", () => {
+  it("uses org whitelist when activeOrganizationId is present", async () => {
     mockOrgId = "org-123";
     // org_orders is in the org whitelist
-    const result = validateSQL("SELECT * FROM org_orders");
+    const result = await validateSQL("SELECT * FROM org_orders");
     expect(result.valid).toBe(true);
   });
 
-  it("rejects tables not in org whitelist even if in file whitelist", () => {
+  it("rejects tables not in org whitelist even if in file whitelist", async () => {
     mockOrgId = "org-123";
     // file_companies is in file whitelist but NOT in org whitelist
-    const result = validateSQL("SELECT * FROM file_companies");
+    const result = await validateSQL("SELECT * FROM file_companies");
     expect(result.valid).toBe(false);
     expect(result.error).toContain("not in the allowed list");
   });
 
-  it("uses file whitelist when no orgId (self-hosted)", () => {
+  it("uses file whitelist when no orgId (self-hosted)", async () => {
     mockOrgId = undefined;
     // file_companies is in the file whitelist
-    const result = validateSQL("SELECT * FROM file_companies");
+    const result = await validateSQL("SELECT * FROM file_companies");
     expect(result.valid).toBe(true);
   });
 
-  it("rejects tables not in file whitelist when no orgId", () => {
+  it("rejects tables not in file whitelist when no orgId", async () => {
     mockOrgId = undefined;
     // org_orders is only in the org whitelist, not file
-    const result = validateSQL("SELECT * FROM org_orders");
+    const result = await validateSQL("SELECT * FROM org_orders");
     expect(result.valid).toBe(false);
     expect(result.error).toContain("not in the allowed list");
   });
 
-  it("org isolation: different orgs see different whitelists", () => {
+  it("preloads the org whitelist on every validateSQL call (regression: MCP edge bug)", async () => {
+    // Pre-fix, the MCP edge tool handler called validateSQL without
+    // first calling loadOrgWhitelist(orgId). getOrgWhitelistedTables
+    // then returned an empty Set (no cache entry for this orgId in
+    // the MCP process), so every table was rejected as unknown_entity.
+    // The chat path (agent.ts:570) preloaded explicitly; the MCP path
+    // didn't. Fixed by lazy-loading inside validateSQL itself —
+    // belt-and-suspenders against any future code path that forgets.
+    mockOrgId = "org-mcp-edge";
+    await validateSQL("SELECT * FROM org_orders");
+    expect(loadOrgWhitelistCallCount).toBe(1);
+    expect(loadOrgWhitelistCalls[0]).toEqual({ orgId: "org-mcp-edge", mode: undefined });
+  });
+
+  it("does NOT preload when no orgId is set (self-hosted no-auth path)", async () => {
+    // Self-hosted with no active org → uses the file whitelist
+    // (loaded once at startup). loadOrgWhitelist must not be called
+    // because there's no org to load for.
+    mockOrgId = undefined;
+    await validateSQL("SELECT * FROM file_companies");
+    expect(loadOrgWhitelistCallCount).toBe(0);
+  });
+
+  it("org isolation: different orgs see different whitelists", async () => {
     // This validates the code path — the mock returns the same set for any orgId,
     // but the important thing is that it calls getOrgWhitelistedTables, not getWhitelistedTables
     mockOrgId = "org-A";
-    const resultA = validateSQL("SELECT * FROM org_users");
+    const resultA = await validateSQL("SELECT * FROM org_users");
     expect(resultA.valid).toBe(true);
 
     mockOrgId = "org-B";
-    const resultB = validateSQL("SELECT * FROM org_users");
+    const resultB = await validateSQL("SELECT * FROM org_users");
     expect(resultB.valid).toBe(true);
 
     // File-only table rejected for both orgs
     mockOrgId = "org-A";
-    const resultFile = validateSQL("SELECT * FROM file_companies");
+    const resultFile = await validateSQL("SELECT * FROM file_companies");
     expect(resultFile.valid).toBe(false);
   });
 });

--- a/packages/api/src/lib/tools/__tests__/sql.test.ts
+++ b/packages/api/src/lib/tools/__tests__/sql.test.ts
@@ -47,13 +47,13 @@ const { validateSQL } = await import("@atlas/api/lib/tools/sql");
 // Helpers
 // ---------------------------------------------------------------------------
 
-function expectValid(sql: string) {
-  const result = validateSQL(sql);
+async function expectValid(sql: string) {
+  const result = await validateSQL(sql);
   expect(result.valid).toBe(true);
 }
 
-function expectInvalid(sql: string, messageSubstring?: string) {
-  const result = validateSQL(sql);
+async function expectInvalid(sql: string, messageSubstring?: string) {
+  const result = await validateSQL(sql);
   expect(result.valid).toBe(false);
   expect(result.error).toBeDefined();
   if (messageSubstring) {
@@ -78,190 +78,190 @@ describe("validateSQL", () => {
   // ----- Valid SELECT queries ------------------------------------------------
 
   describe("valid SELECT queries", () => {
-    it("accepts a simple SELECT", () => {
-      expectValid("SELECT id, name FROM companies");
+    it("accepts a simple SELECT", async () => {
+      await expectValid("SELECT id, name FROM companies");
     });
 
-    it("accepts SELECT *", () => {
-      expectValid("SELECT * FROM companies");
+    it("accepts SELECT *", async () => {
+      await expectValid("SELECT * FROM companies");
     });
 
-    it("accepts SELECT with WHERE", () => {
-      expectValid("SELECT id FROM companies WHERE name = 'Acme'");
+    it("accepts SELECT with WHERE", async () => {
+      await expectValid("SELECT id FROM companies WHERE name = 'Acme'");
     });
 
-    it("accepts SELECT with JOIN", () => {
-      expectValid(
+    it("accepts SELECT with JOIN", async () => {
+      await expectValid(
         "SELECT c.name, p.name FROM companies c JOIN people p ON c.id = p.company_id"
       );
     });
 
-    it("accepts LEFT JOIN", () => {
-      expectValid(
+    it("accepts LEFT JOIN", async () => {
+      await expectValid(
         "SELECT c.name, a.type FROM companies c LEFT JOIN accounts a ON c.id = a.company_id"
       );
     });
 
-    it("accepts subqueries", () => {
-      expectValid(
+    it("accepts subqueries", async () => {
+      await expectValid(
         "SELECT * FROM companies WHERE id IN (SELECT company_id FROM people)"
       );
     });
 
-    it("accepts CTEs (WITH ... AS)", () => {
-      expectValid(
+    it("accepts CTEs (WITH ... AS)", async () => {
+      await expectValid(
         "WITH top AS (SELECT id, name FROM companies LIMIT 10) SELECT * FROM top"
       );
     });
 
-    it("accepts aggregate functions", () => {
-      expectValid(
+    it("accepts aggregate functions", async () => {
+      await expectValid(
         "SELECT COUNT(*), SUM(id), AVG(id), MIN(id), MAX(id) FROM companies"
       );
     });
 
-    it("accepts GROUP BY and HAVING", () => {
-      expectValid(
+    it("accepts GROUP BY and HAVING", async () => {
+      await expectValid(
         "SELECT name, COUNT(*) as cnt FROM companies GROUP BY name HAVING COUNT(*) > 1"
       );
     });
 
-    it("accepts window functions", () => {
-      expectValid(
+    it("accepts window functions", async () => {
+      await expectValid(
         "SELECT name, ROW_NUMBER() OVER (ORDER BY id) FROM companies"
       );
     });
 
-    it("accepts CASE expressions", () => {
-      expectValid(
+    it("accepts CASE expressions", async () => {
+      await expectValid(
         "SELECT CASE WHEN id > 10 THEN 'big' ELSE 'small' END AS size FROM companies"
       );
     });
 
-    it("accepts ORDER BY and LIMIT", () => {
-      expectValid("SELECT * FROM companies ORDER BY name ASC LIMIT 50");
+    it("accepts ORDER BY and LIMIT", async () => {
+      await expectValid("SELECT * FROM companies ORDER BY name ASC LIMIT 50");
     });
 
-    it("accepts DISTINCT", () => {
-      expectValid("SELECT DISTINCT name FROM companies");
+    it("accepts DISTINCT", async () => {
+      await expectValid("SELECT DISTINCT name FROM companies");
     });
 
-    it("accepts UNION of SELECTs", () => {
-      expectValid(
+    it("accepts UNION of SELECTs", async () => {
+      await expectValid(
         "SELECT name FROM companies UNION ALL SELECT name FROM people"
       );
     });
 
-    it("accepts trailing semicolon (stripped)", () => {
-      expectValid("SELECT 1 ;");
+    it("accepts trailing semicolon (stripped)", async () => {
+      await expectValid("SELECT 1 ;");
     });
 
-    it("accepts trailing semicolon with whitespace", () => {
-      expectValid("SELECT 1 ;   ");
+    it("accepts trailing semicolon with whitespace", async () => {
+      await expectValid("SELECT 1 ;   ");
     });
 
-    it("accepts COALESCE", () => {
-      expectValid("SELECT COALESCE(name, 'unknown') FROM companies");
+    it("accepts COALESCE", async () => {
+      await expectValid("SELECT COALESCE(name, 'unknown') FROM companies");
     });
 
-    it("accepts nested CTEs", () => {
-      expectValid(`
+    it("accepts nested CTEs", async () => {
+      await expectValid(`
         WITH a AS (SELECT id FROM companies),
              b AS (SELECT id FROM a)
         SELECT * FROM b
       `);
     });
 
-    it("accepts semicolons inside string literals", () => {
+    it("accepts semicolons inside string literals", async () => {
       // Semicolons in data values are legitimate — the AST parser handles
       // them correctly as part of the string, not as statement separators.
-      expectValid("SELECT * FROM companies WHERE name = 'foo;bar'");
+      await expectValid("SELECT * FROM companies WHERE name = 'foo;bar'");
     });
   });
 
   // ----- Blocked DML/DDL ----------------------------------------------------
 
   describe("blocked DML/DDL", () => {
-    it("rejects INSERT", () => {
-      expectInvalid(
+    it("rejects INSERT", async () => {
+      await expectInvalid(
         "INSERT INTO companies (name) VALUES ('Evil')",
         "forbidden"
       );
     });
 
-    it("rejects UPDATE", () => {
-      expectInvalid("UPDATE companies SET name = 'Evil'", "forbidden");
+    it("rejects UPDATE", async () => {
+      await expectInvalid("UPDATE companies SET name = 'Evil'", "forbidden");
     });
 
-    it("rejects DELETE", () => {
-      expectInvalid("DELETE FROM companies WHERE id = 1", "forbidden");
+    it("rejects DELETE", async () => {
+      await expectInvalid("DELETE FROM companies WHERE id = 1", "forbidden");
     });
 
-    it("rejects DROP TABLE", () => {
-      expectInvalid("DROP TABLE companies", "forbidden");
+    it("rejects DROP TABLE", async () => {
+      await expectInvalid("DROP TABLE companies", "forbidden");
     });
 
-    it("rejects CREATE TABLE", () => {
-      expectInvalid(
+    it("rejects CREATE TABLE", async () => {
+      await expectInvalid(
         "CREATE TABLE evil (id int)",
         "forbidden"
       );
     });
 
-    it("rejects ALTER TABLE", () => {
-      expectInvalid("ALTER TABLE companies ADD COLUMN evil text", "forbidden");
+    it("rejects ALTER TABLE", async () => {
+      await expectInvalid("ALTER TABLE companies ADD COLUMN evil text", "forbidden");
     });
 
-    it("rejects TRUNCATE", () => {
-      expectInvalid("TRUNCATE companies", "forbidden");
+    it("rejects TRUNCATE", async () => {
+      await expectInvalid("TRUNCATE companies", "forbidden");
     });
   });
 
   // ----- Blocked privilege / admin commands -----------------------------------
 
   describe("blocked privilege and admin commands", () => {
-    it("rejects GRANT", () => {
-      expectInvalid("GRANT ALL ON companies TO evil", "forbidden");
+    it("rejects GRANT", async () => {
+      await expectInvalid("GRANT ALL ON companies TO evil", "forbidden");
     });
 
-    it("rejects REVOKE", () => {
-      expectInvalid("REVOKE ALL ON companies FROM evil", "forbidden");
+    it("rejects REVOKE", async () => {
+      await expectInvalid("REVOKE ALL ON companies FROM evil", "forbidden");
     });
 
-    it("rejects EXEC", () => {
-      expectInvalid("EXEC sp_executesql N'DROP TABLE companies'", "forbidden");
+    it("rejects EXEC", async () => {
+      await expectInvalid("EXEC sp_executesql N'DROP TABLE companies'", "forbidden");
     });
 
-    it("rejects EXECUTE", () => {
-      expectInvalid("EXECUTE sp_addrolemember 'db_owner', 'evil'", "forbidden");
+    it("rejects EXECUTE", async () => {
+      await expectInvalid("EXECUTE sp_addrolemember 'db_owner', 'evil'", "forbidden");
     });
 
-    it("rejects CALL", () => {
-      expectInvalid("CALL some_procedure()", "forbidden");
+    it("rejects CALL", async () => {
+      await expectInvalid("CALL some_procedure()", "forbidden");
     });
 
-    it("rejects COPY", () => {
-      expectInvalid("COPY companies TO '/tmp/data.csv'", "forbidden");
+    it("rejects COPY", async () => {
+      await expectInvalid("COPY companies TO '/tmp/data.csv'", "forbidden");
     });
 
-    it("rejects LOAD", () => {
-      expectInvalid("LOAD DATA INFILE '/tmp/data.csv' INTO TABLE companies", "forbidden");
+    it("rejects LOAD", async () => {
+      await expectInvalid("LOAD DATA INFILE '/tmp/data.csv' INTO TABLE companies", "forbidden");
     });
 
-    it("rejects VACUUM", () => {
-      expectInvalid("VACUUM companies", "forbidden");
+    it("rejects VACUUM", async () => {
+      await expectInvalid("VACUUM companies", "forbidden");
     });
 
-    it("rejects REINDEX", () => {
-      expectInvalid("REINDEX TABLE companies", "forbidden");
+    it("rejects REINDEX", async () => {
+      await expectInvalid("REINDEX TABLE companies", "forbidden");
     });
 
-    it("rejects OPTIMIZE TABLE", () => {
-      expectInvalid("OPTIMIZE TABLE companies", "forbidden");
+    it("rejects OPTIMIZE TABLE", async () => {
+      await expectInvalid("OPTIMIZE TABLE companies", "forbidden");
     });
 
-    it("rejects INTO OUTFILE", () => {
-      expectInvalid(
+    it("rejects INTO OUTFILE", async () => {
+      await expectInvalid(
         "SELECT * INTO OUTFILE '/tmp/dump.csv' FROM companies",
         "forbidden"
       );
@@ -271,65 +271,65 @@ describe("validateSQL", () => {
   // ----- Multi-statement injection -------------------------------------------
 
   describe("multi-statement injection", () => {
-    it("rejects semicolon-separated SELECT + DML", () => {
+    it("rejects semicolon-separated SELECT + DML", async () => {
       // DML caught by regex guard before AST even runs
-      expectInvalid("SELECT 1; DROP TABLE companies", "forbidden");
+      await expectInvalid("SELECT 1; DROP TABLE companies", "forbidden");
     });
 
-    it("rejects two SELECT statements", () => {
-      expectInvalid("SELECT 1; SELECT 2", "multiple statements");
+    it("rejects two SELECT statements", async () => {
+      await expectInvalid("SELECT 1; SELECT 2", "multiple statements");
     });
 
-    it("rejects two statements with string literals", () => {
-      expectInvalid("SELECT '1'; SELECT '2'", "multiple statements");
+    it("rejects two statements with string literals", async () => {
+      await expectInvalid("SELECT '1'; SELECT '2'", "multiple statements");
     });
   });
 
   // ----- Comment-based bypass attempts ---------------------------------------
 
   describe("comment-based bypass attempts", () => {
-    it("rejects DML hidden after block comment", () => {
-      expectInvalid(
+    it("rejects DML hidden after block comment", async () => {
+      await expectInvalid(
         "DROP /* harmless */ TABLE companies",
         "forbidden"
       );
     });
 
-    it("rejects DML with inline comment", () => {
-      expectInvalid(
+    it("rejects DML with inline comment", async () => {
+      await expectInvalid(
         "DELETE -- just a select\nFROM companies",
         "forbidden"
       );
     });
 
-    it("allows SELECT with harmless comments", () => {
+    it("allows SELECT with harmless comments", async () => {
       // The regex guard passes (no forbidden keywords) and the parser
       // handles inline comments, so this is valid.
-      expectValid("SELECT /* this is a comment */ 1");
+      await expectValid("SELECT /* this is a comment */ 1");
     });
   });
 
   // ----- AST parse failure (reject unparseable) ------------------------------
 
   describe("AST parse failure — reject unparseable", () => {
-    it("rejects SELECT ... FOR UPDATE (locking clause)", () => {
+    it("rejects SELECT ... FOR UPDATE (locking clause)", async () => {
       // FOR UPDATE acquires row-level locks, violating read-only intent.
       // Caught by the regex guard because "UPDATE" is a forbidden keyword.
-      expectInvalid(
+      await expectInvalid(
         "SELECT * FROM companies FOR UPDATE",
         "forbidden"
       );
     });
 
-    it("rejects completely unparseable gibberish", () => {
-      expectInvalid(
+    it("rejects completely unparseable gibberish", async () => {
+      await expectInvalid(
         "XYZZY PLUGH 42",
         "could not be parsed"
       );
     });
 
-    it("rejects partial SQL that confuses the parser", () => {
-      expectInvalid(
+    it("rejects partial SQL that confuses the parser", async () => {
+      await expectInvalid(
         "SELECT FROM WHERE",
         "could not be parsed"
       );
@@ -339,97 +339,97 @@ describe("validateSQL", () => {
   // ----- Table whitelist -----------------------------------------------------
 
   describe("table whitelist", () => {
-    it("allows queries on whitelisted tables", () => {
-      expectValid("SELECT * FROM companies");
+    it("allows queries on whitelisted tables", async () => {
+      await expectValid("SELECT * FROM companies");
     });
 
-    it("allows queries joining whitelisted tables", () => {
-      expectValid(
+    it("allows queries joining whitelisted tables", async () => {
+      await expectValid(
         "SELECT c.name FROM companies c JOIN people p ON c.id = p.company_id"
       );
     });
 
-    it("rejects queries on non-whitelisted tables", () => {
-      expectInvalid(
+    it("rejects queries on non-whitelisted tables", async () => {
+      await expectInvalid(
         "SELECT * FROM secret_data",
         "not in the allowed list"
       );
     });
 
-    it("rejects when any joined table is not whitelisted", () => {
-      expectInvalid(
+    it("rejects when any joined table is not whitelisted", async () => {
+      await expectInvalid(
         "SELECT * FROM companies c JOIN secret_data s ON c.id = s.company_id",
         "not in the allowed list"
       );
     });
 
-    it("rejects non-whitelisted tables in subqueries", () => {
-      expectInvalid(
+    it("rejects non-whitelisted tables in subqueries", async () => {
+      await expectInvalid(
         "SELECT * FROM companies WHERE id IN (SELECT id FROM secret_data)",
         "not in the allowed list"
       );
     });
 
-    it("does not reject CTE names as non-whitelisted tables", () => {
+    it("does not reject CTE names as non-whitelisted tables", async () => {
       // "my_temp" is not in the whitelist, but it's a CTE name —
       // the validator extracts CTE names and excludes them from the check.
-      expectValid(
+      await expectValid(
         "WITH my_temp AS (SELECT id FROM companies) SELECT * FROM my_temp"
       );
     });
 
-    it("allows all tables when whitelist is disabled", () => {
+    it("allows all tables when whitelist is disabled", async () => {
       process.env.ATLAS_TABLE_WHITELIST = "false";
-      expectValid("SELECT * FROM anything_goes");
+      await expectValid("SELECT * FROM anything_goes");
     });
   });
 
   // ----- Schema-qualified table names ----------------------------------------
 
   describe("schema-qualified table names", () => {
-    it("accepts schema-qualified name when in whitelist", () => {
-      expectValid("SELECT * FROM public.companies");
+    it("accepts schema-qualified name when in whitelist", async () => {
+      await expectValid("SELECT * FROM public.companies");
     });
 
-    it("accepts non-public schema-qualified name when in whitelist", () => {
-      expectValid("SELECT * FROM analytics.companies");
+    it("accepts non-public schema-qualified name when in whitelist", async () => {
+      await expectValid("SELECT * FROM analytics.companies");
     });
 
-    it("rejects schema-qualified name when schema.table not in whitelist", () => {
-      expectInvalid(
+    it("rejects schema-qualified name when schema.table not in whitelist", async () => {
+      await expectInvalid(
         "SELECT * FROM secret.passwords",
         "not in the allowed list"
       );
     });
 
-    it("accepts joins mixing qualified and unqualified names", () => {
-      expectValid(
+    it("accepts joins mixing qualified and unqualified names", async () => {
+      await expectValid(
         "SELECT c.name, o.id FROM public.companies c JOIN orders o ON c.id = o.company_id"
       );
     });
 
-    it("rejects schema-qualified table when only unqualified name is whitelisted (whitelist bypass)", () => {
+    it("rejects schema-qualified table when only unqualified name is whitelisted (whitelist bypass)", async () => {
       // "companies" (unqualified) is whitelisted, but "secret.companies" is NOT.
       // This must be rejected to prevent cross-schema access.
-      expectInvalid(
+      await expectInvalid(
         "SELECT * FROM secret.companies",
         "not in the allowed list"
       );
     });
 
-    it("does not show 'null.' prefix in error messages for unqualified tables", () => {
-      const result = validateSQL("SELECT * FROM nonexistent_table");
+    it("does not show 'null.' prefix in error messages for unqualified tables", async () => {
+      const result = await validateSQL("SELECT * FROM nonexistent_table");
       expect(result.valid).toBe(false);
       expect(result.error).not.toContain("null.");
       expect(result.error).toContain("nonexistent_table");
     });
 
-    it("accepts case-insensitive schema-qualified names (PUBLIC.Companies)", () => {
-      expectValid("SELECT * FROM PUBLIC.Companies");
+    it("accepts case-insensitive schema-qualified names (PUBLIC.Companies)", async () => {
+      await expectValid("SELECT * FROM PUBLIC.Companies");
     });
 
-    it("accepts case-insensitive schema-qualified names (ANALYTICS.COMPANIES)", () => {
-      expectValid("SELECT * FROM ANALYTICS.COMPANIES");
+    it("accepts case-insensitive schema-qualified names (ANALYTICS.COMPANIES)", async () => {
+      await expectValid("SELECT * FROM ANALYTICS.COMPANIES");
     });
   });
 
@@ -440,61 +440,61 @@ describe("validateSQL", () => {
     // These tests verify that validateSQL itself doesn't reject queries with
     // or without LIMIT — the limit logic is tested separately.
 
-    it("accepts queries with explicit LIMIT", () => {
-      expectValid("SELECT * FROM companies LIMIT 10");
+    it("accepts queries with explicit LIMIT", async () => {
+      await expectValid("SELECT * FROM companies LIMIT 10");
     });
 
-    it("accepts queries without LIMIT (auto-appended later)", () => {
-      expectValid("SELECT * FROM companies");
+    it("accepts queries without LIMIT (auto-appended later)", async () => {
+      await expectValid("SELECT * FROM companies");
     });
   });
 
   // ----- Edge cases ----------------------------------------------------------
 
   describe("edge cases", () => {
-    it("rejects empty string", () => {
-      const result = validateSQL("");
+    it("rejects empty string", async () => {
+      const result = await validateSQL("");
       expect(result.valid).toBe(false);
     });
 
-    it("rejects whitespace-only", () => {
-      const result = validateSQL("   \n\t  ");
+    it("rejects whitespace-only", async () => {
+      const result = await validateSQL("   \n\t  ");
       expect(result.valid).toBe(false);
     });
 
-    it("accepts extremely long queries without crashing", () => {
+    it("accepts extremely long queries without crashing", async () => {
       const longQuery = `SELECT ${Array(500).fill("1").join(", ")} FROM companies`;
-      expectValid(longQuery);
+      await expectValid(longQuery);
     });
 
-    it("handles unicode in string literals", () => {
-      expectValid("SELECT * FROM companies WHERE name = '日本語テスト'");
+    it("handles unicode in string literals", async () => {
+      await expectValid("SELECT * FROM companies WHERE name = '日本語テスト'");
     });
 
-    it("handles unicode table names that aren't whitelisted", () => {
-      expectInvalid('SELECT * FROM "données_secrètes"');
+    it("handles unicode table names that aren't whitelisted", async () => {
+      await expectInvalid('SELECT * FROM "données_secrètes"');
     });
 
-    it("rejects a query that is just a number", () => {
-      const result = validateSQL("42");
+    it("rejects a query that is just a number", async () => {
+      const result = await validateSQL("42");
       expect(result.valid).toBe(false);
     });
 
-    it("case-insensitive detection of forbidden keywords", () => {
-      expectInvalid("insert INTO companies (name) VALUES ('x')", "forbidden");
-      expectInvalid("InSeRt INTO companies (name) VALUES ('x')", "forbidden");
+    it("case-insensitive detection of forbidden keywords", async () => {
+      await expectInvalid("insert INTO companies (name) VALUES ('x')", "forbidden");
+      await expectInvalid("InSeRt INTO companies (name) VALUES ('x')", "forbidden");
     });
 
-    it("rejects UPDATE disguised with mixed case", () => {
-      expectInvalid("uPdAtE companies SET name = 'x'", "forbidden");
+    it("rejects UPDATE disguised with mixed case", async () => {
+      await expectInvalid("uPdAtE companies SET name = 'x'", "forbidden");
     });
 
-    it("rejects forbidden keywords inside string literals (known false positive)", () => {
+    it("rejects forbidden keywords inside string literals (known false positive)", async () => {
       // The regex guard runs before AST parsing, so it catches "DELETE"
       // even inside a WHERE string value. This is a deliberate conservative
       // choice — security over usability. The agent can work around this by
       // using different filter values or column aliases.
-      expectInvalid(
+      await expectInvalid(
         "SELECT * FROM companies WHERE status = 'DELETE'",
         "forbidden"
       );
@@ -504,14 +504,14 @@ describe("validateSQL", () => {
   // ----- Known limitations ---------------------------------------------------
 
   describe("known limitations", () => {
-    it("does not block dangerous PostgreSQL functions (mitigated by statement_timeout and DB permissions)", () => {
+    it("does not block dangerous PostgreSQL functions (mitigated by statement_timeout and DB permissions)", async () => {
       // Functions like pg_sleep, pg_read_file, pg_terminate_backend pass
       // validation because there is no function blocklist. Mitigation:
       // - pg_sleep: bounded by statement_timeout (default 30s)
       // - pg_read_file/pg_ls_dir: require superuser or explicit GRANT
       // - pg_terminate_backend: requires pg_signal_backend role
       // The DB user should have minimal permissions in production.
-      expectValid("SELECT pg_sleep(1) FROM companies");
+      await expectValid("SELECT pg_sleep(1) FROM companies");
     });
   });
 
@@ -522,46 +522,46 @@ describe("validateSQL", () => {
       process.env.ATLAS_DATASOURCE_URL = "mysql://test:test@localhost:3306/test";
     });
 
-    it("rejects HANDLER statement", () => {
-      expectInvalid("HANDLER companies OPEN", "forbidden");
+    it("rejects HANDLER statement", async () => {
+      await expectInvalid("HANDLER companies OPEN", "forbidden");
     });
 
-    it("rejects SHOW TABLES", () => {
-      expectInvalid("SHOW TABLES", "forbidden");
+    it("rejects SHOW TABLES", async () => {
+      await expectInvalid("SHOW TABLES", "forbidden");
     });
 
-    it("rejects SHOW DATABASES", () => {
-      expectInvalid("SHOW DATABASES", "forbidden");
+    it("rejects SHOW DATABASES", async () => {
+      await expectInvalid("SHOW DATABASES", "forbidden");
     });
 
-    it("rejects DESCRIBE", () => {
-      expectInvalid("DESCRIBE companies", "forbidden");
+    it("rejects DESCRIBE", async () => {
+      await expectInvalid("DESCRIBE companies", "forbidden");
     });
 
-    it("rejects EXPLAIN", () => {
-      expectInvalid("EXPLAIN SELECT * FROM companies", "forbidden");
+    it("rejects EXPLAIN", async () => {
+      await expectInvalid("EXPLAIN SELECT * FROM companies", "forbidden");
     });
 
-    it("rejects LOAD DATA", () => {
-      expectInvalid(
+    it("rejects LOAD DATA", async () => {
+      await expectInvalid(
         "LOAD DATA INFILE '/tmp/data.csv' INTO TABLE companies",
         "forbidden"
       );
     });
 
-    it("rejects LOAD XML", () => {
-      expectInvalid(
+    it("rejects LOAD XML", async () => {
+      await expectInvalid(
         "LOAD XML INFILE '/tmp/data.xml' INTO TABLE companies",
         "forbidden"
       );
     });
 
-    it("rejects USE database", () => {
-      expectInvalid("USE other_database", "forbidden");
+    it("rejects USE database", async () => {
+      await expectInvalid("USE other_database", "forbidden");
     });
 
-    it("rejects mixed-case HANDLER", () => {
-      expectInvalid("HaNdLeR companies OPEN", "forbidden");
+    it("rejects mixed-case HANDLER", async () => {
+      await expectInvalid("HaNdLeR companies OPEN", "forbidden");
     });
   });
 
@@ -572,66 +572,66 @@ describe("validateSQL", () => {
       process.env.ATLAS_DATASOURCE_URL = "mysql://test:test@localhost:3306/test";
     });
 
-    it("accepts a simple SELECT in MySQL mode", () => {
-      expectValid("SELECT id, name FROM companies");
+    it("accepts a simple SELECT in MySQL mode", async () => {
+      await expectValid("SELECT id, name FROM companies");
     });
 
-    it("accepts SELECT with JOIN in MySQL mode", () => {
-      expectValid(
+    it("accepts SELECT with JOIN in MySQL mode", async () => {
+      await expectValid(
         "SELECT c.name, p.name FROM companies c JOIN people p ON c.id = p.company_id"
       );
     });
 
-    it("accepts CTEs in MySQL mode", () => {
-      expectValid(
+    it("accepts CTEs in MySQL mode", async () => {
+      await expectValid(
         "WITH top AS (SELECT id, name FROM companies LIMIT 10) SELECT * FROM top"
       );
     });
 
-    it("accepts subqueries in MySQL mode", () => {
-      expectValid(
+    it("accepts subqueries in MySQL mode", async () => {
+      await expectValid(
         "SELECT * FROM companies WHERE id IN (SELECT company_id FROM people)"
       );
     });
 
-    it("rejects INSERT in MySQL mode", () => {
-      expectInvalid(
+    it("rejects INSERT in MySQL mode", async () => {
+      await expectInvalid(
         "INSERT INTO companies (name) VALUES ('Evil')",
         "forbidden"
       );
     });
 
-    it("rejects non-whitelisted tables in MySQL mode", () => {
-      expectInvalid(
+    it("rejects non-whitelisted tables in MySQL mode", async () => {
+      await expectInvalid(
         "SELECT * FROM secret_data",
         "not in the allowed list"
       );
     });
 
-    it("accepts MySQL-specific functions (DATE_FORMAT) in MySQL mode", () => {
-      expectValid("SELECT DATE_FORMAT(NOW(), '%Y-%m') as month FROM companies");
+    it("accepts MySQL-specific functions (DATE_FORMAT) in MySQL mode", async () => {
+      await expectValid("SELECT DATE_FORMAT(NOW(), '%Y-%m') as month FROM companies");
     });
 
-    it("accepts MySQL-specific functions (IFNULL) in MySQL mode", () => {
-      expectValid("SELECT IFNULL(name, 'unknown') FROM companies");
+    it("accepts MySQL-specific functions (IFNULL) in MySQL mode", async () => {
+      await expectValid("SELECT IFNULL(name, 'unknown') FROM companies");
     });
 
-    it("accepts MySQL-specific functions (GROUP_CONCAT) in MySQL mode", () => {
-      expectValid("SELECT GROUP_CONCAT(name SEPARATOR ', ') FROM companies");
+    it("accepts MySQL-specific functions (GROUP_CONCAT) in MySQL mode", async () => {
+      await expectValid("SELECT GROUP_CONCAT(name SEPARATOR ', ') FROM companies");
     });
 
-    it("accepts backtick-quoted identifiers in MySQL mode", () => {
-      expectValid("SELECT `id`, `name` FROM companies");
+    it("accepts backtick-quoted identifiers in MySQL mode", async () => {
+      await expectValid("SELECT `id`, `name` FROM companies");
     });
 
-    it("does not reject CTE names as non-whitelisted tables in MySQL mode", () => {
-      expectValid(
+    it("does not reject CTE names as non-whitelisted tables in MySQL mode", async () => {
+      await expectValid(
         "WITH my_temp AS (SELECT id FROM companies) SELECT * FROM my_temp"
       );
     });
 
-    it("accepts UNION of SELECTs in MySQL mode", () => {
-      expectValid(
+    it("accepts UNION of SELECTs in MySQL mode", async () => {
+      await expectValid(
         "SELECT name FROM companies UNION ALL SELECT name FROM people"
       );
     });
@@ -640,37 +640,37 @@ describe("validateSQL", () => {
   // ----- Cross-DB guard: MySQL patterns don't fire in PostgreSQL mode ---------
 
   describe("cross-database regex guard isolation", () => {
-    it("rejects HANDLER in PostgreSQL mode via AST parser, not regex guard", () => {
+    it("rejects HANDLER in PostgreSQL mode via AST parser, not regex guard", async () => {
       process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
-      const result = validateSQL("HANDLER companies OPEN");
+      const result = await validateSQL("HANDLER companies OPEN");
       expect(result.valid).toBe(false);
       expect(result.error).not.toContain("Forbidden SQL operation detected");
     });
 
-    it("rejects SHOW in PostgreSQL mode via AST parser, not regex guard", () => {
+    it("rejects SHOW in PostgreSQL mode via AST parser, not regex guard", async () => {
       process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
-      const result = validateSQL("SHOW TABLES");
+      const result = await validateSQL("SHOW TABLES");
       expect(result.valid).toBe(false);
       expect(result.error).not.toContain("Forbidden SQL operation detected");
     });
 
-    it("rejects DESCRIBE in PostgreSQL mode via AST parser, not regex guard", () => {
+    it("rejects DESCRIBE in PostgreSQL mode via AST parser, not regex guard", async () => {
       process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
-      const result = validateSQL("DESCRIBE companies");
+      const result = await validateSQL("DESCRIBE companies");
       expect(result.valid).toBe(false);
       expect(result.error).not.toContain("Forbidden SQL operation detected");
     });
 
-    it("rejects USE in PostgreSQL mode via AST parser, not regex guard", () => {
+    it("rejects USE in PostgreSQL mode via AST parser, not regex guard", async () => {
       process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
-      const result = validateSQL("USE other_database");
+      const result = await validateSQL("USE other_database");
       expect(result.valid).toBe(false);
       expect(result.error).not.toContain("Forbidden SQL operation detected");
     });
 
-    it("still blocks HANDLER in MySQL mode via regex guard", () => {
+    it("still blocks HANDLER in MySQL mode via regex guard", async () => {
       process.env.ATLAS_DATASOURCE_URL = "mysql://test:test@localhost:3306/test";
-      expectInvalid("HANDLER companies OPEN", "forbidden");
+      await expectInvalid("HANDLER companies OPEN", "forbidden");
     });
   });
 
@@ -681,21 +681,21 @@ describe("validateSQL", () => {
       process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
     });
 
-    it("rejects PRAGMA in PostgreSQL mode", () => {
-      expectInvalid("PRAGMA table_info(companies)", "could not be parsed");
+    it("rejects PRAGMA in PostgreSQL mode", async () => {
+      await expectInvalid("PRAGMA table_info(companies)", "could not be parsed");
     });
 
-    it("rejects ATTACH DATABASE in PostgreSQL mode", () => {
-      expectInvalid("ATTACH DATABASE '/tmp/evil.db' AS evil", "could not be parsed");
+    it("rejects ATTACH DATABASE in PostgreSQL mode", async () => {
+      await expectInvalid("ATTACH DATABASE '/tmp/evil.db' AS evil", "could not be parsed");
     });
 
-    it("rejects DETACH DATABASE in PostgreSQL mode", () => {
-      expectInvalid("DETACH DATABASE evil", "could not be parsed");
+    it("rejects DETACH DATABASE in PostgreSQL mode", async () => {
+      await expectInvalid("DETACH DATABASE evil", "could not be parsed");
     });
 
-    it("rejects PRAGMA in MySQL mode", () => {
+    it("rejects PRAGMA in MySQL mode", async () => {
       process.env.ATLAS_DATASOURCE_URL = "mysql://test:test@localhost:3306/test";
-      expectInvalid("PRAGMA table_info(companies)", "could not be parsed");
+      await expectInvalid("PRAGMA table_info(companies)", "could not be parsed");
     });
   });
 

--- a/packages/api/src/lib/tools/propose-amendment.ts
+++ b/packages/api/src/lib/tools/propose-amendment.ts
@@ -176,7 +176,7 @@ The amendment object should match the YAML structure for that type (e.g., { name
       if (testQuery) {
         try {
           // Validate test query through the same SQL pipeline as executeSQL
-          const validation = validateSQL(testQuery);
+          const validation = await validateSQL(testQuery);
           if (!validation.valid) {
             testResult = {
               success: false,

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -19,7 +19,7 @@ import { Effect } from "effect";
 import { Parser } from "node-sql-parser";
 import { connections, detectDBType, getRegionAwareConnection, isConnectionVisibleInMode, ConnectionNotRegisteredError, NoDatasourceConfiguredError, PoolCapacityExceededError } from "@atlas/api/lib/db/connection";
 import type { DBConnection, DBType } from "@atlas/api/lib/db/connection";
-import { getWhitelistedTables, getOrgWhitelistedTables } from "@atlas/api/lib/semantic";
+import { getWhitelistedTables, getOrgWhitelistedTables, loadOrgWhitelist } from "@atlas/api/lib/semantic";
 import { logQueryAudit } from "@atlas/api/lib/auth/audit";
 import { SENSITIVE_PATTERNS } from "@atlas/api/lib/security";
 import { withSpan } from "@atlas/api/lib/tracing";
@@ -241,7 +241,7 @@ function getExtraPatterns(dbType: DBType | string, connectionId?: string): RegEx
   }
 }
 
-export function validateSQL(sql: string, connectionId?: string): SQLValidationResult {
+export async function validateSQL(sql: string, connectionId?: string): Promise<SQLValidationResult> {
   // Resolve DB type for this connection.
   // When an explicit connectionId is given but not found, return a validation
   // error instead of silently falling back — wrong parser mode is a security risk.
@@ -371,6 +371,20 @@ export function validateSQL(sql: string, connectionId?: string): SQLValidationRe
       const tables = parser.tableList(trimmed, { database: parserDatabase(dbType, connectionId) });
       const sqlReqCtx = getRequestContext();
       const orgId = sqlReqCtx?.user?.activeOrganizationId;
+      // Lazy-load the per-org whitelist into the in-process cache.
+      // The chat path (`agent.ts:570`) explicitly preloads this before
+      // dispatching the agent loop. The MCP edge does NOT — every
+      // executeSQL call from Claude Desktop / Cursor was hitting an
+      // empty whitelist and rejecting every table with `unknown_entity`
+      // regardless of what `listEntities` reported. The fix is to
+      // ensure the whitelist is loaded HERE so every code path that
+      // reaches SQL validation gets the same answer, instead of
+      // relying on each entry-point caller to remember the preload.
+      // `loadOrgWhitelist` is cache-guarded — the second call onward
+      // is O(1).
+      if (orgId) {
+        await loadOrgWhitelist(orgId, sqlReqCtx?.atlasMode);
+      }
       const allowed = orgId
         ? getOrgWhitelistedTables(orgId, connectionId, sqlReqCtx?.atlasMode)
         : getWhitelistedTables(connectionId);
@@ -581,11 +595,13 @@ function runQueryValidationEffect(
   customValidator: CustomValidator | undefined,
 ): Effect.Effect<{ ok: true; classification?: SQLClassification } | { ok: false; error: string; auditError: string }> {
   if (!customValidator) {
-    const validation = validateSQL(sql, connId);
-    if (!validation.valid) {
-      return Effect.succeed({ ok: false as const, error: validation.error, auditError: `Validation rejected: ${validation.error}` });
-    }
-    return Effect.succeed({ ok: true as const, classification: validation.classification });
+    return Effect.promise(async () => {
+      const validation = await validateSQL(sql, connId);
+      if (!validation.valid) {
+        return { ok: false as const, error: validation.error, auditError: `Validation rejected: ${validation.error}` };
+      }
+      return { ok: true as const, classification: validation.classification };
+    });
   }
 
   // Custom validator (async) — errors are caught and returned as result values, not thrown

--- a/packages/api/src/lib/tools/validate-proposal.ts
+++ b/packages/api/src/lib/tools/validate-proposal.ts
@@ -158,7 +158,7 @@ export const validateProposal = tool({
 
       if (payload.testQuery) {
         // Validate test query through SQL pipeline before execution
-        const sqlValidation = validateSQL(payload.testQuery);
+        const sqlValidation = await validateSQL(payload.testQuery);
         if (!sqlValidation.valid) {
           testQueryResult = {
             success: false,


### PR DESCRIPTION
## Summary

**Every customer using executeSQL via Claude Desktop / Cursor has been silently rejected** with `unknown_entity` for every table — even tables that `listEntities` + `describeEntity` correctly return for the same workspace.

## Root cause

`getOrgWhitelistedTables(orgId, ...)` reads from a per-org cache populated by `loadOrgWhitelist(orgId)`. The chat path (`agent.ts:570`) explicitly preloads this. **The MCP edge path doesn't.** MCP's executeSQL handler called `validateSQL` → `getOrgWhitelistedTables` → empty Set → reject every table.

`listEntities` and `describeEntity` work fine — they read from a different code path. That masked the symptom unless someone actually ran executeSQL via MCP.

Surfaced today while interpreting load-test results: 100% of executeSQL calls from k6 returned `unknown_entity`, yet `listEntities`/`describeEntity` worked on the same tables. Same bug hits every real MCP client.

## Fix

Lazy-load the per-org whitelist **inside `validateSQL`** when `orgId` is set. `loadOrgWhitelist` is cache-guarded; second call onward is O(1). Single source of truth — every code path that reaches SQL validation gets the same answer instead of relying on each entry-point caller to remember the preload.

`validateSQL` becomes async. 5 production call sites updated to `await`:
- `lib/tools/sql.ts:598` (executeSQL pipeline)
- `api/routes/dashboards.ts` × 3
- `lib/dashboards.ts:777`
- `api/routes/validate-sql.ts:132`
- `lib/tools/propose-amendment.ts:179`
- `lib/tools/validate-proposal.ts:161`

## Tests

- 2 new regression cases in `sql-org-whitelist.test.ts` documenting the bug and the fix.
- 5 existing test files bulk-updated for the new async signature.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun run scripts/test-isolated.ts --affected` (from `packages/api`) — 23/23 pass
- [x] All SQL test suites (115 cases) pass
- [ ] After deploy: probe `mcp.useatlas.dev/mcp/{ws}/sse` with executeSQL on a real entity table — expect 200 with rows, not the `unknown_entity` envelope.

## Why this is urgent

Pre-launch but real: anyone connecting Claude Desktop or Cursor to `mcp.useatlas.dev` today gets a working session, working `listEntities`, working `describeEntity`, and a 100% broken `executeSQL`. That's the core agent capability. No rollback risk — the fix either preserves the existing behavior (cache loaded) or populates the cache on first call.