### PR TITLE
[codex] Harden Vercel sandbox access

### DIFF
--- a/packages/api/src/lib/logger.ts
+++ b/packages/api/src/lib/logger.ts
@@ -98,6 +98,7 @@ const CREDENTIAL_FIELDS = [
   // F-44: expanded field coverage for webhook / OAuth / chat / header leaks.
   "cookie",
   "bearer",
+  "token",
   "refreshToken",
   "botToken",
   "signingSecret",

--- a/packages/api/src/lib/tools/__tests__/explore-backend.test.ts
+++ b/packages/api/src/lib/tools/__tests__/explore-backend.test.ts
@@ -264,4 +264,36 @@ describe("explore backend selection", () => {
       mod.invalidateExploreBackend(); // Should not throw
     });
   });
+
+  describe("sandbox.priority failure message", () => {
+    it("includes backend reasons and self-hosted just-bash guidance", async () => {
+      const mod = await freshExploreModule();
+      const message = mod._formatSandboxPriorityFailureForTest(
+        ["vercel-sandbox", "sidecar"],
+        [
+          { name: "vercel-sandbox", reason: "401 invalid token" },
+          { name: "sidecar", reason: "connection refused" },
+        ],
+        "self-hosted",
+      );
+
+      expect(message).toContain("vercel-sandbox: 401 invalid token");
+      expect(message).toContain("sidecar: connection refused");
+      expect(message).toContain("VERCEL_TEAM_ID");
+      expect(message).toContain("ATLAS_SANDBOX_URL");
+      expect(message).toContain("Add 'just-bash'");
+    });
+
+    it("suppresses just-bash guidance in SaaS mode", async () => {
+      const mod = await freshExploreModule();
+      const message = mod._formatSandboxPriorityFailureForTest(
+        ["vercel-sandbox", "sidecar"],
+        [{ name: "vercel-sandbox", reason: "401 invalid token" }],
+        "saas",
+      );
+
+      expect(message).toContain("vercel-sandbox: 401 invalid token");
+      expect(message).not.toContain("Add 'just-bash'");
+    });
+  });
 });

