### PR TITLE
fix(api,web): platform admin shows abuse-suspended workspaces

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -15804,7 +15804,8 @@
                               "warning",
                               "throttled",
                               "suspended"
-                            ]
+                            ],
+                            "default": "none"
                           }
                         },
                         "required": [
@@ -16002,7 +16003,8 @@
                             "warning",
                             "throttled",
                             "suspended"
-                          ]
+                          ],
+                          "default": "none"
                         }
                       },
                       "required": [
@@ -58134,10 +58136,20 @@
                           "createdAt"
                         ]
                       }
+                    },
+                    "abuseRestoreStatus": {
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "ok",
+                        "db_unavailable",
+                        "load_failed"
+                      ]
                     }
                   },
                   "required": [
-                    "workspaces"
+                    "workspaces",
+                    "abuseRestoreStatus"
                   ]
                 }
               }

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -15796,6 +15796,15 @@
                               "string",
                               "null"
                             ]
+                          },
+                          "abuseLevel": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "warning",
+                              "throttled",
+                              "suspended"
+                            ]
                           }
                         },
                         "required": [
@@ -15984,6 +15993,15 @@
                           "type": [
                             "string",
                             "null"
+                          ]
+                        },
+                        "abuseLevel": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "warning",
+                            "throttled",
+                            "suspended"
                           ]
                         }
                       },

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -58084,6 +58084,15 @@
                           },
                           "neverSuspend": {
                             "type": "boolean"
+                          },
+                          "abuseLevel": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "warning",
+                              "throttled",
+                              "suspended"
+                            ]
                           }
                         },
                         "required": [
@@ -58296,6 +58305,15 @@
                         },
                         "neverSuspend": {
                           "type": "boolean"
+                        },
+                        "abuseLevel": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "warning",
+                            "throttled",
+                            "suspended"
+                          ]
                         }
                       },
                       "required": [

--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -743,6 +743,8 @@ export function createApiTestMocks(
     checkAbuseStatus: mock(() => ({ level: "none" })),
     recordQueryEvent: mock(() => {}),
     restoreAbuseState: mock(async () => {}),
+    getAbuseRestoreStatus: mock(() => "ok" as const),
+    ABUSE_RESTORE_STATUSES: ["pending", "ok", "db_unavailable", "load_failed"] as const,
     _resetAbuseState: mock(() => {}),
     abuseCleanupTick: mock(() => {}),
     ABUSE_CLEANUP_INTERVAL_MS: 300_000,

--- a/packages/api/src/api/__tests__/admin-orgs.test.ts
+++ b/packages/api/src/api/__tests__/admin-orgs.test.ts
@@ -15,9 +15,12 @@ import {
   it,
   expect,
   beforeEach,
+  afterEach,
   afterAll,
+  mock,
 } from "bun:test";
 import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+import { asRatio, type AbuseLevel } from "@useatlas/types";
 
 // --- Unified mocks ---
 
@@ -31,6 +34,36 @@ const mocks = createApiTestMocks({
   },
   authMode: "managed",
 });
+
+// Re-register the abuse module with a programmable per-workspace map so
+// the abuseLevel surfacing tests below can drive non-"none" verdicts —
+// `createApiTestMocks` pins `checkAbuseStatus` to `{ level: "none" }`,
+// which is fine for the platform-gate parametrized tests but blocks
+// any assertion that a real escalation propagates to the wire.
+const abuseStatusByWorkspace = new Map<string, AbuseLevel>();
+mock.module("@atlas/api/lib/security/abuse", () => ({
+  listFlaggedWorkspaces: mock(() => []),
+  reinstateWorkspace: mock(() => "warning" as const),
+  getAbuseEvents: mock(async () => ({ events: [], status: "ok" })),
+  getAbuseConfig: mock(() => ({
+    queryRateLimit: 200,
+    queryRateWindowSeconds: 300,
+    errorRateThreshold: asRatio(0.5),
+    uniqueTablesLimit: 50,
+    throttleDelayMs: 2000,
+  })),
+  getAbuseDetail: mock(async () => null),
+  checkAbuseStatus: mock((workspaceId: string) => ({
+    level: abuseStatusByWorkspace.get(workspaceId) ?? "none",
+  })),
+  recordQueryEvent: mock(() => {}),
+  restoreAbuseState: mock(async () => {}),
+  getAbuseRestoreStatus: mock(() => "ok" as const),
+  ABUSE_RESTORE_STATUSES: ["pending", "ok", "db_unavailable", "load_failed"] as const,
+  _resetAbuseState: mock(() => abuseStatusByWorkspace.clear()),
+  abuseCleanupTick: mock(() => {}),
+  ABUSE_CLEANUP_INTERVAL_MS: 300_000,
+}));
 
 // --- Import app after mocks ---
 
@@ -237,34 +270,28 @@ describe("/api/v1/admin/organizations/** — F-08 platform-admin gate (#1750)", 
     }
   });
 
-  // #2269 — `/admin/organizations` is a sibling surface to `/admin/platform`
-  // (different role bucket — workspace org-admin vs platform-admin) and
-  // hits the same `checkAbuseStatus` divergence. Closing the bug class on
-  // the platform-admin page without surfacing `abuseLevel` here would have
-  // shipped the same "DB-active + abuse-suspended renders as Active"
-  // confusion to admin-orgs. Both list + detail thread the field.
+  // #2269 — admin-orgs hits the same checkAbuseStatus divergence as
+  // platform-admin; both list + detail must thread abuseLevel.
   describe("abuseLevel surfacing", () => {
     beforeEach(() => {
       setPlatformAdmin();
       mocks.hasInternalDB = true;
     });
 
+    afterEach(() => {
+      abuseStatusByWorkspace.clear();
+    });
+
     it("GET / threads checkAbuseStatus into every row", async () => {
+      // Stub one suspended workspace so the assertion pins the enum
+      // round-trip — a regression that types abuseLevel as
+      // `z.string().optional()` would let any value through.
+      abuseStatusByWorkspace.set("org-dharma", "suspended");
       mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
         if (sql.includes("FROM organization") && !sql.includes("member")) {
           return [
-            {
-              id: "org-clean",
-              name: "Clean",
-              slug: "clean",
-              logo: null,
-              metadata: null,
-              createdAt: "2026-01-01T00:00:00.000Z",
-              workspace_status: "active",
-              plan_tier: "starter",
-              suspended_at: null,
-              deleted_at: null,
-            },
+            { id: "org-clean", name: "Clean", slug: "clean", logo: null, metadata: null, createdAt: "2026-01-01T00:00:00.000Z", workspace_status: "active", plan_tier: "starter", suspended_at: null, deleted_at: null },
+            { id: "org-dharma", name: "Dharma", slug: "dharma", logo: null, metadata: null, createdAt: "2026-01-01T00:00:00.000Z", workspace_status: "active", plan_tier: "starter", suspended_at: null, deleted_at: null },
           ];
         }
         return [];
@@ -275,30 +302,18 @@ describe("/api/v1/admin/organizations/** — F-08 platform-admin gate (#1750)", 
       const body = (await res.json()) as {
         organizations: Array<{ id: string; workspaceStatus: string; abuseLevel?: string }>;
       };
-      expect(body.organizations[0].id).toBe("org-clean");
-      // `checkAbuseStatus` is mocked to a constant `{ level: "none" }` in
-      // api-test-mocks; a regression that drops the field returns
-      // `undefined` instead of `"none"`, which the assertion below
-      // catches.
-      expect(body.organizations[0].abuseLevel).toBe("none");
+      const lookup = Object.fromEntries(body.organizations.map((o) => [o.id, o]));
+      expect(lookup["org-clean"].abuseLevel).toBe("none");
+      expect(lookup["org-dharma"].workspaceStatus).toBe("active");
+      expect(lookup["org-dharma"].abuseLevel).toBe("suspended");
     });
 
     it("GET /:id threads checkAbuseStatus into the detail response", async () => {
+      abuseStatusByWorkspace.set("org-target", "throttled");
       mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
         if (sql.includes("FROM organization")) {
           return [
-            {
-              id: "org-target",
-              name: "Target",
-              slug: "target",
-              logo: null,
-              metadata: null,
-              createdAt: "2026-01-01T00:00:00.000Z",
-              workspace_status: "active",
-              plan_tier: "starter",
-              suspended_at: null,
-              deleted_at: null,
-            },
+            { id: "org-target", name: "Target", slug: "target", logo: null, metadata: null, createdAt: "2026-01-01T00:00:00.000Z", workspace_status: "active", plan_tier: "starter", suspended_at: null, deleted_at: null },
           ];
         }
         return [];
@@ -307,10 +322,10 @@ describe("/api/v1/admin/organizations/** — F-08 platform-admin gate (#1750)", 
       const res = await app.fetch(orgsRequest("GET", "/api/v1/admin/organizations/org-target"));
       expect(res.status).toBe(200);
       const body = (await res.json()) as {
-        organization: { id: string; abuseLevel?: string };
+        organization: { id: string; workspaceStatus: string; abuseLevel?: string };
       };
-      expect(body.organization.id).toBe("org-target");
-      expect(body.organization.abuseLevel).toBe("none");
+      expect(body.organization.workspaceStatus).toBe("active");
+      expect(body.organization.abuseLevel).toBe("throttled");
     });
   });
 });

--- a/packages/api/src/api/__tests__/admin-orgs.test.ts
+++ b/packages/api/src/api/__tests__/admin-orgs.test.ts
@@ -236,4 +236,81 @@ describe("/api/v1/admin/organizations/** — F-08 platform-admin gate (#1750)", 
       });
     }
   });
+
+  // #2269 — `/admin/organizations` is a sibling surface to `/admin/platform`
+  // (different role bucket — workspace org-admin vs platform-admin) and
+  // hits the same `checkAbuseStatus` divergence. Closing the bug class on
+  // the platform-admin page without surfacing `abuseLevel` here would have
+  // shipped the same "DB-active + abuse-suspended renders as Active"
+  // confusion to admin-orgs. Both list + detail thread the field.
+  describe("abuseLevel surfacing", () => {
+    beforeEach(() => {
+      setPlatformAdmin();
+      mocks.hasInternalDB = true;
+    });
+
+    it("GET / threads checkAbuseStatus into every row", async () => {
+      mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+        if (sql.includes("FROM organization") && !sql.includes("member")) {
+          return [
+            {
+              id: "org-clean",
+              name: "Clean",
+              slug: "clean",
+              logo: null,
+              metadata: null,
+              createdAt: "2026-01-01T00:00:00.000Z",
+              workspace_status: "active",
+              plan_tier: "starter",
+              suspended_at: null,
+              deleted_at: null,
+            },
+          ];
+        }
+        return [];
+      });
+
+      const res = await app.fetch(orgsRequest("GET", "/api/v1/admin/organizations"));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        organizations: Array<{ id: string; workspaceStatus: string; abuseLevel?: string }>;
+      };
+      expect(body.organizations[0].id).toBe("org-clean");
+      // `checkAbuseStatus` is mocked to a constant `{ level: "none" }` in
+      // api-test-mocks; a regression that drops the field returns
+      // `undefined` instead of `"none"`, which the assertion below
+      // catches.
+      expect(body.organizations[0].abuseLevel).toBe("none");
+    });
+
+    it("GET /:id threads checkAbuseStatus into the detail response", async () => {
+      mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+        if (sql.includes("FROM organization")) {
+          return [
+            {
+              id: "org-target",
+              name: "Target",
+              slug: "target",
+              logo: null,
+              metadata: null,
+              createdAt: "2026-01-01T00:00:00.000Z",
+              workspace_status: "active",
+              plan_tier: "starter",
+              suspended_at: null,
+              deleted_at: null,
+            },
+          ];
+        }
+        return [];
+      });
+
+      const res = await app.fetch(orgsRequest("GET", "/api/v1/admin/organizations/org-target"));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        organization: { id: string; abuseLevel?: string };
+      };
+      expect(body.organization.id).toBe("org-target");
+      expect(body.organization.abuseLevel).toBe("none");
+    });
+  });
 });

--- a/packages/api/src/api/__tests__/chat.test.ts
+++ b/packages/api/src/api/__tests__/chat.test.ts
@@ -187,6 +187,16 @@ const mockCheckPlanLimits: Mock<() => Promise<PlanCheckMockResult>> = mock(
   () => Promise.resolve({ allowed: true } as PlanCheckMockResult),
 );
 
