### PR TITLE
fix(ci): build @useatlas/plugin-sdk before api-tests shard runs (unblock CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,10 +110,13 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      # @useatlas/types resolves to packages/types/dist via its "exports" field,
-      # so api tests can't import it until the package has been built.
-      - name: Build @useatlas/types
-        run: bun run --filter '@useatlas/types' build
+      # @useatlas/types and @useatlas/plugin-sdk both resolve to their
+      # `dist/` via their "exports" field, so api tests can't import them
+      # until the packages have been built. plugin-sdk is required because
+      # `description-rubric.test.ts` imports `@useatlas/yaml-context`,
+      # which imports `@useatlas/plugin-sdk` for the plugin contract.
+      - name: Build @useatlas/types + @useatlas/plugin-sdk
+        run: bun run --filter '@useatlas/types' build && bun run --filter '@useatlas/plugin-sdk' build
 
       - name: Test @atlas/api (shard ${{ matrix.shard }}/4)
         working-directory: packages/api


### PR DESCRIPTION
## Summary
- Unblocks CI on main — api-tests shards 1–4 fail with `Cannot find module '@useatlas/plugin-sdk'` from `plugins/yaml-context/src/index.ts`
- Root cause: `description-rubric.test.ts` (extended in #2190 / E2) imports `@useatlas/yaml-context`, which imports `@useatlas/plugin-sdk`. Both plugin-sdk and types resolve to their `dist/` via the `exports` field, so the test can't resolve the import until the package is built. The api-tests job built only `types`, not `plugin-sdk`
- Locally it passed because `dist/` was cached from prior `bun run type` runs
- Fix: mirror the existing types-build step. The main `ci` job already builds plugin-sdk via "Build SDK packages" (line 62) so its tests aren't affected — only the parallel sharded api-tests job needed the additional step

## Why we missed this in PR review
- E2's local CI run had `dist/` from prior builds; reviewer's CI run hit a fresh runner without the cache
- This is the same shape as the schema-drift bug from #2186 — a CI gate that depended on a build artifact the local `/ci` flow happens to produce as a side effect

## Test plan
- [x] Diff is a single workflow change; replicates an existing pattern
- [x] CI on this branch should be green; main remains red until merged