### PR TITLE
feat(sdk,react): expose multi-workspace MCP shape (#2196)

### DIFF
--- a/apps/docs/content/docs/sdk/mcp.mdx
+++ b/apps/docs/content/docs/sdk/mcp.mdx
@@ -147,6 +147,79 @@ when you embed multiple workspaces.
 
 ---
 
+## Multi-workspace setup
+
+> **When to use multi-workspace.** Reach for the multi-workspace shape
+> when one human user belongs to more than one Atlas workspace and you
+> want them to install your MCP agent **once** rather than re-running
+> the OAuth flow per workspace. The single-workspace flow above is the
+> right default for solo accounts, dedicated team workspaces, or any
+> situation where each end user has exactly one workspace.
+
+The Atlas OAuth provider mints a multi-workspace token automatically
+when the authenticating user belongs to more than one workspace: the
+JWT carries both `https://atlas.useatlas.dev/workspace_id` (the
+singular claim — the user's primary workspace) and
+`https://atlas.useatlas.dev/workspace_ids` (the plural claim — every
+workspace this token grants access to). `completeConnect` extracts
+both:
+
+```ts
+const { accessToken, workspaceId, workspaces } = await completeConnect({
+  /* …same args as the single-workspace flow… */
+});
+
+if (workspaces.length > 1) {
+  // Multi-workspace token. Render a picker so the user can choose a
+  // default; the singular `workspaceId` is your fallback selection.
+} else {
+  // Single-workspace token — `workspaces` is an empty array.
+}
+```
+
+`buildConfig` opts into the multi-workspace block by accepting the
+`workspaces` array. The emitted config still pins one workspace in the
+URL (the hosted MCP edge mounts at `/mcp/{workspace_id}/sse`), but it
+gains an `env: { ATLAS_DEFAULT_WORKSPACE }` slot — the forward-compat
+hint MCP-client framework wrappers will bridge into the
+`X-Atlas-Default-Workspace` header. Per-request overrides happen via
+the `X-Atlas-Workspace` header (priority 1 in the edge's resolution
+chain — see [#2073](https://github.com/AtlasDevHQ/atlas/issues/2073)).
+
+```ts
+const config = buildConfig({
+  client: "claude-desktop",
+  apiUrl: "https://mcp.useatlas.dev",
+  accessToken,
+  workspaceId,           // default workspace pinned in the URL
+  workspaces,            // opt into the multi-workspace block
+});
+// config.mcpServers.atlas → {
+//   url: "https://mcp.useatlas.dev/mcp/<ws>/sse",
+//   headers: { Authorization: "Bearer <token>" },
+//   env: { ATLAS_DEFAULT_WORKSPACE: "<ws>" },
+// }
+```
+
+Omit `workspaces` (or pass an empty array) and `buildConfig` falls
+back to the byte-identical pre-#2196 single-workspace block — existing
+callers do not need to change.
+
+The React hook surfaces the plural claim on its success branch:
+
+```tsx
+const result = useMcpConnect({ apiUrl, clientName, redirectUri });
+
+if (result.status === "success" && result.workspaces.length > 1) {
+  return <WorkspacePicker default={result.workspaceId} options={result.workspaces} />;
+}
+```
+
+A worked example with the workspace picker lives at
+[`examples/embedded-mcp-onboarding/`](https://github.com/AtlasDevHQ/atlas/tree/main/examples/embedded-mcp-onboarding).
+
+---
+
 ## Listing & revoking agents
 
 Once a user is authenticated against your Atlas client:

--- a/apps/docs/content/docs/sdk/mcp.mdx
+++ b/apps/docs/content/docs/sdk/mcp.mdx
@@ -269,6 +269,7 @@ Every helper throws `AtlasMcpError` with a stable `code`:
 | `malformed_jwt` | The access token wasn't a 3-part JWT |
 | `missing_workspace_claim` | The token had no `https://atlas.useatlas.dev/workspace_id` claim |
 | `grant_not_supported` | `connectMachineToMachine` until [#2024](https://github.com/AtlasDevHQ/atlas/issues/2024) lands |
+| `workspace_not_in_grant_list` | `buildConfig` was called with `workspaces` non-empty and `workspaceId` not in that list. Programmer error — the picker chose a workspace the token didn't grant. |
 
 All errors include the original cause via `Error.cause` when relevant
 (network failures, JSON parse failures), so logging `err.cause` recovers

--- a/examples/embedded-mcp-onboarding/src/app/page.tsx
+++ b/examples/embedded-mcp-onboarding/src/app/page.tsx
@@ -43,14 +43,28 @@ export default function Page() {
   const { connect, status, reset } = result;
 
   const [client, setClient] = useState<McpClientId>("claude-desktop");
+  // Default-workspace selection (#2196). For single-workspace tokens this
+  // is a no-op — the picker is hidden and we use `result.workspaceId`. For
+  // multi-workspace tokens (`result.workspaces.length > 1`), the picker
+  // lets the user pin a different default before copying the config.
+  const [selectedWorkspace, setSelectedWorkspace] = useState<string | null>(null);
+
+  const effectiveWorkspaceId =
+    result.status === "success"
+      ? selectedWorkspace ?? result.workspaceId
+      : null;
 
   const config =
-    result.status === "success"
+    result.status === "success" && effectiveWorkspaceId
       ? buildConfig({
           client,
           apiUrl: ATLAS_API_URL,
           accessToken: result.accessToken,
-          workspaceId: result.workspaceId,
+          workspaceId: effectiveWorkspaceId,
+          // Opt into the multi-workspace block when the JWT carries the
+          // plural claim. Empty array → single-workspace shape, byte-
+          // identical to the legacy block.
+          workspaces: result.workspaces,
         })
       : null;
 
@@ -92,7 +106,10 @@ export default function Page() {
 
         {status === "success" && (
           <button
-            onClick={reset}
+            onClick={() => {
+              setSelectedWorkspace(null);
+              reset();
+            }}
             style={{
               background: "transparent",
               color: "#a1a1aa",
@@ -131,8 +148,40 @@ export default function Page() {
         <section style={{ display: "flex", flexDirection: "column", gap: 8 }}>
           <h2 style={{ margin: 0, fontSize: 18 }}>Paste-ready config</h2>
           <p style={{ color: "#a1a1aa", marginTop: 0 }}>
-            Workspace ID: <code>{result.workspaceId}</code>
+            Default workspace: <code>{effectiveWorkspaceId}</code>
+            {result.workspaces.length > 1 && (
+              <> · {result.workspaces.length} total</>
+            )}
           </p>
+
+          {result.workspaces.length > 1 && (
+            <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+              <span style={{ color: "#a1a1aa", fontSize: 13 }}>
+                Pick a default workspace (per-request overrides happen via the{" "}
+                <code>X-Atlas-Workspace</code> header):
+              </span>
+              <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                {result.workspaces.map((ws) => (
+                  <button
+                    key={ws}
+                    onClick={() => setSelectedWorkspace(ws)}
+                    style={{
+                      background: ws === effectiveWorkspaceId ? "#10b981" : "transparent",
+                      color: ws === effectiveWorkspaceId ? "#0a0a0a" : "#fafafa",
+                      border: "1px solid #333",
+                      borderRadius: 6,
+                      padding: "6px 12px",
+                      cursor: "pointer",
+                      fontSize: 13,
+                      fontFamily: "monospace",
+                    }}
+                  >
+                    {ws}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
 
           <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
             {MCP_CLIENTS.map((id) => (

--- a/examples/embedded-mcp-onboarding/src/app/page.tsx
+++ b/examples/embedded-mcp-onboarding/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { useMcpConnect } from "@useatlas/react/hooks";
 import { buildConfig, type McpClientConfig, type McpClientId } from "@useatlas/sdk";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 /** Drop the `kind` discriminator so the paste output is clean JSON. */
 function stripKind(cfg: McpClientConfig): Record<string, unknown> {
@@ -49,9 +49,24 @@ export default function Page() {
   // lets the user pin a different default before copying the config.
   const [selectedWorkspace, setSelectedWorkspace] = useState<string | null>(null);
 
+  // Reconnect-without-Disconnect can mint a token against a different
+  // session — the previously-picked workspace might not be in the new
+  // grant list. Clear the selection whenever the token's default
+  // workspace changes; the user re-picks from the new set.
+  const successWorkspaceId =
+    result.status === "success" ? result.workspaceId : null;
+  useEffect(() => {
+    setSelectedWorkspace(null);
+  }, [successWorkspaceId]);
+
+  // `buildConfig` throws if the picked workspace isn't in the granted
+  // set — be defensive and only honor the picker selection when it's
+  // still a valid member, otherwise fall back to the JWT default.
   const effectiveWorkspaceId =
     result.status === "success"
-      ? selectedWorkspace ?? result.workspaceId
+      ? selectedWorkspace !== null && result.workspaces.includes(selectedWorkspace)
+        ? selectedWorkspace
+        : result.workspaceId
       : null;
 
   const config =

--- a/packages/react/src/hooks/__tests__/use-mcp-connect.test.tsx
+++ b/packages/react/src/hooks/__tests__/use-mcp-connect.test.tsx
@@ -24,6 +24,7 @@ let completeConnectImpl = mock(async () => ({
   refreshToken: "rfr-abc",
   expiresAt: Date.now() + 3600 * 1000,
   workspaceId: "ws-1",
+  workspaces: [] as string[],
 }));
 
 class StubAtlasMcpError extends Error {
@@ -69,6 +70,7 @@ function resetSdkMocks() {
     refreshToken: "rfr-abc",
     expiresAt: Date.now() + 3600 * 1000,
     workspaceId: "ws-1",
+    workspaces: [] as string[],
   }));
 }
 
@@ -328,6 +330,79 @@ describe("useMcpConnect concurrent connect() calls", () => {
       });
       expect(beginConnectImpl).toHaveBeenCalledTimes(1);
       expect(result.current.status).toBe("awaiting_callback");
+    } finally {
+      window.open = originalOpen;
+    }
+  });
+});
+
+// ── multi-workspace shape (#2196) ─────────────────────────────────────
+
+describe("useMcpConnect — multi-workspace shape (#2196)", () => {
+  it("single-workspace token: workspaces is an empty array on success", async () => {
+    const fakePopup = { closed: false, close: () => {} };
+    const originalOpen = window.open;
+    (window as unknown as { open: () => unknown }).open = () => fakePopup;
+
+    try {
+      const { result } = renderHook(() => useMcpConnect(baseOptions));
+      await act(async () => {
+        await result.current.connect();
+      });
+      await act(async () => {
+        window.dispatchEvent(
+          new (window as unknown as { MessageEvent: typeof MessageEvent }).MessageEvent("message", {
+            data: { type: "atlas-mcp-callback", code: "c", state: "stub-state" },
+            origin: APP_ORIGIN,
+          }),
+        );
+      });
+      await waitFor(() => {
+        expect(result.current.status).toBe("success");
+      });
+      if (result.current.status !== "success") throw new Error("expected success");
+      // Stable: a single-workspace token surfaces an empty workspaces
+      // array so embedders never have to null-check.
+      expect(result.current.workspaces).toEqual([]);
+      expect(result.current.workspaceId).toBe("ws-1");
+    } finally {
+      window.open = originalOpen;
+    }
+  });
+
+  it("multi-workspace token: surfaces the workspaces array for picker rendering", async () => {
+    // Override `completeConnect` to return a multi-workspace result.
+    completeConnectImpl = mock(async () => ({
+      accessToken: "tok-abc",
+      refreshToken: "rfr-abc",
+      expiresAt: Date.now() + 3600 * 1000,
+      workspaceId: "ws-1",
+      workspaces: ["ws-1", "ws-2", "ws-3"],
+    }));
+
+    const fakePopup = { closed: false, close: () => {} };
+    const originalOpen = window.open;
+    (window as unknown as { open: () => unknown }).open = () => fakePopup;
+
+    try {
+      const { result } = renderHook(() => useMcpConnect(baseOptions));
+      await act(async () => {
+        await result.current.connect();
+      });
+      await act(async () => {
+        window.dispatchEvent(
+          new (window as unknown as { MessageEvent: typeof MessageEvent }).MessageEvent("message", {
+            data: { type: "atlas-mcp-callback", code: "c", state: "stub-state" },
+            origin: APP_ORIGIN,
+          }),
+        );
+      });
+      await waitFor(() => {
+        expect(result.current.status).toBe("success");
+      });
+      if (result.current.status !== "success") throw new Error("expected success");
+      expect(result.current.workspaceId).toBe("ws-1");
+      expect(result.current.workspaces).toEqual(["ws-1", "ws-2", "ws-3"]);
     } finally {
       window.open = originalOpen;
     }

--- a/packages/react/src/hooks/__tests__/use-mcp-connect.test.tsx
+++ b/packages/react/src/hooks/__tests__/use-mcp-connect.test.tsx
@@ -444,6 +444,10 @@ describe("useMcpConnect reset()", () => {
       if (result.current.status === "idle") {
         expect(result.current.accessToken).toBeNull();
         expect(result.current.error).toBeNull();
+        // #2196: the new `workspaces` field must also clear on reset,
+        // or a stale post-success array would survive into the next
+        // flow and break the discriminated-union type contract.
+        expect(result.current.workspaces).toBeNull();
       }
     } finally {
       window.open = originalOpen;

--- a/packages/react/src/hooks/use-mcp-connect.ts
+++ b/packages/react/src/hooks/use-mcp-connect.ts
@@ -99,8 +99,13 @@ export type UseMcpConnectReturn =
        * `workspaces.length > 1` to gate a post-onboarding workspace
        * picker; `workspaceId` is always the default selection (the
        * singular claim).
+       *
+       * `ReadonlyArray<string>` to match the SDK's
+       * `CompleteConnectResult.workspaces` shape and prevent in-place
+       * mutation of `useState`-backed React state — `result.workspaces.sort()`
+       * would silently corrupt the picker's source-of-truth across renders.
        */
-      readonly workspaces: string[];
+      readonly workspaces: ReadonlyArray<string>;
       readonly expiresAt: number;
       readonly error: null;
     }
@@ -245,7 +250,7 @@ export function useMcpConnect(options: UseMcpConnectOptions): UseMcpConnectRetur
   const [accessToken, setAccessToken] = useState<string | null>(null);
   const [refreshToken, setRefreshToken] = useState<string | null>(null);
   const [workspaceId, setWorkspaceId] = useState<string | null>(null);
-  const [workspaces, setWorkspaces] = useState<string[] | null>(null);
+  const [workspaces, setWorkspaces] = useState<ReadonlyArray<string> | null>(null);
   const [expiresAt, setExpiresAt] = useState<number | null>(null);
   const [error, setError] = useState<AtlasMcpError | Error | null>(null);
 
@@ -485,7 +490,10 @@ export function useMcpConnect(options: UseMcpConnectOptions): UseMcpConnectRetur
       accessToken: accessToken!,
       refreshToken,
       workspaceId: workspaceId!,
-      workspaces: workspaces ?? [],
+      // Same `!` pattern as the adjacent fields — `applyResult` writes
+      // every field together when transitioning to `success`, so the
+      // null branch is unreachable here.
+      workspaces: workspaces!,
       expiresAt: expiresAt!,
       error: null,
     };

--- a/packages/react/src/hooks/use-mcp-connect.ts
+++ b/packages/react/src/hooks/use-mcp-connect.ts
@@ -81,6 +81,7 @@ export type UseMcpConnectReturn =
       readonly accessToken: null;
       readonly refreshToken: null;
       readonly workspaceId: null;
+      readonly workspaces: null;
       readonly expiresAt: null;
       readonly error: null;
     }
@@ -91,6 +92,15 @@ export type UseMcpConnectReturn =
       readonly accessToken: string;
       readonly refreshToken: string | null;
       readonly workspaceId: string;
+      /**
+       * The plural workspace claim surfaced from the JWT (#2196). Empty
+       * array for single-workspace tokens, populated when the
+       * authenticating user belongs to more than one workspace. Use
+       * `workspaces.length > 1` to gate a post-onboarding workspace
+       * picker; `workspaceId` is always the default selection (the
+       * singular claim).
+       */
+      readonly workspaces: string[];
       readonly expiresAt: number;
       readonly error: null;
     }
@@ -101,6 +111,7 @@ export type UseMcpConnectReturn =
       readonly accessToken: null;
       readonly refreshToken: null;
       readonly workspaceId: null;
+      readonly workspaces: null;
       readonly expiresAt: null;
       readonly error: AtlasMcpError | Error;
     };
@@ -234,6 +245,7 @@ export function useMcpConnect(options: UseMcpConnectOptions): UseMcpConnectRetur
   const [accessToken, setAccessToken] = useState<string | null>(null);
   const [refreshToken, setRefreshToken] = useState<string | null>(null);
   const [workspaceId, setWorkspaceId] = useState<string | null>(null);
+  const [workspaces, setWorkspaces] = useState<string[] | null>(null);
   const [expiresAt, setExpiresAt] = useState<number | null>(null);
   const [error, setError] = useState<AtlasMcpError | Error | null>(null);
 
@@ -251,6 +263,7 @@ export function useMcpConnect(options: UseMcpConnectOptions): UseMcpConnectRetur
     setAccessToken(result.accessToken);
     setRefreshToken(result.refreshToken);
     setWorkspaceId(result.workspaceId);
+    setWorkspaces(result.workspaces);
     setExpiresAt(result.expiresAt);
     setStatus("success");
   }
@@ -392,6 +405,7 @@ export function useMcpConnect(options: UseMcpConnectOptions): UseMcpConnectRetur
     setAccessToken(null);
     setRefreshToken(null);
     setWorkspaceId(null);
+    setWorkspaces(null);
     setExpiresAt(null);
   }
 
@@ -471,6 +485,7 @@ export function useMcpConnect(options: UseMcpConnectOptions): UseMcpConnectRetur
       accessToken: accessToken!,
       refreshToken,
       workspaceId: workspaceId!,
+      workspaces: workspaces ?? [],
       expiresAt: expiresAt!,
       error: null,
     };
@@ -482,6 +497,7 @@ export function useMcpConnect(options: UseMcpConnectOptions): UseMcpConnectRetur
       accessToken: null,
       refreshToken: null,
       workspaceId: null,
+      workspaces: null,
       expiresAt: null,
       error: error!,
     };
@@ -492,6 +508,7 @@ export function useMcpConnect(options: UseMcpConnectOptions): UseMcpConnectRetur
     accessToken: null,
     refreshToken: null,
     workspaceId: null,
+    workspaces: null,
     expiresAt: null,
     error: null,
   };

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/sdk",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "TypeScript SDK for the Atlas text-to-SQL agent API",
   "type": "module",
   "scripts": {

--- a/packages/sdk/src/__tests__/mcp.test.ts
+++ b/packages/sdk/src/__tests__/mcp.test.ts
@@ -53,6 +53,21 @@ const VALID_TOKEN = jwt({
   "https://atlas.useatlas.dev/workspace_id": WORKSPACE_ID,
 });
 
+// Multi-workspace token (#2196) — singular + plural claims, mirrors what
+// the server emits via `customAccessTokenClaims` in
+// `packages/api/src/lib/auth/server.ts` when the user belongs to > 1 ws.
+const MULTI_WORKSPACE_IDS = ["ws-123", "ws-456", "ws-789"];
+const MULTI_WORKSPACE_TOKEN = jwt({
+  iss: `${API_URL}/api/auth`,
+  sub: "user-1",
+  aud: `${API_URL}/mcp`,
+  azp: "client-abc",
+  exp: Math.floor(Date.now() / 1000) + 3600,
+  scope: "mcp:read offline_access",
+  "https://atlas.useatlas.dev/workspace_id": WORKSPACE_ID,
+  "https://atlas.useatlas.dev/workspace_ids": MULTI_WORKSPACE_IDS,
+});
+
 function deterministicRandom(length: number): Uint8Array {
   const bytes = new Uint8Array(length);
   for (let i = 0; i < length; i++) bytes[i] = i & 0xff;
@@ -373,6 +388,80 @@ describe("completeConnect", () => {
     }
   });
 
+  test("multi-workspace token: exposes workspaces array from the plural claim (#2196)", async () => {
+    const { fetchImpl } = captureFetch({
+      "/oauth2/token": () =>
+        jsonResponse({
+          access_token: MULTI_WORKSPACE_TOKEN,
+          refresh_token: "rfr-xyz",
+          token_type: "Bearer",
+          expires_in: 3600,
+          scope: "mcp:read offline_access",
+        }),
+    });
+
+    const result = await completeConnect({
+      ...baseComplete,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    // The singular claim is still the primary workspace; the plural claim
+    // surfaces alongside it as `workspaces`.
+    expect(result.workspaceId).toBe(WORKSPACE_ID);
+    expect(result.workspaces).toEqual(MULTI_WORKSPACE_IDS);
+  });
+
+  test("single-workspace token: workspaces array is empty when plural claim absent (#2196)", async () => {
+    // Backward compat: tokens minted for users with one workspace omit the
+    // plural claim. `workspaces` is an empty array, not undefined — the
+    // type is stable for consumers.
+    const { fetchImpl } = captureFetch({
+      "/oauth2/token": () =>
+        jsonResponse({
+          access_token: VALID_TOKEN,
+          refresh_token: "rfr-xyz",
+          token_type: "Bearer",
+          expires_in: 3600,
+          scope: "mcp:read offline_access",
+        }),
+    });
+
+    const result = await completeConnect({
+      ...baseComplete,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(result.workspaceId).toBe(WORKSPACE_ID);
+    expect(result.workspaces).toEqual([]);
+  });
+
+  test("malformed plural claim is treated as empty workspaces (#2196)", async () => {
+    // The server's `customAccessTokenClaims` always emits an array, but a
+    // misconfigured upstream issuer (custom self-hosted Better Auth fork)
+    // could emit a malformed shape. The SDK must not crash — drop to the
+    // singular-workspace path.
+    const tokenWithBadClaim = jwt({
+      iss: `${API_URL}/api/auth`,
+      sub: "user-1",
+      aud: `${API_URL}/mcp`,
+      azp: "client-abc",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      "https://atlas.useatlas.dev/workspace_id": WORKSPACE_ID,
+      "https://atlas.useatlas.dev/workspace_ids": "not-an-array",
+    });
+    const { fetchImpl } = captureFetch({
+      "/oauth2/token": () =>
+        jsonResponse({ access_token: tokenWithBadClaim, expires_in: 3600 }),
+    });
+
+    const result = await completeConnect({
+      ...baseComplete,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result.workspaceId).toBe(WORKSPACE_ID);
+    expect(result.workspaces).toEqual([]);
+  });
+
   test("double-submit of the same code surfaces the server's invalid_grant", async () => {
     let calls = 0;
     const fetchImpl: FetchStub = async () => {
@@ -486,6 +575,134 @@ describe("buildConfig", () => {
     });
     if (cfg.kind !== "bare") throw new Error("expected bare");
     expect(cfg.url).toBe(`${API_URL}/mcp/${encodeURIComponent("a/b c")}/sse`);
+  });
+
+  // ── Multi-workspace shape (#2196) ────────────────────────────────────
+  //
+  // Passing `workspaces` (a non-empty array of granted ids) opts into the
+  // multi-workspace block — the URL still pins one workspace as the
+  // default (server still requires `/mcp/{ws}/sse`), but an `env:
+  // { ATLAS_DEFAULT_WORKSPACE }` slot is emitted alongside the headers
+  // so future MCP-client frameworks can bridge it into the
+  // `X-Atlas-Default-Workspace` header. Mirrors `buildHostedServerConfig`
+  // in `plugins/mcp/src/init/config-merge.ts` exactly.
+
+  test("multi-workspace: wrapped block carries env.ATLAS_DEFAULT_WORKSPACE (#2196)", () => {
+    const cfg = buildConfig({
+      client: "claude-desktop",
+      apiUrl: API_URL,
+      accessToken: "access-token-xyz",
+      workspaceId: WORKSPACE_ID,
+      workspaces: MULTI_WORKSPACE_IDS,
+    });
+    expect(cfg).toEqual({
+      kind: "wrapped",
+      mcpServers: {
+        atlas: {
+          url: `${API_URL}/mcp/${WORKSPACE_ID}/sse`,
+          headers: { Authorization: "Bearer access-token-xyz" },
+          env: { ATLAS_DEFAULT_WORKSPACE: WORKSPACE_ID },
+        },
+      },
+    });
+  });
+
+  test("multi-workspace: bare block carries env.ATLAS_DEFAULT_WORKSPACE (#2196)", () => {
+    const cfg = buildConfig({
+      client: "generic",
+      apiUrl: API_URL,
+      accessToken: "access-token-xyz",
+      workspaceId: WORKSPACE_ID,
+      workspaces: MULTI_WORKSPACE_IDS,
+    });
+    expect(cfg).toEqual({
+      kind: "bare",
+      url: `${API_URL}/mcp/${WORKSPACE_ID}/sse`,
+      headers: { Authorization: "Bearer access-token-xyz" },
+      env: { ATLAS_DEFAULT_WORKSPACE: WORKSPACE_ID },
+    });
+  });
+
+  test("multi-workspace: single-element workspaces array still emits env (#2196)", () => {
+    // Treat the param as the multi-scope opt-in marker. A caller passing
+    // an explicit one-element array has signalled "this client is
+    // configured against the new shape" — honor that intent rather than
+    // silently falling back to single-workspace.
+    const cfg = buildConfig({
+      client: "generic",
+      apiUrl: API_URL,
+      accessToken: "access-token-xyz",
+      workspaceId: WORKSPACE_ID,
+      workspaces: [WORKSPACE_ID],
+    });
+    if (cfg.kind !== "bare") throw new Error("expected bare");
+    expect(cfg.env).toEqual({ ATLAS_DEFAULT_WORKSPACE: WORKSPACE_ID });
+  });
+
+  test("multi-workspace: empty workspaces array falls back to single-workspace (#2196)", () => {
+    // Defensive: an empty `workspaces: []` means "no multi-scope claims
+    // present" — equivalent to a single-workspace token where the plural
+    // claim was absent. Don't emit a misleading env block.
+    const cfg = buildConfig({
+      client: "claude-desktop",
+      apiUrl: API_URL,
+      accessToken: "access-token-xyz",
+      workspaceId: WORKSPACE_ID,
+      workspaces: [],
+    });
+    if (cfg.kind !== "wrapped") throw new Error("expected wrapped");
+    expect(cfg.mcpServers.atlas).toEqual({
+      url: `${API_URL}/mcp/${WORKSPACE_ID}/sse`,
+      headers: { Authorization: "Bearer access-token-xyz" },
+    });
+    expect("env" in cfg.mcpServers.atlas).toBe(false);
+  });
+
+  test("legacy: omitting workspaces still produces the single-workspace shape (#2196 backward compat)", () => {
+    // The decisive backward-compat pin: every existing call site that
+    // doesn't pass `workspaces` must continue to emit exactly the same
+    // single-workspace block as before, byte-for-byte. No env block.
+    const cfg = buildConfig({
+      client: "claude-desktop",
+      apiUrl: API_URL,
+      accessToken: "access-token-xyz",
+      workspaceId: WORKSPACE_ID,
+    });
+    expect(cfg).toEqual({
+      kind: "wrapped",
+      mcpServers: {
+        atlas: {
+          url: `${API_URL}/mcp/${WORKSPACE_ID}/sse`,
+          headers: { Authorization: "Bearer access-token-xyz" },
+        },
+      },
+    });
+  });
+});
+
+// ── beginConnect — multi-workspace forward-compat slot (#2196) ───────
+
+describe("beginConnect — multi-workspace forward-compat", () => {
+  test("workspaceId option is accepted as a forward-compat slot (#2196)", async () => {
+    // The OAuth provider does not yet accept a workspace hint in the
+    // authorize URL — `customAccessTokenClaims` on the server reads
+    // membership from the session at consent time and emits the
+    // singular + plural claims accordingly. The SDK accepts the
+    // `workspaceId` option as a reserved slot for when the provider
+    // adds the hint; today it is informational only and must not break
+    // the existing flow.
+    const { fetchImpl } = captureFetch({
+      ".well-known/oauth-authorization-server": () => jsonResponse(DISCOVERY_BODY),
+      "/oauth2/register": () => jsonResponse({ client_id: "client-abc" }),
+    });
+    await expect(
+      beginConnect({
+        ...baseBeginOptions,
+        workspaceId: WORKSPACE_ID,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        randomBytesImpl: deterministicRandom,
+      }),
+    ).resolves.toMatchObject({ clientId: "client-abc" });
   });
 });
 

--- a/packages/sdk/src/__tests__/mcp.test.ts
+++ b/packages/sdk/src/__tests__/mcp.test.ts
@@ -454,12 +454,71 @@ describe("completeConnect", () => {
         jsonResponse({ access_token: tokenWithBadClaim, expires_in: 3600 }),
     });
 
-    const result = await completeConnect({
-      ...baseComplete,
-      fetchImpl: fetchImpl as unknown as typeof fetch,
+    // Capture console.warn — the SDK emits a diagnostic for the
+    // malformed branch so a broken upstream issuer surfaces in operator
+    // logs rather than silently downgrading every user to single-workspace.
+    const warnCalls: unknown[][] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnCalls.push(args);
+    };
+    try {
+      const result = await completeConnect({
+        ...baseComplete,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      expect(result.workspaceId).toBe(WORKSPACE_ID);
+      expect(result.workspaces).toEqual([]);
+      // One warning fired for the non-array branch.
+      expect(warnCalls.length).toBe(1);
+      expect(String(warnCalls[0][0])).toContain("not an array");
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  test("mixed-type plural claim drops non-strings, keeps valid entries (#2196)", async () => {
+    // The realistic malformed shape: the claim IS an array but contains
+    // a mix of valid strings, null, numbers, and empty strings. A bug
+    // that dropped the filter would return the raw array — this test
+    // pins the filter as the load-bearing narrow.
+    const tokenWithMixedClaim = jwt({
+      iss: `${API_URL}/api/auth`,
+      sub: "user-1",
+      aud: `${API_URL}/mcp`,
+      azp: "client-abc",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      "https://atlas.useatlas.dev/workspace_id": WORKSPACE_ID,
+      "https://atlas.useatlas.dev/workspace_ids": [
+        "ws-1",
+        null,
+        42,
+        "",
+        "ws-2",
+      ],
     });
-    expect(result.workspaceId).toBe(WORKSPACE_ID);
-    expect(result.workspaces).toEqual([]);
+    const { fetchImpl } = captureFetch({
+      "/oauth2/token": () =>
+        jsonResponse({ access_token: tokenWithMixedClaim, expires_in: 3600 }),
+    });
+
+    const warnCalls: unknown[][] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnCalls.push(args);
+    };
+    try {
+      const result = await completeConnect({
+        ...baseComplete,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      expect(result.workspaces).toEqual(["ws-1", "ws-2"]);
+      // Partial-filter diagnostic fired.
+      expect(warnCalls.length).toBe(1);
+      expect(String(warnCalls[0][0])).toContain("3 non-string or empty");
+    } finally {
+      console.warn = originalWarn;
+    }
   });
 
   test("double-submit of the same code surfaces the server's invalid_grant", async () => {
@@ -656,6 +715,26 @@ describe("buildConfig", () => {
       headers: { Authorization: "Bearer access-token-xyz" },
     });
     expect("env" in cfg.mcpServers.atlas).toBe(false);
+  });
+
+  test("multi-workspace: throws workspace_not_in_grant_list when workspaceId is not in workspaces (#2196)", () => {
+    // Defensive throw — silently encoding a stale picker value into the
+    // URL would surface as a generic 403 cross_workspace_denied at
+    // runtime with no hint that the embedder's picker had a bad value.
+    try {
+      buildConfig({
+        client: "claude-desktop",
+        apiUrl: API_URL,
+        accessToken: "access-token-xyz",
+        workspaceId: "ws-stale",
+        workspaces: MULTI_WORKSPACE_IDS,
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(AtlasMcpError);
+      expect((err as AtlasMcpError).code).toBe("workspace_not_in_grant_list");
+      expect((err as AtlasMcpError).message).toContain("ws-stale");
+    }
   });
 
   test("legacy: omitting workspaces still produces the single-workspace shape (#2196 backward compat)", () => {

--- a/packages/sdk/src/mcp.ts
+++ b/packages/sdk/src/mcp.ts
@@ -132,6 +132,17 @@ function liftHelperSync<T>(fn: () => T): T {
 
 const DEFAULT_SCOPES: ReadonlyArray<string> = ["mcp:read", "offline_access"];
 const WORKSPACE_CLAIM = "https://atlas.useatlas.dev/workspace_id";
+/**
+ * Plural workspace-ids claim (#2073). Emitted by the Atlas Better Auth
+ * `customAccessTokenClaims` hook ONLY when the authenticating user
+ * belongs to more than one workspace. Read here for the same reason the
+ * CLI reads it: lets the embedder render a workspace picker without a
+ * follow-up `/me/workspaces` roundtrip. The runtime authorization layer
+ * at the MCP edge ignores this claim — it does a live grants-table
+ * lookup so membership revocation is immediate; the claim is purely a
+ * UX affordance.
+ */
+const WORKSPACES_CLAIM = "https://atlas.useatlas.dev/workspace_ids";
 
 // ── Public types ──────────────────────────────────────────────────────
 
@@ -153,6 +164,23 @@ export interface BeginConnectOptions {
   redirectUri: string;
   /** Defaults to `["mcp:read", "offline_access"]`. */
   scopes?: ReadonlyArray<string>;
+  /**
+   * Forward-compat slot (#2196) for binding the OAuth flow to one
+   * workspace. The Atlas OAuth provider does not yet accept a workspace
+   * hint on the authorize endpoint — server-side claim issuance reads
+   * the user's session at consent time and emits the singular +
+   * (optionally) plural claims based on membership. Today this option
+   * is informational and does not affect the wire flow; reserved so the
+   * SDK surface doesn't need to change when the provider adds the hint.
+   *
+   * To get a multi-workspace token, omit this option AND ensure the
+   * authenticating user belongs to more than one workspace. To get a
+   * single-workspace token bound to the user's active workspace, do
+   * the same — the server emits the plural claim only when the
+   * membership list has more than one entry. The plural claim then
+   * surfaces on `completeConnect`'s result as `workspaces`.
+   */
+  workspaceId?: string;
   /** Test seam — defaults to global `fetch`. */
   fetchImpl?: typeof fetch;
   /** Test seam — defaults to `crypto.getRandomValues`. */
@@ -223,6 +251,21 @@ export interface CompleteConnectResult {
   expiresAt: number;
   /** `https://atlas.useatlas.dev/workspace_id` claim from the JWT. */
   workspaceId: string;
+  /**
+   * `https://atlas.useatlas.dev/workspace_ids` plural claim (#2196) — the
+   * complete set of workspaces this token grants access to, in the order
+   * the server emitted them. Empty array when the token was minted for
+   * a user belonging to exactly one workspace (the server omits the
+   * plural claim in that case — see `customAccessTokenClaims` in
+   * `packages/api/src/lib/auth/server.ts`). Always a stable type so
+   * embedders rendering a workspace picker don't need to null-check.
+   *
+   * The runtime authorization layer at the MCP edge does NOT rely on
+   * this list — membership is re-checked against the live grants table
+   * on every request so revocation is immediate. Treat the array as a
+   * UX affordance, not a security boundary.
+   */
+  workspaces: string[];
 }
 
 export type McpClientId =
@@ -236,14 +279,54 @@ export interface BuildConfigOptions {
   client: McpClientId;
   apiUrl: string;
   accessToken: string;
+  /**
+   * Workspace pinned in the connection URL. Even for multi-workspace
+   * tokens this is required — the hosted MCP edge mounts at
+   * `/mcp/{workspace_id}/sse`. For multi-workspace setups pass the
+   * default-workspace id (typically the singular claim from
+   * `completeConnect`); per-request overrides happen via the
+   * `X-Atlas-Workspace` header.
+   */
   workspaceId: string;
   /** Override the `mcpServers["..."]` key. Defaults to `"atlas"`. */
   serverName?: string;
+  /**
+   * Multi-workspace opt-in (#2196). Pass the full list of workspaces
+   * this token grants access to (the `workspaces` field from
+   * `completeConnect`'s result). When non-empty, the emitted block
+   * gains an `env: { ATLAS_DEFAULT_WORKSPACE: <workspaceId> }` slot so
+   * future MCP-client framework wrappers can bridge it into the
+   * `X-Atlas-Default-Workspace` header (priority 2 in the edge's
+   * resolution chain). Mirrors `buildHostedServerConfig` in the CLI
+   * (`plugins/mcp/src/init/config-merge.ts`) so the SDK and CLI emit
+   * identical config blocks for the same token.
+   *
+   * **Wire-shape note.** [#2073's recommendation A](https://github.com/AtlasDevHQ/atlas/issues/2073)
+   * sketched `url: "https://mcp.useatlas.dev/sse"` without a workspace
+   * in the path, but the implementation in
+   * `packages/api/src/api/index.ts` mounts the endpoint at
+   * `/mcp/{workspace_id}/sse` and resolves per-request overrides via
+   * the `X-Atlas-Workspace` header (see `resolveMultiScopeWorkspace`
+   * in `packages/mcp/src/hosted.ts`). The SDK emits the
+   * implemented shape — a single config block, one default workspace
+   * in the path, and the env hint for per-request overrides.
+   *
+   * Omit (or pass an empty array) for the legacy single-workspace
+   * shape — backward-compatible with every caller pre-#2196.
+   */
+  workspaces?: ReadonlyArray<string>;
 }
 
 export interface McpHttpServer {
   url: string;
   headers: { Authorization: string };
+  /**
+   * Multi-workspace hint block (#2196). Present only when `buildConfig`
+   * was called with a non-empty `workspaces` array — the legacy
+   * single-workspace shape omits the field entirely so its JSON
+   * output is byte-identical to pre-#2196 callers.
+   */
+  env?: { ATLAS_DEFAULT_WORKSPACE: string };
 }
 
 /**
@@ -381,6 +464,7 @@ export async function completeConnect(
     const claims = decodeJwtPayload(tokenResponse.access_token);
     enforceIssuer(claims, issuer);
     const workspaceId = extractWorkspaceClaim(claims);
+    const workspaces = extractWorkspacesClaim(claims);
 
     const expiresIn =
       typeof tokenResponse.expires_in === "number" && tokenResponse.expires_in > 0
@@ -392,6 +476,7 @@ export async function completeConnect(
       refreshToken: tokenResponse.refresh_token ?? null,
       expiresAt: Date.now() + expiresIn * 1000,
       workspaceId,
+      workspaces,
     };
   });
 }
@@ -405,10 +490,21 @@ export function buildConfig(options: BuildConfigOptions): McpClientConfig {
   // workspaceId is opaque server-issued; encode it defensively so a
   // value containing path-sensitive characters can't reshape the URL.
   const url = `${apiUrl}/mcp/${encodeURIComponent(options.workspaceId)}/sse`;
-  const block: McpHttpServer = {
-    url,
-    headers: { Authorization: `Bearer ${options.accessToken}` },
-  };
+  // Multi-workspace opt-in: `workspaces` non-empty signals the caller
+  // is configuring against the #2196 shape — emit the env hint. An
+  // empty array (or omitted) preserves the byte-identical pre-#2196
+  // single-workspace shape.
+  const isMultiWorkspace = (options.workspaces?.length ?? 0) > 0;
+  const block: McpHttpServer = isMultiWorkspace
+    ? {
+        url,
+        headers: { Authorization: `Bearer ${options.accessToken}` },
+        env: { ATLAS_DEFAULT_WORKSPACE: options.workspaceId },
+      }
+    : {
+        url,
+        headers: { Authorization: `Bearer ${options.accessToken}` },
+      };
   const name = options.serverName ?? SERVER_NAME_DEFAULT;
 
   // Exhaustive switch on the discriminator — adding a new client to
@@ -417,7 +513,14 @@ export function buildConfig(options: BuildConfigOptions): McpClientConfig {
   // branch with the wrong shape.
   switch (options.client) {
     case "generic":
-      return { kind: "bare", url: block.url, headers: block.headers };
+      return isMultiWorkspace
+        ? {
+            kind: "bare",
+            url: block.url,
+            headers: block.headers,
+            env: block.env,
+          }
+        : { kind: "bare", url: block.url, headers: block.headers };
     case "claude-desktop":
     case "cursor":
     case "continue":
@@ -495,4 +598,25 @@ function extractWorkspaceClaim(payload: Record<string, unknown>): string {
     );
   }
   return claim;
+}
+
+/**
+ * Extract the optional plural workspaces claim (#2196). Returns an
+ * empty array when the claim is missing (single-workspace tokens omit
+ * it — see `customAccessTokenClaims` in `packages/api/src/lib/auth/
+ * server.ts`) OR when the claim is present but malformed (defensive
+ * against a custom self-hosted Better Auth fork that emits the wrong
+ * shape). Never throws — the plural claim is informational, not a
+ * security boundary; falling back to the singular workspace is always
+ * safe. Mirrors the CLI's `extractWorkspacesClaim` in
+ * `plugins/mcp/src/init/hosted.ts` so the two surfaces apply the same
+ * tolerant parse.
+ */
+function extractWorkspacesClaim(payload: Record<string, unknown>): string[] {
+  const raw = payload[WORKSPACES_CLAIM];
+  if (raw === undefined) return [];
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (entry): entry is string => typeof entry === "string" && entry.length > 0,
+  );
 }

--- a/packages/sdk/src/mcp.ts
+++ b/packages/sdk/src/mcp.ts
@@ -70,7 +70,8 @@ export type AtlasMcpErrorCode =
   | "callback_missing_code"
   | "popup_blocked"
   | "popup_closed"
-  | "grant_not_supported";
+  | "grant_not_supported"
+  | "workspace_not_in_grant_list";
 
 /**
  * Compile-time witness that `OAuthHelperErrorCode ⊂ AtlasMcpErrorCode`.
@@ -165,20 +166,18 @@ export interface BeginConnectOptions {
   /** Defaults to `["mcp:read", "offline_access"]`. */
   scopes?: ReadonlyArray<string>;
   /**
-   * Forward-compat slot (#2196) for binding the OAuth flow to one
-   * workspace. The Atlas OAuth provider does not yet accept a workspace
-   * hint on the authorize endpoint — server-side claim issuance reads
-   * the user's session at consent time and emits the singular +
-   * (optionally) plural claims based on membership. Today this option
-   * is informational and does not affect the wire flow; reserved so the
-   * SDK surface doesn't need to change when the provider adds the hint.
+   * Forward-compat slot (#2196). **No-op today.** The Atlas OAuth
+   * provider does not yet accept a workspace hint on the authorize
+   * endpoint — server-side claim issuance reads the user's session at
+   * consent time and emits the singular + (optionally) plural claims
+   * based on membership, regardless of what you pass here. Reserved so
+   * the SDK surface doesn't need to change when the provider lands
+   * the hint.
    *
-   * To get a multi-workspace token, omit this option AND ensure the
-   * authenticating user belongs to more than one workspace. To get a
-   * single-workspace token bound to the user's active workspace, do
-   * the same — the server emits the plural claim only when the
-   * membership list has more than one entry. The plural claim then
-   * surfaces on `completeConnect`'s result as `workspaces`.
+   * Passing this option today has no observable effect — to get a
+   * multi-workspace token, just ensure the authenticating user belongs
+   * to more than one workspace. The plural claim then surfaces on
+   * `completeConnect`'s result as `workspaces`.
    */
   workspaceId?: string;
   /** Test seam — defaults to global `fetch`. */
@@ -256,16 +255,21 @@ export interface CompleteConnectResult {
    * complete set of workspaces this token grants access to, in the order
    * the server emitted them. Empty array when the token was minted for
    * a user belonging to exactly one workspace (the server omits the
-   * plural claim in that case — see `customAccessTokenClaims` in
-   * `packages/api/src/lib/auth/server.ts`). Always a stable type so
-   * embedders rendering a workspace picker don't need to null-check.
+   * plural claim in that case). Always a stable type so embedders
+   * rendering a workspace picker don't need to null-check.
+   *
+   * Typed `ReadonlyArray<string>` so consumers can't mutate the
+   * SDK-owned array in place (the value is held in `useState` inside
+   * `useMcpConnect`; an in-place `.sort()` would silently mutate React
+   * state). Pipes cleanly into `buildConfig({ workspaces })` whose
+   * input shape is the same.
    *
    * The runtime authorization layer at the MCP edge does NOT rely on
    * this list — membership is re-checked against the live grants table
    * on every request so revocation is immediate. Treat the array as a
    * UX affordance, not a security boundary.
    */
-  workspaces: string[];
+  workspaces: ReadonlyArray<string>;
 }
 
 export type McpClientId =
@@ -297,19 +301,16 @@ export interface BuildConfigOptions {
    * gains an `env: { ATLAS_DEFAULT_WORKSPACE: <workspaceId> }` slot so
    * future MCP-client framework wrappers can bridge it into the
    * `X-Atlas-Default-Workspace` header (priority 2 in the edge's
-   * resolution chain). Mirrors `buildHostedServerConfig` in the CLI
-   * (`plugins/mcp/src/init/config-merge.ts`) so the SDK and CLI emit
-   * identical config blocks for the same token.
+   * resolution chain). Output matches the CLI's hosted-config writer
+   * so SDK and CLI emit identical config blocks for the same token.
    *
    * **Wire-shape note.** [#2073's recommendation A](https://github.com/AtlasDevHQ/atlas/issues/2073)
    * sketched `url: "https://mcp.useatlas.dev/sse"` without a workspace
-   * in the path, but the implementation in
-   * `packages/api/src/api/index.ts` mounts the endpoint at
+   * in the path, but the implemented hosted MCP endpoint mounts at
    * `/mcp/{workspace_id}/sse` and resolves per-request overrides via
-   * the `X-Atlas-Workspace` header (see `resolveMultiScopeWorkspace`
-   * in `packages/mcp/src/hosted.ts`). The SDK emits the
-   * implemented shape — a single config block, one default workspace
-   * in the path, and the env hint for per-request overrides.
+   * the `X-Atlas-Workspace` header. The SDK emits the implemented
+   * shape — a single config block, one default workspace in the
+   * path, and the env hint for per-request overrides.
    *
    * Omit (or pass an empty array) for the legacy single-workspace
    * shape — backward-compatible with every caller pre-#2196.
@@ -323,8 +324,11 @@ export interface McpHttpServer {
   /**
    * Multi-workspace hint block (#2196). Present only when `buildConfig`
    * was called with a non-empty `workspaces` array — the legacy
-   * single-workspace shape omits the field entirely so its JSON
-   * output is byte-identical to pre-#2196 callers.
+   * single-workspace shape omits the field entirely so the
+   * JSON-serialized server block is byte-identical to pre-#2196
+   * output. (The outer `McpClientConfig` carries a `kind` discriminator
+   * intended to be dropped before JSON output; see `stripKind` in the
+   * worked example for the standard call-site pattern.)
    */
   env?: { ATLAS_DEFAULT_WORKSPACE: string };
 }
@@ -490,11 +494,19 @@ export function buildConfig(options: BuildConfigOptions): McpClientConfig {
   // workspaceId is opaque server-issued; encode it defensively so a
   // value containing path-sensitive characters can't reshape the URL.
   const url = `${apiUrl}/mcp/${encodeURIComponent(options.workspaceId)}/sse`;
-  // Multi-workspace opt-in: `workspaces` non-empty signals the caller
-  // is configuring against the #2196 shape — emit the env hint. An
-  // empty array (or omitted) preserves the byte-identical pre-#2196
-  // single-workspace shape.
+  // Multi-workspace opt-in (#2196): non-empty `workspaces` emits the
+  // env hint. Empty / omitted preserves the legacy single-workspace
+  // shape. Loudly reject the embedder-error case where the picked
+  // default isn't in the granted set — silently encoding a stale id
+  // into the URL would surface as a generic 403 cross_workspace_denied
+  // at runtime with no hint that the picker had a bad value.
   const isMultiWorkspace = (options.workspaces?.length ?? 0) > 0;
+  if (isMultiWorkspace && !options.workspaces!.includes(options.workspaceId)) {
+    throw new AtlasMcpError(
+      `buildConfig: workspaceId \`${options.workspaceId}\` is not in the granted workspaces list — pass a default that is one of: ${options.workspaces!.join(", ")}.`,
+      "workspace_not_in_grant_list",
+    );
+  }
   const block: McpHttpServer = isMultiWorkspace
     ? {
         url,
@@ -603,20 +615,37 @@ function extractWorkspaceClaim(payload: Record<string, unknown>): string {
 /**
  * Extract the optional plural workspaces claim (#2196). Returns an
  * empty array when the claim is missing (single-workspace tokens omit
- * it — see `customAccessTokenClaims` in `packages/api/src/lib/auth/
- * server.ts`) OR when the claim is present but malformed (defensive
- * against a custom self-hosted Better Auth fork that emits the wrong
- * shape). Never throws — the plural claim is informational, not a
- * security boundary; falling back to the singular workspace is always
- * safe. Mirrors the CLI's `extractWorkspacesClaim` in
- * `plugins/mcp/src/init/hosted.ts` so the two surfaces apply the same
- * tolerant parse.
+ * it) OR when the claim is present but malformed. Never throws — the
+ * plural claim is informational, not a security boundary; falling back
+ * to the singular workspace is always safe.
+ *
+ * Diagnostics: the missing-claim path is the documented common case for
+ * single-workspace tokens and stays silent. The malformed paths
+ * (non-array shape, or array with non-string entries) emit a
+ * `console.warn` so a misconfigured self-hosted issuer that ships a
+ * broken plural shape on every token surfaces in operator logs rather
+ * than silently downgrading every user to single-workspace forever.
+ * The matching CLI helper (`plugins/mcp/src/init/hosted.ts`) emits the
+ * same diagnostics via its own logger seam — parity prevents the SDK
+ * and CLI from diverging on which malformed inputs produce a signal.
  */
 function extractWorkspacesClaim(payload: Record<string, unknown>): string[] {
   const raw = payload[WORKSPACES_CLAIM];
   if (raw === undefined) return [];
-  if (!Array.isArray(raw)) return [];
-  return raw.filter(
+  if (!Array.isArray(raw)) {
+    console.warn(
+      `[@useatlas/sdk] ${WORKSPACES_CLAIM} claim was present but not an array (got ${typeof raw}); falling back to single-workspace.`,
+    );
+    return [];
+  }
+  const filtered = raw.filter(
     (entry): entry is string => typeof entry === "string" && entry.length > 0,
   );
+  if (filtered.length !== raw.length) {
+    const dropped = raw.length - filtered.length;
+    console.warn(
+      `[@useatlas/sdk] ${WORKSPACES_CLAIM} claim contained ${dropped} non-string or empty entr${dropped === 1 ? "y" : "ies"}; using only the ${filtered.length} valid entr${filtered.length === 1 ? "y" : "ies"}.`,
+    );
+  }
+  return filtered;
 }


### PR DESCRIPTION
## Summary

Closes #2196. Surfaces the multi-workspace MCP shape in `@useatlas/sdk` + `@useatlas/react` now that [#2073](https://github.com/AtlasDevHQ/atlas/issues/2073) (cross-workspace agent identity) has shipped. SDK helpers were originally released in single-workspace form in [#2079](https://github.com/AtlasDevHQ/atlas/issues/2079) with #2196 tracking the gap.

- `completeConnect` now returns `workspaces: string[]` — extracted from the plural `https://atlas.useatlas.dev/workspace_ids` JWT claim. Empty array for single-workspace tokens (the server omits the claim per `customAccessTokenClaims` in `packages/api/src/lib/auth/server.ts`).
- `buildConfig({ workspaces })` opts into the multi-workspace block — emits an `env: { ATLAS_DEFAULT_WORKSPACE }` slot alongside the legacy headers so future MCP-client framework wrappers can bridge it into the `X-Atlas-Default-Workspace` header (priority 2 in the edge's resolution chain — see `resolveMultiScopeWorkspace` in `packages/mcp/src/hosted.ts`). Mirrors `buildHostedServerConfig` in `plugins/mcp/src/init/config-merge.ts` byte-for-byte.
- `useMcpConnect` surfaces `workspaces: string[]` on its success branch alongside the existing `workspaceId`. Embedders gate a workspace picker on `workspaces.length > 1`.
- `beginConnect({ workspaceId? })` accepts a forward-compat slot for when the OAuth provider adds a workspace hint to the authorize endpoint. Today the server's `customAccessTokenClaims` reads membership from the consenting user's session and emits the plural claim automatically — the SDK option is informational.

## Backward compatibility

Every existing caller is byte-identical to pre-#2196:

- `buildConfig` with no `workspaces` arg returns the legacy block exactly — no `env` field on `McpHttpServer`.
- `completeConnect` adds `workspaces` to its result; consumers that destructure only `workspaceId` are unaffected.
- The `useMcpConnect` success branch adds `workspaces`; ignoring it is harmless.

## Note on the wire shape vs the issue description

[#2073's recommendation A](https://github.com/AtlasDevHQ/atlas/issues/2073) sketched the multi-workspace URL as `https://mcp.useatlas.dev/sse` (no workspace in the path). The implementation in `packages/api/src/api/index.ts` mounts the hosted MCP endpoint at `/mcp/{workspace_id}/sse` and resolves per-request workspace overrides via the `X-Atlas-Workspace` header. The CLI's `buildHostedServerConfig` already matches the implemented shape (path-pinned URL + `env: { ATLAS_DEFAULT_WORKSPACE }`); this PR brings the SDK in line with both. Per the issue's "trust the server" guidance, the multi-workspace `buildConfig` output emits the implemented shape rather than the originally proposed sketch — call this out so future readers don't re-litigate.

## Version bump

`@useatlas/sdk` is bumped to `0.0.14`. Per the [publish ordering rule](https://github.com/AtlasDevHQ/atlas/blob/main/CLAUDE.md#publishing-useatlas-packages), consumer refs in `packages/react/package.json` and the create-atlas templates stay at `>=0.0.13` / `^0.0.13`; the follow-up bump-refs PR ships after the SDK release tag publishes.

## Test plan

- [x] `bun run test` — full suite green (others-suite + api affected)
- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun x syncpack lint` — no issues
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — passed (558 files verified)
- [x] `bash scripts/check-railway-watch.sh` — all COPY sources covered
- [x] Added 6 new SDK tests + 2 new React hook tests pinning both single- and multi-workspace shapes
- [x] Pre-#2196 single-workspace `buildConfig` output is byte-identical (regression-pinned in tests)

## Out of scope

- The `selectWorkspace` MCP tool variant from [#2073's option B](https://github.com/AtlasDevHQ/atlas/issues/2073) — that's a workspace-tool decision, not an SDK shape decision (per the issue).