### PR TITLE
fix(api): allowlist now matches quoted reserved-keyword tables (e.g. `"user"`)

### DIFF
--- a/packages/api/src/lib/__tests__/semantic-multisource.test.ts
+++ b/packages/api/src/lib/__tests__/semantic-multisource.test.ts
@@ -242,6 +242,33 @@ describe("per-source semantic layer loading", () => {
     expect(defaultTables).not.toBe(warehouseTables);
   });
 
+  it("quoted reserved-keyword table names (e.g. Postgres \"user\") are whitelisted unquoted", () => {
+    // Better Auth's `user` table is a Postgres reserved keyword. Importers
+    // quote it in the YAML (`table: '"user"'`) so the round-trip survives,
+    // but `node-sql-parser` strips the quotes when extracting tables from
+    // `FROM "user"`. The whitelist must store the unquoted form or every
+    // lookup misses.
+    const root = ensureDir(`quoted-${testCounter}`);
+    const defaultEntities = ensureDir(`quoted-${testCounter}/entities`);
+
+    writeEntity(defaultEntities, "user.yml", `table: '"user"'\ncolumns:\n  id:\n    type: text\n`);
+    writeEntity(defaultEntities, "events.yml", "table: '`events`'\ncolumns:\n  id:\n    type: integer\n");
+    writeEntity(
+      defaultEntities,
+      "audit.yml",
+      `table: 'public."audit_log"'\ncolumns:\n  id:\n    type: integer\n`,
+    );
+
+    const tables = getWhitelistedTables("default", undefined, root);
+    expect(tables.has("user")).toBe(true);
+    expect(tables.has("events")).toBe(true);
+    expect(tables.has("audit_log")).toBe(true);
+    expect(tables.has("public.audit_log")).toBe(true);
+    // Quoted forms must NOT survive — they'd never match parser output
+    expect(tables.has('"user"')).toBe(false);
+    expect(tables.has('public."audit_log"')).toBe(false);
+  });
+
   it("reserved directories with entities/ subfolder are still excluded", () => {
     const root = ensureDir(`reserved-strict-${testCounter}`);
     const defaultEntities = ensureDir(`reserved-strict-${testCounter}/entities`);

--- a/packages/api/src/lib/semantic/whitelist.ts
+++ b/packages/api/src/lib/semantic/whitelist.ts
@@ -59,6 +59,38 @@ const _whitelists = new Map<string, Set<string>>();
 let _tablesByConnection: Map<string, Set<string>> | null = null;
 let _crossSourceJoins: CrossSourceJoin[] | null = null;
 
+/**
+ * Strip identifier quotes from each dotted segment of a table name.
+ *
+ * Entity YAMLs sometimes carry quoted table names because the underlying
+ * identifier is a SQL reserved keyword (e.g. Better Auth's Postgres `"user"`
+ * table). `node-sql-parser` strips identifier quotes from its `tableList`
+ * output before we look the name up, so the whitelist must store the
+ * unquoted form or the lookup misses on every `FROM "user"` the agent
+ * emits. Handles the three identifier-quote forms our supported dialects
+ * use: `"name"` (Postgres / ANSI), `` `name` `` (MySQL), `[name]` (T-SQL).
+ * Schema-qualified names are normalized per segment so `public."user"`
+ * → `public.user`.
+ */
+export function normalizeTableIdentifier(raw: string): string {
+  return raw
+    .split(".")
+    .map((seg) => {
+      if (seg.length < 2) return seg;
+      const first = seg[0];
+      const last = seg[seg.length - 1];
+      if (
+        (first === '"' && last === '"') ||
+        (first === "`" && last === "`") ||
+        (first === "[" && last === "]")
+      ) {
+        return seg.slice(1, -1);
+      }
+      return seg;
+    })
+    .join(".");
+}
+
 /** Plugin-provided entity tables, keyed by connection ID. */
 const _pluginEntities = new Map<string, Set<string>>();
 
@@ -113,11 +145,14 @@ function loadEntitiesFromDir(
       if (!byConnection.has(connId)) byConnection.set(connId, new Set());
       const tables = byConnection.get(connId)!;
 
-      // Extract table name (may include schema prefix like "public.users")
-      const parts = entity.table.split(".");
+      // Extract table name (may include schema prefix like "public.users").
+      // Normalize identifier quotes so `"user"` / `` `user` `` in the YAML
+      // matches the unquoted name `node-sql-parser` returns from `FROM "user"`.
+      const normalized = normalizeTableIdentifier(entity.table);
+      const parts = normalized.split(".");
       tables.add(parts[parts.length - 1].toLowerCase());
       // Also add the full qualified name
-      tables.add(entity.table.toLowerCase());
+      tables.add(normalized.toLowerCase());
 
       // Validate and collect cross-source joins separately from core entity parsing.
       // Invalid join entries are skipped individually without dropping the entity.
@@ -343,7 +378,7 @@ export function registerPluginEntities(
         skippedCount++;
         continue;
       }
-      const tableName = parsed.data.table;
+      const tableName = normalizeTableIdentifier(parsed.data.table);
       const parts = tableName.split(".");
       tables.add(parts[parts.length - 1].toLowerCase());
       tables.add(tableName.toLowerCase());
@@ -458,9 +493,10 @@ export async function loadOrgWhitelist(orgId: string, mode?: "published" | "deve
       const connId = parsed.data.connection ?? row.connection_id ?? "default";
       if (!byConnection.has(connId)) byConnection.set(connId, new Set());
       const tables = byConnection.get(connId)!;
-      const parts = parsed.data.table.split(".");
+      const normalized = normalizeTableIdentifier(parsed.data.table);
+      const parts = normalized.split(".");
       tables.add(parts[parts.length - 1].toLowerCase());
-      tables.add(parsed.data.table.toLowerCase());
+      tables.add(normalized.toLowerCase());
     } catch (err) {
       parseFailures++;
       log.warn(


### PR DESCRIPTION
## Summary
- New `normalizeTableIdentifier()` helper in `packages/api/src/lib/semantic/whitelist.ts` strips one wrapping pair of `"…"`, `` `…` ``, or `[…]` from each dotted segment before the loader lowercases and stores.
- Applied at all three whitelist ingest paths: file-based (`loadEntitiesFromDir`), plugin (`registerPluginEntities`), and org-DB-backed (`loadOrgWhitelist`).
- Test in `semantic-multisource.test.ts` exercises Postgres `"user"`, MySQL `` `events` ``, and schema-qualified `public."audit_log"`.

## Why
`node-sql-parser` strips identifier quotes from its `tableList` output, so `FROM "user"` (Better Auth's Postgres-reserved-keyword table) reaches the validator as `user`. When an entity YAML stores the quoted form to round-trip through Postgres (`table: '"user"'`), the whitelist held `"user"` verbatim — every agent query hit:

> Table "user" is not in the allowed list. Open admin → Semantic to add this table.

…despite `listEntities` reporting the entity present.

Surfaced while trying to query daily signups across `us-prod` / `eu-prod` / `apac-prod`: every variant (`"user"`, `public."user"`, schema-qualified, with-alias) rejected on every region. Bug is symmetric across self-hosted (file YAML) and SaaS (org DB) — both call sites had identical `entity.table.toLowerCase()` logic.

## Out of scope
- Agent-prompt guidance to quote reserved keywords when emitting SQL. Postgres rejects `FROM user` bare (it's a reserved word), so the agent still needs to know to write `FROM "user"`. That's a prompt-engineering issue, separate.
- Re-importing existing production entities to drop the quotes from the stored YAML. The loader-side normalization handles them in place; no migration needed.

## Test plan
- [x] `bun test src/lib/__tests__/semantic-multisource.test.ts` — 23 pass (22 → 23), new test covers Postgres `"user"`, MySQL backticks, and schema-qualified `public."audit_log"`.
- [x] `bun run scripts/test-isolated.ts --affected` — 9/9 files pass, including `semantic.test.ts`, `semantic-org.test.ts`, `diff-whitelist-scoping.test.ts`.
- [x] `bun run lint` clean.
- [x] `bun run type` clean.
- [ ] Verify in a region after merge: `SELECT DATE("createdAt"), COUNT(*) FROM "user" WHERE "createdAt" >= CURRENT_DATE - INTERVAL '30 days' GROUP BY 1 ORDER BY 1` runs through the agent on us-prod / eu-prod / apac-prod.