### PR TITLE
fix(types,plugin-sdk): #2199 — auto-build dist on bun install via prepare hook

### DIFF
--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "build": "rm -rf dist && bun build src/index.ts src/types.ts src/helpers.ts src/ai.ts src/hono.ts src/testing.ts --outdir dist --target node --packages external && bun x tsc -p tsconfig.build.json",
     "prepare": "bun run build",
-    "prepublishOnly": "bun run build",
     "test": "bun test src/__tests__/types.test.ts && bun test src/__tests__/infer.test.ts && bun test src/__tests__/testing.test.ts"
   },
   "exports": {

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rm -rf dist && bun build src/index.ts src/types.ts src/helpers.ts src/ai.ts src/hono.ts src/testing.ts --outdir dist --target node --packages external && bun x tsc -p tsconfig.build.json",
+    "prepare": "bun run build",
     "prepublishOnly": "bun run build",
     "test": "bun test src/__tests__/types.test.ts && bun test src/__tests__/infer.test.ts && bun test src/__tests__/testing.test.ts"
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -4,7 +4,8 @@
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {
-    "build": "rm -rf dist && bun build src/index.ts src/auth.ts src/conversation.ts src/connection.ts src/action.ts src/scheduled-task.ts src/errors.ts src/semantic.ts src/share.ts src/billing.ts src/dashboard.ts src/mode.ts src/starter-prompt.ts src/integrations.ts src/email-provider.ts src/mcp.ts --outdir dist --root src --target node --packages external && bun x tsc -p tsconfig.build.json"
+    "build": "rm -rf dist && bun build src/index.ts src/auth.ts src/conversation.ts src/connection.ts src/action.ts src/scheduled-task.ts src/errors.ts src/semantic.ts src/share.ts src/billing.ts src/dashboard.ts src/mode.ts src/starter-prompt.ts src/integrations.ts src/email-provider.ts src/mcp.ts --outdir dist --root src --target node --packages external && bun x tsc -p tsconfig.build.json",
+    "prepare": "bun run build"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary
Closes #2199.

The issue's filed diagnosis (a regression from #2190 where `AtlasMcpTool` was renamed/moved) was a misread — the symbol IS exported correctly from `@useatlas/plugin-sdk` and the workspace barrel re-exports it via `export type { AtlasMcpTool }`. The actual root cause is **stale workspace `dist/`**:

- Neither `build` nor `prepublishOnly` runs on `bun install`; only `prepare` does, and these packages didn't declare one
- A fresh clone (or a pull that touches `packages/types/src/` or `packages/plugin-sdk/src/`) leaves the consumed `dist/` files outdated relative to source
- `bun x tsgo --noEmit` resolves `@useatlas/types` / `@useatlas/plugin-sdk` via their `package.json#exports` → `./dist/index.d.ts` → finds the *old* declarations, not what the new source claims
- The root `bun run type` script chains the workspace builds (`bun run --filter '@useatlas/types' build && bun run --filter '@useatlas/plugin-sdk' build && ...` then `tsgo --noEmit`), so CI passes — running tsgo directly tripped the rake

## Fix
Add `"prepare": "bun run build"` to:
- `packages/types/package.json`
- `packages/plugin-sdk/package.json`

Also remove the now-redundant `"prepublishOnly": "bun run build"` from `plugin-sdk` — `prepare` covers both install-time and publish-time. Keeping both was the npm equivalent of running the build twice (with `rm -rf dist` between), meaning the artifact tested by the publish workflow's explicit `bun run build && bun run test` step would not match the artifact `npm publish` ultimately packs.

`prepare` runs:
- After `bun install` in workspace dev — fixes fresh-clone / fresh-pull tsgo errors at the root
- Before `npm publish` — keeps the published tarball in sync with source
- **Not** on downstream consumers — they pull the pre-built tarball from the registry; lifecycle hooks don't execute on package consumers

## Verification
- `rm -rf packages/types/dist packages/plugin-sdk/dist && bun install` → both `dist/` reappear (prepare hook fired)
- `cd packages/api && bun x tsgo --noEmit` → exit 0, no errors
- `/ci` static gates: lint ✓, syncpack ✓, template-drift ✓, schema-drift ✓, railway-watch ✓, dockerfile-workspace ✓, security-headers ✓
- All 6 `/pr-review-toolkit` agents passed; silent-failure-hunter caught the redundant `prepublishOnly` on plugin-sdk (now removed)

## Test plan
- [x] tsgo clean on packages/api after a clean install with no manual build
- [x] All `/ci` gates pass
- [x] No source changes — tests unaffected (affected runner reports no test impact)