### PR TITLE
fix(web): #2234 — /admin/platform/actions p-6 wrapper + h1 heading

### DIFF
--- a/packages/web/src/app/admin/platform/actions/page.tsx
+++ b/packages/web/src/app/admin/platform/actions/page.tsx
@@ -228,10 +228,10 @@ function ActionsPageContent() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-2xl font-bold tracking-tight">Action Log</h2>
+          <h1 className="text-2xl font-bold tracking-tight">Action Log</h1>
           <p className="text-muted-foreground">
             All admin actions across the platform. {total > 0 && `${total} total entries.`}
           </p>


### PR DESCRIPTION
## Summary

- Add the missing `p-6` wrapper so `/admin/platform/actions` matches the gutter of every sibling under `/admin/platform/*`
- Promote the page heading from `<h2>` to `<h1>` for consistency with the other platform pages

Closes #2234.

## Test plan

- [ ] Visit `/admin/platform/actions` and confirm the gutter matches `/admin/platform/backups`, `/admin/platform/sla`, `/admin/platform/residency`
- [ ] Confirm the page heading is the same visual weight/level as siblings
- [ ] No behavior change beyond layout