--- a/packages/api/src/lib/tools/__tests__/python-sandbox.test.ts
+++ b/packages/api/src/lib/tools/__tests__/python-sandbox.test.ts
@@ -138,6 +138,9 @@ describe("createPythonSandboxBackend", () => {
   const originalEnv = { ...process.env };
 
   beforeEach(() => {
+    delete process.env.VERCEL_TEAM_ID;
+    delete process.env.VERCEL_PROJECT_ID;
+    delete process.env.VERCEL_TOKEN;
     setupSandboxMock();
   });
 
@@ -166,6 +169,26 @@ describe("createPythonSandboxBackend", () => {
     if (result.success) {
       expect(result.output).toBe("hello");
     }
+  });
+
+  it("passes explicit Vercel Sandbox access credentials to Sandbox.create", async () => {
+    process.env.VERCEL_TEAM_ID = "team_123";
+    process.env.VERCEL_PROJECT_ID = "prj_123";
+    process.env.VERCEL_TOKEN = "vercel-token";
+
+    setupSandboxMock();
+    const backend = await freshBackend();
+    await backend.exec("print(1)");
+
+    expect(mockCreateCalls.length).toBe(1);
+    const createOpts = mockCreateCalls[0] as {
+      teamId?: string;
+      projectId?: string;
+      token?: string;
+    };
+    expect(createOpts.teamId).toBe("team_123");
+    expect(createOpts.projectId).toBe("prj_123");
+    expect(createOpts.token).toBe("vercel-token");
   });
 
   it("writes wrapper, user code, and data files to sandbox", async () => {

--- a/packages/api/src/lib/tools/backends/__tests__/detect.test.ts
+++ b/packages/api/src/lib/tools/backends/__tests__/detect.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+let warnCalls = 0;
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    debug: () => {},
+    info: () => {},
+    warn: () => {
+      warnCalls += 1;
+    },
+    error: () => {},
+  }),
+}));
+
+const SANDBOX_ENV = [
+  "ATLAS_RUNTIME",
+  "VERCEL",
+  "VERCEL_TEAM_ID",
+  "VERCEL_PROJECT_ID",
+  "VERCEL_TOKEN",
+] as const;
+
+async function detectModule() {
+  const mod = await import("@atlas/api/lib/tools/backends/detect");
+  mod._resetVercelSandboxDetectForTest();
+  return mod;
+}
+
+describe("Vercel sandbox detection", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    warnCalls = 0;
+    for (const key of SANDBOX_ENV) {
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  describe("vercelSandboxAccess", () => {
+    it.each([
+      ["VERCEL_TEAM_ID"],
+      ["VERCEL_PROJECT_ID"],
+      ["VERCEL_TOKEN"],
+    ] as const)("returns undefined when %s is missing", async (missing) => {
+      process.env.VERCEL_TEAM_ID = "team_123";
+      process.env.VERCEL_PROJECT_ID = "prj_123";
+      process.env.VERCEL_TOKEN = "vercel-token";
+      delete process.env[missing];
+
+      const { vercelSandboxAccess } = await detectModule();
+
+      expect(vercelSandboxAccess()).toBeUndefined();
+    });
+
+    it("returns explicit access with a redacted reveal-only token when all credentials are set", async () => {
+      process.env.VERCEL_TEAM_ID = "team_123";
+      process.env.VERCEL_PROJECT_ID = "prj_123";
+      process.env.VERCEL_TOKEN = "vercel-token";
+
+      const { vercelSandboxAccess } = await detectModule();
+
+      const access = vercelSandboxAccess();
+      expect(access?.teamId).toBe("team_123");
+      expect(access?.projectId).toBe("prj_123");
+      expect(access?.token.reveal()).toBe("vercel-token");
+      expect(String(access?.token)).toBe("[REDACTED]");
+      expect(JSON.stringify(access)).not.toContain("vercel-token");
+    });
+
+    it("records the partial-credentials warning only once", async () => {
+      process.env.VERCEL_TEAM_ID = "team_123";
+      process.env.VERCEL_TOKEN = "vercel-token";
+
+      const { _partialCredsWarnedForTest, vercelSandboxAccess } = await detectModule();
+
+      expect(_partialCredsWarnedForTest()).toBe(false);
+      expect(vercelSandboxAccess()).toBeUndefined();
+      expect(_partialCredsWarnedForTest()).toBe(true);
+      expect(vercelSandboxAccess()).toBeUndefined();
+      expect(_partialCredsWarnedForTest()).toBe(true);
+    });
+  });
+
+  describe("useVercelSandbox", () => {
+    it("returns true on ATLAS_RUNTIME=vercel", async () => {
+      process.env.ATLAS_RUNTIME = "vercel";
+      const { useVercelSandbox } = await detectModule();
+      expect(useVercelSandbox()).toBe(true);
+    });
+
+    it("returns true on VERCEL=1", async () => {
+      process.env.VERCEL = "1";
+      const { useVercelSandbox } = await detectModule();
+      expect(useVercelSandbox()).toBe(true);
+    });
+
+    it("returns true when all explicit credentials are set without platform env", async () => {
+      process.env.VERCEL_TEAM_ID = "team_123";
+      process.env.VERCEL_PROJECT_ID = "prj_123";
+      process.env.VERCEL_TOKEN = "vercel-token";
+
+      const { useVercelSandbox } = await detectModule();
+
+      expect(useVercelSandbox()).toBe(true);
+    });
+
+    it("returns false when two explicit credentials are set without platform env", async () => {
+      process.env.VERCEL_TEAM_ID = "team_123";
+      process.env.VERCEL_TOKEN = "vercel-token";
+
+      const { useVercelSandbox } = await detectModule();
+
+      expect(useVercelSandbox()).toBe(false);
+    });
+
+    it("returns false on empty env", async () => {
+      const { useVercelSandbox } = await detectModule();
+      expect(useVercelSandbox()).toBe(false);
+    });
+  });
+});

