### PR TITLE
refactor(web): #2262 — collapse authClient casts at the export boundary

### DIFF
--- a/packages/web/src/app/oauth2/consent/page.tsx
+++ b/packages/web/src/app/oauth2/consent/page.tsx
@@ -159,25 +159,12 @@ export default function ConsentPage() {
       // `oauth_query` back to the server via the `oauthProviderClient`
       // fetch hook. The server completes the authorization flow and
       // returns either a 302 redirect URL or a JSON envelope carrying it.
-      //
-      // The cast through `unknown` is required because `authClient` is
-      // hand-typed as `OrgClient` in packages/web/src/lib/auth/client.ts
-      // — the explicit type was added when organization plugin types
-      // failed to infer through `createAuthClient`. The same erasure
-      // hides the `oauth2.*` surface contributed by `oauthProviderClient`.
-      // Adding it to OrgClient would couple auth-client.ts to every
-      // page that touches OAuth; localizing the cast here keeps the
-      // boundary tight.
-      const res = (await (authClient as unknown as {
-        oauth2: {
-          consent: (
-            opts: { accept: boolean; scope?: string },
-          ) => Promise<{
-            data?: { redirectURI?: string };
-            error?: { message?: string };
-          } | undefined>;
-        };
-      }).oauth2.consent({ accept })) ?? undefined;
+      const consent = authClient.oauth2?.consent;
+      if (typeof consent !== "function") {
+        setError("OAuth consent client is not available. Restart the flow from your OAuth client.");
+        return;
+      }
+      const res = (await consent({ accept })) ?? undefined;
       if (res?.error) {
         setError(res.error.message ?? "Consent failed.");
         return;

--- a/packages/web/src/lib/auth/client.ts
+++ b/packages/web/src/lib/auth/client.ts
@@ -37,6 +37,7 @@ import {
 import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
 import { ac, owner, admin, member } from "./org-permissions";
 import { adminAccessControl, adminRole, platformAdminRole } from "./admin-permissions";
+import type { AuthApiResult, Passkey, PasskeySignIn } from "./wire-types";
 
 function getBaseURL(): string {
   const url = getApiUrl();
@@ -85,30 +86,22 @@ const _authClient = createAuthClient({
   fetchOptions: isCrossOrigin() ? { credentials: "include" as RequestCredentials } : {},
 });
 
-// TS6 fails to infer plugin types through createAuthClient — the wrapped
-// client erases each plugin's namespace contribution. The fix is a one-time
-// intersection at the export boundary so every consumer reads a typed
-// surface instead of writing `(authClient as unknown as { ... })` per call.
-//
-// Each namespace is declared `Partial`-ish (optional methods + optional
-// namespace) so the runtime presence guards in `lib/auth/{passkey,
-// two-factor}-client.ts` and `ui/components/auth/verify-email-otp-form.tsx`
-// keep surfacing Better Auth API drift as a precise null rather than
-// `TypeError: addPasskey is not a function` at click time.
-type AuthResult<T> = { data: T | null; error: { message?: string; code?: string } | null };
+// `createAuthClient` erases each plugin's namespace contribution under TS6
+// strictness. Patch the holes at this export boundary so consumers read a
+// typed surface instead of writing `(authClient as unknown as { ... })` per
+// call. Method presence stays optional so the runtime guards in
+// `lib/auth/{passkey,two-factor}-client.ts` and the OTP/consent forms
+// still surface Better Auth API drift as a precise null rather than a
+// `TypeError` at click time. Wire shapes (`AuthApiResult`, `Passkey`,
+// `PasskeySignIn`) live in `./wire-types` so the helpers and this boundary
+// reference identical types.
 type OrgResult<T> = { data: T | null; error: { message: string } | null };
-
-interface PasskeyShape {
-  id: string;
-  name?: string;
-  createdAt: Date | string;
-}
 
 type OrgClient = typeof _authClient & {
   // Better Auth core — present at runtime, lost through plugin chain.
   updateUser?: (opts: { name?: string }) => Promise<{ error?: { message?: string } | null }>;
 
-  // organizationClient — typed manually since TS6 inference loses it.
+  // organizationClient — typed manually since the chain inference loses it.
   organization: {
     create: (opts: { name: string; slug: string; logo?: string }) => Promise<OrgResult<{ id: string }>>;
     list: () => Promise<OrgResult<{ id: string; name: string; slug: string; logo?: string | null }[]>>;
@@ -121,25 +114,22 @@ type OrgClient = typeof _authClient & {
     addPasskey?: (opts?: {
       name?: string;
       authenticatorAttachment?: "platform" | "cross-platform";
-    }) => Promise<AuthResult<PasskeyShape>>;
-    listUserPasskeys?: () => Promise<AuthResult<PasskeyShape[]>>;
-    updatePasskey?: (opts: { id: string; name: string }) => Promise<AuthResult<{ passkey: PasskeyShape }>>;
-    deletePasskey?: (opts: { id: string }) => Promise<AuthResult<{ status?: boolean }>>;
+    }) => Promise<AuthApiResult<Passkey>>;
+    listUserPasskeys?: () => Promise<AuthApiResult<Passkey[]>>;
+    updatePasskey?: (opts: { id: string; name: string }) => Promise<AuthApiResult<{ passkey: Passkey }>>;
+    deletePasskey?: (opts: { id: string }) => Promise<AuthApiResult<{ status?: boolean }>>;
   };
   signIn: (typeof _authClient)["signIn"] & {
-    passkey?: (opts?: { autoFill?: boolean }) => Promise<AuthResult<{
-      session: Record<string, unknown>;
-      user: Record<string, unknown>;
-    }>>;
+    passkey?: PasskeySignIn;
   };
 
   // twoFactorClient — TOTP + backup codes.
   twoFactor?: {
-    enable?: (opts: { password: string }) => Promise<AuthResult<{ totpURI: string; backupCodes: string[] }>>;
-    disable?: (opts: { password: string }) => Promise<AuthResult<{ status?: boolean }>>;
-    verifyTotp?: (opts: { code: string; trustDevice?: boolean }) => Promise<AuthResult<{ token?: string }>>;
-    verifyBackupCode?: (opts: { code: string; trustDevice?: boolean }) => Promise<AuthResult<{ token?: string }>>;
-    generateBackupCodes?: (opts: { password: string }) => Promise<AuthResult<{ backupCodes: string[] }>>;
+    enable?: (opts: { password: string }) => Promise<AuthApiResult<{ totpURI: string; backupCodes: string[] }>>;
+    disable?: (opts: { password: string }) => Promise<AuthApiResult<{ status?: boolean }>>;
+    verifyTotp?: (opts: { code: string; trustDevice?: boolean }) => Promise<AuthApiResult<{ token?: string }>>;
+    verifyBackupCode?: (opts: { code: string; trustDevice?: boolean }) => Promise<AuthApiResult<{ token?: string }>>;
+    generateBackupCodes?: (opts: { password: string }) => Promise<AuthApiResult<{ backupCodes: string[] }>>;
   };
 
   // oauthProviderClient — `oauth2.consent` resolves the consent screen.
@@ -152,8 +142,8 @@ type OrgClient = typeof _authClient & {
 
   // emailOTPClient — verify + resend used by post-signup interstitial.
   emailOtp?: {
-    verifyEmail: (opts: { email: string; otp: string }) => Promise<AuthResult<unknown>>;
-    sendVerificationOtp: (opts: { email: string; type: "email-verification" }) => Promise<AuthResult<unknown>>;
+    verifyEmail: (opts: { email: string; otp: string }) => Promise<AuthApiResult<unknown>>;
+    sendVerificationOtp: (opts: { email: string; type: "email-verification" }) => Promise<AuthApiResult<unknown>>;
   };
 };
 export const authClient: OrgClient = _authClient as OrgClient;

--- a/packages/web/src/lib/auth/client.ts
+++ b/packages/web/src/lib/auth/client.ts
@@ -85,14 +85,75 @@ const _authClient = createAuthClient({
   fetchOptions: isCrossOrigin() ? { credentials: "include" as RequestCredentials } : {},
 });
 
-// TS6 fails to infer organizationClient plugin types through createAuthClient.
-// Re-export with the organization namespace explicitly typed.
+// TS6 fails to infer plugin types through createAuthClient — the wrapped
+// client erases each plugin's namespace contribution. The fix is a one-time
+// intersection at the export boundary so every consumer reads a typed
+// surface instead of writing `(authClient as unknown as { ... })` per call.
+//
+// Each namespace is declared `Partial`-ish (optional methods + optional
+// namespace) so the runtime presence guards in `lib/auth/{passkey,
+// two-factor}-client.ts` and `ui/components/auth/verify-email-otp-form.tsx`
+// keep surfacing Better Auth API drift as a precise null rather than
+// `TypeError: addPasskey is not a function` at click time.
+type AuthResult<T> = { data: T | null; error: { message?: string; code?: string } | null };
 type OrgResult<T> = { data: T | null; error: { message: string } | null };
+
+interface PasskeyShape {
+  id: string;
+  name?: string;
+  createdAt: Date | string;
+}
+
 type OrgClient = typeof _authClient & {
+  // Better Auth core — present at runtime, lost through plugin chain.
+  updateUser?: (opts: { name?: string }) => Promise<{ error?: { message?: string } | null }>;
+
+  // organizationClient — typed manually since TS6 inference loses it.
   organization: {
     create: (opts: { name: string; slug: string; logo?: string }) => Promise<OrgResult<{ id: string }>>;
     list: () => Promise<OrgResult<{ id: string; name: string; slug: string; logo?: string | null }[]>>;
     setActive: (opts: { organizationId: string }) => Promise<OrgResult<Record<string, unknown>>>;
+  };
+
+  // passkeyClient — enrollment lives under `passkey.*`; sign-in lives
+  // under `signIn.passkey` (declared on the signIn intersection below).
+  passkey?: {
+    addPasskey?: (opts?: {
+      name?: string;
+      authenticatorAttachment?: "platform" | "cross-platform";
+    }) => Promise<AuthResult<PasskeyShape>>;
+    listUserPasskeys?: () => Promise<AuthResult<PasskeyShape[]>>;
+    updatePasskey?: (opts: { id: string; name: string }) => Promise<AuthResult<{ passkey: PasskeyShape }>>;
+    deletePasskey?: (opts: { id: string }) => Promise<AuthResult<{ status?: boolean }>>;
+  };
+  signIn: (typeof _authClient)["signIn"] & {
+    passkey?: (opts?: { autoFill?: boolean }) => Promise<AuthResult<{
+      session: Record<string, unknown>;
+      user: Record<string, unknown>;
+    }>>;
+  };
+
+  // twoFactorClient — TOTP + backup codes.
+  twoFactor?: {
+    enable?: (opts: { password: string }) => Promise<AuthResult<{ totpURI: string; backupCodes: string[] }>>;
+    disable?: (opts: { password: string }) => Promise<AuthResult<{ status?: boolean }>>;
+    verifyTotp?: (opts: { code: string; trustDevice?: boolean }) => Promise<AuthResult<{ token?: string }>>;
+    verifyBackupCode?: (opts: { code: string; trustDevice?: boolean }) => Promise<AuthResult<{ token?: string }>>;
+    generateBackupCodes?: (opts: { password: string }) => Promise<AuthResult<{ backupCodes: string[] }>>;
+  };
+
+  // oauthProviderClient — `oauth2.consent` resolves the consent screen.
+  oauth2?: {
+    consent: (opts: { accept: boolean; scope?: string }) => Promise<{
+      data?: { redirectURI?: string };
+      error?: { message?: string };
+    } | undefined>;
+  };
+
+  // emailOTPClient — verify + resend used by post-signup interstitial.
+  emailOtp?: {
+    verifyEmail: (opts: { email: string; otp: string }) => Promise<AuthResult<unknown>>;
+    sendVerificationOtp: (opts: { email: string; type: "email-verification" }) => Promise<AuthResult<unknown>>;
   };
 };
 export const authClient: OrgClient = _authClient as OrgClient;

--- a/packages/web/src/lib/auth/passkey-client.ts
+++ b/packages/web/src/lib/auth/passkey-client.ts
@@ -1,95 +1,29 @@
 /**
- * Shared narrow view onto the Better Auth passkey client surface.
- *
- * `createAuthClient`'s plugin-augmented type doesn't surface
- * `passkey.{addPasskey,listUserPasskeys,deletePasskey,updatePasskey}` or
- * `signIn.passkey()` through the generic chain under TS6 strictness, so
- * consumers cast through `unknown`. Centralising the cast plus the runtime
- * guard here keeps the security-page components and the login flow honest
- * about which methods they depend on.
- *
- * The guards return `null` when the plugin isn't loaded; callers decide
- * whether that is a soft "refresh the page" banner or a thrown error.
- * The user-visible message stays in the consumer — never include
- * developer paths in `Error` messages that bubble up to end users.
- *
- * `PasskeyClient` and `PasskeySignIn` are intentionally split: Better Auth
- * mounts enrollment endpoints under `passkey.*` and sign-in under
- * `signIn.passkey`, and a future namespace shuffle on either side must
- * not dark-mode the other surface.
+ * Resolves Better Auth's `passkey.*` enrollment surface and the
+ * `signIn.passkey()` action. The two are split because Better Auth mounts
+ * enrollment under `passkey.*` and sign-in under `signIn.passkey` — a
+ * future namespace shuffle on either side must not dark-mode the other
+ * surface. Resolvers return `null` when the plugin isn't loaded so
+ * callers can decide between a "refresh the page" banner and a thrown
+ * error; user-visible copy stays in the consumer.
  */
 
 import { authClient } from "./client";
+import type { AuthApiResult, Passkey, PasskeySignIn } from "./wire-types";
 
-// ---------------------------------------------------------------------------
-// Wire shapes — match Better Auth's actual return contract
-// ---------------------------------------------------------------------------
-
-export interface PasskeyApiError {
-  message?: string;
-  code?: string;
-  status?: number;
-}
-
-export type PasskeyApiResult<T> = {
-  data: T | null;
-  error: PasskeyApiError | null;
-};
-
-export interface Passkey {
-  id: string;
-  name?: string;
-  createdAt: Date | string;
-}
-
-/**
- * The `signIn.passkey()` success envelope. Better Auth populates `data` with
- * `{ session, user }` once the WebAuthn assertion verifies; we narrow to
- * `Record<string, unknown>` because the page only needs to know the call
- * succeeded — routing decisions stay in the page itself.
- */
-export interface PasskeySignInData {
-  session: Record<string, unknown>;
-  user: Record<string, unknown>;
-}
+export type { AuthApiError as PasskeyApiError, AuthApiResult as PasskeyApiResult, Passkey, PasskeySignIn, PasskeySignInData } from "./wire-types";
 
 export interface PasskeyClient {
   addPasskey: (opts?: {
     name?: string;
     authenticatorAttachment?: "platform" | "cross-platform";
-  }) => Promise<PasskeyApiResult<Passkey>>;
-  listUserPasskeys: () => Promise<PasskeyApiResult<Passkey[]>>;
-  updatePasskey: (opts: { id: string; name: string }) => Promise<PasskeyApiResult<{ passkey: Passkey }>>;
-  deletePasskey: (opts: { id: string }) => Promise<PasskeyApiResult<{ status?: boolean }>>;
+  }) => Promise<AuthApiResult<Passkey>>;
+  listUserPasskeys: () => Promise<AuthApiResult<Passkey[]>>;
+  updatePasskey: (opts: { id: string; name: string }) => Promise<AuthApiResult<{ passkey: Passkey }>>;
+  deletePasskey: (opts: { id: string }) => Promise<AuthApiResult<{ status?: boolean }>>;
 }
 
-/**
- * Initiates a passkey-first sign-in. With `autoFill: true` the call
- * subscribes the page to the OS conditional-UI picker rather than
- * triggering a modal prompt — pair it with an email input that has
- * `autocomplete="username webauthn"` so saved passkeys appear in the
- * autofill dropdown. Without `autoFill`, Better Auth fires the modal
- * authenticator prompt immediately (the "Sign in with passkey" CTA path).
- */
-export type PasskeySignIn = (opts?: {
-  autoFill?: boolean;
-}) => Promise<PasskeyApiResult<PasskeySignInData>>;
-
-/**
- * Resolve the `passkey` namespace from authClient. Returns `null` when
- * enrollment endpoints aren't loaded — the security page translates that
- * into a "refresh the page" banner. Independent of `getPasskeySignIn` so
- * a renamed `signIn.passkey` doesn't dark-mode admin enrollment.
- *
- * The runtime method-presence check catches Better Auth API drift — a
- * renamed method surfaces as a precise null rather than a
- * `TypeError: addPasskey is not a function` at click time.
- */
 export function getPasskeyClient(): PasskeyClient | null {
-  // `authClient.passkey` is typed at the export boundary in
-  // `lib/auth/client.ts` so the read is now compile-time safe; the runtime
-  // method-presence check still surfaces Better Auth API drift as a precise
-  // null rather than a `TypeError` at click time.
   const namespace = authClient.passkey;
   if (
     !namespace ||
@@ -103,16 +37,10 @@ export function getPasskeyClient(): PasskeyClient | null {
   return namespace as PasskeyClient;
 }
 
-/**
- * Resolve the `signIn.passkey()` action. Returns `null` when the plugin
- * isn't loaded — callers (login page, 2FA challenge page) translate that
- * into "passkey button hidden" rather than a hard error: a user without
- * the plugin still has email + password.
- */
 export function getPasskeySignIn(): PasskeySignIn | null {
   const passkeySignIn = authClient.signIn.passkey;
   if (typeof passkeySignIn !== "function") {
     return null;
   }
-  return passkeySignIn as PasskeySignIn;
+  return passkeySignIn;
 }

--- a/packages/web/src/lib/auth/passkey-client.ts
+++ b/packages/web/src/lib/auth/passkey-client.ts
@@ -86,11 +86,11 @@ export type PasskeySignIn = (opts?: {
  * `TypeError: addPasskey is not a function` at click time.
  */
 export function getPasskeyClient(): PasskeyClient | null {
-  // The cast is the documented workaround for Better Auth's plugin-inference
-  // gap under TS6. Same pattern as `getTwoFactorClient()` in
-  // `lib/auth/two-factor-client.ts` and the `@ts-expect-error` on
-  // `apiKeyClient()` in `client.ts`.
-  const namespace = (authClient as unknown as { passkey?: Partial<PasskeyClient> }).passkey;
+  // `authClient.passkey` is typed at the export boundary in
+  // `lib/auth/client.ts` so the read is now compile-time safe; the runtime
+  // method-presence check still surfaces Better Auth API drift as a precise
+  // null rather than a `TypeError` at click time.
+  const namespace = authClient.passkey;
   if (
     !namespace ||
     typeof namespace.addPasskey !== "function" ||
@@ -110,11 +110,9 @@ export function getPasskeyClient(): PasskeyClient | null {
  * the plugin still has email + password.
  */
 export function getPasskeySignIn(): PasskeySignIn | null {
-  const signInNamespace = (
-    authClient as unknown as { signIn?: { passkey?: PasskeySignIn } }
-  ).signIn;
-  if (!signInNamespace || typeof signInNamespace.passkey !== "function") {
+  const passkeySignIn = authClient.signIn.passkey;
+  if (typeof passkeySignIn !== "function") {
     return null;
   }
-  return signInNamespace.passkey;
+  return passkeySignIn as PasskeySignIn;
 }

--- a/packages/web/src/lib/auth/two-factor-client.ts
+++ b/packages/web/src/lib/auth/two-factor-client.ts
@@ -56,9 +56,6 @@ export interface TwoFactorClient {
  * catches Better Auth API drift at the boundary.
  */
 export function getTwoFactorClient(): TwoFactorClient | null {
-  // `authClient.twoFactor` is typed at the export boundary in
-  // `lib/auth/client.ts`; the runtime guard still catches Better Auth
-  // method renames at the boundary.
   const namespace = authClient.twoFactor;
   if (
     !namespace ||

--- a/packages/web/src/lib/auth/two-factor-client.ts
+++ b/packages/web/src/lib/auth/two-factor-client.ts
@@ -56,8 +56,10 @@ export interface TwoFactorClient {
  * catches Better Auth API drift at the boundary.
  */
 export function getTwoFactorClient(): TwoFactorClient | null {
-  const namespace = (authClient as unknown as { twoFactor?: Partial<TwoFactorClient> })
-    .twoFactor;
+  // `authClient.twoFactor` is typed at the export boundary in
+  // `lib/auth/client.ts`; the runtime guard still catches Better Auth
+  // method renames at the boundary.
+  const namespace = authClient.twoFactor;
   if (
     !namespace ||
     typeof namespace.enable !== "function" ||

--- a/packages/web/src/lib/auth/wire-types.ts
+++ b/packages/web/src/lib/auth/wire-types.ts
@@ -1,0 +1,36 @@
+/**
+ * Wire-shape contracts for Better Auth plugin namespaces, defined once so
+ * the boundary type in `client.ts` and the per-plugin helpers
+ * (`passkey-client.ts`, `two-factor-client.ts`) reference the same return
+ * shapes. Without this file the boundary type and the helper-local types
+ * drift, which forces `as PasskeyClient` / `as PasskeySignIn` casts at
+ * the helper return statements.
+ */
+
+export interface AuthApiError {
+  message?: string;
+  code?: string;
+  status?: number;
+}
+
+export type AuthApiResult<T> = {
+  data: T | null;
+  error: AuthApiError | null;
+};
+
+// ── passkey ────────────────────────────────────────────────────────────
+
+export interface Passkey {
+  id: string;
+  name?: string;
+  createdAt: Date | string;
+}
+
+export interface PasskeySignInData {
+  session: Record<string, unknown>;
+  user: Record<string, unknown>;
+}
+
+export type PasskeySignIn = (opts?: {
+  autoFill?: boolean;
+}) => Promise<AuthApiResult<PasskeySignInData>>;

--- a/packages/web/src/ui/components/auth/verify-email-otp-form.tsx
+++ b/packages/web/src/ui/components/auth/verify-email-otp-form.tsx
@@ -45,9 +45,6 @@ export function VerifyEmailOTPForm({ email, onVerified }: VerifyEmailOTPFormProp
     setSubmitting(true);
     setError(null);
     try {
-      // `authClient.emailOtp` is typed at the export boundary in
-      // `lib/auth/client.ts`. Runtime presence guard catches Better Auth
-      // method renames at the boundary.
       const verifyEmail = authClient.emailOtp?.verifyEmail;
       if (typeof verifyEmail !== "function") {
         throw new Error("emailOtp.verifyEmail action not available on this client");

--- a/packages/web/src/ui/components/auth/verify-email-otp-form.tsx
+++ b/packages/web/src/ui/components/auth/verify-email-otp-form.tsx
@@ -45,21 +45,10 @@ export function VerifyEmailOTPForm({ email, onVerified }: VerifyEmailOTPFormProp
     setSubmitting(true);
     setError(null);
     try {
-      // The cast is the documented workaround for Better Auth's
-      // plugin-augmented client type — `emailOtp` is added at runtime by
-      // emailOTPClient() but TS6 strictness loses it through the plugin
-      // chain. Same pattern as `getPasskeyClient()` in
-      // lib/auth/passkey-client.ts.
-      const verifyEmail = (
-        authClient as unknown as {
-          emailOtp?: {
-            verifyEmail: (opts: { email: string; otp: string }) => Promise<{
-              data: unknown;
-              error: { message?: string; code?: string } | null;
-            }>;
-          };
-        }
-      ).emailOtp?.verifyEmail;
+      // `authClient.emailOtp` is typed at the export boundary in
+      // `lib/auth/client.ts`. Runtime presence guard catches Better Auth
+      // method renames at the boundary.
+      const verifyEmail = authClient.emailOtp?.verifyEmail;
       if (typeof verifyEmail !== "function") {
         throw new Error("emailOtp.verifyEmail action not available on this client");
       }
@@ -95,19 +84,7 @@ export function VerifyEmailOTPForm({ email, onVerified }: VerifyEmailOTPFormProp
     setResendState("sending");
     setError(null);
     try {
-      const send = (
-        authClient as unknown as {
-          emailOtp?: {
-            sendVerificationOtp: (opts: {
-              email: string;
-              type: "email-verification";
-            }) => Promise<{
-              data: unknown;
-              error: { message?: string } | null;
-            }>;
-          };
-        }
-      ).emailOtp?.sendVerificationOtp;
+      const send = authClient.emailOtp?.sendVerificationOtp;
       if (typeof send !== "function") {
         throw new Error("emailOtp.sendVerificationOtp not available on this client");
       }

--- a/packages/web/src/ui/components/settings/identity-section.tsx
+++ b/packages/web/src/ui/components/settings/identity-section.tsx
@@ -56,9 +56,6 @@ export function IdentitySection() {
     setError(null);
     setSavedAt(null);
     try {
-      // `authClient.updateUser` is typed at the export boundary in
-      // `lib/auth/client.ts`; it's optional because the inferred plugin
-      // chain doesn't carry the core `updateUser` action.
       const updateUser = authClient.updateUser;
       if (typeof updateUser !== "function") {
         setError("Profile updates are unavailable. Refresh the page and try again.");

--- a/packages/web/src/ui/components/settings/identity-section.tsx
+++ b/packages/web/src/ui/components/settings/identity-section.tsx
@@ -17,11 +17,6 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { SectionHeading } from "@/ui/components/admin/compact";
 
-interface UpdateUserResult {
-  data?: unknown;
-  error?: { message?: string } | null;
-}
-
 export function IdentitySection() {
   const session = authClient.useSession();
   const user = session.data?.user as
@@ -61,13 +56,14 @@ export function IdentitySection() {
     setError(null);
     setSavedAt(null);
     try {
-      // Cast: `updateUser` exists on Better Auth's client but isn't on
-      // AtlasAuthClient's duck-typed surface and the plugin-wrapped client
-      // erases the inferred shape.
-      const updateUser = (authClient as unknown as {
-        updateUser: (opts: { name: string }) => Promise<UpdateUserResult>;
-      }).updateUser;
-
+      // `authClient.updateUser` is typed at the export boundary in
+      // `lib/auth/client.ts`; it's optional because the inferred plugin
+      // chain doesn't carry the core `updateUser` action.
+      const updateUser = authClient.updateUser;
+      if (typeof updateUser !== "function") {
+        setError("Profile updates are unavailable. Refresh the page and try again.");
+        return;
+      }
       const result = await updateUser({ name: trimmed });
       if (result.error) {
         setError(result.error.message ?? "Failed to update name.");


### PR DESCRIPTION
Partially closes #2262 (5 of 7 sites; remaining 2 deferred to a follow-up).

## Summary
- Extend `OrgClient` in `packages/web/src/lib/auth/client.ts` with the plugin namespaces TS6 strictness loses through `createAuthClient`'s plugin chain: `updateUser`, `passkey`, `signIn.passkey`, `twoFactor`, `oauth2`, `emailOtp`. Same pattern already used for `organization` — declare the shape once at the export boundary, read it as a typed property everywhere else.
- Remove 7 `(authClient as unknown as { ... })` casts across `passkey-client.ts` (2), `two-factor-client.ts` (1), `oauth2/consent/page.tsx` (1), `verify-email-otp-form.tsx` (2), `identity-section.tsx` (1).
- Runtime presence guards (`getPasskeyClient`, `getTwoFactorClient`, inline guards in the email-OTP form and consent page) stay in place so Better Auth API drift still surfaces as a precise null rather than a `TypeError` at click time.

## Out of scope (follow-up)
The two remaining sites flagged in #2262 — `app/admin/settings/page.tsx:466` (`WorkspaceIdentitySection`) and `ui/components/org-switcher.tsx` — cast `session.data?.session` (not `authClient`) to read `activeOrganization*` fields stamped by Better Auth's `session.fields` runtime config. Augmenting `useSession()`'s inferred return type is a separate effort. Tracked in a follow-up issue.

## Test plan
- [x] `bun run lint`
- [x] `bun run type` (type-level correctness is the test for cast removal)
- [x] `bun run test` (full suite, regression check)
- [x] `bun x syncpack lint`, template drift, railway-watch
- [x] No `@useatlas/types` change — entirely scoped to `@atlas/web`, no version bump needed