+// Residency migration check fires before the abuse gate when a request
+// carries `activeOrganizationId` (chat.ts:~510). The #2269 regression
+// test below seeds an org id; without this mock the dynamic import
+// inside `Effect.tryPromise` fails closed with a 503 and shadows the
+// abuse-gate signal. Default to "not migrating" so the abuse branch is
+// the only one that can produce a non-200 response in that test.
+mock.module("@atlas/api/lib/residency/readonly", () => ({
+  isWorkspaceMigrating: mock(async () => false),
+}));
+
 mock.module("@atlas/api/lib/billing/enforcement", () => ({
   checkPlanLimits: mockCheckPlanLimits,
   // Mocking partial named exports causes a SyntaxError elsewhere in
@@ -1504,6 +1514,71 @@ describe("POST /api/v1/chat", () => {
       );
       const response = await app.fetch(makeRequest());
       expect(response.headers.get("Retry-After")).toBe("15");
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // #2269 — abuse-suspended workspace, lifted by the loadtest allowlist
+  //
+  // End-to-end pinning for the bug the PR fixed at the lib layer: an
+  // allowlisted workspace whose in-memory abuse state is stale-suspended
+  // must NOT 403 with `workspace_suspended`. The lib-level allowlist
+  // guard inside `checkAbuseStatus` (covered by abuse.test.ts) is what
+  // makes that work; this test asserts the chat route honors the
+  // verdict end-to-end — a future regression that re-reads `state.level`
+  // directly (bypassing the allowlist short-circuit) would fail here
+  // even though the unit-level test still passes.
+  // ---------------------------------------------------------------------
+
+  describe("#2269 — allowlisted-with-stale-suspended workspace", () => {
+    it("returns non-403 when checkAbuseStatus is shadowed by the allowlist", async () => {
+      const origAllowlist = process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+      // Real abuse module — no mock.module() override at the top of this
+      // file — so we drive the in-memory ladder via the same `recordQueryEvent`
+      // entry point production uses, then add the workspace to the allowlist.
+      const abuse = await import("@atlas/api/lib/security/abuse");
+      abuse._resetAbuseState();
+      try {
+        // Drive to suspended *without* the allowlist set so the ladder
+        // actually escalates (recordQueryEvent short-circuits on
+        // allowlist membership, so order matters here).
+        delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+        const config = abuse.getAbuseConfig();
+        for (let i = 0; i <= config.queryRateLimit + 5; i++) {
+          abuse.recordQueryEvent("ws-loadtest-stale", { success: true });
+        }
+        expect(abuse.checkAbuseStatus("ws-loadtest-stale").level).toBe("suspended");
+
+        // Allowlist the workspace. The read-time guard inside
+        // `checkAbuseStatus` collapses the stored "suspended" to "none",
+        // and the chat route's `abuse.level === "suspended"` branch
+        // must therefore NOT fire.
+        process.env.ATLAS_LOADTEST_ALLOWED_ORGS = "ws-loadtest-stale";
+        mockAuthenticateRequest.mockResolvedValue({
+          authenticated: true as const,
+          mode: "managed" as const,
+          user: {
+            id: "user-loadtest",
+            mode: "managed" as const,
+            label: "loadtest@useatlas.dev",
+            role: "admin",
+            activeOrganizationId: "ws-loadtest-stale",
+            claims: { twoFactorEnabled: true },
+          },
+        });
+
+        const response = await app.fetch(makeRequest());
+        // Happy path streams 200; the only assertion that matters for
+        // the regression is "not 403". Pin both so a future refactor
+        // that returns 503 (or anything not 200) for a different reason
+        // still flags clearly.
+        expect(response.status).not.toBe(403);
+        expect(response.status).toBe(200);
+      } finally {
+        if (origAllowlist === undefined) delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+        else process.env.ATLAS_LOADTEST_ALLOWED_ORGS = origAllowlist;
+        abuse._resetAbuseState();
+      }
     });
   });
 });

--- a/packages/api/src/api/__tests__/chat.test.ts
+++ b/packages/api/src/api/__tests__/chat.test.ts
@@ -187,12 +187,9 @@ const mockCheckPlanLimits: Mock<() => Promise<PlanCheckMockResult>> = mock(
   () => Promise.resolve({ allowed: true } as PlanCheckMockResult),
 );
 
-// Residency migration check fires before the abuse gate when a request
-// carries `activeOrganizationId` (chat.ts:~510). The #2269 regression
-// test below seeds an org id; without this mock the dynamic import
-// inside `Effect.tryPromise` fails closed with a 503 and shadows the
-// abuse-gate signal. Default to "not migrating" so the abuse branch is
-// the only one that can produce a non-200 response in that test.
+// Residency precheck (chat.ts:~510) fires before the abuse gate when a
+// request carries `activeOrganizationId`. Default to "not migrating" so
+// the abuse branch is the only non-200 source in the #2269 test below.
 mock.module("@atlas/api/lib/residency/readonly", () => ({
   isWorkspaceMigrating: mock(async () => false),
 }));
@@ -1517,31 +1514,18 @@ describe("POST /api/v1/chat", () => {
     });
   });
 
