### PR TITLE
feat(web): Re-run Diff feedback — spinning icon + sonner toast

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -353,6 +353,7 @@
         "lucide-react": "^1.7.0",
         "nanoid": "^5.1.7",
         "next": "^16.2.1",
+        "next-themes": "^0.4.6",
         "nuqs": "^2.8.9",
         "radix-ui": "^1.4.3",
         "react": "^19.2.4",
@@ -365,6 +366,7 @@
         "react-syntax-highlighter": "^16.1.1",
         "recharts": "^3.8.1",
         "remark-gfm": "^4.0.1",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "zod": "^4.3.6",
       },
@@ -3832,6 +3834,8 @@
     "snowflake-sdk": ["snowflake-sdk@2.3.6", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-sdk/client-s3": "^3.983.0", "@aws-sdk/client-sts": "^3.983.0", "@aws-sdk/credential-provider-node": "^3.972.5", "@aws-sdk/ec2-metadata-service": "^3.983.0", "@azure/identity": "^4.10.1", "@azure/storage-blob": "12.26.x", "@smithy/node-http-handler": "^4.4.9", "@smithy/protocol-http": "^5.3.8", "@smithy/signature-v4": "^5.3.8", "@techteamer/ocsp": "1.0.1", "asn1.js": "^5.0.0", "asn1.js-rfc2560": "^5.0.0", "asn1.js-rfc5280": "^3.0.0", "axios": "^1.13.4", "big-integer": "^1.6.43", "bignumber.js": "^9.1.2", "browser-request": "^0.3.3", "expand-tilde": "^2.0.2", "fast-xml-parser": "^5.4.1", "fastest-levenshtein": "^1.0.16", "generic-pool": "^3.8.2", "google-auth-library": "^10.1.0", "https-proxy-agent": "^7.0.2", "jsonwebtoken": "^9.0.3", "mime-types": "^2.1.29", "moment": "^2.29.4", "moment-timezone": "^0.5.15", "oauth4webapi": "^3.0.1", "open": "^7.3.1", "simple-lru-cache": "^0.0.2", "toml": "^3.0.0", "uuid": "^8.3.2", "winston": "^3.1.0" } }, "sha512-yY7ooh00uO0SYL5lSI2w3hNCMphBvUcz7GDktqKE0TasCkIk5G/Ebjypa3XKI2cUBfjrx5wtlQF2vkBH75BODw=="],
 
     "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
+
+    "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -49,6 +49,7 @@
     "lucide-react": "^1.7.0",
     "nanoid": "^5.1.7",
     "next": "^16.2.1",
+    "next-themes": "^0.4.6",
     "nuqs": "^2.8.9",
     "radix-ui": "^1.4.3",
     "react": "^19.2.4",
@@ -61,6 +62,7 @@
     "react-syntax-highlighter": "^16.1.1",
     "recharts": "^3.8.1",
     "remark-gfm": "^4.0.1",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"
   },

--- a/packages/web/src/app/admin/schema-diff/page.tsx
+++ b/packages/web/src/app/admin/schema-diff/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useQueryStates } from "nuqs";
+import { toast } from "sonner";
 import { schemaDiffSearchParams } from "./search-params";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
@@ -111,6 +112,11 @@ export default function SchemaDiffPage() {
   // and disappear). On `imported === 0` we leave the recovery card up so
   // the user knows the call ran but didn't help — that's actionable signal.
   const [recoverResult, setRecoverResult] = useState<{ imported: number } | null>(null);
+
+  // Re-run Diff click state. The hook's `loading` is `isPending` (false on
+  // cached refetches), so we track our own flag to spin the icon and gate
+  // double-clicks. Sonner's `toast.promise` handles the success/error copy.
+  const [rerunning, setRerunning] = useState(false);
 
   return (
     <PageShell connectionSelector={multipleConnections ? (
@@ -329,9 +335,35 @@ export default function SchemaDiffPage() {
 
           {/* Refresh button */}
           <div className="flex justify-end">
-            <Button variant="outline" size="sm" onClick={() => refetch()} className="gap-2">
-              <RefreshCw className="size-3.5" />
-              Re-run Diff
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={rerunning}
+              onClick={async () => {
+                setRerunning(true);
+                const promise = refetch().finally(() => setRerunning(false));
+                toast.promise(promise, {
+                  loading: "Re-running schema diff…",
+                  success: (result) => {
+                    // refetch returns a TanStack QueryObserverResult — read
+                    // the fresh data from result.data so the toast reflects
+                    // the actual outcome (avoids the stale-closure trap of
+                    // reading `diff` here).
+                    const fresh = result?.data;
+                    if (!fresh) return "Diff refreshed";
+                    const drift = fresh.summary.new + fresh.summary.removed + fresh.summary.changed;
+                    if (drift === 0) {
+                      return `Semantic layer in sync (${fresh.summary.unchanged} entities)`;
+                    }
+                    return `Diff refreshed — ${drift} table${drift === 1 ? "" : "s"} drifted, ${fresh.summary.unchanged} in sync`;
+                  },
+                  error: (err) => `Diff failed: ${err instanceof Error ? err.message : String(err)}`,
+                });
+              }}
+              className="gap-2"
+            >
+              <RefreshCw className={`size-3.5 ${rerunning ? "animate-spin" : ""}`} />
+              {rerunning ? "Re-running…" : "Re-run Diff"}
             </Button>
           </div>
         </div>

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { buildThemeInitScript } from "@/ui/hooks/theme-init-script";
 import { AuthGuard } from "@/ui/components/auth-guard";
 import { QueryProvider } from "@/ui/components/query-provider";
 import { ModeBanner } from "@/ui/components/mode-banner";
+import { Toaster } from "@/components/ui/sonner";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -31,6 +32,7 @@ export default function RootLayout({
             </AuthGuard>
           </NuqsAdapter>
         </QueryProvider>
+        <Toaster richColors position="bottom-right" />
       </body>
     </html>
   );

--- a/packages/web/src/components/ui/sonner.tsx
+++ b/packages/web/src/components/ui/sonner.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from "lucide-react"
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }


### PR DESCRIPTION
## Why

Clicking \"Re-run Diff\" on Schema Diff fired \`refetch()\` silently. TanStack Query's \`isPending\` stays false on cached refetches, so the button looked like nothing happened.

## What

- shadcn **sonner** added (Toaster mounted once in root layout — first toast surface in the app).
- Re-run button tracks its own \`rerunning\` flag. RefreshCw icon spins, label flips to \"Re-running…\", double-click is gated.
- \`toast.promise(refetch())\` does loading → success → error in one call. Success copy reflects the actual outcome:
  - In-sync: \"Semantic layer in sync (N entities)\"
  - Drift: \"Diff refreshed — N tables drifted, M in sync\"

## Test plan

- [x] \`bun run lint\` / \`bun run type\` clean
- [ ] Manual: dharma's Schema Diff → click Re-run Diff → toast shows + icon spins + button disabled while in flight