### PR TITLE
fix(seed): demo seed migration-aware — auto-heal additive schema drift on long-lived demo DBs

### DIFF
--- a/examples/docker/scripts/seed-demo.ts
+++ b/examples/docker/scripts/seed-demo.ts
@@ -25,6 +25,19 @@ if (!url) {
   process.exit(1);
 }
 
+interface Migration {
+  /** Stable name for logging — keep these unique within a dataset. */
+  name: string;
+  /**
+   * Idempotent SQL. MUST safely no-op against an already-aligned schema
+   * AND apply the change against a stale one (use `ADD COLUMN IF NOT
+   * EXISTS`, `IF NOT EXISTS` checks in DO blocks, conditional UPDATEs).
+   * The seeder runs every migration on every boot; only the side-effect
+   * branches should fire when actual drift exists.
+   */
+  sql: string;
+}
+
 interface Dataset {
   name: string;
   file: string;
@@ -37,10 +50,54 @@ interface Dataset {
    * when BOTH the table and this column exist and the table has rows.
    */
   sentinelColumn: string;
+  /**
+   * Idempotent schema migrations applied AFTER the seed (or after the
+   * "already seeded" skip). Lets a long-lived demo DB pick up additive
+   * schema changes without a destructive re-seed. Catches the class of
+   * drift where the seed SQL evolves but a previously-seeded prod DB
+   * doesn't pick up new columns / constraints.
+   */
+  migrations?: Migration[];
 }
 
 const datasets: Dataset[] = [
-  { name: "NovaMart (ecommerce)", file: "/app/data/demo.sql", sentinelTable: "customers", sentinelColumn: "acquisition_source" },
+  {
+    name: "NovaMart (ecommerce)",
+    file: "/app/data/demo.sql",
+    sentinelTable: "customers",
+    sentinelColumn: "acquisition_source",
+    migrations: [
+      {
+        // Older seeds (pre-canonical-product_id) created order_items without
+        // `product_id`. Backfill from product_variants.product_id and add
+        // the FK so the canonical YAML's `order_items.product_id` dimension
+        // resolves against a real column.
+        name: "order_items.product_id alignment",
+        sql: `
+          DO $$
+          BEGIN
+            IF NOT EXISTS (
+              SELECT 1 FROM information_schema.columns
+              WHERE table_schema = 'public'
+                AND table_name = 'order_items'
+                AND column_name = 'product_id'
+            ) THEN
+              ALTER TABLE order_items ADD COLUMN product_id INTEGER;
+              UPDATE order_items oi
+              SET product_id = pv.product_id
+              FROM product_variants pv
+              WHERE pv.id = oi.product_variant_id;
+              ALTER TABLE order_items ALTER COLUMN product_id SET NOT NULL;
+              ALTER TABLE order_items
+                ADD CONSTRAINT order_items_product_id_fkey
+                FOREIGN KEY (product_id) REFERENCES products(id);
+            END IF;
+          END
+          $$;
+        `,
+      },
+    ],
+  },
 ];
 
 const client = new pg.Client({
@@ -79,43 +136,66 @@ try {
       ) AS dataset_exists
     `, [ds.sentinelTable, ds.sentinelColumn]);
 
+    let alreadySeeded = false;
     if (tableCheck.rows[0]?.dataset_exists) {
       const count = await client.query(
         `SELECT count(*) AS n FROM ${ds.sentinelTable}`
       );
       if (parseInt(count.rows[0]?.n ?? "0", 10) > 0) {
-        console.log(`seed-demo: ${ds.name} — already seeded, skipping`);
-        continue;
+        console.log(`seed-demo: ${ds.name} — already seeded, skipping initial seed`);
+        alreadySeeded = true;
       }
     }
 
-    // Read and execute the seed SQL
-    const sql = readFileSync(ds.file, "utf-8");
-    console.log(`seed-demo: ${ds.name} — seeding...`);
+    if (!alreadySeeded) {
+      // Read and execute the seed SQL
+      const sql = readFileSync(ds.file, "utf-8");
+      console.log(`seed-demo: ${ds.name} — seeding...`);
 
-    await client.query("BEGIN");
-    try {
-      await client.query(sql);
-      await client.query("COMMIT");
-    } catch (err) {
-      await client.query("ROLLBACK");
-      console.error(
-        `seed-demo: ${ds.name} — FAILED:`,
-        err instanceof Error ? err.message : err,
+      await client.query("BEGIN");
+      try {
+        await client.query(sql);
+        await client.query("COMMIT");
+      } catch (err) {
+        await client.query("ROLLBACK");
+        console.error(
+          `seed-demo: ${ds.name} — FAILED:`,
+          err instanceof Error ? err.message : err,
+        );
+        // With a single canonical seed, a SQL failure means the API will boot
+        // against an empty database — fail loudly instead of exiting 0. (#2021)
+        try { await client.end(); } catch { /* connection close failed; exit anyway */ }
+        process.exit(1);
+      }
+
+      // Verify
+      const verify = await client.query(
+        `SELECT count(*) AS n FROM ${ds.sentinelTable}`
       );
-      // With a single canonical seed, a SQL failure means the API will boot
-      // against an empty database — fail loudly instead of exiting 0. (#2021)
-      try { await client.end(); } catch { /* connection close failed; exit anyway */ }
-      process.exit(1);
+      console.log(
+        `seed-demo: ${ds.name} — seeded ${verify.rows[0]?.n ?? 0} rows in ${ds.sentinelTable}`,
+      );
     }
 
-    // Verify
-    const verify = await client.query(
-      `SELECT count(*) AS n FROM ${ds.sentinelTable}`
-    );
-    console.log(
-      `seed-demo: ${ds.name} — seeded ${verify.rows[0]?.n ?? 0} rows in ${ds.sentinelTable}`,
-    );
+    // Apply schema migrations even when the seed is skipped — long-lived
+    // demo DBs need to pick up additive schema changes (e.g. a new
+    // canonical column the seed file added since first-seed). Each
+    // migration must be idempotent; it runs on every boot.
+    if (ds.migrations && ds.migrations.length > 0) {
+      for (const mig of ds.migrations) {
+        try {
+          await client.query(mig.sql);
+          console.log(`seed-demo: ${ds.name} — migration applied: ${mig.name}`);
+        } catch (err) {
+          console.error(
+            `seed-demo: ${ds.name} — migration "${mig.name}" FAILED:`,
+            err instanceof Error ? err.message : err,
+          );
+          try { await client.end(); } catch { /* connection close failed; exit anyway */ }
+          process.exit(1);
+        }
+      }
+    }
   }
 
   await client.end();


### PR DESCRIPTION
## Why

Tracing dharma's last \"removed: product_id\" Schema Diff entry: the canonical seed SQL has \`order_items.product_id\` (with FK to products), but the prod demo Postgres was first-seeded before that column existed and never got it. The bundled YAML correctly referenced \`product_id\`; the actual demo DB didn't have it. Schema Diff honestly reported the drift.

Surgically aligned the prod demo DB out-of-band (ADD COLUMN + backfill from \`product_variants.product_id\` + NOT NULL + FK). All 55,000 rows got valid \`product_id\` values; verified zero NULLs.

This patch makes the same alignment automatic so the next analogous drift heals on the next API boot rather than requiring another manual psql session.

## How

- \`Dataset\` type extended with optional \`migrations: Migration[]\`. Each migration is idempotent SQL — runs on every boot, no-ops on aligned schemas, applies the change on stale ones.
- Restructured the seed loop so migrations run after the initial seed AND after the \"already seeded\" skip path.
- First migration: idempotent \`order_items.product_id\` alignment in a \`DO $$ ... $$\` block guarded by an \`information_schema\` check.

## Test plan

- [x] \`bun run lint\` / \`bun run type\` clean
- [x] Verified idempotency directly against prod demo Postgres — guard block reports \"idempotent no-op — product_id already present\"
- [ ] Next API boot: confirm the migration logs \"applied\" on the first run that lands this image, and \"applied (no-op)\" on subsequent reboots