### PR TITLE
fix(web,api): unblock demo Delete + org-scope admin semantic detail

### DIFF
--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -365,7 +365,15 @@ mock.module("@atlas/api/lib/semantic/sync", () => ({
   importFromDisk: mock(() => Promise.resolve({ imported: 0, skipped: 0, errors: [], total: 0 })),
   reconcileAllOrgs: mock(() => Promise.resolve()),
   cleanupOrgDirectory: mock(() => Promise.resolve()),
-  getSemanticRoot: mock(() => "/tmp/test"),
+  // Mirror the real `sync.getSemanticRoot(orgId?)` shape: returns the base
+  // root (from the env-driven fixture) when no orgId, or the per-org overlay
+  // under `.orgs/<orgId>/` when an orgId is supplied. Keeping this in sync
+  // with the real signature matters because admin.ts now routes all 5
+  // semantic-root resolutions through this module (PR fix: org-scope admin
+  // disk endpoints).
+  getSemanticRoot: mock((orgId?: string) =>
+    orgId ? path.join(tmpRoot, ".orgs", orgId) : tmpRoot,
+  ),
 }));
 
 const mockPluginHealthCheck: Mock<() => Promise<unknown>> = mock(() =>
@@ -766,6 +774,170 @@ describe("GET /api/v1/admin/semantic/entities/:name", () => {
 
     const body = (await res.json()) as { entity: Record<string, unknown> };
     expect(body.entity.table).toBe("orders");
+  });
+});
+
+// Coverage for the org-scoped + DB-overlay fallback path added to
+// `getEntityRoute`. The headline regression mode is "every SaaS detail click
+// returns 404": the disk endpoint had no awareness of org-scoped overlays
+// or DB-backed user-created entities. These tests pin both branches so a
+// refactor of the resolve / fallback logic can't silently re-introduce it.
+describe("GET /api/v1/admin/semantic/entities/:name — org-scoped + DB overlay", () => {
+  beforeEach(() => {
+    mockAuthenticateRequest.mockReset();
+    mockGetEntityAdmin.mockReset();
+    mockHasInternalDB = true;
+  });
+
+  it("resolves an entity from the DB overlay when the disk file is missing", async () => {
+    setOrgScopedAdmin("org-saas-1");
+    mockGetEntityAdmin.mockResolvedValue({
+      id: "ent-1",
+      org_id: "org-saas-1",
+      entity_type: "entity",
+      name: "apikey",
+      yaml_content: "table: api_keys\ndescription: User-issued API keys\ndimensions:\n  id:\n    type: integer\n",
+      connection_id: null,
+      status: "published",
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+
+    const res = await app.fetch(adminRequest("/api/v1/admin/semantic/entities/apikey"));
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { entity: Record<string, unknown> };
+    expect(body.entity.table).toBe("api_keys");
+    expect(body.entity.dimensions).toBeDefined();
+
+    // Confirm the DB lookup was invoked with the org-scoped key, not the
+    // base-root probe. Catches a silent revert of the fallback branch.
+    expect(mockGetEntityAdmin).toHaveBeenCalledWith("org-saas-1", "entity", "apikey");
+  });
+
+  it("returns 404 with requestId when both disk and DB miss", async () => {
+    setOrgScopedAdmin("org-saas-1");
+    mockGetEntityAdmin.mockResolvedValue(null);
+
+    const res = await app.fetch(adminRequest("/api/v1/admin/semantic/entities/missing"));
+    expect(res.status).toBe(404);
+
+    const body = (await res.json()) as { error: string; requestId?: string };
+    expect(body.error).toBe("not_found");
+    // The 404 must include a requestId for log correlation per project rules.
+    expect(typeof body.requestId).toBe("string");
+    expect(body.requestId).not.toBe("");
+  });
+
+  it("returns 500 with requestId when DB row contains malformed YAML", async () => {
+    setOrgScopedAdmin("org-saas-1");
+    mockGetEntityAdmin.mockResolvedValue({
+      id: "ent-2",
+      org_id: "org-saas-1",
+      entity_type: "entity",
+      name: "broken",
+      // Unbalanced quote / colon — js-yaml throws on parse.
+      yaml_content: 'table: "broken\ndimensions:\n  id: {{not yaml',
+      connection_id: null,
+      status: "published",
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+
+    const res = await app.fetch(adminRequest("/api/v1/admin/semantic/entities/broken"));
+    expect(res.status).toBe(500);
+
+    const body = (await res.json()) as { error: string; message: string; requestId?: string };
+    expect(body.error).toBe("internal_error");
+    expect(body.message).toContain("broken");
+    expect(typeof body.requestId).toBe("string");
+  });
+
+  it("returns 500 when DB-backed YAML parses to a non-object (null/scalar/array)", async () => {
+    // js-yaml happily returns null / scalars / arrays for technically-valid
+    // YAML that isn't an entity definition. The frontend `<EntityDetail>`
+    // would then render garbage instead of failing — the shape guard turns
+    // that into an actionable 500.
+    setOrgScopedAdmin("org-saas-1");
+    for (const yamlContent of ["", "just a string", "- one\n- two\n", "null\n"]) {
+      mockGetEntityAdmin.mockResolvedValueOnce({
+        id: "ent-3",
+        org_id: "org-saas-1",
+        entity_type: "entity",
+        name: "bad-shape",
+        yaml_content: yamlContent,
+        connection_id: null,
+        status: "published",
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      });
+
+      const res = await app.fetch(adminRequest("/api/v1/admin/semantic/entities/bad-shape"));
+      expect(res.status).toBe(500);
+
+      const body = (await res.json()) as { error: string; message: string; requestId?: string };
+      expect(body.error).toBe("internal_error");
+      expect(body.message).toContain("malformed");
+      expect(typeof body.requestId).toBe("string");
+    }
+  });
+
+  it("does not consult the DB overlay when no active org is present", async () => {
+    // Self-hosted single-tenant — no orgId. The DB lookup must be skipped
+    // entirely so we don't leak rows from `__global__` or another tenant
+    // into a request that has no org context.
+    setAdmin();
+    mockGetEntityAdmin.mockReset();
+
+    const res = await app.fetch(adminRequest("/api/v1/admin/semantic/entities/nonexistent"));
+    expect(res.status).toBe(404);
+    expect(mockGetEntityAdmin).not.toHaveBeenCalled();
+  });
+
+  it("does not consult the DB overlay when internal DB is disabled", async () => {
+    setOrgScopedAdmin("org-saas-1");
+    mockHasInternalDB = false;
+    mockGetEntityAdmin.mockReset();
+
+    try {
+      const res = await app.fetch(adminRequest("/api/v1/admin/semantic/entities/nonexistent"));
+      expect(res.status).toBe(404);
+      expect(mockGetEntityAdmin).not.toHaveBeenCalled();
+    } finally {
+      mockHasInternalDB = true;
+    }
+  });
+
+  it("looks up entities under .orgs/<orgId>/ when an org is active", async () => {
+    // Org-scoped FS root resolution. Drop a fixture under the org overlay
+    // and confirm the handler finds it without falling through to the DB.
+    const orgRoot = path.join(tmpRoot, ".orgs", "org-saas-fs", "entities");
+    fs.mkdirSync(orgRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(orgRoot, "scoped.yml"),
+      `table: scoped
+description: From the org overlay
+dimensions:
+  id:
+    type: integer
+`,
+    );
+
+    setOrgScopedAdmin("org-saas-fs");
+    mockGetEntityAdmin.mockReset();
+
+    try {
+      const res = await app.fetch(adminRequest("/api/v1/admin/semantic/entities/scoped"));
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as { entity: Record<string, unknown> };
+      expect(body.entity.table).toBe("scoped");
+      expect(body.entity.description).toBe("From the org overlay");
+      // Disk hit short-circuits the DB fallback.
+      expect(mockGetEntityAdmin).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(path.join(tmpRoot, ".orgs", "org-saas-fs"), { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -40,6 +40,13 @@ import {
   discoverEntities,
   findEntityFile,
 } from "@atlas/api/lib/semantic/files";
+// Org-aware filesystem root — same helper the public /semantic route uses to
+// surface per-org YAML at `semantic/.orgs/<orgId>/`. The admin disk endpoints
+// historically read from the base root only, which 404'd on SaaS workspaces
+// whose entities had been DB-synced to their org subdirectory (and double-bug:
+// user-created DB-only entities were invisible to the disk endpoint entirely).
+import { getSemanticRoot as getOrgSemanticRoot } from "@atlas/api/lib/semantic/sync";
+import * as yaml from "js-yaml";
 import { runDiff } from "@atlas/api/lib/semantic/diff";
 import { adminOrgs } from "./admin-orgs";
 import { adminAudit } from "./admin-audit";
@@ -1257,8 +1264,14 @@ admin.openapi(overviewRoute, async (c) => {
 // -- Semantic Layer ---------------------------------------------------------
 
 admin.openapi(listEntitiesRoute, async (c) => {
-  await adminAuthAndContext(c, "admin:semantic");
-  const root = getSemanticRoot();
+  const { authResult } = await adminAuthAndContext(c, "admin:semantic");
+  // Org-scope so SaaS workspaces see their own `semantic/.orgs/<orgId>/`
+  // overlay rather than the bundled NovaMart shipped in base root. The
+  // SaaS UI fetches /admin/semantic/org/entities instead (DB-backed) so
+  // this branch is what self-hosted hits — but on a SaaS self-hosted
+  // probe path or direct API caller, the org overlay is still correct.
+  const orgId = authResult.user?.activeOrganizationId;
+  const root = orgId ? getOrgSemanticRoot(orgId) : getSemanticRoot();
   const result = discoverEntities(root);
   return c.json({
     entities: result.entities,
@@ -1270,52 +1283,95 @@ admin.openapi(getEntityRoute, async (c) => {
 
   const { name } = c.req.valid("param");
 
-  const { requestId } = await adminAuthAndContext(c, "admin:semantic");
+  const { requestId, authResult } = await adminAuthAndContext(c, "admin:semantic");
   // Path traversal protection
   if (!isValidEntityName(name)) {
     log.warn({ requestId, name }, "Rejected invalid entity name");
     return c.json({ error: "invalid_request", message: "Invalid entity name." }, 400);
   }
 
-  const root = getSemanticRoot();
+  // Resolve the org-scoped root when an active org is present, mirroring the
+  // public /semantic/entities/{name} route (see PR #2303). Without this the
+  // admin disk endpoint reads from the base `semantic/` directory only, which
+  // 404s on every SaaS workspace because their entities live at
+  // `semantic/.orgs/<orgId>/`. The frontend's SaaS list path comes from the
+  // org-scoped DB endpoint (admin-semantic page.tsx:431-433), so the detail
+  // fetch *must* resolve against the same org overlay or every list-click
+  // produces `Failed to load "<entity>": HTTP 404`.
+  const orgId = authResult.user?.activeOrganizationId;
+  const root = orgId ? getOrgSemanticRoot(orgId) : getSemanticRoot();
   const filePath = findEntityFile(root, name);
-  if (!filePath) {
-    return c.json({ error: "not_found", message: `Entity "${name}" not found.` }, 404);
+
+  if (filePath) {
+    // Defense-in-depth: verify resolved path is within semantic root
+    const resolved = path.resolve(filePath);
+    if (!resolved.startsWith(path.resolve(root))) {
+      log.error({ requestId, name, resolved, root }, "Resolved entity path escaped semantic root");
+      return c.json({ error: "forbidden", message: "Access denied." , requestId}, 403);
+    }
+
+    try {
+      const raw = readYamlFile(filePath);
+      return c.json({ entity: raw }, 200);
+    } catch (err) {
+      log.error({ err: err instanceof Error ? err : new Error(String(err)), filePath, entityName: name }, "Failed to parse entity YAML file");
+      return c.json({ error: "internal_error", message: `Failed to parse entity file for "${name}".` , requestId}, 500);
+    }
   }
 
-  // Defense-in-depth: verify resolved path is within semantic root
-  const resolved = path.resolve(filePath);
-  if (!resolved.startsWith(path.resolve(root))) {
-    log.error({ requestId, name, resolved, root }, "Resolved entity path escaped semantic root");
-    return c.json({ error: "forbidden", message: "Access denied." , requestId}, 403);
+  // Fall back to the DB overlay. User-created entities live in
+  // `semantic_entities` and the disk overlay can lag (or be wiped on a
+  // container restart — Railway/SaaS filesystems are ephemeral). Without
+  // this branch the user sees a 404 even though the entity they just
+  // clicked is in their workspace.
+  if (orgId && hasInternalDB()) {
+    try {
+      const { getEntity } = await import("@atlas/api/lib/semantic/entities");
+      const row = await getEntity(orgId, "entity", name);
+      if (row) {
+        try {
+          const parsed = yaml.load(row.yaml_content);
+          return c.json({ entity: parsed }, 200);
+        } catch (parseErr) {
+          log.error(
+            { err: parseErr instanceof Error ? parseErr : new Error(String(parseErr)), entityName: name, orgId, requestId },
+            "Failed to parse YAML from DB-backed semantic entity",
+          );
+          return c.json({ error: "internal_error", message: `Failed to parse entity content for "${name}".`, requestId }, 500);
+        }
+      }
+    } catch (err) {
+      log.error(
+        { err: err instanceof Error ? err : new Error(String(err)), entityName: name, orgId, requestId },
+        "Failed to look up entity in DB overlay",
+      );
+      return c.json({ error: "internal_error", message: `Failed to load entity "${name}".`, requestId }, 500);
+    }
   }
 
-  try {
-    const raw = readYamlFile(filePath);
-    return c.json({ entity: raw }, 200);
-  } catch (err) {
-    log.error({ err: err instanceof Error ? err : new Error(String(err)), filePath, entityName: name }, "Failed to parse entity YAML file");
-    return c.json({ error: "internal_error", message: `Failed to parse entity file for "${name}".` , requestId}, 500);
-  }
+  return c.json({ error: "not_found", message: `Entity "${name}" not found.` }, 404);
 });
 
 admin.openapi(listMetricsRoute, async (c) => {
-  await adminAuthAndContext(c, "admin:semantic");
-  const root = getSemanticRoot();
+  const { authResult } = await adminAuthAndContext(c, "admin:semantic");
+  const orgId = authResult.user?.activeOrganizationId;
+  const root = orgId ? getOrgSemanticRoot(orgId) : getSemanticRoot();
   const metrics = discoverMetrics(root);
   return c.json({ metrics }, 200);
 });
 
 admin.openapi(getGlossaryRoute, async (c) => {
-  await adminAuthAndContext(c, "admin:semantic");
-  const root = getSemanticRoot();
+  const { authResult } = await adminAuthAndContext(c, "admin:semantic");
+  const orgId = authResult.user?.activeOrganizationId;
+  const root = orgId ? getOrgSemanticRoot(orgId) : getSemanticRoot();
   const glossary = loadGlossary(root);
   return c.json({ glossary }, 200);
 });
 
 admin.openapi(getCatalogRoute, async (c) => {
-  const { requestId } = await adminAuthAndContext(c, "admin:semantic");
-  const root = getSemanticRoot();
+  const { requestId, authResult } = await adminAuthAndContext(c, "admin:semantic");
+  const orgId = authResult.user?.activeOrganizationId;
+  const root = orgId ? getOrgSemanticRoot(orgId) : getSemanticRoot();
   const catalogFile = path.join(root, "catalog.yml");
   if (!fs.existsSync(catalogFile)) {
     return c.json({ catalog: null }, 200);

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -41,11 +41,14 @@ import {
   findEntityFile,
 } from "@atlas/api/lib/semantic/files";
 // Org-aware filesystem root — same helper the public /semantic route uses to
-// surface per-org YAML at `semantic/.orgs/<orgId>/`. The admin disk endpoints
-// historically read from the base root only, which 404'd on SaaS workspaces
-// whose entities had been DB-synced to their org subdirectory (and double-bug:
-// user-created DB-only entities were invisible to the disk endpoint entirely).
-import { getSemanticRoot as getOrgSemanticRoot } from "@atlas/api/lib/semantic/sync";
+// surface per-org YAML at `semantic/.orgs/<orgId>/`. Accepts an optional orgId
+// and falls back to the base root when omitted, so it covers both the
+// self-hosted single-tenant case and the SaaS org-scoped case. The admin disk
+// endpoints historically read from the base root only, which 404'd on SaaS
+// workspaces whose entities had been DB-synced to their org subdirectory (and
+// double-bug: user-created DB-only entities were invisible to the disk
+// endpoint entirely).
+import { getSemanticRoot as resolveSemanticRoot } from "@atlas/api/lib/semantic/sync";
 import * as yaml from "js-yaml";
 import { runDiff } from "@atlas/api/lib/semantic/diff";
 import { adminOrgs } from "./admin-orgs";
@@ -1265,13 +1268,11 @@ admin.openapi(overviewRoute, async (c) => {
 
 admin.openapi(listEntitiesRoute, async (c) => {
   const { authResult } = await adminAuthAndContext(c, "admin:semantic");
-  // Org-scope so SaaS workspaces see their own `semantic/.orgs/<orgId>/`
-  // overlay rather than the bundled NovaMart shipped in base root. The
-  // SaaS UI fetches /admin/semantic/org/entities instead (DB-backed) so
-  // this branch is what self-hosted hits — but on a SaaS self-hosted
-  // probe path or direct API caller, the org overlay is still correct.
+  // `activeOrganizationId` is present on both SaaS and self-hosted requests
+  // once a workspace is selected, so the org overlay is the right root
+  // whenever we have one. Falls back to the base root for the no-org case.
   const orgId = authResult.user?.activeOrganizationId;
-  const root = orgId ? getOrgSemanticRoot(orgId) : getSemanticRoot();
+  const root = resolveSemanticRoot(orgId);
   const result = discoverEntities(root);
   return c.json({
     entities: result.entities,
@@ -1291,15 +1292,16 @@ admin.openapi(getEntityRoute, async (c) => {
   }
 
   // Resolve the org-scoped root when an active org is present, mirroring the
-  // public /semantic/entities/{name} route (see PR #2303). Without this the
-  // admin disk endpoint reads from the base `semantic/` directory only, which
-  // 404s on every SaaS workspace because their entities live at
-  // `semantic/.orgs/<orgId>/`. The frontend's SaaS list path comes from the
-  // org-scoped DB endpoint (admin-semantic page.tsx:431-433), so the detail
-  // fetch *must* resolve against the same org overlay or every list-click
-  // produces `Failed to load "<entity>": HTTP 404`.
+  // public `/semantic/entities/{name}` route. Without this, the admin disk
+  // endpoint reads from the base `semantic/` directory only, which 404s on
+  // every SaaS workspace because their entities live at
+  // `semantic/.orgs/<orgId>/`. The frontend's SaaS list branch fetches from
+  // `/admin/semantic/org/entities` (DB-backed) — see the `isSaas` ternary in
+  // `admin/semantic/page.tsx` — so the detail fetch must resolve against the
+  // same org overlay or every list-click produces
+  // `Failed to load "<entity>": HTTP 404`.
   const orgId = authResult.user?.activeOrganizationId;
-  const root = orgId ? getOrgSemanticRoot(orgId) : getSemanticRoot();
+  const root = resolveSemanticRoot(orgId);
   const filePath = findEntityFile(root, name);
 
   if (filePath) {
@@ -1325,37 +1327,68 @@ admin.openapi(getEntityRoute, async (c) => {
   // this branch the user sees a 404 even though the entity they just
   // clicked is in their workspace.
   if (orgId && hasInternalDB()) {
+    // Three failure modes are kept distinct so the wrong on-call playbook
+    // doesn't run: (a) the dynamic import of `entities` is a module-
+    // resolution / bundler problem, (b) the DB call is an infra / pool
+    // problem, (c) yaml.load is a data-integrity problem in the row.
+    // Lumping them into one catch produced "Failed to look up entity in DB
+    // overlay" for all three, which sent investigation down the wrong path.
+    let getEntity: typeof import("@atlas/api/lib/semantic/entities").getEntity;
     try {
-      const { getEntity } = await import("@atlas/api/lib/semantic/entities");
-      const row = await getEntity(orgId, "entity", name);
-      if (row) {
-        try {
-          const parsed = yaml.load(row.yaml_content);
-          return c.json({ entity: parsed }, 200);
-        } catch (parseErr) {
-          log.error(
-            { err: parseErr instanceof Error ? parseErr : new Error(String(parseErr)), entityName: name, orgId, requestId },
-            "Failed to parse YAML from DB-backed semantic entity",
-          );
-          return c.json({ error: "internal_error", message: `Failed to parse entity content for "${name}".`, requestId }, 500);
-        }
-      }
+      ({ getEntity } = await import("@atlas/api/lib/semantic/entities"));
     } catch (err) {
       log.error(
         { err: err instanceof Error ? err : new Error(String(err)), entityName: name, orgId, requestId },
-        "Failed to look up entity in DB overlay",
+        "Failed to load semantic entities module — bundler/module resolution issue, not a DB problem",
       );
       return c.json({ error: "internal_error", message: `Failed to load entity "${name}".`, requestId }, 500);
     }
+
+    let row: Awaited<ReturnType<typeof getEntity>>;
+    try {
+      row = await getEntity(orgId, "entity", name);
+    } catch (err) {
+      log.error(
+        { err: err instanceof Error ? err : new Error(String(err)), entityName: name, orgId, requestId },
+        "Failed to query DB overlay for semantic entity",
+      );
+      return c.json({ error: "internal_error", message: `Failed to load entity "${name}".`, requestId }, 500);
+    }
+
+    if (row) {
+      let parsed: unknown;
+      try {
+        parsed = yaml.load(row.yaml_content);
+      } catch (parseErr) {
+        log.error(
+          { err: parseErr instanceof Error ? parseErr : new Error(String(parseErr)), entityName: name, orgId, requestId },
+          "Failed to parse YAML from DB-backed semantic entity",
+        );
+        return c.json({ error: "internal_error", message: `Failed to parse entity content for "${name}".`, requestId }, 500);
+      }
+      // Shape-validate: a valid entity YAML deserializes to an object
+      // (dimensions / measures / joins / query_patterns are all keyed maps).
+      // js-yaml will happily return `null`, a string, a number, or an array
+      // for malformed input — the frontend `<EntityDetail>` would then
+      // render garbage instead of failing loudly. Reject those here.
+      if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+        log.error(
+          { entityName: name, orgId, requestId, parsedType: parsed === null ? "null" : Array.isArray(parsed) ? "array" : typeof parsed },
+          "DB-backed entity YAML did not parse to an object",
+        );
+        return c.json({ error: "internal_error", message: `Entity content for "${name}" is malformed.`, requestId }, 500);
+      }
+      return c.json({ entity: parsed }, 200);
+    }
   }
 
-  return c.json({ error: "not_found", message: `Entity "${name}" not found.` }, 404);
+  return c.json({ error: "not_found", message: `Entity "${name}" not found.`, requestId }, 404);
 });
 
 admin.openapi(listMetricsRoute, async (c) => {
   const { authResult } = await adminAuthAndContext(c, "admin:semantic");
   const orgId = authResult.user?.activeOrganizationId;
-  const root = orgId ? getOrgSemanticRoot(orgId) : getSemanticRoot();
+  const root = resolveSemanticRoot(orgId);
   const metrics = discoverMetrics(root);
   return c.json({ metrics }, 200);
 });
@@ -1363,7 +1396,7 @@ admin.openapi(listMetricsRoute, async (c) => {
 admin.openapi(getGlossaryRoute, async (c) => {
   const { authResult } = await adminAuthAndContext(c, "admin:semantic");
   const orgId = authResult.user?.activeOrganizationId;
-  const root = orgId ? getOrgSemanticRoot(orgId) : getSemanticRoot();
+  const root = resolveSemanticRoot(orgId);
   const glossary = loadGlossary(root);
   return c.json({ glossary }, 200);
 });
@@ -1371,7 +1404,7 @@ admin.openapi(getGlossaryRoute, async (c) => {
 admin.openapi(getCatalogRoute, async (c) => {
   const { requestId, authResult } = await adminAuthAndContext(c, "admin:semantic");
   const orgId = authResult.user?.activeOrganizationId;
-  const root = orgId ? getOrgSemanticRoot(orgId) : getSemanticRoot();
+  const root = resolveSemanticRoot(orgId);
   const catalogFile = path.join(root, "catalog.yml");
   if (!fs.existsSync(catalogFile)) {
     return c.json({ catalog: null }, 200);

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -33,9 +33,6 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useDemoReadonly } from "@/ui/hooks/use-demo-readonly";
-import { useDevModeNoDrafts } from "@/ui/hooks/use-dev-mode-no-drafts";
-import { DeveloperEmptyState } from "@/ui/components/admin/developer-empty-state";
-import { PublishedContextWrapper } from "@/ui/components/admin/published-context-wrapper";
 import { DemoBadge, DraftBadge } from "@/ui/components/admin/mode-badges";
 import { DEMO_CONNECTION_ID } from "./columns";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -805,14 +802,27 @@ function healthToStatus(
 
 // ── Page ──────────────────────────────────────────────────────────
 
-/** Tooltip text when connection mutations are blocked by published-mode demo readonly. */
-const DEMO_READONLY_TOOLTIP = "Switch to developer mode to manage connections";
+/**
+ * Tooltip text when editing a demo row is blocked in published mode.
+ *
+ * Edit mutates the shared `__global__/__demo__` URL across every tenant, so
+ * it stays gated by developer mode. Delete is per-org — it inserts an archived
+ * tombstone that hides the global from this workspace only — so it is *not*
+ * gated and the button stays enabled regardless of mode.
+ */
+const DEMO_EDIT_READONLY_TOOLTIP = "Switch to developer mode to edit the shared demo connection";
+
+/**
+ * Tooltip text when add/connect CTAs are blocked while a demo is active in
+ * published mode. The fastest path out is to Delete the demo row (per-org
+ * hide) — that flips `demoReadOnly` to false and re-enables Add immediately.
+ */
+const DEMO_ADD_READONLY_TOOLTIP = "Delete the demo connection or switch to developer mode to add a new one";
 
 export default function ConnectionsPage() {
   const { apiUrl, isCrossOrigin } = useAtlasConfig();
   const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
   const { readOnly: demoReadOnly } = useDemoReadonly();
-  const showDevNoDrafts = useDevModeNoDrafts(["connections"]);
 
   const testMutation = useAdminMutation<ConnectionHealth>({ method: "POST" });
   const [mutationError, setMutationError] = useState<string | null>(null);
@@ -963,7 +973,7 @@ export default function ConnectionsPage() {
                     </Button>
                   </span>
                 </TooltipTrigger>
-                <TooltipContent>{DEMO_READONLY_TOOLTIP}</TooltipContent>
+                <TooltipContent>{DEMO_ADD_READONLY_TOOLTIP}</TooltipContent>
               </Tooltip>
             </TooltipProvider>
           ) : (
@@ -998,76 +1008,41 @@ export default function ConnectionsPage() {
             emptyTitle="No datasource connections"
             emptyDescription="Add a connection to start querying your data"
             emptyAction={{ label: "Add connection", onClick: () => handleAdd() }}
-            // Show the generic "No datasource connections" empty state for a
-            // plain admin who has zero connections — the CompactRow provider
-            // menu is useful, but a new admin deserves the focused onboarding
-            // CTA, not a list of 6 "Connect" buttons. In dev-mode-no-drafts we
-            // short-circuit below to DeveloperEmptyState / PublishedContextWrapper
-            // so the CTA language matches "start building" / "create draft"
-            // rather than "add a connection".
-            isEmpty={!loading && displayConnections.length === 0 && !showDevNoDrafts}
+            isEmpty={!loading && displayConnections.length === 0}
           >
-            {showDevNoDrafts && displayConnections.length === 0 ? (
-              <DeveloperEmptyState
-                icon={Cable}
-                title="Connect your first database to start building."
-                description="Add a connection in developer mode, then publish it when you're ready."
-                action={{ kind: "button", label: "Add connection", onClick: () => handleAdd() }}
-              />
-            ) : showDevNoDrafts ? (
-              <PublishedContextWrapper
-                resourceLabel={{ singular: "connection", plural: "connections" }}
-                action={{ kind: "button", label: "Create draft", onClick: () => handleAdd() }}
-              >
-                <section>
-                  <SectionHeading title="Datasources" description="Providers Atlas can read from" />
-                  <div className="space-y-2">
-                    {providerOrder.map((dbType) => {
-                      const conns = byType.get(dbType) ?? [];
-                      return (
-                        <ProviderBlock
-                          key={dbType}
-                          dbType={dbType}
-                          connections={conns}
-                          demoReadOnly={demoReadOnly}
-                          loadingDetail={loadingDetail}
-                          testMutation={testMutation}
-                          testStatus={testStatus}
-                          onTest={testConnection}
-                          onEdit={handleEdit}
-                          onDelete={handleDelete}
-                          onAdd={handleAdd}
-                        />
-                      );
-                    })}
-                  </div>
-                </section>
-              </PublishedContextWrapper>
-            ) : (
-              <section>
-                <SectionHeading title="Datasources" description="Providers Atlas can read from" />
-                <div className="space-y-2">
-                  {providerOrder.map((dbType) => {
-                    const conns = byType.get(dbType) ?? [];
-                    return (
-                      <ProviderBlock
-                        key={dbType}
-                        dbType={dbType}
-                        connections={conns}
-                        demoReadOnly={demoReadOnly}
-                        loadingDetail={loadingDetail}
-                        testMutation={testMutation}
-                        testStatus={testStatus}
-                        onTest={testConnection}
-                        onEdit={handleEdit}
-                        onDelete={handleDelete}
-                        onAdd={handleAdd}
-                      />
-                    );
-                  })}
-                </div>
-              </section>
-            )}
+            {/*
+              Connections aren't draft-publishable content the way prompts or
+              entities are: CREATE in developer mode produces a draft, but
+              UPDATE and DELETE are immediate, and the demo-hide flow is a
+              per-org archived tombstone that doesn't go through publish. So we
+              don't wrap in `<PublishedContextWrapper>` — doing so traps admins
+              in dev-mode-no-drafts behind an `inert` overlay and prevents the
+              very actions (test / hide demo / drain pool) that don't require
+              drafting in the first place.
+            */}
+            <section>
+              <SectionHeading title="Datasources" description="Providers Atlas can read from" />
+              <div className="space-y-2">
+                {providerOrder.map((dbType) => {
+                  const conns = byType.get(dbType) ?? [];
+                  return (
+                    <ProviderBlock
+                      key={dbType}
+                      dbType={dbType}
+                      connections={conns}
+                      demoReadOnly={demoReadOnly}
+                      loadingDetail={loadingDetail}
+                      testMutation={testMutation}
+                      testStatus={testStatus}
+                      onTest={testConnection}
+                      onEdit={handleEdit}
+                      onDelete={handleDelete}
+                      onAdd={handleAdd}
+                    />
+                  );
+                })}
+              </div>
+            </section>
           </AdminContentWrapper>
         </div>
       </ErrorBoundary>
@@ -1145,7 +1120,7 @@ function ProviderBlock({
                     </Button>
                   </span>
                 </TooltipTrigger>
-                <TooltipContent>{DEMO_READONLY_TOOLTIP}</TooltipContent>
+                <TooltipContent>{DEMO_ADD_READONLY_TOOLTIP}</TooltipContent>
               </Tooltip>
             </TooltipProvider>
           ) : (
@@ -1220,7 +1195,13 @@ function ConnectionCard({
       ? "Unhealthy"
       : "Live";
   const isDemo = conn.id === DEMO_CONNECTION_ID;
-  const rowReadOnly = demoReadOnly && isDemo;
+  // Edit-only gate: PUT mutates the shared __global__/__demo__ URL across
+  // every tenant, so it stays gated to developer mode. Delete is a per-org
+  // archived-tombstone insert (admin-connections.ts:1000-1015) — no shared
+  // state mutation — so it must remain enabled in published mode too;
+  // otherwise dogfood tenants get stuck unable to hide the demo
+  // (the dev-mode toggle then traps them behind PublishedContextWrapper).
+  const editReadOnly = demoReadOnly && isDemo;
   const isDraft = conn.status === "draft";
   const isDefault = conn.id === "default";
   const testing = testMutation.isMutating(conn.id);
@@ -1269,7 +1250,7 @@ function ConnectionCard({
       variant="ghost"
       size="sm"
       onClick={() => onEdit(conn.id)}
-      disabled={loadingDetail || rowReadOnly}
+      disabled={loadingDetail || editReadOnly}
       aria-label={`Edit connection ${conn.id}`}
     >
       <Pencil className="mr-1.5 size-3.5" />
@@ -1277,12 +1258,13 @@ function ConnectionCard({
     </Button>
   );
 
+  // Delete is never gated by editReadOnly: even on the shared demo it is a
+  // per-org tombstone, not a global mutation.
   const deleteButton = (
     <Button
       variant="ghost"
       size="sm"
       onClick={() => onDelete(conn.id)}
-      disabled={rowReadOnly}
       aria-label={`Delete connection ${conn.id}`}
       className="text-destructive hover:text-destructive"
     >
@@ -1291,20 +1273,17 @@ function ConnectionCard({
     </Button>
   );
 
-  const manageButtons = isDefault ? null : rowReadOnly ? (
+  // Wrap only the edit button in a tooltip when demo-readonly applies; the
+  // delete button stays interactive in both modes (per-workspace hide).
+  const manageButtons = isDefault ? null : editReadOnly ? (
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>
           <span tabIndex={0}>{editButton}</span>
         </TooltipTrigger>
-        <TooltipContent>{DEMO_READONLY_TOOLTIP}</TooltipContent>
+        <TooltipContent>{DEMO_EDIT_READONLY_TOOLTIP}</TooltipContent>
       </Tooltip>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span tabIndex={0}>{deleteButton}</span>
-        </TooltipTrigger>
-        <TooltipContent>{DEMO_READONLY_TOOLTIP}</TooltipContent>
-      </Tooltip>
+      {deleteButton}
     </TooltipProvider>
   ) : (
     <>

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -805,12 +805,14 @@ function healthToStatus(
 /**
  * Tooltip text when editing a demo row is blocked in published mode.
  *
- * Edit mutates the shared `__global__/__demo__` URL across every tenant, so
- * it stays gated by developer mode. Delete is per-org — it inserts an archived
- * tombstone that hides the global from this workspace only — so it is *not*
- * gated and the button stays enabled regardless of mode.
+ * The backend's PUT handler returns 403 `demo_readonly` when atlas mode is
+ * published and id is `__demo__` — the UI gate mirrors that so the form
+ * doesn't lead the admin into a 403. Delete is treated differently because
+ * the DELETE handler implements demo-hide as a per-org `archived` row that
+ * shadows the canonical demo from this workspace; no shared mutation, so the
+ * mode gate doesn't apply.
  */
-const DEMO_EDIT_READONLY_TOOLTIP = "Switch to developer mode to edit the shared demo connection";
+const DEMO_EDIT_READONLY_TOOLTIP = "Switch to developer mode to edit the demo connection";
 
 /**
  * Tooltip text when add/connect CTAs are blocked while a demo is active in
@@ -1195,12 +1197,13 @@ function ConnectionCard({
       ? "Unhealthy"
       : "Live";
   const isDemo = conn.id === DEMO_CONNECTION_ID;
-  // Edit-only gate: PUT mutates the shared __global__/__demo__ URL across
-  // every tenant, so it stays gated to developer mode. Delete is a per-org
-  // archived-tombstone insert (admin-connections.ts:1000-1015) — no shared
-  // state mutation — so it must remain enabled in published mode too;
-  // otherwise dogfood tenants get stuck unable to hide the demo
-  // (the dev-mode toggle then traps them behind PublishedContextWrapper).
+  // Edit-only gate: PUT on `__demo__` returns 403 `demo_readonly` in
+  // published mode (matched by the backend's `demoReadonly` check), so the
+  // UI gate mirrors that. Delete uses a per-org `archived` tombstone insert
+  // — no shared mutation — so it stays enabled in both modes. Without that
+  // split, dogfood tenants got stuck unable to hide the demo: published
+  // mode disabled the button and the dev-mode toggle then trapped them
+  // behind the `<PublishedContextWrapper>` overlay.
   const editReadOnly = demoReadOnly && isDemo;
   const isDraft = conn.status === "draft";
   const isDefault = conn.id === "default";


### PR DESCRIPTION
## Summary

Two dogfood-pass bugs surfaced on the Atlas internal tenant, both follow-ups to #2303/#2304:

1. **Demo connection Delete trap (web)** — published mode disabled Delete on `__demo__` with "Switch to developer mode". Switching to dev mode then wrapped every connection in `<PublishedContextWrapper>` (`inert` + `opacity-60`), trapping the user behind a "Create draft" CTA. The backend already implements demo delete as a per-org archived tombstone (no shared mutation), so only Edit needs the dev-mode gate. Split the readonly flag so Delete works in any mode and drop the dev-mode-no-drafts wrapper from the connections page (UPDATE/DELETE are immediate, not draftable — the wrapper was the wrong pattern here).

2. **Admin semantic detail returns 404 on SaaS (api)** — SaaS UI lists entities from `/admin/semantic/org/entities` (DB-backed, org-scoped) but the detail fetch went to `/admin/semantic/entities/{name}` which read from the *base* `semantic/` directory only. Every user-created entity 404'd on click with `Failed to load "<name>": HTTP 404`. Mirror PR #2303's fix to the public route — resolve the org-scoped root via `getOrgSemanticRoot(orgId)` — and add a DB-overlay fallback (`getEntity(orgId, "entity", name)`) for entities whose disk file is missing (Railway/SaaS filesystems are ephemeral). Applied the same org-scope fix to `listEntitiesRoute`, `listMetricsRoute`, `getGlossaryRoute`, and `getCatalogRoute` for consistency.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun x syncpack lint` — clean
- [x] `bun test src/api/__tests__/admin.test.ts` — 161/161 pass (covers GET /admin/semantic/entities and entities/:name)
- [x] `bun test src/api/__tests__/admin-connections.test.ts src/api/__tests__/admin-connections-audit.test.ts` — 53/53 pass
- [x] `bun test src/api/routes/__tests__/permission-enforcement.test.ts` — 63/63 pass
- [x] `bun test src/api/__tests__/semantic.test.ts` — 16/16 pass
- [ ] Post-merge on app.useatlas.dev:
  - Connections page: in published mode with `__demo__` active, Delete is enabled and tooltip is gone; clicking Delete archives the per-org tombstone and the demo disappears from the workspace.
  - Edit on `__demo__` is still gated to developer mode (tooltip: "Switch to developer mode to edit the shared demo connection").
  - Semantic page: clicking any user-created entity loads detail without `Failed to load "<name>": HTTP 404`.

## Follow-ups (not in this PR)

- File issue: review whether `<PublishedContextWrapper>` belongs anywhere else in the admin surface that combines immediate mutations with the draft/publish model — same trap likely lurks on other pages.
- File issue: the SaaS list endpoint mismatch is the inverse of this bug (list comes from DB-overlay, detail came from disk). Long-term, the admin list+detail should share one DB-overlay-aware source.