### PR TITLE
refactor(web): extract <MfaPanel> shared by /admin/account-security + /settings/profile

### DIFF
--- a/packages/web/src/app/admin/account-security/page.tsx
+++ b/packages/web/src/app/admin/account-security/page.tsx
@@ -18,88 +18,23 @@
  * The page is rendered by Next.js, not Atlas's API admin router, so the
  * `mfaRequired` API gate doesn't run on the page itself — admins who
  * haven't enrolled any factor can always reach it to complete enrollment.
+ *
+ * The tile composition lives in `<MfaPanel />`, shared with
+ * `/settings/profile` so MFA-flow changes ship to both surfaces at once.
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
 import { ShieldCheck } from "lucide-react";
 import { authClient } from "@/lib/auth/client";
-import { getPasskeyClient, type Passkey } from "@/lib/auth/passkey-client";
-import { TwoFactorSetup } from "@/ui/components/admin/security/two-factor-setup";
-import { PasskeyTile } from "@/ui/components/admin/security/passkey-tile";
-import { PasskeyList, type PasskeyRow } from "@/ui/components/admin/security/passkey-list";
-import { BackupCodesStatus } from "@/ui/components/admin/security/backup-codes-status";
-import { TrustedDevicesList } from "@/ui/components/admin/security/trusted-devices-list";
+import { MfaPanel } from "@/ui/components/admin/security/mfa-panel";
 import { SecurityPosturePanel } from "@/ui/components/admin/security/security-posture-panel";
