### PR TITLE
feat(api): #2184 — CHECK constraint on audit_log.auth_mode

### DIFF
--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -300,6 +300,7 @@ describe("migrateAuthTables", () => {
             { name: "0052_approval_rules_surface.sql" },
             { name: "0053_oauth_client_workspace_grants.sql" },
             { name: "0054_prompt_collections_dedup_unique.sql" },
+            { name: "0055_audit_log_auth_mode_check.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -84,4 +84,24 @@ describeIfPg("migrate-pg (real Postgres)", () => {
 
     expect(count).toBe(0);
   }, PG_TEST_TIMEOUT_MS);
+
+  // #2184 — audit_log.auth_mode CHECK constraint. Inserts that pass
+  // the canonical AuthMode tuple succeed; an insert with an unknown
+  // mode rejects with PostgreSQL error code 23514 (check_violation),
+  // which is the failure mode the DB-side guard is meant to catch.
+  it("rejects non-canonical audit_log.auth_mode with 23514", async () => {
+    // Sanity: a canonical value writes cleanly.
+    await pool.query(
+      `INSERT INTO audit_log (auth_mode, sql, duration_ms, success)
+       VALUES ('managed', 'SELECT 1', 0, true)`,
+    );
+
+    // The drift case from #2182 — literal 'mcp' written by a regression.
+    await expect(
+      pool.query(
+        `INSERT INTO audit_log (auth_mode, sql, duration_ms, success)
+         VALUES ('mcp', 'SELECT 1', 0, true)`,
+      ),
+    ).rejects.toMatchObject({ code: "23514" });
+  }, PG_TEST_TIMEOUT_MS);
 });

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -79,7 +79,7 @@ describe("runMigrations", () => {
 
     const count = await runMigrations(pool);
 
-    expect(count).toBe(55);
+    expect(count).toBe(56);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -163,6 +163,7 @@ describe("runMigrations", () => {
         "0052_approval_rules_surface.sql",
         "0053_oauth_client_workspace_grants.sql",
         "0054_prompt_collections_dedup_unique.sql",
+        "0055_audit_log_auth_mode_check.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0055_audit_log_auth_mode_check.sql
+++ b/packages/api/src/lib/db/migrations/0055_audit_log_auth_mode_check.sql
@@ -1,0 +1,39 @@
+-- 0055 — CHECK constraint on audit_log.auth_mode (#2184).
+--
+-- The TS-side AuthMode union (packages/types/src/auth.ts) is closed:
+--   'none' | 'simple-key' | 'managed' | 'byot'
+--
+-- The DB-side audit_log.auth_mode column has been TEXT NOT NULL with
+-- no CHECK. #2182's first commit silently wrote the literal 'mcp' into
+-- this column; the regression was caught by a human reviewer, not the
+-- DB. Pin the canonical four values so the next regression of this
+-- shape fails at write time with PostgreSQL 23514 instead of polluting
+-- the audit log.
+--
+-- Mirrors the chk_audit_log_actor_kind pattern from migration 0049,
+-- but without the NULL escape hatch — auth_mode is NOT NULL and every
+-- writer already supplies one of the four canonical values.
+
+-- Defensive backfill: any pre-existing non-canonical row would block
+-- the ALTER. Rewrite to 'managed' (the SaaS default; the only path
+-- that legitimately writes any other value is self-host simple-key,
+-- which would already have been canonical). RAISE NOTICE so an
+-- operator running migrations sees the rewrite count if it's non-zero.
+DO $$
+DECLARE
+  rewrite_count INTEGER;
+BEGIN
+  UPDATE audit_log
+  SET auth_mode = 'managed'
+  WHERE auth_mode NOT IN ('none', 'simple-key', 'managed', 'byot');
+  GET DIAGNOSTICS rewrite_count = ROW_COUNT;
+  IF rewrite_count > 0 THEN
+    RAISE NOTICE 'Rewrote % audit_log row(s) with non-canonical auth_mode to managed', rewrite_count;
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  ALTER TABLE audit_log
+    ADD CONSTRAINT chk_audit_log_auth_mode
+    CHECK (auth_mode IN ('none', 'simple-key', 'managed', 'byot'));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -74,6 +74,7 @@ export const auditLog = pgTable(
       .where(sql`actor_kind IS NOT NULL`),
     index("idx_audit_log_client_id").on(t.clientId).where(sql`client_id IS NOT NULL`),
     check("chk_audit_log_actor_kind", sql`actor_kind IS NULL OR actor_kind IN ('human', 'agent', 'mcp', 'scheduler')`),
+    check("chk_audit_log_auth_mode", sql`auth_mode IN ('none', 'simple-key', 'managed', 'byot')`),
   ],
 );
 


### PR DESCRIPTION
Closes #2184.

## Summary

- Pins `audit_log.auth_mode` to the closed `AuthMode` tuple (`'none' | 'simple-key' | 'managed' | 'byot'`) at the DB level via a new CHECK constraint
- Mirrors the `chk_audit_log_actor_kind` pattern from migration 0049 (no NULL escape hatch — `auth_mode` is `NOT NULL` and every writer already supplies a canonical value)
- Defensive backfill rewrites any non-canonical row to `'managed'` with a `RAISE NOTICE` so an operator running the migration sees the rewrite count if it's non-zero — `'managed'` is the SaaS default, and the only path that legitimately writes anything else is self-host `simple-key`, which would already have been canonical

## Why

Spun out of code review on PR #2182 — its first commit silently wrote literal `'mcp'` into `audit_log.auth_mode` and the regression was caught by a human reviewer, not the DB. The TS-side `AuthMode` union (`packages/types/src/auth.ts`) has been closed since launch; this closes the DB-side gap so the next regression of this shape fails at write time with PostgreSQL 23514 (`check_violation`) instead of polluting the audit log.

## Files

- `packages/api/src/lib/db/migrations/0055_audit_log_auth_mode_check.sql` (new)
- `packages/api/src/lib/db/schema.ts` — Drizzle mirror via `check("chk_audit_log_auth_mode", ...)` to keep `scripts/check-schema-drift.sh` green
- `packages/api/src/lib/db/__tests__/migrate-pg.test.ts` — real-Postgres regression: `'mcp'` rejects with `23514`
- `packages/api/src/lib/db/__tests__/migrate.test.ts` — bumped baseline count + applied list for the new migration

## Out of scope

- `action_log.auth_mode` shares the same shape and same drift class — left alone here per the issue scope. Worth a follow-up if there's appetite to harden it the same way

## Test plan

- [x] `bun test src/lib/db/__tests__/migrate-pg.test.ts` (real Postgres) — 3/3 pass
- [x] `bun test src/lib/db/__tests__/migrate.test.ts` (mock) — 58/58 pass
- [x] `bash scripts/check-schema-drift.sh` — passes
- [x] `bun run type` + `bun run lint` — clean