### PR TITLE
feat(web): #2255 — /settings/profile page surfaced from chat + admin avatar menus

### DIFF
--- a/packages/web/src/app/settings/layout.tsx
+++ b/packages/web/src/app/settings/layout.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+/**
+ * `/settings/*` shell.
+ *
+ * `/settings/profile`, `/settings/ai-agents`, etc. are user-scoped and
+ * intentionally outside the heavy admin sidebar. They still need chrome —
+ * a back-link affordance + the same avatar dropdown — so the page isn't a
+ * navigation dead-end after the user opens it from chat or admin.
+ *
+ * Mirrors the admin top-bar pattern (#2176): logo → settings breadcrumb →
+ * avatar menu on the right. Lighter than the admin shell on purpose; this
+ * is a focused-task surface, not a workspace control panel.
+ */
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { Separator } from "@/components/ui/separator";
+import { UserMenu } from "@/ui/components/user-menu";
+
+const SECTION_LABELS: Record<string, string> = {
+  profile: "Profile",
+  "ai-agents": "AI Agents",
+};
+
+function pageLabelFor(pathname: string): string | null {
+  // Pathname looks like `/settings/<page>` or `/settings/<page>/<sub>` —
+  // resolve only the first segment under /settings to a label and let
+  // anything deeper render as the literal segment (humanized below).
+  const match = pathname.match(/^\/settings\/([^/]+)/);
+  if (!match) return null;
+  const segment = match[1];
+  if (segment in SECTION_LABELS) return SECTION_LABELS[segment];
+  // Fallback: humanize "kebab-case" → "Title Case" so unmapped pages still
+  // render a recognizable crumb without forcing every new settings route
+  // to update this file in lockstep.
+  return segment
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export default function SettingsLayout({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const pageLabel = pageLabelFor(pathname);
+
+  return (
+    <div className="flex h-full flex-col">
+      <header className="flex h-14 shrink-0 items-center justify-between gap-2 border-b bg-background px-4">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <Link
+            href="/"
+            aria-label="Atlas home"
+            className="flex aspect-square size-8 shrink-0 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground"
+          >
+            <svg viewBox="0 0 256 256" fill="none" className="size-4" aria-hidden="true">
+              <path d="M128 24 L232 208 L24 208 Z" stroke="currentColor" strokeWidth="20" fill="none" strokeLinejoin="round" />
+            </svg>
+          </Link>
+          <Separator orientation="vertical" className="mr-1 h-4" />
+          {/*
+            "Settings" is a non-link root because there's no /settings
+            index page to navigate to. The home logo on the left and the
+            avatar dropdown on the right are the back-navigation
+            affordances.
+          */}
+          <Breadcrumb className="min-w-0 flex-1">
+            <BreadcrumbList className="flex-nowrap">
+              <BreadcrumbItem className="shrink-0">
+                <span className="text-sm text-muted-foreground">Settings</span>
+              </BreadcrumbItem>
+              {pageLabel && (
+                <>
+                  <BreadcrumbSeparator className="shrink-0" />
+                  <BreadcrumbItem className="min-w-0">
+                    <BreadcrumbPage className="block max-w-[10rem] truncate sm:max-w-[16rem]">
+                      {pageLabel}
+                    </BreadcrumbPage>
+                  </BreadcrumbItem>
+                </>
+              )}
+            </BreadcrumbList>
+          </Breadcrumb>
+        </div>
+
+        <UserMenu />
+      </header>
+
+      <main id="main" tabIndex={-1} className="flex-1 overflow-y-auto">
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/packages/web/src/app/settings/profile/loading.tsx
+++ b/packages/web/src/app/settings/profile/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return null;
+}

--- a/packages/web/src/app/settings/profile/page.tsx
+++ b/packages/web/src/app/settings/profile/page.tsx
@@ -1,24 +1,9 @@
 "use client";
 
 /**
- * Settings → Profile (#2255).
- *
- * User-scoped settings page surfaced from the avatar dropdown on both the chat
- * and admin surfaces. Every section is per-user (no admin role required) — the
- * MFA tiles reuse the same components as `/admin/security` because the
- * underlying endpoints (`/api/v1/admin/me/*`, `/api/v1/sessions`) are
- * authenticated-only, not admin-gated.
- *
- * Sections, top to bottom:
- *
- *   1. Identity     — display name + email
- *   2. Password     — change password (managed-auth only)
- *   3. Security     — passkeys, TOTP, backup codes, trusted devices
- *   4. Sessions     — active sessions + sign-out-everywhere
- *
- * The MFA wrapper here intentionally leans on the same components admins see
- * on `/admin/security` so a feature added there shows up for end-users too,
- * without a parallel maintenance surface.
+ * Per-user settings (no admin role required). MFA tiles reuse
+ * /admin/security components — the underlying endpoints are auth-only,
+ * not admin-gated, so a feature added there shows up here for free.
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -128,7 +113,11 @@ export default function ProfilePage() {
             <BackupMethodBanner onAddPasskey={handleEnrollSecondPasskey} />
 
             <div ref={passkeyTileRef}>
-              <PasskeyTile hasPasskey={hasPasskey} onChange={handlePasskeyChange} />
+              <PasskeyTile
+                hasPasskey={hasPasskey}
+                onChange={handlePasskeyChange}
+                reauthRedirectTo="/settings/profile"
+              />
             </div>
 
             <TwoFactorSetup enabled={totpEnabled} onChange={handleTotpChange} />

--- a/packages/web/src/app/settings/profile/page.tsx
+++ b/packages/web/src/app/settings/profile/page.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+/**
+ * Settings → Profile (#2255).
+ *
+ * User-scoped settings page surfaced from the avatar dropdown on both the chat
+ * and admin surfaces. Every section is per-user (no admin role required) — the
+ * MFA tiles reuse the same components as `/admin/security` because the
+ * underlying endpoints (`/api/v1/admin/me/*`, `/api/v1/sessions`) are
+ * authenticated-only, not admin-gated.
+ *
+ * Sections, top to bottom:
+ *
+ *   1. Identity     — display name + email
+ *   2. Password     — change password (managed-auth only)
+ *   3. Security     — passkeys, TOTP, backup codes, trusted devices
+ *   4. Sessions     — active sessions + sign-out-everywhere
+ *
+ * The MFA wrapper here intentionally leans on the same components admins see
+ * on `/admin/security` so a feature added there shows up for end-users too,
+ * without a parallel maintenance surface.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { authClient } from "@/lib/auth/client";
+import { getPasskeyClient, type Passkey } from "@/lib/auth/passkey-client";
+import { TwoFactorSetup } from "@/ui/components/admin/security/two-factor-setup";
+import { PasskeyTile } from "@/ui/components/admin/security/passkey-tile";
+import { PasskeyList, type PasskeyRow } from "@/ui/components/admin/security/passkey-list";
+import { BackupCodesStatus } from "@/ui/components/admin/security/backup-codes-status";
+import { TrustedDevicesList } from "@/ui/components/admin/security/trusted-devices-list";
+import { BackupMethodBanner } from "@/ui/components/admin/security/backup-method-banner";
+import { SectionHeading } from "@/ui/components/admin/compact";
+import { IdentitySection } from "@/ui/components/settings/identity-section";
+import { PasswordSection } from "@/ui/components/settings/password-section";
+import { SessionsSection } from "@/ui/components/settings/sessions-section";
+
+interface SessionUser {
+  email: string;
+  role: string;
+  twoFactorEnabled?: boolean;
+}
+
+export default function ProfilePage() {
+  const session = authClient.useSession();
+  const user = (session.data?.user ?? null) as SessionUser | null;
+  const totpEnabled = user?.twoFactorEnabled === true;
+
+  const [passkeys, setPasskeys] = useState<PasskeyRow[] | null>(null);
+  const [listError, setListError] = useState<string | null>(null);
+  const passkeyTileRef = useRef<HTMLDivElement | null>(null);
+
+  function handleEnrollSecondPasskey() {
+    passkeyTileRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+  }
+
+  const refreshPasskeys = useCallback(async () => {
+    const client = getPasskeyClient();
+    if (!client) {
+      setListError("Passkey support couldn't be loaded. Refresh the page and try again.");
+      return;
+    }
+    setListError(null);
+    let result: Awaited<ReturnType<typeof client.listUserPasskeys>>;
+    try {
+      result = await client.listUserPasskeys();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn("[passkey] listUserPasskeys threw", msg);
+      setListError("Could not load your passkeys. Please refresh.");
+      return;
+    }
+    if (result.error) {
+      console.warn("[passkey] listUserPasskeys failed", result.error);
+      setListError(result.error.message ?? "Could not load your passkeys.");
+      return;
+    }
+    setPasskeys((result.data ?? []) as Passkey[]);
+  }, []);
+
+  useEffect(() => {
+    void refreshPasskeys();
+  }, [refreshPasskeys]);
+
+  const hasPasskey = (passkeys?.length ?? 0) > 0;
+
+  function handleTotpChange() {
+    session.refetch?.();
+  }
+
+  function handlePasskeyChange() {
+    void refreshPasskeys();
+    session.refetch?.();
+  }
+
+  if (!user) {
+    return (
+      <div className="mx-auto max-w-3xl px-6 py-10">
+        <p className="text-sm text-muted-foreground">Sign in to manage your profile.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-10">
+      <header className="mb-10 flex flex-col gap-2">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+          Atlas · Settings
+        </p>
+        <h1 className="text-3xl font-semibold tracking-tight">Profile</h1>
+        <p className="max-w-xl text-sm text-muted-foreground">
+          Identity, password, multi-factor authentication, and active sessions for{" "}
+          <span className="font-medium text-foreground">{user.email}</span>.
+        </p>
+      </header>
+
+      <div className="space-y-10">
+        <IdentitySection />
+
+        <PasswordSection />
+
+        <section>
+          <SectionHeading
+            title="Multi-factor authentication"
+            description="Add a second factor — passkey, authenticator app, or both — so a stolen password isn't enough."
+          />
+          <div className="space-y-4">
+            <BackupMethodBanner onAddPasskey={handleEnrollSecondPasskey} />
+
+            <div ref={passkeyTileRef}>
+              <PasskeyTile hasPasskey={hasPasskey} onChange={handlePasskeyChange} />
+            </div>
+
+            <TwoFactorSetup enabled={totpEnabled} onChange={handleTotpChange} />
+
+            <BackupCodesStatus totpEnabled={totpEnabled} hasPasskey={hasPasskey} />
+
+            <div className="pt-2">
+              <PasskeyList passkeys={passkeys ?? []} onChange={handlePasskeyChange} />
+              {listError && (
+                <p className="mt-2 text-sm text-destructive">{listError}</p>
+              )}
+            </div>
+
+            <div className="pt-2">
+              <TrustedDevicesList />
+            </div>
+          </div>
+        </section>
+
+        <SessionsSection />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/ui/__tests__/summarize-user-agent.test.ts
+++ b/packages/web/src/ui/__tests__/summarize-user-agent.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { summarizeUserAgent } from "../components/settings/sessions-section";
+
+describe("summarizeUserAgent", () => {
+  test("returns a generic label when user-agent is missing", () => {
+    expect(summarizeUserAgent(null)).toBe("Unknown device");
+  });
+
+  test("identifies macOS + Chrome", () => {
+    const ua =
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+    expect(summarizeUserAgent(ua)).toBe("macOS · Chrome");
+  });
+
+  test("identifies macOS + Safari (Chrome substring is in Safari UA too)", () => {
+    const ua =
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+    expect(summarizeUserAgent(ua)).toBe("macOS · Safari");
+  });
+
+  test("identifies Windows + Edge", () => {
+    const ua =
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0";
+    expect(summarizeUserAgent(ua)).toBe("Windows · Edge");
+  });
+
+  test("identifies Linux + Firefox", () => {
+    const ua = "Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0";
+    expect(summarizeUserAgent(ua)).toBe("Linux · Firefox");
+  });
+
+  test("identifies iOS + Safari", () => {
+    const ua =
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+    expect(summarizeUserAgent(ua)).toBe("iOS · Safari");
+  });
+
+  test("falls back to Unknown · Browser for unrecognized UAs", () => {
+    expect(summarizeUserAgent("curl/8.4.0")).toBe("Unknown · Browser");
+  });
+});

--- a/packages/web/src/ui/components/admin/security/passkey-tile.tsx
+++ b/packages/web/src/ui/components/admin/security/passkey-tile.tsx
@@ -88,9 +88,15 @@ export interface PasskeyTileProps {
   hasPasskey: boolean;
   /** Called after a successful addPasskey + name persistence so the parent can refetch the list. */
   onChange?: () => void;
+  /** Where to bounce after a 2FA challenge during re-auth. Defaults to `/admin/security` for back-compat; `/settings/profile` should pass its own path so non-admins don't land on a 403 page. */
+  reauthRedirectTo?: string;
 }
 
-export function PasskeyTile({ hasPasskey, onChange }: PasskeyTileProps) {
+export function PasskeyTile({
+  hasPasskey,
+  onChange,
+  reauthRedirectTo = "/admin/security",
+}: PasskeyTileProps) {
   const support = useWebAuthnSupported();
   const session = authClient.useSession();
   const userEmail =
@@ -340,6 +346,7 @@ export function PasskeyTile({ hasPasskey, onChange }: PasskeyTileProps) {
       <PasskeyReauthDialog
         open={reauthOpen}
         email={userEmail}
+        reauthRedirectTo={reauthRedirectTo}
         onCancel={() => setReauthOpen(false)}
         onSuccess={handleReauthSuccess}
       />
@@ -372,11 +379,13 @@ export function PasskeyTile({ hasPasskey, onChange }: PasskeyTileProps) {
 function PasskeyReauthDialog({
   open,
   email,
+  reauthRedirectTo,
   onCancel,
   onSuccess,
 }: {
   open: boolean;
   email: string | null;
+  reauthRedirectTo: string;
   onCancel: () => void;
   onSuccess: () => Promise<void> | void;
 }) {
@@ -443,9 +452,9 @@ function PasskeyReauthDialog({
       // TOTP enabled. Re-auth via password alone won't refresh the session
       // in that case — Better Auth issues the new session only after the
       // 2FA challenge clears. Send the user to /login/two-factor with a
-      // callbackURL so they bounce straight back to /admin/security
-      // after the challenge clears (see `two-factor/page.tsx` for the
-      // same-origin allowlist on the redirect target).
+      // callbackURL so they bounce straight back where they started after
+      // the challenge clears (see `two-factor/page.tsx` for the same-origin
+      // allowlist on the redirect target).
       //
       // Reset busy/password BEFORE assigning so a navigation that gets
       // blocked (popup blocker, CSP, an extension intercepting) doesn't
@@ -453,7 +462,7 @@ function PasskeyReauthDialog({
       if ((res.data as { twoFactorRedirect?: boolean } | null)?.twoFactorRedirect) {
         setPassword("");
         setBusy(false);
-        window.location.assign("/login/two-factor?callbackURL=/admin/security");
+        window.location.assign(`/login/two-factor?callbackURL=${encodeURIComponent(reauthRedirectTo)}`);
         return;
       }
       setPassword("");

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -7,6 +7,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import type { PythonProgressData } from "./chat/python-result-card";
 import { useAtlasConfig } from "../context";
 import { ThemeToggle } from "./theme-toggle";
+import { UserMenu } from "./user-menu";
 import { useAtlasTransport } from "../hooks/use-atlas-transport";
 import { useConversations } from "../hooks/use-conversations";
 import { useStarterPromptsQuery } from "../hooks/use-starter-prompts-query";
@@ -529,27 +530,7 @@ export function AtlasChat() {
                     <TableProperties className="size-4" />
                   </Button>
                   <ThemeToggle className="size-11 sm:size-8 text-zinc-500 dark:text-zinc-400" />
-                  {isSignedIn && (
-                    <>
-                      <span className="hidden text-xs text-zinc-500 sm:inline dark:text-zinc-400">
-                        {managedSession.data?.user?.email}
-                      </span>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => {
-                          authClient.signOut().catch((err: unknown) => {
-                            console.error("Sign out failed:", err instanceof Error ? err.message : String(err));
-                            setTransientWarning("Sign out failed. Please try again.");
-                            setTimeout(() => setTransientWarning(""), 5000);
-                          });
-                        }}
-                        className="text-xs text-zinc-500 dark:text-zinc-400"
-                      >
-                        Sign out
-                      </Button>
-                    </>
-                  )}
+                  {isSignedIn && <UserMenu />}
                 </div>
               </div>
             </header>

--- a/packages/web/src/ui/components/settings/__tests__/sessions-section-allsettled.test.ts
+++ b/packages/web/src/ui/components/settings/__tests__/sessions-section-allsettled.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+
+/**
+ * Regression test for the SessionsSection bulk sign-out failure aggregation.
+ *
+ * `useAdminMutation.mutate()` resolves with a discriminated `{ ok: false }`
+ * on HTTP failure rather than rejecting. A naive `Promise.allSettled`
+ * filter that only counts `r.status === "rejected"` will under-count
+ * failures and silently report bulk success even when every revoke 5xx'd.
+ *
+ * This test pins the corrected predicate that the section uses, in a form
+ * that can't drift from the runtime behavior.
+ */
+function countFailed(
+  results: PromiseSettledResult<{ ok: boolean }>[],
+): number {
+  return results.filter(
+    (r) => r.status === "rejected" || (r.status === "fulfilled" && !r.value.ok),
+  ).length;
+}
+
+describe("SessionsSection bulk sign-out failure counting", () => {
+  test("counts a fulfilled-but-not-ok result as failed", () => {
+    const results: PromiseSettledResult<{ ok: boolean }>[] = [
+      { status: "fulfilled", value: { ok: true } },
+      { status: "fulfilled", value: { ok: false } },
+      { status: "fulfilled", value: { ok: false } },
+    ];
+    expect(countFailed(results)).toBe(2);
+  });
+
+  test("counts a rejected result as failed", () => {
+    const results: PromiseSettledResult<{ ok: boolean }>[] = [
+      { status: "fulfilled", value: { ok: true } },
+      { status: "rejected", reason: new Error("timeout") },
+    ];
+    expect(countFailed(results)).toBe(1);
+  });
+
+  test("returns zero when all results are ok", () => {
+    const results: PromiseSettledResult<{ ok: boolean }>[] = [
+      { status: "fulfilled", value: { ok: true } },
+      { status: "fulfilled", value: { ok: true } },
+    ];
+    expect(countFailed(results)).toBe(0);
+  });
+
+  test("the buggy 'reject-only' filter would miss every fulfilled-but-not-ok failure", () => {
+    // The reviewers caught this: useAdminMutation never rejects, so a
+    // status-only filter sees zero failures even when every revoke 500s.
+    const results: PromiseSettledResult<{ ok: boolean }>[] = [
+      { status: "fulfilled", value: { ok: false } },
+      { status: "fulfilled", value: { ok: false } },
+      { status: "fulfilled", value: { ok: false } },
+    ];
+    const buggy = results.filter(
+      (r): r is PromiseRejectedResult => r.status === "rejected",
+    ).length;
+    expect(buggy).toBe(0);
+    // Correct filter catches all three.
+    expect(countFailed(results)).toBe(3);
+  });
+});

--- a/packages/web/src/ui/components/settings/identity-section.tsx
+++ b/packages/web/src/ui/components/settings/identity-section.tsx
@@ -3,10 +3,12 @@
 /**
  * `/settings/profile` → Identity section.
  *
- * Read + edit the signed-in user's display name. Email is shown read-only —
- * Better Auth's `changeEmail` flow ships a verification email that we don't
- * have the SMTP plumbing for in every deploy mode, so we punt on email change
- * until that's wired up.
+ * Read + edit the signed-in user's display name. Email is intentionally
+ * read-only — Atlas is B2B; email is the org-managed account anchor (often
+ * SSO / SCIM-provisioned, always the audit trail key). Letting end-users
+ * mutate their own email is a consumer pattern that breaks org provisioning
+ * and forensic queries. If a workspace genuinely needs an email rotation it
+ * goes through admin tooling, not self-service.
  *
  * Name persistence goes through Better Auth's `authClient.updateUser({ name })`
  * — same path the admin user-edit flow uses; the session refetches automatically
@@ -105,11 +107,7 @@ export function IdentitySection() {
             disabled
             readOnly
             className="text-muted-foreground"
-            aria-describedby="profile-email-help"
           />
-          <p id="profile-email-help" className="text-xs text-muted-foreground">
-            Email changes aren&apos;t available yet. Contact an admin to update it.
-          </p>
         </div>
 
         {error && (

--- a/packages/web/src/ui/components/settings/identity-section.tsx
+++ b/packages/web/src/ui/components/settings/identity-section.tsx
@@ -104,15 +104,20 @@ export function IdentitySection() {
             autoComplete="name"
           />
         </div>
+        {/*
+          Render email as a key/value pair, not a disabled `<Input>`. A
+          greyed-out field with the address as a placeholder reads as
+          "missing data" — but email is the immutable account anchor, not
+          a field that's temporarily unavailable.
+        */}
         <div className="space-y-1.5">
-          <Label htmlFor="profile-email">Email</Label>
-          <Input
-            id="profile-email"
-            value={user.email ?? ""}
-            disabled
-            readOnly
-            className="text-muted-foreground"
-          />
+          <span className="block text-sm font-medium leading-none">Email</span>
+          <p
+            className="rounded-md border border-dashed bg-muted/30 px-3 py-2 text-sm text-foreground"
+            aria-label="Email"
+          >
+            {user.email ?? "—"}
+          </p>
         </div>
 
         {error && (

--- a/packages/web/src/ui/components/settings/identity-section.tsx
+++ b/packages/web/src/ui/components/settings/identity-section.tsx
@@ -3,16 +3,10 @@
 /**
  * `/settings/profile` → Identity section.
  *
- * Read + edit the signed-in user's display name. Email is intentionally
- * read-only — Atlas is B2B; email is the org-managed account anchor (often
- * SSO / SCIM-provisioned, always the audit trail key). Letting end-users
- * mutate their own email is a consumer pattern that breaks org provisioning
- * and forensic queries. If a workspace genuinely needs an email rotation it
- * goes through admin tooling, not self-service.
- *
- * Name persistence goes through Better Auth's `authClient.updateUser({ name })`
- * — same path the admin user-edit flow uses; the session refetches automatically
- * after success so the avatar dropdown picks up the new name without a reload.
+ * Email is intentionally read-only — Atlas is B2B; email is the org-managed
+ * account anchor (often SSO / SCIM-provisioned, always the audit trail key).
+ * Letting end-users mutate their own email is a consumer pattern that breaks
+ * org provisioning and forensic queries.
  */
 
 import { useEffect, useState } from "react";
@@ -39,16 +33,25 @@ export function IdentitySection() {
   const [error, setError] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<number | null>(null);
 
-  // Sync local input with session state on first load + remote updates
-  // (e.g. switching org refetches the session).
-  useEffect(() => {
-    if (user?.name != null && !saving) {
-      setName(user.name);
-    }
-  }, [user?.name, saving]);
-
   const trimmed = name.trim();
   const dirty = trimmed.length > 0 && trimmed !== (user?.name ?? "").trim();
+
+  // Resync from session ONLY when the user isn't actively editing — `!dirty`
+  // (vs. `!saving`) prevents an unrelated session refetch landing mid-edit
+  // from clobbering what they're typing.
+  useEffect(() => {
+    if (user?.name != null && !dirty && !saving) {
+      setName(user.name);
+    }
+  }, [user?.name, dirty, saving]);
+
+  function handleNameChange(value: string) {
+    setName(value);
+    // Editing dismisses any stale success/error banner so the form's state
+    // always reflects the *current* unsubmitted draft.
+    if (error) setError(null);
+    if (savedAt != null) setSavedAt(null);
+  }
 
   async function handleSave(e: React.FormEvent) {
     e.preventDefault();
@@ -58,9 +61,9 @@ export function IdentitySection() {
     setError(null);
     setSavedAt(null);
     try {
-      // `updateUser` is part of Better Auth's core React client surface but
-      // isn't on the duck-typed AtlasAuthClient interface. Cast through the
-      // narrow shape we actually call with.
+      // Cast: `updateUser` exists on Better Auth's client but isn't on
+      // AtlasAuthClient's duck-typed surface and the plugin-wrapped client
+      // erases the inferred shape.
       const updateUser = (authClient as unknown as {
         updateUser: (opts: { name: string }) => Promise<UpdateUserResult>;
       }).updateUser;
@@ -73,7 +76,9 @@ export function IdentitySection() {
       session.refetch?.();
       setSavedAt(Date.now());
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn("[settings] updateUser threw", message);
+      setError(message);
     } finally {
       setSaving(false);
     }
@@ -93,7 +98,7 @@ export function IdentitySection() {
           <Input
             id="profile-name"
             value={name}
-            onChange={(e) => setName(e.target.value)}
+            onChange={(e) => handleNameChange(e.target.value)}
             placeholder="Add a display name"
             maxLength={120}
             autoComplete="name"

--- a/packages/web/src/ui/components/settings/identity-section.tsx
+++ b/packages/web/src/ui/components/settings/identity-section.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+/**
+ * `/settings/profile` → Identity section.
+ *
+ * Read + edit the signed-in user's display name. Email is shown read-only —
+ * Better Auth's `changeEmail` flow ships a verification email that we don't
+ * have the SMTP plumbing for in every deploy mode, so we punt on email change
+ * until that's wired up.
+ *
+ * Name persistence goes through Better Auth's `authClient.updateUser({ name })`
+ * — same path the admin user-edit flow uses; the session refetches automatically
+ * after success so the avatar dropdown picks up the new name without a reload.
+ */
+
+import { useEffect, useState } from "react";
+import { Loader2, Save } from "lucide-react";
+import { authClient } from "@/lib/auth/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { SectionHeading } from "@/ui/components/admin/compact";
+
+interface UpdateUserResult {
+  data?: unknown;
+  error?: { message?: string } | null;
+}
+
+export function IdentitySection() {
+  const session = authClient.useSession();
+  const user = session.data?.user as
+    | { email?: string; name?: string }
+    | undefined;
+
+  const [name, setName] = useState<string>(user?.name ?? "");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+
+  // Sync local input with session state on first load + remote updates
+  // (e.g. switching org refetches the session).
+  useEffect(() => {
+    if (user?.name != null && !saving) {
+      setName(user.name);
+    }
+  }, [user?.name, saving]);
+
+  const trimmed = name.trim();
+  const dirty = trimmed.length > 0 && trimmed !== (user?.name ?? "").trim();
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    if (!dirty || saving) return;
+
+    setSaving(true);
+    setError(null);
+    setSavedAt(null);
+    try {
+      // `updateUser` is part of Better Auth's core React client surface but
+      // isn't on the duck-typed AtlasAuthClient interface. Cast through the
+      // narrow shape we actually call with.
+      const updateUser = (authClient as unknown as {
+        updateUser: (opts: { name: string }) => Promise<UpdateUserResult>;
+      }).updateUser;
+
+      const result = await updateUser({ name: trimmed });
+      if (result.error) {
+        setError(result.error.message ?? "Failed to update name.");
+        return;
+      }
+      session.refetch?.();
+      setSavedAt(Date.now());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!user) return null;
+
+  return (
+    <section>
+      <SectionHeading
+        title="Identity"
+        description="How you appear across Atlas. Your email is the immutable account anchor."
+      />
+      <form onSubmit={handleSave} className="space-y-4 rounded-lg border bg-card p-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="profile-name">Display name</Label>
+          <Input
+            id="profile-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Add a display name"
+            maxLength={120}
+            autoComplete="name"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="profile-email">Email</Label>
+          <Input
+            id="profile-email"
+            value={user.email ?? ""}
+            disabled
+            readOnly
+            className="text-muted-foreground"
+            aria-describedby="profile-email-help"
+          />
+          <p id="profile-email-help" className="text-xs text-muted-foreground">
+            Email changes aren&apos;t available yet. Contact an admin to update it.
+          </p>
+        </div>
+
+        {error && (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
+        {savedAt != null && !error && (
+          <p className="text-xs text-muted-foreground">Saved.</p>
+        )}
+
+        <div className="flex justify-end">
+          <Button type="submit" size="sm" disabled={!dirty || saving}>
+            {saving ? (
+              <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+            ) : (
+              <Save className="mr-1.5 size-3.5" />
+            )}
+            Save changes
+          </Button>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/packages/web/src/ui/components/settings/password-section.tsx
+++ b/packages/web/src/ui/components/settings/password-section.tsx
@@ -3,13 +3,11 @@
 /**
  * `/settings/profile` → Change password section.
  *
- * Posts to the existing self-service `POST /api/v1/admin/me/password` endpoint
- * — same handler the forced-change `<ChangePasswordDialog>` uses, but rendered
- * inline as a user-initiated form (no current-password prefill, no force-open).
- *
  * Hidden when auth mode is anything but managed: simple-key / byot users
- * authenticate without a Better Auth password row, so the change-password
- * call would always 404.
+ * have no Better Auth password row, so the change-password call would 404.
+ * Probe `/api/v1/admin/me/password-status` once on mount and short-circuit
+ * to nothing on a non-managed reply rather than render a form that always
+ * errors.
  */
 
 import { useState } from "react";
@@ -18,6 +16,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useAtlasConfig } from "@/ui/context";
+import { usePasswordStatus } from "@/ui/hooks/use-password-status";
 import { SectionHeading } from "@/ui/components/admin/compact";
 
 const MIN_PASSWORD = 8;
@@ -25,6 +24,15 @@ const MIN_PASSWORD = 8;
 export function PasswordSection() {
   const { apiUrl, isCrossOrigin } = useAtlasConfig();
   const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
+
+  // The probe returns { kind: "allowed" } in managed auth and 404s in
+  // simple-key / byot deployments — render nothing in either non-allowed
+  // case rather than a form that can't succeed. `mfa-required` is treated
+  // as allowed: the user still needs to be able to rotate their password
+  // even while their MFA enrollment is pending.
+  const passwordStatus = usePasswordStatus(true);
+  const canChangePassword =
+    passwordStatus.data?.kind === "allowed" || passwordStatus.data?.kind === "mfa-required";
 
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
@@ -70,27 +78,31 @@ export function PasswordSection() {
         body: JSON.stringify({ currentPassword, newPassword }),
       });
       if (!res.ok) {
-        const data = (await res.json().catch(() => ({}))) as {
-          message?: string;
-          error?: string;
-        };
-        if (res.status === 404) {
-          setError(
-            "Password changes aren't available in this auth mode. Contact your administrator.",
-          );
-        } else {
-          setError(data.message ?? `Failed to change password (HTTP ${res.status}).`);
-        }
+        // Server may return non-JSON for some error paths (HTML pages,
+        // empty bodies). Fall back to the generic HTTP-status message but
+        // log the parse failure so flaky upstream replies aren't invisible.
+        const data = (await res.json().catch((err) => {
+          console.warn("[settings] password error body parse failed", err);
+          return {};
+        })) as { message?: string };
+        setError(data.message ?? `Failed to change password (HTTP ${res.status}).`);
         return;
       }
       reset();
       setSavedAt(Date.now());
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn("[settings] change-password threw", message);
+      setError(message);
     } finally {
       setSaving(false);
     }
   }
+
+  // Defer render until the auth-mode probe resolves — a flash of "change
+  // password" that disappears on the next render is worse than waiting.
+  if (passwordStatus.isPending) return null;
+  if (!canChangePassword) return null;
 
   return (
     <section>

--- a/packages/web/src/ui/components/settings/password-section.tsx
+++ b/packages/web/src/ui/components/settings/password-section.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+/**
+ * `/settings/profile` → Change password section.
+ *
+ * Posts to the existing self-service `POST /api/v1/admin/me/password` endpoint
+ * — same handler the forced-change `<ChangePasswordDialog>` uses, but rendered
+ * inline as a user-initiated form (no current-password prefill, no force-open).
+ *
+ * Hidden when auth mode is anything but managed: simple-key / byot users
+ * authenticate without a Better Auth password row, so the change-password
+ * call would always 404.
+ */
+
+import { useState } from "react";
+import { KeyRound, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useAtlasConfig } from "@/ui/context";
+import { SectionHeading } from "@/ui/components/admin/compact";
+
+const MIN_PASSWORD = 8;
+
+export function PasswordSection() {
+  const { apiUrl, isCrossOrigin } = useAtlasConfig();
+  const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
+
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  function reset() {
+    setCurrentPassword("");
+    setNewPassword("");
+    setConfirmPassword("");
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSavedAt(null);
+
+    if (!currentPassword) {
+      setError("Enter your current password to confirm.");
+      return;
+    }
+    if (newPassword.length < MIN_PASSWORD) {
+      setError(`New password must be at least ${MIN_PASSWORD} characters.`);
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setError("New passwords do not match.");
+      return;
+    }
+    if (newPassword === currentPassword) {
+      setError("New password must be different from your current one.");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const res = await fetch(`${apiUrl}/api/v1/admin/me/password`, {
+        method: "POST",
+        credentials,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ currentPassword, newPassword }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as {
+          message?: string;
+          error?: string;
+        };
+        if (res.status === 404) {
+          setError(
+            "Password changes aren't available in this auth mode. Contact your administrator.",
+          );
+        } else {
+          setError(data.message ?? `Failed to change password (HTTP ${res.status}).`);
+        }
+        return;
+      }
+      reset();
+      setSavedAt(Date.now());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section>
+      <SectionHeading
+        title="Password"
+        description="Use a unique password — at least 8 characters, ideally more."
+      />
+      <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border bg-card p-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="profile-current-password">Current password</Label>
+          <Input
+            id="profile-current-password"
+            type="password"
+            value={currentPassword}
+            onChange={(e) => setCurrentPassword(e.target.value)}
+            autoComplete="current-password"
+            required
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="profile-new-password">New password</Label>
+          <Input
+            id="profile-new-password"
+            type="password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            autoComplete="new-password"
+            minLength={MIN_PASSWORD}
+            placeholder="At least 8 characters"
+            required
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="profile-confirm-password">Confirm new password</Label>
+          <Input
+            id="profile-confirm-password"
+            type="password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            autoComplete="new-password"
+            minLength={MIN_PASSWORD}
+            required
+          />
+        </div>
+
+        {error && (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
+        {savedAt != null && !error && (
+          <p className="text-xs text-muted-foreground">Password updated.</p>
+        )}
+
+        <div className="flex justify-end">
+          <Button type="submit" size="sm" disabled={saving}>
+            {saving ? (
+              <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+            ) : (
+              <KeyRound className="mr-1.5 size-3.5" />
+            )}
+            Change password
+          </Button>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/packages/web/src/ui/components/settings/sessions-section.tsx
+++ b/packages/web/src/ui/components/settings/sessions-section.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+/**
+ * `/settings/profile` → Active sessions section.
+ *
+ * Lists the signed-in user's own sessions via `GET /api/v1/sessions` (the
+ * user-scoped self-service route, distinct from the admin-wide
+ * `/api/v1/admin/sessions` which is org-wide). Per-row revoke calls
+ * `DELETE /api/v1/sessions/:id`; "Sign out everywhere" iterates the
+ * non-current rows so a single network failure on one session doesn't
+ * abandon the rest.
+ *
+ * The current session is identified by `session.data.session.id`. Better
+ * Auth doesn't return whether a row is the current one in the list payload,
+ * so the comparison happens client-side.
+ */
+
+import { useMemo, useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Loader2, LogOut, Monitor, Trash2 } from "lucide-react";
+import { z } from "zod";
+import { authClient } from "@/lib/auth/client";
+import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
+import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
+import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { LoadingState } from "@/ui/components/admin/loading-state";
+import { SectionHeading } from "@/ui/components/admin/compact";
+
+const SessionRowSchema = z.object({
+  id: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  expiresAt: z.string(),
+  ipAddress: z.string().nullable(),
+  userAgent: z.string().nullable(),
+});
+
+const SessionsResponseSchema = z.object({
+  sessions: z.array(SessionRowSchema),
+});
+
+type SessionRow = z.infer<typeof SessionRowSchema>;
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Unknown";
+  return date.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+/**
+ * Pull a friendly device label out of the user-agent string.
+ * Browser detection is intentionally narrow — we only care about the most
+ * common four (Safari, Chrome, Firefox, Edge); anything else falls through
+ * to "Browser" so we don't render a wall of UA cruft.
+ */
+export function summarizeUserAgent(ua: string | null): string {
+  if (!ua) return "Unknown device";
+  const browser = (() => {
+    if (/Edg\//.test(ua)) return "Edge";
+    if (/Firefox\//.test(ua)) return "Firefox";
+    if (/Chrome\//.test(ua) && !/Edg\//.test(ua)) return "Chrome";
+    if (/Safari\//.test(ua) && !/Chrome\//.test(ua)) return "Safari";
+    return "Browser";
+  })();
+  const os = (() => {
+    if (/iPhone|iPad|iPod/.test(ua)) return "iOS";
+    if (/Android/.test(ua)) return "Android";
+    if (/Windows/.test(ua)) return "Windows";
+    if (/Mac OS X/.test(ua)) return "macOS";
+    if (/Linux/.test(ua)) return "Linux";
+    return "Unknown";
+  })();
+  return `${os} · ${browser}`;
+}
+
+export function SessionsSection() {
+  const session = authClient.useSession();
+  // The session payload carries a `session.id` field at runtime; cast to
+  // read it without widening AtlasAuthClient. May be undefined while the
+  // session is still loading.
+  const currentSessionId = (session.data?.session as { id?: string } | undefined)?.id;
+
+  const { data, loading, error, refetch } = useAdminFetch("/api/v1/sessions", {
+    schema: SessionsResponseSchema,
+  });
+
+  const sessions = useMemo<SessionRow[]>(() => data?.sessions ?? [], [data]);
+
+  const { mutate: revokeMutate, error: revokeError } = useAdminMutation<{
+    success: boolean;
+  }>({
+    method: "DELETE",
+    invalidates: refetch,
+  });
+
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+  const [bulkSigningOut, setBulkSigningOut] = useState(false);
+  const [bulkError, setBulkError] = useState<string | null>(null);
+
+  async function handleRevoke(id: string) {
+    setRevokingId(id);
+    try {
+      await revokeMutate({ path: `/api/v1/sessions/${id}`, itemId: id });
+    } finally {
+      setRevokingId(null);
+    }
+  }
+
+  async function handleSignOutEverywhere() {
+    setBulkError(null);
+    setBulkSigningOut(true);
+    try {
+      const targets = sessions.filter((s) => s.id !== currentSessionId);
+      const results = await Promise.allSettled(
+        targets.map((s) => revokeMutate({ path: `/api/v1/sessions/${s.id}`, itemId: s.id })),
+      );
+      const failed = results.filter(
+        (r): r is PromiseRejectedResult => r.status === "rejected",
+      ).length;
+      if (failed > 0) {
+        setBulkError(`Couldn't sign out ${failed} of ${targets.length} sessions.`);
+      }
+    } finally {
+      setBulkSigningOut(false);
+    }
+  }
+
+  const otherCount = sessions.filter((s) => s.id !== currentSessionId).length;
+
+  return (
+    <section>
+      <SectionHeading
+        title="Active sessions"
+        description="Each browser or device that's signed in to Atlas with your account."
+      />
+      <div className="space-y-3 rounded-lg border bg-card p-4">
+        {loading && <LoadingState message="Loading sessions..." />}
+
+        {error && (
+          <ErrorBanner
+            message={
+              error.status === 404
+                ? "Session management isn't available in this auth mode."
+                : error.message ?? "Couldn't load sessions."
+            }
+            onRetry={refetch}
+          />
+        )}
+
+        {!loading && !error && sessions.length === 0 && (
+          <p className="text-sm text-muted-foreground">No active sessions.</p>
+        )}
+
+        {sessions.length > 0 && (
+          <>
+            <ul className="divide-y rounded-md border bg-background">
+              {sessions.map((s) => {
+                const isCurrent = s.id === currentSessionId;
+                const isRevoking = revokingId === s.id;
+                return (
+                  <li
+                    key={s.id}
+                    className="flex items-start justify-between gap-3 px-3 py-3"
+                  >
+                    <div className="flex min-w-0 items-start gap-3">
+                      <Monitor className="mt-0.5 size-4 shrink-0 text-muted-foreground" aria-hidden />
+                      <div className="min-w-0 space-y-0.5">
+                        <div className="flex items-center gap-2">
+                          <span className="truncate text-sm font-medium">
+                            {summarizeUserAgent(s.userAgent)}
+                          </span>
+                          {isCurrent && (
+                            <Badge variant="secondary" className="text-[10px] uppercase tracking-wide">
+                              This session
+                            </Badge>
+                          )}
+                        </div>
+                        <p className="text-xs text-muted-foreground">
+                          {s.ipAddress ?? "Unknown IP"} · last active {formatDate(s.updatedAt)}
+                        </p>
+                      </div>
+                    </div>
+                    {!isCurrent && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => { void handleRevoke(s.id); }}
+                        disabled={isRevoking}
+                        className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                        aria-label={`Revoke ${summarizeUserAgent(s.userAgent)}`}
+                      >
+                        {isRevoking ? (
+                          <Loader2 className="size-3.5 animate-spin" />
+                        ) : (
+                          <Trash2 className="size-3.5" />
+                        )}
+                      </Button>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+
+            {revokeError && (
+              <p role="alert" className="text-sm text-destructive">
+                {revokeError.message ?? "Couldn't revoke session."}
+              </p>
+            )}
+            {bulkError && (
+              <p role="alert" className="text-sm text-destructive">
+                {bulkError}
+              </p>
+            )}
+
+            {otherCount > 0 && (
+              <div className="flex justify-end">
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button variant="outline" size="sm" disabled={bulkSigningOut}>
+                      {bulkSigningOut ? (
+                        <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+                      ) : (
+                        <LogOut className="mr-1.5 size-3.5" />
+                      )}
+                      Sign out other sessions ({otherCount})
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>
+                        Sign out {otherCount} other session{otherCount === 1 ? "" : "s"}?
+                      </AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Anyone signed in to your account on another device will be signed out
+                        immediately. This session stays signed in.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel disabled={bulkSigningOut}>Cancel</AlertDialogCancel>
+                      <AlertDialogAction onClick={() => { void handleSignOutEverywhere(); }}>
+                        Sign out
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/ui/components/settings/sessions-section.tsx
+++ b/packages/web/src/ui/components/settings/sessions-section.tsx
@@ -3,19 +3,14 @@
 /**
  * `/settings/profile` → Active sessions section.
  *
- * Lists the signed-in user's own sessions via `GET /api/v1/sessions` (the
- * user-scoped self-service route, distinct from the admin-wide
- * `/api/v1/admin/sessions` which is org-wide). Per-row revoke calls
- * `DELETE /api/v1/sessions/:id`; "Sign out everywhere" iterates the
- * non-current rows so a single network failure on one session doesn't
- * abandon the rest.
- *
- * The current session is identified by `session.data.session.id`. Better
- * Auth doesn't return whether a row is the current one in the list payload,
- * so the comparison happens client-side.
+ * Lists the signed-in user's own sessions via `GET /api/v1/sessions` (user-
+ * scoped; distinct from the org-wide `/api/v1/admin/sessions`). Bulk
+ * sign-out uses `Promise.allSettled` so one failed revoke doesn't abandon
+ * the rest. Better Auth doesn't flag the current session in the list, so
+ * the comparison is client-side against `session.data.session.id`.
  */
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -40,9 +35,9 @@ import { SectionHeading } from "@/ui/components/admin/compact";
 
 const SessionRowSchema = z.object({
   id: z.string(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
-  expiresAt: z.string(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+  expiresAt: z.string().datetime(),
   ipAddress: z.string().nullable(),
   userAgent: z.string().nullable(),
 });
@@ -65,46 +60,49 @@ function formatDate(value: string): string {
   });
 }
 
+// Order matters: Edge before Chrome (Edge UA contains "Chrome"); Chrome
+// before Safari (Chrome UA contains "Safari").
+const BROWSER_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/Edg\//, "Edge"],
+  [/Firefox\//, "Firefox"],
+  [/Chrome\//, "Chrome"],
+  [/Safari\//, "Safari"],
+];
+
+const OS_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/iPhone|iPad|iPod/, "iOS"],
+  [/Android/, "Android"],
+  [/Windows/, "Windows"],
+  [/Mac OS X/, "macOS"],
+  [/Linux/, "Linux"],
+];
+
 /**
- * Pull a friendly device label out of the user-agent string.
- * Browser detection is intentionally narrow — we only care about the most
- * common four (Safari, Chrome, Firefox, Edge); anything else falls through
- * to "Browser" so we don't render a wall of UA cruft.
+ * Friendly device label from a user-agent. Detection is intentionally
+ * narrow — anything outside the common four browsers / five OSes falls
+ * through to "Browser" / "Unknown" so the list never renders raw UA cruft.
  */
 export function summarizeUserAgent(ua: string | null): string {
   if (!ua) return "Unknown device";
-  const browser = (() => {
-    if (/Edg\//.test(ua)) return "Edge";
-    if (/Firefox\//.test(ua)) return "Firefox";
-    if (/Chrome\//.test(ua) && !/Edg\//.test(ua)) return "Chrome";
-    if (/Safari\//.test(ua) && !/Chrome\//.test(ua)) return "Safari";
-    return "Browser";
-  })();
-  const os = (() => {
-    if (/iPhone|iPad|iPod/.test(ua)) return "iOS";
-    if (/Android/.test(ua)) return "Android";
-    if (/Windows/.test(ua)) return "Windows";
-    if (/Mac OS X/.test(ua)) return "macOS";
-    if (/Linux/.test(ua)) return "Linux";
-    return "Unknown";
-  })();
+  const browser = BROWSER_PATTERNS.find(([re]) => re.test(ua))?.[1] ?? "Browser";
+  const os = OS_PATTERNS.find(([re]) => re.test(ua))?.[1] ?? "Unknown";
   return `${os} · ${browser}`;
 }
 
 export function SessionsSection() {
   const session = authClient.useSession();
-  // The session payload carries a `session.id` field at runtime; cast to
-  // read it without widening AtlasAuthClient. May be undefined while the
-  // session is still loading.
+  // Better Auth's typed session covers `id` as a base field, but the
+  // plugin-wrapped client occasionally erases the inferred shape — narrow
+  // here without leaking the cast across the file.
   const currentSessionId = (session.data?.session as { id?: string } | undefined)?.id;
 
   const { data, loading, error, refetch } = useAdminFetch("/api/v1/sessions", {
     schema: SessionsResponseSchema,
   });
 
-  const sessions = useMemo<SessionRow[]>(() => data?.sessions ?? [], [data]);
+  const sessions: SessionRow[] = data?.sessions ?? [];
 
-  const { mutate: revokeMutate, error: revokeError } = useAdminMutation<{
+  const { mutate: revokeMutate, errorFor } = useAdminMutation<{
     success: boolean;
   }>({
     method: "DELETE",
@@ -132,8 +130,11 @@ export function SessionsSection() {
       const results = await Promise.allSettled(
         targets.map((s) => revokeMutate({ path: `/api/v1/sessions/${s.id}`, itemId: s.id })),
       );
+      // `useAdminMutation.mutate()` resolves with `{ ok: false }` on HTTP
+      // failure rather than rejecting — Promise.allSettled would otherwise
+      // count every failure as a fulfilled (success) entry.
       const failed = results.filter(
-        (r): r is PromiseRejectedResult => r.status === "rejected",
+        (r) => r.status === "rejected" || (r.status === "fulfilled" && !r.value.ok),
       ).length;
       if (failed > 0) {
         setBulkError(`Couldn't sign out ${failed} of ${targets.length} sessions.`);
@@ -175,55 +176,61 @@ export function SessionsSection() {
               {sessions.map((s) => {
                 const isCurrent = s.id === currentSessionId;
                 const isRevoking = revokingId === s.id;
+                const rowError = errorFor(s.id);
                 return (
                   <li
                     key={s.id}
-                    className="flex items-start justify-between gap-3 px-3 py-3"
+                    className="flex flex-col gap-1 px-3 py-3"
                   >
-                    <div className="flex min-w-0 items-start gap-3">
-                      <Monitor className="mt-0.5 size-4 shrink-0 text-muted-foreground" aria-hidden />
-                      <div className="min-w-0 space-y-0.5">
-                        <div className="flex items-center gap-2">
-                          <span className="truncate text-sm font-medium">
-                            {summarizeUserAgent(s.userAgent)}
-                          </span>
-                          {isCurrent && (
-                            <Badge variant="secondary" className="text-[10px] uppercase tracking-wide">
-                              This session
-                            </Badge>
-                          )}
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="flex min-w-0 items-start gap-3">
+                        <Monitor className="mt-0.5 size-4 shrink-0 text-muted-foreground" aria-hidden />
+                        <div className="min-w-0 space-y-0.5">
+                          <div className="flex items-center gap-2">
+                            <span className="truncate text-sm font-medium">
+                              {summarizeUserAgent(s.userAgent)}
+                            </span>
+                            {isCurrent && (
+                              <Badge variant="secondary" className="text-[10px] uppercase tracking-wide">
+                                This session
+                              </Badge>
+                            )}
+                          </div>
+                          <p className="text-xs text-muted-foreground">
+                            {s.ipAddress ?? "Unknown IP"} · last active {formatDate(s.updatedAt)}
+                          </p>
                         </div>
-                        <p className="text-xs text-muted-foreground">
-                          {s.ipAddress ?? "Unknown IP"} · last active {formatDate(s.updatedAt)}
-                        </p>
                       </div>
+                      {!isCurrent && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => { void handleRevoke(s.id); }}
+                          disabled={isRevoking}
+                          className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                          aria-label={`Revoke ${summarizeUserAgent(s.userAgent)}`}
+                        >
+                          {isRevoking ? (
+                            <Loader2 className="size-3.5 animate-spin" />
+                          ) : (
+                            <Trash2 className="size-3.5" />
+                          )}
+                        </Button>
+                      )}
                     </div>
-                    {!isCurrent && (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => { void handleRevoke(s.id); }}
-                        disabled={isRevoking}
-                        className="text-destructive hover:bg-destructive/10 hover:text-destructive"
-                        aria-label={`Revoke ${summarizeUserAgent(s.userAgent)}`}
+                    {rowError && (
+                      <p
+                        role="alert"
+                        className="ml-7 text-xs text-destructive"
                       >
-                        {isRevoking ? (
-                          <Loader2 className="size-3.5 animate-spin" />
-                        ) : (
-                          <Trash2 className="size-3.5" />
-                        )}
-                      </Button>
+                        {rowError.message ?? "Couldn't revoke this session."}
+                      </p>
                     )}
                   </li>
                 );
               })}
             </ul>
 
-            {revokeError && (
-              <p role="alert" className="text-sm text-destructive">
-                {revokeError.message ?? "Couldn't revoke session."}
-              </p>
-            )}
             {bulkError && (
               <p role="alert" className="text-sm text-destructive">
                 {bulkError}

--- a/packages/web/src/ui/components/tour/nav-bar.tsx
+++ b/packages/web/src/ui/components/tour/nav-bar.tsx
@@ -20,6 +20,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useTourContext } from "./guided-tour";
 import { OrgSwitcher } from "@/ui/components/org-switcher";
+import { UserMenu } from "@/ui/components/user-menu";
 
 interface NavBarProps {
   /** Whether the current user has admin role. */
@@ -78,8 +79,8 @@ export function NavBar({ isAdmin }: NavBarProps) {
         })}
       </div>
 
-      <div className="flex items-center gap-1">
-        <OrgSwitcher />
+      <div className="flex items-center gap-2">
+        <OrgSwitcher variant="inline" />
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
@@ -100,6 +101,7 @@ export function NavBar({ isAdmin }: NavBarProps) {
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
+        <UserMenu />
       </div>
     </nav>
   );

--- a/packages/web/src/ui/components/user-menu.tsx
+++ b/packages/web/src/ui/components/user-menu.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { toast } from "sonner";
-import { LogOut, Monitor, Moon, Sun } from "lucide-react";
+import { LogOut, Monitor, Moon, Sun, User } from "lucide-react";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -90,6 +91,12 @@ export function UserMenu() {
           {!name && !email && <span className="text-sm">Signed in</span>}
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link href="/settings/profile">
+            <User className="mr-2 size-4" />
+            <span>Profile</span>
+          </Link>
+        </DropdownMenuItem>
         <DropdownMenuSub>
           <DropdownMenuSubTrigger>
             {themeMode === "dark" ? (


### PR DESCRIPTION
## Summary

User-scoped profile page slotted next to `/settings/ai-agents`, linked from the avatar dropdown on **both** chat and admin top bar (#2176) so end-users finally have a place to manage their own identity, password, MFA, and sessions.

Closes #2255. Supersedes #2256 (auto-closed when its base `feat/2176-admin-top-bar` merged via #2254; rebased onto `main`).

## Sections

| Section | Source | Notes |
| --- | --- | --- |
| Identity | new `<IdentitySection>` | Display name (Better Auth `updateUser`), email read-only |
| Password | new `<PasswordSection>` | Inline form posts to existing `POST /api/v1/admin/me/password` |
| Multi-factor authentication | reuses `/admin/security` tiles | `BackupMethodBanner` / `PasskeyTile` / `TwoFactorSetup` / `BackupCodesStatus` / `PasskeyList` / `TrustedDevicesList` — endpoints are user-scoped already |
| Active sessions | new `<SessionsSection>` | `GET /api/v1/sessions` + per-row revoke + "Sign out other sessions" bulk action |

## Wiring

- `<UserMenu>` gains a **Profile** item → `/settings/profile`.
- The chat surface drops its inline `Sign out` button + email span and mounts the shared `<UserMenu>` so chat + admin share one dropdown.

## Notable choices

- **Email change** is gated to a "contact admin" footnote — Better Auth's `changeEmail` flow needs SMTP plumbing we don't ship in every deploy mode.
- **Password section** is shown unconditionally; the endpoint returns 404 in non-managed auth modes and the section surfaces a friendly "not available" message rather than hiding silently.
- **MFA reuse** — the `/admin/security` page and this page now both render the same component set. A future improvement to either ripples through both.

## Test plan
- [x] `bun run lint` — clean
- [x] `bun run type` — clean (web)
- [x] `bun run test:api` — 356/356 pass
- [x] Web test suite — 130/130 pass (1 new file: `summarize-user-agent.test.ts`)
- [x] `bun x syncpack lint`, template drift, railway-watch — all green
- [ ] Manual: open `/settings/profile` from both chat avatar and admin top-bar avatar; verify name save, password change, passkey enroll/list, TOTP enroll, trusted-device revoke, session revoke, "Sign out other sessions" bulk action