### PR TITLE
fix(web): #2172 — /admin/billing surfaces BYOT next-step CTA + warning banner

### DIFF
--- a/packages/web/src/app/admin/billing/__tests__/byot-key-status.test.tsx
+++ b/packages/web/src/app/admin/billing/__tests__/byot-key-status.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * Regression guard for `ByotKeyStatus` (#2172).
+ *
+ * Toggling BYOT on used to leave the user staring at a flipped switch with
+ * no path to the actual key form. This component is the missing bridge:
+ * a warning when the toggle is on but no key is configured, a confirmation
+ * row when one is, and a docs link in both cases. Losing any of those is
+ * the regression that #2172 was filed against.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { render, cleanup } from "@testing-library/react";
+import { createElement } from "react";
+import { ByotKeyStatus } from "../page";
+
+function rendered(props: { byot: boolean; configuredKey: { provider: string; model: string } | null }) {
+  return render(createElement(ByotKeyStatus, props));
+}
+
+describe("ByotKeyStatus", () => {
+  test("renders nothing when BYOT is off", () => {
+    const { container } = rendered({ byot: false, configuredKey: null });
+    expect(container.textContent).toBe("");
+    cleanup();
+  });
+
+  test("renders the warning + CTA when BYOT is on and no key is configured", () => {
+    const { container, getByRole } = rendered({ byot: true, configuredKey: null });
+    const alert = getByRole("alert");
+    expect(alert).toBeTruthy();
+    expect(alert.textContent).toContain("no API key configured");
+    expect(alert.textContent).toContain("platform default");
+
+    const cta = container.querySelector('a[href="/admin/model-config"]');
+    expect(cta).toBeTruthy();
+    expect(cta?.textContent).toContain("Add your API key");
+
+    expect(container.textContent).toContain("Learn about BYOT");
+    cleanup();
+  });
+
+  test("renders the confirmation + Manage link when BYOT is on with a configured key", () => {
+    const { container } = rendered({
+      byot: true,
+      configuredKey: { provider: "anthropic", model: "claude-sonnet-4-6" },
+    });
+    expect(container.querySelector("[role=alert]")).toBeNull();
+    expect(container.textContent).toContain("Using your");
+    expect(container.textContent).toContain("Anthropic");
+    expect(container.textContent).toContain("claude-sonnet-4-6");
+
+    const manage = container.querySelector('a[href="/admin/model-config"]');
+    expect(manage).toBeTruthy();
+    expect(manage?.textContent).toContain("Manage");
+
+    expect(container.textContent).toContain("Learn about BYOT");
+    cleanup();
+  });
+
+  test("falls back to the raw provider key when no human label exists", () => {
+    const { container } = rendered({
+      byot: true,
+      configuredKey: { provider: "unknown-provider", model: "gpt-99" },
+    });
+    expect(container.textContent).toContain("unknown-provider");
+    expect(container.textContent).toContain("gpt-99");
+    cleanup();
+  });
+});

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
+import { z } from "zod";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
@@ -31,8 +33,11 @@ import { BillingStatusSchema } from "@/ui/lib/admin-schemas";
 import { formatDate, formatNumber } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import type { BillingStatus } from "@useatlas/schemas";
+import { WorkspaceModelConfigSchema } from "@useatlas/schemas";
 import {
+  AlertTriangle,
   Bot,
+  Check,
   Coins,
   CreditCard,
   DollarSign,
@@ -528,6 +533,17 @@ function ModelRow({ data, onSaved }: { data: BillingStatus; onSaved: () => void 
 
 // ── BYOT row (inline switch) ──────────────────────────────────────
 
+const ModelConfigResponseSchema = z.object({
+  config: WorkspaceModelConfigSchema.nullable(),
+});
+
+const PROVIDER_LABEL: Record<string, string> = {
+  anthropic: "Anthropic",
+  openai: "OpenAI",
+  "azure-openai": "Azure OpenAI",
+  custom: "Custom",
+};
+
 function ByotRow({
   data,
   onToggled,
@@ -543,6 +559,14 @@ function ByotRow({
     method: "POST",
     invalidates: onToggled,
   });
+
+  // The BYOT toggle just flips the plan flag — the actual provider+key lives
+  // in /admin/model-config. Fetch that here so we can tell the user when the
+  // toggle is on but no key has been pasted yet.
+  const { data: modelConfig } = useAdminFetch("/api/v1/admin/model-config", {
+    schema: ModelConfigResponseSchema,
+  });
+  const configuredKey = modelConfig?.config ?? null;
 
   async function handleToggle(enabled: boolean) {
     await mutate({ body: { enabled } });
@@ -573,7 +597,81 @@ function ByotRow({
           </div>
         }
       />
+      <ByotKeyStatus
+        byot={data.plan.byot}
+        configuredKey={configuredKey}
+      />
       <MutationErrorSurface error={error} feature="BYOT" variant="inline" />
     </div>
+  );
+}
+
+// Presenter for the BYOT key state (#2172). Pure, prop-driven so it can be
+// tested without spinning up the network plumbing in `ByotRow`.
+export function ByotKeyStatus({
+  byot,
+  configuredKey,
+}: {
+  byot: boolean;
+  configuredKey: { provider: string; model: string } | null;
+}) {
+  if (!byot) return null;
+  return (
+    <>
+      {!configuredKey ? (
+        <div
+          role="alert"
+          className="flex items-start justify-between gap-3 rounded-md border border-amber-500/40 bg-amber-50/60 px-4 py-3 dark:bg-amber-950/20"
+        >
+          <div className="flex items-start gap-2.5">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-700 dark:text-amber-400" />
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-amber-900 dark:text-amber-200">
+                BYOT enabled, but no API key configured yet
+              </p>
+              <p className="text-xs text-amber-800/80 dark:text-amber-300/80">
+                Atlas supports Anthropic, OpenAI, Azure OpenAI, and OpenAI-compatible endpoints.
+                Until a key is saved, chat keeps using the platform default.
+              </p>
+            </div>
+          </div>
+          <Button asChild variant="outline" size="sm" className="shrink-0">
+            <Link href="/admin/model-config">
+              Add your API key
+              <ExternalLink className="ml-1.5 size-3" />
+            </Link>
+          </Button>
+        </div>
+      ) : (
+        <div className="flex items-center justify-between gap-3 rounded-md border bg-muted/30 px-4 py-2.5">
+          <div className="flex items-center gap-2 text-xs">
+            <Check className="size-3.5 text-emerald-600 dark:text-emerald-400" />
+            <span className="text-muted-foreground">
+              Using your{" "}
+              <span className="font-medium text-foreground">
+                {PROVIDER_LABEL[configuredKey.provider] ?? configuredKey.provider}
+              </span>{" "}
+              key{" "}
+              <span className="font-mono text-[11px] text-muted-foreground/80">
+                ({configuredKey.model})
+              </span>
+            </span>
+          </div>
+          <Button asChild variant="ghost" size="sm" className="shrink-0">
+            <Link href="/admin/model-config">Manage</Link>
+          </Button>
+        </div>
+      )}
+      <p className="text-[11px] text-muted-foreground">
+        <a
+          href="https://docs.useatlas.dev/guides/billing-and-plans#byot-bring-your-own-token"
+          target="_blank"
+          rel="noreferrer"
+          className="underline-offset-2 hover:underline"
+        >
+          Learn about BYOT
+        </a>
+      </p>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

- Toggling BYOT on under `/admin/billing` no longer leaves the user with no path to the key form.
- New `<ByotKeyStatus>` presenter renders three states under the BYOT toggle: amber warning + "Add your API key" CTA when BYOT is enabled and no key is configured, a confirmation row + "Manage" link when one is, and a "Learn about BYOT" docs link in both cases.
- Reads existing key state from `/api/v1/admin/model-config` — no new endpoint.
- Presenter is pure so the visual states are unit-tested without mocking the network plumbing.

Closes #2172.

## Test plan

- [ ] `bun test packages/web/src/app/admin/billing/__tests__/byot-key-status.test.tsx` — 4 pass
- [ ] Manual: in dev, toggle BYOT on with no key → amber banner + CTA appear, link goes to `/admin/model-config`
- [ ] Manual: with a key configured → confirmation row + Manage link appear, no warning banner
- [ ] Manual: toggle BYOT off → presenter renders nothing
- [ ] No behavior change to the toggle itself