### PR TITLE
refactor(mcp): #2185 — discriminate CanonicalPrompt by sourceMode/evalMode correlation

### DIFF
--- a/packages/mcp/src/__tests__/prompts/canonical.test.ts
+++ b/packages/mcp/src/__tests__/prompts/canonical.test.ts
@@ -15,6 +15,7 @@ import * as path from "path";
 import {
   loadCanonicalPrompts,
   CANONICAL_PROMPT_PREFIX,
+  type CanonicalPrompt,
 } from "../../prompts/canonical.js";
 
 let tmpRoot: string;
@@ -205,5 +206,111 @@ questions:
     for (const p of result) {
       expect(p.name.startsWith(CANONICAL_PROMPT_PREFIX)).toBe(true);
     }
+  });
+
+  // #2185 — runtime invariant check that mirrors the type-level
+  // discrimination. Every prompt loaded from the real YAML must satisfy
+  // `sourceMode === "glossary"` ↔ `evalMode === "llm"`.
+  it("every loaded prompt satisfies the sourceMode↔evalMode invariant", () => {
+    const result = loadCanonicalPrompts();
+    expect(result.length).toBeGreaterThan(0);
+    for (const p of result) {
+      if (p.sourceMode === "glossary") {
+        expect(p.evalMode).toBe("llm");
+      } else {
+        expect(p.evalMode).toBe("deterministic");
+      }
+    }
+  });
+
+  // #2185 — narrowing on `sourceMode` at the consumer side compiles only
+  // because the type is a discriminated union. If a future refactor
+  // collapses the arms, the `evalMode` literal narrowing here will fail
+  // type-check rather than silently re-widen.
+  it("narrowing on sourceMode produces a literal evalMode (compile-time)", () => {
+    function narrow(p: CanonicalPrompt): "llm" | "deterministic" {
+      if (p.sourceMode === "glossary") {
+        // Type system narrows evalMode to the literal "llm" here. The
+        // explicit annotation documents the narrowing — collapsing the
+        // discriminated union back to a flat shape would fail this line.
+        const evalMode: "llm" = p.evalMode;
+        return evalMode;
+      }
+      const evalMode: "deterministic" = p.evalMode;
+      return evalMode;
+    }
+    const [first] = loadCanonicalPrompts();
+    if (first) {
+      const result = narrow(first);
+      expect(["llm", "deterministic"]).toContain(result);
+    }
+  });
+});
+
+describe("CanonicalPrompt discriminated union (#2185)", () => {
+  // Helper that forces TS to check the value against the full union — a
+  // bare `const x: CanonicalPrompt = {...}` lets contextual typing widen
+  // and sometimes admits invalid combinations; passing through a typed
+  // parameter keeps the union check strict.
+  function asPrompt(p: CanonicalPrompt): CanonicalPrompt {
+    return p;
+  }
+
+  it("rejects mismatched sourceMode + evalMode at compile time", () => {
+    // glossary must pair with llm.
+    // @ts-expect-error — deterministic evalMode on the glossary arm violates the union.
+    asPrompt({
+      name: "x",
+      description: "x",
+      question: "x",
+      category: null,
+      sourceMode: "glossary",
+      evalMode: "deterministic",
+    });
+
+    // metric (and any non-glossary mode) must pair with deterministic.
+    // @ts-expect-error — llm evalMode on the non-glossary arm violates the union.
+    asPrompt({
+      name: "x",
+      description: "x",
+      question: "x",
+      category: null,
+      sourceMode: "metric",
+      evalMode: "llm",
+    });
+
+    // The closed sourceMode union rejects unknown literals — the
+    // constructor normalizes to "other", so a bare unknown string in
+    // a typed literal must not compile.
+    asPrompt({
+      name: "x",
+      description: "x",
+      question: "x",
+      category: null,
+      // @ts-expect-error — "exotic_future_mode" is not a member of CanonicalSourceMode.
+      sourceMode: "exotic_future_mode",
+      evalMode: "deterministic",
+    });
+
+    // The well-formed arms compile without error — sanity-check the
+    // negative tests above by exercising both arms positively.
+    const glossary = asPrompt({
+      name: "x",
+      description: "x",
+      question: "x",
+      category: null,
+      sourceMode: "glossary",
+      evalMode: "llm",
+    });
+    const metric = asPrompt({
+      name: "x",
+      description: "x",
+      question: "x",
+      category: null,
+      sourceMode: "metric",
+      evalMode: "deterministic",
+    });
+    expect(glossary.evalMode).toBe("llm");
+    expect(metric.evalMode).toBe("deterministic");
   });
 });

--- a/packages/mcp/src/prompts/canonical.ts
+++ b/packages/mcp/src/prompts/canonical.ts
@@ -40,20 +40,47 @@ export const CANONICAL_PROMPT_PREFIX = "canonical-";
 export type CanonicalEvalMode = "deterministic" | "llm";
 
 /**
- * Stable shape consumed by the prompts registry. `question` is the
- * verbatim text the agent receives on `prompts/get`; `description` is
- * the human-facing summary shown in `prompts/list`.
+ * Closed union of source modes. The YAML at `eval/canonical-questions/`
+ * uses the four named modes; anything else (a future / typo'd mode)
+ * normalizes to `"other"` so the type stays closed without dropping
+ * the row from the prompts surface.
  */
