### PR TITLE
fix(web): #2316 — stop conversation sidebar chats from overflowing past the right border

### DIFF
--- a/packages/web/src/components/ui/scroll-area.tsx
+++ b/packages/web/src/components/ui/scroll-area.tsx
@@ -22,7 +22,10 @@ function ScrollArea({
       <ScrollAreaPrimitive.Viewport
         ref={viewportRef}
         data-slot="scroll-area-viewport"
-        className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
+        // [&>div]:!block overrides Radix's inline `display: table` on the inner
+        // wrapper so `min-w-0` / `truncate` work for children — Radix's default
+        // sizes the content to its intrinsic width, which clips past the parent.
+        className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 [&>div]:!block"
       >
         {children}
       </ScrollAreaPrimitive.Viewport>

--- a/packages/web/src/components/ui/scroll-area.tsx
+++ b/packages/web/src/components/ui/scroll-area.tsx
@@ -22,9 +22,9 @@ function ScrollArea({
       <ScrollAreaPrimitive.Viewport
         ref={viewportRef}
         data-slot="scroll-area-viewport"
-        // [&>div]:!block overrides Radix's inline `display: table` on the inner
-        // wrapper so `min-w-0` / `truncate` work for children — Radix's default
-        // sizes the content to its intrinsic width, which clips past the parent.
+        // [&>div]:!block overrides Radix's inline styles on the wrapper it
+        // injects under the Viewport (intrinsic-width sizing) so `min-w-0` /
+        // `truncate` work for children instead of clipping past the parent.
         className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 [&>div]:!block"
       >
         {children}


### PR DESCRIPTION
## Summary

- Conversation history rows in the sidebar on `/` and `/notebook` were ~698px wide inside a 280px sidebar — trailing title text and the star / convert / delete actions sat behind the parent's `overflow-hidden`, invisible to the user (#2316).
- Root cause: `ScrollAreaPrimitive.Viewport` wraps children in an inline `<div style="min-width: 100%; display: table">`. The table-display wrapper sizes to its intrinsic content width, defeating `min-w-0` / `truncate` on every flex child.
- Fix: override the inner wrapper to `display: block` via `[&>div]:!block` on the Viewport className in our shared `ScrollArea`. One-line, scoped to the Viewport child Radix injects. Every ScrollArea caller in the app (conversation sidebar, schema explorer, dashboard canvas, entity list, etc.) is a vertical-scroll list where the table-display behavior was a latent bug, not a feature — so fixing it once at the shared component is correct, not just for #2316.

## Verification

Used a Playwright harness mirroring the exact Radix Viewport DOM at the same 280px sidebar width with seven realistic chat titles:

| | Before | After |
|---|---:|---:|
| Row width | 698px | 263px |
| Overflow past sidebar's right edge | **+426px** | −9px (inside) |
| Wrapper `display` | `table` | `block` |
| Long titles ellipsized | 0 / 7 | 6 / 7 (short row doesn't need it) |

Local checks:

- [x] `bun run type` — clean
- [x] `bun run lint` — clean
- [x] `bun run scripts/test-isolated.ts --affected` in `packages/web` — 134 / 134 pass

Closes #2316.

## Test plan

- [ ] On `/` and `/notebook`, every chat row (title + relative time + hover-action cluster) renders entirely inside the 280px sidebar — no content past the right border.
- [ ] Long titles truncate with ellipsis instead of overflowing.
- [ ] Hover-revealed action buttons (star / convert / delete) remain fully visible and clickable.
- [ ] No horizontal scrollbar appears in the sidebar.
- [ ] Spot-check other ScrollArea callers (schema explorer, dashboard canvas, admin entity list) — no visual regression.