### PR TITLE
fix(api): migration 0054 — replace broken keepers CTE blocking API boot

### DIFF
--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -954,4 +954,30 @@ describe("0054_prompt_collections_dedup_unique.sql", () => {
     // deterministically with a tiebreaker on id.
     expect(sql).toMatch(/ORDER BY[\s\S]*?created_at\s+ASC/i);
   });
+
+  it("keepers CTE uses DISTINCT ON rather than GROUP BY + correlated subquery", () => {
+    // The first version of this CTE used `GROUP BY COALESCE(org_id, ''),
+    // lower(name) HAVING COUNT(*) > 1` with a correlated subquery that
+    // referenced bare `outer_pc.org_id` / `outer_pc.name`. Postgres
+    // rejects that at plan time with `subquery uses ungrouped column
+    // from outer query` — every API container failed to boot until the
+    // CTE was rewritten.
+    //
+    // Pin the working shape (DISTINCT ON over the bucket key) and
+    // explicitly forbid the broken shape so a future "simplification"
+    // can't reintroduce the planning error.
+    const sql = stripComments(fs.readFileSync(filePath, "utf-8"));
+
+    expect(sql).toMatch(
+      /WITH\s+keepers\s+AS\s*\(\s*SELECT\s+DISTINCT\s+ON\s*\(\s*COALESCE\s*\(\s*org_id\s*,\s*''\s*\)\s*,\s*lower\s*\(\s*name\s*\)\s*\)/i,
+    );
+
+    // No GROUP BY anywhere in the keepers CTE — the structural mistake
+    // was specifically grouping by expressions and then referencing the
+    // bare column from a correlated subquery. Forbidding GROUP BY in
+    // the CTE precludes that whole class.
+    const keepersBlock = sql.match(/WITH\s+keepers\s+AS\s*\([\s\S]*?\)/i)?.[0] ?? "";
+    expect(keepersBlock).not.toMatch(/\bGROUP\s+BY\b/i);
+    expect(keepersBlock).not.toMatch(/\bouter_pc\b/i);
+  });
 });

--- a/packages/api/src/lib/db/migrations/0054_prompt_collections_dedup_unique.sql
+++ b/packages/api/src/lib/db/migrations/0054_prompt_collections_dedup_unique.sql
@@ -64,24 +64,21 @@ WHERE org_copy.org_id IS NOT NULL
 -- created_at; reparent prompt_items belonging to newer rows so we don't
 -- cascade-delete them; then drop the newer rows.
 --
--- The CTE picks the keeper per (org_id, lower(name)) bucket. Rows where
--- org_id IS NULL collapse into the same NULL bucket — there should only
--- ever be one global row per name, but we belt-and-suspenders this so
--- the unique index below can't be tripped by a stray duplicate global.
+-- DISTINCT ON (bucket-key) returns one keeper per bucket per the
+-- trailing ORDER BY (oldest created_at, id tiebreak). Rows where
+-- org_id IS NULL collapse into a single NULL bucket via COALESCE —
+-- there should only ever be one global row per name, but the
+-- belt-and-suspenders keeps the unique index below safe from a stray
+-- duplicate global. Single-row buckets are emitted too; the UPDATE
+-- excludes self-matches via `dup.id <> keepers.keeper_id`, so they
+-- become no-ops.
 WITH keepers AS (
-  SELECT
+  SELECT DISTINCT ON (COALESCE(org_id, ''), lower(name))
+    id AS keeper_id,
     COALESCE(org_id, '') AS org_key,
-    lower(name) AS name_key,
-    (
-      SELECT id FROM prompt_collections inner_pc
-      WHERE COALESCE(inner_pc.org_id, '') = COALESCE(outer_pc.org_id, '')
-        AND lower(inner_pc.name) = lower(outer_pc.name)
-      ORDER BY inner_pc.created_at ASC, inner_pc.id ASC
-      LIMIT 1
-    ) AS keeper_id
-  FROM prompt_collections outer_pc
-  GROUP BY COALESCE(org_id, ''), lower(name)
-  HAVING COUNT(*) > 1
+    lower(name) AS name_key
+  FROM prompt_collections
+  ORDER BY COALESCE(org_id, ''), lower(name), created_at ASC, id ASC
 )
 UPDATE prompt_items
 SET collection_id = keepers.keeper_id


### PR DESCRIPTION
## Summary