-  // ---------------------------------------------------------------------
-  // #2269 — abuse-suspended workspace, lifted by the loadtest allowlist
-  //
-  // End-to-end pinning for the bug the PR fixed at the lib layer: an
-  // allowlisted workspace whose in-memory abuse state is stale-suspended
-  // must NOT 403 with `workspace_suspended`. The lib-level allowlist
-  // guard inside `checkAbuseStatus` (covered by abuse.test.ts) is what
-  // makes that work; this test asserts the chat route honors the
-  // verdict end-to-end — a future regression that re-reads `state.level`
-  // directly (bypassing the allowlist short-circuit) would fail here
-  // even though the unit-level test still passes.
-  // ---------------------------------------------------------------------
-
+  // Asserts the chat route honors the lib-level allowlist guard
+  // end-to-end. A regression that re-reads `state.level` directly
+  // (bypassing the `checkAbuseStatus` short-circuit) passes the unit
+  // test in abuse.test.ts but fails here.
   describe("#2269 — allowlisted-with-stale-suspended workspace", () => {
     it("returns non-403 when checkAbuseStatus is shadowed by the allowlist", async () => {
       const origAllowlist = process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
-      // Real abuse module — no mock.module() override at the top of this
-      // file — so we drive the in-memory ladder via the same `recordQueryEvent`
-      // entry point production uses, then add the workspace to the allowlist.
       const abuse = await import("@atlas/api/lib/security/abuse");
       abuse._resetAbuseState();
       try {
-        // Drive to suspended *without* the allowlist set so the ladder
-        // actually escalates (recordQueryEvent short-circuits on
-        // allowlist membership, so order matters here).
+        // Order matters: drive suspended BEFORE allowlisting, since
+        // recordQueryEvent short-circuits on allowlist membership.
         delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
         const config = abuse.getAbuseConfig();
         for (let i = 0; i <= config.queryRateLimit + 5; i++) {
@@ -1549,10 +1533,6 @@ describe("POST /api/v1/chat", () => {
         }
         expect(abuse.checkAbuseStatus("ws-loadtest-stale").level).toBe("suspended");
 
-        // Allowlist the workspace. The read-time guard inside
-        // `checkAbuseStatus` collapses the stored "suspended" to "none",
-        // and the chat route's `abuse.level === "suspended"` branch
-        // must therefore NOT fire.
         process.env.ATLAS_LOADTEST_ALLOWED_ORGS = "ws-loadtest-stale";
         mockAuthenticateRequest.mockResolvedValue({
           authenticated: true as const,
@@ -1568,10 +1548,9 @@ describe("POST /api/v1/chat", () => {
         });
 
         const response = await app.fetch(makeRequest());
-        // Happy path streams 200; the only assertion that matters for
-        // the regression is "not 403". Pin both so a future refactor
-        // that returns 503 (or anything not 200) for a different reason
-        // still flags clearly.
+        // Both assertions on purpose — `not.toBe(403)` is the regression
+        // guard; `.toBe(200)` keeps a refactor that returns 503 (or any
+        // non-200) for a different reason from passing vacuously.
         expect(response.status).not.toBe(403);
         expect(response.status).toBe(200);
       } finally {

--- a/packages/api/src/api/__tests__/platform-admin.test.ts
+++ b/packages/api/src/api/__tests__/platform-admin.test.ts
@@ -386,7 +386,7 @@ describe("GET /api/v1/platform/workspaces — abuseLevel surfacing", () => {
   }
 
   it("returns abuseLevel='suspended' for a workspace the abuse detector flagged, even when status='active'", async () => {
-    // The route reads `checkAbuseStatus` per row. We stub a "suspended"
+    // The route reads `checkAbuseStatus` per row. Stub a "suspended"
     // verdict for ws-dharma via `abuseStatusByWorkspace` so the test
     // mirrors a production escalation without depending on the real
     // counter/escalation machinery (covered separately in abuse.test.ts).
@@ -397,15 +397,14 @@ describe("GET /api/v1/platform/workspaces — abuseLevel surfacing", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       workspaces: Array<{ id: string; status: string; abuseLevel?: string }>;
+      abuseRestoreStatus?: string;
     };
     const lookup = Object.fromEntries(body.workspaces.map((w) => [w.id, w]));
     expect(lookup["ws-dharma"].status).toBe("active");
     expect(lookup["ws-dharma"].abuseLevel).toBe("suspended");
     expect(lookup["ws-clean"].abuseLevel).toBe("none");
+    // The route surfaces the boot-time rehydrate outcome so the page
+    // can banner when enforcement is dark. Mock returns "ok".
+    expect(body.abuseRestoreStatus).toBe("ok");
   });
-
-  // Detail-route surfacing through the same `toWorkspaceResponse`
-  // helper (the list route was refactored to call it directly, so the
-  // detail-via-helper test isn't needed any more — the list assertion
-  // above exercises the shared code path).
 });

--- a/packages/api/src/api/__tests__/platform-admin.test.ts
+++ b/packages/api/src/api/__tests__/platform-admin.test.ts
@@ -18,10 +18,11 @@ import {
   it,
   expect,
   beforeEach,
+  afterEach,
   afterAll,
 } from "bun:test";
 import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
-import { PLAN_TIERS, type PlanTier } from "@useatlas/types";
+import { PLAN_TIERS, asRatio, type PlanTier, type AbuseLevel } from "@useatlas/types";
 import { getPlanDefinition } from "@atlas/api/lib/billing/plans";
 import { createHash } from "node:crypto";
 
@@ -38,15 +39,18 @@ import { mock } from "bun:test";
 // `checkAbuseStatus` to a constant `{ level: "none" }`; that fixture is
 // fine for the existing suites but blocks the regression test for the
 // "platform-admin says active while chat is suspended" bug.
-const abuseStatusByWorkspace = new Map<string, "none" | "warning" | "throttled" | "suspended">();
+const abuseStatusByWorkspace = new Map<string, AbuseLevel>();
 mock.module("@atlas/api/lib/security/abuse", () => ({
   listFlaggedWorkspaces: mock(() => []),
   reinstateWorkspace: mock(() => "warning" as const),
   getAbuseEvents: mock(async () => ({ events: [], status: "ok" })),
+  // `asRatio` brands the threshold to match the real `getAbuseConfig`
+  // boundary — keeps this fixture in lockstep with the api-test-mocks
+  // shape so a future caller can swap between the two without a cast.
   getAbuseConfig: mock(() => ({
     queryRateLimit: 200,
     queryRateWindowSeconds: 300,
-    errorRateThreshold: 0.5,
+    errorRateThreshold: asRatio(0.5),
     uniqueTablesLimit: 50,
     throttleDelayMs: 2000,
   })),
@@ -56,6 +60,8 @@ mock.module("@atlas/api/lib/security/abuse", () => ({
   })),
   recordQueryEvent: mock(() => {}),
   restoreAbuseState: mock(async () => {}),
+  getAbuseRestoreStatus: mock(() => "ok" as const),
+  ABUSE_RESTORE_STATUSES: ["pending", "ok", "db_unavailable", "load_failed"] as const,
   _resetAbuseState: mock(() => abuseStatusByWorkspace.clear()),
   abuseCleanupTick: mock(() => {}),
   ABUSE_CLEANUP_INTERVAL_MS: 300_000,
@@ -345,6 +351,12 @@ describe("GET /api/v1/platform/workspaces — abuseLevel surfacing", () => {
     mockLogWarn.mockClear();
   });
 
+  // Clear in afterEach (not end-of-body) so a thrown assertion doesn't
+  // leak `abuseStatusByWorkspace` entries into the next test.
+  afterEach(() => {
+    abuseStatusByWorkspace.clear();
+  });
+
   function mockListWorkspaces(rows: Array<{ id: string; slug: string }>): void {
     mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
       if (sql.includes("FROM organization o")) {
@@ -390,43 +402,10 @@ describe("GET /api/v1/platform/workspaces — abuseLevel surfacing", () => {
     expect(lookup["ws-dharma"].status).toBe("active");
     expect(lookup["ws-dharma"].abuseLevel).toBe("suspended");
     expect(lookup["ws-clean"].abuseLevel).toBe("none");
-
-    abuseStatusByWorkspace.clear();
   });
 
-  // The detail route uses `toWorkspaceResponse` (the helper) while the
-  // list route inlines its own mapper. Both must agree about
-  // `abuseLevel`. Direct helper coverage rather than going through
-  // `getWorkspaceDetails` (which is module-mocked deeper than this test
-  // can reach without re-registering the whole `db/internal` mock).
-  it("toWorkspaceResponse writes abuseLevel into the detail-route shape", async () => {
-    abuseStatusByWorkspace.set("ws-helper-flagged", "throttled");
-    const { _toWorkspaceResponseForTest } = await import("../routes/platform-admin");
-    const row = {
-      id: "ws-helper-flagged",
-      name: "Flagged",
-      slug: "flagged",
-      workspace_status: "active" as const,
-      plan_tier: "starter" as const,
-      byot: false,
-      stripe_customer_id: null,
-      trial_ends_at: null,
-      suspended_at: null,
-      deleted_at: null,
-      region: "us",
-      region_assigned_at: null,
-      createdAt: "2026-01-01T00:00:00.000Z",
-    };
-    const ws = _toWorkspaceResponseForTest(row, {
-      members: 1,
-      conversations: 0,
-      queriesLast24h: 0,
-      connections: 0,
-      scheduledTasks: 0,
-    });
-    expect(ws.status).toBe("active");
-    expect(ws.abuseLevel).toBe("throttled");
-
-    abuseStatusByWorkspace.clear();
-  });
+  // Detail-route surfacing through the same `toWorkspaceResponse`
+  // helper (the list route was refactored to call it directly, so the
+  // detail-via-helper test isn't needed any more — the list assertion
+  // above exercises the shared code path).
 });

--- a/packages/api/src/api/__tests__/platform-admin.test.ts
+++ b/packages/api/src/api/__tests__/platform-admin.test.ts
@@ -32,6 +32,34 @@ const mocks = createApiTestMocks();
 // Top-level ADMIN_ACTIONS import in platform-admin.ts requires a module
 // mock before the app is imported below.
 import { mock } from "bun:test";
+// Programmable abuse status — re-register the abuse module mock so the
+// `abuseLevel` surfacing tests below can dictate per-workspace levels
+// without driving the real escalation ladder. `createApiTestMocks` pins
+// `checkAbuseStatus` to a constant `{ level: "none" }`; that fixture is
+// fine for the existing suites but blocks the regression test for the
+// "platform-admin says active while chat is suspended" bug.
+const abuseStatusByWorkspace = new Map<string, "none" | "warning" | "throttled" | "suspended">();
+mock.module("@atlas/api/lib/security/abuse", () => ({
+  listFlaggedWorkspaces: mock(() => []),
+  reinstateWorkspace: mock(() => "warning" as const),
+  getAbuseEvents: mock(async () => ({ events: [], status: "ok" })),
+  getAbuseConfig: mock(() => ({
+    queryRateLimit: 200,
+    queryRateWindowSeconds: 300,
+    errorRateThreshold: 0.5,
+    uniqueTablesLimit: 50,
+    throttleDelayMs: 2000,
+  })),
+  getAbuseDetail: mock(async () => null),
+  checkAbuseStatus: mock((workspaceId: string) => ({
+    level: abuseStatusByWorkspace.get(workspaceId) ?? "none",
+  })),
+  recordQueryEvent: mock(() => {}),
+  restoreAbuseState: mock(async () => {}),
+  _resetAbuseState: mock(() => abuseStatusByWorkspace.clear()),
+  abuseCleanupTick: mock(() => {}),
+  ABUSE_CLEANUP_INTERVAL_MS: 300_000,
+}));
 mock.module("@atlas/api/lib/audit", () => ({
   logAdminAction: mock(() => {}),
   logAdminActionAwait: mock(async () => {}),
@@ -300,5 +328,105 @@ describe("GET /api/v1/platform/workspaces — neverSuspend flag (#2249)", () => 
     } finally {
       if (original !== undefined) process.env.ATLAS_LOADTEST_ALLOWED_ORGS = original;
     }
+  });
+});
+
+// abuseLevel surfacing — workspace_status (DB column) and the in-memory
+// abuse level are independent. Before this field, a workspace that the
+// abuse detector had auto-suspended via `recordQueryEvent` would still
+// render "Active" on /admin/platform because the platform-admin route
+// only echoed `workspace_status`. Operators saw a healthy workspace
+// while chat returned `workspace_suspended` — the exact divergence this
+// suite is the regression floor for.
+describe("GET /api/v1/platform/workspaces — abuseLevel surfacing", () => {
+  beforeEach(() => {
+    mocks.setPlatformAdmin();
+    mocks.hasInternalDB = true;
+    mockLogWarn.mockClear();
+  });
+
+  function mockListWorkspaces(rows: Array<{ id: string; slug: string }>): void {
+    mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("FROM organization o")) {
+        return rows.map((r) => ({
+          id: r.id,
+          name: r.id,
+          slug: r.slug,
+          workspace_status: "active",
+          plan_tier: "starter",
+          byot: false,
+          stripe_customer_id: null,
+          trial_ends_at: null,
+          suspended_at: null,
+          deleted_at: null,
+          region: "us",
+          region_assigned_at: null,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          members: 1,
+          conversations: 0,
+          queries_last_24h: 0,
+          connections: 0,
+          scheduled_tasks: 0,
+        }));
+      }
+      return [];
+    });
+  }
+
+  it("returns abuseLevel='suspended' for a workspace the abuse detector flagged, even when status='active'", async () => {
+    // The route reads `checkAbuseStatus` per row. We stub a "suspended"
+    // verdict for ws-dharma via `abuseStatusByWorkspace` so the test
+    // mirrors a production escalation without depending on the real
+    // counter/escalation machinery (covered separately in abuse.test.ts).
+    abuseStatusByWorkspace.set("ws-dharma", "suspended");
+    mockListWorkspaces([{ id: "ws-dharma", slug: "dharma" }, { id: "ws-clean", slug: "clean" }]);
+
+    const res = await app.fetch(platformRequest("GET", "/api/v1/platform/workspaces"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      workspaces: Array<{ id: string; status: string; abuseLevel?: string }>;
+    };
+    const lookup = Object.fromEntries(body.workspaces.map((w) => [w.id, w]));
+    expect(lookup["ws-dharma"].status).toBe("active");
+    expect(lookup["ws-dharma"].abuseLevel).toBe("suspended");
+    expect(lookup["ws-clean"].abuseLevel).toBe("none");
+
+    abuseStatusByWorkspace.clear();
+  });
+
+  // The detail route uses `toWorkspaceResponse` (the helper) while the
+  // list route inlines its own mapper. Both must agree about
+  // `abuseLevel`. Direct helper coverage rather than going through
+  // `getWorkspaceDetails` (which is module-mocked deeper than this test
+  // can reach without re-registering the whole `db/internal` mock).
+  it("toWorkspaceResponse writes abuseLevel into the detail-route shape", async () => {
+    abuseStatusByWorkspace.set("ws-helper-flagged", "throttled");
+    const { _toWorkspaceResponseForTest } = await import("../routes/platform-admin");
+    const row = {
+      id: "ws-helper-flagged",
+      name: "Flagged",
+      slug: "flagged",
+      workspace_status: "active" as const,
+      plan_tier: "starter" as const,
+      byot: false,
+      stripe_customer_id: null,
+      trial_ends_at: null,
+      suspended_at: null,
+      deleted_at: null,
+      region: "us",
+      region_assigned_at: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    };
+    const ws = _toWorkspaceResponseForTest(row, {
+      members: 1,
+      conversations: 0,
+      queriesLast24h: 0,
+      connections: 0,
+      scheduledTasks: 0,
+    });
+    expect(ws.status).toBe("active");
+    expect(ws.abuseLevel).toBe("throttled");
+
+    abuseStatusByWorkspace.clear();
   });
 });

--- a/packages/api/src/api/routes/admin-orgs.ts
+++ b/packages/api/src/api/routes/admin-orgs.ts
@@ -42,12 +42,12 @@ const log = createLogger("admin-orgs");
 
 const OrgIdParamSchema = createIdParamSchema("org_abc123");
 
-// Optional + additive — older consumers omit and the UI treats missing
-// as `"none"`. Independent of `workspaceStatus` (DB column flipped by
-// admin actions); sourced from `checkAbuseStatus` so the abuse-
-// suspension divergence visible on `/admin/platform` (#2269) is visible
-// on `/admin/organizations` too.
-const AbuseLevelEnum = z.enum(ABUSE_LEVELS);
+// In-memory abuse-detector verdict from `checkAbuseStatus`. Independent
+// of `workspaceStatus` (DB column flipped by admin actions) — that
+// divergence is the bug this field exists to surface (#2269). Default
+// `"none"` consolidates the missing-field coercion at the Zod boundary
+// so consumers don't each re-derive "missing == none."
+const AbuseLevelEnum = z.enum(ABUSE_LEVELS).default("none");
 
 const OrgSummarySchema = z.object({
   id: z.string(),
@@ -61,7 +61,7 @@ const OrgSummarySchema = z.object({
   planTier: z.string(),
   suspendedAt: z.string().nullable(),
   deletedAt: z.string().nullable(),
-  abuseLevel: AbuseLevelEnum.optional(),
+  abuseLevel: AbuseLevelEnum,
 });
 
 const OrgDetailSchema = z.object({
@@ -75,7 +75,7 @@ const OrgDetailSchema = z.object({
   planTier: z.string(),
   suspendedAt: z.string().nullable(),
   deletedAt: z.string().nullable(),
-  abuseLevel: AbuseLevelEnum.optional(),
+  abuseLevel: AbuseLevelEnum,
 });
 
 const MemberSchema = z.object({

--- a/packages/api/src/api/routes/admin-orgs.ts
+++ b/packages/api/src/api/routes/admin-orgs.ts
@@ -27,6 +27,8 @@ import { invalidatePlanCache } from "@atlas/api/lib/billing/enforcement";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
+import { checkAbuseStatus } from "@atlas/api/lib/security/abuse";
+import { ABUSE_LEVELS } from "@useatlas/types";
 import { ErrorSchema, AuthErrorSchema, createIdParamSchema } from "./shared-schemas";
 import { createPlatformRouter } from "./admin-router";
 
@@ -40,6 +42,13 @@ const log = createLogger("admin-orgs");
 
 const OrgIdParamSchema = createIdParamSchema("org_abc123");
 
+// Optional + additive — older consumers omit and the UI treats missing
+// as `"none"`. Independent of `workspaceStatus` (DB column flipped by
+// admin actions); sourced from `checkAbuseStatus` so the abuse-
+// suspension divergence visible on `/admin/platform` (#2269) is visible
+// on `/admin/organizations` too.
+const AbuseLevelEnum = z.enum(ABUSE_LEVELS);
+
 const OrgSummarySchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -52,6 +61,7 @@ const OrgSummarySchema = z.object({
   planTier: z.string(),
   suspendedAt: z.string().nullable(),
   deletedAt: z.string().nullable(),
+  abuseLevel: AbuseLevelEnum.optional(),
 });
 
 const OrgDetailSchema = z.object({
@@ -65,6 +75,7 @@ const OrgDetailSchema = z.object({
   planTier: z.string(),
   suspendedAt: z.string().nullable(),
   deletedAt: z.string().nullable(),
+  abuseLevel: AbuseLevelEnum.optional(),
 });
 
 const MemberSchema = z.object({
@@ -547,6 +558,7 @@ adminOrgs.openapi(listOrgsRoute, async (c) => {
       createdAt: String(o.createdAt), memberCount: countMap.get(o.id as string) ?? 0,
       workspaceStatus: (o.workspace_status as string) ?? "active", planTier: (o.plan_tier as string) ?? "free",
       suspendedAt: o.suspended_at ? String(o.suspended_at) : null, deletedAt: o.deleted_at ? String(o.deleted_at) : null,
+      abuseLevel: checkAbuseStatus(o.id as string).level,
     }));
 
     return c.json({ organizations: result, total: result.length }, 200);
@@ -571,7 +583,7 @@ adminOrgs.openapi(getOrgRoute, async (c) => {
     ]));
 
     return c.json({
-      organization: { id: org.id as string, name: org.name as string, slug: org.slug as string, logo: (org.logo as string) ?? null, metadata: (org.metadata as Record<string, unknown>) ?? null, createdAt: String(org.createdAt), workspaceStatus: (org.workspace_status as string) ?? "active", planTier: (org.plan_tier as string) ?? "free", suspendedAt: org.suspended_at ? String(org.suspended_at) : null, deletedAt: org.deleted_at ? String(org.deleted_at) : null },
+      organization: { id: org.id as string, name: org.name as string, slug: org.slug as string, logo: (org.logo as string) ?? null, metadata: (org.metadata as Record<string, unknown>) ?? null, createdAt: String(org.createdAt), workspaceStatus: (org.workspace_status as string) ?? "active", planTier: (org.plan_tier as string) ?? "free", suspendedAt: org.suspended_at ? String(org.suspended_at) : null, deletedAt: org.deleted_at ? String(org.deleted_at) : null, abuseLevel: checkAbuseStatus(org.id as string).level },
       members: members.map((m) => ({ id: m.id as string, organizationId: m.organizationId as string, userId: m.userId as string, role: m.role as string, createdAt: String(m.createdAt), user: { id: m.userId as string, name: (m.user_name as string) ?? "", email: (m.user_email as string) ?? "", image: (m.user_image as string) ?? null } })),
       invitations: invitations.map((i) => ({ id: i.id as string, email: i.email as string, role: i.role as string, status: i.status as string, inviterId: i.inviterId as string, expiresAt: String(i.expiresAt), createdAt: String(i.createdAt) })),
     }, 200);

--- a/packages/api/src/api/routes/platform-admin.ts
+++ b/packages/api/src/api/routes/platform-admin.ts
@@ -46,7 +46,11 @@ import {
 import { getPlanDefinition } from "@atlas/api/lib/billing/plans";
 import { invalidatePlanCache } from "@atlas/api/lib/billing/enforcement";
 import { getLoadTestAllowlist } from "@atlas/api/lib/auth/load-test-allowlist";
-import { checkAbuseStatus } from "@atlas/api/lib/security/abuse";
+import {
+  ABUSE_RESTORE_STATUSES,
+  checkAbuseStatus,
+  getAbuseRestoreStatus,
+} from "@atlas/api/lib/security/abuse";
 import {
   PlatformStatsSchema,
   PlatformWorkspaceSchema,
@@ -88,7 +92,19 @@ const listWorkspacesRoute = createRoute({
   responses: {
     200: {
       description: "Workspaces list",
-      content: { "application/json": { schema: z.object({ workspaces: z.array(PlatformWorkspaceSchema) }) } },
+      content: {
+        "application/json": {
+          schema: z.object({
+            workspaces: z.array(PlatformWorkspaceSchema),
+            // Boot-time abuse rehydrate outcome. When `load_failed`, the
+            // engine started with empty in-memory state — every
+            // workspace's `abuseLevel` will render as `"none"` even
+            // though enforcement is effectively off. The web banner
+            // reads this and surfaces the divergence loudly.
+            abuseRestoreStatus: z.enum(ABUSE_RESTORE_STATUSES),
+          }),
+        },
+      },
     },
     401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
     403: { description: "Platform admin role required", content: { "application/json": { schema: AuthErrorSchema } } },
@@ -438,7 +454,7 @@ platformAdmin.openapi(listWorkspacesRoute, async (c) => {
       ),
     );
 
-    return c.json({ workspaces }, 200);
+    return c.json({ workspaces, abuseRestoreStatus: getAbuseRestoreStatus() }, 200);
   }), { label: "list workspaces" });
 });
 

--- a/packages/api/src/api/routes/platform-admin.ts
+++ b/packages/api/src/api/routes/platform-admin.ts
@@ -46,6 +46,7 @@ import {
 import { getPlanDefinition } from "@atlas/api/lib/billing/plans";
 import { invalidatePlanCache } from "@atlas/api/lib/billing/enforcement";
 import { getLoadTestAllowlist } from "@atlas/api/lib/auth/load-test-allowlist";
+import { checkAbuseStatus } from "@atlas/api/lib/security/abuse";
 import {
   PlatformStatsSchema,
   PlatformWorkspaceSchema,
@@ -280,7 +281,11 @@ const noisyNeighborsRoute = createRoute({
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Build a PlatformWorkspace from a WorkspaceRow + health counts. */
+/**
+ * Build a PlatformWorkspace from a WorkspaceRow + health counts.
+ * Re-exported as `_toWorkspaceResponseForTest` below so test suites can
+ * exercise the abuseLevel surfacing without standing up the full DB mock.
+ */
 function toWorkspaceResponse(
   row: WorkspaceRow,
   health: { members: number; conversations: number; queriesLast24h: number; connections: number; scheduledTasks: number },
@@ -307,6 +312,13 @@ function toWorkspaceResponse(
     // #2249 — surface the load-test allowlist override so the detail
     // page renders the same badge as the list view.
     neverSuspend: getLoadTestAllowlist()?.has(row.id) ?? false,
+    // Surface the in-memory abuse level so `/admin/platform` no longer
+    // shows "Active" while the chat path is blocked by
+    // `checkAbuseStatus`. `workspace_status` (the `status` field above)
+    // is the admin-mutation column — it does not reflect auto-escalation
+    // from the abuse detector. The allowlist guard inside
+    // `checkAbuseStatus` keeps never-suspend workspaces at "none" here too.
+    abuseLevel: checkAbuseStatus(row.id).level,
   };
 }
 
@@ -413,6 +425,9 @@ platformAdmin.openapi(listWorkspacesRoute, async (c) => {
       regionAssignedAt: row.region_assigned_at,
       createdAt: row.createdAt,
       neverSuspend: allowlist?.has(row.id) ?? false,
+      // Same rationale as `toWorkspaceResponse` — list view must agree
+      // with the detail panel about whether chat is blocked by abuse.
+      abuseLevel: checkAbuseStatus(row.id).level,
     }));
 
     return c.json({ workspaces }, 200);
@@ -863,3 +878,7 @@ platformAdmin.openapi(noisyNeighborsRoute, async (c) => {
 });
 
 export { platformAdmin };
+
+// Test-only re-export. Keeping it underscore-prefixed makes the
+// "do-not-import-in-prod" signal obvious at every call site.
+export { toWorkspaceResponse as _toWorkspaceResponseForTest };

--- a/packages/api/src/api/routes/platform-admin.ts
+++ b/packages/api/src/api/routes/platform-admin.ts
@@ -282,13 +282,21 @@ const noisyNeighborsRoute = createRoute({
 // ---------------------------------------------------------------------------
 
 /**
- * Build a PlatformWorkspace from a WorkspaceRow + health counts.
- * Re-exported as `_toWorkspaceResponseForTest` below so test suites can
- * exercise the abuseLevel surfacing without standing up the full DB mock.
+ * Build a PlatformWorkspace from a WorkspaceRow + health counts. Shared
+ * between the list route (where the SQL row carries health columns
+ * inline) and the detail route (where health is loaded as a follow-up
+ * Promise.all).
  */
 function toWorkspaceResponse(
   row: WorkspaceRow,
   health: { members: number; conversations: number; queriesLast24h: number; connections: number; scheduledTasks: number },
+  /**
+   * Optional pre-resolved allowlist for batch callers. The list route
+   * parses `ATLAS_LOADTEST_ALLOWED_ORGS` once per request and threads
+   * the result through every row instead of re-parsing per workspace
+   * (#2249). Detail-route callers pass `undefined` and pay the parse.
+   */
+  allowlist: ReadonlySet<string> | null = getLoadTestAllowlist(),
 ): PlatformWorkspace {
   return {
     id: row.id,
@@ -309,15 +317,11 @@ function toWorkspaceResponse(
     region: row.region,
     regionAssignedAt: row.region_assigned_at,
     createdAt: row.createdAt,
-    // #2249 — surface the load-test allowlist override so the detail
-    // page renders the same badge as the list view.
-    neverSuspend: getLoadTestAllowlist()?.has(row.id) ?? false,
-    // Surface the in-memory abuse level so `/admin/platform` no longer
-    // shows "Active" while the chat path is blocked by
-    // `checkAbuseStatus`. `workspace_status` (the `status` field above)
-    // is the admin-mutation column — it does not reflect auto-escalation
-    // from the abuse detector. The allowlist guard inside
-    // `checkAbuseStatus` keeps never-suspend workspaces at "none" here too.
+    neverSuspend: allowlist?.has(row.id) ?? false,
+    // `status` reflects the `workspace_status` DB column; `abuseLevel`
+    // is the in-memory `checkAbuseStatus` verdict. The two diverge when
+    // the detector escalates without a corresponding admin mutation —
+    // that divergence is what surfacing both here exposes.
     abuseLevel: checkAbuseStatus(row.id).level,
   };
 }
@@ -401,34 +405,38 @@ platformAdmin.openapi(listWorkspacesRoute, async (c) => {
        ORDER BY o."createdAt" DESC`,
     );
 
-    // #2249 — read the load-test allowlist once per request rather
-    // than re-parsing the env var inside the per-row map.
+    // Parse the allowlist once per request and thread it through every
+    // row — `toWorkspaceResponse` defaults to calling `getLoadTestAllowlist()`
+    // itself for the detail-route single-row case (#2249).
     const allowlist = getLoadTestAllowlist();
 
-    const workspaces = rows.map((row) => ({
-      id: row.id,
-      name: row.name,
-      slug: row.slug,
-      status: row.workspace_status,
-      planTier: row.plan_tier,
-      byot: row.byot,
-      members: row.members,
-      conversations: row.conversations,
-      queriesLast24h: row.queries_last_24h,
-      connections: row.connections,
-      scheduledTasks: row.scheduled_tasks,
-      stripeCustomerId: row.stripe_customer_id,
-      trialEndsAt: row.trial_ends_at,
-      suspendedAt: row.suspended_at,
-      deletedAt: row.deleted_at,
-      region: row.region,
-      regionAssignedAt: row.region_assigned_at,
-      createdAt: row.createdAt,
-      neverSuspend: allowlist?.has(row.id) ?? false,
-      // Same rationale as `toWorkspaceResponse` — list view must agree
-      // with the detail panel about whether chat is blocked by abuse.
-      abuseLevel: checkAbuseStatus(row.id).level,
-    }));
+    const workspaces = rows.map((row) =>
+      toWorkspaceResponse(
+        {
+          id: row.id,
+          name: row.name,
+          slug: row.slug,
+          workspace_status: row.workspace_status,
+          plan_tier: row.plan_tier,
+          byot: row.byot,
+          stripe_customer_id: row.stripe_customer_id,
+          trial_ends_at: row.trial_ends_at,
+          suspended_at: row.suspended_at,
+          deleted_at: row.deleted_at,
+          region: row.region,
+          region_assigned_at: row.region_assigned_at,
+          createdAt: row.createdAt,
+        },
+        {
+          members: row.members,
+          conversations: row.conversations,
+          queriesLast24h: row.queries_last_24h,
+          connections: row.connections,
+          scheduledTasks: row.scheduled_tasks,
+        },
+        allowlist,
+      ),
+    );
 
     return c.json({ workspaces }, 200);
   }), { label: "list workspaces" });
@@ -878,7 +886,3 @@ platformAdmin.openapi(noisyNeighborsRoute, async (c) => {
 });
 
 export { platformAdmin };
-
-// Test-only re-export. Keeping it underscore-prefixed makes the
-// "do-not-import-in-prod" signal obvious at every call site.
-export { toWorkspaceResponse as _toWorkspaceResponseForTest };

--- a/packages/api/src/lib/security/__tests__/abuse.test.ts
+++ b/packages/api/src/lib/security/__tests__/abuse.test.ts
@@ -91,6 +91,7 @@ const {
   getAbuseEvents,
   getAbuseDetail,
   restoreAbuseState,
+  getAbuseRestoreStatus,
   _resetAbuseState,
 } = await import("../abuse");
 
@@ -225,6 +226,10 @@ describe("Abuse Prevention Engine", () => {
     // would keep reading the stale `suspended` level forever.
     it("checkAbuseStatus returns 'none' for allowlisted workspaces even with stale suspended state", () => {
       const original = process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+      // Defensive — a prior test that forgot to restore the env could
+      // short-circuit the suspension setup below via `recordQueryEvent`'s
+      // allowlist guard, masking a regression as "still works."
+      delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
       // Drive the workspace to suspended *without* the allowlist set.
       const config = getAbuseConfig();
       for (let i = 0; i <= config.queryRateLimit + 5; i++) {
@@ -236,9 +241,43 @@ describe("Abuse Prevention Engine", () => {
       process.env.ATLAS_LOADTEST_ALLOWED_ORGS = "ws-late-allowlist";
       try {
         expect(checkAbuseStatus("ws-late-allowlist").level).toBe("none");
-        // Throttled state would also be reported as `none` — same code path,
-        // but worth a quick sanity check that no `throttleDelayMs` leaks out.
+        // No throttle delay leaks out when the underlying state was
+        // suspended (would be nonsensical) — covered separately for
+        // the throttled branch below.
         expect(checkAbuseStatus("ws-late-allowlist").throttleDelayMs).toBeUndefined();
+      } finally {
+        if (original === undefined) delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+        else process.env.ATLAS_LOADTEST_ALLOWED_ORGS = original;
+      }
+    });
+
+    // Companion test: the throttled branch of `checkAbuseStatus` constructs a
+    // `throttleDelayMs` field that the suspended branch never builds. The
+    // prior `.throttleDelayMs).toBeUndefined()` assertion was tautological
+    // because the seed state was suspended. Pin the throttled-branch
+    // behavior explicitly so a refactor that drops the allowlist guard from
+    // the `throttled` arm doesn't silently leak the delay.
+    it("checkAbuseStatus returns 'none' (no throttleDelayMs) for an allowlisted-with-throttled workspace", () => {
+      const original = process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+      delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+      const config = getAbuseConfig();
+      // Drive through warning → throttled but stop short of suspended.
+      // Each call over the limit bumps escalations; the ladder hits
+      // throttled at the second escalation.
+      for (let i = 0; i <= config.queryRateLimit + 1; i++) {
+        recordQueryEvent("ws-throttle-allowlist", { success: true });
+      }
+      // Seed state should be throttled, not suspended.
+      expect(checkAbuseStatus("ws-throttle-allowlist").level).toBe("throttled");
+      expect(checkAbuseStatus("ws-throttle-allowlist").throttleDelayMs).toBe(
+        config.throttleDelayMs,
+      );
+
+      process.env.ATLAS_LOADTEST_ALLOWED_ORGS = "ws-throttle-allowlist";
+      try {
+        const status = checkAbuseStatus("ws-throttle-allowlist");
+        expect(status.level).toBe("none");
+        expect(status.throttleDelayMs).toBeUndefined();
       } finally {
         if (original === undefined) delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
         else process.env.ATLAS_LOADTEST_ALLOWED_ORGS = original;
@@ -273,16 +312,45 @@ describe("Abuse Prevention Engine", () => {
         await restoreAbuseState();
         expect(checkAbuseStatus("ws-rehydrate-skip").level).toBe("none");
         expect(checkAbuseStatus("ws-rehydrate-keep").level).toBe("suspended");
-        // Restore log includes the allowlistSkipped count so operators can
-        // see the churn without grepping for per-row warnings.
+        // Restore log includes both counts and the offending IDs so
+        // operators can recover from an env-var typo with logs alone
+        // (over-skip via a bare count is unrecoverable). Asserting
+        // both `restored` and `allowlistSkipped` together catches the
+        // symmetric regression: an over-skip would inflate
+        // `allowlistSkipped`, an under-skip would inflate `restored`.
         const restoreLog = infoCalls.find((c) =>
           c.msg.includes("Restored abuse state"),
         );
+        expect(restoreLog?.ctx.count).toBe(1);
         expect(restoreLog?.ctx.allowlistSkipped).toBe(1);
+        expect(restoreLog?.ctx.allowlistSkippedIds).toEqual(["ws-rehydrate-skip"]);
       } finally {
         if (original === undefined) delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
         else process.env.ATLAS_LOADTEST_ALLOWED_ORGS = original;
       }
+    });
+
+    // Companion to the rehydrate-skip test: the restore status getter
+    // surfaces the boot outcome so the platform-admin page can warn
+    // when in-memory state is empty because rehydration *failed*, not
+    // because the workspace is genuinely clean.
+    it("getAbuseRestoreStatus reports the last restoreAbuseState outcome", async () => {
+      expect(getAbuseRestoreStatus()).toBe("pending");
+
+      setInternalDB(true);
+      setInternalQuery(async () => []);
+      await restoreAbuseState();
+      expect(getAbuseRestoreStatus()).toBe("ok");
+
+      setInternalQuery(async () => {
+        throw new Error("simulated DB outage");
+      });
+      await restoreAbuseState();
+      expect(getAbuseRestoreStatus()).toBe("load_failed");
+
+      setInternalDB(false);
+      await restoreAbuseState();
+      expect(getAbuseRestoreStatus()).toBe("db_unavailable");
     });
 
     it("isLoadTestWorkspace reflects env-var changes without restart", () => {
@@ -393,6 +461,29 @@ describe("Abuse Prevention Engine", () => {
     it("excludes workspaces with level none", () => {
       recordQueryEvent("ws-ok", { success: true });
       expect(listFlaggedWorkspaces()).toEqual([]);
+    });
+
+    // Mirrors `checkAbuseStatus`'s read-time allowlist guard — without
+    // this filter, the abuse console keeps showing an allowlisted-
+    // suspended workspace forever even though every other read path
+    // (chat gate, platform-admin abuseLevel, etc.) reports it as none.
+    // A reinstate click on such a row would be a no-op.
+    it("filters out allowlisted workspaces even when in-memory state is non-none", () => {
+      const original = process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+      delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+      const config = getAbuseConfig();
+      for (let i = 0; i <= config.queryRateLimit; i++) {
+        recordQueryEvent("ws-late-allow", { success: true });
+      }
+      expect(checkAbuseStatus("ws-late-allow").level).toBe("warning");
+
+      process.env.ATLAS_LOADTEST_ALLOWED_ORGS = "ws-late-allow";
+      try {
+        expect(listFlaggedWorkspaces()).toEqual([]);
+      } finally {
+        if (original === undefined) delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+        else process.env.ATLAS_LOADTEST_ALLOWED_ORGS = original;
+      }
     });
   });
 

--- a/packages/api/src/lib/security/__tests__/abuse.test.ts
+++ b/packages/api/src/lib/security/__tests__/abuse.test.ts
@@ -217,6 +217,74 @@ describe("Abuse Prevention Engine", () => {
       }
     });
 
+    // Regression for the platform-admin "looks fine while chat is blocked"
+    // bug — a workspace that escalated to suspended *before* it was added
+    // to ATLAS_LOADTEST_ALLOWED_ORGS must report `none` once allowlisted,
+    // even though the in-memory state still says `suspended`. Without this
+    // guard, `recordQueryEvent` would skip new events but the chat path
+    // would keep reading the stale `suspended` level forever.
+    it("checkAbuseStatus returns 'none' for allowlisted workspaces even with stale suspended state", () => {
+      const original = process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+      // Drive the workspace to suspended *without* the allowlist set.
+      const config = getAbuseConfig();
+      for (let i = 0; i <= config.queryRateLimit + 5; i++) {
+        recordQueryEvent("ws-late-allowlist", { success: true });
+      }
+      expect(checkAbuseStatus("ws-late-allowlist").level).toBe("suspended");
+
+      // Now add to the allowlist — read-time guard must lift the suspension.
+      process.env.ATLAS_LOADTEST_ALLOWED_ORGS = "ws-late-allowlist";
+      try {
+        expect(checkAbuseStatus("ws-late-allowlist").level).toBe("none");
+        // Throttled state would also be reported as `none` — same code path,
+        // but worth a quick sanity check that no `throttleDelayMs` leaks out.
+        expect(checkAbuseStatus("ws-late-allowlist").throttleDelayMs).toBeUndefined();
+      } finally {
+        if (original === undefined) delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+        else process.env.ATLAS_LOADTEST_ALLOWED_ORGS = original;
+      }
+    });
+
+    // Companion to the read-time guard above: a fresh process restarting
+    // with persisted `abuse_events` rows for an allowlisted workspace must
+    // skip rehydration. Otherwise a later `delete ATLAS_LOADTEST_ALLOWED_ORGS`
+    // would snap the workspace back to suspended without any new escalation.
+    it("restoreAbuseState skips workspaces in the allowlist", async () => {
+      const original = process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+      process.env.ATLAS_LOADTEST_ALLOWED_ORGS = "ws-rehydrate-skip";
+      setInternalDB(true);
+      setInternalQuery(async () => [
+        {
+          workspace_id: "ws-rehydrate-skip",
+          level: "suspended",
+          trigger_type: "query_rate",
+          message: "old suspension",
+          created_at: "2026-04-01T00:00:00Z",
+        },
+        {
+          workspace_id: "ws-rehydrate-keep",
+          level: "suspended",
+          trigger_type: "query_rate",
+          message: "should still rehydrate",
+          created_at: "2026-04-01T00:00:00Z",
+        },
+      ]);
+      try {
+        await restoreAbuseState();
+        expect(checkAbuseStatus("ws-rehydrate-skip").level).toBe("none");
+        expect(checkAbuseStatus("ws-rehydrate-keep").level).toBe("suspended");
+        // Restore log includes the allowlistSkipped count so operators can
+        // see the churn without grepping for per-row warnings.
+        const restoreLog = infoCalls.find((c) =>
+          c.msg.includes("Restored abuse state"),
+        );
+        expect(restoreLog?.ctx.allowlistSkipped).toBe(1);
+      } finally {
+        if (original === undefined) delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+        else process.env.ATLAS_LOADTEST_ALLOWED_ORGS = original;
+      }
+    });
+
     it("isLoadTestWorkspace reflects env-var changes without restart", () => {
       const original = process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
       try {

--- a/packages/api/src/lib/security/__tests__/abuse.test.ts
+++ b/packages/api/src/lib/security/__tests__/abuse.test.ts
@@ -226,24 +226,21 @@ describe("Abuse Prevention Engine", () => {
     // would keep reading the stale `suspended` level forever.
     it("checkAbuseStatus returns 'none' for allowlisted workspaces even with stale suspended state", () => {
       const original = process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
-      // Defensive — a prior test that forgot to restore the env could
-      // short-circuit the suspension setup below via `recordQueryEvent`'s
-      // allowlist guard, masking a regression as "still works."
-      delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
-      // Drive the workspace to suspended *without* the allowlist set.
-      const config = getAbuseConfig();
-      for (let i = 0; i <= config.queryRateLimit + 5; i++) {
-        recordQueryEvent("ws-late-allowlist", { success: true });
-      }
-      expect(checkAbuseStatus("ws-late-allowlist").level).toBe("suspended");
-
-      // Now add to the allowlist — read-time guard must lift the suspension.
-      process.env.ATLAS_LOADTEST_ALLOWED_ORGS = "ws-late-allowlist";
       try {
+        // Defensive — a prior test that forgot to restore the env could
+        // short-circuit the suspension setup below via `recordQueryEvent`'s
+        // allowlist guard, masking a regression as "still works."
+        delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+        // Drive the workspace to suspended *without* the allowlist set.
+        const config = getAbuseConfig();
+        for (let i = 0; i <= config.queryRateLimit + 5; i++) {
+          recordQueryEvent("ws-late-allowlist", { success: true });
+        }
+        expect(checkAbuseStatus("ws-late-allowlist").level).toBe("suspended");
+
+        // Now add to the allowlist — read-time guard must lift the suspension.
+        process.env.ATLAS_LOADTEST_ALLOWED_ORGS = "ws-late-allowlist";
         expect(checkAbuseStatus("ws-late-allowlist").level).toBe("none");
-        // No throttle delay leaks out when the underlying state was
-        // suspended (would be nonsensical) — covered separately for
-        // the throttled branch below.
         expect(checkAbuseStatus("ws-late-allowlist").throttleDelayMs).toBeUndefined();
       } finally {
         if (original === undefined) delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
@@ -251,30 +248,29 @@ describe("Abuse Prevention Engine", () => {
       }
     });
 
-    // Companion test: the throttled branch of `checkAbuseStatus` constructs a
-    // `throttleDelayMs` field that the suspended branch never builds. The
-    // prior `.throttleDelayMs).toBeUndefined()` assertion was tautological
-    // because the seed state was suspended. Pin the throttled-branch
-    // behavior explicitly so a refactor that drops the allowlist guard from
-    // the `throttled` arm doesn't silently leak the delay.
+    // Companion: pins the throttled-branch path that the suspended-seed
+    // test above couldn't reach. `checkAbuseStatus`'s throttled arm
+    // constructs `throttleDelayMs`; the suspended arm never builds it.
+    // A refactor that drops the allowlist guard from the `throttled`
+    // arm would leak the delay value here.
     it("checkAbuseStatus returns 'none' (no throttleDelayMs) for an allowlisted-with-throttled workspace", () => {
       const original = process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
-      delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
-      const config = getAbuseConfig();
-      // Drive through warning → throttled but stop short of suspended.
-      // Each call over the limit bumps escalations; the ladder hits
-      // throttled at the second escalation.
-      for (let i = 0; i <= config.queryRateLimit + 1; i++) {
-        recordQueryEvent("ws-throttle-allowlist", { success: true });
-      }
-      // Seed state should be throttled, not suspended.
-      expect(checkAbuseStatus("ws-throttle-allowlist").level).toBe("throttled");
-      expect(checkAbuseStatus("ws-throttle-allowlist").throttleDelayMs).toBe(
-        config.throttleDelayMs,
-      );
-
-      process.env.ATLAS_LOADTEST_ALLOWED_ORGS = "ws-throttle-allowlist";
       try {
+        delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+        const config = getAbuseConfig();
+        // Drive through warning → throttled but stop short of suspended.
+        // Each call over the limit bumps escalations; the ladder hits
+        // throttled at the second escalation.
+        for (let i = 0; i <= config.queryRateLimit + 1; i++) {
+          recordQueryEvent("ws-throttle-allowlist", { success: true });
+        }
+        // Seed state should be throttled, not suspended.
+        expect(checkAbuseStatus("ws-throttle-allowlist").level).toBe("throttled");
+        expect(checkAbuseStatus("ws-throttle-allowlist").throttleDelayMs).toBe(
+          config.throttleDelayMs,
+        );
+
+        process.env.ATLAS_LOADTEST_ALLOWED_ORGS = "ws-throttle-allowlist";
         const status = checkAbuseStatus("ws-throttle-allowlist");
         expect(status.level).toBe("none");
         expect(status.throttleDelayMs).toBeUndefined();
@@ -290,14 +286,26 @@ describe("Abuse Prevention Engine", () => {
     // would snap the workspace back to suspended without any new escalation.
     it("restoreAbuseState skips workspaces in the allowlist", async () => {
       const original = process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
-      process.env.ATLAS_LOADTEST_ALLOWED_ORGS = "ws-rehydrate-skip";
+      // Two allowlisted IDs so the `allowlistSkippedIds` assertion
+      // distinguishes "pinned contents" from "pinned length" — a
+      // regression that pushed `row.workspace_id` once per loop
+      // iteration or a constant value would pass with a single-row
+      // seed.
+      process.env.ATLAS_LOADTEST_ALLOWED_ORGS = "ws-rehydrate-skip-a,ws-rehydrate-skip-b";
       setInternalDB(true);
       setInternalQuery(async () => [
         {
-          workspace_id: "ws-rehydrate-skip",
+          workspace_id: "ws-rehydrate-skip-a",
           level: "suspended",
           trigger_type: "query_rate",
-          message: "old suspension",
+          message: "old suspension a",
+          created_at: "2026-04-01T00:00:00Z",
+        },
+        {
+          workspace_id: "ws-rehydrate-skip-b",
+          level: "throttled",
+          trigger_type: "query_rate",
+          message: "old throttle b",
           created_at: "2026-04-01T00:00:00Z",
         },
         {
@@ -310,7 +318,8 @@ describe("Abuse Prevention Engine", () => {
       ]);
       try {
         await restoreAbuseState();
-        expect(checkAbuseStatus("ws-rehydrate-skip").level).toBe("none");
+        expect(checkAbuseStatus("ws-rehydrate-skip-a").level).toBe("none");
+        expect(checkAbuseStatus("ws-rehydrate-skip-b").level).toBe("none");
         expect(checkAbuseStatus("ws-rehydrate-keep").level).toBe("suspended");
         // Restore log includes both counts and the offending IDs so
         // operators can recover from an env-var typo with logs alone
@@ -321,9 +330,15 @@ describe("Abuse Prevention Engine", () => {
         const restoreLog = infoCalls.find((c) =>
           c.msg.includes("Restored abuse state"),
         );
+        expect(restoreLog).toBeDefined();
         expect(restoreLog?.ctx.count).toBe(1);
-        expect(restoreLog?.ctx.allowlistSkipped).toBe(1);
-        expect(restoreLog?.ctx.allowlistSkippedIds).toEqual(["ws-rehydrate-skip"]);
+        expect(restoreLog?.ctx.allowlistSkipped).toBe(2);
+        // Order follows `internalQuery` row order — the rehydrate
+        // loop pushes IDs in iteration order, not lexicographic.
+        expect(restoreLog?.ctx.allowlistSkippedIds).toEqual([
+          "ws-rehydrate-skip-a",
+          "ws-rehydrate-skip-b",
+        ]);
       } finally {
         if (original === undefined) delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
         else process.env.ATLAS_LOADTEST_ALLOWED_ORGS = original;
@@ -470,16 +485,26 @@ describe("Abuse Prevention Engine", () => {
     // A reinstate click on such a row would be a no-op.
     it("filters out allowlisted workspaces even when in-memory state is non-none", () => {
       const original = process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
-      delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
-      const config = getAbuseConfig();
-      for (let i = 0; i <= config.queryRateLimit; i++) {
-        recordQueryEvent("ws-late-allow", { success: true });
-      }
-      expect(checkAbuseStatus("ws-late-allow").level).toBe("warning");
-
-      process.env.ATLAS_LOADTEST_ALLOWED_ORGS = "ws-late-allow";
       try {
+        delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+        const config = getAbuseConfig();
+        for (let i = 0; i <= config.queryRateLimit; i++) {
+          recordQueryEvent("ws-late-allow", { success: true });
+        }
+        expect(checkAbuseStatus("ws-late-allow").level).toBe("warning");
+
+        process.env.ATLAS_LOADTEST_ALLOWED_ORGS = "ws-late-allow";
         expect(listFlaggedWorkspaces()).toEqual([]);
+
+        // Pin the underlying state is *filtered*, not *deleted* — a
+        // future refactor that drops the in-memory entry would also
+        // pass the `toEqual([])` check but break the "remove from
+        // allowlist → snap back to warning" semantic the rest of the
+        // suite relies on. Clearing the env restores the read-time
+        // view of the preserved state.
+        delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
+        expect(checkAbuseStatus("ws-late-allow").level).toBe("warning");
+        expect(listFlaggedWorkspaces()).toHaveLength(1);
       } finally {
         if (original === undefined) delete process.env.ATLAS_LOADTEST_ALLOWED_ORGS;
         else process.env.ATLAS_LOADTEST_ALLOWED_ORGS = original;

--- a/packages/api/src/lib/security/abuse.ts
+++ b/packages/api/src/lib/security/abuse.ts
@@ -153,10 +153,42 @@ const workspaceState = new Map<string, WorkspaceAbuseState>();
  */
 const warnedLoadTestSkip = new Set<string>();
 
+/**
+ * Outcome of the last `restoreAbuseState` boot call. Surfaced to the
+ * platform-admin response so an operator who's looking at a workspace
+ * that confidently renders `abuseLevel: "none"` can tell the difference
+ * between "actually clean" and "rehydration failed — in-memory state
+ * never got loaded, enforcement is effectively off." Mirrors the
+ * `AbuseEventsStatus` pattern (#1682) for the detail panel's events
+ * payload — same three-state status surface, same UI affordance.
+ *
+ *   - `pending`        — `restoreAbuseState` has not run yet (boot
+ *                        in progress, or no `DATABASE_URL`).
+ *   - `ok`             — last run completed; in-memory state matches DB.
+ *   - `db_unavailable` — `hasInternalDB()` returned false; no rehydrate
+ *                        was attempted. Expected for self-hosted deploys.
+ *   - `load_failed`    — the SQL read threw and the engine started with
+ *                        empty state. UI must show a destructive banner.
+ */
+export const ABUSE_RESTORE_STATUSES = [
+  "pending",
+  "ok",
+  "db_unavailable",
+  "load_failed",
+] as const;
+export type AbuseRestoreStatus = (typeof ABUSE_RESTORE_STATUSES)[number];
+let _restoreStatus: AbuseRestoreStatus = "pending";
+
+/** Read the last `restoreAbuseState` outcome. */
+export function getAbuseRestoreStatus(): AbuseRestoreStatus {
+  return _restoreStatus;
+}
+
 /** Reset all in-memory state. For tests. */
 export function _resetAbuseState(): void {
   workspaceState.clear();
   warnedLoadTestSkip.clear();
+  _restoreStatus = "pending";
 }
 
 /** Get or create workspace state. */
@@ -374,11 +406,23 @@ export function checkAbuseStatus(workspaceId: string): {
 // Admin operations
 // ---------------------------------------------------------------------------
 
-/** List all workspaces with non-"none" abuse levels. */
+/**
+ * List all workspaces with non-"none" abuse levels.
+ *
+ * Filters out allowlisted workspaces (`ATLAS_LOADTEST_ALLOWED_ORGS`) so
+ * the abuse console doesn't render stale-suspended rows for workspaces
+ * that every other read path (`checkAbuseStatus`, the platform-admin
+ * `abuseLevel` surface, the chat-route gate) reports as `none`. Without
+ * this filter, an admin would see a "suspended" workspace in the abuse
+ * list, click reinstate, and get back a noop — the in-memory state stays
+ * suspended but is shadowed by the allowlist guard, so the read & write
+ * paths diverge.
+ */
 export function listFlaggedWorkspaces(): AbuseStatus[] {
   const results: AbuseStatus[] = [];
   for (const [workspaceId, state] of workspaceState) {
     if (state.level === "none") continue;
+    if (isLoadTestWorkspace(workspaceId)) continue;
     results.push({
       workspaceId,
       workspaceName: null, // Resolved by the admin route
@@ -643,7 +687,10 @@ export async function getAbuseEvents(
 
 /** Restore in-memory state from DB on startup. */
 export async function restoreAbuseState(): Promise<void> {
-  if (!hasInternalDB()) return;
+  if (!hasInternalDB()) {
+    _restoreStatus = "db_unavailable";
+    return;
+  }
 
   try {
     // Get the latest event per workspace to restore current level
@@ -660,7 +707,7 @@ export async function restoreAbuseState(): Promise<void> {
     );
 
     let driftSkipped = 0;
-    let allowlistSkipped = 0;
+    const allowlistSkippedIds: string[] = [];
     for (const row of rows) {
       const { level, trigger, levelDrifted } = coerceAbuseEnums(
         row.workspace_id,
@@ -676,14 +723,18 @@ export async function restoreAbuseState(): Promise<void> {
         continue;
       }
       if (level === "none") continue; // Already reinstated
-      // Never rehydrate a suspension/throttle/warning for an allowlisted
-      // workspace — `checkAbuseStatus` would short-circuit it to "none"
-      // anyway, but leaving the in-memory ladder primed means the moment
-      // the workspace is removed from `ATLAS_LOADTEST_ALLOWED_ORGS` it
-      // would snap back to suspended without any new escalation. Count
-      // skips so operators can see the historical-state churn.
+      // Never rehydrate a non-"none" level for an allowlisted workspace.
+      // The skip is gated by *current* env-var membership: if the
+      // workspace later leaves `ATLAS_LOADTEST_ALLOWED_ORGS` and the
+      // process restarts, the next `restoreAbuseState` call will see the
+      // same row, find no allowlist match, and rehydrate it. State isn't
+      // dropped at the DB layer — only kept out of memory while
+      // allowlisted. Same read-time guard inside `checkAbuseStatus`
+      // shadows the in-memory ladder when the env var is set, so an
+      // operator removing a workspace from the allowlist *without*
+      // restarting still sees "Active" until the next escalation.
       if (isLoadTestWorkspace(row.workspace_id)) {
-        allowlistSkipped++;
+        allowlistSkippedIds.push(row.workspace_id);
         continue;
       }
 
@@ -697,16 +748,23 @@ export async function restoreAbuseState(): Promise<void> {
     }
 
     const restored = [...workspaceState.values()].filter((s) => s.level !== "none").length;
+    const allowlistSkipped = allowlistSkippedIds.length;
     if (restored > 0 || driftSkipped > 0 || allowlistSkipped > 0) {
       log.info(
-        { count: restored, driftSkipped, allowlistSkipped },
+        // IDs included so an operator who set `ATLAS_LOADTEST_ALLOWED_ORGS`
+        // to the wrong workspace ID can recover from logs alone — a
+        // bare count like `allowlistSkipped: 17` doesn't tell you
+        // *which* 17 got shadowed by an env-var typo.
+        { count: restored, driftSkipped, allowlistSkipped, allowlistSkippedIds },
         "Restored abuse state for %d workspaces (%d skipped due to enum drift, %d skipped via allowlist)",
         restored,
         driftSkipped,
         allowlistSkipped,
       );
     }
+    _restoreStatus = "ok";
   } catch (err) {
+    _restoreStatus = "load_failed";
     log.warn(
       { err: err instanceof Error ? err.message : String(err) },
       "Failed to restore abuse state from DB — starting with empty state",

--- a/packages/api/src/lib/security/abuse.ts
+++ b/packages/api/src/lib/security/abuse.ts
@@ -19,7 +19,6 @@ import { isLoadTestWorkspace } from "@atlas/api/lib/auth/load-test-allowlist";
 import {
   ABUSE_LEVELS,
   ABUSE_TRIGGERS,
-  ABUSE_RESTORE_STATUSES,
   asRatio,
   type AbuseLevel,
   type AbuseRestoreStatus,
@@ -31,11 +30,18 @@ import {
   type AbuseDetail,
 } from "@useatlas/types";
 
-// Re-export so existing `@atlas/api/lib/security/abuse` consumers keep
-// the same import surface — the tuple/type just moved to the shared
-// types package so the web bundle can use them too (admin-schemas.ts
-// needs the same enum for runtime validation).
-export { ABUSE_RESTORE_STATUSES, type AbuseRestoreStatus };
+// Local literal tuple, not imported from `@useatlas/types`'s value
+// export — the scaffold template builds against the registry copy,
+// and a fresh value export there breaks scaffold CI until the next
+// types publish (see #useatlas/types-scaffold-gotcha). `satisfies`
+// pins this to the canonical union so a drift fails compile.
+export const ABUSE_RESTORE_STATUSES = [
+  "pending",
+  "ok",
+  "db_unavailable",
+  "load_failed",
+] as const satisfies readonly AbuseRestoreStatus[];
+export type { AbuseRestoreStatus };
 
 /**
  * A non-`"none"` abuse level — exactly the states a reinstate can lift

--- a/packages/api/src/lib/security/abuse.ts
+++ b/packages/api/src/lib/security/abuse.ts
@@ -19,8 +19,10 @@ import { isLoadTestWorkspace } from "@atlas/api/lib/auth/load-test-allowlist";
 import {
   ABUSE_LEVELS,
   ABUSE_TRIGGERS,
+  ABUSE_RESTORE_STATUSES,
   asRatio,
   type AbuseLevel,
+  type AbuseRestoreStatus,
   type AbuseTrigger,
   type AbuseEvent,
   type AbuseEventsStatus,
@@ -28,6 +30,12 @@ import {
   type AbuseThresholdConfig,
   type AbuseDetail,
 } from "@useatlas/types";
+
+// Re-export so existing `@atlas/api/lib/security/abuse` consumers keep
+// the same import surface — the tuple/type just moved to the shared
+// types package so the web bundle can use them too (admin-schemas.ts
+// needs the same enum for runtime validation).
+export { ABUSE_RESTORE_STATUSES, type AbuseRestoreStatus };
 
 /**
  * A non-`"none"` abuse level — exactly the states a reinstate can lift
@@ -153,30 +161,12 @@ const workspaceState = new Map<string, WorkspaceAbuseState>();
  */
 const warnedLoadTestSkip = new Set<string>();
 
-/**
- * Outcome of the last `restoreAbuseState` boot call. Surfaced to the
- * platform-admin response so an operator who's looking at a workspace
- * that confidently renders `abuseLevel: "none"` can tell the difference
- * between "actually clean" and "rehydration failed — in-memory state
- * never got loaded, enforcement is effectively off." Mirrors the
- * `AbuseEventsStatus` pattern (#1682) for the detail panel's events
- * payload — same three-state status surface, same UI affordance.
- *
- *   - `pending`        — `restoreAbuseState` has not run yet (boot
- *                        in progress, or no `DATABASE_URL`).
- *   - `ok`             — last run completed; in-memory state matches DB.
- *   - `db_unavailable` — `hasInternalDB()` returned false; no rehydrate
- *                        was attempted. Expected for self-hosted deploys.
- *   - `load_failed`    — the SQL read threw and the engine started with
- *                        empty state. UI must show a destructive banner.
- */
-export const ABUSE_RESTORE_STATUSES = [
-  "pending",
-  "ok",
-  "db_unavailable",
-  "load_failed",
-] as const;
-export type AbuseRestoreStatus = (typeof ABUSE_RESTORE_STATUSES)[number];
+// `AbuseRestoreStatus` doc lives in @useatlas/types/abuse.ts (the wire
+// boundary). Single-process: `_restoreStatus` reflects the boot
+// outcome of *this* Node process. Atlas's deployment model is
+// long-lived API processes (Railway/Docker), so this is the right
+// granularity. A multi-replica deploy that splits state across
+// isolates would need a per-replica surface; not a current concern.
 let _restoreStatus: AbuseRestoreStatus = "pending";
 
 /** Read the last `restoreAbuseState` outcome. */
@@ -764,8 +754,19 @@ export async function restoreAbuseState(): Promise<void> {
     }
     _restoreStatus = "ok";
   } catch (err) {
+    // Clear any partial state — if the SQL read threw mid-iteration we
+    // would otherwise leave a polluted in-memory map (some workspaces
+    // rehydrated, the rest missing) under a `load_failed` status that
+    // implies "engine started with empty state." Restoring the
+    // invariant here means `load_failed` is honest.
+    workspaceState.clear();
     _restoreStatus = "load_failed";
-    log.warn(
+    // `log.error` (not `warn`) — a boot-time enforcement-state loss is
+    // compliance-significant: every `checkAbuseStatus` will return
+    // `"none"` until either the next escalation lands a new in-memory
+    // row, or the next boot succeeds. Mirrors the `persistAbuseEvent`
+    // catch which is `log.error` for the same audit-trail reason.
+    log.error(
       { err: err instanceof Error ? err.message : String(err) },
       "Failed to restore abuse state from DB — starting with empty state",
     );

--- a/packages/api/src/lib/security/abuse.ts
+++ b/packages/api/src/lib/security/abuse.ts
@@ -343,11 +343,20 @@ function escalate(
 /**
  * Check the current abuse level for a workspace.
  * Returns the current level and throttle delay if applicable.
+ *
+ * Allowlisted workspaces (`ATLAS_LOADTEST_ALLOWED_ORGS`) always report
+ * `level: "none"` regardless of stored state. `recordQueryEvent` already
+ * short-circuits for these workspaces, but pre-allowlist suspensions
+ * (in-memory or rehydrated from `abuse_events`) would otherwise keep
+ * blocking chat/query indefinitely — the never-suspend semantics need to
+ * apply at *read* time too, not just at escalation time.
  */
 export function checkAbuseStatus(workspaceId: string): {
   level: AbuseLevel;
   throttleDelayMs?: number;
 } {
+  if (isLoadTestWorkspace(workspaceId)) return { level: "none" };
+
   const state = workspaceState.get(workspaceId);
   if (!state || state.level === "none" || state.level === "warning") {
     return { level: state?.level ?? "none" };
@@ -651,6 +660,7 @@ export async function restoreAbuseState(): Promise<void> {
     );
 
     let driftSkipped = 0;
+    let allowlistSkipped = 0;
     for (const row of rows) {
       const { level, trigger, levelDrifted } = coerceAbuseEnums(
         row.workspace_id,
@@ -666,6 +676,16 @@ export async function restoreAbuseState(): Promise<void> {
         continue;
       }
       if (level === "none") continue; // Already reinstated
+      // Never rehydrate a suspension/throttle/warning for an allowlisted
+      // workspace — `checkAbuseStatus` would short-circuit it to "none"
+      // anyway, but leaving the in-memory ladder primed means the moment
+      // the workspace is removed from `ATLAS_LOADTEST_ALLOWED_ORGS` it
+      // would snap back to suspended without any new escalation. Count
+      // skips so operators can see the historical-state churn.
+      if (isLoadTestWorkspace(row.workspace_id)) {
+        allowlistSkipped++;
+        continue;
+      }
 
       const state = getState(row.workspace_id);
       state.level = level;
@@ -677,12 +697,13 @@ export async function restoreAbuseState(): Promise<void> {
     }
 
     const restored = [...workspaceState.values()].filter((s) => s.level !== "none").length;
-    if (restored > 0 || driftSkipped > 0) {
+    if (restored > 0 || driftSkipped > 0 || allowlistSkipped > 0) {
       log.info(
-        { count: restored, driftSkipped },
-        "Restored abuse state for %d workspaces (%d skipped due to enum drift)",
+        { count: restored, driftSkipped, allowlistSkipped },
+        "Restored abuse state for %d workspaces (%d skipped due to enum drift, %d skipped via allowlist)",
         restored,
         driftSkipped,
+        allowlistSkipped,
       );
     }
   } catch (err) {

--- a/packages/schemas/src/platform.ts
+++ b/packages/schemas/src/platform.ts
@@ -31,6 +31,7 @@ import {
   PLAN_TIERS,
   NOISY_NEIGHBOR_METRICS,
   ATLAS_ROLES,
+  ABUSE_LEVELS,
   type PlatformStats,
   type PlatformWorkspace,
   type PlatformWorkspaceUser,
@@ -41,6 +42,7 @@ const WorkspaceStatusEnum = z.enum(WORKSPACE_STATUSES);
 const PlanTierEnum = z.enum(PLAN_TIERS);
 const NoisyMetricEnum = z.enum(NOISY_NEIGHBOR_METRICS);
 const AtlasRoleEnum = z.enum(ATLAS_ROLES);
+const AbuseLevelEnum = z.enum(ABUSE_LEVELS);
 
 export const PlatformStatsSchema = z.object({
   totalWorkspaces: z.number(),
@@ -73,6 +75,10 @@ export const PlatformWorkspaceSchema = z.object({
   // #2249 — optional + additive so older consumers that haven't picked
   // up this @useatlas/schemas release don't reject the response.
   neverSuspend: z.boolean().optional(),
+  // Optional + additive — missing on older API/web pairs (treated as
+  // "none" by the UI). Sourced from `checkAbuseStatus`, independent of
+  // the `status` column.
+  abuseLevel: AbuseLevelEnum.optional(),
 }) satisfies z.ZodType<PlatformWorkspace>;
 
 export const PlatformWorkspaceUserSchema = z.object({

--- a/packages/types/src/__tests__/abuse.test.ts
+++ b/packages/types/src/__tests__/abuse.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for the `AbuseLevel` helpers added alongside #2269.
+ *
+ * `normalizeAbuseLevel`, `compareAbuseLevel`, and `isAbuseLevelAtLeast`
+ * are the typesafe replacements for the `?? "none"` / hand-rolled
+ * severity-comparison patterns sprinkled across SDK and admin
+ * consumers. Pinning the ladder here is the regression floor: a
+ * reordering of `ABUSE_LEVELS` that broke the ordinal contract would
+ * silently change which level gates each threshold across every caller.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  ABUSE_LEVELS,
+  compareAbuseLevel,
+  isAbuseLevelAtLeast,
+  normalizeAbuseLevel,
+  type AbuseLevel,
+} from "../abuse";
+
+describe("normalizeAbuseLevel", () => {
+  it("returns 'none' for undefined", () => {
+    expect(normalizeAbuseLevel(undefined)).toBe("none");
+  });
+
+  it("returns 'none' for null", () => {
+    expect(normalizeAbuseLevel(null)).toBe("none");
+  });
+
+  it("passes through each defined level unchanged", () => {
+    for (const level of ABUSE_LEVELS) {
+      expect(normalizeAbuseLevel(level)).toBe(level);
+    }
+  });
+});
+
+describe("compareAbuseLevel", () => {
+  it("returns 0 for equal levels", () => {
+    for (const level of ABUSE_LEVELS) {
+      expect(compareAbuseLevel(level, level)).toBe(0);
+    }
+  });
+
+  it("orders levels as none < warning < throttled < suspended", () => {
+    expect(compareAbuseLevel("none", "warning")).toBeLessThan(0);
+    expect(compareAbuseLevel("warning", "throttled")).toBeLessThan(0);
+    expect(compareAbuseLevel("throttled", "suspended")).toBeLessThan(0);
+    expect(compareAbuseLevel("suspended", "none")).toBeGreaterThan(0);
+  });
+
+  it("supports sorting an array of mixed levels", () => {
+    const arr: AbuseLevel[] = ["throttled", "none", "suspended", "warning"];
+    arr.sort(compareAbuseLevel);
+    expect(arr).toEqual(["none", "warning", "throttled", "suspended"]);
+  });
+});
+
+describe("isAbuseLevelAtLeast", () => {
+  it("returns true when level equals or exceeds the floor", () => {
+    expect(isAbuseLevelAtLeast("warning", "warning")).toBe(true);
+    expect(isAbuseLevelAtLeast("throttled", "warning")).toBe(true);
+    expect(isAbuseLevelAtLeast("suspended", "warning")).toBe(true);
+  });
+
+  it("returns false when level is below the floor", () => {
+    expect(isAbuseLevelAtLeast("none", "warning")).toBe(false);
+    expect(isAbuseLevelAtLeast("warning", "throttled")).toBe(false);
+    expect(isAbuseLevelAtLeast("throttled", "suspended")).toBe(false);
+  });
+});

--- a/packages/types/src/abuse.ts
+++ b/packages/types/src/abuse.ts
@@ -12,6 +12,39 @@ import type { Percentage, Ratio } from "./percentage";
 export const ABUSE_LEVELS = ["none", "warning", "throttled", "suspended"] as const;
 export type AbuseLevel = (typeof ABUSE_LEVELS)[number];
 
+/**
+ * Coerce a possibly-missing abuse level (older API/web pair, optional
+ * wire field) to the safe `"none"` default. Replaces the `?? "none"`
+ * coercion sprinkled across SDK + admin consumers.
+ */
+export function normalizeAbuseLevel(level: AbuseLevel | undefined | null): AbuseLevel {
+  return level ?? "none";
+}
+
+const LEVEL_RANK: Record<AbuseLevel, number> = {
+  none: 0,
+  warning: 1,
+  throttled: 2,
+  suspended: 3,
+};
+
+/**
+ * Three-way compare on the `none < warning < throttled < suspended`
+ * escalation ladder. Returns < 0 / 0 / > 0 like every other compare fn.
+ */
+export function compareAbuseLevel(a: AbuseLevel, b: AbuseLevel): number {
+  return LEVEL_RANK[a] - LEVEL_RANK[b];
+}
+
+/**
+ * Predicate sugar over `compareAbuseLevel` — "is `level` at least as
+ * severe as `floor`?" Reads cleaner than `compareAbuseLevel(x, y) >= 0`
+ * at call sites that branch on a severity threshold.
+ */
+export function isAbuseLevelAtLeast(level: AbuseLevel, floor: AbuseLevel): boolean {
+  return LEVEL_RANK[level] >= LEVEL_RANK[floor];
+}
+
 /** Which anomaly detector triggered the abuse event. */
 export const ABUSE_TRIGGERS = [
   "query_rate",

--- a/packages/types/src/abuse.ts
+++ b/packages/types/src/abuse.ts
@@ -21,12 +21,16 @@ export function normalizeAbuseLevel(level: AbuseLevel | undefined | null): Abuse
   return level ?? "none";
 }
 
-const LEVEL_RANK: Record<AbuseLevel, number> = {
-  none: 0,
-  warning: 1,
-  throttled: 2,
-  suspended: 3,
-};
+// Derive the rank directly from the tuple's position so the escalation
+// ladder has a single source of truth — adding a level in `ABUSE_LEVELS`
+// (e.g. inserting `"emergency_stop"` before `"suspended"`) re-ranks
+// every consumer without a second edit. A hand-written object literal
+// would let `{ warning: 5, throttled: 1 }` typecheck against
+// `Record<AbuseLevel, number>` despite breaking the ordering invariant
+// that `compareAbuseLevel` depends on.
+const LEVEL_RANK = Object.fromEntries(
+  ABUSE_LEVELS.map((level, i) => [level, i] as const),
+) as Record<AbuseLevel, number>;
 
 /**
  * Three-way compare on the `none < warning < throttled < suspended`
@@ -42,7 +46,7 @@ export function compareAbuseLevel(a: AbuseLevel, b: AbuseLevel): number {
  * at call sites that branch on a severity threshold.
  */
 export function isAbuseLevelAtLeast(level: AbuseLevel, floor: AbuseLevel): boolean {
-  return LEVEL_RANK[level] >= LEVEL_RANK[floor];
+  return compareAbuseLevel(level, floor) >= 0;
 }
 
 /** Which anomaly detector triggered the abuse event. */
@@ -154,6 +158,30 @@ export interface AbuseInstance {
   peakLevel: AbuseLevel;
   events: readonly AbuseEvent[];
 }
+
+/**
+ * Boot outcome of the abuse-state rehydrate. Lives on the wire so the
+ * platform-admin page can surface a destructive banner when in-memory
+ * enforcement was lost — without this, a `load_failed` rehydrate leaves
+ * every workspace rendering `abuseLevel: "none"` despite enforcement
+ * being effectively off. Mirrors `AbuseEventsStatus` for parity.
+ *
+ *   - `pending`        — `restoreAbuseState` has not run yet. Transient
+ *                        during boot only.
+ *   - `ok`             — last run completed; in-memory state matches DB.
+ *   - `db_unavailable` — `hasInternalDB()` returned false. Expected on
+ *                        a self-hosted deploy without `DATABASE_URL`.
+ *   - `load_failed`    — the SQL read threw. UI must show a banner —
+ *                        every `checkAbuseStatus` will return `"none"`
+ *                        until the next escalation or boot.
+ */
+export const ABUSE_RESTORE_STATUSES = [
+  "pending",
+  "ok",
+  "db_unavailable",
+  "load_failed",
+] as const;
+export type AbuseRestoreStatus = (typeof ABUSE_RESTORE_STATUSES)[number];
 
 /**
  * Diagnostic channel for the `events` payload on `AbuseDetail` (#1682).

--- a/packages/types/src/platform.ts
+++ b/packages/types/src/platform.ts
@@ -6,6 +6,7 @@
  */
 
 import type { AtlasRole } from "./auth";
+import type { AbuseLevel } from "./abuse";
 
 /** Resolved deploy mode — binary value after auto-detection. */
 export type DeployMode = "saas" | "self-hosted";
@@ -50,6 +51,17 @@ export interface PlatformWorkspace {
    * Source of truth: `lib/auth/load-test-allowlist.ts:isLoadTestWorkspace`.
    */
   neverSuspend?: boolean;
+  /**
+   * Current in-memory abuse level for the workspace, sourced from
+   * `lib/security/abuse.ts:checkAbuseStatus`. Independent of
+   * `status` (the `workspace_status` DB column flipped by admin
+   * actions) — a workspace can be DB-active but abuse-suspended,
+   * which is exactly the divergence this field exists to expose so
+   * `/admin/platform` no longer looks healthy while chat is blocked
+   * by the abuse path. Optional + additive: omitted on consumers
+   * pre-dating this release; treat missing as `"none"`.
+   */
+  abuseLevel?: AbuseLevel;
 }
 
 export interface PlatformWorkspaceDetail {

--- a/packages/web/src/app/admin/organizations/detail-sheet.tsx
+++ b/packages/web/src/app/admin/organizations/detail-sheet.tsx
@@ -16,6 +16,8 @@ import { Mail, Users } from "lucide-react";
 import { RelativeTimestamp } from "@/ui/components/admin/queue";
 import { roleBadge } from "./roles";
 import { planBadge, statusBadge } from "./statuses";
+import { abuseBadge, AbuseDivergenceBanner } from "@/ui/lib/abuse-badge";
+import type { AbuseLevel } from "@useatlas/types";
 
 interface OrgDetail {
   organization: {
@@ -28,6 +30,8 @@ interface OrgDetail {
     planTier: string;
     suspendedAt: string | null;
     deletedAt: string | null;
+    /** Optional — older API/web pair omits; UI treats missing as "none". */
+    abuseLevel?: AbuseLevel;
   };
   members: Array<{
     id: string;
@@ -88,11 +92,13 @@ function OrgDetailContent({ orgId }: { orgId: string }) {
 
   return (
     <div className="space-y-6 px-4">
+      <AbuseDivergenceBanner level={data.organization.abuseLevel} />
       <div className="flex flex-wrap items-center gap-2">
         <Badge variant="outline" className={status.className}>
           <StatusIcon className="mr-1 size-3" />
           {status.label}
         </Badge>
+        {abuseBadge(data.organization.abuseLevel)}
         <Badge variant="outline" className={plan.className}>
           <PlanIcon className="mr-1 size-3" />
           {plan.label}

--- a/packages/web/src/app/admin/organizations/page.tsx
+++ b/packages/web/src/app/admin/organizations/page.tsx
@@ -83,7 +83,9 @@ interface Org {
   planTier: string;
   suspendedAt: string | null;
   deletedAt: string | null;
-  /** Optional — older API/web pair omits; UI treats missing as "none". */
+  // Server always emits a value (zod `.default("none")`); declare
+  // optional here to keep the parse resilient if an older API ever
+  // ships without the field.
   abuseLevel?: AbuseLevel;
 }
 

--- a/packages/web/src/app/admin/organizations/page.tsx
+++ b/packages/web/src/app/admin/organizations/page.tsx
@@ -54,9 +54,10 @@ import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { RelativeTimestamp } from "@/ui/components/admin/queue";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { PLAN_TIERS } from "@useatlas/types";
-import type { PlanTier } from "@useatlas/types";
+import type { PlanTier, AbuseLevel } from "@useatlas/types";
 import { OrgDetailSheet } from "./detail-sheet";
 import { planBadge, statusBadge } from "./statuses";
+import { abuseBadge } from "@/ui/lib/abuse-badge";
 import {
   Building2,
   Search,
@@ -82,6 +83,8 @@ interface Org {
   planTier: string;
   suspendedAt: string | null;
   deletedAt: string | null;
+  /** Optional — older API/web pair omits; UI treats missing as "none". */
+  abuseLevel?: AbuseLevel;
 }
 
 interface OrgListResponse {
@@ -199,10 +202,13 @@ export default function OrganizationsPage() {
       cell: ({ row }) => {
         const { Icon, className, label } = statusBadge(row.original.workspaceStatus);
         return (
-          <Badge variant="outline" className={className}>
-            <Icon className="mr-1 size-3" />
-            {label}
-          </Badge>
+          <span className="flex flex-wrap items-center gap-1">
+            <Badge variant="outline" className={className}>
+              <Icon className="mr-1 size-3" />
+              {label}
+            </Badge>
+            {abuseBadge(row.original.abuseLevel)}
+          </span>
         );
       },
     },

--- a/packages/web/src/app/admin/platform/page.tsx
+++ b/packages/web/src/app/admin/platform/page.tsx
@@ -63,9 +63,9 @@ import type {
   PlatformWorkspace,
   WorkspaceStatus,
   PlanTier,
-  AbuseLevel,
 } from "@/ui/lib/types";
 import { WORKSPACE_STATUSES, PLAN_TIERS } from "@/ui/lib/types";
+import { abuseBadge, AbuseDivergenceBanner } from "@/ui/lib/abuse-badge";
 import { formatDate } from "@/lib/format";
 
 // Dynamic import for Recharts (heavy dependency)
@@ -106,39 +106,6 @@ function statusBadge(status: WorkspaceStatus) {
       return <Badge variant="outline" className="gap-1 border-amber-500 text-amber-600">Suspended</Badge>;
     case "deleted":
       return <Badge variant="secondary" className="gap-1">Deleted</Badge>;
-  }
-}
-
-/**
- * Badge for the in-memory abuse level — distinct from `statusBadge` which
- * reflects the `workspace_status` DB column flipped by admin actions.
- * The two can disagree (DB-active + abuse-suspended is the bug this badge
- * exists to expose), so always render both when `level` is non-`"none"`.
- * Returns `null` for `"none"` so the row stays uncluttered when there's
- * nothing to surface.
- */
-function abuseBadge(level: AbuseLevel) {
-  switch (level) {
-    case "none":
-      return null;
-    case "warning":
-      return (
-        <Badge variant="outline" className="border-yellow-500 text-yellow-600 gap-1">
-          Abuse: warning
-        </Badge>
-      );
-    case "throttled":
-      return (
-        <Badge variant="outline" className="border-orange-500 text-orange-600 gap-1">
-          Abuse: throttled
-        </Badge>
-      );
-    case "suspended":
-      return (
-        <Badge variant="destructive" className="gap-1">
-          Abuse: suspended
-        </Badge>
-      );
   }
 }
 
@@ -473,7 +440,7 @@ function PlatformPageContent() {
                         <TableCell>
                           <span className="flex flex-wrap items-center gap-1">
                             {statusBadge(ws.status as WorkspaceStatus)}
-                            {abuseBadge((ws.abuseLevel ?? "none") as AbuseLevel)}
+                            {abuseBadge(ws.abuseLevel)}
                           </span>
                         </TableCell>
                         <TableCell>{ws.members}</TableCell>
@@ -633,25 +600,7 @@ function PlatformPageContent() {
             <MutationErrorSurface error={detailError} feature="Platform Admin" />
           ) : detailData ? (
             <div className="space-y-4">
-              {detailData.workspace.abuseLevel && detailData.workspace.abuseLevel !== "none" ? (
-                <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-50 dark:bg-amber-950/30 p-3 text-sm">
-                  <AlertTriangle className="mt-0.5 size-4 text-amber-600 shrink-0" />
-                  <div className="space-y-1">
-                    <p className="font-medium text-amber-900 dark:text-amber-100">
-                      Abuse detector reports{" "}
-                      <span className="font-mono">{detailData.workspace.abuseLevel}</span>.
-                    </p>
-                    <p className="text-amber-800 dark:text-amber-200">
-                      This is independent of the workspace status above — chat &amp; query
-                      requests are being blocked even if status reads &quot;active&quot;.{" "}
-                      <a href="/admin/abuse" className="underline underline-offset-2">
-                        Open Abuse Console
-                      </a>{" "}
-                      to reinstate.
-                    </p>
-                  </div>
-                </div>
-              ) : null}
+              <AbuseDivergenceBanner level={detailData.workspace.abuseLevel} />
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <span className="text-sm text-muted-foreground">Name</span>
@@ -676,7 +625,7 @@ function PlatformPageContent() {
                   <span className="text-sm text-muted-foreground">Status</span>
                   <div className="flex flex-wrap items-center gap-1">
                     {statusBadge(detailData.workspace.status as WorkspaceStatus)}
-                    {abuseBadge((detailData.workspace.abuseLevel ?? "none") as AbuseLevel)}
+                    {abuseBadge(detailData.workspace.abuseLevel)}
                   </div>
                 </div>
                 <div>

--- a/packages/web/src/app/admin/platform/page.tsx
+++ b/packages/web/src/app/admin/platform/page.tsx
@@ -325,6 +325,25 @@ function PlatformPageContent() {
 
         {/* ── Workspaces Tab ────────────────────────────────────── */}
         <TabsContent value="workspaces" className="space-y-4">
+          {wsData?.abuseRestoreStatus === "load_failed" ? (
+            // Boot-time abuse rehydrate failed — every workspace will
+            // render `abuseLevel: "none"` even though in-memory state
+            // is empty and enforcement is effectively off. Operator
+            // must restart or investigate before trusting the badges.
+            <div className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm">
+              <AlertTriangle className="mt-0.5 size-4 text-destructive shrink-0" />
+              <div className="space-y-1">
+                <p className="font-medium text-destructive">
+                  Abuse-state rehydrate failed on boot.
+                </p>
+                <p className="text-destructive/90">
+                  In-memory enforcement is empty — every workspace below renders
+                  &quot;Active&quot; regardless of past escalations. Check the API logs for the
+                  rehydrate error and restart the API once resolved.
+                </p>
+              </div>
+            </div>
+          ) : null}
           <div className="flex items-center gap-4">
             <div className="relative flex-1">
               <Search className="absolute left-2.5 top-2.5 size-4 text-muted-foreground" />

--- a/packages/web/src/app/admin/platform/page.tsx
+++ b/packages/web/src/app/admin/platform/page.tsx
@@ -63,6 +63,7 @@ import type {
   PlatformWorkspace,
   WorkspaceStatus,
   PlanTier,
+  AbuseLevel,
 } from "@/ui/lib/types";
 import { WORKSPACE_STATUSES, PLAN_TIERS } from "@/ui/lib/types";
 import { formatDate } from "@/lib/format";
@@ -105,6 +106,39 @@ function statusBadge(status: WorkspaceStatus) {
       return <Badge variant="outline" className="gap-1 border-amber-500 text-amber-600">Suspended</Badge>;
     case "deleted":
       return <Badge variant="secondary" className="gap-1">Deleted</Badge>;
+  }
+}
+
+/**
+ * Badge for the in-memory abuse level — distinct from `statusBadge` which
+ * reflects the `workspace_status` DB column flipped by admin actions.
+ * The two can disagree (DB-active + abuse-suspended is the bug this badge
+ * exists to expose), so always render both when `level` is non-`"none"`.
+ * Returns `null` for `"none"` so the row stays uncluttered when there's
+ * nothing to surface.
+ */
+function abuseBadge(level: AbuseLevel) {
+  switch (level) {
+    case "none":
+      return null;
+    case "warning":
+      return (
+        <Badge variant="outline" className="border-yellow-500 text-yellow-600 gap-1">
+          Abuse: warning
+        </Badge>
+      );
+    case "throttled":
+      return (
+        <Badge variant="outline" className="border-orange-500 text-orange-600 gap-1">
+          Abuse: throttled
+        </Badge>
+      );
+    case "suspended":
+      return (
+        <Badge variant="destructive" className="gap-1">
+          Abuse: suspended
+        </Badge>
+      );
   }
 }
 
@@ -436,7 +470,12 @@ function PlatformPageContent() {
                           </span>
                         </TableCell>
                         <TableCell>{planBadge(ws.planTier as PlanTier)}</TableCell>
-                        <TableCell>{statusBadge(ws.status as WorkspaceStatus)}</TableCell>
+                        <TableCell>
+                          <span className="flex flex-wrap items-center gap-1">
+                            {statusBadge(ws.status as WorkspaceStatus)}
+                            {abuseBadge((ws.abuseLevel ?? "none") as AbuseLevel)}
+                          </span>
+                        </TableCell>
                         <TableCell>{ws.members}</TableCell>
                         <TableCell>{ws.queriesLast24h.toLocaleString()}</TableCell>
                         <TableCell>{formatDate(ws.createdAt)}</TableCell>
@@ -594,6 +633,25 @@ function PlatformPageContent() {
             <MutationErrorSurface error={detailError} feature="Platform Admin" />
           ) : detailData ? (
             <div className="space-y-4">
+              {detailData.workspace.abuseLevel && detailData.workspace.abuseLevel !== "none" ? (
+                <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-50 dark:bg-amber-950/30 p-3 text-sm">
+                  <AlertTriangle className="mt-0.5 size-4 text-amber-600 shrink-0" />
+                  <div className="space-y-1">
+                    <p className="font-medium text-amber-900 dark:text-amber-100">
+                      Abuse detector reports{" "}
+                      <span className="font-mono">{detailData.workspace.abuseLevel}</span>.
+                    </p>
+                    <p className="text-amber-800 dark:text-amber-200">
+                      This is independent of the workspace status above — chat &amp; query
+                      requests are being blocked even if status reads &quot;active&quot;.{" "}
+                      <a href="/admin/abuse" className="underline underline-offset-2">
+                        Open Abuse Console
+                      </a>{" "}
+                      to reinstate.
+                    </p>
+                  </div>
+                </div>
+              ) : null}
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <span className="text-sm text-muted-foreground">Name</span>
@@ -616,7 +674,10 @@ function PlatformPageContent() {
                 </div>
                 <div>
                   <span className="text-sm text-muted-foreground">Status</span>
-                  <p>{statusBadge(detailData.workspace.status as WorkspaceStatus)}</p>
+                  <div className="flex flex-wrap items-center gap-1">
+                    {statusBadge(detailData.workspace.status as WorkspaceStatus)}
+                    {abuseBadge((detailData.workspace.abuseLevel ?? "none") as AbuseLevel)}
+                  </div>
                 </div>
                 <div>
                   <span className="text-sm text-muted-foreground">Plan</span>

--- a/packages/web/src/ui/lib/abuse-badge.tsx
+++ b/packages/web/src/ui/lib/abuse-badge.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { AlertTriangle } from "lucide-react";
 import type { AbuseLevel } from "@/ui/lib/types";
@@ -70,9 +71,9 @@ export function AbuseDivergenceBanner({ level }: { level: AbuseLevel | undefined
         <p className="text-amber-800 dark:text-amber-200">
           This is independent of the workspace status above — chat &amp; query
           requests are being blocked even if status reads &quot;active&quot;.{" "}
-          <a href="/admin/abuse" className="underline underline-offset-2">
+          <Link href="/admin/abuse" className="underline underline-offset-2">
             Open Abuse Console
-          </a>{" "}
+          </Link>{" "}
           to reinstate.
         </p>
       </div>

--- a/packages/web/src/ui/lib/abuse-badge.tsx
+++ b/packages/web/src/ui/lib/abuse-badge.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { AlertTriangle } from "lucide-react";
+import type { AbuseLevel } from "@/ui/lib/types";
+
+/**
+ * Badge for the in-memory abuse level — distinct from the workspace
+ * status badge (the `workspace_status` DB column flipped by admin
+ * actions). The two can disagree (DB-active + abuse-suspended is the
+ * #2269 bug) so callers render both alongside.
+ *
+ * Returns `null` for `"none"` and `undefined` (older API/web pair) so
+ * the row stays uncluttered when there's nothing to surface. Treating
+ * `undefined` like `"none"` is the conservative default — the audit
+ * trail for divergence is then either present or absent based on the
+ * server reporting it, never inferred from a missing field.
+ */
+export function abuseBadge(level: AbuseLevel | undefined) {
+  switch (level) {
+    case undefined:
+    case "none":
+      return null;
+    case "warning":
+      return (
+        <Badge variant="outline" className="border-yellow-500 text-yellow-600 gap-1">
+          Abuse: warning
+        </Badge>
+      );
+    case "throttled":
+      return (
+        <Badge variant="outline" className="border-orange-500 text-orange-600 gap-1">
+          Abuse: throttled
+        </Badge>
+      );
+    case "suspended":
+      return (
+        <Badge variant="destructive" className="gap-1">
+          Abuse: suspended
+        </Badge>
+      );
+    default: {
+      // Exhaustiveness check — a new `AbuseLevel` member fails compile
+      // here, so the badge never silently renders nothing for a level
+      // the wire format now supports.
+      const _exhaustive: never = level;
+      void _exhaustive;
+      return null;
+    }
+  }
+}
+
+/**
+ * Banner shown on the workspace detail surfaces when the abuse detector
+ * has flagged a workspace whose `workspace_status` is still `"active"`.
+ * Explains the divergence and links to the abuse console for reinstate.
+ *
+ * `level === undefined` (older API/web pair) and `"none"` both render
+ * nothing — same conservative default as `abuseBadge`.
+ */
+export function AbuseDivergenceBanner({ level }: { level: AbuseLevel | undefined }) {
+  if (!level || level === "none") return null;
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-50 dark:bg-amber-950/30 p-3 text-sm">
+      <AlertTriangle className="mt-0.5 size-4 text-amber-600 shrink-0" />
+      <div className="space-y-1">
+        <p className="font-medium text-amber-900 dark:text-amber-100">
+          Abuse detector reports <span className="font-mono">{level}</span>.
+        </p>
+        <p className="text-amber-800 dark:text-amber-200">
+          This is independent of the workspace status above — chat &amp; query
+          requests are being blocked even if status reads &quot;active&quot;.{" "}
+          <a href="/admin/abuse" className="underline underline-offset-2">
+            Open Abuse Console
+          </a>{" "}
+          to reinstate.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -14,6 +14,7 @@
  * `packages/schemas/README.md`.
  */
 import { z } from "zod";
+import { ABUSE_RESTORE_STATUSES } from "@useatlas/types";
 import {
   BackupEntrySchema,
   CustomDomainSchema,
@@ -84,6 +85,10 @@ export {
 
 export const PlatformWorkspacesResponseSchema = z.object({
   workspaces: z.array(PlatformWorkspaceSchema),
+  // Optional + additive — older API doesn't include this field; the
+  // platform-admin page treats absence as `"ok"` (the conservative
+  // "everything's fine" default). Sourced from `getAbuseRestoreStatus()`.
+  abuseRestoreStatus: z.enum(ABUSE_RESTORE_STATUSES).optional(),
 });
 
 export const PlatformNeighborsResponseSchema = z.object({

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -14,7 +14,7 @@
  * `packages/schemas/README.md`.
  */
 import { z } from "zod";
-import { ABUSE_RESTORE_STATUSES } from "@useatlas/types";
+import type { AbuseRestoreStatus } from "@useatlas/types";
 import {
   BackupEntrySchema,
   CustomDomainSchema,
@@ -22,6 +22,20 @@ import {
   PlatformWorkspaceSchema,
   PlatformWorkspaceUserSchema,
 } from "@useatlas/schemas";
+
+// Local literal tuple instead of importing the value-export tuple from
+// `@useatlas/types`. The template scaffold installs `@useatlas/types`
+// from the registry — adding a new value export forces a publish-first
+// merge dance for every PR (#useatlas/types-scaffold-gotcha). The
+// `satisfies` constraint pins this tuple to the same union as the
+// canonical `AbuseRestoreStatus` so adding a level in
+// `@useatlas/types/abuse.ts` fails compile here until both sides match.
+const ABUSE_RESTORE_STATUSES = [
+  "pending",
+  "ok",
+  "db_unavailable",
+  "load_failed",
+] as const satisfies readonly AbuseRestoreStatus[];
 export {
   AbuseStatusSchema,
   AbuseThresholdConfigSchema,


### PR DESCRIPTION
## Summary

- `/admin/platform` showed "Active" while chat returned `workspace_suspended` ("Workspace suspended due to unusual activity.") because the page reads `organization.workspace_status` (DB column) while the chat block reads in-memory `checkAbuseStatus`. Two independent suspension paths with no cross-reference.
- `PlatformWorkspace` gains optional `abuseLevel?: AbuseLevel`; both the list table and detail dialog now render an `Abuse: suspended/throttled/warning` badge alongside the existing status badge, and the detail dialog surfaces an amber banner linking to `/admin/abuse` for reinstate.
- `checkAbuseStatus` and `restoreAbuseState` now honor `ATLAS_LOADTEST_ALLOWED_ORGS` — #2166 / #2247 only short-circuited `recordQueryEvent`, so a workspace escalated *before* being added to the allowlist stayed suspended at read time forever (and got rehydrated from `abuse_events` on every boot). The "never-suspend" badge from #2249 now matches reality at both read time and rehydrate time.

`@useatlas/types` 0.0.21 → 0.0.22 (additive — older consumers treat missing as `"none"`). Consumer refs (sdk/react/templates) stay at ^0.0.21 — bump after `types-v0.0.22` publishes per the npm-publish playbook.

OpenAPI spec regenerated.

## Test plan
- [x] `abuse.test.ts` — stale-suspended-then-allowlisted reports `none` at read time; `restoreAbuseState` skips allowlisted IDs and reports `allowlistSkipped` in the restore log.
- [x] `platform-admin.test.ts` — list route writes `abuseLevel` from `checkAbuseStatus`; allowlisted workspace reports `none`; `toWorkspaceResponse` (detail path) threads `abuseLevel` correctly. Programmable mock via `abuseStatusByWorkspace` overrides the constant fixture in api-test-mocks.
- [x] `bun run scripts/test-isolated.ts --affected` — 35/35 API, 133/133 web.
- [x] `bun run type` + `bun run lint` clean.
- [x] Schema-drift + template-drift checks pass.
- [ ] Manual: hit `/admin/platform` for Dharma — confirm "Suspended (abuse)" badge appears alongside "Active" status, banner shows in detail dialog, /admin/abuse reinstate flow lifts both.