### PR TITLE
test(api): lock down BYOT catalog L1↔L2 wiring (#2287)

### DIFF
--- a/packages/api/src/lib/__tests__/byot-catalog-l2-wiring.test.ts
+++ b/packages/api/src/lib/__tests__/byot-catalog-l2-wiring.test.ts
@@ -1,0 +1,379 @@
+/**
+ * L1↔L2 wiring contract for the BYOT discovery catalogs (#2287).
+ *
+ * Per-provider tests (`anthropic-catalog.test.ts`, `openai-catalog.test.ts`,
+ * `bedrock-catalog.test.ts`) don't mock `byot-catalog-store`, so the store
+ * silently no-ops in test runs (no internal DB → `hasInternalDB()` returns
+ * false). Store tests (`byot-catalog-store.test.ts`) mock `db/internal` but
+ * never thread through a per-provider catalog module. A regression that
+ * dropped `cache.set(orgId, …)` on the L2-hit branch, or skipped
+ * `storeToDB` on the upstream-fresh branch, would ship green under that
+ * split.
+ *
+ * This file closes that gap. It mocks the store module wholesale, observes
+ * `fetch` directly, and asserts the four wiring properties that matter:
+ *   1. Warm L2 → returns `source: "cache"` AND upstream is never called.
+ *   2. Warm L2 → L1 is populated (next call doesn't hit `loadFromDB`).
+ *   3. Stale L2 (`isFresh=false`) → upstream IS called AND L2 is rewritten.
+ *   4. Cold L2 (`loadFromDB → null`) → upstream IS called AND L2 is written.
+ *
+ * Anthropic is the representative — openai/bedrock are structural copies of
+ * the same control flow, so a single parallel smoke per provider keeps the
+ * regression surface honest without duplicating every case. The parallel
+ * imports also let `scripts/test-isolated.ts --affected` pick this file up
+ * when any of the four wired modules change.
+ *
+ * Passes locally with no internal DB configured: `byot-catalog-store` is
+ * mocked at module-load time, so the real `hasInternalDB()` is never
+ * consulted.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, mock } from "bun:test";
+import type { GatewayCatalogModel } from "@useatlas/types";
+import type { BedrockRegion } from "@useatlas/types";
+
+type FetchFn = typeof globalThis.fetch;
+const realFetch: FetchFn = globalThis.fetch;
+
+type StoredPayload = { models: GatewayCatalogModel[]; fetchedAt: string };
+type LoadResult = StoredPayload | null;
+
+// Per-test mutable state. The mock factory is sync (CLAUDE.md feedback:
+// async factories with inner awaits deadlock the bun loader), so we
+// forward into closure-captured variables instead.
+let loadFromDBResult: LoadResult = null;
+let isFreshResult = false;
+
+const loadFromDBSpy = mock(
+  async (_orgId: string, _provider: string, _region?: string): Promise<LoadResult> =>
+    loadFromDBResult,
+);
+const storeToDBSpy = mock(
+  async (
+    _orgId: string,
+    _provider: string,
+    _region: string,
+    _persisted: StoredPayload,
+  ): Promise<void> => {},
+);
+const deleteFromDBSpy = mock(
+  async (_orgId: string, _provider: string): Promise<void> => {},
+);
+const isFreshSpy = mock(
+  (_persisted: StoredPayload, _ttlMs: number): boolean => isFreshResult,
+);
+
+// Mock every named export of `byot-catalog-store` — partial-mock SyntaxError
+// trap from CLAUDE.md. The store is the only seam the per-provider catalogs
+// touch for L2, so this is the entire surface we need to control.
+mock.module("@atlas/api/lib/byot-catalog-store", () => ({
+  loadFromDB: loadFromDBSpy,
+  storeToDB: storeToDBSpy,
+  deleteFromDB: deleteFromDBSpy,
+  isFresh: isFreshSpy,
+}));
+
+// AWS SDK mock for the bedrock smoke. Bedrock doesn't go through `fetch`,
+// so we substitute the SDK client wholesale to observe upstream calls.
+let bedrockSendOutcome: { kind: "ok"; payload: { modelSummaries: unknown[] } } | null = null;
+const bedrockSendSpy = mock(async (_command: { $name: string }) => {
+  if (!bedrockSendOutcome) throw new Error("bedrock send mock outcome not configured");
+  return bedrockSendOutcome.payload;
+});
+
+class MockListFoundationModelsCommand {
+  readonly $name = "ListFoundationModelsCommand";
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mirrors AWS SDK v3 command surface
+  constructor(public readonly input: any) {}
+}
+
+class MockBedrockClient {
+  readonly region: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mirrors AWS SDK v3 BedrockClient constructor
+  constructor(opts: any) {
+    this.region = opts.region;
+  }
+  async send(command: MockListFoundationModelsCommand) {
+    return bedrockSendSpy(command);
+  }
+  destroy() {}
+}
+
+mock.module("@aws-sdk/client-bedrock", () => ({
+  BedrockClient: MockBedrockClient,
+  ListFoundationModelsCommand: MockListFoundationModelsCommand,
+}));
+
+const { __resetAnthropicCatalogCacheForTests, getAnthropicCatalog } = await import(
+  "../anthropic-catalog"
+);
+const { __resetOpenAICatalogCacheForTests, getOpenAICatalog } = await import(
+  "../openai-catalog"
+);
+const { __resetBedrockCatalogCacheForTests, getBedrockCatalog } = await import(
+  "../bedrock-catalog"
+);
+
+const ORG = "org_l2_wiring";
+const ANTHROPIC_KEY = "sk-ant-test-key";
+const OPENAI_KEY = "sk-openai-test-key";
+const BEDROCK_CREDS = { accessKeyId: "AKIA-TEST", secretAccessKey: "secret-test" };
+const BEDROCK_REGION: BedrockRegion = "us-east-1";
+
+// Stored "yesterday" so the wall-clock value can't accidentally satisfy a
+// real TTL window if the mock for `isFresh` ever gets bypassed.
+const PERSISTED_FETCHED_AT = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+
+const ANTHROPIC_PERSISTED: GatewayCatalogModel = {
+  id: "claude-opus-4-7",
+  name: "Claude Opus 4.7",
+  provider: "anthropic",
+  type: "language",
+  contextWindow: null,
+  maxOutputTokens: null,
+  inputPrice: null,
+  outputPrice: null,
+  recommended: true,
+};
+
+const OPENAI_PERSISTED: GatewayCatalogModel = {
+  id: "gpt-4o",
+  name: "gpt-4o",
+  provider: "openai",
+  type: "language",
+  contextWindow: null,
+  maxOutputTokens: null,
+  inputPrice: null,
+  outputPrice: null,
+  recommended: true,
+};
+
+const BEDROCK_PERSISTED: GatewayCatalogModel = {
+  id: "anthropic.claude-opus-4-7",
+  name: "Claude Opus 4.7",
+  provider: "bedrock",
+  type: "language",
+  contextWindow: null,
+  maxOutputTokens: null,
+  inputPrice: null,
+  outputPrice: null,
+  recommended: true,
+};
+
+function mockFetchOk(body: unknown): FetchFn {
+  return mock(
+    async (): Promise<Response> =>
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+  ) as unknown as FetchFn;
+}
+
+function mockFetchThatFailsIfCalled(): FetchFn {
+  return mock(async (): Promise<Response> => {
+    throw new Error("fetch unexpectedly called — L2-hit branch should short-circuit");
+  }) as unknown as FetchFn;
+}
+
+function resetSharedState() {
+  loadFromDBResult = null;
+  isFreshResult = false;
+  bedrockSendOutcome = null;
+  loadFromDBSpy.mockClear();
+  storeToDBSpy.mockClear();
+  deleteFromDBSpy.mockClear();
+  isFreshSpy.mockClear();
+  bedrockSendSpy.mockClear();
+  __resetAnthropicCatalogCacheForTests();
+  __resetOpenAICatalogCacheForTests();
+  __resetBedrockCatalogCacheForTests();
+}
+
+describe("byot-catalog L1↔L2 wiring (anthropic representative)", () => {
+  beforeEach(() => resetSharedState());
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    resetSharedState();
+  });
+
+  // Case 1 — Cold L1 + warm L2 → returns source: "cache" AND fetch was never called.
+  test("warm L2 returns source='cache' and skips upstream fetch", async () => {
+    loadFromDBResult = { models: [ANTHROPIC_PERSISTED], fetchedAt: PERSISTED_FETCHED_AT };
+    isFreshResult = true;
+
+    const fetchMock = mockFetchThatFailsIfCalled();
+    globalThis.fetch = fetchMock;
+
+    const res = await getAnthropicCatalog(ORG, ANTHROPIC_KEY);
+
+    expect(res.source).toBe("cache");
+    expect(res.fetchedAt).toBe(PERSISTED_FETCHED_AT);
+    expect(res.models).toHaveLength(1);
+    expect(res.models[0].id).toBe("claude-opus-4-7");
+    expect(loadFromDBSpy).toHaveBeenCalledTimes(1);
+    expect(loadFromDBSpy.mock.calls[0][1]).toBe("anthropic");
+    expect(isFreshSpy).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(storeToDBSpy).not.toHaveBeenCalled();
+  });
+
+  // Case 2 — Cold L1 + warm L2 → L1 is populated (subsequent calls don't hit loadFromDB).
+  test("warm L2 hit populates L1 — second call short-circuits before loadFromDB", async () => {
+    loadFromDBResult = { models: [ANTHROPIC_PERSISTED], fetchedAt: PERSISTED_FETCHED_AT };
+    isFreshResult = true;
+
+    const fetchMock = mockFetchThatFailsIfCalled();
+    globalThis.fetch = fetchMock;
+
+    const first = await getAnthropicCatalog(ORG, ANTHROPIC_KEY);
+    const second = await getAnthropicCatalog(ORG, ANTHROPIC_KEY);
+
+    expect(first.source).toBe("cache");
+    expect(second.source).toBe("cache");
+    expect(loadFromDBSpy).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  // Case 3 — L2 freshness boundary: isFresh=false → fetch IS called AND storeToDB IS called.
+  test("stale L2 (isFresh=false) falls through to upstream fetch + writes L2 back", async () => {
+    loadFromDBResult = { models: [ANTHROPIC_PERSISTED], fetchedAt: PERSISTED_FETCHED_AT };
+    isFreshResult = false;
+
+    const fetchMock = mockFetchOk({
+      data: [{ type: "model", id: "claude-sonnet-4-6", display_name: "Claude Sonnet 4.6" }],
+    });
+    globalThis.fetch = fetchMock;
+
+    const res = await getAnthropicCatalog(ORG, ANTHROPIC_KEY);
+
+    expect(res.source).toBe("fresh");
+    expect(res.models[0].id).toBe("claude-sonnet-4-6");
+    expect(loadFromDBSpy).toHaveBeenCalledTimes(1);
+    expect(isFreshSpy).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(storeToDBSpy).toHaveBeenCalledTimes(1);
+
+    const [argOrg, argProvider, argRegion, argPayload] = storeToDBSpy.mock.calls[0];
+    expect(argOrg).toBe(ORG);
+    expect(argProvider).toBe("anthropic");
+    expect(argRegion).toBe("");
+    expect(argPayload.models[0].id).toBe("claude-sonnet-4-6");
+  });
+
+  // Case 4 — Cold L2 (loadFromDB → null) → fetch + storeToDB called.
+  test("missing L2 (loadFromDB → null) → upstream fetch + storeToDB writeback", async () => {
+    loadFromDBResult = null;
+
+    const fetchMock = mockFetchOk({
+      data: [{ type: "model", id: "claude-haiku-4-5", display_name: "Claude Haiku 4.5" }],
+    });
+    globalThis.fetch = fetchMock;
+
+    const res = await getAnthropicCatalog(ORG, ANTHROPIC_KEY);
+
+    expect(res.source).toBe("fresh");
+    expect(res.models[0].id).toBe("claude-haiku-4-5");
+    expect(loadFromDBSpy).toHaveBeenCalledTimes(1);
+    // isFresh is only invoked when loadFromDB returned a non-null payload —
+    // null short-circuits the freshness check entirely.
+    expect(isFreshSpy).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(storeToDBSpy).toHaveBeenCalledTimes(1);
+    expect(storeToDBSpy.mock.calls[0][1]).toBe("anthropic");
+  });
+});
+
+// openai/bedrock are structural copies of the anthropic control flow. A
+// minimal parallel smoke per provider is enough to catch a regression
+// scoped to one of those files — and the imports above ensure
+// `--affected` includes this test on changes to either module.
+describe("byot-catalog L1↔L2 wiring — openai parallel smoke", () => {
+  beforeEach(() => resetSharedState());
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    resetSharedState();
+  });
+
+  test("warm L2 returns 'cache' and skips upstream", async () => {
+    loadFromDBResult = { models: [OPENAI_PERSISTED], fetchedAt: PERSISTED_FETCHED_AT };
+    isFreshResult = true;
+
+    const fetchMock = mockFetchThatFailsIfCalled();
+    globalThis.fetch = fetchMock;
+
+    const res = await getOpenAICatalog(ORG, OPENAI_KEY);
+
+    expect(res.source).toBe("cache");
+    expect(loadFromDBSpy.mock.calls[0][1]).toBe("openai");
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(storeToDBSpy).not.toHaveBeenCalled();
+  });
+
+  test("missing L2 → upstream fetch + storeToDB writeback", async () => {
+    loadFromDBResult = null;
+
+    const fetchMock = mockFetchOk({ data: [{ id: "gpt-4o" }] });
+    globalThis.fetch = fetchMock;
+
+    const res = await getOpenAICatalog(ORG, OPENAI_KEY);
+
+    expect(res.source).toBe("fresh");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(storeToDBSpy).toHaveBeenCalledTimes(1);
+    expect(storeToDBSpy.mock.calls[0][1]).toBe("openai");
+    expect(storeToDBSpy.mock.calls[0][2]).toBe("");
+  });
+});
+
+describe("byot-catalog L1↔L2 wiring — bedrock parallel smoke", () => {
+  beforeEach(() => resetSharedState());
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    resetSharedState();
+  });
+
+  test("warm L2 returns 'cache' and skips upstream SDK call", async () => {
+    loadFromDBResult = { models: [BEDROCK_PERSISTED], fetchedAt: PERSISTED_FETCHED_AT };
+    isFreshResult = true;
+    // Leave bedrockSendOutcome null so a stray SDK call would throw loudly.
+
+    const res = await getBedrockCatalog(ORG, BEDROCK_REGION, BEDROCK_CREDS);
+
+    expect(res.source).toBe("cache");
+    expect(res.region).toBe(BEDROCK_REGION);
+    expect(loadFromDBSpy.mock.calls[0][1]).toBe("bedrock");
+    expect(loadFromDBSpy.mock.calls[0][2]).toBe(BEDROCK_REGION);
+    expect(bedrockSendSpy).not.toHaveBeenCalled();
+    expect(storeToDBSpy).not.toHaveBeenCalled();
+  });
+
+  test("missing L2 → upstream SDK call + storeToDB writeback with region key", async () => {
+    loadFromDBResult = null;
+    bedrockSendOutcome = {
+      kind: "ok",
+      payload: {
+        modelSummaries: [
+          {
+            modelId: "anthropic.claude-opus-4-7",
+            modelName: "Claude Opus 4.7",
+            providerName: "Anthropic",
+            outputModalities: ["TEXT"],
+          },
+        ],
+      },
+    };
+
+    const res = await getBedrockCatalog(ORG, BEDROCK_REGION, BEDROCK_CREDS);
+
+    expect(res.source).toBe("fresh");
+    expect(bedrockSendSpy).toHaveBeenCalledTimes(1);
+    expect(storeToDBSpy).toHaveBeenCalledTimes(1);
+    expect(storeToDBSpy.mock.calls[0][1]).toBe("bedrock");
+    // Region rides on the L2 upsert key so multi-region workspaces don't
+    // collide. A regression that wrote `""` instead would shadow a real
+    // region's catalog on the next read.
+    expect(storeToDBSpy.mock.calls[0][2]).toBe(BEDROCK_REGION);
+  });
+});

--- a/packages/api/src/lib/__tests__/byot-catalog-l2-wiring.test.ts
+++ b/packages/api/src/lib/__tests__/byot-catalog-l2-wiring.test.ts
@@ -1,71 +1,57 @@
 /**
- * L1↔L2 wiring contract for the BYOT discovery catalogs (#2287).
+ * L1↔L2 wiring contract for the BYOT discovery catalogs.
  *
- * Per-provider tests (`anthropic-catalog.test.ts`, `openai-catalog.test.ts`,
- * `bedrock-catalog.test.ts`) don't mock `byot-catalog-store`, so the store
- * silently no-ops in test runs (no internal DB → `hasInternalDB()` returns
- * false). Store tests (`byot-catalog-store.test.ts`) mock `db/internal` but
- * never thread through a per-provider catalog module. A regression that
- * dropped `cache.set(orgId, …)` on the L2-hit branch, or skipped
- * `storeToDB` on the upstream-fresh branch, would ship green under that
- * split.
- *
- * This file closes that gap. It mocks the store module wholesale, observes
- * `fetch` directly, and asserts the four wiring properties that matter:
- *   1. Warm L2 → returns `source: "cache"` AND upstream is never called.
- *   2. Warm L2 → L1 is populated (next call doesn't hit `loadFromDB`).
- *   3. Stale L2 (`isFresh=false`) → upstream IS called AND L2 is rewritten.
- *   4. Cold L2 (`loadFromDB → null`) → upstream IS called AND L2 is written.
- *
- * Anthropic is the representative — openai/bedrock are structural copies of
- * the same control flow, so a single parallel smoke per provider keeps the
- * regression surface honest without duplicating every case. The parallel
- * imports also let `scripts/test-isolated.ts --affected` pick this file up
- * when any of the four wired modules change.
- *
- * Passes locally with no internal DB configured: `byot-catalog-store` is
- * mocked at module-load time, so the real `hasInternalDB()` is never
- * consulted.
+ * Mocks `byot-catalog-store` wholesale so the wiring is observable end-to-end
+ * through each per-provider catalog. Anthropic carries the full case-set;
+ * openai/bedrock get parallel smokes scoped to provider-specific divergences
+ * (notably bedrock's per-region L2 key). Safe to run without an internal DB —
+ * `hasInternalDB()` is never consulted because the store is mocked at load.
  */
 
 import { afterEach, beforeEach, describe, expect, test, mock } from "bun:test";
-import type { GatewayCatalogModel } from "@useatlas/types";
-import type { BedrockRegion } from "@useatlas/types";
+import type { GatewayCatalogModel, BedrockRegion } from "@useatlas/types";
+import type {
+  ByotProviderKey,
+  PersistedCatalog,
+} from "@atlas/api/lib/byot-catalog-store";
 
 type FetchFn = typeof globalThis.fetch;
 const realFetch: FetchFn = globalThis.fetch;
 
-type StoredPayload = { models: GatewayCatalogModel[]; fetchedAt: string };
-type LoadResult = StoredPayload | null;
+// Distinct error class so a fixture rejection is visually separable from a
+// genuine upstream failure after the catalog's own try/catch normalizes it
+// into `*CatalogUnavailable`.
+class TestFixtureViolation extends Error {
+  readonly _tag = "TestFixtureViolation";
+}
 
-// Per-test mutable state. The mock factory is sync (CLAUDE.md feedback:
-// async factories with inner awaits deadlock the bun loader), so we
-// forward into closure-captured variables instead.
-let loadFromDBResult: LoadResult = null;
+let loadFromDBResult: PersistedCatalog | null = null;
 let isFreshResult = false;
 
 const loadFromDBSpy = mock(
-  async (_orgId: string, _provider: string, _region?: string): Promise<LoadResult> =>
-    loadFromDBResult,
+  async (
+    _orgId: string,
+    _provider: ByotProviderKey,
+    _region?: string,
+  ): Promise<PersistedCatalog | null> => loadFromDBResult,
 );
 const storeToDBSpy = mock(
   async (
     _orgId: string,
-    _provider: string,
+    _provider: ByotProviderKey,
     _region: string,
-    _persisted: StoredPayload,
+    _persisted: PersistedCatalog,
   ): Promise<void> => {},
 );
 const deleteFromDBSpy = mock(
-  async (_orgId: string, _provider: string): Promise<void> => {},
+  async (_orgId: string, _provider: ByotProviderKey): Promise<void> => {},
 );
 const isFreshSpy = mock(
-  (_persisted: StoredPayload, _ttlMs: number): boolean => isFreshResult,
+  (_persisted: PersistedCatalog, _ttlMs: number): boolean => isFreshResult,
 );
 
-// Mock every named export of `byot-catalog-store` — partial-mock SyntaxError
-// trap from CLAUDE.md. The store is the only seam the per-provider catalogs
-// touch for L2, so this is the entire surface we need to control.
+// Factory must be sync — async mock.module factories with inner awaits
+// deadlock the bun loader.
 mock.module("@atlas/api/lib/byot-catalog-store", () => ({
   loadFromDB: loadFromDBSpy,
   storeToDB: storeToDBSpy,
@@ -73,12 +59,12 @@ mock.module("@atlas/api/lib/byot-catalog-store", () => ({
   isFresh: isFreshSpy,
 }));
 
-// AWS SDK mock for the bedrock smoke. Bedrock doesn't go through `fetch`,
-// so we substitute the SDK client wholesale to observe upstream calls.
-let bedrockSendOutcome: { kind: "ok"; payload: { modelSummaries: unknown[] } } | null = null;
+let bedrockSendPayload: { modelSummaries: unknown[] } | null = null;
 const bedrockSendSpy = mock(async (_command: { $name: string }) => {
-  if (!bedrockSendOutcome) throw new Error("bedrock send mock outcome not configured");
-  return bedrockSendOutcome.payload;
+  if (!bedrockSendPayload) {
+    throw new TestFixtureViolation("bedrock send mock outcome not configured");
+  }
+  return bedrockSendPayload;
 });
 
 class MockListFoundationModelsCommand {
@@ -104,9 +90,11 @@ mock.module("@aws-sdk/client-bedrock", () => ({
   ListFoundationModelsCommand: MockListFoundationModelsCommand,
 }));
 
-const { __resetAnthropicCatalogCacheForTests, getAnthropicCatalog } = await import(
-  "../anthropic-catalog"
-);
+const {
+  __resetAnthropicCatalogCacheForTests,
+  getAnthropicCatalog,
+  invalidateAnthropicCatalog,
+} = await import("../anthropic-catalog");
 const { __resetOpenAICatalogCacheForTests, getOpenAICatalog } = await import(
   "../openai-catalog"
 );
@@ -120,8 +108,8 @@ const OPENAI_KEY = "sk-openai-test-key";
 const BEDROCK_CREDS = { accessKeyId: "AKIA-TEST", secretAccessKey: "secret-test" };
 const BEDROCK_REGION: BedrockRegion = "us-east-1";
 
-// Stored "yesterday" so the wall-clock value can't accidentally satisfy a
-// real TTL window if the mock for `isFresh` ever gets bypassed.
+// "Yesterday" so wall-clock can't accidentally satisfy a real TTL window if
+// isFresh ever gets bypassed.
 const PERSISTED_FETCHED_AT = new Date(Date.now() - 60 * 60 * 1000).toISOString();
 
 const ANTHROPIC_PERSISTED: GatewayCatalogModel = {
@@ -137,27 +125,16 @@ const ANTHROPIC_PERSISTED: GatewayCatalogModel = {
 };
 
 const OPENAI_PERSISTED: GatewayCatalogModel = {
+  ...ANTHROPIC_PERSISTED,
   id: "gpt-4o",
   name: "gpt-4o",
   provider: "openai",
-  type: "language",
-  contextWindow: null,
-  maxOutputTokens: null,
-  inputPrice: null,
-  outputPrice: null,
-  recommended: true,
 };
 
 const BEDROCK_PERSISTED: GatewayCatalogModel = {
+  ...ANTHROPIC_PERSISTED,
   id: "anthropic.claude-opus-4-7",
-  name: "Claude Opus 4.7",
   provider: "bedrock",
-  type: "language",
-  contextWindow: null,
-  maxOutputTokens: null,
-  inputPrice: null,
-  outputPrice: null,
-  recommended: true,
 };
 
 function mockFetchOk(body: unknown): FetchFn {
@@ -172,14 +149,16 @@ function mockFetchOk(body: unknown): FetchFn {
 
 function mockFetchThatFailsIfCalled(): FetchFn {
   return mock(async (): Promise<Response> => {
-    throw new Error("fetch unexpectedly called — L2-hit branch should short-circuit");
+    throw new TestFixtureViolation(
+      "fetch unexpectedly called — L2-hit branch should short-circuit",
+    );
   }) as unknown as FetchFn;
 }
 
 function resetSharedState() {
   loadFromDBResult = null;
   isFreshResult = false;
-  bedrockSendOutcome = null;
+  bedrockSendPayload = null;
   loadFromDBSpy.mockClear();
   storeToDBSpy.mockClear();
   deleteFromDBSpy.mockClear();
@@ -198,7 +177,6 @@ describe("byot-catalog L1↔L2 wiring (anthropic representative)", () => {
     resetSharedState();
   });
 
-  // Case 1 — Cold L1 + warm L2 → returns source: "cache" AND fetch was never called.
   test("warm L2 returns source='cache' and skips upstream fetch", async () => {
     loadFromDBResult = { models: [ANTHROPIC_PERSISTED], fetchedAt: PERSISTED_FETCHED_AT };
     isFreshResult = true;
@@ -213,13 +191,13 @@ describe("byot-catalog L1↔L2 wiring (anthropic representative)", () => {
     expect(res.models).toHaveLength(1);
     expect(res.models[0].id).toBe("claude-opus-4-7");
     expect(loadFromDBSpy).toHaveBeenCalledTimes(1);
+    expect(loadFromDBSpy.mock.calls[0][0]).toBe(ORG);
     expect(loadFromDBSpy.mock.calls[0][1]).toBe("anthropic");
     expect(isFreshSpy).toHaveBeenCalledTimes(1);
     expect(fetchMock).not.toHaveBeenCalled();
     expect(storeToDBSpy).not.toHaveBeenCalled();
   });
 
-  // Case 2 — Cold L1 + warm L2 → L1 is populated (subsequent calls don't hit loadFromDB).
   test("warm L2 hit populates L1 — second call short-circuits before loadFromDB", async () => {
     loadFromDBResult = { models: [ANTHROPIC_PERSISTED], fetchedAt: PERSISTED_FETCHED_AT };
     isFreshResult = true;
@@ -236,8 +214,7 @@ describe("byot-catalog L1↔L2 wiring (anthropic representative)", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  // Case 3 — L2 freshness boundary: isFresh=false → fetch IS called AND storeToDB IS called.
-  test("stale L2 (isFresh=false) falls through to upstream fetch + writes L2 back", async () => {
+  test("stale L2 (isFresh=false) → upstream fetch + L2 writeback + populates L1", async () => {
     loadFromDBResult = { models: [ANTHROPIC_PERSISTED], fetchedAt: PERSISTED_FETCHED_AT };
     isFreshResult = false;
 
@@ -260,10 +237,17 @@ describe("byot-catalog L1↔L2 wiring (anthropic representative)", () => {
     expect(argProvider).toBe("anthropic");
     expect(argRegion).toBe("");
     expect(argPayload.models[0].id).toBe("claude-sonnet-4-6");
+
+    // Fresh-write path must populate L1 — dropping cache.set on the fresh
+    // branch would let upstream get hammered until L2 takes over.
+    const second = await getAnthropicCatalog(ORG, ANTHROPIC_KEY);
+    expect(second.source).toBe("cache");
+    expect(loadFromDBSpy).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(storeToDBSpy).toHaveBeenCalledTimes(1);
   });
 
-  // Case 4 — Cold L2 (loadFromDB → null) → fetch + storeToDB called.
-  test("missing L2 (loadFromDB → null) → upstream fetch + storeToDB writeback", async () => {
+  test("missing L2 (loadFromDB → null) → upstream fetch + L2 writeback + populates L1", async () => {
     loadFromDBResult = null;
 
     const fetchMock = mockFetchOk({
@@ -276,19 +260,54 @@ describe("byot-catalog L1↔L2 wiring (anthropic representative)", () => {
     expect(res.source).toBe("fresh");
     expect(res.models[0].id).toBe("claude-haiku-4-5");
     expect(loadFromDBSpy).toHaveBeenCalledTimes(1);
-    // isFresh is only invoked when loadFromDB returned a non-null payload —
-    // null short-circuits the freshness check entirely.
+    // null payload short-circuits the isFresh check entirely.
     expect(isFreshSpy).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(storeToDBSpy).toHaveBeenCalledTimes(1);
     expect(storeToDBSpy.mock.calls[0][1]).toBe("anthropic");
+
+    // Same L1-population guarantee as the stale-L2 case.
+    const second = await getAnthropicCatalog(ORG, ANTHROPIC_KEY);
+    expect(second.source).toBe("cache");
+    expect(loadFromDBSpy).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("persist: false skips both L2 read and L2 write but still fetches upstream", async () => {
+    loadFromDBResult = { models: [ANTHROPIC_PERSISTED], fetchedAt: PERSISTED_FETCHED_AT };
+    isFreshResult = true;
+
+    const fetchMock = mockFetchOk({
+      data: [{ type: "model", id: "claude-sonnet-4-6", display_name: "Claude Sonnet 4.6" }],
+    });
+    globalThis.fetch = fetchMock;
+
+    const res = await getAnthropicCatalog(ORG, ANTHROPIC_KEY, { persist: false });
+
+    expect(res.source).toBe("fresh");
+    expect(res.models[0].id).toBe("claude-sonnet-4-6");
+    expect(loadFromDBSpy).not.toHaveBeenCalled();
+    expect(storeToDBSpy).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("invalidateAnthropicCatalog flushes L1 and fires L2 delete", async () => {
+    loadFromDBResult = { models: [ANTHROPIC_PERSISTED], fetchedAt: PERSISTED_FETCHED_AT };
+    isFreshResult = true;
+    globalThis.fetch = mockFetchThatFailsIfCalled();
+
+    const warm = await getAnthropicCatalog(ORG, ANTHROPIC_KEY);
+    expect(warm.source).toBe("cache");
+
+    invalidateAnthropicCatalog(ORG);
+
+    // L2 delete is fire-and-forget but the spy registers the call sync.
+    expect(deleteFromDBSpy).toHaveBeenCalledTimes(1);
+    expect(deleteFromDBSpy.mock.calls[0][0]).toBe(ORG);
+    expect(deleteFromDBSpy.mock.calls[0][1]).toBe("anthropic");
   });
 });
 
-// openai/bedrock are structural copies of the anthropic control flow. A
-// minimal parallel smoke per provider is enough to catch a regression
-// scoped to one of those files — and the imports above ensure
-// `--affected` includes this test on changes to either module.
 describe("byot-catalog L1↔L2 wiring — openai parallel smoke", () => {
   beforeEach(() => resetSharedState());
   afterEach(() => {
@@ -306,6 +325,7 @@ describe("byot-catalog L1↔L2 wiring — openai parallel smoke", () => {
     const res = await getOpenAICatalog(ORG, OPENAI_KEY);
 
     expect(res.source).toBe("cache");
+    expect(loadFromDBSpy).toHaveBeenCalledTimes(1);
     expect(loadFromDBSpy.mock.calls[0][1]).toBe("openai");
     expect(fetchMock).not.toHaveBeenCalled();
     expect(storeToDBSpy).not.toHaveBeenCalled();
@@ -337,32 +357,29 @@ describe("byot-catalog L1↔L2 wiring — bedrock parallel smoke", () => {
   test("warm L2 returns 'cache' and skips upstream SDK call", async () => {
     loadFromDBResult = { models: [BEDROCK_PERSISTED], fetchedAt: PERSISTED_FETCHED_AT };
     isFreshResult = true;
-    // Leave bedrockSendOutcome null so a stray SDK call would throw loudly.
 
     const res = await getBedrockCatalog(ORG, BEDROCK_REGION, BEDROCK_CREDS);
 
     expect(res.source).toBe("cache");
     expect(res.region).toBe(BEDROCK_REGION);
+    expect(loadFromDBSpy).toHaveBeenCalledTimes(1);
     expect(loadFromDBSpy.mock.calls[0][1]).toBe("bedrock");
     expect(loadFromDBSpy.mock.calls[0][2]).toBe(BEDROCK_REGION);
     expect(bedrockSendSpy).not.toHaveBeenCalled();
     expect(storeToDBSpy).not.toHaveBeenCalled();
   });
 
-  test("missing L2 → upstream SDK call + storeToDB writeback with region key", async () => {
+  test("missing L2 → upstream SDK call + L2 writeback with region key + populates L1", async () => {
     loadFromDBResult = null;
-    bedrockSendOutcome = {
-      kind: "ok",
-      payload: {
-        modelSummaries: [
-          {
-            modelId: "anthropic.claude-opus-4-7",
-            modelName: "Claude Opus 4.7",
-            providerName: "Anthropic",
-            outputModalities: ["TEXT"],
-          },
-        ],
-      },
+    bedrockSendPayload = {
+      modelSummaries: [
+        {
+          modelId: "anthropic.claude-opus-4-7",
+          modelName: "Claude Opus 4.7",
+          providerName: "Anthropic",
+          outputModalities: ["TEXT"],
+        },
+      ],
     };
 
     const res = await getBedrockCatalog(ORG, BEDROCK_REGION, BEDROCK_CREDS);
@@ -372,8 +389,13 @@ describe("byot-catalog L1↔L2 wiring — bedrock parallel smoke", () => {
     expect(storeToDBSpy).toHaveBeenCalledTimes(1);
     expect(storeToDBSpy.mock.calls[0][1]).toBe("bedrock");
     // Region rides on the L2 upsert key so multi-region workspaces don't
-    // collide. A regression that wrote `""` instead would shadow a real
-    // region's catalog on the next read.
+    // collide on read.
     expect(storeToDBSpy.mock.calls[0][2]).toBe(BEDROCK_REGION);
+
+    // Fresh-write path must populate L1 (keyed by `${orgId}:${region}`).
+    const second = await getBedrockCatalog(ORG, BEDROCK_REGION, BEDROCK_CREDS);
+    expect(second.source).toBe("cache");
+    expect(bedrockSendSpy).toHaveBeenCalledTimes(1);
+    expect(storeToDBSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Closes #2287.

## Summary
- Adds `packages/api/src/lib/__tests__/byot-catalog-l2-wiring.test.ts`. Mocks `@atlas/api/lib/byot-catalog-store` (every named export) and `globalThis.fetch` so the L1↔L2 contract is observable end-to-end through the per-provider catalog modules.
- Anthropic carries the four required cases: warm L2 returns `source='cache'` and skips upstream; warm L2 populates L1 so the next call skips `loadFromDB`; stale L2 (`isFresh=false`) falls through to upstream + rewrites L2; missing L2 (`loadFromDB → null`) does the same.
- OpenAI and Bedrock get parallel smokes — same wiring, fewer cases. They double as `--affected` anchors so changes to any of the four wired modules (`byot-catalog-store`, `anthropic-catalog`, `openai-catalog`, `bedrock-catalog`) pick this test up.

## Why
Per-provider catalog tests don't mock `byot-catalog-store`, so the store silently no-ops in test (no internal DB → `hasInternalDB()` returns false). Store tests mock `db/internal` but never thread through a per-provider module. A regression that dropped `cache.set(orgId, …)` on the L2-hit branch, or skipped `storeToDB` on the upstream-fresh branch, would have shipped green under that split.

## Test plan
- [x] `bun test src/lib/__tests__/byot-catalog-l2-wiring.test.ts` → 8 pass / 0 fail
- [x] `bun run scripts/test-isolated.ts --affected` includes the new file
- [x] Touching each of the four wired modules (store + anthropic/openai/bedrock catalogs) brings the new file into `--affected`
- [x] Passes locally with no internal DB configured (store is mocked at module load)
- [x] `bun run lint` / `bun run type` / `bun run test` / `bun x syncpack lint` / template drift / railway-watch — all green