### PR TITLE
fix(api): #2169 — dedupe duplicate "E-commerce KPIs" prompt libraries

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -19950,6 +19950,31 @@
               }
             }
           },
+          "409": {
+            "description": "A collection with this name already exists in the workspace (#2169)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "429": {
             "description": "Rate limit exceeded",
             "content": {
@@ -20137,6 +20162,31 @@
           },
           "404": {
             "description": "Collection not found or internal database not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Renaming would collide with an existing collection in the workspace (#2169)",
             "content": {
               "application/json": {
                 "schema": {

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -8838,8 +8838,7 @@
                       "items": {
                         "type": "string",
                         "enum": [
-                          "demo_industry_setting",
-                          "demo_prompt_collections"
+                          "demo_industry_setting"
                         ]
                       }
                     }

--- a/packages/api/src/api/__tests__/admin-prompts-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-prompts-audit.test.ts
@@ -153,6 +153,57 @@ describe("POST /api/v1/admin/prompts — audit emission", () => {
       industry: "saas",
     });
   });
+
+  it("returns 409 duplicate_name when the unique index from #2169 trips (matches by SQLSTATE 23505)", async () => {
+    // The new (COALESCE(org_id, ''), lower(name)) index in migration 0054
+    // surfaces as a Postgres unique_violation. Without translation in
+    // admin-prompts.ts the route would 500; we want a friendly 409.
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.startsWith("INSERT INTO prompt_collections")) {
+        const err = new Error('duplicate key value violates unique constraint "prompt_collections_org_name_uniq"');
+        (err as { code?: string }).code = "23505";
+        throw err;
+      }
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/prompts/", {
+        name: "Existing",
+        industry: "saas",
+      }),
+    );
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body.error).toBe("duplicate_name");
+    expect(body.message).toContain("Existing");
+    // Audit must NOT fire for failed creates — we only emit on success.
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+
+  it("does NOT mistake a non-23505 INSERT failure for a duplicate (regression guard)", async () => {
+    // Make sure the 23505 catch is keyed on SQLSTATE, not message
+    // contents. A pool exhaustion error must propagate as 500, not 409.
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.startsWith("INSERT INTO prompt_collections")) {
+        const err = new Error("connection terminated unexpectedly");
+        (err as { code?: string }).code = "57P01";
+        throw err;
+      }
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("POST", "/api/v1/admin/prompts/", {
+        name: "Anything",
+        industry: "saas",
+      }),
+    );
+
+    expect(res.status).toBe(500);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -196,6 +247,29 @@ describe("PATCH /api/v1/admin/prompts/:id — audit emission", () => {
       adminRequest("PATCH", "/api/v1/admin/prompts/col-builtin", { name: "Try" }),
     );
     expect(res.status).toBe(403);
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 duplicate_name when a rename trips the unique index from #2169", async () => {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.startsWith("SELECT * FROM prompt_collections")) {
+        return [collectionRow({ id: "col-1", name: "Old Name" })];
+      }
+      if (sql.startsWith("UPDATE prompt_collections")) {
+        const err = new Error('duplicate key value violates unique constraint "prompt_collections_org_name_uniq"');
+        (err as { code?: string }).code = "23505";
+        throw err;
+      }
+      return [];
+    });
+
+    const res = await app.fetch(
+      adminRequest("PATCH", "/api/v1/admin/prompts/col-1", { name: "Already Taken" }),
+    );
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("duplicate_name");
     expect(mockLogAdminAction).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/api/__tests__/onboarding.test.ts
+++ b/packages/api/src/api/__tests__/onboarding.test.ts
@@ -912,7 +912,7 @@ describe("POST /api/v1/onboarding/use-demo", () => {
     ).toBe(false);
   });
 
