### PR TITLE
chore: bump consumer refs ^0.0.21 → ^0.0.22 after types publish

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -265,7 +265,7 @@
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^5.96.2",
-        "@useatlas/types": "^0.0.21",
+        "@useatlas/types": "^0.0.22",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "radix-ui": "^1.4.3",
@@ -333,7 +333,7 @@
       "name": "@useatlas/sdk",
       "version": "0.0.13",
       "dependencies": {
-        "@useatlas/types": "^0.0.21",
+        "@useatlas/types": "^0.0.22",
       },
       "devDependencies": {
         "@atlas/oauth-helper": "workspace:*",
@@ -4357,10 +4357,6 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typespec/ts-http-runtime/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
-    "@useatlas/react/@useatlas/types": ["@useatlas/types@0.0.21", "", {}, "sha512-RWArn150XuFzKcWXi8O17AatW2pZVTYLzaKuP/CY79uzjN9vumbnKyiVhB18l1RS63qscldyoppoFYV1m/biWw=="],
-
-    "@useatlas/sdk/@useatlas/types": ["@useatlas/types@0.0.21", "", {}, "sha512-RWArn150XuFzKcWXi8O17AatW2pZVTYLzaKuP/CY79uzjN9vumbnKyiVhB18l1RS63qscldyoppoFYV1m/biWw=="],
 
     "@vercel/sandbox/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 

--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -24,7 +24,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.0.7",
     "@useatlas/sdk": "^0.0.12",
-    "@useatlas/types": "^0.0.21",
+    "@useatlas/types": "^0.0.22",
     "@better-auth/api-key": "^1.6.9",
     "@better-auth/oauth-provider": "^1.6.9",
     "@better-auth/passkey": "^1.6.9",

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -21,7 +21,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.0.7",
     "@useatlas/sdk": "^0.0.12",
-    "@useatlas/types": "^0.0.21",
+    "@useatlas/types": "^0.0.22",
     "ai": "^6.0.141",
     "@better-auth/api-key": "^1.6.9",
     "@better-auth/oauth-provider": "^1.6.9",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -83,7 +83,7 @@
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^5.96.2",
-    "@useatlas/types": "^0.0.21",
+    "@useatlas/types": "^0.0.22",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "radix-ui": "^1.4.3",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -49,7 +49,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@useatlas/types": "^0.0.21"
+    "@useatlas/types": "^0.0.22"
   },
   "devDependencies": {
     "@atlas/oauth-helper": "workspace:*"


### PR DESCRIPTION
## Summary

Follow-up to #2268. `@useatlas/types@0.0.22` published to npm during the merge. Bump consumer refs in lockstep per the publish playbook.

- \`packages/sdk/package.json\` — \`^0.0.21\` → \`^0.0.22\`
- \`packages/react/package.json\` — \`^0.0.21\` → \`^0.0.22\`
- \`create-atlas/templates/nextjs-standalone/package.json\` — \`^0.0.21\` → \`^0.0.22\`
- \`create-atlas/templates/docker/package.json\` — \`^0.0.21\` → \`^0.0.22\`
- \`bun.lock\` regenerated.

Required because \`0.0.x\` semver is exact-match — without the bump, consumers stay pinned at 0.0.21 and never pick up the new \`gateway\` provider / \`GatewayCatalogModel\` types.

## Test plan

- [x] \`bun install\` — clean (no installs, lockfile saved)
- [x] \`bun x syncpack lint\` — no issues
- [x] \`SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh\` — 535 files verified