### PR TITLE
fix(api,web): stop /admin/semantic from masking SaaS workspaces' empty DB (#2155)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -8832,13 +8832,24 @@
                     },
                     "entitiesImported": {
                       "type": "number"
+                    },
+                    "partialFailures": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "demo_industry_setting",
+                          "demo_prompt_collections"
+                        ]
+                      }
                     }
                   },
                   "required": [
                     "connectionId",
                     "dbType",
                     "maskedUrl",
-                    "entitiesImported"
+                    "entitiesImported",
+                    "partialFailures"
                   ]
                 }
               }
@@ -54173,6 +54184,31 @@
                 "schema": {
                   "type": "object",
                   "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Workspace doesn't own the requested source connection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
                 }
               }
             }

--- a/packages/api/src/api/__tests__/admin-password-semantic-import-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-password-semantic-import-audit.test.ts
@@ -420,11 +420,18 @@ describe("POST /api/v1/admin/semantic/org/import — audit emission (F-29)", () 
     expect(entry.metadata).toMatchObject({ sourceRef: "disk:all" });
   });
 
-  it("explicit source=demo-seed forces the bundled seed path", async () => {
+  it("explicit source=demo-seed forces the bundled seed path when org owns __demo__", async () => {
     let importedFromSeed = false;
     mockImportFromDisk.mockImplementation(async (_orgId: string, opts?: { connectionId?: string; sourceDir?: string }) => {
       if (opts?.sourceDir) importedFromSeed = true;
       return { imported: 13, skipped: 0, total: 13, errors: [] };
+    });
+    // Ownership check: caller must already have a __demo__ connection.
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (typeof sql === "string" && sql.includes("__demo__")) {
+        return [{ id: "__demo__" }];
+      }
+      return [];
     });
 
     const res = await app.fetch(
@@ -435,5 +442,27 @@ describe("POST /api/v1/admin/semantic/org/import — audit emission (F-29)", () 
     expect(importedFromSeed).toBe(true);
     const entry = lastAuditCall();
     expect(entry.metadata).toMatchObject({ sourceRef: "demo-seed" });
+  });
+
+  it("explicit source=demo-seed is REJECTED when org doesn't own __demo__", async () => {
+    // Ownership safety: a stale URL or programmatic caller can't write
+    // NovaMart entities into a workspace that was never demo-provisioned.
+    mocks.mockInternalQuery.mockResolvedValue([]); // org has no __demo__
+    let importCalls = 0;
+    mockImportFromDisk.mockImplementation(async () => {
+      importCalls++;
+      return { imported: 0, skipped: 0, total: 0, errors: [] };
+    });
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/semantic/org/import", { source: "demo-seed" }),
+    );
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("demo_not_owned");
+    // Critical: no import ran, no audit row, no DB writes attempted.
+    expect(importCalls).toBe(0);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/api/__tests__/onboarding.test.ts
+++ b/packages/api/src/api/__tests__/onboarding.test.ts
@@ -1203,10 +1203,49 @@ describe("POST /api/v1/onboarding/use-demo", () => {
     expect(res.status).toBe(201);
     const data = await json(res);
     expect(data.connectionId).toBe("__demo__");
-    // Phase-4 failures (settings, prompt seeding) used to be silent. Now the
-    // 201 carries a `partialFailures` array so the frontend can render a
-    // degraded-state warning instead of pretending all features work.
+    // Phase-4 failures used to be silent. Now the 201 carries a stable
+    // `partialFailures` array so the frontend can render a degraded-state
+    // warning. The shape is always-array (never optional) and the enum
+    // boundary is enforced — only known phase-4 step names appear.
+    expect(Array.isArray(data.partialFailures)).toBe(true);
     expect(data.partialFailures).toContain("demo_industry_setting");
+    expect(data.partialFailures).not.toContain("demo_prompt_collections");
+  });
+
+  it("partialFailures is always an empty array when both phase-4 decorations succeed", async () => {
+    // Pinning the always-emit shape: a frontend that does
+    // `result.partialFailures.includes(...)` shouldn't have to optional-
+    // chain on success. Empty array > missing key.
+    mockSetSetting.mockImplementation(async () => { /* succeed */ });
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(201);
+    const data = await json(res);
+    expect(data.partialFailures).toEqual([]);
+  });
+
+  it("partialFailures lists BOTH steps when both phase-4 decorations fail", async () => {
+    mockSetSetting.mockImplementation(async () => { throw new Error("settings down"); });
+    const originalImpl = mockInternalQuery.getMockImplementation();
+    mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (typeof sql === "string" && sql.includes("is_builtin = true")) {
+        throw new Error("prompt collections table missing");
+      }
+      return [{ id: "__demo__" }];
+    });
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(201);
+    const data = await json(res);
+    expect(data.partialFailures).toContain("demo_industry_setting");
+    expect(data.partialFailures).toContain("demo_prompt_collections");
+    if (originalImpl) mockInternalQuery.mockImplementation(originalImpl);
   });
 
   it("succeeds even when prompt collection seeding fails (non-fatal)", async () => {

--- a/packages/api/src/api/__tests__/onboarding.test.ts
+++ b/packages/api/src/api/__tests__/onboarding.test.ts
@@ -1032,6 +1032,45 @@ describe("POST /api/v1/onboarding/use-demo", () => {
     mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5 }));
   });
 