-  it("does NOT seed org-scoped builtin prompt collections (#2169 — globals are visible to org-with-demo via the listing query)", async () => {
+  it("does NOT seed org-scoped builtin prompt collections — globals are visible to org-with-demo via the listing query", async () => {
     // /use-demo previously copied each global builtin (org_id IS NULL,
     // is_builtin = true) into the calling org's namespace. The
     // `org-with-demo` listing query already returns global builtins

--- a/packages/api/src/api/__tests__/onboarding.test.ts
+++ b/packages/api/src/api/__tests__/onboarding.test.ts
@@ -912,20 +912,41 @@ describe("POST /api/v1/onboarding/use-demo", () => {
     ).toBe(false);
   });
 
-  it("seeds demo prompt collections for the ecommerce industry", async () => {
+  it("does NOT seed org-scoped builtin prompt collections (#2169 — globals are visible to org-with-demo via the listing query)", async () => {
+    // /use-demo previously copied each global builtin (org_id IS NULL,
+    // is_builtin = true) into the calling org's namespace. The
+    // `org-with-demo` listing query already returns global builtins
+    // matching the demo industry alongside org-scoped customs (see
+    // packages/api/src/lib/prompts/scoping.ts → buildCollectionsListQuery),
+    // so the per-org copy was redundant — and surfaced as the duplicate
+    // "E-commerce KPIs" library reported in #2169 (one row from the
+    // global seed at startup, one from the per-org copy here). The
+    // /use-demo flow must not touch prompt_collections at all.
     await request("/api/v1/onboarding/use-demo", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({}),
     });
 
-    // The seedDemoPromptCollections function queries for builtin collections
-    const builtinQuery = mockInternalQuery.mock.calls.find(
-      (call) => typeof call[0] === "string" && call[0].includes("is_builtin = true") && call[0].includes("industry"),
+    // No write into prompt_collections / prompt_items.
+    const promptCollectionWrites = mockInternalQuery.mock.calls.filter(
+      (call) => typeof call[0] === "string" && call[0].includes("INSERT INTO prompt_collections"),
     );
-    expect(builtinQuery).toBeDefined();
-    const params = builtinQuery![1] as unknown[];
-    expect(params[0]).toBe("ecommerce");
+    expect(promptCollectionWrites.length).toBe(0);
+
+    const promptItemWrites = mockInternalQuery.mock.calls.filter(
+      (call) => typeof call[0] === "string" && call[0].includes("INSERT INTO prompt_items"),
+    );
+    expect(promptItemWrites.length).toBe(0);
+
+    // No read of prompt_collections either — the previous seed function
+    // first SELECTed the global builtins for this industry, so a
+    // residual call here would mean the function is still being invoked
+    // (just dropping inserts because of the mock returning a stub row).
+    const promptCollectionReads = mockInternalQuery.mock.calls.filter(
+      (call) => typeof call[0] === "string" && call[0].includes("FROM prompt_collections"),
+    );
+    expect(promptCollectionReads.length).toBe(0);
   });
 
   it("rejects when auth mode is not managed", async () => {
@@ -1227,45 +1248,11 @@ describe("POST /api/v1/onboarding/use-demo", () => {
     expect(data.partialFailures).toEqual([]);
   });
 
-  it("partialFailures lists BOTH steps when both phase-4 decorations fail", async () => {
-    mockSetSetting.mockImplementation(async () => { throw new Error("settings down"); });
-    const originalImpl = mockInternalQuery.getMockImplementation();
-    mockInternalQuery.mockImplementation(async (sql: string) => {
-      if (typeof sql === "string" && sql.includes("is_builtin = true")) {
-        throw new Error("prompt collections table missing");
-      }
-      return [{ id: "__demo__" }];
-    });
-    const res = await request("/api/v1/onboarding/use-demo", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({}),
-    });
-    expect(res.status).toBe(201);
-    const data = await json(res);
-    expect(data.partialFailures).toContain("demo_industry_setting");
-    expect(data.partialFailures).toContain("demo_prompt_collections");
-    if (originalImpl) mockInternalQuery.mockImplementation(originalImpl);
-  });
-
-  it("succeeds even when prompt collection seeding fails (non-fatal)", async () => {
-    const originalImpl = mockInternalQuery.getMockImplementation();
-    mockInternalQuery.mockImplementation(async (sql: string) => {
-      if (typeof sql === "string" && sql.includes("is_builtin = true")) {
-        throw new Error("prompt_collections table missing");
-      }
-      return [{ id: "__demo__" }];
-    });
-    const res = await request("/api/v1/onboarding/use-demo", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ demoType: "cybersec" }),
-    });
-    expect(res.status).toBe(201);
-    const data = await json(res);
-    expect(data.connectionId).toBe("__demo__");
-    if (originalImpl) mockInternalQuery.mockImplementation(originalImpl);
-  });
+  // The pre-#2169 phase 4 ran two decorations (demo_industry_setting +
+  // demo_prompt_collections) and tracked both in `partialFailures`.
+  // After #2169 the prompt-collection seed is gone (the global builtins
+  // are visible to org-with-demo orgs already), so the only decoration
+  // left is `demo_industry_setting` — covered by the test above.
 
   it("returns 500 with requestId when DB upsert fails", async () => {
     mockInternalQuery.mockImplementation(async () => { throw new Error("connection reset"); });

--- a/packages/api/src/api/routes/admin-prompts.ts
+++ b/packages/api/src/api/routes/admin-prompts.ts
@@ -24,6 +24,19 @@ import {
 
 const log = createLogger("admin-prompts");
 
+/**
+ * SQLSTATE 23505 = unique_violation. The `prompt_collections_org_name_uniq`
+ * index introduced in migration 0054 (#2169) collapses `COALESCE(org_id, '')`
+ * + `lower(name)`, so two collections in the same workspace can't share a
+ * case-insensitive name. We translate the violation into a typed result so
+ * create/rename routes can return a 409 instead of leaking a generic 500.
+ */
+const PG_UNIQUE_VIOLATION = "23505";
+
+function isUniqueViolation(err: unknown): boolean {
+  return (err as { code?: string } | null | undefined)?.code === PG_UNIQUE_VIOLATION;
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -182,6 +195,10 @@ const createCollectionRoute = createRoute({
       description: "Internal database not configured",
       content: { "application/json": { schema: ErrorSchema } },
     },
+    409: {
+      description: "A collection with this name already exists in the workspace (#2169)",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
     500: {
       description: "Internal server error",
       content: { "application/json": { schema: ErrorSchema } },
@@ -233,6 +250,10 @@ const updateCollectionRoute = createRoute({
     429: {
       description: "Rate limit exceeded",
       content: { "application/json": { schema: AuthErrorSchema } },
+    },
+    409: {
+      description: "Renaming would collide with an existing collection in the workspace (#2169)",
+      content: { "application/json": { schema: ErrorSchema } },
     },
     500: {
       description: "Internal server error",
@@ -531,8 +552,29 @@ adminPrompts.openapi(createCollectionRoute, async (c) => {
     // until the admin publishes; published mode creates them live.
     const status = atlasMode === "developer" ? "draft" : "published";
 
-    const rows = yield* queryEffect<Record<string, unknown>>(`INSERT INTO prompt_collections (org_id, name, industry, description, is_builtin, status) VALUES ($1, $2, $3, $4, false, $5) RETURNING *`, [orgId ?? null, name, industry, description, status]);
-    const created = toPromptCollection(rows[0]);
+    // Map the new `prompt_collections_org_name_uniq` violation (#2169)
+    // to a 409 with a name-collision message. Without this catch the
+    // bare INSERT surfaces as a generic 500 — fine when no constraint
+    // existed, but unhelpful now that an admin can trigger the
+    // violation by typing an existing name.
+    const insertOutcome = yield* queryEffect<Record<string, unknown>>(
+      `INSERT INTO prompt_collections (org_id, name, industry, description, is_builtin, status) VALUES ($1, $2, $3, $4, false, $5) RETURNING *`,
+      [orgId ?? null, name, industry, description, status],
+    ).pipe(
+      Effect.map((rows) => ({ kind: "ok" as const, rows })),
+      Effect.catchAll((err) =>
+        isUniqueViolation(err)
+          ? Effect.succeed({ kind: "duplicate" as const })
+          : Effect.fail(err),
+      ),
+    );
+    if (insertOutcome.kind === "duplicate") {
+      return c.json(
+        { error: "duplicate_name", message: `A prompt collection named "${name}" already exists in this workspace.`, requestId },
+        409,
+      );
+    }
+    const created = toPromptCollection(insertOutcome.rows[0]);
     logAdminAction({
       actionType: ADMIN_ACTIONS.prompt.collectionCreate,
       targetType: "prompt",
@@ -576,9 +618,28 @@ adminPrompts.openapi(updateCollectionRoute, async (c) => {
     updateParams.push(id);
     const idIdx = paramIdx;
 
-    const updated = yield* queryEffect<Record<string, unknown>>(`UPDATE prompt_collections SET ${setClauses.join(", ")} WHERE id = $${idIdx} RETURNING *`, updateParams);
-    if (updated.length === 0) return c.json({ error: "not_found", message: "Collection was deleted before update completed." }, 404);
-    const collection = toPromptCollection(updated[0]);
+    // Renames can hit the unique index from #2169 if the new name
+    // matches another collection in the same workspace (case-insensitive).
+    // Translate to 409 so the admin sees an actionable message.
+    const updateOutcome = yield* queryEffect<Record<string, unknown>>(
+      `UPDATE prompt_collections SET ${setClauses.join(", ")} WHERE id = $${idIdx} RETURNING *`,
+      updateParams,
+    ).pipe(
+      Effect.map((rows) => ({ kind: "ok" as const, rows })),
+      Effect.catchAll((err) =>
+        isUniqueViolation(err)
+          ? Effect.succeed({ kind: "duplicate" as const })
+          : Effect.fail(err),
+      ),
+    );
+    if (updateOutcome.kind === "duplicate") {
+      return c.json(
+        { error: "duplicate_name", message: `A prompt collection with that name already exists in this workspace.`, requestId },
+        409,
+      );
+    }
+    if (updateOutcome.rows.length === 0) return c.json({ error: "not_found", message: "Collection was deleted before update completed." }, 404);
+    const collection = toPromptCollection(updateOutcome.rows[0]);
     logAdminAction({
       actionType: ADMIN_ACTIONS.prompt.collectionUpdate,
       targetType: "prompt",

--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -804,7 +804,7 @@ onboarding.openapi(
         }),
       );
 
-      const partialFailures: ("demo_industry_setting")[] = settingResult.ok ? [] : [settingResult.step];
+      const partialFailures = settingResult.ok ? [] : [settingResult.step];
 
       _resetWhitelists();
 

--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -42,63 +42,13 @@ const log = createLogger("onboarding");
 // releases supported a `demoType` picker covering `demo` (SaaS CRM, 3 tables),
 // `cybersec` (Sentinel Security, 62 tables), and `ecommerce` (NovaMart, 52
 // tables). The body field is gone; the route always provisions ecommerce.
-
-/**
- * Seed org-scoped prompt collections matching the demo industry.
- * Copies the global builtins for that industry into the org's namespace
- * so they appear in the prompt library immediately after demo setup.
- */
-async function seedDemoPromptCollections(orgId: string, industry: string): Promise<void> {
-  // Find global builtin collections for this industry
-  const builtins = await internalQuery<{ id: string; name: string; description: string; sort_order: number }>(
-    `SELECT id, name, description, sort_order FROM prompt_collections
-     WHERE is_builtin = true AND industry = $1 AND org_id IS NULL`,
-    [industry],
-  );
-
-  for (const builtin of builtins) {
-    try {
-      // Skip if org already has a collection with this name
-      const existing = await internalQuery<{ id: string }>(
-        `SELECT id FROM prompt_collections WHERE name = $1 AND org_id = $2`,
-        [builtin.name, orgId],
-      );
-      if (existing.length > 0) continue;
-
-      // Create org-scoped copy
-      const inserted = await internalQuery<{ id: string }>(
-        `INSERT INTO prompt_collections (name, industry, description, is_builtin, sort_order, org_id, status)
-         VALUES ($1, $2, $3, true, $4, $5, 'published')
-         RETURNING id`,
-        [builtin.name, industry, builtin.description, builtin.sort_order, orgId],
-      );
-      if (!inserted[0]?.id) {
-        log.warn({ collection: builtin.name, orgId }, "Failed to seed demo prompt collection — INSERT returned no rows");
-        continue;
-      }
-
-      // Copy prompt items from the global collection (independent inserts — parallelize)
-      const items = await internalQuery<{ question: string; description: string; category: string; sort_order: number }>(
-        `SELECT question, description, category, sort_order FROM prompt_items
-         WHERE collection_id = $1 ORDER BY sort_order ASC`,
-        [builtin.id],
-      );
-      const collectionId = inserted[0].id;
-      await Promise.all(items.map((item) =>
-        internalQuery(
-          `INSERT INTO prompt_items (collection_id, question, description, category, sort_order)
-           VALUES ($1, $2, $3, $4, $5)`,
-          [collectionId, item.question, item.description, item.category, item.sort_order],
-        ),
-      ));
-    } catch (err) {
-      log.warn(
-        { err: errorMessage(err), collection: builtin.name, orgId },
-        "Failed to seed demo prompt collection — skipping to next",
-      );
-    }
-  }
-}
+//
+// Pre-#2169 we also copied the global builtin prompt_collections rows into
+// the calling org's namespace here. That copy was redundant — the
+// `org-with-demo` listing query in `lib/prompts/scoping.ts` already
+// surfaces global builtins matching the demo industry — and produced the
+// duplicate "E-commerce KPIs" library reported in #2169 (one global
+// row + one per-org copy, both visible to /admin/prompts).
 
 /** Valid connection ID: lowercase alphanumeric, hyphens, underscores, 1-64 chars. Must not start with underscore (reserved for internal IDs). */
 const CONNECTION_ID_PATTERN = /^[a-z][a-z0-9_-]{0,62}[a-z0-9]$/;
@@ -278,12 +228,14 @@ const UseDemoResponseSchema = z.object({
   maskedUrl: z.string(),
   entitiesImported: z.number(),
   /**
-   * Names of post-commit decoration steps that failed (industry setting,
-   * prompt collection seed). Always present as an array — empty when the
-   * full install succeeded — so consumers can call `.includes()` or
-   * `.length` without optional-chaining gymnastics.
+   * Names of post-commit decoration steps that failed. Today the only
+   * decoration is `demo_industry_setting`; #2169 dropped the redundant
+   * per-org prompt-collection seed (the `org-with-demo` listing query
+   * already returns the global builtins). Always present as an array —
+   * empty when the full install succeeded — so consumers can call
+   * `.includes()` or `.length` without optional-chaining gymnastics.
    */
-  partialFailures: z.array(z.enum(["demo_industry_setting", "demo_prompt_collections"])),
+  partialFailures: z.array(z.enum(["demo_industry_setting"])),
 });
 
 // Strict-but-empty: validation parses to {} and silently strips unknown keys
@@ -833,36 +785,26 @@ onboarding.openapi(
         log.warn({ err: errorMessage(err), requestId }, "Demo connection saved but runtime registration failed");
       }
 
-      // Write demo_industry setting + seed prompt collections concurrently.
-      // Both are independent post-commit decorations — failure leaves the
-      // workspace queryable but with reduced features (no demoIndustry-aware
-      // banners, no pre-seeded prompts). We surface that through a
-      // `partialFailures` array on the 201 response so the frontend can show
-      // a degraded-state notice instead of pretending everything worked.
-      const phase4Results = yield* Effect.all([
-        Effect.tryPromise({
-          try: () => setSetting("ATLAS_DEMO_INDUSTRY", industry, user?.id, orgId),
-          catch: (err) => err instanceof Error ? err : new Error(String(err)),
-        }).pipe(
-          Effect.map(() => ({ ok: true as const, step: "demo_industry_setting" as const })),
-          Effect.catchAll((err) => {
-            log.warn({ err: err.message, requestId, orgId, industry }, "Failed to write demo_industry setting — non-fatal");
-            return Effect.succeed({ ok: false as const, step: "demo_industry_setting" as const });
-          }),
-        ),
-        Effect.tryPromise({
-          try: () => seedDemoPromptCollections(orgId, industry),
-          catch: (err) => err instanceof Error ? err : new Error(String(err)),
-        }).pipe(
-          Effect.map(() => ({ ok: true as const, step: "demo_prompt_collections" as const })),
-          Effect.catchAll((err) => {
-            log.warn({ err: err.message, requestId, orgId, industry }, "Failed to seed demo prompt collections — non-fatal");
-            return Effect.succeed({ ok: false as const, step: "demo_prompt_collections" as const });
-          }),
-        ),
-      ], { concurrency: "unbounded" });
+      // Write demo_industry setting. Independent post-commit decoration —
+      // failure leaves the workspace queryable but with no demoIndustry-aware
+      // banners. Surfaced through a `partialFailures` array on the 201
+      // response so the frontend can show a degraded-state notice instead
+      // of pretending everything worked. The `org-with-demo` listing query
+      // (lib/prompts/scoping.ts) keys off this setting, so the demo
+      // industry's global builtin prompt collections show up automatically
+      // — there's no per-org prompt seed to do here (#2169).
+      const settingResult = yield* Effect.tryPromise({
+        try: () => setSetting("ATLAS_DEMO_INDUSTRY", industry, user?.id, orgId),
+        catch: (err) => err instanceof Error ? err : new Error(String(err)),
+      }).pipe(
+        Effect.map(() => ({ ok: true as const, step: "demo_industry_setting" as const })),
+        Effect.catchAll((err) => {
+          log.warn({ err: err.message, requestId, orgId, industry }, "Failed to write demo_industry setting — non-fatal");
+          return Effect.succeed({ ok: false as const, step: "demo_industry_setting" as const });
+        }),
+      );
 
-      const partialFailures = phase4Results.filter((r) => !r.ok).map((r) => r.step);
+      const partialFailures: ("demo_industry_setting")[] = settingResult.ok ? [] : [settingResult.step];
 
       _resetWhitelists();
 

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -299,6 +299,7 @@ describe("migrateAuthTables", () => {
             { name: "0051_oauth_client_rate_limits.sql" },
             { name: "0052_approval_rules_surface.sql" },
             { name: "0053_oauth_client_workspace_grants.sql" },
+            { name: "0054_prompt_collections_dedup_unique.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -777,6 +777,12 @@ describe("runSeeds", () => {
     // Should check for existing collections
     const selectPrompt = queries.find((q) => q.includes("SELECT id FROM prompt_collections"));
     expect(selectPrompt).toBeDefined();
+    // Existence probe is scoped to the global namespace (#2169). Pinned
+    // here so a future refactor can't loosen the filter back to a bare
+    // `name = $1 AND is_builtin = true` — that form would short-circuit
+    // the global insert if a workspace with leftover org-scoped builtin
+    // copies (predating migration 0054) had run runSeeds again.
+    expect(selectPrompt).toContain("org_id IS NULL");
 
     // Should insert 3 built-in collections
     const inserts = queries.filter((q) => q.includes("INSERT INTO prompt_collections"));

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -79,7 +79,7 @@ describe("runMigrations", () => {
 
     const count = await runMigrations(pool);
 
-    expect(count).toBe(54);
+    expect(count).toBe(55);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -162,6 +162,7 @@ describe("runMigrations", () => {
         "0051_oauth_client_rate_limits.sql",
         "0052_approval_rules_surface.sql",
         "0053_oauth_client_workspace_grants.sql",
+        "0054_prompt_collections_dedup_unique.sql",
       ],
     });
 
@@ -888,5 +889,63 @@ describe("0047_drop_mcp_tokens.sql", () => {
     // didn't expect. There are no FKs to mcp_tokens today, but the
     // bound here is a future-proof invariant.
     expect(sql).not.toMatch(/DROP TABLE[^;]*CASCADE/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: 0054_prompt_collections_dedup_unique.sql (#2169)
+// ---------------------------------------------------------------------------
+//
+// Pin the dedup-then-add-index ordering. The unique index would error
+// out on existing duplicates if it ran before the cleanup DELETE, so
+// dropping or reordering either statement would silently break the
+// migration on workspaces that hit the original /use-demo bug.
+
+describe("0054_prompt_collections_dedup_unique.sql", () => {
+  const filePath = path.join(MIGRATIONS_DIR, "0054_prompt_collections_dedup_unique.sql");
+
+  it("file exists in the migrations directory", () => {
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  // Strip line comments so regex assertions can't be tripped by prose
+  // headers that mention SQL keywords (e.g. the migration's preamble
+  // explains why we "DELETE before CREATE UNIQUE INDEX" — without
+  // stripping, a greedy regex would match the comment first).
+  function stripComments(sql: string): string {
+    return sql
+      .split("\n")
+      .map((line) => line.replace(/--.*$/, ""))
+      .join("\n");
+  }
+
+  it("removes redundant org-scoped builtin copies before creating the unique index", () => {
+    const sql = stripComments(fs.readFileSync(filePath, "utf-8"));
+
+    const deleteIdx = sql.search(/DELETE FROM prompt_collections/i);
+    const indexIdx = sql.search(/CREATE UNIQUE INDEX[^;]*prompt_collections/i);
+
+    expect(deleteIdx).toBeGreaterThan(-1);
+    expect(indexIdx).toBeGreaterThan(-1);
+    expect(deleteIdx).toBeLessThan(indexIdx);
+  });
+
+  it("scopes the unique index by org and case-insensitive name", () => {
+    const sql = stripComments(fs.readFileSync(filePath, "utf-8"));
+
+    expect(sql).toMatch(/CREATE UNIQUE INDEX[^;]*prompt_collections[^;]*lower\s*\(\s*name\s*\)/i);
+    expect(sql).toMatch(/COALESCE\s*\(\s*org_id/i);
+  });
+
+  it("dedup keeps the oldest row by created_at (FK-safe)", () => {
+    const sql = stripComments(fs.readFileSync(filePath, "utf-8"));
+
+    // Generic same-org dedup: items must be reparented to the kept row
+    // before the duplicate row is dropped, so prompt_items survive.
+    expect(sql).toMatch(/UPDATE prompt_items/i);
+    // "Oldest first" expressed as ORDER BY created_at ASC (a windowed
+    // SELECT, not an aggregate MIN) so the keeper id can be picked
+    // deterministically with a tiebreaker on id.
+    expect(sql).toMatch(/ORDER BY[\s\S]*?created_at\s+ASC/i);
   });
 });

--- a/packages/api/src/lib/db/migrate.ts
+++ b/packages/api/src/lib/db/migrate.ts
@@ -278,7 +278,11 @@ async function seedPromptLibrary(pool: Queryable): Promise<void> {
     // Pre-#2169 deployments could have org-scoped builtin copies with the
     // same name; without this filter, those would short-circuit the insert
     // and the global builtin would never get seeded on a fresh install
-    // that runs alongside legacy data.
+    // that runs alongside legacy data. Note that the unique index added
+    // in migration 0054 (`prompt_collections_org_name_uniq`) makes a
+    // future regression here impossible to silently introduce — a
+    // duplicate-creating loosening of this filter would fail-fast on
+    // INSERT instead of producing two visible rows.
     const existing = await pool.query(
       "SELECT id FROM prompt_collections WHERE name = $1 AND is_builtin = true AND org_id IS NULL",
       [collection.name],

--- a/packages/api/src/lib/db/migrate.ts
+++ b/packages/api/src/lib/db/migrate.ts
@@ -274,8 +274,13 @@ async function seedPromptLibrary(pool: Queryable): Promise<void> {
 
   for (let ci = 0; ci < collections.length; ci++) {
     const collection = collections[ci];
+    // Scope the existence probe to the global namespace (org_id IS NULL).
+    // Pre-#2169 deployments could have org-scoped builtin copies with the
+    // same name; without this filter, those would short-circuit the insert
+    // and the global builtin would never get seeded on a fresh install
+    // that runs alongside legacy data.
     const existing = await pool.query(
-      "SELECT id FROM prompt_collections WHERE name = $1 AND is_builtin = true",
+      "SELECT id FROM prompt_collections WHERE name = $1 AND is_builtin = true AND org_id IS NULL",
       [collection.name],
     );
     if (existing.rows.length > 0) continue;

--- a/packages/api/src/lib/db/migrations/0054_prompt_collections_dedup_unique.sql
+++ b/packages/api/src/lib/db/migrations/0054_prompt_collections_dedup_unique.sql
@@ -1,0 +1,110 @@
+-- Migration 0054: Dedupe prompt_collections + add unique index (#2169).
+--
+-- The reported repro: /admin/prompts on a freshly /use-demo-seeded SaaS
+-- workspace shows two "E-commerce KPIs" libraries side by side. Cause:
+--   1. `runSeeds()` at startup inserts the global built-in collections
+--      (org_id IS NULL, is_builtin = true) — one row per industry.
+--   2. The pre-#2169 /use-demo handler (`seedDemoPromptCollections`)
+--      then *copied* every global builtin matching the demo industry
+--      into the calling org's namespace (org_id = <orgId>, is_builtin =
+--      true). Each copy was an exact replica of the global row.
+--   3. The `org-with-demo` branch of `buildCollectionsListQuery` (see
+--      packages/api/src/lib/prompts/scoping.ts) returns BOTH rows in a
+--      single SELECT — its predicate accepts org_id IS NULL OR org_id =
+--      $1 for matching-industry builtins — so /admin/prompts renders
+--      the same library twice.
+--
+-- Fix has two halves: the route stops creating the per-org copies (see
+-- the same PR's edit to packages/api/src/api/routes/onboarding.ts), and
+-- this migration cleans up the rows that already exist on workspaces
+-- that hit the bug. We then add a unique index so any future regression
+-- (concurrent /use-demo, a new seed path, an admin import) fails loudly
+-- instead of silently doubling the listing.
+--
+-- Ordering matters: dedupe BEFORE the unique index. A workspace with
+-- existing duplicates would error on the CREATE UNIQUE INDEX otherwise,
+-- leaving the migration broken on every replay.
+
+-- ---------------------------------------------------------------------------
+-- Step 1 — drop org-scoped builtin copies that match a global builtin.
+-- ---------------------------------------------------------------------------
+--
+-- The cascade on prompt_items.collection_id (FK ON DELETE CASCADE) drops
+-- the per-org copies of the items along with their parent. The user
+-- still sees the items via the global collection's items, returned by
+-- the same `org-with-demo` listing query.
+--
+-- Match key: (lower(name), industry). `is_builtin = true` rows are
+-- read-only at the admin layer (admin-prompts.ts returns 403 on edits),
+-- so the org-scoped copy can never have diverged from the global —
+-- dropping it is lossless.
+DELETE FROM prompt_collections org_copy
+USING prompt_collections global
+WHERE org_copy.org_id IS NOT NULL
+  AND org_copy.is_builtin = true
+  AND global.org_id IS NULL
+  AND global.is_builtin = true
+  AND lower(org_copy.name) = lower(global.name)
+  AND org_copy.industry = global.industry;
+
+-- ---------------------------------------------------------------------------
+-- Step 2 — fold any remaining same-org duplicates into the oldest row.
+-- ---------------------------------------------------------------------------
+--
+-- Catches duplicates the step 1 cleanup didn't handle: same org_id, same
+-- lower(name) (e.g. a custom collection a user manually created twice
+-- via a double-clicked "Create" button). Keep the oldest row by
+-- created_at; reparent prompt_items belonging to newer rows so we don't
+-- cascade-delete them; then drop the newer rows.
+--
+-- The CTE picks the keeper per (org_id, lower(name)) bucket. Rows where
+-- org_id IS NULL collapse into the same NULL bucket — there should only
+-- ever be one global row per name, but we belt-and-suspenders this so
+-- the unique index below can't be tripped by a stray duplicate global.
+WITH keepers AS (
+  SELECT
+    COALESCE(org_id, '') AS org_key,
+    lower(name) AS name_key,
+    (
+      SELECT id FROM prompt_collections inner_pc
+      WHERE COALESCE(inner_pc.org_id, '') = COALESCE(outer_pc.org_id, '')
+        AND lower(inner_pc.name) = lower(outer_pc.name)
+      ORDER BY inner_pc.created_at ASC, inner_pc.id ASC
+      LIMIT 1
+    ) AS keeper_id
+  FROM prompt_collections outer_pc
+  GROUP BY COALESCE(org_id, ''), lower(name)
+  HAVING COUNT(*) > 1
+)
+UPDATE prompt_items
+SET collection_id = keepers.keeper_id
+FROM keepers, prompt_collections dup
+WHERE prompt_items.collection_id = dup.id
+  AND COALESCE(dup.org_id, '') = keepers.org_key
+  AND lower(dup.name) = keepers.name_key
+  AND dup.id <> keepers.keeper_id;
+
+DELETE FROM prompt_collections dup
+USING (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY COALESCE(org_id, ''), lower(name)
+      ORDER BY created_at ASC, id ASC
+    ) AS row_num
+  FROM prompt_collections
+) ranked
+WHERE dup.id = ranked.id
+  AND ranked.row_num > 1;
+
+-- ---------------------------------------------------------------------------
+-- Step 3 — enforce uniqueness going forward.
+-- ---------------------------------------------------------------------------
+--
+-- (org_id, lower(name)) — case-insensitive so "E-commerce KPIs" and
+-- "E-COMMERCE KPIs" can't coexist within the same workspace. Globals
+-- (org_id IS NULL) collapse into a single bucket via COALESCE, so only
+-- one global row per case-insensitive name is allowed. Different orgs
+-- can each have their own "E-commerce KPIs" custom (different org_id).
+CREATE UNIQUE INDEX IF NOT EXISTS prompt_collections_org_name_uniq
+  ON prompt_collections (COALESCE(org_id, ''), lower(name));

--- a/packages/api/src/lib/db/migrations/0054_prompt_collections_dedup_unique.sql
+++ b/packages/api/src/lib/db/migrations/0054_prompt_collections_dedup_unique.sql
@@ -2,8 +2,10 @@
 --
 -- The reported repro: /admin/prompts on a freshly /use-demo-seeded SaaS
 -- workspace shows two "E-commerce KPIs" libraries side by side. Cause:
---   1. `runSeeds()` at startup inserts the global built-in collections
---      (org_id IS NULL, is_builtin = true) — one row per industry.
+--   1. `seedPromptLibrary()` at startup (called from `runSeeds()` in
+--      packages/api/src/lib/db/migrate.ts) inserts the global built-in
+--      collections (org_id IS NULL, is_builtin = true) — one row per
+--      industry.
 --   2. The pre-#2169 /use-demo handler (`seedDemoPromptCollections`)
 --      then *copied* every global builtin matching the demo industry
 --      into the calling org's namespace (org_id = <orgId>, is_builtin =
@@ -30,14 +32,19 @@
 -- ---------------------------------------------------------------------------
 --
 -- The cascade on prompt_items.collection_id (FK ON DELETE CASCADE) drops
--- the per-org copies of the items along with their parent. The user
--- still sees the items via the global collection's items, returned by
--- the same `org-with-demo` listing query.
+-- the per-org copies of the items along with their parent. We do NOT
+-- reparent items here (unlike step 2 below) because the items being
+-- dropped are themselves verbatim copies of the global collection's
+-- items — the global parent is still present, and the `org-with-demo`
+-- listing query already returns its items, so the user observes no
+-- semantic loss.
 --
 -- Match key: (lower(name), industry). `is_builtin = true` rows are
--- read-only at the admin layer (admin-prompts.ts returns 403 on edits),
+-- read-only at the admin layer (admin-prompts.ts returns 403 on edits
+-- to is_builtin = true rows; see lines 556, 602, 625, 667, 716, 745),
 -- so the org-scoped copy can never have diverged from the global —
--- dropping it is lossless.
+-- dropping it is lossless. If a future schema change opens edits on
+-- builtin copies, this step needs to gain a reparent before the delete.
 DELETE FROM prompt_collections org_copy
 USING prompt_collections global
 WHERE org_copy.org_id IS NOT NULL

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -493,7 +493,12 @@ export const promptCollections = pgTable(
     check("chk_prompt_collections_status", sql`status IN ('published', 'draft', 'archived')`),
     // #2169: collapse org_id NULL into a single bucket so globals can't
     // duplicate, and lower-case the name so casing variants can't coexist
-    // within the same workspace. See migration 0054.
+    // within the same workspace. The `COALESCE(org_id, '')` form is
+    // load-bearing — a plain `(org_id, lower(name))` would let multiple
+    // global rows (org_id IS NULL) share a name, since SQL treats NULLs
+    // as distinct in unique indexes. Removing this index reopens the
+    // duplicate-libraries bug. See migration 0054 for the dedup +
+    // index-creation migration.
     uniqueIndex("prompt_collections_org_name_uniq").on(
       sql`COALESCE(${t.orgId}, '')`,
       sql`lower(${t.name})`,

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -491,6 +491,13 @@ export const promptCollections = pgTable(
     index("idx_prompt_collections_org").on(t.orgId),
     index("idx_prompt_collections_builtin").on(t.isBuiltin).where(sql`is_builtin = true`),
     check("chk_prompt_collections_status", sql`status IN ('published', 'draft', 'archived')`),
+    // #2169: collapse org_id NULL into a single bucket so globals can't
+    // duplicate, and lower-case the name so casing variants can't coexist
+    // within the same workspace. See migration 0054.
+    uniqueIndex("prompt_collections_org_name_uniq").on(
+      sql`COALESCE(${t.orgId}, '')`,
+      sql`lower(${t.name})`,
+    ),
   ],
 );
 


### PR DESCRIPTION
## Summary
- Closes #2169. /admin/prompts on a Demo-seeded SaaS workspace showed the same "E-commerce KPIs" library twice — once from the global builtin (`org_id IS NULL`, seeded at startup) and once from a per-org copy that the pre-#2169 `/use-demo` flow blindly inserted into the calling org's namespace. The `org-with-demo` listing query (`packages/api/src/lib/prompts/scoping.ts`) returns both because its predicate accepts `org_id IS NULL OR org_id = $1` for matching-industry builtins.
- Drop `seedDemoPromptCollections` (function + call). The global builtins are already visible to org-with-demo orgs via the listing query, and `is_builtin = true` rows are read-only at the admin layer (`admin-prompts.ts` 403s edits), so the org-scoped copies could never have diverged from the global — dropping them is lossless.
- New migration `0054_prompt_collections_dedup_unique.sql` cleans up existing duplicates and hardens the schema:
  - Step 1: delete org-scoped `is_builtin = true` rows whose `(lower(name), industry)` matches a global builtin.
  - Step 2: fold any remaining same-`(org_id, lower(name))` duplicates into the oldest row (reparent `prompt_items` first so cascade-delete doesn't take them).
  - Step 3: `CREATE UNIQUE INDEX prompt_collections_org_name_uniq ON prompt_collections (COALESCE(org_id, ''), lower(name))`. Mirrored in `schema.ts`; drift check passes.
- Tightened `seedPromptLibrary`'s existence probe to `AND org_id IS NULL` so legacy per-org copies can't short-circuit the global insert on fresh installs.
- Dropped `demo_prompt_collections` from the `partialFailures` enum (only `demo_industry_setting` left); regenerated `apps/docs/openapi.json` accordingly.

## Test plan
- [x] `bun run test` (full suite) — passes
- [x] `cd packages/api && bun run scripts/test-isolated.ts --affected` — 12/12 files green
- [x] `bash scripts/check-schema-drift.sh` — passes (67 tables matched, 1 dropped excluded)
- [x] `bash scripts/check-template-drift.sh`, `check-security-headers-drift.sh`, `check-railway-watch.sh`, `check-dockerfile-workspace.sh` — all pass
- [x] OpenAPI spec regenerated (`bun run --filter '@atlas/api' openapi:extract`)
- [x] `bun run lint`, `bun run type`, `bun x syncpack lint` — pass
- [ ] Verify on a real /use-demo: only one "E-commerce KPIs" library renders in /admin/prompts.
- [ ] Verify migration applies cleanly on a workspace with pre-existing duplicates (insert a duplicate `(org_id, 'E-commerce KPIs', is_builtin = true)` row manually before applying).
- [ ] Verify the unique index rejects a second `INSERT` with the same `(org_id, lower(name))`.