-export interface CanonicalPrompt {
+export const CANONICAL_SOURCE_MODES = [
+  "metric",
+  "pattern",
+  "virtual",
+  "glossary",
+  "other",
+] as const;
+export type CanonicalSourceMode = (typeof CANONICAL_SOURCE_MODES)[number];
+
+interface CanonicalPromptBase {
   readonly name: string;
   readonly description: string;
   readonly question: string;
-  readonly evalMode: CanonicalEvalMode;
   /** Source category (e.g. `simple_metric`, `join`, `glossary`). */
   readonly category: string | null;
-  /** Source mode from the YAML (`metric` / `pattern` / `virtual` / `glossary`). */
-  readonly sourceMode: string;
 }
+
+/**
+ * Stable shape consumed by the prompts registry. `question` is the
+ * verbatim text the agent receives on `prompts/get`; `description` is
+ * the human-facing summary shown in `prompts/list`.
+ *
+ * Discriminated by `sourceMode` so the invariant
+ * `sourceMode === "glossary"` ↔ `evalMode === "llm"` is enforced at
+ * the type level — previously the constructor enforced it but the
+ * type system allowed nonsensical combinations (#2185).
+ */
+export type CanonicalPrompt =
+  | (CanonicalPromptBase & {
+      readonly sourceMode: "glossary";
+      readonly evalMode: "llm";
+    })
+  | (CanonicalPromptBase & {
+      readonly sourceMode: "metric" | "pattern" | "virtual" | "other";
+      readonly evalMode: "deterministic";
+    });
 
 interface RawQuestion {
   id?: unknown;
@@ -187,18 +214,41 @@ function toCanonicalPrompt(q: RawQuestion): CanonicalPrompt | null {
   const slug = slugFor(q as RawQuestion & { id: string });
   const category =
     typeof q.category === "string" && q.category ? q.category : null;
-  const evalMode: CanonicalEvalMode =
-    q.mode === "glossary" ? "llm" : "deterministic";
-  const description = `[canonical:${category ?? q.mode} · ${evalMode}] ${q.question}`;
-
-  return {
+  const sourceMode = normalizeSourceMode(q.mode);
+  // The category-or-mode label keeps using the raw YAML mode when
+  // category is missing — for unknown modes (which normalize to
+  // "other") the raw value still surfaces in the description rather
+  // than being collapsed to the literal "other".
+  const labelMode = category ?? (sourceMode === "other" ? q.mode : sourceMode);
+  const base: CanonicalPromptBase = {
     name: `${CANONICAL_PROMPT_PREFIX}${slug}`,
-    description,
+    description: "",
     question: q.question,
-    evalMode,
     category,
-    sourceMode: q.mode,
   };
+
+  // Build the description+arm in lockstep so the discriminated union
+  // doesn't have to be re-narrowed at the call site.
+  if (sourceMode === "glossary") {
+    return {
+      ...base,
+      description: `[canonical:${labelMode} · llm] ${q.question}`,
+      sourceMode: "glossary",
+      evalMode: "llm",
+    };
+  }
+  return {
+    ...base,
+    description: `[canonical:${labelMode} · deterministic] ${q.question}`,
+    sourceMode,
+    evalMode: "deterministic",
+  };
+}
+
+function normalizeSourceMode(raw: string): CanonicalSourceMode {
+  return (CANONICAL_SOURCE_MODES as readonly string[]).includes(raw)
+    ? (raw as CanonicalSourceMode)
+    : "other";
 }
 
 function slugFor(q: RawQuestion & { id: string }): string {


### PR DESCRIPTION
## Summary

- \`CanonicalPrompt\` had \`sourceMode: string\` + \`evalMode: \"deterministic\" | \"llm\"\` as parallel fields. The invariant \`sourceMode === \"glossary\"\` ↔ \`evalMode === \"llm\"\` was enforced only at construction time; the type system allowed nonsensical combinations.
- Tighten \`sourceMode\` from \`string\` to a closed union (\`\"metric\" | \"pattern\" | \"virtual\" | \"glossary\" | \"other\"\`). Unknown YAML modes normalize to \`\"other\"\` so the constructor stays total — no row is dropped.
- Make \`CanonicalPrompt\` a discriminated union; mismatched \`sourceMode\` / \`evalMode\` combinations fail type-check.
- For unknown modes (mapped to \`\"other\"\`), preserve the raw YAML value in the description label instead of collapsing to the literal \`\"other\"\` — only the type discriminator narrows.

Same shape as the PromptListEntry per-source discriminated union in #2193.

Closes #2185. Architecture-tagged refactor.

## Test plan

- [ ] \`bun test packages/mcp/src/__tests__/prompts/canonical.test.ts\` — 16 pass (13 existing + 3 new)
- [ ] \`bun run type\` — clean. The three \`@ts-expect-error\` lines (glossary+deterministic, metric+llm, unknown sourceMode literal) succeed only because TS rejects the mismatched combinations
- [ ] No behavior change in \`prompts/list\` or \`prompts/get\` — runtime construction logic preserved (verified by all 13 existing unit tests + the new \"every loaded prompt satisfies the invariant\" assertion against the real 20-question YAML)
- [ ] No regression in #2193 / \`PromptListEntry\` consumers (\`registry.ts\`, \`listing.ts\`)

## Architecture wins

To be added to \`.claude/research/architecture-wins.md\` after merge — same family as #2193 (per-source discriminated union for the wire schema).