-import { BackupMethodBanner } from "@/ui/components/admin/security/backup-method-banner";
 
 interface SessionUser {
   email: string;
-  role: string;
-  twoFactorEnabled?: boolean;
 }
 
 export default function SecurityPage() {
   const session = authClient.useSession();
-
-  // Better Auth's session reactivity is the source of truth for
-  // `twoFactorEnabled`. The cast goes from the plugin-erased session shape
-  // to the narrow read above.
   const user = (session.data?.user ?? null) as SessionUser | null;
-  const totpEnabled = user?.twoFactorEnabled === true;
-
-  const [passkeys, setPasskeys] = useState<PasskeyRow[] | null>(null);
-  const [listError, setListError] = useState<string | null>(null);
-  // The banner nudges; the tile owns the WebAuthn ceremony. Scrolling
-  // (vs. programmatic click) keeps enrollment scoped to a single source
-  // of truth.
-  const passkeyTileRef = useRef<HTMLDivElement | null>(null);
-  function handleEnrollSecondPasskey() {
-    passkeyTileRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
-  }
-
-  const refreshPasskeys = useCallback(async () => {
-    const client = getPasskeyClient();
-    if (!client) {
-      setListError("Passkey support couldn't be loaded. Refresh the page and try again.");
-      return;
-    }
-    setListError(null);
-    let result: Awaited<ReturnType<typeof client.listUserPasskeys>>;
-    try {
-      result = await client.listUserPasskeys();
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      console.warn("[passkey] listUserPasskeys threw", msg);
-      setListError("Could not load your passkeys. Please refresh.");
-      return;
-    }
-    if (result.error) {
-      console.warn("[passkey] listUserPasskeys failed", result.error);
-      setListError(result.error.message ?? "Could not load your passkeys.");
-      return;
-    }
-    setPasskeys((result.data ?? []) as Passkey[]);
-  }, []);
-
-  useEffect(() => {
-    void refreshPasskeys();
-  }, [refreshPasskeys]);
-
-  const hasPasskey = (passkeys?.length ?? 0) > 0;
-
-  function handleTotpChange() {
-    // Better Auth refreshes session state automatically after
-    // twoFactor.enable / disable; this hook gives downstream pages
-    // a chance to refetch if they cache the flag.
-    session.refetch?.();
-  }
-
-  function handlePasskeyChange() {
-    void refreshPasskeys();
-    // Session claims include `passkeyCount` — refetch so the MFA gate
-    // sees the new count without a hard reload.
-    session.refetch?.();
-  }
 
   return (
     <div className="p-6">
@@ -119,28 +54,8 @@ export default function SecurityPage() {
       </div>
 
       <div className="mx-auto max-w-2xl space-y-4">
-        <BackupMethodBanner onAddPasskey={handleEnrollSecondPasskey} />
-
         <SecurityPosturePanel />
-
-        <div ref={passkeyTileRef}>
-          <PasskeyTile hasPasskey={hasPasskey} onChange={handlePasskeyChange} />
-        </div>
-
-        <TwoFactorSetup enabled={totpEnabled} onChange={handleTotpChange} />
-
-        <BackupCodesStatus totpEnabled={totpEnabled} hasPasskey={hasPasskey} />
-
-        <div className="pt-2">
-          <PasskeyList passkeys={passkeys ?? []} onChange={handlePasskeyChange} />
-          {listError && (
-            <p className="mt-2 text-sm text-destructive">{listError}</p>
-          )}
-        </div>
-
-        <div className="pt-2">
-          <TrustedDevicesList />
-        </div>
+        <MfaPanel reauthRedirectTo="/admin/account-security" />
       </div>
     </div>
   );

--- a/packages/web/src/app/settings/profile/page.tsx
+++ b/packages/web/src/app/settings/profile/page.tsx
@@ -1,82 +1,26 @@
 "use client";
 
 /**
- * Per-user settings (no admin role required). MFA tiles reuse
- * /admin/account-security components — the underlying endpoints are auth-only,
- * not admin-gated, so a feature added there shows up here for free.
+ * Per-user settings (no admin role required). MFA tiles reuse the shared
+ * <MfaPanel /> with /admin/account-security — the underlying endpoints
+ * are auth-only, not admin-gated, so a feature added there shows up here
+ * for free.
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
 import { authClient } from "@/lib/auth/client";
-import { getPasskeyClient, type Passkey } from "@/lib/auth/passkey-client";
-import { TwoFactorSetup } from "@/ui/components/admin/security/two-factor-setup";
-import { PasskeyTile } from "@/ui/components/admin/security/passkey-tile";
-import { PasskeyList, type PasskeyRow } from "@/ui/components/admin/security/passkey-list";
-import { BackupCodesStatus } from "@/ui/components/admin/security/backup-codes-status";
-import { TrustedDevicesList } from "@/ui/components/admin/security/trusted-devices-list";
-import { BackupMethodBanner } from "@/ui/components/admin/security/backup-method-banner";
 import { SectionHeading } from "@/ui/components/admin/compact";
+import { MfaPanel } from "@/ui/components/admin/security/mfa-panel";
 import { IdentitySection } from "@/ui/components/settings/identity-section";
 import { PasswordSection } from "@/ui/components/settings/password-section";
 import { SessionsSection } from "@/ui/components/settings/sessions-section";
 
 interface SessionUser {
   email: string;
-  role: string;
-  twoFactorEnabled?: boolean;
 }
 
 export default function ProfilePage() {
   const session = authClient.useSession();
   const user = (session.data?.user ?? null) as SessionUser | null;
-  const totpEnabled = user?.twoFactorEnabled === true;
-
-  const [passkeys, setPasskeys] = useState<PasskeyRow[] | null>(null);
-  const [listError, setListError] = useState<string | null>(null);
-  const passkeyTileRef = useRef<HTMLDivElement | null>(null);
-
-  function handleEnrollSecondPasskey() {
-    passkeyTileRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
-  }
-
-  const refreshPasskeys = useCallback(async () => {
-    const client = getPasskeyClient();
-    if (!client) {
-      setListError("Passkey support couldn't be loaded. Refresh the page and try again.");
-      return;
-    }
-    setListError(null);
-    let result: Awaited<ReturnType<typeof client.listUserPasskeys>>;
-    try {
-      result = await client.listUserPasskeys();
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      console.warn("[passkey] listUserPasskeys threw", msg);
-      setListError("Could not load your passkeys. Please refresh.");
-      return;
-    }
-    if (result.error) {
-      console.warn("[passkey] listUserPasskeys failed", result.error);
-      setListError(result.error.message ?? "Could not load your passkeys.");
-      return;
-    }
-    setPasskeys((result.data ?? []) as Passkey[]);
-  }, []);
-
-  useEffect(() => {
-    void refreshPasskeys();
-  }, [refreshPasskeys]);
-
-  const hasPasskey = (passkeys?.length ?? 0) > 0;
-
-  function handleTotpChange() {
-    session.refetch?.();
-  }
-
-  function handlePasskeyChange() {
-    void refreshPasskeys();
-    session.refetch?.();
-  }
 
   if (!user) {
     return (
@@ -109,32 +53,7 @@ export default function ProfilePage() {
             title="Multi-factor authentication"
             description="Add a second factor — passkey, authenticator app, or both — so a stolen password isn't enough."
           />
-          <div className="space-y-4">
-            <BackupMethodBanner onAddPasskey={handleEnrollSecondPasskey} />
-
-            <div ref={passkeyTileRef}>
-              <PasskeyTile
-                hasPasskey={hasPasskey}
-                onChange={handlePasskeyChange}
-                reauthRedirectTo="/settings/profile"
-              />
-            </div>
-
-            <TwoFactorSetup enabled={totpEnabled} onChange={handleTotpChange} />
-
-            <BackupCodesStatus totpEnabled={totpEnabled} hasPasskey={hasPasskey} />
-
-            <div className="pt-2">
-              <PasskeyList passkeys={passkeys ?? []} onChange={handlePasskeyChange} />
-              {listError && (
-                <p className="mt-2 text-sm text-destructive">{listError}</p>
-              )}
-            </div>
-
-            <div className="pt-2">
-              <TrustedDevicesList />
-            </div>
-          </div>
+          <MfaPanel reauthRedirectTo="/settings/profile" />
         </section>
 
         <SessionsSection />

--- a/packages/web/src/ui/components/admin/security/mfa-panel.tsx
+++ b/packages/web/src/ui/components/admin/security/mfa-panel.tsx
@@ -2,16 +2,13 @@
 
 /**
  * Shared MFA tile composition for `/admin/account-security` and
- * `/settings/profile`. Owns the passkey list state, the tile-ref scroll
- * helper, and the BackupMethodBanner → PasskeyTile → TwoFactorSetup →
- * BackupCodesStatus → PasskeyList → TrustedDevicesList stack so future MFA
- * changes ship to both surfaces at once.
+ * `/settings/profile`. Owns the passkey list state and the tile-ref scroll
+ * helper so future MFA changes ship to both surfaces at once.
  *
  * Callers control outer chrome (page header, SecurityPosturePanel,
- * section wrapper). The only per-surface difference is `reauthRedirectTo`,
- * which the PasskeyTile uses to bounce back after a 2FA challenge during
- * re-auth — admins land back on `/admin/account-security`, profile users
- * on `/settings/profile` (a 403 if non-admins are sent to the admin path).
+ * section wrapper). The only per-surface difference is `reauthRedirectTo` —
+ * non-admin profile users would 403 on `/admin/account-security`, so each
+ * caller passes its own return path for the post-2FA-challenge bounce.
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -28,9 +25,17 @@ interface SessionUser {
   twoFactorEnabled?: boolean;
 }
 
+/**
+ * Surfaces that host the MFA panel. Narrowed at the panel boundary
+ * (`PasskeyTile.reauthRedirectTo` stays open for reusability) so a typo
+ * in one of the two call sites fails the type check rather than silently
+ * 403-ing a non-admin on `/admin/account-security`.
+ */
+export type MfaPanelSurface = "/admin/account-security" | "/settings/profile";
+
 export interface MfaPanelProps {
   /** Where the PasskeyTile's re-auth flow returns after a 2FA challenge. */
-  reauthRedirectTo: string;
+  reauthRedirectTo: MfaPanelSurface;
 }
 
 export function MfaPanel({ reauthRedirectTo }: MfaPanelProps) {

--- a/packages/web/src/ui/components/admin/security/mfa-panel.tsx
+++ b/packages/web/src/ui/components/admin/security/mfa-panel.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+/**
+ * Shared MFA tile composition for `/admin/account-security` and
+ * `/settings/profile`. Owns the passkey list state, the tile-ref scroll
+ * helper, and the BackupMethodBanner → PasskeyTile → TwoFactorSetup →
+ * BackupCodesStatus → PasskeyList → TrustedDevicesList stack so future MFA
+ * changes ship to both surfaces at once.
+ *
+ * Callers control outer chrome (page header, SecurityPosturePanel,
+ * section wrapper). The only per-surface difference is `reauthRedirectTo`,
+ * which the PasskeyTile uses to bounce back after a 2FA challenge during
+ * re-auth — admins land back on `/admin/account-security`, profile users
+ * on `/settings/profile` (a 403 if non-admins are sent to the admin path).
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { authClient } from "@/lib/auth/client";
+import { getPasskeyClient, type Passkey } from "@/lib/auth/passkey-client";
+import { BackupCodesStatus } from "@/ui/components/admin/security/backup-codes-status";
+import { BackupMethodBanner } from "@/ui/components/admin/security/backup-method-banner";
+import { PasskeyList, type PasskeyRow } from "@/ui/components/admin/security/passkey-list";
+import { PasskeyTile } from "@/ui/components/admin/security/passkey-tile";
+import { TrustedDevicesList } from "@/ui/components/admin/security/trusted-devices-list";
+import { TwoFactorSetup } from "@/ui/components/admin/security/two-factor-setup";
+
+interface SessionUser {
+  twoFactorEnabled?: boolean;
+}
+
+export interface MfaPanelProps {
+  /** Where the PasskeyTile's re-auth flow returns after a 2FA challenge. */
+  reauthRedirectTo: string;
+}
+
+export function MfaPanel({ reauthRedirectTo }: MfaPanelProps) {
+  const session = authClient.useSession();
+
+  // Better Auth's session reactivity is the source of truth for
+  // `twoFactorEnabled`. The cast goes from the plugin-erased session shape
+  // to the narrow read here.
+  const user = (session.data?.user ?? null) as SessionUser | null;
+  const totpEnabled = user?.twoFactorEnabled === true;
+
+  const [passkeys, setPasskeys] = useState<PasskeyRow[] | null>(null);
+  const [listError, setListError] = useState<string | null>(null);
+  // The banner nudges; the tile owns the WebAuthn ceremony. Scrolling
+  // (vs. programmatic click) keeps enrollment scoped to a single source
+  // of truth.
+  const passkeyTileRef = useRef<HTMLDivElement | null>(null);
+
+  function handleEnrollSecondPasskey() {
+    passkeyTileRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+  }
+
+  const refreshPasskeys = useCallback(async () => {
+    const client = getPasskeyClient();
+    if (!client) {
+      setListError("Passkey support couldn't be loaded. Refresh the page and try again.");
+      return;
+    }
+    setListError(null);
+    let result: Awaited<ReturnType<typeof client.listUserPasskeys>>;
+    try {
+      result = await client.listUserPasskeys();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn("[passkey] listUserPasskeys threw", msg);
+      setListError("Could not load your passkeys. Please refresh.");
+      return;
+    }
+    if (result.error) {
+      console.warn("[passkey] listUserPasskeys failed", result.error);
+      setListError(result.error.message ?? "Could not load your passkeys.");
+      return;
+    }
+    setPasskeys((result.data ?? []) as Passkey[]);
+  }, []);
+
+  useEffect(() => {
+    void refreshPasskeys();
+  }, [refreshPasskeys]);
+
+  const hasPasskey = (passkeys?.length ?? 0) > 0;
+
+  function handleTotpChange() {
+    // Better Auth refreshes session state automatically after
+    // twoFactor.enable / disable; this hook gives downstream pages a
+    // chance to refetch if they cache the flag.
+    session.refetch?.();
+  }
+
+  function handlePasskeyChange() {
+    void refreshPasskeys();
+    // Session claims include `passkeyCount` — refetch so the MFA gate
+    // sees the new count without a hard reload.
+    session.refetch?.();
+  }
+
+  return (
+    <div className="space-y-4">
+      <BackupMethodBanner onAddPasskey={handleEnrollSecondPasskey} />
+
+      <div ref={passkeyTileRef}>
+        <PasskeyTile
+          hasPasskey={hasPasskey}
+          onChange={handlePasskeyChange}
+          reauthRedirectTo={reauthRedirectTo}
+        />
+      </div>
+
+      <TwoFactorSetup enabled={totpEnabled} onChange={handleTotpChange} />
+
+      <BackupCodesStatus totpEnabled={totpEnabled} hasPasskey={hasPasskey} />
+
+      <div className="pt-2">
+        <PasskeyList passkeys={passkeys ?? []} onChange={handlePasskeyChange} />
+        {listError && <p className="mt-2 text-sm text-destructive">{listError}</p>}
+      </div>
+
+      <div className="pt-2">
+        <TrustedDevicesList />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- After #2255 shipped `/settings/profile`, the MFA section there was a line-for-line copy of `/admin/account-security`. Extracted the passkey state + scroll ref + change handlers + tile composition into a single `<MfaPanel reauthRedirectTo="…" />` so future MFA changes ship to both surfaces at once.
- `/admin/account-security` renders `<SecurityPosturePanel />` then `<MfaPanel reauthRedirectTo="/admin/account-security" />`. `/settings/profile` renders `<MfaPanel reauthRedirectTo="/settings/profile" />` inside its MFA `<section>`.
- Net diff: ~50 lines of duplicated state-management code removed (3 files, −177 / +137 total).

## Notes

- Minor admin layout reorder: `<BackupMethodBanner>` (now inside `<MfaPanel>`) renders below `<SecurityPosturePanel />` on the admin surface — previously it rendered above. Matches the issue spec ("admin renders SecurityPosturePanel then MfaPanel"). If we want the banner back on top, lift it out of the panel.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run type` clean
- [x] `bun run test` — full suite green (api 364/364, web 134/134, others 25/25 + 22/22 + 11/11)
- [x] `bun x syncpack lint`, template/security-headers/railway-watch/schema/oauth-helper drift checks all pass
- [ ] Smoke `/admin/account-security` — TOTP enroll, passkey enroll (incl. SESSION_NOT_FRESH re-auth), backup codes status, trusted devices list, posture panel still renders above
- [ ] Smoke `/settings/profile` — same MFA flows; re-auth bounces back to `/settings/profile` not `/admin/account-security`

Closes #2257