### PR TITLE
fix(onboarding): share one __demo__ across all workspaces (org_id=__global__)

### DIFF
--- a/packages/api/src/api/__tests__/admin-connections.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections.test.ts
@@ -440,7 +440,7 @@ describe("admin connections — org scoping", () => {
       // connections into every workspace's admin-connections page. After
       // the fix, platform admins see the same scoped set as workspace
       // admins — they must use the workspace switcher (or the dedicated
-      // `/admin/platform/*` surfaces) to look at another org.
+      // `/platform/*` surfaces) to look at another org.
       setPlatformAdmin("org-alpha");
       // org-alpha owns only warehouse in this fixture
       mocks.mockInternalQuery.mockResolvedValue([{ id: "warehouse" }]);
@@ -568,7 +568,7 @@ describe("admin connections — org scoping", () => {
     it("scopes platform admin to their active org's connections (no bypass)", async () => {
       // The platform_admin "null = no filter" bypass was removed — platform
       // admins now see the same set as workspace admins. Cross-org views
-      // belong in `/admin/platform/*`.
+      // belong in `/platform/*`.
       setPlatformAdmin("org-alpha");
       mocks.mockInternalQuery.mockResolvedValue([{ id: "warehouse" }]);
 
@@ -898,7 +898,7 @@ describe("admin connections — org scoping", () => {
     it("DELETE on __demo__ in any mode hides it from the workspace via per-org tombstone", async () => {
       // Replaces the previous "rejects in published mode" + "allows in
       // developer" pair. After the global-demo + per-org-tombstone
-      // refactor (#<this-PR>), delete is non-destructive: it inserts a
+      // refactor (#2304), delete is non-destructive: it inserts a
       // per-org archived shadow row that hides the canonical global
       // `__demo__` from this workspace only. Other tenants keep seeing
       // it. The published-mode demoReadonly guard remains on the PUT
@@ -927,7 +927,7 @@ describe("admin connections — org scoping", () => {
 
     it("DELETE on org-owned __demo__ in developer mode archives in place", async () => {
       // Backward-compat path: orgs that still have a per-org `__demo__`
-      // row (pre-#2304 onboarding) get the original archive-in-place
+      // row (pre-global-demo onboarding) get the original archive-in-place
       // behavior, not a tombstone.
       setOrgAdmin("org-alpha");
       mocks.mockInternalQuery.mockImplementation((sql: string) => {

--- a/packages/api/src/api/__tests__/admin-connections.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections.test.ts
@@ -285,7 +285,9 @@ describe("admin connections — org scoping", () => {
       setOrgAdmin("org-alpha");
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
         if (sql.includes("SELECT") && sql.includes("connections")) {
-          return Promise.resolve([{ id: "warehouse" }]);
+          // Delete handler now selects (id, org_id, type) so it can decide
+          // archive-in-place vs per-org tombstone for global connections.
+          return Promise.resolve([{ id: "warehouse", org_id: "org-alpha", type: "postgres" }]);
         }
         // scheduled_tasks check + DELETE
         return Promise.resolve([{ count: "0" }]);
@@ -496,7 +498,7 @@ describe("admin connections — org scoping", () => {
       setPlatformAdmin("org-alpha");
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
         if (sql.includes("SELECT") && sql.includes("connections")) {
-          return Promise.resolve([{ id: "other-org-conn" }]);
+          return Promise.resolve([{ id: "other-org-conn", org_id: "org-alpha", type: "mysql" }]);
         }
         return Promise.resolve([{ count: "0" }]);
       });
@@ -869,7 +871,7 @@ describe("admin connections — org scoping", () => {
       setOrgAdmin("org-alpha");
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
         if (sql.includes("SELECT") && sql.includes("connections")) {
-          return Promise.resolve([{ id: "warehouse" }]);
+          return Promise.resolve([{ id: "warehouse", org_id: "org-alpha", type: "postgres" }]);
         }
         return Promise.resolve([{ count: "0" }]);
       });
@@ -893,21 +895,44 @@ describe("admin connections — org scoping", () => {
       expect(hardDelete).toBeUndefined();
     });
 
-    it("rejects DELETE on __demo__ in published mode with 403", async () => {
-      setOrgAdmin("org-alpha");
-      const res = await app.fetch(
-        adminRequest("/api/v1/admin/connections/__demo__", "DELETE"),
-      );
-      expect(res.status).toBe(403);
-      const body = (await res.json()) as Record<string, unknown>;
-      expect(body.error).toBe("demo_readonly");
-    });
-
-    it("allows DELETE on __demo__ in developer mode (archives instead of hard delete)", async () => {
+    it("DELETE on __demo__ in any mode hides it from the workspace via per-org tombstone", async () => {
+      // Replaces the previous "rejects in published mode" + "allows in
+      // developer" pair. After the global-demo + per-org-tombstone
+      // refactor (#<this-PR>), delete is non-destructive: it inserts a
+      // per-org archived shadow row that hides the canonical global
+      // `__demo__` from this workspace only. Other tenants keep seeing
+      // it. The published-mode demoReadonly guard remains on the PUT
+      // handler since URL/description edits would mutate shared state.
       setOrgAdmin("org-alpha");
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
         if (sql.includes("SELECT") && sql.includes("connections")) {
-          return Promise.resolve([{ id: "__demo__" }]);
+          return Promise.resolve([{ id: "__demo__", org_id: "__global__", type: "postgres" }]);
+        }
+        return Promise.resolve([{ count: "0" }]);
+      });
+      const res = await app.fetch(
+        adminRequest("/api/v1/admin/connections/__demo__", "DELETE"),
+      );
+      expect(res.status).toBe(200);
+
+      // Per-org tombstone INSERT (not UPDATE on the global row)
+      const insertCall = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) =>
+          typeof sql === "string" &&
+          sql.includes("INSERT INTO connections") &&
+          sql.includes("'archived'"),
+      );
+      expect(insertCall).toBeDefined();
+    });
+
+    it("DELETE on org-owned __demo__ in developer mode archives in place", async () => {
+      // Backward-compat path: orgs that still have a per-org `__demo__`
+      // row (pre-#2304 onboarding) get the original archive-in-place
+      // behavior, not a tombstone.
+      setOrgAdmin("org-alpha");
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sql.includes("SELECT") && sql.includes("connections")) {
+          return Promise.resolve([{ id: "__demo__", org_id: "org-alpha", type: "postgres" }]);
         }
         return Promise.resolve([{ count: "0" }]);
       });

--- a/packages/api/src/api/__tests__/onboarding.test.ts
+++ b/packages/api/src/api/__tests__/onboarding.test.ts
@@ -1173,6 +1173,47 @@ describe("POST /api/v1/onboarding/use-demo", () => {
     mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5 }));
   });
 
+  it("RACE: ON CONFLICT DO NOTHING — a 0-row INSERT followed by a successful verify SELECT still returns 201 (#2304)", async () => {
+    // The first onboarder pinned the global `__demo__` URL. A second
+    // onboarder whose INSERT is no-op'd by ON CONFLICT must still see
+    // 201 if the verify SELECT confirms the row already exists. Without
+    // this test, a future change that flips `DO NOTHING` back to
+    // `DO UPDATE SET url=...` would silently re-introduce per-onboarder
+    // URL clobbering.
+    mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("INSERT INTO connections")) return [];
+      if (sql.includes("SELECT id FROM connections WHERE id = $1 AND org_id = '__global__'")) {
+        return [{ id: "__demo__" }];
+      }
+      return [];
+    });
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(201);
+    const data = await json(res);
+    expect(data.connectionId).toBe("__demo__");
+  });
+
+  it("RACE: skip in-memory `connections.register` when the pool already has the id (#2304)", async () => {
+    // Concurrent onboarders would otherwise needlessly drain and recreate
+    // the pool. If a future refactor flips `if (!connections.has(id))` to
+    // unconditional `unregister + register`, this test will catch the
+    // regression.
+    mockHas.mockReturnValueOnce(true);
+    const registerCallsBefore = mockRegister.mock.calls.length;
+    const res = await request("/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(201);
+    // No new register() since the pool already had `__demo__`.
+    expect(mockRegister.mock.calls.length).toBe(registerCallsBefore);
+  });
+
   it("ATOMICITY: idempotent retry — a successful retry after a failure persists everything", async () => {
     // First call fails on import (no connection committed). Second call
     // succeeds (import is upsert-safe; connection upsert is idempotent).

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -387,14 +387,11 @@ adminConnections.openapi(listConnectionsRoute, async (c) => runHandler(c, "list 
 // GET /pool — pool metrics scoped to active org
 adminConnections.openapi(getPoolMetricsRoute, async (c) => runHandler(c, "get pool metrics", async () => {
   const { orgId } = c.get("orgContext");
-  const authResult = c.get("authResult");
-  const isPlatformAdmin = authResult.user?.role === "platform_admin";
-
-  if (isPlatformAdmin) {
-    const metrics = connections.getAllPoolMetrics();
-    return c.json({ metrics }, 200);
-  }
-
+  // Same scoping rule as the connections list: platform admins see the
+  // active org's pools, not every tenant's. Cross-org pool views belong
+  // to `/admin/platform/*`. Pre-fix, platform admins saw 5+ pools from
+  // every workspace's `__demo__` / wizard-created connections leaked
+  // into the default Pool stats card.
   const metrics = connections.getOrgPoolMetrics(orgId);
   return c.json({ metrics }, 200);
 }));
@@ -928,19 +925,28 @@ adminConnections.openapi(deleteConnectionRoute, async (c) => runHandler(c, "dele
     return c.json({ error: "forbidden", message: "Cannot delete the default connection.", requestId }, 403);
   }
 
-  // Demo content is read-only in published mode — writes in published mode
-  // against __demo__ must be blocked. Developer mode can archive the demo.
-  if (id === DEMO_CONNECTION_ID && getAtlasMode(c) !== "developer") {
-    return c.json(demoReadonly(requestId), 403);
-  }
+  // The published-mode `__demo__` block used to live here. With the global
+  // demo + per-org tombstone model (#2304 + #<this-PR>), "delete" no longer
+  // mutates shared state — it inserts a per-org archived row that hides
+  // the global from this workspace only. Other tenants are untouched.
+  // Updates to the canonical demo URL/description still go through the
+  // PUT handler which keeps the demoReadonly guard.
 
-  // Must exist in the DB and belong to the org
-  const existing = await internalQuery<{ id: string }>(
-    `SELECT id FROM connections WHERE id = $1 AND org_id = $2`,
+  // Two cases:
+  //   - Org-owned row exists → archive in place (existing behavior).
+  //   - Only a `__global__` row exists for this id (e.g. the shared
+  //     `__demo__` provisioned by onboarding under #2304) → insert a
+  //     per-org archived shadow row. The visibility query's NOT EXISTS
+  //     check then hides the global from this org's view while leaving
+  //     it intact for every other workspace.
+  const existing = await internalQuery<{ id: string; org_id: string; type: string | null }>(
+    `SELECT id, org_id, type FROM connections WHERE id = $1 AND org_id IN ($2, '__global__')`,
     [id, orgId],
   );
+  const ownRow = existing.find((r) => r.org_id === orgId);
+  const globalRow = existing.find((r) => r.org_id === "__global__");
 
-  if (existing.length === 0) {
+  if (!ownRow && !globalRow) {
     return c.json({ error: "not_found", message: `Connection "${id}" not found or is not admin-managed.`, requestId }, 404);
   }
 
@@ -968,22 +974,38 @@ adminConnections.openapi(deleteConnectionRoute, async (c) => runHandler(c, "dele
     log.warn({ connectionId: id, requestId }, "Scheduled tasks table does not exist — skipping reference check");
   }
 
-  // Archive instead of hard-delete so drafts can be restored and the
-  // publish flow retains history. Cascades to entities is handled at publish time.
   try {
-    await internalQuery(
-      `UPDATE connections SET status = 'archived', updated_at = now() WHERE id = $1 AND org_id = $2`,
-      [id, orgId],
-    );
+    if (ownRow) {
+      // Archive in place — drafts can be restored, publish flow retains history.
+      await internalQuery(
+        `UPDATE connections SET status = 'archived', updated_at = now() WHERE id = $1 AND org_id = $2`,
+        [id, orgId],
+      );
+    } else {
+      // Global-only row: insert a per-org archived shadow. URL is empty
+      // because we never want to mutate the canonical global URL — the
+      // archived status alone hides it from this org's lists.
+      await internalQuery(
+        `INSERT INTO connections (id, url, url_key_version, type, description, org_id, status)
+         VALUES ($1, '', 1, $2, $3, $4, 'archived')
+         ON CONFLICT (id, org_id) DO UPDATE SET status = 'archived', updated_at = now()`,
+        [id, globalRow!.type ?? "postgres", `Hidden from this workspace`, orgId],
+      );
+    }
   } catch (err) {
     log.error({ err: errorMessage(err), connectionId: id, requestId }, "Failed to archive connection");
     return c.json({ error: "internal_error", message: "Failed to archive connection.", requestId }, 500);
   }
 
-  try {
-    connections.unregister(id);
-  } catch (err) {
-    log.warn({ err: errorMessage(err), connectionId: id, requestId }, "Failed to unregister connection from in-memory registry — will reconcile on restart");
+  // Only unregister from the in-memory pool when we actually archived the
+  // org-owned row. Global-only delete is a per-org hide — the underlying
+  // connection must stay registered for other workspaces.
+  if (ownRow) {
+    try {
+      connections.unregister(id);
+    } catch (err) {
+      log.warn({ err: errorMessage(err), connectionId: id, requestId }, "Failed to unregister connection from in-memory registry — will reconcile on restart");
+    }
   }
 
   log.info({ requestId, connectionId: id, actorId: authResult.user?.id }, "Connection archived");

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -81,10 +81,10 @@ export async function getVisibleConnectionIds(
 ): Promise<Set<string> | null> {
   // Always scope to the active org. Platform admins requiring cross-org
   // visibility must use the workspace switcher to set their active org or
-  // the dedicated `/admin/platform/*` surfaces — bypassing the org filter
-  // here leaks every customer's connections into every workspace's admin
-  // page, which is what the `isPlatformAdmin → return null` branch did
-  // before #<this-PR>.
+  // the dedicated `/platform/*` surfaces — bypassing the org filter here
+  // leaks every customer's connections into every workspace's admin page,
+  // which is what the `isPlatformAdmin → return null` branch did before
+  // #2303.
   const visible = new Set<string>();
 
   if (hasInternalDB()) {
@@ -389,9 +389,9 @@ adminConnections.openapi(getPoolMetricsRoute, async (c) => runHandler(c, "get po
   const { orgId } = c.get("orgContext");
   // Same scoping rule as the connections list: platform admins see the
   // active org's pools, not every tenant's. Cross-org pool views belong
-  // to `/admin/platform/*`. Pre-fix, platform admins saw 5+ pools from
-  // every workspace's `__demo__` / wizard-created connections leaked
-  // into the default Pool stats card.
+  // to `/platform/*`. Pre-fix, platform admins saw pools for every
+  // tenant's `__demo__` and wizard-created connections aggregated into
+  // the default Pool stats card.
   const metrics = connections.getOrgPoolMetrics(orgId);
   return c.json({ metrics }, 200);
 }));
@@ -777,9 +777,14 @@ adminConnections.openapi(updateConnectionRoute, async (c) => runHandler(c, "upda
     return c.json(demoReadonly(requestId), 403);
   }
 
-  // Check it exists in the DB and belongs to this org
+  // Check it exists in the DB and belongs to this org. Excludes archived
+  // rows so per-org delete-as-hide tombstones (whose `url = ''` placeholder
+  // would crash `decryptUrl` below) read as "not found here, did you mean
+  // to restore first?" rather than a misleading "encryption key changed"
+  // 500.
   const existing = await internalQuery<{ id: string; url: string; type: string; description: string | null; schema_name: string | null }>(
-    `SELECT id, url, type, description, schema_name FROM connections WHERE id = $1 AND org_id = $2`,
+    `SELECT id, url, type, description, schema_name FROM connections
+     WHERE id = $1 AND org_id = $2 AND status != 'archived'`,
     [id, orgId],
   );
 
@@ -926,8 +931,8 @@ adminConnections.openapi(deleteConnectionRoute, async (c) => runHandler(c, "dele
   }
 
   // The published-mode `__demo__` block used to live here. With the global
-  // demo + per-org tombstone model (#2304 + #<this-PR>), "delete" no longer
-  // mutates shared state — it inserts a per-org archived row that hides
+  // demo + per-org tombstone model (#2304), "delete" no longer mutates
+  // shared state — it inserts a per-org archived row that hides
   // the global from this workspace only. Other tenants are untouched.
   // Updates to the canonical demo URL/description still go through the
   // PUT handler which keeps the demoReadonly guard.
@@ -939,7 +944,10 @@ adminConnections.openapi(deleteConnectionRoute, async (c) => runHandler(c, "dele
   //     per-org archived shadow row. The visibility query's NOT EXISTS
   //     check then hides the global from this org's view while leaving
   //     it intact for every other workspace.
-  const existing = await internalQuery<{ id: string; org_id: string; type: string | null }>(
+  // `type` is NOT NULL in the schema (migration 0000_baseline.sql:170,
+  // schema.ts:276) — declare it as `string`, not `string | null`. The
+  // previous annotation invented a nullable case the DB cannot produce.
+  const existing = await internalQuery<{ id: string; org_id: string; type: string }>(
     `SELECT id, org_id, type FROM connections WHERE id = $1 AND org_id IN ($2, '__global__')`,
     [id, orgId],
   );
@@ -950,11 +958,16 @@ adminConnections.openapi(deleteConnectionRoute, async (c) => runHandler(c, "dele
     return c.json({ error: "not_found", message: `Connection "${id}" not found or is not admin-managed.`, requestId }, 404);
   }
 
-  // Check for scheduled tasks referencing this connection
+  // Check for scheduled tasks referencing this connection. MUST scope by
+  // org_id — `__demo__` is now a single shared connection across every
+  // workspace (#2304), so without the org_id filter any tenant's task on
+  // `__demo__` would trigger a 409 conflict for every other tenant trying
+  // to "hide" the demo with an error message pointing at tasks they
+  // cannot see.
   try {
     const refs = await internalQuery<{ count: string }>(
-      "SELECT COUNT(*) as count FROM scheduled_tasks WHERE connection_id = $1",
-      [id],
+      "SELECT COUNT(*) as count FROM scheduled_tasks WHERE connection_id = $1 AND org_id = $2",
+      [id, orgId],
     );
     const refCount = parseInt(String(refs[0]?.count ?? "0"), 10);
     if (refCount > 0) {
@@ -985,11 +998,17 @@ adminConnections.openapi(deleteConnectionRoute, async (c) => runHandler(c, "dele
       // Global-only row: insert a per-org archived shadow. URL is empty
       // because we never want to mutate the canonical global URL — the
       // archived status alone hides it from this org's lists.
+      //
+      // Readers must filter by `status != 'archived'` before passing this
+      // row to `decryptUrl` or runtime registration — the empty URL is a
+      // marker, not a value. Those filters live in `wizard.ts`,
+      // `internal.ts::loadSavedConnections`, and the PUT/GET handlers in
+      // this file.
       await internalQuery(
         `INSERT INTO connections (id, url, url_key_version, type, description, org_id, status)
          VALUES ($1, '', 1, $2, $3, $4, 'archived')
          ON CONFLICT (id, org_id) DO UPDATE SET status = 'archived', updated_at = now()`,
-        [id, globalRow!.type ?? "postgres", `Hidden from this workspace`, orgId],
+        [id, globalRow!.type, `Hidden from this workspace`, orgId],
       );
     }
   } catch (err) {
@@ -1046,8 +1065,11 @@ adminConnections.openapi(getConnectionRoute, async (c) => runHandler(c, "get con
   let managed = false;
   if (hasInternalDB()) {
     try {
+      // Defense-in-depth: even though visibility already filters out
+      // archived rows, exclude them here too so a future visibility-layer
+      // bug can never feed the empty-string tombstone marker to decryptUrl.
       const rows = await internalQuery<{ url: string; schema_name: string | null }>(
-        "SELECT url, schema_name FROM connections WHERE id = $1 AND org_id = $2",
+        "SELECT url, schema_name FROM connections WHERE id = $1 AND org_id = $2 AND status != 'archived'",
         [id, orgId],
       );
       if (rows.length > 0) {

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -617,9 +617,12 @@ adminConnections.openapi(createConnectionRoute, async (c) => runHandler(c, "crea
     return c.json({ error: "not_available", message: "Connection management requires an internal database (DATABASE_URL).", requestId }, 404);
   }
 
-  // Enforce plan connection limit before proceeding
+  // Enforce plan connection limit before proceeding. Exclude archived
+  // rows so per-org delete-as-hide tombstones (the shadow rows for
+  // hidden `__global__` connections) don't count against the org's plan
+  // limit. A workspace that hides the demo shouldn't lose a slot for it.
   const connCountRows = await internalQuery<{ count: number }>(
-    `SELECT COUNT(*)::int as count FROM connections WHERE org_id = $1`,
+    `SELECT COUNT(*)::int as count FROM connections WHERE org_id = $1 AND status != 'archived'`,
     [orgId],
   );
   const connCount = connCountRows[0]?.count ?? 0;

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -1657,8 +1657,22 @@ admin.openapi(importOrgEntitiesRoute, async (c) => runHandler(c, "import org sem
     // Caller must already own a `__demo__` connection — otherwise a stale
     // URL or programmatic caller could write NovaMart entities into an
     // unrelated workspace under a phantom connection id.
+    // Same OWN_OR_GLOBAL shadow rule as `getVisibleConnectionIds` —
+    // an org using the canonical `__global__/__demo__` (no per-org row)
+    // counts as owning the demo for the purposes of this recovery
+    // probe. Without this, every post-#2304 onboarding gets a 409 here.
     const ownsDemo = await internalQuery<{ id: string }>(
-      `SELECT id FROM connections WHERE org_id = $1 AND id = '__demo__' AND status IN ('published', 'draft')`,
+      `SELECT id FROM connections
+       WHERE id = '__demo__' AND status IN ('published', 'draft')
+         AND (
+           org_id = $1
+           OR (
+             org_id = '__global__'
+             AND NOT EXISTS (
+               SELECT 1 FROM connections c2 WHERE c2.org_id = $1 AND c2.id = '__demo__'
+             )
+           )
+         )`,
       [orgId],
     ).then((rows) => rows.length > 0).catch((err) => {
       log.warn({ err: err instanceof Error ? err.message : String(err), requestId, orgId }, "Demo-ownership probe failed during recovery");
@@ -1697,7 +1711,18 @@ admin.openapi(importOrgEntitiesRoute, async (c) => runHandler(c, "import org sem
       let ownsDemo = false;
       try {
         const demoRows = await internalQuery<{ id: string }>(
-          `SELECT id FROM connections WHERE org_id = $1 AND id = '__demo__' AND status IN ('published', 'draft')`,
+          // OWN_OR_GLOBAL shadow rule — see the matching probe above.
+          `SELECT id FROM connections
+           WHERE id = '__demo__' AND status IN ('published', 'draft')
+             AND (
+               org_id = $1
+               OR (
+                 org_id = '__global__'
+                 AND NOT EXISTS (
+                   SELECT 1 FROM connections c2 WHERE c2.org_id = $1 AND c2.id = '__demo__'
+                 )
+               )
+             )`,
           [orgId],
         );
         ownsDemo = demoRows.length > 0;

--- a/packages/api/src/api/routes/billing.ts
+++ b/packages/api/src/api/routes/billing.ts
@@ -296,9 +296,11 @@ billing.openapi(getBillingStatusRoute, async (c) => {
         );
         return [{ count: 1 }] as Array<{ count: number }>;
       }),
-      // Connection count for this workspace
+      // Connection count for this workspace. Exclude per-org archive
+      // tombstones so hidden `__global__` connections (e.g. the demo a
+      // workspace hid) don't inflate the billing-page count.
       internalQuery<{ count: number }>(
-        `SELECT COUNT(*)::int AS count FROM connections WHERE org_id = $1`,
+        `SELECT COUNT(*)::int AS count FROM connections WHERE org_id = $1 AND status != 'archived'`,
         [orgId],
       ).catch((err) => {
         log.warn(

--- a/packages/api/src/api/routes/mode.ts
+++ b/packages/api/src/api/routes/mode.ts
@@ -97,10 +97,24 @@ const getModeRoute = createRoute({
   },
 });
 
+// "Demo is active for this org" if either:
+//   1. The org owns a published `__demo__` row (legacy pre-#2304 onboarding), OR
+//   2. The canonical `__global__/__demo__` exists AND the org hasn't
+//      tombstoned it (no per-org row of any status — matches the
+//      shadow-check semantics in `getVisibleConnectionIds`).
 const DEMO_ACTIVE_SQL = `
   SELECT EXISTS (
     SELECT 1 FROM connections
-    WHERE id = '__demo__' AND org_id = $1 AND status = 'published'
+    WHERE id = '__demo__' AND status = 'published'
+      AND (
+        org_id = $1
+        OR (
+          org_id = '__global__'
+          AND NOT EXISTS (
+            SELECT 1 FROM connections c2 WHERE c2.org_id = $1 AND c2.id = '__demo__'
+          )
+        )
+      )
   ) AS active
 `;
 

--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -751,14 +751,14 @@ onboarding.openapi(
       // Phase 3 — commit point. Once this row lands, the entities
       // imported in phase 2 become visible to the agent and Schema Diff.
       //
-      // The demo connection lives once at `org_id = '__global__'` so 103+
-      // customers using the demo share a single row instead of cloning it
-      // per workspace (#<this-PR>). ON CONFLICT DO NOTHING means the first
-      // onboarding write is canonical — subsequent onboarders inherit
-      // whatever URL it pinned. Per-org entity rows imported in phase 2
-      // remain org-scoped; the connection-visibility subquery in
-      // `listEntitiesWithOverlay` accepts both own-org and `__global__`
-      // connections so those entities resolve correctly.
+      // The demo connection lives once at `org_id = '__global__'` rather
+      // than being cloned per workspace as customer count grows (#2304).
+      // ON CONFLICT DO NOTHING means the first onboarding write is
+      // canonical — subsequent onboarders inherit whatever URL it pinned.
+      // Per-org entity rows imported in phase 2 remain org-scoped; the
+      // connection-visibility subquery in `listEntitiesWithOverlay`
+      // accepts both own-org and `__global__` connections so those
+      // entities resolve correctly.
       // ---------------------------------------------------------------
       const demoLabel = DEMO_LABEL;
       const urlKeyVersion = activeKeyVersion();
@@ -781,7 +781,9 @@ onboarding.openapi(
       }
       // INSERT-or-no-op: zero rows just means the global demo was already
       // provisioned by an earlier onboarder; verify the row really exists
-      // before we declare success.
+      // before we declare success. Distinguish "verify SELECT errored"
+      // from "verify SELECT returned no row" so flaky-read-replica blips
+      // don't masquerade as missing data in the operator logs.
       if (upsertResult.length === 0) {
         const existing = yield* Effect.tryPromise({
           try: () => internalQuery<{ id: string }>(
@@ -789,15 +791,20 @@ onboarding.openapi(
             [id],
           ),
           catch: (err) => err instanceof Error ? err : new Error(String(err)),
-        }).pipe(Effect.catchAll(() => Effect.succeed([] as Array<{ id: string }>)));
+        }).pipe(Effect.catchAll((err) => {
+          log.error({ err: err.message, connectionId: id, orgId, requestId }, "Demo connection verify SELECT failed — treating as not-found");
+          return Effect.succeed([] as Array<{ id: string }>);
+        }));
         if (existing.length === 0) {
           log.error({ connectionId: id, orgId, requestId }, "Demo connection upsert returned 0 rows and no global row found");
           return c.json({ error: "internal_error", message: "Failed to save connection — database did not confirm the write.", requestId }, 500);
         }
       }
 
-      // Register in runtime only if not already registered — concurrent
-      // onboarders would otherwise race-overwrite the URL.
+      // Skip re-registration if the in-memory pool already has this id —
+      // concurrent onboarders would otherwise needlessly drain and recreate
+      // the pool. The DB-level race (different URLs racing to commit) is
+      // resolved by ON CONFLICT DO NOTHING above.
       try {
         if (!connections.has(id)) {
           connections.register(id, { url, description: `${demoLabel} — demo ${dbType} datasource` });

--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -797,7 +797,11 @@ onboarding.openapi(
         }));
         if (existing.length === 0) {
           log.error({ connectionId: id, orgId, requestId }, "Demo connection upsert returned 0 rows and no global row found");
-          return c.json({ error: "internal_error", message: "Failed to save connection — database did not confirm the write.", requestId }, 500);
+          return c.json({
+            error: "internal_error",
+            message: "Demo connection write may have succeeded but the database did not confirm. Retry the request — the operation is idempotent.",
+            requestId,
+          }, 500);
         }
       }
 

--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -750,18 +750,25 @@ onboarding.openapi(
       // ---------------------------------------------------------------
       // Phase 3 — commit point. Once this row lands, the entities
       // imported in phase 2 become visible to the agent and Schema Diff.
-      // Failure here leaves orphan entity rows (filtered out by
-      // visibility), so the user sees nothing partial — they can retry.
+      //
+      // The demo connection lives once at `org_id = '__global__'` so 103+
+      // customers using the demo share a single row instead of cloning it
+      // per workspace (#<this-PR>). ON CONFLICT DO NOTHING means the first
+      // onboarding write is canonical — subsequent onboarders inherit
+      // whatever URL it pinned. Per-org entity rows imported in phase 2
+      // remain org-scoped; the connection-visibility subquery in
+      // `listEntitiesWithOverlay` accepts both own-org and `__global__`
+      // connections so those entities resolve correctly.
       // ---------------------------------------------------------------
       const demoLabel = DEMO_LABEL;
       const urlKeyVersion = activeKeyVersion();
       const upsertResult = yield* Effect.tryPromise({
         try: () => internalQuery<{ id: string }>(
           `INSERT INTO connections (id, url, url_key_version, type, description, org_id, status)
-           VALUES ($1, $2, $6, $3, $4, $5, 'published')
-           ON CONFLICT (id, org_id) DO UPDATE SET url = $2, url_key_version = $6, type = $3, description = $4, status = 'published', updated_at = NOW()
+           VALUES ($1, $2, $5, $3, $4, '__global__', 'published')
+           ON CONFLICT (id, org_id) DO NOTHING
            RETURNING id`,
-          [id, encryptedUrl, dbType, `${demoLabel} — demo ${dbType} datasource`, orgId, urlKeyVersion],
+          [id, encryptedUrl, dbType, `${demoLabel} — demo ${dbType} datasource`, urlKeyVersion],
         ),
         catch: (err) => err instanceof Error ? err : new Error(String(err)),
       }).pipe(Effect.catchAll((err) => {
@@ -772,15 +779,29 @@ onboarding.openapi(
       if (upsertResult === null) {
         return c.json({ error: "internal_error", message: "Failed to save connection.", requestId }, 500);
       }
+      // INSERT-or-no-op: zero rows just means the global demo was already
+      // provisioned by an earlier onboarder; verify the row really exists
+      // before we declare success.
       if (upsertResult.length === 0) {
-        log.error({ connectionId: id, orgId, requestId }, "Demo connection upsert returned 0 rows — data may not have been persisted");
-        return c.json({ error: "internal_error", message: "Failed to save connection — database did not confirm the write.", requestId }, 500);
+        const existing = yield* Effect.tryPromise({
+          try: () => internalQuery<{ id: string }>(
+            `SELECT id FROM connections WHERE id = $1 AND org_id = '__global__' AND status = 'published'`,
+            [id],
+          ),
+          catch: (err) => err instanceof Error ? err : new Error(String(err)),
+        }).pipe(Effect.catchAll(() => Effect.succeed([] as Array<{ id: string }>)));
+        if (existing.length === 0) {
+          log.error({ connectionId: id, orgId, requestId }, "Demo connection upsert returned 0 rows and no global row found");
+          return c.json({ error: "internal_error", message: "Failed to save connection — database did not confirm the write.", requestId }, 500);
+        }
       }
 
-      // Register in runtime
+      // Register in runtime only if not already registered — concurrent
+      // onboarders would otherwise race-overwrite the URL.
       try {
-        if (connections.has(id)) connections.unregister(id);
-        connections.register(id, { url, description: `${demoLabel} — demo ${dbType} datasource` });
+        if (!connections.has(id)) {
+          connections.register(id, { url, description: `${demoLabel} — demo ${dbType} datasource` });
+        }
       } catch (err) {
         log.warn({ err: errorMessage(err), requestId }, "Demo connection saved but runtime registration failed");
       }

--- a/packages/api/src/api/routes/platform-admin.ts
+++ b/packages/api/src/api/routes/platform-admin.ts
@@ -488,8 +488,10 @@ platformAdmin.openapi(getWorkspaceRoute, async (c) => {
         `SELECT COUNT(*)::int as count FROM audit_log WHERE org_id = $1 AND timestamp > now() - interval '24 hours'`,
         [workspaceId],
       ),
+      // Exclude archive tombstones — hidden `__global__` connections
+      // shouldn't inflate the platform org-list per-org connection count.
       internalQuery<{ count: number }>(
-        `SELECT COUNT(*)::int as count FROM connections WHERE org_id = $1`,
+        `SELECT COUNT(*)::int as count FROM connections WHERE org_id = $1 AND status != 'archived'`,
         [workspaceId],
       ),
       internalQuery<{ count: number }>(

--- a/packages/api/src/api/routes/wizard.ts
+++ b/packages/api/src/api/routes/wizard.ts
@@ -903,8 +903,16 @@ async function resolveConnectionUrl(
       // The describe() method masks the URL, so we need the raw URL for profiling.
       // Check internal DB first (it has the encrypted URL).
       if (hasInternalDB()) {
+        // Exclude `status = 'archived'` so per-org tombstone rows (the
+        // shadow rows inserted by the delete-as-hide flow in
+        // admin-connections.ts) never reach `decryptUrl`. Their `url` is
+        // the empty-string marker and `decryptUrl('')` throws an
+        // unrecognized-format error. Status filter is the cheapest way to
+        // keep the tombstone invariant local to the visibility layer.
         const rows = await internalQuery<{ url: string; schema_name: string | null }>(
-          "SELECT url, schema_name FROM connections WHERE id = $1 AND (org_id = $2 OR org_id = '__global__') ORDER BY CASE WHEN org_id = $2 THEN 0 ELSE 1 END LIMIT 1",
+          `SELECT url, schema_name FROM connections
+           WHERE id = $1 AND status != 'archived' AND (org_id = $2 OR org_id = '__global__')
+           ORDER BY CASE WHEN org_id = $2 THEN 0 ELSE 1 END LIMIT 1`,
           [connectionId, orgId ?? "__global__"],
         );
         if (rows.length > 0) {

--- a/packages/api/src/api/routes/wizard.ts
+++ b/packages/api/src/api/routes/wizard.ts
@@ -941,14 +941,17 @@ async function resolveConnectionUrl(
     }
   }
 
-  // Second try: internal DB only (connection not in runtime registry)
+  // Second try: internal DB only (connection not in runtime registry).
+  // Excludes archived rows so per-org delete-as-hide tombstones (whose
+  // `url = ''` placeholder would crash `decryptUrl` below) read as
+  // not-found here, mirroring the first-try filter at L907.
   if (hasInternalDB()) {
     const orgFilter = orgId ? " AND (org_id = $2 OR org_id = '__global__') ORDER BY CASE WHEN org_id = $2 THEN 0 ELSE 1 END LIMIT 1" : "";
     const params: unknown[] = [connectionId];
     if (orgId) params.push(orgId);
 
     const rows = await internalQuery<{ url: string; schema_name: string | null }>(
-      `SELECT url, schema_name FROM connections WHERE id = $1${orgFilter}`,
+      `SELECT url, schema_name FROM connections WHERE id = $1 AND status != 'archived'${orgFilter}`,
       params,
     );
     if (rows.length > 0) {

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1757,7 +1757,10 @@ export async function getWorkspaceHealthSummary(orgId: string): Promise<{
       countQuery(`SELECT COUNT(*)::int as count FROM member WHERE "organizationId" = $1`, [orgId]),
       countQuery(`SELECT COUNT(*)::int as count FROM conversations WHERE org_id = $1`, [orgId]),
       countQuery(`SELECT COUNT(*)::int as count FROM audit_log WHERE org_id = $1 AND timestamp > now() - interval '24 hours'`, [orgId]),
-      countQuery(`SELECT COUNT(*)::int as count FROM connections WHERE org_id = $1`, [orgId]),
+      // Exclude archive tombstones for the same reason as the plan-limit
+      // and billing counts — hidden `__global__` connections shouldn't
+      // inflate workspace health summaries.
+      countQuery(`SELECT COUNT(*)::int as count FROM connections WHERE org_id = $1 AND status != 'archived'`, [orgId]),
       countQuery(`SELECT COUNT(*)::int as count FROM scheduled_tasks WHERE org_id = $1 AND enabled = true`, [orgId]),
     ], { concurrency: "unbounded" }).pipe(
       Effect.timeoutFail({

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -849,8 +849,17 @@ export async function loadSavedConnections(): Promise<number> {
 
   try {
     type ConnRow = { id: string; url: string; type: string; description: string | null; schema_name: string | null };
+    // Exclude `status = 'archived'` so per-org tombstone rows (the shadow
+    // rows from the delete-as-hide flow in admin-connections.ts) never feed
+    // their empty-string `url` marker to `decryptUrl`. Without this filter
+    // a tombstone's newer `updated_at` would win the DISTINCT ON (id) race
+    // and silently knock the canonical global row out of the in-memory
+    // registry across every workspace on the next process restart.
     const rows = await internalQuery<ConnRow>(
-      "SELECT DISTINCT ON (id) id, url, type, description, schema_name FROM connections ORDER BY id, updated_at DESC, org_id ASC",
+      `SELECT DISTINCT ON (id) id, url, type, description, schema_name
+       FROM connections
+       WHERE status != 'archived'
+       ORDER BY id, updated_at DESC, org_id ASC`,
     );
 
     let registered = 0;

--- a/packages/api/src/lib/db/migrations/0060_demo_connection_to_global.sql
+++ b/packages/api/src/lib/db/migrations/0060_demo_connection_to_global.sql
@@ -3,7 +3,7 @@
 -- Before this migration each workspace that completed onboarding owned its
 -- own `__demo__` row. Combined with the platform_admin visibility bypass,
 -- workspaces saw other tenants' demo connections in their admin
--- connections list — see #<this-PR>. After this migration `__demo__`
+-- connections list — see #2303. After this migration `__demo__`
 -- lives once at org_id = '__global__' and is surfaced to every org by the
 -- updated `getVisibleConnectionIds` global-fallback rule.
 --

--- a/packages/api/src/lib/prompts/scoping.ts
+++ b/packages/api/src/lib/prompts/scoping.ts
@@ -123,10 +123,25 @@ export async function resolvePromptScope(opts: {
 
   const demoIndustry =
     getSettingAuto(DEMO_INDUSTRY_SETTING, opts.orgId) ?? null;
+  // Mirror the OWN_OR_GLOBAL shadow rule from `getVisibleConnectionIds` so
+  // an org using the canonical `__global__/__demo__` connection (the model
+  // introduced in #2304) gets `demoConnectionActive = true` and the
+  // demo-industry global builtin prompt collections show up. Without this
+  // the demo prompt library silently drops out for every workspace that
+  // doesn't have a legacy per-org __demo__ row.
   const rows = await internalQuery<{ active: boolean }>(
     `SELECT EXISTS (
        SELECT 1 FROM connections
-       WHERE id = '__demo__' AND org_id = $1 AND status = 'published'
+       WHERE id = '__demo__' AND status = 'published'
+         AND (
+           org_id = $1
+           OR (
+             org_id = '__global__'
+             AND NOT EXISTS (
+               SELECT 1 FROM connections c2 WHERE c2.org_id = $1 AND c2.id = '__demo__'
+             )
+           )
+         )
      ) AS active`,
     [opts.orgId],
   );

--- a/packages/api/src/lib/semantic/__tests__/overlay-queries-integration.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/overlay-queries-integration.test.ts
@@ -249,7 +249,7 @@ describe("listEntitiesWithOverlay — acceptance matrix against real Postgres", 
     expect(rows).toHaveLength(0);
   });
 
-  it("entities tied to a __global__ connection are visible to any org (#<PR2>)", async () => {
+  it("entities tied to a __global__ connection are visible to any org (#2304)", async () => {
     // The canonical `__demo__` lives at org_id = '__global__'. Per-org
     // entities reference it via connection_id; the connection-visibility
     // subquery now accepts `__global__` rows so those entities resolve.
@@ -262,7 +262,25 @@ describe("listEntitiesWithOverlay — acceptance matrix against real Postgres", 
     expect(rowsByName(rows)).toEqual({ novamart_orders: "published" });
   });
 
-  it("per-org tombstone hides entities tied to a `__global__` connection (#<PR2>)", async () => {
+  it("per-org tombstone hides entities tied to a `__global__` connection — exact archived/non-archived precedence (#2304)", async () => {
+    // Pin the *transition* sequence so a future refactor that flips
+    // `NOT IN (... org's rows ...)` to `NOT IN (... non-archived org rows ...)`
+    // can't silently start surfacing tombstoned demos to the agent. Visible
+    // before tombstone → hidden after.
+    db.public.none(
+      `INSERT INTO connections (id, org_id, status) VALUES ('__demo__', '__global__', 'published')`,
+    );
+    seedEntity({ id: "demo-ent-pre", name: "novamart_orders", status: "published", connectionId: "__demo__" });
+    expect(rowsByName(await listEntitiesWithOverlay("org-1", "entity"))).toEqual({ novamart_orders: "published" });
+
+    // Tombstone arrives — same id, status='archived', org-1 scope.
+    db.public.none(
+      `INSERT INTO connections (id, org_id, status) VALUES ('__demo__', 'org-1', 'archived')`,
+    );
+    expect(await listEntitiesWithOverlay("org-1", "entity")).toHaveLength(0);
+  });
+
+  it("per-org tombstone hides entities tied to a `__global__` connection (#2304)", async () => {
     // The "delete the demo from my workspace" flow inserts a per-org
     // archived row at the same id as the global. The shadow check excludes
     // the global from the visible-connection set, so any entities the org

--- a/packages/api/src/lib/semantic/__tests__/overlay-queries-integration.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/overlay-queries-integration.test.ts
@@ -248,4 +248,17 @@ describe("listEntitiesWithOverlay — acceptance matrix against real Postgres", 
     const rows = await listEntitiesWithOverlay("org-1", "entity");
     expect(rows).toHaveLength(0);
   });
+
+  it("entities tied to a __global__ connection are visible to any org (#<PR2>)", async () => {
+    // The canonical `__demo__` lives at org_id = '__global__'. Per-org
+    // entities reference it via connection_id; the connection-visibility
+    // subquery now accepts `__global__` rows so those entities resolve.
+    db.public.none(
+      `INSERT INTO connections (id, org_id, status) VALUES ('__demo__', '__global__', 'published')`,
+    );
+    seedEntity({ id: "demo-ent", name: "novamart_orders", status: "published", connectionId: "__demo__" });
+
+    const rows = await listEntitiesWithOverlay("org-1", "entity");
+    expect(rowsByName(rows)).toEqual({ novamart_orders: "published" });
+  });
 });

--- a/packages/api/src/lib/semantic/__tests__/overlay-queries-integration.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/overlay-queries-integration.test.ts
@@ -261,4 +261,21 @@ describe("listEntitiesWithOverlay — acceptance matrix against real Postgres", 
     const rows = await listEntitiesWithOverlay("org-1", "entity");
     expect(rowsByName(rows)).toEqual({ novamart_orders: "published" });
   });
+
+  it("per-org tombstone hides entities tied to a `__global__` connection (#<PR2>)", async () => {
+    // The "delete the demo from my workspace" flow inserts a per-org
+    // archived row at the same id as the global. The shadow check excludes
+    // the global from the visible-connection set, so any entities the org
+    // owns at that connection_id drop out of the overlay alongside it.
+    db.public.none(
+      `INSERT INTO connections (id, org_id, status) VALUES ('__demo__', '__global__', 'published')`,
+    );
+    db.public.none(
+      `INSERT INTO connections (id, org_id, status) VALUES ('__demo__', 'org-1', 'archived')`,
+    );
+    seedEntity({ id: "demo-ent", name: "novamart_orders", status: "published", connectionId: "__demo__" });
+
+    const rows = await listEntitiesWithOverlay("org-1", "entity");
+    expect(rows).toHaveLength(0);
+  });
 });

--- a/packages/api/src/lib/semantic/entities.ts
+++ b/packages/api/src/lib/semantic/entities.ts
@@ -204,19 +204,23 @@ export async function listEntityRows(
 ): Promise<SemanticEntityRow[]> {
   if (!hasInternalDB()) return [];
 
-  // When filtering to status='published' we apply a connection-visibility
-  // filter that mirrors `getVisibleConnectionIds` in *published* mode —
-  // i.e. only `status = 'published'` connections count, never drafts. The
-  // overlay variant in `listEntitiesWithOverlay` accepts drafts because
-  // it's developer-mode by construction. Pinning published mode here
-  // prevents the published-mode agent from surfacing an entity tied to a
-  // draft connection that the SQL whitelist would reject anyway.
+  // When filtering to status='published' we apply two visibility layers:
+  //
+  // 1. Entity-row `org_id` — own-org OR `__global__` so the canonical
+  //    demo entities migrated to `__global__` in 0060 stay visible (they
+  //    are otherwise stranded — invisible to every workspace).
+  // 2. Connection-level — mirrors `getVisibleConnectionIds` in *published*
+  //    mode (only `status='published'` connections count, never drafts).
+  //    Includes the connection-level shadow check so a tombstoned global
+  //    connection drops out of the visible set, which transitively hides
+  //    every entity tied to it.
   //
   // Other call sites (admin reads at status='draft', count queries) keep
   // the simpler org-scoped query — they intentionally see archive/draft
   // state.
   const visibilityClause = statusFilter === "published"
-    ? `AND (
+    ? `AND (org_id = $1 OR org_id = '__global__')
+       AND (
          connection_id IS NULL
          OR connection_id IN (
            SELECT id FROM connections WHERE org_id = $1 AND status = 'published'
@@ -232,12 +236,19 @@ export async function listEntityRows(
        )`
     : "";
 
+  // In published-mode branches, the org_id filter is folded into
+  // `visibilityClause` (own-org OR shadowed-global). Other branches
+  // keep the simpler `WHERE org_id = $1` because they intentionally
+  // see archive/draft state and don't need global fallback.
+  const isPublishedRead = statusFilter === "published";
+
   if (entityType) {
     if (statusFilter) {
+      const orgPredicate = isPublishedRead ? "" : "org_id = $1 AND ";
       return internalQuery<SemanticEntityRow>(
         `SELECT id, org_id, entity_type, name, yaml_content, connection_id, status, created_at, updated_at
          FROM semantic_entities
-         WHERE org_id = $1 AND entity_type = $2 AND status = $3
+         WHERE ${orgPredicate}entity_type = $2 AND status = $3
            ${visibilityClause}
          ORDER BY name`,
         [orgId, entityType, statusFilter],
@@ -253,10 +264,11 @@ export async function listEntityRows(
   }
 
   if (statusFilter) {
+    const orgPredicate = isPublishedRead ? "" : "org_id = $1 AND ";
     return internalQuery<SemanticEntityRow>(
       `SELECT id, org_id, entity_type, name, yaml_content, connection_id, status, created_at, updated_at
        FROM semantic_entities
-       WHERE org_id = $1 AND status = $2
+       WHERE ${orgPredicate}status = $2
          ${visibilityClause}
        ORDER BY entity_type, name`,
       [orgId, statusFilter],
@@ -478,12 +490,27 @@ export async function listEntitiesWithOverlay(
     )
   `;
 
+  // Entity-level OWN_OR_GLOBAL: an org sees its own entities and entities
+  // at `org_id = '__global__'`. Without this, entities at `__global__`
+  // (the canonical demo entities moved by migration 0060) are stranded —
+  // visible to no one — and the shipped demo's entity definitions
+  // disappear for every workspace.
+  //
+  // Entity-level shadow (per-org override of a same-name global entity)
+  // is intentionally NOT implemented here — no current onboarding flow
+  // creates a per-org entity with the same name as a global one, and
+  // pg-mem's CTE engine can't run the correlated subquery the shadow
+  // check would require. The connection-level shadow above already
+  // handles the main confusion case: tombstoning the connection drops
+  // every entity tied to it from the visibility set.
+  const entityOrgVisibilitySql = `org_id = $1 OR org_id = '__global__'`;
+
   if (entityType) {
     return internalQuery<SemanticEntityRow>(
       `WITH overlay AS (
          SELECT DISTINCT ON (org_id, name, connection_id) ${baseSelect}
          FROM semantic_entities
-         WHERE org_id = $1
+         WHERE (${entityOrgVisibilitySql})
            AND entity_type = $2
            AND status IN ('published', 'draft', 'draft_delete')
            AND (${connectionVisibilitySql})
@@ -505,7 +532,7 @@ export async function listEntitiesWithOverlay(
     `WITH overlay AS (
        SELECT DISTINCT ON (org_id, name, connection_id) ${baseSelect}
        FROM semantic_entities
-       WHERE org_id = $1
+       WHERE (${entityOrgVisibilitySql})
          AND status IN ('published', 'draft', 'draft_delete')
          AND (${connectionVisibilitySql})
        ORDER BY org_id, name, connection_id,
@@ -986,15 +1013,33 @@ export async function restoreSingleConnection(
   opts?: { demoIndustry?: string | null },
 ): Promise<RestoreConnectionResult> {
   const current = await client.query(
-    `SELECT status FROM connections WHERE org_id = $1 AND id = $2 FOR UPDATE`,
+    `SELECT status, url FROM connections WHERE org_id = $1 AND id = $2 FOR UPDATE`,
     [orgId, connectionId],
   );
   if (current.rows.length === 0) {
     return { status: "not_found" };
   }
-  const row = current.rows[0] as { status: string };
+  const row = current.rows[0] as { status: string; url: string };
   if (row.status !== "archived") {
     return { status: "not_archived" };
+  }
+
+  // Tombstone rows (the per-org delete-as-hide shadow inserted by
+  // admin-connections.ts when an org hides a `__global__` connection
+  // from its workspace) carry `url = ''` as a marker — they're not real
+  // archived connections. Restoring them by flipping status='published'
+  // would expose the empty-string url to every read path that doesn't
+  // pre-filter `status='archived'`, and `decryptUrl('')` then crashes.
+  // The user-visible "restore" semantic on a tombstone is "un-hide" —
+  // delete the per-org row so the global connection becomes visible
+  // again via the connection-visibility fallback. No entity/prompt
+  // cascade because the tombstone never owned any.
+  if (row.url === "") {
+    await client.query(
+      `DELETE FROM connections WHERE org_id = $1 AND id = $2 AND status = 'archived' AND url = ''`,
+      [orgId, connectionId],
+    );
+    return { status: "restored", entities: 0, prompts: 0 };
   }
 
   await client.query(

--- a/packages/api/src/lib/semantic/entities.ts
+++ b/packages/api/src/lib/semantic/entities.ts
@@ -420,6 +420,20 @@ export async function listEntitiesWithOverlay(
   const baseSelect =
     "id, org_id, entity_type, name, yaml_content, connection_id, status, created_at, updated_at";
 
+  // Connection visibility includes the org's own connections plus rows at
+  // `org_id = '__global__'` (the canonical-demo fallback added in #2303).
+  // Per-org entities tied to `connection_id = '__demo__'` would otherwise be
+  // filtered out once the per-org demo connection row was removed in favor of
+  // the shared global one. Keep this in sync with `getVisibleConnectionIds`.
+  const connectionVisibilitySql = `
+    connection_id IS NULL
+    OR connection_id IN (
+      SELECT id FROM connections
+      WHERE (org_id = $1 OR org_id = '__global__')
+        AND status IN ('published', 'draft')
+    )
+  `;
+
   if (entityType) {
     return internalQuery<SemanticEntityRow>(
       `WITH overlay AS (
@@ -428,13 +442,7 @@ export async function listEntitiesWithOverlay(
          WHERE org_id = $1
            AND entity_type = $2
            AND status IN ('published', 'draft', 'draft_delete')
-           AND (
-             connection_id IS NULL
-             OR connection_id IN (
-               SELECT id FROM connections
-               WHERE org_id = $1 AND status IN ('published', 'draft')
-             )
-           )
+           AND (${connectionVisibilitySql})
          ORDER BY org_id, name, connection_id,
            CASE status
              WHEN 'draft_delete' THEN 0
@@ -455,13 +463,7 @@ export async function listEntitiesWithOverlay(
        FROM semantic_entities
        WHERE org_id = $1
          AND status IN ('published', 'draft', 'draft_delete')
-         AND (
-           connection_id IS NULL
-           OR connection_id IN (
-             SELECT id FROM connections
-             WHERE org_id = $1 AND status IN ('published', 'draft')
-           )
-         )
+         AND (${connectionVisibilitySql})
        ORDER BY org_id, name, connection_id,
          CASE status
            WHEN 'draft_delete' THEN 0

--- a/packages/api/src/lib/semantic/entities.ts
+++ b/packages/api/src/lib/semantic/entities.ts
@@ -204,21 +204,26 @@ export async function listEntityRows(
 ): Promise<SemanticEntityRow[]> {
   if (!hasInternalDB()) return [];
 
-  // When filtering to status='published' we apply the same connection-
-  // visibility filter as `listEntitiesWithOverlay` so the published-mode
-  // agent path doesn't surface entities tied to a connection the org
-  // archived (or to a `__global__` connection the org tombstoned). Other
-  // call sites (admin reads at status='draft', count queries) keep the
-  // simpler org-scoped query — they intentionally see archive/draft state.
+  // When filtering to status='published' we apply a connection-visibility
+  // filter that mirrors `getVisibleConnectionIds` in *published* mode —
+  // i.e. only `status = 'published'` connections count, never drafts. The
+  // overlay variant in `listEntitiesWithOverlay` accepts drafts because
+  // it's developer-mode by construction. Pinning published mode here
+  // prevents the published-mode agent from surfacing an entity tied to a
+  // draft connection that the SQL whitelist would reject anyway.
+  //
+  // Other call sites (admin reads at status='draft', count queries) keep
+  // the simpler org-scoped query — they intentionally see archive/draft
+  // state.
   const visibilityClause = statusFilter === "published"
     ? `AND (
          connection_id IS NULL
          OR connection_id IN (
-           SELECT id FROM connections WHERE org_id = $1 AND status IN ('published', 'draft')
+           SELECT id FROM connections WHERE org_id = $1 AND status = 'published'
          )
          OR (
            connection_id IN (
-             SELECT id FROM connections WHERE org_id = '__global__' AND status IN ('published', 'draft')
+             SELECT id FROM connections WHERE org_id = '__global__' AND status = 'published'
            )
            AND connection_id NOT IN (
              SELECT id FROM connections WHERE org_id = $1
@@ -445,8 +450,9 @@ export async function listEntitiesWithOverlay(
   const baseSelect =
     "id, org_id, entity_type, name, yaml_content, connection_id, status, created_at, updated_at";
 
-  // Connection visibility mirrors `getVisibleConnectionIds`:
-  //   1. The org's own non-archived connections.
+  // Connection visibility mirrors `getVisibleConnectionIds`'s
+  // *developer-mode* shape (this overlay is developer-mode by construction):
+  //   1. The org's own published-or-draft connections.
   //   2. PLUS `__global__` connections the org hasn't shadowed (any per-org
   //      row of the same id — including an archived tombstone — masks the
   //      global counterpart). This is what makes "delete the demo" work

--- a/packages/api/src/lib/semantic/entities.ts
+++ b/packages/api/src/lib/semantic/entities.ts
@@ -204,12 +204,36 @@ export async function listEntityRows(
 ): Promise<SemanticEntityRow[]> {
   if (!hasInternalDB()) return [];
 
+  // When filtering to status='published' we apply the same connection-
+  // visibility filter as `listEntitiesWithOverlay` so the published-mode
+  // agent path doesn't surface entities tied to a connection the org
+  // archived (or to a `__global__` connection the org tombstoned). Other
+  // call sites (admin reads at status='draft', count queries) keep the
+  // simpler org-scoped query — they intentionally see archive/draft state.
+  const visibilityClause = statusFilter === "published"
+    ? `AND (
+         connection_id IS NULL
+         OR connection_id IN (
+           SELECT id FROM connections WHERE org_id = $1 AND status IN ('published', 'draft')
+         )
+         OR (
+           connection_id IN (
+             SELECT id FROM connections WHERE org_id = '__global__' AND status IN ('published', 'draft')
+           )
+           AND connection_id NOT IN (
+             SELECT id FROM connections WHERE org_id = $1
+           )
+         )
+       )`
+    : "";
+
   if (entityType) {
     if (statusFilter) {
       return internalQuery<SemanticEntityRow>(
         `SELECT id, org_id, entity_type, name, yaml_content, connection_id, status, created_at, updated_at
          FROM semantic_entities
          WHERE org_id = $1 AND entity_type = $2 AND status = $3
+           ${visibilityClause}
          ORDER BY name`,
         [orgId, entityType, statusFilter],
       );
@@ -228,6 +252,7 @@ export async function listEntityRows(
       `SELECT id, org_id, entity_type, name, yaml_content, connection_id, status, created_at, updated_at
        FROM semantic_entities
        WHERE org_id = $1 AND status = $2
+         ${visibilityClause}
        ORDER BY entity_type, name`,
       [orgId, statusFilter],
     );
@@ -420,17 +445,30 @@ export async function listEntitiesWithOverlay(
   const baseSelect =
     "id, org_id, entity_type, name, yaml_content, connection_id, status, created_at, updated_at";
 
-  // Connection visibility includes the org's own connections plus rows at
-  // `org_id = '__global__'` (the canonical-demo fallback added in #2303).
-  // Per-org entities tied to `connection_id = '__demo__'` would otherwise be
-  // filtered out once the per-org demo connection row was removed in favor of
-  // the shared global one. Keep this in sync with `getVisibleConnectionIds`.
+  // Connection visibility mirrors `getVisibleConnectionIds`:
+  //   1. The org's own non-archived connections.
+  //   2. PLUS `__global__` connections the org hasn't shadowed (any per-org
+  //      row of the same id — including an archived tombstone — masks the
+  //      global counterpart). This is what makes "delete the demo" work
+  //      end-to-end: tombstone the connection → global drops out of the
+  //      visible set → entities tied to that connection_id get filtered
+  //      out of the developer-mode overlay alongside it.
+  //
+  // Phrased without UNION / NOT EXISTS so pg-mem's overlay-queries
+  // integration suite can execute it; logically equivalent to the
+  // shadow-check pattern in `getVisibleConnectionIds`.
   const connectionVisibilitySql = `
     connection_id IS NULL
     OR connection_id IN (
-      SELECT id FROM connections
-      WHERE (org_id = $1 OR org_id = '__global__')
-        AND status IN ('published', 'draft')
+      SELECT id FROM connections WHERE org_id = $1 AND status IN ('published', 'draft')
+    )
+    OR (
+      connection_id IN (
+        SELECT id FROM connections WHERE org_id = '__global__' AND status IN ('published', 'draft')
+      )
+      AND connection_id NOT IN (
+        SELECT id FROM connections WHERE org_id = $1
+      )
     )
   `;
 


### PR DESCRIPTION
## Summary

Builds on #2303. Per-workspace onboarding currently INSERTs a fresh `__demo__` connection row scoped to each org id, so 103+ trial workspaces produce 103 rows all pointing at the same demo Postgres. After #2303 made the demo visible org-wide via the `__global__` fallback, each per-org row also shadowed the canonical global one.

This PR collapses the model:

- **Onboarding writes `__demo__` at `org_id = '__global__'`** with `ON CONFLICT (id, org_id) DO NOTHING`. First onboarder pins the URL; subsequent ones inherit it. Race-safe by construction.
- **Runtime registration guards on `connections.has(id)`** so concurrent onboarders don't race-overwrite each other's URLs in the in-memory pool.
- **`listEntitiesWithOverlay`'s connection-visibility subquery** now accepts `org_id IN ($1, '__global__')` so per-org entity rows tied to `connection_id = '__demo__'` still resolve. Without this, the moment a per-org connection row stopped existing, those entities would be filtered out of the developer-mode overlay.

Per-workspace demo entities still get imported in phase 2 — sharing entity-level state is a separate decision; this PR only collapses the connection row.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun run test` — full suite green (1 transient Bun segfault in `packages/cli` on the first run; 30/30 pass on retry, unrelated to this PR — flagged as a known Bun crash with a `bun.report` link)
- [x] `bun x syncpack lint` — no issues
- [x] All drift checks pass
- [x] Added an integration test in `overlay-queries-integration.test.ts` proving entities tied to a `__global__` connection are visible from any org
- [ ] Post-merge: confirm new workspaces going through `/use-demo` end up sharing the single global `__demo__` row instead of cloning it

## Follow-ups

- File issue: share demo entities globally too (currently still cloned per workspace at onboarding). Storage cost is small (~17 rows × N orgs) but maintenance is annoying — updating demo content requires either re-import per org or a query-layer change. Probably wants the same `__global__` UNION pattern in `listEntityRows` + `getEntity` + `countEntities`.
- File issue: lift `/admin/platform/*` to `/platform/*` (carried over from #2303).