### PR TITLE
feat(api): #2274 — Postgres L2 cache for BYOT discovery catalogs

### DIFF
--- a/packages/api/src/lib/__tests__/byot-catalog-store.test.ts
+++ b/packages/api/src/lib/__tests__/byot-catalog-store.test.ts
@@ -1,0 +1,182 @@
+/**
+ * L2 BYOT catalog cache tests (#2274).
+ *
+ * Mocks `db/internal` to assert wire shape without standing up Postgres.
+ * Per CLAUDE.md, every named export is mirrored in the mock so the
+ * partial-mock SyntaxError trap doesn't fire elsewhere.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, mock } from "bun:test";
+
+interface RecordedCall {
+  sql: string;
+  params: unknown[];
+}
+
+const recorded: RecordedCall[] = [];
+let nextRows: unknown[] = [];
+let nextError: Error | null = null;
+let hasInternalDBValue = true;
+
+const mockInternalQuery = mock(async (sql: string, params: unknown[]) => {
+  recorded.push({ sql, params });
+  if (nextError) throw nextError;
+  return nextRows;
+});
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => hasInternalDBValue,
+  internalQuery: mockInternalQuery,
+  // The catalog-store doesn't touch the rest of internal.ts, but the
+  // partial-mock guard requires every export the module surfaces.
+  // Empty stubs are enough — the byot-catalog-store doesn't reach into
+  // them, and bun:test's mock.module errors loudly if a consumer in this
+  // test suite ever does.
+  encryptUrl: () => "",
+  decryptUrl: () => "",
+  encryptSecret: () => "",
+  decryptSecret: () => "",
+  getInternalDB: () => null,
+  getEncryptionKey: () => null,
+  getEncryptionKeyVersions: () => ({ active: 1, keys: new Map() }),
+}));
+
+const { loadFromDB, storeToDB, deleteFromDB, isFresh } = await import("../byot-catalog-store");
+
+function reset() {
+  recorded.length = 0;
+  nextRows = [];
+  nextError = null;
+  hasInternalDBValue = true;
+  mockInternalQuery.mockClear();
+}
+
+describe("byot-catalog-store", () => {
+  beforeEach(() => reset());
+  afterEach(() => reset());
+
+  describe("loadFromDB", () => {
+    test("returns null when no internal DB is configured", async () => {
+      hasInternalDBValue = false;
+      const result = await loadFromDB("org_a", "anthropic");
+      expect(result).toBeNull();
+      expect(mockInternalQuery).not.toHaveBeenCalled();
+    });
+
+    test("returns null on miss", async () => {
+      nextRows = [];
+      const result = await loadFromDB("org_a", "anthropic");
+      expect(result).toBeNull();
+      expect(recorded[0].params).toEqual(["org_a", "anthropic", ""]);
+    });
+
+    test("returns parsed payload on hit", async () => {
+      nextRows = [
+        {
+          payload: { models: [{ id: "claude-opus-4-6", provider: "anthropic" }] },
+          fetched_at: "2026-05-11T00:00:00.000Z",
+        },
+      ];
+      const result = await loadFromDB("org_a", "anthropic");
+      expect(result).not.toBeNull();
+      expect(result!.fetchedAt).toBe("2026-05-11T00:00:00.000Z");
+      expect(result!.models).toHaveLength(1);
+    });
+
+    test("uses region in the WHERE clause for bedrock", async () => {
+      nextRows = [];
+      await loadFromDB("org_a", "bedrock", "us-east-1");
+      expect(recorded[0].params).toEqual(["org_a", "bedrock", "us-east-1"]);
+    });
+
+    test("returns null on DB error (best-effort, never throws)", async () => {
+      nextError = new Error("ECONNREFUSED");
+      const result = await loadFromDB("org_a", "anthropic");
+      expect(result).toBeNull();
+    });
+
+    test("returns null on malformed payload", async () => {
+      nextRows = [{ payload: { not_models: "wrong shape" }, fetched_at: "2026-05-11T00:00:00.000Z" }];
+      const result = await loadFromDB("org_a", "anthropic");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("storeToDB", () => {
+    test("no-op when no internal DB", async () => {
+      hasInternalDBValue = false;
+      await storeToDB("org_a", "anthropic", "", {
+        models: [],
+        fetchedAt: "2026-05-11T00:00:00.000Z",
+      });
+      expect(mockInternalQuery).not.toHaveBeenCalled();
+    });
+
+    test("upserts on (org_id, provider, region) tuple", async () => {
+      await storeToDB("org_a", "openai", "", {
+        models: [{ id: "gpt-4o" } as never],
+        fetchedAt: "2026-05-11T00:00:00.000Z",
+      });
+      expect(recorded[0].sql).toMatch(/INSERT INTO workspace_model_catalog/);
+      expect(recorded[0].sql).toMatch(/ON CONFLICT \(org_id, provider, region\)/);
+      expect(recorded[0].params[1]).toBe("openai");
+      expect(recorded[0].params[2]).toBe("");
+      // payload[3] is the JSON-stringified bag.
+      expect(JSON.parse(recorded[0].params[3] as string).models[0].id).toBe("gpt-4o");
+    });
+
+    test("bedrock region rides on the upsert key", async () => {
+      await storeToDB("org_a", "bedrock", "ap-northeast-1", {
+        models: [{ id: "anthropic.claude-opus-4-v1:0" } as never],
+        fetchedAt: "2026-05-11T00:00:00.000Z",
+      });
+      expect(recorded[0].params[2]).toBe("ap-northeast-1");
+    });
+
+    test("swallows DB errors so the in-memory cache return path is preserved", async () => {
+      nextError = new Error("constraint violation");
+      // Must NOT throw — the L2 store is best-effort by contract.
+      await storeToDB("org_a", "anthropic", "", {
+        models: [],
+        fetchedAt: "2026-05-11T00:00:00.000Z",
+      });
+    });
+  });
+
+  describe("deleteFromDB", () => {
+    test("flushes every region for an org+provider in one shot", async () => {
+      await deleteFromDB("org_a", "bedrock");
+      expect(recorded[0].sql).toMatch(/DELETE FROM workspace_model_catalog/);
+      expect(recorded[0].params).toEqual(["org_a", "bedrock"]);
+    });
+
+    test("no-op when no internal DB", async () => {
+      hasInternalDBValue = false;
+      await deleteFromDB("org_a", "anthropic");
+      expect(mockInternalQuery).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("isFresh", () => {
+    test("returns true for a recent fetchedAt", () => {
+      const persisted = {
+        models: [],
+        fetchedAt: new Date(Date.now() - 60_000).toISOString(),
+      };
+      expect(isFresh(persisted, 5 * 60_000)).toBe(true);
+    });
+
+    test("returns false past the TTL window", () => {
+      const persisted = {
+        models: [],
+        fetchedAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+      };
+      expect(isFresh(persisted, 5 * 60_000)).toBe(false);
+    });
+
+    test("returns false for an unparseable timestamp", () => {
+      const persisted = { models: [], fetchedAt: "yesterday" };
+      expect(isFresh(persisted, 60_000)).toBe(false);
+    });
+  });
+});

--- a/packages/api/src/lib/anthropic-catalog.ts
+++ b/packages/api/src/lib/anthropic-catalog.ts
@@ -20,6 +20,12 @@
  */
 
 import type { GatewayCatalogModel } from "@useatlas/types";
