### PR TITLE
fix(api,wizard,semantic): make demo + wizard workspaces queryable on MCP/executeSQL (#2142)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -10606,6 +10606,31 @@
                       "items": {
                         "type": "string"
                       }
+                    },
+                    "warnings": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": [
+                              "disk_sync_failed"
+                            ]
+                          },
+                          "tableName": {
+                            "type": "string"
+                          },
+                          "reason": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "tableName",
+                          "reason"
+                        ]
+                      }
                     }
                   },
                   "required": [

--- a/packages/api/src/api/__tests__/admin-wizard-save-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-wizard-save-audit.test.ts
@@ -130,6 +130,37 @@ mock.module("@atlas/api/lib/semantic/sync", () => ({
   importFromDisk: mock(async () => ({ imported: 0, skipped: 0, total: 0 })),
 }));
 
+// Mock the entity store: this test exercises the wizard /save audit
+// emission, not the DB write. Returning a full success count keeps
+// the route on the 201 path so the audit assertions can run.
+const mockBulkUpsertEntities: Mock<(
+  orgId: string,
+  entities: Array<{ entityType: string; name: string; yamlContent: string; connectionId?: string }>,
+) => Promise<number>> = mock(async (_orgId, entities) => entities.length);
+
+mock.module("@atlas/api/lib/semantic/entities", () => ({
+  DEMO_CONNECTION_ID: "__demo__",
+  SEMANTIC_ENTITY_STATUSES: ["published", "draft", "draft_delete", "archived"] as const,
+  bulkUpsertEntities: mockBulkUpsertEntities,
+  upsertEntity: async () => {},
+  upsertDraftEntity: async () => {},
+  upsertTombstone: async () => {},
+  deleteDraftEntity: async () => false,
+  listEntities: async () => [],
+  listEntitiesWithOverlay: async () => [],
+  getEntity: async () => null,
+  deleteEntity: async () => false,
+  countEntities: async () => 0,
+  createVersion: async () => "",
+  listVersions: async () => [],
+  getVersion: async () => null,
+  generateChangeSummary: async () => "",
+  applyTombstones: async () => 0,
+  promoteDraftEntities: async () => 0,
+  archiveSingleConnection: async () => ({ ok: true as const, archived: 0 }),
+  restoreSingleConnection: async () => ({ ok: true as const, restored: 0 }),
+}));
+
 // Profiler module — wizard.ts imports the full set (OBJECT_TYPES,
 // outputDirForDatasource, generate* helpers). Only a handful are used in
 // /save; the rest are stubbed to satisfy the import graph. Keep list of

--- a/packages/api/src/api/__tests__/wizard.test.ts
+++ b/packages/api/src/api/__tests__/wizard.test.ts
@@ -692,6 +692,7 @@ describe("POST /api/v1/wizard/save", () => {
     // failure so the operator notices instead of discovering it via a
     // customer report.
     mockBulkUpsertEntities.mockClear();
+    mockWriteFileSync.mockClear();
     mockBulkUpsertEntities.mockImplementationOnce(() => Promise.reject(new Error("internal DB unreachable")));
 
     const res = await postJson("/api/v1/wizard/save", {
@@ -702,6 +703,85 @@ describe("POST /api/v1/wizard/save", () => {
     expect(res.status).toBe(500);
     const data = await json(res);
     expect(data.error).toBe("db_persist_failed");
+    // DB-first ordering: on DB failure, no disk writes should have happened.
+    // Otherwise a 500 leaves orphan YAMLs on disk for the operator to clean up.
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 db_partial_persist when bulkUpsertEntities reports a partial count", async () => {
+    // bulkUpsertEntities swallows per-entity errors and returns the count
+    // that succeeded. Returning 201 in that case would silently recreate
+    // the #2142 unknown_entity failure for the rows that didn't land —
+    // the half-broken state is worse than a clear failure the operator
+    // can retry.
+    mockBulkUpsertEntities.mockClear();
+    mockBulkUpsertEntities.mockImplementationOnce(async (_orgId, entitiesArg) =>
+      Math.max(0, entitiesArg.length - 1),
+    );
+
+    const res = await postJson("/api/v1/wizard/save", {
+      connectionId: "default",
+      entities: [
+        { tableName: "users", yaml: "table: users\n" },
+        { tableName: "orders", yaml: "table: orders\n" },
+      ],
+    });
+
+    expect(res.status).toBe(500);
+    const data = await json(res);
+    expect(data.error).toBe("db_partial_persist");
+    expect(data.attempted).toBe(2);
+    expect(data.succeeded).toBe(1);
+  });
+
+  it("surfaces syncEntityToDisk failures in the response warnings array", async () => {
+    // The org-scoped semantic dir feeds the explore tool. A silent .catch
+    // here recreates the same split-state failure mode #2142 was filed to
+    // fix, just on the file path instead of the DB path. Make per-entity
+    // disk-sync failures visible so the operator can act on them.
+    mockBulkUpsertEntities.mockClear();
+    mockSyncEntityToDisk.mockReset();
+    // First entity syncs cleanly; second entity's disk sync throws.
+    mockSyncEntityToDisk.mockImplementationOnce(async () => {});
+    mockSyncEntityToDisk.mockImplementationOnce(async () => {
+      throw new Error("EACCES: permission denied");
+    });
+
+    const res = await postJson("/api/v1/wizard/save", {
+      connectionId: "default",
+      entities: [
+        { tableName: "users", yaml: "table: users\n" },
+        { tableName: "orders", yaml: "table: orders\n" },
+      ],
+    });
+
+    expect(res.status).toBe(201);
+    const data = await json(res);
+    expect(data.saved).toBe(true);
+    const warnings = data.warnings as Array<{ kind: string; tableName: string; reason: string }>;
+    expect(Array.isArray(warnings)).toBe(true);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({
+      kind: "disk_sync_failed",
+      tableName: "orders",
+    });
+    expect(typeof warnings[0].reason).toBe("string");
+  });
+
+  it("omits the warnings field on a clean save (no disk-sync failures)", async () => {
+    mockBulkUpsertEntities.mockClear();
+    mockSyncEntityToDisk.mockReset();
+    mockSyncEntityToDisk.mockImplementation(async () => {});
+
+    const res = await postJson("/api/v1/wizard/save", {
+      connectionId: "default",
+      entities: [{ tableName: "users", yaml: "table: users\n" }],
+    });
+
+    expect(res.status).toBe(201);
+    const data = await json(res);
+    expect(data.saved).toBe(true);
+    expect("warnings" in data).toBe(false);
   });
 
   it("returns 400 for invalid entity objects (missing tableName/yaml)", async () => {

--- a/packages/api/src/api/__tests__/wizard.test.ts
+++ b/packages/api/src/api/__tests__/wizard.test.ts
@@ -93,17 +93,51 @@ mock.module("@atlas/api/lib/db/internal", () => ({
 }));
 
 const mockResetWhitelists: Mock<() => void> = mock(() => {});
+const mockInvalidateOrgWhitelist: Mock<(orgId: string) => void> = mock(() => {});
 
 mock.module("@atlas/api/lib/semantic", () => ({
   getWhitelistedTables: () => new Set(),
   getOrgWhitelistedTables: () => new Set(),
   loadOrgWhitelist: async () => new Map(),
-  invalidateOrgWhitelist: () => {},
+  invalidateOrgWhitelist: mockInvalidateOrgWhitelist,
   getOrgSemanticIndex: async () => "",
   invalidateOrgSemanticIndex: () => {},
   _resetOrgWhitelists: () => {},
   _resetOrgSemanticIndexes: () => {},
   _resetWhitelists: mockResetWhitelists,
+}));
+
+const mockBulkUpsertEntities: Mock<(
+  orgId: string,
+  entities: Array<{ entityType: string; name: string; yamlContent: string; connectionId?: string }>,
+) => Promise<number>> = mock(async (_orgId, entities) => entities.length);
+
+mock.module("@atlas/api/lib/semantic/entities", () => ({
+  // Constants the wizard route imports statically
+  DEMO_CONNECTION_ID: "__demo__",
+  SEMANTIC_ENTITY_STATUSES: ["published", "draft", "draft_delete", "archived"] as const,
+  // Function under test in this suite
+  bulkUpsertEntities: mockBulkUpsertEntities,
+  // Other named exports — the mock.module() loader requires every export
+  // from the real module to be present, otherwise other test files in the
+  // same isolated process throw `Export named 'X' not found`.
+  upsertEntity: async () => {},
+  upsertDraftEntity: async () => {},
+  upsertTombstone: async () => {},
+  deleteDraftEntity: async () => false,
+  listEntities: async () => [],
+  listEntitiesWithOverlay: async () => [],
+  getEntity: async () => null,
+  deleteEntity: async () => false,
+  countEntities: async () => 0,
+  createVersion: async () => "",
+  listVersions: async () => [],
+  getVersion: async () => null,
+  generateChangeSummary: async () => "",
+  applyTombstones: async () => 0,
+  promoteDraftEntities: async () => 0,
+  archiveSingleConnection: async () => ({ ok: true as const, archived: 0 }),
+  restoreSingleConnection: async () => ({ ok: true as const, restored: 0 }),
 }));
 
 const mockSyncEntityToDisk: Mock<(orgId: string, name: string, type: string, yaml: string) => Promise<void>> = mock(
@@ -614,6 +648,60 @@ describe("POST /api/v1/wizard/save", () => {
       ],
     });
     expect(mockSyncEntityToDisk).toHaveBeenCalledTimes(2);
+  });
+
+  it("populates the per-org semantic_entities table via bulkUpsertEntities (#2142)", async () => {
+    // Pre-fix the wizard wrote YAMLs to disk only — the DB-backed
+    // per-org whitelist consumed by the MCP edge stayed empty, so every
+    // executeSQL call against wizard-onboarded workspaces hit
+    // `unknown_entity`.
+    mockBulkUpsertEntities.mockClear();
+    mockInvalidateOrgWhitelist.mockClear();
+
+    const res = await postJson("/api/v1/wizard/save", {
+      connectionId: "warehouse",
+      entities: [
+        { tableName: "users", yaml: "table: users\n" },
+        { tableName: "orders", yaml: "table: orders\n" },
+      ],
+    });
+    expect(res.status).toBe(201);
+
+    expect(mockBulkUpsertEntities).toHaveBeenCalledTimes(1);
+    const [orgIdArg, entitiesArg] = mockBulkUpsertEntities.mock.calls[0];
+    expect(orgIdArg).toBe("org-1");
+    expect(entitiesArg).toHaveLength(2);
+    expect(entitiesArg[0]).toMatchObject({
+      entityType: "entity",
+      name: "users",
+      yamlContent: "table: users\n",
+      connectionId: "warehouse",
+    });
+    expect(entitiesArg[1]).toMatchObject({
+      entityType: "entity",
+      name: "orders",
+      connectionId: "warehouse",
+    });
+
+    expect(mockInvalidateOrgWhitelist).toHaveBeenCalledWith("org-1");
+  });
+
+  it("returns 500 db_persist_failed when bulkUpsertEntities throws", async () => {
+    // DB write failure must NOT silently succeed — the disk YAMLs alone
+    // leave wizard-onboarded workspaces broken on MCP. Surface the
+    // failure so the operator notices instead of discovering it via a
+    // customer report.
+    mockBulkUpsertEntities.mockClear();
+    mockBulkUpsertEntities.mockImplementationOnce(() => Promise.reject(new Error("internal DB unreachable")));
+
+    const res = await postJson("/api/v1/wizard/save", {
+      connectionId: "default",
+      entities: [{ tableName: "users", yaml: "table: users\n" }],
+    });
+
+    expect(res.status).toBe(500);
+    const data = await json(res);
+    expect(data.error).toBe("db_persist_failed");
   });
 
   it("returns 400 for invalid entity objects (missing tableName/yaml)", async () => {

--- a/packages/api/src/api/routes/wizard.ts
+++ b/packages/api/src/api/routes/wizard.ts
@@ -202,6 +202,15 @@ const SaveResponseSchema = z.object({
   connectionId: z.string(),
   entityCount: z.number(),
   files: z.array(z.string()),
+  warnings: z
+    .array(
+      z.object({
+        kind: z.enum(["disk_sync_failed"]),
+        tableName: z.string(),
+        reason: z.string(),
+      }),
+    )
+    .optional(),
 });
 
 // ---------------------------------------------------------------------------
@@ -695,54 +704,112 @@ wizard.openapi(saveRoute, async (c) => {
     }
   
     try {
-      // Write entities to disk (org-scoped)
+      // Disk + DB are not transactional. Run DB first so a failure leaves
+      // the disk untouched — disk-orphan recovery is harder than DB-only
+      // retry. (#2141 + #2142.)
+      const dbEntities = entities.map((e) => ({
+        entityType: "entity" as const,
+        name: path.basename(e.tableName),
+        yamlContent: e.yaml,
+        connectionId,
+      }));
+      if (hasInternalDB()) {
+        const upserted = yield* Effect.tryPromise({
+          try: () => bulkUpsertEntities(orgId, dbEntities),
+          catch: (err) => err instanceof Error ? err : new Error(String(err)),
+        }).pipe(Effect.catchAll((err) => {
+          log.error(
+            { err: err.message, requestId, orgId, connectionId },
+            "Wizard save: bulkUpsertEntities threw — no rows persisted",
+          );
+          return Effect.succeed(null as number | null);
+        }));
+        if (upserted === null) {
+          return c.json({
+            error: "db_persist_failed",
+            message:
+              "Failed to register entities for queries. SQL execution will reject these tables until this is resolved. Retry the wizard.",
+            requestId,
+          }, 500);
+        }
+        if (upserted < dbEntities.length) {
+          // bulkUpsertEntities swallows per-entity errors and returns a
+          // success count. Returning 201 here would silently recreate the
+          // exact #2142 failure mode for the rows that didn't land.
+          log.error(
+            { requestId, orgId, attempted: dbEntities.length, upserted },
+            "Wizard save: partial entity upsert — failing loud rather than 201ing a half-persisted state",
+          );
+          invalidateOrgWhitelist(orgId);
+          return c.json({
+            error: "db_partial_persist",
+            message: `Registered ${upserted} of ${dbEntities.length} entities. Retry the wizard.`,
+            requestId,
+            attempted: dbEntities.length,
+            succeeded: upserted,
+          }, 500);
+        }
+        invalidateOrgWhitelist(orgId);
+      }
+
+      // Disk writes happen after DB success. Output dir is org-scoped.
       const sourceId = connectionId === "default" ? "default" : connectionId;
       const outputBase = outputDirForDatasource(sourceId, orgId);
       const entitiesDir = path.join(outputBase, "entities");
       const metricsDir = path.join(outputBase, "metrics");
-  
+
       fs.mkdirSync(entitiesDir, { recursive: true });
       fs.mkdirSync(metricsDir, { recursive: true });
-  
+
       const savedFiles: string[] = [];
-  
-      // Write entity YAMLs (table names already validated above)
+      const warnings: Array<{ kind: "disk_sync_failed"; tableName: string; reason: string }> = [];
+
       for (const entity of entities) {
         const safeName = path.basename(entity.tableName);
         const filePath = path.join(entitiesDir, `${safeName}.yml`);
         fs.writeFileSync(filePath, entity.yaml, "utf-8");
         savedFiles.push(`entities/${safeName}.yml`);
-  
-        // Also write to org-scoped semantic directory (semantic/.orgs/{orgId}/)
-        // so the explore tool can discover this entity.
+
+        // Org-scoped semantic dir feeds the explore tool. Failures here
+        // mean the agent can't read the entity even though the DB has it
+        // — surface the specific tableName so the operator can see which
+        // entities are split rather than just a log line.
         if (hasInternalDB()) {
-          yield* Effect.promise(() => syncEntityToDisk(orgId, entity.tableName, "entity", entity.yaml).catch((err) => {
-            log.warn({ err: err instanceof Error ? err.message : String(err), tableName: entity.tableName }, "Disk sync after wizard save failed");
+          const syncResult = yield* Effect.tryPromise({
+            try: () => syncEntityToDisk(orgId, entity.tableName, "entity", entity.yaml),
+            catch: (err) => err instanceof Error ? err : new Error(String(err)),
+          }).pipe(Effect.catchAll((err) => {
+            log.warn(
+              { err: err.message, requestId, orgId, tableName: entity.tableName },
+              "Disk sync after wizard save failed",
+            );
+            return Effect.succeed({ tableName: entity.tableName, reason: err.message });
           }));
+          if (syncResult && typeof syncResult === "object" && "tableName" in syncResult) {
+            warnings.push({ kind: "disk_sync_failed", ...syncResult });
+          }
         }
       }
-  
-      // Generate catalog, glossary, and metric files from raw profile data.
-      // The wizard frontend does not send raw profile data — it sends
-      // pre-generated entity YAML via { connectionId, entities } instead.
-      // This branch handles callers (e.g. future CLI integrations) that
-      // provide raw TableProfile[] data for server-side generation.
+
+      // Catalog/glossary/metrics from raw profile data. The wizard frontend
+      // sends pre-generated entity YAML via { connectionId, entities }; this
+      // branch is for callers (e.g. future CLI integrations) that submit
+      // raw TableProfile[] for server-side generation.
       const { schema: bodySchema, profiles: profileData } = body;
       if (profileData && profileData.length > 0) {
         const profiles = profileData;
         const resolvedSchema = bodySchema ?? "public";
-  
+
         const catalogYaml = generateCatalogYAML(profiles);
         const catalogPath = path.join(outputBase, "catalog.yml");
         fs.writeFileSync(catalogPath, catalogYaml, "utf-8");
         savedFiles.push("catalog.yml");
-  
+
         const glossaryYaml = generateGlossaryYAML(profiles);
         const glossaryPath = path.join(outputBase, "glossary.yml");
         fs.writeFileSync(glossaryPath, glossaryYaml, "utf-8");
         savedFiles.push("glossary.yml");
-  
-        // Generate metric files (sanitize table_name from profiles)
+
         for (const profile of profiles) {
           if (!profile.table_name || !SAFE_TABLE_NAME.test(profile.table_name)) continue;
           const metricYaml = generateMetricYAML(profile, resolvedSchema);
@@ -754,50 +821,7 @@ wizard.openapi(saveRoute, async (c) => {
           }
         }
       }
-  
-      // Persist to the org-scoped semantic_entities table. The disk write
-      // above feeds the file-based whitelist (used by the chat agent's
-      // file-walking code paths and the explore tool) but NOT the DB-backed
-      // per-org whitelist consumed by `loadOrgWhitelist` — which is what the
-      // MCP edge and the post-#2141 SQL validation read. Without this,
-      // wizard-onboarded workspaces have a silent split: chat works, MCP
-      // rejects every table with `unknown_entity` (#2142).
-      if (hasInternalDB()) {
-        const dbEntities = entities.map((e) => ({
-          entityType: "entity" as const,
-          name: path.basename(e.tableName),
-          yamlContent: e.yaml,
-          connectionId,
-        }));
-        const upserted = yield* Effect.tryPromise({
-          try: () => bulkUpsertEntities(orgId, dbEntities),
-          catch: (err) => err instanceof Error ? err : new Error(String(err)),
-        }).pipe(Effect.catchAll((err) => {
-          log.error(
-            { err: err.message, requestId, orgId, connectionId },
-            "Wizard save: bulkUpsertEntities failed — disk YAMLs written but per-org whitelist will be empty",
-          );
-          return Effect.succeed(null as number | null);
-        }));
-        if (upserted === null) {
-          return c.json({
-            error: "db_persist_failed",
-            message:
-              "Saved YAML files to disk, but failed to populate the per-org entity store. " +
-              "MCP / executeSQL will reject these tables until this is resolved. Retry the wizard or contact the operator.",
-            requestId,
-          }, 500);
-        }
-        invalidateOrgWhitelist(orgId);
-        if (upserted < dbEntities.length) {
-          log.warn(
-            { requestId, orgId, attempted: dbEntities.length, upserted },
-            "Wizard entity upsert: some rows failed — disk write succeeded but DB partially populated",
-          );
-        }
-      }
 
-      // Reset semantic whitelist cache so new entities are queryable
       _resetWhitelists();
 
       log.info({
@@ -806,6 +830,7 @@ wizard.openapi(saveRoute, async (c) => {
         connectionId,
         entityCount: entities.length,
         fileCount: savedFiles.length,
+        warningCount: warnings.length,
       }, "Wizard save complete");
 
       // F-34 (#1789): the wizard is the primary UI onboarding flow for a
@@ -834,6 +859,7 @@ wizard.openapi(saveRoute, async (c) => {
         connectionId,
         entityCount: entities.length,
         files: savedFiles,
+        ...(warnings.length > 0 ? { warnings } : {}),
       }, 201);
     } catch (err) {
       log.error({ err: err instanceof Error ? err : new Error(String(err)), requestId, orgId }, "Wizard save failed");

--- a/packages/api/src/api/routes/wizard.ts
+++ b/packages/api/src/api/routes/wizard.ts
@@ -23,8 +23,8 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { validationHook } from "./validation-hook";
 import { connections, detectDBType } from "@atlas/api/lib/db/connection";
 import { hasInternalDB, internalQuery, decryptUrl } from "@atlas/api/lib/db/internal";
-import { _resetWhitelists } from "@atlas/api/lib/semantic";
-import { DEMO_CONNECTION_ID } from "@atlas/api/lib/semantic/entities";
+import { _resetWhitelists, invalidateOrgWhitelist } from "@atlas/api/lib/semantic";
+import { DEMO_CONNECTION_ID, bulkUpsertEntities } from "@atlas/api/lib/semantic/entities";
 import { syncEntityToDisk } from "@atlas/api/lib/semantic/sync";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { adminAuth, requestContext, type AuthEnv } from "./middleware";
@@ -755,6 +755,48 @@ wizard.openapi(saveRoute, async (c) => {
         }
       }
   
+      // Persist to the org-scoped semantic_entities table. The disk write
+      // above feeds the file-based whitelist (used by the chat agent's
+      // file-walking code paths and the explore tool) but NOT the DB-backed
+      // per-org whitelist consumed by `loadOrgWhitelist` — which is what the
+      // MCP edge and the post-#2141 SQL validation read. Without this,
+      // wizard-onboarded workspaces have a silent split: chat works, MCP
+      // rejects every table with `unknown_entity` (#2142).
+      if (hasInternalDB()) {
+        const dbEntities = entities.map((e) => ({
+          entityType: "entity" as const,
+          name: path.basename(e.tableName),
+          yamlContent: e.yaml,
+          connectionId,
+        }));
+        const upserted = yield* Effect.tryPromise({
+          try: () => bulkUpsertEntities(orgId, dbEntities),
+          catch: (err) => err instanceof Error ? err : new Error(String(err)),
+        }).pipe(Effect.catchAll((err) => {
+          log.error(
+            { err: err.message, requestId, orgId, connectionId },
+            "Wizard save: bulkUpsertEntities failed — disk YAMLs written but per-org whitelist will be empty",
+          );
+          return Effect.succeed(null as number | null);
+        }));
+        if (upserted === null) {
+          return c.json({
+            error: "db_persist_failed",
+            message:
+              "Saved YAML files to disk, but failed to populate the per-org entity store. " +
+              "MCP / executeSQL will reject these tables until this is resolved. Retry the wizard or contact the operator.",
+            requestId,
+          }, 500);
+        }
+        invalidateOrgWhitelist(orgId);
+        if (upserted < dbEntities.length) {
+          log.warn(
+            { requestId, orgId, attempted: dbEntities.length, upserted },
+            "Wizard entity upsert: some rows failed — disk write succeeded but DB partially populated",
+          );
+        }
+      }
+
       // Reset semantic whitelist cache so new entities are queryable
       _resetWhitelists();
 

--- a/packages/api/src/lib/__tests__/semantic-org.test.ts
+++ b/packages/api/src/lib/__tests__/semantic-org.test.ts
@@ -21,6 +21,7 @@ import { resolve } from "path";
 import type { SemanticEntityRow } from "../semantic/entities";
 
 const mockListEntities = mock((): Promise<SemanticEntityRow[]> => Promise.resolve([]));
+const mockListEntitiesWithOverlay = mock((): Promise<SemanticEntityRow[]> => Promise.resolve([]));
 const mockGetEntity = mock((): Promise<SemanticEntityRow | null> => Promise.resolve(null));
 const mockUpsertEntity = mock((): Promise<void> => Promise.resolve());
 const mockDeleteEntity = mock((): Promise<boolean> => Promise.resolve(false));
@@ -29,6 +30,7 @@ const mockBulkUpsertEntities = mock((): Promise<number> => Promise.resolve(0));
 
 mock.module("@atlas/api/lib/semantic/entities", () => ({
   listEntities: mockListEntities,
+  listEntitiesWithOverlay: mockListEntitiesWithOverlay,
   getEntity: mockGetEntity,
   upsertEntity: mockUpsertEntity,
   deleteEntity: mockDeleteEntity,
@@ -42,8 +44,10 @@ const mod = await import(`${modPath}?t=${Date.now()}`);
 const loadOrgWhitelist = mod.loadOrgWhitelist as typeof import("../semantic/whitelist").loadOrgWhitelist;
 const getOrgWhitelistedTables = mod.getOrgWhitelistedTables as typeof import("../semantic/whitelist").getOrgWhitelistedTables;
 const invalidateOrgWhitelist = mod.invalidateOrgWhitelist as typeof import("../semantic/whitelist").invalidateOrgWhitelist;
+const registerPluginEntities = mod.registerPluginEntities as typeof import("../semantic/whitelist").registerPluginEntities;
 const _resetOrgWhitelists = mod._resetOrgWhitelists as typeof import("../semantic/whitelist")._resetOrgWhitelists;
 const _resetOrgSemanticIndexes = mod._resetOrgSemanticIndexes as typeof import("../semantic/whitelist")._resetOrgSemanticIndexes;
+const _resetPluginEntities = mod._resetPluginEntities as typeof import("../semantic/whitelist")._resetPluginEntities;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -227,6 +231,48 @@ describe("getOrgWhitelistedTables", () => {
     const tables = getOrgWhitelistedTables("org-mixed", "default");
     expect(tables.has("users")).toBe(true);
     expect(tables.has("events")).toBe(false);
+  });
+
+  it("fallback fires identically for published and developer mode caches", async () => {
+    // Each mode keeps a separate cache key. The fallback heuristic must not
+    // depend on which mode loaded the cache — otherwise demo/wizard MCP
+    // works in published mode but breaks for developer-mode SaaS, or vice
+    // versa.
+    mockListEntities.mockImplementation(() =>
+      Promise.resolve([makeEntityRow("customers", "customers", "__demo__")]),
+    );
+    mockListEntitiesWithOverlay.mockImplementation(() =>
+      Promise.resolve([makeEntityRow("customers", "customers", "__demo__")]),
+    );
+
+    await loadOrgWhitelist("org-demo", "published");
+    const publishedTables = getOrgWhitelistedTables("org-demo", "default", "published");
+    expect(publishedTables.has("customers")).toBe(true);
+
+    await loadOrgWhitelist("org-demo", "developer");
+    const developerTables = getOrgWhitelistedTables("org-demo", "default", "developer");
+    expect(developerTables.has("customers")).toBe(true);
+  });
+
+  it("merges plugin-registered tables on the fallback path", async () => {
+    // Plugin tables register against connectionId="default" (the requested
+    // id, not the stored key). On the demo fallback path, plugin tables
+    // for "default" must still merge into the result.
+    _resetPluginEntities();
+
+    mockListEntities.mockImplementation(() =>
+      Promise.resolve([makeEntityRow("customers", "customers", "__demo__")]),
+    );
+    registerPluginEntities("default", [
+      { name: "audit_log", yaml: "table: audit_log\n" },
+    ]);
+
+    await loadOrgWhitelist("org-demo");
+    const tables = getOrgWhitelistedTables("org-demo", "default");
+    expect(tables.has("customers")).toBe(true); // via fallback
+    expect(tables.has("audit_log")).toBe(true); // via plugin merge
+
+    _resetPluginEntities();
   });
 });
 

--- a/packages/api/src/lib/__tests__/semantic-org.test.ts
+++ b/packages/api/src/lib/__tests__/semantic-org.test.ts
@@ -165,6 +165,69 @@ describe("getOrgWhitelistedTables", () => {
     const tables = getOrgWhitelistedTables("org-not-loaded");
     expect(tables.size).toBe(0);
   });
+
+  it("falls back to the only connection when 'default' is requested on a single-connection org (#2142 demo + wizard)", async () => {
+    // Demo workspaces store entities under connection_id="__demo__";
+    // wizard-onboarded workspaces may use any user-chosen id. Without
+    // this fallback, executeSQL calls without an explicit connectionId
+    // (which default to "default") reject every table on those orgs.
+    mockListEntities.mockImplementation(() =>
+      Promise.resolve([
+        makeEntityRow("customers", "customers", "__demo__"),
+        makeEntityRow("orders", "orders", "__demo__"),
+      ]),
+    );
+
+    await loadOrgWhitelist("org-demo");
+    const tables = getOrgWhitelistedTables("org-demo", "default");
+    expect(tables.has("customers")).toBe(true);
+    expect(tables.has("orders")).toBe(true);
+  });
+
+  it("does NOT fall back when requesting non-'default' connectionId — strict isolation", async () => {
+    // The fallback is intentionally narrow: only fires for connectionId="default".
+    // Asking for a specific non-existent connectionId must still return empty,
+    // so multi-source orgs can't accidentally cross-route queries.
+    mockListEntities.mockImplementation(() =>
+      Promise.resolve([makeEntityRow("customers", "customers", "__demo__")]),
+    );
+
+    await loadOrgWhitelist("org-demo");
+    const tables = getOrgWhitelistedTables("org-demo", "warehouse");
+    expect(tables.size).toBe(0);
+  });
+
+  it("does NOT fall back when the org has multiple connections", async () => {
+    // Multi-source orgs require explicit connectionId; a "default" lookup
+    // with no matching key returns empty rather than picking one
+    // arbitrarily.
+    mockListEntities.mockImplementation(() =>
+      Promise.resolve([
+        makeEntityRow("customers", "customers", "warehouse"),
+        makeEntityRow("events", "events", "ops"),
+      ]),
+    );
+
+    await loadOrgWhitelist("org-multi");
+    const tables = getOrgWhitelistedTables("org-multi", "default");
+    expect(tables.size).toBe(0);
+  });
+
+  it("prefers a real 'default' entry over the fallback path", async () => {
+    // If the org genuinely has a "default" connection, the direct hit must
+    // win — the fallback only fires when "default" yields an empty set.
+    mockListEntities.mockImplementation(() =>
+      Promise.resolve([
+        makeEntityRow("users", "users"), // connection_id null → keys under "default"
+        makeEntityRow("events", "events", "warehouse"),
+      ]),
+    );
+
+    await loadOrgWhitelist("org-mixed");
+    const tables = getOrgWhitelistedTables("org-mixed", "default");
+    expect(tables.has("users")).toBe(true);
+    expect(tables.has("events")).toBe(false);
+  });
 });
 
 describe("invalidateOrgWhitelist", () => {

--- a/packages/api/src/lib/semantic/whitelist.ts
+++ b/packages/api/src/lib/semantic/whitelist.ts
@@ -483,14 +483,8 @@ export function getOrgWhitelistedTables(orgId: string, connectionId: string = "d
     return new Set();
   }
 
-  // Direct hit on the requested connectionId is the primary lookup. The
-  // fallback below makes single-connection orgs work when callers default
-  // to "default" — which is the common case for the chat agent and MCP
-  // clients that don't bind a specific connectionId. Demo workspaces store
-  // entities under `__demo__`, and wizard-onboarded orgs may store under any
-  // user-chosen id (e.g. "warehouse"); without the fallback every executeSQL
-  // call without an explicit connectionId would reject every table on those
-  // orgs (#2142).
+  // Single-connection orgs: callers default to "default", but demo stores
+  // under "__demo__" and wizard orgs under user-chosen ids (#2142).
   let tables = new Set(byConnection.get(connectionId) ?? []);
   if (
     tables.size === 0 &&
@@ -498,8 +492,13 @@ export function getOrgWhitelistedTables(orgId: string, connectionId: string = "d
     byConnection.size === 1 &&
     !byConnection.has("default")
   ) {
+    const [storedKey] = byConnection.keys();
     const [onlyTables] = byConnection.values();
     tables = new Set(onlyTables);
+    log.debug(
+      { orgId, requestedConnectionId: connectionId, resolvedConnectionId: storedKey, mode: mode ?? "developer" },
+      "getOrgWhitelistedTables: single-connection fallback",
+    );
   }
 
   // Merge plugin-provided entities (same behavior as file-based getWhitelistedTables)

--- a/packages/api/src/lib/semantic/whitelist.ts
+++ b/packages/api/src/lib/semantic/whitelist.ts
@@ -483,12 +483,23 @@ export function getOrgWhitelistedTables(orgId: string, connectionId: string = "d
     return new Set();
   }
 
-  const hasNonDefault = Array.from(byConnection.keys()).some((k) => k !== "default");
-  let tables: Set<string>;
-  if (!hasNonDefault) {
-    tables = new Set(byConnection.get("default") ?? []);
-  } else {
-    tables = new Set(byConnection.get(connectionId) ?? []);
+  // Direct hit on the requested connectionId is the primary lookup. The
+  // fallback below makes single-connection orgs work when callers default
+  // to "default" — which is the common case for the chat agent and MCP
+  // clients that don't bind a specific connectionId. Demo workspaces store
+  // entities under `__demo__`, and wizard-onboarded orgs may store under any
+  // user-chosen id (e.g. "warehouse"); without the fallback every executeSQL
+  // call without an explicit connectionId would reject every table on those
+  // orgs (#2142).
+  let tables = new Set(byConnection.get(connectionId) ?? []);
+  if (
+    tables.size === 0 &&
+    connectionId === "default" &&
+    byConnection.size === 1 &&
+    !byConnection.has("default")
+  ) {
+    const [onlyTables] = byConnection.values();
+    tables = new Set(onlyTables);
   }
 
   // Merge plugin-provided entities (same behavior as file-based getWhitelistedTables)


### PR DESCRIPTION
Closes #2142.

## What was actually broken

The issue title said "demo-data flow doesn't sync semantic entities to per-org DB" but the trace turned up two independent root causes in the same blast radius. Fixing only one would leave the other half-broken.

### Root cause 1 — whitelist lookup mismatch

`/use-demo` (`onboarding.ts:792`) calls `importFromDisk(orgId, { connectionId: "__demo__" })`, which DOES persist demo entities into `semantic_entities` — keyed under `connection_id = "__demo__"`. But `executeSQL` defaults to `connectionId = "default"` when callers omit it (`sql.ts:994`), which is the common case for both the chat agent and MCP clients (Claude Desktop, Cursor, etc.).

The old `getOrgWhitelistedTables` in `whitelist.ts:486-491` strict-matched by key once any non-`"default"` connection existed:

```ts
const hasNonDefault = Array.from(byConnection.keys()).some((k) => k !== "default");
if (!hasNonDefault) {
  tables = byConnection.get("default") ?? new Set();
} else {
  tables = byConnection.get(connectionId) ?? new Set();  // empty for demo workspaces
}
```

For a demo workspace `byConnection = { "__demo__": Set<13 tables> }` → `hasNonDefault = true` → lookup for `"default"` → empty Set → every table rejected with `unknown_entity`.

**Fix**: refactor to a single-connection fallback. When the requested `connectionId` is `"default"` and the org has exactly one connection keyed under a non-`"default"` name, use that single connection's tables. The fallback is intentionally narrow: multi-source orgs still require explicit `connectionId`, so we don't create cross-routing risk.

### Root cause 2 — wizard `/save` never populated `semantic_entities`

While tracing root cause 1, I read `wizard.ts:670-805` and noticed the `/save` handler writes YAMLs to disk but doesn't call `bulkUpsertEntities`. Pre-#2141 this didn't bite because the SQL whitelist read from the file-based store. Post-#2141 the MCP edge consults `loadOrgWhitelist` which reads from `semantic_entities`. So **every wizard-onboarded workspace has the same MCP-side breakage as demo workspaces** — chat works, MCP rejects every table.

**Fix**: add a `bulkUpsertEntities` + `invalidateOrgWhitelist` call right before the existing `_resetWhitelists()`. Failure surfaces as 500 `db_persist_failed` (not silently logged) so the operator notices rather than discovering it via a customer report.

## Test plan

- [x] `bun run scripts/test-isolated.ts --affected` — 10 affected files, all green
- [x] `bun run type` — clean
- [x] `bun run lint` — clean
- [x] 4 new whitelist tests in `semantic-org.test.ts`:
  - Demo / wizard fallback fires for single-connection orgs with non-"default" name
  - Strict isolation preserved for non-"default" lookups
  - Multi-source orgs do NOT get the fallback
  - "default" entries take priority over the fallback path
- [x] 2 new wizard tests in `wizard.test.ts`:
  - `/save` calls `bulkUpsertEntities` with the correct args + invalidates the org whitelist
  - DB-write failure surfaces as 500 `db_persist_failed`
- [ ] Smoke against `mcp.useatlas.dev` after deploy: `tools/call executeSQL` on `SELECT id FROM customers LIMIT 5` against the load-test workspace returns rows, not `unknown_entity`

## Follow-ups

- Re-run `tool-call-mix.js` against the live workspace after this lands; the per-tool error-envelope rates in `mcp-performance.mdx` should drop to ~0%. Update the doc with a follow-up commit.
- The wizard's disk-write half is now somewhat vestigial for the SaaS deploy mode (the DB is the source of truth post-this-PR); consolidating that is its own design discussion, not in scope here.