### PR TITLE
fix(api): #2252 — PluginConfigGuardLive warn-only branches surface cause

### DIFF
--- a/packages/api/src/lib/effect/__tests__/plugin-config-guard.test.ts
+++ b/packages/api/src/lib/effect/__tests__/plugin-config-guard.test.ts
@@ -12,14 +12,31 @@
 import { describe, test, expect, mock } from "bun:test";
 import { Effect, Exit, Layer } from "effect";
 
+// Recording logger mock — captures every `log.warn` / `log.error` call
+// so #2252 regression tests can assert the warn-only branches surface
+// the cause instead of dropping it. Reset between tests via
+// `loggerCalls.length = 0`.
+interface LoggerCall {
+  readonly level: "error" | "warn" | "info" | "debug";
+  readonly arg: unknown;
+  readonly message?: string;
+}
+const loggerCalls: LoggerCall[] = [];
+function makeRecordingLogger() {
+  return {
+    error: (arg: unknown, message?: string) =>
+      loggerCalls.push({ level: "error", arg, ...(message !== undefined && { message }) }),
+    warn: (arg: unknown, message?: string) =>
+      loggerCalls.push({ level: "warn", arg, ...(message !== undefined && { message }) }),
+    info: (arg: unknown, message?: string) =>
+      loggerCalls.push({ level: "info", arg, ...(message !== undefined && { message }) }),
+    debug: (arg: unknown, message?: string) =>
+      loggerCalls.push({ level: "debug", arg, ...(message !== undefined && { message }) }),
+  };
+}
 mock.module("@atlas/api/lib/logger", () => ({
-  createLogger: () => ({
-    error: () => {},
-    warn: () => {},
-    info: () => {},
-    debug: () => {},
-  }),
-  getLogger: () => ({ error: () => {}, warn: () => {}, info: () => {}, debug: () => {}, level: "info" }),
+  createLogger: makeRecordingLogger,
+  getLogger: () => ({ ...makeRecordingLogger(), level: "info" }),
   setLogLevel: () => true,
   getRequestContext: () => undefined,
 }));
@@ -191,6 +208,41 @@ describe("PluginConfigGuardLive", () => {
         ),
       );
       expect(Exit.isSuccess(exit)).toBe(true);
+    });
+  });
+
+  // #2252: the warn-only validator-throw branch must log the cause —
+  // dropping it on the floor was the silent-failure-hunter finding.
+  test("#2252 — warn-only validator throw logs cause at warn level", async () => {
+    await withCleanEnv(async () => {
+      loggerCalls.length = 0;
+      const cause = new Error("third-party plugin getConfigSchema() blew up");
+      mockValidator({ kind: "throws", error: cause });
+      const exit = await Effect.runPromiseExit(
+        Effect.void.pipe(
+          Effect.provide(
+            PluginConfigGuardLive.pipe(
+              Layer.provide(makeTestConfigLayer({ deployMode: "saas" })),
+            ),
+          ),
+        ),
+      );
+      expect(Exit.isSuccess(exit)).toBe(true);
+
+      // Assert at least one warn call carrying the cause and naming
+      // the issue refs (#1988 / #2252) so a future refactor can't
+      // silently drop the log without tripping this test.
+      const warnsCarryingCause = loggerCalls.filter(
+        (c) =>
+          c.level === "warn" &&
+          typeof c.arg === "object" &&
+          c.arg !== null &&
+          "err" in c.arg &&
+          (c.arg as { err: unknown }).err === cause,
+      );
+      expect(warnsCarryingCause.length).toBeGreaterThan(0);
+      const messages = warnsCarryingCause.map((c) => c.message ?? "").join(" ");
+      expect(messages).toContain("#2252");
     });
   });
 

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -78,8 +78,11 @@
  */
 
 import { Data, Effect, Layer } from "effect";
+import { createLogger } from "@atlas/api/lib/logger";
 import { Config } from "./layers";
 import { readSaasEnv, type SaasEnv } from "./saas-env";
+
+const log = createLogger("effect:saas-guards");
 
 const ISSUE_REF = "#1978";
 const RATE_LIMIT_ISSUE_REF = "#1983";
@@ -674,7 +677,16 @@ export const PluginConfigGuardLive: Layer.Layer<never, PluginConfigStaleError | 
       // Warn-only: surface the failure but keep booting. The strict
       // path covers operators who explicitly chose "fail boot on this
       // class of error"; everyone else keeps the existing "best effort
-      // validation" behavior.
+      // validation" behavior. Log loudly so the cause is in the boot
+      // log even when boot continues — without this the underlying
+      // error (third-party plugin throwing in `getConfigSchema()`,
+      // JSONB shape drift, module-load failure) would be dropped on
+      // the floor (#2252).
+      log.warn(
+        { err: result.cause },
+        `Plugin config validation threw — proceeding without stale-config checks ` +
+          `(set ATLAS_STRICT_PLUGIN_SECRETS=true to fail boot instead). See ${ISSUE_REF_1988} / #2252.`,
+      );
       return;
     }
 
@@ -692,6 +704,14 @@ export const PluginConfigGuardLive: Layer.Layer<never, PluginConfigStaleError | 
         }),
       );
     }
+    // Warn-only stale-config branch: per-issue `log.warn` lines are
+    // already emitted by `validateStoredPluginConfigs()` itself
+    // (`lib/plugins/validation.ts:180`), and SaaS regions ALSO get a
+    // single `log.error` summary there (line 195). No additional log
+    // call needed at this site — but the cross-reference is load-bearing
+    // because the docstring at the top of this guard claims "stale
+    // configs are always logged as warnings", and that promise lives
+    // in the validator, not here. See #2252.
   }),
 );
 


### PR DESCRIPTION
## Summary

Closes #2252. silent-failure-hunter caught this during /pr-review on #2251 — the two warn-only branches in `PluginConfigGuardLive` returned without logging the cause when `ATLAS_STRICT_PLUGIN_SECRETS` was unset.

### Two distinct fixes (validator already covers half)

1. **`PluginConfigCheckFailedError` warn-only branch** — adds an explicit `log.warn({ err: result.cause }, …)` before the bare `return`. The validator throws before emitting any of its own logs, so without this a self-hosted operator (or non-strict SaaS region) had no signal the boot-time validation aborted.

2. **`PluginConfigStaleError` warn-only branch** — already covered: per-issue `log.warn` calls in `validateStoredPluginConfigs()` ([validation.ts:180](packages/api/src/lib/plugins/validation.ts#L180)) + a SaaS-only `log.error` summary at line 195. Adds a load-bearing comment at the guard site pointing at that wiring so the docstring's "stale configs are always logged as warnings" promise stays grep-able.

### Tests

- Recording-logger mock added to `plugin-config-guard.test.ts` (replaces the no-op mock)
- New regression test asserts the warn-only validator-throw branch emits a warn carrying both the cause `Error` and the #2252 issue ref so a future refactor can't silently drop the log
- All 7 plugin-config-guard tests pass; lint + type + affected api suite green

## Test plan

- [ ] CI green on this PR
- [ ] `/pr-review` shows no new findings

## Related

- #2252 — issue
- #2251 — PR where this was discovered (boot smoke / SaaS env contract)
- #1988 — original PluginConfigGuardLive