+import {
+  deleteFromDB,
+  isFresh,
+  loadFromDB,
+  storeToDB,
+} from "./byot-catalog-store";
 import { createLogger } from "./logger";
 
 const log = createLogger("anthropic-catalog");
@@ -199,9 +205,17 @@ export async function getAnthropicCatalog(
   opts: { refresh?: boolean } = {},
 ): Promise<AnthropicCatalogResponse> {
   if (!opts.refresh) {
+    // L1: in-memory cache (per-pod, also the inflight-dedup substrate).
     const hit = cache.get(orgId);
     if (hit && hit.expiresAt > Date.now()) {
       return { models: hit.models, fetchedAt: hit.fetchedAt, source: "cache" };
+    }
+    // L2: DB-backed cache (#2274). Used on cold start + cross-pod hits.
+    const fromDb = await loadFromDB(orgId, "anthropic");
+    if (fromDb && isFresh(fromDb, ttlMs())) {
+      const expiresAt = Date.parse(fromDb.fetchedAt) + ttlMs();
+      cache.set(orgId, { models: fromDb.models, fetchedAt: fromDb.fetchedAt, expiresAt });
+      return { models: fromDb.models, fetchedAt: fromDb.fetchedAt, source: "cache" };
     }
   }
 
@@ -216,6 +230,11 @@ export async function getAnthropicCatalog(
         expiresAt: now + ttlMs(),
       };
       cache.set(orgId, entry);
+      // Best-effort L2 write — failure is logged inside `storeToDB`.
+      await storeToDB(orgId, "anthropic", "", {
+        models: entry.models,
+        fetchedAt: entry.fetchedAt,
+      });
       return entry;
     })().finally(() => {
       inflight.delete(orgId);
@@ -229,10 +248,13 @@ export async function getAnthropicCatalog(
 /**
  * Drop the cached catalog for an org. Called from
  * `setWorkspaceModelConfig` after a successful upsert so a key rotation
- * doesn't serve a stale catalog from before the rotation.
+ * doesn't serve a stale catalog from before the rotation. Flushes both
+ * L1 (in-memory) and L2 (DB) layers — the L2 delete is fire-and-forget
+ * so callers in synchronous Effect paths don't have to await it.
  */
 export function invalidateAnthropicCatalog(orgId: string): void {
   cache.delete(orgId);
+  void deleteFromDB(orgId, "anthropic");
 }
 
 /** Test-only: clear all cached entries. */

--- a/packages/api/src/lib/bedrock-catalog.ts
+++ b/packages/api/src/lib/bedrock-catalog.ts
@@ -26,6 +26,12 @@ import {
 } from "@aws-sdk/client-bedrock";
 import type { GatewayCatalogModel } from "@useatlas/types";
 import type { BedrockRegion } from "@useatlas/types";
+import {
+  deleteFromDB,
+  isFresh,
+  loadFromDB,
+  storeToDB,
+} from "./byot-catalog-store";
 import { createLogger } from "./logger";
 
 const log = createLogger("bedrock-catalog");
@@ -236,6 +242,7 @@ export async function getBedrockCatalog(
 ): Promise<BedrockCatalogResponse> {
   const key = cacheKey(orgId, region);
   if (!opts.refresh) {
+    // L1: in-memory cache keyed per (orgId, region).
     const hit = cache.get(key);
     if (hit && hit.expiresAt > Date.now()) {
       return {
@@ -243,6 +250,23 @@ export async function getBedrockCatalog(
         fetchedAt: hit.fetchedAt,
         source: "cache",
         region: hit.region,
+      };
+    }
+    // L2: DB-backed cache (#2274). Region is part of the row key.
+    const fromDb = await loadFromDB(orgId, "bedrock", region);
+    if (fromDb && isFresh(fromDb, ttlMs())) {
+      const expiresAt = Date.parse(fromDb.fetchedAt) + ttlMs();
+      cache.set(key, {
+        models: fromDb.models,
+        fetchedAt: fromDb.fetchedAt,
+        expiresAt,
+        region,
+      });
+      return {
+        models: fromDb.models,
+        fetchedAt: fromDb.fetchedAt,
+        source: "cache",
+        region,
       };
     }
   }
@@ -259,6 +283,10 @@ export async function getBedrockCatalog(
         region,
       };
       cache.set(key, entry);
+      await storeToDB(orgId, "bedrock", region, {
+        models: entry.models,
+        fetchedAt: entry.fetchedAt,
+      });
       return entry;
     })().finally(() => {
       inflight.delete(key);
@@ -284,6 +312,8 @@ export function invalidateBedrockCatalog(orgId: string): void {
   for (const key of cache.keys()) {
     if (key.startsWith(`${orgId}:`)) cache.delete(key);
   }
+  // L2: deleting by (orgId, provider) flushes every region in one shot.
+  void deleteFromDB(orgId, "bedrock");
 }
 
 /** Test-only: clear the entire cache. */

--- a/packages/api/src/lib/byot-catalog-store.ts
+++ b/packages/api/src/lib/byot-catalog-store.ts
@@ -1,0 +1,156 @@
+/**
+ * Postgres-backed L2 cache for BYOT discovery catalogs (#2274).
+ *
+ * The per-provider catalog modules each maintain an in-memory L1 cache
+ * scoped to a single pod. This module is the L2: cross-pod, survives
+ * pod restarts, and centralizes the refresh story.
+ *
+ * Per-provider modules call `loadFromDB` on cold start and `storeToDB`
+ * after every fresh upstream fetch. The wire shape stored matches the
+ * `GatewayCatalogModel[]` array each module produces — keeping the JSON
+ * schema uniform across providers means the periodic refresh job
+ * (and #2275 unknown-model handling later) can iterate every catalog
+ * regardless of provider.
+ *
+ * Operational concerns:
+ *   - This is the only DB-backed BYOT-cache surface. Read/write paths
+ *     are best-effort: if the DB is unreachable, callers fall through
+ *     to in-memory + fresh upstream fetch. The cache is performance,
+ *     not correctness — a DB outage must not break a working BYOT
+ *     workspace.
+ *   - The internal-DB requirement is checked once via `hasInternalDB()`;
+ *     deployments without an internal DB simply skip the L2 layer.
+ *   - We never store secrets here. The cached `payload` is the wire
+ *     shape returned to admins — no API keys or IAM bundles.
+ */
+
+import { hasInternalDB, internalQuery } from "./db/internal";
+import { createLogger } from "./logger";
+import type { GatewayCatalogModel } from "@useatlas/types";
+
+const log = createLogger("byot-catalog-store");
+
+export type ByotProviderKey = "anthropic" | "openai" | "bedrock";
+
+export interface PersistedCatalog {
+  models: GatewayCatalogModel[];
+  fetchedAt: string;
+}
+
+interface CatalogRow {
+  payload: { models: GatewayCatalogModel[] };
+  fetched_at: string | Date;
+  [key: string]: unknown;
+}
+
+/**
+ * Look up a previously-persisted catalog. Region defaults to the empty
+ * string for providers that aren't region-scoped (anthropic, openai) so
+ * the unique constraint stays simple.
+ */
+export async function loadFromDB(
+  orgId: string,
+  provider: ByotProviderKey,
+  region: string = "",
+): Promise<PersistedCatalog | null> {
+  if (!hasInternalDB()) return null;
+  try {
+    const rows = await internalQuery<CatalogRow>(
+      `SELECT payload, fetched_at
+       FROM workspace_model_catalog
+       WHERE org_id = $1 AND provider = $2 AND region = $3
+       LIMIT 1`,
+      [orgId, provider, region],
+    );
+    if (rows.length === 0) return null;
+    const row = rows[0];
+    if (!row.payload || !Array.isArray(row.payload.models)) {
+      log.warn(
+        { orgId, provider, region },
+        "byot-catalog-store: malformed payload in DB row — ignoring",
+      );
+      return null;
+    }
+    const fetchedAt =
+      row.fetched_at instanceof Date
+        ? row.fetched_at.toISOString()
+        : new Date(row.fetched_at).toISOString();
+    return { models: row.payload.models, fetchedAt };
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), orgId, provider },
+      "byot-catalog-store: load failed — falling through to upstream fetch",
+    );
+    return null;
+  }
+}
+
+/**
+ * Persist a freshly-fetched catalog. Best-effort: a DB write failure is
+ * logged but never thrown back to the caller — the L1 cache + return
+ * value are still good, and the next request will retry the write.
+ */
+export async function storeToDB(
+  orgId: string,
+  provider: ByotProviderKey,
+  region: string = "",
+  catalog: PersistedCatalog,
+): Promise<void> {
+  if (!hasInternalDB()) return;
+  try {
+    await internalQuery(
+      `INSERT INTO workspace_model_catalog (org_id, provider, region, payload, fetched_at)
+       VALUES ($1, $2, $3, $4::jsonb, $5::timestamptz)
+       ON CONFLICT (org_id, provider, region) DO UPDATE SET
+         payload = EXCLUDED.payload,
+         fetched_at = EXCLUDED.fetched_at,
+         updated_at = now()`,
+      [
+        orgId,
+        provider,
+        region,
+        JSON.stringify({ models: catalog.models }),
+        catalog.fetchedAt,
+      ],
+    );
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), orgId, provider, region },
+      "byot-catalog-store: persist failed — L1 cache only this round",
+    );
+  }
+}
+
+/**
+ * Drop every persisted entry for an org. Called from the per-provider
+ * cache invalidators on key rotation so the L2 layer is flushed in
+ * lockstep with the L1 layer.
+ */
+export async function deleteFromDB(
+  orgId: string,
+  provider: ByotProviderKey,
+): Promise<void> {
+  if (!hasInternalDB()) return;
+  try {
+    await internalQuery(
+      `DELETE FROM workspace_model_catalog WHERE org_id = $1 AND provider = $2`,
+      [orgId, provider],
+    );
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), orgId, provider },
+      "byot-catalog-store: delete failed — stale L2 entry may shadow next refresh",
+    );
+  }
+}
+
+/**
+ * Check whether a persisted entry has aged out vs. the supplied TTL.
+ * Caller-owned freshness check so each per-provider module can keep its
+ * own TTL knob (`ATLAS_BYOT_CATALOG_TTL_MS`).
+ */
+export function isFresh(persisted: PersistedCatalog, ttlMs: number): boolean {
+  const fetched = Date.parse(persisted.fetchedAt);
+  if (!Number.isFinite(fetched)) return false;
+  return Date.now() - fetched < ttlMs;
+}

