### PR TITLE
refactor(web): #2171 — canonical DatePicker / DateRangePicker

### DIFF
--- a/packages/web/src/app/admin/action-log/page.tsx
+++ b/packages/web/src/app/admin/action-log/page.tsx
@@ -2,7 +2,9 @@
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
+import { formatISODate, parseISODate } from "@/lib/format";
 import {
   Select,
   SelectContent,
@@ -281,18 +283,18 @@ function AdminActionsPageContent() {
           </SelectContent>
         </Select>
 
-        <Input
-          type="date"
-          value={params.from}
-          onChange={(e) => setParams({ from: e.target.value, page: 1 })}
-          className="h-9 w-36"
+        <DatePicker
+          value={parseISODate(params.from)}
+          onChange={(d) => setParams({ from: formatISODate(d), page: 1 })}
+          className="w-36"
+          placeholder="From"
           aria-label="From date"
         />
-        <Input
-          type="date"
-          value={params.to}
-          onChange={(e) => setParams({ to: e.target.value, page: 1 })}
-          className="h-9 w-36"
+        <DatePicker
+          value={parseISODate(params.to)}
+          onChange={(d) => setParams({ to: formatISODate(d), page: 1 })}
+          className="w-36"
+          placeholder="To"
           aria-label="To date"
         />
 

--- a/packages/web/src/app/admin/audit/page.tsx
+++ b/packages/web/src/app/admin/audit/page.tsx
@@ -12,6 +12,7 @@ import { DataTableSortList } from "@/components/data-table/data-table-sort-list"
 import { useDataTable } from "@/hooks/use-data-table";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -36,6 +37,7 @@ import {
   AuditOAuthClientsSchema,
 } from "@/ui/lib/admin-schemas";
 import { AuditFilterBar, type ActorKindFilter } from "@/ui/components/admin/audit/filter-bar";
+import { formatISODate, parseISODate } from "@/lib/format";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
@@ -328,22 +330,18 @@ export default function AuditPage() {
           <div className="flex flex-wrap items-end gap-3">
             <div className="space-y-1">
               <label htmlFor="analytics-from" className="text-xs font-medium text-muted-foreground">From</label>
-              <Input
+              <DatePicker
                 id="analytics-from"
-                type="date"
-                value={analyticsFrom}
-                onChange={(e) => setAnalyticsFrom(e.target.value)}
-                className="h-9 w-40"
+                value={parseISODate(analyticsFrom)}
+                onChange={(d) => setAnalyticsFrom(formatISODate(d))}
               />
             </div>
             <div className="space-y-1">
               <label htmlFor="analytics-to" className="text-xs font-medium text-muted-foreground">To</label>
-              <Input
+              <DatePicker
                 id="analytics-to"
-                type="date"
-                value={analyticsTo}
-                onChange={(e) => setAnalyticsTo(e.target.value)}
-                className="h-9 w-40"
+                value={parseISODate(analyticsTo)}
+                onChange={(d) => setAnalyticsTo(formatISODate(d))}
               />
             </div>
             <Button size="sm" className="h-9">
@@ -498,24 +496,20 @@ export default function AuditPage() {
               onChange={(next) => setParams(next)}
             />
 
-            <div className="space-y-0">
-              <Input
-                type="date"
-                value={from}
-                onChange={(e) => setParams({ from: e.target.value })}
-                className="h-9 w-36"
-                aria-label="From date"
-              />
-            </div>
-            <div className="space-y-0">
-              <Input
-                type="date"
-                value={to}
-                onChange={(e) => setParams({ to: e.target.value })}
-                className="h-9 w-36"
-                aria-label="To date"
-              />
-            </div>
+            <DatePicker
+              value={parseISODate(from)}
+              onChange={(d) => setParams({ from: formatISODate(d) })}
+              aria-label="From date"
+              placeholder="From"
+              className="w-36"
+            />
+            <DatePicker
+              value={parseISODate(to)}
+              onChange={(d) => setParams({ to: formatISODate(d) })}
+              aria-label="To date"
+              placeholder="To"
+              className="w-36"
+            />
 
             {hasFilters && (
               <Button variant="ghost" size="sm" className="h-9" onClick={clearFilters}>

--- a/packages/web/src/app/admin/audit/retention-panel.tsx
+++ b/packages/web/src/app/admin/audit/retention-panel.tsx
@@ -6,8 +6,10 @@ import { useAtlasConfig } from "@/ui/context";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { extractFetchError } from "@/ui/lib/fetch-error";
 import { Button } from "@/components/ui/button";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { formatISODate, parseISODate } from "@/lib/format";
 import {
   Select,
   SelectContent,
@@ -378,22 +380,18 @@ export function RetentionPanel() {
             </div>
             <div className="space-y-2">
               <Label htmlFor="export-start">Start date</Label>
-              <Input
+              <DatePicker
                 id="export-start"
-                type="date"
-                value={exportStartDate}
-                onChange={(e) => setExportStartDate(e.target.value)}
-                className="w-40"
+                value={parseISODate(exportStartDate)}
+                onChange={(d) => setExportStartDate(formatISODate(d))}
               />
             </div>
             <div className="space-y-2">
               <Label htmlFor="export-end">End date</Label>
-              <Input
+              <DatePicker
                 id="export-end"
-                type="date"
-                value={exportEndDate}
-                onChange={(e) => setExportEndDate(e.target.value)}
-                className="w-40"
+                value={parseISODate(exportEndDate)}
+                onChange={(d) => setExportEndDate(formatISODate(d))}
               />
             </div>
             <Button onClick={handleExport} disabled={exporting} className="h-10">

--- a/packages/web/src/app/admin/compliance/page.tsx
+++ b/packages/web/src/app/admin/compliance/page.tsx
@@ -6,7 +6,9 @@ import { useAtlasConfig } from "@/ui/context";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
+import { formatISODate, parseISODate } from "@/lib/format";
 import {
   Select,
   SelectContent,
@@ -597,18 +599,18 @@ function ReportsTab() {
             </div>
             <div className="space-y-2">
               <label className="text-sm font-medium">Start Date</label>
-              <Input
-                type="date"
-                value={from}
-                onChange={(e) => setParams({ from: e.target.value })}
+              <DatePicker
+                value={parseISODate(from)}
+                onChange={(d) => setParams({ from: formatISODate(d) })}
+                className="w-full"
               />
             </div>
             <div className="space-y-2">
               <label className="text-sm font-medium">End Date</label>
-              <Input
-                type="date"
-                value={to}
-                onChange={(e) => setParams({ to: e.target.value })}
+              <DatePicker
+                value={parseISODate(to)}
+                onChange={(d) => setParams({ to: formatISODate(d) })}
+                className="w-full"
               />
             </div>
             <div className="space-y-2">

--- a/packages/web/src/app/admin/scheduled-tasks/runs/page.tsx
+++ b/packages/web/src/app/admin/scheduled-tasks/runs/page.tsx
@@ -7,7 +7,8 @@ import { useQueryStates } from "nuqs";
 import { runHistorySearchParams } from "./search-params";
 import { useAtlasConfig } from "@/ui/context";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { DatePicker } from "@/components/ui/date-picker";
+import { formatISODate, parseISODate } from "@/lib/format";
 import {
   Select,
   SelectContent,
@@ -254,19 +255,17 @@ export default function RunHistoryPage() {
           </SelectContent>
         </Select>
 
-        <Input
-          type="date"
-          className="w-40"
+        <DatePicker
           placeholder="From"
-          value={dateFrom ?? ""}
-          onChange={(e) => setParams({ dateFrom: e.target.value || null, page: 1, expandedRun: null })}
+          aria-label="From date"
+          value={parseISODate(dateFrom)}
+          onChange={(d) => setParams({ dateFrom: formatISODate(d) || null, page: 1, expandedRun: null })}
         />
-        <Input
-          type="date"
-          className="w-40"
+        <DatePicker
           placeholder="To"
-          value={dateTo ?? ""}
-          onChange={(e) => setParams({ dateTo: e.target.value || null, page: 1, expandedRun: null })}
+          aria-label="To date"
+          value={parseISODate(dateTo)}
+          onChange={(d) => setParams({ dateTo: formatISODate(d) || null, page: 1, expandedRun: null })}
         />
 
         {hasFilters && (

--- a/packages/web/src/app/admin/token-usage/page.tsx
+++ b/packages/web/src/app/admin/token-usage/page.tsx
@@ -6,9 +6,9 @@ import { tokenUsageSearchParams } from "./search-params";
 import { useAdminFetch, type FetchError } from "@/ui/hooks/use-admin-fetch";
 import { TokenSummarySchema, TrendsResponseSchema, TokenUserResponseSchema } from "@/ui/lib/admin-schemas";
 import { useDarkMode } from "@/ui/hooks/use-dark-mode";
-import { formatNumber } from "@/lib/format";
+import { formatISODate, formatNumber, parseISODate } from "@/lib/format";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Button } from "@/components/ui/button";
 import { StatCard } from "@/ui/components/admin/stat-card";
 import { LoadingState } from "@/ui/components/admin/loading-state";
@@ -109,22 +109,18 @@ export default function TokenUsagePage() {
         <CardContent className="flex flex-wrap items-end gap-3 pt-4">
           <div className="grid gap-1">
             <label htmlFor="from" className="text-xs text-muted-foreground">From</label>
-            <Input
+            <DatePicker
               id="from"
-              type="date"
-              className="h-8 w-40"
-              value={filters.from}
-              onChange={(e) => setFilters((f) => ({ ...f, from: e.target.value }))}
+              value={parseISODate(filters.from)}
+              onChange={(d) => setFilters((f) => ({ ...f, from: formatISODate(d) }))}
             />
           </div>
           <div className="grid gap-1">
             <label htmlFor="to" className="text-xs text-muted-foreground">To</label>
-            <Input
+            <DatePicker
               id="to"
-              type="date"
-              className="h-8 w-40"
-              value={filters.to}
-              onChange={(e) => setFilters((f) => ({ ...f, to: e.target.value }))}
+              value={parseISODate(filters.to)}
+              onChange={(d) => setFilters((f) => ({ ...f, to: formatISODate(d) }))}
             />
           </div>
           <Button size="sm" variant="outline" className="h-8" onClick={applyFilters}>

--- a/packages/web/src/app/platform/actions/page.tsx
+++ b/packages/web/src/app/platform/actions/page.tsx
@@ -2,7 +2,9 @@
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
+import { formatISODate, parseISODate } from "@/lib/format";
 import {
   Select,
   SelectContent,
@@ -304,18 +306,18 @@ function ActionsPageContent() {
           </SelectContent>
         </Select>
 
-        <Input
-          type="date"
-          value={params.from}
-          onChange={(e) => setParams({ from: e.target.value, page: 1 })}
-          className="h-9 w-36"
+        <DatePicker
+          value={parseISODate(params.from)}
+          onChange={(d) => setParams({ from: formatISODate(d), page: 1 })}
+          className="w-36"
+          placeholder="From"
           aria-label="From date"
         />
-        <Input
-          type="date"
-          value={params.to}
-          onChange={(e) => setParams({ to: e.target.value, page: 1 })}
-          className="h-9 w-36"
+        <DatePicker
+          value={parseISODate(params.to)}
+          onChange={(d) => setParams({ to: formatISODate(d), page: 1 })}
+          className="w-36"
+          placeholder="To"
           aria-label="To date"
         />
 

--- a/packages/web/src/components/ui/date-picker.test.tsx
+++ b/packages/web/src/components/ui/date-picker.test.tsx
@@ -1,8 +1,11 @@
 import { describe, expect, test, mock } from "bun:test";
 import { render, fireEvent, waitFor } from "@testing-library/react";
+import { useState } from "react";
+import type { DateRange } from "react-day-picker";
 
 import { DatePicker } from "./date-picker";
-import { DateRangePicker } from "./date-range-picker";
+import { DateRangePicker, normalizeRange } from "./date-range-picker";
+import { formatISODate, parseISODate } from "@/lib/format";
 
 function getTrigger(container: HTMLElement) {
   const trigger = container.querySelector<HTMLButtonElement>(
@@ -62,7 +65,7 @@ describe("DatePicker", () => {
     expect(trigger.disabled).toBe(true);
   });
 
-  test("calls onChange with a Date when a day is picked", async () => {
+  test("calls onChange with a Date for the picked day in the displayed month", async () => {
     const onChange = mock((_: Date | undefined) => {});
     const value = new Date(2026, 2, 1); // March 1, 2026
     const { container, baseElement } = render(
@@ -74,26 +77,74 @@ describe("DatePicker", () => {
       expect(baseElement.querySelector('[data-slot="calendar"]')).not.toBeNull();
     });
 
-    const day = baseElement.querySelector<HTMLButtonElement>(
-      'button[data-day="3/15/2026"]',
+    // Pick the first day cell in March. `data-day` formatting is locale-dependent,
+    // so we don't pin a specific date string — instead we assert the callback got
+    // a Date in March (the displayed month).
+    const dayCell = baseElement.querySelector<HTMLButtonElement>(
+      '[data-slot="calendar"] button[data-day]',
     );
-    if (!day) {
-      // happy-dom may not surface the data-day attribute; fall back to clicking
-      // any day cell button inside the popover.
-      const fallback = baseElement.querySelector<HTMLButtonElement>(
-        '[data-slot="calendar"] button[data-day]',
-      );
-      if (!fallback) throw new Error("No day cell rendered");
-      fireEvent.click(fallback);
-    } else {
-      fireEvent.click(day);
-    }
+    if (!dayCell) throw new Error("No day cell rendered");
+    fireEvent.click(dayCell);
 
     await waitFor(() => {
       expect(onChange).toHaveBeenCalled();
     });
     const arg = onChange.mock.calls[0]?.[0];
     expect(arg).toBeInstanceOf(Date);
+    // Whatever day cell was clicked, it must be from a displayed month (Feb-Apr
+    // since react-day-picker shows outside days). Reject any year other than 2026.
+    expect((arg as Date).getFullYear()).toBe(2026);
+  });
+
+  test("treats an Invalid Date value as undefined (NaN-Date guard)", () => {
+    // A parent passing `new Date("garbage")` would otherwise reach <Calendar>
+    // and render NaN. The guard short-circuits to the placeholder.
+    const { container } = render(
+      <DatePicker
+        value={new Date("not-a-date")}
+        onChange={() => {}}
+        placeholder="Pick a date"
+      />,
+    );
+    expect(getTrigger(container).textContent).toContain("Pick a date");
+  });
+
+  test("URL-state round-trip: parseISODate → DatePicker → onChange → formatISODate", async () => {
+    // This is the integration contract every migrated admin page relies on.
+    let captured = "";
+
+    function Wrapper({ initial }: { initial: string }) {
+      const [state, setState] = useState(initial);
+      captured = state;
+      return (
+        <DatePicker
+          value={parseISODate(state)}
+          onChange={(d) => setState(formatISODate(d))}
+        />
+      );
+    }
+
+    const { container, baseElement } = render(<Wrapper initial="2026-03-15" />);
+    // Initial render reflects the URL string.
+    expect(getTrigger(container).textContent).toContain("March");
+    expect(captured).toBe("2026-03-15");
+
+    fireEvent.click(getTrigger(container));
+    await waitFor(() => {
+      expect(baseElement.querySelector('[data-slot="calendar"]')).not.toBeNull();
+    });
+
+    const dayCell = baseElement.querySelector<HTMLButtonElement>(
+      '[data-slot="calendar"] button[data-day]',
+    );
+    if (!dayCell) throw new Error("No day cell rendered");
+    fireEvent.click(dayCell);
+
+    await waitFor(() => {
+      // After clicking, state must hold a yyyy-MM-dd string (not "" — that
+      // would be the "no filter" state, which we shouldn't have produced here)
+      expect(captured).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
   });
 });
 
@@ -137,5 +188,55 @@ describe("DateRangePicker", () => {
     await waitFor(() => {
       expect(baseElement.querySelector('[data-slot="calendar"]')).not.toBeNull();
     });
+  });
+
+  test("reflects updates when value changes from range to undefined", () => {
+    function Harness() {
+      const [value, setValue] = useState<DateRange | undefined>({
+        from: new Date(2026, 4, 1),
+        to: new Date(2026, 4, 10),
+      });
+      return (
+        <>
+          <DateRangePicker value={value} onChange={setValue} placeholder="Pick" />
+          <button data-testid="clear" onClick={() => setValue(undefined)}>
+            clear
+          </button>
+        </>
+      );
+    }
+    const { container } = render(<Harness />);
+    expect(getRangeTrigger(container).textContent).toMatch(/May/);
+    fireEvent.click(container.querySelector('[data-testid="clear"]')!);
+    expect(getRangeTrigger(container).textContent).toContain("Pick");
+  });
+
+});
+
+describe("normalizeRange", () => {
+  test("passes through undefined / empty / partial ranges unchanged", () => {
+    expect(normalizeRange(undefined)).toBeUndefined();
+    expect(normalizeRange({ from: undefined, to: undefined })).toEqual({
+      from: undefined,
+      to: undefined,
+    });
+    const fromOnly = { from: new Date(2026, 4, 1), to: undefined };
+    expect(normalizeRange(fromOnly)).toBe(fromOnly);
+  });
+
+  test("passes through an already-ordered range unchanged", () => {
+    const range = {
+      from: new Date(2026, 4, 1),
+      to: new Date(2026, 4, 10),
+    };
+    expect(normalizeRange(range)).toBe(range);
+  });
+
+  test("swaps from/to when inverted", () => {
+    const from = new Date(2026, 4, 10);
+    const to = new Date(2026, 4, 1);
+    const result = normalizeRange({ from, to });
+    expect(result?.from).toBe(to);
+    expect(result?.to).toBe(from);
   });
 });

--- a/packages/web/src/components/ui/date-picker.test.tsx
+++ b/packages/web/src/components/ui/date-picker.test.tsx
@@ -1,0 +1,141 @@
+import { describe, expect, test, mock } from "bun:test";
+import { render, fireEvent, waitFor } from "@testing-library/react";
+
+import { DatePicker } from "./date-picker";
+import { DateRangePicker } from "./date-range-picker";
+
+function getTrigger(container: HTMLElement) {
+  const trigger = container.querySelector<HTMLButtonElement>(
+    'button[data-slot="date-picker-trigger"]',
+  );
+  if (!trigger) throw new Error("Trigger button not found");
+  return trigger;
+}
+
+function getRangeTrigger(container: HTMLElement) {
+  const trigger = container.querySelector<HTMLButtonElement>(
+    'button[data-slot="date-range-picker-trigger"]',
+  );
+  if (!trigger) throw new Error("Range trigger button not found");
+  return trigger;
+}
+
+describe("DatePicker", () => {
+  test("renders placeholder when value is undefined", () => {
+    const { container } = render(
+      <DatePicker value={undefined} onChange={() => {}} placeholder="Pick a date" />,
+    );
+    expect(getTrigger(container).textContent).toContain("Pick a date");
+  });
+
+  test("renders formatted date when value is set", () => {
+    const value = new Date(2026, 2, 27); // March 27, 2026 local
+    const { container } = render(
+      <DatePicker value={value} onChange={() => {}} />,
+    );
+    const text = getTrigger(container).textContent ?? "";
+    expect(text).toContain("March");
+    expect(text).toContain("2026");
+  });
+
+  test("opens calendar popover when trigger clicked", async () => {
+    const { container, baseElement } = render(
+      <DatePicker value={undefined} onChange={() => {}} />,
+    );
+    fireEvent.click(getTrigger(container));
+    await waitFor(() => {
+      expect(baseElement.querySelector('[data-slot="calendar"]')).not.toBeNull();
+    });
+  });
+
+  test("forwards aria-label and disabled to trigger", () => {
+    const { container } = render(
+      <DatePicker
+        value={undefined}
+        onChange={() => {}}
+        aria-label="From date"
+        disabled
+      />,
+    );
+    const trigger = getTrigger(container);
+    expect(trigger.getAttribute("aria-label")).toBe("From date");
+    expect(trigger.disabled).toBe(true);
+  });
+
+  test("calls onChange with a Date when a day is picked", async () => {
+    const onChange = mock((_: Date | undefined) => {});
+    const value = new Date(2026, 2, 1); // March 1, 2026
+    const { container, baseElement } = render(
+      <DatePicker value={value} onChange={onChange} />,
+    );
+
+    fireEvent.click(getTrigger(container));
+    await waitFor(() => {
+      expect(baseElement.querySelector('[data-slot="calendar"]')).not.toBeNull();
+    });
+
+    const day = baseElement.querySelector<HTMLButtonElement>(
+      'button[data-day="3/15/2026"]',
+    );
+    if (!day) {
+      // happy-dom may not surface the data-day attribute; fall back to clicking
+      // any day cell button inside the popover.
+      const fallback = baseElement.querySelector<HTMLButtonElement>(
+        '[data-slot="calendar"] button[data-day]',
+      );
+      if (!fallback) throw new Error("No day cell rendered");
+      fireEvent.click(fallback);
+    } else {
+      fireEvent.click(day);
+    }
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+    const arg = onChange.mock.calls[0]?.[0];
+    expect(arg).toBeInstanceOf(Date);
+  });
+});
+
+describe("DateRangePicker", () => {
+  test("renders placeholder when range empty", () => {
+    const { container } = render(
+      <DateRangePicker
+        value={undefined}
+        onChange={() => {}}
+        placeholder="Date range"
+      />,
+    );
+    expect(getRangeTrigger(container).textContent).toContain("Date range");
+  });
+
+  test("renders single date when only from is set", () => {
+    const { container } = render(
+      <DateRangePicker
+        value={{ from: new Date(2026, 4, 1), to: undefined }}
+        onChange={() => {}}
+      />,
+    );
+    expect(getRangeTrigger(container).textContent).toContain("May");
+  });
+
+  test("renders 'from – to' when both ends set", () => {
+    const { container } = render(
+      <DateRangePicker
+        value={{ from: new Date(2026, 4, 1), to: new Date(2026, 4, 10) }}
+        onChange={() => {}}
+      />,
+    );
+    expect(getRangeTrigger(container).textContent).toMatch(/May.*May/);
+  });
+
+  test("opens calendar popover when trigger clicked", async () => {
+    const { container, baseElement } = render(
+      <DateRangePicker value={undefined} onChange={() => {}} />,
+    );
+    fireEvent.click(getRangeTrigger(container));
+    await waitFor(() => {
+      expect(baseElement.querySelector('[data-slot="calendar"]')).not.toBeNull();
+    });
+  });
+});

--- a/packages/web/src/components/ui/date-picker.tsx
+++ b/packages/web/src/components/ui/date-picker.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { CalendarIcon } from "lucide-react";
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { formatLongDate } from "@/lib/format";
+import { cn } from "@/lib/utils";
+
+export interface DatePickerProps {
+  value: Date | undefined;
+  onChange: (date: Date | undefined) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+  id?: string;
+  "aria-label"?: string;
+}
+
+export function DatePicker({
+  value,
+  onChange,
+  placeholder = "Pick a date",
+  disabled,
+  className,
+  id,
+  "aria-label": ariaLabel,
+}: DatePickerProps) {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          variant="outline"
+          disabled={disabled}
+          aria-label={ariaLabel}
+          data-slot="date-picker-trigger"
+          className={cn(
+            "h-9 w-40 justify-start text-left font-normal",
+            !value && "text-muted-foreground",
+            className,
+          )}
+        >
+          <CalendarIcon className="mr-2 size-3.5 shrink-0" />
+          <span className="truncate">
+            {value ? formatLongDate(value) : placeholder}
+          </span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <Calendar
+          autoFocus
+          captionLayout="dropdown"
+          mode="single"
+          selected={value}
+          onSelect={(date) => {
+            onChange(date);
+            if (date) setOpen(false);
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/web/src/components/ui/date-picker.tsx
+++ b/packages/web/src/components/ui/date-picker.tsx
@@ -23,6 +23,10 @@ export interface DatePickerProps {
   "aria-label"?: string;
 }
 
+function isValidDate(d: Date | undefined): d is Date {
+  return d instanceof Date && !Number.isNaN(d.getTime());
+}
+
 export function DatePicker({
   value,
   onChange,
@@ -33,6 +37,7 @@ export function DatePicker({
   "aria-label": ariaLabel,
 }: DatePickerProps) {
   const [open, setOpen] = React.useState(false);
+  const safeValue = isValidDate(value) ? value : undefined;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -45,13 +50,13 @@ export function DatePicker({
           data-slot="date-picker-trigger"
           className={cn(
             "h-9 w-40 justify-start text-left font-normal",
-            !value && "text-muted-foreground",
+            !safeValue && "text-muted-foreground",
             className,
           )}
         >
           <CalendarIcon className="mr-2 size-3.5 shrink-0" />
           <span className="truncate">
-            {value ? formatLongDate(value) : placeholder}
+            {safeValue ? formatLongDate(safeValue) : placeholder}
           </span>
         </Button>
       </PopoverTrigger>
@@ -60,7 +65,7 @@ export function DatePicker({
           autoFocus
           captionLayout="dropdown"
           mode="single"
-          selected={value}
+          selected={safeValue}
           onSelect={(date) => {
             onChange(date);
             if (date) setOpen(false);

--- a/packages/web/src/components/ui/date-range-picker.tsx
+++ b/packages/web/src/components/ui/date-range-picker.tsx
@@ -35,6 +35,21 @@ function renderRangeLabel(range: DateRange | undefined, placeholder: string) {
   return formatLongDate(range.from ?? range.to);
 }
 
+/**
+ * Swap from/to when the user picks an inverted range. Makes `to >= from` a
+ * postcondition of the component without changing the prop type — callers
+ * never see {from: dec31, to: jan1}.
+ *
+ * Exported for unit testing; not part of the component's stable API.
+ */
+export function normalizeRange(range: DateRange | undefined): DateRange | undefined {
+  if (!range?.from || !range?.to) return range;
+  if (range.from.getTime() > range.to.getTime()) {
+    return { from: range.to, to: range.from };
+  }
+  return range;
+}
+
 export function DateRangePicker({
   value,
   onChange,
@@ -74,8 +89,9 @@ export function DateRangePicker({
           mode="range"
           selected={value}
           onSelect={(range) => {
-            onChange(range);
-            if (range?.from && range?.to) setOpen(false);
+            const normalized = normalizeRange(range);
+            onChange(normalized);
+            if (normalized?.from && normalized?.to) setOpen(false);
           }}
           numberOfMonths={numberOfMonths}
         />

--- a/packages/web/src/components/ui/date-range-picker.tsx
+++ b/packages/web/src/components/ui/date-range-picker.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { CalendarIcon } from "lucide-react";
+import * as React from "react";
+import type { DateRange } from "react-day-picker";
+
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { formatLongDate } from "@/lib/format";
+import { cn } from "@/lib/utils";
+
+export type { DateRange };
+
+export interface DateRangePickerProps {
+  value: DateRange | undefined;
+  onChange: (range: DateRange | undefined) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+  id?: string;
+  numberOfMonths?: number;
+  "aria-label"?: string;
+}
+
+function renderRangeLabel(range: DateRange | undefined, placeholder: string) {
+  if (!range || (!range.from && !range.to)) return placeholder;
+  if (range.from && range.to) {
+    return `${formatLongDate(range.from)} – ${formatLongDate(range.to)}`;
+  }
+  return formatLongDate(range.from ?? range.to);
+}
+
+export function DateRangePicker({
+  value,
+  onChange,
+  placeholder = "Pick a date range",
+  disabled,
+  className,
+  id,
+  numberOfMonths = 2,
+  "aria-label": ariaLabel,
+}: DateRangePickerProps) {
+  const [open, setOpen] = React.useState(false);
+  const hasValue = Boolean(value?.from || value?.to);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          variant="outline"
+          disabled={disabled}
+          aria-label={ariaLabel}
+          data-slot="date-range-picker-trigger"
+          className={cn(
+            "h-9 w-[260px] justify-start text-left font-normal",
+            !hasValue && "text-muted-foreground",
+            className,
+          )}
+        >
+          <CalendarIcon className="mr-2 size-3.5 shrink-0" />
+          <span className="truncate">{renderRangeLabel(value, placeholder)}</span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <Calendar
+          autoFocus
+          captionLayout="dropdown"
+          mode="range"
+          selected={value}
+          onSelect={(range) => {
+            onChange(range);
+            if (range?.from && range?.to) setOpen(false);
+          }}
+          numberOfMonths={numberOfMonths}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/web/src/lib/format.test.ts
+++ b/packages/web/src/lib/format.test.ts
@@ -5,6 +5,8 @@ import {
   formatDateTime,
   formatShortDateTime,
   formatNumber,
+  parseISODate,
+  formatISODate,
 } from "./format";
 
 const EM_DASH = "\u2014";
@@ -90,6 +92,57 @@ describe("formatShortDateTime", () => {
     const result = formatShortDateTime(ISO);
     expect(result).toMatch(/\d{1,2}:\d{2}/);
     expect(result).not.toContain("2026");
+  });
+});
+
+describe("parseISODate", () => {
+  test("returns undefined for null/undefined/empty", () => {
+    expect(parseISODate(null)).toBeUndefined();
+    expect(parseISODate(undefined)).toBeUndefined();
+    expect(parseISODate("")).toBeUndefined();
+  });
+
+  test("returns undefined for malformed input", () => {
+    expect(parseISODate("2026/03/27")).toBeUndefined();
+    expect(parseISODate("2026-3-27")).toBeUndefined();
+    expect(parseISODate("not a date")).toBeUndefined();
+  });
+
+  test("returns undefined for out-of-range values (Feb 30)", () => {
+    expect(parseISODate("2026-02-30")).toBeUndefined();
+  });
+
+  test("parses yyyy-MM-dd as local midnight", () => {
+    const result = parseISODate("2026-03-27");
+    expect(result).toBeInstanceOf(Date);
+    expect(result?.getFullYear()).toBe(2026);
+    expect(result?.getMonth()).toBe(2); // March, zero-indexed
+    expect(result?.getDate()).toBe(27);
+    expect(result?.getHours()).toBe(0);
+  });
+
+  test("round-trips with formatISODate", () => {
+    const iso = "2026-05-11";
+    const parsed = parseISODate(iso);
+    expect(parsed).toBeInstanceOf(Date);
+    expect(formatISODate(parsed)).toBe(iso);
+  });
+});
+
+describe("formatISODate", () => {
+  test("returns empty string for null/undefined", () => {
+    expect(formatISODate(null)).toBe("");
+    expect(formatISODate(undefined)).toBe("");
+  });
+
+  test("formats a Date as yyyy-MM-dd in local time", () => {
+    const d = new Date(2026, 0, 5); // Jan 5, 2026 local
+    expect(formatISODate(d)).toBe("2026-01-05");
+  });
+
+  test("zero-pads month and day", () => {
+    const d = new Date(2026, 8, 9); // Sep 9
+    expect(formatISODate(d)).toBe("2026-09-09");
   });
 });
 

--- a/packages/web/src/lib/format.test.ts
+++ b/packages/web/src/lib/format.test.ts
@@ -144,6 +144,14 @@ describe("formatISODate", () => {
     const d = new Date(2026, 8, 9); // Sep 9
     expect(formatISODate(d)).toBe("2026-09-09");
   });
+
+  test("formats in local time, not UTC (Dec 31 evening stays Dec 31)", () => {
+    // The motivating bug: `toISOString().slice(0, 10)` would return "2026-01-01"
+    // for this Date in any UTC-offset west of GMT. formatISODate uses local
+    // getters so the calendar day matches what the user picked.
+    const lateLocal = new Date(2025, 11, 31, 23, 0, 0); // Dec 31 11pm local
+    expect(formatISODate(lateLocal)).toBe("2025-12-31");
+  });
 });
 
 describe("formatNumber", () => {

--- a/packages/web/src/lib/format.ts
+++ b/packages/web/src/lib/format.ts
@@ -47,6 +47,43 @@ export function formatDateTime(date: DateInput): string {
   });
 }
 
+const ISO_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/**
+ * Parse a yyyy-MM-dd date string into a Date at local midnight.
+ * Returns undefined for empty/invalid input. Used at the boundary between
+ * URL/API string state and the DatePicker primitives.
+ */
+export function parseISODate(value: string | null | undefined): Date | undefined {
+  if (!value) return undefined;
+  const match = value.match(ISO_DATE_PATTERN);
+  if (!match) return undefined;
+  const year = Number(match[1]);
+  const month = Number(match[2]) - 1;
+  const day = Number(match[3]);
+  const d = new Date(year, month, day);
+  if (
+    d.getFullYear() !== year ||
+    d.getMonth() !== month ||
+    d.getDate() !== day
+  ) {
+    return undefined;
+  }
+  return d;
+}
+
+/**
+ * Format a Date as yyyy-MM-dd in local time. Returns "" for undefined/null
+ * so the result drops straight into URL/API string state.
+ */
+export function formatISODate(date: Date | null | undefined): string {
+  if (!date) return "";
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
 /** Format a number with K/M suffixes for compact display. */
 export function formatNumber(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;

--- a/packages/web/src/lib/format.ts
+++ b/packages/web/src/lib/format.ts
@@ -50,9 +50,11 @@ export function formatDateTime(date: DateInput): string {
 const ISO_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
 
 /**
- * Parse a yyyy-MM-dd date string into a Date at local midnight.
- * Returns undefined for empty/invalid input. Used at the boundary between
- * URL/API string state and the DatePicker primitives.
+ * Parse yyyy-MM-dd at LOCAL midnight (not UTC) so the parsed date renders as
+ * the same calendar day the user typed. `new Date("2026-03-27")` parses as
+ * UTC midnight and shifts west of GMT. Also rejects overflow like "2026-02-30"
+ * via the round-trip check below — the Date constructor would silently coerce
+ * those to a different valid date.
  */
 export function parseISODate(value: string | null | undefined): Date | undefined {
   if (!value) return undefined;
@@ -73,8 +75,9 @@ export function parseISODate(value: string | null | undefined): Date | undefined
 }
 
 /**
- * Format a Date as yyyy-MM-dd in local time. Returns "" for undefined/null
- * so the result drops straight into URL/API string state.
+ * Inverse of parseISODate — formats in LOCAL time (not UTC) so a date picked
+ * on March 27 doesn't serialize as March 26 west of GMT. Returns "" for
+ * undefined/null so the result drops straight into URL/API string state.
  */
 export function formatISODate(date: Date | null | undefined): string {
   if (!date) return "";


### PR DESCRIPTION
Closes #2171.

## Summary

- Add `<DatePicker />` and `<DateRangePicker />` in `packages/web/src/components/ui/` — shadcn-style (`Popover` + `Calendar` + formatted button trigger, new-york / neutral / Lucide).
- Replace 7 admin sites that used native `<Input type="date">` with the new `<DatePicker />`:
  - `admin/audit/page.tsx` (analytics from/to, filter from/to)
  - `admin/audit/retention-panel.tsx` (export start/end)
  - `admin/scheduled-tasks/runs/page.tsx` (date filter from/to)
  - `admin/compliance/page.tsx` (report start/end)
  - `platform/actions/page.tsx` (date filter from/to)
  - `admin/action-log/page.tsx` (date filter from/to)
  - `admin/token-usage/page.tsx` (filter from/to)
- Add `parseISODate` / `formatISODate` helpers in `lib/format.ts` so URL/API `yyyy-MM-dd` string state stays at the boundary, while the primitives keep a clean `Date | undefined` API.
- Tests: 11 new specs covering primitive behavior (placeholder, formatted value, popover open, aria/disabled forwarding, onChange Date callback, range label rendering) and the ISO helpers (parse round-trip, malformed/out-of-range rejection, zero-padding).

## Why `DataTableDateFilter` is untouched

`DataTableDateFilter` is a column-level **faceted filter** used inside `data-table-toolbar`. Its dashed-border-with-inline-title button styling intentionally matches its peer `DataTableFacetedFilter` chips in the toolbar — the *consistency* it provides is to other faceted filters, not to standalone form fields. It already composes the same shadcn `Calendar` underneath, so calendar behavior matches the new primitives. Replacing it with the new `DatePicker` would be a visual regression for data tables.

If we want a single primitive across both surfaces later, the right move is to let `DataTableDateFilter` keep its custom trigger and have it `import { Calendar }` (already does) — which is exactly the current state.

## Out of scope (per the issue)

No new picker behavior (typeahead, natural-language). Just consistency.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun run test` — full suite, all packages pass
- [x] `bun x syncpack lint`, template-drift, security-headers-drift, railway-watch, schema-drift, oauth-helper-drift — all pass
- [x] New: 9 DatePicker/DateRangePicker tests + 9 parseISODate/formatISODate tests
- [ ] Manual: open each migrated admin page, pick a date in the DatePicker, confirm the filter applies and the URL `yyyy-MM-dd` state round-trips