### PR TITLE
fix(web): #2170 — Create Role permission checkboxes don't toggle

### DIFF
--- a/e2e/browser/admin-roles-create.spec.ts
+++ b/e2e/browser/admin-roles-create.spec.ts
@@ -14,8 +14,11 @@ import { test, expect, type Page, type Route } from "@playwright/test";
  *   1. Clicking a permission checkbox flips it to data-state="checked"
  *      and a second click flips it back (no double-fire in either
  *      direction).
- *   2. The submitted POST body carries the selected permissions verbatim.
- *   3. The new role row renders after the dialog closes.
+ *   2. Clicking the friendly label text toggles via the htmlFor binding.
+ *   3. The submit body carries exactly the permissions whose final
+ *      state is checked — toggle-then-untoggle drops the perm.
+ *   4. Zero-permission submit surfaces the zod .min(1) validation
+ *      error and never reaches the wire.
  *
  * Page-level mocking (not real DB rows) — the persistent admin session
  * created by global-setup.ts is itself how this test logs in, and
@@ -23,8 +26,11 @@ import { test, expect, type Page, type Route } from "@playwright/test";
  * license layer, which isn't part of the dev seed. Mocking keeps the
  * spec hermetic.
  *
- * The `@llm` tag opts this spec into the serial worker so other admin-
- * surface mocks aren't raced.
+ * `@llm` tags this spec for the segmentation convention used elsewhere
+ * in the suite (e.g. the `test:browser:llm` script). The CI worker
+ * count is set globally in playwright.config.ts and does not key on
+ * the tag — this is a documentation/grep convention, not an isolation
+ * mechanism.
  */
 
 interface MockRole {
@@ -50,13 +56,12 @@ const ALL_PERMISSIONS = [
 ];
 
 interface InstalledMocks {
-  state: MockRole[];
-  postCalls: Array<{ body: Record<string, unknown> }>;
+  postBodies: Array<Record<string, unknown>>;
 }
 
 async function installRolesMocks(page: Page): Promise<InstalledMocks> {
   const state: MockRole[] = [];
-  const postCalls: Array<{ body: Record<string, unknown> }> = [];
+  const postBodies: Array<Record<string, unknown>> = [];
 
   await page.route(
     /\/api\/v1\/admin\/roles(?:\?[^/]*)?$/,
@@ -64,7 +69,7 @@ async function installRolesMocks(page: Page): Promise<InstalledMocks> {
       const req = route.request();
       if (req.method() === "POST") {
         const body = JSON.parse(req.postData() ?? "{}") as Record<string, unknown>;
-        postCalls.push({ body });
+        postBodies.push(body);
         const created: MockRole = {
           id: `role_mock_${state.length + 1}`,
           orgId: "org-1",
@@ -101,7 +106,23 @@ async function installRolesMocks(page: Page): Promise<InstalledMocks> {
     },
   );
 
-  return { state, postCalls };
+  return { postBodies };
+}
+
+async function openCreateRoleDialog(page: Page) {
+  await page.goto("/admin/roles");
+  await expect(
+    page.getByRole("heading", { name: "Roles", level: 1 }),
+  ).toBeVisible({ timeout: 15_000 });
+  // Substring matching on the accessible name picks the page-level
+  // header button only — the empty-state's "Create First Role" doesn't
+  // contain "Create Role" as a substring, and the dialog's submit
+  // button isn't rendered until the dialog opens. `.first()` is belt-
+  // and-suspenders.
+  await page.getByRole("button", { name: "Create Role" }).first().click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  return dialog;
 }
 
 test.describe("Admin roles — Create Role permission checkboxes (#2170) @llm", () => {
@@ -110,43 +131,33 @@ test.describe("Admin roles — Create Role permission checkboxes (#2170) @llm", 
   test("permission checkbox toggles on click and persists through submit", async ({
     page,
   }) => {
-    const { postCalls } = await installRolesMocks(page);
-    await page.goto("/admin/roles");
+    const { postBodies } = await installRolesMocks(page);
+    const dialog = await openCreateRoleDialog(page);
 
-    await expect(page.locator("h1", { hasText: "Roles" })).toBeVisible({
-      timeout: 15_000,
-    });
-
-    // Open the dialog. With no custom roles seeded the page renders both
-    // a header "Create Role" and an empty-state "Create First Role" —
-    // the header button is always present, so anchor on it.
-    await page.locator('button:has-text("Create Role")').first().click();
-
-    const dialog = page.getByRole("dialog");
-    await expect(dialog).toBeVisible();
     await expect(dialog.getByRole("heading", { name: "Create Role" })).toBeVisible();
 
     await dialog.getByLabel("Name").fill("data-engineer");
     await dialog.getByLabel("Description").fill("Read-only data analyst");
 
-    // The checkbox carries `id="perm-<slug>"` — the cleanest, least-
-    // ambiguous handle. Pre-fix the regression manifested specifically
-    // on direct checkbox clicks (the wrapping <label> fired a synthetic
-    // re-click on the same button, net-toggling back).
-    const queryCheckbox = dialog.locator("#perm-query");
-    const auditCheckbox = dialog.locator("#perm-admin\\:audit");
+    // The fix added stable `id="perm-<slug>"` to each checkbox. Bracket-
+    // id form avoids escaping the `:` in slugs like `admin:audit`.
+    const queryCheckbox = dialog.locator('[id="perm-query"]');
+    const auditCheckbox = dialog.locator('[id="perm-admin:audit"]');
 
     await expect(queryCheckbox).toHaveAttribute("data-state", "unchecked");
     await expect(auditCheckbox).toHaveAttribute("data-state", "unchecked");
 
+    // Pre-fix the regression manifested specifically on direct checkbox
+    // clicks (the wrapping <label> fired a synthetic re-click on the
+    // same button, net-toggling back).
     await queryCheckbox.click();
     await expect(queryCheckbox).toHaveAttribute("data-state", "checked");
 
     await auditCheckbox.click();
     await expect(auditCheckbox).toHaveAttribute("data-state", "checked");
 
-    // Click again to verify there's no asymmetry — toggling off must
-    // also work in a single click.
+    // Off→on cycle catches any asymmetry — the original double-fire bug
+    // could in principle have flipped one direction but not the other.
     await auditCheckbox.click();
     await expect(auditCheckbox).toHaveAttribute("data-state", "unchecked");
     await auditCheckbox.click();
@@ -154,21 +165,20 @@ test.describe("Admin roles — Create Role permission checkboxes (#2170) @llm", 
 
     await dialog.getByRole("button", { name: "Create Role" }).click();
 
-    // Wire-level assertion — the POST body must carry the permissions
-    // we toggled.
-    await expect.poll(() => postCalls.length).toBeGreaterThan(0);
-    const lastBody = postCalls[postCalls.length - 1]!.body;
-    expect(lastBody).toMatchObject({
+    // Dialog hides only on success — once it's gone, the POST has been
+    // recorded by the mock route handler.
+    await expect(dialog).toBeHidden({ timeout: 5_000 });
+    expect(postBodies).toHaveLength(1);
+    const body = postBodies[0]!;
+    expect(body).toMatchObject({
       name: "data-engineer",
       description: "Read-only data analyst",
     });
-    expect(lastBody.permissions).toEqual(
+    expect(body.permissions).toEqual(
       expect.arrayContaining(["query", "admin:audit"]),
     );
-    expect((lastBody.permissions as string[]).length).toBe(2);
+    expect((body.permissions as string[]).length).toBe(2);
 
-    // Dialog closes and the new row renders.
-    await expect(dialog).toBeHidden({ timeout: 5_000 });
     await expect(page.getByRole("cell", { name: "data-engineer" })).toBeVisible({
       timeout: 5_000,
     });
@@ -182,19 +192,63 @@ test.describe("Admin roles — Create Role permission checkboxes (#2170) @llm", 
     // the checkbox — so users who click on the visible label, not the
     // small checkbox, still get a working toggle.
     await installRolesMocks(page);
-    await page.goto("/admin/roles");
+    const dialog = await openCreateRoleDialog(page);
 
-    await expect(page.locator("h1", { hasText: "Roles" })).toBeVisible({
-      timeout: 15_000,
-    });
-    await page.locator('button:has-text("Create Role")').first().click();
-    const dialog = page.getByRole("dialog");
-    await expect(dialog).toBeVisible();
-
-    const queryCheckbox = dialog.locator("#perm-query");
+    const queryCheckbox = dialog.locator('[id="perm-query"]');
     await expect(queryCheckbox).toHaveAttribute("data-state", "unchecked");
 
     await dialog.getByText("Query data", { exact: true }).click();
     await expect(queryCheckbox).toHaveAttribute("data-state", "checked");
+  });
+
+  test("submit with zero permissions surfaces validation and never POSTs", async ({
+    page,
+  }) => {
+    // The schema's `permissions: z.array(z.string()).min(1)` is the
+    // last line of defense against empty-permission roles. A future
+    // refactor that drops the `.min(1)` rule, or removes the inline
+    // FormMessage that surfaces it, must be caught here.
+    const { postBodies } = await installRolesMocks(page);
+    const dialog = await openCreateRoleDialog(page);
+
+    await dialog.getByLabel("Name").fill("empty-role");
+    await dialog.getByRole("button", { name: "Create Role" }).click();
+
+    await expect(
+      dialog.getByText(/At least one permission is required/i),
+    ).toBeVisible({ timeout: 5_000 });
+    expect(postBodies).toHaveLength(0);
+    // Dialog stays open on validation failure.
+    await expect(dialog).toBeVisible();
+  });
+
+  test("toggle-then-untoggle drops the permission from the submit body", async ({
+    page,
+  }) => {
+    // Symmetry case for the off→on→off path: a future single-direction
+    // toggle bug (e.g. `add()` without a paired `remove()`) would let
+    // the visible checkbox unflag while the form value clung to the
+    // perm. Wire-level assertion guards against that drift.
+    const { postBodies } = await installRolesMocks(page);
+    const dialog = await openCreateRoleDialog(page);
+
+    await dialog.getByLabel("Name").fill("settings-only");
+
+    const queryCheckbox = dialog.locator('[id="perm-query"]');
+    const settingsCheckbox = dialog.locator('[id="perm-admin:settings"]');
+
+    await queryCheckbox.click();
+    await expect(queryCheckbox).toHaveAttribute("data-state", "checked");
+    await queryCheckbox.click();
+    await expect(queryCheckbox).toHaveAttribute("data-state", "unchecked");
+
+    await settingsCheckbox.click();
+    await expect(settingsCheckbox).toHaveAttribute("data-state", "checked");
+
+    await dialog.getByRole("button", { name: "Create Role" }).click();
+    await expect(dialog).toBeHidden({ timeout: 5_000 });
+
+    expect(postBodies).toHaveLength(1);
+    expect(postBodies[0]!.permissions).toEqual(["admin:settings"]);
   });
 });

--- a/e2e/browser/admin-roles-create.spec.ts
+++ b/e2e/browser/admin-roles-create.spec.ts
@@ -1,0 +1,200 @@
+import { test, expect, type Page, type Route } from "@playwright/test";
+
+/**
+ * Admin custom roles — Create Role permission checkboxes (#2170) @llm
+ *
+ * Regression coverage for the "Create Role" dialog: the permission
+ * checkboxes used to be wrapped in a `<label>`, which double-fired
+ * `onCheckedChange` (Radix Checkbox is a button — the wrapping label
+ * dispatched a synthetic activation click on its labelable descendant,
+ * net-toggling back). The fix replaces the wrap with htmlFor/id
+ * association.
+ *
+ * What this spec asserts:
+ *   1. Clicking a permission checkbox flips it to data-state="checked"
+ *      and a second click flips it back (no double-fire in either
+ *      direction).
+ *   2. The submitted POST body carries the selected permissions verbatim.
+ *   3. The new role row renders after the dialog closes.
+ *
+ * Page-level mocking (not real DB rows) — the persistent admin session
+ * created by global-setup.ts is itself how this test logs in, and
+ * exercising the real /api/v1/admin/roles requires the enterprise
+ * license layer, which isn't part of the dev seed. Mocking keeps the
+ * spec hermetic.
+ *
+ * The `@llm` tag opts this spec into the serial worker so other admin-
+ * surface mocks aren't raced.
+ */
+
+interface MockRole {
+  id: string;
+  orgId: string;
+  name: string;
+  description: string;
+  permissions: string[];
+  isBuiltin: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const ALL_PERMISSIONS = [
+  "query",
+  "query:raw_data",
+  "admin:users",
+  "admin:connections",
+  "admin:settings",
+  "admin:audit",
+  "admin:roles",
+  "admin:semantic",
+];
+
+interface InstalledMocks {
+  state: MockRole[];
+  postCalls: Array<{ body: Record<string, unknown> }>;
+}
+
+async function installRolesMocks(page: Page): Promise<InstalledMocks> {
+  const state: MockRole[] = [];
+  const postCalls: Array<{ body: Record<string, unknown> }> = [];
+
+  await page.route(
+    /\/api\/v1\/admin\/roles(?:\?[^/]*)?$/,
+    async (route: Route) => {
+      const req = route.request();
+      if (req.method() === "POST") {
+        const body = JSON.parse(req.postData() ?? "{}") as Record<string, unknown>;
+        postCalls.push({ body });
+        const created: MockRole = {
+          id: `role_mock_${state.length + 1}`,
+          orgId: "org-1",
+          name: String(body.name ?? ""),
+          description: typeof body.description === "string" ? body.description : "",
+          permissions: Array.isArray(body.permissions)
+            ? (body.permissions as string[])
+            : [],
+          isBuiltin: false,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        };
+        state.push(created);
+        await route.fulfill({
+          status: 201,
+          contentType: "application/json",
+          body: JSON.stringify({ role: created }),
+        });
+        return;
+      }
+      if (req.method() !== "GET") {
+        await route.abort("failed");
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          roles: state,
+          permissions: ALL_PERMISSIONS,
+          total: state.length,
+        }),
+      });
+    },
+  );
+
+  return { state, postCalls };
+}
+
+test.describe("Admin roles — Create Role permission checkboxes (#2170) @llm", () => {
+  test.describe.configure({ timeout: 45_000 });
+
+  test("permission checkbox toggles on click and persists through submit", async ({
+    page,
+  }) => {
+    const { postCalls } = await installRolesMocks(page);
+    await page.goto("/admin/roles");
+
+    await expect(page.locator("h1", { hasText: "Roles" })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Open the dialog. With no custom roles seeded the page renders both
+    // a header "Create Role" and an empty-state "Create First Role" —
+    // the header button is always present, so anchor on it.
+    await page.locator('button:has-text("Create Role")').first().click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole("heading", { name: "Create Role" })).toBeVisible();
+
+    await dialog.getByLabel("Name").fill("data-engineer");
+    await dialog.getByLabel("Description").fill("Read-only data analyst");
+
+    // The checkbox carries `id="perm-<slug>"` — the cleanest, least-
+    // ambiguous handle. Pre-fix the regression manifested specifically
+    // on direct checkbox clicks (the wrapping <label> fired a synthetic
+    // re-click on the same button, net-toggling back).
+    const queryCheckbox = dialog.locator("#perm-query");
+    const auditCheckbox = dialog.locator("#perm-admin\\:audit");
+
+    await expect(queryCheckbox).toHaveAttribute("data-state", "unchecked");
+    await expect(auditCheckbox).toHaveAttribute("data-state", "unchecked");
+
+    await queryCheckbox.click();
+    await expect(queryCheckbox).toHaveAttribute("data-state", "checked");
+
+    await auditCheckbox.click();
+    await expect(auditCheckbox).toHaveAttribute("data-state", "checked");
+
+    // Click again to verify there's no asymmetry — toggling off must
+    // also work in a single click.
+    await auditCheckbox.click();
+    await expect(auditCheckbox).toHaveAttribute("data-state", "unchecked");
+    await auditCheckbox.click();
+    await expect(auditCheckbox).toHaveAttribute("data-state", "checked");
+
+    await dialog.getByRole("button", { name: "Create Role" }).click();
+
+    // Wire-level assertion — the POST body must carry the permissions
+    // we toggled.
+    await expect.poll(() => postCalls.length).toBeGreaterThan(0);
+    const lastBody = postCalls[postCalls.length - 1]!.body;
+    expect(lastBody).toMatchObject({
+      name: "data-engineer",
+      description: "Read-only data analyst",
+    });
+    expect(lastBody.permissions).toEqual(
+      expect.arrayContaining(["query", "admin:audit"]),
+    );
+    expect((lastBody.permissions as string[]).length).toBe(2);
+
+    // Dialog closes and the new row renders.
+    await expect(dialog).toBeHidden({ timeout: 5_000 });
+    await expect(page.getByRole("cell", { name: "data-engineer" })).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+
+  test("clicking the permission row label toggles the associated checkbox", async ({
+    page,
+  }) => {
+    // The label/htmlFor association replaced a wrapping <label>. This
+    // case asserts that clicking the row's friendly text still toggles
+    // the checkbox — so users who click on the visible label, not the
+    // small checkbox, still get a working toggle.
+    await installRolesMocks(page);
+    await page.goto("/admin/roles");
+
+    await expect(page.locator("h1", { hasText: "Roles" })).toBeVisible({
+      timeout: 15_000,
+    });
+    await page.locator('button:has-text("Create Role")').first().click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    const queryCheckbox = dialog.locator("#perm-query");
+    await expect(queryCheckbox).toHaveAttribute("data-state", "unchecked");
+
+    await dialog.getByText("Query data", { exact: true }).click();
+    await expect(queryCheckbox).toHaveAttribute("data-state", "checked");
+  });
+});

--- a/packages/web/src/app/admin/roles/page.tsx
+++ b/packages/web/src/app/admin/roles/page.tsx
@@ -228,33 +228,30 @@ function RoleDialog({
               {Object.entries(PERMISSION_GROUPS).map(([group, perms]) => (
                 <div key={group} className="space-y-2">
                   <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">{group}</p>
+                  {/* Don't wrap <Checkbox> in <label> — Radix Checkbox is a button, and
+                      a wrapping label dispatches a synthetic activation click on its
+                      labelable descendant when the descendant itself is clicked, double-
+                      firing onCheckedChange and net-toggling back. Use htmlFor. (#2170) */}
                   <div className="space-y-1.5">
-                    {perms.filter((p) => allPermissions.includes(p)).map((perm) => {
-                      const checkboxId = `perm-${perm}`;
-                      // Don't wrap <Checkbox> in <label> — Radix Checkbox is a button, and
-                      // a wrapping label dispatches a synthetic click on its labelable
-                      // descendant when the descendant itself is clicked, double-firing
-                      // onCheckedChange and net-toggling back. Use htmlFor instead. (#2170)
-                      return (
-                        <div
-                          key={perm}
-                          className="flex items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted/50"
+                    {perms.filter((p) => allPermissions.includes(p)).map((perm) => (
+                      <div
+                        key={perm}
+                        className="flex items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted/50"
+                      >
+                        <Checkbox
+                          id={`perm-${perm}`}
+                          checked={selectedPerms.includes(perm)}
+                          onCheckedChange={() => togglePermission(perm)}
+                        />
+                        <label
+                          htmlFor={`perm-${perm}`}
+                          className="flex flex-1 items-center gap-2 cursor-pointer select-none"
                         >
-                          <Checkbox
-                            id={checkboxId}
-                            checked={selectedPerms.includes(perm)}
-                            onCheckedChange={() => togglePermission(perm)}
-                          />
-                          <label
-                            htmlFor={checkboxId}
-                            className="flex flex-1 items-center gap-2 cursor-pointer select-none"
-                          >
-                            <span className="text-sm">{PERMISSION_LABELS[perm] ?? perm}</span>
-                            <span className="text-xs text-muted-foreground font-mono ml-auto">{perm}</span>
-                          </label>
-                        </div>
-                      );
-                    })}
+                          <span className="text-sm">{PERMISSION_LABELS[perm] ?? perm}</span>
+                          <span className="text-xs text-muted-foreground font-mono ml-auto">{perm}</span>
+                        </label>
+                      </div>
+                    ))}
                   </div>
                 </div>
               ))}

--- a/packages/web/src/app/admin/roles/page.tsx
+++ b/packages/web/src/app/admin/roles/page.tsx
@@ -229,19 +229,32 @@ function RoleDialog({
                 <div key={group} className="space-y-2">
                   <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">{group}</p>
                   <div className="space-y-1.5">
-                    {perms.filter((p) => allPermissions.includes(p)).map((perm) => (
-                      <label
-                        key={perm}
-                        className="flex items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted/50 cursor-pointer"
-                      >
-                        <Checkbox
-                          checked={selectedPerms.includes(perm)}
-                          onCheckedChange={() => togglePermission(perm)}
-                        />
-                        <span className="text-sm">{PERMISSION_LABELS[perm] ?? perm}</span>
-                        <span className="text-xs text-muted-foreground font-mono ml-auto">{perm}</span>
-                      </label>
-                    ))}
+                    {perms.filter((p) => allPermissions.includes(p)).map((perm) => {
+                      const checkboxId = `perm-${perm}`;
+                      // Don't wrap <Checkbox> in <label> — Radix Checkbox is a button, and
+                      // a wrapping label dispatches a synthetic click on its labelable
+                      // descendant when the descendant itself is clicked, double-firing
+                      // onCheckedChange and net-toggling back. Use htmlFor instead. (#2170)
+                      return (
+                        <div
+                          key={perm}
+                          className="flex items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted/50"
+                        >
+                          <Checkbox
+                            id={checkboxId}
+                            checked={selectedPerms.includes(perm)}
+                            onCheckedChange={() => togglePermission(perm)}
+                          />
+                          <label
+                            htmlFor={checkboxId}
+                            className="flex flex-1 items-center gap-2 cursor-pointer select-none"
+                          >
+                            <span className="text-sm">{PERMISSION_LABELS[perm] ?? perm}</span>
+                            <span className="text-xs text-muted-foreground font-mono ml-auto">{perm}</span>
+                          </label>
+                        </div>
+                      );
+                    })}
                   </div>
                 </div>
               ))}


### PR DESCRIPTION
## Summary

- `/admin/roles` "Create Role" dialog wrapped each Radix `<Checkbox>` (a button) in a `<label>`. The label's spec'd activation behavior dispatched a synthetic click on the labelable descendant whenever the user clicked the checkbox itself, double-firing `onCheckedChange` and net-toggling the form value back. Visually the checkbox never moved.
- Replace the wrap with `htmlFor`/`id` association — same hit area for the friendly text, no double-fire on direct checkbox clicks.
- New `@llm`-tagged Playwright spec mocks `/api/v1/admin/roles`, asserts checkbox-direct + label-text clicks both flip `data-state="checked"`, and verifies the POST body carries the toggled permissions.

Closes #2170.

## Test plan

- [x] `bun run lint`
- [x] `bun run type`
- [x] `bun run test` — full suite (351 api / 123 web / 25 ee / 22 cli + all plugins, 0 failures)
- [x] `bun x syncpack lint`
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh`
- [x] `bash scripts/check-railway-watch.sh`
- [x] `bash scripts/check-schema-drift.sh`
- [ ] `bun run test:browser:llm -g "Create Role"` — run locally to confirm the new spec passes (CI doesn't run browser tests automatically)