### PR TITLE
feat(api): group-scoped approval queue (#2344)

### DIFF
--- a/apps/docs/content/docs/guides/approval-workflows.mdx
+++ b/apps/docs/content/docs/guides/approval-workflows.mdx
@@ -132,6 +132,18 @@ Pending requests expire automatically after 24 hours by default. Configure via t
 ATLAS_APPROVAL_EXPIRY_HOURS=48
 ```
 
+### Environment-Scoped Approvals
+
+Approvals are scoped to the connection's **environment group** (called a "connection group" in the schema; see the [multi-environment guide](/docs/guides/multi-environment)). When an admin approves a query, the approval covers any member of that group running the same query — operators don't have to re-approve once for each replica of a federated dataset.
+
+In practice:
+
+- A query approved against the `us-int` connection in the `prod` group automatically applies when the same user re-runs it against the `eu` or `apac` connection in the same `prod` group.
+- An approved query does **not** apply across groups — `prod` and `staging` are independent approval scopes.
+- Archiving a connection or moving it out of the group invalidates approvals issued against the old group; the next execution will queue a new request.
+
+The originating connection id is preserved on each approval row so reviewers can still see which group member submitted the request (visible in the expanded row details). The lookup itself keys on the group.
+
 ---
 
 ## API Reference

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -34315,7 +34315,16 @@
                                 ]
                               },
                               "connectionId": {
-                                "type": "string"
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "connectionGroupId": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
                               },
                               "tablesAccessed": {
                                 "type": "array",
@@ -34379,6 +34388,7 @@
                               "querySql",
                               "explanation",
                               "connectionId",
+                              "connectionGroupId",
                               "tablesAccessed",
                               "columnsAccessed",
                               "surface",
@@ -34425,7 +34435,16 @@
                                 ]
                               },
                               "connectionId": {
-                                "type": "string"
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "connectionGroupId": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
                               },
                               "tablesAccessed": {
                                 "type": "array",
@@ -34495,6 +34514,7 @@
                               "querySql",
                               "explanation",
                               "connectionId",
+                              "connectionGroupId",
                               "tablesAccessed",
                               "columnsAccessed",
                               "surface",
@@ -34541,7 +34561,16 @@
                                 ]
                               },
                               "connectionId": {
-                                "type": "string"
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "connectionGroupId": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
                               },
                               "tablesAccessed": {
                                 "type": "array",
@@ -34611,6 +34640,7 @@
                               "querySql",
                               "explanation",
                               "connectionId",
+                              "connectionGroupId",
                               "tablesAccessed",
                               "columnsAccessed",
                               "surface",
@@ -34657,7 +34687,16 @@
                                 ]
                               },
                               "connectionId": {
-                                "type": "string"
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "connectionGroupId": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
                               },
                               "tablesAccessed": {
                                 "type": "array",
@@ -34721,6 +34760,7 @@
                               "querySql",
                               "explanation",
                               "connectionId",
+                              "connectionGroupId",
                               "tablesAccessed",
                               "columnsAccessed",
                               "surface",
@@ -34921,7 +34961,16 @@
                               ]
                             },
                             "connectionId": {
-                              "type": "string"
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "connectionGroupId": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
                             },
                             "tablesAccessed": {
                               "type": "array",
@@ -34985,6 +35034,7 @@
                             "querySql",
                             "explanation",
                             "connectionId",
+                            "connectionGroupId",
                             "tablesAccessed",
                             "columnsAccessed",
                             "surface",
@@ -35031,7 +35081,16 @@
                               ]
                             },
                             "connectionId": {
-                              "type": "string"
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "connectionGroupId": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
                             },
                             "tablesAccessed": {
                               "type": "array",
@@ -35101,6 +35160,7 @@
                             "querySql",
                             "explanation",
                             "connectionId",
+                            "connectionGroupId",
                             "tablesAccessed",
                             "columnsAccessed",
                             "surface",
@@ -35147,7 +35207,16 @@
                               ]
                             },
                             "connectionId": {
-                              "type": "string"
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "connectionGroupId": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
                             },
                             "tablesAccessed": {
                               "type": "array",
@@ -35217,6 +35286,7 @@
                             "querySql",
                             "explanation",
                             "connectionId",
+                            "connectionGroupId",
                             "tablesAccessed",
                             "columnsAccessed",
                             "surface",
@@ -35263,7 +35333,16 @@
                               ]
                             },
                             "connectionId": {
-                              "type": "string"
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "connectionGroupId": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
                             },
                             "tablesAccessed": {
                               "type": "array",
@@ -35327,6 +35406,7 @@
                             "querySql",
                             "explanation",
                             "connectionId",
+                            "connectionGroupId",
                             "tablesAccessed",
                             "columnsAccessed",
                             "surface",
@@ -35528,7 +35608,16 @@
                               ]
                             },
                             "connectionId": {
-                              "type": "string"
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "connectionGroupId": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
                             },
                             "tablesAccessed": {
                               "type": "array",
@@ -35592,6 +35681,7 @@
                             "querySql",
                             "explanation",
                             "connectionId",
+                            "connectionGroupId",
                             "tablesAccessed",
                             "columnsAccessed",
                             "surface",
@@ -35638,7 +35728,16 @@
                               ]
                             },
                             "connectionId": {
-                              "type": "string"
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "connectionGroupId": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
                             },
                             "tablesAccessed": {
                               "type": "array",
@@ -35708,6 +35807,7 @@
                             "querySql",
                             "explanation",
                             "connectionId",
+                            "connectionGroupId",
                             "tablesAccessed",
                             "columnsAccessed",
                             "surface",
@@ -35754,7 +35854,16 @@
                               ]
                             },
                             "connectionId": {
-                              "type": "string"
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "connectionGroupId": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
                             },
                             "tablesAccessed": {
                               "type": "array",
@@ -35824,6 +35933,7 @@
                             "querySql",
                             "explanation",
                             "connectionId",
+                            "connectionGroupId",
                             "tablesAccessed",
                             "columnsAccessed",
                             "surface",
@@ -35870,7 +35980,16 @@
                               ]
                             },
                             "connectionId": {
-                              "type": "string"
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "connectionGroupId": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
                             },
                             "tablesAccessed": {
                               "type": "array",
@@ -35934,6 +36053,7 @@
                             "querySql",
                             "explanation",
                             "connectionId",
+                            "connectionGroupId",
                             "tablesAccessed",
                             "columnsAccessed",
                             "surface",

--- a/ee/src/governance/approval.test.ts
+++ b/ee/src/governance/approval.test.ts
@@ -538,7 +538,7 @@ describe("createApprovalRequest", () => {
   beforeEach(resetMocks);
 
   it("creates an approval request", async () => {
-    ee.queueMockRows([makeQueueRow()]);
+    ee.queueMockRows([], [makeQueueRow()]);
     const result = await run(createApprovalRequest({
       orgId: "org-1",
       ruleId: "rule-1",
@@ -554,11 +554,11 @@ describe("createApprovalRequest", () => {
     expect(result.id).toBe("req-1");
     expect(result.status).toBe("pending");
     expect(result.tablesAccessed).toEqual(["users"]);
-    expect(ee.capturedQueries[0].sql).toContain("INSERT INTO approval_queue");
+    expect(ee.capturedQueries.some((q) => q.sql.includes("INSERT INTO approval_queue"))).toBe(true);
   });
 
   it("#2072: stamps surface on the queued row when caller provides it", async () => {
-    ee.queueMockRows([makeQueueRow({ surface: "mcp" })]);
+    ee.queueMockRows([], [makeQueueRow({ surface: "mcp" })]);
     const result = await run(createApprovalRequest({
       orgId: "org-1",
       ruleId: "rule-1",
@@ -581,7 +581,7 @@ describe("createApprovalRequest", () => {
   });
 
   it("#2072: stores surface as null when the caller does not provide it (legacy shape)", async () => {
-    ee.queueMockRows([makeQueueRow({ surface: null })]);
+    ee.queueMockRows([], [makeQueueRow({ surface: null })]);
     const result = await run(createApprovalRequest({
       orgId: "org-1",
       ruleId: "rule-1",
@@ -878,15 +878,36 @@ describe("hasApprovedRequest — group-scoped (#2344)", () => {
     expect(approvalLookup!.params).not.toContain("conn-eu");
   });
 
+  it("falls back to connection scope for ungrouped connections", async () => {
+    // NULL group_id is not a shared environment. The approval lookup must
+    // require the originating connection_id so an approval for one
+    // ungrouped connection does not authorize another ungrouped connection.
+    ee.queueMockRows(
+      [{ group_id: null }],
+      [],
+    );
+    const result = await run(hasApprovedRequest(
+      "org-1",
+      "user-1",
+      "SELECT * FROM accounts",
+      "conn-ungrouped-b",
+    ));
+    expect(result).toBe(false);
+
+    const approvalLookup = ee.capturedQueries.find((q) =>
+      q.sql.includes("FROM approval_queue") && q.sql.includes("connection_group_id IS NULL"),
+    );
+    expect(approvalLookup).toBeDefined();
+    expect(approvalLookup!.sql).toContain("connection_id = $4");
+    expect(approvalLookup!.params).toContain("conn-ungrouped-b");
+  });
+
   it("rejects when the connection has been archived (group_id no longer resolves)", async () => {
     // Archived / deleted connection: the group resolver returns no
-    // rows. Without a resolvable group, the lookup falls through to
-    // the COALESCE sentinel and only matches a NULL-group approval
-    // — i.e. legacy pre-#2344 rows — so the approved row issued
-    // against `g-prod` does NOT apply to an orphaned execution.
+    // rows. Without a resolvable connection context, the check fails
+    // closed instead of falling through to another approval bucket.
     ee.queueMockRows(
-      [], // no row → group resolver returns null
-      [], // approval_queue lookup finds nothing for sentinel
+      [], // no row → group resolver cannot resolve the connection
     );
     const result = await run(hasApprovedRequest(
       "org-1",
@@ -926,7 +947,7 @@ describe("createApprovalRequest — group-scoped (#2344)", () => {
   beforeEach(resetMocks);
 
   it("stamps connection_group_id on the queued row when caller passes one", async () => {
-    ee.queueMockRows([makeQueueRow({ connection_group_id: "g-prod" })]);
+    ee.queueMockRows([], [], [makeQueueRow({ connection_group_id: "g-prod" })]);
     const result = await run(createApprovalRequest({
       orgId: "org-1",
       ruleId: "rule-1",
@@ -951,7 +972,7 @@ describe("createApprovalRequest — group-scoped (#2344)", () => {
     // Mirrors the inline scalar-subquery shape used by
     // `inlineConnectionGroupSql`. The returned queue row carries the
     // group resolved by the subquery rather than the caller passing it.
-    ee.queueMockRows([makeQueueRow({ connection_group_id: "g-prod", connection_id: "conn-us" })]);
+    ee.queueMockRows([], [makeQueueRow({ connection_group_id: "g-prod", connection_id: "conn-us" })]);
     const result = await run(createApprovalRequest({
       orgId: "org-1",
       ruleId: "rule-1",

--- a/ee/src/governance/approval.test.ts
+++ b/ee/src/governance/approval.test.ts
@@ -99,6 +99,9 @@ function makeQueueRow(overrides: Partial<Record<string, unknown>> = {}): Record<
     query_sql: "SELECT * FROM users",
     explanation: "Fetching user data",
     connection_id: "default",
+    // #2344 — group-scoped approval queue. Legacy rows pre-#2344 are
+    // NULL; tests that exercise the new lookup override explicitly.
+    connection_group_id: null,
     tables_accessed: '["users"]',
     columns_accessed: '["id","name","email"]',
     status: "pending",
@@ -831,6 +834,142 @@ describe("hasApprovedRequest", () => {
     } catch (err) {
       expect(err).toBe(original);
     }
+  });
+});
+
+// #2344 — group-scoped approval. The PRD's HITL assumption is that one
+// approval row covers any group member running the same query: an
+// approval issued against `conn-us` flows through to a follow-up
+// execution against `conn-eu` if both are members of the same group.
+// Connection-id continues to be written so the audit log carries which
+// member originated the request, but the lookup keys on group.
+describe("hasApprovedRequest — group-scoped (#2344)", () => {
+  beforeEach(resetMocks);
+
+  it("matches an approval issued against a different connection in the same group", async () => {
+    // Two-step query trace mock: (1) resolve connection's group_id,
+    // (2) approval_queue lookup. The execution-side caller is on
+    // `conn-eu`, which resolves to `g-prod`; the approval row was
+    // issued for `conn-us` (same group). The lookup must succeed.
+    ee.queueMockRows(
+      [{ group_id: "g-prod" }],
+      [{ id: "req-approved" }],
+    );
+    const result = await run(hasApprovedRequest(
+      "org-1",
+      "user-1",
+      "SELECT * FROM accounts",
+      "conn-eu",
+    ));
+    expect(result).toBe(true);
+
+    // The approval_queue SELECT must filter on the resolved group_id —
+    // not the raw connection_id — so two members of the same group
+    // share approvals. The captured params should carry the resolved
+    // group_id as $4.
+    const approvalLookup = ee.capturedQueries.find((q) =>
+      q.sql.includes("FROM approval_queue") && q.sql.includes("status = 'approved'"),
+    );
+    expect(approvalLookup).toBeDefined();
+    expect(approvalLookup!.params).toContain("g-prod");
+    // And the lookup must NOT bind the raw connection id — the regression
+    // shape we're guarding against is "lookup filters by connection_id"
+    // which would force re-approval per-member.
+    expect(approvalLookup!.params).not.toContain("conn-eu");
+  });
+
+  it("rejects when the connection has been archived (group_id no longer resolves)", async () => {
+    // Archived / deleted connection: the group resolver returns no
+    // rows. Without a resolvable group, the lookup falls through to
+    // the COALESCE sentinel and only matches a NULL-group approval
+    // — i.e. legacy pre-#2344 rows — so the approved row issued
+    // against `g-prod` does NOT apply to an orphaned execution.
+    ee.queueMockRows(
+      [], // no row → group resolver returns null
+      [], // approval_queue lookup finds nothing for sentinel
+    );
+    const result = await run(hasApprovedRequest(
+      "org-1",
+      "user-1",
+      "SELECT * FROM accounts",
+      "conn-archived",
+    ));
+    expect(result).toBe(false);
+  });
+
+  it("preserves the legacy no-connection-id shape for callers that don't pass one", async () => {
+    // sql.ts call sites that pre-date #2344 (and the agent loop's
+    // backwards-compat path) call `hasApprovedRequest` with three
+    // positional args. The legacy shape must keep returning a boolean
+    // based on the (orgId, requesterId, querySql) match without
+    // attempting a group resolve. This guards the migration sequencing.
+    ee.queueMockRows([{ id: "req-approved" }]);
+    const result = await run(hasApprovedRequest(
+      "org-1",
+      "user-1",
+      "SELECT * FROM accounts",
+    ));
+    expect(result).toBe(true);
+    // No group-resolution query was issued — the legacy path is one SELECT.
+    expect(ee.capturedQueries).toHaveLength(1);
+    expect(ee.capturedQueries[0].sql).toContain("FROM approval_queue");
+  });
+});
+
+// #2344 — group-scoped createApprovalRequest. The approval row carries
+// `connection_group_id` so the lookup above can filter on it. The
+// caller may pass it explicitly (preferred — sql.ts has the connection
+// in hand), and the service resolves it inline via the connections
+// 1:1 group map when omitted, mirroring `inlineConnectionGroupSql` in
+// `semantic/entities.ts`.
+describe("createApprovalRequest — group-scoped (#2344)", () => {
+  beforeEach(resetMocks);
+
+  it("stamps connection_group_id on the queued row when caller passes one", async () => {
+    ee.queueMockRows([makeQueueRow({ connection_group_id: "g-prod" })]);
+    const result = await run(createApprovalRequest({
+      orgId: "org-1",
+      ruleId: "rule-1",
+      ruleName: "PII table approval",
+      requesterId: "user-1",
+      requesterEmail: "user@example.com",
+      querySql: "SELECT * FROM accounts",
+      explanation: null,
+      connectionId: "conn-us",
+      connectionGroupId: "g-prod",
+      tablesAccessed: ["accounts"],
+      columnsAccessed: ["id"],
+    }));
+    expect(result.connectionGroupId).toBe("g-prod");
+    const insert = ee.capturedQueries.find((q) => q.sql.includes("INSERT INTO approval_queue"));
+    expect(insert).toBeDefined();
+    expect(insert!.sql).toContain("connection_group_id");
+    expect(insert!.params).toContain("g-prod");
+  });
+
+  it("resolves connection_group_id inline from connection_id when caller omits it", async () => {
+    // Mirrors the inline scalar-subquery shape used by
+    // `inlineConnectionGroupSql`. The returned queue row carries the
+    // group resolved by the subquery rather than the caller passing it.
+    ee.queueMockRows([makeQueueRow({ connection_group_id: "g-prod", connection_id: "conn-us" })]);
+    const result = await run(createApprovalRequest({
+      orgId: "org-1",
+      ruleId: "rule-1",
+      ruleName: "PII table approval",
+      requesterId: "user-1",
+      requesterEmail: "user@example.com",
+      querySql: "SELECT * FROM accounts",
+      explanation: null,
+      connectionId: "conn-us",
+      tablesAccessed: ["accounts"],
+      columnsAccessed: ["id"],
+    }));
+    expect(result.connectionGroupId).toBe("g-prod");
+    const insert = ee.capturedQueries.find((q) => q.sql.includes("INSERT INTO approval_queue"));
+    expect(insert).toBeDefined();
+    // Inline subquery against connections — the SQL contains both the
+    // connection_id parameter and the inline group lookup.
+    expect(insert!.sql).toContain("FROM connections");
   });
 });
 

--- a/ee/src/governance/approval.ts
+++ b/ee/src/governance/approval.ts
@@ -80,7 +80,10 @@ interface ApprovalQueueRow {
   requester_email: string | null;
   query_sql: string;
   explanation: string | null;
-  connection_id: string;
+  /** #2344 — nullable post-migration 0065. Audit-trail only; lookup keys on `connection_group_id`. */
+  connection_id: string | null;
+  /** #2344 — group scope. NULL for legacy rows and for callers without a group context. */
+  connection_group_id: string | null;
   tables_accessed: string | null;
   columns_accessed: string | null;
   status: string;
@@ -197,6 +200,11 @@ function rowToRequest(row: ApprovalQueueRow): ApprovalRequest | null {
     querySql: row.query_sql,
     explanation: row.explanation,
     connectionId: row.connection_id,
+    // #2344 — undefined-tolerant access guards the in-memory test
+    // fixtures (`makeQueueRow` in approval.test.ts predates the
+    // column). Real DB rows always carry the column post-0065 — the
+    // missing-column case is purely a unit-test convenience.
+    connectionGroupId: row.connection_group_id ?? null,
     tablesAccessed: parseJsonArray(row.tables_accessed),
     columnsAccessed: parseJsonArray(row.columns_accessed),
     surface,
@@ -272,6 +280,16 @@ function validateRuleInput(input: CreateApprovalRuleRequest): Effect.Effect<void
   }
   return Effect.void;
 }
+
+// #2344 — single source of truth for the approval_queue projection so
+// SELECT, RETURNING (insert), and RETURNING (update) all carry the
+// new `connection_group_id` column without drifting from each other.
+// Drift was the exact #2191-class regression PR review caught on the
+// surface column rollout; centralizing here keeps the three sites in
+// lockstep.
+const APPROVAL_QUEUE_COLUMNS = `id, org_id, rule_id, rule_name, requester_id, requester_email, query_sql,
+  explanation, connection_id, connection_group_id, tables_accessed, columns_accessed, status,
+  reviewer_id, reviewer_email, review_comment, reviewed_at, surface, created_at, expires_at`;
 
 // ── Default expiry ──────────────────────────────────────────────────
 
@@ -666,7 +684,21 @@ export const createApprovalRequest = (opts: {
   requesterEmail: string | null;
   querySql: string;
   explanation: string | null;
-  connectionId: string;
+  /**
+   * Originating connection id. Nullable post-#2344 — the lookup keys
+   * on {@link connectionGroupId}; this column survives as the audit
+   * trail for which member submitted the request.
+   */
+  connectionId: string | null;
+  /**
+   * #2344 — group scope. When provided, stored verbatim. When omitted
+   * and a `connectionId` is given, the INSERT resolves the group
+   * inline via a scalar subquery against `connections.group_id`
+   * (mirrors `inlineConnectionGroupSql` in semantic/entities.ts). When
+   * neither is provided, the row carries NULL and matches only the
+   * legacy NULL-group lookup branch.
+   */
+  connectionGroupId?: string | null;
   tablesAccessed: string[];
   columnsAccessed: string[];
   /**
@@ -713,14 +745,44 @@ export const createApprovalRequest = (opts: {
       }));
     }
 
-    const rows = yield* Effect.promise(() => internalQuery<ApprovalQueueRow>(
-      `INSERT INTO approval_queue
+    // #2344 — branch on whether the caller passed a group id verbatim.
+    // Inline shape: when omitted but a connectionId is present, resolve
+    // the group via a scalar subquery against `connections` in the
+    // same INSERT — no SELECT-then-INSERT race with concurrent
+    // connection deletes. Matches the resolution rule in
+    // `semantic/entities.ts: inlineConnectionGroupSql`: prefer the
+    // org's own connection row, fall back to `__global__` for demo /
+    // built-in connections.
+    const hasExplicitGroup = opts.connectionGroupId !== undefined;
+    const hasConnectionForResolve = !hasExplicitGroup && opts.connectionId !== null && opts.connectionId !== undefined;
+    const groupExpression = hasExplicitGroup
+      ? "$8"
+      : hasConnectionForResolve
+        ? `(
+            SELECT group_id FROM connections
+            WHERE id = $8
+              AND (org_id = $1 OR org_id = '__global__')
+            ORDER BY CASE WHEN org_id = $1 THEN 0 ELSE 1 END
+            LIMIT 1
+          )`
+        : "NULL";
+    const groupParam: string | null = hasExplicitGroup
+      ? (opts.connectionGroupId ?? null)
+      : hasConnectionForResolve
+        ? (opts.connectionId as string)
+        : null;
+    // Param ordering: $1..$7 stable; $8 carries either the explicit
+    // group_id or (when resolving inline) the connection_id consumed by
+    // the scalar subquery. $9 is connection_id stored verbatim on the
+    // row regardless of which path produced the group.
+    const insertSql = `INSERT INTO approval_queue
          (org_id, rule_id, rule_name, requester_id, requester_email, query_sql, explanation,
-          connection_id, tables_accessed, columns_accessed, surface, expires_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, now() + make_interval(hours => $12))
-       RETURNING id, org_id, rule_id, rule_name, requester_id, requester_email, query_sql,
-         explanation, connection_id, tables_accessed, columns_accessed, status,
-         reviewer_id, reviewer_email, review_comment, reviewed_at, surface, created_at, expires_at`,
+          connection_group_id, connection_id, tables_accessed, columns_accessed, surface, expires_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, ${groupExpression}, $9, $10, $11, $12, now() + make_interval(hours => $13))
+       RETURNING ${APPROVAL_QUEUE_COLUMNS}`;
+
+    const rows = yield* Effect.promise(() => internalQuery<ApprovalQueueRow>(
+      insertSql,
       [
         opts.orgId,
         opts.ruleId,
@@ -729,6 +791,7 @@ export const createApprovalRequest = (opts: {
         opts.requesterEmail,
         opts.querySql,
         opts.explanation,
+        groupParam,
         opts.connectionId,
         JSON.stringify(opts.tablesAccessed),
         JSON.stringify(opts.columnsAccessed),
@@ -741,7 +804,10 @@ export const createApprovalRequest = (opts: {
       return yield* Effect.fail(new ApprovalError({ message: "Failed to create approval request.", code: "validation" }));
     }
 
-    log.info({ orgId: opts.orgId, requestId: rows[0].id, ruleId: opts.ruleId }, "Approval request created");
+    log.info(
+      { orgId: opts.orgId, requestId: rows[0].id, ruleId: opts.ruleId, connectionGroupId: rows[0].connection_group_id },
+      "Approval request created",
+    );
     const request = rowToRequest(rows[0]);
     if (!request) return yield* Effect.fail(new ApprovalError({ message: `Created request has unexpected status "${rows[0].status}" after insert.`, code: "conflict" }));
     return request;
@@ -761,9 +827,7 @@ export const listApprovalRequests = (
     const safeLimit = Math.min(Math.max(1, limit), 1000);
     const safeOffset = Math.max(0, offset);
 
-    let sql = `SELECT id, org_id, rule_id, rule_name, requester_id, requester_email, query_sql,
-         explanation, connection_id, tables_accessed, columns_accessed, status,
-         reviewer_id, reviewer_email, review_comment, reviewed_at, surface, created_at, expires_at
+    let sql = `SELECT ${APPROVAL_QUEUE_COLUMNS}
        FROM approval_queue
        WHERE org_id = $1`;
     const params: unknown[] = [orgId];
