### PR TITLE
fix(deploy): COPY examples/embedded-mcp-onboarding/package.json in Dockerfiles (unblock Railway)

### DIFF
--- a/deploy/api/Dockerfile
+++ b/deploy/api/Dockerfile
@@ -23,6 +23,7 @@ COPY packages/schemas/package.json packages/schemas/package.json
 COPY apps/docs/package.json apps/docs/package.json
 COPY apps/www/package.json apps/www/package.json
 COPY examples/nextjs-standalone/package.json examples/nextjs-standalone/package.json
+COPY examples/embedded-mcp-onboarding/package.json examples/embedded-mcp-onboarding/package.json
 # Plugins are workspace members — their package.json files must be
 # present for the lockfile to validate during bun ci (--frozen-lockfile).
 COPY plugins/clickhouse/package.json plugins/clickhouse/package.json

--- a/deploy/web/Dockerfile
+++ b/deploy/web/Dockerfile
@@ -23,6 +23,7 @@ COPY packages/schemas/package.json packages/schemas/package.json
 COPY apps/docs/package.json apps/docs/package.json
 COPY apps/www/package.json apps/www/package.json
 COPY examples/nextjs-standalone/package.json examples/nextjs-standalone/package.json
+COPY examples/embedded-mcp-onboarding/package.json examples/embedded-mcp-onboarding/package.json
 COPY plugins/clickhouse/package.json plugins/clickhouse/package.json
 COPY plugins/yaml-context/package.json plugins/yaml-context/package.json
 COPY plugins/daytona/package.json plugins/daytona/package.json

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -14,6 +14,7 @@ COPY packages/react/package.json packages/react/package.json
 COPY apps/docs/package.json apps/docs/package.json
 COPY apps/www/package.json apps/www/package.json
 COPY examples/nextjs-standalone/package.json examples/nextjs-standalone/package.json
+COPY examples/embedded-mcp-onboarding/package.json examples/embedded-mcp-onboarding/package.json
 # Plugins are workspace members — their package.json files must be
 # present for the lockfile to validate during bun ci (--frozen-lockfile).
 COPY plugins/clickhouse/package.json plugins/clickhouse/package.json


### PR DESCRIPTION
## Summary
- 🚨 **Production hotfix** — Railway api + web deploys failing on every push since #2198 merged
- E3 (#2198) added `examples/embedded-mcp-onboarding/` to root `package.json` workspaces but didn't update the deploy Dockerfiles
- `bun ci --frozen-lockfile` aborts at the deps stage: `error: Workspace not found "examples/embedded-mcp-onboarding"`
- Mirrors the existing `examples/nextjs-standalone` COPY pattern

## Files
- `deploy/api/Dockerfile` — gate-enforced
- `deploy/web/Dockerfile` — gate-enforced
- `examples/docker/Dockerfile` — added for consistency (not enforced by `check-dockerfile-workspace.sh` since it doesn't use `bun ci`)

## Pre-existing process gap
`scripts/check-dockerfile-workspace.sh` exists and **does** catch this — it failed locally on the unfixed state with:
```
::error file=deploy/api/Dockerfile::Missing COPY for workspace member examples/embedded-mcp-onboarding/package.json
::error file=deploy/web/Dockerfile::Missing COPY for workspace member examples/embedded-mcp-onboarding/package.json
```
Either the gate didn't run on PR #2198's CI, or it ran and was overridden by an admin merge. Worth a separate investigation issue.

## Test plan
- [x] `bash scripts/check-dockerfile-workspace.sh` passes locally
- [x] Pattern mirrors `examples/nextjs-standalone` line-for-line
- [x] CI on this branch should be green; Railway deploys on main should resume after merge