### PR TITLE
docs(roadmap): add 1.4.2 — End-user shakeout parallel track

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -175,6 +175,10 @@ Ordering recommendation: B → D (eval safety net) → C (governance) → E (dis
 
 ---
 
+## Parallel: 1.4.2 — End-user shakeout
+
+Tracker: [milestone #42](https://github.com/AtlasDevHQ/atlas/milestones/42). Bug-hunting and polish from dogfooding Atlas as an end-user/tester after 1.4.1 ships. Mostly admin console rough edges (#2167–#2172, #2175–#2177), BYOT gaps (#2173, #2174), and platform-admin/operational findings (#2165, #2166, #2168). Scope is intentionally elastic — issues land here as bug-bash passes file them. Promote items to a dedicated milestone if scope grows (e.g. BYOT may outgrow #2173/#2174).
+
 ## Closed parallel tracks
 
 - [x] **Multi-method MFA hardening** (6 issues #2082/#2090/#2091/#2092/#2093/#2094) — WebAuthn passkeys + TOTP + trusted-device 30d shipped end-to-end across enrollment, sign-in, governance, telemetry, and recovery. Full detail in `ROADMAP-archive.md`.


### PR DESCRIPTION
## Summary
- Adds [milestone #42](https://github.com/AtlasDevHQ/atlas/milestones/42) — **1.4.2 — End-user shakeout** — to ROADMAP.md as a parallel track to 1.4.1.
- Buckets bug-hunting / dogfood findings discovered while testing 1.4.1.
- 13 issues (#2165–#2177) already assigned at milestone creation: admin polish, BYOT gaps (#2173/#2174), platform-admin/operational.
- Scope is intentionally elastic — ongoing bug-bash passes keep filling it. Promote items to a dedicated milestone if scope grows.

## Test plan
- [x] Roadmap renders correctly on github.com
- [x] All 13 issues show milestone assignment
- [x] No CI impact (docs-only)