### PR TITLE
fix(api,db): semantic_entities upsert ON CONFLICT drift (#2157) — the actual cause of dharma

### DIFF
--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -396,13 +396,17 @@ export const semanticEntities = pgTable(
     index("idx_semantic_entities_org_type").on(t.orgId, t.entityType),
     check("chk_semantic_entities_status", sql`status IN ('published', 'draft', 'draft_delete', 'archived')`),
     // IMPORTANT: These are placeholder stubs — the real indexes are UNIQUE on
-    // (org_id, name, COALESCE(connection_id, '__default__')) and are managed by
-    // raw SQL in migration 0025. Drizzle can't represent expression indexes,
-    // so these non-unique two-column approximations exist solely to suppress
-    // drift warnings. Do NOT rely on these for constraint reasoning.
-    index("uq_semantic_entity_published").on(t.orgId, t.name).where(sql`status = 'published'`),
-    index("uq_semantic_entity_draft").on(t.orgId, t.name).where(sql`status = 'draft'`),
-    index("uq_semantic_entity_tombstone").on(t.orgId, t.name).where(sql`status = 'draft_delete'`),
+    // (org_id, entity_type, name, COALESCE(connection_id, '__default__')) and
+    // are managed by raw SQL in migration 0028. Drizzle can't represent
+    // expression indexes, so these non-unique approximations exist solely
+    // to suppress drift warnings. Do NOT rely on these for constraint
+    // reasoning — and any code calling `ON CONFLICT (...)` against these
+    // indexes must include `entity_type` in the conflict-target column list,
+    // otherwise Postgres raises "no unique or exclusion constraint matching
+    // the ON CONFLICT specification" and the upsert silently fails.
+    index("uq_semantic_entity_published").on(t.orgId, t.entityType, t.name).where(sql`status = 'published'`),
+    index("uq_semantic_entity_draft").on(t.orgId, t.entityType, t.name).where(sql`status = 'draft'`),
+    index("uq_semantic_entity_tombstone").on(t.orgId, t.entityType, t.name).where(sql`status = 'draft_delete'`),
   ],
 );
 

--- a/packages/api/src/lib/semantic/entities.ts
+++ b/packages/api/src/lib/semantic/entities.ts
@@ -54,7 +54,7 @@ export async function upsertEntity(
   await internalQuery(
     `INSERT INTO semantic_entities (org_id, entity_type, name, yaml_content, connection_id, status)
      VALUES ($1, $2, $3, $4, $5, 'published')
-     ON CONFLICT (org_id, name, COALESCE(connection_id, '__default__')) WHERE status = 'published'
+     ON CONFLICT (org_id, entity_type, name, COALESCE(connection_id, '__default__')) WHERE status = 'published'
      DO UPDATE SET yaml_content = EXCLUDED.yaml_content,
                    entity_type = EXCLUDED.entity_type,
                    connection_id = EXCLUDED.connection_id,
@@ -83,7 +83,7 @@ export async function upsertDraftEntity(
   await internalQuery(
     `INSERT INTO semantic_entities (org_id, entity_type, name, yaml_content, connection_id, status)
      VALUES ($1, $2, $3, $4, $5, 'draft')
-     ON CONFLICT (org_id, name, COALESCE(connection_id, '__default__')) WHERE status = 'draft'
+     ON CONFLICT (org_id, entity_type, name, COALESCE(connection_id, '__default__')) WHERE status = 'draft'
      DO UPDATE SET yaml_content = EXCLUDED.yaml_content,
                    entity_type = EXCLUDED.entity_type,
                    connection_id = EXCLUDED.connection_id,
@@ -112,7 +112,7 @@ export async function upsertTombstone(
   await internalQuery(
     `INSERT INTO semantic_entities (org_id, entity_type, name, yaml_content, connection_id, status)
      VALUES ($1, $2, $3, '', $4, 'draft_delete')
-     ON CONFLICT (org_id, name, COALESCE(connection_id, '__default__')) WHERE status = 'draft_delete'
+     ON CONFLICT (org_id, entity_type, name, COALESCE(connection_id, '__default__')) WHERE status = 'draft_delete'
      DO UPDATE SET updated_at = now()`,
     [orgId, entityType, name, connectionId ?? null],
   );
@@ -810,8 +810,14 @@ export async function bulkUpsertEntities(
       await upsertEntity(orgId, e.entityType, e.name, e.yamlContent, e.connectionId);
       upserted++;
     } catch (err) {
-      log.warn(
-        { orgId, entityType: e.entityType, name: e.name, err: err instanceof Error ? err.message : String(err) },
+      // log.error (not log.warn) because a row-level upsert failure means
+      // the YAML parsed cleanly but the DB rejected it — usually a schema
+      // drift between the ON CONFLICT clause and the unique index. Silent
+      // warns let migration 0028 ship the index change without anyone
+      // noticing every upsert started failing. Loud error makes the next
+      // such drift visible in any log aggregator.
+      log.error(
+        { orgId, entityType: e.entityType, name: e.name, err: err instanceof Error ? err.message : String(err), cause: err instanceof Error ? err.cause : undefined },
         "Failed to upsert semantic entity — skipping",
       );
     }


### PR DESCRIPTION
## TL;DR

Migration 0028 added `entity_type` to the partial unique indexes. The upsert SQL never got the matching update. Every `semantic_entities` upsert has been failing with \`there is no unique or exclusion constraint matching the ON CONFLICT specification\` since 0028 ran. Per-row errors were swallowed at `log.warn` (rendered as `[INFO]` in prod) so no alerts fired. /admin/semantic's disk-fallback (just fixed in #2155) hid the empty-DB symptom.

## Reproduction (against prod us-int-postgres before this PR)

\`\`\`
ERROR: there is no unique or exclusion constraint matching the ON CONFLICT specification
\`\`\`

After the fix, the same INSERT returns the row id.

## Changes

- `entities.ts` — add `entity_type` to all 3 ON CONFLICT clauses (`upsertEntity`, `upsertDraftEntity`, `upsertTombstone`).
- `schema.ts` — Drizzle stub indexes updated to the (now 3-column) approximation. Comment warns that ON CONFLICT callers MUST include `entity_type` to avoid silent failure.
- `bulkUpsertEntities` per-row catch: `log.warn` → `log.error`, includes `err.cause`. The silent warn is the meta-bug that let 0028's drift ship invisibly — loud error makes the next such drift visible.

Fixes #2157.

## Test plan

- [x] `bun run test:api --affected` (31 files green)
- [x] Manual: `INSERT ... ON CONFLICT (org_id, entity_type, name, COALESCE(...))` succeeds against us-int-postgres.
- [ ] Post-deploy: dharma clicks "Recover demo data" on Schema Diff → expect 13 entities imported, audit `sourceRef: "demo-seed:auto-recover"`.
- [ ] Post-deploy: any new SaaS signup that runs /use-demo (now atomic + bug-free) populates `semantic_entities` correctly.