### PR TITLE
fix(admin): scope connection list to active org, surface __global__ demos, toast on delete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ docs/superpowers/
 # under WSL2. Pre-empt it so `git add` doesn't sweep ~50KB of garbage in.
 C:\\Users\\*
 critique-*.png
+
+# Atlas team dogfood semantic layer + setup script (internal product naming, not part of shipping repo)
+internal/

--- a/packages/api/src/api/__tests__/admin-connections-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections-audit.test.ts
@@ -138,7 +138,16 @@ beforeEach(() => {
   mocks.setPlatformAdmin("org-alpha");
   mockLogAdminAction.mockClear();
   mocks.mockInternalQuery.mockReset();
-  mocks.mockInternalQuery.mockImplementation(async () => []);
+  // The audit suite drives platform admin flows. After the platform_admin
+  // visibility bypass was removed (every caller now goes through
+  // `getVisibleConnectionIds`), the warehouse connection must be present in
+  // the visibility set or `/:id/test` and `/:id/drain` 404 before they emit.
+  mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+    if (typeof sql === "string" && sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
+      return [{ id: "warehouse" }];
+    }
+    return [];
+  });
   mockConnectionList.mockClear();
   mockConnectionList.mockReturnValue(["warehouse"]);
   mockConnectionHas.mockClear();

--- a/packages/api/src/api/__tests__/admin-connections.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections.test.ts
@@ -344,14 +344,18 @@ describe("admin connections — org scoping", () => {
       expect(res.status).toBe(200);
     });
 
-    it("platform admin can health-check any connection", async () => {
+    it("platform admin health-checking a connection not in their active org gets 404", async () => {
+      // Mirrors the platform-admin scoping fix: per-connection routes use
+      // active-org visibility for everyone. Switch active org to reach
+      // another tenant's connection.
       setPlatformAdmin("org-alpha");
+      mocks.mockInternalQuery.mockResolvedValue([]);
 
       const res = await app.fetch(
         adminRequest("/api/v1/admin/connections/other-org-conn/test", "POST"),
       );
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(404);
     });
   });
 
@@ -370,14 +374,21 @@ describe("admin connections — org scoping", () => {
       expect(res.status).toBe(404);
     });
 
-    it("platform admin can drain any connection", async () => {
+    it("platform admin draining a connection not in their active org gets 404", async () => {
+      // After the platform_admin visibility bypass was removed, the
+      // per-connection drain endpoint scopes by active org for everyone.
+      // Cross-org pool drain still works via `POST /pool/orgs/:orgId/drain`
+      // (which accepts an explicit orgId) — that surface remains
+      // platform-admin-only via its own check.
       setPlatformAdmin("org-alpha");
+      // org-alpha does not own warehouse in this fixture
+      mocks.mockInternalQuery.mockResolvedValue([]);
 
       const res = await app.fetch(
         adminRequest("/api/v1/admin/connections/warehouse/drain", "POST"),
       );
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(404);
     });
   });
 
