### PR TITLE
feat(api,web,admin): #2272 — OpenAI BYOT + /v1/models discovery picker

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -31172,13 +31172,14 @@
               "type": "string",
               "enum": [
                 "gateway",
-                "anthropic"
+                "anthropic",
+                "openai"
               ],
-              "description": "Provider catalog to return. Defaults to 'gateway' (Vercel AI Gateway, anonymous). 'anthropic' returns the workspace's catalog from api.anthropic.com/v1/models using the saved BYOT key — requires a saved Anthropic configuration.",
+              "description": "Provider catalog to return. Defaults to 'gateway' (Vercel AI Gateway, anonymous). 'anthropic' returns api.anthropic.com/v1/models; 'openai' returns api.openai.com/v1/models filtered to chat-capable models. Both BYOT variants use the workspace's saved key and require a matching saved configuration.",
               "example": "anthropic"
             },
             "required": false,
-            "description": "Provider catalog to return. Defaults to 'gateway' (Vercel AI Gateway, anonymous). 'anthropic' returns the workspace's catalog from api.anthropic.com/v1/models using the saved BYOT key — requires a saved Anthropic configuration.",
+            "description": "Provider catalog to return. Defaults to 'gateway' (Vercel AI Gateway, anonymous). 'anthropic' returns api.anthropic.com/v1/models; 'openai' returns api.openai.com/v1/models filtered to chat-capable models. Both BYOT variants use the workspace's saved key and require a matching saved configuration.",
             "name": "provider",
             "in": "query"
           },

