### PR TITLE
feat(types): add DefaultLanding / DEFAULT_LANDINGS / isDefaultLanding

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -342,7 +342,7 @@
     },
     "packages/types": {
       "name": "@useatlas/types",
-      "version": "0.0.24",
+      "version": "0.0.25",
     },
     "packages/web": {
       "name": "@atlas/web",
@@ -4758,6 +4758,10 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typespec/ts-http-runtime/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "@useatlas/react/@useatlas/types": ["@useatlas/types@0.0.24", "", {}, "sha512-T6XXvG6QFkI6FlE3TG01nOPKCjtzTboQw8NKNguuFRlQV8yIoKKgYr3ybm6U41pBR7S35yFkzvzZhUPy9RLHcQ=="],
+
+    "@useatlas/sdk/@useatlas/types": ["@useatlas/types@0.0.24", "", {}, "sha512-T6XXvG6QFkI6FlE3TG01nOPKCjtzTboQw8NKNguuFRlQV8yIoKKgYr3ybm6U41pBR7S35yFkzvzZhUPy9RLHcQ=="],
 
     "@vercel/sandbox/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@useatlas/types",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {
-    "build": "rm -rf dist && bun build src/index.ts src/auth.ts src/conversation.ts src/connection.ts src/action.ts src/scheduled-task.ts src/errors.ts src/semantic.ts src/share.ts src/billing.ts src/dashboard.ts src/mode.ts src/starter-prompt.ts src/integrations.ts src/email-provider.ts src/mcp.ts --outdir dist --root src --target node --packages external && bun x tsc -p tsconfig.build.json",
+    "build": "rm -rf dist && bun build src/index.ts src/auth.ts src/conversation.ts src/connection.ts src/action.ts src/scheduled-task.ts src/errors.ts src/semantic.ts src/share.ts src/billing.ts src/dashboard.ts src/mode.ts src/starter-prompt.ts src/integrations.ts src/email-provider.ts src/mcp.ts src/preferences.ts --outdir dist --root src --target node --packages external && bun x tsc -p tsconfig.build.json",
     "prepare": "bun run build"
   },
   "exports": {
@@ -87,6 +87,11 @@
       "types": "./dist/mcp.d.ts",
       "import": "./dist/mcp.js",
       "default": "./dist/mcp.js"
+    },
+    "./preferences": {
+      "types": "./dist/preferences.d.ts",
+      "import": "./dist/preferences.js",
+      "default": "./dist/preferences.js"
     }
   },
   "main": "./dist/index.js",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -34,3 +34,4 @@ export * from "./email-provider";
 export * from "./audit-retention";
 export * from "./mcp";
 export * from "./security";
+export * from "./preferences";

--- a/packages/types/src/preferences.ts
+++ b/packages/types/src/preferences.ts
@@ -1,0 +1,22 @@
+/**
+ * Per-user preference types shared across API, frontend, and SDK.
+ *
+ * `DEFAULT_LANDINGS` is the single source of truth for the legal value set —
+ * the DB CHECK constraint, the Zod enum on the API, and the narrowing guards
+ * on the web all reference this tuple so a future addition (`notebook`,
+ * `reports`, ...) lands in one place instead of three.
+ */
+
+export const DEFAULT_LANDINGS = ["chat", "admin"] as const;
+export type DefaultLanding = (typeof DEFAULT_LANDINGS)[number];
+
+export function isDefaultLanding(value: unknown): value is DefaultLanding {
+  return (
+    typeof value === "string" &&
+    (DEFAULT_LANDINGS as readonly string[]).includes(value)
+  );
+}
+
+export interface UserPreferences {
+  defaultLanding: DefaultLanding;
+}


### PR DESCRIPTION
## Summary

Lands the per-user preference type set in \`@useatlas/types\` ahead of the chat-first front door feature (PR #2323 / issue #2022).

- Adds \`DEFAULT_LANDINGS\` (value tuple), \`DefaultLanding\` (literal union derived from the tuple), \`isDefaultLanding\` (narrowing guard), and \`UserPreferences\` interface.
- Registers \`./preferences\` as a separate exports entrypoint alongside the existing \`./mcp\`, \`./auth\`, etc.
- Bumps \`@useatlas/types\` 0.0.24 → 0.0.25.

## Why split from #2323

Scaffolded templates run \`npm install @useatlas/types@^0.0.24\` at scaffold-CI time and import from the published bundle. If #2323 introduces a value export that the published types don't have yet, Scaffold CI fails with \`Export X doesn't exist in target module\` (the \`@useatlas/types scaffold gotcha\` in CLAUDE.md feedback). Landing the types release first — then bumping template refs to 0.0.25 — is the documented version-bump-ordering flow.

## Sequence (per repo convention)

1. **This PR** — bump types version, add value exports. Template refs stay at \`^0.0.24\`. ← we are here
2. **Merge + tag** \`types-v0.0.25\` and push the tag to trigger the npm publish workflow.
3. **Wait** for the publish workflow to land on the registry.
4. **Follow-up commit (in #2323)** — bump \`^0.0.24\` → \`^0.0.25\` in \`packages/sdk\`, \`packages/react\`, \`packages/web\`, \`packages/api\`, and \`create-atlas/templates/*/package.json\`.

## Test plan

- [x] \`bun run --filter '@useatlas/types' build\` — produces \`dist/preferences.{js,d.ts}\`
- [x] \`bun run lint\` clean
- [x] \`bun run type\` clean
- [ ] Manual: after merge, tag types-v0.0.25 and watch the publish workflow succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)