### PR TITLE
chore(web): 1.4.2 profile bundle + PCW docs — three closes (#2260, #2261, #2313)

### DIFF
--- a/packages/web/src/app/settings/ai-agents/loading.tsx
+++ b/packages/web/src/app/settings/ai-agents/loading.tsx
@@ -1,3 +1,5 @@
+// TODO(#2321): replace this null return with a Skeleton layout matching the
+// rendered route (mirror the treatment that #2260 applied to /settings/profile).
 export default function Loading() {
   return null;
 }

--- a/packages/web/src/app/settings/profile/__tests__/identity-section.test.tsx
+++ b/packages/web/src/app/settings/profile/__tests__/identity-section.test.tsx
@@ -1,0 +1,235 @@
+/**
+ * Regression guard for `<IdentitySection>` (#2261).
+ *
+ * PR #2256 fixed a subtle bug where the dirty flag stayed set after a
+ * successful save + `session.refetch()`. The cause: the `useEffect` that
+ * resyncs `name` from session data only fires when `!dirty && !saving`, so
+ * the flush has to land in the *post-saving* render — not while `saving` is
+ * still true. A naive resync that ran in every render would clobber the
+ * user's draft mid-edit; the fix has to keep both invariants:
+ *
+ *   - typing changes name → dirty=true
+ *   - save → API succeeds → refetch flushes session.data.user.name → dirty=false
+ *
+ * This file pins both. The session mock is mutable so the test can simulate
+ * Better Auth resolving the refetched user shape between renders.
+ *
+ * `mock.module(...)` covers every named export of `@/lib/auth/client` so a
+ * sibling test importing a different export doesn't trip a partial-mock
+ * SyntaxError.
+ */
+
+import {
+  describe,
+  expect,
+  test,
+  mock,
+  beforeEach,
+  afterEach,
+} from "bun:test";
+import { render, fireEvent, waitFor, cleanup, act } from "@testing-library/react";
+
+interface MockUser {
+  email: string;
+  name?: string;
+}
+
+let currentUser: MockUser | null = null;
+let refetchCalls = 0;
+
+// Re-render mechanism — Better Auth's real `useSession` subscribes to a
+// store; we approximate that with a forceUpdate counter that consumers can
+// nudge. `session.refetch()` bumps the counter so the component re-reads
+// `currentUser` via the new render.
+let forceUpdateTick = 0;
+const subscribers = new Set<() => void>();
+function notify() {
+  forceUpdateTick++;
+  for (const fn of subscribers) fn();
+}
+
+const updateUserMock = mock(
+  async (_opts: { name: string }): Promise<{ error?: { message?: string } | null }> => ({
+    error: null,
+  }),
+);
+
+mock.module("@/lib/auth/client", () => ({
+  authClient: {
+    updateUser: (opts: { name: string }) => updateUserMock(opts),
+    useSession: () => {
+      // The component reads `session.data?.user` and `session.refetch`; the
+      // tick is in the hook body so React captures a stable reference per
+      // render but re-runs the hook on each `notify()`.
+      void forceUpdateTick;
+      // Subscribe each render so notify() can trigger a forceUpdate in the
+      // consumer via the use-sync-external-store-like trick below.
+      return {
+        data: currentUser ? { user: currentUser } : null,
+        isPending: false,
+        refetch: () => {
+          refetchCalls++;
+          // The default behaviour is "refetch returns the same data" — tests
+          // that want to simulate a server update mutate `currentUser` first
+          // and then trigger the rerender via `notify()`.
+          notify();
+        },
+      };
+    },
+  },
+}));
+
+import { IdentitySection } from "@/ui/components/settings/identity-section";
+
+// A wrapper that subscribes to `notify()` so the component re-renders when
+// the mocked session changes — without this, our mutable `currentUser`
+// updates wouldn't reach React's reconciliation.
+import { useEffect, useState } from "react";
+function Harness() {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const fn = () => setTick((t) => t + 1);
+    subscribers.add(fn);
+    return () => {
+      subscribers.delete(fn);
+    };
+  }, []);
+  return <IdentitySection />;
+}
+
+beforeEach(() => {
+  currentUser = { email: "user@example.com", name: "Alice" };
+  refetchCalls = 0;
+  forceUpdateTick = 0;
+  updateUserMock.mockReset();
+  updateUserMock.mockImplementation(async () => ({ error: null }));
+});
+
+afterEach(() => {
+  cleanup();
+  subscribers.clear();
+});
+
+function getNameInput(): HTMLInputElement {
+  const el = document.querySelector<HTMLInputElement>("#profile-name");
+  if (!el) throw new Error("display-name input not rendered");
+  return el;
+}
+
+function getSaveButton(): HTMLButtonElement {
+  const el = document.querySelector<HTMLButtonElement>('button[type="submit"]');
+  if (!el) throw new Error("save button not rendered");
+  return el;
+}
+
+describe("IdentitySection — dirty-state derivation", () => {
+  test("returns null when no session user is loaded", () => {
+    currentUser = null;
+    const { container } = render(<Harness />);
+    expect(container.textContent).toBe("");
+  });
+
+  test("initial render: name input is seeded from session, save is disabled", () => {
+    render(<Harness />);
+    expect(getNameInput().value).toBe("Alice");
+    expect(getSaveButton().disabled).toBe(true);
+  });
+
+  test("typing changes name → dirty=true → save enables", () => {
+    render(<Harness />);
+
+    fireEvent.change(getNameInput(), { target: { value: "Alice Updated" } });
+
+    expect(getNameInput().value).toBe("Alice Updated");
+    expect(getSaveButton().disabled).toBe(false);
+  });
+
+  test("blank-only edits don't flip dirty (whitespace trims to the same value)", () => {
+    render(<Harness />);
+    // "Alice " trimmed equals "Alice" — not dirty.
+    fireEvent.change(getNameInput(), { target: { value: "Alice " } });
+    expect(getSaveButton().disabled).toBe(true);
+  });
+});
+
+describe("IdentitySection — save + refetch flushes dirty back to false (#2256 regression)", () => {
+  test("save → API succeeds → refetched session.data.user.name flushes → dirty resets", async () => {
+    render(<Harness />);
+
+    // 1. User types a new name — dirty=true.
+    fireEvent.change(getNameInput(), { target: { value: "Alice Updated" } });
+    expect(getSaveButton().disabled).toBe(false);
+
+    // 2. Submit. Drive the API mock so that *during the refetch*, the
+    //    mutable session user reflects the new name — that's the server
+    //    "saw the update" half of the flow.
+    updateUserMock.mockImplementation(async (opts) => {
+      currentUser = { email: "user@example.com", name: opts.name };
+      return { error: null };
+    });
+
+    await act(async () => {
+      fireEvent.submit(document.querySelector("form")!);
+    });
+
+    // 3. Refetch was called exactly once.
+    await waitFor(() => {
+      expect(refetchCalls).toBe(1);
+    });
+
+    // 4. The saved confirmation shows up — sanity check that the success
+    //    path ran end to end.
+    expect(document.body.textContent).toContain("Saved.");
+
+    // 5. Critical assertion: after the refetch flushed `user.name = "Alice
+    //    Updated"`, the trimmed-name comparison resolves dirty=false and
+    //    the save button re-disables. This is the exact regression from
+    //    PR #2256 — losing it means a saved form stays "dirty" forever.
+    await waitFor(() => {
+      expect(getSaveButton().disabled).toBe(true);
+    });
+    expect(getNameInput().value).toBe("Alice Updated");
+  });
+
+  test("API error: refetch is NOT called and dirty state is preserved", async () => {
+    updateUserMock.mockImplementation(async () => ({
+      error: { message: "Name too long" },
+    }));
+
+    render(<Harness />);
+
+    fireEvent.change(getNameInput(), { target: { value: "Alice Updated" } });
+    await act(async () => {
+      fireEvent.submit(document.querySelector("form")!);
+    });
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Name too long");
+    });
+
+    // No refetch — the server rejected the update.
+    expect(refetchCalls).toBe(0);
+    // Dirty preserved — the user's draft hasn't been clobbered.
+    expect(getNameInput().value).toBe("Alice Updated");
+    expect(getSaveButton().disabled).toBe(false);
+  });
+
+  test("a session refetch that drifts the user's name does NOT clobber an active edit", async () => {
+    render(<Harness />);
+
+    // User starts editing — dirty=true.
+    fireEvent.change(getNameInput(), { target: { value: "Mid-edit" } });
+    expect(getSaveButton().disabled).toBe(false);
+
+    // An unrelated refetch lands (e.g. another tab updated the org). The
+    // session resync guard (`!dirty && !saving`) must hold — the active
+    // edit stays put.
+    act(() => {
+      currentUser = { email: "user@example.com", name: "Server Drift" };
+      notify();
+    });
+
+    expect(getNameInput().value).toBe("Mid-edit");
+    expect(getSaveButton().disabled).toBe(false);
+  });
+});