--- a/ee/src/platform/model-routing.ts
+++ b/ee/src/platform/model-routing.ts
@@ -23,6 +23,7 @@ import {
 import { activeKeyVersion } from "@atlas/api/lib/db/encryption-keys";
 import { getGatewayCatalog } from "@atlas/api/lib/gateway-catalog";
 import { invalidateAnthropicCatalog } from "@atlas/api/lib/anthropic-catalog";
+import { invalidateOpenAICatalog } from "@atlas/api/lib/openai-catalog";
 import { createLogger } from "@atlas/api/lib/logger";
 import type {
   ApiKeyStatus,
@@ -381,6 +382,8 @@ export const setWorkspaceModelConfig = (
     // per-org cache so it gets no hook.
     if (config.provider === "anthropic") {
       invalidateAnthropicCatalog(orgId);
+    } else if (config.provider === "openai") {
+      invalidateOpenAICatalog(orgId);
     }
 
     return rowToConfig(rows[0]);

--- a/packages/api/src/api/__tests__/admin-model-config.test.ts
+++ b/packages/api/src/api/__tests__/admin-model-config.test.ts
@@ -189,6 +189,62 @@ mock.module("@atlas/api/lib/anthropic-catalog", () => ({
   AnthropicCatalogUnavailable: MockAnthropicCatalogUnavailable,
 }));
 
+// --- OpenAI catalog mocks (mirror Anthropic — same threat model + envelope). ---
+class MockOpenAICatalogUnauthorized extends Error {
+  readonly _tag = "OpenAICatalogUnauthorized" as const;
+  constructor(message: string) {
+    super(message);
+    this.name = "OpenAICatalogUnauthorized";
+  }
+}
+class MockOpenAICatalogRateLimited extends Error {
+  readonly _tag = "OpenAICatalogRateLimited" as const;
+  readonly retryAfterSeconds: number | null;
+  constructor(message: string, retryAfterSeconds: number | null) {
+    super(message);
+    this.name = "OpenAICatalogRateLimited";
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}
+class MockOpenAICatalogUnavailable extends Error {
+  readonly _tag = "OpenAICatalogUnavailable" as const;
+  constructor(message: string) {
+    super(message);
+    this.name = "OpenAICatalogUnavailable";
+  }
+}
+
+const mockGetOpenAICatalog: Mock<(...args: unknown[]) => unknown> = mock(
+  async () => ({
+    models: [
+      {
+        id: "gpt-4o",
+        name: "gpt-4o",
+        provider: "openai",
+        type: "language",
+        contextWindow: null,
+        maxOutputTokens: null,
+        inputPrice: null,
+        outputPrice: null,
+        recommended: true,
+      },
+    ],
+    fetchedAt: "2026-05-11T00:00:00.000Z",
+    source: "fresh" as const,
+  }),
+);
+const mockInvalidateOpenAICatalog: Mock<(orgId: string) => void> = mock(
+  () => {},
+);
+
+mock.module("@atlas/api/lib/openai-catalog", () => ({
+  getOpenAICatalog: mockGetOpenAICatalog,
+  invalidateOpenAICatalog: mockInvalidateOpenAICatalog,
+  OpenAICatalogUnauthorized: MockOpenAICatalogUnauthorized,
+  OpenAICatalogRateLimited: MockOpenAICatalogRateLimited,
+  OpenAICatalogUnavailable: MockOpenAICatalogUnavailable,
+}));
+
 // --- Import the app AFTER all mocks ---
 const { app } = await import("../index");
 
@@ -231,6 +287,25 @@ beforeEach(() => {
         id: "claude-opus-4-6",
         name: "Claude Opus 4.6",
         provider: "anthropic",
+        type: "language",
+        contextWindow: null,
+        maxOutputTokens: null,
+        inputPrice: null,
+        outputPrice: null,
+        recommended: true,
+      },
+    ],
+    fetchedAt: "2026-05-11T00:00:00.000Z",
+    source: "fresh" as const,
+  }));
+  mockGetOpenAICatalog.mockClear();
+  mockInvalidateOpenAICatalog.mockClear();
+  mockGetOpenAICatalog.mockImplementation(async () => ({
+    models: [
+      {
+        id: "gpt-4o",
+        name: "gpt-4o",
+        provider: "openai",
         type: "language",
         contextWindow: null,
         maxOutputTokens: null,
@@ -827,5 +902,147 @@ describe("GET /api/v1/admin/model-config/catalog?provider=anthropic", () => {
     }
     expect(mockGetWorkspaceModelConfigRaw).not.toHaveBeenCalled();
     expect(mockGetAnthropicCatalog).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/admin/model-config/catalog?provider=openai (#2272)
+// ---------------------------------------------------------------------------
+
+describe("GET /api/v1/admin/model-config/catalog?provider=openai", () => {
+  it("returns the workspace's openai catalog using the stored BYOT key", async () => {
+    mockGetWorkspaceModelConfigRaw.mockImplementation(() =>
+      Effect.succeed({
+        provider: "openai",
+        model: "gpt-4o",
+        apiKey: "sk-oai-stored",
+        baseUrl: null,
+      }),
+    );
+    const res = await app.fetch(
+      adminRequest("GET", "/api/v1/admin/model-config/catalog?provider=openai"),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      models: { id: string; provider: string }[];
+      fallback: boolean;
+    };
+    expect(body.models[0].id).toBe("gpt-4o");
+    expect(body.models[0].provider).toBe("openai");
+    expect(body.fallback).toBe(false);
+    expect(mockGetOpenAICatalog).toHaveBeenCalledTimes(1);
+    const args = mockGetOpenAICatalog.mock.calls[0]! as unknown as [
+      string,
+      string,
+      { refresh?: boolean } | undefined,
+    ];
+    expect(args[1]).toBe("sk-oai-stored");
+    expect(args[2]).toEqual({ refresh: false });
+  });
+
+  it("returns 400 missing_byot_key when saved provider is not openai", async () => {
+    mockGetWorkspaceModelConfigRaw.mockImplementation(() =>
+      Effect.succeed({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        apiKey: "sk-ant-stored",
+        baseUrl: null,
+      }),
+    );
+    const res = await app.fetch(
+      adminRequest("GET", "/api/v1/admin/model-config/catalog?provider=openai"),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body.error).toBe("missing_byot_key");
+    expect(body.message).toMatch(/openai/i);
+  });
+
+  it("returns 401 byot_key_invalid when OpenAI rejects the key", async () => {
+    mockGetWorkspaceModelConfigRaw.mockImplementation(() =>
+      Effect.succeed({
+        provider: "openai",
+        model: "gpt-4o",
+        apiKey: "sk-oai-rotten",
+        baseUrl: null,
+      }),
+    );
+    mockGetOpenAICatalog.mockImplementation(() => {
+      throw new MockOpenAICatalogUnauthorized("rejected by openai");
+    });
+    const res = await app.fetch(
+      adminRequest("GET", "/api/v1/admin/model-config/catalog?provider=openai"),
+    );
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("byot_key_invalid");
+    const entry = lastAuditCall();
+    expect(entry.metadata).toMatchObject({ provider: "openai", error: "byot_key_invalid" });
+    // apiKey must never appear in audit metadata.
+    expect(JSON.stringify(entry)).not.toContain("sk-oai-rotten");
+  });
+
+  it("returns 429 with Retry-After when OpenAI rate-limits the workspace", async () => {
+    mockGetWorkspaceModelConfigRaw.mockImplementation(() =>
+      Effect.succeed({
+        provider: "openai",
+        model: "gpt-4o",
+        apiKey: "sk-oai-stored",
+        baseUrl: null,
+      }),
+    );
+    mockGetOpenAICatalog.mockImplementation(() => {
+      throw new MockOpenAICatalogRateLimited("slow down", 90);
+    });
+    const res = await app.fetch(
+      adminRequest("GET", "/api/v1/admin/model-config/catalog?provider=openai"),
+    );
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("90");
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("byot_provider_rate_limited");
+  });
+
+  it("returns 503 byot_provider_unavailable on upstream outage", async () => {
+    mockGetWorkspaceModelConfigRaw.mockImplementation(() =>
+      Effect.succeed({
+        provider: "openai",
+        model: "gpt-4o",
+        apiKey: "sk-oai-stored",
+        baseUrl: null,
+      }),
+    );
+    mockGetOpenAICatalog.mockImplementation(() => {
+      throw new MockOpenAICatalogUnavailable("openai returned 503");
+    });
+    const res = await app.fetch(
+      adminRequest("GET", "/api/v1/admin/model-config/catalog?provider=openai"),
+    );
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("byot_provider_unavailable");
+  });
+
+  it("emits model_config.catalog_refresh with provider:'openai' on success", async () => {
+    mockGetWorkspaceModelConfigRaw.mockImplementation(() =>
+      Effect.succeed({
+        provider: "openai",
+        model: "gpt-4o",
+        apiKey: "sk-oai-stored",
+        baseUrl: null,
+      }),
+    );
+    const res = await app.fetch(
+      adminRequest("GET", "/api/v1/admin/model-config/catalog?provider=openai"),
+    );
+    expect(res.status).toBe(200);
+    const entry = lastAuditCall();
+    expect(entry.actionType).toBe("model_config.catalog_refresh");
+    expect(entry.metadata).toEqual({
+      provider: "openai",
+      modelCount: 1,
+      source: "fresh",
+    });
+    expect(JSON.stringify(entry)).not.toContain("sk-oai-stored");
   });
 });

--- a/packages/api/src/api/routes/admin-model-config.ts
+++ b/packages/api/src/api/routes/admin-model-config.ts
@@ -27,6 +27,12 @@ import {
   AnthropicCatalogUnavailable,
   getAnthropicCatalog,
 } from "@atlas/api/lib/anthropic-catalog";
+import {
+  OpenAICatalogRateLimited,
+  OpenAICatalogUnauthorized,
+  OpenAICatalogUnavailable,
+  getOpenAICatalog,
+} from "@atlas/api/lib/openai-catalog";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requirePermission } from "./admin-router";
 
@@ -171,9 +177,9 @@ const testConfigRoute = createRoute({
 });
 
 const CatalogQuerySchema = z.object({
-  provider: z.enum(["gateway", "anthropic"]).optional().openapi({
+  provider: z.enum(["gateway", "anthropic", "openai"]).optional().openapi({
     description:
-      "Provider catalog to return. Defaults to 'gateway' (Vercel AI Gateway, anonymous). 'anthropic' returns the workspace's catalog from api.anthropic.com/v1/models using the saved BYOT key — requires a saved Anthropic configuration.",
+      "Provider catalog to return. Defaults to 'gateway' (Vercel AI Gateway, anonymous). 'anthropic' returns api.anthropic.com/v1/models; 'openai' returns api.openai.com/v1/models filtered to chat-capable models. Both BYOT variants use the workspace's saved key and require a matching saved configuration.",
     example: "anthropic",
   }),
   refresh: z.enum(["1", "true"]).optional().openapi({
@@ -422,13 +428,25 @@ adminModelConfig.openapi(catalogRoute, async (c) => {
       return c.json(catalog, 200);
     }
 
-    // Anthropic BYOT catalog — requires a saved anthropic configuration.
+    // BYOT direct-provider catalogs (anthropic, openai) share a flow:
+    //   1. The workspace must have a saved config matching the requested
+    //      provider and a healthy (decryptable) key.
+    //   2. The catalog fetch is credentialed — audit the outcome (never
+    //      the key).
+    //   3. Provider-specific exceptions map to a small set of HTTP
+    //      envelopes: 401 / 429 / 503.
+    //
+    // The dispatch table below keeps the per-provider knobs (fetcher,
+    // error classes, friendly provider name) in one place so adding
+    // a new direct-provider (e.g. Bedrock #2273) is a single entry.
     if (!orgId) {
       return c.json(
         { error: "bad_request", message: "No active organization. Set an active org first.", requestId },
         400,
       );
     }
+
+    const adapter = byotAdapter(provider);
 
     // Decrypt errors surface as 422 with a clear "re-enter the key" message
     // rather than as a generic 500. Catch inline so the response shape is
@@ -446,7 +464,7 @@ adminModelConfig.openapi(catalogRoute, async (c) => {
         targetType: "model_config",
         targetId: orgId,
         status: "failure",
-        metadata: { provider: "anthropic", error: "decrypt_failed" },
+        metadata: { provider: adapter.providerKey, error: "decrypt_failed" },
       });
       return c.json(
         {
@@ -460,36 +478,21 @@ adminModelConfig.openapi(catalogRoute, async (c) => {
     }
     const rawConfig = rawConfigOrDecryptError.cfg;
 
-    if (!rawConfig || rawConfig.provider !== "anthropic" || !rawConfig.apiKey) {
+    if (!rawConfig || rawConfig.provider !== adapter.providerKey || !rawConfig.apiKey) {
       return c.json(
         {
           error: "missing_byot_key",
-          message:
-            "Save an Anthropic API key on this workspace before refreshing the catalog.",
+          message: `Save a ${adapter.displayName} API key on this workspace before refreshing the catalog.`,
           requestId,
         },
         400,
       );
     }
 
-    // Discovery fetches against an external provider are credentialed
-    // operations: same audit threat model as `model_config.test`. Log the
-    // fetch outcome (never the apiKey). The provider-specific exceptions
-    // are caught inside the promise so the Effect channel carries a clean
-    // discriminated result rather than tunneling through `Effect.tryPromise`'s
-    // generic catch (which becomes "unmapped tagged error" at the bridge).
-    type CatalogResult =
-      | { kind: "ok"; models: typeof rawConfig extends never ? never : Awaited<ReturnType<typeof getAnthropicCatalog>>["models"]; fetchedAt: string; source: "cache" | "fresh" }
-      | { kind: "byot_key_invalid"; message: string }
-      | { kind: "byot_provider_rate_limited"; message: string; retryAfter: number | null }
-      | { kind: "byot_provider_unavailable"; message: string };
-
     const catalogResult = yield* Effect.tryPromise({
-      try: async (): Promise<CatalogResult> => {
+      try: async (): Promise<ByotCatalogResult> => {
         try {
-          const cat = await getAnthropicCatalog(orgId, rawConfig.apiKey ?? "", {
-            refresh,
-          });
+          const cat = await adapter.fetch(orgId, rawConfig.apiKey ?? "", { refresh });
           return {
             kind: "ok",
             models: cat.models,
@@ -498,17 +501,15 @@ adminModelConfig.openapi(catalogRoute, async (c) => {
           };
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          if (err instanceof AnthropicCatalogUnauthorized) {
+          if (err instanceof adapter.errors.Unauthorized) {
             return { kind: "byot_key_invalid", message };
           }
-          if (err instanceof AnthropicCatalogRateLimited) {
-            return {
-              kind: "byot_provider_rate_limited",
-              message,
-              retryAfter: err.retryAfterSeconds,
-            };
+          if (err instanceof adapter.errors.RateLimited) {
+            // Both error classes carry `retryAfterSeconds: number | null`.
+            const retryAfter = (err as unknown as { retryAfterSeconds: number | null }).retryAfterSeconds;
+            return { kind: "byot_provider_rate_limited", message, retryAfter };
           }
-          if (err instanceof AnthropicCatalogUnavailable) {
+          if (err instanceof adapter.errors.Unavailable) {
             return { kind: "byot_provider_unavailable", message };
           }
           throw err;
@@ -523,7 +524,7 @@ adminModelConfig.openapi(catalogRoute, async (c) => {
         targetType: "model_config",
         targetId: orgId,
         metadata: {
-          provider: "anthropic",
+          provider: adapter.providerKey,
           modelCount: catalogResult.models.length,
           source: catalogResult.source,
         },
@@ -533,9 +534,10 @@ adminModelConfig.openapi(catalogRoute, async (c) => {
         {
           models: catalogResult.models,
           fetchedAt: catalogResult.fetchedAt,
-          // Anthropic discovery has no curated fallback — upstream failures
-          // surface as the matching HTTP envelope above. `fallback` stays
-          // false for shape parity with the gateway response.
+          // BYOT direct providers have no curated fallback — upstream
+          // failures surface as the matching HTTP envelope above.
+          // `fallback` stays false for shape parity with the gateway
+          // response.
           fallback: false,
         },
         200,
@@ -548,7 +550,7 @@ adminModelConfig.openapi(catalogRoute, async (c) => {
       targetId: orgId,
       status: "failure",
       metadata: {
-        provider: "anthropic",
+        provider: adapter.providerKey,
         error: catalogResult.kind,
         detail: catalogResult.message,
       },
@@ -572,5 +574,82 @@ adminModelConfig.openapi(catalogRoute, async (c) => {
     );
   }), { label: "get model catalog", domainErrors: [modelConfigDomainError] });
 });
+
+// ---------------------------------------------------------------------------
+// BYOT direct-provider catalog adapter
+//
+// Anthropic + OpenAI share an identical flow (config gate → fetch →
+// classified-error envelope). The adapter is the smallest surface that
+// captures the per-provider knobs without abstracting away the per-route
+// audit + envelope logic. Future direct providers (Bedrock #2273) plug in
+// by adding a single case to `byotAdapter`.
+// ---------------------------------------------------------------------------
+
+interface ByotErrorClasses {
+  readonly Unauthorized: new (...args: never[]) => Error;
+  readonly RateLimited: new (...args: never[]) => Error;
+  readonly Unavailable: new (...args: never[]) => Error;
+}
+
+// Wire-shape entry. Stays mutable to match the response schema generated
+// from `GatewayCatalogResponseSchema` — Hono's typed-response narrowing
+// rejects ReadonlyArray here even though the value is never mutated.
+interface ByotCatalogEntry {
+  id: string;
+  name: string;
+  provider: string;
+  type: string;
+  contextWindow: number | null;
+  maxOutputTokens: number | null;
+  inputPrice: string | null;
+  outputPrice: string | null;
+  recommended: boolean;
+}
+
+interface ByotProviderAdapter {
+  readonly providerKey: "anthropic" | "openai";
+  readonly displayName: string;
+  readonly fetch: (
+    orgId: string,
+    apiKey: string,
+    opts: { refresh?: boolean },
+  ) => Promise<{
+    models: ByotCatalogEntry[];
+    fetchedAt: string;
+    source: "cache" | "fresh";
+  }>;
+  readonly errors: ByotErrorClasses;
+}
+
+type ByotCatalogResult =
+  | { kind: "ok"; models: ByotCatalogEntry[]; fetchedAt: string; source: "cache" | "fresh" }
+  | { kind: "byot_key_invalid"; message: string }
+  | { kind: "byot_provider_rate_limited"; message: string; retryAfter: number | null }
+  | { kind: "byot_provider_unavailable"; message: string };
+
+function byotAdapter(provider: "anthropic" | "openai"): ByotProviderAdapter {
+  if (provider === "anthropic") {
+    return {
+      providerKey: "anthropic",
+      displayName: "Anthropic",
+      fetch: getAnthropicCatalog,
+      errors: {
+        Unauthorized: AnthropicCatalogUnauthorized,
+        RateLimited: AnthropicCatalogRateLimited,
+        Unavailable: AnthropicCatalogUnavailable,
+      },
+    };
+  }
+  return {
+    providerKey: "openai",
+    displayName: "OpenAI",
+    fetch: getOpenAICatalog,
+    errors: {
+      Unauthorized: OpenAICatalogUnauthorized,
+      RateLimited: OpenAICatalogRateLimited,
+      Unavailable: OpenAICatalogUnavailable,
+    },
+  };
+}
 
 export { adminModelConfig };

--- a/packages/api/src/lib/__tests__/openai-catalog.test.ts
+++ b/packages/api/src/lib/__tests__/openai-catalog.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, test, mock } from "bun:test";
+import {
+  __resetOpenAICatalogCacheForTests,
+  __getRecommendedOpenAIIdsForTests,
+  OpenAICatalogRateLimited,
+  OpenAICatalogUnauthorized,
+  OpenAICatalogUnavailable,
+  getOpenAICatalog,
+  invalidateOpenAICatalog,
+} from "../openai-catalog";
+
+type FetchFn = typeof globalThis.fetch;
+const realFetch: FetchFn = globalThis.fetch;
+
+const ORG_A = "org_a";
+const KEY = "sk-test-key";
+
+function mockFetchOk(body: unknown): FetchFn {
+  return mock(async (): Promise<Response> => {
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as FetchFn;
+}
+
+function mockFetchStatus(status: number, headers: Record<string, string> = {}): FetchFn {
+  return mock(async (): Promise<Response> => {
+    return new Response("upstream", { status, headers });
+  }) as unknown as FetchFn;
+}
+
+describe("openai-catalog", () => {
+  beforeEach(() => {
+    __resetOpenAICatalogCacheForTests();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    __resetOpenAICatalogCacheForTests();
+  });
+
+  test("filters /v1/models down to chat-capable models", async () => {
+    globalThis.fetch = mockFetchOk({
+      object: "list",
+      data: [
+        // Chat — kept.
+        { id: "gpt-4o", object: "model", created: 1, owned_by: "openai" },
+        { id: "gpt-4o-mini", object: "model", created: 1, owned_by: "openai" },
+        { id: "o3-mini", object: "model", created: 1, owned_by: "openai" },
+        // Filtered.
+        { id: "text-embedding-3-large", object: "model" },
+        { id: "whisper-1", object: "model" },
+        { id: "tts-1", object: "model" },
+        { id: "dall-e-3", object: "model" },
+        { id: "omni-moderation-latest", object: "model" },
+        { id: "gpt-3.5-turbo-instruct", object: "model" },
+        { id: "gpt-4o-realtime-preview", object: "model" },
+        { id: "gpt-4o-audio-preview", object: "model" },
+        // Malformed — dropped.
+        { object: "model" },
+      ],
+    });
+
+    const res = await getOpenAICatalog(ORG_A, KEY);
+    expect(res.source).toBe("fresh");
+    const ids = res.models.map((m) => m.id).sort();
+    expect(ids).toEqual(["gpt-4o", "gpt-4o-mini", "o3-mini"]);
+    const flagship = res.models.find((m) => m.id === "gpt-4o");
+    expect(flagship?.provider).toBe("openai");
+    expect(flagship?.recommended).toBe(true);
+  });
+
+  test("non-recommended chat models are kept but flagged recommended:false", async () => {
+    globalThis.fetch = mockFetchOk({
+      data: [
+        { id: "gpt-4o", object: "model" },
+        { id: "gpt-future-model-2027", object: "model" },
+      ],
+    });
+    const res = await getOpenAICatalog(ORG_A, KEY);
+    expect(res.models.find((m) => m.id === "gpt-future-model-2027")?.recommended).toBe(false);
+    expect(res.models.find((m) => m.id === "gpt-4o")?.recommended).toBe(true);
+  });
+
+  test("401 surfaces OpenAICatalogUnauthorized", async () => {
+    globalThis.fetch = mockFetchStatus(401);
+    await expect(getOpenAICatalog(ORG_A, "bad-key")).rejects.toBeInstanceOf(
+      OpenAICatalogUnauthorized,
+    );
+  });
+
+  test("429 surfaces OpenAICatalogRateLimited with retry-after parsed", async () => {
+    globalThis.fetch = mockFetchStatus(429, { "retry-after": "60" });
+    try {
+      await getOpenAICatalog(ORG_A, KEY);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(OpenAICatalogRateLimited);
+      if (err instanceof OpenAICatalogRateLimited) {
+        expect(err.retryAfterSeconds).toBe(60);
+      }
+    }
+  });
+
+  test("503 surfaces OpenAICatalogUnavailable", async () => {
+    globalThis.fetch = mockFetchStatus(503);
+    await expect(getOpenAICatalog(ORG_A, KEY)).rejects.toBeInstanceOf(
+      OpenAICatalogUnavailable,
+    );
+  });
+
+  test("network failure surfaces OpenAICatalogUnavailable", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as FetchFn;
+    await expect(getOpenAICatalog(ORG_A, KEY)).rejects.toBeInstanceOf(
+      OpenAICatalogUnavailable,
+    );
+  });
+
+  test("malformed `data` field surfaces OpenAICatalogUnavailable", async () => {
+    globalThis.fetch = mockFetchOk({ data: "not-an-array" });
+    await expect(getOpenAICatalog(ORG_A, KEY)).rejects.toBeInstanceOf(
+      OpenAICatalogUnavailable,
+    );
+  });
+
+  test("caches a successful fetch per orgId", async () => {
+    const fetchMock = mock(
+      async () =>
+        new Response(JSON.stringify({ data: [{ id: "gpt-4o" }] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    globalThis.fetch = fetchMock as unknown as FetchFn;
+    const first = await getOpenAICatalog(ORG_A, KEY);
+    const second = await getOpenAICatalog(ORG_A, KEY);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(first.source).toBe("fresh");
+    expect(second.source).toBe("cache");
+  });
+
+  test("opts.refresh bypasses the cache", async () => {
+    const fetchMock = mock(
+      async () =>
+        new Response(JSON.stringify({ data: [{ id: "gpt-4o" }] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    globalThis.fetch = fetchMock as unknown as FetchFn;
+    await getOpenAICatalog(ORG_A, KEY);
+    const refreshed = await getOpenAICatalog(ORG_A, KEY, { refresh: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(refreshed.source).toBe("fresh");
+  });
+
+  test("invalidateOpenAICatalog forces a re-fetch on next call", async () => {
+    const fetchMock = mock(
+      async () =>
+        new Response(JSON.stringify({ data: [{ id: "gpt-4o" }] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    globalThis.fetch = fetchMock as unknown as FetchFn;
+    await getOpenAICatalog(ORG_A, KEY);
+    invalidateOpenAICatalog(ORG_A);
+    const second = await getOpenAICatalog(ORG_A, KEY);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(second.source).toBe("fresh");
+  });
+
+  test("concurrent fetches for the same org dedupe to one upstream call", async () => {
+    const pending = Promise.withResolvers<Response>();
+    const slowFetch: FetchFn = mock(() => pending.promise) as unknown as FetchFn;
+    globalThis.fetch = slowFetch;
+
+    const p1 = getOpenAICatalog(ORG_A, KEY);
+    const p2 = getOpenAICatalog(ORG_A, KEY);
+
+    pending.resolve(
+      new Response(JSON.stringify({ data: [{ id: "gpt-4o" }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(slowFetch).toHaveBeenCalledTimes(1);
+    expect(r1.models[0].id).toBe("gpt-4o");
+    expect(r2.models[0].id).toBe("gpt-4o");
+  });
+
+  test("recommended set is non-empty and includes the flagship", () => {
+    const ids = __getRecommendedOpenAIIdsForTests();
+    expect(ids.size).toBeGreaterThan(0);
+    expect(ids.has("gpt-4o")).toBe(true);
+  });
+});

--- a/packages/api/src/lib/openai-catalog.ts
+++ b/packages/api/src/lib/openai-catalog.ts
@@ -1,0 +1,273 @@
+/**
+ * OpenAI BYOT `/v1/models` discovery + per-workspace cache.
+ *
+ * Mirrors `anthropic-catalog.ts` (#2271). OpenAI's `/v1/models` endpoint
+ * returns the workspace's full model entitlement (chat + embeddings +
+ * whisper + tts + dall-e + moderation + image), so we filter to
+ * chat-capable models before surfacing them in the picker — non-chat
+ * IDs would just lead to confusing test-call failures downstream.
+ *
+ * The cache is per-orgId with a configurable TTL
+ * (`ATLAS_BYOT_CATALOG_TTL_MS`, shared with the Anthropic catalog —
+ * direct-provider discovery is the same threat model).
+ */
+
+import type { GatewayCatalogModel } from "@useatlas/types";
+import { createLogger } from "./logger";
+
+const log = createLogger("openai-catalog");
+
+const OPENAI_MODELS_URL = "https://api.openai.com/v1/models";
+const DEFAULT_TTL_MS = 6 * 60 * 60 * 1_000; // 6 hours, matching anthropic-catalog
+const FETCH_TIMEOUT_MS = 10_000;
+
+/**
+ * Recommended subset surfaced in the picker. Anchored on the flagship
+ * (gpt-4o), the cheap-fast pair (gpt-4o-mini), and the reasoning family
+ * representative (o3-mini). The set is conservative on purpose — the
+ * full catalog is dozens of entries deep, and a flat "everything is
+ * equally recommended" payload defeats the picker's grouping affordance.
+ */
+const RECOMMENDED_MODEL_IDS: ReadonlySet<string> = new Set([
+  "gpt-4o",
+  "gpt-4o-mini",
+  "o3-mini",
+]);
+
+/**
+ * Filters /v1/models entries to chat-capable models. OpenAI does not
+ * surface a "capability" field on /v1/models, so we filter by ID prefix:
+ *   - `gpt-*` — chat completions
+ *   - `o*` — reasoning family (o1, o3, …)
+ *   - `chatgpt-*` — chat-tuned variants
+ * Excludes:
+ *   - `text-embedding-*`, `text-search-*` (embeddings)
+ *   - `whisper-*` (transcription)
+ *   - `tts-*` (text-to-speech)
+ *   - `dall-e-*` (image generation)
+ *   - `omni-moderation-*`, `text-moderation-*` (moderation)
+ *   - `babbage-*`, `davinci-*`, `gpt-3.5-turbo-instruct*` (legacy completion)
+ *   - `*-realtime-preview*` (Realtime API; not standard chat)
+ */
+function isChatCapable(id: string): boolean {
+  const normalized = id.toLowerCase();
+  if (normalized.includes("realtime")) return false;
+  if (normalized.includes("audio")) return false;
+  if (normalized.includes("instruct")) return false;
+  if (normalized.includes("transcribe")) return false;
+  if (normalized.includes("search")) return false;
+  if (normalized.includes("moderation")) return false;
+  if (normalized.includes("embedding")) return false;
+  if (normalized.startsWith("whisper")) return false;
+  if (normalized.startsWith("tts-")) return false;
+  if (normalized.startsWith("dall-e")) return false;
+  if (normalized.startsWith("babbage")) return false;
+  if (normalized.startsWith("davinci")) return false;
+  // gpt-image / gpt-4o-image variants — image generation surface, not chat.
+  if (normalized.startsWith("gpt-image")) return false;
+  return normalized.startsWith("gpt-") || normalized.startsWith("o") || normalized.startsWith("chatgpt-");
+}
+
+export class OpenAICatalogUnauthorized extends Error {
+  readonly _tag = "OpenAICatalogUnauthorized";
+  constructor(message: string) {
+    super(message);
+    this.name = "OpenAICatalogUnauthorized";
+  }
+}
+
+export class OpenAICatalogRateLimited extends Error {
+  readonly _tag = "OpenAICatalogRateLimited";
+  readonly retryAfterSeconds: number | null;
+  constructor(message: string, retryAfterSeconds: number | null) {
+    super(message);
+    this.name = "OpenAICatalogRateLimited";
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}
+
+export class OpenAICatalogUnavailable extends Error {
+  readonly _tag = "OpenAICatalogUnavailable";
+  constructor(message: string) {
+    super(message);
+    this.name = "OpenAICatalogUnavailable";
+  }
+}
+
+interface RawOpenAIModel {
+  id?: unknown;
+  object?: unknown;
+  created?: unknown;
+  owned_by?: unknown;
+}
+
+export interface OpenAICatalogResponse {
+  models: GatewayCatalogModel[];
+  fetchedAt: string;
+  source: "cache" | "fresh";
+}
+
+interface CacheEntry {
+  models: GatewayCatalogModel[];
+  fetchedAt: string;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+const inflight = new Map<string, Promise<CacheEntry>>();
+
+function ttlMs(): number {
+  const raw = process.env.ATLAS_BYOT_CATALOG_TTL_MS;
+  if (!raw) return DEFAULT_TTL_MS;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TTL_MS;
+}
+
+function normalizeEntry(raw: RawOpenAIModel): GatewayCatalogModel | null {
+  if (typeof raw.id !== "string" || raw.id.length === 0) return null;
+  const id = raw.id;
+  if (!isChatCapable(id)) return null;
+  return {
+    id,
+    name: id,
+    provider: "openai",
+    type: "language",
+    contextWindow: null,
+    maxOutputTokens: null,
+    inputPrice: null,
+    outputPrice: null,
+    recommended: RECOMMENDED_MODEL_IDS.has(id),
+  };
+}
+
+async function fetchOpenAIModels(apiKey: string): Promise<GatewayCatalogModel[]> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(OPENAI_MODELS_URL, {
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        accept: "application/json",
+      },
+    });
+
+    if (res.status === 401 || res.status === 403) {
+      throw new OpenAICatalogUnauthorized(
+        "OpenAI rejected the workspace API key. Verify it on the AI Provider page.",
+      );
+    }
+    if (res.status === 429) {
+      const retryAfterRaw = res.headers.get("retry-after");
+      const retryAfterSeconds = retryAfterRaw ? Number.parseInt(retryAfterRaw, 10) : null;
+      throw new OpenAICatalogRateLimited(
+        "OpenAI rate-limited the catalog refresh. Try again shortly.",
+        Number.isFinite(retryAfterSeconds) ? retryAfterSeconds : null,
+      );
+    }
+    if (!res.ok) {
+      throw new OpenAICatalogUnavailable(
+        `OpenAI /v1/models returned ${res.status}. Try again shortly.`,
+      );
+    }
+
+    const body = (await res.json()) as { data?: unknown };
+    if (!Array.isArray(body.data)) {
+      throw new OpenAICatalogUnavailable(
+        "OpenAI /v1/models response missing `data` array.",
+      );
+    }
+
+    const normalized: GatewayCatalogModel[] = [];
+    let dropped = 0;
+    let filtered = 0;
+    for (const entry of body.data) {
+      if (!entry || typeof entry !== "object") {
+        dropped += 1;
+        continue;
+      }
+      const raw = entry as RawOpenAIModel;
+      const idMaybe = typeof raw.id === "string" ? raw.id : null;
+      const model = normalizeEntry(raw);
+      if (model) normalized.push(model);
+      else if (idMaybe) filtered += 1;
+      else dropped += 1;
+    }
+    if (dropped > 0 || filtered > 0) {
+      log.debug(
+        { dropped, filtered, kept: normalized.length },
+        "openai-catalog: drop+filter applied to upstream response",
+      );
+    }
+    return normalized;
+  } catch (err) {
+    if (
+      err instanceof OpenAICatalogUnauthorized ||
+      err instanceof OpenAICatalogRateLimited ||
+      err instanceof OpenAICatalogUnavailable
+    ) {
+      throw err;
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    throw new OpenAICatalogUnavailable(`OpenAI /v1/models fetch failed: ${message}`);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Return the workspace's cached OpenAI catalog if fresh, otherwise fetch
+ * from OpenAI with the supplied BYOT key. Concurrent callers for the
+ * same orgId share a single inflight fetch (matches anthropic-catalog).
+ */
+export async function getOpenAICatalog(
+  orgId: string,
+  apiKey: string,
+  opts: { refresh?: boolean } = {},
+): Promise<OpenAICatalogResponse> {
+  if (!opts.refresh) {
+    const hit = cache.get(orgId);
+    if (hit && hit.expiresAt > Date.now()) {
+      return { models: hit.models, fetchedAt: hit.fetchedAt, source: "cache" };
+    }
+  }
+
+  let pending = inflight.get(orgId);
+  if (!pending) {
+    pending = (async (): Promise<CacheEntry> => {
+      const models = await fetchOpenAIModels(apiKey);
+      const now = Date.now();
+      const entry: CacheEntry = {
+        models,
+        fetchedAt: new Date(now).toISOString(),
+        expiresAt: now + ttlMs(),
+      };
+      cache.set(orgId, entry);
+      return entry;
+    })().finally(() => {
+      inflight.delete(orgId);
+    });
+    inflight.set(orgId, pending);
+  }
+  const entry = await pending;
+  return { models: entry.models, fetchedAt: entry.fetchedAt, source: "fresh" };
+}
+
+/**
+ * Drop the cached catalog for an org. Called from
+ * `setWorkspaceModelConfig` on a successful openai upsert.
+ */
+export function invalidateOpenAICatalog(orgId: string): void {
+  cache.delete(orgId);
+}
+
+/** Test-only: clear all cached entries. */
+export function __resetOpenAICatalogCacheForTests(): void {
+  cache.clear();
+  inflight.clear();
+}
+
+/** Test-only: inspect the curated recommended list. */
+export function __getRecommendedOpenAIIdsForTests(): ReadonlySet<string> {
+  return RECOMMENDED_MODEL_IDS;
+}

--- a/packages/web/src/app/admin/model-config/page.tsx
+++ b/packages/web/src/app/admin/model-config/page.tsx
@@ -133,14 +133,18 @@ export default function ModelConfigPage() {
     { schema: GatewayCatalogResponseSchema },
   );
 
-  // Anthropic BYOT catalog (#2271) — only fetched when the workspace has a
-  // saved Anthropic configuration with a healthy key. Without these
-  // preconditions the endpoint would return 400 `missing_byot_key` on every
-  // page load, which would surface as a noisy error banner. Gating with
-  // `enabled` keeps the request firmly tied to the picker's render gate.
+  // BYOT direct-provider catalogs (#2271 anthropic, #2272 openai) — only
+  // fetched when the workspace has a saved configuration on the matching
+  // provider with a healthy key. Without these preconditions the endpoint
+  // would return 400 `missing_byot_key` on every page load, surfacing as
+  // a noisy error banner. Gating with `enabled` keeps the request firmly
+  // tied to the picker's render gate.
   const existingConfigForGate = data?.config ?? null;
   const anthropicCatalogEnabled =
     existingConfigForGate?.provider === "anthropic" &&
+    existingConfigForGate.apiKeyStatus === "masked";
+  const openaiCatalogEnabled =
+    existingConfigForGate?.provider === "openai" &&
     existingConfigForGate.apiKeyStatus === "masked";
   const {
     data: anthropicCatalog,
@@ -151,6 +155,17 @@ export default function ModelConfigPage() {
     {
       schema: GatewayCatalogResponseSchema,
       enabled: anthropicCatalogEnabled,
+    },
+  );
+  const {
+    data: openaiCatalog,
+    loading: openaiCatalogLoading,
+    refetch: refetchOpenaiCatalog,
+  } = useAdminFetch(
+    "/api/v1/admin/model-config/catalog?provider=openai",
+    {
+      schema: GatewayCatalogResponseSchema,
+      enabled: openaiCatalogEnabled,
     },
   );
 
@@ -311,12 +326,17 @@ export default function ModelConfigPage() {
 
   const currentProvider = form.watch("provider");
   const isGateway = currentProvider === "gateway";
-  // Anthropic picker requires the saved config to also be anthropic — we use
-  // the workspace's stored BYOT key for the discovery call. Switching the
-  // form to anthropic without saving falls back to the free-text input.
+  // BYOT picker requires the saved config to match the current form
+  // provider — we use the workspace's stored BYOT key for the discovery
+  // call. Switching the form to a provider without saving falls back to
+  // the free-text input.
   const showAnthropicPicker =
     currentProvider === "anthropic" &&
     existingConfig?.provider === "anthropic" &&
+    existingConfig?.apiKeyStatus === "masked";
+  const showOpenaiPicker =
+    currentProvider === "openai" &&
+    existingConfig?.provider === "openai" &&
     existingConfig?.apiKeyStatus === "masked";
   const saveDisabled =
     saving ||
@@ -611,6 +631,14 @@ export default function ModelConfigPage() {
                                   loading={anthropicCatalogLoading}
                                   onRetry={refetchAnthropicCatalog}
                                 />
+                              ) : showOpenaiPicker ? (
+                                <GatewayModelPicker
+                                  models={openaiCatalog?.models ?? []}
+                                  value={field.value}
+                                  onChange={field.onChange}
+                                  loading={openaiCatalogLoading}
+                                  onRetry={refetchOpenaiCatalog}
+                                />
                               ) : (
                                 <Input
                                   placeholder={
@@ -632,9 +660,21 @@ export default function ModelConfigPage() {
                                 refreshing={anthropicCatalogLoading}
                               />
                             )}
+                            {showOpenaiPicker && openaiCatalog && (
+                              <CatalogFreshness
+                                fetchedAt={openaiCatalog.fetchedAt}
+                                onRefresh={refetchOpenaiCatalog}
+                                refreshing={openaiCatalogLoading}
+                              />
+                            )}
                             {currentProvider === "anthropic" && !showAnthropicPicker && (
                               <FormDescription>
                                 Save your Anthropic API key first to pick from the live model catalog.
+                              </FormDescription>
+                            )}
+                            {currentProvider === "openai" && !showOpenaiPicker && (
+                              <FormDescription>
+                                Save your OpenAI API key first to pick from the live model catalog.
                               </FormDescription>
                             )}
                             <FormMessage />


### PR DESCRIPTION
## Summary

Second direct-provider slice of #2174 BYOT. Stacked on #2276 (Anthropic) — review/merge that one first; this PR's diff base re-targets to `main` once it lands.

- `packages/api/src/lib/openai-catalog.ts` — fetches OpenAI \`/v1/models\` with the workspace's BYOT key. Filters to chat-capable IDs (drops embeddings / whisper / tts / dall-e / moderation / instruct / realtime / audio / image variants). Same per-orgId cache shape and tagged failure classes as anthropic-catalog; shares the \`ATLAS_BYOT_CATALOG_TTL_MS\` TTL knob.
- Route \`/catalog?provider=openai\` now flows through a small \`byotAdapter()\` dispatch table that holds the per-provider knobs (fetcher, error classes, friendly name). This cuts what would have been ~60 lines of duplicate Anthropic-vs-OpenAI handler logic, and gives Bedrock (#2273) a single-entry plug-in point. The existing \`?provider=anthropic\` flow now flows through the same dispatch — same envelopes, same audit shape.
- \`setWorkspaceModelConfig\` calls \`invalidateOpenAICatalog(orgId)\` on a successful openai upsert.
- \`/admin/model-config\` swaps the free-text input for the picker when the saved provider is openai with a healthy key.

Closes #2272.

## Test plan
- [x] \`bun test src/lib/__tests__/openai-catalog.test.ts\` — 12 unit tests covering filtering, every error class, per-orgId scoping, refresh-bypass, invalidation, inflight dedup, recommended set.
- [x] \`bun test src/api/__tests__/admin-model-config.test.ts\` — 30/30 (anthropic + openai + gateway + audit + decrypt paths).
- [x] \`bun run type\` + \`bun run lint\` — both clean.
- [x] \`bun run scripts/test-isolated.ts --affected\` — 57/57.
- [x] Schema + template drift checks pass.
- [x] OpenAPI spec regenerated.
- [ ] Manual: save an OpenAI key on a SaaS workspace, confirm the picker renders the filtered chat-capable list, "Refresh now" forces a fresh fetch.