### PR TITLE
feat(pii): group-scoped PII classifications (#2341)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -36117,10 +36117,20 @@
           {
             "schema": {
               "type": "string",
-              "description": "Filter by connection ID"
+              "description": "Filter by connection group (environment) ID"
             },
             "required": false,
-            "description": "Filter by connection ID",
+            "description": "Filter by connection group (environment) ID",
+            "name": "connectionGroupId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Legacy: filter by connection ID — resolved to the connection's group via 0062's 1:1 mapping. Prefer `connectionGroupId` for new callers."
+            },
+            "required": false,
+            "description": "Legacy: filter by connection ID — resolved to the connection's group via 0062's 1:1 mapping. Prefer `connectionGroupId` for new callers.",
             "name": "connectionId",
             "in": "query"
           }
@@ -36151,7 +36161,16 @@
                             "type": "string"
                           },
                           "connectionId": {
-                            "type": "string"
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "connectionGroupId": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
                           },
                           "category": {
                             "type": "string",
@@ -36407,7 +36426,16 @@
                           "type": "string"
                         },
                         "connectionId": {
-                          "type": "string"
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "connectionGroupId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
                         },
                         "category": {
                           "type": "string",

--- a/bun.lock
+++ b/bun.lock
@@ -342,7 +342,7 @@
     },
     "packages/types": {
       "name": "@useatlas/types",
-      "version": "0.0.28",
+      "version": "0.0.29",
     },
     "packages/web": {
       "name": "@atlas/web",
@@ -4756,6 +4756,10 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typespec/ts-http-runtime/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "@useatlas/react/@useatlas/types": ["@useatlas/types@0.0.28", "", {}, "sha512-wMKESWjN+rhYv6AqH4v2M86zEFaVEko8+/jYUCjZvQXlV7Mh7Vgz9vZkrwFYL9SM3Ymm19Zf59fJZaq5PWqt2Q=="],
+
+    "@useatlas/sdk/@useatlas/types": ["@useatlas/types@0.0.28", "", {}, "sha512-wMKESWjN+rhYv6AqH4v2M86zEFaVEko8+/jYUCjZvQXlV7Mh7Vgz9vZkrwFYL9SM3Ymm19Zf59fJZaq5PWqt2Q=="],
 
     "@vercel/sandbox/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 

--- a/ee/src/compliance/masking.test.ts
+++ b/ee/src/compliance/masking.test.ts
@@ -352,6 +352,105 @@ describe("applyMasking", () => {
     // Undefined role defaults to viewer (full mask)
     expect(result[0].email).toBe("***");
   });
+
+  it("group filter (#2341): skips classifications from a different group when connectionId provided", async () => {
+    // Multi-environment org: `users.email` is classified separately in
+    // `prod` (full) and `staging` (partial). A query running on a
+    // `staging` connection sees only the staging classification — the
+    // prod row is filtered out before the lookup is built.
+    //
+    // This is the structural promise of #2341: replicas inside a group
+    // share schema, classifications live on the group, and groups
+    // don't leak across each other.
+    mockEnterpriseEnabled = true;
+    mockHasInternalDB = true;
+    mockQueryRows.push([]); // CREATE TABLE
+    mockQueryRows.push([
+      {
+        id: "cls-prod",
+        org_id: "org-1",
+        table_name: "users",
+        column_name: "email",
+        connection_id: "us-int",
+        connection_group_id: "g_prod",
+        category: "email",
+        confidence: "high",
+        masking_strategy: "full",
+        reviewed: true,
+        dismissed: false,
+        created_at: "2026-01-01",
+        updated_at: "2026-01-01",
+      },
+      {
+        id: "cls-staging",
+        org_id: "org-1",
+        table_name: "users",
+        column_name: "email",
+        connection_id: "staging-1",
+        connection_group_id: "g_staging",
+        category: "email",
+        confidence: "low",
+        masking_strategy: "redact",
+        reviewed: true,
+        dismissed: false,
+        created_at: "2026-01-01",
+        updated_at: "2026-01-01",
+      },
+    ]);
+    // resolveGroupIdForConnection lookup for the query's connection.
+    mockQueryRows.push([{ group_id: "g_staging" }]);
+
+    const result = await run(applyMasking({
+      columns: ["email"],
+      rows: [{ email: "alice@example.com" }],
+      tablesAccessed: ["users"],
+      orgId: "org-1",
+      userRole: "analyst",
+      connectionId: "staging-1",
+    }));
+
+    // Staging's `redact` wins — analyst sees `[REDACTED]`, NOT the
+    // prod `full` strategy.
+    expect(result[0].email).toBe("[REDACTED]");
+  });
+
+  it("group filter (#2341): NULL-scoped (un-grouped) classifications apply regardless of connection", async () => {
+    // Backfill leaves rows with `connection_group_id = NULL` when the
+    // source connection has been deleted. Those rows are intentionally
+    // "global within the org" — they apply to every query, regardless
+    // of which connection it ran on.
+    mockEnterpriseEnabled = true;
+    mockHasInternalDB = true;
+    mockQueryRows.push([]); // CREATE TABLE
+    mockQueryRows.push([
+      {
+        id: "cls-null",
+        org_id: "org-1",
+        table_name: "users",
+        column_name: "email",
+        connection_id: null,
+        connection_group_id: null,
+        category: "email",
+        confidence: "medium",
+        masking_strategy: "full",
+        reviewed: true,
+        dismissed: false,
+        created_at: "2026-01-01",
+        updated_at: "2026-01-01",
+      },
+    ]);
+    mockQueryRows.push([{ group_id: "g_staging" }]); // resolve
+
+    const result = await run(applyMasking({
+      columns: ["email"],
+      rows: [{ email: "alice@example.com" }],
+      tablesAccessed: ["users"],
+      orgId: "org-1",
+      userRole: "viewer",
+      connectionId: "staging-1",
+    }));
+    expect(result[0].email).toBe("***");
+  });
 });
 
 // ── ComplianceError ─────────────────────────────────────────────
