### PR TITLE
ci(deploy-validation): boot-smoke cache-to mode=max → mode=min

### DIFF
--- a/.github/workflows/deploy-validation.yml
+++ b/.github/workflows/deploy-validation.yml
@@ -253,10 +253,16 @@ jobs:
           file: deploy/api/Dockerfile
           load: true
           tags: atlas-api:boot-smoke
-          # gha cache makes warm runs 30-60s vs 3-4 min cold. Branch and
-          # main share the cache so PR builds reuse main's layers.
+          # cache-from reads intermediate layers populated by `boot-build`
+          # (which writes mode=max to the same scope). Boot Smoke writes
+          # mode=min so it only exports the final-image (runner-stage)
+          # layers — uploading intermediates here just duplicates what
+          # boot-build already pushed and was costing ~7 min per run on
+          # GHA cache writes (single layers taking ~60s each). Warm runs
+          # land in ~4-5 min — dominated by `load: true` tarball export
+          # (~2 min) and the runner-stage layer write (~1-2 min).
           cache-from: type=gha,scope=boot-smoke
-          cache-to: type=gha,scope=boot-smoke,mode=max
+          cache-to: type=gha,scope=boot-smoke,mode=min
 
       - name: Run API container
         run: |


### PR DESCRIPTION
## Summary

- Boot Smoke job's `cache-to` was `mode=max`, duplicating intermediate-layer writes that `boot-build` already pushes to the same `boot-smoke` cache scope. Switched to `mode=min`.
- Updated the inline comment that claimed "warm runs 30-60s" — that hasn't been true since the cache writes started dominating.

## Investigation

Pulled the prior successful Boot Smoke run (25708056625, 11m 53s end-to-end). Build step itself was 10m 59s, broken down:

| Phase | Time |
|---|---|
| Buildx warmup + base image | ~9s |
| Build (mostly cache hits — `bun ci`, builds, COPYs) | ~1m 50s |
| `exporting to docker image format` (`load: true`) | **118.7s** |
| `exporting to GitHub Actions Cache` (`mode=max`) | **~7m 4s** |

The cache-write phase was the killer. Individual layers like `090169e0...` took 57.9s each to upload. `mode=max` exports every intermediate stage (deps + builder + nsjail-builder + runner) — but `boot-build` (the unconditional pre-check) already writes those same intermediate layers to the same `boot-smoke` scope. Boot Smoke's `mode=max` writes were pure duplication.

## Why `mode=min` is safe

- `boot-build` still runs on every PR with `mode=max`, so intermediate layers (deps, builder) continue to be cache-populated.
- `boot-smoke`'s `cache-from` reads those layers fine — confirmed in the build log (most stages showed `CACHED`).
- `mode=min` exports only the final-image (runner-stage) layers, so subsequent boot-smoke runs still get runner-stage cache hits.

## Expected outcome

- **Boot Smoke wallclock: ~12 min → ~4-5 min**
- Remaining cost: `load: true` tarball export (~2 min, intrinsic — needed for `docker run`) + runner-stage layer write (~1-2 min).

## Test plan

- [ ] CI runs Boot Smoke on this PR and completes in <6 min
- [ ] Boot Smoke result is `success` (no functional regression — same Dockerfile, same run command, same probe)
- [ ] Subsequent PR's Boot Smoke also stays under 6 min (cache reuse confirmed)