### PR TITLE
feat(api): #2166 — abuse-prevention skip via ATLAS_LOADTEST_ALLOWED_ORGS

### DIFF
--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -337,12 +337,17 @@ See [Rate Limiting & Retry](/guides/rate-limiting) for client-side handling, SDK
 | `ATLAS_ABUSE_ERROR_RATE` | `0.5` | Max error rate (0–1) before escalation |
 | `ATLAS_ABUSE_UNIQUE_TABLES` | `50` | Max unique tables accessed per window |
 | `ATLAS_ABUSE_THROTTLE_DELAY_MS` | `2000` | Delay injected for throttled workspaces (ms) |
+| `ATLAS_LOADTEST_ALLOWED_ORGS` | _unset_ | Comma-separated workspace IDs designated for load testing. Listed workspaces (a) may mint MCP load-test JWTs via `POST /api/v1/me/load-test/mcp-token` (see [MCP load-test tokens](/platform-ops/mcp-load-test-tokens)) and (b) bypass abuse-prevention escalation so a load run can't auto-suspend the workspace it's running against. Operator escape hatch — never a substitute for raising thresholds. |
 
 ```bash
 # Stricter abuse detection for production
 ATLAS_ABUSE_QUERY_RATE=100
 ATLAS_ABUSE_ERROR_RATE=0.3
 ATLAS_ABUSE_THROTTLE_DELAY_MS=5000
+
+# Allowlist a load-test workspace — same env var that gates the
+# MCP load-test JWT mint endpoint
+ATLAS_LOADTEST_ALLOWED_ORGS=ws_dharma_uuid,ws_canary_uuid
 ```
 
 See [Abuse Prevention](/platform-ops/abuse-prevention) for details on graduated response and admin reinstatement.

--- a/packages/api/src/api/routes/me-load-test.ts
+++ b/packages/api/src/api/routes/me-load-test.ts
@@ -42,6 +42,7 @@ import {
   LOAD_TEST_TOKEN_MAX_TTL_SECONDS,
   LOAD_TEST_TOKEN_MIN_TTL_SECONDS,
 } from "@atlas/api/lib/auth/load-test-tokens";
+import { getLoadTestAllowlist } from "@atlas/api/lib/auth/load-test-allowlist";
 import { validationHook } from "./validation-hook";
 import { standardAuth, requestContext, type AuthEnv } from "./middleware";
 
@@ -109,6 +110,11 @@ function clock(): number {
 }
 
 // ── Org allowlist ──────────────────────────────────────────────────
+// Lives in `lib/auth/load-test-allowlist.ts` — the abuse-prevention
+// skip in `lib/security/abuse.ts` (#2166) shares the same allowlist so
+// load-test workspaces don't auto-suspend themselves while running
+// scenarios that legitimately push past the rate limits. Single source
+// of truth for `ATLAS_LOADTEST_ALLOWED_ORGS`.
 //
 // SaaS hardening: even though /me self-mint is functionally
 // equivalent to a workspace member completing the OAuth ceremony
@@ -132,16 +138,6 @@ function clock(): number {
 // hash lookup, and matching the rate-limiter pattern in this file
 // keeps the surface uniform. An operator can edit the allowlist on
 // Railway and the next request picks it up without a redeploy.
-
-function loadTestAllowlist(): ReadonlySet<string> | null {
-  const raw = process.env.ATLAS_LOADTEST_ALLOWED_ORGS?.trim();
-  if (!raw) return null;
-  const ids = raw
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean);
-  return ids.length === 0 ? null : new Set(ids);
-}
 
 // ── Schemas ─────────────────────────────────────────────────────────
 
