### PR TITLE
fix(api,billing): #2240 — allow platform_admin to toggle BYOT

### DIFF
--- a/packages/api/src/api/__tests__/billing.test.ts
+++ b/packages/api/src/api/__tests__/billing.test.ts
@@ -471,5 +471,43 @@ describe("billing routes", () => {
       });
       expect(res.status).toBe(403);
     });
+
+    // #2240 — platform_admin (system-wide superuser) was getting 403 because
+    // the inline gate was hardcoded to {admin, owner}. The outer adminAuth
+    // already accepts platform_admin, so the inner check now needs to match.
+    it("allows platform_admin to toggle BYOT", async () => {
+      mockAuthenticateRequest.mockImplementation(() =>
+        Promise.resolve({
+          authenticated: true,
+          mode: "simple-key",
+          user: { id: "user-1", mode: "simple-key", label: "User", role: "platform_admin", activeOrganizationId: "org-1" },
+        }),
+      );
+      const res = await request("/api/v1/billing/byot", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: true }),
+      });
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test assertions on response shape
+      const body = await res.json() as any;
+      expect(body.byot).toBe(true);
+    });
+
+    it("allows owner role to toggle BYOT", async () => {
+      mockAuthenticateRequest.mockImplementation(() =>
+        Promise.resolve({
+          authenticated: true,
+          mode: "simple-key",
+          user: { id: "user-1", mode: "simple-key", label: "User", role: "owner", activeOrganizationId: "org-1" },
+        }),
+      );
+      const res = await request("/api/v1/billing/byot", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: false }),
+      });
+      expect(res.status).toBe(200);
+    });
   });
 });

--- a/packages/api/src/api/routes/billing.ts
+++ b/packages/api/src/api/routes/billing.ts
@@ -31,6 +31,7 @@ import { getPlanDefinition, getPlanLimits, computeTokenBudget, isUnlimited } fro
 import { buildMetricStatus } from "@atlas/api/lib/billing/enforcement";
 import { getSettingLive } from "@atlas/api/lib/settings";
 import { BillingStatusSchema } from "@useatlas/schemas";
+import { ADMIN_ROLES, type AdminRole } from "@useatlas/types/auth";
 import { ErrorSchema } from "./shared-schemas";
 import { adminAuth, requestContext, type AuthEnv } from "./middleware";
 
@@ -456,9 +457,13 @@ billing.openapi(toggleByotRoute, async (c) => {
       return c.json({ error: "not_available", message: "Billing is not available." }, 404);
     }
 
-    // Require admin or owner role for BYOT toggle
-    if (mode !== "none" && (!user || (user.role !== "admin" && user.role !== "owner"))) {
-      return c.json({ error: "forbidden_role", message: "Admin or owner role required to change BYOT setting.", requestId }, 403);
+    // Require admin, owner, or platform_admin role for BYOT toggle. The
+    // outer `adminAuth` already accepts the same set, but BYOT historically
+    // re-asserted the gate inline and forgot platform_admin (#2240) — keep
+    // the source of truth on `ADMIN_ROLES` so future role additions don't
+    // need to find every duplicated literal.
+    if (mode !== "none" && (!user || !user.role || !ADMIN_ROLES.includes(user.role as AdminRole))) {
+      return c.json({ error: "forbidden_role", message: "Admin, owner, or platform admin role required to change BYOT setting.", requestId }, 403);
     }
 
     if (!orgId) {


### PR DESCRIPTION
## Summary

- The BYOT toggle's inline role gate at \`billing.ts:460\` was hardcoded to \`{admin, owner}\` and returned \`403 forbidden_role\` for \`platform_admin\` users. This was incoherent — the outer \`adminAuth\` middleware already accepts \`platform_admin\`, so the user could view \`/admin/billing\` but not flip the BYOT switch.
- Drive the inner check off the canonical \`ADMIN_ROLES\` tuple from \`@useatlas/types/auth\` so future role additions land in one place.
- Added regression tests for \`platform_admin\` and \`owner\` (the existing \`member → 403\` case stays).

Closes #2240.

## Why this is one line + a constant import

\`grep -rn 'user.role !== \"admin\"' packages/api/src/api/routes/\` shows this was the only inline role check in non-admin-router routes that was missing \`platform_admin\`. \`middleware.ts:adminAuth\` and \`admin-auth.ts:requireAdminAuth\` already include it. So the architectural concern is bounded — no other routes need the same fix.

## Test plan

- [ ] \`bun test packages/api/src/api/__tests__/billing.test.ts\` — 18 pass (16 existing + 2 new)
- [ ] Manual: log in as platform_admin, hit \`/admin/billing\`, toggle BYOT — succeeds with 200
- [ ] Manual: existing admin/owner roles still work
- [ ] Manual: member still gets 403 (outer \`adminAuth\` blocks first; inline check would too)