### PR TITLE
chore: bump @useatlas/types ^0.0.26 → ^0.0.28 in consumers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -266,7 +266,7 @@
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^5.96.2",
-        "@useatlas/types": "^0.0.26",
+        "@useatlas/types": "^0.0.28",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "radix-ui": "^1.4.3",
@@ -334,7 +334,7 @@
       "name": "@useatlas/sdk",
       "version": "0.0.14",
       "dependencies": {
-        "@useatlas/types": "^0.0.26",
+        "@useatlas/types": "^0.0.28",
       },
       "devDependencies": {
         "@atlas/oauth-helper": "workspace:*",
@@ -4756,10 +4756,6 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typespec/ts-http-runtime/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
-    "@useatlas/react/@useatlas/types": ["@useatlas/types@0.0.26", "", {}, "sha512-e3bE0+iO0H4qFbnfxb9LJFRl8WGMIe8q+LqLHgPG9y0LlzO7f/xZIYwj/rFnhqe3sttxYDDW8Fv3k5H9YFjIcQ=="],
-
-    "@useatlas/sdk/@useatlas/types": ["@useatlas/types@0.0.26", "", {}, "sha512-e3bE0+iO0H4qFbnfxb9LJFRl8WGMIe8q+LqLHgPG9y0LlzO7f/xZIYwj/rFnhqe3sttxYDDW8Fv3k5H9YFjIcQ=="],
 
     "@vercel/sandbox/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 

--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -25,7 +25,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.0.7",
     "@useatlas/sdk": "^0.0.14",
-    "@useatlas/types": "^0.0.26",
+    "@useatlas/types": "^0.0.28",
     "@better-auth/api-key": "^1.6.9",
     "@better-auth/oauth-provider": "^1.6.9",
     "@better-auth/passkey": "^1.6.9",

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -22,7 +22,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.0.7",
     "@useatlas/sdk": "^0.0.14",
-    "@useatlas/types": "^0.0.26",
+    "@useatlas/types": "^0.0.28",
     "ai": "^6.0.141",
     "@better-auth/api-key": "^1.6.9",
     "@better-auth/oauth-provider": "^1.6.9",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -83,7 +83,7 @@
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^5.96.2",
-    "@useatlas/types": "^0.0.26",
+    "@useatlas/types": "^0.0.28",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "radix-ui": "^1.4.3",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -49,7 +49,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@useatlas/types": "^0.0.26"
+    "@useatlas/types": "^0.0.28"
   },
   "devDependencies": {
     "@atlas/oauth-helper": "workspace:*"


### PR DESCRIPTION
## Summary

Catch SDK, react, and both create-atlas templates up to the published `@useatlas/types` contract.

- **0.0.27** (#2381 / commit `f877ac3e`) added `ConnectionGroup` + `ConnectionGroupMember` for the multi-env semantic layer foundation.
- **0.0.28** (#2392 / commit `1892d1c8`) added `ExportedSemanticEntity.connectionGroupId` for the entities slice.

Both source bumps had landed without a corresponding `types-v*` tag, so npm was still serving `0.0.26` to external consumers. Tagged + pushed `types-v0.0.27` (run [25808581247](https://github.com/AtlasDevHQ/atlas/actions/runs/25808581247)) and `types-v0.0.28` (run [25808643538](https://github.com/AtlasDevHQ/atlas/actions/runs/25808643538)) one at a time per the silent-drop playbook in [`npm-publish.md`](.claude/projects/-home-msywu-oss-atlas-ide/memory/npm-publish.md). Both packages now resolve from the registry.

This PR completes the second half of the version-bump-ordering rule: tag-publish first (done), then consumer refs (this PR).

## Files

- `packages/sdk/package.json` — `^0.0.26` → `^0.0.28`
- `packages/react/package.json` — `^0.0.26` → `^0.0.28`
- `create-atlas/templates/nextjs-standalone/package.json` — `^0.0.26` → `^0.0.28`
- `create-atlas/templates/docker/package.json` — `^0.0.26` → `^0.0.28`
- `bun.lock` — regenerated

## Test plan

- [x] `bun install` — clean resolve, no other lockfile churn
- [x] `bun x syncpack lint` — no issues
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — 562 files verified
- [ ] CI: lint, type, test, deploy validation (scaffold needs `^0.0.28` resolvable on npm — confirmed via `curl https://registry.npmjs.org/@useatlas/types/0.0.28`)