### PR TITLE
fix(scaffold): copy CLI src/commands + helpers to templates (unblock main Deploy Validation)

### DIFF
--- a/create-atlas/scripts/prepare-templates.sh
+++ b/create-atlas/scripts/prepare-templates.sh
@@ -210,12 +210,26 @@ for tpl in docker nextjs-standalone; do
 done
 
 # ── Step 5d: Copy CLI source files referenced by bin/atlas.ts ────────
-# bin/atlas.ts imports ../src/env-check and ../src/progress.
+# bin/atlas.ts imports both top-level files (../src/env-check,
+# ../src/progress, ../src/completions, ../src/validate, ../src/doctor)
+# AND every command (../src/commands/{init,plugin,migrate,migrate-import,
+# diff,export,import,improve,learn,query}). Static imports fail at
+# scaffold smoke-test time if any of these are missing, even when the
+# command isn't invoked — bun resolves static imports eagerly.
 # Must happen AFTER src/ is populated (Steps 2-4 wipe and rebuild src/).
 CLI_SRC="$MONOREPO/packages/cli/src"
 for tpl in docker nextjs-standalone; do
-  cp "$CLI_SRC/env-check.ts" "$TEMPLATES/$tpl/src/"
-  cp "$CLI_SRC/progress.ts"  "$TEMPLATES/$tpl/src/"
+  cp "$CLI_SRC/env-check.ts"   "$TEMPLATES/$tpl/src/"
+  cp "$CLI_SRC/progress.ts"    "$TEMPLATES/$tpl/src/"
+  cp "$CLI_SRC/completions.ts" "$TEMPLATES/$tpl/src/"
+  cp "$CLI_SRC/validate.ts"    "$TEMPLATES/$tpl/src/"
+  cp "$CLI_SRC/doctor.ts"      "$TEMPLATES/$tpl/src/"
+
+  rm -rf "$TEMPLATES/$tpl/src/commands"
+  cp -r "$CLI_SRC/commands" "$TEMPLATES/$tpl/src/commands"
+  # Tests don't ship with scaffolded apps.
+  find "$TEMPLATES/$tpl/src/commands" -name '__tests__' -type d -exec rm -rf {} + 2>/dev/null || true
+  find "$TEMPLATES/$tpl/src/commands" -name '*.test.ts' -delete 2>/dev/null || true
 done
 
 # ── Step 5e: Copy @useatlas/schemas source into ALL templates ────────


### PR DESCRIPTION
## Summary
- 🚨 **Main hotfix** — Deploy Validation has been failing on main since C3 (#2202) merged. Same `Cannot find module '../src/commands/plugin'` error that's been silently broken in scaffold templates since the CLI Phase 2 refactor (#1228), only just surfaced because earlier 1.4.1 PRs didn't trip the "Detect scaffold-relevant changes" gate
- Root cause: `bin/atlas.ts` static-imports many `../src/*` modules but `prepare-templates.sh` was only copying `env-check.ts` + `progress.ts`. Scaffolded apps blew up on every invocation
- Fix: extend Step 5d to copy `src/{completions,validate,doctor}.ts` + the full `src/commands/` directory (recursive, tests stripped)

## Test plan
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` passes locally — 515 files verified
- [x] `create-atlas/templates/nextjs-standalone/src/commands/` now contains all 10 command modules
- [x] Templates are gitignored, so this PR's diff is just the script change
- [x] CI on this branch should produce green Scaffold (docker) + Scaffold (vercel)

## Why we missed this for so long
Scaffold tests are gated by "Detect scaffold-relevant changes" — they SKIP unless the PR touches deploy/, create-atlas/, or specific paths. Most 1.4.1 PRs touched `packages/api`, `packages/mcp`, `packages/web` only — none scaffold-relevant. C3 modified `plugins/mcp/src/init/*.ts` which IS scaffold-relevant, so the scaffold tests finally ran.

This is the 4th CI gap shipped in 1.4.x:
- #2186 — schema-drift not in /ci
- #2201 — plugin-sdk dist not built before api-tests
- #2206 (open) — dockerfile-workspace gate didn't block PR #2198
- This — long-broken scaffold templates exposed by gate-skip

Common shape: silent breakage that depends on cached state or skipped gates. Worth a separate look at whether `bin/atlas.ts` should be bundled instead of ad-hoc-copied.