### PR TITLE
chore: bump @useatlas/types ^0.0.18 → ^0.0.19 across consumer refs (unblock Deploy Validation)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -261,7 +261,7 @@
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^5.96.2",
-        "@useatlas/types": "^0.0.18",
+        "@useatlas/types": "^0.0.19",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "radix-ui": "^1.4.3",
@@ -329,7 +329,7 @@
       "name": "@useatlas/sdk",
       "version": "0.0.13",
       "dependencies": {
-        "@useatlas/types": "^0.0.18",
+        "@useatlas/types": "^0.0.19",
       },
     },
     "packages/types": {
@@ -4347,10 +4347,6 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typespec/ts-http-runtime/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
-    "@useatlas/react/@useatlas/types": ["@useatlas/types@0.0.18", "", {}, "sha512-VwJ8twZ3K6NuiuycGndklOlHKkQaF+DbyNZhFVDDVwvYmf/N63klZFlO71Oy1kZFHQZe61+RMiRWrCyy+udr0A=="],
-
-    "@useatlas/sdk/@useatlas/types": ["@useatlas/types@0.0.18", "", {}, "sha512-VwJ8twZ3K6NuiuycGndklOlHKkQaF+DbyNZhFVDDVwvYmf/N63klZFlO71Oy1kZFHQZe61+RMiRWrCyy+udr0A=="],
 
     "@vercel/sandbox/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 

--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -24,7 +24,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.0.7",
     "@useatlas/sdk": "^0.0.12",
-    "@useatlas/types": "^0.0.18",
+    "@useatlas/types": "^0.0.19",
     "@better-auth/api-key": "^1.6.9",
     "@better-auth/oauth-provider": "^1.6.9",
     "@better-auth/passkey": "^1.6.9",

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -21,7 +21,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.0.7",
     "@useatlas/sdk": "^0.0.12",
-    "@useatlas/types": "^0.0.18",
+    "@useatlas/types": "^0.0.19",
     "ai": "^6.0.141",
     "@better-auth/api-key": "^1.6.9",
     "@better-auth/oauth-provider": "^1.6.9",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -83,7 +83,7 @@
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^5.96.2",
-    "@useatlas/types": "^0.0.18",
+    "@useatlas/types": "^0.0.19",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "radix-ui": "^1.4.3",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -49,6 +49,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@useatlas/types": "^0.0.18"
+    "@useatlas/types": "^0.0.19"
   }
 }


### PR DESCRIPTION
## Summary
- types-v0.0.19 was tagged + published earlier today (#2191's APPROVAL_RULE_SURFACES + APPROVAL_REQUEST_SURFACES exports)
- 0.0.x semver is exact-match, so ^0.0.18 in consumer refs won't pull 0.0.19 — keeps scaffold-CI red
- Bump `@useatlas/types` to `^0.0.19` in `packages/sdk`, `packages/react`, and both `create-atlas/templates/*/package.json`
- Refresh bun.lock per `feedback_bun_lock.md`

This is the deferred step from the version-bump-ordering playbook — refs bumped only after the publish completed.

## Test plan
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — passes
- [ ] Deploy Validation goes green on this PR