### PR TITLE
chore: branch-protection test marker (will close without merge)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ docs/superpowers/
 # Lighthouse CLI dumps Chrome's profile dir into cwd as a Windows-shaped path
 # under WSL2. Pre-empt it so `git add` doesn't sweep ~50KB of garbage in.
 C:\\Users\\*
+
+# branch-protection test marker (will be reverted; PR closed without merge — see #2206)


### PR DESCRIPTION
Throwaway PR to verify the fix for #2206 — branch protection on `main` blocks `gh pr merge` while required checks are still pending.

**This PR will be closed without merging.**

Plan:
1. Push triggers CI (gate)
2. Immediately attempt `gh pr merge` → expect refusal
3. Close PR, delete branch