--- a/packages/api/src/lib/tools/backends/detect.ts
+++ b/packages/api/src/lib/tools/backends/detect.ts
@@ -9,10 +9,28 @@ import { createLogger } from "@atlas/api/lib/logger";
 
 const log = createLogger("sandbox-detect");
 
+const REDACTED = "[REDACTED]";
+
+export interface RuntimeOpaqueSecret {
+  readonly __brand: "OpaqueSecret";
+  reveal(): string;
+  toJSON(): string;
+  toString(): string;
+}
+
+function opaqueSecret(value: string): RuntimeOpaqueSecret {
+  return Object.freeze({
+    __brand: "OpaqueSecret" as const,
+    reveal: () => value,
+    toJSON: () => REDACTED,
+    toString: () => REDACTED,
+  });
+}
+
 export interface VercelSandboxAccess {
   teamId: string;
   projectId: string;
-  token: string;
+  token: RuntimeOpaqueSecret;
 }
 
 let _partialCredsWarned = false;
@@ -47,7 +65,7 @@ export function vercelSandboxAccess(): VercelSandboxAccess | undefined {
     }
     return undefined;
   }
-  return { teamId, projectId, token };
+  return { teamId, projectId, token: opaqueSecret(token) };
 }
 
 /**
@@ -66,4 +84,12 @@ export function useVercelSandbox(): boolean {
 /** Returns true when ATLAS_SANDBOX_URL is set (sidecar backend available). */
 export function useSidecar(): boolean {
   return !!process.env.ATLAS_SANDBOX_URL;
+}
+
+export function _resetVercelSandboxDetectForTest(): void {
+  _partialCredsWarned = false;
+}
+
+export function _partialCredsWarnedForTest(): boolean {
+  return _partialCredsWarned;
 }

--- a/packages/api/src/lib/tools/backends/detect.ts
+++ b/packages/api/src/lib/tools/backends/detect.ts
@@ -9,10 +9,28 @@ import { createLogger } from "@atlas/api/lib/logger";
 
 const log = createLogger("sandbox-detect");
 
+const REDACTED = "[REDACTED]";
+
+export interface RedactedSecret {
+  readonly __brand: "RedactedSecret";
+  reveal(): string;
+  toJSON(): string;
+  toString(): string;
+}
+
+function redactedSecret(value: string): RedactedSecret {
+  return Object.freeze({
+    __brand: "RedactedSecret" as const,
+    reveal: () => value,
+    toJSON: () => REDACTED,
+    toString: () => REDACTED,
+  });
+}
+
 export interface VercelSandboxAccess {
   teamId: string;
   projectId: string;
-  token: string;
+  token: RedactedSecret;
 }
 
 let _partialCredsWarned = false;
@@ -47,7 +65,7 @@ export function vercelSandboxAccess(): VercelSandboxAccess | undefined {
     }
     return undefined;
   }
-  return { teamId, projectId, token };
+  return { teamId, projectId, token: redactedSecret(token) };
 }
 
 /**
@@ -66,4 +84,12 @@ export function useVercelSandbox(): boolean {
 /** Returns true when ATLAS_SANDBOX_URL is set (sidecar backend available). */
 export function useSidecar(): boolean {
   return !!process.env.ATLAS_SANDBOX_URL;
+}
+
+export function _resetVercelSandboxDetectForTest(): void {
+  _partialCredsWarned = false;
+}
+
+export function _partialCredsWarnedForTest(): boolean {
+  return _partialCredsWarned;
 }

