### PR TITLE
feat(api,web,admin): #2271 — Anthropic BYOT + /v1/models discovery picker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -151,6 +151,10 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 
 # === Agent ===
 # ATLAS_AGENT_MAX_STEPS=25     # Default: 25, range 1–100. Max tool-call steps per agent run
+# ATLAS_BYOT_CATALOG_TTL_MS=21600000        # Default 6h. Server-side TTL for the per-workspace BYOT
+#                                           # provider catalog (Anthropic /v1/models — #2271). Discovery
+#                                           # hits upstream when the workspace's cache entry has
+#                                           # expired or admin clicks "Refresh now" on AI Provider.
 # ATLAS_CONVERSATION_STEP_CAP=500           # Aggregate step ceiling per conversation (F-77).
 #                                           # Default 500 = 20 follow-ups × 25 steps. Once total_steps
 #                                           # crosses this value the chat handler returns 429

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -31164,11 +31164,42 @@
         "tags": [
           "Admin — Model Config"
         ],
-        "summary": "Vercel AI Gateway model catalog",
-        "description": "Returns the catalog of models available via the Vercel AI Gateway, grouped by provider. Cached server-side; the `fallback` field is true when the live fetch failed and a bundled subset was returned.",
+        "summary": "BYOT model catalog",
+        "description": "Returns a model catalog for the requested provider. With no `?provider` (or `?provider=gateway`), returns the Vercel AI Gateway catalog (server-cached; `fallback: true` when the live fetch failed and a bundled subset was returned). With `?provider=anthropic`, returns Anthropic /v1/models for the workspace using its saved BYOT key — requires a saved Anthropic provider configuration.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "gateway",
+                "anthropic"
+              ],
+              "description": "Provider catalog to return. Defaults to 'gateway' (Vercel AI Gateway, anonymous). 'anthropic' returns the workspace's catalog from api.anthropic.com/v1/models using the saved BYOT key — requires a saved Anthropic configuration.",
+              "example": "anthropic"
+            },
+            "required": false,
+            "description": "Provider catalog to return. Defaults to 'gateway' (Vercel AI Gateway, anonymous). 'anthropic' returns the workspace's catalog from api.anthropic.com/v1/models using the saved BYOT key — requires a saved Anthropic configuration.",
+            "name": "provider",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "1",
+                "true"
+              ],
+              "description": "Bypass the catalog cache and force a fresh upstream fetch."
+            },
+            "required": false,
+            "description": "Bypass the catalog cache and force a fresh upstream fetch.",
+            "name": "refresh",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
-            "description": "Gateway catalog",
+            "description": "Provider catalog",
             "content": {
               "application/json": {
                 "schema": {
@@ -31248,8 +31279,33 @@
               }
             }
           },