@@ -329,7 +325,7 @@ meLoadTest.openapi(
       // unmounted route — so probing customers can't even confirm the
       // endpoint exists. Don't audit on this rejection: the would-be
       // attacker should have no signal that the route is real.
-      const allowlist = loadTestAllowlist();
+      const allowlist = getLoadTestAllowlist();
       if (allowlist !== null && !allowlist.has(workspaceId)) {
         log.warn(
           { requestId, workspaceId, actorId: user.id },

--- a/packages/api/src/lib/auth/load-test-allowlist.ts
+++ b/packages/api/src/lib/auth/load-test-allowlist.ts
@@ -1,0 +1,41 @@
+/**
+ * Operator-set allowlist of workspace IDs explicitly authorized for load
+ * testing — `ATLAS_LOADTEST_ALLOWED_ORGS=ws_a,ws_b,...`.
+ *
+ * Two consumers today:
+ *   - Self-mint MCP load-test JWT endpoint (`api/routes/me-load-test.ts`)
+ *     — when the allowlist is set, only listed workspaces may mint.
+ *   - Abuse-prevention skip (`lib/security/abuse.ts`) — listed
+ *     workspaces bypass the escalate→suspend chain so load tests don't
+ *     auto-suspend themselves.
+ *
+ * `getLoadTestAllowlist()` returns `null` when unset/empty — "no
+ * allowlist configured". Each consumer interprets that per its own
+ * semantics: the mint endpoint is permissive on null (preserves
+ * self-hosted single-instance load testing), abuse-prevention is
+ * non-overriding on null (normal escalation).
+ *
+ * Re-read on every call so flipping the env var doesn't require a
+ * restart; the parse cost is one trim + split, dwarfed by the
+ * surrounding work.
+ */
+
+export function getLoadTestAllowlist(): ReadonlySet<string> | null {
+  const raw = process.env.ATLAS_LOADTEST_ALLOWED_ORGS?.trim();
+  if (!raw) return null;
+  const ids = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return ids.length === 0 ? null : new Set(ids);
+}
+
+/**
+ * Whether `workspaceId` is in the load-test allowlist. Returns `false`
+ * when the allowlist is unset (which is the default in self-hosted
+ * deployments) — callers that want "no allowlist = permissive" should
+ * call `getLoadTestAllowlist()` directly and branch on `null`.
+ */
+export function isLoadTestWorkspace(workspaceId: string): boolean {
+  return getLoadTestAllowlist()?.has(workspaceId) ?? false;
+}

--- a/packages/api/src/lib/security/__tests__/abuse.test.ts
+++ b/packages/api/src/lib/security/__tests__/abuse.test.ts
@@ -94,6 +94,8 @@ const {
   _resetAbuseState,
 } = await import("../abuse");
 
+const { isLoadTestWorkspace } = await import("../../auth/load-test-allowlist");
+
 describe("Abuse Prevention Engine", () => {
   beforeEach(() => {
     _resetAbuseState();
@@ -187,6 +189,48 @@ describe("Abuse Prevention Engine", () => {
       // More events don't change anything (no crash, stays suspended)
       recordQueryEvent("ws-stopped", { success: true });
       expect(checkAbuseStatus("ws-stopped").level).toBe("suspended");
+    });
+
+    // #2166 — load-test allowlist. Workspaces in
+    // ATLAS_LOADTEST_ALLOWED_ORGS (the same allowlist that gates the
+    // self-mint MCP load-test JWT endpoint) skip every counter so they
+    // cannot escalate past `none`, regardless of how aggressively they
+    // hammer the rate limits.
+    it("does not escalate workspaces in ATLAS_LOADTEST_ALLOWED_ORGS", () => {
+      const original = process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+      process.env.ATLAS_LOADTEST_ALLOWED_ORGS = "ws-loadtest";
+      try {
+        const config = getAbuseConfig();
+        // Same loop that suspends a non-allowlisted org in the prior tests.
+        for (let i = 0; i <= config.queryRateLimit + 5; i++) {
+          recordQueryEvent("ws-loadtest", { success: true });
+        }
+        expect(checkAbuseStatus("ws-loadtest").level).toBe("none");
+        // First skip emits a single info log; subsequent skips stay quiet.
+        const skipLogs = infoCalls.filter((c) =>
+          c.msg.includes("ATLAS_LOADTEST_ALLOWED_ORGS"),
+        );
+        expect(skipLogs.length).toBe(1);
+      } finally {
+        if (original === undefined) delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+        else process.env.ATLAS_LOADTEST_ALLOWED_ORGS = original;
+      }
+    });
+
+    it("isLoadTestWorkspace reflects env-var changes without restart", () => {
+      const original = process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+      try {
+        delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+        expect(isLoadTestWorkspace("ws-x")).toBe(false);
+        process.env.ATLAS_LOADTEST_ALLOWED_ORGS = "ws-x, ws-y ,  ";
+        // Whitespace + empty entries get trimmed/dropped.
+        expect(isLoadTestWorkspace("ws-x")).toBe(true);
+        expect(isLoadTestWorkspace("ws-y")).toBe(true);
+        expect(isLoadTestWorkspace("ws-z")).toBe(false);
+      } finally {
+        if (original === undefined) delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+        else process.env.ATLAS_LOADTEST_ALLOWED_ORGS = original;
+      }
     });
 
     it("triggers on high error rate", () => {

--- a/packages/api/src/lib/security/abuse.ts
+++ b/packages/api/src/lib/security/abuse.ts
@@ -15,6 +15,7 @@
 import { createLogger } from "@atlas/api/lib/logger";
 import { abuseEscalations } from "@atlas/api/lib/metrics";
 import { hasInternalDB, internalExecute, internalQuery } from "@atlas/api/lib/db/internal";
+import { isLoadTestWorkspace } from "@atlas/api/lib/auth/load-test-allowlist";
 import {
   ABUSE_LEVELS,
   ABUSE_TRIGGERS,
@@ -145,9 +146,17 @@ interface WorkspaceAbuseState {
 
 const workspaceState = new Map<string, WorkspaceAbuseState>();
 
+/**
+ * Workspaces that have already had their load-test allowlist skip
+ * logged once. Bounded by the size of `ATLAS_LOADTEST_ALLOWED_ORGS`
+ * (operator-controlled), so unbounded growth isn't a concern.
+ */
+const warnedLoadTestSkip = new Set<string>();
+
 /** Reset all in-memory state. For tests. */
 export function _resetAbuseState(): void {
   workspaceState.clear();
+  warnedLoadTestSkip.clear();
 }
 
 /** Get or create workspace state. */
@@ -195,6 +204,25 @@ export function recordQueryEvent(
   workspaceId: string,
   opts: { success: boolean; tablesAccessed?: string[] },
 ): void {
+  // #2166 — workspaces in the load-test allowlist
+  // (`ATLAS_LOADTEST_ALLOWED_ORGS`) bypass the escalation chain so a
+  // designated load-test workspace can't auto-suspend itself while
+  // running scenarios that legitimately exceed the rate limits. Same
+  // allowlist that gates the self-mint MCP load-test JWT endpoint
+  // (`api/routes/me-load-test.ts`) — single source of truth in
+  // `lib/auth/load-test-allowlist.ts`. Log the first skip per process
+  // so operators see the escape hatch is engaged without log spam.
+  if (isLoadTestWorkspace(workspaceId)) {
+    if (!warnedLoadTestSkip.has(workspaceId)) {
+      warnedLoadTestSkip.add(workspaceId);
+      log.info(
+        { workspaceId },
+        "Abuse tracking skipped (workspace in ATLAS_LOADTEST_ALLOWED_ORGS)",
+      );
+    }
+    return;
+  }
+
   const config = getAbuseConfig();
   const windowMs = config.queryRateWindowSeconds * 1000;
   const state = getState(workspaceId);


### PR DESCRIPTION
Closes #2166 (server-side core).

## Summary

Workspaces in the existing `ATLAS_LOADTEST_ALLOWED_ORGS` allowlist — the same env var that gates the self-mint MCP load-test JWT endpoint at `POST /api/v1/me/load-test/mcp-token` — now also bypass the abuse-prevention escalation chain. A workspace operators have explicitly designated for load testing can push past `queryRateLimit` without auto-suspending itself partway through the run.

Reusing the existing env var (rather than introducing a new `ATLAS_NEVER_SUSPEND_ORGS`) avoids drift between two parallel allowlists with the same intended membership: "workspaces we've explicitly authorized for load testing."

## Files

- `packages/api/src/lib/auth/load-test-allowlist.ts` (new) — `getLoadTestAllowlist()` + `isLoadTestWorkspace(workspaceId)`. Single source of truth for the env-var parsing
- `packages/api/src/api/routes/me-load-test.ts` — collapsed the private `loadTestAllowlist()` onto the shared module
- `packages/api/src/lib/security/abuse.ts` — `recordQueryEvent` short-circuits at the top before any counter ticks for allowlisted orgs; one-time info log per workspace per process
- `packages/api/src/lib/security/__tests__/abuse.test.ts` — two new cases: allowlisted workspace doesn't escalate even past `queryRateLimit + 5`; `isLoadTestWorkspace` reflects env-var changes without restart (whitespace + empty entries trimmed)
- `apps/docs/content/docs/reference/environment-variables.mdx` — adds `ATLAS_LOADTEST_ALLOWED_ORGS` to the canonical reference (was only documented in `platform-ops/mcp-load-test-tokens.mdx`); updated example shows both the rate-limit and allowlist usage

## Why

Dharma is the designated stress-test / load-test org and keeps tripping abuse heuristics that auto-suspend the workspace, blocking ongoing perf work. There was no operator escape hatch — every spike risked another suspension. The intent of `ATLAS_LOADTEST_ALLOWED_ORGS` ("workspaces we've authorized for load testing") is exactly the same set we need to skip suspension for.

## Out of scope (follow-up)

The issue also asks for a "load-test" / "no-suspend" badge in the platform-admin org view. That requires a small admin-UI patch reading `getLoadTestAllowlist()` server-side and flagging workspaces in the platform list. Worth a separate, smaller PR — the core suspension-prevention is fully resolved by this change.

## Test plan

- [x] `bun test src/lib/security/__tests__/abuse.test.ts` — 45/45 pass (43 pre-existing + 2 new)
- [x] `bun test src/api/__tests__/me-load-test.test.ts` — 23/23 pass (the existing allowlist-gate cases still cover the route side after the refactor)
- [x] `bun run scripts/test-isolated.ts --affected` — 6/6 affected files pass
- [x] `bun run type` + `bun run lint` — clean