--- a/packages/api/src/lib/tools/explore-sandbox.ts
+++ b/packages/api/src/lib/tools/explore-sandbox.ts
@@ -104,12 +104,19 @@ export async function createSandboxBackend(
   // credentials; on Vercel itself, OIDC handles auth automatically and these
   // are undefined.
   const access = vercelSandboxAccess();
+  const explicitAccess = access
+    ? {
+        teamId: access.teamId,
+        projectId: access.projectId,
+        token: access.token.reveal(),
+      }
+    : undefined;
   let sandbox: InstanceType<typeof Sandbox>;
   try {
     sandbox = await Sandbox.create({
       runtime: "node24",
       networkPolicy: "deny-all",
-      ...(access ?? {}),
+      ...(explicitAccess ?? {}),
     });
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);

--- a/packages/api/src/lib/tools/explore.ts
+++ b/packages/api/src/lib/tools/explore.ts
@@ -179,36 +179,84 @@ export function getExploreBackendType(): ExploreBackendType {
 }
 
 /**
- * Try to create a specific backend by name. Returns null if the backend
- * is not available (env vars not set, binary not found, etc.).
+ * Try to create a specific backend by name. Returns a backend on success,
+ * otherwise a sanitized reason suitable for operator-facing config errors.
  */
-async function tryCreateBackend(name: SandboxBackendName, semanticRoot: string, orgId?: string): Promise<ExploreBackend | null> {
+interface BackendInitFailure {
+  name: SandboxBackendName;
+  reason: string;
+}
+
+interface BackendInitResult {
+  backend: ExploreBackend | null;
+  failure?: BackendInitFailure;
+}
+
+function unavailable(name: SandboxBackendName, reason: string): BackendInitResult {
+  return { backend: null, failure: { name, reason } };
+}
+
+function formatSandboxPriorityFailure(
+  priority: readonly SandboxBackendName[],
+  failures: readonly BackendInitFailure[],
+  deployMode: "saas" | "self-hosted" | undefined,
+): string {
+  const summary = failures.length > 0
+    ? ` Failed backends: ${failures.map((f) => `${f.name}: ${f.reason}`).join("; ")}.`
+    : "";
+  const guidance: string[] = [];
+  if (priority.includes("vercel-sandbox")) {
+    guidance.push("For Vercel Sandbox off-Vercel, set VERCEL_TEAM_ID, VERCEL_PROJECT_ID, and VERCEL_TOKEN.");
+  }
+  if (priority.includes("sidecar")) {
+    guidance.push("For sidecar, set ATLAS_SANDBOX_URL.");
+  }
+  if (deployMode !== "saas") {
+    guidance.push("Add 'just-bash' to the priority list if you want an unsandboxed fallback.");
+  }
+  guidance.push("Fix the backend configuration.");
+
+  return `All backends in sandbox.priority (${priority.join(", ")}) failed to initialize.${summary} ${guidance.join(" ")}`;
+}
+
+export const _formatSandboxPriorityFailureForTest = formatSandboxPriorityFailure;
+
+async function tryCreateBackend(name: SandboxBackendName, semanticRoot: string, orgId?: string): Promise<BackendInitResult> {
   switch (name) {
     case "vercel-sandbox": {
-      if (!useVercelSandbox()) return null;
+      if (!useVercelSandbox()) {
+        return unavailable(
+          name,
+          "not configured (set ATLAS_RUNTIME=vercel, VERCEL=1, or all of VERCEL_TEAM_ID / VERCEL_PROJECT_ID / VERCEL_TOKEN)",
+        );
+      }
       try {
         const { createSandboxBackend } = await import("./explore-sandbox");
-        return createSandboxBackend(semanticRoot);
+        return { backend: await createSandboxBackend(semanticRoot) };
       } catch (err) {
         const detail = errorMessage(err);
         log.warn(
           { error: detail },
           "vercel-sandbox backend failed to initialize — trying next in priority",
         );
-        return null;
+        return unavailable(name, detail);
       }
     }
 
     case "nsjail": {
-      if (_nsjailFailed) return null;
+      if (_nsjailFailed) return unavailable(name, "previous initialization failed");
       // Check if nsjail is available (explicit or auto-detect)
-      if (process.env.ATLAS_SANDBOX !== "nsjail" && !useNsjail()) return null;
+      if (process.env.ATLAS_SANDBOX !== "nsjail" && !useNsjail()) {
+        return unavailable(name, "nsjail binary not available");
+      }
       try {
         const { createNsjailBackend } = await import("./explore-nsjail");
-        return await createNsjailBackend(semanticRoot, {
-          onInfrastructureError: invalidateExploreBackend,
-          onNsjailFailed: markNsjailFailed,
-        });
+        return {
+          backend: await createNsjailBackend(semanticRoot, {
+            onInfrastructureError: invalidateExploreBackend,
+            onNsjailFailed: markNsjailFailed,
+          }),
+        };
       } catch (err) {
         _nsjailFailed = true;
         const detail = errorMessage(err);
@@ -216,7 +264,7 @@ async function tryCreateBackend(name: SandboxBackendName, semanticRoot: string, 
           { error: detail },
           "nsjail backend failed to initialize — trying next in priority",
         );
-        return null;
+        return unavailable(name, detail);
       }
     }
 
@@ -224,11 +272,13 @@ async function tryCreateBackend(name: SandboxBackendName, semanticRoot: string, 
       // Workspace-level URL override takes priority over env var
       const wsSidecarUrl = orgId ? getSetting("ATLAS_SANDBOX_URL", orgId) : undefined;
       const sidecarUrl = wsSidecarUrl ?? process.env.ATLAS_SANDBOX_URL;
-      if ((!sidecarUrl && !useSidecar()) || _sidecarFailed) return null;
-      if (!sidecarUrl) return null;
+      if (_sidecarFailed) return unavailable(name, "previous initialization failed");
+      if ((!sidecarUrl && !useSidecar()) || !sidecarUrl) {
+        return unavailable(name, "not configured (set ATLAS_SANDBOX_URL)");
+      }
       try {
         const { createSidecarBackend } = await import("./explore-sidecar");
-        return createSidecarBackend(sidecarUrl, { semanticRoot });
+        return { backend: await createSidecarBackend(sidecarUrl, { semanticRoot }) };
       } catch (err) {
         _sidecarFailed = true;
         const detail = errorMessage(err);
@@ -236,7 +286,7 @@ async function tryCreateBackend(name: SandboxBackendName, semanticRoot: string, 
           { error: detail },
           "sidecar backend failed to initialize — trying next in priority",
         );
-        return null;
+        return unavailable(name, detail);
       }
     }
 
@@ -252,7 +302,7 @@ async function tryCreateBackend(name: SandboxBackendName, semanticRoot: string, 
       } else {
         log.debug("Explore tool using just-bash backend (acceptable for development)");
       }
-      return createBashBackend(semanticRoot);
+      return { backend: await createBashBackend(semanticRoot) };
     }
   }
 }
@@ -302,10 +352,10 @@ function getExploreBackend(semanticRoot: string, orgId?: string): Promise<Explor
         // Check if override is a built-in backend name
         const builtInNames: readonly string[] = ["vercel-sandbox", "nsjail", "sidecar", "just-bash"];
         if (builtInNames.includes(wsOverride)) {
-          const backend = await tryCreateBackend(wsOverride as SandboxBackendName, semanticRoot, orgId);
-          if (backend) return backend;
+          const result = await tryCreateBackend(wsOverride as SandboxBackendName, semanticRoot, orgId);
+          if (result.backend) return result.backend;
           log.warn(
-            { backend: wsOverride, orgId },
+            { backend: wsOverride, orgId, reason: result.failure?.reason },
             "Workspace sandbox override %s unavailable — falling through to default",
             wsOverride,
           );
@@ -368,17 +418,25 @@ function getExploreBackend(semanticRoot: string, orgId?: string): Promise<Explor
           "Using configured sandbox priority: %s",
           configPriority.join(" > "),
         );
+        const failures: BackendInitFailure[] = [];
         for (const name of configPriority) {
-          const backend = await tryCreateBackend(name, semanticRoot, orgId);
-          if (backend) {
+          const result = await tryCreateBackend(name, semanticRoot, orgId);
+          if (result.backend) {
             log.info(
               { backend: name, source: "config" },
               "Explore backend selected: %s (config priority)",
               name,
             );
-            return backend;
+            return result.backend;
           }
-          log.debug({ backend: name }, "Backend %s unavailable — trying next in priority", name);
+          if (result.failure) {
+            failures.push(result.failure);
+          }
+          log.debug(
+            { backend: name, reason: result.failure?.reason },
+            "Backend %s unavailable — trying next in priority",
+            name,
+          );
         }
         // All config backends failed
         if (configPriority.includes("just-bash")) {
@@ -390,11 +448,7 @@ function getExploreBackend(semanticRoot: string, orgId?: string): Promise<Explor
           return createBashBackend(semanticRoot);
         }
         // Operator did NOT include just-bash — respect their intent
-        throw new Error(
-          `All backends in sandbox.priority (${configPriority.join(", ")}) failed to initialize. ` +
-          "Add 'just-bash' to the priority list if you want an unsandboxed fallback, " +
-          "or fix the backend configuration.",
-        );
+        throw new Error(formatSandboxPriorityFailure(configPriority, failures, getConfig()?.deployMode));
       }
 
       // --- Default priority chain ---

--- a/packages/api/src/lib/tools/explore.ts
+++ b/packages/api/src/lib/tools/explore.ts
@@ -179,36 +179,84 @@ export function getExploreBackendType(): ExploreBackendType {
 }
 
 /**
- * Try to create a specific backend by name. Returns null if the backend
- * is not available (env vars not set, binary not found, etc.).
+ * Try to create a specific backend by name. Returns a backend on success,
+ * otherwise a sanitized reason suitable for operator-facing config errors.
  */
-async function tryCreateBackend(name: SandboxBackendName, semanticRoot: string, orgId?: string): Promise<ExploreBackend | null> {
+interface BackendInitFailure {
+  name: SandboxBackendName;
+  reason: string;
+}
+
+interface BackendInitResult {
+  backend: ExploreBackend | null;
+  failure?: BackendInitFailure;
+}
+
+function unavailable(name: SandboxBackendName, reason: string): BackendInitResult {
+  return { backend: null, failure: { name, reason } };
+}
+
+function formatSandboxPriorityFailure(
+  priority: readonly SandboxBackendName[],
+  failures: readonly BackendInitFailure[],
+  deployMode: "saas" | "self-hosted" | undefined,
+): string {
+  const summary = failures.length > 0
+    ? ` Failed backends: ${failures.map((f) => `${f.name}: ${f.reason}`).join("; ")}.`
+    : "";
+  const guidance: string[] = [];
+  if (priority.includes("vercel-sandbox")) {
+    guidance.push("For Vercel Sandbox off-Vercel, set VERCEL_TEAM_ID, VERCEL_PROJECT_ID, and VERCEL_TOKEN.");
+  }
+  if (priority.includes("sidecar")) {
+    guidance.push("For sidecar, set ATLAS_SANDBOX_URL.");
+  }
+  if (deployMode !== "saas") {
+    guidance.push("Add 'just-bash' to the priority list if you want an unsandboxed fallback.");
+  }
+  guidance.push("Fix the backend configuration.");
+
+  return `All backends in sandbox.priority (${priority.join(", ")}) failed to initialize.${summary} ${guidance.join(" ")}`;
+}
+
+export const _formatSandboxPriorityFailureForTest = formatSandboxPriorityFailure;
+
+async function tryCreateBackend(name: SandboxBackendName, semanticRoot: string, orgId?: string): Promise<BackendInitResult> {
   switch (name) {
     case "vercel-sandbox": {
-      if (!useVercelSandbox()) return null;
+      if (!useVercelSandbox()) {
+        return unavailable(
+          name,
+          "not configured (set ATLAS_RUNTIME=vercel, VERCEL=1, or all of VERCEL_TEAM_ID / VERCEL_PROJECT_ID / VERCEL_TOKEN)",
+        );
+      }
       try {
         const { createSandboxBackend } = await import("./explore-sandbox");
-        return createSandboxBackend(semanticRoot);
+        return { backend: await createSandboxBackend(semanticRoot) };
       } catch (err) {
         const detail = errorMessage(err);
         log.warn(
           { error: detail },
           "vercel-sandbox backend failed to initialize — trying next in priority",
         );
-        return null;
+        return unavailable(name, detail);
       }
     }
 
     case "nsjail": {
-      if (_nsjailFailed) return null;
+      if (_nsjailFailed) return unavailable(name, "previous initialization failed");
       // Check if nsjail is available (explicit or auto-detect)
-      if (process.env.ATLAS_SANDBOX !== "nsjail" && !useNsjail()) return null;
+      if (process.env.ATLAS_SANDBOX !== "nsjail" && !useNsjail()) {
+        return unavailable(name, "nsjail binary not available");
+      }
       try {
         const { createNsjailBackend } = await import("./explore-nsjail");
-        return await createNsjailBackend(semanticRoot, {
-          onInfrastructureError: invalidateExploreBackend,
-          onNsjailFailed: markNsjailFailed,
-        });
+        return {
+          backend: await createNsjailBackend(semanticRoot, {
+            onInfrastructureError: invalidateExploreBackend,
+            onNsjailFailed: markNsjailFailed,
+          }),
+        };
       } catch (err) {
         _nsjailFailed = true;
         const detail = errorMessage(err);
@@ -216,7 +264,7 @@ async function tryCreateBackend(name: SandboxBackendName, semanticRoot: string, 
           { error: detail },
           "nsjail backend failed to initialize — trying next in priority",
         );
-        return null;
+        return unavailable(name, detail);
       }
     }
 
@@ -224,11 +272,13 @@ async function tryCreateBackend(name: SandboxBackendName, semanticRoot: string, 
       // Workspace-level URL override takes priority over env var
       const wsSidecarUrl = orgId ? getSetting("ATLAS_SANDBOX_URL", orgId) : undefined;
       const sidecarUrl = wsSidecarUrl ?? process.env.ATLAS_SANDBOX_URL;
-      if ((!sidecarUrl && !useSidecar()) || _sidecarFailed) return null;
-      if (!sidecarUrl) return null;
+      if (_sidecarFailed) return unavailable(name, "previous initialization failed");
+      if (!sidecarUrl) {
+        return unavailable(name, "not configured (set ATLAS_SANDBOX_URL)");
+      }
       try {
         const { createSidecarBackend } = await import("./explore-sidecar");
-        return createSidecarBackend(sidecarUrl, { semanticRoot });
+        return { backend: await createSidecarBackend(sidecarUrl, { semanticRoot }) };
       } catch (err) {
         _sidecarFailed = true;
         const detail = errorMessage(err);
@@ -236,7 +286,7 @@ async function tryCreateBackend(name: SandboxBackendName, semanticRoot: string, 
           { error: detail },
           "sidecar backend failed to initialize — trying next in priority",
         );
-        return null;
+        return unavailable(name, detail);
       }
     }
 
@@ -252,7 +302,7 @@ async function tryCreateBackend(name: SandboxBackendName, semanticRoot: string, 
       } else {
         log.debug("Explore tool using just-bash backend (acceptable for development)");
       }
-      return createBashBackend(semanticRoot);
+      return { backend: await createBashBackend(semanticRoot) };
     }
   }
 }
@@ -302,10 +352,10 @@ function getExploreBackend(semanticRoot: string, orgId?: string): Promise<Explor
         // Check if override is a built-in backend name
         const builtInNames: readonly string[] = ["vercel-sandbox", "nsjail", "sidecar", "just-bash"];
         if (builtInNames.includes(wsOverride)) {
-          const backend = await tryCreateBackend(wsOverride as SandboxBackendName, semanticRoot, orgId);
-          if (backend) return backend;
+          const result = await tryCreateBackend(wsOverride as SandboxBackendName, semanticRoot, orgId);
+          if (result.backend) return result.backend;
           log.warn(
-            { backend: wsOverride, orgId },
+            { backend: wsOverride, orgId, reason: result.failure?.reason },
             "Workspace sandbox override %s unavailable — falling through to default",
             wsOverride,
           );
@@ -368,17 +418,25 @@ function getExploreBackend(semanticRoot: string, orgId?: string): Promise<Explor
           "Using configured sandbox priority: %s",
           configPriority.join(" > "),
         );
+        const failures: BackendInitFailure[] = [];
         for (const name of configPriority) {
-          const backend = await tryCreateBackend(name, semanticRoot, orgId);
-          if (backend) {
+          const result = await tryCreateBackend(name, semanticRoot, orgId);
+          if (result.backend) {
             log.info(
               { backend: name, source: "config" },
               "Explore backend selected: %s (config priority)",
               name,
             );
-            return backend;
+            return result.backend;
           }
-          log.debug({ backend: name }, "Backend %s unavailable — trying next in priority", name);
+          if (result.failure) {
+            failures.push(result.failure);
+          }
+          log.debug(
+            { backend: name, reason: result.failure?.reason },
+            "Backend %s unavailable — trying next in priority",
+            name,
+          );
         }
         // All config backends failed
         if (configPriority.includes("just-bash")) {
@@ -390,11 +448,7 @@ function getExploreBackend(semanticRoot: string, orgId?: string): Promise<Explor
           return createBashBackend(semanticRoot);
         }
         // Operator did NOT include just-bash — respect their intent
-        throw new Error(
-          `All backends in sandbox.priority (${configPriority.join(", ")}) failed to initialize. ` +
-          "Add 'just-bash' to the priority list if you want an unsandboxed fallback, " +
-          "or fix the backend configuration.",
-        );
+        throw new Error(formatSandboxPriorityFailure(configPriority, failures, getConfig()?.deployMode));
       }
 
       // --- Default priority chain ---

--- a/packages/api/src/lib/tools/python-sandbox.ts
+++ b/packages/api/src/lib/tools/python-sandbox.ts
@@ -148,12 +148,19 @@ export function createPythonSandboxBackend(): PythonBackend {
       // VERCEL_TOKEN; on Vercel proper, OIDC handles auth and `access` is
       // undefined.
       const access = vercelSandboxAccess();
+      const explicitAccess = access
+        ? {
+            teamId: access.teamId,
+            projectId: access.projectId,
+            token: access.token.reveal(),
+          }
+        : undefined;
       const sandbox = yield* Effect.tryPromise({
         try: () =>
           Sandbox.create({
             runtime: "python3.13",
             networkPolicy: "allow-all",
-            ...(access ?? {}),
+            ...(explicitAccess ?? {}),
           }),
         catch: (err) => {
           const detail = sandboxErrorDetail(err);


### PR DESCRIPTION
## Summary

- Brand explicit Vercel Sandbox tokens as reveal-only redacted runtime secrets
- Reveal the token only at the two @vercel/sandbox Sandbox.create() boundaries
- Preserve per-backend sandbox.priority initialization failure reasons and hide just-bash fallback advice in SaaS mode
- Add detector, Python sandbox credential handoff, and failure-message tests

## Why

Follow-up for #2384, #2385, and #2386. The previous helper returned VERCEL_TOKEN as a plain string and config-priority sandbox failures collapsed backend errors into a generic operator message.

## Validation

- bun test packages/api/src/lib/tools/backends/__tests__/detect.test.ts packages/api/src/lib/tools/__tests__/python-sandbox.test.ts packages/api/src/lib/tools/__tests__/explore-backend.test.ts
- git diff --check
- bun run type reached tsgo --noEmit, then failed in @atlas/web on stale .next validator references to missing page modules unrelated to this API change
