### PR TITLE
feat(types): widen AtlasAuthClient with name + session.id + updateUser + refetch (0.0.20)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -341,7 +341,7 @@
     },
     "packages/types": {
       "name": "@useatlas/types",
-      "version": "0.0.19",
+      "version": "0.0.20",
     },
     "packages/web": {
       "name": "@atlas/web",
@@ -4357,6 +4357,10 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typespec/ts-http-runtime/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "@useatlas/react/@useatlas/types": ["@useatlas/types@0.0.19", "", {}, "sha512-co9v1qmC3ntMNRA6vUTTz3V6j2Y3umV/tBn5t58V/lvi8uSNkGM9tAhwXS4u3ZmClIEZ2AnegQeJmFsS+/YGEg=="],
+
+    "@useatlas/sdk/@useatlas/types": ["@useatlas/types@0.0.19", "", {}, "sha512-co9v1qmC3ntMNRA6vUTTz3V6j2Y3umV/tBn5t58V/lvi8uSNkGM9tAhwXS4u3ZmClIEZ2AnegQeJmFsS+/YGEg=="],
 
     "@vercel/sandbox/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/types",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -52,8 +52,13 @@ export type AdminRole = (typeof ADMIN_ROLES)[number];
 // a single source of truth for auth client shapes.
 
 /**
- * Duck-typed interface that matches better-auth's client shape.
- * Components like ManagedAuthCard call signIn/signUp/signOut and useSession().
+ * Duck-typed interface that matches better-auth's client shape. Only the
+ * fields Atlas actually reads or calls are declared — adding a new
+ * better-auth API to the surface is a deliberate edit here, which is the
+ * right friction for an external dependency.
+ *
+ * Recurring `as unknown as { ... }` casts at call sites mean a field is
+ * missing from this surface — widen here instead of widening one consumer.
  */
 export interface AtlasAuthClient {
   signIn: {
@@ -63,7 +68,34 @@ export interface AtlasAuthClient {
     email: (opts: { email: string; password: string; name: string }) => Promise<{ error?: { message?: string } | null }>;
   };
   signOut: () => Promise<unknown>;
-  useSession: () => { data?: { user?: { email?: string; role?: string } } | null; isPending: boolean };
+  /**
+   * Update the signed-in user's profile fields. Better Auth ships more
+   * keys than `name`; declare only the ones Atlas actually writes.
+   */
+  updateUser?: (opts: { name?: string }) => Promise<{ error?: { message?: string } | null }>;
+  useSession: () => {
+    data?: {
+      user?: {
+        email?: string;
+        role?: string;
+        /** Display name — present at runtime, not always populated. */
+        name?: string;
+        /** True when TOTP is enrolled — surfaced by the two-factor plugin. */
+        twoFactorEnabled?: boolean;
+      };
+      session?: {
+        /** Session row id — used to identify "this session" in revoke flows. */
+        id?: string;
+        /** Active organization id — set by the organization plugin. */
+        activeOrganizationId?: string;
+        /** Active organization name — fallback when the org list hasn't loaded. */
+        activeOrganizationName?: string;
+      };
+    } | null;
+    isPending: boolean;
+    /** Imperative refetch — better-auth exposes this on the React hook. */
+    refetch?: () => unknown;
+  };
 }
 
 /** Auth helpers passed to action approval cards via context. */


### PR DESCRIPTION
## Summary

Widens the duck-typed \`AtlasAuthClient\` to formalize the fields recent UI work needs (\`user.name\`, \`session.id\`, \`session.activeOrganization*\`, \`updateUser\`, \`useSession().refetch\`) — pulling per-call \`as unknown as { ... }\` casts at consumer sites into a single audited surface.

Bumps \`@useatlas/types\` 0.0.19 → 0.0.20. Lands first so PR #2254 and PR #2256 (which depend on the new fields) can rebase off main and drop their casts.

## Why

The interface is intentionally duck-typed (we only declare what Atlas calls), but each missing-field cast at a call site silently breaks on every Better Auth upgrade. The reviews of #2254 and #2256 (12 specialist agents) flagged this as a structural maintenance hazard with 9+ recurrences across the codebase.

## Fields added

- \`updateUser?: (opts: { name? }) => Promise<{ error? }>\` — only the keys Atlas writes today; declare more as the surface grows.
- \`useSession().data.user.name?\` — display name; unpopulated for many SSO users.
- \`useSession().data.user.twoFactorEnabled?\` — surfaced by the two-factor plugin.
- \`useSession().data.session?.id?\` — needed to identify "this session" in revoke flows.
- \`useSession().data.session?.activeOrganizationId?\` / \`activeOrganizationName?\` — set by the organization plugin via \`session.fields\`.
- \`useSession().refetch?\` — better-auth's React hook returns this; was being called via a missing-shape cast.

## Test plan
- [x] \`bun run lint\` — clean
- [x] \`bun run type\` — clean (web)
- [x] \`bun x syncpack lint\` — no issues
- [x] \`SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh\` — 521 files verified
- [x] \`bash scripts/check-railway-watch.sh\` — all COPY sources covered

## Follow-ups
- After merge: tag \`types-v0.0.20\` and push to trigger OIDC publish (per playbook).
- After \`types-v0.0.20\` publishes: bump \`^0.0.19\` → \`^0.0.20\` in \`packages/sdk\`, \`packages/react\`, and \`create-atlas/templates/*/package.json\`.
- Tracked: #2262 (collapse remaining \`(authClient as unknown as ...)\` casts) covers the long-tail consumers this PR doesn't reach.