### PR TITLE
feat(web,admin): #2249 — platform-admin badge for never-suspend workspaces

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -57604,6 +57604,9 @@
                           },
                           "createdAt": {
                             "type": "string"
+                          },
+                          "neverSuspend": {
+                            "type": "boolean"
                           }
                         },
                         "required": [
@@ -57813,6 +57816,9 @@
                         },
                         "createdAt": {
                           "type": "string"
+                        },
+                        "neverSuspend": {
+                          "type": "boolean"
                         }
                       },
                       "required": [

--- a/packages/api/src/api/__tests__/platform-admin.test.ts
+++ b/packages/api/src/api/__tests__/platform-admin.test.ts
@@ -231,3 +231,74 @@ describe("GET /api/v1/platform/stats — MRR calculation", () => {
     expect(mockLogWarn.mock.calls.length).toBe(2);
   });
 });
+
+// #2249 — `neverSuspend` flag reflects ATLAS_LOADTEST_ALLOWED_ORGS
+// membership on every list-route row. The flag is what the platform-
+// admin orgs page reads to render the "Load-test" badge — drift here
+// silently un-badges allowlisted workspaces.
+describe("GET /api/v1/platform/workspaces — neverSuspend flag (#2249)", () => {
+  beforeEach(() => {
+    mocks.setPlatformAdmin();
+    mocks.hasInternalDB = true;
+    mockLogWarn.mockClear();
+  });
+
+  function mockListWorkspaces(rows: Array<{ id: string; slug: string }>): void {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("FROM organization o")) {
+        return rows.map((r) => ({
+          id: r.id,
+          name: r.id,
+          slug: r.slug,
+          workspace_status: "active",
+          plan_tier: "starter",
+          byot: false,
+          stripe_customer_id: null,
+          trial_ends_at: null,
+          suspended_at: null,
+          deleted_at: null,
+          region: "us",
+          region_assigned_at: null,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          members: 1,
+          conversations: 0,
+          queries_last_24h: 0,
+          connections: 0,
+          scheduled_tasks: 0,
+        }));
+      }
+      return [];
+    });
+  }
+
+  it("flips neverSuspend=true for workspaces in ATLAS_LOADTEST_ALLOWED_ORGS", async () => {
+    mockListWorkspaces([{ id: "ws-loadtest", slug: "loadtest" }, { id: "ws-normal", slug: "normal" }]);
+    const original = process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+    process.env.ATLAS_LOADTEST_ALLOWED_ORGS = "ws-loadtest";
+    try {
+      const res = await app.fetch(platformRequest("GET", "/api/v1/platform/workspaces"));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { workspaces: Array<{ id: string; neverSuspend: boolean }> };
+      const lookup = Object.fromEntries(body.workspaces.map((w) => [w.id, w.neverSuspend]));
+      expect(lookup["ws-loadtest"]).toBe(true);
+      expect(lookup["ws-normal"]).toBe(false);
+    } finally {
+      if (original === undefined) delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+      else process.env.ATLAS_LOADTEST_ALLOWED_ORGS = original;
+    }
+  });
+
+  it("returns neverSuspend=false for every workspace when env var is unset", async () => {
+    mockListWorkspaces([{ id: "ws-a", slug: "a" }, { id: "ws-b", slug: "b" }]);
+    const original = process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+    delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+    try {
+      const res = await app.fetch(platformRequest("GET", "/api/v1/platform/workspaces"));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { workspaces: Array<{ neverSuspend: boolean }> };
+      expect(body.workspaces.every((w) => w.neverSuspend === false)).toBe(true);
+    } finally {
+      if (original !== undefined) process.env.ATLAS_LOADTEST_ALLOWED_ORGS = original;
+    }
+  });
+});

--- a/packages/api/src/api/routes/platform-admin.ts
+++ b/packages/api/src/api/routes/platform-admin.ts
@@ -45,6 +45,7 @@ import {
 } from "@useatlas/types";
 import { getPlanDefinition } from "@atlas/api/lib/billing/plans";
 import { invalidatePlanCache } from "@atlas/api/lib/billing/enforcement";