- The keepers CTE in `0054_prompt_collections_dedup_unique.sql` (PR #2217) was invalid SQL — a `GROUP BY <expression>` outer query with a correlated subquery referencing the bare ungrouped column. Postgres rejects this at plan time with `subquery uses ungrouped column "outer_pc.org_id" from outer query`, regardless of row count.
- Every API region (us / eu / apac) failed to boot the moment the migration ran, hit the 5-attempt retry ceiling, and Railway killed each replica after 14 healthcheck misses. Existing replicas kept serving from the prior image so users weren't down — but new deploys to the API services were blocked.
- Replace the CTE with `SELECT DISTINCT ON (bucket-key)` over the same trailing ORDER BY. Outcome is identical: one keeper row per `(COALESCE(org_id,''), lower(name))` bucket, single-row buckets pass through as no-ops via the existing `dup.id <> keepers.keeper_id` self-match exclusion in the downstream UPDATE.

## Reproduction

The bug is plan-time, deterministic on any Postgres regardless of data.

```sql
-- Original (rejected at plan time)
WITH keepers AS (
  SELECT
    COALESCE(org_id, '') AS org_key,
    lower(name) AS name_key,
    (
      SELECT id FROM prompt_collections inner_pc
      WHERE COALESCE(inner_pc.org_id, '') = COALESCE(outer_pc.org_id, '')   -- ← outer_pc.org_id ungrouped
        AND lower(inner_pc.name) = lower(outer_pc.name)                    -- ← outer_pc.name ungrouped
      ORDER BY inner_pc.created_at ASC, inner_pc.id ASC
      LIMIT 1
    ) AS keeper_id
  FROM prompt_collections outer_pc
  GROUP BY COALESCE(org_id, ''), lower(name)
  HAVING COUNT(*) > 1
)
SELECT * FROM keepers;
-- ERROR: subquery uses ungrouped column "outer_pc.org_id" from outer query
```

The outer query groups by *expressions* (`COALESCE(org_id,'')`, `lower(name)`), but the correlated subquery references *bare columns* (`outer_pc.org_id`, `outer_pc.name`). Those bare columns are ungrouped after `GROUP BY`, so the subquery is invalid.

## Fix

```sql
WITH keepers AS (
  SELECT DISTINCT ON (COALESCE(org_id, ''), lower(name))
    id AS keeper_id,
    COALESCE(org_id, '') AS org_key,
    lower(name) AS name_key
  FROM prompt_collections
  ORDER BY COALESCE(org_id, ''), lower(name), created_at ASC, id ASC
)
```

`DISTINCT ON` returns one row per bucket per the trailing ORDER BY (oldest created_at, id tiebreak). Single-row buckets are emitted but eliminated as no-ops by the downstream UPDATE's `dup.id <> keepers.keeper_id` clause.

## Validation

End-to-end against local docker Postgres (`postgres:16-alpine`, the prod image):

- ✅ Original shape reproduces the production error verbatim
- ✅ New shape plans cleanly (`EXPLAIN` returns a sane plan)
- ✅ Full migration on seeded duplicates: org-scoped builtin copies dropped, case-different same-org dups folded, items reparented from non-keepers to keepers, singles preserved, unique index created
- ✅ Idempotent on already-clean data (`UPDATE 0`, `DELETE 0`)

## Tests

Added a structural pin in `migrate.test.ts` that:
- Asserts the keepers CTE uses `DISTINCT ON (COALESCE(org_id,''), lower(name))`
- Forbids `GROUP BY` and references to `outer_pc` inside the keepers block

This catches a regression to the broken shape *without* needing a real Postgres. The broader gap — running every migration end-to-end against a live Postgres in CI — is tracked separately as #2219, since proper coverage requires CI service-container plumbing beyond this hot-fix's scope.

`bun test packages/api/src/lib/db/__tests__/migrate.test.ts` — 57 pass / 0 fail.

## CI gates

All 8 local gates pass: lint, type, full test suite, syncpack, template drift, security headers drift, railway watch, schema drift.

## Test plan

- [x] Migration applies cleanly on a fresh Postgres
- [x] Migration applies cleanly on a Postgres with the seeded duplicates (the #2169 repro)
- [x] Migration is idempotent (re-running on deduped data is no-op)
- [x] `migrate.test.ts` 57/57 green
- [x] Full `bun run test` green
- [ ] Verified after merge: api / api-eu / api-apac deploys succeed on Railway

## Related

- Caused by: PR #2217 (the original 0054 dedup migration that introduced the broken CTE)
- Sibling deploy-gate hole: #2206 (Railway watchPatterns vs Dockerfile drift)
- Follow-up: #2219 (real-Postgres migration smoke in CI — would have caught this pre-merge)