### PR TITLE
fix(web): #2321 — /settings/ai-agents loading skeleton

### DIFF
--- a/packages/web/src/app/settings/ai-agents/loading.tsx
+++ b/packages/web/src/app/settings/ai-agents/loading.tsx
@@ -1,5 +1,71 @@
-// TODO(#2321): replace this null return with a Skeleton layout matching the
-// rendered route (mirror the treatment that #2260 applied to /settings/profile).
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Suspense fallback for `/settings/ai-agents`. Mirrors the rendered
+ * shape (header + connected-agents list + prompts preview) so the
+ * layout doesn't collapse-then-jump on first paint. Same treatment
+ * #2260 applied to `/settings/profile`.
+ */
 export default function Loading() {
-  return null;
+  return (
+    <div
+      className="mx-auto max-w-3xl px-6 py-10"
+      role="status"
+      aria-busy
+      aria-live="polite"
+      aria-label="Loading AI Agents settings"
+    >
+      <header className="mb-10 flex flex-col gap-2">
+        <Skeleton className="h-3 w-32" />
+        <div className="flex items-baseline justify-between gap-6">
+          <Skeleton className="h-9 w-44" />
+          <Skeleton className="h-4 w-24" />
+        </div>
+        <Skeleton className="h-4 w-full max-w-xl" />
+        <Skeleton className="mt-4 h-8 w-44" />
+      </header>
+
+      <section>
+        <div className="mb-3 space-y-1">
+          <Skeleton className="h-3 w-40" />
+          <Skeleton className="h-3.5 w-80" />
+        </div>
+        <div className="space-y-2">
+          <AgentShellSkeleton />
+          <AgentShellSkeleton />
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function AgentShellSkeleton() {
+  return (
+    <section className="overflow-hidden rounded-xl border bg-card/60">
+      <header className="flex items-start gap-3 p-4 pb-3">
+        <Skeleton className="size-9 shrink-0 rounded-lg" />
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="ml-auto h-4 w-16" />
+          </div>
+          <Skeleton className="h-3 w-56" />
+        </div>
+      </header>
+      <div className="space-y-2 px-4 pb-3">
+        <div className="rounded-lg border bg-muted/20 px-3 py-2 space-y-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="flex items-center justify-between gap-3">
+              <Skeleton className="h-3 w-20" />
+              <Skeleton className="h-3 w-40" />
+            </div>
+          ))}
+        </div>
+      </div>
+      <footer className="flex items-center justify-end gap-2 border-t border-border/50 bg-muted/20 px-4 py-2.5">
+        <Skeleton className="h-7 w-28" />
+        <Skeleton className="h-7 w-20" />
+      </footer>
+    </section>
+  );
 }

--- a/packages/web/src/app/settings/ai-agents/loading.tsx
+++ b/packages/web/src/app/settings/ai-agents/loading.tsx
@@ -2,9 +2,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 /**
  * Suspense fallback for `/settings/ai-agents`. Mirrors the rendered
- * shape (header + connected-agents list + prompts preview) so the
- * layout doesn't collapse-then-jump on first paint. Same treatment
- * #2260 applied to `/settings/profile`.
+ * shape so the layout doesn't collapse-then-jump on first paint.
  */
 export default function Loading() {
   return (


### PR DESCRIPTION
Closes #2321.

## Summary
- Replace `null` return in `packages/web/src/app/settings/ai-agents/loading.tsx` with a Skeleton layout that mirrors the rendered route — header eyebrow + h1 row (with counter) + description + Connect CTA, plus a connected-agents section with two Shell-shaped cards (icon + title row + detail list + action footer).
- Removes the `TODO(#2321)` marker pinned by #2260.
- Same treatment #2260 applied to `/settings/profile/loading.tsx`. `role="status"` + `aria-busy` + `aria-live="polite"` so screen readers announce the load.

## Test plan
- [x] `bun run lint`
- [x] `bun run type`
- [x] `bun run test` (full suite)
- [x] `bun x syncpack lint`, template drift, railway-watch
- [ ] Visual: route renders skeleton during data fetch and the rendered page slots in without a layout jump