### PR TITLE
fix(web): two-factor trust-device checkbox — same #2170 hazard

### DIFF
--- a/packages/web/src/app/login/two-factor/page.tsx
+++ b/packages/web/src/app/login/two-factor/page.tsx
@@ -317,7 +317,11 @@ function TwoFactorChallengeForm() {
               />
             </div>
 
-            <label className="flex items-start gap-2.5 text-sm">
+            {/* Don't wrap <Checkbox> in <label> — Radix Checkbox is a button, and a
+                wrapping label dispatches a synthetic activation click on its labelable
+                descendant when the descendant itself is clicked, double-firing
+                onCheckedChange and net-toggling back. Use htmlFor. (#2170 follow-up) */}
+            <div className="flex items-start gap-2.5 text-sm">
               <Checkbox
                 id="trust-device"
                 checked={trustDevice}
@@ -325,14 +329,14 @@ function TwoFactorChallengeForm() {
                 disabled={busy || passkeyBusy}
                 className="mt-0.5"
               />
-              <span className="flex-1 select-none">
+              <label htmlFor="trust-device" className="flex-1 select-none cursor-pointer">
                 <span className="font-medium">Trust this device for 30 days</span>
                 <span className="mt-0.5 block text-xs text-muted-foreground">
                   Skip the code prompt on this browser until {formatTrustExpiry()}.
                   Don't enable on a shared computer.
                 </span>
-              </span>
-            </label>
+              </label>
+            </div>
 
             {error && <ChallengeErrorAlert message={error} />}
 


### PR DESCRIPTION
## Summary

- The `/login/two-factor` page wraps the "Trust this device for 30 days" Radix `<Checkbox>` in a `<label>` — same pattern PR #2222 fixed on `/admin/roles`. Direct clicks on the checkbox bubble to the label, which dispatches a synthetic activation click on its labelable descendant; `onCheckedChange` fires twice and the trust-device value net-toggles back.
- Less user-visible than the roles bug (most users click the label text, which works fine), but it's the same hazard.
- Replace the wrap with `htmlFor`/`id` association — same hit area, no double-fire.

Caught by the `comment-analyzer` agent during the PR #2222 review as an out-of-scope occurrence of the same pattern.

## Test plan

- [x] `bun run lint`
- [x] `bun run type`
- [x] `bun run test` — full suite (351 api / 123 web / 25 ee / 22 cli + plugins, 0 failures)
- [x] `bun x syncpack lint`
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh`
- [x] `bash scripts/check-railway-watch.sh`
- [x] `bash scripts/check-schema-drift.sh`