+  it("ATOMICITY: bundled YAML scan returning zero entities fails before writing connection (dharma-class)", async () => {
+    // The actual cause of dharma's state: pre-#2154 the bundled YAML was
+    // missing on the API image, so `importFromDisk` returned
+    // `{ imported: 0, total: 0 }` (scan found nothing). The old code only
+    // failed on `total > 0`, so it silently absorbed the no-op, set
+    // ATLAS_DEMO_INDUSTRY, and committed the __demo__ connection. dharma
+    // got a half-installed workspace with `connection but no entities` —
+    // exactly the state Schema Diff exposed today.
+    //
+    // The fix: any scan returning `total === 0` is a deploy-time
+    // misconfiguration (the bundled seed isn't on the server) and must
+    // fail loudly with `demo_not_available` so no connection commits and
+    // the user sees a clear error instead of a silent half-success.
+    mockImportFromDisk.mockImplementation(async () => ({
+      imported: 0,
+      skipped: 0,
+      errors: [],
+      total: 0,
+    }));
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(500);
+    const data = await json(res);
+    expect(data.error).toBe("demo_not_available");
+
+    const connectionInsert = mockInternalQuery.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("INSERT INTO connections"),
+    );
+    expect(connectionInsert).toBeUndefined();
+
+    // Settings/prompt seeding must NOT have run either — those are
+    // post-commit decorations and shouldn't fire on a failed install.
+    expect(mockSetSetting).not.toHaveBeenCalled();
+    mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5 }));
+  });
+
   it("ATOMICITY: missing bundled YAML fails before writing connection", async () => {
     // getDemoSemanticDir() throws when neither the configured root nor the
     // bundled-seed dir has an entities/ subdir. The pre-validation phase
@@ -1154,7 +1193,7 @@ describe("POST /api/v1/onboarding/use-demo", () => {
     mockEncryptUrl.mockImplementation((url: string) => `encrypted:${url}`);
   });
 
-  it("succeeds even when setSetting fails (non-fatal)", async () => {
+  it("succeeds even when setSetting fails — but surfaces partialFailures", async () => {
     mockSetSetting.mockImplementation(async () => { throw new Error("settings db down"); });
     const res = await request("/api/v1/onboarding/use-demo", {
       method: "POST",
@@ -1164,6 +1203,10 @@ describe("POST /api/v1/onboarding/use-demo", () => {
     expect(res.status).toBe(201);
     const data = await json(res);
     expect(data.connectionId).toBe("__demo__");
+    // Phase-4 failures (settings, prompt seeding) used to be silent. Now the
+    // 201 carries a `partialFailures` array so the frontend can render a
+    // degraded-state warning instead of pretending all features work.
+    expect(data.partialFailures).toContain("demo_industry_setting");
   });
 
   it("succeeds even when prompt collection seeding fails (non-fatal)", async () => {

--- a/packages/api/src/api/routes/__tests__/admin-semantic-improve.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-semantic-improve.test.ts
@@ -162,4 +162,72 @@ describe("admin-semantic-improve", () => {
       expect(body.error).toBe("invalid_id");
     });
   });
+
+  describe("GET /health — DB vs disk source selection", () => {
+    // Pin the load-bearing branch: when there's an org context + internal
+    // DB the endpoint must read from `loadEntitiesFromDB`. A refactor that
+    // flips back to disk would silently restore the conflation that made
+    // empty-DB SaaS workspaces show "13 entities, 100% coverage".
+    let dbCalls = 0;
+    let diskCalls = 0;
+    beforeEach(() => {
+      dbCalls = 0;
+      diskCalls = 0;
+      mock.module("@atlas/api/lib/semantic/expert/context-loader", () => ({
+        loadEntitiesFromDB: async () => {
+          dbCalls++;
+          return { entities: [], totalRows: 0, parseFailures: 0 };
+        },
+        loadEntitiesFromDisk: async () => {
+          diskCalls++;
+          return [];
+        },
+        loadGlossaryFromDisk: async () => [],
+      }));
+      mock.module("@atlas/api/lib/semantic/expert/health", () => ({
+        computeSemanticHealth: () => ({
+          overall: 0,
+          coverage: 0,
+          descriptionQuality: 0,
+          measureCoverage: 0,
+          joinCoverage: 0,
+          entityCount: 0,
+          dimensionCount: 0,
+          measureCount: 0,
+          glossaryTermCount: 0,
+        }),
+      }));
+    });
+
+    it("prefers loadEntitiesFromDB when org context + internal DB present", async () => {
+      mockHasInternalDB = true;
+      const res = await adminSemanticImprove.request("/health");
+      expect(res.status).toBe(200);
+      expect(dbCalls).toBe(1);
+      expect(diskCalls).toBe(0);
+    });
+
+    // Note: the disk-fallback branch (`!orgId || !hasInternalDB()`) requires
+    // routing past requireOrgContext which itself depends on the internal
+    // DB — exercising that path needs deeper middleware mocking than this
+    // suite carries. The branch is small enough that the type system + the
+    // single conditional in admin-semantic-improve.ts:923 keeps it honest;
+    // the load-bearing assertion is "DB wins when both are present", above.
+
+    it("response includes a status discriminator distinguishing empty from corrupt", async () => {
+      mockHasInternalDB = true;
+      // Override loader to return totalRows=2, parseFailures=2 (full corruption)
+      mock.module("@atlas/api/lib/semantic/expert/context-loader", () => ({
+        loadEntitiesFromDB: async () => ({ entities: [], totalRows: 2, parseFailures: 2 }),
+        loadEntitiesFromDisk: async () => [],
+        loadGlossaryFromDisk: async () => [],
+      }));
+      const res = await adminSemanticImprove.request("/health");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { status: string; parseFailures: number; totalRows: number };
+      expect(body.status).toBe("corrupt");
+      expect(body.parseFailures).toBe(2);
+      expect(body.totalRows).toBe(2);
+    });
+  });
 });

--- a/packages/api/src/api/routes/admin-semantic-improve.ts
+++ b/packages/api/src/api/routes/admin-semantic-improve.ts
@@ -908,11 +908,20 @@ adminSemanticImprove.openapi(reviewAmendmentRoute, async (c) =>
 // GET /health — let runHandler handle errors (no manual try/catch)
 adminSemanticImprove.openapi(healthScoreRoute, async (c) =>
   runHandler(c, "semantic-health-score", async () => {
-    const { loadEntitiesFromDisk, loadGlossaryFromDisk } =
+    const { orgId } = c.get("orgContext");
+    const { loadEntitiesFromDB, loadEntitiesFromDisk, loadGlossaryFromDisk } =
       await import("@atlas/api/lib/semantic/expert/context-loader");
+    const { hasInternalDB } = await import("@atlas/api/lib/db/internal");
     const { computeSemanticHealth } = await import("@atlas/api/lib/semantic/expert/health");
 
-    const entities = await loadEntitiesFromDisk();
+    // Prefer DB-backed entities when we have an org context. Disk-only is
+    // for self-hosted with no internal DB. The conflation pre-#2155 had this
+    // endpoint reading bundled YAML for every workspace, so SaaS orgs with
+    // empty `semantic_entities` showed "13 entities, 100% coverage" — the
+    // misleading score that hid dharma's broken state from operators.
+    const entities = orgId && hasInternalDB()
+      ? await loadEntitiesFromDB(orgId, "published")
+      : await loadEntitiesFromDisk();
     const glossary = await loadGlossaryFromDisk();
 
     const score = computeSemanticHealth({

--- a/packages/api/src/api/routes/admin-semantic-improve.ts
+++ b/packages/api/src/api/routes/admin-semantic-improve.ts
@@ -914,14 +914,22 @@ adminSemanticImprove.openapi(healthScoreRoute, async (c) =>
     const { hasInternalDB } = await import("@atlas/api/lib/db/internal");
     const { computeSemanticHealth } = await import("@atlas/api/lib/semantic/expert/health");
 
-    // Prefer DB-backed entities when we have an org context. Disk-only is
-    // for self-hosted with no internal DB. The conflation pre-#2155 had this
-    // endpoint reading bundled YAML for every workspace, so SaaS orgs with
-    // empty `semantic_entities` showed "13 entities, 100% coverage" — the
-    // misleading score that hid dharma's broken state from operators.
-    const entities = orgId && hasInternalDB()
-      ? await loadEntitiesFromDB(orgId, "published")
-      : await loadEntitiesFromDisk();
+    // Prefer DB-backed entities when we have an org context + internal DB.
+    // Reading bundled YAML for every workspace would show "13 entities,
+    // 100% coverage" for orgs whose `semantic_entities` is empty — a
+    // misleading score that hides broken workspaces from operators.
+    let entities: Awaited<ReturnType<typeof loadEntitiesFromDisk>>;
+    let parseFailures = 0;
+    let totalRows: number;
+    if (orgId && hasInternalDB()) {
+      const dbResult = await loadEntitiesFromDB(orgId, "published");
+      entities = dbResult.entities;
+      parseFailures = dbResult.parseFailures;
+      totalRows = dbResult.totalRows;
+    } else {
+      entities = await loadEntitiesFromDisk();
+      totalRows = entities.length;
+    }
     const glossary = await loadGlossaryFromDisk();
 
     const score = computeSemanticHealth({
@@ -932,6 +940,16 @@ adminSemanticImprove.openapi(healthScoreRoute, async (c) =>
       rejectedKeys: new Set(),
     });
 
-    return c.json(score, 200);
+    // Surface a status discriminator so the widget can distinguish the
+    // empty case (`no_entities`) from the corruption case (`corrupt` —
+    // every entity row failed parse) instead of conflating both with a
+    // 0% score that gives no actionable signal.
+    const status = parseFailures > 0 && parseFailures === totalRows && totalRows > 0
+      ? ("corrupt" as const)
+      : totalRows === 0
+        ? ("no_entities" as const)
+        : ("ok" as const);
+
+    return c.json({ ...score, status, parseFailures, totalRows }, 200);
   }),
 );

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -868,6 +868,7 @@ const importOrgEntitiesRoute = createRoute({
     400: { description: "Invalid request", content: { "application/json": { schema: ErrorSchema } } },
     401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
     403: { description: "Forbidden — admin role required", content: { "application/json": { schema: AuthErrorSchema } } },
+    409: { description: "Workspace doesn't own the requested source connection", content: { "application/json": { schema: ErrorSchema } } },
     429: { description: "Rate limit exceeded", content: { "application/json": { schema: AuthErrorSchema } } },
     500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
     501: { description: "Internal database not available", content: { "application/json": { schema: ErrorSchema } } },
@@ -1653,6 +1654,24 @@ admin.openapi(importOrgEntitiesRoute, async (c) => runHandler(c, "import org sem
   let result: Awaited<ReturnType<typeof importFromDisk>>;
   let resolvedSource: string;
   if (body.source === "demo-seed") {
+    // Caller must already own a `__demo__` connection — otherwise a stale
+    // URL or programmatic caller could write NovaMart entities into an
+    // unrelated workspace under a phantom connection id.
+    const ownsDemo = await internalQuery<{ id: string }>(
+      `SELECT id FROM connections WHERE org_id = $1 AND id = '__demo__' AND status IN ('published', 'draft')`,
+      [orgId],
+    ).then((rows) => rows.length > 0).catch((err) => {
+      log.warn({ err: err instanceof Error ? err.message : String(err), requestId, orgId }, "Demo-ownership probe failed during recovery");
+      return false;
+    });
+    if (!ownsDemo) {
+      return c.json({
+        error: "demo_not_owned",
+        message: "This workspace does not own a __demo__ connection. Re-run onboarding to provision the canonical demo first.",
+        requestId,
+      }, 409);
+    }
+
     const { getDemoSemanticDir } = await import("./onboarding-helpers");
     let semanticDir: string;
     try {

--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -279,11 +279,11 @@ const UseDemoResponseSchema = z.object({
   entitiesImported: z.number(),
   /**
    * Names of post-commit decoration steps that failed (industry setting,
-   * prompt collection seed). The workspace is queryable, but features
-   * keyed off these may be degraded — the frontend shows a degraded-state
-   * banner so users aren't silently in a half-installed state.
+   * prompt collection seed). Always present as an array — empty when the
+   * full install succeeded — so consumers can call `.includes()` or
+   * `.length` without optional-chaining gymnastics.
    */
-  partialFailures: z.array(z.enum(["demo_industry_setting", "demo_prompt_collections"])).optional(),
+  partialFailures: z.array(z.enum(["demo_industry_setting", "demo_prompt_collections"])),
 });
 
 // Strict-but-empty: validation parses to {} and silently strips unknown keys
@@ -757,14 +757,13 @@ onboarding.openapi(
         }, 500);
       }
       if (importResult.total === 0) {
-        // Scan returned zero candidates — the bundled NovaMart YAML isn't
-        // on the API container even though `getDemoSemanticDir()` resolved
-        // a path (e.g., the directory exists but is empty). This is a
-        // deploy-time misconfiguration, not user error. Failing here is
-        // what would have stopped dharma's class of incident: pre-#2154
-        // /use-demo silently absorbed `total === 0`, set
-        // `ATLAS_DEMO_INDUSTRY`, committed the connection, and left the
-        // workspace with no queryable semantic layer.
+        // Scan returned zero candidates — the bundled YAML isn't on the
+        // API container even though `getDemoSemanticDir()` resolved a path
+        // (e.g., the directory exists but is empty). This is a deploy-time
+        // misconfiguration, not user error. Older /use-demo absorbed this
+        // case silently: it set `ATLAS_DEMO_INDUSTRY`, committed the
+        // connection, and 201'd a workspace with no queryable semantic
+        // layer. Fail loudly so the install is all-or-nothing.
         log.error(
           { orgId, requestId, semanticDir },
           "Demo semantic import scan returned zero entities — bundled YAML missing on this server",
@@ -877,7 +876,7 @@ onboarding.openapi(
         dbType,
         maskedUrl: maskConnectionUrl(url),
         entitiesImported,
-        ...(partialFailures.length > 0 ? { partialFailures } : {}),
+        partialFailures,
       }, 201);
     }), { label: "use demo data" });
   },

--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -277,6 +277,13 @@ const UseDemoResponseSchema = z.object({
   dbType: z.string(),
   maskedUrl: z.string(),
   entitiesImported: z.number(),
+  /**
+   * Names of post-commit decoration steps that failed (industry setting,
+   * prompt collection seed). The workspace is queryable, but features
+   * keyed off these may be degraded — the frontend shows a degraded-state
+   * banner so users aren't silently in a half-installed state.
+   */
+  partialFailures: z.array(z.enum(["demo_industry_setting", "demo_prompt_collections"])).optional(),
 });
 
 // Strict-but-empty: validation parses to {} and silently strips unknown keys
@@ -749,9 +756,28 @@ onboarding.openapi(
           requestId,
         }, 500);
       }
-      if (importResult.imported === 0 && importResult.total > 0) {
-        // Bundled YAML was scanned but every row failed the upsert. Treat
-        // as a hard failure — a connection without entities is the exact
+      if (importResult.total === 0) {
+        // Scan returned zero candidates — the bundled NovaMart YAML isn't
+        // on the API container even though `getDemoSemanticDir()` resolved
+        // a path (e.g., the directory exists but is empty). This is a
+        // deploy-time misconfiguration, not user error. Failing here is
+        // what would have stopped dharma's class of incident: pre-#2154
+        // /use-demo silently absorbed `total === 0`, set
+        // `ATLAS_DEMO_INDUSTRY`, committed the connection, and left the
+        // workspace with no queryable semantic layer.
+        log.error(
+          { orgId, requestId, semanticDir },
+          "Demo semantic import scan returned zero entities — bundled YAML missing on this server",
+        );
+        return c.json({
+          error: "demo_not_available",
+          message: "The canonical demo semantic layer is missing on this server. Contact the platform administrator.",
+          requestId,
+        }, 500);
+      }
+      if (importResult.imported === 0) {
+        // Scan found entities but every row failed the upsert. Treat as
+        // a hard failure — a connection without entities is the exact
         // partial state we're trying to prevent.
         log.error(
           { orgId, requestId, total: importResult.total, errors: importResult.errors },
@@ -808,33 +834,50 @@ onboarding.openapi(
         log.warn({ err: errorMessage(err), requestId }, "Demo connection saved but runtime registration failed");
       }
 
-      // Write demo_industry setting + seed prompt collections concurrently (independent, non-fatal)
-      yield* Effect.all([
+      // Write demo_industry setting + seed prompt collections concurrently.
+      // Both are independent post-commit decorations — failure leaves the
+      // workspace queryable but with reduced features (no demoIndustry-aware
+      // banners, no pre-seeded prompts). We surface that through a
+      // `partialFailures` array on the 201 response so the frontend can show
+      // a degraded-state notice instead of pretending everything worked.
+      const phase4Results = yield* Effect.all([
         Effect.tryPromise({
           try: () => setSetting("ATLAS_DEMO_INDUSTRY", industry, user?.id, orgId),
           catch: (err) => err instanceof Error ? err : new Error(String(err)),
-        }).pipe(Effect.catchAll((err) => {
-          log.warn({ err: err.message, requestId, orgId, industry }, "Failed to write demo_industry setting — non-fatal");
-          return Effect.void;
-        })),
+        }).pipe(
+          Effect.map(() => ({ ok: true as const, step: "demo_industry_setting" as const })),
+          Effect.catchAll((err) => {
+            log.warn({ err: err.message, requestId, orgId, industry }, "Failed to write demo_industry setting — non-fatal");
+            return Effect.succeed({ ok: false as const, step: "demo_industry_setting" as const });
+          }),
+        ),
         Effect.tryPromise({
           try: () => seedDemoPromptCollections(orgId, industry),
           catch: (err) => err instanceof Error ? err : new Error(String(err)),
-        }).pipe(Effect.catchAll((err) => {
-          log.warn({ err: err.message, requestId, orgId, industry }, "Failed to seed demo prompt collections — non-fatal");
-          return Effect.void;
-        })),
+        }).pipe(
+          Effect.map(() => ({ ok: true as const, step: "demo_prompt_collections" as const })),
+          Effect.catchAll((err) => {
+            log.warn({ err: err.message, requestId, orgId, industry }, "Failed to seed demo prompt collections — non-fatal");
+            return Effect.succeed({ ok: false as const, step: "demo_prompt_collections" as const });
+          }),
+        ),
       ], { concurrency: "unbounded" });
+
+      const partialFailures = phase4Results.filter((r) => !r.ok).map((r) => r.step);
 
       _resetWhitelists();
 
-      log.info({ requestId, orgId, dbType, userId: user?.id, entitiesImported, industry }, "Demo onboarding complete");
+      log.info(
+        { requestId, orgId, dbType, userId: user?.id, entitiesImported, industry, partialFailures },
+        "Demo onboarding complete",
+      );
 
       return c.json({
         connectionId: id,
         dbType,
         maskedUrl: maskConnectionUrl(url),
         entitiesImported,
+        ...(partialFailures.length > 0 ? { partialFailures } : {}),
       }, 201);
     }), { label: "use demo data" });
   },

--- a/packages/api/src/lib/__tests__/diff-whitelist-scoping.test.ts
+++ b/packages/api/src/lib/__tests__/diff-whitelist-scoping.test.ts
@@ -486,28 +486,41 @@ describe("runDiff — org+mode scoping (#1431)", () => {
     expect(omitted.summary).toBeDefined();
   });
 
-  it("whitelist cache expires after TTL — out-of-band entity changes propagate without an API restart", async () => {
+  it("whitelist cache expires after TTL — wall-clock advance triggers re-query", async () => {
     // Without a TTL, the whitelist cache held forever (only entity CRUD
     // invalidated it). Manual SQL or external recovery scripts left the
-    // API serving stale "no entities" until restart. Cache entries now
-    // expire after _ORG_WHITELIST_TTL_MS so eventual consistency wins.
+    // API serving stale "no entities" until restart. The TTL must be
+    // wall-clock driven — pinning that here with a Date.now mock so the
+    // test fails if the TTL is ever set to Infinity or removed.
     const { _resetOrgWhitelists, loadOrgWhitelist } = await import("../semantic/whitelist");
     _resetOrgWhitelists();
-    entityRows = []; // first load: empty
-    await loadOrgWhitelist("ttl-org", "published");
-    // Add rows out-of-band, simulating a recovery SQL insert.
-    entityRows = [
-      { name: "users", table: "users", status: "published", org_id: "ttl-org", connection_id: "__demo__" },
-    ];
-    // Within TTL: still returns cached empty.
-    const cached = await loadOrgWhitelist("ttl-org", "published");
-    expect(cached.size).toBe(0);
-    // Force expiry by re-reading the module-level cache via the reset hook
-    // and re-loading — TTL behavior end-to-end is exercised; bypassing
-    // wall-clock time is left as an integration concern.
-    _resetOrgWhitelists();
-    const fresh = await loadOrgWhitelist("ttl-org", "published");
-    expect(fresh.get("__demo__")?.has("users")).toBe(true);
+
+    const realNow = Date.now;
+    let nowMs = 1_000_000;
+    Date.now = () => nowMs;
+
+    try {
+      entityRows = []; // first load: empty
+      const first = await loadOrgWhitelist("ttl-org", "published");
+      expect(first.size).toBe(0);
+
+      // Add rows out-of-band, simulating a recovery SQL insert.
+      entityRows = [
+        { name: "users", table: "users", status: "published", org_id: "ttl-org", connection_id: "__demo__" },
+      ];
+
+      // Within TTL window (advance < 60s): cache hit, still empty.
+      nowMs += 30_000;
+      const cached = await loadOrgWhitelist("ttl-org", "published");
+      expect(cached.size).toBe(0);
+
+      // Cross the TTL boundary: cache evicts, re-queries, sees the new row.
+      nowMs += 31_000;
+      const fresh = await loadOrgWhitelist("ttl-org", "published");
+      expect(fresh.get("__demo__")?.has("users")).toBe(true);
+    } finally {
+      Date.now = realNow;
+    }
   });
 
   it("falls back to disk YAML when the org has zero DB entries for the connection", async () => {

--- a/packages/api/src/lib/__tests__/diff-whitelist-scoping.test.ts
+++ b/packages/api/src/lib/__tests__/diff-whitelist-scoping.test.ts
@@ -486,6 +486,30 @@ describe("runDiff — org+mode scoping (#1431)", () => {
     expect(omitted.summary).toBeDefined();
   });
 
+  it("whitelist cache expires after TTL — out-of-band entity changes propagate without an API restart", async () => {
+    // Without a TTL, the whitelist cache held forever (only entity CRUD
+    // invalidated it). Manual SQL or external recovery scripts left the
+    // API serving stale "no entities" until restart. Cache entries now
+    // expire after _ORG_WHITELIST_TTL_MS so eventual consistency wins.
+    const { _resetOrgWhitelists, loadOrgWhitelist } = await import("../semantic/whitelist");
+    _resetOrgWhitelists();
+    entityRows = []; // first load: empty
+    await loadOrgWhitelist("ttl-org", "published");
+    // Add rows out-of-band, simulating a recovery SQL insert.
+    entityRows = [
+      { name: "users", table: "users", status: "published", org_id: "ttl-org", connection_id: "__demo__" },
+    ];
+    // Within TTL: still returns cached empty.
+    const cached = await loadOrgWhitelist("ttl-org", "published");
+    expect(cached.size).toBe(0);
+    // Force expiry by re-reading the module-level cache via the reset hook
+    // and re-loading — TTL behavior end-to-end is exercised; bypassing
+    // wall-clock time is left as an integration concern.
+    _resetOrgWhitelists();
+    const fresh = await loadOrgWhitelist("ttl-org", "published");
+    expect(fresh.get("__demo__")?.has("users")).toBe(true);
+  });
+
   it("falls back to disk YAML when the org has zero DB entries for the connection", async () => {
     // Self-hosted-with-internal-DB-and-disk-edited YAML: an admin hand-edits
     // `semantic/entities/*.yml` without importing to the DB. The DB loader

--- a/packages/api/src/lib/semantic/expert/context-loader.ts
+++ b/packages/api/src/lib/semantic/expert/context-loader.ts
@@ -22,6 +22,53 @@ function getSemanticRoot(): string {
 }
 
 /**
+ * Load entities for an org from the internal DB.
+ *
+ * Preferred for SaaS surfaces (e.g. the Health widget on /admin/semantic).
+ * The disk loader returns the bundled NovaMart YAML on every API container,
+ * which on SaaS shows up as "13 entities, 100% coverage" even for orgs that
+ * have nothing in `semantic_entities` — the exact conflation that masked the
+ * dharma incident. Reading from the DB returns the org's actual queryable
+ * semantic layer.
+ */
+export async function loadEntitiesFromDB(
+  orgId: string,
+  mode?: "published" | "developer",
+): Promise<ParsedEntity[]> {
+  const { hasInternalDB } = await import("@atlas/api/lib/db/internal");
+  if (!hasInternalDB()) return [];
+
+  const { listEntities, listEntitiesWithOverlay } = await import("@atlas/api/lib/semantic/entities");
+  const rows = mode === "developer"
+    ? await listEntitiesWithOverlay(orgId, "entity")
+    : await listEntities(orgId, "entity", "published");
+
+  const entities: ParsedEntity[] = [];
+  for (const row of rows) {
+    try {
+      const parsed = yaml.load(row.yaml_content) as Record<string, unknown> | null;
+      if (!parsed || typeof parsed !== "object") continue;
+      entities.push({
+        name: String(parsed.table ?? row.name),
+        table: String(parsed.table ?? row.name),
+        description: typeof parsed.description === "string" ? parsed.description : undefined,
+        dimensions: Array.isArray(parsed.dimensions) ? parsed.dimensions as ParsedEntity["dimensions"] : [],
+        measures: Array.isArray(parsed.measures) ? parsed.measures as ParsedEntity["measures"] : [],
+        joins: Array.isArray(parsed.joins) ? parsed.joins as ParsedEntity["joins"] : [],
+        query_patterns: Array.isArray(parsed.query_patterns) ? parsed.query_patterns as ParsedEntity["query_patterns"] : [],
+        connection: typeof parsed.connection === "string" ? parsed.connection : (row.connection_id ?? undefined),
+      });
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err), entity: row.name, orgId },
+        "Failed to parse entity YAML from DB",
+      );
+    }
+  }
+  return entities;
+}
+
+/**
  * Load all entity YAML files from disk.
  */
 export async function loadEntitiesFromDisk(): Promise<ParsedEntity[]> {

--- a/packages/api/src/lib/semantic/expert/context-loader.ts
+++ b/packages/api/src/lib/semantic/expert/context-loader.ts
@@ -21,22 +21,39 @@ function getSemanticRoot(): string {
   return process.env.ATLAS_SEMANTIC_ROOT ?? path.resolve(process.cwd(), "semantic");
 }
 
+/** Outcome of {@link loadEntitiesFromDB} — a discriminator so callers can tell
+ * "no entities" from "every entity row failed to parse" (the latter signals
+ * data corruption and should drive a different UI signal than "0% coverage"). */
+export interface LoadEntitiesFromDBResult {
+  entities: ParsedEntity[];
+  totalRows: number;
+  parseFailures: number;
+}
+
 /**
  * Load entities for an org from the internal DB.
  *
- * Preferred for SaaS surfaces (e.g. the Health widget on /admin/semantic).
- * The disk loader returns the bundled NovaMart YAML on every API container,
- * which on SaaS shows up as "13 entities, 100% coverage" even for orgs that
- * have nothing in `semantic_entities` — the exact conflation that masked the
- * dharma incident. Reading from the DB returns the org's actual queryable
- * semantic layer.
+ * Preferred whenever the caller has both an org context and an internal DB
+ * (SaaS, or self-hosted with `DATABASE_URL` set). The disk loader returns the
+ * bundled YAML present on every API container, which would otherwise make
+ * empty-DB workspaces look fully populated.
+ *
+ * Returns a discriminated result so callers can distinguish:
+ *   - `totalRows === 0` — org has no entity rows (legitimate empty state)
+ *   - `parseFailures === totalRows && totalRows > 0` — every row failed YAML
+ *     parse; the workspace is corrupt, not empty
+ *   - `parseFailures > 0` — partial corruption; surface warning
+ *
+ * Without this discriminator the Health widget shows "0% coverage" for both
+ * "no entities" and "all entities corrupt" — two states that need different
+ * operator actions.
  */
 export async function loadEntitiesFromDB(
   orgId: string,
   mode?: "published" | "developer",
-): Promise<ParsedEntity[]> {
+): Promise<LoadEntitiesFromDBResult> {
   const { hasInternalDB } = await import("@atlas/api/lib/db/internal");
-  if (!hasInternalDB()) return [];
+  if (!hasInternalDB()) return { entities: [], totalRows: 0, parseFailures: 0 };
 
   const { listEntities, listEntitiesWithOverlay } = await import("@atlas/api/lib/semantic/entities");
   const rows = mode === "developer"
@@ -44,10 +61,14 @@ export async function loadEntitiesFromDB(
     : await listEntities(orgId, "entity", "published");
 
   const entities: ParsedEntity[] = [];
+  let parseFailures = 0;
   for (const row of rows) {
     try {
       const parsed = yaml.load(row.yaml_content) as Record<string, unknown> | null;
-      if (!parsed || typeof parsed !== "object") continue;
+      if (!parsed || typeof parsed !== "object") {
+        parseFailures++;
+        continue;
+      }
       entities.push({
         name: String(parsed.table ?? row.name),
         table: String(parsed.table ?? row.name),
@@ -59,13 +80,22 @@ export async function loadEntitiesFromDB(
         connection: typeof parsed.connection === "string" ? parsed.connection : (row.connection_id ?? undefined),
       });
     } catch (err) {
+      parseFailures++;
       log.warn(
         { err: err instanceof Error ? err.message : String(err), entity: row.name, orgId },
         "Failed to parse entity YAML from DB",
       );
     }
   }
-  return entities;
+
+  if (parseFailures > 0 && parseFailures === rows.length) {
+    log.error(
+      { orgId, totalRows: rows.length, parseFailures },
+      "All org entity rows failed YAML parse — semantic layer is corrupt",
+    );
+  }
+
+  return { entities, totalRows: rows.length, parseFailures };
 }
 
 /**

--- a/packages/api/src/lib/semantic/whitelist.ts
+++ b/packages/api/src/lib/semantic/whitelist.ts
@@ -385,16 +385,31 @@ export function _resetPluginEntities(): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Per-org whitelist cache: Map<cacheKey, Map<connectionId, Set<tableName>>>.
+ * Per-org whitelist cache: Map<cacheKey, { tables, expiresAt }>.
  * Each mode gets a distinct cache key so the three result shapes (published
  * filter, developer overlay, no-mode legacy) can never be confused:
  *   - `${orgId}:published` — status = 'published'
  *   - `${orgId}:developer` — CTE overlay
  *   - `${orgId}` — legacy path, no mode supplied (all rows incl. tombstones)
- * Populated by `loadOrgWhitelist()` before the agent loop starts.
- * Invalidated by `invalidateOrgWhitelist(orgId)` on entity CRUD (clears all modes).
+ *
+ * Cache entries expire after `_ORG_WHITELIST_TTL_MS`. Without a TTL,
+ * out-of-band changes (manual SQL, cross-region replication, recovery
+ * scripts) leave the API serving stale data forever — entity CRUD
+ * invalidates only when it goes through our handlers. The TTL makes the
+ * cache eventually consistent with the DB.
  */
-const _orgWhitelists = new Map<string, Map<string, Set<string>>>();
+interface CachedWhitelist {
+  tables: Map<string, Set<string>>;
+  expiresAt: number;
+}
+const _orgWhitelists = new Map<string, CachedWhitelist>();
+
+const _ORG_WHITELIST_TTL_MS = (() => {
+  const raw = process.env.ATLAS_ORG_WHITELIST_TTL_MS;
+  if (!raw) return 60_000; // 60s default
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : 60_000;
+})();
 
 function whitelistCacheKey(orgId: string, mode?: "published" | "developer"): string {
   if (mode === "published") return `${orgId}:published`;
@@ -419,7 +434,12 @@ function whitelistCacheKey(orgId: string, mode?: "published" | "developer"): str
 export async function loadOrgWhitelist(orgId: string, mode?: "published" | "developer"): Promise<Map<string, Set<string>>> {
   const cacheKey = whitelistCacheKey(orgId, mode);
   const cached = _orgWhitelists.get(cacheKey);
-  if (cached) return cached;
+  if (cached && cached.expiresAt > Date.now()) return cached.tables;
+  if (cached) {
+    // Expired entry — drop it so the load below repopulates with a fresh
+    // expiresAt instead of mutating a stale entry's window.
+    _orgWhitelists.delete(cacheKey);
+  }
 
   const { listEntities, listEntitiesWithOverlay } = await import("@atlas/api/lib/semantic/entities");
   const rows = mode === "developer"
@@ -456,7 +476,7 @@ export async function loadOrgWhitelist(orgId: string, mode?: "published" | "deve
     log.error({ orgId, entityCount: rows.length, parseFailures }, "All org entities failed to parse — whitelist is empty");
   }
 
-  _orgWhitelists.set(cacheKey, byConnection);
+  _orgWhitelists.set(cacheKey, { tables: byConnection, expiresAt: Date.now() + _ORG_WHITELIST_TTL_MS });
   const totalTables = Array.from(byConnection.values()).reduce((s, set) => s + set.size, 0);
   log.info({ orgId, mode: mode ?? "developer", entityCount: rows.length, parsedCount: rows.length - parseFailures, tableCount: totalTables, connections: Array.from(byConnection.keys()) }, "Loaded org whitelist from DB");
   return byConnection;
@@ -477,11 +497,12 @@ export async function loadOrgWhitelist(orgId: string, mode?: "published" | "deve
  */
 export function getOrgWhitelistedTables(orgId: string, connectionId: string = "default", mode?: "published" | "developer"): Set<string> {
   const cacheKey = whitelistCacheKey(orgId, mode);
-  const byConnection = _orgWhitelists.get(cacheKey);
-  if (!byConnection) {
+  const cached = _orgWhitelists.get(cacheKey);
+  if (!cached) {
     log.warn({ orgId, connectionId, mode: mode ?? "developer" }, "Org whitelist not loaded — all tables will be rejected");
     return new Set();
   }
+  const byConnection = cached.tables;
 
   // Single-connection orgs: callers default to "default", but demo stores
   // under "__demo__" and wizard orgs under user-chosen ids (#2142).

--- a/packages/web/src/app/admin/schema-diff/page.tsx
+++ b/packages/web/src/app/admin/schema-diff/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useQueryStates } from "nuqs";
 import { schemaDiffSearchParams } from "./search-params";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
+import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { StatCard } from "@/ui/components/admin/stat-card";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
@@ -88,6 +89,22 @@ export default function SchemaDiffPage() {
 
   const hasDrift = diff ? diff.summary.new > 0 || diff.summary.removed > 0 || diff.summary.changed > 0 : false;
 
+  // Recover-demo flow: detect a partial-state demo workspace and offer a
+  // one-click fix. The condition triggers when the diff returned with zero
+  // entities AND the visible picker is `__demo__` — that's the dharma-class
+  // signature (connection committed by /use-demo, entities never imported).
+  // The button fires the admin import endpoint with `source: "demo-seed"`
+  // which the backend wires to the bundled NovaMart YAML.
+  const isDemoConnection = connectionId === "__demo__";
+  const isEmptyDb = diff !== null && diff.summary.total === 0;
+  const showDemoRecover = isDemoConnection && isEmptyDb;
+
+  const { mutate: recoverDemo, saving: recovering, error: recoverError } = useAdminMutation<{ imported: number }>({
+    path: "/api/v1/admin/semantic/org/import",
+    method: "POST",
+    invalidates: refetch,
+  });
+
   return (
     <PageShell connectionSelector={multipleConnections ? (
       <ConnectionSelector
@@ -147,8 +164,39 @@ export default function SchemaDiffPage() {
             />
           </div>
 
-          {/* No drift — success message */}
-          {!hasDrift && (
+          {/* Demo recovery: empty DB on __demo__ → offer one-click recovery */}
+          {showDemoRecover ? (
+            <Card className="border-amber-500/50 bg-amber-50/50 shadow-none dark:bg-amber-950/20">
+              <CardContent className="flex flex-col gap-3 py-5 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex items-start gap-3">
+                  <AlertTriangle className="mt-0.5 size-5 shrink-0 text-amber-600 dark:text-amber-400" />
+                  <div>
+                    <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
+                      Demo connection has no semantic entities
+                    </p>
+                    <p className="mt-0.5 text-xs text-amber-700/80 dark:text-amber-400/80">
+                      The <code className="rounded bg-amber-500/10 px-1 py-0.5 font-mono">__demo__</code> connection exists but no entities are registered for queries. Re-import the NovaMart demo data to fix this.
+                    </p>
+                  </div>
+                </div>
+                <Button
+                  variant="default"
+                  size="sm"
+                  className="shrink-0 gap-1.5"
+                  disabled={recovering}
+                  onClick={() => recoverDemo({ body: { source: "demo-seed" } })}
+                >
+                  <RefreshCw className={`size-3.5 ${recovering ? "animate-spin" : ""}`} />
+                  {recovering ? "Recovering..." : "Recover demo data"}
+                </Button>
+              </CardContent>
+              {recoverError && (
+                <div className="border-t border-amber-500/20 px-5 pb-3 pt-2 text-xs text-red-700 dark:text-red-400">
+                  Recovery failed: {recoverError.message}
+                </div>
+              )}
+            </Card>
+          ) : !hasDrift && (
             <Card className="border-green-500/50 bg-green-50/50 shadow-none dark:bg-green-950/20">
               <CardContent className="flex items-center gap-3 py-6">
                 <CheckCircle2 className="size-5 text-green-600 dark:text-green-400" />

--- a/packages/web/src/app/admin/schema-diff/page.tsx
+++ b/packages/web/src/app/admin/schema-diff/page.tsx
@@ -91,19 +91,26 @@ export default function SchemaDiffPage() {
 
   // Recover-demo flow: detect a partial-state demo workspace and offer a
   // one-click fix. The condition triggers when the diff returned with zero
-  // entities AND the visible picker is `__demo__` — that's the dharma-class
-  // signature (connection committed by /use-demo, entities never imported).
-  // The button fires the admin import endpoint with `source: "demo-seed"`
-  // which the backend wires to the bundled NovaMart YAML.
+  // entities, the visible picker is `__demo__`, AND the org actually owns
+  // `__demo__` (cross-checked against /admin/connections so a stale URL
+  // can't trick a non-demo workspace into pulling the bundled YAML).
+  // The signature catches workspaces where /use-demo committed the
+  // connection but never imported entity rows.
   const isDemoConnection = connectionId === "__demo__";
   const isEmptyDb = diff !== null && diff.summary.total === 0;
-  const showDemoRecover = isDemoConnection && isEmptyDb;
+  const orgOwnsDemo = connectionsData?.some((c) => c.id === "__demo__") ?? false;
+  const showDemoRecover = isDemoConnection && isEmptyDb && orgOwnsDemo;
 
-  const { mutate: recoverDemo, saving: recovering, error: recoverError } = useAdminMutation<{ imported: number }>({
+  const { mutate: recoverDemo, saving: recovering, error: recoverError } = useAdminMutation<{ imported: number; total?: number }>({
     path: "/api/v1/admin/semantic/org/import",
     method: "POST",
     invalidates: refetch,
   });
+  // Last-result feedback so a successful recovery shows what happened even
+  // after the diff refetches (without this the success banner would flash
+  // and disappear). On `imported === 0` we leave the recovery card up so
+  // the user knows the call ran but didn't help — that's actionable signal.
+  const [recoverResult, setRecoverResult] = useState<{ imported: number } | null>(null);
 
   return (
     <PageShell connectionSelector={multipleConnections ? (
@@ -184,7 +191,12 @@ export default function SchemaDiffPage() {
                   size="sm"
                   className="shrink-0 gap-1.5"
                   disabled={recovering}
-                  onClick={() => recoverDemo({ body: { source: "demo-seed" } })}
+                  onClick={async () => {
+                    const result = await recoverDemo({ body: { source: "demo-seed" } });
+                    if (result.ok && result.data) {
+                      setRecoverResult({ imported: result.data.imported });
+                    }
+                  }}
                 >
                   <RefreshCw className={`size-3.5 ${recovering ? "animate-spin" : ""}`} />
                   {recovering ? "Recovering..." : "Recover demo data"}
@@ -193,6 +205,19 @@ export default function SchemaDiffPage() {
               {recoverError && (
                 <div className="border-t border-amber-500/20 px-5 pb-3 pt-2 text-xs text-red-700 dark:text-red-400">
                   Recovery failed: {recoverError.message}
+                </div>
+              )}
+              {recoverResult !== null && !recoverError && (
+                <div className="border-t border-amber-500/20 px-5 pb-3 pt-2 text-xs">
+                  {recoverResult.imported > 0 ? (
+                    <span className="text-green-700 dark:text-green-400">
+                      Imported {recoverResult.imported} entities. Re-running the diff…
+                    </span>
+                  ) : (
+                    <span className="text-red-700 dark:text-red-400">
+                      Recovery ran but imported 0 entities. The bundled demo seed may be missing on this server — contact support.
+                    </span>
+                  )}
                 </div>
               )}
             </Card>

--- a/packages/web/src/app/admin/semantic/page.tsx
+++ b/packages/web/src/app/admin/semantic/page.tsx
@@ -463,6 +463,16 @@ export default function SemanticPage() {
           description: typeof e.description === "string" ? e.description : "",
           columnCount: typeof e.columnCount === "number" ? e.columnCount : 0,
         })).filter((e) => e.table.length > 0);
+        const dropped = rawEntities.length - normalized.length;
+        if (dropped > 0) {
+          // Silent shape-drops on this page would recreate the conflation
+          // bug we just fixed — surface it so a server-side schema regression
+          // (e.g., a renamed `name` column) is visible in dev tools instead
+          // of looking like an empty workspace.
+          console.debug(
+            `admin/semantic: dropped ${dropped} entities with unrecognized shape from ${entitiesPath}`,
+          );
+        }
         setEntities(normalized);
       } else {
         const err = entitiesRes.reason;

--- a/packages/web/src/app/admin/semantic/page.tsx
+++ b/packages/web/src/app/admin/semantic/page.tsx
@@ -412,13 +412,27 @@ export default function SemanticPage() {
 
   const refetchAll = () => setFetchKey((k) => k + 1);
 
-  // Fetch all semantic data
+  // Fetch all semantic data.
+  //
+  // On SaaS we read entities from the DB-scoped org endpoint so the file
+  // tree reflects what's actually queryable for this workspace. The disk-
+  // baked /api/v1/admin/semantic/entities returns the bundled NovaMart YAML
+  // present on every API container — for SaaS orgs that's misleading
+  // (empty-DB workspaces looked "fully populated"). Self-hosted with no
+  // internal DB still uses the disk endpoint as the authoritative source.
+  //
+  // Glossary / metrics / catalog stay disk-based for now: those are not yet
+  // org-scoped in the DB schema, so until the broader migration they're
+  // shared per-deployment content. Tracked separately.
   useEffect(() => {
     let cancelled = false;
 
     async function fetchAll() {
+      const entitiesPath = isSaas
+        ? `/api/v1/admin/semantic/org/entities?type=entity`
+        : `/api/v1/admin/semantic/entities`;
       const [entitiesRes, glossaryRes, metricsRes, catalogRes] = await Promise.allSettled([
-        fetch(`${apiUrl}/api/v1/admin/semantic/entities`, fetchOpts).then((r) => {
+        fetch(`${apiUrl}${entitiesPath}`, fetchOpts).then((r) => {
           if (!r.ok) throw Object.assign(new Error(`HTTP ${r.status}`), { status: r.status });
           return r.json();
         }),
@@ -440,7 +454,16 @@ export default function SemanticPage() {
 
       if (entitiesRes.status === "fulfilled") {
         const data = entitiesRes.value;
-        setEntities(Array.isArray(data?.entities) ? data.entities : Array.isArray(data) ? data : []);
+        const rawEntities = Array.isArray(data?.entities) ? data.entities : Array.isArray(data) ? data : [];
+        // Org endpoint returns rows with { name, entityType, status, connectionId, updatedAt }.
+        // File endpoint returns rows with { table, description, columnCount }.
+        // Normalize to the shared EntitySummary shape regardless of source.
+        const normalized: EntitySummary[] = (rawEntities as Record<string, unknown>[]).map((e) => ({
+          table: typeof e.table === "string" ? e.table : (typeof e.name === "string" ? e.name : ""),
+          description: typeof e.description === "string" ? e.description : "",
+          columnCount: typeof e.columnCount === "number" ? e.columnCount : 0,
+        })).filter((e) => e.table.length > 0);
+        setEntities(normalized);
       } else {
         const err = entitiesRes.reason;
         setError({ message: err.message, status: err.status });
@@ -657,7 +680,7 @@ export default function SemanticPage() {
                 Improve
               </Button>
             </Link>
-            {isSaas && !demoReadOnly && (
+            {isSaas && (
               <Button
                 variant="outline"
                 className="gap-1.5"


### PR DESCRIPTION
## Summary

Tracing dharma's symptom — Schema Diff says 0/0/0/0, Semantic page says "NovaMart, 13 entities, 100% coverage" — surfaced a structural bug larger than any of the recent atomicity / picker fixes:

- **`/admin/semantic` merged disk-baked YAML with DB rows.** Bundled NovaMart on every API container looked like every org's content. Empty-DB workspaces appeared fully populated.
- **Health widget endpoint was disk-only.** Coverage % computed against bundled YAML, regardless of org state.
- **`/use-demo` silently absorbed `total === 0`.** Pre-this-PR's atomicity fix only treated `imported: 0, total > 0` as fatal. dharma's audit log shows the bundled YAML scan returned empty at signup time → ATLAS_DEMO_INDUSTRY written, `__demo__` committed, 201 returned, no entities ever existed.
- **Whitelist cache was forever-cached** (only entity CRUD invalidated). Out-of-band changes required an API restart.
- **Phase-4 failures in `/use-demo`** (settings, prompt seeding) silently absorbed.
- **Recovery affordance was on the wrong page** (Semantic, which lied) instead of Schema Diff (which exposed truth), and hidden in demo mode.

## Changes

- `/use-demo` `total === 0` → 500 `demo_not_available`. Pinned with the `ATOMICITY: bundled YAML scan returning zero entities (dharma-class)` test.
- `/use-demo` 201 carries `partialFailures: ["demo_industry_setting" | "demo_prompt_collections"]` when phase-4 fails.
- `/admin/semantic` on SaaS reads entities from `/admin/semantic/org/entities` (DB). Self-hosted-no-DB stays on disk endpoint.
- Health widget endpoint prefers new `loadEntitiesFromDB(orgId, mode)`. Disk is fallback for self-hosted-no-DB.
- Schema Diff page detects empty-DB on `__demo__` → one-click "Recover demo data" button posting `source: "demo-seed"` to the auto-recovery endpoint from #2154.
- "Import from disk" button visible in demo mode.
- `loadOrgWhitelist` 60s TTL (`ATLAS_ORG_WHITELIST_TTL_MS`).

Fixes #2155.

## Test plan

- [x] `bun run test:api --affected` (14 files green)
- [x] `bun run lint` / `bun run type` clean
- [ ] Manual: dharma's `/admin/semantic` now shows 0 entities (truth) instead of 13 (lie)
- [ ] Manual: dharma's Schema Diff offers "Recover demo data" button → click → 13 entities populate
- [ ] Manual: fresh signup with bundled YAML present succeeds; with bundled YAML absent fails clean (no half-install)
- [ ] Manual: self-hosted dev unchanged