--- a/packages/web/src/app/settings/profile/__tests__/identity-section.test.tsx
+++ b/packages/web/src/app/settings/profile/__tests__/identity-section.test.tsx
@@ -28,6 +28,7 @@ import {
   afterEach,
 } from "bun:test";
 import { render, fireEvent, waitFor, cleanup, act } from "@testing-library/react";
+import { useEffect, useState } from "react";
 
 interface MockUser {
   email: string;
@@ -37,14 +38,15 @@ interface MockUser {
 let currentUser: MockUser | null = null;
 let refetchCalls = 0;
 
-// Re-render mechanism — Better Auth's real `useSession` subscribes to a
-// store; we approximate that with a forceUpdate counter that consumers can
-// nudge. `session.refetch()` bumps the counter so the component re-reads
-// `currentUser` via the new render.
-let forceUpdateTick = 0;
+// External-store simulation. Better Auth's real `useSession` subscribes
+// through `useSyncExternalStore`; we approximate just enough of that here.
+// Mutating `currentUser` alone isn't enough — React won't re-render unless
+// something tells it to. `notify()` fans out to every mounted `Harness`
+// instance, which holds a tiny `useState` counter so calling its listener
+// schedules a render. The component then re-runs the mocked `useSession`
+// and picks up the new `currentUser`.
 const subscribers = new Set<() => void>();
 function notify() {
-  forceUpdateTick++;
   for (const fn of subscribers) fn();
 }
 
@@ -57,34 +59,32 @@ const updateUserMock = mock(
 mock.module("@/lib/auth/client", () => ({
   authClient: {
     updateUser: (opts: { name: string }) => updateUserMock(opts),
-    useSession: () => {
-      // The component reads `session.data?.user` and `session.refetch`; the
-      // tick is in the hook body so React captures a stable reference per
-      // render but re-runs the hook on each `notify()`.
-      void forceUpdateTick;
-      // Subscribe each render so notify() can trigger a forceUpdate in the
-      // consumer via the use-sync-external-store-like trick below.
-      return {
-        data: currentUser ? { user: currentUser } : null,
-        isPending: false,
-        refetch: () => {
-          refetchCalls++;
-          // The default behaviour is "refetch returns the same data" — tests
-          // that want to simulate a server update mutate `currentUser` first
-          // and then trigger the rerender via `notify()`.
-          notify();
-        },
-      };
-    },
+    useSession: () => ({
+      data: currentUser ? { user: currentUser } : null,
+      isPending: false,
+      refetch: () => {
+        refetchCalls++;
+        // Default behaviour: refetch returns the same data. Tests that
+        // simulate a server update mutate `currentUser` *before* calling
+        // refetch (or inside the `updateUser` mock, before resolving) so
+        // that the subsequent `notify()` re-render reads the new shape.
+        notify();
+      },
+    }),
   },
 }));
 
 import { IdentitySection } from "@/ui/components/settings/identity-section";
 
-// A wrapper that subscribes to `notify()` so the component re-renders when
-// the mocked session changes — without this, our mutable `currentUser`
-// updates wouldn't reach React's reconciliation.
-import { useEffect, useState } from "react";
+/**
+ * The harness mounts `<IdentitySection>` once and exposes a single React
+ * state-driven re-render handle to the module-level `notify()`. We can't
+ * just call RTL's `rerender(<IdentitySection />)` from a test because that
+ * would remount the component, and a fresh mount re-seeds `name` from the
+ * new session data — masking the very dirty-flag bug we're trying to pin.
+ * Keeping the *same* component instance and feeding it new `useSession()`
+ * return values is what reproduces the post-save flush in production.
+ */
 function Harness() {
   const [, setTick] = useState(0);
   useEffect(() => {
@@ -100,7 +100,6 @@ function Harness() {
 beforeEach(() => {
   currentUser = { email: "user@example.com", name: "Alice" };
   refetchCalls = 0;
-  forceUpdateTick = 0;
   updateUserMock.mockReset();
   updateUserMock.mockImplementation(async () => ({ error: null }));
 });
@@ -119,6 +118,12 @@ function getNameInput(): HTMLInputElement {
 function getSaveButton(): HTMLButtonElement {
   const el = document.querySelector<HTMLButtonElement>('button[type="submit"]');
   if (!el) throw new Error("save button not rendered");
+  return el;
+}
+
+function getForm(): HTMLFormElement {
+  const el = document.querySelector<HTMLFormElement>("form");
+  if (!el) throw new Error("identity form not rendered");
   return el;
 }
 
@@ -169,7 +174,7 @@ describe("IdentitySection — save + refetch flushes dirty back to false (#2256 
     });
 
     await act(async () => {
-      fireEvent.submit(document.querySelector("form")!);
+      fireEvent.submit(getForm());
     });
 
     // 3. Refetch was called exactly once.
@@ -177,11 +182,18 @@ describe("IdentitySection — save + refetch flushes dirty back to false (#2256 
       expect(refetchCalls).toBe(1);
     });
 
-    // 4. The saved confirmation shows up — sanity check that the success
+    // 4. The mocked `updateUser` actually ran with the typed name — pin
+    //    this so a future refactor that bypasses `authClient.updateUser`
+    //    (e.g. swapping it for a fetch call) fails loudly instead of
+    //    passing under a stale assertion.
+    expect(updateUserMock.mock.calls.length).toBe(1);
+    expect(updateUserMock.mock.calls[0]?.[0]).toEqual({ name: "Alice Updated" });
+
+    // 5. The saved confirmation shows up — sanity check that the success
     //    path ran end to end.
     expect(document.body.textContent).toContain("Saved.");
 
-    // 5. Critical assertion: after the refetch flushed `user.name = "Alice
+    // 6. Critical assertion: after the refetch flushed `user.name = "Alice
     //    Updated"`, the trimmed-name comparison resolves dirty=false and
     //    the save button re-disables. This is the exact regression from
     //    PR #2256 — losing it means a saved form stays "dirty" forever.
@@ -192,6 +204,13 @@ describe("IdentitySection — save + refetch flushes dirty back to false (#2256 
   });
 
   test("API error: refetch is NOT called and dirty state is preserved", async () => {
+    // Use `expect.assertions` to guarantee the rejection path actually
+    // ran. Without it, a refactor that made the banner render via a
+    // local-validation branch (no API call) could leave `refetchCalls`
+    // at 0 and the dirty-state preservation assertions still pass — a
+    // silent skip of the very branch this test is pinning.
+    expect.assertions(5);
+
     updateUserMock.mockImplementation(async () => ({
       error: { message: "Name too long" },
     }));
@@ -200,13 +219,16 @@ describe("IdentitySection — save + refetch flushes dirty back to false (#2256 
 
     fireEvent.change(getNameInput(), { target: { value: "Alice Updated" } });
     await act(async () => {
-      fireEvent.submit(document.querySelector("form")!);
+      fireEvent.submit(getForm());
     });
 
     await waitFor(() => {
       expect(document.body.textContent).toContain("Name too long");
     });
 
+    // The mock was actually invoked — i.e. the API rejection path ran
+    // rather than a local validation branch short-circuiting.
+    expect(updateUserMock.mock.calls.length).toBe(1);
     // No refetch — the server rejected the update.
     expect(refetchCalls).toBe(0);
     // Dirty preserved — the user's draft hasn't been clobbered.
@@ -214,7 +236,7 @@ describe("IdentitySection — save + refetch flushes dirty back to false (#2256 
     expect(getSaveButton().disabled).toBe(false);
   });
 
-  test("a session refetch that drifts the user's name does NOT clobber an active edit", async () => {
+  test("a session refetch that drifts the user's name does NOT clobber an active edit", () => {
     render(<Harness />);
 
     // User starts editing — dirty=true.
@@ -230,6 +252,31 @@ describe("IdentitySection — save + refetch flushes dirty back to false (#2256 
     });
 
     expect(getNameInput().value).toBe("Mid-edit");
+    expect(getSaveButton().disabled).toBe(false);
+  });
+
+  test("typing after a successful save dismisses the 'Saved.' banner", async () => {
+    // Pins the savedAt-clears-on-edit branch in handleNameChange — without
+    // it, the banner sticks around stale while the user types a new draft,
+    // misrepresenting the form's state.
+    updateUserMock.mockImplementation(async (opts) => {
+      currentUser = { email: "user@example.com", name: opts.name };
+      return { error: null };
+    });
+
+    render(<Harness />);
+
+    fireEvent.change(getNameInput(), { target: { value: "Alice Updated" } });
+    await act(async () => {
+      fireEvent.submit(getForm());
+    });
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Saved.");
+    });
+
+    // A second edit starts — the success banner must go away.
+    fireEvent.change(getNameInput(), { target: { value: "Alice Updated 2" } });
+    expect(document.body.textContent).not.toContain("Saved.");
     expect(getSaveButton().disabled).toBe(false);
   });
 });

--- a/packages/web/src/app/settings/profile/__tests__/password-section.test.tsx
+++ b/packages/web/src/app/settings/profile/__tests__/password-section.test.tsx
@@ -1,0 +1,376 @@
+/**
+ * Regression guard for `<PasswordSection>` (#2261).
+ *
+ * PR #2256 (the original `/settings/profile` ship) flagged two coverage gaps.
+ * This file pins the password side:
+ *
+ *   1. The four cross-field validation branches run in a specific order —
+ *      empty current → length → mismatch → equals-current. Reordering or
+ *      dropping the equals-current check would silently accept a weak
+ *      password reuse, so every branch gets its own assertion.
+ *
+ *   2. When the auth mode probe denies (the simple-key / byot 404 path),
+ *      the section renders nothing rather than a form that always 404s on
+ *      submit. That's the "friendly error" — no broken form, no scary
+ *      message; the surface disappears entirely.
+ *
+ * `mock.module(...)` mocks the entire `@/lib/auth/client` surface so a
+ * sibling test importing any other export from it doesn't trip a
+ * partial-mock SyntaxError.
+ */
+
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { render, fireEvent, waitFor, cleanup, act } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+mock.module("@/lib/auth/client", () => ({ authClient: {} }));
+
+import { PasswordSection } from "@/ui/components/settings/password-section";
+import { AtlasProvider, type AtlasAuthClient } from "@/ui/context";
+
+const stubAuthClient: AtlasAuthClient = {
+  signIn: { email: async () => ({}) },
+  signUp: { email: async () => ({}) },
+  signOut: async () => {},
+  useSession: () => ({ data: null, isPending: false }),
+};
+
+let queryClient: QueryClient;
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(
+    QueryClientProvider,
+    { client: queryClient },
+    createElement(
+      AtlasProvider,
+      {
+        config: {
+          apiUrl: "http://localhost:3001",
+          isCrossOrigin: false as const,
+          authClient: stubAuthClient,
+        },
+      },
+      children,
+    ),
+  );
+}
+
+function renderSection() {
+  return render(<PasswordSection />, { wrapper });
+}
+
+/** Three password inputs render in source order: current, new, confirm. */
+function getInputs() {
+  return document.querySelectorAll<HTMLInputElement>('input[type="password"]');
+}
+
+function getForm() {
+  return document.querySelector("form");
+}
+
+function fill({
+  current,
+  next,
+  confirm,
+}: {
+  current: string;
+  next: string;
+  confirm: string;
+}) {
+  const inputs = getInputs();
+  fireEvent.change(inputs[0], { target: { value: current } });
+  fireEvent.change(inputs[1], { target: { value: next } });
+  fireEvent.change(inputs[2], { target: { value: confirm } });
+}
+
+function submit() {
+  // act-wrap so synchronous validation paths don't trip the React warning;
+  // success/error paths await `waitFor` for the async settle.
+  act(() => {
+    fireEvent.submit(getForm()!);
+  });
+}
+
+/**
+ * Pull the validation banner text. The form's description copy contains
+ * phrases like "at least 8 characters" — asserting against the whole body
+ * would let a regression that swapped two banners pass. Scope every
+ * order-of-rules assertion to `[role="alert"]`.
+ */
+function getErrorBannerText(): string {
+  return document.querySelector('[role="alert"]')?.textContent ?? "";
+}
+
+/**
+ * Mock fetch with a per-URL routing function. The password-status probe is
+ * driven separately from the change-password POST so each test can pin
+ * exactly what state PasswordSection is rendering against.
+ */
+function mockFetch(opts: {
+  statusKind?: "allowed" | "denied" | "mfa-required";
+  changeResponse?: () => Response;
+}): ReturnType<typeof mock> {
+  const { statusKind = "allowed", changeResponse } = opts;
+  return mock(async (input: RequestInfo | URL): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.includes("/api/v1/admin/me/password-status")) {
+      if (statusKind === "denied") {
+        return new Response(JSON.stringify({ error: "forbidden_role" }), {
+          status: 403,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (statusKind === "mfa-required") {
+        return new Response(
+          JSON.stringify({
+            error: "mfa_enrollment_required",
+            enrollmentUrl: "/admin/account-security",
+          }),
+          { status: 403, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(
+        JSON.stringify({ passwordChangeRequired: false }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    if (url.includes("/api/v1/admin/me/password")) {
+      return (
+        changeResponse?.() ??
+        new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      );
+    }
+    return new Response("not found", { status: 404 });
+  });
+}
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+});
+
+afterEach(() => {
+  queryClient.clear();
+  cleanup();
+  globalThis.fetch = originalFetch;
+});
+
+describe("PasswordSection — auth-mode gating", () => {
+  test("renders nothing while the password-status probe is pending (no flash)", () => {
+    // A fetch that never resolves keeps the probe in flight forever.
+    globalThis.fetch = mock(
+      () => new Promise(() => {}),
+    ) as unknown as typeof fetch;
+
+    const { container } = renderSection();
+    expect(container.textContent).toBe("");
+  });
+
+  test("renders nothing on denied (simple-key / byot 404 friendly path)", async () => {
+    globalThis.fetch = mockFetch({ statusKind: "denied" }) as unknown as typeof fetch;
+
+    const { container } = renderSection();
+
+    // The probe resolves to `denied`, the section short-circuits to null.
+    // No form, no error banner, no scary "Password changes aren't available"
+    // copy — the surface simply disappears in this auth mode.
+    await waitFor(() => {
+      expect(container.textContent).toBe("");
+    });
+    expect(getForm()).toBeNull();
+  });
+
+  test("renders the form when allowed", async () => {
+    globalThis.fetch = mockFetch({ statusKind: "allowed" }) as unknown as typeof fetch;
+
+    renderSection();
+
+    await waitFor(() => {
+      expect(getInputs().length).toBe(3);
+    });
+    expect(document.body.textContent).toContain("Password");
+    expect(document.body.textContent).toContain(
+      "Use a unique password",
+    );
+  });
+
+  test("renders the form when mfa-required (rotation must still be possible mid-enrollment)", async () => {
+    globalThis.fetch = mockFetch({ statusKind: "mfa-required" }) as unknown as typeof fetch;
+
+    renderSection();
+
+    await waitFor(() => {
+      expect(getInputs().length).toBe(3);
+    });
+  });
+});
+
+describe("PasswordSection — cross-field validation order", () => {
+  beforeEach(() => {
+    globalThis.fetch = mockFetch({ statusKind: "allowed" }) as unknown as typeof fetch;
+  });
+
+  test("(a) empty current password short-circuits before any other check", async () => {
+    renderSection();
+    await waitFor(() => expect(getInputs().length).toBe(3));
+
+    // New and confirm intentionally trip other rules — if the order
+    // regresses, this test will start asserting on a downstream message.
+    fill({ current: "", next: "short", confirm: "different" });
+    submit();
+
+    await waitFor(() => {
+      expect(getErrorBannerText()).toContain(
+        "Enter your current password to confirm.",
+      );
+    });
+    expect(getErrorBannerText()).not.toContain("at least 8");
+    expect(getErrorBannerText()).not.toContain("do not match");
+  });
+
+  test("(b) new < MIN_PASSWORD is reported before the mismatch / equals-current checks", async () => {
+    renderSection();
+    await waitFor(() => expect(getInputs().length).toBe(3));
+
+    fill({ current: "old-secret", next: "short", confirm: "mismatch" });
+    submit();
+
+    await waitFor(() => {
+      expect(getErrorBannerText()).toContain("at least 8 characters");
+    });
+    expect(getErrorBannerText()).not.toContain("do not match");
+    expect(getErrorBannerText()).not.toContain("must be different");
+  });
+
+  test("(c) new ≠ confirm is reported before the equals-current check", async () => {
+    renderSection();
+    await waitFor(() => expect(getInputs().length).toBe(3));
+
+    // If the equals-current rule shadowed the mismatch rule, this case
+    // (next === current, but confirm differs) would surface the wrong
+    // banner. Pin the mismatch path.
+    fill({
+      current: "same-as-current-12",
+      next: "same-as-current-12",
+      confirm: "totally-different-99",
+    });
+    submit();
+
+    await waitFor(() => {
+      expect(getErrorBannerText()).toContain("do not match");
+    });
+    expect(getErrorBannerText()).not.toContain("must be different");
+  });
+
+  test("(d) new === current is rejected (regression guard — dropping this branch silently accepts password reuse)", async () => {
+    renderSection();
+    await waitFor(() => expect(getInputs().length).toBe(3));
+
+    fill({
+      current: "same-secret-12",
+      next: "same-secret-12",
+      confirm: "same-secret-12",
+    });
+    submit();
+
+    await waitFor(() => {
+      expect(getErrorBannerText()).toContain(
+        "must be different from your current one",
+      );
+    });
+  });
+});
+
+describe("PasswordSection — submit + error paths", () => {
+  test("POSTs to /api/v1/admin/me/password with the typed payload on success", async () => {
+    const fetchMock = mockFetch({ statusKind: "allowed" });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    renderSection();
+    await waitFor(() => expect(getInputs().length).toBe(3));
+
+    fill({
+      current: "old-secret",
+      next: "new-secret-123",
+      confirm: "new-secret-123",
+    });
+    submit();
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Password updated.");
+    });
+
+    const calls = (fetchMock as unknown as ReturnType<typeof mock>).mock.calls as Array<[
+      string,
+      RequestInit,
+    ]>;
+    const postCall = calls.find((c) => c[1]?.method === "POST");
+    expect(postCall).toBeDefined();
+    expect(postCall![0]).toContain("/api/v1/admin/me/password");
+    expect(JSON.parse(postCall![1].body as string)).toEqual({
+      currentPassword: "old-secret",
+      newPassword: "new-secret-123",
+    });
+  });
+
+  test("surfaces the API error message on non-ok JSON response", async () => {
+    globalThis.fetch = mockFetch({
+      statusKind: "allowed",
+      changeResponse: () =>
+        new Response(JSON.stringify({ message: "Wrong current password" }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        }),
+    }) as unknown as typeof fetch;
+
+    renderSection();
+    await waitFor(() => expect(getInputs().length).toBe(3));
+
+    fill({
+      current: "wrong-secret",
+      next: "new-secret-123",
+      confirm: "new-secret-123",
+    });
+    submit();
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Wrong current password");
+    });
+  });
+
+  test("falls back to a status-code error when the body isn't parseable", async () => {
+    const originalWarn = console.warn;
+    console.warn = mock(() => {}) as typeof console.warn;
+    try {
+      globalThis.fetch = mockFetch({
+        statusKind: "allowed",
+        changeResponse: () => new Response("Internal Server Error", { status: 500 }),
+      }) as unknown as typeof fetch;
+
+      renderSection();
+      await waitFor(() => expect(getInputs().length).toBe(3));
+
+      fill({
+        current: "old-secret",
+        next: "new-secret-123",
+        confirm: "new-secret-123",
+      });
+      submit();
+
+      await waitFor(() => {
+        expect(document.body.textContent).toContain(
+          "Failed to change password (HTTP 500)",
+        );
+      });
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});

--- a/packages/web/src/app/settings/profile/__tests__/password-section.test.tsx
+++ b/packages/web/src/app/settings/profile/__tests__/password-section.test.tsx
@@ -12,14 +12,16 @@
  *   2. When the auth mode probe denies (the simple-key / byot 404 path),
  *      the section renders nothing rather than a form that always 404s on
  *      submit. That's the "friendly error" — no broken form, no scary
- *      message; the surface disappears entirely.
+ *      message; the surface disappears entirely. The 5xx-probe path is
+ *      tested separately because it lands in the same null-render branch
+ *      but via `isError` instead of `denied`.
  *
  * `mock.module(...)` mocks the entire `@/lib/auth/client` surface so a
  * sibling test importing any other export from it doesn't trip a
  * partial-mock SyntaxError.
  */
 
-import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { describe, expect, test, mock, beforeEach, afterEach, beforeAll, afterAll } from "bun:test";
 import { render, fireEvent, waitFor, cleanup, act } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -60,13 +62,32 @@ function renderSection() {
   return render(<PasswordSection />, { wrapper });
 }
 
-/** Three password inputs render in source order: current, new, confirm. */
-function getInputs() {
-  return document.querySelectorAll<HTMLInputElement>('input[type="password"]');
+/**
+ * Resolve the three password inputs by their stable IDs (assigned in the
+ * source: profile-current-password / profile-new-password / profile-confirm-
+ * password). Earlier revisions of this file used `querySelectorAll('input
+ * [type="password"]')[i]`, which would silently shift indices if a new
+ * password-type input ever lands above the three rows — IDs fail loudly
+ * with a clear error instead.
+ */
+function getCurrentInput(): HTMLInputElement {
+  const el = document.querySelector<HTMLInputElement>("#profile-current-password");
+  if (!el) throw new Error("current-password input not rendered");
+  return el;
+}
+function getNewInput(): HTMLInputElement {
+  const el = document.querySelector<HTMLInputElement>("#profile-new-password");
+  if (!el) throw new Error("new-password input not rendered");
+  return el;
+}
+function getConfirmInput(): HTMLInputElement {
+  const el = document.querySelector<HTMLInputElement>("#profile-confirm-password");
+  if (!el) throw new Error("confirm-password input not rendered");
+  return el;
 }
 
-function getForm() {
-  return document.querySelector("form");
+function getForm(): HTMLFormElement | null {
+  return document.querySelector<HTMLFormElement>("form");
 }
 
 function fill({
@@ -78,10 +99,9 @@ function fill({
   next: string;
   confirm: string;
 }) {
-  const inputs = getInputs();
-  fireEvent.change(inputs[0], { target: { value: current } });
-  fireEvent.change(inputs[1], { target: { value: next } });
-  fireEvent.change(inputs[2], { target: { value: confirm } });
+  fireEvent.change(getCurrentInput(), { target: { value: current } });
+  fireEvent.change(getNewInput(), { target: { value: next } });
+  fireEvent.change(getConfirmInput(), { target: { value: confirm } });
 }
 
 function submit() {
@@ -90,6 +110,11 @@ function submit() {
   act(() => {
     fireEvent.submit(getForm()!);
   });
+}
+
+/** Wait until the form has mounted (probe resolved, allowed branch). */
+async function waitForFormMounted(): Promise<void> {
+  await waitFor(() => expect(getForm()).not.toBeNull());
 }
 
 /**
@@ -108,8 +133,8 @@ function getErrorBannerText(): string {
  * exactly what state PasswordSection is rendering against.
  */
 function mockFetch(opts: {
-  statusKind?: "allowed" | "denied" | "mfa-required";
-  changeResponse?: () => Response;
+  statusKind?: "allowed" | "denied" | "mfa-required" | "error-500";
+  changeResponse?: () => Response | Promise<Response>;
 }): ReturnType<typeof mock> {
   const { statusKind = "allowed", changeResponse } = opts;
   return mock(async (input: RequestInfo | URL): Promise<Response> => {
@@ -130,6 +155,9 @@ function mockFetch(opts: {
           { status: 403, headers: { "content-type": "application/json" } },
         );
       }
+      if (statusKind === "error-500") {
+        return new Response("upstream down", { status: 500 });
+      }
       return new Response(
         JSON.stringify({ passwordChangeRequired: false }),
         { status: 200, headers: { "content-type": "application/json" } },
@@ -137,7 +165,7 @@ function mockFetch(opts: {
     }
     if (url.includes("/api/v1/admin/me/password")) {
       return (
-        changeResponse?.() ??
+        (await changeResponse?.()) ??
         new Response(JSON.stringify({}), {
           status: 200,
           headers: { "content-type": "application/json" },
@@ -148,7 +176,21 @@ function mockFetch(opts: {
   });
 }
 
+// Hoist `originalFetch` / `originalWarn` capture to file scope so a thrown
+// `mockFetch(...)` constructor can't leave the previous suite's stub
+// installed. `afterEach` restores fetch; the warn stub is restored per-test.
 const originalFetch = globalThis.fetch;
+const originalWarn = console.warn;
+
+beforeAll(() => {
+  // Silence the parse-failure log that the non-JSON 500 fallback path
+  // emits — keeps the test output focused on assertion failures.
+  console.warn = mock(() => {}) as typeof console.warn;
+});
+
+afterAll(() => {
+  console.warn = originalWarn;
+});
 
 beforeEach(() => {
   queryClient = new QueryClient({
@@ -187,14 +229,38 @@ describe("PasswordSection — auth-mode gating", () => {
     expect(getForm()).toBeNull();
   });
 
+  test("renders nothing on probe transient failure (5xx → isError → same null branch)", async () => {
+    // `usePasswordStatus` is configured with `retry: 1`, so a persistent 500
+    // turns the query into `isError: true` after the retry window. The
+    // section then short-circuits via `!canChangePassword`. Without this
+    // test, a user on a flaky network would see the section vanish with
+    // zero indication why — keep the null-on-error branch pinned.
+    const fetchMock = mockFetch({ statusKind: "error-500" });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const { container } = renderSection();
+
+    await waitFor(
+      () => {
+        // After retries settle, the form must NOT be rendered.
+        expect(getForm()).toBeNull();
+      },
+      { timeout: 5000 },
+    );
+    expect(container.textContent).toBe("");
+    // Sanity: the probe was actually attempted (otherwise this test would
+    // pass with any pre-flight null branch).
+    expect(
+      (fetchMock as unknown as ReturnType<typeof mock>).mock.calls.length,
+    ).toBeGreaterThan(0);
+  });
+
   test("renders the form when allowed", async () => {
     globalThis.fetch = mockFetch({ statusKind: "allowed" }) as unknown as typeof fetch;
 
     renderSection();
 
-    await waitFor(() => {
-      expect(getInputs().length).toBe(3);
-    });
+    await waitForFormMounted();
     expect(document.body.textContent).toContain("Password");
     expect(document.body.textContent).toContain(
       "Use a unique password",
@@ -206,9 +272,7 @@ describe("PasswordSection — auth-mode gating", () => {
 
     renderSection();
 
-    await waitFor(() => {
-      expect(getInputs().length).toBe(3);
-    });
+    await waitForFormMounted();
   });
 });
 
@@ -219,7 +283,7 @@ describe("PasswordSection — cross-field validation order", () => {
 
   test("(a) empty current password short-circuits before any other check", async () => {
     renderSection();
-    await waitFor(() => expect(getInputs().length).toBe(3));
+    await waitForFormMounted();
 
     // New and confirm intentionally trip other rules — if the order
     // regresses, this test will start asserting on a downstream message.
@@ -237,7 +301,7 @@ describe("PasswordSection — cross-field validation order", () => {
 
   test("(b) new < MIN_PASSWORD is reported before the mismatch / equals-current checks", async () => {
     renderSection();
-    await waitFor(() => expect(getInputs().length).toBe(3));
+    await waitForFormMounted();
 
     fill({ current: "old-secret", next: "short", confirm: "mismatch" });
     submit();
@@ -251,7 +315,7 @@ describe("PasswordSection — cross-field validation order", () => {
 
   test("(c) new ≠ confirm is reported before the equals-current check", async () => {
     renderSection();
-    await waitFor(() => expect(getInputs().length).toBe(3));
+    await waitForFormMounted();
 
     // If the equals-current rule shadowed the mismatch rule, this case
     // (next === current, but confirm differs) would surface the wrong
@@ -271,7 +335,7 @@ describe("PasswordSection — cross-field validation order", () => {
 
   test("(d) new === current is rejected (regression guard — dropping this branch silently accepts password reuse)", async () => {
     renderSection();
-    await waitFor(() => expect(getInputs().length).toBe(3));
+    await waitForFormMounted();
 
     fill({
       current: "same-secret-12",
@@ -289,12 +353,12 @@ describe("PasswordSection — cross-field validation order", () => {
 });
 
 describe("PasswordSection — submit + error paths", () => {
-  test("POSTs to /api/v1/admin/me/password with the typed payload on success", async () => {
+  test("POSTs the typed payload, shows confirmation, AND clears the three inputs", async () => {
     const fetchMock = mockFetch({ statusKind: "allowed" });
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
     renderSection();
-    await waitFor(() => expect(getInputs().length).toBe(3));
+    await waitForFormMounted();
 
     fill({
       current: "old-secret",
@@ -318,6 +382,13 @@ describe("PasswordSection — submit + error paths", () => {
       currentPassword: "old-secret",
       newPassword: "new-secret-123",
     });
+
+    // `reset()` on success — without this, the user's password sits in
+    // three plaintext inputs after submit. Pin the field clear so a
+    // refactor that drops `reset()` is loud, not silent.
+    expect(getCurrentInput().value).toBe("");
+    expect(getNewInput().value).toBe("");
+    expect(getConfirmInput().value).toBe("");
   });
 
   test("surfaces the API error message on non-ok JSON response", async () => {
@@ -331,7 +402,7 @@ describe("PasswordSection — submit + error paths", () => {
     }) as unknown as typeof fetch;
 
     renderSection();
-    await waitFor(() => expect(getInputs().length).toBe(3));
+    await waitForFormMounted();
 
     fill({
       current: "wrong-secret",
@@ -341,36 +412,63 @@ describe("PasswordSection — submit + error paths", () => {
     submit();
 
     await waitFor(() => {
-      expect(document.body.textContent).toContain("Wrong current password");
+      expect(getErrorBannerText()).toContain("Wrong current password");
     });
+
+    // On error the form keeps the user's draft so they can correct just
+    // the current-password field without retyping the new one.
+    expect(getCurrentInput().value).toBe("wrong-secret");
+    expect(getNewInput().value).toBe("new-secret-123");
   });
 
   test("falls back to a status-code error when the body isn't parseable", async () => {
-    const originalWarn = console.warn;
-    console.warn = mock(() => {}) as typeof console.warn;
-    try {
-      globalThis.fetch = mockFetch({
-        statusKind: "allowed",
-        changeResponse: () => new Response("Internal Server Error", { status: 500 }),
-      }) as unknown as typeof fetch;
+    globalThis.fetch = mockFetch({
+      statusKind: "allowed",
+      changeResponse: () => new Response("Internal Server Error", { status: 500 }),
+    }) as unknown as typeof fetch;
 
-      renderSection();
-      await waitFor(() => expect(getInputs().length).toBe(3));
+    renderSection();
+    await waitForFormMounted();
 
-      fill({
-        current: "old-secret",
-        next: "new-secret-123",
-        confirm: "new-secret-123",
-      });
-      submit();
+    fill({
+      current: "old-secret",
+      next: "new-secret-123",
+      confirm: "new-secret-123",
+    });
+    submit();
 
-      await waitFor(() => {
-        expect(document.body.textContent).toContain(
-          "Failed to change password (HTTP 500)",
-        );
-      });
-    } finally {
-      console.warn = originalWarn;
-    }
+    await waitFor(() => {
+      expect(getErrorBannerText()).toContain(
+        "Failed to change password (HTTP 500)",
+      );
+    });
+  });
+
+  test("network rejection on submit surfaces as a typed error in the banner", async () => {
+    // Pins the `catch` branch in PasswordSection.handleSubmit — without
+    // coverage, a future refactor that swaps `setError(message)` for
+    // `setError(null)` would silently swallow connectivity errors. Use a
+    // changeResponse that rejects to drive that path; the probe still
+    // resolves "allowed" so the form is mounted.
+    globalThis.fetch = mockFetch({
+      statusKind: "allowed",
+      changeResponse: async () => {
+        throw new Error("net::ERR_CONNECTION_REFUSED");
+      },
+    }) as unknown as typeof fetch;
+
+    renderSection();
+    await waitForFormMounted();
+
+    fill({
+      current: "old-secret",
+      next: "new-secret-123",
+      confirm: "new-secret-123",
+    });
+    submit();
+
+    await waitFor(() => {
+      expect(getErrorBannerText()).toContain("net::ERR_CONNECTION_REFUSED");
+    });
   });
 });

--- a/packages/web/src/app/settings/profile/loading.tsx
+++ b/packages/web/src/app/settings/profile/loading.tsx
@@ -6,8 +6,19 @@ import { Skeleton } from "@/components/ui/skeleton";
  * skeleton-side keeps the layout from collapsing-then-jumping on first paint.
  */
 export default function Loading() {
+  // `role="status"` + a polite live region so screen readers announce a load
+  // is in progress rather than narrate a silent stretch of decorative pulse
+  // rectangles. The shadcn primitive is a bare div with no ARIA of its own
+  // (packages/web/src/components/ui/skeleton.tsx), so the announcement has
+  // to live on the wrapper.
   return (
-    <div className="mx-auto max-w-3xl px-6 py-10">
+    <div
+      className="mx-auto max-w-3xl px-6 py-10"
+      role="status"
+      aria-busy
+      aria-live="polite"
+      aria-label="Loading profile settings"
+    >
       <header className="mb-10 flex flex-col gap-2">
         <Skeleton className="h-3 w-32" />
         <Skeleton className="h-9 w-40" />

--- a/packages/web/src/app/settings/profile/loading.tsx
+++ b/packages/web/src/app/settings/profile/loading.tsx
@@ -1,3 +1,47 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Suspense fallback for `/settings/profile`. The route renders four
+ * section-shaped cards (identity, password, MFA, sessions); mirroring that
+ * skeleton-side keeps the layout from collapsing-then-jumping on first paint.
+ */
 export default function Loading() {
-  return null;
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-10">
+      <header className="mb-10 flex flex-col gap-2">
+        <Skeleton className="h-3 w-32" />
+        <Skeleton className="h-9 w-40" />
+        <Skeleton className="h-4 w-80" />
+      </header>
+
+      <div className="space-y-10">
+        <SectionSkeleton rows={2} />
+        <SectionSkeleton rows={3} />
+        <SectionSkeleton rows={2} />
+        <SectionSkeleton rows={3} />
+      </div>
+    </div>
+  );
+}
+
+function SectionSkeleton({ rows }: { rows: number }) {
+  return (
+    <section>
+      <div className="mb-3 space-y-2">
+        <Skeleton className="h-5 w-44" />
+        <Skeleton className="h-3.5 w-72" />
+      </div>
+      <div className="space-y-3 rounded-lg border bg-card p-4">
+        {Array.from({ length: rows }).map((_, i) => (
+          <div key={i} className="space-y-1.5">
+            <Skeleton className="h-3.5 w-28" />
+            <Skeleton className="h-9 w-full" />
+          </div>
+        ))}
+        <div className="flex justify-end pt-1">
+          <Skeleton className="h-8 w-32" />
+        </div>
+      </div>
+    </section>
+  );
 }

--- a/packages/web/src/ui/components/admin/published-context-wrapper.tsx
+++ b/packages/web/src/ui/components/admin/published-context-wrapper.tsx
@@ -31,6 +31,56 @@ export interface PublishedContextWrapperProps {
  * This is purely presentational: mode detection and draft-count checks live
  * in the caller (`useDevModeNoDrafts`) so pages remain in control of when
  * to render it.
+ *
+ * ---
+ *
+ * ## When NOT to use this wrapper
+ *
+ * The wrapper applies `inert + pointer-events-none + opacity-60` to its
+ * subtree. That's deliberate — without `inert`, a tabbing admin would still
+ * trigger row clicks or sort toggles on the "read-only" list. But it also
+ * means **every button and link inside is unreachable** while the wrapper is
+ * mounted. That is safe only when every mutation on the page is itself
+ * publish-gated (i.e. produces a draft in developer mode, which then
+ * promotes via `/api/v1/admin/publish`).
+ *
+ * If the page exposes any *immediate* mutation — a per-org `archived`
+ * tombstone, a demo-hide that bypasses publish, a DELETE/UPDATE handler
+ * that doesn't honor `atlasMode`, a connection test, a credential rotate —
+ * wrapping the page traps the admin: they entered developer mode to draft
+ * something, but the buttons they need to perform those non-draftable
+ * actions are now behind an `inert` overlay. PR #2310 hit this exactly on
+ * `/admin/connections`; the fix was to remove the wrapper, not work around
+ * it.
+ *
+ * ### Audit (as of 2026-05)
+ *
+ * | Page | Wrapper? | All mutations draft-aware? | Trap risk |
+ * | --- | --- | --- | --- |
+ * | `/admin/connections` | **removed** (#2310) | No — DELETE = per-org archived tombstone; demo-hide bypasses publish | was active; mitigated |
+ * | `/admin/prompts` | yes (conditional) | Yes — CREATE/PATCH/DELETE all set `status='draft'` in dev mode | none |
+ * | `/admin/semantic` | hook only (no wrapper) | Yes — entity edits/deletes go through the overlay tables | none |
+ * | `/admin/schema-diff` | hook only (no wrapper) | n/a — read-only page | none |
+ *
+ * ### Decision rule
+ *
+ *  - **Safe → wrap**: every mutation on the page is draft-publishable
+ *    (`status='draft'` on insert / queued via overlay tables).
+ *  - **Unsafe → don't wrap**: any immediate mutation exists (tombstones,
+ *    archives, bypass-publish toggles, demo-mode probes that mutate state,
+ *    operational actions like "drain pool" or "rotate credential").
+ *
+ * If the page is unsafe to wrap but still wants the dev-mode-no-drafts
+ * banner counts to stay accurate, call `useDevModeNoDrafts(["surface"])`
+ * directly — the hook drives the global banner without overlaying the
+ * page. See `/admin/schema-diff/page.tsx` for the read-only variant of
+ * this pattern.
+ *
+ * The constraint is enforced by the backend handlers, not the type system —
+ * adding the wrapper to a page whose handlers mutate immediately will type-
+ * check and render fine, then silently break the operator workflow. Re-run
+ * the audit (or grep for `<PublishedContextWrapper>`) before adding a new
+ * call site.
  */
 export function PublishedContextWrapper({
   children,

--- a/packages/web/src/ui/components/admin/published-context-wrapper.tsx
+++ b/packages/web/src/ui/components/admin/published-context-wrapper.tsx
@@ -53,7 +53,7 @@ export interface PublishedContextWrapperProps {
  * `/admin/connections`; the fix was to remove the wrapper, not work around
  * it.
  *
- * ### Audit (as of 2026-05)
+ * ### Audit snapshot (as of 2026-05 — re-verify before relying on it)
  *
  * | Page | Wrapper? | All mutations draft-aware? | Trap risk |
  * | --- | --- | --- | --- |
@@ -61,6 +61,16 @@ export interface PublishedContextWrapperProps {
  * | `/admin/prompts` | yes (conditional) | Yes — CREATE/PATCH/DELETE all set `status='draft'` in dev mode | none |
  * | `/admin/semantic` | hook only (no wrapper) | Yes — entity edits/deletes go through the overlay tables | none |
  * | `/admin/schema-diff` | hook only (no wrapper) | n/a — read-only page | none |
+ *
+ * The table is a snapshot — the decision rule below is what's load-bearing.
+ * To re-audit, list every current caller:
+ *
+ *     grep -rln 'PublishedContextWrapper' packages/web/src/app
+ *
+ * and for each hit, verify the page's mutations are all draft-publishable
+ * by reading its backend route(s). If a mutation in dev mode does NOT
+ * write `status='draft'` (or go through an overlay table that publish
+ * promotes), the wrapper traps that action.
  *
  * ### Decision rule
  *


### PR DESCRIPTION
Bundle three small 1.4.2 closes — all touch distinct files inside `packages/web/src/app/settings/profile/` or `<PublishedContextWrapper>`.

## Closes

- Closes #2260 — `/settings/profile` loading skeleton
- Closes #2261 — component tests for `<PasswordSection>` + `<IdentitySection>`
- Closes #2313 — document `<PublishedContextWrapper>` constraint

Milestone: 1.4.2 — End-user shakeout

## Summary

### #2260 — `/settings/profile` loading skeleton
`loading.tsx` used to return `null`, so the route flashed empty content on first paint. Now returns a shadcn `<Skeleton>` layout that mirrors the rendered page — header eyebrow + h1 row + four section-shaped cards (identity, password, MFA, sessions). No more layout jump.

`/settings/ai-agents/loading.tsx` has the same `return null` shape — left a `TODO(#2321)` on it referencing a new follow-up issue under 1.4.2 so the next pass picks it up. Didn't duplicate the skeleton because the ai-agents route renders different sections; the follow-up needs its own treatment.

### #2261 — component tests for `<PasswordSection>` + `<IdentitySection>`
PR #2256 (the original `/settings/profile` ship) flagged two coverage gaps via `pr-review-toolkit:pr-test-analyzer`:

- **`<PasswordSection>`** — three cross-field validation rules + a fourth equals-current guard run in a specific order. Reordering or dropping the equals-current check would silently accept password reuse. Pinned every branch + the auth-mode probe denied path (renders nothing rather than a form that 404s) + success POST payload + JSON error surface + non-JSON status-code fallback. 11 tests.
- **`<IdentitySection>`** — dirty-state derivation across `session.refetch()`. PR #2256 fixed a bug where the dirty flag stayed set after a save + refetch. Pinned that save → API success → refetch → user.name flushes → dirty resets to false. Also pinned that an unrelated session refetch mid-edit does NOT clobber an active draft (`!dirty && !saving` guard). 7 tests.

`mock.module(...)` covers every named export of `@/lib/auth/client` (per project rule) so a sibling test importing a different export doesn't trip a partial-mock `SyntaxError`.

### #2313 — `<PublishedContextWrapper>` jsdoc audit
PR #2310 removed the wrapper from `/admin/connections` because the wrapper's `inert + opacity-60` overlay made the page's immediate (non-draftable) mutations unreachable — DELETE inserts a per-org `archived` tombstone, demo-hide bypasses publish entirely.

The constraint that makes the wrapper safe is invariant on the backend handlers, not on the wrapper itself — a future contributor can re-introduce the trap by adding the wrapper to a page whose backend has an immediate mutation, or by adding an immediate mutation to a currently-safe page. Neither tripping a type checker.

Added a structured jsdoc on the wrapper export with the connections rationale, the audit table covering connections / prompts / semantic editor / schema diff, and the safe/unsafe decision rule. If unsafe, the doc points contributors at `useDevModeNoDrafts(["surface"])` directly — that drives the global banner without overlaying the page.

## Test plan

- [x] `bun run lint` — 0 errors
- [x] `bun run type` — 0 errors
- [x] `bun run test` — all packages pass (web profile tests: 18/18 pass; published-context-wrapper: pass)
- [x] `bun x syncpack lint` — no issues
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — 543 files verified
- [x] `bash scripts/check-security-headers-drift.sh` — 3 mirror(s) match
- [x] `bash scripts/check-railway-watch.sh` — all Dockerfile COPY sources covered
- [x] `bash scripts/check-schema-drift.sh` — 68 migration tables in schema.ts
- [x] `bash scripts/check-oauth-helper-drift.sh` — vendored helper matches canonical
- [ ] CI green on the PR