### PR TITLE
refactor(web): invert NavSubItem default → prefixMatch (#2259)

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -155,13 +155,14 @@ Tracker: [milestone #42](https://github.com/AtlasDevHQ/atlas/milestones/42). Bug
 - [x] Path-gate Boot Smoke + parallelize `ci` + cache bun installs ([#2302](https://github.com/AtlasDevHQ/atlas/issues/2302), [#2308](https://github.com/AtlasDevHQ/atlas/pull/2308)) — Boot Smoke skips on doc-only PRs (new always-on `Boot Build` keeps Dockerfile-shape gated), `ci` lint/type/test/syncpack/template-drift fan out as parallel jobs under an umbrella required check, per-package bun installs cached by `bun.lock` hash.
 - [x] Co-locate BYOT provider + key with workspace billing ([#2309](https://github.com/AtlasDevHQ/atlas/pull/2309)) — reverts the `/admin/model-config → /platform/model-config` move from #2305 (audit miss: API is org-scoped, not platform-tier) and inlines provider/key setup on `/admin/billing` so workspace admins stop bouncing between pages.
 - [x] Extract `<MfaPanel>` shared by `/admin/account-security` + `/settings/profile` ([#2257](https://github.com/AtlasDevHQ/atlas/issues/2257), [#2317](https://github.com/AtlasDevHQ/atlas/pull/2317)) — collapses ~50 lines of duplicated passkey state + handlers + tile composition into a single component; typed `MfaPanelSurface` literal-union prop locks the two valid return paths so a typo can't silently 403 non-admins on re-auth.
+- [x] Invert `NavSubItem` default → `prefixMatch` ([#2259](https://github.com/AtlasDevHQ/atlas/issues/2259)) — renames the implicit-prefix-match flag, flips the default to exact-match so siblings sharing a prefix (e.g. `/admin/settings` vs `/admin/settings/mcp`) stop collapsing into the parent, and opts only `/admin/users` + `/admin/scheduled-tasks` into prefix-mode for legitimate detail-page children. Locks in the #2176 regression with explicit tests.
 
 ### Open
 
 - [ ] Dev-mode discoverability: banner-overlap fix + LaunchDarkly-style pending-changes counter + Publish flow ([#2177](https://github.com/AtlasDevHQ/atlas/issues/2177)).
 - [ ] Standardize all date selectors on a single shadcn DatePicker / DateRangePicker ([#2171](https://github.com/AtlasDevHQ/atlas/issues/2171)).
 - [ ] `/admin/semantic` — rethink Import-from-disk affordance once entities load from Demo ([#2168](https://github.com/AtlasDevHQ/atlas/issues/2168)).
-- [ ] Top-bar spawn follow-ups ([#2258](https://github.com/AtlasDevHQ/atlas/issues/2258)–[#2262](https://github.com/AtlasDevHQ/atlas/issues/2262)) — `AdminBreadcrumb` union, `NavSubItem.exact → prefixMatch`, `/settings/profile` loading skeleton, password/identity tests, residual `authClient as unknown as` cast cleanup.
+- [ ] Top-bar spawn follow-ups ([#2258](https://github.com/AtlasDevHQ/atlas/issues/2258), [#2260](https://github.com/AtlasDevHQ/atlas/issues/2260)–[#2262](https://github.com/AtlasDevHQ/atlas/issues/2262)) — `AdminBreadcrumb` union, `/settings/profile` loading skeleton, password/identity tests, residual `authClient as unknown as` cast cleanup.
 
 <!-- 1.4.1 — MCP: Bringing It All Together: closed 2026-05-09 with 34 issues shipped; per-theme detail above in Shipped Milestones. -->
 

--- a/packages/web/src/ui/components/admin/__tests__/admin-nav.test.ts
+++ b/packages/web/src/ui/components/admin/__tests__/admin-nav.test.ts
@@ -20,9 +20,9 @@ describe("resolveAdminBreadcrumb", () => {
   });
 
   test("#2176 regression — /admin/settings does not collapse /admin/settings/mcp", () => {
-    // Before the prefixMatch inversion, `exact` was opt-in and easy to forget,
-    // so `/admin/settings` prefix-matched `/admin/settings/mcp`. The default
-    // is now exact; both leaves resolve to their own entry.
+    // /admin/settings and /admin/settings/mcp are sibling leaves; if the
+    // parent ever opts into prefixMatch this test fails — that's exactly
+    // the bug #2176 shipped.
     expect(resolveAdminBreadcrumb("/admin/settings")).toEqual({
       section: "Configuration",
       page: "Settings",
@@ -31,6 +31,15 @@ describe("resolveAdminBreadcrumb", () => {
       section: "Configuration",
       page: "MCP",
     });
+  });
+
+  test("prefixMatch respects segment boundaries — sibling routes sharing a prefix don't collapse", () => {
+    // Guards the trailing "/" in `pathname.startsWith(item.href + "/")`. Without
+    // it, /admin/users would prefix-match any sibling whose path happens to
+    // begin with the same letters. A future refactor that drops the "+ "/""
+    // would silently reintroduce a #2176-class regression under a new name.
+    expect(resolveAdminBreadcrumb("/admin/usersearch")).toEqual({});
+    expect(resolveAdminBreadcrumb("/admin/scheduled-tasks-archive")).toEqual({});
   });
 
   test("prefixMatch: true items match nested child routes", () => {

--- a/packages/web/src/ui/components/admin/__tests__/admin-nav.test.ts
+++ b/packages/web/src/ui/components/admin/__tests__/admin-nav.test.ts
@@ -6,9 +6,9 @@ describe("resolveAdminBreadcrumb", () => {
     expect(resolveAdminBreadcrumb("/admin")).toEqual({});
   });
 
-  test("matches an exact-mode item without prefix-matching its children", () => {
-    // /admin/semantic is exact:true so /admin/semantic/improve must not collapse
-    // into the Semantic-Layer entry.
+  test("default is exact-match — siblings with a shared prefix don't collapse", () => {
+    // Semantic Layer parent + Improve Layer child share `/admin/semantic`.
+    // Default-exact means each resolves to its own leaf entry.
     expect(resolveAdminBreadcrumb("/admin/semantic")).toEqual({
       section: "Data",
       page: "Semantic Layer",
@@ -19,14 +19,41 @@ describe("resolveAdminBreadcrumb", () => {
     });
   });
 
-  test("matches a prefix-mode item for nested routes", () => {
-    expect(resolveAdminBreadcrumb("/admin/audit")).toEqual({
-      section: "Monitoring",
-      page: "Audit Log",
+  test("#2176 regression — /admin/settings does not collapse /admin/settings/mcp", () => {
+    // Before the prefixMatch inversion, `exact` was opt-in and easy to forget,
+    // so `/admin/settings` prefix-matched `/admin/settings/mcp`. The default
+    // is now exact; both leaves resolve to their own entry.
+    expect(resolveAdminBreadcrumb("/admin/settings")).toEqual({
+      section: "Configuration",
+      page: "Settings",
     });
-    expect(resolveAdminBreadcrumb("/admin/audit/123")).toEqual({
+    expect(resolveAdminBreadcrumb("/admin/settings/mcp")).toEqual({
+      section: "Configuration",
+      page: "MCP",
+    });
+  });
+
+  test("prefixMatch: true items match nested child routes", () => {
+    // /admin/users has prefixMatch:true so the [id] detail page resolves to
+    // the Users entry rather than dropping off the sidebar.
+    expect(resolveAdminBreadcrumb("/admin/users")).toEqual({
+      section: "Users & Access",
+      page: "Users",
+    });
+    expect(resolveAdminBreadcrumb("/admin/users/abc-123")).toEqual({
+      section: "Users & Access",
+      page: "Users",
+    });
+  });
+
+  test("prefixMatch on /admin/scheduled-tasks resolves the /runs subpage", () => {
+    expect(resolveAdminBreadcrumb("/admin/scheduled-tasks")).toEqual({
       section: "Monitoring",
-      page: "Audit Log",
+      page: "Scheduled Tasks",
+    });
+    expect(resolveAdminBreadcrumb("/admin/scheduled-tasks/runs")).toEqual({
+      section: "Monitoring",
+      page: "Scheduled Tasks",
     });
   });
 

--- a/packages/web/src/ui/components/admin/__tests__/admin-top-bar.test.tsx
+++ b/packages/web/src/ui/components/admin/__tests__/admin-top-bar.test.tsx
@@ -68,7 +68,7 @@ describe("AdminTopBar breadcrumb", () => {
     expect(container.textContent).not.toContain("Semantic Layer");
   });
 
-  test("/admin/settings/mcp resolves to MCP, not Settings (regression on exact-match flag)", () => {
+  test("/admin/settings/mcp resolves to MCP, not Settings (#2176 regression — sibling leaf must not collapse the child)", () => {
     mockedPath = "/admin/settings/mcp";
     cleanup();
     const { container } = render(<AdminTopBar />, { wrapper: Wrapper });

--- a/packages/web/src/ui/components/admin/admin-nav.ts
+++ b/packages/web/src/ui/components/admin/admin-nav.ts
@@ -12,7 +12,7 @@ import {
 export interface NavSubItem {
   href: string;
   label: string;
-  /** Opt-in: match `pathname.startsWith(href + "/")` for nested routes (e.g. detail pages). Default is exact-match — siblings sharing a prefix don't collapse into the parent. */
+  /** Opt-in: match `pathname.startsWith(href + "/")` so a nested route highlights its parent (e.g. `/admin/users` covers `/admin/users/[id]`). Default is exact-match — siblings sharing a prefix don't collapse into the parent. */
   prefixMatch?: boolean;
   requiredRole?: "platform_admin";
   selfHostedOnly?: boolean;
@@ -125,16 +125,25 @@ export interface AdminBreadcrumb {
   page?: string;
 }
 
-/** Single source of truth so sidebar + breadcrumb labels can never drift. */
+/**
+ * Single source of truth for nav-item matching. Sidebar active-state and
+ * breadcrumb resolution must agree on every pathname — duplicating this rule
+ * across two sites is the failure mode that caused #2176.
+ */
+export function matchesNavItem(item: NavSubItem, pathname: string): boolean {
+  if (item.prefixMatch) {
+    return pathname === item.href || pathname.startsWith(item.href + "/");
+  }
+  return pathname === item.href;
+}
+
+/** Resolves a pathname to its sidebar section + page label via `matchesNavItem`. */
 export function resolveAdminBreadcrumb(pathname: string): AdminBreadcrumb {
   if (pathname === "/admin") return {};
 
   for (const group of navGroups) {
     for (const item of group.items) {
-      const matches = item.prefixMatch
-        ? pathname === item.href || pathname.startsWith(item.href + "/")
-        : pathname === item.href;
-      if (matches) return { section: group.title, page: item.label };
+      if (matchesNavItem(item, pathname)) return { section: group.title, page: item.label };
     }
   }
 

--- a/packages/web/src/ui/components/admin/admin-nav.ts
+++ b/packages/web/src/ui/components/admin/admin-nav.ts
@@ -12,8 +12,8 @@ import {
 export interface NavSubItem {
   href: string;
   label: string;
-  /** When true, exact-match only (no prefix). Needed for parent routes that share a prefix with a child (e.g. `/admin/settings` vs `/admin/settings/mcp`). */
-  exact?: boolean;
+  /** Opt-in: match `pathname.startsWith(href + "/")` for nested routes (e.g. detail pages). Default is exact-match — siblings sharing a prefix don't collapse into the parent. */
+  prefixMatch?: boolean;
   requiredRole?: "platform_admin";
   selfHostedOnly?: boolean;
   badge?: number;
@@ -31,7 +31,7 @@ export const navGroups: NavGroup[] = [
     title: "Data",
     icon: Database,
     items: [
-      { href: "/admin/semantic", label: "Semantic Layer", exact: true },
+      { href: "/admin/semantic", label: "Semantic Layer" },
       { href: "/admin/semantic/improve", label: "Improve Layer" },
       { href: "/admin/schema-diff", label: "Schema Diff" },
       { href: "/admin/connections", label: "Connections" },
@@ -53,7 +53,7 @@ export const navGroups: NavGroup[] = [
     title: "Users & Access",
     icon: Users,
     items: [
-      { href: "/admin/users", label: "Users" },
+      { href: "/admin/users", label: "Users", prefixMatch: true },
       { href: "/admin/roles", label: "Roles" },
       { href: "/admin/sessions", label: "Sessions" },
       { href: "/admin/api-keys", label: "API Keys" },
@@ -80,7 +80,7 @@ export const navGroups: NavGroup[] = [
       { href: "/admin/action-log", label: "Admin Action Log" },
       { href: "/admin/token-usage", label: "Token Usage" },
       { href: "/admin/usage", label: "Usage" },
-      { href: "/admin/scheduled-tasks", label: "Scheduled Tasks" },
+      { href: "/admin/scheduled-tasks", label: "Scheduled Tasks", prefixMatch: true },
     ],
   },
   {
@@ -94,7 +94,7 @@ export const navGroups: NavGroup[] = [
       { href: "/admin/custom-domain", label: "Custom Domain" },
       { href: "/admin/sandbox", label: "Sandbox" },
       { href: "/admin/residency", label: "Data Residency" },
-      { href: "/admin/settings", label: "Settings", exact: true },
+      { href: "/admin/settings", label: "Settings" },
       { href: "/admin/settings/mcp", label: "MCP" },
     ],
   },
@@ -103,7 +103,7 @@ export const navGroups: NavGroup[] = [
     icon: Globe,
     requiredRole: "platform_admin",
     items: [
-      { href: "/platform", label: "Overview", exact: true },
+      { href: "/platform", label: "Overview" },
       { href: "/platform/organizations", label: "Organizations" },
       { href: "/platform/actions", label: "Action Log" },
       { href: "/platform/security", label: "Security Adoption" },
@@ -131,9 +131,9 @@ export function resolveAdminBreadcrumb(pathname: string): AdminBreadcrumb {
 
   for (const group of navGroups) {
     for (const item of group.items) {
-      const matches = item.exact
-        ? pathname === item.href
-        : pathname === item.href || pathname.startsWith(item.href + "/");
+      const matches = item.prefixMatch
+        ? pathname === item.href || pathname.startsWith(item.href + "/")
+        : pathname === item.href;
       if (matches) return { section: group.title, page: item.label };
     }
   }

--- a/packages/web/src/ui/components/admin/admin-sidebar.tsx
+++ b/packages/web/src/ui/components/admin/admin-sidebar.tsx
@@ -81,8 +81,8 @@ export function AdminSidebar() {
   const isSaas = deployMode === "saas";
 
   function isSubItemActive(item: NavSubItem) {
-    if (item.exact) return pathname === item.href;
-    return pathname === item.href || pathname.startsWith(item.href + "/");
+    if (item.prefixMatch) return pathname === item.href || pathname.startsWith(item.href + "/");
+    return pathname === item.href;
   }
 
   function isGroupActive(group: NavGroup) {

--- a/packages/web/src/ui/components/admin/admin-sidebar.tsx
+++ b/packages/web/src/ui/components/admin/admin-sidebar.tsx
@@ -37,7 +37,7 @@ import {
 } from "@/components/ui/collapsible";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
-import { navGroups, type NavGroup, type NavSubItem } from "./admin-nav";
+import { matchesNavItem, navGroups, type NavGroup } from "./admin-nav";
 
 // ---------------------------------------------------------------------------
 // Component
@@ -80,13 +80,8 @@ export function AdminSidebar() {
   const pendingCount = usePendingAmendmentCount();
   const isSaas = deployMode === "saas";
 
-  function isSubItemActive(item: NavSubItem) {
-    if (item.prefixMatch) return pathname === item.href || pathname.startsWith(item.href + "/");
-    return pathname === item.href;
-  }
-
   function isGroupActive(group: NavGroup) {
-    return group.items.some((item) => isSubItemActive(item));
+    return group.items.some((item) => matchesNavItem(item, pathname));
   }
 
   const visibleGroups = navGroups
@@ -180,7 +175,7 @@ export function AdminSidebar() {
                     <SidebarMenuSub>
                       {group.items.map((item) => (
                         <SidebarMenuSubItem key={item.href}>
-                          <SidebarMenuSubButton asChild isActive={isSubItemActive(item)}>
+                          <SidebarMenuSubButton asChild isActive={matchesNavItem(item, pathname)}>
                             <Link href={item.href}>
                               <span>{item.label}</span>
                               {item.badge != null && item.badge > 0 && (


### PR DESCRIPTION
## Summary

- `NavSubItem.exact?: boolean` defaulted to false, so every leaf route silently prefix-matched its children — the dangerous mode was the implicit default. Rename to `prefixMatch?: boolean` and flip the default to exact-match.
- Sweep removes all `exact: true` flags (now redundant) and opts only `/admin/users` (`[id]` detail pages) and `/admin/scheduled-tasks` (`/runs`) into prefix mode — the two nav entries with legitimate detail-page children.
- Tests lock in the #2176 regression explicitly: `/admin/settings` resolves to "Settings" and `/admin/settings/mcp` resolves to "MCP" without one collapsing into the other.

## Test plan

- [x] `bun test packages/web/src/ui/components/admin/__tests__/` — 34/34 pass (new prefixMatch + #2176-regression cases included).
- [x] `bun run type` — clean (the rename surfaces every call site).
- [x] `bun run lint` — clean.
- [x] `/ci` — lint, type, full test suite, syncpack, template drift, sec-headers drift, railway-watch, schema drift, oauth-helper drift all green.
- [ ] Manual click-through after merge: `/admin`, `/admin/settings`, `/admin/settings/mcp`, `/admin/users`, `/admin/users/<id>`, `/admin/scheduled-tasks`, `/admin/scheduled-tasks/runs`, `/admin/semantic`, `/admin/semantic/improve` — sidebar highlight + breadcrumb match the page on each.

Closes #2259