@@ -420,9 +431,17 @@ describe("admin connections — org scoping", () => {
 
   // ─── 4. Platform admin bypasses org filter ──────────────────────────
 
-  describe("platform admin — cross-org access", () => {
-    it("list returns all connections without org filter", async () => {
+  describe("platform admin — list still org-scoped", () => {
+    it("list is scoped to the active org (no cross-org bypass)", async () => {
+      // The previous implementation short-circuited getVisibleConnectionIds
+      // to `return null` for platform admins, which leaked every tenant's
+      // connections into every workspace's admin-connections page. After
+      // the fix, platform admins see the same scoped set as workspace
+      // admins — they must use the workspace switcher (or the dedicated
+      // `/admin/platform/*` surfaces) to look at another org.
       setPlatformAdmin("org-alpha");
+      // org-alpha owns only warehouse in this fixture
+      mocks.mockInternalQuery.mockResolvedValue([{ id: "warehouse" }]);
 
       const res = await app.fetch(
         adminRequest("/api/v1/admin/connections"),
@@ -432,16 +451,13 @@ describe("admin connections — org scoping", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
       const body = (await res.json()) as any;
       const ids = body.connections.map((c: { id: string }) => c.id);
-      // Platform admin sees everything — no filtering
-      expect(ids).toContain("default");
-      expect(ids).toContain("warehouse");
-      expect(ids).toContain("other-org-conn");
+      expect(ids).toEqual(["warehouse"]);
 
-      // getVisibleConnectionIds returns null for platform admins (no DB query), so no org filter applied
+      // Org filter SQL was issued (no platform_admin bypass)
       const orgFilterCall = mocks.mockInternalQuery.mock.calls.find(
         ([sql]) => typeof sql === "string" && sql.includes("SELECT c.id FROM connections c WHERE c.org_id"),
       );
-      expect(orgFilterCall).toBeUndefined();
+      expect(orgFilterCall).toBeDefined();
     });
 
     it("update scopes by active org even for platform admin", async () => {
@@ -547,8 +563,12 @@ describe("admin connections — org scoping", () => {
       expect(ids).toEqual(["warehouse"]);
     });
 
-    it("returns null (no filter) for platform admins — all connections visible", async () => {
+    it("scopes platform admin to their active org's connections (no bypass)", async () => {
+      // The platform_admin "null = no filter" bypass was removed — platform
+      // admins now see the same set as workspace admins. Cross-org views
+      // belong in `/admin/platform/*`.
       setPlatformAdmin("org-alpha");
+      mocks.mockInternalQuery.mockResolvedValue([{ id: "warehouse" }]);
 
       const res = await app.fetch(
         adminRequest("/api/v1/admin/connections"),
@@ -557,8 +577,32 @@ describe("admin connections — org scoping", () => {
       expect(res.status).toBe(200);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
       const body = (await res.json()) as any;
-      // All 3 connections from describe() are returned
-      expect(body.connections).toHaveLength(3);
+      const ids = body.connections.map((c: { id: string }) => c.id);
+      expect(ids).toEqual(["warehouse"]);
+    });
+
+    it("visibility query UNIONs `__global__` connections as a fallback", async () => {
+      // The new visibility SQL UNIONs the org's own rows with rows at
+      // org_id = '__global__' (with an EXISTS check so an own-row shadows
+      // a same-id global row). Used for canonical demos like `__demo__`.
+      setOrgAdmin("org-alpha");
+      mocks.mockInternalQuery.mockResolvedValue([{ id: "warehouse" }]);
+
+      const res = await app.fetch(
+        adminRequest("/api/v1/admin/connections"),
+      );
+
+      expect(res.status).toBe(200);
+
+      // Verify the SQL queried `__global__` in addition to the active org.
+      const visibilityCall = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) => typeof sql === "string" && sql.includes("SELECT c.id FROM connections c WHERE c.org_id"),
+      );
+      expect(visibilityCall).toBeDefined();
+      expect(visibilityCall![0]).toContain("__global__");
+      // Shadow-precedence is enforced via NOT EXISTS, not at the SQL UNION
+      // level — same-id own-rows mask the global counterpart.
+      expect(visibilityCall![0]).toContain("NOT EXISTS");
     });
 
     it("get-by-id returns 404 for connection not visible to org", async () => {

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -76,19 +76,33 @@ function demoReadonly(requestId: string): { error: string; message: string; requ
  */
 export async function getVisibleConnectionIds(
   orgId: string,
-  isPlatformAdmin: boolean,
+  _isPlatformAdmin: boolean,
   mode?: import("@useatlas/types/auth").AtlasMode,
 ): Promise<Set<string> | null> {
-  if (isPlatformAdmin) return null; // null = no filter
-
+  // Always scope to the active org. Platform admins requiring cross-org
+  // visibility must use the workspace switcher to set their active org or
+  // the dedicated `/admin/platform/*` surfaces — bypassing the org filter
+  // here leaks every customer's connections into every workspace's admin
+  // page, which is what the `isPlatformAdmin → return null` branch did
+  // before #<this-PR>.
   const visible = new Set<string>();
 
   if (hasInternalDB()) {
     const statusClause = Effect.runSync(
       contentModeRegistry.readFilter("connections", mode ?? "published", "c"),
     );
+    // Org's own rows + `__global__` fallback. A per-org row with the same
+    // id shadows the global row so onboarding-chosen demos (e.g. an
+    // industry-specific `__demo__`) override the canonical global one.
     const rows = await internalQuery<{ id: string }>(
-      `SELECT c.id FROM connections c WHERE c.org_id = $1 AND ${statusClause} ORDER BY c.id`,
+      `SELECT c.id FROM connections c WHERE c.org_id = $1 AND ${statusClause}
+       UNION
+       SELECT c.id FROM connections c
+       WHERE c.org_id = '__global__' AND ${statusClause}
+         AND NOT EXISTS (
+           SELECT 1 FROM connections c2 WHERE c2.org_id = $1 AND c2.id = c.id
+         )
+       ORDER BY 1`,
       [orgId],
     );
     for (const row of rows) {

--- a/packages/api/src/api/routes/semantic.ts
+++ b/packages/api/src/api/routes/semantic.ts
@@ -14,14 +14,31 @@ import { RequestContext } from "@atlas/api/lib/effect/services";
 import { validationHook } from "./validation-hook";
 import { createLogger } from "@atlas/api/lib/logger";
 import {
-  getSemanticRoot,
+  getSemanticRoot as getBaseSemanticRoot,
   isValidEntityName,
   readYamlFile,
   discoverEntities,
   findEntityFile,
 } from "@atlas/api/lib/semantic/files";
+// Org-aware variant: returns `<base>/.orgs/<orgId>/` when an orgId is present
+// so SaaS workspaces read their own entities instead of the shipped demo.
+import { getSemanticRoot as getOrgSemanticRoot } from "@atlas/api/lib/semantic/sync";
 import { ErrorSchema } from "./shared-schemas";
 import { standardAuth, requestContext, type AuthEnv } from "./middleware";
+
+/**
+ * Resolve the semantic root for this request — org-scoped when the caller's
+ * session has an active org, base root otherwise (self-hosted single-tenant).
+ *
+ * The pre-fix behavior used the base root unconditionally, which meant every
+ * SaaS workspace saw the shipped demo entities (NovaMart) on the chat schema
+ * explorer regardless of their own org-scoped data on disk.
+ */
+function resolveRoot(c: { get: (k: "authResult") => { user?: { activeOrganizationId?: string } } | undefined }): string {
+  const authResult = c.get("authResult");
+  const orgId = authResult?.user?.activeOrganizationId;
+  return orgId ? getOrgSemanticRoot(orgId) : getBaseSemanticRoot();
+}
 
 const log = createLogger("semantic-routes");
 
@@ -136,7 +153,7 @@ semantic.use(requestContext);
 // GET /entities — list all entities (public summary: drops measureCount, connection, source)
 semantic.openapi(listEntitiesRoute, async (c) => {
   return runEffect(c, Effect.sync(() => {
-    const root = getSemanticRoot();
+    const root = resolveRoot(c);
     const discovered = discoverEntities(root);
     const entities = discovered.entities.map(({ table, description, columnCount, joinCount, type }) => ({
       table, description, columnCount, joinCount, type: type ?? "",
@@ -160,7 +177,7 @@ semantic.openapi(getEntityRoute, async (c) => {
       return c.json({ error: "invalid_request", message: "Invalid entity name." }, 400);
     }
 
-    const root = getSemanticRoot();
+    const root = resolveRoot(c);
     const filePath = findEntityFile(root, name);
     if (!filePath) {
       return c.json({ error: "not_found", message: `Entity "${name}" not found.` }, 404);

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -305,6 +305,7 @@ describe("migrateAuthTables", () => {
             { name: "0057_workspace_model_config_bedrock.sql" },
             { name: "0058_workspace_model_catalog.sql" },
             { name: "0059_workspace_model_config_deprecation.sql" },
+            { name: "0060_demo_connection_to_global.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -79,7 +79,7 @@ describe("runMigrations", () => {
 
     const count = await runMigrations(pool);
 
-    expect(count).toBe(60);
+    expect(count).toBe(61);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -168,6 +168,7 @@ describe("runMigrations", () => {
         "0057_workspace_model_config_bedrock.sql",
         "0058_workspace_model_catalog.sql",
         "0059_workspace_model_config_deprecation.sql",
+        "0060_demo_connection_to_global.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0060_demo_connection_to_global.sql
+++ b/packages/api/src/lib/db/migrations/0060_demo_connection_to_global.sql
@@ -1,0 +1,34 @@
+-- Consolidate the `__demo__` connection under org_id = '__global__'.
+--
+-- Before this migration each workspace that completed onboarding owned its
+-- own `__demo__` row. Combined with the platform_admin visibility bypass,
+-- workspaces saw other tenants' demo connections in their admin
+-- connections list — see #<this-PR>. After this migration `__demo__`
+-- lives once at org_id = '__global__' and is surfaced to every org by the
+-- updated `getVisibleConnectionIds` global-fallback rule.
+--
+-- Semantic entities attached to `__demo__` are migrated alongside so the
+-- entity shape stays paired with the connection. The unique constraint
+-- (org_id, entity_type, name, COALESCE(connection_id, '__default__')) is
+-- not at risk because no rows exist at org_id = '__global__' today.
+
+-- 1. Promote the most-recently-touched per-org __demo__ row to __global__.
+WITH chosen AS (
+  SELECT id, url, url_key_version, type, description, schema_name, status
+  FROM connections
+  WHERE id = '__demo__' AND org_id <> '__global__'
+  ORDER BY updated_at DESC NULLS LAST, created_at DESC NULLS LAST
+  LIMIT 1
+)
+INSERT INTO connections (id, url, url_key_version, type, description, schema_name, org_id, status, created_at, updated_at)
+SELECT id, url, url_key_version, type, description, schema_name, '__global__', status, NOW(), NOW()
+FROM chosen
+ON CONFLICT (id, org_id) DO NOTHING;
+
+-- 2. Re-scope semantic entities attached to `__demo__` to the global org.
+UPDATE semantic_entities
+SET org_id = '__global__', updated_at = NOW()
+WHERE connection_id = '__demo__' AND org_id <> '__global__';
+
+-- 3. Drop the now-redundant per-org `__demo__` connection rows.
+DELETE FROM connections WHERE id = '__demo__' AND org_id <> '__global__';

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { toast } from "sonner";
 import { z } from "zod";
 import { useAtlasConfig } from "@/ui/context";
 import { Button } from "@/components/ui/button";
@@ -414,10 +415,16 @@ function DeleteConnectionDialog({
 
   async function handleDelete() {
     if (!connectionId) return;
-    await deleteMutation.mutate({
+    const result = await deleteMutation.mutate({
       path: `/api/v1/admin/connections/${encodeURIComponent(connectionId)}`,
       onSuccess: () => onOpenChange(false),
     });
+    if (result.ok) {
+      toast.success(`Deleted connection “${connectionId}”`);
+    } else {
+      const message = result.error instanceof Error ? result.error.message : "Delete failed";
+      toast.error(`Couldn't delete “${connectionId}”`, { description: message });
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary

Three correctness fixes + one UX fix that surfaced while dogfooding Atlas on the Atlas team org.

- **Platform-admin connection leak (security)** — `getVisibleConnectionIds` short-circuited to `return null` for platform admins, which the list endpoint treated as "no filter" and returned every tenant's connections across every workspace's admin connections page. Removed the bypass — platform admins now see the same scoped set as workspace admins. Cross-org views belong in `/admin/platform/*` (which uses its own dedicated routes).
- **`__global__` connection visibility** — visibility SQL now UNIONs the org's own rows with rows at `org_id = '__global__'`, with a `NOT EXISTS` shadow check so a per-org row of the same id wins. Lets canonical demos live once globally instead of being per-org-pinned. Migration 0060 consolidates existing per-org `__demo__` rows under `__global__` and re-scopes any `semantic_entities` attached to the demo connection so the entity shape travels with it.
- **Schema-explorer NovaMart leak** — `semantic.ts`'s `/entities` + `/entities/:name` routes resolved `getSemanticRoot()` without an orgId, so every SaaS workspace's chat schema explorer served the shipped NovaMart demo files from base root regardless of `.orgs/<orgId>/` content on disk. Routes now resolve the org-scoped root from the auth context (falling back to base root when no active org, e.g. self-hosted single-tenant).
- **Sonner toast on connection delete (UX)** — the admin delete dialog spun silently on both success and error paths. Added `toast.success` / `toast.error` so users get feedback either way; the inline `<MutationErrorSurface>` is preserved for in-dialog error detail.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun run test` — full suite green (after updating the 3 tests that documented the old behavior: 2 migrate-test fixtures got the new `0060_*.sql` entry, and the audit + admin-connections tests now mock the visibility query for platform admins instead of relying on the bypass)
- [x] `bun x syncpack lint` — no issues
- [x] All drift checks pass (template, security headers, railway watch, schema, oauth helper)
- [ ] Post-merge: verify on app.useatlas.dev that (a) the Atlas team org's admin connections list shows only `us-prod`/`eu-prod`/`apac-prod` (no `default`, no Dharma's `__demo__`), (b) the `__demo__` connection is visible to all orgs after migration 0060 runs, (c) the chat schema explorer shows the org's own entities instead of NovaMart, (d) deleting a connection surfaces a sonner toast on success and on error.

## Follow-ups (not in this PR)

- File issue: lift `/admin/platform/*` to a top-level `/platform/*` so the platform-admin context is unmistakable in the URL and impossible to confuse with org-scoped admin pages.
- File issue: revisit `__demo__` design for multi-industry demos (NovaMart vs Sentinel vs others). Onboarding currently still creates per-org rows; the global fallback only fires when no per-org row exists. Whether `__global__` should hold multiple demos (`__demo_ecommerce__`, `__demo_cybersec__`) or stay single-canonical is a design call worth its own discussion.