### PR TITLE
fix(api,auth): #2242 — let org owners mint SCIM tokens

### DIFF
--- a/packages/api/src/lib/auth/__tests__/server.test.ts
+++ b/packages/api/src/lib/auth/__tests__/server.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from "bun:test";
 import { betterAuth } from "better-auth";
 import { bearer } from "better-auth/plugins";
 import { apiKey } from "@better-auth/api-key";
-import { resetAuthInstance } from "../server";
+import { resetAuthInstance, canMintSCIMToken } from "../server";
 
 describe("Better Auth instance shape", () => {
   afterEach(() => {
@@ -31,5 +31,41 @@ describe("Better Auth instance shape", () => {
     // Drain the $context promise so the async DB adapter init error
     // doesn't surface as an unhandled rejection after the test ends.
     await instance.$context.catch(() => {});
+  });
+});
+
+// #2242 — regression coverage for the SCIM token role gate. The previous
+// gate accepted {admin, platform_admin} only; an org owner would pass the
+// upstream admin SCIM router (which accepts owner via adminAuth) and then
+// bomb at this predicate with "Only admin users can generate SCIM
+// tokens". Aligning to the canonical ADMIN_ROLES triple closes that
+// inconsistency.
+describe("canMintSCIMToken", () => {
+  it("accepts admin", () => {
+    expect(canMintSCIMToken("admin")).toBe(true);
+  });
+
+  it("accepts owner — #2242 regression", () => {
+    expect(canMintSCIMToken("owner")).toBe(true);
+  });
+
+  it("accepts platform_admin", () => {
+    expect(canMintSCIMToken("platform_admin")).toBe(true);
+  });
+
+  it("rejects member", () => {
+    expect(canMintSCIMToken("member")).toBe(false);
+  });
+
+  it("rejects undefined / missing role", () => {
+    expect(canMintSCIMToken(undefined)).toBe(false);
+    expect(canMintSCIMToken(null)).toBe(false);
+  });
+
+  it("rejects unknown / typo'd role values", () => {
+    expect(canMintSCIMToken("administrator")).toBe(false);
+    expect(canMintSCIMToken("Owner")).toBe(false);
+    expect(canMintSCIMToken("")).toBe(false);
+    expect(canMintSCIMToken(42)).toBe(false);
   });
 });

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -78,6 +78,31 @@ const log = createLogger("auth:server");
 const billingLog = createLogger("billing");
 
 /**
+ * Role gate for SCIM token generation. SCIM tokens are bearer tokens an
+ * external IdP uses to provision/deprovision users in the workspace, so
+ * minting one is an admin-level action.
+ *
+ * Mirrors the canonical `ADMIN_ROLES` triple used by every other admin
+ * gate (middleware.ts:adminAuth, admin-auth.ts:requireAdminAuth,
+ * admin-router.ts:createAdminRouter). #2242 — pre-fix this set was
+ * {admin, platform_admin} which bombed org owners with "Only admin users
+ * can generate SCIM tokens" even though they could manage SCIM
+ * connections at `/api/v1/admin/scim/*`.
+ *
+ * Note: SCIM token-generation lives on Better Auth's catch-all
+ * (`POST /api/auth/scim/generate-token`), NOT under `createAdminRouter()`
+ * — so the `beforeSCIMTokenGenerated` hook that calls this predicate IS
+ * the role gate, not a defense-in-depth guard.
+ *
+ * Hardcoded literal (not imported from `@useatlas/types/auth:ADMIN_ROLES`)
+ * because this file is template-synced to create-atlas; see the same
+ * pattern in `api/routes/middleware.ts`.
+ */
+export function canMintSCIMToken(role: unknown): boolean {
+  return role === "admin" || role === "owner" || role === "platform_admin";
+}
+
+/**
  * Promote the org creator's user-level role to "admin" so Better Auth's
  * admin plugin APIs (list users, manage roles, etc.) work. Without this,
  * org owners have user.role="member" and Better Auth blocks admin
@@ -1197,14 +1222,12 @@ export function buildPlugins() {
       scim({
         storeSCIMToken: "encrypted",
         async beforeSCIMTokenGenerated(data) {
-          // Only admins can generate SCIM tokens — enforced via Better Auth hook.
-          // The admin check is done upstream by the admin route preamble;
-          // this hook acts as a defense-in-depth guard.
-          // Cast needed: the admin plugin adds `role` to the user object but the
-          // SCIM plugin's hook type only includes base user fields.
+          // Cast needed: the admin plugin adds `role` to the user
+          // object but the SCIM plugin's hook type only includes base
+          // user fields.
           const user = data.user as Record<string, unknown> | undefined;
-          if (user?.role !== "admin" && user?.role !== "platform_admin") {
-            throw new Error("Only admin users can generate SCIM tokens.");
+          if (!canMintSCIMToken(user?.role)) {
+            throw new Error("Only admin, owner, or platform-admin users can generate SCIM tokens.");
           }
         },
       }),


### PR DESCRIPTION
Closes #2242.

## Summary

`beforeSCIMTokenGenerated` accepted `{admin, platform_admin}` only — every other admin gate in the codebase uses the canonical `{admin, owner, platform_admin}` triple (`middleware.ts:adminAuth`, `admin-router.ts:createAdminRouter`, `admin-auth.ts:requireAdminAuth`). An org owner could load `/api/v1/admin/scim/*` (which `createAdminRouter` accepts) but bombed minting a token at `POST /api/auth/scim/generate-token` with "Only admin users can generate SCIM tokens".

## Investigation finding (Option B per the issue)

The pre-existing comment said the hook was "defense-in-depth" sitting downstream of an admin route preamble — that was misleading. SCIM token-generation lives on Better Auth's catch-all (`/api/auth/*`), which has **no upstream `adminAuth` middleware**. The hook **is** the role gate, not a guard. So the narrow check wasn't an intentional system-admin-only narrowing — it was drift, and the only effect was breaking owner UX. Comment rewritten to reflect the actual call shape.

## Files

- `packages/api/src/lib/auth/server.ts` — extracted the role check into `canMintSCIMToken(role)` (exported for unit testing) and reduced the hook to a one-line predicate call
- `packages/api/src/lib/auth/__tests__/server.test.ts` — 6 new cases: admin / owner / platform_admin accept, member reject, undefined/null reject, typo / case-mismatch / non-string reject

## Why hardcode the role list rather than import `ADMIN_ROLES`

`server.ts` is template-synced to `create-atlas` — same constraint as `api/routes/middleware.ts`, which hardcodes for the same reason. The published `@useatlas/types` may not always carry `ADMIN_ROLES` for older scaffolds; mirror the middleware pattern and inline the literal.

## Out of scope

- The asymmetric `masking.ts:321` gate (`admin || owner`, excludes `platform_admin`) — already audited as **intentionally** asymmetric (SaaS operator must not unmask customer PII). Not changing.
- The last-admin guard in `admin.ts:2145/2427` — narrow check is correct (target-role-specific, not subject-role-specific). Not changing.

## Test plan

- [x] `bun test src/lib/auth/__tests__/server.test.ts` — 7/7 pass (1 pre-existing + 6 new)
- [x] `bun run type` + `bun run lint` — clean