### PR TITLE
fix(api,sql): point whitelist error at admin → Semantic on SaaS, not catalog.yml (#2143)

### DIFF
--- a/packages/api/src/lib/tools/__tests__/sql-org-whitelist.test.ts
+++ b/packages/api/src/lib/tools/__tests__/sql-org-whitelist.test.ts
@@ -138,6 +138,28 @@ describe("org-scoped SQL whitelist enforcement", () => {
     expect(result.error).toContain("not in the allowed list");
   });
 
+  it("SaaS rejection points at the admin UI, NOT catalog.yml (#2143)", async () => {
+    // On a hosted SaaS workspace there is no catalog.yml in the image —
+    // the whitelist is sourced from the per-org `entities` table managed
+    // through admin → Semantic. The pre-fix error tail told users to
+    // "Check catalog.yml" which is a dead end on SaaS.
+    mockOrgId = "org-123";
+    const result = await validateSQL("SELECT * FROM file_companies");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("admin → Semantic");
+    expect(result.error).not.toContain("catalog.yml");
+  });
+
+  it("self-hosted rejection still points at catalog.yml", async () => {
+    // The on-disk YAML guidance must remain for self-hosters who edit
+    // `semantic/entities/*.yml` directly.
+    mockOrgId = undefined;
+    const result = await validateSQL("SELECT * FROM org_orders");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("catalog.yml");
+    expect(result.error).not.toContain("admin → Semantic");
+  });
+
   it("uses file whitelist when no orgId (self-hosted)", async () => {
     mockOrgId = undefined;
     // file_companies is in the file whitelist

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -389,6 +389,14 @@ export async function validateSQL(sql: string, connectionId?: string): Promise<S
         ? getOrgWhitelistedTables(orgId, connectionId, sqlReqCtx?.atlasMode)
         : getWhitelistedTables(connectionId);
 
+      // Self-hosted reads its whitelist from on-disk `catalog.yml` / entity
+      // YAML files; SaaS workspaces read from the per-org `entities` table
+      // managed via the admin UI. Pointing a SaaS user at `catalog.yml` is
+      // a dead end — there is no such file in the deployed image.
+      const guidance = orgId
+        ? "Open admin → Semantic to add this table."
+        : "Check catalog.yml for available tables.";
+
       for (const ref of tables) {
         // tableList returns "select::schema::table" format
         const parts = ref.split("::");
@@ -404,7 +412,7 @@ export async function validateSQL(sql: string, connectionId?: string): Promise<S
           if (!(qualifiedName && allowed.has(qualifiedName))) {
             return {
               valid: false,
-              error: `Table "${qualifiedName}" is not in the allowed list. Check catalog.yml for available tables.`,
+              error: `Table "${qualifiedName}" is not in the allowed list. ${guidance}`,
             };
           }
         } else {
@@ -412,7 +420,7 @@ export async function validateSQL(sql: string, connectionId?: string): Promise<S
           if (!allowed.has(tableName)) {
             return {
               valid: false,
-              error: `Table "${tableName}" is not in the allowed list. Check catalog.yml for available tables.`,
+              error: `Table "${tableName}" is not in the allowed list. ${guidance}`,
             };
           }
         }


### PR DESCRIPTION
Closes #2143.

## Summary

- The SQL whitelist rejection error told every user to "Check catalog.yml for available tables." On SaaS workspaces there is no `catalog.yml` in the deployed image — the whitelist is sourced from the per-org `entities` table managed through admin → Semantic. The old copy was a dead end for SaaS users.
- Branch the guidance tail on `orgId` presence in `packages/api/src/lib/tools/sql.ts` (the same lazy-loaded `orgId` already used for whitelist resolution two lines above):
  - **SaaS** (`orgId` present): `Open admin → Semantic to add this table.`
  - **Self-hosted** (no `orgId`): retains `Check catalog.yml for available tables.` — the on-disk YAML guidance is still correct for users editing `semantic/entities/*.yml` directly.
- Pin the suffix split with two new tests in `sql-org-whitelist.test.ts` so the SaaS / self-hosted branch can't silently regress.

The route-level `table_whitelist` layer mapper (`packages/api/src/api/routes/validate-sql.ts:49`) keys on the substring `"not in the allowed list"`, which both new messages still contain — so existing layer-classification tests pass unchanged.

## Test plan

- [x] `bun run scripts/test-isolated.ts --affected` — 21 affected files, all green
- [x] New tests assert `admin → Semantic` is present on the SaaS path and `catalog.yml` is absent
- [x] New tests assert the inverse on the self-hosted path
- [ ] Smoke against a SaaS deploy: trigger the rejection, confirm the new copy renders end-to-end (the agent surfaces this string verbatim)