### PR TITLE
fix(api): atomic /use-demo + auto-recovery for partial-state demo orgs (#2153)

### DIFF
--- a/packages/api/src/api/__tests__/admin-password-semantic-import-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-password-semantic-import-audit.test.ts
@@ -53,7 +53,7 @@ mock.module("@atlas/api/lib/auth/server", () => ({
 }));
 
 // importFromDisk — the bulk-import handler dynamically imports it.
-const mockImportFromDisk: Mock<(orgId: string, opts?: { connectionId?: string }) => Promise<unknown>> = mock(
+const mockImportFromDisk: Mock<(orgId: string, opts?: { connectionId?: string; sourceDir?: string }) => Promise<unknown>> = mock(
   async () => ({ imported: 12, skipped: 3, total: 15, entries: [] }),
 );
 mock.module("@atlas/api/lib/semantic/sync", () => ({
@@ -349,6 +349,74 @@ describe("POST /api/v1/admin/semantic/org/import — audit emission (F-29)", () 
     expect(res.status).toBe(200);
     expect(importCallCount).toBe(1);
     const entry = lastAuditCall();
+    expect(entry.metadata).toMatchObject({ sourceRef: "disk:all" });
+  });
+
+  it("does not auto-recover when the caller passes an explicit connectionId", async () => {
+    // Critical safety: an org might own BOTH `warehouse` and `__demo__`. If
+    // the caller asks specifically about `warehouse` and its disk happens
+    // to be empty, we MUST NOT silently overwrite/import NovaMart entities
+    // — that would corrupt the warehouse semantic layer.
+    let importCallCount = 0;
+    let lastImportOpts: unknown = null;
+    mockImportFromDisk.mockImplementation(async (_orgId: string, opts?: { connectionId?: string; sourceDir?: string }) => {
+      importCallCount++;
+      lastImportOpts = opts;
+      return { imported: 0, skipped: 0, total: 0, errors: [] };
+    });
+    // Org owns __demo__ — but caller asked about warehouse.
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (typeof sql === "string" && sql.includes("__demo__")) {
+        return [{ id: "__demo__" }];
+      }
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/semantic/org/import", { connectionId: "warehouse" }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(importCallCount).toBe(1);
+    expect(lastImportOpts).toMatchObject({ connectionId: "warehouse" });
+    const data = (await res.json()) as { imported: number };
+    expect(data.imported).toBe(0);
+    const entry = lastAuditCall();
+    expect(entry.metadata).toMatchObject({ sourceRef: "disk:warehouse" });
+  });
+
+  it("auto-recovery reports honestly when the bundled seed itself yields zero imports", async () => {
+    // A degenerate case: seed dir present but every YAML row fails the
+    // upsert. The auto-recovery branch must NOT mis-claim recovery — the
+    // sourceRef stays as the original disk:all, no auto-recover audit
+    // trail, and the user sees the truthful 0-imported result.
+    let importCallCount = 0;
+    mockImportFromDisk.mockImplementation(async (_orgId: string, opts?: { sourceDir?: string }) => {
+      importCallCount++;
+      // First call (org-scoped disk, no sourceDir) → empty.
+      // Second call (recovery, sourceDir set) → seed yielded zero.
+      if (opts?.sourceDir) {
+        return { imported: 0, skipped: 13, total: 13, errors: [] };
+      }
+      return { imported: 0, skipped: 0, total: 0, errors: [] };
+    });
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (typeof sql === "string" && sql.includes("__demo__")) {
+        return [{ id: "__demo__" }];
+      }
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/semantic/org/import", {}),
+    );
+
+    expect(res.status).toBe(200);
+    expect(importCallCount).toBeGreaterThanOrEqual(2);
+    const entry = lastAuditCall();
+    // The recovery call happened, but it didn't produce rows — so we
+    // must NOT mark this as `demo-seed:auto-recover`.
+    expect(entry.metadata).not.toMatchObject({ sourceRef: "demo-seed:auto-recover" });
     expect(entry.metadata).toMatchObject({ sourceRef: "disk:all" });
   });
 

--- a/packages/api/src/api/__tests__/admin-password-semantic-import-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-password-semantic-import-audit.test.ts
@@ -287,4 +287,85 @@ describe("POST /api/v1/admin/semantic/org/import — audit emission (F-29)", () 
     expect(res.status).toBe(400);
     expect(mockLogAdminAction).not.toHaveBeenCalled();
   });
+
+  it("auto-recovers a partial-demo org from the bundled seed", async () => {
+    // Reproduces the dharma class of incident: the org has a `__demo__`
+    // connection but the org-scoped disk has zero entities (because the
+    // pre-#2153 /use-demo flow committed the connection before the import
+    // attempt). Clicking "Import from disk" should now silently fall
+    // through to the bundled NovaMart seed and recover the workspace —
+    // the user gets a coherent state in one click.
+    let importCallCount = 0;
+    mockImportFromDisk.mockImplementation(async (orgId: string, opts?: { connectionId?: string; sourceDir?: string }) => {
+      importCallCount++;
+      if (importCallCount === 1) {
+        // First call — org-scoped disk yields nothing
+        expect(opts?.sourceDir).toBeUndefined();
+        return { imported: 0, skipped: 0, total: 0, errors: [] };
+      }
+      // Second call — bundled-seed fallback
+      expect(opts?.connectionId).toBe("__demo__");
+      expect(opts?.sourceDir).toBeDefined();
+      return { imported: 13, skipped: 0, total: 13, errors: [] };
+    });
+    // Org owns __demo__ — triggers the auto-recovery branch.
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (typeof sql === "string" && sql.includes("FROM connections") && sql.includes("__demo__")) {
+        return [{ id: "__demo__" }];
+      }
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/semantic/org/import", {}),
+    );
+
+    expect(res.status).toBe(200);
+    expect(importCallCount).toBe(2);
+    const data = (await res.json()) as { imported: number };
+    expect(data.imported).toBe(13);
+
+    const entry = lastAuditCall();
+    expect(entry.metadata).toMatchObject({
+      importedCount: 13,
+      sourceRef: "demo-seed:auto-recover",
+    });
+  });
+
+  it("does not auto-recover when the org has no __demo__ connection", async () => {
+    // Wizard org with empty disk — no auto-fallthrough. The user sees the
+    // honest 0-imported result rather than a surprise NovaMart import.
+    let importCallCount = 0;
+    mockImportFromDisk.mockImplementation(async () => {
+      importCallCount++;
+      return { imported: 0, skipped: 0, total: 0, errors: [] };
+    });
+    mocks.mockInternalQuery.mockImplementation(async () => []); // no __demo__ row
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/semantic/org/import", {}),
+    );
+
+    expect(res.status).toBe(200);
+    expect(importCallCount).toBe(1);
+    const entry = lastAuditCall();
+    expect(entry.metadata).toMatchObject({ sourceRef: "disk:all" });
+  });
+
+  it("explicit source=demo-seed forces the bundled seed path", async () => {
+    let importedFromSeed = false;
+    mockImportFromDisk.mockImplementation(async (_orgId: string, opts?: { connectionId?: string; sourceDir?: string }) => {
+      if (opts?.sourceDir) importedFromSeed = true;
+      return { imported: 13, skipped: 0, total: 13, errors: [] };
+    });
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/semantic/org/import", { source: "demo-seed" }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(importedFromSeed).toBe(true);
+    const entry = lastAuditCall();
+    expect(entry.metadata).toMatchObject({ sourceRef: "demo-seed" });
+  });
 });

