### PR TITLE
docs(ci,claude-md): add schema-drift gate to /ci + Database & Migrations rule

### DIFF
--- a/.claude/commands/ci.md
+++ b/.claude/commands/ci.md
@@ -10,6 +10,7 @@ bun x syncpack lint    # Workspace dependency versions consistent
 SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh  # Template drift
 bash scripts/check-security-headers-drift.sh  # Scaffold next.config.ts security-header parity
 bash scripts/check-railway-watch.sh  # Railway watchPatterns cover Dockerfile COPY sources
+bash scripts/check-schema-drift.sh   # Drizzle schema.ts ↔ migrations parity
 ```
 
 Use the full `bun run test` here — `/ci` is the pre-PR check, not an iteration loop. For iteration, use `cd packages/api && bun run scripts/test-isolated.ts --affected` (only tests whose source graph your branch touched — typical 10–60s vs 225s full).
@@ -24,6 +25,7 @@ Use the full `bun run test` here — `/ci` is the pre-PR check, not an iteration
 | Syncpack | `No issues found` |
 | Template drift | `Template drift check passed` |
 | Railway watch | `all deploy Dockerfile COPY sources are covered` |
+| Schema drift | `Schema drift check passed` (every migration table is in `packages/api/src/lib/db/schema.ts`) |
 
 **If any gate fails:**
 
@@ -36,9 +38,11 @@ Use the full `bun run test` here — `/ci` is the pre-PR check, not an iteration
 
 2. After fixing, re-run only the failed gate to verify, then run all gates once more.
 
+   - **Schema drift**: a new migration created/altered a table without a matching definition in `packages/api/src/lib/db/schema.ts`. Add the drizzle table (mirror SQL types, PK, indexes, CHECK constraints) and re-run.
+
 **If all gates pass:**
 
-Report: `CI gates: lint, type, test, syncpack, drift, railway-watch — all pass.`
+Report: `CI gates: lint, type, test, syncpack, drift, railway-watch, schema-drift — all pass.`
 
 ---
 
@@ -73,7 +77,7 @@ gh api repos/AtlasDevHQ/atlas/commits/main/statuses --jq '[.[] | {context, state
 
 **If all checks pass:**
 
-Report: `CI gates: lint, type, test, syncpack, drift, railway-watch — all pass. Remote: CI, Sync Starters, Railway (api/web/docs) — all green.`
+Report: `CI gates: lint, type, test, syncpack, drift, railway-watch, schema-drift — all pass. Remote: CI, Sync Starters, Railway (api/web/docs) — all green.`
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,10 @@ Guidance for Claude Code when working in this repository.
 - [ ] **Flat ESLint config** — `eslint.config.mjs`, not `.eslintrc`
 - [ ] **`FeatureName` registry for admin surfaces** — `<MutationErrorSurface>`, `<EnterpriseUpsell>`, `<FeatureGate>`, `<AdminContentWrapper>`, and `<ReasonDialog>` type their `feature` prop as `FeatureName` from `@/ui/components/admin/feature-registry`. Adding a new admin surface means appending its canonical name to `FEATURE_NAMES` first — then TS guides every call site into agreement. Casing matches the banner copy ("SSO" not "sso"); consolidate duplicates rather than adding variants. The registry is the `tsgo`-enforced source of truth for user-visible feature labels — skip it and typos render in production upsells
 
+### Database & Migrations
+- [ ] **Drizzle schema mirrors every migration** — Adding a `packages/api/src/lib/db/migrations/####_*.sql` file that creates or alters a table requires a matching update to `packages/api/src/lib/db/schema.ts` **in the same PR**. Mirror SQL types, primary keys (composite via `primaryKey({ columns: [...] })`), indexes (`index` / `uniqueIndex`), and CHECK constraints (`check("name", sql\`...\`)`). CI runs `bash scripts/check-schema-drift.sh` and fails if a migration table is missing from `schema.ts`. Without the mirror, the next `drizzle-kit generate` emits a `DROP TABLE` that wipes the table on the next deploy. The drift check is part of `/ci`; never push a migration-only PR
+- [ ] **DROP TABLE migrations are tracked separately** — `scripts/check-schema-drift.sh` excludes tables explicitly dropped by migrations (e.g. `mcp_tokens`, dropped by 0047). When you drop a table, remove its `pgTable` definition from `schema.ts` in the same commit and the drift check stays green
+
 ### Effect.ts (packages/api only)
 - [ ] **Use Context.Tag for services** — All backend services use `class Foo extends Context.Tag("Foo")<Foo, FooShape>()`. Service interfaces are `FooShape` with `readonly` fields
 - [ ] **Layer.effect vs Layer.scoped** — Use `Layer.scoped` when the service has a finalizer (cleanup on shutdown). Use `Layer.effect` for stateless services


### PR DESCRIPTION
## Summary
- Closes the class-of-bug from #2180 — migration landed without matching `schema.ts`, CI on main went red post-merge
- `/ci` now runs `scripts/check-schema-drift.sh` alongside lint/type/test/syncpack/template/security/railway gates
- CLAUDE.md gains a new `### Database & Migrations` section requiring the drizzle mirror in the same PR as the migration
- Memory file `feedback_drizzle_schema_migration_sync.md` so future sessions internalize the rule

## Test plan
- [x] `/ci` skill text reads cleanly with the new gate listed
- [x] CLAUDE.md rule references actual files / actual helpers
- [x] No code changes; docs-only