@@ -387,12 +486,14 @@ describe("savePIIClassification", () => {
 
   it("saves a classification and returns it", async () => {
     mockQueryRows.push([]); // CREATE TABLE
+    mockQueryRows.push([{ group_id: "g_default" }]); // resolveGroupIdForConnection
     mockQueryRows.push([{
       id: "cls-new",
       org_id: "org-1",
       table_name: "users",
       column_name: "email",
       connection_id: "default",
+      connection_group_id: "g_default",
       category: "email",
       confidence: "high",
       masking_strategy: "partial",
@@ -408,6 +509,7 @@ describe("savePIIClassification", () => {
     expect(result.id).toBe("cls-new");
     expect(result.category).toBe("email");
     expect(result.maskingStrategy).toBe("partial");
+    expect(result.connectionGroupId).toBe("g_default");
   });
 
   it("throws on invalid category", async () => {
@@ -436,6 +538,38 @@ describe("savePIIClassification", () => {
     await expect(
       run(savePIIClassification("org-1", "t", "c", "default", "email", "high")),
     ).rejects.toThrow("Internal database not available");
+  });
+
+  it("with connectionId=null skips group resolution and writes NULL-scoped row", async () => {
+    // Callers that don't have a connection (e.g. global / cross-env
+    // classifications) pass `null`. The save path skips the
+    // resolveGroupIdForConnection lookup and writes
+    // connection_group_id = NULL — the row lives in the COALESCE
+    // sentinel bucket. The unique index treats it like any other
+    // scope, so a second NULL-scoped row for the same (org, table,
+    // column) still collides.
+    mockQueryRows.push([]); // CREATE TABLE
+    // NOTE: no resolve query — connectionId is null so it short-circuits.
+    mockQueryRows.push([{
+      id: "cls-null",
+      org_id: "org-1",
+      table_name: "users",
+      column_name: "email",
+      connection_id: null,
+      connection_group_id: null,
+      category: "email",
+      confidence: "high",
+      masking_strategy: "partial",
+      reviewed: false,
+      dismissed: false,
+      created_at: "2026-01-01",
+      updated_at: "2026-01-01",
+    }]);
+    const result = await run(savePIIClassification(
+      "org-1", "users", "email", null, "email", "high", "partial",
+    ));
+    expect(result.connectionId).toBeNull();
+    expect(result.connectionGroupId).toBeNull();
   });
 });
 

--- a/ee/src/compliance/masking.ts
+++ b/ee/src/compliance/masking.ts
@@ -23,6 +23,10 @@ import {
   hasInternalDB,
   internalQuery,
 } from "@atlas/api/lib/db/internal";
+import {
+  coalescedScopeColumn,
+  withGroupScope,
+} from "@atlas/api/lib/db/with-group-scope";
 import { createLogger } from "@atlas/api/lib/logger";
 import type {
   PIICategory,
@@ -50,6 +54,14 @@ export class ComplianceError extends Data.TaggedError("ComplianceError")<{
 
 const TABLE_NAME = "pii_column_classifications";
 
+// Bootstrap CREATE TABLE for legacy self-hosted installs that bypassed
+// the migration runner (older deploys ran the masking module's ensure-
+// table lazily). The shape mirrors the post-0064 schema: nullable
+// `connection_id` (no NOT NULL DEFAULT 'default') and the
+// `connection_group_id` column. The UNIQUE constraint here is the
+// column-level form (no COALESCE) — bootstrap-only; production deploys
+// reach this table via the migration runner first and get the
+// COALESCE-sentinel form from 0064, so this code path is a no-op there.
 const ensureTable = (): Effect.Effect<void, Error> =>
   Effect.gen(function* () {
     if (!hasInternalDB()) return;
@@ -60,7 +72,8 @@ const ensureTable = (): Effect.Effect<void, Error> =>
           org_id TEXT NOT NULL,
           table_name TEXT NOT NULL,
           column_name TEXT NOT NULL,
-          connection_id TEXT NOT NULL DEFAULT 'default',
+          connection_id TEXT,
+          connection_group_id TEXT,
           category TEXT NOT NULL,
           confidence TEXT NOT NULL DEFAULT 'medium',
           masking_strategy TEXT NOT NULL DEFAULT 'partial',
@@ -68,7 +81,7 @@ const ensureTable = (): Effect.Effect<void, Error> =>
           dismissed BOOLEAN NOT NULL DEFAULT false,
           created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
           updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-          UNIQUE(org_id, table_name, column_name, connection_id)
+          UNIQUE(org_id, table_name, column_name, connection_group_id)
         )
       `),
       catch: (err) => err instanceof Error ? err : new Error(String(err)),
@@ -102,7 +115,11 @@ interface PIIClassificationRow {
   org_id: string;
   table_name: string;
   column_name: string;
-  connection_id: string;
+  /** Legacy connection scope. Nullable post-0064. Dual-written by the
+   *  save path during the transitional slice; final removal in #2346. */
+  connection_id: string | null;
+  /** Group scope (#2341). One row per (org, table, column, group). */
+  connection_group_id: string | null;
   category: string;
   confidence: string;
   masking_strategy: string;
@@ -120,6 +137,7 @@ function rowToClassification(row: PIIClassificationRow): PIIColumnClassification
     tableName: row.table_name,
     columnName: row.column_name,
     connectionId: row.connection_id,
+    connectionGroupId: row.connection_group_id,
     category: row.category as PIICategory,
     confidence: row.confidence as PIIConfidence,
     maskingStrategy: row.masking_strategy as MaskingStrategy,
@@ -130,11 +148,70 @@ function rowToClassification(row: PIIClassificationRow): PIIColumnClassification
   };
 }
 
+/**
+ * Resolve the `connection_group_id` for a given connection via 0062's
+ * 1:1 backfill. Returns `null` for unknown connections and for the
+ * legacy NULL-scope (caller passed `undefined` / `null`).
+ *
+ * Mirrors `resolveGroupIdForConnection` in `semantic/entities.ts` so
+ * write paths can dual-set `connection_id` + `connection_group_id`
+ * atomically. The lookup tolerates connections living at
+ * `org_id = '__global__'` (demo / built-in connections moved by 0060)
+ * so demo writes resolve to the demo group.
+ */
+export const resolveConnectionGroupForFilter = (
+  orgId: string,
+  connectionId: string | null | undefined,
+): Effect.Effect<string | null> => resolveGroupIdForConnection(orgId, connectionId);
+
+const resolveGroupIdForConnection = (
+  orgId: string,
+  connectionId: string | null | undefined,
+): Effect.Effect<string | null> =>
+  Effect.gen(function* () {
+    if (!connectionId) return null;
+    if (!hasInternalDB()) return null;
+    const rows = yield* Effect.tryPromise({
+      try: () => internalQuery<{ group_id: string | null }>(
+        `SELECT group_id FROM connections
+         WHERE id = $1 AND (org_id = $2 OR org_id = '__global__')
+         ORDER BY CASE WHEN org_id = $2 THEN 0 ELSE 1 END
+         LIMIT 1`,
+        [connectionId, orgId],
+      ),
+      catch: (err) => err instanceof Error ? err : new Error(String(err)),
+    }).pipe(
+      Effect.catchAll((err) => {
+        log.warn(
+          { err: err instanceof Error ? err.message : String(err), connectionId, orgId },
+          "Failed to resolve connection_group_id — falling back to NULL scope",
+        );
+        return Effect.succeed([] as ReadonlyArray<{ group_id: string | null }>);
+      }),
+    );
+    return rows[0]?.group_id ?? null;
+  });
+
 // ── CRUD operations (enterprise-gated) ──────────────────────────
 
+/**
+ * List PII classifications for an org, optionally filtered by group scope.
+ *
+ * `connectionGroupId` accepts both a literal group id (`g_prod`) and the
+ * legacy `undefined` for "no filter". Passing `null` would normalise to
+ * the COALESCE sentinel via `withGroupScope` but isn't exposed through
+ * the route layer — admins always filter by an explicit group id or by
+ * org-wide (no filter).
+ *
+ * Pre-#2341 callers passed `connectionId` directly. The route layer
+ * still accepts the legacy `connectionId` query param, resolves it to a
+ * group id via `resolveGroupIdForConnection`, and forwards the group
+ * here — the SQL only ever looks at the group column. See PRD #2336
+ * §"Migration sequencing".
+ */
 export const listPIIClassifications = (
   orgId: string | undefined,
-  connectionId?: string,
+  connectionGroupId?: string,
 ): Effect.Effect<PIIColumnClassification[], EnterpriseError> =>
   Effect.gen(function* () {
     yield* requireEnterpriseEffect("pii-detection");
@@ -147,9 +224,10 @@ export const listPIIClassifications = (
       params.push(orgId);
       sql += ` AND org_id = $${params.length}`;
     }
-    if (connectionId) {
-      params.push(connectionId);
-      sql += ` AND connection_id = $${params.length}`;
+    if (connectionGroupId) {
+      const scope = withGroupScope(connectionGroupId);
+      params.push(scope.param);
+      sql += ` AND ${scope.match(params.length, { column: "connection_group_id" })}`;
     }
     sql += " ORDER BY table_name, column_name";
 
@@ -157,11 +235,24 @@ export const listPIIClassifications = (
     return rows.map(rowToClassification);
   });
 
+/**
+ * Persist a PII classification at group scope.
+ *
+ * Accepts `connectionId` for back-compat with the PII detection write
+ * path; the connection's `group_id` is resolved inline via 0062's 1:1
+ * mapping and stored on `connection_group_id`. ON CONFLICT targets the
+ * group-keyed unique index — multiple connections in the same group
+ * share one classification row (PRD #2336 acceptance criterion).
+ *
+ * Reassigning a connection between groups does NOT carry classifications
+ * — the row stays on the originating group. Staging admins decide their
+ * own posture from scratch (the migration-pg smoke pins this).
+ */
 export const savePIIClassification = (
   orgId: string,
   tableName: string,
   columnName: string,
-  connectionId: string,
+  connectionId: string | null | undefined,
   category: PIICategory,
   confidence: PIIConfidence,
   maskingStrategy: MaskingStrategy = "partial",
@@ -175,13 +266,19 @@ export const savePIIClassification = (
     validateCategory(category);
     validateStrategy(maskingStrategy);
 
+    // Dual-write: legacy `connection_id` stays populated for transitional
+    // SDK compatibility (#2336 §"Migration sequencing"). The natural key
+    // is `connection_group_id` — ON CONFLICT targets the group-keyed
+    // partial index from 0064.
+    const groupId = yield* resolveGroupIdForConnection(orgId, connectionId);
+
     const rows = yield* Effect.promise(() => internalQuery<PIIClassificationRow>(
-      `INSERT INTO ${TABLE_NAME} (org_id, table_name, column_name, connection_id, category, confidence, masking_strategy)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)
-       ON CONFLICT (org_id, table_name, column_name, connection_id)
-       DO UPDATE SET category = $5, confidence = $6, masking_strategy = $7, updated_at = now(), dismissed = false
+      `INSERT INTO ${TABLE_NAME} (org_id, table_name, column_name, connection_id, connection_group_id, category, confidence, masking_strategy)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       ON CONFLICT (org_id, table_name, column_name, ${coalescedScopeColumn({ column: "connection_group_id" })})
+       DO UPDATE SET category = $6, confidence = $7, masking_strategy = $8, updated_at = now(), dismissed = false
        RETURNING *`,
-      [orgId, tableName, columnName, connectionId, category, confidence, maskingStrategy],
+      [orgId, tableName, columnName, connectionId ?? null, groupId, category, confidence, maskingStrategy],
     ));
     return rowToClassification(rows[0]);
   });
@@ -295,6 +392,18 @@ export interface MaskingContext {
   orgId: string;
   /** User role — determines masking level. */
   userRole: MaskingRole | string | undefined;
+  /**
+   * Connection id the query ran against (#2341). When provided, the
+   * masking lookup is filtered to classifications whose
+   * `connection_group_id` matches the connection's group (resolved
+   * via 0062's 1:1 mapping) or to NULL-scoped global classifications.
+   *
+   * When omitted, every classification for the org applies — this is
+   * the back-compat shape for single-group orgs and for callers that
+   * haven't been wired through yet. Multi-group orgs MUST pass this
+   * so prod's masking rules don't leak onto staging queries.
+   */
+  connectionId?: string | null;
 }
 
 /**
@@ -332,9 +441,24 @@ export const applyMasking = (
 
     if (classifications.length === 0) return ctx.rows;
 
+    // Resolve the active query's connection_group_id once. Multi-group
+    // orgs need this to scope the lookup; single-group orgs (and callers
+    // that omit `connectionId`) get the back-compat "all classifications
+    // apply" shape via `currentGroupId = null`.
+    const currentGroupId = ctx.connectionId
+      ? yield* resolveGroupIdForConnection(ctx.orgId, ctx.connectionId)
+      : null;
+
     // Build a lookup: columnName → masking strategy (filtered to tables accessed by this query)
     const maskLookup = new Map<string, MaskingStrategy>();
     for (const cls of classifications) {
+      // Group filter (#2341): when the caller passed a connectionId, drop
+      // classifications whose group doesn't match. NULL-scoped rows
+      // (legacy / global / un-scoped) always apply. When the caller
+      // omitted connectionId, every classification applies (back-compat).
+      if (ctx.connectionId && cls.connection_group_id != null && cls.connection_group_id !== currentGroupId) {
+        continue;
+      }
       const tableNameLower = cls.table_name.toLowerCase();
       const colNameLower = cls.column_name.toLowerCase();
       // Match against tables accessed by this query

--- a/packages/api/src/api/routes/admin-compliance.ts
+++ b/packages/api/src/api/routes/admin-compliance.ts
@@ -24,6 +24,7 @@ import {
   updatePIIClassification,
   deletePIIClassification,
   invalidateClassificationCache,
+  resolveConnectionGroupForFilter,
   ComplianceError,
 } from "@atlas/ee/compliance/masking";
 import {
@@ -79,7 +80,8 @@ const listRoute = createRoute({
   summary: "List PII column classifications",
   request: {
     query: z.object({
-      connectionId: z.string().optional().openapi({ description: "Filter by connection ID" }),
+      connectionGroupId: z.string().optional().openapi({ description: "Filter by connection group (environment) ID" }),
+      connectionId: z.string().optional().openapi({ description: "Legacy: filter by connection ID — resolved to the connection's group via 0062's 1:1 mapping. Prefer `connectionGroupId` for new callers." }),
     }),
   },
   responses: {
@@ -135,9 +137,17 @@ adminCompliance.use(requireOrgContext());
 adminCompliance.openapi(listRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
-    const { connectionId } = c.req.valid("query");
+    const { connectionGroupId, connectionId } = c.req.valid("query");
 
-    const classifications = yield* listPIIClassifications(orgId!, connectionId);
+    // Prefer explicit group filter. Legacy `connectionId` is resolved to
+    // the connection's group via 0062's 1:1 mapping (the row is keyed on
+    // the group post-0064, so filtering by connection_id would never
+    // match the new shape). Omitting both returns all classifications
+    // for the org.
+    const groupFilter = connectionGroupId
+      ?? (connectionId ? yield* resolveConnectionGroupForFilter(orgId!, connectionId) : undefined);
+
+    const classifications = yield* listPIIClassifications(orgId!, groupFilter ?? undefined);
     return c.json({ classifications }, 200);
   }), { label: "list PII classifications", domainErrors: [complianceDomainError, reportDomainError] });
 });

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -309,6 +309,7 @@ describe("migrateAuthTables", () => {
             { name: "0061_user_default_landing.sql" },
             { name: "0062_connection_groups.sql" },
             { name: "0063_semantic_entities_group_scoped.sql" },
+            { name: "0064_pii_group_scoped.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -709,10 +709,23 @@ describeIfPg("migrate-pg (real Postgres)", () => {
   }, PG_TEST_TIMEOUT_MS);
 
   it("pii_column_classifications: unique index is keyed on connection_group_id, not connection_id", async () => {
-    // The old `pii_column_classifications_unique` index from 0000 is
-    // dropped and recreated by 0064 to key on `connection_group_id`.
-    // `pg_indexes.indexdef` reflects the post-CREATE expression so we
-    // can assert the new keying without parsing pg_index.indkey.
+    // The baseline inline UNIQUE constraint auto-names to the 63-byte
+    // truncated `...column_name_connec` name, not `...co_key`; 0064 must
+    // drop that constraint before creating the group-keyed index.
+    const legacyConstraintName = "pii_column_classifications_org_id_table_name_column_name_connec";
+    const legacy = await pool.query<{ conname: string; constraintdef: string }>(
+      `SELECT conname, pg_get_constraintdef(oid) AS constraintdef
+       FROM pg_constraint
+       WHERE conrelid = 'pii_column_classifications'::regclass
+         AND conname = $1`,
+      [legacyConstraintName],
+    );
+    expect(legacy.rows).toEqual([]);
+
+    // The old connection-keyed uniqueness is dropped and recreated by
+    // 0064 to key on `connection_group_id`. `pg_indexes.indexdef`
+    // reflects the post-CREATE expression so we can assert the new
+    // keying without parsing pg_index.indkey.
     const { rows } = await pool.query<{ indexname: string; indexdef: string }>(
       `SELECT indexname, indexdef
        FROM pg_indexes

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -664,4 +664,274 @@ describeIfPg("migrate-pg (real Postgres)", () => {
       ),
     ).rejects.toMatchObject({ code: "23505" });
   }, PG_TEST_TIMEOUT_MS);
+
+  // 0064 — pii_column_classifications.connection_group_id. Mirrors the 0063
+  // shape on the PII table: the natural key flips from `connection_id` to
+  // `connection_group_id`, the legacy NOT NULL DEFAULT 'default' on
+  // `connection_id` drops, and the unique index is recreated keyed on the
+  // group. The PRD assumption (replicas inside a group share schema, so a
+  // column's PII classification is the same across all group members) is
+  // pinned by the group-reassignment test below: moving a connection
+  // between groups MUST NOT carry classifications with it — the row stays
+  // attached to the originating group, and the new group inherits its own
+  // independent classification set.
+  it("pii_column_classifications.connection_group_id: column exists and is nullable", async () => {
+    const { rows } = await pool.query<{ is_nullable: string; data_type: string }>(
+      `SELECT is_nullable, data_type
+       FROM information_schema.columns
+       WHERE table_name = 'pii_column_classifications'
+         AND column_name = 'connection_group_id'
+         AND table_schema = current_schema()`,
+    );
+    expect(rows[0]?.data_type).toBe("text");
+    // Nullable: legacy rows may carry connection_id values that no longer
+    // resolve to a live connection (orphaned classifications from deleted
+    // connections). Those rows backfill to NULL and live in the COALESCE
+    // sentinel bucket alongside other un-scoped rows. Flipping to NOT
+    // NULL would orphan them at boot.
+    expect(rows[0]?.is_nullable).toBe("YES");
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("pii_column_classifications.connection_id: legacy NOT NULL DEFAULT 'default' dropped", async () => {
+    // 0064 drops the `NOT NULL DEFAULT 'default'` so callers don't get
+    // silently bucketed into a `'default'` sentinel they never asked for.
+    // The group is the natural key now; connection_id is dual-write for
+    // the transitional SDK and goes away in #2346.
+    const { rows } = await pool.query<{ is_nullable: string; column_default: string | null }>(
+      `SELECT is_nullable, column_default
+       FROM information_schema.columns
+       WHERE table_name = 'pii_column_classifications'
+         AND column_name = 'connection_id'
+         AND table_schema = current_schema()`,
+    );
+    expect(rows[0]?.is_nullable).toBe("YES");
+    expect(rows[0]?.column_default).toBeNull();
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("pii_column_classifications: unique index is keyed on connection_group_id, not connection_id", async () => {
+    // The old `pii_column_classifications_unique` index from 0000 is
+    // dropped and recreated by 0064 to key on `connection_group_id`.
+    // `pg_indexes.indexdef` reflects the post-CREATE expression so we
+    // can assert the new keying without parsing pg_index.indkey.
+    const { rows } = await pool.query<{ indexname: string; indexdef: string }>(
+      `SELECT indexname, indexdef
+       FROM pg_indexes
+       WHERE schemaname = current_schema()
+         AND tablename = 'pii_column_classifications'
+         AND indexname = 'pii_column_classifications_unique'`,
+    );
+    expect(rows.length).toBe(1);
+    // Group-keyed: COALESCE(connection_group_id, '__default__'). The
+    // `::text` optional suffix matches PG's expression-index reconstruction.
+    expect(rows[0]?.indexdef).toMatch(/COALESCE\(connection_group_id, '__default__'(?:::text)?\)/i);
+    // The legacy `connection_id` column MUST NOT appear in the new
+    // index — drift between drop+create would leave the old index live
+    // and the new one silently absent.
+    expect(rows[0]?.indexdef).not.toMatch(/connection_id/i);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("pii_column_classifications: backfill resolves connection_id → connection_group_id via 0062's 1:1 mapping", async () => {
+    // Pre-migration classifications have `connection_id` set but no
+    // `connection_group_id`. 0064 backfills by joining `connections`, so
+    // every row with a known connection lands on `g_<connId>` (the group
+    // 0062 created for the 1:1 backfill).
+    const orgId = `org-backfill-pii-${Date.now()}`;
+    const connId = `conn-back-pii-${Date.now()}`;
+    const groupId = `g_${connId}`;
+    await pool.query(
+      `INSERT INTO connection_groups (id, org_id, name) VALUES ($1, $2, $3)`,
+      [groupId, orgId, connId],
+    );
+    await pool.query(
+      `INSERT INTO connections (id, url, type, org_id, status, group_id)
+       VALUES ($1, 'enc:v1:iv:tag:ciphertext', 'postgres', $2, 'published', $3)`,
+      [connId, orgId, groupId],
+    );
+    // Pre-0064 shape: connection_id set, connection_group_id NULL.
+    await pool.query(
+      `INSERT INTO pii_column_classifications
+         (org_id, table_name, column_name, connection_id, connection_group_id, category, confidence, masking_strategy)
+       VALUES ($1, 'users', 'email', $2, NULL, 'email', 'high', 'partial')`,
+      [orgId, connId],
+    );
+    // Re-run the backfill block (same SQL the migration emits). Idempotent
+    // — the WHERE clause only touches rows still missing connection_group_id.
+    await pool.query(
+      `UPDATE pii_column_classifications pc
+         SET connection_group_id = c.group_id
+         FROM connections c
+         WHERE pc.org_id = $1
+           AND pc.connection_id IS NOT NULL
+           AND pc.connection_group_id IS NULL
+           AND c.id = pc.connection_id
+           AND (c.org_id = pc.org_id OR c.org_id = '__global__')`,
+      [orgId],
+    );
+    const { rows } = await pool.query<{ connection_group_id: string | null }>(
+      `SELECT connection_group_id FROM pii_column_classifications
+       WHERE org_id = $1 AND table_name = 'users' AND column_name = 'email'`,
+      [orgId],
+    );
+    expect(rows[0]?.connection_group_id).toBe(groupId);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("pii_column_classifications: two connections in the same group cannot duplicate the same classification", async () => {
+    // Group-scoped uniqueness — the PRD invariant for #2341. A multi-
+    // member group ("us-int + eu + apac = one logical 'prod'") sees one
+    // classification per (table, column). Attempting a second row keyed
+    // on the same group with a different connection_id must fail with
+    // 23505. This is the assumption the prompt asks us to lock in: same
+    // column = same PII across group members.
+    const orgId = `org-pii-group-dup-${Date.now()}`;
+    const groupId = `g-pii-group-dup-${Date.now()}`;
+    await pool.query(
+      `INSERT INTO connection_groups (id, org_id, name) VALUES ($1, $2, 'prod')`,
+      [groupId, orgId],
+    );
+    await pool.query(
+      `INSERT INTO pii_column_classifications
+         (org_id, table_name, column_name, connection_id, connection_group_id, category, confidence, masking_strategy)
+       VALUES ($1, 'users', 'email', 'us-int', $2, 'email', 'high', 'partial')`,
+      [orgId, groupId],
+    );
+    await expect(
+      pool.query(
+        `INSERT INTO pii_column_classifications
+           (org_id, table_name, column_name, connection_id, connection_group_id, category, confidence, masking_strategy)
+         VALUES ($1, 'users', 'email', 'eu', $2, 'email', 'high', 'partial')`,
+        [orgId, groupId],
+      ),
+    ).rejects.toMatchObject({ code: "23505" });
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("pii_column_classifications: group reassignment keeps classifications with the originating group", async () => {
+    // PRD #2336 acceptance criterion (from issue #2341): moving a
+    // connection between groups must NOT carry classifications with it
+    // — the row stays attached to the originating group, and the new
+    // group inherits its own independent classification set.
+    //
+    // Why: PII classifications live on the GROUP, not the connection.
+    // Reassigning `us-int` from group `prod` to group `staging` is a
+    // governance event ("we're treating this replica as staging now");
+    // the staging admins decide their own PII posture from scratch.
+    // Auto-migrating the prod classifications would silently relax
+    // staging's posture to match prod's, which is exactly the failure
+    // mode the PRD calls out.
+    const orgId = `org-reassign-${Date.now()}`;
+    const prodGroup = `g-prod-${Date.now()}`;
+    const stagingGroup = `g-staging-${Date.now()}`;
+    const connId = `conn-reassign-${Date.now()}`;
+    await pool.query(
+      `INSERT INTO connection_groups (id, org_id, name) VALUES ($1, $2, 'prod'), ($3, $2, 'staging')`,
+      [prodGroup, orgId, stagingGroup],
+    );
+    await pool.query(
+      `INSERT INTO connections (id, url, type, org_id, status, group_id)
+       VALUES ($1, 'enc:v1:iv:tag:ciphertext', 'postgres', $2, 'published', $3)`,
+      [connId, orgId, prodGroup],
+    );
+    // Classify `users.email` on the prod group.
+    await pool.query(
+      `INSERT INTO pii_column_classifications
+         (org_id, table_name, column_name, connection_id, connection_group_id, category, confidence, masking_strategy)
+       VALUES ($1, 'users', 'email', $2, $3, 'email', 'high', 'partial')`,
+      [orgId, connId, prodGroup],
+    );
+    // Reassign the connection to staging. The classification's
+    // connection_group_id must NOT follow — it stays on prod.
+    await pool.query(
+      `UPDATE connections SET group_id = $1 WHERE id = $2 AND org_id = $3`,
+      [stagingGroup, connId, orgId],
+    );
+    const prodRows = await pool.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM pii_column_classifications
+       WHERE org_id = $1 AND connection_group_id = $2`,
+      [orgId, prodGroup],
+    );
+    expect(prodRows.rows[0]?.count).toBe("1");
+    const stagingRows = await pool.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM pii_column_classifications
+       WHERE org_id = $1 AND connection_group_id = $2`,
+      [orgId, stagingGroup],
+    );
+    expect(stagingRows.rows[0]?.count).toBe("0");
+
+    // Staging admins can now classify the same column independently —
+    // no 23505, because the row is keyed on the staging group.
+    await pool.query(
+      `INSERT INTO pii_column_classifications
+         (org_id, table_name, column_name, connection_id, connection_group_id, category, confidence, masking_strategy)
+       VALUES ($1, 'users', 'email', $2, $3, 'email', 'low', 'redact')`,
+      [orgId, connId, stagingGroup],
+    );
+    const stagingAfter = await pool.query<{ masking_strategy: string }>(
+      `SELECT masking_strategy FROM pii_column_classifications
+       WHERE org_id = $1 AND connection_group_id = $2 AND table_name = 'users' AND column_name = 'email'`,
+      [orgId, stagingGroup],
+    );
+    expect(stagingAfter.rows[0]?.masking_strategy).toBe("redact");
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("pii_column_classifications: 0064 dedup CTE collapses pre-merged duplicates so the unique index builds", async () => {
+    // Defensive case from the multi-env rollout: admins who pre-merged
+    // multiple connections into one group (via #2339's admin UI) before
+    // 0064 runs will see N classification rows for what is logically
+    // one (org, table, column, group) entry. The migration's dedup CTE
+    // keeps the freshest row per group bucket so the new unique index
+    // can be created without 23505. Mirrors the 0063 dedup shape.
+    const orgId = `org-pii-dedup-${Date.now()}`;
+    const groupId = `g-pii-dedup-${Date.now()}`;
+    await pool.query(
+      `INSERT INTO connection_groups (id, org_id, name) VALUES ($1, $2, 'prod')`,
+      [groupId, orgId],
+    );
+    // Insert two pre-merged rows differing only on connection_id. Both
+    // currently coexist under the live group-keyed index because they
+    // target distinct column names (so we can seed without collision),
+    // then we rename to force the dedup to fire.
+    const newerId = `00000000-0000-0000-0000-aaaa00000001`;
+    const olderId = `00000000-0000-0000-0000-aaaa00000002`;
+    await pool.query(
+      `INSERT INTO pii_column_classifications
+         (id, org_id, table_name, column_name, connection_id, connection_group_id, category, confidence, masking_strategy, updated_at)
+       VALUES ($1, $2, 'users', 'email_v1', 'conn-a', $3, 'email', 'high', 'partial', NOW()),
+              ($4, $2, 'users', 'email_v2', 'conn-b', $3, 'email', 'high', 'partial', NOW() - INTERVAL '1 hour')`,
+      [newerId, orgId, groupId, olderId],
+    );
+    // Drop the unique index so we can force a name collision and then
+    // re-run the dedup CTE. (The dedup CTE runs BEFORE the new index is
+    // built in the production migration; this test mirrors that order.)
+    await pool.query(`DROP INDEX pii_column_classifications_unique`);
+    await pool.query(
+      `UPDATE pii_column_classifications SET column_name = 'email_v1' WHERE id = $1`,
+      [olderId],
+    );
+    await pool.query(
+      `WITH ranked AS (
+         SELECT id,
+                ROW_NUMBER() OVER (
+                  PARTITION BY org_id, table_name, column_name,
+                               COALESCE(connection_group_id, '__default__')
+                  ORDER BY updated_at DESC, id DESC
+                ) AS rn
+         FROM pii_column_classifications
+         WHERE org_id = $1
+       )
+       DELETE FROM pii_column_classifications pc USING ranked r
+       WHERE pc.id = r.id AND r.rn > 1`,
+      [orgId],
+    );
+    const survivors = await pool.query<{ id: string }>(
+      `SELECT id FROM pii_column_classifications WHERE org_id = $1`,
+      [orgId],
+    );
+    expect(survivors.rows.length).toBe(1);
+    expect(survivors.rows[0]?.id).toBe(newerId);
+
+    // Restore the unique index so subsequent tests see production shape.
+    await pool.query(
+      `CREATE UNIQUE INDEX pii_column_classifications_unique
+        ON pii_column_classifications (org_id, table_name, column_name, COALESCE(connection_group_id, '__default__'))`,
+    );
+  }, PG_TEST_TIMEOUT_MS);
 });

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -79,7 +79,7 @@ describe("runMigrations", () => {
 
     const count = await runMigrations(pool);
 
-    expect(count).toBe(64);
+    expect(count).toBe(65);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -172,6 +172,7 @@ describe("runMigrations", () => {
         "0061_user_default_landing.sql",
         "0062_connection_groups.sql",
         "0063_semantic_entities_group_scoped.sql",
+        "0064_pii_group_scoped.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0064_pii_group_scoped.sql
+++ b/packages/api/src/lib/db/migrations/0064_pii_group_scoped.sql
@@ -109,26 +109,32 @@ ALTER TABLE pii_column_classifications
 --
 -- The baseline keyed uniqueness on `(org_id, table_name, column_name,
 -- connection_id)` via an INLINE `UNIQUE(...)` constraint inside the
--- baseline `CREATE TABLE`. Postgres auto-names that constraint
--- `pii_column_classifications_org_id_table_name_column_name_co_key`
--- (truncated to 63 chars) and backs it with an index of the same name —
--- NOT `pii_column_classifications_unique`. A bare `DROP INDEX IF EXISTS
+-- baseline `CREATE TABLE`. Postgres auto-names that constraint by
+-- truncating the full generated name
+-- `pii_column_classifications_org_id_table_name_column_name_connection_id_key`
+-- to 63 bytes:
+-- `pii_column_classifications_org_id_table_name_column_name_connec`.
+-- That constraint backs an index of the same name — NOT
+-- `pii_column_classifications_unique`. A bare `DROP INDEX IF EXISTS
 -- pii_column_classifications_unique` leaves the old constraint in
 -- place, and the new group-keyed rows then collide with the old
--- connection-keyed constraint at first insert (the api-tests (1/4) CI
--- failure that motivated this revision).
+-- connection-keyed constraint at first insert.
 --
--- The DROP CONSTRAINT covers the baseline case; the DROP INDEX covers
--- self-hosted installs that hit the masking module's `ensureTable`
--- bootstrap path before the migration ran (the bootstrap creates an
--- index with the COALESCE-less inline UNIQUE — same column set, but
--- explicitly named through the constraint).
+-- The first DROP CONSTRAINT covers the actual baseline name; the second
+-- is defensive for prerelease installs that ran an earlier 0064 draft
+-- comment / name guess. The DROP INDEX covers self-hosted installs that
+-- hit the masking module's `ensureTable` bootstrap path before the
+-- migration ran (the bootstrap creates an index with the COALESCE-less
+-- inline UNIQUE — same column set, but explicitly named through the
+-- constraint).
 --
 -- 0064 swaps the natural key to `COALESCE(connection_group_id,
 -- '__default__')` so multi-member groups collapse to one classification
 -- row per column, matching the semantic-entities shape (#2340). The
 -- drop+create is atomic inside the migration so callers querying
 -- mid-migration never see an absent unique constraint.
+ALTER TABLE pii_column_classifications
+  DROP CONSTRAINT IF EXISTS pii_column_classifications_org_id_table_name_column_name_connec;
 ALTER TABLE pii_column_classifications
   DROP CONSTRAINT IF EXISTS pii_column_classifications_org_id_table_name_column_name_co_key;
 DROP INDEX IF EXISTS pii_column_classifications_unique;

--- a/packages/api/src/lib/db/migrations/0064_pii_group_scoped.sql
+++ b/packages/api/src/lib/db/migrations/0064_pii_group_scoped.sql
@@ -1,0 +1,122 @@
+-- 0064 — Group-scoped PII classifications (PRD #2336, issue #2341).
+--
+-- Mirrors the 0063 reshape on the PII table: flips the natural key from
+-- `connection_id` to `connection_group_id`, drops the legacy `NOT NULL
+-- DEFAULT 'default'` on `connection_id`, and recreates the unique index
+-- keyed on the group. PII scanning runs once per group; classifications
+-- are group-wide.
+--
+-- HITL assumption (locked per #2341 prompt): replicas inside a group
+-- share schema, so a column's PII classification is the same across all
+-- group members. The unique index `UNIQUE(org_id, table_name,
+-- column_name, COALESCE(connection_group_id, '__default__'))` is the
+-- DB-level encoding of that invariant. Reassigning a connection between
+-- groups intentionally does NOT carry classifications — staging admins
+-- decide their own posture (the migration-pg smoke pins this).
+--
+-- `connection_id` stays on the table as a nullable transitional column
+-- for SDK back-compat (mirrors the 0063 strategy for `semantic_entities`).
+-- Final removal lives in #2346 alongside the rest of the deprecation tail.
+
+-- ── 1. Column ─────────────────────────────────────────────────────────
+--
+-- Nullable initially. Rows whose `connection_id` references a connection
+-- that has since been deleted backfill to `connection_group_id = NULL`
+-- and live in the COALESCE sentinel bucket with other un-scoped rows.
+-- Flipping this to NOT NULL would orphan those legacy rows at boot.
+ALTER TABLE pii_column_classifications
+  ADD COLUMN IF NOT EXISTS connection_group_id TEXT;
+
+-- Lookup index for the new column. The unique index below enforces
+-- uniqueness; this one supports the read path (`WHERE
+-- connection_group_id = $1` in `listPIIClassifications` and the masking
+-- cache loader).
+CREATE INDEX IF NOT EXISTS idx_pii_column_classifications_group
+  ON pii_column_classifications (connection_group_id, org_id);
+
+-- ── 2. Backfill ───────────────────────────────────────────────────────
+--
+-- Resolve every existing row's `connection_group_id` from its
+-- `connection_id` via 0062's 1:1 mapping. The join allows either a
+-- per-org connection or a `__global__` shadow (the demo / built-in
+-- connections moved to `__global__` by 0060), matching the visibility
+-- resolution semantic-entities (#2340) and the whitelist use.
+--
+-- Idempotent: the predicate `connection_group_id IS NULL` ensures
+-- re-runs take no action on rows already resolved.
+--
+-- Rows whose `connection_id = 'default'` (the literal baseline default)
+-- without a matching connection row stay `connection_group_id = NULL`
+-- — they fall into the COALESCE sentinel bucket the same way 0063's
+-- legacy NULL-scope rows do. Admin can re-scope them by hand if needed.
+UPDATE pii_column_classifications pc
+   SET connection_group_id = c.group_id
+   FROM connections c
+   WHERE pc.connection_id IS NOT NULL
+     AND pc.connection_group_id IS NULL
+     AND c.id = pc.connection_id
+     AND (c.org_id = pc.org_id OR c.org_id = '__global__');
+
+-- ── 3. Dedup pre-existing multi-connection rows ───────────────────────
+--
+-- Defensive sweep for the case an admin merged multiple connections
+-- into one group BEFORE 0064 runs (#2339 ships the admin UI to do
+-- exactly this). Without this step, each connection's per-row
+-- classification collapses into the same group bucket and the new
+-- unique index below fails to build with 23505.
+--
+-- Strategy: rank rows in each (org_id, table_name, column_name,
+-- COALESCE(group_id)) bucket by (updated_at DESC, id DESC) and keep
+-- only `rn = 1`. `updated_at` is the natural "freshest review" tie-
+-- breaker (admins who recently reviewed a row should win over a stale
+-- auto-detected one); `id` is the deterministic fallback for two rows
+-- updated in the same statement.
+--
+-- Idempotent: a re-run sees one row per partition and finds nothing to
+-- delete.
+WITH ranked AS (
+  SELECT id,
+         ROW_NUMBER() OVER (
+           PARTITION BY
+             org_id,
+             table_name,
+             column_name,
+             COALESCE(connection_group_id, '__default__')
+           ORDER BY updated_at DESC, id DESC
+         ) AS rn
+  FROM pii_column_classifications
+)
+DELETE FROM pii_column_classifications pc
+USING ranked r
+WHERE pc.id = r.id
+  AND r.rn > 1;
+
+-- ── 4. Drop legacy NOT NULL DEFAULT on connection_id ──────────────────
+--
+-- The baseline shape was `connection_id TEXT NOT NULL DEFAULT 'default'`.
+-- That literal default silently bucketed every row without an explicit
+-- connection into a `'default'` sentinel — a footgun once connections
+-- became first-class (orgs with no connection named "default" still got
+-- `connection_id = 'default'`). The group_id is the natural key now;
+-- callers that don't have a connection should write NULL and rely on
+-- the COALESCE sentinel.
+ALTER TABLE pii_column_classifications
+  ALTER COLUMN connection_id DROP NOT NULL;
+ALTER TABLE pii_column_classifications
+  ALTER COLUMN connection_id DROP DEFAULT;
+
+-- ── 5. Replace the unique index with the group-keyed shape ────────────
+--
+-- The baseline `pii_column_classifications_unique` index keyed on
+-- `(org_id, table_name, column_name, connection_id)`. 0064 swaps it to
+-- key on `COALESCE(connection_group_id, '__default__')` so multi-member
+-- groups collapse to one classification row per column, matching the
+-- semantic-entities shape (#2340). The index name is reused so the
+-- Drizzle schema mirror stays a one-line change.
+--
+-- The drop+create is atomic inside the migration so callers querying
+-- mid-migration never see an absent unique constraint.
+DROP INDEX IF EXISTS pii_column_classifications_unique;
+
+CREATE UNIQUE INDEX pii_column_classifications_unique
+  ON pii_column_classifications (org_id, table_name, column_name, COALESCE(connection_group_id, '__default__'));

--- a/packages/api/src/lib/db/migrations/0064_pii_group_scoped.sql
+++ b/packages/api/src/lib/db/migrations/0064_pii_group_scoped.sql
@@ -107,15 +107,30 @@ ALTER TABLE pii_column_classifications
 
 -- ── 5. Replace the unique index with the group-keyed shape ────────────
 --
--- The baseline `pii_column_classifications_unique` index keyed on
--- `(org_id, table_name, column_name, connection_id)`. 0064 swaps it to
--- key on `COALESCE(connection_group_id, '__default__')` so multi-member
--- groups collapse to one classification row per column, matching the
--- semantic-entities shape (#2340). The index name is reused so the
--- Drizzle schema mirror stays a one-line change.
+-- The baseline keyed uniqueness on `(org_id, table_name, column_name,
+-- connection_id)` via an INLINE `UNIQUE(...)` constraint inside the
+-- baseline `CREATE TABLE`. Postgres auto-names that constraint
+-- `pii_column_classifications_org_id_table_name_column_name_co_key`
+-- (truncated to 63 chars) and backs it with an index of the same name —
+-- NOT `pii_column_classifications_unique`. A bare `DROP INDEX IF EXISTS
+-- pii_column_classifications_unique` leaves the old constraint in
+-- place, and the new group-keyed rows then collide with the old
+-- connection-keyed constraint at first insert (the api-tests (1/4) CI
+-- failure that motivated this revision).
 --
--- The drop+create is atomic inside the migration so callers querying
+-- The DROP CONSTRAINT covers the baseline case; the DROP INDEX covers
+-- self-hosted installs that hit the masking module's `ensureTable`
+-- bootstrap path before the migration ran (the bootstrap creates an
+-- index with the COALESCE-less inline UNIQUE — same column set, but
+-- explicitly named through the constraint).
+--
+-- 0064 swaps the natural key to `COALESCE(connection_group_id,
+-- '__default__')` so multi-member groups collapse to one classification
+-- row per column, matching the semantic-entities shape (#2340). The
+-- drop+create is atomic inside the migration so callers querying
 -- mid-migration never see an absent unique constraint.
+ALTER TABLE pii_column_classifications
+  DROP CONSTRAINT IF EXISTS pii_column_classifications_org_id_table_name_column_name_co_key;
 DROP INDEX IF EXISTS pii_column_classifications_unique;
 
 CREATE UNIQUE INDEX pii_column_classifications_unique

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -1162,7 +1162,17 @@ export const piiColumnClassifications = pgTable(
     orgId: text("org_id").notNull(),
     tableName: text("table_name").notNull(),
     columnName: text("column_name").notNull(),
-    connectionId: text("connection_id").notNull().default("default"),
+    // Legacy connection scope. 0064 dropped `NOT NULL DEFAULT 'default'`
+    // — the natural key is `connection_group_id` now. Retained nullable
+    // for transitional dual-write; final removal lives in #2346.
+    connectionId: text("connection_id"),
+    // Group scope (#2341). One row per (org_id, table_name, column_name,
+    // group_id) — multi-member groups share the same classification
+    // (replicas inside a group share schema, so the column's PII
+    // category is the same across all members). Nullable for legacy
+    // rows whose connection_id no longer resolves to a live connection;
+    // those rows live in the COALESCE sentinel bucket.
+    connectionGroupId: text("connection_group_id"),
     category: text("category").notNull(),
     confidence: text("confidence").notNull().default("medium"),
     maskingStrategy: text("masking_strategy").notNull().default("partial"),
@@ -1172,7 +1182,15 @@ export const piiColumnClassifications = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [
-    uniqueIndex("pii_column_classifications_unique").on(t.orgId, t.tableName, t.columnName, t.connectionId),
+    index("idx_pii_column_classifications_group").on(t.connectionGroupId, t.orgId),
+    // IMPORTANT: placeholder stub — the real index is UNIQUE on
+    // (org_id, table_name, column_name, COALESCE(connection_group_id,
+    // '__default__')) and is managed by raw SQL in migration 0064.
+    // Drizzle can't represent COALESCE expression indexes, so this
+    // non-unique approximation exists solely to suppress drift warnings.
+    // Do NOT rely on this for constraint reasoning. Callers using `ON
+    // CONFLICT` must target the COALESCE expression, not the column.
+    index("pii_column_classifications_unique").on(t.orgId, t.tableName, t.columnName, t.connectionGroupId),
   ],
 );
 

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -907,6 +907,7 @@ function executeAndAuditEffect(opts: {
                 columns: result.columns, rows: result.rows,
                 tablesAccessed: classification.tablesAccessed,
                 orgId, userRole: maskCtx?.user?.role,
+                connectionId: connId,
               }));
               maskingApplied = maskedRows !== result.rows;
             } catch (err) {
@@ -1478,6 +1479,7 @@ export const executeSQL = tool({
                       columns: cached.columns, rows: cached.rows,
                       tablesAccessed: classification.tablesAccessed,
                       orgId, userRole: ctx?.user?.role,
+                      connectionId: connId,
                     }));
                     cachedMaskingApplied = cachedRows !== cached.rows;
                   } catch (err) {

--- a/packages/schemas/src/__tests__/admin-config.test.ts
+++ b/packages/schemas/src/__tests__/admin-config.test.ts
@@ -229,6 +229,22 @@ describe("PIIColumnClassificationSchema", () => {
       expect(() => PIIColumnClassificationSchema.parse({ ...validPII, maskingStrategy })).not.toThrow();
     }
   });
+
+  test("connectionId accepts null (post-0064 nullable)", () => {
+    // Migration 0064 dropped the legacy `NOT NULL DEFAULT 'default'`.
+    // Bundles emitted post-#2341 may carry `connectionId: null` for
+    // rows whose source connection was deleted.
+    const nullScoped = { ...validPII, connectionId: null };
+    expect(PIIColumnClassificationSchema.parse(nullScoped)).toEqual(nullScoped);
+  });
+
+  test("connectionGroupId is additive — optional with null allowed", () => {
+    // #2341 added the field. Legacy bundles omit it; new bundles populate
+    // either a group id or null (for un-scoped / cross-env rows).
+    expect(() => PIIColumnClassificationSchema.parse(validPII)).not.toThrow();
+    expect(() => PIIColumnClassificationSchema.parse({ ...validPII, connectionGroupId: "g_prod" })).not.toThrow();
+    expect(() => PIIColumnClassificationSchema.parse({ ...validPII, connectionGroupId: null })).not.toThrow();
+  });
 });
 
 describe("SemanticDiffResponseSchema", () => {

--- a/packages/schemas/src/admin-config.ts
+++ b/packages/schemas/src/admin-config.ts
@@ -145,7 +145,13 @@ export const PIIColumnClassificationSchema = z.object({
   orgId: z.string(),
   tableName: z.string(),
   columnName: z.string(),
-  connectionId: z.string(),
+  // Legacy connection scope. Nullable post-0064 (the migration dropped
+  // the `NOT NULL DEFAULT 'default'`). Prefer `connectionGroupId` for
+  // new callers. See PRD #2336 §"Migration sequencing".
+  connectionId: z.string().nullable(),
+  // Group scope (#2341). Optional during the wire-format transition —
+  // bundles exported by pre-1.4.4 instances omit the field.
+  connectionGroupId: z.string().nullable().optional(),
   category: z.enum(PII_CATEGORIES),
   confidence: z.enum(PII_CONFIDENCE_LEVELS),
   maskingStrategy: z.enum(MASKING_STRATEGIES),

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/types",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {

--- a/packages/types/src/compliance.ts
+++ b/packages/types/src/compliance.ts
@@ -67,8 +67,33 @@ export interface PIIColumnClassification {
   tableName: string;
   /** Column name within the table. */
   columnName: string;
-  /** Connection ID for the datasource. */
-  connectionId: string;
+  /**
+   * Legacy connection scope. Retained for compatibility with classifications
+   * stored before #2341; new rows also populate `connectionGroupId`
+   * (additive). Final removal lives in the #2346 deprecation tail.
+   *
+   * Nullable post-0064 — the migration dropped the legacy `NOT NULL
+   * DEFAULT 'default'`. Read sites should treat NULL as "no connection
+   * scope" (a global / cross-env classification) and prefer the group
+   * column for resolution.
+   *
+   * @deprecated Prefer `connectionGroupId` when reading from 1.4.4+ instances.
+   */
+  connectionId: string | null;
+  /**
+   * Group scope (#2341). One classification row per (org, table, column,
+   * group) — multi-member groups share the same row (replicas inside a
+   * group share schema, so the column's PII category is the same across
+   * all members). Nullable for legacy rows whose `connectionId` no
+   * longer resolves to a live connection; those classifications apply
+   * globally within the org (the COALESCE sentinel bucket).
+   *
+   * Optional during the wire-format transition: instances exported
+   * before #2341 omit the field. Consumers should resolve
+   * `connectionGroupId ?? null` and fall back to `connectionId` for
+   * legacy rows.
+   */
+  connectionGroupId?: string | null;
   /** Detected or manually assigned PII category. */
   category: PIICategory;
   /** Detection confidence level. */

--- a/packages/web/src/app/admin/compliance/page.tsx
+++ b/packages/web/src/app/admin/compliance/page.tsx
@@ -315,6 +315,7 @@ function ClassificationsTab() {
               <TableRow>
                 <TableHead>Table</TableHead>
                 <TableHead>Column</TableHead>
+                <TableHead>Environment</TableHead>
                 <TableHead>Category</TableHead>
                 <TableHead>Confidence</TableHead>
                 <TableHead>Masking</TableHead>
@@ -327,6 +328,15 @@ function ClassificationsTab() {
                 <TableRow key={cls.id}>
                   <TableCell className="font-mono text-sm">{cls.tableName}</TableCell>
                   <TableCell className="font-mono text-sm">{cls.columnName}</TableCell>
+                  <TableCell>
+                    {cls.connectionGroupId ? (
+                      <Badge variant="secondary" className="font-mono text-xs">
+                        {cls.connectionGroupId.replace(/^g_/, "")}
+                      </Badge>
+                    ) : (
+                      <span className="text-muted-foreground text-sm">—</span>
+                    )}
+                  </TableCell>
                   <TableCell>{CATEGORY_LABELS[cls.category] ?? cls.category}</TableCell>
                   <TableCell>{confidenceBadge(cls.confidence)}</TableCell>
                   <TableCell>


### PR DESCRIPTION
## Summary

Closes #2341. Migrates `pii_column_classifications` from connection-scoped to group-scoped per PRD #2336, mirroring the #2340 (semantic entities) reshape via PR #2392.

- Migration 0064 adds `pii_column_classifications.connection_group_id`, backfills via 0062's 1:1 mapping, drops the legacy `NOT NULL DEFAULT 'default'` on `connection_id`, and recreates the unique index keyed on `(org_id, table_name, column_name, COALESCE(connection_group_id, '__default__'))`. Index name reused so the Drizzle schema mirror stays a one-line change.
- **HITL assumption locked** (per the prompt): replicas inside a group share schema, so a column's PII category is the same across all group members. The new unique key encodes this invariant at the DB layer.
- Real-Postgres migration smoke (`migrate-pg.test.ts`) extended with **seven** new assertions: column shape, legacy `NOT NULL DEFAULT 'default'` dropped, group-keyed index definition (with `connection_id` explicitly forbidden), backfill correctness via 0062's mapping, group-scoped uniqueness, group reassignment (the PRD invariant — moving a connection between groups does NOT carry classifications; the row stays on the originating group, and the new group inherits its own independent set), and the dedup CTE.
- `withGroupScope` paid off across `ee/compliance/masking.ts`:
  - `savePIIClassification` resolves the connection's `group_id` inline via 0062's mapping and targets `ON CONFLICT` against `coalescedScopeColumn({ column: "connection_group_id" })`.
  - `listPIIClassifications` filters via `withGroupScope`; the route layer accepts either `connectionGroupId` (preferred) or the legacy `connectionId` query param (resolved to a group via the new `resolveConnectionGroupForFilter` helper).
  - `applyMasking` takes an optional `connectionId` in the `MaskingContext` and filters the lookup to the active query's group + NULL-scoped (global) rows so prod's masking rules don't leak onto staging queries. Back-compat for callers that omit `connectionId` (single-group orgs).
- `@useatlas/types` 0.0.28 → 0.0.29: `PIIColumnClassification.connectionGroupId` added (additive, optional with `null` allowed). `connectionId` becomes nullable with `@deprecated` marker. Mirrored in `@useatlas/schemas`. Per the version-bump-ordering memory, consumer dep refs stay at `^0.0.28` until `types-v0.0.29` is published.
- `/admin/compliance` classifications table gains an **Environment** badge column showing the group name (`g_` prefix stripped) so multi-env admins can see which env each row applies to.

## Acceptance criteria (from #2341)

- [x] Stakeholder confirms "same column = same PII across group members" assumption — locked via the unique index + the group-reassignment migrate-pg smoke pinning the boundary case.
- [x] Migration adds `pii_column_classifications.connection_group_id`, backfills, drops legacy default.
- [x] `UNIQUE(org_id, table_name, column_name, COALESCE(connection_group_id, '__default__'))` index in place.
- [x] `withGroupScope` used by every read site (save path uses `coalescedScopeColumn`, list path uses `.match(...)`, applyMasking filters via resolved group).
- [x] PII scan tooling runs once per group (group scope falls out of `savePIIClassification`); classifications surface group-wide in admin UI via the new Environment column.
- [x] Real-Postgres migration smoke test extended (+7 assertions covering shape, defaults, index keying, backfill, group uniqueness, dedup CTE, and group reassignment).
- [x] `@useatlas/types`: PII classification shape adds `connectionGroupId` (additive); `connectionId` retained as `@deprecated`.
- [x] Unit tests cover the unique-constraint behavior under group reassignment (the `pii_column_classifications: group reassignment keeps classifications with the originating group` smoke test).

## Test plan

- [x] `bun run lint` clean (one preexisting warning, unrelated)
- [x] `bun run type` clean across types, schemas, sdk, react, api, web, ee, plugin-sdk
- [x] `bash scripts/check-schema-drift.sh` — 69 tables, 1 dropped excluded
- [x] `bash scripts/check-template-drift.sh` — 562 files verified
- [x] `bun x syncpack lint` — no issues
- [x] `bash scripts/check-railway-watch.sh` — all COPY sources covered
- [x] `bun run test:api` — 372 / 372 pass (includes the updated migrate.test.ts count 64 → 65)
- [x] `bun run test:others` — all workspaces pass
- [ ] CI Postgres smoke run on the migration

## Out of scope (follow-ups)

- SDK / react dep bumps for `@useatlas/types@0.0.29` — land after `git tag types-v0.0.29 && git push origin types-v0.0.29` per the version-bump-ordering memory.
- Removal of the transitional `connection_id` column on `pii_column_classifications` — covered by #2346 (the deprecation tail).
- Resolving group display names in the `/admin/compliance` Environment badge (currently shows the group id stripped of the `g_` prefix). Same shape as the `/admin/semantic` env badge from #2392; will land together when the connection-groups admin endpoint exposes display names alongside ids on the classifications response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)