### PR TITLE
fix(web): rail polish — collapse trigger, hover scoping, merged identity row

### DIFF
--- a/packages/web/src/ui/__tests__/chat-sidebar.test.tsx
+++ b/packages/web/src/ui/__tests__/chat-sidebar.test.tsx
@@ -43,13 +43,9 @@ mock.module("@/ui/components/conversations/conversation-list", () => ({
     ),
 }));
 
-mock.module("@/ui/components/org-switcher", () => ({
-  OrgSwitcher: () =>
-    React.createElement("div", { "data-testid": "org-switcher" }),
-}));
-
-mock.module("@/ui/components/user-menu", () => ({
-  UserMenu: () => React.createElement("div", { "data-testid": "user-menu" }),
+mock.module("@/ui/components/chat/sidebar-user-menu", () => ({
+  SidebarUserMenu: () =>
+    React.createElement("div", { "data-testid": "sidebar-user-menu" }),
 }));
 
 mock.module("@/ui/components/demo-indicator-chip", () => ({

--- a/packages/web/src/ui/components/chat/chat-sidebar.tsx
+++ b/packages/web/src/ui/components/chat/chat-sidebar.tsx
@@ -25,16 +25,15 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarRail,
+  SidebarTrigger,
   useSidebar,
 } from "@/components/ui/sidebar";
-import { Button } from "@/components/ui/button";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { ConversationList } from "@/ui/components/conversations/conversation-list";
-import { OrgSwitcher } from "@/ui/components/org-switcher";
-import { UserMenu } from "@/ui/components/user-menu";
+import { SidebarUserMenu } from "./sidebar-user-menu";
 import { DemoIndicatorChip } from "@/ui/components/demo-indicator-chip";
 import { PALETTE_EVENT } from "./palette-events";
 import type { Conversation } from "@/ui/lib/types";
@@ -105,53 +104,46 @@ export function ChatSidebar({
   return (
     <Sidebar collapsible="icon">
       <SidebarHeader>
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <SidebarMenuButton size="lg" asChild tooltip="Atlas home">
-              <Link href="/" aria-label="Atlas home">
-                <div className="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center rounded-lg">
-                  <svg
-                    viewBox="0 0 256 256"
-                    fill="none"
-                    className="size-4"
-                    aria-hidden="true"
-                  >
-                    <path
-                      d="M128 24 L232 208 L24 208 Z"
-                      stroke="currentColor"
-                      strokeWidth="20"
+        <div className="flex items-center gap-1">
+          <SidebarMenu className="min-w-0 flex-1">
+            <SidebarMenuItem>
+              <SidebarMenuButton size="lg" asChild tooltip="Atlas home">
+                <Link href="/" aria-label="Atlas home">
+                  <div className="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center rounded-lg">
+                    <svg
+                      viewBox="0 0 256 256"
                       fill="none"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                </div>
-                <div className="flex min-w-0 flex-1 flex-col gap-0.5 text-sm leading-tight">
-                  <span className="truncate font-semibold">Atlas</span>
-                </div>
-              </Link>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-        </SidebarMenu>
-        <div className="px-1 group-data-[collapsible=icon]:hidden">
-          <OrgSwitcher variant="inline" />
+                      className="size-4"
+                      aria-hidden="true"
+                    >
+                      <path
+                        d="M128 24 L232 208 L24 208 Z"
+                        stroke="currentColor"
+                        strokeWidth="20"
+                        fill="none"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  </div>
+                  <div className="flex min-w-0 flex-1 flex-col gap-0.5 text-sm leading-tight">
+                    <span className="truncate font-semibold">Atlas</span>
+                  </div>
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+          <SidebarTrigger
+            aria-label="Collapse sidebar"
+            className="shrink-0 group-data-[collapsible=icon]:hidden"
+          />
         </div>
       </SidebarHeader>
 
       <SidebarContent>
         <SidebarGroup>
           <SidebarGroupContent>
-            <div className="px-2 pb-1 group-data-[collapsible=icon]:hidden">
-              <Button
-                onClick={onNewChat}
-                size="sm"
-                className="h-9 w-full justify-start gap-2 font-medium"
-              >
-                <Plus className="size-4" />
-                New conversation
-              </Button>
-            </div>
             <SidebarMenu>
-              <SidebarMenuItem className="hidden group-data-[collapsible=icon]:block">
+              <SidebarMenuItem>
                 <SidebarMenuButton
                   onClick={onNewChat}
                   tooltip="New conversation"
@@ -299,9 +291,11 @@ export function ChatSidebar({
             </SidebarMenuItem>
           )}
         </SidebarMenu>
-        <div className="flex items-center gap-2 px-2 py-1.5 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0">
-          <UserMenu />
-        </div>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarUserMenu />
+          </SidebarMenuItem>
+        </SidebarMenu>
       </SidebarFooter>
       <SidebarRail />
     </Sidebar>

--- a/packages/web/src/ui/components/chat/sidebar-user-menu.tsx
+++ b/packages/web/src/ui/components/chat/sidebar-user-menu.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { toast } from "sonner";
+import {
+  Check,
+  ChevronsUpDown,
+  LogOut,
+  Monitor,
+  Moon,
+  Sun,
+  User,
+} from "lucide-react";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { SidebarMenuButton, useSidebar } from "@/components/ui/sidebar";
+import { authClient } from "@/lib/auth/client";
+import { deriveInitials } from "@/ui/components/user-menu";
+import { setTheme, useThemeMode, type ThemeMode } from "@/ui/hooks/use-dark-mode";
+
+interface OrgOption {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+const THEME_OPTIONS = [
+  { value: "light", label: "Light", icon: Sun },
+  { value: "dark", label: "Dark", icon: Moon },
+  { value: "system", label: "System", icon: Monitor },
+] as const satisfies readonly { value: ThemeMode; label: string; icon: typeof Sun }[];
+
+// Claude-style combined identity row: avatar + name + active-org subtitle in
+// one SidebarMenuButton, with org switching + user actions inside a single
+// dropdown. Replaces the split OrgSwitcher (header) + UserMenu (footer)
+// in the chat-surface sidebar only — the standalone components are still
+// used by /settings, /admin top bar, and the embeddable <AtlasChat>.
+export function SidebarUserMenu() {
+  const session = authClient.useSession();
+  const themeMode = useThemeMode();
+  const { isMobile } = useSidebar();
+  const [orgs, setOrgs] = useState<OrgOption[]>([]);
+  const [orgsLoading, setOrgsLoading] = useState(true);
+  const [signingOut, setSigningOut] = useState(false);
+
+  const user = session.data?.user;
+  const sessionExtra = session.data?.session as
+    | { activeOrganizationId?: string; activeOrganizationName?: string }
+    | undefined;
+  const activeOrgId = sessionExtra?.activeOrganizationId;
+
+  useEffect(() => {
+    if (!user) return;
+    let cancelled = false;
+    authClient.organization
+      .list()
+      .then((res) => {
+        if (!cancelled && res.data) setOrgs(res.data as OrgOption[]);
+      })
+      .catch((err) => {
+        console.error("Failed to load organizations:", err);
+      })
+      .finally(() => {
+        if (!cancelled) setOrgsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
+  if (!user) return null;
+
+  const name = user.name ?? null;
+  const email = user.email ?? null;
+  const initials = deriveInitials(name, email);
+  const activeOrg = orgs.find((o) => o.id === activeOrgId);
+  const orgName = activeOrg?.name ?? sessionExtra?.activeOrganizationName ?? null;
+  const canSwitch = orgs.length > 1;
+  const subtitle = orgName ?? email ?? null;
+
+  async function handleSignOut() {
+    if (signingOut) return;
+    setSigningOut(true);
+    try {
+      await authClient.signOut();
+      window.location.assign("/login");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error("Sign out failed:", message);
+      toast.error("Sign out failed. Try again.");
+      setSigningOut(false);
+    }
+  }
+
+  async function switchOrg(orgId: string) {
+    try {
+      await authClient.organization.setActive({ organizationId: orgId });
+      window.location.reload();
+    } catch (err) {
+      console.error("Failed to switch organization:", err);
+      toast.error("Failed to switch organization. Try again.");
+    }
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <SidebarMenuButton
+          size="lg"
+          tooltip={name ?? email ?? "Account"}
+          className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+        >
+          <Avatar className="size-8 shrink-0 rounded-lg">
+            <AvatarFallback className="rounded-lg bg-primary/10 text-[11px] font-semibold text-primary">
+              {initials}
+            </AvatarFallback>
+          </Avatar>
+          <div className="grid min-w-0 flex-1 text-left text-sm leading-tight group-data-[collapsible=icon]:hidden">
+            <span className="truncate font-medium">{name ?? "Signed in"}</span>
+            {subtitle && (
+              <span className="truncate text-xs text-muted-foreground">
+                {subtitle}
+              </span>
+            )}
+          </div>
+          <ChevronsUpDown className="ml-auto size-4 opacity-50 group-data-[collapsible=icon]:hidden" />
+        </SidebarMenuButton>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        side={isMobile ? "bottom" : "right"}
+        align="end"
+        sideOffset={8}
+        className="w-56"
+      >
+        <DropdownMenuLabel className="flex flex-col gap-0.5">
+          {name && <span className="truncate text-sm font-medium">{name}</span>}
+          {email && (
+            <span className="truncate text-xs font-normal text-muted-foreground">
+              {email}
+            </span>
+          )}
+          {!name && !email && <span className="text-sm">Signed in</span>}
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          <DropdownMenuItem asChild>
+            <Link href="/settings/profile">
+              <User className="mr-2 size-4" />
+              <span>Profile</span>
+            </Link>
+          </DropdownMenuItem>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              {themeMode === "dark" ? (
+                <Moon className="mr-2 size-4" />
+              ) : themeMode === "light" ? (
+                <Sun className="mr-2 size-4" />
+              ) : (
+                <Monitor className="mr-2 size-4" />
+              )}
+              <span>Theme</span>
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              {THEME_OPTIONS.map(({ value, label, icon: Icon }) => (
+                <DropdownMenuItem
+                  key={value}
+                  onClick={() => setTheme(value)}
+                  className={themeMode === value ? "bg-accent" : ""}
+                >
+                  <Icon className="mr-2 size-4" />
+                  {label}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        </DropdownMenuGroup>
+        {!orgsLoading && canSwitch && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="text-xs font-medium text-muted-foreground">
+              Switch organization
+            </DropdownMenuLabel>
+            {orgs.map((org) => (
+              <DropdownMenuItem
+                key={org.id}
+                onClick={() => switchOrg(org.id)}
+                className="gap-2"
+              >
+                <div className="flex size-6 items-center justify-center rounded bg-primary/10 text-xs font-semibold">
+                  {org.name.charAt(0).toUpperCase()}
+                </div>
+                <span className="flex-1 truncate">{org.name}</span>
+                {org.id === activeOrgId && <Check className="size-4" />}
+              </DropdownMenuItem>
+            ))}
+          </>
+        )}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onClick={() => {
+            void handleSignOut();
+          }}
+          disabled={signingOut}
+        >
+          <LogOut className="mr-2 size-4" />
+          <span>{signingOut ? "Signing out…" : "Sign out"}</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/web/src/ui/components/conversations/conversation-item.tsx
+++ b/packages/web/src/ui/components/conversations/conversation-item.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type CSSProperties } from "react";
+import { useState } from "react";
 import { Loader2, NotebookPen, Star, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
@@ -84,121 +84,120 @@ export function ConversationItem({
 
   const convertToNotebook =
     onConvertToNotebook && conversation.surface !== "notebook" ? onConvertToNotebook : null;
-  // Title fades on its right edge to make room for absolutely-positioned action buttons.
-  // Width is set via CSS var (Tailwind's JIT can't see interpolated arbitrary values).
-  // Hover reveals trash + optional convert (~4.75rem / ~7rem); the star button
-  // is always laid out — only its visibility flips when the row isn't starred.
-  const hoverMaskW = convertToNotebook ? "7rem" : "4.75rem";
 
+  // Named group (`group/convo-item`) keeps hover scoped to this row. shadcn's
+  // <Sidebar> root has a bare `.group` class, so a plain `group-hover:` would
+  // trigger from anywhere inside the rail.
   return (
     <div
-      className={`group relative w-full rounded-lg transition-colors ${
+      className={cn(
+        "group/convo-item w-full rounded-lg transition-colors",
         isActive
           ? "bg-primary/10 ring-1 ring-inset ring-primary/30 dark:bg-primary/15 dark:ring-primary/40"
-          : "hover:bg-zinc-100 dark:hover:bg-zinc-800"
-      }`}
+          : "hover:bg-zinc-100 dark:hover:bg-zinc-800",
+      )}
     >
-      <button
-        type="button"
-        onClick={onSelect}
-        aria-current={isActive ? "page" : undefined}
-        className={`block w-full cursor-pointer rounded-lg px-3 py-2.5 text-left text-sm focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 ${
-          isActive
-            ? "text-zinc-900 dark:text-zinc-100"
-            : "text-zinc-700 dark:text-zinc-300"
-        }`}
-      >
-        <span
-          style={{ "--mask-w": hoverMaskW } as CSSProperties}
+      <div className="flex items-center">
+        <button
+          type="button"
+          onClick={onSelect}
+          aria-current={isActive ? "page" : undefined}
           className={cn(
-            "block truncate text-sm font-medium",
-            conversation.starred &&
-              "[mask-image:linear-gradient(to_right,black_calc(100%-2.25rem),transparent)]",
-            "group-hover:[mask-image:linear-gradient(to_right,black_calc(100%-var(--mask-w)),transparent)]",
+            "min-w-0 flex-1 cursor-pointer rounded-lg px-3 py-2.5 text-left text-sm focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50",
+            isActive
+              ? "text-zinc-900 dark:text-zinc-100"
+              : "text-zinc-700 dark:text-zinc-300",
           )}
         >
-          {conversation.title || "New conversation"}
-        </span>
-        <span className="block text-xs text-zinc-600 dark:text-zinc-400">
-          {relativeTime(conversation.updatedAt)}
-        </span>
-      </button>
+          <span className="block truncate text-sm font-medium">
+            {conversation.title || "New conversation"}
+          </span>
+          <span className="block text-xs text-zinc-600 dark:text-zinc-400">
+            {relativeTime(conversation.updatedAt)}
+          </span>
+        </button>
+        <div className="flex shrink-0 items-center gap-0.5 pr-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={async () => {
+              if (starPending) return;
+              setStarPending(true);
+              try {
+                await onStar(!conversation.starred);
+              } catch (err: unknown) {
+                console.warn("Failed to update star:", err instanceof Error ? err.message : String(err));
+                setError(`Couldn't update star — ${explainError(err)}.`);
+                setTimeout(() => setError(null), 4000);
+              } finally {
+                setStarPending(false);
+              }
+            }}
+            disabled={starPending}
+            className={cn(
+              "size-8 transition-opacity",
+              conversation.starred
+                ? "text-amber-400 opacity-100 hover:text-amber-500 dark:text-amber-400 dark:hover:text-amber-300"
+                : "text-zinc-400 opacity-100 hover:text-amber-400 md:opacity-0 md:group-hover/convo-item:opacity-100 dark:hover:text-amber-400",
+              starPending && "opacity-50",
+            )}
+            aria-label={conversation.starred ? "Unstar conversation" : "Star conversation"}
+          >
+            {starPending ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Star className="h-3.5 w-3.5" fill={conversation.starred ? "currentColor" : "none"} />
+            )}
+          </Button>
+          {convertToNotebook && (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={async () => {
+                if (converting) return;
+                setConverting(true);
+                try {
+                  const { id } = await convertToNotebook();
+                  router.push(`/notebook?id=${id}`);
+                } catch (err: unknown) {
+                  console.warn("Failed to convert to notebook:", err instanceof Error ? err.message : String(err));
+                  setError(`Couldn't convert — ${explainError(err)}.`);
+                  setTimeout(() => setError(null), 4000);
+                } finally {
+                  setConverting(false);
+                }
+              }}
+              disabled={converting}
+              className={cn(
+                "size-8 text-zinc-400 opacity-100 transition-opacity hover:text-zinc-600 md:opacity-0 md:group-hover/convo-item:opacity-100 dark:hover:text-zinc-300",
+                converting && "opacity-50",
+              )}
+              aria-label="Convert to notebook"
+            >
+              {converting ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <NotebookPen className="size-3.5" />
+              )}
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => setConfirmDelete(true)}
+            disabled={deleting}
+            className="size-8 shrink-0 text-zinc-400 opacity-100 transition-opacity hover:bg-red-50 hover:text-red-500 md:opacity-0 md:group-hover/convo-item:opacity-100 dark:hover:bg-red-950/20 dark:hover:text-red-400"
+            aria-label="Delete conversation"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </div>
       {error && (
         <p role="alert" className="px-3 pb-2 text-xs text-red-600 dark:text-red-400">
           {error}
         </p>
       )}
-      <div className="absolute right-1 top-1 flex items-center gap-0.5">
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={async () => {
-            if (starPending) return;
-            setStarPending(true);
-            try {
-              await onStar(!conversation.starred);
-            } catch (err: unknown) {
-              console.warn("Failed to update star:", err instanceof Error ? err.message : String(err));
-              setError(`Couldn't update star — ${explainError(err)}.`);
-              setTimeout(() => setError(null), 4000);
-            } finally {
-              setStarPending(false);
-            }
-          }}
-          disabled={starPending}
-          className={`size-8 transition-all ${
-            conversation.starred
-              ? "text-amber-400 opacity-100 hover:text-amber-500 dark:text-amber-400 dark:hover:text-amber-300"
-              : "text-zinc-400 opacity-100 md:opacity-0 hover:text-amber-400 md:group-hover:opacity-100 dark:hover:text-amber-400"
-          } ${starPending ? "opacity-50" : ""}`}
-          aria-label={conversation.starred ? "Unstar conversation" : "Star conversation"}
-        >
-          {starPending ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
-          ) : (
-            <Star className="h-3.5 w-3.5" fill={conversation.starred ? "currentColor" : "none"} />
-          )}
-        </Button>
-        {convertToNotebook && (
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={async () => {
-              if (converting) return;
-              setConverting(true);
-              try {
-                const { id } = await convertToNotebook();
-                router.push(`/notebook?id=${id}`);
-              } catch (err: unknown) {
-                console.warn("Failed to convert to notebook:", err instanceof Error ? err.message : String(err));
-                setError(`Couldn't convert — ${explainError(err)}.`);
-                setTimeout(() => setError(null), 4000);
-              } finally {
-                setConverting(false);
-              }
-            }}
-            disabled={converting}
-            className={`size-8 text-zinc-400 opacity-100 md:opacity-0 transition-all hover:text-zinc-600 md:group-hover:opacity-100 dark:hover:text-zinc-300 ${converting ? "opacity-50" : ""}`}
-            aria-label="Convert to notebook"
-          >
-            {converting ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <NotebookPen className="size-3.5" />
-            )}
-          </Button>
-        )}
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={() => setConfirmDelete(true)}
-          disabled={deleting}
-          className="size-8 shrink-0 text-zinc-400 opacity-100 md:opacity-0 transition-all hover:bg-red-50 hover:text-red-500 md:group-hover:opacity-100 dark:hover:bg-red-950/20 dark:hover:text-red-400"
-          aria-label="Delete conversation"
-        >
-          <Trash2 className="h-3.5 w-3.5" />
-        </Button>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Follow-up touchups to #2350 caught by `/polish` + `/critique`. No new issue — direct refinements on the rail that just landed.

**ChatSidebar**
- Add `<SidebarTrigger>` in the header next to the logo (rail had no explicit collapse action — only the easy-to-miss `<SidebarRail>` hover handle).
- Demote "New conversation" from a green primary `<Button>` to a regular `<SidebarMenuButton>` so it shares row style with Search and the Workspace section. The green CTA was a visual outlier; Claude's rail uses one uniform style across all rows.
- Collapse the split `OrgSwitcher` (header) + `UserMenu` (footer) into one Claude-style identity row at the bottom — avatar + name + active-org subtitle + chevron, dropdown contains profile / theme / org-switching (when multi-org) / sign out.

**SidebarUserMenu (new)**
- `packages/web/src/ui/components/chat/sidebar-user-menu.tsx`.
- Uses `SidebarMenuButton size="lg"` with `DropdownMenuTrigger`; tooltip in icon-collapsed mode; right-side dropdown on desktop, bottom on mobile (via `useSidebar().isMobile`).
- Org-switch section only renders when 2+ orgs (defensive — falls through cleanly on single-org workspaces).
- `OrgSwitcher` and `UserMenu` are intentionally untouched — still used by `/settings/layout`, `admin-top-bar`, and the embeddable `<AtlasChat>`. The merged shape is a vertical-rail pattern; the admin top bar is horizontal and keeps the split.

**ConversationItem**
- Hover scope fix: rename `group` → `group/convo-item` and `group-hover:` → `group-hover/convo-item:`. shadcn's `<Sidebar>` root has a bare `.group` class, so a plain `group-hover:` was triggering for every conversation row whenever the user hovered anywhere in the rail.
- Replace `absolute right-1 top-1` action container + `mask-image` title fade with an inline flex column. Icons no longer overlap text; layout is stable on hover. Mobile-always-visible preserved (`opacity-100 md:opacity-0 md:group-hover/convo-item:opacity-100`).

**Polish pass via Playwright**
- Found one real bug in the new identity row: in icon-collapsed mode the avatar overflowed the 32×32 button because the name/subtitle `<div>` and `<ChevronsUpDown>` were still in the flex layout. Hid both with `group-data-[collapsible=icon]:hidden`.
- Bumped avatar initials from `text-xs` (12px, 400) → `text-[11px] font-semibold` for legibility at the 32px size.

Refs #2350. Refs #2349.

## Test plan

- [ ] Expanded rail on `/`: `New conversation` + `Search` + Workspace rows share the same `SidebarMenuButton` style.
- [ ] Header `<SidebarTrigger>` collapses the rail; expanded state persists across reloads via `sidebar_state` cookie.
- [ ] Collapsed rail: every icon (logo, +, search, chat/notebook/dashboards, schema/prompt/admin, avatar) fits cleanly with no overflow.
- [ ] Hover on a conversation row reveals star/notebook/delete icons inline next to the title — does NOT trigger when hovering elsewhere in the rail.
- [ ] Hover icons don't overlap title text; star stays visible always when conversation is starred.
- [ ] Bottom identity row: avatar + name + org subtitle visible; dropdown opens with Profile / Theme / Sign out; multi-org workspaces show a "Switch organization" section.
- [ ] `/settings`, `/admin`, and embedded `<AtlasChat>` (`/demo`) still render their pre-existing `OrgSwitcher` / `UserMenu` (unchanged).
- [ ] Dark mode parity across the rail, dropdown, and identity row.
- [ ] Existing `chat-sidebar` tests pass (mock updated for new `sidebar-user-menu` module path).

## CI gates (local)

`lint`, `type`, `test` (full suite, 0 fail), `syncpack`, `template-drift`, `security-headers-drift`, `railway-watch`, `schema-drift`, `oauth-helper-drift` — all pass.