### PR TITLE
fix(api): normalize YAML dimension types in Schema Diff (false-positive timestamp/date drift)

### DIFF
--- a/packages/api/src/lib/__tests__/semantic-diff.test.ts
+++ b/packages/api/src/lib/__tests__/semantic-diff.test.ts
@@ -151,6 +151,35 @@ describe("parseEntityYAML", () => {
     });
     expect(snap.columns.size).toBe(1);
   });
+
+  it("normalizes YAML semantic types into mapSQLType's target space", () => {
+    // The DB side runs every column through `mapSQLType` (which collapses
+    // every date-class SQL type into "date"). The YAML side must use the
+    // same normalization or canonical YAML types like "timestamp" produce
+    // false-positive drift against DB columns of type "timestamp with time
+    // zone" (which `mapSQLType` reports as "date"). Repro: dharma's
+    // post-recovery diff showed 13 phantom "Changed Tables" rows where
+    // every `created_at`/`updated_at` claimed `YAML: timestamp → DB: date`.
+    const snap = parseEntityYAML({
+      table: "users",
+      dimensions: [
+        { name: "id", type: "number" },
+        { name: "name", type: "string" },
+        // Three date-class aliases that all collapse to "date":
+        { name: "created_at", type: "timestamp" },
+        { name: "updated_at", type: "datetime" },
+        { name: "due", type: "date" },
+        { name: "active", type: "boolean" },
+      ],
+    });
+
+    expect(snap.columns.get("id")).toBe("number");
+    expect(snap.columns.get("name")).toBe("string");
+    expect(snap.columns.get("created_at")).toBe("date");
+    expect(snap.columns.get("updated_at")).toBe("date");
+    expect(snap.columns.get("due")).toBe("date");
+    expect(snap.columns.get("active")).toBe("boolean");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/semantic/diff.ts
+++ b/packages/api/src/lib/semantic/diff.ts
@@ -56,7 +56,12 @@ export function mapSQLType(sqlType: string): string {
     t.includes("double") ||
     t === "currency" ||
     t === "percent" ||
-    t === "long"
+    t === "long" ||
+    // YAML semantic-layer aliases — `parseEntityYAML` runs every dimension
+    // type through this same normalizer so the diff comparison stays in
+    // one target space. Without these, canonical YAML types like "number"
+    // fall through to the "string" default and produce phantom drift rows.
+    t === "number"
   )
     return "number";
   if (t.startsWith("bool")) return "boolean";
@@ -82,7 +87,14 @@ export function parseEntityYAML(doc: Record<string, unknown>): EntitySnapshot {
   for (const dim of dimensions) {
     if (dim.virtual) continue;
     if (typeof dim.name !== "string" || typeof dim.type !== "string") continue;
-    columns.set(dim.name, dim.type);
+    // Normalize YAML dimension types into the same target space as
+    // `mapSQLType` so the diff compares apples to apples. Without this,
+    // YAML "timestamp" was being compared against DB-normalized "date"
+    // (because `mapSQLType` collapses every date-class SQL type into
+    // "date"), producing 13 false-positive "drift" rows for every
+    // workspace whose YAML used the canonical semantic-layer type names
+    // ("timestamp", "number", "boolean", etc).
+    columns.set(dim.name, mapSQLType(dim.type));
   }
 
   const rawJoins = doc.joins ?? [];


### PR DESCRIPTION
## Symptom

After dharma's recovery, Schema Diff showed 13 Changed Tables — every demo entity reported `YAML: timestamp → DB: date` for `created_at` / `updated_at` columns. Real drift on `order_items.product_id` is also surfaced (genuine staleness in the bundled YAML), but the 13 timestamp rows are false positives.

## Cause

`parseEntityYAML` stored raw YAML types (`"timestamp"`, `"number"`, etc.) while `getDBSchema` runs every DB column through `mapSQLType` which collapses every date-class SQL type to `"date"` and every integer/decimal/numeric to `"number"`. Apples vs oranges.

## Fix

- `parseEntityYAML` calls `mapSQLType(dim.type)` so YAML "timestamp" lands on "date" (same target space as DB-side normalization).
- `mapSQLType` extended to recognize canonical YAML semantic-layer alias `"number"` (was falling through to the `"string"` default).

## Test plan

- [x] `bun run test --affected` (6 files green)
- [x] `bun run lint` / `bun run type` clean
- [ ] Post-deploy on dharma: re-run Schema Diff on `__demo__` → expect drift only for the genuine `order_items.product_id` mismatch (which a future bundled-YAML refresh will fix)