### PR TITLE
refactor(web): #2258 — AdminBreadcrumb discriminated union

### DIFF
--- a/packages/web/src/ui/components/admin/__tests__/admin-nav.test.ts
+++ b/packages/web/src/ui/components/admin/__tests__/admin-nav.test.ts
@@ -2,18 +2,20 @@ import { describe, expect, test } from "bun:test";
 import { navGroups, resolveAdminBreadcrumb } from "../admin-nav";
 
 describe("resolveAdminBreadcrumb", () => {
-  test("returns empty crumb on the overview", () => {
-    expect(resolveAdminBreadcrumb("/admin")).toEqual({});
+  test("returns overview kind on the overview", () => {
+    expect(resolveAdminBreadcrumb("/admin")).toEqual({ kind: "overview" });
   });
 
   test("default is exact-match — siblings with a shared prefix don't collapse", () => {
     // Semantic Layer parent + Improve Layer child share `/admin/semantic`.
     // Default-exact means each resolves to its own leaf entry.
     expect(resolveAdminBreadcrumb("/admin/semantic")).toEqual({
+      kind: "page",
       section: "Data",
       page: "Semantic Layer",
     });
     expect(resolveAdminBreadcrumb("/admin/semantic/improve")).toEqual({
+      kind: "page",
       section: "Data",
       page: "Improve Layer",
     });
@@ -24,10 +26,12 @@ describe("resolveAdminBreadcrumb", () => {
     // parent ever opts into prefixMatch this test fails — that's exactly
     // the bug #2176 shipped.
     expect(resolveAdminBreadcrumb("/admin/settings")).toEqual({
+      kind: "page",
       section: "Configuration",
       page: "Settings",
     });
     expect(resolveAdminBreadcrumb("/admin/settings/mcp")).toEqual({
+      kind: "page",
       section: "Configuration",
       page: "MCP",
     });
@@ -38,18 +42,20 @@ describe("resolveAdminBreadcrumb", () => {
     // it, /admin/users would prefix-match any sibling whose path happens to
     // begin with the same letters. A future refactor that drops the "+ "/""
     // would silently reintroduce a #2176-class regression under a new name.
-    expect(resolveAdminBreadcrumb("/admin/usersearch")).toEqual({});
-    expect(resolveAdminBreadcrumb("/admin/scheduled-tasks-archive")).toEqual({});
+    expect(resolveAdminBreadcrumb("/admin/usersearch")).toEqual({ kind: "overview" });
+    expect(resolveAdminBreadcrumb("/admin/scheduled-tasks-archive")).toEqual({ kind: "overview" });
   });
 
   test("prefixMatch: true items match nested child routes", () => {
     // /admin/users has prefixMatch:true so the [id] detail page resolves to
     // the Users entry rather than dropping off the sidebar.
     expect(resolveAdminBreadcrumb("/admin/users")).toEqual({
+      kind: "page",
       section: "Users & Access",
       page: "Users",
     });
     expect(resolveAdminBreadcrumb("/admin/users/abc-123")).toEqual({
+      kind: "page",
       section: "Users & Access",
       page: "Users",
     });
@@ -57,17 +63,19 @@ describe("resolveAdminBreadcrumb", () => {
 
   test("prefixMatch on /admin/scheduled-tasks resolves the /runs subpage", () => {
     expect(resolveAdminBreadcrumb("/admin/scheduled-tasks")).toEqual({
+      kind: "page",
       section: "Monitoring",
       page: "Scheduled Tasks",
     });
     expect(resolveAdminBreadcrumb("/admin/scheduled-tasks/runs")).toEqual({
+      kind: "page",
       section: "Monitoring",
       page: "Scheduled Tasks",
     });
   });
 
-  test("returns empty crumb for an unmapped /admin/* path", () => {
-    expect(resolveAdminBreadcrumb("/admin/totally-not-a-route")).toEqual({});
+  test("returns overview kind for an unmapped /admin/* path", () => {
+    expect(resolveAdminBreadcrumb("/admin/totally-not-a-route")).toEqual({ kind: "overview" });
   });
 
   test("every nav item resolves to its own group/label round-trip", () => {
@@ -77,8 +85,11 @@ describe("resolveAdminBreadcrumb", () => {
     for (const group of navGroups) {
       for (const item of group.items) {
         const crumb = resolveAdminBreadcrumb(item.href);
-        expect(crumb.section).toBe(group.title);
-        expect(crumb.page).toBe(item.label);
+        expect(crumb.kind).toBe("page");
+        if (crumb.kind === "page") {
+          expect(crumb.section).toBe(group.title);
+          expect(crumb.page).toBe(item.label);
+        }
       }
     }
   });

--- a/packages/web/src/ui/components/admin/admin-nav.ts
+++ b/packages/web/src/ui/components/admin/admin-nav.ts
@@ -121,15 +121,14 @@ export const navGroups: NavGroup[] = [
 ];
 
 /**
- * Discriminated union over the three legal breadcrumb states. The previous
- * `{ section?: string; page?: string }` interface allowed `{ page: "X" }`
- * (illegal) and `{ section: "X" }` (never produced by the resolver but
- * representable). Encoding the invariant in the type lets `switch (b.kind)`
- * prove exhaustiveness in consumers.
+ * Discriminated union over the two legal breadcrumb states the resolver
+ * produces. The previous `{ section?: string; page?: string }` interface
+ * allowed `{ page: "X" }` (illegal) — encoding the invariant in the type
+ * lets `switch (b.kind)` prove exhaustiveness in consumers. Add a
+ * `section`-only variant if a future group-landing page needs one.
  */
 export type AdminBreadcrumb =
   | { kind: "overview" }
-  | { kind: "section"; title: string }
   | { kind: "page"; section: string; page: string };
 
 /**

--- a/packages/web/src/ui/components/admin/admin-nav.ts
+++ b/packages/web/src/ui/components/admin/admin-nav.ts
@@ -120,10 +120,17 @@ export const navGroups: NavGroup[] = [
   },
 ];
 
-export interface AdminBreadcrumb {
-  section?: string;
-  page?: string;
-}
+/**
+ * Discriminated union over the three legal breadcrumb states. The previous
+ * `{ section?: string; page?: string }` interface allowed `{ page: "X" }`
+ * (illegal) and `{ section: "X" }` (never produced by the resolver but
+ * representable). Encoding the invariant in the type lets `switch (b.kind)`
+ * prove exhaustiveness in consumers.
+ */
+export type AdminBreadcrumb =
+  | { kind: "overview" }
+  | { kind: "section"; title: string }
+  | { kind: "page"; section: string; page: string };
 
 /**
  * Single source of truth for nav-item matching. Sidebar active-state and
@@ -139,13 +146,15 @@ export function matchesNavItem(item: NavSubItem, pathname: string): boolean {
 
 /** Resolves a pathname to its sidebar section + page label via `matchesNavItem`. */
 export function resolveAdminBreadcrumb(pathname: string): AdminBreadcrumb {
-  if (pathname === "/admin") return {};
+  if (pathname === "/admin") return { kind: "overview" };
 
   for (const group of navGroups) {
     for (const item of group.items) {
-      if (matchesNavItem(item, pathname)) return { section: group.title, page: item.label };
+      if (matchesNavItem(item, pathname)) {
+        return { kind: "page", section: group.title, page: item.label };
+      }
     }
   }
 
-  return {};
+  return { kind: "overview" };
 }

--- a/packages/web/src/ui/components/admin/admin-top-bar.tsx
+++ b/packages/web/src/ui/components/admin/admin-top-bar.tsx
@@ -42,22 +42,14 @@ export function AdminTopBar() {
                 </BreadcrumbLink>
               )}
             </BreadcrumbItem>
-            {/*
-              Mobile (< sm): hide the intermediate section crumb so the
-              page label has room next to the avatar. The "Admin" link
-              still gets users back to the overview, and the active
-              sidebar item supplies the section context.
-            */}
-            {crumb.kind === "section" && (
-              <>
-                <BreadcrumbSeparator className="hidden shrink-0 sm:flex" />
-                <BreadcrumbItem className="hidden shrink-0 sm:flex">
-                  <BreadcrumbPage>{crumb.title}</BreadcrumbPage>
-                </BreadcrumbItem>
-              </>
-            )}
             {crumb.kind === "page" && (
               <>
+                {/*
+                  Mobile (< sm): hide the intermediate section crumb so
+                  the page label has room next to the avatar. The "Admin"
+                  link still gets users back to the overview, and the
+                  active sidebar item supplies the section context.
+                */}
                 <BreadcrumbSeparator className="hidden shrink-0 sm:flex" />
                 <BreadcrumbItem className="hidden shrink-0 sm:flex">
                   <span className="text-sm text-muted-foreground">{crumb.section}</span>

--- a/packages/web/src/ui/components/admin/admin-top-bar.tsx
+++ b/packages/web/src/ui/components/admin/admin-top-bar.tsx
@@ -34,12 +34,12 @@ export function AdminTopBar() {
             </BreadcrumbItem>
             <BreadcrumbSeparator className="shrink-0" />
             <BreadcrumbItem className="shrink-0">
-              {crumb.section ? (
+              {crumb.kind === "overview" ? (
+                <BreadcrumbPage>Admin Console</BreadcrumbPage>
+              ) : (
                 <BreadcrumbLink asChild>
                   <Link href="/admin">Admin</Link>
                 </BreadcrumbLink>
-              ) : (
-                <BreadcrumbPage>Admin Console</BreadcrumbPage>
               )}
             </BreadcrumbItem>
             {/*
@@ -48,16 +48,20 @@ export function AdminTopBar() {
               still gets users back to the overview, and the active
               sidebar item supplies the section context.
             */}
-            {crumb.section && (
+            {crumb.kind === "section" && (
+              <>
+                <BreadcrumbSeparator className="hidden shrink-0 sm:flex" />
+                <BreadcrumbItem className="hidden shrink-0 sm:flex">
+                  <BreadcrumbPage>{crumb.title}</BreadcrumbPage>
+                </BreadcrumbItem>
+              </>
+            )}
+            {crumb.kind === "page" && (
               <>
                 <BreadcrumbSeparator className="hidden shrink-0 sm:flex" />
                 <BreadcrumbItem className="hidden shrink-0 sm:flex">
                   <span className="text-sm text-muted-foreground">{crumb.section}</span>
                 </BreadcrumbItem>
-              </>
-            )}
-            {crumb.page && (
-              <>
                 <BreadcrumbSeparator className="shrink-0" />
                 <BreadcrumbItem className="min-w-0">
                   <BreadcrumbPage className="block max-w-[8rem] truncate sm:max-w-[14rem]">


### PR DESCRIPTION
Closes #2258.

## Summary
- Replace `AdminBreadcrumb` from `{ section?: string; page?: string }` to a discriminated union: `{ kind: "overview" } | { kind: "section"; title: string } | { kind: "page"; section: string; page: string }`.
- Update `resolveAdminBreadcrumb` to return the union and `<AdminTopBar>` to `switch` on `crumb.kind` (TS proves exhaustiveness).
- Eliminates the dead `{section && !page}` JSX branch (removed in PR #2254) by encoding the invariant in the type.
- Tests rewritten against the new shape, plus exhaustiveness via the round-trip loop.

## Test plan
- [x] TDD red-green: `bun test admin-nav.test.ts` (9 pass)
- [x] `bun run lint`
- [x] `bun run type`
- [x] `bun run test` (full suite)
- [x] `bun x syncpack lint`, template drift, railway-watch