### PR TITLE
feat(web,admin): #2233 — copyable workspace ID in Settings

### DIFF
--- a/packages/web/src/app/admin/settings/__tests__/workspace-identity-card.test.tsx
+++ b/packages/web/src/app/admin/settings/__tests__/workspace-identity-card.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Regression guard for `WorkspaceIdentityCard` (#2233).
+ *
+ * Operators previously had to query Postgres or dig through `Set-Cookie` to
+ * read their workspace ID. The card is the in-UI surface that closes that
+ * gap; losing the readonly input, the copy button, or the caption would
+ * reintroduce the original navigation hole.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { render, cleanup, fireEvent, act } from "@testing-library/react";
+import { createElement } from "react";
+import { WorkspaceIdentityCard } from "../page";
+
+function renderCard(props: { orgId: string | null; orgName: string | null }) {
+  return render(createElement(WorkspaceIdentityCard, props));
+}
+
+describe("WorkspaceIdentityCard", () => {
+  test("renders nothing when no orgId is available", () => {
+    const { container } = renderCard({ orgId: null, orgName: null });
+    expect(container.textContent).toBe("");
+    cleanup();
+  });
+
+  test("renders the readonly ID + caption + copy affordance when orgId is present", () => {
+    const { container, getByLabelText } = renderCard({
+      orgId: "org_abc123",
+      orgName: "Atlas Labs",
+    });
+    const input = container.querySelector<HTMLInputElement>("#workspace-id");
+    expect(input).toBeTruthy();
+    expect(input?.value).toBe("org_abc123");
+    expect(input?.readOnly).toBe(true);
+
+    expect(container.textContent).toContain("Atlas Labs");
+    expect(container.textContent).toContain(
+      "Use this when configuring the CLI, SDK, or load-test allowlists.",
+    );
+
+    expect(getByLabelText("Copy workspace ID")).toBeTruthy();
+    cleanup();
+  });
+
+  test("omits the Name row when orgName is null", () => {
+    const { container } = renderCard({ orgId: "org_xyz", orgName: null });
+    expect(container.textContent).not.toContain("Name");
+    expect(container.textContent).toContain("Workspace ID");
+    cleanup();
+  });
+
+  test("copies the orgId to the clipboard and flips the icon to the copied state", async () => {
+    const writeText = mock(async () => undefined);
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    const { getByLabelText } = renderCard({
+      orgId: "org_copy_me",
+      orgName: null,
+    });
+
+    await act(async () => {
+      fireEvent.click(getByLabelText("Copy workspace ID"));
+    });
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText.mock.calls[0]?.[0]).toBe("org_copy_me");
+
+    // After the click resolves, the button's accessible label flips so the
+    // user knows the copy succeeded — losing this would be a silent regression.
+    expect(getByLabelText("Copied workspace ID")).toBeTruthy();
+
+    cleanup();
+  });
+});

--- a/packages/web/src/app/admin/settings/page.tsx
+++ b/packages/web/src/app/admin/settings/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, type ComponentType } from "react";
 import { z } from "zod";
+import { authClient } from "@/lib/auth/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
@@ -31,6 +32,8 @@ import { cn } from "@/lib/utils";
 import {
   Bot,
   Brain,
+  Check,
+  Copy,
   Cpu,
   Database,
   FlaskConical,
@@ -373,6 +376,103 @@ function SettingRow({
   );
 }
 
+// ── Workspace identity (#2233) ────────────────────────────────────
+
+// Pure presenter so the rendered states have a regression test without
+// pulling Better Auth's session client into the test harness.
+export function WorkspaceIdentityCard({
+  orgId,
+  orgName,
+}: {
+  orgId: string | null;
+  orgName: string | null;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    if (!orgId) return;
+    try {
+      await navigator.clipboard.writeText(orgId);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch (err) {
+      console.debug(
+        "Clipboard write failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+
+  if (!orgId) return null;
+
+  return (
+    <section className="mb-8">
+      <SectionHeading
+        title="Workspace identity"
+        description="Machine-readable identifiers for the active workspace"
+      />
+      <div className="space-y-3 rounded-xl border bg-card/40 px-4 py-3.5">
+        {orgName && (
+          <div className="flex items-baseline justify-between text-xs">
+            <span className="text-muted-foreground">Name</span>
+            <span className="font-medium text-foreground">{orgName}</span>
+          </div>
+        )}
+        <div className="space-y-1.5">
+          <label
+            htmlFor="workspace-id"
+            className="block text-xs text-muted-foreground"
+          >
+            Workspace ID
+          </label>
+          <div className="flex items-center gap-2">
+            <Input
+              id="workspace-id"
+              readOnly
+              value={orgId}
+              onFocus={(e) => e.currentTarget.select()}
+              className="font-mono text-xs"
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={handleCopy}
+              className="size-9 shrink-0"
+              aria-label={copied ? "Copied workspace ID" : "Copy workspace ID"}
+            >
+              {copied ? (
+                <Check className="size-4 text-emerald-600 dark:text-emerald-400" />
+              ) : (
+                <Copy className="size-4" />
+              )}
+            </Button>
+          </div>
+          <p className="text-[11px] text-muted-foreground">
+            Use this when configuring the CLI, SDK, or load-test allowlists.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function WorkspaceIdentitySection() {
+  const session = authClient.useSession();
+  // Better Auth's public session type doesn't expose `activeOrganizationId` /
+  // `activeOrganizationName`; the Atlas org plugin stamps them on the session
+  // payload, so cast through `Record<string, unknown>` to read them — same
+  // pattern as `org-switcher.tsx` and `connect-wizard.tsx`.
+  const sessionData = session.data?.session as
+    | Record<string, unknown>
+    | undefined;
+  const orgId = (sessionData?.activeOrganizationId as string | undefined) ?? null;
+  const orgName =
+    (sessionData?.activeOrganizationName as string | undefined) ?? null;
+
+  return <WorkspaceIdentityCard orgId={orgId} orgName={orgName} />;
+}
+
 // ── Main Page ─────────────────────────────────────────────────────
 
 export default function SettingsPage() {
@@ -447,6 +547,10 @@ export default function SettingsPage() {
               <span className="text-muted-foreground/60">overridden</span>
             </div>
           )}
+        </div>
+
+        <div className="mx-auto max-w-3xl">
+          <WorkspaceIdentitySection />
         </div>
 
         <AdminContentWrapper


### PR DESCRIPTION
## Summary

- Adds a **Workspace identity** section to `/admin/settings` with the active workspace name + ID and a copy button
- Reads the org from the Better Auth session payload that `org-switcher.tsx` already consumes — no new endpoint
- Pure `WorkspaceIdentityCard` presenter is exported so the visual states + copy interaction get a regression test without touching the auth client

Closes #2233. Unblocks the operator UX gap that surfaced during #2129 — `ATLAS_LOADTEST_ALLOWED_ORGS` no longer needs a DB shell.

## Test plan

- [ ] `bun test packages/web/src/app/admin/settings/__tests__/workspace-identity-card.test.tsx` — 4 pass
- [ ] Manual: visit `/admin/settings` — section renders at the top with Name (if available) + ID
- [ ] Manual: click the copy icon — clipboard receives the workspace ID, icon flips to ✓ for ~1.5s
- [ ] Manual: focusing the readonly input selects the ID for legacy clipboard fallback
- [ ] No regression to the existing settings sections (Plan / Usage / Configuration unchanged)