--- a/packages/api/src/api/__tests__/onboarding.test.ts
+++ b/packages/api/src/api/__tests__/onboarding.test.ts
@@ -1053,6 +1053,66 @@ describe("POST /api/v1/onboarding/use-demo", () => {
     expect(mockImportFromDisk).not.toHaveBeenCalled();
   });
 
+  it("ATOMICITY: import is invoked BEFORE the connection insert in the happy path", async () => {
+    // The phase-reorder is the load-bearing invariant. Asserting the
+    // call order pins it directly so a future refactor that flips
+    // phases 2 and 3 (both succeeding) is caught.
+    let importInvocationOrder = -1;
+    let connectionInsertOrder = -1;
+    let counter = 0;
+    mockImportFromDisk.mockImplementation(async () => {
+      importInvocationOrder = ++counter;
+      return { imported: 13, skipped: 0, errors: [], total: 13 };
+    });
+    const baseImpl = mockInternalQuery.getMockImplementation();
+    mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (typeof sql === "string" && sql.includes("INSERT INTO connections")) {
+        connectionInsertOrder = ++counter;
+        return [{ id: "__demo__" }];
+      }
+      return baseImpl ? baseImpl(sql, params) : [];
+    });
+
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(201);
+    expect(importInvocationOrder).toBeGreaterThan(0);
+    expect(connectionInsertOrder).toBeGreaterThan(0);
+    expect(importInvocationOrder).toBeLessThan(connectionInsertOrder);
+
+    if (baseImpl) mockInternalQuery.mockImplementation(baseImpl);
+    mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5 }));
+  });
+
+  it("PARTIAL: imported > 0 && imported < total still commits the connection (lenient contract)", async () => {
+    // Pinning the lenient behavior so a future tightening to all-or-
+    // nothing would have to update this test deliberately. The 0-of-N
+    // case is handled separately as a hard fail.
+    mockImportFromDisk.mockImplementation(async () => ({
+      imported: 8,
+      skipped: 5,
+      errors: [{ file: "broken.yml", reason: "yaml parse" }],
+      total: 13,
+    }));
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(201);
+    const data = await json(res);
+    expect(data.entitiesImported).toBe(8);
+
+    const connectionInsert = mockInternalQuery.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("INSERT INTO connections"),
+    );
+    expect(connectionInsert).toBeDefined();
+    mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5 }));
+  });
+
   it("ATOMICITY: idempotent retry — a successful retry after a failure persists everything", async () => {
     // First call fails on import (no connection committed). Second call
     // succeeds (import is upsert-safe; connection upsert is idempotent).

--- a/packages/api/src/api/__tests__/onboarding.test.ts
+++ b/packages/api/src/api/__tests__/onboarding.test.ts
@@ -981,6 +981,105 @@ describe("POST /api/v1/onboarding/use-demo", () => {
     mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5 }));
   });
 