+          "400": {
+            "description": "Missing BYOT key for the requested provider",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "401": {
-            "description": "Authentication required",
+            "description": "Authentication required — or upstream rejected the BYOT key",
             "content": {
               "application/json": {
                 "schema": {
@@ -31270,8 +31326,33 @@
               }
             }
           },
+          "422": {
+            "description": "Stored BYOT key cannot be decrypted (likely key-rotation drift)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "429": {
-            "description": "Rate limit exceeded",
+            "description": "Rate limited — by Atlas or by upstream provider",
             "content": {
               "application/json": {
                 "schema": {
@@ -31283,6 +31364,31 @@
           },
           "500": {
             "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Upstream provider unavailable",
             "content": {
               "application/json": {
                 "schema": {

--- a/ee/src/platform/model-routing.ts
+++ b/ee/src/platform/model-routing.ts
@@ -22,6 +22,7 @@ import {
 } from "@atlas/api/lib/db/internal";
 import { activeKeyVersion } from "@atlas/api/lib/db/encryption-keys";
 import { getGatewayCatalog } from "@atlas/api/lib/gateway-catalog";
+import { invalidateAnthropicCatalog } from "@atlas/api/lib/anthropic-catalog";
 import { createLogger } from "@atlas/api/lib/logger";
 import type {
   ApiKeyStatus,
@@ -372,6 +373,16 @@ export const setWorkspaceModelConfig = (
       { orgId, provider: config.provider, model: config.model },
       "Workspace model config saved",
     );
+
+    // BYOT discovery caches are keyed per (org, provider) and outlast a
+    // single save — flush the matching cache entry so a key rotation or
+    // provider switch doesn't serve a stale catalog from the previous
+    // shape. Each provider owns its own invalidator; gateway has no
+    // per-org cache so it gets no hook.
+    if (config.provider === "anthropic") {
+      invalidateAnthropicCatalog(orgId);
+    }
+
     return rowToConfig(rows[0]);
   });
 

--- a/packages/api/src/api/__tests__/admin-model-config.test.ts
+++ b/packages/api/src/api/__tests__/admin-model-config.test.ts
@@ -52,8 +52,23 @@ class MockModelConfigError extends Error {
   }
 }
 
+class MockModelConfigDecryptError extends Error {
+  public readonly _tag = "ModelConfigDecryptError" as const;
+  public readonly configId: string;
+  public readonly cause: string;
+  constructor(args: { configId: string; cause: string }) {
+    super(`Failed to decrypt key for ${args.configId}`);
+    this.name = "ModelConfigDecryptError";
+    this.configId = args.configId;
+    this.cause = args.cause;
+  }
+}
+
 const mockGetWorkspaceModelConfig: Mock<(orgId: string) => unknown> = mock(() =>
   Effect.succeed(null),
+);
+const mockGetWorkspaceModelConfigRaw: Mock<(orgId: string) => unknown> = mock(
+  () => Effect.succeed(null),
 );
 const mockSetWorkspaceModelConfig: Mock<(...args: unknown[]) => unknown> = mock(
   () =>
@@ -82,10 +97,12 @@ const mockTestModelConfig: Mock<(...args: unknown[]) => unknown> = mock(() =>
 
 mock.module("@atlas/ee/platform/model-routing", () => ({
   getWorkspaceModelConfig: mockGetWorkspaceModelConfig,
+  getWorkspaceModelConfigRaw: mockGetWorkspaceModelConfigRaw,
   setWorkspaceModelConfig: mockSetWorkspaceModelConfig,
   deleteWorkspaceModelConfig: mockDeleteWorkspaceModelConfig,
   testModelConfig: mockTestModelConfig,
   ModelConfigError: MockModelConfigError,
+  ModelConfigDecryptError: MockModelConfigDecryptError,
 }));
 
 // --- Audit capture: use the real ADMIN_ACTIONS catalog so route emissions
@@ -114,6 +131,64 @@ mock.module("@atlas/api/lib/audit", async () => {
   };
 });
 
+// --- Anthropic catalog mocks. Real module is HTTP-bound; mock it so the
+// /catalog?provider=anthropic route flow is unit-testable. Mirrors every
+// named export the route currently imports (mock.module is all-or-nothing).
+class MockAnthropicCatalogUnauthorized extends Error {
+  readonly _tag = "AnthropicCatalogUnauthorized" as const;
+  constructor(message: string) {
+    super(message);
+    this.name = "AnthropicCatalogUnauthorized";
+  }
+}
+class MockAnthropicCatalogRateLimited extends Error {
+  readonly _tag = "AnthropicCatalogRateLimited" as const;
+  readonly retryAfterSeconds: number | null;
+  constructor(message: string, retryAfterSeconds: number | null) {
+    super(message);
+    this.name = "AnthropicCatalogRateLimited";
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}
+class MockAnthropicCatalogUnavailable extends Error {
+  readonly _tag = "AnthropicCatalogUnavailable" as const;
+  constructor(message: string) {
+    super(message);
+    this.name = "AnthropicCatalogUnavailable";
+  }
+}
+
+const mockGetAnthropicCatalog: Mock<(...args: unknown[]) => unknown> = mock(
+  async () => ({
+    models: [
+      {
+        id: "claude-opus-4-6",
+        name: "Claude Opus 4.6",
+        provider: "anthropic",
+        type: "language",
+        contextWindow: null,
+        maxOutputTokens: null,
+        inputPrice: null,
+        outputPrice: null,
+        recommended: true,
+      },
+    ],
+    fetchedAt: "2026-05-11T00:00:00.000Z",
+    source: "fresh" as const,
+  }),
+);
+const mockInvalidateAnthropicCatalog: Mock<(orgId: string) => void> = mock(
+  () => {},
+);
+
+mock.module("@atlas/api/lib/anthropic-catalog", () => ({
+  getAnthropicCatalog: mockGetAnthropicCatalog,
+  invalidateAnthropicCatalog: mockInvalidateAnthropicCatalog,
+  AnthropicCatalogUnauthorized: MockAnthropicCatalogUnauthorized,
+  AnthropicCatalogRateLimited: MockAnthropicCatalogRateLimited,
+  AnthropicCatalogUnavailable: MockAnthropicCatalogUnavailable,
+}));
+
 // --- Import the app AFTER all mocks ---
 const { app } = await import("../index");
 
@@ -141,11 +216,32 @@ beforeEach(() => {
   mocks.hasInternalDB = true;
   mockLogAdminAction.mockClear();
   mockGetWorkspaceModelConfig.mockClear();
+  mockGetWorkspaceModelConfigRaw.mockClear();
   mockSetWorkspaceModelConfig.mockClear();
   mockDeleteWorkspaceModelConfig.mockClear();
   mockTestModelConfig.mockClear();
 
   mockGetWorkspaceModelConfig.mockImplementation(() => Effect.succeed(null));
+  mockGetWorkspaceModelConfigRaw.mockImplementation(() => Effect.succeed(null));
+  mockGetAnthropicCatalog.mockClear();
+  mockInvalidateAnthropicCatalog.mockClear();
+  mockGetAnthropicCatalog.mockImplementation(async () => ({
+    models: [
+      {
+        id: "claude-opus-4-6",
+        name: "Claude Opus 4.6",
+        provider: "anthropic",
+        type: "language",
+        contextWindow: null,
+        maxOutputTokens: null,
+        inputPrice: null,
+        outputPrice: null,
+        recommended: true,
+      },
+    ],
+    fetchedAt: "2026-05-11T00:00:00.000Z",
+    source: "fresh" as const,
+  }));
   mockSetWorkspaceModelConfig.mockImplementation(() =>
     Effect.succeed({
       id: "cfg-1",
@@ -505,5 +601,231 @@ describe("audit emission — POST /api/v1/admin/model-config/test", () => {
       model: "claude-opus-4-6",
     });
     expect(JSON.stringify(entry)).not.toContain("sk-ant-probe");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/admin/model-config/catalog?provider=anthropic
+// ---------------------------------------------------------------------------
+
+describe("GET /api/v1/admin/model-config/catalog?provider=anthropic", () => {
+  it("returns the workspace's anthropic catalog using the stored BYOT key", async () => {
+    mockGetWorkspaceModelConfigRaw.mockImplementation(() =>
+      Effect.succeed({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        apiKey: "sk-ant-stored-key",
+        baseUrl: null,
+      }),
+    );
+    const res = await app.fetch(
+      adminRequest("GET", "/api/v1/admin/model-config/catalog?provider=anthropic"),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      models: { id: string }[];
+      fetchedAt: string;
+      fallback: boolean;
+    };
+    expect(body.models).toHaveLength(1);
+    expect(body.models[0].id).toBe("claude-opus-4-6");
+    expect(body.fallback).toBe(false);
+    // Verify the catalog was called with the workspace's stored key.
+    expect(mockGetAnthropicCatalog).toHaveBeenCalledTimes(1);
+    const args = mockGetAnthropicCatalog.mock.calls[0]! as unknown as [
+      string,
+      string,
+      { refresh?: boolean } | undefined,
+    ];
+    expect(args[1]).toBe("sk-ant-stored-key");
+    expect(args[2]).toEqual({ refresh: false });
+  });
+
+  it("passes ?refresh=1 through to bypass the cache", async () => {
+    mockGetWorkspaceModelConfigRaw.mockImplementation(() =>
+      Effect.succeed({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        apiKey: "sk-ant-stored-key",
+        baseUrl: null,
+      }),
+    );
+    const res = await app.fetch(
+      adminRequest(
+        "GET",
+        "/api/v1/admin/model-config/catalog?provider=anthropic&refresh=1",
+      ),
+    );
+    expect(res.status).toBe(200);
+    const args = mockGetAnthropicCatalog.mock.calls[0]! as unknown as [
+      string,
+      string,
+      { refresh?: boolean } | undefined,
+    ];
+    expect(args[2]).toEqual({ refresh: true });
+  });
+
+  it("returns 400 missing_byot_key when no anthropic config exists", async () => {
+    mockGetWorkspaceModelConfigRaw.mockImplementation(() => Effect.succeed(null));
+    const res = await app.fetch(
+      adminRequest("GET", "/api/v1/admin/model-config/catalog?provider=anthropic"),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("missing_byot_key");
+    // Do NOT emit a successful catalog-refresh audit when the precondition
+    // fails — there's no key in play, so no credential-oracle risk.
+    expect(mockLogAdminAction).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 missing_byot_key when saved provider is not anthropic", async () => {
+    mockGetWorkspaceModelConfigRaw.mockImplementation(() =>
+      Effect.succeed({
+        provider: "openai",
+        model: "gpt-4o",
+        apiKey: "sk-openai-stored",
+        baseUrl: null,
+      }),
+    );
+    const res = await app.fetch(
+      adminRequest("GET", "/api/v1/admin/model-config/catalog?provider=anthropic"),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("missing_byot_key");
+  });
+
+  it("returns 422 decrypt_failed when the stored key cannot be decrypted", async () => {
+    mockGetWorkspaceModelConfigRaw.mockImplementation(() =>
+      Effect.fail(
+        new MockModelConfigDecryptError({
+          configId: "cfg-1",
+          cause: "wrong key version",
+        }),
+      ),
+    );
+    const res = await app.fetch(
+      adminRequest("GET", "/api/v1/admin/model-config/catalog?provider=anthropic"),
+    );
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("decrypt_failed");
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    expect(lastAuditCall().status).toBe("failure");
+    expect(lastAuditCall().metadata).toMatchObject({
+      provider: "anthropic",
+      error: "decrypt_failed",
+    });
+  });
+
+  it("returns 401 byot_key_invalid when Anthropic rejects the key", async () => {
+    mockGetWorkspaceModelConfigRaw.mockImplementation(() =>
+      Effect.succeed({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        apiKey: "sk-ant-rotten",
+        baseUrl: null,
+      }),
+    );
+    mockGetAnthropicCatalog.mockImplementation(() => {
+      throw new MockAnthropicCatalogUnauthorized("rejected by anthropic");
+    });
+    const res = await app.fetch(
+      adminRequest("GET", "/api/v1/admin/model-config/catalog?provider=anthropic"),
+    );
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("byot_key_invalid");
+    const entry = lastAuditCall();
+    expect(entry.status).toBe("failure");
+    expect(entry.metadata).toMatchObject({
+      provider: "anthropic",
+      error: "byot_key_invalid",
+    });
+    // The apiKey must never appear in any captured audit metadata.
+    expect(JSON.stringify(entry)).not.toContain("sk-ant-rotten");
+  });
+
+  it("returns 429 with Retry-After when Anthropic rate-limits the workspace", async () => {
+    mockGetWorkspaceModelConfigRaw.mockImplementation(() =>
+      Effect.succeed({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        apiKey: "sk-ant-stored",
+        baseUrl: null,
+      }),
+    );
+    mockGetAnthropicCatalog.mockImplementation(() => {
+      throw new MockAnthropicCatalogRateLimited("slow down", 45);
+    });
+    const res = await app.fetch(
+      adminRequest("GET", "/api/v1/admin/model-config/catalog?provider=anthropic"),
+    );
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("45");
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("byot_provider_rate_limited");
+  });
+
+  it("returns 503 byot_provider_unavailable on upstream outage", async () => {
+    mockGetWorkspaceModelConfigRaw.mockImplementation(() =>
+      Effect.succeed({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        apiKey: "sk-ant-stored",
+        baseUrl: null,
+      }),
+    );
+    mockGetAnthropicCatalog.mockImplementation(() => {
+      throw new MockAnthropicCatalogUnavailable("anthropic returned 503");
+    });
+    const res = await app.fetch(
+      adminRequest("GET", "/api/v1/admin/model-config/catalog?provider=anthropic"),
+    );
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("byot_provider_unavailable");
+  });
+
+  it("emits model_config.catalog_refresh on success with provider + modelCount + source", async () => {
+    mockGetWorkspaceModelConfigRaw.mockImplementation(() =>
+      Effect.succeed({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        apiKey: "sk-ant-stored",
+        baseUrl: null,
+      }),
+    );
+    const res = await app.fetch(
+      adminRequest("GET", "/api/v1/admin/model-config/catalog?provider=anthropic"),
+    );
+    expect(res.status).toBe(200);
+    expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("model_config.catalog_refresh");
+    expect(entry.targetType).toBe("model_config");
+    expect(entry.metadata).toEqual({
+      provider: "anthropic",
+      modelCount: 1,
+      source: "fresh",
+    });
+    // The apiKey must never appear in any captured audit metadata.
+    expect(JSON.stringify(entry)).not.toContain("sk-ant-stored");
+  });
+
+  it("?provider=gateway and the default still return the gateway catalog (backward compat)", async () => {
+    // Default path (no provider param) — should hit the gateway catalog flow,
+    // not touch getWorkspaceModelConfigRaw or getAnthropicCatalog.
+    const res = await app.fetch(adminRequest("GET", "/api/v1/admin/model-config/catalog"));
+    // The real `getGatewayCatalog` is invoked here — it'll either reach the
+    // gateway (test env: false) or fall back to the bundled subset. Either
+    // way we get a 200 with `fallback: true|false`.
+    expect([200, 500]).toContain(res.status);
+    if (res.status === 200) {
+      const body = (await res.json()) as { fallback: boolean };
+      expect(typeof body.fallback).toBe("boolean");
+    }
+    expect(mockGetWorkspaceModelConfigRaw).not.toHaveBeenCalled();
+    expect(mockGetAnthropicCatalog).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/api/routes/admin-model-config.ts
+++ b/packages/api/src/api/routes/admin-model-config.ts
@@ -12,6 +12,7 @@ import { runEffect, domainError } from "@atlas/api/lib/effect/hono";
 import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
 import {
   getWorkspaceModelConfig,
+  getWorkspaceModelConfigRaw,
   setWorkspaceModelConfig,
   deleteWorkspaceModelConfig,
   testModelConfig,
@@ -20,6 +21,12 @@ import {
 import { WorkspaceModelConfigSchema as ModelConfigSchema } from "@useatlas/schemas";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { getGatewayCatalog } from "@atlas/api/lib/gateway-catalog";
+import {
+  AnthropicCatalogRateLimited,
+  AnthropicCatalogUnauthorized,
+  AnthropicCatalogUnavailable,
+  getAnthropicCatalog,
+} from "@atlas/api/lib/anthropic-catalog";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requirePermission } from "./admin-router";
 
@@ -163,18 +170,33 @@ const testConfigRoute = createRoute({
   },
 });
 
+const CatalogQuerySchema = z.object({
+  provider: z.enum(["gateway", "anthropic"]).optional().openapi({
+    description:
+      "Provider catalog to return. Defaults to 'gateway' (Vercel AI Gateway, anonymous). 'anthropic' returns the workspace's catalog from api.anthropic.com/v1/models using the saved BYOT key — requires a saved Anthropic configuration.",
+    example: "anthropic",
+  }),
+  refresh: z.enum(["1", "true"]).optional().openapi({
+    description: "Bypass the catalog cache and force a fresh upstream fetch.",
+  }),
+});
+
 const catalogRoute = createRoute({
   method: "get",
   path: "/catalog",
   tags: ["Admin — Model Config"],
-  summary: "Vercel AI Gateway model catalog",
+  summary: "BYOT model catalog",
   description:
-    "Returns the catalog of models available via the Vercel AI Gateway, grouped by provider. Cached server-side; the `fallback` field is true when the live fetch failed and a bundled subset was returned.",
+    "Returns a model catalog for the requested provider. With no `?provider` (or `?provider=gateway`), returns the Vercel AI Gateway catalog (server-cached; `fallback: true` when the live fetch failed and a bundled subset was returned). With `?provider=anthropic`, returns Anthropic /v1/models for the workspace using its saved BYOT key — requires a saved Anthropic provider configuration.",
+  request: { query: CatalogQuerySchema },
   responses: {
-    200: { description: "Gateway catalog", content: { "application/json": { schema: GatewayCatalogResponseSchema } } },
-    401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
+    200: { description: "Provider catalog", content: { "application/json": { schema: GatewayCatalogResponseSchema } } },
+    400: { description: "Missing BYOT key for the requested provider", content: { "application/json": { schema: ErrorSchema } } },
+    401: { description: "Authentication required — or upstream rejected the BYOT key", content: { "application/json": { schema: AuthErrorSchema } } },
     403: { description: "Forbidden — admin role or enterprise license required", content: { "application/json": { schema: AuthErrorSchema } } },
-    429: { description: "Rate limit exceeded", content: { "application/json": { schema: AuthErrorSchema } } },
+    422: { description: "Stored BYOT key cannot be decrypted (likely key-rotation drift)", content: { "application/json": { schema: ErrorSchema } } },
+    429: { description: "Rate limited — by Atlas or by upstream provider", content: { "application/json": { schema: AuthErrorSchema } } },
+    503: { description: "Upstream provider unavailable", content: { "application/json": { schema: ErrorSchema } } },
     500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
@@ -381,15 +403,174 @@ adminModelConfig.openapi(testConfigRoute, async (c) => {
   }), { label: "test model config", domainErrors: [modelConfigDomainError] });
 });
 
-// GET /catalog — Vercel AI Gateway model catalog (server-cached)
+// GET /catalog — BYOT model catalog (server-cached). Defaults to gateway
+// (anonymous); `?provider=anthropic` returns the workspace's Anthropic
+// /v1/models catalog using the stored BYOT key.
 adminModelConfig.openapi(catalogRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
-    const catalog = yield* Effect.tryPromise({
-      try: () => getGatewayCatalog(),
+    const { requestId } = yield* RequestContext;
+    const { orgId } = yield* AuthContext;
+    const { provider: requestedProvider, refresh: refreshRaw } = c.req.valid("query");
+    const provider = requestedProvider ?? "gateway";
+    const refresh = refreshRaw === "1" || refreshRaw === "true";
+
+    if (provider === "gateway") {
+      const catalog = yield* Effect.tryPromise({
+        try: () => getGatewayCatalog(),
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      });
+      return c.json(catalog, 200);
+    }
+
+    // Anthropic BYOT catalog — requires a saved anthropic configuration.
+    if (!orgId) {
+      return c.json(
+        { error: "bad_request", message: "No active organization. Set an active org first.", requestId },
+        400,
+      );
+    }
+
+    // Decrypt errors surface as 422 with a clear "re-enter the key" message
+    // rather than as a generic 500. Catch inline so the response shape is
+    // colocated with the rest of this route's envelopes.
+    const rawConfigOrDecryptError = yield* getWorkspaceModelConfigRaw(orgId).pipe(
+      Effect.map((cfg) => ({ ok: true as const, cfg })),
+      Effect.catchTag("ModelConfigDecryptError", (err) =>
+        Effect.succeed({ ok: false as const, err }),
+      ),
+    );
+
+    if (!rawConfigOrDecryptError.ok) {
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.model_config.catalogRefresh,
+        targetType: "model_config",
+        targetId: orgId,
+        status: "failure",
+        metadata: { provider: "anthropic", error: "decrypt_failed" },
+      });
+      return c.json(
+        {
+          error: "decrypt_failed",
+          message:
+            "The stored API key could not be decrypted (likely a key-rotation drift). Re-enter the key on the AI Provider page.",
+          requestId,
+        },
+        422,
+      );
+    }
+    const rawConfig = rawConfigOrDecryptError.cfg;
+
+    if (!rawConfig || rawConfig.provider !== "anthropic" || !rawConfig.apiKey) {
+      return c.json(
+        {
+          error: "missing_byot_key",
+          message:
+            "Save an Anthropic API key on this workspace before refreshing the catalog.",
+          requestId,
+        },
+        400,
+      );
+    }
+
+    // Discovery fetches against an external provider are credentialed
+    // operations: same audit threat model as `model_config.test`. Log the
+    // fetch outcome (never the apiKey). The provider-specific exceptions
+    // are caught inside the promise so the Effect channel carries a clean
+    // discriminated result rather than tunneling through `Effect.tryPromise`'s
+    // generic catch (which becomes "unmapped tagged error" at the bridge).
+    type CatalogResult =
+      | { kind: "ok"; models: typeof rawConfig extends never ? never : Awaited<ReturnType<typeof getAnthropicCatalog>>["models"]; fetchedAt: string; source: "cache" | "fresh" }
+      | { kind: "byot_key_invalid"; message: string }
+      | { kind: "byot_provider_rate_limited"; message: string; retryAfter: number | null }
+      | { kind: "byot_provider_unavailable"; message: string };
+
+    const catalogResult = yield* Effect.tryPromise({
+      try: async (): Promise<CatalogResult> => {
+        try {
+          const cat = await getAnthropicCatalog(orgId, rawConfig.apiKey ?? "", {
+            refresh,
+          });
+          return {
+            kind: "ok",
+            models: cat.models,
+            fetchedAt: cat.fetchedAt,
+            source: cat.source,
+          };
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          if (err instanceof AnthropicCatalogUnauthorized) {
+            return { kind: "byot_key_invalid", message };
+          }
+          if (err instanceof AnthropicCatalogRateLimited) {
+            return {
+              kind: "byot_provider_rate_limited",
+              message,
+              retryAfter: err.retryAfterSeconds,
+            };
+          }
+          if (err instanceof AnthropicCatalogUnavailable) {
+            return { kind: "byot_provider_unavailable", message };
+          }
+          throw err;
+        }
+      },
       catch: (err) => (err instanceof Error ? err : new Error(String(err))),
     });
-    return c.json(catalog, 200);
-  }), { label: "get gateway catalog", domainErrors: [modelConfigDomainError] });
+
+    if (catalogResult.kind === "ok") {
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.model_config.catalogRefresh,
+        targetType: "model_config",
+        targetId: orgId,
+        metadata: {
+          provider: "anthropic",
+          modelCount: catalogResult.models.length,
+          source: catalogResult.source,
+        },
+      });
+
+      return c.json(
+        {
+          models: catalogResult.models,
+          fetchedAt: catalogResult.fetchedAt,
+          // Anthropic discovery has no curated fallback — upstream failures
+          // surface as the matching HTTP envelope above. `fallback` stays
+          // false for shape parity with the gateway response.
+          fallback: false,
+        },
+        200,
+      );
+    }
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.model_config.catalogRefresh,
+      targetType: "model_config",
+      targetId: orgId,
+      status: "failure",
+      metadata: {
+        provider: "anthropic",
+        error: catalogResult.kind,
+        detail: catalogResult.message,
+      },
+    });
+
+    if (catalogResult.kind === "byot_key_invalid") {
+      return c.json({ error: "byot_key_invalid", message: catalogResult.message, requestId }, 401);
+    }
+    if (catalogResult.kind === "byot_provider_rate_limited") {
+      if (catalogResult.retryAfter !== null) {
+        c.header("Retry-After", String(catalogResult.retryAfter));
+      }
+      return c.json(
+        { error: "byot_provider_rate_limited", message: catalogResult.message, requestId },
+        429,
+      );
+    }
+    return c.json(
+      { error: "byot_provider_unavailable", message: catalogResult.message, requestId },
+      503,
+    );
+  }), { label: "get model catalog", domainErrors: [modelConfigDomainError] });
 });
 
 export { adminModelConfig };

--- a/packages/api/src/lib/__tests__/anthropic-catalog.test.ts
+++ b/packages/api/src/lib/__tests__/anthropic-catalog.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, beforeEach, describe, expect, test, mock } from "bun:test";
+import {
+  __resetAnthropicCatalogCacheForTests,
+  __getRecommendedAnthropicIdsForTests,
+  AnthropicCatalogRateLimited,
+  AnthropicCatalogUnauthorized,
+  AnthropicCatalogUnavailable,
+  getAnthropicCatalog,
+  invalidateAnthropicCatalog,
+} from "../anthropic-catalog";
+
+type FetchFn = typeof globalThis.fetch;
+const realFetch: FetchFn = globalThis.fetch;
+
+const ORG_A = "org_a";
+const ORG_B = "org_b";
+const KEY = "sk-ant-test-key";
+
+function mockFetchOk(body: unknown): FetchFn {
+  return mock(async (): Promise<Response> => {
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as FetchFn;
+}
+
+function mockFetchStatus(status: number, headers: Record<string, string> = {}): FetchFn {
+  return mock(async (): Promise<Response> => {
+    return new Response("upstream", { status, headers });
+  }) as unknown as FetchFn;
+}
+
+describe("anthropic-catalog", () => {
+  beforeEach(() => {
+    __resetAnthropicCatalogCacheForTests();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    __resetAnthropicCatalogCacheForTests();
+  });
+
+  test("normalizes a live /v1/models payload", async () => {
+    globalThis.fetch = mockFetchOk({
+      data: [
+        { type: "model", id: "claude-opus-4-6", display_name: "Claude Opus 4.6" },
+        { type: "model", id: "claude-sonnet-4-6", display_name: "Claude Sonnet 4.6" },
+        // Entry without id is dropped.
+        { type: "model", display_name: "Phantom" },
+      ],
+    });
+
+    const res = await getAnthropicCatalog(ORG_A, KEY);
+    expect(res.source).toBe("fresh");
+    expect(res.models).toHaveLength(2);
+    const opus = res.models.find((m) => m.id === "claude-opus-4-6");
+    expect(opus?.name).toBe("Claude Opus 4.6");
+    expect(opus?.provider).toBe("anthropic");
+    expect(opus?.type).toBe("language");
+    expect(opus?.recommended).toBe(true);
+  });
+
+  test("falls back to id when display_name is missing", async () => {
+    globalThis.fetch = mockFetchOk({
+      data: [{ type: "model", id: "claude-future-model" }],
+    });
+    const res = await getAnthropicCatalog(ORG_A, KEY);
+    expect(res.models[0].name).toBe("claude-future-model");
+    expect(res.models[0].recommended).toBe(false);
+  });
+
+  test("401 surfaces AnthropicCatalogUnauthorized", async () => {
+    globalThis.fetch = mockFetchStatus(401);
+    await expect(getAnthropicCatalog(ORG_A, "bad-key")).rejects.toBeInstanceOf(
+      AnthropicCatalogUnauthorized,
+    );
+  });
+
+  test("403 also surfaces AnthropicCatalogUnauthorized", async () => {
+    globalThis.fetch = mockFetchStatus(403);
+    await expect(getAnthropicCatalog(ORG_A, "bad-key")).rejects.toBeInstanceOf(
+      AnthropicCatalogUnauthorized,
+    );
+  });
+
+  test("429 surfaces AnthropicCatalogRateLimited with retry-after parsed", async () => {
+    globalThis.fetch = mockFetchStatus(429, { "retry-after": "30" });
+    try {
+      await getAnthropicCatalog(ORG_A, KEY);
+      throw new Error("expected rate-limit throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(AnthropicCatalogRateLimited);
+      if (err instanceof AnthropicCatalogRateLimited) {
+        expect(err.retryAfterSeconds).toBe(30);
+      }
+    }
+  });
+
+  test("429 without retry-after still surfaces AnthropicCatalogRateLimited", async () => {
+    globalThis.fetch = mockFetchStatus(429);
+    try {
+      await getAnthropicCatalog(ORG_A, KEY);
+      throw new Error("expected rate-limit throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(AnthropicCatalogRateLimited);
+      if (err instanceof AnthropicCatalogRateLimited) {
+        expect(err.retryAfterSeconds).toBeNull();
+      }
+    }
+  });
+
+  test("503 surfaces AnthropicCatalogUnavailable", async () => {
+    globalThis.fetch = mockFetchStatus(503);
+    await expect(getAnthropicCatalog(ORG_A, KEY)).rejects.toBeInstanceOf(
+      AnthropicCatalogUnavailable,
+    );
+  });
+
+  test("network failure surfaces AnthropicCatalogUnavailable", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as FetchFn;
+    await expect(getAnthropicCatalog(ORG_A, KEY)).rejects.toBeInstanceOf(
+      AnthropicCatalogUnavailable,
+    );
+  });
+
+  test("malformed `data` field surfaces AnthropicCatalogUnavailable", async () => {
+    globalThis.fetch = mockFetchOk({ data: "not-an-array" });
+    await expect(getAnthropicCatalog(ORG_A, KEY)).rejects.toBeInstanceOf(
+      AnthropicCatalogUnavailable,
+    );
+  });
+
+  test("caches a successful fetch per orgId", async () => {
+    const fetchMock = mock(
+      async () =>
+        new Response(JSON.stringify({ data: [{ id: "claude-opus-4-6" }] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    globalThis.fetch = fetchMock as unknown as FetchFn;
+
+    const first = await getAnthropicCatalog(ORG_A, KEY);
+    const second = await getAnthropicCatalog(ORG_A, KEY);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(first.source).toBe("fresh");
+    expect(second.source).toBe("cache");
+  });
+
+  test("cache is scoped per orgId", async () => {
+    const fetchMock = mock(
+      async () =>
+        new Response(JSON.stringify({ data: [{ id: "claude-opus-4-6" }] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    globalThis.fetch = fetchMock as unknown as FetchFn;
+
+    await getAnthropicCatalog(ORG_A, KEY);
+    await getAnthropicCatalog(ORG_B, KEY);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("opts.refresh bypasses the cache", async () => {
+    const fetchMock = mock(
+      async () =>
+        new Response(JSON.stringify({ data: [{ id: "claude-opus-4-6" }] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    globalThis.fetch = fetchMock as unknown as FetchFn;
+
+    await getAnthropicCatalog(ORG_A, KEY);
+    const refreshed = await getAnthropicCatalog(ORG_A, KEY, { refresh: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(refreshed.source).toBe("fresh");
+  });
+
+  test("invalidateAnthropicCatalog forces a re-fetch on next call", async () => {
+    const fetchMock = mock(
+      async () =>
+        new Response(JSON.stringify({ data: [{ id: "claude-opus-4-6" }] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    globalThis.fetch = fetchMock as unknown as FetchFn;
+
+    await getAnthropicCatalog(ORG_A, KEY);
+    invalidateAnthropicCatalog(ORG_A);
+    const second = await getAnthropicCatalog(ORG_A, KEY);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(second.source).toBe("fresh");
+  });
+
+  test("concurrent fetches for the same org dedupe to one upstream call", async () => {
+    type ResolveBody = (value: Response) => void;
+    const pending = Promise.withResolvers<Response>();
+    const slowFetch: FetchFn = mock(() => pending.promise) as unknown as FetchFn;
+    globalThis.fetch = slowFetch;
+
+    const p1 = getAnthropicCatalog(ORG_A, KEY);
+    const p2 = getAnthropicCatalog(ORG_A, KEY);
+
+    // Resolve the in-flight fetch once; both callers must share the result.
+    (pending.resolve as ResolveBody)(
+      new Response(JSON.stringify({ data: [{ id: "claude-opus-4-6" }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(slowFetch).toHaveBeenCalledTimes(1);
+    expect(r1.models[0].id).toBe("claude-opus-4-6");
+    expect(r2.models[0].id).toBe("claude-opus-4-6");
+  });
+
+  test("recommended set is non-empty and stable", () => {
+    const ids = __getRecommendedAnthropicIdsForTests();
+    expect(ids.size).toBeGreaterThan(0);
+    expect(ids.has("claude-opus-4-6")).toBe(true);
+  });
+});

--- a/packages/api/src/lib/anthropic-catalog.ts
+++ b/packages/api/src/lib/anthropic-catalog.ts
@@ -1,0 +1,247 @@
+/**
+ * Anthropic BYOT `/v1/models` discovery + per-workspace cache.
+ *
+ * Workspaces using `provider='anthropic'` save their own API key. We fetch
+ * the model catalog from Anthropic with that key and cache it per orgId
+ * with a configurable TTL (`ATLAS_BYOT_CATALOG_TTL_MS`, default 6h).
+ *
+ * Failure shape differs from `gateway-catalog`: gateway is anonymous and
+ * we fall back to a curated bundle on outage. Anthropic discovery is
+ * keyed by the workspace's secret — a 401/403 means the key is bad,
+ * surfacing that to the admin is the whole point. Tagged errors carry
+ * the classification up to the route layer; the route maps them to the
+ * matching HTTP envelope.
+ *
+ * Cache invalidation: `setWorkspaceModelConfig` calls
+ * `invalidateAnthropicCatalog(orgId)` after a successful upsert so a key
+ * rotation flushes the stale entry. Otherwise a rotated key would
+ * authenticate but the catalog would stay frozen until TTL elapsed —
+ * confusing if the rotation was *because* the old key was scoped wrong.
+ */
+
+import type { GatewayCatalogModel } from "@useatlas/types";
+import { createLogger } from "./logger";
+
+const log = createLogger("anthropic-catalog");
+
+const ANTHROPIC_MODELS_URL = "https://api.anthropic.com/v1/models";
+const ANTHROPIC_API_VERSION = "2023-06-01";
+const DEFAULT_TTL_MS = 6 * 60 * 60 * 1_000; // 6 hours
+const FETCH_TIMEOUT_MS = 10_000;
+
+/**
+ * Curated subset surfaced as "recommended" in the picker. IDs match the
+ * Anthropic /v1/models response. Anchor on flagship + cheap-fast pair.
+ */
+const RECOMMENDED_MODEL_IDS: ReadonlySet<string> = new Set([
+  "claude-opus-4-6",
+  "claude-sonnet-4-6",
+  "claude-haiku-4-5",
+]);
+
+export class AnthropicCatalogUnauthorized extends Error {
+  readonly _tag = "AnthropicCatalogUnauthorized";
+  constructor(message: string) {
+    super(message);
+    this.name = "AnthropicCatalogUnauthorized";
+  }
+}
+
+export class AnthropicCatalogRateLimited extends Error {
+  readonly _tag = "AnthropicCatalogRateLimited";
+  readonly retryAfterSeconds: number | null;
+  constructor(message: string, retryAfterSeconds: number | null) {
+    super(message);
+    this.name = "AnthropicCatalogRateLimited";
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}
+
+export class AnthropicCatalogUnavailable extends Error {
+  readonly _tag = "AnthropicCatalogUnavailable";
+  constructor(message: string) {
+    super(message);
+    this.name = "AnthropicCatalogUnavailable";
+  }
+}
+
+interface RawAnthropicModel {
+  id?: unknown;
+  display_name?: unknown;
+  type?: unknown;
+  created_at?: unknown;
+}
+
+export interface AnthropicCatalogResponse {
+  models: GatewayCatalogModel[];
+  fetchedAt: string;
+  source: "cache" | "fresh";
+}
+
+interface CacheEntry {
+  models: GatewayCatalogModel[];
+  fetchedAt: string;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+const inflight = new Map<string, Promise<CacheEntry>>();
+
+function ttlMs(): number {
+  const raw = process.env.ATLAS_BYOT_CATALOG_TTL_MS;
+  if (!raw) return DEFAULT_TTL_MS;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TTL_MS;
+}
+
+function normalizeEntry(raw: RawAnthropicModel): GatewayCatalogModel | null {
+  if (typeof raw.id !== "string" || raw.id.length === 0) return null;
+  const id = raw.id;
+  const displayName = typeof raw.display_name === "string" && raw.display_name.length > 0
+    ? raw.display_name
+    : id;
+  return {
+    id,
+    name: displayName,
+    provider: "anthropic",
+    type: "language",
+    contextWindow: null,
+    maxOutputTokens: null,
+    inputPrice: null,
+    outputPrice: null,
+    recommended: RECOMMENDED_MODEL_IDS.has(id),
+  };
+}
+
+async function fetchAnthropicModels(apiKey: string): Promise<GatewayCatalogModel[]> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(ANTHROPIC_MODELS_URL, {
+      signal: controller.signal,
+      headers: {
+        "x-api-key": apiKey,
+        "anthropic-version": ANTHROPIC_API_VERSION,
+        accept: "application/json",
+      },
+    });
+
+    if (res.status === 401 || res.status === 403) {
+      throw new AnthropicCatalogUnauthorized(
+        "Anthropic rejected the workspace API key. Verify it on the AI Provider page.",
+      );
+    }
+    if (res.status === 429) {
+      const retryAfterRaw = res.headers.get("retry-after");
+      const retryAfterSeconds = retryAfterRaw ? Number.parseInt(retryAfterRaw, 10) : null;
+      throw new AnthropicCatalogRateLimited(
+        "Anthropic rate-limited the catalog refresh. Try again shortly.",
+        Number.isFinite(retryAfterSeconds) ? retryAfterSeconds : null,
+      );
+    }
+    if (!res.ok) {
+      throw new AnthropicCatalogUnavailable(
+        `Anthropic /v1/models returned ${res.status}. Try again shortly.`,
+      );
+    }
+
+    const body = (await res.json()) as { data?: unknown };
+    if (!Array.isArray(body.data)) {
+      throw new AnthropicCatalogUnavailable(
+        "Anthropic /v1/models response missing `data` array.",
+      );
+    }
+
+    const normalized: GatewayCatalogModel[] = [];
+    let dropped = 0;
+    for (const entry of body.data) {
+      const model = entry && typeof entry === "object"
+        ? normalizeEntry(entry as RawAnthropicModel)
+        : null;
+      if (model) normalized.push(model);
+      else dropped += 1;
+    }
+    if (dropped > 0) {
+      log.warn(
+        { dropped, kept: normalized.length },
+        "anthropic-catalog: dropped malformed entries from upstream",
+      );
+    }
+    return normalized;
+  } catch (err) {
+    if (
+      err instanceof AnthropicCatalogUnauthorized ||
+      err instanceof AnthropicCatalogRateLimited ||
+      err instanceof AnthropicCatalogUnavailable
+    ) {
+      throw err;
+    }
+    // AbortError / network failures land here. Map to unavailable so the
+    // route surfaces a 503 with a clean message rather than a 500.
+    const message = err instanceof Error ? err.message : String(err);
+    throw new AnthropicCatalogUnavailable(`Anthropic /v1/models fetch failed: ${message}`);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Return the workspace's cached Anthropic catalog if fresh, otherwise
+ * fetch from Anthropic with the supplied BYOT key. Concurrent callers
+ * for the same orgId share a single inflight fetch.
+ *
+ * `opts.refresh` bypasses the cache and forces a fresh fetch (used for
+ * the explicit "Refresh now" admin action).
+ */
+export async function getAnthropicCatalog(
+  orgId: string,
+  apiKey: string,
+  opts: { refresh?: boolean } = {},
+): Promise<AnthropicCatalogResponse> {
+  if (!opts.refresh) {
+    const hit = cache.get(orgId);
+    if (hit && hit.expiresAt > Date.now()) {
+      return { models: hit.models, fetchedAt: hit.fetchedAt, source: "cache" };
+    }
+  }
+
+  let pending = inflight.get(orgId);
+  if (!pending) {
+    pending = (async (): Promise<CacheEntry> => {
+      const models = await fetchAnthropicModels(apiKey);
+      const now = Date.now();
+      const entry: CacheEntry = {
+        models,
+        fetchedAt: new Date(now).toISOString(),
+        expiresAt: now + ttlMs(),
+      };
+      cache.set(orgId, entry);
+      return entry;
+    })().finally(() => {
+      inflight.delete(orgId);
+    });
+    inflight.set(orgId, pending);
+  }
+  const entry = await pending;
+  return { models: entry.models, fetchedAt: entry.fetchedAt, source: "fresh" };
+}
+
+/**
+ * Drop the cached catalog for an org. Called from
+ * `setWorkspaceModelConfig` after a successful upsert so a key rotation
+ * doesn't serve a stale catalog from before the rotation.
+ */
+export function invalidateAnthropicCatalog(orgId: string): void {
+  cache.delete(orgId);
+}
+
+/** Test-only: clear all cached entries. */
+export function __resetAnthropicCatalogCacheForTests(): void {
+  cache.clear();
+  inflight.clear();
+}
+
+/** Test-only: inspect the curated recommended list. */
+export function __getRecommendedAnthropicIdsForTests(): ReadonlySet<string> {
+  return RECOMMENDED_MODEL_IDS;
+}

--- a/packages/api/src/lib/audit/__tests__/admin.test.ts
+++ b/packages/api/src/lib/audit/__tests__/admin.test.ts
@@ -296,10 +296,11 @@ describe("ADMIN_ACTIONS catalog — BYOT credential audit", () => {
     expect(ADMIN_ACTIONS.email_provider.test).toBe("email_provider.test");
   });
 
-  it("defines model_config.update / delete / test", () => {
+  it("defines model_config.update / delete / test / catalog_refresh", () => {
     expect(ADMIN_ACTIONS.model_config.update).toBe("model_config.update");
     expect(ADMIN_ACTIONS.model_config.delete).toBe("model_config.delete");
     expect(ADMIN_ACTIONS.model_config.test).toBe("model_config.test");
+    expect(ADMIN_ACTIONS.model_config.catalogRefresh).toBe("model_config.catalog_refresh");
   });
 });
 

--- a/packages/api/src/lib/audit/actions.ts
+++ b/packages/api/src/lib/audit/actions.ts
@@ -584,6 +584,15 @@ export const ADMIN_ACTIONS = {
     update: "model_config.update",
     delete: "model_config.delete",
     test: "model_config.test",
+    /**
+     * BYOT discovery refresh (#2271) — workspace's saved provider key is used
+     * to fetch the upstream model catalog (Anthropic /v1/models, etc.).
+     * Metadata carries `{ provider, modelCount, source: 'cache' | 'fresh' }`;
+     * the apiKey is never logged. Audited because the discovery call exercises
+     * the stored credential server-side and a misconfigured key (401) is the
+     * same forensic signal as a `model_config.test` failure.
+     */
+    catalogRefresh: "model_config.catalog_refresh",
   },
   /**
    * Workspace white-label branding. Enterprise-gated. Without these entries

--- a/packages/web/src/app/admin/model-config/page.tsx
+++ b/packages/web/src/app/admin/model-config/page.tsx
@@ -121,9 +121,9 @@ export default function ModelConfigPage() {
     { schema: ModelConfigResponseSchema },
   );
 
-  // Catalog only matters when the user is on or considering the gateway
-  // provider, but fetching it eagerly keeps the picker responsive on first
-  // toggle. The endpoint is server-cached so the cost is one cold hit.
+  // Gateway catalog (anonymous, server-cached) — fetched eagerly so the
+  // picker is responsive on first toggle. The endpoint is server-cached so
+  // the cost is one cold hit per pod.
   const {
     data: catalog,
     loading: catalogLoading,
@@ -131,6 +131,27 @@ export default function ModelConfigPage() {
   } = useAdminFetch(
     "/api/v1/admin/model-config/catalog",
     { schema: GatewayCatalogResponseSchema },
+  );
+
+  // Anthropic BYOT catalog (#2271) — only fetched when the workspace has a
+  // saved Anthropic configuration with a healthy key. Without these
+  // preconditions the endpoint would return 400 `missing_byot_key` on every
+  // page load, which would surface as a noisy error banner. Gating with
+  // `enabled` keeps the request firmly tied to the picker's render gate.
+  const existingConfigForGate = data?.config ?? null;
+  const anthropicCatalogEnabled =
+    existingConfigForGate?.provider === "anthropic" &&
+    existingConfigForGate.apiKeyStatus === "masked";
+  const {
+    data: anthropicCatalog,
+    loading: anthropicCatalogLoading,
+    refetch: refetchAnthropicCatalog,
+  } = useAdminFetch(
+    "/api/v1/admin/model-config/catalog?provider=anthropic",
+    {
+      schema: GatewayCatalogResponseSchema,
+      enabled: anthropicCatalogEnabled,
+    },
   );
 
   // Billing drives the BYOT gate + the platform-default label. 404 means
@@ -290,6 +311,13 @@ export default function ModelConfigPage() {
 
   const currentProvider = form.watch("provider");
   const isGateway = currentProvider === "gateway";
+  // Anthropic picker requires the saved config to also be anthropic — we use
+  // the workspace's stored BYOT key for the discovery call. Switching the
+  // form to anthropic without saving falls back to the free-text input.
+  const showAnthropicPicker =
+    currentProvider === "anthropic" &&
+    existingConfig?.provider === "anthropic" &&
+    existingConfig?.apiKeyStatus === "masked";
   const saveDisabled =
     saving ||
     !form.watch("model").trim() ||
@@ -575,6 +603,14 @@ export default function ModelConfigPage() {
                                   fallback={catalog?.fallback}
                                   onRetry={refetchCatalog}
                                 />
+                              ) : showAnthropicPicker ? (
+                                <GatewayModelPicker
+                                  models={anthropicCatalog?.models ?? []}
+                                  value={field.value}
+                                  onChange={field.onChange}
+                                  loading={anthropicCatalogLoading}
+                                  onRetry={refetchAnthropicCatalog}
+                                />
                               ) : (
                                 <Input
                                   placeholder={
@@ -589,6 +625,18 @@ export default function ModelConfigPage() {
                                 />
                               )}
                             </FormControl>
+                            {showAnthropicPicker && anthropicCatalog && (
+                              <CatalogFreshness
+                                fetchedAt={anthropicCatalog.fetchedAt}
+                                onRefresh={refetchAnthropicCatalog}
+                                refreshing={anthropicCatalogLoading}
+                              />
+                            )}
+                            {currentProvider === "anthropic" && !showAnthropicPicker && (
+                              <FormDescription>
+                                Save your Anthropic API key first to pick from the live model catalog.
+                              </FormDescription>
+                            )}
                             <FormMessage />
                           </FormItem>
                         )}
@@ -701,4 +749,46 @@ export default function ModelConfigPage() {
       </ErrorBoundary>
     </div>
   );
+}
+
+// Picker freshness footer — surfaces "last refreshed N hours ago" + a manual
+// refresh action for BYOT catalogs (#2271). The discovery cache TTLs at 6h
+// server-side; this gives admins a way to force a fresh fetch when they've
+// rotated keys or seen a new model land upstream.
+function CatalogFreshness({
+  fetchedAt,
+  onRefresh,
+  refreshing,
+}: {
+  fetchedAt: string;
+  onRefresh: () => void;
+  refreshing: boolean;
+}) {
+  const relative = relativeTime(fetchedAt);
+  return (
+    <div className="mt-1.5 flex items-center justify-between text-[11px] text-muted-foreground">
+      <span>Last refreshed {relative}</span>
+      <button
+        type="button"
+        onClick={onRefresh}
+        disabled={refreshing}
+        className="inline-flex items-center gap-1 font-medium underline-offset-2 hover:underline disabled:opacity-50"
+      >
+        {refreshing && <Loader2 className="size-3 animate-spin" />}
+        Refresh now
+      </button>
+    </div>
+  );
+}
+
+function relativeTime(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime();
+  if (!Number.isFinite(diffMs) || diffMs < 0) return "just now";
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? "" : "s"} ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} hour${hours === 1 ? "" : "s"} ago`;
+  const days = Math.floor(hours / 24);
+  return `${days} day${days === 1 ? "" : "s"} ago`;
 }


### PR DESCRIPTION
## Summary

- First direct-provider slice of #2174 BYOT (after the gateway BYOT shipped in #2173). Establishes the per-workspace discovery pattern that the OpenAI / Bedrock / cache-promotion / unknown-model-handling slices (#2272–#2275) will reuse.
- `packages/api/src/lib/anthropic-catalog.ts` — fetches Anthropic `/v1/models` with the workspace's BYOT key, in-memory cache keyed by `orgId` with 6h TTL (`ATLAS_BYOT_CATALOG_TTL_MS`). Tagged failure classes for 401 / 429 (with `Retry-After`) / 5xx so the route maps cleanly to envelopes.
- `GET /api/v1/admin/model-config/catalog?provider=anthropic[&refresh=1]` — reads the workspace's stored Anthropic key via `getWorkspaceModelConfigRaw` and returns the catalog. Decrypt drift surfaces as **422** with a re-enter-key message; missing key → **400 `missing_byot_key`**. Default (no `?provider`) still returns the gateway catalog (backward-compat for the existing UI fetch).
- `setWorkspaceModelConfig` calls `invalidateAnthropicCatalog(orgId)` on upsert so a key rotation doesn't serve a stale catalog from before the rotation.
- New audit action `model_config.catalog_refresh` records the fetch outcome (`{ provider, modelCount, source, error? }`) — apiKey is never logged, matching the `model_config.test` threat model.
- `/admin/model-config` swaps the free-text input for `<GatewayModelPicker>` when the saved provider is anthropic with a healthy key. Adds a "Last refreshed N ago / Refresh now" footer.

Closes #2271. Parent #2174 stays open until #2272–#2275 land.

## Test plan
- [x] `bun test src/lib/__tests__/anthropic-catalog.test.ts` — 15 unit tests cover normalization, 401/403/429 (with and without Retry-After) / 5xx / network / malformed-data paths, per-orgId scoping, refresh bypasses cache, invalidation forces re-fetch, and the inflight-promise dedup.
- [x] `bun test src/api/__tests__/admin-model-config.test.ts` — 24/24 tests pass; new block covers the `?provider=anthropic` flow end-to-end (success / 400 missing key / 400 wrong provider / 422 decrypt / 401 / 429 with Retry-After / 503 / audit emissions / backward-compat default).
- [x] `bun run type` (root) — tsgo + web typecheck both green.
- [x] `bun run lint` — clean.
- [x] `bun run scripts/test-isolated.ts --affected` (packages/api) — 56/56 affected suites pass.
- [x] `bun run --filter '@atlas/web' test` — 133/133 pass.
- [x] `scripts/check-schema-drift.sh` + `scripts/check-template-drift.sh` — both pass.
- [x] OpenAPI spec regenerated (`bun run openapi:extract`).
- [ ] Manual: save an Anthropic BYOT key on a SaaS workspace → confirm picker renders the upstream model list, "Refresh now" forces a fresh fetch, rotate the key and confirm the cache is invalidated.