+import { getLoadTestAllowlist } from "@atlas/api/lib/auth/load-test-allowlist";
 import {
   PlatformStatsSchema,
   PlatformWorkspaceSchema,
@@ -303,6 +304,9 @@ function toWorkspaceResponse(
     region: row.region,
     regionAssignedAt: row.region_assigned_at,
     createdAt: row.createdAt,
+    // #2249 — surface the load-test allowlist override so the detail
+    // page renders the same badge as the list view.
+    neverSuspend: getLoadTestAllowlist()?.has(row.id) ?? false,
   };
 }
 
@@ -385,6 +389,10 @@ platformAdmin.openapi(listWorkspacesRoute, async (c) => {
        ORDER BY o."createdAt" DESC`,
     );
 
+    // #2249 — read the load-test allowlist once per request rather
+    // than re-parsing the env var inside the per-row map.
+    const allowlist = getLoadTestAllowlist();
+
     const workspaces = rows.map((row) => ({
       id: row.id,
       name: row.name,
@@ -404,6 +412,7 @@ platformAdmin.openapi(listWorkspacesRoute, async (c) => {
       region: row.region,
       regionAssignedAt: row.region_assigned_at,
       createdAt: row.createdAt,
+      neverSuspend: allowlist?.has(row.id) ?? false,
     }));
 
     return c.json({ workspaces }, 200);

--- a/packages/schemas/src/platform.ts
+++ b/packages/schemas/src/platform.ts
@@ -70,6 +70,9 @@ export const PlatformWorkspaceSchema = z.object({
   region: z.string().nullable(),
   regionAssignedAt: z.string().nullable(),
   createdAt: z.string(),
+  // #2249 — optional + additive so older consumers that haven't picked
+  // up this @useatlas/schemas release don't reject the response.
+  neverSuspend: z.boolean().optional(),
 }) satisfies z.ZodType<PlatformWorkspace>;
 
 export const PlatformWorkspaceUserSchema = z.object({

--- a/packages/types/src/platform.ts
+++ b/packages/types/src/platform.ts
@@ -41,6 +41,15 @@ export interface PlatformWorkspace {
   region: string | null;
   regionAssignedAt: string | null;
   createdAt: string;
+  /**
+   * True when the workspace ID is in `ATLAS_LOADTEST_ALLOWED_ORGS` — the
+   * env-driven allowlist that lets designated load-test workspaces
+   * bypass abuse-prevention escalation (#2166) and mint MCP load-test
+   * JWTs. Optional + additive: omitted on consumers that haven't picked
+   * up this @useatlas/types release yet, treated as `false` in the UI.
+   * Source of truth: `lib/auth/load-test-allowlist.ts:isLoadTestWorkspace`.
+   */
+  neverSuspend?: boolean;
 }
 
 export interface PlatformWorkspaceDetail {

--- a/packages/web/src/app/admin/platform/page.tsx
+++ b/packages/web/src/app/admin/platform/page.tsx
@@ -23,6 +23,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   Dialog,
   DialogContent,
@@ -412,7 +413,28 @@ function PlatformPageContent() {
                   ) : (
                     filtered.map((ws) => (
                       <TableRow key={ws.id}>
-                        <TableCell className="font-medium">{ws.name}</TableCell>
+                        <TableCell className="font-medium">
+                          <span className="flex items-center gap-2">
+                            {ws.name}
+                            {ws.neverSuspend ? (
+                              <TooltipProvider delayDuration={150}>
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <Badge
+                                      variant="outline"
+                                      className="border-blue-500 text-blue-600 text-[10px] uppercase tracking-wide"
+                                    >
+                                      Load-test
+                                    </Badge>
+                                  </TooltipTrigger>
+                                  <TooltipContent>
+                                    Allowlisted via <code>ATLAS_LOADTEST_ALLOWED_ORGS</code> — abuse-prevention escalation skipped.
+                                  </TooltipContent>
+                                </Tooltip>
+                              </TooltipProvider>
+                            ) : null}
+                          </span>
+                        </TableCell>
                         <TableCell>{planBadge(ws.planTier as PlanTier)}</TableCell>
                         <TableCell>{statusBadge(ws.status as WorkspaceStatus)}</TableCell>
                         <TableCell>{ws.members}</TableCell>
@@ -575,7 +597,18 @@ function PlatformPageContent() {
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <span className="text-sm text-muted-foreground">Name</span>
-                  <p className="font-medium">{detailData.workspace.name}</p>
+                  <p className="font-medium flex items-center gap-2">
+                    {detailData.workspace.name}
+                    {detailData.workspace.neverSuspend ? (
+                      <Badge
+                        variant="outline"
+                        className="border-blue-500 text-blue-600 text-[10px] uppercase tracking-wide"
+                        title="Allowlisted via ATLAS_LOADTEST_ALLOWED_ORGS — abuse-prevention escalation skipped."
+                      >
+                        Load-test
+                      </Badge>
+                    ) : null}
+                  </p>
                 </div>
                 <div>
                   <span className="text-sm text-muted-foreground">Slug</span>


### PR DESCRIPTION
Closes #2249.

## Summary

Surfaces an operator-visible signal in the platform-admin org view when a workspace is in `ATLAS_LOADTEST_ALLOWED_ORGS` — the env-driven allowlist that lets designated load-test workspaces bypass abuse-prevention escalation (#2166 / #2247). Without this badge, an SRE triaging "why didn't Dharma auto-suspend?" had no visible signal short of running `gh secret list` against Railway.

A small "Load-test" badge renders next to the workspace name in the list view + detail panel, with a tooltip pointing at the env-var source.

## Wire-level details

- **`PlatformWorkspace.neverSuspend?: boolean`** — additive, optional field on both `packages/types/src/platform.ts` and `packages/schemas/src/platform.ts` (`z.boolean().optional()`). Optional → no `@useatlas/types` / `@useatlas/schemas` version bump required. Older consumers that haven't picked up this release behave correctly: missing → undefined → falsy → no badge.
- **List route** — `platform-admin.ts:listWorkspacesRoute` calls `getLoadTestAllowlist()` once per request (outside the `.map`) and sets `neverSuspend: allowlist?.has(row.id) ?? false` on each row.
- **Detail route** — `toWorkspaceResponse` helper does the same single-call lookup so the detail panel renders the same badge as the list.
- **Web** — list view wraps the workspace name in a flex container with the optional badge + shadcn `Tooltip`. Detail panel uses a plain `title=` attribute since it's already inside a Dialog and the tooltip layering would conflict.

## Files

- `packages/types/src/platform.ts` — `neverSuspend?: boolean`
- `packages/schemas/src/platform.ts` — matching optional zod field
- `packages/api/src/api/routes/platform-admin.ts` — populate from `getLoadTestAllowlist()` in both list + detail
- `packages/api/src/api/__tests__/platform-admin.test.ts` — 2 new cases: env-set flips matching/non-matching workspaces; env-unset → all false
- `packages/web/src/app/admin/platform/page.tsx` — badge in list + detail

## Out of scope

- Surfacing the badge anywhere else (workspace detail page in non-platform admin, audit log filters, etc.)
- Per-org curation / runtime UI toggle. Operator-only via env, same as today

## Test plan

- [x] `bun test src/api/__tests__/platform-admin.test.ts` — 13/13 pass (11 pre-existing + 2 new)
- [x] `cd packages/api && bun run scripts/test-isolated.ts --affected` — 31/31 pass
- [x] `cd packages/web && bun run scripts/test-isolated.ts --affected` — 127/127 pass
- [x] `bun run type` + `bun run lint` — clean