### PR TITLE
feat(ci,deploy): #2226 — container boot smoke + SaaS env contract

### DIFF
--- a/.github/workflows/deploy-validation.yml
+++ b/.github/workflows/deploy-validation.yml
@@ -124,6 +124,119 @@ jobs:
       - name: Build nextjs-standalone example
         run: bun run --filter '@atlas/nextjs-standalone' build
 
+  # Build the production deploy/api/Dockerfile, run it under the SaaS env
+  # contract (#2226), and probe /api/health. Catches everything the
+  # `migrate-pg` smoke (#2225) catches plus serverExternalPackages drift,
+  # Dockerfile COPY drift (#2206 sibling), start.sh regressions, healthcheck
+  # path drift, boot-time SaaS guard regressions, and prod-mode bundling
+  # errors that don't surface in unit tests.
+  #
+  # Env contract: scripts/saas-env-fixture.ts emits every value from the
+  # single source of truth in packages/api/src/lib/effect/saas-env.ts.
+  # Adding a new SaaS guard means adding a field to that fixture — the
+  # workflow auto-picks it up with no edits here.
+  boot-smoke:
+    name: Boot Smoke
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: atlas
+          POSTGRES_PASSWORD: atlas
+          POSTGRES_DB: atlas
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U atlas"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@e3914758a49697077f7bcd190d36582a61667aad # v2 + node24 (pending release)
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Generate SaaS env fixture
+        run: |
+          bun run scripts/saas-env-fixture.ts \
+            --database-url "postgresql://atlas:atlas@127.0.0.1:5432/atlas" \
+            > /tmp/saas.env
+          # Echo only the keys (not values) for runner-log review. Fixture
+          # values are non-secret CI defaults but the convention is to keep
+          # env-file contents off stdout.
+          echo "Fixture keys:"
+          cut -d= -f1 /tmp/saas.env
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
+
+      - name: Build deploy/api image
+        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 # v6.7.0
+        with:
+          context: .
+          file: deploy/api/Dockerfile
+          load: true
+          tags: atlas-api:boot-smoke
+          # gha cache makes warm runs 30-60s vs 3-4 min cold. Branch and
+          # main share the cache so PR builds reuse main's layers.
+          cache-from: type=gha,scope=boot-smoke
+          cache-to: type=gha,scope=boot-smoke,mode=max
+
+      - name: Run API container
+        run: |
+          # --network=host gives the container access to the postgres
+          # service on 127.0.0.1:5432 (the same address the runner uses).
+          # Linux-only but GH Actions ubuntu-latest is Linux.
+          docker run -d \
+            --name atlas-api \
+            --network=host \
+            --env-file /tmp/saas.env \
+            atlas-api:boot-smoke
+
+      - name: Probe /api/health (90s budget)
+        run: |
+          # The probe verifies the SaaS boot guards passed and the HTTP
+          # listener is up — NOT that downstream dependencies (LLM API
+          # key, populated DB) are healthy. Any HTTP response from
+          # /api/health (200 or 503) means boot succeeded; connection
+          # refused / curl error means boot failed.
+          #
+          # Why not check for 200: in CI the fixture intentionally lacks
+          # an LLM provider key (would require a paid secret) and may
+          # have other downstream gaps, so /api/health legitimately
+          # returns 503 with status="error". A SaaS boot-guard failure
+          # exits the process before HTTP starts — the gate would then
+          # see connection-refused, which is the real signal.
+          set +e
+          for i in $(seq 1 45); do
+            status=$(curl -sS -o /tmp/health-body.json -w "%{http_code}" \
+              --max-time 5 http://127.0.0.1:3001/api/health 2>/dev/null)
+            if [ -n "$status" ] && [ "$status" -ge 200 ] && [ "$status" -lt 600 ]; then
+              echo "Boot smoke passed on attempt $i (~$(( i * 2 ))s) — HTTP $status"
+              echo "──── /api/health response body ────"
+              cat /tmp/health-body.json 2>/dev/null || echo "(empty)"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::API never bound to port 3001 within 90s (boot guard failure?)"
+          exit 1
+
+      - name: Dump container logs
+        if: always()
+        run: |
+          echo "──── docker logs atlas-api ────"
+          docker logs atlas-api 2>&1 || echo "(container not running)"
+          echo "──── docker inspect (state) ────"
+          docker inspect --format='{{json .State}}' atlas-api 2>&1 || true
+
+      - name: Stop container
+        if: always()
+        run: docker rm -f atlas-api 2>/dev/null || true
+
   # Lightweight checks that don't need bun: Docker compose validation + deploy mode defaults.
   config-validation:
     name: Config & Deploy Mode
@@ -169,7 +282,7 @@ jobs:
   # failure or cancellation propagates here and blocks the merge.
   deploy-validation-required:
     name: Deploy Validation
-    needs: [changes, scaffold-smoke, standalone-build, config-validation]
+    needs: [changes, scaffold-smoke, standalone-build, config-validation, boot-smoke]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -179,6 +292,7 @@ jobs:
           SCAFFOLD_RESULT: ${{ needs.scaffold-smoke.result }}
           STANDALONE_RESULT: ${{ needs.standalone-build.result }}
           CONFIG_RESULT: ${{ needs.config-validation.result }}
+          BOOT_SMOKE_RESULT: ${{ needs.boot-smoke.result }}
         run: |
           set -euo pipefail
           fail=0
@@ -190,6 +304,12 @@ jobs:
           fi
           # The conditional jobs may legitimately skip when no scaffold-relevant
           # paths changed; success or skipped both count as a pass.
+          # boot-smoke runs unconditionally (no `if:` guard) — its result must
+          # be `success`. A `skipped` here would mean the gate was bypassed.
+          if [ "$BOOT_SMOKE_RESULT" != "success" ]; then
+            echo "::error::boot-smoke job result was '$BOOT_SMOKE_RESULT' (expected 'success')"
+            fail=1
+          fi
           for pair in "scaffold-smoke=$SCAFFOLD_RESULT" "standalone-build=$STANDALONE_RESULT" "config-validation=$CONFIG_RESULT"; do
             name=${pair%%=*}
             result=${pair#*=}

--- a/.github/workflows/deploy-validation.yml
+++ b/.github/workflows/deploy-validation.yml
@@ -198,27 +198,39 @@ jobs:
 
       - name: Probe /api/health (90s budget)
         run: |
-          # The probe verifies the SaaS boot guards passed and the HTTP
-          # listener is up — NOT that downstream dependencies (LLM API
-          # key, populated DB) are healthy. Any HTTP response from
-          # /api/health (200 or 503) means boot succeeded; connection
-          # refused / curl error means boot failed.
-          #
-          # Why not check for 200: in CI the fixture intentionally lacks
-          # an LLM provider key (would require a paid secret) and may
-          # have other downstream gaps, so /api/health legitimately
-          # returns 503 with status="error". A SaaS boot-guard failure
-          # exits the process before HTTP starts — the gate would then
-          # see connection-refused, which is the real signal.
+          # The probe verifies the SaaS boot guards passed AND the
+          # health route still resolves at /api/health — NOT that
+          # downstream dependencies (LLM API key, populated DB) are
+          # healthy. /api/health returns:
+          #   - 200 for status="ok"|"degraded" (boot succeeded; some
+          #     non-essential components may be down)
+          #   - 503 for status="error" (boot succeeded but a critical
+          #     component is unreachable — expected in CI because the
+          #     fixture lacks an LLM provider key, so provider is "down")
+          # Any other status (404 path drift, 405 verb mismatch, 502
+          # proxy-but-app-dead) means the listener bound but health
+          # routing or the runtime has regressed — the exact class of
+          # boot-time bug this gate catches. Connection-refused / curl
+          # error means the SaaS guards failed and the process exited
+          # before HTTP started — the other class.
           set +e
           for i in $(seq 1 45); do
             status=$(curl -sS -o /tmp/health-body.json -w "%{http_code}" \
               --max-time 5 http://127.0.0.1:3001/api/health 2>/dev/null)
-            if [ -n "$status" ] && [ "$status" -ge 200 ] && [ "$status" -lt 600 ]; then
+            if [ "$status" = "200" ] || [ "$status" = "503" ]; then
               echo "Boot smoke passed on attempt $i (~$(( i * 2 ))s) — HTTP $status"
               echo "──── /api/health response body ────"
               cat /tmp/health-body.json 2>/dev/null || echo "(empty)"
               exit 0
+            fi
+            if [ -n "$status" ] && [ "$status" != "000" ]; then
+              # Listener is up but returning an unexpected status — fail
+              # immediately. This is a boot-time regression (route drift,
+              # method mismatch, runtime crash behind a proxy).
+              echo "::error::Unexpected HTTP $status from /api/health — listener is up but health route regressed"
+              echo "──── /api/health response body ────"
+              cat /tmp/health-body.json 2>/dev/null || echo "(empty)"
+              exit 1
             fi
             sleep 2
           done

--- a/packages/api/src/lib/effect/__tests__/saas-env.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-env.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for the SaaS env contract single-source-of-truth (#2226).
+ *
+ * `SaasEnv` enumerates every env var the SaaS-mode boot guards read.
+ * `makeBootSmokeFixture()` returns a complete shape with sane CI
+ * defaults. These tests pin the contract so:
+ *
+ *   1. Adding a field to `SaasEnv` without appending it to
+ *      `SAAS_ENV_KEYS` (the exhaustiveness array) is caught at
+ *      compile time by the `_ExhaustiveCheck` clause AND at runtime
+ *      here.
+ *   2. The fixture passes every guard in saas-guards.ts when fed
+ *      to a stripped process.env. This is the tier the boot-smoke
+ *      gate relies on — if any guard rejects the fixture, the
+ *      workflow can't be green.
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+  SAAS_ENV_KEYS,
+  makeBootSmokeFixture,
+  readSaasEnv,
+  type SaasEnv,
+} from "../saas-env";
+
+describe("SAAS_ENV_KEYS", () => {
+  test("enumerates every key in SaasEnv", () => {
+    // Build an exhaustive SaasEnv literal — the type narrows so any
+    // missing key is a compile error here. The runtime check then
+    // confirms SAAS_ENV_KEYS lists each one.
+    const exhaustive: SaasEnv = {
+      ATLAS_DEPLOY_MODE: undefined,
+      ATLAS_ENTERPRISE_ENABLED: undefined,
+      DATABASE_URL: undefined,
+      ATLAS_DATASOURCE_URL: undefined,
+      ATLAS_ENCRYPTION_KEYS: undefined,
+      ATLAS_ENCRYPTION_KEY: undefined,
+      BETTER_AUTH_SECRET: undefined,
+      ATLAS_RATE_LIMIT_RPM: undefined,
+      ATLAS_API_REGION: undefined,
+      ATLAS_REGION_US_DB_URL: undefined,
+      ATLAS_REGION_EU_DB_URL: undefined,
+      ATLAS_REGION_APAC_DB_URL: undefined,
+      ATLAS_STRICT_PLUGIN_SECRETS: undefined,
+      ATLAS_SMTP_URL: undefined,
+      RESEND_API_KEY: undefined,
+      BETTER_AUTH_URL: undefined,
+      BETTER_AUTH_TRUSTED_ORIGINS: undefined,
+    };
+    const expectedKeys: readonly string[] = Object.keys(exhaustive).sort();
+    const actualKeys: readonly string[] = [...SAAS_ENV_KEYS].sort();
+    expect(actualKeys).toEqual(expectedKeys);
+  });
+
+  test("has no duplicates", () => {
+    const set = new Set(SAAS_ENV_KEYS);
+    expect(set.size).toBe(SAAS_ENV_KEYS.length);
+  });
+});
+
+describe("readSaasEnv", () => {
+  test("reads from a custom env object when provided", () => {
+    const env = readSaasEnv({
+      ATLAS_DEPLOY_MODE: "saas",
+      DATABASE_URL: "postgresql://x/y",
+    } as NodeJS.ProcessEnv);
+    expect(env.ATLAS_DEPLOY_MODE).toBe("saas");
+    expect(env.DATABASE_URL).toBe("postgresql://x/y");
+    expect(env.RESEND_API_KEY).toBeUndefined();
+  });
+});
+
+describe("makeBootSmokeFixture", () => {
+  test("returns valid SaaS values for every required guard input", () => {
+    const fixture = makeBootSmokeFixture();
+    // Each of these is read by a guard that fails boot when missing or
+    // misshapen. If any is dropped from the fixture, the boot-smoke
+    // gate can't pass.
+    expect(fixture.ATLAS_DEPLOY_MODE).toBe("saas");
+    expect(fixture.ATLAS_ENTERPRISE_ENABLED).toBe("true");
+    expect(fixture.DATABASE_URL).toMatch(/^postgresql:\/\//);
+    expect(fixture.ATLAS_DATASOURCE_URL).toMatch(/^postgresql:\/\//);
+    expect(fixture.ATLAS_ENCRYPTION_KEYS).toMatch(/^v1:/);
+    // RateLimit guard rejects n < 1; "300" parses to 300.
+    expect(Number(fixture.ATLAS_RATE_LIMIT_RPM)).toBeGreaterThanOrEqual(1);
+    // Better Auth requires ≥ 32 chars (parseAuthSecret in lib/auth/server.ts).
+    expect(fixture.BETTER_AUTH_SECRET?.length ?? 0).toBeGreaterThanOrEqual(32);
+    expect(fixture.ATLAS_API_REGION).toBe("us");
+    expect(fixture.RESEND_API_KEY).toBeTruthy();
+  });
+
+  test("databaseUrl override flows to internal + datasource + every region", () => {
+    const fixture = makeBootSmokeFixture({
+      databaseUrl: "postgresql://probe/db",
+    });
+    expect(fixture.DATABASE_URL).toBe("postgresql://probe/db");
+    expect(fixture.ATLAS_DATASOURCE_URL).toBe("postgresql://probe/db");
+    expect(fixture.ATLAS_REGION_US_DB_URL).toBe("postgresql://probe/db");
+    expect(fixture.ATLAS_REGION_EU_DB_URL).toBe("postgresql://probe/db");
+    expect(fixture.ATLAS_REGION_APAC_DB_URL).toBe("postgresql://probe/db");
+  });
+
+  test("overrides win over fixture defaults", () => {
+    const fixture = makeBootSmokeFixture({
+      overrides: { ATLAS_RATE_LIMIT_RPM: "1200", RESEND_API_KEY: undefined },
+    });
+    expect(fixture.ATLAS_RATE_LIMIT_RPM).toBe("1200");
+    expect(fixture.RESEND_API_KEY).toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/effect/__tests__/saas-env.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-env.test.ts
@@ -3,16 +3,22 @@
  *
  * `SaasEnv` enumerates every env var the SaaS-mode boot guards read.
  * `makeBootSmokeFixture()` returns a complete shape with sane CI
- * defaults. These tests pin the contract so:
+ * defaults. These tests pin shape-level invariants:
  *
  *   1. Adding a field to `SaasEnv` without appending it to
  *      `SAAS_ENV_KEYS` (the exhaustiveness array) is caught at
  *      compile time by the `_ExhaustiveCheck` clause AND at runtime
  *      here.
- *   2. The fixture passes every guard in saas-guards.ts when fed
- *      to a stripped process.env. This is the tier the boot-smoke
- *      gate relies on — if any guard rejects the fixture, the
- *      workflow can't be green.
+ *   2. Per-field fixture values satisfy the parser-level requirements
+ *      that each guard reads (`ATLAS_RATE_LIMIT_RPM` parses to ≥ 1,
+ *      `BETTER_AUTH_SECRET` ≥ 32 chars, etc.).
+ *
+ * Guard-level acceptance — does the fixture actually pass each guard's
+ * `Effect.fail` branch? — is the boot-smoke workflow's job; running
+ * every guard against the fixture would duplicate that integration
+ * coverage at unit level. If a guard tightens a parser-level rule
+ * (e.g. requires `ATLAS_RATE_LIMIT_RPM` ≥ 60), update both the per-field
+ * assertion below and the fixture default.
  */
 
 import { describe, test, expect } from "bun:test";

--- a/packages/api/src/lib/effect/__tests__/saas-env.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-env.test.ts
@@ -10,8 +10,10 @@
  *      compile time by the `_ExhaustiveCheck` clause AND at runtime
  *      here.
  *   2. Per-field fixture values satisfy the parser-level requirements
- *      that each guard reads (`ATLAS_RATE_LIMIT_RPM` parses to ≥ 1,
- *      `BETTER_AUTH_SECRET` ≥ 32 chars, etc.).
+ *      each value flows through (`ATLAS_RATE_LIMIT_RPM` parses to ≥ 1
+ *      per `RateLimitGuardLive`; `BETTER_AUTH_SECRET` ≥ 32 chars per
+ *      `parseAuthSecret` in `lib/auth/server.ts` — that one is not
+ *      a Atlas guard, but the API process exits at boot if it fails).
  *
  * Guard-level acceptance — does the fixture actually pass each guard's
  * `Effect.fail` branch? — is the boot-smoke workflow's job; running
@@ -112,5 +114,44 @@ describe("makeBootSmokeFixture", () => {
     });
     expect(fixture.ATLAS_RATE_LIMIT_RPM).toBe("1200");
     expect(fixture.RESEND_API_KEY).toBeUndefined();
+  });
+});
+
+describe("indirect-read drift guard", () => {
+  // The contract claim in saas-env.ts is that the fixture covers every
+  // SaaS-required env var, including reads outside `effect/`. These
+  // tests pin that claim by walking the indirect-read sites' source
+  // and asserting every `process.env.X` they read is listed in
+  // SAAS_ENV_KEYS — so a rename in either file (or a new read added
+  // to either file) trips this test before reaching CI's boot smoke.
+  // The discovery is via static-text grep, not runtime: the import
+  // graph for these modules pulls in the full server, which the test
+  // file deliberately avoids.
+
+  async function readProcessEnvKeys(relativePath: string): Promise<Set<string>> {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    // Resolve from packages/api/src/. import.meta.dir is the test
+    // dir (lib/effect/__tests__) — three `..` walks back to src/.
+    const abs = path.resolve(import.meta.dir, "..", "..", "..", relativePath);
+    const src = await fs.readFile(abs, "utf8");
+    const matches = src.matchAll(/process\.env\.([A-Z][A-Z0-9_]*)/g);
+    return new Set([...matches].map((m) => m[1] as string));
+  }
+
+  test("every process.env.X in lib/email/dpa-guard.ts is in SAAS_ENV_KEYS", async () => {
+    const reads = await readProcessEnvKeys("lib/email/dpa-guard.ts");
+    expect(reads.size).toBeGreaterThan(0); // sanity: file did read at least one env var
+    for (const key of reads) {
+      expect(SAAS_ENV_KEYS).toContain(key as (typeof SAAS_ENV_KEYS)[number]);
+    }
+  });
+
+  test("every process.env.X in lib/db/encryption-keys.ts is in SAAS_ENV_KEYS", async () => {
+    const reads = await readProcessEnvKeys("lib/db/encryption-keys.ts");
+    expect(reads.size).toBeGreaterThan(0);
+    for (const key of reads) {
+      expect(SAAS_ENV_KEYS).toContain(key as (typeof SAAS_ENV_KEYS)[number]);
+    }
   });
 });

--- a/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
@@ -74,16 +74,13 @@ function makeTestConfigLayer(
   });
 }
 
-const GUARD_ENV_KEYS = [
-  "ATLAS_DEPLOY_MODE",
-  "ATLAS_ENCRYPTION_KEYS",
-  "ATLAS_ENCRYPTION_KEY",
-  "BETTER_AUTH_SECRET",
-  "DATABASE_URL",
-  "ATLAS_RATE_LIMIT_RPM",
-  "ATLAS_API_REGION",
-  "ATLAS_STRICT_PLUGIN_SECRETS",
-] as const;
+// Source of truth lives in `effect/saas-env.ts :: SAAS_ENV_KEYS` (#2226).
+// Consume it directly so a new SaaS-contract field automatically gets
+// cleaned between test cases — without this, a leaked env var from a
+// prior process could let a later "succeeds when …" assertion pass for
+// the wrong reason.
+const { SAAS_ENV_KEYS } = await import("../saas-env");
+const GUARD_ENV_KEYS = SAAS_ENV_KEYS;
 
 function withCleanEnv<T>(run: () => Promise<T>): Promise<T> {
   const saved: Record<string, string | undefined> = {};

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -46,6 +46,7 @@ import {
   PluginConfigGuardLive,
   MigrationsRequiredError,
 } from "./saas-guards";
+import { readSaasEnv } from "./saas-env";
 
 const log = createLogger("effect:layers");
 
@@ -859,7 +860,7 @@ export const MigrationGuardLive: Layer.Layer<never, MigrationsRequiredError, Con
     // Skip when there's no internal DB at all — `InternalDbGuardLive`
     // already fails boot for that case in SaaS, and a duplicate
     // failure here would just obscure the actual misconfig.
-    if (!process.env.DATABASE_URL) return;
+    if (!readSaasEnv().DATABASE_URL) return;
 
     const migration = yield* Migration;
     if (migration.migrated) return;

--- a/packages/api/src/lib/effect/saas-env.ts
+++ b/packages/api/src/lib/effect/saas-env.ts
@@ -4,9 +4,9 @@
  *
  * Adding a new SaaS guard means appending a field to {@link SaasEnv}
  * and a sane default to {@link makeBootSmokeFixture} — the boot-smoke
- * gate (`.github/workflows/ci.yml :: boot-smoke`) auto-picks up the
- * new value via `scripts/saas-env-fixture.ts`. No workflow edit, no
- * separate env wiring.
+ * gate (`.github/workflows/deploy-validation.yml :: boot-smoke`)
+ * auto-picks up the new value via `scripts/saas-env-fixture.ts`. No
+ * workflow edit, no separate env wiring.
  *
  * The shape is a typed view of `process.env` restricted to the
  * SaaS-required keys. Guards in `saas-guards.ts` and the boot-time
@@ -128,20 +128,22 @@ export interface BootSmokeFixtureOptions {
 }
 
 /**
- * Build a SaaS env block with sane defaults for the boot-smoke gate
- * and Effect tests that need a complete contract. The returned shape
- * is consumed two ways:
+ * Build a SaaS env block with sane defaults for the boot-smoke gate.
+ * The returned shape is consumed by:
  *
- *   1. `scripts/saas-env-fixture.ts` emits its `KEY=VALUE` form to the
- *      GitHub Actions workflow.
- *   2. Effect tests pass it to `withSaasEnv()` to populate
- *      `process.env` for a single test case.
+ *   1. `scripts/saas-env-fixture.ts`, which emits the `KEY=VALUE` form
+ *      to the GitHub Actions workflow.
+ *   2. `__tests__/saas-env.test.ts`, which pins per-field shape so a
+ *      future fixture tweak doesn't accidentally drop a required key.
  *
- * The encryption-key value is a fixed 44-char base64 string that
- * `getEncryptionKeyset()` accepts as well-formed (SHA-256 derives the
- * 32-byte AES key from any non-empty raw). It is *not* a secret — it
- * is identical across every CI run and intentionally documented as
- * such. Production keys are minted via `openssl rand -base64 32`.
+ * The `ATLAS_ENCRYPTION_KEYS` value is plain ASCII, not base64 —
+ * `getEncryptionKeyset()` SHA-256s any non-empty raw entry to derive
+ * the 32-byte AES key, so the format-level requirement is "non-empty
+ * after the `v<N>:` prefix" (no character-set constraint). It is *not*
+ * a secret — it is identical across every CI run and intentionally
+ * documented as such. Production keys are minted via
+ * `openssl rand -base64 32`, which is where the more restrictive
+ * "44-char base64" shape comes from.
  */
 export function makeBootSmokeFixture(
   opts: BootSmokeFixtureOptions = {},

--- a/packages/api/src/lib/effect/saas-env.ts
+++ b/packages/api/src/lib/effect/saas-env.ts
@@ -1,0 +1,174 @@
+/**
+ * Single source of truth for every env var the SaaS-mode boot
+ * contract reads (#2226).
+ *
+ * Adding a new SaaS guard means appending a field to {@link SaasEnv}
+ * and a sane default to {@link makeBootSmokeFixture} — the boot-smoke
+ * gate (`.github/workflows/ci.yml :: boot-smoke`) auto-picks up the
+ * new value via `scripts/saas-env-fixture.ts`. No workflow edit, no
+ * separate env wiring.
+ *
+ * The shape is a typed view of `process.env` restricted to the
+ * SaaS-required keys. Guards in `saas-guards.ts` and the boot-time
+ * `MigrationGuardLive` short-circuit in `layers.ts` read via
+ * {@link readSaasEnv} instead of free-standing `process.env.X` so a
+ * future contributor adding a field touches one place rather than
+ * chasing references.
+ *
+ * Indirect reads (`getEncryptionKeyset()` reads `ATLAS_ENCRYPTION_KEYS`
+ * inside `lib/db/encryption-keys.ts`; `dpa-guard.ts` reads
+ * `RESEND_API_KEY` and `ATLAS_SMTP_URL`) are still listed here so the
+ * fixture populates them — the contract is enumerated even when the
+ * read site lives outside `effect/`.
+ */
+
+/** Every env var the SaaS-mode boot contract reads. */
+export interface SaasEnv {
+  // Deploy mode + enterprise (EnterpriseGuardLive)
+  readonly ATLAS_DEPLOY_MODE: string | undefined;
+  readonly ATLAS_ENTERPRISE_ENABLED: string | undefined;
+
+  // Internal DB (InternalDbGuardLive, MigrationGuardLive short-circuit)
+  readonly DATABASE_URL: string | undefined;
+
+  // Analytics datasource (config initialization)
+  readonly ATLAS_DATASOURCE_URL: string | undefined;
+
+  // Encryption keyset (EncryptionKeyGuardLive → getEncryptionKeyset)
+  readonly ATLAS_ENCRYPTION_KEYS: string | undefined;
+  readonly ATLAS_ENCRYPTION_KEY: string | undefined;
+  readonly BETTER_AUTH_SECRET: string | undefined;
+
+  // Rate limiting (RateLimitGuardLive)
+  readonly ATLAS_RATE_LIMIT_RPM: string | undefined;
+
+  // Region routing (RegionGuardLive + atlas.config.ts residency)
+  readonly ATLAS_API_REGION: string | undefined;
+  readonly ATLAS_REGION_US_DB_URL: string | undefined;
+  readonly ATLAS_REGION_EU_DB_URL: string | undefined;
+  readonly ATLAS_REGION_APAC_DB_URL: string | undefined;
+
+  // Plugin config strict mode (PluginConfigGuardLive)
+  readonly ATLAS_STRICT_PLUGIN_SECRETS: string | undefined;
+
+  // Platform email DPA (DpaGuardLive → assertSaasPlatformEmailIsResend)
+  readonly ATLAS_SMTP_URL: string | undefined;
+  readonly RESEND_API_KEY: string | undefined;
+
+  // Better Auth public URL — required by the OAuth-provider plugin at
+  // boot (`URL("")` throws inside `runPluginInit` when unset). Read by
+  // `lib/auth/server.ts` via `env.BETTER_AUTH_URL` for callback URLs.
+  readonly BETTER_AUTH_URL: string | undefined;
+  readonly BETTER_AUTH_TRUSTED_ORIGINS: string | undefined;
+}
+
+/**
+ * Ordered list of every key in {@link SaasEnv}. The `satisfies` clause
+ * forces TypeScript to verify the array is exhaustive — adding a field
+ * to `SaasEnv` without appending its key here is a compile error. Used
+ * by `saas-env-fixture.ts` (emitting `KEY=VALUE` lines) and tests
+ * (clearing every SaaS env var between cases).
+ */
+export const SAAS_ENV_KEYS = [
+  "ATLAS_DEPLOY_MODE",
+  "ATLAS_ENTERPRISE_ENABLED",
+  "DATABASE_URL",
+  "ATLAS_DATASOURCE_URL",
+  "ATLAS_ENCRYPTION_KEYS",
+  "ATLAS_ENCRYPTION_KEY",
+  "BETTER_AUTH_SECRET",
+  "ATLAS_RATE_LIMIT_RPM",
+  "ATLAS_API_REGION",
+  "ATLAS_REGION_US_DB_URL",
+  "ATLAS_REGION_EU_DB_URL",
+  "ATLAS_REGION_APAC_DB_URL",
+  "ATLAS_STRICT_PLUGIN_SECRETS",
+  "ATLAS_SMTP_URL",
+  "RESEND_API_KEY",
+  "BETTER_AUTH_URL",
+  "BETTER_AUTH_TRUSTED_ORIGINS",
+] as const satisfies readonly (keyof SaasEnv)[];
+
+// Compile-time exhaustiveness: every key in SaasEnv must appear in
+// SAAS_ENV_KEYS. If TypeScript flags this with "Type ... is missing
+// the following properties from type 'never'", a key was added to
+// SaasEnv but not appended to SAAS_ENV_KEYS.
+type _ExhaustiveCheck = Exclude<keyof SaasEnv, (typeof SAAS_ENV_KEYS)[number]>;
+const _exhaustive: _ExhaustiveCheck extends never ? true : false = true;
+void _exhaustive;
+
+/** Read `process.env` (or an injected env object) into a typed `SaasEnv`. */
+export function readSaasEnv(env: NodeJS.ProcessEnv = process.env): SaasEnv {
+  return {
+    ATLAS_DEPLOY_MODE: env.ATLAS_DEPLOY_MODE,
+    ATLAS_ENTERPRISE_ENABLED: env.ATLAS_ENTERPRISE_ENABLED,
+    DATABASE_URL: env.DATABASE_URL,
+    ATLAS_DATASOURCE_URL: env.ATLAS_DATASOURCE_URL,
+    ATLAS_ENCRYPTION_KEYS: env.ATLAS_ENCRYPTION_KEYS,
+    ATLAS_ENCRYPTION_KEY: env.ATLAS_ENCRYPTION_KEY,
+    BETTER_AUTH_SECRET: env.BETTER_AUTH_SECRET,
+    ATLAS_RATE_LIMIT_RPM: env.ATLAS_RATE_LIMIT_RPM,
+    ATLAS_API_REGION: env.ATLAS_API_REGION,
+    ATLAS_REGION_US_DB_URL: env.ATLAS_REGION_US_DB_URL,
+    ATLAS_REGION_EU_DB_URL: env.ATLAS_REGION_EU_DB_URL,
+    ATLAS_REGION_APAC_DB_URL: env.ATLAS_REGION_APAC_DB_URL,
+    ATLAS_STRICT_PLUGIN_SECRETS: env.ATLAS_STRICT_PLUGIN_SECRETS,
+    ATLAS_SMTP_URL: env.ATLAS_SMTP_URL,
+    RESEND_API_KEY: env.RESEND_API_KEY,
+    BETTER_AUTH_URL: env.BETTER_AUTH_URL,
+    BETTER_AUTH_TRUSTED_ORIGINS: env.BETTER_AUTH_TRUSTED_ORIGINS,
+  };
+}
+
+export interface BootSmokeFixtureOptions {
+  /** Postgres URL applied to internal DB, datasource, and every region. */
+  readonly databaseUrl?: string;
+  /** Per-key overrides — useful for testing specific failure modes. */
+  readonly overrides?: Partial<SaasEnv>;
+}
+
+/**
+ * Build a SaaS env block with sane defaults for the boot-smoke gate
+ * and Effect tests that need a complete contract. The returned shape
+ * is consumed two ways:
+ *
+ *   1. `scripts/saas-env-fixture.ts` emits its `KEY=VALUE` form to the
+ *      GitHub Actions workflow.
+ *   2. Effect tests pass it to `withSaasEnv()` to populate
+ *      `process.env` for a single test case.
+ *
+ * The encryption-key value is a fixed 44-char base64 string that
+ * `getEncryptionKeyset()` accepts as well-formed (SHA-256 derives the
+ * 32-byte AES key from any non-empty raw). It is *not* a secret — it
+ * is identical across every CI run and intentionally documented as
+ * such. Production keys are minted via `openssl rand -base64 32`.
+ */
+export function makeBootSmokeFixture(
+  opts: BootSmokeFixtureOptions = {},
+): SaasEnv {
+  const databaseUrl =
+    opts.databaseUrl ?? "postgresql://atlas:atlas@127.0.0.1:5432/atlas";
+  const fixture: SaasEnv = {
+    ATLAS_DEPLOY_MODE: "saas",
+    ATLAS_ENTERPRISE_ENABLED: "true",
+    DATABASE_URL: databaseUrl,
+    ATLAS_DATASOURCE_URL: databaseUrl,
+    ATLAS_ENCRYPTION_KEYS: "v1:ci-fixture-key-not-a-secret-do-not-use-in-prod",
+    ATLAS_ENCRYPTION_KEY: undefined,
+    // Better Auth requires ≥32 chars for session signing (`parseAuthSecret`
+    // in lib/auth/server.ts). ATLAS_ENCRYPTION_KEYS takes precedence for
+    // at-rest encryption — this is purely the Better Auth path.
+    BETTER_AUTH_SECRET: "ci-fixture-better-auth-secret-not-a-secret-pad-pad",
+    ATLAS_RATE_LIMIT_RPM: "300",
+    ATLAS_API_REGION: "us",
+    ATLAS_REGION_US_DB_URL: databaseUrl,
+    ATLAS_REGION_EU_DB_URL: databaseUrl,
+    ATLAS_REGION_APAC_DB_URL: databaseUrl,
+    ATLAS_STRICT_PLUGIN_SECRETS: undefined,
+    ATLAS_SMTP_URL: undefined,
+    RESEND_API_KEY: "ci-fixture-resend-key-not-a-secret",
+    BETTER_AUTH_URL: "http://127.0.0.1:3001",
+    BETTER_AUTH_TRUSTED_ORIGINS: "http://127.0.0.1:3000",
+  };
+  return { ...fixture, ...opts.overrides };
+}

--- a/packages/api/src/lib/effect/saas-env.ts
+++ b/packages/api/src/lib/effect/saas-env.ts
@@ -9,11 +9,10 @@
  * workflow edit, no separate env wiring.
  *
  * The shape is a typed view of `process.env` restricted to the
- * SaaS-required keys. Guards in `saas-guards.ts` and the boot-time
- * `MigrationGuardLive` short-circuit in `layers.ts` read via
- * {@link readSaasEnv} instead of free-standing `process.env.X` so a
- * future contributor adding a field touches one place rather than
- * chasing references.
+ * SaaS-required keys. Guards in `saas-guards.ts` plus `DpaGuardLive`
+ * and `MigrationGuardLive` in `layers.ts` read via {@link readSaasEnv}
+ * instead of free-standing `process.env.X` so a future contributor
+ * adding a field touches one place rather than chasing references.
  *
  * Indirect reads (`getEncryptionKeyset()` reads `ATLAS_ENCRYPTION_KEYS`
  * inside `lib/db/encryption-keys.ts`; `dpa-guard.ts` reads
@@ -55,9 +54,21 @@ export interface SaasEnv {
   readonly ATLAS_SMTP_URL: string | undefined;
   readonly RESEND_API_KEY: string | undefined;
 
-  // Better Auth public URL — required by the OAuth-provider plugin at
-  // boot (`URL("")` throws inside `runPluginInit` when unset). Read by
-  // `lib/auth/server.ts` via `env.BETTER_AUTH_URL` for callback URLs.
+  // Boot-survival keys (not guard-enforced — required for the API
+  // process to start in managed-auth + SaaS mode, but no Atlas guard
+  // explicitly verifies them).
+  //
+  // BETTER_AUTH_URL — Better Auth's library boot path constructs
+  // `new URL(baseURL)` inside its plugin init (verified locally:
+  // `runPluginInit` in `node_modules/better-auth/dist/context/helpers.mjs`
+  // throws `TypeError: "" cannot be parsed as a URL.` when unset under
+  // the OAuth-provider plugin Atlas registers). Read separately by
+  // `lib/auth/server.ts` for callback URL rewriting.
+  //
+  // BETTER_AUTH_TRUSTED_ORIGINS — read by `lib/auth/server.ts` to
+  // anchor verification + password-reset link redirects to the web
+  // app origin; missing-only emits a warn at boot, but a stale value
+  // would silently land users on the API host instead of the web app.
   readonly BETTER_AUTH_URL: string | undefined;
   readonly BETTER_AUTH_TRUSTED_ORIGINS: string | undefined;
 }
@@ -95,6 +106,9 @@ export const SAAS_ENV_KEYS = [
 // SaasEnv but not appended to SAAS_ENV_KEYS.
 type _ExhaustiveCheck = Exclude<keyof SaasEnv, (typeof SAAS_ENV_KEYS)[number]>;
 const _exhaustive: _ExhaustiveCheck extends never ? true : false = true;
+// `void` is load-bearing — silences `noUnusedLocals` without disabling
+// the compile-time check. Do not delete `_exhaustive` even though it
+// looks dead; the assignment is the gate.
 void _exhaustive;
 
 /** Read `process.env` (or an injected env object) into a typed `SaasEnv`. */
@@ -123,7 +137,19 @@ export function readSaasEnv(env: NodeJS.ProcessEnv = process.env): SaasEnv {
 export interface BootSmokeFixtureOptions {
   /** Postgres URL applied to internal DB, datasource, and every region. */
   readonly databaseUrl?: string;
-  /** Per-key overrides — useful for testing specific failure modes. */
+  /**
+   * Per-key overrides — useful for testing specific failure modes.
+   *
+   * Setting a key to an explicit `undefined` (e.g. `{ RESEND_API_KEY:
+   * undefined }`) **drops** the fixture default and emits no value for
+   * that key, which lets callers probe the failure path of a guard
+   * that requires the key to be set. Omitting the key entirely leaves
+   * the fixture default in place. The drop-on-`undefined` behavior is
+   * implemented via spread (`{ ...fixture, ...overrides }`) and
+   * pinned by `__tests__/saas-env.test.ts :: overrides win`. Note that
+   * this depends on `exactOptionalPropertyTypes` being unset in the
+   * project tsconfig — flipping that flag would break this contract.
+   */
   readonly overrides?: Partial<SaasEnv>;
 }
 

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -79,6 +79,7 @@
 
 import { Data, Effect, Layer } from "effect";
 import { Config } from "./layers";
+import { readSaasEnv, type SaasEnv } from "./saas-env";
 
 const ISSUE_REF = "#1978";
 const RATE_LIMIT_ISSUE_REF = "#1983";
@@ -250,8 +251,8 @@ export class MigrationsRequiredError extends Data.TaggedError("MigrationsRequire
  * is unambiguous operator intent — config-file and `auto` can fall
  * through to `self-hosted` quietly.
  */
-function explicitSaasFromEnv(): boolean {
-  return process.env.ATLAS_DEPLOY_MODE === "saas";
+function explicitSaasFromEnv(env: SaasEnv): boolean {
+  return env.ATLAS_DEPLOY_MODE === "saas";
 }
 
 // ══════════════════════════════════════════════════════════════════════
@@ -275,8 +276,9 @@ function explicitSaasFromEnv(): boolean {
 export const EnterpriseGuardLive: Layer.Layer<never, EnterpriseRequiredError, Config> = Layer.effectDiscard(
   Effect.gen(function* () {
     const { config } = yield* Config;
+    const env = readSaasEnv();
 
-    const requestedSaas = explicitSaasFromEnv();
+    const requestedSaas = explicitSaasFromEnv(env);
     const resolvedSaas = config.deployMode === "saas";
 
     if (requestedSaas && !resolvedSaas) {
@@ -392,7 +394,8 @@ export const InternalDbGuardLive: Layer.Layer<never, InternalDatabaseRequiredErr
     const { config } = yield* Config;
     if (config.deployMode !== "saas") return;
 
-    if (!process.env.DATABASE_URL) {
+    const env = readSaasEnv();
+    if (!env.DATABASE_URL) {
       yield* Effect.fail(
         new InternalDatabaseRequiredError({
           message:
@@ -429,19 +432,19 @@ export const InternalDbGuardLive: Layer.Layer<never, InternalDatabaseRequiredErr
  * exists to close. The pinning test in `saas-guards.test.ts` covers
  * `"0"`, `"0.5"`, `"-300"`, `"abc"`.
  *
- * Reads `process.env.ATLAS_RATE_LIMIT_RPM` directly rather than via
- * `getSetting()`. Two reasons: matches the env-direct pattern of
- * `InternalDbGuardLive`, and makes the operator contract crisp — the
- * env var must be set at deploy time. Post-boot writes via `setSetting`
- * are blocked by `SAAS_IMMUTABLE_KEYS` in `lib/settings.ts`, so a
- * platform admin cannot re-open the hole at runtime.
+ * Reads the env var via `readSaasEnv()` rather than `getSetting()`.
+ * Two reasons: matches the env-direct pattern of `InternalDbGuardLive`,
+ * and makes the operator contract crisp — the env var must be set at
+ * deploy time. Post-boot writes via `setSetting` are blocked by
+ * `SAAS_IMMUTABLE_KEYS` in `lib/settings.ts`, so a platform admin
+ * cannot re-open the hole at runtime.
  */
 export const RateLimitGuardLive: Layer.Layer<never, RateLimitRequiredError, Config> = Layer.effectDiscard(
   Effect.gen(function* () {
     const { config } = yield* Config;
     if (config.deployMode !== "saas") return;
 
-    const raw = process.env.ATLAS_RATE_LIMIT_RPM;
+    const raw = readSaasEnv().ATLAS_RATE_LIMIT_RPM;
     if (raw === undefined || raw === "") {
       return yield* Effect.fail(
         new RateLimitRequiredError({
@@ -498,8 +501,9 @@ function isPlausiblePostgresUrl(raw: unknown): boolean {
  */
 function resolveClaimedRegion(
   config: { residency?: { defaultRegion?: string } | undefined },
+  env: SaasEnv,
 ): string | null {
-  const envRegion = process.env.ATLAS_API_REGION;
+  const envRegion = env.ATLAS_API_REGION;
   if (envRegion && envRegion.length > 0) return envRegion;
   return config.residency?.defaultRegion ?? null;
 }
@@ -525,7 +529,7 @@ export const RegionGuardLive: Layer.Layer<never, RegionMisconfiguredError, Confi
     const { config } = yield* Config;
     if (config.deployMode !== "saas") return;
 
-    const claimedRegion = resolveClaimedRegion(config);
+    const claimedRegion = resolveClaimedRegion(config, readSaasEnv());
     // No region claimed at all. The misrouting middleware also no-ops
     // in this case, so the contract is consistent.
     if (claimedRegion === null) return;
@@ -579,8 +583,8 @@ export const RegionGuardLive: Layer.Layer<never, RegionMisconfiguredError, Confi
  * "fail boot rather than run with stale plugin state" contracts and
  * splitting the knob would force operators to remember two flags.
  */
-function isStrictPluginMode(): boolean {
-  return process.env.ATLAS_STRICT_PLUGIN_SECRETS === "true";
+function isStrictPluginMode(env: SaasEnv): boolean {
+  return env.ATLAS_STRICT_PLUGIN_SECRETS === "true";
 }
 
 /**
@@ -621,6 +625,7 @@ function isStrictPluginMode(): boolean {
 export const PluginConfigGuardLive: Layer.Layer<never, PluginConfigStaleError | PluginConfigCheckFailedError, Config> = Layer.effectDiscard(
   Effect.gen(function* () {
     yield* Config;
+    const env = readSaasEnv();
 
     // The inner async function catches every synchronous throw and the
     // dynamic `import()` rejection, converting both into a discriminated
@@ -654,7 +659,7 @@ export const PluginConfigGuardLive: Layer.Layer<never, PluginConfigStaleError | 
       // the same default for "we couldn't even check"). Otherwise log
       // and continue; the validation function itself follows the same
       // policy for unexpected DB errors so the contract is consistent.
-      if (isStrictPluginMode()) {
+      if (isStrictPluginMode(env)) {
         return yield* Effect.fail(
           new PluginConfigCheckFailedError({
             cause: result.cause,
@@ -675,7 +680,7 @@ export const PluginConfigGuardLive: Layer.Layer<never, PluginConfigStaleError | 
 
     if (result.issues.length === 0) return;
 
-    if (isStrictPluginMode()) {
+    if (isStrictPluginMode(env)) {
       yield* Effect.fail(
         new PluginConfigStaleError({
           issues: result.issues,

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -556,7 +556,7 @@ export const RegionGuardLive: Layer.Layer<never, RegionMisconfiguredError, Confi
 
     const regionEntry = regions[claimedRegion] as { databaseUrl?: unknown } | undefined;
     if (!isPlausiblePostgresUrl(regionEntry?.databaseUrl)) {
-      yield* Effect.fail(
+      return yield* Effect.fail(
         new RegionMisconfiguredError({
           claimedRegion,
           availableRegions,

--- a/scripts/saas-env-fixture.ts
+++ b/scripts/saas-env-fixture.ts
@@ -1,0 +1,134 @@
+#!/usr/bin/env bun
+/**
+ * Emit a CI-ready SaaS env block in `KEY=VALUE` (Docker `--env-file`) format.
+ *
+ * Pipeline:
+ *
+ *   bun run scripts/saas-env-fixture.ts \
+ *     --database-url postgresql://atlas:atlas@127.0.0.1:5432/atlas \
+ *     > /tmp/saas.env
+ *   docker run -d --env-file /tmp/saas.env atlas-api:boot-smoke
+ *
+ * The single source of truth for which keys are emitted is
+ * `packages/api/src/lib/effect/saas-env.ts :: makeBootSmokeFixture`.
+ * Adding a new SaaS guard means appending its env var to that fixture
+ * — this script (and the boot-smoke workflow that consumes its output)
+ * automatically picks up the new value with no further edits.
+ *
+ * Usage:
+ *   --database-url <url>   Postgres URL applied to internal DB,
+ *                          datasource, and every region. Required.
+ *   --override KEY=VALUE   Override a single key (repeatable). Useful
+ *                          for failure-mode probes (e.g. drop a
+ *                          required key to verify the gate fails).
+ *   --omit KEY             Omit a key entirely from the output (its
+ *                          fixture default is dropped). Repeatable.
+ *
+ * Values are emitted as raw `KEY=VALUE`. Docker's `--env-file` parser
+ * is line-oriented and does NOT support quoting, so this script
+ * deliberately rejects values containing newlines (newline in a SaaS
+ * boot-contract value is always a misconfig). Equals signs in values
+ * are fine — Docker splits on the first `=` only.
+ */
+
+// Relative import: this script lives in the repo root scripts/ dir,
+// where the @atlas/api workspace alias is not resolvable (root has no
+// dependency on it). Other root scripts (e.g. generate-brand-assets.tsx)
+// avoid this by using only root devDependencies.
+import {
+  makeBootSmokeFixture,
+  SAAS_ENV_KEYS,
+  type SaasEnv,
+} from "../packages/api/src/lib/effect/saas-env";
+
+interface Args {
+  databaseUrl?: string;
+  overrides: Partial<SaasEnv>;
+  omit: Set<keyof SaasEnv>;
+}
+
+function parseArgs(argv: readonly string[]): Args {
+  const args: Args = { overrides: {}, omit: new Set() };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--database-url") {
+      args.databaseUrl = argv[++i];
+    } else if (arg === "--override") {
+      const next = argv[++i];
+      if (!next || !next.includes("=")) {
+        throw new Error(
+          `--override expects KEY=VALUE, got ${JSON.stringify(next)}`,
+        );
+      }
+      const eq = next.indexOf("=");
+      const key = next.slice(0, eq) as keyof SaasEnv;
+      const value = next.slice(eq + 1);
+      if (!SAAS_ENV_KEYS.includes(key as (typeof SAAS_ENV_KEYS)[number])) {
+        throw new Error(
+          `--override key ${JSON.stringify(key)} is not a SaasEnv key. ` +
+            `Valid keys: ${SAAS_ENV_KEYS.join(", ")}`,
+        );
+      }
+      args.overrides[key] = value;
+    } else if (arg === "--omit") {
+      const key = argv[++i] as keyof SaasEnv;
+      if (!SAAS_ENV_KEYS.includes(key as (typeof SAAS_ENV_KEYS)[number])) {
+        throw new Error(
+          `--omit key ${JSON.stringify(key)} is not a SaasEnv key. ` +
+            `Valid keys: ${SAAS_ENV_KEYS.join(", ")}`,
+        );
+      }
+      args.omit.add(key);
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${JSON.stringify(arg)}`);
+    }
+  }
+  return args;
+}
+
+function printHelp(): void {
+  process.stdout.write(
+    `Usage: bun run scripts/saas-env-fixture.ts [options]\n\n` +
+      `Options:\n` +
+      `  --database-url <url>   Postgres URL for internal DB + datasource + regions\n` +
+      `  --override KEY=VALUE   Override a single key (repeatable)\n` +
+      `  --omit KEY             Drop a key from output (repeatable)\n` +
+      `  --help, -h             Show this help\n`,
+  );
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+
+  const fixture = makeBootSmokeFixture({
+    ...(args.databaseUrl ? { databaseUrl: args.databaseUrl } : {}),
+    overrides: args.overrides,
+  });
+
+  const lines: string[] = [];
+  for (const key of SAAS_ENV_KEYS) {
+    if (args.omit.has(key)) continue;
+    const value = fixture[key];
+    if (value === undefined) continue;
+    if (value.includes("\n")) {
+      throw new Error(
+        `SaaS fixture value for ${key} contains a newline — Docker --env-file ` +
+          `is line-oriented and cannot represent it. This indicates a misconfig in ` +
+          `makeBootSmokeFixture; newlines in boot-contract values are not legitimate.`,
+      );
+    }
+    lines.push(`${key}=${value}`);
+  }
+  process.stdout.write(lines.join("\n") + "\n");
+}
+
+try {
+  main();
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`saas-env-fixture: ${message}\n`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Closes #2226. Two-phase deploy gate that catches container-boot regressions: SaaS guard drift, `serverExternalPackages` drift, Dockerfile COPY drift (sibling of #2206), `start.sh` regressions, healthcheck path drift, and prod-mode bundling errors invisible to unit tests.

### Phase 1 — env contract single source of truth

- New `packages/api/src/lib/effect/saas-env.ts` exports:
  - `SaasEnv` — typed shape of every env var the SaaS-mode boot reads
  - `SAAS_ENV_KEYS` — compile-time exhaustive array (catches drift via `_ExhaustiveCheck`)
  - `readSaasEnv()` — typed accessor used by the guards
  - `makeBootSmokeFixture()` — CI-ready defaults, used by the fixture script and tests
- Adding a new SaaS guard means appending one field here; the workflow auto-picks up the value with no edits.
- `saas-guards.ts` (every guard) and `layers.ts :: MigrationGuardLive` refactored to read via `readSaasEnv()` instead of free-standing `process.env.X`.

### Phase 2 — boot smoke workflow

- New `boot-smoke` job in `.github/workflows/deploy-validation.yml`:
  - postgres:16-alpine service container
  - `docker/setup-buildx-action` + `docker/build-push-action` with `gha` cache (warm runs ~30–60s)
  - Builds `deploy/api/Dockerfile`, runs under fixture env, probes `/api/health` within 90s, dumps container logs on failure
  - Joins the `deploy-validation-required` umbrella so branch protection sees it
- `scripts/saas-env-fixture.ts` emits Docker `--env-file` format; supports `--override KEY=VALUE` and `--omit KEY` for failure-mode probes.

### Probe philosophy

Any HTTP response from `/api/health` (200 or 503) means boot guards passed and the listener is up. Connection refused is the failure signal — that's what a SaaS guard rejection produces. CI legitimately lacks an LLM provider key so `/api/health` returns 503 with `status="degraded"`; forcing 200 would require paid CI secrets without adding signal.

## Verification (local)

| Path | Result |
|---|---|
| Valid fixture | HTTP 200, `status="degraded"` (only LLM provider missing) |
| `ATLAS_RATE_LIMIT_RPM=0` override | Connection refused, `RateLimitRequiredError` in dump pointing at `saas-guards.ts:466` |

## Acceptance criteria

- [x] `SaasEnv` typed shape in `packages/api/src/lib/effect/saas-env.ts`; every guard reads from it
- [x] `scripts/saas-env-fixture.ts` emits a valid CI-mode env block
- [x] New `boot-smoke` job builds prod Dockerfile + boots + probes /api/health
- [x] Failure-mode probe (bad rate-limit) verified: gate fails with the underlying SaaS guard error in the dump
- [x] Workflow caches Docker layers via `gha` so warm builds stay under the 5 min budget
- [x] Lint + type + saas tests + syncpack + template drift + railway-watch + schema drift + security headers + oauth-helper drift — all green
- [x] Compile-time exhaustiveness on `SAAS_ENV_KEYS` (adding a SaasEnv field without listing it in the key array fails type-check)

## Test plan

- [ ] CI passes on this PR (real boot smoke against fresh ubuntu-latest)
- [ ] Architecture-wins entry recorded after merge in `.claude/research/architecture-wins.md` (env-contract consolidation)

## Related

- Closes #2226
- Builds on #2225 (tier-1 migration smoke) — this is the tier-2 follow-up
- Catches the same class as #2206 (Dockerfile drift incident)