### PR TITLE
chore: clear 14 CodeQL unused-import/variable findings

### DIFF
--- a/e2e/browser/charts.spec.ts
+++ b/e2e/browser/charts.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { askQuestion, waitForSQLResult, ensureChatReady, startNewChat } from "./helpers";
+import { askQuestion, waitForSQLResult, ensureChatReady } from "./helpers";
 
 test.describe("Chat — Charts @llm", () => {
   // LLM responses take 60-120s via gateway; run serially to avoid overwhelming the API.

--- a/e2e/browser/global-setup.ts
+++ b/e2e/browser/global-setup.ts
@@ -1,4 +1,4 @@
-import { test as setup, expect } from "@playwright/test";
+import { test as setup } from "@playwright/test";
 import path from "path";
 
 const ADMIN_EMAIL = process.env.ATLAS_ADMIN_EMAIL ?? "admin@useatlas.dev";

--- a/e2e/browser/widget-starter-prompts.spec.ts
+++ b/e2e/browser/widget-starter-prompts.spec.ts
@@ -1,8 +1,5 @@
 import { test, expect } from "@playwright/test";
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-declare const window: any;
-
 const API_URL = process.env.ATLAS_API_URL ?? "http://localhost:3001";
 
 /**

--- a/e2e/surfaces/actions.test.ts
+++ b/e2e/surfaces/actions.test.ts
@@ -745,7 +745,6 @@ describe("E2E: Action framework", () => {
     // - So the auto path in handleAction is never triggered (always falls back to "manual")
     // TODO: Test auto-approval execution in a separate file with config mocked to return
     // actions: { defaults: { approval: "auto" } }
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     it.todo("auto-approval mode executes action immediately without separate approve", () => {});
   });
 

--- a/e2e/surfaces/agent-multistep.test.ts
+++ b/e2e/surfaces/agent-multistep.test.ts
@@ -23,7 +23,6 @@ import {
   it,
   expect,
   beforeEach,
-  afterAll,
   mock,
   type Mock,
 } from "bun:test";

--- a/e2e/surfaces/auth-managed.test.ts
+++ b/e2e/surfaces/auth-managed.test.ts
@@ -20,7 +20,6 @@ import {
   describe,
   it,
   expect,
-  beforeAll,
   beforeEach,
   afterAll,
   mock,

--- a/e2e/surfaces/error-scenarios.test.ts
+++ b/e2e/surfaces/error-scenarios.test.ts
@@ -18,7 +18,6 @@ import {
   it,
   expect,
   beforeEach,
-  afterAll,
   mock,
   type Mock,
 } from "bun:test";

--- a/e2e/surfaces/scheduler.test.ts
+++ b/e2e/surfaces/scheduler.test.ts
@@ -21,7 +21,6 @@ import {
 } from "bun:test";
 import {
   createMockServer,
-  createRoutedMockServer,
   type MockServer,
 } from "../helpers/mock-server";
 import { createConnectionMock } from "../../packages/api/src/__mocks__/connection";

--- a/packages/cli/lib/profilers/clickhouse.ts
+++ b/packages/cli/lib/profilers/clickhouse.ts
@@ -68,19 +68,6 @@ async function queryClickHousePrimaryKeys(
   return rows.map((r) => r.name);
 }
 
-/** Map ClickHouse native types to Atlas semantic types. */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- scaffolding for ClickHouse profiler
-function mapClickHouseType(chType: string): string {
-  const t = chType
-    .replace(/Nullable\((.+)\)/, "$1")
-    .replace(/LowCardinality\((.+)\)/, "$1")
-    .toLowerCase();
-  if (/^(u?int\d+|float\d+|decimal|numeric)/.test(t)) return "number";
-  if (/^(date|datetime)/.test(t)) return "date";
-  if (t.startsWith("bool")) return "boolean";
-  return "string";
-}
-
 export async function profileClickHouse(
   connectionString: string,
   filterTables?: string[],

--- a/plugins/chat/src/bridge.test.ts
+++ b/plugins/chat/src/bridge.test.ts
@@ -1018,7 +1018,6 @@ describe("chatPlugin Teams adapter config", () => {
 describe("createTeamsAdapter", () => {
   it("sets MultiTenant when no tenantId", async () => {
     const { createTeamsAdapter: createAdapter } = await import("./adapters/teams");
-    const { createTeamsAdapter: upstream } = await import("@chat-adapter/teams");
 
     // We can't easily inspect what was passed to the upstream, but we can
     // verify the adapter is created successfully and has the right name.

--- a/plugins/duckdb/src/connection.ts
+++ b/plugins/duckdb/src/connection.ts
@@ -57,7 +57,6 @@ export function createDuckDBConnection(
   async function getConnection() {
     if (!instancePromise) {
       instancePromise = (async () => {
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
         let DuckDBInstance: unknown;
         try {
           ({ DuckDBInstance } = require("@duckdb/node-api"));

--- a/plugins/email-digest/__tests__/email-digest.test.ts
+++ b/plugins/email-digest/__tests__/email-digest.test.ts
@@ -12,7 +12,6 @@ import {
   expect,
   mock,
   afterEach,
-  type Mock,
 } from "bun:test";
 import { Hono } from "hono";
 import { definePlugin, isInteractionPlugin } from "@useatlas/plugin-sdk";

--- a/plugins/email-digest/src/index.ts
+++ b/plugins/email-digest/src/index.ts
@@ -39,7 +39,7 @@ import type {
   PluginLogger,
 } from "@useatlas/plugin-sdk";
 import { EmailDigestConfigSchema } from "./config";
-import type { EmailDigestPluginConfig, MetricResult } from "./config";
+import type { EmailDigestPluginConfig } from "./config";
 
 // Re-export types for consumers
 export type { EmailDigestPluginConfig, MetricResult } from "./config";

--- a/plugins/mcp/__tests__/init/hosted.test.ts
+++ b/plugins/mcp/__tests__/init/hosted.test.ts
@@ -7,10 +7,9 @@
  * `defaultServeImpl` against a real Bun.serve port to pin the once-fired
  * listener guard.
  */
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import {
   chmodSync,
-  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,

--- a/plugins/nsjail/__tests__/nsjail-sandbox.test.ts
+++ b/plugins/nsjail/__tests__/nsjail-sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { describe, test, expect } from "bun:test";
 import { definePlugin, isSandboxPlugin } from "@useatlas/plugin-sdk";
 import {
   nsjailSandboxPlugin,

--- a/plugins/nsjail/__tests__/nsjail-sandbox.test.ts
+++ b/plugins/nsjail/__tests__/nsjail-sandbox.test.ts
@@ -5,7 +5,6 @@ import {
   buildNsjailSandboxPlugin,
   findNsjailBinary,
 } from "../src/index";
-import type { AtlasSandboxPlugin } from "@useatlas/plugin-sdk";
 
 // Zod defaults make timeLimitSec/memoryLimitMb required in the output type
 // but optional at runtime. Tests that rely on defaults use `as any`.

--- a/plugins/salesforce/src/index.ts
+++ b/plugins/salesforce/src/index.ts
@@ -27,7 +27,7 @@ import {
   extractHost,
 } from "./connection";
 import type { SalesforceConnection } from "./connection";
-import { validateSOQLStructure, SOQL_FORBIDDEN_PATTERNS } from "./validation";
+import { validateSOQLStructure } from "./validation";
 import { createQuerySalesforceTool } from "./tool";
 
 const SalesforceConfigSchema = z.object({

--- a/plugins/slack/__tests__/plugin.test.ts
+++ b/plugins/slack/__tests__/plugin.test.ts
@@ -132,7 +132,6 @@ function createMockCtx() {
 function createTestApp(config: SlackPluginConfig): Hono {
   const plugin = buildSlackPlugin(config);
   const app = new Hono();
-  const { ctx } = createMockCtx();
 
   // Simulate the host calling initialize + routes
   // We need to call initialize synchronously for the test setup,

--- a/plugins/teams/src/teams-client.ts
+++ b/plugins/teams/src/teams-client.ts
@@ -55,7 +55,7 @@ const tokenCache = new Map<string, { token: string; expiresAt: number }>();
 export async function getAccessToken(
   appId: string,
   appPassword: string,
-  log?: PluginLogger,
+  _log?: PluginLogger,
 ): Promise<string> {
   const cached = tokenCache.get(appId);
   if (cached && Date.now() < cached.expiresAt) {

--- a/plugins/vercel-sandbox/__tests__/vercel-sandbox.test.ts
+++ b/plugins/vercel-sandbox/__tests__/vercel-sandbox.test.ts
@@ -34,7 +34,6 @@ import {
   vercelSandboxPlugin,
   buildVercelSandboxPlugin,
   sandboxErrorDetail,
-  collectSemanticFiles,
 } from "../src/index";
 
 // ---------------------------------------------------------------------------

--- a/plugins/webhook/src/index.ts
+++ b/plugins/webhook/src/index.ts
@@ -39,7 +39,7 @@ import type {
   PluginLogger,
 } from "@useatlas/plugin-sdk";
 import { WebhookConfigSchema } from "./config";
-import type { WebhookPluginConfig, WebhookChannel, WebhookQueryResult } from "./config";
+import type { WebhookPluginConfig, WebhookChannel } from "./config";
 import { createWebhookRoutes } from "./routes";
 import type { WebhookRuntimeDeps } from "./routes";
 


### PR DESCRIPTION
## Summary
Cleans up all 14 open CodeQL js/unused-local-variable findings:

- **Unused test imports** (`beforeAll` / `afterAll` / `beforeEach` / `mock` / `expect` / `mkdirSync` / `createRoutedMockServer` / `startNewChat`) across `e2e/`, `plugins/mcp`, `plugins/nsjail`
- **Unused production import** `SOQL_FORBIDDEN_PATTERNS` in `plugins/salesforce/src/index.ts` (already re-exported on a separate line)
- **Unused destructures** `ctx` in `plugins/slack` `createTestApp` and `upstream` in `plugins/chat/src/bridge.test.ts` Teams adapter test
- **Unused import** `collectSemanticFiles` in `plugins/vercel-sandbox` (only referenced in a comment)
- **Dead scaffolding** `mapClickHouseType` in `packages/cli/lib/profilers/clickhouse.ts` (eslint-disabled to silence the warning rather than wired up)

Surgical edits — every removal verified with `grep` against the file to ensure no remaining reference. Pre-existing `bun run type` errors are unchanged (plugin-sdk dist build artifacts; reproducible on `main`).

## Test plan
- [ ] CodeQL re-scans clear on the security/quality page
- [ ] `ci` + `api-tests` shards green
- [ ] `Deploy Validation` green