### PR TITLE
feat(web,admin): #2176 — persistent admin top bar with org breadcrumb + avatar menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ docs/superpowers/
 # Lighthouse CLI dumps Chrome's profile dir into cwd as a Windows-shaped path
 # under WSL2. Pre-empt it so `git add` doesn't sweep ~50KB of garbage in.
 C:\\Users\\*
+critique-*.png

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -52,8 +52,13 @@ export type AdminRole = (typeof ADMIN_ROLES)[number];
 // a single source of truth for auth client shapes.
 
 /**
- * Duck-typed interface that matches better-auth's client shape.
- * Components like ManagedAuthCard call signIn/signUp/signOut and useSession().
+ * Duck-typed interface that matches better-auth's client shape. Only the
+ * fields Atlas actually reads or calls are declared — adding a new
+ * better-auth API to the surface is a deliberate edit here, which is the
+ * right friction for an external dependency.
+ *
+ * Recurring `as unknown as { ... }` casts at call sites mean a field is
+ * missing from this surface — widen here instead of widening one consumer.
  */
 export interface AtlasAuthClient {
   signIn: {
@@ -63,7 +68,34 @@ export interface AtlasAuthClient {
     email: (opts: { email: string; password: string; name: string }) => Promise<{ error?: { message?: string } | null }>;
   };
   signOut: () => Promise<unknown>;
-  useSession: () => { data?: { user?: { email?: string; role?: string } } | null; isPending: boolean };
+  /**
+   * Update the signed-in user's profile fields. Better Auth ships more
+   * keys than `name`; declare only the ones Atlas actually writes.
+   */
+  updateUser?: (opts: { name?: string }) => Promise<{ error?: { message?: string } | null }>;
+  useSession: () => {
+    data?: {
+      user?: {
+        email?: string;
+        role?: string;
+        /** Display name — present at runtime, not always populated. */
+        name?: string;
+        /** True when TOTP is enrolled — surfaced by the two-factor plugin. */
+        twoFactorEnabled?: boolean;
+      };
+      session?: {
+        /** Session row id — used to identify "this session" in revoke flows. */
+        id?: string;
+        /** Active organization id — set by the organization plugin. */
+        activeOrganizationId?: string;
+        /** Active organization name — fallback when the org list hasn't loaded. */
+        activeOrganizationName?: string;
+      };
+    } | null;
+    isPending: boolean;
+    /** Imperative refetch — better-auth exposes this on the React hook. */
+    refetch?: () => unknown;
+  };
 }
 
 /** Auth helpers passed to action approval cards via context. */

--- a/packages/web/src/components/ui/avatar.tsx
+++ b/packages/web/src/components/ui/avatar.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import * as React from "react"
+import { Avatar as AvatarPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Avatar({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Root> & {
+  size?: "default" | "sm" | "lg"
+}) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      data-size={size}
+      className={cn(
+        "group/avatar relative flex size-8 shrink-0 overflow-hidden rounded-full select-none data-[size=lg]:size-10 data-[size=sm]:size-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarImage({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn("aspect-square size-full", className)}
+      {...props}
+    />
+  )
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "flex size-full items-center justify-center rounded-full bg-muted text-sm text-muted-foreground group-data-[size=sm]/avatar:text-xs",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="avatar-badge"
+      className={cn(
+        "absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-primary text-primary-foreground ring-2 ring-background select-none",
+        "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
+        "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
+        "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group"
+      className={cn(
+        "group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:ring-background",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroupCount({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group-count"
+      className={cn(
+        "relative flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm text-muted-foreground ring-2 ring-background group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  AvatarBadge,
+  AvatarGroup,
+  AvatarGroupCount,
+}

--- a/packages/web/src/components/ui/breadcrumb.tsx
+++ b/packages/web/src/components/ui/breadcrumb.tsx
@@ -1,0 +1,109 @@
+import * as React from "react"
+import { ChevronRight, MoreHorizontal } from "lucide-react"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Breadcrumb({ ...props }: React.ComponentProps<"nav">) {
+  return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />
+}
+
+function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
+  return (
+    <ol
+      data-slot="breadcrumb-list"
+      className={cn(
+        "flex flex-wrap items-center gap-1.5 text-sm break-words text-muted-foreground sm:gap-2.5",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-item"
+      className={cn("inline-flex items-center gap-1.5", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbLink({
+  asChild,
+  className,
+  ...props
+}: React.ComponentProps<"a"> & {
+  asChild?: boolean
+}) {
+  const Comp = asChild ? Slot.Root : "a"
+
+  return (
+    <Comp
+      data-slot="breadcrumb-link"
+      className={cn("transition-colors hover:text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-page"
+      role="link"
+      aria-disabled="true"
+      aria-current="page"
+      className={cn("font-normal text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-separator"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("[&>svg]:size-3.5", className)}
+      {...props}
+    >
+      {children ?? <ChevronRight />}
+    </li>
+  )
+}
+
+function BreadcrumbEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-ellipsis"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("flex size-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontal className="size-4" />
+      <span className="sr-only">More</span>
+    </span>
+  )
+}
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+}

--- a/packages/web/src/ui/__tests__/admin-sidebar-saas.test.tsx
+++ b/packages/web/src/ui/__tests__/admin-sidebar-saas.test.tsx
@@ -59,11 +59,6 @@ mock.module("@/components/ui/collapsible", () => ({
   CollapsibleContent: ({ children }: { children: React.ReactNode }) => React.createElement("div", null, children),
 }));
 
-// Mock org-switcher
-mock.module("@/ui/components/org-switcher", () => ({
-  OrgSwitcher: () => React.createElement("div", { "data-testid": "org-switcher" }),
-}));
-
 // Mock separator
 mock.module("@/components/ui/separator", () => ({
   Separator: () => React.createElement("hr"),

--- a/packages/web/src/ui/__tests__/admin-sidebar.test.tsx
+++ b/packages/web/src/ui/__tests__/admin-sidebar.test.tsx
@@ -62,11 +62,6 @@ mock.module("@/components/ui/collapsible", () => ({
   CollapsibleContent: ({ children }: { children: React.ReactNode }) => React.createElement("div", null, children),
 }));
 
-// Mock org-switcher
-mock.module("@/ui/components/org-switcher", () => ({
-  OrgSwitcher: () => React.createElement("div", { "data-testid": "org-switcher" }),
-}));
-
 // Mock shadcn separator
 mock.module("@/components/ui/separator", () => {
 

--- a/packages/web/src/ui/__tests__/admin-sidebar.test.tsx
+++ b/packages/web/src/ui/__tests__/admin-sidebar.test.tsx
@@ -103,10 +103,14 @@ describe("AdminSidebar", () => {
     expect(container.textContent).toContain("Back to Chat");
   });
 
-  test("renders Atlas branding", () => {
+  test("sidebar header renders the logo affordance, not duplicated workspace text", () => {
+    // Workspace name + "Admin Console" live in the top-bar breadcrumb now
+    // (#2176). The sidebar header is logo-only — the link still navigates
+    // home but doesn't repeat the labels.
     const { container } = render(<AdminSidebar />, { wrapper: Wrapper });
-    expect(container.textContent).toContain("Atlas");
-    expect(container.textContent).toContain("Admin Console");
+    const homeLink = container.querySelector('a[aria-label="Admin home"]');
+    expect(homeLink).not.toBeNull();
+    expect(homeLink?.getAttribute("href")).toBe("/admin");
   });
 
   test("renders overview and back-to-chat hrefs", () => {

--- a/packages/web/src/ui/__tests__/user-menu-initials.test.ts
+++ b/packages/web/src/ui/__tests__/user-menu-initials.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { deriveInitials } from "../components/user-menu";
+
+describe("deriveInitials", () => {
+  test("uses first letter of two name parts", () => {
+    expect(deriveInitials("Ada Lovelace", null)).toBe("AL");
+  });
+
+  test("falls back to email when name is missing", () => {
+    expect(deriveInitials(null, "ada.lovelace@example.com")).toBe("AL");
+  });
+
+  test("returns single letter for one-word name", () => {
+    expect(deriveInitials("Ada", null)).toBe("A");
+  });
+
+  test("falls back to '?' when both inputs are blank", () => {
+    expect(deriveInitials(null, null)).toBe("?");
+    expect(deriveInitials("", "")).toBe("?");
+    expect(deriveInitials("   ", "   ")).toBe("?");
+  });
+
+  test("name takes precedence over email", () => {
+    expect(deriveInitials("Bob Builder", "ada@example.com")).toBe("BB");
+  });
+
+  test("handles email-only input with single local part", () => {
+    expect(deriveInitials(null, "ada@example.com")).toBe("AE");
+  });
+});

--- a/packages/web/src/ui/__tests__/user-menu.test.tsx
+++ b/packages/web/src/ui/__tests__/user-menu.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, test, mock, beforeEach } from "bun:test";
+import React from "react";
+
+mock.module("sonner", () => ({
+  toast: { error: () => {} },
+}));
+
+mock.module("@/ui/hooks/use-dark-mode", () => ({
+  setTheme: () => {},
+  useThemeMode: () => "system",
+}));
+
+let sessionData: { user?: { name?: string; email?: string; role?: string } } | null = null;
+mock.module("@/ui/context", () => ({
+  useAtlasConfig: () => ({
+    apiUrl: "http://localhost:3001",
+    isCrossOrigin: false,
+    authClient: {
+      signOut: () => Promise.resolve(),
+      useSession: () => ({ data: sessionData, isPending: false }),
+    },
+  }),
+}));
+
+import { render, cleanup } from "@testing-library/react";
+import { UserMenu } from "../components/user-menu";
+
+beforeEach(() => {
+  cleanup();
+});
+
+describe("UserMenu", () => {
+  test("renders nothing when there is no signed-in user", () => {
+    sessionData = null;
+    const { container } = render(<UserMenu />);
+    // No user → no avatar trigger
+    expect(container.querySelector('button[aria-label="Account menu"]')).toBeNull();
+  });
+
+  test("renders the avatar trigger with derived initials when a user is present", () => {
+    sessionData = { user: { name: "Ada Lovelace", email: "ada@example.com" } };
+    const { container } = render(<UserMenu />);
+    const trigger = container.querySelector('button[aria-label="Account menu"]');
+    expect(trigger).not.toBeNull();
+    expect(trigger?.textContent).toBe("AL");
+  });
+
+  test("falls back to email-derived initials when name is missing", () => {
+    sessionData = { user: { email: "ada.lovelace@example.com" } };
+    const { container } = render(<UserMenu />);
+    const trigger = container.querySelector('button[aria-label="Account menu"]');
+    expect(trigger?.textContent).toBe("AL");
+  });
+});

--- a/packages/web/src/ui/components/admin/__tests__/admin-nav.test.ts
+++ b/packages/web/src/ui/components/admin/__tests__/admin-nav.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { navGroups, resolveAdminBreadcrumb } from "../admin-nav";
+
+describe("resolveAdminBreadcrumb", () => {
+  test("returns empty crumb on the overview", () => {
+    expect(resolveAdminBreadcrumb("/admin")).toEqual({});
+  });
+
+  test("matches an exact-mode item without prefix-matching its children", () => {
+    // /admin/semantic is exact:true so /admin/semantic/improve must not collapse
+    // into the Semantic-Layer entry.
+    expect(resolveAdminBreadcrumb("/admin/semantic")).toEqual({
+      section: "Data",
+      page: "Semantic Layer",
+    });
+    expect(resolveAdminBreadcrumb("/admin/semantic/improve")).toEqual({
+      section: "Data",
+      page: "Improve Layer",
+    });
+  });
+
+  test("matches a prefix-mode item for nested routes", () => {
+    expect(resolveAdminBreadcrumb("/admin/audit")).toEqual({
+      section: "Monitoring",
+      page: "Audit Log",
+    });
+    expect(resolveAdminBreadcrumb("/admin/audit/123")).toEqual({
+      section: "Monitoring",
+      page: "Audit Log",
+    });
+  });
+
+  test("returns empty crumb for an unmapped /admin/* path", () => {
+    expect(resolveAdminBreadcrumb("/admin/totally-not-a-route")).toEqual({});
+  });
+
+  test("every nav item resolves to its own group/label round-trip", () => {
+    // Belt + suspenders: the resolver and the navGroups list must stay in
+    // lockstep — adding a new sidebar item without updating the resolver
+    // would silently miss the breadcrumb label.
+    for (const group of navGroups) {
+      for (const item of group.items) {
+        const crumb = resolveAdminBreadcrumb(item.href);
+        expect(crumb.section).toBe(group.title);
+        expect(crumb.page).toBe(item.label);
+      }
+    }
+  });
+});

--- a/packages/web/src/ui/components/admin/__tests__/admin-top-bar.test.tsx
+++ b/packages/web/src/ui/components/admin/__tests__/admin-top-bar.test.tsx
@@ -1,0 +1,89 @@
+import { describe, expect, test, mock } from "bun:test";
+import React from "react";
+import type { ReactNode } from "react";
+
+let mockedPath = "/admin";
+mock.module("next/navigation", () => ({
+  usePathname: () => mockedPath,
+}));
+
+mock.module("next/link", () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) =>
+    React.createElement("a", { href }, children),
+}));
+
+mock.module("@/components/ui/sidebar", () => ({
+  SidebarTrigger: () => React.createElement("button", { "data-testid": "sidebar-trigger" }),
+}));
+
+mock.module("@/components/ui/separator", () => ({
+  Separator: () => React.createElement("hr"),
+}));
+
+// OrgSwitcher hits the auth client at module load — stub to a stable label
+// so the breadcrumb is the only thing under test.
+mock.module("@/ui/components/org-switcher", () => ({
+  OrgSwitcher: () => React.createElement("span", { "data-testid": "org-switcher" }, "Acme"),
+}));
+
+mock.module("@/ui/components/user-menu", () => ({
+  UserMenu: () => React.createElement("div", { "data-testid": "user-menu" }),
+}));
+
+import { render, cleanup } from "@testing-library/react";
+import { AdminTopBar } from "../admin-top-bar";
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return React.createElement(React.Fragment, null, children);
+}
+
+describe("AdminTopBar breadcrumb", () => {
+  test("/admin renders [org] / Admin Console", () => {
+    mockedPath = "/admin";
+    cleanup();
+    const { container } = render(<AdminTopBar />, { wrapper: Wrapper });
+    expect(container.textContent).toContain("Acme");
+    expect(container.textContent).toContain("Admin Console");
+    expect(container.textContent).not.toContain("Admin /");
+  });
+
+  test("/admin/security renders [org] / Admin / Security / MFA & Sessions", () => {
+    mockedPath = "/admin/security";
+    cleanup();
+    const { container } = render(<AdminTopBar />, { wrapper: Wrapper });
+    expect(container.textContent).toContain("Acme");
+    expect(container.textContent).toContain("Admin");
+    expect(container.textContent).toContain("Security");
+    expect(container.textContent).toContain("MFA & Sessions");
+    // The "Admin" link goes back to /admin so deep crumbs are navigable.
+    const adminLink = container.querySelector('a[href="/admin"]');
+    expect(adminLink?.textContent).toBe("Admin");
+  });
+
+  test("/admin/semantic/improve resolves the improve-layer leaf, not the parent", () => {
+    mockedPath = "/admin/semantic/improve";
+    cleanup();
+    const { container } = render(<AdminTopBar />, { wrapper: Wrapper });
+    expect(container.textContent).toContain("Improve Layer");
+    expect(container.textContent).not.toContain("Semantic Layer");
+  });
+
+  test("/admin/settings/mcp resolves to MCP, not Settings (regression on exact-match flag)", () => {
+    mockedPath = "/admin/settings/mcp";
+    cleanup();
+    const { container } = render(<AdminTopBar />, { wrapper: Wrapper });
+    expect(container.textContent).toContain("MCP");
+    // "Settings" is the section name (Configuration), not the page label here.
+    const text = container.textContent ?? "";
+    // Page label MCP appears, and "Configuration" (group) appears, but the
+    // sibling "Settings" leaf entry must not collapse the MCP child.
+    expect(text.includes("Configuration")).toBe(true);
+  });
+
+  test("an unmapped /admin/* path collapses to overview crumb", () => {
+    mockedPath = "/admin/totally-not-a-route";
+    cleanup();
+    const { container } = render(<AdminTopBar />, { wrapper: Wrapper });
+    expect(container.textContent).toContain("Admin Console");
+  });
+});

--- a/packages/web/src/ui/components/admin/admin-layout.tsx
+++ b/packages/web/src/ui/components/admin/admin-layout.tsx
@@ -3,8 +3,7 @@
 import type { ReactNode } from "react";
 import { useEffect } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { SidebarProvider, SidebarInset, SidebarTrigger } from "@/components/ui/sidebar";
-import { Separator } from "@/components/ui/separator";
+import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -16,6 +15,7 @@ import {
 import { ShieldX } from "lucide-react";
 import Link from "next/link";
 import { AdminSidebar } from "./admin-sidebar";
+import { AdminTopBar } from "./admin-top-bar";
 import { useAtlasConfig } from "@/ui/context";
 import { LoadingState } from "./loading-state";
 import { ChangePasswordDialog } from "./change-password-dialog";
@@ -106,13 +106,7 @@ function AdminLayoutInner({ children }: { children: ReactNode }) {
     <SidebarProvider className="!min-h-0 h-full">
       <AdminSidebar />
       <SidebarInset id="main" tabIndex={-1}>
-        <header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
-          <div className="flex items-center gap-2 px-4">
-            <SidebarTrigger className="-ml-1" />
-            <Separator orientation="vertical" className="mr-2 h-4" />
-            <span className="text-sm font-medium text-muted-foreground">Admin Console</span>
-          </div>
-        </header>
+        <AdminTopBar />
         <ScrollArea className="flex-1">{children}</ScrollArea>
       </SidebarInset>
 

--- a/packages/web/src/ui/components/admin/admin-layout.tsx
+++ b/packages/web/src/ui/components/admin/admin-layout.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from "react";
 import { useEffect } from "react";
+import { toast } from "sonner";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { Button } from "@/components/ui/button";
@@ -92,7 +93,15 @@ function AdminLayoutInner({ children }: { children: ReactNode }) {
             <Button
               variant="ghost"
               className="w-full"
-              onClick={() => authClient.signOut().then(() => window.location.assign("/login"))}
+              onClick={() => {
+                authClient.signOut()
+                  .then(() => window.location.assign("/login"))
+                  .catch((err: unknown) => {
+                    const msg = err instanceof Error ? err.message : String(err);
+                    console.error("Sign out failed:", msg);
+                    toast.error("Sign out failed. Try again.");
+                  });
+              }}
             >
               Sign in as a different user
             </Button>

--- a/packages/web/src/ui/components/admin/admin-nav.ts
+++ b/packages/web/src/ui/components/admin/admin-nav.ts
@@ -12,13 +12,10 @@ import {
 export interface NavSubItem {
   href: string;
   label: string;
-  /** When true, only highlight on exact pathname match (no prefix matching). */
+  /** When true, exact-match only (no prefix). Needed for parent routes that share a prefix with a child (e.g. `/admin/settings` vs `/admin/settings/mcp`). */
   exact?: boolean;
-  /** When set, only users with this role see this item. */
   requiredRole?: "platform_admin";
-  /** When true, this item is hidden in SaaS deploy mode. */
   selfHostedOnly?: boolean;
-  /** When set, shows a numeric badge next to the label. */
   badge?: number;
 }
 
@@ -123,17 +120,11 @@ export const navGroups: NavGroup[] = [
 ];
 
 export interface AdminBreadcrumb {
-  /** Section name (matches a NavGroup.title) — `undefined` on the `/admin` overview. */
   section?: string;
-  /** Page label (matches a NavSubItem.label) — `undefined` when only a section is active. */
   page?: string;
 }
 
-/**
- * Resolve the active section + page labels for a `/admin/*` pathname using the
- * shared `navGroups` registry. Used by the top-bar breadcrumb so both sidebar
- * and breadcrumb derive labels from a single source of truth.
- */
+/** Single source of truth so sidebar + breadcrumb labels can never drift. */
 export function resolveAdminBreadcrumb(pathname: string): AdminBreadcrumb {
   if (pathname === "/admin") return {};
 

--- a/packages/web/src/ui/components/admin/admin-nav.ts
+++ b/packages/web/src/ui/components/admin/admin-nav.ts
@@ -1,0 +1,150 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  BarChart3,
+  Brain,
+  Database,
+  Globe,
+  Settings,
+  Shield,
+  Users,
+} from "lucide-react";
+
+export interface NavSubItem {
+  href: string;
+  label: string;
+  /** When true, only highlight on exact pathname match (no prefix matching). */
+  exact?: boolean;
+  /** When set, only users with this role see this item. */
+  requiredRole?: "platform_admin";
+  /** When true, this item is hidden in SaaS deploy mode. */
+  selfHostedOnly?: boolean;
+  /** When set, shows a numeric badge next to the label. */
+  badge?: number;
+}
+
+export interface NavGroup {
+  title: string;
+  icon: LucideIcon;
+  items: NavSubItem[];
+  requiredRole?: "platform_admin";
+}
+
+export const navGroups: NavGroup[] = [
+  {
+    title: "Data",
+    icon: Database,
+    items: [
+      { href: "/admin/semantic", label: "Semantic Layer", exact: true },
+      { href: "/admin/semantic/improve", label: "Improve Layer" },
+      { href: "/admin/schema-diff", label: "Schema Diff" },
+      { href: "/admin/connections", label: "Connections" },
+      { href: "/admin/cache", label: "Cache" },
+    ],
+  },
+  {
+    title: "Intelligence",
+    icon: Brain,
+    items: [
+      { href: "/admin/model-config", label: "AI Provider", requiredRole: "platform_admin" },
+      { href: "/admin/learned-patterns", label: "Learned Patterns" },
+      { href: "/admin/prompts", label: "Prompt Library" },
+      { href: "/admin/starter-prompts", label: "Starter Prompts" },
+      { href: "/admin/actions", label: "Actions" },
+    ],
+  },
+  {
+    title: "Users & Access",
+    icon: Users,
+    items: [
+      { href: "/admin/users", label: "Users" },
+      { href: "/admin/organizations", label: "Organizations", requiredRole: "platform_admin" },
+      { href: "/admin/roles", label: "Roles" },
+      { href: "/admin/sessions", label: "Sessions" },
+      { href: "/admin/api-keys", label: "API Keys" },
+      { href: "/admin/oauth-clients", label: "OAuth Clients" },
+    ],
+  },
+  {
+    title: "Security",
+    icon: Shield,
+    items: [
+      { href: "/admin/security", label: "MFA & Sessions" },
+      { href: "/admin/sso", label: "SSO" },
+      { href: "/admin/scim", label: "SCIM" },
+      { href: "/admin/ip-allowlist", label: "IP Allowlist" },
+      { href: "/admin/abuse", label: "Abuse Prevention", requiredRole: "platform_admin" },
+      { href: "/admin/approval", label: "Approval Workflows" },
+      { href: "/admin/compliance", label: "PII Compliance" },
+    ],
+  },
+  {
+    title: "Monitoring",
+    icon: BarChart3,
+    items: [
+      { href: "/admin/audit", label: "Audit Log" },
+      { href: "/admin/admin-actions", label: "Admin Action Log" },
+      { href: "/admin/token-usage", label: "Token Usage" },
+      { href: "/admin/usage", label: "Usage" },
+      { href: "/admin/scheduled-tasks", label: "Scheduled Tasks" },
+    ],
+  },
+  {
+    title: "Configuration",
+    icon: Settings,
+    items: [
+      { href: "/admin/plugins", label: "Plugins", selfHostedOnly: true },
+      { href: "/admin/integrations", label: "Integrations" },
+      { href: "/admin/email-provider", label: "Email Provider" },
+      { href: "/admin/billing", label: "Billing" },
+      { href: "/admin/branding", label: "Branding" },
+      { href: "/admin/custom-domain", label: "Custom Domain" },
+      { href: "/admin/sandbox", label: "Sandbox" },
+      { href: "/admin/residency", label: "Data Residency" },
+      { href: "/admin/settings", label: "Settings", exact: true },
+      { href: "/admin/settings/mcp", label: "MCP" },
+    ],
+  },
+  {
+    title: "Platform",
+    icon: Globe,
+    requiredRole: "platform_admin",
+    items: [
+      { href: "/admin/platform", label: "Overview", exact: true },
+      { href: "/admin/platform/actions", label: "Action Log" },
+      { href: "/admin/platform/security", label: "Security Adoption" },
+      { href: "/admin/platform/sla", label: "SLA Monitoring" },
+      { href: "/admin/platform/backups", label: "Backups" },
+      { href: "/admin/platform/residency", label: "Data Residency" },
+      { href: "/admin/platform/domains", label: "Custom Domains" },
+      { href: "/admin/platform/settings", label: "Settings" },
+      { href: "/admin/platform/plugins", label: "Plugin Catalog", selfHostedOnly: true },
+    ],
+  },
+];
+
+export interface AdminBreadcrumb {
+  /** Section name (matches a NavGroup.title) — `undefined` on the `/admin` overview. */
+  section?: string;
+  /** Page label (matches a NavSubItem.label) — `undefined` when only a section is active. */
+  page?: string;
+}
+
+/**
+ * Resolve the active section + page labels for a `/admin/*` pathname using the
+ * shared `navGroups` registry. Used by the top-bar breadcrumb so both sidebar
+ * and breadcrumb derive labels from a single source of truth.
+ */
+export function resolveAdminBreadcrumb(pathname: string): AdminBreadcrumb {
+  if (pathname === "/admin") return {};
+
+  for (const group of navGroups) {
+    for (const item of group.items) {
+      const matches = item.exact
+        ? pathname === item.href
+        : pathname === item.href || pathname.startsWith(item.href + "/");
+      if (matches) return { section: group.title, page: item.label };
+    }
+  }
+
+  return {};
+}

--- a/packages/web/src/ui/components/admin/admin-sidebar.tsx
+++ b/packages/web/src/ui/components/admin/admin-sidebar.tsx
@@ -8,18 +8,10 @@ import { useBranding } from "@/ui/hooks/use-branding";
 import { useDeployMode } from "@/ui/hooks/use-deploy-mode";
 import { useMode } from "@/ui/hooks/use-mode";
 import { useAtlasConfig } from "@/ui/context";
-import type { LucideIcon } from "lucide-react";
 import {
   ArrowLeft,
   ChevronRight,
   LayoutDashboard,
-  Database,
-  Users,
-  BarChart3,
-  Brain,
-  Settings,
-  Shield,
-  Globe,
   Code,
 } from "lucide-react";
 import {
@@ -45,124 +37,7 @@ import {
 } from "@/components/ui/collapsible";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
-import { OrgSwitcher } from "@/ui/components/org-switcher";
-
-// ---------------------------------------------------------------------------
-// Nav data
-// ---------------------------------------------------------------------------
-
-interface NavSubItem {
-  href: string;
-  label: string;
-  /** When true, only highlight on exact pathname match (no prefix matching). */
-  exact?: boolean;
-  /** When set, only users with this role see this item. */
-  requiredRole?: "platform_admin";
-  /** When true, this item is hidden in SaaS deploy mode. */
-  selfHostedOnly?: boolean;
-  /** When set, shows a numeric badge next to the label. */
-  badge?: number;
-}
-
-interface NavGroup {
-  title: string;
-  icon: LucideIcon;
-  items: NavSubItem[];
-  requiredRole?: "platform_admin";
-}
-
-const navGroups: NavGroup[] = [
-  {
-    title: "Data",
-    icon: Database,
-    items: [
-      { href: "/admin/semantic", label: "Semantic Layer", exact: true },
-      { href: "/admin/semantic/improve", label: "Improve Layer" },
-      { href: "/admin/schema-diff", label: "Schema Diff" },
-      { href: "/admin/connections", label: "Connections" },
-      { href: "/admin/cache", label: "Cache" },
-    ],
-  },
-  {
-    title: "Intelligence",
-    icon: Brain,
-    items: [
-      { href: "/admin/model-config", label: "AI Provider", requiredRole: "platform_admin" },
-      { href: "/admin/learned-patterns", label: "Learned Patterns" },
-      { href: "/admin/prompts", label: "Prompt Library" },
-      { href: "/admin/starter-prompts", label: "Starter Prompts" },
-      { href: "/admin/actions", label: "Actions" },
-    ],
-  },
-  {
-    title: "Users & Access",
-    icon: Users,
-    items: [
-      { href: "/admin/users", label: "Users" },
-      { href: "/admin/organizations", label: "Organizations", requiredRole: "platform_admin" },
-      { href: "/admin/roles", label: "Roles" },
-      { href: "/admin/sessions", label: "Sessions" },
-      { href: "/admin/api-keys", label: "API Keys" },
-      { href: "/admin/oauth-clients", label: "OAuth Clients" },
-    ],
-  },
-  {
-    title: "Security",
-    icon: Shield,
-    items: [
-      { href: "/admin/security", label: "MFA & Sessions" },
-      { href: "/admin/sso", label: "SSO" },
-      { href: "/admin/scim", label: "SCIM" },
-      { href: "/admin/ip-allowlist", label: "IP Allowlist" },
-      { href: "/admin/abuse", label: "Abuse Prevention", requiredRole: "platform_admin" },
-      { href: "/admin/approval", label: "Approval Workflows" },
-      { href: "/admin/compliance", label: "PII Compliance" },
-    ],
-  },
-  {
-    title: "Monitoring",
-    icon: BarChart3,
-    items: [
-      { href: "/admin/audit", label: "Audit Log" },
-      { href: "/admin/admin-actions", label: "Admin Action Log" },
-      { href: "/admin/token-usage", label: "Token Usage" },
-      { href: "/admin/usage", label: "Usage" },
-      { href: "/admin/scheduled-tasks", label: "Scheduled Tasks" },
-    ],
-  },
-  {
-    title: "Configuration",
-    icon: Settings,
-    items: [
-      { href: "/admin/plugins", label: "Plugins", selfHostedOnly: true },
-      { href: "/admin/integrations", label: "Integrations" },
-      { href: "/admin/email-provider", label: "Email Provider" },
-      { href: "/admin/billing", label: "Billing" },
-      { href: "/admin/branding", label: "Branding" },
-      { href: "/admin/custom-domain", label: "Custom Domain" },
-      { href: "/admin/sandbox", label: "Sandbox" },
-      { href: "/admin/residency", label: "Data Residency" },
-      { href: "/admin/settings", label: "Settings" },
-      { href: "/admin/settings/mcp", label: "MCP" },
-    ],
-  },
-  {
-    title: "Platform",
-    icon: Globe,
-    requiredRole: "platform_admin",
-    items: [
-      { href: "/admin/platform", label: "Overview", exact: true },
-      { href: "/admin/platform/actions", label: "Action Log" },
-      { href: "/admin/platform/security", label: "Security Adoption" },
-      { href: "/admin/platform/sla", label: "SLA Monitoring" },
-      { href: "/admin/platform/backups", label: "Backups" },
-      { href: "/admin/platform/residency", label: "Data Residency" },
-      { href: "/admin/platform/domains", label: "Custom Domains" },
-      { href: "/admin/platform/settings", label: "Settings" },
-      { href: "/admin/platform/plugins", label: "Plugin Catalog", selfHostedOnly: true },
-    ],
-  },
-];
+import { navGroups, type NavGroup, type NavSubItem } from "./admin-nav";
 
 // ---------------------------------------------------------------------------
 // Component
@@ -267,10 +142,6 @@ export function AdminSidebar() {
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarHeader>
-
-      <div className="border-b px-2 py-2">
-        <OrgSwitcher />
-      </div>
 
       <SidebarContent>
         {/* Overview — always visible, no group wrapper */}

--- a/packages/web/src/ui/components/admin/admin-sidebar.tsx
+++ b/packages/web/src/ui/components/admin/admin-sidebar.tsx
@@ -105,18 +105,19 @@ export function AdminSidebar() {
     .filter((group) => group.items.length > 0);
 
   const showCustomLogo = branding?.logoUrl;
-  const headerTitle = branding?.hideAtlasBranding
-    ? (branding.logoText || "Admin")
-    : (branding?.logoText || "Atlas");
-  const headerSubtitle = branding?.hideAtlasBranding ? "" : "Admin Console";
 
   return (
     <Sidebar collapsible="icon">
+      {/*
+        Header is logo-only — workspace name + "Admin Console" surface live
+        in the top-bar breadcrumb (#2176). Duplicating them here was the
+        redundancy the redesign was meant to remove.
+      */}
       <SidebarHeader>
         <SidebarMenu>
           <SidebarMenuItem>
-            <SidebarMenuButton size="lg" asChild>
-              <Link href="/admin">
+            <SidebarMenuButton size="lg" asChild tooltip="Admin home">
+              <Link href="/admin" aria-label="Admin home">
                 {showCustomLogo ? (
                   <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-muted">
                     {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -133,10 +134,6 @@ export function AdminSidebar() {
                     </svg>
                   </div>
                 )}
-                <div className="grid flex-1 text-left text-sm leading-tight">
-                  <span className="truncate font-semibold">{headerTitle}</span>
-                  {headerSubtitle && <span className="truncate text-xs">{headerSubtitle}</span>}
-                </div>
               </Link>
             </SidebarMenuButton>
           </SidebarMenuItem>

--- a/packages/web/src/ui/components/admin/admin-top-bar.tsx
+++ b/packages/web/src/ui/components/admin/admin-top-bar.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { Separator } from "@/components/ui/separator";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import { OrgSwitcher } from "@/ui/components/org-switcher";
+import { UserMenu } from "@/ui/components/user-menu";
+import { resolveAdminBreadcrumb } from "@/ui/components/admin/admin-nav";
+
+/**
+ * Persistent top bar shared by every `/admin/*` route.
+ *
+ * Layout (left → right):
+ *   [sidebar trigger] | [org ▾] / Admin [/ section [/ page]]      [avatar ▾]
+ *
+ * The org switcher is rendered as the breadcrumb root so the most
+ * navigationally-significant concept (workspace) sits at the top of the page
+ * tree on every admin surface — matching the chat top-right pattern.
+ */
+export function AdminTopBar() {
+  const pathname = usePathname();
+  const { section, page } = resolveAdminBreadcrumb(pathname);
+  const isOverview = !section;
+
+  return (
+    <header className="flex h-14 shrink-0 items-center justify-between gap-2 border-b bg-background px-4 transition-[height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
+      <div className="flex min-w-0 items-center gap-2">
+        <SidebarTrigger className="-ml-1" />
+        <Separator orientation="vertical" className="mr-1 h-4" />
+        <Breadcrumb>
+          <BreadcrumbList className="flex-nowrap">
+            <BreadcrumbItem>
+              <OrgSwitcher variant="inline" />
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              {isOverview ? (
+                <BreadcrumbPage>Admin Console</BreadcrumbPage>
+              ) : (
+                <BreadcrumbLink asChild>
+                  <Link href="/admin">Admin</Link>
+                </BreadcrumbLink>
+              )}
+            </BreadcrumbItem>
+            {section && (
+              <>
+                <BreadcrumbSeparator />
+                <BreadcrumbItem>
+                  {page ? (
+                    <span className="text-sm text-muted-foreground">{section}</span>
+                  ) : (
+                    <BreadcrumbPage>{section}</BreadcrumbPage>
+                  )}
+                </BreadcrumbItem>
+              </>
+            )}
+            {page && (
+              <>
+                <BreadcrumbSeparator />
+                <BreadcrumbItem>
+                  <BreadcrumbPage className="max-w-[14rem] truncate">{page}</BreadcrumbPage>
+                </BreadcrumbItem>
+              </>
+            )}
+          </BreadcrumbList>
+        </Breadcrumb>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-1">
+        <UserMenu />
+      </div>
+    </header>
+  );
+}

--- a/packages/web/src/ui/components/admin/admin-top-bar.tsx
+++ b/packages/web/src/ui/components/admin/admin-top-bar.tsx
@@ -16,20 +16,10 @@ import { OrgSwitcher } from "@/ui/components/org-switcher";
 import { UserMenu } from "@/ui/components/user-menu";
 import { resolveAdminBreadcrumb } from "@/ui/components/admin/admin-nav";
 
-/**
- * Persistent top bar shared by every `/admin/*` route.
- *
- * Layout (left → right):
- *   [sidebar trigger] | [org ▾] / Admin [/ section [/ page]]      [avatar ▾]
- *
- * The org switcher is rendered as the breadcrumb root so the most
- * navigationally-significant concept (workspace) sits at the top of the page
- * tree on every admin surface — matching the chat top-right pattern.
- */
+/** Org switcher anchors the breadcrumb root so workspace context heads every admin page. */
 export function AdminTopBar() {
   const pathname = usePathname();
-  const { section, page } = resolveAdminBreadcrumb(pathname);
-  const isOverview = !section;
+  const crumb = resolveAdminBreadcrumb(pathname);
 
   return (
     <header className="flex h-14 shrink-0 items-center justify-between gap-2 border-b bg-background px-4 transition-[height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
@@ -43,31 +33,27 @@ export function AdminTopBar() {
             </BreadcrumbItem>
             <BreadcrumbSeparator />
             <BreadcrumbItem>
-              {isOverview ? (
-                <BreadcrumbPage>Admin Console</BreadcrumbPage>
-              ) : (
+              {crumb.section ? (
                 <BreadcrumbLink asChild>
                   <Link href="/admin">Admin</Link>
                 </BreadcrumbLink>
+              ) : (
+                <BreadcrumbPage>Admin Console</BreadcrumbPage>
               )}
             </BreadcrumbItem>
-            {section && (
+            {crumb.section && (
               <>
                 <BreadcrumbSeparator />
                 <BreadcrumbItem>
-                  {page ? (
-                    <span className="text-sm text-muted-foreground">{section}</span>
-                  ) : (
-                    <BreadcrumbPage>{section}</BreadcrumbPage>
-                  )}
+                  <span className="text-sm text-muted-foreground">{crumb.section}</span>
                 </BreadcrumbItem>
               </>
             )}
-            {page && (
+            {crumb.page && (
               <>
                 <BreadcrumbSeparator />
                 <BreadcrumbItem>
-                  <BreadcrumbPage className="max-w-[14rem] truncate">{page}</BreadcrumbPage>
+                  <BreadcrumbPage className="max-w-[14rem] truncate">{crumb.page}</BreadcrumbPage>
                 </BreadcrumbItem>
               </>
             )}
@@ -75,9 +61,7 @@ export function AdminTopBar() {
         </Breadcrumb>
       </div>
 
-      <div className="flex shrink-0 items-center gap-1">
-        <UserMenu />
-      </div>
+      <UserMenu />
     </header>
   );
 }

--- a/packages/web/src/ui/components/admin/admin-top-bar.tsx
+++ b/packages/web/src/ui/components/admin/admin-top-bar.tsx
@@ -23,16 +23,16 @@ export function AdminTopBar() {
 
   return (
     <header className="flex h-14 shrink-0 items-center justify-between gap-2 border-b bg-background px-4 transition-[height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
-      <div className="flex min-w-0 items-center gap-2">
+      <div className="flex min-w-0 flex-1 items-center gap-2">
         <SidebarTrigger className="-ml-1" />
         <Separator orientation="vertical" className="mr-1 h-4" />
-        <Breadcrumb>
+        <Breadcrumb className="min-w-0 flex-1">
           <BreadcrumbList className="flex-nowrap">
-            <BreadcrumbItem>
+            <BreadcrumbItem className="shrink-0">
               <OrgSwitcher variant="inline" />
             </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
+            <BreadcrumbSeparator className="shrink-0" />
+            <BreadcrumbItem className="shrink-0">
               {crumb.section ? (
                 <BreadcrumbLink asChild>
                   <Link href="/admin">Admin</Link>
@@ -41,19 +41,27 @@ export function AdminTopBar() {
                 <BreadcrumbPage>Admin Console</BreadcrumbPage>
               )}
             </BreadcrumbItem>
+            {/*
+              Mobile (< sm): hide the intermediate section crumb so the
+              page label has room next to the avatar. The "Admin" link
+              still gets users back to the overview, and the active
+              sidebar item supplies the section context.
+            */}
             {crumb.section && (
               <>
-                <BreadcrumbSeparator />
-                <BreadcrumbItem>
+                <BreadcrumbSeparator className="hidden shrink-0 sm:flex" />
+                <BreadcrumbItem className="hidden shrink-0 sm:flex">
                   <span className="text-sm text-muted-foreground">{crumb.section}</span>
                 </BreadcrumbItem>
               </>
             )}
             {crumb.page && (
               <>
-                <BreadcrumbSeparator />
-                <BreadcrumbItem>
-                  <BreadcrumbPage className="max-w-[14rem] truncate">{crumb.page}</BreadcrumbPage>
+                <BreadcrumbSeparator className="shrink-0" />
+                <BreadcrumbItem className="min-w-0">
+                  <BreadcrumbPage className="block max-w-[8rem] truncate sm:max-w-[14rem]">
+                    {crumb.page}
+                  </BreadcrumbPage>
                 </BreadcrumbItem>
               </>
             )}

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -6,7 +6,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import type { PythonProgressData } from "./chat/python-result-card";
 import { useAtlasConfig } from "../context";
-import { useThemeMode, setTheme, type ThemeMode } from "../hooks/use-dark-mode";
+import { ThemeToggle } from "./theme-toggle";
 import { useAtlasTransport } from "../hooks/use-atlas-transport";
 import { useConversations } from "../hooks/use-conversations";
 import { useStarterPromptsQuery } from "../hooks/use-starter-prompts-query";
@@ -25,18 +25,12 @@ import { ShareDialog } from "./chat/share-dialog";
 import { ConversationSidebar } from "./conversations/conversation-sidebar";
 import { ChangePasswordDialog } from "./admin/change-password-dialog";
 import { usePasswordStatus } from "@/ui/hooks/use-password-status";
-import { Sun, Moon, Monitor, Star, TableProperties, BookOpen, Send, Pin } from "lucide-react";
+import { Star, TableProperties, BookOpen, Send, Pin } from "lucide-react";
 import { SchemaExplorer } from "./schema-explorer/schema-explorer";
 import { PromptLibrary } from "./chat/prompt-library";
 import { StarterPromptList } from "./chat/starter-prompt-list";
 import type { StarterPrompt } from "@useatlas/types/starter-prompt";
 import { useContextWarnings } from "../hooks/use-context-warnings";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -57,40 +51,6 @@ const AtlasLogo = (
     <circle cx="128" cy="28" r="16" fill="currentColor"/>
   </svg>
 );
-
-const THEME_OPTIONS = [
-  { value: "light", label: "Light", icon: Sun },
-  { value: "dark", label: "Dark", icon: Moon },
-  { value: "system", label: "System", icon: Monitor },
-] as const satisfies readonly { value: ThemeMode; label: string; icon: typeof Sun }[];
-
-function ThemeToggle() {
-  const mode = useThemeMode();
-  const CurrentIcon = mode === "dark" ? Moon : mode === "light" ? Sun : Monitor;
-
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="size-11 sm:size-8 text-zinc-500 dark:text-zinc-400">
-          <CurrentIcon className="size-4" />
-          <span className="sr-only">Toggle theme</span>
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        {THEME_OPTIONS.map(({ value, label, icon: Icon }) => (
-          <DropdownMenuItem
-            key={value}
-            onClick={() => setTheme(value)}
-            className={mode === value ? "bg-accent" : ""}
-          >
-            <Icon className="mr-2 size-4" />
-            {label}
-          </DropdownMenuItem>
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
 
 function SaveButton({
   conversationId,
@@ -568,7 +528,7 @@ export function AtlasChat() {
                   >
                     <TableProperties className="size-4" />
                   </Button>
-                  <ThemeToggle />
+                  <ThemeToggle className="size-11 sm:size-8 text-zinc-500 dark:text-zinc-400" />
                   {isSignedIn && (
                     <>
                       <span className="hidden text-xs text-zinc-500 sm:inline dark:text-zinc-400">

--- a/packages/web/src/ui/components/org-switcher.tsx
+++ b/packages/web/src/ui/components/org-switcher.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { toast } from "sonner";
 import { ChevronsUpDown, Check, AlertCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -35,7 +36,13 @@ export function OrgSwitcher({ variant = "sidebar" }: OrgSwitcherProps) {
   const [loading, setLoading] = useState(true);
   const [switchError, setSwitchError] = useState<string | null>(null);
 
-  const activeOrgId = (session.data?.session as Record<string, unknown> | undefined)?.activeOrganizationId as string | undefined;
+  // Better Auth's typed session covers the base shape; `activeOrganization*`
+  // are custom fields configured via `session.fields` in the auth setup, so
+  // they're not on the inferred interface — narrow them at the read.
+  const sessionExtra = session.data?.session as
+    | { activeOrganizationId?: string; activeOrganizationName?: string }
+    | undefined;
+  const activeOrgId = sessionExtra?.activeOrganizationId;
 
   useEffect(() => {
     if (!session.data?.user) return;
@@ -60,7 +67,7 @@ export function OrgSwitcher({ variant = "sidebar" }: OrgSwitcherProps) {
 
   const activeOrg = orgs.find((o) => o.id === activeOrgId);
   // Fall back to session metadata for the active org name when the list hasn't loaded
-  const sessionOrgName = (session.data?.session as Record<string, unknown> | undefined)?.activeOrganizationName as string | undefined;
+  const sessionOrgName = sessionExtra?.activeOrganizationName;
   const displayName = activeOrg?.name ?? sessionOrgName ?? "Workspace";
 
   async function switchOrg(orgId: string) {
@@ -70,7 +77,14 @@ export function OrgSwitcher({ variant = "sidebar" }: OrgSwitcherProps) {
       window.location.reload();
     } catch (err) {
       console.error("Failed to switch organization:", err);
-      setSwitchError("Failed to switch organization. Please try again.");
+      // Sidebar variant has room for an inline banner; inline (top bar) doesn't,
+      // so it routes through sonner. Both surface the failure — neither swallows.
+      const message = "Failed to switch organization. Please try again.";
+      if (variant === "inline") {
+        toast.error(message);
+      } else {
+        setSwitchError(message);
+      }
     }
   }
 
@@ -107,7 +121,7 @@ export function OrgSwitcher({ variant = "sidebar" }: OrgSwitcherProps) {
   );
 
   if (!canSwitch) {
-    return isInline ? <div className="px-1">{orgLabel}</div> : <div>{orgLabel}</div>;
+    return <div className={cn(isInline && "px-1")}>{orgLabel}</div>;
   }
 
   return (

--- a/packages/web/src/ui/components/org-switcher.tsx
+++ b/packages/web/src/ui/components/org-switcher.tsx
@@ -12,6 +12,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { authClient } from "@/lib/auth/client";
+import { cn } from "@/lib/utils";
 
 interface OrgOption {
   id: string;
@@ -20,7 +21,15 @@ interface OrgOption {
   logo?: string | null;
 }
 
-export function OrgSwitcher() {
+export interface OrgSwitcherProps {
+  /**
+   * `sidebar` — full-width sidebar block (default).
+   * `inline` — compact button suited to a top-bar / breadcrumb root.
+   */
+  variant?: "sidebar" | "inline";
+}
+
+export function OrgSwitcher({ variant = "sidebar" }: OrgSwitcherProps) {
   const session = authClient.useSession();
   const [orgs, setOrgs] = useState<OrgOption[]>([]);
   const [loading, setLoading] = useState(true);
@@ -71,11 +80,24 @@ export function OrgSwitcher() {
   if (orgs.length === 0 && !activeOrgId) return null;
 
   const canSwitch = orgs.length > 1;
+  const isInline = variant === "inline";
+  const initial = displayName.charAt(0).toUpperCase();
 
-  const orgLabel = (
+  const orgLabel = isInline ? (
+    <div className="flex items-center gap-2">
+      <div
+        aria-hidden
+        className="bg-primary/10 flex size-5 shrink-0 items-center justify-center rounded text-[10px] font-semibold"
+      >
+        {initial}
+      </div>
+      <span className="max-w-[10rem] truncate text-sm font-medium">{displayName}</span>
+      {canSwitch && <ChevronsUpDown className="size-3.5 shrink-0 opacity-50" />}
+    </div>
+  ) : (
     <div className="flex w-full items-center gap-2 px-3 py-2">
       <div className="bg-primary/10 flex size-6 items-center justify-center rounded text-xs font-semibold">
-        {displayName.charAt(0).toUpperCase()}
+        {initial}
       </div>
       <span className="flex-1 truncate text-sm font-medium">
         {displayName}
@@ -85,16 +107,20 @@ export function OrgSwitcher() {
   );
 
   if (!canSwitch) {
-    return <div>{orgLabel}</div>;
+    return isInline ? <div className="px-1">{orgLabel}</div> : <div>{orgLabel}</div>;
   }
 
   return (
-    <div>
+    <div className={cn(isInline && "inline-flex")}>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
             variant="ghost"
-            className="w-full justify-start gap-0 p-0 text-left"
+            className={cn(
+              isInline
+                ? "h-7 gap-1 px-1.5 text-left"
+                : "w-full justify-start gap-0 p-0 text-left",
+            )}
           >
             {orgLabel}
           </Button>
@@ -117,7 +143,7 @@ export function OrgSwitcher() {
           ))}
         </DropdownMenuContent>
       </DropdownMenu>
-      {switchError && (
+      {switchError && !isInline && (
         <div className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-destructive">
           <AlertCircle className="size-3 shrink-0" />
           <span>{switchError}</span>

--- a/packages/web/src/ui/components/theme-toggle.tsx
+++ b/packages/web/src/ui/components/theme-toggle.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Monitor, Moon, Sun } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import { setTheme, useThemeMode, type ThemeMode } from "@/ui/hooks/use-dark-mode";
+
+const THEME_OPTIONS = [
+  { value: "light", label: "Light", icon: Sun },
+  { value: "dark", label: "Dark", icon: Moon },
+  { value: "system", label: "System", icon: Monitor },
+] as const satisfies readonly { value: ThemeMode; label: string; icon: typeof Sun }[];
+
+export interface ThemeToggleProps {
+  /** Optional className passed to the trigger button. */
+  className?: string;
+}
+
+/**
+ * Theme picker dropdown — light / dark / system. Used in both the chat header
+ * and the admin top bar so both surfaces share a single trigger and behavior.
+ */
+export function ThemeToggle({ className }: ThemeToggleProps) {
+  const mode = useThemeMode();
+  const CurrentIcon = mode === "dark" ? Moon : mode === "light" ? Sun : Monitor;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className={cn("size-8 text-muted-foreground", className)}
+        >
+          <CurrentIcon className="size-4" />
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {THEME_OPTIONS.map(({ value, label, icon: Icon }) => (
+          <DropdownMenuItem
+            key={value}
+            onClick={() => setTheme(value)}
+            className={mode === value ? "bg-accent" : ""}
+          >
+            <Icon className="mr-2 size-4" />
+            {label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/web/src/ui/components/theme-toggle.tsx
+++ b/packages/web/src/ui/components/theme-toggle.tsx
@@ -18,14 +18,9 @@ const THEME_OPTIONS = [
 ] as const satisfies readonly { value: ThemeMode; label: string; icon: typeof Sun }[];
 
 export interface ThemeToggleProps {
-  /** Optional className passed to the trigger button. */
   className?: string;
 }
 
-/**
- * Theme picker dropdown — light / dark / system. Used in both the chat header
- * and the admin top bar so both surfaces share a single trigger and behavior.
- */
 export function ThemeToggle({ className }: ThemeToggleProps) {
   const mode = useThemeMode();
   const CurrentIcon = mode === "dark" ? Moon : mode === "light" ? Sun : Monitor;

--- a/packages/web/src/ui/components/user-menu.tsx
+++ b/packages/web/src/ui/components/user-menu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "sonner";
 import { LogOut, Monitor, Moon, Sun } from "lucide-react";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -24,10 +25,7 @@ const THEME_OPTIONS = [
   { value: "system", label: "System", icon: Monitor },
 ] as const satisfies readonly { value: ThemeMode; label: string; icon: typeof Sun }[];
 
-/**
- * Derive 1–2 character initials for the avatar fallback.
- * Falls back to email when name is missing, and to "?" when both are blank.
- */
+/** Falls through name → email → "?" so the avatar always renders something. */
 export function deriveInitials(name?: string | null, email?: string | null): string {
   const source = (name || email || "").trim();
   if (!source) return "?";
@@ -38,10 +36,6 @@ export function deriveInitials(name?: string | null, email?: string | null): str
   return source.charAt(0).toUpperCase();
 }
 
-/**
- * Avatar dropdown showing the signed-in user with theme picker + sign-out.
- * Renders nothing when no user is in the session.
- */
 export function UserMenu() {
   const { authClient } = useAtlasConfig();
   const session = authClient.useSession();
@@ -51,12 +45,7 @@ export function UserMenu() {
   const user = session.data?.user;
   if (!user) return null;
 
-  // Better Auth's runtime user object carries `name`, but the duck-typed
-  // `AtlasAuthClient` interface only declares the fields Atlas needs everywhere
-  // (email + role). Cast through Record to access optional name without
-  // widening the shared interface for one consumer.
-  const userRecord = user as Record<string, unknown>;
-  const name = typeof userRecord.name === "string" ? userRecord.name : null;
+  const name = user.name ?? null;
   const email = user.email ?? null;
   const initials = deriveInitials(name, email);
 
@@ -67,7 +56,9 @@ export function UserMenu() {
       await authClient.signOut();
       window.location.assign("/login");
     } catch (err) {
-      console.error("Sign out failed:", err instanceof Error ? err.message : String(err));
+      const message = err instanceof Error ? err.message : String(err);
+      console.error("Sign out failed:", message);
+      toast.error("Sign out failed. Try again.");
       setSigningOut(false);
     }
   }

--- a/packages/web/src/ui/components/user-menu.tsx
+++ b/packages/web/src/ui/components/user-menu.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useState } from "react";
+import { LogOut, Monitor, Moon, Sun } from "lucide-react";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useAtlasConfig } from "@/ui/context";
+import { setTheme, useThemeMode, type ThemeMode } from "@/ui/hooks/use-dark-mode";
+
+const THEME_OPTIONS = [
+  { value: "light", label: "Light", icon: Sun },
+  { value: "dark", label: "Dark", icon: Moon },
+  { value: "system", label: "System", icon: Monitor },
+] as const satisfies readonly { value: ThemeMode; label: string; icon: typeof Sun }[];
+
+/**
+ * Derive 1–2 character initials for the avatar fallback.
+ * Falls back to email when name is missing, and to "?" when both are blank.
+ */
+export function deriveInitials(name?: string | null, email?: string | null): string {
+  const source = (name || email || "").trim();
+  if (!source) return "?";
+  const parts = source.split(/[\s@.]+/).filter(Boolean);
+  if (parts.length >= 2) {
+    return (parts[0][0] + parts[1][0]).toUpperCase();
+  }
+  return source.charAt(0).toUpperCase();
+}
+
+/**
+ * Avatar dropdown showing the signed-in user with theme picker + sign-out.
+ * Renders nothing when no user is in the session.
+ */
+export function UserMenu() {
+  const { authClient } = useAtlasConfig();
+  const session = authClient.useSession();
+  const themeMode = useThemeMode();
+  const [signingOut, setSigningOut] = useState(false);
+
+  const user = session.data?.user;
+  if (!user) return null;
+
+  // Better Auth's runtime user object carries `name`, but the duck-typed
+  // `AtlasAuthClient` interface only declares the fields Atlas needs everywhere
+  // (email + role). Cast through Record to access optional name without
+  // widening the shared interface for one consumer.
+  const userRecord = user as Record<string, unknown>;
+  const name = typeof userRecord.name === "string" ? userRecord.name : null;
+  const email = user.email ?? null;
+  const initials = deriveInitials(name, email);
+
+  async function handleSignOut() {
+    if (signingOut) return;
+    setSigningOut(true);
+    try {
+      await authClient.signOut();
+      window.location.assign("/login");
+    } catch (err) {
+      console.error("Sign out failed:", err instanceof Error ? err.message : String(err));
+      setSigningOut(false);
+    }
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-8 rounded-full p-0"
+          aria-label="Account menu"
+        >
+          <Avatar size="sm">
+            <AvatarFallback className="bg-primary/10 text-primary">
+              {initials}
+            </AvatarFallback>
+          </Avatar>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuLabel className="flex flex-col gap-0.5">
+          {name && <span className="truncate text-sm font-medium">{name}</span>}
+          {email && (
+            <span className="truncate text-xs font-normal text-muted-foreground">
+              {email}
+            </span>
+          )}
+          {!name && !email && <span className="text-sm">Signed in</span>}
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            {themeMode === "dark" ? (
+              <Moon className="mr-2 size-4" />
+            ) : themeMode === "light" ? (
+              <Sun className="mr-2 size-4" />
+            ) : (
+              <Monitor className="mr-2 size-4" />
+            )}
+            <span>Theme</span>
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent>
+            {THEME_OPTIONS.map(({ value, label, icon: Icon }) => (
+              <DropdownMenuItem
+                key={value}
+                onClick={() => setTheme(value)}
+                className={themeMode === value ? "bg-accent" : ""}
+              >
+                <Icon className="mr-2 size-4" />
+                {label}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onClick={() => { void handleSignOut(); }}
+          disabled={signingOut}
+        >
+          <LogOut className="mr-2 size-4" />
+          <span>{signingOut ? "Signing out…" : "Sign out"}</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a persistent `<AdminTopBar>` to every `/admin/*` route — shadcn `<Breadcrumb>` rooted on the org switcher (`[org] / Admin / Section [/ Page]`) plus an avatar dropdown on the right with theme picker + sign out. Closes the "no logout in admin" gap.
- Org switcher gains a `variant="inline"` mode for the breadcrumb root; the duplicate sidebar block is removed (single source of truth for active workspace).
- `<ThemeToggle>` extracted to a shared component so the chat header and the new top bar drive the same picker — no parallel implementation.
- Nav data extracted to `admin-nav.ts` so sidebar + breadcrumb derive labels from one registry. `/admin/settings` flipped to `exact: true` so `/admin/settings/mcp` highlights MCP alone.

Closes #2176. Foundation for #2177 (dev-mode discoverability + pending-changes pill in this same chrome).

## Notable choices
- **Profile** menu item omitted — there is no `/profile` page today. Theme + Sign out only; can add Profile when a profile page lands.
- **Dev-mode banner placement** is unchanged (still at the root layout above the admin shell). #2177 will revisit once the pending-changes pill needs a home in this top bar.
- **`<UserMenu>`** casts `user.name` through `Record<string, unknown>` — Better Auth's runtime user carries `name`, but `AtlasAuthClient` only declares `email + role` to keep the duck-typed interface narrow.

## Test plan
- [x] `bun run lint` — clean
- [x] `bun run type` — clean (web)
- [x] `bun run test:api` — 356/356 pass
- [x] `bun run test:others` — web 129/129, ee 25/25, react 11/11, cli 22/22, slack/teams/webhook plugins all green
- [x] `bun x syncpack lint` — no issues
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — 527 files verified
- [x] `bash scripts/check-railway-watch.sh` — all COPY sources covered
- [x] New tests:
  - `admin-nav.test.ts` — every `navGroups` item round-trips through `resolveAdminBreadcrumb`; exact vs prefix-match coverage
  - `user-menu-initials.test.ts` — `deriveInitials` edge cases
- [ ] Manual: load `/admin`, `/admin/security`, `/admin/settings`, `/admin/settings/mcp` and confirm breadcrumb labels + avatar dropdown work; verify org switcher dropdown still switches workspace; confirm dev-mode banner still renders above the top bar without z-index collision