@@ -790,9 +854,7 @@ export const getApprovalRequest = (
     if (!hasInternalDB()) return null;
 
     const rows = yield* Effect.promise(() => internalQuery<ApprovalQueueRow>(
-      `SELECT id, org_id, rule_id, rule_name, requester_id, requester_email, query_sql,
-         explanation, connection_id, tables_accessed, columns_accessed, status,
-         reviewer_id, reviewer_email, review_comment, reviewed_at, surface, created_at, expires_at
+      `SELECT ${APPROVAL_QUEUE_COLUMNS}
        FROM approval_queue
        WHERE org_id = $1 AND id = $2
        LIMIT 1`,
@@ -851,9 +913,7 @@ export const reviewApprovalRequest = (
       `UPDATE approval_queue
        SET status = $3, reviewer_id = $4, reviewer_email = $5, review_comment = $6, reviewed_at = now()
        WHERE org_id = $1 AND id = $2 AND status = 'pending'
-       RETURNING id, org_id, rule_id, rule_name, requester_id, requester_email, query_sql,
-         explanation, connection_id, tables_accessed, columns_accessed, status,
-         reviewer_id, reviewer_email, review_comment, reviewed_at, surface, created_at, expires_at`,
+       RETURNING ${APPROVAL_QUEUE_COLUMNS}`,
       [orgId, requestId, newStatus, reviewerId, reviewerEmail, comment ?? null],
     ));
 
@@ -942,6 +1002,21 @@ export const getPendingCount = (orgId: string): Effect.Effect<number, never> =>
  * Used by the SQL interception to allow re-execution of approved queries.
  * Returns true if an approved request exists for this exact query text.
  *
+ * #2344 — when `connectionId` is provided, the lookup resolves the
+ * caller's `group_id` from `connections` and matches on
+ * `connection_group_id`. One approval covers every member of the same
+ * group running the same query — keying on connection forced re-
+ * approval per replica even when an admin had already greenlit the
+ * query for the group. When the connection is archived / deleted, the
+ * resolver returns NULL and only legacy NULL-group approvals match,
+ * which is the "reject-on-archived-group" shape — the approval issued
+ * against the original group no longer applies.
+ *
+ * The legacy 3-arg shape (`omit connectionId`) keeps the pre-#2344
+ * unscoped match for callers that don't yet thread the connection
+ * id. Used by the agent loop and the test harnesses; removed in a
+ * follow-up slice once every caller carries a connection.
+ *
  * Returns false when enterprise is disabled — stale approved records from a
  * previously-enabled enterprise license should not grant query access.
  * Only `EnterpriseError` is caught — unexpected errors propagate to avoid
@@ -951,17 +1026,57 @@ export const hasApprovedRequest = (
   orgId: string,
   requesterId: string,
   querySql: string,
+  connectionId?: string,
 ): Effect.Effect<boolean, never> =>
   Effect.gen(function* () {
     if (!hasInternalDB()) return false;
 
     yield* requireEnterpriseEffect("approval-workflows");
 
+    // #2344 — legacy 3-arg shape preserves the pre-migration unscoped
+    // lookup so the agent loop and the test harnesses that still call
+    // through the old signature don't regress. The new branch only
+    // engages when the caller supplies a connection — sql.ts does so;
+    // a follow-up slice removes the legacy branch once every consumer
+    // is migrated.
+    if (connectionId === undefined) {
+      const legacyRows = yield* Effect.promise(() => internalQuery<{ id: string }>(
+        `SELECT id FROM approval_queue
+         WHERE org_id = $1 AND requester_id = $2 AND query_sql = $3 AND status = 'approved'
+         LIMIT 1`,
+        [orgId, requesterId, querySql],
+      ));
+      return legacyRows.length > 0;
+    }
+
+    // #2344 — resolve the connection's group_id at lookup time.
+    // Separate SELECT (not a joined CTE on `approval_queue`) so the
+    // archived-connection case is a clean signal: the resolver
+    // returning zero rows means the connection has been removed /
+    // archived, and we fall through to the NULL-group sentinel
+    // branch which only matches legacy pre-#2344 rows.
+    const groupRows = yield* Effect.promise(() => internalQuery<{ group_id: string | null }>(
+      `SELECT group_id FROM connections
+       WHERE id = $1 AND (org_id = $2 OR org_id = '__global__')
+       ORDER BY CASE WHEN org_id = $2 THEN 0 ELSE 1 END
+       LIMIT 1`,
+      [connectionId, orgId],
+    ));
+    const resolvedGroupId = groupRows[0]?.group_id ?? null;
+
+    // Match approval rows whose group equals the resolved group. The
+    // COALESCE sentinel keeps NULL-group lookups indexable via
+    // idx_approval_queue_group and matches the legacy
+    // pre-#2344 rows that carry connection_group_id IS NULL.
     const rows = yield* Effect.promise(() => internalQuery<{ id: string }>(
       `SELECT id FROM approval_queue
-       WHERE org_id = $1 AND requester_id = $2 AND query_sql = $3 AND status = 'approved'
+       WHERE org_id = $1
+         AND requester_id = $2
+         AND query_sql = $3
+         AND status = 'approved'
+         AND COALESCE(connection_group_id, '__default__') = COALESCE($4, '__default__')
        LIMIT 1`,
-      [orgId, requesterId, querySql],
+      [orgId, requesterId, querySql, resolvedGroupId],
     ));
 
     return rows.length > 0;

--- a/ee/src/governance/approval.ts
+++ b/ee/src/governance/approval.ts
@@ -116,6 +116,24 @@ function isValidRequestSurface(surface: string): surface is ApprovalRequestSurfa
   return (APPROVAL_REQUEST_SURFACES as readonly string[]).includes(surface);
 }
 
+const mirrorGlobalConnectionGroupForTenantSql = `INSERT INTO connection_groups (id, org_id, name)
+SELECT g.id, $1, ('__global__:' || g.id) AS name
+  FROM connections c
+  JOIN connection_groups g
+    ON g.id = c.group_id
+   AND g.org_id = c.org_id
+ WHERE c.id = $2
+   AND c.org_id = '__global__'
+   AND c.group_id IS NOT NULL
+ON CONFLICT (id, org_id) DO NOTHING`;
+
+const mirrorExplicitGlobalGroupForTenantSql = `INSERT INTO connection_groups (id, org_id, name)
+SELECT id, $1, ('__global__:' || id) AS name
+  FROM connection_groups
+ WHERE id = $2
+   AND org_id = '__global__'
+ON CONFLICT (id, org_id) DO NOTHING`;
+
 function rowToRule(row: ApprovalRuleRow): ApprovalRule | null {
   if (!isValidRuleType(row.rule_type)) {
     log.warn({ ruleId: row.id, ruleType: row.rule_type }, "Approval rule has unexpected rule_type in database — skipping rule");
@@ -695,8 +713,8 @@ export const createApprovalRequest = (opts: {
    * and a `connectionId` is given, the INSERT resolves the group
    * inline via a scalar subquery against `connections.group_id`
    * (mirrors `inlineConnectionGroupSql` in semantic/entities.ts). When
-   * neither is provided, the row carries NULL and matches only the
-   * legacy NULL-group lookup branch.
+   * neither is provided, the row carries NULL and is only eligible for
+   * the legacy 3-arg unscoped lookup path.
    */
   connectionGroupId?: string | null;
   tablesAccessed: string[];
@@ -771,6 +789,26 @@ export const createApprovalRequest = (opts: {
       : hasConnectionForResolve
         ? (opts.connectionId as string)
         : null;
+
+    // Global/demo connections live under `__global__`, while approval
+    // rows are tenant-scoped. The composite FK on approval_queue requires
+    // `(connection_group_id, org_id)` to exist in `connection_groups`, so
+    // mirror the global group into the tenant before inserting the queue
+    // row. This is idempotent and preserves the same group id that lookup
+    // uses, without weakening cross-tenant FK protection.
+    if (opts.connectionId !== null && opts.connectionId !== undefined) {
+      yield* Effect.promise(() => internalQuery(
+        mirrorGlobalConnectionGroupForTenantSql,
+        [opts.orgId, opts.connectionId],
+      ));
+    }
+    if (hasExplicitGroup && opts.connectionGroupId != null) {
+      yield* Effect.promise(() => internalQuery(
+        mirrorExplicitGlobalGroupForTenantSql,
+        [opts.orgId, opts.connectionGroupId],
+      ));
+    }
+
     // Param ordering: $1..$7 stable; $8 carries either the explicit
     // group_id or (when resolving inline) the connection_id consumed by
     // the scalar subquery. $9 is connection_id stored verbatim on the
@@ -1007,10 +1045,9 @@ export const getPendingCount = (orgId: string): Effect.Effect<number, never> =>
  * `connection_group_id`. One approval covers every member of the same
  * group running the same query — keying on connection forced re-
  * approval per replica even when an admin had already greenlit the
- * query for the group. When the connection is archived / deleted, the
- * resolver returns NULL and only legacy NULL-group approvals match,
- * which is the "reject-on-archived-group" shape — the approval issued
- * against the original group no longer applies.
+ * query for the group. When a connection has no group, the lookup falls
+ * back to the originating `connection_id` scope; when the connection is
+ * archived / deleted and cannot be resolved, no approval applies.
  *
  * The legacy 3-arg shape (`omit connectionId`) keeps the pre-#2344
  * unscoped match for callers that don't yet thread the connection
@@ -1053,8 +1090,7 @@ export const hasApprovedRequest = (
     // Separate SELECT (not a joined CTE on `approval_queue`) so the
     // archived-connection case is a clean signal: the resolver
     // returning zero rows means the connection has been removed /
-    // archived, and we fall through to the NULL-group sentinel
-    // branch which only matches legacy pre-#2344 rows.
+    // archived and no connection-scoped approval can safely apply.
     const groupRows = yield* Effect.promise(() => internalQuery<{ group_id: string | null }>(
       `SELECT group_id FROM connections
        WHERE id = $1 AND (org_id = $2 OR org_id = '__global__')
@@ -1062,19 +1098,39 @@ export const hasApprovedRequest = (
        LIMIT 1`,
       [connectionId, orgId],
     ));
+    if (groupRows.length === 0) return false;
+
     const resolvedGroupId = groupRows[0]?.group_id ?? null;
 
-    // Match approval rows whose group equals the resolved group. The
-    // COALESCE sentinel keeps NULL-group lookups indexable via
-    // idx_approval_queue_group and matches the legacy
-    // pre-#2344 rows that carry connection_group_id IS NULL.
+    if (resolvedGroupId === null) {
+      // Ungrouped connections are not an environment group. Fall back to
+      // the originating connection scope so an approval for one NULL-group
+      // connection cannot authorize the same SQL on another NULL-group
+      // connection in the org.
+      const rows = yield* Effect.promise(() => internalQuery<{ id: string }>(
+        `SELECT id FROM approval_queue
+         WHERE org_id = $1
+           AND requester_id = $2
+           AND query_sql = $3
+           AND status = 'approved'
+           AND connection_group_id IS NULL
+           AND connection_id = $4
+         LIMIT 1`,
+        [orgId, requesterId, querySql, connectionId],
+      ));
+      return rows.length > 0;
+    }
+
+    // Match approval rows whose group equals the resolved group. NULL-group
+    // rows are handled by the connection-scoped branch above, because NULL
+    // does not identify a shared environment group.
     const rows = yield* Effect.promise(() => internalQuery<{ id: string }>(
       `SELECT id FROM approval_queue
        WHERE org_id = $1
          AND requester_id = $2
          AND query_sql = $3
          AND status = 'approved'
-         AND COALESCE(connection_group_id, '__default__') = COALESCE($4, '__default__')
+         AND connection_group_id = $4
        LIMIT 1`,
       [orgId, requesterId, querySql, resolvedGroupId],
     ));

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -310,6 +310,7 @@ describe("migrateAuthTables", () => {
             { name: "0062_connection_groups.sql" },
             { name: "0063_semantic_entities_group_scoped.sql" },
             { name: "0064_pii_group_scoped.sql" },
+            { name: "0065_approvals_group_scoped.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -1053,6 +1053,83 @@ describeIfPg("migrate-pg (real Postgres)", () => {
     expect(rows[0]?.connection_group_id).toBe(groupId);
   }, PG_TEST_TIMEOUT_MS);
 
+  it("approval_queue: global connection backfill mirrors group into tenant before FK use", async () => {
+    // Demo / built-in connections are stored under `__global__`, but
+    // approval rows are tenant-scoped. 0065 mirrors the global group row
+    // into the tenant before writing approval_queue.connection_group_id so
+    // the composite FK can remain tenant-local.
+    const orgId = `org-approval-global-${Date.now()}`;
+    const connId = `conn-global-approval-${Date.now()}`;
+    const groupId = `g_${connId}`;
+
+    await pool.query(
+      `INSERT INTO connection_groups (id, org_id, name) VALUES ($1, '__global__', $2)`,
+      [groupId, connId],
+    );
+    await pool.query(
+      `INSERT INTO connections (id, url, type, org_id, status, group_id)
+       VALUES ($1, 'enc:v1:iv:tag:ciphertext', 'postgres', '__global__', 'published', $2)`,
+      [connId, groupId],
+    );
+    const ruleRow = await pool.query<{ id: string }>(
+      `INSERT INTO approval_rules (org_id, name, rule_type, pattern, threshold, enabled)
+       VALUES ($1, 'Global backfill rule', 'table', 'orders', NULL, true)
+       RETURNING id`,
+      [orgId],
+    );
+    await pool.query(
+      `INSERT INTO approval_queue
+         (org_id, rule_id, rule_name, requester_id, query_sql, connection_id, connection_group_id)
+       VALUES ($1, $2, 'Global backfill rule', 'user-global-backfill', 'SELECT * FROM orders', $3, NULL)`,
+      [orgId, ruleRow.rows[0].id, connId],
+    );
+
+    await pool.query(
+      `WITH global_approval_groups AS (
+         SELECT DISTINCT
+                COALESCE(aq.connection_group_id, c.group_id) AS group_id,
+                aq.org_id AS tenant_org_id,
+                ('__global__:' || g.id) AS name
+           FROM approval_queue aq
+           JOIN connections c
+             ON c.id = aq.connection_id
+            AND c.org_id = '__global__'
+           JOIN connection_groups g
+             ON g.id = c.group_id
+            AND g.org_id = '__global__'
+          WHERE aq.org_id = $1
+            AND aq.org_id <> '__global__'
+            AND COALESCE(aq.connection_group_id, c.group_id) IS NOT NULL
+       )
+       INSERT INTO connection_groups (id, org_id, name)
+       SELECT group_id, tenant_org_id, name
+         FROM global_approval_groups
+       ON CONFLICT (id, org_id) DO NOTHING`,
+      [orgId],
+    );
+    await pool.query(
+      `UPDATE approval_queue aq
+         SET connection_group_id = c.group_id
+         FROM connections c
+         WHERE aq.org_id = $1
+           AND aq.connection_id IS NOT NULL
+           AND aq.connection_group_id IS NULL
+           AND c.id = aq.connection_id
+           AND (c.org_id = aq.org_id OR c.org_id = '__global__')`,
+      [orgId],
+    );
+
+    const { rows } = await pool.query<{ connection_group_id: string | null; mirrored: string | null }>(
+      `SELECT aq.connection_group_id,
+              (SELECT g.id FROM connection_groups g WHERE g.id = aq.connection_group_id AND g.org_id = aq.org_id) AS mirrored
+         FROM approval_queue aq
+        WHERE aq.org_id = $1 AND aq.requester_id = 'user-global-backfill'`,
+      [orgId],
+    );
+    expect(rows[0]?.connection_group_id).toBe(groupId);
+    expect(rows[0]?.mirrored).toBe(groupId);
+  }, PG_TEST_TIMEOUT_MS);
+
   it("approval_queue.connection_group_id: composite FK blocks cross-org membership", async () => {
     // Same shape as `connections.group_id` in 0062: the composite FK
     // (connection_group_id, org_id) → connection_groups (id, org_id)

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -947,4 +947,205 @@ describeIfPg("migrate-pg (real Postgres)", () => {
         ON pii_column_classifications (org_id, table_name, column_name, COALESCE(connection_group_id, '__default__'))`,
     );
   }, PG_TEST_TIMEOUT_MS);
+
+  // 0065 — group-scoped approval queue. The migration adds
+  // `approval_queue.connection_group_id` (FK to connection_groups), drops
+  // the vestigial `connection_id NOT NULL DEFAULT 'default'`, and back-
+  // fills via the 0062 1:1 connection→group map. What this set of
+  // assertions guards against:
+  //   - A future migration that re-introduces NOT NULL on connection_id,
+  //     breaking the audit-only nullable shape post-#2344.
+  //   - A future migration that drops connection_group_id without an
+  //     equivalent group-scope replacement, regressing the "approve once
+  //     per group" semantics.
+  //   - The backfill drifting: every existing row that had a valid
+  //     connection_id must end up with the corresponding
+  //     connection_group_id resolved through 0062's `g_<connId>` map.
+  it("approval_queue.connection_group_id: column exists and is nullable", async () => {
+    const { rows } = await pool.query<{ is_nullable: string; data_type: string }>(
+      `SELECT is_nullable, data_type
+       FROM information_schema.columns
+       WHERE table_name = 'approval_queue'
+         AND column_name = 'connection_group_id'
+         AND table_schema = current_schema()`,
+    );
+    expect(rows[0]?.data_type).toBe("text");
+    // Nullable: legacy pre-#2344 rows and callers without a group
+    // context (the agent loop's identityMissing path stays NULL too)
+    // must keep booting; the lookup uses a COALESCE sentinel to match
+    // the NULL case.
+    expect(rows[0]?.is_nullable).toBe("YES");
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("approval_queue.connection_id: column is nullable post-#2344 (no NOT NULL DEFAULT)", async () => {
+    // The pre-#2344 schema had `connection_id NOT NULL DEFAULT 'default'`,
+    // which silently rewrote unstamped inserts to the string 'default'.
+    // 0065 drops both — the column is audit-only, the lookup keys on
+    // connection_group_id. A future migration that re-tightens this
+    // would force every caller back through the 'default' drift shape.
+    const { rows } = await pool.query<{ is_nullable: string; column_default: string | null }>(
+      `SELECT is_nullable, column_default
+       FROM information_schema.columns
+       WHERE table_name = 'approval_queue'
+         AND column_name = 'connection_id'
+         AND table_schema = current_schema()`,
+    );
+    expect(rows[0]?.is_nullable).toBe("YES");
+    expect(rows[0]?.column_default).toBeNull();
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("approval_queue: backfill resolves connection_id → connection_group_id via 0062's 1:1 mapping", async () => {
+    // Pre-migration approval rows have `connection_id` set but no
+    // `connection_group_id`. 0065 backfills by joining `connections`,
+    // so every row with a known connection lands on `g_<connId>` (the
+    // group_id 0062 created for the 1:1 backfill).
+    const orgId = `org-approval-backfill-${Date.now()}`;
+    const connId = `conn-approval-${Date.now()}`;
+    const groupId = `g_${connId}`;
+    // Seed the 1:1 group + connection that 0062 would have produced.
+    await pool.query(
+      `INSERT INTO connection_groups (id, org_id, name) VALUES ($1, $2, $3)`,
+      [groupId, orgId, connId],
+    );
+    await pool.query(
+      `INSERT INTO connections (id, url, type, org_id, status, group_id)
+       VALUES ($1, 'enc:v1:iv:tag:ciphertext', 'postgres', $2, 'published', $3)`,
+      [connId, orgId, groupId],
+    );
+    // Seed an approval rule the approval_queue row can reference (the
+    // queue has no rule_id FK, but using a real UUID keeps the row
+    // shape consistent with production inserts).
+    const ruleRow = await pool.query<{ id: string }>(
+      `INSERT INTO approval_rules (org_id, name, rule_type, pattern, threshold, enabled)
+       VALUES ($1, 'Backfill rule', 'table', 'orders', NULL, true)
+       RETURNING id`,
+      [orgId],
+    );
+    const ruleId = ruleRow.rows[0].id;
+    // Insert an approval row matching the pre-0065 shape: connection_id
+    // set, connection_group_id left NULL — same shape an upgrade row
+    // would have on the moment 0065 starts running.
+    await pool.query(
+      `INSERT INTO approval_queue
+         (org_id, rule_id, rule_name, requester_id, query_sql, connection_id, connection_group_id)
+       VALUES ($1, $2, 'Backfill rule', 'user-backfill', 'SELECT * FROM orders', $3, NULL)`,
+      [orgId, ruleId, connId],
+    );
+    // Re-run the backfill block (same SQL the migration uses).
+    // Idempotent: the WHERE clause only touches rows still missing
+    // connection_group_id.
+    await pool.query(
+      `UPDATE approval_queue aq
+         SET connection_group_id = c.group_id
+         FROM connections c
+         WHERE aq.org_id = $1
+           AND aq.connection_id IS NOT NULL
+           AND aq.connection_group_id IS NULL
+           AND c.id = aq.connection_id
+           AND (c.org_id = aq.org_id OR c.org_id = '__global__')`,
+      [orgId],
+    );
+    const { rows } = await pool.query<{ connection_group_id: string | null }>(
+      `SELECT connection_group_id FROM approval_queue
+       WHERE org_id = $1 AND requester_id = 'user-backfill'`,
+      [orgId],
+    );
+    expect(rows[0]?.connection_group_id).toBe(groupId);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("approval_queue.connection_group_id: composite FK blocks cross-org membership", async () => {
+    // Same shape as `connections.group_id` in 0062: the composite FK
+    // (connection_group_id, org_id) → connection_groups (id, org_id)
+    // makes it impossible for an approval row in org B to reference a
+    // group that lives in org A.
+    const orgA = `org-approval-fk-a-${Date.now()}`;
+    const orgB = `org-approval-fk-b-${Date.now()}`;
+    const groupId = `g-approval-fk-${Date.now()}`;
+    await pool.query(
+      `INSERT INTO connection_groups (id, org_id, name) VALUES ($1, $2, 'shared')`,
+      [groupId, orgA],
+    );
+    const ruleRow = await pool.query<{ id: string }>(
+      `INSERT INTO approval_rules (org_id, name, rule_type, pattern, threshold, enabled)
+       VALUES ($1, 'Cross-org rule', 'table', 'orders', NULL, true)
+       RETURNING id`,
+      [orgB],
+    );
+    // 23503 = foreign_key_violation. Pointing org B's approval row at
+    // org A's group must fail loudly at the DB layer.
+    await expect(
+      pool.query(
+        `INSERT INTO approval_queue
+           (org_id, rule_id, rule_name, requester_id, query_sql, connection_group_id)
+         VALUES ($1, $2, 'Cross-org rule', 'user-1', 'SELECT 1', $3)`,
+        [orgB, ruleRow.rows[0].id, groupId],
+      ),
+    ).rejects.toMatchObject({ code: "23503" });
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("approval_queue.connection_group_id: deleting a referenced group is rejected with 23503", async () => {
+    // ON DELETE RESTRICT on the FK is the last-resort defence against
+    // a group teardown that would orphan live approval rows. The route
+    // handler in `admin-connection-groups.ts` already rejects non-
+    // empty groups with a 409; this guards the path where a caller
+    // bypasses the handler (raw SQL or future call site).
+    const orgId = `org-approval-restrict-${Date.now()}`;
+    const groupId = `g-approval-restrict-${Date.now()}`;
+    await pool.query(
+      `INSERT INTO connection_groups (id, org_id, name) VALUES ($1, $2, 'temp')`,
+      [groupId, orgId],
+    );
+    const ruleRow = await pool.query<{ id: string }>(
+      `INSERT INTO approval_rules (org_id, name, rule_type, pattern, threshold, enabled)
+       VALUES ($1, 'Restrict rule', 'table', 'orders', NULL, true)
+       RETURNING id`,
+      [orgId],
+    );
+    await pool.query(
+      `INSERT INTO approval_queue
+         (org_id, rule_id, rule_name, requester_id, query_sql, connection_group_id)
+       VALUES ($1, $2, 'Restrict rule', 'user-1', 'SELECT 1', $3)`,
+      [orgId, ruleRow.rows[0].id, groupId],
+    );
+    // 23503: dropping a group with a live approval row pointing at it
+    // must fail.
+    await expect(
+      pool.query(
+        `DELETE FROM connection_groups WHERE id = $1 AND org_id = $2`,
+        [groupId, orgId],
+      ),
+    ).rejects.toMatchObject({ code: "23503" });
+
+    // Removing the approval row's group reference lets the delete
+    // proceed — proves the FK isn't blocking on phantom data.
+    await pool.query(
+      `UPDATE approval_queue SET connection_group_id = NULL WHERE org_id = $1 AND requester_id = 'user-1'`,
+      [orgId],
+    );
+    await pool.query(
+      `DELETE FROM connection_groups WHERE id = $1 AND org_id = $2`,
+      [groupId, orgId],
+    );
+    const { rows } = await pool.query<{ id: string }>(
+      `SELECT id FROM connection_groups WHERE id = $1 AND org_id = $2`,
+      [groupId, orgId],
+    );
+    expect(rows.length).toBe(0);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("approval_queue: idx_approval_queue_group is the partial-index on approved-only rows", async () => {
+    // The new lookup-path index is partial (status = 'approved') so it
+    // stays small even on workspaces with a deep historical queue.
+    // A future "drop the partial predicate" change would explode the
+    // index size and burn IO on every hasApprovedRequest call.
+    const { rows } = await pool.query<{ indexdef: string }>(
+      `SELECT indexdef FROM pg_indexes
+       WHERE schemaname = current_schema()
+         AND tablename = 'approval_queue'
+         AND indexname = 'idx_approval_queue_group'`,
+    );
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.indexdef).toMatch(/status = 'approved'/i);
+    expect(rows[0]?.indexdef).toMatch(/connection_group_id/i);
+  }, PG_TEST_TIMEOUT_MS);
 });

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -79,7 +79,9 @@ describe("runMigrations", () => {
 
     const count = await runMigrations(pool);
 
-    expect(count).toBe(65);
+    // 64 base migrations + 0064 (PII, #2341) + 0065 (approvals, #2344) = 66.
+    // Bump when the next 1.4.4 group-scoped slice lands.
+    expect(count).toBe(66);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -173,6 +175,7 @@ describe("runMigrations", () => {
         "0062_connection_groups.sql",
         "0063_semantic_entities_group_scoped.sql",
         "0064_pii_group_scoped.sql",
+        "0065_approvals_group_scoped.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0065_approvals_group_scoped.sql
+++ b/packages/api/src/lib/db/migrations/0065_approvals_group_scoped.sql
@@ -1,0 +1,116 @@
+-- 0065 — Group-scoped approval queue (PRD #2336, issue #2344).
+--
+-- Adds `approval_queue.connection_group_id` and drops the vestigial
+-- `connection_id NOT NULL DEFAULT 'default'` so the row keys on the
+-- environment group rather than the originating connection. The HITL
+-- assumption baked into the PRD: one approval covers any group member
+-- running the same query. Keying on connection forced re-approval per
+-- replica even when an admin had already greenlit the query for the
+-- group — the exact dogfood pain #2336 set out to remove.
+--
+-- `connection_id` stays on the table for the transitional window so
+-- audit reviewers can see which member originated the request. The
+-- NOT NULL DEFAULT 'default' goes away: legacy callers that didn't
+-- stamp a real connection_id were silently rewritten to the string
+-- 'default' on insert, which is itself drift the audit log should not
+-- carry post-#2344. Nullable from here; the column gets removed in a
+-- follow-up slice once the SDK consumers settle.
+--
+-- Migration sequencing: #2344 owns 0065. #2340 (semantic) shipped at
+-- 0063; #2343 (PII) lands at 0064; #2342 (dashboards) at 0066. All
+-- four slices share the same recipe: nullable FK to connection_groups,
+-- backfill via the 0062 1:1 map, no NOT NULL flip in this PR.
+
+-- ── 1. Column ─────────────────────────────────────────────────────────
+--
+-- Nullable initially. Legacy rows pre-#2344 carry `connection_group_id
+-- IS NULL` until the backfill below resolves them; the `hasApprovedRequest`
+-- lookup uses a COALESCE sentinel so a NULL-group approval and a NULL-
+-- group execution lookup match each other, preserving pre-migration
+-- semantics until every consumer threads connection_id through.
+ALTER TABLE approval_queue
+  ADD COLUMN IF NOT EXISTS connection_group_id TEXT;
+
+-- Composite FK so an approval row's `connection_group_id` can never
+-- reference a group in a different org. Same shape as `connections.group_id`
+-- in 0062. ON DELETE RESTRICT: dropping a group with live approval rows
+-- pointing at it must fail loudly — admins are expected to expire or
+-- reject the queue before tearing down the group. The route-layer
+-- DELETE handler in `admin-connection-groups.ts` already checks for
+-- members; this FK is the last-resort defence if a caller bypasses it.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.table_constraints
+    WHERE table_name = 'approval_queue'
+      AND constraint_name = 'fk_approval_queue_group'
+  ) THEN
+    ALTER TABLE approval_queue
+      ADD CONSTRAINT fk_approval_queue_group
+      FOREIGN KEY (connection_group_id, org_id)
+      REFERENCES connection_groups (id, org_id)
+      ON DELETE RESTRICT;
+  END IF;
+END $$;
+
+-- Lookup index supporting the new read path:
+--   `WHERE org_id = $1 AND requester_id = $2 AND query_sql = $3
+--    AND status = 'approved' AND COALESCE(connection_group_id, '__default__')
+--                                 = COALESCE($4, '__default__')`
+-- Same `__default__` sentinel as semantic_entities (0028 / 0063) so the
+-- NULL-group execution path keeps a hot index path. Partial on
+-- status = 'approved' because that's the only state the lookup ever
+-- reads — keeps the index small.
+CREATE INDEX IF NOT EXISTS idx_approval_queue_group
+  ON approval_queue (org_id, connection_group_id, requester_id)
+  WHERE status = 'approved';
+
+-- ── 2. Backfill ───────────────────────────────────────────────────────
+--
+-- Resolve every existing row's `connection_group_id` from its
+-- `connection_id` via 0062's 1:1 mapping. The default literal
+-- 'default' (legacy NOT NULL DEFAULT) joins through to a group named
+-- 'default' if one exists for the org; otherwise it stays NULL and the
+-- lookup falls through to the legacy "no group" path. Same join
+-- predicate as 0063 so demo / `__global__` rows resolve via the same
+-- visibility rule the whitelist already uses.
+--
+-- Idempotent: the predicate `connection_group_id IS NULL` ensures
+-- re-runs leave already-resolved rows alone.
+UPDATE approval_queue aq
+   SET connection_group_id = c.group_id
+   FROM connections c
+   WHERE aq.connection_id IS NOT NULL
+     AND aq.connection_group_id IS NULL
+     AND c.id = aq.connection_id
+     AND (c.org_id = aq.org_id OR c.org_id = '__global__');
+
+-- ── 3. Drop legacy NOT NULL DEFAULT 'default' on connection_id ────────
+--
+-- The vestigial guard from the pre-#2344 era — every insert that didn't
+-- carry a connection_id got rewritten to the string 'default', which
+-- then drifted into the audit log as if a connection actually named
+-- 'default' was the source. Now that the lookup keys on group, the
+-- column can carry the originating connection_id verbatim (including
+-- NULL for callers that genuinely have no member context yet).
+--
+-- The DROP NOT NULL is wrapped to be re-runnable: a second migration
+-- pass against an already-migrated schema is a no-op rather than an
+-- error.
+DO $$ BEGIN
+  ALTER TABLE approval_queue ALTER COLUMN connection_id DROP NOT NULL;
+EXCEPTION
+  WHEN others THEN
+    -- Column was already nullable (re-run) or another structural change
+    -- removed the NOT NULL constraint. Either way, the post-condition
+    -- (column is nullable) is the goal; swallow the exact reason.
+    NULL;
+END $$;
+
+ALTER TABLE approval_queue ALTER COLUMN connection_id DROP DEFAULT;
+
+COMMENT ON COLUMN approval_queue.connection_group_id IS
+  'Group scope for this approval (#2344). NULL for legacy pre-#2344 rows; new rows carry the connection''s group_id resolved via 0062''s 1:1 backfill. The hasApprovedRequest lookup keys on this column so one approval covers every member of the group running the same query.';
+
+COMMENT ON COLUMN approval_queue.connection_id IS
+  'Originating connection id (audit trail). Nullable post-#2344 — the lookup keys on connection_group_id; this column survives so audit reviewers can see which member submitted the request. Removed in a follow-up slice once SDK consumers settle.';

--- a/packages/api/src/lib/db/migrations/0065_approvals_group_scoped.sql
+++ b/packages/api/src/lib/db/migrations/0065_approvals_group_scoped.sql
@@ -24,20 +24,49 @@
 -- ── 1. Column ─────────────────────────────────────────────────────────
 --
 -- Nullable initially. Legacy rows pre-#2344 carry `connection_group_id
--- IS NULL` until the backfill below resolves them; the `hasApprovedRequest`
--- lookup uses a COALESCE sentinel so a NULL-group approval and a NULL-
--- group execution lookup match each other, preserving pre-migration
--- semantics until every consumer threads connection_id through.
+-- IS NULL` until the backfill below resolves them. Runtime lookups only
+-- share approvals across non-NULL groups; ungrouped connections fall back
+-- to `connection_id` scope so unrelated NULL-group connections do not
+-- authorize each other.
 ALTER TABLE approval_queue
   ADD COLUMN IF NOT EXISTS connection_group_id TEXT;
 
+-- Global/demo connections live in the sentinel `__global__` org, but
+-- approval_queue rows are tenant-scoped. Before we enforce the composite
+-- FK below, mirror any global connection's group row into each tenant
+-- that already has approval rows for that global connection. The approval
+-- row stores the same group id with the tenant org_id, so the FK remains
+-- tenant-local while demo / built-in connections still resolve through the
+-- same visibility rule used by the runtime.
+WITH global_approval_groups AS (
+  SELECT DISTINCT
+         COALESCE(aq.connection_group_id, c.group_id) AS group_id,
+         aq.org_id AS tenant_org_id,
+         ('__global__:' || g.id) AS name
+    FROM approval_queue aq
+    JOIN connections c
+      ON c.id = aq.connection_id
+     AND c.org_id = '__global__'
+    JOIN connection_groups g
+      ON g.id = c.group_id
+     AND g.org_id = '__global__'
+   WHERE aq.org_id <> '__global__'
+     AND COALESCE(aq.connection_group_id, c.group_id) IS NOT NULL
+)
+INSERT INTO connection_groups (id, org_id, name)
+SELECT group_id, tenant_org_id, name
+  FROM global_approval_groups
+ON CONFLICT (id, org_id) DO NOTHING;
+
 -- Composite FK so an approval row's `connection_group_id` can never
--- reference a group in a different org. Same shape as `connections.group_id`
--- in 0062. ON DELETE RESTRICT: dropping a group with live approval rows
--- pointing at it must fail loudly — admins are expected to expire or
--- reject the queue before tearing down the group. The route-layer
--- DELETE handler in `admin-connection-groups.ts` already checks for
--- members; this FK is the last-resort defence if a caller bypasses it.
+-- reference a group in a different tenant org. Global/demo connection
+-- groups are handled by the tenant-local mirror above before the FK is
+-- enforced. Same shape as `connections.group_id` in 0062. ON DELETE
+-- RESTRICT: dropping a group with live approval rows pointing at it must
+-- fail loudly — admins are expected to expire or reject the queue before
+-- tearing down the group. The route-layer DELETE handler in
+-- `admin-connection-groups.ts` already checks for members; this FK is the
+-- last-resort defence if a caller bypasses it.
 DO $$ BEGIN
   IF NOT EXISTS (
     SELECT 1
@@ -54,13 +83,13 @@ DO $$ BEGIN
 END $$;
 
 -- Lookup index supporting the new read path:
---   `WHERE org_id = $1 AND requester_id = $2 AND query_sql = $3
---    AND status = 'approved' AND COALESCE(connection_group_id, '__default__')
---                                 = COALESCE($4, '__default__')`
--- Same `__default__` sentinel as semantic_entities (0028 / 0063) so the
--- NULL-group execution path keeps a hot index path. Partial on
--- status = 'approved' because that's the only state the lookup ever
--- reads — keeps the index small.
+--   grouped:   `WHERE org_id = $1 AND requester_id = $2 AND query_sql = $3
+--               AND status = 'approved' AND connection_group_id = $4`
+--   ungrouped: `WHERE org_id = $1 AND requester_id = $2 AND query_sql = $3
+--               AND status = 'approved' AND connection_group_id IS NULL
+--               AND connection_id = $4`
+-- Partial on status = 'approved' because that's the only state the lookup
+-- ever reads — keeps the index small.
 CREATE INDEX IF NOT EXISTS idx_approval_queue_group
   ON approval_queue (org_id, connection_group_id, requester_id)
   WHERE status = 'approved';

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -987,7 +987,20 @@ export const approvalQueue = pgTable(
     requesterEmail: text("requester_email"),
     querySql: text("query_sql").notNull(),
     explanation: text("explanation"),
-    connectionId: text("connection_id").notNull().default("default"),
+    // #2344 — connection_id is now nullable. Pre-#2344 rows carried
+    // `NOT NULL DEFAULT 'default'` which silently rewrote unstamped
+    // inserts to the literal string 'default'. The new lookup keys on
+    // `connection_group_id`, so this column survives only as the audit
+    // trail for which member originated the request — and the legacy
+    // default is gone so the audit log no longer carries the drift.
+    connectionId: text("connection_id"),
+    // #2344 — group scope. Nullable during the transition; backfilled
+    // from `connections.group_id` via 0062's 1:1 map. Composite FK to
+    // (connection_groups.id, connection_groups.orgId) so a row cannot
+    // reference a group in a different org. ON DELETE RESTRICT mirrors
+    // `connections.group_id` and forces admins to expire / reject the
+    // queue before tearing down the group.
+    connectionGroupId: text("connection_group_id"),
     tablesAccessed: jsonb("tables_accessed").default(sql`'[]'`),
     columnsAccessed: jsonb("columns_accessed").default(sql`'[]'`),
     status: text("status").notNull().default("pending"),
@@ -1008,9 +1021,18 @@ export const approvalQueue = pgTable(
       "chk_approval_request_surface",
       sql`surface IS NULL OR surface IN ('chat', 'mcp', 'scheduler', 'slack', 'teams', 'webhook')`,
     ),
+    foreignKey({
+      columns: [t.connectionGroupId, t.orgId],
+      foreignColumns: [connectionGroups.id, connectionGroups.orgId],
+      name: "fk_approval_queue_group",
+    }).onDelete("restrict"),
     index("idx_approval_queue_org_status").on(t.orgId, t.status),
     index("idx_approval_queue_expires").on(t.expiresAt).where(sql`status = 'pending'`),
     index("idx_approval_queue_requester").on(t.requesterId),
+    // #2344 — partial index covers the hasApprovedRequest hot path.
+    index("idx_approval_queue_group")
+      .on(t.orgId, t.connectionGroupId, t.requesterId)
+      .where(sql`status = 'approved'`),
   ],
 );
 

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -1097,7 +1097,7 @@ export function runUserQueryPipeline(opts: RunUserQueryOpts): Promise<UserQueryO
               };
             }
 
-            const alreadyApproved = await Effect.runPromise(hasApprovedRequest(approvalOrgId, userId, normalizedSql));
+            const alreadyApproved = await Effect.runPromise(hasApprovedRequest(approvalOrgId, userId, normalizedSql, connId));
             if (!alreadyApproved) {
               const firstRule = approvalMatch.matchedRules[0];
               const approvalReq = await Effect.runPromise(createApprovalRequest({
@@ -1403,7 +1403,7 @@ export const executeSQL = tool({
                 };
               }
 
-              const alreadyApproved = await Effect.runPromise(hasApprovedRequest(approvalOrgId, userId, normalizedSql));
+              const alreadyApproved = await Effect.runPromise(hasApprovedRequest(approvalOrgId, userId, normalizedSql, connId));
               if (!alreadyApproved) {
                 const firstRule = approvalMatch.matchedRules[0];
                 const approvalReq = await Effect.runPromise(createApprovalRequest({

--- a/packages/schemas/src/__tests__/approval.test.ts
+++ b/packages/schemas/src/__tests__/approval.test.ts
@@ -44,6 +44,9 @@ const pendingRequest = {
   querySql: "SELECT * FROM users",
   explanation: "Quarterly audit",
   connectionId: "conn_1",
+  // #2344 — group scope. Asserts the additive field parses on the
+  // happy path; null is the legacy / unstamped shape.
+  connectionGroupId: "g_prod",
   tablesAccessed: ["users"],
   columnsAccessed: ["users.email"],
   // #2072 — null is the legacy / unstamped default. A specific surface

--- a/packages/schemas/src/approval.ts
+++ b/packages/schemas/src/approval.ts
@@ -96,7 +96,9 @@ const ApprovalRequestBaseShape = {
   requesterEmail: z.string().nullable(),
   querySql: z.string(),
   explanation: z.string().nullable(),
-  connectionId: z.string(),
+  // #2344 — connectionId now nullable; lookup keys on connectionGroupId.
+  connectionId: z.string().nullable(),
+  connectionGroupId: z.string().nullable(),
   tablesAccessed: z.array(z.string()),
   columnsAccessed: z.array(z.string()),
   surface: RequestSurfaceEnum.nullable(),

--- a/packages/types/src/approval.ts
+++ b/packages/types/src/approval.ts
@@ -106,7 +106,22 @@ interface ApprovalRequestBase {
   /** The SQL query awaiting approval. */
   querySql: string;
   explanation: string | null;
-  connectionId: string;
+  /**
+   * Originating connection id (audit trail). Nullable post-#2344 — the
+   * approval lookup keys on {@link connectionGroupId}; this column
+   * survives so reviewers can see which group member submitted the
+   * request. Removed in a follow-up slice once SDK consumers settle.
+   */
+  connectionId: string | null;
+  /**
+   * Group scope for this approval (#2344). NULL for legacy pre-#2344
+   * rows and for callers that don't have a group context yet; new
+   * rows resolve via the connection's `group_id`. One approval covers
+   * every member of the group running the same query — keying on
+   * connection forced re-approval per replica even when an admin had
+   * already greenlit the query for the group.
+   */
+  connectionGroupId: string | null;
   tablesAccessed: string[];
   columnsAccessed: string[];
   /**

--- a/packages/web/src/app/admin/approval/page.tsx
+++ b/packages/web/src/app/admin/approval/page.tsx
@@ -574,6 +574,29 @@ function QueueSection() {
   const someSelected = selectedIds.size > 0;
   const bulkInProgress = bulkAction !== null;
 
+  // #2344 — collapse pending requests by (environment, querySql) so
+  // reviewers see when the same query is queued multiple times in the
+  // same group. Approving any one row will satisfy the gate for every
+  // member running the same query, so visual de-duplication helps the
+  // reviewer skip past obvious dupes. Minimal pass: a banner showing
+  // "N pending across M environments — K duplicates within an
+  // environment can be approved together." `?? "__no-env__"` lifts the
+  // legacy NULL-group rows into a single bucket rather than pretending
+  // each is its own environment.
+  const pendingGroupBuckets = new Map<string, ApprovalRequest[]>();
+  for (const req of pendingRequests) {
+    const env = req.connectionGroupId ?? req.connectionId ?? "__no-env__";
+    const key = `${env} ${req.querySql}`;
+    const bucket = pendingGroupBuckets.get(key);
+    if (bucket) bucket.push(req);
+    else pendingGroupBuckets.set(key, [req]);
+  }
+  const dupBuckets = [...pendingGroupBuckets.values()].filter((b) => b.length > 1);
+  const dupCount = dupBuckets.reduce((sum, b) => sum + (b.length - 1), 0);
+  const distinctEnvCount = new Set(
+    pendingRequests.map((r) => r.connectionGroupId ?? r.connectionId ?? "__no-env__"),
+  ).size;
+
   function toggleSelect(id: string) {
     setSelectedIds((prev) => {
       const next = new Set(prev);
@@ -803,6 +826,23 @@ function QueueSection() {
           />
         )}
 
+        {/* #2344 — environment-aware list summary. Only shown when the
+            pending queue has at least one (environment, query) bucket
+            that contains multiples — single-bucket queues don't need
+            the noise. Approving one row in a bucket implicitly covers
+            the rest because the lookup keys on environment, not on
+            connection id. */}
+        {statusFilter === "pending" && dupCount > 0 && (
+          <p className="text-xs text-muted-foreground">
+            {pendingRequests.length} pending across {distinctEnvCount}{" "}
+            environment{distinctEnvCount === 1 ? "" : "s"}.{" "}
+            <span className="text-muted-foreground/80">
+              {dupCount} duplicate{dupCount === 1 ? "" : "s"} within an
+              environment — approving one covers the rest.
+            </span>
+          </p>
+        )}
+
         {loading ? (
           <p className="py-8 text-center text-sm text-muted-foreground">Loading approval queue...</p>
         ) : requests.length === 0 ? (
@@ -1023,6 +1063,25 @@ function ExpandedRequestDetails({
               {t}
             </Badge>
           ))}
+        </div>
+      )}
+
+      {/* #2344 — surface the environment context. Approvals are now
+          group-wide: one greenlight covers any member of the same
+          environment running the same query, so reviewers need to see
+          which group they're approving for. Legacy pre-#2344 rows fall
+          back to the originating connection id. */}
+      {(req.connectionGroupId || req.connectionId) && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-xs text-muted-foreground">Environment:</span>
+          <Badge variant="outline" className="text-xs font-mono">
+            {req.connectionGroupId ?? req.connectionId}
+          </Badge>
+          {!req.connectionGroupId && req.connectionId && (
+            <span className="text-[10px] text-muted-foreground/70">
+              (legacy — pre-environment-grouping)
+            </span>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary

- Migration 0065 adds `approval_queue.connection_group_id` (composite FK → `connection_groups`), backfills via the 0062 1:1 connection→group map, and drops the vestigial `connection_id NOT NULL DEFAULT 'default'` — the approval row now keys on the environment group rather than the originating connection.
- `hasApprovedRequest` resolves the caller's group inline so one approval covers any sibling running the same query in the same environment; `createApprovalRequest` stamps `connection_group_id` (either verbatim or via an inline subquery against `connections`).
- @useatlas/types carries an additive `connectionGroupId: string | null`; admin queue surfaces the environment badge plus a duplicate-bucket summary line so reviewers see when approving one row collapses the rest.

## Test plan

- [x] EE approval tests: TDD red→green for `approve-then-execute-on-different-member`, `reject-on-archived-group`, and the legacy-no-connection-id passthrough (73 pass).
- [x] migrate-pg smoke covers the new column, backfill, composite FK, ON DELETE RESTRICT, and the partial-index shape.
- [x] Schemas + sql-approval test fixtures updated for the additive field (109 approval-related tests green).
- [x] /ci: lint clean, type-check clean, full api isolated suite green (370/372 — 2 pre-existing notebook flakes unrelated), syncpack clean, schema drift clean, template drift clean, railway-watch clean.

## HITL assumption (carried from PRD)

One approval covers any group member running the same query. Connection id is preserved on the row as audit trail. If a future route requires per-execution approval (e.g. write-side mutations on a federated dataset), that's a follow-up — see PRD #2336.

## Migration sequencing

This branch owns 0065. 0064 is reserved for the PII slice (#2343); 0066 for dashboards (#2342). The `migrate.test.ts` count is bumped to 65 in this PR — the parallel branches will bump again when they land.

Closes #2344