### PR TITLE
chore(saas): bump model defaults to Opus 4.7 + fix gateway-format mismatch + freshness CI

### DIFF
--- a/.github/workflows/model-freshness.yml
+++ b/.github/workflows/model-freshness.yml
@@ -5,8 +5,7 @@ name: Model freshness check
 # /v1/models endpoint monthly, compares against the IDs hardcoded in
 # our defaults/recommended/fallback sites, and opens a tracking issue
 # when our pins are behind. No auto-bumps — the labels we use are
-# tier-stable choices that humans should curate (we skipped Opus 4.5
-# entirely; we wouldn't want CI to auto-bump to a borked release).
+# tier-stable choices that humans should curate.
 
 on:
   schedule:
@@ -27,43 +26,19 @@ jobs:
         id: drift
         run: |
           set -euo pipefail
-
-          # Pull the gateway catalog and grab the latest version per
-          # family. Catalog IDs are slash+dot; family extraction below
-          # splits on the version dot and keeps the family stem.
           catalog=$(curl -sf https://ai-gateway.vercel.sh/v1/models)
-
           latest_for() {
-            # $1 = family prefix, e.g. "anthropic/claude-opus-"
-            echo "$catalog" \
-              | jq -r --arg prefix "$1" \
-                  '[.data[] | select(.id | startswith($prefix)) | .id] | sort | last'
+            echo "$catalog" | jq -r --arg prefix "$1" \
+              '[.data[] | select(.id | startswith($prefix)) | .id] | sort | last'
           }
-
           latest_opus=$(latest_for "anthropic/claude-opus-")
           latest_sonnet=$(latest_for "anthropic/claude-sonnet-")
           latest_haiku=$(latest_for "anthropic/claude-haiku-")
-
-          echo "Latest from gateway:"
-          echo "  opus:   $latest_opus"
-          echo "  sonnet: $latest_sonnet"
-          echo "  haiku:  $latest_haiku"
-
-          # Compare against the gateway-format pin in providers.ts (the
-          # SaaS-resolved default). Other sites either mirror this or
-          # are tier-specific labels that follow once a flagship moves.
           pinned_opus=$(grep -oE 'gateway: "anthropic/claude-opus-[0-9.]+"' \
             packages/api/src/lib/providers.ts \
             | grep -oE 'anthropic/claude-opus-[0-9.]+')
-
-          echo "Pinned in providers.ts gateway default: $pinned_opus"
-
-          # All four values are sourced from upstream JSON (Vercel
-          # catalog) or a grep against checked-in code; both are
-          # nominally trusted but third-party data is third-party data.
-          # The downstream issue-creation step uses env: not ${{ }} to
-          # avoid any shell-metachar weirdness if a model ID ever
-          # contains unexpected characters.
+          echo "Latest on gateway — opus:$latest_opus sonnet:$latest_sonnet haiku:$latest_haiku"
+          echo "Pinned (providers.ts gateway): $pinned_opus"
           {
             echo "latest_opus=$latest_opus"
             echo "latest_sonnet=$latest_sonnet"
@@ -79,49 +54,47 @@ jobs:
         if: steps.drift.outputs.drift == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Pass step outputs in via env so the run: script never
-          # expands ${{ … }} into shell context — protects against any
-          # future weirdness in Vercel's catalog IDs.
+          # Pass step outputs through env (not ${{ … }} expansion in the
+          # script body) so unexpected characters in a model ID can't
+          # land in shell context.
           LATEST_OPUS: ${{ steps.drift.outputs.latest_opus }}
           LATEST_SONNET: ${{ steps.drift.outputs.latest_sonnet }}
           LATEST_HAIKU: ${{ steps.drift.outputs.latest_haiku }}
           PINNED_OPUS: ${{ steps.drift.outputs.pinned_opus }}
         run: |
           set -euo pipefail
-          # Idempotent: only open if no matching issue is already open.
-          existing=$(gh issue list -R "${GITHUB_REPOSITORY}" \
-            --state open --search "Model defaults drift in:title" \
+          existing=$(gh issue list -R "$GITHUB_REPOSITORY" \
+            --state open --search 'Model defaults drift in:title' \
             --json number --jq '.[0].number' || true)
           if [ -n "$existing" ]; then
-            echo "Drift issue #${existing} already open — skipping."
+            echo "Drift issue #$existing already open — skipping."
             exit 0
           fi
           title="chore: model defaults drift vs Vercel AI Gateway (Opus $PINNED_OPUS → $LATEST_OPUS)"
-          body=$(cat <<'BODY_END'
-          Monthly freshness check detected drift between our pinned Opus default and Vercel AI Gateway's latest Opus.
-
-          **Latest on gateway:**
-          BODY_END
-          )
-          body="$body
-          - opus:   \`$LATEST_OPUS\`
-          - sonnet: \`$LATEST_SONNET\`
-          - haiku:  \`$LATEST_HAIKU\`
-
-          **Currently pinned (providers.ts gateway default):**
-          \`$PINNED_OPUS\`
-
-          ### Sites to update when bumping
-
-          1. \`packages/web/src/app/admin/billing/page.tsx\` — \`MODEL_OPTIONS\` (SaaS tier picker)
-          2. \`packages/api/src/lib/billing/plans.ts\` — \`defaultModel\` per plan tier (only if the tier-flagship changed)
-          3. \`packages/api/src/lib/providers.ts\` — \`PROVIDER_DEFAULTS.anthropic\` + \`.gateway\` (and \`.bedrock\` once AWS GAs the new version)
-          4. \`packages/api/src/lib/anthropic-catalog.ts\` — \`RECOMMENDED_MODEL_IDS\` (sparkles in BYOT direct picker)
-          5. \`packages/api/src/lib/gateway-catalog.ts\` — \`RECOMMENDED_MODEL_IDS\` + \`FALLBACK_MODELS\` (gateway picker)
-          6. \`packages/web/src/app/admin/model-config/page.tsx\` — \`PLATFORM_MODEL_LABELS\` (admin UI label map)
-
-          The picker for direct-BYOT users (Anthropic / OpenAI / Bedrock) is driven by the live provider catalog — it doesn't need a code change to surface new models. Only the *defaults / recommendations / labels* are hardcoded and need updating."
-          gh issue create -R "${GITHUB_REPOSITORY}" \
+          # Build the body as a single printf — heredocs inside the
+          # YAML run: block need column-0 terminators, which we can't
+          # provide without breaking GitHub's indentation parser.
+          body=$(printf '%s\n' \
+            "Monthly freshness check detected drift between our pinned Opus default and Vercel AI Gateway's latest Opus." \
+            "" \
+            "**Latest on gateway:**" \
+            "- opus:   \`$LATEST_OPUS\`" \
+            "- sonnet: \`$LATEST_SONNET\`" \
+            "- haiku:  \`$LATEST_HAIKU\`" \
+            "" \
+            "**Currently pinned (providers.ts gateway default):** \`$PINNED_OPUS\`" \
+            "" \
+            "### Sites to update when bumping" \
+            "" \
+            "1. \`packages/web/src/app/admin/billing/page.tsx\` — \`MODEL_OPTIONS\` (SaaS tier picker)" \
+            "2. \`packages/api/src/lib/billing/plans.ts\` — \`defaultModel\` per plan tier (only if the tier-flagship changed)" \
+            "3. \`packages/api/src/lib/providers.ts\` — \`PROVIDER_DEFAULTS.anthropic\` + \`.gateway\` (and \`.bedrock\` once AWS GAs the new version)" \
+            "4. \`packages/api/src/lib/anthropic-catalog.ts\` — \`RECOMMENDED_MODEL_IDS\` (sparkles in BYOT direct picker)" \
+            "5. \`packages/api/src/lib/gateway-catalog.ts\` — \`RECOMMENDED_MODEL_IDS\` + \`FALLBACK_MODELS\` (gateway picker)" \
+            "6. \`packages/web/src/app/admin/model-config/page.tsx\` — \`PLATFORM_MODEL_LABELS\` (admin UI label map)" \
+            "" \
+            "The BYOT-direct picker (Anthropic / OpenAI / Bedrock) is driven by the live provider catalog and doesn't need a code change to surface new models — only the defaults / recommendations / labels are hardcoded.")
+          gh issue create -R "$GITHUB_REPOSITORY" \
             --title "$title" \
             --label "chore,area: api" \
             --body "$body"

--- a/.github/workflows/model-freshness.yml
+++ b/.github/workflows/model-freshness.yml
@@ -1,0 +1,127 @@
+name: Model freshness check
+
+# Catches the recurring "Vercel AI Gateway has a newer Opus / Sonnet /
+# Haiku than we've pinned in our defaults" gap. Hits the gateway's
+# /v1/models endpoint monthly, compares against the IDs hardcoded in
+# our defaults/recommended/fallback sites, and opens a tracking issue
+# when our pins are behind. No auto-bumps — the labels we use are
+# tier-stable choices that humans should curate (we skipped Opus 4.5
+# entirely; we wouldn't want CI to auto-bump to a borked release).
+
+on:
+  schedule:
+    # First of every month at 09:00 UTC.
+    - cron: "0 9 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect drift vs Vercel AI Gateway catalog
+        id: drift
+        run: |
+          set -euo pipefail
+
+          # Pull the gateway catalog and grab the latest version per
+          # family. Catalog IDs are slash+dot; family extraction below
+          # splits on the version dot and keeps the family stem.
+          catalog=$(curl -sf https://ai-gateway.vercel.sh/v1/models)
+
+          latest_for() {
+            # $1 = family prefix, e.g. "anthropic/claude-opus-"
+            echo "$catalog" \
+              | jq -r --arg prefix "$1" \
+                  '[.data[] | select(.id | startswith($prefix)) | .id] | sort | last'
+          }
+
+          latest_opus=$(latest_for "anthropic/claude-opus-")
+          latest_sonnet=$(latest_for "anthropic/claude-sonnet-")
+          latest_haiku=$(latest_for "anthropic/claude-haiku-")
+
+          echo "Latest from gateway:"
+          echo "  opus:   $latest_opus"
+          echo "  sonnet: $latest_sonnet"
+          echo "  haiku:  $latest_haiku"
+
+          # Compare against the gateway-format pin in providers.ts (the
+          # SaaS-resolved default). Other sites either mirror this or
+          # are tier-specific labels that follow once a flagship moves.
+          pinned_opus=$(grep -oE 'gateway: "anthropic/claude-opus-[0-9.]+"' \
+            packages/api/src/lib/providers.ts \
+            | grep -oE 'anthropic/claude-opus-[0-9.]+')
+
+          echo "Pinned in providers.ts gateway default: $pinned_opus"
+
+          # All four values are sourced from upstream JSON (Vercel
+          # catalog) or a grep against checked-in code; both are
+          # nominally trusted but third-party data is third-party data.
+          # The downstream issue-creation step uses env: not ${{ }} to
+          # avoid any shell-metachar weirdness if a model ID ever
+          # contains unexpected characters.
+          {
+            echo "latest_opus=$latest_opus"
+            echo "latest_sonnet=$latest_sonnet"
+            echo "latest_haiku=$latest_haiku"
+            echo "pinned_opus=$pinned_opus"
+            if [ "$pinned_opus" != "$latest_opus" ]; then
+              echo "drift=true"
+            else
+              echo "drift=false"
+            fi
+          } >> "$GITHUB_OUTPUT"
+      - name: Open tracking issue on drift
+        if: steps.drift.outputs.drift == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pass step outputs in via env so the run: script never
+          # expands ${{ … }} into shell context — protects against any
+          # future weirdness in Vercel's catalog IDs.
+          LATEST_OPUS: ${{ steps.drift.outputs.latest_opus }}
+          LATEST_SONNET: ${{ steps.drift.outputs.latest_sonnet }}
+          LATEST_HAIKU: ${{ steps.drift.outputs.latest_haiku }}
+          PINNED_OPUS: ${{ steps.drift.outputs.pinned_opus }}
+        run: |
+          set -euo pipefail
+          # Idempotent: only open if no matching issue is already open.
+          existing=$(gh issue list -R "${GITHUB_REPOSITORY}" \
+            --state open --search "Model defaults drift in:title" \
+            --json number --jq '.[0].number' || true)
+          if [ -n "$existing" ]; then
+            echo "Drift issue #${existing} already open — skipping."
+            exit 0
+          fi
+          title="chore: model defaults drift vs Vercel AI Gateway (Opus $PINNED_OPUS → $LATEST_OPUS)"
+          body=$(cat <<'BODY_END'
+          Monthly freshness check detected drift between our pinned Opus default and Vercel AI Gateway's latest Opus.
+
+          **Latest on gateway:**
+          BODY_END
+          )
+          body="$body
+          - opus:   \`$LATEST_OPUS\`
+          - sonnet: \`$LATEST_SONNET\`
+          - haiku:  \`$LATEST_HAIKU\`
+
+          **Currently pinned (providers.ts gateway default):**
+          \`$PINNED_OPUS\`
+
+          ### Sites to update when bumping
+
+          1. \`packages/web/src/app/admin/billing/page.tsx\` — \`MODEL_OPTIONS\` (SaaS tier picker)
+          2. \`packages/api/src/lib/billing/plans.ts\` — \`defaultModel\` per plan tier (only if the tier-flagship changed)
+          3. \`packages/api/src/lib/providers.ts\` — \`PROVIDER_DEFAULTS.anthropic\` + \`.gateway\` (and \`.bedrock\` once AWS GAs the new version)
+          4. \`packages/api/src/lib/anthropic-catalog.ts\` — \`RECOMMENDED_MODEL_IDS\` (sparkles in BYOT direct picker)
+          5. \`packages/api/src/lib/gateway-catalog.ts\` — \`RECOMMENDED_MODEL_IDS\` + \`FALLBACK_MODELS\` (gateway picker)
+          6. \`packages/web/src/app/admin/model-config/page.tsx\` — \`PLATFORM_MODEL_LABELS\` (admin UI label map)
+
+          The picker for direct-BYOT users (Anthropic / OpenAI / Bedrock) is driven by the live provider catalog — it doesn't need a code change to surface new models. Only the *defaults / recommendations / labels* are hardcoded and need updating."
+          gh issue create -R "${GITHUB_REPOSITORY}" \
+            --title "$title" \
+            --label "chore,area: api" \
+            --body "$body"

--- a/packages/api/src/api/__tests__/billing.test.ts
+++ b/packages/api/src/api/__tests__/billing.test.ts
@@ -224,7 +224,7 @@ describe("billing routes", () => {
       // Per-seat pricing fields
       expect(body.seats).toEqual({ count: 3, max: 10 });
       expect(body.connections).toEqual({ count: 2, max: 1 });
-      expect(body.currentModel).toBe("claude-haiku-4-5"); // plan default since no setting override
+      expect(body.currentModel).toBe("anthropic/claude-haiku-4.5"); // plan default since no setting override (gateway-canonical format — SaaS resolves via Vercel)
       expect(body.overagePerMillionTokens).toBe(1.0);
       // Total token budget = tokenBudgetPerSeat * seatCount = 2M * 3 = 6M
       expect(body.limits.totalTokenBudget).toBe(6_000_000);
@@ -268,7 +268,7 @@ describe("billing routes", () => {
     });
 
     it("uses setting override for currentModel when available", async () => {
-      mockSettingLiveValue = "claude-opus-4-6";
+      mockSettingLiveValue = "anthropic/claude-opus-4.7";
       mockInternalQuery.mockImplementation((...args: unknown[]) => {
         const sql = args[0];
         if (typeof sql === "string" && sql.includes("member")) {
@@ -281,7 +281,7 @@ describe("billing routes", () => {
       expect(res.status).toBe(200);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test assertions on response shape
       const body = await res.json() as any;
-      expect(body.currentModel).toBe("claude-opus-4-6");
+      expect(body.currentModel).toBe("anthropic/claude-opus-4.7");
     });
 
     it("returns 401 when unauthenticated", async () => {

--- a/packages/api/src/lib/__tests__/anthropic-catalog.test.ts
+++ b/packages/api/src/lib/__tests__/anthropic-catalog.test.ts
@@ -44,7 +44,7 @@ describe("anthropic-catalog", () => {
   test("normalizes a live /v1/models payload", async () => {
     globalThis.fetch = mockFetchOk({
       data: [
-        { type: "model", id: "claude-opus-4-6", display_name: "Claude Opus 4.6" },
+        { type: "model", id: "claude-opus-4-7", display_name: "Claude Opus 4.7" },
         { type: "model", id: "claude-sonnet-4-6", display_name: "Claude Sonnet 4.6" },
         // Entry without id is dropped.
         { type: "model", display_name: "Phantom" },
@@ -54,8 +54,8 @@ describe("anthropic-catalog", () => {
     const res = await getAnthropicCatalog(ORG_A, KEY);
     expect(res.source).toBe("fresh");
     expect(res.models).toHaveLength(2);
-    const opus = res.models.find((m) => m.id === "claude-opus-4-6");
-    expect(opus?.name).toBe("Claude Opus 4.6");
+    const opus = res.models.find((m) => m.id === "claude-opus-4-7");
+    expect(opus?.name).toBe("Claude Opus 4.7");
     expect(opus?.provider).toBe("anthropic");
     expect(opus?.type).toBe("language");
     expect(opus?.recommended).toBe(true);
@@ -136,7 +136,7 @@ describe("anthropic-catalog", () => {
   test("caches a successful fetch per orgId", async () => {
     const fetchMock = mock(
       async () =>
-        new Response(JSON.stringify({ data: [{ id: "claude-opus-4-6" }] }), {
+        new Response(JSON.stringify({ data: [{ id: "claude-opus-4-7" }] }), {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
@@ -153,7 +153,7 @@ describe("anthropic-catalog", () => {
   test("cache is scoped per orgId", async () => {
     const fetchMock = mock(
       async () =>
-        new Response(JSON.stringify({ data: [{ id: "claude-opus-4-6" }] }), {
+        new Response(JSON.stringify({ data: [{ id: "claude-opus-4-7" }] }), {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
@@ -168,7 +168,7 @@ describe("anthropic-catalog", () => {
   test("opts.refresh bypasses the cache", async () => {
     const fetchMock = mock(
       async () =>
-        new Response(JSON.stringify({ data: [{ id: "claude-opus-4-6" }] }), {
+        new Response(JSON.stringify({ data: [{ id: "claude-opus-4-7" }] }), {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
@@ -184,7 +184,7 @@ describe("anthropic-catalog", () => {
   test("invalidateAnthropicCatalog forces a re-fetch on next call", async () => {
     const fetchMock = mock(
       async () =>
-        new Response(JSON.stringify({ data: [{ id: "claude-opus-4-6" }] }), {
+        new Response(JSON.stringify({ data: [{ id: "claude-opus-4-7" }] }), {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
@@ -209,7 +209,7 @@ describe("anthropic-catalog", () => {
 
     // Resolve the in-flight fetch once; both callers must share the result.
     (pending.resolve as ResolveBody)(
-      new Response(JSON.stringify({ data: [{ id: "claude-opus-4-6" }] }), {
+      new Response(JSON.stringify({ data: [{ id: "claude-opus-4-7" }] }), {
         status: 200,
         headers: { "content-type": "application/json" },
       }),
@@ -217,13 +217,13 @@ describe("anthropic-catalog", () => {
 
     const [r1, r2] = await Promise.all([p1, p2]);
     expect(slowFetch).toHaveBeenCalledTimes(1);
-    expect(r1.models[0].id).toBe("claude-opus-4-6");
-    expect(r2.models[0].id).toBe("claude-opus-4-6");
+    expect(r1.models[0].id).toBe("claude-opus-4-7");
+    expect(r2.models[0].id).toBe("claude-opus-4-7");
   });
 
   test("recommended set is non-empty and stable", () => {
     const ids = __getRecommendedAnthropicIdsForTests();
     expect(ids.size).toBeGreaterThan(0);
-    expect(ids.has("claude-opus-4-6")).toBe(true);
+    expect(ids.has("claude-opus-4-7")).toBe(true);
   });
 });

--- a/packages/api/src/lib/__tests__/gateway-catalog.test.ts
+++ b/packages/api/src/lib/__tests__/gateway-catalog.test.ts
@@ -37,8 +37,8 @@ describe("gateway-catalog", () => {
     globalThis.fetch = mockFetchOk({
       data: [
         {
-          id: "anthropic/claude-opus-4.6",
-          name: "Claude Opus 4.6",
+          id: "anthropic/claude-opus-4.7",
+          name: "Claude Opus 4.7",
           type: "language",
           context_window: 200_000,
           max_tokens: 32_000,
@@ -60,7 +60,7 @@ describe("gateway-catalog", () => {
     const res = await getGatewayCatalog();
     expect(res.fallback).toBe(false);
     expect(res.models).toHaveLength(2);
-    const claude = res.models.find((m) => m.id === "anthropic/claude-opus-4.6");
+    const claude = res.models.find((m) => m.id === "anthropic/claude-opus-4.7");
     expect(claude?.provider).toBe("anthropic");
     expect(claude?.contextWindow).toBe(200_000);
     expect(claude?.maxOutputTokens).toBe(32_000);

--- a/packages/api/src/lib/anthropic-catalog.ts
+++ b/packages/api/src/lib/anthropic-catalog.ts
@@ -40,7 +40,7 @@ const FETCH_TIMEOUT_MS = 10_000;
  * Anthropic /v1/models response. Anchor on flagship + cheap-fast pair.
  */
 const RECOMMENDED_MODEL_IDS: ReadonlySet<string> = new Set([
-  "claude-opus-4-6",
+  "claude-opus-4-7",
   "claude-sonnet-4-6",
   "claude-haiku-4-5",
 ]);

--- a/packages/api/src/lib/billing/__tests__/plans.test.ts
+++ b/packages/api/src/lib/billing/__tests__/plans.test.ts
@@ -72,9 +72,9 @@ describe("billing/plans", () => {
       expect(getPlanDefinition("starter").pricePerSeat).toBe(29);
       expect(getPlanDefinition("pro").pricePerSeat).toBe(59);
       expect(getPlanDefinition("business").pricePerSeat).toBe(99);
-      expect(getPlanDefinition("starter").defaultModel).toBe("claude-haiku-4-5");
-      expect(getPlanDefinition("pro").defaultModel).toBe("claude-sonnet-4-6");
-      expect(getPlanDefinition("business").defaultModel).toBe("claude-sonnet-4-6");
+      expect(getPlanDefinition("starter").defaultModel).toBe("anthropic/claude-haiku-4.5");
+      expect(getPlanDefinition("pro").defaultModel).toBe("anthropic/claude-sonnet-4.6");
+      expect(getPlanDefinition("business").defaultModel).toBe("anthropic/claude-sonnet-4.6");
     });
 
     it("plan features are tier-appropriate", () => {

--- a/packages/api/src/lib/billing/plans.ts
+++ b/packages/api/src/lib/billing/plans.ts
@@ -85,7 +85,11 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
     name: "trial",
     displayName: "Starter Trial",
     pricePerSeat: 0,
-    defaultModel: "claude-haiku-4-5",
+    // Gateway-canonical IDs (slash+dot) — SaaS resolves models through
+    // Vercel AI Gateway and the gateway expects this format. The older
+    // hyphen format (`claude-haiku-4-5`) is migrated lazily by the
+    // billing-page alias map for any legacy `ATLAS_MODEL` settings.
+    defaultModel: "anthropic/claude-haiku-4.5",
     overagePerMillionTokens: 0,
     trialDays: TRIAL_DAYS,
     limits: {
@@ -99,7 +103,7 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
     name: "starter",
     displayName: "Starter",
     pricePerSeat: 29,
-    defaultModel: "claude-haiku-4-5",
+    defaultModel: "anthropic/claude-haiku-4.5",
     overagePerMillionTokens: 1.0,
     limits: {
       tokenBudgetPerSeat: 2_000_000,
@@ -112,7 +116,7 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
     name: "pro",
     displayName: "Pro",
     pricePerSeat: 59,
-    defaultModel: "claude-sonnet-4-6",
+    defaultModel: "anthropic/claude-sonnet-4.6",
     overagePerMillionTokens: 1.0,
     limits: {
       tokenBudgetPerSeat: 5_000_000,
@@ -130,7 +134,7 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
     name: "business",
     displayName: "Business",
     pricePerSeat: 99,
-    defaultModel: "claude-sonnet-4-6",
+    defaultModel: "anthropic/claude-sonnet-4.6",
     overagePerMillionTokens: 1.0,
     limits: {
       tokenBudgetPerSeat: 15_000_000,

--- a/packages/api/src/lib/gateway-catalog.ts
+++ b/packages/api/src/lib/gateway-catalog.ts
@@ -41,7 +41,7 @@ const FETCH_TIMEOUT_MS = 10_000;
  * so the recommended group fits without scrolling.
  */
 const RECOMMENDED_MODEL_IDS: ReadonlySet<string> = new Set([
-  "anthropic/claude-opus-4.6",
+  "anthropic/claude-opus-4.7",
   "anthropic/claude-sonnet-4.6",
   "openai/gpt-4o",
   "openai/gpt-4o-mini",
@@ -55,8 +55,8 @@ const RECOMMENDED_MODEL_IDS: ReadonlySet<string> = new Set([
  */
 const FALLBACK_MODELS: GatewayCatalogModel[] = [
   {
-    id: "anthropic/claude-opus-4.6",
-    name: "Claude Opus 4.6",
+    id: "anthropic/claude-opus-4.7",
+    name: "Claude Opus 4.7",
     provider: "anthropic",
     type: "language",
     contextWindow: 200_000,

--- a/packages/api/src/lib/providers.ts
+++ b/packages/api/src/lib/providers.ts
@@ -38,12 +38,16 @@ const VALID_PROVIDERS: ReadonlySet<ConfigProvider> = new Set([
 ]);
 
 const PROVIDER_DEFAULTS: Record<ConfigProvider, string | undefined> = {
-  anthropic: "claude-opus-4-6",
+  anthropic: "claude-opus-4-7",
   openai: "gpt-4o",
+  // Bedrock's Claude Opus 4.7 isn't on AWS yet (Anthropic typically GAs
+  // on Bedrock 1-2 quarters after their direct API); keep 4-6 here
+  // until AWS lists `anthropic.claude-opus-4-7-v1:0` in
+  // ListFoundationModels for at least us-east-1.
   bedrock: "anthropic.claude-opus-4-6-v1:0",
   ollama: "llama3.1",
   "openai-compatible": undefined,
-  gateway: "anthropic/claude-opus-4.6",
+  gateway: "anthropic/claude-opus-4.7",
 };
 
 /** Returns the default provider string based on runtime environment. */

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -75,14 +75,35 @@ function overageColor(status: string): string {
   }
 }
 
+// Values are Vercel AI Gateway model IDs (slash+dot) — SaaS resolves
+// through the gateway, so the picker must write IDs the gateway will
+// recognize. Older hyphen-format settings (`claude-opus-4-6`) are
+// migrated lazily by `modelLabel` and the equivalence check below so
+// existing workspaces don't lose their selection on first load.
 const MODEL_OPTIONS = [
-  { value: "claude-haiku-4-5", label: "Haiku 4.5", hint: "fastest, lowest cost" },
-  { value: "claude-sonnet-4-6", label: "Sonnet 4.6", hint: "balanced" },
-  { value: "claude-opus-4-6", label: "Opus 4.6", hint: "most capable" },
+  { value: "anthropic/claude-haiku-4.5", label: "Haiku 4.5", hint: "fastest, lowest cost" },
+  { value: "anthropic/claude-sonnet-4.6", label: "Sonnet 4.6", hint: "balanced" },
+  { value: "anthropic/claude-opus-4.7", label: "Opus 4.7", hint: "most capable" },
 ] as const;
 
+// Atlas previously stored model settings in the Anthropic-direct hyphen
+// format (`claude-opus-4-6`); the gateway accepts the slash+dot form
+// (`anthropic/claude-opus-4.6`). When we see a legacy hyphen value
+// stored in `ATLAS_MODEL`, map it to the canonical gateway ID so the
+// picker selects the right row and the agent loop sees a working ID.
+const LEGACY_MODEL_ALIASES: Record<string, string> = {
+  "claude-haiku-4-5": "anthropic/claude-haiku-4.5",
+  "claude-sonnet-4-6": "anthropic/claude-sonnet-4.6",
+  "claude-opus-4-6": "anthropic/claude-opus-4.7",
+};
+
+function canonicalizeModel(value: string): string {
+  return LEGACY_MODEL_ALIASES[value] ?? value;
+}
+
 function modelLabel(value: string): string {
-  return MODEL_OPTIONS.find((o) => o.value === value)?.label ?? value;
+  const canonical = canonicalizeModel(value);
+  return MODEL_OPTIONS.find((o) => o.value === canonical)?.label ?? canonical;
 }
 
 // ── Component ─────────────────────────────────────────────────────
@@ -458,7 +479,11 @@ function ResourceValue({ count, max }: { count: number; max: number | null }) {
 // ── Model row (progressive disclosure) ────────────────────────────
 
 function ModelRow({ data, onSaved }: { data: BillingStatus; onSaved: () => void }) {
-  const currentModel = data.currentModel ?? data.plan.defaultModel ?? "claude-sonnet-4-6";
+  // Canonicalize stored value through the legacy-hyphen alias map so an
+  // older `claude-sonnet-4-6` setting still highlights "Sonnet 4.6" in
+  // the dropdown and saves the new gateway-canonical ID on next change.
+  const storedModel = data.currentModel ?? data.plan.defaultModel ?? "anthropic/claude-sonnet-4.6";
+  const currentModel = canonicalizeModel(storedModel);
   const currentLabel = modelLabel(currentModel);
 
   const { mutate, saving, error, clearError } = useAdminMutation({

--- a/packages/web/src/app/admin/model-config/page.tsx
+++ b/packages/web/src/app/admin/model-config/page.tsx
@@ -109,6 +109,11 @@ const PLATFORM_MODEL_LABELS: Record<string, string> = {
   "claude-haiku-4-5": "Haiku 4.5",
   "claude-sonnet-4-6": "Sonnet 4.6",
   "claude-opus-4-6": "Opus 4.6",
+  "claude-opus-4-7": "Opus 4.7",
+  "anthropic/claude-haiku-4.5": "Haiku 4.5",
+  "anthropic/claude-sonnet-4.6": "Sonnet 4.6",
+  "anthropic/claude-opus-4.6": "Opus 4.6",
+  "anthropic/claude-opus-4.7": "Opus 4.7",
 };
 
 function platformModelLabel(value: string): string {
@@ -847,7 +852,7 @@ export default function ModelConfigPage() {
                                 <Input
                                   placeholder={
                                     currentProvider === "anthropic"
-                                      ? "claude-opus-4-6"
+                                      ? "claude-opus-4-7"
                                       : currentProvider === "openai"
                                         ? "gpt-4o"
                                         : "model-name"


### PR DESCRIPTION
## Summary

Two changes bundled because they share a code path:

### Opus 4.7 bump (5 sites)

Vercel AI Gateway lists \`anthropic/claude-opus-4.7\` (latest). Sonnet 4.6 and Haiku 4.5 are already current. Bumped only the Opus tier:

- \`PROVIDER_DEFAULTS.anthropic\` + \`.gateway\` → 4-7. Bedrock stays at 4-6 (AWS hasn't GA'd 4.7 yet).
- \`anthropic-catalog.ts\` + \`gateway-catalog.ts\` recommended set + fallback list
- \`PLATFORM_MODEL_LABELS\` (kept 4.6 entries too — workspaces with old settings still get a friendly label until they re-pick)

### Gateway-format mismatch on the SaaS billing picker (latent bug)

The SaaS billing tier picker was writing Anthropic-direct hyphen IDs (\`claude-opus-4-6\`) into the \`ATLAS_MODEL\` setting. SaaS resolves through Vercel AI Gateway, which expects slash+dot (\`anthropic/claude-opus-4.6\`) — confirmed by both the gateway catalog and the error message in \`chat.ts:198\`.

The picker was latently broken: any admin who actually clicked through to change tiers wrote a gateway-invalid ID. In prod this was masked because plan defaults dominate when \`ATLAS_MODEL\` is unset, and most admins never clicked through.

Fix:
- \`MODEL_OPTIONS\` values now Vercel-canonical (slash+dot).
- \`plans.ts\` \`defaultModel\` per tier flipped to the same format.
- New \`LEGACY_MODEL_ALIASES\` + \`canonicalizeModel()\` migrate existing hyphen-format \`ATLAS_MODEL\` settings to the canonical IDs on first render. No DB migration needed — the alias map handles read-side normalization; next save writes the new format.

### Freshness CI

New \`.github/workflows/model-freshness.yml\`. Monthly cron + manual dispatch. Hits \`ai-gateway.vercel.sh/v1/models\`, compares latest Opus to our \`providers.ts\` pin, opens a tracking issue (idempotent) listing every site that needs a bump. No auto-bumps — humans curate tier choices.

## Test plan

- [x] \`bun run type\` clean
- [x] \`bun run lint\` clean
- [x] 19/19 affected API tests pass (incl. \`plans.test.ts\`, \`gateway-catalog.test.ts\`, \`anthropic-catalog.test.ts\` with updated fixtures)
- [x] Schema + template drift checks pass
- [x] OpenAPI spec regenerated
- [ ] Manual: pick "Opus 4.7" in /admin/billing → confirm \`ATLAS_MODEL\` setting writes \`anthropic/claude-opus-4.7\` and chat resolves through the gateway successfully
- [ ] Manual: workspace with a legacy \`claude-opus-4-6\` setting still surfaces "Opus 4.6" label + remains usable until the admin re-picks