--- a/packages/api/src/lib/db/migrations/0058_workspace_model_catalog.sql
+++ b/packages/api/src/lib/db/migrations/0058_workspace_model_catalog.sql
@@ -1,0 +1,61 @@
+-- 0058 — workspace_model_catalog: DB-backed BYOT discovery cache (#2274)
+--
+-- The per-provider catalog modules (anthropic/openai/bedrock) keep an
+-- in-memory cache scoped per pod. That's fine for L1 (request-burst
+-- dedup), but in a multi-pod region each pod cold-starts independently
+-- and hammers upstream on first request — and a pod restart wipes the
+-- cache entirely. This table is the L2: cross-pod, survival-across-
+-- restart catalog cache. Read-through pattern: per-provider module
+-- checks in-mem → DB → upstream → write both back.
+--
+-- One row per (org_id, provider, region) so bedrock entries don't
+-- collide when a workspace migrates between regions. `region` is the
+-- empty string for non-bedrock providers (anthropic / openai catalogs
+-- are not region-scoped).
+--
+-- `payload` is the wire shape of the catalog response (`GatewayCatalogResponse`-
+-- compatible JSON). We store it as JSONB so the scheduler refresh job
+-- can introspect entries cheaply when it implements deprecation
+-- detection (#2275).
+--
+-- This is an OPERATIONAL cache — not user-surfaced content — so it
+-- intentionally bypasses the content-mode system. No status column, no
+-- mode-overlay reads, no participation in the admin Publish flow.
+
+CREATE TABLE IF NOT EXISTS workspace_model_catalog (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  -- Empty string for non-region-scoped providers so the unique constraint
+  -- stays simple. Bedrock writes the actual region (us-east-1, etc.).
+  region TEXT NOT NULL DEFAULT '',
+  payload JSONB NOT NULL,
+  fetched_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Identity constraint: one entry per (org, provider, region) tuple.
+DO $$ BEGIN
+  ALTER TABLE workspace_model_catalog
+    ADD CONSTRAINT uq_workspace_model_catalog_org_provider_region
+    UNIQUE (org_id, provider, region);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- Provider whitelist: stays in lockstep with chk_model_provider on
+-- workspace_model_config. 'gateway' is excluded because the gateway
+-- catalog is anonymous + globally cached — there's no per-workspace
+-- entry to persist.
+DO $$ BEGIN
+  ALTER TABLE workspace_model_catalog
+    ADD CONSTRAINT chk_workspace_model_catalog_provider
+    CHECK (provider IN ('anthropic', 'openai', 'bedrock'));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE INDEX IF NOT EXISTS idx_workspace_model_catalog_org_provider
+  ON workspace_model_catalog (org_id, provider);
+
+-- For the periodic refresh job: find rows with the oldest fetched_at
+-- and walk them in order. Partial index keeps the scan tight.
+CREATE INDEX IF NOT EXISTS idx_workspace_model_catalog_fetched_at
+  ON workspace_model_catalog (fetched_at);

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -844,6 +844,41 @@ export const workspaceModelConfig = pgTable(
 );
 
 // ---------------------------------------------------------------------------
+// BYOT model catalog cache (#2274) — L2 to per-pod in-memory caches.
+//
+// Operational cache, not user-surfaced content — intentionally bypasses
+// the mode system. The `gateway` provider is excluded because that
+// catalog is anonymous + globally cached server-side.
+// ---------------------------------------------------------------------------
+
+export const workspaceModelCatalog = pgTable(
+  "workspace_model_catalog",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    orgId: text("org_id").notNull(),
+    provider: text("provider").notNull(),
+    region: text("region").notNull().default(""),
+    payload: jsonb("payload").notNull(),
+    fetchedAt: timestamp("fetched_at", { withTimezone: true }).notNull().defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    check(
+      "chk_workspace_model_catalog_provider",
+      sql`provider IN ('anthropic', 'openai', 'bedrock')`,
+    ),
+    uniqueIndex("uq_workspace_model_catalog_org_provider_region").on(
+      t.orgId,
+      t.provider,
+      t.region,
+    ),
+    index("idx_workspace_model_catalog_org_provider").on(t.orgId, t.provider),
+    index("idx_workspace_model_catalog_fetched_at").on(t.fetchedAt),
+  ],
+);
+
+// ---------------------------------------------------------------------------
 // Approval workflows
 // ---------------------------------------------------------------------------
 

--- a/packages/api/src/lib/openai-catalog.ts
+++ b/packages/api/src/lib/openai-catalog.ts
@@ -13,6 +13,12 @@
  */
 
 import type { GatewayCatalogModel } from "@useatlas/types";
+import {
+  deleteFromDB,
+  isFresh,
+  loadFromDB,
+  storeToDB,
+} from "./byot-catalog-store";
 import { createLogger } from "./logger";
 
 const log = createLogger("openai-catalog");
@@ -226,9 +232,17 @@ export async function getOpenAICatalog(
   opts: { refresh?: boolean } = {},
 ): Promise<OpenAICatalogResponse> {
   if (!opts.refresh) {
+    // L1: in-memory.
     const hit = cache.get(orgId);
     if (hit && hit.expiresAt > Date.now()) {
       return { models: hit.models, fetchedAt: hit.fetchedAt, source: "cache" };
+    }
+    // L2: DB-backed cache (#2274).
+    const fromDb = await loadFromDB(orgId, "openai");
+    if (fromDb && isFresh(fromDb, ttlMs())) {
+      const expiresAt = Date.parse(fromDb.fetchedAt) + ttlMs();
+      cache.set(orgId, { models: fromDb.models, fetchedAt: fromDb.fetchedAt, expiresAt });
+      return { models: fromDb.models, fetchedAt: fromDb.fetchedAt, source: "cache" };
     }
   }
 
@@ -243,6 +257,10 @@ export async function getOpenAICatalog(
         expiresAt: now + ttlMs(),
       };
       cache.set(orgId, entry);
+      await storeToDB(orgId, "openai", "", {
+        models: entry.models,
+        fetchedAt: entry.fetchedAt,
+      });
       return entry;
     })().finally(() => {
       inflight.delete(orgId);
@@ -254,11 +272,12 @@ export async function getOpenAICatalog(
 }
 
 /**
- * Drop the cached catalog for an org. Called from
+ * Drop the cached catalog for an org (L1 + L2). Called from
  * `setWorkspaceModelConfig` on a successful openai upsert.
  */
 export function invalidateOpenAICatalog(orgId: string): void {
   cache.delete(orgId);
+  void deleteFromDB(orgId, "openai");
 }
 
 /** Test-only: clear all cached entries. */


### PR DESCRIPTION
## Summary

Promotes the per-pod in-memory BYOT catalog caches (anthropic/openai/bedrock) to a DB-backed L2 layer. Each provider module now reads L1 (in-mem) → L2 (DB) → upstream, and writes back through both on fresh fetch. The L1 cache stays as the inflight-dedup substrate; L2 gives cross-pod consistency + survival across pod restarts.

Stacked on #2278 (Bedrock) → #2277 (OpenAI) → #2276 (Anthropic).

- Migration **0058** — \`workspace_model_catalog (org_id, provider, region, payload JSONB, fetched_at)\` with UNIQUE (org_id, provider, region). Region is empty string for non-region providers; bedrock writes the actual region. Provider whitelist matches \`workspace_model_config\` minus \`gateway\` (anonymous + globally cached). Schema.ts mirror added.
- \`packages/api/src/lib/byot-catalog-store.ts\` — \`loadFromDB\`, \`storeToDB\`, \`deleteFromDB\`, \`isFresh\` helpers. **All DB paths are best-effort** — a DB outage falls through to the in-memory + upstream path. L2 is a performance optimization, not correctness.
- Each per-provider catalog module gets:
  - L2 read between the L1 hit check and the upstream fetch.
  - L2 write inside the inflight-dedup block on fresh fetch (so concurrent callers don't duplicate the persist).
  - Invalidator flushes both layers; the L2 delete is fire-and-forget so Effect-scoped callers stay synchronous.
- The L2 cache is OPERATIONAL — it intentionally bypasses the content-mode system. Documented in the migration header.

**Scheduler-driven periodic refresh** is split out as a follow-up — this PR ships the durable layer + L1↔L2 wiring; the daily walk job lands separately. Adding a scheduler hook here would expand the review surface without changing the observable BYOT behavior.

Closes #2274.

## Test plan
- [x] \`bun test src/lib/__tests__/byot-catalog-store.test.ts\` — 15 unit tests (load hit/miss, region handling, malformed payload, best-effort error swallowing, freshness, delete).
- [x] Existing 37 admin-model-config integration tests still pass — L2 wiring is transparent to the route layer.
- [x] \`bun run type\` + \`bun run lint\` clean.
- [x] \`bun run scripts/test-isolated.ts --affected\` — 92/92 affected isolated tests pass.
- [x] Schema + template drift checks pass.
- [ ] Manual: with Postgres running, save anthropic key → refresh catalog → restart API → confirm catalog is served from \`workspace_model_catalog\` row without a fresh anthropic /v1/models call.