+  it("ATOMICITY: import failure leaves no connection row committed", async () => {
+    // Reproduces the dharma symptom — connection had been committed BEFORE
+    // the import attempt, so a failed import left a half-state. Phase order
+    // is now: import first, connection last. A throwing import must mean
+    // zero `INSERT INTO connections` calls.
+    mockImportFromDisk.mockImplementation(async () => {
+      throw new Error("simulated disk failure");
+    });
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(500);
+    const data = await json(res);
+    expect(data.error).toBe("import_failed");
+
+    const connectionInsert = mockInternalQuery.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("INSERT INTO connections"),
+    );
+    expect(connectionInsert).toBeUndefined();
+    expect(mockRegister).not.toHaveBeenCalled();
+    mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5 }));
+  });
+
+  it("ATOMICITY: import returning zero imports out of N total fails before writing connection", async () => {
+    // bulkUpsertEntities swallows per-row errors and returns a count. If
+    // every row fails (imported=0, total>0) we'd have a connection without
+    // entities — the exact partial state we're preventing. Treat as fatal.
+    mockImportFromDisk.mockImplementation(async () => ({
+      imported: 0,
+      skipped: 13,
+      errors: [{ file: "users.yml", reason: "broken yaml" }],
+      total: 13,
+    }));
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(500);
+    const data = await json(res);
+    expect(data.error).toBe("import_failed");
+
+    const connectionInsert = mockInternalQuery.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("INSERT INTO connections"),
+    );
+    expect(connectionInsert).toBeUndefined();
+    mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5 }));
+  });
+
+  it("ATOMICITY: missing bundled YAML fails before writing connection", async () => {
+    // getDemoSemanticDir() throws when neither the configured root nor the
+    // bundled-seed dir has an entities/ subdir. The pre-validation phase
+    // must catch this before any DB write.
+    existsSyncImpl = () => false;
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(500);
+    const data = await json(res);
+    expect(data.error).toBe("demo_not_available");
+
+    const connectionInsert = mockInternalQuery.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("INSERT INTO connections"),
+    );
+    expect(connectionInsert).toBeUndefined();
+    expect(mockImportFromDisk).not.toHaveBeenCalled();
+  });
+
+  it("ATOMICITY: idempotent retry — a successful retry after a failure persists everything", async () => {
+    // First call fails on import (no connection committed). Second call
+    // succeeds (import is upsert-safe; connection upsert is idempotent).
+    // The user can self-recover without admin intervention — that's the
+    // recovery story for the dharma-class incident.
+    mockImportFromDisk.mockImplementationOnce(async () => {
+      throw new Error("transient disk error");
+    });
+    const firstRes = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(firstRes.status).toBe(500);
+
+    mockImportFromDisk.mockImplementation(async () => ({ imported: 13, skipped: 0, errors: [], total: 13 }));
+    const secondRes = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(secondRes.status).toBe(201);
+    const data = await json(secondRes);
+    expect(data.connectionId).toBe("__demo__");
+    expect(data.entitiesImported).toBe(13);
+  });
+
   it("returns 500 with requestId when encryption fails", async () => {
     mockEncryptUrl.mockImplementation(() => { throw new Error("bad key"); });
     const res = await request("/api/v1/onboarding/use-demo", {

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -1625,7 +1625,7 @@ admin.openapi(importOrgEntitiesRoute, async (c) => runHandler(c, "import org sem
     return c.json({ error: "not_available", message: "Org-scoped semantic entities require an internal database (DATABASE_URL)." , requestId}, 501);
   }
 
-  let body: { connectionId?: string } = {};
+  let body: { connectionId?: string; source?: "org-disk" | "demo-seed" } = {};
   const contentType = c.req.header("content-type") ?? "";
   if (contentType.includes("application/json")) {
     try {
@@ -1636,21 +1636,75 @@ admin.openapi(importOrgEntitiesRoute, async (c) => runHandler(c, "import org sem
   }
 
   const { importFromDisk } = await import("@atlas/api/lib/semantic/sync");
-  const result = await importFromDisk(orgId, {
-    connectionId: body.connectionId,
-  });
+
+  // Two paths:
+  //   1. Explicit `source: "demo-seed"` — caller asks for the bundled
+  //      NovaMart seed (used by recovery flows or future tools).
+  //   2. Default — try the org-scoped disk first. If that yields zero
+  //      entities AND the org owns a `__demo__` connection, retry from the
+  //      bundled demo seed automatically. This is the self-heal for
+  //      partial-demo orgs (the dharma class of incident pre-#2153): one
+  //      button click in /admin/semantic recovers the state.
+  let result: Awaited<ReturnType<typeof importFromDisk>>;
+  let resolvedSource: string;
+  if (body.source === "demo-seed") {
+    const { getDemoSemanticDir } = await import("./onboarding-helpers");
+    let semanticDir: string;
+    try {
+      semanticDir = getDemoSemanticDir().dir;
+    } catch (err) {
+      log.error({ err: err instanceof Error ? err.message : String(err), requestId, orgId }, "Demo seed not found on this server");
+      return c.json({
+        error: "demo_not_available",
+        message: "The canonical demo semantic layer is not installed on this server.",
+        requestId,
+      }, 500);
+    }
+    result = await importFromDisk(orgId, { connectionId: "__demo__", sourceDir: semanticDir });
+    resolvedSource = "demo-seed";
+  } else {
+    result = await importFromDisk(orgId, { connectionId: body.connectionId });
+    resolvedSource = body.connectionId ? `disk:${body.connectionId}` : "disk:all";
+
+    if (result.imported === 0 && result.total === 0) {
+      // Org-scoped disk had nothing. If the org has a __demo__ connection
+      // we recover from the bundled seed transparently — saves the admin
+      // from a second click and the cognitive load of figuring out why
+      // the org-scoped disk is empty.
+      const demoRows = await internalQuery<{ id: string }>(
+        `SELECT id FROM connections WHERE org_id = $1 AND id = '__demo__' AND status IN ('published', 'draft')`,
+        [orgId],
+      );
+      if (demoRows.length > 0) {
+        const { getDemoSemanticDir } = await import("./onboarding-helpers");
+        try {
+          const semanticDir = getDemoSemanticDir().dir;
+          result = await importFromDisk(orgId, { connectionId: "__demo__", sourceDir: semanticDir });
+          resolvedSource = "demo-seed:auto-recover";
+          log.info(
+            { requestId, orgId, imported: result.imported, total: result.total },
+            "Auto-recovered partial-demo state via bundled seed fallback",
+          );
+        } catch (err) {
+          log.warn(
+            { err: err instanceof Error ? err.message : String(err), requestId, orgId },
+            "Auto-recovery skipped — bundled demo seed not available",
+          );
+        }
+      }
+    }
+  }
 
   log.info(
-    { requestId, orgId, imported: result.imported, skipped: result.skipped, total: result.total },
+    { requestId, orgId, imported: result.imported, skipped: result.skipped, total: result.total, source: resolvedSource },
     "Org semantic import completed",
   );
 
   // Bulk disk → DB sync: one row per import call instead of per entity
   // so the audit trail scales with admin intent, not entity count. The
   // per-entity trail (if ever needed) can be reconstructed from the
-  // sync log lines. `sourceRef` falls back to "disk:all" when the
-  // caller didn't narrow to a single connection — forensic queries can
-  // filter on the per-connection variant. See F-29.
+  // sync log lines. `sourceRef` distinguishes the auto-recovery path so
+  // forensic queries can identify partial-state self-heals.
   logAdminAction({
     actionType: ADMIN_ACTIONS.semantic.bulkImport,
     targetType: "semantic",
@@ -1658,7 +1712,7 @@ admin.openapi(importOrgEntitiesRoute, async (c) => runHandler(c, "import org sem
     ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
     metadata: {
       importedCount: result.imported,
-      sourceRef: body.connectionId ? `disk:${body.connectionId}` : "disk:all",
+      sourceRef: resolvedSource,
     },
   });
 

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -1641,10 +1641,15 @@ admin.openapi(importOrgEntitiesRoute, async (c) => runHandler(c, "import org sem
   //   1. Explicit `source: "demo-seed"` — caller asks for the bundled
   //      NovaMart seed (used by recovery flows or future tools).
   //   2. Default — try the org-scoped disk first. If that yields zero
-  //      entities AND the org owns a `__demo__` connection, retry from the
-  //      bundled demo seed automatically. This is the self-heal for
-  //      partial-demo orgs (the dharma class of incident pre-#2153): one
-  //      button click in /admin/semantic recovers the state.
+  //      entities AND the org owns a `__demo__` connection AND the caller
+  //      didn't ask about a specific connection, retry from the bundled
+  //      demo seed automatically. This recovers orgs whose `__demo__`
+  //      connection committed without entity rows (the partial-state bug
+  //      fixed in /use-demo by ordering import-before-connection-write).
+  //      The `!body.connectionId` gate is critical: a caller asking
+  //      explicitly about `warehouse` should NOT have NovaMart silently
+  //      written to its semantic layer even if the org also owns
+  //      `__demo__`.
   let result: Awaited<ReturnType<typeof importFromDisk>>;
   let resolvedSource: string;
   if (body.source === "demo-seed") {
@@ -1666,30 +1671,67 @@ admin.openapi(importOrgEntitiesRoute, async (c) => runHandler(c, "import org sem
     result = await importFromDisk(orgId, { connectionId: body.connectionId });
     resolvedSource = body.connectionId ? `disk:${body.connectionId}` : "disk:all";
 
-    if (result.imported === 0 && result.total === 0) {
-      // Org-scoped disk had nothing. If the org has a __demo__ connection
-      // we recover from the bundled seed transparently — saves the admin
-      // from a second click and the cognitive load of figuring out why
-      // the org-scoped disk is empty.
-      const demoRows = await internalQuery<{ id: string }>(
-        `SELECT id FROM connections WHERE org_id = $1 AND id = '__demo__' AND status IN ('published', 'draft')`,
-        [orgId],
-      );
-      if (demoRows.length > 0) {
+    if (result.imported === 0 && result.total === 0 && !body.connectionId) {
+      // Org-scoped disk had nothing AND the caller didn't narrow to a
+      // specific connection. If the org has a `__demo__` connection we
+      // recover from the bundled seed transparently.
+      let ownsDemo = false;
+      try {
+        const demoRows = await internalQuery<{ id: string }>(
+          `SELECT id FROM connections WHERE org_id = $1 AND id = '__demo__' AND status IN ('published', 'draft')`,
+          [orgId],
+        );
+        ownsDemo = demoRows.length > 0;
+      } catch (err) {
+        // A transient DB blip during the recovery probe shouldn't mask the
+        // legitimate "nothing to import" outcome the caller already got.
+        log.warn(
+          { err: err instanceof Error ? err.message : String(err), requestId, orgId },
+          "Auto-recovery probe failed — skipping recovery",
+        );
+      }
+
+      if (ownsDemo) {
+        // Resolve and import in separate try blocks so a thrown
+        // `importFromDisk` (DB pool, FS perms, etc.) isn't logged as
+        // "bundled demo seed not available" — that was the old conflated
+        // error path.
         const { getDemoSemanticDir } = await import("./onboarding-helpers");
+        let semanticDir: string | null = null;
         try {
-          const semanticDir = getDemoSemanticDir().dir;
-          result = await importFromDisk(orgId, { connectionId: "__demo__", sourceDir: semanticDir });
-          resolvedSource = "demo-seed:auto-recover";
-          log.info(
-            { requestId, orgId, imported: result.imported, total: result.total },
-            "Auto-recovered partial-demo state via bundled seed fallback",
-          );
+          semanticDir = getDemoSemanticDir().dir;
         } catch (err) {
           log.warn(
             { err: err instanceof Error ? err.message : String(err), requestId, orgId },
             "Auto-recovery skipped — bundled demo seed not available",
           );
+        }
+
+        if (semanticDir) {
+          try {
+            const recovered = await importFromDisk(orgId, { connectionId: "__demo__", sourceDir: semanticDir });
+            // Only claim recovery if it actually produced rows — a
+            // `recovered.imported === 0` from a present-but-empty seed
+            // tree shouldn't mislead the audit trail.
+            if (recovered.imported > 0) {
+              result = recovered;
+              resolvedSource = "demo-seed:auto-recover";
+              log.info(
+                { requestId, orgId, imported: result.imported, total: result.total },
+                "Auto-recovered partial-demo state via bundled seed fallback",
+              );
+            } else {
+              log.warn(
+                { requestId, orgId, total: recovered.total },
+                "Auto-recovery attempted but bundled seed yielded zero imports",
+              );
+            }
+          } catch (err) {
+            log.error(
+              { err: err instanceof Error ? err.message : String(err), requestId, orgId },
+              "Auto-recovery import threw — leaving caller with original empty result",
+            );
+          }
         }
       }
     }

--- a/packages/api/src/api/routes/onboarding-helpers.ts
+++ b/packages/api/src/api/routes/onboarding-helpers.ts
@@ -1,0 +1,57 @@
+/**
+ * Helpers shared between `/api/v1/onboarding/*` and the admin recovery
+ * surface in `admin.ts`. Anything that needs to know how to resolve the
+ * bundled canonical demo seed lives here so the two routes can't drift.
+ */
+
+import path from "path";
+import { existsSync } from "fs";
+import { getSemanticRoot } from "@atlas/api/lib/semantic/files";
+
+/** Reserved connection ID for the canonical demo workspace. */
+export const DEMO_CONNECTION_ID = "__demo__";
+
+/** Display label for the canonical NovaMart demo. */
+export const DEMO_LABEL = "NovaMart (E-commerce)";
+
+/** Canonical industry slug for the demo. */
+export const DEMO_INDUSTRY = "ecommerce";
+
+/**
+ * Resolve the canonical demo semantic-layer directory.
+ *
+ * Prefers the configured semantic root from `getSemanticRoot()` (the path the
+ * runtime mounts as `semantic/` — Docker images bundle the ecommerce layer
+ * here at build time; dev workspaces have the repo-root `semantic/` dir).
+ * Falls back to the bundled ecommerce seed under
+ * `packages/cli/data/seeds/ecommerce/semantic` for dev workspaces that
+ * haven't run `atlas init` yet.
+ *
+ * Throws if neither location exists — this is a deploy-time misconfiguration
+ * that should fail loudly rather than silently install a half-workspace.
+ */
+export function getDemoSemanticDir(): { dir: string; source: "semantic-root" | "bundled-seed" } {
+  const root = getSemanticRoot();
+  if (existsSync(path.join(root, "entities"))) {
+    return { dir: root, source: "semantic-root" };
+  }
+
+  // Dev fallback when the working directory hasn't been initialized yet
+  const seedsPath = path.resolve(
+    process.cwd(),
+    "packages",
+    "cli",
+    "data",
+    "seeds",
+    "ecommerce",
+    "semantic",
+  );
+  if (existsSync(path.join(seedsPath, "entities"))) {
+    return { dir: seedsPath, source: "bundled-seed" };
+  }
+
+  throw new Error(
+    `Canonical demo semantic layer not found. ` +
+      `Expected entities/ in ${root} or ${seedsPath}.`,
+  );
+}

--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -646,10 +646,11 @@ onboarding.openapi(
       // not expected to parse it. Hono caches the raw request body, so this
       // telemetry peek doesn't consume the stream the validated body
       // downstream relies on.
-      const rawBody = (yield* Effect.tryPromise({
-        try: () => c.req.json() as Promise<unknown>,
-        catch: () => null,
-      }).pipe(Effect.catchAll(() => Effect.succeed(null)))) as unknown;
+      // Telemetry-only peek; failures stay silent because the validated
+      // body downstream is the load-bearing read.
+      const rawBody = (yield* Effect.promise(() =>
+        c.req.json().catch(() => null) as Promise<unknown>,
+      )) as unknown;
       if (
         rawBody &&
         typeof rawBody === "object" &&
@@ -723,13 +724,15 @@ onboarding.openapi(
 
       // ---------------------------------------------------------------
       // Phase 2 — import entities FIRST. Orphan rows (entities whose
-      // `connection_id` matches a connection that doesn't yet exist for
-      // this org) are filtered out by `listEntitiesWithOverlay`'s
-      // archived-connection check, so a failure here leaves nothing
-      // visible to the user. On retry, `bulkUpsertEntities` upserts
-      // safely; once the connection commits in phase 3 the existing
-      // entity rows become visible. This is the inversion that makes
-      // /use-demo bulletproof.
+      // `connection_id` references a connection row that doesn't exist
+      // for this org, or whose connection isn't `published` / `draft`)
+      // are filtered out by `listEntitiesWithOverlay`'s connection-
+      // visibility join — so a failure between phase 2 and phase 3
+      // leaves nothing visible to the user. On retry,
+      // `bulkUpsertEntities` upserts on `(org_id, name, connection_id)`,
+      // so prior partial state is reabsorbed cleanly; once phase 3
+      // commits the connection, the existing entity rows become
+      // visible.
       // ---------------------------------------------------------------
       const importResult = yield* Effect.tryPromise({
         try: () => importFromDisk(orgId, { sourceDir: semanticDir, connectionId: DEMO_CONNECTION_ID }),

--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -26,65 +26,22 @@ import { activeKeyVersion } from "@atlas/api/lib/db/encryption-keys";
 import { maskConnectionUrl } from "@atlas/api/lib/security";
 import { _resetWhitelists } from "@atlas/api/lib/semantic";
 import { importFromDisk } from "@atlas/api/lib/semantic/sync";
-import { getSemanticRoot } from "@atlas/api/lib/semantic/files";
 import { setSetting } from "@atlas/api/lib/settings";
 import { ErrorSchema } from "./shared-schemas";
 import { standardAuth, requestContext, type AuthEnv } from "./middleware";
-import path from "path";
-import { existsSync } from "fs";
+import {
+  DEMO_CONNECTION_ID,
+  DEMO_INDUSTRY,
+  DEMO_LABEL,
+  getDemoSemanticDir,
+} from "./onboarding-helpers";
 
 const log = createLogger("onboarding");
 
-// ---------------------------------------------------------------------------
-// Canonical demo dataset (NovaMart e-commerce)
-//
 // Atlas ships a single canonical demo seed since 1.4.0 (#2021). Earlier
 // releases supported a `demoType` picker covering `demo` (SaaS CRM, 3 tables),
 // `cybersec` (Sentinel Security, 62 tables), and `ecommerce` (NovaMart, 52
 // tables). The body field is gone; the route always provisions ecommerce.
-// ---------------------------------------------------------------------------
-
-const DEMO_LABEL = "NovaMart (E-commerce)";
-const DEMO_INDUSTRY = "ecommerce";
-
-/** Reserved connection ID for demo workspaces. */
-const DEMO_CONNECTION_ID = "__demo__";
-
-/**
- * Resolve the canonical demo semantic-layer directory.
- *
- * Prefers the configured semantic root from `getSemanticRoot()` (the path the
- * runtime mounts as `semantic/` — Docker images bundle the ecommerce layer
- * here at build time; dev workspaces have the repo-root `semantic/` dir).
- * Falls back to the bundled ecommerce seed under
- * `packages/cli/data/seeds/ecommerce/semantic` for dev workspaces that
- * haven't run `atlas init` yet.
- */
-function getDemoSemanticDir(): { dir: string; source: "semantic-root" | "bundled-seed" } {
-  const root = getSemanticRoot();
-  if (existsSync(path.join(root, "entities"))) {
-    return { dir: root, source: "semantic-root" };
-  }
-
-  // Dev fallback when the working directory hasn't been initialized yet
-  const seedsPath = path.resolve(
-    process.cwd(),
-    "packages",
-    "cli",
-    "data",
-    "seeds",
-    "ecommerce",
-    "semantic",
-  );
-  if (existsSync(path.join(seedsPath, "entities"))) {
-    return { dir: seedsPath, source: "bundled-seed" };
-  }
-
-  throw new Error(
-    `Canonical demo semantic layer not found. ` +
-      `Expected entities/ in ${root} or ${seedsPath}.`,
-  );
-}
 
 /**
  * Seed org-scoped prompt collections matching the demo industry.
@@ -712,6 +669,16 @@ onboarding.openapi(
         );
       }
 
+      // ---------------------------------------------------------------
+      // Phase 1 — fail-fast pre-validation. Resolve and check everything
+      // we'll need before touching the DB so a misconfigured deploy 500s
+      // without leaving a half-installed workspace behind. The previous
+      // ordering committed the connection row before attempting the
+      // entity import; if the import then failed (or the bundled YAML
+      // wasn't on disk), the user ended up with a `__demo__` connection
+      // and zero `semantic_entities` — Schema Diff and the agent both
+      // saw a broken setup.
+      // ---------------------------------------------------------------
       const url = resolveDatasourceUrl();
       if (!url) {
         return c.json({ error: "no_demo_datasource", message: "No demo datasource configured. Set ATLAS_DATASOURCE_URL." }, 400);
@@ -727,7 +694,25 @@ onboarding.openapi(
         return c.json({ error: "invalid_datasource", message: "Demo datasource URL has an unsupported scheme.", requestId }, 500);
       }
 
-      // Encrypt and persist with status='published'
+      let semanticDir: string;
+      try {
+        const resolved = getDemoSemanticDir();
+        semanticDir = resolved.dir;
+        if (resolved.source === "bundled-seed") {
+          log.info(
+            { requestId, semanticDir },
+            "Demo semantic layer resolved via bundled-seed dev fallback (semantic/ not initialized at the configured root)",
+          );
+        }
+      } catch (err) {
+        log.error({ err: errorMessage(err), requestId }, "Canonical demo semantic layer not found");
+        return c.json({
+          error: "demo_not_available",
+          message: "The canonical demo semantic layer is not installed on this server. Contact the platform administrator.",
+          requestId,
+        }, 500);
+      }
+
       let encryptedUrl: string;
       try {
         encryptedUrl = encryptUrl(url);
@@ -736,6 +721,58 @@ onboarding.openapi(
         return c.json({ error: "encryption_failed", message: "Failed to encrypt connection URL.", requestId }, 500);
       }
 
+      // ---------------------------------------------------------------
+      // Phase 2 — import entities FIRST. Orphan rows (entities whose
+      // `connection_id` matches a connection that doesn't yet exist for
+      // this org) are filtered out by `listEntitiesWithOverlay`'s
+      // archived-connection check, so a failure here leaves nothing
+      // visible to the user. On retry, `bulkUpsertEntities` upserts
+      // safely; once the connection commits in phase 3 the existing
+      // entity rows become visible. This is the inversion that makes
+      // /use-demo bulletproof.
+      // ---------------------------------------------------------------
+      const importResult = yield* Effect.tryPromise({
+        try: () => importFromDisk(orgId, { sourceDir: semanticDir, connectionId: DEMO_CONNECTION_ID }),
+        catch: (err) => err instanceof Error ? err : new Error(String(err)),
+      }).pipe(Effect.catchAll((err) => {
+        log.error({ err: err.message, requestId, semanticDir }, "Demo semantic layer import failed");
+        return Effect.succeed(null);
+      }));
+
+      if (importResult === null) {
+        return c.json({
+          error: "import_failed",
+          message: "Failed to import the demo semantic layer. No partial state was committed — retry in a moment.",
+          requestId,
+        }, 500);
+      }
+      if (importResult.imported === 0 && importResult.total > 0) {
+        // Bundled YAML was scanned but every row failed the upsert. Treat
+        // as a hard failure — a connection without entities is the exact
+        // partial state we're trying to prevent.
+        log.error(
+          { orgId, requestId, total: importResult.total, errors: importResult.errors },
+          "Demo semantic import found entities but persisted zero",
+        );
+        return c.json({
+          error: "import_failed",
+          message: "Failed to import the demo semantic layer. Retry in a moment.",
+          requestId,
+        }, 500);
+      }
+
+      const entitiesImported = importResult.imported;
+      log.info(
+        { orgId, imported: importResult.imported, skipped: importResult.skipped, requestId },
+        "Imported demo semantic layer",
+      );
+
+      // ---------------------------------------------------------------
+      // Phase 3 — commit point. Once this row lands, the entities
+      // imported in phase 2 become visible to the agent and Schema Diff.
+      // Failure here leaves orphan entity rows (filtered out by
+      // visibility), so the user sees nothing partial — they can retry.
+      // ---------------------------------------------------------------
       const demoLabel = DEMO_LABEL;
       const urlKeyVersion = activeKeyVersion();
       const upsertResult = yield* Effect.tryPromise({
@@ -766,47 +803,6 @@ onboarding.openapi(
         connections.register(id, { url, description: `${demoLabel} — demo ${dbType} datasource` });
       } catch (err) {
         log.warn({ err: errorMessage(err), requestId }, "Demo connection saved but runtime registration failed");
-      }
-
-      // Resolve and import the canonical demo semantic layer
-      let semanticDir: string;
-      try {
-        const resolved = getDemoSemanticDir();
-        semanticDir = resolved.dir;
-        if (resolved.source === "bundled-seed") {
-          log.info(
-            { requestId, semanticDir },
-            "Demo semantic layer resolved via bundled-seed dev fallback (semantic/ not initialized at the configured root)",
-          );
-        }
-      } catch (err) {
-        log.error({ err: errorMessage(err), requestId }, "Canonical demo semantic layer not found");
-        return c.json({
-          error: "demo_not_available",
-          message: "The canonical demo semantic layer is not installed on this server. Contact the platform administrator.",
-          requestId,
-        }, 500);
-      }
-
-      const importResult = yield* Effect.tryPromise({
-        try: () => importFromDisk(orgId, { sourceDir: semanticDir, connectionId: DEMO_CONNECTION_ID }),
-        catch: (err) => err instanceof Error ? err : new Error(String(err)),
-      }).pipe(Effect.catchAll((err) => {
-        log.error({ err: err.message, requestId, semanticDir }, "Demo semantic layer import failed");
-        return Effect.succeed(null);
-      }));
-
-      if (importResult === null) {
-        return c.json({
-          error: "import_failed",
-          message: "Failed to import the demo semantic layer. The connection was saved but the workspace needs manual setup.",
-          requestId,
-        }, 500);
-      }
-
-      const entitiesImported = importResult.imported;
-      if (entitiesImported > 0) {
-        log.info({ orgId, imported: importResult.imported, skipped: importResult.skipped, requestId }, "Imported demo semantic layer");
       }
 
       // Write demo_industry setting + seed prompt collections concurrently (independent, non-fatal)


### PR DESCRIPTION
## Summary

- Reorders `/use-demo` so entity import runs before the connection write — orphan rows (filtered out by `listEntitiesWithOverlay`'s archived-connection clause) are invisible to users, so a failed import leaves no half-state. Connection commit is the final atomic step.
- Hard-fails when `bulkUpsertEntities` returns `imported: 0, total > 0` (the exact degenerate case dharma hit).
- Adds auto-recovery to `/admin/semantic/org/import`: when the org-scoped disk yields zero entities AND the org owns `__demo__`, the endpoint silently retries from the bundled NovaMart seed. One-click recovery via the existing "Import from disk" button.
- Adds explicit `source: "demo-seed"` body field for tooling / future recovery flows; audit `sourceRef` distinguishes `disk:all` vs `demo-seed` vs `demo-seed:auto-recover`.
- Extracts demo-seed resolver to `packages/api/src/api/routes/onboarding-helpers.ts` so `/use-demo` and the admin recovery path share one source of truth.

Fixes #2153.

## Test plan

- [x] `bun run test:api --affected` (87 files green)
- [x] `bun run lint` / `bun run type` clean
- [ ] Manual: dharma clicks "Import from disk" on `/admin/semantic` → 13 NovaMart entities populate `semantic_entities`
- [ ] Manual: Schema Diff for `__demo__` shows real diff (no longer "0 entities match")
- [ ] Manual: a fresh sign-up + NovaMart picks works end-to-end
- [ ] Manual: simulate a /use-demo failure mid-import → confirm no `__demo__` row in `connections` after the 500