### PR TITLE
refactor(web): migrate four Context/useState clusters to zustand

### DIFF
--- a/create-atlas/scripts/prepare-templates.sh
+++ b/create-atlas/scripts/prepare-templates.sh
@@ -96,7 +96,16 @@ for tpl in docker nextjs-standalone; do
   # Merge web lib files into existing API lib (don't delete — API source lives there too)
   if [ -d "$WEB_SRC/lib" ]; then
     cp "$WEB_SRC"/lib/*.ts "$TEMPLATES/$tpl/src/lib/" 2>/dev/null || true
-    # Copy web lib subdirs that don't exist in API (auth/client.ts has special handling)
+    # Copy web lib subdirs (delete+replace each one) — auth/ has the special
+    # docker-only client.ts override applied below; everything else is a
+    # straight copy. Without this, anything web imports via `@/lib/<dir>/`
+    # (e.g. `@/lib/stores/ui-store`) fails to resolve in scaffolded apps.
+    for libsub in stores; do
+      if [ -d "$WEB_SRC/lib/$libsub" ]; then
+        rm -rf "$TEMPLATES/$tpl/src/lib/$libsub"
+        cp -r "$WEB_SRC/lib/$libsub" "$TEMPLATES/$tpl/src/lib/$libsub"
+      fi
+    done
   fi
   # Remove test files from synced web source
   find "$TEMPLATES/$tpl/src/ui" -name '__tests__' -type d -exec rm -rf {} + 2>/dev/null || true

--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -77,7 +77,8 @@
     "stripe": "^21.0.1",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "zustand": "^5.0.13"
   },
   "optionalDependencies": {
     "@vercel/sandbox": "^1"

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -74,7 +74,8 @@
     "stripe": "^21.0.1",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "zustand": "^5.0.13"
   },
   "optionalDependencies": {
     "@vercel/sandbox": "^1"

--- a/packages/web/src/app/notebook/page.tsx
+++ b/packages/web/src/app/notebook/page.tsx
@@ -16,6 +16,7 @@ import { NavBar } from "@/ui/components/tour/nav-bar";
 import { Button } from "@/components/ui/button";
 import type { NotebookStateWire, ForkBranchWire } from "@/ui/lib/types";
 import type { ForkInfo } from "@/ui/components/notebook/types";
+import { useUiStore } from "@/lib/stores/ui-store";
 
 const GuidedTour = dynamic(
   () => import("@/ui/components/tour/guided-tour").then((m) => m.GuidedTour),
@@ -42,7 +43,7 @@ function NotebookContent() {
   const focusCellId = params.cell || undefined;
 
   const [error, setError] = useState<string | null>(null);
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const setMobileSidebarOpen = useUiStore((s) => s.setMobileSidebarOpen);
   const [loadingConversation, setLoadingConversation] = useState(false);
   const tempIdRef = useRef(`temp:${Date.now()}`);
 
@@ -263,7 +264,7 @@ function NotebookContent() {
       setMessages(transformMessages(convData.messages));
       setParams({ id, cell: "" });
       convos.setSelectedId(id);
-      setMobileMenuOpen(false);
+      setMobileSidebarOpen(false);
     } catch (err: unknown) {
       console.warn(
         "Failed to load conversation:",
@@ -317,8 +318,6 @@ function NotebookContent() {
               onDelete={(id) => convos.deleteConversation(id)}
               onStar={(id, starred) => convos.starConversation(id, starred)}
               onNewChat={handleNewChat}
-              mobileOpen={mobileMenuOpen}
-              onMobileClose={() => setMobileMenuOpen(false)}
             />
           )}
           <main id="main" className="flex-1 flex flex-col overflow-hidden">

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -29,6 +29,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Send, TableProperties, BookOpen, Menu } from "lucide-react";
+import { useUiStore } from "@/lib/stores/ui-store";
 
 const OPENSTATUS_SLUG = process.env.NEXT_PUBLIC_OPENSTATUS_SLUG;
 const STATUS_URL = process.env.NEXT_PUBLIC_STATUS_URL;
@@ -58,10 +59,12 @@ function ChatPage() {
 
   const [input, setInput] = useState("");
   const [error, setError] = useState<string | null>(null);
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const setMobileSidebarOpen = useUiStore((s) => s.setMobileSidebarOpen);
   const [loadingConversation, setLoadingConversation] = useState(false);
-  const [schemaExplorerOpen, setSchemaExplorerOpen] = useState(false);
-  const [promptLibraryOpen, setPromptLibraryOpen] = useState(false);
+  const schemaExplorerOpen = useUiStore((s) => s.schemaExplorerOpen);
+  const setSchemaExplorerOpen = useUiStore((s) => s.setSchemaExplorerOpen);
+  const promptLibraryOpen = useUiStore((s) => s.promptLibraryOpen);
+  const setPromptLibraryOpen = useUiStore((s) => s.setPromptLibraryOpen);
   const [fetchErrorDismissed, setFetchErrorDismissed] = useState(false);
   // Adaptive empty-chat starter surface — backend composes the ranked
   // prompt list from favorites / popular / library tiers (#1474).
@@ -250,7 +253,7 @@ function ChatPage() {
       lastLoadedIdRef.current = id;
       setParams({ id });
       convos.setSelectedId(id);
-      setMobileMenuOpen(false);
+      setMobileSidebarOpen(false);
     } catch (err: unknown) {
       console.warn(
         "Failed to load conversation:",
@@ -316,8 +319,6 @@ function ChatPage() {
               onStar={(id, starred) => convos.starConversation(id, starred)}
               onConvertToNotebook={(id) => convos.convertToNotebook(id)}
               onNewChat={handleNewChat}
-              mobileOpen={mobileMenuOpen}
-              onMobileClose={() => setMobileMenuOpen(false)}
             />
           )}
 
@@ -330,7 +331,7 @@ function ChatPage() {
                     <Button
                       variant="ghost"
                       size="icon"
-                      onClick={() => setMobileMenuOpen(true)}
+                      onClick={() => setMobileSidebarOpen(true)}
                       className="size-8 text-zinc-400 hover:text-zinc-700 md:hidden dark:hover:text-zinc-200"
                       aria-label="Open conversation history"
                     >

--- a/packages/web/src/lib/stores/mfa-gate-store.ts
+++ b/packages/web/src/lib/stores/mfa-gate-store.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+
+interface MfaGateState {
+  enrollmentUrl: string;
+}
+
+interface MfaGateStore {
+  state: MfaGateState | null;
+  setState: (state: MfaGateState | null) => void;
+  clear: () => void;
+}
+
+export const useMfaGateStore = create<MfaGateStore>()((set) => ({
+  state: null,
+  setState: (state) => set({ state }),
+  clear: () => set({ state: null }),
+}));

--- a/packages/web/src/lib/stores/signup-region-store.ts
+++ b/packages/web/src/lib/stores/signup-region-store.ts
@@ -1,0 +1,59 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import { z } from "zod";
+import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
+
+const RegionsResponseSchema = z.object({
+  configured: z.boolean(),
+  availableRegions: z.array(z.unknown()),
+});
+
+export type SignupRegionState =
+  | { status: "loading" }
+  | { status: "ready"; showRegion: boolean };
+
+interface SignupRegionStore {
+  state: SignupRegionState;
+  init: () => Promise<void>;
+}
+
+function getApiBase(): string {
+  const url = getApiUrl();
+  if (url) return url;
+  if (typeof window !== "undefined") return window.location.origin;
+  return "http://localhost:3000";
+}
+
+export const useSignupRegionStore = create<SignupRegionStore>()(
+  persist(
+    (set, get) => ({
+      state: { status: "loading" },
+      init: async () => {
+        if (get().state.status === "ready") return;
+        try {
+          const res = await fetch(`${getApiBase()}/api/v1/onboarding/regions`, {
+            credentials: isCrossOrigin() ? "include" : "same-origin",
+          });
+          if (!res.ok) throw new Error(`status ${res.status}`);
+          const raw: unknown = await res.json();
+          const data = RegionsResponseSchema.parse(raw);
+          const showRegion = data.configured && data.availableRegions.length > 0;
+          set({ state: { status: "ready", showRegion } });
+        } catch (err) {
+          // Hide the region step by default — mirrors the region page's auto-skip
+          // when the API is unreachable or returns configured=false.
+          console.warn(
+            "[signup] region availability probe failed:",
+            err instanceof Error ? err.message : String(err),
+          );
+          set({ state: { status: "ready", showRegion: false } });
+        }
+      },
+    }),
+    {
+      name: "atlas:signup:show-region",
+      storage: createJSONStorage(() => sessionStorage),
+      partialize: (s) => ({ state: s.state }),
+    },
+  ),
+);

--- a/packages/web/src/lib/stores/tour-store.ts
+++ b/packages/web/src/lib/stores/tour-store.ts
@@ -1,0 +1,63 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+interface TourStore {
+  /** Persisted: has the user completed (or skipped) the tour previously? */
+  completed: boolean;
+  /** Whether the overlay is rendering right now. */
+  isActive: boolean;
+  /** Zero-based index into the active step list. */
+  currentStep: number;
+  setCompleted: (completed: boolean) => void;
+  setActive: (isActive: boolean) => void;
+  setStep: (currentStep: number) => void;
+  reset: () => void;
+}
+
+const LEGACY_KEY = "atlas-tour-completed";
+
+function readLegacyCompleted(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(LEGACY_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function clearLegacyKey(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(LEGACY_KEY);
+  } catch {
+    // intentionally ignored: best-effort migration cleanup
+  }
+}
+
+export const useTourStore = create<TourStore>()(
+  persist(
+    (set) => ({
+      completed: false,
+      isActive: false,
+      currentStep: 0,
+      setCompleted: (completed) => set({ completed }),
+      setActive: (isActive) => set({ isActive }),
+      setStep: (currentStep) => set({ currentStep }),
+      reset: () => set({ completed: false, isActive: true, currentStep: 0 }),
+    }),
+    {
+      name: "atlas:tour",
+      storage: createJSONStorage(() => localStorage),
+      partialize: (s) => ({ completed: s.completed }),
+      // Carry the boolean from the hand-rolled key written before the
+      // store existed so users who already finished the tour don't
+      // see it replay after upgrade.
+      onRehydrateStorage: () => (state) => {
+        if (state && !state.completed && readLegacyCompleted()) {
+          state.completed = true;
+        }
+        clearLegacyKey();
+      },
+    },
+  ),
+);

--- a/packages/web/src/lib/stores/ui-store.ts
+++ b/packages/web/src/lib/stores/ui-store.ts
@@ -1,13 +1,19 @@
 import { create } from "zustand";
 
 interface UiState {
-  commandMenuOpen: boolean;
-  setCommandMenuOpen: (open: boolean) => void;
-  toggleCommandMenu: () => void;
+  mobileSidebarOpen: boolean;
+  schemaExplorerOpen: boolean;
+  promptLibraryOpen: boolean;
+  setMobileSidebarOpen: (open: boolean) => void;
+  setSchemaExplorerOpen: (open: boolean) => void;
+  setPromptLibraryOpen: (open: boolean) => void;
 }
 
 export const useUiStore = create<UiState>()((set) => ({
-  commandMenuOpen: false,
-  setCommandMenuOpen: (open) => set({ commandMenuOpen: open }),
-  toggleCommandMenu: () => set((s) => ({ commandMenuOpen: !s.commandMenuOpen })),
+  mobileSidebarOpen: false,
+  schemaExplorerOpen: false,
+  promptLibraryOpen: false,
+  setMobileSidebarOpen: (open) => set({ mobileSidebarOpen: open }),
+  setSchemaExplorerOpen: (open) => set({ schemaExplorerOpen: open }),
+  setPromptLibraryOpen: (open) => set({ promptLibraryOpen: open }),
 }));

--- a/packages/web/src/ui/components/admin/mfa-gate-context.tsx
+++ b/packages/web/src/ui/components/admin/mfa-gate-context.tsx
@@ -5,7 +5,8 @@
  * `trigger()`; `MfaEnrollmentDialog` reads the same state and renders the
  * modal.
  *
- * Two policies that don't belong in either the hook layer or the dialog:
+ * State lives in `useMfaGateStore` (zustand). This file composes the store
+ * with two hook-only concerns that can't live in a store action:
  *
  * 1. **Skip on the enrollment page.** When pathname starts with
  *    `/admin/settings/security`, `trigger` is a no-op. Otherwise a
@@ -15,17 +16,22 @@
  *    the gate in `sessionStorage` so the security page can bounce the
  *    user back after enrollment completes. `consumeOriginPath()` reads +
  *    clears the slot atomically.
+ *
+ * `MfaGateProvider` is a thin scope marker — it tracks whether an admin
+ * surface is mounted (so `useMfaGate` can throw on misuse) and clears
+ * state when the admin tree unmounts (so a stale trigger from elsewhere
+ * doesn't auto-open the dialog the next time admin mounts).
  */
 
 import {
   createContext,
   useCallback,
   useContext,
-  useMemo,
-  useState,
+  useEffect,
   type ReactNode,
 } from "react";
 import { usePathname } from "next/navigation";
+import { useMfaGateStore } from "@/lib/stores/mfa-gate-store";
 
 const ENROLLMENT_PATH_PREFIX = "/admin/settings/security";
 
@@ -51,7 +57,7 @@ export interface MfaGateContextValue {
   clear: () => void;
 }
 
-const MfaGateContext = createContext<MfaGateContextValue | null>(null);
+const ScopeContext = createContext<boolean>(false);
 
 /** Read + clear the origin path. Null when no origin was captured (direct nav). */
 export function consumeOriginPath(): string | null {
@@ -70,10 +76,23 @@ export function consumeOriginPath(): string | null {
 }
 
 export function MfaGateProvider({ children }: { children: ReactNode }) {
-  const pathname = usePathname();
-  const [state, setState] = useState<MfaGateState | null>(null);
+  const clear = useMfaGateStore((s) => s.clear);
 
-  const trigger = useCallback(
+  // Tie the dialog's lifecycle to the admin layout the way React Context did
+  // before this state moved to a global store: when the admin tree unmounts,
+  // forget any open gate. The optional-gate variant returns NOOP outside the
+  // provider, so non-admin surfaces can't leave stale state behind.
+  useEffect(() => () => clear(), [clear]);
+
+  return <ScopeContext.Provider value={true}>{children}</ScopeContext.Provider>;
+}
+
+function useTrigger(): (enrollmentUrl: string) => void {
+  const pathname = usePathname();
+  const state = useMfaGateStore((s) => s.state);
+  const setState = useMfaGateStore((s) => s.setState);
+
+  return useCallback(
     (enrollmentUrl: string) => {
       // Skip when already on the enrollment page so the page's own fetches
       // can't re-arm the dialog and trap the user on the destination.
@@ -82,34 +101,23 @@ export function MfaGateProvider({ children }: { children: ReactNode }) {
       // Idempotent: the first failed fetch wins. Concurrent fan-out
       // (parallel admin queries on a fresh page load) shouldn't stomp the
       // origin path that the first failure captured.
-      setState((prev) => {
-        if (prev) return prev;
-        if (typeof window !== "undefined") {
-          try {
-            const origin = pathname ?? window.location.pathname;
-            window.sessionStorage.setItem(ORIGIN_PATH_KEY, origin);
-          } catch {
-            // intentionally ignored: sessionStorage write can throw in
-            // private mode; the dialog still opens, the user just doesn't
-            // get the redirect-back nicety.
-          }
+      if (state) return;
+
+      if (typeof window !== "undefined") {
+        try {
+          const origin = pathname ?? window.location.pathname;
+          window.sessionStorage.setItem(ORIGIN_PATH_KEY, origin);
+        } catch {
+          // intentionally ignored: sessionStorage write can throw in
+          // private mode; the dialog still opens, the user just doesn't
+          // get the redirect-back nicety.
         }
-        return { enrollmentUrl };
-      });
+      }
+
+      setState({ enrollmentUrl });
     },
-    [pathname],
+    [pathname, state, setState],
   );
-
-  const clear = useCallback(() => {
-    setState(null);
-  }, []);
-
-  const value = useMemo<MfaGateContextValue>(
-    () => ({ state, trigger, clear }),
-    [state, trigger, clear],
-  );
-
-  return <MfaGateContext.Provider value={value}>{children}</MfaGateContext.Provider>;
 }
 
 /**
@@ -121,13 +129,17 @@ export function MfaGateProvider({ children }: { children: ReactNode }) {
  * conversation views) should use {@link useMfaGateOptional} instead.
  */
 export function useMfaGate(): MfaGateContextValue {
-  const ctx = useContext(MfaGateContext);
-  if (!ctx) {
+  const inScope = useContext(ScopeContext);
+  const state = useMfaGateStore((s) => s.state);
+  const clear = useMfaGateStore((s) => s.clear);
+  const trigger = useTrigger();
+
+  if (!inScope) {
     throw new Error(
       "useMfaGate must be used inside <MfaGateProvider>. Mount it in the admin layout.",
     );
   }
-  return ctx;
+  return { state, trigger, clear };
 }
 
 /**
@@ -137,8 +149,13 @@ export function useMfaGate(): MfaGateContextValue {
  * (e.g. embedded in the chat) without throwing on every fetch.
  */
 export function useMfaGateOptional(): MfaGateContextValue {
-  const ctx = useContext(MfaGateContext);
-  return ctx ?? NOOP_GATE;
+  const inScope = useContext(ScopeContext);
+  const state = useMfaGateStore((s) => s.state);
+  const clear = useMfaGateStore((s) => s.clear);
+  const trigger = useTrigger();
+
+  if (!inScope) return NOOP_GATE;
+  return { state, trigger, clear };
 }
 
 const NOOP_GATE: MfaGateContextValue = {

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -42,6 +42,7 @@ import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { parseSuggestions } from "../lib/helpers";
 import { ErrorBoundary } from "./error-boundary";
+import { useUiStore } from "@/lib/stores/ui-store";
 
 /* Static SVG icons — hoisted to avoid recreation on every render */
 const MenuIcon = (
@@ -142,11 +143,13 @@ export function AtlasChat() {
   const [input, setInput] = useState("");
   const [conversationId, setConversationId] = useState<string | null>(null);
   const [transientWarning, setTransientWarning] = useState("");
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [loadingConversation, setLoadingConversation] = useState(false);
   const [passwordDialogDismissed, setPasswordDialogDismissed] = useState(false);
-  const [schemaExplorerOpen, setSchemaExplorerOpen] = useState(false);
-  const [promptLibraryOpen, setPromptLibraryOpen] = useState(false);
+  const setMobileSidebarOpen = useUiStore((s) => s.setMobileSidebarOpen);
+  const schemaExplorerOpen = useUiStore((s) => s.schemaExplorerOpen);
+  const setSchemaExplorerOpen = useUiStore((s) => s.setSchemaExplorerOpen);
+  const promptLibraryOpen = useUiStore((s) => s.promptLibraryOpen);
+  const setPromptLibraryOpen = useUiStore((s) => s.setPromptLibraryOpen);
   // Tracks the message text being pinned so the affordance disables
   // mid-flight — without this, a quick double-click fires two POSTs and
   // the second 409s after a visible success toast.
@@ -474,7 +477,7 @@ export function AtlasChat() {
       setMessages(uiMessages);
       setConversationId(id);
       convos.setSelectedId(id);
-      setMobileMenuOpen(false);
+      setMobileSidebarOpen(false);
       // Loaded turns predate this session — no warning frames replay over
       // the wire, so any prior in-memory bucket is stale relative to the
       // freshly loaded message ids.
@@ -493,7 +496,7 @@ export function AtlasChat() {
     setConversationId(null);
     convos.setSelectedId(null);
     setInput("");
-    setMobileMenuOpen(false);
+    setMobileSidebarOpen(false);
     setPythonProgress(new Map());
     warningCtl.reset();
   }
@@ -519,8 +522,6 @@ export function AtlasChat() {
             onStar={(id, starred) => convos.starConversation(id, starred)}
             onConvertToNotebook={(id) => convos.convertToNotebook(id)}
             onNewChat={handleNewChat}
-            mobileOpen={mobileMenuOpen}
-            onMobileClose={() => setMobileMenuOpen(false)}
           />
         )}
 
@@ -533,7 +534,7 @@ export function AtlasChat() {
                     <Button
                       variant="ghost"
                       size="icon"
-                      onClick={() => setMobileMenuOpen(true)}
+                      onClick={() => setMobileSidebarOpen(true)}
                       className="size-11 text-zinc-400 hover:text-zinc-700 md:hidden dark:hover:text-zinc-200"
                       aria-label="Open conversation history"
                     >

--- a/packages/web/src/ui/components/conversations/conversation-sidebar.tsx
+++ b/packages/web/src/ui/components/conversations/conversation-sidebar.tsx
@@ -9,6 +9,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import type { Conversation } from "../../lib/types";
 import { ConversationList } from "./conversation-list";
 import { DemoIndicatorChip } from "../demo-indicator-chip";
+import { useUiStore } from "@/lib/stores/ui-store";
 
 type SidebarFilter = "all" | "saved";
 
@@ -21,8 +22,6 @@ export function ConversationSidebar({
   onStar,
   onConvertToNotebook,
   onNewChat,
-  mobileOpen,
-  onMobileClose,
 }: {
   conversations: Conversation[];
   selectedId: string | null;
@@ -32,20 +31,20 @@ export function ConversationSidebar({
   onStar: (id: string, starred: boolean) => Promise<void>;
   onConvertToNotebook?: (id: string) => Promise<{ id: string }>;
   onNewChat: () => void;
-  mobileOpen: boolean;
-  onMobileClose: () => void;
 }) {
   const [filter, setFilter] = useState<SidebarFilter>("all");
+  const mobileOpen = useUiStore((s) => s.mobileSidebarOpen);
+  const setMobileOpen = useUiStore((s) => s.setMobileSidebarOpen);
 
   // Close mobile sidebar on Escape
   useEffect(() => {
     if (!mobileOpen) return;
     function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape") onMobileClose();
+      if (e.key === "Escape") setMobileOpen(false);
     }
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [mobileOpen, onMobileClose]);
+  }, [mobileOpen, setMobileOpen]);
 
   const starredConversations = conversations.filter((c) => c.starred);
   const filteredConversations = filter === "saved" ? starredConversations : conversations;
@@ -130,7 +129,7 @@ export function ConversationSidebar({
         <>
           <div
             className="fixed inset-0 z-40 bg-black/30 md:hidden"
-            onClick={onMobileClose}
+            onClick={() => setMobileOpen(false)}
           />
           <div className="fixed inset-y-0 left-0 z-50 w-[280px] md:hidden">
             {sidebar}

--- a/packages/web/src/ui/components/signup/signup-context-provider.tsx
+++ b/packages/web/src/ui/components/signup/signup-context-provider.tsx
@@ -1,101 +1,25 @@
 "use client";
 
-import { createContext, useContext, useEffect, useState } from "react";
-import { z } from "zod";
-import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
+import { useEffect } from "react";
+import { useSignupRegionStore } from "@/lib/stores/signup-region-store";
 
-const RegionsResponseSchema = z.object({
-  configured: z.boolean(),
-  availableRegions: z.array(z.unknown()),
-});
-
-export type SignupContextState =
-  | { status: "loading" }
-  | { status: "ready"; showRegion: boolean };
-
-const Context = createContext<SignupContextState>({ status: "loading" });
-
-const CACHE_KEY = "atlas:signup:show-region";
-
-function readCache(): boolean | null {
-  if (typeof window === "undefined") return null;
-  try {
-    const raw = window.sessionStorage.getItem(CACHE_KEY);
-    if (raw === "true") return true;
-    if (raw === "false") return false;
-    return null;
-  } catch {
-    // sessionStorage can throw in private browsing or sandboxed contexts;
-    // fall through to a re-fetch.
-    return null;
-  }
-}
-
-function writeCache(value: boolean): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.sessionStorage.setItem(CACHE_KEY, value ? "true" : "false");
-  } catch {
-    // Best-effort cache; ignore quota / privacy errors.
-  }
-}
-
-function getApiBase(): string {
-  const url = getApiUrl();
-  if (url) return url;
-  if (typeof window !== "undefined") return window.location.origin;
-  return "http://localhost:3000";
-}
-
-function getCredentials(): RequestCredentials {
-  return isCrossOrigin() ? "include" : "same-origin";
-}
+export type { SignupRegionState as SignupContextState } from "@/lib/stores/signup-region-store";
 
 /**
  * Renders once per signup session at the layout level so the residency probe
- * fires a single time — every route then reads the same value via context and
- * the step indicator never reflows between pages. The result is cached in
- * sessionStorage so even a hard reload mid-flow stays consistent.
+ * fires a single time — every route then reads the same value via the store
+ * and the step indicator never reflows between pages. The result is cached in
+ * sessionStorage (via zustand persist) so a hard reload mid-flow stays
+ * consistent.
  */
 export function SignupContextProvider({ children }: { children: React.ReactNode }) {
-  const [state, setState] = useState<SignupContextState>(() => {
-    const cached = readCache();
-    return cached === null ? { status: "loading" } : { status: "ready", showRegion: cached };
-  });
-
+  const init = useSignupRegionStore((s) => s.init);
   useEffect(() => {
-    let cancelled = false;
-    fetch(`${getApiBase()}/api/v1/onboarding/regions`, { credentials: getCredentials() })
-      .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`status ${res.status}`))))
-      .then((raw) => RegionsResponseSchema.parse(raw))
-      .then((data) => {
-        if (cancelled) return;
-        const showRegion = data.configured && data.availableRegions.length > 0;
-        writeCache(showRegion);
-        setState({ status: "ready", showRegion });
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        // Hide the region step by default — mirrors the region page's auto-skip
-        // when the API is unreachable or returns configured=false.
-        console.warn(
-          "[signup] region availability probe failed:",
-          err instanceof Error ? err.message : String(err),
-        );
-        setState({ status: "ready", showRegion: false });
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  return <Context.Provider value={state}>{children}</Context.Provider>;
+    void init();
+  }, [init]);
+  return <>{children}</>;
 }
 
-/**
- * Read the layout-provided signup context. Returns a discriminated union so
- * callers must acknowledge the loading state before reading `showRegion`.
- */
-export function useSignupContext(): SignupContextState {
-  return useContext(Context);
+export function useSignupContext() {
+  return useSignupRegionStore((s) => s.state);
 }

--- a/packages/web/src/ui/components/tour/use-tour.ts
+++ b/packages/web/src/ui/components/tour/use-tour.ts
@@ -1,11 +1,9 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import type { TourStep, TourStatus } from "./types";
 import { TOUR_STEPS } from "./tour-steps";
-
-/** Local storage key used as fallback when the API is unavailable. */
-const TOUR_STORAGE_KEY = "atlas-tour-completed";
+import { useTourStore } from "@/lib/stores/tour-store";
 
 interface UseTourOptions {
   /** Atlas API base URL. */
@@ -45,32 +43,33 @@ export function useTour({
   isAdmin,
   serverTrackingEnabled,
 }: UseTourOptions): UseTourResult {
-  const [isActive, setIsActive] = useState(false);
-  const [currentStep, setCurrentStep] = useState(0);
+  const completed = useTourStore((s) => s.completed);
+  const isActive = useTourStore((s) => s.isActive);
+  const currentStep = useTourStore((s) => s.currentStep);
+  const setCompleted = useTourStore((s) => s.setCompleted);
+  const setActive = useTourStore((s) => s.setActive);
+  const setStep = useTourStore((s) => s.setStep);
+  const resetStore = useTourStore((s) => s.reset);
   const [loading, setLoading] = useState(true);
   const [statusChecked, setStatusChecked] = useState(false);
 
   const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
-
-  // Filter steps based on user role
   const steps = isAdmin ? TOUR_STEPS : TOUR_STEPS.filter((s) => !s.adminOnly);
 
-  // Check tour completion status on mount
+  // Resolve initial status: persisted `completed` short-circuits the API
+  // check. Otherwise probe the server (when tracking is enabled) and fall
+  // back to auto-starting the tour for users who've never seen it.
   useEffect(() => {
     if (statusChecked) return;
 
-    async function checkStatus() {
-      // Check local storage first for fast path
-      try {
-        if (localStorage.getItem(TOUR_STORAGE_KEY) === "true") {
-          setLoading(false);
-          setStatusChecked(true);
-          return;
-        }
-      } catch {
-        // intentionally ignored: localStorage unavailable — continue to API check
-      }
+    if (completed) {
+      setLoading(false);
+      setStatusChecked(true);
+      return;
+    }
 
+    let cancelled = false;
+    async function checkStatus() {
       if (serverTrackingEnabled) {
         try {
           const res = await fetch(`${apiUrl}/api/v1/onboarding/tour-status`, {
@@ -79,12 +78,8 @@ export function useTour({
           if (res.ok) {
             const data: TourStatus = await res.json();
             if (data.tourCompleted) {
-              // Sync to local storage
-              try {
-                localStorage.setItem(TOUR_STORAGE_KEY, "true");
-              } catch {
-                /// intentionally ignored: localStorage may be unavailable in some environments
-              }
+              if (cancelled) return;
+              setCompleted(true);
               setLoading(false);
               setStatusChecked(true);
               return;
@@ -98,25 +93,32 @@ export function useTour({
         }
       }
 
-      // Tour not completed — auto-start
-      setIsActive(true);
-      setCurrentStep(0);
+      if (cancelled) return;
+      // Tour not completed — auto-start.
+      setActive(true);
+      setStep(0);
       setLoading(false);
       setStatusChecked(true);
     }
 
     checkStatus();
-  }, [apiUrl, credentials, serverTrackingEnabled, statusChecked]);
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    apiUrl,
+    credentials,
+    serverTrackingEnabled,
+    statusChecked,
+    completed,
+    setCompleted,
+    setActive,
+    setStep,
+  ]);
 
   async function markComplete() {
-    // Save to local storage immediately
-    try {
-      localStorage.setItem(TOUR_STORAGE_KEY, "true");
-    } catch {
-      /// intentionally ignored: localStorage may be unavailable in some environments
-    }
+    setCompleted(true);
 
-    // Save to server
     if (serverTrackingEnabled) {
       try {
         await fetch(`${apiUrl}/api/v1/onboarding/tour-complete`, {
@@ -134,34 +136,26 @@ export function useTour({
 
   function next() {
     if (currentStep < steps.length - 1) {
-      setCurrentStep((s) => s + 1);
+      setStep(currentStep + 1);
     } else {
       // Last step — complete tour
-      setIsActive(false);
-      markComplete();
+      setActive(false);
+      void markComplete();
     }
   }
 
   function prev() {
-    if (currentStep > 0) {
-      setCurrentStep((s) => s - 1);
-    }
+    if (currentStep > 0) setStep(currentStep - 1);
   }
 
   function skip() {
-    setIsActive(false);
-    markComplete();
+    setActive(false);
+    void markComplete();
   }
 
   function start() {
-    // Reset local storage for replay
-    try {
-      localStorage.removeItem(TOUR_STORAGE_KEY);
-    } catch {
-      /// intentionally ignored: localStorage may be unavailable in some environments
-    }
+    resetStore();
 
-    // Reset server-side status
     if (serverTrackingEnabled) {
       fetch(`${apiUrl}/api/v1/onboarding/tour-reset`, {
         method: "POST",
@@ -174,9 +168,7 @@ export function useTour({
       });
     }
 
-    setCurrentStep(0);
     setStatusChecked(true);
-    setIsActive(true);
   }
 
   return {


### PR DESCRIPTION
## Summary
Picks up the migration backlog noted alongside the zustand scaffolding in #2162. Each migration replaces an existing Context-or-lifted-useState pattern with a focused store under `packages/web/src/lib/stores/`. Net **−61 LOC**.

| Migration | Before | After | Effort |
|-----------|--------|-------|--------|
| Chat drawer toggles | 3 booleans lifted into `AtlasChat` (and duplicated in `app/page.tsx`/`notebook/page.tsx`), prop-drilled to `ConversationSidebar` | `useUiStore` — `mobileSidebarOpen`, `schemaExplorerOpen`, `promptLibraryOpen` | S |
| Signup region probe | React Context + hand-rolled `sessionStorage` cache + `useEffect` probe | `useSignupRegionStore` with `persist` middleware (`sessionStorage`) + `init()` action; the layout `SignupContextProvider` becomes a thin initializer | S |
| MFA gate | React Context holding `state` + `trigger` + `clear` | `useMfaGateStore` for state; `mfa-gate-context.tsx` keeps a minimal scope `Context` so `useMfaGate` still throws on misuse and `useMfaGateOptional` still no-ops outside admin trees | M |
| Tour state | `useState` + manual `localStorage` try/catch for `atlas-tour-completed` | `useTourStore` with `persist` middleware (`localStorage`) + one-shot `onRehydrateStorage` migration from the legacy key | M |

## Notes on each migration
**Chat drawers**: Removes `mobileOpen` / `onMobileClose` from `ConversationSidebar`'s prop signature entirely — every consumer now reads from the store. Three-way state (chat page, notebook page, embedded `AtlasChat`) is unified.

**Signup region probe**: Idempotent `init()` short-circuits when already in `ready` state, so the layout-level effect calling `init()` on mount is safe across navigations within `/signup/*`. Public re-export of `SignupContextState` is kept so `signup-shell.tsx` doesn't change.

**MFA gate**: The pathname-aware `trigger()` (skip on `/admin/settings/security`, idempotent first-write, `sessionStorage` origin capture) stays in the hook layer because `usePathname()` can't run in a store action. The provider unmount-effect clears the gate so the dialog's lifecycle still tracks the admin layout.

**Tour state**: The legacy `atlas-tour-completed` key (a bare `"true"` string, not JSON) is read once on rehydrate and merged into the store so users mid-flight don't see the tour replay after upgrade. After migration the legacy key is deleted.

## Test plan
- [x] `bun run lint`
- [x] `bun run type`
- [x] `bun x syncpack lint`
- [x] `bash scripts/check-template-drift.sh`
- [x] `cd packages/web && bun scripts/test-isolated.ts` (122/122)
- [x] `cd packages/api && bun run scripts/test-isolated.ts --affected` (no api tests affected)
- [x] Existing `mfa-gate-context.test.tsx` (5 tests) and `mfa-enrollment-dialog.test.tsx` (9 tests) pass unchanged

## Deferred
- **Notebook cell state** (`use-notebook.ts`) — High value but L effort: 8+ `useState` calls, dual localStorage+server persistence with debounced saves, complex 3-phase server reconciliation. Big test footprint. Better tackled as its own focused PR after this pattern beds in.
- **Dashboard bridge context** — architectural glue tied to notebook cell state; revisit alongside the notebook migration.